### PR TITLE
fix(release): handle initial installer promotion

### DIFF
--- a/.github/workflows/promote-installers.yml
+++ b/.github/workflows/promote-installers.yml
@@ -99,10 +99,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          current="$(
+          current_response=""
+          if current_response="$(
             gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/installer-stable" \
-              --jq .object.sha 2>/dev/null || true
-          )"
+              2>/dev/null
+          )"; then
+            current="$(
+              jq --exit-status --raw-output \
+                '.object.sha | strings | select(test("^[0-9a-f]{40}$"))' \
+                <<<"$current_response"
+            )"
+          elif jq --exit-status \
+            '.message == "Not Found" and (.status | tostring) == "404"' \
+            <<<"$current_response" >/dev/null 2>&1; then
+            current=""
+          else
+            echo "failed to read installer-stable ref" >&2
+            printf '%s\n' "$current_response" >&2
+            exit 1
+          fi
           if [[ "$LANE" = installer-hotfix && -z "$current" ]]; then
             echo "installer-hotfix requires an existing full-release promotion" >&2
             exit 1

--- a/packages/agenc/test/runtime-release-contract.test.mjs
+++ b/packages/agenc/test/runtime-release-contract.test.mjs
@@ -122,6 +122,14 @@ test("installer promotion is exact-SHA, fast-forward-only, and lane-scoped", () 
   assert.match(workflow, /installer-stable/u);
   assert.match(workflow, /git merge-base --is-ancestor/u);
   assert.match(workflow, /-F force=false/u);
+  assert.match(
+    workflow,
+    /\.message == "Not Found" and \(\.status \| tostring\) == "404"/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /git\/ref\/heads\/installer-stable"[\s\S]{0,160}\|\| true/u,
+  );
   assert.match(workflow, /test "\$TESTED_SHA" = "\$GITHUB_SHA"/u);
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- distinguish an absent installer-stable ref from other GitHub API failures
- fail closed on authentication, network, and malformed ref responses
- add a revert-sensitive workflow contract test so a 404 body cannot be mistaken for a commit SHA again

## Validation

- `node --test packages/agenc/test/runtime-release-contract.test.mjs` — 10/10 passed
- `npm test` — 1,880 files / 16,482 tests passed
- pre-commit build and real PTY startup smoke passed
- YAML parse and `git diff --check` passed

This hardens the resumable installer promotion path discovered while releasing 0.9.3. It does not move or rebuild the immutable 0.9.3 release SHA.