### PR TITLE
perf(swarm): reap abandoned keep-alive workers to free registry slots

### DIFF
--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -129,6 +129,16 @@ import type { ThreadManager } from "./thread-manager.js";
  */
 const DEFAULT_MAX_AGENT_DEPTH = 1;
 
+/**
+ * How long a keep-alive collab worker may sit `idle` between turns before the
+ * control plane reclaims it as abandoned (frees its registry slot). Generous
+ * enough to cover realistic assign_task reuse windows; any follow-up turn
+ * flips the worker back to `running` and resets the clock.
+ */
+const IDLE_KEEPALIVE_GRACE_MS = 10 * 60_000;
+/** Cadence of the abandoned keep-alive worker sweep. */
+const IDLE_KEEPALIVE_REAP_INTERVAL_MS = 60_000;
+
 function asPositiveIntegerDepth(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
     return undefined;
@@ -322,6 +332,7 @@ export class AgentControl {
    *  and subtree cascade, since we have no state-db in-tree yet). */
   private readonly parentOf = new Map<ThreadId, ThreadId>();
   private threadManager: ThreadManager | undefined;
+  private idleReapTimer: ReturnType<typeof setInterval> | undefined;
 
   constructor(opts: AgentControlOpts) {
     this.session = opts.session;
@@ -335,6 +346,35 @@ export class AgentControl {
     this.maxDepth =
       opts.maxDepth ?? resolveSessionMaxDepth(opts.session) ?? MAX_AGENT_DEPTH;
     this.threadManager = opts.threadManager;
+    this.startIdleKeepaliveReaper();
+  }
+
+  /**
+   * Reclaim abandoned keep-alive workers so they don't exhaust the 32-slot
+   * registry cap. A keep-alive collab worker parks in `idle` between turns
+   * waiting for `assign_task`, holding its registry slot; if the model never
+   * reuses or closes it, the slot leaks. Every interval, shut down spawned
+   * (non-root) workers that have been idle past IDLE_KEEPALIVE_GRACE_MS with
+   * no follow-up turn — a worker reused within the window goes back to
+   * `running` and is never reaped. The root/main agent (depth 0) is never
+   * reaped.
+   */
+  private startIdleKeepaliveReaper(): void {
+    this.idleReapTimer = setInterval(() => {
+      const now = performance.now();
+      const toReap: ThreadId[] = [];
+      for (const agent of this.live.values()) {
+        const status = agent.status.value;
+        if (status.status !== "idle") continue;
+        if (depthOfAgentPath(agent.agentPath) <= 0) continue;
+        if (now - status.endedAtMs < IDLE_KEEPALIVE_GRACE_MS) continue;
+        toReap.push(agent.agentId);
+      }
+      for (const threadId of toReap) {
+        void this.shutdown(threadId, "idle_keepalive_reap").catch(() => {});
+      }
+    }, IDLE_KEEPALIVE_REAP_INTERVAL_MS);
+    this.idleReapTimer.unref?.();
   }
 
   bindThreadManager(threadManager: ThreadManager): void {

--- a/runtime/tests/agents/control.test.ts
+++ b/runtime/tests/agents/control.test.ts
@@ -140,6 +140,45 @@ describe("AgentControl", () => {
     expect(live.metadata.agentPath).toBe("/root/task_3");
   });
 
+  it("reaps a keep-alive worker idle past the grace and frees its registry slot", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = stubSession();
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry });
+      const live = await control.spawn({ parentPath: "/root" });
+      expect(registry.activeCount).toBe(1);
+      // Worker finishes a turn and parks idle (keep-alive between turns).
+      live.status.markRunning("turn-1");
+      live.status.markIdle("turn-1");
+      // Advance past the 10min grace + one 60s reaper interval.
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 60_000 + 1_000);
+      expect(live.status.value.status).toBe("shutdown");
+      expect(registry.activeCount).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not reap a keep-alive worker that went back to running", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = stubSession();
+      const registry = new AgentRegistry();
+      const control = new AgentControl({ session, registry });
+      const live = await control.spawn({ parentPath: "/root" });
+      live.status.markRunning("turn-1");
+      live.status.markIdle("turn-1");
+      // Reused before the grace elapses: flips back to running.
+      live.status.markRunning("turn-2");
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 60_000 + 1_000);
+      expect(live.status.value.status).toBe("running");
+      expect(registry.activeCount).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("I-1: depth beyond cap is rejected", async () => {
     // maxDepth=2 means depth=2 is accepted and depth=3 rejects.
     const session = stubSession();


### PR DESCRIPTION
## Problem

Keep-alive collab workers park in `idle` between turns waiting for `assign_task`, each holding one of the **32 registry slots**. If the model never reuses or `close_agent`s them, the slots leak until `spawn_agent` fails with `AGENT_CONCURRENCY_LIMIT` — killing the swarm.

## Change

A 60s sweep in `AgentControl` shuts down spawned (non-root) workers that have been **idle past a 10-minute grace**:
- A worker **reused** within the window flips back to `running` and is **never reaped** (reuse preserved).
- The **root/main agent** (depth 0) is never touched.
- `shutdown()` frees the slot, closes the mailboxes, and cascades to descendants.

## Tests

- Idle past grace → worker shut down, slot freed (`activeCount` 1→0).
- Reused worker (idle → running) → not reaped.
- Full agents suite green (353 tests).