### PR TITLE
fix(runtime): stop CLI options at prompt boundary

### DIFF
--- a/docs/agent-eval-reports.md
+++ b/docs/agent-eval-reports.md
@@ -120,7 +120,7 @@ npm --workspace=@tetsuo-ai/runtime run eval:agent -- \
 ```bash
 npm --workspace=@tetsuo-ai/runtime run eval:agent -- \
   --suite eval/tasks \
-  --agent-command "agenc -p {prompt} --output-format json" \
+  --agent-command "agenc -p --output-format json {prompt}" \
   --provider xai --model grok-4 \
   --output eval/reports/grok-4.json
 ```

--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -47,7 +47,7 @@ Real agent (headless CLI; the command receives `{prompt}` already shell-quoted):
 
 ```bash
 npm run eval:agent -- --suite eval/tasks \
-  --agent-command "agenc -p {prompt} --output-format json" \
+  --agent-command "agenc -p --output-format json {prompt}" \
   --provider xai --model grok-4 \
   --output eval/reports/grok-4.json
 ```

--- a/runtime/eval/eval-config.example.json
+++ b/runtime/eval/eval-config.example.json
@@ -10,7 +10,7 @@
       "id": "grok-4",
       "provider": "xai",
       "model": "grok-4",
-      "agentCommand": "agenc -p {prompt} --output-format json"
+      "agentCommand": "agenc -p --output-format json {prompt}"
     }
   ]
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/98-prompt-yolo-stays-literal.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/98-prompt-yolo-stays-literal.mjs
@@ -1,0 +1,31 @@
+/**
+ * Safety regression: a --yolo token inside an argv prompt must stay prompt
+ * text. The real PTY starts the prompt turn immediately; default permission
+ * mode must stop the mock model's Bash request at the approval overlay.
+ */
+const marker = "agenc-prompt-yolo-must-not-run-98";
+
+export const meta = {
+  description: "Prompt text containing --yolo cannot bypass tool approval.",
+  args: [
+    "Use",
+    "the",
+    "Bash",
+    "tool",
+    "to",
+    "run:",
+    "echo",
+    marker,
+    "--yolo",
+  ],
+  timeoutMs: 60_000,
+  slimCwd: true,
+  useTempHome: true,
+  sandboxMode: "danger-full-access",
+};
+
+export default async function (session) {
+  await session.start();
+  await session.waitForPermissionOverlay({ timeout: 45_000 });
+  await session.denyPermissionOverlay();
+}

--- a/runtime/scripts/check-tui-e2e/scenarios/99-delimiter-permission-mode-stays-literal.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/99-delimiter-permission-mode-stays-literal.mjs
@@ -1,0 +1,32 @@
+/**
+ * Safety regression: `--` ends startup option parsing. Permission-looking
+ * tokens after it are prompt text and cannot select bypassPermissions.
+ */
+const marker = "agenc-delimited-permission-mode-must-not-run-99";
+
+export const meta = {
+  description: "Tokens after -- cannot select bypassPermissions.",
+  args: [
+    "--",
+    "Use",
+    "the",
+    "Bash",
+    "tool",
+    "to",
+    "run:",
+    "echo",
+    marker,
+    "--permission-mode",
+    "bypassPermissions",
+  ],
+  timeoutMs: 60_000,
+  slimCwd: true,
+  useTempHome: true,
+  sandboxMode: "danger-full-access",
+};
+
+export default async function (session) {
+  await session.start();
+  await session.waitForPermissionOverlay({ timeout: 45_000 });
+  await session.denyPermissionOverlay();
+}

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -12,6 +12,10 @@ import {
   type BootstrapLocalRuntimeSessionOptions,
   type LocalRuntimeBootstrap,
 } from "../bin/bootstrap.js";
+import {
+  insertProcessCliOptionsBeforePrompt,
+  tokenizeCliOptionRegion,
+} from "../bin/cli-option-region.js";
 import { ensureAgentControl } from "../bin/delegate-tool.js";
 import { clearSession } from "../commands/clear.js";
 import type { AgentControl } from "../agents/control.js";
