### PR TITLE
feat(tui): prominent SWARM badge next to the mode label

### DIFF
--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -641,8 +641,16 @@ function DesignBottomLeftLabel({
     () => Object.values(tasks ?? {}).filter((task: any) => task?.type !== "local_bash" && (task?.status === "running" || task?.status === "pending")).length,
     [tasks],
   );
-  const swarmLabel = swarmMode ? (runningAgents > 0 ? ` · swarm ${runningAgents}` : " · swarm") : "";
-  return <ThemedText color="text2" wrap="truncate-end">● {modeLabel}{swarmLabel} · {modelLabel}{gitLabel === null ? '' : ` · ${gitLabel}`}</ThemedText>;
+  const swarmBadgeText = ` SWARM${runningAgents > 0 ? ` ${runningAgents}` : ""} `;
+  return (
+    <>
+      <ThemedText color="text2" wrap="truncate-end">● {modeLabel}</ThemedText>
+      {swarmMode ? (
+        <ThemedText backgroundColor="agenc" color="ansi:white" bold wrap="truncate-end">{swarmBadgeText}</ThemedText>
+      ) : null}
+      <ThemedText color="text2" wrap="truncate-end"> · {modelLabel}{gitLabel === null ? '' : ` · ${gitLabel}`}</ThemedText>
+    </>
+  );
 }
 
 function DesignBottomRightLabel({

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -20,6 +20,7 @@ import { PromptDialogOverlay, PromptSuggestionsOverlay } from "../components/Pro
 import type { PendingRequest } from "../permission-requests.js";
 import type { SpinnerMode } from "../components/spinner/types.js";
 import { AgentsRail } from "./agents/AgentsRail.js";
+import ThemedText from "../components/design-system/ThemedText.js";
 import { PreviewSurface } from "./surfaces/PreviewSurface.js";
 import { isDangerousPermissionMode } from "./WorkbenchContextStrip.js";
 import { ProjectExplorer } from "./project-tree/ProjectExplorer.js";
@@ -102,18 +103,16 @@ function ComposerContextRow({
       task?.type !== "local_bash" &&
       (task?.status === "running" || task?.status === "pending"),
   ).length;
-  const swarmLabel = swarmMode
-    ? ` · swarm${runningAgents > 0 ? ` ${runningAgents}` : ""}`
-    : "";
+  const swarmBadgeText = ` SWARM${runningAgents > 0 ? ` ${runningAgents}` : ""} `;
   return (
     <Box flexDirection="row" paddingX={1} height={1} overflowY="hidden">
       <Text color={mode === "plan" ? "planMode" : dangerous ? "warning" : "inactive"}>
         {modeLabel}
       </Text>
       {swarmMode ? (
-        <Text color="agenc" wrap="truncate-end">
-          {swarmLabel}
-        </Text>
+        <ThemedText backgroundColor="agenc" color="ansi:white" bold wrap="truncate-end">
+          {swarmBadgeText}
+        </ThemedText>
       ) : null}
       <Text color="inactive" wrap="truncate-end">
         {` · ${modelLabel}${contextPctLabel !== null ? ` · ${contextPctLabel}` : ""}`}


### PR DESCRIPTION
When swarm mode is on (`/swarm`), the fan-out mode was easy to miss: a lowercase ` · swarm ` in a dim `text2`/`agenc` foreground blended into the mode+model status run.

Render a solid agenc-orange pill reading **` SWARM n `** (bold white on the brand color) immediately right of the permission-mode label (yolo/plan/default) — in both the Workbench composer context row and the Fullscreen bottom-left label. The badge carries the live running-agent count, so the active fan-out mode is obvious at a glance (kimi-cli style).

Verified via PTY: `/swarm on` makes the badge appear as `default SWARM · grok-4.5`; it's absent when off.