### PR TITLE
fix(release): isolate candidate seal artifacts

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -1405,11 +1405,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: agenc-runtime-*
-          path: candidate-artifacts
+          path: ${{ runner.temp }}/candidate-artifacts
           merge-multiple: true
       - name: Seal the exact candidate inventory at current main
         id: candidate-receipt
         env:
+          CANDIDATE_ARTIFACTS_DIR: ${{ runner.temp }}/candidate-artifacts
           GH_CONFIG_DIR: ${{ runner.temp }}/candidate-seal-gh-config
           GH_NO_UPDATE_NOTIFIER: "true"
           GH_PROMPT_DISABLED: "true"
@@ -1441,7 +1442,7 @@ jobs:
           receipt="$seal_root/agenc-runtime-candidate-seal.json"
           bundle="${receipt}.sigstore.json"
           python3 scripts/release_candidate_policy.py seal \
-            --source-dir candidate-artifacts \
+            --source-dir "$CANDIDATE_ARTIFACTS_DIR" \
             --receipt "$receipt" \
             --version "$version" \
             --repository "$GITHUB_REPOSITORY" \
@@ -1461,7 +1462,7 @@ jobs:
             --deny-self-hosted-runners
           )
           for slug in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win-x64; do
-            archive="candidate-artifacts/agenc-runtime-${version}-${slug}-node26-abi147.tar.gz"
+            archive="$CANDIDATE_ARTIFACTS_DIR/agenc-runtime-${version}-${slug}-node26-abi147.tar.gz"
             metadata="${archive}.meta.json"
             candidate_bundle="${archive}.sigstore.json"
             gh attestation verify "$archive" \

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -1363,7 +1363,27 @@ describe("reproducible install and release contract", () => {
       "candidate seal refuses an already-consumed release tag",
     );
     expect(candidateSeal).toContain("pattern: agenc-runtime-*");
+    expect(candidateSeal).toContain(
+      "path: ${{ runner.temp }}/candidate-artifacts",
+    );
+    expect(candidateSeal).not.toMatch(/^\s+path: candidate-artifacts$/mu);
     expect(candidateSeal).toContain("merge-multiple: true");
+    expect(candidateSeal).toContain(
+      "CANDIDATE_ARTIFACTS_DIR: ${{ runner.temp }}/candidate-artifacts",
+    );
+    expect(candidateSeal).toContain(
+      'test -z "$(git status --porcelain=v1 --untracked-files=all)"',
+    );
+    expect(candidateSeal.match(/candidate-artifacts/g)).toHaveLength(2);
+    expect(
+      candidateSeal.indexOf(
+        "path: ${{ runner.temp }}/candidate-artifacts",
+      ),
+    ).toBeLessThan(
+      candidateSeal.indexOf(
+        'test -z "$(git status --porcelain=v1 --untracked-files=all)"',
+      ),
+    );
     expect(candidateSeal).toContain('test "$gh_version" = "2.96.0"');
     expect(candidateSeal.match(/gh attestation verify/g)).toHaveLength(2);
     expect(candidateSeal).toContain("--source-ref refs/heads/main");
@@ -1371,7 +1391,7 @@ describe("reproducible install and release contract", () => {
       "python3 scripts/release_candidate_policy.py seal",
     );
     for (const argument of [
-      "--source-dir candidate-artifacts",
+      '--source-dir "$CANDIDATE_ARTIFACTS_DIR"',
       '--receipt "$receipt"',
       '--repository "$GITHUB_REPOSITORY"',
       '--run-id "$GITHUB_RUN_ID"',
@@ -1381,6 +1401,9 @@ describe("reproducible install and release contract", () => {
     ]) {
       expect(candidateSeal).toContain(argument);
     }
+    expect(candidateSeal).toContain(
+      'archive="$CANDIDATE_ARTIFACTS_DIR/agenc-runtime-${version}-${slug}-node26-abi147.tar.gz"',
+    );
     expect(candidateSeal).not.toContain("def require_candidate_provenance");
     expect(candidateSeal).toContain("Attest the candidate seal");
     expect(candidateSeal).toContain("name: agenc-runtime-candidate-seal");


### PR DESCRIPTION
## Summary

- download candidate artifacts into the runner-private temp directory instead of the Git checkout
- preserve the strict full clean-tree assertion before sealing
- add revert-sensitive workflow contract assertions that reject workspace-relative artifact paths and orphan consumers

## Root cause

Candidate run 30605514199 built all five native artifacts successfully, then the seal job deterministically failed because `actions/download-artifact` created untracked `candidate-artifacts/` inside the checkout immediately before `git status --untracked-files=all` asserted the tree was clean.

## Local verification

- full `npm test`: 17,253/17,253 runtime tests, 1,922/1,922 files; zero skips
- required gates: 128/128; zero skips
- launcher/release tests: 180/180; zero skips
- candidate release contract: 15/15
- workflow YAML parse: pass
- pre-commit build and PTY startup smoke: pass at 148x40, 120x30, and 80x24, normal and `--yolo`
