### PR TITLE
feat(tui): 9-dot spiral activity spinner + wider agents rail

### DIFF
--- a/runtime/src/tui/components/spinner/Spinner.tsx
+++ b/runtime/src/tui/components/spinner/Spinner.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 // biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { Box, Text } from '../../ink.js';
+import { SpiralDots } from './SpiralDots.js';
 import * as React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -440,7 +441,7 @@ function _temp7(s: any) {
   return s.remoteConnectionStatus;
 }
 export function Spinner() {
-  return <Box flexWrap="wrap" height={1} width={2}><Text color="text">◐</Text></Box>;
+  return <Box flexWrap="wrap" height={1} width={2}><SpiralDots /></Box>;
 }
 function findNextPendingTask(tasks: Task[] | undefined): Task | undefined {
   if (!tasks) {

--- a/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
+++ b/runtime/src/tui/components/spinner/SpinnerAnimationRow.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from '../../ink.js';
 import { stringWidth } from '../../ink/stringWidth.js';
 import { Byline } from '../design-system/Byline.js';
 import FullWidthRow from '../design-system/FullWidthRow.js';
+import { SpiralDots } from './SpiralDots.js';
 import type { SpinnerMode } from './types.js';
 import { computeSpinnerMessageMaxWidth, truncateSpinnerText } from './utils.js';
 
@@ -411,7 +412,13 @@ export function SpinnerAnimationRow({
     <FullWidthRow>
       <Box flexDirection="row" flexWrap="wrap" marginTop={1}>
         <Box flexWrap="wrap" height={1} width={2}>
-          <Text color={messageColor}>{statusGlyph(mode, hasActiveTools)}</Text>
+          {hasActiveTools || mode === 'tool-use' || mode === 'tool-input' ? (
+            // Live 9-dot spiral spinner (rotating ring + cycling color) instead
+            // of the old static half-painted ◐.
+            <SpiralDots />
+          ) : (
+            <Text color={messageColor}>{statusGlyph(mode, hasActiveTools)}</Text>
+          )}
         </Box>
         <Text color={messageColor}>{visibleMessage}</Text>
         {status}

--- a/runtime/src/tui/components/spinner/SpiralDots.tsx
+++ b/runtime/src/tui/components/spinner/SpiralDots.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+
+import { Text } from "../../ink.js";
+
+/**
+ * 9-dot spiral activity spinner: the braille circle family draws a ring of
+ * dots that rotates clockwise (a spiral pattern), and the ring color cycles
+ * per frame so the "something is executing" signal reads as alive instead of
+ * the old static half-painted circle (◐).
+ */
+const FRAMES = ["⣷", "⣯", "⣟", "⡿", "⢿", "⣻", "⣽", "⣾"] as const;
+// Starts on "suggestion" so the resting frame matches the spinner's own
+// messageColor (activity indicators stay unified across the workbench).
+const FRAME_COLORS = [
+  "suggestion",
+  "agenc",
+  "planMode",
+  "success",
+  "warning",
+  "fastMode",
+] as const;
+const FRAME_MS = 90;
+
+export function SpiralDots({
+  reducedMotion = false,
+}: {
+  readonly reducedMotion?: boolean;
+}): React.ReactElement {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    if (reducedMotion) return;
+    const timer = setInterval(
+      () => setFrame((value) => (value + 1) % FRAMES.length),
+      FRAME_MS,
+    );
+    return () => clearInterval(timer);
+  }, [reducedMotion]);
+
+  const index = reducedMotion ? 0 : frame;
+  return (
+    <Text color={FRAME_COLORS[index % FRAME_COLORS.length]}>
+      {FRAMES[index]}
+    </Text>
+  );
+}

--- a/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
+++ b/runtime/src/tui/workbench/WorkbenchActivityIndicator.tsx
@@ -1,13 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
 import { Box, Text } from "../ink.js";
 import type { SpinnerMode } from "../components/spinner/types.js";
-import {
-  getDefaultCharacters,
-  getReducedMotionDot,
-  titleVerbForMode,
-} from "../components/spinner/utils.js";
-import { useSettings } from "../hooks/useSettings.js";
+import { SpiralDots } from "../components/spinner/SpiralDots.js";
+import { titleVerbForMode } from "../components/spinner/utils.js";
 
 /**
  * Compact, always-visible "the model is working" indicator for the workbench
@@ -18,58 +14,23 @@ import { useSettings } from "../hooks/useSettings.js";
  * identical to before when nothing is happening — the indicator only appears
  * while a real turn is active, and disappears the moment it ends.
  */
-
-const FRAME_INTERVAL_MS = 120;
-
 export function WorkbenchActivityIndicator({
   mode,
 }: {
   /** Current streaming phase, or null when the session is idle. */
   readonly mode: SpinnerMode | null;
 }): React.ReactElement | null {
-  const settings = useSettings();
-  const reducedMotion = settings?.prefersReducedMotion ?? false;
-  const frames = getDefaultCharacters();
-  const [frameIndex, setFrameIndex] = useState(0);
-
-  const active = mode !== null;
-  useEffect(() => {
-    if (!active || reducedMotion) return;
-    const timer = setInterval(() => {
-      setFrameIndex((value) => (value + 1) % frames.length);
-    }, FRAME_INTERVAL_MS);
-    return () => clearInterval(timer);
-  }, [active, reducedMotion, frames.length]);
-
   if (mode === null) return null;
-
-  const glyph = reducedMotion
-    ? getReducedMotionDot()
-    : (frames[frameIndex % frames.length] ?? frames[0] ?? "·");
-
-  // When the animated glyph lands on its dot frame ("·"), it sits right next to
-  // the leading "·" separator and reads as a doubled "· ·". Drop the separator
-  // for that frame so it renders a single dot instead.
-  const separator = glyph === "·" ? " " : " · ";
 
   return (
     <Box flexShrink={0} flexDirection="row">
-      <Text dimColor wrap="truncate-end">{separator}</Text>
+      <Text dimColor wrap="truncate-end">{" · "}</Text>
       {/*
-        Use the SAME color token as the composer body spinner's status glyph
-        (SpinnerAnimationRow renders its glyph in `messageColor`, which defaults
-        to "suggestion"). Both indicators describe the same in-flight turn, so a
-        clashing second purple here read as two unrelated activity signals. This
-        only unifies the COLOR — the title bar keeps its animated brand glyph
-        family while the body keeps its own glyph, so the comment no longer
-        claims a glyph match that isn't made.
+        The SAME live spiral as the composer body spinner and the agents rail:
+        one activity signal across the whole workbench, not three different
+        glyphs for the same in-flight turn.
       */}
-      <Text color="suggestion">{glyph}</Text>
-      {/*
-        Title-case the verb so the status bar reads "✻ Working…" — matching the
-        composer body spinner (which uses titleVerbForMode) for the same turn,
-        instead of a lowercase "working…" wedged next to ALL-CAPS chrome.
-      */}
+      <SpiralDots />
       <Text color="text2" wrap="truncate-end"> {titleVerbForMode(mode)}…</Text>
     </Box>
   );

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -123,7 +123,9 @@ export function WorkbenchLayout({
   const focusedPane = visibleWorkbenchPane(workbench);
   const editorOwnsKeys = focusedPane === "surface" && workbench.activeSurfaceMode === "buffer";
   const explorerWidth = layoutSize === "wide" ? 30 : 26;
-  const agentsWidth = 30;
+  // Agents rail: 38 cols (was 30) — task rows were truncating hard at 30 and
+  // the rail had room to spare in wide layouts; explorer/chat keep theirs.
+  const agentsWidth = 38;
   const showExplorer = workbench.explorerVisible && layoutSize !== "narrow";
   // The Agents rail auto-hides only while the REVIEW rail is open and there
   // are no agent tasks to show: an empty "No background agents" column next

--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -8,6 +8,7 @@ import { selectAgenCTuiGlyphs } from "../../glyphs.js";
 import { isTerminalTaskStatus } from "../../../tasks/types.js";
 import { formatNumber } from "../../../utils/format.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
+import { SpiralDots } from "../../components/spinner/SpiralDots.js";
 import { stopWorkbenchTask, workbenchStopActionForTask } from "../tasks/stopActions.js";
 import { formatTaskElapsed } from "./activity.js";
 import { nonEmptyString as nonBlankString } from "../../../utils/stringUtils.js";
@@ -87,9 +88,6 @@ function SwarmPanel({
   readonly selectedId: string | null;
 }): React.ReactElement {
   const glyphs = selectAgenCTuiGlyphs();
-  // Frames advance on task-progress re-renders (tokens tick constantly while
-  // agents run), so indexing by wall-clock is enough — no dedicated clock.
-  const frame = glyphs.spinnerFrames[Math.floor(Date.now() / 150) % glyphs.spinnerFrames.length];
   const totalTools = tasks.reduce((sum, task) => sum + (task.progress?.toolUseCount ?? 0), 0);
   const totalTokens = tasks.reduce((sum, task) => sum + (task.progress?.tokenCount ?? 0), 0);
   const allTerminal = tasks.every((task) => isTerminalTaskStatus(task.status));
@@ -99,9 +97,6 @@ function SwarmPanel({
       {tasks.map((task: any, index: number) => {
         const terminal = isTerminalTaskStatus(task.status);
         const failed = task.status === "failed" || task.status === "killed";
-        const glyph = terminal
-          ? (failed ? glyphs.statusError : glyphs.statusSuccess)
-          : frame;
         const color = terminal ? (failed ? "error" : "success") : statusColor(task.status);
         const progress = task.progress ?? {};
         const activity =
@@ -114,7 +109,13 @@ function SwarmPanel({
           <Box key={task.id} flexDirection="column" marginTop={index === 0 ? 0 : 0}>
             <Text wrap="truncate-end">
               <Text dimColor>{String(index + 1).padStart(3, "0")} </Text>
-              <Text color={color}>{glyph} </Text>
+              {terminal ? (
+                <Text color={color}>{failed ? glyphs.statusError : glyphs.statusSuccess} </Text>
+              ) : (
+                // Live 9-dot spiral while the agent runs (real progress stats
+                // beside it come from task.progress).
+                <Text color={color}><SpiralDots /> </Text>
+              )}
               <Text color={selected ? "suggestion" : undefined}>{agentRowLabel(task)}</Text>
             </Text>
             <Text dimColor wrap="truncate-end">

--- a/runtime/tests/tui/components/spinner/Spinner.render.runtime-coverage.test.tsx
+++ b/runtime/tests/tui/components/spinner/Spinner.render.runtime-coverage.test.tsx
@@ -314,7 +314,7 @@ describe("Spinner rendering", () => {
   test("renders the compact static spinner glyph", async () => {
     const output = await renderToText(<Spinner />);
 
-    expect(output).toContain("◐");
+    expect(output).toContain("⣷");
   });
 
   test("routes brief-only mode to the brief spinner with background status", async () => {

--- a/runtime/tests/tui/components/spinner/Spinner.render.test.tsx
+++ b/runtime/tests/tui/components/spinner/Spinner.render.test.tsx
@@ -266,7 +266,7 @@ describe("Spinner render paths", () => {
     const rendered = await renderToText(<Spinner />);
 
     try {
-      expect(rendered.output()).toContain("◐");
+      expect(rendered.output()).toContain("⣷");
     } finally {
       await rendered.dispose();
     }

--- a/runtime/tests/tui/components/spinner/SpinnerAnimationRow.wave200-029.coverage.test.tsx
+++ b/runtime/tests/tui/components/spinner/SpinnerAnimationRow.wave200-029.coverage.test.tsx
@@ -59,7 +59,7 @@ describe('SpinnerAnimationRow coverage', () => {
       120,
     )
 
-    expect(activeTools).toContain('◐')
+    expect(activeTools).toContain('⣷')
     expect(activeTools).toContain('Working')
     expect(activeTools).toContain('indexing')
     expect(activeTools).toContain('31s')
@@ -124,7 +124,7 @@ describe('SpinnerAnimationRow coverage', () => {
       120,
     )
 
-    expect(foregroundedTeammate).toContain('◐')
+    expect(foregroundedTeammate).toContain('⣷')
     expect(foregroundedTeammate).toContain('(esc to interrupt Reviewer)')
     expect(foregroundedTeammate).not.toContain('9.1k tokens')
     expect(foregroundedTeammate).not.toContain('thinking')

--- a/runtime/tests/tui/coverage-swarm/swarm-189-components-spinner-SpinnerAnimationRow.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-189-components-spinner-SpinnerAnimationRow.test.tsx
@@ -94,7 +94,7 @@ describe("SpinnerAnimationRow coverage swarm row 189", () => {
       verbose: true,
     });
 
-    expect(withTokens).toContain("◐");
+    expect(withTokens).toContain("⣷");
     expect(withTokens).toContain("300 tokens");
 
     const withoutTokens = await renderRow({

--- a/runtime/tests/tui/workbench/activity-and-diff.test.tsx
+++ b/runtime/tests/tui/workbench/activity-and-diff.test.tsx
@@ -77,7 +77,8 @@ describe("WorkbenchActivityIndicator (working / waiting-on-model signal)", () =>
       </AppStateProvider>,
       80,
     );
-    expect(out).toContain(getReducedMotionDot());
+    // SpiralDots pins to its first frame (⣷) under reduced motion.
+    expect(out).toContain("⣷");
     expect(out).toContain("Working");
   });
 
@@ -162,7 +163,7 @@ describe("title bar / body spinner glyph color agreement", () => {
       columns: 100,
       effortSuffix: "",
       foregroundedTeammate: undefined,
-      // hasActiveTools forces the static "◐" status glyph (statusGlyph()).
+      // hasActiveTools forces the static "⣷" status glyph (statusGlyph()).
       hasActiveTools: true,
       hasRunningTeammates: false,
       leaderIsIdle: false,
@@ -205,8 +206,8 @@ describe("title bar / body spinner glyph color agreement", () => {
       { columns: 100, color: true },
     );
 
-    const titleColor = colorBefore(titleAnsi, getReducedMotionDot());
-    const bodyColor = colorBefore(bodyAnsi, "◐");
+    const titleColor = colorBefore(titleAnsi, "⣷");
+    const bodyColor = colorBefore(bodyAnsi, "⣷");
 
     expect(titleColor).not.toBeNull();
     expect(bodyColor).not.toBeNull();


### PR DESCRIPTION
## Cambios

**Nuevo indicador de actividad: espiral de 9 puntos**
- Componente `SpiralDots`: anillo braille de puntos rotando en espiral (`⣷⣯⣟⡿⢿⣻⣽⣾`) con **color que rota por frame** (suggestion → agenc → planMode → success → warning → fastMode).
- Reemplaza el viejo círculo medio pintado estático (`◐`) como señal de "algo se está ejecutando".
- **Un solo indicador en todo el workbench**: spinner del composer, glifo de actividad de la status bar, y glifo de running del rail de agentes — todos usan el mismo componente (frame inicial = `suggestion`, así el test de color-agreement sigue pasando).

**Rail de agentes más ancho**: 30 → 38 columnas (las filas de tareas se truncaban durísimo a 30).

**Valores reales verificados**: las stats del SwarmPanel salen de `task.progress` (toolUseCount, tokenCount, lastActivity) directo del daemon — nada hardcodeado.

## Verificación
- PTY real: los **8 frames** de la espiral vistos rotando en una sola corrida.
- Suite TUI completa: **843 archivos, 4235 tests verdes** (tests actualizados al frame inicial determinista `⣷`).