### PR TITLE
fix(release): tolerate reviewed runner rollout

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -923,12 +923,26 @@ jobs:
           observed = {
               "runnerLabel": os.environ.get("AGENC_RUNNER_LABEL"),
               "imageOS": os.environ.get("ImageOS"),
-              "imageVersion": os.environ.get("ImageVersion"),
               "runnerArch": os.environ.get("RUNNER_ARCH"),
           }
           for field, actual in observed.items():
               if actual != contract[field]:
                   raise SystemExit(f"hosted runner drift for {slug} {field}: {actual!r} != {contract[field]!r}")
+          image_version = os.environ.get("ImageVersion")
+          alternate_image_versions = contract.get("alternateImageVersions", [])
+          if not isinstance(alternate_image_versions, list):
+              raise SystemExit(f"invalid reviewed alternate image versions for {slug}")
+          image_versions = [contract["imageVersion"], *alternate_image_versions]
+          if (
+              any(not isinstance(value, str) or not value for value in image_versions)
+              or len(set(image_versions)) != len(image_versions)
+          ):
+              raise SystemExit(f"invalid reviewed image versions for {slug}")
+          if image_version not in image_versions:
+              raise SystemExit(
+                  f"hosted runner drift for {slug} imageVersion: "
+                  f"{image_version!r} not in {image_versions!r}"
+              )
           def capture(*command):
               return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
           xcode = capture("xcodebuild", "-version")
@@ -960,7 +974,7 @@ jobs:
           )
           builder = ":".join((
               "github-hosted", contract["runnerLabel"], contract["imageOS"],
-              contract["imageVersion"], contract["runnerArch"],
+              image_version, contract["runnerArch"],
           ))
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8", newline="\n") as environment:
               environment.write(f"AGENC_BUILDER_ID={builder}\n")

