### PR TITLE
feat(swarm): /swarm mode — status-bar indicator, command, prompt nudge

### DIFF
--- a/runtime/src/commands/registry.ts
+++ b/runtime/src/commands/registry.ts
@@ -46,6 +46,7 @@ import { authCommands } from "./auth.js";
 import { xaiAuthCommands } from "./xai-auth.js";
 import { effortCommand } from "./effort.js";
 import { resolveCommand } from "./resolve.js";
+import { swarmCommand } from "./swarm.js";
 
 /**
  * Concrete in-memory implementation of `CommandRegistry`.
@@ -161,6 +162,7 @@ export function buildDefaultRegistry(
     providerCommand,
     effortCommand,
     resolveCommand,
+    swarmCommand,
     permissionsCommand,
     planCommand,
     agentsCommand,

--- a/runtime/src/commands/swarm.ts
+++ b/runtime/src/commands/swarm.ts
@@ -1,0 +1,97 @@
+/**
+ * /swarm — toggle swarm mode.
+ *
+ * Swarm mode declares intent: while it is on, the agent is nudged (via the
+ * swarm-mode prompt attachment) to fan out divisible work to parallel
+ * sub-agents by default instead of grinding sequentially. It changes the
+ * model's guidance, NOT the permission policy — spawn_agent/multi-agent
+ * calls are side-effecting and still require approval per the active
+ * permission mode (yolo/bypass auto-approves them like everything else).
+ *
+ * /swarm          → toggle on/off
+ * /swarm on|off   → set explicitly
+ * /swarm status   → show mode + live agent count from AppState.tasks
+ */
+
+import {
+  updateSettingsForSource,
+  getSettingsForSource,
+} from "../utils/settings/settings.js";
+
+import {
+  safeExecute,
+  type SlashCommand,
+  type SlashCommandContext,
+} from "./types.js";
+
+function readSwarmMode(ctx: SlashCommandContext): boolean {
+  const state = ctx.appState?.getAppState?.() as
+    | { swarmMode?: unknown }
+    | undefined;
+  return state?.swarmMode === true;
+}
+
+function liveAgentCount(ctx: SlashCommandContext): number {
+  const state = ctx.appState?.getAppState?.() as
+    | { tasks?: Record<string, { status?: string; type?: string }> }
+    | undefined;
+  const tasks = Object.values(state?.tasks ?? {});
+  return tasks.filter(
+    (task) =>
+      task.type !== "local_bash" &&
+      (task.status === "running" || task.status === "pending"),
+  ).length;
+}
+
+function setSwarmMode(ctx: SlashCommandContext, on: boolean): void {
+  updateSettingsForSource("userSettings", { swarmMode: on });
+  ctx.appState?.setAppState?.((prev: unknown) => ({
+    ...(prev as Record<string, unknown>),
+    swarmMode: on,
+  }));
+}
+
+export const swarmCommand: SlashCommand = {
+  name: "swarm",
+  description: "Toggle swarm mode — fan out divisible work to parallel sub-agents by default",
+  immediate: true,
+  supportsNonInteractive: true,
+  execute: async (ctx) =>
+    safeExecute(async () => {
+      const arg = ctx.argsRaw.trim().toLowerCase();
+      const running = liveAgentCount(ctx);
+
+      if (arg === "status" || arg === "") {
+        const on = readSwarmMode(ctx);
+        const persisted = getSettingsForSource("userSettings")?.swarmMode;
+        const lines = [
+          `swarm mode: ${on ? "ON" : "off"}${persisted !== undefined ? ` (${persisted ? "saved on" : "saved off"})` : ""}`,
+          `live agents: ${running}`,
+          on
+            ? "Divisible work fans out to parallel sub-agents by default (spawns still follow approval policy)."
+            : "Use /swarm on to fan out divisible work to parallel sub-agents by default.",
+        ];
+        return { kind: "text", text: lines.join("\n") };
+      }
+
+      if (arg === "on") {
+        setSwarmMode(ctx, true);
+        return {
+          kind: "text",
+          text: "swarm mode ON — divisible work fans out to parallel sub-agents by default (spawns still follow approval policy).",
+        };
+      }
+      if (arg === "off") {
+        setSwarmMode(ctx, false);
+        return {
+          kind: "text",
+          text: "swarm mode OFF — the agent works sequentially unless a swarm is explicitly requested.",
+        };
+      }
+
+      return {
+        kind: "error",
+        message: "Usage: /swarm [on|off|status]",
+      };
+    }),
+};

