### PR TITLE
fix(tui): never clip the action picker off the approval card

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1441,8 +1441,14 @@ const APPROVAL_PREVIEW_LINE_CAP = 7
  * from the BOTTOM and the diff box renders ABOVE these rows, so the diff must be
  * shed BEFORE it can push the legend/confirm off the bottom edge — reserve all
  * of them up front.
+ *
+ * Picker rebuild: the action block is now the picker (3 option rows) + key
+ * hint, not the old one-line legend + confirm — the reservation must cover
+ * summary + facts + picker + hint or the popup body clip sheds the picker
+ * itself on tight slots (observed: a 40-line Write diff left the card with
+ * only `CONFIRMATION enter` in the facts row and no way to answer).
  */
-const APPROVAL_ESSENTIAL_BODY_ROWS = 5
+const APPROVAL_ESSENTIAL_BODY_ROWS = 6
 
 /**
  * Decide whether the approval popup can show its embedded `DiffInline` preview
@@ -1602,6 +1608,64 @@ export function ApprovalCard({
         <ThemedText color="text2" wrap="truncate-end">
           {approvalSummary}
         </ThemedText>
+        {requireTypedConfirmation ? (
+          <Box flexDirection="column" flexShrink={0}>
+            <ThemedText color="muted3" wrap="truncate-end">
+              type '{typedConfirmationTarget}' to approve · esc cancel
+            </ThemedText>
+            <Box flexDirection="row" gap={1}>
+              <ThemedText color={typedConfirmationValue === typedConfirmationTarget ? 'agenc' : 'text2'}>
+                {typedConfirmationValue.length > 0 ? typedConfirmationValue : ' '}
+              </ThemedText>
+              <ThemedText color="muted3">/ {typedConfirmationTarget}</ThemedText>
+            </Box>
+          </Box>
+        ) : (
+          // The action picker comes FIRST: the popup body clips from the
+          // bottom, so everything below this block (command, diff, facts,
+          // note) is the sheddable part — the answer rows never leave the
+          // card, same rule as the plan picker (observed live: a 40-line
+          // Write diff pushed the picker off the card entirely).
+          <ThemedBox
+            flexDirection="column"
+            flexShrink={0}
+            borderStyle="single"
+            borderLeft={true}
+            borderTop={false}
+            borderRight={false}
+            borderBottom={false}
+            borderColor="agenc"
+            paddingLeft={1}
+          >
+            {APPROVAL_ACTIONS.map((action, index) => {
+              const selected = index === (selectedIndex ?? 0)
+              const marker = selected ? '❯ ' : '  '
+              const rowText = `${marker}${index + 1}  ${action.label}`
+              const detailText = `  ${action.suffix}`
+              return (
+                <Box key={action.label}>
+                  {selected ? (
+                    <ThemedText color="agenc" bold={true}>
+                      {`${rowText}${detailText}`}
+                    </ThemedText>
+                  ) : (
+                    <ThemedText color="text2">
+                      {rowText}
+                      <ThemedText color="muted3">{detailText}</ThemedText>
+                    </ThemedText>
+                  )}
+                </Box>
+              )
+            })}
+          </ThemedBox>
+        )}
+        {!requireTypedConfirmation ? (
+          <Box marginTop={1} marginBottom={1} flexShrink={0}>
+            <ThemedText color="muted3" wrap="truncate-end">
+              1·2·3 choose   ↑↓ move   ⏎ confirm   esc cancel{diffPreview !== undefined ? '   ctrl+w d full diff' : ''}
+            </ThemedText>
+          </Box>
+        ) : null}
         {commandIsShell ? (
           // A real shell command (Run/Bash): show it behind the `$ ` prompt glyph.
           <ThemedText color="text2" wrap="truncate-end">
@@ -1660,62 +1724,6 @@ export function ApprovalCard({
           <ThemedText color="muted3" wrap="truncate-end">
             note · {note}
           </ThemedText>
-        ) : null}
-        {requireTypedConfirmation ? (
-          <Box flexDirection="column" flexShrink={0}>
-            <ThemedText color="muted3" wrap="truncate-end">
-              type '{typedConfirmationTarget}' to approve · esc cancel
-            </ThemedText>
-            <Box flexDirection="row" gap={1}>
-              <ThemedText color={typedConfirmationValue === typedConfirmationTarget ? 'agenc' : 'text2'}>
-                {typedConfirmationValue.length > 0 ? typedConfirmationValue : ' '}
-              </ThemedText>
-              <ThemedText color="muted3">/ {typedConfirmationTarget}</ThemedText>
-            </Box>
-          </Box>
-        ) : (
-          // The action picker: one row per choice, inline marker, highlighted
-          // selection — same structure as the plan/question pickers, replacing
-          // the old triple repetition ([1]… legend, ▸ confirm, summary line).
-          <ThemedBox
-            flexDirection="column"
-            flexShrink={0}
-            borderStyle="single"
-            borderLeft={true}
-            borderTop={false}
-            borderRight={false}
-            borderBottom={false}
-            borderColor="agenc"
-            paddingLeft={1}
-          >
-            {APPROVAL_ACTIONS.map((action, index) => {
-              const selected = index === (selectedIndex ?? 0)
-              const marker = selected ? '❯ ' : '  '
-              const rowText = `${marker}${index + 1}  ${action.label}`
-              const detailText = `  ${action.suffix}`
-              return (
-                <Box key={action.label}>
-                  {selected ? (
-                    <ThemedText color="agenc" bold={true}>
-                      {`${rowText}${detailText}`}
-                    </ThemedText>
-                  ) : (
-                    <ThemedText color="text2">
-                      {rowText}
-                      <ThemedText color="muted3">{detailText}</ThemedText>
-                    </ThemedText>
-                  )}
-                </Box>
-              )
-            })}
-          </ThemedBox>
-        )}
-        {!requireTypedConfirmation ? (
-          <Box marginTop={1} flexShrink={0}>
-            <ThemedText color="muted3" wrap="truncate-end">
-              1·2·3 choose   ↑↓ move   ⏎ confirm   esc cancel{diffPreview !== undefined ? '   ctrl+w d full diff' : ''}
-            </ThemedText>
-          </Box>
         ) : null}
       </Box>
     </Popup>

--- a/runtime/tests/tui/approval-card-diff-budget.test.tsx
+++ b/runtime/tests/tui/approval-card-diff-budget.test.tsx
@@ -53,10 +53,11 @@ describe('approvalDiffPreviewBudget (BUG 1: never a header-only unterminated box
   })
 
   test('shows the preview with >=1 diff line once the full chrome fits', () => {
-    // The threshold: popupBodyRows = 11 leaves exactly room for the essential
-    // body + box chrome + one diff line. Whenever the preview is shown, at least
-    // one line is shown (never a header-only box).
-    for (let popupBodyRows = 11; popupBodyRows <= 40; popupBodyRows++) {
+    // The threshold: popupBodyRows = 12 leaves exactly room for the essential
+    // body (summary + facts + picker + hint, 6 rows) + box chrome + one diff
+    // line. Whenever the preview is shown, at least one line is shown (never
+    // a header-only box).
+    for (let popupBodyRows = 12; popupBodyRows <= 40; popupBodyRows++) {
       const budget = approvalDiffPreviewBudget(popupBodyRows, 153)
       expect(budget.showPreview).toBe(true)
       expect(budget.previewLineCap).toBeGreaterThanOrEqual(1)
@@ -64,16 +65,15 @@ describe('approvalDiffPreviewBudget (BUG 1: never a header-only unterminated box
   })
 
   test('REVERT-SENSITIVITY: the budget reserves the box header + continuation, not just borders', () => {
-    // The bug was gating on a budget (`>= 2` after reserving only 5 essential +
-    // 2 border = 7) that did NOT reserve the box header, its separator, or the
-    // continuation row — so at marginal heights the box either clipped after its
-    // header (unterminated) or pushed the [1]/[2]/[3] legend off the bottom. The
-    // corrected helper reserves all of it, so the preview is OMITTED below
-    // popupBodyRows = 11. Against the broken gate, popupBodyRows = 10 SHOWED the
-    // diff (and clipped the legend); now it is omitted.
+    // The bug was gating on a budget that did NOT reserve the box header, its
+    // separator, or the continuation row — so at marginal heights the box
+    // either clipped after its header (unterminated) or pushed the action off
+    // the bottom. The corrected helper reserves all of it plus the picker
+    // (6 essential rows), so the preview is OMITTED below popupBodyRows = 12.
     expect(approvalDiffPreviewBudget(10, 153).showPreview).toBe(false)
+    expect(approvalDiffPreviewBudget(11, 153).showPreview).toBe(false)
     // And at the first height where the full chrome fits, exactly one line.
-    expect(approvalDiffPreviewBudget(11, 153)).toEqual({
+    expect(approvalDiffPreviewBudget(12, 153)).toEqual({
       showPreview: true,
       previewLineCap: 1,
     })


### PR DESCRIPTION
## Problema

Un diff grande de Write/Edit podía expulsar el picker de la tarjeta de aprobación: la tarjeta solo mostraba `CONFIRMATION enter` en la fila de facts, sin opciones ni forma de responder (reporte del usuario: la UI de TOOL WRITE MEDIUM RISK APPROVAL no dice qué hacer).

Causa raíz: el popup recorta el body **desde el final**, y el picker estaba al final — tras summary, command, diff, facts y note.

## Fix

- **El picker va PRIMERO** en el body (tras el summary). Todo lo que queda debajo (command, diff preview, facts, note) es lo recortable — las filas de respuesta nunca salen de la tarjeta. Misma regla que el plan picker de #1563.
- **`APPROVAL_ESSENTIAL_BODY_ROWS` 5 → 6**: el budget reserva summary + facts + picker (3 filas) + hint, así que el diff se omite antes de poder desplazar al picker. Umbrales del test de budget actualizados (popupBodyRows 11 → 12 para el primer preview de una línea).

## Verificación

- PTY real: Write de 40 líneas → picker + `❯` + hint `1·2·3 · ↑↓ · ⏎ · esc · ctrl+w d full diff` visibles; el diff se reduce para caber.
- Suite TUI completa: **843 archivos, 4235 tests verdes**.

Sigue a #1563 (plan picker) y #1564 (generic picker).