### PR TITLE
fix(grok): use flat Responses tool choice

### DIFF
--- a/runtime/src/llm/wire/responses-xai.ts
+++ b/runtime/src/llm/wire/responses-xai.ts
@@ -50,9 +50,12 @@ function normalizeXaiResponsesToolChoice(
     ? toolChoice.name.trim()
     : "";
   if (toolChoice.type === "function" && directName.length > 0) {
+    // xAI's /v1/responses endpoint consumes the Responses-native flat
+    // ToolChoiceFunction shape. The nested Chat Completions shape is rejected
+    // with a 422 ModelToolChoice deserialization error.
     return {
       type: "function",
-      function: { name: encodeMcpToolNameForWire(directName) },
+      name: encodeMcpToolNameForWire(directName),
     };
   }
 
@@ -63,7 +66,7 @@ function normalizeXaiResponsesToolChoice(
   if (toolChoice.type === "function" && legacyName.length > 0) {
     return {
       type: "function",
-      function: { name: encodeMcpToolNameForWire(legacyName) },
+      name: encodeMcpToolNameForWire(legacyName),
     };
   }
 

--- a/runtime/tests/llm/wire/responses-xai.test.ts
+++ b/runtime/tests/llm/wire/responses-xai.test.ts
@@ -270,7 +270,7 @@ describe("responses-xai wire shim", () => {
       // an entry in `tools` byte-for-byte.
       tool_choice: {
         type: "function",
-        function: { name: TEST_TOOL_WIRE_NAME },
+        name: TEST_TOOL_WIRE_NAME,
       },
       tools: [
         {


### PR DESCRIPTION
## What changed

- Serialize named xAI Responses API tool choices using the flat `{ type: "function", name }` shape.
- Keep provider-safe MCP tool-name encoding unchanged.
- Update the xAI wire regression test to assert the accepted request shape.

## Why

Parallel SWARM routes force-select `spawn_agent` on the initial model call. AgenC was sending the nested Chat Completions selector shape, which xAI's `/v1/responses` endpoint rejected with HTTP 422 (`ModelToolChoice` deserialization failure). The turn then ended before the first token and the TUI appeared to lose its daemon agent.

## Impact

Explicit parallel SWARM tasks can now complete the forced initial `spawn_agent` request instead of failing silently at provider dispatch.

## Validation

- `responses-xai` and Grok adapter suites: 29 tests passed
- SWARM initial-spawn regression: passed
- Runtime TypeScript typecheck: passed
- Runtime production build and package-entrypoint checks: passed
- Live YOLO + SWARM smoke test: three read-only workers spawned and completed successfully