--- a/runtime/src/prompts/attachments/orchestrator.ts
+++ b/runtime/src/prompts/attachments/orchestrator.ts
@@ -28,6 +28,7 @@ import type { AttachmentTrackingState } from "../../session/attachment-state.js"
 import { getAttachmentTrackingState } from "../../session/attachment-state.js";
 import { agentListingDeltaProducer } from "./agent-listing-delta.js";
 import { autoModeProducer } from "./auto-mode.js";
+import { swarmModeProducer } from "./swarm-mode.js";
 import { criticalReminderProducer } from "./critical-reminder.js";
 import { dateChangeProducer } from "./date-change.js";
 import { deferredToolsDeltaProducer } from "./deferred-tools-delta.js";
@@ -147,6 +148,7 @@ const PRODUCERS: readonly AttachmentProducer[] = [
   planModeProducer,
   verifyPlanReminderProducer,
   autoModeProducer,
+  swarmModeProducer,
   //
   // Phase 3 — Mid-session deltas:
   deferredToolsDeltaProducer,

--- a/runtime/src/prompts/attachments/swarm-mode.ts
+++ b/runtime/src/prompts/attachments/swarm-mode.ts
@@ -1,0 +1,41 @@
+/**
+ * Swarm-mode attachment producer.
+ *
+ * While swarm mode is on (`/swarm`, persisted in user settings), inject a
+ * system reminder nudging the agent to fan out divisible work to parallel
+ * sub-agents by default. This is a GUIDANCE nudge only: it changes what the
+ * model is told, never the permission policy — spawn_agent/multi-agent
+ * calls are side-effecting and still require approval per the active
+ * permission mode (yolo/bypass auto-approves them like everything else).
+ *
+ * The producer reads the persisted flag from user settings (the same
+ * settings.json channel /swarm writes and the daemon reloads via the
+ * settings watcher), so the TUI toggle takes effect on the next turn
+ * without any session restart.
+ *
+ * @module
+ */
+
+import {
+  getExecutionAuthoritySettings,
+} from "../../utils/settings/settings.js";
+import type { AttachmentProducer } from "./orchestrator.js";
+
+const SWARM_MODE_REMINDER =
+  "Swarm mode is active. For divisible work (multiple independent items, " +
+  "areas, or hypotheses), prefer spawning parallel sub-agents " +
+  "(spawn_agent / multi-agent fan-out) over grinding sequentially, then " +
+  "merge their results. Keep the main thread on coordination and " +
+  "verification. Spawning still follows the user's approval policy.";
+
+export const swarmModeProducer: AttachmentProducer = async (opts) => {
+  if (getExecutionAuthoritySettings().swarmMode !== true) {
+    return [];
+  }
+  // Only nudge the main thread; a swarm child would otherwise re-read the
+  // same instruction and try to fan out recursively.
+  if (opts.subagentDepth !== 0) {
+    return [];
+  }
+  return [{ kind: "critical_system_reminder", content: SWARM_MODE_REMINDER }];
+};

--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -630,7 +630,19 @@ function DesignBottomLeftLabel({
   readonly modelLabel: string;
 }): React.ReactNode {
   const modeLabel = permissionModeFooterChrome(mode).label;
-  return <ThemedText color="text2" wrap="truncate-end">● {modeLabel} · {modelLabel}{gitLabel === null ? '' : ` · ${gitLabel}`}</ThemedText>;
+  // Swarm indicator sits next to the mode (like yolo): visible only while
+  // swarm mode is on; carries the live running-agent count from AppState.
+  // Read from AppState (the appStateBridge /swarm writes through), with the
+  // provider-safe hook so the label also renders without AppStateProvider.
+  const swarmMode =
+    useAppStateMaybeOutsideOfProvider((state) => state.swarmMode) === true;
+  const tasks = useAppStateMaybeOutsideOfProvider(state => state.tasks) ?? {};
+  const runningAgents = React.useMemo(
+    () => Object.values(tasks ?? {}).filter((task: any) => task?.type !== "local_bash" && (task?.status === "running" || task?.status === "pending")).length,
+    [tasks],
+  );
+  const swarmLabel = swarmMode ? (runningAgents > 0 ? ` · swarm ${runningAgents}` : " · swarm") : "";
+  return <ThemedText color="text2" wrap="truncate-end">● {modeLabel}{swarmLabel} · {modelLabel}{gitLabel === null ? '' : ` · ${gitLabel}`}</ThemedText>;
 }
 
 function DesignBottomRightLabel({

--- a/runtime/src/tui/state/AppStateStore.ts
+++ b/runtime/src/tui/state/AppStateStore.ts
@@ -379,6 +379,10 @@ export type AppState = DeepImmutable<{
   advisorModel?: string
   // Effort value
   effortValue?: EffortValue
+  // Swarm mode: when on, the agent is nudged to fan out divisible work to
+  // parallel sub-agents by default (see the /swarm command and the
+  // swarm-mode prompt attachment). Spawns still require approval per policy.
+  swarmMode?: boolean
 }
 
 export type AppStateStore = Store<AppState>
@@ -494,6 +498,7 @@ export function getDefaultAppState(): AppState {
     authVersion: 0,
     initialMessage: null,
     effortValue: undefined,
+    swarmMode: false,
     activeOverlays: new Set<string>(),
     fastMode: false,
   }

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -92,11 +92,29 @@ function ComposerContextRow({
   const modelLabel = renderModelName(parseUserSpecifiedModel(modelSetting));
   const modeLabel = permissionModeShortTitle(mode).toLowerCase();
   const dangerous = isDangerousPermissionMode(mode);
+  // Swarm indicator next to the mode (like yolo): visible only while swarm
+  // mode is on (/swarm), carrying the live running-agent count from AppState.
+  const swarmMode =
+    useAppStateMaybeOutsideOfProvider((state) => state.swarmMode) === true;
+  const tasks = useAppStateMaybeOutsideOfProvider((state) => state.tasks) ?? {};
+  const runningAgents = Object.values(tasks).filter(
+    (task: any) =>
+      task?.type !== "local_bash" &&
+      (task?.status === "running" || task?.status === "pending"),
+  ).length;
+  const swarmLabel = swarmMode
+    ? ` · swarm${runningAgents > 0 ? ` ${runningAgents}` : ""}`
+    : "";
   return (
     <Box flexDirection="row" paddingX={1} height={1} overflowY="hidden">
       <Text color={mode === "plan" ? "planMode" : dangerous ? "warning" : "inactive"}>
         {modeLabel}
       </Text>
+      {swarmMode ? (
+        <Text color="agenc" wrap="truncate-end">
+          {swarmLabel}
+        </Text>
+      ) : null}
       <Text color="inactive" wrap="truncate-end">
         {` · ${modelLabel}${contextPctLabel !== null ? ` · ${contextPctLabel}` : ""}`}
       </Text>

--- a/runtime/src/utils/settings/applySettingsChange.ts
+++ b/runtime/src/utils/settings/applySettingsChange.ts
@@ -78,6 +78,9 @@ export function applySettingsChange(
     const prevEffort = prev.settings.effortLevel
     const newEffort = authoritySettings.effortLevel
     const effortChanged = prevEffort !== newEffort
+    const prevSwarm = prev.settings.swarmMode
+    const newSwarm = authoritySettings.swarmMode
+    const swarmChanged = prevSwarm !== newSwarm
 
     return {
       ...prev,
@@ -90,6 +93,12 @@ export function applySettingsChange(
       // be true and we'd wipe a session-scoped value held in effortValue.
       ...(effortChanged && newEffort !== undefined
         ? { effortValue: newEffort }
+        : {}),
+      // swarmMode follows the same settings → AppState channel as effortValue:
+      // /swarm writes the disk key, this mirrors it into top-level AppState for
+      // the status bar and the prompt attachment to read.
+      ...(swarmChanged && newSwarm !== undefined
+        ? { swarmMode: newSwarm }
         : {}),
     }
   })

--- a/runtime/src/utils/settings/types.ts
+++ b/runtime/src/utils/settings/types.ts
@@ -715,6 +715,13 @@ export const SettingsSchema = lazySchema(() =>
         .optional()
         .catch(undefined)
         .describe('Persisted effort level for supported models.'),
+      swarmMode: z
+        .boolean()
+        .optional()
+        .catch(undefined)
+        .describe(
+          'Persisted swarm mode: fan out divisible work to parallel sub-agents by default.',
+        ),
       advisorModel: z
         .string()
         .optional()

--- a/runtime/tests/commands/command-surface.test.ts
+++ b/runtime/tests/commands/command-surface.test.ts
@@ -41,6 +41,7 @@ const MINIMAL_NAMES = [
   "provider",
   "effort",
   "resolve",
+  "swarm",
   "permissions",
   "plan",
   "agents",

--- a/runtime/tests/commands/swarm.test.ts
+++ b/runtime/tests/commands/swarm.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+
+import { swarmCommand } from "../../src/commands/swarm.js";
+import { swarmModeProducer } from "../../src/prompts/attachments/swarm-mode.js";
+import {
+  getSettingsForSource,
+  updateSettingsForSource,
+} from "../../src/utils/settings/settings.js";
+
+function makeCtx(argsRaw: string) {
+  const appState = {
+    state: { swarmMode: false as boolean | undefined },
+    getAppState() {
+      return this.state;
+    },
+    setAppState(updater: (prev: unknown) => unknown) {
+      this.state = updater(this.state) as typeof this.state;
+    },
+  };
+  return { argsRaw, appState } as never;
+}
+
+describe("/swarm command", () => {
+  test("status reports the current mode and usage hint", async () => {
+    updateSettingsForSource("userSettings", { swarmMode: undefined });
+    const result = (await swarmCommand.execute(makeCtx("status"))) as {
+      kind: string;
+      text: string;
+    };
+    expect(result.kind).toBe("text");
+    expect(result.text).toContain("swarm mode: off");
+    expect(result.text).toContain("/swarm on");
+  });
+
+  test("on enables swarm mode in settings and AppState", async () => {
+    const ctx = makeCtx("on") as {
+      appState: { state: { swarmMode?: boolean } };
+    };
+    const result = (await swarmCommand.execute(ctx as never)) as {
+      kind: string;
+      text: string;
+    };
+    expect(result.kind).toBe("text");
+    expect(ctx.appState.state.swarmMode).toBe(true);
+    expect(getSettingsForSource("userSettings")?.swarmMode).toBe(true);
+  });
+
+  test("off disables swarm mode again", async () => {
+    const ctx = makeCtx("off") as {
+      appState: { state: { swarmMode?: boolean } };
+    };
+    const result = (await swarmCommand.execute(ctx as never)) as {
+      kind: string;
+      text: string;
+    };
+    expect(result.kind).toBe("text");
+    expect(ctx.appState.state.swarmMode).toBe(false);
+    expect(getSettingsForSource("userSettings")?.swarmMode).toBe(false);
+  });
+
+  test("rejects unknown arguments", async () => {
+    const result = (await swarmCommand.execute(makeCtx("maybe"))) as {
+      kind: string;
+      message: string;
+    };
+    expect(result.kind).toBe("error");
+    expect(result.message).toContain("Usage");
+  });
+});
+
+describe("swarmModeProducer", () => {
+  const opts = { subagentDepth: 0 } as never;
+  const childOpts = { subagentDepth: 1 } as never;
+
+  test("emits the parallel fan-out nudge while swarm mode is on", async () => {
+    updateSettingsForSource("userSettings", { swarmMode: true });
+    const attachments = await swarmModeProducer(opts, {} as never);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      kind: "critical_system_reminder",
+    });
+    expect(
+      (attachments[0] as { content?: string }).content ?? "",
+    ).toContain("Swarm mode is active");
+  });
+
+  test("emits nothing when swarm mode is off", async () => {
+    updateSettingsForSource("userSettings", { swarmMode: false });
+    expect(await swarmModeProducer(opts, {} as never)).toEqual([]);
+  });
+
+  test("emits nothing on swarm children (no recursive fan-out)", async () => {
+    updateSettingsForSource("userSettings", { swarmMode: true });
+    expect(await swarmModeProducer(childOpts, {} as never)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Qué es

Paridad con el `/swarm` de Kimi CLI sobre la infraestructura de swarm que AgenC ya tiene (spawnMultiAgent, teammates in-process, SwarmPanel con stats reales):

- **Flag `swarmMode`** en AppState + key persistida en user settings (schema zod + sync `applySettingsChange` a AppState).
- **Comando `/swarm`** (`on` / `off` / `status` con conteo de agents vivos) — escribe settings y AppState via el appStateBridge de comandos.
- **Indicador en la status bar** junto al modo de permisos (en la línea de contexto del composer): `default · swarm · grok-4.5` (+ conteo de agents corriendo), leído de AppState con el hook provider-safe. La etiqueta inferior de FullscreenLayout también lo lleva por consistencia.
- **Nudge al system prompt**: mientras está activo, el thread principal recibe la instrucción de fan-out de trabajo divisible a sub-agentes en paralelo por defecto (solo main thread — los hijos del swarm no reciben la instrucción para no fan-out recursivo). Es guía al modelo, NO política: los spawns siguen pidiendo aprobación según el modo activo (yolo auto-aprueba como siempre).

## Verificación

- Comando despacha y escribe settings (PTY); indicador pinta `default · swarm · grok-4.5` y se limpia con `/swarm off`.
- Tests del comando + producer + superficie de comandos.
- Suite TUI completa: **843 archivos, 4235 tests verdes**.