### PR TITLE
fix(workflow): M5 residuals — review-terminal adoption + honest child usage rollup

### DIFF
--- a/docs/design/verified-change-workflow-m5.md
+++ b/docs/design/verified-change-workflow-m5.md
@@ -67,11 +67,30 @@ Effect classification drives restart recovery:
   commit. A post-restart `inspect(childRunId)` therefore adopts the durable
   terminal — this closes exactly the
   `after_spawn_before_effect_result` crash window when the child finished
-  first. A child that genuinely died mid-flight with the daemon recorded no
-  terminal and honestly stays "unknown" → `unknown_outcome`. (The
-  independent-review child settles inside its own effect execution and does
-  not yet record a separate durable terminal; a crash mid-review still
-  resolves `unknown_outcome` — an explicit M6 candidate.)
+  first. The independent-review child gets the same treatment even though
+  it settles inside its own effect execution: the controller records its
+  durable terminal (whose payload carries the parsed ReviewOutput and the
+  recorded `independent_review` artifact pointer) strictly before the
+  review `effect_result` can commit, so a crash in the
+  `before_review_commit` window resumes to the same committed review by
+  adoption — the reviewer is never re-invoked. A child that genuinely died
+  mid-flight with the daemon recorded no terminal and honestly stays
+  "unknown" → `unknown_outcome`; a review terminal whose payload cannot be
+  decoded is treated the same way.
+
+Child usage is reported honestly from the durable source that already
+exists: the admission kernel reconciles ACTUAL provider usage per
+reservation, so a real delegate child's rollup is the sum of the reconciled
+reservations under its own admission run id
+(`sumReconciledUsageByRunId`). `held_unknown` reservations are surfaced as
+a count in the step evidence and never summed — reserved is never reported
+as spent, and a child with nothing reconciled reports `null`, not invented
+zeros. The rollup rides the durable child terminal and step evidence, so
+replayed and adopted steps re-accumulate it into the post-restart terminal
+usage. Honest residuals that remain: a child's own sub-agents admit under
+their own run ids and are not folded into the child's rollup, and the
+independent reviewer's one-shot model spend is not attributed to the
+review child's rollup.
 
 Dependency unlocks stop on failed verification, cancellation, budget
 exhaustion, and `unknown_outcome` — enforced first by the controller's