@@ -5466,10 +5470,12 @@ function buildBootstrapArgv(
   },
   baseArgv: readonly string[] | undefined,
 ): readonly string[] {
-  const argv = [...(baseArgv ?? process.argv)];
-  appendFlag(argv, "--provider", params.provider);
-  appendFlag(argv, "--model", params.model);
-  appendFlag(argv, "--profile", params.profile);
+  const argv = baseArgv ?? process.argv;
+  const optionArgs = tokenizeCliOptionRegion(argv.slice(2)).optionArgs;
+  const generatedOptions: string[] = [];
+  appendFlag(generatedOptions, "--provider", params.provider);
+  appendFlag(generatedOptions, "--model", params.model);
+  appendFlag(generatedOptions, "--profile", params.profile);
   // Forward `--yolo` when the caller asked for bypassPermissions mode.
   // bin/bootstrap.ts:1146 keys off cli.allowDangerouslySkipPermissions
   // (which startup-selection.ts sets when --yolo is in argv), so adding
@@ -5478,11 +5484,11 @@ function buildBootstrapArgv(
   // already carries one.
   if (
     params.permissionMode === "bypassPermissions" &&
-    !argv.includes("--yolo") &&
-    !argv.includes("--dangerously-bypass-approvals-and-sandbox") &&
-    !argv.includes("--allow-dangerously-skip-permissions")
+    !optionArgs.includes("--yolo") &&
+    !optionArgs.includes("--dangerously-bypass-approvals-and-sandbox") &&
+    !optionArgs.includes("--allow-dangerously-skip-permissions")
   ) {
-    argv.push("--yolo");
+    generatedOptions.push("--yolo");
   }
   // Mirror non-bypass modes via `--permission-mode <value>` so plan and
   // acceptEdits also propagate. startup-selection.ts already parses
@@ -5490,15 +5496,15 @@ function buildBootstrapArgv(
   if (
     params.permissionMode !== undefined &&
     params.permissionMode !== "bypassPermissions" &&
-    !argv.includes("--permission-mode")
+    !optionArgs.includes("--permission-mode")
   ) {
-    argv.push("--permission-mode", params.permissionMode);
+    generatedOptions.push("--permission-mode", params.permissionMode);
   }
   // todo-114: do not force --autonomous on every daemon agent. Unattended
   // permission policy is installed separately; keepalive ticks only exist on
   // the TUI contract path. Forcing autonomous here made models expect ticks
   // that never arrived and defaulted empty unattended allowlists to pause-all.
-  return argv;
+  return insertProcessCliOptionsBeforePrompt(argv, generatedOptions);
 }
 
 function appendFlag(

--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -34,6 +34,10 @@ import {
   bootstrapLocalRuntimeSession,
   type LocalRuntimeBootstrap,
 } from "../../bin/bootstrap.js";
+import {
+  insertProcessCliOptionsBeforePrompt,
+  tokenizeCliOptionRegion,
+} from "../../bin/cli-option-region.js";
 import { ensureAgentControl } from "../../bin/delegate-tool.js";
 import { delegate } from "../../agents/delegate.js";
 import type { AgentPath } from "../../agents/registry.js";
@@ -257,22 +261,23 @@ export function workflowPermissionModeArgv(
   permissionMode: WorkflowRunSessionPolicy["permissionMode"],
   baseArgv: readonly string[] = process.argv,
 ): readonly string[] {
-  const argv = [...baseArgv];
+  const optionArgs = tokenizeCliOptionRegion(baseArgv.slice(2)).optionArgs;
+  const generatedOptions: string[] = [];
   if (
     permissionMode === "bypassPermissions" &&
-    !argv.includes("--yolo") &&
-    !argv.includes("--dangerously-bypass-approvals-and-sandbox") &&
-    !argv.includes("--allow-dangerously-skip-permissions")
+    !optionArgs.includes("--yolo") &&
+    !optionArgs.includes("--dangerously-bypass-approvals-and-sandbox") &&
+    !optionArgs.includes("--allow-dangerously-skip-permissions")
   ) {
-    argv.push("--yolo");
+    generatedOptions.push("--yolo");
   }
   if (
     permissionMode !== "bypassPermissions" &&
-    !argv.includes("--permission-mode")
+    !optionArgs.includes("--permission-mode")
   ) {
-    argv.push("--permission-mode", permissionMode);
+    generatedOptions.push("--permission-mode", permissionMode);
   }
-  return argv;
+  return insertProcessCliOptionsBeforePrompt(baseArgv, generatedOptions);
 }
 
 /**

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -32,13 +32,13 @@ import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import {
   classifyCLI,
   extractFlagValues,
-  isStartupValueFlagToken,
   routeCLI,
   stripRoutingFlags,
   type BootTUIArgs,
   type ContinueTUIArgs,
   type ResumeTUIArgs,
 } from "./route.js";
+import { tokenizeCliOptionRegion } from "./cli-option-region.js";
 import type {
   LLMContentPart,
   LLMMessage,
@@ -311,24 +311,8 @@ function leadingFlagBeforePrompt(
   argv: readonly string[],
   targets: readonly string[],
 ): boolean {
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i]!;
-    // Literal `--` ends the option region: everything after is prompt.
-    if (arg === "--") return false;
-    if (targets.includes(arg)) return true;
-    if (isStartupValueFlagToken(arg)) {
-      // `--flag value` form consumes the next token as its value, so that
-      // value is not a positional that would end the option region.
-      const next = argv[i + 1];
-      if (typeof next === "string" && !next.startsWith("-")) i += 1;
-      continue;
-    }
-    // Any other option-looking token (`-x`, `--foo`, `--foo=bar`) stays in
-    // the option region; the first bare positional ends it.
-    if (arg.startsWith("-")) continue;
-    return false;
-  }
-  return false;
+  const { optionArgs } = tokenizeCliOptionRegion(argv);
+  return optionArgs.some((arg) => targets.includes(arg));
 }
 
 export function formatCliHelpText(): string {
@@ -1412,12 +1396,8 @@ async function prepareOneShotPromptForDaemon(params: {
   | { readonly blocked: true; readonly blockMessage: string }
 > {
   const target = createOneShotHookTarget();
-  const argv = process.argv.slice(2);
   const explicitDanger =
-    argv.includes("--yolo") ||
-    argv.includes("--dangerously-bypass-approvals-and-sandbox") ||
-    argv.includes("--dangerously-skip-permissions") ||
-    argv.includes("--allow-dangerously-skip-permissions");
+    readStartupCliFlags(process.argv).allowDangerouslySkipPermissions === true;
   const configuredSandbox = params.configStore.current().sandbox_mode;
   const sandboxExecutionBroker = new SandboxExecutionBroker({
     mode: explicitDanger
@@ -2298,6 +2278,7 @@ export async function oneShotCLI(
     throwIfAborted("validateAgencHome");
     const agencHome = resolveAgencHome(process.env);
     const oneShotArgv = process.argv.slice(2);
+    const startupCliFlags = readStartupCliFlags(process.argv);
     const outputFormat = readOneShotOutputFormat(oneShotArgv);
     readOneShotInputFormat(oneShotArgv);
 
@@ -2370,9 +2351,7 @@ export async function oneShotCLI(
     // print-mode oneShot agent runs under bypassPermissions, matching
     // the bootTUI path. See GAP-PE-GUARDIAN-YOLO-LEAK.
     const isYoloOneShot =
-      oneShotArgv.includes("--yolo") ||
-      oneShotArgv.includes("--dangerously-bypass-approvals-and-sandbox") ||
-      oneShotArgv.includes("--allow-dangerously-skip-permissions");
+      startupCliFlags.allowDangerouslySkipPermissions === true;
     // Honor a validated `--permission-mode <value>` in the print path. Without
     // this, only --yolo/bypass propagated and acceptEdits/plan/default were
     // silently dropped. readStartupCliFlags already validated the flag (throwing
@@ -2384,7 +2363,6 @@ export async function oneShotCLI(
     // bypassPermissions takes precedence over any other forwarded mode. Narrow
     // to the daemon-accepted subset (agent.create rejects dontAsk/auto); other
     // user-addressable modes fall back to the unattended default as before.
-    const startupCliFlags = readStartupCliFlags(process.argv);
     const oneShotPermissionMode = isYoloOneShot
       ? ("bypassPermissions" as const)
       : startupCliFlags.permissionMode === "default" ||
@@ -3081,11 +3059,9 @@ async function createDeferredDaemonPromptTuiSession(params: {
       // Propagate --yolo from the user's argv into the daemon-spawned
       // agent's session config so the deferred TUI mirrors the bootTUI
       // path. See GAP-PE-GUARDIAN-YOLO-LEAK.
-      const deferredArgvForYolo = process.argv.slice(2);
       const isYoloDeferred =
-        deferredArgvForYolo.includes("--yolo") ||
-        deferredArgvForYolo.includes("--dangerously-bypass-approvals-and-sandbox") ||
-        deferredArgvForYolo.includes("--allow-dangerously-skip-permissions");
+        readStartupCliFlags(process.argv).allowDangerouslySkipPermissions ===
+        true;
       try {
         const started = await params.deps.startPromptAgent({
           prompt,
@@ -3899,11 +3875,8 @@ export async function bootTUIEntry(args: BootTUIEntryArgs): Promise<number> {
       startupImages.length === 0
     ) {
       const deps = daemonCliDeps();
-      const idleArgvForYolo = process.argv.slice(2);
       const isYoloIdle =
-        idleArgvForYolo.includes("--yolo") ||
-        idleArgvForYolo.includes("--dangerously-bypass-approvals-and-sandbox") ||
-        idleArgvForYolo.includes("--allow-dangerously-skip-permissions");
+        startupCliFlags.allowDangerouslySkipPermissions === true;
       const {
         configStore,
         workspaceRoot,
@@ -4013,11 +3986,8 @@ export async function bootTUIEntry(args: BootTUIEntryArgs): Promise<number> {
     // this, --yolo only affected the local CLI bootstrap and dropped on
     // the wire — see GAP-PE-GUARDIAN-YOLO-LEAK and the daemon-side
     // forwarding in background-agent-runner.buildBootstrapArgv.
-    const cliArgvForYolo = process.argv.slice(2);
     const isYoloFromCli =
-      cliArgvForYolo.includes("--yolo") ||
-      cliArgvForYolo.includes("--dangerously-bypass-approvals-and-sandbox") ||
-      cliArgvForYolo.includes("--allow-dangerously-skip-permissions");
+      startupCliFlags.allowDangerouslySkipPermissions === true;
     const started = await deps.startPromptAgent({
       prompt: preparedObjective,
       env: process.env,
@@ -4137,13 +4107,8 @@ export async function attachAgentTuiEntry(
       return 1;
     }
     const bootstrapEnv = envForAttachBootstrap(env, bootstrapCwd);
-    const attachArgvForYolo = process.argv.slice(2);
     const isYoloAttach =
-      attachArgvForYolo.includes("--yolo") ||
-      attachArgvForYolo.includes(
-        "--dangerously-bypass-approvals-and-sandbox",
-      ) ||
-      attachArgvForYolo.includes("--allow-dangerously-skip-permissions");
+      readStartupCliFlags(process.argv).allowDangerouslySkipPermissions === true;
     const {
       configStore,
       workspaceRoot,

--- a/runtime/src/bin/cli-option-region.ts
+++ b/runtime/src/bin/cli-option-region.ts
@@ -1,0 +1,130 @@
+/**
+ * Startup options that consume the next non-option token when they use the
+ * `--flag value` form. This list defines how the shared CLI tokenizer skips
+ * option values before deciding that the positional prompt has begun.
+ */
+export const STARTUP_VALUE_OPTIONS = Object.freeze([
+  "--resume",
+  "-r",
+  "--provider",
+  "--model",
+  "--profile",
+  "--permission-mode",
+  "--output-format",
+  "--input-format",
+  "--image",
+] as const);
+
+export const CLI_VALUE_OPTIONS = Object.freeze([
+  ...STARTUP_VALUE_OPTIONS,
+  "--debug-file",
+] as const);
+
+export interface CliOptionRegion {
+  /** Every token before the first positional argument or `--`. */
+  readonly optionArgs: readonly string[];
+  /** Positional prompt tokens; the `--` delimiter itself is not included. */
+  readonly promptArgs: readonly string[];
+  readonly endedBy: "positional" | "delimiter" | "end";
+}
+
+export interface TokenizeCliOptionRegionOptions {
+  /**
+   * Additional value-taking options known by a caller. The default startup
+   * value options are always recognized.
+   */
+  readonly additionalValueOptions?: readonly string[];
+}
+
+export function isCliValueOptionToken(arg: string): boolean {
+  return CLI_VALUE_OPTIONS.includes(
+    arg as (typeof CLI_VALUE_OPTIONS)[number],
+  );
+}
+
+/**
+ * Split user argv into its leading option region and positional prompt.
+ *
+ * Parsing ends permanently at the first positional token or the explicit
+ * end-of-options delimiter. Known value-taking options consume one following
+ * non-option token so that values such as `gpt-5` do not begin the prompt.
+ * Unknown option-looking tokens stay in the leading region; consumers may
+ * preserve them as prompt text, but they do not move the safety boundary.
+ */
+export function tokenizeCliOptionRegion(
+  argv: readonly string[],
+  options: TokenizeCliOptionRegionOptions = {},
+): CliOptionRegion {
+  const additionalValueOptions = new Set(
+    options.additionalValueOptions ?? [],
+  );
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--") {
+      return {
+        optionArgs: argv.slice(0, index),
+        promptArgs: argv.slice(index + 1),
+        endedBy: "delimiter",
+      };
+    }
+    if (arg === "-" || !arg.startsWith("-")) {
+      return {
+        optionArgs: argv.slice(0, index),
+        promptArgs: argv.slice(index),
+        endedBy: "positional",
+      };
+    }
+    if (
+      !arg.includes("=") &&
+      (isCliValueOptionToken(arg) || additionalValueOptions.has(arg))
+    ) {
+      const next = argv[index + 1];
+      if (
+        typeof next === "string" &&
+        next !== "--" &&
+        !next.startsWith("-")
+      ) {
+        index += 1;
+      }
+    }
+  }
+
+  return {
+    optionArgs: argv.slice(),
+    promptArgs: [],
+    endedBy: "end",
+  };
+}
+
+/**
+ * Insert generated options at the end of the leading option region while
+ * preserving the positional boundary (including an explicit `--`).
+ */
+export function insertCliOptionsBeforePrompt(
+  argv: readonly string[],
+  insertedOptions: readonly string[],
+): readonly string[] {
+  if (insertedOptions.length === 0) return argv.slice();
+  const region = tokenizeCliOptionRegion(argv);
+  return [
+    ...region.optionArgs,
+    ...insertedOptions,
+    ...(region.endedBy === "delimiter" ? ["--"] : []),
+    ...region.promptArgs,
+  ];
+}
+
+/**
+ * Process argv variant for generated daemon/bootstrap options. Node's
+ * executable and script entries stay fixed; only user argv is tokenized.
+ */
+export function insertProcessCliOptionsBeforePrompt(
+  processArgv: readonly string[],
+  insertedOptions: readonly string[],
+): readonly string[] {
+  return [
+    ...processArgv.slice(0, 2),
+    ...insertCliOptionsBeforePrompt(processArgv.slice(2), insertedOptions),
+  ];
+}

--- a/runtime/src/bin/route.ts
+++ b/runtime/src/bin/route.ts
@@ -19,6 +19,11 @@
  * without touching Ink, the session subsystem, or the provider layer.
  */
 
+import {
+  STARTUP_VALUE_OPTIONS,
+  tokenizeCliOptionRegion,
+} from "./cli-option-region.js";
+
 /**
  * Parse a `--flag <value>` or `--flag=<value>` pair out of an argv
  * vector. Returns `null` when the flag is absent or has no value. When
@@ -31,11 +36,14 @@ export function extractFlagValue(
   argv: readonly string[],
   flag: string,
 ): string | null {
+  const { optionArgs } = tokenizeCliOptionRegion(argv, {
+    additionalValueOptions: [flag],
+  });
   const prefix = `${flag}=`;
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i]!;
+  for (let i = 0; i < optionArgs.length; i += 1) {
+    const arg = optionArgs[i]!;
     if (arg === flag) {
-      const next = argv[i + 1];
+      const next = optionArgs[i + 1];
       if (typeof next !== "string" || next.startsWith("-")) return null;
       return next;
     }
@@ -50,12 +58,15 @@ export function extractFlagValues(
   argv: readonly string[],
   flag: string,
 ): string[] {
+  const { optionArgs } = tokenizeCliOptionRegion(argv, {
+    additionalValueOptions: [flag],
+  });
   const out: string[] = [];
   const prefix = `${flag}=`;
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i]!;
+  for (let i = 0; i < optionArgs.length; i += 1) {
+    const arg = optionArgs[i]!;
     if (arg === flag) {
-      const next = argv[i + 1];
+      const next = optionArgs[i + 1];
       if (typeof next === "string" && !next.startsWith("-")) {
         out.push(next);
         i += 1;
@@ -73,6 +84,7 @@ const ROUTING_BOOLEAN_FLAGS = Object.freeze(["--no-tui"] as const);
 
 const STARTUP_BOOLEAN_FLAGS = Object.freeze([
   "--help",
+  "-h",
   "--version",
   "--yolo",
   "--continue",
@@ -91,17 +103,7 @@ const STARTUP_BOOLEAN_FLAGS = Object.freeze([
 // here silently swallowed the flag AND its value, dropping the user's
 // intent with no behavior and no feedback. Removing them lets the flag
 // text fall through as visible prompt content instead of vanishing.
-const STARTUP_VALUE_FLAGS = Object.freeze([
-  "--resume",
-  "-r",
-  "--provider",
-  "--model",
-  "--profile",
-  "--permission-mode",
-  "--output-format",
-  "--input-format",
-  "--image",
-] as const);
+const STARTUP_VALUE_FLAGS = STARTUP_VALUE_OPTIONS;
 
 function shouldStripValueFlag(arg: string): boolean {
   return STARTUP_VALUE_FLAGS.some(
@@ -133,8 +135,8 @@ function isResumeFlagToken(arg: string): boolean {
  * Returns false for the `--flag=value` form, which carries its own value.
  */
 export function isStartupValueFlagToken(arg: string): boolean {
-  return STARTUP_VALUE_FLAGS.includes(
-    arg as (typeof STARTUP_VALUE_FLAGS)[number],
+  return STARTUP_VALUE_OPTIONS.includes(
+    arg as (typeof STARTUP_VALUE_OPTIONS)[number],
   );
 }
 
@@ -245,20 +247,21 @@ function shouldStripBooleanFlag(arg: string): boolean {
  * stripping logic before it builds its prompt string.
  */
 export function stripRoutingFlags(argv: readonly string[]): string[] {
+  const { optionArgs, promptArgs } = tokenizeCliOptionRegion(argv);
   const out: string[] = [];
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i]!;
+  for (let i = 0; i < optionArgs.length; i += 1) {
+    const arg = optionArgs[i]!;
     if (shouldStripBooleanFlag(arg)) continue;
     if (shouldStripValueFlag(arg)) {
       if (arg.includes("=")) continue;
       // Skip flag + its value (if any non-flag follows).
-      const next = argv[i + 1];
+      const next = optionArgs[i + 1];
       if (typeof next === "string" && !next.startsWith("-")) i += 1;
       continue;
     }
     out.push(arg);
   }
-  return out;
+  return [...out, ...promptArgs];
 }
 
 export interface BootTUIArgs {
@@ -319,16 +322,18 @@ export function classifyCLI(opts: ClassifyCLIOptions): RouteCLIPlan {
   // provided args start at argv[2] and are the input the caller wants to
   // treat as the prompt (after stripping routing flags).
   const userArgv = opts.argv.slice(2);
-  const hasNoTuiFlag = userArgv.includes("--no-tui");
+  const { optionArgs } = tokenizeCliOptionRegion(userArgv);
+  const hasNoTuiFlag = optionArgs.includes("--no-tui");
   const hasPrintFlag =
-    userArgv.includes("-p") || userArgv.includes("--print");
+    optionArgs.includes("-p") || optionArgs.includes("--print");
   const hasContinueFlag =
-    userArgv.includes("--continue") || userArgv.includes("-c");
+    optionArgs.includes("--continue") || optionArgs.includes("-c");
   const resumeId =
-    extractFlagValue(userArgv, "--resume") ?? extractFlagValue(userArgv, "-r");
-  const hasResumeFlag = userArgv.some(isResumeFlagToken);
+    extractFlagValue(optionArgs, "--resume") ??
+    extractFlagValue(optionArgs, "-r");
+  const hasResumeFlag = optionArgs.some(isResumeFlagToken);
   const prompt = stripRoutingFlags(userArgv).join(" ").trim();
-  const startupImages = extractFlagValues(userArgv, "--image");
+  const startupImages = extractFlagValues(optionArgs, "--image");
 
   // 0. A resume flag token was supplied but with no session id (bare
   //    `--resume`/`-r`, or the empty `--resume=`/`-r=` form). Resuming
@@ -356,7 +361,7 @@ export function classifyCLI(opts: ClassifyCLIOptions): RouteCLIPlan {
   //     errorAndExit shape, exitCode 2, both TTY and non-TTY). Only a real
   //     leading flag token matches — a `--model=gpt` value form or a prompt
   //     that merely contains the word "model" is unaffected.
-  const missingSelectionFlag = findMissingValueSelectionFlag(userArgv);
+  const missingSelectionFlag = findMissingValueSelectionFlag(optionArgs);
   if (missingSelectionFlag !== null) {
     return {
       kind: "errorAndExit",
@@ -364,7 +369,8 @@ export function classifyCLI(opts: ClassifyCLIOptions): RouteCLIPlan {
       exitCode: 2,
     };
   }
-  const missingHeadlessFormatFlag = findMissingHeadlessFormatValueFlag(userArgv);
+  const missingHeadlessFormatFlag =
+    findMissingHeadlessFormatValueFlag(optionArgs);
   if (missingHeadlessFormatFlag !== null) {
     return {
       kind: "errorAndExit",

--- a/runtime/src/bin/startup-selection.ts
+++ b/runtime/src/bin/startup-selection.ts
@@ -13,6 +13,7 @@ import { configuredModelForProvider, defaultModelForProvider, resolveDisambiguat
 import { resolveProfile } from "../config/profiles.js";
 import { resolveProfileName } from "../config/env.js";
 import type { AgenCConfig } from "../config/schema.js";
+import { tokenizeCliOptionRegion } from "./cli-option-region.js";
 import { extractFlagValue } from "./route.js";
 
 const DEFAULT_MODEL = "grok-4.5";
@@ -44,11 +45,12 @@ export function readStartupCliFlags(
   argv: readonly string[],
 ): StartupCliFlags {
   const userArgv = argv.slice(2);
-  const provider = extractFlagValue(userArgv, "--provider") ?? undefined;
-  const model = extractFlagValue(userArgv, "--model") ?? undefined;
-  const profile = extractFlagValue(userArgv, "--profile") ?? undefined;
+  const { optionArgs } = tokenizeCliOptionRegion(userArgv);
+  const provider = extractFlagValue(optionArgs, "--provider") ?? undefined;
+  const model = extractFlagValue(optionArgs, "--model") ?? undefined;
+  const profile = extractFlagValue(optionArgs, "--profile") ?? undefined;
   const rawPermissionMode =
-    extractFlagValue(userArgv, "--permission-mode") ?? undefined;
+    extractFlagValue(optionArgs, "--permission-mode") ?? undefined;
   // Distinguish "flag absent" from "flag present but invalid". An invalid
   // value must not be silently coerced to `undefined` (which would boot in
   // DEFAULT mode — a silent failure toward a LESS restrictive session). Throw
@@ -56,11 +58,11 @@ export function readStartupCliFlags(
   // mode`, surfacing as a clean error + non-zero exit at the CLI entrypoint.
   const permissionMode = resolvePermissionModeOrThrow(rawPermissionMode);
   const allowDangerouslySkipPermissions =
-    userArgv.includes("--yolo") ||
-    userArgv.includes("--dangerously-bypass-approvals-and-sandbox") ||
-    userArgv.includes("--allow-dangerously-skip-permissions");
+    optionArgs.includes("--yolo") ||
+    optionArgs.includes("--dangerously-bypass-approvals-and-sandbox") ||
+    optionArgs.includes("--allow-dangerously-skip-permissions");
   const autonomousMode =
-    userArgv.includes("--autonomous") || userArgv.includes("--proactive");
+    optionArgs.includes("--autonomous") || optionArgs.includes("--proactive");
   return Object.freeze({
     ...(provider ? { provider } : {}),
     ...(model ? { model } : {}),

--- a/runtime/src/services/PromptSuggestion/runtime.ts
+++ b/runtime/src/services/PromptSuggestion/runtime.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from 'crypto'
 import { tmpdir } from 'os'
 import { join, resolve } from 'path'
+import { tokenizeCliOptionRegion } from '../../bin/cli-option-region.js'
 import type { LLMProvider } from '../../llm/types.js'
 import { isDangerousCommand } from '../../permissions/bash.js'
 import {
@@ -225,9 +226,10 @@ export function getInitialPromptSuggestionSettings(
 
 export function isAgentSwarmsEnabled(): boolean {
   if (process.env.USER_TYPE === 'ant') return true
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
   if (
     !isEnvTruthy(process.env.AGENC_EXPERIMENTAL_AGENT_TEAMS) &&
-    !process.argv.includes('--agent-teams')
+    !optionArgs.includes('--agent-teams')
   ) {
     return false
   }

--- a/runtime/src/services/api/logging.ts
+++ b/runtime/src/services/api/logging.ts
@@ -16,6 +16,7 @@ import type { AssistantMessage } from 'src/types/message.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { logError } from 'src/utils/log.js'
 import type { PermissionMode } from 'src/utils/permissions/PermissionMode.js'
+import { tokenizeCliOptionRegion } from '../../bin/cli-option-region.js'
 import type { NonNullableUsage } from '../../entrypoints/sdk/sdkUtilityTypes.js'
 import { consumeInvokingRequestId } from '../../utils/agentContext.js'
 import { EMPTY_USAGE } from './emptyUsage.js'
@@ -248,8 +249,9 @@ function logAPISuccess({
 }): void {
   const isNonInteractiveSession = getIsNonInteractiveSession()
   const isPostCompaction = consumePostCompaction()
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
   const hasPrintFlag =
-    process.argv.includes('-p') || process.argv.includes('--print')
+    optionArgs.includes('-p') || optionArgs.includes('--print')
 
   const now = Date.now()
   const lastCompletion = getLastApiCompletionTimestamp()

--- a/runtime/src/utils/agentSwarmsEnabled.ts
+++ b/runtime/src/utils/agentSwarmsEnabled.ts
@@ -1,4 +1,5 @@
 import { isEnvTruthy } from './envUtils.js'
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 
 /**
  * Check if --agent-teams flag is provided via CLI.
@@ -7,7 +8,9 @@ import { isEnvTruthy } from './envUtils.js'
  * pass it anyway, it will work (subject to the killswitch).
  */
 function isAgentTeamsFlagSet(): boolean {
-  return process.argv.includes('--agent-teams')
+  return tokenizeCliOptionRegion(process.argv.slice(2)).optionArgs.includes(
+    '--agent-teams',
+  )
 }
 
 /**

--- a/runtime/src/utils/debug.ts
+++ b/runtime/src/utils/debug.ts
@@ -3,6 +3,7 @@ import { appendFile, mkdir, symlink, unlink } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import memoize from 'lodash-es/memoize.js'
 
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 import {
   getSessionId,
   setSessionTrustAccepted,
@@ -46,14 +47,15 @@ export const getMinDebugLogLevel = memoize((): DebugLogLevel => {
 let runtimeDebugEnabled = false
 
 export const isDebugMode = memoize((): boolean => {
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
   return (
     runtimeDebugEnabled ||
     isEnvTruthy(process.env.DEBUG) ||
     isEnvTruthy(process.env.DEBUG_SDK) ||
-    process.argv.includes('--debug') ||
-    process.argv.includes('-d') ||
+    optionArgs.includes('--debug') ||
+    optionArgs.includes('-d') ||
     isDebugToStdErr() ||
-    process.argv.some(arg => arg.startsWith('--debug=')) ||
+    optionArgs.some(arg => arg.startsWith('--debug=')) ||
     getDebugFilePath() !== null
   )
 })
@@ -102,7 +104,8 @@ const parseDebugFilter = memoize(
 )
 
 export const getDebugFilter = memoize((): DebugFilter | null => {
-  const debugArg = process.argv.find(arg => arg.startsWith('--debug='))
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
+  const debugArg = optionArgs.find(arg => arg.startsWith('--debug='))
   if (!debugArg) {
     return null
   }
@@ -112,19 +115,21 @@ export const getDebugFilter = memoize((): DebugFilter | null => {
 })
 
 export const isDebugToStdErr = memoize((): boolean => {
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
   return (
-    process.argv.includes('--debug-to-stderr') || process.argv.includes('-d2e')
+    optionArgs.includes('--debug-to-stderr') || optionArgs.includes('-d2e')
   )
 })
 
 export const getDebugFilePath = memoize((): string | null => {
-  for (let i = 0; i < process.argv.length; i++) {
-    const arg = process.argv[i]!
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
+  for (let i = 0; i < optionArgs.length; i++) {
+    const arg = optionArgs[i]!
     if (arg.startsWith('--debug-file=')) {
       return arg.substring('--debug-file='.length)
     }
-    if (arg === '--debug-file' && i + 1 < process.argv.length) {
-      return process.argv[i + 1]!
+    if (arg === '--debug-file' && i + 1 < optionArgs.length) {
+      return optionArgs[i + 1]!
     }
   }
   return null

--- a/runtime/src/utils/earlyInput.ts
+++ b/runtime/src/utils/earlyInput.ts
@@ -12,6 +12,7 @@
  */
 
 import { lastGrapheme } from './intl.js'
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 
 // Buffer for early input characters
 let earlyInputBuffer = ''
@@ -27,14 +28,15 @@ let readableHandler: (() => void) | null = null
  * Only captures if stdin is a TTY (interactive terminal).
  */
 export function startCapturingEarlyInput(): void {
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
   // Only capture in interactive mode: stdin must be a TTY, and we must not
   // be in print mode. Raw mode disables ISIG (terminal Ctrl+C → SIGINT),
   // which would make -p uninterruptible.
   if (
     !process.stdin.isTTY ||
     isCapturing ||
-    process.argv.includes('-p') ||
-    process.argv.includes('--print')
+    optionArgs.includes('-p') ||
+    optionArgs.includes('--print')
   ) {
     return
   }

--- a/runtime/src/utils/envUtils.ts
+++ b/runtime/src/utils/envUtils.ts
@@ -1,6 +1,7 @@
 import memoize from 'lodash-es/memoize.js'
 import { homedir } from 'os'
 import { join } from 'path'
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 
 export function resolveAgenCConfigHomeDir(options?: {
   configDirEnv?: string
@@ -73,9 +74,10 @@ export function isEnvDefinedFalsy(
  * — notably startKeychainPrefetch() at main.tsx top-level.
  */
 export function isBareMode(): boolean {
+  const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
   return (
     isEnvTruthy(process.env.AGENC_SIMPLE) ||
-    process.argv.includes('--bare')
+    optionArgs.includes('--bare')
   )
 }
 

--- a/runtime/src/utils/gracefulShutdown.ts
+++ b/runtime/src/utils/gracefulShutdown.ts
@@ -3,6 +3,7 @@ import { writeSync } from 'fs'
 import memoize from 'lodash-es/memoize.js'
 import { onExit } from 'signal-exit'
 import type { ExitReason } from 'src/entrypoints/sdk/coreTypes.generated.js'
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 import {
   getIsInteractive,
   getIsScrollDraining,
@@ -351,7 +352,8 @@ export const setupGracefulShutdown = memoize(() => {
     // avoid racing with it. Only check print mode — other non-interactive
     // sessions (--sdk-url, --init-only, non-TTY) don't register their own
     // SIGINT handler and need gracefulShutdown to run.
-    if (process.argv.includes('-p') || process.argv.includes('--print')) {
+    const { optionArgs } = tokenizeCliOptionRegion(process.argv.slice(2))
+    if (optionArgs.includes('-p') || optionArgs.includes('--print')) {
       return
     }
     logForDiagnosticsNoPII('info', 'shutdown_signal', { signal: 'SIGINT' })

--- a/runtime/src/utils/log.ts
+++ b/runtime/src/utils/log.ts
@@ -5,6 +5,7 @@ import { readdir, readFile, stat } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { join } from 'path'
 import type { QuerySource } from 'src/constants/querySource.js'
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 import {
   setLastAPIRequest,
   setLastAPIRequestMessages,
@@ -154,7 +155,9 @@ export function attachErrorLogSink(newSink: ErrorLogSink): void {
  * - In-memory: Call `getInMemoryErrors()` to get recent errors for the current session
  */
 const isHardFailMode = memoize((): boolean => {
-  return process.argv.includes('--hard-fail')
+  return tokenizeCliOptionRegion(process.argv.slice(2)).optionArgs.includes(
+    '--hard-fail',
+  )
 })
 
 export function logError(error: unknown): void {

--- a/runtime/src/utils/providerValidation.ts
+++ b/runtime/src/utils/providerValidation.ts
@@ -5,6 +5,7 @@ import {
   resolveProviderCodeApiCredentials,
   resolveProviderRequest,
 } from '../services/api/providerConfig.js'
+import { tokenizeCliOptionRegion } from '../bin/cli-option-region.js'
 import { getGlobalAgenCFile } from './env.js'
 import { isBareMode } from './envUtils.js'
 import {
@@ -175,6 +176,9 @@ export function shouldExitForStartupProviderValidationError(options: {
   stdoutIsTTY?: boolean
 } = {}): boolean {
   const args = options.args ?? process.argv.slice(2)
+  const { optionArgs } = tokenizeCliOptionRegion(args, {
+    additionalValueOptions: ['--sdk-url'],
+  })
   const stdoutIsTTY = options.stdoutIsTTY ?? process.stdout.isTTY
 
   if (!stdoutIsTTY) {
@@ -182,10 +186,10 @@ export function shouldExitForStartupProviderValidationError(options: {
   }
 
   return (
-    args.includes('-p') ||
-    args.includes('--print') ||
-    args.includes('--init-only') ||
-    args.some(arg => arg.startsWith('--sdk-url'))
+    optionArgs.includes('-p') ||
+    optionArgs.includes('--print') ||
+    optionArgs.includes('--init-only') ||
+    optionArgs.some(arg => arg.startsWith('--sdk-url'))
   )
 }
 

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -1435,6 +1435,42 @@ describe("AgenC delegate background-agent runner", () => {
     expect(shutdown).not.toHaveBeenCalled();
   });
 
+  it("inserts generated bootstrap options before a positional daemon argv", async () => {
+    const { runner, bootstrap } = makeTopLevelRunner({
+      conversationId: "positional-bootstrap-session",
+      argv: ["node", "agenc", "daemon", "run"],
+    });
+
+    await runner.startAgent({
+      objective: "compile the daemon",
+      provider: "openai",
+      model: "gpt-5",
+      profile: "fast",
+      permissionMode: "plan",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    expect(bootstrap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        argv: [
+          "node",
+          "agenc",
+          "--provider",
+          "openai",
+          "--model",
+          "gpt-5",
+          "--profile",
+          "fast",
+          "--permission-mode",
+          "plan",
+          "daemon",
+          "run",
+        ],
+      }),
+    );
+  });
+
   it("lets the shared admission kernel exclusively enforce agent budget caps", async () => {
     const executionAdmissionKernel = {} as ExecutionAdmissionKernel;
     const { runner, bootstrap, shutdown } = makeTopLevelRunner({

--- a/runtime/tests/bin/agenc.cli-branch.test.ts
+++ b/runtime/tests/bin/agenc.cli-branch.test.ts
@@ -428,6 +428,61 @@ describe("classifyCLI", () => {
       startupImages: ["/tmp/cat.png"],
     });
   });
+
+  it("treats every option-looking token after the prompt begins as literal text", () => {
+    const promptTokens = [
+      "explain",
+      "--yolo",
+      "--permission-mode",
+      "bypassPermissions",
+      "--provider",
+      "openai",
+      "--model",
+      "gpt-5",
+      "--image",
+      "/tmp/prompt.png",
+      "-p",
+      "--no-tui",
+      "--continue",
+      "--resume",
+      "session-from-prompt",
+    ];
+
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, ...promptTokens],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "bootTUI",
+      args: { initialPrompt: promptTokens.join(" ") },
+    });
+  });
+
+  it("treats every token after -- as literal prompt text and removes the delimiter", () => {
+    const promptTokens = [
+      "explain",
+      "--permission-mode",
+      "bypassPermissions",
+      "--yolo",
+      "--model",
+      "gpt-5",
+      "--help",
+      "--version",
+    ];
+
+    expect(
+      classifyCLI({
+        argv: [NODE, SCRIPT, "--", ...promptTokens],
+        isTTY: true,
+        isStdoutTTY: true,
+      }),
+    ).toEqual({
+      kind: "bootTUI",
+      args: { initialPrompt: promptTokens.join(" ") },
+    });
+  });
 });
 
 describe("classifyCLI startup selection value-flag missing-value guard", () => {
@@ -674,5 +729,41 @@ describe("extractFlagValue + stripRoutingFlags helpers", () => {
       ]),
     ).toStrictEqual(["hello"]);
     expect(stripRoutingFlags(["hello"])).toStrictEqual(["hello"]);
+  });
+
+  it("never extracts or strips flags after the prompt boundary", () => {
+    expect(
+      extractFlagValue(
+        ["explain", "--permission-mode", "bypassPermissions"],
+        "--permission-mode",
+      ),
+    ).toBeNull();
+    expect(
+      stripRoutingFlags([
+        "explain",
+        "--yolo",
+        "--model",
+        "gpt-5",
+        "--no-tui",
+      ]),
+    ).toStrictEqual([
+      "explain",
+      "--yolo",
+      "--model",
+      "gpt-5",
+      "--no-tui",
+    ]);
+    expect(
+      stripRoutingFlags([
+        "--",
+        "--permission-mode",
+        "bypassPermissions",
+        "--yolo",
+      ]),
+    ).toStrictEqual([
+      "--permission-mode",
+      "bypassPermissions",
+      "--yolo",
+    ]);
   });
 });

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -2406,6 +2406,60 @@ describe("main() smoke", () => {
     }
   });
 
+  it("oneShotCLI never forwards a permission bypass token from prompt text", async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-prompt-yolo-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-prompt-yolo-cwd-"));
+    const prevEnv = { ...process.env };
+    const prevArgv = [...process.argv];
+
+    process.env.AGENC_HOME = tmpHome;
+    process.env.AGENC_WORKSPACE = tmpCwd;
+    process.env.AGENC_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "stub-openai-key-for-test";
+    process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+    process.argv = [
+      "/usr/bin/node",
+      "/opt/agenc/bin/agenc.js",
+      "explain",
+      "--yolo",
+      "--permission-mode",
+      "bypassPermissions",
+    ];
+
+    const daemon = installDaemonCliDepsForTest({
+      agentId: "agent_prompt_yolo",
+      sessionId: "session_prompt_yolo",
+      cwd: tmpCwd,
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      await expect(
+        oneShotCLI("explain --yolo --permission-mode bypassPermissions"),
+      ).resolves.toBe(0);
+      const createCall = daemon.requests.find(
+        (request) => request.method === "agent.create",
+      );
+      expect(createCall).toBeDefined();
+      expect(
+        (createCall?.params as { permissionMode?: string } | undefined)
+          ?.permissionMode,
+      ).toBeUndefined();
+    } finally {
+      process.argv = prevArgv;
+      stdoutSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in prevEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, prevEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
   it("bootTUIEntry streams startup prompt and images as one daemon message", async () => {
     const tmpHome = await mkdtemp(join(tmpdir(), "agenc-tui-image-home-"));
     const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-tui-image-cwd-"));
@@ -3344,4 +3398,117 @@ describe("main() smoke", () => {
     }
     expect(rejections).toEqual([]);
   });
+
+  it.each([
+    {
+      label: "after the positional prompt begins",
+      argv: [
+        "literal prompt",
+        "--yolo",
+        "--permission-mode",
+        "bypassPermissions",
+        "--provider",
+        "openai",
+        "--model",
+        "gpt-5",
+        "--help",
+        "--version",
+      ],
+      expectedPrompt:
+        "literal prompt --yolo --permission-mode bypassPermissions --provider openai --model gpt-5 --help --version",
+    },
+    {
+      label: "after the end-of-options delimiter",
+      argv: [
+        "--",
+        "literal prompt",
+        "--yolo",
+        "--permission-mode",
+        "bypassPermissions",
+        "--provider",
+        "openai",
+        "--model",
+        "gpt-5",
+        "--help",
+        "--version",
+      ],
+      expectedPrompt:
+        "literal prompt --yolo --permission-mode bypassPermissions --provider openai --model gpt-5 --help --version",
+    },
+  ])(
+    "main keeps startup-looking tokens literal $label",
+    async ({ argv, expectedPrompt }) => {
+      const tmpHome = await mkdtemp(join(tmpdir(), "agenc-boundary-main-"));
+      const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-boundary-cwd-"));
+      const prevArgv = process.argv;
+      const prevEnv = { ...process.env };
+      const prevStdinIsTTY = Object.getOwnPropertyDescriptor(
+        process.stdin,
+        "isTTY",
+      );
+
+      process.argv = [
+        process.argv[0] ?? "node",
+        "agenc-test-entry",
+        ...argv,
+      ];
+      process.env.AGENC_HOME = tmpHome;
+      process.env.AGENC_WORKSPACE = tmpCwd;
+      process.env.AGENC_PROVIDER = "grok";
+      process.env.AGENC_MODEL = "grok-4.3";
+      process.env.XAI_API_KEY = "stub-key-for-test";
+      process.env.AGENC_CLI_ENTRY_DISABLE = "1";
+      process.env.AGENC_DAEMON_AUTOSTART = "0";
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: false,
+      });
+      const daemon = installDaemonCliDepsForTest({
+        agentId: "agent_boundary_main",
+        sessionId: "session_boundary_main",
+        cwd: tmpCwd,
+      });
+      const stdoutSpy = vi
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+
+      try {
+        await expect(main()).resolves.toBe(0);
+        const createCall = daemon.requests.find(
+          (request) => request.method === "agent.create",
+        );
+        expect(createCall).toBeDefined();
+        expect(createCall?.params).toEqual(
+          expect.objectContaining({
+            objective: expectedPrompt,
+            instructions: expectedPrompt,
+            provider: "grok",
+            model: "grok-4.3",
+          }),
+        );
+        expect(
+          (createCall?.params as { permissionMode?: string } | undefined)
+            ?.permissionMode,
+        ).toBeUndefined();
+        expect(
+          stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join(""),
+        ).toBe("daemon answer\n");
+      } finally {
+        stdoutSpy.mockRestore();
+        process.argv = prevArgv;
+        if (prevStdinIsTTY === undefined) {
+          delete (process.stdin as { isTTY?: boolean }).isTTY;
+        } else {
+          Object.defineProperty(process.stdin, "isTTY", prevStdinIsTTY);
+        }
+        for (const key of Object.keys(process.env)) {
+          if (!(key in prevEnv)) delete process.env[key];
+        }
+        Object.assign(process.env, prevEnv);
+        await rm(tmpHome, { recursive: true, force: true });
+        await rm(tmpCwd, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/runtime/tests/bin/cli-option-region.test.ts
+++ b/runtime/tests/bin/cli-option-region.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  insertCliOptionsBeforePrompt,
+  insertProcessCliOptionsBeforePrompt,
+  tokenizeCliOptionRegion,
+} from "../../src/bin/cli-option-region.js";
+
+describe("tokenizeCliOptionRegion", () => {
+  it("lets known value options consume values before the positional prompt", () => {
+    expect(
+      tokenizeCliOptionRegion([
+        "--provider",
+        "openai",
+        "--model=gpt-5",
+        "--permission-mode",
+        "plan",
+        "explain",
+        "--yolo",
+      ]),
+    ).toEqual({
+      optionArgs: [
+        "--provider",
+        "openai",
+        "--model=gpt-5",
+        "--permission-mode",
+        "plan",
+      ],
+      promptArgs: ["explain", "--yolo"],
+      endedBy: "positional",
+    });
+  });
+
+  it("ends at -- and excludes only the delimiter", () => {
+    expect(
+      tokenizeCliOptionRegion([
+        "--model",
+        "gpt-5",
+        "--",
+        "--permission-mode",
+        "bypassPermissions",
+      ]),
+    ).toEqual({
+      optionArgs: ["--model", "gpt-5"],
+      promptArgs: ["--permission-mode", "bypassPermissions"],
+      endedBy: "delimiter",
+    });
+  });
+
+  it("keeps unknown option-looking tokens before the first positional", () => {
+    expect(
+      tokenizeCliOptionRegion(["--future-flag", "its-value", "--yolo"]),
+    ).toEqual({
+      optionArgs: ["--future-flag"],
+      promptArgs: ["its-value", "--yolo"],
+      endedBy: "positional",
+    });
+  });
+
+  it("treats a lone dash as positional prompt text", () => {
+    expect(tokenizeCliOptionRegion(["-", "--yolo"])).toEqual({
+      optionArgs: [],
+      promptArgs: ["-", "--yolo"],
+      endedBy: "positional",
+    });
+  });
+});
+
+describe("generated CLI option insertion", () => {
+  it("inserts before positional prompt text", () => {
+    expect(
+      insertCliOptionsBeforePrompt(
+        ["daemon", "run"],
+        ["--permission-mode", "plan"],
+      ),
+    ).toEqual(["--permission-mode", "plan", "daemon", "run"]);
+  });
+
+  it("inserts before and preserves an explicit delimiter", () => {
+    expect(
+      insertProcessCliOptionsBeforePrompt(
+        ["node", "agenc", "--", "--yolo"],
+        ["--permission-mode", "plan"],
+      ),
+    ).toEqual([
+      "node",
+      "agenc",
+      "--permission-mode",
+      "plan",
+      "--",
+      "--yolo",
+    ]);
+  });
+});

--- a/runtime/tests/bin/startup-selection.test.ts
+++ b/runtime/tests/bin/startup-selection.test.ts
@@ -97,4 +97,42 @@ describe("readStartupCliFlags --permission-mode validation", () => {
     ]);
     expect(flags.permissionMode).toBeUndefined();
   });
+
+  it("ignores startup-looking tokens after the positional prompt begins", () => {
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "explain",
+      "--provider",
+      "openai",
+      "--model",
+      "gpt-5",
+      "--profile",
+      "fast",
+      "--permission-mode",
+      "bypassPermissions",
+      "--yolo",
+      "--autonomous",
+    ]);
+
+    expect(flags).toEqual({});
+  });
+
+  it("ignores startup-looking tokens after the end-of-options delimiter", () => {
+    const flags = readStartupCliFlags([
+      "node",
+      "agenc",
+      "--",
+      "--provider",
+      "openai",
+      "--model",
+      "gpt-5",
+      "--permission-mode",
+      "bypassPermissions",
+      "--yolo",
+      "--proactive",
+    ]);
+
+    expect(flags).toEqual({});
+  });
 });

--- a/runtime/tests/utils/providerValidation.test.ts
+++ b/runtime/tests/utils/providerValidation.test.ts
@@ -138,3 +138,18 @@ test('startup provider validation stays strict for non-interactive launches', ()
     }),
   ).toBe(true)
 })
+
+test('startup provider validation ignores control-looking prompt text', () => {
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: ['explain', '-p', '--init-only', '--sdk-url=ws://prompt.invalid'],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(false)
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: ['--', '--print', '--sdk-url', 'ws://prompt.invalid'],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(false)
+})

--- a/runtime/tests/workflow/session-adapters.policy.test.ts
+++ b/runtime/tests/workflow/session-adapters.policy.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../../src/app-server/workflow/session-adapters.js";
 import type { WorkflowRunSessionPolicy } from "../../src/app-server/workflow/verified-change-controller.js";
 import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
+import { readStartupCliFlags } from "../../src/bin/startup-selection.js";
 import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
 import type { ToolPermissionContext } from "../../src/permissions/types.js";
 import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
@@ -225,6 +226,29 @@ describe("A2 — spec permission policy on the run session", () => {
       "--permission-mode",
       "plan",
     ]);
+  });
+
+  it("inserts generated permission options before a positional argv boundary", () => {
+    const argv = workflowPermissionModeArgv("plan", [
+      "node",
+      "agenc",
+      "daemon",
+      "run",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+
+    expect(argv).toEqual([
+      "node",
+      "agenc",
+      "--permission-mode",
+      "plan",
+      "daemon",
+      "run",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+    expect(readStartupCliFlags(argv).permissionMode).toBe("plan");
   });
 });
 


### PR DESCRIPTION
## Summary
- add one shared leading option-region tokenizer that stops at the first positional argument or explicit delimiter
- apply the boundary to routing, startup selection, permission forwarding, hidden runtime flags, and generated daemon bootstrap argv
- add revert-sensitive parser, full-entrypoint, daemon-forwarding, and real PTY permission regressions

## Verification
- npm test
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run build
- npm run check:agent-surface-contract
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- TUI E2E scenarios 98 and 99

The final runtime suite passed 1,883 files and 16,529 tests.