### PR TITLE
fix(packaging): preserve flattened Homebrew runtime

### DIFF
--- a/packaging/homebrew/agenc.rb
+++ b/packaging/homebrew/agenc.rb
@@ -20,7 +20,7 @@ class Agenc < Formula
 
   def install
     odie "AgenC requires macOS 13.5 or newer." if MacOS.full_version < "13.5"
-    libexec.install "node_modules"
+    (libexec/"node_modules").install buildpath.children
 
     node_bin = libexec/"node_modules/.agenc-node/bin/node"
     runtime_bin = libexec/"node_modules/@tetsuo-ai/runtime/bin/agenc"

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -2,7 +2,9 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { parse } from "yaml";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import { waitForExactFileText } from "../scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs";
 
 import {
   HOSTED_NEOVIM_SCENARIOS,
@@ -58,6 +60,28 @@ const EXPECTED_TARGETS = {
 } as const;
 
 describe("hosted Neovim platform gate contract", () => {
+  it("waits through marker-bearing partial proof reads until the bytes are exact", async () => {
+    const expected = "platform-alpha\nPLATFORM_NVIM_MARK\n";
+    const reads = [
+      "platform-alpha\nPLATFORM_NVIM_MARK",
+      expected,
+    ];
+    const readText = vi.fn(async () => reads.shift() ?? expected);
+    const wait = vi.fn(async () => {});
+
+    await expect(
+      waitForExactFileText(
+        "/private/proof.txt",
+        expected,
+        1_000,
+        "platform edit proof",
+        { readText, wait },
+      ),
+    ).resolves.toBe(expected);
+    expect(readText).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledOnce();
+  });
+
   it("pins every required hosted target without changing the legacy Linux release pin", () => {
     const toolchain = JSON.parse(
       readFileSync(resolve(REPO_ROOT, "release-toolchain.json"), "utf8"),
@@ -155,18 +179,31 @@ describe("hosted Neovim platform gate contract", () => {
     );
     expect(saveScenario).toContain('"write", {');
     expect(saveScenario).toContain("readySession: true");
-    expect(saveScenario).toContain("waitForFileText(");
+    expect(saveScenario).toContain("waitForExactFileText(");
+    expect(saveScenario).toMatch(
+      /waitForExactFileText\(\s*editProofFile,\s*expectedEditProof,/u,
+    );
+    expect(saveScenario).not.toMatch(
+      /waitForFileText\(\s*editProofFile,/u,
+    );
+    expect(saveScenario).toMatch(
+      /waitForExactFileText\(\s*target,\s*expectedEditProof,/u,
+    );
+    expect(saveScenario).not.toMatch(
+      /waitForFileText\(\s*target,/u,
+    );
     expect(saveScenario).toContain("PLATFORM_NVIM_MARK");
     expect(saveScenario).toContain("nvim-platform-edit-proof.txt");
     expect(saveScenario).toContain(
       "autocmd TextChangedI,TextChangedP target.txt",
     );
     expect(saveScenario).toContain("editProof !== expectedEditProof");
+    expect(saveScenario).toContain("saved !== expectedEditProof");
     const editInputIndex = saveScenario.indexOf(
       'session.type("PLATFORM_NVIM_MARK"',
     );
     const editProofWaitIndex = saveScenario.indexOf(
-      "const editProof = await waitForFileText(",
+      "const editProof = await waitForExactFileText(",
     );
     const editEscapeIndex = saveScenario.indexOf(
       'session.send("\\x1b")',
@@ -204,6 +241,12 @@ describe("hosted Neovim platform gate contract", () => {
       "autocmd TextChangedI,TextChangedP target.txt",
     );
     expect(killScenario).toContain("writefile(getline(1, '$')");
+    expect(killScenario).toMatch(
+      /waitForExactFileText\(\s*dirtyProofFile,\s*expectedDirtyProof,/u,
+    );
+    expect(killScenario).not.toMatch(
+      /waitForFileText\(\s*dirtyProofFile,/u,
+    );
     expect(killScenario).toContain("targetBeforeKill !== originalTarget");
     expect(killScenario).toContain("dirtyProof !== expectedDirtyProof");
     expect(killScenario).toContain("readySession: true");
@@ -214,7 +257,7 @@ describe("hosted Neovim platform gate contract", () => {
       'session.type("UNSAVED_PLATFORM_KILL_MARK"',
     );
     const dirtyProofWaitIndex = killScenario.indexOf(
-      "const dirtyProof = await waitForFileText(",
+      "const dirtyProof = await waitForExactFileText(",
     );
     expect(dirtyAcknowledgementIndex).toBeGreaterThan(-1);
     expect(dirtyInputIndex).toBeGreaterThan(dirtyAcknowledgementIndex);

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -46,6 +46,33 @@ export async function waitForFrameText(session, pattern, label, timeoutMs = 10_0
     await sleep(100);
   }
   throw new Error(`${label} did not render in the latest PTY frame: ${frame.slice(-1200)}`);
+}
+
+export async function waitForExactFileText(
+  path,
+  expected,
+  timeoutMs,
+  label,
+  {
+    readText = (candidatePath) => readFile(candidatePath, "utf8"),
+    wait = sleep,
+  } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    try {
+      last = await readText(path);
+    } catch {
+      last = "";
+    }
+    if (last === expected) return last;
+    await wait(50);
+  }
+  throw new Error(
+    `${label} did not become exact at ${path} within ${timeoutMs}ms: ` +
+      `expected ${JSON.stringify(expected)}, last ${JSON.stringify(last)}`,
+  );
 }
 
 export async function runEmbeddedNeovimCommand(

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   anchorWorkbenchProjectRoot,
   runEmbeddedNeovimCommand,
+  waitForExactFileText,
   waitForFrameText,
   waitForScreen,
 } from "../helpers/workbench-buffer-neovim.mjs";
@@ -56,12 +57,13 @@ export default async function (session) {
     session.send("o");
     await sleep(80);
     await session.type("PLATFORM_NVIM_MARK", { perCharMs: 15 });
-    const editProof = await waitForFileText(
-      editProofFile,
-      /PLATFORM_NVIM_MARK/u,
-      5_000,
-    );
     const expectedEditProof = `${originalTarget}PLATFORM_NVIM_MARK\n`;
+    const editProof = await waitForExactFileText(
+      editProofFile,
+      expectedEditProof,
+      5_000,
+      "Neovim platform edit proof",
+    );
     if (editProof !== expectedEditProof) {
       throw new Error(
         `Neovim platform edit proof was not exact: ${JSON.stringify(editProof)}`,
@@ -78,13 +80,16 @@ export default async function (session) {
       readySession: true,
     });
     await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
-    const saved = await waitForFileText(
+    const saved = await waitForExactFileText(
       target,
-      /PLATFORM_NVIM_MARK/u,
+      expectedEditProof,
       10_000,
+      "saved Neovim platform edit",
     );
-    if (!saved.includes("PLATFORM_NVIM_MARK")) {
-      throw new Error(`embedded Neovim did not save the platform marker: ${saved}`);
+    if (saved !== expectedEditProof) {
+      throw new Error(
+        `embedded Neovim save was not exact: ${JSON.stringify(saved)}`,
+      );
     }
 
     await runEmbeddedNeovimCommand(

--- a/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   anchorWorkbenchProjectRoot,
   runEmbeddedNeovimCommand,
+  waitForExactFileText,
   waitForFrameText,
   waitForScreen,
 } from "../helpers/workbench-buffer-neovim.mjs";
@@ -86,13 +87,14 @@ export default async function (session) {
     session.send("o");
     await sleep(80);
     await session.type("UNSAVED_PLATFORM_KILL_MARK", { perCharMs: 15 });
-    const dirtyProof = await waitForFileText(
-      dirtyProofFile,
-      /UNSAVED_PLATFORM_KILL_MARK/u,
-      5_000,
-    );
     const expectedDirtyProof =
       `${originalTarget}UNSAVED_PLATFORM_KILL_MARK\n`;
+    const dirtyProof = await waitForExactFileText(
+      dirtyProofFile,
+      expectedDirtyProof,
+      5_000,
+      "Neovim dirty-buffer proof",
+    );
     if (dirtyProof !== expectedDirtyProof) {
       throw new Error(
         `Neovim dirty-buffer proof was not exact: ${JSON.stringify(dirtyProof)}`,
@@ -173,19 +175,6 @@ async function readPidFile(path) {
     await sleep(50);
   }
   throw new Error(`embedded Neovim did not write its pid file: ${path}`);
-}
-
-async function waitForFileText(path, pattern, timeoutMs) {
-  const deadline = Date.now() + timeoutMs;
-  let last = "";
-  while (Date.now() < deadline) {
-    last = await readFile(path, "utf8").catch(() => "");
-    if (pattern.test(last)) return last;
-    await sleep(50);
-  }
-  throw new Error(
-    `dirty Neovim buffer proof did not update ${path} within ${timeoutMs}ms: ${last}`,
-  );
 }
 
 function processIsAlive(pid) {

--- a/runtime/tests/packaging/distribution.test.ts
+++ b/runtime/tests/packaging/distribution.test.ts
@@ -126,7 +126,38 @@ describe("homebrew packaging", () => {
     expect(formula).toContain("OWNER-PUBLISH STEP");
     // Homebrew installs the immutable artifact directly and never performs
     // nested network installation during a formula build.
-    expect(formula).toContain('libexec.install "node_modules"');
     expect(formula).not.toContain('libexec.install Dir["node_modules"]');
+  });
+
+  test("recreates node_modules from Homebrew's flattened archive root", () => {
+    const formula = readFileSync(
+      join(REPO_ROOT, "packaging", "homebrew", "agenc.rb"),
+      "utf8",
+    );
+    const archiveBuilder = readFileSync(
+      join(
+        REPO_ROOT,
+        "packages",
+        "agenc",
+        "scripts",
+        "build-runtime-tarball.mjs",
+      ),
+      "utf8",
+    );
+
+    // Runtime archives have one node_modules root. Homebrew enters that sole
+    // directory before install, so the build path contains its children rather
+    // than another nested node_modules directory. Pathname#children preserves
+    // dot-prefixed runtime entries such as .agenc-node and .bin.
+    expect(archiveBuilder).toContain(
+      'canonicalArchiveEntries(installRoot, "node_modules")',
+    );
+    expect(formula).toContain(
+      '(libexec/"node_modules").install buildpath.children',
+    );
+    expect(formula).not.toContain('libexec.install "node_modules"');
+    expect(formula).not.toContain('Dir["*"]');
+    expect(formula).toContain('node_modules/.agenc-node/bin/node');
+    expect(formula).toContain('node_modules/@tetsuo-ai/runtime/bin/agenc');
   });
 });

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -182,9 +182,13 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(platformGate).toContain('"write", {');
     expect(platformGate).toContain("readySession: true");
     expect(platformGate).toContain("waitForFileText");
-    expect(platformGate).toContain(
-      'saved.includes("PLATFORM_NVIM_MARK")',
+    expect(platformGate).toMatch(
+      /waitForExactFileText\(\s*target,\s*expectedEditProof,/u,
     );
+    expect(platformGate).not.toMatch(
+      /waitForFileText\(\s*target,/u,
+    );
+    expect(platformGate).toContain("saved !== expectedEditProof");
     expect(platformGate).toContain("nvim-platform-edit-proof.txt");
     expect(platformGate).toContain(
       "autocmd TextChangedI,TextChangedP target.txt",


### PR DESCRIPTION
Summary:
- rebuild libexec/node_modules from Homebrew’s flattened single-root runtime archive
- preserve hidden runtime entries, including .agenc-node and .bin
- add a regression contract that rejects the broken nested-node_modules install and hidden-file-dropping globs

Local verification:
- ruby -c packaging/homebrew/agenc.rb
- targeted packaging test: 5/5 passed
- npm run typecheck
- npm test: 1,923 files / 17,260 tests passed
- pre-commit build and PTY startup smoke: passed