--- a/runtime/src/app-server/workflow/child-terminals.ts
+++ b/runtime/src/app-server/workflow/child-terminals.ts
@@ -1,0 +1,152 @@
+/**
+ * M5 A1 — durable workflow child terminals for cross-restart adoption.
+ *
+ * Extracted from `session-adapters.ts` so BOTH the session-backed spawner
+ * and the workflow controller (which settles the independent-review child
+ * inside its own effect execution) can durably record child terminals
+ * through the EXISTING run machinery without the controller importing the
+ * daemon session stack. `session-adapters.ts` re-exports everything here,
+ * so existing importers are unchanged.
+ */
+
+import type {
+  RunArtifactPointer,
+} from "../../contracts/run-contracts.js";
+import { canonicalizeJson } from "../../eval-contract/canonical-json.js";
+import type { ReviewOutput } from "../../session/review.js";
+import type { StateRunDurabilityRepository } from "../../state/run-durability.js";
+import type { WorkflowChildOutcome } from "./verified-change-controller.js";
+
+/** Deterministic event id for a child's durable terminal record. */
+export const WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX = "workflow-child-terminal:";
+
+/**
+ * Durably record a workflow child's terminal outcome in the owning run's
+ * state database, keyed by the deterministic child run id that the parent
+ * effect intent already carries. This honestly extends the EXISTING run
+ * machinery — the child gets its own `run_lifecycle_epochs` row and its own
+ * immutable `run_terminal_results` row (no new store, no parallel table) —
+ * so a post-restart `spawner.inspect(childRunId)` can adopt the outcome
+ * instead of reporting "unknown".
+ *
+ * Idempotent: re-recording an existing terminal is a no-op; the sticky
+ * per-(run, epoch) terminal-conflict rules of the repository still apply to
+ * genuinely conflicting content.
+ */
+export function recordWorkflowChildTerminal(
+  repo: StateRunDurabilityRepository,
+  childRunId: string,
+  outcome: WorkflowChildOutcome,
+  now: () => Date = () => new Date(),
+): void {
+  const at = now().toISOString();
+  repo.ensureInitialEpoch({ runId: childRunId, openedAt: at });
+  const epoch = repo.currentEpoch(childRunId)?.epoch ?? 1;
+  if (repo.getTerminalResult(childRunId, epoch) !== undefined) return;
+  repo.recordTerminalResult({
+    epoch,
+    eventId: `${WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX}${childRunId}`,
+    result: {
+      runId: childRunId,
+      status: outcome.status,
+      exitCode: outcome.status === "completed" ? 0 : 1,
+      stopReason: null,
+      finalMessage: outcome.finalMessage,
+      usage: outcome.usage,
+      lastSequence: null,
+      finishedAt: at,
+    },
+  });
+}
+
+/**
+ * D3 adoption source of truth after a daemon restart: the child's durable
+ * terminal, if one was recorded before the crash. A child that genuinely
+ * died mid-flight with the daemon recorded nothing and stays `undefined`
+ * (the caller reports "unknown" → the run terminates `unknown_outcome`).
+ */
+export function inspectWorkflowChildTerminal(
+  repo: StateRunDurabilityRepository,
+  childRunId: string,
+): WorkflowChildOutcome | undefined {
+  const terminal = repo.getCurrentTerminalResult(childRunId);
+  if (terminal === undefined) return undefined;
+  return {
+    status: terminal.status,
+    finalMessage: terminal.finalMessage,
+    usage: terminal.usage,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Independent-review child terminal payload
+// ---------------------------------------------------------------------------
+
+/**
+ * The review child settles inside the review effect's own execution, so its
+ * durable terminal must carry enough to complete the parent effect honestly
+ * on adoption: the parsed ReviewOutput plus the recorded
+ * `independent_review` artifact pointer. The payload rides the terminal's
+ * `finalMessage` as canonical JSON with a versioned kind marker; a terminal
+ * whose payload does not decode stays honestly unknowable.
+ */
+export const WORKFLOW_REVIEW_TERMINAL_KIND =
+  "agenc.workflow.review-terminal.v1";
+
+export interface WorkflowReviewTerminalPayload {
+  readonly kind: typeof WORKFLOW_REVIEW_TERMINAL_KIND;
+  readonly review: ReviewOutput;
+  readonly reviewerModel: string;
+  readonly artifact: RunArtifactPointer;
+}
+
+export function encodeWorkflowReviewTerminal(
+  payload: Omit<WorkflowReviewTerminalPayload, "kind">,
+): string {
+  return canonicalizeJson({
+    kind: WORKFLOW_REVIEW_TERMINAL_KIND,
+    review: payload.review,
+    reviewerModel: payload.reviewerModel,
+    artifact: payload.artifact,
+  });
+}
+
+export function decodeWorkflowReviewTerminal(
+  finalMessage: string | null | undefined,
+): WorkflowReviewTerminalPayload | undefined {
+  if (finalMessage === null || finalMessage === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(finalMessage);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== "object") return undefined;
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.kind !== WORKFLOW_REVIEW_TERMINAL_KIND) return undefined;
+  const review = candidate.review;
+  if (
+    review === null ||
+    typeof review !== "object" ||
+    !Array.isArray((review as { findings?: unknown }).findings) ||
+    typeof (review as { overallCorrectness?: unknown }).overallCorrectness !==
+      "string"
+  ) {
+    return undefined;
+  }
+  const artifact = candidate.artifact;
+  if (
+    artifact === null ||
+    typeof artifact !== "object" ||
+    typeof (artifact as { digest?: unknown }).digest !== "string"
+  ) {
+    return undefined;
+  }
+  if (typeof candidate.reviewerModel !== "string") return undefined;
+  return {
+    kind: WORKFLOW_REVIEW_TERMINAL_KIND,
+    review: review as ReviewOutput,
+    reviewerModel: candidate.reviewerModel,
+    artifact: artifact as RunArtifactPointer,
+  };
+}

--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -80,6 +80,11 @@ import type {
   WorkflowTerminalJournalIntent,
   WorkflowWorktreeBroker,
 } from "./verified-change-controller.js";
+import type { RunUsageTotals } from "../../contracts/run-contracts.js";
+import {
+  inspectWorkflowChildTerminal,
+  recordWorkflowChildTerminal,
+} from "./child-terminals.js";
 import { parseWorkflowStepId } from "./steps.js";
 
 const COMMAND_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
@@ -196,64 +201,43 @@ function ownerRunIdOfChild(childRunId: string): string | undefined {
 // A1 — durable child terminals for cross-restart adoption
 // ---------------------------------------------------------------------------
 
-/** Deterministic event id for a child's durable terminal record. */
-export const WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX = "workflow-child-terminal:";
+// The A1 helpers live in `child-terminals.ts` (shared with the controller,
+// which records the independent-review child's terminal itself); re-export
+// them here so existing importers are unchanged.
+export {
+  WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX,
+  inspectWorkflowChildTerminal,
+  recordWorkflowChildTerminal,
+} from "./child-terminals.js";
 
 /**
- * Durably record a workflow child's terminal outcome in the owning run's
- * state database, keyed by the deterministic child run id that the parent
- * effect intent already carries. This honestly extends the EXISTING run
- * machinery — the child gets its own `run_lifecycle_epochs` row and its own
- * immutable `run_terminal_results` row (no new store, no parallel table) —
- * so a post-restart `spawner.inspect(childRunId)` can adopt the outcome
- * instead of reporting "unknown".
- *
- * Idempotent: re-recording an existing terminal is a no-op; the sticky
- * per-(run, epoch) terminal-conflict rules of the repository still apply to
- * genuinely conflicting content.
+ * The child usage rollup for a real delegate spawn, resolved from the
+ * durable source that already exists: the admission kernel reconciles
+ * ACTUAL provider usage per reservation for the child run's admissions.
+ * Only reconciled actuals are reported; `held_unknown` reservations are
+ * counted (never summed) so holds are surfaced without ever reporting
+ * reserved as spent. `null` usage means nothing was reconciled — honestly
+ * unknown, never invented.
  */
-export function recordWorkflowChildTerminal(
-  repo: StateRunDurabilityRepository,
-  childRunId: string,
-  outcome: WorkflowChildOutcome,
-  now: () => Date = () => new Date(),
-): void {
-  const at = now().toISOString();
-  repo.ensureInitialEpoch({ runId: childRunId, openedAt: at });
-  const epoch = repo.currentEpoch(childRunId)?.epoch ?? 1;
-  if (repo.getTerminalResult(childRunId, epoch) !== undefined) return;
-  repo.recordTerminalResult({
-    epoch,
-    eventId: `${WORKFLOW_CHILD_TERMINAL_EVENT_PREFIX}${childRunId}`,
-    result: {
-      runId: childRunId,
-      status: outcome.status,
-      exitCode: outcome.status === "completed" ? 0 : 1,
-      stopReason: null,
-      finalMessage: outcome.finalMessage,
-      usage: outcome.usage,
-      lastSequence: null,
-      finishedAt: at,
-    },
-  });
-}
-
-/**
- * D3 adoption source of truth after a daemon restart: the child's durable
- * terminal, if one was recorded before the crash. A child that genuinely
- * died mid-flight with the daemon recorded nothing and stays `undefined`
- * (the caller reports "unknown" → the run terminates `unknown_outcome`).
- */
-export function inspectWorkflowChildTerminal(
-  repo: StateRunDurabilityRepository,
-  childRunId: string,
-): WorkflowChildOutcome | undefined {
-  const terminal = repo.getCurrentTerminalResult(childRunId);
-  if (terminal === undefined) return undefined;
+export function workflowChildAdmissionUsage(
+  kernel: ExecutionAdmissionKernel,
+  childAdmissionRunId: string,
+): {
+  readonly usage: RunUsageTotals | null;
+  readonly heldUnknownCount: number;
+} {
+  const summary = kernel.sumReconciledUsageByRunId(childAdmissionRunId);
   return {
-    status: terminal.status,
-    finalMessage: terminal.finalMessage,
-    usage: terminal.usage,
+    usage:
+      summary.reconciledCount > 0
+        ? {
+            inputTokens: summary.inputTokens,
+            outputTokens: summary.outputTokens,
+            totalTokens: summary.totalTokens,
+            costUsd: summary.costUsd,
+          }
+        : null,
+    heldUnknownCount: summary.heldUnknownCount,
   };
 }
 
@@ -805,10 +789,39 @@ export function createWorkflowSessionSeams(
             : result.outcome === "interrupted" || result.outcome === "aborted"
               ? "cancelled"
               : "failed";
+        // Honest usage rollup: delegate's RunAgentResult carries no usage
+        // totals, but the admission kernel durably reconciled ACTUAL
+        // provider usage per reservation under the child's admission run id
+        // (its thread id — `run-agent` binds `forSession({ runId:
+        // live.agentId })`). Sum what was reconciled; never invent numbers
+        // for held_unknown reservations.
+        let usage: RunUsageTotals | null = null;
+        let heldUnknownCount = 0;
+        try {
+          const resolved = workflowChildAdmissionUsage(
+            options.kernel,
+            result.threadId,
+          );
+          usage = resolved.usage;
+          heldUnknownCount = resolved.heldUnknownCount;
+          if (heldUnknownCount > 0) {
+            options.warn(
+              `workflow ${input.kind} child ${input.childRunId} holds ${heldUnknownCount} held_unknown admission reservation(s); ` +
+                "their spend is unknowable and is NOT counted in the reported usage",
+            );
+          }
+        } catch (error) {
+          options.warn(
+            `workflow ${input.kind} child ${input.childRunId} admission usage lookup failed: ${errorMessage(error)}`,
+          );
+        }
         return {
           status,
           finalMessage: result.finalMessage ?? null,
-          usage: null,
+          usage,
+          ...(heldUnknownCount > 0
+            ? { usageHeldUnknownCount: heldUnknownCount }
+            : {}),
         };
       })();
       entry.liveChildren.set(input.childRunId, pending);

--- a/runtime/src/app-server/workflow/steps.ts
+++ b/runtime/src/app-server/workflow/steps.ts
@@ -159,6 +159,18 @@ export interface WorkflowChildEvidence {
   readonly childRunId: string;
   readonly status: string;
   readonly finalMessage?: string;
+  /**
+   * Reconciled actual usage of the child's own admissions (absent =
+   * honestly unknown; reserved amounts are never reported as spent).
+   */
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+    readonly costUsd: number;
+  };
+  /** Child reservations held unknown — noted, never summed into `usage`. */
+  readonly usageHeldUnknown?: number;
 }
 
 export interface WorkflowReviewEvidence {

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -78,10 +78,12 @@ import {
   type VerifiedChangeStepRecord,
 } from "../../workflow/evidence-record.js";
 import {
+  extractBlockers,
   ReviewParseError,
   runIndependentReview,
   type ReviewerInvoker,
 } from "../../workflow/independent-review.js";
+import type { ReviewOutput } from "../../session/review.js";
 import {
   DEFAULT_VERIFICATION_TIMEOUT_MS,
   parseVerificationVerdict,
@@ -96,6 +98,11 @@ import {
   type ExportedPatchArtifacts,
   type SealedEvidenceProof,
 } from "../../workflow/worktree-lifecycle.js";
+import {
+  decodeWorkflowReviewTerminal,
+  encodeWorkflowReviewTerminal,
+  recordWorkflowChildTerminal,
+} from "./child-terminals.js";
 import { projectWorkflowStatus, type WorkflowRunStatus } from "./status-projection.js";
 import {
   deriveStageProjection,
@@ -216,7 +223,18 @@ export type WorkflowSpawnKind = "plan" | "implement" | "verify_agent" | "review"
 export interface WorkflowChildOutcome {
   readonly status: RunTerminalStatus;
   readonly finalMessage: string | null;
+  /**
+   * Reconciled actual usage for the child's own admissions (null = nothing
+   * reconciled / honestly unknown). Already charged against the budget by
+   * the child's own reservations — reported into the run's usage rollup,
+   * never re-reconciled against the parent spawn reservation.
+   */
   readonly usage: RunUsageTotals | null;
+  /**
+   * Admission reservations of the child whose spend is unknowable
+   * (`held_unknown`); surfaced as a count, NEVER summed into `usage`.
+   */
+  readonly usageHeldUnknownCount?: number;
 }
 
 export type WorkflowChildInspection =
@@ -395,7 +413,15 @@ interface CompletedGates {
 interface EffectExecution {
   readonly outcome: "committed" | "failed" | "cancelled";
   readonly evidence: WorkflowStepEvidence;
+  /** Usage reconciled against THIS step's admission reservation. */
   readonly usage?: AdmissionUsage;
+  /**
+   * Usage already reconciled at its durable source (the child run's own
+   * admission reservations): accumulated into the run's usage rollup only,
+   * never re-reconciled against this step's reservation — reconciling it
+   * here would double-charge the shared allocation scopes.
+   */
+  readonly rollupUsage?: AdmissionUsage;
 }
 
 interface EffectStepPlan {
@@ -1157,29 +1183,38 @@ export class VerifiedChangeWorkflowController {
                 sink: ledger,
                 step: { runId: ctx.runId, stepId },
               });
-              const nonBlocking = review.review.findings
-                .map((finding) => finding.title)
-                .filter((title) => !review.blockers.includes(title));
-              return {
-                outcome: "committed",
-                evidence: {
-                  stage: "workflow.review",
-                  attempt,
-                  review: {
-                    blockerCount: review.blockers.length,
-                    findingCount: review.review.findings.length,
-                    overallCorrectness: review.review.overallCorrectness,
-                    overallConfidenceScore:
-                      review.review.overallConfidenceScore,
-                    blockers: review.blockers,
-                    nonBlockingFindings: nonBlocking,
-                    reviewerModel: ctx.spec.reviewerModel,
-                  },
-                  artifacts: [review.artifact],
-                },
-              };
+              // A1 for the review child: the reviewer settled inside this
+              // effect execution, so ITS terminal becomes durable here —
+              // strictly before the review effect_result can commit. The
+              // payload carries the parsed ReviewOutput and the recorded
+              // independent_review artifact pointer, enough to complete the
+              // parent effect honestly on post-restart adoption.
+              this.#recordReviewChildTerminal(ctx, childRunId, {
+                status: "completed",
+                finalMessage: encodeWorkflowReviewTerminal({
+                  review: review.review,
+                  reviewerModel: ctx.spec.reviewerModel,
+                  artifact: review.artifact,
+                }),
+                usage: null,
+              });
+              return this.#reviewExecution(
+                attempt,
+                review.review,
+                ctx.spec.reviewerModel,
+                review.artifact,
+              );
             } catch (error) {
               if (error instanceof ReviewParseError) {
+                // A settled-but-unparseable reviewer is a KNOWN failure —
+                // durable for adoption too, so a crash in the commit window
+                // resumes into the same failed outcome (and its bounded
+                // retry), never into unknown_outcome.
+                this.#recordReviewChildTerminal(ctx, childRunId, {
+                  status: "failed",
+                  finalMessage: error.message,
+                  usage: null,
+                });
                 return {
                   outcome: "failed",
                   evidence: {
@@ -1195,7 +1230,7 @@ export class VerifiedChangeWorkflowController {
               throw error;
             }
           },
-          adopt: async (existing) => this.#adoptChild(ctx, existing),
+          adopt: async (existing) => this.#adoptReview(ctx, existing, attempt),
         } satisfies EffectStepPlan;
       },
     });
