### PR TITLE
fix(runtime): bump shell-quote to 1.10.0 and correct assign_task prompt wording

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8117,9 +8117,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9506,7 +9506,7 @@
         "react": "^19.0.0",
         "react-compiler-runtime": "^1.0.0",
         "react-reconciler": "^0.33.0",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.10.0",
         "signal-exit": "^4.1.0",
         "strip-ansi": "^7.2.0",
         "tree-kill": "^1.2.2",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -142,7 +142,7 @@
     "react": "^19.0.0",
     "react-compiler-runtime": "^1.0.0",
     "react-reconciler": "^0.33.0",
-    "shell-quote": "1.8.4",
+    "shell-quote": "1.10.0",
     "signal-exit": "^4.1.0",
     "strip-ansi": "^7.2.0",
     "tree-kill": "^1.2.2",

--- a/runtime/src/coordinator/coordinatorMode.ts
+++ b/runtime/src/coordinator/coordinatorMode.ts
@@ -71,7 +71,7 @@ You do NOT edit files or run commands yourself — workers do. Every message you
 
 - **spawn_agent** — spawn a worker (message, task_name; optional agent_type, model, isolation:"worktree" for parallel writers)
 - **send_message** — send a follow-up to a running worker without triggering a turn
-- **assign_task** — give a running worker a new task (triggers a turn)
+- **assign_task** — give an idle reusable worker a new task (triggers a turn)
 - **wait_agent** — block on a worker only when its result is the immediate critical-path need
 - **list_agents / TaskOutput / TaskStop** — inspect and manage running workers
 - **AskUserQuestion / TodoWrite** — interact with the user and track the plan

--- a/runtime/tests/coordinator/live-coordinator.test.ts
+++ b/runtime/tests/coordinator/live-coordinator.test.ts
@@ -45,6 +45,8 @@ describe("live coordinator surface", () => {
     expect(prompt).toContain("spawn_agent");
     expect(prompt).toContain("send_message");
     expect(prompt).toContain("wait_agent");
+    expect(prompt).toContain("give an idle reusable worker a new task");
+    expect(prompt).not.toContain("give a running worker a new task");
     expect(prompt).not.toContain("SendMessageTool");
     // Coordinator never edits directly.
     expect(prompt).toContain("do NOT edit files or run commands yourself");


### PR DESCRIPTION
Picks the two live changes out of the superseded release branch (#1586); everything else there (0.9.0 version bump, docs, release notes) already landed on main via 454028f83 / eb4ec6344.

## shell-quote 1.8.4 → 1.10.0
1.8.4 treats `\'` inside single quotes as an escaped quote; POSIX shells treat backslash inside single quotes as a literal. The divergence lets a chained command hide inside what the permission splitter sees as a single quoted token:

```
CMD: echo 'a\' && rm -rf ~'
 1.8.4 : ["echo", {op:"'a\' && rm -rf ~'"}]        ← && hidden inside one token
 1.10.0: ["echo","a\\", {op:"&&"}, "rm","-rf","~"]  ← matches what bash executes
```

`splitCommandWithOperators` (runtime/src/utils/bash/commands.ts) feeds Bash permission checks from this parse, so the parser must agree with the real shell.

## assign_task prompt wording
`assign_task` only admits idle reusable workers (`assign-task.ts` rejects busy workers / outstanding assignments), but the coordinator prompt said it targets a *running* worker. Wording now matches admission semantics, pinned by revert-sensitive test assertions (verified red without the source change).

## Verification
- 216 tests across the 4 shell-quote-dependent suites (permissions/bash, tui/slash/shell-quote, shell-command/parser, gaphunt3/commands-config) + 6 coordinator tests: all pass
- typecheck, build, TUI startup smoke: pass
- lockfile diff is exactly the shell-quote entry