--- a/FIX_RELEASE.MD
+++ b/FIX_RELEASE.MD
@@ -1,0 +1,166 @@
+# Fix the AgenC Release Process
+
+## Problem
+
+An AgenC release currently takes hours because the release tooling records
+state but does not orchestrate the complete process. An operator or AI must
+manually:
+
+- Run and monitor several workflows.
+- Copy SHA, evidence, and workflow-run identifiers between commands.
+- Download, verify, and re-upload 17 candidate files.
+- Create candidate and source tags.
+- Assemble manifests, attestations, and the final GitHub release.
+- Promote installers, deploy the website, update Homebrew, and publish npm.
+- Check every public channel for convergence.
+
+The verification itself is not the main bottleneck. Most of the delay is
+serial coordination, repeated checks, and manual recovery.
+
+## Goal
+
+Provide one deterministic and resumable command:
+
+```bash
+npm run release:run -- --version 0.13.0
+```
+
+The command should complete the release automatically, pausing only for a
+genuine failure or the required npm production approval.
+
+Target:
+
+- 45 to 75 minutes of elapsed time under normal CI conditions.
+- Less than five minutes of operator involvement.
+- No manual source-tag creation.
+- Safe resume from the last publicly verified checkpoint.
+
+## Target release flow
+
+```text
+exact-main verification + Rocky/toolchain proof
+                         |
+               five native candidates
+                         |
+              immutable candidate escrow
+                         |
+               exact source tag creation
+                         |
+              tagged byte re-attestation
+                         |
+              immutable GitHub release
+                         |
+       +-----------------+------------------+
+       |                 |                  |
+   installers         Homebrew          npm + website
+       +-----------------+------------------+
+                         |
+                convergence smokes
+```
+
+## Required changes
+
+### 1. Add a release controller
+
+Extend the release state tooling with a `run` command that:
+
+- Dispatches each required workflow.
+- Watches jobs to completion.
+- Validates outputs before advancing.
+- Records checkpoints automatically.
+- Queries public state when resuming.
+- Treats an already-correct public result as success.
+- Stops with a precise recovery instruction when a gate fails.
+
+The controller should be a scheduler around the existing validators, not a
+replacement for their security checks.
+
+### 2. Automate candidate escrow and source tags
+
+After all five candidate builders and the candidate seal pass, a narrowly
+scoped GitHub App should:
+
+1. Verify the exact candidate receipt and all 17 files.
+2. Publish the immutable candidate escrow.
+3. Confirm the escrow through GitHub's public API.
+4. Atomically create `agenc-vX.Y.Z` at the verified source SHA.
+
+Operators and AI should never create release tags manually. This removes the
+largest source of wrong-version and wrong-commit releases.
+
+### 3. Run source verification once
+
+Run typecheck, sharded tests, PTY startup, clean-build checks, and compatible
+toolchain checks concurrently against the exact merged `main` SHA.
+
+Produce signed evidence keyed by:
+
+```text
+source SHA + release-toolchain.json digest + lockfile digest
+```
+
+Resumed releases must consume that evidence instead of rerunning successful
+gates. Immutable bootstrap proofs may be reused when their toolchain inputs
+have not changed.
+
+### 4. Assemble the final release in CI
+
+Tagged promotion should automatically:
+
+- Re-attest the escrowed candidate bytes without rebuilding them.
+- Generate runtime manifests and the SBOM.
+- Validate the complete release inventory.
+- Create and verify the immutable GitHub release.
+
+No release assets should need to pass through an operator's filesystem.
+
+### 5. Promote downstream channels concurrently
+
+Once the immutable GitHub release exists:
+
+- Promote the stable installers automatically.
+- Deploy get.agenc.ag only when its tracked bytes changed.
+- Generate the Homebrew formula directly from the release manifest.
+- Open and auto-merge the Homebrew PR after both macOS jobs pass.
+- Dispatch npm trusted publishing behind its existing production approval.
+- Run isolated installation and update smokes for every channel.
+
+These operations should run in parallel wherever their dependencies allow it.
+
+## Safety guarantees to preserve
+
+Automation must not weaken the current release contract:
+
+- Every release is bound to one exact merged source SHA.
+- No source tag exists before all native candidates pass.
+- Candidate artifacts come only from workflow attempt one.
+- Candidate escrow and the final release are immutable.
+- Tagged promotion reuses verified candidate bytes and never rebuilds them.
+- All five native targets and the glibc 2.28 floor remain enforced.
+- Build and tag provenance remain independently verified.
+- npm production publishing retains its human approval boundary.
+- Completion requires public convergence across every supported channel.
+
+## Implementation order
+
+1. Add `release:run` to dispatch, monitor, resume, and checkpoint the existing
+   process.
+2. Move candidate escrow and source-tag creation into trusted automation.
+3. Move final release assembly and validation into the workflow.
+4. Automate installer, website, Homebrew, and npm promotion.
+5. Parallelize source gates and reuse unchanged toolchain evidence.
+6. Add an end-to-end dry-run lane that exercises the whole state machine
+   without publishing public versions.
+
+## Definition of done
+
+A release is fixed when an operator can run one command, approve npm once, and
+receive a final report containing:
+
+- The exact source SHA and release tag.
+- Candidate and final immutable release URLs.
+- All five native artifact digests.
+- Installer, website, Homebrew, and npm publication results.
+- End-to-end installation and update smoke results.
+- A complete checkpoint ledger suitable for safe resume and audit.
+

