### PR TITLE
fix(tui): readable secondary text on the approval card wash

### DIFF
--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1610,14 +1610,14 @@ export function ApprovalCard({
         </ThemedText>
         {requireTypedConfirmation ? (
           <Box flexDirection="column" flexShrink={0}>
-            <ThemedText color="muted3" wrap="truncate-end">
+            <ThemedText color="inactive" wrap="truncate-end">
               type '{typedConfirmationTarget}' to approve · esc cancel
             </ThemedText>
             <Box flexDirection="row" gap={1}>
               <ThemedText color={typedConfirmationValue === typedConfirmationTarget ? 'agenc' : 'text2'}>
                 {typedConfirmationValue.length > 0 ? typedConfirmationValue : ' '}
               </ThemedText>
-              <ThemedText color="muted3">/ {typedConfirmationTarget}</ThemedText>
+              <ThemedText color="inactive">/ {typedConfirmationTarget}</ThemedText>
             </Box>
           </Box>
         ) : (
@@ -1651,7 +1651,7 @@ export function ApprovalCard({
                   ) : (
                     <ThemedText color="text2">
                       {rowText}
-                      <ThemedText color="muted3">{detailText}</ThemedText>
+                      <ThemedText color="inactive">{detailText}</ThemedText>
                     </ThemedText>
                   )}
                 </Box>
@@ -1661,7 +1661,7 @@ export function ApprovalCard({
         )}
         {!requireTypedConfirmation ? (
           <Box marginTop={1} marginBottom={1} flexShrink={0}>
-            <ThemedText color="muted3" wrap="truncate-end">
+            <ThemedText color="inactive" wrap="truncate-end">
               1·2·3 choose   ↑↓ move   ⏎ confirm   esc cancel{diffPreview !== undefined ? '   ctrl+w d full diff' : ''}
             </ThemedText>
           </Box>
@@ -1709,7 +1709,7 @@ export function ApprovalCard({
                 width={fact.label === 'network' || fact.label === 'net' ? 30 : 22}
               >
                 <Box flexShrink={0}>
-                  <ThemedText color="muted3">{fact.label.toUpperCase()}</ThemedText>
+                  <ThemedText color="inactive">{fact.label.toUpperCase()}</ThemedText>
                 </Box>
                 <Box flexShrink={1} minWidth={0}>
                   <ThemedText color={fact.color ?? 'text2'} wrap="truncate-middle">
@@ -1721,7 +1721,7 @@ export function ApprovalCard({
           </Box>
         ) : null}
         {showNote ? (
-          <ThemedText color="muted3" wrap="truncate-end">
+          <ThemedText color="inactive" wrap="truncate-end">
             note · {note}
           </ThemedText>
         ) : null}


### PR DESCRIPTION
## Problema

El texto gris `muted3` (rgb 190,190,190) sobre el fondo verde `successWash` (rgb 230,248,236) de la tarjeta de aprobación es casi ilegible (~1.5:1 de contraste) — reporte del usuario.

## Fix

Todo el texto secundario de la tarjeta (sufijos de opciones, hint de teclas, note, labels de facts, líneas de confirmación tipeada) pasa de `muted3` a `inactive` del tema (rgb 102,102,102 — ~4× más contraste), manteniendo la jerarquía visual secundaria. `muted3` no se toca para superficies sin wash.

## Verificación

- Suite TUI completa: 843 archivos, 4235 tests verdes.
- Temas claro/oscuro: `inactive` contrasta bien sobre ambos washes (verde claro y el oscuro rgb(19,38,31)).