### PR TITLE
fix(release): honor declared package executables

### DIFF
--- a/packages/agenc/test/package-mode-contract.test.mjs
+++ b/packages/agenc/test/package-mode-contract.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { create as createTar } from "tar";
+
+import { assertCanonicalNpmPackageModes } from "../../../scripts/check-clean-build.mjs";
+
+async function writePackageTarball(packageRoot, tarball) {
+  await createTar(
+    {
+      cwd: packageRoot,
+      file: tarball,
+      gzip: true,
+      portable: true,
+      prefix: "package/",
+    },
+    ["package.json", "README.md", "bin", "dist"],
+  );
+}
+
+test("npm package modes honor declared non-bin executables", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agenc-package-modes-"));
+  const packageRoot = join(root, "package");
+  const validTarball = join(root, "valid.tgz");
+  const invalidTarball = join(root, "invalid.tgz");
+  try {
+    mkdirSync(join(packageRoot, "bin"), { recursive: true, mode: 0o755 });
+    mkdirSync(join(packageRoot, "dist"), { recursive: true, mode: 0o755 });
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      `${JSON.stringify({
+        name: "@tetsuo-ai/mode-fixture",
+        bin: { fixture: "bin/fixture" },
+        agencExecutableFiles: ["dist/process-broker"],
+      })}\n`,
+      { mode: 0o644 },
+    );
+    writeFileSync(join(packageRoot, "README.md"), "fixture\n", { mode: 0o644 });
+    writeFileSync(join(packageRoot, "bin", "fixture"), "#!/bin/sh\n", {
+      mode: 0o755,
+    });
+    writeFileSync(join(packageRoot, "dist", "process-broker"), "binary\n", {
+      mode: 0o755,
+    });
+    for (const directory of [
+      join(packageRoot, "bin"),
+      join(packageRoot, "dist"),
+    ]) {
+      chmodSync(directory, 0o755);
+    }
+    for (const file of [
+      join(packageRoot, "package.json"),
+      join(packageRoot, "README.md"),
+    ]) {
+      chmodSync(file, 0o644);
+    }
+    chmodSync(join(packageRoot, "bin", "fixture"), 0o755);
+    chmodSync(join(packageRoot, "dist", "process-broker"), 0o755);
+
+    await writePackageTarball(packageRoot, validTarball);
+    await assert.doesNotReject(
+      assertCanonicalNpmPackageModes(validTarball, packageRoot),
+    );
+
+    chmodSync(join(packageRoot, "dist", "process-broker"), 0o644);
+    await writePackageTarball(packageRoot, invalidTarball);
+    await assert.rejects(
+      assertCanonicalNpmPackageModes(invalidTarball, packageRoot),
+      /package\/dist\/process-broker:644 \(expected 755\)/u,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-clean-build.mjs
+++ b/scripts/check-clean-build.mjs
@@ -440,11 +440,28 @@ function requireFile(path, label) {
   }
 }
 
-async function assertCanonicalNpmPackageModes(tarball, workspaceRoot) {
+export async function assertCanonicalNpmPackageModes(tarball, workspaceRoot) {
   const pkg = JSON.parse(readFileSync(join(workspaceRoot, "package.json"), "utf8"));
   const bins = typeof pkg.bin === "string" ? [pkg.bin] : Object.values(pkg.bin ?? {});
+  if (bins.some((path) => typeof path !== "string")) {
+    throw new Error(`${pkg.name ?? workspaceRoot} has an invalid bin mapping`);
+  }
+  const executableFiles = pkg.agencExecutableFiles ?? [];
+  if (
+    !Array.isArray(executableFiles) ||
+    executableFiles.some(
+      (path) =>
+        typeof path !== "string" ||
+        path.length === 0 ||
+        /[*?![\]{}]/.test(path),
+    )
+  ) {
+    throw new Error(`${pkg.name ?? workspaceRoot} has an invalid agencExecutableFiles list`);
+  }
   const executable = new Set(
-    bins.map((path) => `package/${String(path).replace(/^\.\//, "")}`),
+    [...bins, ...executableFiles].map(
+      (path) => `package/${path.replace(/^\.\//, "")}`,
+    ),
   );
   const invalid = [];
   await listTar({
@@ -1377,7 +1394,12 @@ async function main() {
   }
 }
 
-await main().catch((error) => {
-  console.error(`[clean-build] FAILED: ${error?.stack ?? error}`);
-  process.exitCode = 1;
-});
+if (
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main().catch((error) => {
+    console.error(`[clean-build] FAILED: ${error?.stack ?? error}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- teach the clean-build npm mode validator about `agencExecutableFiles`
- preserve the required executable mode for generated native process brokers
- add a synthetic tarball regression covering ordinary files, package bins, and declared helper executables

## Root cause

The runtime canonicalizer correctly shipped `dist/agenc-process-broker` as `0755`, but the clean-build validator only recognized package `bin` entries and incorrectly demanded `0644` for the declared helper executable.

## Validation

- `npm test` — 122 required gates, 22 agent-contract tests, 165 launcher tests, 17,246 runtime tests; zero failures/skips
- `npm run typecheck` — zero errors
- focused package-mode regression — pass
- pre-commit runtime build and PTY startup smoke — pass
- `npm run check:clean-build -- --skip-docker` — two pristine builds byte-reproducible; 569 installed packages and 6 artifacts

The first clean-build retry passed the original package-mode failure, then exhausted the host `/tmp` tmpfs during its second install. The identical command completed successfully with a private temp root on the main filesystem.