### PR TITLE
fix(runtime): make embedded Neovim startup input-safe

### DIFF
--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -157,11 +157,40 @@ describe("hosted Neovim platform gate contract", () => {
     expect(saveScenario).toContain("readySession: true");
     expect(saveScenario).toContain("waitForFileText(");
     expect(saveScenario).toContain("PLATFORM_NVIM_MARK");
+    expect(saveScenario).toContain("nvim-platform-edit-proof.txt");
+    expect(saveScenario).toContain(
+      "autocmd TextChangedI,TextChangedP target.txt",
+    );
+    expect(saveScenario).toContain("editProof !== expectedEditProof");
+    const editInputIndex = saveScenario.indexOf(
+      'session.type("PLATFORM_NVIM_MARK"',
+    );
+    const editProofWaitIndex = saveScenario.indexOf(
+      "const editProof = await waitForFileText(",
+    );
+    const editEscapeIndex = saveScenario.indexOf(
+      'session.send("\\x1b")',
+      editInputIndex,
+    );
+    expect(editInputIndex).toBeGreaterThan(-1);
+    expect(editProofWaitIndex).toBeGreaterThan(editInputIndex);
+    expect(editEscapeIndex).toBeGreaterThan(editProofWaitIndex);
     expect(saveScenario).toContain("nvim-platform-exit.intent");
     expect(saveScenario).toContain("| qa!");
     expect(saveScenario).toContain(
       "Ctrl+S boundary is covered separately through the terminal parser",
     );
+    const helperSource = readFileSync(
+      resolve(
+        RUNTIME_ROOT,
+        "scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs",
+      ),
+      "utf8",
+    );
+    expect(helperSource).toContain("/CMDLINE_NORMAL/u");
+    expect(helperSource).toContain("\\x1b[200~");
+    expect(helperSource).toContain("\\x1b[201~");
+    expect(helperSource).not.toContain("session.type(`:${command}`");
     const killScenario = readFileSync(
       resolve(
         RUNTIME_ROOT,

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -157,6 +157,8 @@ describe("hosted Neovim platform gate contract", () => {
     expect(saveScenario).toContain("readySession: true");
     expect(saveScenario).toContain("waitForFileText(");
     expect(saveScenario).toContain("PLATFORM_NVIM_MARK");
+    expect(saveScenario).toContain("nvim-platform-exit.intent");
+    expect(saveScenario).toContain("| qa!");
     expect(saveScenario).toContain(
       "Ctrl+S boundary is covered separately through the terminal parser",
     );

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -153,7 +153,9 @@ describe("hosted Neovim platform gate contract", () => {
       ),
       "utf8",
     );
-    expect(saveScenario).toContain('runNeovimCommand(session, "write")');
+    expect(saveScenario).toContain(
+      'runEmbeddedNeovimCommand(session, "write")',
+    );
     expect(saveScenario).toContain("waitForFileText(");
     expect(saveScenario).toContain("PLATFORM_NVIM_MARK");
     expect(saveScenario).toContain(

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -153,14 +153,25 @@ describe("hosted Neovim platform gate contract", () => {
       ),
       "utf8",
     );
-    expect(saveScenario).toContain(
-      'runEmbeddedNeovimCommand(session, "write")',
-    );
+    expect(saveScenario).toContain('"write", {');
+    expect(saveScenario).toContain("readySession: true");
     expect(saveScenario).toContain("waitForFileText(");
     expect(saveScenario).toContain("PLATFORM_NVIM_MARK");
     expect(saveScenario).toContain(
       "Ctrl+S boundary is covered separately through the terminal parser",
     );
+    const killScenario = readFileSync(
+      resolve(
+        RUNTIME_ROOT,
+        "scripts/check-tui-e2e/scenarios",
+        "131-workbench-buffer-neovim-platform-kill-cleanup.mjs",
+      ),
+      "utf8",
+    );
+    expect(killScenario).toContain("nvim-platform-dirty-proof.txt");
+    expect(killScenario).toContain("writefile(getline(1, '$')");
+    expect(killScenario).toContain("targetBeforeKill.includes");
+    expect(killScenario).toContain("readySession: true");
     expect(() =>
       selectPlatformScenarios([...HOSTED_NEOVIM_SCENARIOS], "freebsd-x64")
     ).toThrow("unsupported TUI E2E platform");

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -171,9 +171,28 @@ describe("hosted Neovim platform gate contract", () => {
       "utf8",
     );
     expect(killScenario).toContain("nvim-platform-dirty-proof.txt");
+    expect(killScenario).toContain(
+      "autocmd TextChangedI,TextChangedP target.txt",
+    );
     expect(killScenario).toContain("writefile(getline(1, '$')");
-    expect(killScenario).toContain("targetBeforeKill.includes");
+    expect(killScenario).toContain("targetBeforeKill !== originalTarget");
+    expect(killScenario).toContain("dirtyProof !== expectedDirtyProof");
     expect(killScenario).toContain("readySession: true");
+    const dirtyAcknowledgementIndex = killScenario.indexOf(
+      "autocmd TextChangedI,TextChangedP target.txt",
+    );
+    const dirtyInputIndex = killScenario.indexOf(
+      'session.type("UNSAVED_PLATFORM_KILL_MARK"',
+    );
+    const dirtyProofWaitIndex = killScenario.indexOf(
+      "const dirtyProof = await waitForFileText(",
+    );
+    expect(dirtyAcknowledgementIndex).toBeGreaterThan(-1);
+    expect(dirtyInputIndex).toBeGreaterThan(dirtyAcknowledgementIndex);
+    expect(dirtyProofWaitIndex).toBeGreaterThan(dirtyInputIndex);
+    expect(
+      killScenario.slice(dirtyInputIndex),
+    ).not.toContain("runEmbeddedNeovimCommand");
     expect(() =>
       selectPlatformScenarios([...HOSTED_NEOVIM_SCENARIOS], "freebsd-x64")
     ).toThrow("unsupported TUI E2E platform");

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -48,6 +48,36 @@ export async function waitForFrameText(session, pattern, label, timeoutMs = 10_0
   throw new Error(`${label} did not render in the latest PTY frame: ${frame.slice(-1200)}`);
 }
 
+export async function runEmbeddedNeovimCommand(session, command) {
+  // The terminal grid can paint NORMAL before the provider commits the session
+  // that receives input. Require both the committed "ready" header and NORMAL
+  // mode, then let that acknowledged frame settle before entering a command.
+  await waitForFrameText(
+    session,
+    /\[embedded Neovim [^,\n]+,\s*normal,\s*ready(?:,|\])/iu,
+    `committed embedded Neovim session before :${command}`,
+    5_000,
+  );
+  await waitForFrameText(
+    session,
+    /\bNORMAL\s+ctrl\+s save\b/u,
+    `embedded Neovim normal mode before :${command}`,
+    5_000,
+  );
+  await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
+  session.send(":");
+  await waitForFrameText(
+    session,
+    /\bCMDLINE_NORMAL\s+ctrl\+s save\b/u,
+    `embedded Neovim command-line mode for :${command}`,
+    5_000,
+  );
+  await sleep(80);
+  await session.type(command, { perCharMs: 5 });
+  session.send("\r");
+  await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
+}
+
 export async function listNeovimPids() {
   const processes = await listProcesses();
   return processes

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -50,25 +50,20 @@ export async function waitForFrameText(session, pattern, label, timeoutMs = 10_0
 
 export async function runEmbeddedNeovimCommand(session, command) {
   // The terminal grid can paint NORMAL before the provider commits the session
-  // that receives input. Require both the committed "ready" header and NORMAL
-  // mode, then let that acknowledged frame settle before entering a command.
+  // that receives input. The provider header binds normal mode and ready state
+  // to that committed session; long presentation footers may be elided by
+  // ConPTY, so keep the handshake on the provider state itself.
   await waitForFrameText(
     session,
     /\[embedded Neovim [^,\n]+,\s*normal,\s*ready(?:,|\])/iu,
     `committed embedded Neovim session before :${command}`,
     5_000,
   );
-  await waitForFrameText(
-    session,
-    /\bNORMAL\s+ctrl\+s save\b/u,
-    `embedded Neovim normal mode before :${command}`,
-    5_000,
-  );
   await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
   session.send(":");
   await waitForFrameText(
     session,
-    /\bCMDLINE_NORMAL\s+ctrl\+s save\b/u,
+    /\bCMDLINE_NORMAL\b/u,
     `embedded Neovim command-line mode for :${command}`,
     5_000,
   );

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -73,12 +73,21 @@ export async function runEmbeddedNeovimCommand(
   session.send("\x1b");
   await sleep(80);
   session.send(":");
-  await sleep(80);
+  // Neovim's provider footer remains in CMDLINE_NORMAL for the lifetime of
+  // command mode. Do not paste the command body until that real editor-state
+  // acknowledgement proves the normalized Escape and colon were consumed.
+  await waitForFrameText(
+    session,
+    /CMDLINE_NORMAL/u,
+    `embedded Neovim command mode before :${command}`,
+    5_000,
+  );
   // Deliver the command body through the terminal's real bracketed-paste
   // protocol. BufferSurface routes that one paste event to one acknowledged
   // nvim_paste RPC instead of launching an unobserved nvim_input request for
-  // every character. The surrounding Escape, colon, and Enter remain real
-  // editor keystrokes, so this still exercises the complete PTY input path.
+  // every character. Escape, colon, the command-mode acknowledgement, and
+  // Enter remain real editor interactions, so this still exercises the
+  // complete PTY input path.
   session.send(`\x1b[200~${command}\x1b[201~`);
   await sleep(80);
   session.send("\r");

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -50,9 +50,11 @@ export async function waitForFrameText(session, pattern, label, timeoutMs = 10_0
 
 export async function runEmbeddedNeovimCommand(session, command) {
   // The terminal grid can paint NORMAL before the provider commits the session
-  // that receives input. The provider header binds normal mode and ready state
-  // to that committed session; long presentation footers may be elided by
-  // ConPTY, so keep the handshake on the provider state itself.
+  // that receives input. The provider header binds ready state to that
+  // committed session, but its coarse "normal" label also covers transient
+  // native modes. Normalize the owned session with Escape before entering Ex.
+  // The callers prove command delivery through concrete process/file effects;
+  // do not make that contract depend on a ConPTY-rendered presentation footer.
   await waitForFrameText(
     session,
     /\[embedded Neovim [^,\n]+,\s*normal,\s*ready(?:,|\])/iu,
@@ -60,15 +62,9 @@ export async function runEmbeddedNeovimCommand(session, command) {
     5_000,
   );
   await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
-  session.send(":");
-  await waitForFrameText(
-    session,
-    /\bCMDLINE_NORMAL\b/u,
-    `embedded Neovim command-line mode for :${command}`,
-    5_000,
-  );
+  session.send("\x1b");
   await sleep(80);
-  await session.type(command, { perCharMs: 5 });
+  await session.type(`:${command}`, { perCharMs: 5 });
   session.send("\r");
   await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
 }

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -48,19 +48,27 @@ export async function waitForFrameText(session, pattern, label, timeoutMs = 10_0
   throw new Error(`${label} did not render in the latest PTY frame: ${frame.slice(-1200)}`);
 }
 
-export async function runEmbeddedNeovimCommand(session, command) {
+export async function runEmbeddedNeovimCommand(
+  session,
+  command,
+  { readySession = false } = {},
+) {
   // The terminal grid can paint NORMAL before the provider commits the session
   // that receives input. The provider header binds ready state to that
   // committed session, but its coarse "normal" label also covers transient
   // native modes. Normalize the owned session with Escape before entering Ex.
   // The callers prove command delivery through concrete process/file effects;
   // do not make that contract depend on a ConPTY-rendered presentation footer.
-  await waitForFrameText(
-    session,
-    /\[embedded Neovim [^,\n]+,\s*normal,\s*ready(?:,|\])/iu,
-    `committed embedded Neovim session before :${command}`,
-    5_000,
-  );
+  // A caller may bypass the presentation gate only after concrete evidence
+  // proves that this same Neovim process is live and already received input.
+  if (!readySession) {
+    await waitForFrameText(
+      session,
+      /\[embedded Neovim [^,\n]+,\s*normal,\s*ready(?:,|\])/iu,
+      `committed embedded Neovim session before :${command}`,
+      5_000,
+    );
+  }
   await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
   session.send("\x1b");
   await sleep(80);

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -72,7 +72,15 @@ export async function runEmbeddedNeovimCommand(
   await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
   session.send("\x1b");
   await sleep(80);
-  await session.type(`:${command}`, { perCharMs: 5 });
+  session.send(":");
+  await sleep(80);
+  // Deliver the command body through the terminal's real bracketed-paste
+  // protocol. BufferSurface routes that one paste event to one acknowledged
+  // nvim_paste RPC instead of launching an unobserved nvim_input request for
+  // every character. The surrounding Escape, colon, and Enter remain real
+  // editor keystrokes, so this still exercises the complete PTY input path.
+  session.send(`\x1b[200~${command}\x1b[201~`);
+  await sleep(80);
   session.send("\r");
   await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
 }

--- a/runtime/scripts/check-tui-e2e/runner.mjs
+++ b/runtime/scripts/check-tui-e2e/runner.mjs
@@ -29,6 +29,7 @@ import {
   installTuiGateSignalHandlers,
   startTuiGateDaemon,
   teardownTuiGateState,
+  writeTuiGateDefaultConfig,
 } from "../tui-gate-state.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -90,6 +91,19 @@ export function platformSelectionFromArgv(argv) {
     throw new Error("--platform requires a target slug");
   }
   return value;
+}
+
+export function shouldSeedTuiGateDefaultConfig(meta = {}) {
+  const firstUsePredictionConsent = meta.firstUsePredictionConsent;
+  if (
+    firstUsePredictionConsent !== undefined &&
+    typeof firstUsePredictionConsent !== "boolean"
+  ) {
+    throw new Error(
+      "firstUsePredictionConsent scenario metadata must be boolean",
+    );
+  }
+  return firstUsePredictionConsent !== true;
 }
 
 export function applyScenarioFilters(names, argv) {
@@ -337,6 +351,9 @@ async function runScenarioEntry(
         scenario.meta.env ?? {},
       );
       replaceProcessEnvironment(gateState.env);
+      if (shouldSeedTuiGateDefaultConfig(scenario.meta)) {
+        await writeTuiGateDefaultConfig(gateState);
+      }
       await configureTuiGateSandbox(
         gateState,
         BIN_AGENC,

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -26,6 +26,7 @@ export const meta = {
 export default async function (session) {
   const cwd = await mkdtemp(join(tmpdir(), "agenc-platform-nvim-e2e-"));
   const pidFile = join(cwd, "nvim-platform.pid");
+  const exitIntentFile = join(cwd, "nvim-platform-exit.intent");
   let neovimPid = 0;
   try {
     await anchorWorkbenchProjectRoot(cwd);
@@ -68,10 +69,13 @@ export default async function (session) {
       throw new Error(`embedded Neovim did not save the platform marker: ${saved}`);
     }
 
-    await runEmbeddedNeovimCommand(session, "q!", {
-      readySession: true,
-    });
-    await waitForPidGone(neovimPid, 10_000, "embedded Neovim after :q!");
+    await runEmbeddedNeovimCommand(
+      session,
+      "call writefile(['qa!'], 'nvim-platform-exit.intent') | qa!",
+      { readySession: true },
+    );
+    await waitForFileText(exitIntentFile, /qa!/u, 5_000);
+    await waitForPidGone(neovimPid, 10_000, "embedded Neovim after :qa!");
     await waitForFrameText(
       session,
       /Describe a task…/u,

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -27,11 +27,13 @@ export default async function (session) {
   const cwd = await mkdtemp(join(tmpdir(), "agenc-platform-nvim-e2e-"));
   const pidFile = join(cwd, "nvim-platform.pid");
   const exitIntentFile = join(cwd, "nvim-platform-exit.intent");
+  const editProofFile = join(cwd, "nvim-platform-edit-proof.txt");
   let neovimPid = 0;
   try {
     await anchorWorkbenchProjectRoot(cwd);
     const target = join(cwd, "target.txt");
-    await writeFile(target, "platform-alpha\n", "utf8");
+    const originalTarget = "platform-alpha\n";
+    await writeFile(target, originalTarget, "utf8");
     session.cwd = cwd;
     await openEmbeddedNeovim(session);
 
@@ -44,11 +46,27 @@ export default async function (session) {
       throw new Error(`embedded Neovim pid ${neovimPid} was not alive after startup`);
     }
 
+    await runEmbeddedNeovimCommand(
+      session,
+      "autocmd TextChangedI,TextChangedP target.txt call writefile(getline(1, '$'), 'nvim-platform-edit-proof.txt')",
+      { readySession: true },
+    );
     session.send("G");
     await sleep(80);
     session.send("o");
     await sleep(80);
     await session.type("PLATFORM_NVIM_MARK", { perCharMs: 15 });
+    const editProof = await waitForFileText(
+      editProofFile,
+      /PLATFORM_NVIM_MARK/u,
+      5_000,
+    );
+    const expectedEditProof = `${originalTarget}PLATFORM_NVIM_MARK\n`;
+    if (editProof !== expectedEditProof) {
+      throw new Error(
+        `Neovim platform edit proof was not exact: ${JSON.stringify(editProof)}`,
+      );
+    }
     session.send("\x1b");
     // Exercise Neovim's real write path in the hosted PTY. The host-owned
     // Ctrl+S boundary is covered separately through the terminal parser and
@@ -133,7 +151,7 @@ async function waitForFileText(path, pattern, timeoutMs) {
     await sleep(50);
   }
   throw new Error(
-    `provider save did not update ${path} within ${timeoutMs}ms: ${last}`,
+    `expected file text did not update ${path} within ${timeoutMs}ms: ${last}`,
   );
 }
 

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -49,16 +49,12 @@ export default async function (session) {
     await sleep(80);
     await session.type("PLATFORM_NVIM_MARK", { perCharMs: 15 });
     session.send("\x1b");
-    await waitForFrameText(
-      session,
-      /PLATFORM_NVIM_MARK/u,
-      "hosted-platform Neovim edit",
-      10_000,
-    );
     // Exercise Neovim's real write path in the hosted PTY. The host-owned
     // Ctrl+S boundary is covered separately through the terminal parser and
     // rendered BufferSurface integration test; emitting Ctrl+S from node-pty
     // is not portable because PTY line discipline can retain XOFF handling.
+    // The saved bytes are the authoritative end-to-end edit proof; ConPTY can
+    // omit the transient frame containing the newly inserted marker.
     await runEmbeddedNeovimCommand(session, "write");
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     const saved = await waitForFileText(

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -55,7 +55,9 @@ export default async function (session) {
     // is not portable because PTY line discipline can retain XOFF handling.
     // The saved bytes are the authoritative end-to-end edit proof; ConPTY can
     // omit the transient frame containing the newly inserted marker.
-    await runEmbeddedNeovimCommand(session, "write");
+    await runEmbeddedNeovimCommand(session, "write", {
+      readySession: true,
+    });
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     const saved = await waitForFileText(
       target,
@@ -66,7 +68,9 @@ export default async function (session) {
       throw new Error(`embedded Neovim did not save the platform marker: ${saved}`);
     }
 
-    await runEmbeddedNeovimCommand(session, "q!");
+    await runEmbeddedNeovimCommand(session, "q!", {
+      readySession: true,
+    });
     await waitForPidGone(neovimPid, 10_000, "embedded Neovim after :q!");
     await waitForFrameText(
       session,

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import {
   anchorWorkbenchProjectRoot,
+  runEmbeddedNeovimCommand,
   waitForFrameText,
   waitForScreen,
 } from "../helpers/workbench-buffer-neovim.mjs";
@@ -33,7 +34,7 @@ export default async function (session) {
     session.cwd = cwd;
     await openEmbeddedNeovim(session);
 
-    await runNeovimCommand(
+    await runEmbeddedNeovimCommand(
       session,
       "call writefile([string(getpid())], 'nvim-platform.pid')",
     );
@@ -58,7 +59,7 @@ export default async function (session) {
     // Ctrl+S boundary is covered separately through the terminal parser and
     // rendered BufferSurface integration test; emitting Ctrl+S from node-pty
     // is not portable because PTY line discipline can retain XOFF handling.
-    await runNeovimCommand(session, "write");
+    await runEmbeddedNeovimCommand(session, "write");
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
     const saved = await waitForFileText(
       target,
@@ -69,7 +70,7 @@ export default async function (session) {
       throw new Error(`embedded Neovim did not save the platform marker: ${saved}`);
     }
 
-    await runNeovimCommand(session, "q!");
+    await runEmbeddedNeovimCommand(session, "q!");
     await waitForPidGone(neovimPid, 10_000, "embedded Neovim after :q!");
     await waitForFrameText(
       session,
@@ -104,22 +105,6 @@ async function openEmbeddedNeovim(session) {
     "hosted-platform target loaded in embedded Neovim",
     20_000,
   );
-}
-
-async function runNeovimCommand(session, command) {
-  session.send("\x1b");
-  await sleep(80);
-  session.send(":");
-  await waitForFrameText(
-    session,
-    /CMDLINE_NORMAL/u,
-    "embedded Neovim command-line mode",
-    5_000,
-  );
-  await sleep(80);
-  await session.type(command, { perCharMs: 5 });
-  session.send("\r");
-  await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
 }
 
 async function readPidFile(path) {

--- a/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
@@ -33,7 +33,8 @@ export default async function (session) {
   let detachedJobPid = 0;
   try {
     await anchorWorkbenchProjectRoot(cwd);
-    await writeFile(target, "platform-kill-alpha\n", "utf8");
+    const originalTarget = "platform-kill-alpha\n";
+    await writeFile(target, originalTarget, "utf8");
     session.cwd = cwd;
     await openEmbeddedNeovim(session);
 
@@ -71,30 +72,36 @@ export default async function (session) {
       );
     }
 
+    // Outer-PTY write completion and rendered idleness do not acknowledge
+    // Neovim's asynchronous nvim_input requests. Have the editor itself
+    // publish each insert-mode change so the full marker is proven before the
+    // TUI is killed, without depending on a transient terminal frame.
+    await runEmbeddedNeovimCommand(
+      session,
+      "autocmd TextChangedI,TextChangedP target.txt call writefile(getline(1, '$'), 'nvim-platform-dirty-proof.txt')",
+      { readySession: true },
+    );
     session.send("G");
     await sleep(80);
     session.send("o");
     await sleep(80);
     await session.type("UNSAVED_PLATFORM_KILL_MARK", { perCharMs: 15 });
-    await runEmbeddedNeovimCommand(
-      session,
-      "call writefile(getline(1, '$'), 'nvim-platform-dirty-proof.txt')",
-      { readySession: true },
-    );
     const dirtyProof = await waitForFileText(
       dirtyProofFile,
       /UNSAVED_PLATFORM_KILL_MARK/u,
       5_000,
     );
-    if (!dirtyProof.includes("UNSAVED_PLATFORM_KILL_MARK")) {
+    const expectedDirtyProof =
+      `${originalTarget}UNSAVED_PLATFORM_KILL_MARK\n`;
+    if (dirtyProof !== expectedDirtyProof) {
       throw new Error(
-        `Neovim dirty-buffer proof omitted the marker: ${dirtyProof}`,
+        `Neovim dirty-buffer proof was not exact: ${JSON.stringify(dirtyProof)}`,
       );
     }
     const targetBeforeKill = await readFile(target, "utf8");
-    if (targetBeforeKill.includes("UNSAVED_PLATFORM_KILL_MARK")) {
+    if (targetBeforeKill !== originalTarget) {
       throw new Error(
-        `dirty Neovim text reached disk before TUI termination: ${targetBeforeKill}`,
+        `dirty Neovim text changed disk before TUI termination: ${JSON.stringify(targetBeforeKill)}`,
       );
     }
 
@@ -110,8 +117,10 @@ export default async function (session) {
       "detached Neovim job after hosted-platform TUI termination",
     );
     const saved = await readFile(target, "utf8");
-    if (saved.includes("UNSAVED_PLATFORM_KILL_MARK")) {
-      throw new Error(`TUI termination wrote dirty Neovim text: ${saved}`);
+    if (saved !== originalTarget) {
+      throw new Error(
+        `TUI termination changed dirty Neovim text on disk: ${JSON.stringify(saved)}`,
+      );
     }
   } finally {
     if (detachedJobPid > 0 && processIsAlive(detachedJobPid)) {

--- a/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import {
   anchorWorkbenchProjectRoot,
+  runEmbeddedNeovimCommand,
   waitForFrameText,
   waitForScreen,
 } from "../helpers/workbench-buffer-neovim.mjs";
@@ -35,7 +36,7 @@ export default async function (session) {
     session.cwd = cwd;
     await openEmbeddedNeovim(session);
 
-    await runNeovimCommand(
+    await runEmbeddedNeovimCommand(
       session,
       "call writefile([string(getpid())], 'nvim-platform-kill.pid')",
     );
@@ -49,7 +50,7 @@ export default async function (session) {
       "process.on('SIGTERM', () => {});",
       "setInterval(() => {}, 1000);",
     ].join("");
-    await runNeovimCommand(
+    await runEmbeddedNeovimCommand(
       session,
       `call jobstart([${
         [
@@ -133,22 +134,6 @@ async function openEmbeddedNeovim(session) {
     "hosted-platform kill target loaded in embedded Neovim",
     20_000,
   );
-}
-
-async function runNeovimCommand(session, command) {
-  session.send("\x1b");
-  await sleep(80);
-  session.send(":");
-  await waitForFrameText(
-    session,
-    /CMDLINE_NORMAL/u,
-    "embedded Neovim command-line mode",
-    5_000,
-  );
-  await sleep(80);
-  await session.type(command, { perCharMs: 5 });
-  session.send("\r");
-  await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
 }
 
 async function readPidFile(path) {

--- a/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
@@ -28,6 +28,7 @@ export default async function (session) {
   const target = join(cwd, "target.txt");
   const pidFile = join(cwd, "nvim-platform-kill.pid");
   const jobPidFile = join(cwd, "nvim-platform-detached-job.pid");
+  const dirtyProofFile = join(cwd, "nvim-platform-dirty-proof.txt");
   let neovimPid = 0;
   let detachedJobPid = 0;
   try {
@@ -61,6 +62,7 @@ export default async function (session) {
           "agenc-neovim-platform-descendant",
         ].map(vimLiteral).join(", ")
       }], {'detach': v:true})`,
+      { readySession: true },
     );
     detachedJobPid = await readPidFile(jobPidFile);
     if (!processIsAlive(detachedJobPid)) {
@@ -74,12 +76,27 @@ export default async function (session) {
     session.send("o");
     await sleep(80);
     await session.type("UNSAVED_PLATFORM_KILL_MARK", { perCharMs: 15 });
-    await waitForFrameText(
+    await runEmbeddedNeovimCommand(
       session,
-      /UNSAVED_PLATFORM_KILL_MARK/u,
-      "dirty hosted-platform Neovim edit",
-      10_000,
+      "call writefile(getline(1, '$'), 'nvim-platform-dirty-proof.txt')",
+      { readySession: true },
     );
+    const dirtyProof = await waitForFileText(
+      dirtyProofFile,
+      /UNSAVED_PLATFORM_KILL_MARK/u,
+      5_000,
+    );
+    if (!dirtyProof.includes("UNSAVED_PLATFORM_KILL_MARK")) {
+      throw new Error(
+        `Neovim dirty-buffer proof omitted the marker: ${dirtyProof}`,
+      );
+    }
+    const targetBeforeKill = await readFile(target, "utf8");
+    if (targetBeforeKill.includes("UNSAVED_PLATFORM_KILL_MARK")) {
+      throw new Error(
+        `dirty Neovim text reached disk before TUI termination: ${targetBeforeKill}`,
+      );
+    }
 
     session.kill("SIGKILL");
     await waitForPidGone(
@@ -147,6 +164,19 @@ async function readPidFile(path) {
     await sleep(50);
   }
   throw new Error(`embedded Neovim did not write its pid file: ${path}`);
+}
+
+async function waitForFileText(path, pattern, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = await readFile(path, "utf8").catch(() => "");
+    if (pattern.test(last)) return last;
+    await sleep(50);
+  }
+  throw new Error(
+    `dirty Neovim buffer proof did not update ${path} within ${timeoutMs}ms: ${last}`,
+  );
 }
 
 function processIsAlive(pid) {

--- a/runtime/scripts/check-tui-e2e/scenarios/133-editor-code-prediction.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/133-editor-code-prediction.mjs
@@ -19,6 +19,7 @@ export const meta = {
   description:
     "First-use prediction consent persists and reloads the daemon, then a tool-free provider call paints and accepts Neovim ghost text.",
   args: ["--yolo"],
+  firstUsePredictionConsent: true,
   timeoutMs: 90_000,
   env: {
     AGENC_TUI_WORKBENCH: "1",

--- a/runtime/scripts/check-tui-runtime-startup.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.mjs
@@ -21,6 +21,7 @@ import {
   installTuiGateSignalHandlers,
   startTuiGateDaemon,
   teardownTuiGateState,
+  writeTuiGateDefaultConfig,
   writeTuiGateTrust,
 } from "./tui-gate-state.mjs";
 
@@ -702,6 +703,7 @@ async function main() {
   try {
     gateState = await gateStatePromise;
     await writeTuiGateTrust(gateState.env, [RUNTIME_DIR]);
+    await writeTuiGateDefaultConfig(gateState);
     if (interrupted) return 1;
     await startTuiGateDaemon(gateState, BIN_AGENC_PATH);
     if (interrupted) return 1;

--- a/runtime/scripts/check-tui-runtime-startup.test.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.test.mjs
@@ -7,6 +7,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -27,6 +28,7 @@ import {
   teardownTuiGateState,
   TUI_GATE_TRUST_TIMESTAMP,
   tuiGateEnvironment,
+  writeTuiGateDefaultConfig,
   writeTuiGateTrust,
 } from "./tui-gate-state.mjs";
 
@@ -259,6 +261,65 @@ test("private gate trust is canonical and deterministic without copied operator 
     rmSync(state.root, { recursive: true, force: true });
     rmSync(operatorRoot, { recursive: true, force: true });
   }
+});
+
+test("private gate default config disables predictions before ordinary TUI startup", async () => {
+  const state = await createTuiGateState({
+    prefix: "agenc-tui-default-config-test-",
+  });
+  try {
+    const configPath = await writeTuiGateDefaultConfig(state);
+    assert.equal(configPath, path.join(state.agencHome, "config.toml"));
+    assert.equal(
+      readFileSync(configPath, "utf8"),
+      [
+        "configVersion = 1",
+        "",
+        "[buffer.prediction]",
+        'enabled = "off"',
+        "",
+      ].join("\n"),
+    );
+    if (process.platform !== "win32") {
+      assert.equal(statSync(configPath).mode & 0o777, 0o600);
+    }
+    await assert.rejects(
+      writeTuiGateDefaultConfig(state),
+      (error) => error?.code === "EEXIST",
+    );
+    assert.equal(
+      readFileSync(configPath, "utf8"),
+      [
+        "configVersion = 1",
+        "",
+        "[buffer.prediction]",
+        'enabled = "off"',
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    await teardownTuiGateState(state);
+  }
+});
+
+test("startup smoke seeds its default config before starting the daemon", () => {
+  const source = readFileSync(
+    new URL("./check-tui-runtime-startup.mjs", import.meta.url),
+    "utf8",
+  );
+  const mainIndex = source.indexOf("async function main()");
+  const configIndex = source.indexOf(
+    "await writeTuiGateDefaultConfig(gateState);",
+    mainIndex,
+  );
+  const daemonIndex = source.indexOf(
+    "await startTuiGateDaemon(gateState, BIN_AGENC_PATH);",
+    mainIndex,
+  );
+
+  assert.ok(mainIndex >= 0);
+  assert.ok(configIndex > mainIndex);
+  assert.ok(daemonIndex > configIndex);
 });
 
 test("private gate teardown removes only an owned root and proves it absent", async () => {

--- a/runtime/scripts/tui-gate-state.mjs
+++ b/runtime/scripts/tui-gate-state.mjs
@@ -31,6 +31,13 @@ const PROJECT_FIXTURE_FILES = Object.freeze({
   "README.md": "# AgenC TUI gate fixture\n",
   "package.json": '{"private":true}\n',
 });
+const DEFAULT_CONFIG = [
+  "configVersion = 1",
+  "",
+  "[buffer.prediction]",
+  'enabled = "off"',
+  "",
+].join("\n");
 
 const PASSTHROUGH_ENV_KEYS = Object.freeze([
   "CI",
@@ -357,6 +364,25 @@ export async function writeTuiGateTrust(env, projectPaths) {
     { encoding: "utf8", mode: 0o600 },
   );
   return trustFile;
+}
+
+/**
+ * Seed ordinary TUI gates with deterministic, disclosure-safe editor state.
+ *
+ * The dedicated first-use consent scenario deliberately skips this helper.
+ * Exclusive creation catches lifecycle regressions where another setup step
+ * writes config before the runner has established its baseline.
+ */
+export async function writeTuiGateDefaultConfig(state) {
+  await assertOwnedState(state);
+  const configPath = path.join(state.agencHome, "config.toml");
+  await writeFile(configPath, DEFAULT_CONFIG, {
+    encoding: "utf8",
+    mode: 0o600,
+    flag: "wx",
+  });
+  await assertOrdinaryPath(configPath, "file");
+  return configPath;
 }
 
 function daemonCommand(binAgenc, args, env, timeout) {

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -920,9 +920,16 @@ export class NeovimBufferProvider implements BufferEditorProvider {
         onSnapshot: (terminal) => {
           if (!isCurrentOpen()) return;
           this.#terminal = terminal;
-          if (generation === this.#openGeneration) {
+          if (
+            generation === this.#openGeneration &&
+            openSucceeded
+          ) {
             this.#setSnapshot("ready", null);
           } else {
+            // Neovim can paint a complete NORMAL frame before startup returns
+            // the session that handleInput needs. Preserve the loading state
+            // until the whole open succeeds; otherwise the UI advertises an
+            // editor that silently drops early keystrokes.
             this.#emitSnapshot();
           }
         },

--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -3347,34 +3347,35 @@ function registerInstallPs1Tests(): void {
           "tetsuo-ai/agenc-releases",
         );
         mutate(manifest);
-        const fixture = startHttpsFixture(work, {
-          [`/${name}.json`]: { bodyText: JSON.stringify(manifest) },
-        });
         const rewrite = writeGithubArtifactFetchRewrite(work);
         const installerPath = writeInstrumentedInstallPs1(work);
         const home = join(work, `powershell-official-${name}`);
-        try {
-          const result = runPowerShell(
-            home,
-            undefined,
-            join(home, ".agenc"),
-            {
-              AGENC_INSTALL_VERSION: VERSION,
-              NODE_EXTRA_CA_CERTS: fixture.ca,
-              NODE_OPTIONS:
-                `${process.env.NODE_OPTIONS ?? ""} --require=${rewrite}`.trim(),
-              AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL:
-                `${fixture.baseUrl}/${name}.json`,
-            },
-            installerPath,
-          );
-          const output = `${result.stdout}\n${result.stderr}`;
-          expect(result.status, `${name}: ${output}`).not.toBe(0);
-          expect(output, name).toContain(expected);
-          expectFailedInstallCleanup(home);
-        } finally {
-          fixture.stop();
-        }
+        const fetchLog = join(work, `${name}-fetch.log`);
+        const manifestDataUrl =
+          `data:application/json;base64,${
+            Buffer.from(JSON.stringify(manifest), "utf8").toString("base64")
+          }`;
+        const result = runPowerShell(
+          home,
+          undefined,
+          join(home, ".agenc"),
+          {
+            AGENC_INSTALL_VERSION: VERSION,
+            NODE_OPTIONS:
+              `${process.env.NODE_OPTIONS ?? ""} --require=${rewrite}`.trim(),
+            AGENC_INSTALL_TEST_FETCH_LOG: fetchLog,
+            AGENC_INSTALL_TEST_GITHUB_MANIFEST_URL: manifestDataUrl,
+          },
+          installerPath,
+        );
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(result.status, `${name}: ${output}`).not.toBe(0);
+        expect(output, name).toContain(expected);
+        expect(readFileSync(fetchLog, "utf8").trim(), name).toBe(
+          `https://github.com/tetsuo-ai/agenc-releases/releases/download/` +
+            `agenc-v${VERSION}/agenc-runtime-manifest-v2.json`,
+        );
+        expectFailedInstallCleanup(home);
       },
       30_000,
     );

--- a/runtime/tests/tui-e2e-harness-env.test.ts
+++ b/runtime/tests/tui-e2e-harness-env.test.ts
@@ -11,7 +11,10 @@ import {
   tempDaemonEnv,
   tuiE2eGateEnv,
 } from "../scripts/check-tui-e2e/harness.mjs";
-import { runScenario } from "../scripts/check-tui-e2e/runner.mjs";
+import {
+  runScenario,
+  shouldSeedTuiGateDefaultConfig,
+} from "../scripts/check-tui-e2e/runner.mjs";
 import {
   createTuiGateState,
   teardownTuiGateState,
@@ -265,6 +268,77 @@ describe("TUI E2E harness state isolation", () => {
 
     expect(configIndex).toBeGreaterThan(-1);
     expect(daemonIndex).toBeGreaterThan(configIndex);
+  });
+
+  it("seeds prediction-off state before ordinary scenario daemons while preserving first-use consent coverage", () => {
+    const runner = readFileSync(
+      new URL("../scripts/check-tui-e2e/runner.mjs", import.meta.url),
+      "utf8",
+    );
+    const scenarioEntryIndex = runner.indexOf(
+      "async function runScenarioEntry(",
+    );
+    const environmentIndex = runner.indexOf(
+      "gateState.env = environmentForTuiGateState(",
+      scenarioEntryIndex,
+    );
+    const configIndex = runner.indexOf(
+      "await writeTuiGateDefaultConfig(gateState);",
+      scenarioEntryIndex,
+    );
+    const sandboxIndex = runner.indexOf(
+      "await configureTuiGateSandbox(",
+      scenarioEntryIndex,
+    );
+    const daemonIndex = runner.indexOf(
+      "await startTuiGateDaemon(gateState, BIN_AGENC)",
+      scenarioEntryIndex,
+    );
+
+    expect(scenarioEntryIndex).toBeGreaterThan(-1);
+    expect(environmentIndex).toBeGreaterThan(scenarioEntryIndex);
+    expect(configIndex).toBeGreaterThan(environmentIndex);
+    expect(sandboxIndex).toBeGreaterThan(configIndex);
+    expect(daemonIndex).toBeGreaterThan(sandboxIndex);
+    expect(shouldSeedTuiGateDefaultConfig({})).toBe(true);
+    expect(
+      shouldSeedTuiGateDefaultConfig({ firstUsePredictionConsent: false }),
+    ).toBe(true);
+    expect(
+      shouldSeedTuiGateDefaultConfig({ firstUsePredictionConsent: true }),
+    ).toBe(false);
+    expect(() =>
+      shouldSeedTuiGateDefaultConfig({
+        firstUsePredictionConsent: "yes",
+      }),
+    ).toThrow(/must be boolean/u);
+
+    const ordinaryScenarios = [
+      "130-workbench-buffer-neovim-platform-gate.mjs",
+      "131-workbench-buffer-neovim-platform-kill-cleanup.mjs",
+    ].map((scenario) =>
+      readFileSync(
+        new URL(
+          `../scripts/check-tui-e2e/scenarios/${scenario}`,
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    );
+    const consentScenario = readFileSync(
+      new URL(
+        "../scripts/check-tui-e2e/scenarios/133-editor-code-prediction.mjs",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    for (const source of ordinaryScenarios) {
+      expect(source).not.toContain("firstUsePredictionConsent");
+    }
+    expect(consentScenario).toContain("firstUsePredictionConsent: true");
+    expect(consentScenario).toContain("Enable editor code predictions");
+    expect(consentScenario).toContain('session.send("\\x1by")');
   });
 
   it("keeps /init writes out of the source checkout", () => {

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -177,6 +177,8 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(platformGate).toContain(
       'saved.includes("PLATFORM_NVIM_MARK")',
     );
+    expect(platformGate).toContain("nvim-platform-exit.intent");
+    expect(platformGate).toContain("| qa!");
     expect(platformGate).not.toContain(
       '"hosted-platform Neovim edit"',
     );

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -162,6 +162,16 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
         "async function runNeovimCommand",
       );
     }
+    expect(platformGate).toContain(
+      'runEmbeddedNeovimCommand(session, "write")',
+    );
+    expect(platformGate).toContain("waitForFileText");
+    expect(platformGate).toContain(
+      'saved.includes("PLATFORM_NVIM_MARK")',
+    );
+    expect(platformGate).not.toContain(
+      '"hosted-platform Neovim edit"',
+    );
     expect(helpers).toContain("listDescendantNeovimPids");
     expect(helpers).toContain("waitForPidsGone");
     expect(helpers).toContain("waitForFrameText");

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -186,10 +186,16 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
       "nvim-platform-dirty-proof.txt",
     );
     expect(platformKillCleanup).toContain(
+      "autocmd TextChangedI,TextChangedP target.txt",
+    );
+    expect(platformKillCleanup).toContain(
       "writefile(getline(1, '$')",
     );
     expect(platformKillCleanup).toContain(
-      "targetBeforeKill.includes",
+      "targetBeforeKill !== originalTarget",
+    );
+    expect(platformKillCleanup).toContain(
+      "dirtyProof !== expectedDirtyProof",
     );
     expect(platformKillCleanup).toContain("readySession: true");
     expect(platformKillCleanup).not.toContain(

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -21,8 +21,10 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
       send(input: string) {
         events.push(`send:${JSON.stringify(input)}`);
       },
-      async type(input: string) {
-        events.push(`type:${input}`);
+      async type() {
+        throw new Error(
+          "embedded Neovim commands must not fan out into unacknowledged character inputs",
+        );
       },
       async waitForIdle(options: { idleWindow: number }) {
         events.push(`idle:${options.idleWindow}`);
@@ -38,12 +40,14 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(events).toEqual([
       "idle:200",
       'send:"\\u001b"',
-      "type::write",
+      'send:":"',
+      'send:"\\u001b[200~write\\u001b[201~"',
       'send:"\\r"',
       "idle:500",
       "idle:200",
       'send:"\\u001b"',
-      "type::q!",
+      'send:":"',
+      'send:"\\u001b[200~q!\\u001b[201~"',
       'send:"\\r"',
       "idle:500",
     ]);
@@ -206,6 +210,9 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(helpers).toContain("waitForFrameText");
     expect(helpers).toContain("workspaceSnapshot");
     expect(helpers).toContain("anchorWorkbenchProjectRoot");
+    expect(helpers).toContain("\\x1b[200~");
+    expect(helpers).toContain("\\x1b[201~");
+    expect(helpers).not.toContain("session.type(`:${command}`");
     for (const anchoredScenario of [
       scenario,
       missingFallback,

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -2,6 +2,8 @@ import { readFile } from "node:fs/promises";
 
 import { describe, expect, it } from "vitest";
 
+import { runEmbeddedNeovimCommand } from "../../../scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs";
+
 // NOTE: This is a STATIC contract check that the PTY gate scripts exist and
 // declare the expected lifecycle assertions — it does NOT spawn nvim or run a
 // real session. The actual embedded-Neovim PTY end-to-end gate (including the
@@ -10,6 +12,41 @@ import { describe, expect, it } from "vitest";
 // Neovim lane covers four lower-level real-process lifecycle tests; the full
 // PTY scenario remains local, so do not treat this file as e2e coverage.
 describe("embedded Neovim BUFFER PTY gate files", () => {
+  it("enters command mode only after the rendered normal-mode acknowledgement", async () => {
+    const events: string[] = [];
+    const session = {
+      cols: 80,
+      rows: 24,
+      raw: [
+        "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
+        "NORMAL  ctrl+s save",
+      ].join("\n"),
+      send(input: string) {
+        events.push(`send:${JSON.stringify(input)}`);
+        if (input === ":") {
+          this.raw = "CMDLINE_NORMAL  ctrl+s save";
+        }
+      },
+      async type(input: string) {
+        events.push(`type:${input}`);
+      },
+      async waitForIdle(options: { idleWindow: number }) {
+        events.push(`idle:${options.idleWindow}`);
+      },
+    };
+
+    await runEmbeddedNeovimCommand(session, "write");
+
+    expect(events).toEqual([
+      "idle:200",
+      'send:":"',
+      "type:write",
+      'send:"\\r"',
+      "idle:500",
+    ]);
+    expect(events).not.toContain('send:"\\u001b"');
+  });
+
   it("defines the workbench Neovim scenarios and wrapper command", async () => {
     const scenario = await readFile(
       "scripts/check-tui-e2e/scenarios/120-workbench-buffer-neovim.mjs",
@@ -37,6 +74,14 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     );
     const codePrediction = await readFile(
       "scripts/check-tui-e2e/scenarios/133-editor-code-prediction.mjs",
+      "utf8",
+    );
+    const platformGate = await readFile(
+      "scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs",
+      "utf8",
+    );
+    const platformKillCleanup = await readFile(
+      "scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs",
       "utf8",
     );
     const helpers = await readFile(
@@ -118,6 +163,12 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(codePrediction).toContain("prediction text leaked");
     expect(codePrediction).toContain('session.send("\\t")');
     expect(codePrediction).toContain("accepted prediction saved from Neovim");
+    for (const platformScenario of [platformGate, platformKillCleanup]) {
+      expect(platformScenario).toContain("runEmbeddedNeovimCommand");
+      expect(platformScenario).not.toContain(
+        "async function runNeovimCommand",
+      );
+    }
     expect(helpers).toContain("listDescendantNeovimPids");
     expect(helpers).toContain("waitForPidsGone");
     expect(helpers).toContain("waitForFrameText");

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -30,11 +30,20 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     };
 
     await runEmbeddedNeovimCommand(session, "write");
+    session.raw = "";
+    await runEmbeddedNeovimCommand(session, "q!", {
+      readySession: true,
+    });
 
     expect(events).toEqual([
       "idle:200",
       'send:"\\u001b"',
       "type::write",
+      'send:"\\r"',
+      "idle:500",
+      "idle:200",
+      'send:"\\u001b"',
+      "type::q!",
       'send:"\\r"',
       "idle:500",
     ]);
@@ -162,15 +171,27 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
         "async function runNeovimCommand",
       );
     }
-    expect(platformGate).toContain(
-      'runEmbeddedNeovimCommand(session, "write")',
-    );
+    expect(platformGate).toContain('"write", {');
+    expect(platformGate).toContain("readySession: true");
     expect(platformGate).toContain("waitForFileText");
     expect(platformGate).toContain(
       'saved.includes("PLATFORM_NVIM_MARK")',
     );
     expect(platformGate).not.toContain(
       '"hosted-platform Neovim edit"',
+    );
+    expect(platformKillCleanup).toContain(
+      "nvim-platform-dirty-proof.txt",
+    );
+    expect(platformKillCleanup).toContain(
+      "writefile(getline(1, '$')",
+    );
+    expect(platformKillCleanup).toContain(
+      "targetBeforeKill.includes",
+    );
+    expect(platformKillCleanup).toContain("readySession: true");
+    expect(platformKillCleanup).not.toContain(
+      '"dirty hosted-platform Neovim edit"',
     );
     expect(helpers).toContain("listDescendantNeovimPids");
     expect(helpers).toContain("waitForPidsGone");

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -20,6 +20,10 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
       raw: "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
       send(input: string) {
         events.push(`send:${JSON.stringify(input)}`);
+        if (input === ":") {
+          this.raw =
+            "target.txt [embedded Neovim NVIM v0.11.4, normal, ready] CMDLINE_NORMAL";
+        }
       },
       async type() {
         throw new Error(
@@ -181,6 +185,13 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(platformGate).toContain(
       'saved.includes("PLATFORM_NVIM_MARK")',
     );
+    expect(platformGate).toContain("nvim-platform-edit-proof.txt");
+    expect(platformGate).toContain(
+      "autocmd TextChangedI,TextChangedP target.txt",
+    );
+    expect(platformGate).toContain(
+      "editProof !== expectedEditProof",
+    );
     expect(platformGate).toContain("nvim-platform-exit.intent");
     expect(platformGate).toContain("| qa!");
     expect(platformGate).not.toContain(
@@ -210,6 +221,7 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(helpers).toContain("waitForFrameText");
     expect(helpers).toContain("workspaceSnapshot");
     expect(helpers).toContain("anchorWorkbenchProjectRoot");
+    expect(helpers).toContain("/CMDLINE_NORMAL/u");
     expect(helpers).toContain("\\x1b[200~");
     expect(helpers).toContain("\\x1b[201~");
     expect(helpers).not.toContain("session.type(`:${command}`");

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -12,19 +12,16 @@ import { runEmbeddedNeovimCommand } from "../../../scripts/check-tui-e2e/helpers
 // Neovim lane covers four lower-level real-process lifecycle tests; the full
 // PTY scenario remains local, so do not treat this file as e2e coverage.
 describe("embedded Neovim BUFFER PTY gate files", () => {
-  it("enters command mode only after the rendered normal-mode acknowledgement", async () => {
+  it("enters command mode only after committed provider-state acknowledgements", async () => {
     const events: string[] = [];
     const session = {
       cols: 80,
       rows: 24,
-      raw: [
-        "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
-        "NORMAL  ctrl+s save",
-      ].join("\n"),
+      raw: "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
       send(input: string) {
         events.push(`send:${JSON.stringify(input)}`);
         if (input === ":") {
-          this.raw = "CMDLINE_NORMAL  ctrl+s save";
+          this.raw = "CMDLINE_NORMAL";
         }
       },
       async type(input: string) {

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -20,9 +20,6 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
       raw: "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
       send(input: string) {
         events.push(`send:${JSON.stringify(input)}`);
-        if (input === ":") {
-          this.raw = "CMDLINE_NORMAL";
-        }
       },
       async type(input: string) {
         events.push(`type:${input}`);
@@ -36,12 +33,11 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
 
     expect(events).toEqual([
       "idle:200",
-      'send:":"',
-      "type:write",
+      'send:"\\u001b"',
+      "type::write",
       'send:"\\r"',
       "idle:500",
     ]);
-    expect(events).not.toContain('send:"\\u001b"');
   });
 
   it("defines the workbench Neovim scenarios and wrapper command", async () => {

--- a/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
@@ -121,6 +121,64 @@ describe("embedded Neovim BUFFER provider", () => {
     );
   });
 
+  it("keeps an early NORMAL frame loading until the startup session can receive input", async () => {
+    const pending = controlled<EmbeddedNeovimSession>();
+    let onSnapshot:
+      | StartEmbeddedNeovimOptions["onSnapshot"]
+      | null = null;
+    const harness = createHarness({
+      startSession: vi.fn((options: StartEmbeddedNeovimOptions) => {
+        onSnapshot = options.onSnapshot;
+        return pending.promise;
+      }),
+    });
+    const provider = new NeovimBufferProvider(harness.options);
+
+    const opening = provider.open({ filePath: "target.txt" });
+    await flush();
+    const startupFrame = {
+      ...createNeovimRenderSnapshot(20, 80),
+      lines: ["", "    alpha", ""],
+      cursor: { row: 1, column: 4, grid: 1 },
+      mode: "normal",
+    };
+    onSnapshot?.(startupFrame);
+
+    expect(provider.getSnapshot()).toMatchObject({
+      status: "loading",
+      providerStatus: "loading",
+      terminal: {
+        mode: "normal",
+        lines: startupFrame.lines,
+      },
+    });
+    expect(
+      provider.handleInput({
+        input: ":",
+        key: baseKey(),
+        context: { rows: 20, columns: 80 },
+      }),
+    ).toBe(false);
+    expect(harness.session.input).not.toHaveBeenCalled();
+
+    pending.resolve(harness.session);
+    await opening;
+    expect(provider.getSnapshot()).toMatchObject({
+      status: "ready",
+      providerStatus: "ready",
+    });
+
+    expect(
+      provider.handleInput({
+        input: ":",
+        key: baseKey(),
+        context: { rows: 20, columns: 80 },
+      }),
+    ).toBe(true);
+    await flush();
+    expect(harness.session.input).toHaveBeenCalledWith(":");
+  });
+
   it("runs user init once and retries the real startup clean when auto mode fails safely", async () => {
     const harness = createHarness();
     harness.startSession.mockRejectedValueOnce(new Error("user init boom"));

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -2115,6 +2115,8 @@ describe("BufferSurface", () => {
       // handler returns false and the user's native Neovim mapping survives.
       stdin.write("\x1bl");
       await sleep();
+      stdin.write(":");
+      await sleep();
 
       expect(provider.handleInput).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -2137,6 +2139,12 @@ describe("BufferSurface", () => {
         expect.objectContaining({
           input: "l",
           key: expect.objectContaining({ meta: true }),
+        }),
+      );
+      expect(provider.handleInput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: ":",
+          key: expect.objectContaining({ ctrl: false, meta: false }),
         }),
       );
       expect(

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -95,6 +95,9 @@ const bunOnlyTestFiles = bunTestFiles.filter(
 export const DEFAULT_TEST_INCLUDE = Object.freeze([
   'tests/**/*.test.ts',
   'tests/**/*.test.tsx',
+  // This hosted-lane contract is static and hermetic. Keep it in the ordinary
+  // local suite so workflow/scenario drift fails before a platform dispatch.
+  'platform-tests/neovim-platform-gate.contract.test.ts',
 ]);
 
 export const DESIGN_TEST_INCLUDE = Object.freeze([


### PR DESCRIPTION
## Summary

- seed ordinary private TUI gates with prediction mode off before daemon startup while preserving the dedicated first-use consent scenario
- keep the Neovim provider in loading state until its input-owning session is committed
- normalize the committed Neovim session, wait for the real CMDLINE_NORMAL editor state, and deliver each Ex body as one bracketed paste
- prove hosted edits through exact editor-authored TextChangedI/TextChangedP sidecars before Escape, save, or process termination
- run the static hosted Neovim platform contract in the ordinary local test suite so scenario drift fails before dispatch

## Root cause

Two startup races were exposed by slower hosted runners. A first-use prediction overlay could intercept the next editor key, and Neovim could paint a complete NORMAL frame before the provider owned the input session. The PTY helper also treated outer-terminal write completion as Neovim input completion, allowing per-character Ex input or Escape to overtake queued editor input on Windows and Intel Darwin.

The final command path now waits for persistent Neovim command-line state, sends one acknowledged paste body, and waits for concrete filesystem or process effects. The edit path waits for an exact editor-authored sidecar before it can save or kill Neovim.

## Verification

- full local suite on Node 26.5.0: 1,923 files and 17,259 tests passed; 0 failed, 0 skipped
- TypeScript: 0 errors
- checksum-pinned Neovim 0.12.1 platform contracts: 61/61 passed, 0 skipped
- fresh paired PTY stress: 10/10 repetitions, 20/20 scenarios, 0 failures
- build and PTY startup hook: normal and yolo modes passed at 148x40, 120x30, and 80x24
- independent final review: no remaining code or test blocker
- exact-head hosted platform run: 9/9 jobs passed

Hosted evidence: https://github.com/tetsuo-ai/agenc-core/actions/runs/30619272217