### PR TITLE
fix(tools): give exec_command/write_stdin a long timeout for hardware-approval flows

### DIFF
--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -290,6 +290,11 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
     requiresApproval: true,
     concurrencyClass: { kind: "background_terminal" },
     isReadOnly: false,
+    // Long backstop so interactive hardware-approval flows (e.g. a Ledger
+    // device command that waits for a human to confirm on the signer) aren't
+    // killed at the 30s default. exec_command returns at yield_time_ms for
+    // normal commands, so this only matters when a long yield/timeout is set.
+    timeoutMs: 180_000,
     recoveryCategory: "side-effecting",
     supportsParallelToolCalls: false,
     isConcurrencySafe: () => false,

--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -67,6 +67,11 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
     requiresApproval: true,
     concurrencyClass: { kind: "background_terminal" },
     isReadOnly: false,
+    // Long backstop so polling a session that's waiting on human hardware
+    // approval (e.g. a Ledger signer confirming on-device) isn't killed at the
+    // 30s default before the human finishes. Normal polls return at
+    // yield_time_ms, so this only affects long interactive waits.
+    timeoutMs: 300_000,
     recoveryCategory: "side-effecting",
     supportsParallelToolCalls: false,
     isConcurrencySafe: () => false,


### PR DESCRIPTION
## Problem

Driving the Ledger wallet-cli from the agent produced `tool write_stdin exceeded 30000ms timeout` followed by `Unknown process id`. Both `exec_command` and `write_stdin` fell back to `DEFAULT_TOOL_TIMEOUT_MS = 30s`. A Ledger device command (`wallet-cli account discover`, `send`, `swap execute`) waits for the human to **physically approve on the signer** — routinely >30s — so the 30s harness backstop killed the poll, and the orphaned session then failed with `unknown_process`.

## Fix

Set a long per-tool `timeoutMs` (same pattern as the ImagineVideo/ImagineImage fix):
- `exec_command` → **180s**
- `write_stdin` → **300s**

Both tools return at `yield_time_ms` for normal commands, so the long backstop only affects genuine long interactive waits (human hardware approval) — normal shell usage is unchanged. This matches the wallet-cli-usage skill's rule: *don't time out or kill device commands*.