### PR TITLE
fix(release): trust the exact Rocky checkout path

### DIFF
--- a/.github/workflows/verify-node-bootstrap.yml
+++ b/.github/workflows/verify-node-bootstrap.yml
@@ -62,8 +62,13 @@ jobs:
           test "$GITHUB_REPOSITORY" = tetsuo-ai/agenc-core
           test "$REPOSITORY_VISIBILITY" = public
           test "$GITHUB_REF" = refs/heads/main
-          test "$(git rev-parse HEAD)" = "$TESTED_SHA"
-          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          source_root="$(pwd -P)"
+          # actions/checkout registers this bind-mounted path only in its
+          # temporary HOME. Keep Git's ownership check enabled everywhere else
+          # and register only the exact reviewed workspace for container steps.
+          git config --global --add safe.directory "$source_root"
+          test "$(git -C "$source_root" rev-parse HEAD)" = "$TESTED_SHA"
+          test -z "$(git -C "$source_root" status --porcelain=v1 --untracked-files=all)"
       - name: Reproduce the immutable compatibility bootstrap
         env:
           AGENC_RELEASE_SLUG: ${{ matrix.slug }}

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -543,6 +543,12 @@ describe("reproducible install and release contract", () => {
     expect(pretagWorkflow).toContain("test \"$TESTED_SHA\" = \"$GITHUB_SHA\"");
     expect(pretagWorkflow).toContain("test \"$GITHUB_REF\" = refs/heads/main");
     expect(pretagWorkflow).toContain(
+      'git config --global --add safe.directory "$source_root"',
+    );
+    expect(pretagWorkflow).toContain(
+      'git -C "$source_root" status --porcelain=v1 --untracked-files=all',
+    );
+    expect(pretagWorkflow).toContain(
       "rockylinux@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c",
     );
     expect(pretagWorkflow).toContain("runner: ubuntu-24.04");


### PR DESCRIPTION
## Summary
- register only the canonical bind-mounted workspace as a Git safe directory inside the native Rocky container
- keep exact SHA and clean-tree checks scoped to that workspace
- add a structural regression for the hosted ownership boundary

## Evidence
- hosted pre-tag run 30300077872 failed before artifact generation with Git dubious ownership on both architectures
- focused reproducible-build contract: 11/11 passed
- typecheck passed
- YAML and diff checks passed
- commit hook build + PTY startup passed
- independent review: no blockers