@@ -1526,6 +1561,7 @@ export class VerifiedChangeWorkflowController {
     const spec = ctx.spec;
     const toEvidence = (outcome: WorkflowChildOutcome): EffectExecution => {
       const decorated = input.decorate?.(outcome) ?? {};
+      const heldUnknown = outcome.usageHeldUnknownCount ?? 0;
       const evidence: WorkflowStepEvidence = {
         stage: input.stage,
         attempt: input.attempt,
@@ -1535,6 +1571,8 @@ export class VerifiedChangeWorkflowController {
           ...(truncate(outcome.finalMessage) !== undefined
             ? { finalMessage: truncate(outcome.finalMessage)! }
             : {}),
+          ...(outcome.usage !== null ? { usage: outcome.usage } : {}),
+          ...(heldUnknown > 0 ? { usageHeldUnknown: heldUnknown } : {}),
         },
         ...decorated,
       };
@@ -1544,7 +1582,12 @@ export class VerifiedChangeWorkflowController {
           : outcome.status === "cancelled"
             ? "cancelled"
             : "failed";
-      const usage =
+      // The child's usage is already reconciled at its durable source (the
+      // child run's own admission reservations charge the shared allocation
+      // scopes), so it rides `rollupUsage` — accumulated into the run's
+      // terminal usage rollup, never re-reconciled against the parent spawn
+      // reservation (that would double-charge the budget).
+      const rollupUsage =
         outcome.usage === null
           ? undefined
           : {
@@ -1555,7 +1598,7 @@ export class VerifiedChangeWorkflowController {
       return {
         outcome: mapped,
         evidence,
-        ...(usage !== undefined ? { usage } : {}),
+        ...(rollupUsage !== undefined ? { rollupUsage } : {}),
       };
     };
     return {
@@ -1608,16 +1651,123 @@ export class VerifiedChangeWorkflowController {
       adopt: async (existing) => {
         const adopted = await this.#adoptChild(ctx, existing);
         if (adopted === undefined) return undefined;
-        // Re-decorate verdict-bearing evidence from the adopted message.
+        // Re-decorate verdict-bearing evidence from the adopted message,
+        // preserving the durable terminal's usage rollup.
         const child = adopted.evidence.child;
         if (input.decorate !== undefined && child !== undefined) {
           return toEvidence({
             status: child.status as RunTerminalStatus,
             finalMessage: child.finalMessage ?? null,
-            usage: null,
+            usage: child.usage ?? null,
+            ...(child.usageHeldUnknown !== undefined
+              ? { usageHeldUnknownCount: child.usageHeldUnknown }
+              : {}),
           });
         }
         return adopted;
+      },
+    };
+  }
+
+  /** Best-effort durable terminal for the review child (never fatal). */
+  #recordReviewChildTerminal(
+    ctx: RunContext,
+    childRunId: string,
+    outcome: WorkflowChildOutcome,
+  ): void {
+    try {
+      recordWorkflowChildTerminal(ctx.repo, childRunId, outcome, this.#now);
+    } catch (error) {
+      this.#deps.warn(
+        `workflow review child ${childRunId} terminal was not durably recorded: ${errorMessage(error)}`,
+      );
+    }
+  }
+
+  /**
+   * The ONE assembly point for committed review-effect evidence — used by
+   * the live execution and by durable-terminal adoption, so both paths
+   * derive identical blockers/non-blocking findings from the ReviewOutput.
+   */
+  #reviewExecution(
+    attempt: number,
+    review: ReviewOutput,
+    reviewerModel: string,
+    artifact: RunArtifactPointer,
+  ): EffectExecution {
+    const blockers = extractBlockers(review);
+    const nonBlocking = review.findings
+      .map((finding) => finding.title)
+      .filter((title) => !blockers.includes(title));
+    return {
+      outcome: "committed",
+      evidence: {
+        stage: "workflow.review",
+        attempt,
+        review: {
+          blockerCount: blockers.length,
+          findingCount: review.findings.length,
+          overallCorrectness: review.overallCorrectness,
+          overallConfidenceScore: review.overallConfidenceScore,
+          blockers,
+          nonBlockingFindings: nonBlocking,
+          reviewerModel,
+        },
+        artifacts: [artifact],
+      },
+    };
+  }
+
+  /**
+   * D3 adoption for the independent-review child: a durable terminal whose
+   * payload decodes to the recorded ReviewOutput + independent_review
+   * artifact completes the parent effect exactly as the live execution
+   * would. A reviewer that genuinely died mid-flight recorded no terminal
+   * (or an undecodable one) and honestly stays unknowable.
+   */
+  async #adoptReview(
+    _ctx: RunContext,
+    existing: DurableRunEffect,
+    attempt: number,
+  ): Promise<EffectExecution | undefined> {
+    const childRunId = existing.childRunId;
+    if (childRunId === undefined) return undefined;
+    const inspection = await this.#deps.spawner.inspect(childRunId);
+    if (inspection.state === "unknown") return undefined;
+    const outcome =
+      inspection.state === "terminal"
+        ? inspection.outcome
+        : await inspection.outcome;
+    if (outcome.status === "unknown_outcome") return undefined;
+    if (outcome.status === "completed") {
+      const payload = decodeWorkflowReviewTerminal(outcome.finalMessage);
+      if (payload === undefined) {
+        this.#deps.warn(
+          `workflow review child ${childRunId} terminal carries no decodable review payload; the outcome stays unknown`,
+        );
+        return undefined;
+      }
+      return this.#reviewExecution(
+        attempt,
+        payload.review,
+        payload.reviewerModel,
+        payload.artifact,
+      );
+    }
+    return {
+      outcome: outcome.status === "cancelled" ? "cancelled" : "failed",
+      evidence: {
+        stage: "workflow.review",
+        attempt,
+        failure: {
+          reason:
+            outcome.status === "cancelled"
+              ? "review_cancelled"
+              : "review_unparseable",
+          ...(outcome.finalMessage !== null
+            ? { message: outcome.finalMessage }
+            : {}),
+        },
       },
     };
   }