--- a/docs/design/reproducible-installs-releases.md
+++ b/docs/design/reproducible-installs-releases.md
@@ -114,12 +114,16 @@ Research was refreshed on 2026-07-27. The load-bearing sources are:
   [`actions/attest` multiple subjects](https://github.com/actions/attest#identify-multiple-subjects),
   [`npm dist-tag`](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag),
   [GitHub release assets](https://docs.github.com/rest/releases/assets)
-- GitHub-hosted native runner labels receive weekly mutable images. The exact
-  image versions reviewed for this release contract are macOS arm64
-  `20260727.0256.1`, macOS x64 `20260720.0353.1`, and Windows x64
-  `20260714.173.1`; their release inventories are the primary source for the
-  pinned Xcode, SDK, Visual Studio, MSVC, and Windows SDK identities.
-  [macOS arm64 image](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260727.0256),
+- GitHub-hosted native runner labels receive weekly mutable images. During an
+  image rollout, GitHub may schedule jobs on either the previous GA image or
+  the deploying image. The exact image versions reviewed for this release
+  contract are macOS arm64 `20260715.0234.1` and `20260727.0256.1`, macOS x64
+  `20260720.0353.1`, and Windows x64 `20260714.173.1`; their release inventories
+  are the primary source for the pinned Xcode, SDK, Visual Studio, MSVC, and
+  Windows SDK identities. Artifact metadata and builder identity record the
+  exact accepted image that ran the build.
+  [macOS arm64 GA image](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260715.0234),
+  [macOS arm64 rollout image](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260727.0256),
   [macOS x64 image](https://github.com/actions/runner-images/releases/tag/macos-15%2F20260720.0353),
   [Windows x64 image](https://github.com/actions/runner-images/releases/tag/win25-vs2026%2F20260714.173)
 - Node 26.5.0 is the Current release, carries module ABI 147 and npm 11.17.0,

--- a/packages/agenc/scripts/build-runtime-tarball.mjs
+++ b/packages/agenc/scripts/build-runtime-tarball.mjs
@@ -573,9 +573,26 @@ export function canonicalizeRpmContentInventory(inventory, allowedSigningKeyIds)
   };
 }
 
-function expectedHostedBuilder(contract) {
+function reviewedHostedImageVersions(contract, slug) {
+  const alternates = contract.alternateImageVersions ?? [];
+  if (
+    typeof contract.imageVersion !== "string" ||
+    contract.imageVersion.length === 0 ||
+    !Array.isArray(alternates) ||
+    alternates.some((value) => typeof value !== "string" || value.length === 0)
+  ) {
+    throw new Error(`release-toolchain.json has invalid hosted image versions for ${slug}`);
+  }
+  const versions = [contract.imageVersion, ...alternates];
+  if (new Set(versions).size !== versions.length) {
+    throw new Error(`release-toolchain.json has duplicate hosted image versions for ${slug}`);
+  }
+  return versions;
+}
+
+function expectedHostedBuilder(contract, imageVersion) {
   return `github-hosted:${contract.runnerLabel}:${contract.imageOS}:` +
-    `${contract.imageVersion}:${contract.runnerArch}`;
+    `${imageVersion}:${contract.runnerArch}`;
 }
 
 export function assertHostedRunnerContract(metadata, contract, slug) {
@@ -585,7 +602,6 @@ export function assertHostedRunnerContract(metadata, contract, slug) {
   for (const [field, metadataField] of [
     ["runnerLabel", "runnerLabel"],
     ["imageOS", "runnerImage"],
-    ["imageVersion", "runnerImageVersion"],
     ["runnerArch", "runnerArch"],
   ]) {
     if (typeof contract[field] !== "string" || metadata[metadataField] !== contract[field]) {
@@ -595,7 +611,14 @@ export function assertHostedRunnerContract(metadata, contract, slug) {
       );
     }
   }
-  const builder = expectedHostedBuilder(contract);
+  const imageVersions = reviewedHostedImageVersions(contract, slug);
+  if (!imageVersions.includes(metadata.runnerImageVersion)) {
+    throw new Error(
+      `release ${slug} runnerImageVersion does not match release-toolchain.json: ` +
+      `${metadata.runnerImageVersion ?? "missing"} not in ${imageVersions.join(", ")}`,
+    );
+  }
+  const builder = expectedHostedBuilder(contract, metadata.runnerImageVersion);
   if (metadata.builder !== builder) {
     throw new Error(
       `release ${slug} builder identity does not match release-toolchain.json: ` +

--- a/packages/agenc/scripts/check-package-ready.mjs
+++ b/packages/agenc/scripts/check-package-ready.mjs
@@ -51,7 +51,6 @@ function validateHostedRunnerContract(nativeToolchain, key, releaseToolchain) {
   for (const [actualField, contractField] of [
     ["runnerLabel", "runnerLabel"],
     ["runnerImage", "imageOS"],
-    ["runnerImageVersion", "imageVersion"],
     ["runnerArch", "runnerArch"],
   ]) {
     if (
@@ -61,9 +60,25 @@ function validateHostedRunnerContract(nativeToolchain, key, releaseToolchain) {
       fail(`${key} ${actualField} does not match the reviewed hosted runner contract`);
     }
   }
+  const alternateImageVersions = contract.alternateImageVersions ?? [];
+  if (
+    typeof contract.imageVersion !== "string" ||
+    contract.imageVersion.length === 0 ||
+    !Array.isArray(alternateImageVersions) ||
+    alternateImageVersions.some((value) => typeof value !== "string" || value.length === 0)
+  ) {
+    fail(`${key} has invalid reviewed hosted runner image versions`);
+  }
+  const imageVersions = [contract.imageVersion, ...alternateImageVersions];
+  if (
+    new Set(imageVersions).size !== imageVersions.length ||
+    !imageVersions.includes(nativeToolchain.runnerImageVersion)
+  ) {
+    fail(`${key} runnerImageVersion does not match the reviewed hosted runner contract`);
+  }
   const expectedBuilder =
     `github-hosted:${contract.runnerLabel}:${contract.imageOS}:` +
-    `${contract.imageVersion}:${contract.runnerArch}`;
+    `${nativeToolchain.runnerImageVersion}:${contract.runnerArch}`;
   if (nativeToolchain.builder !== expectedBuilder) {
     fail(`${key} builder identity is detached from the hosted runner contract`);
   }

--- a/packages/agenc/scripts/gen-manifest.mjs
+++ b/packages/agenc/scripts/gen-manifest.mjs
@@ -723,7 +723,6 @@ function requireHostedRunnerToolchain(nativeToolchain, key, expectedBuild) {
   for (const [actualField, contractField] of [
     ["runnerLabel", "runnerLabel"],
     ["runnerImage", "imageOS"],
-    ["runnerImageVersion", "imageVersion"],
     ["runnerArch", "runnerArch"],
   ]) {
     if (
@@ -735,9 +734,27 @@ function requireHostedRunnerToolchain(nativeToolchain, key, expectedBuild) {
       );
     }
   }
+  const alternateImageVersions = contract.alternateImageVersions ?? [];
+  if (
+    typeof contract.imageVersion !== "string" ||
+    contract.imageVersion.length === 0 ||
+    !Array.isArray(alternateImageVersions) ||
+    alternateImageVersions.some((value) => typeof value !== "string" || value.length === 0)
+  ) {
+    throw new Error(`${key} has invalid reviewed hosted runner image versions`);
+  }
+  const imageVersions = [contract.imageVersion, ...alternateImageVersions];
+  if (
+    new Set(imageVersions).size !== imageVersions.length ||
+    !imageVersions.includes(nativeToolchain.runnerImageVersion)
+  ) {
+    throw new Error(
+      `${key} runnerImageVersion does not match the reviewed hosted runner contract`,
+    );
+  }
   const expectedBuilder =
     `github-hosted:${contract.runnerLabel}:${contract.imageOS}:` +
-    `${contract.imageVersion}:${contract.runnerArch}`;
+    `${nativeToolchain.runnerImageVersion}:${contract.runnerArch}`;
   if (nativeToolchain.builder !== expectedBuilder) {
     throw new Error(`${key} builder identity is detached from the hosted runner contract`);
   }

--- a/packages/agenc/test/gen-manifest.test.mjs
+++ b/packages/agenc/test/gen-manifest.test.mjs
@@ -383,10 +383,12 @@ function addArtifact(directory, platform, arch, body, archiveOptions) {
     : undefined;
   const key = `${platform}-${arch}`;
   const hostedRunner = releaseToolchain.hostedRunners[key];
+  const hostedImageVersion =
+    hostedRunner?.alternateImageVersions?.[0] ?? hostedRunner?.imageVersion;
   const hostedBuilder = hostedRunner === undefined
     ? undefined
     : `github-hosted:${hostedRunner.runnerLabel}:${hostedRunner.imageOS}:` +
-      `${hostedRunner.imageVersion}:${hostedRunner.runnerArch}`;
+      `${hostedImageVersion}:${hostedRunner.runnerArch}`;
   const compilerIdentity = platform === "darwin"
     ? hostedRunner.clangVersion
     : platform === "win"
@@ -440,7 +442,7 @@ function addArtifact(directory, platform, arch, body, archiveOptions) {
         ? {
             runnerLabel: hostedRunner.runnerLabel,
             runnerImage: hostedRunner.imageOS,
-            runnerImageVersion: hostedRunner.imageVersion,
+            runnerImageVersion: hostedImageVersion,
             runnerArch: hostedRunner.runnerArch,
           }
         : {}),

--- a/packages/agenc/test/reproducible-artifact.test.mjs
+++ b/packages/agenc/test/reproducible-artifact.test.mjs
@@ -804,6 +804,7 @@ test("hosted release runner contracts reject valid-looking drift", () => {
     runnerLabel: "macos-15",
     imageOS: "macos15",
     imageVersion: "20260706.0213.1",
+    alternateImageVersions: ["20260715.0234.1"],
     runnerArch: "ARM64",
     xcodeVersion: "16.4",
     xcodeBuild: "16F6",
@@ -823,6 +824,29 @@ test("hosted release runner contracts reject valid-looking drift", () => {
   };
   assert.doesNotThrow(() =>
     assertHostedRunnerContract(metadata, darwinContract, "darwin-arm64"),
+  );
+  assert.doesNotThrow(() =>
+    assertHostedRunnerContract(
+      {
+        ...metadata,
+        builder: "github-hosted:macos-15:macos15:20260715.0234.1:ARM64",
+        runnerImageVersion: "20260715.0234.1",
+      },
+      darwinContract,
+      "darwin-arm64",
+    ),
+  );
+  assert.throws(
+    () =>
+      assertHostedRunnerContract(
+        {
+          ...metadata,
+          runnerImageVersion: "20260715.0234.1",
+        },
+        darwinContract,
+        "darwin-arm64",
+      ),
+    /builder identity/,
   );
   for (const [field, value, expected] of [
     ["runnerImageVersion", "20260714.1", /runnerImageVersion/],

--- a/release-toolchain.json
+++ b/release-toolchain.json
@@ -316,7 +316,10 @@
     "darwin-arm64": {
       "runnerLabel": "macos-15",
       "imageOS": "macos15",
-      "imageVersion": "20260727.0256.1",
+      "imageVersion": "20260715.0234.1",
+      "alternateImageVersions": [
+        "20260727.0256.1"
+      ],
       "runnerArch": "ARM64",
       "xcodeVersion": "16.4",
       "xcodeBuild": "16F6",

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -679,7 +679,7 @@ describe("reproducible install and release contract", () => {
     const nativeContract = JSON.parse(
       readFileSync(join(REPO_ROOT, "release-toolchain.json"), "utf8"),
     ) as {
-      hostedRunners: Record<string, Record<string, string>>;
+      hostedRunners: Record<string, Record<string, string | string[]>>;
       nodeDistributions: Record<
         string,
         { file: string; sha256: string; bytes: number }
@@ -722,7 +722,8 @@ describe("reproducible install and release contract", () => {
       "darwin-arm64": {
         runnerLabel: "macos-15",
         imageOS: "macos15",
-        imageVersion: "20260727.0256.1",
+        imageVersion: "20260715.0234.1",
+        alternateImageVersions: ["20260727.0256.1"],
         runnerArch: "ARM64",
         xcodeVersion: "16.4",
         xcodeBuild: "16F6",


### PR DESCRIPTION
Fixes the blocked 0.13.0 Darwin ARM64 candidate caused by GitHub serving the previous GA macOS image during rollout.

- accepts only the two reviewed official ARM64 image revisions
- records and revalidates the exact observed builder revision
- retains exact Xcode 16.4 / SDK 15.5 / Clang validation
- adds a revert-sensitive detached-builder regression
- adds FIX_RELEASE.MD as the one-command resumable release-controller specification

Verified: launcher/release tests 180/180, reproducibility contract 15/15, focused artifact tests 20/20, typecheck, YAML parse, build, and real PTY startup smokes.