### PR TITLE
test(runtime): eliminate skipped coverage

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -480,9 +480,6 @@ jobs:
           $ErrorActionPreference = "Stop"
           & npm.cmd ci --ignore-scripts --no-audit --no-fund
           if ($LASTEXITCODE -ne 0) { throw "npm ci failed" }
-          $env:npm_config_build_from_source = "true"
-          & npm.cmd rebuild better-sqlite3 esbuild node-pty
-          if ($LASTEXITCODE -ne 0) { throw "native dependency rebuild failed" }
 
       - name: Run the exact Windows native capability lane
         shell: pwsh

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1,0 +1,550 @@
+name: platform-tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: platform-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "26.5.0"
+  NPM_VERSION: "11.17.0"
+
+jobs:
+  powershell:
+    name: powershell
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Bind the checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "tetsuo-ai/agenc-core"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Install digest-pinned Node, npm, and PowerShell
+        shell: bash
+        run: |
+          set -euo pipefail
+          node_file="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["nodeDistributions"]["linux-x64"]["file"])')"
+          node_sha="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["nodeDistributions"]["linux-x64"]["sha256"])')"
+          node_bytes="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["nodeDistributions"]["linux-x64"]["bytes"])')"
+          npm_file="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["npmDistribution"]["file"])')"
+          npm_url="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["npmDistribution"]["url"])')"
+          npm_sha="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["npmDistribution"]["sha256"])')"
+          powershell_version="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["powershellTestRuntime"]["version"])')"
+          powershell_file="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["powershellTestRuntime"]["linux-x64"]["file"])')"
+          powershell_url="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["powershellTestRuntime"]["linux-x64"]["url"])')"
+          powershell_sha="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["powershellTestRuntime"]["linux-x64"]["sha256"])')"
+          powershell_bytes="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["powershellTestRuntime"]["linux-x64"]["bytes"])')"
+
+          test "$node_file" = "node-v${NODE_VERSION}-linux-x64.tar.gz"
+          test "$npm_file" = "npm-${NPM_VERSION}.tgz"
+          test "$powershell_file" = "powershell-${powershell_version}-linux-x64.tar.gz"
+          [[ "$node_sha" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$npm_sha" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$powershell_sha" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$node_bytes" =~ ^[1-9][0-9]*$ ]]
+          [[ "$powershell_bytes" =~ ^[1-9][0-9]*$ ]]
+          test "$npm_url" = "https://registry.npmjs.org/npm/-/${npm_file}"
+          test "$powershell_url" = \
+            "https://github.com/PowerShell/PowerShell/releases/download/v${powershell_version}/${powershell_file}"
+
+          node_archive="$RUNNER_TEMP/$node_file"
+          npm_archive="$RUNNER_TEMP/$npm_file"
+          powershell_archive="$RUNNER_TEMP/$powershell_file"
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --fail --location --silent --show-error \
+            "https://nodejs.org/dist/v${NODE_VERSION}/${node_file}" \
+            --output "$node_archive"
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --fail --location --silent --show-error \
+            "$npm_url" --output "$npm_archive"
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --fail --location --silent --show-error \
+            "$powershell_url" --output "$powershell_archive"
+
+          test "$(sha256sum "$node_archive" | awk '{print $1}')" = "$node_sha"
+          test "$(sha256sum "$npm_archive" | awk '{print $1}')" = "$npm_sha"
+          test "$(sha256sum "$powershell_archive" | awk '{print $1}')" = "$powershell_sha"
+          test "$(stat --format='%s' "$node_archive")" = "$node_bytes"
+          test "$(stat --format='%s' "$powershell_archive")" = "$powershell_bytes"
+
+          node_root="$RUNNER_TEMP/node-distribution"
+          powershell_root="$RUNNER_TEMP/powershell-distribution"
+          mkdir -p "$node_root" "$powershell_root"
+          tar -xzf "$node_archive" --strip-components=1 -C "$node_root"
+          tar -xzf "$powershell_archive" -C "$powershell_root"
+          chmod -R a+rX,go-w "$powershell_root"
+          chmod 0555 "$powershell_root/pwsh"
+
+          bundled_npm_cli="$node_root/lib/node_modules/npm/bin/npm-cli.js"
+          "$node_root/bin/node" "$bundled_npm_cli" install --global \
+            "$npm_archive" --prefix "$node_root" \
+            --ignore-scripts --no-audit --no-fund
+          npm_cli="$node_root/lib/node_modules/npm/bin/npm-cli.js"
+          test "$("$node_root/bin/node" --version)" = "v${NODE_VERSION}"
+          test "$("$node_root/bin/node" "$npm_cli" --version)" = "$NPM_VERSION"
+          test "$(POWERSHELL_TELEMETRY_OPTOUT=1 \
+            POWERSHELL_UPDATECHECK=Off \
+            DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+            DOTNET_NOLOGO=1 \
+            "$powershell_root/pwsh" -NoLogo -NoProfile -Command \
+            '$PSVersionTable.PSVersion.ToString()')" = "$powershell_version"
+
+          {
+            echo "$node_root/bin"
+            echo "$powershell_root"
+          } >> "$GITHUB_PATH"
+          {
+            echo "AGENC_NODE_EXECUTABLE_PATH=$node_root/bin/node"
+            echo "AGENC_NPM_CLI_PATH=$npm_cli"
+            echo "npm_config_nodedir=$node_root"
+            echo "POWERSHELL_TELEMETRY_OPTOUT=1"
+            echo "POWERSHELL_UPDATECHECK=Off"
+            echo "DOTNET_CLI_TELEMETRY_OPTOUT=1"
+            echo "DOTNET_NOLOGO=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Install the reviewed dependency graph
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$AGENC_NODE_EXECUTABLE_PATH" "$AGENC_NPM_CLI_PATH" ci \
+            --ignore-scripts --no-audit --no-fund
+          npm_config_build_from_source=true \
+            "$AGENC_NODE_EXECUTABLE_PATH" "$AGENC_NPM_CLI_PATH" rebuild \
+              better-sqlite3 esbuild node-pty
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(npm --version)" = "$NPM_VERSION"
+          test "$(pwsh -NoLogo -NoProfile -Command \
+            '$PSVersionTable.PSVersion.ToString()')" = \
+            "$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["powershellTestRuntime"]["version"])')"
+
+      - name: Run the exact PowerShell capability lane
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="$RUNNER_TEMP/powershell-test-results.json"
+          "$AGENC_NODE_EXECUTABLE_PATH" \
+            runtime/scripts/run-hermetic-vitest.mjs \
+              --require-zero-skips \
+              run \
+              --config vitest.powershell.config.ts \
+              --allowOnly=false \
+              --reporter=verbose \
+              --reporter=json \
+              --outputFile.json "$results"
+          "$AGENC_NODE_EXECUTABLE_PATH" --input-type=module - \
+            "$results" <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing PowerShell-test results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const expectedTests = 19;
+          const expectedFiles = [
+            "tests/budget/admitted-legacy-powershell.powershell.test.ts",
+            "tests/packaging/install-ps1.powershell.test.ts",
+            "tests/shell-command/powershell-parser.powershell.test.ts",
+            "tests/tools/PowerShellTool.execution.powershell.test.ts",
+          ];
+          const exactCounts = {
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTestSuites: 7,
+            numPassedTestSuites: 7,
+            numTotalTests: expectedTests,
+            numPassedTests: expectedTests,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `PowerShell-test result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (results.success !== true || !Array.isArray(results.testResults)) {
+            throw new Error("PowerShell-test result did not report success");
+          }
+          const files = results.testResults
+            .map(result => relative(resolve("runtime"), result.name).split("\\").join("/"))
+            .sort();
+          if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+            throw new Error(
+              `PowerShell-test files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
+            );
+          }
+          console.log(
+            `PowerShell capability lane passed ${expectedTests} tests in ${files.length} files with zero skipped`,
+          );
+          NODE
+
+          leaked_pids="$RUNNER_TEMP/powershell-leaked-pids.txt"
+          if pgrep -f -- \
+            '[/]powershell-distribution/pwsh([[:space:]]|$)' \
+            > "$leaked_pids"; then
+            echo "PowerShell capability lane leaked process(es):" >&2
+            cat "$leaked_pids" >&2
+            exit 1
+          fi
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+  neovim:
+    name: neovim
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Bind the checkout and provision pinned npm and Neovim
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "tetsuo-ai/agenc-core"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$(node --version)" = "v${NODE_VERSION}"
+
+          npm_archive="$RUNNER_TEMP/npm-${NPM_VERSION}.tgz"
+          node scripts/fetch-pinned-npm.mjs "$npm_archive"
+          npm install --global "$npm_archive" \
+            --ignore-scripts --no-audit --no-fund
+          test "$(npm --version)" = "$NPM_VERSION"
+
+          neovim_version="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["neovimTestRuntime"]["version"])')"
+          neovim_file="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["neovimTestRuntime"]["linux-x64"]["file"])')"
+          neovim_url="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["neovimTestRuntime"]["linux-x64"]["url"])')"
+          neovim_sha="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["neovimTestRuntime"]["linux-x64"]["sha256"])')"
+          neovim_bytes="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["neovimTestRuntime"]["linux-x64"]["bytes"])')"
+          test "$neovim_version" = "0.12.1"
+          test "$neovim_file" = "nvim-linux-x86_64.tar.gz"
+          test "$neovim_url" = \
+            "https://github.com/neovim/neovim/releases/download/v${neovim_version}/${neovim_file}"
+          [[ "$neovim_sha" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$neovim_bytes" =~ ^[1-9][0-9]*$ ]]
+
+          neovim_archive="$RUNNER_TEMP/$neovim_file"
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --fail --location --silent --show-error \
+            "$neovim_url" --output "$neovim_archive"
+          test "$(sha256sum "$neovim_archive" | awk '{print $1}')" = "$neovim_sha"
+          test "$(stat --format='%s' "$neovim_archive")" = "$neovim_bytes"
+
+          neovim_root="$RUNNER_TEMP/neovim-distribution"
+          mkdir -p "$neovim_root"
+          tar -xzf "$neovim_archive" --strip-components=1 -C "$neovim_root"
+          chmod -R a+rX,go-w "$neovim_root"
+          chmod 0555 "$neovim_root/bin/nvim"
+          test "$("$neovim_root/bin/nvim" --version | sed -n '1p')" = \
+            "NVIM v${neovim_version}"
+          echo "$neovim_root/bin" >> "$GITHUB_PATH"
+          echo "AGENC_PINNED_NVIM=$neovim_root/bin/nvim" >> "$GITHUB_ENV"
+
+      - name: Install the reviewed dependency graph
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm_config_build_from_source=true \
+            npm rebuild better-sqlite3 esbuild node-pty
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(npm --version)" = "$NPM_VERSION"
+          test "$(command -v nvim)" = "$AGENC_PINNED_NVIM"
+          test "$(nvim --version | sed -n '1p')" = "NVIM v0.12.1"
+
+      - name: Run the exact real-Neovim capability lane
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="$RUNNER_TEMP/neovim-test-results.json"
+          node runtime/scripts/run-hermetic-vitest.mjs \
+            --require-zero-skips \
+            run \
+            --config vitest.neovim.config.ts \
+            --allowOnly=false \
+            --reporter=verbose \
+            --reporter=json \
+            --outputFile.json "$results"
+          node --input-type=module - "$results" <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing Neovim-test results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const expectedFile =
+            "tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts";
+          const exactCounts = {
+            numTotalTestSuites: 2,
+            numPassedTestSuites: 2,
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTests: 4,
+            numPassedTests: 4,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `Neovim-test result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (
+            results.success !== true ||
+            !Array.isArray(results.testResults) ||
+            results.testResults.length !== 1
+          ) {
+            throw new Error("Neovim-test result did not report one successful file");
+          }
+          const file = relative(
+            resolve("runtime"),
+            results.testResults[0].name,
+          ).split("\\").join("/");
+          if (file !== expectedFile) {
+            throw new Error(
+              `Neovim-test file was ${JSON.stringify(file)}, expected ${expectedFile}`,
+            );
+          }
+          console.log("Neovim capability lane passed 4 tests in 1 file with zero skipped");
+          NODE
+          if pgrep -f -- "$AGENC_PINNED_NVIM" >/dev/null; then
+            pgrep -af -- "$AGENC_PINNED_NVIM" >&2
+            echo "real-Neovim capability lane leaked a child process" >&2
+            exit 1
+          fi
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+  macos-native:
+    name: macos-native
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Bind the checkout and install pinned npm
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "tetsuo-ai/agenc-core"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$(node --version)" = "v${NODE_VERSION}"
+          npm_archive="$RUNNER_TEMP/npm-${NPM_VERSION}.tgz"
+          node scripts/fetch-pinned-npm.mjs "$npm_archive"
+          npm install --global "$npm_archive" \
+            --ignore-scripts --no-audit --no-fund
+          test "$(npm --version)" = "$NPM_VERSION"
+
+      - name: Install the reviewed dependency graph
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm_config_build_from_source=true \
+            npm rebuild better-sqlite3 esbuild node-pty
+
+      - name: Run the exact macOS native capability lane
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="$RUNNER_TEMP/macos-native-test-results.json"
+          node runtime/scripts/run-hermetic-vitest.mjs \
+            --require-zero-skips \
+            run tests/tools/runtimes/runtime.darwin.test.ts \
+            --config vitest.native.config.ts \
+            --allowOnly=false \
+            --reporter=verbose \
+            --reporter=json \
+            --outputFile.json "$results"
+          node --input-type=module - "$results" <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing macOS-native results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const expectedFile = "tests/tools/runtimes/runtime.darwin.test.ts";
+          const exactCounts = {
+            numTotalTestSuites: 1,
+            numPassedTestSuites: 1,
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTests: 1,
+            numPassedTests: 1,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `macOS-native result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (
+            results.success !== true ||
+            !Array.isArray(results.testResults) ||
+            results.testResults.length !== 1
+          ) {
+            throw new Error("macOS-native result did not report one successful file");
+          }
+          const file = relative(
+            resolve("runtime"),
+            results.testResults[0].name,
+          ).split("\\").join("/");
+          if (file !== expectedFile) {
+            throw new Error(
+              `macOS-native file was ${JSON.stringify(file)}, expected ${expectedFile}`,
+            );
+          }
+          console.log("macOS native capability lane passed 1 test in 1 file with zero skipped");
+          NODE
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+  windows-native:
+    name: windows-native
+    runs-on: windows-2025
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Bind the checkout and install pinned npm
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:GITHUB_REPOSITORY -ne "tetsuo-ai/agenc-core") {
+            throw "unexpected repository: $env:GITHUB_REPOSITORY"
+          }
+          if ((git rev-parse HEAD) -ne $env:GITHUB_SHA) {
+            throw "checkout is not bound to GITHUB_SHA"
+          }
+          if (-not [string]::IsNullOrWhiteSpace(
+            (git status --porcelain=v1 --untracked-files=all | Out-String)
+          )) {
+            throw "checkout is not clean"
+          }
+          if ((node --version) -ne "v$env:NODE_VERSION") {
+            throw "unexpected Node version"
+          }
+          $npmArchive = Join-Path $env:RUNNER_TEMP "npm-$env:NPM_VERSION.tgz"
+          & node scripts/fetch-pinned-npm.mjs $npmArchive
+          if ($LASTEXITCODE -ne 0) { throw "pinned npm download failed" }
+          & npm.cmd install --global $npmArchive `
+            --ignore-scripts --no-audit --no-fund
+          if ($LASTEXITCODE -ne 0) { throw "pinned npm install failed" }
+          if ((npm.cmd --version) -ne $env:NPM_VERSION) {
+            throw "unexpected npm version"
+          }
+
+      - name: Install the reviewed dependency graph
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & npm.cmd ci --ignore-scripts --no-audit --no-fund
+          if ($LASTEXITCODE -ne 0) { throw "npm ci failed" }
+          $env:npm_config_build_from_source = "true"
+          & npm.cmd rebuild better-sqlite3 esbuild node-pty
+          if ($LASTEXITCODE -ne 0) { throw "native dependency rebuild failed" }
+
+      - name: Run the exact Windows native capability lane
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $results = Join-Path $env:RUNNER_TEMP "windows-native-test-results.json"
+          & node runtime/scripts/run-hermetic-vitest.mjs `
+            --require-zero-skips `
+            run `
+            tests/durability/atomic-artifact.win32.test.ts `
+            tests/utils/execFileNoThrow.win32.test.ts `
+            --config vitest.native.config.ts `
+            --allowOnly=false `
+            --reporter=verbose `
+            --reporter=json `
+            --outputFile.json $results
+          if ($LASTEXITCODE -ne 0) { throw "Windows native tests failed" }
+          @'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing Windows-native results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const expectedFiles = [
+            "tests/durability/atomic-artifact.win32.test.ts",
+            "tests/utils/execFileNoThrow.win32.test.ts",
+          ];
+          const exactCounts = {
+            numTotalTestSuites: 3,
+            numPassedTestSuites: 3,
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTests: 3,
+            numPassedTests: 3,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `Windows-native result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (results.success !== true || !Array.isArray(results.testResults)) {
+            throw new Error("Windows-native result did not report success");
+          }
+          const files = results.testResults
+            .map(result => relative(resolve("runtime"), result.name).split("\\").join("/"))
+            .sort();
+          if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+            throw new Error(
+              `Windows-native files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
+            );
+          }
+          console.log("Windows native capability lane passed 3 tests in 2 files with zero skipped");
+          '@ | node --input-type=module - $results
+          if ($LASTEXITCODE -ne 0) { throw "Windows native result contract failed" }
+          if (-not [string]::IsNullOrWhiteSpace(
+            (git status --porcelain=v1 --untracked-files=all | Out-String)
+          )) {
+            throw "Windows native lane dirtied the checkout"
+          }

--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -6,9 +6,11 @@
 # Linux native dependencies build in a glibc 2.28 container so the generic
 # linux artifacts retain Node's Tier-1 compatibility baseline.
 #
-# This is an artifact-build workflow, not a test workflow. Before dispatch, the
-# operator must complete and retain the exact-tag local release evidence defined
-# in docs/ci-required-gates.md. Publishing stays local/operator-driven (no
+# This is an artifact-build workflow, not a replacement for the local test
+# plan. Its native jobs additionally run the exact macOS and Windows integration
+# probes that Linux cannot execute. Before dispatch, the operator must complete
+# and retain the exact-tag local release evidence defined in
+# docs/ci-required-gates.md. Publishing stays local/operator-driven (no
 # cross-repository write secret in this workflow). The reviewed draft, explicit
 # destination tag, artifact attestation, immutable publication, and downstream
 # npm/Docker/Homebrew sequence are documented in docs/install.md under
@@ -768,7 +770,7 @@ jobs:
           "AGENC_NODE_IMPORT_LIBRARY_BYTES=$($importLibrary.bytes)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "AGENC_NODE_COMMON_GYPI_SHA256=$($headerProof.sha256)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "AGENC_NPM_DISTRIBUTION_SHA256=$($toolchain.npmDistribution.sha256)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Build from two isolated worktrees and compare bytes
+      - name: Run native probes and build from two isolated worktrees
         shell: bash
         run: |
           set -euo pipefail
@@ -785,6 +787,26 @@ jobs:
           second_source="$owned_root/source-second"
           first="$owned_root/artifact-first"
           second="$owned_root/artifact-second"
+          native_results="$owned_root/native-test-results.json"
+          case "$AGENC_RELEASE_SLUG" in
+            darwin-arm64|darwin-x64)
+              native_tests=("tests/tools/runtimes/runtime.darwin.test.ts")
+              expected_native_tests=1
+              expected_native_suites=1
+              ;;
+            win-x64)
+              native_tests=(
+                "tests/durability/atomic-artifact.win32.test.ts"
+                "tests/utils/execFileNoThrow.win32.test.ts"
+              )
+              expected_native_tests=3
+              expected_native_suites=3
+              ;;
+            *)
+              echo "unsupported native release slug: $AGENC_RELEASE_SLUG" >&2
+              exit 1
+              ;;
+          esac
           cleanup() {
             git -C "$source_root" worktree remove --force "$first_source" 2>/dev/null || true
             git -C "$source_root" worktree remove --force "$second_source" 2>/dev/null || true
@@ -808,6 +830,79 @@ jobs:
             test -z "$(git -C "$build_source" status --porcelain=v1 --untracked-files=all)"
             "$AGENC_NODE_EXECUTABLE_PATH" "$AGENC_NPM_CLI_PATH" ci --prefix "$build_source" \
               --cache "$owned_root/npm-cache-$build" --no-audit --no-fund
+            if test "$build" = first; then
+              "$AGENC_NODE_EXECUTABLE_PATH" \
+                "$build_source/runtime/scripts/run-hermetic-vitest.mjs" \
+                --require-zero-skips \
+                run "${native_tests[@]}" \
+                --config "$build_source/runtime/vitest.native.config.ts" \
+                --allowOnly=false \
+                --reporter=verbose \
+                --reporter=json \
+                --outputFile.json "$native_results"
+              "$AGENC_NODE_EXECUTABLE_PATH" --input-type=module - \
+                "$native_results" "$expected_native_tests" \
+                "$expected_native_suites" "${native_tests[@]}" <<'NODE'
+          import { readFileSync } from "node:fs";
+
+          const [
+            resultsPath,
+            expectedTestsText,
+            expectedSuitesText,
+            ...expectedFiles
+          ] = process.argv.slice(2);
+          const expectedTests = Number.parseInt(expectedTestsText ?? "", 10);
+          const expectedSuites = Number.parseInt(expectedSuitesText ?? "", 10);
+          if (
+            !resultsPath ||
+            expectedFiles.length < 1 ||
+            !Number.isSafeInteger(expectedTests) ||
+            expectedTests < 1 ||
+            !Number.isSafeInteger(expectedSuites) ||
+            expectedSuites < 1
+          ) {
+            throw new Error("invalid native-test result assertion inputs");
+          }
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const exactCounts = {
+            numTotalTestSuites: expectedSuites,
+            numPassedTestSuites: expectedSuites,
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTests: expectedTests,
+            numPassedTests: expectedTests,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `native-test result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (results.success !== true || !Array.isArray(results.testResults)) {
+            throw new Error("native-test result did not report success");
+          }
+          const files = results.testResults
+            .map(result => String(result.name).split("\\").join("/"))
+            .map(file => expectedFiles.find(expectedFile =>
+              file.endsWith(`/runtime/${expectedFile}`),
+            ) ?? file)
+            .sort();
+          expectedFiles.sort();
+          if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+            throw new Error(
+              `native-test files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
+            );
+          }
+          console.log(
+            `native integration probe passed ${expectedTests} test(s) in ${expectedFiles.length} file(s) with zero skipped`,
+          );
+          NODE
+              test -z "$(git -C "$build_source" status --porcelain=v1 --untracked-files=all)"
+            fi
             AGENC_RELEASE_OUT_DIR="$build_output" \
               "$AGENC_NODE_EXECUTABLE_PATH" \
                 "$build_source/packages/agenc/scripts/build-runtime-tarball.mjs"

--- a/README.md
+++ b/README.md
@@ -377,15 +377,19 @@ The optional design-audit browser is likewise an explicit external process:
 it receives background-network suppression flags, but only `npm test` provides
 the authoritative OS egress boundary.
 
-**Required checks:** the complete suite runs locally, never in GitHub Actions.
-Before merge, the PR records the exact tested SHA, commands, results, and
-skips; GitHub is only the branch/PR/merge record. Release verification repeats
+**Required checks:** the complete platform-independent suite runs locally.
+GitHub Actions carries only exact, narrow PowerShell, Neovim, macOS, and
+Windows capability lanes. Before merge, the PR records the exact locally
+tested SHA, commands, results, and skips. Release verification repeats
 the same local gates against the immutable release-tag commit and retains the
 defined local evidence record. Manual release workflows may build artifacts
-afterward, but run no tests. The repository retains an optional GitHub
-App/ruleset design, but it is inactive and not required by the current
-local-only operating policy. Contract and reproduction details live in
-[`docs/ci-required-gates.md`](docs/ci-required-gates.md).
+afterward; the tagged native runtime builders also require one macOS Seatbelt
+probe or three Windows atomic-artifact/`.cmd` probes in two files to pass with
+zero skips before building. Those native probes do not replace the local test
+plan. The
+repository retains an optional GitHub App/ruleset design, but it is inactive
+and not required by the current local-only operating policy. Contract and
+reproduction details live in [`docs/ci-required-gates.md`](docs/ci-required-gates.md).
 
 Doc index: [`docs/INDEX.md`](docs/INDEX.md). Local contributor notes may live in a gitignored `AGENTS.md`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -372,15 +372,20 @@ crashing the process.
   installs and package builds under different umasks, then uses two additional
   pristine checkouts to prove byte-identical recursive OCI layouts with an
   exact Buildx client and digest-pinned BuildKit daemon.
-- **Local required verification** — the complete stable contract runs locally,
-  never in GitHub Actions. Each PR records the exact tested SHA, commands,
-  results, and skips before merge; release verification repeats the gates on
-  the immutable release-tag commit and retains the defined local evidence
-  record. GitHub remains the branch/PR/merge record; manual release workflows
-  may build artifacts afterward, but run no tests. The repository-scoped
-  App/ruleset implementation is retained as an inactive optional design, not a
-  current merge requirement. Reproduction and trust boundaries are documented
-  in
+- **Local required verification** — the complete platform-independent stable
+  contract runs locally. GitHub Actions carries only exact, narrow PowerShell,
+  Neovim, macOS, and Windows capability lanes. Each PR records the exact
+  locally tested SHA, commands, results, and skips before merge; release
+  verification repeats the gates on the immutable release-tag commit and
+  retains the defined local evidence record. GitHub remains the
+  branch/PR/merge record; manual release workflows
+  may build artifacts afterward. The tagged native runtime builders also gate
+  artifact construction on one macOS Seatbelt probe or three Windows
+  atomic-artifact/`.cmd` probes in two files with zero skips; those probes do
+  not replace the local test plan. The repository-scoped App/ruleset
+  implementation is retained as
+  an inactive optional design, not a current merge requirement. Reproduction
+  and trust boundaries are documented in
   [`ci-required-gates.md`](ci-required-gates.md).
 
 Root development loop (from repo root):

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -4,14 +4,19 @@ Decision record: 2026-07-15
 
 Operating policy update: 2026-07-16
 
-The current policy is **local-only verification**. GitHub Actions runs no test
-suite, and merge does not require a GitHub App Check Run or an App-bound
-ruleset. Before merge, the PR must record the exact locally tested SHA,
-commands, results, and every skip. Release verification repeats the required
-gates locally against the immutable release-tag commit. For PR verification,
-GitHub is only the branch/PR/merge record. The dispatch-only release workflows
-may later build or publish artifacts, but they run no test suite and must not be
-invoked merely to verify a change.
+The current merge policy keeps the complete platform-independent suite
+**local-only**. GitHub Actions runs only exact, narrow capability lanes, and
+merge does not require a GitHub App Check Run or an App-bound ruleset. Before
+merge, the PR must record the exact locally tested
+SHA, commands, results, and every skip. Release verification repeats the
+required gates locally against the immutable release-tag commit. GitHub remains
+the branch/PR/merge record for that broad verification. The dispatch-only
+release workflows may later build or publish artifacts. The tagged native
+runtime builders additionally run an exact allowlist of one macOS Seatbelt test
+and three Windows atomic-artifact/`.cmd` tests in two files that Linux cannot
+execute; these probes
+gate their artifacts but do not authorize merge or replace the local evidence.
+Release workflows must not be invoked merely to verify a change.
 
 The sections explicitly labeled **Inactive optional** retain the reviewed App,
 dedicated-host, and ruleset deployment design. That design is not part of
@@ -790,8 +795,12 @@ exact SHA in its receipt; a prior SHA never authorizes a newer one.
 [`release-runtime.yml`](../.github/workflows/release-runtime.yml), and
 [`promote-installers.yml`](../.github/workflows/promote-installers.yml) use
 GitHub-hosted jobs to publish or promote exact reviewed bytes. They do not
-repeat the local verification plan. Before artifact or promotion work starts,
-each workflow:
+repeat the local verification plan. The `release-runtime.yml` native matrix
+does run the exact native-only allowlist after its first clean install and
+requires the recorded result to contain one passing macOS test in one file or
+three passing Windows tests in two files with zero failed, pending, skipped, or
+todo tests. Before artifact
+or promotion work starts, each workflow:
 
 1. requires typed `tested_sha` and `local_evidence_sha256` dispatch inputs;
 2. normally requires `tested_sha` to equal the workflow's exact
@@ -816,9 +825,35 @@ attestations and npm provenance bind the separate reviewed `main` tooling
 commit. Runtime publication has no recovery exception and still requires
 `tested_sha == GITHUB_SHA`.
 
-They run no tests and do not read a GitHub App check. The operator must first
-complete and retain the exact-tag local evidence defined above. A PR-head test
-record cannot authorize release of a different squash-merged commit.
+Apart from those three native-only artifact probes, the workflows run no tests
+and do not read a GitHub App check. The operator must first complete and retain
+the exact-tag local evidence defined above. A PR-head test record cannot
+authorize release of a different squash-merged commit.
+
+## Hosted capability lanes
+
+[`platform-tests.yml`](../.github/workflows/platform-tests.yml) carries only
+tests whose required runtime or operating system is unavailable to the normal
+Linux local gate. Its `powershell` job installs the digest- and byte-pinned
+PowerShell runtime from [`release-toolchain.json`](../release-toolchain.json),
+enters the same credential-stripped, private-home Vitest boundary as the
+default suite, and runs an exact four-file allowlist. The Node tripwire remains
+active, while the native PowerShell subprocess is restricted to local
+fixtures, fixed telemetry/update opt-outs, and an asserted no-process-leak
+postcondition; this narrow lane is not an OS egress boundary.
+The `neovim` job similarly provisions the official digest- and byte-pinned
+Neovim 0.12.1 Linux binary and requires all four real-process lifecycle tests
+in its one-file allowlist. The `macos-native` and `windows-native` jobs run the
+same exact native probes used by release builders: one Seatbelt test in one
+file on macOS, and three atomic-publication/`.cmd` tests in two files on
+Windows. Every result parser requires the exact reviewed suite, test, and file
+counts with no failed, pending, skipped, or todo tests.
+
+This narrow hosted check supplements the local required gate; it does not
+replace or authorize the broader test, typecheck, build, TUI, or release
+contracts. Adding a capability file requires an explicit config and result
+inventory change. A missing capability causes the lane to fail closed rather
+than silently passing or registering a skipped test.
 
 ## Inactive optional policy-context rotation
 
@@ -1028,9 +1063,10 @@ The repository policy tests, stable suite, builds, contracts, SBOM check, and
 PTY supervisor run locally. PR descriptions are the human-reviewed evidence
 record and must follow the exact-SHA protocol above. Release records use the
 defined local evidence path and immutable-tag protocol. No dedicated GitHub
-App, active App-bound ruleset, or hosted test workflow is claimed or required
-in local-only mode. The optional multi-UID systemd/App design has not been
-activated.
+App or active App-bound ruleset is claimed or required in local-only mode.
+The hosted platform workflow supplements PRs with the four narrow capability
+lanes above; the same native probes also run before tagged native artifacts
+are built. The optional multi-UID systemd/App design has not been activated.
 
 ## Primary sources
 
@@ -1080,8 +1116,12 @@ Research refreshed 2026-07-15:
 - [npm 11 `npm ci`](https://docs.npmjs.com/cli/v11/commands/npm-ci/)
   defines frozen-lockfile installs.
 
-GitHub-hosted test execution was rejected because it spends remote runner time
-without strengthening the local hermetic boundary. The current policy keeps
-all verification local and records evidence in the PR. The optional App design
-would add authenticated exact-SHA enforcement without moving test compute to
-GitHub, but that extra control-plane complexity is deliberately inactive.
+General GitHub-hosted suite execution remains rejected because it spends remote
+runner time without strengthening the local hermetic boundary. Narrow
+exceptions cover capabilities Linux cannot otherwise prove: tagged artifact
+builders and PR lanes run exact macOS and Windows native probes, while the PR
+`powershell` and `neovim` lanes run exact pinned-runtime allowlists. None repeat
+the complete local plan. The current policy keeps broad merge verification local
+and records evidence in the PR. The optional App design would add authenticated
+exact-SHA enforcement without moving that complete plan to GitHub, but that
+extra control-plane complexity is deliberately inactive.

--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -116,6 +116,10 @@ npm --workspace=@tetsuo-ai/runtime exec -- vitest run \
   tests/tui/workbench/buffer-neovim-e2e-contract.test.ts \
   tests/tui/workbench/buffer-docs-config.contract.test.ts \
   --reporter=dot
+# Hosted `platform-tests / neovim` provisions the exact v0.12.1 binary.
+# This command deliberately fails when that pinned capability is unavailable.
+node runtime/scripts/run-hermetic-vitest.mjs --require-zero-skips \
+  run --config vitest.neovim.config.ts --allowOnly=false
 npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-buffer-neovim
 npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-visual-smoke
 npm run build

--- a/packages/agenc/test/fetch-pinned-npm.test.mjs
+++ b/packages/agenc/test/fetch-pinned-npm.test.mjs
@@ -12,7 +12,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { fetchPinnedNpm } from "../../../scripts/fetch-pinned-npm.mjs";
+import {
+  fetchPinnedNpm,
+  fsyncDirectorySync,
+} from "../../../scripts/fetch-pinned-npm.mjs";
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
@@ -138,4 +141,46 @@ test("fetchPinnedNpm rejects a non-canonical registry contract before network ac
   } finally {
     rmSync(work.root, { recursive: true, force: true });
   }
+});
+
+test("directory durability tolerates only the unsupported Windows EPERM result", () => {
+  const windowsUnsupported = Object.assign(
+    new Error("directory fsync is unsupported"),
+    { code: "EPERM" },
+  );
+  assert.doesNotThrow(() => {
+    fsyncDirectorySync(123, {
+      platform: "win32",
+      fsyncImpl: () => {
+        throw windowsUnsupported;
+      },
+    });
+  });
+  assert.throws(
+    () => {
+      fsyncDirectorySync(123, {
+        platform: "linux",
+        fsyncImpl: () => {
+          throw windowsUnsupported;
+        },
+      });
+    },
+    (error) => error === windowsUnsupported,
+  );
+
+  const unexpectedWindowsFailure = Object.assign(
+    new Error("unexpected directory fsync failure"),
+    { code: "EIO" },
+  );
+  assert.throws(
+    () => {
+      fsyncDirectorySync(123, {
+        platform: "win32",
+        fsyncImpl: () => {
+          throw unexpectedWindowsFailure;
+        },
+      });
+    },
+    (error) => error === unexpectedWindowsFailure,
+  );
 });

