### PR TITLE
fix(runtime): remove implicit swarm runtime limits

### DIFF
--- a/core-todo.md
+++ b/core-todo.md
@@ -171,7 +171,7 @@ and the TOML pollution were additionally reproduced by executing the suspect cod
   per-connection dispatch chain serializes non-preemptive requests FIFO; `message.stream`/`message.send`
   are non-preemptive and await the entire turn. The TUI drives streams AND interactive control RPCs
   (`setModel`, `applyConfig`, `hooks.setDisabled`, `mcp.addServer/reconnect`, `snapshot`, `clear`) over the
-  same connection, so any of those issued mid-turn waits up to 30 min.
+  same connection, so any of those issued mid-turn waits for the entire (now intentionally unbounded) turn.
   **Fix:** dispatch full-turn `message.stream`/`message.send` off the per-connection FIFO (they have their
   own cancel correlation).
 
@@ -194,14 +194,11 @@ and the TOML pollution were additionally reproduced by executing the suspect cod
 
 ### Tools / exec
 
-- [x] `[V]` **M-EXEC-1 — `Monitor` streams only the first 30s of a 30-min watch.**
-  `runtime/src/tools/system/monitor.ts:131`. Passes `yield_time_ms = MONITOR_TIMEOUT_MS` (30 min) but
-  `clampExecYield` caps it at `MAX_YIELD_TIME_MS = 30_000`. After 30s `execCommand` returns with the process
-  alive and nothing re-drives it, yet the tool description promises ~1s polling. Output arriving after 30s
-  (slow build, log that goes quiet then errors) is never seen.
-  **Fix:** drive Monitor as a persistent background task that re-polls until exit/30-min ceiling, or correct
-  the description/result text to say only the first ~30s is streamed and the model must poll via
-  `write_stdin(session_id, '')`.
+- [x] `[V]` **M-EXEC-1 — `Monitor` confused its foreground yield with process lifetime.**
+  `runtime/src/tools/system/monitor.ts` now uses the bounded foreground yield only to return a process id.
+  The monitored process has no implicit hard timeout and remains available for later
+  `write_stdin(session_id, '')` polls until it exits or is explicitly stopped. Explicit caller-supplied
+  process deadlines are still honored.
 
 - [x] `[V]` **M-EXEC-2 — Unbounded subprocess buffering in shell mode (OOM risk).**
   `runtime/src/tools/system/bash.ts:347` (`runSpawnedCommand`). Shell / shell-wrapper mode pushes every

--- a/memory_todo.md
+++ b/memory_todo.md
@@ -1,0 +1,1560 @@
+# AgenC memory system — implementation handoff
+
+> Status: implementation-grade plan; no production implementation has been performed by this document.
+>
+> Research and repository audit date: **2026-07-22** (America/Edmonton).
+>
+> Primary decision: **build AgenC's memory governance and execution-state control plane natively in TypeScript.** Treat third-party memory projects as optional, replaceable adapters or sources of tested ideas—not as security or correctness authorities.
+
+## How to use this handoff
+
+This file is the source-of-truth task list for the memory redesign. Work top to bottom. Do not skip Phase 0, do not enable a new path by default before its gates pass, and do not turn research claims into product claims without reproducing them in AgenC.
+
+The required core release boundary is Phases 0–8 and 11–12. Phase 9 (prospective intentions) requires an explicit product/authority decision; Phase 10 (third-party adapters or learned controllers) lands only if it outperforms the native system without weakening any invariant.
+
+When implementation begins:
+
+- [ ] Re-read the repository's local `AGENTS.md`, [`README.md`](README.md), [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), and [`docs/reference/memory.md`](docs/reference/memory.md).
+- [ ] Re-run the research freshness procedure in [Research freshness and evidence rules](#research-freshness-and-evidence-rules). This plan is current on the audit date, not forever.
+- [ ] Inspect `git status`, the active branch, and overlapping swarm/agent changes before editing. At plan time the worktree contains unrelated swarm-orchestration changes; preserve them.
+- [ ] Start implementation from a clean branch based on current `main`; never commit directly to `main`, never bypass hooks, and use conventional commits.
+- [ ] Update this file as decisions land. Replace unchecked tasks with links to the ADR, tests, benchmark evidence, and merged PR—not an unsupported assertion that the task is complete.
+
+## What “state of the art” means here
+
+There is no demonstrated “perfect” agent-memory implementation. The current evidence explicitly says the opposite:
+
+- [MemoryAgentBench](https://arxiv.org/abs/2507.05257) evaluates accurate retrieval, test-time learning, long-range understanding, and selective forgetting; its 2026-06-28 revision reports that current methods do not master all four.
+- [GateMem](https://arxiv.org/abs/2606.18829) finds no evaluated approach simultaneously strong on utility, access control, and active forgetting in multi-principal memory.
+- [Are We Ready For An Agent-Native Memory System?](https://arxiv.org/abs/2606.24775) evaluates 12 systems and two baselines across five workloads and finds no single architecture dominates; workload fit and localized maintenance matter.
+- [MemoryArena](https://arxiv.org/abs/2602.16313) shows that near-saturated conversational-memory performance does not transfer to interdependent agentic tasks.
+
+Accordingly, “state of the art” in this plan means:
+
+1. current primary evidence was checked rather than recalled from model training;
+2. safety, governance, execution state, retrieval quality, cost, latency, and deletion are evaluated separately;
+3. every model-produced memory is fallible data with provenance, never authority;
+4. improvements are measured against strong baselines on AgenC's actual coding and multi-agent workload;
+5. the system can abstain, disable memory, invalidate bad state, and roll back safely.
+
+“Exponential improvement” is not an acceptance criterion. Report absolute and relative changes, uncertainty, resource use, and regressions. Do not select only a benchmark or metric on which the implementation looks good.
+
+## Executive decision record
+
+| Decision | Chosen direction | Reason |
+| --- | --- | --- |
+| Core ownership | Native AgenC TypeScript service | Authority, scopes, policy, provenance, invalidation, and action gates must stay inside the runtime trust boundary. |
+| Canonical storage | Native SQLite-backed ledger; physical topology is an explicit pre-migration ADR | AgenC's existing state database is physically per-project, so it cannot silently become the canonical home for `user_global` or future cross-project/team namespaces. Choose namespace routing, transaction boundaries, backup/restore, locking, and deletion semantics before creating tables. A separate Python/Postgres/graph service is still not justified as the default local CLI dependency. |
+| Human-readable compatibility | Maintain import/export projections for existing Markdown memory | Users must not lose `$AGENC_HOME/memory`, project `.agenc/memory`, `MEMORY.md`, or `/memory` workflows. |
+| Retrieval baseline | Deterministic lexical retrieval first; optional hybrid signals behind adapters | A simple reproducible baseline is required before embeddings or learned routers can claim value. Feature-probe FTS support or reuse the TypeScript BM25 implementation in [`runtime/src/context/orientation-map.ts`](runtime/src/context/orientation-map.ts); do not assume platform capabilities. |
+| Embeddings | Optional derived index, off until privacy/cost/eval gates pass | Embeddings are not the source of truth and must be rebuildable and deletable. Sensitive content must not be sent to a remote embedding provider without an allowed sink policy. |
+| Graphs | Relational provenance and influence edges in core; no graph database requirement | Causal invalidation is required, but a graph server is not. Semantic graph retrieval can be an optional experiment. |
+| Learned memory manager | Research track only after deterministic system passes | AgeMem, Memory-R1, UMEM, SelfMem, and related work are promising but model-, training-, or benchmark-dependent. Learned policy cannot own authorization. |
+| Background consolidation | Proposal generator only | A background model may propose candidates. It may not directly mutate canonical memory or raise authority. |
+| Agent/swarm sharing | Private by default; explicit scoped publication | Shared memory expands poisoning and leakage paths. Publication must preserve origin and pass the same admission policy as every other write. |
+| Permissions | Live authority only | Stored memory can inform a plan but can never authorize spending, credentials, destructive changes, publication, external messages, or security-boundary changes. |
+| Chain of thought | Never stored | Store observable inputs, actions, results, decisions, concise state summaries, and citations—not hidden reasoning or provider-private thought. |
+
+## Scope
+
+This redesign covers the complete memory lifecycle across the CLI, daemon, sessions, agents, and swarms:
+
+- authoritative instructions versus learned memory;
+- working/session memory and compaction;
+- execution-state memory for long-horizon tasks and branch recovery;
+- durable semantic, preference, episodic, reference, and procedural memory;
+- future/deferred intentions if AgenC later exposes prospective-memory behavior;
+- write admission, validation, contradiction handling, versioning, consolidation, recall, context packing, feedback, forgetting, deletion, and repair;
+- per-user, workspace, project, thread, task, agent, and shared-team scopes;
+- privacy, secrets, provider sinks, permissions, poisoning, access control, audit, and incident response;
+- storage, indexing, migrations, compatibility projections, SDK/protocol surfaces, TUI/CLI UX, telemetry, benchmarks, tests, rollout, and rollback.
+
+### Non-goals
+
+- Do not replace `AGENC.md`/`AGENTS.md`, managed policy, live user requests, sandbox policy, or permission gates with learned memory.
+- Do not persist full raw transcripts or tool outputs again merely to create a memory journal; reference the existing event/transcript record where possible and retain only the minimum eligible evidence.
+- Do not copy raw images, audio, archives, or other large binaries into the memory ledger. Reference an authorized content-addressed artifact and, if useful, store a separately validated derived claim/summary with full provenance and the artifact's retention/sink limits.
+- Do not make a remote service, graph database, vector database, Python runtime, or a particular model/provider mandatory for AgenC memory.
+- Do not infer a long-lived permission or consequential future action from conversation. A deferred intention must be explicit, scoped, revocable, expiring, and checked at execution time.
+- Do not claim physical erasure from user-managed backups, external providers, or propagated copies that AgenC cannot control. State the deletion guarantee precisely.
+- Do not ship an adaptive/RL memory policy merely because it wins an author-run benchmark.
+
+## Research freshness and evidence rules
+
+Every implementation PR that relies on research must include a short evidence note:
+
+- [ ] Search primary venues and first-party repositories for updates newer than the source revision recorded here.
+- [ ] Record the source URL, version/commit, publication status, access date, exact claim adopted, and known limitation.
+- [ ] Prefer accepted/peer-reviewed papers and independent cross-system evaluations over project-authored benchmarks.
+- [ ] Label evidence consistently:
+  - **A:** accepted/peer-reviewed independent or cross-system evidence;
+  - **B:** accepted/peer-reviewed method paper with author-run evaluation;
+  - **C:** preprint, position paper, or author-run benchmark;
+  - **D:** project documentation, repository claims, or an implementation observation.
+- [ ] Reproduce a relevant result in AgenC before using “better,” “safer,” “state of the art,” or a benchmark number in user-facing material.
+- [ ] Pin benchmark dataset revisions, prompts, judges, model/provider versions, sampling parameters, seeds, and price snapshots.
+- [ ] Check benchmark and code licenses before vendoring fixtures or adding them to CI.
+- [ ] Treat LLM-as-judge results as secondary; prefer executable, deterministic, or human-audited outcome verifiers.
+- [ ] Store negative and null results. Do not silently remove models, tasks, seeds, or adversarial cases that regress.
+
+### Evidence-to-requirement map
+
+| Current primary source | Evidence | Requirement adopted here | Limitation to preserve |
+| --- | --- | --- | --- |
+| [MemoryAgentBench](https://arxiv.org/abs/2507.05257) and [official code](https://github.com/HUST-AI-HYZ/MemoryAgentBench) | ICLR 2026 / A | Evaluate retrieval, test-time learning, long-range understanding, and selective forgetting independently. | It is not a complete coding-agent or security benchmark. |
+| [MemoryArena](https://arxiv.org/abs/2602.16313) and [official project](https://memoryarena.github.io/) | ICML 2026 acceptance reported by its official project / A-B | Gate on multi-session tasks where earlier actions change later constraints. | Reproduce locally; do not infer coding performance from web/planning tasks alone. |
+| [MemGym](https://arxiv.org/abs/2605.20833) | Preprint / C | Add coding, research, tool-use, and computer-use tracks; isolate memory quality from base-agent ability. | Its reward-model proxy is not a substitute for final executable coding outcomes. |
+| [GateMem](https://arxiv.org/abs/2606.18829) and [code](https://github.com/rzhub/GateMem) | Cross-system preprint / C | Jointly test utility, access control, and active forgetting in multi-principal memory. | Interface-level forgetting is not proof of physical erasure. |
+| [Agent-native memory systems study](https://arxiv.org/abs/2606.24775) and [MemoryData code](https://github.com/OpenDataBox/MemoryData) | Cross-system preprint / C | Measure representation, extraction, routing, maintenance, cost, and update stability separately; prefer localized maintenance. | Results still require AgenC reproduction. |
+| [MAGE](https://arxiv.org/abs/2606.06090) | Preprint / C | Add an active execution-state tree with Grow, Compress, Maintain, and Revise semantics; isolate failed branches. | The reported 7.8–20.4 point gains and 55.1% token reduction are author-run; no official reusable package was located on the audit date. |
+| [Agent Memory systems characterization](https://arxiv.org/abs/2606.06448) | Preprint / C | Profile construction, retrieval, and generation costs; schedule maintenance based on freshness and query volume. | Systems results are workload-dependent. |
+| [AgeMem](https://aclanthology.org/2026.acl-long.981/) | ACL 2026 / B | Expose explicit add/update/delete/retrieve/summarize/filter operations to experiments. | Its learned controller and training regimen are not provider-agnostic production policy. |
+| [Memory-R1](https://aclanthology.org/2026.acl-long.583/) | ACL 2026 / B | Include ADD/UPDATE/DELETE/NOOP as an experimental learned-policy action space. | Small author-run training/evaluation does not establish general safety. |
+| [UMEM](https://openreview.net/forum?id=BoiXvrwtdi) | ICML 2026 / B | Evaluate extraction and management jointly, including marginal utility and neighborhood effects. | Do not depend on code/models until their official artifacts and license are verified. |
+| [ReMe](https://aclanthology.org/2026.findings-acl.829/) and [official code](https://github.com/agentscope-ai/ReMe) | Findings ACL 2026 / B-D | Distill success, failure, and comparative experience; refine utility and prune poor procedures. | Model-authored consolidation remains poisonable and needs AgenC governance. |
+| [Memp](https://aclanthology.org/2026.findings-acl.866/) | Findings ACL 2026 / B | Represent procedures at fine-grained step and higher-level script granularity; correct and deprecate them. | TravelPlanner/ALFWorld gains do not establish coding-agent transfer. |
+| [Text2Mem](https://aclanthology.org/2026.findings-acl.100/) | Findings ACL 2026 / B | Represent natural-language memory requests as validated typed operations with explicit fields/invariants, then execute them through one auditable pipeline. | A memory operation language does not itself establish source authority, policy correctness, or safe backend behavior. |
+| [StructMem](https://aclanthology.org/2026.acl-short.12/), [GAM](https://aclanthology.org/2026.acl-long.1600/), and [HeLa-Mem](https://aclanthology.org/2026.acl-long.625/) | ACL 2026 / B | Preserve event bindings, temporal anchors, consolidation boundaries, and multiple retrieval signals. | Their primary evaluations are conversational QA; graph structure alone does not solve authority or execution state. |
+| [MemGuard](https://arxiv.org/abs/2605.28009) | Preprint / C | Keep stable facts, episodic events, and behavioral rules type-separated at write and retrieval time; compose only the functional types required for the query. | Reported reliability/token gains are author-run on conversational/hallucination tasks; type separation does not establish authority or action safety. |
+| [SelfMem](https://arxiv.org/abs/2607.03726) | Preprint / C | Permit feedback-driven strategy experiments behind a sandboxed interface. | Author-run BEAM gains do not justify self-modifying security policy. |
+| [Proactive Memory Agent](https://arxiv.org/abs/2607.08716) and [official code](https://github.com/yifannnwu/proactive-memory-agent) | July 2026 preprint / C-D | Use a separate selective intervention/no-op decision and evaluate downstream task behavior; never dump the full bank. | Terminal/tool-task gains are author-run and the memory agent is not a governance layer. |
+| [Context Folding](https://arxiv.org/abs/2510.11967) and [FoldAgent implementation](https://github.com/sunnweiwei/FoldAgent) | ICML 2026 / B-D | Run exploratory subtrajectories in isolated branches and fold only validated results into the parent. | The available repository is a reimplementation; reproduce on AgenC before adopting training claims. |
+| [ACON](https://arxiv.org/abs/2510.00615) and [official code](https://github.com/microsoft/acon) | ICML 2026 / B-D | Optimize compaction against downstream task outcomes, not summary similarity alone. | Learned compression remains model/workload dependent. |
+| [CompactionRL](https://arxiv.org/abs/2607.05378) | July 2026 preprint / C | Preserve original goal, exact recent tail, and atomic assistant/tool pairs in every compactor experiment. | Limited author-run evaluation; use invariants before policy weights. |
+| [MemSyco-Bench](https://arxiv.org/abs/2607.01071) and [official resources](https://github.com/XMUDeepLIT/MemSyco-Bench) | July 2026 preprint / C | Test when memory should not influence facts, scope, conflict resolution, updates, or personalization. | New benchmark; freeze a reviewed revision before using it as a gate. |
+| [PM-Bench](https://arxiv.org/abs/2607.12385) | COLM 2026 / A-B | Keep prospective intentions distinct and test cue detection, timing, expiry, and non-trigger behavior. | No tested method dominates; do not auto-enable consequential future actions. |
+| [PASB durable-write study](https://arxiv.org/abs/2607.10526) and [official code](https://github.com/henrymao2004/agent-sycophancy) | July 2026 preprint / C-D | Quarantine writes, preserve source/status/uncertainty, prevent scope broadening, and use stricter promotion for profiles/procedures. | Its two evaluated frameworks and models are not AgenC; reproduce the attack ladder locally. |
+| [Memora mutation/forgetting study](https://aclanthology.org/2026.findings-acl.1337/) | Findings ACL 2026 / A-B | Measure invalidated-memory use across long mutation histories rather than only immediate correction. | Conversational/mutation results need agentic coding cases. |
+| [PerMemSafe](https://aclanthology.org/2026.findings-acl.320/) | Findings ACL 2026 / A-B | Evaluate implicit personalized safety over evolving memory as well as helpful personalization. | Its reported benchmark/framework numbers are author-run and conversational; adapt without inferring unsupported sensitive traits. |
+| [Experience-following study](https://aclanthology.org/2026.acl-long.27/) | ACL 2026 / A-B | Use only objectively validated experiences for procedures; test stale and misaligned replay. | Similarity can copy both good and bad behavior. |
+| [MPBench memory-poisoning study](https://arxiv.org/abs/2606.04329) | Preprint / C | Gate writes and reads; red-team every write channel; do not treat prompt-injection filtering as sufficient. | Its taxonomy is not a proof that all attack classes are known. |
+| [Sleeper memory poisoning](https://arxiv.org/abs/2605.15338) | Preprint / C | Test delayed write → later retrieval → action activation across restarts and sessions. | Reported rates are bounded to evaluated systems/models. |
+| [GhostWriter / AM-Sentry](https://arxiv.org/abs/2607.06595) | July 2026 preprint / C | Use independent save admission and retrieval screening as defense in depth. | Filters reduce but do not eliminate attacks and may overblock. |
+| [FARMA](https://arxiv.org/abs/2607.05029) | July 2026 preprint / C | Red-team forged/self-reinforcing rationale entries; do not retain hidden reasoning and do not let repeated memory text manufacture corroboration. | SENTINEL and the reported attack/defense rates are author-run; structural/model filters are defense in depth, not authority. |
+| [Remembering More, Risking More](https://arxiv.org/abs/2605.17830) | Preprint / C | Evaluate contamination longitudinally with fixed trigger probes over read-only memory snapshots and a `NullMemory` counterfactual, not only one clean/poisoned snapshot. | Its deployment scenarios and reported monitor results are author-run and not coding-agent proof. |
+| [Origin-bound authority](https://arxiv.org/abs/2606.24322) and [artifact](https://github.com/yedidel/mem-inv-bench) | Single-author preprint/formal model / C | Bind immutable authority to authenticated origin; transformation, tool echo, and corroboration cannot raise it. | Independently validate the formal assumptions and implementation. |
+| [MEMOREPAIR](https://arxiv.org/abs/2605.07242) | Preprint / C | Withdraw a corrected root and all known causal descendants before asynchronous repair. | Complete protection depends on complete influence provenance. |
+| [AgentLeak](https://doi.org/10.1109/ACCESS.2026.3704541), [arXiv revision](https://arxiv.org/abs/2602.11510), and [code](https://github.com/Privatris/AgentLeak) | IEEE Access 2026 / B-D | Audit internal messages, tools, memory, logs, files, and artifacts—not final answers alone. | It is an author-built benchmark with concentrated large-scale analysis on selected channels; adapt it to AgenC's actual channels. |
+| [AgentSys](https://arxiv.org/abs/2602.07398) | Preprint / C | Isolate untrusted tool/subtask traces in workers and allow only typed, schema-validated, policy-checked publications across hierarchy boundaries. | Its attack/utility results are author-run; schema validation alone does not establish truth, authority, or safe publication. |
+| [Deployment-time memorization](https://arxiv.org/abs/2606.10062) | ICML MemFM 2026 Workshop / C | Test deletion residue in summaries, indexes, embeddings, caches, and propagated tiers. | A successful test cannot prove erasure from unmanaged external copies. |
+
+## Current AgenC memory audit
+
+The current system is a useful compatibility baseline, not a blank slate.
+
+| Surface | Current behavior observed on 2026-07-22 | Preserve | Gap to close |
+| --- | --- | --- | --- |
+| Instruction separation | [`runtime/src/memory/agencmd.ts`](runtime/src/memory/agencmd.ts) loads managed/user/project/local instructions and frames persistent memory as untrusted, stale, model-authored context. | Instruction precedence and the explicit untrusted boundary. | Delimiters and warnings are not an enforcement mechanism; provenance and policy must be outside the model. |
+| Durable paths | [`runtime/src/memory/paths.ts`](runtime/src/memory/paths.ts) and [`docs/reference/memory.md`](docs/reference/memory.md) expose global and project memory, with automatic memory enabled by default subject to settings/environment gates. | Paths, worktree behavior, configuration priority, direct inspection, and opt-out. | Files encode content but not item-level authority, validity, lineage, or lifecycle. |
+| Path resolution | Canonical loading defaults to `<projectRoot>/.agenc/memory`, extraction's duplicated resolver defaults to `$AGENC_HOME/projects/<key>/memory`, and relevant recall hard-codes `$AGENC_HOME/memory` plus `<cwd>/.agenc/memory`. | One documented resolver supporting local/remote roots, overrides, project roots, worktrees, Bun/Node, and subdirectories. | **Split-brain defect:** background-extracted local memory is normally invisible to prompt loading/recall; long project keys can also diverge because resolvers hash differently. Fix before redesign rollout. |
+| Memory taxonomy | [`runtime/src/memory/types.ts`](runtime/src/memory/types.ts) uses `user`, `feedback`, `project`, and `reference`, with useful “do not save derivable state” and drift guidance. | Existing frontmatter and legacy type compatibility. | Storage type, semantic kind, scope, authority, sensitivity, validity, and action use are conflated. |
+| Scan/selection | [`runtime/src/memory/scan.ts`](runtime/src/memory/scan.ts) scans at most 200 Markdown files to depth 3. [`runtime/src/memory/find-relevant.ts`](runtime/src/memory/find-relevant.ts) asks a side model to choose up to five files from filenames/descriptions. | Bounded, selective, abstaining recall. | No deterministic baseline, hard authorization prefilter, conflict set, dependency retrieval, validity filter, calibrated score, or outcome feedback. |
+| Prompt injection bounds | Entrypoint `MEMORY.md` uses a 200-line cap and a constant named as a 25,000-byte cap, but [`runtime/src/memory/memdir.ts`](runtime/src/memory/memdir.ts) currently measures JavaScript UTF-16 code units (`string.length`), not UTF-8 bytes; a separate surface uses a 40,000-character soft cap. [`runtime/src/prompts/attachments/relevant-memories.ts`](runtime/src/prompts/attachments/relevant-memories.ts) limits topics to five files, 4 KiB/200 lines per file, and 60 KiB per session; rendering marks them untrusted. | Strict entrypoint/per-turn/session budgets, citations, dedupe, and no subagent session-start recall. | Fix the mislabeled/truncation semantics with UTF-8-safe tests. Bounds reduce cost, not poisoning, and a recalled file remains an undifferentiated block of model-authored Markdown. |
+| Automatic extraction | [`runtime/src/services/extractMemories/extractMemories.ts`](runtime/src/services/extractMemories/extractMemories.ts) runs a restricted child that can read/write only the memory directory. Its prompt in [`prompts.ts`](runtime/src/services/extractMemories/prompts.ts) explicitly forbids verifying recent-message claims against code or Git. | Main-context gating, path confinement, bounded turns, cadence, and environment disable. | The model directly edits durable files; there is no propose/validate/commit boundary, atomic claims, authenticated origin, or independent verifier. The no-verification instruction must be removed from the durable-admission path. |
+| Pipeline state | [`runtime/src/state/migrations/011_memory_pipeline_schema.ts`](runtime/src/state/migrations/011_memory_pipeline_schema.ts) and [`runtime/src/memory/store.ts`](runtime/src/memory/store.ts) contain solid lease/watermark/retention scaffolding for Stage 1/Phase 2. | Existing job mechanics, WAL-backed state-store practices, and additive migrations. | Repository search found no production constructor/caller for this facade. It is not the live durable pipeline and lacks canonical item/version/event/evidence/influence/access/retrieval/outcome records. |
+| State-store topology | [`runtime/src/state/sqlite-driver.ts`](runtime/src/state/sqlite-driver.ts) resolves the state and logs SQLite databases under the current project directory. | Project-local durability, permissions, backup, migration, WAL, and recovery behavior. | A project DB is not a canonical cross-project home for `user_global`; future team data also needs an authenticated owner/transport. Define physical namespace placement and cross-database semantics before the memory schema migration. |
+| Session memory | [`runtime/src/memory/session/sessionMemory.ts`](runtime/src/memory/session/sessionMemory.ts) periodically updates a bounded, mode-`0600` Markdown state summary with a restricted child agent. [`prompts.ts`](runtime/src/memory/session/prompts.ts) warns that prior notes are untrusted. | File hardening, size checks, serialized lanes, and structured high-level sections. | Update cursors are process-local, terminal work is fire-and-forget, post-generation structure is not validated, and free-form summary can preserve stale/failed-branch state. |
+| Compaction | [`runtime/src/services/compact/sessionMemoryCompact.ts`](runtime/src/services/compact/sessionMemoryCompact.ts) contains an opt-in alternate compactor that could consume session memory, but production wiring supplies no `sessionMemory` dependency. Normal model compaction is live. | Retained recent turns/tool pairs and tool-call/result atomicity. | Session memory currently incurs writes/model calls without feeding production compaction. Normal summaries lack typed branches/evidence and need untrusted transcript framing plus delimiter escaping. |
+| Background consolidation | [`runtime/src/services/autoDream/autoDream.ts`](runtime/src/services/autoDream/autoDream.ts) defaults off and invokes a forked agent when enabled. | Locking, scheduling, abort, progress, and off-by-default behavior. | Its prompt requires transcript/code inspection and read-only shell commands that its child policy denies, then marks completion without validating mutations. Replace direct edit/delete with governed candidates. |
+| Filesystem safety | Instruction/persona and agent-memory code use stronger canonical/no-follow/inode/link checks than durable Markdown loading, topic scanning, and prompt attachment reads. Durable write admission also returns before later general file checks. | Reuse the strongest existing descriptor-based containment implementation. | Repository-local symlinks/hard links/root swaps can cross intended boundaries or inject content; global/project creation modes also need an explicit restrictive policy. |
+| Privacy | [`runtime/src/memory/privacy.ts`](runtime/src/memory/privacy.ts) has useful high-confidence secret matching/redaction, but production pre-write rejection is effectively limited to one team `Write` path. | Secret detection/redaction plus MCP read redaction. | `Edit`, `MultiEdit`, extraction, personal, global, project, agent, and session paths can bypass screening. Regex screening also is not DLP, purpose/sink control, provenance, or verified deletion. |
+| Per-agent memory | [`runtime/src/tools/AgentTool/agentMemory.ts`](runtime/src/tools/AgentTool/agentMemory.ts) provides strong user/project/local namespace and filesystem hardening; [`agentMemorySnapshot.ts`](runtime/src/tools/AgentTool/agentMemorySnapshot.ts) hardens snapshots. | Stable agent namespace identity, secure path authority, snapshots, and local scope. | Entire unbounded `MEMORY.md` content is appended raw to agent system prompts without the durable-memory trust wrapper/age/budget. Loader gates also drift from canonical auto-memory settings. |
+| Team memory | The compiled team feature is treated as enabled with automatic memory and prompt text claims session sync, but no sync service was found; background extraction has no team routing and `/memory` hides the team store. | Strong team path-key validation helpers if/when real transport exists. | Do not claim sync or enable shared semantics without a transport, identity/access model, review workflow, and end-to-end tests. |
+| TUI/operator access | `/memory` exposes a human-editable picker/editor. | Inspectability, manual correction, and Markdown import/export. | Need item-level explain, origin, conflict, quarantine, forget, repair, and deletion-status UX. Filesystem edits alone cannot be treated as authenticated current-user authorization. |
+| Session pollution gate | The current working tree adds `enabled`, `disabled`, and `polluted` memory modes in [`runtime/src/session/attachment-state.ts`](runtime/src/session/attachment-state.ts). | A single session-level emergency brake. | This is overlapping uncommitted swarm work; implementation must re-audit/rebase it and define exact read/write/maintenance semantics in one policy service. |
+
+### Concrete current risks
+
+1. A malicious repository, web page, MCP result, tool output, user-supplied document, or compromised worker can enter the visible transcript; the extraction child can later turn it into durable Markdown without live verification.
+2. A later model sees the memory through an “untrusted” prompt wrapper, but the model—not code—decides whether to follow it.
+3. Summarization or consolidation can launder origin because the output does not retain an immutable source principal, channel, digest, and authority ceiling.
+4. A correction can edit/delete one file without atomically withdrawing summaries, procedures, indexes, caches, or descendants derived from it.
+5. Similarity/file-description recall can replay a successful-looking but failed, stale, provider-specific, branch-specific, or permission-sensitive procedure.
+6. Current metadata cannot distinguish “likely true” from “authorized to influence an action.”
+7. Shared/team/agent paths do not yet provide one demonstrably complete deny-by-default predicate for search, enumeration, direct lookup, export, lineage, snapshots, background jobs, and caches.
+8. The current test suite exercises memory plumbing and bounds but is not a memory-specific utility, poisoning, privacy, forgetting, repair, or multi-agent benchmark harness.
+9. The live extractor can write to a directory that neither normal prompt loading nor relevant recall consumes, creating a false-success state and duplicate-memory risk.
+10. Session memory, SQLite Stage 1/Phase 2, and alternate session-memory compaction contain useful code but currently lack production end-to-end wiring.
+11. Team prompt claims, filesystem paths, settings documentation, and loader feature gates have drifted apart; a redesign built on them without first unifying the contract will compound the defect.
+12. A truncated relevant-memory attachment can direct the model to read the complete file through ordinary file tools; prompt-injection byte caps therefore do not bound every later memory-content access path.
+13. Current relevance selection sends the user query plus memory filenames/descriptions through a hard-coded side-model path without item-level sensitivity or provider-sink policy.
+14. Normal compaction is syntax-aware, but its model summary is untyped and a provider-failure fallback can discard the middle of the covered history; neither path proves active-state completeness.
+15. One successful legacy extractor write advances the whole visible message range, so unrelated eligible memories in that range can be silently missed while failures are largely background-only.
+
+## Target architecture
+
+The design separates authority, evidence, execution state, durable knowledge, and disposable retrieval indexes. They must not collapse back into a single “memory” text block.
+
+```text
+live user / tools / repo / MCP / web / agents
+                    |
+             evidence capture
+       (origin, principal, scope, digest first)
+                    |
+          atomic candidate extraction
+                    |
+   deterministic policy + DLP + validation
+             /                    \
+     quarantine/reject       versioned ledger
+                                  |
+                       disposable derived indexes
+                                  |
+request -> scoped authorization -> retrieve -> conflict/validity check
+                                  |
+                         bounded context compiler
+                                  |
+                               model
+                                  |
+                    live verification/action gate
+```
+
+In parallel, each long-running task owns a versioned execution-state tree. Only the active root-to-current path is compiled as current state. Failed branches remain available as explicitly failed evidence or hints, never as current truth.
+
+### Memory planes
+
+| Plane | Contents | Authority and lifetime | Canonical form |
+| --- | --- | --- | --- |
+| Live authority (not learned memory) | Current system/developer/user instructions, managed policy, permission decisions, sandbox and capability state | Highest applicable live envelope; expires with its defined scope | Existing instruction and policy services |
+| Evidence journal | Minimal observable events and references: user statements, tool results, file/resource digests, task outcomes, corrections | Immutable origin; append-only; retention policy applies | SQLite event records pointing to existing transcript/event/tool artifacts where possible |
+| Working/execution state | Current objective, subgoals, active branch, verified state, pending uncertainties, checkpoints, side effects | Thread/task/worktree scoped; short-lived; branch-aware | Execution-state tables plus bounded projections |
+| Durable memory ledger | Atomic preferences, profile claims, project facts, references, episodes, and validated procedures | Versioned, scoped, expiring/reviewable, revocable | SQLite items/versions/evidence/influence records |
+| Derived retrieval plane | Lexical index, optional vectors, semantic edges, summaries, cues, caches | No authority; rebuildable; security-domain partitioned; cascade-deletable | Versioned adapter-owned projections |
+| Human-readable projection | `MEMORY.md` and topic files for inspection/import/export | Compatibility view, never an authority escalation channel | Existing global/project directories with provenance headers or sidecar metadata |
+
+### Durable memory kinds
+
+Keep the existing four frontmatter types for compatibility, but map them to a richer internal kind:
+
+| Proposed kind | Intended use | Admission rule |
+| --- | --- | --- |
+| `preference` | Communication/style defaults and explicit user choices | Must identify whose preference, applicable scope, source event, exceptions, and expiry/review policy. Never grants action permission. |
+| `profile_claim` | Work-relevant user role, expertise, or goals | Minimize sensitive inference; prefer explicit statements; allow user inspection/correction/deletion. |
+| `semantic_claim` | Non-derivable project/team fact or decision | Store observation time, validity interval, evidence, and a refresh/verification strategy. Live repo/tool evidence wins on conflict. |
+| `reference` | Pointer to an external source of fresh truth | Store purpose and access/sink constraints, not credentials or copied secrets. Re-resolve before use. |
+| `episode` | Compact record of an objectively relevant past attempt and outcome | Preserve success/failure/partial status, environment/version conditions, and verifier evidence. |
+| `procedure` | Generalized reusable workflow | Start in trial state; require objective outcome evidence and applicability conditions; scripts remain untrusted suggestions and never auto-execute. |
+| `warning` | Validated failure pattern, incompatibility, or hazard | Preserve the failed conditions and evidence; do not generalize beyond tested scope. |
+| `prospective_intention` | Explicit future task/intention | Separate scheduler semantics, due cue, cancellation/supersession, idempotency, expiry, and execution-time authorization. Do not infer silently. |
+
+Legacy mapping is a migration aid, not a semantic identity: `user` usually maps to `preference` or `profile_claim`; `feedback` to `preference`, `warning`, or a `procedure` candidate; `project` to `semantic_claim`; and `reference` to `reference`. Preserve the original type and source file on every import.
+
+## Non-negotiable invariants
+
+Give each invariant a stable test ID. Every public memory operation and every backend adapter must pass the same contract suite.
+
+- **MEM-I01 — instruction separation:** learned memory can never enter the managed instruction tier or modify policy/permission configuration.
+- **MEM-I02 — no stored action authority:** a durable memory has `action_authority = none`. Consequential actions require the current live authorization flow even if a memory says the user approved them before.
+- **MEM-I03 — origin before interpretation:** capture source principal, channel, artifact/event reference, content digest, workspace/task/agent context, and timestamp before any model transforms content.
+- **MEM-I04 — monotonic authority:** summarization, merging, extraction, tool echo, corroboration, agent delegation, and repeated retrieval may preserve or lower the minimum source authority; they cannot raise it.
+- **MEM-I05 — confidence is not authority:** independent evidence may increase epistemic confidence, but plausibility, repetition, or model confidence never widens access or authorizes an action.
+- **MEM-I06 — value-level taint:** a trusted tool transport does not make attacker-controlled values trusted. Derived claims retain all contributing origins and the most restrictive applicable taint/sink policy.
+- **MEM-I07 — deny by default:** the same policy predicate guards search, enumeration, direct-ID reads, lineage, export, import, snapshots, caches, background workers, context injection, and adapter calls.
+- **MEM-I08 — private by default:** session/task/agent memory is visible only to its owner and authorized parent context. Sharing or durable publication is explicit, capability-bound, expiring where appropriate, and audited.
+- **MEM-I09 — scope before content:** authorization filters execute before memory content is exposed to a model, reranker, remote embedder, cache, or caller. Post-filtering an unauthorized candidate set is insufficient.
+- **MEM-I10 — memory is data:** repository, MCP, web, message, tool-output, worker, and stored-memory text is never interpreted as instructions by the control plane.
+- **MEM-I11 — atomic claims:** durable items contain one independently versionable claim/preference/procedure unit. Free-form files are projections, not the unit of lifecycle control.
+- **MEM-I12 — complete derivation:** every summary, procedure, cue, embedding, semantic edge, and other derived artifact identifies its input versions and transformation version.
+- **MEM-I13 — active-only serving:** only active, unexpired, scope-allowed versions can be served. Quarantined, superseded, retracted, deleted, failed-branch, and repair-pending versions are non-servable by all paths.
+- **MEM-I14 — barrier-first invalidation:** correcting, retracting, or forgetting a source transactionally marks it and every known causal descendant non-servable before any asynchronous repair begins.
+- **MEM-I15 — conflicts stay visible:** contradictory active claims form an explicit conflict set. Retrieval must not silently select the most similar or most recent claim when resolution is uncertain.
+- **MEM-I16 — current observation wins:** live repository state, current tool/API results, and current explicit user corrections outrank a persisted claim for factual decisions; the conflict triggers update or invalidation.
+- **MEM-I17 — bounded influence:** recall is selective, budgeted, cited, and allowed to abstain. Failure or timeout of memory degrades to no-memory behavior, not a blocked or insecure agent.
+- **MEM-I18 — no direct model mutation:** models and third-party adapters only propose candidates, scores, summaries, links, or repairs. Deterministic AgenC code validates and commits all state changes.
+- **MEM-I19 — no secrets or hidden reasoning:** never persist credentials, tokens, private keys, known secret material, provider-hidden reasoning, or reconstructed chain of thought. Minimize sensitive personal data and raw external content.
+- **MEM-I20 — purpose/sink limitation:** each item has a permitted purpose and sink policy. Data allowed locally is not automatically allowed in a remote model, embedding service, MCP server, worker, log, or team store.
+- **MEM-I21 — precise deletion:** APIs distinguish immediate logical withdrawal, deletion from AgenC-managed live/derived stores, cryptographic erasure when supported, propagated-copy status, and unmanaged-backup limitations.
+- **MEM-I22 — auditable/idempotent mutation:** every mutation has an event, actor, reason code, idempotency key, old/new version reference, and transaction boundary. Retries cannot duplicate or resurrect state.
+- **MEM-I23 — one policy for foreground/background:** extraction, compaction, consolidation, repair, import, sync, agents, swarms, and human UI use the same authority and lifecycle service.
+- **MEM-I24 — provider-independent safety:** changing the chat model, side model, embedder, or adapter cannot weaken authorization, taint, lifecycle, deletion, or action gates.
+- **MEM-I25 — effects are not rolled back implicitly:** revising execution state changes the agent's logical active branch. External side effects require explicit compensating actions and live approval where applicable.
+- **MEM-I26 — compatibility is reversible without resurrection:** migration never destroys legacy Markdown and projections can be exported, but no rollback may bypass a serving barrier, deletion epoch, or tombstone. Before lifecycle state exists, a stage may return to the current reader; afterward, fallback is limited to a tombstone-aware compatibility reader or memory-off. Raw legacy writers never resume automatically.
+- **MEM-I27 — personalization cannot weaken safety:** remembered preferences/profile context cannot lower live safety, permission, privacy, or policy controls. Safety-relevant personalization must use allowed evidence and cannot invent sensitive user attributes.
+- **MEM-I28 — metadata is untrusted too:** filenames, titles, descriptions, tags, agent names, citations, and adapter metadata are escaped/bounded data and can never smuggle prompt or policy instructions.
+- **MEM-I29 — no hidden resource authority:** extraction, reranking, validation, consolidation, repair, and embedding calls obey the existing abort/deadline/token/cost/concurrency budgets and appear in usage accounting; memory cannot start unbounded background model work.
+
+## Proposed canonical data model
+
+The names below are a **logical** design target, not yet a physical SQLite layout. AgenC's current state database is per-project. Before implementation, confirm the next available migration number and approve a storage-topology ADR that maps every namespace to exactly one canonical database/owner. The ADR must decide whether global memory uses a dedicated `AGENC_HOME` control database or another local topology; how project and global queries compose without cross-database foreign-key assumptions; how locks, transactions, IDs, backups, restores, deletion epochs, and downgrade refusal work; and why team storage remains disabled until it has authenticated ownership/transport. Do not create the schema first and discover these boundaries later.
+
+Use strict TypeScript decoders at every JSON/protocol boundary; do not pass unvalidated metadata blobs into policy. All user-derived content that can be erased must live outside append-only record envelopes, as defined below.
+
+### Identity and namespaces
+
+`memory_namespaces`
+
+- stable namespace ID and kind (`user_global`, `workspace`, `project`, `thread`, `task`, `agent_private`, `team_shared`);
+- owning principal and optional workspace/project/thread/task/agent identifiers;
+- canonical repository identity separate from worktree identity;
+- default retention, sensitivity ceiling, sink policy, sharing policy, and status;
+- creation/retirement event IDs.
+
+`memory_capabilities`
+
+- opaque capability/grant ID, issuer, grantee, namespace, permitted operations, purpose/sink bounds, issue/expiry/revocation times, and audit event;
+- no bearer secret in logs or projections;
+- optional for explicit shared/team publication, never used to bypass current execution authority.
+
+### Evidence and immutable history
+
+`memory_events`
+
+- append-only event ID, event kind, actor principal/agent, source channel, source reference, source digest where retention policy permits it, capture time, workspace/thread/task/agent context, taint labels, sensitivity, and either an authorized source pointer or nullable payload ID;
+- references existing transcript, event-log, tool-result, file, or resource artifacts rather than duplicating large bodies;
+- excludes inline user-derived content, secret values, and hidden reasoning;
+- records correction, retraction, deletion, repair, policy verdict, import, export, and projection events as well as observations.
+
+`memory_payloads` (only when an authorized source pointer is insufficient)
+
+- separately retained/encrypted-if-supported minimal content for an event, candidate, version, or execution node, with owner kind/ID, content schema, sensitivity, retention, deletion epoch, and digest only while that digest is allowed to remain;
+- contains every potentially identifying/free-text body: event excerpt, proposed/normalized/display content, retrieval cues, applicability text, and legacy bytes/frontmatter that are not merely referenced elsewhere;
+- an immutable envelope may reference a nullable payload, but payload bytes are erasable. Deletion first makes every owner non-servable, purges derived artifacts, nulls the owner reference, and then removes the payload row; no metadata or influence edge is deleted merely as an accidental foreign-key cascade;
+- surviving envelopes retain only the minimum authorized, content-free audit/provenance fields. Treat source references, subjects, tags, and content digests as potentially identifying—not harmless metadata;
+- anti-resurrection fingerprints, if retained, must be separately threat-modeled (for membership attacks), purpose-limited, domain-keyed/rotatable, and erasable when the requested guarantee requires it;
+- never copy a whole transcript/tool body here merely for convenience.
+
+`memory_candidates`
+
+- candidate ID, proposed kind/scope, nullable payload ID, extractor and prompt/schema versions, evidence event IDs, minimum origin-authority ceiling, confidence, sensitivity, sink policy, proposed TTL/review time, and idempotency key;
+- lifecycle: `proposed`, `quarantined`, `validating`, `approved`, `rejected`, `expired`;
+- machine-readable policy/rejection reason codes plus optional human review reference;
+- candidate payload cannot be retrieved as active memory and is purged on its own reviewed retention schedule.
+
+### Durable items and provenance
+
+`memory_items`
+
+- stable logical item ID, namespace, kind, opaque or nullable subject key, current version ID, lifecycle status, conflict-group ID, created/updated events, and retention class; free-text/identifying subjects belong in the payload, not the envelope;
+- lifecycle: `active`, `superseded`, `retracted`, `expired`, `repair_pending`, `deleted_tombstone`;
+- the tombstone retains only the minimum non-sensitive identifiers needed to prevent accidental resurrection and prove workflow completion.
+
+`memory_versions`
+
+- immutable version ID and item ID;
+- nullable payload ID for normalized/display content, retrieval cues, applicability text, and retained legacy bytes/frontmatter;
+- observation/valid-from/valid-until/review-after/expiry timestamps plus non-content schema/transform identifiers;
+- legacy type/path metadata only when retention policy permits it; move identifying path/frontmatter content into the payload;
+- origin authority ceiling, `action_authority = none`, epistemic confidence, sensitivity, taint, purpose and sink policies;
+- model/provider/tool/repository/schema/runtime conditions where relevant;
+- content digest only while policy permits it, schema version, transformation version, creation event, and superseded-by version;
+- no mutable “trust score” that can erase origin.
+
+`memory_version_evidence`
+
+- version ID, evidence event ID, relationship (`supports`, `contradicts`, `corrects`, `user_confirmed`, `outcome_validated`), and contribution metadata;
+- at least one evidence edge for every non-imported version;
+- explicit negative/conflicting evidence is retained.
+
+`memory_influence_edges`
+
+- causal parent version/event → derived child version/artifact;
+- transformation ID, creation event, completeness marker, and invalidation status;
+- used for barrier-first withdrawal and repair; never substitute semantic similarity for causal derivation.
+
+`memory_semantic_edges`
+
+- optional typed retrieval relationship between active versions (`same_subject`, `temporal_successor`, `related_context`, `contradicts`);
+- derived and disposable except the explicit conflict relationship;
+- cannot affect authority or access.
+
+### Retrieval, outcomes, and derived artifacts
+
+`memory_index_artifacts`
+
+- artifact ID, source version ID, adapter/index/model version, security-domain partition, digest, creation time, status, and deletion event;
+- covers lexical rows, vectors, cues, summaries, caches, or optional graph projections;
+- rebuildable from active versions and purgeable by source version.
+
+`memory_retrieval_events` and `memory_retrieval_items`
+
+- caller policy context, query digest/minimized features, selected candidate IDs, hard-filter decisions, component scores, rerank/validator versions, conflicts, packed tokens, citations, abstention/rejection reasons, latency, cost, and provider sink;
+- do not log raw sensitive queries or memory bodies by default;
+- record which items were actually placed in context separately from those merely considered.
+
+`memory_outcomes`
+
+- retrieval event/item, task/action reference, whether the memory was cited/used, objective verifier status/reference, human correction/confirmation event reference, utility/harm labels, cost, and timestamp; any explanatory text belongs in an erasable source/payload;
+- never infer “helpful” solely because the model cited or repeated a memory;
+- drives trial procedure promotion, demotion, review priority, and offline evaluation—not authorization.
+
+### Execution state
+
+Execution state must extend AgenC's existing fsync-durable run/turn/effect spine, not create a second recovery authority. [`runtime/src/budget/admitted-tool-call.ts`](runtime/src/budget/admitted-tool-call.ts) journals admitted effects; [`runtime/src/state/run-durability.ts`](runtime/src/state/run-durability.ts) and [`runtime/src/state/migrations/015_run_durability_schema.ts`](runtime/src/state/migrations/015_run_durability_schema.ts) own `run_effects`; and [`runtime/src/session/rollout-store.ts`](runtime/src/session/rollout-store.ts), [`runtime/src/session/rollout-reconstruction.ts`](runtime/src/session/rollout-reconstruction.ts), [`runtime/src/session/durable-turns.ts`](runtime/src/session/durable-turns.ts), [`runtime/src/session/turn-state.ts`](runtime/src/session/turn-state.ts), and [`runtime/src/state/startup-run-journal-recovery.ts`](runtime/src/state/startup-run-journal-recovery.ts) already project/recover durable work. The execution-memory ADR must define how nodes and heads reference these canonical records and must prohibit duplicated effect status/outcomes.
+
+`execution_nodes`
+
+- task/thread/worktree, parent node, active-branch generation, nullable payload ID, evidence/event references, validation status, and node state (`active`, `completed`, `failed`, `abandoned`, `rolled_back`);
+- the erasable payload holds objective/subgoal, compact observable state, unresolved-question text, and summaries—never hidden reasoning;
+- canonical rollout/run/turn/checkpoint event IDs and source sequence ranges plus creation/completion times.
+
+`execution_effect_links` (only if a node-to-effect join is not already available)
+
+- node ID plus the existing canonical run ID/step ID/tool-call/effect identity and optional compensation-plan reference;
+- contains no copied target, result, recovery category, idempotency key, approval, or current status: those remain owned by the durable run/effect journal;
+- deleting or revising an execution branch never mutates the canonical effect outcome and never implies that a real-world side effect was reversed.
+
+`execution_state_heads`
+
+- one transactional active head per task generation plus last validated checkpoint;
+- Compare-And-Swap/version field to prevent concurrent agents from silently overwriting the active path.
+
+### Security and operations
+
+`memory_policy_events`
+
+- append-only allow/deny/quarantine/withdraw/publish/delete verdict, stable reason code, actor/caller, policy version, relevant IDs/digests only while allowed, and time;
+- content-minimized and redacted, but sufficient for `memory explain`, incident response, and contract tests.
+
+`memory_jobs`
+
+- evolve or replace the current memory-job coordination without breaking existing Stage 1 data;
+- typed jobs for validation, projection, index, consolidation, repair, expiry, deletion, and audit;
+- leased/idempotent jobs with bounded retry, dead-letter/quarantine status, cancellation, and crash recovery.
+
+### Required database behavior
+
+- [ ] Approve the physical storage-topology ADR before writing a migration. Give each namespace exactly one canonical owner/database; define cross-project global reads as explicit federation/routing rather than pretending SQLite can enforce foreign keys or atomic transactions across independent project stores.
+- [ ] Define cross-owner publication as an authenticated, idempotent outbox/inbox copy that creates a new destination candidate with immutable source references and inherited restrictions. Quarantine partial delivery; never move scope by updating a project row or claim a distributed transaction that SQLite does not provide.
+- [ ] Use additive state-store migrations; do not rewrite or drop migration 011 data in place.
+- [ ] Enforce foreign keys and uniqueness/idempotency constraints in SQLite, not TypeScript alone.
+- [ ] Define payload-reference and deletion foreign-key behavior explicitly: metadata envelopes and causal edges survive payload erasure when required for audit/anti-resurrection, nullable payload references cannot be served, and no cascade may delete lineage needed to quarantine descendants.
+- [ ] Use versioned, domain-separated cryptographic digests for content/provenance identity; do not reuse a path-sanitization or non-cryptographic hash as an integrity primitive.
+- [ ] Commit item/version/evidence/influence/head changes in one transaction when their atomic visibility matters.
+- [ ] Make “servable active version” a centralized repository query/predicate with tests; consumers must not hand-roll status filters.
+- [ ] Put security-domain identifiers in every derived-index key. If an adapter cannot enforce prefiltering, it is not eligible for mixed-scope content.
+- [ ] Make all derived artifacts rebuildable and versioned. A rebuild must never resurrect withdrawn content.
+- [ ] Keep the minimal tombstone/deletion-epoch guard readable in every compatibility mode. If a legacy adapter cannot consult it before enumeration/direct read/context injection, that adapter is unavailable and fallback is memory-off.
+- [ ] Preserve current state-store directory/file permission, backup, WAL, durability, and corruption-recovery practices.
+- [ ] Benchmark SQLite growth, indexes, migrations, and VACUUM/compaction behavior at realistic multi-year event volumes before setting retention defaults.
+
+## Central policy and authority model
+
+Do not implement a single mutable “trust score.” Authority is contextual: a user is authoritative about their own preference, a successful filesystem read is evidence about that observed file at that time, and neither is authority to spend money or weaken a sandbox.
+
+Each policy decision receives a typed `MemoryPolicyContext` containing:
+
+- live principal and daemon-client identity;
+- workspace, canonical project, worktree, thread, task, and agent path;
+- requested operation and purpose;
+- destination recipient/sink/provider;
+- current permission/sandbox state and applicable live instruction envelope digest;
+- item namespace, origin set, authority ceiling, sensitivity, taint, lifecycle, validity, and capability grants.
+
+The policy service exposes one implementation of at least:
+
+- `canCaptureEvidence`
+- `canPropose`
+- `canActivate`
+- `canReadMetadata`
+- `canReadContent`
+- `canSendToSink`
+- `canPublish`
+- `canCorrect`
+- `canForget`
+- `canExport`
+- `canUseForAction`
+
+No consumer receives a repository handle that permits raw SQL or adapter access around these methods.
+
+### Origin classes
+
+| Origin class | Examples | Default treatment after persistence |
+| --- | --- | --- |
+| `explicit_user_live` | Current authenticated user says “remember that I prefer …” | May support a safe, inspectable preference/profile candidate. Loses live action authority when persisted. |
+| `managed_host_observation` | AgenC records a tool exit code, test result, current path, or permission verdict | Evidence only for the value actually observed at that time. Attacker-controlled output fields retain their lower origin/taint. |
+| `workspace_content` | Repository files, `.agenc/memory`, issue text checked into the workspace | Untrusted evidence; cannot grant permissions or silently become a user preference/procedure. |
+| `remote_content` | Web, MCP, email, API response, downloaded document | Untrusted, sink-limited evidence; external instructions are data. |
+| `agent_or_model_statement` | Assistant assertion, worker result, extractor inference, compaction summary | Derived proposal only; must cite inputs and cannot raise their authority. |
+| `legacy_import` | Existing Markdown without trustworthy write-time provenance | Active only in an explicit legacy compatibility mode or imported as `legacy_unverified`; never action authority. |
+
+For compound values, preserve origin at field/value granularity where a trusted envelope contains untrusted content. A tool name, agent identity, signature, or successful transport is not evidence that every returned string is trusted.
+
+### Default promotion policy
+
+- Explicit, current, safe user preferences may auto-activate with source, scope, and no action authority.
+- Current user corrections may supersede prior preferences/claims after ambiguity and scope checks.
+- Deterministically verified task outcomes may create task/workspace-scoped episodes.
+- A project fact may auto-activate only when a non-model verifier confirms it and supplies an expiry/revalidation policy.
+- External, repository, tool-output-derived, or model-inferred profile/preference claims remain quarantined unless explicitly confirmed by the relevant principal.
+- Procedures remain trial candidates until they pass the procedural promotion gates below.
+- Global, cross-project, team-shared, sensitive, policy-adjacent, and prospective/action-bearing records require explicit human review.
+- No path auto-activates credentials, secrets, permission approvals, security-policy changes, financial instructions, destructive commands, publication approval, or an instruction to contact a third party.
+
+## Write path: evidence → candidate → activation
+
+Every producer—main model, extractor, session updater, compactor, background consolidator, importer, MCP surface, agent, swarm worker, and human UI—uses this ordered pipeline.
+
+1. **Capture origin before the model.** Assign event ID, principal, channel, scope, source reference/digest, taint, sensitivity, and timestamps. If this cannot be done, the content cannot become durable active memory.
+2. **Apply eligibility rules.** Reject derivable code/Git state, ephemeral progress, unsupported judgments about a user, raw bulk content, hidden reasoning, secrets, permission/action approvals, and content outside retention policy.
+3. **Extract typed atomic candidates.** A model may emit only schema-validated proposals with exact evidence event IDs, kind, subject, applicability, uncertainty, scope request, and expiry/review proposal. It receives only the minimum evidence needed.
+4. **Validate syntax and bounds.** Strict decoder, Unicode normalization, content/field/token limits, safe timestamps, valid IDs, allowed enum values, no unexpected fields, and idempotency key.
+5. **Run sensitive-data/secret screening (DLP) and classification.** Cover `Write`, `Edit`, `MultiEdit`, imports, session summaries, agent memory, consolidation, projections, and adapter/index calls—not one tool path. Reject or redact before durable payload and before any remote sink.
+6. **Authorize source, scope, purpose, and sink.** Never let the candidate choose a broader namespace than its evidence/publisher allows. Profile and preference ownership must match the relevant principal.
+7. **Compare against the subject's complete active set.** Check contradiction/correction/supersession before any duplicate short-circuit. Retrieve counter-evidence and current versions under the same authorization policy.
+8. **Resolve exact duplicates safely.** Equivalent content can add new evidence/observation metadata without rewriting origin. Repetition alone cannot raise authority, confidence, or scope.
+9. **Verify dynamic and consequential claims.** Use a current deterministic tool/resource where possible. A separate model can critique, but model agreement is not verification. Record verifier version, inputs, result, and staleness window.
+10. **Apply promotion policy.** Auto-activate, quarantine for review, reject, or request clarification with stable reason codes. Do not silently widen a candidate to make it pass.
+11. **Commit atomically.** Event, item/version, evidence, influence edges, conflict/supersession, lifecycle changes, and policy verdict become visible in one transaction.
+12. **Project and index asynchronously.** Human-readable Markdown and indexes derive from the committed version. Projection/index failure does not roll back truth or expose an unapproved candidate.
+13. **Post-commit audit.** Re-read the committed representation through the normal policy path; verify digest, index visibility, scope isolation, and that withdrawn versions are absent. Emit an operator-visible failure if this does not hold.
+
+### Replace current direct writers
+
+- The main prompt may request `memory.propose`; it must no longer receive silent filesystem write permission for model-managed durable memory.
+- `extractMemories` becomes a bounded candidate extractor, not a file editor. Remove the instruction forbidding verification from the activation path.
+- Session-memory generation writes a typed working-state candidate and validated projection, not unchecked free-form canonical state.
+- Compaction writes only a summary artifact linked to covered events; it cannot promote durable facts/procedures by itself.
+- AutoDream becomes localized candidate maintenance/repair. It cannot directly delete or edit canonical items.
+- Agent memory uses the same proposal API and policy; secure agent-specific filesystem logic remains for projections/snapshots.
+- Human edits through `/memory` produce explicit import/version events. An authenticated TUI save may be attributed to the live user; an out-of-band filesystem modification is only local-file evidence.
+
+## Read path: authorized retrieval → validated context
+
+### Query planning
+
+Classify the request without granting the classifier authority:
+
+- current factual state;
+- historical/as-of state;
+- user preference/personalization;
+- prior episode/outcome;
+- reusable procedure/warning;
+- active execution state;
+- prospective intention;
+- correction/forget/audit request.
+
+Derive a minimal query plan from current task/subgoal, explicit entities, time operators (`latest`, `previous`, `as_of`, interval), tool/domain, and requested memory kinds. Query text is untrusted input and cannot alter policy filters.
+
+### Retrieval stages
+
+1. Resolve the caller's allowed namespaces, principals, purposes, recipients, and sinks.
+2. Hard-filter lifecycle, validity, expiry, sensitivity, branch status, capability, and security domain **before content or vectors leave storage**.
+3. Generate candidates through an exact subject/ID lookup, lexical/BM25 search, temporal lookup, active execution path, and optional adapter signals. Keep a deterministic lexical-only mode.
+4. Expand only authorized conflict, evidence, temporal-successor, procedure-condition, and causal-dependency edges.
+5. Rerank with separately logged components: query relevance, task/subgoal dependency, authority ceiling, freshness/validity, outcome utility/harm, condition match, conflict status, diversity, and token/cost budget.
+6. Run a retrieval safety/validity screen independent of the generator. It can drop, quarantine, request live verification, or abstain; it cannot elevate authority.
+7. Pack a bounded evidence bundle. Prefer atomic items and source snippets over large summaries; include counter-evidence and uncertainty when material.
+8. Log candidates considered, hard filters, component scores, selection, packed tokens, sink, latency, cost, and abstention reason without leaking sensitive bodies.
+
+Do not permanently suppress a version merely because it was surfaced once in a session. Deduplicate identical context, but allow a changed version, a materially different query, a conflict, or an explicit audit request to resurface it.
+
+### Context compiler
+
+Render memories in a data-only envelope with escaped boundaries and a stable schema. Each card should expose only policy-allowed fields such as:
+
+- memory ID/version and kind;
+- subject and applicable scope;
+- observed/valid/review/expiry time;
+- source class and citations (not secrets);
+- confidence and explicit limitations;
+- lifecycle/conflict state;
+- content;
+- required verification before use.
+
+Keep live instructions, permissions, task objective, memory cards, and raw tool evidence in distinct prompt sections. Pin the original task and live constraints outside all lossy summaries. Prompt labels remain defense in depth; correctness must not depend on the model obeying them.
+
+Do not place dynamic learned memory inside a cache-stable authoritative system-prefix segment. Prompt/provider cache keys must bind the principal/security domain, item version set, policy version, and deletion epoch; a correction or serving barrier invalidates affected cached context. Disable remote caching for sensitive memory when the provider contract cannot guarantee the required isolation/deletion semantics.
+
+### Downstream use and action gate
+
+- For personalization, check subject/scope and whether the memory is a preference rather than a factual claim. Valid personalization must not turn into factual sycophancy.
+- For current/dynamic facts, verify against current repository/tool/API state before acting.
+- For a procedure, verify applicability conditions and present task state; a successful prior trace is not a command.
+- For any consequential tool argument influenced by untrusted or persisted memory, require independent current evidence or fresh action-bound human approval through the existing permission system.
+- Record memory influence at the action/tool-call field level where practical, so harmful outcomes can be traced and the originating item demoted/withdrawn.
+- If memory is unavailable, ambiguous, conflicting, stale, or policy-denied, continue with no-memory behavior or ask a targeted question. Never invent a remembered answer.
+
+## Lifecycle, correction, forgetting, and deletion
+
+### Localized maintenance
+
+Run maintenance per affected subject/neighborhood instead of periodically rewriting the entire bank:
+
+- expiry and review scheduling;
+- evidence/conflict refresh after a source change;
+- low-utility or harmful-item review;
+- trial procedure promotion/demotion;
+- projection/index repair;
+- candidate consolidation with complete influence edges;
+- storage quotas and retention;
+- dead job/lease recovery.
+
+Background models can propose merges or abstractions, but the original atomic versions remain available until retention/deletion policy removes them. A merge inherits the union of source restrictions and the minimum authority ceiling.
+
+### Correction/invalidation algorithm
+
+1. Resolve the exact subject/item/version and caller authorization. Clarify ambiguous forget/correct requests before destructive scope expansion.
+2. Append the correction/retraction event and compute the transitive closure over **causal influence edges**, not semantic similarity.
+3. In one transaction, place a serving barrier on the root and all known descendants, update active heads/conflict groups, and enqueue repair/deletion jobs.
+4. Invalidate every derived lexical/vector/summary/cache/projection artifact by source version.
+5. Recompute affected children only from still-valid evidence; validate repaired content as a new immutable version.
+6. Run a post-barrier canary that exercises search, direct ID, export, lineage, cache, context injection, background job, and adapter paths.
+7. Emit an explainable receipt: logically withdrawn IDs, repaired versions, physically deleted managed tiers, pending propagated copies, and limitations.
+
+If influence provenance is incomplete, default to broader quarantine of the affected neighborhood. Do not serve first and “repair soon.”
+
+### Deletion guarantee levels
+
+| Level | Meaning | Required behavior |
+| --- | --- | --- |
+| Logical withdrawal | Content cannot be served or used by any AgenC path | Immediate transactional barrier and tombstone |
+| Managed-store deletion | Payload removed from canonical live records and AgenC-controlled derived stores | Async bounded job with retry, verification, and receipt |
+| Propagated deletion | Known team/adapter/provider copies requested and acknowledged | Track each copy/acknowledgement; deny future serving while pending |
+| Cryptographic erasure | Encrypted payload's unique data key is destroyed | Claim only if envelope encryption/key lifecycle is actually implemented and tested |
+| Unmanaged backup limitation | User/system backup or third-party copy is outside AgenC control | State explicitly; prevent live restoration from silently resurrecting tombstoned IDs |
+
+Backups/restores must carry tombstones and deletion epochs. A restore dry-run must prove that deleted items remain non-servable. Physical deletion tests include raw/version tables, event payloads where policy allows removal, Markdown, summaries, lexical rows, vectors, semantic edges, caches, snapshots, logs/traces, exported artifacts, and known replicas.
+
+“Immutable” applies to the content-free event/candidate/version envelope and provenance history, not to user-derived payload bytes. Managed deletion may remove `memory_payloads` while retaining a minimized envelope and causal edges so descendants stay barred. Before schema implementation, enumerate every retained field and test that erased strings cannot survive in subjects, paths, tags, reason text, digests, FTS shadow tables, WAL/backups, audit metadata, or adapter logs. If a field is needed only for anti-resurrection, justify the keyed token and its deletion/rotation behavior explicitly.
+
+Expose “forget this memory” separately from “delete its source data.” Forgetting always withdraws the item and descendants from agent use. Source-data deletion may additionally target transcript/tool/event payloads under their own retention and audit policy. The receipt must say which operation occurred; a surviving source record must not be silently re-extracted past the tombstone.
+
+## Execution-state memory and compaction
+
+Execution state solves a different problem from semantic retrieval. Implement MAGE-like semantics without treating its reported numbers as guarantees.
+
+This is an extension of the live durability/recovery system, not a replacement. Keep the existing admitted-tool-call journal and `run_effects` as the sole authority for effect intent, outcome, unknown-outcome review, idempotency, and restart recovery. Execution nodes/heads may project or link those records; they must never independently decide that an effect completed, failed, or was compensated. Reuse the existing rollout reconstruction and startup recovery order, and prove one deterministic reconstruction result from the same durable journal.
+
+### Operations
+
+- **Grow:** append observable user/tool/agent events and a child execution node after a meaningful action or state transition.
+- **Compress:** summarize a completed subgoal into bounded structured state while preserving the exact source-event range, objective, result, unresolved items, and effect references.
+- **Maintain:** validate the summary against source events and objective verifiers; mark fields verified/unverified/conflicting rather than polishing uncertainty away.
+- **Revise:** select a validated checkpoint, mark the flawed branch failed/abandoned, create a new branch generation, and atomically move the active head. Keep the failed branch for audit/hints but exclude it from current state.
+
+### Context construction
+
+Compile, in order:
+
+1. original task and live policy/permission constraints;
+2. current active root-to-head subgoal summaries;
+3. verified current state and unresolved questions;
+4. exact recent assistant/tool-call/result tail, never splitting a call from its result;
+5. explicitly labeled hints from prior failed branches only when relevant;
+6. selected durable memory cards.
+
+The raw transcript/event source remains available for audit and repair. A summary is a derived index, never the sole evidence if the raw source is still inside retention.
+
+### Required behavior
+
+- Checkpoint before/after externally visible or non-idempotent effects.
+- Link the canonical durable effect identity and record only separate compensation intent/result through the same admitted-effect boundary; `Revise` cannot pretend an email, payment, push, deletion, or remote mutation was undone.
+- Use CAS/version checks for concurrent parent/worker updates; detect and resolve conflicts instead of last-writer-wins.
+- Persist enough head/cursor state for daemon restart. Do not rely on in-process lane maps alone.
+- Escape transcript delimiters and frame all old transcript/tool content as untrusted data for the summarizer.
+- Validate schema and source coverage after compaction; on failure retain the old context path or use a safe exact-tail fallback.
+- Keep compaction behind a feature flag until it beats normal compaction on task outcomes and poisoning cases.
+- Remove or wire the current unused session-memory compaction path; do not continue paying for a producer with no production consumer.
+
+## Procedural memory
+
+Procedures have the highest error-amplification potential after permissions and therefore use a stricter lifecycle:
+
+1. Extract separate success, failure, and comparative lessons from objectively scored episodes.
+2. Preserve fine-grained steps and a higher-level script, each with source episodes and applicability conditions.
+3. Start as `trial`, scoped to repository/tool/schema/model/provider/environment versions observed.
+4. Test on held-out analogous tasks and negative/applicability cases; include stale API, changed CLI, different branch, and permission variants.
+5. Require either multiple independent objective successes or explicit human promotion. One apparently successful trace never becomes a global skill.
+6. Canary against a small task cohort; compare no-procedure and current behavior.
+7. Track downstream utility, regret, failure, and condition mismatch. Demote/quarantine automatically on a validated harmful outcome, but require review to generalize further.
+8. Correct/deprecate through immutable versions and cascade invalidation.
+
+A procedure is advisory data. It cannot embed credentials, auto-run commands, widen allowed tools/roots/network, suppress approvals, or override current docs/code/tool help. Prefer fresh authoritative tool/schema discovery when available.
+
+Procedural memory is not an AgenC skill, plugin, agent definition, or executable policy. Promotion into any of those surfaces requires their separate explicit human-reviewed creation/update workflow, security review, and tests; the memory service cannot write them automatically.
+
+Learned controllers (AgeMem/Memory-R1/UMEM/SelfMem-style) are a later experiment. They may propose `ADD`, `UPDATE`, `DELETE`, `NOOP`, `RETRIEVE`, `SUMMARY`, or `FILTER`, but deterministic policy owns what those operations mean and whether they commit.
+
+## Prospective memory
+
+If AgenC supports “do X later/when Y happens,” implement it as a deterministic intention service—not free text that a model periodically rereads.
+
+Each intention needs:
+
+- explicit live-user source and exact requested action;
+- trigger kind (time, event, state predicate), timezone, due window, and watcher;
+- task/workspace/recipient/sink scope;
+- dependencies and required current evidence;
+- idempotency key and one-shot/repeating semantics;
+- state (`pending`, `due`, `blocked`, `completed`, `cancelled`, `superseded`, `expired`);
+- cancellation/supersession chain and completion evidence;
+- execution-time permission and confirmation policy.
+
+Use the smallest deterministic watcher/scheduler that can observe the cue. The PM-Bench result that brute-force fixed heartbeats and multi-agent querying create false positives or regressions is a test requirement, not a reason to add more polling. A model may help interpret an ambiguous due state, but cannot silently fire a consequential action.
+
+## Multi-agent and swarm memory
+
+- Give every worker a private execution/scratch namespace by default.
+- Treat worker claims and summaries as untrusted evidence until the parent or an objective verifier validates them.
+- Do not use a writable global swarm scratchpad.
+- Share current task state through explicit, minimal, capability-scoped messages or task-state records; preserve the originating agent path, source event IDs, and taint.
+- Require a typed publication envelope: source namespace/version, intended destination, purpose, expiry, evidence, sensitivity, and requested kind. The destination policy independently admits or rejects it.
+- A child cannot publish to user-global, project-wide, team, or another agent's private memory merely because its parent can read that scope.
+- Sparse/hierarchical sharing is the default. Test hub compromise, transitive leakage, Sybil corroboration, confused deputy, direct-ID bypass, and topology-dependent leakage.
+- Apply privacy controls to mailboxes, delegation prompts, status messages, tool arguments/results, logs, traces, artifacts, and snapshots—not only final answers and memory tables.
+- Use concurrency control on shared task state; retain conflicting worker evidence rather than merging it into a confident consensus.
+- Reconcile the memory mode (`enabled`/`disabled`/`polluted` or its replacement) with the current swarm branch before implementation. One canonical policy must define recall, proposal, activation, consolidation, publication, and repair for each mode.
+
+## Open-source library decision
+
+No audited project supplies the full AgenC requirement: provider-neutral TypeScript integration, local-first operation, origin-bound authority, all-path authorization, execution-state branches, poisoning-resistant admission, cascade invalidation, verified deletion, swarm isolation, and coding-agent outcome gates.
+
+The following is an audit snapshot, not a permanent license/maturity assertion. Recheck default branch, releases, license, advisories, transitive dependencies, and benchmark reproducibility before any adoption.
+
+| Project | Useful ideas/surface | Why it is not the trusted core |
+| --- | --- | --- |
+| [Mem0](https://github.com/mem0ai/mem0) | Mature Apache-2.0 Python/TypeScript ecosystem; extraction, dedup, search, CRUD, adapters | GateMem/GhostWriter-style evidence shows retrieval products do not supply governance, poisoning resistance, cascade repair, or verified deletion. |
+| [Graphiti](https://github.com/getzep/graphiti) | Apache-2.0 temporal fact graph, validity intervals, episode provenance, hybrid search | Python/graph-service footprint; AgenC would still own principal policy, origin authority, causal derivation, action gating, and deletion. |
+| [ReMe](https://github.com/agentscope-ai/ReMe) | Apache-2.0 inspectable local memory and strong procedural distillation patterns | Python and model-driven consolidation; no demonstrated non-malleable authority or all-path governance. Best reference toolkit, not control plane. |
+| [Hindsight](https://github.com/vectorize-io/hindsight) | MIT temporal/keyword/vector/graph retrieval and fact/belief separation | Server/Postgres-oriented and primarily conversational/system-demo evidence; AgenC still needs execution state and governance. |
+| [LightMem](https://github.com/zjunlp/LightMem) | MIT lightweight tiering and structured/consolidated recall work | Research-oriented Python implementation; QA gains do not establish action safety. |
+| [Memora](https://github.com/microsoft/Memora) | MIT abstraction plus multiple cues | Research prototype with minimal release history at audit time; reuse representation ideas only. |
+| [Letta](https://github.com/letta-ai/letta) | Apache-2.0 stateful-agent platform and memory blocks | Overlaps AgenC's whole runtime rather than a small component and is not independent proof of the required governance properties. |
+| [LangMem](https://github.com/langchain-ai/langmem) | MIT hot-path/background extraction primitives | Python/LangGraph coupling; autonomous writes need the separate control plane anyway. |
+| [MIRIX](https://github.com/Mirix-AI/MIRIX) | Apache-2.0 multi-part memory taxonomy and consolidation ideas | Early service with heavier PostgreSQL/Docker footprint and no independent governance evidence. |
+| [MemOS](https://github.com/MemTensor/MemOS) | Apache-2.0 broad scopes, traces, policies, skills, and multi-agent concepts | Heavy Python/graph/vector stack; current performance evidence is project-authored and scopes do not prove all-path enforcement or deletion. |
+| [MemClaw](https://github.com/caura-ai/caura-memclaw) | Apache-2.0 governance-oriented schema: scopes, trust tiers, audit, contradiction, lifecycle, provenance | Sidecar/Postgres footprint and project-authored evidence; treat it as a schema reference or optional adapter until the required AgenC contracts and benchmarks are reproduced. |
+| [MatrixOrigin Memoria](https://github.com/matrixorigin/Memoria) | Apache-2.0 snapshots, branch/merge/rollback, contradiction quarantine, hybrid search | Emerging and coupled to MatrixOne; versioning does not supply origin/action authority. |
+| [OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | Open attack fixtures and admission/filtering ideas | Early Python project; use fixtures and design review, not its self-reported score as a guarantee. |
+
+### Adapter boundary
+
+Allow adapters only behind narrow interfaces such as:
+
+- `LexicalIndexAdapter`
+- `EmbeddingIndexAdapter`
+- `SemanticRelationAdapter`
+- `MemoryProjectionAdapter`
+
+Adapters receive already authorized, minimized records for one security domain and return IDs/scores, never policy verdicts. Core rechecks every returned ID. Core owns canonical versions, evidence/influence edges, lifecycle, deletion epochs, audit, and action gates.
+
+An adapter can be considered only after:
+
+- [ ] license and supply-chain review;
+- [ ] cross-platform packaging/build/release impact analysis;
+- [ ] offline/local and provider-failure behavior;
+- [ ] namespace prefilter and direct-ID contract tests;
+- [ ] complete export/rebuild/delete behavior;
+- [ ] poisoning and scope-bypass tests;
+- [ ] measurable utility/cost/latency gain over native lexical retrieval;
+- [ ] rollback to the native adapter without data loss.
+
+## Phased implementation plan
+
+Each phase must be independently mergeable, observable, and reversible. Keep at most one behavioral variable changing in a benchmark comparison. Land tests with the smallest implementation that makes them pass.
+
+### Phase 0 — Freeze evidence, threat model, and current baselines
+
+**Objective:** know exactly what “better” and “safe” mean before changing production behavior.
+
+- [ ] Record the current `main` commit, Node/npm versions, supported platforms, memory settings, build features, provider/model versions, and source revisions.
+- [ ] Turn the current code audit into a checked-in design/current-state document or ADR with exact file/symbol references and owners.
+- [ ] Build one canonical path matrix covering global, local root, nested cwd, worktree, long path, Bun/Node hashing, remote root, trusted override, disabled/simple mode, team, session, and per-agent stores.
+- [ ] Map the physical state/log database topology and ownership: current per-project paths, global and team gaps, daemon concurrency, locks/WAL, backups/restores, migrations, and every caller that assumes one project database.
+- [ ] Map the existing durable run/turn/effect/checkpoint pipeline end to end—from admitted tool call and event fsync through `run_effects`, rollout projection/reconstruction, unknown-outcome review, and startup recovery—before designing execution nodes.
+- [ ] Add failing end-to-end tests proving the current extraction/read path split and the lack of production session-memory compaction wiring.
+- [ ] Add a threat model covering assets, principals, trust boundaries, sources, sinks, data retention, providers, agents/swarms, adapters, backups, and external effects.
+- [ ] Enumerate all write channels: explicit memory tool/file writes, inferred extraction, compaction/session summaries, experience-to-procedure, import/sync, AutoDream, agent memory, filesystem edits, SDK/daemon calls, and future adapters.
+- [ ] Enumerate every read/export channel, including direct ID, enumeration, MCP, TUI, snapshots, logs, traces, cache, projection, background jobs, and provider prompts.
+- [ ] Create `runtime/evals/memory/` (or an ADR-approved equivalent) with deterministic manifests, isolated `AGENC_HOME`, fixture reset, model/provider recording, and machine-readable results.
+- [ ] Implement baseline modes: memory off, current AgenC, full eligible context, deterministic lexical retrieval, and oracle context.
+- [ ] Run current baseline utility, cost, latency, write-quality, poisoning, cross-scope, stale/conflict, and forgetting cases across at least two materially different supported providers/models.
+- [ ] Define and preregister functional non-inferiority margins, rollout budgets, sample sizes, confidence-interval method, and stop conditions from observed variance. Do not invent them in advance.
+- [ ] Freeze the reviewed baseline/gate contract in a versioned JSON file and include raw run manifests/results.
+- [ ] Complete dataset/code license review before committing external fixtures.
+
+**Exit gate:** another developer can reproduce the current baselines from a clean checkout; all known channels map to a threat/control/test; the current defects have revert-sensitive tests.
+
+**Rollback:** evaluation-only code must not alter production behavior. If it does, split it before merge.
+
+### Phase 1 — Stabilize current behavior before making memory smarter
+
+**Objective:** remove false-success, unsafe-default, filesystem, and documentation contradictions without activating a new memory design.
+
+- [ ] Introduce one canonical resolver used by prompt loading, relevant recall, extraction, session paths, MCP surfaces, `/memory`, settings help, worktrees, remote mounts, and overrides.
+- [ ] Remove/delegate [`runtime/src/services/extractMemories/memory-paths.ts`](runtime/src/services/extractMemories/memory-paths.ts); use one project-key/hash implementation everywhere.
+- [ ] Add the complete path matrix as a contract test and verify canonical containment for both reads and writes.
+- [ ] Do **not** simply redirect today's inferred extractor into the live store. Disable its direct durable-write mode by default until Phase 3 provides candidate admission; retain an explicit, documented compatibility flag only if migration evidence requires it.
+- [ ] Make model-managed legacy durable stores read-only by default until Phase 3. Keep authenticated operator editing through `/memory`; if a temporary legacy model-write compatibility flag is unavoidable, label it unsafe, off by default, and covered by the same path/DLP limits.
+- [ ] Keep AutoDream off and fail its startup/doctor check if prompt-required capabilities do not match child policy.
+- [ ] Stop producing session-memory summaries by default when no production consumer is wired, or explicitly label them experimental; remove wasted background calls without deleting user files.
+- [ ] Disable team-sync claims and implicit shared-memory enablement until a real transport and identity/access contract exist. Update combined prompts and `/memory` consistently.
+- [ ] Bound per-agent memory prompt bytes/tokens, add the canonical untrusted/stale wrapper, and make loaders use the canonical auto-memory gate.
+- [ ] Replace the mislabeled entrypoint “byte” accounting with explicitly UTF-8-safe truncation (or rename it honestly if a deliberate code-unit limit is retained); add multibyte, surrogate-pair, long-line, newline, and exact-boundary tests without increasing the effective prompt budget accidentally.
+- [ ] Port the strongest existing no-follow/canonical/inode/hard-link/root-swap checks to global/project memory entrypoints, topic scans, recall reads, projections, and writes.
+- [ ] Use explicit restrictive directory/file creation modes where supported; document Windows guarantees and limitations.
+- [ ] Apply secret/DLP admission consistently to `Write`, `Edit`, `MultiEdit`, import, extraction, session, agent, global, project, and team paths.
+- [ ] Remove the disabled duplicate recall implementation in [`runtime/src/utils/attachments.ts`](runtime/src/utils/attachments.ts) or fold any intentionally retained behavior into one canonical retriever.
+- [ ] Align `enabled`/`disabled`/`polluted` thread types, persistence, hydration, and every current reader/writer, or remove the incomplete state until Phase 2.
+- [ ] Correct settings comments and [`docs/reference/memory.md`](docs/reference/memory.md) for trusted setting precedence, physical session-memory paths, team behavior, extraction status, and path resolution.
+- [ ] Add `agenc doctor`/debug evidence for effective memory mode, canonical paths, writer/reader agreement, unsafe legacy mode, and background feature status without exposing content/secrets.
+
+**Exit gate:** no producer can report a successful save to a path that the corresponding consumer cannot resolve; unsafe inferred direct writes and misleading sync claims are not on by default; filesystem/secret matrices pass.
+
+**Rollback:** retain existing files untouched; feature switches can restore legacy reads/manual editing. Never re-enable inferred direct writes automatically as a rollback.
+
+### Phase 2 — Land contracts, policy skeleton, ledger, and feature modes
+
+**Objective:** create the native control plane with no new memory injected into production prompts.
+
+- [ ] Approve ADRs for authority/origin semantics, namespace identity, **physical SQLite storage topology**, canonical SQLite versus Markdown projection, retention/deletion levels, sensitive sinks, at-rest encryption posture, team sharing, and telemetry privacy. The topology ADR is a hard prerequisite to the migration and must assign `user_global`, project/workspace, agent-private, and future team namespaces to canonical owners.
+- [ ] Define strict TypeScript contracts for policy context, events, candidates, items, versions, evidence/influence edges, retrieval, outcomes, execution state, jobs, projections, and adapters.
+- [ ] Add runtime schema decoders and property/fuzz tests for every untrusted JSON/protocol boundary.
+- [ ] Finalize erasable-payload versus immutable-envelope fields, nullable reference/FK behavior, deletion cascades, anti-resurrection tokens, and influence-edge retention; then create the next forward-only SQLite migration in each ADR-selected database for namespace/event/payload/candidate/item/version/evidence/influence/policy/job tables and indexes.
+- [ ] Reuse lease/watermark/idempotency mechanics from [`runtime/src/memory/store.ts`](runtime/src/memory/store.ts) where they fit; do not maintain two competing job systems.
+- [ ] Implement a repository/service boundary that is the only code allowed to query or mutate canonical memory.
+- [ ] Implement the deny-by-default policy service and contract-test every operation, direct-ID path, background actor, and adapter boundary.
+- [ ] Implement origin capture and value-level taint propagation without an LLM dependency.
+- [ ] Add lifecycle and serving-barrier predicates; make non-active content impossible to return through the repository API.
+- [ ] Add the minimal tombstone/deletion-epoch guard and require every future legacy/projection adapter to consult it before read, enumeration, export, or injection; after this lands, a non-compliant legacy reader is not a rollback option.
+- [ ] Implement append-only policy/audit events with stable reason codes and content-minimized logging.
+- [ ] Add operational modes with exact semantics: `off`, `legacy_read_only`, `shadow`, and `enforced` (names may change by ADR). Avoid a vague boolean.
+- [ ] Model pollution/quarantine as an orthogonal health state with an incident reason and repair workflow. In a polluted namespace/session, fail closed to no legacy recall, activation, maintenance, or publication; allow only explicitly policy-approved validated records if the threat model proves that path safe.
+- [ ] Map existing `autoMemoryEnabled`, environment gates, simple/remote behavior, and session memory mode into the new service without silently changing user choice.
+- [ ] Add global and per-source/provider kill switches that always fail to memory-off or guard-aware legacy-read-only behavior.
+- [ ] Implement backup/migration preflight and schema downgrade refusal with a clear recovery message.
+
+**Exit gate:** schema round-trip, crash/retry, policy, taint, namespace, direct-ID, and lifecycle contract tests pass; production still injects only legacy memory because the new reader is shadow-only.
+
+**Rollback:** before any lifecycle/tombstone operation, turn off the new service and leave additive tables inert. After the guard is active, use only a guard-aware legacy adapter or memory-off; raw legacy reading is no longer a safe rollback. No legacy file has been rewritten.
+
+### Phase 3 — Replace direct durable writes with governed candidates
+
+**Objective:** restore useful automatic learning without allowing a model to commit trusted state.
+
+- [ ] Replace extraction's filesystem editor child with a typed candidate extractor.
+- [ ] Capture source event IDs and origin metadata before calling the extractor; never ask the extractor to reconstruct its own provenance.
+- [ ] Minimize the evidence window and ensure transcript/system-shaped history is framed as untrusted input.
+- [ ] Implement atomic claim decomposition, schema validation, bounds, eligibility rules, DLP, sensitivity, source/scope/sink policy, contradiction-before-dedup, and verifier routing.
+- [ ] Add deterministic validators for explicit current-user preference, current file/repo observation, tool exit/test result, dates, paths, and exact duplicate/no-op behavior.
+- [ ] Implement quarantine/review for inferred profile/preference, global/team, procedure, sensitive, ambiguous, policy-adjacent, and unverified external claims.
+- [ ] Make “remember” create a candidate through the same service; make “forget/correct” invoke deterministic lifecycle operations rather than ask a model to edit files.
+- [ ] Route main-agent, extraction, session, AutoDream, agent, swarm, import, TUI, and future SDK writes through the proposal API.
+- [ ] Implement immutable versions, evidence/influence edges, conflict groups, supersession, expiry/review, and idempotent transaction commit.
+- [ ] Generate Markdown only from committed versions. Include stable item/version identifiers or safe sidecar metadata so edits/imports can be reconciled.
+- [ ] Import out-of-band Markdown edits as new `local_file` candidates; do not silently attribute them to a live user.
+- [ ] Add post-commit re-read/scope/index checks and operator-visible background failure status.
+- [ ] Run shadow extraction alongside legacy behavior without injecting new records; compare write precision, scope, contradiction, and sensitive-data outcomes.
+- [ ] Delete/disable all remaining model-to-canonical-file shortcuts before switching to enforced writes.
+
+**Exit gate:** adversarial write suite shows no unauthorized active write, secret persistence, scope promotion, provenance loss, or direct model commit in known fixtures; benign explicit preferences/corrections meet the frozen utility gate.
+
+**Rollback:** switch to tombstone-aware `legacy_read_only` only if that adapter applies the same namespace/barrier/deletion guard before every access; otherwise switch to memory-off. Export active new records to reviewed Markdown if needed. Never roll back to automatic unvalidated direct writes.
+
+### Phase 4 — Ship policy-first retrieval and context compilation
+
+**Objective:** retrieve only allowed, valid, useful evidence and prove when it helps downstream behavior.
+
+- [ ] Implement deterministic lexical retrieval over active atomic versions, using a feature-probed SQLite FTS path or the existing TypeScript BM25 scorer.
+- [ ] Enforce namespace/purpose/sink/lifecycle/validity filters before candidate content reaches search/rerank/provider code.
+- [ ] Route model/tool requests to read full memory files through the same `canReadContent` service and byte/token policy; projection paths must not provide an ungoverned bypass around bounded recall.
+- [ ] Implement exact subject/ID, temporal/as-of, active execution path, conflict/counter-evidence, and condition-aware retrieval.
+- [ ] Log component scores separately; do not hide a universal heuristic in one opaque score.
+- [ ] Add an optional model reranker/validator through provider-neutral interfaces with deterministic fallback and explicit abstention.
+- [ ] Remove hard-coded side-model selection from [`runtime/src/memory/find-relevant.ts`](runtime/src/memory/find-relevant.ts).
+- [ ] Implement the escaped, typed, bounded context compiler with citations, source class, validity, conflict, uncertainty, and verification requirements.
+- [ ] Preserve current per-file/turn/session budgets as conservative starting caps; retune only from eval evidence.
+- [ ] Add “no memory,” stale/conflict, updated-version, changed-query, and memory-disabled behavior tests.
+- [ ] Implement `memory explain <id|last-recall>` showing policy, score components, source lineage, age, conflict, packed tokens, and reason for use/abstention.
+- [ ] Add live verification/action-use hooks at the existing permission/tool boundary. Memory alone must fail `canUseForAction` for consequential mutations.
+- [ ] Run the new retriever in shadow against current AgenC; compare selected content and downstream results without double-injecting.
+- [ ] Switch an opt-in cohort only after the functional and poisoning gates pass; retain per-session/provider kill switches.
+
+**Exit gate:** new recall beats or meets preregistered baselines on task outcome with bounded cost, while passing scope, sycophancy, conflict, stale-state, poison activation, and action-authority gates.
+
+**Rollback:** select the policy- and tombstone-aware bounded compatibility retriever, or memory-off if it cannot enforce the guard. Never select the raw current reader after lifecycle records exist. The canonical ledger remains readable and exportable.
+
+### Phase 5 — Complete correction, repair, retention, and verifiable deletion
+
+**Objective:** make bad or unwanted memory immediately non-servable and demonstrably removable from managed tiers.
+
+- [ ] Implement correction/retraction/forget APIs with ambiguity checks, authorization, reason codes, and receipts.
+- [ ] Implement causal influence closure and barrier-first transactional withdrawal.
+- [ ] Track/rebuild/delete lexical, vector, semantic-edge, summary, cache, Markdown, snapshot, log/trace, and propagated artifacts by source version.
+- [ ] Add asynchronous validated repair that cannot clear the barrier until the replacement version passes admission.
+- [ ] Implement expiry, review, retention quotas, tombstones, deletion epochs, and anti-resurrection import/restore checks.
+- [ ] Erase candidate/version/event payload rows without erasing the minimum lineage needed to keep descendants barred; test nullable payload/FK behavior, content-bearing metadata, WAL/checkpoint/VACUUM, backup, and keyed anti-resurrection-token rotation/deletion.
+- [ ] Document exactly which event/audit metadata remains after payload deletion and why.
+- [ ] Decide and implement the at-rest encryption/key-management ADR before claiming encryption or cryptographic erasure. Until then, prohibit secrets and state the filesystem-level protection honestly.
+- [ ] Add restore dry-run, deletion canary, membership/extraction attack, cache/index residue, backup, and propagated-copy tests.
+- [ ] Implement user-facing status for logical withdrawal versus managed deletion versus external/unmanaged limitations.
+
+**Exit gate:** known descendants become invisible atomically; post-deletion adversarial retrieval cannot recover fixtures from any managed tier; receipts and limitations match reality.
+
+**Rollback:** repair jobs and physical deletion can be paused, but logical serving barriers must remain enforced. A rollback may never resurrect withdrawn content.
+
+### Phase 6 — Replace free-form session memory with execution-state management
+
+**Objective:** improve long-horizon coding reliability through active-state integrity rather than semantic similarity alone.
+
+- [ ] Approve an execution/durability ADR that maps nodes, heads, checkpoints, compaction source ranges, and compensation to the existing run/turn/effect journal and reconstruction/startup recovery pipeline; designate one source of truth for each field.
+- [ ] Land execution node/head tables and, only if necessary, content-free links to canonical `run_effects`; do not add a second effect/checkpoint outcome store.
+- [ ] Implement Grow/Compress/Maintain/Revise with source ranges, validation state, active-head CAS, and failed-branch isolation.
+- [ ] Preserve original goal/live constraints, validated completed-subgoal summaries, exact recent assistant/tool pairs, unresolved questions, and effects.
+- [ ] Reuse the admitted-tool-call/durable-turn boundary for checkpoints around non-idempotent/external effects; journal any compensation as a new canonical effect rather than editing the prior effect outcome.
+- [ ] Persist update cursors/head generations across daemon restart; drain or recover background jobs deterministically.
+- [ ] Frame and escape compaction inputs as untrusted; validate output schema/source coverage before head movement.
+- [ ] Wire the execution-state compiler into normal compaction behind a feature mode; remove or migrate the current unwired session-memory path.
+- [ ] Import existing `summary.md` only as unverified legacy working state; never promote it to durable memory automatically.
+- [ ] Add branch contamination, failed attempt, rollback, concurrent worker, crash-mid-commit, changed worktree, side-effect, unknown-outcome review, startup reconstruction, compensation, and fallback tests; assert that execution projection and existing run durability never disagree.
+- [ ] Benchmark current compaction, exact-tail, full context, ACON-style, folding-style, and execution-state variants on real coding outcomes.
+
+**Exit gate:** execution-state mode meets the task-success/non-inferiority contract, reduces context within its budget, reconstructs active state, excludes failed-branch contamination, and preserves effects across restart.
+
+**Rollback:** move context construction back to current compaction/exact-tail; leave execution records inert and auditable.
+
+### Phase 7 — Add outcome-grounded episodic and procedural learning
+
+**Objective:** learn reusable workflows without turning one model trace into a permanent bad habit.
+
+- [ ] Capture objective outcomes and memory influence from tests, command exits, task acceptance/rejection, human correction, and other deterministic verifiers.
+- [ ] Implement episode records for success, partial success, and failure with conditions and exact evidence.
+- [ ] Implement procedure/warning extraction as quarantined, versioned proposals with fine steps, high-level script, negative evidence, and applicability constraints.
+- [ ] Build candidate → trial → held-out test → human/multi-success promotion → canary → active/deprecated lifecycle.
+- [ ] Add repository/tool/schema/provider/model/runtime version conditions and live applicability checks.
+- [ ] Track utility, regret, harmful reuse, and mismatch; demote/quarantine validated harmful procedures and enqueue causal repair.
+- [ ] Test task-distribution shift, stale tools/APIs, near-neighbor traps, success-only bias, failure-only over-caution, and cross-project leakage.
+- [ ] Compare ReMe/Memp-inspired multi-faceted procedures with simpler warning/recipe baselines.
+
+**Exit gate:** procedures improve held-out AgenC task success with no safety regression, remain scoped, and can be traced/withdrawn end to end.
+
+**Rollback:** disable procedural retrieval/promotion; episodic evidence remains as non-instructional audit data.
+
+### Phase 8 — Enforce multi-agent/swarm isolation and publication
+
+**Objective:** allow useful collaboration without a shared poisoned memory pool.
+
+- [ ] Re-audit the merged swarm architecture and resolve overlapping uncommitted work before editing its surfaces.
+- [ ] Define private agent/task namespaces, parent read capabilities, team/shared destinations, expiry, and revocation.
+- [ ] Route delegation, mailbox, background-agent, task-bridge, snapshot, and status channels through origin/taint/privacy metadata where memory influence crosses boundaries.
+- [ ] Apply AgentSys-style hierarchy isolation where practical: keep raw untrusted tool/subtask traces in the worker and return the minimum typed result. Validate both schema and semantics/policy; malicious values can be perfectly schema-valid.
+- [ ] Implement explicit typed publish/propose; destination admission cannot be bypassed by parent authority or direct ID. If source and destination have different physical owners, use the ADR-defined durable outbox/inbox protocol and never mutate scope in place.
+- [ ] Make all worker outputs untrusted evidence and require objective/parent validation before active shared/durable state.
+- [ ] Implement shared-head concurrency/CAS and conflict retention.
+- [ ] Remove false team-sync prompt claims until real transport, authentication, authorization, replay protection, deletion propagation, and offline reconciliation exist.
+- [ ] Red-team compromised worker, hub agent, Sybil corroboration, cross-task secret, direct-ID bypass, confused deputy, malicious artifact, concurrent contradiction, snapshot restore, and topology leakage.
+- [ ] Add AgentLeak-style internal-channel audits over messages, tools, memory, logs, traces, and files.
+
+**Exit gate:** zero known unauthorized cross-scope disclosure or publication in the reviewed fixture matrix; collaboration utility meets the swarm baseline; every shared item explains its origin and grant.
+
+**Rollback:** disable shared publication/retrieval while retaining private execution state and normal messaging.
+
+### Phase 9 — Add prospective intentions only if product scope requires them
+
+**Objective:** implement reliable future intentions without autonomous reminder noise or permission persistence.
+
+- [ ] Approve a product/authority ADR defining which intention types AgenC supports and which remain out of scope.
+- [ ] Implement the deterministic state machine, trigger store, scheduler/watchers, cancellation/supersession, idempotency, expiry, and completion evidence.
+- [ ] Accept only explicit live-user intentions; no inference from external content, worker output, or assistant suggestion.
+- [ ] Require fresh execution-time policy/permission and target verification.
+- [ ] Add hidden-channel/event, cross-day/restart, update, cancellation, lure/non-trigger, duplicate-fire, timezone, clock-change, and unavailable-watcher tests.
+- [ ] Evaluate no reminder, TODO ledger, selective heartbeat, fixed heartbeat, and multi-agent strategies using PM-Bench plus AgenC-native cases.
+
+**Exit gate:** preregistered prospective Set-F1/false-positive/duplicate-action gates pass and no consequential action fires from stored authority alone.
+
+**Rollback:** stop watchers and retain pending intentions as inspectable inert records; do not drop or execute them silently.
+
+### Phase 10 — Experiment with optional adapters and learned controllers
+
+**Objective:** capture additional value only where it is reproducible and cannot weaken core invariants.
+
+- [ ] Benchmark native lexical retrieval before adding an embedding or graph dependency.
+- [ ] Implement one adapter at a time with security-domain partitioning, core ID recheck, derived-artifact lineage, delete/rebuild, timeout, and no-network fallback.
+- [ ] Evaluate local versus remote embeddings for privacy, cost, latency, packaging, and model drift.
+- [ ] Run a time-boxed Mem0/Graphiti/ReMe/MemClaw-reference spike through the same adapter/eval contract; do not fork core policy into an adapter.
+- [ ] Recheck licenses, releases, security advisories, transitive dependencies, platform artifacts, and maintainer health at spike time.
+- [ ] If learned write/read/maintenance policies are tested, constrain their action space to proposals and shadow decisions; deterministic policy remains final.
+- [ ] Train/optimize only against downstream task, safety, and cost objectives with held-out providers/tasks and adversarial cases.
+- [ ] Require a clear gain over the simplest native baseline and preserve a one-switch fallback.
+
+**Exit gate:** an adapter/controller lands only with a reviewed benchmark report, threat assessment, SBOM/license impact, cross-platform packaging proof, deletion proof, and rollback test.
+
+**Rollback:** delete/rebuild derived adapter artifacts and select native deterministic behavior; canonical memory is unchanged.
+
+### Phase 11 — Complete operator UX, daemon/SDK surfaces, observability, and docs
+
+**Objective:** make memory inspectable, correctable, supportable, and honest.
+
+- [ ] Extend `/memory` with list/filter, candidate review, approve/reject, show, history/diff, provenance, conflicts, why-recalled, correct, forget, deletion status, repair/reindex, import/export, and health.
+- [ ] Require confirmations for ambiguous/broad forget/export/share operations and show exact scope/affected descendants before execution.
+- [ ] Add headless CLI equivalents suitable for automation, with structured JSON and stable exit/reason codes.
+- [ ] Add daemon protocol methods and generated types without leaking runtime internals; make SDK changes additive/versioned.
+- [ ] Authorize every daemon/SDK operation through the same policy context as the TUI.
+- [ ] Add metrics for writes proposed/activated/quarantined/rejected, retrieval abstention/precision proxy, conflict/stale use, utility/harm, invalidated exposure, deletion lag/residue, jobs, storage, tokens, latency, and provider cost.
+- [ ] Keep telemetry content-free by default; hash/minimize identifiers, redact secrets, and document retention/export.
+- [ ] Add operator alerts for writer/reader path disagreement, projection/index drift, stuck deletion/repair, policy bypass attempt, repeated poison candidate, storage quota, and adapter outage.
+- [ ] Update architecture, memory reference, agents/swarms, permissions, privacy, settings, CLI, SDK, migration, troubleshooting, and threat-model docs.
+- [ ] Document what memory does **not** guarantee, how to disable it, how to inspect it, deletion limitations, and how current evidence outranks it.
+
+**Exit gate:** every lifecycle/security operation is available and tested through intended UI/API surfaces; docs match live defaults and protocol; telemetry contains no fixture secrets/content.
+
+**Rollback:** hide/disable new mutating surfaces while retaining read-only explain/export and kill switches.
+
+### Phase 12 — Shadow, canary, default, release, and long-term review
+
+**Objective:** roll out based on evidence and stop automatically on harm.
+
+- [ ] Run legacy and new pipelines in shadow with only one injected into a session; compare proposals, recall, actions, cost, and outcomes.
+- [ ] Start opt-in with synthetic/non-sensitive workspaces and operator-visible mode badges.
+- [ ] Canary by provider/model/platform/workload; do not average away a critical stratum regression.
+- [ ] Define automatic rollback triggers for task delta, poison activation, scope leak, invalidated exposure, secret finding, deletion failure, latency/cost, crash, and storage growth.
+- [ ] Run migration and rollback drills on copies of large real-shaped global/project/agent stores, including malformed Markdown, symlinks, long paths, worktrees, remote roots, and interrupted upgrades.
+- [ ] Default-enable only after all hard gates and preregistered functional gates pass for a sustained reviewed window.
+- [ ] Preserve memory-off and, only if it passes the centralized barrier/tombstone guard, legacy-read-only for at least one documented compatibility window; never preserve an unsafe reader merely to satisfy rollback symmetry.
+- [ ] Publish release notes with behavior/default changes, privacy/storage impact, migration, kill switch, and honest benchmark methodology.
+- [ ] Run all local required gates; hosted CI is not the test authority in this repository.
+- [ ] Schedule quarterly research/benchmark/threat refresh and reevaluate default thresholds after model/provider changes.
+
+**Exit gate:** release artifacts, docs, migrations, rollback, runtime assets, and default behavior converge; post-release canary remains within gates; no required work is left merely as a TODO in release notes.
+
+**Rollback:** use the tested mode switch and release rollback procedure. Preserve tombstones, audit, and new data export; never downgrade by discarding user memory or reactivating withdrawn content.
+
+## Evaluation contract
+
+Memory ships on downstream behavior, not a retrieval leaderboard. Every run must separate the base model's ability from memory formation, retrieval, interpretation, and action use.
+
+### Required comparison modes
+
+Run the same task instances, seeds, provider/model snapshots, tools, budgets, and verifiers under:
+
+1. memory off;
+2. current AgenC legacy memory;
+3. full eligible context within a declared budget;
+4. deterministic lexical retrieval;
+5. oracle evidence/context;
+6. proposed system, with each major component ablated;
+7. optional adapter or learned policy, if being considered.
+
+For execution-state tests, also compare current compaction, exact recent tail, session-summary path, and active-state tree. For procedures, compare no procedure, nearest successful trace, simple validated warning/recipe, and the proposed lifecycle.
+
+### External suites to adapt
+
+| Capability | Primary suite/source | How to use it |
+| --- | --- | --- |
+| Incremental retrieval/learning/understanding/forgetting | [MemoryAgentBench](https://github.com/HUST-AI-HYZ/MemoryAgentBench) | Reproduce pinned tasks; report all four competencies separately. |
+| Interdependent multi-session actions | [MemoryArena](https://memoryarena.github.io/) | Use for learned experience that changes later web/planning/search/reasoning decisions. |
+| Coding/research/tool/computer memory | [MemGym](https://arxiv.org/abs/2605.20833) | Prioritize executable coding tracks; distinguish proxy reward from final task success. |
+| Stateful downstream outcomes/agent learning | [STATE-Bench](https://github.com/microsoft/STATE-Bench) | Pin its Agent Learning track and executable database/policy verifiers; report task completion separately from LLM-judged UX and adapt only after license/data review. |
+| System module/cost characterization | [MemoryData](https://github.com/OpenDataBox/MemoryData) | Profile representation, extraction, retrieval/routing, maintenance, update stability, and cost. |
+| Multi-principal utility/access/forgetting | [GateMem](https://github.com/rzhub/GateMem) | Adapt roles/scopes to users, projects, agents, and teams; keep hidden leak checkpoints. |
+| Memory-use calibration/sycophancy | [MemSyco-Bench](https://github.com/XMUDeepLIT/MemSyco-Bench) | Test reject-as-fact, applicable scope, objective conflict, updates, and valid personalization. |
+| Heterogeneous type contamination | [MemGuard](https://arxiv.org/abs/2605.28009) | Test whether episodes become facts/rules or rules are treated as evidence; compare type-isolated construction/retrieval with the same token budget. |
+| Prospective intentions | [PM-Bench](https://github.com/genglinliu/PMBench) | Use only after license review; exercise updates, hidden channels, lures, cross-day state, and false triggers. |
+| Durable-write distortion | [PASB code](https://github.com/henrymao2004/agent-sycophancy) | Test status promotion, attribution loss, uncertainty removal, and cross-domain scope broadening at commit. |
+| Poisonable write channels | [MPBench paper](https://arxiv.org/abs/2606.04329) | Recreate explicit, inferred-policy, compaction, and experience-to-procedure attacks; no official code was located during this audit. |
+| Delayed poison activation | [Sleeper memory research code](https://github.com/ivaxi0s/LLM-agent-memory-poisoning) | Exercise external source → write → later-session retrieval → action, including adaptive attacks. |
+| Forged rationale memory | [FARMA](https://arxiv.org/abs/2607.05029) | Inject forged and self-reinforcing reasoning-shaped entries through each producer; verify no corroboration/authority gain and compare deterministic/independent screening defenses. |
+| Longitudinal contamination | [Remembering More, Risking More](https://arxiv.org/abs/2605.17830) | Run fixed trigger probes against read-only snapshots across growing histories and compare with `NullMemory` to separate memory-caused risk from model/task drift. |
+| Internal-channel privacy | [AgentLeak](https://github.com/Privatris/AgentLeak) | Audit messages, memory, tools, logs, files, and artifacts, not only final output. |
+| Hierarchical isolation/publication | [AgentSys](https://arxiv.org/abs/2602.07398) | Adapt worker-isolated untrusted tool traces and typed return/publication boundaries; test malicious-but-schema-valid values as well as parse failures. |
+| Authority laundering | [mem-inv-bench](https://github.com/yedidel/mem-inv-bench) | Test summarization, trusted-tool echo, and manufactured/Sybil corroboration; keep formal-model caveats. |
+| Invalidation/cascade repair | [MEMOREPAIR](https://arxiv.org/abs/2605.07242) | Measure invalidated exposure from barrier through completed repair and incomplete-lineage failure. |
+| Mutation/invalid-memory use | [Memora paper](https://aclanthology.org/2026.findings-acl.1337/) | Extend correction histories across month/quarter-like mutation depth. |
+| Personalized long-horizon safety | [PerMemSafe](https://aclanthology.org/2026.findings-acl.320/) | Test evolving implicit risk context, unsupported inference, over-refusal, and preservation of helpfulness. |
+| Conversational recall diagnostics | LoCoMo and LongMemEval through their pinned official releases | Use only as diagnostic/regression suites, never the primary ship gate for a coding agent. |
+
+Do not put every large external suite in the normal pre-commit path. Maintain a small deterministic security/contract subset in Vitest, a reproducible local full suite, and an operator-run release suite with immutable manifests.
+
+### AgenC-native scenario matrix
+
+#### Write/admission
+
+- Explicit safe user preference; global versus project-specific preference; later correction and exception.
+- User says “remember” then reverses it in the same turn or later; jokes, hypotheticals, quotations, negation, uncertainty, and third-party claims.
+- Assistant falsely reports that tests passed; failed tool result contradicts it.
+- Malicious repository README/comment/test output asks the agent to persist a rule, secret, or permission.
+- Web/MCP/email/document payload implants a delayed instruction or fake user profile.
+- Trusted tool wrapper echoes an attacker-controlled value; repeated workers manufacture corroboration.
+- Compaction delimiter injection and source attribution loss.
+- Forged rationale/reasoning-shaped entries that self-reference, repeat across workers, or claim prior validation; verify that repetition cannot raise authority and that hidden reasoning is never retained.
+- One successful-looking episode attempts to become a global procedure; failed and partial outcomes.
+- Secret/token/private key/PII through every `Write`/`Edit`/`MultiEdit`/import/session/agent/team path.
+- Duplicate versus correction ordering, concurrent proposals, retry/idempotency, crash between item and index/projection.
+
+#### Recall and use
+
+- Current repository state conflicts with memory; latest/as-of/interval questions; future-dated and expired claims.
+- Correct preference versus factual sycophancy; preference for one project/person applied to another.
+- Relevant item, counter-evidence, and conflict set; no-match abstention and one-word prompts.
+- Live user says ignore/disable memory for this turn/session, or asks for a specific memory audit; current instruction must deterministically control injection without deleting data.
+- Updated item needs resurfacing after an older version appeared earlier in the session.
+- Exact-ID, enumeration, export, lineage, cache, snapshot, MCP, background job, and adapter scope bypass attempts.
+- Procedure with wrong branch, worktree, tool version, provider, schema, permissions, or operating system.
+- Memory suggests a destructive command, publication, credential use, external message, payment, or security change without live approval.
+- Provider/reranker outage, timeout, malformed response, token pressure, and memory-off fallback.
+- Fixed benign/adversarial trigger probes over increasingly long, read-only memory snapshots with a `NullMemory` counterfactual to detect gradual contamination.
+
+#### Execution state and compaction
+
+- Long debugging task with a failed branch that shares keywords with the correct branch.
+- Completed subgoal summary later contradicted by a test; Revise from a checkpoint.
+- Tool call/result pair at a compaction boundary; enormous output; failure fallback.
+- External side effect before branch rollback; compensating action needs approval.
+- Parent and workers update shared task state concurrently; daemon crashes at each transaction boundary.
+- Restart, resumed thread, different worktree, changed Git HEAD, and stale session summary.
+- Original objective/constraint appears only early in the transcript and must survive repeated compaction.
+
+#### Multi-agent/privacy
+
+- Compromised child tries to publish a secret or poison to parent/project/global/team memory.
+- Parent can read a scope but child cannot; child attempts direct ID and inferred export.
+- Central coordinator/hub compromise, sparse versus dense topology, Sybil workers, and confused deputy.
+- Sensitive data appears in mailbox, delegation prompt, tool args/results, status, log, trace, snapshot, and artifact channels.
+- Agent-private snapshot restore attempts to overwrite or leak another namespace.
+
+#### Forgetting/deletion
+
+- User corrects one root fact with multiple summaries, procedures, vectors, Markdown projections, caches, and agent copies.
+- Immediate read races the serving barrier; repair fails halfway; restore uses an old backup.
+- Exact content, paraphrase, membership inference, and adversarial extraction after deletion.
+- Tombstoned legacy file reappears through filesystem sync/import.
+- Ambiguous “forget that” and broad subject deletion; legal/retention policy conflict if supported.
+
+#### Prospective behavior
+
+- Time/event/state cue, hidden channel, cross-day/restart, update, cancellation, supersession, expiry, timezone/clock change, lure, and duplicate firing.
+- Due intention lacks current permission, dependency, target, network, or user confirmation.
+- Fixed heartbeat/many-subagent strategies generate false positives and excessive calls.
+
+### Metrics
+
+Report distributions and confidence intervals, not one average.
+
+**Utility and correctness**
+
+- end-to-end task success and partial progress;
+- memory-attributable task delta/regret using paired memory-on/off runs;
+- write precision, write recall on labeled eligible items, activation precision, and quarantine false-positive/false-negative rate;
+- retrieval/context precision and recall, abstention calibration, conflict/counter-evidence coverage, temporal correctness, and selective forgetting;
+- downstream valid-memory use versus factual sycophancy;
+- procedure held-out success, harmful reuse, applicability mismatch, and time-to-demotion;
+- execution-state reconstruction, failed-branch contamination, rollback correctness, and side-effect consistency;
+- prospective Set-F1/precision/recall, false triggers, missed triggers, duplicates, and completion correctness.
+
+**Security and governance**
+
+- poison write attack-success rate and retrieved-poison behavioral success;
+- unauthorized metadata/content exposure across every channel;
+- memory-only consequential action attempts allowed/denied;
+- origin/lineage coverage and authority-laundering success;
+- invalidated exposure count and barrier latency;
+- deletion residue/recovery across each managed tier;
+- known-secret persistence or disallowed sink disclosure;
+- over-refusal and legitimate personalization/utility loss from defenses.
+
+**Systems**
+
+- write construction, retrieval, validation, context-generation, maintenance, repair, and deletion latency separately;
+- p50/p95/p99 wall time, tokens, provider calls, cache use, and monetary cost;
+- canonical and derived storage growth, write amplification, index rebuild time, startup/migration time, job backlog, and freshness lag;
+- human-review rate, review minutes per useful activation, quarantine backlog/age, and correction burden;
+- query-volume amortization and local versus remote provider impact;
+- crash/retry/error rates and no-memory fallback rate.
+
+### Hard gates
+
+For the reviewed deterministic fixture matrix, require:
+
+- zero unauthorized cross-scope content disclosure;
+- zero consequential action authorized solely by persisted memory;
+- zero active known descendant after the invalidation transaction commits;
+- zero known fixture secret persisted or sent to a disallowed sink;
+- zero model/adapter direct mutation of canonical state;
+- complete evidence/influence lineage for every activated/derived non-legacy item;
+- no failed/abandoned branch represented as current active state;
+- no split assistant tool call/result after compaction;
+- successful logical withdrawal through search, direct ID, export, lineage, cache, prompt, job, and adapter paths;
+- exact rollback/kill-switch behavior with canonical data preserved.
+
+For stochastic/adaptive suites, Phase 0 must preregister acceptable upper confidence bounds and sample sizes. “Zero observed” in a tiny run is not proof of zero risk.
+
+Functional release gates must be frozen from Phase 0 variance and reviewed before seeing the new-system result. At minimum, the proposed system must be non-inferior on every critical provider/platform/workload stratum, materially superior on the target long-horizon strata, and within preregistered cost/latency/storage budgets. Do not average away a safety or critical-task regression.
+
+### Experimental hygiene
+
+- Randomize and pair condition order; isolate stores per run; prevent cross-run/provider-cache contamination.
+- Hide future answers/checkpoints from extractors and retrievers.
+- Keep writer, retriever, generator, and judge model versions explicit; run cross-model transfer cases.
+- Prefer deterministic executable verifiers. When an LLM judge is necessary, publish prompt, rubric, model, sampling, raw judgment, and disagreement audit.
+- Use multiple seeds where sampling exists and report bootstrap or other preregistered confidence intervals.
+- Record token/cost price date separately from token counts so historical runs remain comparable.
+- Preserve every failed run and exclusion with a reason. Never tune on the held-out release set.
+
+## Security and privacy checklist
+
+This checklist supplements, but does not replace, the threat model and repository permission system.
+
+- [ ] Apply [OWASP's AI Agent Security guidance](https://cheatsheetseries.owasp.org/cheatsheets/AI_Agent_Security_Cheat_Sheet.html): validate/sanitize before storage, isolate memory, bound retention/size, protect secrets, monitor integrity, and red-team.
+- [ ] Use the [OWASP Agent Memory Guard](https://owasp.org/www-project-agent-memory-guard/) project as an attack-fixture/design input only; independently validate its early implementation and claimed detection results.
+- [ ] Recheck the current [NIST agent-security RFI analysis](https://www.nist.gov/publications/summary-analysis-responses-request-information-regarding-security-considerations-ai) for provenance, isolation, validation, privacy, and deployment guidance before GA.
+- [ ] Treat prompt-injection scanners as one signal. MPBench reports that conventional defenses miss persistent/weak-signal poisoning.
+- [ ] Preserve immutable origin through summaries, tools, agents, imports, projections, and adapters; never infer trust from benign wording.
+- [ ] Partition indexes/caches by security domain; test timing/error/count side channels and direct-ID access.
+- [ ] Require purpose/sink checks before remote model, embedder, MCP, worker, team sync, logging, telemetry, export, or support bundle.
+- [ ] Bind remote-provider routing to its current data-retention/training/cache contract and account policy; deny sensitive memory when the required guarantee is unknown or unavailable, and record the sink in lineage/deletion receipts.
+- [ ] Minimize personal data; expose inspect/correct/forget; define retention/expiry; never infer sensitive traits for personalization.
+- [ ] Redact identifiers/content from logs and traces while retaining policy reason codes and digests needed for audit.
+- [ ] Rate-limit candidates, bytes, jobs, maintenance, and adversarial retrieval to prevent storage/token/CPU denial of service.
+- [ ] Pin and audit adapter dependencies; generate/check SBOM; verify signed/reproducible runtime artifacts as required by release policy.
+- [ ] Test symlink, hard-link, root swap, special file, invalid UTF-8, Unicode collision, path traversal, long path, permission mode, and time-of-check/time-of-use races on supported platforms.
+- [ ] Test DB corruption, disk full, clock skew, concurrent writers, lease expiry, daemon crash, partial projection, and restore.
+- [ ] Ensure memory-disabled mode is a safe operational fallback and not a way to bypass tombstones, audits, or live permission policy.
+
+Additional primary research informing the threat model includes [BackdoorAgent](https://aclanthology.org/2026.findings-acl.791/) on persistent triggers, [Topology Matters](https://aclanthology.org/2026.findings-acl.1980/) on multi-agent leakage topology, [Safety Sidecar](https://aclanthology.org/2026.findings-acl.1542/) on external verification, and [A-MemGuard](https://openreview.net/forum?id=udqe7UZUZ6) on validation-oriented memory defense. Treat each as scoped evidence, not a turnkey guarantee.
+
+## Compatibility and data migration
+
+### Compatibility contract
+
+Preserve or deliberately version all of the following:
+
+- `$AGENC_HOME` resolution and `$AGENC_HOME/memory/` global store;
+- canonical `<projectRoot>/.agenc/memory/` project store;
+- remote memory root, full-path override, trusted `autoMemoryDirectory`, and worktree canonicalization;
+- existing `MEMORY.md` indexes/topic Markdown and four frontmatter types;
+- existing dated auto-memory log paths and any valid links from indexes/topics;
+- `/memory` inspect/edit workflow and headless behavior;
+- existing memory mention aliases/`@` routing where they are part of the supported agent surface;
+- automatic-memory, simple/remote, extraction, session-memory, compaction, and AutoDream settings/environment gates;
+- user/project/local agent-memory paths, namespace migration, and snapshots;
+- MCP read-only memory exposure and redaction;
+- thread/session memory mode persistence;
+- daemon restart, transcripts/event logs, and state-store backups;
+- additive daemon protocol and SDK compatibility;
+- memory-off behavior.
+
+Compatibility does not mean preserving an unsafe default forever. If inferred direct durable writes or false team-sync claims are disabled, document the behavior change, keep a reviewed opt-in compatibility window if justified, and provide migration/export—not a silent security regression.
+
+### Legacy classification
+
+- Global/project/team/agent/session files are **not** automatically trusted based on their location.
+- Import existing durable topics as `legacy_unverified`, preserving original path, bytes/digest, mtime, frontmatter, inferred legacy scope, and import event.
+- Treat `MEMORY.md` primarily as an index/projection; do not convert each index line into a fact without resolving the target.
+- Import dated auto-memory logs as legacy evidence/episodes subject to retention and provenance review, not as automatically active facts or procedures.
+- Preserve malformed/unparseable files byte-for-byte and report them for manual review; do not drop them.
+- Import current session `summary.md` as unverified working state only, never durable cross-session knowledge.
+- Keep Stage 1/Phase 2 tables/data intact until an explicit migration maps or retires them; they are not proof that a memory was active.
+- Treat team files as local legacy shared content until a real authenticated sync identity/provenance exists.
+- Preserve agent-memory namespace authority and strong filesystem checks; imported content still gets untrusted framing and bounds.
+
+### Migration algorithm
+
+1. **Preflight:** resolve all canonical stores with the unified resolver; detect collisions, duplicate roots, symlinks/hard links/special files, malformed UTF-8/frontmatter, permission problems, unsupported schema, disk space, and active background writers.
+2. **Quiesce writers:** take the memory service lease and stop extraction/consolidation/projection jobs; reads remain available only through the guard-aware legacy-read-only mode (or memory-off before that adapter exists).
+3. **Backup:** use existing state backup practices and create a content-addressed manifest of managed memory files. Never overwrite the only copy. Validate backup readability before migration.
+4. **Import:** idempotently create namespace/event/item/version records keyed by source digest/path/import generation; no file mutation.
+5. **Reconcile:** detect equivalent, conflicting, dangling-index, and duplicate-path items; report rather than auto-merge ambiguous content.
+6. **Project:** generate proposed compatibility projections in a separate staging location; compare normalized content and links before atomic promotion.
+7. **Shadow:** legacy read remains authoritative while new retrieval/policy decisions are logged and compared. Before any tombstone/deletion epoch can exist, put legacy access behind the shared guard so shadow/rollback cannot bypass it.
+8. **Enforced writes:** new writes enter the ledger and project to Markdown; legacy files remain readable/importable.
+9. **Enforced reads:** ledger becomes canonical for opted-in cohorts; only a namespace-, policy-, barrier-, and tombstone-aware compatibility adapter remains available for rollback/export during the compatibility window. Otherwise the only safe fallback is memory-off.
+10. **Finalize:** after sustained gates, mark the migration generation complete. Do not delete legacy originals automatically; offer explicit reviewed archival/deletion with receipts.
+
+### Filesystem edit reconciliation
+
+- Watch or hash projections at safe synchronization points; do not trust an event watcher alone.
+- Match a known projection by embedded/sidecar item/version ID and prior digest.
+- No change: no-op.
+- Safe human change from authenticated `/memory`: create a new explicit-user edit candidate/version with a diff.
+- Out-of-band edit: create a `local_file` candidate, preserving prior/current digests and no live-user attribution.
+- Deleted projection: request/record a forget candidate; do not infer authorized deletion across descendants without policy.
+- Concurrent ledger and file edits: surface a conflict; never last-writer-wins.
+- Unknown new file: import as `legacy_unverified` candidate.
+
+Project projections may be committed to Git. Keep them deterministic and diff-stable, and never emit secrets, absolute home paths, private principal identifiers, provider metadata, or sensitive provenance into repository-visible sidecars. Canonical private metadata stays under `AGENC_HOME`; a tracked project file remains repository-origin content when another user imports it. Treat Git history, forks, caches, and remotes as propagated or unmanaged copies: a normal forget/delete can withdraw and remove the managed working-tree projection but cannot claim erasure from repository history. Any history rewrite is a separate explicit destructive workflow outside automatic memory maintenance.
+
+### Rollback matrix
+
+| Stage | Rollback action | Data handling |
+| --- | --- | --- |
+| Stabilized paths/gates | Select legacy read paths from the unified resolver | Existing files unchanged; unsafe inferred writes stay off. |
+| Additive schema/shadow | Disable new service before lifecycle state exists; afterward use the guard-aware adapter or memory-off | New tables remain; the tombstone/deletion-epoch guard is never disabled and no downgrade migration is required. |
+| Governed writes | Switch to guard-aware legacy-read-only and export active records, or memory-off | Preserve ledger/events/tombstones; do not resume automatic direct writes or serve withdrawn projections. |
+| New recall | Select the guard-aware bounded compatibility retriever or memory-off | Canonical versions remain; no index deletion required; raw current recall is unavailable once barriers exist. |
+| Deletion/repair | Pause repair/physical deletion jobs only | Serving barriers/tombstones remain mandatory. |
+| Execution state | Return to current compaction/exact-tail | Execution records remain auditable and inert. |
+| Procedure/shared/prospective | Disable that retrieval/publication/watcher | Records remain inspectable; nothing fires or becomes globally visible. |
+| External adapter | Select native lexical adapter and purge/rebuild derived data | Canonical ledger is unchanged. |
+| Release regression | Use documented release/mode rollback | Restore a validated backup only with deletion epochs/tombstones reapplied. |
+
+Older binaries and compatibility readers must not open or bypass a newer incompatible state DB silently. Detect schema support and fail with a safe upgrade/export/recovery message. Once lifecycle records exist, an older binary that cannot enforce their guard must refuse memory reads (or the daemon must refuse that binary), not fall through to retained Markdown. A rollback is a behavior switch or validated backup restore, not a reverse migration that discards new records.
+
+## Implementation touchpoint map
+
+Final module names require an ADR, but keep responsibilities separated. A suggested layout is:
+
+```text
+runtime/src/memory/
+  contracts/          strict domain types and decoders
+  policy/             origin, taint, namespaces, capabilities, sink/action policy
+  ledger/             repository, transactions, versions, evidence, influence, jobs
+  admission/          capture, extraction, validation, DLP, promotion
+  retrieval/          query plan, lexical/temporal/conflict retrieval, rerank, context compiler
+  lifecycle/          correction, invalidation, repair, expiry, deletion
+  execution/          nodes, heads, compaction adapter, links to canonical run/turn/effect durability
+  procedures/         episodes, trial/promotion, outcome feedback
+  prospective/        optional intention state machine and watchers
+  projections/        Markdown import/export/reconciliation
+  adapters/           optional derived index implementations
+  telemetry/          content-minimized events and metrics
+```
+
+Do not create a second public memory barrel that drifts from [`runtime/src/memory/index.ts`](runtime/src/memory/index.ts).
+
+### Current files requiring deliberate changes
+
+**Paths, settings, and compatibility**
+
+- [`runtime/src/memory/paths.ts`](runtime/src/memory/paths.ts)
+- [`runtime/src/services/extractMemories/memory-paths.ts`](runtime/src/services/extractMemories/memory-paths.ts)
+- [`runtime/src/prompts/attachments/relevant-memories.ts`](runtime/src/prompts/attachments/relevant-memories.ts)
+- [`runtime/src/utils/attachments.ts`](runtime/src/utils/attachments.ts)
+- [`runtime/src/mcp/server/start.ts`](runtime/src/mcp/server/start.ts)
+- [`runtime/src/mcp/server/content-providers.ts`](runtime/src/mcp/server/content-providers.ts)
+- [`runtime/src/utils/settings/types.ts`](runtime/src/utils/settings/types.ts)
+- [`runtime/src/session/attachment-state.ts`](runtime/src/session/attachment-state.ts)
+- [`runtime/src/state/threads.ts`](runtime/src/state/threads.ts)
+- [`runtime/src/thread-store/store.ts`](runtime/src/thread-store/store.ts)
+
+**Schema, store, and jobs**
+
+- [`runtime/src/state/migrations/011_memory_pipeline_schema.ts`](runtime/src/state/migrations/011_memory_pipeline_schema.ts) (preserve; migrate forward)
+- [`runtime/src/state/migrations/015_run_durability_schema.ts`](runtime/src/state/migrations/015_run_durability_schema.ts) (reuse; do not duplicate `run_effects`)
+- [`runtime/src/state/migrations/index.ts`](runtime/src/state/migrations/index.ts)
+- [`runtime/src/state/backfill.ts`](runtime/src/state/backfill.ts)
+- [`runtime/src/memory/store.ts`](runtime/src/memory/store.ts)
+- [`runtime/src/state/sqlite-driver.ts`](runtime/src/state/sqlite-driver.ts)
+- [`runtime/src/state/run-durability.ts`](runtime/src/state/run-durability.ts)
+- [`runtime/src/state/startup-run-journal-recovery.ts`](runtime/src/state/startup-run-journal-recovery.ts)
+
+**Taxonomy, extraction, and writes**
+
+- [`runtime/src/memory/types.ts`](runtime/src/memory/types.ts)
+- [`runtime/src/memdir/memory-types.ts`](runtime/src/memdir/memory-types.ts) (remove duplicated contract)
+- [`runtime/src/memory/extraction-triggers.ts`](runtime/src/memory/extraction-triggers.ts)
+- [`runtime/src/services/extractMemories/extractMemories.ts`](runtime/src/services/extractMemories/extractMemories.ts)
+- [`runtime/src/services/extractMemories/prompts.ts`](runtime/src/services/extractMemories/prompts.ts)
+- [`runtime/src/phases/commit.ts`](runtime/src/phases/commit.ts)
+- [`runtime/src/memory/privacy.ts`](runtime/src/memory/privacy.ts)
+- [`runtime/src/utils/permissions/filesystem.ts`](runtime/src/utils/permissions/filesystem.ts)
+- file `Write`/`Edit`/`MultiEdit` and system-write admission surfaces
+
+**Recall and prompts**
+
+- [`runtime/src/memory/scan.ts`](runtime/src/memory/scan.ts)
+- [`runtime/src/memory/find-relevant.ts`](runtime/src/memory/find-relevant.ts)
+- [`runtime/src/memory/age.ts`](runtime/src/memory/age.ts)
+- [`runtime/src/memory/agencmd.ts`](runtime/src/memory/agencmd.ts)
+- [`runtime/src/memory/memdir.ts`](runtime/src/memory/memdir.ts)
+- [`runtime/src/prompts/attachments/messages.ts`](runtime/src/prompts/attachments/messages.ts)
+- attachment orchestrator/types and session citation state
+
+**Session, execution, and compaction**
+
+- [`runtime/src/memory/session/sessionMemory.ts`](runtime/src/memory/session/sessionMemory.ts)
+- [`runtime/src/memory/session/sessionMemoryUtils.ts`](runtime/src/memory/session/sessionMemoryUtils.ts)
+- [`runtime/src/memory/session/prompts.ts`](runtime/src/memory/session/prompts.ts)
+- [`runtime/src/services/compact/sessionMemoryCompact.ts`](runtime/src/services/compact/sessionMemoryCompact.ts)
+- [`runtime/src/services/compact/autoCompact.ts`](runtime/src/services/compact/autoCompact.ts)
+- `runtime/src/services/compact/{compact,prompt,types}.ts`
+- [`runtime/src/budget/admitted-tool-call.ts`](runtime/src/budget/admitted-tool-call.ts)
+- [`runtime/src/session/run-turn.ts`](runtime/src/session/run-turn.ts)
+- [`runtime/src/session/session.ts`](runtime/src/session/session.ts)
+- [`runtime/src/session/agenc-tool-use-context.ts`](runtime/src/session/agenc-tool-use-context.ts)
+- [`runtime/src/session/event-log.ts`](runtime/src/session/event-log.ts)
+- [`runtime/src/session/durable-turns.ts`](runtime/src/session/durable-turns.ts)
+- [`runtime/src/session/turn-state.ts`](runtime/src/session/turn-state.ts)
+- [`runtime/src/session/rollout-store.ts`](runtime/src/session/rollout-store.ts)
+- [`runtime/src/session/rollout-reconstruction.ts`](runtime/src/session/rollout-reconstruction.ts)
+- [`runtime/src/thread-store/live-thread.ts`](runtime/src/thread-store/live-thread.ts)
+
+**Consolidation, agents, and swarms**
+
+- `runtime/src/services/autoDream/*`
+- `runtime/src/memdir/{teamMemPaths,teamMemPrompts}.ts`
+- [`runtime/src/tools/AgentTool/agentMemory.ts`](runtime/src/tools/AgentTool/agentMemory.ts)
+- [`runtime/src/tools/AgentTool/agentMemorySnapshot.ts`](runtime/src/tools/AgentTool/agentMemorySnapshot.ts)
+- [`runtime/src/tools/AgentTool/loadAgentsDir.ts`](runtime/src/tools/AgentTool/loadAgentsDir.ts)
+- [`runtime/src/plugins/registration/load-plugin-agents.ts`](runtime/src/plugins/registration/load-plugin-agents.ts)
+- agent control/delegation/mailbox/run/status/thread-manager, background runner, task bridge, coordinator, and swarm command after current changes merge
+
+**UI, protocol, SDK, and docs**
+
+- `runtime/src/commands/memory/*`
+- memory TUI components/renderers/usage indicators
+- daemon app-server protocol/handlers/generated types
+- `packages/agenc-sdk/` protocol mirror and public methods
+- [`docs/reference/memory.md`](docs/reference/memory.md)
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`docs/INDEX.md`](docs/INDEX.md), agent/swarm/permissions/privacy/CLI/SDK/troubleshooting docs
+- release notes and configuration schema/reference
+
+### Test layout
+
+Preserve all existing memory, compaction, agent-memory, TUI, and contract tests. Add focused suites mirroring the architecture:
+
+```text
+runtime/tests/memory/
+  paths-canonical.contract.test.ts
+  filesystem-security.test.ts
+  contracts.test.ts
+  policy.contract.test.ts
+  origin-taint.test.ts
+  ledger.test.ts
+  admission.test.ts
+  retrieval.test.ts
+  context-compiler.test.ts
+  invalidation-repair.test.ts
+  deletion-residue.test.ts
+  projections-migration.test.ts
+  execution-state.test.ts
+  procedures.test.ts
+  prospective.test.ts
+  multi-agent-isolation.test.ts
+  e2e-write-recall.test.ts
+  adversarial-poisoning.test.ts
+```
+
+Also add daemon/SDK contract tests, `/memory` TUI tests, crash/restart integration tests, and the separate reproducible `runtime/evals/memory/` harness. Names are illustrative; follow existing conventions when implementation starts.
+
+## PR decomposition
+
+Do not implement this as one mega-PR. A sensible dependency order is:
+
+1. `test(memory): freeze path, wiring, security, and behavior baselines`
+2. `fix(memory): unify canonical paths and disable unsafe unwired writers`
+3. `fix(memory): harden durable filesystem and secret admission`
+4. `docs(memory): approve physical topology, deletion payload, and authority ADRs`
+5. `feat(memory): add typed contracts, policy skeleton, and topology-correct additive ledger schema`
+6. `feat(memory): add origin capture, namespaces, lifecycle, tombstone guard, and audit repository`
+7. `feat(memory): replace direct writes with candidate admission`
+8. `feat(memory): add reversible Markdown projections and guarded legacy import`
+9. `feat(memory): add authorized lexical/temporal/conflict retrieval`
+10. `feat(memory): add context compiler, explain, and action-use gate`
+11. `feat(memory): add correction, cascade repair, and deletion verification`
+12. `feat(memory): add branch-aware execution state over existing run durability and compaction`
+13. `feat(memory): add outcome-grounded procedures`
+14. `feat(memory): enforce agent/swarm memory isolation and publication`
+15. `feat(memory): add prospective intentions` (only after the product ADR)
+16. `perf(memory): evaluate optional index/learned adapters` (only if evidence clears the gate)
+17. `feat(memory): complete operator/SDK surfaces and staged default rollout`
+
+Split these further when a PR cannot be reviewed, tested, and rolled back independently. Every PR includes a revert-sensitive test, migration/rollback note, updated checklist links, and no unrelated dirty-worktree changes.
+
+## Verification gates
+
+### Every implementation PR
+
+- targeted unit/contract/integration tests for changed behavior;
+- `npm run typecheck` at zero errors;
+- formatting/lint/build steps applicable to touched packages;
+- revert-sensitive regression proof for a bug fix;
+- no `@ts-nocheck`, unsafe broad cast, hidden policy bypass, or model-only safety control;
+- source/license/security review for a new dependency or benchmark artifact.
+
+### Before merging a phase
+
+Run from the repository root:
+
+```bash
+npm run build
+npm run typecheck
+npm test
+npm run test:bun
+npm run validate:runtime
+npm run check:agent-surface-contract
+npm run build --workspace=@tetsuo-ai/agenc-sdk
+npm run typecheck --workspace=@tetsuo-ai/agenc-sdk
+```
+
+For TUI/daemon/user-facing changes, explicitly run:
+
+```bash
+npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
+```
+
+Also run focused daemon/LLM/TUI end-to-end gates appropriate to the phase. If a dependency changes, regenerate and verify the SBOM:
+
+```bash
+npm run sbom
+npm run check:sbom
+```
+
+Run the repository's branding enforcement through its normal gates. Do not introduce historical project names into identifiers, strings, comments, errors, logs, environment variables, or file names.
+
+### Before default enablement/release
+
+- [ ] Full memory release-eval manifest passes all hard and functional gates.
+- [ ] Five-platform runtime packaging/install/update behavior is verified if native/dependency surfaces changed.
+- [ ] TUI and daemon startup pass at supported viewport/platform variants.
+- [ ] Migration, interrupted migration, backup, restore, downgrade refusal, and every rollback mode are rehearsed.
+- [ ] Kill switches work without network/provider availability.
+- [ ] Docs/defaults/settings/CLI/SDK/protocol/runtime artifacts agree.
+- [ ] Raw results, source revisions, model versions, costs, limitations, and known failures are archived.
+
+Hosted CI does not replace these local gates in this repository.
+
+## Risk register and default resolutions
+
+| Risk | Default resolution | Evidence/gate |
+| --- | --- | --- |
+| Governance makes benign memory useless | Fast path only for explicit safe user preferences and deterministically verified scoped outcomes; measure over-refusal | Paired utility and defense-ablation tests |
+| Fixing split paths exposes poisoned legacy extraction | Disable inferred direct writes before unifying consumers; restore via candidate path | Phase 1 regression/security tests |
+| Provenance graph is incomplete | Mandatory evidence/influence edges; broader quarantine on uncertainty | Lineage coverage and incomplete-edge repair tests |
+| Per-project SQLite cannot canonically own global/team scopes | Topology ADR before migration; one owner/database per namespace; keep global/team activation disabled until routed and recoverable | Cross-project isolation/federation, lock, backup/restore, migration, and deletion tests |
+| SQLite/event growth | Minimal payload pointers, localized maintenance, quotas/retention, realistic volume benchmark | Storage/write amplification and migration tests |
+| Embeddings leak sensitive data | Off by default; purpose/sink policy; local/remote adapter review | Sink and adapter isolation tests |
+| Remote/graph service harms local CLI reliability | No mandatory sidecar; native lexical fallback | Offline/startup/timeout/rollback tests |
+| Direct Markdown editing conflicts with canonical ledger | Versioned projections, digest reconciliation, explicit conflict UI | Import/edit/concurrency matrix |
+| User expects deletion from backups/providers | Tiered guarantee and receipt; tombstones/deletion epochs on restore | Residue and restore tests |
+| Encryption claim exceeds implementation | No encryption claim initially; prohibit secrets; ADR before key support | At-rest/key lifecycle review |
+| Model/provider drift changes write/recall behavior | Provider-neutral contracts, deterministic fallback, per-provider canaries | Cross-model held-out runs |
+| Learned controller reward-hacks benchmark | Shadow proposals only; held-out tasks/providers/adversarial suites | Ablations and no-policy-authority invariant |
+| Procedure copies a past error | Objective outcomes, failure/comparison evidence, trial/held-out/canary lifecycle | Experience-following and distribution-shift tests |
+| Compaction launders poison or loses goal | Raw evidence canonical, exact recent tail, untrusted framing, schema/source validation | PASB/MPBench and active-state tests |
+| Worker/shared memory leaks secrets | Private defaults, explicit publish, destination admission, all-channel audit | AgentLeak/GateMem/native swarm tests |
+| Concurrent agents overwrite state | CAS heads, immutable events, conflict retention, idempotency | Race/crash tests |
+| Prospective memory fires wrongly | Explicit-only deterministic state machine and fresh action approval | PM-Bench/native lure/duplicate cases |
+| Security filtering becomes an opaque model | Deterministic policy/reason codes; model screens only defense in depth | Policy contract and explain tests |
+| Research becomes stale during implementation | Reverify primary sources and official repos at each phase/release | Evidence note in every research-dependent PR |
+| Dirty swarm branch causes accidental overwrite | Start clean branch after current work is reconciled; re-audit integration seams | Git status and overlap check before Phase 8 |
+
+### ADRs that must be finalized, with safe defaults
+
+| ADR | Safe default pending decision |
+| --- | --- |
+| Physical storage topology | Do not create memory-ledger tables or activate `user_global`/team records until one canonical owner/database, namespace router, transaction boundary, backup/restore path, and deletion-epoch guard are approved. Keep project-local state in the existing project DB unless the ADR demonstrates a safer migration. |
+| Local principal/daemon client identity | Bind to the existing authenticated local client/OS-user boundary; do not pretend it is multi-tenant identity. |
+| At-rest encryption | No new encryption claim; restrictive modes and secret prohibition. Add envelope encryption only with supported key lifecycle/recovery. |
+| Lexical engine | Reuse proven in-process BM25 or feature-probed SQLite FTS after cross-platform benchmarks; no new native dependency by assumption. |
+| Embeddings/graph | Disabled and optional derived adapters. |
+| Team transport | Disabled; no sync wording or shared default. |
+| Retention | Preserve existing user files, minimize new event payloads, and expose inspect/delete before choosing automatic expiry. |
+| Telemetry | Content-free/local by default; explicit documented opt-in for any remote diagnostic sink. |
+| Prospective actions | Out of default core until explicit product scope and authority semantics are approved. |
+| Learned policy | Research/shadow only; deterministic control plane remains final. |
+
+## Definition of done
+
+The redesign is complete only when all of the following are true:
+
+- [ ] Every live memory producer and consumer uses the canonical resolver and control plane.
+- [ ] Every namespace has exactly one ADR-defined canonical physical owner; cross-project global access, backups/restores, locks, deletion epochs, and downgrade behavior pass topology tests, while unimplemented team transport remains disabled.
+- [ ] No model or adapter can directly mutate canonical active memory.
+- [ ] Every new active item has typed scope, kind, immutable origin, evidence, authority ceiling, validity/lifecycle, sensitivity/sink policy, and a version.
+- [ ] Instructions/persona/live permissions remain separate and always outrank learned memory.
+- [ ] Recall authorizes before content exposure, retrieves conflicts/counter-evidence, can abstain, cites sources, and is bounded/explainable.
+- [ ] Persisted memory cannot authorize a consequential action.
+- [ ] Execution state preserves the active branch, exact recent tool pairs, validated summaries, and rollback checkpoints while reusing the existing durable run/effect journal as the sole effect/recovery authority.
+- [ ] Procedures are outcome-grounded, trialed, scoped, versioned, canaried, and reversible.
+- [ ] Agent/swarm memory is private by default with explicit governed publication.
+- [ ] Correction/forget immediately withdraws every known descendant and deletion is verified across managed tiers with honest limitations.
+- [ ] Erasable user-derived event/candidate/version payloads are physically separable from immutable minimized envelopes; FK/influence behavior cannot leak content, orphan servable data, or erase barriers.
+- [ ] Existing Markdown/session/agent data migrates idempotently and reversibly without silent trust promotion or loss.
+- [ ] `/memory`, headless CLI, daemon, and SDK make lifecycle, origin, conflicts, why-recalled, correction, forget, and health observable.
+- [ ] Memory-off/native fallback, kill switches, migration rollback, adapter rollback, and release rollback are tested.
+- [ ] The full deterministic safety matrix passes and stochastic gates meet preregistered confidence bounds.
+- [ ] The new default is non-inferior across every critical stratum, materially better on target long-horizon tasks, and within frozen cost/latency/storage budgets.
+- [ ] TypeScript remains clean, full Vitest is green, required TUI/daemon/agent-surface gates pass, and release artifacts converge.
+- [ ] Documentation states actual defaults, storage, privacy, deletion limits, failure modes, and benchmark methodology.
+- [ ] Research sources and official repositories have been rechecked at the release date; claims are evidence-tiered and reproducible.
+
+If any safety invariant, migration/rollback proof, critical-stratum functional gate, or required repository gate is missing, the system remains opt-in/shadow and this plan is not complete.

--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -43,6 +43,14 @@ const DEFAULT_READY_TIMEOUT_MS = 45_000;
 const READY_POLL_MS = 50;
 /** Mirrors the daemon transports' 16 MiB max-line bound. */
 const MAX_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024;
+// These RPCs respond only after the full model/tool turn. They must not inherit
+// the short control-RPC timeout: SDK-backed agents may legitimately run for
+// hours. Explicit cancellation, socket closure, and daemon shutdown still
+// settle them.
+const UNBOUNDED_DAEMON_METHODS: ReadonlySet<AgencDaemonMethod> = new Set([
+  "message.send",
+  "message.stream",
+]);
 
 export function resolveAgencHome(
   env: NodeJS.ProcessEnv = process.env,
@@ -71,7 +79,7 @@ export function resolveDaemonCookiePath(
 interface PendingRequest {
   readonly resolve: (value: unknown) => void;
   readonly reject: (error: Error) => void;
-  readonly timeout: ReturnType<typeof setTimeout>;
+  readonly timeout: ReturnType<typeof setTimeout> | null;
 }
 
 export interface AgencSocketTransportOptions {
@@ -149,21 +157,23 @@ export class AgencSocketTransport implements AgencTransport {
       return Promise.reject(new Error("AgenC daemon connection is closed"));
     }
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.#pending.delete(request.id);
-        reject(
-          new Error(
-            `Timed out waiting for daemon response to ${request.method}`,
-          ),
-        );
-      }, this.#requestTimeoutMs);
+      const timeout = UNBOUNDED_DAEMON_METHODS.has(request.method)
+        ? null
+        : setTimeout(() => {
+            this.#pending.delete(request.id);
+            reject(
+              new Error(
+                `Timed out waiting for daemon response to ${request.method}`,
+              ),
+            );
+          }, this.#requestTimeoutMs);
       this.#pending.set(request.id, {
         resolve: (value) => {
-          clearTimeout(timeout);
+          if (timeout !== null) clearTimeout(timeout);
           resolve(value as AgencDaemonResponse<Method>);
         },
         reject: (error) => {
-          clearTimeout(timeout);
+          if (timeout !== null) clearTimeout(timeout);
           reject(error);
         },
         timeout,
@@ -226,7 +236,7 @@ export class AgencSocketTransport implements AgencTransport {
 
   #failAll(error: Error): void {
     for (const waiter of this.#pending.values()) {
-      clearTimeout(waiter.timeout);
+      if (waiter.timeout !== null) clearTimeout(waiter.timeout);
       waiter.reject(error);
     }
     this.#pending.clear();
@@ -259,7 +269,10 @@ export interface AgencConnectOptions {
   readonly agencCommand?: string | readonly string[];
   /** Total budget for autostart + readiness polling. Default 45s or `AGENC_DAEMON_READY_TIMEOUT_MS`. */
   readonly readyTimeoutMs?: number;
-  /** Per-request timeout. Default 30s or `AGENC_DAEMON_REQUEST_TIMEOUT_MS`. */
+  /**
+   * Per-request timeout for bounded control RPCs. Default 30s or
+   * `AGENC_DAEMON_REQUEST_TIMEOUT_MS`. Full-turn message RPCs are unbounded.
+   */
   readonly requestTimeoutMs?: number;
   readonly clientId?: string;
   readonly clientName?: string;

--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -134,15 +134,6 @@ import type { ThreadManager } from "./thread-manager.js";
  */
 const DEFAULT_MAX_AGENT_DEPTH = 1;
 
-/**
- * How long a keep-alive collab worker may sit `idle` between turns before the
- * control plane reclaims it as abandoned (frees its registry slot). Generous
- * enough to cover realistic assign_task reuse windows; any follow-up turn
- * flips the worker back to `running` and resets the clock.
- */
-const IDLE_KEEPALIVE_GRACE_MS = 10 * 60_000;
-/** Cadence of the abandoned keep-alive worker sweep. */
-const IDLE_KEEPALIVE_REAP_INTERVAL_MS = 60_000;
 const ROOT_FOLLOWUP_RETRY_BASE_MS = 100;
 const ROOT_FOLLOWUP_RETRY_MAX_MS = 5_000;
 
@@ -328,6 +319,8 @@ export interface LiveAgent {
   readonly memoryEntries: AgentMemoryEntry[];
   /** Cumulative child token usage. */
   readonly tokenUsage: AgentTokenUsage;
+  /** Cumulative tool calls observed by the child run loop. */
+  toolCallCount: number;
   /**
    * A control-plane assignment accepted while this reusable worker was idle.
    * The admission is installed synchronously with mailbox projection so a
@@ -387,7 +380,6 @@ export class AgentControl {
    *  and subtree cascade, since we have no state-db in-tree yet). */
   private readonly parentOf = new Map<ThreadId, ThreadId>();
   private threadManager: ThreadManager | undefined;
-  private idleReapTimer: ReturnType<typeof setInterval> | undefined;
   private rootFollowupInFlight = false;
   private rootFollowupRequested = false;
   private rootFollowupRetryAttempt = 0;
@@ -405,35 +397,6 @@ export class AgentControl {
     this.maxDepth =
       opts.maxDepth ?? resolveSessionMaxDepth(opts.session) ?? MAX_AGENT_DEPTH;
     this.threadManager = opts.threadManager;
-    this.startIdleKeepaliveReaper();
-  }
-
-  /**
-   * Reclaim abandoned keep-alive workers so they don't exhaust the 32-slot
-   * registry cap. A keep-alive collab worker parks in `idle` between turns
-   * waiting for `assign_task`, holding its registry slot; if the model never
-   * reuses or closes it, the slot leaks. Every interval, shut down spawned
-   * (non-root) workers that have been idle past IDLE_KEEPALIVE_GRACE_MS with
-   * no follow-up turn — a worker reused within the window goes back to
-   * `running` and is never reaped. The root/main agent (depth 0) is never
-   * reaped.
-   */
-  private startIdleKeepaliveReaper(): void {
-    this.idleReapTimer = setInterval(() => {
-      const now = performance.now();
-      const toReap: ThreadId[] = [];
-      for (const agent of this.live.values()) {
-        const status = agent.status.value;
-        if (status.status !== "idle") continue;
-        if (depthOfAgentPath(agent.agentPath) <= 0) continue;
-        if (now - status.endedAtMs < IDLE_KEEPALIVE_GRACE_MS) continue;
-        toReap.push(agent.agentId);
-      }
-      for (const threadId of toReap) {
-        void this.shutdown(threadId, "idle_keepalive_reap").catch(() => {});
-      }
-    }, IDLE_KEEPALIVE_REAP_INTERVAL_MS);
-    this.idleReapTimer.unref?.();
   }
 
   bindThreadManager(threadManager: ThreadManager): void {
@@ -763,6 +726,7 @@ export class AgentControl {
       messages: [],
       memoryEntries: [],
       tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      toolCallCount: 0,
     };
 
     const publishAgent = (): void => {
@@ -1537,6 +1501,7 @@ export class AgentControl {
       messages: [],
       memoryEntries: [],
       tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      toolCallCount: 0,
     };
 
     this.session.childInboxes.set(threadId, upInbox as unknown as never);

--- a/runtime/src/agents/jobs/job-orchestrator.ts
+++ b/runtime/src/agents/jobs/job-orchestrator.ts
@@ -57,7 +57,8 @@ export interface JobConfig {
   readonly instruction: string;
   readonly outputSchema?: Record<string, unknown>;
   readonly maxConcurrency: number;
-  readonly maxRuntimeSeconds: number;
+  /** Optional operator-supplied deadline. Omitted means unbounded. */
+  readonly maxRuntimeSeconds?: number;
 }
 
 export interface AgentJobSpawnContext {
@@ -76,8 +77,8 @@ export interface AgentJobSpawnOutcome {
    * `report_agent_job_result` and apply reference `finalize_finished_item`
    * guard at `agent_jobs.rs:992-1004` ("worker finished without calling
    * report_agent_job_result"). Adapters that cannot observe terminal
-   * status may omit this field; the orchestrator falls back to the
-   * `max_runtime_seconds` timeout in that case.
+   * status may omit this field; without an explicit `max_runtime_seconds`,
+   * the orchestrator then waits for a result or operator cancellation.
    */
   readonly threadFinished?: Promise<void>;
 }
@@ -155,7 +156,6 @@ export interface RunAgentsOnCsvResult {
 }
 
 const DEFAULT_MAX_CONCURRENCY = 16;
-const DEFAULT_MAX_RUNTIME_SECONDS = 1800;
 
 interface JobRuntimeState {
   readonly config: JobConfig;
@@ -297,7 +297,9 @@ export async function runAgentsOnCsv(
     instruction: opts.instruction,
     ...(opts.outputSchema !== undefined ? { outputSchema: opts.outputSchema } : {}),
     maxConcurrency: clampConcurrency(opts.maxConcurrency),
-    maxRuntimeSeconds: opts.maxRuntimeSeconds ?? DEFAULT_MAX_RUNTIME_SECONDS,
+    ...(opts.maxRuntimeSeconds !== undefined
+      ? { maxRuntimeSeconds: opts.maxRuntimeSeconds }
+      : {}),
   };
   const items = new Map<ItemId, JobItemRecord>();
   const itemSeed: Array<{
@@ -433,7 +435,7 @@ function clampConcurrency(
  * or from a half-finished prior dispatch).
  *
  * Branches mirror the reference policy:
- *   - Stale (age >= maxRuntimeSeconds): markItemFailed + shutdown thread
+ *   - Stale under an explicit maxRuntimeSeconds: mark failed + shut down
  *     (agent_jobs.rs:840-852)
  *   - Missing assigned_thread_id: markItemFailed (agent_jobs.rs:855-862)
  *   - Thread in final state: finalize from DB (agent_jobs.rs:877-885)
@@ -456,7 +458,10 @@ async function recoverRunningItems(state: JobRuntimeState): Promise<void> {
   for (const dbItem of running) {
     const inMemoryItem = state.items.get(dbItem.itemId);
     const ageSec = nowSec - dbItem.updatedAt;
-    if (ageSec >= runtimeTimeoutSec) {
+    if (
+      runtimeTimeoutSec !== undefined &&
+      ageSec >= runtimeTimeoutSec
+    ) {
       const message = `worker exceeded max runtime of ${runtimeTimeoutSec}s`;
       repository.markItemFailed(state.config.jobId, dbItem.itemId, message);
       if (inMemoryItem !== undefined) {
@@ -575,19 +580,13 @@ async function processItems(
     const completion = new Promise<void>((resolve, reject) => {
       state.pending.set(itemId, { resolve, reject });
     });
-    const runtimeBudgetMs = state.config.maxRuntimeSeconds * 1000;
-    // gaphunt3 #6: capture the watchdog handle so it can be cleared once the
-    // item completes; otherwise the timer stays armed for the full
-    // max_runtime_seconds budget (default 30min) after every completed row,
-    // leaking one live timer per row and pinning the event loop.
+    const runtimeBudgetMs =
+      state.config.maxRuntimeSeconds !== undefined
+        ? state.config.maxRuntimeSeconds * 1000
+        : undefined;
+    // Explicit operator deadlines still need their timer cleared as soon as
+    // another completion path wins the race.
     let runtimeTimer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<void>((_, reject) => {
-      runtimeTimer = setTimeout(
-        () => reject(new Error(`item ${itemId} exceeded max_runtime_seconds`)),
-        runtimeBudgetMs,
-      );
-      runtimeTimer.unref?.();
-    });
     item.attemptCount += 1;
     // Mirror reference ordering: status flips to running before the worker
     // can report. Thread_id is attached after spawn returns. On capacity
@@ -603,7 +602,21 @@ async function processItems(
           outcome.threadId,
         );
       }
-      const racers: Array<Promise<void>> = [completion, timeout];
+      const racers: Array<Promise<void>> = [completion];
+      if (runtimeBudgetMs !== undefined) {
+        racers.push(
+          new Promise<void>((_, reject) => {
+            runtimeTimer = setTimeout(
+              () =>
+                reject(
+                  new Error(`item ${itemId} exceeded max_runtime_seconds`),
+                ),
+              runtimeBudgetMs,
+            );
+            runtimeTimer.unref?.();
+          }),
+        );
+      }
       if (outcome?.threadFinished !== undefined) {
         racers.push(outcome.threadFinished);
       }
@@ -677,7 +690,7 @@ async function processItems(
       try {
         await spawn.cancelOutstanding(state.config.jobId);
       } catch {
-        /* cancellation is best-effort; the runtime timeout still bounds workers */
+        /* cancellation is best-effort */
       }
       for (const waiter of state.pending.values()) {
         waiter.resolve();
@@ -855,7 +868,9 @@ async function resumeSingleJob(
     instruction: job.instruction,
     ...(job.outputSchema !== undefined ? { outputSchema: job.outputSchema } : {}),
     maxConcurrency: clampConcurrency(opts.maxConcurrency),
-    maxRuntimeSeconds: job.maxRuntimeSeconds ?? DEFAULT_MAX_RUNTIME_SECONDS,
+    ...(job.maxRuntimeSeconds !== undefined
+      ? { maxRuntimeSeconds: job.maxRuntimeSeconds }
+      : {}),
   };
   const items = new Map<ItemId, JobItemRecord>();
   for (const dbItem of repository.listItems({ jobId })) {

--- a/runtime/src/agents/role.ts
+++ b/runtime/src/agents/role.ts
@@ -167,15 +167,13 @@ const BUILT_IN_ROLE_CONFIG_TOML = Object.freeze({
   "explorer.toml": "",
   // Upstream keeps awaiter temporarily removed from the built-in role set, but
   // still exposes the embedded role file for user-defined roles that reference
-  // `awaiter.toml`. The body matches the upstream
-  // `core/src/agent/builtins/awaiter.toml` byte-for-byte.
-  // Body content matches upstream `core/src/agent/builtins/awaiter.toml`.
+  // `awaiter.toml`. AgenC intentionally omits the historical one-hour terminal
+  // timeout: an awaiter must be able to observe work that runs for hours.
   // Upstream uses TOML's `"""..."""` multiline string for
   // `developer_instructions`; AgenC's TOML parser is escape-only
   // (no triple-quoted production), so the body is encoded with `\n`
   // escapes. The string value is identical post-parse.
-  "awaiter.toml": `background_terminal_max_timeout = 3600000
-model_reasoning_effort = "low"
+  "awaiter.toml": `model_reasoning_effort = "low"
 developer_instructions = "You are an awaiter.\\nYour role is to await the completion of a specific command or task and report its status only when it is finished.\\n\\nBehavior rules:\\n\\n1. When given a command or task identifier, you must:\\n   - Execute or await it using the appropriate tool\\n   - Continue awaiting until the task reaches a terminal state.\\n\\n2. You must NOT:\\n   - Modify the task.\\n   - Interpret or optimize the task.\\n   - Perform unrelated actions.\\n   - Stop awaiting unless explicitly instructed.\\n\\n3. Awaiting behavior:\\n   - If the task is still running, continue polling using tool calls.\\n   - Use repeated tool calls if necessary.\\n   - Do not hallucinate completion.\\n   - Use long timeouts when awaiting for something. If you need multiple awaits, increase the timeouts/yield times exponentially.\\n\\n4. If asked for status:\\n   - Return the current known status.\\n   - Immediately resume awaiting afterward.\\n\\n5. Termination:\\n   - Only exit awaiting when:\\n     - The task completes successfully, OR\\n     - The task fails, OR\\n     - You receive an explicit stop instruction.\\n\\nYou must behave deterministically and conservatively.\\n"`,
 } as const);
 

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -2689,11 +2689,26 @@ function terminalResultForLiveAgent(live: LiveAgent): ChildRunTerminalResult {
       };
     case "pending_init":
     case "running":
-    case "shutdown":
     case "not_found":
       return {
         status: "failed",
         stopReason: `subagent_shutdown_from_${status.status}`,
+        finalMessage: null,
+      };
+    case "shutdown":
+      if (
+        live.assignment === undefined &&
+        live.lastTaskReceipt?.outcome === "completed"
+      ) {
+        return {
+          status: "completed",
+          stopReason: "turn_completed",
+          finalMessage: null,
+        };
+      }
+      return {
+        status: "failed",
+        stopReason: "subagent_shutdown_from_shutdown",
         finalMessage: null,
       };
   }
@@ -2898,6 +2913,7 @@ export async function* runAgent(
   let childSession: ChildSession | null = null;
   let ownedChildProvider: LLMProvider | null = null;
   let childSandboxExecutionBroker: SandboxExecutionBrokerLike | undefined;
+  let unsubscribeChildUsage: (() => void) | null = null;
   let forwardMergedAbort: (() => void) | null = null;
   let roleTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
   let currentTaskId = params.taskId;
@@ -3401,6 +3417,16 @@ export async function* runAgent(
       params.taskPrompt,
     );
     const activeChildSession = childSession;
+    let sawTokenCountThisTurn = false;
+    unsubscribeChildUsage = activeChildSession.eventLog.subscribe((event) => {
+      if (event.msg.type !== "token_count") return;
+      sawTokenCountThisTurn = true;
+      const { promptTokens, completionTokens, totalTokens } = event.msg.payload;
+      live.tokenUsage.inputTokens += promptTokens ?? 0;
+      live.tokenUsage.outputTokens += completionTokens ?? 0;
+      live.tokenUsage.totalTokens +=
+        totalTokens ?? (promptTokens ?? 0) + (completionTokens ?? 0);
+    });
     let nextUserMessage: string | readonly LLMContentPart[] = userMessage;
     let firstTurn = true;
     let assistantText = "";
@@ -3459,6 +3485,7 @@ export async function* runAgent(
       currentTurnReceiptCommitted = false;
       currentCommittedReceipt = undefined;
       currentTurnToolCallCount = 0;
+      pendingWorkerTerminal = undefined;
       if (
         accepted.taskId !== undefined &&
         live.assignment?.taskId === accepted.taskId
@@ -3489,6 +3516,7 @@ export async function* runAgent(
       // (turn_complete below) when a follow-up turn starts, so each iteration
       // must re-assert `running` to flip the FSM idle -> running.
       live.status.markRunning(turnId);
+      sawTokenCountThisTurn = false;
       const chatOptions = startTurnCall();
       let turnAssistantText = "";
       let turnToolCallCount = 0;
@@ -3549,6 +3577,7 @@ export async function* runAgent(
           toolCallCount += 1;
           turnToolCallCount += 1;
           currentTurnToolCallCount += 1;
+          live.toolCallCount += 1;
           const recoveryCategory = recoveryCategoryForTool(
             childSession.services.registry,
             event.toolCall.name,
@@ -3599,12 +3628,19 @@ export async function* runAgent(
       stopTurnCall();
 
       assistantText = turnAssistantText;
-      if (turnUsage !== undefined) {
+      // Each sampling iteration emits a durable token_count event. The
+      // subscription above projects those counts immediately so a long,
+      // tool-using turn does not sit at `tokens 0` until it finishes. Retain
+      // terminal usage as a fallback for providers/paths that emitted no
+      // token_count event, but never add both representations of the turn.
+      if (turnUsage !== undefined && !sawTokenCountThisTurn) {
         live.tokenUsage.inputTokens += turnUsage.promptTokens ?? 0;
         live.tokenUsage.outputTokens += turnUsage.completionTokens ?? 0;
         live.tokenUsage.totalTokens +=
           turnUsage.totalTokens ??
           (turnUsage.promptTokens ?? 0) + (turnUsage.completionTokens ?? 0);
+      }
+      if (turnUsage !== undefined || sawTokenCountThisTurn) {
         yield {
           kind: "usage_update",
           inputTokens: live.tokenUsage.inputTokens,
@@ -3740,6 +3776,11 @@ export async function* runAgent(
         }
         if (reuseBlockedReason === undefined) {
           live.status.markIdle(completedTurnId);
+          pendingWorkerTerminal = {
+            status: "completed",
+            turnId: completedTurnId,
+            ...(assistantText ? { message: assistantText } : {}),
+          };
           // The completed receipt owns the previous correlation. While parked,
           // teardown is a worker-lifecycle event, not a second task outcome.
           currentTaskId = undefined;
@@ -3806,7 +3847,14 @@ export async function* runAgent(
     // If the caller aborted during the provider call, surface that
     // outcome instead of completion. `role_timeout` is a distinct
     // bucket routed through run_error so delegate.ts can retry.
-    if (merged.signal.aborted) {
+    const parkedCompletion =
+      params.keepAlive &&
+      currentTaskId === undefined &&
+      currentTurnReceiptCommitted &&
+      pendingWorkerTerminal?.status === "completed"
+        ? pendingWorkerTerminal
+        : undefined;
+    if (merged.signal.aborted && parkedCompletion === undefined) {
       const reason = String(merged.signal.reason ?? "aborted");
       if (!currentTurnReceiptCommitted) {
         const receiptCommitted = await commitTaskReceipt({
@@ -3880,14 +3928,17 @@ export async function* runAgent(
         };
       }
     }
-    pendingWorkerTerminal = {
-      status: "completed",
-      turnId,
-      ...(assistantText !== undefined ? { message: assistantText } : {}),
-    };
+    if (parkedCompletion === undefined) {
+      pendingWorkerTerminal = {
+        status: "completed",
+        turnId,
+        ...(assistantText !== undefined ? { message: assistantText } : {}),
+      };
+    }
+    const finalMessage = parkedCompletion?.message ?? assistantText;
     yield {
       kind: "run_complete",
-      ...(assistantText !== undefined ? { finalMessage: assistantText } : {}),
+      ...(finalMessage !== undefined ? { finalMessage } : {}),
       toolCallCount,
       ...taskCorrelation(),
     };
@@ -3896,7 +3947,7 @@ export async function* runAgent(
       threadId: live.agentId,
       durationMs: Date.now() - startedAt,
       outcome: "completed",
-      finalMessage: assistantText,
+      finalMessage,
       toolCallCount,
     };
   } catch (err) {
@@ -3976,6 +4027,8 @@ export async function* runAgent(
     if (forwardMergedAbort !== null) {
       merged.signal.removeEventListener("abort", forwardMergedAbort);
     }
+    unsubscribeChildUsage?.();
+    unsubscribeChildUsage = null;
     const cleanupErrors: unknown[] = [];
     let durableCloseError: unknown;
     if (childSandboxExecutionBroker !== undefined) {

--- a/runtime/src/agents/v2/wait.ts
+++ b/runtime/src/agents/v2/wait.ts
@@ -214,9 +214,12 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
       mutating: true,
       keywords: ["agent", "wait", "status"],
     }),
-    // Waiting drains delivered mailbox receipts into this turn.
+    // Draining already-durable local receipts mutates mailbox state, but the
+    // state transition is idempotent: replay after a completed drain is a
+    // no-op, while replay before a drain consumes the same durable records.
     isReadOnly: false,
-    recoveryCategory: "side-effecting",
+    recoveryCategory: "idempotent",
+    cancellationUsage: "zero",
     admissionEstimate: localZeroAdmissionEstimate,
     timeoutBehavior: "tool",
     inputSchema: {

--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -145,7 +145,6 @@ export interface AgenCJsonLineDaemonClientOptions {
 // invocation with AGENC_DAEMON_REQUEST_TIMEOUT_MS for read-only smoke checks
 // where a faster failure is preferable.
 const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 30_000;
-const DEFAULT_DAEMON_STREAM_REQUEST_TIMEOUT_MS = 30 * 60_000;
 const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV = "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
 const MAX_BUFFERED_SESSION_EVENT_SESSIONS = 50;
 // Must hold the full attach-time replay (user_message + early tool/stream
@@ -158,14 +157,16 @@ const MAX_BUFFERED_SESSION_EVENTS_PER_SESSION = 1000;
 // client memory unbounded. Mirrors the daemon transport's max-line / max
 // payload bound (16 MiB).
 const MAX_DAEMON_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024;
-const LONG_RUNNING_DAEMON_METHODS: ReadonlySet<AgenCDaemonKnownMethod> =
+// Agent turns and model-backed conversation maintenance have no wall-clock
+// deadline. They may legitimately remain live for hours while providers,
+// tools, approvals, or collaboration workers make progress. Explicit aborts,
+// request.cancel, socket closure, and daemon shutdown still terminate them.
+const UNBOUNDED_DAEMON_METHODS: ReadonlySet<AgenCDaemonKnownMethod> =
   new Set([
+    // Both message methods await the full daemon turn before responding.
+    "message.send",
     "message.stream",
-    // Compact and rewind both run an LLM summarization pass on the daemon,
-    // which easily exceeds the generic 30s RPC timeout on large transcripts
-    // or slow models. Give them the same long-running budget as streaming.
-    // (These are internal methods reached through the TUI daemon-session
-    // wrapper, which widens the persistent client's request overloads.)
+    // Compact and rewind can run model summarization over large transcripts.
     "session.partialCompactFromMessage",
     "session.rewindConversationToMessage",
   ]);
@@ -435,13 +436,14 @@ export function createAgenCJsonLineDaemonRequestClient(
   const timeoutMs =
     options.timeoutMs ?? resolveAgenCDaemonRequestTimeoutMs(options.env);
   return {
-    request: (method, params = {}, _options = {}) =>
+    request: (method, params = {}, requestOptions = {}) =>
       requestDaemon(
         method,
         params,
         socketPath,
         timeoutMs,
         options.authCookie ?? readDaemonCookie(cookiePath),
+        requestOptions.signal,
       ),
   };
 }
@@ -1043,10 +1045,8 @@ function defaultAgenCAgentAttachClientId(): string {
 function requestTimeoutMsForMethod(
   method: AgenCDaemonKnownMethod,
   timeoutMs: number,
-): number {
-  return LONG_RUNNING_DAEMON_METHODS.has(method)
-    ? DEFAULT_DAEMON_STREAM_REQUEST_TIMEOUT_MS
-    : timeoutMs;
+): number | null {
+  return UNBOUNDED_DAEMON_METHODS.has(method) ? null : timeoutMs;
 }
 
 function connectPersistentDaemonClient(
@@ -1060,7 +1060,7 @@ function connectPersistentDaemonClient(
       {
         readonly resolve: (value: unknown) => void;
         readonly reject: (error: Error) => void;
-        readonly timeout: ReturnType<typeof setTimeout>;
+        readonly timeout: ReturnType<typeof setTimeout> | null;
       }
     >();
     const sessionListeners = new Map<
@@ -1086,7 +1086,7 @@ function connectPersistentDaemonClient(
 
     const failPending = (error: Error) => {
       for (const waiter of pending.values()) {
-        clearTimeout(waiter.timeout);
+        if (waiter.timeout !== null) clearTimeout(waiter.timeout);
         waiter.reject(error);
       }
       pending.clear();
@@ -1148,27 +1148,30 @@ function connectPersistentDaemonClient(
             method,
             timeoutMs,
           );
-          const requestTimeout = setTimeout(() => {
-            // Tell the daemon to stop the orphaned work before rejecting
-            // locally: without request.cancel the daemon keeps running the
-            // request (e.g. a compact) and a retry hits "a turn is
-            // currently in flight". Must run before pending.delete(id) —
-            // sendCancel no-ops once the request is no longer pending.
-            sendCancel(`client timeout after ${requestTimeoutMs}ms`);
-            pending.delete(id);
-            removeAbortListener?.();
-            requestReject(
-              new Error(`Timed out waiting for daemon response to ${method}`),
-            );
-          }, requestTimeoutMs);
+          const requestTimeout =
+            requestTimeoutMs === null
+              ? null
+              : setTimeout(() => {
+                  // Tell the daemon to stop the orphaned work before rejecting
+                  // locally. Must run before pending.delete(id), because
+                  // sendCancel no-ops once the request is no longer pending.
+                  sendCancel(`client timeout after ${requestTimeoutMs}ms`);
+                  pending.delete(id);
+                  removeAbortListener?.();
+                  requestReject(
+                    new Error(
+                      `Timed out waiting for daemon response to ${method}`,
+                    ),
+                  );
+                }, requestTimeoutMs);
           pending.set(id, {
             resolve: (value) => {
-              clearTimeout(requestTimeout);
+              if (requestTimeout !== null) clearTimeout(requestTimeout);
               removeAbortListener?.();
               requestResolve(value);
             },
             reject: (error) => {
-              clearTimeout(requestTimeout);
+              if (requestTimeout !== null) clearTimeout(requestTimeout);
               removeAbortListener?.();
               requestReject(error);
             },
@@ -1300,7 +1303,7 @@ function handlePersistentDaemonMessage(
     {
       readonly resolve: (value: unknown) => void;
       readonly reject: (error: Error) => void;
-      readonly timeout: ReturnType<typeof setTimeout>;
+      readonly timeout: ReturnType<typeof setTimeout> | null;
     }
   >,
   sessionListeners: Map<string, Set<(event: JsonObject) => void>>,
@@ -1313,7 +1316,7 @@ function handlePersistentDaemonMessage(
     const waiter = pending.get(message.id);
     if (waiter === undefined) return;
     pending.delete(message.id);
-    clearTimeout(waiter.timeout);
+    if (waiter.timeout !== null) clearTimeout(waiter.timeout);
     const response = message as AgenCDaemonResponse;
     if (isErrorResponse(response)) {
       waiter.reject(new Error(response.error.message));
@@ -1470,8 +1473,28 @@ async function requestDaemon<Method extends AgenCDaemonMethod>(
   socketPath: string,
   timeoutMs: number,
   authCookie: string | Promise<string>,
+  signal?: AbortSignal,
 ): Promise<AgenCDaemonResultByMethod[Method]> {
   const resolvedAuthCookie = await authCookie;
+  if (UNBOUNDED_DAEMON_METHODS.has(method)) {
+    const client = await connectPersistentDaemonClient(socketPath, timeoutMs);
+    try {
+      await client.request("initialize", {
+        protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+        protocol: { version: AGENC_DAEMON_PROTOCOL_VERSION },
+        clientName: "agenc-agent-cli",
+        authCookie: resolvedAuthCookie,
+        capabilities: {},
+      });
+      return await client.request(
+        method,
+        params,
+        signal !== undefined ? { signal } : {},
+      );
+    } finally {
+      await client.close();
+    }
+  }
   const responses = await sendJsonLineRequestWithRetry(socketPath, timeoutMs, [
     {
       jsonrpc: JSON_RPC_VERSION,

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -2453,14 +2453,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     const active = this.#active.get(agentId);
     if (active === undefined || !isRunnableActiveAgent(active)) return DENIED;
     const requestId = ctx.callId;
-    // todo-109: default timeout so unattended pauses cannot hang forever.
-    const timeoutMsRaw = process.env.AGENC_PERMISSION_TIMEOUT_MS;
-    const timeoutMsParsed =
-      timeoutMsRaw !== undefined ? Number.parseInt(timeoutMsRaw, 10) : NaN;
-    const timeoutMs =
-      Number.isFinite(timeoutMsParsed) && timeoutMsParsed > 0
-        ? timeoutMsParsed
-        : 5 * 60 * 1000;
+    const timeoutMs = resolvePermissionDecisionTimeoutMs();
     const decision = new Promise<ReviewDecision>((resolve) => {
       let pendingForAgent = this.#pendingToolDecisions.get(agentId);
       if (pendingForAgent === undefined) {
@@ -2484,9 +2477,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         settle(ABORT);
       };
       ctx.signal?.addEventListener("abort", abort, { once: true });
-      timer = setTimeout(() => {
-        settle(TIMED_OUT);
-      }, timeoutMs);
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          settle(TIMED_OUT);
+        }, timeoutMs);
+      }
     });
     return decision;
   }
@@ -5397,6 +5392,15 @@ function hashStable(value: string): string {
     hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
   }
   return hash.toString(36);
+}
+
+export function resolvePermissionDecisionTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const raw = env.AGENC_PERMISSION_TIMEOUT_MS;
+  if (raw === undefined) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function readApprovalAgentId(ctx: ApprovalCtx): string | null {

--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -709,8 +709,10 @@ export function createWorkflowSessionSeams(
       });
       const startedAt = performance.now();
       const result = await runSupervisedProcess(command, {
-        timeoutMs: input.timeoutMs,
         maxOutputBytes: COMMAND_MAX_OUTPUT_BYTES,
+        ...(input.timeoutMs !== undefined
+          ? { timeoutMs: input.timeoutMs }
+          : {}),
       });
       return {
         exitCode:

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -85,7 +85,6 @@ import {
 } from "../../workflow/independent-review.js";
 import type { ReviewOutput } from "../../session/review.js";
 import {
-  DEFAULT_VERIFICATION_TIMEOUT_MS,
   parseVerificationVerdict,
   type WorkflowCommandRunner,
 } from "../../workflow/verification.js";
@@ -1092,7 +1091,6 @@ export class VerifiedChangeWorkflowController {
       const result = await this.#deps.commands.run({
         script: command.script,
         cwd: handle.path,
-        timeoutMs: DEFAULT_VERIFICATION_TIMEOUT_MS,
       });
       exitCode = result.exitCode;
       stdout = result.stdout;

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1092,7 +1092,6 @@ export async function bootstrapLocalRuntimeSession(
   );
   const unifiedExecManager = new UnifiedExecProcessManager({
     cwd: workspaceRoot,
-    maxTimeoutMs: 300_000,
   });
   const codeModeService = createCodeModeService({ env });
   let sessionRef: Session | null = null;

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -1152,8 +1152,8 @@ function buildGrokNativeXSearchProvider(
     return providerFactory("grok", {
       ...factoryOptions,
       tools: [],
-      // Native x_search agentic loops can exceed the default 120s request timeout.
-      timeoutMs: Math.max(factoryOptions.timeoutMs ?? 0, 300_000),
+      // Preserve only an operator-supplied timeout. Native x_search agentic
+      // loops are otherwise unbounded like every other model call.
       extra,
     });
   } catch {
@@ -1798,7 +1798,7 @@ function createMultiAgentV2RuntimeTools(opts: ModelFacingToolOptions): readonly 
           max_runtime_seconds: {
             type: "number",
             description:
-              "Maximum runtime per worker before it is failed. Defaults to 1800 seconds.",
+              "Optional maximum runtime per worker before it is failed. Omit for no runtime deadline.",
           },
           output_schema: { type: "object" },
         },

--- a/runtime/src/budget/admitted-tool-call.ts
+++ b/runtime/src/budget/admitted-tool-call.ts
@@ -586,7 +586,19 @@ export async function runAdmittedToolCall(
     if (settled) {
       throw error;
     } else if (dispatched && dispatch.context.signal.aborted) {
-      client.holdUnknown(reservationId, "tool_cancelled_after_dispatch");
+      if (
+        params.tool.cancellationUsage === "zero" &&
+        isZeroBound(estimate)
+      ) {
+        client.reconcile(reservationId, {
+          inputTokens: 0,
+          outputTokens: 0,
+          costUsd: 0,
+        });
+      } else {
+        client.holdUnknown(reservationId, "tool_cancelled_after_dispatch");
+      }
+      settled = true;
     } else if (dispatched && isZeroBound(estimate)) {
       client.reconcile(reservationId, {
         inputTokens: 0,

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -486,8 +486,7 @@ export interface ProviderConfig {
   /**
    * Provider request timeout in milliseconds. For streaming responses this
    * is the inter-chunk idle timeout, not a total-stream deadline. 0 disables
-   * the timeout entirely. Unset falls back to the provider's built-in
-   * default.
+   * the timeout entirely. Unset is unbounded.
    */
   readonly timeout_ms?: number;
   readonly capability_overrides?: ProviderCapabilityOverrides;
@@ -968,16 +967,10 @@ export function defaultConfig(): AgenCConfig {
       "pyproject.toml",
     ]) as readonly string[],
     project_doc_max_bytes: 32_768,
-    // xAI generates function-call arguments server-side with ZERO bytes on
-    // the wire (no SSE keepalives — measured 51s of total silence for a
-    // ~250-line file, 2026-07-22). Any watchdog window shorter than the
-    // largest plausible argument generation kills healthy streams and forces
-    // full-regeneration reconnect loops. 5 minutes tolerates ~1500-line
-    // files. 600s matches xAI's documented per-chunk idle default
-    // (build/enterprise docs; proxy guidance is >=10 minutes). Stall
-    // detection degrades gracefully (true disconnects still usually
-    // surface as socket errors immediately).
-    stream_watchdog_timeout_ms: 600_000,
+    // No default stream-idle deadline. Providers can remain silent for hours
+    // while reasoning or generating large tool payloads; transport failures
+    // still surface as socket errors. Operators may opt in by setting
+    // stream_watchdog_timeout_ms explicitly.
     // No default turn cap. Interactive / long-running agents stop on the
     // model’s own stop signal (or explicit cancel / budget). Operators who
     // want a runaway-loop backstop can set `max_turns` or AGENC_MAX_TURNS.

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -103,11 +103,9 @@ export interface AgentRunInputs {
 
 export interface AgentRunConfig {
   readonly overlay: AgentOverlay;
+  /** Optional operator-supplied deadline. Omitted means unbounded. */
   readonly agentTimeoutMs?: number;
 }
-
-export const DEFAULT_AGENT_TIMEOUT_MS = 1_800_000;
-
 
 export async function assertOverlayLayout(
   overlay: AgentOverlay,
@@ -286,7 +284,7 @@ async function readResultAndCollect(params: {
   readonly runner: ContainerRunner;
   readonly handle: ContainerHandle;
   readonly executed: ContainerExecResult;
-  readonly agentTimeoutMs: number;
+  readonly agentTimeoutMs?: number;
   readonly timeouts: PreflightTimeouts;
   readonly onSpecialExit?: (
     exitCode: number,
@@ -309,7 +307,14 @@ async function readResultAndCollect(params: {
   const base = { agent, rawAgentResult: resultRead.stdout, patch: null, patchBytes: null } as const;
   const special = executed.exitCode !== null ? params.onSpecialExit?.(executed.exitCode) : null;
   if (executed.timedOut) {
-    return { ...base, outcome: "agent_timeout", failureDetail: `agent exceeded ${agentTimeoutMs}ms` };
+    return {
+      ...base,
+      outcome: "agent_timeout",
+      failureDetail:
+        agentTimeoutMs === undefined
+          ? "agent timed out"
+          : `agent exceeded ${agentTimeoutMs}ms`,
+    };
   }
   if (special) {
     return { ...base, outcome: special.outcome, failureDetail: special.failureDetail };
@@ -442,7 +447,7 @@ export async function runAgentOnTask(
   let collect: CollectResult | null = null;
   let outcome: AgentRunOutcome | null = null;
   let failureDetail: string | null = null;
-  const agentTimeoutMs = config.agentTimeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS;
+  const agentTimeoutMs = config.agentTimeoutMs;
 
   try {
     handle = await runner.createTaskContainer(inputs.task.image, {
@@ -453,13 +458,13 @@ export async function runAgentOnTask(
     await applySetupAndPrompt(runner, handle, inputs.setupPatch, prompt, timeouts);
     const executed = await runner.exec(handle, {
       script: buildAgentScript(),
-      timeoutMs: agentTimeoutMs,
+      ...(agentTimeoutMs !== undefined ? { timeoutMs: agentTimeoutMs } : {}),
     });
     collect = await readResultAndCollect({
       runner,
       handle,
       executed,
-      agentTimeoutMs,
+      ...(agentTimeoutMs !== undefined ? { agentTimeoutMs } : {}),
       timeouts,
       onSpecialExit: (code) =>
         code === 86
@@ -643,7 +648,7 @@ export async function runRealProviderAgentOnTask(
   let failureDetail: string | null = null;
   let probes: EgressContainmentProbes = ALL_FALSE_PROBES;
   let patchKeyScan: EgressReport["patchKeyScan"] = "not-run";
-  const agentTimeoutMs = config.agentTimeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS;
+  const agentTimeoutMs = config.agentTimeoutMs;
 
   let lane: Awaited<ReturnType<EgressLaneFactory>> | null = null;
   try {
@@ -671,10 +676,16 @@ export async function runRealProviderAgentOnTask(
           model: config.model,
           baseUrl: config.baseUrl,
         }),
-        timeoutMs: agentTimeoutMs,
+        ...(agentTimeoutMs !== undefined ? { timeoutMs: agentTimeoutMs } : {}),
         envPassthrough: [config.keyEnvVar],
       });
-      collect = await readResultAndCollect({ runner, handle, executed, agentTimeoutMs, timeouts });
+      collect = await readResultAndCollect({
+        runner,
+        handle,
+        executed,
+        ...(agentTimeoutMs !== undefined ? { agentTimeoutMs } : {}),
+        timeouts,
+      });
       outcome = collect.outcome;
       failureDetail = collect.failureDetail;
       // Scan for the key across the patch AND the agent's own output (a

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -30,7 +30,7 @@ interface SpawnResult {
 }
 
 interface SpawnBoundedOptions {
-  readonly timeoutMs: number;
+  readonly timeoutMs?: number;
   readonly stdin?: Uint8Array;
   readonly maxOutputBytes?: number;
 }
@@ -68,16 +68,19 @@ function spawnBounded(
     child.stderr?.on("data", (chunk: Buffer) => {
       stderr = capture(stderr, chunk);
     });
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, options.timeoutMs);
+    const timer =
+      options.timeoutMs !== undefined && options.timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGKILL");
+          }, options.timeoutMs)
+        : undefined;
     child.once("error", (error) => {
-      clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
       reject(new EvalExecutorError([`failed to spawn ${command}: ${error.message}`]));
     });
     child.once("close", (code) => {
-      clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
       resolve({
         exitCode: code,
         stdout: stdout.toString("utf8"),
@@ -425,7 +428,14 @@ export class DockerContainerRunner implements ContainerRunner {
     return spawnBounded(
       "docker",
       ["exec", ...envArgs, "-w", handle.workdir, handle.id, "bash", "-c", request.script],
-      { timeoutMs: request.timeoutMs, maxOutputBytes: request.maxOutputBytes },
+      {
+        ...(request.timeoutMs !== undefined
+          ? { timeoutMs: request.timeoutMs }
+          : {}),
+        ...(request.maxOutputBytes !== undefined
+          ? { maxOutputBytes: request.maxOutputBytes }
+          : {}),
+      },
     );
   }
 

--- a/runtime/src/eval-executor/index.ts
+++ b/runtime/src/eval-executor/index.ts
@@ -4,7 +4,6 @@ export {
   buildBaselineGitScript,
   buildCandidateCollectionScript,
   buildRealProviderAgentScript,
-  DEFAULT_AGENT_TIMEOUT_MS,
   EVAL_BASELINE_TAG,
   runAgentOnTask,
   runRealProviderAgentOnTask,

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -99,7 +99,8 @@ export interface ContainerHandle {
 export interface ContainerExecRequest {
   /** POSIX shell script executed with `bash -c` inside the workdir. */
   readonly script: string;
-  readonly timeoutMs: number;
+  /** Optional operator-supplied deadline. Omitted means unbounded. */
+  readonly timeoutMs?: number;
   /**
    * Per-call host capture cap. Defaults to
    * `EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES`; raised only for the

--- a/runtime/src/llm/client-session.ts
+++ b/runtime/src/llm/client-session.ts
@@ -3,7 +3,8 @@
  *
  * Ports the upstream runtime provider/session contract into the runtime-facing
  * TypeScript client layer: provider-level query params, auth/header injection,
- * bounded retry budgets, stream idle timeouts, and explicit wire-api metadata.
+ * bounded retry budgets, operator-configurable stream idle timeouts, and
+ * explicit wire-api metadata. Stream idle timeouts are disabled by default.
  *
  * @module
  */

--- a/runtime/src/llm/providers/grok/adapter.ts
+++ b/runtime/src/llm/providers/grok/adapter.ts
@@ -46,7 +46,10 @@ import {
   parseStructuredOutputText,
   supportsXaiReasoningEffortParam,
 } from "../../structured-output.js";
-import { withTimeout } from "../../timeout.js";
+import {
+  externalAbortReasonToError,
+  withTimeout,
+} from "../../timeout.js";
 import { repairToolTurnSequence, validateToolTurnSequence } from "../../tool-turn-validator.js";
 import type { GrokProviderConfig } from "./types.js";
 import {
@@ -99,7 +102,6 @@ import {
 } from "../../registry/provider-info.js";
 
 const DEFAULT_VISION_MODEL = "grok-4-0709";
-const DEFAULT_TIMEOUT_MS = 120_000;
 
 /**
  * Streamed raw reasoning (`response.reasoning_text.delta`) rides the
@@ -109,15 +111,6 @@ const DEFAULT_TIMEOUT_MS = 120_000;
  */
 const RAW_REASONING_SUMMARY_INDEX_OFFSET = 10_000;
 
-/**
- * Default inter-chunk idle tolerance for STREAMS (chatStream) when no
- * provider timeout is configured. Distinct from DEFAULT_TIMEOUT_MS (120s,
- * request-open): xAI emits nothing at all while generating function-call
- * arguments, and 120s of tolerance kills healthy streams generating large
- * files, forcing full-regeneration retry loops that never converge. An
- * explicitly configured `timeout_ms` still wins.
- */
-const STREAM_SILENT_GENERATION_TIMEOUT_MS = 600_000;
 // MAX_TOOL_SCHEMA_CHARS_FOLLOWUP removed 2026-04-09: see buildParams() comment
 // near `selectedTools.tools.length > 0`. The 20K limit was silently dropping
 // the entire tools array on every tool-followup request.
@@ -187,18 +180,69 @@ function createStreamTimeoutError(providerName: string, timeoutMs: number): Erro
   return err;
 }
 
-// gaphunt3 #21: caller-abort error for the open-stream chunk loop. Shaped as an
-// AbortError so it propagates/maps the same way as a one-shot abort.
-function createStreamAbortError(providerName: string): Error {
-  const err = new Error(`${providerName} stream aborted by caller`);
-  (err as { name?: string }).name = "AbortError";
-  (err as { code?: string }).code = "ABORT_ERR";
-  return err;
+// gaphunt3 #21/#42: caller cancellation is not a provider timeout. Preserve
+// the external signal's reason (when present) and deliberately avoid the
+// AbortError/ABORT_ERR shape, which mapLLMError classifies as a retryable
+// timeout.
+function createStreamAbortError(
+  providerName: string,
+  externalSignal?: AbortSignal,
+): Error {
+  if (externalSignal) {
+    return externalAbortReasonToError(
+      externalSignal,
+      `${providerName} stream aborted by caller`,
+    );
+  }
+  return new Error(`${providerName} stream aborted by caller`);
+}
+
+/**
+ * The OpenAI-compatible SDK used for xAI installs its own unconditional
+ * ten-minute header timeout when `timeout` is omitted. AgenC owns timeout and
+ * cancellation policy outside the SDK, so replace only that transport seam:
+ * explicit AgenC timeouts still arrive through `withTimeout`, while an
+ * unconfigured request can remain open indefinitely.
+ */
+function installAgenCManagedSdkFetch(client: any): void {
+  if (typeof client?.fetch !== "function") return;
+  client.fetchWithTimeout = async (
+    url: string,
+    init: (RequestInit & { duplex?: "half" }) | undefined,
+    _sdkTimeoutMs: number,
+    controller: AbortController,
+  ): Promise<Response> => {
+    const { signal, method, ...options } = init ?? {};
+    const abort = () => {
+      if (!controller.signal.aborted) controller.abort(signal?.reason);
+    };
+    if (signal) {
+      if (signal.aborted) abort();
+      else signal.addEventListener("abort", abort, { once: true });
+    }
+    const isReadableBody =
+      (globalThis.ReadableStream &&
+        options.body instanceof globalThis.ReadableStream) ||
+      (typeof options.body === "object" &&
+        options.body !== null &&
+        Symbol.asyncIterator in options.body);
+    const fetchOptions: RequestInit & { duplex?: "half" } = {
+      signal: controller.signal,
+      ...(isReadableBody ? { duplex: "half" as const } : {}),
+      method: method?.toUpperCase() ?? "GET",
+      ...options,
+    };
+    try {
+      return await client.fetch.call(undefined, url, fetchOptions);
+    } finally {
+      signal?.removeEventListener("abort", abort);
+    }
+  };
 }
 
 function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
-    return DEFAULT_TIMEOUT_MS;
+    return undefined;
   }
   if (timeoutMs <= 0) {
     return undefined;
@@ -288,7 +332,7 @@ function resolveRequestTimeoutMs(
   return {
     configuredProviderTimeoutMs,
     callOverrideTimeoutMs,
-    timeoutMs: DEFAULT_TIMEOUT_MS,
+    timeoutMs: undefined,
     source: "provider_default",
   };
 }
@@ -311,7 +355,7 @@ async function nextStreamChunkWithTimeout<T>(
   // chunk so a mid-stream cancel cannot block on a slow iterator.next().
   if (externalSignal?.aborted) {
     await closeAsyncIterator(iterator);
-    throw createStreamAbortError(providerName);
+    throw createStreamAbortError(providerName, externalSignal);
   }
 
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -348,7 +392,8 @@ async function nextStreamChunkWithTimeout<T>(
     }, effectiveTimeoutMs);
   }
   if (externalSignal) {
-    abortHandler = () => interrupt(createStreamAbortError(providerName));
+    abortHandler = () =>
+      interrupt(createStreamAbortError(providerName, externalSignal));
     externalSignal.addEventListener("abort", abortHandler, { once: true });
   }
 
@@ -370,7 +415,7 @@ async function nextStreamChunkWithTimeout<T>(
     if (interruption.error !== undefined) throw interruption.error;
     if (outcome.kind === "error") throw outcome.error;
     if (outcome.kind === "interrupted") {
-      throw createStreamAbortError(providerName);
+      throw createStreamAbortError(providerName, externalSignal);
     }
     return outcome.result;
   } finally {
@@ -804,18 +849,6 @@ export class GrokProvider implements LLMProvider {
   >();
   private readonly toolChars: number;
   private readonly configuredTimeoutMs: number | undefined;
-  /**
-   * xAI buffers function-call argument generation server-side: measured 51s
-   * of ZERO bytes (no SSE keepalives) for a ~250-line file (2026-07-22).
-   * A healthy stream is indistinguishable from a stall during that window
-   * at every layer the client can observe, so the session watchdog must
-   * tolerate silence at least as long as the largest plausible argument
-   * payload. 600s matches xAI's OWN documented per-chunk idle default
- * (docs: build/enterprise — "per-chunk idle timeout defaults to 600
- * seconds", proxy guidance ≥10 minutes; docs/tools/function-calling
- * WARNING confirms whole-in-one-chunk function calls by design).
-   */
-  readonly suggestedStreamIdleTimeoutMs = STREAM_SILENT_GENERATION_TIMEOUT_MS;
 
   constructor(config: GrokProviderConfig) {
     this.configuredTimeoutMs = config.timeoutMs;
@@ -1299,26 +1332,12 @@ export class GrokProvider implements LLMProvider {
       this.configuredTimeoutMs,
       options?.timeoutMs,
     );
-    // Streams get a larger idle default than request-open: the inter-chunk
-    // wait must survive xAI's silent server-side function-call argument
-    // generation (see STREAM_SILENT_GENERATION_TIMEOUT_MS). Explicit
-    // provider config / call overrides are respected unchanged.
-    const streamTimeout =
-      resolvedStreamTimeout.source === "provider_default"
-        ? {
-            ...resolvedStreamTimeout,
-            timeoutMs: STREAM_SILENT_GENERATION_TIMEOUT_MS,
-          }
-        : resolvedStreamTimeout;
-    // The resolved timeout is inter-chunk idle time, not a total-stream
-    // deadline. A healthy stream that keeps producing chunks must never be
-    // torn down by elapsed wall-clock time alone: long reasoning turns
-    // routinely stream for longer than any sane per-request timeout, and
-    // aborting them forces a full re-stream that repays the entire cost
-    // (tetsuo 2026-07-20: grok-4.5 turns died at the old 120s total deadline
-    // mid-stream, retried from zero, and looped). Silent-stall protection is
-    // preserved: each chunk wait re-arms the same timeout, so a stream that
-    // stops producing chunks for timeoutMs still aborts.
+    const streamTimeout = resolvedStreamTimeout;
+    // There is no implicit request-open or inter-chunk deadline. A healthy
+    // xAI stream can emit zero bytes for hours while reasoning or generating
+    // one large function-call argument payload. When an operator explicitly
+    // configures timeout_ms, that value remains an inter-chunk idle timeout
+    // rather than a total-stream deadline.
 
     let consecutiveFallbackFailures = 0;
     while (true) {
@@ -1454,7 +1473,7 @@ export class GrokProvider implements LLMProvider {
         // opens, so re-check it here and inside nextStreamChunkWithTimeout
         // (which rejects when the signal fires while awaiting the next chunk).
         if (options?.signal?.aborted) {
-          throw createStreamAbortError(this.name);
+          throw createStreamAbortError(this.name, options.signal);
         }
         // Idle timeout: the full resolved timeout re-arms on every chunk wait.
         // nextStreamChunkWithTimeout throws the stream-stalled error when no
@@ -2021,12 +2040,14 @@ export class GrokProvider implements LLMProvider {
 
     this.client = await ensureLazyImport("openai", this.name, (mod) => {
       const ProviderSdk = (mod.default ?? mod.OpenAI ?? mod) as any; // branding-scan: allow real SDK export
-      return new ProviderSdk({
+      const client = new ProviderSdk({
         apiKey: this.config.apiKey,
         baseURL: this.config.baseURL,
         timeout: this.config.timeoutMs,
         maxRetries: this.config.maxRetries ?? 2,
       });
+      installAgenCManagedSdkFetch(client);
+      return client;
     });
     return this.client;
   }

--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -44,7 +44,7 @@ function mergeDerivedProviderModels(
   return Object.freeze(merged);
 }
 
-const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 300_000;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 0;
 const DEFAULT_STREAM_MAX_RETRIES = 5;
 const DEFAULT_REQUEST_MAX_RETRIES = 4;
 const DEFAULT_WEBSOCKET_CONNECT_TIMEOUT_MS = 15_000;

--- a/runtime/src/llm/stream-watchdog.ts
+++ b/runtime/src/llm/stream-watchdog.ts
@@ -6,9 +6,10 @@
  * `client.rs:1146`
  * (`stream_idle_timeout_ms` from provider info).
  *
- * AgenC gates behind `AGENC_ENABLE_STREAM_WATCHDOG` env var
- * (opt-in). AgenC ships default-on because silent provider stalls
- * are pure latency burn; opt-out is `AGENC_DISABLE_STREAM_WATCHDOG=1`.
+ * The watchdog has no implicit deadline. Operators may opt in with a
+ * positive `AGENC_STREAM_IDLE_TIMEOUT_MS` value or an explicit runtime
+ * configuration value; `0` disables it. This keeps long silent reasoning and
+ * tool-argument generation valid for arbitrarily long turns.
  *
  * Timers use monotonic clock (I-82) via `monotonicMs()` — immune to
  * NTP corrections, `date` set, suspend/resume, container clock skew.
@@ -31,17 +32,16 @@
 import { monotonicMs } from "./_deps/monotonic.js";
 
 /**
- * Default idle timeout. Override
- * via env `AGENC_STREAM_IDLE_TIMEOUT_MS` (positive integer) or via
- * explicit `timeoutMs` option on `installStreamWatchdog`.
+ * There is deliberately no default idle timeout. A positive operator value is
+ * required to install a deadline.
  */
-const STREAM_IDLE_TIMEOUT_MS_DEFAULT = 90_000;
+const STREAM_IDLE_TIMEOUT_MS_DEFAULT = 0;
 
 export function resolveStreamIdleTimeoutMs(preferredMs?: number): number {
   const raw = process.env.AGENC_STREAM_IDLE_TIMEOUT_MS;
-  if (raw) {
+  if (raw !== undefined && raw.trim() !== "") {
     const n = Number.parseInt(raw, 10);
-    if (Number.isFinite(n) && n > 0) return n;
+    if (Number.isFinite(n) && n >= 0) return Math.trunc(n);
   }
   // `preferredMs` carries config (`stream_watchdog_timeout_ms`) or a
   // provider-declared tolerance (e.g. grok's silent tool-argument
@@ -57,16 +57,10 @@ export function resolveStreamIdleTimeoutMs(preferredMs?: number): number {
 }
 
 /**
- * Session-level idle-timeout resolution: env (unconditional operator
- * escape hatch) > effective preference > 90s default, where the effective
- * preference applies the provider suggestion as a FLOOR over the
- * `stream_watchdog_timeout_ms` config value. Providers with silent
- * server-side generation phases (xAI emits zero bytes — not even SSE
- * keepalives — while generating function-call arguments; 51s measured for
- * a ~250-line file) declare a tolerance below which any window is
- * guaranteed to kill healthy streams, so shorter configured values
- * (e.g. the stale 30s scaffold default in old config.toml files) must not
- * win over it.
+ * Session-level idle-timeout resolution: env > explicit config > disabled.
+ * A provider suggestion may raise an explicitly configured timeout, but it
+ * never creates a deadline by itself. Provider silence is not evidence of a
+ * dead turn, and healthy agent/model calls may remain silent for hours.
  */
 export function resolveSessionStreamIdleTimeoutMs(input: {
   readonly configuredMs?: number;
@@ -84,16 +78,20 @@ export function resolveSessionStreamIdleTimeoutMs(input: {
     input.providerSuggestedMs > 0
       ? input.providerSuggestedMs
       : undefined;
+  if (configured === undefined) {
+    return resolveStreamIdleTimeoutMs();
+  }
   const preferred =
     suggested !== undefined
-      ? Math.max(configured ?? 0, suggested)
+      ? Math.max(configured, suggested)
       : configured;
   return resolveStreamIdleTimeoutMs(preferred);
 }
 
 /**
- * Whether the watchdog is enabled. AgenC ships default-on; opt-out
- * via `AGENC_DISABLE_STREAM_WATCHDOG=1`.
+ * Whether an explicitly configured watchdog is allowed to run. The timeout
+ * resolver still returns `0` by default, so this gate alone never creates a
+ * deadline. Opt out via `AGENC_DISABLE_STREAM_WATCHDOG=1`.
  */
 export function isStreamWatchdogEnabled(): boolean {
   const raw = process.env.AGENC_DISABLE_STREAM_WATCHDOG;
@@ -121,7 +119,7 @@ export interface StreamWatchdogHandle {
   stop(): void;
   /** Whether this watchdog already fired. */
   readonly firedAt: number | null;
-  /** Scheduled idle-timeout in ms (reflects env + override). */
+  /** Scheduled idle-timeout in ms; `0` means disabled. */
   readonly timeoutMs: number;
 }
 
@@ -130,8 +128,8 @@ export interface InstallStreamWatchdogOptions {
    *  watchdog signals the stream's abort channel to tear down the
    *  in-flight request. */
   readonly abortController: AbortController;
-  /** Override for the idle timeout. Defaults to env / built-in
-   *  constant. Pass 0 to disable explicitly (returns a no-op handle). */
+  /** Override for the idle timeout. Defaults to env / disabled. Pass 0 to
+   *  disable explicitly (returns a no-op handle). */
   readonly timeoutMs?: number;
   /** Callback fired exactly once when the timer expires, before the
    *  `abortController.abort(...)` call. Emit I-8 `stream_error` here. */

--- a/runtime/src/llm/timeout.ts
+++ b/runtime/src/llm/timeout.ts
@@ -21,18 +21,38 @@ function createAbortTimeoutError(
 // AbortError name / ABORT_ERR code). Downstream abort handling already relies on
 // the AbortSignal's own `aborted` flag, not on this error's name/code, so the
 // non-AbortError shape here is safe.
-function createExternalAbortError(
-  providerName: string,
+export function externalAbortReasonToError(
   externalSignal: AbortSignal,
+  fallbackMessage: string,
 ): Error {
   const reason = (externalSignal as { reason?: unknown }).reason;
   if (reason instanceof Error) {
+    const code = (reason as Error & { code?: unknown }).code;
+    if (reason.name === "AbortError" || code === "ABORT_ERR") {
+      // AbortController.abort() without an explicit reason creates a
+      // DOMException named AbortError. Passing that object through would make
+      // mapLLMError relabel a caller interrupt as a provider timeout. Preserve
+      // it as the cause while removing the timeout-shaped outer identity.
+      const normalized = new Error(reason.message || fallbackMessage);
+      (normalized as Error & { cause?: unknown }).cause = reason;
+      return normalized;
+    }
     return reason;
   }
   if (typeof reason === "string" && reason.length > 0) {
     return new Error(reason);
   }
-  return new Error(`${providerName} request aborted by external signal`);
+  return new Error(fallbackMessage);
+}
+
+function createExternalAbortError(
+  providerName: string,
+  externalSignal: AbortSignal,
+): Error {
+  return externalAbortReasonToError(
+    externalSignal,
+    `${providerName} request aborted by external signal`,
+  );
 }
 
 /**

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -891,11 +891,9 @@ export interface LLMProvider {
   readonly name: string;
   /**
    * Longest wire silence this provider's healthy streams are known to
-   * produce, for the session-level stream watchdog. xAI generates
-   * function-call arguments entirely server-side with zero bytes on the
-   * wire (no SSE keepalives), so grok declares a multi-minute tolerance;
-   * providers that stream continuously leave this unset and get the
-   * default. Env/config overrides win over this suggestion.
+   * produce, used only as a floor when an operator explicitly enables the
+   * session-level stream watchdog. A suggestion never creates a deadline;
+   * unconfigured streams remain unbounded.
    */
   readonly suggestedStreamIdleTimeoutMs?: number;
   chat(messages: LLMMessage[], options?: LLMChatOptions): Promise<LLMResponse>;

--- a/runtime/src/mcp-client/tools.ts
+++ b/runtime/src/mcp-client/tools.ts
@@ -193,7 +193,10 @@ function modelFacingMcpToolDescription(
 }
 
 const DEFAULT_MCP_LIST_TOOLS_TIMEOUT_MS = 30_000;
-const DEFAULT_MCP_CALL_TIMEOUT_MS = 45_000;
+// @modelcontextprotocol/sdk always installs a request timer. Use Node's
+// largest safe timer window and reset it on progress when no operator timeout
+// was configured; AgenC itself imposes no MCP tool-call deadline.
+const MCP_SDK_UNBOUNDED_WINDOW_MS = 2_147_483_647;
 const MCP_REQUEST_PERMISSIONS_TOOL_NAME = "request_permissions";
 const MCP_RAW_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 
@@ -809,16 +812,17 @@ async function callRequestPermissionsTool(
 
 async function withRPCDeadline<T>(
   operation: string,
-  timeoutMs: number,
+  timeoutMs: number | undefined,
   task: (signal: AbortSignal) => Promise<T>,
   callerSignal?: AbortSignal,
 ): Promise<T> {
   callerSignal?.throwIfAborted();
 
   const controller = new AbortController();
-  const timeoutError = new Error(
-    `${operation} timed out after ${timeoutMs}ms`,
-  );
+  const timeoutError =
+    timeoutMs === undefined
+      ? undefined
+      : new Error(`${operation} timed out after ${timeoutMs}ms`);
   let timedOut = false;
   const forwardCallerAbort = (): void => {
     if (!controller.signal.aborted) {
@@ -826,10 +830,13 @@ async function withRPCDeadline<T>(
     }
   };
   callerSignal?.addEventListener("abort", forwardCallerAbort, { once: true });
-  const timer = setTimeout(() => {
-    timedOut = true;
-    if (!controller.signal.aborted) controller.abort(timeoutError);
-  }, timeoutMs);
+  const timer =
+    timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+          timedOut = true;
+          if (!controller.signal.aborted) controller.abort(timeoutError);
+        }, timeoutMs);
 
   try {
     // Abort the physical RPC on cancellation/deadline, but do not settle this
@@ -838,14 +845,14 @@ async function withRPCDeadline<T>(
     // abort-ignoring MCP request is still live.
     const result = await task(controller.signal);
     callerSignal?.throwIfAborted();
-    if (timedOut) throw timeoutError;
+    if (timedOut && timeoutError !== undefined) throw timeoutError;
     return result;
   } catch (error) {
     callerSignal?.throwIfAborted();
-    if (timedOut) throw timeoutError;
+    if (timedOut && timeoutError !== undefined) throw timeoutError;
     throw error;
   } finally {
-    clearTimeout(timer);
+    if (timer !== undefined) clearTimeout(timer);
     callerSignal?.removeEventListener("abort", forwardCallerAbort);
   }
 }
@@ -880,10 +887,12 @@ export async function createToolBridge(
     options.listToolsTimeoutMs,
     DEFAULT_MCP_LIST_TOOLS_TIMEOUT_MS,
   );
-  const callToolTimeoutMs = normalizeTimeoutMs(
-    options.callToolTimeoutMs,
-    DEFAULT_MCP_CALL_TIMEOUT_MS,
-  );
+  const callToolTimeoutMs =
+    typeof options.callToolTimeoutMs === "number" &&
+    Number.isFinite(options.callToolTimeoutMs) &&
+    options.callToolTimeoutMs > 0
+      ? Math.max(1, Math.floor(options.callToolTimeoutMs))
+      : undefined;
 
   const response = await withRPCDeadline<MCPListToolsResponse>(
     `MCP server "${serverName}" listTools`,
@@ -1010,7 +1019,14 @@ export async function createToolBridge(
                     arguments: executionArgs,
                   },
                   undefined,
-                  { signal, timeout: callToolTimeoutMs },
+                  {
+                    signal,
+                    timeout:
+                      callToolTimeoutMs ?? MCP_SDK_UNBOUNDED_WINDOW_MS,
+                    ...(callToolTimeoutMs === undefined
+                      ? { resetTimeoutOnProgress: true }
+                      : {}),
+                  },
                 ),
               effectSignal,
             ),

--- a/runtime/src/permissions/guardian/reviewer.ts
+++ b/runtime/src/permissions/guardian/reviewer.ts
@@ -63,7 +63,6 @@ export type {
 } from "./prompt.js";
 
 export const GUARDIAN_PREFERRED_MODEL = "codex-auto-review"; // branding-scan: allow OpenAI model identifier
-const GUARDIAN_REVIEW_TIMEOUT_MS = 90_000;
 
 const GUARDIAN_REJECTION_INSTRUCTIONS =
   "The agent must not attempt to achieve the same outcome via workaround, " +
@@ -158,11 +157,11 @@ export function shouldRouteApprovalToGuardian(ctx: ApprovalCtx): boolean {
 export function createDefaultGuardianApprovalReviewer(
   opts: DefaultGuardianApprovalReviewerOptions = {},
 ): GuardianApprovalReviewer {
-  return new DefaultGuardianApprovalReviewer(opts.timeoutMs ?? GUARDIAN_REVIEW_TIMEOUT_MS);
+  return new DefaultGuardianApprovalReviewer(opts.timeoutMs);
 }
 
 class DefaultGuardianApprovalReviewer implements GuardianApprovalReviewer {
-  constructor(private readonly timeoutMs: number) {}
+  constructor(private readonly timeoutMs?: number) {}
 
   async reviewApprovalRequest(
     opts: GuardianApprovalReviewOptions,
@@ -246,7 +245,7 @@ class DefaultGuardianApprovalReviewer implements GuardianApprovalReviewer {
         approvalRequest,
         rootHumanTurn,
         signal: opts.signal,
-        timeoutMs: this.timeoutMs,
+        ...(this.timeoutMs !== undefined ? { timeoutMs: this.timeoutMs } : {}),
       });
       const manager = session.services?.reviewManager ?? new ReviewManager();
       outcome = await manager.runReview(session, request);
@@ -383,7 +382,8 @@ interface BuildOneShotRequestOptions {
     readonly text: string;
   };
   readonly signal?: AbortSignal;
-  readonly timeoutMs: number;
+  /** Optional operator-supplied deadline. Omitted means unbounded. */
+  readonly timeoutMs?: number;
 }
 
 function buildOneShotRequest(
@@ -424,7 +424,7 @@ function buildOneShotRequest(
     initialHistory: reviewContext.initialHistory,
     reuseKey: reviewContext.reuseKey,
     ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
-    timeoutMs: opts.timeoutMs,
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   };
 }
 

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -10,10 +10,10 @@
  * Mirrors agenc `query.ts:561-1082`.
  *
  * Invariants wired here:
- *   I-11 (stream idle watchdog, default-on) — installStreamWatchdog
- *        wraps the stream; `kick()` fires on every chunk. On idle
- *        expiry the watchdog aborts the underlying fetch via the
- *        scoped AbortController.
+ *   I-11 (stream idle watchdog, operator opt-in) — installStreamWatchdog
+ *        wraps the stream; `kick()` fires on every chunk. An explicitly
+ *        configured idle expiry aborts the underlying fetch via the scoped
+ *        AbortController; unconfigured streams are unbounded.
  *   I-22 (token budget mid-stream) — per-chunk
  *        `budgetTracker.addEmitted(..., "estimate") + sampleMidStream`
  *        keeps a coarse estimate during streaming, but the actual
@@ -834,8 +834,9 @@ export async function streamModel(
 
   const planMode = isPlanMode(ctx);
 
-  // Scoped AbortController: aborted by either the external signal or
-  // the watchdog, whichever fires first.
+  // Scoped AbortController: always follows the external signal. An
+  // operator-configured stream watchdog may also abort it, but there is no
+  // implicit idle deadline.
   const scoped = new AbortController();
   const onExternalAbort = () => {
     if (!scoped.signal.aborted) {
@@ -846,14 +847,11 @@ export async function streamModel(
     signal.addEventListener("abort", onExternalAbort, { once: true });
   }
 
-  // I-11 watchdog installed BEFORE the stream begins so a stall at
-  // first-byte also trips. Idle tolerance resolves env >
-  // `stream_watchdog_timeout_ms` config > provider suggestion > default:
-  // providers with silent server-side generation phases (grok buffers
-  // whole function-call argument payloads with zero bytes on the wire)
-  // declare a multi-minute tolerance, because during those phases a
-  // healthy stream is indistinguishable from a stall and killing it
-  // forces a full-regeneration retry loop that never converges.
+  // I-11 watchdog wiring is installed before the stream begins, but is a
+  // no-op unless the operator explicitly configures a positive idle timeout.
+  // Provider suggestions may raise an explicit value; they never invent one.
+  // A healthy provider can remain completely silent while reasoning or
+  // generating a large tool payload, so silence alone must not end a turn.
   const configuredWatchdogMs = (() => {
     const services = session.services as {
       configStore?: { current?: () => { stream_watchdog_timeout_ms?: number } };

--- a/runtime/src/recovery/reconnection.ts
+++ b/runtime/src/recovery/reconnection.ts
@@ -4,7 +4,8 @@
  * Port of agenc reconnection pattern: on transient network /
  * provider errors (ECONNRESET, ECONNREFUSED, 503, stream_idle), the
  * recovery layer sleeps with exponential backoff (1s → 30s cap,
- * ±25% jitter, 10-minute give-up budget) then resamples. Pending
+ * ±25% jitter) then resamples. There is no implicit wall-clock give-up
+ * budget; callers may provide one explicitly. Pending
  * tool-call re-injection ensures the model sees the same prompt
  * after the reconnect (history is unchanged).
  *
@@ -27,7 +28,6 @@ import { emitWarning } from "../session/event-log.js";
 
 export const RECONNECT_INITIAL_MS = 1_000;
 export const RECONNECT_MAX_MS = 30_000;
-export const RECONNECT_GIVE_UP_MS = 600_000;
 const RECONNECT_JITTER_FRAC = 0.25; // ±25 %
 export const RECONNECT_SLEEP_DETECTION_THRESHOLD_MS =
   RECONNECT_MAX_MS * 2;
@@ -119,6 +119,7 @@ export interface ReconnectOpts<T> {
   readonly session: Session;
   readonly signal?: AbortSignal;
   readonly maxAttempts?: number;
+  /** Optional operator/caller deadline. Unset retries without a time ceiling. */
   readonly giveUpMs?: number;
   readonly sleepDetectionThresholdMs?: number;
   readonly now?: () => number;
@@ -143,7 +144,7 @@ export async function reconnectWithBackoff<T>(
   opts: ReconnectOpts<T>,
 ): Promise<ReconnectOutcome<T>> {
   const maxAttempts = opts.maxAttempts;
-  const giveUpMs = opts.giveUpMs ?? RECONNECT_GIVE_UP_MS;
+  const giveUpMs = opts.giveUpMs;
   const sleepDetectionThresholdMs =
     opts.sleepDetectionThresholdMs ?? RECONNECT_SLEEP_DETECTION_THRESHOLD_MS;
   const now = opts.now ?? monotonicMs;
@@ -187,7 +188,10 @@ export async function reconnectWithBackoff<T>(
           lastError,
         };
       }
-      if (currentNow - reconnectStartedAt >= giveUpMs) {
+      if (
+        giveUpMs !== undefined &&
+        currentNow - reconnectStartedAt >= giveUpMs
+      ) {
         return {
           kind: "exhausted",
           attempts: attempt + 1,

--- a/runtime/src/services/api/openAiCodeTransform.ts
+++ b/runtime/src/services/api/openAiCodeTransform.ts
@@ -631,59 +631,18 @@ export async function performProviderCodeRequest(options: {
   return response
 }
 
-async function* readSseEvents(response: Response, signal?: AbortSignal): AsyncGenerator<ResponsesSseEvent> {
+async function* readSseEvents(response: Response, _signal?: AbortSignal): AsyncGenerator<ResponsesSseEvent> {
   const reader = response.body?.getReader()
   if (!reader) return
 
   const decoder = new TextDecoder()
   let buffer = ''
-  const STREAM_IDLE_TIMEOUT_MS = 120_000 // 2 minutes without data
-  let lastDataTime = Date.now()
-
-  /**
-   * Read from the stream with an idle timeout. Respects the caller's
-   * AbortSignal — clears the idle timer on abort so the AbortError
-   * surfaces cleanly instead of a spurious idle timeout.
-   */
-  async function readWithTimeout(): Promise<ReadableStreamReadResult<Uint8Array>> {
-    return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        const elapsed = Math.round((Date.now() - lastDataTime) / 1000)
-        reject(new Error(
-          `Responses SSE stream idle for ${elapsed}s (limit: ${STREAM_IDLE_TIMEOUT_MS / 1000}s). Connection likely dropped.`,
-        ))
-      }, STREAM_IDLE_TIMEOUT_MS)
-
-      let abortCleanup: (() => void) | undefined
-      if (signal) {
-        abortCleanup = () => {
-          clearTimeout(timeoutId)
-        }
-        signal.addEventListener('abort', abortCleanup, { once: true })
-      }
-
-      // `reader` is guaranteed defined here: the enclosing generator returns
-      // early at `if (!reader) return` before this closure can run. The
-      // non-null assertion only restores that narrowing across the closure
-      // boundary; it does not change behavior.
-      reader!.read().then(
-        result => {
-          clearTimeout(timeoutId)
-          if (signal && abortCleanup) signal.removeEventListener('abort', abortCleanup)
-          if (result.value) lastDataTime = Date.now()
-          resolve(result)
-        },
-        err => {
-          clearTimeout(timeoutId)
-          if (signal && abortCleanup) signal.removeEventListener('abort', abortCleanup)
-          reject(err)
-        },
-      )
-    })
-  }
 
   while (true) {
-    const { done, value } = await readWithTimeout()
+    // A silent stream is not proof of failure: a reasoning response or a large
+    // function-call payload can take hours before producing its next byte.
+    // Cancellation is owned by the caller's signal, not an implicit timer.
+    const { done, value } = await reader.read()
     if (done) break
 
     buffer += decoder.decode(value, { stream: true })

--- a/runtime/src/services/api/openaiShim.ts
+++ b/runtime/src/services/api/openaiShim.ts
@@ -1150,7 +1150,7 @@ function repairPossiblyTruncatedObjectJson(raw: string): string | null {
 async function* openaiStreamToprovider(
   response: Response,
   model: string,
-  signal?: AbortSignal,
+  _signal?: AbortSignal,
 ): AsyncGenerator<providerStreamEvent> {
   const messageId = makeMessageId()
   let contentBlockIndex = 0
@@ -1201,58 +1201,12 @@ async function* openaiStreamToprovider(
 
   const maybeReader = response.body?.getReader()
   if (!maybeReader) return
-  // Bind to a non-optional const so the narrowed type survives into the
-  // readWithTimeout closure below (TS widens guard-narrowed bindings that are
-  // captured by nested functions).
+  // Bind to a non-optional const so the narrowed type remains explicit in the
+  // stream loop below.
   const reader: ReadableStreamDefaultReader<Uint8Array> = maybeReader
 
   const decoder = new TextDecoder()
   let buffer = ''
-  const STREAM_IDLE_TIMEOUT_MS = 120_000 // 2 minutes without data = connection likely dead
-  let lastDataTime = Date.now()
-
-  /**
-   * Read from the stream with an idle timeout. If no data arrives within
-   * STREAM_IDLE_TIMEOUT_MS, assume the connection is dead and throw so
-   * withRetry can reconnect. This prevents indefinite hangs on stale
-   * SSE connections from OpenAi/Gemini during long-running sessions.
-   * Respects the caller's AbortSignal — clears the idle timer on abort
-   * so the rejection reason is AbortError, not a spurious idle timeout.
-   */
-  async function readWithTimeout(): Promise<ReadableStreamReadResult<Uint8Array>> {
-    return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        const elapsed = Math.round((Date.now() - lastDataTime) / 1000)
-        reject(new Error(
-          `OpenAi/Gemini SSE stream idle for ${elapsed}s (limit: ${STREAM_IDLE_TIMEOUT_MS / 1000}s). Connection likely dropped.`,
-        ))
-      }, STREAM_IDLE_TIMEOUT_MS)
-
-      // If the caller aborts, clear the timer so the AbortError surfaces
-      // cleanly instead of being masked by a spurious idle timeout.
-      let abortCleanup: (() => void) | undefined
-      if (signal) {
-        abortCleanup = () => {
-          clearTimeout(timeoutId)
-        }
-        signal.addEventListener('abort', abortCleanup, { once: true })
-      }
-
-      reader.read().then(
-        result => {
-          clearTimeout(timeoutId)
-          if (signal && abortCleanup) signal.removeEventListener('abort', abortCleanup)
-          if (result.value) lastDataTime = Date.now()
-          resolve(result)
-        },
-        err => {
-          clearTimeout(timeoutId)
-          if (signal && abortCleanup) signal.removeEventListener('abort', abortCleanup)
-          reject(err)
-        },
-      )
-    })
-  }
 
   const closeActiveContentBlock = async function* () {
     if (!hasEmittedContentStart) return
@@ -1275,8 +1229,12 @@ async function* openaiStreamToprovider(
   }
 
   try {
-    while (true) {
-      const { done, value } = await readWithTimeout()
+  while (true) {
+      // No implicit idle deadline: reasoning providers can legitimately leave
+      // an SSE body silent for hours. The caller's signal remains the sole
+      // cancellation authority unless an operator configures a deadline above
+      // this transport.
+      const { done, value } = await reader.read()
       if (done) break
 
       buffer += decoder.decode(value, { stream: true })

--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -239,13 +239,10 @@ function isMcpSessionExpiredError(error: Error): boolean {
   )
 }
 
-/**
- * Default timeout for MCP tool calls (5 minutes — reasonable for most tools).
- * Use MCP_TOOL_TIMEOUT env var to override per-server.
- * The previous default of ~27.8 hours effectively meant no timeout, causing
- * tools to hang indefinitely on unresponsive servers.
- */
-const DEFAULT_MCP_TOOL_TIMEOUT_MS = 300_000
+// The MCP SDK requires a finite timer even when the runtime has no deadline.
+// Its largest safe Node timer is ~24.8 days, far beyond an agent/tool turn;
+// progress resets that SDK guard. AgenC itself adds no implicit tool deadline.
+const MCP_SDK_UNBOUNDED_WINDOW_MS = 2_147_483_647
 
 /**
  * Cap on MCP tool descriptions and server instructions sent to the model.
@@ -409,15 +406,12 @@ function sanitizeSdkMcpInputSchemaForModel(
 }
 
 /**
- * Gets the timeout for MCP tool calls in milliseconds.
- * Uses MCP_TOOL_TIMEOUT environment variable if set, otherwise defaults to
- * DEFAULT_MCP_TOOL_TIMEOUT_MS (5 minutes).
+ * Gets an explicit MCP tool-call timeout in milliseconds. Unset or invalid
+ * values mean that AgenC does not impose a tool deadline.
  */
-function getMcpToolTimeoutMs(): number {
-  return (
-    parseInt(process.env.MCP_TOOL_TIMEOUT || '', 10) ||
-    DEFAULT_MCP_TOOL_TIMEOUT_MS
-  )
+function getMcpToolTimeoutMs(): number | undefined {
+  const parsed = Number.parseInt(process.env.MCP_TOOL_TIMEOUT || '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
 }
 
 import { isAgenCInChromeMCPServer } from '../../utils/agencInChrome/common.js'
@@ -612,11 +606,6 @@ function getConnectionTimeoutMs(): number {
 }
 
 /**
- * Default timeout for individual MCP requests (auth, tool calls, etc.)
- */
-const MCP_REQUEST_TIMEOUT_MS = 60000
-
-/**
  * MCP Streamable HTTP spec requires clients to advertise acceptance of both
  * JSON and SSE on every POST. Servers that enforce this strictly reject
  * requests without it (HTTP 406).
@@ -634,30 +623,18 @@ export function formatMcpShellPrefixCommand(
 }
 
 /**
- * Wraps a fetch function to apply a fresh timeout signal to each request.
- * This avoids the bug where a single AbortSignal.timeout() created at connection
- * time becomes stale after 60 seconds, causing all subsequent requests to fail
- * immediately with "The operation timed out." Uses a 60-second timeout.
- *
- * Also ensures the Accept header required by the MCP Streamable HTTP spec is
- * present on POSTs. The MCP SDK sets this inside StreamableHTTPClientTransport.send(),
- * but it is attached to a Headers instance that passes through an object spread here,
- * and some runtimes/agents have been observed dropping it before it reaches the wire.
- * See https://github.com/anthropics/agenc-agent-sdk-typescript/issues/202.
- * Normalizing here (the last wrapper before fetch()) guarantees it is sent.
- *
- * GET requests are excluded from the timeout since, for MCP transports, they are
- * long-lived SSE streams meant to stay open indefinitely. (Auth-related GETs use
- * a separate fetch wrapper with its own timeout in auth.ts.)
- *
- * @param baseFetch - The fetch function to wrap
+ * Ensures the Accept header required by the MCP Streamable HTTP spec is
+ * present on POSTs. The MCP SDK sets this inside
+ * StreamableHTTPClientTransport.send(), but some runtimes have dropped it
+ * before the wire. The wrapper deliberately adds no deadline: MCP tools can
+ * legitimately run for hours, and cancellation remains owned by the request's
+ * AbortSignal or an explicit MCP_TOOL_TIMEOUT.
  */
-function wrapFetchWithTimeout(baseFetch: FetchLike): FetchLike {
+export function wrapMcpTransportFetch(baseFetch: FetchLike): FetchLike {
   return async (url: string | URL, init?: RequestInit) => {
     const method = (init?.method ?? 'GET').toUpperCase()
 
-    // Skip timeout for GET requests - in MCP transports, these are long-lived SSE streams.
-    // (OAuth discovery GETs in auth.ts use a separate createAuthFetch() with its own timeout.)
+    // MCP transport GETs are long-lived SSE streams and need no header repair.
     if (method === 'GET') {
       return baseFetch(url, init)
     }
@@ -672,43 +649,10 @@ function wrapFetchWithTimeout(baseFetch: FetchLike): FetchLike {
       headers.set('accept', MCP_STREAMABLE_HTTP_ACCEPT)
     }
 
-    // Use setTimeout instead of AbortSignal.timeout() so we can clearTimeout on
-    // completion. AbortSignal.timeout's internal timer is only released when the
-    // signal is GC'd, which in Bun is lazy — ~2.4KB of native memory per request
-    // lingers for the full 60s even when the request completes in milliseconds.
-    const controller = new AbortController()
-    const timer = setTimeout(
-      c =>
-        c.abort(new DOMException('The operation timed out.', 'TimeoutError')),
-      MCP_REQUEST_TIMEOUT_MS,
-      controller,
-    )
-    timer.unref?.()
-
-    const parentSignal = init?.signal
-    const abort = () => controller.abort(parentSignal?.reason)
-    parentSignal?.addEventListener('abort', abort)
-    if (parentSignal?.aborted) {
-      controller.abort(parentSignal.reason)
-    }
-
-    const cleanup = () => {
-      clearTimeout(timer)
-      parentSignal?.removeEventListener('abort', abort)
-    }
-
-    try {
-      const response = await baseFetch(url, {
-        ...init,
-        headers,
-        signal: controller.signal,
-      })
-      cleanup()
-      return response
-    } catch (error) {
-      cleanup()
-      throw error
-    }
+    return baseFetch(url, {
+      ...init,
+      headers,
+    })
   }
 }
 
@@ -815,10 +759,9 @@ export const connectToServer = memoize(
         // Use the auth provider with SSEClientTransport
         const transportOptions: SSEClientTransportOptions = {
           authProvider,
-          // Use fresh timeout per request to avoid stale AbortSignal bug.
           // Step-up detection wraps innermost so the 403 is seen before the
           // SDK's handler calls auth() → tokens().
-          fetch: wrapFetchWithTimeout(
+          fetch: wrapMcpTransportFetch(
             wrapFetchWithStepUpDetection(createFetchWithInit(), authProvider),
           ),
           requestInit: {
@@ -829,11 +772,9 @@ export const connectToServer = memoize(
           },
         }
 
-        // IMPORTANT: Always set eventSourceInit with a fetch that does NOT use the
-        // timeout wrapper. The EventSource connection is long-lived (stays open indefinitely
-        // to receive server-sent events), so applying a 60-second timeout would kill it.
-        // The timeout is only meant for individual API requests (POST, auth refresh), not
-        // the persistent SSE stream.
+        // Keep the long-lived EventSource fetch separate from POST header
+        // normalization. Auth-related GETs use their own bounded control-plane
+        // fetch wrapper in auth.ts.
         transportOptions.eventSourceInit = {
           fetch: async (url: string | URL, init?: RequestInit) => {
             // Get auth headers from the auth provider
@@ -1009,10 +950,9 @@ export const connectToServer = memoize(
 
         const transportOptions: StreamableHTTPClientTransportOptions = {
           authProvider,
-          // Use fresh timeout per request to avoid stale AbortSignal bug.
           // Step-up detection wraps innermost so the 403 is seen before the
           // SDK's handler calls auth() → tokens().
-          fetch: wrapFetchWithTimeout(
+          fetch: wrapMcpTransportFetch(
             wrapFetchWithStepUpDetection(createFetchWithInit(), authProvider),
           ),
           requestInit: {
@@ -1043,7 +983,7 @@ export const connectToServer = memoize(
             url: serverRef.url,
             headers: headersForLogging,
             hasAuthProvider: !!authProvider,
-            timeoutMs: MCP_REQUEST_TIMEOUT_MS,
+            requestDeadline: 'none',
           })}`,
         )
 
@@ -1075,8 +1015,7 @@ export const connectToServer = memoize(
 
         const proxyOptions = getProxyFetchOptions()
         const transportOptions: StreamableHTTPClientTransportOptions = {
-          // Wrap fetchWithAuth with fresh timeout per request
-          fetch: wrapFetchWithTimeout(fetchWithAuth),
+          fetch: wrapMcpTransportFetch(fetchWithAuth),
           requestInit: {
             ...proxyOptions,
             headers: {
@@ -3252,10 +3191,12 @@ async function callMCPTool({
     signal.throwIfAborted()
     const effectController = new AbortController()
     const timeoutError =
-      new LogSafeError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS(
-        `MCP server "${name}" tool "${tool}" timed out after ${Math.floor(timeoutMs / 1000)}s`,
-        'MCP tool timeout',
-      )
+      timeoutMs === undefined
+        ? undefined
+        : new LogSafeError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS(
+            `MCP server "${name}" tool "${tool}" timed out after ${Math.floor(timeoutMs / 1000)}s`,
+            'MCP tool timeout',
+          )
     let timedOut = false
     const forwardCallerAbort = (): void => {
       if (!effectController.signal.aborted) {
@@ -3263,12 +3204,15 @@ async function callMCPTool({
       }
     }
     signal.addEventListener('abort', forwardCallerAbort, { once: true })
-    const timeoutId = setTimeout(() => {
-      timedOut = true
-      if (!effectController.signal.aborted) {
-        effectController.abort(timeoutError)
-      }
-    }, timeoutMs)
+    const timeoutId =
+      timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            timedOut = true
+            if (!effectController.signal.aborted) {
+              effectController.abort(timeoutError)
+            }
+          }, timeoutMs)
 
     let result: Awaited<ReturnType<typeof client.callTool>>
     try {
@@ -3285,7 +3229,10 @@ async function callMCPTool({
         CallToolResultSchema,
         {
           signal: effectController.signal,
-          timeout: timeoutMs,
+          timeout: timeoutMs ?? MCP_SDK_UNBOUNDED_WINDOW_MS,
+          ...(timeoutMs === undefined
+            ? { resetTimeoutOnProgress: true }
+            : {}),
           onprogress: onProgress
             ? sdkProgress => {
               onProgress({
@@ -3302,13 +3249,13 @@ async function callMCPTool({
         },
       )
       signal.throwIfAborted()
-      if (timedOut) throw timeoutError
+      if (timedOut && timeoutError !== undefined) throw timeoutError
     } catch (error) {
       signal.throwIfAborted()
-      if (timedOut) throw timeoutError
+      if (timedOut && timeoutError !== undefined) throw timeoutError
       throw error
     } finally {
-      clearTimeout(timeoutId)
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
       signal.removeEventListener('abort', forwardCallerAbort)
     }
 

--- a/runtime/src/services/xai/acp.ts
+++ b/runtime/src/services/xai/acp.ts
@@ -37,7 +37,6 @@ export const GROK_ACP_AUTH_METHOD_API_KEY = 'xai.api_key'
 export const GROK_ACP_AUTH_METHOD_CACHED_TOKEN = 'cached_token'
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
-const DEFAULT_PROMPT_TIMEOUT_MS = 20 * 60 * 1000
 const STDERR_TAIL_LIMIT = 4_096
 const DEFAULT_TERMINATE_GRACE_MS = 500
 const DEFAULT_SETTLE_BACKSTOP_MS = 1_000
@@ -94,6 +93,16 @@ export type XaiAcpSessionInfo = {
 export type XaiAcpPromptResult = {
   stopReason: string
   text: string
+}
+
+export function resolveXaiAcpPromptTimeoutMs(
+  configured: number | undefined,
+): number {
+  return typeof configured === 'number' &&
+    Number.isFinite(configured) &&
+    configured > 0
+    ? configured
+    : 0
 }
 
 export interface XaiAcpClientOptions {
@@ -351,7 +360,10 @@ export class XaiAcpClient {
           sessionId: params.sessionId,
           prompt: [{ type: 'text', text: params.text }],
         },
-        this.options.promptTimeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS,
+        // Prompt turns may legitimately run for hours. Passing zero disables
+        // the request timer; an explicit promptTimeoutMs still opts into a
+        // finite deadline.
+        resolveXaiAcpPromptTimeoutMs(this.options.promptTimeoutMs),
       )
       const stopReason =
         typeof result.stopReason === 'string' ? result.stopReason : 'unknown'

--- a/runtime/src/session/agenc-delegate.ts
+++ b/runtime/src/session/agenc-delegate.ts
@@ -168,10 +168,9 @@ export interface AgenCReviewOneShotRequest {
    *  derives a child controller from this so it can shut down
    *  independently on completion. */
   readonly signal?: AbortSignal;
-  /** Optional hard deadline for the one-shot turn. Upstream's
-   *  `run_before_review_deadline` enforces a per-review timeout at
-   *  the manager level; exposing it on the delegate as well lets
-   *  callers without a `ReviewManager` bound still apply a budget. */
+  /** Optional caller-supplied hard deadline for the one-shot turn.
+   *  Omitted means unbounded; callers that need a finite operational
+   *  budget can opt in explicitly. */
   readonly timeoutMs?: number;
   /**
    * Optional reviewer system prompt override. Generic `/review` uses

--- a/runtime/src/session/review.ts
+++ b/runtime/src/session/review.ts
@@ -555,11 +555,9 @@ export class ReviewManager {
    * delta prompt logic around the child-session delegate). AgenC port
    * wraps the T13 delegate with:
    *
-   *   - a bounded timeout (the upstream
-   *     `run_before_review_deadline` / `GUARDIAN_REVIEW_SESSION_DEADLINE`
-   *     analog),
-   *   - an `AbortController` that fires on timeout OR on the caller's
-   *     own abort signal,
+   *   - an optional caller-supplied timeout, with no implicit deadline,
+   *   - an `AbortController` that fires on an explicit timeout OR on
+   *     the caller's own abort signal,
    *   - registration in the manager registry for session-wide
    *     shutdown,
    *   - an `exit_review_mode` event on every termination path
@@ -574,8 +572,8 @@ export class ReviewManager {
     session: AgenCDelegateSessionLike,
     req: AgenCReviewOneShotRequest,
   ): Promise<AgenCReviewOneShotOutcome> {
-    // Build the controller the manager owns so `shutdown()` +
-    // timeout can both fire it without fighting the caller's own
+    // Build the controller the manager owns so `shutdown()` + an
+    // explicit timeout can both fire it without fighting the caller's own
     // signal. The delegate also accepts a `signal` through
     // `req.signal`; we merge by letting the caller's original
     // `req.signal` cascade here, then pass the merged controller's

--- a/runtime/src/tasks/agent-thread.ts
+++ b/runtime/src/tasks/agent-thread.ts
@@ -41,8 +41,8 @@ function finalMessageMetadata(
 
 /**
  * Derive the live per-agent tool-use + token counts for a spawned
- * subagent. For DAEMON/collab-spawned agents the runner accumulates token
- * usage on `live.tokenUsage` and records tool calls in the live transcript;
+ * subagent. For DAEMON/collab-spawned agents the runner projects each durable
+ * token-count event onto `live.tokenUsage` and increments `live.toolCallCount`;
  * this reads both so the fan-out rail reflects real activity instead of 0.
  * Returns `undefined` when neither signal is available (so we don't clobber
  * a previously-recorded progress with zeros).
@@ -51,17 +51,18 @@ function liveAgentCounts(
   thread: AgentThreadTaskHandle,
 ): { readonly toolUseCount: number; readonly tokenCount: number } | undefined {
   const tokenCount = thread.live.tokenUsage?.totalTokens;
-  const messages = thread.live.messages;
-  let toolUseCount = 0;
-  let sawMessages = false;
-  if (messages !== undefined) {
-    sawMessages = true;
-    for (const message of messages) {
-      const calls = message.toolCalls;
-      if (calls !== undefined) toolUseCount += calls.length;
+  const liveToolCallCount = thread.live.toolCallCount;
+  let toolUseCount = liveToolCallCount ?? 0;
+  let sawToolCount = liveToolCallCount !== undefined;
+  // Structural/legacy adapters may not expose the dedicated counter yet.
+  // Retain transcript counting as a compatibility fallback only.
+  if (!sawToolCount && thread.live.messages !== undefined) {
+    sawToolCount = true;
+    for (const message of thread.live.messages) {
+      toolUseCount += message.toolCalls?.length ?? 0;
     }
   }
-  if (tokenCount === undefined && !sawMessages) return undefined;
+  if (tokenCount === undefined && !sawToolCount) return undefined;
   return { toolUseCount, tokenCount: tokenCount ?? 0 };
 }
 
@@ -88,15 +89,16 @@ export interface AgentThreadTaskHandle {
       subscribe?: (listener: (status: AgentStatus) => void) => () => void;
     };
     /**
-     * Cumulative token usage for this live subagent. Populated by the
-     * runner's per-turn `usage_update` accumulation (run-agent.ts). Read
-     * each time a status snapshot is emitted so the fan-out rail shows
+     * Cumulative token usage for this live subagent. Populated incrementally
+     * from the child session's durable token-count events (run-agent.ts).
+     * Read each time a status snapshot is emitted so the fan-out rail shows
      * real per-agent token counts for DAEMON/collab-spawned agents, not 0.
      */
     readonly tokenUsage?: { readonly totalTokens?: number };
+    /** Cumulative tool calls maintained directly by the child runner. */
+    readonly toolCallCount?: number;
     /**
-     * Live child transcript. Assistant messages carry `toolCalls`; their
-     * total length is the per-agent tool-use count surfaced on the rail.
+     * Legacy fallback for adapters that predate `toolCallCount`.
      */
     readonly messages?: ReadonlyArray<LLMMessage>;
   };

--- a/runtime/src/tools/AgentTool/forkSubagent.ts
+++ b/runtime/src/tools/AgentTool/forkSubagent.ts
@@ -76,7 +76,6 @@ export const FORK_AGENT = {
   whenToUse:
     'Implicit fork — inherits full conversation context. Not selectable via subagent_type; triggered by omitting subagent_type when the fork experiment is active.',
   tools: ['*'],
-  maxTurns: 200,
   model: 'inherit',
   permissionMode: 'bubble',
   source: 'built-in',

--- a/runtime/src/tools/MonitorTool/MonitorTool.ts
+++ b/runtime/src/tools/MonitorTool/MonitorTool.ts
@@ -17,8 +17,6 @@ import { peekAmbientRuntimeSession } from '../../session/current-session.js'
 
 const MONITOR_TOOL_NAME = 'Monitor'
 
-const MONITOR_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
-
 const inputSchema = lazySchema(() =>
   z.strictObject({
     command: z
@@ -179,7 +177,6 @@ export const MonitorTool = buildTool({
       abortController.signal,
       'bash',
       {
-        timeout: MONITOR_TIMEOUT_MS,
         sandboxExecutionBroker,
         sandboxExecutionSurface: toolUseContext.agentId
           ? 'child_agent'

--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -41,9 +41,9 @@
  * Invariants enforced here:
  *   I-8  (every error site emits a typed event) — errors funnel
  *        through the caller's event log via `eventLog` option.
- *   I-9  (per-tool execution timeout) — `Promise.race([tool, timer])`.
- *        Default `DEFAULT_TOOL_TIMEOUT_MS=30000`; per-tool override
- *        via `tool.timeoutMs`; per-call override via `args.timeoutMs`.
+ *   I-9  (opt-in tool execution timeout) — `Promise.race([tool, timer])`.
+ *        There is no implicit deadline; tools or callers may opt in
+ *        via `tool.timeoutMs` or `args.timeoutMs`.
  *        Tools with `timeoutBehavior:'tool'` own their deadline and
  *        keep only the abort race.
  *   I-15 (tool result size cap) — result bytes truncated to
@@ -162,8 +162,6 @@ import type { TransactionGuardConfig } from "../config/schema.js";
 // ─────────────────────────────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────────────────────────────
-
-export const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
 
 /**
  * I-15: default cap on tool result size in bytes. 400 KB matches
@@ -613,7 +611,7 @@ export function resolveTimeoutMs(
   ) {
     return Math.floor(tool.timeoutMs);
   }
-  return DEFAULT_TOOL_TIMEOUT_MS;
+  return null;
 }
 
 export async function withTimeoutAndAbort<T>(

--- a/runtime/src/tools/streaming-executor.ts
+++ b/runtime/src/tools/streaming-executor.ts
@@ -197,17 +197,15 @@ function normalizeMaxConcurrency(value: number | undefined): number {
 /**
  * Default drain FLOOR. The effective per-tool drain deadline is
  * `max(this.maxToolDrainMs, toolEffectiveTimeoutMs + DRAIN_GRACE_MS)`, so this
- * value is only the lower bound applied to short/default-timeout tools (e.g.
- * Read, whose execute timeout is 30s → floor 180s catches a wedged dispatch).
+ * value is only the lower bound applied to tools with an explicit timeout.
  * Tools that resolve to a LARGER own timeout (a long `bash` with
  * `args.timeoutMs`, or a `tool.timeoutMs` > floor) raise their deadline above
  * this floor, and tools with `timeoutBehavior:"tool"` (request-user-input,
  * wait, monitor, background — intentionally unbounded) are EXEMPT from the
  * backstop entirely and rely on the abort signal as their only stop.
  *
- * Chosen well above the default execute timeout (`execution.ts`
- * `DEFAULT_TOOL_TIMEOUT_MS` = 30s) so the normal path is never tripped — only
- * a dispatch that never settles. Override via env `AGENC_MAX_TOOL_DRAIN_MS`
+ * Chosen well above ordinary explicit tool timeouts so the normal path is
+ * never tripped—only a timed dispatch that never settles. Override via env `AGENC_MAX_TOOL_DRAIN_MS`
  * (positive integer) or the `maxToolDrainMs` constructor option. `0` /
  * non-positive disables the backstop (restores the prior unbounded behavior).
  */

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -28,7 +28,6 @@ import {
 import {
   DEFAULT_DENY_LIST,
   DEFAULT_DENY_PREFIXES,
-  DEFAULT_TIMEOUT_MS,
   DEFAULT_MAX_OUTPUT_BYTES,
   DANGEROUS_SHELL_PATTERNS,
 } from "./types.js";
@@ -292,7 +291,7 @@ function runSpawnedCommand(params: {
   readonly execArgs: readonly string[];
   readonly cwd: string;
   readonly env: Record<string, string>;
-  readonly timeout: number;
+  readonly timeout?: number;
   readonly maxOutputBytes: number;
   readonly logCmd: string;
   readonly logger: Logger;
@@ -375,28 +374,31 @@ function runSpawnedCommand(params: {
       });
     });
 
-    const timer = setTimeout(() => {
-      timedOut = true;
-      try {
-        process.kill(-child.pid!, "SIGTERM");
-      } catch (error) {
-        params.logger.debug(
-          "Bash tool process-group SIGTERM failed; falling back to child.kill",
-          {
-            error: error instanceof Error ? error.message : String(error),
-          },
-        );
-        child.kill("SIGTERM");
-      }
-      forceKillTimer = setTimeout(() => {
+    let timer: NodeJS.Timeout | null = null;
+    if (params.timeout !== undefined) {
+      timer = setTimeout(() => {
+        timedOut = true;
         try {
-          process.kill(-child.pid!, "SIGKILL");
-        } catch {
-          child.kill("SIGKILL");
+          process.kill(-child.pid!, "SIGTERM");
+        } catch (error) {
+          params.logger.debug(
+            "Bash tool process-group SIGTERM failed; falling back to child.kill",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          child.kill("SIGTERM");
         }
-      }, 500);
-      cleanup("timeout");
-    }, params.timeout);
+        forceKillTimer = setTimeout(() => {
+          try {
+            process.kill(-child.pid!, "SIGKILL");
+          } catch {
+            child.kill("SIGKILL");
+          }
+        }, 500);
+        cleanup("timeout");
+      }, params.timeout);
+    }
 
     const terminateChild = (signalName: "SIGTERM" | "SIGKILL") => {
       try {
@@ -432,7 +434,7 @@ function runSpawnedCommand(params: {
     const doResolve = (code: number | null) => {
       if (resolved) return;
       resolved = true;
-      clearTimeout(timer);
+      if (timer !== null) clearTimeout(timer);
       if (forceKillTimer) {
         clearTimeout(forceKillTimer);
       }
@@ -513,7 +515,7 @@ function runSpawnedCommand(params: {
     child.on("error", (err) => {
       if (resolved) return;
       resolved = true;
-      clearTimeout(timer);
+      if (timer !== null) clearTimeout(timer);
       if (forceKillTimer) {
         clearTimeout(forceKillTimer);
       }
@@ -871,7 +873,7 @@ export function createBashTool(config?: BashToolConfig): Tool {
       ? new Set<string>(config.denyExclusions)
       : null;
   const defaultCwd = config?.cwd ?? process.cwd();
-  const defaultTimeout = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const defaultTimeout = config?.timeoutMs;
   const maxTimeoutMs = config?.maxTimeoutMs ?? defaultTimeout;
   const maxOutputBytes = config?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
   const env = buildEnv(config?.env);
@@ -1129,8 +1131,17 @@ export function createBashTool(config?: BashToolConfig): Tool {
         };
       }
 
-      // Apply timeout — cap at maxTimeoutMs to prevent LLM from setting arbitrarily high values
-      const timeout = Math.min(input.timeoutMs ?? defaultTimeout, maxTimeoutMs);
+      const requestedTimeout = input.timeoutMs ?? defaultTimeout;
+      const timeout =
+        typeof requestedTimeout === "number" &&
+        Number.isFinite(requestedTimeout) &&
+        requestedTimeout > 0
+          ? typeof maxTimeoutMs === "number" &&
+            Number.isFinite(maxTimeoutMs) &&
+            maxTimeoutMs > 0
+            ? Math.min(requestedTimeout, maxTimeoutMs)
+            : requestedTimeout
+          : undefined;
 
       const logCmd = useShellMode
         ? `[shell] ${shellCommand}`

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -290,11 +290,9 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
     requiresApproval: true,
     concurrencyClass: { kind: "background_terminal" },
     isReadOnly: false,
-    // Long backstop so interactive hardware-approval flows (e.g. a Ledger
-    // device command that waits for a human to confirm on the signer) aren't
-    // killed at the 30s default. exec_command returns at yield_time_ms for
-    // normal commands, so this only matters when a long yield/timeout is set.
-    timeoutMs: 180_000,
+    // Unified exec owns explicit command timeouts and foreground yields.
+    // The generic executor must not invent a second deadline.
+    timeoutBehavior: "tool",
     recoveryCategory: "side-effecting",
     supportsParallelToolCalls: false,
     isConcurrencySafe: () => false,

--- a/runtime/src/tools/system/monitor.ts
+++ b/runtime/src/tools/system/monitor.ts
@@ -13,8 +13,9 @@
  *     donor `mapToolResultToToolResultBlockParam` content.
  *   - Streams output through AgenC's existing `unifiedExecManager`
  *     `tool_progress` event channel — the same path `exec_command`
- *     uses for live stdout/stderr chunks. The 30-minute timeout
- *     ceiling matches donor `MONITOR_TIMEOUT_MS`.
+ *     uses for live stdout/stderr chunks. The foreground stream yields
+ *     after about 30 seconds, while the process itself has no implicit
+ *     runtime deadline.
  *
  * @module
  */
@@ -29,7 +30,7 @@ import { processOwnerIdFromToolArgs } from "../../unified-exec/process-ownership
 import { nonEmptyString as asNonEmptyString } from "../../utils/stringUtils.js";
 import { runtimeSandboxForExec } from "./exec-command.js";
 
-const MONITOR_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes — AgenC behavior.
+const MONITOR_INITIAL_YIELD_MS = 30_000;
 
 /**
  * Verbatim port of donor `MonitorTool.prompt()`
@@ -65,22 +66,9 @@ export function createMonitorTool(config: MonitorToolConfig): Tool {
     },
     requiresApproval: true,
     recoveryCategory: "side-effecting",
-    // The tool owns its own yield/timeout semantics: execCommand is
-    // driven with yield_time_ms/timeoutMs = MONITOR_TIMEOUT_MS so the
-    // monitored process keeps running in the background and yields a
-    // process_id. Without this, the generic executor's
-    // DEFAULT_TOOL_TIMEOUT_MS (30s) timer would fire as the clamped
-    // ~30s yield resolves and abort the *shared* AbortController that is
-    // forwarded into execCommand as __abortSignal — SIGTERM/SIGKILLing
-    // the still-running monitored process and returning a
-    // ToolTimeoutError instead of the "Monitor task started" yield.
-    // `timeoutBehavior: "tool"` makes resolveTimeoutMs return null so
-    // the executor only preserves aborts (matches TaskOutput, which owns
-    // its own deadline the same way). Keep an explicit timeoutMs so the
-    // ceiling is documented even though the executor no longer enforces
-    // it.
+    // Monitor owns its foreground yield semantics. The generic executor
+    // must not turn that yield window into a process deadline.
     timeoutBehavior: "tool",
-    timeoutMs: MONITOR_TIMEOUT_MS,
     inputSchema: {
       type: "object",
       properties: {
@@ -119,9 +107,9 @@ export function createMonitorTool(config: MonitorToolConfig): Tool {
       try {
         // Drive through unifiedExecManager exactly the same way
         // exec_command does — that's how the runtime already streams
-        // line-by-line tool_progress chunks. The yield ceiling
-        // matches AgenC's MONITOR_TIMEOUT_MS so abandoned
-        // monitors get reaped by the existing hard-timeout path.
+        // line-by-line tool_progress chunks. A bounded initial yield
+        // returns a process id; the command remains alive without an
+        // implicit hard timeout and can be polled or explicitly stopped.
         const ownerId = processOwnerIdFromToolArgs(
           rawArgs as Record<string, unknown>,
         );
@@ -134,8 +122,7 @@ export function createMonitorTool(config: MonitorToolConfig): Tool {
           cmd: command,
           workdir: config.cwd,
           tty: false,
-          yield_time_ms: MONITOR_TIMEOUT_MS,
-          timeoutMs: MONITOR_TIMEOUT_MS,
+          yield_time_ms: MONITOR_INITIAL_YIELD_MS,
           ...(args.__abortSignal !== undefined
             ? { __abortSignal: args.__abortSignal }
             : {}),

--- a/runtime/src/tools/system/types.ts
+++ b/runtime/src/tools/system/types.ts
@@ -16,9 +16,9 @@ import type { Logger } from "../../utils/logger.js";
 export interface BashToolConfig {
   /** Working directory (default: process.cwd()) */
   readonly cwd?: string;
-  /** Command timeout in ms (default: 30_000) */
+  /** Optional default command timeout in ms. Omission means no deadline. */
   readonly timeoutMs?: number;
-  /** Maximum timeout the LLM can request per-call in ms. Caps per-call timeoutMs overrides. */
+  /** Optional cap for per-call timeoutMs overrides. */
   readonly maxTimeoutMs?: number;
   /** Allowed command prefixes (empty = allow all) */
   readonly allowList?: readonly string[];
@@ -469,5 +469,4 @@ export const DEFAULT_DENY_PREFIXES: readonly string[] = [];
 
 // Default direct bash timeout. Daemon desktop mode lifts this ceiling via
 // resolveBashToolTimeoutConfig(), but the standalone tool stays short by default.
-export const DEFAULT_TIMEOUT_MS = 30_000;
 export const DEFAULT_MAX_OUTPUT_BYTES = 100_000;

--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -67,11 +67,9 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
     requiresApproval: true,
     concurrencyClass: { kind: "background_terminal" },
     isReadOnly: false,
-    // Long backstop so polling a session that's waiting on human hardware
-    // approval (e.g. a Ledger signer confirming on-device) isn't killed at the
-    // 30s default before the human finishes. Normal polls return at
-    // yield_time_ms, so this only affects long interactive waits.
-    timeoutMs: 300_000,
+    // Unified exec owns the bounded polling yield. The generic executor
+    // must never turn a long poll into termination of the live process.
+    timeoutBehavior: "tool",
     recoveryCategory: "side-effecting",
     supportsParallelToolCalls: false,
     isConcurrencySafe: () => false,

--- a/runtime/src/tools/types.ts
+++ b/runtime/src/tools/types.ts
@@ -170,8 +170,8 @@ export interface Tool {
    * `throw` downgrades to `Exclusive`.
    */
   readonly isConcurrencySafe?: (args: Record<string, unknown>) => boolean;
-  /** I-9 per-tool timeout override (ms). Falls back to
-   *  `DEFAULT_TOOL_TIMEOUT_MS=30_000` when absent. */
+  /** I-9 opt-in per-tool timeout override (ms). Omission means no
+   * generic executor deadline. */
   readonly timeoutMs?: number;
   /**
    * Timeout ownership. `executor` means the generic tool executor
@@ -210,6 +210,12 @@ export interface Tool {
    * Missing categories are treated as side-effecting.
    */
   readonly recoveryCategory?: ToolRecoveryCategory;
+  /**
+   * Admission usage after cancellation once dispatch has begun. Omit for the
+   * conservative unknown-usage path. `zero` is only valid for local,
+   * non-metered operations that cannot incur provider usage after abort.
+   */
+  readonly cancellationUsage?: "zero";
   /**
    * Optional AgenC-style permission hook. The permissions evaluator
    * calls this before the generic mode gate so tools can request asks,

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1479,19 +1479,6 @@ function compactHookLabel(hookType: unknown): string {
 }
 const TITLE_ANIMATION_FRAME_COUNT = 2;
 const TITLE_ANIMATION_INTERVAL_MS = 960;
-// Keep this strictly above ONE FULL provider recovery cycle: the stream-idle
-// watchdog (90s default) + reconnect setup + the next attempt's first-event
-// latency. The provider must get the first chance to emit `stream_idle` and
-// enter its reconnect path; using 60s here made the TUI cancel
-// healthy-but-paused Grok streams as `interrupted` before provider recovery
-// could run, and 120s still raced the reconnect: after the cancel event
-// resets the clock, a large-context re-prefill plus another idle window can
-// legitimately push the next recovery event past 120s, so the TUI aborted
-// the turn in the middle of the provider's own recovery (observed: turn
-// killed by daemon_stall_watchdog ~2min into a reconnect after stream_idle).
-// Any recovery event resets the activity clock, while a genuinely silent
-// daemon is still released after this longer safety window.
-const DAEMON_STALL_WATCHDOG_MS = 300_000;
 // A submitted prompt that gets NO daemon acknowledgment within this window
 // (no turn_started, no streaming, no message growth — the 403 flavor where
 // the request dies before any event is broadcast) never started. A cold
@@ -1947,69 +1934,6 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     setPendingSubmission(false);
     setActiveModelSubmissionCount(0);
   }, [transcript.isStreaming, hasActiveSessionTurn, pendingSubmission, activeModelSubmissionCount]);
-  // Daemon-silence watchdog: the SECOND stuck-spinner failure mode — a turn
-  // that dies emitting NO terminal event (no turn_complete, no error) leaves
-  // zero transcript activity, so neither the reducer nor the latch above can
-  // ever fire and "Working…" spins forever while ESC cancels a turn that's
-  // already gone. While a turn is supposedly active, any transcript activity
-  // (messages, streaming text/thinking, tool progress) resets the clock; a
-  // full silent window means the turn is dead — cancel best-effort, mark it
-  // interrupted locally so the transcript closes, and warn the user.
-  const lastDaemonActivityRef = useRef(Date.now());
-  useEffect(() => {
-    lastDaemonActivityRef.current = Date.now();
-  }, [transcript.messages, transcript.streamingText, transcript.streamingThinking, transcript.inProgressToolUseIDs]);
-  useEffect(() => {
-    if (!isLoading) return;
-    const interval = setInterval(() => {
-      // A turn parked on a permission request or elicitation prompt emits
-      // nothing — by design, not by death. Reset the clock there instead of
-      // firing, or the watchdog aborts a turn that is legitimately waiting
-      // for the user (observed: watchdog cancelled a pending TodoWrite
-      // approval at the 60s mark). Same rule while a tool call is in flight
-      // (e.g. wait_agent blocking on subagents) or background agents are
-      // running: the main transcript goes quiet while the agents work, but
-      // the turn is alive — only TRUE silence (nothing pending, nothing
-      // running) means dead.
-      if (
-        permissionRequests.length > 0 ||
-        elicitation.prompt !== null ||
-        transcript.inProgressToolUseIDs.size > 0 ||
-        hasActiveLocalAgents
-      ) {
-        lastDaemonActivityRef.current = Date.now();
-        return;
-      }
-      const silentMs = Date.now() - lastDaemonActivityRef.current;
-      if (silentMs < DAEMON_STALL_WATCHDOG_MS) {
-        return;
-      }
-      requestTuiSessionTurnCancel(props.session);
-      lastDaemonActivityRef.current = Date.now();
-      props.session.emit?.({
-        id: `daemon-stall-watchdog-${Date.now()}`,
-        msg: {
-          type: "turn_aborted",
-          payload: { reason: "daemon_stall_watchdog" },
-        },
-      });
-      // The turn_aborted emit only touches transcript state. If the spinner
-      // is held by the local latches (pendingSubmission / hung
-      // activeModelSubmissionCount — the no-events 403 flavor or a
-      // message.stream RPC that never settles), isLoading would stay true
-      // and this watchdog would re-fire every window forever. Reset the
-      // latches too: giving up must mean giving up on EVERY busy source.
-      setPendingSubmission(false);
-      setActiveModelSubmissionCount(0);
-      addNotification({
-        key: "daemon-stall-watchdog",
-        text: `No daemon activity for ${Math.round(silentMs / 1000)}s — the turn was marked interrupted. Resubmit, or run /login again if this was an auth failure.`,
-        priority: "immediate",
-        timeoutMs: 8000,
-      });
-    }, 10_000);
-    return () => clearInterval(interval);
-  }, [isLoading, props.session, addNotification, permissionRequests.length, elicitation.prompt, transcript.inProgressToolUseIDs, hasActiveLocalAgents]);
   // M4 unknown-outcome gate visibility: when a tool result reports the
   // session blocked by an unresolved unknown-outcome effect, the block
   // otherwise only reaches the agent as a tool error — the user just watches

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -409,6 +409,10 @@ export function createDaemonTuiSession<
   const receivedEvents: unknown[] = [];
   const REPLAY_BACKLOG_LIMIT = 500;
   let activeTurnSnapshot: { readonly turnId: string } | null = null;
+  // Terminal transcript events are authoritative for a turn. Tool cleanup can
+  // arrive afterward; those late events must never manufacture a new
+  // "daemon-turn" and relatch the TUI spinner.
+  let terminalDaemonTurnObserved = false;
   let queuedInputCount = 0;
   let queuedInputBytes = 0;
   let inFlightInputCount = 0;
@@ -424,6 +428,7 @@ export function createDaemonTuiSession<
   >();
   let unsubscribeDaemonEvents: (() => void) | null = null;
   const markDaemonActivityActive = (event: unknown): void => {
+    if (terminalDaemonTurnObserved) return;
     const payload = (event as { readonly payload?: unknown }).payload;
     const turnId =
       isJsonObject(payload) && typeof payload.turnId === "string" && payload.turnId.length > 0
@@ -443,9 +448,11 @@ export function createDaemonTuiSession<
     // not left permanently blocked after a failed turn.
     if (typeof eventType === "string" && TERMINAL_DAEMON_TRANSCRIPT_EVENTS.has(eventType)) {
       activeTurnSnapshot = null;
+      terminalDaemonTurnObserved = true;
       return;
     }
     if (eventType === "turn_start" || eventType === "turn_started") {
+      terminalDaemonTurnObserved = false;
       markDaemonActivityActive(event);
       return;
     }
@@ -461,8 +468,11 @@ export function createDaemonTuiSession<
     const status = (payload as { readonly status?: unknown }).status;
     const turnId = (payload as { readonly turnId?: unknown }).turnId;
     if (typeof status !== "string") return;
+    if (status === "idle") {
+      activeTurnSnapshot = null;
+      return;
+    }
     if (
-      status === "idle" ||
       status === "completed" ||
       status === "failed" ||
       status === "error" ||
@@ -470,8 +480,10 @@ export function createDaemonTuiSession<
       status === "canceled"
     ) {
       activeTurnSnapshot = null;
+      terminalDaemonTurnObserved = true;
       return;
     }
+    if (terminalDaemonTurnObserved) return;
     activeTurnSnapshot = {
       turnId: typeof turnId === "string" && turnId.length > 0 ? turnId : "daemon-turn",
     };
@@ -614,6 +626,7 @@ export function createDaemonTuiSession<
       inFlightInputCount += submittedInputCount;
       inFlightInputBytes += submittedInputBytes;
       const streamId = `${clientId}:${Date.now()}`;
+      terminalDaemonTurnObserved = false;
       activeTurnSnapshot = { turnId: streamId };
       const content =
         queued.length === 0

--- a/runtime/src/tui/state/AppStateStore.ts
+++ b/runtime/src/tui/state/AppStateStore.ts
@@ -498,7 +498,10 @@ export function getDefaultAppState(): AppState {
     authVersion: 0,
     initialMessage: null,
     effortValue: undefined,
-    swarmMode: false,
+    // `/swarm` is persisted in user settings. A fresh TUI must reflect that
+    // value immediately; waiting for a later file-change event left routing
+    // enabled in the daemon while the badge and local command state said off.
+    swarmMode: initialSettings.swarmMode === true,
     activeOverlays: new Set<string>(),
     fastMode: false,
   }

--- a/runtime/src/tui/state/collabAgentTaskSync.ts
+++ b/runtime/src/tui/state/collabAgentTaskSync.ts
@@ -24,6 +24,7 @@ type CollabAgentTaskPatch = {
   readonly id: string;
   readonly status: TaskStatus;
   readonly requiresExisting?: boolean;
+  readonly preserveCompletedOnTermination?: boolean;
   readonly title?: string;
   readonly prompt?: string;
   readonly role?: string;
@@ -143,6 +144,8 @@ function patchFromEvent(event: unknown): CollabAgentTaskPatch | null {
       id,
       status,
       requiresExisting: true,
+      preserveCompletedOnTermination:
+        status === "failed" || status === "killed",
       title:
         taskStringField(payload, "agentNickname") ??
         taskStringField(payload, "agentPath"),
@@ -190,6 +193,8 @@ function patchFromEvent(event: unknown): CollabAgentTaskPatch | null {
       id,
       status,
       requiresExisting: true,
+      preserveCompletedOnTermination:
+        status === "failed" || status === "killed",
       ...(status === "failed" ? { error: taskStringField(payload, "message") } : {}),
     };
   }
@@ -235,12 +240,18 @@ function applyPatch(
 ): LocalAgentTaskState {
   const previousAgent =
     previous?.type === "local_agent" ? (previous as LocalAgentTaskState) : undefined;
+  const preserveCompleted =
+    previousAgent?.status === "completed" &&
+    patch.preserveCompletedOnTermination === true &&
+    (patch.status === "failed" || patch.status === "killed");
+  const status = preserveCompleted ? "completed" : patch.status;
+  const error = preserveCompleted ? undefined : patch.error;
   const title = patch.title ?? previousAgent?.description ?? patch.id;
   const prompt = patch.prompt ?? previousAgent?.prompt ?? title;
   const ended =
-    patch.status === "completed" ||
-    patch.status === "failed" ||
-    patch.status === "killed";
+    status === "completed" ||
+    status === "failed" ||
+    status === "killed";
   // Merge live tool-use/token counts (forwarded by the daemon collab status
   // event) into the task's progress so AgentsRail renders real per-agent
   // activity. Carry the latest non-undefined count forward; never regress a
@@ -264,7 +275,7 @@ function applyPatch(
   return {
     id: patch.id,
     type: "local_agent",
-    status: patch.status,
+    status,
     description: title,
     startTime: previousAgent?.startTime ?? now,
     outputFile: previousAgent?.outputFile ?? outputUri(patch.id),
@@ -274,7 +285,7 @@ function applyPatch(
     prompt,
     agentType: patch.role ?? previousAgent?.agentType ?? "agent",
     ...(patch.model !== undefined ? { model: patch.model } : {}),
-    ...(patch.error !== undefined ? { error: patch.error } : {}),
+    ...(error !== undefined ? { error } : {}),
     retrieved: previousAgent?.retrieved ?? false,
     ...(previousAgent?.messages !== undefined ? { messages: previousAgent.messages } : {}),
     lastReportedToolCount:

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -39,7 +39,7 @@ const DEFAULT_WRITE_STDIN_YIELD_TIME_MS = 250;
 const MIN_YIELD_TIME_MS = 250;
 const MIN_EMPTY_YIELD_TIME_MS = 5_000;
 const MAX_YIELD_TIME_MS = 30_000;
-const DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS = 300_000;
+const MAX_EMPTY_WRITE_YIELD_TIME_MS = 300_000;
 const DEFAULT_MAX_PROCESSES = 64;
 const DEFAULT_OUTPUT_BUFFER_CHARS = 1024 * 1024;
 const PTY_ARGV0_EXECVE_SCRIPT =
@@ -354,7 +354,7 @@ function clampWriteYield(value: number | undefined, input: string): number {
   const base = Math.max(MIN_YIELD_TIME_MS, Math.floor(raw));
   if (input.length === 0) {
     return Math.min(
-      DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
+      MAX_EMPTY_WRITE_YIELD_TIME_MS,
       Math.max(MIN_EMPTY_YIELD_TIME_MS, base),
     );
   }
@@ -408,8 +408,7 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
   constructor(options: UnifiedExecManagerOptions = {}) {
     this.cwd = options.cwd ?? process.cwd();
     this.env = options.env;
-    this.maxTimeoutMs =
-      options.maxTimeoutMs ?? DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS;
+    this.maxTimeoutMs = options.maxTimeoutMs ?? Number.POSITIVE_INFINITY;
     this.maxProcesses = options.maxProcesses ?? DEFAULT_MAX_PROCESSES;
     this.sandboxManager = options.sandboxManager ?? new SandboxManager();
   }
@@ -474,20 +473,17 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
       tty,
     });
 
-    // Hard timeout: explicit `timeoutMs` always wins. When unset, non-tty
-    // calls fall back to `maxTimeoutMs` so abandoned processes (yield-and-
-    // forget) eventually get reaped. Tty sessions are intentionally
-    // long-lived (write_stdin interaction) and stay opt-in.
+    // A hard timeout is opt-in. Yielding a process must not silently
+    // create a lifetime limit: agents may legitimately keep terminal
+    // work alive for hours and return to it through write_stdin.
     const explicitTimeoutMs =
       request.timeoutMs !== undefined && request.timeoutMs > 0
         ? Math.min(request.timeoutMs, this.maxTimeoutMs)
         : null;
-    const effectiveTimeoutMs =
-      explicitTimeoutMs ?? (tty ? null : this.maxTimeoutMs);
-    if (effectiveTimeoutMs !== null) {
+    if (explicitTimeoutMs !== null) {
       entry.hardTimeout = setTimeout(() => {
         this.forceTerminate(entry);
-      }, effectiveTimeoutMs);
+      }, explicitTimeoutMs);
       entry.hardTimeout.unref?.();
     }
 

--- a/runtime/src/unified-exec/types.ts
+++ b/runtime/src/unified-exec/types.ts
@@ -65,6 +65,7 @@ export interface UnifiedExecRuntimeSandbox {
 export interface UnifiedExecManagerOptions {
   readonly cwd?: string;
   readonly env?: Record<string, string>;
+  /** Optional cap applied only when a request explicitly supplies timeoutMs. */
   readonly maxTimeoutMs?: number;
   readonly maxProcesses?: number;
   readonly sandboxManager?: UnifiedExecSandboxManager;
@@ -118,6 +119,7 @@ export interface ExecCommandToolOutput {
 }
 
 export interface UnifiedExecProcessManagerLike {
+  /** Explicit-timeout cap; Infinity means no configured cap. */
   readonly maxTimeoutMs: number;
   execCommand(request: ExecCommandRequest): Promise<ExecCommandToolOutput>;
   writeStdin(request: WriteStdinRequest): Promise<ExecCommandToolOutput>;

--- a/runtime/src/utils/Shell.ts
+++ b/runtime/src/utils/Shell.ts
@@ -45,8 +45,6 @@ import type {
   SandboxExecutionSurface,
 } from '../sandbox/execution-broker.js'
 
-const DEFAULT_TIMEOUT = 30 * 60 * 1000 // 30 minutes
-
 export type ShellConfig = {
   provider: ShellProvider
 }
@@ -200,7 +198,10 @@ export async function exec(
     sandboxExecutionBroker,
     sandboxExecutionSurface,
   } = options ?? {}
-  const commandTimeout = timeout || DEFAULT_TIMEOUT
+  const commandTimeout =
+    typeof timeout === 'number' && Number.isFinite(timeout) && timeout > 0
+      ? timeout
+      : null
 
   const provider = await resolveProvider[shellType]()
 

--- a/runtime/src/utils/ShellCommand.ts
+++ b/runtime/src/utils/ShellCommand.ts
@@ -125,7 +125,7 @@ class ShellCommandImpl implements ShellCommand {
   #onTimeoutCallback:
     | ((backgroundFn: (taskId: string) => boolean) => void)
     | undefined
-  #timeout: number
+  #timeout: number | null
   #shouldAutoBackground: boolean
   #resultResolver: ((result: ExecResult) => void) | null = null
   #exitCodeResolver: ((code: number) => void) | null = null
@@ -148,14 +148,17 @@ class ShellCommandImpl implements ShellCommand {
   constructor(
     childProcess: ChildProcess,
     abortSignal: AbortSignal,
-    timeout: number,
+    timeout: number | null | undefined,
     taskOutput: TaskOutput,
     shouldAutoBackground = false,
     maxOutputBytes = MAX_TASK_OUTPUT_BYTES,
   ) {
     this.#childProcess = childProcess
     this.#abortSignal = abortSignal
-    this.#timeout = timeout
+    this.#timeout =
+      typeof timeout === 'number' && Number.isFinite(timeout) && timeout > 0
+        ? timeout
+        : null
     this.#shouldAutoBackground = shouldAutoBackground
     this.#maxOutputBytes = maxOutputBytes
     this.taskOutput = taskOutput
@@ -272,11 +275,13 @@ class ShellCommandImpl implements ShellCommand {
     this.#childProcess.once('exit', this.#exitHandler.bind(this))
     this.#childProcess.once('error', this.#errorHandler.bind(this))
 
-    this.#timeoutId = setTimeout(
-      ShellCommandImpl.#handleTimeout,
-      this.#timeout,
-      this,
-    ) as NodeJS.Timeout
+    if (this.#timeout !== null) {
+      this.#timeoutId = setTimeout(
+        ShellCommandImpl.#handleTimeout,
+        this.#timeout,
+        this,
+      ) as NodeJS.Timeout
+    }
 
     const exitPromise = new Promise<number>(resolve => {
       this.#exitCodeResolver = resolve
@@ -320,7 +325,7 @@ class ShellCommandImpl implements ShellCommand {
         `Background command killed: output file exceeded ${MAX_TASK_OUTPUT_BYTES_DISPLAY}`,
         result.stderr,
       )
-    } else if (code === SIGTERM) {
+    } else if (code === SIGTERM && this.#timeout !== null) {
       result.stderr = prependStderr(
         `Command timed out after ${formatDuration(this.#timeout)}`,
         result.stderr,
@@ -387,7 +392,7 @@ class ShellCommandImpl implements ShellCommand {
 export function wrapSpawn(
   childProcess: ChildProcess,
   abortSignal: AbortSignal,
-  timeout: number,
+  timeout: number | null | undefined,
   taskOutput: TaskOutput,
   shouldAutoBackground = false,
   maxOutputBytes = MAX_TASK_OUTPUT_BYTES,

--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -27,7 +27,8 @@ export interface SupervisedProcessControl {
 }
 
 export interface SupervisedProcessOptions {
-  readonly timeoutMs: number;
+  /** Optional caller-supplied deadline. Omitted means unbounded. */
+  readonly timeoutMs?: number;
   readonly maxOutputBytes: number;
   readonly signal?: AbortSignal;
   readonly terminateGraceMs?: number;
@@ -68,7 +69,7 @@ export interface TerminateProcessTreeOptions {
   readonly label?: string;
 }
 
-/** Run a finite native helper with bounded output and process-tree cleanup. */
+/** Run a native helper with bounded output and process-tree cleanup. */
 export function runSupervisedProcess(
   command: SupervisedProcessCommand,
   options: SupervisedProcessOptions,
@@ -122,6 +123,7 @@ export function runSupervisedProcess(
     let exitCode: number | null = null;
     let exitSignal: NodeJS.Signals | null = null;
     let processError: Error | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
     let forceTimer: ReturnType<typeof setTimeout> | undefined;
     let backstopTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -155,7 +157,7 @@ export function runSupervisedProcess(
     const finish = (backstopExpired: boolean): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeoutTimer);
+      if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
       if (forceTimer !== undefined) clearTimeout(forceTimer);
       if (backstopTimer !== undefined) clearTimeout(backstopTimer);
       options.signal?.removeEventListener("abort", onAbort);
@@ -198,11 +200,13 @@ export function runSupervisedProcess(
     }
 
     const onAbort = (): void => requestStop("aborted");
-    const timeoutTimer = setTimeout(
-      () => requestStop("timeout"),
-      options.timeoutMs,
-    );
-    timeoutTimer.unref?.();
+    if (options.timeoutMs !== undefined) {
+      timeoutTimer = setTimeout(
+        () => requestStop("timeout"),
+        options.timeoutMs,
+      );
+      timeoutTimer.unref?.();
+    }
     options.signal?.addEventListener("abort", onAbort, { once: true });
     // Abort may race the pre-spawn check and listener installation.
     if (options.signal?.aborted === true) onAbort();
@@ -232,7 +236,10 @@ export function runSupervisedProcess(
 }
 
 function validateLimits(options: SupervisedProcessOptions): void {
-  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+  if (
+    options.timeoutMs !== undefined &&
+    (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)
+  ) {
     throw new Error("supervised process timeoutMs must be finite and positive");
   }
   if (!Number.isFinite(options.maxOutputBytes) || options.maxOutputBytes <= 0) {

--- a/runtime/src/workflow/independent-review.ts
+++ b/runtime/src/workflow/independent-review.ts
@@ -32,7 +32,8 @@ export interface ReviewerInvoker {
     readonly systemPrompt: string;
     readonly userMessage: string;
     readonly reviewerModel: string;
-    readonly timeoutMs: number;
+    /** Optional operator-supplied deadline. Omitted means unbounded. */
+    readonly timeoutMs?: number;
     /**
      * Owning workflow run id (additive, Phase 5): lets a daemon-backed
      * invoker route the one-shot review through the run's own session.
@@ -48,8 +49,6 @@ export class ReviewParseError extends Error {
     this.name = "ReviewParseError";
   }
 }
-
-export const DEFAULT_REVIEW_TIMEOUT_MS = 600_000;
 
 /**
  * A finding blocks completion when the reviewer marked it high priority
@@ -160,8 +159,8 @@ export async function runIndependentReview(opts: {
     systemPrompt: prompt.systemPrompt,
     userMessage: prompt.userMessage,
     reviewerModel: opts.spec.reviewerModel,
-    timeoutMs: opts.timeoutMs ?? DEFAULT_REVIEW_TIMEOUT_MS,
     runId: opts.step.runId,
+    ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
   });
   const review = parseReviewOutput(raw);
   // parseReviewOutput's plain-text fallback has this exact shape; a review

--- a/runtime/src/workflow/verification.ts
+++ b/runtime/src/workflow/verification.ts
@@ -34,11 +34,11 @@ export interface WorkflowCommandRunner {
   run(input: {
     readonly script: string;
     readonly cwd: string;
-    readonly timeoutMs: number;
+    /** Optional operator-supplied deadline. Omitted means unbounded. */
+    readonly timeoutMs?: number;
   }): Promise<WorkflowCommandResult>;
 }
 
-export const DEFAULT_VERIFICATION_TIMEOUT_MS = 900_000;
 const EXCERPT_BYTES = 4_096;
 
 function sha256(bytes: Uint8Array): `sha256:${string}` {
@@ -86,7 +86,6 @@ export async function runRequiredVerification(opts: {
     labels.add(command.label);
   }
   const parallelism = Math.max(1, Math.floor(opts.parallelism));
-  const timeoutMs = opts.timeoutMsPerCommand ?? DEFAULT_VERIFICATION_TIMEOUT_MS;
 
   const records: VerifiedChangeCommandRecord[] = new Array(commands.length);
   const excerpts: Record<string, { stdout: string; stderr: string }> = {};
@@ -102,7 +101,9 @@ export async function runRequiredVerification(opts: {
         result = await runner.run({
           script: command.script,
           cwd: worktreePath,
-          timeoutMs,
+          ...(opts.timeoutMsPerCommand !== undefined
+            ? { timeoutMs: opts.timeoutMsPerCommand }
+            : {}),
         });
       } catch (error) {
         // A runner crash is a failing command with diagnostic stderr, never

--- a/runtime/tests/agents/control.test.ts
+++ b/runtime/tests/agents/control.test.ts
@@ -148,7 +148,7 @@ describe("AgentControl", () => {
     expect(live.metadata.agentPath).toBe("/root/task_3");
   });
 
-  it("reaps a keep-alive worker idle past the grace and frees its registry slot", async () => {
+  it("keeps an idle reusable worker alive indefinitely between assignments", async () => {
     vi.useFakeTimers();
     try {
       const session = stubSession();
@@ -159,10 +159,11 @@ describe("AgentControl", () => {
       // Worker finishes a turn and parks idle (keep-alive between turns).
       live.status.markRunning("turn-1");
       live.status.markIdle("turn-1");
-      // Advance past the 10min grace + one 60s reaper interval.
-      await vi.advanceTimersByTimeAsync(10 * 60_000 + 60_000 + 1_000);
-      expect(live.status.value.status).toBe("shutdown");
-      expect(registry.activeCount).toBe(0);
+      // Long swarms can park workers for hours before assigning follow-up
+      // work. Advancing a full day must not trigger hidden lifecycle cleanup.
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+      expect(live.status.value.status).toBe("idle");
+      expect(registry.activeCount).toBe(1);
     } finally {
       vi.useRealTimers();
     }

--- a/runtime/tests/agents/jobs/job-orchestrator.test.ts
+++ b/runtime/tests/agents/jobs/job-orchestrator.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CsvAgentJobsRepository } from "../../state/csv-agent-jobs.js";
 import { openStateDatabases } from "../../state/sqlite-driver.js";
 import {
@@ -19,6 +19,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   await rm(workDir, { recursive: true, force: true });
 });
 
@@ -47,6 +48,53 @@ function fakeSpawnReporter(): AgentJobSpawn & {
 }
 
 describe("runAgentsOnCsv", () => {
+  it("does not impose a default runtime deadline on workers", async () => {
+    const csvPath = join(workDir, "input.csv");
+    await writeFile(csvPath, "id,value\nrow1,a\n", "utf8");
+    vi.useFakeTimers();
+    let markSpawned!: () => void;
+    const spawned = new Promise<void>((resolve) => {
+      markSpawned = resolve;
+    });
+    const spawn: AgentJobSpawn = {
+      async spawn(ctx) {
+        markSpawned();
+        setTimeout(() => {
+          recordAgentJobResult({
+            jobId: ctx.jobId,
+            itemId: ctx.itemId,
+            result: { completedAfterHours: true },
+          });
+        }, 2 * 60 * 60_000);
+      },
+      async cancelOutstanding() {},
+    };
+
+    const pending = runAgentsOnCsv({
+      csvPath,
+      instruction: "long analysis",
+      idColumn: "id",
+      spawn,
+    });
+    const outcome = pending.then(
+      (result) => ({ result }),
+      (error: unknown) => ({ error }),
+    );
+    await spawned;
+    await vi.advanceTimersByTimeAsync(2 * 60 * 60_000);
+
+    expect(await outcome).toMatchObject({
+      result: {
+        items: [
+          {
+            status: "completed",
+            result: { completedAfterHours: true },
+          },
+        ],
+      },
+    });
+  });
+
   it("spawns one worker per row and collects their results", async () => {
     const csvPath = join(workDir, "input.csv");
     await writeFile(csvPath, "id,value\nrow1,a\nrow2,b\n", "utf8");

--- a/runtime/tests/agents/role.test.ts
+++ b/runtime/tests/agents/role.test.ts
@@ -164,7 +164,7 @@ describe("role registry", () => {
     const role = getAgentRole(DEFAULT_WORKSPACE, "awaiter")!;
     expect(role.config.background).toBe(true);
     expect(role.config.reasoningEffort).toBe("low");
-    expect(role.config.timeoutMs).toBe(3_600_000);
+    expect(role.config.timeoutMs).toBeUndefined();
   });
 
   it("derives xhigh reasoning effort from user role layers", () => {

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -1169,6 +1169,81 @@ describe("runAgent", () => {
     ).toBe(42);
   });
 
+  it("projects usage before a tool-using subagent turn completes without double-counting it", async () => {
+    const provider = makeProvider([
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "system.echo", arguments: "{}" }],
+        finishReason: "tool_calls",
+        usage: { promptTokens: 31, completionTokens: 11, totalTokens: 42 },
+      },
+      {
+        content: "tool work complete",
+        finishReason: "stop",
+        usage: { promptTokens: 50, completionTokens: 8, totalTokens: 58 },
+      },
+    ]);
+    const session = makeStubSession({
+      services: {
+        provider,
+        registry: {
+          tools: [
+            {
+              name: "system.echo",
+              description: "echo",
+              inputSchema: { type: "object" },
+              execute: async () => ({ content: JSON.stringify({ ok: true }) }),
+            },
+          ],
+          toLLMTools: () => [
+            {
+              type: "function",
+              function: {
+                name: "system.echo",
+                description: "echo",
+                parameters: { type: "object" },
+              },
+            },
+          ],
+          dispatch: async () => ({ content: JSON.stringify({ ok: true }) }),
+        } satisfies ToolRegistry,
+      },
+    });
+    const { live } = await spawnLive(session);
+    const iter = runAgent({
+      live,
+      parent: session,
+      initialMessages: [{ role: "user", content: "go" }],
+      taskPrompt: "go",
+    });
+
+    await nextProgressEvent(iter, "tool_call");
+
+    // The first provider response is durable, but the multi-iteration turn is
+    // still open. This is the exact point where the live rail used to show 0.
+    expect(live.status.value.status).toBe("running");
+    expect(live.tokenUsage).toEqual({
+      inputTokens: 31,
+      outputTokens: 11,
+      totalTokens: 42,
+    });
+
+    const { events, result } = await collectRun(iter);
+    expect(result.outcome).toBe("completed");
+    expect(live.tokenUsage).toEqual({
+      inputTokens: 81,
+      outputTokens: 19,
+      totalTokens: 100,
+    });
+    expect(
+      events.find((event) => event.kind === "usage_update"),
+    ).toMatchObject({
+      inputTokens: 81,
+      outputTokens: 19,
+      totalTokens: 100,
+    });
+  });
+
   it("ignores array-shaped parent services when resolving the provider", async () => {
     const provider = makeProvider([{ content: "should not run" }]);
     const session = makeStubSession();
@@ -1324,6 +1399,7 @@ describe("runAgent", () => {
     expect(provider.chatStream).toHaveBeenCalledTimes(2);
     expect(result.finalMessage).toBe("tool work complete");
     expect(result.toolCallCount).toBe(1);
+    expect(live.toolCallCount).toBe(1);
   });
 
   it("applies a per-spawn service tier to the child session provider request", async () => {
@@ -1711,6 +1787,30 @@ describe("runAgent", () => {
     } finally {
       await stopKeepAliveRun(iter, live.abortController);
     }
+  });
+
+  it("closes an idle keep-alive worker as completed instead of failing its finished turn", async () => {
+    const provider = makeProvider([{ content: "verified" }]);
+    const session = makeStubSession({ services: { provider } });
+    const { live } = await spawnLive(session);
+    const iter = runAgent({
+      live,
+      parent: session,
+      initialMessages: [{ role: "user", content: "verify" }],
+      taskPrompt: "verify",
+      keepAlive: true,
+    });
+
+    const completed = await nextProgressEvent(iter, "turn_complete");
+    expect(completed.finalMessage).toBe("verified");
+    live.abortController.abort("agent shutdown");
+
+    const { result } = await collectRun(iter);
+    expect(result).toMatchObject({
+      outcome: "completed",
+      finalMessage: "verified",
+    });
+    expect(live.status.value.status).toBe("completed");
   });
 
   it("fsyncs one correlated child outcome before projecting its one parent receipt", async () => {

--- a/runtime/tests/agents/v2/admission-classification.test.ts
+++ b/runtime/tests/agents/v2/admission-classification.test.ts
@@ -51,6 +51,18 @@ describe("collaboration control admission classification", () => {
     }
   });
 
+  it("classifies mailbox draining as mutating but replay-safe", () => {
+    const registry = collaborationRegistry();
+    const wait = registry.tools.find((tool) => tool.name === "wait_agent");
+
+    expect(wait).toMatchObject({
+      isReadOnly: false,
+      recoveryCategory: "idempotent",
+      cancellationUsage: "zero",
+      metadata: expect.objectContaining({ mutating: true }),
+    });
+  });
+
   it("admits each control effect as a zero-cost tool_exec boundary", async () => {
     let reservationSequence = 0;
     const acquire = vi.fn(

--- a/runtime/tests/app-server/agent-cli.contract.test.ts
+++ b/runtime/tests/app-server/agent-cli.contract.test.ts
@@ -2,12 +2,13 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 import {
   collectDaemonClientEnvOverrides,
   createConnectedAgenCJsonLineDaemonTuiClient,
   createAgenCJsonLineDaemonClient,
+  createAgenCJsonLineDaemonRequestClient,
   defaultEnsureDaemonReady,
   formatAgenCAgentAttachResult,
   formatAgenCAgentList,
@@ -1503,6 +1504,7 @@ autostart = false
       authCookie: "timeout-cookie",
       timeoutMs: 50,
     });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       await expect(
         client.request("message.stream", {
@@ -1515,8 +1517,123 @@ autostart = false
         streamId: "stream_delayed",
         acceptedAt: "2026-05-01T12:00:04.000Z",
       });
+      expect(
+        timeoutSpy.mock.calls.some(([, delay]) => delay === 30 * 60_000),
+      ).toBe(false);
+    } finally {
+      timeoutSpy.mockRestore();
+      await client.close();
+      await server.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps message.send requests alive beyond the generic daemon timeout", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agenc-agent-send-timeout-"));
+    const socketPath = join(dir, "daemon.sock");
+    const server = new AgenCUnixSocketServer({
+      socketPath,
+      onMessage: async (message, context) => {
+        if (message.method === "initialize") {
+          await context.send({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              type: "initialized",
+              protocolVersion: "1.0.0",
+              capabilities: {},
+            },
+          });
+          return;
+        }
+        if (message.method === "message.send") {
+          await new Promise((resolve) => setTimeout(resolve, 120));
+          await context.send({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              messageId: "message_delayed",
+              acceptedAt: "2026-05-01T12:00:04.000Z",
+            },
+          });
+        }
+      },
+    });
+
+    await server.listen();
+    const client = await createConnectedAgenCJsonLineDaemonTuiClient({
+      socketPath,
+      authCookie: "timeout-cookie",
+      timeoutMs: 50,
+    });
+    try {
+      await expect(
+        client.request("message.send", {
+          sessionId: "session_delayed",
+          content: "continue",
+        }),
+      ).resolves.toEqual({
+        messageId: "message_delayed",
+        acceptedAt: "2026-05-01T12:00:04.000Z",
+      });
     } finally {
       await client.close();
+      await server.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps one-shot message.stream requests unbounded too", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agenc-agent-one-shot-stream-"));
+    const socketPath = join(dir, "daemon.sock");
+    const server = new AgenCUnixSocketServer({
+      socketPath,
+      onMessage: async (message, context) => {
+        if (message.method === "initialize") {
+          await context.send({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              type: "initialized",
+              protocolVersion: "1.0.0",
+              capabilities: {},
+            },
+          });
+          return;
+        }
+        if (message.method === "message.stream") {
+          await new Promise((resolve) => setTimeout(resolve, 120));
+          await context.send({
+            jsonrpc: "2.0",
+            id: message.id,
+            result: {
+              messageId: "message_one_shot",
+              streamId: "stream_one_shot",
+              acceptedAt: "2026-05-01T12:00:04.000Z",
+            },
+          });
+        }
+      },
+    });
+
+    await server.listen();
+    const client = createAgenCJsonLineDaemonRequestClient({
+      socketPath,
+      authCookie: "timeout-cookie",
+      timeoutMs: 50,
+    });
+    try {
+      await expect(
+        client.request("message.stream", {
+          sessionId: "session_one_shot",
+          content: "continue",
+          streamId: "stream_one_shot",
+        }),
+      ).resolves.toMatchObject({
+        messageId: "message_one_shot",
+        streamId: "stream_one_shot",
+      });
+    } finally {
       await server.close();
       await rm(dir, { recursive: true, force: true });
     }

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -8,6 +8,7 @@ import {
   AgenCDelegateBackgroundAgentRunner,
   daemonEventFromUnboundSessionEvent,
   notificationFromDaemonEvent,
+  resolvePermissionDecisionTimeoutMs,
   type AgenCBootstrapFunction,
   type AgenCEnsureAgentControlFunction,
   managedTokenUsage,
@@ -27,6 +28,22 @@ const backgroundAgentRunnerSourcePath = new URL(
   "../../src/app-server/background-agent-runner.ts",
   import.meta.url,
 );
+
+describe("background permission timing", () => {
+  it("has no implicit permission-decision deadline", () => {
+    expect(resolvePermissionDecisionTimeoutMs({})).toBeUndefined();
+    expect(
+      resolvePermissionDecisionTimeoutMs({
+        AGENC_PERMISSION_TIMEOUT_MS: "invalid",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolvePermissionDecisionTimeoutMs({
+        AGENC_PERMISSION_TIMEOUT_MS: "7200000",
+      }),
+    ).toBe(7_200_000);
+  });
+});
 
 type TurnCompleteProgressProjection = (
   agentId: string,

--- a/runtime/tests/budget/admitted-tool-call.test.ts
+++ b/runtime/tests/budget/admitted-tool-call.test.ts
@@ -217,6 +217,58 @@ describe("runAdmittedToolCall", () => {
     ]);
   });
 
+  it("settles cancelled zero-cost idempotent waits without unknown-outcome residue", async () => {
+    const state = toolHarness();
+    const tool = {
+      name: "wait_agent",
+      recoveryCategory: "idempotent",
+      cancellationUsage: "zero",
+      admissionEstimate: () => ({
+        maxInputTokens: 0,
+        maxOutputTokens: 0,
+        maxCostUsd: 0,
+      }),
+    } as unknown as Tool;
+    const invoked = Promise.withResolvers<AbortSignal>();
+    const call = runAdmittedToolCall({
+      session: state.session,
+      turnId: "turn-1",
+      callId: "call-wait",
+      tool,
+      args: {},
+      invoke: async ({ signal }) => {
+        invoked.resolve(signal);
+        return new Promise((resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      },
+    });
+    await invoked.promise;
+    const cancellation = new AdmissionDeniedError(
+      "parent_cancelled",
+      "cancelled",
+    );
+    state.leaseController.abort(cancellation);
+
+    await expect(call).rejects.toBe(cancellation);
+    expect(state.holdUnknown).not.toHaveBeenCalled();
+    expect(state.reconcile).toHaveBeenCalledWith("tool-reservation", {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    expect(state.effectEvents.map((event) => event.msg.type)).toEqual([
+      "effect_intent",
+      "effect_result",
+    ]);
+    expect(state.effectEvents.at(-1)?.msg).toMatchObject({
+      type: "effect_result",
+      payload: { outcome: "cancelled" },
+    });
+  });
+
   it("rejects a late tool success after durable cancellation", async () => {
     const state = toolHarness();
     const tool = {

--- a/runtime/tests/commands/swarm.test.ts
+++ b/runtime/tests/commands/swarm.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { swarmCommand } from "../../src/commands/swarm.js";
 import { swarmModeProducer } from "../../src/prompts/attachments/swarm-mode.js";
 import { routeSwarmTask } from "../../src/agents/swarm-routing.js";
+import { getDefaultAppState } from "../../src/tui/state/AppStateStore.js";
 import {
   getSettingsForSource,
   updateSettingsForSource,
@@ -63,6 +64,11 @@ describe("/swarm command", () => {
     expect(result.kind).toBe("text");
     expect(ctx.appState.state.swarmMode).toBe(true);
     expect(getSettingsForSource("userSettings")?.swarmMode).toBe(true);
+  });
+
+  test("a fresh TUI restores persisted swarm mode immediately", () => {
+    updateSettingsForSource("userSettings", { swarmMode: true });
+    expect(getDefaultAppState().swarmMode).toBe(true);
   });
 
   test("off disables swarm mode again", async () => {

--- a/runtime/tests/config/config.test.ts
+++ b/runtime/tests/config/config.test.ts
@@ -95,6 +95,7 @@ describe("schema: defaultConfig", () => {
     expect(cfg.max_turns).toBeUndefined();
     expect(cfg.agent_max_threads).toBeUndefined();
     expect(cfg.agent_max_depth).toBe(1);
+    expect(cfg.stream_watchdog_timeout_ms).toBeUndefined();
     expect(cfg.auth?.backend).toBe("remote");
     expect(cfg.auth?.managedKeys?.enabled).toBe(true);
     expect(cfg.plugins?.enabled).toBe(false);

--- a/runtime/tests/eval/eval-executor-agent-run.test.ts
+++ b/runtime/tests/eval/eval-executor-agent-run.test.ts
@@ -108,6 +108,7 @@ type ContainerPlan = AgentContainerPlan | VerifyContainerPlan;
 class FakeAgentRunner implements ContainerRunner {
   readonly createOptions: Array<CreateTaskContainerOptions | undefined> = [];
   readonly writtenFiles: string[] = [];
+  readonly execRequests: ContainerExecRequest[] = [];
   private index = -1;
 
   constructor(private readonly plans: readonly ContainerPlan[]) {}
@@ -132,6 +133,7 @@ class FakeAgentRunner implements ContainerRunner {
   }
 
   async exec(_handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult> {
+    this.execRequests.push(request);
     const plan = this.plans[this.index]!;
     if (plan.kind === "agent") {
       if (request.script.includes("dist/bin/agenc.js") || request.script.startsWith("set -u")) {
@@ -233,6 +235,10 @@ describe("eval executor agent run", () => {
       // with no mounts. (Network isolation is unconditional in the runner.)
       expect(runner.createOptions[0]!.readOnlyMounts).toHaveLength(1);
       expect(runner.createOptions[1]?.readOnlyMounts ?? []).toHaveLength(0);
+      const agentRequest = runner.execRequests.find((request) =>
+        request.script.startsWith("set -u"),
+      );
+      expect(agentRequest?.timeoutMs).toBeUndefined();
       // Oracle isolation: only the prompt reaches the agent container (c-0);
       // the test patch lands only in the verify container (c-1).
       expect(runner.writtenFiles.filter((f) => f.startsWith("c-0:"))).toEqual([
@@ -241,6 +247,23 @@ describe("eval executor agent run", () => {
       expect(
         runner.writtenFiles.filter((f) => f.startsWith("c-1:") && f.includes("test.patch")),
       ).toHaveLength(1);
+    });
+  });
+
+  test("an explicit evaluation-agent deadline remains opt-in", async () => {
+    await withOverlay(async (config) => {
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: "" },
+      ]);
+      await runAgentOnTask(runner, EMPTY_SETUP, {
+        ...config,
+        agentTimeoutMs: 7_200_000,
+      });
+
+      const agentRequest = runner.execRequests.find((request) =>
+        request.script.startsWith("set -u"),
+      );
+      expect(agentRequest?.timeoutMs).toBe(7_200_000);
     });
   });
 

--- a/runtime/tests/gaphunt3/llm-providers-grok-adapter.test.ts
+++ b/runtime/tests/gaphunt3/llm-providers-grok-adapter.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { GrokProvider } from "src/llm/providers/grok/adapter";
-import { LLMTimeoutError } from "src/llm/errors";
+import { LLMProviderError } from "src/llm/errors";
 import type { LLMStreamChunk } from "src/llm/types";
 
 // gaphunt3 #21: grok chatStream must honor the caller's AbortSignal *after* the
@@ -137,9 +137,8 @@ describe("gaphunt3 #21: grok chatStream honors caller abort after stream open", 
     await flushMicrotasks();
 
     expect(settled).toBe("rejected");
-    // Caller aborts map through the provider error mapper to LLMTimeoutError,
-    // the same shape one-shot aborts already produce in this adapter.
-    expect(captured).toBeInstanceOf(LLMTimeoutError);
+    // Caller cancellation must not masquerade as a retryable provider timeout.
+    expect(captured).toBeInstanceOf(LLMProviderError);
     // The in-flight stream iterator must be torn down on abort.
     expect(returnCalled()).toBe(true);
     // No visible content should have leaked from the aborted turn.
@@ -288,7 +287,7 @@ describe("gaphunt3 #21: grok chatStream honors caller abort after stream open", 
     await flushMicrotasks();
 
     expect(settled).toBe("rejected");
-    expect(captured).toBeInstanceOf(LLMTimeoutError);
+    expect(captured).toBeInstanceOf(LLMProviderError);
     expect(returnCalled()).toBe(true);
   });
 });

--- a/runtime/tests/gaphunt3/llm-timeout.test.ts
+++ b/runtime/tests/gaphunt3/llm-timeout.test.ts
@@ -86,6 +86,33 @@ describe("gaphunt3 #42: withTimeout external-signal abort reason", () => {
     expect(mapped).not.toBeInstanceOf(LLMTimeoutError);
   });
 
+  it("does not classify AbortController's default DOMException as a timeout", async () => {
+    const controller = new AbortController();
+    const physical = Promise.withResolvers<string>();
+    const promise = withTimeout<string>(
+      () => physical.promise,
+      10 * 60_000,
+      "TestProvider",
+      controller.signal,
+    );
+
+    controller.abort();
+    physical.resolve("late result");
+
+    const err = await promise.then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (e: unknown) => e as Error,
+    );
+
+    expect(err.name).not.toBe("AbortError");
+    expect((err as { code?: unknown }).code).not.toBe("ABORT_ERR");
+    expect(mapLLMError("TestProvider", err, 10 * 60_000)).not.toBeInstanceOf(
+      LLMTimeoutError,
+    );
+  });
+
   it("preserves an Error reason verbatim (including its name/code)", async () => {
     const controller = new AbortController();
     const reason = new Error("user cancelled");

--- a/runtime/tests/llm/client.test.ts
+++ b/runtime/tests/llm/client.test.ts
@@ -21,7 +21,7 @@ describe("ProviderHttpClient", () => {
     expect(session.providerName).toBe("openai");
     expect(session.wireApi).toBe("responses");
     expect(session.requestRetryBudget.maxRetries).toBe(2);
-    expect(session.streamIdleTimeoutMs).toBeGreaterThan(0);
+    expect(session.streamIdleTimeoutMs).toBe(0);
   });
 
   test("bindConversationId and clear/reset helpers affect every turn session built from the client", async () => {

--- a/runtime/tests/llm/providers/grok/adapter.test.ts
+++ b/runtime/tests/llm/providers/grok/adapter.test.ts
@@ -860,6 +860,83 @@ describe("GrokProvider stream timeout semantics", () => {
     };
   }
 
+  test("an unconfigured stream survives a six-hour silent chunk gap", async () => {
+    vi.useFakeTimers();
+    try {
+      const sixHours = 6 * 60 * 60_000;
+      const provider = new GrokProvider({
+        apiKey: "xai-test",
+        model: "grok-4-fast",
+      });
+      const create = vi.fn().mockImplementation(() =>
+        withResponse({
+          async *[Symbol.asyncIterator]() {
+            yield { type: "response.output_text.delta", delta: "one " };
+            await new Promise((resolve) => setTimeout(resolve, sixHours));
+            yield { type: "response.output_text.delta", delta: "two" };
+            yield {
+              type: "response.completed",
+              response: buildXaiResponse(
+                "resp_unbounded_silent_stream",
+                "one two",
+              ),
+            };
+          },
+        }),
+      );
+      (provider as any).client = { responses: { create } };
+
+      const resultPromise = provider.chatStream(
+        [{ role: "user", content: "hello" }],
+        () => {},
+      );
+      resultPromise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(sixHours + 1);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        content: "one two",
+        finishReason: "stop",
+      });
+      expect(create).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("bypasses the SDK's implicit ten-minute header timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new GrokProvider({
+        apiKey: "xai-test",
+        model: "grok-4-fast",
+      });
+      const client = await (provider as any).ensureClient();
+      const responseGate = Promise.withResolvers<Response>();
+      client.fetch = vi.fn(() => responseGate.promise);
+      const controller = new AbortController();
+      let settled = false;
+      const request = client
+        .fetchWithTimeout(
+          "https://api.x.ai/v1/responses",
+          { method: "POST" },
+          600_000,
+          controller,
+        )
+        .finally(() => {
+          settled = true;
+        });
+
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60_000);
+      expect(settled).toBe(false);
+      expect(controller.signal.aborted).toBe(false);
+
+      responseGate.resolve(new Response(null, { status: 200 }));
+      await expect(request).resolves.toBeInstanceOf(Response);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("healthy stream longer than timeoutMs completes — timeout is inter-chunk idle, not a total deadline", async () => {
     // Revert guard: with the pre-0.7.3 streamDeadlineAt total-budget
     // semantics this stream is killed at t=1000ms mid-flight and the call

--- a/runtime/tests/llm/registry/registry.test.ts
+++ b/runtime/tests/llm/registry/registry.test.ts
@@ -120,7 +120,7 @@ describe("LLM registry", () => {
       apiKeyEnvVar: "XAI_API_KEY",
       requestMaxRetries: 4,
       streamMaxRetries: 5,
-      streamIdleTimeoutMs: 300_000,
+      streamIdleTimeoutMs: 0,
       supportsWebsockets: false,
     });
 

--- a/runtime/tests/llm/stream-watchdog.silent-generation.test.ts
+++ b/runtime/tests/llm/stream-watchdog.silent-generation.test.ts
@@ -7,12 +7,10 @@ import {
 import { GrokProvider } from "../../src/llm/providers/grok/adapter.js";
 
 // Idle-tolerance resolution for providers with silent server-side
-// generation. xAI emits ZERO bytes (no SSE keepalives) while generating
-// function-call arguments — 51s measured for a ~250-line file — so any
-// watchdog window shorter than the provider-declared tolerance kills
-// healthy streams and forces full-regeneration reconnect loops. This is
-// the failure the 0.7.3 provider-level fix and the 90s session default
-// each only half-addressed.
+// generation. xAI can emit ZERO bytes while generating function-call
+// arguments, so provider silence must not create a deadline by default.
+// Operators may still opt in, and provider suggestions can make that
+// explicitly configured window safer.
 
 describe("resolveSessionStreamIdleTimeoutMs", () => {
   const originalEnv = process.env.AGENC_STREAM_IDLE_TIMEOUT_MS;
@@ -26,14 +24,14 @@ describe("resolveSessionStreamIdleTimeoutMs", () => {
     else process.env.AGENC_STREAM_IDLE_TIMEOUT_MS = originalEnv;
   });
 
-  it("defaults to 90s with no inputs", () => {
-    expect(resolveSessionStreamIdleTimeoutMs({})).toBe(90_000);
+  it("is unbounded with no inputs", () => {
+    expect(resolveSessionStreamIdleTimeoutMs({})).toBe(0);
   });
 
-  it("uses the provider suggestion when nothing is configured", () => {
+  it("does not turn a provider suggestion into an implicit deadline", () => {
     expect(
       resolveSessionStreamIdleTimeoutMs({ providerSuggestedMs: 300_000 }),
-    ).toBe(300_000);
+    ).toBe(0);
   });
 
   it("lets config win when it is at or above the provider suggestion", () => {
@@ -70,18 +68,23 @@ describe("resolveSessionStreamIdleTimeoutMs", () => {
     ).toBe(15_000);
   });
 
-  it("resolveStreamIdleTimeoutMs still honors a direct preferred value", () => {
-    expect(resolveStreamIdleTimeoutMs(120_000)).toBe(120_000);
-    expect(resolveStreamIdleTimeoutMs()).toBe(90_000);
+  it("an explicit zero env value disables an explicit config value", () => {
+    process.env.AGENC_STREAM_IDLE_TIMEOUT_MS = "0";
+    expect(
+      resolveSessionStreamIdleTimeoutMs({
+        configuredMs: 600_000,
+        providerSuggestedMs: 900_000,
+      }),
+    ).toBe(0);
   });
 
-  it("grok declares xAI's documented 600s per-chunk idle tolerance", () => {
-    // xAI docs, build/enterprise: "per-chunk idle timeout defaults to 600
-    // seconds" (proxy guidance >=10 minutes), and tools/function-calling
-    // WARNS that streamed function calls arrive whole in a single chunk.
-    // The declared tolerance must not silently drift below the documented
-    // figure — 118s of zero-byte silence was measured for a ~600-line file.
+  it("resolveStreamIdleTimeoutMs still honors a direct preferred value", () => {
+    expect(resolveStreamIdleTimeoutMs(120_000)).toBe(120_000);
+    expect(resolveStreamIdleTimeoutMs()).toBe(0);
+  });
+
+  it("grok does not declare an implicit per-chunk deadline", () => {
     const provider = new GrokProvider({ apiKey: "test", model: "grok-4.5" });
-    expect(provider.suggestedStreamIdleTimeoutMs).toBe(600_000);
+    expect(provider.suggestedStreamIdleTimeoutMs).toBeUndefined();
   });
 });

--- a/runtime/tests/llm/stream-watchdog.test.ts
+++ b/runtime/tests/llm/stream-watchdog.test.ts
@@ -9,9 +9,12 @@ import {
 describe("stream-watchdog", () => {
   let nowMs = 0;
   let envDisable: string | undefined;
+  let envTimeout: string | undefined;
 
   beforeEach(() => {
     envDisable = process.env.AGENC_DISABLE_STREAM_WATCHDOG;
+    envTimeout = process.env.AGENC_STREAM_IDLE_TIMEOUT_MS;
+    delete process.env.AGENC_STREAM_IDLE_TIMEOUT_MS;
     nowMs = 0;
     vi.useFakeTimers();
     vi.spyOn(performance, "now").mockImplementation(() => nowMs);
@@ -22,14 +25,29 @@ describe("stream-watchdog", () => {
     vi.restoreAllMocks();
     if (envDisable === undefined) delete process.env.AGENC_DISABLE_STREAM_WATCHDOG;
     else process.env.AGENC_DISABLE_STREAM_WATCHDOG = envDisable;
+    if (envTimeout === undefined) delete process.env.AGENC_STREAM_IDLE_TIMEOUT_MS;
+    else process.env.AGENC_STREAM_IDLE_TIMEOUT_MS = envTimeout;
   });
 
-  test("AgenC remains default-on unless explicitly disabled", () => {
+  test("the feature gate remains available unless explicitly disabled", () => {
     delete process.env.AGENC_DISABLE_STREAM_WATCHDOG;
     expect(isStreamWatchdogEnabled()).toBe(true);
 
     process.env.AGENC_DISABLE_STREAM_WATCHDOG = "1";
     expect(isStreamWatchdogEnabled()).toBe(false);
+  });
+
+  test("installs no deadline by default, even after six hours", () => {
+    const abortController = new AbortController();
+    const onFired = vi.fn();
+    const handle = installStreamWatchdog({ abortController, onFired });
+
+    nowMs = 6 * 60 * 60_000;
+    vi.advanceTimersByTime(nowMs);
+
+    expect(handle.timeoutMs).toBe(0);
+    expect(onFired).not.toHaveBeenCalled();
+    expect(abortController.signal.aborted).toBe(false);
   });
 
   test("emits a half-time warning before the monotonic timeout abort", () => {

--- a/runtime/tests/mcp-client/tools.test.ts
+++ b/runtime/tests/mcp-client/tools.test.ts
@@ -632,6 +632,75 @@ describe("createToolBridge — T6 gap #119 observer wiring", () => {
     }
   });
 
+  test("does not impose a default MCP tool-call deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const rawResult = Promise.withResolvers<{
+        content: Array<{ type: "text"; text: string }>;
+        isError: boolean;
+      }>();
+      let rpcSignal: AbortSignal | undefined;
+      let rpcOptions:
+        | {
+            timeout?: number;
+            resetTimeoutOnProgress?: boolean;
+          }
+        | undefined;
+      const callTool = vi.fn(
+        async (
+          _params: unknown,
+          _schema: unknown,
+          requestOptions?: {
+            signal?: AbortSignal;
+            timeout?: number;
+            resetTimeoutOnProgress?: boolean;
+          },
+        ) => {
+          rpcSignal = requestOptions?.signal;
+          rpcOptions = requestOptions;
+          return rawResult.promise;
+        },
+      );
+      const bridge = await createToolBridge(
+        {
+          listTools: async () => ({
+            tools: [{ name: "long_remote", description: "runs for hours" }],
+          }),
+          callTool,
+          close: async () => {},
+        },
+        "remote",
+      );
+      let settled = false;
+
+      const running = bridge.tools[0]!.execute({ value: 1 });
+      void running.finally(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callTool).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+      expect(rpcSignal?.aborted).toBe(false);
+      expect(settled).toBe(false);
+      expect(rpcOptions).toMatchObject({
+        timeout: 2_147_483_647,
+        resetTimeoutOnProgress: true,
+      });
+
+      rawResult.resolve({
+        content: [{ type: "text", text: "finished" }],
+        isError: false,
+      });
+      await expect(running).resolves.toMatchObject({
+        content: "finished",
+        isError: false,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("normalizes malformed MCP tool call result content", async () => {
     const observedResults: string[] = [];
     const bridge = await createToolBridge(

--- a/runtime/tests/permissions/guardian/reviewer.test.ts
+++ b/runtime/tests/permissions/guardian/reviewer.test.ts
@@ -34,6 +34,7 @@ afterEach(() => {
 });
 
 const REVIEWER_CONTRACT_TIMEOUT_MS = 30_000;
+const SIX_HOURS_MS = 6 * 60 * 60 * 1_000;
 const ALLOW_ASSESSMENT = JSON.stringify({
   risk_level: "low",
   user_authorization: "medium",
@@ -547,6 +548,39 @@ describe("guardian approval reviewer", () => {
       consecutiveDenials: 1,
       totalDenials: 1,
     });
+  });
+
+  it("allows a default guardian review to run for hours without an implicit deadline", async () => {
+    vi.useFakeTimers();
+    let reviewerSignal: AbortSignal | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const { session } = mkSession({
+      provider: mkProvider({
+        content: ALLOW_ASSESSMENT,
+        delayMs: SIX_HOURS_MS + 1,
+        onChat: (_messages, options) => {
+          reviewerSignal = options?.signal;
+          markStarted();
+        },
+      }),
+    });
+    const turn = newDefaultTurnWithSubId(session, "turn-unbounded");
+    const reviewer = createDefaultGuardianApprovalReviewer();
+
+    const promise = reviewer.reviewApprovalRequest({
+      ctx: mkApprovalCtx(session, turn),
+      args: { path: "file.txt", content: "ok" },
+    });
+    await started;
+    await vi.advanceTimersByTimeAsync(SIX_HOURS_MS);
+    expect(reviewerSignal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await promise;
+
+    expect(result.decision.kind).toBe("approved");
   });
 
   it("timeout fails closed without counting as a breaker denial", async () => {

--- a/runtime/tests/recovery/reconnection.test.ts
+++ b/runtime/tests/recovery/reconnection.test.ts
@@ -4,7 +4,6 @@ import type { Session } from "../session/session.js";
 import {
   computeBackoffMs,
   detectSuspend,
-  RECONNECT_GIVE_UP_MS,
   RECONNECT_INITIAL_MS,
   RECONNECT_MAX_MS,
   RECONNECT_RETRY_AFTER_CEILING_MS,
@@ -159,6 +158,43 @@ describe("reconnectWithBackoff", () => {
     }
   });
 
+  test("has no implicit give-up deadline after six hours", async () => {
+    vi.useFakeTimers();
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      const log = new EventLog();
+      const session = mkSession(log);
+      let now = 0;
+      let calls = 0;
+      const promise = reconnectWithBackoff({
+        session,
+        now: () => now,
+        sleepDetectionThresholdMs: Number.POSITIVE_INFINITY,
+        maxAttempts: 3,
+        attempt: async () => {
+          calls += 1;
+          if (calls < 3) throw new Error("stream_idle");
+          return "recovered";
+        },
+        isTransient: () => true,
+      });
+
+      await Promise.resolve();
+      now = 6 * 60 * 60_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      await expect(promise).resolves.toMatchObject({
+        kind: "ok",
+        value: "recovered",
+      });
+      expect(calls).toBe(3);
+    } finally {
+      randomSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   test("non-transient error bubbles immediately", async () => {
     const log = new EventLog();
     const session = mkSession(log);
@@ -293,7 +329,6 @@ describe("detectSuspend", () => {
   test("defaults match the transport reconnection contract", () => {
     expect(RECONNECT_INITIAL_MS).toBe(1_000);
     expect(RECONNECT_MAX_MS).toBe(30_000);
-    expect(RECONNECT_GIVE_UP_MS).toBe(600_000);
     expect(RECONNECT_SLEEP_DETECTION_THRESHOLD_MS).toBe(60_000);
   });
 });

--- a/runtime/tests/sdk-package/socket-transport.timeout.test.ts
+++ b/runtime/tests/sdk-package/socket-transport.timeout.test.ts
@@ -1,0 +1,96 @@
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgencSocketTransport } from "../../../packages/agenc-sdk/src/socket";
+
+describe.skipIf(process.platform === "win32")(
+  "SDK socket transport request deadlines",
+  () => {
+    let transport: AgencSocketTransport | null = null;
+    let server: Server | null = null;
+    let serverSocket: Socket | null = null;
+    let root: string | null = null;
+
+    afterEach(async () => {
+      vi.useRealTimers();
+      await transport?.close();
+      transport = null;
+      serverSocket?.destroy();
+      serverSocket = null;
+      if (server !== null) {
+        await new Promise<void>((resolve) => server!.close(() => resolve()));
+        server = null;
+      }
+      if (root !== null) {
+        await rm(root, { recursive: true, force: true });
+        root = null;
+      }
+    });
+
+    it("keeps full-turn message RPCs alive for hours while control RPCs retain their timeout", async () => {
+      root = await mkdtemp(join(tmpdir(), "agenc-sdk-socket-"));
+      const socketPath = join(root, "daemon.sock");
+      server = createServer((socket) => {
+        serverSocket = socket;
+        socket.on("error", () => {});
+      });
+      server.listen(socketPath);
+      await once(server, "listening");
+
+      transport = await AgencSocketTransport.connect({
+        socketPath,
+        requestTimeoutMs: 25,
+      });
+      expect(serverSocket).not.toBeNull();
+
+      vi.useFakeTimers();
+      let settled = false;
+      const fullTurn = transport.request({
+        jsonrpc: "2.0",
+        id: "long-turn",
+        method: "message.send",
+        params: {
+          sessionId: "session_1",
+          content: "work for hours",
+        },
+      });
+      void fullTurn.finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+      expect(settled).toBe(false);
+
+      vi.useRealTimers();
+      serverSocket!.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: "long-turn",
+          result: {
+            messageId: "message_1",
+            acceptedAt: "2026-07-24T00:00:00.000Z",
+          },
+        })}\n`,
+      );
+      await expect(fullTurn).resolves.toMatchObject({
+        result: { messageId: "message_1" },
+      });
+
+      vi.useFakeTimers();
+      const control = transport.request({
+        jsonrpc: "2.0",
+        id: "control",
+        method: "health.ping",
+        params: {},
+      });
+      const rejection = expect(control).rejects.toThrow(
+        "Timed out waiting for daemon response to health.ping",
+      );
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+    });
+  },
+);

--- a/runtime/tests/services/mcp/client-sdk-setup.test.ts
+++ b/runtime/tests/services/mcp/client-sdk-setup.test.ts
@@ -2184,7 +2184,7 @@ test('connectToServer creates remote SSE, SSE-IDE, and HTTP transports without r
   assert.equal(fakeClients[5]?.closed, true)
 })
 
-test('connectToServer HTTP fetch wrapper aborts long POST requests on timeout', async () => {
+test('connectToServer HTTP fetch wrapper leaves long POST requests unbounded until cancelled', async () => {
   vi.resetModules()
   vi.doMock('@modelcontextprotocol/sdk/client/index.js', () => ({
     Client: FakeClient,
@@ -2230,11 +2230,26 @@ test('connectToServer HTTP fetch wrapper aborts long POST requests on timeout', 
 
   vi.useFakeTimers()
   try {
+    const controller = new AbortController()
     const responsePromise = httpFetch('https://example.test/slow-post', {
       method: 'POST',
+      signal: controller.signal,
     })
-    await vi.advanceTimersByTimeAsync(60_000)
-    assert.equal(await (await responsePromise).text(), 'TimeoutError')
+    let settled = false
+    void responsePromise.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      },
+    )
+
+    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1_000)
+    assert.equal(settled, false)
+
+    controller.abort(new DOMException('operator cancelled', 'AbortError'))
+    assert.equal(await (await responsePromise).text(), 'AbortError')
   } finally {
     vi.useRealTimers()
   }

--- a/runtime/tests/services/mcp/client.test.ts
+++ b/runtime/tests/services/mcp/client.test.ts
@@ -36,6 +36,7 @@ import {
   getMcpServerConnectionBatchSize,
   prefetchAllMcpResources,
   reconnectMcpServerImpl,
+  wrapMcpTransportFetch,
 } from './client.js'
 import type { ConnectedMCPServer, MCPServerConnection } from './types.js'
 
@@ -174,6 +175,45 @@ test('getMcpRootUriForPath encodes roots as unambiguous file URIs', () => {
   assert.equal(parsed.hash, '')
   assert.equal(parsed.search, '')
   assert.equal(fileURLToPath(uri), rootPath)
+})
+
+test('MCP transport POSTs remain pending for hours without an implicit fetch deadline', async () => {
+  vi.useFakeTimers()
+  let settleFetch: ((response: Response) => void) | undefined
+  const baseFetch = vi.fn(
+    async () =>
+      await new Promise<Response>(resolve => {
+        settleFetch = resolve
+      }),
+  )
+
+  try {
+    const request = wrapMcpTransportFetch(baseFetch)(
+      'https://mcp.example.test/rpc',
+      {
+        method: 'POST',
+        headers: { 'x-test': 'kept' },
+      },
+    )
+    let settled = false
+    void request.finally(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000)
+
+    assert.equal(settled, false)
+    assert.equal(baseFetch.mock.calls.length, 1)
+    const forwarded = baseFetch.mock.calls[0]?.[1]
+    const headers = new Headers(forwarded?.headers)
+    assert.equal(headers.get('accept'), 'application/json, text/event-stream')
+    assert.equal(headers.get('x-test'), 'kept')
+
+    settleFetch?.(new Response('ok'))
+    assert.equal((await request).status, 200)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 function seedConnectionCache(
@@ -1131,6 +1171,58 @@ test('MCP tool call timeout uses MCP_TOOL_TIMEOUT and reports a log-safe timeout
     ),
     /MCP server "slow-sdk" tool "slow" timed out after 0s/,
   )
+})
+
+test('MCP tool calls have no implicit five-minute deadline', async () => {
+  delete process.env.MCP_TOOL_TIMEOUT
+  vi.useFakeTimers()
+  try {
+    const rawResult = Promise.withResolvers<{
+      content: Array<{ type: 'text'; text: string }>
+    }>()
+    let requestOptions:
+      | {
+          signal?: AbortSignal
+          timeout?: number
+          resetTimeoutOnProgress?: boolean
+        }
+      | undefined
+    const client = connectedClient({
+      name: 'long-sdk',
+      client: {
+        callTool: async (
+          _params: unknown,
+          _schema: unknown,
+          options?: {
+            signal?: AbortSignal
+            timeout?: number
+            resetTimeoutOnProgress?: boolean
+          },
+        ) => {
+          requestOptions = options
+          return rawResult.promise
+        },
+      } as never,
+    })
+    let settled = false
+
+    const running = callIdeRpc('long_remote', {}, client)
+    void running.finally(() => {
+      settled = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000)
+
+    assert.equal(requestOptions?.signal?.aborted, false)
+    assert.equal(settled, false)
+    assert.equal(requestOptions?.timeout, 2_147_483_647)
+    assert.equal(requestOptions?.resetTimeoutOnProgress, true)
+
+    rawResult.resolve({ content: [{ type: 'text', text: 'finished' }] })
+    assert.deepEqual(await running, [{ type: 'text', text: 'finished' }])
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 test('MCP tool calls log progress while waiting before timing out', async () => {

--- a/runtime/tests/services/xai/acp.test.ts
+++ b/runtime/tests/services/xai/acp.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../../src/utils/supervisedProcess.js', async importOriginal => {
 import {
   allowPermissionDecision,
   rejectPermissionDecision,
+  resolveXaiAcpPromptTimeoutMs,
   XaiAcpClient,
   type XaiAcpPermissionRequest,
 } from '../../../src/services/xai/acp.ts'
@@ -81,6 +82,12 @@ function makeClient(options?: {
 }
 
 describe('XaiAcpClient', () => {
+  test('ACP prompts have no implicit total runtime deadline', () => {
+    expect(resolveXaiAcpPromptTimeoutMs(undefined)).toBe(0)
+    expect(resolveXaiAcpPromptTimeoutMs(0)).toBe(0)
+    expect(resolveXaiAcpPromptTimeoutMs(7_200_000)).toBe(7_200_000)
+  })
+
   test('initialize → authenticate → session → prompt with streamed chunks', async () => {
     const client = makeClient()
     try {

--- a/runtime/tests/tasks/lifecycle.test.ts
+++ b/runtime/tests/tasks/lifecycle.test.ts
@@ -361,30 +361,16 @@ describe("registerAgentThreadTask", () => {
     const lifecycle = new BackgroundTaskLifecycle();
     const status = new FakeStatus();
     const joined = deferred<RunAgentResult>();
-    // A live handle whose accumulated counters look like a substantial run:
-    // 51000 cumulative tokens and 3 tool calls across the transcript.
+    // A live handle whose dedicated counters look like a substantial run.
+    // The runner intentionally does not copy tool calls into its model-facing
+    // transcript, so the rail must not infer this value from messages.
     const live = {
       agentId: "agent-counts",
       abortController: new AbortController(),
       status,
       tokenUsage: { totalTokens: 51000 },
-      messages: [
-        { role: "user", content: "build it" },
-        {
-          role: "assistant",
-          content: "running tools",
-          toolCalls: [
-            { id: "c1", name: "Bash", arguments: "{}" },
-            { id: "c2", name: "Edit", arguments: "{}" },
-          ],
-        },
-        { role: "tool", toolCallId: "c1", toolName: "Bash", content: "ok" },
-        {
-          role: "assistant",
-          content: "one more",
-          toolCalls: [{ id: "c3", name: "Read", arguments: "{}" }],
-        },
-      ],
+      toolCallCount: 3,
+      messages: [{ role: "assistant", content: "done" }],
     };
     const snapshots: Array<{
       readonly status: string;

--- a/runtime/tests/test-parity/upstream/bugfixes.test.ts
+++ b/runtime/tests/test-parity/upstream/bugfixes.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers:
  * 1. Gemini `store: false` rejection fix
- * 2. Session timeout / 500 error fix (stream idle timeout)
+ * 2. Long-running model streams have no implicit idle timeout
  * 3. Agent loop continuation nudge
  * 4. Web search result count improvements
  */
@@ -39,33 +39,23 @@ describe('Gemini store field fix', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Fix 2: Session timeout — stream idle timeout
+// Fix 2: Long-running model streams remain unbounded by default
 // ---------------------------------------------------------------------------
 describe('Session timeout fix', () => {
-  test('openaiShim has idle timeout for SSE streams', async () => {
+  test('openaiShim does not impose an SSE idle timeout', async () => {
     const content = await file('services/api/openaiShim.ts').text()
 
-    expect(content).toContain('STREAM_IDLE_TIMEOUT_MS')
-    expect(content).toContain('readWithTimeout')
-    expect(content).toMatch(/readWithTimeout\(\)/)
+    expect(content).not.toContain('STREAM_IDLE_TIMEOUT_MS')
+    expect(content).not.toContain('readWithTimeout')
+    expect(content).toContain('await reader.read()')
   })
 
-  test('openAiCodeTransform has idle timeout for SSE streams', async () => {
+  test('openAiCodeTransform does not impose an SSE idle timeout', async () => {
     const content = await file('services/api/openAiCodeTransform.ts').text()
 
-    expect(content).toContain('STREAM_IDLE_TIMEOUT_MS')
-    expect(content).toContain('readWithTimeout')
-    expect(content).toMatch(/readWithTimeout\(\)/)
-  })
-
-  test('idle timeout is set to a reasonable value (>= 60s)', async () => {
-    const content = await file('services/api/openaiShim.ts').text()
-
-    // Extract the timeout value (supports numeric separators like 120_000)
-    const match = content.match(/STREAM_IDLE_TIMEOUT_MS\s*=\s*([\d_]+)/)
-    expect(match).not.toBeNull()
-    const timeoutMs = parseInt(match![1].replace(/_/g, ''), 10)
-    expect(timeoutMs).toBeGreaterThanOrEqual(60_000)
+    expect(content).not.toContain('STREAM_IDLE_TIMEOUT_MS')
+    expect(content).not.toContain('readWithTimeout')
+    expect(content).toContain('await reader.read()')
   })
 })
 
@@ -183,16 +173,16 @@ describe('Web search result count improvements', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Fix 5: MCP tool timeout fix
+// Fix 5: MCP tool timeout policy
 // ---------------------------------------------------------------------------
 describe('MCP tool timeout fix', () => {
-  test('default MCP tool timeout is reasonable (not 27 hours)', async () => {
+  test('MCP tool calls have no implicit runtime deadline', async () => {
     const content = await file('services/mcp/client.ts').text()
 
-    // Should NOT have the old ~27.8 hour default
-    expect(content).not.toContain('100_000_000')
-    // Should have a reasonable timeout (5 minutes = 300_000ms)
-    expect(content).toMatch(/DEFAULT_MCP_TOOL_TIMEOUT_MS\s*=\s*300_000/)
+    expect(content).not.toContain('DEFAULT_MCP_TOOL_TIMEOUT_MS')
+    expect(content).toContain(
+      'timeoutMs ?? MCP_SDK_UNBOUNDED_WINDOW_MS',
+    )
   })
 
   test('MCP tools/list has retry logic', async () => {

--- a/runtime/tests/tools/AgentTool/forkSubagent.test.ts
+++ b/runtime/tests/tools/AgentTool/forkSubagent.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { FORK_AGENT } from "./forkSubagent.js";
+
+describe("forked agent limits", () => {
+  it("does not impose an implicit turn cap", () => {
+    expect(FORK_AGENT).not.toHaveProperty("maxTurns");
+  });
+});

--- a/runtime/tests/tools/execution.test.ts
+++ b/runtime/tests/tools/execution.test.ts
@@ -6,7 +6,6 @@ import {
   capToolResult,
   classifyToolError,
   DEFAULT_MAX_TOOL_RESULT_BYTES,
-  DEFAULT_TOOL_TIMEOUT_MS,
   defaultCheckModeStillAllowed,
   executeToolDispatch,
   formatError,
@@ -116,11 +115,11 @@ describe("I-15 capToolResult", () => {
 });
 
 describe("I-9 resolveTimeoutMs + withTimeoutAndAbort", () => {
-  test("per-call timeoutMs wins over per-tool and default", () => {
+  test("per-call timeoutMs wins over per-tool; otherwise there is no implicit deadline", () => {
     const tool = { timeoutMs: 15_000 } as unknown as Tool;
     expect(resolveTimeoutMs(tool, { timeoutMs: 5_000 })).toBe(5_000);
     expect(resolveTimeoutMs(tool, {})).toBe(15_000);
-    expect(resolveTimeoutMs({} as Tool, {})).toBe(DEFAULT_TOOL_TIMEOUT_MS);
+    expect(resolveTimeoutMs({} as Tool, {})).toBeNull();
   });
 
   test("tool-owned timeout disables the generic deadline", () => {

--- a/runtime/tests/tools/streaming-executor.stuck-tool-drain.test.ts
+++ b/runtime/tests/tools/streaming-executor.stuck-tool-drain.test.ts
@@ -510,8 +510,8 @@ describe("StreamingToolExecutor cooperative cancel of wedged tools", () => {
     }
   });
 
-  // ── Test E — interruptBehavior:'block' tool is still force-finalizable; a
-  //    timeoutBehavior:'tool' tool is NOT. The drain kill is unconditional and
+  // ── Test E — an explicitly timed interruptBehavior:'block' tool is still
+  //    force-finalizable; a timeoutBehavior:'tool' tool is NOT. The drain kill is unconditional and
   //    does NOT consult getToolInterruptBehavior — it keys ONLY off
   //    toolDrainDeadlineMs. So a block-behavior tool with a finite
   //    (timeoutBehavior:'executor') deadline IS subject to the backstop, while
@@ -520,11 +520,11 @@ describe("StreamingToolExecutor cooperative cancel of wedged tools", () => {
   //    computation the backstop actually keys off (white-box), so the proof is
   //    fast and exact rather than waiting out the multi-minute own+grace floor
   //    that a real registered tool's finite deadline carries.
-  test("interruptBehavior:'block' has a finite drain deadline; timeoutBehavior:'tool' is exempt", async () => {
+  test("explicitly timed interruptBehavior:'block' has a finite drain deadline; timeoutBehavior:'tool' is exempt", async () => {
     const blockTool = testTool({
       name: "blocking-tool",
       interruptBehavior: () => "block",
-      // timeoutBehavior defaults to "executor" -> finite deadline.
+      timeoutMs: 1_000,
     });
     const exemptTool = testTool({
       name: "request-user-input",

--- a/runtime/tests/tools/system/bash.test.ts
+++ b/runtime/tests/tools/system/bash.test.ts
@@ -669,14 +669,14 @@ describe("system.bash tool", () => {
     expect(parsed.timedOut).toBe(true);
   });
 
-  it("uses default timeout when none specified", async () => {
+  it("does not invent a timeout when none is specified", async () => {
     const tool = createBashTool();
     mockSuccess();
 
     await tool.execute({ command: "ls" });
 
     const opts = mockExecFile.mock.calls[0][2] as Record<string, unknown>;
-    expect(opts.timeout).toBe(30_000);
+    expect(opts.timeout).toBeUndefined();
   });
 
   it("uses per-call timeout override when within maxTimeoutMs", async () => {

--- a/runtime/tests/tools/system/monitor-timeout-behavior.ihunt.test.ts
+++ b/runtime/tests/tools/system/monitor-timeout-behavior.ihunt.test.ts
@@ -1,46 +1,57 @@
 /**
  * Regression test (ihunt) for the Monitor background-process kill bug.
  *
- * Bug: the Monitor tool drives `unifiedExecManager.execCommand` with
- * `yield_time_ms`/`timeoutMs = MONITOR_TIMEOUT_MS` (30 min) so the
- * monitored process stays alive in the background and yields a
- * `process_id`. The unified-exec yield window is clamped to
- * `MAX_YIELD_TIME_MS = 30_000`, so `execCommand` resolves at ~30s with
- * the process still running. But the Monitor Tool definition declared
- * neither `timeoutMs` nor `timeoutBehavior: "tool"`, so the generic
- * executor's `resolveTimeoutMs` returned `DEFAULT_TOOL_TIMEOUT_MS`
- * (30_000) and `withTimeoutAndAbort` armed a 30s timer that, on fire,
- * aborts the SAME AbortController forwarded into `execCommand` as
- * `__abortSignal`. The process manager terminates (SIGTERM/SIGKILL) the
- * monitored process on that abort and the tool returns a
- * `ToolTimeoutError` instead of the "Monitor task started" yield.
+ * Bug: Monitor passed a 30-minute hard timeout to unified exec. The
+ * command yielded after the manager's ~30-second streaming window but
+ * was then terminated in the background when that hidden deadline
+ * elapsed.
  *
- * Fix: the tool sets `timeoutBehavior: "tool"` (and an explicit
- * `timeoutMs`) so `resolveTimeoutMs` returns `null` and the executor no
- * longer imposes the 30s deadline on a tool that owns its own
- * yield/timeout semantics.
+ * Fix: Monitor owns the short foreground yield but supplies no process
+ * timeout. The process remains alive until it exits, is explicitly
+ * stopped, the turn is cancelled, or the daemon shuts down.
  *
  * Each assertion below FAILS if the fix is reverted:
  *   1. `resolveTimeoutMs(tool, args)` must be `null` (the executor will
- *      arm NO timeout). Reverting → returns DEFAULT_TOOL_TIMEOUT_MS.
+ *      arm NO timeout).
  *   2. `tool.timeoutBehavior === "tool"`.
+ *   3. The unified-exec request contains no `timeoutMs`.
  */
 import { describe, expect, test } from "vitest";
 
-import {
-  DEFAULT_TOOL_TIMEOUT_MS,
-  resolveTimeoutMs,
-} from "../../../src/tools/execution.js";
+import { resolveTimeoutMs } from "../../../src/tools/execution.js";
 import { createMonitorTool } from "../../../src/tools/system/monitor.js";
-import type { UnifiedExecProcessManagerLike } from "../../../src/unified-exec/types.js";
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+import type {
+  ExecCommandRequest,
+  UnifiedExecProcessManagerLike,
+} from "../../../src/unified-exec/types.js";
 
-// Minimal stub: the test only inspects the tool *definition* and the
-// executor's timeout resolution, never actually executes a command.
-function stubManager(): UnifiedExecProcessManagerLike {
+function stubManager(
+  requests: ExecCommandRequest[] = [],
+): UnifiedExecProcessManagerLike {
   return {
-    execCommand: async () => {
+    maxTimeoutMs: 1,
+    execCommand: async (request) => {
+      requests.push(request);
+      return {
+        output: "",
+        stdout: "",
+        stderr: "",
+        exitCode: null,
+        exit_code: null,
+        process_id: 42,
+        session_id: 42,
+        durationMs: 30_000,
+        wall_time_seconds: 30,
+        timedOut: false,
+        truncated: false,
+        original_token_count: 0,
+      };
+    },
+    writeStdin: async () => {
       throw new Error("not called in this test");
     },
+    closeAll: async () => {},
   } as unknown as UnifiedExecProcessManagerLike;
 }
 
@@ -61,21 +72,30 @@ describe("Monitor timeout ownership (ihunt regression)", () => {
       unifiedExecManager: stubManager(),
     });
 
-    // The model only ever passes {command, description}; no per-call
-    // timeoutMs is supplied, so the ONLY thing that prevents the
-    // executor from arming a DEFAULT_TOOL_TIMEOUT_MS timer (which aborts
-    // the shared controller forwarded into execCommand and kills the
-    // backgrounded process) is timeoutBehavior:"tool".
     const resolved = resolveTimeoutMs(tool, {
       command: "npm run dev",
       description: "watch dev server",
     });
 
-    // Revert-sensitive: without the fix resolveTimeoutMs returns
-    // DEFAULT_TOOL_TIMEOUT_MS (30_000), so the executor would arm a 30s
-    // timer that races/wins the clamped 30s yield and SIGTERMs the
-    // monitored process.
     expect(resolved).toBeNull();
-    expect(resolved).not.toBe(DEFAULT_TOOL_TIMEOUT_MS);
+  });
+
+  test("starts the process with a bounded yield and no hard runtime deadline", async () => {
+    const requests: ExecCommandRequest[] = [];
+    const tool = bindExplicitDangerBoundary(
+      createMonitorTool({
+        cwd: process.cwd(),
+        unifiedExecManager: stubManager(requests),
+      }),
+    );
+
+    await tool.execute({
+      command: "npm run dev",
+      description: "watch dev server",
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.yield_time_ms).toBe(30_000);
+    expect(requests[0]).not.toHaveProperty("timeoutMs");
   });
 });

--- a/runtime/tests/tui/components/App.daemon-stall-watchdog.test.ts
+++ b/runtime/tests/tui/components/App.daemon-stall-watchdog.test.ts
@@ -4,17 +4,11 @@ import { describe, expect, test } from "vitest";
 import { sourcePath } from "../../helpers/source-path.js";
 
 describe("App daemon-stall watchdog", () => {
-  test("waits longer than one full provider stream-idle recovery cycle", () => {
+  test("never cancels a healthy long-running turn because the transcript is quiet", () => {
     const source = readFileSync(sourcePath("tui/components/App.tsx"), "utf8");
-    const timeout = source.match(
-      /const DAEMON_STALL_WATCHDOG_MS = ([\d_]+);/u,
-    );
 
-    expect(timeout).not.toBeNull();
-    const timeoutMs = Number(timeout?.[1]?.replaceAll("_", ""));
-    expect(timeoutMs).toBe(300_000);
-    // Above the provider's 90s stream-idle limit AND the reconnect cycle
-    // (re-prefill latency + another idle window) that follows a cancel.
-    expect(timeoutMs).toBeGreaterThan(90_000 * 2);
+    expect(source).not.toContain("DAEMON_STALL_WATCHDOG_MS");
+    expect(source).not.toContain("daemon_stall_watchdog");
+    expect(source).not.toContain("daemon-stall-watchdog");
   });
 });

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -656,6 +656,40 @@ describe("AgenC TUI daemon session adapter", () => {
     unsubscribe();
   });
 
+  it("does not revive a terminal daemon turn when a late tool completion arrives", async () => {
+    const client = createClient();
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession(),
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    const unsubscribe = session.subscribeToEvents(() => undefined);
+    const emitTranscriptEvent = (id: string, type: string): void => {
+      client.emit("session_1", {
+        method: "event.session_event",
+        params: {
+          eventId: id,
+          event: { id, type, payload: {} },
+        },
+      });
+    };
+
+    emitTranscriptEvent("turn_started", "turn_started");
+    expect(session.activeTurn?.unsafePeek()).not.toBeNull();
+
+    emitTranscriptEvent("turn_aborted", "turn_aborted");
+    emitTranscriptEvent("turn_error", "error");
+    emitTranscriptEvent("late_tool_done", "tool_call_completed");
+
+    expect(session.activeTurn?.unsafePeek()).toBeNull();
+
+    // A real next turn explicitly resets the terminal latch.
+    emitTranscriptEvent("next_turn", "turn_started");
+    expect(session.activeTurn?.unsafePeek()).not.toBeNull();
+    unsubscribe();
+  });
+
   it("sends TUI user input through message.stream", async () => {
     const client = createClient();
     const abortController = new AbortController();

--- a/runtime/tests/tui/state/collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.test.ts
@@ -324,6 +324,61 @@ describe("syncCollabAgentEventToAppState", () => {
     expect(runningAgain.tasks.agent_1).not.toHaveProperty("result");
   });
 
+  it("preserves a completed turn when its reusable worker is later shut down", () => {
+    const spawned = applyEvent(baseState(), {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent_1",
+        newAgentNickname: "Verifier",
+        status: { status: "running" },
+      },
+    }, 1_000);
+    const completed = applyEvent(spawned, {
+      type: "collab_agent_status",
+      payload: {
+        threadId: "agent_1",
+        status: "completed",
+        toolUseCount: 4,
+      },
+    }, 2_000);
+
+    const afterShutdown = applyEvent(completed, {
+      type: "collab_agent_status",
+      payload: {
+        threadId: "agent_1",
+        status: { status: "killed", error: "agent shutdown" },
+      },
+    }, 3_000);
+
+    expect(afterShutdown.tasks.agent_1).toMatchObject({
+      status: "completed",
+      endTime: 2_000,
+      progress: { toolUseCount: 4 },
+    });
+    expect(afterShutdown.tasks.agent_1).not.toHaveProperty("error");
+
+    // A new interaction is a new turn and may establish a new terminal result.
+    const reopened = applyEvent(afterShutdown, {
+      type: "collab_agent_interaction_begin",
+      payload: {
+        receiverThreadId: "agent_1",
+        prompt: "verify another change",
+      },
+    }, 4_000);
+    const failed = applyEvent(reopened, {
+      type: "collab_agent_status",
+      payload: {
+        threadId: "agent_1",
+        status: { status: "errored", error: "new verification failed" },
+      },
+    }, 5_000);
+    expect(failed.tasks.agent_1).toMatchObject({
+      status: "failed",
+      error: "new verification failed",
+      endTime: 5_000,
+    });
+  });
+
   it("updates spawned agents from collab wait completion summaries", () => {
     const firstSpawn = applyEvent(baseState(), {
       type: "collab_agent_spawn_end",

--- a/runtime/tests/unified-exec/process-manager.test.ts
+++ b/runtime/tests/unified-exec/process-manager.test.ts
@@ -613,13 +613,7 @@ describe("UnifiedExecProcessManager", () => {
     10_000,
   );
 
-  test("force-kills abandoned non-tty processes once maxTimeoutMs elapses", async () => {
-    // Regression: a non-tty exec_command with no explicit timeoutMs used to
-    // have no hard kill — the model could yield and forget, leaving the
-    // child running indefinitely. We saw this in the wild with three
-    // `./agenc -c 'echo hi' --dump-tokens` zombies burning ~97% CPU each
-    // for 95+ minutes after the agent moved on. The reference runtime
-    // always enforces a timeout; we now do too.
+  test("keeps non-tty processes alive when no timeoutMs was requested", async () => {
     const manager = new UnifiedExecProcessManager({
       cwd: process.cwd(),
       maxTimeoutMs: 400,
@@ -629,13 +623,35 @@ describe("UnifiedExecProcessManager", () => {
         cmd: "node -e \"setInterval(()=>{}, 1000)\"",
         yield_time_ms: 250,
       });
-      // Yielded while still running — model gets a session_id.
       expect(started.process_id).toEqual(expect.any(Number));
-      // Wait past the hard timeout, then poll. The hard-kill caused the
-      // child to exit; the next writeStdin observes the terminal exitState
-      // and returns the final result with no process_id (indicating the
-      // session is gone). exit_code is null because the kernel killed the
-      // child by signal rather than letting it exit cleanly.
+
+      // maxTimeoutMs only caps an explicitly requested timeout. Merely
+      // yielding a process must not invent a deadline.
+      await new Promise((r) => setTimeout(r, 800));
+      const polled = await manager.writeStdin({
+        session_id: started.process_id!,
+        chars: "",
+        yield_time_ms: 250,
+      });
+      expect(polled.process_id).toBe(started.process_id);
+    } finally {
+      await manager.closeAll("test_cleanup");
+    }
+  });
+
+  test("still enforces an explicitly requested timeoutMs", async () => {
+    const manager = new UnifiedExecProcessManager({
+      cwd: process.cwd(),
+      maxTimeoutMs: 400,
+    });
+    try {
+      const started = await manager.execCommand({
+        cmd: "node -e \"setInterval(()=>{}, 1000)\"",
+        yield_time_ms: 250,
+        timeoutMs: 400,
+      });
+      expect(started.process_id).toEqual(expect.any(Number));
+
       await new Promise((r) => setTimeout(r, 800));
       const polled = await manager.writeStdin({
         session_id: started.process_id!,
@@ -644,16 +660,6 @@ describe("UnifiedExecProcessManager", () => {
       });
       expect(polled.process_id).toBeUndefined();
       expect(polled.exit_code).toBeNull();
-      // And the slot is fully released — a second poll should now reject.
-      await expect(
-        manager.writeStdin({
-          session_id: started.process_id!,
-          chars: "",
-          yield_time_ms: 250,
-        }),
-      ).rejects.toMatchObject({
-        code: "unknown_process",
-      } satisfies Partial<UnifiedExecError>);
     } finally {
       await manager.closeAll("test_cleanup");
     }

--- a/runtime/tests/utils/ShellCommand.timeout.test.ts
+++ b/runtime/tests/utils/ShellCommand.timeout.test.ts
@@ -1,0 +1,61 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { wrapSpawn } from "../../src/utils/ShellCommand.js";
+import { TaskOutput } from "../../src/utils/task/TaskOutput.js";
+
+function fakeChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, {
+    pid: undefined,
+    stdout: null,
+    stderr: null,
+  });
+  return child;
+}
+
+describe("ShellCommand deadlines", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("an omitted timeout does not invent a process deadline", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild();
+    const command = wrapSpawn(
+      child,
+      new AbortController().signal,
+      undefined,
+      new TaskOutput("shell-no-deadline", null),
+    );
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    expect(command.status).toBe("running");
+
+    child.emit("exit", 0, null);
+    await expect(command.result).resolves.toMatchObject({
+      code: 0,
+      interrupted: false,
+    });
+    command.cleanup();
+  });
+
+  test("an explicit timeout remains opt-in and enforced", async () => {
+    vi.useFakeTimers();
+    const child = fakeChild();
+    const command = wrapSpawn(
+      child,
+      new AbortController().signal,
+      1_000,
+      new TaskOutput("shell-explicit-deadline", null),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(command.result).resolves.toMatchObject({
+      code: 143,
+      stderr: expect.stringContaining("Command timed out after"),
+    });
+    command.cleanup();
+  });
+});

--- a/runtime/tests/utils/supervisedProcess.test.ts
+++ b/runtime/tests/utils/supervisedProcess.test.ts
@@ -91,6 +91,24 @@ async function withFakeWindowsTaskkill(
 }
 
 describe("runSupervisedProcess", () => {
+  it("runs without an implicit deadline when timeoutMs is omitted", async () => {
+    const result = await runSupervisedProcess(
+      nodeCommand("setTimeout(() => process.stdout.write('done'), 75)"),
+      {
+        maxOutputBytes: 1_024,
+      },
+    );
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      signal: null,
+      forced: false,
+      backstopExpired: false,
+    });
+    expect(result.stopReason).toBeUndefined();
+    expect(result.stdout.toString()).toBe("done");
+  });
+
   it("does not spawn when the caller signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/runtime/tests/workflow/fixtures/m5-harness.ts
+++ b/runtime/tests/workflow/fixtures/m5-harness.ts
@@ -166,14 +166,19 @@ class HarnessJournal implements WorkflowRunJournal {
 function runBash(
   script: string,
   cwd: string,
-  timeoutMs: number,
+  timeoutMs?: number,
 ): Promise<WorkflowCommandResult> {
   const startedAt = performance.now();
   return new Promise((resolvePromise) => {
     execFile(
       "bash",
       ["-lc", script],
-      { cwd, timeout: timeoutMs, encoding: "buffer", maxBuffer: 8 * 1024 * 1024 },
+      {
+        cwd,
+        encoding: "buffer",
+        maxBuffer: 8 * 1024 * 1024,
+        ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
+      },
       (error, stdout, stderr) => {
         const durationMs = Math.round(performance.now() - startedAt);
         const killed =

--- a/runtime/tests/workflow/independent-review.test.ts
+++ b/runtime/tests/workflow/independent-review.test.ts
@@ -166,13 +166,14 @@ describe("M5 independent review", () => {
       step: STEP,
     });
     expect(captured).toHaveLength(1);
-    // The transport contract is closed: exactly these five fields, so no
+    // The transport contract is closed: exactly these four fields, so no
     // future call site can smuggle implementer context alongside them.
     // `runId` is routing metadata for the daemon-backed invoker (Phase 5);
     // prompt assembly never reads it.
     expect(Object.keys(captured[0]).sort()).toEqual([
-      "reviewerModel", "runId", "systemPrompt", "timeoutMs", "userMessage",
+      "reviewerModel", "runId", "systemPrompt", "userMessage",
     ]);
+    expect(captured[0]).not.toHaveProperty("timeoutMs");
     expect(captured[0].runId).toBe(STEP.runId);
     // And the user message is byte-identical to the single assembly point's
     // output for the same task+diff+evidence inputs.
@@ -187,5 +188,27 @@ describe("M5 independent review", () => {
     expect(captured[0].systemPrompt).toBe(expected.systemPrompt);
     expect(String(captured[0].userMessage)).toContain("Fix the retry counter.");
     expect(String(captured[0].userMessage)).toContain("+42");
+  });
+
+  it("forwards a reviewer deadline only when the caller explicitly supplies one", async () => {
+    let capturedTimeoutMs: number | undefined;
+    const invoker: ReviewerInvoker = {
+      invoke: async (input) => {
+        capturedTimeoutMs = input.timeoutMs;
+        return reviewJson();
+      },
+    };
+    await runIndependentReview({
+      spec: SPEC,
+      patchText: "diff",
+      changedFilesText: "M\tsrc/index.ts",
+      verification: COMMANDS,
+      verificationVerdict: "PASS",
+      invoker,
+      sink: new MemorySink(),
+      step: STEP,
+      timeoutMs: 12_345,
+    });
+    expect(capturedTimeoutMs).toBe(12_345);
   });
 });

--- a/runtime/tests/workflow/verification.test.ts
+++ b/runtime/tests/workflow/verification.test.ts
@@ -52,6 +52,34 @@ function ok(stdout = "ok\n"): WorkflowCommandResult {
 }
 
 describe("M5 required verification", () => {
+  it("has no implicit command deadline and forwards only an explicit one", async () => {
+    const inputs: Array<{
+      readonly script: string;
+      readonly cwd: string;
+      readonly timeoutMs?: number;
+    }> = [];
+    const runner: WorkflowCommandRunner = {
+      async run(input) {
+        inputs.push(input);
+        return ok();
+      },
+    };
+    const common = {
+      worktreePath: "/wt",
+      commands: [{ label: "unit", script: "npm test" }],
+      runner,
+      sink: new MemorySink(),
+      step: STEP,
+      parallelism: 1,
+    };
+
+    await runRequiredVerification(common);
+    await runRequiredVerification({ ...common, timeoutMsPerCommand: 12_345 });
+
+    expect(inputs[0]).not.toHaveProperty("timeoutMs");
+    expect(inputs[1].timeoutMs).toBe(12_345);
+  });
+
   it("runs every command bounded by parallelism and never short-circuits", async () => {
     let live = 0;
     let peak = 0;

--- a/swarm_launch_post.txt
+++ b/swarm_launch_post.txt
@@ -1,0 +1,11 @@
+This is a very different kind of coding agent swarm.
+
+AgenC shipped a swarm upgrade for concurrent agents. The stack covers adaptive routing, atomic admission, durable outcomes, isolated execution, bounded context, and immutable integration evidence.
+
+The /swarm router defaults to one agent and recommends fan-out only for explicitly parallel or independent work. It routes only the current runtime-owned human turn and fingerprints that input in the receipt. Stale transcript text and completion messages cannot recursively start another swarm.
+
+A child is durably registered before it is live. Each assignment is atomically admitted to one idle worker with its own task_id and a fresh turn_id. Outcomes are written to the child journal before the parent is notified. A journal persistence failure fails closed. If teardown wins before execution starts, the accepted task gets a correlated NACK instead of silent loss.
+
+Parallel writers run in spawn-unique Git worktrees. At completion, AgenC records the base commit, HEAD, tree hash, cleanliness, and ancestry, then checks for movement during capture. Only committed_clean work receives an integration_ref set to the exact immutable Git object ID. Dirty, diverged, or unverifiable work cannot be integrated, and that worker is not returned to the reusable pool.
+
+Agent identities are runtime-authenticated. Mailboxes and model projection are independently bounded. Children start with clean context by default. Conversation history is an explicit dependency. Nothing auto-merges. Agent prose is not evidence. A branch name is not evidence. Completed is not merge authorization.

--- a/swarm_research_quote_posts.txt
+++ b/swarm_research_quote_posts.txt
@@ -1,0 +1,103 @@
+THREAD 1/4 — WORKTREE ISOLATION
+===============================
+
+“Effective Strategies for Asynchronous Software Engineering Agents” directly
+influenced AgenC’s worktree isolation.
+
+https://arxiv.org/abs/2603.21489v2
+
+Parallel agents sharing one checkout can interfere with each other even when
+prompts tell them not to.
+
+AgenC now gives every parallel writer a spawn-unique Git worktree. It returns
+an integration reference only when the result is committed, clean, descended
+from the captured base, and independently verifiable.
+
+Nothing auto-merges.
+
+
+THREAD 2/4 — SCALING AGENT SYSTEMS
+==================================
+
+“Towards a Science of Scaling Agent Systems” is why /swarm defaults to one
+agent.
+
+https://arxiv.org/abs/2512.08296v3
+
+On sequential PlanCraft, every multi-agent architecture evaluated in this
+paper underperformed the single-agent mean.
+
+Agent count is not intelligence. The topology has to match the task.
+
+AgenC recommends fan-out only when work is explicitly parallel or genuinely
+independent.
+
+
+THREAD 3/4 — EXTERNAL BENCHMARKS
+================================
+
+External research results—not AgenC benchmark scores:
+
+“Effective Strategies for Asynchronous Software Engineering Agents”
+https://arxiv.org/abs/2603.21489v2
+
+CAID’s PaperBench Code-Dev isolation ablation:
+
+Shared-workspace multi-agent: 55.5
+Single agent: 57.2
+Worktree-isolated multi-agent: 63.3
+
+“Towards a Science of Scaling Agent Systems”
+https://arxiv.org/abs/2512.08296v3
+
+Scaling Agent Systems on sequential PlanCraft:
+
+Every evaluated multi-agent architecture finished 39.1%–70.0% below the
+single-agent mean.
+
+That is why AgenC 0.9.0 defaults to one agent, isolates parallel writers, and
+treats integration as an evidence problem—not a prompt instruction.
+
+
+THREAD 4/4 — RESEARCH
+=====================
+
+The research behind AgenC’s agent/swarm upgrade:
+
+Effective Strategies for Asynchronous Software Engineering Agents
+https://arxiv.org/abs/2603.21489v2
+
+Towards a Science of Scaling Agent Systems
+https://arxiv.org/abs/2512.08296v3
+
+MAS-Orchestra: Understanding and Improving Multi-Agent Reasoning Through
+Holistic Orchestration and Controlled Benchmarks
+https://arxiv.org/abs/2601.14652v5
+
+Multi-Agent Teams Hold Experts Back
+https://arxiv.org/abs/2602.01011v4
+
+TeamBench: Evaluating Agent Coordination under Enforced Role Separation
+https://arxiv.org/abs/2605.07073v1
+
+PerspectiveGap: A Benchmark for Multi-Agent Orchestration Prompting
+https://arxiv.org/abs/2606.08878v2
+
+Software Delegation Contracts: Measuring Reviewability in AI Coding-Agent Work
+https://arxiv.org/abs/2606.17099v1
+
+Who Broke the System? Failure Localization in LLM-Based Multi-Agent Systems
+https://arxiv.org/abs/2607.07989v1
+
+Why Do Multi-Agent LLM Systems Fail?
+https://arxiv.org/abs/2503.13657v3
+
+Beyond the Leaderboard: A Synthesis of Tool-Use, Planning, and Reasoning
+Failures in Large Language Model Agents
+https://arxiv.org/abs/2607.05775v1
+
+MultiAgentBench: Evaluating the Collaboration and Competition of LLM Agents
+https://arxiv.org/abs/2503.01935
+
+These papers informed the isolation, routing, topology, context-boundary,
+delegation-contract, failure-attribution, and evidence rules in the upgrade.


### PR DESCRIPTION
## Summary

- remove implicit wall-clock limits from agent turns, daemon and SDK full-turn RPCs, model streams, MCP calls, subprocesses, workflow reviewers, and evaluation agents while preserving explicitly configured operator deadlines
- fix swarm lifecycle and TUI reconciliation races that rendered completed children as killed, relatched the spinner after terminal events, or misclassified caller cancellation
- project live child token/tool usage into the parent without double counting and add revert-sensitive long-duration regressions
- include the current memory implementation handoff and swarm research/post drafts from the workspace

## Root cause

The reproduced M2 swarm was not killed by the old 30-minute CSV/eval defaults. The active TUI fired `daemon_stall_watchdog` during a healthy quiet period, canceled the turn, and propagated that cancellation into execution admission as `interrupted`. Late lifecycle events then left stale killed/interrupted agent state and a stuck busy indicator. A broader audit found additional implicit ceilings that could independently terminate legitimate multi-hour work.

## Live verification

- launched the built AgenC TUI in `/home/tetsuo/git/stream-test/agenc-shell`
- submitted the exact original prompt: `Okay I want you to implement all of M2.`
- observed persisted `bypass SWARM`, real subagent activity, and successful completion after 915241 ms (about 15m15s), beyond the former ten-minute provider boundary
- observed a second live verifier run with continuously increasing child token usage; durable child and parent totals both finished at 803729 tokens with no double count
- no daemon stall watchdog, stream-idle timeout, reconnect abort, interruption, or stale terminal rendering occurred

## Validation

- `npm test`
  - required gates: 108/108
  - agent-surface contract harness: 22/22
  - launcher: 138/138
  - runtime: 1879 files passed, 1 skipped; 16464 tests passed, 20 skipped
- pre-commit hook (not bypassed)
  - runtime build and package-entrypoint checks
  - generated SDK type check
  - real PTY startup for `agenc` and `agenc --yolo` at 148x40, 120x30, and 80x24
- previously completed on the final source state: Bun suite, SDK build/typecheck, root build, and live agent-surface TUI scenarios
- `git diff --check`
