### PR TITLE
perf(swarm): throttle the per-agent summarizer — skip no-op polls, longer interval

### DIFF
--- a/runtime/src/services/AgentSummary/agentSummary.ts
+++ b/runtime/src/services/AgentSummary/agentSummary.ts
@@ -29,7 +29,7 @@ import {
   runForkedAgent as defaultRunForkedAgent,
 } from "../PromptSuggestion/runtime.js";
 
-export const SUMMARY_INTERVAL_MS = 30_000;
+export const SUMMARY_INTERVAL_MS = 120_000;
 
 /**
  * Adapter across the deliberate PromptSuggestion decoupling boundary. The fork
@@ -223,6 +223,11 @@ export function startAgentSummarization(
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
   let previousSummary: string | null = null;
+  // Message count at the last successful summary. Lets the periodic sweep skip
+  // a redundant LLM call when nothing new was produced since — the common case
+  // for a keep-alive worker sitting idle between turns, where re-summarizing
+  // the same transcript just burns tokens and an admission slot.
+  let lastSummarizedMessageCount = 0;
 
   function scheduleNext(): void {
     if (stopped) return;
@@ -242,6 +247,15 @@ export function startAgentSummarization(
       if (!transcript || transcript.messages.length < 3) {
         options.logDebug?.(
           `Skipping agent summary for ${options.taskId}: not enough messages (${transcript?.messages.length ?? 0})`,
+        );
+        return;
+      }
+      // No new messages since the last summary — nothing to condense. This is
+      // what stops an idle keep-alive worker from re-forking its whole
+      // transcript into an LLM call every interval.
+      if (transcript.messages.length <= lastSummarizedMessageCount) {
+        options.logDebug?.(
+          `Skipping agent summary for ${options.taskId}: no new messages since last summary`,
         );
         return;
       }
@@ -269,6 +283,7 @@ export function startAgentSummarization(
       const summaryText = extractAssistantSummaryText(result);
       if (!summaryText) return;
       previousSummary = summaryText;
+      lastSummarizedMessageCount = transcript.messages.length;
       options.updateAgentSummary(options.taskId, summaryText);
     } catch (error) {
       if (!stopped) options.logError?.(error);

--- a/runtime/tests/services/AgentSummary/agentSummary.test.ts
+++ b/runtime/tests/services/AgentSummary/agentSummary.test.ts
@@ -273,15 +273,23 @@ describe("AgentSummary service", () => {
       });
     const updateAgentSummary = vi.fn();
 
+    let transcriptCall = 0;
     startAgentSummarization({
       taskId: "task-1",
       agentId: "agent-1",
       cacheSafeParams: cacheSafeParams(),
-      getAgentTranscript: vi.fn().mockResolvedValue(transcript([
-        userMessage("u1", "one"),
-        assistantMessage("a1", "two"),
-        userMessage("u2", "three"),
-      ])),
+      // Grow the transcript on every poll so each tick has new content to
+      // summarize (the sweep skips a poll when nothing new was produced).
+      getAgentTranscript: vi.fn().mockImplementation(async () => {
+        transcriptCall += 1;
+        return transcript([
+          userMessage("u1", "one"),
+          assistantMessage("a1", "two"),
+          ...Array.from({ length: transcriptCall }, (_, i) =>
+            userMessage(`u${i + 2}`, `m${i}`),
+          ),
+        ]);
+      }),
       updateAgentSummary,
       runForkedAgent,
       createUserMessage,
@@ -313,15 +321,23 @@ describe("AgentSummary service", () => {
         return { messages: [textAssistant("second", "Writing tests")], totalUsage: {} };
       });
 
+    let transcriptCall = 0;
     startAgentSummarization({
       taskId: "task-1",
       agentId: "agent-1",
       cacheSafeParams: cacheSafeParams(),
-      getAgentTranscript: vi.fn().mockResolvedValue(transcript([
-        userMessage("u1", "one"),
-        assistantMessage("a1", "two"),
-        userMessage("u2", "three"),
-      ])),
+      // Grow the transcript on every poll so each tick has new content to
+      // summarize (the sweep skips a poll when nothing new was produced).
+      getAgentTranscript: vi.fn().mockImplementation(async () => {
+        transcriptCall += 1;
+        return transcript([
+          userMessage("u1", "one"),
+          assistantMessage("a1", "two"),
+          ...Array.from({ length: transcriptCall }, (_, i) =>
+            userMessage(`u${i + 2}`, `m${i}`),
+          ),
+        ]);
+      }),
       updateAgentSummary: vi.fn(),
       runForkedAgent,
       createUserMessage,
@@ -342,6 +358,35 @@ describe("AgentSummary service", () => {
     expect(controllers).toHaveLength(2);
     expect(controllers[1]).not.toBe(controllers[0]);
     expect(controllers[1]!.signal.aborted).toBe(false);
+  });
+
+  it("skips a poll when no new messages were produced since the last summary", async () => {
+    const runForkedAgent = vi.fn().mockResolvedValue({
+      messages: [textAssistant("s", "summary")],
+      totalUsage: {},
+    });
+    startAgentSummarization({
+      taskId: "task-1",
+      agentId: "agent-1",
+      cacheSafeParams: cacheSafeParams(),
+      // Fixed transcript: never grows, so only the first poll has new content;
+      // later polls must be skipped instead of re-forking the same transcript.
+      getAgentTranscript: vi.fn().mockResolvedValue(transcript([
+        userMessage("u1", "one"),
+        assistantMessage("a1", "two"),
+        userMessage("u2", "three"),
+      ])),
+      updateAgentSummary: vi.fn(),
+      runForkedAgent,
+      createUserMessage,
+      intervalMs: 10,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(runForkedAgent).toHaveBeenCalledTimes(1);
   });
 
   it("stop is idempotent, aborts in-flight work, suppresses abort logs, and ignores late results", async () => {


### PR DESCRIPTION
## Problem

Every spawned agent ran a background summarizer that forked its **entire transcript** into a fresh LLM call **every 30s** — even when the agent had produced nothing new. That's O(agents × transcript × duration/30s) tokens, and those summary calls competed for the same admission slots as real swarm work. Worst for keep-alive workers idling between turns with an unchanged transcript.

## Change

- **Skip a poll when no new messages** were produced since the last summary (the common idle case) — tracked via the last-summarized message count.
- **Raise the default interval 30s → 120s.**

## Tests

- New test: a no-new-content poll is skipped (runForkedAgent called once across many ticks).
- Updated the two tests that relied on a fixed transcript across ticks (now grow the transcript so each tick has new content).
- Full agents + AgentSummary suites green (369 tests).