### PR TITLE
fix(tui): derive portable logo from brand raster

### DIFF
--- a/runtime/src/tui/components/v2/agencLogoGraphics.generated.ts
+++ b/runtime/src/tui/components/v2/agencLogoGraphics.generated.ts
@@ -6,5 +6,28 @@
 // terminal-cell rectangle. Keep the SVG as the source of truth.
 export const AGENC_LOGO_RASTER_SIZE = 160
 
+// Portable monochrome previews generated from the same alpha raster at a 0.22
+// coverage threshold. Each Braille cell encodes a 2×4 sample grid, preserving
+// the official mark's geometry in terminals without an image protocol.
+export const AGENC_LOGO_BRAILLE_LINES = [
+  '⣠⣾⡷⠺⡷⠺⣷⣄⡀⠀⣠⣾⠷⢾⡷⠾⣷⣄',
+  '⣨⣯⠀⠀⠀⠀⠈⢻⣿⣿⡟⠁⠀⠀⠀⠀⣸⣧',
+  '⣼⣧⡀⠀⠀⢀⣴⣿⠟⠻⣿⣦⣀⠀⠀⢀⣼⣧',
+  '⠀⠙⢿⣦⣾⡿⠟⠁⠀⠀⠈⠙⢿⣷⣴⡿⠋⠁',
+  '⠀⣠⣾⠿⢿⣷⣦⡀⠀⠀⢀⣠⣾⡿⠻⣷⣄⡀',
+  '⢻⡟⠁⠀⠀⠈⠻⣿⣦⣴⣿⠟⠉⠀⠀⠈⢻⡟',
+  '⢙⣟⠀⠀⠀⠀⢀⣼⣿⣿⣧⡀⠀⠀⠀⠀⢻⡟',
+  '⠙⢿⡷⢴⡷⢴⡿⠋⠁⠀⠙⢿⡶⢾⡷⢶⡿⠋',
+] as const
+
+export const AGENC_LOGO_BRAILLE_COMPACT_LINES = [
+  '⢴⡿⠒⠗⠺⣶⣄⣠⣴⠗⠺⠓⢿⣦',
+  '⢺⡂⠀⠀⠀⣨⣿⣿⣅⡀⠀⠀⢐⣗',
+  '⠙⠿⣦⣴⡿⠛⠁⠀⠙⢿⣦⣴⡿⠋',
+  '⣠⣴⠟⠻⣷⣄⡀⠀⣠⣾⠟⠻⣶⣄',
+  '⢽⡅⠀⠀⠈⢙⣿⣿⡛⠁⠀⠀⠨⡯',
+  '⠺⣷⢤⡦⢴⡿⠋⠙⠿⣦⢴⡤⣶⠗',
+] as const
+
 export const AGENC_LOGO_RGBA_ZLIB_BASE64 =
   'eNrt3W1z3DQQB/ALDPA5YaAtbZOmSdvLpQczhaRJc8eFkD4k4T28gcIwfD2y1IwdFJ8fJO1K2pVWH+AfW/5FZ8vyajLBNwDYBYATgpzHALAkyLkDABcAsDER3qpzAICfAGCTIOsYAKYEOYcAsM+kfyp7TVsg7TVtibR3XedcSjZY2zuvz6U6p4eIrCOjf6dIe03bZ2SvaSceOdsdOUuPnK8MeyDZYMseYAy27DU5j5D2khrssedssMees8EeeyIN9tjzMthhz8zZQtpLYnDEnrXBEXvWBkfsiTI4Ys/JIAC8tMjZQtqLatDS3qhBS3ujBi3tiTBoPGvYtEGDFvbMnM2BnAOH67TPyF7TXiHt9RoEgC8B4B/HHJYGHe0NGrQcr0YNOtoLatDT3prB2t61Z84SaY+lQU97pp0HCHudBj3tBTEIAM8A315U9xoIe007RtprGov5QaS9Wwar/3OCnPsDzywu7SmDca99vacEOT8TH9OGcHtNmwPAa6Kcc6Jj2mdkb4NgLL0CgI/qnB3JBontPTcyMQbnDs/gQQ2GHGM8Dd7YM3JEGiS2t9+R/drXnuM8UBCDMX7fHA2u2ZNqMKQ9hME5Yi6S1GDMeytLg1cWOSIMxrDnYXBOMB9OdczR7+tHnkmuHHJYG4xpz8HgnPCdDHbMTvZM2WPwyiOHpcEU9iwMzj1yghjkMJ/RMniJyGFlMKW9AYNzRA6pQU5zabXBS4IcKoM/Yo6Fg70Og3OCHDKDRHPdZ9zeqaY2yMleoHvZdwTndUzwro/tOndCg6cu50hsb8Z4rQ5mrntBsNaB/TcWsQ2WYI/A4IJgrZeY73tiGSzJHsLgYiTvICd7sQzW1+GsJHseBheWeYc52QthUO05GzxxzDvMyV4og2rPyuCJZ95hTvYc3zvbtBXh/d5OJn3bNniCzDvMyV6AcZCi7WXWt41BipoYW1RrqdVg/vaMvn0OAPeQGXeN7zX21aDas+zTp/X5edcMadkDNaj2HO2BYXCTwF7TnqtBtWdpz9ngiD01qPZc7VkbtLSnBtWeqz3T4BaBPTWo9lzt9Rr0tIdaS1vQHHXVHqu9NYOPCOxlaZB4ja/z+sHM7d0yWL9DQq+9V3tlGay/k8C2Hyb/16X2bT/3fRsu1N5PAZ8/TjN6h1711RvCNUTHai+oPTXYY8/ToNpTg03fvcXaM7J+VHtqMJDBlWXWmdpTgx59+Q5jz8Kg2lODPgZXnllnGds7Az4tZ4Mrguuk9tSgax9fYOwZWfco9r5Te7hnQ4F9XdUV+hyZ0bybQ+19l7G9PwDgLzXYaQ/qPQq+QNoD7FrqjO19AgCfqsFOe+BrcGB/Dac96zK29zcAfGb8jU9rj0XfD7b20G27+RppT6RB5LvtUXtqcNSe6eY+0p4og7HslW7Qwt6oQY89rVgbjG2vVIMO9noNIvZTY2kwlb3SDHrYWzNIsJcfG4P1s8YypT3jWD7J2SDCnunmAXINIZu5mUDPue8rR4hjqsbBP3ObmyGsWX9OuN482TjIadzLfRwkGPeadmXsSSnWIGd7uRkMYa91HUUZrI95QXxdf8f85uZqMKS91vV8S2TwYYQ+oR733oewJ/1+kPB7/DcWe0mKGAdHalSzGfekj4Mxxj1pBqXaaxl8z91gCnvcDUq3J8VgSntcDeZij7tBDva4GczNHleDnOxxMfjhufFljva4GSS29xFxHyUxmLs9LgY520tlsBR7qQ1KsBfbYGn2UhmUZC+WwVLtxTYo0V5og6XbM/rhYwD4NZRByfYCvS/erOphqr21cfD3AAap3ue+S70eNmC92qLtBR4HKRqbmiwMDWZhj7FBdvWAGBnMyl7L4C9qj7XBLO0xMsi+DlpCg7/lbI+BQTE1+BIYLMJeQoPi6j9GNFiUvQQGxdYejWCwSHsRDYqvexvQYNH2IhjMqebykT7rivN3lUM96kD21GCc31/RBgPbK9pgxOcPkQYj2SvSYIL5F1EGI9srymDC+WcRBhPZK+n9W8p1CKwNJrZXwvoDDmtgWBpkYk/XXxVokJk9XX8ap11yMEhobxZgP1Tp6+9D2LsgrJ+b1CChvb1JuD159fuj2/aovz9KYpDanpFbvMHQ9oy/I9JgKHtqMJi9y4Hvz3ckGSTc22Vv5O8UZzC2PWkGY9kr0WCgmgeXDvWHWBuMba8kg6ntcTeYyl4JBrnY42owtb2cDQayR1HzloVBLvZyNMjVHheD3OzlZJC7vQAGL1yOjau9lsFziQal2EtlsK7PRdF2Al/HDaK9Y832W+D9t0LYexN63hcAnhEd69nQsRKOe7NIv2NixkFp417H8e+GHAel2ZNkULq90Aal2pNgMBd7oQwCwIoobzfxPC67+0Gp93sW5zUlOpfqWeNuXX9Z3LjHeRzMbdwLMA7e1J1HGmRhj5PB3O0RGPyv3nwry8cgK3scDHJ7n8vQ4Jo9T4Ms7aU0WJo9D4OVrYcjWTYGWdtLYbC290dp9hwMjtozsu4MGBRhL6bB0u1ZGKwsPXDM2uowuDsR2ELOzQSydy617ln1zr/D3j3PrE3DoEh7LYNvAxhUe/0GKzt3kVmVwSeTDFogg2qvu6+regJ3CHKOJN6LRL4fLPJ+b6SPXwPAEpnzMuP+OVd7Qe01bUlgTw2GaxcZ2/MyOLIH9GUB/aX26P+flwT21KDaw/yWLEdyDvWeRe0Fvo9ZEthTg2oP8y3iksBeSffPao/O3i2DRGvvzyaZtIAG1d56Oyb6vvPbSUYtgMFs7Bl9RLEGf3+C/8Y4K3tG/z4l9LeZaR9hDM5aWTtqD9UXVt86qMH+NXyO9YC/UXtq0MPgbCTrccH2HkPYVrrBPYLroPbUYF8fPsPaG7keak8N+hicElyXudpTg44Gq3N8hMzalfbNkQB7JRj8Bmuvzvm+qhGj9tSgQ99u1LX+XhHYa9oqo/6hmmM5I/quLhuDhr2mvSKwl41BwnGvqR9G9S70muL3ipk9L4MA8N1AP63U3lr9xOINDthzMjhiT6zBUPbUoJU9K4OW9sQZDG2vZIMO9gYNOtoTYzCWvRINetjrNPgh5wWin1ZqrzyDCHu3DCLtsTUIANsp144S79M0zczejUHCdZYrgvN6QpST1B5Hg4aZGRN7N+sJOBis7TXtVLo9TgY7zMy42DOykxls2bsx6LF/Mit7HAwOmJlxsZfSYI89Z4Nc7aU0aGFmxsVeCoMj9pr2bswDd3spDDqYmXGxF9Ogpb1RF1LsBTK4R2RmFsHenOCejMSgZ/aaD2n2YhhEmJlxsRfSIDLzxolUeyENEpiZcbEXwiBR1kWq9xrMDc6IzOxzsUdscEHkhmrPRBY1MYgMXtf7ZRxRPNdY1oCMYo/I4ILoneypkYMxyKoeC9LgrbXTSINTI+clF3tIgwuidQGnHTk+BlnWAvI02Llu39PgtCPHpy7f88D99ARjz/PZ9XQgx8Ug6zpUjgYHvxlxNDgdyDnkYs84pl2MPUeDpxY5NgZF1ECzNHhtU1PL0uDUIueQiz1LgwuHnG2MPSNnaM9EUfX3Rgxeu9RzGzE4dcg54GJvxODCI2e7w86pR06XQZG1H3sMXvvUEuwxOPXIOeBir8fgApFjGsSsvzINiq472jJ4jalj2TI4ReQccLFnHFM1Z3REkPOIaP3pZj2HKr7mrVEL+AFBVjV3uk2QU9VtfkZxfv8C269hCg=='

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -17,6 +17,8 @@ import {
   useWorkbenchTranscriptLayout,
 } from '../../workbench/transcriptLayoutContext.js'
 import {
+  AGENC_LOGO_BRAILLE_COMPACT_LINES,
+  AGENC_LOGO_BRAILLE_LINES,
   AGENC_LOGO_RASTER_SIZE,
   AGENC_LOGO_RGBA_ZLIB_BASE64,
 } from './agencLogoGraphics.generated.js'
