### PR TITLE
fix: xAI OAuth cross-process refresh race, token-ledger double count, honest spinner tok/s

### DIFF
--- a/runtime/src/llm/provider.ts
+++ b/runtime/src/llm/provider.ts
@@ -56,6 +56,7 @@ import {
   forceRefreshXaiOauthCredentials,
   isXaiOauthBearer,
   readXaiOauthAccessToken,
+  xaiOauthRequiresRelogin,
 } from "../utils/xaiOauthCredentials.js";
 import { isTrustedXaiOauthInferenceBaseUrl } from "../services/xai/oauth.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
@@ -1454,11 +1455,26 @@ export function createProvider(
           refreshBearer: async () => {
             const refreshed = await forceRefreshXaiOauthCredentials();
             if (refreshed === undefined) {
+              // Honesty split: only claim the user is logged out when the
+              // stored grant is genuinely dead (quarantined terminal
+              // invalid_grant, or gone). A transient network/endpoint
+              // failure during refresh must not flap the TUI to
+              // "Not logged in" while the grant is still viable — the next
+              // 401/pre-flight retries the single-flight refresh.
+              if (xaiOauthRequiresRelogin()) {
+                return {
+                  kind: "exhausted",
+                  reason:
+                    "xAI OAuth session expired — run /grok-login to sign in again, " +
+                    "or set XAI_API_KEY to use API-key billing",
+                };
+              }
               return {
                 kind: "exhausted",
                 reason:
-                  "xAI OAuth refresh failed — run /grok-login to sign in again, " +
-                  "or set XAI_API_KEY to use API-key billing",
+                  "xAI OAuth token refresh temporarily failed (network or " +
+                  "provider error). Your sign-in is still valid; retrying — " +
+                  "no /grok-login needed",
               };
             }
             grokProvider.applyRefreshedBearer(refreshed.accessToken);

--- a/runtime/src/llm/providers/grok/auth-refresh.ts
+++ b/runtime/src/llm/providers/grok/auth-refresh.ts
@@ -137,7 +137,19 @@ export async function retryWithAuthRefresh<T>(
         bearer = outcome.bearer;
         continue;
       }
-      // skipped / exhausted → bubble the original 401 up.
+      if (outcome.kind === "exhausted") {
+        // Surface WHY recovery stopped: the raw 401/403 alone reads as
+        // "Forbidden" in the TUI, which users misread as "logged out"
+        // even when the refresh failure was transient. Preserve the
+        // original status for classifiers.
+        const wrapped = new Error(
+          `${error.message} (${outcome.reason})`,
+        ) as Error & { status?: number; cause?: unknown };
+        wrapped.status = error.status;
+        wrapped.cause = error;
+        throw wrapped;
+      }
+      // skipped → bubble the original 401 up.
       throw error;
     }
   }

--- a/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
+++ b/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
@@ -27,6 +27,11 @@ const STALL_NOTE_AFTER_MS = 8_000;
 // enough tokens that the figure is meaningful (mirrors the budget-path gate).
 const RATE_MIN_ELAPSED_MS = 5_000;
 const RATE_MIN_TOKENS = 20;
+// "slow model" is a claim about the MODEL, so it needs genuine streaming-rate
+// evidence: only attach the label when the measured active-streaming rate is
+// below this floor. Silence alone (e.g. between chunks) stays a neutral
+// "last token Ns ago" note.
+const SLOW_MODEL_MAX_RATE_PER_SEC = 10;
 // Mirrors Claude Code's spinner affordance: shown at the end of the status
 // byline whenever there is any status content to attach it to.
 const ESC_HINT_TEXT = 'esc to interrupt';