@@ -1644,6 +1794,7 @@ export class VerifiedChangeWorkflowController {
         : outcome.status === "cancelled"
           ? "cancelled"
           : "failed";
+    const heldUnknown = outcome.usageHeldUnknownCount ?? 0;
     return {
       outcome: mapped,
       evidence: {
@@ -1656,8 +1807,19 @@ export class VerifiedChangeWorkflowController {
           ...(truncate(outcome.finalMessage) !== undefined
             ? { finalMessage: truncate(outcome.finalMessage)! }
             : {}),
+          ...(outcome.usage !== null ? { usage: outcome.usage } : {}),
+          ...(heldUnknown > 0 ? { usageHeldUnknown: heldUnknown } : {}),
         },
       },
+      ...(outcome.usage !== null
+        ? {
+            rollupUsage: {
+              inputTokens: outcome.usage.inputTokens,
+              outputTokens: outcome.usage.outputTokens,
+              costUsd: outcome.usage.costUsd,
+            },
+          }
+        : {}),
     };
   }
 
@@ -1717,10 +1879,22 @@ export class VerifiedChangeWorkflowController {
   ): Promise<EffectStepResult> {
     const existing = ctx.repo.getEffect(ctx.runId, plan.stepId);
     if (existing?.outcome !== undefined) {
-      // Sticky durable outcome — replay, never re-execute.
+      // Sticky durable outcome — replay, never re-execute. A replayed spawn
+      // step re-accumulates its durably recorded child usage so the
+      // post-restart terminal rollup stays honest (the in-memory rollup
+      // restarts at zero on resume; the durable evidence is the source).
+      const evidence = readWorkflowStepEvidence(existing);
+      const childUsage = evidence.child?.usage;
+      if (childUsage !== undefined) {
+        this.#accumulateUsage(ctx, {
+          inputTokens: childUsage.inputTokens,
+          outputTokens: childUsage.outputTokens,
+          costUsd: childUsage.costUsd,
+        });
+      }
       return {
         outcome: existing.outcome,
-        evidence: readWorkflowStepEvidence(existing),
+        evidence,
         replayed: true,
       };
     }
@@ -1749,6 +1923,9 @@ export class VerifiedChangeWorkflowController {
           ),
           replayed: false,
         };
+      }
+      if (adopted.rollupUsage !== undefined) {
+        this.#accumulateUsage(ctx, adopted.rollupUsage);
       }
       return this.#commitResult(ctx, plan, adopted, false);
     }
@@ -1849,6 +2026,9 @@ export class VerifiedChangeWorkflowController {
           outputTokens: 0,
           costUsd: 0,
         });
+      }
+      if (execution.rollupUsage !== undefined) {
+        this.#accumulateUsage(ctx, execution.rollupUsage);
       }
       settled = true;
       return result;

--- a/runtime/src/budget/execution-admission-kernel.ts
+++ b/runtime/src/budget/execution-admission-kernel.ts
@@ -27,6 +27,7 @@ import type { ExecutionAdmissionBudgetPolicy } from "./admission-config.js";
 import { DEFAULT_ADMISSION_CONCURRENCY_LIMITS } from "./admission-config.js";
 import {
   ExecutionAdmissionRepository,
+  type AdmissionRunUsageSummary,
   type PersistedAdmissionReservation,
 } from "../state/execution-admission.js";
 import {
@@ -615,6 +616,41 @@ export class ExecutionAdmissionKernel {
         : {}),
       ...(options.limit !== undefined ? { limit: options.limit } : {}),
     });
+  }
+
+  /**
+   * Sum the ACTUAL reconciled usage recorded for one run id (additive read
+   * over the repository's `sumReconciledUsageByRunId`). The run's own
+   * workspace database is used when a binding is known; otherwise every
+   * open workspace database is swept — reservation rows for one run id live
+   * in exactly one database, so component-wise addition is exact.
+   */
+  sumReconciledUsageByRunId(runId: string): AdmissionRunUsageSummary {
+    this.#assertOpen();
+    const statePath = this.#runStatePath.get(runId);
+    const bound =
+      statePath === undefined ? undefined : this.#byStatePath.get(statePath);
+    if (bound !== undefined) {
+      return bound.repository.sumReconciledUsageByRunId(runId);
+    }
+    const total = {
+      reconciledCount: 0,
+      heldUnknownCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+    };
+    for (const binding of this.#byStatePath.values()) {
+      const summary = binding.repository.sumReconciledUsageByRunId(runId);
+      total.reconciledCount += summary.reconciledCount;
+      total.heldUnknownCount += summary.heldUnknownCount;
+      total.inputTokens += summary.inputTokens;
+      total.outputTokens += summary.outputTokens;
+      total.totalTokens += summary.totalTokens;
+      total.costUsd += summary.costUsd;
+    }
+    return total;
   }
 
   cancelRun(

--- a/runtime/src/state/execution-admission.ts
+++ b/runtime/src/state/execution-admission.ts
@@ -157,6 +157,22 @@ export interface PersistedAdmissionReservation {
   readonly updatedAt: string;
 }
 
+/**
+ * Actual reconciled usage summed over one run id's reservations, with
+ * held-unknown reservations surfaced as a count (their reserved amounts are
+ * never reported as spent).
+ */
+export interface AdmissionRunUsageSummary {
+  /** Reservations whose actual usage was reconciled (incl. overruns). */
+  readonly reconciledCount: number;
+  /** Reservations whose spend is unknowable; NOT included in the sums. */
+  readonly heldUnknownCount: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+}
+
 export interface PersistedAdmissionAllocation {
   readonly key: string;
   readonly ownerRunId: string;
@@ -1309,6 +1325,60 @@ export class ExecutionAdmissionRepository {
         .all(...params)
         .map(reservationFromRow);
     });
+  }
+
+  /**
+   * Sum the ACTUAL reconciled provider usage recorded for one run id —
+   * the durable source for a workflow child's usage rollup (additive read,
+   * following the `listRunIdsWithStep` precedent on the durability
+   * repository). Only `reconciled` and `provider_overrun` rows contribute
+   * their reported actuals; `held_unknown` rows are COUNTED but never
+   * summed, so reserved amounts are never reported as spent. An overrun row
+   * with an unpriceable cost contributes its actual tokens and zero cost.
+   */
+  sumReconciledUsageByRunId(runId: string): AdmissionRunUsageSummary {
+    requireNonEmpty(runId, "runId");
+    const row = this.#driver
+      .prepareState<
+        [string],
+        {
+          readonly reconciled_count: number;
+          readonly held_unknown_count: number;
+          readonly input_tokens: number;
+          readonly output_tokens: number;
+          readonly total_tokens: number;
+          readonly cost_nanos: number;
+        }
+      >(
+        `SELECT
+           COALESCE(SUM(CASE WHEN status IN ('reconciled', 'provider_overrun') THEN 1 ELSE 0 END), 0) AS reconciled_count,
+           COALESCE(SUM(CASE WHEN status = 'held_unknown' THEN 1 ELSE 0 END), 0) AS held_unknown_count,
+           COALESCE(SUM(CASE WHEN status IN ('reconciled', 'provider_overrun') THEN COALESCE(actual_input_tokens, 0) ELSE 0 END), 0) AS input_tokens,
+           COALESCE(SUM(CASE WHEN status IN ('reconciled', 'provider_overrun') THEN COALESCE(actual_output_tokens, 0) ELSE 0 END), 0) AS output_tokens,
+           COALESCE(SUM(CASE WHEN status IN ('reconciled', 'provider_overrun') THEN COALESCE(actual_tokens, 0) ELSE 0 END), 0) AS total_tokens,
+           COALESCE(SUM(CASE WHEN status IN ('reconciled', 'provider_overrun') THEN COALESCE(actual_cost_nanos, 0) ELSE 0 END), 0) AS cost_nanos
+         FROM execution_admission_reservations
+         WHERE run_id = ?`,
+      )
+      .get(runId);
+    if (row === undefined) {
+      return {
+        reconciledCount: 0,
+        heldUnknownCount: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        costUsd: 0,
+      };
+    }
+    return {
+      reconciledCount: row.reconciled_count,
+      heldUnknownCount: row.held_unknown_count,
+      inputTokens: row.input_tokens,
+      outputTokens: row.output_tokens,
+      totalTokens: row.total_tokens,
+      costUsd: nanosToUsd(row.cost_nanos),
+    };
   }
 
   listAllocations(

--- a/runtime/tests/state/execution-admission.test.ts
+++ b/runtime/tests/state/execution-admission.test.ts
@@ -849,3 +849,104 @@ describe("ExecutionAdmissionRepository", () => {
     expect(admissions.listReservations({ runId: "safe-run" })).toHaveLength(2);
   });
 });
