### PR TITLE
test(runtime): gate Linux sandbox on real kernel isolation

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -16,6 +16,329 @@ env:
   NPM_VERSION: "11.17.0"
 
 jobs:
+  linux-kernel-sandbox:
+    name: linux-kernel-sandbox
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Bind the checkout and provision pinned bubblewrap
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "tetsuo-ai/agenc-core"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(id -u)" -ne 0
+          cap_eff="$(awk '$1 == "CapEff:" { print $2 }' /proc/self/status)"
+          [[ "$cap_eff" =~ ^0+$ ]]
+
+          npm_archive="$RUNNER_TEMP/npm-${NPM_VERSION}.tgz"
+          node scripts/fetch-pinned-npm.mjs "$npm_archive"
+          npm install --global "$npm_archive" \
+            --ignore-scripts --no-audit --no-fund
+          test "$(npm --version)" = "$NPM_VERSION"
+
+          bwrap_version="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["bubblewrapTestRuntime"]["version"])')"
+          bwrap_package_version="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]["packageVersion"])')"
+          bwrap_file="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]["file"])')"
+          bwrap_url="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]["url"])')"
+          bwrap_sha="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]["sha256"])')"
+          bwrap_bytes="$(python3 -c 'import json; print(json.load(open("release-toolchain.json"))["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]["bytes"])')"
+          test "$bwrap_file" = "bubblewrap_${bwrap_package_version}_amd64.deb"
+          [[ "$bwrap_sha" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$bwrap_bytes" =~ ^[1-9][0-9]*$ ]]
+
+          bwrap_archive="$RUNNER_TEMP/$bwrap_file"
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --fail --location --silent --show-error \
+            "$bwrap_url" --output "$bwrap_archive"
+          test "$(sha256sum "$bwrap_archive" | awk '{print $1}')" = "$bwrap_sha"
+          test "$(stat --format='%s' "$bwrap_archive")" = "$bwrap_bytes"
+          test "$(dpkg-deb --field "$bwrap_archive" Package)" = "bubblewrap"
+          test "$(dpkg-deb --field "$bwrap_archive" Version)" = \
+            "$bwrap_package_version"
+          test "$(dpkg-deb --field "$bwrap_archive" Architecture)" = "amd64"
+          sudo dpkg --install "$bwrap_archive"
+
+          test "$(command -v bwrap)" = "/usr/bin/bwrap"
+          test "$(dpkg-query --show --showformat='${Version}' bubblewrap)" = \
+            "$bwrap_package_version"
+          test -z "$(dpkg --verify bubblewrap)"
+          test "$(stat --format='%U:%G:%a' /usr/bin/bwrap)" = "root:root:755"
+          test ! -w /usr/bin/bwrap
+          test -z "$(getcap -n /usr/bin/bwrap)"
+          test "$(bwrap --version)" = "bubblewrap ${bwrap_version}"
+          test "$(command -v apparmor_parser)" = "/usr/sbin/apparmor_parser"
+          echo "kernel capability uses bubblewrap ${bwrap_package_version}"
+
+      - name: Install and build the production launcher
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm rebuild esbuild
+          npm run build --workspace=@tetsuo-ai/runtime
+          test -x runtime/bin/agenc-linux-sandbox
+          test -r runtime/dist/sandbox/linux-launcher/main.js
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(npm --version)" = "$NPM_VERSION"
+
+      - name: Run the exact real-kernel bubblewrap lane
+        shell: bash
+        run: |
+          set -euo pipefail
+          userns_clone_path="/proc/sys/kernel/unprivileged_userns_clone"
+          apparmor_userns_path="/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+          profile="$RUNNER_TEMP/agenc-native-userns"
+          wrapper="/opt/agenc-kernel-e2e"
+          node_copy="/opt/agenc-kernel-e2e-node"
+          profile_loaded=0
+          wrapper_installed=0
+          node_copy_installed=0
+
+          cleanup() {
+            status=$?
+            trap - EXIT
+            leaks_remaining=0
+            mapfile -t leaked_pids < <(
+              {
+                pgrep -x bwrap || true
+                pgrep -f -- \
+                  'agenc-kernel-e2e-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' ||
+                  true
+              } | sort -un
+            )
+            if test "${#leaked_pids[@]}" -gt 0; then
+              echo "kernel capability lane leaked process(es):" >&2
+              for pid in "${leaked_pids[@]}"; do
+                ps -o pid=,ppid=,stat=,args= -p "$pid" >&2 || true
+                kill -TERM "$pid" 2>/dev/null || true
+              done
+              status=1
+              for _ in {1..50}; do
+                live=0
+                for pid in "${leaked_pids[@]}"; do
+                  if kill -0 "$pid" 2>/dev/null; then live=1; fi
+                done
+                if test "$live" = "0"; then break; fi
+                sleep 0.1
+              done
+              for pid in "${leaked_pids[@]}"; do
+                if kill -0 "$pid" 2>/dev/null; then
+                  kill -KILL "$pid" 2>/dev/null || true
+                fi
+              done
+              for _ in {1..50}; do
+                live=0
+                for pid in "${leaked_pids[@]}"; do
+                  if kill -0 "$pid" 2>/dev/null; then live=1; fi
+                done
+                if test "$live" = "0"; then break; fi
+                sleep 0.1
+              done
+              for pid in "${leaked_pids[@]}"; do
+                if kill -0 "$pid" 2>/dev/null; then
+                  echo "failed to terminate leaked process $pid" >&2
+                  leaks_remaining=1
+                  status=1
+                fi
+              done
+            fi
+            if test "$profile_loaded" = "1" &&
+              test "$leaks_remaining" = "0"; then
+              if ! sudo apparmor_parser -R "$profile"; then
+                echo "failed to unload the kernel-test AppArmor profile" >&2
+                status=1
+              fi
+            elif test "$profile_loaded" = "1"; then
+              echo "refusing to unconfine a leaked kernel-test process" >&2
+              status=1
+            fi
+            if sudo grep -q '^agenc-native-userns ' \
+              /sys/kernel/security/apparmor/profiles; then
+              echo "kernel capability lane leaked its AppArmor profile" >&2
+              status=1
+            fi
+            if test "$wrapper_installed" = "1" &&
+              test "$leaks_remaining" = "0"; then
+              sudo unlink "$wrapper" || status=1
+            fi
+            if test "$node_copy_installed" = "1" &&
+              test "$leaks_remaining" = "0"; then
+              sudo unlink "$node_copy" || status=1
+            fi
+            if test "$(cat "$apparmor_userns_path")" != "1"; then
+              echo "AppArmor user-namespace restriction changed" >&2
+              status=1
+            fi
+            if test -r "$userns_clone_path" &&
+              test "$(cat "$userns_clone_path")" != "1"; then
+              echo "unprivileged user-namespace setting changed" >&2
+              status=1
+            fi
+            if test -n "$(git status --porcelain=v1 --untracked-files=all)"; then
+              echo "kernel capability lane dirtied the checkout" >&2
+              status=1
+            fi
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          test "$(id -u)" -ne 0
+          cap_eff="$(awk '$1 == "CapEff:" { print $2 }' /proc/self/status)"
+          [[ "$cap_eff" =~ ^0+$ ]]
+          test -r "$apparmor_userns_path"
+          test "$(cat "$apparmor_userns_path")" = "1"
+          if test -r "$userns_clone_path"; then
+            test "$(cat "$userns_clone_path")" = "1"
+          fi
+          test "$(cat /proc/sys/user/max_user_namespaces)" -gt 0
+          test -e /proc/self/ns/user
+          test -e /proc/self/ns/pid
+          test -e /proc/self/ns/net
+          test -e /proc/self/ns/mnt
+          test ! -e /etc/apparmor.d/local/agenc-native-userns
+          if sudo grep -q '^agenc-native-userns ' \
+            /sys/kernel/security/apparmor/profiles; then
+            echo "kernel-test AppArmor profile already exists" >&2
+            exit 1
+          fi
+
+          denied_probe="$RUNNER_TEMP/bwrap-denied-before-profile.txt"
+          if bwrap \
+            --unshare-user \
+            --unshare-pid \
+            --unshare-net \
+            --ro-bind / / \
+            --proc /proc \
+            -- /bin/true >"$denied_probe" 2>&1; then
+            echo "bubblewrap unexpectedly worked before the scoped profile" >&2
+            exit 1
+          fi
+          grep -Eq \
+            'Failed RTM_NEW(ADDR|LINK)|setting up uid map: (Permission denied|Operation not permitted)' \
+            "$denied_probe"
+
+          wrapper_source="$RUNNER_TEMP/agenc-kernel-e2e-wrapper"
+          test ! -e "$wrapper"
+          test ! -L "$wrapper"
+          test ! -e "$node_copy"
+          test ! -L "$node_copy"
+          sudo install --owner=root --group=root --mode=0755 \
+            "$(realpath "$(command -v node)")" "$node_copy"
+          node_copy_installed=1
+          test "$(stat --format='%U:%G:%a' "$node_copy")" = "root:root:755"
+          test ! -w "$node_copy"
+          test -z "$(getcap -n "$node_copy")"
+          test "$("$node_copy" --version)" = "v${NODE_VERSION}"
+          node_bin="$node_copy"
+          runtime_bin="$(realpath runtime/scripts/run-hermetic-vitest.mjs)"
+          node --input-type=module - \
+            "$wrapper_source" "$node_bin" "$runtime_bin" \
+            "$RUNNER_TEMP/agenc-home" <<'NODE'
+          import { writeFileSync } from "node:fs";
+          import { renderGeneratedWrapperContent } from "./packages/agenc/lib/generated-wrapper.mjs";
+
+          const [path, nodeBin, runtimeBin, agencHome] = process.argv.slice(2);
+          if (!path || !nodeBin || !runtimeBin || !agencHome) {
+            throw new Error("missing generated-wrapper input");
+          }
+          writeFileSync(
+            path,
+            renderGeneratedWrapperContent({
+              kind: "posix",
+              nodeBin,
+              runtimeBin,
+              agencHome,
+            }),
+            { flag: "wx", mode: 0o755 },
+          );
+          NODE
+          sudo install --owner=root --group=root --mode=0755 \
+            "$wrapper_source" "$wrapper"
+          wrapper_installed=1
+          test "$(stat --format='%U:%G:%a' "$wrapper")" = "root:root:755"
+          test ! -w "$wrapper"
+
+          ./node_modules/.bin/tsx --eval \
+            'import { renderAgenCAppArmorProfile } from "./runtime/src/sandbox/apparmor.ts"; process.stdout.write(renderAgenCAppArmorProfile(process.argv[1]));' \
+            "$wrapper" > "$profile"
+          grep -Fqx \
+            'profile agenc-native-userns "/opt/agenc-kernel-e2e" flags=(unconfined) {' \
+            "$profile"
+          test "$(grep -Fxc '  userns,' "$profile")" = "1"
+          sudo apparmor_parser -r "$profile"
+          profile_loaded=1
+          sudo grep -q '^agenc-native-userns ' \
+            /sys/kernel/security/apparmor/profiles
+          test "$(cat "$apparmor_userns_path")" = "1"
+
+          results="$RUNNER_TEMP/kernel-test-results.json"
+          "$wrapper" \
+            --require-zero-skips \
+            run \
+            --config vitest.kernel.config.ts \
+            --allowOnly=false \
+            --reporter=verbose \
+            --reporter=json \
+            --outputFile.json "$results"
+          node --input-type=module - "$results" <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing kernel-test results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const expectedFile =
+            "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts";
+          const exactCounts = {
+            numTotalTestSuites: 1,
+            numPassedTestSuites: 1,
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTests: 1,
+            numPassedTests: 1,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `kernel-test result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (
+            results.success !== true ||
+            !Array.isArray(results.testResults) ||
+            results.testResults.length !== 1
+          ) {
+            throw new Error("kernel-test result did not report one successful file");
+          }
+          const file = relative(
+            resolve("runtime"),
+            results.testResults[0].name,
+          ).split("\\").join("/");
+          if (file !== expectedFile) {
+            throw new Error(
+              `kernel-test file was ${JSON.stringify(file)}, expected ${expectedFile}`,
+            );
+          }
+          console.log(
+            "real-kernel bubblewrap lane passed 1 test in 1 file with zero skipped",
+          );
+          NODE
+
   powershell:
     name: powershell
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -378,8 +378,9 @@ it receives background-network suppression flags, but only `npm test` provides
 the authoritative OS egress boundary.
 
 **Required checks:** the complete platform-independent suite runs locally.
-GitHub Actions carries only exact, narrow PowerShell, Neovim, macOS, and
-Windows capability lanes. Before merge, the PR records the exact locally
+GitHub Actions carries only exact, narrow Linux-kernel sandbox, PowerShell,
+Neovim, macOS, and Windows capability lanes. Before merge, the PR records the
+exact locally
 tested SHA, commands, results, and skips. Release verification repeats
 the same local gates against the immutable release-tag commit and retains the
 defined local evidence record. Manual release workflows may build artifacts

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -373,9 +373,10 @@ crashing the process.
   pristine checkouts to prove byte-identical recursive OCI layouts with an
   exact Buildx client and digest-pinned BuildKit daemon.
 - **Local required verification** — the complete platform-independent stable
-  contract runs locally. GitHub Actions carries only exact, narrow PowerShell,
-  Neovim, macOS, and Windows capability lanes. Each PR records the exact
-  locally tested SHA, commands, results, and skips before merge; release
+  contract runs locally. GitHub Actions carries only exact, narrow Linux-kernel
+  sandbox, PowerShell, Neovim, macOS, and Windows capability lanes. Each PR
+  records the exact locally tested SHA, commands, results, and skips before
+  merge; release
   verification repeats the gates on the immutable release-tag commit and
   retains the defined local evidence record. GitHub remains the
   branch/PR/merge record; manual release workflows

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -834,7 +834,19 @@ authorize release of a different squash-merged commit.
 
 [`platform-tests.yml`](../.github/workflows/platform-tests.yml) carries only
 tests whose required runtime or operating system is unavailable to the normal
-Linux local gate. Its `powershell` job installs the digest- and byte-pinned
+Linux local gate. Its `linux-kernel-sandbox` job installs the digest- and
+byte-pinned Ubuntu bubblewrap package from
+[`release-toolchain.json`](../release-toolchain.json), keeps Ubuntu's global
+AppArmor user-namespace restriction enabled, and loads the narrow profile
+rendered by AgenC for a root-owned generated wrapper. The one-test allowlist
+then exercises the production broker, manager, packaged launcher, bubblewrap,
+user/PID/mount/network namespaces, network seccomp, filesystem mounts, and
+descendant cleanup as an unprivileged process with no effective capabilities.
+The job proves host loopback reachability before the sandbox, requires the
+sandboxed socket syscall to fail with `EPERM`, and unloads the profile with
+process- and checkout-cleanliness postconditions.
+
+The `powershell` job installs the digest- and byte-pinned
 PowerShell runtime from [`release-toolchain.json`](../release-toolchain.json),
 enters the same credential-stripped, private-home Vitest boundary as the
 default suite, and runs an exact four-file allowlist. The Node tripwire remains
@@ -1064,7 +1076,7 @@ PTY supervisor run locally. PR descriptions are the human-reviewed evidence
 record and must follow the exact-SHA protocol above. Release records use the
 defined local evidence path and immutable-tag protocol. No dedicated GitHub
 App or active App-bound ruleset is claimed or required in local-only mode.
-The hosted platform workflow supplements PRs with the four narrow capability
+The hosted platform workflow supplements PRs with the five narrow capability
 lanes above; the same native probes also run before tagged native artifacts
 are built. The optional multi-UID systemd/App design has not been activated.
 

--- a/release-toolchain.json
+++ b/release-toolchain.json
@@ -10,6 +10,17 @@
     "url": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
     "sha256": "b290bbb35b9e72c3ef84edbe041f28c4479c4d9ee79f555817b8caafe7ce4bba"
   },
+  "bubblewrapTestRuntime": {
+    "schemaVersion": 1,
+    "version": "0.9.0",
+    "ubuntu-24.04-x64": {
+      "packageVersion": "0.9.0-1ubuntu0.1",
+      "file": "bubblewrap_0.9.0-1ubuntu0.1_amd64.deb",
+      "url": "https://security.ubuntu.com/ubuntu/pool/main/b/bubblewrap/bubblewrap_0.9.0-1ubuntu0.1_amd64.deb",
+      "sha256": "1b506492bd9c7fd0cdb4f02ac822f1d3e336b0aead5113c1239baf8db5db562a",
+      "bytes": 50178
+    }
+  },
   "powershellTestRuntime": {
     "schemaVersion": 1,
     "version": "7.6.4",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -57,6 +57,7 @@
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
     "test": "node scripts/run-hermetic-test-boundary.mjs run",
     "test:host-functional": "node scripts/run-hermetic-vitest.mjs run",
+    "test:kernel": "node scripts/run-hermetic-vitest.mjs --require-zero-skips run --config vitest.kernel.config.ts",
     "test:powershell": "node scripts/run-hermetic-vitest.mjs --require-zero-skips run --config vitest.powershell.config.ts",
     "test:cross-repo": "node scripts/run-hermetic-vitest.mjs run --config vitest.cross-repo.config.ts",
     "test:live": "vitest run --config vitest.live.config.ts",

--- a/runtime/src/sandbox/linux-launcher/bwrap.ts
+++ b/runtime/src/sandbox/linux-launcher/bwrap.ts
@@ -21,7 +21,8 @@ export interface BwrapOptions {
   readonly mountProc: boolean;
   readonly networkMode: BwrapNetworkMode;
   readonly seccompFd?: number;
-  readonly extraBindRoots?: readonly string[];
+  readonly extraReadOnlyBindRoots?: readonly string[];
+  readonly extraWritableBindRoots?: readonly string[];
 }
 
 export interface BwrapCommandArgs {
@@ -202,7 +203,10 @@ function createFilesystemArgs(
   for (const root of writableRoots) {
     appendWritableRoot(args, root, protectedCreateTargets);
   }
-  for (const root of options.extraBindRoots ?? []) {
+  for (const root of options.extraReadOnlyBindRoots ?? []) {
+    appendReadOnlyIfExists(args, root);
+  }
+  for (const root of options.extraWritableBindRoots ?? []) {
     appendBindIfExists(args, root);
   }
   for (const root of unreadableTargets.filter(isNestedUnreadable)) {

--- a/runtime/src/sandbox/linux-launcher/linux-run-main.ts
+++ b/runtime/src/sandbox/linux-launcher/linux-run-main.ts
@@ -102,10 +102,9 @@ async function runLinuxSandboxOptions(
     selfCommand,
     preparedProxy?.serializedSpec ?? null,
   );
-  const extraBindRoots = [
-    ...inferredInnerLauncherBindRoots(selfCommand),
-    ...(preparedProxy === null ? [] : [preparedProxy.socketDir]),
-  ];
+  const extraReadOnlyBindRoots = inferredInnerLauncherBindRoots(selfCommand);
+  const extraWritableBindRoots =
+    preparedProxy === null ? [] : [preparedProxy.socketDir];
   const proxyRoutedNetwork = options.allowNetworkForProxy;
   const seccompMode = networkSeccompMode(
     network,
@@ -124,7 +123,8 @@ async function runLinuxSandboxOptions(
         mountProc: options.mountProc,
         networkMode,
         ...(bwrapSeccompMode !== null ? { seccompFd: SECCOMP_STDIN_FD } : {}),
-        extraBindRoots,
+        extraReadOnlyBindRoots,
+        extraWritableBindRoots,
       },
     );
     if (!bwrapArgs.usesBubblewrap) {
@@ -159,7 +159,8 @@ async function runLinuxSandboxOptions(
           mountProc: false,
           networkMode,
           ...(bwrapSeccompMode !== null ? { seccompFd: SECCOMP_STDIN_FD } : {}),
-          extraBindRoots,
+          extraReadOnlyBindRoots,
+          extraWritableBindRoots,
         },
       );
     }

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -58,6 +58,10 @@ const NATIVE_TEST_FILES = [
   'tests/utils/execFileNoThrow.win32.test.ts',
 ] as const;
 
+const KERNEL_TEST_FILES = [
+  'tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts',
+] as const;
+
 const POWERSHELL_TEST_FILES = [
   'tests/budget/admitted-legacy-powershell.powershell.test.ts',
   'tests/packaging/install-ps1.powershell.test.ts',
@@ -131,6 +135,13 @@ describe('hermetic test discovery', () => {
       ).not.toContain(nativeFile);
     }
 
+    for (const kernelFile of KERNEL_TEST_FILES) {
+      expect(
+        files,
+        `${kernelFile} leaked into the ordinary Linux suite`,
+      ).not.toContain(kernelFile);
+    }
+
     for (const powershellFile of POWERSHELL_TEST_FILES) {
       expect(
         files,
@@ -183,6 +194,29 @@ describe('hermetic test discovery', () => {
       const source = readFileSync(resolve(runtimeRoot, file), 'utf8');
       expect(source).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
     }
+  });
+
+  it('kernel discovery is an exact fail-closed real-bubblewrap allowlist', () => {
+    expect(listTestFiles('vitest.kernel.config.ts')).toEqual([
+      ...KERNEL_TEST_FILES,
+    ]);
+    const source = readFileSync(resolve(runtimeRoot, KERNEL_TEST_FILES[0]), 'utf8');
+    expect(source).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
+    expect(source).toContain('new SandboxExecutionBroker({');
+    expect(source).toContain('const status = broker.status()');
+    expect(source).toContain('broker.prepareSpawn("tool"');
+    expect(source).toContain('agenc-native-userns (unconfined)');
+    expect(source).toContain('tcpRoundTrip(address.port, baselineToken)');
+    expect(source).toContain('error: "EPERM"');
+    expect(source).toContain('evidence.namespaces.mnt');
+    expect(source).toContain('evidence.namespaces.net');
+    expect(source).toContain('evidence.namespaces.pid');
+    expect(source).toContain('evidence.namespaces.user');
+    expect(source).toContain('expect(hostConnections).toBe(0)');
+    expect(source).toContain('expect(existsSync(descendantLeakMarker)).toBe(false)');
+    expect(source).toContain('visibleInProc: true');
+    expect(source).toContain('expect(readFileSync(hostSentinel, "utf8")).toBe(');
+    expect(source).toContain('expect(readFileSync(launcherSentinel, "utf8")).toBe(');
   });
 
   it('PowerShell discovery is an exact hosted capability allowlist without skip gates', () => {
@@ -327,6 +361,11 @@ describe('hermetic test discovery', () => {
       resolve(runtimeRoot, 'vitest.native.config.ts'),
       runtimeRoot,
     );
+    const kernelResult = await loadConfigFromFile(
+      environment,
+      resolve(runtimeRoot, 'vitest.kernel.config.ts'),
+      runtimeRoot,
+    );
     const powershellResult = await loadConfigFromFile(
       environment,
       resolve(runtimeRoot, 'vitest.powershell.config.ts'),
@@ -353,6 +392,9 @@ describe('hermetic test discovery', () => {
       './vitest.setup.ts',
     ]);
     expect(nativeResult?.config.test?.setupFiles).toEqual([
+      './vitest.setup.ts',
+    ]);
+    expect(kernelResult?.config.test?.setupFiles).toEqual([
       './vitest.setup.ts',
     ]);
     expect(powershellResult?.config.test?.setupFiles).toEqual([

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -121,6 +121,17 @@ describe("reproducible install and release contract", () => {
     const toolchain = JSON.parse(
       readFileSync(join(REPO_ROOT, "release-toolchain.json"), "utf8"),
     ) as {
+      bubblewrapTestRuntime: {
+        schemaVersion: number;
+        version: string;
+        "ubuntu-24.04-x64": {
+          packageVersion: string;
+          file: string;
+          url: string;
+          sha256: string;
+          bytes: number;
+        };
+      };
       powershellTestRuntime: {
         schemaVersion: number;
         version: string;
@@ -142,6 +153,17 @@ describe("reproducible install and release contract", () => {
         };
       };
     };
+    expect(toolchain.bubblewrapTestRuntime).toEqual({
+      schemaVersion: 1,
+      version: "0.9.0",
+      "ubuntu-24.04-x64": {
+        packageVersion: "0.9.0-1ubuntu0.1",
+        file: "bubblewrap_0.9.0-1ubuntu0.1_amd64.deb",
+        url: "https://security.ubuntu.com/ubuntu/pool/main/b/bubblewrap/bubblewrap_0.9.0-1ubuntu0.1_amd64.deb",
+        sha256: "1b506492bd9c7fd0cdb4f02ac822f1d3e336b0aead5113c1239baf8db5db562a",
+        bytes: 50_178,
+      },
+    });
     expect(toolchain.powershellTestRuntime).toEqual({
       schemaVersion: 1,
       version: "7.6.4",
@@ -168,10 +190,68 @@ describe("reproducible install and release contract", () => {
       "utf8",
     );
     expect(workflow).toContain("\n  pull_request:");
+    expect(workflow).toContain("\n  linux-kernel-sandbox:");
     expect(workflow).toContain("\n  powershell:");
     expect(workflow).toContain("\n  neovim:");
     expect(workflow).toContain("\n  macos-native:");
     expect(workflow).toContain("\n  windows-native:");
+
+    const linuxKernelJob = workflow.slice(
+      workflow.indexOf("\n  linux-kernel-sandbox:"),
+      workflow.indexOf("\n  powershell:"),
+    );
+    expect(linuxKernelJob).toContain("runs-on: ubuntu-24.04");
+    expect(linuxKernelJob).toContain(
+      '["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]',
+    );
+    expect(linuxKernelJob).toContain("sudo dpkg --install");
+    expect(linuxKernelJob).toContain(
+      "stat --format='%U:%G:%a' /usr/bin/bwrap",
+    );
+    expect(linuxKernelJob).toContain("getcap -n /usr/bin/bwrap");
+    expect(linuxKernelJob).toContain(
+      'node_copy="/opt/agenc-kernel-e2e-node"',
+    );
+    expect(linuxKernelJob).toContain(
+      'stat --format=\'%U:%G:%a\' "$node_copy"',
+    );
+    expect(linuxKernelJob).toContain('test "$(id -u)" -ne 0');
+    expect(linuxKernelJob).toContain('[[ "$cap_eff" =~ ^0+$ ]]');
+    expect(linuxKernelJob).toContain(
+      'test "$(cat "$apparmor_userns_path")" = "1"',
+    );
+    expect(linuxKernelJob).toContain("renderAgenCAppArmorProfile");
+    expect(linuxKernelJob).toContain("sudo apparmor_parser -r");
+    expect(linuxKernelJob).toContain("sudo apparmor_parser -R");
+    expect(linuxKernelJob).toContain("--require-zero-skips");
+    expect(linuxKernelJob).toContain("--config vitest.kernel.config.ts");
+    expect(linuxKernelJob).toContain(
+      "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
+    );
+    expect(linuxKernelJob).toContain("numTotalTestSuites: 1");
+    expect(linuxKernelJob).toContain("numTotalTests: 1");
+    expect(linuxKernelJob).toContain("pgrep -x bwrap");
+    expect(linuxKernelJob).toContain(
+      "agenc-kernel-e2e-[0-9a-f]{8}-[0-9a-f]{4}",
+    );
+    expect(linuxKernelJob).toContain('kill -TERM "$pid"');
+    expect(linuxKernelJob).toContain('kill -KILL "$pid"');
+    expect(linuxKernelJob).toContain(
+      "refusing to unconfine a leaked kernel-test process",
+    );
+    expect(linuxKernelJob).toContain('test ! -e "$wrapper"');
+    expect(linuxKernelJob).toContain('test ! -e "$node_copy"');
+    expect(linuxKernelJob).toContain("wrapper_installed=1");
+    expect(linuxKernelJob).toContain("node_copy_installed=1");
+    expect(linuxKernelJob).toContain(
+      "git status --porcelain=v1 --untracked-files=all",
+    );
+    expect(linuxKernelJob).not.toContain("sysctl -w");
+    expect(linuxKernelJob).not.toContain(
+      "kernel.apparmor_restrict_unprivileged_userns=0",
+    );
+    expect(linuxKernelJob).not.toContain("--privileged");
+    expect(linuxKernelJob).not.toContain("sudo bwrap");
 
     const powershellJob = workflow.slice(
       workflow.indexOf("\n  powershell:"),
@@ -252,11 +332,11 @@ describe("reproducible install and release contract", () => {
 
     expect(workflow.match(
       /actions\/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/g,
-    )).toHaveLength(4);
+    )).toHaveLength(5);
     expect(workflow.match(
       /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/g,
-    )).toHaveLength(3);
-    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(4);
+    )).toHaveLength(4);
+    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(5);
     expect(workflow).not.toMatch(/uses:\s+actions\/[\w-]+@v\d/);
     expect(workflow).not.toContain("cache: npm");
     expect(workflow).not.toContain("--passWithNoTests");

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts
@@ -1,0 +1,614 @@
+import {
+  spawn,
+  spawnSync,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, connect, type Server } from "node:net";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+import { SandboxExecutionBroker } from "../../../src/sandbox/execution-broker.js";
+import { findSystemBubblewrapInPath } from "../../../src/sandbox/linux-launcher/launcher.js";
+
+const runtimeRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const launcherEntry = join(runtimeRoot, "bin", "agenc-linux-sandbox");
+const builtLauncher = join(
+  runtimeRoot,
+  "dist",
+  "sandbox",
+  "linux-launcher",
+  "main.js",
+);
+
+test(
+  "enforces the production Linux sandbox boundary with the real kernel",
+  { timeout: 30_000 },
+  async () => {
+    expect(process.platform).toBe("linux");
+    expect(typeof process.getuid).toBe("function");
+    expect(process.getuid!()).toBeGreaterThan(0);
+    expect(effectiveCapabilities()).toBe(0n);
+    expect(existsSync(launcherEntry), launcherEntry).toBe(true);
+    expect(existsSync(builtLauncher), builtLauncher).toBe(true);
+
+    const bubblewrap = findSystemBubblewrapInPath(process.env.PATH, process.cwd());
+    expect(bubblewrap).toBe("/usr/bin/bwrap");
+    const version = spawnSync(bubblewrap!, ["--version"], {
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+    expect(
+      version.status,
+      `bubblewrap version probe failed\nstdout=${version.stdout}\nstderr=${version.stderr}`,
+    ).toBe(0);
+    expect(version.stdout.trim()).toMatch(/^bubblewrap \d+\.\d+\.\d+$/u);
+
+    const token = `agenc-kernel-e2e-${randomUUID()}`;
+    const root = mkdtempSync(join("/var/tmp", "agenc-kernel-e2e-"));
+    const workspace = join(root, "workspace");
+    const hostReadOnlyDirectory = join(root, "host-read-only");
+    const hostSentinel = join(hostReadOnlyDirectory, "sentinel.txt");
+    const hostCreate = join(hostReadOnlyDirectory, "created.txt");
+    const allowedWrite = join(workspace, "allowed.txt");
+    const evidencePath = join(workspace, "evidence.json");
+    const descendantReadyMarker = join(workspace, "descendant-ready.txt");
+    const descendantLeakMarker = join(workspace, "descendant-leak.txt");
+    const launcherSentinel = join(runtimeRoot, "dist", `.${token}.sentinel`);
+    const launcherCreate = join(runtimeRoot, "dist", `.${token}.created`);
+    mkdirSync(workspace, { mode: 0o700 });
+    mkdirSync(hostReadOnlyDirectory, { mode: 0o700 });
+    writeFileSync(hostSentinel, "host-read-only", { mode: 0o600 });
+    writeFileSync(launcherSentinel, "launcher-read-only", { mode: 0o600 });
+
+    const server = createServer();
+    let hostConnections = 0;
+    let hostPayloads: string[] = [];
+    server.on("connection", (socket) => {
+      hostConnections += 1;
+      socket.setTimeout(2_000, () => socket.destroy());
+      socket.once("data", (chunk) => {
+        hostPayloads.push(chunk.toString("utf8"));
+        socket.end("host-network-visible");
+      });
+    });
+
+    let launcher: ChildProcessWithoutNullStreams | undefined;
+    try {
+      await listen(server);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("kernel capability server did not bind a TCP port");
+      }
+
+      const baselineToken = `baseline-${token}`;
+      await expect(tcpRoundTrip(address.port, baselineToken)).resolves.toBe(
+        "host-network-visible",
+      );
+      expect(hostConnections).toBe(1);
+      expect(hostPayloads).toEqual([baselineToken]);
+      hostConnections = 0;
+      hostPayloads = [];
+
+      const childEnv = stringEnvironment(process.env);
+      delete childEnv.NODE_OPTIONS;
+      delete childEnv.AGENC_TEST_NETWORK_ATTEMPT_LEDGER;
+      const broker = new SandboxExecutionBroker({
+        mode: "workspace_write",
+        cwd: workspace,
+        env: childEnv,
+        agencLinuxSandboxExe: launcherEntry,
+      });
+      const status = broker.status();
+      expect(status, JSON.stringify(status, null, 2)).toMatchObject({
+        kind: "ready",
+        mode: "workspace_write",
+        platform: "linux",
+        helperPath: realpathSync(launcherEntry),
+        isolationProgram: "/usr/bin/bwrap",
+      });
+      expect(
+        readFileSync("/proc/self/attr/current", "utf8").trim(),
+      ).toBe("agenc-native-userns (unconfined)");
+
+      const payload = Buffer.from(
+        JSON.stringify({
+          allowedWrite,
+          descendantLeakMarker,
+          descendantReadyMarker,
+          descendantScript: Buffer.from(
+            descendantProbeScript(),
+            "utf8",
+          ).toString("base64"),
+          evidencePath,
+          host: "127.0.0.1",
+          hostCreate,
+          hostSentinel,
+          launcherCreate,
+          launcherSentinel,
+          port: address.port,
+          token,
+        }),
+        "utf8",
+      ).toString("base64");
+      const prepared = broker.prepareSpawn("tool", {
+        program: process.execPath,
+        args: [
+          "--input-type=module",
+          "--eval",
+          kernelProbeScript(),
+          payload,
+        ],
+        cwd: workspace,
+        env: childEnv,
+      });
+      expect(prepared.program).toBe(realpathSync(process.execPath));
+      expect(prepared.args[0]).toBe(realpathSync(launcherEntry));
+      expect(prepared.args).toContain("--permission-profile");
+      expect(prepared.args).toContain("--");
+
+      launcher = spawn(prepared.program, [...prepared.args], {
+        cwd: prepared.cwd,
+        env: prepared.env,
+        argv0: prepared.argv0,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const result = await waitForProcess(launcher, 20_000);
+      const diagnostics = [
+        `bubblewrap=${bubblewrap}`,
+        `version=${version.stdout.trim()}`,
+        `broker=${JSON.stringify(status)}`,
+        `prepared=${JSON.stringify({
+          program: prepared.program,
+          args: prepared.args,
+          cwd: prepared.cwd,
+          argv0: prepared.argv0,
+        })}`,
+        `status=${String(result.code)}`,
+        `signal=${String(result.signal)}`,
+        `timedOut=${String(result.timedOut)}`,
+        `stdout=${JSON.stringify(result.stdout)}`,
+        `stderr=${JSON.stringify(result.stderr)}`,
+      ].join("\n");
+
+      expect(result.timedOut, diagnostics).toBe(false);
+      expect(result.signal, diagnostics).toBeNull();
+      expect(result.code, diagnostics).toBe(0);
+      expect(existsSync(evidencePath), diagnostics).toBe(true);
+
+      const evidence = JSON.parse(readFileSync(evidencePath, "utf8")) as {
+        readonly allowedWrite: boolean;
+        readonly appArmorProfile: string;
+        readonly descendant: {
+          readonly ready: boolean;
+          readonly visibleInProc: boolean;
+        };
+        readonly hostReadOnly: {
+          readonly content: string | null;
+          readonly createError: string | null;
+          readonly visible: boolean;
+          readonly writeError: string | null;
+        };
+        readonly launcherRoot: {
+          readonly content: string | null;
+          readonly createError: string | null;
+          readonly writeError: string | null;
+        };
+        readonly network: {
+          readonly blocked: boolean;
+          readonly error: string | null;
+        };
+        readonly namespaces: {
+          readonly mnt: string;
+          readonly net: string;
+          readonly pid: string;
+          readonly user: string;
+        };
+      };
+      expect(evidence.allowedWrite).toBe(true);
+      expect(evidence.appArmorProfile).toBe(
+        "agenc-native-userns (unconfined)",
+      );
+      expect(readFileSync(allowedWrite, "utf8")).toBe("workspace-write-ok");
+      expect(evidence.hostReadOnly).toEqual({
+        content: "host-read-only",
+        createError: "EROFS",
+        visible: true,
+        writeError: "EROFS",
+      });
+      expect(readFileSync(hostSentinel, "utf8")).toBe("host-read-only");
+      expect(existsSync(hostCreate)).toBe(false);
+      expect(evidence.launcherRoot).toEqual({
+        content: "launcher-read-only",
+        createError: "EROFS",
+        writeError: "EROFS",
+      });
+      expect(readFileSync(launcherSentinel, "utf8")).toBe("launcher-read-only");
+      expect(existsSync(launcherCreate)).toBe(false);
+      expect(evidence.network).toEqual({ blocked: true, error: "EPERM" });
+      expect(evidence.namespaces.mnt).not.toBe(readlinkSync("/proc/self/ns/mnt"));
+      expect(evidence.namespaces.net).not.toBe(readlinkSync("/proc/self/ns/net"));
+      expect(evidence.namespaces.pid).not.toBe(readlinkSync("/proc/self/ns/pid"));
+      expect(evidence.namespaces.user).not.toBe(readlinkSync("/proc/self/ns/user"));
+      expect(evidence.descendant).toEqual({
+        ready: true,
+        visibleInProc: true,
+      });
+      expect(readFileSync(descendantReadyMarker, "utf8")).toBe(token);
+
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(hostConnections).toBe(0);
+      expect(hostPayloads).toEqual([]);
+      await waitForNoProcessToken(token, 2_000);
+      await new Promise((resolve) => setTimeout(resolve, 2_500));
+      expect(existsSync(descendantLeakMarker)).toBe(false);
+      expect(processesContaining(token)).toEqual([]);
+      expect(hostConnections).toBe(0);
+      expect(hostPayloads).toEqual([]);
+    } finally {
+      await terminateProcess(launcher);
+      killProcessesContaining(token);
+      await waitUntilNoProcessToken(token, 2_000);
+      await closeServer(server);
+      rmSync(root, { force: true, recursive: true });
+      rmSync(launcherSentinel, { force: true });
+      rmSync(launcherCreate, { force: true });
+    }
+  },
+);
+
+function kernelProbeScript(): string {
+  return `
+    import { spawn } from "node:child_process";
+    import {
+      existsSync,
+      readFileSync,
+      readdirSync,
+      readlinkSync,
+      writeFileSync,
+    } from "node:fs";
+    import { connect } from "node:net";
+    import { join } from "node:path";
+
+    const payload = JSON.parse(
+      Buffer.from(process.argv[1], "base64").toString("utf8"),
+    );
+
+    function errorCode(error) {
+      return typeof error?.code === "string" ? error.code : String(error);
+    }
+
+    function attemptWrite(path, value) {
+      try {
+        writeFileSync(path, value);
+        return null;
+      } catch (error) {
+        return errorCode(error);
+      }
+    }
+
+    function networkProbe() {
+      return new Promise((resolve) => {
+        let settled = false;
+        const socket = connect({ host: payload.host, port: payload.port });
+        const finish = (result) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          socket.destroy();
+          resolve(result);
+        };
+        const timer = setTimeout(
+          () => finish({ blocked: false, error: "timeout" }),
+          1500,
+        );
+        socket.once("connect", () => {
+          socket.write(payload.token);
+          finish({ blocked: false, error: null });
+        });
+        socket.once("error", (error) => {
+          const code = errorCode(error);
+          finish({ blocked: code === "EPERM", error: code });
+        });
+      });
+    }
+
+    async function waitForFile(path, timeoutMs) {
+      const deadline = Date.now() + timeoutMs;
+      while (!existsSync(path) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      return existsSync(path);
+    }
+
+    function processTokenVisible(token) {
+      for (const entry of readdirSync("/proc", { withFileTypes: true })) {
+        if (!entry.isDirectory() || !/^\\d+$/.test(entry.name)) continue;
+        try {
+          const command = readFileSync(
+            join("/proc", entry.name, "cmdline"),
+            "utf8",
+          ).split("\\0").filter(Boolean);
+          if (command.includes(token)) return true;
+        } catch {
+          // A process can exit during procfs enumeration.
+        }
+      }
+      return false;
+    }
+
+    writeFileSync(payload.allowedWrite, "workspace-write-ok");
+    const hostReadOnly = {
+      visible: existsSync(payload.hostSentinel),
+      content: existsSync(payload.hostSentinel)
+        ? readFileSync(payload.hostSentinel, "utf8")
+        : null,
+      writeError: attemptWrite(payload.hostSentinel, "sandbox-overwrite"),
+      createError: attemptWrite(payload.hostCreate, "sandbox-create"),
+    };
+    const launcherRoot = {
+      content: readFileSync(payload.launcherSentinel, "utf8"),
+      writeError: attemptWrite(payload.launcherSentinel, "sandbox-overwrite"),
+      createError: attemptWrite(payload.launcherCreate, "sandbox-create"),
+    };
+    const network = await networkProbe();
+    const survivor = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        Buffer.from(payload.descendantScript, "base64").toString("utf8"),
+        payload.descendantReadyMarker,
+        payload.descendantLeakMarker,
+        payload.token,
+      ],
+      {
+        detached: true,
+        stdio: "ignore",
+      },
+    );
+    survivor.unref();
+    const descendantReady = await waitForFile(
+      payload.descendantReadyMarker,
+      2000,
+    );
+    const descendantVisible = processTokenVisible(payload.token);
+
+    const evidence = {
+      allowedWrite: true,
+      appArmorProfile: readFileSync(
+        "/proc/self/attr/current",
+        "utf8",
+      ).trim(),
+      descendant: {
+        ready: descendantReady,
+        visibleInProc: descendantVisible,
+      },
+      hostReadOnly,
+      launcherRoot,
+      network,
+      namespaces: {
+        mnt: readlinkSync("/proc/self/ns/mnt"),
+        net: readlinkSync("/proc/self/ns/net"),
+        pid: readlinkSync("/proc/self/ns/pid"),
+        user: readlinkSync("/proc/self/ns/user"),
+      },
+    };
+    writeFileSync(payload.evidencePath, JSON.stringify(evidence));
+    const passed =
+      hostReadOnly.visible === true &&
+      hostReadOnly.content === "host-read-only" &&
+      hostReadOnly.writeError === "EROFS" &&
+      hostReadOnly.createError === "EROFS" &&
+      launcherRoot.content === "launcher-read-only" &&
+      launcherRoot.writeError === "EROFS" &&
+      launcherRoot.createError === "EROFS" &&
+      evidence.appArmorProfile === "agenc-native-userns (unconfined)" &&
+      network.blocked === true &&
+      network.error === "EPERM" &&
+      descendantReady === true &&
+      descendantVisible === true;
+    process.exit(passed ? 0 : 23);
+  `;
+}
+
+function descendantProbeScript(): string {
+  return `
+    import { writeFileSync } from "node:fs";
+
+    const [readyMarker, leakMarker, token] = process.argv.slice(1);
+    for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
+      process.on(signal, () => {});
+    }
+    writeFileSync(readyMarker, token);
+    setTimeout(() => writeFileSync(leakMarker, token), 2000);
+    setInterval(() => {}, 1000);
+  `;
+}
+
+function effectiveCapabilities(): bigint {
+  const status = readFileSync("/proc/self/status", "utf8");
+  const value = /^CapEff:\s*([0-9a-f]+)$/imu.exec(status)?.[1];
+  if (value === undefined) {
+    throw new Error("/proc/self/status did not report CapEff");
+  }
+  return BigInt(`0x${value}`);
+}
+
+function stringEnvironment(
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function waitForProcess(
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+): Promise<{
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stderr: string;
+  readonly stdout: string;
+  readonly timedOut: boolean;
+}> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, stderr, stdout, timedOut });
+    });
+  });
+}
+
+async function terminateProcess(
+  child: ChildProcessWithoutNullStreams | undefined,
+): Promise<void> {
+  if (
+    child === undefined ||
+    child.exitCode !== null ||
+    child.signalCode !== null
+  ) {
+    return;
+  }
+  const closed = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("sandbox launcher did not terminate")),
+      5_000,
+    );
+    child.once("close", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+  child.kill("SIGKILL");
+  await closed;
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function tcpRoundTrip(port: number, payload: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const socket = connect({ host: "127.0.0.1", port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("host loopback positive control timed out"));
+    }, 2_000);
+    socket.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    socket.once("connect", () => {
+      socket.write(payload);
+    });
+    socket.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+    socket.once("end", () => {
+      clearTimeout(timer);
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function waitForNoProcessToken(
+  token: string,
+  timeoutMs: number,
+): Promise<void> {
+  await waitUntilNoProcessToken(token, timeoutMs);
+  expect(processesContaining(token)).toEqual([]);
+}
+
+async function waitUntilNoProcessToken(
+  token: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (processesContaining(token).length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+function killProcessesContaining(token: string): void {
+  for (const match of processesContaining(token)) {
+    try {
+      process.kill(match.pid, "SIGKILL");
+    } catch {
+      // A matched descendant can exit between enumeration and signal delivery.
+    }
+  }
+}
+
+function processesContaining(
+  token: string,
+): Array<{ readonly command: string; readonly pid: number }> {
+  const matches: Array<{ command: string; pid: number }> = [];
+  for (const entry of readdirSync("/proc", { withFileTypes: true })) {
+    if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) continue;
+    try {
+      const command = readFileSync(join("/proc", entry.name, "cmdline"), "utf8")
+        .split("\0")
+        .filter(Boolean)
+        .join(" ");
+      if (command.includes(token)) {
+        matches.push({ command, pid: Number.parseInt(entry.name, 10) });
+      }
+    } catch {
+      // Processes can exit between directory enumeration and cmdline open.
+    }
+  }
+  return matches.sort((left, right) => left.pid - right.pid);
+}

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -188,6 +188,35 @@ describe("Linux sandbox launcher", () => {
     expect(args).toContain("--unshare-net");
   });
 
+  it("mounts launcher roots read-only and keeps proxy roots explicitly writable", () => {
+    const root = withTempDir("agenc-linux-launcher-extra-roots-");
+    const workspace = path.join(root, "workspace");
+    const launcherRoot = path.join(root, "launcher");
+    const proxyRoot = path.join(root, "proxy");
+    fs.mkdirSync(workspace);
+    fs.mkdirSync(launcherRoot);
+    fs.mkdirSync(proxyRoot);
+
+    const args = createBwrapCommandArgs(
+      ["/bin/true"],
+      restrictedFileSystemPolicy([
+        { path: { kind: "special", value: { kind: "root" } }, access: "read" },
+        { path: { kind: "path", path: workspace }, access: "write" },
+      ]),
+      workspace,
+      workspace,
+      {
+        mountProc: true,
+        networkMode: "isolated",
+        extraReadOnlyBindRoots: [launcherRoot],
+        extraWritableBindRoots: [proxyRoot],
+      },
+    ).args;
+
+    expect(bindModeForDestination(args, launcherRoot)).toBe("--ro-bind");
+    expect(bindModeForDestination(args, proxyRoot)).toBe("--bind");
+  });
+
   it("fails closed for missing read-only carveouts that cannot be typed", () => {
     const root = withTempDir("agenc-linux-launcher-missing-ro-");
     const policy = restrictedFileSystemPolicy([
@@ -826,6 +855,22 @@ function writeExecutable(filePath: string, source: string): void {
 function sliceAfter(args: readonly string[], flag: string): string[] {
   const index = args.indexOf(flag);
   return index === -1 ? [] : args.slice(index + 1, index + 3);
+}
+
+function bindModeForDestination(
+  args: readonly string[],
+  destination: string,
+): "--bind" | "--ro-bind" | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (
+      (value === "--bind" || value === "--ro-bind") &&
+      args[index + 2] === destination
+    ) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function listenOn(server: net.Server, host: string, port: number): Promise<void> {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -118,6 +118,11 @@ export const NATIVE_TEST_INCLUDE = Object.freeze([
   'tests/utils/execFileNoThrow.win32.test.ts',
 ]);
 
+/** Real Linux-kernel sandbox coverage executed on a disposable hosted runner. */
+export const KERNEL_TEST_INCLUDE = Object.freeze([
+  'tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts',
+]);
+
 /** PowerShell integration tests executed by the pinned hosted capability lane. */
 export const POWERSHELL_TEST_INCLUDE = Object.freeze([
   'tests/budget/admitted-legacy-powershell.powershell.test.ts',
@@ -153,6 +158,7 @@ export const DEFAULT_TEST_EXCLUDE = Object.freeze([
   ...DESIGN_TEST_INCLUDE,
   ...CROSS_REPO_TEST_INCLUDE,
   ...NATIVE_TEST_INCLUDE,
+  ...KERNEL_TEST_INCLUDE,
   ...POWERSHELL_TEST_INCLUDE,
   ...NEOVIM_TEST_INCLUDE,
 ]);
@@ -174,6 +180,7 @@ export type AgenCVitestMode =
   | 'design'
   | 'cross-repo'
   | 'native'
+  | 'kernel'
   | 'powershell'
   | 'neovim';
 
@@ -452,6 +459,16 @@ export function createAgenCVitestConfig(mode: AgenCVitestMode = 'default') {
               include: [...NATIVE_TEST_INCLUDE],
               exclude: [...configDefaults.exclude],
             }
+          : mode === 'kernel'
+            ? {
+                // The disposable hosted lane loads the narrow AppArmor profile
+                // and fails closed on missing kernel facilities, while the
+                // ordinary hermetic environment still strips credentials and
+                // isolates AgenC state.
+                setupFiles: ['./vitest.setup.ts'],
+                include: [...KERNEL_TEST_INCLUDE],
+                exclude: [...configDefaults.exclude],
+              }
           : mode === 'powershell'
             ? {
                 // The hosted capability lane provisions an exact PowerShell

--- a/runtime/vitest.kernel.config.ts
+++ b/runtime/vitest.kernel.config.ts
@@ -1,0 +1,6 @@
+import { createAgenCVitestConfig } from './vitest.config.ts';
+
+// Exact real-kernel bubblewrap allowlist for the disposable hosted Linux lane.
+// The test fails closed unless the runner can create real user, PID, mount,
+// and network namespaces.
+export default createAgenCVitestConfig('kernel');

--- a/scripts/required-gate-contract.mjs
+++ b/scripts/required-gate-contract.mjs
@@ -155,6 +155,7 @@ export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   "runtime/tsconfig.bundle.json",
   "runtime/tsconfig.json",
   "runtime/vitest.config.ts",
+  "runtime/vitest.kernel.config.ts",
   "runtime/vitest.native.config.ts",
   "runtime/vitest.neovim.config.ts",
   "runtime/vitest.powershell.config.ts",


### PR DESCRIPTION
## Summary

- add a zero-skip Ubuntu 24.04 capability lane that exercises the production broker → manager → packaged launcher → bubblewrap → kernel path
- prove real user/PID/mount/network namespace isolation, seccomp network denial, workspace/read-only mounts, and descendant teardown
- pin and verify the Ubuntu bubblewrap package, load the canonical narrow AppArmor profile, and assert process/profile/artifact cleanup
- mount inferred launcher roots read-only while keeping only the proxy socket directory writable

## Local verification

Exact tested SHA: `db9a3df84451ce97dee5fb5cd807d6c037bec25c`

- `npm test` — 121 required-gate tests, 22 agent-surface tests, 163 launcher tests, and 16,583 runtime tests passed; zero skipped
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- pre-commit runtime build and `check:tui-runtime-startup`
- `npm run check:sbom` — 684 canonical packages, 1,106 graph relationships
- `npm run check:agent-surface-contract -- --no-run-commands`
- SDK build and typecheck
- targeted sandbox/config suite — 64 passed
- YAML parse and every Linux workflow shell block passes `bash -n`

The local operator host intentionally fails the dedicated kernel config closed because the scoped AppArmor exception is not installed. The hosted [`linux-kernel-sandbox`](https://github.com/tetsuo-ai/agenc-core/actions/runs/30317927584/job/90147478455) job passed 1 test in 1 file with zero skipped on the exact PR SHA, including its cleanup postconditions.