@@ -51,12 +56,85 @@ function getWholeSecondNow(): number {
 }
 
 /**
+ * Pure per-render step for token-liveness tracking. Exported for unit tests;
+ * the {@link useTokenLiveness} hook owns the ref plumbing.
+ *
+ * Honesty contract (operator bug 2026-07-20): the tok/s denominator counts
+ * ONLY active streaming windows. Wall-clock spent executing tools (or
+ * otherwise not waiting on the model) previously stayed in the denominator,
+ * so a healthy model read "2.4 tok/s · slow model" after a long tool run.
+ * While `streamingActive` is false the active clock pauses AND the
+ * no-token clock slides forward — tool time is never billed to the model.
+ */
+export interface TokenLivenessState {
+  firstSeenAt: number | null;
+  lastChangeAt: number;
+  lastTokens: number;
+  /** Accumulated ms spent in active streaming windows since first token. */
+  activeStreamMs: number;
+  /** Wall clock of the previous step (for active-window accumulation). */
+  lastStepAt: number;
+}
+
+export function initialTokenLivenessState(
+  totalTokens: number,
+  now: number,
+  turnStartedAt: number,
+): TokenLivenessState {
+  // First render of this turn. If no token has streamed yet, anchor the
+  // no-token clock at the turn start so a long pre-token silence reads as
+  // honest immediately (e.g. a remount mid-stall). If tokens are already
+  // present we don't know when the last one arrived, so treat "now" as fresh
+  // and never falsely flag a clearly-alive stream as stalled.
+  return {
+    firstSeenAt: totalTokens > 0 ? now : null,
+    lastChangeAt: totalTokens > 0 ? now : Math.min(turnStartedAt, now),
+    lastTokens: totalTokens,
+    activeStreamMs: 0,
+    lastStepAt: now,
+  };
+}
+
+export function stepTokenLiveness(
+  s: TokenLivenessState,
+  input: {
+    readonly totalTokens: number;
+    readonly now: number;
+    /** True while the turn is waiting on / receiving model output (no tools running). */
+    readonly streamingActive: boolean;
+  },
+): { msSinceLastToken: number; ratePerSec: number } {
+  const { totalTokens, now, streamingActive } = input;
+  const stepMs = Math.max(0, now - s.lastStepAt);
+  if (streamingActive && s.firstSeenAt !== null) {
+    s.activeStreamMs += stepMs;
+  }
+  s.lastStepAt = now;
+  if (!streamingActive) {
+    // Not the model's silence: tools (or another non-model phase) own this
+    // window. Slide the no-token clock so the eventual "last token Ns ago"
+    // note measures only model-owned silence.
+    s.lastChangeAt = Math.max(s.lastChangeAt, now);
+  }
+  if (totalTokens !== s.lastTokens) {
+    if (s.firstSeenAt === null && totalTokens > 0) s.firstSeenAt = now;
+    s.lastTokens = totalTokens;
+    s.lastChangeAt = now;
+  }
+  const msSinceLastToken = Math.max(0, now - s.lastChangeAt);
+  const ratePerSec =
+    totalTokens >= RATE_MIN_TOKENS && s.activeStreamMs >= RATE_MIN_ELAPSED_MS
+      ? (totalTokens / s.activeStreamMs) * 1000
+      : 0;
+  return { msSinceLastToken, ratePerSec };
+}
+
+/**
  * Tracks token liveness across renders so the row can tell "alive but slow"
  * from "hung". Returns ms since the token counter last moved and a tokens/sec
- * rate once tokens are flowing. Refs (not state) — the row re-renders from
- * its own 1s tick and from streaming state changes, so reading on render is
- * enough and avoids extra re-renders. `firstSeenAt` lets us measure rate from
- * when tokens started, not from a pre-stream zero.
+ * rate (active-streaming-window denominator) once tokens are flowing. Refs
+ * (not state) — the row re-renders from its own 1s tick and from streaming
+ * state changes, so reading on render is enough and avoids extra re-renders.
  *
  * `turnStartedAt` seeds the no-token clock so a turn that has already been
  * silent for minutes reports its real silence on the very first render (e.g.
@@ -66,46 +144,55 @@ function useTokenLiveness(
   totalTokens: number,
   now: number,
   turnStartedAt: number,
+  streamingActive: boolean,
 ): {
   msSinceLastToken: number;
   ratePerSec: number;
 } {
-  const state = React.useRef<{
-    firstSeenAt: number | null;
-    lastChangeAt: number;
-    lastTokens: number;
-  } | null>(null);
+  const state = React.useRef<TokenLivenessState | null>(null);
   if (state.current === null) {
-    // First render of this turn. If no token has streamed yet, anchor the
-    // no-token clock at the turn start so a long pre-token silence reads as
-    // honest immediately (e.g. a remount mid-stall). If tokens are already
-    // present we don't know when the last one arrived, so treat "now" as fresh
-    // and never falsely flag a clearly-alive stream as stalled.
-    state.current = {
-      firstSeenAt: totalTokens > 0 ? now : null,
-      lastChangeAt: totalTokens > 0 ? now : Math.min(turnStartedAt, now),
-      lastTokens: totalTokens,
-    };
+    state.current = initialTokenLivenessState(totalTokens, now, turnStartedAt);
   }
-  const s = state.current;
-  if (totalTokens !== s.lastTokens) {
-    if (s.firstSeenAt === null && totalTokens > 0) s.firstSeenAt = now;
-    s.lastTokens = totalTokens;
-    s.lastChangeAt = now;
-  }
-  const msSinceLastToken = Math.max(0, now - s.lastChangeAt);
-  const sinceFirst = s.firstSeenAt !== null ? now - s.firstSeenAt : 0;
-  const ratePerSec =
-    totalTokens >= RATE_MIN_TOKENS && sinceFirst >= RATE_MIN_ELAPSED_MS
-      ? (totalTokens / sinceFirst) * 1000
-      : 0;
-  return { msSinceLastToken, ratePerSec };
+  return stepTokenLiveness(state.current, { totalTokens, now, streamingActive });
 }
 
-function formatRate(ratePerSec: number): string {
+/**
+ * The rate is derived from a chars/4 token ESTIMATE, not provider-reported
+ * usage — mark it so it cannot be mistaken for provider truth.
+ */
+export function formatRate(ratePerSec: number): string {
   return ratePerSec >= 10
-    ? `${Math.round(ratePerSec)} tok/s`
-    : `${ratePerSec.toFixed(1)} tok/s`;
+    ? `~${Math.round(ratePerSec)} tok/s`
+    : `~${ratePerSec.toFixed(1)} tok/s`;
+}
+
+/**
+ * Stall-note selection, exported for unit tests.
+ *
+ * - While tools are running the model is not being asked for tokens, so no
+ *   note at all (the previous behavior showed "slow model · last token 16s
+ *   ago" mid-tool-run — meaningless and defamatory).
+ * - "slow model" requires genuine streaming-rate evidence (a measured
+ *   active-window rate below {@link SLOW_MODEL_MAX_RATE_PER_SEC}); plain
+ *   silence gets a neutral "last token Ns ago".
+ * - Pre-first-token silence reads "waiting for model" — we have no rate
+ *   evidence to blame the model with.
+ */
+export function selectStallNote(input: {
+  readonly totalTokens: number;
+  readonly msSinceLastToken: number;
+  readonly ratePerSec: number;
+  readonly toolsRunning: boolean;
+}): string | null {
+  if (input.toolsRunning) return null;
+  if (input.msSinceLastToken <= STALL_NOTE_AFTER_MS) return null;
+  if (input.totalTokens <= 0) {
+    return "waiting for model · no output yet";
+  }
+  const gap = `last token ${formatDuration(input.msSinceLastToken)} ago`;
+  const slowEvidence =
+    input.ratePerSec > 0 && input.ratePerSec < SLOW_MODEL_MAX_RATE_PER_SEC;
+  return slowEvidence ? `slow model · ${gap}` : gap;
 }
 
 export type SpinnerAnimationRowProps = {
@@ -197,24 +284,31 @@ export function SpinnerAnimationRow({
   // the leader's own stream (a foregrounded teammate reports its own progress).
   const trackLiveness =
     showLeaderTokenStats && !(foregroundedTeammate && !foregroundedTeammate.isIdle);
+  // While tools run the model is not streaming; the rate denominator pauses
+  // and stall notes are suppressed (tool time is not model time).
+  const toolsRunning =
+    hasActiveTools || mode === 'tool-use' || mode === 'tool-input';
   const { msSinceLastToken, ratePerSec } = useTokenLiveness(
     trackLiveness ? totalTokens : 0,
     now,
     loadingStartTimeRef.current,
+    !toolsRunning,
   );
   // Show the heartbeat once the turn has been waiting on a token long enough to
   // look stuck — but not while "thinking" is already explaining the silence.
-  const showStallNote =
+  const stallNoteText =
     trackLiveness &&
     !hasRunningTeammates &&
     thinkingStatus !== 'thinking' &&
-    elapsedTimeMs > STALL_NOTE_AFTER_MS &&
-    msSinceLastToken > STALL_NOTE_AFTER_MS;
-  const stallNoteText = showStallNote
-    ? totalTokens > 0
-      ? `slow model · last token ${formatDuration(msSinceLastToken)} ago`
-      : 'slow model · still generating'
-    : null;
+    elapsedTimeMs > STALL_NOTE_AFTER_MS
+      ? selectStallNote({
+          totalTokens,
+          msSinceLastToken,
+          ratePerSec,
+          toolsRunning,
+        })
+      : null;
+  const showStallNote = stallNoteText !== null;
   const stallNoteWidth = stallNoteText ? stringWidth(stallNoteText) : 0;
   const rateText = ratePerSec > 0 ? formatRate(ratePerSec) : null;
 

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1000,13 +1000,14 @@ function usageFromTokenCountPayload(payload: Record<string, unknown>): ModelUsag
   const cacheCreationInputTokens = nonNegativeInteger(payload.cacheCreationInputTokens);
   const reasoningOutputTokens = nonNegativeInteger(payload.reasoningOutputTokens);
   const webSearchRequests = nonNegativeInteger(payload.webSearchRequests);
+  // Fallback mirrors coerceUsage's own totalTokens fallback (prompt +
+  // completion). The old fallback also re-added cached/cache-creation/
+  // reasoning tokens — for the OpenAI/xAI convention cached is a SUBSET of
+  // promptTokens (and reasoning a subset of completion on the Responses
+  // API), so a missing provider total nearly doubled the displayed ledger
+  // total and its cost estimate.
   const totalTokens =
-    nonNegativeInteger(payload.totalTokens) ||
-    inputTokens +
-      outputTokens +
-      cachedInputTokens +
-      cacheCreationInputTokens +
-      reasoningOutputTokens;
+    nonNegativeInteger(payload.totalTokens) || inputTokens + outputTokens;
 
   return {
     model: nonEmptyString(payload.model) ?? "unknown",

--- a/runtime/src/utils/xaiOauthCredentials.ts
+++ b/runtime/src/utils/xaiOauthCredentials.ts
@@ -11,6 +11,9 @@
  *    the user must sign in again.
  */
 
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
 import {
   discoverXaiOauthEndpoints,
   decodeXaiJwtClaims,
@@ -20,7 +23,8 @@ import {
   isTrustedXaiOauthEndpoint,
 } from '../services/xai/oauth.js'
 import type { XaiOauthTokens } from '../services/xai/oauth.js'
-import { isBareMode } from './envUtils.js'
+import { getAgenCConfigHomeDir, isBareMode } from './envUtils.js'
+import * as lockfile from './lockfile.js'
 import { getSecureStorage } from './secureStorage/index.js'
 
 export const XAI_OAUTH_STORAGE_KEY = 'xaiOauth' as const
@@ -200,6 +204,32 @@ export async function refreshXaiOauthCredentialsIfNeeded(): Promise<
   return forceRefreshXaiOauthCredentials()
 }
 
+/**
+ * Cross-process advisory lock around the token-endpoint exchange. The
+ * in-process single-flight above cannot see a sibling agenc process (TUI +
+ * daemon, or two daemons on different projects share ~/.agenc credentials);
+ * two processes exchanging the same rotating refresh token concurrently
+ * means the loser gets a terminal `invalid_grant` and — before this fix —
+ * quarantined the blob, clobbering the winner's freshly rotated grant and
+ * killing the live session ("Not logged in" mid-turn).
+ *
+ * Best-effort: when the lock cannot be acquired the refresh still proceeds,
+ * protected by the adopt-on-conflict checks in {@link doRefresh}.
+ */
+async function acquireRefreshLock(): Promise<() => Promise<void>> {
+  try {
+    const dir = getAgenCConfigHomeDir()
+    await mkdir(dir, { recursive: true })
+    return await lockfile.lock(join(dir, '.xai-oauth-refresh'), {
+      realpath: false,
+      stale: 30_000,
+      retries: { retries: 5, minTimeout: 200, maxTimeout: 2_000 },
+    })
+  } catch {
+    return async () => {}
+  }
+}
+
 async function doRefresh(): Promise<XaiOauthCredentialBlob | undefined> {
   // Fresh read: another process may have already rotated the grant, and a
   // refresh with a stale (consumed) refresh token would burn it.
@@ -208,38 +238,95 @@ async function doRefresh(): Promise<XaiOauthCredentialBlob | undefined> {
   const refreshToken = blob.refreshToken?.trim()
   if (!refreshToken) return undefined
 
-  let tokenEndpoint = blob.tokenEndpoint
-  if (tokenEndpoint === undefined || !isTrustedXaiOauthEndpoint(tokenEndpoint)) {
-    try {
-      tokenEndpoint = (await discoverXaiOauthEndpoints()).tokenEndpoint
-    } catch {
+  const release = await acquireRefreshLock()
+  try {
+    // Re-read under the lock: a sibling process may have rotated the grant
+    // while we waited. Exchanging the stale token would burn the account's
+    // rotating-refresh chain, so adopt the sibling's rotation instead.
+    const current = readXaiOauthCredentialsFresh()
+    if (current === undefined || current.quarantinedAt !== undefined) {
       return undefined
     }
-  }
-
-  try {
-    const tokens = await refreshXaiOauthTokens({ tokenEndpoint, refreshToken })
-    const next = xaiOauthTokensToBlob(tokens, { tokenEndpoint, previous: blob })
-    saveXaiOauthCredentials(next)
-    return next
-  } catch (error) {
-    if (
-      error instanceof XaiOauthError &&
-      (error.code === 'invalid_grant' ||
-        error.code === 'access_denied' ||
-        error.code === 'expired_token')
-    ) {
-      // Terminal: the rotated grant is dead. Quarantine so no caller
-      // replays a doomed refresh; the user must run the login again.
-      saveXaiOauthCredentials({
-        ...blob,
-        quarantinedAt: Date.now(),
-        quarantineReason: error.message,
-      })
+    const currentRefresh = current.refreshToken?.trim()
+    if (!currentRefresh) return undefined
+    if (currentRefresh !== refreshToken) {
+      return current
     }
-    // Transport/transient failures leave the blob untouched: the refresh
-    // token may not have been consumed, and a retry would burn it if it
-    // was. The next 401 triggers another single attempt.
-    return undefined
+
+    let tokenEndpoint = current.tokenEndpoint
+    if (
+      tokenEndpoint === undefined ||
+      !isTrustedXaiOauthEndpoint(tokenEndpoint)
+    ) {
+      try {
+        tokenEndpoint = (await discoverXaiOauthEndpoints()).tokenEndpoint
+      } catch {
+        return undefined
+      }
+    }
+
+    try {
+      const tokens = await refreshXaiOauthTokens({
+        tokenEndpoint,
+        refreshToken: currentRefresh,
+      })
+      const next = xaiOauthTokensToBlob(tokens, {
+        tokenEndpoint,
+        previous: current,
+      })
+      saveXaiOauthCredentials(next)
+      return next
+    } catch (error) {
+      if (
+        error instanceof XaiOauthError &&
+        (error.code === 'invalid_grant' ||
+          error.code === 'access_denied' ||
+          error.code === 'expired_token')
+      ) {
+        // Terminal for OUR refresh token — but only quarantine when the
+        // stored grant is still the one that just failed. If a sibling
+        // process rotated the grant between our read and the failure
+        // (lock unavailable / bypassed), writing a quarantined stale blob
+        // here would destroy the sibling's good rotation and force a
+        // needless re-login. Adopt the sibling's grant instead.
+        const latest = readXaiOauthCredentialsFresh()
+        if (
+          latest !== undefined &&
+          latest.quarantinedAt === undefined &&
+          latest.refreshToken?.trim() !== currentRefresh
+        ) {
+          return latest
+        }
+        // Quarantine so no caller replays a doomed refresh; the user must
+        // run the login again.
+        saveXaiOauthCredentials({
+          ...(latest ?? current),
+          quarantinedAt: Date.now(),
+          quarantineReason: error.message,
+        })
+      }
+      // Transport/transient failures leave the blob untouched: the refresh
+      // token may not have been consumed, and a retry would burn it if it
+      // was. The next 401 triggers another single attempt.
+      return undefined
+    }
+  } finally {
+    await release()
   }
+}
+
+/**
+ * True when the stored grant is quarantined (terminal refresh failure) or
+ * absent — i.e. a new `/grok-login` is genuinely required. Used by the
+ * provider's refresh callback to keep the "run /grok-login" error honest:
+ * a transient network failure during refresh must NOT tell the user they
+ * are logged out.
+ */
+export function xaiOauthRequiresRelogin(): boolean {
+  const blob = readXaiOauthCredentialsFresh()
+  return (
+    blob === undefined ||
+    blob.quarantinedAt !== undefined ||
+    !blob.refreshToken?.trim()
+  )
 }

--- a/runtime/tests/llm/grok-oauth-factory.test.ts
+++ b/runtime/tests/llm/grok-oauth-factory.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 const credentialsModulePath = '../../src/utils/xaiOauthCredentials.js'
 
 let storedAccessToken: string | undefined
+let requiresRelogin = true
 const forceRefreshMock = vi.fn()
 
 async function importProviderModule() {
@@ -18,12 +19,14 @@ async function importProviderModule() {
     isXaiOauthBearer: (key: string | undefined) =>
       key !== undefined && key === storedAccessToken,
     forceRefreshXaiOauthCredentials: forceRefreshMock,
+    xaiOauthRequiresRelogin: () => requiresRelogin,
   }))
   return import('../../src/llm/provider.ts')
 }
 
 beforeEach(() => {
   storedAccessToken = undefined
+  requiresRelogin = true
   forceRefreshMock.mockReset()
 })
 
@@ -144,7 +147,34 @@ test('exhausted refresh reports a re-login hint instead of retrying', async () =
     previousError: Object.assign(new Error('401'), { status: 401 }),
   })
   expect(outcome.kind).toBe('exhausted')
-  expect(outcome.reason).toMatch(/grok-login/)
+  expect(outcome.reason).toMatch(/run \/grok-login/)
+  expect(outcome.reason).toMatch(/expired/)
+})
+
+test('transient refresh failure does not claim the user is logged out', async () => {
+  // The live failure this pins: a refresh that fails while the stored grant
+  // is still viable (network blip, endpoint 5xx, sibling-process race) used
+  // to surface "run /grok-login to sign in again" and flap the TUI to
+  // "Not logged in" mid-session. Honesty: only a dead grant may demand
+  // re-login.
+  storedAccessToken = 'oauth-bearer-1'
+  requiresRelogin = false
+  forceRefreshMock.mockResolvedValue(undefined)
+  const { createProvider } = await importProviderModule()
+
+  const provider = createProvider('grok', { model: 'grok-4.5' }) as unknown as {
+    authRefreshCallbacks?: {
+      refreshBearer: (ctx: unknown) => Promise<{ kind: string; reason?: string }>
+    }
+  }
+  const outcome = await provider.authRefreshCallbacks!.refreshBearer({
+    attempt: 1,
+    previousError: Object.assign(new Error('403'), { status: 403 }),
+  })
+  expect(outcome.kind).toBe('exhausted')
+  expect(outcome.reason).toMatch(/temporarily/)
+  expect(outcome.reason).toMatch(/still valid/)
+  expect(outcome.reason).not.toMatch(/sign in again/)
 })
 
 test('API-key mode keeps the no-refresh default callback', async () => {

--- a/runtime/tests/llm/providers/grok/adapter.test.ts
+++ b/runtime/tests/llm/providers/grok/adapter.test.ts
@@ -681,6 +681,72 @@ describe("GrokProvider incremental continuation", () => {
     });
   });
 
+  test("streamed usage is last-cumulative-wins, never a sum across events", async () => {
+    // xAI streams usage snapshots as CUMULATIVE totals; a stream can carry
+    // usage on more than one event (in_progress snapshots plus the final
+    // response.completed). Per-turn usage must equal the FINAL cumulative
+    // value — summing the snapshots would blow up quadratically (the
+    // absurd "+900M cached" family of readings). Pins exactly-once
+    // per-response usage accounting at the adapter boundary.
+    const provider = new GrokProvider({
+      apiKey: "xai-test",
+      model: "grok-4-fast",
+    });
+    const finalUsage = {
+      input_tokens: 48_892,
+      output_tokens: 169,
+      total_tokens: 49_061,
+      input_tokens_details: { cached_tokens: 46_720 },
+      output_tokens_details: { reasoning_tokens: 15 },
+    };
+    const create = vi.fn(() =>
+      withResponse(
+        streamFromEvents([
+          {
+            type: "response.in_progress",
+            response: {
+              ...buildXaiResponse("resp_usage_stream", ""),
+              status: "in_progress",
+              usage: {
+                input_tokens: 48_892,
+                output_tokens: 40,
+                total_tokens: 48_932,
+                input_tokens_details: { cached_tokens: 46_720 },
+              },
+            },
+          },
+          { type: "response.output_text.delta", delta: "part one " },
+          { type: "response.output_text.delta", delta: "part two" },
+          {
+            type: "response.completed",
+            response: {
+              ...buildXaiResponse("resp_usage_stream", "part one part two"),
+              usage: finalUsage,
+            },
+          },
+        ]),
+      )
+    );
+    (provider as any).client = { responses: { create } };
+
+    const result = await provider.chatStream(
+      [{ role: "user", content: "go" }],
+      () => {},
+    );
+
+    expect(result.usage).toMatchObject({
+      promptTokens: 48_892,
+      completionTokens: 169,
+      totalTokens: 49_061,
+      cachedInputTokens: 46_720,
+      reasoningOutputTokens: 15,
+    });
+    // Guard the failure mode explicitly: any summing across the two
+    // usage-bearing events would exceed the final cumulative values.
+    expect(result.usage.totalTokens).toBeLessThanOrEqual(49_061);
+    expect(result.usage.cachedInputTokens).toBeLessThanOrEqual(46_720);
+  });
+
   test("does not replace streamed text with a tool-disabled retry", async () => {
     const provider = new GrokProvider({
       apiKey: "xai-test",

--- a/runtime/tests/llm/providers/grok/auth-refresh.test.ts
+++ b/runtime/tests/llm/providers/grok/auth-refresh.test.ts
@@ -1,0 +1,74 @@
+import { expect, test, vi } from "vitest";
+
+import {
+  retryWithAuthRefresh,
+  type AuthRefreshCallbacks,
+  type UnauthorizedError,
+} from "../../../../src/llm/providers/grok/auth-refresh.js";
+
+function unauthorized(status: 401 | 403, message = "Forbidden"): UnauthorizedError {
+  return Object.assign(new Error(message), { status }) as UnauthorizedError;
+}
+
+test("refreshed outcome retries the operation with the new bearer", async () => {
+  const op = vi
+    .fn<(bearer: string) => Promise<string>>()
+    .mockRejectedValueOnce(unauthorized(401))
+    .mockResolvedValueOnce("ok");
+  const callbacks: AuthRefreshCallbacks = {
+    refreshBearer: async () => ({ kind: "refreshed", bearer: "bearer-2" }),
+  };
+
+  await expect(retryWithAuthRefresh("bearer-1", op, callbacks)).resolves.toBe("ok");
+  expect(op).toHaveBeenNthCalledWith(1, "bearer-1");
+  expect(op).toHaveBeenNthCalledWith(2, "bearer-2");
+});
+
+test("exhausted outcome surfaces the reason in the thrown error", async () => {
+  // Before this fix the raw 401/403 bubbled with just "Forbidden", which the
+  // TUI rendered with zero context — users read it as "logged out" even when
+  // the refresh failure was transient. The reason must ride along.
+  const op = vi
+    .fn<(bearer: string) => Promise<string>>()
+    .mockRejectedValue(unauthorized(403, "Forbidden"));
+  const callbacks: AuthRefreshCallbacks = {
+    refreshBearer: async () => ({
+      kind: "exhausted",
+      reason: "xAI OAuth token refresh temporarily failed",
+    }),
+  };
+
+  const thrown = await retryWithAuthRefresh("bearer-1", op, callbacks).then(
+    () => {
+      throw new Error("expected rejection");
+    },
+    (error: unknown) => error as Error & { status?: number; cause?: unknown },
+  );
+  expect(thrown.message).toContain("Forbidden");
+  expect(thrown.message).toContain("xAI OAuth token refresh temporarily failed");
+  expect(thrown.status).toBe(403);
+  expect((thrown.cause as Error).message).toBe("Forbidden");
+});
+
+test("skipped outcome bubbles the original error unchanged", async () => {
+  const original = unauthorized(401, "Unauthorized");
+  const op = vi.fn<(bearer: string) => Promise<string>>().mockRejectedValue(original);
+  const callbacks: AuthRefreshCallbacks = {
+    refreshBearer: async () => ({
+      kind: "skipped",
+      reason: "grok_bearer_key_mode_has_no_refresh",
+    }),
+  };
+
+  await expect(retryWithAuthRefresh("bearer-1", op, callbacks)).rejects.toBe(original);
+});
+
+test("non-auth errors are not retried", async () => {
+  const boom = new Error("boom");
+  const op = vi.fn<(bearer: string) => Promise<string>>().mockRejectedValue(boom);
+  const refreshBearer = vi.fn();
+  await expect(
+    retryWithAuthRefresh("bearer-1", op, { refreshBearer } as unknown as AuthRefreshCallbacks),
+  ).rejects.toBe(boom);
+  expect(refreshBearer).not.toHaveBeenCalled();
+});

--- a/runtime/tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx
+++ b/runtime/tests/tui/components/spinner/SpinnerAnimationRow.liveness.test.tsx
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
   SpinnerAnimationRow,
+  formatRate,
+  initialTokenLivenessState,
+  selectStallNote,
+  stepTokenLiveness,
   type SpinnerAnimationRowProps,
 } from "../../../../src/tui/components/spinner/SpinnerAnimationRow.js";
 import { renderToString } from "../../../../src/utils/staticRender.js";
@@ -80,8 +84,11 @@ describe("SpinnerAnimationRow liveness + token grammar", () => {
 
   // #2: a slow turn that has produced no new token for a while must surface a
   // moving liveness note so it reads as "alive but slow", not "hung". This
-  // reproduces the frozen "↓ 1 token (12m …)" build session.
-  test("shows a slow-model heartbeat after a long no-token gap", async () => {
+  // reproduces the frozen "↓ 1 token (12m …)" build session. Honesty update
+  // (2026-07-20): with zero tokens there is no rate evidence to blame the
+  // MODEL with, so the note is a neutral "waiting for model", not
+  // "slow model".
+  test("shows a waiting-for-model heartbeat after a long no-token gap", async () => {
     vi.spyOn(Date, "now").mockReturnValue(NOW);
 
     const output = await renderRow({
@@ -91,8 +98,28 @@ describe("SpinnerAnimationRow liveness + token grammar", () => {
       mode: "responding",
     });
 
-    expect(output).toContain("slow model");
-    expect(output).toContain("still generating");
+    expect(output).toContain("waiting for model");
+    expect(output).toContain("no output yet");
+    expect(output).not.toContain("slow model");
+  });
+
+  // Operator bug 2026-07-20: "Running tools… (1m 33s · ↓ 208 tokens ·
+  // 2.4 tok/s · slow model · last token 16s ago)" — while tools execute the
+  // model is not being asked for tokens, so no stall note may render at all.
+  test("suppresses the stall note entirely while tools are running", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      loadingStartTimeRef: makeRef(NOW - 13 * 60_000),
+      responseLengthRef: makeRef(832), // 208 tokens
+      mode: "tool-use",
+      hasActiveTools: true,
+      verbose: true,
+    });
+
+    expect(output).not.toContain("slow model");
+    expect(output).not.toContain("last token");
+    expect(output).not.toContain("waiting for model");
   });
 
   test("reports time since the last token once some output has streamed", async () => {
@@ -154,6 +181,82 @@ describe("SpinnerAnimationRow liveness + token grammar", () => {
     });
 
     expect(output).not.toContain("slow model");
+  });
+
+  // The tok/s figure divides an ESTIMATED token count (chars/4) by ACTIVE
+  // streaming time only. Tool-execution windows must pause the denominator:
+  // previously 90s of tool time diluted a healthy stream to "2.4 tok/s".
+  test("tok/s rate counts only active streaming windows", () => {
+    const t0 = 1_000_000;
+    const state = initialTokenLivenessState(0, t0, t0);
+
+    // 10s of active streaming producing 400 tokens → 40 tok/s.
+    let result = stepTokenLiveness(state, {
+      totalTokens: 40,
+      now: t0 + 1_000,
+      streamingActive: true,
+    });
+    for (let i = 2; i <= 10; i++) {
+      result = stepTokenLiveness(state, {
+        totalTokens: 40 * i,
+        now: t0 + i * 1_000,
+        streamingActive: true,
+      });
+    }
+    expect(result.ratePerSec).toBeCloseTo(400 / 9, 0);
+
+    // 90s of tool execution: no tokens, denominator must NOT grow.
+    for (let i = 1; i <= 90; i++) {
+      result = stepTokenLiveness(state, {
+        totalTokens: 400,
+        now: t0 + 10_000 + i * 1_000,
+        streamingActive: false,
+      });
+    }
+    expect(result.ratePerSec).toBeCloseTo(400 / 9, 0);
+    // Tool-window silence is not model silence.
+    expect(result.msSinceLastToken).toBe(0);
+  });
+
+  test("post-tool silence is measured from the tool window end, not the last token", () => {
+    const t0 = 1_000_000;
+    const state = initialTokenLivenessState(0, t0, t0);
+    stepTokenLiveness(state, { totalTokens: 100, now: t0 + 5_000, streamingActive: true });
+    // 60s of tools…
+    stepTokenLiveness(state, { totalTokens: 100, now: t0 + 65_000, streamingActive: false });
+    // …then 9s of model-owned silence.
+    const result = stepTokenLiveness(state, {
+      totalTokens: 100,
+      now: t0 + 74_000,
+      streamingActive: true,
+    });
+    expect(result.msSinceLastToken).toBe(9_000);
+  });
+
+  // "slow model" is a claim about the model — it needs rate evidence.
+  test("selectStallNote labels slow model only with genuine rate evidence", () => {
+    // Tools running → never a note.
+    expect(
+      selectStallNote({ totalTokens: 208, msSinceLastToken: 16_000, ratePerSec: 2.4, toolsRunning: true }),
+    ).toBeNull();
+    // Silence with a healthy measured rate → neutral gap note.
+    expect(
+      selectStallNote({ totalTokens: 208, msSinceLastToken: 16_000, ratePerSec: 40, toolsRunning: false }),
+    ).toBe("last token 16s ago");
+    // Silence with measured slow streaming → honest slow-model label.
+    expect(
+      selectStallNote({ totalTokens: 208, msSinceLastToken: 16_000, ratePerSec: 4, toolsRunning: false }),
+    ).toBe("slow model · last token 16s ago");
+    // No tokens yet → waiting, not "slow model".
+    expect(
+      selectStallNote({ totalTokens: 0, msSinceLastToken: 20_000, ratePerSec: 0, toolsRunning: false }),
+    ).toBe("waiting for model · no output yet");
+  });
+
+  // The rate is an estimate (chars/4) — it must be visibly marked as one.
+  test("formatRate marks the figure as an estimate", () => {
+    expect(formatRate(42)).toBe("~42 tok/s");
+    expect(formatRate(2.4)).toBe("~2.4 tok/s");
   });
 
   // The verb (e.g. "Working…") and the status group's opening "(" must be

--- a/runtime/tests/tui/parity/session-transcript.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.test.ts
@@ -196,6 +196,42 @@ describe("AgenC TUI session transcript", () => {
     });
   });
 
+  test("token ledger fallback total never re-adds cached tokens", () => {
+    // Cached input tokens are a SUBSET of promptTokens (OpenAI/xAI
+    // convention the daemon's LLMUsage normalizes to); when the provider
+    // omits totalTokens the fallback must be in + out — the old fallback
+    // added cached + cacheCreation + reasoning back in and nearly doubled
+    // the displayed total (absurd cached/total readings, 2026-07-20).
+    const transcript = adaptTranscriptEvents([
+      {
+        id: "usage",
+        seq: 1,
+        msg: {
+          type: "token_count",
+          payload: {
+            promptTokens: 48_892,
+            completionTokens: 169,
+            // no totalTokens from the provider
+            cachedInputTokens: 46_720,
+            reasoningOutputTokens: 15,
+            model: "grok-4.5",
+            provider: "grok",
+          },
+        },
+      },
+    ]);
+
+    const row = transcript.messages[0];
+    expect(row).toMatchObject({ type: "system" });
+    const content = String((row as { content?: unknown })?.content ?? "");
+    // 48,892 + 169 = 49,061 → "49.1K total"; the buggy fallback produced
+    // 95,796 → "95.8K total".
+    expect(content).toContain("49.1K total");
+    expect(content).not.toContain("95.8K total");
+    // Cache read still reported separately, honestly.
+    expect(content).toContain("46.7K cache read");
+  });
+
   test("renders protocol events as inline system rows with badge variants", () => {
     const transcript = adaptTranscriptEvents([
       {

--- a/runtime/tests/utils/xaiOauthCredentials.test.ts
+++ b/runtime/tests/utils/xaiOauthCredentials.test.ts
@@ -51,9 +51,18 @@ function storedBlob(overrides: Record<string, unknown> = {}) {
   }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   process.env = { ...originalEnv }
   delete process.env.AGENC_SIMPLE
+  // Hermetic per-test home for the cross-process refresh lock.
+  // AGENC_CONFIG_DIR (not AGENC_HOME) is what getAgenCConfigHomeDir prefers,
+  // and the shared vitest setup already pins it per worker — override it per
+  // test so lock contention cannot leak between tests. The memoize is keyed
+  // off the env var, so each test dir gets a fresh value.
+  const { mkdtemp } = await import('node:fs/promises')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  process.env.AGENC_CONFIG_DIR = await mkdtemp(join(tmpdir(), 'xai-oauth-test-'))
   process.argv = originalArgv.filter(arg => arg !== '--bare')
   storageState = {}
   refreshMock.mockReset()
@@ -216,11 +225,116 @@ test('concurrent force refreshes share a single flight', async () => {
 
   const first = forceRefreshXaiOauthCredentials()
   const second = forceRefreshXaiOauthCredentials()
+  // The refresh now acquires a cross-process lock before hitting the
+  // endpoint; wait for the exchange to actually start before releasing.
+  await vi.waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1))
   release(undefined)
   const [a, b] = await Promise.all([first, second])
   expect(a?.accessToken).toBe('access-2')
   expect(b?.accessToken).toBe('access-2')
   expect(refreshMock).toHaveBeenCalledTimes(1)
+})
+
+test('refresh adopts a sibling rotation instead of exchanging a stale token', async () => {
+  const {
+    forceRefreshXaiOauthCredentials,
+    readXaiOauthCredentials,
+    saveXaiOauthCredentials,
+  } = await importFreshModule()
+  const lockfileMod = await import('../../src/utils/lockfile.js')
+  const { join } = await import('node:path')
+  const { mkdir } = await import('node:fs/promises')
+
+  saveXaiOauthCredentials(storedBlob())
+  refreshMock.mockImplementation(async () => {
+    throw new Error('endpoint must not be called when a sibling rotated')
+  })
+
+  // Simulate a sibling process holding the refresh lock: acquire the same
+  // lock target first, start the refresh (it waits on lock retries), rotate
+  // the stored grant "from the sibling", then release. The under-lock
+  // re-read must observe the rotation and adopt it without hitting the
+  // token endpoint.
+  const { getAgenCConfigHomeDir } = await import('../../src/utils/envUtils.js')
+  const home = getAgenCConfigHomeDir()
+  await mkdir(home, { recursive: true })
+  const releaseSibling = await lockfileMod.lock(
+    join(home, '.xai-oauth-refresh'),
+    { realpath: false },
+  )
+  const pending = forceRefreshXaiOauthCredentials()
+  await new Promise(resolve => setTimeout(resolve, 50))
+  storageState = {
+    xaiOauth: storedBlob({
+      accessToken: 'access-sibling',
+      refreshToken: 'refresh-sibling',
+    }),
+  }
+  await releaseSibling()
+
+  const result = await pending
+  expect(result?.accessToken).toBe('access-sibling')
+  expect(refreshMock).not.toHaveBeenCalled()
+  expect(readXaiOauthCredentials()?.refreshToken).toBe('refresh-sibling')
+})
+
+test('terminal invalid_grant must not clobber a sibling rotation with quarantine', async () => {
+  const module = await importFreshModule()
+  const {
+    forceRefreshXaiOauthCredentials,
+    readXaiOauthAccessToken,
+    readXaiOauthCredentials,
+    saveXaiOauthCredentials,
+  } = module
+  const { XaiOauthError } = await vi.importActual<
+    typeof import('../../src/services/xai/oauth.ts')
+  >(oauthServiceModulePath)
+
+  saveXaiOauthCredentials(storedBlob())
+  // The exchange fails with terminal invalid_grant because a sibling
+  // process consumed refresh-1 first — and by the time the failure lands,
+  // the sibling has persisted its rotated grant. Quarantining now would
+  // destroy the sibling's good credentials (the observed live failure:
+  // grok session flaps to "Not logged in" mid-turn).
+  refreshMock.mockImplementation(async () => {
+    storageState = {
+      xaiOauth: storedBlob({
+        accessToken: 'access-sibling',
+        refreshToken: 'refresh-sibling',
+      }),
+    }
+    throw new XaiOauthError('invalid_grant', 'xAI OAuth error invalid_grant', 400)
+  })
+
+  const result = await forceRefreshXaiOauthCredentials()
+  expect(result?.accessToken).toBe('access-sibling')
+  const stored = readXaiOauthCredentials()
+  expect(stored?.quarantinedAt).toBeUndefined()
+  expect(stored?.refreshToken).toBe('refresh-sibling')
+  expect(readXaiOauthAccessToken()).toBe('access-sibling')
+})
+
+test('xaiOauthRequiresRelogin distinguishes dead grants from viable ones', async () => {
+  const { saveXaiOauthCredentials, xaiOauthRequiresRelogin, clearXaiOauthCredentials } =
+    await importFreshModule()
+
+  // No credentials at all → re-login required.
+  expect(xaiOauthRequiresRelogin()).toBe(true)
+
+  // Viable grant → no re-login.
+  saveXaiOauthCredentials(storedBlob())
+  expect(xaiOauthRequiresRelogin()).toBe(false)
+
+  // Quarantined grant → re-login required.
+  saveXaiOauthCredentials(
+    storedBlob({ quarantinedAt: Date.now(), quarantineReason: 'invalid_grant' }),
+  )
+  expect(xaiOauthRequiresRelogin()).toBe(true)
+
+  // Grant without a refresh token → re-login required.
+  clearXaiOauthCredentials()
+  saveXaiOauthCredentials(storedBlob({ refreshToken: undefined }))
+  expect(xaiOauthRequiresRelogin()).toBe(true)
 })
 
 test('missing token endpoint falls back to discovery', async () => {


### PR DESCRIPTION
Three operator-observed bugs from today's screenshots, root-caused and fixed.

- **fix(llm)**: xAI rotating-refresh race across TUI/daemon processes clobbered fresh rotations via stale-copy quarantine → 'Not logged in' flap mid-session. Cross-process lock around the exchange, sibling-rotation adoption, quarantine only when the failing token is still stored, honest re-login-vs-transient errors (failure sequence reconstructed from credential mtimes + rollout timestamps).
- **fix(tui)**: token-ledger fallback added cached (a subset of input) into totals, ~doubling displayed usage/cost; exactly-once cumulative-stream usage pinned.
- **fix(tui)**: spinner tok/s divided estimated tokens by wall-clock incl. tool execution and labeled the model slow from silence ('2.4 tok/s · slow model' mid-tool-run). Active-streaming-window rate, tool-aware silence clock, estimate marker, slow-model only from real sub-10 streaming evidence. Reality check from 97 real grok-4.5 calls: median 24 tok/s, aggregate 54 — the model was fine, the meter was not.

## Verification (local)
- typecheck clean; full stable vitest: 1864 files / 16266 passed / 0 failed (SUITE-EXIT:0)
- Targeted: 56 files / 626 tests green; revert-sensitivity proven per fix (3+3, 5, and 1 tests red respectively against stashed sources)
- Honest open item: the literal 900M '(+ N cached)' render could not be reproduced from current source; ledger fix + pins cover the found double-count
- Tested SHA: ba60aa3bf29e219e00e809a2c65c11a0ac51a19c