+
+describe("sumReconciledUsageByRunId — the child usage rollup read", () => {
+  function reconciledReservation(
+    runId: string,
+    stepId: string,
+    usage: { inputTokens: number; outputTokens: number; costUsd: number },
+  ): void {
+    const step = request(runId, stepId, { input: 500, output: 500, cost: 1 });
+    admissions.enqueue(step);
+    const reservation = claimReservation(admissionRecordKey(step.step));
+    admissions.markDispatched(reservation.reservationId);
+    expect(
+      admissions.reconcile(reservation.reservationId, {
+        kind: "reported",
+        usage,
+      }),
+    ).toEqual({ applied: true, outcome: "reconciled" });
+  }
+
+  it("sums only reconciled actuals; held_unknown is counted, never summed", () => {
+    reconciledReservation("child-x", "turn-1", {
+      inputTokens: 10,
+      outputTokens: 20,
+      costUsd: 0.25,
+    });
+    reconciledReservation("child-x", "turn-2", {
+      inputTokens: 5,
+      outputTokens: 7,
+      costUsd: 0.5,
+    });
+    // A dispatched reservation whose spend is unknowable: held, its RESERVED
+    // 1000 tokens / $1 must never be reported as spent.
+    const held = request("child-x", "turn-3", {
+      input: 500,
+      output: 500,
+      cost: 1,
+    });
+    admissions.enqueue(held);
+    const heldReservation = claimReservation(admissionRecordKey(held.step));
+    admissions.markDispatched(heldReservation.reservationId);
+    admissions.holdUnknown(heldReservation.reservationId, "daemon_killed");
+    // Another run's reconciled row must not leak into child-x's sums.
+    reconciledReservation("child-y", "turn-1", {
+      inputTokens: 100,
+      outputTokens: 100,
+      costUsd: 0.125,
+    });
+
+    expect(admissions.sumReconciledUsageByRunId("child-x")).toEqual({
+      reconciledCount: 2,
+      heldUnknownCount: 1,
+      inputTokens: 15,
+      outputTokens: 27,
+      totalTokens: 42,
+      costUsd: 0.75,
+    });
+    expect(admissions.sumReconciledUsageByRunId("child-y")).toEqual({
+      reconciledCount: 1,
+      heldUnknownCount: 0,
+      inputTokens: 100,
+      outputTokens: 100,
+      totalTokens: 200,
+      costUsd: 0.125,
+    });
+  });
+
+  it("a run with no reservations sums to zero with no holds", () => {
+    expect(admissions.sumReconciledUsageByRunId("child-absent")).toEqual({
+      reconciledCount: 0,
+      heldUnknownCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+    });
+  });
+
+  it("provider_overrun rows contribute their reported actuals", () => {
+    const step = request("child-overrun", "turn-1", {
+      input: 10,
+      output: 10,
+      cost: 0.001,
+    });
+    admissions.enqueue(step);
+    const reservation = claimReservation(admissionRecordKey(step.step));
+    admissions.markDispatched(reservation.reservationId);
+    admissions.reportProviderOverrun(reservation.reservationId, {
+      inputTokens: 50,
+      outputTokens: 10,
+      costUsd: 0.5,
+    });
+    expect(admissions.sumReconciledUsageByRunId("child-overrun")).toEqual({
+      reconciledCount: 1,
+      heldUnknownCount: 0,
+      inputTokens: 50,
+      outputTokens: 10,
+      totalTokens: 60,
+      costUsd: 0.5,
+    });
+  });
+});

--- a/runtime/tests/workflow/fixtures/m5-exit-child.ts
+++ b/runtime/tests/workflow/fixtures/m5-exit-child.ts
@@ -25,10 +25,12 @@ import { join } from "node:path";
 import { buildM5Harness, M5_EXIT_RUN_ID } from "./m5-harness.js";
 
 const FAILPOINT = "after_spawn_before_effect_result";
+const REVIEW_FAILPOINT = "before_review_commit";
 const FAILPOINT_TOKEN = "m5-workflow-child";
 
 type Command = "crash" | "resume";
 type Mode = "controller" | "wiring";
