### PR TITLE
test(runtime): hermeticize TUI gates

### DIFF
--- a/runtime/scripts/check-tui-command-visual-smoke.mjs
+++ b/runtime/scripts/check-tui-command-visual-smoke.mjs
@@ -7,7 +7,29 @@
  * frame. It catches transient rich commands, missing hint spacing, and menu
  * content that starts below the viewport.
  */
-import { TuiSession, renderPtyRows } from "./check-tui-e2e/harness.mjs";
+import { fileURLToPath } from "node:url";
+
+import {
+  TuiSession,
+  renderPtyRows,
+  tuiE2eGateEnv,
+} from "./check-tui-e2e/harness.mjs";
+import {
+  buildMockProviderEnv,
+  startMockModelServer,
+} from "./local-openai-compatible-mock.mjs";
+import {
+  configureTuiGateSandbox,
+  createTuiGateProject,
+  createTuiGateState,
+  installTuiGateSignalHandlers,
+  startTuiGateDaemon,
+  teardownTuiGateState,
+} from "./tui-gate-state.mjs";
+
+const BIN_AGENC = fileURLToPath(
+  new URL("../dist/bin/agenc.js", import.meta.url),
+);
 
 const DIMENSIONS = [
   { cols: 148, rows: 40 },
@@ -48,9 +70,9 @@ const COMMANDS = [
   },
   {
     command: "/hooks",
-    anchors: ["HOOKS", "hooks runtime", "runtime bridge missing"],
-    supporting: ["hooks"],
-    requiresFooter: true,
+    anchors: ["AgenC Hooks", "Commands: /hooks"],
+    supporting: ["Configured hooks:", "PreToolUse: 0 hooks", "/hooks diagnostics"],
+    requiresLiveSession: true,
   },
   {
     command: "/mcp",
@@ -61,7 +83,7 @@ const COMMANDS = [
   {
     command: "/agents",
     anchors: ["AGENTS"],
-    supporting: ["delegate-capable", "registered"],
+    supporting: ["Built-in agents"],
     requiresFooter: true,
   },
   {
@@ -95,7 +117,7 @@ const COMMANDS = [
   {
     command: "/diff",
     anchors: ["DIFF", "git diff HEAD", "modified", "deleted"],
-    supporting: ["git diff HEAD", "no uncommitted changes", "runtime/src"],
+    supporting: ["diff-fixture.txt"],
     requiresFooter: true,
   },
 ];
@@ -131,6 +153,66 @@ function forceKillSession(session) {
     } catch {
       // best-effort teardown
     }
+  }
+}
+
+function trackActiveSession(lifecycle, session) {
+  if (lifecycle.activeSession !== null) {
+    throw new Error("command visual smoke already has an active TUI session");
+  }
+  lifecycle.activeSession = session;
+  lifecycle.activeSessionCleanup = null;
+}
+
+async function cleanupActiveSession(lifecycle) {
+  const session = lifecycle.activeSession;
+  if (session === null) return;
+
+  if (lifecycle.activeSessionCleanup === null) {
+    forceKillSession(session);
+    lifecycle.activeSessionCleanup = session.cleanup();
+  }
+  const cleanupPromise = lifecycle.activeSessionCleanup;
+  try {
+    await cleanupPromise;
+  } finally {
+    if (
+      lifecycle.activeSession === session &&
+      lifecycle.activeSessionCleanup === cleanupPromise
+    ) {
+      lifecycle.activeSession = null;
+      lifecycle.activeSessionCleanup = null;
+    }
+  }
+}
+
+async function cleanupLifecycle(lifecycle) {
+  const errors = [];
+  try {
+    await cleanupActiveSession(lifecycle);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    const gateState =
+      lifecycle.gateState ?? await lifecycle.pendingGateState;
+    lifecycle.gateState = gateState;
+    lifecycle.pendingGateState = null;
+    await teardownTuiGateState(gateState, BIN_AGENC);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (lifecycle.mockClosePromise === null) {
+    lifecycle.mockClosePromise = lifecycle.mockServer.close();
+  }
+  try {
+    await lifecycle.mockClosePromise;
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "command visual smoke cleanup failed");
   }
 }
 
@@ -227,54 +309,113 @@ function assertSurfaceVisible(session, spec, dimension) {
   }
 }
 
-async function runOne(spec, dimension) {
+async function runOne(spec, dimension, lifecycle) {
   const session = new TuiSession({
     cols: dimension.cols,
     rows: dimension.rows,
+    cwd: lifecycle.cwd,
+    gateState: lifecycle.gateState,
   });
+  trackActiveSession(lifecycle, session);
   const label = `${spec.command} ${dimension.cols}x${dimension.rows}`;
   try {
     await session.start({ firstPaintMs: 1_000, postReplyMs: 1_000 });
     await session.waitForPrompt({ timeout: 20_000 });
     assertNoMalformedHints(session.latestFrame, `${label} cold-start`);
 
+    if (spec.requiresLiveSession) {
+      await session.type("hello");
+      await session.submit();
+      await session.waitForAssistantReply({ timeout: 45_000 });
+      await session.waitForPrompt({ timeout: 30_000 });
+    }
     await session.submitSlashCommand(spec.command);
     await session.waitForIdle({ idleWindow: 900, timeout: 20_000 });
     if (spec.settleMs) await sleep(spec.settleMs);
     assertSurfaceVisible(session, spec, dimension);
     session.assertNoCrash();
   } finally {
-    forceKillSession(session);
-    await session.cleanup();
+    await cleanupActiveSession(lifecycle);
   }
 }
 
 async function main() {
-  const failures = [];
-  for (const dimension of DIMENSIONS) {
-    for (const spec of COMMANDS) {
-      const label = `${spec.command} ${dimension.cols}x${dimension.rows}`;
-      process.stdout.write(`command visual smoke: ${label} ... `);
-      try {
-        await runOne(spec, dimension);
-        process.stdout.write("ok\n");
-      } catch (error) {
-        process.stdout.write("failed\n");
-        failures.push({ label, error });
+  const mockServer = await startMockModelServer();
+  const gateStatePromise = createTuiGateState({
+    injectedEnv: tuiE2eGateEnv(
+      buildMockProviderEnv(mockServer.baseUrl, {}),
+    ),
+    prefix: "agenc-tui-command-visual-",
+  });
+  const lifecycle = {
+    gateState: null,
+    pendingGateState: gateStatePromise,
+    cwd: null,
+    activeSession: null,
+    activeSessionCleanup: null,
+    aborted: false,
+    mockServer,
+    mockClosePromise: null,
+  };
+  let uninstallSignalHandlers = () => {};
+  try {
+    uninstallSignalHandlers = installTuiGateSignalHandlers(async () => {
+      lifecycle.aborted = true;
+      await cleanupLifecycle(lifecycle);
+    });
+    const gateState = await gateStatePromise;
+    lifecycle.gateState = gateState;
+    lifecycle.pendingGateState = null;
+    lifecycle.cwd = createTuiGateProject(gateState, { dirty: true });
+    // The hooks surface needs one live mock turn. Avoid depending on the
+    // host's optional bubblewrap/user-namespace support for that precondition.
+    await configureTuiGateSandbox(
+      gateState,
+      BIN_AGENC,
+      "danger-full-access",
+    );
+    if (lifecycle.aborted) return 1;
+    await startTuiGateDaemon(gateState, BIN_AGENC);
+    if (lifecycle.aborted) return 1;
+
+    const failures = [];
+    for (const dimension of DIMENSIONS) {
+      for (const spec of COMMANDS) {
+        if (lifecycle.aborted) return 1;
+        const label = `${spec.command} ${dimension.cols}x${dimension.rows}`;
+        process.stdout.write(`command visual smoke: ${label} ... `);
+        try {
+          await runOne(spec, dimension, lifecycle);
+          process.stdout.write("ok\n");
+        } catch (error) {
+          process.stdout.write("failed\n");
+          failures.push({ label, error });
+        }
+        if (lifecycle.aborted) return 1;
       }
     }
-  }
 
-  if (failures.length > 0) {
-    for (const failure of failures) {
-      console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
+    if (failures.length > 0) {
+      for (const failure of failures) {
+        console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
+      }
+      return 1;
     }
-    process.exit(1);
+    return 0;
+  } finally {
+    try {
+      await cleanupLifecycle(lifecycle);
+    } finally {
+      uninstallSignalHandlers();
+    }
   }
-  process.exit(0);
 }
 
-main().catch((error) => {
-  console.error(error?.stack ?? error?.message ?? String(error));
-  process.exit(1);
-});
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(error?.stack ?? error?.message ?? String(error));
+    process.exitCode = 1;
+  });

--- a/runtime/scripts/check-tui-e2e/harness.mjs
+++ b/runtime/scripts/check-tui-e2e/harness.mjs
@@ -15,21 +15,26 @@
  *   - The startup smoke at `scripts/check-tui-runtime-startup.mjs` already
  *     uses node-pty directly. Reuse that pattern; build on top.
  *
- * Scope:
- *   - Phase A scenarios assume the user has a real provider configured in
- *     `~/.agenc/config.toml` (currently LMStudio). We do NOT run a fake
- *     provider; the gate exercises the real wire path.
- *   - Each scenario runs against the user's real `$HOME`. Sessions
- *     accumulate in the daemon. Phase B will introduce per-scenario
- *     temp-HOME isolation.
+ * Every scenario runs against private gate-owned HOME/AGENC_HOME state. The
+ * runner supplies a local mock provider and a daemon on an ephemeral port, so
+ * neither scenario startup nor teardown can target the operator's daemon.
  */
-import { copyFile, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  configureTuiGateSandbox,
+  createTuiGateState,
+  environmentForTuiGateState,
+  startTuiGateDaemon,
+  stopTuiGateDaemon,
+  teardownTuiGateHome,
+  writeTuiGateTrust,
+  tuiGateEnvironment,
+} from "../tui-gate-state.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..");
@@ -37,13 +42,6 @@ const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
 
 const require = createRequire(path.join(RUNTIME_DIR, "package.json"));
 const pty = require("node-pty");
-
-const TEMP_HOME_DAEMON_START_ATTEMPTS = 3;
-const TEMP_HOME_DAEMON_READY_TIMEOUT_MS = 20_000;
-
-function randomTempDaemonWebSocketPort() {
-  return 17_766 + Math.floor(Math.random() * 10_000);
-}
 
 export function resolveHarnessAgencHome(
   env = process.env,
@@ -56,13 +54,7 @@ export function resolveHarnessAgencHome(
 }
 
 export function isolatedHomeEnv(home, baseEnv = process.env) {
-  const agencHome = path.join(home, ".agenc");
-  return {
-    ...baseEnv,
-    HOME: home,
-    AGENC_CONFIG_DIR: agencHome,
-    AGENC_HOME: agencHome,
-  };
+  return tuiGateEnvironment(home, baseEnv);
 }
 
 export function tuiE2eGateEnv(baseEnv = process.env) {
@@ -77,213 +69,60 @@ export function tuiE2eGateEnv(baseEnv = process.env) {
   };
 }
 
-export function tempDaemonEnv(home, wsPort, baseEnv = process.env) {
-  return {
-    ...isolatedHomeEnv(home, baseEnv),
-    AGENC_DAEMON_WEBSOCKET_PORT: String(wsPort),
-  };
-}
-
-async function waitForTempDaemonReady(env, timeoutMs = TEMP_HOME_DAEMON_READY_TIMEOUT_MS) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const status = spawnSync(
-      process.execPath,
-      [BIN_AGENC, "daemon", "status"],
-      { encoding: "utf8", env, timeout: 5_000 },
-    );
-    if (status.status === 0 && /\brunning\b/.test(status.stdout)) {
-      return true;
-    }
-    await sleep(200);
-  }
-  return false;
+export function tempDaemonEnv(home, _wsPort = 0, baseEnv = process.env) {
+  return isolatedHomeEnv(home, baseEnv);
 }
 
 /**
- * Ensure the given absolute path is in `~/.agenc/trusted-projects.json`. The
- * file is additive: we never remove entries. Without this, the TUI shows a
- * "Trust this project?" dialog at cold start and the harness's XTVERSION
- * reply gets fed to that dialog as input, which causes the TUI to exit
- * before the prompt renders.
- *
- * Schema (per AGENC.md gotcha note): the `version` field is REQUIRED. The
- * trust check uses realpath, so we add both the input path and its realpath
- * form so symlinked roots match on either side.
+ * Seed deterministic trust in the private gate state. Without this, the TUI
+ * shows a project-trust dialog and can consume the terminal capability reply
+ * as dialog input before the prompt renders.
  */
 async function ensureProjectTrusted(projectPath, env = process.env) {
-  const trustFile = path.join(
-    resolveHarnessAgencHome(env),
-    "trusted-projects.json",
-  );
-  await mkdir(path.dirname(trustFile), { recursive: true });
-  let trust = { version: 1, trustedProjects: [] };
-  if (existsSync(trustFile)) {
-    try {
-      const raw = await readFile(trustFile, "utf8");
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === "object" && Array.isArray(parsed.trustedProjects)) {
-        trust = parsed;
-        if (!Number.isFinite(trust.version)) trust.version = 1;
-      }
-    } catch {
-      // Corrupt or missing: rebuild from scratch.
-    }
-  }
-  const candidates = new Set();
-  candidates.add(path.resolve(projectPath));
-  try {
-    candidates.add(await realpath(projectPath));
-  } catch {
-    // Path may not exist or be inaccessible; skip realpath form.
-  }
-  let mutated = false;
-  const have = new Set(
-    (trust.trustedProjects ?? []).map((entry) => entry?.path).filter(Boolean),
-  );
-  for (const candidate of candidates) {
-    if (!have.has(candidate)) {
-      trust.trustedProjects.push({
-        path: candidate,
-        trustedAt: new Date().toISOString(),
-      });
-      mutated = true;
-    }
-  }
-  if (mutated) {
-    await writeFile(trustFile, JSON.stringify(trust, null, 2), "utf8");
-  }
+  await writeTuiGateTrust(env, [projectPath]);
 }
 
 /**
- * Create a fresh `$HOME` for one scenario and copy the minimum config the
- * runtime needs to start a fresh daemon there. This isolates daemon
- * sockets, permission policy, session registries, and audit logs from
- * the user's real `~/.agenc` so that mutating scenarios (always-allow,
- * Write tool, etc.) don't pollute later scenarios or the operator's
- * actual setup.
- *
- * What we copy:
- *   - `config.toml` — provider / model / base URL settings.
- *   - `auth.json` — vended credentials (may be absent on first-run boxes).
- *
- * What we deliberately don't copy: trust-projects (we'll trust the cwd
- * fresh), permission policy, session state. Anything else should be
- * stateless across daemon spawns.
+ * Create a standalone private home for scenarios that launch a non-PTY child.
+ * The home contains no copied operator configuration or credentials.
  */
-export async function createTempHome({ sandboxMode } = {}) {
-  const home = await mkdtemp(path.join(tmpdir(), "agenc-tui-e2e-home-"));
-  const agencDir = resolveHarnessAgencHome({ HOME: home });
-  await mkdir(agencDir, { recursive: true });
-  // Files to clone from the user's real ~/.agenc so the spawned agenc
-  // doesn't fire onboarding, ask for an API key, or stall on trust.
-  const cloneFiles = [
-    "config.toml",
-    "auth.json",
-    "onboarding.json",
-    "settings.json",
-  ];
-  for (const name of cloneFiles) {
-    const source = path.join(resolveHarnessAgencHome(), name);
-    if (existsSync(source)) {
-      await copyFile(source, path.join(agencDir, name));
-    }
-  }
-  if (sandboxMode !== undefined) {
-    if (sandboxMode !== "danger-full-access") {
-      throw new Error(`unsupported TUI E2E sandbox mode: ${sandboxMode}`);
-    }
-    // Approval-overlay scenarios must remain in permission mode `default`, so
-    // --yolo would invalidate what they exercise. Set only the sandbox policy
-    // in the throwaway HOME before its daemon starts; production startup stays
-    // fail-closed and the scenario still asks for tool approval.
-    const configSet = spawnSync(
-      process.execPath,
-      [BIN_AGENC, "config", "set", "sandbox_mode", sandboxMode],
-      {
-        encoding: "utf8",
-        env: isolatedHomeEnv(home),
-        timeout: 10_000,
-      },
-    );
-    if (configSet.status !== 0) {
-      throw new Error(
-        `failed to configure temporary TUI E2E sandbox mode: ${configSet.stderr || configSet.stdout}`,
+export async function createTempHome({
+  sandboxMode,
+  baseEnv = process.env,
+  injectedEnv = {},
+} = {}) {
+  const state = await createTuiGateState({
+    baseEnv,
+    injectedEnv,
+    prefix: "agenc-tui-e2e-home-",
+  });
+  try {
+    await configureTuiGateSandbox(state, BIN_AGENC, sandboxMode);
+    await startTuiGateDaemon(state, BIN_AGENC);
+    return { home: state.home, wsPort: 0 };
+  } catch (error) {
+    try {
+      await teardownTuiGateHome(state.home, BIN_AGENC, state.env);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "temporary TUI home startup and cleanup both failed",
       );
     }
+    throw error;
   }
-  // Pre-start the daemon and wait for status to report running. Without
-  // this, the spawned agenc CLI can connect before the daemon has finished
-  // writing its cookie/socket readiness markers and fail autostart.
-  //
-  // The daemon also binds a WebSocket on AGENC_DAEMON_WEBSOCKET_PORT
-  // (default 7766) for portal/IDE clients. The user's main daemon is
-  // already on 7766, so each temp HOME daemon must use a different
-  // port. Random in 17766–27765 to avoid collisions with each other
-  // and with anything else on the dev box.
-  let lastStart = null;
-  for (let attempt = 1; attempt <= TEMP_HOME_DAEMON_START_ATTEMPTS; attempt += 1) {
-    const wsPort = randomTempDaemonWebSocketPort();
-    const daemonEnv = tempDaemonEnv(home, wsPort);
-    lastStart = spawnSync(
-      process.execPath,
-      [BIN_AGENC, "daemon", "start"],
-      { encoding: "utf8", env: daemonEnv, timeout: 30_000 },
-    );
-    if (await waitForTempDaemonReady(daemonEnv)) {
-      return { home, wsPort };
-    }
-    spawnSync(
-      process.execPath,
-      [BIN_AGENC, "daemon", "stop"],
-      { encoding: "utf8", env: daemonEnv, timeout: 10_000 },
-    );
-    await rm(path.join(agencDir, "daemon.pid"), { force: true });
-    await rm(path.join(agencDir, "daemon.sock"), { force: true });
-  }
-  throw new Error(
-    [
-      "temp HOME daemon did not become ready",
-      `start status: ${lastStart?.status ?? "unknown"}`,
-      `stdout: ${lastStart?.stdout ?? ""}`,
-      `stderr: ${lastStart?.stderr ?? ""}`,
-    ].join("\n"),
-  );
 }
 
 /**
- * Tear down a temp HOME: stop any daemon bound to its socket, delete the
- * directory tree. Best-effort; failures are logged but don't block the
- * scenario teardown.
+ * Tear down a standalone private home and prove its daemon, socket, and state
+ * root are gone. A cleanup failure fails the scenario.
  */
 export async function teardownTempHome(home) {
-  if (!home) return;
-  try {
-    spawnSync(
-      process.execPath,
-      [BIN_AGENC, "daemon", "stop"],
-      { encoding: "utf8", env: isolatedHomeEnv(home), timeout: 10_000 },
-    );
-  } catch {
-    // best-effort
-  }
-  try {
-    await rm(home, { recursive: true, force: true });
-  } catch {
-    // best-effort
-  }
+  await teardownTuiGateHome(home, BIN_AGENC);
 }
 
 export async function trustProjectForHome(home, projectPath) {
-  const tempTrust = path.join(home, ".agenc", "trusted-projects.json");
-  await writeFile(
-    tempTrust,
-    JSON.stringify({
-      version: 1,
-      trustedProjects: [{ path: projectPath, trustedAt: new Date().toISOString() }],
-    }, null, 2),
-    "utf8",
-  );
+  await writeTuiGateTrust(isolatedHomeEnv(home), [projectPath]);
 }
 
 async function walkFiles(dir) {
@@ -300,8 +139,8 @@ async function walkFiles(dir) {
   return files;
 }
 
-async function latestRolloutFilesForHome(home) {
-  const projectsDir = path.join(home, ".agenc", "projects");
+async function latestRolloutFilesForAgencHome(agencHome) {
+  const projectsDir = path.join(agencHome, "projects");
   let files = [];
   try {
     files = await walkFiles(projectsDir);
@@ -320,8 +159,8 @@ async function latestRolloutFilesForHome(home) {
     .map((entry) => entry.file);
 }
 
-async function readRolloutItemsForHome(home) {
-  const files = await latestRolloutFilesForHome(home);
+async function readRolloutItemsForAgencHome(agencHome) {
+  const files = await latestRolloutFilesForAgencHome(agencHome);
   const items = [];
   for (const file of files) {
     const lines = (await readFile(file, "utf8")).split("\n").filter(Boolean);
@@ -629,6 +468,7 @@ export class TuiSession {
     rows = 40,
     env = {},
     cwd,
+    gateState,
     useTempHome = false,
     sandboxMode,
   } = {}) {
@@ -637,10 +477,16 @@ export class TuiSession {
     this.rows = rows;
     this.envOverrides = { ...env };
     this.cwd = cwd ?? process.cwd();
+    this.gateState = gateState ?? null;
     this.useTempHome = useTempHome;
     this.sandboxMode = sandboxMode;
     this.tempHome = null;
+    this.ownsTempHome = false;
+    this.runtimeEnv = null;
     this.term = null;
+    this.childRecords = new Map();
+    this.abortError = null;
+    this.cleanupPromise = null;
     this.buffer = "";
     this.exited = false;
     this.exitInfo = null;
@@ -660,6 +506,192 @@ export class TuiSession {
     this.watermark = this.buffer.length;
   }
 
+  throwIfAborted() {
+    if (this.abortError !== null) throw this.abortError;
+  }
+
+  /**
+   * Resolve the exact private environment used by this session and seed
+   * deterministic trust. Non-PTY scenarios use this before spawning their
+   * own tracked CLI child.
+   */
+  async prepare() {
+    this.throwIfAborted();
+    if (this.runtimeEnv !== null) return this.runtimeEnv;
+    if (this.gateState === null && !this.useTempHome) {
+      throw new Error(
+        "TuiSession requires runner-owned gate state or useTempHome isolation",
+      );
+    }
+    if (this.gateState !== null && this.useTempHome) {
+      throw new Error(
+        "TuiSession cannot nest useTempHome inside runner-owned gate state",
+      );
+    }
+    let env = this.gateState === null
+      ? { ...process.env, ...this.envOverrides }
+      : environmentForTuiGateState(this.gateState, this.envOverrides);
+    if (this.gateState !== null) {
+      this.tempHome = this.gateState.home;
+    }
+    if (this.useTempHome) {
+      const { home } = await createTempHome({
+        sandboxMode: this.sandboxMode,
+        baseEnv: env,
+        injectedEnv: this.envOverrides,
+      });
+      this.tempHome = home;
+      this.ownsTempHome = true;
+      env = tuiGateEnvironment(home, env, this.envOverrides);
+    }
+    await ensureProjectTrusted(this.cwd, env);
+    this.throwIfAborted();
+    this.runtimeEnv = env;
+    return env;
+  }
+
+  trackChild(child) {
+    const record = {
+      child,
+      closed: false,
+      close: null,
+      closePromise: null,
+    };
+    record.closePromise = new Promise((resolve) => {
+      const finish = (value) => {
+        if (record.closed) return;
+        record.closed = true;
+        record.close = value;
+        resolve(value);
+      };
+      child.once("close", (code, signal) => finish({ code, signal }));
+      child.once("error", (error) => finish({ code: null, signal: null, error }));
+    });
+    this.childRecords.set(child, record);
+    return child;
+  }
+
+  async spawnTracked(command, args, options = {}) {
+    const env = await this.prepare();
+    this.throwIfAborted();
+    const childEnv = options.env === undefined
+      ? env
+      : this.gateState === null
+        ? tuiGateEnvironment(this.tempHome, env, {
+            ...this.envOverrides,
+            ...options.env,
+          })
+        : environmentForTuiGateState(this.gateState, {
+            ...this.envOverrides,
+            ...options.env,
+          });
+    return this.trackChild(spawn(command, args, {
+      ...options,
+      // Gate isolation cannot be overridden by a scenario's spawn options.
+      cwd: options.cwd ?? this.cwd,
+      env: childEnv,
+    }));
+  }
+
+  async waitForChildClose(child, timeoutMs) {
+    const record = this.childRecords.get(child);
+    if (record === undefined) {
+      throw new Error("cannot wait for an untracked child process");
+    }
+    if (record.closed) return record.close;
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(null), timeoutMs);
+      record.closePromise.then((result) => {
+        clearTimeout(timer);
+        resolve(result);
+      });
+    });
+  }
+
+  async terminateTrackedChild(child, {
+    graceMs = 2_000,
+    forceKillGraceMs = 2_000,
+  } = {}) {
+    const record = this.childRecords.get(child);
+    if (record === undefined || record.closed) return record?.close ?? null;
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // The close observer remains authoritative.
+    }
+    let result = await this.waitForChildClose(child, graceMs);
+    if (result !== null) return result;
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // The close observer remains authoritative.
+    }
+    result = await this.waitForChildClose(child, forceKillGraceMs);
+    if (result !== null) return result;
+    throw new Error(`tracked child survived SIGKILL (pid ${child.pid ?? "unknown"})`);
+  }
+
+  async runAgenc(args, {
+    cwd = this.cwd,
+    env,
+    input,
+    timeoutMs = 30_000,
+  } = {}) {
+    const child = await this.spawnTracked(
+      process.execPath,
+      [BIN_AGENC, ...args],
+      {
+        cwd,
+        env,
+        stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    if (input !== undefined) {
+      child.stdin.end(input);
+    }
+    const result = await this.waitForChildClose(child, timeoutMs);
+    if (result === null) {
+      await this.terminateTrackedChild(child);
+      throw new Error(`agenc ${args.join(" ")} exceeded ${timeoutMs}ms`);
+    }
+    if (result.error) throw result.error;
+    return { code: result.code, signal: result.signal, stdout, stderr };
+  }
+
+  async startGateDaemon() {
+    if (this.gateState === null) {
+      throw new Error("cannot start a gate daemon without runner-owned state");
+    }
+    return startTuiGateDaemon(this.gateState, BIN_AGENC);
+  }
+
+  async restartGateDaemon() {
+    if (this.gateState === null) {
+      throw new Error("cannot restart a gate daemon without runner-owned state");
+    }
+    await stopTuiGateDaemon(this.gateState);
+    return startTuiGateDaemon(this.gateState, BIN_AGENC);
+  }
+
+  async abort(reason = new Error("TUI scenario aborted")) {
+    if (this.abortError === null) {
+      this.abortError = reason instanceof Error ? reason : new Error(String(reason));
+    }
+    this.kill("SIGKILL");
+    await Promise.allSettled(
+      [...this.childRecords.keys()].map((child) =>
+        this.terminateTrackedChild(child, { graceMs: 250 })),
+    );
+  }
+
   /**
    * Spawn the TUI under PTY and wait until the cold-start handshake is done
    * (XTVERSION + DA1 replies sent, post-reply tick elapsed). Does not wait
@@ -669,27 +701,8 @@ export class TuiSession {
     if (this.term !== null) {
       throw new Error("TuiSession already started");
     }
-    let env = { ...process.env, ...this.envOverrides };
-    if (this.useTempHome) {
-      const { home, wsPort } = await createTempHome({
-        sandboxMode: this.sandboxMode,
-      });
-      this.tempHome = home;
-      env = tempDaemonEnv(home, wsPort, env);
-      // Trust file lives under HOME — recompute under the temp HOME so
-      // the trust dialog doesn't fire.
-      const tempTrust = path.join(home, ".agenc", "trusted-projects.json");
-      await writeFile(
-        tempTrust,
-        JSON.stringify({
-          version: 1,
-          trustedProjects: [{ path: this.cwd, trustedAt: new Date().toISOString() }],
-        }, null, 2),
-        "utf8",
-      );
-    } else {
-      await ensureProjectTrusted(this.cwd, env);
-    }
+    const env = await this.prepare();
+    this.throwIfAborted();
     this.term = pty.spawn(process.execPath, [BIN_AGENC, ...this.args], {
       name: "xterm-256color",
       cols: this.cols,
@@ -711,7 +724,9 @@ export class TuiSession {
       this.exitInfo = { exitCode, signal };
     });
     await sleep(firstPaintMs);
+    this.throwIfAborted();
     await sleep(postReplyMs);
+    this.throwIfAborted();
   }
 
   /**
@@ -721,6 +736,7 @@ export class TuiSession {
    */
   async type(text, { perCharMs = 30 } = {}) {
     for (const ch of text) {
+      this.throwIfAborted();
       this.term.write(ch);
       await sleep(perCharMs);
     }
@@ -731,6 +747,7 @@ export class TuiSession {
    * Ctrl+C, arrow keys, etc.
    */
   send(bytes) {
+    this.throwIfAborted();
     this.term.write(bytes);
   }
 
@@ -738,6 +755,7 @@ export class TuiSession {
    * Type-and-submit shortcut. Optional `text` lets you pre-fill before Enter.
    */
   async submit(text = "") {
+    this.throwIfAborted();
     if (text) await this.type(text);
     await sleep(80);
     this.mark();
@@ -752,6 +770,7 @@ export class TuiSession {
     const re = pattern instanceof RegExp ? pattern : new RegExp(pattern);
     const start = Date.now();
     while (Date.now() - start < timeout) {
+      this.throwIfAborted();
       const slice = normalizePtyOutput(this.buffer.slice(this.watermark), {
         cols: this.cols,
         rows: this.rows,
@@ -795,6 +814,7 @@ export class TuiSession {
     let lastSize = this.buffer.length;
     let stableSince = Date.now();
     while (Date.now() - start < timeout) {
+      this.throwIfAborted();
       if (this.buffer.length === lastSize) {
         const frame = this.latestFrame;
         if (frameLooksBusy(frame)) {
@@ -826,12 +846,13 @@ export class TuiSession {
   }
 
   /**
-   * Read rollout entries for this scenario's HOME. Temp-HOME scenarios use
-   * their isolated daemon state; default-HOME scenarios fall back to the
-   * operator's HOME, so callers should use unique markers.
+   * Read rollout entries from the exact private AGENC_HOME used by the PTY.
    */
   async readRolloutItems() {
-    return readRolloutItemsForHome(this.tempHome ?? homedir());
+    const agencHome = this.runtimeEnv === null
+      ? resolveHarnessAgencHome()
+      : resolveHarnessAgencHome(this.runtimeEnv);
+    return readRolloutItemsForAgencHome(agencHome);
   }
 
   async completedRolloutToolCalls({ toolName } = {}) {
@@ -980,6 +1001,7 @@ export class TuiSession {
    * the slash menu.
    */
   async submitSlashCommand(command) {
+    this.throwIfAborted();
     if (!command.startsWith("/")) {
       throw new Error(`submitSlashCommand expects a leading slash: ${command}`);
     }
@@ -1005,6 +1027,7 @@ export class TuiSession {
   async waitForAssistantReply({ timeout = 60_000 } = {}) {
     const start = Date.now();
     while (Date.now() - start < timeout) {
+      this.throwIfAborted();
       const rows = renderPtyRows(this.buffer.slice(this.watermark), {
         cols: this.cols,
         rows: this.rows,
@@ -1028,39 +1051,79 @@ export class TuiSession {
    * TUI does not exit within the grace window.
    */
   async exitGracefully({ timeout = 5_000 } = {}) {
-    if (this.exited) return;
-    this.term.write("/exit\r");
-    const start = Date.now();
-    while (Date.now() - start < timeout) {
-      if (this.exited) return;
-      await sleep(50);
+    if (this.exited || this.term === null) return;
+    if (this.abortError !== null) {
+      this.kill("SIGKILL");
+      if (await this.waitForExit(1_000)) return;
+      throw new Error("aborted TUI PTY survived SIGKILL during cleanup");
     }
-    this.kill();
+    this.term.write("/exit\r");
+    if (await this.waitForExit(timeout)) return;
+    this.kill("SIGTERM");
+    if (await this.waitForExit(1_000)) return;
+    this.kill("SIGKILL");
+    if (await this.waitForExit(1_000)) return;
+    throw new Error("TUI PTY survived SIGKILL during cleanup");
+  }
+
+  async waitForExit(timeout = 1_000) {
+    if (this.exited || this.term === null) return true;
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (this.exited) return true;
+      await sleep(25);
+    }
+    return this.exited;
   }
 
   /**
    * Force-terminate the PTY. Use as teardown safety; prefer `exitGracefully`.
    */
-  kill() {
+  kill(signal = "SIGTERM") {
     if (this.exited || this.term === null) return;
     try {
-      this.term.kill("SIGTERM");
+      this.term.kill(signal);
     } catch {
-      // Already dead
+      // The exit observer remains authoritative.
     }
   }
 
   /**
-   * Tear down per-scenario resources. Safe to call multiple times.
-   * If `useTempHome` was set, stops the daemon bound to the temp HOME and
-   * removes the directory tree.
+   * Tear down resources owned by this session. Runner-provided gate state is
+   * intentionally left to the runner, which stops the daemon only after the
+   * PTY has been proven dead.
    */
   async cleanup() {
-    if (this.tempHome !== null) {
-      const home = this.tempHome;
-      this.tempHome = null;
-      await teardownTempHome(home);
-    }
+    if (this.cleanupPromise !== null) return this.cleanupPromise;
+    this.cleanupPromise = (async () => {
+      const errors = [];
+      try {
+        await this.exitGracefully({ timeout: 2_000 });
+      } catch (error) {
+        errors.push(error);
+      }
+      const childResults = await Promise.allSettled(
+        [...this.childRecords.keys()].map((child) =>
+          this.terminateTrackedChild(child)),
+      );
+      for (const result of childResults) {
+        if (result.status === "rejected") errors.push(result.reason);
+      }
+      if (this.ownsTempHome && this.tempHome !== null) {
+        const home = this.tempHome;
+        this.tempHome = null;
+        this.ownsTempHome = false;
+        try {
+          await teardownTempHome(home);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "TUI session cleanup failed");
+      }
+    })();
+    return this.cleanupPromise;
   }
 
   /**

--- a/runtime/scripts/check-tui-e2e/runner.mjs
+++ b/runtime/scripts/check-tui-e2e/runner.mjs
@@ -5,14 +5,12 @@
  * failures, dumps full PTY output to `/tmp/tui-e2e-failure-<scenario>.log`
  * on failure, and exits non-zero if any scenario failed.
  *
- * Scenarios run serially. They share the user's daemon and HOME, so
- * parallelism would cause cross-contamination. Phase B will introduce
- * temp-HOME isolation and enable parallel execution.
+ * Scenarios run serially within one runner. Each scenario owns a private
+ * HOME/AGENC_HOME, daemon, ephemeral WebSocket endpoint, and temp tree, so
+ * independent filtered runners can be sharded safely.
  */
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { realpathSync } from "node:fs";
 import { readdir, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { TuiSession, tuiE2eGateEnv } from "./harness.mjs";
@@ -21,130 +19,27 @@ import {
   buildMockProviderEnv,
   startMockModelServer,
 } from "../local-openai-compatible-mock.mjs";
+import {
+  configureTuiGateSandbox,
+  createTuiGateProject,
+  createTuiGateState,
+  environmentForTuiGateState,
+  installTuiGateSignalHandlers,
+  startTuiGateDaemon,
+  teardownTuiGateState,
+} from "../tui-gate-state.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCENARIOS_DIR = path.join(SCRIPT_DIR, "scenarios");
 const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..");
 const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-const DEFAULT_DAEMON_SOCKET = path.join(
-  process.env.AGENC_HOME ?? path.join(homedir(), ".agenc"),
-  "daemon.sock",
-);
 const DEFAULT_TIMEOUT_MS = 60_000;
-const PROVIDER_ENV_KEYS = [
-  "XAI_API_KEY",
-  "GROK_API_KEY",
-  "AGENC_XAI_API_KEY",
-  "OPENAI_API_KEY",
-  "OPENAI_BASE_URL",
-  "OPENAI_MODEL",
-  "AGENC_PROVIDER",
-  "AGENC_MODEL",
-  "OPENAI_COMPATIBLE_MODEL",
-  "OPENAI_COMPATIBLE_BASE_URL",
-  "OPENAI_COMPATIBLE_API_KEY",
-  "API_TIMEOUT_MS",
-  "AGENC_AUTH_MANAGED_KEYS_ENABLED",
-  "AGENC_ONBOARDING",
-];
-
-function applyProcessEnv(nextEnv) {
-  for (const key of PROVIDER_ENV_KEYS) {
-    if (!(key in nextEnv)) delete process.env[key];
+const ABORT_QUIESCE_MS = 10_000;
+export function replaceProcessEnvironment(nextEnv) {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
   }
   Object.assign(process.env, nextEnv);
-}
-
-function restoreProcessEnv(originalEnv) {
-  for (const key of PROVIDER_ENV_KEYS) {
-    if (key in originalEnv) {
-      process.env[key] = originalEnv[key];
-    } else {
-      delete process.env[key];
-    }
-  }
-}
-
-/**
- * Restart the user's daemon so each gate run starts from a clean session
- * registry, fresh permission policy cache, no accumulated state from
- * earlier runs. Without this, scenarios near the end of a multi-scenario
- * run start failing with `Timed out waiting for daemon response` because
- * the daemon's session/permission state has drifted.
- */
-function restartDaemon() {
-  spawnSync(
-    process.execPath,
-    [BIN_AGENC, "daemon", "stop"],
-    { encoding: "utf8", timeout: 15_000 },
-  );
-  let stopped = false;
-  for (let i = 0; i < 60; i += 1) {
-    if (!isDefaultDaemonAlive()) {
-      stopped = true;
-      break;
-    }
-    spawnSync("sleep", ["0.25"]);
-  }
-  if (!stopped) return false;
-  const result = spawnSync(
-    process.execPath,
-    [BIN_AGENC, "daemon", "start"],
-    { encoding: "utf8", timeout: 30_000 },
-  );
-  if (result.status !== 0 && !isDefaultDaemonAlive()) return false;
-  for (let i = 0; i < 60; i += 1) {
-    if (isDefaultDaemonAlive()) return true;
-    spawnSync("sleep", ["0.25"]);
-  }
-  return false;
-}
-
-/**
- * Probe the user's default daemon socket. Returns true if the daemon is up
- * and responsive. Some scenarios (notably the `useTempHome` ones) tear down
- * a temp daemon, and on rare timing the user's main daemon ends up
- * unreachable for the next scenario; without this probe the next
- * default-HOME scenario fails with ECONNREFUSED. Cheap (`agenc daemon
- * status` exits in <500ms when the daemon is alive).
- */
-function isDefaultDaemonAlive() {
-  const result = spawnSync(
-    process.execPath,
-    [BIN_AGENC, "daemon", "status"],
-    { encoding: "utf8", timeout: 5_000 },
-  );
-  return result.status === 0 && existsSync(DEFAULT_DAEMON_SOCKET);
-}
-
-function ensureDefaultDaemon() {
-  if (isDefaultDaemonAlive()) return true;
-  // Auto-respawn the default daemon. First attempt: plain `daemon start`.
-  // If that doesn't come up within 15s, stop any zombie state and retry —
-  // a stale pid file or wedged socket can otherwise keep the next
-  // attempt from binding cleanly.
-  const tryStart = () => {
-    spawnSync(
-      process.execPath,
-      [BIN_AGENC, "daemon", "start"],
-      { encoding: "utf8", timeout: 20_000 },
-    );
-    for (let i = 0; i < 60; i += 1) {
-      if (isDefaultDaemonAlive()) return true;
-      spawnSync("sleep", ["0.25"]);
-    }
-    return false;
-  };
-  if (tryStart()) return true;
-  // Hard reset: stop any half-up daemon, clear sentinel files, then start
-  // fresh. This handles the case where an earlier scenario left the
-  // daemon in a transitional state that `daemon start` can't recover from.
-  spawnSync(
-    process.execPath,
-    [BIN_AGENC, "daemon", "stop"],
-    { encoding: "utf8", timeout: 10_000 },
-  );
-  return tryStart();
 }
 
 const COLORS = {
@@ -200,41 +95,28 @@ function applyScenarioFilters(names, argv) {
   return filtered;
 }
 
-function createSlimCwd() {
-  const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-slim-"));
-  writeFileSync(path.join(slimCwd, "README.md"), "test cwd\n", "utf8");
-  // Anchor project-root discovery inside the scenario directory. Otherwise
-  // an unrelated marker in a shared ancestor such as /tmp/package.json can
-  // make the trust preflight target the entire temp root.
-  writeFileSync(
-    path.join(slimCwd, "package.json"),
-    '{"private":true}\n',
-    "utf8",
-  );
-  return slimCwd;
-}
-
-function createScenarioSession(scenario, slimCwd) {
+function createScenarioSession(scenario, scenarioCwd, gateState) {
   return new TuiSession({
     args: scenario.meta.args ?? [],
-    useTempHome: scenario.meta.useTempHome === true,
+    gateState,
     ...(scenario.meta.sandboxMode
       ? { sandboxMode: scenario.meta.sandboxMode }
       : {}),
     ...(scenario.meta.env ? { env: scenario.meta.env } : {}),
     ...(scenario.meta.cwd
       ? { cwd: scenario.meta.cwd }
-      : slimCwd
-        ? { cwd: slimCwd }
-        : {}),
+      : { cwd: scenarioCwd }),
   });
 }
 
 function createScenarioTimeout(timeoutMs) {
   let timer;
-  const promise = new Promise((_, reject) => {
+  const promise = new Promise((resolve) => {
     timer = setTimeout(
-      () => reject(new Error(`scenario timeout after ${timeoutMs}ms`)),
+      () => resolve({
+        kind: "timeout",
+        error: new Error(`scenario timeout after ${timeoutMs}ms`),
+      }),
       timeoutMs,
     );
   });
@@ -244,57 +126,86 @@ function createScenarioTimeout(timeoutMs) {
   };
 }
 
-async function cleanupSession(session) {
-  try {
-    await session.exitGracefully({ timeout: 2_000 });
-  } catch {
-    session.kill();
-  }
-  try {
-    await session.cleanup();
-  } catch {
-    // best-effort
-  }
+function combineErrors(primary, cleanup, message) {
+  if (primary && cleanup) return new AggregateError([primary, cleanup], message);
+  return primary ?? cleanup ?? null;
 }
 
-async function runScenario(scenario) {
+function waitForScenarioQuiescence(scenarioSettled) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(
+      () => resolve({ kind: "unquiesced" }),
+      ABORT_QUIESCE_MS,
+    );
+    scenarioSettled.then((result) => {
+      clearTimeout(timer);
+      resolve(result);
+    });
+  });
+}
+
+export async function runScenario(scenario, gateState, lifecycle = null) {
   const startedAt = Date.now();
-  // Slim cwd: when meta.slimCwd === true, mkdtemp a fresh empty
-  // directory under /tmp and spawn agenc there. Avoids the daemon's
-  // project-context auto-load swamping the model with hundreds of K of
-  // tokens (which was making yolo-tool scenarios time out even though
-  // the bypass mode was working). Each tool round-trip can opt in by
-  // setting `slimCwd: true` in its meta.
-  const slimCwd = scenario.meta.slimCwd === true && !scenario.meta.cwd
-    ? createSlimCwd()
-    : undefined;
-  const session = createScenarioSession(scenario, slimCwd);
+  // Every scenario gets a small private git fixture. This keeps project
+  // discovery fast, makes git-oriented slash commands realistic, and makes
+  // filtered runners safe to shard against the same source checkout.
+  const scenarioCwd = createTuiGateProject(gateState, {
+    dirty: scenario.meta.dirtyCwd === true,
+  });
+  const session = createScenarioSession(scenario, scenarioCwd, gateState);
+  if (lifecycle !== null) lifecycle.activeSession = session;
   const debug = process.env.TUI_E2E_DEBUG === "1";
   const timeoutMs = scenario.meta.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const timeout = createScenarioTimeout(timeoutMs);
+  const scenarioSettled = Promise.resolve()
+    .then(() => scenario.run(session))
+    .then(
+      () => ({ kind: "settled", error: null }),
+      (error) => ({ kind: "settled", error }),
+    );
+  let scenarioError = null;
+  let quiesced = true;
   try {
-    await Promise.race([scenario.run(session), timeout.promise]);
-    session.assertNoCrash();
-    return {
-      ok: true,
-      durationMs: Date.now() - startedAt,
-      capturedOutput: debug ? session.raw : undefined,
-    };
+    const outcome = await Promise.race([scenarioSettled, timeout.promise]);
+    if (outcome.kind === "timeout") {
+      scenarioError = outcome.error;
+      await session.abort(outcome.error);
+      const quiescence = await waitForScenarioQuiescence(scenarioSettled);
+      quiesced = quiescence.kind === "settled";
+    } else {
+      scenarioError = outcome.error;
+    }
+    if (scenarioError === null) session.assertNoCrash();
   } catch (error) {
-    return {
-      ok: false,
-      durationMs: Date.now() - startedAt,
-      error,
-      capturedOutput: session.raw,
-    };
+    scenarioError = error;
   } finally {
     timeout.clear();
-    await cleanupSession(session);
   }
+  let cleanupError = null;
+  try {
+    await session.cleanup();
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (lifecycle?.activeSession === session) lifecycle.activeSession = null;
+  const error = combineErrors(
+    scenarioError,
+    cleanupError,
+    `scenario ${scenario.name} and its cleanup both failed`,
+  );
+  return {
+    ok: error === null,
+    quiesced,
+    session,
+    durationMs: Date.now() - startedAt,
+    ...(error === null ? {} : { error }),
+    capturedOutput: error === null && !debug ? undefined : session.raw,
+  };
 }
 
 async function dumpFailureLog(scenario, result) {
-  const logPath = `/tmp/tui-e2e-failure-${scenario.name.replace(/\.mjs$/, "")}.log`;
+  const logPath =
+    `/tmp/tui-e2e-failure-${process.pid}-${scenario.name.replace(/\.mjs$/, "")}.log`;
   const header = [
     `# TUI E2E failure: ${scenario.name}`,
     `# Description: ${scenario.meta.description ?? "(none)"}`,
@@ -310,10 +221,12 @@ async function dumpFailureLog(scenario, result) {
 
 async function startMockedGate() {
   const mockServer = await startMockModelServer();
-  applyProcessEnv(
-    tuiE2eGateEnv(buildMockProviderEnv(mockServer.baseUrl, process.env)),
-  );
-  return mockServer;
+  return {
+    mockServer,
+    injectedEnv: tuiE2eGateEnv(
+      buildMockProviderEnv(mockServer.baseUrl, {}),
+    ),
+  };
 }
 
 function printGateHeader(names, mockServer) {
@@ -323,25 +236,8 @@ function printGateHeader(names, mockServer) {
   console.log(
     color("dim", `  model: openai-compatible:${MOCK_MODEL} (${mockServer.baseUrl})`),
   );
-  process.stdout.write(color("dim", "  restarting daemon for clean baseline ... "));
-  const restarted = restartDaemon();
-  console.log(color("dim", restarted ? "ok" : "skipped"));
+  console.log(color("dim", "  state: private HOME/AGENC_HOME + ephemeral daemon per scenario"));
   console.log("");
-}
-
-function scenarioDaemonError(scenario) {
-  // Scenarios that don't isolate via temp HOME share the user's default
-  // daemon. If a prior scenario killed it (autostart hiccup, lock
-  // contention, or a temp-HOME teardown that mis-targeted the default
-  // socket), respawn before continuing. useTempHome scenarios spawn
-  // their own daemon and must not be touched here.
-  if (scenario.meta.restartDaemonBefore === true && !restartDaemon()) {
-    return new Error("default daemon not reachable after restart");
-  }
-  if (scenario.meta.useTempHome !== true && !ensureDefaultDaemon()) {
-    return new Error("default daemon not reachable; respawn failed");
-  }
-  return null;
 }
 
 function recordPreflightFailure(state, name, error) {
@@ -354,7 +250,8 @@ async function recordScenarioResult(state, scenario, result) {
     state.passed += 1;
     console.log(`${color("green", "PASS")} ${color("dim", `(${result.durationMs}ms)`)}`);
     if (process.env.TUI_E2E_DEBUG === "1" && result.capturedOutput) {
-      const logPath = `/tmp/tui-e2e-pass-${scenario.name.replace(/\.mjs$/, "")}.log`;
+      const logPath =
+        `/tmp/tui-e2e-pass-${process.pid}-${scenario.name.replace(/\.mjs$/, "")}.log`;
       await writeFile(logPath, result.capturedOutput, "utf8");
       console.log(`      ${color("dim", `debug log: ${logPath}`)}`);
     }
@@ -368,20 +265,111 @@ async function recordScenarioResult(state, scenario, result) {
   state.failed.push({ name: scenario.name, error: result.error, logPath });
 }
 
-async function runScenarioEntry(name, state) {
-  const scenario = await loadScenario(name);
-  process.stdout.write(`  ${color("dim", "→")} ${name} … `);
-  if (scenario.meta.skip) {
-    console.log(`${color("yellow", "SKIP")} ${color("dim", `(${scenario.meta.skip})`)}`);
-    state.skipped.push({ name, reason: scenario.meta.skip });
+async function runScenarioEntry(
+  name,
+  state,
+  gateBaseEnv,
+  gateInjectedEnv,
+  lifecycle,
+) {
+  const originalEnv = { ...process.env };
+  const gateStatePromise = createTuiGateState({
+    baseEnv: gateBaseEnv,
+    injectedEnv: gateInjectedEnv,
+    prefix: `agenc-tui-e2e-${name.replace(/\.mjs$/u, "")}-`,
+  });
+  lifecycle.pendingGateState = gateStatePromise;
+  const gateState = await gateStatePromise;
+  if (lifecycle.pendingGateState === gateStatePromise) {
+    lifecycle.pendingGateState = null;
+  }
+  lifecycle.activeGateState = gateState;
+  let scenario = null;
+  let result = null;
+  replaceProcessEnvironment(gateState.env);
+  try {
+    if (lifecycle.interrupted) {
+      throw new Error("TUI E2E gate interrupted before scenario startup");
+    }
+    scenario = await loadScenario(name);
+    process.stdout.write(`  ${color("dim", "→")} ${name} … `);
+    if (scenario.meta.skip) {
+      console.log(`${color("yellow", "SKIP")} ${color("dim", `(${scenario.meta.skip})`)}`);
+      state.skipped.push({ name, reason: scenario.meta.skip });
+    } else {
+      gateState.env = environmentForTuiGateState(
+        gateState,
+        scenario.meta.env ?? {},
+      );
+      replaceProcessEnvironment(gateState.env);
+      await configureTuiGateSandbox(
+        gateState,
+        BIN_AGENC,
+        scenario.meta.sandboxMode,
+      );
+      if (lifecycle.interrupted) {
+        throw new Error("TUI E2E gate interrupted before daemon startup");
+      }
+      await startTuiGateDaemon(gateState, BIN_AGENC);
+      if (lifecycle.interrupted) {
+        throw new Error("TUI E2E gate interrupted before scenario execution");
+      }
+      result = await runScenario(scenario, gateState, lifecycle);
+    }
+  } catch (error) {
+    result = {
+      ok: false,
+      durationMs: 0,
+      error,
+      capturedOutput: "",
+    };
+  } finally {
+    let cleanupError = null;
+    try {
+      await teardownTuiGateState(gateState, BIN_AGENC);
+    } catch (error) {
+      cleanupError = error;
+    }
+    if (result?.quiesced !== false) {
+      replaceProcessEnvironment(originalEnv);
+    }
+    if (lifecycle.activeGateState === gateState) {
+      lifecycle.activeGateState = null;
+    }
+    if (cleanupError !== null) {
+      if (result === null) {
+        result = {
+          ok: false,
+          durationMs: 0,
+          error: cleanupError,
+          capturedOutput: "",
+        };
+      } else {
+        result = {
+          ...result,
+          ok: false,
+          error: combineErrors(
+            result.ok ? null : result.error,
+            cleanupError,
+            `scenario ${name} and private-state cleanup both failed`,
+          ),
+        };
+      }
+    }
+  }
+  if (result?.quiesced === false) {
+    const error = new Error(
+      `scenario ${name} did not quiesce after cancellation; terminating runner`,
+    );
+    error.fatalIsolationFailure = true;
+    throw error;
+  }
+  if (scenario === null) {
+    recordPreflightFailure(state, name, result.error);
     return;
   }
-  const daemonError = scenarioDaemonError(scenario);
-  if (daemonError) {
-    recordPreflightFailure(state, name, daemonError);
-    return;
-  }
-  await recordScenarioResult(state, scenario, await runScenario(scenario));
+  if (scenario.meta.skip && result === null) return;
+  await recordScenarioResult(state, scenario, result);
 }
 
 function printSummary(state) {
@@ -412,32 +400,104 @@ function printSummary(state) {
 }
 
 async function main() {
-  const originalEnv = { ...process.env };
-  const mockServer = await startMockedGate();
-  let ranScenarios = false;
+  const gateBaseEnv = { ...process.env };
+  const { mockServer, injectedEnv } = await startMockedGate();
+  const lifecycle = {
+    activeGateState: null,
+    activeSession: null,
+    interrupted: false,
+    mockClosePromise: null,
+    pendingGateState: null,
+  };
+  const closeMock = async () => {
+    if (lifecycle.mockClosePromise === null) {
+      lifecycle.mockClosePromise = mockServer.close();
+    }
+    await lifecycle.mockClosePromise;
+  };
+  const uninstallSignalHandlers = installTuiGateSignalHandlers(async () => {
+    lifecycle.interrupted = true;
+    const errors = [];
+    if (lifecycle.activeSession !== null) {
+      try {
+        await lifecycle.activeSession.abort(new Error("TUI gate interrupted"));
+        await lifecycle.activeSession.cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (lifecycle.activeGateState !== null) {
+      try {
+        await teardownTuiGateState(lifecycle.activeGateState, BIN_AGENC);
+      } catch (error) {
+        errors.push(error);
+      }
+    } else if (lifecycle.pendingGateState !== null) {
+      try {
+        const pendingState = await lifecycle.pendingGateState;
+        lifecycle.activeGateState = pendingState;
+        await teardownTuiGateState(pendingState, BIN_AGENC);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    try {
+      await closeMock();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "TUI E2E signal cleanup failed");
+    }
+  });
   try {
     const names = applyScenarioFilters(await discoverScenarios(), process.argv.slice(2));
     if (names.length === 0) {
-      console.log(color("yellow", "no scenarios found under scenarios/"));
-      return 0;
+      console.error(color("red", "no scenarios matched the requested selection"));
+      return 1;
     }
-    ranScenarios = true;
     printGateHeader(names, mockServer);
     const state = { failed: [], skipped: [], passed: 0 };
     for (const name of names) {
-      await runScenarioEntry(name, state);
+      if (lifecycle.interrupted) return 1;
+      await runScenarioEntry(
+        name,
+        state,
+        gateBaseEnv,
+        injectedEnv,
+        lifecycle,
+      );
+      if (lifecycle.interrupted) return 1;
     }
     return printSummary(state);
   } finally {
-    restoreProcessEnv(originalEnv);
-    if (ranScenarios) restartDaemon();
-    await mockServer.close();
+    try {
+      await closeMock();
+    } finally {
+      uninstallSignalHandlers();
+    }
   }
 }
 
-main()
-  .then((code) => process.exit(code))
-  .catch((error) => {
-    console.error(color("red", `runner crashed: ${error?.stack ?? error}`));
-    process.exit(2);
-  });
+function isEntrypoint() {
+  if (process.argv[1] === undefined) return false;
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+}
+
+if (isEntrypoint()) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(color("red", `runner crashed: ${error?.stack ?? error}`));
+      if (error?.fatalIsolationFailure === true) {
+        process.exit(2);
+      }
+      process.exitCode = 2;
+    });
+}

--- a/runtime/scripts/check-tui-e2e/scenarios/11-yolo-tool-read.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/11-yolo-tool-read.mjs
@@ -14,7 +14,6 @@ export const meta = {
   args: ["--yolo"],
   timeoutMs: 90_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/12-yolo-tool-grep.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/12-yolo-tool-grep.mjs
@@ -13,7 +13,6 @@ export const meta = {
   args: ["--yolo"],
   timeoutMs: 90_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs
@@ -13,6 +13,8 @@ import {
 } from "../helpers/workbench-buffer-neovim.mjs";
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const NORMAL_MODE_FRAME =
+  /NORMAL|embedded Neovim[^\n]*normal, ready/iu;
 
 export const meta = {
   description: "Workbench BUFFER embedded Neovim provider opens, edits, saves, quits, and cleans child process.",
@@ -60,7 +62,7 @@ export default async function (session) {
     await sleep(80);
     await session.type("E2E_MARK", { perCharMs: 20 });
     session.send("\x1b");
-    await waitForFrameText(session, /NORMAL/u, "normal mode after E2E_MARK insert", 10_000);
+    await waitForFrameText(session, NORMAL_MODE_FRAME, "normal mode after E2E_MARK insert", 10_000);
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     session.send(":");
     await sleep(80);
@@ -100,7 +102,7 @@ export default async function (session) {
     await session.type("o", { perCharMs: 60 });
     await session.type("REGISTER_MARK", { perCharMs: 15 });
     session.send("\x1b");
-    await waitForFrameText(session, /NORMAL/u, "normal mode after register marker insert", 10_000);
+    await waitForFrameText(session, NORMAL_MODE_FRAME, "normal mode after register marker insert", 10_000);
     await session.type("\"ayy", { perCharMs: 60 });
     await sleep(120);
     await session.type("G", { perCharMs: 60 });
@@ -115,7 +117,7 @@ export default async function (session) {
     await session.type("o", { perCharMs: 60 });
     await session.type("MACRO_MARK", { perCharMs: 15 });
     session.send("\x1b");
-    await waitForFrameText(session, /NORMAL/u, "normal mode before stopping macro recording", 10_000);
+    await waitForFrameText(session, NORMAL_MODE_FRAME, "normal mode before stopping macro recording", 10_000);
     await session.type("q", { perCharMs: 60 });
     await sleep(80);
     await session.type("@a", { perCharMs: 60 });
@@ -132,9 +134,18 @@ export default async function (session) {
       await session.type("_AFTER", { perCharMs: 15 });
       await waitForFrameText(session, /RESIZE_MARK_AFTER/u, "resized Neovim grid");
       session.send("\x1b");
-      await waitForFrameText(session, /NORMAL/u, "normal mode after resized insert", 10_000);
+      await waitForFrameText(
+        session,
+        NORMAL_MODE_FRAME,
+        "normal mode after resized insert",
+        10_000,
+      );
       await session.waitForIdle({ idleWindow: 400, timeout: 10_000 });
-      await waitForFrameText(session, /NORMAL[\s\S]*RESIZE_MARK_AFTER|RESIZE_MARK_AFTER[\s\S]*NORMAL/u, "normal mode after resized grid");
+      await waitForFrameText(
+        session,
+        /normal[\s\S]*RESIZE_MARK_AFTER|RESIZE_MARK_AFTER[\s\S]*normal/iu,
+        "normal mode after resized grid",
+      );
       session.send(":");
       await sleep(80);
       await session.type("call writefile([getline('.'), string(col('.'))], 'resize-cursor.txt')", { perCharMs: 10 });
@@ -183,7 +194,7 @@ export default async function (session) {
     }
     await session.type("iCLICK_ROUTE_", { perCharMs: 15 });
     session.send("\x1b");
-    await waitForFrameText(session, /NORMAL/u, "normal mode after click-route insert", 10_000);
+    await waitForFrameText(session, NORMAL_MODE_FRAME, "normal mode after click-route insert", 10_000);
     await session.waitForIdle({ idleWindow: 400, timeout: 10_000 });
 
     session.send(":");
@@ -232,7 +243,7 @@ export default async function (session) {
     await sleep(80);
     await session.type("DIRTY_MARK", { perCharMs: 20 });
     session.send("\x1b");
-    await waitForFrameText(session, /NORMAL/u, "normal mode after dirty marker insert", 10_000);
+    await waitForFrameText(session, NORMAL_MODE_FRAME, "normal mode after dirty marker insert", 10_000);
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     session.send(":");
     await sleep(80);

--- a/runtime/scripts/check-tui-e2e/scenarios/125-at-picker-line-feed-enter.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/125-at-picker-line-feed-enter.mjs
@@ -13,18 +13,22 @@ export const meta = {
   description: "@ files/resources picker accepts line-feed Enter.",
   slimCwd: true,
   timeoutMs: 45_000,
-  useTempHome: true,
 };
 
 export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
 
-  await session.type("@", { perCharMs: 60 });
+  await session.type("@READ", { perCharMs: 60 });
   await session.waitFor(/FILES & RESOURCES/u, {
     timeout: 15_000,
     label: "files/resources picker",
   });
+  await waitForFrameText(
+    session,
+    /❯ \+ README\.md/u,
+    "filtered README.md picker selection",
+  );
 
   session.send("\n");
   await waitForFrameText(

--- a/runtime/scripts/check-tui-e2e/scenarios/126-at-picker-carriage-return-enter.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/126-at-picker-carriage-return-enter.mjs
@@ -21,7 +21,6 @@ export const meta = {
   description: "@ files/resources picker accepts carriage-return Enter.",
   slimCwd: true,
   timeoutMs: 45_000,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/129-onboard-command.mjs
@@ -14,7 +14,6 @@ export const meta = {
   description:
     "agenc onboard forces the setup wizard; completing it reaches a first model turn.",
   timeoutMs: 180_000,
-  useTempHome: true,
   slimCwd: true,
   sandboxMode: "danger-full-access",
   args: ["onboard"],

--- a/runtime/scripts/check-tui-e2e/scenarios/13-yolo-tool-glob.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/13-yolo-tool-glob.mjs
@@ -14,7 +14,6 @@ export const meta = {
   args: ["--yolo"],
   timeoutMs: 90_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/18-slash-init.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/18-slash-init.mjs
@@ -1,13 +1,14 @@
 /**
  * /init scenario.
  *
- * Generates AGENC.md for the current project. May write a file as a
- * side-effect; we only assert no crash and idle return. Per-scenario
- * temp HOME (Tier C) will let us assert the file content directly.
+ * Generates AGENC.md for the current project. The runner-owned slim cwd keeps
+ * that side effect out of the source checkout and is removed with the private
+ * scenario state.
  */
 export const meta = {
   description: "/init runs without crash and returns to idle.",
   timeoutMs: 60_000,
+  slimCwd: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/25-slash-commit.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/25-slash-commit.mjs
@@ -1,9 +1,9 @@
 /**
  * /commit scenario.
  *
- * Creates a git commit. Run from a repo where there are no staged changes
- * — should report "nothing to commit" and idle, not crash. This scenario
- * only asserts no crash.
+ * Runs in the runner-owned clean git fixture, so it can never consume or
+ * commit changes staged in the source checkout. It should report "nothing to
+ * commit" and idle, not crash.
  */
 export const meta = {
   description: "/commit handles no-staged-changes gracefully without crash.",

--- a/runtime/scripts/check-tui-e2e/scenarios/31-permission-accept.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/31-permission-accept.mjs
@@ -6,13 +6,6 @@
  * completed Bash stdout marker. This keeps the scenario scoped to tool
  * approval rather than sandbox file-write policy or assistant echo behavior.
  */
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-
-const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-permission-"));
-writeFileSync(path.join(slimCwd, "README.md"), "permission accept cwd\n", "utf8");
-writeFileSync(path.join(slimCwd, "package.json"), '{"private":true}\n', "utf8");
 
 const marker = "agenc-permission-accept-marker-3a9c";
 const prompt = [
@@ -27,10 +20,9 @@ function shellQuote(value) {
 export const meta = {
   description: "Permission overlay (default mode): accept path runs the tool.",
   timeoutMs: 120_000,
-  useTempHome: true,
+  slimCwd: true,
   sandboxMode: "danger-full-access",
   args: ["--permission-mode", "default"],
-  cwd: slimCwd,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/32-permission-deny.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/32-permission-deny.mjs
@@ -4,17 +4,11 @@
  * Default mode. Triggers Bash, denies the overlay, then verifies the command
  * never created its marker file in an isolated cwd.
  */
-import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import path from "node:path";
-
-const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-deny-"));
-writeFileSync(path.join(slimCwd, "README.md"), "permission deny cwd\n", "utf8");
-writeFileSync(path.join(slimCwd, "package.json"), '{"private":true}\n', "utf8");
 
 const marker = "agenc-permission-deny-marker-fe17";
 const markerFile = "permission-deny-output.txt";
-const markerPath = path.join(slimCwd, markerFile);
 
 function shellQuote(value) {
   return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -23,13 +17,13 @@ function shellQuote(value) {
 export const meta = {
   description: "Permission overlay (default mode): deny path closes overlay cleanly.",
   timeoutMs: 120_000,
-  useTempHome: true,
+  slimCwd: true,
   sandboxMode: "danger-full-access",
   args: ["--permission-mode", "default"],
-  cwd: slimCwd,
 };
 
 export default async function (session) {
+  const markerPath = path.join(session.cwd, markerFile);
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.type(

--- a/runtime/scripts/check-tui-e2e/scenarios/33-permission-always.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/33-permission-always.mjs
@@ -2,10 +2,10 @@
  * Permission overlay "always allow" scenario.
  *
  * Default mode. Triggers Bash, hits the overlay, sends "2" to accept
- * for the current session. The harness uses temp HOME isolation so the
+ * for the current session. The runner uses private HOME isolation so the
  * session-scoped policy entry doesn't leak.
  *
- * Uses a SLIM cwd (mkdtemp under /tmp with a single trivial file) so
+ * Uses a runner-owned slim cwd with a single trivial file so
  * the daemon's project-context auto-load doesn't bloat the token
  * budget. With agenc-core's runtime/ as cwd, AGENC.md and surrounding
  * files pushed >237k tokens and starved compaction; in /tmp/<empty>
@@ -15,13 +15,6 @@
  * completed without depending on the model echoing stdout in its final
  * assistant message.
  */
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-
-const slimCwd = mkdtempSync(path.join(tmpdir(), "agenc-tui-e2e-always-"));
-writeFileSync(path.join(slimCwd, "README.md"), "permission always cwd\n", "utf8");
-writeFileSync(path.join(slimCwd, "package.json"), '{"private":true}\n', "utf8");
 
 const marker = "agenc-permission-always-marker-bc42";
 const prompt = [
@@ -36,10 +29,9 @@ function shellQuote(value) {
 export const meta = {
   description: "Permission overlay (default mode): session approval runs the tool.",
   timeoutMs: 120_000,
-  useTempHome: true,
+  slimCwd: true,
   sandboxMode: "danger-full-access",
   args: ["--permission-mode", "default"],
-  cwd: slimCwd,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/34-yolo-tool-write.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/34-yolo-tool-write.mjs
@@ -12,7 +12,6 @@ export const meta = {
   args: ["--yolo"],
   timeoutMs: 90_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/35-yolo-tool-edit.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/35-yolo-tool-edit.mjs
@@ -12,7 +12,6 @@ export const meta = {
   args: ["--yolo"],
   timeoutMs: 120_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/36-print-mode-basic.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/36-print-mode-basic.mjs
@@ -5,56 +5,24 @@
  * cleanly. No TUI, no PTY needed. Catches: print-mode-only crashes,
  * stdout buffering bugs, exit-code regressions.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  createTempHome,
-  tempDaemonEnv,
-  teardownTempHome,
-  trustProjectForHome,
-} from "../harness.mjs";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc -p prints model reply and exits cleanly.",
   timeoutMs: 90_000,
 };
 
-export default async function () {
-  const { home, wsPort } = await createTempHome();
-  await trustProjectForHome(home, process.cwd());
-  try {
-    const result = await new Promise((resolve, reject) => {
-      const child = spawn(process.execPath, [BIN_AGENC, "--yolo", "-p", "say only the word HELLO and nothing else"], {
-        stdio: ["ignore", "pipe", "pipe"],
-        env: tempDaemonEnv(home, wsPort),
-      });
-      let stdout = "";
-      let stderr = "";
-      child.stdout.on("data", (d) => (stdout += d.toString()));
-      child.stderr.on("data", (d) => (stderr += d.toString()));
-      child.on("close", (code) => resolve({ code, stdout, stderr }));
-      child.on("error", reject);
-      setTimeout(() => {
-        child.kill("SIGTERM");
-        reject(new Error("print mode exceeded timeout"));
-      }, 80_000).unref();
-    });
-    if (result.code !== 0) {
-      throw new Error(
-        `print mode exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
-      );
-    }
-    if (result.stdout.trim().length === 0) {
-      throw new Error(
-        `print mode produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
-      );
-    }
-  } finally {
-    await teardownTempHome(home);
+export default async function (session) {
+  const result = await session.runAgenc(
+    ["--yolo", "-p", "say only the word HELLO and nothing else"],
+    { timeoutMs: 80_000 },
+  );
+  if (result.code !== 0) {
+    throw new Error(
+      `print mode exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
+    );
+  }
+  if (result.stdout.trim().length === 0) {
+    throw new Error(
+      `print mode produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
+    );
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/37-print-mode-yolo.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/37-print-mode-yolo.mjs
@@ -4,66 +4,30 @@
  * --yolo + -p should print and exit. Catches yolo-specific print-mode
  * regressions (permission elision, status-line drift in headless mode).
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  createTempHome,
-  tempDaemonEnv,
-  teardownTempHome,
-  trustProjectForHome,
-} from "../harness.mjs";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc --yolo -p prints model reply and exits cleanly.",
   timeoutMs: 90_000,
 };
 
-export default async function () {
-  const { home, wsPort } = await createTempHome();
-  await trustProjectForHome(home, process.cwd());
-  try {
-    const result = await new Promise((resolve, reject) => {
-      const child = spawn(
-        process.execPath,
-        [BIN_AGENC, "--yolo", "-p", "say only the word HELLO and nothing else"],
-        {
-          stdio: ["ignore", "pipe", "pipe"],
-          env: tempDaemonEnv(home, wsPort),
-        },
-      );
-      let stdout = "";
-      let stderr = "";
-      child.stdout.on("data", (d) => (stdout += d.toString()));
-      child.stderr.on("data", (d) => (stderr += d.toString()));
-      child.on("close", (code) => resolve({ code, stdout, stderr }));
-      child.on("error", reject);
-      setTimeout(() => {
-        child.kill("SIGTERM");
-        reject(new Error("yolo print mode exceeded timeout"));
-      }, 80_000).unref();
-    });
-    // Strip the noisy config-migration banner so the assertion error
-    // surfaces the actual cause.
-    const cleanStderr = result.stderr
-      .split("\n")
-      .filter((line) => !line.includes("[agenc:config-migration]"))
-      .join("\n");
-    if (result.code !== 0) {
-      throw new Error(
-        `yolo print mode exited code=${result.code}; stderr: ${cleanStderr.slice(0, 600)}`,
-      );
-    }
-    if (result.stdout.trim().length === 0) {
-      throw new Error(
-        `yolo print mode produced no stdout; stderr: ${cleanStderr.slice(0, 600)}`,
-      );
-    }
-  } finally {
-    await teardownTempHome(home);
+export default async function (session) {
+  const result = await session.runAgenc(
+    ["--yolo", "-p", "say only the word HELLO and nothing else"],
+    { timeoutMs: 80_000 },
+  );
+  // Strip the noisy config-migration banner so the assertion error
+  // surfaces the actual cause.
+  const cleanStderr = result.stderr
+    .split("\n")
+    .filter((line) => !line.includes("[agenc:config-migration]"))
+    .join("\n");
+  if (result.code !== 0) {
+    throw new Error(
+      `yolo print mode exited code=${result.code}; stderr: ${cleanStderr.slice(0, 600)}`,
+    );
+  }
+  if (result.stdout.trim().length === 0) {
+    throw new Error(
+      `yolo print mode produced no stdout; stderr: ${cleanStderr.slice(0, 600)}`,
+    );
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/38-cli-version.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/38-cli-version.mjs
@@ -5,31 +5,14 @@
  * regressions, runtime-side init that runs even on --version (it
  * shouldn't), wrapper-vs-runtime version drift.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc --version prints semver and exits cleanly.",
   timeoutMs: 10_000,
 };
 
-export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, "--version"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
+export default async function (session) {
+  const result = await session.runAgenc(["--version"], {
+    timeoutMs: 10_000,
   });
   if (result.code !== 0) {
     throw new Error(

--- a/runtime/scripts/check-tui-e2e/scenarios/39-cli-help.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/39-cli-help.mjs
@@ -3,31 +3,14 @@
  *
  * Prints usage to stdout, exits 0. Should NOT spin up the TUI.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc --help prints usage and exits cleanly.",
   timeoutMs: 10_000,
 };
 
-export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, "--help"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
+export default async function (session) {
+  const result = await session.runAgenc(["--help"], {
+    timeoutMs: 10_000,
   });
   if (result.code !== 0) {
     throw new Error(

--- a/runtime/scripts/check-tui-e2e/scenarios/40-daemon-status.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/40-daemon-status.mjs
@@ -5,72 +5,28 @@
  * regressions, daemon discovery via daemon.pid file, peer auth race
  * during status query.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc daemon status reports running PID.",
   timeoutMs: 10_000,
 };
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-async function statusOnce() {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, "daemon", "status"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
+export default async function (session) {
+  const result = await session.runAgenc(["daemon", "status"], {
+    timeoutMs: 10_000,
   });
-}
-
-async function restart() {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, "daemon", "restart"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
-    });
-    child.on("close", (code) => resolve(code));
-    child.on("error", reject);
-  });
-}
-
-export default async function () {
-  // Earlier scenarios that spawn `agenc` subprocesses sometimes leave the
-  // daemon in a state where it appears stopped to the next caller. The
-  // remediation in production is `agenc daemon restart`; the gate models
-  // that here. After restart, status MUST succeed — if it doesn't, the
-  // daemon is genuinely broken.
-  let lastResult = await statusOnce();
-  if (lastResult.code !== 0 || !/running/.test(lastResult.stdout)) {
-    await restart();
-    await sleep(1_500);
-    lastResult = await statusOnce();
-  }
-  if (lastResult.code !== 0) {
+  if (result.code !== 0) {
     throw new Error(
-      `daemon status exited ${lastResult.code} after retries; stderr: ${lastResult.stderr.slice(0, 200)}`,
+      `daemon status exited ${result.code}; stderr: ${result.stderr.slice(0, 200)}`,
     );
   }
-  if (!/running/.test(lastResult.stdout)) {
+  if (!/running/.test(result.stdout)) {
     throw new Error(
-      `daemon status did not report running after retries: "${lastResult.stdout}"`,
+      `daemon status did not report running: "${result.stdout}"`,
     );
   }
-  if (!/pid\s+\d+/.test(lastResult.stdout)) {
+  if (!/pid\s+\d+/.test(result.stdout)) {
     throw new Error(
-      `daemon status did not include PID: "${lastResult.stdout}"`,
+      `daemon status did not include PID: "${result.stdout}"`,
     );
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/41-mcp-serve-noop.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/41-mcp-serve-noop.mjs
@@ -8,7 +8,6 @@
  * Per GAP-MCP-02 the `mcp` CLI only supports `serve` today; the other
  * subcommands fail. This scenario validates the one that works.
  */
-import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,29 +22,37 @@ export const meta = {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-export default async function () {
-  const child = spawn(process.execPath, [BIN_AGENC, "mcp", "serve"], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: process.env,
-  });
+export default async function (session) {
+  const child = await session.spawnTracked(
+    process.execPath,
+    [BIN_AGENC, "mcp", "serve"],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
   let stdout = "";
   let stderr = "";
   let earlyExit = null;
+  let childError = null;
   child.stdout.on("data", (d) => (stdout += d.toString()));
   child.stderr.on("data", (d) => (stderr += d.toString()));
   child.on("close", (code) => (earlyExit = code));
+  child.on("error", (error) => (childError = error));
   // 3 seconds is enough for a bind error to surface.
   await sleep(3_000);
+  if (childError !== null) {
+    throw childError;
+  }
   if (earlyExit !== null && earlyExit !== 0) {
     throw new Error(
       `agenc mcp serve exited early code=${earlyExit}; stderr: ${stderr.slice(0, 400)}`,
     );
   }
-  child.kill("SIGTERM");
-  await Promise.race([
-    new Promise((r) => child.on("close", r)),
-    sleep(2_000).then(() => child.kill("SIGKILL")),
-  ]);
+  const termination = await session.terminateTrackedChild(child, {
+    graceMs: 2_000,
+    forceKillGraceMs: 2_000,
+  });
+  if (termination?.error) {
+    throw termination.error;
+  }
   // Crash patterns in stderr (the server writes status to stderr).
   if (/Cannot find module|TypeError|ReferenceError|UnhandledPromiseRejection/.test(stderr)) {
     throw new Error(`mcp serve emitted crash pattern: ${stderr.slice(0, 400)}`);

--- a/runtime/scripts/check-tui-e2e/scenarios/42-yolo-multi-tool-pipeline.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/42-yolo-multi-tool-pipeline.mjs
@@ -10,7 +10,6 @@ export const meta = {
   args: ["--yolo"],
   timeoutMs: 120_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/44-yolo-cwd-context.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/44-yolo-cwd-context.mjs
@@ -5,23 +5,10 @@
  * the agenc process was launched from. Catches: cwd not propagated to
  * subagent, daemon-side cwd reset, child-shell cd before exec.
  */
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-// The harness launches agenc with cwd = process.cwd() (the runtime
-// workspace dir when running `npm run check:tui-e2e`). We expect that
-// path back from the model's pwd output.
-const expectedCwd = path.resolve(SCRIPT_DIR, "..", "..", "..");
-
 export const meta = {
   description: "--yolo: model uses Bash pwd, output matches launch cwd.",
   args: ["--yolo"],
   timeoutMs: 120_000,
-  // Intentionally NOT using slimCwd — this scenario tests cwd
-  // propagation to subagent, so it MUST run with the runtime cwd that
-  // matches the SCRIPT_DIR-derived expectedCwd assertion below.
-  useTempHome: true,
 };
 
 export default async function (session) {
@@ -32,7 +19,7 @@ export default async function (session) {
   );
   await session.submit();
   await session.waitForIdle({ idleWindow: 4_000, timeout: 120_000 });
-  await session.assertRolloutToolOutput(expectedCwd, {
+  await session.assertRolloutToolOutput(session.cwd, {
     label: "pwd output matches launch cwd",
     toolName: "exec_command",
   });

--- a/runtime/scripts/check-tui-e2e/scenarios/48-arrow-history-recall.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/48-arrow-history-recall.mjs
@@ -9,7 +9,6 @@
 export const meta = {
   description: "Up arrow recalls previous input from history.",
   timeoutMs: 90_000,
-  useTempHome: true,
   slimCwd: true,
 };
 

--- a/runtime/scripts/check-tui-e2e/scenarios/49-paste-multiline.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/49-paste-multiline.mjs
@@ -16,7 +16,6 @@ export const meta = {
   description: "Multi-line bracketed paste is accepted without crash.",
   timeoutMs: 90_000,
   args: ["--yolo"],
-  useTempHome: true,
   slimCwd: true,
 };
 

--- a/runtime/scripts/check-tui-e2e/scenarios/55-stdin-not-tty.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/55-stdin-not-tty.mjs
@@ -14,63 +14,28 @@
  * 03 (which inspects the rollout for the routing decision regardless of
  * how slow the model responds).
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  createTempHome,
-  tempDaemonEnv,
-  teardownTempHome,
-  trustProjectForHome,
-} from "../harness.mjs";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 const TIMEOUT_MS = 240_000;
 
 export const meta = {
   description: "Piped stdin (no TTY) routes through one-shot CLI path.",
   timeoutMs: TIMEOUT_MS + 30_000,
-  useTempHome: true,
   slimCwd: true,
 };
 
 export default async function (session) {
-  const { home, wsPort } = await createTempHome();
-  await trustProjectForHome(home, session.cwd);
-  try {
-    const result = await new Promise((resolve, reject) => {
-      const child = spawn(process.execPath, [BIN_AGENC, "--yolo"], {
-        cwd: session.cwd,
-        stdio: ["pipe", "pipe", "pipe"],
-        env: tempDaemonEnv(home, wsPort),
-      });
-      let stdout = "";
-      let stderr = "";
-      child.stdout.on("data", (d) => (stdout += d.toString()));
-      child.stderr.on("data", (d) => (stderr += d.toString()));
-      child.on("close", (code) => resolve({ code, stdout, stderr }));
-      child.on("error", reject);
-      child.stdin.write("reply with the single word PIPED");
-      child.stdin.end();
-      setTimeout(() => {
-        child.kill("SIGTERM");
-        reject(new Error("piped stdin exceeded timeout"));
-      }, TIMEOUT_MS).unref();
-    });
-    if (result.code !== 0) {
-      throw new Error(
-        `piped stdin exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
-      );
-    }
-    if (result.stdout.trim().length === 0) {
-      throw new Error(
-        `piped stdin produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
-      );
-    }
-  } finally {
-    await teardownTempHome(home);
+  const result = await session.runAgenc(["--yolo"], {
+    cwd: session.cwd,
+    input: "reply with the single word PIPED",
+    timeoutMs: TIMEOUT_MS,
+  });
+  if (result.code !== 0) {
+    throw new Error(
+      `piped stdin exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
+    );
+  }
+  if (result.stdout.trim().length === 0) {
+    throw new Error(
+      `piped stdin produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
+    );
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/57-cli-resume-no-session.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/57-cli-resume-no-session.mjs
@@ -12,37 +12,16 @@
  * exact error message would re-do work the resumeTUI unit tests already
  * cover; this scenario gates the non-TTY hang regression.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc --resume <bogus> exits cleanly with not-found message.",
   timeoutMs: 20_000,
 };
 
-export default async function () {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      [BIN_AGENC, "--resume", "session-that-does-not-exist-7c3f"],
-      { stdio: ["ignore", "pipe", "pipe"], env: process.env },
-    );
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-    setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error("--resume exceeded timeout"));
-    }, 18_000).unref();
-  });
+export default async function (session) {
+  const result = await session.runAgenc(
+    ["--resume", "session-that-does-not-exist-7c3f"],
+    { timeoutMs: 18_000 },
+  );
   if (result.code === 0) {
     throw new Error(`expected non-zero exit for bogus --resume, got 0`);
   }

--- a/runtime/scripts/check-tui-e2e/scenarios/58-cli-no-tui-flag.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/58-cli-no-tui-flag.mjs
@@ -5,63 +5,28 @@
  * one-shot path even inside a TTY. Verify it works and produces
  * model output to stdout.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import {
-  createTempHome,
-  tempDaemonEnv,
-  teardownTempHome,
-  trustProjectForHome,
-} from "../harness.mjs";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "--no-tui forces daemon one-shot path; produces stdout.",
   timeoutMs: 120_000,
-  useTempHome: true,
   slimCwd: true,
 };
 
 export default async function (session) {
-  const { home, wsPort } = await createTempHome();
-  await trustProjectForHome(home, session.cwd);
-  try {
-    const result = await new Promise((resolve, reject) => {
-      const child = spawn(
-        process.execPath,
-        [BIN_AGENC, "--yolo", "--no-tui", "reply with the single word NOTUI"],
-        {
-          cwd: session.cwd,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: tempDaemonEnv(home, wsPort),
-        },
-      );
-      let stdout = "";
-      let stderr = "";
-      child.stdout.on("data", (d) => (stdout += d.toString()));
-      child.stderr.on("data", (d) => (stderr += d.toString()));
-      child.on("close", (code) => resolve({ code, stdout, stderr }));
-      child.on("error", reject);
-      setTimeout(() => {
-        child.kill("SIGTERM");
-        reject(new Error("--no-tui exceeded timeout"));
-      }, 110_000).unref();
-    });
-    if (result.code !== 0) {
-      throw new Error(
-        `--no-tui exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
-      );
-    }
-    if (result.stdout.trim().length === 0) {
-      throw new Error(
-        `--no-tui produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
-      );
-    }
-  } finally {
-    await teardownTempHome(home);
+  const result = await session.runAgenc(
+    ["--yolo", "--no-tui", "reply with the single word NOTUI"],
+    {
+      cwd: session.cwd,
+      timeoutMs: 110_000,
+    },
+  );
+  if (result.code !== 0) {
+    throw new Error(
+      `--no-tui exited code=${result.code}; stderr: ${result.stderr.slice(0, 400)}`,
+    );
+  }
+  if (result.stdout.trim().length === 0) {
+    throw new Error(
+      `--no-tui produced no stdout; stderr: ${result.stderr.slice(0, 400)}`,
+    );
   }
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/59-daemon-stop-clean.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/59-daemon-stop-clean.mjs
@@ -4,40 +4,16 @@
  * Catches: stop command leaves the daemon zombie, status command
  * misreports state after stop.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-function spawnSyncAgenc(args, timeoutMs = 15_000) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, ...args], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-    setTimeout(() => {
-      child.kill("SIGTERM");
-      reject(new Error(`${args.join(" ")} timeout`));
-    }, timeoutMs).unref();
-  });
-}
-
-async function waitForStoppedStatus(timeoutMs = 10_000) {
+async function waitForStoppedStatus(session, timeoutMs = 10_000) {
   const deadline = Date.now() + timeoutMs;
   let lastStatus = null;
   while (Date.now() < deadline) {
-    lastStatus = await spawnSyncAgenc(["daemon", "status"]);
+    lastStatus = await session.runAgenc(
+      ["daemon", "status"],
+      { timeoutMs: 15_000 },
+    );
     if (lastStatus.code !== 0 || !/running/.test(lastStatus.stdout)) {
       return lastStatus;
     }
@@ -50,31 +26,34 @@ async function waitForStoppedStatus(timeoutMs = 10_000) {
 
 export const meta = {
   description: "daemon stop → status reports stopped, then start works.",
-  timeoutMs: 30_000,
+  timeoutMs: 90_000,
 };
 
-export default async function () {
+export default async function (session) {
   // Stop
-  const stopResult = await spawnSyncAgenc(["daemon", "stop"], 20_000);
+  const stopResult = await session.runAgenc(
+    ["daemon", "stop"],
+    { timeoutMs: 20_000 },
+  );
   if (stopResult.code !== 0) {
     throw new Error(
       `daemon stop failed (${stopResult.code}): ${stopResult.stderr}${stopResult.stdout}`,
     );
   }
   // Status should report stopped (exit non-zero or message)
-  const stoppedStatus = await waitForStoppedStatus();
+  const stoppedStatus = await waitForStoppedStatus(session);
   if (stoppedStatus.code === 0 && /running/.test(stoppedStatus.stdout)) {
     throw new Error(
       `daemon status shows running after stop: ${stoppedStatus.stdout}`,
     );
   }
-  // Start back up so the rest of the gate keeps working.
-  const startResult = await spawnSyncAgenc(["daemon", "start"]);
-  if (startResult.code !== 0) {
-    throw new Error(`daemon start failed: ${startResult.stderr}`);
-  }
+  // Restore the runner's foreground ownership before continuing.
+  await session.startGateDaemon();
   await sleep(5_000);
-  const runStatus = await spawnSyncAgenc(["daemon", "status"]);
+  const runStatus = await session.runAgenc(
+    ["daemon", "status"],
+    { timeoutMs: 15_000 },
+  );
   if (!/running/.test(runStatus.stdout)) {
     throw new Error(`daemon didn't restart cleanly: ${runStatus.stdout}`);
   }

--- a/runtime/scripts/check-tui-e2e/scenarios/60-cli-runtime-version.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/60-cli-runtime-version.mjs
@@ -5,35 +5,19 @@
  * version. Catches build regressions where the runtime entry is
  * missing or fails to import.
  */
-import { spawn } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description: "agenc-runtime daemon-related entry imports and runs.",
   timeoutMs: 10_000,
 };
 
-export default async function () {
+export default async function (session) {
   // Use `agenc daemon status` as the smoke — it imports the same daemon
   // surface as `agenc-runtime` (a separate npm bin pointing at a thin
   // wrapper).
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [BIN_AGENC, "daemon", "status"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: process.env,
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-    child.on("error", reject);
-  });
+  const result = await session.runAgenc(
+    ["daemon", "status"],
+    { timeoutMs: 10_000 },
+  );
   // Don't care about the status — care that it didn't crash with
   // a Node-level error. Any code 0 or "stopped/running" output is fine.
   if (/Cannot find module|TypeError|ReferenceError/.test(result.stderr)) {

--- a/runtime/scripts/check-tui-e2e/scenarios/75-slash-skills.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/75-slash-skills.mjs
@@ -8,7 +8,6 @@ export const meta = {
   description: "/skills renders skill list, returns to idle without crash.",
   timeoutMs: 30_000,
   slimCwd: true,
-  useTempHome: true,
 };
 
 export default async function (session) {

--- a/runtime/scripts/check-tui-e2e/scenarios/76-slash-diff.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/76-slash-diff.mjs
@@ -1,11 +1,13 @@
 /**
  * /diff scenario.
  *
- * `/diff` shows pending file changes (or a diff over a range). Smoke-test
- * the command loads + idles without crash.
+ * `/diff` shows pending file changes (or a diff over a range). The runner
+ * seeds a deterministic tracked modification so this proves changed-file
+ * rendering instead of only opening the empty-state panel.
  */
 export const meta = {
   description: "/diff renders diff UI, returns to idle without crash.",
+  dirtyCwd: true,
   timeoutMs: 30_000,
 };
 
@@ -13,5 +15,9 @@ export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.submitSlashCommand("/diff");
+  await session.waitFor(/DIFF[\s\S]*M diff-fixture\.txt/u, {
+    timeout: 15_000,
+    label: "/diff surface with tracked fixture",
+  });
   await session.waitForIdle({ timeout: 15_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/84-slash-hooks.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/84-slash-hooks.mjs
@@ -1,17 +1,27 @@
 /**
  * /hooks scenario.
  *
- * Opens the hooks editor (pre/post-tool hooks). Smoke-test that the
- * command loads + idles without crashing.
+ * Opens the hooks editor (pre/post-tool hooks). A private daemon has no live
+ * agent session until the first turn, so seed one before inspecting its real
+ * hooks runtime.
  */
 export const meta = {
   description: "/hooks opens hooks editor, returns to idle.",
-  timeoutMs: 30_000,
+  sandboxMode: "danger-full-access",
+  timeoutMs: 90_000,
 };
 
 export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
+  await session.type("hello");
+  await session.submit();
+  await session.waitForAssistantReply({ timeout: 45_000 });
+  await session.waitForPrompt({ timeout: 30_000 });
   await session.submitSlashCommand("/hooks");
+  await session.waitFor(/AgenC Hooks|Commands: \/hooks/u, {
+    timeout: 15_000,
+    label: "live hooks runtime surface",
+  });
   await session.waitForIdle({ timeout: 15_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/87-daemon-restart-during-session.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/87-daemon-restart-during-session.mjs
@@ -17,14 +17,6 @@
  * no auto-reconnect path. Filed as GAP-DMN-PERSISTENT-RECONNECT.
  * Unskip when reconnect (or graceful-error-with-retry) lands.
  */
-import { spawnSync } from "node:child_process";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const RUNTIME_DIR = path.resolve(SCRIPT_DIR, "..", "..", "..");
-const BIN_AGENC = path.join(RUNTIME_DIR, "dist", "bin", "agenc.js");
-
 export const meta = {
   description:
     "TUI survives a daemon restart between turns (or fails cleanly).",
@@ -43,10 +35,7 @@ export default async function (session) {
   // Restart the daemon out-of-band — same operation that any external
   // tool, upgrade script, or `agenc daemon restart` invocation would
   // perform.
-  spawnSync(process.execPath, [BIN_AGENC, "daemon", "restart"], {
-    encoding: "utf8",
-    timeout: 30_000,
-  });
+  await session.restartGateDaemon();
 
   await session.type("and again");
   await session.submit();

--- a/runtime/scripts/check-tui-e2e/scenarios/88-long-token-input-wrap.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/88-long-token-input-wrap.mjs
@@ -1,7 +1,6 @@
 export const meta = {
   description: "long unbroken prompt input wraps inside the prompt box",
   args: ["--yolo"],
-  useTempHome: true,
   timeoutMs: 30_000,
 };
 

--- a/runtime/scripts/check-tui-e2e/scenarios/97-slash-menu-navigation.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/97-slash-menu-navigation.mjs
@@ -12,7 +12,6 @@ export const meta = {
     AGENC_TUI_WORKBENCH: "1",
     AGENC_TUI_GLYPHS: "ascii",
   },
-  useTempHome: true,
 };
 
 function sleep(ms) {

--- a/runtime/scripts/check-tui-e2e/scenarios/98-prompt-yolo-stays-literal.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/98-prompt-yolo-stays-literal.mjs
@@ -20,7 +20,6 @@ export const meta = {
   ],
   timeoutMs: 60_000,
   slimCwd: true,
-  useTempHome: true,
   sandboxMode: "danger-full-access",
 };
 

--- a/runtime/scripts/check-tui-e2e/scenarios/99-delimiter-permission-mode-stays-literal.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/99-delimiter-permission-mode-stays-literal.mjs
@@ -21,7 +21,6 @@ export const meta = {
   ],
   timeoutMs: 60_000,
   slimCwd: true,
-  useTempHome: true,
   sandboxMode: "danger-full-access",
 };
 

--- a/runtime/scripts/check-tui-runtime-startup.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.mjs
@@ -16,6 +16,14 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import {
+  createTuiGateState,
+  installTuiGateSignalHandlers,
+  startTuiGateDaemon,
+  teardownTuiGateState,
+  writeTuiGateTrust,
+} from "./tui-gate-state.mjs";
+
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = path.dirname(SCRIPT_PATH);
 const TRUSTED_REPOSITORY_ROOT = path.resolve(SCRIPT_DIR, "../..");
@@ -28,10 +36,9 @@ const MAX_PTY_OUTPUT_BYTES = 1024 * 1024;
 // timeout, but leave enough headroom that the pre-commit build immediately
 // followed by this smoke does not fail a healthy first viewport.
 const FIRST_PAINT_MS = 3_000;
-// A rebuild makes the next CLI reap a build-skewed daemon for up to 5s before
-// starting its replacement. The throwaway warmup must outlive that reap
-// window plus the ordinary first-paint budget; otherwise it kills the CLI
-// midway through recovery and hands the measured probe the same cold start.
+// The first CLI in a private gate home must cold-start its daemon before it can
+// paint. Keep the throwaway warmup comfortably above the measured first-paint
+// budget so every measured viewport exercises warm runtime/daemon caches.
 export const COLD_WARMUP_FIRST_PAINT_MS = 5_000 + FIRST_PAINT_MS;
 const POST_REPLY_MS = 1_500;
 const SIGTERM_GRACE_MS = 1_000;
@@ -424,42 +431,6 @@ function scanOutput(buffer) {
   return matches;
 }
 
-function ptyEnvironment() {
-  const allowed = [
-    "AGENC_AUTH_BACKEND",
-    "AGENC_CONFIG_DIR",
-    "AGENC_HOME",
-    "CI",
-    "HOME",
-    "LANG",
-    "LC_ALL",
-    "LOGNAME",
-    "NO_COLOR",
-    "PATH",
-    "SHELL",
-    "TEMP",
-    "TERM",
-    "TMP",
-    "TMPDIR",
-    "TZ",
-    "USER",
-    "USERPROFILE",
-    "XDG_CACHE_HOME",
-    "XDG_CONFIG_HOME",
-    "XDG_DATA_HOME",
-    "XDG_STATE_HOME",
-  ];
-  const environment = Object.fromEntries(
-    allowed.flatMap((name) => process.env[name] === undefined ? [] : [[name, process.env[name]]]),
-  );
-  return {
-    ...environment,
-    AGENC_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-    NODE_OPTIONS: "",
-    TERM: "xterm-256color",
-  };
-}
-
 function safePtyKill(term, signal) {
   try {
     if (process.platform === "win32") term.kill();
@@ -507,8 +478,9 @@ export async function observePtySession(term, {
   });
   let exited = false;
   let exitValue;
+  let exitSubscription;
   const exitPromise = new Promise((resolve) => {
-    term.onExit((value) => {
+    exitSubscription = term.onExit((value) => {
       exited = true;
       exitValue = value;
       resolve(value);
@@ -540,10 +512,12 @@ export async function observePtySession(term, {
       ? { kind: "exit", exit: exitValue }
       : await waitForPhaseOrExit(exitPromise, sigtermGraceMs);
     let survivedTermination = false;
+    let survivedForceKill = false;
     if (graceful.kind !== "exit") {
       survivedTermination = true;
       safePtyKill(term, "SIGKILL");
-      await waitForPhaseOrExit(exitPromise, forceKillGraceMs);
+      const forced = await waitForPhaseOrExit(exitPromise, forceKillGraceMs);
+      survivedForceKill = forced.kind !== "exit";
     }
     const gracefulExit = graceful.kind === "exit" ? graceful.exit : null;
     const invalidTerminationExit = terminationRequested && gracefulExit !== null && !(
@@ -560,6 +534,7 @@ export async function observePtySession(term, {
       earlyFailure === null &&
       !overflow &&
       !survivedTermination &&
+      !survivedForceKill &&
       !invalidTerminationExit &&
       semanticReadiness &&
       matches.length === 0
@@ -567,7 +542,11 @@ export async function observePtySession(term, {
       console.log(green(`[3/4] ${label} ${viewport.cols}x${viewport.rows}: clean startup`));
       return true;
     }
-    if (resultIgnored === true) {
+    if (
+      resultIgnored === true &&
+      !survivedTermination &&
+      !survivedForceKill
+    ) {
       console.log(
         `[3/4] ${label} ${viewport.cols}x${viewport.rows}: cold start absorbed (result ignored)`,
       );
@@ -577,6 +556,7 @@ export async function observePtySession(term, {
     if (earlyFailure !== null) console.error(red(`        ${earlyFailure}`));
     if (overflow) console.error(red("        PTY output exceeded 1 MiB"));
     if (survivedTermination) console.error(red("        PTY survived the SIGTERM grace period"));
+    if (survivedForceKill) console.error(red("        PTY survived the SIGKILL grace period"));
     if (!semanticReadiness) {
       console.error(red("        PTY never rendered the AgenC interactive screen invariant"));
     }
@@ -592,12 +572,29 @@ export async function observePtySession(term, {
     if (tail !== "") console.error(tail);
     return false;
   } finally {
-    dataSubscription.dispose();
-    if (!exited) safePtyKill(term, "SIGKILL");
+    try {
+      if (!exited) {
+        safePtyKill(term, "SIGKILL");
+        const finalExit = await waitForPhaseOrExit(exitPromise, forceKillGraceMs);
+        if (finalExit.kind !== "exit") {
+          throw new Error(`${label ?? "TUI"} PTY survived the final SIGKILL grace period`);
+        }
+      }
+    } finally {
+      dataSubscription.dispose();
+      exitSubscription?.dispose?.();
+    }
   }
 }
 
-async function ptyStartupSmoke(label, args, viewport, opts = {}) {
+async function ptyStartupSmoke(
+  label,
+  args,
+  viewport,
+  env,
+  opts = {},
+  activeTerms = null,
+) {
   const pty = loadPtyModule();
   console.log(
     `[3/4] PTY spawn ${label} ${viewport.cols}x${viewport.rows}: ${args.join(" ") || "(no args)"}`,
@@ -607,9 +604,48 @@ async function ptyStartupSmoke(label, args, viewport, opts = {}) {
     cols: viewport.cols,
     rows: viewport.rows,
     cwd: RUNTIME_DIR,
-    env: ptyEnvironment(),
+    env,
   });
-  return observePtySession(term, { label, viewport, ...opts });
+  let signalRecord = null;
+  if (activeTerms !== null) {
+    signalRecord = {
+      term,
+      exited: false,
+      exitPromise: null,
+      subscription: null,
+    };
+    signalRecord.exitPromise = new Promise((resolve) => {
+      signalRecord.subscription = term.onExit((value) => {
+        signalRecord.exited = true;
+        resolve(value);
+      });
+    });
+    activeTerms.add(signalRecord);
+  }
+  try {
+    return await observePtySession(term, { label, viewport, ...opts });
+  } finally {
+    if (signalRecord !== null) {
+      activeTerms.delete(signalRecord);
+      signalRecord.subscription?.dispose?.();
+    }
+  }
+}
+
+async function terminateStartupPty(record) {
+  if (record.exited) return;
+  safePtyKill(record.term, "SIGTERM");
+  const graceful = await Promise.race([
+    record.exitPromise.then(() => true),
+    delay(SIGTERM_GRACE_MS).then(() => record.exited),
+  ]);
+  if (graceful) return;
+  safePtyKill(record.term, "SIGKILL");
+  const forced = await Promise.race([
+    record.exitPromise.then(() => true),
+    delay(FORCE_KILL_GRACE_MS).then(() => record.exited),
+  ]);
+  if (!forced) throw new Error("startup PTY survived signal cleanup SIGKILL");
 }
 
 async function main() {
@@ -639,27 +675,97 @@ async function main() {
   }
   console.log(green("[2/4] built TUI artifact returned a verified import proof"));
 
-  // Warmup: the very first PTY spawn after a fresh `npm run build` pays cold
-  // module/daemon-attach caches and may also spend 5s reaping a build-skewed
-  // daemon. Give this throwaway spawn enough time to finish that recovery so
-  // every MEASURED scenario asserts the real first-paint budget against warm
-  // caches; only the warmup result is deliberately ignored.
-  await ptyStartupSmoke("warmup", [], VIEWPORTS[0], {
-    firstPaintMs: COLD_WARMUP_FIRST_PAINT_MS,
-    resultIgnored: true,
+  const gateStatePromise = createTuiGateState({
+    prefix: "agenc-tui-startup-",
   });
+  let gateState = null;
+  const activeTerms = new Set();
+  let interrupted = false;
+  const uninstallSignalHandlers = installTuiGateSignalHandlers(async () => {
+    interrupted = true;
+    const termResults = await Promise.allSettled(
+      [...activeTerms].map(terminateStartupPty),
+    );
+    const errors = termResults
+      .filter((result) => result.status === "rejected")
+      .map((result) => result.reason);
+    try {
+      const state = gateState ?? await gateStatePromise;
+      await teardownTuiGateState(state, BIN_AGENC_PATH);
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "TUI startup signal cleanup failed");
+    }
+  });
+  try {
+    gateState = await gateStatePromise;
+    await writeTuiGateTrust(gateState.env, [RUNTIME_DIR]);
+    if (interrupted) return 1;
+    await startTuiGateDaemon(gateState, BIN_AGENC_PATH);
+    if (interrupted) return 1;
 
-  const results = [];
-  for (const viewport of VIEWPORTS) {
-    results.push(await ptyStartupSmoke("agenc", [], viewport));
-    results.push(await ptyStartupSmoke("agenc --yolo", ["--yolo"], viewport));
+    // Warmup: the first PTY in this invocation pays cold module and private
+    // daemon startup costs. Only its functional result is ignored; teardown
+    // and process-exit invariants remain mandatory.
+    const warmupCleanedUp = await ptyStartupSmoke(
+      "warmup",
+      [],
+      VIEWPORTS[0],
+      gateState.env,
+      {
+        firstPaintMs: COLD_WARMUP_FIRST_PAINT_MS,
+        resultIgnored: true,
+      },
+      activeTerms,
+    );
+    if (interrupted) return 1;
+    if (!warmupCleanedUp) {
+      console.error(red("[4/4] TUI runtime startup smoke FAILED"));
+      return 1;
+    }
+
+    const results = [];
+    for (const viewport of VIEWPORTS) {
+      if (interrupted) return 1;
+      results.push(
+        await ptyStartupSmoke(
+          "agenc",
+          [],
+          viewport,
+          gateState.env,
+          {},
+          activeTerms,
+        ),
+      );
+      if (interrupted) return 1;
+      results.push(
+        await ptyStartupSmoke(
+          "agenc --yolo",
+          ["--yolo"],
+          viewport,
+          gateState.env,
+          {},
+          activeTerms,
+        ),
+      );
+      if (interrupted) return 1;
+    }
+    if (results.every(Boolean)) {
+      console.log(green("[4/4] TUI runtime startup smoke passed"));
+      return 0;
+    }
+    console.error(red("[4/4] TUI runtime startup smoke FAILED"));
+    return 1;
+  } finally {
+    try {
+      const state = gateState ?? await gateStatePromise;
+      await teardownTuiGateState(state, BIN_AGENC_PATH);
+    } finally {
+      uninstallSignalHandlers();
+    }
   }
-  if (results.every(Boolean)) {
-    console.log(green("[4/4] TUI runtime startup smoke passed"));
-    return 0;
-  }
-  console.error(red("[4/4] TUI runtime startup smoke FAILED"));
-  return 1;
 }
 
 function isEntrypoint() {

--- a/runtime/scripts/check-tui-runtime-startup.test.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.test.mjs
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -10,6 +19,15 @@ import {
   observePtySession,
   runImportProbe,
 } from "./check-tui-runtime-startup.mjs";
+import {
+  createTuiGateProject,
+  createTuiGateState,
+  startTuiGateDaemon,
+  teardownTuiGateState,
+  TUI_GATE_TRUST_TIMESTAMP,
+  tuiGateEnvironment,
+  writeTuiGateTrust,
+} from "./tui-gate-state.mjs";
 
 async function probeFixture(source) {
   const root = mkdtempSync(path.join(tmpdir(), "agenc-tui-import-proof-"));
@@ -77,11 +95,389 @@ test("candidate iterator poisoning cannot skip export requirements", async () =>
 
 const SEMANTIC_PAINT = `\x1b[?2004h${" ".repeat(128)}AgenC interactive screen`;
 
-test("cold warmup outlives the build-skew daemon reap window", () => {
+test("cold warmup leaves headroom for private daemon startup", () => {
   assert.ok(COLD_WARMUP_FIRST_PAINT_MS > 5_000);
 });
 
-function fakeTerm({ earlyExit = false, terminationExit, paint = SEMANTIC_PAINT, spontaneousExitMs } = {}) {
+test("startup PTYs replace poisoned operator roots with private gate state", () => {
+  const operatorRoot = path.join(tmpdir(), "operator-state");
+  const privateHome = path.join(tmpdir(), "private-startup-state");
+  const env = tuiGateEnvironment(privateHome, {
+    AGENC_AUTH_BACKEND: "remote",
+    AGENC_CONFIG_DIR: path.join(operatorRoot, "config"),
+    AGENC_DAEMON_WEBSOCKET_HOST: "0.0.0.0",
+    AGENC_DAEMON_WEBSOCKET_PORT: "7766",
+    AGENC_HOME: path.join(operatorRoot, ".agenc"),
+    AGENC_ONBOARDING: "force",
+    GIT_OPTIONAL_LOCKS: "1",
+    HOME: operatorRoot,
+    OPENAI_API_KEY: "operator-secret",
+    OPENAI_COMPATIBLE_API_KEY: "operator-compatible-secret",
+    OPENAI_COMPATIBLE_BASE_URL: "https://operator.invalid/v1",
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    TMPDIR: path.join(operatorRoot, "tmp"),
+    XDG_CONFIG_HOME: path.join(operatorRoot, "xdg"),
+  });
+
+  assert.equal(env.HOME, path.resolve(privateHome));
+  assert.equal(env.AGENC_HOME, path.join(path.resolve(privateHome), ".agenc"));
+  assert.equal(env.AGENC_CONFIG_DIR, env.AGENC_HOME);
+  assert.equal(env.TMPDIR, path.join(path.resolve(privateHome), "tmp"));
+  assert.equal(env.XDG_CONFIG_HOME, path.join(path.resolve(privateHome), ".config"));
+  assert.equal(env.AGENC_AUTH_BACKEND, "local");
+  assert.equal(env.AGENC_DAEMON_WEBSOCKET_HOST, "127.0.0.1");
+  assert.equal(env.AGENC_DAEMON_WEBSOCKET_PORT, "0");
+  assert.equal(env.AGENC_ONBOARDING, "0");
+  assert.equal(env.GIT_CONFIG_NOSYSTEM, "1");
+  assert.equal(env.GIT_OPTIONAL_LOCKS, "0");
+  assert.equal(env.GIT_TERMINAL_PROMPT, "0");
+  assert.equal(env.OPENAI_API_KEY, undefined);
+  assert.equal(env.OPENAI_COMPATIBLE_API_KEY, undefined);
+  assert.equal(env.OPENAI_COMPATIBLE_BASE_URL, undefined);
+});
+
+test("mock provider configuration must be injected explicitly", () => {
+  const privateHome = path.join(tmpdir(), "private-provider-state");
+  const env = tuiGateEnvironment(
+    privateHome,
+    {
+      OPENAI_COMPATIBLE_API_KEY: "operator-secret",
+      PATH: process.env.PATH,
+    },
+    {
+      AGENC_PROVIDER: "openai-compatible",
+      OPENAI_COMPATIBLE_API_KEY: "local-test-key",
+      OPENAI_COMPATIBLE_BASE_URL: "http://127.0.0.1:43210/v1",
+    },
+  );
+  assert.equal(env.OPENAI_COMPATIBLE_API_KEY, "local-test-key");
+  assert.equal(env.OPENAI_COMPATIBLE_BASE_URL, "http://127.0.0.1:43210/v1");
+  assert.equal(env.AGENC_PROVIDER, "openai-compatible");
+});
+
+test("private gate trust is canonical and deterministic without copied operator state", async () => {
+  const operatorRoot = mkdtempSync(path.join(tmpdir(), "agenc-tui-operator-"));
+  writeFileSync(path.join(operatorRoot, "auth.json"), '{"secret":true}\n');
+  const state = await createTuiGateState({
+    baseEnv: {
+      HOME: operatorRoot,
+      AGENC_HOME: operatorRoot,
+      OPENAI_API_KEY: "operator-secret",
+      PATH: process.env.PATH,
+    },
+    prefix: "agenc-tui-state-test-",
+  });
+  try {
+    const project = path.join(state.root, "project");
+    writeFileSync(path.join(state.root, "project"), "", { flag: "wx" });
+    await writeTuiGateTrust(state.env, [project, project]);
+    const trust = JSON.parse(
+      readFileSync(path.join(state.agencHome, "trusted-projects.json"), "utf8"),
+    );
+    assert.deepEqual(trust, {
+      version: 1,
+      trustedProjects: [{
+        path: project,
+        trustedAt: TUI_GATE_TRUST_TIMESTAMP,
+      }],
+    });
+    assert.equal(existsSync(path.join(state.agencHome, "auth.json")), false);
+    assert.equal(state.env.OPENAI_API_KEY, undefined);
+  } finally {
+    rmSync(state.root, { recursive: true, force: true });
+    rmSync(operatorRoot, { recursive: true, force: true });
+  }
+});
+
+test("private gate teardown removes only an owned root and proves it absent", async () => {
+  const state = await createTuiGateState({ prefix: "agenc-tui-cleanup-test-" });
+  try {
+    assert.match(path.basename(state.root), /^agt-/u);
+    assert.ok(
+      Buffer.byteLength(path.join(state.agencHome, "daemon.sock")) < 96,
+    );
+    await teardownTuiGateState(state);
+    assert.equal(existsSync(state.root), false);
+    await assert.rejects(
+      startTuiGateDaemon(state, "/not-used-after-cleanup"),
+      /shutting down/u,
+    );
+    assert.equal(existsSync(state.root), false);
+  } finally {
+    rmSync(state.root, { recursive: true, force: true });
+  }
+});
+
+test("private gate project fixtures are deterministic and can expose real diffs", async () => {
+  const state = await createTuiGateState({
+    prefix: "agenc-tui-project-fixture-",
+  });
+  try {
+    const project = createTuiGateProject(state, { dirty: true });
+    assert.equal(path.dirname(project), state.root);
+    const status = spawn(
+      "git",
+      ["status", "--short", "--untracked-files=all"],
+      { cwd: project, env: state.env, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let output = "";
+    status.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    const exit = await new Promise((resolve) => status.once("exit", resolve));
+    assert.equal(exit, 0);
+    assert.match(output, /^ M diff-fixture\.txt$/mu);
+    assert.match(output, /^\?\? untracked-fixture\.txt$/mu);
+    await teardownTuiGateState(state);
+    assert.equal(existsSync(state.root), false);
+  } finally {
+    rmSync(state.root, { recursive: true, force: true });
+  }
+});
+
+function fakeDelayedDaemonCli() {
+  const root = mkdtempSync(path.join(tmpdir(), "agenc-tui-fake-daemon-"));
+  const script = path.join(root, "agenc.mjs");
+  writeFileSync(script, [
+    "import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';",
+    "import path from 'node:path';",
+    "const action = process.argv[3];",
+    "const home = process.env.AGENC_HOME;",
+    "const pidPath = path.join(home, 'daemon.pid');",
+    "const socketPath = path.join(home, 'daemon.sock');",
+    "if (action === 'status') {",
+    "  try {",
+    "    const pid = Number.parseInt(readFileSync(pidPath, 'utf8'), 10);",
+    "    process.kill(pid, 0);",
+    "    if (existsSync(socketPath)) { console.log(`AgenC daemon running (pid ${pid})`); process.exit(0); }",
+    "  } catch {}",
+    "  process.exit(1);",
+    "}",
+    "const cleanup = () => { rmSync(pidPath, { force: true }); rmSync(socketPath, { force: true }); process.exit(0); };",
+    "process.on('SIGTERM', cleanup);",
+    "setTimeout(() => {",
+    "  mkdirSync(home, { recursive: true });",
+    "  writeFileSync(pidPath, `${process.pid}\\n`);",
+    "  writeFileSync(socketPath, 'fake socket\\n');",
+    "}, 250);",
+    "setInterval(() => {}, 1000);",
+    "",
+  ].join("\n"));
+  return { root, script };
+}
+
+test("teardown serializes with an in-flight daemon start", async () => {
+  const fake = fakeDelayedDaemonCli();
+  const state = await createTuiGateState({
+    prefix: "agenc-tui-start-cleanup-race-",
+  });
+  try {
+    const starting = startTuiGateDaemon(state, fake.script);
+    const deadline = Date.now() + 5_000;
+    while (state.daemonProcesses.size === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(state.daemonProcesses.size, 1);
+    const cleanup = teardownTuiGateState(state);
+    const [startResult, cleanupResult] = await Promise.allSettled([
+      starting,
+      cleanup,
+    ]);
+    assert.equal(startResult.status, "rejected");
+    assert.match(startResult.reason.message, /interrupted by cleanup/u);
+    assert.equal(cleanupResult.status, "fulfilled");
+    assert.equal(existsSync(state.root), false);
+    for (const record of state.daemonProcesses.values()) {
+      assert.notEqual(record.exit, null);
+    }
+  } finally {
+    rmSync(state.root, { recursive: true, force: true });
+    rmSync(fake.root, { recursive: true, force: true });
+  }
+});
+
+test("pid-file poisoning never signals an unowned process", async () => {
+  const state = await createTuiGateState({ prefix: "agenc-tui-pid-poison-" });
+  try {
+    writeFileSync(path.join(state.agencHome, "daemon.pid"), `${process.pid}\n`);
+    await assert.rejects(
+      teardownTuiGateState(state),
+      /refusing to signal unowned pid/u,
+    );
+    process.kill(process.pid, 0);
+    assert.equal(existsSync(state.root), true);
+  } finally {
+    rmSync(state.root, { recursive: true, force: true });
+  }
+});
+
+function retainDaemonChildForTest(state, child) {
+  const record = {
+    child,
+    pid: child.pid,
+    stdout: "",
+    stderr: "",
+    exit: null,
+    exitPromise: null,
+  };
+  record.exitPromise = new Promise((resolve) => {
+    child.once("exit", (code, signal) => {
+      record.exit = { code, signal };
+      resolve(record.exit);
+    });
+  });
+  state.daemonPids.add(child.pid);
+  state.daemonProcesses.set(child.pid, record);
+  return record;
+}
+
+test("a symlinked private daemon home cannot redirect cleanup", async () => {
+  const operatorRoot = mkdtempSync(path.join(tmpdir(), "agenc-tui-operator-"));
+  const operatorAgencHome = path.join(operatorRoot, ".agenc");
+  mkdirSync(operatorAgencHome, { mode: 0o700 });
+  const marker = path.join(operatorAgencHome, "operator-marker");
+  writeFileSync(marker, "untouched\n");
+  const state = await createTuiGateState({ prefix: "agenc-tui-symlink-poison-" });
+  const shutdownWrite = path.join(state.agencHome, "shutdown-followed-symlink");
+  const child = spawn(
+    process.execPath,
+    [
+      "-e",
+      [
+        "const fs = require('node:fs');",
+        "const target = process.argv[1];",
+        "process.on('SIGTERM', () => { fs.writeFileSync(target, 'poisoned\\n'); process.exit(0); });",
+        "process.stdout.write('ready\\n');",
+        "setInterval(() => {}, 1000);",
+      ].join(" "),
+      shutdownWrite,
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] },
+  );
+  const record = retainDaemonChildForTest(state, child);
+  try {
+    await new Promise((resolve, reject) => {
+      child.stdout.once("data", resolve);
+      child.once("error", reject);
+    });
+    rmSync(state.agencHome, { recursive: true });
+    symlinkSync(operatorAgencHome, state.agencHome, "dir");
+    await assert.rejects(
+      teardownTuiGateState(state),
+      /symlinked TUI gate directory/u,
+    );
+    await record.exitPromise;
+    assert.equal(record.exit.signal, "SIGKILL");
+    assert.equal(readFileSync(marker, "utf8"), "untouched\n");
+    assert.equal(existsSync(path.join(operatorAgencHome, "shutdown-followed-symlink")), false);
+  } finally {
+    if (record.exit === null) child.kill("SIGKILL");
+    rmSync(state.root, { recursive: true, force: true });
+    rmSync(operatorRoot, { recursive: true, force: true });
+  }
+});
+
+test("a deleted private root still terminates every retained daemon child", async () => {
+  const state = await createTuiGateState({ prefix: "agenc-tui-missing-root-" });
+  const child = spawn(
+    process.execPath,
+    ["-e", "process.on('SIGTERM', () => process.exit(0)); setInterval(() => {}, 1000)"],
+    { stdio: "ignore" },
+  );
+  const record = retainDaemonChildForTest(state, child);
+  rmSync(state.root, { recursive: true });
+  await assert.rejects(
+    teardownTuiGateState(state),
+    /root disappeared before cleanup/u,
+  );
+  await record.exitPromise;
+  try {
+    process.kill(child.pid, 0);
+    assert.fail("retained daemon child remained alive");
+  } catch (error) {
+    assert.equal(error.code, "ESRCH");
+  }
+});
+
+async function runGateSignalProbe(signal, expectedExitCode) {
+  const helperUrl = new URL("./tui-gate-state.mjs", import.meta.url).href;
+  const source = [
+    "import { spawn } from 'node:child_process';",
+    `import { createTuiGateState, installTuiGateSignalHandlers, teardownTuiGateState } from ${JSON.stringify(helperUrl)};`,
+    "const state = await createTuiGateState();",
+    "const daemon = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+    "const record = { child: daemon, pid: daemon.pid, stdout: '', stderr: '', exit: null, exitPromise: null };",
+    "record.exitPromise = new Promise((resolve) => daemon.once('exit', (code, signal) => { record.exit = { code, signal }; resolve(record.exit); }));",
+    "state.daemonPids.add(daemon.pid);",
+    "state.daemonProcesses.set(daemon.pid, record);",
+    "installTuiGateSignalHandlers(() => teardownTuiGateState(state));",
+    "process.stdout.write(`${JSON.stringify({ root: state.root, daemonPid: daemon.pid })}\\n`);",
+    "setInterval(() => {}, 1000);",
+  ].join("\n");
+  const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  const firstLine = await new Promise((resolve, reject) => {
+    let finished = false;
+    const timeout = setTimeout(() => {
+      finished = true;
+      reject(new Error(`signal probe did not become ready: ${stderr}`));
+    }, 5_000);
+    const poll = () => {
+      if (finished) return;
+      const newline = stdout.indexOf("\n");
+      if (newline === -1) {
+        setTimeout(poll, 10);
+        return;
+      }
+      finished = true;
+      clearTimeout(timeout);
+      resolve(stdout.slice(0, newline));
+    };
+    child.once("error", (error) => {
+      finished = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    poll();
+  });
+  const { root, daemonPid } = JSON.parse(firstLine);
+  assert.equal(existsSync(root), true);
+  process.kill(daemonPid, 0);
+  child.kill(signal);
+  const exit = await new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+  assert.deepEqual(exit, { code: expectedExitCode, signal: null });
+  assert.equal(existsSync(root), false);
+  assert.throws(
+    () => process.kill(daemonPid, 0),
+    (error) => error?.code === "ESRCH",
+  );
+}
+
+test("catchable terminal signals clean state and retained daemons before exit", async () => {
+  for (const [signal, exitCode] of [["SIGHUP", 129], ["SIGTERM", 143]]) {
+    await runGateSignalProbe(signal, exitCode);
+  }
+});
+
+function fakeTerm({
+  earlyExit = false,
+  ignoreKills = false,
+  ignoreSigterm = false,
+  terminationExit,
+  paint = SEMANTIC_PAINT,
+  spontaneousExitMs,
+} = {}) {
   const dataHandlers = [];
   const exitHandlers = [];
   let exited = false;
@@ -108,6 +504,8 @@ function fakeTerm({ earlyExit = false, terminationExit, paint = SEMANTIC_PAINT, 
     },
     write() {},
     kill(signal) {
+      if (ignoreKills) return;
+      if (ignoreSigterm && signal === "SIGTERM") return;
       emitExit(terminationExit ?? { exitCode: 0, signal: signal === "SIGKILL" ? 9 : 15 });
     },
   };
@@ -180,4 +578,38 @@ test("a PTY crash during the requested termination grace is a failure", async ()
     );
     assert.equal(passed, false);
   }
+});
+
+test("an ignored warmup cannot hide a PTY that survives SIGKILL", async () => {
+  await assert.rejects(
+    observePtySession(
+      fakeTerm({ ignoreKills: true }),
+      {
+        label: "unkillable-warmup",
+        viewport: { cols: 80, rows: 24 },
+        firstPaintMs: 5,
+        postReplyMs: 5,
+        sigtermGraceMs: 5,
+        forceKillGraceMs: 5,
+        resultIgnored: true,
+      },
+    ),
+    /PTY survived the final SIGKILL grace period/u,
+  );
+});
+
+test("an ignored warmup cannot hide a PTY that requires SIGKILL", async () => {
+  const passed = await observePtySession(
+    fakeTerm({ ignoreSigterm: true }),
+    {
+      label: "sigkill-only-warmup",
+      viewport: { cols: 80, rows: 24 },
+      firstPaintMs: 5,
+      postReplyMs: 5,
+      sigtermGraceMs: 5,
+      forceKillGraceMs: 5,
+      resultIgnored: true,
+    },
+  );
+  assert.equal(passed, false);
 });

--- a/runtime/scripts/check-tui-workbench-transcript-scroll.mjs
+++ b/runtime/scripts/check-tui-workbench-transcript-scroll.mjs
@@ -1,5 +1,27 @@
 #!/usr/bin/env node
-import { TuiSession, renderPtyRows } from "./check-tui-e2e/harness.mjs";
+import { fileURLToPath } from "node:url";
+
+import {
+  TuiSession,
+  renderPtyRows,
+  tuiE2eGateEnv,
+} from "./check-tui-e2e/harness.mjs";
+import {
+  buildMockProviderEnv,
+  startMockModelServer,
+} from "./local-openai-compatible-mock.mjs";
+import {
+  configureTuiGateSandbox,
+  createTuiGateProject,
+  createTuiGateState,
+  installTuiGateSignalHandlers,
+  startTuiGateDaemon,
+  teardownTuiGateState,
+} from "./tui-gate-state.mjs";
+
+const BIN_AGENC = fileURLToPath(
+  new URL("../dist/bin/agenc.js", import.meta.url),
+);
 
 const DIMENSIONS = [
   { cols: 148, rows: 40 },
@@ -13,10 +35,76 @@ const WORKBENCH_ENV = {
   AGENC_TUI_WORKBENCH: "1",
 };
 
-const LONG_OUTPUT_COMMAND = "!seq -f WBANCHOR-%03g 1 120 #";
+const LONG_OUTPUT_PROMPT =
+  "WORKBENCH-TRANSCRIPT-SCROLL: return the deterministic fixture.";
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function trackActiveSession(lifecycle, session) {
+  if (lifecycle.activeSession !== null) {
+    throw new Error(
+      "workbench transcript scroll already has an active TUI session",
+    );
+  }
+  lifecycle.activeSession = session;
+  lifecycle.activeSessionCleanup = null;
+}
+
+async function cleanupActiveSession(lifecycle) {
+  const session = lifecycle.activeSession;
+  if (session === null) return;
+
+  if (lifecycle.activeSessionCleanup === null) {
+    session.kill();
+    lifecycle.activeSessionCleanup = session.cleanup();
+  }
+  const cleanupPromise = lifecycle.activeSessionCleanup;
+  try {
+    await cleanupPromise;
+  } finally {
+    if (
+      lifecycle.activeSession === session &&
+      lifecycle.activeSessionCleanup === cleanupPromise
+    ) {
+      lifecycle.activeSession = null;
+      lifecycle.activeSessionCleanup = null;
+    }
+  }
+}
+
+async function cleanupLifecycle(lifecycle) {
+  const errors = [];
+  try {
+    await cleanupActiveSession(lifecycle);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    const gateState =
+      lifecycle.gateState ?? await lifecycle.pendingGateState;
+    lifecycle.gateState = gateState;
+    lifecycle.pendingGateState = null;
+    await teardownTuiGateState(gateState, BIN_AGENC);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (lifecycle.mockClosePromise === null) {
+    lifecycle.mockClosePromise = lifecycle.mockServer.close();
+  }
+  try {
+    await lifecycle.mockClosePromise;
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(
+      errors,
+      "workbench transcript scroll cleanup failed",
+    );
+  }
 }
 
 function fail(message, details = {}) {
@@ -63,7 +151,9 @@ function assertExplorerRailVisible(session, dimension, label) {
   if (dimension.cols < 100) return;
   const rows = frameRows(session, dimension);
   const frame = rows.join("\n");
-  const hasTreeRow = rows.some((row) => /^\s+[v>] \S/u.test(row.slice(0, 26)));
+  const hasTreeRow = rows.some((row) =>
+    /^\s+(?:\[[-+]\]|[v>])\s+\S/u.test(row.slice(0, 26))
+  );
   if (!frame.includes("WORKSPACE") || !hasTreeRow) {
     fail("workspace explorer rail disappeared during transcript scroll", {
       label,
@@ -99,13 +189,16 @@ function sgrWheel(button, dimension) {
   return `\x1b[<${button};${col};${row}M`;
 }
 
-async function runOne(dimension) {
+async function runOne(dimension, lifecycle) {
   const session = new TuiSession({
+    args: ["--yolo"],
     cols: dimension.cols,
     rows: dimension.rows,
+    cwd: lifecycle.cwd,
     env: WORKBENCH_ENV,
-    useTempHome: true,
+    gateState: lifecycle.gateState,
   });
+  trackActiveSession(lifecycle, session);
   const label = `${dimension.cols}x${dimension.rows}`;
 
   try {
@@ -113,7 +206,9 @@ async function runOne(dimension) {
     await session.waitForPrompt({ timeout: 20_000 });
     assertFrameShape(session, dimension, `${label} cold start`);
 
-    await session.submit(LONG_OUTPUT_COMMAND);
+    // The loopback model returns 120 deterministic anchor lines for this
+    // prompt, avoiding shell admission and host command dependencies.
+    await session.submit(LONG_OUTPUT_PROMPT);
     await session.waitFor(/WBANCHOR-120/, {
       timeout: 20_000,
       label: `${label} tail anchor`,
@@ -174,34 +269,86 @@ async function runOne(dimension) {
 
     session.assertNoCrash();
   } finally {
-    session.kill();
-    await session.cleanup();
+    await cleanupActiveSession(lifecycle);
   }
 }
 
 async function main() {
-  const failures = [];
-  for (const dimension of DIMENSIONS) {
-    const label = `${dimension.cols}x${dimension.rows}`;
-    process.stdout.write(`workbench transcript scroll: ${label} ... `);
-    try {
-      await runOne(dimension);
-      process.stdout.write("ok\n");
-    } catch (error) {
-      process.stdout.write("failed\n");
-      failures.push({ label, error });
-    }
-  }
+  const mockServer = await startMockModelServer();
+  const gateStatePromise = createTuiGateState({
+    injectedEnv: tuiE2eGateEnv(
+      buildMockProviderEnv(mockServer.baseUrl, {}),
+    ),
+    prefix: "agenc-tui-transcript-scroll-",
+  });
+  const lifecycle = {
+    gateState: null,
+    pendingGateState: gateStatePromise,
+    cwd: null,
+    activeSession: null,
+    activeSessionCleanup: null,
+    aborted: false,
+    mockServer,
+    mockClosePromise: null,
+  };
+  let uninstallSignalHandlers = () => {};
+  try {
+    uninstallSignalHandlers = installTuiGateSignalHandlers(async () => {
+      lifecycle.aborted = true;
+      await cleanupLifecycle(lifecycle);
+    });
+    const gateState = await gateStatePromise;
+    lifecycle.gateState = gateState;
+    lifecycle.pendingGateState = null;
+    lifecycle.cwd = createTuiGateProject(gateState);
+    // The transcript fixture intentionally runs a local `!seq` command.
+    // Make its sandbox policy explicit instead of depending on host support
+    // for optional bubblewrap/user namespaces.
+    await configureTuiGateSandbox(
+      gateState,
+      BIN_AGENC,
+      "danger-full-access",
+    );
+    if (lifecycle.aborted) return 1;
+    await startTuiGateDaemon(gateState, BIN_AGENC);
+    if (lifecycle.aborted) return 1;
 
-  if (failures.length > 0) {
-    for (const failure of failures) {
-      console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
+    const failures = [];
+    for (const dimension of DIMENSIONS) {
+      if (lifecycle.aborted) return 1;
+      const label = `${dimension.cols}x${dimension.rows}`;
+      process.stdout.write(`workbench transcript scroll: ${label} ... `);
+      try {
+        await runOne(dimension, lifecycle);
+        process.stdout.write("ok\n");
+      } catch (error) {
+        process.stdout.write("failed\n");
+        failures.push({ label, error });
+      }
+      if (lifecycle.aborted) return 1;
     }
-    process.exit(1);
+
+    if (failures.length > 0) {
+      for (const failure of failures) {
+        console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
+      }
+      return 1;
+    }
+    return 0;
+  } finally {
+    try {
+      await cleanupLifecycle(lifecycle);
+    } finally {
+      uninstallSignalHandlers();
+    }
   }
 }
 
-main().catch((error) => {
-  console.error(error?.stack ?? error?.message ?? String(error));
-  process.exit(1);
-});
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(error?.stack ?? error?.message ?? String(error));
+    process.exitCode = 1;
+  });

--- a/runtime/scripts/check-tui-workbench-visual-smoke.mjs
+++ b/runtime/scripts/check-tui-workbench-visual-smoke.mjs
@@ -1,5 +1,19 @@
 #!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
 import { TuiSession, renderPtyRows } from "./check-tui-e2e/harness.mjs";
+import {
+  configureTuiGateSandbox,
+  createTuiGateProject,
+  createTuiGateState,
+  installTuiGateSignalHandlers,
+  startTuiGateDaemon,
+  teardownTuiGateState,
+} from "./tui-gate-state.mjs";
+
+const BIN_AGENC = fileURLToPath(
+  new URL("../dist/bin/agenc.js", import.meta.url),
+);
 
 const DIMENSIONS = [
   { cols: 148, rows: 40 },
@@ -10,6 +24,58 @@ const DIMENSIONS = [
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function trackActiveSession(lifecycle, session) {
+  if (lifecycle.activeSession !== null) {
+    throw new Error("workbench visual smoke already has an active TUI session");
+  }
+  lifecycle.activeSession = session;
+  lifecycle.activeSessionCleanup = null;
+}
+
+async function cleanupActiveSession(lifecycle) {
+  const session = lifecycle.activeSession;
+  if (session === null) return;
+
+  if (lifecycle.activeSessionCleanup === null) {
+    session.kill();
+    lifecycle.activeSessionCleanup = session.cleanup();
+  }
+  const cleanupPromise = lifecycle.activeSessionCleanup;
+  try {
+    await cleanupPromise;
+  } finally {
+    if (
+      lifecycle.activeSession === session &&
+      lifecycle.activeSessionCleanup === cleanupPromise
+    ) {
+      lifecycle.activeSession = null;
+      lifecycle.activeSessionCleanup = null;
+    }
+  }
+}
+
+async function cleanupLifecycle(lifecycle) {
+  const errors = [];
+  try {
+    await cleanupActiveSession(lifecycle);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    const gateState =
+      lifecycle.gateState ?? await lifecycle.pendingGateState;
+    lifecycle.gateState = gateState;
+    lifecycle.pendingGateState = null;
+    await teardownTuiGateState(gateState, BIN_AGENC);
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "workbench visual smoke cleanup failed");
+  }
 }
 
 function fail(message, details = {}) {
@@ -120,15 +186,18 @@ function assertFrame(session, dimension, label, anchors) {
   }
 }
 
-async function runOne(dimension) {
+async function runOne(dimension, lifecycle) {
   const session = new TuiSession({
     cols: dimension.cols,
     rows: dimension.rows,
+    cwd: lifecycle.cwd,
+    gateState: lifecycle.gateState,
     env: {
       AGENC_TUI_WORKBENCH: "1",
       AGENC_OAUTH_TOKEN: "test-workbench-visual-token",
     },
   });
+  trackActiveSession(lifecycle, session);
   const label = `${dimension.cols}x${dimension.rows}`;
   try {
     await session.start({ firstPaintMs: 1_000, postReplyMs: 1_000 });
@@ -139,41 +208,100 @@ async function runOne(dimension) {
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     assertFrame(session, dimension, `${label} explorer focus`, ["WORKSPACE", "WORKSPA"]);
 
-    session.send("\x17l");
+    // Ctrl-W j is the documented composer-focus shortcut at every responsive
+    // layout. Moving right from the explorer is ambiguous once panes collapse.
+    session.send("\x17j");
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     await session.submitSlashCommand("/diff");
     await session.waitForIdle({ idleWindow: 900, timeout: 20_000 });
     await sleep(300);
-    assertFrame(session, dimension, `${label} diff surface`, ["DIFF", "git diff HEAD", "[q] close"]);
+    assertFrame(
+      session,
+      dimension,
+      `${label} diff surface`,
+      ["AgenC Workbench | DIFF"],
+    );
+    assertFrame(
+      session,
+      dimension,
+      `${label} diff command`,
+      ["git diff HEAD"],
+    );
+    assertFrame(
+      session,
+      dimension,
+      `${label} diff fixture`,
+      ["M diff-fixture.txt"],
+    );
     session.assertNoCrash();
   } finally {
-    session.kill();
-    await session.cleanup();
+    await cleanupActiveSession(lifecycle);
   }
 }
 
 async function main() {
-  const failures = [];
-  for (const dimension of DIMENSIONS) {
-    const label = `${dimension.cols}x${dimension.rows}`;
-    process.stdout.write(`workbench visual smoke: ${label} ... `);
+  const gateStatePromise = createTuiGateState({
+    prefix: "agenc-tui-workbench-visual-",
+  });
+  const lifecycle = {
+    gateState: null,
+    pendingGateState: gateStatePromise,
+    cwd: null,
+    activeSession: null,
+    activeSessionCleanup: null,
+    aborted: false,
+  };
+  let uninstallSignalHandlers = () => {};
+  try {
+    uninstallSignalHandlers = installTuiGateSignalHandlers(async () => {
+      lifecycle.aborted = true;
+      await cleanupLifecycle(lifecycle);
+    });
+    const gateState = await gateStatePromise;
+    lifecycle.gateState = gateState;
+    lifecycle.pendingGateState = null;
+    lifecycle.cwd = createTuiGateProject(gateState, { dirty: true });
+    await configureTuiGateSandbox(gateState, BIN_AGENC, undefined);
+    if (lifecycle.aborted) return 1;
+    await startTuiGateDaemon(gateState, BIN_AGENC);
+    if (lifecycle.aborted) return 1;
+
+    const failures = [];
+    for (const dimension of DIMENSIONS) {
+      if (lifecycle.aborted) return 1;
+      const label = `${dimension.cols}x${dimension.rows}`;
+      process.stdout.write(`workbench visual smoke: ${label} ... `);
+      try {
+        await runOne(dimension, lifecycle);
+        process.stdout.write("ok\n");
+      } catch (error) {
+        process.stdout.write("failed\n");
+        failures.push({ label, error });
+      }
+      if (lifecycle.aborted) return 1;
+    }
+
+    if (failures.length > 0) {
+      for (const failure of failures) {
+        console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
+      }
+      return 1;
+    }
+    return 0;
+  } finally {
     try {
-      await runOne(dimension);
-      process.stdout.write("ok\n");
-    } catch (error) {
-      process.stdout.write("failed\n");
-      failures.push({ label, error });
+      await cleanupLifecycle(lifecycle);
+    } finally {
+      uninstallSignalHandlers();
     }
-  }
-  if (failures.length > 0) {
-    for (const failure of failures) {
-      console.error(`\n${failure.label}: ${failure.error?.message ?? failure.error}`);
-    }
-    process.exit(1);
   }
 }
 
-main().catch((error) => {
-  console.error(error?.stack ?? error?.message ?? String(error));
-  process.exit(1);
-});
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(error?.stack ?? error?.message ?? String(error));
+    process.exitCode = 1;
+  });

--- a/runtime/scripts/local-openai-compatible-mock.mjs
+++ b/runtime/scripts/local-openai-compatible-mock.mjs
@@ -54,6 +54,13 @@ function toolResultCount(messages) {
 }
 
 function completionForPrompt(prompt) {
+  if (/\bWORKBENCH-TRANSCRIPT-SCROLL\b/i.test(prompt)) {
+    const lines = Array.from(
+      { length: 120 },
+      (_, index) => `WBANCHOR-${String(index + 1).padStart(3, "0")}`,
+    );
+    return `\`\`\`text\n${lines.join("\n")}\n\`\`\``;
+  }
   const singleWord =
     /\b(?:reply with|say only)\s+(?:the\s+)?(?:single\s+)?word\s+([A-Za-z0-9_-]+)/i
       .exec(prompt)?.[1];

--- a/runtime/scripts/tui-gate-state.mjs
+++ b/runtime/scripts/tui-gate-state.mjs
@@ -1,0 +1,868 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const OWNER_FILENAME = ".agenc-tui-gate-owner.json";
+const OWNER_KIND = "agenc-tui-gate-state-v1";
+const TRUST_TIMESTAMP = "1970-01-01T00:00:00.000Z";
+const DAEMON_START_TIMEOUT_MS = 60_000;
+const DAEMON_STOP_TIMEOUT_MS = 20_000;
+const DAEMON_FORCE_KILL_GRACE_MS = 2_000;
+const DAEMON_POLL_MS = 100;
+const MAX_DAEMON_OUTPUT_BYTES = 64 * 1024;
+const SHORT_ROOT_PREFIX = "agt-";
+const PROJECT_FIXTURE_FILES = Object.freeze({
+  "README.md": "# AgenC TUI gate fixture\n",
+  "package.json": '{"private":true}\n',
+});
+
+const PASSTHROUGH_ENV_KEYS = Object.freeze([
+  "CI",
+  "COLORTERM",
+  "ComSpec",
+  "COMSPEC",
+  "EDITOR",
+  "FORCE_COLOR",
+  "LOGNAME",
+  "NO_COLOR",
+  "PATH",
+  "PATHEXT",
+  "SHELL",
+  "SystemRoot",
+  "SYSTEMROOT",
+  "TERM",
+  "TUI_E2E_DEBUG",
+  "USER",
+  "VISUAL",
+  "windir",
+  "WINDIR",
+]);
+
+const ISOLATION_ENV_KEYS = Object.freeze([
+  "HOME",
+  "USERPROFILE",
+  "AGENC_HOME",
+  "AGENC_CONFIG_DIR",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "AGENC_AUTH_BACKEND",
+  "AGENC_DAEMON_WEBSOCKET_HOST",
+  "AGENC_DAEMON_WEBSOCKET_PORT",
+  "AGENC_DISABLE_NONESSENTIAL_TRAFFIC",
+  "AGENC_ONBOARDING",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_OPTIONAL_LOCKS",
+  "GIT_TERMINAL_PROMPT",
+  "LANG",
+  "LC_ALL",
+  "NODE_OPTIONS",
+  "TERM",
+  "TZ",
+]);
+
+const ACTIVE_STATES_BY_HOME = new Map();
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function systemEnvironment(baseEnv) {
+  return Object.fromEntries(
+    PASSTHROUGH_ENV_KEYS.flatMap((key) =>
+      baseEnv[key] === undefined ? [] : [[key, baseEnv[key]]],
+    ),
+  );
+}
+
+function isolationEnvironment(home) {
+  const resolvedHome = path.resolve(home);
+  const agencHome = path.join(resolvedHome, ".agenc");
+  const privateTemp = path.join(resolvedHome, "tmp");
+  return {
+    HOME: resolvedHome,
+    USERPROFILE: resolvedHome,
+    AGENC_HOME: agencHome,
+    AGENC_CONFIG_DIR: agencHome,
+    APPDATA: path.join(resolvedHome, "AppData", "Roaming"),
+    LOCALAPPDATA: path.join(resolvedHome, "AppData", "Local"),
+    XDG_CACHE_HOME: path.join(resolvedHome, ".cache"),
+    XDG_CONFIG_HOME: path.join(resolvedHome, ".config"),
+    XDG_DATA_HOME: path.join(resolvedHome, ".local", "share"),
+    XDG_STATE_HOME: path.join(resolvedHome, ".local", "state"),
+    TEMP: privateTemp,
+    TMP: privateTemp,
+    TMPDIR: privateTemp,
+    AGENC_AUTH_BACKEND: "local",
+    AGENC_DAEMON_WEBSOCKET_HOST: "127.0.0.1",
+    AGENC_DAEMON_WEBSOCKET_PORT: "0",
+    AGENC_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+    AGENC_ONBOARDING: "0",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_TERMINAL_PROMPT: "0",
+    LANG: "C",
+    LC_ALL: "C",
+    NODE_OPTIONS: "",
+    TERM: "xterm-256color",
+    TZ: "UTC",
+  };
+}
+
+/**
+ * Build a private TUI-gate environment.
+ *
+ * `baseEnv` contributes only ordinary process-launch essentials. Provider
+ * credentials, endpoints, and scenario knobs must be passed explicitly via
+ * `injectedEnv`; this keeps startup smoke from inheriting operator secrets.
+ * Isolation keys always win over both inputs.
+ */
+export function tuiGateEnvironment(
+  home,
+  baseEnv = process.env,
+  injectedEnv = {},
+) {
+  return {
+    ...systemEnvironment(baseEnv),
+    ...injectedEnv,
+    ...isolationEnvironment(home),
+  };
+}
+
+async function makePrivateDirectories(env) {
+  const directories = new Set([
+    env.HOME,
+    env.AGENC_HOME,
+    env.APPDATA,
+    env.LOCALAPPDATA,
+    env.XDG_CACHE_HOME,
+    env.XDG_CONFIG_HOME,
+    env.XDG_DATA_HOME,
+    env.XDG_STATE_HOME,
+    env.TMPDIR,
+  ]);
+  await Promise.all(
+    [...directories].map((directory) =>
+      mkdir(directory, { recursive: true, mode: 0o700 }),
+    ),
+  );
+}
+
+async function createShortGateRoot() {
+  const parents = process.platform === "win32"
+    ? [tmpdir()]
+    : ["/tmp", tmpdir()];
+  const failures = [];
+  for (const parent of new Set(parents)) {
+    try {
+      return await mkdtemp(path.join(parent, SHORT_ROOT_PREFIX));
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  throw new AggregateError(failures, "could not create a private TUI gate root");
+}
+
+function assertShortSocketPath(agencHome) {
+  if (process.platform === "win32") return;
+  const socketPath = path.join(agencHome, "daemon.sock");
+  if (Buffer.byteLength(socketPath) >= 96) {
+    throw new Error(`private TUI gate socket path is too long: ${socketPath}`);
+  }
+}
+
+export async function createTuiGateState({
+  baseEnv = process.env,
+  injectedEnv = {},
+  prefix = "agenc-tui-gate-",
+} = {}) {
+  const root = await createShortGateRoot();
+  const ownerId = randomUUID();
+  try {
+    await chmod(root, 0o700);
+    const canonicalRoot = await realpath(root);
+    const env = tuiGateEnvironment(root, baseEnv, injectedEnv);
+    assertShortSocketPath(env.AGENC_HOME);
+    await makePrivateDirectories(env);
+    await writeFile(
+      path.join(root, OWNER_FILENAME),
+      `${JSON.stringify({
+        kind: OWNER_KIND,
+        ownerId,
+        root,
+        label: prefix,
+      })}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    const state = {
+      root,
+      canonicalRoot,
+      home: root,
+      agencHome: env.AGENC_HOME,
+      env,
+      baseEnv: systemEnvironment(baseEnv),
+      injectedEnv: { ...injectedEnv },
+      ownerId,
+      daemonPids: new Set(),
+      daemonProcesses: new Map(),
+      pendingDaemonStarts: new Set(),
+      cleanupPromise: null,
+      closing: false,
+      cleaned: false,
+    };
+    ACTIVE_STATES_BY_HOME.set(state.home, state);
+    return state;
+  } catch (error) {
+    await rm(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function environmentForTuiGateState(state, overrides = {}) {
+  if (state.cleaned || state.closing) {
+    throw new Error(`TUI gate state is shutting down: ${state.root}`);
+  }
+  return tuiGateEnvironment(state.home, state.baseEnv, {
+    ...state.injectedEnv,
+    ...overrides,
+  });
+}
+
+export function createTuiGateProject(state, { dirty = false } = {}) {
+  if (state.cleaned || state.closing) {
+    throw new Error(`TUI gate state is shutting down: ${state.root}`);
+  }
+  if (realpathSync(state.root) !== state.canonicalRoot) {
+    throw new Error(`TUI gate root identity changed: ${state.root}`);
+  }
+
+  const project = path.join(state.root, "project");
+  mkdirSync(project, { recursive: true, mode: 0o700 });
+  const canonicalProject = realpathSync(project);
+  if (!isWithin(state.canonicalRoot, canonicalProject)) {
+    throw new Error(`TUI gate project escaped its root: ${project}`);
+  }
+  for (const [filename, contents] of Object.entries(PROJECT_FIXTURE_FILES)) {
+    writeFileSync(path.join(project, filename), contents, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+  }
+  const trackedFiles = Object.keys(PROJECT_FIXTURE_FILES);
+  if (dirty) {
+    writeFileSync(
+      path.join(project, "diff-fixture.txt"),
+      "baseline\n",
+      { encoding: "utf8", mode: 0o600, flag: "wx" },
+    );
+    trackedFiles.push("diff-fixture.txt");
+  }
+
+  const gitEnv = {
+    ...state.env,
+    GIT_AUTHOR_EMAIL: "tui-gate@agenc.invalid",
+    GIT_AUTHOR_NAME: "AgenC TUI Gate",
+    GIT_AUTHOR_DATE: "1970-01-01T00:00:00Z",
+    GIT_COMMITTER_EMAIL: "tui-gate@agenc.invalid",
+    GIT_COMMITTER_NAME: "AgenC TUI Gate",
+    GIT_COMMITTER_DATE: "1970-01-01T00:00:00Z",
+    GIT_CONFIG_NOSYSTEM: "1",
+  };
+  for (const args of [
+    ["init", "--quiet", "--initial-branch=main"],
+    ["add", ...trackedFiles],
+    ["commit", "--quiet", "-m", "test: initialize TUI gate fixture"],
+  ]) {
+    const result = spawnSync("git", args, {
+      cwd: project,
+      encoding: "utf8",
+      env: gitEnv,
+      timeout: 10_000,
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        `failed to initialize private TUI gate git fixture: ${
+          result.stderr || result.stdout
+        }`,
+      );
+    }
+  }
+
+  if (dirty) {
+    writeFileSync(
+      path.join(project, "diff-fixture.txt"),
+      "baseline\nprivate TUI gate change\n",
+      "utf8",
+    );
+    writeFileSync(
+      path.join(project, "untracked-fixture.txt"),
+      "private TUI gate untracked file\n",
+      "utf8",
+    );
+  }
+  return project;
+}
+
+async function canonicalProjectPaths(projectPaths) {
+  const canonical = new Set();
+  for (const projectPath of projectPaths) {
+    const resolved = path.resolve(projectPath);
+    canonical.add(resolved);
+    try {
+      canonical.add(await realpath(resolved));
+    } catch {
+      // A caller can trust a path before creating it. The absolute form is
+      // still deterministic and will be replaced on the next trust write.
+    }
+  }
+  return [...canonical].sort((left, right) => left.localeCompare(right));
+}
+
+export async function writeTuiGateTrust(env, projectPaths) {
+  const trustFile = path.join(env.AGENC_HOME, "trusted-projects.json");
+  await mkdir(path.dirname(trustFile), { recursive: true, mode: 0o700 });
+  const paths = await canonicalProjectPaths(projectPaths);
+  await writeFile(
+    trustFile,
+    `${JSON.stringify({
+      version: 1,
+      trustedProjects: paths.map((projectPath) => ({
+        path: projectPath,
+        trustedAt: TRUST_TIMESTAMP,
+      })),
+    }, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return trustFile;
+}
+
+function daemonCommand(binAgenc, args, env, timeout) {
+  return spawnSync(
+    process.execPath,
+    [binAgenc, "daemon", ...args],
+    { encoding: "utf8", env, timeout },
+  );
+}
+
+async function readDaemonPid(agencHome) {
+  try {
+    const raw = (await readFile(path.join(agencHome, "daemon.pid"), "utf8")).trim();
+    return /^\d+$/u.test(raw) ? Number.parseInt(raw, 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPidAlive(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+async function pathExists(candidate) {
+  try {
+    await lstat(candidate);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function isWithin(parent, candidate) {
+  const relative = path.relative(parent, candidate);
+  return relative === "" || (
+    !path.isAbsolute(relative) &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`)
+  );
+}
+
+async function assertOrdinaryPath(candidate, type) {
+  const metadata = await lstat(candidate);
+  if (metadata.isSymbolicLink()) {
+    throw new Error(`refusing symlinked TUI gate ${type}: ${candidate}`);
+  }
+  if (type === "directory" && !metadata.isDirectory()) {
+    throw new Error(`TUI gate path is not a directory: ${candidate}`);
+  }
+  if (type === "file" && !metadata.isFile()) {
+    throw new Error(`TUI gate path is not a regular file: ${candidate}`);
+  }
+}
+
+async function assertOwnedState(state) {
+  if (state.cleaned) {
+    throw new Error(`TUI gate state is already cleaned: ${state.root}`);
+  }
+  await assertOrdinaryPath(state.root, "directory");
+  const canonicalRoot = await realpath(state.root);
+  if (canonicalRoot !== state.canonicalRoot) {
+    throw new Error(`TUI gate root identity changed: ${state.root}`);
+  }
+
+  const expectedAgencHome = path.join(state.root, ".agenc");
+  if (
+    state.home !== state.root ||
+    state.agencHome !== expectedAgencHome ||
+    state.env.HOME !== state.root ||
+    state.env.AGENC_HOME !== expectedAgencHome ||
+    state.env.AGENC_CONFIG_DIR !== expectedAgencHome
+  ) {
+    throw new Error(`TUI gate state paths changed: ${state.root}`);
+  }
+  await assertOrdinaryPath(expectedAgencHome, "directory");
+  const canonicalAgencHome = await realpath(expectedAgencHome);
+  if (!isWithin(canonicalRoot, canonicalAgencHome)) {
+    throw new Error(`TUI gate home escaped its root: ${expectedAgencHome}`);
+  }
+
+  const ownerPath = path.join(state.root, OWNER_FILENAME);
+  await assertOrdinaryPath(ownerPath, "file");
+  const owner = JSON.parse(await readFile(ownerPath, "utf8"));
+  if (
+    owner?.kind !== OWNER_KIND ||
+    owner?.ownerId !== state.ownerId ||
+    owner?.root !== state.root
+  ) {
+    throw new Error(`refusing to clean unowned TUI gate root: ${state.root}`);
+  }
+
+  for (const filename of ["daemon.pid", "daemon.sock"]) {
+    const candidate = path.join(expectedAgencHome, filename);
+    if (!await pathExists(candidate)) continue;
+    const metadata = await lstat(candidate);
+    if (metadata.isSymbolicLink()) {
+      throw new Error(`refusing symlinked TUI gate daemon path: ${candidate}`);
+    }
+    if (filename === "daemon.pid" && !metadata.isFile()) {
+      throw new Error(`TUI gate daemon pid is not a regular file: ${candidate}`);
+    }
+  }
+}
+
+export async function configureTuiGateSandbox(
+  state,
+  binAgenc,
+  sandboxMode,
+) {
+  if (sandboxMode === undefined) return;
+  if (sandboxMode !== "danger-full-access") {
+    throw new Error(`unsupported TUI gate sandbox mode: ${sandboxMode}`);
+  }
+  await assertOwnedState(state);
+  const result = spawnSync(
+    process.execPath,
+    [binAgenc, "config", "set", "sandbox_mode", sandboxMode],
+    { encoding: "utf8", env: state.env, timeout: 10_000 },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to configure TUI gate sandbox mode: ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+function appendBoundedOutput(record, chunk, key) {
+  if (record[key].length >= MAX_DAEMON_OUTPUT_BYTES) return;
+  record[key] = `${record[key]}${chunk.toString()}`.slice(
+    -MAX_DAEMON_OUTPUT_BYTES,
+  );
+}
+
+function spawnForegroundDaemon(state, binAgenc) {
+  const child = spawn(
+    process.execPath,
+    [binAgenc, "daemon", "start", "--foreground"],
+    {
+      env: state.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    },
+  );
+  const record = {
+    child,
+    pid: child.pid,
+    stdout: "",
+    stderr: "",
+    exit: null,
+    exitPromise: null,
+  };
+  record.exitPromise = new Promise((resolve) => {
+    child.once("exit", (code, signal) => {
+      record.exit = { code, signal };
+      resolve(record.exit);
+    });
+    child.once("error", (error) => {
+      if (record.exit === null) {
+        record.exit = { code: null, signal: null, error };
+        resolve(record.exit);
+      }
+    });
+  });
+  child.stdout?.on("data", (chunk) => appendBoundedOutput(record, chunk, "stdout"));
+  child.stderr?.on("data", (chunk) => appendBoundedOutput(record, chunk, "stderr"));
+  state.daemonPids.add(child.pid);
+  state.daemonProcesses.set(child.pid, record);
+  return record;
+}
+
+async function waitForDaemonReady(state, binAgenc, record) {
+  const deadline = Date.now() + DAEMON_START_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (state.closing) {
+      throw new Error("private TUI gate daemon start interrupted by cleanup");
+    }
+    if (record.exit !== null) {
+      throw new Error(
+        [
+          `private TUI gate daemon exited before readiness (pid ${record.pid})`,
+          `exit: ${record.exit.signal ?? record.exit.code ?? record.exit.error ?? "unknown"}`,
+          `stdout: ${record.stdout}`,
+          `stderr: ${record.stderr}`,
+        ].join("\n"),
+      );
+    }
+    const pid = await readDaemonPid(state.agencHome);
+    if (pid === record.pid) {
+      const status = daemonCommand(binAgenc, ["status"], state.env, 5_000);
+      if (
+        status.status === 0 &&
+        new RegExp(`\\bAgenC daemon running \\(pid ${record.pid}\\)`, "u")
+          .test(status.stdout)
+      ) {
+        return;
+      }
+    }
+    await sleep(DAEMON_POLL_MS);
+  }
+  throw new Error(
+    [
+      `private TUI gate daemon readiness timed out (pid ${record.pid})`,
+      `stdout: ${record.stdout}`,
+      `stderr: ${record.stderr}`,
+    ].join("\n"),
+  );
+}
+
+async function performStartTuiGateDaemon(state, binAgenc) {
+  await assertOwnedState(state);
+  if (state.closing) {
+    throw new Error("private TUI gate daemon start interrupted by cleanup");
+  }
+  const liveRecords = [...state.daemonProcesses.values()]
+    .filter((record) => record.exit === null && isPidAlive(record.pid));
+  if (liveRecords.length > 0) return liveRecords[0].pid;
+
+  const record = spawnForegroundDaemon(state, binAgenc);
+  try {
+    await waitForDaemonReady(state, binAgenc, record);
+    if (state.closing) {
+      throw new Error("private TUI gate daemon start interrupted by cleanup");
+    }
+    await assertOwnedState(state);
+    const currentPid = await readDaemonPid(state.agencHome);
+    if (currentPid !== record.pid) {
+      throw new Error("private TUI gate daemon pid changed during readiness");
+    }
+    return record.pid;
+  } catch (error) {
+    await terminateDaemonRecord(record).catch(() => {});
+    throw error;
+  }
+}
+
+export function startTuiGateDaemon(state, binAgenc) {
+  if (state.cleaned || state.closing) {
+    return Promise.reject(
+      new Error(`TUI gate state is shutting down: ${state.root}`),
+    );
+  }
+  const operation = performStartTuiGateDaemon(state, binAgenc);
+  state.pendingDaemonStarts.add(operation);
+  operation.then(
+    () => state.pendingDaemonStarts.delete(operation),
+    () => state.pendingDaemonStarts.delete(operation),
+  );
+  return operation;
+}
+
+async function waitForRecordExit(record, timeoutMs) {
+  if (record.exit !== null) return true;
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(record.exit !== null), timeoutMs);
+    record.exitPromise.then(() => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+async function terminateDaemonRecord(record, { force = false } = {}) {
+  if (record.exit !== null) return;
+  if (!force) {
+    try {
+      record.child.kill("SIGTERM");
+    } catch {
+      // The retained ChildProcess exit observation remains authoritative.
+    }
+    if (await waitForRecordExit(record, DAEMON_STOP_TIMEOUT_MS)) return;
+  }
+  try {
+    record.child.kill("SIGKILL");
+  } catch {
+    // The retained ChildProcess exit observation remains authoritative.
+  }
+  if (await waitForRecordExit(record, DAEMON_FORCE_KILL_GRACE_MS)) return;
+  throw new Error(`private TUI gate daemon survived SIGKILL (pid ${record.pid})`);
+}
+
+async function terminateOwnedDaemons(state, options = {}) {
+  const results = await Promise.allSettled(
+    [...state.daemonProcesses.values()].map((record) =>
+      terminateDaemonRecord(record, options)),
+  );
+  const failures = results
+    .filter((result) => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "private TUI gate daemon cleanup failed");
+  }
+  const livePids = [...state.daemonPids].filter((pid) => {
+    const record = state.daemonProcesses.get(pid);
+    return record !== undefined && record.exit === null && isPidAlive(pid);
+  });
+  if (livePids.length > 0) {
+    throw new Error(
+      `private TUI gate daemon cleanup was not proven: ${livePids.join(", ")}`,
+    );
+  }
+}
+
+export async function stopTuiGateDaemon(state) {
+  if (!state || state.cleaned) return;
+  const rootPresent = await pathExists(state.root);
+  let ownershipError = null;
+  if (rootPresent) {
+    try {
+      await assertOwnedState(state);
+    } catch (error) {
+      ownershipError = error;
+    }
+  }
+  await terminateOwnedDaemons(state, {
+    force: !rootPresent || ownershipError !== null,
+  });
+  if (!rootPresent) {
+    throw new Error(
+      `private TUI gate root disappeared while stopping its daemon: ${state.root}`,
+    );
+  }
+  if (ownershipError !== null) throw ownershipError;
+  await assertOwnedState(state);
+  const currentPid = await readDaemonPid(state.agencHome);
+  if (
+    currentPid !== null &&
+    isPidAlive(currentPid) &&
+    !state.daemonProcesses.has(currentPid)
+  ) {
+    throw new Error(
+      `refusing to signal unowned pid from private TUI gate state: ${currentPid}`,
+    );
+  }
+  const deadline = Date.now() + DAEMON_FORCE_KILL_GRACE_MS;
+  const socketPath = path.join(state.agencHome, "daemon.sock");
+  while (
+    (await pathExists(socketPath) || await readDaemonPid(state.agencHome) !== null) &&
+    Date.now() < deadline
+  ) {
+    await sleep(DAEMON_POLL_MS);
+  }
+  if (await pathExists(socketPath) || await readDaemonPid(state.agencHome) !== null) {
+    throw new Error("private TUI gate daemon state survived process cleanup");
+  }
+}
+
+async function performTeardown(state) {
+  const rootPresent = await pathExists(state.root);
+  let ownershipError = null;
+  if (rootPresent) {
+    try {
+      await assertOwnedState(state);
+    } catch (error) {
+      ownershipError = error;
+    }
+  }
+  let daemonError = null;
+  try {
+    // If candidate code deleted or redirected private state, skip graceful
+    // daemon cleanup: retained-child SIGKILL prevents the daemon itself from
+    // following poisoned paths while shutting down.
+    await terminateOwnedDaemons(state, {
+      force: !rootPresent || ownershipError !== null,
+    });
+  } catch (error) {
+    daemonError = error;
+  }
+  if (daemonError !== null) throw daemonError;
+
+  if (!rootPresent) {
+    state.cleaned = true;
+    ACTIVE_STATES_BY_HOME.delete(state.home);
+    throw new Error(`private TUI gate root disappeared before cleanup: ${state.root}`);
+  }
+
+  if (ownershipError !== null) throw ownershipError;
+  await assertOwnedState(state);
+  const currentPid = await readDaemonPid(state.agencHome);
+  if (
+    currentPid !== null &&
+    isPidAlive(currentPid) &&
+    !state.daemonProcesses.has(currentPid)
+  ) {
+    throw new Error(
+      `refusing to signal unowned pid from private TUI gate state: ${currentPid}`,
+    );
+  }
+
+  const socketPath = path.join(state.agencHome, "daemon.sock");
+  const socketDeadline = Date.now() + DAEMON_FORCE_KILL_GRACE_MS;
+  while (await pathExists(socketPath) && Date.now() < socketDeadline) {
+    await sleep(DAEMON_POLL_MS);
+  }
+  if (await pathExists(socketPath)) {
+    throw new Error(`private TUI gate socket survived daemon cleanup: ${socketPath}`);
+  }
+
+  await assertOwnedState(state);
+  await rm(state.root, { recursive: true });
+  if (await pathExists(state.root)) {
+    throw new Error(`private TUI gate root survived cleanup: ${state.root}`);
+  }
+  state.cleaned = true;
+  ACTIVE_STATES_BY_HOME.delete(state.home);
+}
+
+async function settlePendingDaemonStarts(state) {
+  while (state.pendingDaemonStarts.size > 0) {
+    await Promise.allSettled([...state.pendingDaemonStarts]);
+  }
+}
+
+export function teardownTuiGateState(state, _binAgenc) {
+  if (!state || state.cleaned) return Promise.resolve();
+  if (state.cleanupPromise === null) {
+    state.closing = true;
+    state.cleanupPromise = (async () => {
+      await settlePendingDaemonStarts(state);
+      await performTeardown(state);
+    })();
+  }
+  return state.cleanupPromise;
+}
+
+async function loadOwnedTuiGateState(home, baseEnv) {
+  const root = path.resolve(home);
+  const owner = JSON.parse(
+    await readFile(path.join(root, OWNER_FILENAME), "utf8"),
+  );
+  if (owner?.kind !== OWNER_KIND || owner?.root !== root || !owner?.ownerId) {
+    throw new Error(`temporary TUI gate home is not owned by this gate: ${root}`);
+  }
+  const env = tuiGateEnvironment(root, baseEnv);
+  return {
+    root,
+    canonicalRoot: await realpath(root),
+    home: root,
+    agencHome: env.AGENC_HOME,
+    env,
+    baseEnv: systemEnvironment(baseEnv),
+    injectedEnv: {},
+    ownerId: owner.ownerId,
+    daemonPids: new Set(),
+    daemonProcesses: new Map(),
+    pendingDaemonStarts: new Set(),
+    cleanupPromise: null,
+    closing: false,
+    cleaned: false,
+  };
+}
+
+export async function teardownTuiGateHome(home, binAgenc, baseEnv = process.env) {
+  if (!home) return;
+  const resolvedHome = path.resolve(home);
+  const activeState = ACTIVE_STATES_BY_HOME.get(resolvedHome);
+  if (activeState !== undefined) {
+    await teardownTuiGateState(activeState, binAgenc);
+    return;
+  }
+  if (!await pathExists(resolvedHome)) {
+    throw new Error(`temporary TUI gate home disappeared before cleanup: ${resolvedHome}`);
+  }
+  const state = await loadOwnedTuiGateState(resolvedHome, baseEnv);
+  await teardownTuiGateState(state, binAgenc);
+}
+
+export function installTuiGateSignalHandlers(cleanup) {
+  let handling = false;
+  const handlers = new Map();
+  for (const [signal, exitCode] of [
+    ["SIGHUP", 129],
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+  ]) {
+    const handler = () => {
+      if (handling) return;
+      handling = true;
+      Promise.resolve()
+        .then(() => cleanup(signal))
+        .catch((error) => {
+          process.stderr.write(
+            `TUI gate signal cleanup failed: ${
+              error instanceof Error ? error.stack ?? error.message : String(error)
+            }\n`,
+          );
+        })
+        .finally(() => {
+          process.exit(exitCode);
+        });
+    };
+    handlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+  return () => {
+    for (const [signal, handler] of handlers) {
+      process.off(signal, handler);
+    }
+  };
+}
+
+export const TUI_GATE_ISOLATION_ENV_KEYS = ISOLATION_ENV_KEYS;
+export const TUI_GATE_TRUST_TIMESTAMP = TRUST_TIMESTAMP;

--- a/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
+++ b/runtime/src/tui/workbench/WorkbenchStatusBar.tsx
@@ -44,7 +44,7 @@ export function WorkbenchStatusBar({
   const stripAvailable =
     typeof columns === "number" ? columns - leftLabelWidth - contextPctWidth - 1 : 0;
   return (
-    <Box height={1} width="100%" flexDirection="row">
+    <Box height={1} width="100%" flexDirection="row" flexShrink={0}>
       <Text color="text2" wrap="truncate-end">AgenC Workbench</Text>
       <Text dimColor wrap="truncate-end"> | {active}</Text>
       <WorkbenchActivityIndicator mode={activityMode} />

--- a/runtime/tests/tui-e2e-harness-env.test.ts
+++ b/runtime/tests/tui-e2e-harness-env.test.ts
@@ -4,12 +4,19 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  TuiSession,
   hasRenderedAssistantReply,
   isolatedHomeEnv,
   resolveHarnessAgencHome,
   tempDaemonEnv,
   tuiE2eGateEnv,
 } from "../scripts/check-tui-e2e/harness.mjs";
+import { runScenario } from "../scripts/check-tui-e2e/runner.mjs";
+import {
+  createTuiGateState,
+  teardownTuiGateState,
+  tuiGateEnvironment,
+} from "../scripts/tui-gate-state.mjs";
 
 describe("TUI E2E harness state isolation", () => {
   it("recognizes the current full-height assistant message gutter", () => {
@@ -58,7 +65,7 @@ describe("TUI E2E harness state isolation", () => {
     );
   });
 
-  it("overrides ambient AgenC roots for a temporary scenario home", () => {
+  it("replaces ambient state roots and drops unrelated operator values", () => {
     const home = "/private/scenario-home";
     const env = isolatedHomeEnv(home, {
       AGENC_CONFIG_DIR: "/ambient/config",
@@ -71,11 +78,15 @@ describe("TUI E2E harness state isolation", () => {
       AGENC_CONFIG_DIR: join(home, ".agenc"),
       AGENC_HOME: join(home, ".agenc"),
       HOME: home,
-      SENTINEL: "preserved",
+      USERPROFILE: home,
+      AGENC_AUTH_BACKEND: "local",
+      AGENC_DAEMON_WEBSOCKET_PORT: "0",
+      TMPDIR: join(home, "tmp"),
     });
+    expect(env.SENTINEL).toBeUndefined();
   });
 
-  it("assembles a temporary daemon environment without ambient state leaks", () => {
+  it("always requests an ephemeral daemon port", () => {
     const home = "/private/scenario-home";
     const env = tempDaemonEnv(home, 19_876, {
       AGENC_CONFIG_DIR: "/ambient/config",
@@ -87,11 +98,11 @@ describe("TUI E2E harness state isolation", () => {
 
     expect(env).toMatchObject({
       AGENC_CONFIG_DIR: join(home, ".agenc"),
-      AGENC_DAEMON_WEBSOCKET_PORT: "19876",
+      AGENC_DAEMON_WEBSOCKET_PORT: "0",
       AGENC_HOME: join(home, ".agenc"),
       HOME: home,
-      SENTINEL: "preserved",
     });
+    expect(env.SENTINEL).toBeUndefined();
   });
 
   it("disables ambient first-run onboarding for ordinary gate scenarios", () => {
@@ -100,16 +111,40 @@ describe("TUI E2E harness state isolation", () => {
     ).toEqual({ AGENC_ONBOARDING: "0", SENTINEL: "preserved" });
   });
 
-  it("applies the deterministic gate environment in the runner", () => {
+  it("applies private state lifecycle in the runner without ambient daemon control", () => {
     const runner = readFileSync(
       new URL("../scripts/check-tui-e2e/runner.mjs", import.meta.url),
       "utf8",
     );
 
-    expect(runner).toContain('"AGENC_ONBOARDING",');
-    expect(runner).toContain(
-      "tuiE2eGateEnv(buildMockProviderEnv(mockServer.baseUrl, process.env))",
-    );
+    expect(runner).toContain("createTuiGateState({");
+    expect(runner).toContain("startTuiGateDaemon(gateState, BIN_AGENC)");
+    expect(runner).toContain("teardownTuiGateState(gateState, BIN_AGENC)");
+    expect(runner).not.toContain("DEFAULT_DAEMON_SOCKET");
+    expect(runner).not.toContain("restartDaemon()");
+  });
+
+  it("forces deterministic gate controls after scenario overrides", () => {
+    const env = tuiGateEnvironment("/private/gate", {
+      AGENC_AUTH_BACKEND: "remote",
+      AGENC_DAEMON_WEBSOCKET_HOST: "0.0.0.0",
+      AGENC_DAEMON_WEBSOCKET_PORT: "7766",
+      AGENC_ONBOARDING: "force",
+      NODE_OPTIONS: "--inspect=9229",
+      OPENAI_API_KEY: "operator-secret",
+    });
+
+    expect(env).toMatchObject({
+      AGENC_AUTH_BACKEND: "local",
+      AGENC_DAEMON_WEBSOCKET_HOST: "127.0.0.1",
+      AGENC_DAEMON_WEBSOCKET_PORT: "0",
+      AGENC_ONBOARDING: "0",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_OPTIONAL_LOCKS: "0",
+      GIT_TERMINAL_PROMPT: "0",
+      NODE_OPTIONS: "",
+    });
+    expect(env.OPENAI_API_KEY).toBeUndefined();
   });
 
   it.each([
@@ -117,14 +152,15 @@ describe("TUI E2E harness state isolation", () => {
     "37-print-mode-yolo.mjs",
     "55-stdin-not-tty.mjs",
     "58-cli-no-tui-flag.mjs",
-  ])("isolates the manual temp-home child in %s", (scenario) => {
+  ])("uses the runner-owned tracked child in %s", (scenario) => {
     const source = readFileSync(
       new URL(`../scripts/check-tui-e2e/scenarios/${scenario}`, import.meta.url),
       "utf8",
     );
 
-    expect(source).toContain("env: tempDaemonEnv(home, wsPort)");
-    expect(source).not.toMatch(/env:\s*\{[^}]*HOME:\s*home/su);
+    expect(source).toContain("session.runAgenc");
+    expect(source).not.toContain("createTempHome");
+    expect(source).not.toContain("tempDaemonEnv");
   });
 
   it.each([
@@ -139,21 +175,105 @@ describe("TUI E2E harness state isolation", () => {
 
     expect(source).toContain('sandboxMode: "danger-full-access"');
     expect(source).toContain('args: ["--permission-mode", "default"]');
-    expect(source).toContain('path.join(slimCwd, "package.json")');
+    expect(source).toContain("slimCwd: true");
+    expect(source).not.toContain("mkdtemp");
     expect(source).not.toContain('args: ["--yolo"]');
   });
 
   it("configures a scenario-only sandbox override before starting its temp daemon", () => {
-    const harness = readFileSync(
-      new URL("../scripts/check-tui-e2e/harness.mjs", import.meta.url),
+    const runner = readFileSync(
+      new URL("../scripts/check-tui-e2e/runner.mjs", import.meta.url),
       "utf8",
     );
-    const configIndex = harness.indexOf(
-      '[BIN_AGENC, "config", "set", "sandbox_mode", sandboxMode]',
+    const configIndex = runner.indexOf("await configureTuiGateSandbox(");
+    const daemonIndex = runner.indexOf(
+      "await startTuiGateDaemon(gateState, BIN_AGENC)",
     );
-    const daemonIndex = harness.indexOf('[BIN_AGENC, "daemon", "start"]');
 
     expect(configIndex).toBeGreaterThan(-1);
     expect(daemonIndex).toBeGreaterThan(configIndex);
+  });
+
+  it("keeps /init writes out of the source checkout", () => {
+    const source = readFileSync(
+      new URL(
+        "../scripts/check-tui-e2e/scenarios/18-slash-init.mjs",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(source).toContain("slimCwd: true");
+  });
+
+  it("refuses an ambient TUI session without private gate ownership", async () => {
+    const session = new TuiSession();
+    await expect(session.prepare()).rejects.toThrow(
+      /requires runner-owned gate state or useTempHome isolation/u,
+    );
+  });
+
+  it("gives every scenario a private clean git fixture", () => {
+    const runner = readFileSync(
+      new URL("../scripts/check-tui-e2e/runner.mjs", import.meta.url),
+      "utf8",
+    );
+    const gateState = readFileSync(
+      new URL("../scripts/tui-gate-state.mjs", import.meta.url),
+      "utf8",
+    );
+    const commitScenario = readFileSync(
+      new URL(
+        "../scripts/check-tui-e2e/scenarios/25-slash-commit.mjs",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(runner).toContain("createTuiGateProject(gateState");
+    expect(runner).toContain("dirty: scenario.meta.dirtyCwd === true");
+    expect(runner).toContain('{ cwd: scenarioCwd }');
+    expect(gateState).toContain(
+      '["init", "--quiet", "--initial-branch=main"]',
+    );
+    expect(gateState).toContain('if (dirty) {');
+    expect(gateState).toContain('trackedFiles.push("diff-fixture.txt")');
+    expect(commitScenario).toContain("runner-owned clean git fixture");
+  });
+
+  it("cancels tracked children and waits for scenario quiescence on timeout", async () => {
+    const gateState = await createTuiGateState({
+      prefix: "agenc-tui-timeout-test-",
+    });
+    let childPid: number | undefined;
+    try {
+      const result = await runScenario(
+        {
+          name: "timeout-test.mjs",
+          meta: { timeoutMs: 50 },
+          run: async (session: TuiSession) => {
+            const child = await session.spawnTracked(
+              process.execPath,
+              ["-e", "setInterval(() => {}, 1000)"],
+              { stdio: "ignore" },
+            );
+            childPid = child.pid;
+            await session.waitForChildClose(child, 5_000);
+          },
+        },
+        gateState,
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.quiesced).toBe(true);
+      expect(result.error?.message).toMatch(/scenario timeout/u);
+      expect(result.session.cwd).toBe(join(gateState.root, "project"));
+      expect(childPid).toBeTypeOf("number");
+      expect(() => process.kill(childPid!, 0)).toThrow(
+        expect.objectContaining({ code: "ESRCH" }),
+      );
+    } finally {
+      await teardownTuiGateState(gateState);
+    }
   });
 });

--- a/runtime/tests/tui/workbench-context-strip.test.tsx
+++ b/runtime/tests/tui/workbench-context-strip.test.tsx
@@ -160,6 +160,34 @@ describe("selectStripSegments degradation", () => {
 });
 
 describe("WorkbenchStatusBar context strip rendering", () => {
+  test("keeps the fixed title row under tall transcript pressure", async () => {
+    const pressured = await renderToString(
+      <AppStateProvider initialState={stateWith()}>
+        <Box flexDirection="column" height={3} overflow="hidden">
+          <WorkbenchStatusBar columns={80} />
+          <Box height={3} flexShrink={0}>
+            <Text>TRANSCRIPT BODY</Text>
+          </Box>
+        </Box>
+      </AppStateProvider>,
+      { columns: 80, rows: 3 },
+    );
+    const shrinkableControl = await renderToString(
+      <Box flexDirection="column" height={3} overflow="hidden">
+        <Box height={1}>
+          <Text>SHRINKABLE TITLE</Text>
+        </Box>
+        <Box height={3} flexShrink={0}>
+          <Text>TRANSCRIPT BODY</Text>
+        </Box>
+      </Box>,
+      { columns: 80, rows: 3 },
+    );
+
+    expect(pressured).toContain("AgenC Workbench");
+    expect(shrinkableControl).not.toContain("SHRINKABLE TITLE");
+  });
+
   test("shows model, a non-default permission mode, and a compact cwd at a wide width", async () => {
     const { getCwdState } = await import("../../src/bootstrap/state.js");
     const out = await renderStatusBar(120, { mode: "plan" });

--- a/scripts/required-gate-contract.mjs
+++ b/scripts/required-gate-contract.mjs
@@ -159,6 +159,7 @@ export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   "runtime/scripts/check-sdk-generated-types.mjs",
   "runtime/scripts/check-tui-runtime-startup.mjs",
   "runtime/scripts/check-tui-runtime-startup.test.mjs",
+  "runtime/scripts/tui-gate-state.mjs",
   "runtime/scripts/hermetic-docker-seccomp.json",
   "runtime/scripts/hermetic-network-boundary.c",
   "runtime/scripts/run-hermetic-test-boundary.mjs",


### PR DESCRIPTION
## Summary

- Run every TUI E2E scenario, startup smoke, and visual gate in an owned private HOME/AGENC_HOME with a port-0 daemon, isolated Git/XDG state, deterministic trust, and scrubbed provider credentials.
- Centralize foreground daemon and PTY ownership so cleanup is serialized, signal-safe, timeout-safe, resistant to symlink/PID poisoning, and asserted; parallel shards no longer touch operator state.
- Upgrade scenarios to use tracked subprocesses and real private Git fixtures for diff, hooks, Neovim, and transcript behavior; keep workbench status chrome visible under tall transcripts with revert-sensitive coverage.

## Operator impact

- TUI gates no longer stop, restart, read, or write the operator daemon and home.
- No user-facing configuration migration or breaking change.

## Verification

- `npm run typecheck`
- `npm test` — 1,883 files passed; 16,535 tests passed
- `npm run build`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e` — 111/111 scenarios passed
- command visual smoke across 148x40, 120x30, and 80x24
- workbench visual smoke across 148x40, 120x30, 80x24, and 60x20
- transcript-scroll smoke across 148x40, 100x28, and 80x24
- 20-run signal cleanup stress plus parallel shard probes

## Breaking changes

None.