### PR TITLE
fix(imagine): give ImagineVideo/ImagineImage real tool timeouts

### DIFF
--- a/runtime/src/tools/system/imagine-image.ts
+++ b/runtime/src/tools/system/imagine-image.ts
@@ -79,6 +79,10 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
     isReadOnly: false,
     requiresApproval: true,
     concurrencyClass: { kind: "exclusive" },
+    // Image generation uses an internal 120s timeout (AbortSignal.timeout); the
+    // 30s default tool timeout could cut a slow generation just short. Give the
+    // harness backstop 2.5min so it always exceeds the tool's own timeout.
+    timeoutMs: 150_000,
     recoveryCategory: "side-effecting",
     admissionEstimate: () => ({
       maxInputTokens: 0,

--- a/runtime/src/tools/system/imagine-video.ts
+++ b/runtime/src/tools/system/imagine-video.ts
@@ -136,6 +136,12 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
     isReadOnly: false,
     requiresApproval: true,
     concurrencyClass: { kind: "exclusive" },
+    // Video generation legitimately outlives the 30s default tool timeout: the
+    // internal poll alone waits up to 240s (pollTimeoutMs), plus the initial
+    // POST and the MP4 download. Give the harness backstop 5min so a healthy
+    // long generation isn't killed mid-poll; the tool's own internal timeouts
+    // still fire first with a clean error.
+    timeoutMs: 300_000,
     recoveryCategory: "side-effecting",
     admissionEstimate: () => ({
       maxInputTokens: 0,


### PR DESCRIPTION
## Problem

`ImagineVideo` kept failing with `ToolTimeoutError: tool ImagineVideo exceeded 30000ms timeout`. Neither Imagine tool declared `timeoutMs`, so both fell back to `DEFAULT_TOOL_TIMEOUT_MS = 30s`. But `ImagineVideo`'s internal poll alone waits up to **240s**, so every video generation was killed at 30s — the agent even worked around it by generating a keyframe image first (which worked, since images finish <30s) then image-to-video, and still timed out.

## Fix

Set per-tool `timeoutMs`:
- `ImagineVideo` → **300s** (covers the 240s poll + initial POST + MP4 download).
- `ImagineImage` → **150s** (covers its internal 120s timeout with margin).

The tool's own internal timeouts still fire first with a clean error; the harness timeout is only the outer backstop, so a genuinely stuck call can't hang past these bounds.