### PR TITLE
feat(runtime): add account sign-in to onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Documentation map: [`docs/INDEX.md`](docs/INDEX.md). Architecture:
   concurrency, cancellation, and evidence across interactive/background work,
   including heartbeat / cron / hooks. Design:
   [`docs/design/execution-admission-kernel.md`](docs/design/execution-admission-kernel.md).
-- **Guided onboarding** — `agenc onboard` plus acts: `identity`, `channel`,
-  `autonomy`, `recap` (personas, channels, budget/heartbeat/webhooks).
+- **Guided onboarding** — `agenc onboard` includes AgenC account sign-in,
+  X / xAI sign-in for Grok, provider API keys, and local providers without
+  requiring slash commands; follow-on acts: `identity`, `channel`, `autonomy`,
+  `recap` (personas, channels, budget/heartbeat/webhooks).
 - **Remote control** — pair iOS or Android with `agenc remote on|off|status`;
   co-drive chats, receive background completion/attention events, and settle
   permissions from the phone. Android can route an explicit, physically
@@ -81,8 +83,9 @@ Documentation map: [`docs/INDEX.md`](docs/INDEX.md). Architecture:
   openai, anthropic, ollama, lmstudio, openai-compatible, openrouter, groq,
   deepseek, gemini, mistral, nvidia-nim, minimax, github, amazon-bedrock, agenc.
   See [`docs/reference/providers.md`](docs/reference/providers.md).
-- **Grok OAuth** — sign in with X via `/grok-login` for subscription Grok access
-  without an API key ([`docs/grok-oauth.md`](docs/grok-oauth.md)).
+- **Grok OAuth** — sign in with X during onboarding or via `/grok-login` for
+  subscription Grok access without an API key
+  ([`docs/grok-oauth.md`](docs/grok-oauth.md)).
 - **Embedding SDK** — `@tetsuo-ai/agenc-sdk` for socket / subprocess embedding.
   See [`docs/sdk.md`](docs/sdk.md).
 - **Durable sessions** — append-only rollout logs + SQLite state; `--continue` /

--- a/docs/grok-oauth.md
+++ b/docs/grok-oauth.md
@@ -1,8 +1,10 @@
 # Sign in with X — Grok subscription access (no API key)
 
-`/grok-login` signs you into xAI with your X / xAI account and uses your
-**SuperGrok or X Premium subscription** for Grok inference — including
-`grok-4.5` — instead of a metered `XAI_API_KEY`.
+The first-run model-access step can sign you into xAI directly; choose
+**Sign in with X / xAI** without entering a slash command. The same flow is
+available later through `/grok-login`. It uses an eligible **SuperGrok or
+X Premium subscription** for Grok inference — including `grok-4.5` — instead
+of a metered `XAI_API_KEY`.
 
 ## Usage
 

--- a/docs/managed-openrouter.md
+++ b/docs/managed-openrouter.md
@@ -38,8 +38,9 @@ enabled = false
 
 ## Runtime flow
 
-1. `agenc login` (or `/login`) stores the remote auth token under
-   `AGENC_HOME` (`auth.json` / session state).
+1. The first-run **Sign in or create an AgenC account** choice stores the
+   remote auth token under `AGENC_HOME` (`auth.json` / session state). The same
+   flow remains available later through `agenc login` or `/login`.
 2. With `auth.managedKeys.enabled` (default true), entitled sessions can
    request a short-lived managed OpenRouter credential from the auth backend.
 3. Free-tier accounts may use the **hosted free OpenRouter routes** only

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -58,8 +58,12 @@ in `runtime/src/onboarding/Onboarding.tsx` (`FIRST_RUN_STEP_ORDER`):
 2. **theme** — dark / light / system
 3. **provider** — built-in providers, local runtimes, managed OpenRouter when
    logged in
-4. **api-key** — live verification for key-required providers (skipped for
-   local / managed paths when appropriate)
+4. **model access** — choose directly in the wizard:
+   - sign in or create an AgenC account for hosted models (free accounts get
+     the free-model catalog)
+   - sign in with X / xAI for Grok through an eligible subscription
+   - verify and save a provider API key
+   - configure access later
 5. **connection-test** — real provider check
 6. **security** — fail-closed defaults
 7. **terminal-setup** — shell/terminal integration
@@ -70,11 +74,14 @@ Then you are in chat. Flags:
 - `--reset` — show the wizard again next interactive start (does not wipe
   keys, persona, or gateway config)
 
-Credentials: BYOK env keys, pasted keys, local Ollama/LM Studio, or
-`agenc login` for remote auth + managed OpenRouter (default
-`auth.managedKeys.enabled = true`). Free accounts can use hosted `:free`
-routes; paid default model is `x-ai/grok-4.5`. See
-[managed-openrouter.md](managed-openrouter.md).
+No slash command is required during first run. The model-access step launches
+either account flow itself and displays the browser URL/device code in the
+wizard. BYOK env keys, directly pasted keys, and local Ollama/LM Studio remain
+available. AgenC account access uses managed OpenRouter (default
+`auth.managedKeys.enabled = true`): free accounts receive hosted `:free`
+routes, while the paid default model is `x-ai/grok-4.5`. See
+[managed-openrouter.md](managed-openrouter.md) and
+[grok-oauth.md](grok-oauth.md).
 
 ## Act 2a — identity
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,8 @@ First-run wizard order:
 1. **preflight**
 2. **theme**
 3. **provider**
-4. **api-key** (live-verified when required)
+4. **model access** — AgenC account, X / xAI sign-in, provider API key, or
+   configure later
 5. **connection-test**
 6. **security**
 7. **terminal-setup**
