### PR TITLE
chore(tui): spell out /swarm on|off in the command description

### DIFF
--- a/runtime/src/commands/swarm.ts
+++ b/runtime/src/commands/swarm.ts
@@ -53,7 +53,7 @@ function setSwarmMode(ctx: SlashCommandContext, on: boolean): void {
 
 export const swarmCommand: SlashCommand = {
   name: "swarm",
-  description: "Toggle swarm mode — fan out divisible work to parallel sub-agents by default",
+  description: "Fan out divisible work to parallel sub-agents — /swarm on to activate, /swarm off to stop",
   immediate: true,
   supportsNonInteractive: true,
   execute: async (ctx) =>


### PR DESCRIPTION
The `/swarm` description said "Toggle swarm mode" but never told the user how to activate it. Now it reads: *Fan out divisible work to parallel sub-agents — /swarm on to activate, /swarm off to stop.*