### PR TITLE
fix(packaging): keep Homebrew formula auditable

### DIFF
--- a/packaging/homebrew/agenc.rb
+++ b/packaging/homebrew/agenc.rb
@@ -6,27 +6,21 @@
 class Agenc < Formula
   desc "Daemon-backed, terminal-native coding agent"
   homepage "https://github.com/tetsuo-ai/agenc-core"
+  url "https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.11.2/agenc-runtime-0.11.2-darwin-#{Hardware::CPU.arm? ? "arm64" : "x64"}-node26-abi147.tar.gz"
   version "0.11.2"
+  arm64_sha256 = "REPLACE_WITH_DARWIN_ARM64_SHA256"
+  x64_sha256 = "REPLACE_WITH_DARWIN_X64_SHA256"
+  sha256 Hardware::CPU.arm? ? arm64_sha256 : x64_sha256
   license "MIT"
-
-  on_arm do
-    url "https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.11.2/agenc-runtime-0.11.2-darwin-arm64-node26-abi147.tar.gz"
-    sha256 "REPLACE_WITH_DARWIN_ARM64_SHA256"
-  end
-
-  on_intel do
-    url "https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.11.2/agenc-runtime-0.11.2-darwin-x64-node26-abi147.tar.gz"
-    sha256 "REPLACE_WITH_DARWIN_X64_SHA256"
-  end
 
   # The runtime artifact includes its reviewed Node 26.5.0 executable. Keep
   # ripgrep as the only host tool dependency used by the coding-agent surface.
-  depends_on :macos => :ventura
+  depends_on macos: :ventura
   depends_on "ripgrep"
 
   def install
     odie "AgenC requires macOS 13.5 or newer." if MacOS.full_version < "13.5"
-    libexec.install Dir["node_modules"]
+    libexec.install "node_modules"
 
     node_bin = libexec/"node_modules/.agenc-node/bin/node"
     runtime_bin = libexec/"node_modules/@tetsuo-ai/runtime/bin/agenc"

--- a/runtime/tests/packaging/distribution.test.ts
+++ b/runtime/tests/packaging/distribution.test.ts
@@ -73,12 +73,28 @@ describe("homebrew packaging", () => {
     );
     expect(existsSync(formulaPath)).toBe(true);
     const formula = readFileSync(formulaPath, "utf8");
+    expect(formula).toContain(`  homepage "https://github.com/tetsuo-ai/agenc-core"
+  url "https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.11.2/agenc-runtime-0.11.2-darwin-#{Hardware::CPU.arm? ? "arm64" : "x64"}-node26-abi147.tar.gz"
+  version "0.11.2"
+  arm64_sha256 = "REPLACE_WITH_DARWIN_ARM64_SHA256"
+  x64_sha256 = "REPLACE_WITH_DARWIN_X64_SHA256"
+  sha256 Hardware::CPU.arm? ? arm64_sha256 : x64_sha256
+  license "MIT"`);
     expect(formula).toContain("class Agenc < Formula");
     expect(formula).not.toContain("disable!");
     expect(formula).not.toContain('depends_on "node"');
-    expect(formula).toContain("depends_on :macos => :ventura");
+    expect(formula).toContain("depends_on macos: :ventura");
+    expect(formula).not.toContain("depends_on :macos => :ventura");
     expect(formula).toContain('MacOS.full_version < "13.5"');
     expect(formula).toContain('depends_on "ripgrep"');
+    expect(formula).toContain(
+      'darwin-#{Hardware::CPU.arm? ? "arm64" : "x64"}-node26-abi147.tar.gz',
+    );
+    expect(formula).not.toContain("on_arm do");
+    expect(formula).not.toContain("on_intel do");
+    expect(formula).toContain(
+      "sha256 Hardware::CPU.arm? ? arm64_sha256 : x64_sha256",
+    );
     expect(formula).toContain('libexec/"node_modules/.agenc-node/bin/node"');
     expect(formula).toContain(
       'libexec/"node_modules/@tetsuo-ai/runtime/bin/agenc"',
@@ -105,6 +121,7 @@ describe("homebrew packaging", () => {
     expect(formula).toContain("OWNER-PUBLISH STEP");
     // Homebrew installs the immutable artifact directly and never performs
     // nested network installation during a formula build.
-    expect(formula).toContain("libexec.install");
+    expect(formula).toContain('libexec.install "node_modules"');
+    expect(formula).not.toContain('libexec.install Dir["node_modules"]');
   });
 });


### PR DESCRIPTION
## Summary

- replace architecture metadata blocks rejected by Homebrew with one architecture-selecting URL and checksum
- use current dependency and libexec install syntax proven by the published tap
- add order-sensitive and revert-sensitive packaging assertions

## Validation

- ruby -c packaging/homebrew/agenc.rb
- targeted distribution test: 4 passed
- npm run typecheck
- npm test: 16,578 passed, 22 skipped
- pre-commit runtime build and PTY startup smoke
- downstream brew test-bot on macOS 26 arm64 and macOS 15 Intel