@@ -783,29 +785,12 @@ function useWelcomeHeroWidth(): number {
   return Math.min(capped, usable)
 }
 
-// Portable fallback for terminals without a graphics protocol. In Kitty the
-// component below replaces these block cells with the exact rasterization of
-// `tui/assets/agenc-logo.svg`, the official AgenC symbol served by
-// marketplace.agenc.tech.
-export const AGENC_LOGO_MARK_LINES = [
-  '▄█▀█▀█▄  ▄█▀█▀█▄',
-  '█▄    ▀██▀    ▄█',
-  '█▄   ▄█▀▀█▄   ▄█',
-  ' ▀█▄█▀    ▀█▄█▀',
-  ' ▄█▀█▄    ▄█▀█▄',
-  '█▀   ▀█▄▄█▀   ▀█',
-  '█▀    ▄██▄    ▀█',
-  '▀█▄█▄█▀  ▀█▄█▄█▀',
-] as const
-
-export const AGENC_LOGO_MARK_COMPACT_LINES = [
-  '▄▀▀▀█▄▄█▀▀▀▄',
-  '█   ▄██▄   █',
-  '▀█▄█▀  ▀█▄█▀',
-  '▄█▀█▄  ▄█▀█▄',
-  '█   ▀██▀   █',
-  '▀▄▄▄█▀▀█▄▄▄▀',
-] as const
+// Portable fallback for terminals without a graphics protocol. These Braille
+// cells are sampled from the same official raster used by Kitty, so Apple
+// Terminal and other text-only terminals no longer drift to a hand-drawn mark.
+export const AGENC_LOGO_MARK_LINES = AGENC_LOGO_BRAILLE_LINES
+export const AGENC_LOGO_MARK_COMPACT_LINES =
+  AGENC_LOGO_BRAILLE_COMPACT_LINES
 
 // Unicode image placeholders encode the low 24 bits of the image ID in their
 // foreground color. White therefore gives us a collision-resistant ID while

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -31,6 +31,63 @@ import {
   WelcomeColdPanel,
 } from './primitives.js'
 