@@ -45,9 +46,12 @@ agenc onboard --status
 agenc onboard --reset    # show the wizard again on next interactive start
 ```
 
-Optional: `agenc login` for remote auth + managed models
-([managed-openrouter.md](managed-openrouter.md)). BYOK env keys always win
-over managed vending.
+The wizard launches both account flows directly; no slash command is needed.
+An AgenC account provides hosted models (including the free-model catalog for
+free accounts). X / xAI sign-in uses Grok through an eligible subscription.
+Provider BYOK keys are live-verified before the wizard asks permission to save
+them. Details: [managed-openrouter.md](managed-openrouter.md) and
+[grok-oauth.md](grok-oauth.md).
 
 ## 3. Check your posture
 

--- a/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
@@ -30,16 +30,40 @@ export default async function (session) {
   // src/onboarding/Onboarding.tsx submitFirstRunOnboardingInput.)
   await session.waitFor(/Press Enter to continue/, { timeout: 60_000 });
 
-  const wizardInputs = [
+  const setupInputs = [
     "", // preflight: Enter → theme
     "1", // theme: dark → provider
-    "openai-compatible", // provider (mock server) → api-key
-    "", // api-key: Enter on keyless local provider → connection-test
+    "openai-compatible", // provider (mock server) → model access
+  ];
+  for (const input of setupInputs) {
+    await session.submit(input);
+    await session.waitForIdle({ timeout: 60_000 });
+  }
+
+  const accessFrame = session.latestFrame;
+  assert.match(
+    accessFrame,
+    /Sign in or create an AgenC account/u,
+    "model access must offer AgenC account sign-in/signup",
+  );
+  assert.match(
+    accessFrame,
+    /Sign in with X \/ xAI/u,
+    "model access must offer X / xAI sign-in",
+  );
+  assert.match(
+    accessFrame,
+    /Configure later/u,
+    "model access must offer a credential-free continuation",
+  );
+
+  const remainingWizardInputs = [
+    "", // model access: Enter configures later → connection-test
     "", // connection-test: Enter runs the mock-server check → security
     "", // security: Enter keeps defaults → terminal-setup
     "", // terminal-setup: Enter finishes onboarding
   ];
-  for (const input of wizardInputs) {
+  for (const input of remainingWizardInputs) {
     await session.submit(input);
     // Bytes-quiet is the only repaint-agnostic step barrier; a rejected
     // input stalls the wizard and the post-wizard asserts below fail loudly.

--- a/runtime/src/onboarding/Onboarding.tsx
+++ b/runtime/src/onboarding/Onboarding.tsx
@@ -12,7 +12,15 @@ import {
   resolveProviderSettings,
 } from "../config/resolve-provider.js";
 import type { AgenCConfig } from "../config/schema.js";
-import { resolveAuthManagedKeysEnabled } from "../auth/selection.js";
+import {
+  createAuthBackend,
+  resolveAuthManagedKeysEnabled,
+} from "../auth/selection.js";
+import type {
+  AuthIdentity,
+  AuthSubscriptionTier,
+} from "../auth/backend.js";
+import type { RemoteAuthDeviceCodePrompt } from "../auth/backends/remote.js";
 import {
   hasEntitledRemoteAuthSessionSync,
   hasRemoteAuthSessionSync,
@@ -59,7 +67,12 @@ import {
   verifyApiKey,
   type VerificationStatus,
 } from "./useApiKeyVerification.js";
-import { subscriptionManagedDefaultModel } from "../commands/subscription-managed-models.js";
+import {
+  isFreeSubscriptionManagedModel,
+  SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+  subscriptionManagedDefaultModel,
+  subscriptionManagedDefaultModelForTier,
+} from "../commands/subscription-managed-models.js";
 
 export type FirstRunOnboardingStepId =
   | "preflight"
@@ -115,6 +128,8 @@ export interface FirstRunOnboardingState {
   readonly connection: ProviderConnectionCheck | null;
   readonly pastedContents: readonly PastedContent[];
   readonly pendingApiKeyApproval: PendingApiKeyApproval | null;
+  readonly modelAccessInput: "menu" | "api-key";
+  readonly authPrompt: OnboardingAuthPrompt | null;
   readonly error: string | null;
   readonly isCheckingConnection: boolean;
   /** Local runtimes found listening (O-1): annotated in the provider step. */
@@ -131,6 +146,21 @@ export interface FirstRunByokAuthBackend {
 export type GrokOauthLoginResult =
   | { readonly ok: true; readonly accountLabel: string }
   | { readonly ok: false; readonly message: string };
+
+export type AgenCAccountLoginResult =
+  | {
+      readonly ok: true;
+      readonly accountLabel: string;
+      readonly subscriptionTier: AuthSubscriptionTier;
+    }
+  | { readonly ok: false; readonly message: string };
+
+export interface OnboardingAuthPrompt {
+  readonly heading: string;
+  readonly detail: string;
+  readonly url: string;
+  readonly userCode?: string;
+}
 
 export interface FirstRunOnboardingContext {
   readonly agencHome?: string;
@@ -149,26 +179,72 @@ export interface FirstRunOnboardingContext {
    * browser; the default lazily imports the real flow.
    */
   readonly runGrokOauthLogin?: () => Promise<GrokOauthLoginResult>;
+  /**
+   * Runs AgenC account sign-in (the same remote auth backend as /login).
+   * Injectable so wizard tests never open a browser.
+   */
+  readonly runAgenCAccountLogin?: () => Promise<AgenCAccountLoginResult>;
+  /** Reports the URL/code while a browser or device sign-in is pending. */
+  readonly onAuthPrompt?: (prompt: OnboardingAuthPrompt) => void;
 }
 
 /**
- * Default grok OAuth sign-in used by the api-key step's `login` input: the
- * browser PKCE loopback flow with tokens persisted exactly like /grok-login.
- * Lazy imports keep the wizard module light for the non-grok path.
+ * Default Grok OAuth sign-in used by the model-access step. Browser PKCE is
+ * primary and device code is the headless fallback, matching /grok-login.
+ * Lazy imports keep the wizard module light for the non-Grok path.
  */
-async function defaultRunGrokOauthLogin(): Promise<GrokOauthLoginResult> {
+async function defaultRunGrokOauthLogin(
+  context: FirstRunOnboardingContext,
+): Promise<GrokOauthLoginResult> {
   try {
-    const [{ runXaiBrowserLogin }, { openUrlInBrowser }, creds] =
+    const [oauth, { openUrlInBrowser }, creds] =
       await Promise.all([
         import("../services/xai/oauth.js"),
         import("../commands/auth.js"),
         import("../utils/xaiOauthCredentials.js"),
       ]);
-    const login = await runXaiBrowserLogin({
-      onAuthorizeUrl: (url) => {
-        void openUrlInBrowser(url);
-      },
-    });
+    let login;
+    try {
+      login = await oauth.runXaiBrowserLogin({
+        onAuthorizeUrl: async (url) => {
+          context.onAuthPrompt?.({
+            heading: "Sign in with X / xAI",
+            detail:
+              "Finish the xAI consent flow in your browser. The page may say Grok Build.",
+            url,
+          });
+          await openUrlInBrowser(url).catch(() => {
+            // The URL remains visible in the onboarding card.
+          });
+        },
+      });
+    } catch (error) {
+      if (
+        !(error instanceof oauth.XaiOauthError) ||
+        error.code !== "callback_failed"
+      ) {
+        throw error;
+      }
+      login = await oauth.runXaiDeviceLogin({
+        onUserCode: async ({
+          userCode,
+          verificationUri,
+          verificationUriComplete,
+        }) => {
+          const url = verificationUriComplete ?? verificationUri;
+          context.onAuthPrompt?.({
+            heading: "Sign in with X / xAI",
+            detail:
+              "Finish the xAI device sign-in in your browser. The page may say Grok Build.",
+            url,
+            userCode,
+          });
+          await openUrlInBrowser(url).catch(() => {
+            // The URL and code remain visible in the onboarding card.
+          });
+        },
+      });
+    }
     const blob = creds.xaiOauthTokensToBlob(login.tokens, {
       tokenEndpoint: login.tokenEndpoint,
     });
@@ -187,7 +263,72 @@ async function defaultRunGrokOauthLogin(): Promise<GrokOauthLoginResult> {
     const detail = error instanceof Error ? error.message : String(error);
     return {
       ok: false,
-      message: `Browser sign-in did not complete (${detail}). Paste XAI_API_KEY instead, or run /grok-login device after setup.`,
+      message:
+        `X / xAI sign-in did not complete (${detail}). ` +
+        "Try again, use an API key, or configure model access later.",
+    };
+  }
+}
+
+function authIdentityLabel(identity: AuthIdentity | undefined): string {
+  return (
+    identity?.displayName?.trim() ||
+    identity?.email?.trim() ||
+    identity?.accountId?.trim() ||
+    "AgenC account"
+  );
+}
+
+function reportAgenCDeviceCode(
+  context: FirstRunOnboardingContext,
+  prompt: RemoteAuthDeviceCodePrompt,
+): void {
+  if (prompt.verificationUri === undefined) return;
+  context.onAuthPrompt?.({
+    heading: "Sign in or create an AgenC account",
+    detail:
+      "Finish the browser sign-in. New users can create their account in the same flow.",
+    url: prompt.verificationUri,
+    ...(prompt.userCode !== undefined ? { userCode: prompt.userCode } : {}),
+  });
+}
+
+async function defaultRunAgenCAccountLogin(
+  context: FirstRunOnboardingContext,
+): Promise<AgenCAccountLoginResult> {
+  try {
+    const { openUrlInBrowser } = await import("../commands/auth.js");
+    const backend = createAuthBackend(context.config, {
+      ...(context.agencHome !== undefined
+        ? { agencHome: context.agencHome }
+        : {}),
+      env: context.env ?? process.env,
+      remote: {
+        onDeviceCode: async (prompt) => {
+          reportAgenCDeviceCode(context, prompt);
+          if (prompt.verificationUri === undefined) return;
+          await openUrlInBrowser(prompt.verificationUri).catch(() => {
+            // The URL and optional code remain visible in the onboarding card.
+          });
+        },
+      },
+    });
+    const login = await backend.login({ sessionId: "tui" });
+    const subscriptionTier = await backend.getSubscriptionTier({
+      sessionId: "tui",
+    });
+    return {
+      ok: true,
+      accountLabel: authIdentityLabel(login.identity),
+      subscriptionTier,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      message:
+        `AgenC account sign-in did not complete (${detail}). ` +
+        "Try again, use another access method, or configure model access later.",
     };
   }
 }
@@ -228,7 +369,7 @@ const STEP_TITLES: Readonly<Record<FirstRunOnboardingStepId, string>> =
     theme: "Theme",
     provider: "Provider",
     "connection-test": "Connection check",
-    "api-key": "API key",
+    "api-key": "Model access",
     security: "Security",
     "terminal-setup": "Terminal setup",
   });
@@ -285,9 +426,13 @@ function providerDefaultModel(
   if (
     MANAGED_KEY_PROVIDERS.has(provider) &&
     resolveAuthManagedKeysEnabled(config) &&
-    hasEntitledRemoteAuthSessionSync(env)
+    hasRemoteAuthSessionSync(env)
   ) {
     return (
+      subscriptionManagedDefaultModelForTier(
+        provider,
+        remoteAuthSessionSubscriptionTierSync(env),
+      ) ??
       subscriptionManagedDefaultModel(provider) ??
       BUILT_IN_PROVIDER_DEFAULT_MODELS[provider]
     );
@@ -306,7 +451,7 @@ function initialProvider(
   });
   if (envOrShortcut !== undefined) return envOrShortcut;
   const configured = normalizeBuiltInProviderSlug(config.model_provider);
-  if (resolveAuthManagedKeysEnabled(config) && hasEntitledRemoteAuthSessionSync(env)) {
+  if (resolveAuthManagedKeysEnabled(config) && hasRemoteAuthSessionSync(env)) {
     return configured === undefined || configured === "grok"
       ? "openrouter"
       : configured;
@@ -333,6 +478,8 @@ export function createInitialFirstRunOnboardingState(
     connection: null,
     pastedContents: [],
     pendingApiKeyApproval: null,
+    modelAccessInput: "menu",
+    authPrompt: null,
     error: null,
     isCheckingConnection: false,
     detectedLocalProviders: [],
@@ -370,12 +517,12 @@ export async function detectRunningLocalProviders(
 function providerChoices(
   context?: Pick<FirstRunOnboardingContext, "config" | "env">,
 ): readonly BuiltInProviderSlug[] {
-  const proHostedReady =
+  const hostedReady =
     context !== undefined &&
     resolveAuthManagedKeysEnabled(context.config) &&
-    hasEntitledRemoteAuthSessionSync(context.env);
+    hasRemoteAuthSessionSync(context.env);
   const preferredOrder: readonly BuiltInProviderSlug[] = Object.freeze(
-    proHostedReady
+    hostedReady
       ? [
           "openrouter",
           "grok",
@@ -500,7 +647,42 @@ function lowerCommand(raw: string): string {
 }
 
 function isSkipApiKeyCommand(command: string): boolean {
-  return command === "" || command === "next" || command === "skip";
+  return (
+    command === "" ||
+    command === "4" ||
+    command === "later" ||
+    command === "next" ||
+    command === "skip"
+  );
+}
+
+function isAgenCAccountLoginCommand(command: string): boolean {
+  return (
+    command === "1" ||
+    command === "account" ||
+    command === "agenc" ||
+    command === "agenc-login" ||
+    command === "login"
+  );
+}
+
+function isGrokOauthLoginCommand(command: string): boolean {
+  return (
+    command === "2" ||
+    command === "grok-login" ||
+    command === "x" ||
+    command === "xai" ||
+    command === "xai-login"
+  );
+}
+
+function isApiKeyEntryCommand(command: string): boolean {
+  return (
+    command === "3" ||
+    command === "api" ||
+    command === "api-key" ||
+    command === "key"
+  );
 }
 
 function apiKeySkipError(
@@ -576,6 +758,20 @@ function verifiedApiKeyConnection(
     ok: true,
     detail: "Provider API key verified.",
     keyEnvVar: BUILT_IN_PROVIDER_API_KEY_ENVS[provider],
+  };
+}
+
+function authenticatedConnection(
+  provider: BuiltInProviderSlug,
+  model: string,
+  detail: string,
+): ProviderConnectionCheck {
+  return {
+    provider,
+    model,
+    status: "ready",
+    ok: true,
+    detail,
   };
 }
 
@@ -795,9 +991,22 @@ export async function checkOnboardingProviderConnection(
     resolveAuthManagedKeysEnabled(context.config) &&
     hasRemoteAuthSessionSync(context.env)
   ) {
+    const tier =
+      remoteAuthSessionSubscriptionTierSync(context.env) ?? "unknown";
+    if (
+      tier === "free" &&
+      isFreeSubscriptionManagedModel(provider, model)
+    ) {
+      return {
+        provider,
+        model,
+        status: "ready",
+        ok: true,
+        detail: "AgenC account is signed in. Free hosted model access is ready.",
+        baseURL,
+      };
+    }
     if (!hasEntitledRemoteAuthSessionSync(context.env)) {
-      const tier =
-        remoteAuthSessionSubscriptionTierSync(context.env) ?? "unknown";
       const keyLabel = keyEnvVar ?? "a BYOK API key";
       return {
         provider,
@@ -940,6 +1149,8 @@ export async function submitFirstRunOnboardingInput(
             connection: null,
             pastedContents: [],
             pendingApiKeyApproval: null,
+            modelAccessInput: "menu",
+            authPrompt: null,
           },
           "provider",
           "api-key",
@@ -1045,31 +1256,155 @@ export async function submitFirstRunOnboardingInput(
       }
       {
         const command = lowerCommand(raw);
-        // Grok: `login` runs the X / xAI OAuth sign-in instead of a pasted
-        // key. On success the step advances to the connection test, which
-        // verifies the stored OAuth bearer through the same provider
-        // resolution the session will use (OAuth always wins over env BYOK).
-        if (
-          state.selectedProvider === "grok" &&
-          (command === "login" ||
-            command === "grok-login" ||
-            command === "xai-login")
-        ) {
+        if (isAgenCAccountLoginCommand(command)) {
           const runLogin =
-            context.runGrokOauthLogin ?? defaultRunGrokOauthLogin;
+            context.runAgenCAccountLogin ??
+            (() => defaultRunAgenCAccountLogin(context));
           const result = await runLogin();
           if (!result.ok) {
             return {
-              state: { ...state, error: result.message },
+              state: {
+                ...state,
+                authPrompt: null,
+                error: result.message,
+              },
+              completed: false,
+            };
+          }
+          if (!resolveAuthManagedKeysEnabled(context.config)) {
+            return {
+              state: {
+                ...state,
+                authPrompt: null,
+                error:
+                  `Signed in as ${result.accountLabel}, but hosted model access ` +
+                  "is disabled in this AgenC configuration. Choose an API key " +
+                  "or configure model access later.",
+              },
+              completed: false,
+            };
+          }
+          const hostedProvider = normalizeBuiltInProviderSlug(
+            SUBSCRIPTION_MANAGED_DEFAULT_PROVIDER,
+          );
+          const hostedModel =
+            hostedProvider === undefined
+              ? undefined
+              : subscriptionManagedDefaultModelForTier(
+                  hostedProvider,
+                  result.subscriptionTier,
+                );
+          if (hostedProvider === undefined || hostedModel === undefined) {
+            return {
+              state: {
+                ...state,
+                authPrompt: null,
+                error:
+                  `Signed in as ${result.accountLabel}, but no hosted model is ` +
+                  `available for the ${result.subscriptionTier} plan. ` +
+                  "Choose another access method or configure model access later.",
+              },
+              completed: false,
+            };
+          }
+          const accessDetail =
+            result.subscriptionTier === "free"
+              ? `Signed in to AgenC as ${result.accountLabel}. Free hosted model access is ready.`
+              : `Signed in to AgenC as ${result.accountLabel}. Hosted model access for the ${result.subscriptionTier} plan is ready.`;
+          return {
+            state: withCompletedSteps(
+              {
+                ...state,
+                selectedProvider: hostedProvider,
+                selectedModel: hostedModel,
+                connection: authenticatedConnection(
+                  hostedProvider,
+                  hostedModel,
+                  accessDetail,
+                ),
+                modelAccessInput: "menu",
+                authPrompt: null,
+              },
+              ["api-key", "connection-test"],
+              "security",
+            ),
+            completed: false,
+          };
+        }
+        if (isGrokOauthLoginCommand(command)) {
+          const runLogin =
+            context.runGrokOauthLogin ??
+            (() => defaultRunGrokOauthLogin(context));
+          const result = await runLogin();
+          if (!result.ok) {
+            return {
+              state: {
+                ...state,
+                authPrompt: null,
+                error: result.message,
+              },
+              completed: false,
+            };
+          }
+          const provider: BuiltInProviderSlug = "grok";
+          const model = providerDefaultModel(
+            provider,
+            context.config,
+            context.env,
+          );
+          return {
+            state: withCompletedSteps(
+              {
+                ...state,
+                selectedProvider: provider,
+                selectedModel: model,
+                connection: authenticatedConnection(
+                  provider,
+                  model,
+                  `Signed in to X / xAI as ${result.accountLabel}. Grok subscription access is ready.`,
+                ),
+                modelAccessInput: "menu",
+                authPrompt: null,
+              },
+              ["api-key", "connection-test"],
+              "security",
+            ),
+            completed: false,
+          };
+        }
+        if (isApiKeyEntryCommand(command)) {
+          if (!KEY_REQUIRED_PROVIDERS.has(state.selectedProvider)) {
+            return {
+              state: withCompletedStep(
+                {
+                  ...state,
+                  modelAccessInput: "menu",
+                  authPrompt: null,
+                },
+                "api-key",
+                "connection-test",
+              ),
               completed: false,
             };
           }
           return {
-            state: withCompletedStep(
-              { ...state, error: null },
-              "api-key",
-              "connection-test",
-            ),
+            state: {
+              ...state,
+              modelAccessInput: "api-key",
+              authPrompt: null,
+              error: null,
+            },
+            completed: false,
+          };
+        }
+        if (command === "back" && state.modelAccessInput === "api-key") {
+          return {
+            state: {
+              ...state,
+              modelAccessInput: "menu",
+              authPrompt: null,
+              error: null,
+            },
             completed: false,
           };
         }
@@ -1082,7 +1417,15 @@ export async function submitFirstRunOnboardingInput(
             };
           }
           return {
-            state: withCompletedStep(state, "api-key", "connection-test"),
+            state: withCompletedStep(
+              {
+                ...state,
+                modelAccessInput: "menu",
+                authPrompt: null,
+              },
+              "api-key",
+              "connection-test",
+            ),
             completed: false,
           };
         }
@@ -1238,15 +1581,30 @@ export function useFirstRunOnboardingController(
       // render overwrite a newer transition when input arrives quickly.
       const checkingState = {
         ...stateRef.current,
+        authPrompt: null,
+        error: null,
         isCheckingConnection: true,
       };
       stateRef.current = checkingState;
       setState(checkingState);
       try {
+        const submitContext: FirstRunOnboardingContext = {
+          ...options,
+          onAuthPrompt: (prompt) => {
+            const promptState = {
+              ...stateRef.current,
+              authPrompt: prompt,
+              error: null,
+            };
+            stateRef.current = promptState;
+            setState(promptState);
+            options.onAuthPrompt?.(prompt);
+          },
+        };
         const result = await submitFirstRunOnboardingInput(
           checkingState,
           input,
-          options,
+          submitContext,
         );
         const nextState = {
           ...result.state,
@@ -1315,16 +1673,8 @@ function apiKeyInstructionForConnection(
 
 function apiKeyInstructionForProvider(
   provider: BuiltInProviderSlug,
-  context: FirstRunOnboardingContext,
 ): string {
   const keyEnvVar = BUILT_IN_PROVIDER_API_KEY_ENVS[provider];
-  if (
-    MANAGED_KEY_PROVIDERS.has(provider) &&
-    resolveAuthManagedKeysEnabled(context.config) &&
-    hasEntitledRemoteAuthSessionSync(context.env)
-  ) {
-    return "Your Pro account can use hosted model access here. Press Enter to verify it.";
-  }
   if (!KEY_REQUIRED_PROVIDERS.has(provider)) {
     return "This provider can continue without a BYOK API key. Press Enter to continue.";
   }
@@ -1390,12 +1740,20 @@ export function firstRunOnboardingInputPresentation(
           allowEmptySubmit: false,
         };
       }
+      if (state.modelAccessInput === "api-key") {
+        const keyEnvVar =
+          BUILT_IN_PROVIDER_API_KEY_ENVS[state.selectedProvider] ?? "API key";
+        return {
+          placeholder: `Paste ${keyEnvVar}, type back, or press Enter to configure later`,
+          footerHint:
+            "Keys are verified before an explicit save confirmation · /exit leaves setup",
+          allowEmptySubmit: true,
+        };
+      }
       return {
-        placeholder:
-          state.selectedProvider === "grok"
-            ? "Paste XAI_API_KEY, type login, or press Enter to add it later"
-            : "Paste an API key, or press Enter to add it later",
-        footerHint: standardFooter,
+        placeholder: "Choose 1–4, or paste a provider API key directly",
+        footerHint:
+          "No slash commands needed · Enter chooses Configure later · /exit leaves setup",
         allowEmptySubmit: true,
       };
     case "connection-test":
@@ -1484,35 +1842,60 @@ export function detailLinesForStep(
       if (state.pendingApiKeyApproval !== null) {
         return [];
       }
-      // Grok has a keyless path: the X / xAI OAuth sign-in behind
-      // /grok-login (subscription access; always wins over env BYOK).
-      // Offer it here so first-run users are not funneled into creating a
-      // console.x.ai key they may not need.
-      const grokLoginOffer =
-        state.selectedProvider === "grok"
-          ? [
-              "Or type login to sign in with your X / xAI account — no API key needed.",
-            ]
-          : [];
+      if (state.authPrompt !== null) {
+        return [
+          state.authPrompt.heading,
+          state.authPrompt.detail,
+          ...(state.authPrompt.userCode !== undefined
+            ? [`Code: ${state.authPrompt.userCode}`]
+            : []),
+          `URL: ${state.authPrompt.url}`,
+          "Finish sign-in in your browser; AgenC will continue automatically.",
+        ];
+      }
+      if (state.modelAccessInput === "menu") {
+        const keyEnvVar =
+          BUILT_IN_PROVIDER_API_KEY_ENVS[state.selectedProvider];
+        const billingProvider =
+          state.selectedProvider === "grok" ? "xAI" : state.selectedProvider;
+        const providerAccess =
+          KEY_REQUIRED_PROVIDERS.has(state.selectedProvider)
+            ? `Use ${keyEnvVar ?? `a ${state.selectedProvider} API key`} — requests are billed by ${billingProvider}.`
+            : `Use ${state.selectedProvider} directly — no account sign-in or provider API key required.`;
+        return [
+          `Provider: ${state.selectedProvider}`,
+          `Model: ${state.selectedModel}`,
+          "1. Sign in or create an AgenC account — use hosted models; free accounts get the free-model catalog.",
+          "2. Sign in with X / xAI — use Grok through an eligible X or xAI subscription.",
+          `3. ${providerAccess}`,
+          "4. Configure later — continue without signing in or saving a key.",
+          "Choose a number. You can also paste a provider API key directly.",
+        ];
+      }
       const connection = state.connection;
       if (connection === null) {
         return [
           `Provider: ${state.selectedProvider}`,
-          apiKeyInstructionForProvider(state.selectedProvider, context),
-          ...grokLoginOffer,
+          apiKeyInstructionForProvider(state.selectedProvider),
+          "Type back to choose a different access method.",
         ];
       }
       return [
         connection.detail,
         apiKeyInstructionForConnection(connection),
-        ...grokLoginOffer,
+        "Type back to choose a different access method.",
         ...(state.pastedContents.length > 0
           ? [`Captured ${state.pastedContents.length} large paste privately.`]
           : []),
       ];
     }
     case "security":
-      return securityLinesForContext(context);
+      return [
+        ...(state.connection?.ok === true
+          ? [`Model access: ${state.connection.detail}`]
+          : []),
+        ...securityLinesForContext(context),
+      ];
     case "terminal-setup":
       return [
         `Terminal: ${context.terminalName ?? "terminal"}`,
@@ -1549,7 +1932,11 @@ function classifyOnboardingDetail(line: string): OnboardingDetailEntry {
       current: /\(current\)\s*$/u.test(line),
     };
   }
-  if (/^(Press Enter|Type |Or type |Tip:|Onboarding input only)/u.test(line)) {
+  if (
+    /^(Choose |Finish |Onboarding input only|Or type |Press Enter|Tip:|Type )/u.test(
+      line,
+    )
+  ) {
     return { kind: "hint", text: line };
   }
   const kv = /^([A-Za-z][A-Za-z ]+):\s+(.*)$/u.exec(line);

--- a/runtime/tests/onboarding/onboarding.test.tsx
+++ b/runtime/tests/onboarding/onboarding.test.tsx
@@ -351,8 +351,13 @@ describe("first-run onboarding wizard", () => {
       expect(detailLinesForStep({ ...state, currentStepId: "provider" }, context)[0]).toBe(
         "1. openrouter (current)",
       );
-      expect(detailLinesForStep({ ...state, currentStepId: "api-key" }, context)).toContain(
-        "Your Pro account can use hosted model access here. Press Enter to verify it.",
+      expect(
+        detailLinesForStep(
+          { ...state, currentStepId: "api-key" },
+          context,
+        ).join("\n"),
+      ).toContain(
+        "Sign in or create an AgenC account — use hosted models",
       );
     } finally {
       rmSync(agencHome, { recursive: true, force: true });
@@ -416,6 +421,43 @@ describe("first-run onboarding wizard", () => {
     }
   });
 
+  test("recognizes a signed-in free account's hosted free model as ready", async () => {
+    const agencHome = mkdtempSync(join(tmpdir(), "agenc-onboarding-free-ready-"));
+    try {
+      writeFileSync(
+        join(agencHome, "auth.json"),
+        JSON.stringify({
+          version: 1,
+          provider: "remote",
+          token: "remote-session-token",
+          subscriptionTier: "free",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+      );
+      const context = {
+        config: defaultConfig(),
+        env: { AGENC_HOME: agencHome },
+      };
+      const state = createInitialFirstRunOnboardingState(context);
+
+      expect(state.selectedProvider).toBe("openrouter");
+      expect(state.selectedModel).toMatch(/:free$/);
+      await expect(
+        checkOnboardingProviderConnection(
+          context,
+          state.selectedProvider,
+          state.selectedModel,
+        ),
+      ).resolves.toMatchObject({
+        ok: true,
+        status: "ready",
+        detail: "AgenC account is signed in. Free hosted model access is ready.",
+      });
+    } finally {
+      rmSync(agencHome, { recursive: true, force: true });
+    }
+  });
+
   test("describes verified provider credentials without asking users to add them later", () => {
     const config = defaultConfig();
     const context = {
@@ -426,6 +468,7 @@ describe("first-run onboarding wizard", () => {
     const state = {
       ...createInitialFirstRunOnboardingState(context),
       currentStepId: "api-key" as const,
+      modelAccessInput: "api-key" as const,
       connection: {
         provider: "grok",
         model: "grok-4.3",
@@ -497,7 +540,11 @@ describe("first-run onboarding wizard", () => {
     expect(result.state.error).toContain("provider");
 
     state = (await submitFirstRunOnboardingInput(state, "1", context)).state;
-    result = await submitFirstRunOnboardingInput(state, "later", context);
+    result = await submitFirstRunOnboardingInput(
+      state,
+      "not-a-real-key",
+      context,
+    );
     expect(result.state.currentStepId).toBe("api-key");
     expect(result.state.error).toContain("Press Enter");
     expect(fetchImpl).toHaveBeenCalledOnce();
@@ -664,7 +711,7 @@ describe("first-run onboarding wizard", () => {
     let state = await advanceToApiKey(context);
 
     expect(detailLinesForStep(state, context).join("\n")).toContain(
-      "Paste XAI_API_KEY",
+      "Use XAI_API_KEY",
     );
 
     let result = await submitFirstRunOnboardingInput(
@@ -1180,7 +1227,7 @@ describe("theme step terminal-background awareness", () => {
   });
 });
 
-describe("grok OAuth sign-in from the api-key step", () => {
+describe("account sign-in from the model-access step", () => {
   async function advanceToGrokApiKey(context: Parameters<typeof createInitialFirstRunOnboardingState>[0]) {
     let state = createInitialFirstRunOnboardingState(context);
     state = (await submitFirstRunOnboardingInput(state, "next", context)).state;
@@ -1191,25 +1238,72 @@ describe("grok OAuth sign-in from the api-key step", () => {
     return state;
   }
 
-  test("offers the keyless X / xAI sign-in for grok only", async () => {
+  test("explains AgenC, X / xAI, API-key, and configure-later access without slash commands", async () => {
     const config = defaultConfig();
     const context = { config, env: {}, checkLocalProviders: false };
-    const grokState = await advanceToGrokApiKey(context);
-    expect(detailLinesForStep(grokState, context).join("\n")).toContain(
-      "Or type login to sign in with your X / xAI account",
-    );
+    const state = await advanceToGrokApiKey(context);
+    const details = detailLinesForStep(state, context).join("\n");
 
-    const openaiState = {
-      ...grokState,
-      selectedProvider: "openai" as const,
-      connection: null,
-    };
-    expect(detailLinesForStep(openaiState, context).join("\n")).not.toContain(
-      "Or type login",
+    expect(details).toContain(
+      "Sign in or create an AgenC account — use hosted models; free accounts get the free-model catalog.",
+    );
+    expect(details).toContain(
+      "Sign in with X / xAI — use Grok through an eligible X or xAI subscription.",
+    );
+    expect(details).toContain(
+      "Use XAI_API_KEY — requests are billed by xAI.",
+    );
+    expect(details).toContain(
+      "Configure later — continue without signing in or saving a key.",
+    );
+    expect(details).not.toContain("/login");
+    expect(firstRunOnboardingInputPresentation(state).placeholder).toBe(
+      "Choose 1–4, or paste a provider API key directly",
     );
   });
 
-  test("login runs the injected OAuth flow and advances to the connection test", async () => {
+  test("choice 1 signs in or creates an AgenC account and selects its free hosted route", async () => {
+    const config = defaultConfig();
+    const runAgenCAccountLogin = vi
+      .fn<
+        () => Promise<{
+          ok: true;
+          accountLabel: string;
+          subscriptionTier: "free";
+        }>
+      >()
+      .mockResolvedValue({
+        ok: true,
+        accountLabel: "new-user@example.com",
+        subscriptionTier: "free",
+      });
+    const context = {
+      config,
+      env: {},
+      checkLocalProviders: false,
+      runAgenCAccountLogin,
+    };
+    const state = await advanceToGrokApiKey(context);
+
+    const result = await submitFirstRunOnboardingInput(state, "1", context);
+
+    expect(runAgenCAccountLogin).toHaveBeenCalledTimes(1);
+    expect(result.state.currentStepId).toBe("security");
+    expect(result.state.selectedProvider).toBe("openrouter");
+    expect(result.state.selectedModel).toMatch(/:free$/);
+    expect(result.state.connection).toMatchObject({
+      ok: true,
+      status: "ready",
+    });
+    expect(result.state.connection?.detail).toContain(
+      "Free hosted model access is ready.",
+    );
+    expect(result.state.completedStepIds).toEqual(
+      expect.arrayContaining(["api-key", "connection-test"]),
+    );
+  });
+
+  test("choice 2 runs X / xAI OAuth, selects Grok, and needs no follow-up command", async () => {
     const config = defaultConfig();
     const runGrokOauthLogin = vi
       .fn<() => Promise<{ ok: true; accountLabel: string }>>()
@@ -1220,16 +1314,30 @@ describe("grok OAuth sign-in from the api-key step", () => {
       checkLocalProviders: false,
       runGrokOauthLogin,
     };
-    const state = await advanceToGrokApiKey(context);
+    const state = {
+      ...(await advanceToGrokApiKey(context)),
+      selectedProvider: "openai" as const,
+      selectedModel: "gpt-4.1",
+    };
 
-    const result = await submitFirstRunOnboardingInput(state, "login", context);
+    const result = await submitFirstRunOnboardingInput(state, "2", context);
     expect(runGrokOauthLogin).toHaveBeenCalledTimes(1);
-    expect(result.state.currentStepId).toBe("connection-test");
-    expect(result.state.completedStepIds).toContain("api-key");
+    expect(result.state.currentStepId).toBe("security");
+    expect(result.state.selectedProvider).toBe("grok");
+    expect(result.state.connection).toMatchObject({
+      ok: true,
+      status: "ready",
+    });
+    expect(result.state.connection?.detail).toContain(
+      "Grok subscription access is ready.",
+    );
+    expect(result.state.completedStepIds).toEqual(
+      expect.arrayContaining(["api-key", "connection-test"]),
+    );
     expect(result.state.error).toBeNull();
   });
 
-  test("a failed sign-in surfaces the message and stays on the api-key step", async () => {
+  test("a failed X / xAI sign-in surfaces the message and stays on model access", async () => {
     const config = defaultConfig();
     const context = {
       config,
@@ -1242,28 +1350,57 @@ describe("grok OAuth sign-in from the api-key step", () => {
     };
     const state = await advanceToGrokApiKey(context);
 
-    const result = await submitFirstRunOnboardingInput(state, "login", context);
+    const result = await submitFirstRunOnboardingInput(state, "2", context);
     expect(result.state.currentStepId).toBe("api-key");
     expect(result.state.error).toContain("Browser sign-in did not complete");
   });
 
-  test("login on a non-grok provider is treated as a key attempt, not a sign-in", async () => {
+  test("choice 3 enters API-key mode and back returns to the access menu", async () => {
     const config = defaultConfig();
-    const runGrokOauthLogin = vi.fn();
     const context = {
       config,
       env: {},
       checkLocalProviders: false,
-      runGrokOauthLogin,
-      fetchImpl: (async () =>
-        new Response("unauthorized", { status: 401 })) as typeof fetch,
     };
-    let state = await advanceToGrokApiKey(context);
-    state = { ...state, selectedProvider: "openai" as const };
+    const state = await advanceToGrokApiKey(context);
 
-    const result = await submitFirstRunOnboardingInput(state, "login", context);
-    expect(runGrokOauthLogin).not.toHaveBeenCalled();
-    expect(result.state.currentStepId).toBe("api-key");
-    expect(result.state.error).not.toBeNull();
+    const keyEntry = await submitFirstRunOnboardingInput(state, "3", context);
+    expect(keyEntry.state.currentStepId).toBe("api-key");
+    expect(keyEntry.state.modelAccessInput).toBe("api-key");
+    expect(firstRunOnboardingInputPresentation(keyEntry.state).placeholder).toContain(
+      "Paste XAI_API_KEY",
+    );
+
+    const menu = await submitFirstRunOnboardingInput(
+      keyEntry.state,
+      "back",
+      context,
+    );
+    expect(menu.state.modelAccessInput).toBe("menu");
+  });
+
+  test("keeps a browser URL and device code visible while sign-in is pending", async () => {
+    const context = {
+      config: defaultConfig(),
+      env: {},
+      checkLocalProviders: false,
+    };
+    const state = {
+      ...(await advanceToGrokApiKey(context)),
+      authPrompt: {
+        heading: "Sign in or create an AgenC account",
+        detail: "Finish the browser sign-in.",
+        url: "https://id.agenc.ag/activate",
+        userCode: "ABCD-EFGH",
+      },
+    };
+
+    expect(detailLinesForStep(state, context)).toEqual([
+      "Sign in or create an AgenC account",
+      "Finish the browser sign-in.",
+      "Code: ABCD-EFGH",
+      "URL: https://id.agenc.ag/activate",
+      "Finish sign-in in your browser; AgenC will continue automatically.",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- add first-run AgenC account sign-in/signup for hosted models and the free-model catalog
- add first-run X / xAI OAuth for eligible Grok subscription access
- keep provider API keys, local providers, and configure-later paths explicit without slash commands
- fix free account onboarding so hosted `:free` routes are recognized as ready

## Verification

- `npm run typecheck`
- `npm test` (16,487 passed; 20 skipped)
- `npm run build`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 129-onboard-command`