### PR TITLE
fix(swarm): keep-alive workers render idle between turns, not running forever

### DIFF
--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -2149,6 +2149,7 @@ function completionStatusKey(status: AgentStatus): string {
     case "errored":
     case "interrupted":
     case "running":
+    case "idle":
       return `${status.status}:${status.turnId}`;
     case "shutdown":
       return `${status.status}:${status.endedAtMs}`;

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -1825,6 +1825,14 @@ function terminalResultForLiveAgent(live: LiveAgent): ChildRunTerminalResult {
         stopReason: "turn_completed",
         finalMessage: status.lastMessage ?? null,
       };
+    case "idle":
+      // Keep-alive worker whose run ended between turns: its last turn
+      // completed, so the terminal account is a completion.
+      return {
+        status: "completed",
+        stopReason: "turn_completed",
+        finalMessage: null,
+      };
     case "errored":
       return {
         status: "failed",
@@ -2289,6 +2297,11 @@ export async function* runAgent(
     let assistantText = "";
     let toolCallCount = 0;
     while (true) {
+      // Mark running at the top of every turn. The initial pre-loop markRunning
+      // covers turn one; keep-alive workers return here after an `idle` gap
+      // (turn_complete below) when a follow-up turn starts, so each iteration
+      // must re-assert `running` to flip the FSM idle -> running.
+      live.status.markRunning(turnId);
       let turnAssistantText = "";
       let turnUsage: LLMUsage | undefined;
       let stopReason:
@@ -2528,6 +2541,11 @@ export async function* runAgent(
         turnId,
         ...(assistantText ? { finalMessage: assistantText } : {}),
       };
+      // Mark the keep-alive worker idle while it waits for more work. `idle`
+      // is non-final and reversible (status.ts), so the worker stays alive for
+      // assign_task yet the fan-out rail stops showing it as actively
+      // "running" between turns. The next loop iteration re-marks `running`.
+      live.status.markIdle(turnId);
       const advanced = await waitForNextMailboxMessage(
         live.downInbox,
         merged.signal,

--- a/runtime/src/agents/status.ts
+++ b/runtime/src/agents/status.ts
@@ -7,7 +7,12 @@
  *
  * Final states for wait/list semantics: `completed`, `errored`, `shutdown`,
  * `not_found`.
- * Non-final: `pending_init`, `running`, `interrupted`.
+ * Non-final: `pending_init`, `running`, `idle`, `interrupted`.
+ *
+ * `idle` is a keep-alive worker between turns: alive and reusable, but not
+ * actively working. Like `completed`, it is reversible — `assign_task` moves
+ * the agent back to `running` for its next turn — but unlike `completed` it
+ * is not a wait/list terminal state, so watchers keep observing a live worker.
  *
  * A completed turn is reusable: `assign_task` may move the same live agent
  * from `completed` back to `running` for its next turn. Shutdown, errored, and
@@ -30,6 +35,14 @@ export type AgentStatus =
       readonly status: "running";
       readonly turnId: string;
       readonly startedAtMs: number;
+    }
+  | {
+      // Keep-alive worker that finished a turn and is waiting for more work.
+      // Non-final (like `running`) so wait/list semantics keep watching, and
+      // reversible so a later assign_task turn can mark it `running` again.
+      readonly status: "idle";
+      readonly turnId: string;
+      readonly endedAtMs: number;
     }
   | {
       readonly status: "completed";
@@ -55,6 +68,7 @@ export type AgentStatus =
 export type AgentStatusJson =
   | "pending_init"
   | "running"
+  | "idle"
   | "interrupted"
   | "shutdown"
   | "not_found"
@@ -177,6 +191,8 @@ export function toAgentStatusJson(
       return "pending_init";
     case "running":
       return "running";
+    case "idle":
+      return "idle";
     case "interrupted":
       return "interrupted";
     case "completed":
@@ -217,6 +233,10 @@ export class AgentStatusTracker {
 
   markRunning(turnId: string): void {
     this.set({ status: "running", turnId, startedAtMs: monotonicMs() });
+  }
+
+  markIdle(turnId: string): void {
+    this.set({ status: "idle", turnId, endedAtMs: monotonicMs() });
   }
 
   markCompleted(turnId: string, lastMessage?: string): void {

--- a/runtime/src/agents/thread-manager.ts
+++ b/runtime/src/agents/thread-manager.ts
@@ -86,6 +86,8 @@ function normalizeSessionStatus(status: SessionAgentStatus): AgentStatus {
       };
     case "running":
       return status;
+    case "idle":
+      return status;
     case "pending_init":
       return status;
     case "not_found":

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -5016,6 +5016,7 @@ function mapThreadStatus(status: ThreadAgentStatus): DaemonAgentStatus {
     case "shutdown":
       return "stopped";
     case "interrupted":
+    case "idle":
       return "idle";
     case "errored":
       return "error";
@@ -5052,6 +5053,19 @@ function eventFromThreadStatus(
           ...(status.endedAtMs !== undefined
             ? { completedAt: status.endedAtMs }
             : {}),
+        },
+      };
+    case "idle":
+      // Keep-alive worker between turns: surface a turn_complete so the daemon
+      // flips the agent to idle/completed instead of leaving it "running"
+      // forever. The id must be unique per transition (the keep-alive turnId is
+      // constant across turns), so suffix the monotonic end timestamp.
+      return {
+        id: `idle-${status.turnId}-${status.endedAtMs}`,
+        type: "turn_complete",
+        payload: {
+          turnId: status.turnId,
+          completedAt: status.endedAtMs,
         },
       };
     case "errored":

--- a/runtime/src/tasks/agent-thread.ts
+++ b/runtime/src/tasks/agent-thread.ts
@@ -18,7 +18,11 @@ import type {
 } from "../services/PromptSuggestion/runtime.js";
 import type { Message } from "../types/message.js";
 import type { BackgroundTaskSnapshot } from "./lifecycle.js";
-import { BackgroundTaskLifecycle } from "./lifecycle.js";
+import {
+  BackgroundTaskLifecycle,
+  isTerminalTaskStatus,
+  type BackgroundTaskStatus,
+} from "./lifecycle.js";
 import {
   startAgentSummarization,
   type AgentSummaryHandle,
@@ -170,8 +174,22 @@ export function registerAgentThreadTask(
     }
   };
   const notifySnapshot = (snapshot: BackgroundTaskSnapshot): BackgroundTaskSnapshot => {
-    opts.onSnapshot?.(snapshot);
-    return snapshot;
+    // Single choke point for every emitted snapshot (status subscription,
+    // progress timer, registration, join). A keep-alive worker between turns
+    // has FSM state `idle` but its lifecycle record stays non-terminal
+    // "running" (so close_agent/stop and a later assign_task turn still work).
+    // Relabel the emitted snapshot to "idle" here so the fan-out rail renders
+    // the worker as done-between-turns instead of spinning "running" forever —
+    // including the progress-timer snapshot that can land a tick after the
+    // idle transition. Terminal snapshots (completed/failed/killed) are never
+    // relabeled. collabStatusToTaskStatus maps "idle" -> "completed".
+    const relabeled =
+      thread.live.status.value.status === "idle" &&
+      !isTerminalTaskStatus(snapshot.status)
+        ? { ...snapshot, status: "idle" as BackgroundTaskStatus }
+        : snapshot;
+    opts.onSnapshot?.(relabeled);
+    return relabeled;
   };
   const task = notifySnapshot(lifecycle.register({
     id: threadId,
@@ -440,6 +458,11 @@ function mapAgentStatus(
       case "pending_init":
         return undefined;
       case "running":
+      case "idle":
+        // Both map to a non-terminal "running" record. When the FSM is `idle`
+        // (keep-alive between turns), notifySnapshot relabels the emitted
+        // snapshot to "idle" so the panel shows done-between-turns; the record
+        // itself stays "running" so the worker remains stoppable/reusable.
         return lifecycle.markRunning(taskId, { turnId: status.turnId });
       case "interrupted":
         return lifecycle.appendOutput(taskId, `\n[agent interrupted: ${status.reason}]\n`);

--- a/runtime/tests/agents/status.test.ts
+++ b/runtime/tests/agents/status.test.ts
@@ -68,6 +68,38 @@ describe("AgentStatusTracker", () => {
     expect(t.value.status).toBe("running");
   });
 
+  it("markIdle moves a keep-alive worker to idle between turns", () => {
+    const t = new AgentStatusTracker();
+    t.markRunning("turn-1");
+    t.markIdle("turn-1");
+    const s = t.value;
+    expect(s.status).toBe("idle");
+    if (s.status === "idle") expect(s.turnId).toBe("turn-1");
+  });
+
+  it("idle is non-final so wait/list keeps watching a live worker", () => {
+    expect(isFinal({ status: "idle", turnId: "turn-1", endedAtMs: 0 })).toBe(
+      false,
+    );
+  });
+
+  it("idle is reversible: a follow-up turn re-marks running", () => {
+    const t = new AgentStatusTracker();
+    t.markRunning("turn-1");
+    t.markIdle("turn-1");
+    expect(t.value.status).toBe("idle");
+    t.markRunning("turn-2");
+    expect(t.value).toMatchObject({ status: "running", turnId: "turn-2" });
+  });
+
+  it("idle can still reach a terminal state on shutdown", () => {
+    const t = new AgentStatusTracker();
+    t.markRunning("turn-1");
+    t.markIdle("turn-1");
+    t.markShutdown();
+    expect(t.value.status).toBe("shutdown");
+  });
+
   it("shutdown stays sticky and rejects further transitions", () => {
     const t = new AgentStatusTracker();
     t.markShutdown();

--- a/runtime/tests/tasks/lifecycle.test.ts
+++ b/runtime/tests/tasks/lifecycle.test.ts
@@ -441,6 +441,50 @@ describe("registerAgentThreadTask", () => {
     expect(completed?.progress?.tokenCount).toBe(51000);
   });
 
+  it("emits an idle snapshot for a keep-alive worker between turns while the record stays running", async () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    const status = new FakeStatus();
+    const joined = deferred<RunAgentResult>();
+    const statuses: string[] = [];
+    const thread: AgentThreadTaskHandle = {
+      threadId: "agent-keepalive",
+      taskPrompt: "work",
+      live: {
+        abortController: new AbortController(),
+        status,
+      },
+      join: () => joined.promise,
+    };
+
+    registerAgentThreadTask(lifecycle, thread, {
+      // Disable the poller; drive snapshots through status transitions so the
+      // assertions are deterministic.
+      progressIntervalMs: 0,
+      onSnapshot: (snapshot) => {
+        statuses.push(snapshot.status);
+      },
+    });
+
+    // Active turn -> running snapshot and running record.
+    status.set({ status: "running", turnId: "turn-1", startedAtMs: 10 });
+    expect(statuses.at(-1)).toBe("running");
+    expect(lifecycle.get("agent-keepalive")?.status).toBe("running");
+
+    // Turn completes and the keep-alive worker waits for more work: the
+    // emitted snapshot is relabeled "idle" (so the panel renders
+    // done-between-turns) but the lifecycle record stays non-terminal
+    // "running" so close_agent/stop and a later assign_task turn still work.
+    status.set({ status: "idle", turnId: "turn-1", endedAtMs: 20 });
+    expect(statuses.at(-1)).toBe("idle");
+    expect(lifecycle.get("agent-keepalive")?.status).toBe("running");
+
+    // A follow-up turn (assign_task) re-marks running: snapshot returns to
+    // running and the record was never terminal, so the transition is allowed.
+    status.set({ status: "running", turnId: "turn-2", startedAtMs: 30 });
+    expect(statuses.at(-1)).toBe("running");
+    expect(lifecycle.get("agent-keepalive")?.status).toBe("running");
+  });
+
   it("starts AgentSummary for registered threads and writes progress summaries", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Problem

Collab/swarm workers are spawned `keepAlive: true` so `assign_task` can reuse them after their first turn. But their `AgentStatus` FSM stayed `running` from the first `markRunning` until shutdown — `markCompleted` only fires on agent exit. The fan-out rail read that as a worker spinning **running** eternally, even after the chat said its work was done.

## Root cause

`runAgent` marked a keep-alive worker `running` once before the turn loop and never transitioned it between turns. The panel's `collab_agent_status` events carry the lifecycle snapshot status (`running`), so a finished-but-alive worker looked permanently busy.

## Fix

Introduce a **non-final, reversible `idle` `AgentStatus`**:

- `runAgent` calls `markIdle` at the keep-alive `turn_complete` boundary and re-marks `running` at the top of every turn — so a worker between turns reads done, and a reused worker reads active again. `idle` is non-final (wait/list keeps watching a live worker) and reversible (`assign_task` flips it back to `running`).
- The lifecycle record **stays non-terminal `running`** so `close_agent`/`stop` and reuse keep working. Only the *emitted snapshot* is relabeled `idle` at the `registerAgentThreadTask` `notifySnapshot` choke point; `collabStatusToTaskStatus` already maps `idle` → `completed` in the panel.
- `background-agent-runner` maps thread `idle` → daemon `idle` / `turn_complete` for the same rendering.
- New `idle` cases added to every exhaustive `AgentStatus` switch.

This also covers the **progress-timer race**: a late `running` snapshot landing a tick after the idle transition is relabeled to `idle` too, so the panel can't flip back.

## Tests

- `tests/agents/status.test.ts` + `tests/tasks/lifecycle.test.ts`: idle FSM transitions + keep-alive idle snapshot relabel.
- Full agents/tasks/app-server/collab-sync suites green (500+ tests); `tsc --noEmit` clean.
- Live PTY smoke: two consecutive keep-alive turns both respond and clear the busy spinner, no crash, no latch.