### PR TITLE
feat(commands): /ledger — query the Ledger wallet via wallet-cli

### DIFF
--- a/runtime/src/commands/ledger.ts
+++ b/runtime/src/commands/ledger.ts
@@ -1,0 +1,184 @@
+/**
+ * `/ledger` — query the Ledger wallet via the official `wallet-cli`
+ * (Ledger Agent Stack). Thin pass-through: `/ledger <subcommand> [args]`
+ * runs `wallet-cli <subcommand> [args]` and shows the output.
+ *
+ * Design notes (mirroring the wallet-cli-usage skill's safety rules):
+ * - Read-only subcommands (session, balances, operations, assets, swap
+ *   quote/status, earn yields/positions) run with a short timeout — no
+ *   device needed.
+ * - Device subcommands (account discover, receive, send, genuine-check,
+ *   swap execute, earn deposit/withdraw, ring *) need the Ledger on USB and
+ *   a physical on-device approval, so they get a long timeout and a heads-up
+ *   line — per the skill, device commands must NOT be killed while the CLI
+ *   is waiting for the human to confirm on the signer.
+ * - Value-moving actions are never executed by this command alone; the
+ *   Ledger hardware enforces the "agents propose, humans approve" boundary.
+ *
+ * @module
+ */
+
+import { spawn } from "node:child_process";
+import {
+  safeExecute,
+  type SlashCommand,
+  type SlashCommandResult,
+} from "./types.js";
+
+const READONLY_TIMEOUT_MS = 30_000;
+const DEVICE_TIMEOUT_MS = 120_000;
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  timedOut: boolean;
+}
+
+/** Exported for injection from tests. */
+export function runWalletCli(
+  args: readonly string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<CliResult> {
+  return new Promise((resolve) => {
+    const child = spawn("wallet-cli", [...args], { cwd });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+    }, timeoutMs);
+    timer.unref?.();
+
+    child.stdout.on("data", (d) => (stdout += d.toString("utf8")));
+    child.stderr.on("data", (d) => (stderr += d.toString("utf8")));
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr: stderr + String(err), code: -1, timedOut });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code, timedOut });
+    });
+  });
+}
+
+/**
+ * Subcommands that talk to the Ledger device over USB and wait for a
+ * physical approval. Matched against the leading one/two words of the args.
+ */
+const DEVICE_PREFIXES = [
+  "account discover",
+  "receive",
+  "send",
+  "genuine-check",
+  "swap execute",
+  "earn deposit",
+  "earn withdraw",
+  "ring init",
+  "ring encrypt",
+  "ring decrypt",
+  "ring keys",
+  "ring destroy",
+];
+
+function requiresDevice(args: readonly string[]): boolean {
+  const joined = args.join(" ").toLowerCase();
+  return DEVICE_PREFIXES.some((prefix) => joined.startsWith(prefix));
+}
+
+const USAGE = [
+  "/ledger — Ledger wallet (via wallet-cli)",
+  "",
+  "Read-only (no device):",
+  "  /ledger session                     saved accounts",
+  "  /ledger balances <label>            native + token balances",
+  "  /ledger operations <label>          transaction history",
+  "  /ledger swap quote ...              swap quotes",
+  "  /ledger earn yields [-n ethereum]   staking / DeFi yields",
+  "",
+  "Needs the Ledger on USB + on-device approval:",
+  "  /ledger account discover <bitcoin|ethereum|solana>",
+  "  /ledger receive <label> [--verify]",
+  "  /ledger genuine-check",
+  "  /ledger send <label> --to <addr> --amount '<amt> <ticker>'",
+  "  /ledger swap execute ...",
+  "",
+  "Networks: bitcoin, ethereum, solana. Value-moving actions always pause",
+  "for physical approval on the device — agents propose, humans approve.",
+].join("\n");
+
+export const ledgerCommand: SlashCommand = {
+  name: "ledger",
+  description:
+    "Ledger wallet via wallet-cli — balances, operations, send/swap/receive, earn. /ledger session to start",
+  immediate: true,
+  supportsNonInteractive: true,
+  execute: async (ctx): Promise<SlashCommandResult> =>
+    safeExecute(async () => {
+      const args = ctx.argsRaw.split(/\s+/).filter((s) => s.length > 0);
+
+      // Bare `/ledger` → show the session (per the skill's "session first"
+      // rule) followed by usage, so the user sees saved accounts immediately.
+      if (args.length === 0) {
+        const session = await runWalletCli(
+          ["session", "view", "--output", "human"],
+          ctx.cwd,
+          READONLY_TIMEOUT_MS,
+        );
+        const sessionText =
+          session.code === 0 && session.stdout.trim().length > 0
+            ? session.stdout.trimEnd()
+            : "(no saved accounts yet — run /ledger account discover <network>)";
+        return {
+          kind: "text",
+          text: `${sessionText}\n\n${USAGE}`,
+        };
+      }
+
+      const device = requiresDevice(args);
+      const timeoutMs = device ? DEVICE_TIMEOUT_MS : READONLY_TIMEOUT_MS;
+      const result = await runWalletCli(
+        [...args, "--output", "human"],
+        ctx.cwd,
+        timeoutMs,
+      );
+
+      // wallet-cli not installed (spawn error / ENOENT).
+      if (result.code === -1) {
+        return {
+          kind: "error",
+          message:
+            "wallet-cli not found. Install it: npm i -g @ledgerhq/wallet-cli (requires Bun).",
+        };
+      }
+      if (result.timedOut) {
+        return {
+          kind: "error",
+          message: device
+            ? `wallet-cli timed out after ${DEVICE_TIMEOUT_MS / 1000}s waiting for on-device approval. Confirm on your Ledger and retry.`
+            : `wallet-cli timed out after ${READONLY_TIMEOUT_MS / 1000}s.`,
+        };
+      }
+      if (result.code !== 0) {
+        const detail = result.stderr.trim() || result.stdout.trim();
+        return {
+          kind: "error",
+          message: `wallet-cli failed (exit ${result.code}): ${detail}`,
+        };
+      }
+
+      const body = result.stdout.trimEnd() || "(no output)";
+      const text = device
+        ? `[confirm on your Ledger device]\n${body}`
+        : body;
+      return { kind: "text", text };
+    }),
+};