--- a/release-toolchain.json
+++ b/release-toolchain.json
@@ -10,6 +10,26 @@
     "url": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
     "sha256": "b290bbb35b9e72c3ef84edbe041f28c4479c4d9ee79f555817b8caafe7ce4bba"
   },
+  "powershellTestRuntime": {
+    "schemaVersion": 1,
+    "version": "7.6.4",
+    "linux-x64": {
+      "file": "powershell-7.6.4-linux-x64.tar.gz",
+      "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-x64.tar.gz",
+      "sha256": "4471b5a36bfe86ec7af8525d36bb1cacba0128e7aac22d05cc064bc00e604721",
+      "bytes": 77628778
+    }
+  },
+  "neovimTestRuntime": {
+    "schemaVersion": 1,
+    "version": "0.12.1",
+    "linux-x64": {
+      "file": "nvim-linux-x86_64.tar.gz",
+      "url": "https://github.com/neovim/neovim/releases/download/v0.12.1/nvim-linux-x86_64.tar.gz",
+      "sha256": "ab757a1fd9ad307d53d2df4045698906a7ca3993d92260dd8fe49108712d57d0",
+      "bytes": 11359184
+    }
+  },
   "githubCli": {
     "version": "2.96.0",
     "linuxX64": {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -57,6 +57,7 @@
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
     "test": "node scripts/run-hermetic-test-boundary.mjs run",
     "test:host-functional": "node scripts/run-hermetic-vitest.mjs run",
+    "test:powershell": "node scripts/run-hermetic-vitest.mjs --require-zero-skips run --config vitest.powershell.config.ts",
     "test:cross-repo": "node scripts/run-hermetic-vitest.mjs run --config vitest.cross-repo.config.ts",
     "test:live": "vitest run --config vitest.live.config.ts",
     "test:coverage": "node scripts/run-hermetic-vitest.mjs run --coverage --maxWorkers=1",

--- a/runtime/scripts/run-hermetic-test-boundary.mjs
+++ b/runtime/scripts/run-hermetic-test-boundary.mjs
@@ -992,7 +992,7 @@ async function runRequiredGates(supervisorRoot) {
     observerBinary,
     'sh',
     '-c',
-    'umask 077 && mkdir -p "$HOME" && chmod 700 "$HOME" && node ../node_modules/typescript/bin/tsc --noEmit && exec node scripts/run-hermetic-vitest.mjs "$@"',
+    'umask 077 && mkdir -p "$HOME" && chmod 700 "$HOME" && node ../node_modules/typescript/bin/tsc --noEmit && exec node scripts/run-hermetic-vitest.mjs --require-zero-skips "$@"',
     'agenc-hermetic-suite',
     ...requestedArgs,
   ])

--- a/runtime/scripts/run-hermetic-vitest.mjs
+++ b/runtime/scripts/run-hermetic-vitest.mjs
@@ -17,6 +17,10 @@ import {
   HERMETIC_MARKER_ENV_VAR,
   sanitizeHermeticEnv,
 } from '../tests/helpers/hermetic-env.mjs'
+import {
+  readZeroSkipEvidence,
+  ZERO_SKIP_REPORT_ENV_VAR,
+} from './zero-skip-reporter.mjs'
 
 const runtimeRoot = fileURLToPath(new URL('../', import.meta.url))
 const vitestCli = fileURLToPath(
@@ -25,12 +29,22 @@ const vitestCli = fileURLToPath(
 const networkTripwire = fileURLToPath(
   new URL('../tests/helpers/network-tripwire.cjs', import.meta.url),
 )
+const zeroSkipReporter = fileURLToPath(
+  new URL('./zero-skip-reporter.mjs', import.meta.url),
+)
 
 const args = process.argv.slice(2)
 const designIndex = args.indexOf('--design')
 const design = designIndex !== -1
 if (design) args.splice(designIndex, 1)
+const requireZeroSkips = args.includes('--require-zero-skips')
+for (let index = args.length - 1; index >= 0; index -= 1) {
+  if (args[index] === '--require-zero-skips') args.splice(index, 1)
+}
 if (args.length === 0) args.push('run')
+const hasRequestedReporter = args.some(
+  argument => argument === '--reporter' || argument.startsWith('--reporter='),
+)
 
 async function run() {
   // The unsandboxed prelauncher owns one disposable run root. Every worker
@@ -51,6 +65,10 @@ async function run() {
     const attemptLedger = join(runRoot, 'network-attempts')
     mkdirSync(attemptLedger, { mode: 0o700, recursive: true })
     childEnv.AGENC_TEST_NETWORK_ATTEMPT_LEDGER = attemptLedger
+    const zeroSkipReport = join(runRoot, 'zero-skips.json')
+    if (requireZeroSkips) {
+      childEnv[ZERO_SKIP_REPORT_ENV_VAR] = zeroSkipReport
+    }
 
     // This marker proves setupFiles ran in each Vitest worker; the prelauncher
     // must not stamp it or a removed setupFiles entry would be masked.
@@ -63,7 +81,18 @@ async function run() {
     // reviewed preload guards the coordinator and propagates itself to workers.
     childEnv.NODE_OPTIONS = `--require ${JSON.stringify(networkTripwire)}`
 
-    const child = spawn(process.execPath, [vitestCli, ...args], {
+    const childArgs = [
+      vitestCli,
+      ...args,
+      ...(requireZeroSkips
+        ? [
+            ...(hasRequestedReporter ? [] : ['--reporter', 'default']),
+            '--reporter',
+            zeroSkipReporter,
+          ]
+        : []),
+    ]
+    const child = spawn(process.execPath, childArgs, {
       cwd: runtimeRoot,
       env: childEnv,
       stdio: 'inherit',
@@ -128,6 +157,34 @@ async function run() {
         }
       }
       exitCode = 1
+    }
+
+    if (requireZeroSkips) {
+      try {
+        const evidence = readZeroSkipEvidence(zeroSkipReport)
+        if (evidence.skippedTests.length > 0) {
+          process.stderr.write(
+            `Hermetic Vitest requires zero skipped tests; observed ${evidence.skippedTests.length}\n`,
+          )
+          for (const skipped of evidence.skippedTests.slice(0, 20)) {
+            process.stderr.write(
+              `  ${skipped.file} > ${skipped.name} [${skipped.mode}]\n`,
+            )
+          }
+          if (evidence.skippedTests.length > 20) {
+            process.stderr.write(
+              `  ... ${evidence.skippedTests.length - 20} more skipped test(s)\n`,
+            )
+          }
+          exitCode = 1
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        process.stderr.write(
+          `Hermetic Vitest zero-skip evidence was missing or unreadable: ${message}\n`,
+        )
+        exitCode = 1
+      }
     }
 
     if (result.signal !== null) {

--- a/runtime/scripts/zero-skip-reporter.mjs
+++ b/runtime/scripts/zero-skip-reporter.mjs
@@ -1,0 +1,90 @@
+import {
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { isAbsolute } from 'node:path'
+
+export const ZERO_SKIP_REPORT_ENV_VAR = 'AGENC_TEST_ZERO_SKIP_REPORT'
+export const ZERO_SKIP_REPORT_SCHEMA_VERSION = 1
+
+function normalizePath(value) {
+  return value.split(/[/\\]+/u).join('/')
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function readZeroSkipEvidence(reportPath) {
+  const parsed = JSON.parse(readFileSync(reportPath, 'utf8'))
+  if (
+    !isRecord(parsed) ||
+    parsed.schemaVersion !== ZERO_SKIP_REPORT_SCHEMA_VERSION ||
+    !Array.isArray(parsed.skippedTests)
+  ) {
+    throw new Error('zero-skip report has an invalid schema')
+  }
+
+  const skippedTests = parsed.skippedTests.map((entry, index) => {
+    if (
+      !isRecord(entry) ||
+      typeof entry.file !== 'string' ||
+      entry.file.length === 0 ||
+      typeof entry.name !== 'string' ||
+      entry.name.length === 0 ||
+      typeof entry.mode !== 'string' ||
+      entry.mode.length === 0
+    ) {
+      throw new Error(`zero-skip report entry ${index} is invalid`)
+    }
+    return {
+      file: normalizePath(entry.file),
+      mode: entry.mode,
+      name: entry.name,
+    }
+  })
+
+  return {
+    schemaVersion: ZERO_SKIP_REPORT_SCHEMA_VERSION,
+    skippedTests,
+  }
+}
+
+export default class ZeroSkipReporter {
+  onTestRunEnd(testModules) {
+    const reportPath = process.env[ZERO_SKIP_REPORT_ENV_VAR]
+    if (
+      typeof reportPath !== 'string' ||
+      !isAbsolute(reportPath) ||
+      reportPath.includes('\0')
+    ) {
+      throw new Error('zero-skip reporter requires an absolute evidence path')
+    }
+
+    const skippedTests = []
+    for (const testModule of testModules) {
+      for (const testCase of testModule.children.allTests()) {
+        if (testCase.result().state !== 'skipped') continue
+        skippedTests.push({
+          file: normalizePath(testCase.module.relativeModuleId),
+          mode: testCase.options.mode,
+          name: testCase.fullName,
+        })
+      }
+    }
+    skippedTests.sort((left, right) =>
+      left.file.localeCompare(right.file) ||
+      left.name.localeCompare(right.name) ||
+      left.mode.localeCompare(right.mode),
+    )
+
+    writeFileSync(
+      reportPath,
+      `${JSON.stringify({
+        schemaVersion: ZERO_SKIP_REPORT_SCHEMA_VERSION,
+        skippedTests,
+      })}\n`,
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+    )
+  }
+}

--- a/runtime/tests/budget/admitted-legacy-powershell-tests.ts
+++ b/runtime/tests/budget/admitted-legacy-powershell-tests.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AdmissionAcquireInput,
+  ExecutionAdmissionClient,
+} from "../../src/budget/admission-client.js";
+import { AdmissionDeniedError } from "../../src/budget/admission-client.js";
+import type { AdmissionLease } from "../../src/budget/admission-types.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import {
+  clearCurrentRuntimeSession,
+  runWithCurrentRuntimeSession,
+} from "../../src/session/current-session.js";
+import type { Session } from "../../src/session/session.js";
+import { createTestEffectJournal } from "../helpers/test-effect-journal.js";
+import { getEmptyToolPermissionContext } from "../../src/tools/Tool.js";
+
+const shellProbe = vi.hoisted(() => ({
+  signals: [] as AbortSignal[],
+  onExec: undefined as (() => void) | undefined,
+}));
+
+vi.mock("bun:bundle", () => ({ feature: () => false }));
+vi.mock("../../src/utils/Shell.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/utils/Shell.js")>();
+  return {
+    ...actual,
+    exec: async (...args: Parameters<typeof actual.exec>) => {
+      shellProbe.signals.push(args[1]);
+      shellProbe.onExec?.();
+      return actual.exec(...args);
+    },
+  };
+});
+
+import { PowerShellTool } from "../../src/tools/PowerShellTool/PowerShellTool.js";
+
+function admissionHarness(signal = new AbortController().signal) {
+  const acquire = vi.fn(
+    async (input: AdmissionAcquireInput): Promise<AdmissionLease> => ({
+      decision: "allow",
+      reservation: {
+        reservationId: `reservation:${input.stepId}`,
+        step: { runId: "run-powershell", stepId: input.stepId },
+        reservedCostUsd: input.maxCostUsd ?? 0,
+        reservedTokens: input.maxInputTokens + input.maxOutputTokens,
+        reservedAt: "2026-07-18T00:00:00.000Z",
+      },
+      request: {
+        step: { runId: "run-powershell", stepId: input.stepId },
+        kind: input.kind,
+        estimate: {
+          maxInputTokens: input.maxInputTokens,
+          maxOutputTokens: input.maxOutputTokens,
+          maxCostUsd: input.maxCostUsd,
+        },
+        workspaceId: "workspace-powershell",
+        sessionId: "session-powershell",
+        parentScopeId: input.parentScopeId,
+        autonomous: false,
+      },
+      signal,
+    }),
+  );
+  const admission = {
+    scope: {
+      runId: "run-powershell",
+      workspaceId: "workspace-powershell",
+      sessionId: "session-powershell",
+      autonomous: false,
+    },
+    acquire,
+    markDispatched: vi.fn(),
+    reconcile: vi.fn(() => ({ applied: true, outcome: "reconciled" })),
+    holdUnknown: vi.fn(),
+    void: vi.fn(),
+    acknowledgeCompletion: vi.fn(),
+    recordFallback: vi.fn(),
+    forSession: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  } as unknown as ExecutionAdmissionClient;
+  const effectJournal = createTestEffectJournal();
+  const session = {
+    ...effectJournal,
+    conversationId: "session-powershell",
+    activeTurn: { unsafePeek: () => ({ turnId: "turn-powershell" }) },
+    services: {
+      executionAdmission: admission,
+      admissionRequired: true,
+    },
+  } as unknown as Session;
+  return { admission, acquire, session };
+}
+
+function toolContext(broker: SandboxExecutionBroker) {
+  const appState = { toolPermissionContext: getEmptyToolPermissionContext() };
+  return {
+    abortController: new AbortController(),
+    getAppState: () => appState,
+    setAppState: () => {},
+    setToolJSX: () => {},
+    services: { sandboxExecutionBroker: broker },
+  } as never;
+}
+
+afterEach(() => {
+  clearCurrentRuntimeSession();
+  shellProbe.signals.length = 0;
+  shellProbe.onExec = undefined;
+});
+
+export function registerDirectPowerShellAdmissionTests(
+  lane: "default" | "powershell",
+): void {
+  describe("direct PowerShell admission", () => {
+    if (lane === "default") {
+      it("admits and settles before a direct TUI/prompt PowerShell effect", async () => {
+        const state = admissionHarness();
+        const broker = new SandboxExecutionBroker({
+          mode: "workspace_write",
+          cwd: process.cwd(),
+          platform: "linux",
+          probe: () => ({
+            kind: "unavailable",
+            mode: "workspace_write",
+            platform: "linux",
+            reason: "probe: unavailable in admission test",
+          }),
+        });
+
+        await expect(
+          runWithCurrentRuntimeSession(state.session, () =>
+            PowerShellTool.call(
+              { command: "Write-Output 'must-not-run'" },
+              toolContext(broker),
+              undefined as never,
+              undefined as never,
+            ),
+          ),
+        ).rejects.toMatchObject({ code: "sandbox_probe_failed" });
+
+        expect(state.acquire).toHaveBeenCalledWith(
+          expect.objectContaining({
+            kind: "tool_exec",
+            maxInputTokens: 0,
+            maxOutputTokens: 0,
+            maxCostUsd: 0,
+          }),
+          expect.any(AbortSignal),
+        );
+        expect(state.admission.markDispatched).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            details: expect.objectContaining({
+              toolName: "PowerShell",
+              recoveryCategory: "side-effecting",
+            }),
+          }),
+        );
+        expect(state.admission.reconcile).toHaveBeenCalledWith(
+          expect.any(String),
+          {
+            inputTokens: 0,
+            outputTokens: 0,
+            costUsd: 0,
+          },
+        );
+      });
+    } else {
+      it(
+        "forwards lease cancellation into the running PowerShell process",
+        async () => {
+          const leaseController = new AbortController();
+          const state = admissionHarness(leaseController.signal);
+          const broker = new SandboxExecutionBroker({
+            mode: "danger_full_access",
+            cwd: process.cwd(),
+          });
+          const started = Promise.withResolvers<void>();
+          shellProbe.onExec = () => started.resolve();
+
+          const call = runWithCurrentRuntimeSession(state.session, () =>
+            PowerShellTool.call(
+              { command: "Start-Sleep -Seconds 30", timeout: 35_000 },
+              toolContext(broker),
+              undefined as never,
+              undefined as never,
+            ),
+          );
+          await started.promise;
+          const effectSignal = shellProbe.signals.at(-1)!;
+          const cancellation = new AdmissionDeniedError(
+            "parent_cancelled",
+            "cancelled",
+          );
+          leaseController.abort(cancellation);
+
+          await expect(call).rejects.toBeDefined();
+          expect(effectSignal.aborted).toBe(true);
+          expect(effectSignal.reason).toBe(cancellation);
+          expect(state.admission.holdUnknown).toHaveBeenCalledWith(
+            expect.any(String),
+            "tool_cancelled_after_dispatch",
+          );
+        },
+        10_000,
+      );
+    }
+  });
+}

--- a/runtime/tests/budget/admitted-legacy-powershell.powershell.test.ts
+++ b/runtime/tests/budget/admitted-legacy-powershell.powershell.test.ts
@@ -1,3 +1,3 @@
 import { registerDirectPowerShellAdmissionTests } from "./admitted-legacy-powershell-tests.js";
 
-registerDirectPowerShellAdmissionTests("default");
+registerDirectPowerShellAdmissionTests("powershell");

--- a/runtime/tests/durability/atomic-artifact.test.ts
+++ b/runtime/tests/durability/atomic-artifact.test.ts
@@ -17,7 +17,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   __setAtomicArtifactOperationForTesting,
   AtomicArtifactConflictError,
-  AtomicArtifactOperationUnsupportedError,
   AtomicArtifactUnsafePathError,
   cleanupOrphanedArtifactTemps,
   cleanupOrphanedArtifactTempsSync,
@@ -409,42 +408,6 @@ describe("atomic artifact commit", () => {
       expect(existsSync(firstTemp) || existsSync(secondTemp)).toBe(false);
       expect(readFileSync(siblingTemp, "utf8")).toBe("must stay");
       expect(existsSync(matchingDirectory)).toBe(true);
-    },
-  );
-
-  it.runIf(process.platform === "win32")(
-    "fails closed when publication has no descriptor-relative child operations",
-    async () => {
-      const artifact = target();
-
-      await expect(
-        commitArtifactAtomically(artifact.path, "must not publish", {
-          trustedRoot: artifact.directory,
-        }),
-      ).rejects.toBeInstanceOf(AtomicArtifactOperationUnsupportedError);
-      expect(existsSync(artifact.path)).toBe(false);
-    },
-  );
-
-  it.runIf(process.platform === "win32")(
-    "fails closed when cleanup has no descriptor-relative child operations",
-    async () => {
-      const artifact = target();
-      writeFileSync(`${artifact.path}.101.orphan.tmp`, "must stay");
-
-      await expect(
-        cleanupOrphanedArtifactTemps(artifact.path, {
-          trustedRoot: artifact.directory,
-        }),
-      ).rejects.toBeInstanceOf(AtomicArtifactOperationUnsupportedError);
-      expect(() =>
-        cleanupOrphanedArtifactTempsSync(artifact.path, {
-          trustedRoot: artifact.directory,
-        }),
-      ).toThrow(AtomicArtifactOperationUnsupportedError);
-      expect(readFileSync(`${artifact.path}.101.orphan.tmp`, "utf8")).toBe(
-        "must stay",
-      );
     },
   );
 });

--- a/runtime/tests/durability/atomic-artifact.win32.test.ts
+++ b/runtime/tests/durability/atomic-artifact.win32.test.ts
@@ -1,0 +1,73 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AtomicArtifactOperationUnsupportedError,
+  cleanupOrphanedArtifactTemps,
+  cleanupOrphanedArtifactTempsSync,
+  commitArtifactAtomically,
+} from "../../src/durability/atomic-artifact.js";
+
+if (process.platform !== "win32") {
+  throw new Error("the native atomic-artifact integration tests require Windows");
+}
+
+describe("atomic artifact commit on Windows", () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  function target(): { directory: string; path: string } {
+    const directory = mkdtempSync(join(tmpdir(), "agenc-artifact-"));
+    directories.push(directory);
+    return { directory, path: join(directory, "artifact.txt") };
+  }
+
+  it(
+    "fails closed when publication has no descriptor-relative child operations",
+    async () => {
+      const artifact = target();
+
+      await expect(
+        commitArtifactAtomically(artifact.path, "must not publish", {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactOperationUnsupportedError);
+      expect(existsSync(artifact.path)).toBe(false);
+    },
+  );
+
+  it(
+    "fails closed when cleanup has no descriptor-relative child operations",
+    async () => {
+      const artifact = target();
+      writeFileSync(`${artifact.path}.101.orphan.tmp`, "must stay");
+
+      await expect(
+        cleanupOrphanedArtifactTemps(artifact.path, {
+          trustedRoot: artifact.directory,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactOperationUnsupportedError);
+      expect(() =>
+        cleanupOrphanedArtifactTempsSync(artifact.path, {
+          trustedRoot: artifact.directory,
+        }),
+      ).toThrow(AtomicArtifactOperationUnsupportedError);
+      expect(readFileSync(`${artifact.path}.101.orphan.tmp`, "utf8")).toBe(
+        "must stay",
+      );
+    },
+  );
+});

--- a/runtime/tests/helpers/hermetic-env.mjs
+++ b/runtime/tests/helpers/hermetic-env.mjs
@@ -497,6 +497,7 @@ export const HERMETIC_LIVE_TEST_OPT_IN_ENV_VARS = Object.freeze([
 export const HERMETIC_HARNESS_INPUT_ENV_VARS = Object.freeze([
   'AGENC_TEST_HERMETIC_RUN_ROOT',
   'AGENC_TEST_NETWORK_ATTEMPT_LEDGER',
+  'AGENC_TEST_ZERO_SKIP_REPORT',
 ])
 
 /** OS launch inputs that cannot be synthesized portably. */
@@ -518,6 +519,7 @@ export const HERMETIC_LAUNCH_PASSTHROUGH_ENV_VARS = Object.freeze([
 export const HERMETIC_LAUNCH_TEST_INPUT_ENV_VARS = Object.freeze([
   'AGENC_TEST_DESIGN_ENV_PROBE',
   'AGENC_TEST_NETWORK_ATTEMPT_CHILD_MODE',
+  'AGENC_TEST_ZERO_SKIP_CHILD_MODE',
 ])
 
 /**

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -52,6 +52,29 @@ const CROSS_REPO_TEST_FILES = [
   'tests/app-server/sdk-tui-coattach-example.contract.test.ts',
 ] as const;
 
+const NATIVE_TEST_FILES = [
+  'tests/durability/atomic-artifact.win32.test.ts',
+  'tests/tools/runtimes/runtime.darwin.test.ts',
+  'tests/utils/execFileNoThrow.win32.test.ts',
+] as const;
+
+const POWERSHELL_TEST_FILES = [
+  'tests/budget/admitted-legacy-powershell.powershell.test.ts',
+  'tests/packaging/install-ps1.powershell.test.ts',
+  'tests/shell-command/powershell-parser.powershell.test.ts',
+  'tests/tools/PowerShellTool.execution.powershell.test.ts',
+] as const;
+
+const DEFAULT_POWERSHELL_TEST_FILES = [
+  'tests/budget/admitted-legacy-powershell.test.ts',
+  'tests/shell-command/powershell-parser.test.ts',
+  'tests/tools/PowerShellTool.execution.test.ts',
+] as const;
+
+const NEOVIM_TEST_FILES = [
+  'tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts',
+] as const;
+
 function listTestFiles(config: string): string[] {
   const result = spawnSync(
     process.execPath,
@@ -101,6 +124,36 @@ describe('hermetic test discovery', () => {
       ).not.toContain(crossRepoFile);
     }
 
+    for (const nativeFile of NATIVE_TEST_FILES) {
+      expect(
+        files,
+        `${nativeFile} leaked into the Linux clean-checkout suite`,
+      ).not.toContain(nativeFile);
+    }
+
+    for (const powershellFile of POWERSHELL_TEST_FILES) {
+      expect(
+        files,
+        `${powershellFile} leaked into the default suite`,
+      ).not.toContain(powershellFile);
+    }
+    for (const defaultPowerShellFile of DEFAULT_POWERSHELL_TEST_FILES) {
+      expect(
+        files,
+        `${defaultPowerShellFile} must retain its capability-independent coverage`,
+      ).toContain(defaultPowerShellFile);
+    }
+
+    for (const neovimFile of NEOVIM_TEST_FILES) {
+      expect(
+        files,
+        `${neovimFile} leaked into the default suite`,
+      ).not.toContain(neovimFile);
+    }
+    expect(files).toContain(
+      'tests/tui/workbench/buffer-neovim-discovery.contract.test.ts',
+    );
+
     // Despite its historical filename, this test only inspects production
     // rendering source and is intentionally part of the offline suite.
     expect(files).toContain(
@@ -120,6 +173,131 @@ describe('hermetic test discovery', () => {
     expect(listTestFiles('vitest.cross-repo.config.ts')).toEqual([
       ...CROSS_REPO_TEST_FILES,
     ]);
+  });
+
+  it('native discovery is an exact hosted-builder allowlist without skip gates', () => {
+    expect(listTestFiles('vitest.native.config.ts')).toEqual([
+      ...NATIVE_TEST_FILES,
+    ]);
+    for (const file of NATIVE_TEST_FILES) {
+      const source = readFileSync(resolve(runtimeRoot, file), 'utf8');
+      expect(source).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
+    }
+  });
+
+  it('PowerShell discovery is an exact hosted capability allowlist without skip gates', () => {
+    expect(listTestFiles('vitest.powershell.config.ts')).toEqual([
+      ...POWERSHELL_TEST_FILES,
+    ]);
+    for (const file of POWERSHELL_TEST_FILES) {
+      const source = readFileSync(resolve(runtimeRoot, file), 'utf8');
+      expect(source).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
+    }
+
+    const shellEntry = readFileSync(
+      resolve(runtimeRoot, 'tests/packaging/install-sh.test.ts'),
+      'utf8',
+    );
+    const powershellEntry = readFileSync(
+      resolve(runtimeRoot, 'tests/packaging/install-ps1.powershell.test.ts'),
+      'utf8',
+    );
+    expect(shellEntry).toContain('registerInstallerTests("shell")');
+    expect(shellEntry).not.toContain('registerInstallerTests("powershell")');
+    expect(powershellEntry).toContain('registerInstallerTests("powershell")');
+    expect(powershellEntry).not.toContain('registerInstallerTests("shell")');
+
+    const defaultAdmissionEntry = readFileSync(
+      resolve(runtimeRoot, 'tests/budget/admitted-legacy-powershell.test.ts'),
+      'utf8',
+    );
+    const capabilityAdmissionEntry = readFileSync(
+      resolve(
+        runtimeRoot,
+        'tests/budget/admitted-legacy-powershell.powershell.test.ts',
+      ),
+      'utf8',
+    );
+    expect(defaultAdmissionEntry).toContain(
+      'registerDirectPowerShellAdmissionTests("default")',
+    );
+    expect(capabilityAdmissionEntry).toContain(
+      'registerDirectPowerShellAdmissionTests("powershell")',
+    );
+
+    const defaultToolEntry = readFileSync(
+      resolve(runtimeRoot, 'tests/tools/PowerShellTool.execution.test.ts'),
+      'utf8',
+    );
+    const capabilityToolEntry = readFileSync(
+      resolve(
+        runtimeRoot,
+        'tests/tools/PowerShellTool.execution.powershell.test.ts',
+      ),
+      'utf8',
+    );
+    expect(defaultToolEntry).toContain(
+      "registerPowerShellToolExecutionTests('default')",
+    );
+    expect(capabilityToolEntry).toContain(
+      "registerPowerShellToolExecutionTests('powershell')",
+    );
+
+    const sharedInstallerTests = readFileSync(
+      resolve(runtimeRoot, 'tests/packaging/installer-tests.ts'),
+      'utf8',
+    );
+    const powershellTests = sharedInstallerTests.slice(
+      sharedInstallerTests.indexOf('function registerInstallPs1Tests'),
+    );
+    expect(powershellTests).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
+  });
+
+  it('real-Neovim discovery is an exact fail-closed hosted allowlist', () => {
+    expect(listTestFiles('vitest.neovim.config.ts')).toEqual([
+      ...NEOVIM_TEST_FILES,
+    ]);
+    const capabilitySource = readFileSync(
+      resolve(runtimeRoot, NEOVIM_TEST_FILES[0]),
+      'utf8',
+    );
+    expect(capabilitySource).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
+    expect(capabilitySource).not.toMatch(
+      /if\s*\(\s*!discovery\.usable\s*\)\s*\{[^}]*\breturn\b/su,
+    );
+    expect(capabilitySource).toContain(
+      'throw new Error(`the pinned real-Neovim capability is required:',
+    );
+    expect(capabilitySource).toContain('raw: "NVIM v0.12.1"');
+
+    const defaultLifecycleSource = readFileSync(
+      resolve(
+        runtimeRoot,
+        'tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts',
+      ),
+      'utf8',
+    );
+    for (const testName of [
+      'closes a clean real Neovim session through the all-buffer safe-close path',
+      'detects a modified hidden buffer before an external-editor handoff',
+      'opens Neovim, refuses dirty quit, and force cleans the child',
+      'reports visible grid highlight cells for visual selections',
+    ]) {
+      expect(defaultLifecycleSource).not.toContain(testName);
+      expect(capabilitySource).toContain(testName);
+    }
+
+    const discoverySource = readFileSync(
+      resolve(
+        runtimeRoot,
+        'tests/tui/workbench/buffer-neovim-discovery.contract.test.ts',
+      ),
+      'utf8',
+    );
+    expect(discoverySource).toContain(
+      'returns a missing-binary fallback when configured and default executables are absent',
+    );
+    expect(discoverySource).toContain('reasonCode: "missing-binary"');
   });
 
   it('loads live mode with no setup files while default mode keeps its setup', async () => {
@@ -144,6 +322,21 @@ describe('hermetic test discovery', () => {
       resolve(runtimeRoot, 'vitest.cross-repo.config.ts'),
       runtimeRoot,
     );
+    const nativeResult = await loadConfigFromFile(
+      environment,
+      resolve(runtimeRoot, 'vitest.native.config.ts'),
+      runtimeRoot,
+    );
+    const powershellResult = await loadConfigFromFile(
+      environment,
+      resolve(runtimeRoot, 'vitest.powershell.config.ts'),
+      runtimeRoot,
+    );
+    const neovimResult = await loadConfigFromFile(
+      environment,
+      resolve(runtimeRoot, 'vitest.neovim.config.ts'),
+      runtimeRoot,
+    );
 
     expect(defaultResult?.config.test?.setupFiles).toEqual(['./vitest.setup.ts']);
     expect(liveResult?.config.test?.setupFiles).toEqual([]);
@@ -157,6 +350,21 @@ describe('hermetic test discovery', () => {
       './vitest.design.setup.ts',
     ]);
     expect(crossRepoResult?.config.test?.setupFiles).toEqual([
+      './vitest.setup.ts',
+    ]);
+    expect(nativeResult?.config.test?.setupFiles).toEqual([
+      './vitest.setup.ts',
+    ]);
+    expect(powershellResult?.config.test?.setupFiles).toEqual([
+      './vitest.setup.ts',
+    ]);
+    expect(powershellResult?.config.test?.env).toEqual({
+      DOTNET_CLI_TELEMETRY_OPTOUT: '1',
+      DOTNET_NOLOGO: '1',
+      POWERSHELL_TELEMETRY_OPTOUT: '1',
+      POWERSHELL_UPDATECHECK: 'Off',
+    });
+    expect(neovimResult?.config.test?.setupFiles).toEqual([
       './vitest.setup.ts',
     ]);
   });

--- a/runtime/tests/llm/providers/grok/incremental-registry-leak.test.ts
+++ b/runtime/tests/llm/providers/grok/incremental-registry-leak.test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -25,31 +27,90 @@ describe("grok incremental tracker registry — M-LLM-3 leak", () => {
     expect(registeredIncrementalTrackerCountForTest()).toBe(0);
   });
 
-  it("does not strongly retain trackers whose owner was dropped", async () => {
-    // Register many trackers via a throwaway closure so no strong reference to
-    // them survives this block (mirrors per-call providers that never dispose()).
+  it("does not strongly retain trackers whose owner was dropped", () => {
     const created = 50;
-    (() => {
-      for (let i = 0; i < created; i += 1) {
-        registerIncrementalTracker(new IncrementalTracker());
+    const moduleUrl = new URL(
+      "../../../../src/llm/providers/grok/incremental.ts",
+      import.meta.url,
+    ).href;
+    const childScript = `
+      const {
+        IncrementalTracker,
+        registerIncrementalTracker,
+        registeredIncrementalTrackerCountForTest,
+      } = await import(${JSON.stringify(moduleUrl)});
+      const created = ${created};
+      function registerDroppedTrackers() {
+        for (let i = 0; i < created; i += 1) {
+          registerIncrementalTracker(new IncrementalTracker());
+        }
       }
-    })();
+      registerDroppedTrackers();
+      const before = registeredIncrementalTrackerCountForTest();
+      await new Promise((resolve) => setImmediate(resolve));
+      for (let i = 0; i < 10; i += 1) {
+        globalThis.gc();
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      const after = registeredIncrementalTrackerCountForTest();
+      process.stdout.write(JSON.stringify({
+        gcType: typeof globalThis.gc,
+        created,
+        before,
+        after,
+      }));
+    `;
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "--eval",
+        childScript,
+      ],
+      {
+        cwd: fileURLToPath(new URL("../../../../", import.meta.url)),
+        encoding: "utf8",
+        // Preserve the hermetic runner's reviewed NODE_OPTIONS preload so its
+        // network tripwire also governs this focused child.
+        env: process.env,
+        timeout: 15_000,
+      },
+    );
+    const diagnostics = [
+      `status=${String(child.status)}`,
+      `signal=${String(child.signal)}`,
+      `error=${child.error?.stack ?? "none"}`,
+      `stdout=${JSON.stringify(child.stdout)}`,
+      `stderr=${JSON.stringify(child.stderr)}`,
+    ].join("\n");
 
-    // Force GC if the runtime exposes it, then let finalizers run.
-    const gc = (globalThis as { gc?: () => void }).gc;
-    if (typeof gc !== "function") {
-      // Without --expose-gc we cannot force collection; assert the weaker
-      // invariant that the count never exceeds what was created (i.e. no runaway),
-      // and skip the strict collection assertion.
-      expect(registeredIncrementalTrackerCountForTest()).toBeLessThanOrEqual(created);
-      return;
+    expect(child.error, diagnostics).toBeUndefined();
+    expect(child.signal, diagnostics).toBeNull();
+    expect(child.status, diagnostics).toBe(0);
+
+    let evidence: {
+      gcType: string;
+      created: number;
+      before: number;
+      after: number;
+    };
+    try {
+      evidence = JSON.parse(child.stdout) as typeof evidence;
+    } catch (error) {
+      throw new Error(
+        `GC retention child did not return valid evidence: ${
+          error instanceof Error ? error.message : String(error)
+        }\n${diagnostics}`,
+      );
     }
-    for (let i = 0; i < 5; i += 1) {
-      gc();
-      await new Promise((r) => setTimeout(r, 0));
-    }
-    // A strong Set would still report all `created` trackers; the WeakRef set
-    // reports them collected (0 live, since nothing else references them).
-    expect(registeredIncrementalTrackerCountForTest()).toBe(0);
+
+    expect(evidence.gcType).toBe("function");
+    expect(evidence.created).toBe(created);
+    expect(evidence.before).toBe(created);
+    // Reverting the registry to a strong Set leaves all `created` trackers here.
+    expect(evidence.after).toBe(0);
   });
 });

--- a/runtime/tests/packaging/install-ps1.powershell.test.ts
+++ b/runtime/tests/packaging/install-ps1.powershell.test.ts
@@ -1,3 +1,3 @@
 import { registerInstallerTests } from "./installer-tests.js";
 
-registerInstallerTests("shell");
+registerInstallerTests("powershell");

--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -1,0 +1,3170 @@
+// End-to-end tests for scripts/install/install.sh (TODO task 1).
+//
+// The installer must speak the exact runtime-manager install contract
+// (runtime/<version>/<platform>-<arch>-<libc>-node-abi-<abi>-sha256-<digest>/ + marker)
+// so the npm launcher and the shell installer can reuse each other's
+// installs. Everything runs against a synthetic tarball + file:// manifest,
+// mirroring packages/agenc/test/runtime-manager.test.mjs.
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  parseGeneratedWrapper,
+  parseInstallShWrapper,
+  renderInstallShWrapper,
+} from "../../src/bin/update-cli.js";
+import {
+  resolveActivationLockRegistry,
+  wrapperActivationLockPath,
+} from "../../src/utils/activation-lock-identity.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const INSTALL_SH = join(REPO_ROOT, "scripts", "install", "install.sh");
+const INSTALL_PS1 = join(REPO_ROOT, "scripts", "install", "install.ps1");
+const RELEASE_TOOLCHAIN = join(REPO_ROOT, "release-toolchain.json");
+
+const VERSION = "9.9.9-test";
+const BIN_REL = "node_modules/@tetsuo-ai/runtime/bin/agenc";
+const NODE_BIN_REL = "node_modules/.agenc-node/bin/node";
+const WINDOWS_NODE_BIN_REL = "node_modules/.agenc-node/node.exe";
+const NODE_LIBRARY_REL = "node_modules/.agenc-node/lib";
+const NODE_ABI = process.versions.modules;
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function removePersistentWrapperLocks(root: string): void {
+  const registry = resolveActivationLockRegistry();
+  if (!existsSync(registry) || !existsSync(root)) return;
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const path = join(current, entry.name);
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        pending.push(path);
+      } else if (entry.isFile() && (entry.name === "agenc" || entry.name === "agenc.cmd")) {
+        if (parseGeneratedWrapper(path) === null) continue;
+        const lockPath = wrapperActivationLockPath(path, registry);
+        for (const suffix of ["", "-shm", "-wal"]) {
+          rmSync(`${lockPath}${suffix}`, { force: true });
+        }
+      }
+    }
+  }
+}
+
+// Synthetic runtime tarball with the real extraction layout; the bin is a
+// node script so the generated wrapper can actually be executed.
+function makeSyntheticArtifact(
+  dir: string,
+  options: { omitPrivateNode?: boolean; omitPrivateNodeLibrary?: boolean } = {},
+): { tarball: string; sha: string } {
+  const tree = join(dir, "tree");
+  const binDir = join(tree, "node_modules", "@tetsuo-ai", "runtime", "bin");
+  const privateNodeRoot = join(tree, "node_modules", ".agenc-node");
+  const privateNodeBin = join(privateNodeRoot, "bin", "node");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(dirname(privateNodeBin), { recursive: true });
+  mkdirSync(join(privateNodeRoot, "lib"), { recursive: true });
+  writeFileSync(
+    join(binDir, "agenc"),
+    [
+      'if (process.argv.includes("--agenc-child-node-probe")) {',
+      '  const { spawnSync } = require("node:child_process");',
+      '  const child = spawnSync("node", ["--agenc-private-node-probe"], { encoding: "utf8" });',
+      "  if (child.error) throw child.error;",
+      "  process.stdout.write(child.stdout);",
+      "} else {",
+      '  console.log("ok " + process.argv.slice(2).join(" "));',
+      "}",
+      "",
+    ].join("\n"),
+  );
+  const nodeShim = [
+    "#!/bin/sh",
+    'if [ "${1:-}" = "--agenc-private-node-probe" ]; then',
+    "  printf 'private-node-path-ok\\n'",
+    "  exit 0",
+    "fi",
+    `exec ${JSON.stringify(process.execPath)} "$@"`,
+    "",
+  ].join("\n");
+  if (!options.omitPrivateNode) {
+    writeFileSync(privateNodeBin, nodeShim, { mode: 0o755 });
+    chmodSync(privateNodeBin, 0o755);
+    writeFileSync(join(privateNodeRoot, "node.exe"), nodeShim, { mode: 0o755 });
+    chmodSync(join(privateNodeRoot, "node.exe"), 0o755);
+  }
+  writeFileSync(join(privateNodeRoot, "LICENSE"), "synthetic Node license\n");
+  writeFileSync(join(privateNodeRoot, "identity.json"), JSON.stringify({
+    schemaVersion: 1,
+    nodeVersion: process.versions.node,
+    nodeMajor: Number(process.versions.node.split(".")[0]),
+    nodeModuleAbi: process.versions.modules,
+    nodeApiVersion: process.versions.napi,
+  }));
+  if (!options.omitPrivateNodeLibrary) {
+    if (process.platform === "linux" && process.arch === "x64") {
+      cpSync(
+        "/usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0",
+        join(privateNodeRoot, "lib", "libatomic.so.1"),
+      );
+    } else {
+      writeFileSync(join(privateNodeRoot, "lib", "libatomic.so.1"), "synthetic libatomic\n");
+    }
+  }
+  const tarball = join(dir, `agenc-runtime-${VERSION}-test.tar.gz`);
+  const res = spawnSync("tar", ["-czf", tarball, "-C", tree, "node_modules"]);
+  expect(res.status).toBe(0);
+  return { tarball, sha: sha256(readFileSync(tarball)) };
+}
+
+type RawTarEntry = { name: string; type?: "0" | "2" | "5"; link?: string; body?: string };
+
+function makeRawTarArtifact(dir: string, entries: RawTarEntry[]): { tarball: string; sha: string } {
+  const blocks: Buffer[] = [];
+  for (const entry of entries) {
+    const body = Buffer.from(entry.body ?? "");
+    const header = Buffer.alloc(512);
+    header.write(entry.name, 0, 100, "utf8");
+    header.write("0000755\0", 100, 8, "ascii");
+    header.write("0000000\0", 108, 8, "ascii");
+    header.write("0000000\0", 116, 8, "ascii");
+    header.write(`${body.length.toString(8).padStart(11, "0")}\0`, 124, 12, "ascii");
+    header.write("00000000000\0", 136, 12, "ascii");
+    header.fill(0x20, 148, 156);
+    header.write(entry.type ?? "0", 156, 1, "ascii");
+    if (entry.link) header.write(entry.link, 157, 100, "utf8");
+    header.write("ustar\0", 257, 6, "ascii");
+    header.write("00", 263, 2, "ascii");
+    let checksum = 0;
+    for (const byte of header) checksum += byte;
+    header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+    blocks.push(header, body, Buffer.alloc((512 - (body.length % 512)) % 512));
+  }
+  blocks.push(Buffer.alloc(1024));
+  const tarball = join(dir, `raw-${Math.random().toString(16).slice(2)}.tar.gz`);
+  const compressed = gzipSync(Buffer.concat(blocks), { level: 9, mtime: 0 });
+  writeFileSync(tarball, compressed);
+  return { tarball, sha: sha256(compressed) };
+}
+
+function writeManifest(
+  dir: string,
+  artifact: { tarball: string; sha: string },
+  overrides: Record<string, unknown> = {},
+): string {
+  const platform = String(overrides.platform ?? "linux");
+  const bins = platform === "win"
+    ? { agenc: BIN_REL, node: WINDOWS_NODE_BIN_REL }
+    : platform === "linux"
+      ? { agenc: BIN_REL, node: NODE_BIN_REL, nodeLibrary: NODE_LIBRARY_REL }
+      : { agenc: BIN_REL, node: NODE_BIN_REL };
+  const manifest = {
+    manifestVersion: 2,
+    runtimeVersion: VERSION,
+    releaseRepository: "tetsuo-ai/agenc-core",
+    releaseTag: `agenc-v${VERSION}`,
+    artifacts: [
+      {
+        platform: "linux",
+        arch: "x64",
+        runtimeVersion: VERSION,
+        nodeMajor: Number(process.versions.node.split(".")[0]),
+        nodeModuleAbi: NODE_ABI,
+        nodeApiVersion: process.versions.napi,
+        libcFamily: "glibc",
+        minimumGlibcVersion: "2.28",
+        minimumGlibcxxVersion: "3.4.25",
+        minimumCxxAbiVersion: "1.3.11",
+        url: pathToFileURL(artifact.tarball).href,
+        sha256: artifact.sha,
+        bytes: statSync(artifact.tarball).size,
+        bins,
+        ...overrides,
+      },
+    ],
+  };
+  const file = join(dir, "manifest.json");
+  writeFileSync(file, JSON.stringify(manifest, null, 2));
+  return file;
+}
+
+function remoteManifest(
+  artifact: { tarball: string; sha: string },
+  platform: "linux" | "win",
+  _artifactUrl: string,
+  releaseRepository = "test/mirror",
+): Record<string, any> {
+  const runtime = process.version;
+  const nodeMajor = Number(process.versions.node.split(".")[0]);
+  const artifactName =
+    `agenc-runtime-${VERSION}-${platform}-x64-node${nodeMajor}-abi${NODE_ABI}.tar.gz`;
+  const artifactUrl =
+    `https://github.com/${releaseRepository}/releases/download/agenc-v${VERSION}/` +
+    artifactName;
+  const attestation = Buffer.from("{}");
+  return {
+    manifestVersion: 2,
+    runtimeVersion: VERSION,
+    releaseRepository,
+    releaseTag: `agenc-v${VERSION}`,
+    build: {
+      sourceCommit: "a".repeat(40),
+      sourceRef: `refs/tags/agenc-v${VERSION}`,
+      sourceDateEpoch: 1,
+      lockfileSha256: "b".repeat(64),
+      nodeVersion: runtime,
+      nodeMajor,
+      nodeModuleAbi: NODE_ABI,
+      nodeApiVersion: process.versions.napi,
+      npmVersion: "11.17.0",
+      artifactProfile: "release",
+    },
+    artifacts: [{
+      platform,
+      arch: "x64",
+      runtimeVersion: VERSION,
+      nodeMajor,
+      nodeModuleAbi: NODE_ABI,
+      nodeApiVersion: process.versions.napi,
+      ...(platform === "linux" ? {
+        libcFamily: "glibc",
+        minimumGlibcVersion: "2.28",
+        minimumGlibcxxVersion: "3.4.25",
+        minimumCxxAbiVersion: "1.3.11",
+      } : {}),
+      url: artifactUrl,
+      sha256: artifact.sha,
+      bytes: statSync(artifact.tarball).size,
+      attestationUrl: `${artifactUrl}.sigstore.json`,
+      attestationSha256: sha256(attestation),
+      attestationBytes: attestation.length,
+      bins: platform === "win"
+        ? { agenc: BIN_REL, node: WINDOWS_NODE_BIN_REL }
+        : { agenc: BIN_REL, node: NODE_BIN_REL, nodeLibrary: NODE_LIBRARY_REL },
+    }],
+  };
+}
+
+function replaceExactlyOnce(source: string, needle: string, replacement: string): string {
+  const first = source.indexOf(needle);
+  if (first === -1 || source.indexOf(needle, first + needle.length) !== -1) {
+    throw new Error(`expected exactly one installer test patch target: ${needle}`);
+  }
+  return source.slice(0, first) + replacement + source.slice(first + needle.length);
+}
+
+/**
+ * Fault tests need Node instrumentation. Patch only a private test copy; the
+ * shipped installer has no environment-controlled bypass for its preload scrub.
+ */
+function writeInstrumentedInstallSh(dir: string, pinnedGhArchive?: string): string {
+  const target = join(dir, "instrumented-install.sh");
+  let source = replaceExactlyOnce(
+    readFileSync(INSTALL_SH, "utf8"),
+    "unset NODE_OPTIONS",
+    ": # test copy only: retain NODE_OPTIONS for fault instrumentation",
+  );
+  if (pinnedGhArchive !== undefined) {
+    source = replaceExactlyOnce(
+      source,
+      "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60",
+      sha256(readFileSync(pinnedGhArchive)),
+    );
+  }
+  writeFileSync(target, source, { mode: 0o755 });
+  return target;
+}
+
+function writeInstrumentedInstallPs1(dir: string): string {
+  const target = join(dir, "instrumented-install.ps1");
+  const source = replaceExactlyOnce(
+    readFileSync(INSTALL_PS1, "utf8"),
+    '[Environment]::SetEnvironmentVariable("NODE_OPTIONS", $null, "Process")',
+    '# test copy only: retain NODE_OPTIONS for fault instrumentation',
+  );
+  writeFileSync(target, source);
+  return target;
+}
+
+function makeBootstrapNodeDistribution(dir: string): string {
+  const distribution = join(dir, "node-v26.5.0-linux-x64");
+  const bin = join(distribution, "bin");
+  mkdirSync(bin, { recursive: true });
+  const node = join(bin, "node");
+  writeFileSync(node, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`, {
+    mode: 0o755,
+  });
+  chmodSync(node, 0o755);
+  const archive = join(dir, "node-v26.5.0-linux-x64.tar.gz");
+  const result = spawnSync("tar", ["-czf", archive, "-C", dir, "node-v26.5.0-linux-x64"]);
+  expect(result.status, result.stderr?.toString()).toBe(0);
+  return archive;
+}
+
+function makeBootstrapLibatomicDistribution(dir: string): {
+  archive: string;
+  library: string;
+} {
+  const root = join(dir, "bootstrap-libatomic");
+  const licenses = join(root, "LICENSES");
+  const libraries = join(root, "lib");
+  mkdirSync(licenses, { recursive: true, mode: 0o755 });
+  mkdirSync(libraries, { recursive: true, mode: 0o755 });
+  chmodSync(root, 0o755);
+  chmodSync(licenses, 0o755);
+  chmodSync(libraries, 0o755);
+  writeFileSync(join(licenses, "COPYING.RUNTIME"), "synthetic runtime exception\n", {
+    mode: 0o644,
+  });
+  writeFileSync(join(licenses, "COPYING3"), "synthetic GPLv3\n", { mode: 0o644 });
+  chmodSync(join(licenses, "COPYING.RUNTIME"), 0o644);
+  chmodSync(join(licenses, "COPYING3"), 0o644);
+  const library = join(libraries, "libatomic.so.1");
+  cpSync("/usr/lib/x86_64-linux-gnu/libatomic.so.1.2.0", library);
+  chmodSync(library, 0o644);
+  const archive = join(dir, "agenc-node-bootstrap-libatomic-linux-x64.tar.gz");
+  const result = spawnSync(
+    "tar",
+    ["--sort=name", "--format=posix", "--mtime=@0", "--owner=0", "--group=0",
+      "--numeric-owner", "--pax-option=delete=atime,delete=ctime",
+      "-czf", archive, "-C", root, "LICENSES", "lib"],
+  );
+  expect(result.status, result.stderr?.toString()).toBe(0);
+  return { archive, library };
+}
+
+function writeBootstrapFixtureInstallSh(
+  dir: string,
+  archive: string,
+  compatibility: { archive: string; library: string },
+): string {
+  const target = join(dir, "bootstrap-fixture-install.sh");
+  let source = readFileSync(INSTALL_SH, "utf8");
+  source = replaceExactlyOnce(
+    source,
+    'NODE_DIST_SHA="22b5f47ad6ae78837e4c2b846019965ce1a06ba143de176102294a1bf44fc677"',
+    `NODE_DIST_SHA="${sha256(readFileSync(archive))}"`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    "NODE_DIST_BYTES=61529729",
+    `NODE_DIST_BYTES=${statSync(archive).size}`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    'NODE_COMPAT_SHA="1f7bafeb33c504e59e0143d917354f70d40989e286e651ecabafbb9ad4c31833"',
+    `NODE_COMPAT_SHA="${sha256(readFileSync(compatibility.archive))}"`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    "NODE_COMPAT_BYTES=26074",
+    `NODE_COMPAT_BYTES=${statSync(compatibility.archive).size}`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    'NODE_COMPAT_LIBRARY_SHA="5d7b55b28da42d1f298277089903a3eca81610b6aed627fc25270353ff24cbbd"',
+    `NODE_COMPAT_LIBRARY_SHA="${sha256(readFileSync(compatibility.library))}"`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    "NODE_COMPAT_LIBRARY_BYTES=28920",
+    `NODE_COMPAT_LIBRARY_BYTES=${statSync(compatibility.library).size}`,
+  );
+  writeFileSync(target, source, { mode: 0o755 });
+  return target;
+}
+
+function makeBootstrapWindowsNodeDistribution(dir: string): string {
+  const distribution = join(dir, "node-v26.5.0-win-x64");
+  mkdirSync(distribution, { recursive: true });
+  const node = join(distribution, "node.exe");
+  writeFileSync(node, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`, {
+    mode: 0o755,
+  });
+  chmodSync(node, 0o755);
+  const archive = join(dir, "node-v26.5.0-win-x64.zip");
+  const result = spawnSync(
+    "pwsh",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-Command",
+      [
+        "[System.IO.Compression.ZipFile]::CreateFromDirectory(",
+        `'${distribution.replaceAll("'", "''")}',`,
+        `'${archive.replaceAll("'", "''")}',`,
+        "[System.IO.Compression.CompressionLevel]::NoCompression,",
+        "$true)",
+      ].join(" "),
+    ],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+  return archive;
+}
+
+function writeBootstrapFixtureInstallPs1(
+  dir: string,
+  archive: string,
+  options: { bootstrapUrl?: string; trustTestCertificate?: boolean } = {},
+): string {
+  const target = join(dir, "bootstrap-fixture-install.ps1");
+  let source = readFileSync(INSTALL_PS1, "utf8");
+  source = replaceExactlyOnce(
+    source,
+    '$nodeDistributionSha256 = "d3b2277dbcccfdf24ef6302928f64f484cff1d77a6d3caa3a28f4d20ce9158f6"',
+    `$nodeDistributionSha256 = "${sha256(readFileSync(archive))}"`,
+  );
+  source = replaceExactlyOnce(
+    source,
+    "$nodeDistributionBytes = 41113391",
+    `$nodeDistributionBytes = ${statSync(archive).size}`,
+  );
+  if (options.bootstrapUrl !== undefined) {
+    source = replaceExactlyOnce(
+      source,
+      [
+        "$nodeDistributionUrl =",
+        '      "https://nodejs.org/dist/v$SupportedNodeVersion/$nodeDistributionFile"',
+      ].join("\n"),
+      `$nodeDistributionUrl = "${options.bootstrapUrl.replaceAll('"', '`"')}"`,
+    );
+  }
+  if (options.trustTestCertificate) {
+    source = replaceExactlyOnce(
+      source,
+      "$handler = [System.Net.Http.HttpClientHandler]::new()",
+      [
+        "$handler = [System.Net.Http.HttpClientHandler]::new()",
+        "# private test copy only: trust the loopback fixture certificate",
+        "$handler.ServerCertificateCustomValidationCallback = " +
+          "[System.Net.Http.HttpClientHandler]::DangerousAcceptAnyServerCertificateValidator",
+      ].join("\n"),
+    );
+  }
+  writeFileSync(target, source);
+  return target;
+}
+
+function writeGithubArtifactFetchRewrite(dir: string): string {
+  const preload = join(dir, "rewrite-github-artifact-fetch.cjs");
+  writeFileSync(preload, `
+const originalFetch = globalThis.fetch.bind(globalThis);
+globalThis.fetch = (input, init) => {
+  const source = input instanceof Request ? input.url : String(input);
+  const parsed = new URL(source);
+  if (process.env.AGENC_INSTALL_TEST_FETCH_LOG) {
+    require("node:fs").appendFileSync(process.env.AGENC_INSTALL_TEST_FETCH_LOG, source + "\\n");
+  }
+  if (parsed.hostname === "github.com") {
+    let replacement;
+    if (parsed.pathname.endsWith("/agenc-runtime-manifest-v2.json")) {
+      replacement = process.env.AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL;
+    } else if (parsed.pathname.endsWith(".sigstore.json")) {
+      replacement = process.env.AGENC_INSTALL_TEST_GITHUB_BUNDLE_URL;
+    } else if (parsed.pathname.includes("/cli/cli/releases/download/")) {
+      replacement = process.env.AGENC_INSTALL_TEST_GH_ARCHIVE_URL;
+    } else if (parsed.pathname.includes("/releases/download/") && parsed.pathname.endsWith(".tar.gz")) {
+      replacement = process.env.AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL;
+    }
+    if (replacement) return originalFetch(replacement, init);
+  }
+  return originalFetch(input, init);
+};
+`);
+  return preload;
+}
+
+function makeFakeGhArchive(dir: string): string {
+  const rootName = "gh_2.96.0_linux_amd64";
+  const binDir = join(dir, "fake-gh", rootName, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const binary = join(binDir, "gh");
+  writeFileSync(binary, `#!/bin/sh
+printf '%s\\n' "$@" > "$AGENC_INSTALL_TEST_GH_LOG"
+if [ -n "\${AGENC_INSTALL_TEST_GH_ENV_LOG:-}" ]; then
+  {
+    printf 'GH_CONFIG_DIR=%s\\n' "\${GH_CONFIG_DIR:-}"
+    printf 'GH_TOKEN=%s\\n' "\${GH_TOKEN:-}"
+    printf 'GITHUB_TOKEN=%s\\n' "\${GITHUB_TOKEN:-}"
+    printf 'HTTPS_PROXY=%s\\n' "\${HTTPS_PROXY:-}"
+    printf 'GH_TELEMETRY=%s\\n' "\${GH_TELEMETRY:-}"
+    printf 'DO_NOT_TRACK=%s\\n' "\${DO_NOT_TRACK:-}"
+    printf 'GH_NO_UPDATE_NOTIFIER=%s\\n' "\${GH_NO_UPDATE_NOTIFIER:-}"
+    printf 'GH_SPINNER_DISABLED=%s\\n' "\${GH_SPINNER_DISABLED:-}"
+  } > "$AGENC_INSTALL_TEST_GH_ENV_LOG"
+fi
+exit "\${AGENC_INSTALL_TEST_GH_EXIT:-0}"
+`);
+  chmodSync(binary, 0o755);
+  const archive = join(dir, "fake-gh.tar.gz");
+  const result = spawnSync("tar", ["-czf", archive, "-C", join(dir, "fake-gh"), rootName]);
+  expect(result.status, result.stderr?.toString()).toBe(0);
+  const content = readFileSync(archive);
+  const pinnedBytes = 14_652_560;
+  expect(content.length).toBeLessThan(pinnedBytes);
+  // GNU/BSD tar tolerate zero trailer blocks. Padding lets the fixture exercise
+  // the production exact-byte pin while the digest fault seam remains confined
+  // to the private instrumented installer copy.
+  writeFileSync(archive, Buffer.concat([content, Buffer.alloc(pinnedBytes - content.length)]));
+  return archive;
+}
+
+function writeLocalSwapPreload(dir: string): string {
+  const preload = join(dir, "swap-local-resource.cjs");
+  writeFileSync(preload, `
+const fs = require("node:fs");
+const original = fs.lstatSync;
+let swapped = false;
+fs.lstatSync = (path, ...args) => {
+  const metadata = original(path, ...args);
+  if (!swapped && String(path) === process.env.AGENC_INSTALL_TEST_SWAP_TARGET) {
+    swapped = true;
+    fs.renameSync(path, process.env.AGENC_INSTALL_TEST_SWAP_BACKUP);
+    fs.renameSync(process.env.AGENC_INSTALL_TEST_SWAP_REPLACEMENT, path);
+  }
+  return metadata;
+};
+`);
+  return preload;
+}
+
+function writeDurabilityPreload(dir: string): string {
+  const preload = join(dir, "trace-installer-durability.cjs");
+  writeFileSync(preload, `
+const fs = require("node:fs");
+const { resolve } = require("node:path");
+const root = resolve(process.env.AGENC_INSTALL_TEST_DURABILITY_ROOT);
+const logPath = process.env.AGENC_INSTALL_TEST_DURABILITY_LOG;
+const append = fs.appendFileSync.bind(fs);
+const descriptors = new Map();
+const within = (path) => {
+  const absolute = resolve(String(path));
+  return absolute === root || absolute.startsWith(root + require("node:path").sep);
+};
+const log = (line) => append(logPath, line + "\\n");
+const originalOpen = fs.openSync;
+fs.openSync = (path, ...args) => {
+  const descriptor = originalOpen(path, ...args);
+  if (within(path)) descriptors.set(descriptor, resolve(String(path)));
+  return descriptor;
+};
+const originalClose = fs.closeSync;
+fs.closeSync = (descriptor) => {
+  try { return originalClose(descriptor); }
+  finally { descriptors.delete(descriptor); }
+};
+const originalFsync = fs.fsyncSync;
+fs.fsyncSync = (descriptor) => {
+  const path = descriptors.get(descriptor);
+  if (path) {
+    log("fsync " + path);
+    const suffix = process.env.AGENC_INSTALL_TEST_FAIL_FSYNC_SUFFIX;
+    if (suffix && path.endsWith(suffix)) throw new Error("injected fsync failure for " + path);
+  }
+  return originalFsync(descriptor);
+};
+const originalRename = fs.renameSync;
+fs.renameSync = (from, to) => {
+  if (within(from) || within(to)) log("rename " + resolve(String(from)) + " -> " + resolve(String(to)));
+  return originalRename(from, to);
+};
+const originalRemove = fs.rmSync;
+fs.rmSync = (path, ...args) => {
+  if (within(path)) log("remove " + resolve(String(path)));
+  return originalRemove(path, ...args);
+};
+`);
+  return preload;
+}
+
+function trustArtifactRoute(manifestName: string): string | undefined {
+  if (manifestName === "short-manifest.json") return "/short.tar.gz";
+  if (manifestName === "overrun-manifest.json") return "/overrun.tar.gz";
+  if (manifestName === "length-manifest.json") return "/length.tar.gz";
+  return undefined;
+}
+
+type HttpsRoute = {
+  bodyText?: string;
+  bodyBase64?: string;
+  contentLength?: number;
+  omitContentLength?: boolean;
+  status?: number;
+  location?: string;
+  delayMs?: number;
+  stallHeaders?: boolean;
+  stallBody?: boolean;
+};
+
+function startHttpsFixture(
+  dir: string,
+  routes: Record<string, HttpsRoute>,
+): { baseUrl: string; ca: string; stop: () => void } {
+  const openssl = spawnSync("openssl", ["version"], { encoding: "utf8" });
+  if (openssl.status !== 0) throw new Error("openssl is required for installer HTTPS tests");
+  const key = join(dir, "https-key.pem");
+  const cert = join(dir, "https-cert.pem");
+  execFileSync("openssl", [
+    "req", "-x509", "-newkey", "rsa:2048", "-sha256", "-nodes", "-days", "1",
+    "-subj", "/CN=localhost", "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    "-keyout", key, "-out", cert,
+  ], { stdio: "ignore" });
+  const config = join(dir, "https-routes.json");
+  const ready = join(dir, "https-port");
+  const server = join(dir, "https-server.cjs");
+  writeFileSync(config, JSON.stringify(routes));
+  writeFileSync(server, `
+const https = require("node:https");
+const { readFileSync, writeFileSync } = require("node:fs");
+const [key, cert, config, ready] = process.argv.slice(2);
+const routes = JSON.parse(readFileSync(config, "utf8"));
+const sockets = new Set();
+const server = https.createServer({ key: readFileSync(key), cert: readFileSync(cert) }, (req, res) => {
+  const route = routes[new URL(req.url, "https://localhost").pathname];
+  if (!route) { res.writeHead(404); res.end(); return; }
+  if (route.stallHeaders) return;
+  const port = server.address().port;
+  const body = route.bodyBase64 === undefined
+    ? Buffer.from((route.bodyText || "").replaceAll("__PORT__", String(port)))
+    : Buffer.from(route.bodyBase64, "base64");
+  const headers = { "content-type": "application/octet-stream" };
+  if (route.contentLength !== undefined) headers["content-length"] = String(route.contentLength);
+  else if (!route.omitContentLength) headers["content-length"] = String(body.length);
+  if (route.location !== undefined) {
+    headers.location = route.location.replaceAll("__PORT__", String(port));
+  }
+  const respond = () => {
+    res.writeHead(route.status || 200, headers);
+    if (body.length > 0) res.write(route.stallBody ? body.subarray(0, 1) : body);
+    if (!route.stallBody) res.end();
+  };
+  if (route.delayMs) setTimeout(respond, route.delayMs);
+  else respond();
+});
+server.on("connection", (socket) => {
+  sockets.add(socket);
+  socket.on("close", () => sockets.delete(socket));
+});
+server.listen(0, "127.0.0.1", () => writeFileSync(ready, String(server.address().port)));
+process.on("SIGTERM", () => {
+  for (const socket of sockets) socket.destroy();
+  server.close(() => process.exit(0));
+});
+`);
+  const child = spawn(process.execPath, [server, key, cert, config, ready], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(ready) && Date.now() < deadline) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+  if (!existsSync(ready)) {
+    child.kill("SIGTERM");
+    throw new Error("HTTPS fixture did not start");
+  }
+  const port = readFileSync(ready, "utf8").trim();
+  return {
+    baseUrl: `https://127.0.0.1:${port}`,
+    ca: cert,
+    stop: () => { if (!child.killed) child.kill("SIGTERM"); },
+  };
+}
+
+function startConnectProxy(
+  dir: string,
+): { proxyUrl: string; log: string; stop: () => void } {
+  const ready = join(dir, "proxy-port");
+  const log = join(dir, "proxy-connect.log");
+  const server = join(dir, "connect-proxy.cjs");
+  writeFileSync(server, `
+const http = require("node:http");
+const net = require("node:net");
+const { appendFileSync, writeFileSync } = require("node:fs");
+const [ready, log] = process.argv.slice(2);
+const sockets = new Set();
+const proxy = http.createServer((_req, res) => { res.writeHead(405); res.end(); });
+proxy.on("connect", (req, client, head) => {
+  appendFileSync(log, req.url + "\\n");
+  const split = req.url.lastIndexOf(":");
+  const host = req.url.slice(0, split);
+  const port = Number(req.url.slice(split + 1));
+  const upstream = net.connect(port, host, () => {
+    client.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");
+    if (head.length > 0) upstream.write(head);
+    upstream.pipe(client);
+    client.pipe(upstream);
+  });
+  for (const socket of [client, upstream]) {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  }
+  upstream.on("error", () => client.destroy());
+  client.on("error", () => upstream.destroy());
+});
+proxy.listen(0, "127.0.0.1", () => writeFileSync(ready, String(proxy.address().port)));
+process.on("SIGTERM", () => {
+  for (const socket of sockets) socket.destroy();
+  proxy.close(() => process.exit(0));
+});
+`);
+  const child = spawn(process.execPath, [server, ready, log], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(ready) && Date.now() < deadline) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+  if (!existsSync(ready)) {
+    child.kill("SIGTERM");
+    throw new Error("CONNECT proxy fixture did not start");
+  }
+  return {
+    proxyUrl: `http://127.0.0.1:${readFileSync(ready, "utf8").trim()}`,
+    log,
+    stop: () => { if (!child.killed) child.kill("SIGTERM"); },
+  };
+}
+
+function trustBoundaryRoutes(
+  artifact: { tarball: string; sha: string },
+  platform: "linux" | "win",
+): Record<string, HttpsRoute> {
+  const artifactBytes = readFileSync(artifact.tarball);
+  const manifestFor = (artifactPath: string): Record<string, any> =>
+    remoteManifest(artifact, platform, `https://127.0.0.1:__PORT__${artifactPath}`);
+  const json = (value: unknown): string => JSON.stringify(value);
+  const short = manifestFor("/short.tar.gz");
+  const overrun = manifestFor("/overrun.tar.gz");
+  const length = manifestFor("/length.tar.gz");
+  const duplicate = manifestFor("/unused.tar.gz");
+  duplicate.artifacts.push(structuredClone(duplicate.artifacts[0]));
+  const missingTag = manifestFor("/unused.tar.gz");
+  delete missingTag.releaseTag;
+  const missingProvenance = manifestFor("/unused.tar.gz");
+  delete missingProvenance.build;
+  const detachedArtifact = manifestFor("/unused.tar.gz");
+  detachedArtifact.artifacts[0].url = "https://mirror.example.invalid/runtime.tar.gz";
+  const crossScheme = manifestFor("/unused.tar.gz");
+  crossScheme.artifacts[0].url = pathToFileURL(artifact.tarball).href;
+  const artifactCeiling = manifestFor("/unused.tar.gz");
+  artifactCeiling.artifacts[0].bytes = 256 * 1024 * 1024 + 1;
+  return {
+    "/oversized-manifest.json": {
+      bodyText: "x".repeat(1024 * 1024 + 1),
+      omitContentLength: true,
+    },
+    "/manifest-length.json": { bodyText: "{}", contentLength: 1024 * 1024 + 1 },
+    "/invalid-utf8.json": { bodyBase64: Buffer.from([0xff]).toString("base64") },
+    "/short-manifest.json": { bodyText: json(short) },
+    "/overrun-manifest.json": { bodyText: json(overrun) },
+    "/length-manifest.json": { bodyText: json(length) },
+    "/duplicate-manifest.json": { bodyText: json(duplicate) },
+    "/missing-tag-manifest.json": { bodyText: json(missingTag) },
+    "/missing-provenance-manifest.json": { bodyText: json(missingProvenance) },
+    "/detached-artifact-manifest.json": { bodyText: json(detachedArtifact) },
+    "/cross-scheme-manifest.json": { bodyText: json(crossScheme) },
+    "/artifact-ceiling-manifest.json": { bodyText: json(artifactCeiling) },
+    "/short.tar.gz": {
+      bodyBase64: artifactBytes.subarray(0, Math.max(0, artifactBytes.length - 1)).toString("base64"),
+      omitContentLength: true,
+    },
+    "/overrun.tar.gz": {
+      bodyBase64: Buffer.concat([artifactBytes, Buffer.from("x")]).toString("base64"),
+      omitContentLength: true,
+    },
+    "/length.tar.gz": {
+      bodyBase64: artifactBytes.toString("base64"),
+      contentLength: artifactBytes.length + 1,
+    },
+  };
+}
+
+function expectFailedInstallCleanup(home: string): void {
+  const versionDir = join(home, ".agenc", "runtime", VERSION);
+  if (existsSync(versionDir)) {
+    expect(
+      readdirSync(versionDir).filter((name) =>
+        (name.includes("-sha256-") && !name.endsWith(".agenc-lock.sqlite")) ||
+        name.includes(".install-") || name.includes(".old-")),
+    ).toEqual([]);
+  }
+  const temporary = join(home, "tmp");
+  if (existsSync(temporary)) {
+    expect(readdirSync(temporary).filter((name) => name.startsWith("agenc-install-"))).toEqual([]);
+  }
+}
+
+type RunResult = { status: number; stdout: string; stderr: string };
+
+function runInstaller(opts: {
+  home: string;
+  agencHome?: string;
+  cwd?: string;
+  args?: string[];
+  manifest?: string;
+  manifestUrl?: string;
+  repoDerived?: boolean;
+  pathPrepend?: string[];
+  envOverrides?: Record<string, string>;
+  installerPath?: string;
+  useDefaultPrefix?: boolean;
+}): RunResult {
+  mkdirSync(opts.home, { recursive: true, mode: 0o700 });
+  chmodSync(opts.home, 0o700);
+  const env = {
+    HOME: opts.home,
+    AGENC_HOME: opts.agencHome ?? join(opts.home, ".agenc"),
+    TMPDIR: join(opts.home, "tmp"),
+    PATH: [...(opts.pathPrepend ?? []), process.env.PATH ?? ""].join(":"),
+    // Deterministic platform selection regardless of the host machine.
+    AGENC_INSTALL_PLATFORM: "linux",
+    AGENC_INSTALL_ARCH: "x64",
+    AGENC_INSTALL_LIBC_FAMILY: "glibc",
+    AGENC_INSTALL_GLIBC_VERSION: "2.39",
+    AGENC_INSTALL_GLIBCXX_VERSION: "3.4.33",
+    AGENC_INSTALL_CXXABI_VERSION: "1.3.15",
+    ...opts.envOverrides,
+  };
+  mkdirSync(env.TMPDIR, { recursive: true });
+  const res = spawnSync(
+    "sh",
+    [
+      opts.installerPath ?? INSTALL_SH,
+      ...(opts.repoDerived
+        ? []
+        : ["--manifest-url", opts.manifestUrl ?? pathToFileURL(opts.manifest!).href]),
+      ...(opts.useDefaultPrefix ? [] : ["--prefix", join(opts.home, ".local")]),
+      ...(opts.args ?? []),
+    ],
+    { env, encoding: "utf8", ...(opts.cwd === undefined ? {} : { cwd: opts.cwd }) },
+  );
+  return {
+    status: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+function runInstallerAsync(opts: {
+  home: string;
+  manifest: string;
+  args?: string[];
+}): Promise<RunResult> {
+  if (existsSync(opts.home)) chmodSync(opts.home, 0o700);
+  const env = {
+    HOME: opts.home,
+    AGENC_HOME: join(opts.home, ".agenc"),
+    TMPDIR: join(opts.home, "tmp"),
+    PATH: process.env.PATH ?? "",
+    AGENC_INSTALL_PLATFORM: "linux",
+    AGENC_INSTALL_ARCH: "x64",
+    AGENC_INSTALL_LIBC_FAMILY: "glibc",
+    AGENC_INSTALL_GLIBC_VERSION: "2.39",
+    AGENC_INSTALL_GLIBCXX_VERSION: "3.4.33",
+    AGENC_INSTALL_CXXABI_VERSION: "1.3.15",
+  };
+  mkdirSync(env.TMPDIR, { recursive: true });
+  return new Promise((resolveRun) => {
+    const child = spawn(
+      "sh",
+      [
+        INSTALL_SH,
+        "--manifest-url",
+        pathToFileURL(opts.manifest).href,
+        "--prefix",
+        join(opts.home, ".local"),
+        "--no-daemon",
+        ...(opts.args ?? []),
+      ],
+      { env, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolveRun({ status: code ?? -1, stdout, stderr }));
+  });
+}
+
+export type InstallerTestLane = "shell" | "powershell";
+
+let registeredInstallerTestLane: InstallerTestLane | undefined;
+
+export function registerInstallerTests(lane: InstallerTestLane): void {
+  if (registeredInstallerTestLane !== undefined) {
+    throw new Error(
+      `installer tests already registered for ${registeredInstallerTestLane}; refusing ${lane}`,
+    );
+  }
+  registeredInstallerTestLane = lane;
+  if (lane === "shell") registerInstallShTests();
+  else registerInstallPs1Tests();
+}
+
+function registerInstallShTests(): void {
+describe.skipIf(process.platform === "win32")("install.sh", () => {
+  let work: string;
+  beforeEach(() => {
+    work = mkdtempSync(join(tmpdir(), "agenc-install-test-"));
+  });
+  afterEach(() => {
+    removePersistentWrapperLocks(work);
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  function paths(home: string, artifactSha = "") {
+    const installDir = join(
+      home,
+      ".agenc",
+      "runtime",
+      VERSION,
+      `linux-x64-glibc-node-abi-${NODE_ABI}${artifactSha === "" ? "" : `-sha256-${artifactSha}`}`,
+    );
+    return {
+      installDir,
+      marker: join(installDir, ".agenc-runtime-ok"),
+      provenanceReceipt: join(installDir, ".agenc-runtime-provenance-v1.json"),
+      privateNode: join(installDir, NODE_BIN_REL),
+      privateNodeLibrary: join(installDir, NODE_LIBRARY_REL),
+      wrapper: join(home, ".local", "bin", "agenc"),
+    };
+  }
+
+  test("fresh install: downloads, verifies, extracts, writes marker + working wrapper", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const res = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(res.stderr).toContain("checksum verified");
+    expect(res.status).toBe(0);
+
+    const { marker, privateNode, privateNodeLibrary, wrapper } = paths(home, artifact.sha);
+    expect(readFileSync(marker, "utf8")).toBe(artifact.sha);
+    expect(existsSync(privateNode)).toBe(true);
+    expect(existsSync(join(privateNodeLibrary, "libatomic.so.1"))).toBe(true);
+    expect(statSync(wrapper).mode & 0o111).not.toBe(0);
+    expect(parseInstallShWrapper(wrapper)).toMatchObject({
+      nodeBin: privateNode,
+      nodeLibraryPath: privateNodeLibrary,
+    });
+    // The created AGENC_HOME must be owner-only regardless of umask — a
+    // stranger-install container test caught mkdir -p leaving it 755.
+    expect(statSync(join(home, ".agenc")).mode & 0o777).toBe(0o700);
+    const homeIdentity = statSync(join(home, ".agenc"), { bigint: true });
+    expect(existsSync(resolve(`${homeIdentity.dev}:${homeIdentity.ino}`))).toBe(false);
+    expect(existsSync(join(home, ".agenc", "runtime", ".activation-lock.sqlite"))).toBe(true);
+    // The wrapper actually launches the installed runtime bin.
+    const out = execFileSync(wrapper, ["--version"], { encoding: "utf8" });
+    expect(out).toContain("ok --version");
+    const ambientBin = join(work, "ambient-bin-without-node");
+    mkdirSync(ambientBin);
+    const childNode = execFileSync(wrapper, ["--agenc-child-node-probe"], {
+      encoding: "utf8",
+      env: {
+        PATH: ambientBin,
+        NODE_OPTIONS: "--heapsnapshot-near-heap-limit=1",
+      },
+    });
+    expect(childNode).toBe("private-node-path-ok\n");
+  });
+
+  test.each([
+    ["private Node executable", { omitPrivateNode: true }, "private Node payload is incomplete"],
+    ["private Node library", { omitPrivateNodeLibrary: true }, "private Node library payload is incomplete"],
+  ])("rejects an artifact missing its %s", (_label, options, expected) => {
+    const home = join(work, `missing-${String(_label).replaceAll(" ", "-")}`);
+    const artifact = makeSyntheticArtifact(work, options);
+    const manifest = writeManifest(work, artifact);
+
+    const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(expected);
+    expect(existsSync(paths(home, artifact.sha).marker)).toBe(false);
+    expectFailedInstallCleanup(home);
+  });
+
+  test("ready-cache recovery refuses a marker-only tree missing private Node", () => {
+    const home = join(work, "damaged-private-node-home");
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const first = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(first.status, first.stderr).toBe(0);
+    const installed = paths(home, artifact.sha);
+    rmSync(installed.privateNode);
+
+    const repaired = runInstaller({ home, manifest, args: ["--no-daemon"] });
+
+    expect(repaired.status, repaired.stderr).toBe(0);
+    expect(repaired.stderr).not.toContain("already installed");
+    expect(existsSync(installed.privateNode)).toBe(true);
+  });
+
+  test("default install repairs an existing owner-owned group-writable wrapper directory", () => {
+    const home = join(work, "group-writable-wrapper-home");
+    const prefix = join(home, ".local");
+    const wrapperDir = join(prefix, "bin");
+    mkdirSync(wrapperDir, { recursive: true });
+    chmodSync(home, 0o700);
+    chmodSync(prefix, 0o770);
+    chmodSync(wrapperDir, 0o770);
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const result = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      useDefaultPrefix: true,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(statSync(prefix).mode & 0o022).toBe(0);
+    expect(statSync(wrapperDir).mode & 0o022).toBe(0);
+    expect(result.stderr).toContain("secured existing default wrapper directories");
+    expect(result.stderr).not.toContain("data:text/javascript");
+    expect(execFileSync(paths(home, artifact.sha).wrapper, ["--version"], {
+      encoding: "utf8",
+    })).toContain("ok --version");
+  });
+
+  test("rejects an unsafe explicit wrapper directory before artifact download with a concise error", () => {
+    const home = join(work, "unsafe-explicit-wrapper-home");
+    const prefix = join(home, ".local");
+    const wrapperDir = join(prefix, "bin");
+    mkdirSync(wrapperDir, { recursive: true });
+    chmodSync(home, 0o700);
+    chmodSync(prefix, 0o700);
+    chmodSync(wrapperDir, 0o770);
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    rmSync(artifact.tarball);
+
+    const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("protected directory chain permits untrusted mutation");
+    expect(result.stderr).not.toContain("downloading runtime");
+    expect(result.stderr).not.toContain("data:text/javascript");
+    expect(result.stderr).not.toMatch(/\n\s+at /u);
+  });
+
+  test("production installer ignores ambient Node preload and TLS-disable controls", () => {
+    const home = join(work, "preload-scrub-home");
+    const sentinel = join(work, "ambient-preload-ran");
+    const preload = join(work, "hostile-preload.cjs");
+    writeFileSync(preload, `require("node:fs").writeFileSync(${JSON.stringify(sentinel)}, "ran");\n`);
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const result = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      envOverrides: {
+        NODE_OPTIONS: `--require=${preload}`,
+        NODE_PATH: join(work, "hostile-node-path"),
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  test("HTTPS downloads traverse the configured enterprise CONNECT proxy", () => {
+    const fixture = startHttpsFixture(work, { "/manifest": { bodyText: "{}" } });
+    const proxy = startConnectProxy(work);
+    try {
+      const result = runInstaller({
+        home: join(work, "proxy-home"),
+        manifestUrl: `${fixture.baseUrl}/manifest`,
+        args: ["--no-daemon"],
+        envOverrides: {
+          HTTPS_PROXY: proxy.proxyUrl,
+          NO_PROXY: "",
+          NODE_EXTRA_CA_CERTS: fixture.ca,
+          NODE_USE_ENV_PROXY: "0",
+        },
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("unsupported runtime manifest version");
+      expect(readFileSync(proxy.log, "utf8")).toContain(
+        new URL(fixture.baseUrl).host,
+      );
+    } finally {
+      proxy.stop();
+      fixture.stop();
+    }
+  });
+
+  test("durability barriers commit payloads before promotion and journals around wrapper replacement", () => {
+    const home = join(work, "durable-home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const preload = writeDurabilityPreload(work);
+    const trace = join(work, "durability.log");
+    const result = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      installerPath: writeInstrumentedInstallSh(work),
+      envOverrides: {
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${preload}`.trim(),
+        AGENC_INSTALL_TEST_DURABILITY_ROOT: home,
+        AGENC_INSTALL_TEST_DURABILITY_LOG: trace,
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+
+    const events = readFileSync(trace, "utf8").trim().split("\n");
+    const { installDir, wrapper } = paths(home, artifact.sha);
+    const versionDir = dirname(installDir);
+    const runtimeRoot = join(home, ".agenc", "runtime");
+    const journal = join(runtimeRoot, ".activation-transaction.json");
+    const markerSync = events.findIndex(
+      (event) => event.startsWith("fsync ") && event.endsWith("/.agenc-runtime-ok"),
+    );
+    const promotion = events.findIndex((event) => event.endsWith(` -> ${installDir}`));
+    expect(markerSync).toBeGreaterThanOrEqual(0);
+    expect(promotion).toBeGreaterThan(markerSync);
+    expect(events.slice(promotion + 1)).toContain(`fsync ${versionDir}`);
+
+    const journalSync = events.findIndex(
+      (event) => event.startsWith(`fsync ${journal}.agenc-activate-`),
+    );
+    const journalRename = events.findIndex(
+      (event) => event.startsWith("rename ") && event.endsWith(` -> ${journal}`),
+    );
+    expect(journalSync).toBeGreaterThanOrEqual(0);
+    expect(journalRename).toBeGreaterThan(journalSync);
+    expect(events.slice(journalRename + 1)).toContain(`fsync ${runtimeRoot}`);
+
+    const wrapperSync = events.findIndex(
+      (event) => event.startsWith(`fsync ${wrapper}.agenc-activate-`),
+    );
+    const wrapperRename = events.findIndex(
+      (event) => event.startsWith("rename ") && event.endsWith(` -> ${wrapper}`),
+    );
+    expect(wrapperSync).toBeGreaterThanOrEqual(0);
+    expect(wrapperRename).toBeGreaterThan(wrapperSync);
+    const journalRemoval = events.findIndex((event) => event === `remove ${journal}`);
+    expect(journalRemoval).toBeGreaterThan(wrapperRename);
+    expect(events.slice(journalRemoval + 1)).toContain(`fsync ${runtimeRoot}`);
+  });
+
+  test("a marker flush failure aborts before runtime promotion and cleans staging residue", () => {
+    const home = join(work, "failed-flush-home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const preload = writeDurabilityPreload(work);
+    const result = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      installerPath: writeInstrumentedInstallSh(work),
+      envOverrides: {
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${preload}`.trim(),
+        AGENC_INSTALL_TEST_DURABILITY_ROOT: home,
+        AGENC_INSTALL_TEST_DURABILITY_LOG: join(work, "failed-durability.log"),
+        AGENC_INSTALL_TEST_FAIL_FSYNC_SUFFIX: ".agenc-runtime-ok",
+      },
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("injected fsync failure");
+    expect(existsSync(paths(home, artifact.sha).installDir)).toBe(false);
+    expectFailedInstallCleanup(home);
+  });
+
+  test("rejects relative AGENC_HOME before cwd can become persistent identity", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const res = runInstaller({
+      home,
+      agencHome: "relative-home",
+      cwd: work,
+      manifest,
+      args: ["--no-daemon"],
+    });
+
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("AGENC_HOME must be an absolute path");
+    expect(existsSync(join(work, "relative-home"))).toBe(false);
+  });
+
+  test("canonicalizes an existing AGENC_HOME symlink before install and wrapper rendering", () => {
+    const home = join(work, "home");
+    const canonicalHome = join(home, "canonical-agenc-home");
+    const aliasHome = join(home, "agenc-home-alias");
+    mkdirSync(canonicalHome, { recursive: true, mode: 0o700 });
+    symlinkSync(canonicalHome, aliasHome, "dir");
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const res = runInstaller({
+      home,
+      agencHome: aliasHome,
+      manifest,
+      args: ["--no-daemon"],
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    const wrapper = join(home, ".local", "bin", "agenc");
+    expect(parseInstallShWrapper(wrapper)).toMatchObject({ agencHome: canonicalHome });
+    expect(
+      existsSync(join(
+        canonicalHome,
+        "runtime",
+        VERSION,
+        `linux-x64-glibc-node-abi-${NODE_ABI}-sha256-${artifact.sha}`,
+      )),
+    ).toBe(true);
+  });
+
+  test("checksum mismatch: aborts nonzero, installs nothing", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact, {
+      sha256: "0".repeat(64),
+    });
+
+    const res = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("checksum mismatch");
+
+    const { installDir, wrapper } = paths(home);
+    expect(existsSync(installDir)).toBe(false);
+    expect(existsSync(wrapper)).toBe(false);
+  });
+
+  test("idempotent: verified marker short-circuits the download entirely", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const first = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(first.status).toBe(0);
+
+    // Remove the artifact: a second run can only succeed via the marker path.
+    rmSync(artifact.tarball);
+    const second = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(second.status).toBe(0);
+    expect(second.stderr).toContain("already installed");
+  });
+
+  test.each(["symlinked", "writable"] as const)(
+    "refuses a %s runtime ancestor before cache fast-path reuse",
+    (kind) => {
+      const home = join(work, `unsafe-cache-${kind}`);
+      const artifact = makeSyntheticArtifact(join(work, kind));
+      const manifest = writeManifest(join(work, kind), artifact);
+      expect(runInstaller({ home, manifest, args: ["--no-daemon"] }).status).toBe(0);
+      const runtimeRoot = join(home, ".agenc", "runtime");
+      if (kind === "symlinked") {
+        const canonicalRuntime = join(home, ".agenc", "runtime-canonical");
+        renameSync(runtimeRoot, canonicalRuntime);
+        symlinkSync(canonicalRuntime, runtimeRoot, "dir");
+      } else {
+        chmodSync(runtimeRoot, 0o777);
+      }
+      rmSync(artifact.tarball);
+
+      const reused = runInstaller({ home, manifest, args: ["--no-daemon"] });
+      expect(reused.status).not.toBe(0);
+      expect(reused.stderr).not.toContain("already installed");
+      expect(reused.stderr).toMatch(/canonical path|protected directory chain/);
+    },
+  );
+
+  test("preserves a custom wrapper that only contains the historical generated marker", () => {
+    const home = join(work, "home");
+    const wrapperDir = join(home, ".local", "bin");
+    mkdirSync(wrapperDir, { recursive: true, mode: 0o700 });
+    for (const path of [home, join(home, ".local"), wrapperDir]) chmodSync(path, 0o700);
+    const wrapper = join(wrapperDir, "agenc");
+    const custom = [
+      "#!/bin/sh",
+      "# Generated by AgenC install.sh — rewritten on every install/upgrade.",
+      "echo user-owned-wrapper",
+      "",
+    ].join("\n");
+    writeFileSync(wrapper, custom, { mode: 0o755 });
+    chmodSync(wrapper, 0o755);
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("refusing to replace a wrapper not generated by AgenC");
+    expect(readFileSync(wrapper, "utf8")).toBe(custom);
+  });
+
+  test("a verified promotion backup is restored before artifact download", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    expect(runInstaller({ home, manifest, args: ["--no-daemon"] }).status).toBe(0);
+    const { installDir, marker } = paths(home, artifact.sha);
+    const backup = `${installDir}.old-crash`;
+    renameSync(installDir, backup);
+    rmSync(artifact.tarball);
+
+    const recovered = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(recovered.status, recovered.stderr).toBe(0);
+    expect(readFileSync(marker, "utf8")).toBe(artifact.sha);
+    expect(existsSync(backup)).toBe(false);
+    expect(recovered.stderr).toContain("already installed");
+  });
+
+  test("a prepared stage wins over invalid promotion residue without network I/O", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    expect(runInstaller({ home, manifest, args: ["--no-daemon"] }).status).toBe(0);
+    const { installDir } = paths(home, artifact.sha);
+    const base = installDir.split(/[\\/]/).at(-1)!;
+    const stage = join(dirname(installDir), `.${base}.install-crash`);
+    renameSync(installDir, stage);
+    mkdirSync(installDir);
+    writeFileSync(join(installDir, ".agenc-runtime-ok"), "invalid");
+    cpSync(installDir, `${installDir}.old-invalid`, { recursive: true });
+    rmSync(artifact.tarball);
+
+    const recovered = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(recovered.status, recovered.stderr).toBe(0);
+    expect(readFileSync(join(installDir, BIN_REL), "utf8")).toContain("console.log");
+    expect(
+      readdirSync(dirname(installDir)).filter((name) => name.includes(".install-") || name.includes(".old-")),
+    ).toEqual([]);
+  });
+
+  test("a valid marker with a missing runtime entrypoint is repaired", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    expect(runInstaller({ home, manifest, args: ["--no-daemon"] }).status).toBe(0);
+
+    const { installDir } = paths(home, artifact.sha);
+    rmSync(join(installDir, BIN_REL));
+    const repaired = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(repaired.status).toBe(0);
+    expect(readFileSync(join(installDir, BIN_REL), "utf8")).toContain("console.log");
+  });
+
+  test("rejects byte-count tampering before extraction", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact, {
+      bytes: statSync(artifact.tarball).size + 1,
+    });
+    const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("byte count mismatch");
+    expect(existsSync(paths(home).installDir)).toBe(false);
+  });
+
+  test("embedded runtime install preserves primary and cleanup failures in order", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeRawTarArtifact(work, [
+      { name: "node_modules/", type: "5" },
+      { name: "node_modules/placeholder.txt", body: "missing runtime entrypoint\n" },
+    ]);
+    const manifest = writeManifest(work, artifact);
+
+    const result = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      envOverrides: {
+        AGENC_INSTALL_TEST_FAIL_STAGING_CLEANUP: "1",
+        AGENC_INSTALL_TEST_FAIL_RELEASE_CLEANUP: "1",
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    const primary = result.stderr.indexOf("runtime entrypoint is not a contained regular file");
+    const staging = result.stderr.indexOf("injected staging cleanup failure");
+    const release = result.stderr.indexOf("injected release cleanup failure");
+    expect(primary, result.stderr).toBeGreaterThanOrEqual(0);
+    expect(staging).toBeGreaterThan(primary);
+    expect(release).toBeGreaterThan(staging);
+    const versionDir = join(home, ".agenc", "runtime", VERSION);
+    expect(readdirSync(versionDir).some((name) => name.startsWith("."))).toBe(false);
+  });
+
+  test.each([
+    ["traversal", { name: "../escape", body: "owned" }, /unsafe runtime archive path/],
+    ["escaping symlink", { name: "node_modules/link", type: "2", link: "../../escape" }, /runtime archive link escapes/],
+  ] as const)("rejects an unsafe %s archive before tar extraction", (_label, malicious, error) => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeRawTarArtifact(work, [
+      { name: "node_modules/", type: "5" },
+      malicious,
+    ]);
+    const manifest = writeManifest(work, artifact);
+    const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(error);
+    expect(existsSync(join(work, "escape"))).toBe(false);
+    expect(existsSync(paths(home).installDir)).toBe(false);
+  });
+
+  test("rejects duplicate matching artifacts and path-bearing identity tampering", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifestPath = writeManifest(work, artifact);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.artifacts.push({ ...manifest.artifacts[0] });
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    const duplicate = runInstaller({ home, manifest: manifestPath, args: ["--no-daemon"] });
+    expect(duplicate.status).not.toBe(0);
+    expect(duplicate.stderr).toContain("duplicate runtime manifest artifact");
+
+    manifest.artifacts.length = 1;
+    manifest.artifacts[0].bins.agenc = "../../escape";
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    const pathTamper = runInstaller({ home, manifest: manifestPath, args: ["--no-daemon"] });
+    expect(pathTamper.status).not.toBe(0);
+    expect(pathTamper.stderr).toContain("manifest artifact identity is invalid");
+  });
+
+  test("rejects HTTP artifacts and a manifest that disagrees with --version", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifestPath = writeManifest(work, artifact, { url: "http://example.invalid/runtime.tar.gz" });
+    const insecure = runInstaller({ home, manifest: manifestPath, args: ["--no-daemon"] });
+    expect(insecure.status).not.toBe(0);
+    expect(insecure.stderr).toContain("explicit local manifests may only use canonical file artifact URLs");
+
+    writeManifest(work, artifact);
+    const mismatchedPin = runInstaller({
+      home,
+      manifest: manifestPath,
+      args: ["--version", "1.2.3", "--no-daemon"],
+    });
+    expect(mismatchedPin.status).not.toBe(0);
+    expect(mismatchedPin.stderr).toContain("does not match pinned version");
+  });
+
+  test("rejects authority, UNC, device-namespace, and drive-relative local artifact URLs", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifestPath = writeManifest(work, artifact);
+    const invalidUrls = [
+      `file://localhost${new URL(pathToFileURL(artifact.tarball).href).pathname}`,
+      "file:////server/share/runtime.tar.gz",
+      "file:///%5C%5C%3F%5CC:%5Cruntime.tar.gz",
+      "file:///C:runtime.tar.gz",
+    ];
+    for (const [index, url] of invalidUrls.entries()) {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      manifest.artifacts[0].url = url;
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+      const result = runInstaller({
+        home,
+        manifest: manifestPath,
+        args: ["--no-daemon"],
+      });
+      expect(result.status, `${index}: ${result.stderr}`).not.toBe(0);
+      expect(result.stderr).toContain(
+        "explicit local manifests may only use canonical file artifact URLs",
+      );
+    }
+  });
+
+  test.each(["attestationUrl", "attestationSha256", "attestationBytes"])(
+    "explicit-local manifests reject a declared %s even when it is null",
+    (field) => {
+      const fixtureRoot = join(work, `local-attestation-${field}`);
+      const home = join(fixtureRoot, "home");
+      mkdirSync(home, { recursive: true });
+      const artifact = makeSyntheticArtifact(fixtureRoot);
+      const manifest = writeManifest(fixtureRoot, artifact, { [field]: null });
+      const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "explicit local runtime artifacts must not declare remote attestations",
+      );
+      expectFailedInstallCleanup(home);
+    },
+  );
+
+  test("rejects a local resource swapped between metadata validation and descriptor open", () => {
+    const home = join(work, "home");
+    const replacementDir = join(work, "replacement");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(replacementDir);
+    const artifact = makeSyntheticArtifact(work);
+    const replacement = makeSyntheticArtifact(replacementDir);
+    const manifest = writeManifest(work, artifact);
+    const preload = writeLocalSwapPreload(work);
+    const backup = `${artifact.tarball}.before-swap`;
+
+    const result = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      installerPath: writeInstrumentedInstallSh(work),
+      envOverrides: {
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${preload}`.trim(),
+        AGENC_INSTALL_TEST_SWAP_TARGET: artifact.tarball,
+        AGENC_INSTALL_TEST_SWAP_BACKUP: backup,
+        AGENC_INSTALL_TEST_SWAP_REPLACEMENT: replacement.tarball,
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("local resource changed while it was opened");
+    expect(existsSync(backup)).toBe(true);
+    expectFailedInstallCleanup(home);
+  });
+
+  test("one monotonic download deadline covers stalled headers, bodies, and redirect chains", () => {
+    const fixture = startHttpsFixture(work, {
+      "/stall-headers": { stallHeaders: true },
+      "/stall-body": { bodyText: "{}", contentLength: 32, stallBody: true },
+      "/slow-redirect-one": {
+        status: 302,
+        location: "/slow-redirect-two",
+        delayMs: 90,
+      },
+      "/slow-redirect-two": {
+        status: 302,
+        location: "/never-reached",
+        delayMs: 90,
+      },
+      "/never-reached": { bodyText: "{}" },
+      "/redirect-loop": { status: 302, location: "/redirect-loop" },
+    });
+    try {
+      for (const route of ["stall-headers", "stall-body", "slow-redirect-one"]) {
+        const home = join(work, `deadline-${route}`);
+        mkdirSync(home, { recursive: true, mode: 0o700 });
+        const started = Date.now();
+        const result = runInstaller({
+          home,
+          manifestUrl: `${fixture.baseUrl}/${route}`,
+          args: ["--no-daemon"],
+          envOverrides: {
+            NODE_EXTRA_CA_CERTS: fixture.ca,
+            AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: "150",
+          },
+        });
+        expect(result.status, `${route}: ${result.stderr}`).not.toBe(0);
+        expect(result.stderr, route).toContain("download deadline exceeded after 150ms");
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expectFailedInstallCleanup(home);
+      }
+      const redirectHome = join(work, "deadline-redirect-count");
+      const redirectResult = runInstaller({
+        home: redirectHome,
+        manifestUrl: `${fixture.baseUrl}/redirect-loop`,
+        args: ["--no-daemon"],
+        envOverrides: {
+          NODE_EXTRA_CA_CERTS: fixture.ca,
+          AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: "2000",
+        },
+      });
+      expect(redirectResult.status).not.toBe(0);
+      expect(redirectResult.stderr).toContain("too many HTTPS redirects");
+      expectFailedInstallCleanup(redirectHome);
+    } finally {
+      fixture.stop();
+    }
+  }, 15_000);
+
+  test("repo-derived manifests bind releaseRepository while explicit manifest URLs remain explicit trust", () => {
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = remoteManifest(artifact, "linux", "unused");
+    const fixture = startHttpsFixture(work, {
+      "/repo-manifest.json": { bodyText: JSON.stringify(manifest) },
+      "/repo-artifact.tar.gz": { bodyBase64: readFileSync(artifact.tarball).toString("base64") },
+    });
+    const fetchRewrite = writeGithubArtifactFetchRewrite(work);
+    const installerPath = writeInstrumentedInstallSh(work);
+    const common = {
+      NODE_EXTRA_CA_CERTS: fixture.ca,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${fetchRewrite}`.trim(),
+      AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL: `${fixture.baseUrl}/repo-manifest.json`,
+      AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL: `${fixture.baseUrl}/repo-artifact.tar.gz`,
+    };
+    try {
+      const matchingHome = join(work, "repo-matching");
+      const matching = runInstaller({
+        home: matchingHome,
+        repoDerived: true,
+        args: ["--repo", "test/mirror", "--no-daemon"],
+        installerPath,
+        envOverrides: common,
+      });
+      expect(matching.status, matching.stderr).toBe(0);
+
+      const mismatchHome = join(work, "repo-mismatch");
+      const mismatch = runInstaller({
+        home: mismatchHome,
+        repoDerived: true,
+        args: ["--repo", "requested/repository", "--no-daemon"],
+        installerPath,
+        envOverrides: common,
+      });
+      expect(mismatch.status).not.toBe(0);
+      expect(mismatch.stderr).toContain(
+        "releaseRepository test/mirror does not match requested requested/repository",
+      );
+      expectFailedInstallCleanup(mismatchHome);
+
+      const explicitHome = join(work, "repo-explicit-url");
+      const explicit = runInstaller({
+        home: explicitHome,
+        manifestUrl: `${fixture.baseUrl}/repo-manifest.json`,
+        args: ["--no-daemon"],
+        installerPath,
+        envOverrides: common,
+      });
+      expect(explicit.status, explicit.stderr).toBe(0);
+    } finally {
+      fixture.stop();
+    }
+  }, 30_000);
+
+  test("official manifests require a complete canonical attestation identity", () => {
+    const artifact = makeSyntheticArtifact(work);
+    const base = remoteManifest(
+      artifact,
+      "linux",
+      "unused",
+      "tetsuo-ai/agenc-releases",
+    );
+    const cases: Array<[string, (manifest: Record<string, any>) => void, string]> = [
+      ["missing-url", (manifest) => { delete manifest.artifacts[0].attestationUrl; }, "attestation URL"],
+      ["missing-sha", (manifest) => { delete manifest.artifacts[0].attestationSha256; }, "attestation digest"],
+      ["missing-bytes", (manifest) => { delete manifest.artifacts[0].attestationBytes; }, "attestation size"],
+      ["wrong-url", (manifest) => { manifest.artifacts[0].attestationUrl = "https://example.invalid/bundle"; }, "attestation URL"],
+      ["wrong-sha", (manifest) => { manifest.artifacts[0].attestationSha256 = "A".repeat(64); }, "attestation digest"],
+      ["oversized", (manifest) => { manifest.artifacts[0].attestationBytes = 4 * 1024 * 1024 + 1; }, "attestation size"],
+    ];
+    const routes = Object.fromEntries(cases.map(([name, mutate]) => {
+      const manifest = structuredClone(base);
+      mutate(manifest);
+      return [`/${name}.json`, { bodyText: JSON.stringify(manifest) }];
+    }));
+    const fixture = startHttpsFixture(work, routes);
+    const rewrite = writeGithubArtifactFetchRewrite(work);
+    const installerPath = writeInstrumentedInstallSh(work);
+    try {
+      for (const [name, _mutate, expected] of cases) {
+        const result = runInstaller({
+          home: join(work, `official-${name}`),
+          repoDerived: true,
+          args: ["--no-daemon"],
+          installerPath,
+          envOverrides: {
+            NODE_EXTRA_CA_CERTS: fixture.ca,
+            NODE_OPTIONS: `--require=${rewrite}`,
+            AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL: `${fixture.baseUrl}/${name}.json`,
+          },
+        });
+        expect(result.status).not.toBe(0);
+        expect(result.stderr, name).toContain(expected);
+      }
+    } finally {
+      fixture.stop();
+    }
+  }, 30_000);
+
+  test("official v2 installs verify the canonical Sigstore bundle with a fresh pinned gh", () => {
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = remoteManifest(
+      artifact,
+      "linux",
+      "unused",
+      "tetsuo-ai/agenc-releases",
+    );
+    const fakeGh = makeFakeGhArchive(work);
+    const fixture = startHttpsFixture(work, {
+      "/official-manifest.json": { bodyText: JSON.stringify(manifest) },
+      "/official-runtime.tar.gz": { bodyBase64: readFileSync(artifact.tarball).toString("base64") },
+      "/official-runtime.sigstore.json": { bodyText: "{}" },
+      "/fake-gh.tar.gz": { bodyBase64: readFileSync(fakeGh).toString("base64") },
+      "/oversized-bundle": { bodyText: "{}", contentLength: 4 * 1024 * 1024 + 1 },
+    });
+    const fetchRewrite = writeGithubArtifactFetchRewrite(work);
+    const installerPath = writeInstrumentedInstallSh(work, fakeGh);
+    const fetchLog = join(work, "official-fetches.log");
+    const ghLog = join(work, "verified-gh-args.log");
+    const ghEnvLog = join(work, "verified-gh-env.log");
+    const ambientLog = join(work, "ambient-gh.log");
+    const ambientTarLog = join(work, "ambient-tar.log");
+    const ambientBin = join(work, "ambient-bin");
+    mkdirSync(ambientBin);
+    writeFileSync(join(ambientBin, "gh"), `#!/bin/sh\nprintf ambient > "${ambientLog}"\nexit 99\n`);
+    chmodSync(join(ambientBin, "gh"), 0o755);
+    writeFileSync(join(ambientBin, "tar"), `#!/bin/sh\nprintf ambient > "${ambientTarLog}"\nexit 99\n`);
+    chmodSync(join(ambientBin, "tar"), 0o755);
+    const common = {
+      NODE_EXTRA_CA_CERTS: fixture.ca,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${fetchRewrite}`.trim(),
+      AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL: `${fixture.baseUrl}/official-manifest.json`,
+      AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL: `${fixture.baseUrl}/official-runtime.tar.gz`,
+      AGENC_INSTALL_TEST_GITHUB_BUNDLE_URL: `${fixture.baseUrl}/official-runtime.sigstore.json`,
+      AGENC_INSTALL_TEST_GH_ARCHIVE_URL: `${fixture.baseUrl}/fake-gh.tar.gz`,
+      AGENC_INSTALL_TEST_FETCH_LOG: fetchLog,
+      AGENC_INSTALL_TEST_GH_LOG: ghLog,
+      AGENC_INSTALL_TEST_GH_ENV_LOG: ghEnvLog,
+      GH_TOKEN: "ambient-gh-secret",
+      GITHUB_TOKEN: "ambient-github-secret",
+      HTTPS_PROXY: "http://enterprise-proxy.invalid:8443",
+      NO_PROXY: "127.0.0.1,localhost",
+    };
+    try {
+      const home = join(work, "official-success");
+      const result = runInstaller({
+        home,
+        repoDerived: true,
+        args: ["--no-daemon"],
+        installerPath,
+        pathPrepend: [ambientBin],
+        envOverrides: common,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).toContain("source-workflow provenance verified");
+      expect(existsSync(ambientLog)).toBe(false);
+      expect(existsSync(ambientTarLog)).toBe(false);
+      const ghArgs = readFileSync(ghLog, "utf8");
+      expect(ghArgs).toContain("attestation\nverify\n");
+      expect(ghArgs).toContain("--repo\ntetsuo-ai/agenc-core\n");
+      expect(ghArgs).toContain(
+        "--signer-workflow\ntetsuo-ai/agenc-core/.github/workflows/release-runtime.yml\n",
+      );
+      expect(ghArgs).toContain(`--source-digest\n${"a".repeat(40)}\n`);
+      expect(ghArgs).toContain(`--signer-digest\n${"a".repeat(40)}\n`);
+      expect(ghArgs).toContain(`--source-ref\nrefs/tags/agenc-v${VERSION}\n`);
+      expect(ghArgs).toContain("--hostname\ngithub.com\n");
+      expect(ghArgs).toContain(
+        "--cert-oidc-issuer\nhttps://token.actions.githubusercontent.com\n",
+      );
+      expect(ghArgs).toContain("--predicate-type\nhttps://slsa.dev/provenance/v1\n");
+      expect(ghArgs).toContain("--deny-self-hosted-runners\n");
+      const ghEnvironment = readFileSync(ghEnvLog, "utf8");
+      expect(ghEnvironment).toContain("GH_CONFIG_DIR=");
+      expect(ghEnvironment).toContain("/gh-config\n");
+      expect(ghEnvironment).toContain("GH_TOKEN=\n");
+      expect(ghEnvironment).toContain("GITHUB_TOKEN=\n");
+      expect(ghEnvironment).toContain(
+        "HTTPS_PROXY=http://enterprise-proxy.invalid:8443\n",
+      );
+      expect(ghEnvironment).toContain("GH_TELEMETRY=0\n");
+      expect(ghEnvironment).toContain("DO_NOT_TRACK=1\n");
+      expect(ghEnvironment).toContain("GH_NO_UPDATE_NOTIFIER=1\n");
+      expect(ghEnvironment).toContain("GH_SPINNER_DISABLED=1\n");
+      const fetched = readFileSync(fetchLog, "utf8");
+      expect(fetched).toContain(`${manifest.artifacts[0].url}.sigstore.json`);
+      expect(fetched).toContain(
+        "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz",
+      );
+
+      const receiptPath = paths(home, artifact.sha).provenanceReceipt;
+      expect(JSON.parse(readFileSync(receiptPath, "utf8"))).toEqual({
+        schema: "agenc-runtime-provenance/v1",
+        artifactSha256: artifact.sha,
+        artifactUrl: manifest.artifacts[0].url,
+        sourceRepository: "tetsuo-ai/agenc-core",
+        sourceWorkflow: "tetsuo-ai/agenc-core/.github/workflows/release-runtime.yml",
+        sourceCommit: "a".repeat(40),
+        sourceRef: `refs/tags/agenc-v${VERSION}`,
+        attestationUrl: manifest.artifacts[0].attestationUrl,
+        attestationSha256: sha256(Buffer.from("{}")),
+        attestationBytes: Buffer.byteLength("{}"),
+        verificationPolicy: {
+          hostname: "github.com",
+          certOidcIssuer: "https://token.actions.githubusercontent.com",
+          predicateType: "https://slsa.dev/provenance/v1",
+          denySelfHostedRunners: true,
+        },
+      });
+
+      // A SHA-only cache from before provenance receipts existed must be
+      // migrated through a fresh official download and verification.
+      rmSync(receiptPath);
+      rmSync(fetchLog, { force: true });
+      const migrated = runInstaller({
+        home,
+        repoDerived: true,
+        args: ["--no-daemon"],
+        installerPath,
+        pathPrepend: [ambientBin],
+        envOverrides: common,
+      });
+      expect(migrated.status, migrated.stderr).toBe(0);
+      expect(migrated.stderr).toContain("source-workflow provenance verified");
+      expect(existsSync(receiptPath)).toBe(true);
+      expect(readFileSync(fetchLog, "utf8")).toContain(
+        `${manifest.artifacts[0].url}.sigstore.json`,
+      );
+
+      // The versioned policy receipt restores safe content-addressed reuse.
+      rmSync(fetchLog, { force: true });
+      const cached = runInstaller({
+        home,
+        repoDerived: true,
+        args: ["--no-daemon"],
+        installerPath,
+        pathPrepend: [ambientBin],
+        envOverrides: {
+          ...common,
+          AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL: `${fixture.baseUrl}/missing-artifact`,
+          AGENC_INSTALL_TEST_GITHUB_BUNDLE_URL: `${fixture.baseUrl}/missing-bundle`,
+          AGENC_INSTALL_TEST_GH_ARCHIVE_URL: `${fixture.baseUrl}/missing-gh`,
+        },
+      });
+      expect(cached.status, cached.stderr).toBe(0);
+      expect(cached.stderr).toContain("already installed (verified marker)");
+      const cachedFetches = readFileSync(fetchLog, "utf8");
+      expect(cachedFetches).not.toContain(manifest.artifacts[0].url);
+      expect(cachedFetches).not.toContain(".sigstore.json");
+      expect(cachedFetches).not.toContain("/cli/cli/releases/download/");
+
+      for (const [field, value] of [
+        ["attestationUrl", `${manifest.artifacts[0].url}.tampered`],
+        ["attestationSha256", "0".repeat(64)],
+        ["attestationBytes", 1],
+      ] as const) {
+        const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+        receipt[field] = value;
+        writeFileSync(receiptPath, `${JSON.stringify(receipt)}\n`);
+        rmSync(fetchLog, { force: true });
+        const repaired = runInstaller({
+          home,
+          repoDerived: true,
+          args: ["--no-daemon"],
+          installerPath,
+          pathPrepend: [ambientBin],
+          envOverrides: common,
+        });
+        expect(repaired.status, `${field}: ${repaired.stderr}`).toBe(0);
+        expect(repaired.stderr).toContain("source-workflow provenance verified");
+        expect(readFileSync(fetchLog, "utf8")).toContain(
+          manifest.artifacts[0].attestationUrl,
+        );
+      }
+
+      const rejectedHome = join(work, "official-rejected-provenance");
+      const rejected = runInstaller({
+        home: rejectedHome,
+        repoDerived: true,
+        args: ["--no-daemon"],
+        installerPath,
+        envOverrides: { ...common, AGENC_INSTALL_TEST_GH_EXIT: "1" },
+      });
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stderr).toContain("official runtime provenance verification failed");
+      expectFailedInstallCleanup(rejectedHome);
+
+      const oversizedHome = join(work, "official-oversized-bundle");
+      const oversized = runInstaller({
+        home: oversizedHome,
+        repoDerived: true,
+        args: ["--no-daemon"],
+        installerPath,
+        envOverrides: {
+          ...common,
+          AGENC_INSTALL_TEST_GITHUB_BUNDLE_URL: `${fixture.baseUrl}/oversized-bundle`,
+        },
+      });
+      expect(oversized.status).not.toBe(0);
+      expect(oversized.stderr).toContain("Content-Length exceeds 4194304 byte limit");
+      expectFailedInstallCleanup(oversizedHome);
+    } finally {
+      fixture.stop();
+    }
+  }, 45_000);
+
+  test("official provenance fails closed when the downloaded gh digest drifts", () => {
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = remoteManifest(
+      artifact,
+      "linux",
+      "unused",
+      "tetsuo-ai/agenc-releases",
+    );
+    const fakeGh = makeFakeGhArchive(work);
+    const fixture = startHttpsFixture(work, {
+      "/manifest": { bodyText: JSON.stringify(manifest) },
+      "/artifact": { bodyBase64: readFileSync(artifact.tarball).toString("base64") },
+      "/bundle": { bodyText: "{}" },
+      "/gh": { bodyBase64: readFileSync(fakeGh).toString("base64") },
+    });
+    const rewrite = writeGithubArtifactFetchRewrite(work);
+    const installerPath = writeInstrumentedInstallSh(work);
+    try {
+      const home = join(work, "official-gh-drift");
+      const result = runInstaller({
+        home,
+        repoDerived: true,
+        args: ["--no-daemon"],
+        installerPath,
+        envOverrides: {
+          NODE_EXTRA_CA_CERTS: fixture.ca,
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${rewrite}`.trim(),
+          AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL: `${fixture.baseUrl}/manifest`,
+          AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL: `${fixture.baseUrl}/artifact`,
+          AGENC_INSTALL_TEST_GITHUB_BUNDLE_URL: `${fixture.baseUrl}/bundle`,
+          AGENC_INSTALL_TEST_GH_ARCHIVE_URL: `${fixture.baseUrl}/gh`,
+        },
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("GitHub CLI checksum mismatch");
+      expectFailedInstallCleanup(home);
+    } finally {
+      fixture.stop();
+    }
+  }, 30_000);
+
+  test("bounded HTTPS trust rejects malformed manifests and truncated/overrun artifacts without residue", () => {
+    const artifact = makeSyntheticArtifact(work);
+    const fixture = startHttpsFixture(work, trustBoundaryRoutes(artifact, "linux"));
+    const fetchRewrite = writeGithubArtifactFetchRewrite(work);
+    const installerPath = writeInstrumentedInstallSh(work);
+    try {
+      const cases = [
+        ["oversized-manifest.json", "download exceeds 1048576 byte limit"],
+        ["manifest-length.json", "Content-Length exceeds 1048576 byte limit"],
+        ["invalid-utf8.json", "runtime manifest is not valid UTF-8"],
+        ["short-manifest.json", "download byte count mismatch"],
+        ["overrun-manifest.json", "download exceeds declared"],
+        ["length-manifest.json", "Content-Length mismatch"],
+        ["duplicate-manifest.json", "duplicate runtime manifest artifact"],
+        ["missing-tag-manifest.json", "runtime manifest release identity is invalid"],
+        ["missing-provenance-manifest.json", "runtime manifest build provenance is invalid"],
+        ["detached-artifact-manifest.json", "manifest artifact URL is not canonical"],
+        ["cross-scheme-manifest.json", "remote manifests may only reference HTTPS artifacts"],
+        ["artifact-ceiling-manifest.json", "manifest artifact identity is invalid"],
+      ] as const;
+      for (const [name, expected] of cases) {
+        const home = join(work, `shell-${name}`);
+        mkdirSync(home, { recursive: true, mode: 0o700 });
+        const result = runInstaller({
+          home,
+          manifestUrl: `${fixture.baseUrl}/${name}`,
+          args: ["--no-daemon"],
+          installerPath,
+          envOverrides: {
+            NODE_EXTRA_CA_CERTS: fixture.ca,
+            NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${fetchRewrite}`.trim(),
+            AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL:
+              trustArtifactRoute(name) === undefined
+                ? ""
+                : `${fixture.baseUrl}${trustArtifactRoute(name)}`,
+          },
+        });
+        expect(result.status, `${name}: ${result.stderr}`).not.toBe(0);
+        expect(result.stderr, name).toContain(expected);
+        expectFailedInstallCleanup(home);
+      }
+    } finally {
+      fixture.stop();
+    }
+  }, 30_000);
+
+  test("four concurrent installers converge on one complete tree", async () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () => runInstallerAsync({ home, manifest })),
+    );
+    expect(results.map((result) => result.status)).toEqual([0, 0, 0, 0]);
+    const { installDir, marker } = paths(home, artifact.sha);
+    expect(readFileSync(marker, "utf8")).toBe(artifact.sha);
+    expect(readFileSync(join(installDir, BIN_REL), "utf8")).toContain("console.log");
+    const versionDir = dirname(installDir);
+    expect(
+      readdirSync(versionDir).filter((name) => name.includes(".install-") || name.includes(".old-") || name.endsWith(".lock")),
+    ).toEqual([]);
+  });
+
+  test("a SIGKILL while holding the SQLite install lock is recovered immediately", async () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true, mode: 0o700 });
+    chmodSync(home, 0o700);
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const { installDir } = paths(home, artifact.sha);
+    const versionDir = dirname(installDir);
+    mkdirSync(versionDir, { recursive: true, mode: 0o700 });
+    for (const privateDir of [
+      join(home, ".agenc"),
+      join(home, ".agenc", "runtime"),
+      versionDir,
+    ]) chmodSync(privateDir, 0o700);
+    const embedded = readFileSync(INSTALL_SH, "utf8").match(
+      /<<'AGENC_RUNTIME_INSTALLER'\n([\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
+    )?.[1];
+    expect(embedded).toBeTruthy();
+    const helper = join(work, "runtime-installer-crash.cjs");
+    writeFileSync(helper, embedded!);
+    const holder = spawn(
+      process.execPath,
+      [helper, "recover", "", installDir, BIN_REL, artifact.sha, "linux"],
+      {
+        env: { ...process.env, AGENC_INSTALL_TEST_HOLD_RUNTIME_LOCK_MS: "5000" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const holderExit = new Promise<void>((resolveExit) => holder.once("exit", () => resolveExit()));
+    const lockDatabase = `${installDir}.agenc-lock.sqlite`;
+    const deadline = Date.now() + 2_000;
+    while (!existsSync(lockDatabase) && Date.now() < deadline) {
+      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    }
+    expect(existsSync(lockDatabase)).toBe(true);
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+    holder.kill("SIGKILL");
+    await holderExit;
+
+    const started = Date.now();
+    const result = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(result.status, result.stderr).toBe(0);
+    expect(Date.now() - started).toBeLessThan(10_000);
+    expect(readFileSync(join(installDir, ".agenc-runtime-ok"), "utf8")).toBe(artifact.sha);
+  });
+
+  test("an unpinned older installer cannot replace a newer active wrapper", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const makeVersion = (version: string, subdir: string) => {
+      const dir = join(work, subdir);
+      mkdirSync(dir);
+      const artifact = makeSyntheticArtifact(dir);
+      const manifestPath = writeManifest(dir, artifact);
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      manifest.runtimeVersion = version;
+      manifest.releaseTag = `agenc-v${version}`;
+      manifest.artifacts[0].runtimeVersion = version;
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+      return { artifact, manifestPath };
+    };
+    const high = makeVersion("10.0.0", "high");
+    const low = makeVersion("9.0.0", "low");
+    const wrapper = join(home, ".local", "bin", "agenc");
+
+    expect(runInstaller({ home, manifest: high.manifestPath, args: ["--no-daemon"] }).status).toBe(0);
+    expect(readFileSync(wrapper, "utf8")).toContain(join("runtime", "10.0.0"));
+    const retained = runInstaller({ home, manifest: low.manifestPath, args: ["--no-daemon"] });
+    expect(retained.status, retained.stderr).toBe(0);
+    expect(retained.stderr).toContain("kept newer active wrapper (10.0.0)");
+    expect(readFileSync(wrapper, "utf8")).toContain(join("runtime", "10.0.0"));
+
+    const pinned = runInstaller({
+      home,
+      manifest: low.manifestPath,
+      args: ["--version", "9.0.0", "--no-daemon"],
+    });
+    expect(pinned.status, pinned.stderr).toBe(0);
+    expect(readFileSync(wrapper, "utf8")).toContain(join("runtime", "9.0.0"));
+  });
+
+  test("the embedded activation lock makes a waiting older version re-read the winner", async () => {
+    const embedded = readFileSync(INSTALL_SH, "utf8").match(
+      /<<'AGENC_RUNTIME_INSTALLER'\n([\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
+    )?.[1];
+    expect(embedded).toBeTruthy();
+    const helper = join(work, "runtime-installer.cjs");
+    writeFileSync(helper, embedded!);
+    const agencHome = join(work, "activation-home");
+    mkdirSync(agencHome, { recursive: true, mode: 0o700 });
+    const wrapper = join(work, "activation-bin", "agenc");
+    mkdirSync(dirname(wrapper), { recursive: true });
+    chmodSync(dirname(wrapper), 0o700);
+    const runtimeBin = (version: string) =>
+      join(agencHome, "runtime", version, `linux-x64-glibc-node-abi-${NODE_ABI}`, BIN_REL);
+    const wrapperText = (version: string) => renderInstallShWrapper({
+      nodeBin: process.execPath,
+      runtimeBin: runtimeBin(version),
+      agencHome,
+    });
+    writeFileSync(wrapper, wrapperText("8.0.0"));
+    chmodSync(wrapper, 0o755);
+    const highDesired = join(work, "high-wrapper");
+    const lowDesired = join(work, "low-wrapper");
+    writeFileSync(highDesired, wrapperText("10.0.0"));
+    writeFileSync(lowDesired, wrapperText("9.0.0"));
+
+    const runActivation = (
+      desired: string,
+      version: string,
+      env: NodeJS.ProcessEnv,
+    ): Promise<RunResult> => new Promise((resolveRun) => {
+      const child = spawn(
+        process.execPath,
+        [helper, "activate", desired, wrapper, agencHome, version, "false"],
+        { env: { ...process.env, ...env }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+      child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+      child.on("close", (code) => resolveRun({ status: code ?? -1, stdout, stderr }));
+    });
+
+    const high = runActivation(highDesired, "10.0.0", {
+      AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS: "300",
+    });
+    const activationLock = join(agencHome, "runtime", ".activation-lock.sqlite");
+    const deadline = Date.now() + 2_000;
+    while (!existsSync(activationLock) && Date.now() < deadline) {
+      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    }
+    expect(existsSync(activationLock)).toBe(true);
+    const low = runActivation(lowDesired, "9.0.0", {
+      AGENC_INSTALL_TEST_AFTER_ACTIVATION_READ_MS: "500",
+    });
+    const [highResult, lowResult] = await Promise.all([high, low]);
+
+    expect(highResult.status, highResult.stderr).toBe(0);
+    expect(lowResult.status, lowResult.stderr).toBe(0);
+    expect(highResult.stdout.trim()).toBe("activated");
+    expect(lowResult.stdout.trim()).toBe("retained 10.0.0");
+    expect(readFileSync(wrapper, "utf8")).toBe(wrapperText("10.0.0"));
+  });
+
+  test("cross-home activations share the OS-account registry despite mutable HOME variables", async () => {
+    const embedded = readFileSync(INSTALL_SH, "utf8").match(
+      /<<'AGENC_RUNTIME_INSTALLER'\n([\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
+    )?.[1];
+    expect(embedded).toBeTruthy();
+    const helper = join(work, "cross-home-runtime-installer.cjs");
+    writeFileSync(helper, embedded!);
+    const firstHome = join(work, "first-agenc-home");
+    const secondHome = join(work, "second-agenc-home");
+    mkdirSync(firstHome, { recursive: true, mode: 0o700 });
+    mkdirSync(secondHome, { recursive: true, mode: 0o700 });
+    const wrapper = join(work, "shared-bin", "agenc");
+    mkdirSync(dirname(wrapper), { recursive: true });
+    chmodSync(dirname(wrapper), 0o700);
+    const desired = (home: string, version: string, name: string) => {
+      const path = join(work, name);
+      writeFileSync(path, renderInstallShWrapper({
+        nodeBin: process.execPath,
+        runtimeBin: join(
+          home,
+          "runtime",
+          version,
+          `linux-x64-glibc-node-abi-${NODE_ABI}`,
+          BIN_REL,
+        ),
+        agencHome: home,
+      }));
+      return path;
+    };
+    const firstDesired = desired(firstHome, "10.0.0", "first-desired-wrapper");
+    const secondDesired = desired(secondHome, "11.0.0", "second-desired-wrapper");
+    const spawnActivation = (
+      desiredPath: string,
+      home: string,
+      version: string,
+      env: NodeJS.ProcessEnv,
+    ): { child: ReturnType<typeof spawn>; result: Promise<RunResult> } => {
+      const child = spawn(
+        process.execPath,
+        [helper, "activate", desiredPath, wrapper, home, version, "false"],
+        { env: { ...process.env, ...env }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      const result = new Promise<RunResult>((resolveRun) => {
+        let stdout = "";
+        let stderr = "";
+        child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+        child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+        child.on("close", (code) => resolveRun({ status: code ?? -1, stdout, stderr }));
+      });
+      return { child, result };
+    };
+
+    const first = spawnActivation(firstDesired, firstHome, "10.0.0", {
+      HOME: join(work, "mutable-home-a"),
+      LOCALAPPDATA: join(work, "mutable-local-app-data-a"),
+      AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS: "400",
+    });
+    const firstHomeLock = join(firstHome, "runtime", ".activation-lock.sqlite");
+    const deadline = Date.now() + 2_000;
+    while (!existsSync(firstHomeLock) && Date.now() < deadline) {
+      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    }
+    expect(existsSync(firstHomeLock)).toBe(true);
+    await new Promise((resolveWait) => setTimeout(resolveWait, 75));
+    const second = spawnActivation(secondDesired, secondHome, "11.0.0", {
+      HOME: join(work, "mutable-home-b"),
+      LOCALAPPDATA: join(work, "mutable-local-app-data-b"),
+    });
+    const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
+
+    expect(firstResult.status, firstResult.stderr).toBe(0);
+    expect(secondResult.status).not.toBe(0);
+    expect(secondResult.stderr).toContain("wrapper belongs to a different AGENC_HOME");
+    expect(parseInstallShWrapper(wrapper)).toMatchObject({ agencHome: firstHome });
+  });
+
+  test("daemon: writes a systemd user unit pointing at the wrapper and enables it", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    // Stub systemctl that records its argv lines.
+    const stubDir = join(work, "stub-bin");
+    mkdirSync(stubDir, { recursive: true });
+    const callLog = join(work, "systemctl-calls.log");
+    writeFileSync(
+      join(stubDir, "systemctl"),
+      `#!/bin/sh\necho "$@" >> "${callLog}"\nexit 0\n`,
+    );
+    chmodSync(join(stubDir, "systemctl"), 0o755);
+
+    const res = runInstaller({ home, manifest, pathPrepend: [stubDir] });
+    expect(res.status).toBe(0);
+
+    const unit = readFileSync(
+      join(home, ".config", "systemd", "user", "agenc-daemon.service"),
+      "utf8",
+    );
+    const { wrapper } = paths(home);
+    expect(unit).toContain(`ExecStart=:"${wrapper}" daemon start --foreground`);
+    expect(unit).toContain("WantedBy=default.target");
+
+    const calls = readFileSync(callLog, "utf8");
+    expect(calls).toContain("--user daemon-reload");
+    expect(calls).toContain("--user enable --now agenc-daemon.service");
+  });
+
+  test("--no-daemon skips service installation", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const res = runInstaller({ home, manifest, args: ["--no-daemon"] });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("daemon installation skipped");
+    expect(
+      existsSync(join(home, ".config", "systemd", "user", "agenc-daemon.service")),
+    ).toBe(false);
+  });
+
+  test("unsupported architecture override is rejected before it can become a path component", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+
+    const env = {
+      HOME: home,
+      AGENC_HOME: join(home, ".agenc"),
+      PATH: process.env.PATH ?? "",
+      AGENC_INSTALL_PLATFORM: "linux",
+      AGENC_INSTALL_ARCH: "riscv64",
+    };
+    const res = spawnSync(
+      "sh",
+      [INSTALL_SH, "--manifest-url", pathToFileURL(manifest).href, "--no-daemon"],
+      { env, encoding: "utf8" },
+    );
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("unsupported operating-system architecture override: riscv64");
+    expect(res.stderr).not.toContain("fetching release manifest");
+  });
+
+  test("default release repo is the PUBLIC releases repo", () => {
+    // agenc-core is private: defaulting the manifest fetch to it 404s for
+    // every stranger. The public binary repo is the only valid default.
+    const sh = readFileSync(INSTALL_SH, "utf8");
+    expect(sh).toContain('AGENC_INSTALL_REPO:-tetsuo-ai/agenc-releases}');
+    expect(sh).not.toContain("agenc-core/releases");
+    const ps1 = readFileSync(INSTALL_PS1, "utf8");
+    expect(ps1).toContain('"tetsuo-ai/agenc-releases"');
+    expect(ps1).not.toContain("agenc-core/releases");
+  });
+
+  test("standalone installers detect the target before selecting a bootstrap Node", () => {
+    const sh = readFileSync(INSTALL_SH, "utf8");
+    expect(sh).toContain('case "$(/usr/bin/uname -m)"');
+    expect(sh).toContain("minimumGlibcVersion");
+    expect(sh).toContain("${a.platform}-${a.arch}-${libc}-node-abi-${a.nodeModuleAbi}");
+    expect(sh).toContain("AGENC_INSTALL_BOOTSTRAP_NODE_ARCHIVE");
+
+    const ps1 = readFileSync(INSTALL_PS1, "utf8");
+    expect(ps1).toContain("[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture");
+    expect(ps1).toContain('"win-$arch-native-node-abi-$nodeModuleAbi"');
+    expect(ps1).toContain("AGENC_INSTALL_BOOTSTRAP_NODE_ARCHIVE");
+    expect(ps1).toContain(
+      '"PATH", "LD_LIBRARY_PATH", "LD_PRELOAD", "DYLD_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES"',
+    );
+    expect(ps1).toContain('[System.Reflection.Assembly]::Load("System.Net.Http")');
+    expect(ps1).toContain(".SendAsync(");
+    expect(ps1).toContain(".ReadAsStreamAsync()");
+    expect(ps1).toContain(
+      '[System.Reflection.Assembly]::Load("System.IO.Compression.FileSystem")',
+    );
+  });
+
+  test("standalone bootstrap pins are mechanically bound to release-toolchain.json", () => {
+    const toolchain = JSON.parse(readFileSync(RELEASE_TOOLCHAIN, "utf8")) as any;
+    const sh = readFileSync(INSTALL_SH, "utf8");
+    const ps1 = readFileSync(INSTALL_PS1, "utf8");
+
+    expect(sh).toContain(`SUPPORTED_NODE_MAJOR=${toolchain.nodeMajor}`);
+    expect(sh).toContain(`SUPPORTED_NODE_VERSION=${toolchain.nodeVersion}`);
+    expect(sh).toContain(
+      'NODE_DIST_URL="https://nodejs.org/dist/v${SUPPORTED_NODE_VERSION}/${NODE_DIST_FILE}"',
+    );
+    expect(ps1).toContain(`$SupportedNodeMajor = ${toolchain.nodeMajor}`);
+    expect(ps1).toContain(`$SupportedNodeVersion = "${toolchain.nodeVersion}"`);
+    expect(ps1).toContain(
+      '"https://nodejs.org/dist/v$SupportedNodeVersion/$nodeDistributionFile"',
+    );
+    for (const slug of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64"]) {
+      const distribution = toolchain.nodeDistributions[slug];
+      expect(sh).toContain(`NODE_DIST_FILE="${distribution.file}"`);
+      expect(sh).toContain(`NODE_DIST_SHA="${distribution.sha256}"`);
+      expect(sh).toContain(`NODE_DIST_BYTES=${distribution.bytes}`);
+    }
+    const windows = toolchain.nodeDistributions["win-x64"];
+    expect(ps1).toContain(`$nodeDistributionFile = "${windows.file}"`);
+    expect(ps1).toContain(`$nodeDistributionSha256 = "${windows.sha256}"`);
+    expect(ps1).toContain(`$nodeDistributionBytes = ${windows.bytes}`);
+
+    const bootstrap = toolchain.nodeBootstrap;
+    expect(bootstrap.minimumRuntimeVersion).toBe("0.11.2");
+    expect(bootstrap.releaseTag).toBe(
+      `agenc-v${bootstrap.minimumRuntimeVersion}`,
+    );
+    expect(sh).toContain(
+      `NODE_COMPAT_RELEASE_TAG="${bootstrap.releaseTag}"`,
+    );
+    expect(sh).toContain(
+      `NODE_COMPAT_URL="https://github.com/tetsuo-ai/agenc-releases/releases/download/` +
+        `\${NODE_COMPAT_RELEASE_TAG}/\${NODE_COMPAT_FILE}"`,
+    );
+    for (const slug of ["linux-x64", "linux-arm64"]) {
+      const compat = bootstrap[slug];
+      expect(compat.url).toBe(
+        `https://github.com/tetsuo-ai/agenc-releases/releases/download/` +
+          `${bootstrap.releaseTag}/${compat.file}`,
+      );
+      expect(sh).toContain(`NODE_COMPAT_FILE="${compat.file}"`);
+      expect(sh).toContain(`NODE_COMPAT_SHA="${compat.sha256}"`);
+      expect(sh).toContain(`NODE_COMPAT_BYTES=${compat.bytes}`);
+      expect(sh).toContain(`NODE_COMPAT_LIBRARY_SHA="${compat.librarySha256}"`);
+      expect(sh).toContain(`NODE_COMPAT_LIBRARY_BYTES=${compat.libraryBytes}`);
+    }
+    for (const installer of [sh, ps1]) {
+      expect(installer).toContain(
+        `process.versions.node !== "${toolchain.nodeVersion}"`,
+      );
+      expect(installer).toContain(
+        `process.versions.modules !== "${toolchain.nodeModuleAbi}"`,
+      );
+      expect(installer).toContain(
+        `process.versions.napi !== "${toolchain.nodeApiVersion}"`,
+      );
+    }
+  });
+
+  test("PowerShell bootstrap uses one cancellation deadline for headers and every body read", () => {
+    const ps1 = readFileSync(INSTALL_PS1, "utf8");
+    expect(ps1).toContain("$deadline.CancelAfter($bootstrapTimeoutMs)");
+    expect(ps1).toContain("$client.Timeout = [System.Threading.Timeout]::InfiniteTimeSpan");
+    expect(ps1).toMatch(
+      /\.SendAsync\(\s*\$request,\s*\[System\.Net\.Http\.HttpCompletionOption\]::ResponseHeadersRead,\s*\$deadline\.Token\s*\)/,
+    );
+    expect(ps1).toMatch(
+      /\.ReadAsync\(\s*\$buffer,\s*0,\s*\$buffer\.Length,\s*\$deadline\.Token\s*\)/,
+    );
+    expect(ps1).not.toContain("$inputStream.Read($buffer");
+    expect(ps1).toContain("$deadline.Dispose()");
+  });
+
+  test.skipIf(process.platform !== "linux" || process.arch !== "x64")(
+    "modern install bootstraps pinned Node when host Node is incompatible",
+    () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifest = writeManifest(work, artifact);
+    const bootstrapArchive = makeBootstrapNodeDistribution(work);
+    const compatibility = makeBootstrapLibatomicDistribution(work);
+    const installerPath = writeBootstrapFixtureInstallSh(
+      work,
+      bootstrapArchive,
+      compatibility,
+    );
+
+    const res = runInstaller({
+      home,
+      manifest,
+      args: ["--no-daemon"],
+      installerPath,
+      envOverrides: {
+        PATH: "/usr/bin:/bin",
+        AGENC_INSTALL_BOOTSTRAP_NODE_ARCHIVE: bootstrapArchive,
+        AGENC_INSTALL_BOOTSTRAP_LIBATOMIC_ARCHIVE: compatibility.archive,
+      },
+    });
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stderr).toContain("using private Node.js 26.5.0 bootstrap");
+    const installed = paths(home, artifact.sha);
+    expect(parseInstallShWrapper(installed.wrapper)).toMatchObject({
+      nodeBin: installed.privateNode,
+      nodeLibraryPath: installed.privateNodeLibrary,
+    });
+    expect(readFileSync(installed.wrapper, "utf8")).not.toContain("agenc-node-bootstrap");
+    expect(
+      readdirSync(join(home, "tmp")).filter((name) =>
+        name.startsWith("agenc-node-bootstrap.")),
+    ).toEqual([]);
+    },
+  );
+
+  test("the frozen v0.7.2 pin requires Node 25 before any manifest fetch", () => {
+    const home = join(work, "home");
+    const res = runInstaller({
+      home,
+      repoDerived: true,
+      args: ["--version", "0.7.2", "--no-daemon"],
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain(
+      "The frozen v0.7.2 bridge requires Node.js >=25.9 <26",
+    );
+    expect(res.stderr).not.toContain("fetching release manifest");
+  });
+
+  test("pre-anchor releases fail with an actionable diagnostic before manifest fetch", () => {
+    const home = join(work, "home");
+    const pinned = runInstaller({
+      home,
+      repoDerived: true,
+      args: ["--version", "0.11.1", "--no-daemon"],
+    });
+    expect(pinned.status).not.toBe(0);
+    expect(pinned.stderr).toContain(
+      "runtime 0.11.1 has no supported standalone activation contract",
+    );
+    expect(pinned.stderr).toContain(
+      "0.7.2 bridge with host Node 25.9, or 0.11.2 and newer with private Node",
+    );
+    expect(pinned.stderr).not.toContain("fetching release manifest");
+
+    const ps1 = readFileSync(INSTALL_PS1, "utf8");
+    expect(ps1).toContain(
+      "runtime $($env:AGENC_INSTALL_VERSION) has no supported standalone activation contract",
+    );
+    expect(ps1).toContain(
+      "0.7.2 bridge with host Node 25.9, or 0.11.2 and newer with private Node",
+    );
+  });
+
+  test("unpinned pre-anchor manifests fail as compatibility errors, not malformed artifacts", () => {
+    const home = join(work, "home");
+    mkdirSync(home, { recursive: true });
+    const artifact = makeSyntheticArtifact(work);
+    const manifestPath = writeManifest(work, artifact);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.runtimeVersion = "0.11.1";
+    manifest.releaseTag = "agenc-v0.11.1";
+    manifest.artifacts[0].runtimeVersion = "0.11.1";
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    const result = runInstaller({ home, manifest: manifestPath, args: ["--no-daemon"] });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "runtime 0.11.1 has no supported standalone activation contract",
+    );
+    expect(result.stderr).not.toContain("manifest artifact identity is invalid");
+  });
+
+  test("ordinary v0.7.2 pins resolve the frozen legacy manifest in both installers", () => {
+    const sh = readFileSync(INSTALL_SH, "utf8");
+    expect(sh).toContain(
+      'MANIFEST_URL="https://github.com/${REPO}/releases/download/agenc-v0.7.2/agenc-runtime-manifest.json"',
+    );
+    expect(sh.indexOf('MANIFEST_TRUST="officialLegacy"')).toBeLessThan(
+      sh.indexOf('MANIFEST_TRUST="official"'),
+    );
+
+    const ps1 = readFileSync(INSTALL_PS1, "utf8");
+    expect(ps1).toContain(
+      '$manifestUrl = "https://github.com/$repo/releases/download/agenc-v0.7.2/agenc-runtime-manifest.json"',
+    );
+    expect(ps1.indexOf('"officialLegacy"')).toBeLessThan(
+      ps1.indexOf('elseif ($repo -eq $OfficialRepo -and -not $manifestExplicit) { "official" }'),
+    );
+  });
+
+});
+
+test("standalone installers embed the exact same archive/install validator", () => {
+  const shell = readFileSync(INSTALL_SH, "utf8").match(
+    /<<'AGENC_RUNTIME_INSTALLER'[\s\S]*?\n(const \{ spawnSync \}[\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
+  )?.[1];
+  const powershell = readFileSync(INSTALL_PS1, "utf8").match(
+    /\$RuntimeInstaller = @'\n([\s\S]*?)\n'@/,
+  )?.[1];
+  expect(shell).toBeTruthy();
+  expect(powershell).toBe(shell);
+  expect(shell).toContain("loadActivationLockIdentityModule()");
+  expect(shell).toContain("resolveActivationLockRegistry()");
+  expect(shell).not.toContain("function windowsAccountLockRegistry");
+  expect(shell).not.toContain("/run/user/");
+  expect(shell).not.toContain("process.env.LOCALAPPDATA");
+});
+
+test("official standalone paths pin gh and bind Sigstore verification to the source workflow", () => {
+  const shell = readFileSync(INSTALL_SH, "utf8");
+  const powershell = readFileSync(INSTALL_PS1, "utf8");
+  const githubCli = JSON.parse(readFileSync(RELEASE_TOOLCHAIN, "utf8")).githubCli;
+  for (const value of [
+    "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60",
+    "06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909",
+    "4bd449df9ad639391bc62b8032546f0fe9edcd8526e06682a4f88abd8c5d163c",
+    "f23a0c37d963aacc3bed703ccbd59b41c5ca22101fab7f00eb2b7cad23aba463",
+  ]) expect(shell).toContain(value);
+  expect(powershell).toContain(
+    "c2d6acc935cd2f00e2144d7e036d5cd82e6b6bd5594e8c75aa75ef2a4ed6aac3",
+  );
+  expect(shell).toContain(githubCli.version);
+  const expandedShellPins = shell.replaceAll("${GH_VERSION}", githubCli.version);
+  for (const platform of ["linuxX64", "linuxArm64", "macosX64", "macosArm64"]) {
+    expect(expandedShellPins).toContain(githubCli[platform].file);
+    expect(shell).toContain(githubCli[platform].sha256);
+  }
+  expect(powershell).toContain(githubCli.version);
+  expect(powershell.replaceAll("${ghVersion}", githubCli.version)).toContain(
+    githubCli.windowsX64.file,
+  );
+  expect(powershell).toContain(githubCli.windowsX64.sha256);
+  for (const installer of [shell, powershell]) {
+    expect(installer).toContain("2.96.0");
+    expect(installer).toContain(".sigstore.json");
+    expect(installer).toContain("--repo");
+    expect(installer).toContain("--signer-workflow");
+    expect(installer).toContain("--source-digest");
+    expect(installer).toContain("--signer-digest");
+    expect(installer).toContain("--source-ref");
+    expect(installer).toContain("--hostname");
+    expect(installer).toContain("--cert-oidc-issuer");
+    expect(installer).toContain("--predicate-type");
+    expect(installer).toContain("--deny-self-hosted-runners");
+    expect(installer).toContain("agenc-runtime-provenance/v1");
+    expect(installer).toContain("attestationSha256");
+  }
+  expect(shell).toContain("GH_TELEMETRY=0");
+  expect(shell).toContain("DO_NOT_TRACK=1");
+  expect(shell).toContain("GH_SPINNER_DISABLED=1");
+  expect(powershell).toContain('$env:GH_TELEMETRY = "0"');
+  expect(powershell).toContain('$env:DO_NOT_TRACK = "1"');
+  expect(powershell).toContain('$env:GH_SPINNER_DISABLED = "1"');
+  expect(shell).not.toContain("command -v gh");
+  expect(shell).toContain("file.nlink !== 1");
+  expect(shell).toContain("(file.mode & 0o022) !== 0");
+  expect(powershell).not.toContain("Get-Command gh");
+});
+}
+
+function registerInstallPs1Tests(): void {
+  test("install.ps1 parses under the required PowerShell runtime", () => {
+    const version = spawnSync(
+      "pwsh",
+      ["-NoLogo", "-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"],
+      { encoding: "utf8" },
+    );
+    expect(version.status, version.stderr).toBe(0);
+    expect(version.stdout.trim()).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+/);
+
+    const result = spawnSync(
+      "pwsh",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        `$null = [scriptblock]::Create((Get-Content -Raw '${INSTALL_PS1.replaceAll("'", "''")}')); 'parsed'`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("parsed");
+  });
+
+  describe("install.ps1 behavior", () => {
+    let work: string;
+    beforeEach(() => {
+      work = mkdtempSync(join(tmpdir(), "agenc-install-ps-test-"));
+    });
+    afterEach(() => {
+      removePersistentWrapperLocks(work);
+      rmSync(work, { recursive: true, force: true });
+    });
+
+    function runPowerShell(
+      home: string,
+      manifest: string | undefined,
+      agencHome = join(home, ".agenc"),
+      envOverrides: Record<string, string> = {},
+      installerPath = INSTALL_PS1,
+    ): RunResult {
+      if (existsSync(home)) chmodSync(home, 0o700);
+      const temporary = join(home, "tmp");
+      mkdirSync(temporary, { recursive: true, mode: 0o700 });
+      const env = {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        LOCALAPPDATA: join(home, "local-app-data"),
+        TMPDIR: temporary,
+        TEMP: temporary,
+        TMP: temporary,
+        AGENC_HOME: agencHome,
+        AGENC_INSTALL_PREFIX: join(home, "prefix"),
+        AGENC_INSTALL_MANIFEST_URL: manifest ?? "",
+        AGENC_INSTALL_PLATFORM: "win32",
+        AGENC_INSTALL_ARCH: "x64",
+        ...envOverrides,
+      };
+      const result = spawnSync("pwsh", ["-NoProfile", "-File", installerPath], {
+        env,
+        encoding: "utf8",
+      });
+      return {
+        status: result.status ?? -1,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+      };
+    }
+
+    function windowsPaths(home: string, artifactSha = "") {
+      const installDir = join(
+        home,
+        ".agenc",
+        "runtime",
+        VERSION,
+        `win-x64-native-node-abi-${NODE_ABI}${artifactSha === "" ? "" : `-sha256-${artifactSha}`}`,
+      );
+      return {
+        installDir,
+        marker: join(installDir, ".agenc-runtime-ok"),
+        bin: join(installDir, BIN_REL),
+        privateNode: join(installDir, WINDOWS_NODE_BIN_REL),
+        wrapper: join(home, "prefix", "bin", "agenc.cmd"),
+      };
+    }
+
+    test("PowerShell bootstraps pinned Node when the host command is incompatible", () => {
+      const home = join(work, "bootstrap-home");
+      mkdirSync(home, { recursive: true, mode: 0o700 });
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+      const bootstrapArchive = makeBootstrapWindowsNodeDistribution(work);
+      const installerPath = writeBootstrapFixtureInstallPs1(work, bootstrapArchive);
+      const incompatibleBin = join(work, "incompatible-node");
+      mkdirSync(incompatibleBin);
+      writeFileSync(join(incompatibleBin, "node"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+      chmodSync(join(incompatibleBin, "node"), 0o755);
+
+      const result = runPowerShell(home, manifest, join(home, ".agenc"), {
+        PATH: `${incompatibleBin}:${process.env.PATH ?? ""}`,
+        AGENC_INSTALL_BOOTSTRAP_NODE_ARCHIVE: bootstrapArchive,
+      }, installerPath);
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("using private Node.js 26.5.0 bootstrap");
+      const installed = windowsPaths(home, artifact.sha);
+      expect(parseGeneratedWrapper(installed.wrapper)).toMatchObject({
+        nodeBin: installed.privateNode,
+      });
+      expect(readFileSync(installed.wrapper, "utf8")).not.toContain("agenc-node-bootstrap");
+      expect(
+        readdirSync(join(home, "tmp")).filter((name) =>
+          name.startsWith("agenc-node-bootstrap-")),
+      ).toEqual([]);
+    });
+
+    test("PowerShell bootstrap deadline covers a stalled response body", () => {
+      const home = join(work, "bootstrap-stall-home");
+      mkdirSync(home, { recursive: true, mode: 0o700 });
+      const bootstrapArchive = makeBootstrapWindowsNodeDistribution(work);
+      const fixture = startHttpsFixture(work, {
+        "/node.zip": {
+          bodyBase64: readFileSync(bootstrapArchive).toString("base64"),
+          stallBody: true,
+        },
+      });
+      const incompatibleBin = join(work, "incompatible-node-stall");
+      mkdirSync(incompatibleBin);
+      writeFileSync(join(incompatibleBin, "node"), "#!/bin/sh\nexit 1\n", { mode: 0o755 });
+      chmodSync(join(incompatibleBin, "node"), 0o755);
+      const installerPath = writeBootstrapFixtureInstallPs1(
+        work,
+        bootstrapArchive,
+        {
+          bootstrapUrl: `${fixture.baseUrl}/node.zip`,
+          trustTestCertificate: true,
+        },
+      );
+      try {
+        const started = Date.now();
+        const result = runPowerShell(home, join(work, "must-not-be-read.json"), join(home, ".agenc"), {
+          PATH: `${incompatibleBin}:${process.env.PATH ?? ""}`,
+          AGENC_INSTALL_TEST_BOOTSTRAP_TIMEOUT_MS: "500",
+          HTTP_PROXY: "",
+          HTTPS_PROXY: "",
+          ALL_PROXY: "",
+          NO_PROXY: "127.0.0.1,localhost",
+        }, installerPath);
+        const output = `${result.stdout}\n${result.stderr}`;
+
+        expect(result.status).not.toBe(0);
+        expect(output).toContain("Node.js bootstrap deadline exceeded after 500ms");
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expect(
+          readdirSync(join(home, "tmp")).filter((name) =>
+            name.startsWith("agenc-node-bootstrap-")),
+        ).toEqual([]);
+      } finally {
+        fixture.stop();
+      }
+    });
+
+    test("PowerShell rejects a reparse temporary parent before child mutation", () => {
+      const home = join(work, "reparse-parent-home");
+      const agencHome = join(home, ".agenc");
+      const target = join(work, "reparse-parent-target");
+      const parentAlias = join(agencHome, ".installer-tmp");
+      mkdirSync(agencHome, { recursive: true, mode: 0o700 });
+      mkdirSync(target, { mode: 0o700 });
+      writeFileSync(join(target, "sentinel"), "preserve\n");
+      symlinkSync(target, parentAlias, "dir");
+
+      const result = runPowerShell(home, join(work, "must-not-be-read.json"));
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        "private installer temporary parent is not a real",
+      );
+      expect(lstatSync(parentAlias).isSymbolicLink()).toBe(true);
+      expect(readdirSync(target)).toEqual(["sentinel"]);
+      expect(readFileSync(join(target, "sentinel"), "utf8")).toBe("preserve\n");
+    });
+
+    test("PowerShell preserves a pre-existing private temporary parent", () => {
+      const home = join(work, "existing-parent-home");
+      const agencHome = join(home, ".agenc");
+      const workParent = join(agencHome, ".installer-tmp");
+      mkdirSync(workParent, { recursive: true, mode: 0o700 });
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+
+      const result = runPowerShell(home, manifest);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(lstatSync(workParent).isDirectory()).toBe(true);
+      expect(lstatSync(workParent).isSymbolicLink()).toBe(false);
+      expect(readdirSync(workParent)).toEqual([]);
+    });
+
+    test("PowerShell restores caller Node environment controls after an installer failure", () => {
+      const home = join(work, "environment-restore-home");
+      mkdirSync(home, { recursive: true });
+      const wrapper = join(work, "environment-restore.ps1");
+      writeFileSync(
+        wrapper,
+        [
+          "$ErrorActionPreference = 'Stop'",
+          "$env:NODE_OPTIONS = '--trace-warnings'",
+          "$env:NODE_PATH = 'agenc-node-path-sentinel'",
+          "$env:NODE_TLS_REJECT_UNAUTHORIZED = '0'",
+          "$env:NODE_USE_ENV_PROXY = 'agenc-proxy-sentinel'",
+          "$env:AGENC_HOME = 'relative-home-must-fail'",
+          `try { . '${INSTALL_PS1.replaceAll("'", "''")}' } catch { }`,
+          "$result = [ordered]@{",
+          "  NODE_OPTIONS = $env:NODE_OPTIONS",
+          "  NODE_PATH = $env:NODE_PATH",
+          "  NODE_TLS_REJECT_UNAUTHORIZED = $env:NODE_TLS_REJECT_UNAUTHORIZED",
+          "  NODE_USE_ENV_PROXY = $env:NODE_USE_ENV_PROXY",
+          "}",
+          "Write-Output ('AGENC_ENV_AFTER=' + ($result | ConvertTo-Json -Compress))",
+          "",
+        ].join("\n"),
+      );
+      const temporary = join(home, "tmp");
+      mkdirSync(temporary, { recursive: true, mode: 0o700 });
+      const result = spawnSync("pwsh", ["-NoProfile", "-File", wrapper], {
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          LOCALAPPDATA: join(home, "local-app-data"),
+          TMPDIR: temporary,
+          TEMP: temporary,
+          TMP: temporary,
+          AGENC_INSTALL_PREFIX: join(home, "prefix"),
+        },
+        encoding: "utf8",
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const record = result.stdout
+        .split(/\r?\n/)
+        .find((line) => line.startsWith("AGENC_ENV_AFTER="));
+      expect(record).toBeTruthy();
+      expect(JSON.parse(record!.slice("AGENC_ENV_AFTER=".length))).toEqual({
+        NODE_OPTIONS: "--trace-warnings",
+        NODE_PATH: "agenc-node-path-sentinel",
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        NODE_USE_ENV_PROXY: "agenc-proxy-sentinel",
+      });
+    });
+
+    test("PowerShell restores caller Node environment controls after a successful iex-style install", () => {
+      const home = join(work, "environment-restore-success-home");
+      mkdirSync(home, { recursive: true });
+      chmodSync(home, 0o700);
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+      const wrapper = join(work, "environment-restore-success.ps1");
+      writeFileSync(
+        wrapper,
+        [
+          "$ErrorActionPreference = 'Stop'",
+          "$env:NODE_OPTIONS = '--trace-warnings'",
+          "$env:NODE_PATH = 'agenc-node-path-sentinel'",
+          "$env:NODE_TLS_REJECT_UNAUTHORIZED = '0'",
+          "$env:NODE_USE_ENV_PROXY = 'agenc-proxy-sentinel'",
+          `. '${INSTALL_PS1.replaceAll("'", "''")}'`,
+          "$result = [ordered]@{",
+          "  NODE_OPTIONS = $env:NODE_OPTIONS",
+          "  NODE_PATH = $env:NODE_PATH",
+          "  NODE_TLS_REJECT_UNAUTHORIZED = $env:NODE_TLS_REJECT_UNAUTHORIZED",
+          "  NODE_USE_ENV_PROXY = $env:NODE_USE_ENV_PROXY",
+          "}",
+          "Write-Output ('AGENC_ENV_AFTER=' + ($result | ConvertTo-Json -Compress))",
+          "",
+        ].join("\n"),
+      );
+      const temporary = join(home, "tmp");
+      mkdirSync(temporary, { recursive: true, mode: 0o700 });
+      const result = spawnSync("pwsh", ["-NoProfile", "-File", wrapper], {
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          LOCALAPPDATA: join(home, "local-app-data"),
+          TMPDIR: temporary,
+          TEMP: temporary,
+          TMP: temporary,
+          AGENC_HOME: join(home, ".agenc"),
+          AGENC_INSTALL_PREFIX: join(home, "prefix"),
+          AGENC_INSTALL_MANIFEST_URL: manifest,
+          AGENC_INSTALL_PLATFORM: "win32",
+          AGENC_INSTALL_ARCH: "x64",
+        },
+        encoding: "utf8",
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const record = result.stdout
+        .split(/\r?\n/)
+        .find((line) => line.startsWith("AGENC_ENV_AFTER="));
+      expect(record).toBeTruthy();
+      expect(JSON.parse(record!.slice("AGENC_ENV_AFTER=".length))).toEqual({
+        NODE_OPTIONS: "--trace-warnings",
+        NODE_PATH: "agenc-node-path-sentinel",
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        NODE_USE_ENV_PROXY: "agenc-proxy-sentinel",
+      });
+      expect(existsSync(windowsPaths(home, artifact.sha).marker)).toBe(true);
+    });
+
+    test("fresh and idempotent PowerShell installs use the complete-tree marker contract", () => {
+      const home = join(work, "home");
+      mkdirSync(home, { recursive: true });
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+      const first = runPowerShell(home, manifest);
+      expect(first.status, first.stderr).toBe(0);
+      const paths = windowsPaths(home, artifact.sha);
+      expect(readFileSync(paths.marker, "utf8")).toBe(artifact.sha);
+      expect(readFileSync(paths.bin, "utf8")).toContain("console.log");
+      expect(existsSync(paths.privateNode)).toBe(true);
+      expect(parseGeneratedWrapper(paths.wrapper)).toMatchObject({
+        nodeBin: paths.privateNode,
+      });
+      const homeIdentity = statSync(join(home, ".agenc"), { bigint: true });
+      expect(existsSync(resolve(`${homeIdentity.dev}:${homeIdentity.ino}`))).toBe(false);
+      expect(existsSync(join(home, ".agenc", "runtime", ".activation-lock.sqlite"))).toBe(true);
+
+      const backup = `${paths.installDir}.old-crash`;
+      renameSync(paths.installDir, backup);
+      rmSync(artifact.tarball);
+      const second = runPowerShell(home, manifest);
+      expect(second.status, second.stderr).toBe(0);
+      expect(second.stdout).toContain("already installed");
+      expect(existsSync(backup)).toBe(false);
+    });
+
+    test("PowerShell rejects relative AGENC_HOME before resolving the manifest install path", () => {
+      const home = join(work, "home");
+      mkdirSync(home, { recursive: true });
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+
+      const result = runPowerShell(home, manifest, "relative-home");
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toContain("AGENC_HOME must be an absolute path");
+      expect(result.stdout).not.toContain("fetching release manifest");
+    });
+
+    test("PowerShell repo-derived manifests bind releaseRepository", () => {
+      const home = join(work, "repo-derived-home");
+      mkdirSync(home, { recursive: true, mode: 0o700 });
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = remoteManifest(artifact, "win", "unused");
+      const fixture = startHttpsFixture(work, {
+        "/manifest": { bodyText: JSON.stringify(manifest) },
+      });
+      const rewrite = writeGithubArtifactFetchRewrite(work);
+      try {
+        const result = runPowerShell(home, undefined, join(home, ".agenc"), {
+          AGENC_INSTALL_REPO: "requested/repository",
+          NODE_EXTRA_CA_CERTS: fixture.ca,
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${rewrite}`.trim(),
+          AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL: `${fixture.baseUrl}/manifest`,
+        }, writeInstrumentedInstallPs1(work));
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(result.status).not.toBe(0);
+        expect(output).toContain("releaseRepository test/mirror");
+        expect(output).toContain("does not match requested requested/repository");
+        expectFailedInstallCleanup(home);
+      } finally {
+        fixture.stop();
+      }
+    });
+
+    test("PowerShell bounded fetch aborts a stalled response on its total deadline", () => {
+      const home = join(work, "deadline-home");
+      mkdirSync(home, { recursive: true, mode: 0o700 });
+      const fixture = startHttpsFixture(work, {
+        "/stall": { bodyText: "{}", contentLength: 32, stallBody: true },
+      });
+      try {
+        const started = Date.now();
+        const result = runPowerShell(home, `${fixture.baseUrl}/stall`, join(home, ".agenc"), {
+          NODE_EXTRA_CA_CERTS: fixture.ca,
+          AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: "150",
+        });
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(result.status).not.toBe(0);
+        expect(output).toContain("download deadline exceeded after 150ms");
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expectFailedInstallCleanup(home);
+      } finally {
+        fixture.stop();
+      }
+    });
+
+    test("PowerShell local reads reject a path swap between lstat and descriptor open", () => {
+      const home = join(work, "swap-home");
+      const replacementDir = join(work, "swap-replacement");
+      mkdirSync(home, { recursive: true, mode: 0o700 });
+      mkdirSync(replacementDir);
+      const artifact = makeSyntheticArtifact(work);
+      const replacement = makeSyntheticArtifact(replacementDir);
+      const manifest = writeManifest(work, artifact, { platform: "win", arch: "x64" });
+      const preload = writeLocalSwapPreload(work);
+      const result = runPowerShell(home, manifest, join(home, ".agenc"), {
+        NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${preload}`.trim(),
+        AGENC_INSTALL_TEST_SWAP_TARGET: artifact.tarball,
+        AGENC_INSTALL_TEST_SWAP_BACKUP: `${artifact.tarball}.before-swap`,
+        AGENC_INSTALL_TEST_SWAP_REPLACEMENT: replacement.tarball,
+      }, writeInstrumentedInstallPs1(work));
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(result.status).not.toBe(0);
+      expect(output).toContain("local resource changed while it was opened");
+      expectFailedInstallCleanup(home);
+    });
+
+    test("PowerShell rejects ambiguous and Windows-special local artifact URLs", () => {
+      const home = join(work, "home");
+      mkdirSync(home, { recursive: true });
+      const artifact = makeSyntheticArtifact(work);
+      const manifestPath = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+      const invalidUrls = [
+        `file://localhost${new URL(pathToFileURL(artifact.tarball).href).pathname}`,
+        "file:////server/share/runtime.tar.gz",
+        "file:///%5C%5C%3F%5CC:%5Cruntime.tar.gz",
+        "file:///C:runtime.tar.gz",
+      ];
+      for (const [index, url] of invalidUrls.entries()) {
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+        manifest.artifacts[0].url = url;
+        writeFileSync(manifestPath, JSON.stringify(manifest));
+        const result = runPowerShell(home, manifestPath);
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(result.status, `${index}: ${output}`).not.toBe(0);
+        expect(output).toMatch(
+          /local artifact URL|manifest artifact URL is invalid/,
+        );
+      }
+    });
+
+    test("PowerShell rejects Windows ADS paths before invoking tar", () => {
+      const home = join(work, "home");
+      mkdirSync(home, { recursive: true });
+      const artifact = makeRawTarArtifact(work, [
+        { name: "node_modules/", type: "5" },
+        { name: "node_modules/pkg/file:stream", body: "owned" },
+      ]);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+      const result = runPowerShell(home, manifest);
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toContain("unsafe runtime archive path for win");
+      expect(existsSync(windowsPaths(home).installDir)).toBe(false);
+    });
+
+    test("PowerShell bounded HTTPS trust rejects malformed manifests and truncated/overrun artifacts without residue", () => {
+      const artifact = makeSyntheticArtifact(work);
+      const fixture = startHttpsFixture(work, trustBoundaryRoutes(artifact, "win"));
+      const fetchRewrite = writeGithubArtifactFetchRewrite(work);
+      try {
+        const cases = [
+          ["oversized-manifest.json", "download exceeds 1048576 byte limit"],
+          ["manifest-length.json", "Content-Length exceeds 1048576 byte limit"],
+          ["invalid-utf8.json", "runtime manifest is not valid UTF-8"],
+          ["short-manifest.json", "download byte count mismatch"],
+          ["overrun-manifest.json", "download exceeds declared"],
+          ["length-manifest.json", "Content-Length mismatch"],
+          ["duplicate-manifest.json", "duplicate runtime manifest artifact"],
+          ["missing-tag-manifest.json", "runtime manifest release identity is invalid"],
+          ["missing-provenance-manifest.json", "runtime manifest build provenance is invalid"],
+          ["detached-artifact-manifest.json", "manifest artifact URL is not canonical"],
+          ["cross-scheme-manifest.json", "remote manifests may only reference HTTPS artifacts"],
+          ["artifact-ceiling-manifest.json", "manifest artifact identity is invalid"],
+        ] as const;
+        for (const [name, expected] of cases) {
+          const home = join(work, `powershell-${name}`);
+          mkdirSync(home, { recursive: true, mode: 0o700 });
+          const result = runPowerShell(
+            home,
+            `${fixture.baseUrl}/${name}`,
+            join(home, ".agenc"),
+            {
+              NODE_EXTRA_CA_CERTS: fixture.ca,
+              NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require=${fetchRewrite}`.trim(),
+              AGENC_INSTALL_TEST_GITHUB_ARTIFACT_URL:
+                trustArtifactRoute(name) === undefined
+                  ? ""
+                  : `${fixture.baseUrl}${trustArtifactRoute(name)}`,
+            },
+            writeInstrumentedInstallPs1(work),
+          );
+          const output = `${result.stdout}\n${result.stderr}`;
+          expect(result.status, `${name}: ${output}`).not.toBe(0);
+          expect(output, name).toContain(expected);
+          expectFailedInstallCleanup(home);
+        }
+      } finally {
+        fixture.stop();
+      }
+    }, 30_000);
+
+    test("PowerShell preserves a custom CMD shim containing only the historical marker", () => {
+      const home = join(work, "home");
+      const wrapperDir = join(home, "prefix", "bin");
+      mkdirSync(wrapperDir, { recursive: true, mode: 0o700 });
+      for (const path of [home, join(home, "prefix"), wrapperDir]) chmodSync(path, 0o700);
+      const wrapper = join(wrapperDir, "agenc.cmd");
+      const custom = [
+        "@echo off",
+        "rem Generated by AgenC install.ps1 - rewritten on every install/upgrade.",
+        "echo user-owned-wrapper",
+        "",
+      ].join("\r\n");
+      writeFileSync(wrapper, custom, { mode: 0o644 });
+      chmodSync(wrapper, 0o644);
+      const artifact = makeSyntheticArtifact(work);
+      const manifest = writeManifest(work, artifact, {
+        platform: "win",
+        arch: "x64",
+      });
+
+      const result = runPowerShell(home, manifest);
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`)
+        .toContain("refusing to replace a wrapper not generated by AgenC");
+      expect(readFileSync(wrapper, "utf8")).toBe(custom);
+    });
+  });
+}

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -242,6 +242,11 @@ describe("reproducible install and release contract", () => {
     expect(windowsJob).toContain("numTotalTestSuites: 3");
     expect(windowsJob).toContain("numTotalTests: 3");
     expect(windowsJob).toContain(
+      "npm.cmd ci --ignore-scripts --no-audit --no-fund",
+    );
+    expect(windowsJob).not.toContain("npm.cmd rebuild");
+    expect(windowsJob).not.toContain("npm_config_build_from_source");
+    expect(windowsJob).toContain(
       "Windows native capability lane passed 3 tests in 2 files with zero skipped",
     );
 

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const REPO_ROOT = resolve(process.cwd(), "..");
-const HOSTED_TEST_COMMANDS = [
+const BROAD_HOSTED_GATE_COMMANDS = [
   "npm test",
   "npm run test",
   "npm run typecheck",
@@ -13,12 +13,24 @@ const HOSTED_TEST_COMMANDS = [
   "npm run check:agent-surface-contract",
   "npm run check:sbom",
   "check:tui-runtime-startup",
-  "vitest",
   "tsc --noEmit",
 ] as const;
 
+const ANY_HOSTED_TEST_COMMANDS = [
+  ...BROAD_HOSTED_GATE_COMMANDS,
+  "vitest",
+] as const;
+
 function expectArtifactWorkflowWithoutHostedTests(workflow: string) {
-  for (const command of HOSTED_TEST_COMMANDS) expect(workflow).not.toContain(command);
+  for (const command of ANY_HOSTED_TEST_COMMANDS) {
+    expect(workflow).not.toContain(command);
+  }
+}
+
+function expectArtifactWorkflowWithoutBroadHostedGates(workflow: string) {
+  for (const command of BROAD_HOSTED_GATE_COMMANDS) {
+    expect(workflow).not.toContain(command);
+  }
 }
 
 describe("reproducible install and release contract", () => {
@@ -103,6 +115,146 @@ describe("reproducible install and release contract", () => {
     expect(readFileSync(join(REPO_ROOT, ".npmrc"), "utf8")).toBe(
       "install-strategy=hoisted\nstrict-allow-scripts=true\n",
     );
+  });
+
+  test("hosted capability lanes pin their runtimes and exact zero-skip allowlists", () => {
+    const toolchain = JSON.parse(
+      readFileSync(join(REPO_ROOT, "release-toolchain.json"), "utf8"),
+    ) as {
+      powershellTestRuntime: {
+        schemaVersion: number;
+        version: string;
+        "linux-x64": {
+          file: string;
+          url: string;
+          sha256: string;
+          bytes: number;
+        };
+      };
+      neovimTestRuntime: {
+        schemaVersion: number;
+        version: string;
+        "linux-x64": {
+          file: string;
+          url: string;
+          sha256: string;
+          bytes: number;
+        };
+      };
+    };
+    expect(toolchain.powershellTestRuntime).toEqual({
+      schemaVersion: 1,
+      version: "7.6.4",
+      "linux-x64": {
+        file: "powershell-7.6.4-linux-x64.tar.gz",
+        url: "https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-x64.tar.gz",
+        sha256: "4471b5a36bfe86ec7af8525d36bb1cacba0128e7aac22d05cc064bc00e604721",
+        bytes: 77_628_778,
+      },
+    });
+    expect(toolchain.neovimTestRuntime).toEqual({
+      schemaVersion: 1,
+      version: "0.12.1",
+      "linux-x64": {
+        file: "nvim-linux-x86_64.tar.gz",
+        url: "https://github.com/neovim/neovim/releases/download/v0.12.1/nvim-linux-x86_64.tar.gz",
+        sha256: "ab757a1fd9ad307d53d2df4045698906a7ca3993d92260dd8fe49108712d57d0",
+        bytes: 11_359_184,
+      },
+    });
+
+    const workflow = readFileSync(
+      join(REPO_ROOT, ".github/workflows/platform-tests.yml"),
+      "utf8",
+    );
+    expect(workflow).toContain("\n  pull_request:");
+    expect(workflow).toContain("\n  powershell:");
+    expect(workflow).toContain("\n  neovim:");
+    expect(workflow).toContain("\n  macos-native:");
+    expect(workflow).toContain("\n  windows-native:");
+
+    const powershellJob = workflow.slice(
+      workflow.indexOf("\n  powershell:"),
+      workflow.indexOf("\n  neovim:"),
+    );
+    expect(powershellJob).toContain("runs-on: ubuntu-24.04");
+    expect(powershellJob).toContain('["powershellTestRuntime"]["linux-x64"]');
+    expect(powershellJob).toContain("--require-zero-skips");
+    expect(powershellJob).toContain("--config vitest.powershell.config.ts");
+    expect(powershellJob).toContain("const expectedTests = 19");
+    expect(powershellJob).toContain("numTotalTestSuites: 7");
+    expect(powershellJob).toContain("numPassedTestSuites: 7");
+    for (const testFile of [
+      "tests/budget/admitted-legacy-powershell.powershell.test.ts",
+      "tests/packaging/install-ps1.powershell.test.ts",
+      "tests/shell-command/powershell-parser.powershell.test.ts",
+      "tests/tools/PowerShellTool.execution.powershell.test.ts",
+    ]) {
+      expect(powershellJob).toContain(testFile);
+    }
+    expect(powershellJob).toContain("POWERSHELL_TELEMETRY_OPTOUT=1");
+    expect(powershellJob).toContain("POWERSHELL_UPDATECHECK=Off");
+    expect(powershellJob).toContain("DOTNET_CLI_TELEMETRY_OPTOUT=1");
+    expect(powershellJob).toContain("DOTNET_NOLOGO=1");
+    expect(powershellJob).toContain(
+      "'[/]powershell-distribution/pwsh([[:space:]]|$)'",
+    );
+    expect(powershellJob).toContain(
+      'git status --porcelain=v1 --untracked-files=all',
+    );
+
+    const neovimJob = workflow.slice(
+      workflow.indexOf("\n  neovim:"),
+      workflow.indexOf("\n  macos-native:"),
+    );
+    expect(neovimJob).toContain("runs-on: ubuntu-24.04");
+    expect(neovimJob).toContain('["neovimTestRuntime"]["linux-x64"]');
+    expect(neovimJob).toContain("--config vitest.neovim.config.ts");
+    expect(neovimJob).toContain(
+      "tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts",
+    );
+    expect(neovimJob).toContain("numTotalTestSuites: 2");
+    expect(neovimJob).toContain("numTotalTests: 4");
+    expect(neovimJob).toContain("results.testResults.length !== 1");
+    expect(neovimJob).toContain("pgrep -f --");
+
+    const macosJob = workflow.slice(
+      workflow.indexOf("\n  macos-native:"),
+      workflow.indexOf("\n  windows-native:"),
+    );
+    expect(macosJob).toContain("runs-on: macos-15");
+    expect(macosJob).toContain(
+      "run tests/tools/runtimes/runtime.darwin.test.ts",
+    );
+    expect(macosJob).toContain("--config vitest.native.config.ts");
+    expect(macosJob).toContain("numTotalTestSuites: 1");
+    expect(macosJob).toContain("numTotalTests: 1");
+
+    const windowsJob = workflow.slice(workflow.indexOf("\n  windows-native:"));
+    expect(windowsJob).toContain("runs-on: windows-2025");
+    expect(windowsJob).toContain(
+      "tests/durability/atomic-artifact.win32.test.ts",
+    );
+    expect(windowsJob).toContain(
+      "tests/utils/execFileNoThrow.win32.test.ts",
+    );
+    expect(windowsJob).toContain("--config vitest.native.config.ts");
+    expect(windowsJob).toContain("numTotalTestSuites: 3");
+    expect(windowsJob).toContain("numTotalTests: 3");
+    expect(windowsJob).toContain(
+      "Windows native capability lane passed 3 tests in 2 files with zero skipped",
+    );
+
+    expect(workflow.match(
+      /actions\/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/g,
+    )).toHaveLength(4);
+    expect(workflow.match(
+      /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/g,
+    )).toHaveLength(3);
+    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(4);
+    expect(workflow).not.toMatch(/uses:\s+actions\/[\w-]+@v\d/);
+    expect(workflow).not.toContain("cache: npm");
+    expect(workflow).not.toContain("--passWithNoTests");
   });
 
   test("release-sensitive text inputs check out with canonical LF endings", () => {
@@ -261,7 +413,7 @@ describe("reproducible install and release contract", () => {
     expect(windowsValidation).toContain("if ($name -ieq 'PATH') { $name = 'PATH' }");
     const windowsInstall = nativeJob.slice(
       nativeJob.indexOf("Install digest-pinned Node, headers, and npm (Windows)"),
-      nativeJob.indexOf("Build from two isolated worktrees and compare bytes"),
+      nativeJob.indexOf("Run native probes and build from two isolated worktrees"),
     );
     expect(windowsInstall).toContain("$headersRelease = Join-Path $headersRoot 'Release'");
     expect(windowsInstall).toContain(
@@ -697,7 +849,7 @@ describe("reproducible install and release contract", () => {
     );
   });
 
-  test("runtime artifact jobs bind to the exact release tag without running tests", () => {
+  test("runtime artifact jobs bind to the exact tag and run only exact native probes", () => {
     const workflow = readFileSync(
       join(REPO_ROOT, ".github/workflows/release-runtime.yml"),
       "utf8",
@@ -715,9 +867,60 @@ describe("reproducible install and release contract", () => {
       'test "$(git rev-parse --verify "${expected_ref}^{commit}")" = "$GITHUB_SHA"',
     );
     expect(workflow).not.toContain("required-gates:");
-    expectArtifactWorkflowWithoutHostedTests(workflow);
+    expectArtifactWorkflowWithoutBroadHostedGates(workflow);
     expect(workflow).toMatch(/\n  linux-tarball:\n    needs: release-source\n/u);
     expect(workflow).toMatch(/\n  native-tarball:\n    needs: release-source\n/u);
+
+    const nativeJob = workflow.slice(workflow.indexOf("\n  native-tarball:"));
+    const nativeBuild = nativeJob.slice(
+      nativeJob.indexOf("Run native probes and build from two isolated worktrees"),
+      nativeJob.indexOf("Upload failed reproducibility inputs"),
+    );
+    expect(nativeBuild).toContain(
+      'native_tests=("tests/tools/runtimes/runtime.darwin.test.ts")',
+    );
+    expect(nativeBuild).toContain(
+      '"tests/durability/atomic-artifact.win32.test.ts"',
+    );
+    expect(nativeBuild).toContain(
+      '"tests/utils/execFileNoThrow.win32.test.ts"',
+    );
+    expect(nativeBuild).toContain("expected_native_tests=1");
+    expect(nativeBuild).toContain("expected_native_tests=3");
+    expect(nativeBuild).toContain("expected_native_suites=1");
+    expect(nativeBuild).toContain("expected_native_suites=3");
+    expect(nativeBuild).toContain('run "${native_tests[@]}"');
+    expect(nativeBuild).toContain('"${native_tests[@]}" <<\'NODE\'');
+    expect(nativeBuild).toContain("...expectedFiles");
+    expect(nativeBuild.match(/run-hermetic-vitest\.mjs/g)).toHaveLength(1);
+    expect(nativeBuild).toContain("vitest.native.config.ts");
+    expect(nativeBuild).toContain("--require-zero-skips");
+    expect(nativeBuild).toContain("--allowOnly=false");
+    expect(nativeBuild).toContain("--reporter=verbose");
+    expect(nativeBuild).toContain("--reporter=json");
+    expect(nativeBuild).toContain('--outputFile.json "$native_results"');
+    expect(nativeBuild).not.toContain("--passWithNoTests");
+    for (const field of [
+      "numTotalTestSuites",
+      "numPassedTestSuites",
+      "numFailedTestSuites",
+      "numPendingTestSuites",
+      "numTotalTests",
+      "numPassedTests",
+      "numFailedTests",
+      "numPendingTests",
+      "numTodoTests",
+    ]) {
+      expect(nativeBuild).toContain(field);
+    }
+    expect(nativeBuild).toContain("results.success !== true");
+    expect(nativeBuild).toContain("zero skipped");
+    expect(nativeBuild.indexOf('ci --prefix "$build_source"')).toBeLessThan(
+      nativeBuild.indexOf("run-hermetic-vitest.mjs"),
+    );
+    expect(nativeBuild.indexOf("run-hermetic-vitest.mjs")).toBeLessThan(
+      nativeBuild.indexOf("build-runtime-tarball.mjs"),
+    );
   });
 
   test("the ESM bundle disables redundant per-module strict directives", () => {

--- a/runtime/tests/prompts/secure-instruction-file.test.ts
+++ b/runtime/tests/prompts/secure-instruction-file.test.ts
@@ -134,7 +134,10 @@ describe("descriptor-bound instruction snapshots", () => {
       const root = tempRoot();
       const fifo = join(root, "rule.md");
       const made = spawnSync("mkfifo", [fifo]);
-      if (made.status !== 0) return;
+      expect(
+        made.status,
+        made.stderr?.toString() || "mkfifo must be available in the Unix test lane",
+      ).toBe(0);
       const read = await readInstructionFileSnapshot({
         requestedPath: fifo,
         boundaryRoot: root,

--- a/runtime/tests/sandbox/hardening/hardening.test.ts
+++ b/runtime/tests/sandbox/hardening/hardening.test.ts
@@ -337,12 +337,10 @@ describe("process hardening", () => {
     }
   });
 
-  const nativeBuildTest = process.platform === "linux" && hasNativeBuildTools()
-    ? test
-    : test.skip;
+  const linuxNativeBuildTest = process.platform === "linux" ? test : test.skip;
 
-  nativeBuildTest("loads the native hardening path inside a spawned process", () => {
-
+  linuxNativeBuildTest("loads the native hardening path inside a spawned process", () => {
+    expectNativeBuildTools();
     const cacheDir = tempDir("agenc-hardening-test-");
     const moduleUrl = sourceUrl("sandbox/hardening/index.ts").href;
     const script = `
@@ -391,7 +389,8 @@ describe("process hardening", () => {
     expect(payload.dumpable).toBe(0);
   });
 
-  nativeBuildTest("can compile through explicit runtime-build opt-in", () => {
+  linuxNativeBuildTest("can compile through explicit runtime-build opt-in", () => {
+    expectNativeBuildTools();
     const cacheDir = tempDir("agenc-hardening-build-opt-in-");
     const moduleUrl = sourceUrl("sandbox/hardening/index.ts").href;
     const script = `
@@ -432,11 +431,23 @@ function step(
   return result.steps.find((entry) => entry.operation === operation);
 }
 
-function hasNativeBuildTools(): boolean {
-  return existsSync("/usr/include/node/node_api.h") &&
-    spawnSync("sh", ["-c", "command -v cc"], {
-      stdio: "ignore",
-    }).status === 0;
+function expectNativeBuildTools(): void {
+  const includeDir = [
+    "/usr/include/node",
+    path.resolve(path.dirname(process.execPath), "..", "include", "node"),
+  ].find((candidate) => existsSync(path.join(candidate, "node_api.h")));
+  expect(
+    includeDir,
+    "native hardening tests require node_api.h in a production-supported include directory",
+  ).toBeDefined();
+
+  const compiler = spawnSync("sh", ["-c", "command -v cc"], {
+    encoding: "utf8",
+  });
+  expect(
+    compiler.status,
+    compiler.stderr || "native hardening tests require cc on PATH",
+  ).toBe(0);
 }
 
 function tempNodeIncludeDir(): string {

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -478,49 +478,6 @@ describe("Linux sandbox launcher", () => {
     ]);
   });
 
-  it("blocks network syscalls with real bubblewrap when the platform allows it", async () => {
-    const bwrap = findSystemBubblewrapInPath(process.env.PATH, process.cwd());
-    if (bwrap === null || !systemBubblewrapWorks(bwrap)) return;
-    const root = withTempDir("agenc-linux-launcher-real-bwrap-");
-    const profile: PermissionProfile = {
-      fileSystem: unrestrictedFileSystemPolicy(),
-      network: "disabled",
-    };
-    const script = [
-      "const net = require('node:net');",
-      "const socket = net.connect({ host: '198.51.100.10', port: 9 });",
-      "socket.once('connect', () => process.exit(3));",
-      "socket.once('error', () => process.exit(0));",
-      "setTimeout(() => process.exit(0), 500);",
-    ].join("");
-    // This is the one sanctioned native-network probe: bubblewrap creates the
-    // isolated network namespace before this Node command starts. Remove the
-    // JavaScript preload so the assertion exercises the kernel boundary, not
-    // the default-suite tripwire. No public route exists inside the namespace.
-    const probeEnv = { ...process.env };
-    delete probeEnv.NODE_OPTIONS;
-    delete probeEnv.AGENC_TEST_NETWORK_ATTEMPT_LEDGER;
-
-    const exitCode = await runLinuxSandboxMain([
-      "--sandbox-policy-cwd",
-      root,
-      "--command-cwd",
-      root,
-      "--permission-profile",
-      JSON.stringify(profile),
-      "--no-proc",
-      "--",
-      process.execPath,
-      "-e",
-      script,
-    ], {
-      env: probeEnv,
-      preferredLauncher: () => ({ program: bwrap, supportsArgv0: true }),
-    });
-
-    expect(exitCode).toBe(0);
-  });
-
   it("ships the launcher as an executable package binary", () => {
     const runtimeRoot = process.cwd();
     const packageJson = JSON.parse(
@@ -864,19 +821,6 @@ function withTempDir(prefix: string): string {
 
 function writeExecutable(filePath: string, source: string): void {
   fs.writeFileSync(filePath, source, { mode: 0o755 });
-}
-
-function systemBubblewrapWorks(program: string): boolean {
-  const output = spawnSync(program, [
-    "--unshare-user",
-    "--unshare-net",
-    "--ro-bind",
-    "/",
-    "/",
-    "--",
-    "/bin/true",
-  ]);
-  return output.status === 0;
 }
 
 function sliceAfter(args: readonly string[], flag: string): string[] {

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -239,7 +239,21 @@ describe("session-store", () => {
       `;
       child = spawn(process.execPath, ["-e", childScript], {
         detached: true,
-        stdio: "ignore",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let childStdout = "";
+      let childStderr = "";
+      let childSpawnError: Error | undefined;
+      child.stdout?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => {
+        childStdout += chunk;
+      });
+      child.stderr?.setEncoding("utf8");
+      child.stderr?.on("data", (chunk: string) => {
+        childStderr += chunk;
+      });
+      child.once("error", (error) => {
+        childSpawnError = error;
       });
       child.unref();
 
@@ -249,11 +263,22 @@ describe("session-store", () => {
         await new Promise((r) => setTimeout(r, 25));
       }
 
-      if (!existsSync(readyPath) || !existsSync(lockPath)) {
-        // Child couldn't acquire (e.g. linkSync unavailable on an
-        // exotic filesystem). Don't fail the test — stale-reclaim +
-        // live-holder-same-pid + reentry tests cover the rest.
-        return;
+      const readyExists = existsSync(readyPath);
+      const lockExists = existsSync(lockPath);
+      if (!readyExists || !lockExists) {
+        throw new Error(
+          [
+            "SessionLock child failed to establish the cross-process lock within 3000ms",
+            `pid=${String(child.pid)}`,
+            `exitCode=${String(child.exitCode)}`,
+            `signalCode=${String(child.signalCode)}`,
+            `spawnError=${childSpawnError?.stack ?? "none"}`,
+            `readyPath=${JSON.stringify(readyPath)} exists=${String(readyExists)}`,
+            `lockPath=${JSON.stringify(lockPath)} exists=${String(lockExists)}`,
+            `stdout=${JSON.stringify(childStdout)}`,
+            `stderr=${JSON.stringify(childStderr)}`,
+          ].join("\n"),
+        );
       }
 
       // Sanity: verify the lock file holds the child's pid, not

--- a/runtime/tests/shell-command/powershell-parser.powershell.test.ts
+++ b/runtime/tests/shell-command/powershell-parser.powershell.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  clearPowerShellParserCacheForTests,
+  parsePowerShellScriptWithNativeAst,
+} from "./powershell-parser.js";
+
+function findPowerShellExecutable(): string | null {
+  for (const candidate of ["pwsh", "powershell"]) {
+    const result = spawnSync(
+      candidate,
+      ["-NoLogo", "-NoProfile", "-Command", "$PSVersionTable.PSVersion"],
+      {
+        encoding: "utf8",
+        timeout: 1_000,
+      },
+    );
+    if (result.status === 0) return candidate;
+  }
+  return null;
+}
+
+describe("parsePowerShellScriptWithNativeAst capability", () => {
+  afterEach(() => {
+    clearPowerShellParserCacheForTests();
+  });
+
+  test("uses the native AST parser in the PowerShell capability lane", () => {
+    const executable = findPowerShellExecutable();
+    if (executable === null) {
+      throw new Error("PowerShell capability lane requires pwsh or powershell");
+    }
+
+    const outcome = parsePowerShellScriptWithNativeAst(
+      executable,
+      "Get-ChildItem . | Select-Object Name",
+    );
+    expect(outcome).toEqual({
+      ok: true,
+      commands: [["Get-ChildItem", "."], ["Select-Object", "Name"]],
+    });
+
+    const second = parsePowerShellScriptWithNativeAst(
+      executable,
+      "Write-Output foo | Measure-Object",
+    );
+    expect(second).toEqual({
+      ok: true,
+      commands: [["Write-Output", "foo"], ["Measure-Object"]],
+    });
+  });
+});

--- a/runtime/tests/shell-command/powershell-parser.powershell.test.ts
+++ b/runtime/tests/shell-command/powershell-parser.powershell.test.ts
@@ -5,6 +5,8 @@ import {
   parsePowerShellScriptWithNativeAst,
 } from "./powershell-parser.js";
 
+const CAPABILITY_STARTUP_TIMEOUT_MS = 10_000;
+
 function findPowerShellExecutable(): string | null {
   for (const candidate of ["pwsh", "powershell"]) {
     const result = spawnSync(
@@ -12,7 +14,7 @@ function findPowerShellExecutable(): string | null {
       ["-NoLogo", "-NoProfile", "-Command", "$PSVersionTable.PSVersion"],
       {
         encoding: "utf8",
-        timeout: 1_000,
+        timeout: CAPABILITY_STARTUP_TIMEOUT_MS,
       },
     );
     if (result.status === 0) return candidate;
@@ -34,6 +36,7 @@ describe("parsePowerShellScriptWithNativeAst capability", () => {
     const outcome = parsePowerShellScriptWithNativeAst(
       executable,
       "Get-ChildItem . | Select-Object Name",
+      { timeoutMs: CAPABILITY_STARTUP_TIMEOUT_MS },
     );
     expect(outcome).toEqual({
       ok: true,
@@ -43,6 +46,7 @@ describe("parsePowerShellScriptWithNativeAst capability", () => {
     const second = parsePowerShellScriptWithNativeAst(
       executable,
       "Write-Output foo | Measure-Object",
+      { timeoutMs: CAPABILITY_STARTUP_TIMEOUT_MS },
     );
     expect(second).toEqual({
       ok: true,

--- a/runtime/tests/shell-command/powershell-parser.test.ts
+++ b/runtime/tests/shell-command/powershell-parser.test.ts
@@ -1,20 +1,8 @@
-import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, test } from "vitest";
 import {
   clearPowerShellParserCacheForTests,
   parsePowerShellScriptWithNativeAst,
 } from "./powershell-parser.js";
-
-function findPowerShellExecutable(): string | null {
-  for (const candidate of ["pwsh", "powershell"]) {
-    const result = spawnSync(candidate, ["-NoLogo", "-NoProfile", "-Command", "$PSVersionTable.PSVersion"], {
-      encoding: "utf8",
-      timeout: 1_000,
-    });
-    if (result.status === 0) return candidate;
-  }
-  return null;
-}
 
 describe("parsePowerShellScriptWithNativeAst", () => {
   afterEach(() => {
@@ -32,31 +20,5 @@ describe("parsePowerShellScriptWithNativeAst", () => {
       expect(outcome.reason).toBe("failed");
       expect(outcome.diagnostics.length).toBeGreaterThan(0);
     }
-  });
-
-  test("uses the native AST parser when PowerShell is present", () => {
-    const executable = findPowerShellExecutable();
-    if (executable === null) {
-      expect(executable).toBeNull();
-      return;
-    }
-
-    const outcome = parsePowerShellScriptWithNativeAst(
-      executable,
-      "Get-ChildItem . | Select-Object Name",
-    );
-    expect(outcome).toEqual({
-      ok: true,
-      commands: [["Get-ChildItem", "."], ["Select-Object", "Name"]],
-    });
-
-    const second = parsePowerShellScriptWithNativeAst(
-      executable,
-      "Write-Output foo | Measure-Object",
-    );
-    expect(second).toEqual({
-      ok: true,
-      commands: [["Write-Output", "foo"], ["Measure-Object"]],
-    });
   });
 });

--- a/runtime/tests/tools/PowerShellTool.execution-tests.ts
+++ b/runtime/tests/tools/PowerShellTool.execution-tests.ts
@@ -1,0 +1,147 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+import {
+  resetStateForTests,
+  setCwdState,
+  setOriginalCwd,
+  setProjectRoot,
+} from '../../src/bootstrap/state.ts'
+import {
+  getEmptyToolPermissionContext,
+  type ToolUseContext,
+} from '../../src/tools/Tool.ts'
+import { PowerShellTool } from '../../src/tools/PowerShellTool/PowerShellTool.tsx'
+import { SandboxExecutionBroker } from '../../src/sandbox/execution-broker.ts'
+import {
+  clearCurrentRuntimeSession,
+  setCurrentRuntimeSession,
+} from '../../src/session/current-session.ts'
+
+let tempRoot: string | undefined
+const legacyTestSession = {
+  conversationId: 'powershell-execution-test-session',
+  services: { admissionRequired: false },
+} as never
+
+function findPowerShellExecutable(): string | null {
+  for (const candidate of ['pwsh', 'powershell']) {
+    const result = spawnSync(
+      candidate,
+      ['-NoLogo', '-NoProfile', '-Command', '$PSVersionTable.PSVersion'],
+      {
+        encoding: 'utf8',
+        timeout: 1_000,
+      },
+    )
+    if (result.status === 0) return candidate
+  }
+  return null
+}
+
+async function makeToolUseContext(
+  boundary: 'danger' | 'unavailable' = 'danger',
+): Promise<ToolUseContext> {
+  setCurrentRuntimeSession(legacyTestSession)
+  tempRoot = await mkdtemp(join(tmpdir(), 'agenc-powershell-tool-'))
+  setProjectRoot(tempRoot)
+  setOriginalCwd(tempRoot)
+  setCwdState(tempRoot)
+
+  const appState = {
+    toolPermissionContext: getEmptyToolPermissionContext(),
+  }
+
+  return {
+    abortController: new AbortController(),
+    getAppState() {
+      return appState
+    },
+    setAppState() {},
+    setToolJSX() {},
+    toolUseId: 'powershell-smoke',
+    services: {
+      sandboxExecutionBroker: boundary === 'danger'
+        ? new SandboxExecutionBroker({
+            mode: 'danger_full_access',
+            cwd: tempRoot,
+          })
+        : new SandboxExecutionBroker({
+            mode: 'workspace_write',
+            cwd: tempRoot,
+            platform: 'linux',
+            probe: () => ({
+              kind: 'unavailable',
+              mode: 'workspace_write',
+              platform: 'linux',
+              reason: 'probe: namespaces disabled by test',
+              remediation: 'repair namespaces',
+            }),
+          }),
+    },
+  } as unknown as ToolUseContext
+}
+
+afterEach(async () => {
+  clearCurrentRuntimeSession(legacyTestSession)
+  resetStateForTests()
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = undefined
+  }
+})
+
+export function registerPowerShellToolExecutionTests(
+  lane: 'default' | 'powershell',
+): void {
+  if (lane === 'powershell') {
+    test('PowerShellTool executes a real command in the PowerShell capability lane', async () => {
+      const executable = findPowerShellExecutable()
+      if (executable === null) {
+        throw new Error('PowerShell capability lane requires pwsh or powershell')
+      }
+
+      const result = await PowerShellTool.call(
+        {
+          command:
+            "Write-Output 'agenc-powershell-smoke'; " +
+            'Write-Output "$env:POWERSHELL_TELEMETRY_OPTOUT|' +
+            '$env:POWERSHELL_UPDATECHECK|' +
+            '$env:DOTNET_CLI_TELEMETRY_OPTOUT|' +
+            '$env:DOTNET_NOLOGO"',
+          timeout: 5_000,
+          description: 'emit smoke marker',
+        },
+        await makeToolUseContext(),
+        undefined as never,
+        undefined as never,
+      )
+
+      expect(result.data.interrupted).toBe(false)
+      expect(result.data.stderr).toBe('')
+      expect(result.data.stdout).toContain('agenc-powershell-smoke')
+      expect(result.data.stdout).toContain('1|Off|1|1')
+    })
+    return
+  }
+
+  test('PowerShellTool preserves a required-sandbox readiness failure', async () => {
+    await expect(
+      PowerShellTool.call(
+        {
+          command: "Write-Output 'must-not-run'",
+          timeout: 5_000,
+          description: 'sandbox failure regression',
+        },
+        await makeToolUseContext('unavailable'),
+        undefined as never,
+        undefined as never,
+      ),
+    ).rejects.toMatchObject({
+      code: 'sandbox_probe_failed',
+      surface: 'interactive',
+    })
+  })
+}

--- a/runtime/tests/tools/PowerShellTool.execution.powershell.test.ts
+++ b/runtime/tests/tools/PowerShellTool.execution.powershell.test.ts
@@ -1,3 +1,3 @@
 import { registerPowerShellToolExecutionTests } from './PowerShellTool.execution-tests.js'
 
-registerPowerShellToolExecutionTests('default')
+registerPowerShellToolExecutionTests('powershell')

--- a/runtime/tests/tools/runtimes/runtime.darwin.test.ts
+++ b/runtime/tests/tools/runtimes/runtime.darwin.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+
+import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
+import { permissionProfileForRuntimeContext } from "./sandboxing.js";
+
+if (process.platform !== "darwin") {
+  throw new Error("the native Seatbelt integration test requires macOS");
+}
+
+test(
+  "live default workspace-write policy launches pwd through macOS Seatbelt",
+  async () => {
+    const cwd = process.cwd();
+    const profile = permissionProfileForRuntimeContext(
+      {
+        sandboxMode: "workspace_write",
+        invocation: {
+          turn: {
+            cwd,
+            fileSystemSandboxPolicy: {
+              allowWrite: [cwd],
+              denyWrite: [],
+              allowRead: [],
+              denyRead: [],
+            },
+          },
+        },
+      } as never,
+      { cwd },
+    );
+    const manager = new UnifiedExecProcessManager({ cwd });
+
+    try {
+      const result = await manager.execCommand({
+        cmd: "pwd",
+        yield_time_ms: 1_000,
+        runtimeSandbox: {
+          permissionProfile: profile,
+          sandboxPolicyCwd: cwd,
+          preference: "require",
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(cwd);
+    } finally {
+      await manager.closeAll("test cleanup");
+    }
+  },
+);

--- a/runtime/tests/tools/runtimes/runtime.test.ts
+++ b/runtime/tests/tools/runtimes/runtime.test.ts
@@ -16,7 +16,6 @@ import {
   hasFullDiskReadAccess,
 } from "../../sandbox/engine/index.js";
 import { EventLog } from "../../session/event-log.js";
-import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
 import type { LLMToolCall } from "../../llm/types.js";
 import { ToolRouter } from "../router.js";
 import type { Tool } from "../types.js";
@@ -262,48 +261,6 @@ describe("tools/runtimes", () => {
     expect(canReadPathWithCwd(profile.fileSystem, "/repo/private/key", "/repo"))
       .toBe(false);
   });
-
-  test.runIf(process.platform === "darwin")(
-    "live default workspace-write policy launches pwd through macOS Seatbelt",
-    async () => {
-      const cwd = process.cwd();
-      const profile = permissionProfileForRuntimeContext(
-        {
-          sandboxMode: "workspace_write",
-          invocation: {
-            turn: {
-              cwd,
-              fileSystemSandboxPolicy: {
-                allowWrite: [cwd],
-                denyWrite: [],
-                allowRead: [],
-                denyRead: [],
-              },
-            },
-          },
-        } as never,
-        { cwd },
-      );
-      const manager = new UnifiedExecProcessManager({ cwd });
-
-      try {
-        const result = await manager.execCommand({
-          cmd: "pwd",
-          yield_time_ms: 1_000,
-          runtimeSandbox: {
-            permissionProfile: profile,
-            sandboxPolicyCwd: cwd,
-            preference: "require",
-          },
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(result.stdout.trim()).toBe(cwd);
-      } finally {
-        await manager.closeAll("test cleanup");
-      }
-    },
-  );
 
   test("runtime sandbox enforcement denies read-only writes and outside-workspace writes", () => {
     const mutatingTool: Tool = {

--- a/runtime/tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx
@@ -166,6 +166,17 @@ describe('useApiKeyVerification api key helper coverage', () => {
       expect(authHarness.getApiKeyFromApiKeyHelper).toHaveBeenCalledWith(true)
       expect(authHarness.getAnthropicApiKeyWithSource).toHaveBeenLastCalledWith()
       expect(authHarness.verifyApiKey).not.toHaveBeenCalled()
+
+      await waitForCondition(
+        () =>
+          snapshots.some(
+            snapshot =>
+              snapshot.status === 'error' &&
+              snapshot.errorMessage ===
+                'API key helper did not return a valid key',
+          ),
+        'Timed out waiting for the helper error effect snapshot',
+      )
       expect(snapshots).toContainEqual({
         errorMessage: 'API key helper did not return a valid key',
         status: 'error',

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -6,8 +6,9 @@ import { describe, expect, it } from "vitest";
 // declare the expected lifecycle assertions — it does NOT spawn nvim or run a
 // real session. The actual embedded-Neovim PTY end-to-end gate (including the
 // "kill TUI / runtime-exit ⇒ no orphaned nvim child" lifecycle checks, scenarios
-// 120-124) runs via `npm run check:tui-workbench-buffer-neovim`. Hosted CI is
-// disabled, so do not treat this file as e2e coverage on its own.
+// 120-124) runs via `npm run check:tui-workbench-buffer-neovim`. The hosted
+// Neovim lane covers four lower-level real-process lifecycle tests; the full
+// PTY scenario remains local, so do not treat this file as e2e coverage.
 describe("embedded Neovim BUFFER PTY gate files", () => {
   it("defines the workbench Neovim scenarios and wrapper command", async () => {
     const scenario = await readFile("scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs", "utf8");

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -6,8 +6,6 @@ import { EventEmitter } from "node:events";
 import { encode } from "@msgpack/msgpack";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { discoverNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimDiscovery.js";
-import type { NeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
 import { dirtyFlagFromRpcNotificationParams, EmbeddedNeovimSession, NeovimStartupCleanupError, startEmbeddedNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
 import { NeovimRpcError } from "../../../src/tui/workbench/buffer/neovim/NeovimRpc.js";
 import { cleanupTrackedNeovimProcesses, getTrackedNeovimProcessCountForTesting, killNeovimChild, normalizeNeovimPid, runTrackedNeovimProcessExitCleanupForTesting, spawnNeovimProcess, waitForNeovimExit } from "../../../src/tui/workbench/buffer/neovim/NeovimProcess.js";
@@ -717,174 +715,6 @@ describe("embedded Neovim lifecycle", () => {
     expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
   });
 
-  it("closes a clean real Neovim session through the all-buffer safe-close path", async () => {
-    const discovery = await discoverNeovim({ timeoutMs: 1000, useUserInit: false });
-    if (!discovery.usable) {
-      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
-      return;
-    }
-    const filePath = join(dir, "clean-close.txt");
-    await writeFile(filePath, "alpha\n", "utf8");
-    const session = await startEmbeddedNeovim({
-      executable: discovery.executable,
-      args: discovery.args,
-      filePath,
-      line: 1,
-      column: 0,
-      cwd: dir,
-      size: { rows: 4, columns: 24 },
-      onSnapshot: () => {},
-      onError: (error) => {
-        throw error;
-      },
-      onExit: () => {},
-    });
-    const pid = session.pid;
-
-    await expect(session.quit(false)).resolves.toEqual({ closed: true });
-    await session.cleanup();
-    await waitUntilDead(pid);
-
-    expect(isProcessAlive(pid)).toBe(false);
-    expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
-  });
-
-  it("detects a modified hidden buffer before an external-editor handoff", async () => {
-    const discovery = await discoverNeovim({ timeoutMs: 1000, useUserInit: false });
-    if (!discovery.usable) {
-      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
-      return;
-    }
-    const filePath = join(dir, "hidden-buffer.txt");
-    await writeFile(filePath, "alpha\n", "utf8");
-    const session = await startEmbeddedNeovim({
-      executable: discovery.executable,
-      args: discovery.args,
-      filePath,
-      line: 1,
-      column: 0,
-      cwd: dir,
-      size: { rows: 4, columns: 24 },
-      onSnapshot: () => {},
-      onError: () => {},
-      onExit: () => {},
-    });
-    const pid = session.pid;
-
-    await session.input("<Esc>:set hidden<CR>:enew<CR>ihidden edit");
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    await session.input(`<Esc>:hide edit ${filePath}<CR>`);
-    await new Promise((resolve) => setTimeout(resolve, 120));
-
-    await expect(session.isDirty()).resolves.toBe(false);
-    await expect(session.hasUnsavedBuffers()).resolves.toBe(true);
-    await session.quit(true);
-    await session.cleanup();
-    await waitUntilDead(pid);
-
-    expect(isProcessAlive(pid)).toBe(false);
-    expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
-  });
-
-  it("opens Neovim, refuses dirty quit, and force cleans the child", async () => {
-    const discovery = await discoverNeovim({ timeoutMs: 1000 });
-    if (!discovery.usable) {
-      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
-      return;
-    }
-    const filePath = join(dir, "target.txt");
-    await writeFile(filePath, "alpha\n", "utf8");
-    const snapshots: string[][] = [];
-    const dirtyChanges: boolean[] = [];
-
-    const session = await startEmbeddedNeovim({
-      executable: discovery.executable,
-      args: discovery.args,
-      filePath,
-      line: 1,
-      column: 0,
-      cwd: dir,
-      size: { rows: 21, columns: 116 },
-      onSnapshot: (snapshot) => {
-        snapshots.push([...snapshot.lines]);
-      },
-      onDirtyChange: (dirty) => {
-        dirtyChanges.push(dirty);
-      },
-      onError: (error) => {
-        throw error;
-      },
-      onExit: () => {},
-    });
-    const pid = session.pid;
-
-    await session.input("ibeta");
-    await session.paste(" gamma");
-    await session.resize({ rows: 4, columns: 24 });
-    await session.focus(true);
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    await expect(session.isDirty()).resolves.toBe(true);
-    const dirtyQuit = await session.quit(false);
-    expect(dirtyQuit).toMatchObject({ closed: false });
-
-    await expect(session.save(true)).resolves.toBe(true);
-    await expect(session.isDirty()).resolves.toBe(false);
-    expect(await readFile(filePath, "utf8")).toContain("beta gamma");
-    expect(dirtyChanges).toContain(false);
-    await session.input("omore");
-    await session.quit(true);
-    await session.cleanup();
-
-    expect(snapshots.length).toBeGreaterThan(0);
-    expect(await readFile(filePath, "utf8")).not.toContain("more");
-    expect(isProcessAlive(pid)).toBe(false);
-  });
-
-  it("reports visible grid highlight cells for visual selections", async () => {
-    const discovery = await discoverNeovim({ timeoutMs: 1000, useUserInit: false });
-    if (!discovery.usable) {
-      expect(discovery.reason).toContain("Embedded Neovim is unavailable");
-      return;
-    }
-    const filePath = join(dir, "target.txt");
-    await writeFile(filePath, "alpha beta gamma\nsecond line\n", "utf8");
-    const snapshots: NeovimRenderSnapshot[] = [];
-
-    const session = await startEmbeddedNeovim({
-      executable: discovery.executable,
-      args: discovery.args,
-      filePath,
-      line: 1,
-      column: 0,
-      cwd: dir,
-      size: { rows: 8, columns: 40 },
-      onSnapshot: (snapshot) => {
-        snapshots.push(snapshot);
-      },
-      onError: (error) => {
-        throw error;
-      },
-      onExit: () => {},
-    });
-
-    try {
-      await session.input("gg0");
-      await waitForSnapshot(snapshots, (snapshot) => snapshot.cursor.row === 0 && snapshot.cursor.column === 0);
-      await session.input("v$");
-      const visual = await waitForSnapshot(snapshots, (snapshot) => snapshot.mode.startsWith("visual"));
-      const highlightsById = new Map(visual.highlights.map((highlight) => [highlight.id, highlight.attributes]));
-      const selectedCells = visual.cells[0]?.filter((cell) => {
-        const attributes = highlightsById.get(cell.highlightId);
-        return attributes?.reverse === true || typeof attributes?.background === "number";
-      }) ?? [];
-
-      expect(visual.lines[0]).toContain("alpha beta gamma");
-      expect(selectedCells.length).toBeGreaterThan(0);
-    } finally {
-      await session.quit(true);
-      await session.cleanup();
-    }
-  });
 });
 
 function fakeChild(options: {
@@ -945,21 +775,6 @@ async function waitForPidFile(path: string): Promise<number> {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(`timed out waiting for pid file ${path}`);
-}
-
-async function waitForSnapshot<T>(
-  snapshots: readonly T[],
-  predicate: (snapshot: T) => boolean,
-): Promise<T> {
-  const deadline = Date.now() + 1500;
-  let last = snapshots.at(-1);
-  while (Date.now() < deadline) {
-    const match = snapshots.findLast(predicate);
-    if (match) return match;
-    last = snapshots.at(-1);
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  throw new Error(`timed out waiting for embedded Neovim snapshot; last=${JSON.stringify(last)}`);
 }
 
 function mockMissingProcessGroups(): void {

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
@@ -1,0 +1,250 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  discoverNeovim,
+  type NeovimDiscoveryResult,
+} from "../../../src/tui/workbench/buffer/neovim/NeovimDiscovery.js";
+import type { NeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
+import { startEmbeddedNeovim } from "../../../src/tui/workbench/buffer/neovim/NeovimLifecycle.js";
+import {
+  cleanupTrackedNeovimProcesses,
+  getTrackedNeovimProcessCountForTesting,
+} from "../../../src/tui/workbench/buffer/neovim/NeovimProcess.js";
+
+type UsableNeovim = Extract<NeovimDiscoveryResult, { readonly usable: true }>;
+
+let dir: string;
+let neovim: UsableNeovim;
+
+beforeAll(async () => {
+  const discovery = await discoverNeovim({
+    executable: "nvim",
+    timeoutMs: 1000,
+    useUserInit: false,
+  });
+  if (!discovery.usable) {
+    throw new Error(`the pinned real-Neovim capability is required: ${discovery.reason}`);
+  }
+  expect(discovery).toMatchObject({
+    usable: true,
+    version: {
+      major: 0,
+      minor: 12,
+      patch: 1,
+      raw: "NVIM v0.12.1",
+    },
+    args: ["--embed", "--clean", "-n"],
+    useUserInit: false,
+  });
+  neovim = discovery;
+});
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "agenc-real-nvim-lifecycle-"));
+});
+
+afterEach(async () => {
+  cleanupTrackedNeovimProcesses("SIGKILL");
+  await rm(dir, { recursive: true, force: true });
+  expect(getTrackedNeovimProcessCountForTesting()).toBe(0);
+});
+
+afterAll(() => {
+  cleanupTrackedNeovimProcesses("SIGKILL");
+});
+
+describe("real embedded Neovim lifecycle", () => {
+  it("closes a clean real Neovim session through the all-buffer safe-close path", async () => {
+    const filePath = join(dir, "clean-close.txt");
+    await writeFile(filePath, "alpha\n", "utf8");
+    const session = await startEmbeddedNeovim({
+      executable: neovim.executable,
+      args: neovim.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 4, columns: 24 },
+      onSnapshot: () => {},
+      onError: (error) => {
+        throw error;
+      },
+      onExit: () => {},
+    });
+    const pid = session.pid;
+
+    await expect(session.quit(false)).resolves.toEqual({ closed: true });
+    await session.cleanup();
+    await waitUntilDead(pid);
+
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it("detects a modified hidden buffer before an external-editor handoff", async () => {
+    const filePath = join(dir, "hidden-buffer.txt");
+    await writeFile(filePath, "alpha\n", "utf8");
+    const session = await startEmbeddedNeovim({
+      executable: neovim.executable,
+      args: neovim.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 4, columns: 24 },
+      onSnapshot: () => {},
+      onError: () => {},
+      onExit: () => {},
+    });
+    const pid = session.pid;
+
+    await session.input("<Esc>:set hidden<CR>:enew<CR>ihidden edit");
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    await session.input(`<Esc>:hide edit ${filePath}<CR>`);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    await expect(session.isDirty()).resolves.toBe(false);
+    await expect(session.hasUnsavedBuffers()).resolves.toBe(true);
+    await session.quit(true);
+    await session.cleanup();
+    await waitUntilDead(pid);
+
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it("opens Neovim, refuses dirty quit, and force cleans the child", async () => {
+    const filePath = join(dir, "target.txt");
+    await writeFile(filePath, "alpha\n", "utf8");
+    const snapshots: string[][] = [];
+    const dirtyChanges: boolean[] = [];
+
+    const session = await startEmbeddedNeovim({
+      executable: neovim.executable,
+      args: neovim.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 21, columns: 116 },
+      onSnapshot: (snapshot) => {
+        snapshots.push([...snapshot.lines]);
+      },
+      onDirtyChange: (dirty) => {
+        dirtyChanges.push(dirty);
+      },
+      onError: (error) => {
+        throw error;
+      },
+      onExit: () => {},
+    });
+    const pid = session.pid;
+
+    await session.input("ibeta");
+    await session.paste(" gamma");
+    await session.resize({ rows: 4, columns: 24 });
+    await session.focus(true);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    await expect(session.isDirty()).resolves.toBe(true);
+    await expect(session.quit(false)).resolves.toMatchObject({ closed: false });
+
+    await expect(session.save(true)).resolves.toBe(true);
+    await expect(session.isDirty()).resolves.toBe(false);
+    expect(await readFile(filePath, "utf8")).toContain("beta gamma");
+    expect(dirtyChanges).toContain(false);
+    await session.input("omore");
+    await session.quit(true);
+    await session.cleanup();
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    expect(await readFile(filePath, "utf8")).not.toContain("more");
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it("reports visible grid highlight cells for visual selections", async () => {
+    const filePath = join(dir, "target.txt");
+    await writeFile(filePath, "alpha beta gamma\nsecond line\n", "utf8");
+    const snapshots: NeovimRenderSnapshot[] = [];
+
+    const session = await startEmbeddedNeovim({
+      executable: neovim.executable,
+      args: neovim.args,
+      filePath,
+      line: 1,
+      column: 0,
+      cwd: dir,
+      size: { rows: 8, columns: 40 },
+      onSnapshot: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+      onError: (error) => {
+        throw error;
+      },
+      onExit: () => {},
+    });
+    const pid = session.pid;
+
+    try {
+      await session.input("gg0");
+      await waitForSnapshot(
+        snapshots,
+        (snapshot) => snapshot.cursor.row === 0 && snapshot.cursor.column === 0,
+      );
+      await session.input("v$");
+      const visual = await waitForSnapshot(
+        snapshots,
+        (snapshot) => snapshot.mode.startsWith("visual"),
+      );
+      const highlightsById = new Map(
+        visual.highlights.map((highlight) => [highlight.id, highlight.attributes]),
+      );
+      const selectedCells = visual.cells[0]?.filter((cell) => {
+        const attributes = highlightsById.get(cell.highlightId);
+        return attributes?.reverse === true || typeof attributes?.background === "number";
+      }) ?? [];
+
+      expect(visual.lines[0]).toContain("alpha beta gamma");
+      expect(selectedCells.length).toBeGreaterThan(0);
+    } finally {
+      await session.quit(true);
+      await session.cleanup();
+      await waitUntilDead(pid);
+    }
+
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+});
+
+function isProcessAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilDead(pid: number): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function waitForSnapshot<T>(
+  snapshots: readonly T[],
+  predicate: (snapshot: T) => boolean,
+): Promise<T> {
+  const deadline = Date.now() + 1500;
+  let last = snapshots.at(-1);
+  while (Date.now() < deadline) {
+    const match = snapshots.findLast(predicate);
+    if (match) return match;
+    last = snapshots.at(-1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for embedded Neovim snapshot; last=${JSON.stringify(last)}`);
+}

--- a/runtime/tests/utils/execFileNoThrow.test.ts
+++ b/runtime/tests/utils/execFileNoThrow.test.ts
@@ -1,7 +1,4 @@
 import { expect, test } from 'bun:test'
-import { mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { execFileNoThrowWithCwd } from '../../src/utils/execFileNoThrow.ts'
 
 test('execFileNoThrowWithCwd rejects shell-like executable names', async () => {
@@ -39,19 +36,4 @@ test('execFileNoThrowWithCwd rejects environment entries with control characters
 
   expect(result.code).toBe(1)
   expect(result.error).toContain('Unsafe environment')
-})
-
-test('execFileNoThrowWithCwd preserves Windows .cmd compatibility', async () => {
-  if (process.platform !== 'win32') {
-    return
-  }
-
-  const dir = mkdtempSync(join(tmpdir(), 'agenc-execfile-'))
-  const file = join(dir, 'hello.cmd')
-  writeFileSync(file, '@echo off\r\necho hello\r\n')
-
-  const result = await execFileNoThrowWithCwd(file, [])
-
-  expect(result.code).toBe(0)
-  expect(result.stdout).toContain('hello')
 })

--- a/runtime/tests/utils/execFileNoThrow.win32.test.ts
+++ b/runtime/tests/utils/execFileNoThrow.win32.test.ts
@@ -1,0 +1,31 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, expect, test } from "vitest";
+
+import { execFileNoThrowWithCwd } from "../../src/utils/execFileNoThrow.js";
+
+if (process.platform !== "win32") {
+  throw new Error("the native .cmd compatibility test requires Windows");
+}
+
+let directory: string | undefined;
+
+afterEach(() => {
+  if (directory !== undefined) {
+    rmSync(directory, { recursive: true, force: true });
+    directory = undefined;
+  }
+});
+
+test("execFileNoThrowWithCwd preserves Windows .cmd compatibility", async () => {
+  directory = mkdtempSync(join(tmpdir(), "agenc-execfile-"));
+  const file = join(directory, "hello.cmd");
+  writeFileSync(file, "@echo off\r\necho hello\r\n");
+
+  const result = await execFileNoThrowWithCwd(file, []);
+
+  expect(result.code).toBe(0);
+  expect(result.stdout).toContain("hello");
+});

--- a/runtime/tests/workflow/m5-exit.acceptance.test.ts
+++ b/runtime/tests/workflow/m5-exit.acceptance.test.ts
@@ -1,10 +1,9 @@
 /**
- * M5 exit proof — opt-in acceptance lane.
+ * M5 exit proof — hermetic daemon-wiring acceptance lane.
  *
- * Skipped unless `AGENC_M5_ACCEPTANCE=1` (the M4 matrix-style opt-in
- * gating convention for heavier acceptance runs). Same SIGKILL-at-
- * `after_spawn_before_effect_result` crash/restart flow as the hermetic
- * lane, but assembled through the REAL daemon wiring
+ * Runs in the default suite. It uses the same SIGKILL-at-
+ * `after_spawn_before_effect_result` crash/restart flow as the controller
+ * lane, but is assembled through the REAL daemon wiring
  * (`createDaemonWorkflowController`: per-run durability resolution,
  * multi-project resume sweep, real daemon evidence-ledger factory) —
  * model seams stay scripted by default; a real-model mode is a deliberate
@@ -27,14 +26,12 @@ import {
 } from "./fixtures/m5-exit-shared.js";
 import { M5_EXIT_RUN_ID } from "./fixtures/m5-harness.js";
 
-const ACCEPTANCE_ENABLED = process.env.AGENC_M5_ACCEPTANCE === "1";
-
 afterEach(() => {
   cleanupM5ExitStateDirs();
 });
 
-describe.sequential.skipIf(!ACCEPTANCE_ENABLED)(
-  "M5 exit proof — acceptance lane (AGENC_M5_ACCEPTANCE=1)",
+describe.sequential(
+  "M5 exit proof — daemon-wiring acceptance lane",
   () => {
     it(
       "crash/restart through the real daemon wiring completes by adoption and reconstructs from evidence alone",

--- a/runtime/tests/zero-skip-reporter.test.ts
+++ b/runtime/tests/zero-skip-reporter.test.ts
@@ -1,0 +1,134 @@
+import { spawnSync } from "node:child_process";
+import {
+  readFileSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  readZeroSkipEvidence,
+  ZERO_SKIP_REPORT_ENV_VAR,
+} from "../scripts/zero-skip-reporter.mjs";
+
+const CHILD_MODE = "AGENC_TEST_ZERO_SKIP_CHILD_MODE";
+const runtimeRoot = fileURLToPath(new URL("../", import.meta.url));
+const prelauncher = fileURLToPath(
+  new URL("../scripts/run-hermetic-vitest.mjs", import.meta.url),
+);
+const boundary = fileURLToPath(
+  new URL("../scripts/run-hermetic-test-boundary.mjs", import.meta.url),
+);
+
+if (process.env[CHILD_MODE] === "passing") {
+  describe("zero-skip passing fixture", () => {
+    it("runs without seeing coordinator evidence state", () => {
+      expect(process.env[ZERO_SKIP_REPORT_ENV_VAR]).toBeUndefined();
+    });
+  });
+} else if (process.env[CHILD_MODE] === "skipped") {
+  describe("zero-skip skipped fixture", () => {
+    it.skip("is reported by exact identity", () => undefined);
+  });
+} else {
+  describe("zero-skip reporter contract", () => {
+    function runNested(
+      mode: "passing" | "skipped",
+      options: { reporter?: boolean } = {},
+    ) {
+      return spawnSync(
+        process.execPath,
+        [
+          prelauncher,
+          "--require-zero-skips",
+          "run",
+          "tests/zero-skip-reporter.test.ts",
+          "--config",
+          "vitest.config.ts",
+          ...(options.reporter === false ? [] : ["--reporter=dot"]),
+        ],
+        {
+          cwd: runtimeRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            [CHILD_MODE]: mode,
+          },
+          timeout: 30_000,
+        },
+      );
+    }
+
+    it("preserves requested reporters while forcing zero-skip evidence", () => {
+      const result = runNested("passing");
+
+      expect(
+        result.status,
+        `nested zero-skip pass failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      ).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain(
+        "zero-skip evidence was missing or unreadable",
+      );
+    });
+
+    it("retains the default reporter when no reporter was requested", () => {
+      const result = runNested("passing", { reporter: false });
+
+      expect(
+        result.status,
+        `nested zero-skip pass failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      ).toBe(0);
+      expect(result.stdout).toContain("Test Files");
+      expect(result.stdout).toContain("Tests");
+    });
+
+    it("fails with the exact identity of every skipped test", () => {
+      const result = runNested("skipped");
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.status).toBe(1);
+      expect(output).toContain(
+        "Hermetic Vitest requires zero skipped tests; observed 1",
+      );
+      expect(output).toContain(
+        "tests/zero-skip-reporter.test.ts > zero-skip skipped fixture > is reported by exact identity [skip]",
+      );
+    });
+
+    it("rejects missing and malformed evidence", () => {
+      const root = mkdtempSync(join(tmpdir(), "agenc-zero-skip-evidence-"));
+      try {
+        expect(() =>
+          readZeroSkipEvidence(join(root, "missing.json")),
+        ).toThrow();
+
+        const malformed = join(root, "malformed.json");
+        writeFileSync(malformed, "{", { mode: 0o600 });
+        expect(() => readZeroSkipEvidence(malformed)).toThrow();
+
+        const invalidSchema = join(root, "invalid-schema.json");
+        writeFileSync(
+          invalidSchema,
+          JSON.stringify({ schemaVersion: 1, skippedTests: [{}] }),
+          { mode: 0o600 },
+        );
+        expect(() => readZeroSkipEvidence(invalidSchema)).toThrow(
+          "zero-skip report entry 0 is invalid",
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+
+    it("keeps zero-skip enforcement on the authoritative boundary", () => {
+      expect(readFileSync(boundary, "utf8")).toContain(
+        "run-hermetic-vitest.mjs --require-zero-skips",
+      );
+    });
+  });
+}

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -111,6 +111,26 @@ export const CROSS_REPO_TEST_INCLUDE = Object.freeze([
   'tests/app-server/sdk-tui-coattach-example.contract.test.ts',
 ]);
 
+/** Native integration tests executed only by their matching hosted builder. */
+export const NATIVE_TEST_INCLUDE = Object.freeze([
+  'tests/durability/atomic-artifact.win32.test.ts',
+  'tests/tools/runtimes/runtime.darwin.test.ts',
+  'tests/utils/execFileNoThrow.win32.test.ts',
+]);
+
+/** PowerShell integration tests executed by the pinned hosted capability lane. */
+export const POWERSHELL_TEST_INCLUDE = Object.freeze([
+  'tests/budget/admitted-legacy-powershell.powershell.test.ts',
+  'tests/packaging/install-ps1.powershell.test.ts',
+  'tests/shell-command/powershell-parser.powershell.test.ts',
+  'tests/tools/PowerShellTool.execution.powershell.test.ts',
+]);
+
+/** Real-Neovim integration tests executed by the pinned hosted capability lane. */
+export const NEOVIM_TEST_INCLUDE = Object.freeze([
+  'tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts',
+]);
+
 /**
  * Tests that may contact a provider, browser, or chain are never discovered by
  * the default suite. `HookProgressMessage.live.parity.test.ts` deliberately
@@ -132,6 +152,9 @@ export const DEFAULT_TEST_EXCLUDE = Object.freeze([
   'tests/transaction-guard/devnet-live.e2e.test.ts',
   ...DESIGN_TEST_INCLUDE,
   ...CROSS_REPO_TEST_INCLUDE,
+  ...NATIVE_TEST_INCLUDE,
+  ...POWERSHELL_TEST_INCLUDE,
+  ...NEOVIM_TEST_INCLUDE,
 ]);
 
 /** Explicit allowlist for credential-preserving, operator-invoked live runs. */
@@ -145,7 +168,14 @@ export const LIVE_TEST_INCLUDE = Object.freeze([
   'tests/transaction-guard/devnet-live.e2e.test.ts',
 ]);
 
-export type AgenCVitestMode = 'default' | 'live' | 'design' | 'cross-repo';
+export type AgenCVitestMode =
+  | 'default'
+  | 'live'
+  | 'design'
+  | 'cross-repo'
+  | 'native'
+  | 'powershell'
+  | 'neovim';
 
 function splitModuleId(id: string): { readonly path: string; readonly suffix: string } {
   const index = id.search(/[?#]/);
@@ -413,11 +443,42 @@ export function createAgenCVitestConfig(mode: AgenCVitestMode = 'default') {
             include: [...CROSS_REPO_TEST_INCLUDE],
             exclude: [...configDefaults.exclude],
           }
-      : {
-        setupFiles: ['./vitest.setup.ts'],
-        include: [...DEFAULT_TEST_INCLUDE],
-        exclude: [...DEFAULT_TEST_EXCLUDE],
-      };
+        : mode === 'native'
+          ? {
+              // Platform integration probes run only on their matching hosted
+              // native builder, with normal credential stripping and the JS
+              // network tripwire.
+              setupFiles: ['./vitest.setup.ts'],
+              include: [...NATIVE_TEST_INCLUDE],
+              exclude: [...configDefaults.exclude],
+            }
+          : mode === 'powershell'
+            ? {
+                // The hosted capability lane provisions an exact PowerShell
+                // runtime before entering the ordinary hermetic test boundary.
+                setupFiles: ['./vitest.setup.ts'],
+                include: [...POWERSHELL_TEST_INCLUDE],
+                exclude: [...configDefaults.exclude],
+                env: {
+                  DOTNET_CLI_TELEMETRY_OPTOUT: '1',
+                  DOTNET_NOLOGO: '1',
+                  POWERSHELL_TELEMETRY_OPTOUT: '1',
+                  POWERSHELL_UPDATECHECK: 'Off',
+                },
+              }
+            : mode === 'neovim'
+              ? {
+                  // The hosted capability lane provisions a digest-pinned
+                  // Neovim before entering the ordinary hermetic boundary.
+                  setupFiles: ['./vitest.setup.ts'],
+                  include: [...NEOVIM_TEST_INCLUDE],
+                  exclude: [...configDefaults.exclude],
+                }
+            : {
+                setupFiles: ['./vitest.setup.ts'],
+                include: [...DEFAULT_TEST_INCLUDE],
+                exclude: [...DEFAULT_TEST_EXCLUDE],
+              };
 
   return defineConfig({
     plugins: [

--- a/runtime/vitest.native.config.ts
+++ b/runtime/vitest.native.config.ts
@@ -1,0 +1,6 @@
+import { createAgenCVitestConfig } from './vitest.config.ts';
+
+// Exact native-only allowlist for release builders. The normal hermetic setup
+// still strips credentials, isolates AgenC state, and installs the JS network
+// tripwire; workflow assertions additionally require zero skipped tests.
+export default createAgenCVitestConfig('native');

--- a/runtime/vitest.neovim.config.ts
+++ b/runtime/vitest.neovim.config.ts
@@ -1,0 +1,6 @@
+import { createAgenCVitestConfig } from './vitest.config.ts';
+
+// Exact real-Neovim allowlist for the hosted capability lane. The normal
+// hermetic setup strips credentials, isolates AgenC state, and installs the
+// public-network tripwire.
+export default createAgenCVitestConfig('neovim');

--- a/runtime/vitest.powershell.config.ts
+++ b/runtime/vitest.powershell.config.ts
@@ -1,0 +1,6 @@
+import { createAgenCVitestConfig } from './vitest.config.ts';
+
+// Exact PowerShell-only allowlist for the hosted capability lane. The normal
+// hermetic setup still strips credentials, isolates AgenC state, and installs
+// the public-network tripwire.
+export default createAgenCVitestConfig('powershell');

--- a/scripts/fetch-pinned-npm.mjs
+++ b/scripts/fetch-pinned-npm.mjs
@@ -8,6 +8,24 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const MAX_NPM_ARCHIVE_BYTES = 32 * 1024 * 1024;
 
+export function fsyncDirectorySync(
+  descriptor,
+  {
+    platform = process.platform,
+    fsyncImpl = fsyncSync,
+  } = {},
+) {
+  try {
+    fsyncImpl(descriptor);
+  } catch (error) {
+    // Windows does not expose a portable directory FlushFileBuffers
+    // operation. Node 26 reports EPERM after successfully opening the
+    // directory, while the archive itself has already been fsynced above.
+    if (platform === "win32" && error?.code === "EPERM") return;
+    throw error;
+  }
+}
+
 async function readBoundedBody(response, maximumBytes = MAX_NPM_ARCHIVE_BYTES) {
   const reader = response.body?.getReader?.();
   if (reader === undefined) throw new Error("pinned npm response has no readable body");
@@ -86,7 +104,7 @@ export async function fetchPinnedNpm({
     closeSync(descriptor);
     descriptor = undefined;
     directoryDescriptor = openSync(dirname(destination), "r");
-    fsyncSync(directoryDescriptor);
+    fsyncDirectorySync(directoryDescriptor);
     closeSync(directoryDescriptor);
     directoryDescriptor = undefined;
     committed = true;

--- a/scripts/required-gate-contract.mjs
+++ b/scripts/required-gate-contract.mjs
@@ -128,6 +128,7 @@ export const REQUIRED_GATES = Object.freeze([
 // test files remain reviewable without requiring a gate-policy rotation.
 export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   ".npmrc",
+  ".github/workflows/platform-tests.yml",
   ".github/workflows/publish-npm.yml",
   ".github/workflows/release-runtime.yml",
   "package.json",
@@ -154,6 +155,9 @@ export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   "runtime/tsconfig.bundle.json",
   "runtime/tsconfig.json",
   "runtime/vitest.config.ts",
+  "runtime/vitest.native.config.ts",
+  "runtime/vitest.neovim.config.ts",
+  "runtime/vitest.powershell.config.ts",
   "runtime/scripts/build-runtime.mjs",
   "runtime/scripts/check-package-entrypoints.mjs",
   "runtime/scripts/check-sdk-generated-types.mjs",
@@ -165,6 +169,7 @@ export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   "runtime/scripts/run-hermetic-test-boundary.mjs",
   "runtime/scripts/run-hermetic-vitest.mjs",
   "runtime/scripts/write-build-version.mjs",
+  "runtime/scripts/zero-skip-reporter.mjs",
   "runtime/tests/helpers/hermetic-env.mjs",
   "runtime/tests/helpers/hermetic-managed-policy-mocks.ts",
   "runtime/tests/helpers/hermetic-secure-storage-mocks.ts",


### PR DESCRIPTION
## Summary

- make the authoritative hermetic Vitest boundary fail closed on any skipped test, with exact skip identities and revert-sensitive reporter coverage
- replace Linux false-green guards with real assertions for native hardening, forced GC, FIFO handling, cross-process locks, and the daemon-wiring acceptance path
- move actual PowerShell and Neovim process coverage into exact digest-pinned capability lanes
- add exact macOS Seatbelt and Windows native probes to PR checks and the matching release builders
- keep capability-independent PowerShell and Neovim coverage in the default suite
- make the pinned npm fetch durable on Windows without treating unsupported directory fsync as archive failure

The opportunistic real-bubblewrap probe was removed because unavailable or restricted namespaces made it report a pass without exercising the assertion. Its deterministic launcher argv and descriptor contracts remain; a dedicated kernel-capability lane is a separate follow-up.

## Exact-SHA local evidence

Tested SHA: `2ed0832a15ec0a32c44dcf8882ab1a1ed59689c7` with Node 26.5.0 / npm 11.17.0.

- authoritative root `npm test`: 16,887 passed / 0 failed / 0 skipped / 0 todo
  - required gates: 121 passed
  - agent-surface contract: 22 passed
  - launcher: 163 passed
  - runtime Vitest: 1,886 files / 16,581 tests passed; mandatory zero-skip evidence accepted
- exact-SHA pre-commit hook: runtime build, 4 package entrypoints, generated SDK types, and all 6 PTY launches passed
- final worktree clean; no staged or unstaged changes

Additional validation on the parent before the final workflow-only contract delta:

- Bun: 91 files / 0 failures
- local PowerShell lane: 4 files / 7 suites / 19 tests / 0 skipped
- real Neovim lane: 1 file / 2 suites / 4 tests / 0 skipped
- SDK build and typecheck: passed with 0 errors
- SBOM generation and verification: 684 packages / 1,106 relationships

## Hosted exact-SHA evidence

Run `30313817150` passed on the tested SHA:

- PowerShell: 4 files / 7 suites / 19 tests / 0 skipped
- Neovim: 1 file / 2 suites / 4 tests / 0 skipped
- macOS native: 1 file / 1 suite / 1 test / 0 skipped
- Windows native: 2 files / 3 suites / 3 tests / 0 skipped