### PR TITLE
refactor(tui): read Ledger status on demand, not on a 15s poll

### DIFF
--- a/runtime/src/commands/ledger.ts
+++ b/runtime/src/commands/ledger.ts
@@ -19,6 +19,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { refreshLedgerStatus } from "../services/Ledger/ledgerStatus.js";
 import {
   safeExecute,
   type SlashCommand,
@@ -123,6 +124,9 @@ export const ledgerCommand: SlashCommand = {
   supportsNonInteractive: true,
   execute: async (ctx): Promise<SlashCommandResult> =>
     safeExecute(async () => {
+      // Engaging Ledger — refresh the bottom-bar connection indicator (this is
+      // the on-demand read; nothing polls in the background).
+      void refreshLedgerStatus();
       const args = ctx.argsRaw.split(/\s+/).filter((s) => s.length > 0);
 
       // Bare `/ledger` → show the session (per the skill's "session first"

--- a/runtime/src/services/Ledger/ledgerStatus.ts
+++ b/runtime/src/services/Ledger/ledgerStatus.ts
@@ -1,0 +1,89 @@
+/**
+ * Ledger connection status — on-demand store (no continuous polling).
+ *
+ * The USB read (`lsusb`, Ledger vendor id 0x2c97) only runs when something
+ * explicitly asks for it via `refreshLedgerStatus()` — wired to fire when the
+ * user submits a prompt mentioning "ledger" or runs the `/ledger` command.
+ * Nothing polls in the background; the indicator simply renders the last
+ * on-demand result and ages it locally (connected → recent → hidden) without
+ * touching the device again.
+ *
+ * Detection is passive (lsusb lists the USB bus; the model name trails the
+ * id, e.g. "ID 2c97:5011 Ledger Nano S Plus" → "Nano S Plus"). It never
+ * prompts the signer, unlike `wallet-cli genuine-check`.
+ *
+ * @module
+ */
+
+import { execFile } from "node:child_process";
+
+const LSUSB_TIMEOUT_MS = 3_000;
+/** How long a lost device keeps showing as "recent" before hiding. */
+export const LEDGER_STALE_MS = 10 * 60_000;
+
+export type LedgerSnapshot = {
+  /** When the last read FOUND the device (null if never found). */
+  readonly lastSeenAt: number | null;
+  /** Last known model name (kept so "recent" can still show it). */
+  readonly model: string | null;
+  /** Whether the most recent read found the device connected. */
+  readonly detected: boolean;
+};
+
+/** Ledger's USB vendor id is 0x2c97; the model name trails the id in lsusb. */
+export function parseLedgerModel(lsusbOutput: string): string | null {
+  const line = lsusbOutput.split("\n").find((l) => /2c97:/i.test(l));
+  if (line === undefined) return null;
+  const match = line.match(/2c97:[0-9a-f]+\s+(.+)$/i);
+  const model = match?.[1]?.trim().replace(/^ledger\s+/i, "") ?? "";
+  return model.length > 0 ? model : "Ledger";
+}
+
+function detectLedgerModel(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("lsusb", [], { timeout: LSUSB_TIMEOUT_MS }, (error, stdout) => {
+      if (error || typeof stdout !== "string") {
+        resolve(null);
+        return;
+      }
+      resolve(parseLedgerModel(stdout));
+    });
+  });
+}
+
+let snapshot: LedgerSnapshot = {
+  lastSeenAt: null,
+  model: null,
+  detected: false,
+};
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeLedgerStatus(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getLedgerStatusSnapshot(): LedgerSnapshot {
+  return snapshot;
+}
+
+/**
+ * Run a single on-demand USB read and update the store. Fire-and-forget from
+ * triggers (prompt mention / /ledger) — never call on a timer.
+ */
+export async function refreshLedgerStatus(): Promise<void> {
+  const model = await detectLedgerModel();
+  snapshot = {
+    model: model ?? snapshot.model,
+    lastSeenAt: model !== null ? Date.now() : snapshot.lastSeenAt,
+    detected: model !== null,
+  };
+  emit();
+}

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -97,6 +97,7 @@ import { getCurrentWorktreeSession } from "../../utils/worktree.js";
 import { escapeXml, unescapeXml } from "../../utils/xml.js";
 import { Onboarding, type FirstRunOnboardingState, useFirstRunOnboardingController } from "../../onboarding/Onboarding.js";
 import type { MCPServerConnection } from "../../services/mcp/types.js";
+import { refreshLedgerStatus } from "../../services/Ledger/ledgerStatus.js";
 import {
   completionPipelineOwnsPrompt,
   formatCompletionPipelineRows,
@@ -2145,6 +2146,9 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     const activePastedContents = options?.pastedContentsOverride ?? pastedContents;
     const hasAttachments = Object.keys(activePastedContents).length > 0;
     if (text_0.length === 0 && !hasAttachments) return;
+    // On-demand Ledger status read: mentioning "ledger" refreshes the bottom
+    // connection indicator (no background polling — this is the only read).
+    if (/\bledger\b/i.test(text_0)) void refreshLedgerStatus();
     // A submitted prompt means "back to the conversation": if a center
     // surface (preview/buffer/diff/etc.) is open, close it so the chat owns
     // the center pane again. A dirty BUFFER blocks the switch through the

--- a/runtime/src/tui/components/LedgerStatus.tsx
+++ b/runtime/src/tui/components/LedgerStatus.tsx
@@ -1,92 +1,57 @@
 /**
  * LedgerStatus — bottom-bar indicator for a connected Ledger hardware wallet.
  *
- * Passively polls `lsusb` (no device interaction — safe to run on a timer,
- * unlike `wallet-cli genuine-check`, which would prompt the signer) and parses
- * the model from the device line (e.g. "ID 2c97:5011 Ledger Nano S Plus" →
- * "Nano S Plus"). Three states:
+ * Renders the on-demand snapshot from `services/Ledger/ledgerStatus` — no
+ * background USB polling. The snapshot refreshes only when the user engages
+ * Ledger (mentions "ledger" in a prompt or runs `/ledger`). The only timer
+ * here is render-only (no subprocess): it ages a lost device from amber to
+ * hidden after LEDGER_STALE_MS.
  *
- *   connected — detected right now       → green icon + model
- *   recent    — not detected, but seen within the stale window → amber
- *   hidden    — not seen for longer than the stale window      → not rendered
+ *   connected — last read found the device   → green icon + model
+ *   recent    — lost, but seen within window → amber
+ *   hidden    — never seen, or stale         → not rendered
  *
  * @module
  */
 
-import React, { useEffect, useRef, useState } from "react";
-import { execFile } from "node:child_process";
+import React, { useEffect, useState, useSyncExternalStore } from "react";
+import {
+  getLedgerStatusSnapshot,
+  LEDGER_STALE_MS,
+  subscribeLedgerStatus,
+} from "../../services/Ledger/ledgerStatus.js";
 import ThemedText from "./design-system/ThemedText.js";
 
-const POLL_MS = 15_000;
-/** How long a lost device keeps showing amber before the indicator hides. */
-const STALE_MS = 10 * 60_000;
-const LSUSB_TIMEOUT_MS = 3_000;
-
-export type LedgerStatus =
-  | { readonly state: "connected"; readonly model: string }
-  | { readonly state: "recent"; readonly model: string }
-  | { readonly state: "hidden" };
-
-/** Ledger's USB vendor id is 0x2c97; the model name trails the id in lsusb. */
-export function parseLedgerModel(lsusbOutput: string): string | null {
-  const line = lsusbOutput.split("\n").find((l) => /2c97:/i.test(l));
-  if (line === undefined) return null;
-  const match = line.match(/2c97:[0-9a-f]+\s+(.+)$/i);
-  const model = match?.[1]?.trim().replace(/^ledger\s+/i, "") ?? "";
-  return model.length > 0 ? model : "Ledger";
-}
-
-function detectLedgerModel(): Promise<string | null> {
-  return new Promise((resolve) => {
-    execFile("lsusb", [], { timeout: LSUSB_TIMEOUT_MS }, (error, stdout) => {
-      if (error || typeof stdout !== "string") {
-        resolve(null);
-        return;
-      }
-      resolve(parseLedgerModel(stdout));
-    });
-  });
-}
-
-export function useLedgerStatus(): LedgerStatus {
-  const [status, setStatus] = useState<LedgerStatus>({ state: "hidden" });
-  const lastSeenRef = useRef<{ model: string; at: number } | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async (): Promise<void> => {
-      const model = await detectLedgerModel();
-      if (cancelled) return;
-      if (model !== null) {
-        lastSeenRef.current = { model, at: Date.now() };
-        setStatus({ state: "connected", model });
-        return;
-      }
-      const last = lastSeenRef.current;
-      if (last !== null && Date.now() - last.at < STALE_MS) {
-        setStatus({ state: "recent", model: last.model });
-      } else {
-        setStatus({ state: "hidden" });
-      }
-    };
-    void tick();
-    const id = setInterval(() => void tick(), POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
-  }, []);
-
-  return status;
-}
+/** Render-only aging tick — no subprocess, just re-evaluates the stale window. */
+const AGE_TICK_MS = 30_000;
 
 export function LedgerStatus(): React.ReactElement | null {
-  const status = useLedgerStatus();
-  if (status.state === "hidden") return null;
-  const color = status.state === "connected" ? "success" : "warning";
-  return (
-    <ThemedText color={color} wrap="truncate-end">
-      {`▣ ${status.model}`}
-    </ThemedText>
+  const snap = useSyncExternalStore(
+    subscribeLedgerStatus,
+    getLedgerStatusSnapshot,
   );
+  // Force a periodic re-render so a lost device ages amber → hidden on time.
+  const [, setAgeTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setAgeTick((t) => t + 1), AGE_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  if (snap.lastSeenAt === null) return null;
+  const model = snap.model ?? "Ledger";
+  if (snap.detected) {
+    return (
+      <ThemedText color="success" wrap="truncate-end">
+        {`▣ ${model}`}
+      </ThemedText>
+    );
+  }
+  if (Date.now() - snap.lastSeenAt < LEDGER_STALE_MS) {
+    return (
+      <ThemedText color="warning" wrap="truncate-end">
+        {`▣ ${model}`}
+      </ThemedText>
+    );
+  }
+  return null;
 }

--- a/runtime/tests/commands/ledger.test.ts
+++ b/runtime/tests/commands/ledger.test.ts
@@ -43,6 +43,18 @@ vi.mock("node:child_process", () => ({
     lastSpawn = { cmd, args };
     return fakeChild(nextResult);
   }),
+  // ledgerStatus.refreshLedgerStatus (fired by the command) reads via execFile;
+  // resolve to "no device" so it stays inert in tests.
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: readonly string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string) => void,
+    ) => {
+      cb(null, "");
+    },
+  ),
 }));
 
 function makeCtx(argsRaw: string) {

--- a/runtime/tests/tui/components/LedgerStatus.test.ts
+++ b/runtime/tests/tui/components/LedgerStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { parseLedgerModel } from "../../../src/tui/components/LedgerStatus.js";
+import { parseLedgerModel } from "../../../src/services/Ledger/ledgerStatus.js";
 
 describe("parseLedgerModel", () => {
   test("extracts the model from a Nano S Plus lsusb line", () => {


### PR DESCRIPTION
The Ledger indicator polled `lsusb` every 15s continuously — wasteful when Ledger is never used.

Move detection behind `refreshLedgerStatus()`, fired only when:
- the user submits a prompt mentioning **"ledger"** (word match), or
- the **`/ledger`** command runs.

No background subprocess. The indicator renders the last on-demand snapshot and ages it locally (connected → amber for the 10-minute window → hidden) with a render-only tick that spawns nothing.

Verified live via PTY: the indicator stays **hidden at startup** (no poll), then **appears (green Nano S Plus)** after a prompt mentioning ledger.