### PR TITLE
refactor(runtime): streamline process broker lifecycle

### DIFF
--- a/runtime/native/agenc-process-broker.c
+++ b/runtime/native/agenc-process-broker.c
@@ -60,6 +60,8 @@ struct child_signal_context {
 };
 
 int main(int argc, char **argv);
+static int launch_supervised_target(int argc, char **argv, sigset_t *wait_mask);
+static int complete_broker_cleanup(void);
 static int validate_invocation(int argc);
 static int prepare_broker(sigset_t *wait_mask);
 static int block_control_signals(sigset_t *wait_mask);
@@ -111,44 +113,60 @@ static pid_t root_pid = AGENC_BROKER_INVALID_ROOT_PID;
 
 int main(int argc, char **argv) {
   sigset_t wait_mask;
-  char **target_argv;
   int root_status = AGENC_BROKER_EMPTY_WAIT_STATUS;
-  bool residual_observed = false;
 
-  if (validate_invocation(argc) != AGENC_BROKER_SUCCESS) {
-    return AGENC_BROKER_ERROR_EXIT;
-  }
-  if (prepare_broker(&wait_mask) != AGENC_BROKER_SUCCESS) {
-    return AGENC_BROKER_ERROR_EXIT;
-  }
-  target_argv = create_target_argv(argc, argv);
-  if (target_argv == NULL) {
-    return AGENC_BROKER_ERROR_EXIT;
-  }
-  if (start_root_process(argv[AGENC_BROKER_PROGRAM_ARGUMENT], target_argv) !=
+  if (launch_supervised_target(argc, argv, &wait_mask) !=
       AGENC_BROKER_SUCCESS) {
-    free(target_argv);
     return AGENC_BROKER_ERROR_EXIT;
   }
-  free(target_argv);
-  (void)close(STDIN_FILENO);
-
   if (monitor_root_process(&wait_mask, &root_status) != AGENC_BROKER_SUCCESS) {
     return AGENC_BROKER_ERROR_EXIT;
   }
+  if (complete_broker_cleanup() != AGENC_BROKER_SUCCESS) {
+    return AGENC_BROKER_ERROR_EXIT;
+  }
+  exit_like_root(root_status);
+}
+
+static int launch_supervised_target(int argc, char **argv,
+                                    sigset_t *wait_mask) {
+  char **target_argv;
+  int launch_result;
+
+  if (validate_invocation(argc) != AGENC_BROKER_SUCCESS ||
+      prepare_broker(wait_mask) != AGENC_BROKER_SUCCESS) {
+    return AGENC_BROKER_FAILURE;
+  }
+  target_argv = create_target_argv(argc, argv);
+  if (target_argv == NULL) {
+    return AGENC_BROKER_FAILURE;
+  }
+  launch_result =
+      start_root_process(argv[AGENC_BROKER_PROGRAM_ARGUMENT], target_argv);
+  free(target_argv);
+  if (launch_result != AGENC_BROKER_SUCCESS) {
+    return AGENC_BROKER_FAILURE;
+  }
+  (void)close(STDIN_FILENO);
+  return AGENC_BROKER_SUCCESS;
+}
+
+static int complete_broker_cleanup(void) {
+  bool residual_observed = false;
+
   if (observe_residual_descendants(&residual_observed) !=
       AGENC_BROKER_SUCCESS) {
-    return AGENC_BROKER_ERROR_EXIT;
+    return AGENC_BROKER_FAILURE;
   }
   if (force_cleanup_descendants() != AGENC_BROKER_SUCCESS) {
     report_errno("descendant cleanup failed");
-    return AGENC_BROKER_ERROR_EXIT;
+    return AGENC_BROKER_FAILURE;
   }
   if (publish_cleanup_status(residual_observed) != AGENC_BROKER_SUCCESS) {
-    return AGENC_BROKER_ERROR_EXIT;
+    return AGENC_BROKER_FAILURE;
   }
   (void)close(AGENC_BROKER_STATUS_FD);
-  exit_like_root(root_status);
+  return AGENC_BROKER_SUCCESS;
 }
 
 static int validate_invocation(int argc) {

--- a/runtime/tests/utils/supervisedProcess.test.ts
+++ b/runtime/tests/utils/supervisedProcess.test.ts
@@ -1111,6 +1111,32 @@ describe("process-tree root safety", () => {
         /(?<![A-Za-z0-9_])(?:0[xX][0-9A-Fa-f]+|[0-9]+[uUlL]*)(?![A-Za-z0-9_])/u,
       );
 
+      const mainEnd = functionDefinitions[1]?.index ?? brokerSource.length;
+      const mainImplementation = brokerSource.slice(mainDefinition, mainEnd);
+      const normalizeCSource = (source: string): string =>
+        source.replace(/\s+/gu, " ").trim();
+      expect(normalizeCSource(mainImplementation)).toBe(
+        normalizeCSource(`
+          int main(int argc, char **argv) {
+            sigset_t wait_mask;
+            int root_status = AGENC_BROKER_EMPTY_WAIT_STATUS;
+
+            if (launch_supervised_target(argc, argv, &wait_mask) !=
+                AGENC_BROKER_SUCCESS) {
+              return AGENC_BROKER_ERROR_EXIT;
+            }
+            if (monitor_root_process(&wait_mask, &root_status) !=
+                AGENC_BROKER_SUCCESS) {
+              return AGENC_BROKER_ERROR_EXIT;
+            }
+            if (complete_broker_cleanup() != AGENC_BROKER_SUCCESS) {
+              return AGENC_BROKER_ERROR_EXIT;
+            }
+            exit_like_root(root_status);
+          }
+        `),
+      );
+
       const childSetupDefinitionIndex = functionDefinitions.findIndex(
         (definition) => definition[1] === "run_target_child",
       );


### PR DESCRIPTION
## Summary

- reduce the Linux process broker main function to launch, monitor, cleanup, and exit stages
- isolate target setup/launch and descendant cleanup in focused helpers
- enforce the exact main lifecycle and error mapping in the broker structural test

## Validation

- strict GCC and Clang production-flag builds
- direct fd3 protocol probe: target exit 7, broker status SC
- 23/23 supervised-process tests
- npm run typecheck
- npm run build
- npm run check:tui-runtime-startup --workspace=@tetsuo-ai/runtime
- npm test: 1,916 files / 17,194 tests passed