### PR TITLE
fix(tui): rebuild the generic tool-approval card as a real picker too

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1487,12 +1487,12 @@ export function ApprovalCard({
   commandIsShell = true,
   facts,
   note,
-  confirmLabel,
   diffPreview,
   requestId,
   requireTypedConfirmation = false,
   typedConfirmationValue = '',
   typedConfirmationTarget = 'yes',
+  selectedIndex,
 }: {
   readonly risk: 'low' | 'high'
   readonly title: string
@@ -1517,10 +1517,14 @@ export function ApprovalCard({
   readonly requireTypedConfirmation?: boolean
   readonly typedConfirmationValue?: string
   readonly typedConfirmationTarget?: string
+  /** Selected row of the action picker (0 approve-once, 1 session, 2 deny). */
+  readonly selectedIndex?: number
 }): React.ReactNode {
   const variant: BadgeVariant = risk === 'high' ? 'error' : 'accent'
   const primaryFact = facts[0]?.value ?? title
-  const approvalSummary = `${risk === 'high' ? 'high-risk approval' : 'needs approval'} · ${primaryFact} · ${command} · ${confirmLabel}`
+  // The action picker below owns the "1/2/3 + confirm" affordance — keep the
+  // summary line to identity only (no repeated confirm text, no `{}` inputs).
+  const approvalSummary = `${risk === 'high' ? 'high-risk approval' : 'needs approval'} · ${primaryFact}`
   // The approval popup is rendered into a fixed-height slot (the workbench
   // overlay row, or the modal context). Without a height cap the body grows
   // past the popup's own bottom border and bleeds onto the footer below it.
@@ -1603,12 +1607,13 @@ export function ApprovalCard({
           <ThemedText color="text2" wrap="truncate-end">
             $ {command}
           </ThemedText>
-        ) : showPreview ? null : (
+        ) : showPreview || command.trim().length === 0 || command.trim() === '{}' ? null : (
           // A non-shell input (a Write/Edit file_path). Never prefix it with the
           // `$ ` shell-prompt marker — it would misread as a runnable command.
           // When the embedded diff is shown its CREATE/EDIT header already names
           // the file, so this line is redundant and omitted (the `showPreview`
           // branch above); only surface the bare path when no diff is rendered.
+          // Empty/`{}` inputs (EnterPlanMode and friends) render no line at all.
           <ThemedText color="text2" wrap="truncate-end">
             {command}
           </ThemedText>
@@ -1657,23 +1662,71 @@ export function ApprovalCard({
           </ThemedText>
         ) : null}
         {requireTypedConfirmation ? (
-          <Box flexDirection="row" gap={1}>
-            <ThemedText color={typedConfirmationValue === typedConfirmationTarget ? 'agenc' : 'text2'}>
-              {typedConfirmationValue.length > 0 ? typedConfirmationValue : ' '}
+          <Box flexDirection="column" flexShrink={0}>
+            <ThemedText color="muted3" wrap="truncate-end">
+              type '{typedConfirmationTarget}' to approve · esc cancel
             </ThemedText>
-            <ThemedText color="muted3">/ {typedConfirmationTarget}</ThemedText>
+            <Box flexDirection="row" gap={1}>
+              <ThemedText color={typedConfirmationValue === typedConfirmationTarget ? 'agenc' : 'text2'}>
+                {typedConfirmationValue.length > 0 ? typedConfirmationValue : ' '}
+              </ThemedText>
+              <ThemedText color="muted3">/ {typedConfirmationTarget}</ThemedText>
+            </Box>
           </Box>
         ) : (
-          <ThemedText color="muted3" wrap="truncate-end">[1] approve once · [2] approve for session · [3] deny</ThemedText>
+          // The action picker: one row per choice, inline marker, highlighted
+          // selection — same structure as the plan/question pickers, replacing
+          // the old triple repetition ([1]… legend, ▸ confirm, summary line).
+          <ThemedBox
+            flexDirection="column"
+            flexShrink={0}
+            borderStyle="single"
+            borderLeft={true}
+            borderTop={false}
+            borderRight={false}
+            borderBottom={false}
+            borderColor="agenc"
+            paddingLeft={1}
+          >
+            {APPROVAL_ACTIONS.map((action, index) => {
+              const selected = index === (selectedIndex ?? 0)
+              const marker = selected ? '❯ ' : '  '
+              const rowText = `${marker}${index + 1}  ${action.label}`
+              const detailText = `  ${action.suffix}`
+              return (
+                <Box key={action.label}>
+                  {selected ? (
+                    <ThemedText color="agenc" bold={true}>
+                      {`${rowText}${detailText}`}
+                    </ThemedText>
+                  ) : (
+                    <ThemedText color="text2">
+                      {rowText}
+                      <ThemedText color="muted3">{detailText}</ThemedText>
+                    </ThemedText>
+                  )}
+                </Box>
+              )
+            })}
+          </ThemedBox>
         )}
-        <Box flexDirection="row" gap={2}>
-          <ThemedText color="agenc" wrap="truncate-end">▸ {confirmLabel}</ThemedText>
-          <KeyHint k="esc" label="cancel" />
-        </Box>
+        {!requireTypedConfirmation ? (
+          <Box marginTop={1} flexShrink={0}>
+            <ThemedText color="muted3" wrap="truncate-end">
+              1·2·3 choose   ↑↓ move   ⏎ confirm   esc cancel{diffPreview !== undefined ? '   ctrl+w d full diff' : ''}
+            </ThemedText>
+          </Box>
+        ) : null}
       </Box>
     </Popup>
   )
 }
+
+const APPROVAL_ACTIONS: readonly { readonly label: string; readonly suffix: string }[] = [
+  { label: 'approve once', suffix: 'just this call' },
+  { label: 'approve for session', suffix: 'allow in this session' },
+  { label: 'deny', suffix: 'reject' },
+]
 
 export type PopupFooterItem = {
   readonly keyName: string

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -548,6 +548,7 @@ function AgenCApprovalOverlay({
     description: toolUseConfirm.description,
   });
   const [typed, setTyped] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
   useRegisterKeybindingContext("Confirmation");
   const approve = useCallback(() => {
     toolUseConfirm.onAllow(toolUseConfirm.input, []);
@@ -563,6 +564,21 @@ function AgenCApprovalOverlay({
     toolUseConfirm.onAbort();
   }, [toolUseConfirm]);
 
+  const confirmSelection = useCallback(
+    (index: number) => {
+      if (index === 0) {
+        approve();
+        return;
+      }
+      if (index === 1) {
+        approveForSession();
+        return;
+      }
+      reject();
+    },
+    [approve, approveForSession, reject],
+  );
+
   useKeybindings(
     {
       "confirm:yes": () => {
@@ -576,20 +592,38 @@ function AgenCApprovalOverlay({
   );
 
   useInput(
-    (input, _key, event) => {
+    (input, key, event) => {
       if (input === "1") {
         event.stopImmediatePropagation();
+        setSelectedIndex(0);
         approve();
         return;
       }
       if (input === "2") {
         event.stopImmediatePropagation();
+        setSelectedIndex(1);
         approveForSession();
         return;
       }
       if (input === "3") {
         event.stopImmediatePropagation();
+        setSelectedIndex(2);
         reject();
+        return;
+      }
+      if (key.upArrow) {
+        event.stopImmediatePropagation();
+        setSelectedIndex((index) => (index + 2) % 3);
+        return;
+      }
+      if (key.downArrow) {
+        event.stopImmediatePropagation();
+        setSelectedIndex((index) => (index + 1) % 3);
+        return;
+      }
+      if (key.return) {
+        event.stopImmediatePropagation();
+        confirmSelection(selectedIndex);
       }
     },
     { isActive: !destructive },
@@ -652,14 +686,10 @@ function AgenCApprovalOverlay({
         note={toolUseConfirm.description}
         {...(diffPreview !== undefined ? { diffPreview } : {})}
         requestId={request.id}
-        confirmLabel={
-          destructive
-            ? `type '${requiredWord}' to approve`
-            : "1/enter approve · 2 session · 3 deny"
-        }
         requireTypedConfirmation={destructive}
         typedConfirmationValue={typed}
         typedConfirmationTarget={requiredWord}
+        selectedIndex={selectedIndex}
       />
     </Box>
   );

--- a/runtime/src/tui/workbench/approvals/ApprovalSurfaceBridge.tsx
+++ b/runtime/src/tui/workbench/approvals/ApprovalSurfaceBridge.tsx
@@ -1,23 +1,17 @@
 import React from "react";
 
-import { Box, Text } from "../../ink.js";
 import { useKeybinding } from "../../keybindings/useKeybinding.js";
 import type { PendingRequest } from "../../permission-requests.js";
 import { useWorkbenchDispatch } from "../state.js";
-import { classifyApprovalRisk } from "../../../permissions/risk.js";
-import { approvalInputText } from "./inputText.js";
-import { EXIT_PLAN_MODE_TOOL_NAME } from "../../../tools/ExitPlanModeTool/constants.js";
-import { ASK_USER_QUESTION_TOOL_NAME } from "../../../tools/ask-user-question/tool.js";
 
-// Tools with their own full approval UI (plan review card, question picker)
-// must NOT also get this hint row: both render above the same overlay area
-// and stomp each other (observed: "risk low - press d…" line printed over
-// the plan-review card, fusing with its text into "reviewall").
-const HINTLESS_TOOL_NAMES: ReadonlySet<string> = new Set([
-  EXIT_PLAN_MODE_TOOL_NAME,
-  ASK_USER_QUESTION_TOOL_NAME,
-]);
-
+/**
+ * Headless opt-in for full diff review: registers the `ctrl+w d` (openDiff)
+ * keybinding while an approval is pending and renders NOTHING. The approval
+ * card itself now prints the `ctrl+w d full diff` hint, so this bridge no
+ * longer paints a line of its own — it used to render a duplicate
+ * "risk X - press d…" row that fused with the card below into "reviewall".
+ * Kept mounted (B3.5 parity): diff review stays opt-in, never auto-focused.
+ */
 export function ApprovalSurfaceBridge({
   request,
 }: {
@@ -34,21 +28,5 @@ export function ApprovalSurfaceBridge({
     { context: "Confirmation", isActive: request !== undefined },
   );
 
-  if (!request) return null;
-  if (HINTLESS_TOOL_NAMES.has(request.ctx.toolName)) return null;
-  const risk = classifyApprovalRisk({
-    request,
-    description: request.description,
-    command: approvalInputText(request.input),
-  });
-  return (
-    <Box flexDirection="column">
-      <Text color={risk === "destructive" ? "error" : risk === "medium" ? "warning" : "text2"} wrap="truncate-end">
-        Approval pending: {request.description}
-      </Text>
-      <Text dimColor wrap="truncate-end">
-        risk {risk} - press d or ctrl+w d for full diff review
-      </Text>
-    </Box>
-  );
+  return null;
 }

--- a/runtime/tests/tui/approval-card-diff-budget.test.tsx
+++ b/runtime/tests/tui/approval-card-diff-budget.test.tsx
@@ -129,10 +129,13 @@ describe('ApprovalCard (BUG 1: embedded diff is complete or absent, never half-d
         expect(topCorners).toBe(2)
         expect(out).toMatch(/\+ line \d+ content/)
       }
-      // The primary action legend + confirm row are NEVER the thing clipped —
-      // at every height, whether or not the diff is shown.
-      expect(out).toContain('[1] approve once')
-      expect(out).toContain('▸ enter approve')
+      // The primary action picker (all three rows) is NEVER the thing
+      // clipped — at every height, whether or not the diff is shown. The key
+      // hint row below it is secondary: it yields to the diff preview first
+      // (the keys themselves always work), so it is not asserted here.
+      expect(out).toContain('approve once')
+      expect(out).toContain('approve for session')
+      expect(out).toContain('deny')
     })
   }
 })

--- a/runtime/tests/tui/approval-card-diff-preview.test.tsx
+++ b/runtime/tests/tui/approval-card-diff-preview.test.tsx
@@ -16,7 +16,7 @@ import { renderToString } from '../../src/utils/staticRender.js'
 // CRITICAL: this must NOT regress the height/overflow discipline that the
 // approval popup was recently repaired for. The preview is part of the existing
 // maxHeight + overflow:'hidden' budget and is the FIRST optional block shed when
-// the slot is tight — never the primary [1]/[2]/[3] action legend.
+// the slot is tight — never the primary action picker.
 
 // A realistic Edit diff: one changed line + one added line.
 function editPreview(): ApprovalDiffPreview {
@@ -115,11 +115,11 @@ describe('ApprovalCard diff preview (in-dialog change preview)', () => {
     expect(sigilRows.some((l) => l.includes('+'))).toBe(true)
   })
 
-  test('the diff preview does NOT push out the [1]/[2]/[3] action legend', async () => {
+  test('the diff preview does NOT push out the action picker', async () => {
     const out = await renderEditApproval(40)
-    expect(out).toContain('[1] approve once')
-    expect(out).toContain('[2] approve for session')
-    expect(out).toContain('[3] deny')
+    expect(out).toContain('approve once')
+    expect(out).toContain('approve for session')
+    expect(out).toContain('deny')
   })
 
   test('REGRESSION: the popup with a diff still fits its border (one top, one bottom)', async () => {
@@ -150,10 +150,10 @@ describe('ApprovalCard diff preview (in-dialog change preview)', () => {
 
   test('a tight slot DROPS the diff preview BEFORE the action legend', async () => {
     // At a tight height the diff preview (the largest optional block) is shed,
-    // but the primary [1]/[2]/[3] action legend survives.
+    // but the primary action picker survives.
     const tight = await renderEditApproval(16)
     expect(tight).not.toContain('DIFF')
-    expect(tight).toContain('[1] approve once')
+    expect(tight).toContain('approve once')
   })
 
   test('a long Write diff collapses its tail to a "… +N more" affordance row', async () => {
@@ -172,15 +172,15 @@ describe('ApprovalCard diff preview (in-dialog change preview)', () => {
     )
     expect(out).toContain('DIFF')
     expect(out).toMatch(/… \+\d+ more lines · ctrl\+w d for full diff/)
-    // The action legend still survives alongside the collapsed preview.
-    expect(out).toContain('[1] approve once')
+    // The action picker still survives alongside the collapsed preview.
+    expect(out).toContain('approve once')
   })
 
   test('a Bash approval shows NO diff preview (command-only card)', async () => {
     const out = await renderBashApproval()
     expect(out).not.toContain('DIFF')
     expect(out).toContain('rm -rf build')
-    expect(out).toContain('[1] approve once')
+    expect(out).toContain('approve once')
   })
 
   test('an Edit approval labels the inline diff EDIT (matching the transcript card)', async () => {
@@ -264,7 +264,7 @@ describe('ApprovalCard diff preview (in-dialog change preview)', () => {
     // its command + action legend (the pre-improvement behavior).
     expect(withoutPreview).not.toContain('DIFF')
     expect(withoutPreview).not.toContain('const c = 3')
-    expect(withoutPreview).toContain('[1] approve once')
+    expect(withoutPreview).toContain('approve once')
     // Guard: both still fit one closing bottom border (no overflow regression).
     expect(countLines(withPreview, (l) => l.includes('└'))).toBeGreaterThanOrEqual(1)
     expect(countLines(withoutPreview, (l) => l.includes('└'))).toBe(1)

--- a/runtime/tests/tui/approval-card-layout.test.tsx
+++ b/runtime/tests/tui/approval-card-layout.test.tsx
@@ -107,11 +107,11 @@ describe('ApprovalCard layout (tool-approval popup)', () => {
     expect(offenders).toEqual([])
   })
 
-  test('(C) the action legend [1]/[2]/[3] is present and survives a tight slot', async () => {
+  test('(C) the action picker is present and survives a tight slot', async () => {
     const generous = await renderWriteApproval(40)
-    expect(generous).toContain('[1] approve once')
-    expect(generous).toContain('[2] approve for session')
-    expect(generous).toContain('[3] deny')
+    expect(generous).toContain('approve once')
+    expect(generous).toContain('approve for session')
+    expect(generous).toContain('deny')
     // The footer holds only real affordances — there is no `e` handler, so the
     // old `[e] edit command` hint (a dead key) was deliberately removed.
     expect(generous).not.toContain('[e] edit command')
@@ -119,7 +119,7 @@ describe('ApprovalCard layout (tool-approval popup)', () => {
     // The action legend is the primary action and is gated to stay visible
     // even when the slot is too tight to show the secondary facts/note rows.
     const tight = await renderWriteApproval(16)
-    expect(tight).toContain('[1] approve once')
+    expect(tight).toContain('approve once')
   })
 
   test('(A) a non-bash tool is never relabeled as bash', async () => {

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -302,7 +302,7 @@ describe("permission request overlay coverage", () => {
       await sleep();
 
       expect(stripAnsi(extractLastFrame(output())).replace(/\s+/gu, "")).toContain(
-        "2session",
+        "approveforsession",
       );
       stdin.write("2");
       await sleep();

--- a/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
+++ b/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
@@ -25,7 +25,7 @@ import { ApprovalSurfaceBridge } from "../../../src/tui/workbench/approvals/Appr
 import { renderToString } from "../../../src/utils/staticRender.js";
 
 describe("ApprovalSurfaceBridge", () => {
-  it("classifies destructive approval risk from request input commands", async () => {
+  it("renders nothing (headless): the card owns the visible hint now", async () => {
     const request = pendingRequest({
       id: "approval-1",
       description: "Run shell command",
@@ -40,8 +40,15 @@ describe("ApprovalSurfaceBridge", () => {
       80,
     );
 
-    expect(output).toContain("Approval pending: Run shell command");
-    expect(output).toContain("risk destructive");
+    // The bridge used to paint a duplicate "risk X - press d…" row that fused
+    // with the approval card below ("reviewall"). It must stay invisible.
+    expect(output).not.toContain("Approval pending:")
+    expect(output).not.toContain("risk destructive")
+    // …while STILL registering the opt-in openDiff keybinding for it.
+    expect(keybindingHarness).toMatchObject({
+      action: "workbench:openDiff",
+      options: { context: "Confirmation", isActive: true },
+    })
   });
 
   it("classifies destructive approval risk from split command arguments", async () => {
@@ -59,8 +66,11 @@ describe("ApprovalSurfaceBridge", () => {
       80,
     );
 
-    expect(output).toContain("Approval pending: Run shell command");
-    expect(output).toContain("risk destructive");
+    expect(output).not.toContain("Approval pending:")
+    expect(keybindingHarness).toMatchObject({
+      action: "workbench:openDiff",
+      options: { context: "Confirmation", isActive: true },
+    })
   });
 
   it("classifies destructive approval risk from structured command arguments", async () => {
@@ -78,8 +88,11 @@ describe("ApprovalSurfaceBridge", () => {
       80,
     );
 
-    expect(output).toContain("Approval pending: Run shell command");
-    expect(output).toContain("risk destructive");
+    expect(output).not.toContain("Approval pending:")
+    expect(keybindingHarness).toMatchObject({
+      action: "workbench:openDiff",
+      options: { context: "Confirmation", isActive: true },
+    })
   });
 
   it("opens the diff surface for the active approval request", async () => {


### PR DESCRIPTION
## Problema

La tarjeta genérica de aprobación (`✳ TOOL · X · NEEDS APPROVAL`):

- **Repetía las opciones 3 veces** (`[1] approve once…`, `▸ 1/enter approve…`, y la línea summary).
- Mostraba `{}` para tools sin input (EnterPlanMode).
- El `ApprovalSurfaceBridge` imprimía encima su `risk X - press d…` fusionándose en `for full diff reviewall`.

## Fix

- **ApprovalCard → picker real**: filas con borde izquierdo `❯ 1 approve once / 2 approve for session / 3 deny`, marker inline, selección resaltada, hint único abajo (`1·2·3 · ↑↓ · ⏎ · esc`, más `ctrl+w d full diff` cuando hay diff). Summary solo con identidad; `{}` no se muestra; destructive recupera la instrucción `type '<word>' to approve`.
- **AgenCApprovalOverlay**: estado de selección — `↑↓` mueve la fila `❯`, `⏎` confirma, `1/2/3` siguen yendo directo.
- **ApprovalSurfaceBridge headless**: mantiene la keybinding `ctrl+w d → openDiff` (paridad B3.5 opt-in) pero ya no pinta nada — la tarjeta misma anuncia el hint.

## Verificación

- Suite TUI completa: **843 archivos, 4235 tests verdes**.
- PTY real 160x50: tarjeta sin bridge ni `{}` ni repetición; `↓` mueve `❯ 1 → ❯ 2` correctamente.

Misma línea que #1563 (ExitPlanMode picker).