### PR TITLE
feat(tui): Ledger connection indicator at the bottom-right

### DIFF
--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -26,6 +26,7 @@ import type { StickyPrompt } from './VirtualMessageList';
 import { useAppStateMaybeOutsideOfProvider } from '../state/AppState.js';
 import { BrandCells, PlanModeBanner, TuiHeader, StatusBar as V2StatusBar, StatusSegment } from './v2/primitives.js';
 import ThemedText from './design-system/ThemedText.js';
+import { LedgerStatus } from './LedgerStatus.js';
 
 /** Rows of transcript context kept visible above the modal pane's ▔ divider. */
 const MODAL_TRANSCRIPT_PEEK = 2;
@@ -658,7 +659,12 @@ function DesignBottomRightLabel({
 }: {
   readonly spend: string;
 }): React.ReactNode {
-  return <ThemedText color="text2" wrap="truncate-end">spend {spend}</ThemedText>;
+  return (
+    <>
+      <LedgerStatus />
+      <ThemedText color="text2" wrap="truncate-end"> spend {spend}</ThemedText>
+    </>
+  );
 }
 
 function DesignPlanModeBanner(): React.ReactNode {

--- a/runtime/src/tui/components/LedgerStatus.tsx
+++ b/runtime/src/tui/components/LedgerStatus.tsx
@@ -1,0 +1,92 @@
+/**
+ * LedgerStatus — bottom-bar indicator for a connected Ledger hardware wallet.
+ *
+ * Passively polls `lsusb` (no device interaction — safe to run on a timer,
+ * unlike `wallet-cli genuine-check`, which would prompt the signer) and parses
+ * the model from the device line (e.g. "ID 2c97:5011 Ledger Nano S Plus" →
+ * "Nano S Plus"). Three states:
+ *
+ *   connected — detected right now       → green icon + model
+ *   recent    — not detected, but seen within the stale window → amber
+ *   hidden    — not seen for longer than the stale window      → not rendered
+ *
+ * @module
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { execFile } from "node:child_process";
+import ThemedText from "./design-system/ThemedText.js";
+
+const POLL_MS = 15_000;
+/** How long a lost device keeps showing amber before the indicator hides. */
+const STALE_MS = 10 * 60_000;
+const LSUSB_TIMEOUT_MS = 3_000;
+
+export type LedgerStatus =
+  | { readonly state: "connected"; readonly model: string }
+  | { readonly state: "recent"; readonly model: string }
+  | { readonly state: "hidden" };
+
+/** Ledger's USB vendor id is 0x2c97; the model name trails the id in lsusb. */
+export function parseLedgerModel(lsusbOutput: string): string | null {
+  const line = lsusbOutput.split("\n").find((l) => /2c97:/i.test(l));
+  if (line === undefined) return null;
+  const match = line.match(/2c97:[0-9a-f]+\s+(.+)$/i);
+  const model = match?.[1]?.trim().replace(/^ledger\s+/i, "") ?? "";
+  return model.length > 0 ? model : "Ledger";
+}
+
+function detectLedgerModel(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("lsusb", [], { timeout: LSUSB_TIMEOUT_MS }, (error, stdout) => {
+      if (error || typeof stdout !== "string") {
+        resolve(null);
+        return;
+      }
+      resolve(parseLedgerModel(stdout));
+    });
+  });
+}
+
+export function useLedgerStatus(): LedgerStatus {
+  const [status, setStatus] = useState<LedgerStatus>({ state: "hidden" });
+  const lastSeenRef = useRef<{ model: string; at: number } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async (): Promise<void> => {
+      const model = await detectLedgerModel();
+      if (cancelled) return;
+      if (model !== null) {
+        lastSeenRef.current = { model, at: Date.now() };
+        setStatus({ state: "connected", model });
+        return;
+      }
+      const last = lastSeenRef.current;
+      if (last !== null && Date.now() - last.at < STALE_MS) {
+        setStatus({ state: "recent", model: last.model });
+      } else {
+        setStatus({ state: "hidden" });
+      }
+    };
+    void tick();
+    const id = setInterval(() => void tick(), POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  return status;
+}
+
+export function LedgerStatus(): React.ReactElement | null {
+  const status = useLedgerStatus();
+  if (status.state === "hidden") return null;
+  const color = status.state === "connected" ? "success" : "warning";
+  return (
+    <ThemedText color={color} wrap="truncate-end">
+      {`▣ ${status.model}`}
+    </ThemedText>
+  );
+}

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -21,6 +21,7 @@ import type { PendingRequest } from "../permission-requests.js";
 import type { SpinnerMode } from "../components/spinner/types.js";
 import { AgentsRail } from "./agents/AgentsRail.js";
 import ThemedText from "../components/design-system/ThemedText.js";
+import { LedgerStatus } from "../components/LedgerStatus.js";
 import { PreviewSurface } from "./surfaces/PreviewSurface.js";
 import { isDangerousPermissionMode } from "./WorkbenchContextStrip.js";
 import { ProjectExplorer } from "./project-tree/ProjectExplorer.js";
@@ -105,18 +106,21 @@ function ComposerContextRow({
   ).length;
   const swarmBadgeText = ` SWARM${runningAgents > 0 ? ` ${runningAgents}` : ""} `;
   return (
-    <Box flexDirection="row" paddingX={1} height={1} overflowY="hidden">
-      <Text color={mode === "plan" ? "planMode" : dangerous ? "warning" : "inactive"}>
-        {modeLabel}
-      </Text>
-      {swarmMode ? (
-        <ThemedText backgroundColor="agenc" color="ansi:white" bold wrap="truncate-end">
-          {swarmBadgeText}
-        </ThemedText>
-      ) : null}
-      <Text color="inactive" wrap="truncate-end">
-        {` · ${modelLabel}${contextPctLabel !== null ? ` · ${contextPctLabel}` : ""}`}
-      </Text>
+    <Box flexDirection="row" paddingX={1} height={1} overflowY="hidden" justifyContent="space-between">
+      <Box flexDirection="row">
+        <Text color={mode === "plan" ? "planMode" : dangerous ? "warning" : "inactive"}>
+          {modeLabel}
+        </Text>
+        {swarmMode ? (
+          <ThemedText backgroundColor="agenc" color="ansi:white" bold wrap="truncate-end">
+            {swarmBadgeText}
+          </ThemedText>
+        ) : null}
+        <Text color="inactive" wrap="truncate-end">
+          {` · ${modelLabel}${contextPctLabel !== null ? ` · ${contextPctLabel}` : ""}`}
+        </Text>
+      </Box>
+      <LedgerStatus />
     </Box>
   );
 }

--- a/runtime/tests/tui/components/LedgerStatus.test.ts
+++ b/runtime/tests/tui/components/LedgerStatus.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { parseLedgerModel } from "../../../src/tui/components/LedgerStatus.js";
+
+describe("parseLedgerModel", () => {
+  test("extracts the model from a Nano S Plus lsusb line", () => {
+    const out =
+      "Bus 001 Device 018: ID 2c97:5011 Ledger Nano S Plus\n" +
+      "Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub\n";
+    expect(parseLedgerModel(out)).toBe("Nano S Plus");
+  });
+
+  test("extracts other Ledger models", () => {
+    expect(parseLedgerModel("Bus 002 Device 004: ID 2c97:0004 Ledger Nano X\n")).toBe(
+      "Nano X",
+    );
+    expect(parseLedgerModel("Bus 002 Device 005: ID 2c97:6000 Ledger Stax\n")).toBe(
+      "Stax",
+    );
+  });
+
+  test("returns null when no Ledger vendor id is present", () => {
+    const out =
+      "Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub\n" +
+      "Bus 003 Device 002: ID 046d:c52b Logitech USB Receiver\n";
+    expect(parseLedgerModel(out)).toBeNull();
+    expect(parseLedgerModel("")).toBeNull();
+  });
+
+  test("falls back to a generic label when the model text is empty", () => {
+    expect(parseLedgerModel("Bus 001 Device 018: ID 2c97:5011\n")).toBe("Ledger");
+  });
+});


### PR DESCRIPTION
Bottom-bar indicator showing a wallet icon + the connected Ledger model, so you can see at a glance when a signer is plugged in.

- **Placement**: right of the Workbench status row (next to mode/model) and next to spend in the Fullscreen bottom label.
- **Detection**: passive `lsusb` poll every 15s (Ledger vendor id `2c97`; the model trails the id, e.g. `2c97:5011 Ledger Nano S Plus` → "Nano S Plus"). No device interaction — unlike `genuine-check`, which would prompt the signer, so it's safe on a timer.
- **States**: **green** while connected, **amber** for a 10-minute grace window after the device is lost, then **hidden**.

Verified live via PTY: with a Nano S Plus plugged in, the bar shows `▣ Nano S Plus` at the bottom-right. Unit tests cover the model parser.