+type Scenario = "implement" | "review";
 
 function requireArgument(value: string | undefined, name: string): string {
   if (value === undefined || value.length === 0) {
@@ -40,6 +42,7 @@ function requireArgument(value: string | undefined, name: string): string {
 const command = requireArgument(process.argv[2], "command") as Command;
 const mode = requireArgument(process.argv[3], "mode") as Mode;
 const stateDir = requireArgument(process.argv[4], "state directory");
+const scenario = (process.argv[5] ?? "implement") as Scenario;
 
 const home = join(stateDir, "home");
 const repoPath = join(stateDir, "repo");
@@ -59,7 +62,7 @@ function buildHarness(withCrashArming: boolean) {
     receiptsDir,
     implementFix: IMPLEMENT_FIX,
     throughDaemonWiring: mode === "wiring",
-    ...(withCrashArming
+    ...(withCrashArming && scenario === "implement"
       ? {
           onImplementSettled: () => {
             // Arm the production failpoint ONLY now: the child terminal is
@@ -75,6 +78,15 @@ function buildHarness(withCrashArming: boolean) {
 }
 
 async function crash(): Promise<never> {
+  if (scenario === "review") {
+    // `before_review_commit` fires strictly AFTER the review execute — the
+    // reviewer has settled and the controller has durably recorded the
+    // review child's terminal — and BEFORE the review effect_result
+    // journals. Arming it from process start is safe: no earlier boundary
+    // matches this name.
+    process.env.AGENC_TEST_DURABILITY_FAILPOINT = REVIEW_FAILPOINT;
+    process.env.AGENC_TEST_DURABILITY_FAILPOINT_TOKEN = FAILPOINT_TOKEN;
+  }
   const harness = buildHarness(true);
   const started = await harness.controller.start({
     goal: "lib/add.js returns the wrong value: add(2, 3) must equal 5. Fix the arithmetic bug so the required script passes.",
@@ -120,6 +132,12 @@ async function resume(): Promise<void> {
     implementChildTerminal:
       harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:implement#1`)
         ?.status ?? null,
+    reviewOutcome:
+      harness.repo.getEffect(M5_EXIT_RUN_ID, "workflow.review")?.outcome ??
+      null,
+    reviewChildTerminal:
+      harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:review#1`)
+        ?.status ?? null,
     terminal:
       harness.repo.getCurrentTerminalResult(M5_EXIT_RUN_ID)?.status ?? null,
   };
@@ -163,6 +181,7 @@ async function resume(): Promise<void> {
 
   const report = {
     mode,
+    scenario,
     preResume,
     resumed,
     terminal:
@@ -184,6 +203,15 @@ async function resume(): Promise<void> {
         harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:implement#2`)
           ?.status ?? null,
     },
+    reviewChildTerminals: {
+      attempt1:
+        harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:review#1`)
+          ?.status ?? null,
+      attempt2:
+        harness.repo.getCurrentTerminalResult(`${M5_EXIT_RUN_ID}:review#2`)
+          ?.status ?? null,
+    },
+    reviewInvocations: readReceipts("review-invocations.jsonl"),
     resumeSpawnKinds: harness.spawnKinds,
     reservations,
     warnings: harness.warnings,

--- a/runtime/tests/workflow/fixtures/m5-exit-shared.ts
+++ b/runtime/tests/workflow/fixtures/m5-exit-shared.ts
@@ -32,6 +32,9 @@ const NODE_TEST_LOADER = fileURLToPath(
 const TSX_IMPORT = fileURLToPath(import.meta.resolve("tsx"));
 
 export const M5_EXIT_FAILPOINT = "after_spawn_before_effect_result";
+export const M5_EXIT_REVIEW_FAILPOINT = "before_review_commit";
+
+export type M5ExitScenario = "implement" | "review";
 
 const HIDDEN_VERIFIER = `#!/usr/bin/env bash
 # HIDDEN verifier: never present in the fixture repo, any prompt, or the
@@ -58,9 +61,12 @@ interface ChildExit {
 
 export interface M5ExitReport {
   readonly mode: string;
+  readonly scenario: M5ExitScenario;
   readonly preResume: {
     readonly implementOutcome: string | null;
     readonly implementChildTerminal: string | null;
+    readonly reviewOutcome: string | null;
+    readonly reviewChildTerminal: string | null;
     readonly terminal: string | null;
   };
   readonly resumed: readonly string[];
@@ -83,6 +89,11 @@ export interface M5ExitReport {
     readonly attempt1: string | null;
     readonly attempt2: string | null;
   };
+  readonly reviewChildTerminals: {
+    readonly attempt1: string | null;
+    readonly attempt2: string | null;
+  };
+  readonly reviewInvocations: readonly unknown[];
   readonly resumeSpawnKinds: readonly string[];
   readonly reservations: readonly {
     readonly id: string;
@@ -181,6 +192,7 @@ function spawnFixture(
   mode: M5ExitMode,
   stateDir: string,
   env: NodeJS.ProcessEnv,
+  scenario: M5ExitScenario,
 ): ChildProcess {
   return spawn(
     process.execPath,
@@ -193,6 +205,7 @@ function spawnFixture(
       command,
       mode,
       stateDir,
+      scenario,
     ],
     { cwd: stateDir, env, stdio: ["ignore", "pipe", "pipe"] },
   );
@@ -201,14 +214,18 @@ function spawnFixture(
 export async function crashPhase(
   mode: M5ExitMode,
   stateDir: string,
+  scenario: M5ExitScenario = "implement",
 ): Promise<void> {
   const marker = join(stateDir, "failpoint-reached.json");
   const env = cleanChildEnvironment();
   // Only the marker path is armed from outside; the child arms the
-  // failpoint NAME itself, strictly after the implement child's terminal is
-  // durable — that engineered ordering IS the exit-criterion window.
+  // failpoint NAME itself — for the implement scenario strictly after the
+  // implement child's terminal is durable, for the review scenario at the
+  // `before_review_commit` boundary (which the controller reaches only
+  // after the reviewer settled and its terminal became durable). That
+  // engineered ordering IS the exit-criterion window.
   env.AGENC_TEST_DURABILITY_FAILPOINT_MARKER = marker;
-  const child = spawnFixture("crash", mode, stateDir, env);
+  const child = spawnFixture("crash", mode, stateDir, env, scenario);
   const exitPromise = collectChild(child);
   const deadline = Date.now() + 120_000;
   while (!existsSync(marker)) {
@@ -228,15 +245,23 @@ export async function crashPhase(
     `crash child output:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
   ).toMatchObject({ code: null, signal: "SIGKILL" });
   expect(JSON.parse(readFileSync(marker, "utf8"))).toMatchObject({
-    failpoint: M5_EXIT_FAILPOINT,
+    failpoint:
+      scenario === "review" ? M5_EXIT_REVIEW_FAILPOINT : M5_EXIT_FAILPOINT,
   });
 }
 
 export async function resumePhase(
   mode: M5ExitMode,
   stateDir: string,
+  scenario: M5ExitScenario = "implement",
 ): Promise<M5ExitReport> {
-  const child = spawnFixture("resume", mode, stateDir, cleanChildEnvironment());
+  const child = spawnFixture(
+    "resume",
+    mode,
+    stateDir,
+    cleanChildEnvironment(),
+    scenario,
+  );
   const result = await collectChild(child);
   expect(
     result,
@@ -254,6 +279,8 @@ export function assertExitReport(report: M5ExitReport, runId: string): void {
   expect(report.preResume).toEqual({
     implementOutcome: null,
     implementChildTerminal: "completed",
+    reviewOutcome: null,
+    reviewChildTerminal: null,
     terminal: null,
   });
   expect(report.resumed).toContain(runId);
@@ -301,6 +328,59 @@ export function assertExitReport(report: M5ExitReport, runId: string): void {
       (reservation) => reservation.status === "held_unknown",
     ).length,
   ).toBeGreaterThanOrEqual(1);
+}
+
+/**
+ * Review-scenario exit assertions: a SIGKILL AFTER the reviewer's durable
+ * terminal was recorded but BEFORE the review effect_result committed must
+ * resume to `completed` by ADOPTING the durable review terminal — the
+ * reviewer is never re-invoked. This is revert-sensitive to the
+ * controller's review-terminal recording: without it the resume resolves
+ * `unknown_outcome`.
+ */
+export function assertReviewExitReport(
+  report: M5ExitReport,
+  runId: string,
+): void {
+  // The engineered kill window: review child terminal durable, review
+  // effect result NOT committed, run not terminal.
+  expect(report.preResume).toMatchObject({
+    implementOutcome: "committed",
+    reviewOutcome: null,
+    reviewChildTerminal: "completed",
+    terminal: null,
+  });
+  expect(report.resumed).toContain(runId);
+  expect(report.terminal?.status).toBe("completed");
+  expect(report.terminal?.finalMessage).toContain("verified change completed");
+  // Exactly ONE reviewer invocation ever happened — in the crashed
+  // process. Adoption completed the effect from the durable terminal.
+  expect(report.reviewInvocations).toHaveLength(1);
+  expect(report.reviewChildTerminals).toEqual({
+    attempt1: "completed",
+    attempt2: null,
+  });
+  expect(
+    report.effects.filter((effect) =>
+      effect.stepId.startsWith("workflow.review"),
+    ),
+  ).toEqual([
+    {
+      stepId: "workflow.review",
+      outcome: "committed",
+      childRunId: `${runId}:review#1`,
+    },
+  ]);
+  // The whole pipeline is durably committed after resume.
+  for (const effect of report.effects) {
+    expect(effect.outcome).toBe("committed");
+  }
+  // Budget honesty is unchanged: nothing dangling.
+  for (const reservation of report.reservations) {
+    expect(["reconciled", "held_unknown", "voided"]).toContain(
+      reservation.status,
+    );
+  }
 }
 
 export async function assertBundleAndHiddenVerifier(

--- a/runtime/tests/workflow/fixtures/m5-harness.ts
+++ b/runtime/tests/workflow/fixtures/m5-harness.ts
@@ -338,7 +338,15 @@ export function buildM5Harness(options: M5HarnessOptions): M5Harness {
   };
 
   const reviewer: ReviewerInvoker = {
-    invoke: async () => M5_APPROVING_REVIEW,
+    invoke: async () => {
+      // Physical receipt: reviewer invocations survive kills, so the resume
+      // phase can prove adoption never re-ran the reviewer.
+      appendFileSync(
+        join(options.receiptsDir, "review-invocations.jsonl"),
+        `${JSON.stringify({ pid: process.pid })}\n`,
+      );
+      return M5_APPROVING_REVIEW;
+    },
   };
 
   const warn = (message: string): void => {

--- a/runtime/tests/workflow/m5-exit.hermetic.test.ts
+++ b/runtime/tests/workflow/m5-exit.hermetic.test.ts
@@ -31,6 +31,7 @@ import { resolveStateDatabasePaths } from "../../src/state/sqlite-driver.js";
 import {
   assertBundleAndHiddenVerifier,
   assertExitReport,
+  assertReviewExitReport,
   cleanupM5ExitStateDirs,
   crashPhase,
   makeStateDir,
@@ -120,6 +121,22 @@ describe.sequential("M5 exit proof — hermetic SIGKILL crash/restart", () => {
       expect(tail.events).toEqual([]);
       expect(tail.gap).toBeNull();
 
+      await assertBundleAndHiddenVerifier(stateDir, report.bundleDir);
+    },
+  );
+
+  it(
+    "completes after a kill at before_review_commit by adopting the reviewer's durable terminal",
+    { timeout: 240_000 },
+    async () => {
+      // The kill lands AFTER the reviewer settled and its terminal was
+      // durably recorded, BEFORE the review effect_result committed. The
+      // restart must complete the run by ADOPTION — never re-invoking the
+      // reviewer — and the sealed bundle must still verify end to end.
+      const stateDir = makeStateDir("agenc-m5-exit-review-");
+      await crashPhase("controller", stateDir, "review");
+      const report = await resumePhase("controller", stateDir, "review");
+      assertReviewExitReport(report, M5_EXIT_RUN_ID);
       await assertBundleAndHiddenVerifier(stateDir, report.bundleDir);
     },
   );

--- a/runtime/tests/workflow/session-adapters.policy.test.ts
+++ b/runtime/tests/workflow/session-adapters.policy.test.ts
@@ -24,11 +24,12 @@ import {
   createWorkflowSessionSeams,
   inspectWorkflowChildTerminal,
   recordWorkflowChildTerminal,
+  workflowChildAdmissionUsage,
   workflowPermissionModeArgv,
   type WorkflowSessionSeams,
 } from "../../src/app-server/workflow/session-adapters.js";
 import type { WorkflowRunSessionPolicy } from "../../src/app-server/workflow/verified-change-controller.js";
-import type { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
 import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
 import type { ToolPermissionContext } from "../../src/permissions/types.js";
 import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
@@ -280,5 +281,91 @@ describe("A1 — durable child terminals for cross-restart adoption", () => {
       seams.spawner.inspect(`${RUN_ID}:verify-agent#1`),
     ).resolves.toEqual({ state: "unknown" });
     await seams.close();
+  });
+});
+
+describe("child usage rollup from reconciled admissions", () => {
+  it("sums the child run's reconciled actuals and surfaces held_unknown as a count", async () => {
+    const kernel = new ExecutionAdmissionKernel({
+      agencHome: home,
+      ownerId: "m5-usage-test",
+      ownerPid: process.pid,
+    });
+    try {
+      const client = kernel.bindClient({
+        cwd,
+        budgetIdentity: "wf-usage-run",
+        scope: {
+          runId: "wf-usage-run",
+          sessionId: "wf-usage-session",
+          autonomous: true,
+        },
+      });
+      // The delegate child's admissions live under ITS run id (the child
+      // thread id) — exactly how run-agent binds forSession for a spawned
+      // agent.
+      const child = client.forSession({
+        runId: "thread-child-1",
+        sessionId: "thread-child-1",
+      });
+      const settle = async (
+        stepId: string,
+        outcome:
+          | { kind: "reconciled"; inputTokens: number; outputTokens: number; costUsd: number }
+          | { kind: "held_unknown" },
+      ): Promise<void> => {
+        const lease = await child.acquire({
+          stepId,
+          kind: "model_turn",
+          maxInputTokens: 1_000,
+          maxOutputTokens: 1_000,
+          maxCostUsd: 1,
+        });
+        const reservationId = lease.reservation.reservationId;
+        child.markDispatched(reservationId, { boundary: "provider_wire" });
+        if (outcome.kind === "reconciled") {
+          child.reconcile(reservationId, {
+            inputTokens: outcome.inputTokens,
+            outputTokens: outcome.outputTokens,
+            costUsd: outcome.costUsd,
+          });
+        } else {
+          child.holdUnknown(reservationId, "daemon_killed_mid_turn");
+        }
+        child.acknowledgeCompletion(reservationId);
+      };
+      await settle("turn-1", {
+        kind: "reconciled",
+        inputTokens: 11,
+        outputTokens: 22,
+        costUsd: 0.25,
+      });
+      await settle("turn-2", {
+        kind: "reconciled",
+        inputTokens: 4,
+        outputTokens: 6,
+        costUsd: 0.5,
+      });
+      await settle("turn-3", { kind: "held_unknown" });
+
+      // Reconciled actuals only; the held reservation's RESERVED 2000
+      // tokens / $1 are never reported as spent.
+      expect(workflowChildAdmissionUsage(kernel, "thread-child-1")).toEqual({
+        usage: {
+          inputTokens: 15,
+          outputTokens: 28,
+          totalTokens: 43,
+          costUsd: 0.75,
+        },
+        heldUnknownCount: 1,
+      });
+      // Nothing reconciled → honestly null, never invented zeros-as-spend.
+      expect(workflowChildAdmissionUsage(kernel, "thread-none")).toEqual({
+        usage: null,
+        heldUnknownCount: 0,
+      });
+    } finally {
+      kernel.close();
+    }
   });
 });

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -15,7 +15,9 @@ import {
   type WorkflowStartParams,
   type WorkflowWorktreeBroker,
 } from "../../src/app-server/workflow/verified-change-controller.js";
+import { inspectWorkflowChildTerminal } from "../../src/app-server/workflow/child-terminals.js";
 import { AdmissionDeniedError, type ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
+import { M5WorkflowFailpointError } from "../../src/durability/failpoints.js";
 import type { AdmissionLease } from "../../src/budget/admission-types.js";
 import type {
   RunArtifactPointer,
@@ -372,6 +374,8 @@ class FakeSpawner implements WorkflowAgentSpawner {
   }[] = [];
   readonly queues = new Map<WorkflowSpawnKind, WorkflowChildOutcome[]>();
   readonly inspections = new Map<string, WorkflowChildInspection>();
+  /** Mirrors production: inspect falls back to the durable child terminal. */
+  durableRepo?: StateRunDurabilityRepository;
   beforeReturn?: (input: { kind: WorkflowSpawnKind }) => void;
 
   queue(kind: WorkflowSpawnKind, outcome: WorkflowChildOutcome): void {
@@ -410,7 +414,13 @@ class FakeSpawner implements WorkflowAgentSpawner {
   }
 
   async inspect(childRunId: string): Promise<WorkflowChildInspection> {
-    return this.inspections.get(childRunId) ?? { state: "unknown" };
+    const scripted = this.inspections.get(childRunId);
+    if (scripted !== undefined) return scripted;
+    if (this.durableRepo !== undefined) {
+      const durable = inspectWorkflowChildTerminal(this.durableRepo, childRunId);
+      if (durable !== undefined) return { state: "terminal", outcome: durable };
+    }
+    return { state: "unknown" };
   }
 }
 
@@ -424,6 +434,8 @@ const APPROVING_REVIEW = JSON.stringify({
 class FakeReviewer implements ReviewerInvoker {
   readonly invocations: { reviewerModel: string; userMessage: string }[] = [];
   readonly responses: string[] = [];
+  /** Simulate a daemon death mid-review (before the reviewer settled). */
+  onInvoke?: () => void;
 
   async invoke(input: {
     reviewerModel: string;
@@ -433,6 +445,7 @@ class FakeReviewer implements ReviewerInvoker {
       reviewerModel: input.reviewerModel,
       userMessage: input.userMessage,
     });
+    this.onInvoke?.();
     return this.responses.shift() ?? APPROVING_REVIEW;
   }
 }
@@ -488,6 +501,7 @@ function makeHarness(): Harness {
   const spawner = new FakeSpawner();
   const reviewer = new FakeReviewer();
   const commands = new FakeCommands();
+  spawner.durableRepo = repo;
   const ledgers = new Map<string, MemoryLedger>();
   const warnings: string[] = [];
   const controller = new VerifiedChangeWorkflowController({
@@ -1029,5 +1043,238 @@ describe("VerifiedChangeWorkflowController — crash recovery (D3)", () => {
     expect(
       harness.spawner.spawns.filter((s) => s.kind === "verify_agent"),
     ).toHaveLength(1);
+  });
+});
+
+describe("VerifiedChangeWorkflowController — review-child adoption (A1 for the reviewer)", () => {
+  const REVIEW_CHILD = `${RUN_ID}:review#1`;
+
+  it("crash after the reviewer's durable terminal, before the review effect result commits → resume completes by adoption", async () => {
+    // `before_review_commit` sits AFTER the review execute (where the
+    // reviewer settled and its terminal became durable) and BEFORE the
+    // review effect_result journals — the engineered window.
+    armFailpoint("before_review_commit");
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    disarmFailpoint();
+
+    // The objective window: review intent journaled without an outcome,
+    // and the reviewer's terminal ALREADY durable. This durable terminal is
+    // the revert-sensitive fact — without the controller recording it, the
+    // resume below resolves unknown_outcome instead of completing.
+    const interrupted = harness.repo.getEffect(RUN_ID, "workflow.review")!;
+    expect(interrupted.outcome).toBeUndefined();
+    expect(interrupted.childRunId).toBe(REVIEW_CHILD);
+    expect(
+      harness.repo.getCurrentTerminalResult(REVIEW_CHILD)?.status,
+    ).toBe("completed");
+    expect(harness.reviewer.invocations).toHaveLength(1);
+
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    const adopted = harness.repo.getEffect(RUN_ID, "workflow.review")!;
+    expect(adopted.outcome).toBe("committed");
+    const evidence = adopted.evidence as {
+      review?: { blockerCount: number; reviewerModel: string };
+      artifacts?: unknown[];
+    };
+    expect(evidence.review).toMatchObject({
+      blockerCount: 0,
+      reviewerModel: "test-reviewer",
+    });
+    expect(evidence.artifacts).toHaveLength(1);
+    // Adoption, never a re-run: the reviewer was invoked exactly once.
+    expect(harness.reviewer.invocations).toHaveLength(1);
+  });
+
+  it("a reviewer that genuinely died mid-flight (no durable terminal) stays unknown → unknown_outcome", async () => {
+    harness.reviewer.onInvoke = () => {
+      // The daemon dies while the reviewer is in flight: nothing settles,
+      // nothing becomes durable.
+      throw new M5WorkflowFailpointError("before_review_commit");
+    };
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    harness.reviewer.onInvoke = undefined as never;
+
+    expect(
+      harness.repo.getEffect(RUN_ID, "workflow.review")?.outcome,
+    ).toBeUndefined();
+    expect(
+      harness.repo.getCurrentTerminalResult(REVIEW_CHILD),
+    ).toBeUndefined();
+
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "unknown_outcome",
+      stopReason: "unknown_outcome_effect",
+    });
+    const effect = harness.repo.getEffect(RUN_ID, "workflow.review")!;
+    expect(effect.outcome).toBe("unknown_outcome");
+    expect(effect.reviewStatus).toBe("pending");
+    // Honesty: the reviewer is never silently re-run.
+    expect(harness.reviewer.invocations).toHaveLength(1);
+  });
+
+  it("a settled-but-unparseable reviewer adopted after a crash keeps its failed outcome and retries once", async () => {
+    harness.reviewer.responses.push("no structured output at all");
+    armFailpoint("before_review_commit");
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    disarmFailpoint();
+    // The unparseable settle IS durable — as a FAILED review child terminal.
+    expect(
+      harness.repo.getCurrentTerminalResult(REVIEW_CHILD)?.status,
+    ).toBe("failed");
+
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+
+    // Attempt 1 adopted as failed; attempt 2 re-ran the reviewer fresh and
+    // approved.
+    expect(harness.repo.getEffect(RUN_ID, "workflow.review")?.outcome).toBe(
+      "failed",
+    );
+    expect(
+      harness.repo.getEffect(RUN_ID, "workflow.review#2")?.outcome,
+    ).toBe("committed");
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    expect(harness.reviewer.invocations).toHaveLength(2);
+  });
+});
+
+describe("VerifiedChangeWorkflowController — child usage rollup", () => {
+  it("the terminal usage reflects the children's reconciled sums exactly; holds are noted, never spent", async () => {
+    harness.spawner.queue("plan", {
+      status: "completed",
+      finalMessage: "PLAN: make the edit",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        costUsd: 0.25,
+      },
+    });
+    harness.spawner.queue("implement", {
+      status: "completed",
+      finalMessage: "done",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+        costUsd: 0.5,
+      },
+      usageHeldUnknownCount: 2,
+    });
+    harness.spawner.queue("verify_agent", {
+      status: "completed",
+      finalMessage: "checked everything\nVERDICT: PASS",
+      usage: {
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+        costUsd: 0.125,
+      },
+    });
+    await runToTerminal(harness);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal.status).toBe("completed");
+    // Exact reconciled sums: 10+100+7 / 5+50+3 / 0.25+0.5+0.125.
+    expect(terminal.usage).toEqual({
+      inputTokens: 117,
+      outputTokens: 58,
+      totalTokens: 175,
+      costUsd: 0.875,
+    });
+    // The durable child evidence carries the usage and NOTES the holds
+    // (held_unknown spend is never summed into any total).
+    const implement = harness.repo.getEffect(RUN_ID, "workflow.implement")!;
+    const child = (implement.evidence as {
+      child?: { usage?: unknown; usageHeldUnknown?: number };
+    }).child!;
+    expect(child.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      costUsd: 0.5,
+    });
+    expect(child.usageHeldUnknown).toBe(2);
+  });
+
+  it("adoption and replay carry durably recorded child usage into the post-restart terminal rollup", async () => {
+    harness.spawner.queue("plan", {
+      status: "completed",
+      finalMessage: "PLAN: make the edit",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        costUsd: 0.25,
+      },
+    });
+    harness.spawner.queue("verify_agent", {
+      status: "completed",
+      finalMessage: "checked everything\nVERDICT: PASS",
+      usage: {
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+        costUsd: 0.125,
+      },
+    });
+    harness.spawner.beforeReturn = (input) => {
+      if (input.kind === "implement") {
+        armFailpoint("after_spawn_before_effect_result");
+      }
+    };
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    harness.spawner.beforeReturn = undefined as never;
+    disarmFailpoint();
+
+    // The implementer's durable terminal (recorded before the crash)
+    // carries its reconciled usage — adoption must roll it up.
+    harness.spawner.inspections.set(`${RUN_ID}:implement#1`, {
+      state: "terminal",
+      outcome: {
+        status: "completed",
+        finalMessage: "done",
+        usage: {
+          inputTokens: 40,
+          outputTokens: 2,
+          totalTokens: 42,
+          costUsd: 0.5,
+        },
+      },
+    });
+    await harness.controller.resumeOpenWorkflows();
+    await harness.controller.awaitRun(RUN_ID);
+
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID)!;
+    expect(terminal.status).toBe("completed");
+    // Replayed plan (10/5/0.25) + adopted implement (40/2/0.5) + fresh
+    // verify agent (7/3/0.125): the post-restart rollup keeps every child.
+    expect(terminal.usage).toEqual({
+      inputTokens: 57,
+      outputTokens: 10,
+      totalTokens: 67,
+      costUsd: 0.875,
+    });
   });
 });


### PR DESCRIPTION
Closes the two known M5 residuals (improve loop, step 1).

- Review child gets the full durable-terminal treatment: recorded via the A1 helper strictly before the review effect result can commit; crash in that window now resumes to completed by adoption. Honesty pinned: a reviewer that died mid-flight stays unknown_outcome; settled-but-unparseable adopts as failed with bounded retry.
- Child usage rollup sourced from reconciled admission reservations (additive `sumReconciledUsageByRunId`); held_unknown surfaced, never counted as spend; no double-charge against the parent reservation.

## Verification (local)
- typecheck clean; full stable vitest: 1862 files / 16244 passed / 0 failed (SUITE-EXIT:0)
- Four-suite battery: 97 files / 957 tests green incl. new SIGKILL-at-before_review_commit lane
- Revert-proofs observed: terminal-recording disabled → exit lane red; usage accumulation disabled → rollup collapses (57/10/67 → 7/3/10)
- Tested SHA: 7f3bdd8dd79caf2389ca138dc034633f5328b0aa