### PR TITLE
fix(runtime): make onboarding input actionable

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
@@ -1,5 +1,5 @@
 /**
- * `agenc onboard` scenario (TODO task 2).
+ * `agenc onboard` scenario.
  *
  * The explicit onboard subcommand boots the TUI with the first-run wizard
  * forced. Drive the whole wizard with the mock openai-compatible provider
@@ -28,16 +28,16 @@ export default async function (session) {
   // so phrase anchors are only reliable on this first screen; subsequent
   // steps are driven input→idle. The wizard's input protocol is fixed:
   // src/onboarding/Onboarding.tsx submitFirstRunOnboardingInput.)
-  await session.waitFor(/Type next to continue\./, { timeout: 60_000 });
+  await session.waitFor(/Press Enter to continue/, { timeout: 60_000 });
 
   const wizardInputs = [
-    "next", // preflight → theme
+    "", // preflight: Enter → theme
     "1", // theme: dark → provider
     "openai-compatible", // provider (mock server) → api-key
-    "next", // api-key: keyless local provider → connection-test
-    "next", // connection-test: runs the mock-server check → security
-    "next", // security: keep defaults → terminal-setup
-    "done", // terminal-setup: finish onboarding
+    "", // api-key: Enter on keyless local provider → connection-test
+    "", // connection-test: Enter runs the mock-server check → security
+    "", // security: Enter keeps defaults → terminal-setup
+    "", // terminal-setup: Enter finishes onboarding
   ];
   for (const input of wizardInputs) {
     await session.submit(input);

--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -474,7 +474,7 @@ function parseProvider(
 function invalidCommandError(raw: string, expected: string): string | null {
   return raw.trim().toLowerCase() === expected
     ? null
-    : `Type ${expected} to continue.`;
+    : `Press Enter to continue, or type ${expected}.`;
 }
 
 function normalizeApiKeyEntry(raw: string): string {
@@ -522,6 +522,29 @@ function normalizeOnboardingCommand(raw: string): string {
   return raw;
 }
 
+function defaultOnboardingCommand(
+  state: FirstRunOnboardingState,
+  raw: string,
+): string {
+  if (raw.trim() !== "") return raw;
+  switch (state.currentStepId) {
+    case "preflight":
+    case "connection-test":
+    case "security":
+      return "next";
+    case "terminal-setup":
+      return "done";
+    case "theme":
+    case "provider":
+      return raw;
+    case "api-key":
+      // Empty input intentionally means "continue without saving" on the
+      // ordinary credential step. Never choose for the user once a verified
+      // key is awaiting the explicit yes/no persistence decision.
+      return state.pendingApiKeyApproval === null ? raw : "";
+  }
+}
+
 function approvalAnswer(command: string): "yes" | "no" | null {
   if (command === "y" || command === "yes") return "yes";
   if (command === "n" || command === "no" || command === "skip") return "no";
@@ -534,12 +557,12 @@ function onboardingSlashCommandError(raw: string): string | null {
     return "Onboarding is active. Finish setup before loading $skills, or use /exit, Ctrl-C twice, or Ctrl-D twice to leave.";
   }
   if (!input.startsWith("/") || input.length <= 1) return null;
-  return "Onboarding is active. Type next or skip to continue setup, or use /exit, Ctrl-C twice, or Ctrl-D twice to leave.";
+  return "Onboarding is active. Press Enter to continue setup, or use /exit, Ctrl-C twice, or Ctrl-D twice to leave.";
 }
 
 function apiKeyVerificationErrorMessage(error: string | undefined): string {
   const base = error?.trim() || "API key verification failed.";
-  return `${base} Type next or skip to continue without saving, or paste a replacement key.`;
+  return `${base} Press Enter to continue without saving, or paste a replacement key.`;
 }
 
 function verifiedApiKeyConnection(
@@ -851,7 +874,10 @@ export async function submitFirstRunOnboardingInput(
   rawInput: string,
   context: FirstRunOnboardingContext,
 ): Promise<FirstRunOnboardingSubmitResult> {
-  const raw = normalizeOnboardingCommand(rawInput);
+  const raw = defaultOnboardingCommand(
+    state,
+    normalizeOnboardingCommand(rawInput),
+  );
   const slashError = onboardingSlashCommandError(raw);
   if (slashError !== null) {
     return {
@@ -925,7 +951,10 @@ export async function submitFirstRunOnboardingInput(
       const command = raw.trim().toLowerCase();
       if (command !== "next" && command !== "test") {
         return {
-          state: { ...state, error: "Type test or next to run the connection check." },
+          state: {
+            ...state,
+            error: "Press Enter to run the connection check, or type test.",
+          },
           completed: false,
         };
       }
@@ -1063,7 +1092,7 @@ export async function submitFirstRunOnboardingInput(
             state: {
               ...state,
               error:
-                "Type next or skip to continue without saving, or paste a single API key without whitespace.",
+                "Press Enter to continue without saving, or paste a single API key without whitespace.",
             },
             completed: false,
           };
@@ -1131,7 +1160,10 @@ export async function submitFirstRunOnboardingInput(
         const command = raw.trim().toLowerCase();
         if (command !== "done") {
           return {
-            state: { ...state, error: "Type done to finish onboarding." },
+            state: {
+              ...state,
+              error: "Press Enter to finish onboarding, or type done.",
+            },
             completed: false,
           };
         }
@@ -1258,16 +1290,16 @@ function apiKeyInstructionForConnection(
   connection: ProviderConnectionCheck | null,
 ): string {
   if (connection === null) {
-    return "Paste an API key to verify it, or type next to continue without saving.";
+    return "Paste an API key to verify it, or press Enter to continue without saving.";
   }
   if (connection.status === "ready") {
     if (connection.keyEnvVar !== undefined) {
-      return `${connection.keyEnvVar} is present and verified. Type next to continue, or paste a replacement key.`;
+      return `${connection.keyEnvVar} is present and verified. Press Enter to continue, or paste a replacement key.`;
     }
-    return "Provider credential is verified. Type next to continue, or paste a replacement key.";
+    return "Provider credential is verified. Press Enter to continue, or paste a replacement key.";
   }
   if (connection.keyEnvVar === undefined) {
-    return "Paste an API key to verify it, or type next or skip to continue.";
+    return "Paste an API key to verify it, or press Enter to continue.";
   }
   if (connection.canSkip === false) {
     return `Paste ${connection.keyEnvVar} to verify it before continuing.`;
@@ -1276,9 +1308,9 @@ function apiKeyInstructionForConnection(
     connection.status === "auth-failed" ||
     connection.status === "provider-unreachable"
   ) {
-    return `${connection.keyEnvVar} did not verify. Type next or skip to continue without saving, or paste a replacement key.`;
+    return `${connection.keyEnvVar} did not verify. Press Enter to continue without saving, or paste a replacement key.`;
   }
-  return `Paste ${connection.keyEnvVar} to verify it, or type next or skip to add it later.`;
+  return `Paste ${connection.keyEnvVar} to verify it, or press Enter to add it later.`;
 }
 
 function apiKeyInstructionForProvider(
@@ -1291,15 +1323,15 @@ function apiKeyInstructionForProvider(
     resolveAuthManagedKeysEnabled(context.config) &&
     hasEntitledRemoteAuthSessionSync(context.env)
   ) {
-    return "Your Pro account can use hosted model access here. Type next to verify it.";
+    return "Your Pro account can use hosted model access here. Press Enter to verify it.";
   }
   if (!KEY_REQUIRED_PROVIDERS.has(provider)) {
-    return "This provider can continue without a BYOK API key. Type next to continue.";
+    return "This provider can continue without a BYOK API key. Press Enter to continue.";
   }
   if (keyEnvVar === undefined) {
-    return "Paste an API key to verify it, or type next or skip to add it later.";
+    return "Paste an API key to verify it, or press Enter to add it later.";
   }
-  return `Paste ${keyEnvVar} to verify it, or type next or skip to add it later.`;
+  return `Paste ${keyEnvVar} to verify it, or press Enter to add it later.`;
 }
 
 function securityLinesForContext(
@@ -1309,14 +1341,82 @@ function securityLinesForContext(
     return [
       "Permission mode: bypassPermissions (--yolo skips tool approval prompts).",
       "Sandbox: danger-full-access (--yolo disables workspace sandboxing for this session).",
-      "Type next to continue with --yolo, or restart without --yolo for prompts and sandboxing.",
+      "Press Enter to continue with --yolo, or restart without --yolo for prompts and sandboxing.",
     ];
   }
   return [
     `Permission mode: ${context.permissionMode ?? "default"}`,
     `Sandbox: ${context.sandboxMode ?? "workspace-write"}`,
-    "Type next to keep these defaults.",
+    "Press Enter to keep these defaults.",
   ];
+}
+
+export interface FirstRunOnboardingInputPresentation {
+  readonly placeholder: string;
+  readonly footerHint: string;
+  readonly allowEmptySubmit: boolean;
+}
+
+export function firstRunOnboardingInputPresentation(
+  state: FirstRunOnboardingState,
+): FirstRunOnboardingInputPresentation {
+  const standardFooter =
+    "Enter confirms the shown default · type a listed choice to change it · /exit leaves setup";
+  switch (state.currentStepId) {
+    case "preflight":
+      return {
+        placeholder: "Press Enter to start setup",
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+    case "theme":
+      return {
+        placeholder: `Press Enter to keep ${state.selectedTheme}, or type 1–3`,
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+    case "provider":
+      return {
+        placeholder: `Press Enter to keep ${state.selectedProvider}, or type a provider number`,
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+    case "api-key":
+      if (state.pendingApiKeyApproval !== null) {
+        return {
+          placeholder: "Type yes to save this key, or no to discard it",
+          footerHint:
+            "Saving a verified key always requires an explicit yes · /exit leaves setup",
+          allowEmptySubmit: false,
+        };
+      }
+      return {
+        placeholder:
+          state.selectedProvider === "grok"
+            ? "Paste XAI_API_KEY, type login, or press Enter to add it later"
+            : "Paste an API key, or press Enter to add it later",
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+    case "connection-test":
+      return {
+        placeholder: `Press Enter to test ${state.selectedProvider}`,
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+    case "security":
+      return {
+        placeholder: "Press Enter to keep these security defaults",
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+    case "terminal-setup":
+      return {
+        placeholder: "Press Enter to finish onboarding",
+        footerHint: standardFooter,
+        allowEmptySubmit: true,
+      };
+  }
 }
 
 export function detailLinesForStep(
@@ -1332,7 +1432,7 @@ export function detailLinesForStep(
           ? ["--yolo is active: tool approvals and workspace sandboxing are bypassed for this session."]
           : []),
         "Onboarding input only. Use /exit, Ctrl-C twice, or Ctrl-D twice to leave.",
-        "Type next to continue.",
+        "Press Enter to continue (or type next).",
       ];
     case "theme": {
       // The TUI colours text but does NOT repaint the terminal's own
@@ -1355,7 +1455,7 @@ export function detailLinesForStep(
           `${index + 1}. ${theme}${theme === state.selectedTheme ? " (current)" : ""}`
         ),
         themeTip,
-        "Type a number or theme name.",
+        `Press Enter to keep ${state.selectedTheme}, or type a number or theme name.`,
       ];
     }
     case "provider": {
@@ -1369,7 +1469,7 @@ export function detailLinesForStep(
               `Tip: ${[...detected][0]} is already running on this machine — pick it for a zero-key start.`,
             ]
           : []),
-        "Type a number or provider slug.",
+        `Press Enter to keep ${state.selectedProvider}, or type a number or provider slug.`,
       ];
     }
     case "connection-test":
@@ -1378,7 +1478,7 @@ export function detailLinesForStep(
         : [
             `Provider: ${state.selectedProvider}`,
             `Model: ${state.selectedModel}`,
-            "Type test or next to run the connection check.",
+            "Press Enter to run the connection check (or type test).",
           ];
     case "api-key": {
       if (state.pendingApiKeyApproval !== null) {
@@ -1416,7 +1516,7 @@ export function detailLinesForStep(
     case "terminal-setup":
       return [
         `Terminal: ${context.terminalName ?? "terminal"}`,
-        "Type done to finish onboarding.",
+        "Press Enter to finish onboarding (or type done).",
       ];
   }
 }
@@ -1449,7 +1549,7 @@ function classifyOnboardingDetail(line: string): OnboardingDetailEntry {
       current: /\(current\)\s*$/u.test(line),
     };
   }
-  if (/^(Type |Or type |Tip:|Onboarding input only)/u.test(line)) {
+  if (/^(Press Enter|Type |Or type |Tip:|Onboarding input only)/u.test(line)) {
     return { kind: "hint", text: line };
   }
   const kv = /^([A-Za-z][A-Za-z ]+):\s+(.*)$/u.exec(line);
@@ -1509,7 +1609,7 @@ function renderOnboardingDetail(lines: readonly string[]): React.ReactNode[] {
   entries.forEach((entry, index) => {
     const previous = entries[index - 1];
     // A blank line before the first hint after any content splits the action
-    // instructions ("Type next…") from the data/choices above them.
+    // instructions ("Press Enter…") from the data/choices above them.
     if (entry.kind === "hint" && previous !== undefined && previous.kind !== "hint") {
       nodes.push(<Box key={`gap-${index}`} height={1} />);
     }

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -95,7 +95,12 @@ import { createFileStateCacheWithSizeLimit, READ_FILE_STATE_CACHE_SIZE } from ".
 import { fileHistoryRewind } from "../../utils/fileHistory.js";
 import { getCurrentWorktreeSession } from "../../utils/worktree.js";
 import { escapeXml, unescapeXml } from "../../utils/xml.js";
-import { Onboarding, type FirstRunOnboardingState, useFirstRunOnboardingController } from "../../onboarding/Onboarding.js";
+import {
+  firstRunOnboardingInputPresentation,
+  Onboarding,
+  type FirstRunOnboardingState,
+  useFirstRunOnboardingController,
+} from "../../onboarding/Onboarding.js";
 import type { MCPServerConnection } from "../../services/mcp/types.js";
 import { refreshLedgerStatus } from "../../services/Ledger/ledgerStatus.js";
 import {
@@ -3040,13 +3045,14 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
 
   // Onboarding renders standalone — composer-only flow drives its own input.
   if (onboarding.active) {
+    const onboardingInput = firstRunOnboardingInputPresentation(onboarding.state);
     return <Box flexDirection="column" width="100%">
         <AnimatedTerminalTitle isAnimating={titleIsAnimating} title={title} />
         <Onboarding state={onboarding.state} steps={onboarding.steps} currentStep={onboarding.currentStep} context={onboardingContext} />
       {toolJSX !== null ? <Box flexDirection="column" width="100%">
           {toolJSX.jsx}
         </Box> : null}
-      <PromptInput debug={false} ideSelection={undefined} toolPermissionContext={toolPermissionContext as any} setToolPermissionContext={setToolPermissionContext as any} apiKeyStatus={apiKeyStatus} agencHome={agencHome} commands={EMPTY_ONBOARDING_COMMANDS} agents={agents as any} isLoading={false} verbose={false} getMessages={getTranscriptMessages} hasMessages={hasTranscriptMessages} isMidConversation={hasTranscriptMessages} lastAssistantMessageId={lastAssistantMessageId} onAutoUpdaterResult={() => {}} autoUpdaterResult={null} input={input} onInputChange={setInput} mode={mode} onModeChange={setMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={handleShowMessageSelector} mcpClients={mcpClients as never} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onExit={handleExit} getToolUseContext={getToolUseContext} onSubmit={async (value_0, helpers) => {
+      <PromptInput debug={false} ideSelection={undefined} toolPermissionContext={toolPermissionContext as any} setToolPermissionContext={setToolPermissionContext as any} apiKeyStatus="valid" agencHome={agencHome} commands={EMPTY_ONBOARDING_COMMANDS} agents={agents as any} isLoading={false} verbose={false} getMessages={getTranscriptMessages} hasMessages={hasTranscriptMessages} isMidConversation={hasTranscriptMessages} lastAssistantMessageId={lastAssistantMessageId} onAutoUpdaterResult={() => {}} autoUpdaterResult={null} input={input} onInputChange={setInput} mode={mode} onModeChange={setMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={handleShowMessageSelector} mcpClients={mcpClients as never} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onExit={handleExit} getToolUseContext={getToolUseContext} onboardingInput={onboardingInput} onSubmit={async (value_0, helpers) => {
         if (isExitSlashCommand(value_0)) {
           setInput("");
           helpers.clearBuffer();

--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -434,6 +434,11 @@ type Props = {
   setHelpOpen: React.Dispatch<React.SetStateAction<boolean>>;
   hasSuppressedDialogs?: boolean;
   isLocalJSXCommandActive?: boolean;
+  onboardingInput?: {
+    readonly placeholder: string;
+    readonly footerHint: string;
+    readonly allowEmptySubmit: boolean;
+  };
 };
 
 // Bottom slot has maxHeight="50%"; reserve lines for footer, border, status.
@@ -559,7 +564,8 @@ function PromptInput({
   helpOpen,
   setHelpOpen,
   hasSuppressedDialogs,
-  isLocalJSXCommandActive = false
+  isLocalJSXCommandActive = false,
+  onboardingInput
 }: Props): React.ReactNode {
   const mainLoopModel = useMainLoopModel();
   // A local-jsx command (e.g., /mcp while agent is running) renders a full-
@@ -1179,7 +1185,7 @@ function PromptInput({
     const currentInput = lastInternalInputRef.current;
     const currentCursorOffset = cursorOffsetRef.current;
     const currentPastedContents = pastedContentsRef.current;
-    if (interpretShortcuts && value === '?') {
+    if (onboardingInput === undefined && interpretShortcuts && value === '?') {
       setHelpOpen(v => !v);
       return;
     }
@@ -1196,7 +1202,7 @@ function PromptInput({
     // mode itself is shown via the prompt prefix in the UI. Without this,
     // typing `!` into empty input would enter bash mode but leave the literal
     // `!` in the buffer (issue #662).
-    const modeEntry = interpretShortcuts ? detectModeEntry({
+    const modeEntry = onboardingInput === undefined && interpretShortcuts ? detectModeEntry({
       value,
       prevInputLength: currentInput.length,
       cursorOffset: currentCursorOffset,
@@ -1222,7 +1228,7 @@ function PromptInput({
       footerSelection: null
     });
     trackAndSetInput(processedValue);
-  }, [trackAndSetInput, onModeChange, pushToBuffer, dismissStashHint, setAppState, setCurrentCursorOffset]);
+  }, [trackAndSetInput, onModeChange, pushToBuffer, dismissStashHint, setAppState, setCurrentCursorOffset, onboardingInput]);
   const {
     resetHistory,
     onHistoryUp,
@@ -1340,7 +1346,7 @@ function PromptInput({
     // Only in leader view — promptSuggestion is leader-context, not teammate.
     const suggestionText = promptSuggestionState.text;
     const inputMatchesSuggestion = inputParam.trim() === '' || inputParam === suggestionText;
-    if (inputMatchesSuggestion && suggestionText && !hasImages && !hasWorkbenchAttachments && !state.viewingAgentTaskId) {
+    if (onboardingInput === undefined && inputMatchesSuggestion && suggestionText && !hasImages && !hasWorkbenchAttachments && !state.viewingAgentTaskId) {
       // If speculation is active, inject messages immediately as they stream
       if (speculation.status === 'active') {
         markAccepted();
@@ -1407,7 +1413,7 @@ function PromptInput({
     }
 
     // Allow submission if there are images attached, even without text
-    if (inputParam.trim() === '' && !hasImages && !hasWorkbenchAttachments) {
+    if (inputParam.trim() === '' && !hasImages && !hasWorkbenchAttachments && onboardingInput?.allowEmptySubmit !== true) {
       return;
     }
 
@@ -1542,7 +1548,7 @@ function PromptInput({
     if (hasWorkbenchAttachments) {
       setAppState(prev => applyWorkbenchCommand(prev, { type: 'clearAttachments' }));
     }
-  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, removeNotification, vimMode, mode, getToolUseContext, getMessages, mainLoopModel, trackAndSetInput, onModeChange, isLoading, addNotification, setCurrentCursorOffset, setPastedContentsAndRef]);
+  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, removeNotification, vimMode, mode, getToolUseContext, getMessages, mainLoopModel, trackAndSetInput, onModeChange, isLoading, addNotification, setCurrentCursorOffset, setPastedContentsAndRef, onboardingInput]);
   const {
     suggestions,
     selectedSuggestion,
@@ -1561,14 +1567,14 @@ function PromptInput({
     agents,
     setSuggestionsState,
     suggestionsState,
-    suppressSuggestions: isSearchingHistory || historyIndex > 0,
+    suppressSuggestions: onboardingInput !== undefined || isSearchingHistory || historyIndex > 0,
     markAccepted,
     onModeChange
   });
 
   // Track if prompt suggestion should be shown (computed later with terminal width).
   // Hidden in teammate view — suggestion is leader-context only.
-  const showPromptSuggestion = shouldShowPromptSuggestionPlaceholder({
+  const showPromptSuggestion = onboardingInput === undefined && shouldShowPromptSuggestionPlaceholder({
     mode,
     promptSuggestion,
     suggestionCount: suggestions.length,
@@ -1581,7 +1587,7 @@ function PromptInput({
   // If suggestion was generated but can't be shown due to timing, log suppression.
   // Exclude teammate view: markShown() is gated above, so shownAt stays 0 there —
   // but that's not a timing failure, the suggestion is valid when returning to leader.
-  const shouldSuppressPromptSuggestion = shouldSuppressPromptSuggestionForTiming({
+  const shouldSuppressPromptSuggestion = onboardingInput === undefined && shouldSuppressPromptSuggestionForTiming({
     promptSuggestionText: promptSuggestionState.text,
     visiblePromptSuggestion: promptSuggestion,
     shownAt: promptSuggestionState.shownAt,
@@ -2532,6 +2538,8 @@ function PromptInput({
   // frame and compete for attention.
   const placeholder = isPasting
     ? undefined
+    : onboardingInput !== undefined
+      ? onboardingInput.placeholder
     : showPromptSuggestion && promptSuggestion
       ? promptSuggestion
       : defaultPlaceholder;
@@ -2704,8 +2712,8 @@ function PromptInput({
     // NOT via useKeybindings. This allows useTextInput's upOrHistoryUp/downOrHistoryDown
     // to try cursor movement first and only fall through to history navigation when the
     // cursor can't move further (important for wrapped text and multi-line input).
-    onHistoryUp: handleHistoryUp,
-    onHistoryDown: handleHistoryDown,
+    onHistoryUp: onboardingInput === undefined ? handleHistoryUp : undefined,
+    onHistoryDown: onboardingInput === undefined ? handleHistoryDown : undefined,
     onHistoryReset: resetHistory,
     placeholder,
     onExit,
@@ -2738,6 +2746,9 @@ function PromptInput({
     inputFilter: lazySpaceInputFilter
   };
   const getBorderColor = (): keyof Theme => {
+    if (onboardingInput !== undefined) {
+      return 'agenc';
+    }
     const modeColors: Record<string, keyof Theme> = {
       bash: 'worker'
     };
@@ -2792,22 +2803,29 @@ function PromptInput({
             </Box>
           </Box>
           <Text color={swarmBanner.bgColor}>{promptGlyphs.horizontal.repeat(columns)}</Text>
-        </> : <Box flexDirection="row" alignItems="flex-start" justifyContent="flex-start" borderColor={getBorderColor()} borderStyle="single" width="100%" paddingX={1} backgroundColor={mode === 'bash' ? 'workerWash' : undefined} borderText={buildBorderText(showFastIcon ?? false, showFastIconHint, fastModeCooldown)}>
+        </> : <Box flexDirection="row" alignItems="flex-start" justifyContent="flex-start" borderColor={getBorderColor()} borderStyle="single" width="100%" paddingX={1} backgroundColor={mode === 'bash' ? 'workerWash' : undefined} borderText={onboardingInput !== undefined ? {
+          content: ' setup ',
+          position: 'top',
+          align: 'start',
+          offset: 1
+        } : buildBorderText(showFastIcon ?? false, showFastIconHint, fastModeCooldown)}>
           <PromptInputModeIndicator mode={mode} permissionMode={effectiveToolPermissionContext.mode} isLoading={isLoading} viewingAgentName={viewingAgentName} viewingAgentColor={viewingAgentColor} />
           <Box flexGrow={1} flexShrink={1} onClick={handleInputClick}>
             {textInputElement}
           </Box>
         </Box>}
-      {!isFullscreenEnvEnabled() && modeSwitcherElement ? <Box flexDirection="column" marginTop={1}>{modeSwitcherElement}</Box> : null}
+      {onboardingInput === undefined && !isFullscreenEnvEnabled() && modeSwitcherElement ? <Box flexDirection="column" marginTop={1}>{modeSwitcherElement}</Box> : null}
       {/* Round-2 M-NEW6: don't hide "? for shortcuts" on the first
           keystroke — the hint is about discovering keybindings, not
           about typing. Suppress it only when an active dropdown (the
           slash command picker / @-mention list) needs the same row,
           which the suggestions branch in PromptInputFooter handles
           via its own early return. */}