--- a/runtime/src/commands/registry.ts
+++ b/runtime/src/commands/registry.ts
@@ -47,6 +47,7 @@ import { xaiAuthCommands } from "./xai-auth.js";
 import { effortCommand } from "./effort.js";
 import { resolveCommand } from "./resolve.js";
 import { swarmCommand } from "./swarm.js";
+import { ledgerCommand } from "./ledger.js";
 
 /**
  * Concrete in-memory implementation of `CommandRegistry`.
@@ -163,6 +164,7 @@ export function buildDefaultRegistry(
     effortCommand,
     resolveCommand,
     swarmCommand,
+    ledgerCommand,
     permissionsCommand,
     planCommand,
     agentsCommand,

--- a/runtime/tests/commands/ledger.test.ts
+++ b/runtime/tests/commands/ledger.test.ts
@@ -1,0 +1,118 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { ledgerCommand } from "../../src/commands/ledger.js";
+
+type FakeResult = {
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly code?: number;
+  readonly error?: Error;
+  readonly neverClose?: boolean;
+};
+
+let lastSpawn: { cmd: string; args: readonly string[] } | null = null;
+
+function fakeChild(result: FakeResult) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  if (!result.neverClose) {
+    process.nextTick(() => {
+      if (result.error) {
+        child.emit("error", result.error);
+        return;
+      }
+      if (result.stdout) child.stdout.emit("data", result.stdout);
+      if (result.stderr) child.stderr.emit("data", result.stderr);
+      child.emit("close", result.code ?? 0);
+    });
+  }
+  return child;
+}
+
+let nextResult: FakeResult = { code: 0, stdout: "" };
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn((cmd: string, args: readonly string[]) => {
+    lastSpawn = { cmd, args };
+    return fakeChild(nextResult);
+  }),
+}));
+
+function makeCtx(argsRaw: string) {
+  return { argsRaw, cwd: "/tmp" } as never;
+}
+
+afterEach(() => {
+  lastSpawn = null;
+  nextResult = { code: 0, stdout: "" };
+});
+
+describe("/ledger command", () => {
+  test("bare /ledger runs session view and appends usage", async () => {
+    nextResult = { code: 0, stdout: "ethereum-1\nbitcoin-1\n" };
+    const result = (await ledgerCommand.execute(makeCtx(""))) as {
+      kind: string;
+      text: string;
+    };
+    expect(result.kind).toBe("text");
+    expect(lastSpawn?.cmd).toBe("wallet-cli");
+    expect(lastSpawn?.args).toEqual(["session", "view", "--output", "human"]);
+    expect(result.text).toContain("ethereum-1");
+    expect(result.text).toContain("/ledger balances");
+  });
+
+  test("passes a read-only subcommand through to wallet-cli", async () => {
+    nextResult = { code: 0, stdout: "0.42 ETH\n" };
+    const result = (await ledgerCommand.execute(
+      makeCtx("balances ethereum-1"),
+    )) as { kind: string; text: string };
+    expect(result.kind).toBe("text");
+    expect(lastSpawn?.args).toEqual([
+      "balances",
+      "ethereum-1",
+      "--output",
+      "human",
+    ]);
+    expect(result.text).toBe("0.42 ETH");
+    expect(result.text).not.toContain("confirm on your Ledger");
+  });
+
+  test("flags device subcommands with an on-device confirmation note", async () => {
+    nextResult = { code: 0, stdout: "broadcast tx 0xabc\n" };
+    const result = (await ledgerCommand.execute(
+      makeCtx("send ethereum-1 --to 0x123 --amount '0.01 ETH'"),
+    )) as { kind: string; text: string };
+    expect(result.kind).toBe("text");
+    expect(result.text).toContain("confirm on your Ledger device");
+    expect(result.text).toContain("broadcast tx 0xabc");
+  });
+
+  test("reports a clean error when wallet-cli is not installed", async () => {
+    nextResult = { error: new Error("spawn wallet-cli ENOENT") };
+    const result = (await ledgerCommand.execute(makeCtx("session"))) as {
+      kind: string;
+      message: string;
+    };
+    expect(result.kind).toBe("error");
+    expect(result.message).toContain("wallet-cli not found");
+    expect(result.message).toContain("@ledgerhq/wallet-cli");
+  });
+
+  test("surfaces wallet-cli failures with exit code and detail", async () => {
+    nextResult = { code: 4, stderr: "Wrong app. Open Ledger dashboard." };
+    const result = (await ledgerCommand.execute(makeCtx("genuine-check"))) as {
+      kind: string;
+      message: string;
+    };
+    expect(result.kind).toBe("error");
+    expect(result.message).toContain("exit 4");
+    expect(result.message).toContain("Open Ledger dashboard");
+  });
+});


### PR DESCRIPTION
Native `/ledger` slash command wrapping the official [Ledger Agent Stack](https://github.com/LedgerHQ/ledger-live/tree/develop/apps/wallet-cli) `wallet-cli`.

- **Bare `/ledger`** → runs `session view` (the skill's session-first rule) + usage.
- **`/ledger <subcommand> [args]`** → pass-through to `wallet-cli` (`balances`, `operations`, `send`, `swap`, `receive`, `earn`, `genuine-check`, `account discover`, `ring`).

Safety modeled on the wallet-cli-usage skill:
- **Read-only** subcommands → 30s timeout, no device needed.
- **Device** subcommands → 120s timeout + an "confirm on your Ledger device" note, because they wait for a physical on-device approval and must not be killed mid-prompt.
- Clean error when `wallet-cli` isn't installed (points at `npm i -g @ledgerhq/wallet-cli`).

Value-moving actions stay hardware-gated: **agents propose, humans approve** — the command never moves funds without the human confirming on the signer.

Pairs with the official `wallet-cli-usage` agent skill (installed into `~/.agents/skills`) so mentioning "ledger" in a prompt makes the agent load it and drive wallet-cli correctly. Tests cover session-first, pass-through, device flagging, not-installed, and exit-code surfacing.