### PR TITLE
fix(runtime): polish swarm status and transcript

### DIFF
--- a/runtime/scripts/check-tui-runtime-startup.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.mjs
@@ -28,6 +28,11 @@ const MAX_PTY_OUTPUT_BYTES = 1024 * 1024;
 // timeout, but leave enough headroom that the pre-commit build immediately
 // followed by this smoke does not fail a healthy first viewport.
 const FIRST_PAINT_MS = 3_000;
+// A rebuild makes the next CLI reap a build-skewed daemon for up to 5s before
+// starting its replacement. The throwaway warmup must outlive that reap
+// window plus the ordinary first-paint budget; otherwise it kills the CLI
+// midway through recovery and hands the measured probe the same cold start.
+export const COLD_WARMUP_FIRST_PAINT_MS = 5_000 + FIRST_PAINT_MS;
 const POST_REPLY_MS = 1_500;
 const SIGTERM_GRACE_MS = 1_000;
 const FORCE_KILL_GRACE_MS = 1_000;
@@ -635,12 +640,14 @@ async function main() {
   console.log(green("[2/4] built TUI artifact returned a verified import proof"));
 
   // Warmup: the very first PTY spawn after a fresh `npm run build` pays cold
-  // module/daemon-attach caches and reliably blows the FIRST_PAINT_MS budget
-  // on a loaded machine (reproduced 3/3 in the pre-commit hook, 0/2
-  // standalone). One untimed throwaway spawn warms those paths so every
-  // MEASURED scenario asserts the real budget against warm caches; its
-  // result is deliberately ignored.
-  await ptyStartupSmoke("warmup", [], VIEWPORTS[0], { resultIgnored: true });
+  // module/daemon-attach caches and may also spend 5s reaping a build-skewed
+  // daemon. Give this throwaway spawn enough time to finish that recovery so
+  // every MEASURED scenario asserts the real first-paint budget against warm
+  // caches; only the warmup result is deliberately ignored.
+  await ptyStartupSmoke("warmup", [], VIEWPORTS[0], {
+    firstPaintMs: COLD_WARMUP_FIRST_PAINT_MS,
+    resultIgnored: true,
+  });
 
   const results = [];
   for (const viewport of VIEWPORTS) {

--- a/runtime/scripts/check-tui-runtime-startup.test.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  COLD_WARMUP_FIRST_PAINT_MS,
   hasSemanticPtyReadiness,
   observePtySession,
   runImportProbe,
@@ -75,6 +76,10 @@ test("candidate iterator poisoning cannot skip export requirements", async () =>
 });
 
 const SEMANTIC_PAINT = `\x1b[?2004h${" ".repeat(128)}AgenC interactive screen`;
+
+test("cold warmup outlives the build-skew daemon reap window", () => {
+  assert.ok(COLD_WARMUP_FIRST_PAINT_MS > 5_000);
+});
 
 function fakeTerm({ earlyExit = false, terminationExit, paint = SEMANTIC_PAINT, spontaneousExitMs } = {}) {
   const dataHandlers = [];

--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -27,6 +27,7 @@ import { useAppStateMaybeOutsideOfProvider } from '../state/AppState.js';
 import { BrandCells, PlanModeBanner, TuiHeader, StatusBar as V2StatusBar, StatusSegment } from './v2/primitives.js';
 import ThemedText from './design-system/ThemedText.js';
 import { LedgerStatus } from './LedgerStatus.js';
+import { SwarmStatusIndicator } from './SwarmStatusIndicator.js';
 
 /** Rows of transcript context kept visible above the modal pane's ▔ divider. */
 const MODAL_TRANSCRIPT_PEEK = 2;
@@ -631,8 +632,8 @@ function DesignBottomLeftLabel({
   readonly modelLabel: string;
 }): React.ReactNode {
   const modeLabel = permissionModeFooterChrome(mode).label;
-  // Swarm indicator sits next to the mode (like yolo): visible only while
-  // swarm mode is on; carries the live running-agent count from AppState.
+  // Swarm status sits next to the mode: visible only while swarm mode is on
+  // and carrying the live running-agent count from AppState.
   // Read from AppState (the appStateBridge /swarm writes through), with the
   // provider-safe hook so the label also renders without AppStateProvider.
   const swarmMode =
@@ -642,12 +643,11 @@ function DesignBottomLeftLabel({
     () => Object.values(tasks ?? {}).filter((task: any) => task?.type !== "local_bash" && (task?.status === "running" || task?.status === "pending")).length,
     [tasks],
   );
-  const swarmBadgeText = ` SWARM${runningAgents > 0 ? ` ${runningAgents}` : ""} `;
   return (
     <>
       <ThemedText color="text2" wrap="truncate-end">● {modeLabel}</ThemedText>
       {swarmMode ? (
-        <ThemedText backgroundColor="agenc" color="ansi:white" bold wrap="truncate-end">{swarmBadgeText}</ThemedText>
+        <SwarmStatusIndicator runningAgents={runningAgents} />
       ) : null}
       <ThemedText color="text2" wrap="truncate-end"> · {modelLabel}{gitLabel === null ? '' : ` · ${gitLabel}`}</ThemedText>
     </>

--- a/runtime/src/tui/components/SwarmStatusIndicator.tsx
+++ b/runtime/src/tui/components/SwarmStatusIndicator.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import { Box } from "../ink.js";
+import ThemedText from "./design-system/ThemedText.js";
+
+export type SwarmStatusPresentation = {
+  readonly glyph: "◆" | "◇";
+  readonly label: string;
+};
+
+/**
+ * Keep the swarm-mode signal compact and human-readable. A filled diamond
+ * means agents are active; the outline means swarm mode is ready but idle.
+ */
+export function swarmStatusPresentation(
+  runningAgents: number,
+): SwarmStatusPresentation {
+  const count = Number.isFinite(runningAgents)
+    ? Math.max(0, Math.trunc(runningAgents))
+    : 0;
+
+  if (count === 0) {
+    return { glyph: "◇", label: "swarm" };
+  }
+
+  return {
+    glyph: "◆",
+    label: `${count} ${count === 1 ? "agent" : "agents"}`,
+  };
+}
+
+/**
+ * A quiet inline status, intentionally not a filled badge: the old white-on-
+ * orange `SWARM` slab dominated the composer chrome and looked disconnected
+ * from the surrounding mode/model context.
+ */
+export function SwarmStatusIndicator({
+  runningAgents,
+}: {
+  readonly runningAgents: number;
+}): React.ReactElement {
+  const presentation = swarmStatusPresentation(runningAgents);
+
+  return (
+    <Box flexDirection="row" flexShrink={0}>
+      <ThemedText color="inactive" wrap="truncate-end">
+        {" · "}
+      </ThemedText>
+      <ThemedText color="agenc" wrap="truncate-end">
+        {presentation.glyph}
+      </ThemedText>
+      <ThemedText color="inactive" wrap="truncate-end">
+        {` ${presentation.label}`}
+      </ThemedText>
+    </Box>
+  );
+}

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -308,13 +308,16 @@ const USER_VISIBLE_WARNING_CAUSES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Collab v2 agent tools that produce their own structured transcript
- * rows via `collab_agent_spawn_*`, `collab_agent_interaction_*`,
- * `collab_waiting_*`, and `collab_close_*` events. The raw
- * `tool_call_started`/`tool_call_completed` rows for these names are
- * suppressed so the transcript shows a single structured collab-agent row
- * per call, matching `CollabAgentToolCall` ThreadItem routing where the
- * generic function-call ThreadItem variant is never produced for these tools.
+ * Collab v2 agent-control tools whose raw function-call rows are internal
+ * plumbing rather than useful transcript content. Lifecycle operations have
+ * structured rows via `collab_agent_spawn_*`, `collab_agent_interaction_*`,
+ * `collab_waiting_*`, and `collab_close_*`; `list_agents` is represented by
+ * the always-current Agents rail and the assistant's status narration.
+ * Suppressing the raw `tool_call_started`/`tool_call_completed` rows keeps
+ * function names and machine JSON out of the user-facing transcript.
+ * Provider-level `tool_input_block_*` events are suppressed for the same
+ * reason: their incomplete inputs otherwise become vague synthetic rows such
+ * as `spawn_agent ({})` before or after the structured lifecycle card.
  */
 const COLLAB_V2_TOOL_NAMES: ReadonlySet<string> = new Set([
   "spawn_agent",
@@ -322,6 +325,7 @@ const COLLAB_V2_TOOL_NAMES: ReadonlySet<string> = new Set([
   "close_agent",
   "assign_task",
   "send_message",
+  "list_agents",
   // followup_task (a deleted assign_task alias) stays here so historical
   // transcripts that recorded it still render a single structured row.
   "followup_task",
@@ -1741,6 +1745,8 @@ export function adaptTranscriptEvents(
   const runningToolNames = new Map<string, string>();
   const settledToolCallIds = new Set<string>();
   const suppressedToolResults = new Set<string>();
+  const suppressedStreamingToolCallIds = new Set<string>();
+  const suppressedStreamingToolInputIndexes = new Map<number, string>();
   const pendingToolInputDeltas = new Map<number, string[]>();
   const durableQueuedPromptUuids = new Set<string>();
   const collabAgents = new Map<string, CollabAgentDisplay>();
@@ -1776,6 +1782,24 @@ export function adaptTranscriptEvents(
     streamingText = "";
   };
 
+  const discardStreamingToolUse = (callId: string): void => {
+    const slot = streamingToolUses.findIndex(
+      (entry) => entry.contentBlock.id === callId,
+    );
+    if (slot !== -1) {
+      streamingToolUses.splice(slot, 1);
+    }
+  };
+
+  const clearSuppressedStreamingToolInput = (callId: string): void => {
+    suppressedStreamingToolCallIds.delete(callId);
+    for (const [index, suppressedCallId] of suppressedStreamingToolInputIndexes) {
+      if (suppressedCallId === callId) {
+        suppressedStreamingToolInputIndexes.delete(index);
+      }
+    }
+  };
+
   for (const raw of orderedEvents) {
     const event = unwrap(raw);
     if (seen.has(event.key)) continue;
@@ -1802,6 +1826,8 @@ export function adaptTranscriptEvents(
         runningToolNames.clear();
         settledToolCallIds.clear();
         suppressedToolResults.clear();
+        suppressedStreamingToolCallIds.clear();
+        suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         collabAgents.clear();
         streamingToolUses.length = 0;
@@ -1822,6 +1848,8 @@ export function adaptTranscriptEvents(
         runningToolNames.clear();
         settledToolCallIds.clear();
         suppressedToolResults.clear();
+        suppressedStreamingToolCallIds.clear();
+        suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         collabAgents.clear();
         streamingToolUses.length = 0;
@@ -1872,6 +1900,8 @@ export function adaptTranscriptEvents(
         // because they will never receive a matching completion event in this
         // turn.
         streamingToolUses.length = 0;
+        suppressedStreamingToolCallIds.clear();
+        suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         // Drop any thinking accumulator from a previous turn so the live
         // visibility window resets cleanly. Persisted `agent_thinking`
@@ -1889,6 +1919,8 @@ export function adaptTranscriptEvents(
         persistAssistantText(content, nextUuid);
         streamingText = "";
         streamingToolUses.length = 0;
+        suppressedStreamingToolCallIds.clear();
+        suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         isStreaming = false;
         if (
@@ -1938,6 +1970,8 @@ export function adaptTranscriptEvents(
         // abandoned because their completion events will never arrive
         // for this turn.
         streamingToolUses.length = 0;
+        suppressedStreamingToolCallIds.clear();
+        suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         out.push(makeSystemMessage(`Turn aborted: ${stringResult(payload.reason)}`, "warning", nextUuid()));
         break;
@@ -2190,6 +2224,12 @@ export function adaptTranscriptEvents(
           // spawn_agent/close_agent cards).
           toolNames.add(toolName);
           suppressedToolResults.add(callId);
+          suppressedStreamingToolCallIds.add(callId);
+          // A provider may have emitted tool_input_block_start before this
+          // durable tool start. Collaboration calls have their own named
+          // lifecycle cards, so discard any generic streaming cell that was
+          // provisionally created from an incomplete block.
+          discardStreamingToolUse(callId);
           break;
         }
         pushToolUse(out, openTools, toolNames, callId, toolName, toolInput(payload), nextUuid);
@@ -2234,6 +2274,21 @@ export function adaptTranscriptEvents(
         ) {
           toolNames.add(contentBlock.name);
         }
+        // Collaboration tools render through their structured lifecycle
+        // events (`Spawned <name>`, `Waiting for agents`, and so on). Keeping
+        // their provider-level input block would make <Messages> synthesize a
+        // second, context-free row such as `spawn_agent ({})` while the JSON
+        // arguments are still streaming.
+        if (COLLAB_V2_TOOL_NAMES.has(contentBlock.name)) {
+          suppressedStreamingToolCallIds.add(callId);
+          suppressedStreamingToolInputIndexes.set(indexCandidate, callId);
+          pendingToolInputDeltas.delete(indexCandidate);
+          discardStreamingToolUse(callId);
+          break;
+        }
+        // Provider content-block indexes are scoped to a sampling iteration
+        // and may be reused by the next tool call.
+        suppressedStreamingToolInputIndexes.delete(indexCandidate);
         // De-dupe on (index, contentBlock.id): if the same block_start fires
         // twice (e.g. retried stream), reuse the existing slot rather than
         // appending a duplicate that would confuse the Messages filter.
@@ -2282,6 +2337,17 @@ export function adaptTranscriptEvents(
               : null;
         if (partialJson === null) break;
         turnStreamedChars += partialJson.length;
+        const callId =
+          typeof payload.callId === "string" ? payload.callId : null;
+        const suppressedCallId =
+          suppressedStreamingToolInputIndexes.get(indexCandidate);
+        if (
+          (callId !== null && suppressedStreamingToolCallIds.has(callId)) ||
+          (suppressedCallId !== undefined &&
+            (callId === null || suppressedCallId === callId))
+        ) {
+          break;
+        }
         const slot = streamingToolUses.findIndex(
           (entry) => entry.index === indexCandidate,
         );
@@ -2304,8 +2370,13 @@ export function adaptTranscriptEvents(
         const callId =
           typeof payload.callId === "string" ? payload.callId : null;
         if (callId === null) break;
-        if (suppressedToolResults.has(callId)) {
+        if (
+          suppressedToolResults.has(callId) ||
+          suppressedStreamingToolCallIds.has(callId)
+        ) {
           suppressedToolResults.delete(callId);
+          discardStreamingToolUse(callId);
+          clearSuppressedStreamingToolInput(callId);
           settledToolCallIds.add(callId);
           break;
         }
@@ -2364,12 +2435,8 @@ export function adaptTranscriptEvents(
         // the Messages.tsx:446 filter (drop ids in inProgressToolUseIDs or
         // normalizedToolUseIDs) to do this; we drop here on completion because
         // AgenC moves the call out of openTools at the same step.
-        const slot = streamingToolUses.findIndex(
-          (entry) => entry.contentBlock.id === callId,
-        );
-        if (slot !== -1) {
-          streamingToolUses.splice(slot, 1);
-        }
+        discardStreamingToolUse(callId);
+        clearSuppressedStreamingToolInput(callId);
         break;
       }
       case "context_compacted":
@@ -2438,6 +2505,8 @@ export function adaptTranscriptEvents(
         streamingText = "";
         streamingThinking = null;
         streamingToolUses.length = 0;
+        suppressedStreamingToolCallIds.clear();
+        suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         isStreaming = false;
         currentTurnId = null;

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -20,8 +20,8 @@ import { PromptDialogOverlay, PromptSuggestionsOverlay } from "../components/Pro
 import type { PendingRequest } from "../permission-requests.js";
 import type { SpinnerMode } from "../components/spinner/types.js";
 import { AgentsRail } from "./agents/AgentsRail.js";
-import ThemedText from "../components/design-system/ThemedText.js";
 import { LedgerStatus } from "../components/LedgerStatus.js";
+import { SwarmStatusIndicator } from "../components/SwarmStatusIndicator.js";
 import { PreviewSurface } from "./surfaces/PreviewSurface.js";
 import { isDangerousPermissionMode } from "./WorkbenchContextStrip.js";
 import { ProjectExplorer } from "./project-tree/ProjectExplorer.js";
@@ -94,8 +94,8 @@ function ComposerContextRow({
   const modelLabel = renderModelName(parseUserSpecifiedModel(modelSetting));
   const modeLabel = permissionModeShortTitle(mode).toLowerCase();
   const dangerous = isDangerousPermissionMode(mode);
-  // Swarm indicator next to the mode (like yolo): visible only while swarm
-  // mode is on (/swarm), carrying the live running-agent count from AppState.
+  // Swarm status sits next to the mode: visible only while swarm mode is on
+  // and carrying the live running-agent count from AppState.
   const swarmMode =
     useAppStateMaybeOutsideOfProvider((state) => state.swarmMode) === true;
   const tasks = useAppStateMaybeOutsideOfProvider((state) => state.tasks) ?? {};
@@ -104,7 +104,6 @@ function ComposerContextRow({
       task?.type !== "local_bash" &&
       (task?.status === "running" || task?.status === "pending"),
   ).length;
-  const swarmBadgeText = ` SWARM${runningAgents > 0 ? ` ${runningAgents}` : ""} `;
   return (
     <Box flexDirection="row" paddingX={1} height={1} overflowY="hidden" justifyContent="space-between">
       <Box flexDirection="row">
@@ -112,9 +111,7 @@ function ComposerContextRow({
           {modeLabel}
         </Text>
         {swarmMode ? (
-          <ThemedText backgroundColor="agenc" color="ansi:white" bold wrap="truncate-end">
-            {swarmBadgeText}
-          </ThemedText>
+          <SwarmStatusIndicator runningAgents={runningAgents} />
         ) : null}
         <Text color="inactive" wrap="truncate-end">
           {` · ${modelLabel}${contextPctLabel !== null ? ` · ${contextPctLabel}` : ""}`}

--- a/runtime/tests/tui/components/SwarmStatusIndicator.test.tsx
+++ b/runtime/tests/tui/components/SwarmStatusIndicator.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import {
+  SwarmStatusIndicator,
+  swarmStatusPresentation,
+} from "./SwarmStatusIndicator.js";
+import { renderToString } from "../../utils/staticRender.js";
+
+describe("SwarmStatusIndicator", () => {
+  test.each([
+    [0, { glyph: "◇", label: "swarm" }],
+    [-2, { glyph: "◇", label: "swarm" }],
+    [Number.NaN, { glyph: "◇", label: "swarm" }],
+    [1, { glyph: "◆", label: "1 agent" }],
+    [2, { glyph: "◆", label: "2 agents" }],
+    [2.9, { glyph: "◆", label: "2 agents" }],
+  ])("formats running-agent count %s", (count, expected) => {
+    expect(swarmStatusPresentation(count)).toEqual(expected);
+  });
+
+  test("renders a quiet inline idle state without the old uppercase slab", async () => {
+    const output = await renderToString(
+      <SwarmStatusIndicator runningAgents={0} />,
+      40,
+    );
+
+    expect(output).toBe(" · ◇ swarm");
+    expect(output).not.toContain("SWARM");
+  });
+
+  test("renders an explicit human-readable active count", async () => {
+    const output = await renderToString(
+      <SwarmStatusIndicator runningAgents={3} />,
+      40,
+    );
+
+    expect(output).toBe(" · ◆ 3 agents");
+  });
+});

--- a/runtime/tests/tui/parity/session-transcript.contract.test.ts
+++ b/runtime/tests/tui/parity/session-transcript.contract.test.ts
@@ -240,6 +240,34 @@ describe("tool-call correlation contract", () => {
   test("collab-v2 raw spawn_agent tool events do not duplicate the structured agent row", () => {
     const transcript = adaptTranscriptEvents([
       {
+        id: "raw-spawn-input-start",
+        msg: {
+          type: "tool_input_block_start",
+          payload: {
+            callId: "agent-10",
+            index: 1,
+            contentBlock: {
+              type: "tool_use",
+              id: "agent-10",
+              name: "spawn_agent",
+              input: {},
+            },
+          },
+        },
+      },
+      {
+        id: "raw-spawn-input-delta",
+        msg: {
+          type: "tool_input_delta",
+          payload: {
+            callId: "agent-10",
+            index: 1,
+            partialJson:
+              '{"task_name":"reviewer","message":"review the diff"}',
+          },
+        },
+      },
+      {
         id: "raw-spawn-begin",
         msg: {
           type: "tool_call_started",
@@ -296,6 +324,9 @@ describe("tool-call correlation contract", () => {
     // unavailable" cards). Name registration is display-metadata, not a
     // row.
     expect(transcript.toolNames.has("spawn_agent")).toBe(true);
+    // Provider input streaming is another generic rendering path. It must
+    // not leak a second `spawn_agent ({})` row beside the structured card.
+    expect(transcript.streamingToolUses).toEqual([]);
     expect(transcript.messages).toMatchObject([
       { type: "system", subtype: "collab_agent", title: "Spawned reviewer", state: "success" },
     ]);

--- a/runtime/tests/tui/session-transcript.collab-toolnames.test.ts
+++ b/runtime/tests/tui/session-transcript.collab-toolnames.test.ts
@@ -2,15 +2,10 @@ import { describe, expect, test } from "vitest";
 
 import { adaptTranscriptEvents } from "../../src/tui/session-transcript.js";
 
-// Regression for the resumed-swarm "Tool use unavailable: spawn_agent"
-// cards that SURVIVED the 0.8.5 history_replaced fix. The real delivery
-// path (verbatim event shapes below are lifted from an affected session's
-// rollout, conv-mrwq1pfy 2026-07-22) is tool_input_block_start +
-// tool_call_started replay — and the reducer's collab branch suppressed
-// the generic spawn_agent row WITHOUT registering the name in toolNames,
-// while tool_input_block_start built a streaming cell that renders through
-// parseToolUse with the name equally unregistered. Both paths must feed
-// the renderer tool set.
+// Regressions from real resumed and live swarm sessions. Collaboration tool
+// names must reach the renderer so historical structured rows remain
+// resolvable, but their provider-level input blocks must not create duplicate
+// generic rows such as `spawn_agent ({})` beside the named lifecycle cards.
 
 const REAL_EVENTS = [
   {
@@ -43,10 +38,52 @@ const REAL_EVENTS = [
 ] as const;
 
 describe("collab tool names reach the renderer tool set", () => {
-  test("tool_input_block_start registers the block's tool name", () => {
-    const transcript = adaptTranscriptEvents([REAL_EVENTS[0]] as never[]);
-    expect(transcript.toolNames.has("spawn_agent")).toBe(true);
-  });
+  test.each([
+    "spawn_agent",
+    "wait_agent",
+    "close_agent",
+    "assign_task",
+    "send_message",
+    "list_agents",
+    "followup_task",
+  ])(
+    "%s input streaming registers its name without exposing a generic row",
+    (toolName) => {
+      const callId = `call-${toolName}`;
+      const transcript = adaptTranscriptEvents([
+        {
+          id: `${callId}-start`,
+          msg: {
+            type: "tool_input_block_start",
+            payload: {
+              callId,
+              index: 2,
+              contentBlock: {
+                type: "tool_use",
+                id: callId,
+                name: toolName,
+                input: {},
+              },
+            },
+          },
+        },
+        {
+          id: `${callId}-delta`,
+          msg: {
+            type: "tool_input_delta",
+            payload: {
+              callId,
+              index: 2,
+              partialJson: '{"task_name":"audit"}',
+            },
+          },
+        },
+      ] as never[]);
+
+      expect(transcript.toolNames.has(toolName)).toBe(true);
+      expect(transcript.streamingToolUses).toEqual([]);
+    },
+  );
 
   test("suppressed collab tool_call_started still registers the name", () => {
     const transcript = adaptTranscriptEvents([REAL_EVENTS[1]] as never[]);
@@ -56,5 +93,78 @@ describe("collab tool names reach the renderer tool set", () => {
   test("the full real replay sequence registers spawn_agent exactly once each way", () => {
     const transcript = adaptTranscriptEvents([...REAL_EVENTS] as never[]);
     expect(transcript.toolNames.has("spawn_agent")).toBe(true);
+    expect(transcript.streamingToolUses).toEqual([]);
+  });
+
+  test("a normal tool can reuse a suppressed collaboration input index", () => {
+    const transcript = adaptTranscriptEvents([
+      REAL_EVENTS[0],
+      {
+        id: "normal-tool-start",
+        msg: {
+          type: "tool_input_block_start",
+          payload: {
+            callId: "call-bash",
+            index: 2,
+            contentBlock: {
+              type: "tool_use",
+              id: "call-bash",
+              name: "Bash",
+              input: {},
+            },
+          },
+        },
+      },
+      {
+        id: "normal-tool-delta",
+        msg: {
+          type: "tool_input_delta",
+          payload: {
+            callId: "call-bash",
+            index: 2,
+            partialJson: '{"command":"pwd"}',
+          },
+        },
+      },
+    ] as never[]);
+
+    expect(transcript.streamingToolUses).toHaveLength(1);
+    expect(transcript.streamingToolUses[0]).toMatchObject({
+      index: 2,
+      contentBlock: { id: "call-bash", name: "Bash" },
+      unparsedToolInput: '{"command":"pwd"}',
+    });
+  });
+
+  test("list_agents machine JSON stays in the Agents rail, not the transcript", () => {
+    const transcript = adaptTranscriptEvents([
+      {
+        id: "list-agents-start",
+        msg: {
+          type: "tool_call_started",
+          payload: {
+            callId: "call-list-agents",
+            toolName: "list_agents",
+            args: "{}",
+          },
+        },
+      },
+      {
+        id: "list-agents-complete",
+        msg: {
+          type: "tool_call_completed",
+          payload: {
+            callId: "call-list-agents",
+            result:
+              '{"agents":[{"agent_name":"/root/a","agent_status":"running"}]}',
+            isError: false,
+          },
+        },
+      },
+    ] as never[]);
+
+    expect(transcript.toolNames.has("list_agents")).toBe(true);
+    expect(transcript.messages).toEqual([]);
+    expect(transcript.streamingToolUses).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- suppress provider-streamed internal collaboration calls so spawn_agent, wait_agent, close_agent, and list_agents no longer leak vague raw rows or machine JSON into the transcript
- replace the loud filled SWARM slab with a quiet inline diamond status and human-readable active-agent count
- make the pre-commit TUI warmup outlive the existing five-second build-skew daemon reap window

## Live verification
- ran real AgenC swarms in /home/tetsuo/git/stream-test/agenc-shell and watched the built TUI through spawn, wait, list, close, and completion
- verified only named lifecycle rows remain and the footer transitions between · ◇ swarm and · ◆ 2 agents

## Local gates
- npm run typecheck
- npm run test --workspace=@tetsuo-ai/runtime (1,880 files; 16,480 tests passed)
- npm run test:required-gates (109 passed)
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- pre-commit build and PTY startup hook