### PR TITLE
fix(tui): opt ptyxis out of DEC 2026 sync output (chat blank+repaint flicker)

### DIFF
--- a/runtime/src/tui/ink/terminal.ts
+++ b/runtime/src/tui/ink/terminal.ts
@@ -73,6 +73,13 @@ export function isSynchronizedOutputSupported(): boolean {
   // broken atomicity by chunking. Skip to save 16 bytes/frame + parser work.
   if (process.env.TMUX) return false
 
+  // Ptyxis reports a new VTE_VERSION (>= 6800) but its DEC 2026 / DECSTBM
+  // handling renders the non-atomic intermediate scroll state — the chat
+  // visibly blanks and repaints on every scroll (e.g. when a task completes).
+  // The VTE_VERSION check below would wrongly enable sync output for it; the
+  // plain diff loop is correct (just a few more bytes), so opt ptyxis out.
+  if (process.env.PTYXIS_VERSION) return false
+
   const termProgram = process.env.TERM_PROGRAM
   const term = process.env.TERM
 

--- a/runtime/tests/tui/ink/terminal.wave200-041.coverage.test.ts
+++ b/runtime/tests/tui/ink/terminal.wave200-041.coverage.test.ts
@@ -18,6 +18,7 @@ const TERMINAL_ENV_KEYS = [
   'KONSOLE_VERSION',
   'MSYSTEM',
   'NODE_ENV',
+  'PTYXIS_VERSION',
   'SESSIONNAME',
   'SSH_CLIENT',
   'SSH_CONNECTION',
@@ -202,6 +203,11 @@ describe('terminal capability detection', () => {
     expect(terminal.isSynchronizedOutputSupported()).toBe(false)
 
     resetTerminalEnv({ TERM_PROGRAM: 'Apple_Terminal', VTE_VERSION: '6799' })
+    expect(terminal.isSynchronizedOutputSupported()).toBe(false)
+
+    // Ptyxis reports a new VTE_VERSION but mishandles DEC 2026/DECSTBM, so it
+    // is opted out even though its VTE_VERSION would otherwise qualify.
+    resetTerminalEnv({ PTYXIS_VERSION: '50.1', VTE_VERSION: '8400' })
     expect(terminal.isSynchronizedOutputSupported()).toBe(false)
   })
 


### PR DESCRIPTION
## Problem

On **ptyxis**, the whole chat visibly blanked and repainted on every scroll — most noticeable when a task completed and the transcript jumped. 

Root cause: ptyxis reports `VTE_VERSION >= 6800`, so `isSynchronizedOutputSupported()` enabled DEC 2026 sync output + the DECSTBM hardware-scroll optimization. But ptyxis renders the **non-atomic intermediate scroll state**, producing the blank-then-repaint flicker.

## Diagnosis (confirmed live)

- Repro attempts ruled out the `clearTerminal` full-reset (0 `ESC[2J/3J` in the byte stream during streaming + agent completion).
- Relaunching the TUI with sync output disabled (`decstbmSafe=false`) **eliminated the flicker** — confirming the DECSTBM/sync-output scroll path in ptyxis as the cause.

## Fix

Opt ptyxis out of sync output via `PTYXIS_VERSION`, so it falls back to the plain diff loop (always correct, marginally more bytes). Adds the case to the terminal-capability test and registers `PTYXIS_VERSION` in the test env-reset list.