### PR TITLE
perf(swarm): give each spawned child its own admission parent-scope

### DIFF
--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -1975,7 +1975,13 @@ function buildChildSession(
                 sessionId: params.live.agentId,
                 parentRunId:
                   params.parent.services.executionAdmission.scope.runId,
-                parentScopeId: params.parent.conversationId,
+                // Give each spawned child its OWN admission parent-scope (its
+                // agentId) instead of sharing the parent's single bucket. A
+                // shared scope capped the whole fan-out at `parent: 4`
+                // concurrent streams regardless of swarm size; per-child scopes
+                // let N workers actually run in parallel, bounded by the
+                // provider/workspace/global limits (the real backstop).
+                parentScopeId: params.live.agentId,
               }),
           }
         : {}),

--- a/runtime/tests/budget/execution-admission-concurrency.test.ts
+++ b/runtime/tests/budget/execution-admission-concurrency.test.ts
@@ -213,6 +213,41 @@ describe("execution admission concurrency dimensions", () => {
     );
   });
 
+  it("admits per-child parent scopes in parallel (own bucket, not a shared parent bucket)", async () => {
+    // Swarm fix: each spawned child binds its OWN parentScopeId (its agentId),
+    // so siblings do not compete for one shared `parent` bucket. With
+    // parent: 1, two children with distinct scopes are both admitted in
+    // parallel — the same limit that serialized a shared scope above.
+    const kernel = createKernel("parent");
+    const first = bind(kernel, {
+      cwd: firstCwd,
+      runId: "child-a",
+      sessionId: "child-a",
+      parentScopeId: "child-a",
+    });
+    const second = bind(kernel, {
+      cwd: firstCwd,
+      runId: "child-b",
+      sessionId: "child-b",
+      parentScopeId: "child-b",
+    });
+    const firstLease = await acquire(first, "provider-a");
+    const secondLease = await acquire(second, "provider-a");
+    expect(kernel.activeCount).toBe(2);
+    expect(kernel.queuedCount).toBe(0);
+    first.reconcile(firstLease.reservation.reservationId, {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    second.reconcile(secondLease.reservation.reservationId, {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    expect(kernel.activeCount).toBe(0);
+  });
+
   it("enforces the provider limit across workspaces", async () => {
     const kernel = createKernel("provider");
     await expectSerialized(


### PR DESCRIPTION
## Problem

Every spawned child shared the parent's single admission bucket (`parentScopeId = parent.conversationId`). The default `parent: 4` limit then capped the **whole fan-out** at 4 concurrent LLM/tool streams — a 10-agent swarm or a 16-worker CSV job effectively ran 4-wide regardless of the configured pool size, with excess agents silently queueing.

## Change

Bind each child's admission scope to its **own agentId** instead of the parent's conversationId. Siblings no longer share one parent bucket, so N workers actually run in parallel. The operative caps become the **provider/workspace/global** limits (the real backstop against flooding), and the admission kernel still queues bursts beyond those.

`parentScopeId` is only a concurrency-grouping key (not budget/cost attribution), so nothing else changes.

## Tests

New kernel test: two children with **distinct** parent scopes admit in parallel under `parent: 1`, where a **shared** scope serialized. Full budget + agents suites green (449 tests).