-      <PromptInputFooter apiKeyStatus={apiKeyStatus} agencHome={agencHome} debug={debug} exitMessage={exitMessage} vimMode={isVimModeEnabled() ? vimMode : undefined} mode={mode} autoUpdaterResult={autoUpdaterResult} isAutoUpdating={isAutoUpdating} verbose={verbose} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={setIsAutoUpdating} suggestions={suggestions} selectedSuggestion={selectedSuggestion} suggestionType={suggestionType} maxColumnWidth={maxColumnWidth} toolPermissionContext={effectiveToolPermissionContext} helpOpen={helpOpen} suppressHint={false} isLoading={isLoading} tasksSelected={tasksSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} ideSelection={ideSelection} mcpClients={mcpClients} isPasting={isPasting} isInputWrapped={isInputWrapped} getMessages={getMessages} lastAssistantMessageId={lastAssistantMessageId} isSearching={isSearchingHistory} historyQuery={historyQuery} setHistoryQuery={setHistoryQuery} historyFailedMatch={historyFailedMatch} onOpenTasksDialog={isFullscreenEnvEnabled() ? handleOpenTasksDialog : undefined} />
-      {isFullscreenEnvEnabled() ? null : autoModeOptInDialog}
-      {isFullscreenEnvEnabled() ?
+      {onboardingInput !== undefined ? <Box paddingX={2}>
+          <Text dimColor>{onboardingInput.footerHint}</Text>
+        </Box> : <PromptInputFooter apiKeyStatus={apiKeyStatus} agencHome={agencHome} debug={debug} exitMessage={exitMessage} vimMode={isVimModeEnabled() ? vimMode : undefined} mode={mode} autoUpdaterResult={autoUpdaterResult} isAutoUpdating={isAutoUpdating} verbose={verbose} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={setIsAutoUpdating} suggestions={suggestions} selectedSuggestion={selectedSuggestion} suggestionType={suggestionType} maxColumnWidth={maxColumnWidth} toolPermissionContext={effectiveToolPermissionContext} helpOpen={helpOpen} suppressHint={false} isLoading={isLoading} tasksSelected={tasksSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} ideSelection={ideSelection} mcpClients={mcpClients} isPasting={isPasting} isInputWrapped={isInputWrapped} getMessages={getMessages} lastAssistantMessageId={lastAssistantMessageId} isSearching={isSearchingHistory} historyQuery={historyQuery} setHistoryQuery={setHistoryQuery} historyFailedMatch={historyFailedMatch} onOpenTasksDialog={isFullscreenEnvEnabled() ? handleOpenTasksDialog : undefined} />}
+      {onboardingInput !== undefined || isFullscreenEnvEnabled() ? null : autoModeOptInDialog}
+      {onboardingInput === undefined && isFullscreenEnvEnabled() ?
     // position=absolute takes zero layout height so the spinner
     // doesn't shift when a notification appears/disappears. Yoga
     // anchors absolute children at the parent's content-box origin;

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -23,6 +23,7 @@ import {
   createInitialFirstRunOnboardingState,
   detectRunningLocalProviders,
   detailLinesForStep,
+  firstRunOnboardingInputPresentation,
   submitFirstRunOnboardingInput,
   wizardThemeToSetting,
 } from "./Onboarding.js";
@@ -167,6 +168,40 @@ describe("first-run onboarding wizard", () => {
     const result = await submitFirstRunOnboardingInput(state, "done", context);
     expect(result.completed).toBe(true);
     expect(result.state.completedStepIds).toContain("terminal-setup");
+  });
+
+  test("makes Enter advance every default step except credential persistence", async () => {
+    const context = {
+      config: defaultConfig(),
+      env: {},
+      checkLocalProviders: false,
+    };
+    let state = createInitialFirstRunOnboardingState(context);
+
+    expect(firstRunOnboardingInputPresentation(state)).toMatchObject({
+      placeholder: "Press Enter to start setup",
+      allowEmptySubmit: true,
+    });
+    state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+    expect(state.currentStepId).toBe("theme");
+
+    state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+    expect(state.currentStepId).toBe("provider");
+
+    state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+    expect(state.currentStepId).toBe("api-key");
+
+    state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+    expect(state.currentStepId).toBe("connection-test");
+
+    state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+    expect(state.currentStepId).toBe("security");
+
+    state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+    expect(state.currentStepId).toBe("terminal-setup");
+
+    const result = await submitFirstRunOnboardingInput(state, "", context);
+    expect(result.completed).toBe(true);
   });
 
   test("checks configured provider credentials and local endpoints", async () => {
@@ -317,7 +352,7 @@ describe("first-run onboarding wizard", () => {
         "1. openrouter (current)",
       );
       expect(detailLinesForStep({ ...state, currentStepId: "api-key" }, context)).toContain(
-        "Your Pro account can use hosted model access here. Type next to verify it.",
+        "Your Pro account can use hosted model access here. Press Enter to verify it.",
       );
     } finally {
       rmSync(agencHome, { recursive: true, force: true });
@@ -405,7 +440,7 @@ describe("first-run onboarding wizard", () => {
 
     expect(lines).toContain("Provider credential found via XAI_API_KEY.");
     expect(lines).toContain(
-      "XAI_API_KEY is present and verified. Type next to continue, or paste a replacement key.",
+      "XAI_API_KEY is present and verified. Press Enter to continue, or paste a replacement key.",
     );
     expect(lines.join("\n")).not.toContain("add it later");
   });
@@ -434,7 +469,7 @@ describe("first-run onboarding wizard", () => {
     );
     expect(lines.join("\n")).not.toContain("Sandbox: workspace-write");
     expect(lines).toContain(
-      "Type next to continue with --yolo, or restart without --yolo for prompts and sandboxing.",
+      "Press Enter to continue with --yolo, or restart without --yolo for prompts and sandboxing.",
     );
   });
 
@@ -464,7 +499,7 @@ describe("first-run onboarding wizard", () => {
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
     result = await submitFirstRunOnboardingInput(state, "later", context);
     expect(result.state.currentStepId).toBe("api-key");
-    expect(result.state.error).toContain("next or skip");
+    expect(result.state.error).toContain("Press Enter");
     expect(fetchImpl).toHaveBeenCalledOnce();
 
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
@@ -605,7 +640,7 @@ describe("first-run onboarding wizard", () => {
       expect(result.state.currentStepId).toBe("api-key");
       expect(result.state.pendingApiKeyApproval).toBeNull();
       expect(result.state.error).toContain("Provider rejected");
-      expect(result.state.error).toContain("next or skip");
+      expect(result.state.error).toContain("Press Enter");
       await expect(
         new LocalAuthBackend({ agencHome }).readByokKey("grok"),
       ).resolves.toBeUndefined();
@@ -638,7 +673,7 @@ describe("first-run onboarding wizard", () => {
       context,
     );
     expect(result.state.currentStepId).toBe("api-key");
-    expect(result.state.error).toContain("next or skip");
+    expect(result.state.error).toContain("Press Enter");
 
     result = await submitFirstRunOnboardingInput(
       result.state,
@@ -731,6 +766,14 @@ describe("first-run onboarding wizard", () => {
         provider: "grok",
         maskedTail: "...-key",
       });
+      expect(firstRunOnboardingInputPresentation(state)).toMatchObject({
+        placeholder: "Type yes to save this key, or no to discard it",
+        allowEmptySubmit: false,
+      });
+
+      state = (await submitFirstRunOnboardingInput(state, "", context)).state;
+      expect(state.currentStepId).toBe("api-key");
+      expect(state.error).toContain("yes");
 
       state = (await submitFirstRunOnboardingInput(state, "no", context)).state;
       expect(state.currentStepId).toBe("connection-test");
@@ -888,7 +931,7 @@ describe("first-run onboarding wizard", () => {
     }
   });
 
-  test("requires explicit commands for command-only steps", async () => {
+  test("rejects unrelated text on setup-action steps", async () => {
     const config = defaultConfig();
     const context = { config, env: {}, checkLocalProviders: false };
     let state = createInitialFirstRunOnboardingState(context);
@@ -899,7 +942,7 @@ describe("first-run onboarding wizard", () => {
       context,
     );
     expect(result.state.currentStepId).toBe("preflight");
-    expect(result.state.error).toContain("Type next");
+    expect(result.state.error).toContain("Press Enter");
 
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
@@ -912,7 +955,7 @@ describe("first-run onboarding wizard", () => {
       context,
     );
     expect(result.state.currentStepId).toBe("api-key");
-    expect(result.state.error).toContain("Type next");
+    expect(result.state.error).toContain("Press Enter");
 
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
     result = await submitFirstRunOnboardingInput(
@@ -933,7 +976,7 @@ describe("first-run onboarding wizard", () => {
     );
     expect(result.completed).toBe(false);
     expect(result.state.currentStepId).toBe("terminal-setup");
-    expect(result.state.error).toContain("Type done");
+    expect(result.state.error).toContain("Press Enter");
   });
 
   test("reports onboarding-only input for slash commands", async () => {

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -552,6 +552,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       mode,
       onModeChange,
       setToolPermissionContext,
+      onboardingInput,
     }: {
       input: string;
       onSubmit: (input: string, helpers: {
@@ -576,6 +577,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
       mode?: unknown;
       onModeChange?: unknown;
       setToolPermissionContext?: unknown;
+      onboardingInput?: unknown;
     }) => {
       providerProbe.promptSubmits.push(onSubmit);
       providerProbe.promptProps.push({
@@ -598,6 +600,7 @@ vi.mock("./PromptInput/PromptInput.js", async () => {
         mode,
         onModeChange,
         setToolPermissionContext,
+        onboardingInput,
       });
       return React.createElement("ink-text", null, `prompt:${input}`);
     },
@@ -2962,6 +2965,8 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
     const session = createSession();
     const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-app-"));
     const fetchSpy = mockOfflineOnboardingFetch();
+    const previousApiKeyStatus = apiKeyVerificationProbe.status;
+    apiKeyVerificationProbe.status = "missing";
     try {
       const output = await renderApp(
         <AgenCTuiApp
@@ -2980,7 +2985,17 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       expect(output).toContain("agenc");
       expect(output).toContain("Preflight");
       expect(output).not.toContain("messages:0");
+      expect(providerProbe.promptProps.at(-1)).toEqual(
+        expect.objectContaining({
+          apiKeyStatus: "valid",
+          onboardingInput: expect.objectContaining({
+            placeholder: "Press Enter to start setup",
+            allowEmptySubmit: true,
+          }),
+        }),
+      );
     } finally {
+      apiKeyVerificationProbe.status = previousApiKeyStatus;
       fetchSpy.mockRestore();
       rmSync(agencHome, { recursive: true, force: true });
     }
@@ -3623,16 +3638,19 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           // This marker already exists before the invalid submission, so the
           // next input can arrive before its error frame commits. That keeps
           // this regression sensitive to stale passive-effect state writes.
-          await submit("summarize this repository", "Typenexttocontinue.");
+          await submit(
+            "summarize this repository",
+            "PressEntertocontinue,ortypenext.",
+          );
           expect(output()).toContain("Preflight");
           expect(session.setPendingProviderSwitch).not.toHaveBeenCalled();
-          await submit("next", "Typeanumberorthemename.");
-          await submit("1", "Typeanumberorproviderslug.");
+          await submit("", "PressEntertokeepdark,ortypeanumberorthemename.");
+          await submit("1", "PressEntertokeepgrok,ortypeanumberorproviderslug.");
           await submit("2", "OPENAI_API_KEY");
-          await submit("skip", "runtheconnectioncheck.");
+          await submit("skip", "PressEntertoruntheconnectioncheck");
           await submit("test", "Sandboxworkspace-write");
-          await submit("next", "Typedonetofinishonboarding.");
-          await submit("done", "spinner:requesting:");
+          await submit("", "PressEntertofinishonboarding");
+          await submit("", "spinner:requesting:");
 
           expect(session.setPendingProviderSwitch).toHaveBeenLastCalledWith({
             provider: "openai",

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -988,6 +988,45 @@ describe('PromptInput render surface', () => {
     }
   })
 
+  test('renders onboarding as a distinct input surface and submits empty Enter', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({
+      input: '',
+      onSubmit,
+      onboardingInput: {
+        placeholder: 'Press Enter to start setup',
+        footerHint: 'Enter confirms the shown default',
+        allowEmptySubmit: true,
+      },
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      expect(baseProps.placeholder).toBe('Press Enter to start setup')
+      expect(baseProps.onHistoryUp).toBeUndefined()
+      expect(baseProps.onHistoryDown).toBeUndefined()
+
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('')
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        '',
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+          setCursorOffset: expect.any(Function),
+        }),
+        undefined,
+        expect.objectContaining({
+          mode: 'prompt',
+          vimRoutingState: expect.objectContaining({ enabled: false }),
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('submits normal prompt input through the leader path', async () => {
     const onSubmit = vi.fn(async () => {})
     const rendered = await renderPromptInput({ input: 'hello', onSubmit })


### PR DESCRIPTION
## Summary

- give first-run onboarding a distinct setup composer instead of normal chat chrome
- make Enter accept the displayed default on every ordinary wizard step
- keep API-key persistence behind an explicit yes/no decision
- replace hidden `next`/`done` instructions and cover the real PTY flow

## Verification

- `npm test` (16,484 passed, 20 skipped)
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 129-onboard-command`
- targeted onboarding/App/PromptInput tests (173 passed)