+const BRAILLE_ALPHA_THRESHOLD = 0.22
+const BRAILLE_DOT_BITS = [
+  [0x01, 0x08],
+  [0x02, 0x10],
+  [0x04, 0x20],
+  [0x40, 0x80],
+] as const
+
+function renderLogoBraille(
+  raster: Buffer,
+  columns: number,
+  rows: number,
+): readonly string[] {
+  const sampleColumns = columns * 2
+  const sampleRows = rows * 4
+
+  function sampleAlpha(sampleColumn: number, sampleRow: number): boolean {
+    const xStart = Math.floor(
+      (sampleColumn * AGENC_LOGO_RASTER_SIZE) / sampleColumns,
+    )
+    const xEnd = Math.floor(
+      ((sampleColumn + 1) * AGENC_LOGO_RASTER_SIZE) / sampleColumns,
+    )
+    const yStart = Math.floor(
+      (sampleRow * AGENC_LOGO_RASTER_SIZE) / sampleRows,
+    )
+    const yEnd = Math.floor(
+      ((sampleRow + 1) * AGENC_LOGO_RASTER_SIZE) / sampleRows,
+    )
+    let alpha = 0
+    let pixels = 0
+
+    for (let y = yStart; y < yEnd; y += 1) {
+      for (let x = xStart; x < xEnd; x += 1) {
+        alpha += raster[(y * AGENC_LOGO_RASTER_SIZE + x) * 4 + 3] ?? 0
+        pixels += 1
+      }
+    }
+
+    return alpha / (pixels * 255) >= BRAILLE_ALPHA_THRESHOLD
+  }
+
+  return Array.from({ length: rows }, (_, row) =>
+    Array.from({ length: columns }, (_, column) => {
+      let dots = 0
+      for (let dotRow = 0; dotRow < 4; dotRow += 1) {
+        for (let dotColumn = 0; dotColumn < 2; dotColumn += 1) {
+          if (sampleAlpha(column * 2 + dotColumn, row * 4 + dotRow)) {
+            dots |= BRAILLE_DOT_BITS[dotRow]![dotColumn]!
+          }
+        }
+      }
+      return String.fromCodePoint(0x2800 + dots)
+    }).join(''),
+  )
+}
+
 describe('v2 primitives', () => {
   it('renders the runtime-bound mode switcher state with the current mode selected', async () => {
     const output = await renderToString(
@@ -147,6 +204,23 @@ describe('v2 primitives', () => {
     // Transparent canvas plus opaque white brand geometry.
     expect(raster.includes(Buffer.from([0, 0, 0, 0]))).toBe(true)
     expect(raster.includes(Buffer.from([255, 255, 255, 255]))).toBe(true)
+  })
+
+  it('derives both portable logo sizes from the official raster', () => {
+    const raster = inflateSync(
+      Buffer.from(AGENC_LOGO_RGBA_ZLIB_BASE64, 'base64'),
+    )
+
+    expect(AGENC_LOGO_MARK_LINES).toEqual(renderLogoBraille(raster, 18, 8))
+    expect(AGENC_LOGO_MARK_COMPACT_LINES).toEqual(
+      renderLogoBraille(raster, 14, 6),
+    )
+    expect(AGENC_LOGO_MARK_LINES.every(line => stringWidth(line) === 18)).toBe(
+      true,
+    )
+    expect(
+      AGENC_LOGO_MARK_COMPACT_LINES.every(line => stringWidth(line) === 14),
+    ).toBe(true)
   })
 
   it('detects Kitty directly but keeps multiplexers and other terminals on the fallback', () => {


### PR DESCRIPTION
## What changed

- replaces the hand-drawn welcome-logo fallback with full and compact monochrome Braille previews generated from the official 160×160 AgenC raster
- keeps the exact Kitty Graphics raster path unchanged
- adds a regression test that re-derives both portable previews from the raster and verifies their terminal-cell widths

## Why

Apple Terminal and other terminals without the Kitty Graphics protocol could not display the official raster, so they fell back to a separate hand-authored mark that looked like the old logo. The portable fallback now comes from the same SVG/raster source of truth.

## Impact

macOS users and users of other text-only terminals see a faithful monochrome AgenC mark in the welcome view; Kitty users continue to see the exact raster logo.

## Checks

- focused welcome/logo tests: 26 passed
- workbench render tests: 52 passed
- runtime typecheck: passed
- runtime build and package contracts: passed
- design-state smoke: 96 passed / 7 existing stale-fixture failures, identical on `main`
