### PR TITLE
fix(release): make installer promotion retries idempotent

### DIFF
--- a/.github/workflows/promote-installers.yml
+++ b/.github/workflows/promote-installers.yml
@@ -169,18 +169,22 @@ jobs:
           fi
           if [[ -n "$current" ]]; then
             [[ "$current" =~ ^[0-9a-f]{40}$ ]]
-            git merge-base --is-ancestor "$current" "$TESTED_SHA"
-            if [[ "$LANE" = installer-hotfix ]]; then
-              previous_version="$(
-                git show "${current}:package.json" |
-                  node -e 'let input="";process.stdin.on("data",c=>input+=c).on("end",()=>process.stdout.write(JSON.parse(input).version))'
-              )"
-              current_version="$(node -p 'require("./package.json").version')"
-              test "$previous_version" = "$current_version"
-              if git diff --quiet "$current" "$TESTED_SHA" -- \
-                scripts/install/install.sh scripts/install/install.ps1; then
-                echo "installer-hotfix lane requires changed installer bytes" >&2
-                exit 1
+            if [[ "$current" = "$TESTED_SHA" ]]; then
+              echo "installer-stable already points to $TESTED_SHA"
+            else
+              git merge-base --is-ancestor "$current" "$TESTED_SHA"
+              if [[ "$LANE" = installer-hotfix ]]; then
+                previous_version="$(
+                  git show "${current}:package.json" |
+                    node -e 'let input="";process.stdin.on("data",c=>input+=c).on("end",()=>process.stdout.write(JSON.parse(input).version))'
+                )"
+                current_version="$(node -p 'require("./package.json").version')"
+                test "$previous_version" = "$current_version"
+                if git diff --quiet "$current" "$TESTED_SHA" -- \
+                  scripts/install/install.sh scripts/install/install.ps1; then
+                  echo "installer-hotfix lane requires changed installer bytes" >&2
+                  exit 1
+                fi
               fi
             fi
           fi
@@ -206,11 +210,28 @@ jobs:
               --raw-field ref=refs/heads/installer-stable \
               --raw-field sha="$TESTED_SHA" >/dev/null
           fi
-          observed="$(
-            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/installer-stable" \
-              --jq .object.sha
-          )"
-          test "$observed" = "$TESTED_SHA"
+          matched=false
+          observed=""
+          for attempt in $(seq 1 30); do
+            if observed="$(
+              gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/installer-stable" \
+                --jq .object.sha 2>/dev/null
+            )"; then
+              if [[ "$observed" = "$TESTED_SHA" ]]; then
+                matched=true
+                break
+              fi
+            else
+              observed="<unreadable>"
+            fi
+            if [[ "$attempt" -lt 30 ]]; then
+              sleep 2
+            fi
+          done
+          if [[ "$matched" != true ]]; then
+            echo "installer-stable did not converge to $TESTED_SHA; last observed: $observed" >&2
+            exit 1
+          fi
 
       - name: Verify public installer bytes
         env:

--- a/packages/agenc/test/runtime-release-contract.test.mjs
+++ b/packages/agenc/test/runtime-release-contract.test.mjs
@@ -149,6 +149,34 @@ test("installer promotion is exact-SHA, fast-forward-only, and lane-scoped", () 
     workflow,
     /installer-hotfix requires an existing full-release promotion/u,
   );
+  const targetStepStart = workflow.indexOf(
+    "      - name: Verify fast-forward promotion",
+  );
+  const promoteStepStart = workflow.indexOf(
+    "      - name: Promote installer-stable",
+  );
+  const publicBytesStepStart = workflow.indexOf(
+    "      - name: Verify public installer bytes",
+  );
+  assert.ok(targetStepStart >= 0);
+  assert.ok(promoteStepStart > targetStepStart);
+  assert.ok(publicBytesStepStart > promoteStepStart);
+  const targetStep = workflow.slice(targetStepStart, promoteStepStart);
+  const promoteStep = workflow.slice(promoteStepStart, publicBytesStepStart);
+  assert.match(
+    targetStep,
+    /if \[\[ "\$current" = "\$TESTED_SHA" \]\]; then[\s\S]*else[\s\S]*git merge-base --is-ancestor "\$current" "\$TESTED_SHA"[\s\S]*installer-hotfix lane requires changed installer bytes/u,
+  );
+  assert.match(promoteStep, /matched=false/u);
+  assert.match(promoteStep, /for attempt in \$\(seq 1 30\); do/u);
+  assert.match(
+    promoteStep,
+    /if \[\[ "\$observed" = "\$TESTED_SHA" \]\]; then[\s\S]*matched=true[\s\S]*break/u,
+  );
+  assert.match(
+    promoteStep,
+    /installer-stable did not converge to \$TESTED_SHA/u,
+  );
   const toolchain = JSON.parse(readFileSync(
     new URL("../../../release-toolchain.json", import.meta.url),
     "utf8",


### PR DESCRIPTION
## Summary

- treat an already-promoted installer SHA as a successful idempotent retry
- poll GitHub ref readback for bounded convergence after ref mutation
- add step-scoped regression assertions for both recovery paths

## Context

Promotion run 30409643602 advanced installer-stable successfully, then failed because the immediate GitHub API readback was stale. Its retry then failed because the hotfix byte-change guard compared the target commit to itself.

## Verification

- npm run typecheck
- npm test: 121 required gates, 22 surface-contract tests, 164 launcher tests, 16,598 runtime tests; zero skips
- pre-commit build and TUI PTY startup smoke
- git diff --check