### PR TITLE
test(runtime): add critical-path benchmark baselines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,8 @@ runtime/bin/agenc-linux-sandbox text eol=lf
 # Runtime manifests bind every native build to the exact committed lockfile
 # bytes. Keep that identity stable across Windows and POSIX checkouts.
 package-lock.json text eol=lf
+
+# FND benchmark artifacts are canonical byte-for-byte evidence. Their embedded
+# digest and canonical-JSON checks require LF on every supported checkout.
+runtime/benchmarks/fnd/baseline.v1.json text eol=lf
+runtime/benchmarks/fnd/baseline.v1.md text eol=lf

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -976,6 +976,7 @@ jobs:
           node runtime/scripts/run-hermetic-vitest.mjs \
             --require-zero-skips \
             run \
+            tests/fnd/benchmark-harness-faults.test.ts \
             tests/fnd/bounded-file-io.test.ts \
             tests/fnd/fnd-fixtures.test.ts \
             tests/fnd/portable-repository-path.test.ts \
@@ -994,6 +995,7 @@ jobs:
           if (!resultsPath) throw new Error("missing macOS-native results path");
           const results = JSON.parse(readFileSync(resultsPath, "utf8"));
           const expectedFiles = [
+            "tests/fnd/benchmark-harness-faults.test.ts",
             "tests/fnd/bounded-file-io.test.ts",
             "tests/fnd/fnd-fixtures.test.ts",
             "tests/fnd/portable-repository-path.test.ts",
@@ -1001,12 +1003,12 @@ jobs:
             "tests/tools/runtimes/runtime.darwin.test.ts",
           ];
           const exactCounts = {
-            numTotalTestSuites: 8,
-            numPassedTestSuites: 8,
+            numTotalTestSuites: 10,
+            numPassedTestSuites: 10,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 45,
-            numPassedTests: 45,
+            numTotalTests: 81,
+            numPassedTests: 81,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -1033,7 +1035,7 @@ jobs:
               `macOS-native files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
             );
           }
-          console.log("macOS FND/native capability lane passed 45 tests in 5 files with zero skipped");
+          console.log("macOS FND/native capability lane passed 81 tests in 6 files with zero skipped");
           NODE
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
 
@@ -1106,6 +1108,7 @@ jobs:
             run `
             tests/app-server/windows-named-pipe.win32.test.ts `
             tests/durability/atomic-artifact.win32.test.ts `
+            tests/fnd/benchmark-harness-faults.test.ts `
             tests/fnd/bounded-file-io.test.ts `
             tests/fnd/fnd-fixtures.test.ts `
             tests/fnd/portable-repository-path.test.ts `
@@ -1127,6 +1130,7 @@ jobs:
           const expectedFiles = [
             "tests/app-server/windows-named-pipe.win32.test.ts",
             "tests/durability/atomic-artifact.win32.test.ts",
+            "tests/fnd/benchmark-harness-faults.test.ts",
             "tests/fnd/bounded-file-io.test.ts",
             "tests/fnd/fnd-fixtures.test.ts",
             "tests/fnd/portable-repository-path.test.ts",
@@ -1134,12 +1138,12 @@ jobs:
             "tests/utils/execFileNoThrow.win32.test.ts",
           ];
           const exactCounts = {
-            numTotalTestSuites: 11,
-            numPassedTestSuites: 11,
+            numTotalTestSuites: 13,
+            numPassedTestSuites: 13,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 49,
-            numPassedTests: 49,
+            numTotalTests: 86,
+            numPassedTests: 86,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -1162,7 +1166,7 @@ jobs:
               `Windows-native files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
             );
           }
-          console.log("Windows FND/native capability lane passed 49 tests in 7 files with zero skipped");
+          console.log("Windows FND/native capability lane passed 86 tests in 8 files with zero skipped");
           '@ | node --input-type=module - $results
           if ($LASTEXITCODE -ne 0) { throw "Windows native result contract failed" }
           if (-not [string]::IsNullOrWhiteSpace(

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ obj/
 !docs/api-baseline/*.json
 !docs/security/fender-medium-baseline.json
 !docs/security/fender-full-baseline.json
+!runtime/benchmarks/fnd/*.json
 !mcp/security-stack.mcp.json
 !mcp/tests/fixtures/golden/*.json
 !scripts/idl/*.json

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -912,14 +912,18 @@ postcondition; this narrow lane is not an OS egress boundary.
 The `neovim` job similarly provisions the official digest- and byte-pinned
 Neovim 0.12.1 Linux binary and requires all four real-process lifecycle tests
 in its one-file allowlist. The `macos-native` and `windows-native` jobs first
-run the shared 44-test, seven-suite, four-file FND set used by release builders.
-The macOS job adds one Seatbelt test for an exact total of 45 tests, eight
-suites, and five files. The Windows PR job adds its named-pipe and
-atomic-publication/`.cmd` contracts for an exact total of 49 tests, eleven
-suites, and seven files; the Windows release subset excludes the two
-named-pipe-only PR tests and therefore contains 47 tests, ten suites, and six
-files. Every result parser requires its exact reviewed suite, test, and file
-counts with no failed, pending, skipped, or todo tests.
+run a shared 80-test, eight-suite, five-file FND set. It combines the 44-test
+release-builder set with 36 benchmark-harness fault contracts for process-tree
+containment, owned-root retention, exclusive artifact publication, minimal
+subprocess environments, bounded metadata commands, and provenance binding.
+The macOS job adds one Seatbelt test for an exact total of 81 tests, ten
+suites, and six files. The Windows PR job adds its named-pipe and
+atomic-publication/`.cmd` contracts for an exact total of 86 tests, thirteen
+suites, and eight files. Release builders deliberately retain their narrower
+44-test shared set: the Windows release subset excludes the two named-pipe-only
+PR tests and the benchmark fault contract, so it remains 47 tests, ten suites,
+and six files. Every result parser requires its exact reviewed suite, test, and
+file counts with no failed, pending, skipped, or todo tests.
 
 This narrow hosted check supplements the local required gate; it does not
 replace or authorize the broader test, typecheck, build, TUI, or release

--- a/runtime/benchmarks/fnd/README.md
+++ b/runtime/benchmarks/fnd/README.md
@@ -1,0 +1,159 @@
+# FND algorithm baselines
+
+This directory contains the FND-001 deterministic microbenchmark harness and
+the checked-in observation of AgenC's audited CSV scheduler, patch parser,
+JavaScript regex fallback, and fuzzy-search failure modes.
+
+The baseline is deliberately not a performance gate. Every case is classified
+as `known_failure_observation`, has `gateEnforced: false`, and has no threshold.
+Future fixes must add separate correctness/resource/asymptotic gates; they must
+not relabel these known-bad measurements as passing.
+
+## Isolation and measurement
+
+- Each case and input point runs in a fresh child process under an external
+  deadline. Linux workers use the production cgroup/subreaper boundary;
+  Windows workers are created inside the production Job Object broker before
+  target launch; Darwin retains its process group plus observed descendant
+  identities. A successful worker flushes an authenticated completion record
+  and remains alive until the supervisor initiates contained teardown. Forced
+  termination has a separate bounded settlement deadline. On Linux and
+  Windows, timeout, output-limit, residual-process, or normal-exit handling does
+  not settle successfully until the ownership boundary reports quiescence. On
+  Darwin, the supervisor confirms that the process group and every descendant
+  identity it observed are gone, but cannot prove containment of a process that
+  forks, calls `setsid`, and reparents entirely between observation snapshots.
+  The regex case runs three fresh children because synchronous V8 backtracking
+  prevents in-process cancellation.
+- The supervisor creates and owns every temporary root before launch, passes it
+  to the child, and removes it after exit even when setup times out before the
+  worker can emit its start record. If recursive settlement cannot be proven,
+  cleanup fails closed: the root is retained and its exact path is reported for
+  operator inspection instead of being deleted under a possibly live process.
+  Automatic cleanup is bound to the original directory device/inode identity
+  and refuses a missing or replaced pathname. Manual cleanup of a reported
+  retained path is an explicit operator action rather than an automatic proof.
+- Fixtures are deterministically generated after the case is selected. No
+  checked-in bulk corpus, repository content, user path, prompt, or transcript
+  becomes benchmark input.
+- The runner requires an empty direct Node `execArgv` and rejects every
+  nonempty ambient `NODE_*` or `TSX_*` entry, case-insensitively. These are
+  reproducibility checks against visible runtime controls, not a security
+  boundary: code requested by `NODE_OPTIONS` can execute before the runner can
+  inspect the environment. Workers receive a fixed, minimal environment with
+  no inherited home, path, provider key, or other secret-bearing variable.
+  `AGENC_HOME`, `TEMP`, `TMP`, and `TMPDIR` all resolve to the supervisor-owned
+  per-worker root, so workers never share the ambient temporary namespace.
+  Windows carries only the case-insensitively matched `SystemRoot` value needed
+  by the worker; libuv's finite required-variable set is removed before
+  validation and before any measured production module loads. `tsx` uses no
+  ambient TypeScript config or disk cache.
+- Git, ripgrep, npm-version, and other metadata commands run through the same
+  production process-containment boundary with a minimal locale/PATH bootstrap
+  and no inherited home, provider, wallet, or cloud credentials. A referenced
+  outer supervisor enforces a hard deadline; Linux and Windows retain detached
+  descendants even when a target ignores `SIGTERM`, while Darwin carries the
+  observed-descendant limitation above. On Windows, Git is resolved to a
+  canonical regular file from a bounded `PATH`, in directory order with
+  `.com` before `.exe`; the checkout directory is never an implicit executable
+  source. npm metadata resolves only from fixed layouts beneath the canonical
+  current Node installation and ignores ambient `npm_execpath` injection.
+- The daemon fuzzy case fails closed if its temporary root or any ancestor has
+  `.ignore` or `.git` control state. This prevents host ignore files and global
+  Git configuration from becoming undeclared fixture inputs.
+- Setup and index construction happen before warmup and timed samples. Completed
+  cases report five or more measured samples; the regex case reports the median
+  and median absolute deviation of three supervisor kills.
+- Elapsed time uses `performance.now()`. Operation counts are exact where the
+  current implementation exposes a direct count and otherwise carry an
+  explicitly named upper bound.
+- Completed workers report the process high-water RSS from
+  `process.resourceUsage().maxRSS`, normalized from KiB to bytes. Endpoint RSS
+  samples remain a separately labeled lower-bound diagnostic. A synchronously
+  blocked worker that is forcibly terminated cannot emit its final high-water
+  mark, so that point records an unavailable peak plus its last start-RSS lower
+  bound instead of presenting the lower bound as a peak.
+- The complete tracked `runtime/src` tree is bound to its exact Git tree object
+  at the recorded ancestor revision. Capture rejects staged, unstaged, ignored,
+  or ordinary untracked production-tree files before and after measurement.
+  The loader records the exact production-module closure actually loaded by
+  every case, including transitive imports. Those modules carry immutable Git
+  blob bindings and are compared with the current checkout by `--check`;
+  unrelated `runtime/src` changes do not stale the historical observation. Git
+  metadata commands strip ambient repository, index, object, and config
+  overrides. Separate LF-normalized SHA-256 bindings cover checkout attributes,
+  the worker, fixture generator, environment policy, loader tracker, contract,
+  supervisor, provenance code, runtime manifest, and lockfile.
+- This observation assumes a quiescent, trusted checkout. The endpoint checks
+  reject changes visible before or after execution, but cannot detect a file
+  that another actor mutates, executes, and restores entirely between those
+  checks. Git and the `PATH` used to resolve it, Node, npm, `tsx`, installed
+  `node_modules`, ripgrep, the native compiler, and the host system toolchain
+  are trusted inputs. The artifact is bounded reproducibility evidence, not a
+  cryptographic attestation of every byte executed by the host.
+- macOS injects `__CF_USER_TEXT_ENCODING` while starting a process even when the
+  supervisor supplies a minimal environment. The case worker accepts only the
+  bounded hexadecimal CoreFoundation form and removes it before loading any
+  measured production module; every other inherited name remains an error.
+- Windows process creation similarly restores libuv's documented required
+  variables when they are absent. The case worker removes the finite injected
+  set before its exact allowlist check; unrelated inherited names remain an
+  error.
+- Baseline and evidence files are opened with no-follow and nonblocking flags
+  where the platform exposes them, then type-, size-, and identity-checked
+  through one bounded descriptor before and after reading. Reads allocate only
+  the named ceiling plus a one-byte overflow probe and reject pathname swaps,
+  links, special files, growth, and oversized inputs.
+
+## Named fixture bounds
+
+| Case                     | Bounded generated inputs                                                  | Child deadline |
+| ------------------------ | ------------------------------------------------------------------------- | -------------: |
+| CSV scheduler/progress   | at most 4,096 rows and 524,288 generated bytes                            |           45 s |
+| Delete-only patch parser | at most 32,768 hunks and 2,097,152 generated bytes                        |           45 s |
+| Regex fallback           | one file, 30 repeated characters, 4,096 generated bytes                   |          2.5 s |
+| Daemon fuzzy matcher     | 32 candidates, 128 path-stem units, 8 query units, 65,536 generated bytes |           45 s |
+| TUI fuzzy matcher        | two candidates, 69 query units, 4,096 generated bytes                     |           10 s |
+
+Worker output is independently capped at 1,048,576 bytes. JSON output is capped
+at 2,097,152 bytes and Markdown at 262,144 bytes. Metadata subprocesses have a
+five-second deadline and bounded output. The harness does not contain a hidden
+stress mode or accept caller-supplied fixture sizes.
+
+Artifact publication creates both caller paths exclusively and never truncates
+an existing file. If the second creation fails, the first is removed only after
+its still-open descriptor and current pathname identity match; a replaced or
+otherwise unprovable path is retained and reported. This makes failures clean
+up the pair safely, but it does not claim impossible simultaneous visibility
+across two independent filesystem pathnames.
+
+## Commands
+
+Use Node 26.5.0 and npm 11.17.0. Capture into temporary paths so a local run
+cannot silently replace the reviewed artifact:
+
+```sh
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- \
+  --source-revision HEAD \
+  --output /tmp/agenc-fnd-baseline.v1.json \
+  --markdown-output /tmp/agenc-fnd-baseline.v1.md
+
+npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --plan
+```
+
+`--source-revision` must resolve to an ancestor whose complete `runtime/src`
+tree exactly matches the checkout. Use the topic's parent when the benchmark
+harness and generated artifact are being committed together; this avoids a
+self-reference while still binding every executed production dependency.
+
+Compare runs made on the same pinned runtime and machine state. Review raw
+samples, median absolute deviation, operation counts, and relative scaling.
+Absolute wall-clock differences remain informative rather than gating until a
+separate, platform-calibrated gate is justified.
+
+`baseline.v1.json` is canonical JSON. `baseline.v1.md` is generated
+deterministically from it, embeds the JSON SHA-256, records the reproduction
+command, and summarizes machine/OS/CPU/RAM/filesystem, Node/npm, SQLite, and
+ripgrep metadata. Source-checkout and temporary-fixture filesystems are recorded
+separately because they may be different mounts.

--- a/runtime/benchmarks/fnd/artifact-output.mjs
+++ b/runtime/benchmarks/fnd/artifact-output.mjs
@@ -1,0 +1,147 @@
+import {
+  closeSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+
+const FILE_SYSTEM_OPERATIONS = Object.freeze({
+  closeSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  unlinkSync,
+  writeFileSync,
+});
+
+export function publishBenchmarkArtifacts(artifacts, operationOverrides = {}) {
+  const validated = validateArtifacts(artifacts);
+  const operations = { ...FILE_SYSTEM_OPERATIONS, ...operationOverrides };
+  const ownedArtifacts = [];
+  try {
+    ownedArtifacts.push(
+      createExclusiveArtifact(validated.jsonPath, validated.json, operations),
+    );
+    ownedArtifacts.push(
+      createExclusiveArtifact(
+        validated.markdownPath,
+        validated.markdown,
+        operations,
+      ),
+    );
+    for (const artifact of ownedArtifacts) closeArtifact(artifact, operations);
+  } catch (error) {
+    const cleanupErrors = [];
+    for (const artifact of ownedArtifacts.reverse()) {
+      try {
+        removeOwnedArtifact(artifact, operations);
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupErrors],
+        "benchmark artifact publication failed and owned-output cleanup was incomplete",
+      );
+    }
+    throw new Error(
+      "benchmark artifact publication failed without replacing existing files",
+      { cause: error },
+    );
+  }
+}
+
+function createExclusiveArtifact(path, content, operations) {
+  const descriptor = operations.openSync(path, "wx", 0o600);
+  const artifact = {
+    descriptor,
+    path,
+    closed: false,
+    identity: undefined,
+  };
+  try {
+    artifact.identity = fileIdentity(operations.fstatSync(descriptor));
+    operations.writeFileSync(descriptor, content, "utf8");
+    operations.fsyncSync(descriptor);
+    return artifact;
+  } catch (error) {
+    try {
+      removeOwnedArtifact(artifact, operations);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        `failed to create and clean partial benchmark artifact ${path}`,
+      );
+    }
+    throw error;
+  }
+}
+
+function removeOwnedArtifact(artifact, operations) {
+  if (artifact.closed) {
+    throw new Error(
+      `cannot prove ownership while cleaning benchmark artifact ${artifact.path}`,
+    );
+  }
+  if (artifact.identity === undefined) {
+    closeArtifact(artifact, operations);
+    throw new Error(
+      `retained unproven partial benchmark artifact ${artifact.path}`,
+    );
+  }
+  const descriptorIdentity = fileIdentity(
+    operations.fstatSync(artifact.descriptor),
+  );
+  const pathMetadata = operations.lstatSync(artifact.path);
+  const pathIdentity = fileIdentity(pathMetadata);
+  if (
+    pathMetadata.isSymbolicLink() ||
+    !pathMetadata.isFile() ||
+    !sameFileIdentity(artifact.identity, descriptorIdentity) ||
+    !sameFileIdentity(artifact.identity, pathIdentity)
+  ) {
+    closeArtifact(artifact, operations);
+    throw new Error(
+      `refused to remove replaced benchmark artifact ${artifact.path}`,
+    );
+  }
+  try {
+    operations.unlinkSync(artifact.path);
+  } finally {
+    closeArtifact(artifact, operations);
+  }
+}
+
+function closeArtifact(artifact, operations) {
+  if (artifact.closed) return;
+  operations.closeSync(artifact.descriptor);
+  artifact.closed = true;
+}
+
+function fileIdentity(metadata) {
+  return { device: metadata.dev, inode: metadata.ino };
+}
+
+function sameFileIdentity(left, right) {
+  return left.device === right.device && left.inode === right.inode;
+}
+
+function validateArtifacts(artifacts) {
+  if (artifacts === null || typeof artifacts !== "object") {
+    throw new Error("benchmark artifacts must be an object");
+  }
+  for (const name of ["json", "jsonPath", "markdown", "markdownPath"]) {
+    if (typeof artifacts[name] !== "string" || artifacts[name].length === 0) {
+      throw new Error(`benchmark artifact ${name} must be non-empty`);
+    }
+  }
+  if (artifacts.jsonPath === artifacts.markdownPath) {
+    throw new Error("benchmark artifact paths must differ");
+  }
+  return artifacts;
+}

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -1,0 +1,1169 @@
+{
+  "artifactKind": "known-failure-observations",
+  "cases": [
+    {
+      "assessment": {
+        "classification": "known_failure_observation",
+        "gateEnforced": false,
+        "observation": "Array.shift queue movement and full progress-map scans have quadratic operation counts; the prior audit observed about 35/112/392 ms at 8k/16k/32k items.",
+        "threshold": null
+      },
+      "family": "csv",
+      "id": "csv_scheduler_progress_scan",
+      "implementation": "production_api",
+      "measurementKind": "end_to_end_microbenchmark",
+      "points": [
+        {
+          "correctness": {
+            "expected": "1000 generated rows reach one terminal state",
+            "matchesOracle": true,
+            "observed": "1000 rows returned; 1000 terminal failures",
+            "oracle": "generated row-count and terminal-state oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.383903,
+            "maxMs": 10.894199,
+            "medianMs": 5.985377,
+            "minMs": 5.55261,
+            "sampleCount": 5,
+            "samplesMs": [
+              5.985377,
+              6.318093,
+              5.55261,
+              5.601474,
+              10.894199
+            ]
+          },
+          "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
+          "input": {
+            "generatedUtf8Bytes": 22015,
+            "rowCount": 1000
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 92852224,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                82366464,
+                86036480,
+                87085056,
+                87085056,
+                88133632,
+                88133632,
+                88657920,
+                88657920,
+                88657920,
+                88657920,
+                92852224
+              ]
+            },
+            "peakRssBytes": 92852224,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "progress_item_visits": 1002000,
+            "queue_shift_moved_slots": 499500,
+            "worker_spawns": 1000
+          },
+          "status": "completed"
+        },
+        {
+          "correctness": {
+            "expected": "2000 generated rows reach one terminal state",
+            "matchesOracle": true,
+            "observed": "2000 rows returned; 2000 terminal failures",
+            "oracle": "generated row-count and terminal-state oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.569425,
+            "maxMs": 23.417776,
+            "medianMs": 16.19761,
+            "minMs": 14.296411,
+            "sampleCount": 5,
+            "samplesMs": [
+              15.628185,
+              16.19761,
+              23.417776,
+              16.361469,
+              14.296411
+            ]
+          },
+          "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
+          "input": {
+            "generatedUtf8Bytes": 48015,
+            "rowCount": 2000
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 122150912,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                82829312,
+                88072192,
+                89645056,
+                89645056,
+                96985088,
+                96985088,
+                112189440,
+                112189440,
+                122150912,
+                122150912,
+                122150912
+              ]
+            },
+            "peakRssBytes": 122150912,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "progress_item_visits": 4004000,
+            "queue_shift_moved_slots": 1999000,
+            "worker_spawns": 2000
+          },
+          "status": "completed"
+        },
+        {
+          "correctness": {
+            "expected": "4000 generated rows reach one terminal state",
+            "matchesOracle": true,
+            "observed": "4000 rows returned; 4000 terminal failures",
+            "oracle": "generated row-count and terminal-state oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 1.025889,
+            "maxMs": 65.404986,
+            "medianMs": 38.80299,
+            "minMs": 37.777101,
+            "sampleCount": 5,
+            "samplesMs": [
+              65.404986,
+              42.75011,
+              38.80299,
+              38.383653,
+              37.777101
+            ]
+          },
+          "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
+          "input": {
+            "generatedUtf8Bytes": 96015,
+            "rowCount": 4000
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 136294400,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                82853888,
+                99106816,
+                131612672,
+                132136960,
+                133185536,
+                133185536,
+                133185536,
+                133185536,
+                134758400,
+                134758400,
+                136294400
+              ]
+            },
+            "peakRssBytes": 136331264,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "progress_item_visits": 16008000,
+            "queue_shift_moved_slots": 7998000,
+            "worker_spawns": 4000
+          },
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "assessment": {
+        "classification": "known_failure_observation",
+        "gateEnforced": false,
+        "observation": "Delete-only parsing repeatedly slices the unconsumed suffix; the prior audit observed about 28 ms/238 ms/2.98 s at 16k/32k/64k lines.",
+        "threshold": null
+      },
+      "family": "patch",
+      "id": "patch_delete_parser_suffix_slicing",
+      "implementation": "production_api",
+      "measurementKind": "parser_microbenchmark",
+      "points": [
+        {
+          "correctness": {
+            "expected": "8000 ordered delete hunks",
+            "matchesOracle": true,
+            "observed": "8000 hunks parsed; 8000 delete hunks",
+            "oracle": "generated patch grammar and hunk-count oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.773696,
+            "maxMs": 11.63169,
+            "medianMs": 6.688927,
+            "minMs": 5.594454,
+            "sampleCount": 5,
+            "samplesMs": [
+              5.594454,
+              5.915231,
+              11.63169,
+              6.752614,
+              6.688927
+            ]
+          },
+          "fixtureDigest": "20e6f251f058537fb579b40427cfc4c69a025d8da738d498863815d41a88f6b7",
+          "input": {
+            "generatedUtf8Bytes": 328029,
+            "hunkCount": 8000
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 123228160,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                82333696,
+                97013760,
+                98586624,
+                98586624,
+                99635200,
+                99635200,
+                119033856,
+                119033856,
+                119558144,
+                119558144,
+                123228160
+              ]
+            },
+            "peakRssBytes": 123228160,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "parsed_hunks": 8000,
+            "remaining_suffix_references_copied": 31996000,
+            "source_lines": 8002
+          },
+          "status": "completed"
+        },
+        {
+          "correctness": {
+            "expected": "16000 ordered delete hunks",
+            "matchesOracle": true,
+            "observed": "16000 hunks parsed; 16000 delete hunks",
+            "oracle": "generated patch grammar and hunk-count oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 1.719763,
+            "maxMs": 34.781248,
+            "medianMs": 30.571399,
+            "minMs": 17.909883,
+            "sampleCount": 5,
+            "samplesMs": [
+              17.909883,
+              34.781248,
+              32.291162,
+              29.82185,
+              30.571399
+            ]
+          },
+          "fixtureDigest": "b5ed1acf6dcd628542025466c326a7ca14bfc4875684227c66736176561607d5",
+          "input": {
+            "generatedUtf8Bytes": 672029,
+            "hunkCount": 16000
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 157253632,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                81752064,
+                115830784,
+                118976512,
+                118976512,
+                155676672,
+                155676672,
+                155156480,
+                155156480,
+                156205056,
+                156205056,
+                157253632
+              ]
+            },
+            "peakRssBytes": 157253632,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "parsed_hunks": 16000,
+            "remaining_suffix_references_copied": 127992000,
+            "source_lines": 16002
+          },
+          "status": "completed"
+        },
+        {
+          "correctness": {
+            "expected": "32000 ordered delete hunks",
+            "matchesOracle": true,
+            "observed": "32000 hunks parsed; 32000 delete hunks",
+            "oracle": "generated patch grammar and hunk-count oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 3.343451,
+            "maxMs": 381.456384,
+            "medianMs": 355.764281,
+            "minMs": 352.42083,
+            "sampleCount": 5,
+            "samplesMs": [
+              354.870975,
+              352.42083,
+              381.456384,
+              380.364585,
+              355.764281
+            ]
+          },
+          "fixtureDigest": "60598ff316c144a59697d6e13c539f2877b49bdcd1b6f8427c436f9850314509",
+          "input": {
+            "generatedUtf8Bytes": 1344029,
+            "hunkCount": 32000
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 234844160,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                84738048,
+                208912384,
+                191021056,
+                191021056,
+                212361216,
+                212361216,
+                234844160,
+                234844160,
+                201908224,
+                201908224,
+                222085120
+              ]
+            },
+            "peakRssBytes": 263548928,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "parsed_hunks": 32000,
+            "remaining_suffix_references_copied": 511984000,
+            "source_lines": 32002
+          },
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "assessment": {
+        "classification": "known_failure_observation",
+        "gateEnforced": false,
+        "observation": "The synchronous JavaScript fallback cannot be preempted while V8 evaluates (a+)+$; 30 repeated characters exceeded the external two-second audit kill.",
+        "threshold": null
+      },
+      "family": "regex",
+      "id": "regex_fallback_catastrophic_backtracking",
+      "implementation": "production_api",
+      "measurementKind": "supervised_timeout_probe",
+      "points": [
+        {
+          "correctness": {
+            "expected": "fallback completes without blocking its owner event loop",
+            "matchesOracle": false,
+            "observed": "externally terminated after 2500 ms",
+            "oracle": "externally supervised responsiveness oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.564666,
+            "maxMs": 2532.545571,
+            "medianMs": 2520.939856,
+            "minMs": 2520.37519,
+            "sampleCount": 3,
+            "samplesMs": [
+              2532.545571,
+              2520.37519,
+              2520.939856
+            ]
+          },
+          "fixtureDigest": "c6d8f7a4a98827903f02f35df08655219e5c22c72e4a8f0a7dc3145e4aba9a69",
+          "input": {
+            "fileCount": 1,
+            "generatedUtf8Bytes": 38,
+            "repeatedCharacters": 30
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "The child reported RSS immediately before entering synchronous work and was then externally terminated; this is a lower-bound diagnostic, not a process peak.",
+              "maximumObservedBytes": 110346240,
+              "method": "child_start_rss_lower_bound",
+              "observationsBytes": [
+                107368448,
+                106766336,
+                110346240
+              ]
+            },
+            "peakRssBytes": null,
+            "peakRssMethod": "unavailable_after_forced_termination"
+          },
+          "operations": {
+            "backtracking_input_code_units": 31,
+            "files_scanned": 1,
+            "pattern_code_units": 6
+          },
+          "status": "timed_out"
+        }
+      ]
+    },
+    {
+      "assessment": {
+        "classification": "known_failure_observation",
+        "gateEnforced": false,
+        "observation": "The daemon matcher memoizes recursive states but scans remaining candidate positions from each state, yielding roughly O(m*n^2) work and allocation.",
+        "threshold": null
+      },
+      "family": "fuzzy",
+      "id": "fuzzy_daemon_recursive_scaling",
+      "implementation": "production_api",
+      "measurementKind": "end_to_end_microbenchmark",
+      "points": [
+        {
+          "correctness": {
+            "expected": "32 full-query subsequence matches",
+            "matchesOracle": true,
+            "observed": "32 ranked matches",
+            "oracle": "straightforward full-query subsequence oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.078779,
+            "maxMs": 4.373377,
+            "medianMs": 4.054893,
+            "minMs": 3.976114,
+            "sampleCount": 5,
+            "samplesMs": [
+              3.976114,
+              3.99999,
+              4.18458,
+              4.373377,
+              4.054893
+            ]
+          },
+          "fixtureDigest": "6dc2d7033a701cb871275327613ffef173ca251f453a9b586554b9f3ce14811a",
+          "input": {
+            "candidateCount": 32,
+            "generatedUtf8Bytes": 1320,
+            "pathStemCodeUnits": 32,
+            "queryCodeUnits": 8
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 93421568,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                85442560,
+                89227264,
+                89227264,
+                89227264,
+                89227264,
+                89227264,
+                89751552,
+                89751552,
+                92372992,
+                92372992,
+                93421568
+              ]
+            },
+            "peakRssBytes": 93421568,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "candidate_query_code_unit_pairs": 9984,
+            "filesystem_entries": 32,
+            "recursive_comparison_upper_bound": 778752
+          },
+          "status": "completed"
+        },
+        {
+          "correctness": {
+            "expected": "32 full-query subsequence matches",
+            "matchesOracle": true,
+            "observed": "32 ranked matches",
+            "oracle": "straightforward full-query subsequence oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.129377,
+            "maxMs": 13.068304,
+            "medianMs": 12.929943,
+            "minMs": 12.332896,
+            "sampleCount": 5,
+            "samplesMs": [
+              13.068304,
+              13.05932,
+              12.929943,
+              12.805103,
+              12.332896
+            ]
+          },
+          "fixtureDigest": "2c4e993a93b588a4e90763225ab10e2c7e80c7e52c006b4ce0d8d042a41d456c",
+          "input": {
+            "candidateCount": 32,
+            "generatedUtf8Bytes": 2344,
+            "pathStemCodeUnits": 64,
+            "queryCodeUnits": 8
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 92778496,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                84389888,
+                92778496,
+                92778496,
+                92778496,
+                92778496,
+                92778496,
+                92778496,
+                92778496,
+                92778496,
+                92778496,
+                92778496
+              ]
+            },
+            "peakRssBytes": 92778496,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "candidate_query_code_unit_pairs": 18176,
+            "filesystem_entries": 32,
+            "recursive_comparison_upper_bound": 2580992
+          },
+          "status": "completed"
+        },
+        {
+          "correctness": {
+            "expected": "32 full-query subsequence matches",
+            "matchesOracle": true,
+            "observed": "32 ranked matches",
+            "oracle": "straightforward full-query subsequence oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 2.125711,
+            "maxMs": 52.359767,
+            "medianMs": 49.394879,
+            "minMs": 47.269168,
+            "sampleCount": 5,
+            "samplesMs": [
+              48.600382,
+              49.394879,
+              51.657078,
+              52.359767,
+              47.269168
+            ]
+          },
+          "fixtureDigest": "c1a21af75169441df1d4fd0a5c8a99dbe96bbd556db181e064a6f70b83a91cf6",
+          "input": {
+            "candidateCount": 32,
+            "generatedUtf8Bytes": 4392,
+            "pathStemCodeUnits": 128,
+            "queryCodeUnits": 8
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 102354944,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                87572480,
+                93966336,
+                93966336,
+                93966336,
+                93966336,
+                93966336,
+                102354944,
+                102354944,
+                102354944,
+                102354944,
+                102354944
+              ]
+            },
+            "peakRssBytes": 102354944,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "candidate_query_code_unit_pairs": 34560,
+            "filesystem_entries": 32,
+            "recursive_comparison_upper_bound": 9331200
+          },
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "assessment": {
+        "classification": "known_failure_observation",
+        "gateEnforced": false,
+        "observation": "The TUI matcher silently truncates a 69-code-unit query at 64 and ranks the generated path ending WRONG ahead of the only full-query match ending RIGHT.",
+        "threshold": null
+      },
+      "family": "fuzzy",
+      "id": "fuzzy_tui_query_truncation",
+      "implementation": "production_api",
+      "measurementKind": "correctness_microbenchmark",
+      "points": [
+        {
+          "correctness": {
+            "expected": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRIGHT",
+            "matchesOracle": false,
+            "observed": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaWRONG",
+            "oracle": "full-query literal suffix oracle"
+          },
+          "elapsed": {
+            "clock": "performance.now",
+            "madMs": 0.002514,
+            "maxMs": 0.031788,
+            "medianMs": 0.015504,
+            "minMs": 0.011988,
+            "sampleCount": 9,
+            "samplesMs": [
+              0.0199,
+              0.031788,
+              0.018999,
+              0.014472,
+              0.015504,
+              0.01347,
+              0.011988,
+              0.01299,
+              0.017206
+            ]
+          },
+          "fixtureDigest": "06964b37b02568fd25e3c7c7788a86751336199f8ae67a29529912d184f6131d",
+          "input": {
+            "candidateCount": 2,
+            "generatedUtf8Bytes": 207,
+            "indexedQueryCodeUnits": 64,
+            "queryCodeUnits": 69
+          },
+          "memory": {
+            "lowerBound": {
+              "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
+              "maximumObservedBytes": 80064512,
+              "method": "endpoint_rss_lower_bound",
+              "observationsBytes": [
+                77443072,
+                77967360,
+                78491648,
+                78491648,
+                78491648,
+                78491648,
+                79015936,
+                79015936,
+                79015936,
+                79540224,
+                79540224,
+                80064512,
+                80064512,
+                80064512,
+                80064512,
+                80064512,
+                80064512,
+                80064512,
+                80064512
+              ]
+            },
+            "peakRssBytes": 80064512,
+            "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
+          },
+          "operations": {
+            "candidate_query_code_unit_pairs": 128,
+            "discarded_query_code_units": 5,
+            "indexed_candidates": 2
+          },
+          "status": "completed"
+        }
+      ]
+    }
+  ],
+  "environment": {
+    "cpu": {
+      "logicalCount": 64,
+      "model": "AMD Ryzen Threadripper PRO 9975WX 32-Cores"
+    },
+    "filesystems": {
+      "sourceCheckout": {
+        "blockSizeBytes": 4096,
+        "type": "61267"
+      },
+      "temporaryFixtures": {
+        "blockSizeBytes": 4096,
+        "type": "16914836"
+      }
+    },
+    "memory": {
+      "totalBytes": 1081089331200
+    },
+    "os": {
+      "arch": "x64",
+      "platform": "linux",
+      "release": "7.0.0-28-generic"
+    },
+    "ripgrep": {
+      "distribution": "pinned_package",
+      "version": "ripgrep 15.0.0 (rev 3a612f88b8)"
+    },
+    "runtime": {
+      "node": "v26.5.0",
+      "npm": "11.17.0",
+      "v8": "14.6.202.34-node.24"
+    },
+    "sqlite": {
+      "compileOptions": [
+        "ATOMIC_INTRINSICS=1",
+        "COMPILER=clang-20.1.8",
+        "DEFAULT_AUTOVACUUM",
+        "DEFAULT_CACHE_SIZE=-2000",
+        "DEFAULT_FILE_FORMAT=4",
+        "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+        "DEFAULT_MEMSTATUS=0",
+        "DEFAULT_MMAP_SIZE=0",
+        "DEFAULT_PAGE_SIZE=4096",
+        "DEFAULT_PCACHE_INITSZ=20",
+        "DEFAULT_RECURSIVE_TRIGGERS",
+        "DEFAULT_SECTOR_SIZE=4096",
+        "DEFAULT_SYNCHRONOUS=2",
+        "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+        "DEFAULT_WAL_SYNCHRONOUS=2",
+        "DEFAULT_WORKER_THREADS=0",
+        "DIRECT_OVERFLOW_READ",
+        "ENABLE_COLUMN_METADATA",
+        "ENABLE_DBSTAT_VTAB",
+        "ENABLE_FTS3",
+        "ENABLE_FTS3_PARENTHESIS",
+        "ENABLE_FTS5",
+        "ENABLE_GEOPOLY",
+        "ENABLE_MATH_FUNCTIONS",
+        "ENABLE_PERCENTILE",
+        "ENABLE_PREUPDATE_HOOK",
+        "ENABLE_RBU",
+        "ENABLE_RTREE",
+        "ENABLE_SESSION",
+        "MALLOC_SOFT_LIMIT=1024",
+        "MAX_ATTACHED=10",
+        "MAX_COLUMN=2000",
+        "MAX_COMPOUND_SELECT=500",
+        "MAX_DEFAULT_PAGE_SIZE=8192",
+        "MAX_EXPR_DEPTH=1000",
+        "MAX_FUNCTION_ARG=1000",
+        "MAX_LENGTH=1000000000",
+        "MAX_LIKE_PATTERN_LENGTH=50000",
+        "MAX_MMAP_SIZE=0x7fff0000",
+        "MAX_PAGE_COUNT=0xfffffffe",
+        "MAX_PAGE_SIZE=65536",
+        "MAX_SQL_LENGTH=1000000000",
+        "MAX_TRIGGER_DEPTH=1000",
+        "MAX_VARIABLE_NUMBER=32766",
+        "MAX_VDBE_OP=250000000",
+        "MAX_WORKER_THREADS=8",
+        "MUTEX_PTHREADS",
+        "SYSTEM_MALLOC",
+        "TEMP_STORE=1",
+        "THREADSAFE=1"
+      ],
+      "version": "3.53.3"
+    }
+  },
+  "evidenceBindings": [
+    {
+      "normalization": "utf8_lf",
+      "path": ".gitattributes",
+      "sha256": "292d362f4207092e2a3a697bb9c7c9eb6aff2340de6949d58274d0380242e67a"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "package-lock.json",
+      "sha256": "bb806a1a762aed6d1a4beaed8e1a06eb073e3f32bf6215429b6c8016d99b7432"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/artifact-output.mjs",
+      "sha256": "c42f3b44303d48f0ded67b0fa37ab766c1e8968b75eb800f2a369fb0ec888659"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/bounded-file.mjs",
+      "sha256": "2f96be1c0a7b4959ce86ff6f8511707b8e8a2c4c698df7c92de99a2e09086ebc"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/case-worker.mjs",
+      "sha256": "868067b2cc8e001ba7032c671e723f37d15fc26de2d01b8e1a617a6917c85dac"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/contract.mjs",
+      "sha256": "d4f7794503ff80ea23cae215fc29fe1697ecc3b64c94afbe6bd5462824f1e767"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/environment.mjs",
+      "sha256": "45929cc2bdf5c75bffa740de0fa3e2e60764ba9d159b14b3f50e4ddb2722b023"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/fixtures.mjs",
+      "sha256": "ce99b687e0f4b39e56b2391b1b00dab42bfac8c19c206448f1a068879f493b72"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/isolation.mjs",
+      "sha256": "624eb97b565e8c5f06a898ef63f0d6c3342eca40f366eb443c9ced5b05116826"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/metadata-command-worker.mjs",
+      "sha256": "4322637c5eb97e2ee35e517e2537f5a08099079135cf7851d20e8b7f4b2ca423"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/module-closure.mjs",
+      "sha256": "2e6c6d0efbadc69f746ed26570023a56b74540b6ff9c63d14044a6fd4df3c620"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/provenance.mjs",
+      "sha256": "2c77fb5070cc99756fb227aa50ccd5e0139309b75e8bb9ca678679933b07e44a"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/run-baselines.mjs",
+      "sha256": "38e50eab5310ae134fbaaadfdab309bf2a80006cd31a719821852d3139933155"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/benchmarks/fnd/supervisor.mjs",
+      "sha256": "c5330837e574eec81d588b722eb9353e6398e693833d1ded64d79511daee64a6"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/native/agenc-process-broker.c",
+      "sha256": "51c7818dbb2d4dcb2de13cb2b27d2a09f21be9e4a0b454223d23678979738907"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/native/agenc-process-job-broker.cs",
+      "sha256": "eec6d65cda05b9da05c91f4506c68579e5b824be07e0cf45bb8960f5f05854ec"
+    },
+    {
+      "normalization": "utf8_lf",
+      "path": "runtime/package.json",
+      "sha256": "208bb5eea8c98ed2c253890cc5a44af0d9fd41709b4060f5a0d94e9b5d05cf5d"
+    }
+  ],
+  "planDigest": "c2377e6d378a616f8a8e3169a87687c354e6cf4e5a8c0f233ae6c0207281d4ed",
+  "productionModuleClosures": [
+    {
+      "caseId": "csv_scheduler_progress_scan",
+      "modules": [
+        {
+          "path": "runtime/src/agents/jobs/csv-reader.ts",
+          "sha256": "2babbeeb615653c7b1d33206b6e2939ee4c58c47c0790bcef153d24dd2e8d17e"
+        },
+        {
+          "path": "runtime/src/agents/jobs/instruction-template.ts",
+          "sha256": "b4ffff8706057367e3da397347b4f08ffa77e50dbaed88827a963212b45a1418"
+        },
+        {
+          "path": "runtime/src/agents/jobs/job-orchestrator.ts",
+          "sha256": "8feb1553bfe18ac12066d02606f1beeb8646f5820f72c31846f0e614e1e251e4"
+        },
+        {
+          "path": "runtime/src/utils/supervisedProcess.ts",
+          "sha256": "81796058a7c3eff35b9f1136a343a695f13b68b4bbe7d8e29e563abe9bd4cc6e"
+        }
+      ]
+    },
+    {
+      "caseId": "patch_delete_parser_suffix_slicing",
+      "modules": [
+        {
+          "path": "runtime/src/tools/apply-patch/parser.ts",
+          "sha256": "1a7f2dd60629cf68751f23747c46986b95fc19821f47959a96cfdd6d81272029"
+        },
+        {
+          "path": "runtime/src/tools/apply-patch/types.ts",
+          "sha256": "a246279921a3200c2d64239526ac7718e400c5c07e1c451063261ed4fb59325d"
+        },
+        {
+          "path": "runtime/src/utils/supervisedProcess.ts",
+          "sha256": "81796058a7c3eff35b9f1136a343a695f13b68b4bbe7d8e29e563abe9bd4cc6e"
+        }
+      ]
+    },
+    {
+      "caseId": "regex_fallback_catastrophic_backtracking",
+      "modules": [
+        {
+          "path": "runtime/src/agents/_deps/filesystem-args.ts",
+          "sha256": "f03e1424d276b976a1d6ada513fb7e0e401851f50e89598a0107d78c64c65d53"
+        },
+        {
+          "path": "runtime/src/app-server/daemon-runtime-info.ts",
+          "sha256": "2963340d27175b8a8a6917440fbc1748390dcdd772717367f85f2aca7a70546c"
+        },
+        {
+          "path": "runtime/src/config/env.ts",
+          "sha256": "164d46abe61707f8a225b529b6f086ba141500c972a43b03126132a734b54d08"
+        },
+        {
+          "path": "runtime/src/config/schema.ts",
+          "sha256": "1706fee7bc52a7c7fe35a666d5714caa0a6cb7bd273a0bd17ae91e43d1118ece"
+        },
+        {
+          "path": "runtime/src/llm/_deps/command-line.ts",
+          "sha256": "6785779054aa82997de076219892b3e2b78d9235594501142f2e4d8ceedb04bc"
+        },
+        {
+          "path": "runtime/src/llm/shell-write-policy.ts",
+          "sha256": "fa8ed261cf339155b372089f6d79524c57c31f8c946d697852d83a5111d9a9b6"
+        },
+        {
+          "path": "runtime/src/permissions/sandbox.ts",
+          "sha256": "a8cb2e5f797f7d504a26bc3398f4b377cbfa7e4cda2905cdbb41787cdb0a66a4"
+        },
+        {
+          "path": "runtime/src/planning/plan-files.ts",
+          "sha256": "8fbed7a07299adb6c3da6f46a193bfc07664b1bb8e5551f3e41d6de6888a0051"
+        },
+        {
+          "path": "runtime/src/pty/loadPty.ts",
+          "sha256": "22722ef903a25bb262788d5d0621ece0601346ae55e695999172439b9b71bd39"
+        },
+        {
+          "path": "runtime/src/sandbox/apparmor.ts",
+          "sha256": "74329aa34100712d1bfff5aa6915460d73caab802fae7709ca8b55554941c0ca"
+        },
+        {
+          "path": "runtime/src/sandbox/engine/bwrap.ts",
+          "sha256": "7c32b44450950a9ac05d1036ffa917a159960ac3503c3c97ce17c98b8b43f0ac"
+        },
+        {
+          "path": "runtime/src/sandbox/engine/index.ts",
+          "sha256": "bb3471c4bc36310a9f987cdb3cdf8a9fd66ec4a04521c872f6120286f3c5f433"
+        },
+        {
+          "path": "runtime/src/sandbox/engine/landlock.ts",
+          "sha256": "871f40d66db8f818a93ce89f89c8d21773cc692e1bff9d02b8d518c42ec155cc"
+        },
+        {
+          "path": "runtime/src/sandbox/engine/manager.ts",
+          "sha256": "8bf4e7026d8380f9fee1698b0d1698602a9c4da4a0001218a7c8fab4c95aec5b"
+        },
+        {
+          "path": "runtime/src/sandbox/engine/policy-transforms.ts",
+          "sha256": "742b367fb8aa74fe99845fcf4d102a6eb1b5c00c909221a7e436d065796e33b9"
+        },
+        {
+          "path": "runtime/src/sandbox/engine/seatbelt.ts",
+          "sha256": "a21aedda4f60e9735c331a703c1a2028e759fa912594da653302dcfae35fa231"
+        },
+        {
+          "path": "runtime/src/sandbox/execution-broker.ts",
+          "sha256": "ef0a699dcb12d491d4228f76b9301d04ef7620a2617bc1f3fad0fba220515be2"
+        },
+        {
+          "path": "runtime/src/sandbox/launcher-environment.ts",
+          "sha256": "49350549e20c9c3a8e29bc627b798b066f00115e6d3d50ae1347283161576b8b"
+        },
+        {
+          "path": "runtime/src/sandbox/linux-launcher/config.ts",
+          "sha256": "c61228dd7319454dd88c7890c635adf2fef5b54f87062c0090827752d169e751"
+        },
+        {
+          "path": "runtime/src/sandbox/linux-launcher/landlock.ts",
+          "sha256": "3112788ea5910656f39061ad4a12375ba115f36166a8b5eddbb67aa9bbcda795"
+        },
+        {
+          "path": "runtime/src/sandbox/linux-launcher/launcher.ts",
+          "sha256": "ff693df33782fb994dc6d50299219d6c1773b63b478b0641454988570691db78"
+        },
+        {
+          "path": "runtime/src/tools/apply-patch/parser.ts",
+          "sha256": "1a7f2dd60629cf68751f23747c46986b95fc19821f47959a96cfdd6d81272029"
+        },
+        {
+          "path": "runtime/src/tools/apply-patch/types.ts",
+          "sha256": "a246279921a3200c2d64239526ac7718e400c5c07e1c451063261ed4fb59325d"
+        },
+        {
+          "path": "runtime/src/tools/concurrency.ts",
+          "sha256": "a410f40aa7807082a7911a1f73ed8cc00575ffa3afd54c409e77071d013fb08e"
+        },
+        {
+          "path": "runtime/src/tools/result-metadata.ts",
+          "sha256": "faf64436e9e266004fb30b20b46097488336cdcbe09838f119f490adfd6c0f6e"
+        },
+        {
+          "path": "runtime/src/tools/results.ts",
+          "sha256": "97f7138051880daad0ef1e9dfcc0093c19a0cb2790ff3c00626a9e8e098951c0"
+        },
+        {
+          "path": "runtime/src/tools/runtimes/apply-patch.ts",
+          "sha256": "0fba5ab5f257acefee228bcb1adb8208ace3bd04e0471d72a6e207a4860b3e89"
+        },
+        {
+          "path": "runtime/src/tools/runtimes/context.ts",
+          "sha256": "f6fb0cb89e8f98e88e57f1a034af5faf7c10765fcce7da399cd46730cba12195"
+        },
+        {
+          "path": "runtime/src/tools/runtimes/paths.ts",
+          "sha256": "28489eab3a21ec4198f708dd205409143af488c143579ca81f469697b31ba439"
+        },
+        {
+          "path": "runtime/src/tools/runtimes/sandboxing.ts",
+          "sha256": "18119783f1eb2081a9b23b2a2154e1141fbc29d748ccba7e4130e5769791ccc2"
+        },
+        {
+          "path": "runtime/src/tools/runtimes/shell.ts",
+          "sha256": "97c6523f37fd1eddb2673058ae762bb9e3a7cf52ac62964165a72bac3a03d51a"
+        },
+        {
+          "path": "runtime/src/tools/runtimes/unified-exec.ts",
+          "sha256": "1bf5d16180f3b3113c8e99defa303586fecdaa4f286627e20efcf92acaacbd68"
+        },
+        {
+          "path": "runtime/src/tools/system/apply-runtime-sandbox.ts",
+          "sha256": "ce0a2a4c6407d74defdb7def690b03a4a3be4a65547526beb17c5e9edbf1e5ce"
+        },
+        {
+          "path": "runtime/src/tools/system/exec-command.ts",
+          "sha256": "a01e9f353855013fb5d76cf77b6b7cdc0c31e7209945b9f4507103a0e878d6db"
+        },
+        {
+          "path": "runtime/src/tools/system/exec-result-format.ts",
+          "sha256": "7c7b99517ea55178de5e19d16eae0008d01f6388e4ffb194d3034f17965d2a82"
+        },
+        {
+          "path": "runtime/src/tools/system/filesystem.ts",
+          "sha256": "a3d41ba79f8c60d82cfb348ba1e11ca464a1b27b32f1b01bbfaca465c932afa8"
+        },
+        {
+          "path": "runtime/src/tools/system/grep.ts",
+          "sha256": "904c14900ed0383dfb520c93657fa1bc432fa73536fa1f85e4434af6f74b8d61"
+        },
+        {
+          "path": "runtime/src/tools/system/pinned-ripgrep.ts",
+          "sha256": "a0159c9f8e1719ee4135faf0f3033625344ffa2fa72a0fb680509caf0ffcba0a"
+        },
+        {
+          "path": "runtime/src/tools/types.ts",
+          "sha256": "bc1ddfbc82fa0577f5d4623fc33a1e3f5b993ed6aecc9828b1c2b6b85ae3b730"
+        },
+        {
+          "path": "runtime/src/unified-exec/head-tail-buffer.ts",
+          "sha256": "aa4192132725aa2906ebcd2013d127ddec799007a84159cc34caa3615cb419ce"
+        },
+        {
+          "path": "runtime/src/unified-exec/process-manager.ts",
+          "sha256": "20f84d6b8b3ec2f819bf11b6cf5d9c05f3b69b5ebeba5f81a11dd167b304f2c8"
+        },
+        {
+          "path": "runtime/src/unified-exec/process-ownership.ts",
+          "sha256": "c905ccdcf7903ef57786cf73610a76b1e48552d64bfb4d4136966b876d12a711"
+        },
+        {
+          "path": "runtime/src/unified-exec/scrub-env.ts",
+          "sha256": "d069464d71a4fe553cc3fb6ad30b1939212590662c048c2b22c3dfe5026665be"
+        },
+        {
+          "path": "runtime/src/unified-exec/types.ts",
+          "sha256": "0e66b246df210eaeb7c59584aa4a91291763775c36ea679f3ba776618c056fdb"
+        },
+        {
+          "path": "runtime/src/utils/async-rwlock.ts",
+          "sha256": "aa685238bfd7a0f1f1add16c5431d941df9c6450abe088a04365dc5e25dca2b4"
+        },
+        {
+          "path": "runtime/src/utils/providerSecrets.ts",
+          "sha256": "b3f1d359b0d4662ff2d6c4639017deedaee7afd5706f09920f5f75ddcfeecf0b"
+        },
+        {
+          "path": "runtime/src/utils/record.ts",
+          "sha256": "a9f6ea0832d24620460adb6314ae99c779ee0e9d817082348e9f60c1ccd39dc8"
+        },
+        {
+          "path": "runtime/src/utils/secretEnv.ts",
+          "sha256": "8522995f2dac616bf3b9640be509d0122909992a4138082ffd3244297d245e3b"
+        },
+        {
+          "path": "runtime/src/utils/stringUtils.ts",
+          "sha256": "e3771405f45441b88a1fe807d0624cbfc10c3a4ec83ee32e6996730a5ad91172"
+        },
+        {
+          "path": "runtime/src/utils/supervisedProcess.ts",
+          "sha256": "81796058a7c3eff35b9f1136a343a695f13b68b4bbe7d8e29e563abe9bd4cc6e"
+        },
+        {
+          "path": "runtime/src/workspace/file-mutation-transaction.ts",
+          "sha256": "3b237142ccd190dea63b0c4cca282f7d2cd05fdf6bd20460c7ca8f75ecb3eeca"
+        },
+        {
+          "path": "runtime/src/workspace/mutation-coordinator.ts",
+          "sha256": "3ab0fc94a1ebc6ff2c011bb432ebe32a776b0bf572a8f27eaff95a416da25480"
+        },
+        {
+          "path": "runtime/src/workspace/tool-operation-lifetime.ts",
+          "sha256": "6592e61c1311b9453bb893201b29ece1dd88a03637a70d1567bc911648a8d779"
+        }
+      ]
+    },
+    {
+      "caseId": "fuzzy_daemon_recursive_scaling",
+      "modules": [
+        {
+          "path": "runtime/src/app-server/fuzzy-file-search.ts",
+          "sha256": "9159c97b2e0499d186ef068b3197a2c9ee69099c4eef1aff0cb1f84114dee4d8"
+        },
+        {
+          "path": "runtime/src/utils/supervisedProcess.ts",
+          "sha256": "81796058a7c3eff35b9f1136a343a695f13b68b4bbe7d8e29e563abe9bd4cc6e"
+        }
+      ]
+    },
+    {
+      "caseId": "fuzzy_tui_query_truncation",
+      "modules": [
+        {
+          "path": "runtime/src/tui/ink/native-ts/file-index/index.ts",
+          "sha256": "4fed1fa54ad7dcf1b8782519ddebe8c60296177334850184d652ff121fd79fd0"
+        },
+        {
+          "path": "runtime/src/utils/supervisedProcess.ts",
+          "sha256": "81796058a7c3eff35b9f1136a343a695f13b68b4bbe7d8e29e563abe9bd4cc6e"
+        }
+      ]
+    }
+  ],
+  "productionTreeBinding": {
+    "gitObjectId": "d802c0cd2dccdfa714252859bcd7e19605a8c8fb",
+    "objectType": "tree",
+    "path": "runtime/src"
+  },
+  "schemaVersion": 1,
+  "sourceRevision": "925f3ec2860abf48e0c6c0830d135da2587a4d69",
+  "suiteId": "agenc.fnd.algorithm-baseline.v1"
+}

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -1,0 +1,56 @@
+# FND algorithm baseline v1
+
+This artifact records bounded observations of known failures. Every row is
+informational: no current result is a passing performance threshold or gate.
+Generated inputs are synthetic and created only for the benchmark process.
+
+- JSON SHA-256: `8c72fc88fd10dfde2f91bd7cc3ce8028af552781b7b699db9931529cac0abd07`
+- Source revision: `925f3ec2860abf48e0c6c0830d135da2587a4d69`
+- Production tree: `runtime/src` at Git object `d802c0cd2dccdfa714252859bcd7e19605a8c8fb`
+- Loaded production closure: `64` module bindings across `5` cases
+- Plan SHA-256: `c2377e6d378a616f8a8e3169a87687c354e6cf4e5a8c0f233ae6c0207281d4ed`
+- Node/npm: `v26.5.0` / `11.17.0`
+- OS/CPU: `linux 7.0.0-28-generic x64` / `AMD Ryzen Threadripper PRO 9975WX 32-Cores` (64 logical)
+- RAM: `1081089331200` bytes
+- Source filesystem: type `61267`, block `4096` bytes
+- Fixture filesystem: type `16914836`, block `4096` bytes
+- SQLite/ripgrep: `3.53.3` / `ripgrep 15.0.0 (rev 3a612f88b8)`
+
+| Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 5.985 | 0.384 | 92852224 | 92852224 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 16.198 | 0.569 | 122150912 | 122150912 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 38.803 | 1.026 | 136331264 | 136294400 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 6.689 | 0.774 | 123228160 | 123228160 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 30.571 | 1.720 | 157253632 | 157253632 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 355.764 | 3.343 | 263548928 | 234844160 |
+| `regex_fallback_catastrophic_backtracking` | `fileCount=1,repeatedCharacters=30` | `timed_out` | 2520.940 | 0.565 | n/a | 110346240 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 4.055 | 0.079 | 93421568 | 93421568 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.930 | 0.129 | 92778496 | 92778496 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 49.395 | 2.126 | 102354944 | 102354944 |
+| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.016 | 0.003 | 80064512 | 80064512 |
+
+## Known-failure policy
+
+- `csv_scheduler_progress_scan`: Array.shift queue movement and full progress-map scans have quadratic operation counts; the prior audit observed about 35/112/392 ms at 8k/16k/32k items.
+- `patch_delete_parser_suffix_slicing`: Delete-only parsing repeatedly slices the unconsumed suffix; the prior audit observed about 28 ms/238 ms/2.98 s at 16k/32k/64k lines.
+- `regex_fallback_catastrophic_backtracking`: The synchronous JavaScript fallback cannot be preempted while V8 evaluates (a+)+$; 30 repeated characters exceeded the external two-second audit kill.
+- `fuzzy_daemon_recursive_scaling`: The daemon matcher memoizes recursive states but scans remaining candidate positions from each state, yielding roughly O(m*n^2) work and allocation.
+- `fuzzy_tui_query_truncation`: The TUI matcher silently truncates a 69-code-unit query at 64 and ranks the generated path ending WRONG ahead of the only full-query match ending RIGHT.
+
+## Reproduce
+
+Run on the same pinned runtime and machine state; compare medians, MAD,
+operation counts, and relative scaling rather than one wall-clock sample.
+
+```sh
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 925f3ec2860abf48e0c6c0830d135da2587a4d69 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
+```
+
+Completed workers report their actual process high-water RSS from
+`process.resourceUsage().maxRSS`, normalized from KiB to bytes. A worker
+terminated during synchronous work cannot emit that final high-water mark,
+so its peak is `n/a`; its last start RSS remains a clearly labeled lower
+bound. Endpoint observations are retained as diagnostics and are never
+presented as the worker peak.

--- a/runtime/benchmarks/fnd/bounded-file.mjs
+++ b/runtime/benchmarks/fnd/bounded-file.mjs
@@ -1,0 +1,198 @@
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readSync,
+} from "node:fs";
+
+const EOF_PROBE_BYTES = 1;
+export const MAX_BOUNDED_REGULAR_FILE_BYTES = 67_108_864;
+const READ_ONLY_BOUND_FLAGS =
+  fsConstants.O_RDONLY |
+  (fsConstants.O_NOFOLLOW ?? 0) |
+  (fsConstants.O_NONBLOCK ?? 0);
+const DEFAULT_FILE_OPERATIONS = Object.freeze({
+  closeSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readSync,
+});
+
+export function readBoundedRegularFile(
+  path,
+  maximumBytes,
+  label,
+  operationOverrides = {},
+) {
+  validateOptions(path, maximumBytes, label, operationOverrides);
+  const operations = { ...DEFAULT_FILE_OPERATIONS, ...operationOverrides };
+  const pathBefore = snapshotRegularFile(
+    operations.lstatSync(path, { bigint: true }),
+    maximumBytes,
+    label,
+  );
+  const descriptor = operations.openSync(path, READ_ONLY_BOUND_FLAGS);
+  let result;
+  let readFailure;
+  try {
+    result = readOpenedFile(
+      descriptor,
+      path,
+      pathBefore,
+      maximumBytes,
+      label,
+      operations,
+    );
+  } catch (error) {
+    readFailure = error;
+  }
+
+  let closeFailure;
+  try {
+    operations.closeSync(descriptor);
+  } catch (error) {
+    closeFailure = error;
+  }
+  if (readFailure !== undefined && closeFailure !== undefined) {
+    throw new AggregateError(
+      [readFailure, closeFailure],
+      `${label} read and descriptor close both failed`,
+    );
+  }
+  if (readFailure !== undefined) throw readFailure;
+  if (closeFailure !== undefined) {
+    throw new Error(`${label} descriptor did not close cleanly`, {
+      cause: closeFailure,
+    });
+  }
+  if (result === undefined) {
+    throw new Error(`${label} descriptor read produced no result`);
+  }
+  return result;
+}
+
+function readOpenedFile(
+  descriptor,
+  path,
+  pathBefore,
+  maximumBytes,
+  label,
+  operations,
+) {
+  const descriptorBefore = snapshotRegularFile(
+    operations.fstatSync(descriptor, { bigint: true }),
+    maximumBytes,
+    label,
+  );
+  assertSameSnapshot(
+    pathBefore,
+    descriptorBefore,
+    label,
+    "while it was opened",
+  );
+
+  const allocation = Buffer.alloc(maximumBytes + EOF_PROBE_BYTES);
+  let bytesRead = 0;
+  while (bytesRead < allocation.length) {
+    const count = operations.readSync(
+      descriptor,
+      allocation,
+      bytesRead,
+      allocation.length - bytesRead,
+      bytesRead,
+    );
+    if (!Number.isSafeInteger(count) || count < 0) {
+      throw new Error(`${label} descriptor returned an invalid read count`);
+    }
+    if (count === 0) break;
+    bytesRead += count;
+  }
+  if (bytesRead > maximumBytes) {
+    throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+  }
+
+  const descriptorAfter = snapshotRegularFile(
+    operations.fstatSync(descriptor, { bigint: true }),
+    maximumBytes,
+    label,
+  );
+  const pathAfter = snapshotRegularFile(
+    operations.lstatSync(path, { bigint: true }),
+    maximumBytes,
+    label,
+  );
+  assertSameSnapshot(
+    descriptorBefore,
+    descriptorAfter,
+    label,
+    "while it was read",
+  );
+  assertSameSnapshot(descriptorBefore, pathAfter, label, "at its pathname");
+  if (bytesRead !== Number(descriptorBefore.size)) {
+    throw new Error(`${label} length changed while it was read`);
+  }
+  return allocation.subarray(0, bytesRead);
+}
+
+function snapshotRegularFile(metadata, maximumBytes, label) {
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error(`${label} must be a regular non-symlink file`);
+  }
+  if (metadata.nlink !== 1n) {
+    throw new Error(`${label} must be a singly linked file`);
+  }
+  if (metadata.size < 0n || metadata.size > BigInt(maximumBytes)) {
+    throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+  }
+  return Object.freeze({
+    changedNs: metadata.ctimeNs,
+    device: metadata.dev,
+    inode: metadata.ino,
+    links: metadata.nlink,
+    mode: metadata.mode,
+    modifiedNs: metadata.mtimeNs,
+    size: metadata.size,
+  });
+}
+
+function assertSameSnapshot(expected, actual, label, phase) {
+  if (
+    expected.changedNs !== actual.changedNs ||
+    expected.device !== actual.device ||
+    expected.inode !== actual.inode ||
+    expected.links !== actual.links ||
+    expected.mode !== actual.mode ||
+    expected.modifiedNs !== actual.modifiedNs ||
+    expected.size !== actual.size
+  ) {
+    throw new Error(`${label} changed ${phase}`);
+  }
+}
+
+function validateOptions(path, maximumBytes, label, operationOverrides) {
+  if (typeof path !== "string" || path.length === 0 || path.includes("\0")) {
+    throw new Error("bounded file path must be a non-empty string");
+  }
+  if (
+    !Number.isSafeInteger(maximumBytes) ||
+    maximumBytes < 0 ||
+    maximumBytes > MAX_BOUNDED_REGULAR_FILE_BYTES
+  ) {
+    throw new Error(
+      `bounded file byte ceiling must be in [0, ${MAX_BOUNDED_REGULAR_FILE_BYTES}]`,
+    );
+  }
+  if (typeof label !== "string" || label.length === 0) {
+    throw new Error("bounded file label must be non-empty");
+  }
+  if (
+    operationOverrides === null ||
+    typeof operationOverrides !== "object" ||
+    Array.isArray(operationOverrides)
+  ) {
+    throw new Error("bounded file operation overrides must be an object");
+  }
+}

--- a/runtime/benchmarks/fnd/case-worker.mjs
+++ b/runtime/benchmarks/fnd/case-worker.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+import { performance } from "node:perf_hooks";
+import { writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  BENCHMARK_WORKER_COMPLETION_PREFIX,
+  normalizeResourceUsageMaxRssBytes,
+  summarizeSamples,
+} from "./contract.mjs";
+import {
+  assertBenchmarkWorkerEnvironment,
+  removeDarwinInjectedBenchmarkEnvironment,
+  removeWindowsInjectedBenchmarkEnvironment,
+} from "./environment.mjs";
+import { buildFixture } from "./fixtures.mjs";
+import {
+  assertNoAncestorBenchmarkControls,
+  assertOwnedTemporaryRoot,
+} from "./isolation.mjs";
+import { registerProductionModuleTracker } from "./module-closure.mjs";
+
+const START_PREFIX = "AGENC_FND_BENCH_START ";
+const RSS_LIMITATION =
+  "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.";
+const COMPLETION_HOLD_INTERVAL_MS = 60_000;
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runtimeRoot = resolve(benchmarkRoot, "../..");
+const repositoryRoot = resolve(runtimeRoot, "..");
+const productionRoot = join(runtimeRoot, "src");
+
+const requested = parseArguments(process.argv.slice(2));
+let prepared;
+let productionModuleTracker;
+
+try {
+  removeDarwinInjectedBenchmarkEnvironment(process.env);
+  removeWindowsInjectedBenchmarkEnvironment(process.env);
+  assertBenchmarkWorkerEnvironment(
+    process.env,
+    process.platform,
+    requested.temporaryRoot,
+  );
+  productionModuleTracker = registerProductionModuleTracker({
+    productionRoot,
+    repositoryRoot,
+    writeRecord(record) {
+      process.stderr.write(record);
+    },
+  });
+  const temporaryRoot = assertOwnedTemporaryRoot(requested.temporaryRoot, {
+    requireEmpty: true,
+    temporaryDirectory: dirname(requested.temporaryRoot),
+  });
+  const fixture = buildFixture(requested.caseId, requested.pointIndex);
+  prepared = await prepareCase(fixture, temporaryRoot);
+  const setupRssBytes = process.memoryUsage().rss;
+  process.stderr.write(
+    `${START_PREFIX}${JSON.stringify({
+      caseId: requested.caseId,
+      fixtureDigest: fixture.fixtureDigest,
+      input: fixture.input,
+      operations: fixture.operations,
+      rssBytes: setupRssBytes,
+    })}\n`,
+  );
+
+  for (let index = 0; index < fixture.definition.warmups; index += 1) {
+    await prepared.beforeRun();
+    await prepared.run();
+  }
+
+  const elapsedSamplesMs = [];
+  const rssObservationsBytes = [setupRssBytes];
+  let latestObservation;
+  for (let index = 0; index < fixture.definition.repetitions; index += 1) {
+    await prepared.beforeRun();
+    rssObservationsBytes.push(process.memoryUsage().rss);
+    const startedAt = performance.now();
+    latestObservation = await prepared.run();
+    elapsedSamplesMs.push(performance.now() - startedAt);
+    rssObservationsBytes.push(process.memoryUsage().rss);
+  }
+
+  const correctness = prepared.correctness(latestObservation);
+  const peakRssBytes = normalizeResourceUsageMaxRssBytes(
+    process.resourceUsage().maxRSS,
+  );
+  const result = {
+    correctness,
+    elapsed: {
+      clock: "performance.now",
+      ...summarizeSamples(elapsedSamplesMs),
+    },
+    fixtureDigest: fixture.fixtureDigest,
+    input: fixture.input,
+    memory: {
+      lowerBound: {
+        limitation: RSS_LIMITATION,
+        maximumObservedBytes: Math.max(...rssObservationsBytes),
+        method: "endpoint_rss_lower_bound",
+        observationsBytes: rssObservationsBytes,
+      },
+      peakRssBytes,
+      peakRssMethod: "process.resourceUsage.maxRSS_kib_to_bytes",
+    },
+    operations: fixture.operations,
+    status: "completed",
+  };
+
+  await prepared.cleanup();
+  prepared = undefined;
+  await productionModuleTracker.close();
+  productionModuleTracker = undefined;
+  await writeProcessStream(process.stdout, `${JSON.stringify(result)}\n`);
+  await writeProcessStream(
+    process.stderr,
+    `${BENCHMARK_WORKER_COMPLETION_PREFIX}${requested.completionNonce}\n`,
+  );
+  setInterval(() => {}, COMPLETION_HOLD_INTERVAL_MS);
+} catch (error) {
+  if (prepared !== undefined) await prepared.cleanup().catch(() => {});
+  if (productionModuleTracker !== undefined) {
+    await productionModuleTracker.close().catch(() => {});
+  }
+  const message =
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}
+
+async function prepareCase(fixture, temporaryRoot) {
+  switch (fixture.definition.id) {
+    case "csv_scheduler_progress_scan":
+      return prepareCsvCase(fixture, temporaryRoot);
+    case "patch_delete_parser_suffix_slicing":
+      return preparePatchCase(fixture);
+    case "regex_fallback_catastrophic_backtracking":
+      return prepareRegexCase(fixture, temporaryRoot);
+    case "fuzzy_daemon_recursive_scaling":
+      return prepareDaemonFuzzyCase(fixture, temporaryRoot);
+    case "fuzzy_tui_query_truncation":
+      return prepareTuiFuzzyCase(fixture);
+    default:
+      throw new Error(`unknown benchmark case ${fixture.definition.id}`);
+  }
+}
+
+async function prepareCsvCase(fixture, temporaryRoot) {
+  const csvPath = join(temporaryRoot, "input.csv");
+  await writeFile(csvPath, fixture.payload.content, "utf8");
+  const { runAgentsOnCsv } =
+    await import("../../src/agents/jobs/job-orchestrator.ts");
+  const spawn = {
+    async spawn() {
+      return { threadFinished: Promise.resolve() };
+    },
+    async cancelOutstanding() {},
+  };
+  return {
+    async beforeRun() {},
+    async run() {
+      return runAgentsOnCsv({
+        csvPath,
+        idColumn: "source_id",
+        instruction: "Process {task}",
+        maxConcurrency: 1,
+        progressEmitter() {},
+        spawn,
+      });
+    },
+    correctness(result) {
+      const expectedCount = fixture.input.rowCount;
+      const terminalCount = result.items.filter(
+        (item) => item.status === "failed",
+      ).length;
+      return {
+        expected: `${expectedCount} generated rows reach one terminal state`,
+        matchesOracle:
+          result.items.length === expectedCount &&
+          terminalCount === expectedCount,
+        observed: `${result.items.length} rows returned; ${terminalCount} terminal failures`,
+        oracle: "generated row-count and terminal-state oracle",
+      };
+    },
+    async cleanup() {},
+  };
+}
+
+async function preparePatchCase(fixture) {
+  const { parsePatch } = await import("../../src/tools/apply-patch/parser.ts");
+  return {
+    async beforeRun() {},
+    async run() {
+      return parsePatch(fixture.payload.patch);
+    },
+    correctness(result) {
+      const deleteHunks = result.hunks.filter(
+        (hunk) => hunk.kind === "delete",
+      ).length;
+      return {
+        expected: `${fixture.input.hunkCount} ordered delete hunks`,
+        matchesOracle:
+          result.hunks.length === fixture.input.hunkCount &&
+          deleteHunks === fixture.input.hunkCount,
+        observed: `${result.hunks.length} hunks parsed; ${deleteHunks} delete hunks`,
+        oracle: "generated patch grammar and hunk-count oracle",
+      };
+    },
+    async cleanup() {},
+  };
+}
+
+async function prepareRegexCase(fixture, temporaryRoot) {
+  const inputPath = join(temporaryRoot, "input.txt");
+  await writeFile(inputPath, fixture.payload.content, "utf8");
+  const [{ createGrepTool, __setRipgrepAvailabilityForTests }, sandbox] =
+    await Promise.all([
+      import("../../src/tools/system/grep.ts"),
+      import("../../src/sandbox/execution-broker.ts"),
+    ]);
+  const broker = new sandbox.SandboxExecutionBroker({
+    cwd: temporaryRoot,
+    mode: "danger_full_access",
+  });
+  const tool = createGrepTool({ allowedPaths: [temporaryRoot] });
+  return {
+    async beforeRun() {},
+    async run() {
+      __setRipgrepAvailabilityForTests(false);
+      const args = {
+        output_mode: "files_with_matches",
+        path: temporaryRoot,
+        pattern: fixture.payload.pattern,
+      };
+      sandbox.attachSandboxExecutionBroker(args, broker);
+      return tool.execute(args);
+    },
+    correctness() {
+      return {
+        expected: "fallback completes without blocking its owner event loop",
+        matchesOracle: true,
+        observed: "fallback completed",
+        oracle: "externally supervised responsiveness oracle",
+      };
+    },
+    async cleanup() {},
+  };
+}
+
+async function prepareDaemonFuzzyCase(fixture, temporaryRoot) {
+  assertNoAncestorBenchmarkControls(temporaryRoot, dirname(temporaryRoot));
+  await Promise.all(
+    fixture.payload.paths.map(async (relativePath) => {
+      const absolutePath = join(temporaryRoot, relativePath);
+      await writeFile(absolutePath, fixture.payload.fileContent, "utf8");
+    }),
+  );
+  const { runFuzzyFileSearch } =
+    await import("../../src/app-server/fuzzy-file-search.ts");
+  const expectedMatches = fixture.payload.paths.filter((path) =>
+    isSubsequence(path.toLowerCase(), fixture.payload.query.toLowerCase()),
+  ).length;
+  return {
+    async beforeRun() {
+      assertNoAncestorBenchmarkControls(temporaryRoot, dirname(temporaryRoot));
+    },
+    async run() {
+      return runFuzzyFileSearch({
+        query: fixture.payload.query,
+        roots: [temporaryRoot],
+      });
+    },
+    correctness(result) {
+      return {
+        expected: `${expectedMatches} full-query subsequence matches`,
+        matchesOracle: result.length === expectedMatches,
+        observed: `${result.length} ranked matches`,
+        oracle: "straightforward full-query subsequence oracle",
+      };
+    },
+    async cleanup() {},
+  };
+}
+
+async function prepareTuiFuzzyCase(fixture) {
+  const { FileIndex } =
+    await import("../../src/tui/ink/native-ts/file-index/index.ts");
+  const index = new FileIndex();
+  index.loadFromFileList(fixture.payload.paths);
+  return {
+    async beforeRun() {},
+    async run() {
+      return index.search(fixture.payload.query, 1);
+    },
+    correctness(result) {
+      const observedPath = result[0]?.path ?? "no result";
+      return {
+        expected: fixture.payload.rightPath,
+        matchesOracle: observedPath === fixture.payload.rightPath,
+        observed: observedPath,
+        oracle: "full-query literal suffix oracle",
+      };
+    },
+    async cleanup() {},
+  };
+}
+
+function isSubsequence(haystack, needle) {
+  let needleIndex = 0;
+  for (const character of haystack) {
+    if (character === needle[needleIndex]) needleIndex += 1;
+    if (needleIndex === needle.length) return true;
+  }
+  return needle.length === 0;
+}
+
+function parseArguments(args) {
+  if (
+    args.length !== 8 ||
+    args[0] !== "--case" ||
+    args[2] !== "--point" ||
+    args[4] !== "--temporary-root" ||
+    args[6] !== "--completion-nonce"
+  ) {
+    throw new Error(
+      "usage: case-worker.mjs --case CASE_ID --point INDEX --temporary-root PATH --completion-nonce NONCE",
+    );
+  }
+  const pointIndex = Number(args[3]);
+  if (!Number.isSafeInteger(pointIndex) || pointIndex < 0) {
+    throw new Error("point index must be a non-negative integer");
+  }
+  if (!/^[0-9a-f]{64}$/u.test(args[7])) {
+    throw new Error("completion nonce must be 32 lowercase hexadecimal bytes");
+  }
+  return {
+    caseId: args[1],
+    completionNonce: args[7],
+    pointIndex,
+    temporaryRoot: args[5],
+  };
+}
+
+function writeProcessStream(stream, value) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    stream.write(value, (error) => {
+      if (error === null || error === undefined) {
+        resolvePromise();
+      } else {
+        rejectPromise(error);
+      }
+    });
+  });
+}

--- a/runtime/benchmarks/fnd/contract.mjs
+++ b/runtime/benchmarks/fnd/contract.mjs
@@ -1,0 +1,915 @@
+import { createHash } from "node:crypto";
+
+export const BENCHMARK_SCHEMA_VERSION = 1;
+export const BENCHMARK_SUITE_ID = "agenc.fnd.algorithm-baseline.v1";
+export const BENCHMARK_ARTIFACT_KIND = "known-failure-observations";
+export const BENCHMARK_PRODUCTION_TREE_PATH = "runtime/src";
+export const MAX_WORKER_OUTPUT_BYTES = 1_048_576;
+export const MAX_BASELINE_JSON_BYTES = 2_097_152;
+export const MAX_BASELINE_MARKDOWN_BYTES = 262_144;
+export const MAX_PRODUCTION_MODULES_PER_CASE = 512;
+export const BENCHMARK_WORKER_COMPLETION_PREFIX = "AGENC_FND_BENCH_COMPLETE ";
+export const BENCHMARK_EVIDENCE_PATHS = Object.freeze([
+  ".gitattributes",
+  "package-lock.json",
+  "runtime/benchmarks/fnd/artifact-output.mjs",
+  "runtime/benchmarks/fnd/bounded-file.mjs",
+  "runtime/benchmarks/fnd/case-worker.mjs",
+  "runtime/benchmarks/fnd/contract.mjs",
+  "runtime/benchmarks/fnd/environment.mjs",
+  "runtime/benchmarks/fnd/fixtures.mjs",
+  "runtime/benchmarks/fnd/isolation.mjs",
+  "runtime/benchmarks/fnd/metadata-command-worker.mjs",
+  "runtime/benchmarks/fnd/module-closure.mjs",
+  "runtime/benchmarks/fnd/provenance.mjs",
+  "runtime/benchmarks/fnd/run-baselines.mjs",
+  "runtime/benchmarks/fnd/supervisor.mjs",
+  "runtime/native/agenc-process-broker.c",
+  "runtime/native/agenc-process-job-broker.cs",
+  "runtime/package.json",
+]);
+
+const KNOWN_FAILURE_ASSESSMENT = Object.freeze({
+  classification: "known_failure_observation",
+  gateEnforced: false,
+  threshold: null,
+});
+
+export const BENCHMARK_PLAN = Object.freeze({
+  schemaVersion: BENCHMARK_SCHEMA_VERSION,
+  suiteId: BENCHMARK_SUITE_ID,
+  cases: Object.freeze([
+    Object.freeze({
+      id: "csv_scheduler_progress_scan",
+      family: "csv",
+      implementation: "production_api",
+      measurementKind: "end_to_end_microbenchmark",
+      inputSeries: Object.freeze([
+        Object.freeze({ rowCount: 1_000 }),
+        Object.freeze({ rowCount: 2_000 }),
+        Object.freeze({ rowCount: 4_000 }),
+      ]),
+      maxInput: Object.freeze({
+        rowCount: 4_096,
+        generatedUtf8Bytes: 524_288,
+      }),
+      warmups: 1,
+      repetitions: 5,
+      supervisorTrials: 1,
+      timeoutMs: 45_000,
+      expectedTermination: "completed",
+      expectedOracleMatch: true,
+      assessment: Object.freeze({
+        ...KNOWN_FAILURE_ASSESSMENT,
+        observation:
+          "Array.shift queue movement and full progress-map scans have quadratic operation counts; the prior audit observed about 35/112/392 ms at 8k/16k/32k items.",
+      }),
+    }),
+    Object.freeze({
+      id: "patch_delete_parser_suffix_slicing",
+      family: "patch",
+      implementation: "production_api",
+      measurementKind: "parser_microbenchmark",
+      inputSeries: Object.freeze([
+        Object.freeze({ hunkCount: 8_000 }),
+        Object.freeze({ hunkCount: 16_000 }),
+        Object.freeze({ hunkCount: 32_000 }),
+      ]),
+      maxInput: Object.freeze({
+        hunkCount: 32_768,
+        generatedUtf8Bytes: 2_097_152,
+      }),
+      warmups: 1,
+      repetitions: 5,
+      supervisorTrials: 1,
+      timeoutMs: 45_000,
+      expectedTermination: "completed",
+      expectedOracleMatch: true,
+      assessment: Object.freeze({
+        ...KNOWN_FAILURE_ASSESSMENT,
+        observation:
+          "Delete-only parsing repeatedly slices the unconsumed suffix; the prior audit observed about 28 ms/238 ms/2.98 s at 16k/32k/64k lines.",
+      }),
+    }),
+    Object.freeze({
+      id: "regex_fallback_catastrophic_backtracking",
+      family: "regex",
+      implementation: "production_api",
+      measurementKind: "supervised_timeout_probe",
+      inputSeries: Object.freeze([
+        Object.freeze({ fileCount: 1, repeatedCharacters: 30 }),
+      ]),
+      maxInput: Object.freeze({
+        fileCount: 1,
+        repeatedCharacters: 30,
+        generatedUtf8Bytes: 4_096,
+      }),
+      warmups: 0,
+      repetitions: 1,
+      supervisorTrials: 3,
+      timeoutMs: 2_500,
+      expectedTermination: "timed_out",
+      expectedOracleMatch: false,
+      assessment: Object.freeze({
+        ...KNOWN_FAILURE_ASSESSMENT,
+        observation:
+          "The synchronous JavaScript fallback cannot be preempted while V8 evaluates (a+)+$; 30 repeated characters exceeded the external two-second audit kill.",
+      }),
+    }),
+    Object.freeze({
+      id: "fuzzy_daemon_recursive_scaling",
+      family: "fuzzy",
+      implementation: "production_api",
+      measurementKind: "end_to_end_microbenchmark",
+      inputSeries: Object.freeze([
+        Object.freeze({
+          candidateCount: 32,
+          pathStemCodeUnits: 32,
+          queryCodeUnits: 8,
+        }),
+        Object.freeze({
+          candidateCount: 32,
+          pathStemCodeUnits: 64,
+          queryCodeUnits: 8,
+        }),
+        Object.freeze({
+          candidateCount: 32,
+          pathStemCodeUnits: 128,
+          queryCodeUnits: 8,
+        }),
+      ]),
+      maxInput: Object.freeze({
+        candidateCount: 32,
+        pathStemCodeUnits: 128,
+        queryCodeUnits: 8,
+        generatedUtf8Bytes: 65_536,
+      }),
+      warmups: 1,
+      repetitions: 5,
+      supervisorTrials: 1,
+      timeoutMs: 45_000,
+      expectedTermination: "completed",
+      expectedOracleMatch: true,
+      assessment: Object.freeze({
+        ...KNOWN_FAILURE_ASSESSMENT,
+        observation:
+          "The daemon matcher memoizes recursive states but scans remaining candidate positions from each state, yielding roughly O(m*n^2) work and allocation.",
+      }),
+    }),
+    Object.freeze({
+      id: "fuzzy_tui_query_truncation",
+      family: "fuzzy",
+      implementation: "production_api",
+      measurementKind: "correctness_microbenchmark",
+      inputSeries: Object.freeze([
+        Object.freeze({
+          candidateCount: 2,
+          queryCodeUnits: 69,
+          indexedQueryCodeUnits: 64,
+        }),
+      ]),
+      maxInput: Object.freeze({
+        candidateCount: 2,
+        queryCodeUnits: 69,
+        indexedQueryCodeUnits: 64,
+        generatedUtf8Bytes: 4_096,
+      }),
+      warmups: 2,
+      repetitions: 9,
+      supervisorTrials: 1,
+      timeoutMs: 10_000,
+      expectedTermination: "completed",
+      expectedOracleMatch: false,
+      assessment: Object.freeze({
+        ...KNOWN_FAILURE_ASSESSMENT,
+        observation:
+          "The TUI matcher silently truncates a 69-code-unit query at 64 and ranks the generated path ending WRONG ahead of the only full-query match ending RIGHT.",
+      }),
+    }),
+  ]),
+});
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const GIT_REVISION_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const CASE_ID_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)*$/u;
+
+export function canonicalJson(value) {
+  return `${JSON.stringify(canonicalize(value), null, 2)}\n`;
+}
+
+export function sha256Hex(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function benchmarkPlanDigest() {
+  return sha256Hex(canonicalJson(BENCHMARK_PLAN));
+}
+
+export function summarizeSamples(samples) {
+  if (!Array.isArray(samples) || samples.length === 0) {
+    throw new Error("elapsed samples must be a non-empty array");
+  }
+  const values = samples.map((sample) => {
+    if (!Number.isFinite(sample) || sample < 0) {
+      throw new Error("elapsed samples must be finite non-negative numbers");
+    }
+    return sample;
+  });
+  const sorted = [...values].sort((left, right) => left - right);
+  const medianMs = medianOfSorted(sorted);
+  const deviations = sorted
+    .map((sample) => Math.abs(sample - medianMs))
+    .sort((left, right) => left - right);
+  return {
+    sampleCount: values.length,
+    samplesMs: values.map(roundMetric),
+    medianMs: roundMetric(medianMs),
+    madMs: roundMetric(medianOfSorted(deviations)),
+    minMs: roundMetric(sorted[0]),
+    maxMs: roundMetric(sorted[sorted.length - 1]),
+  };
+}
+
+export function normalizeResourceUsageMaxRssBytes(maxRssKibibytes) {
+  if (!Number.isSafeInteger(maxRssKibibytes) || maxRssKibibytes <= 0) {
+    throw new Error(
+      "process.resourceUsage().maxRSS must be a positive integer in KiB",
+    );
+  }
+  const bytes = maxRssKibibytes * 1_024;
+  if (!Number.isSafeInteger(bytes)) {
+    throw new Error(
+      "normalized process peak RSS exceeds the safe integer range",
+    );
+  }
+  return bytes;
+}
+
+export function validateBenchmarkReport(report) {
+  requireRecord(report, "report");
+  requireExactKeys(
+    report,
+    [
+      "artifactKind",
+      "cases",
+      "environment",
+      "evidenceBindings",
+      "planDigest",
+      "productionModuleClosures",
+      "productionTreeBinding",
+      "schemaVersion",
+      "sourceRevision",
+      "suiteId",
+    ],
+    "report",
+  );
+  requireEqual(
+    report.schemaVersion,
+    BENCHMARK_SCHEMA_VERSION,
+    "report.schemaVersion",
+  );
+  requireEqual(report.suiteId, BENCHMARK_SUITE_ID, "report.suiteId");
+  requireEqual(
+    report.artifactKind,
+    BENCHMARK_ARTIFACT_KIND,
+    "report.artifactKind",
+  );
+  requireEqual(report.planDigest, benchmarkPlanDigest(), "report.planDigest");
+  requireGitRevision(report.sourceRevision, "report.sourceRevision");
+  validateProductionTreeBinding(report.productionTreeBinding);
+  validateProductionModuleClosures(report.productionModuleClosures);
+  validateEnvironment(report.environment);
+  validateEvidenceBindings(report.evidenceBindings);
+  if (!Array.isArray(report.cases)) {
+    throw new Error("report.cases must be an array");
+  }
+  requireEqual(
+    report.cases.length,
+    BENCHMARK_PLAN.cases.length,
+    "report.cases.length",
+  );
+  BENCHMARK_PLAN.cases.forEach((definition, index) => {
+    validateCaseReport(report.cases[index], definition, index);
+  });
+  return report;
+}
+
+export function renderBaselineMarkdown(report, jsonDigest) {
+  validateBenchmarkReport(report);
+  requireSha(jsonDigest, "jsonDigest");
+  const lines = [
+    "# FND algorithm baseline v1",
+    "",
+    "This artifact records bounded observations of known failures. Every row is",
+    "informational: no current result is a passing performance threshold or gate.",
+    "Generated inputs are synthetic and created only for the benchmark process.",
+    "",
+    `- JSON SHA-256: \`${jsonDigest}\``,
+    `- Source revision: \`${report.sourceRevision}\``,
+    `- Production tree: \`${report.productionTreeBinding.path}\` at Git object \`${report.productionTreeBinding.gitObjectId}\``,
+    `- Loaded production closure: \`${report.productionModuleClosures.reduce((count, closure) => count + closure.modules.length, 0)}\` module bindings across \`${report.productionModuleClosures.length}\` cases`,
+    `- Plan SHA-256: \`${report.planDigest}\``,
+    `- Node/npm: \`${report.environment.runtime.node}\` / \`${report.environment.runtime.npm}\``,
+    `- OS/CPU: \`${report.environment.os.platform} ${report.environment.os.release} ${report.environment.os.arch}\` / \`${report.environment.cpu.model}\` (${report.environment.cpu.logicalCount} logical)`,
+    `- RAM: \`${report.environment.memory.totalBytes}\` bytes`,
+    `- Source filesystem: type \`${report.environment.filesystems.sourceCheckout.type}\`, block \`${report.environment.filesystems.sourceCheckout.blockSizeBytes}\` bytes`,
+    `- Fixture filesystem: type \`${report.environment.filesystems.temporaryFixtures.type}\`, block \`${report.environment.filesystems.temporaryFixtures.blockSizeBytes}\` bytes`,
+    `- SQLite/ripgrep: \`${report.environment.sqlite.version}\` / \`${report.environment.ripgrep.version}\``,
+    "",
+    "| Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |",
+    "| --- | ---: | --- | ---: | ---: | ---: | ---: |",
+  ];
+  for (const benchmarkCase of report.cases) {
+    for (const point of benchmarkCase.points) {
+      lines.push(
+        `| \`${benchmarkCase.id}\` | \`${compactInput(point.input)}\` | \`${point.status}\` | ${formatMetric(point.elapsed.medianMs)} | ${formatMetric(point.elapsed.madMs)} | ${formatOptionalInteger(point.memory.peakRssBytes)} | ${point.memory.lowerBound.maximumObservedBytes} |`,
+      );
+    }
+  }
+  lines.push("", "## Known-failure policy", "");
+  for (const benchmarkCase of report.cases) {
+    lines.push(
+      `- \`${benchmarkCase.id}\`: ${benchmarkCase.assessment.observation}`,
+    );
+  }
+  lines.push(
+    "",
+    "## Reproduce",
+    "",
+    "Run on the same pinned runtime and machine state; compare medians, MAD,",
+    "operation counts, and relative scaling rather than one wall-clock sample.",
+    "",
+    "```sh",
+    `npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision ${report.sourceRevision} --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md`,
+    "npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime",
+    "```",
+    "",
+    "Completed workers report their actual process high-water RSS from",
+    "`process.resourceUsage().maxRSS`, normalized from KiB to bytes. A worker",
+    "terminated during synchronous work cannot emit that final high-water mark,",
+    "so its peak is `n/a`; its last start RSS remains a clearly labeled lower",
+    "bound. Endpoint observations are retained as diagnostics and are never",
+    "presented as the worker peak.",
+    "",
+  );
+  return lines.join("\n");
+}
+
+function validateCaseReport(value, definition, index) {
+  const label = `report.cases[${index}]`;
+  requireRecord(value, label);
+  requireExactKeys(
+    value,
+    [
+      "assessment",
+      "family",
+      "id",
+      "implementation",
+      "measurementKind",
+      "points",
+    ],
+    label,
+  );
+  for (const key of ["id", "family", "implementation", "measurementKind"]) {
+    requireEqual(value[key], definition[key], `${label}.${key}`);
+  }
+  requireRecord(value.assessment, `${label}.assessment`);
+  requireExactKeys(
+    value.assessment,
+    ["classification", "gateEnforced", "observation", "threshold"],
+    `${label}.assessment`,
+  );
+  requireEqual(
+    value.assessment.classification,
+    "known_failure_observation",
+    `${label}.assessment.classification`,
+  );
+  requireEqual(
+    value.assessment.gateEnforced,
+    false,
+    `${label}.assessment.gateEnforced`,
+  );
+  requireEqual(
+    value.assessment.threshold,
+    null,
+    `${label}.assessment.threshold`,
+  );
+  requireEqual(
+    value.assessment.observation,
+    definition.assessment.observation,
+    `${label}.assessment.observation`,
+  );
+  if (!Array.isArray(value.points)) {
+    throw new Error(`${label}.points must be an array`);
+  }
+  requireEqual(
+    value.points.length,
+    definition.inputSeries.length,
+    `${label}.points.length`,
+  );
+  definition.inputSeries.forEach((expectedInput, pointIndex) => {
+    validatePoint(
+      value.points[pointIndex],
+      definition,
+      expectedInput,
+      `${label}.points[${pointIndex}]`,
+    );
+  });
+}
+
+function validatePoint(value, definition, expectedInput, label) {
+  requireRecord(value, label);
+  requireExactKeys(
+    value,
+    [
+      "correctness",
+      "elapsed",
+      "fixtureDigest",
+      "input",
+      "memory",
+      "operations",
+      "status",
+    ],
+    label,
+  );
+  requireRecord(value.input, `${label}.input`);
+  for (const [key, expected] of Object.entries(expectedInput)) {
+    requireEqual(value.input[key], expected, `${label}.input.${key}`);
+  }
+  requireBoundedInteger(
+    value.input.generatedUtf8Bytes,
+    0,
+    definition.maxInput.generatedUtf8Bytes,
+    `${label}.input.generatedUtf8Bytes`,
+  );
+  for (const [key, maximum] of Object.entries(definition.maxInput)) {
+    if (key === "generatedUtf8Bytes") continue;
+    if (value.input[key] !== undefined) {
+      requireBoundedInteger(
+        value.input[key],
+        0,
+        maximum,
+        `${label}.input.${key}`,
+      );
+    }
+  }
+  requireSha(value.fixtureDigest, `${label}.fixtureDigest`);
+  requireEqual(value.status, definition.expectedTermination, `${label}.status`);
+  validateElapsed(value.elapsed, definition, label);
+  validateMemory(value.memory, definition, `${label}.memory`);
+  validateOperations(value.operations, `${label}.operations`);
+  validateCorrectness(value.correctness, definition, `${label}.correctness`);
+}
+
+function validateElapsed(value, definition, pointLabel) {
+  const label = `${pointLabel}.elapsed`;
+  requireRecord(value, label);
+  requireExactKeys(
+    value,
+    [
+      "clock",
+      "madMs",
+      "maxMs",
+      "medianMs",
+      "minMs",
+      "sampleCount",
+      "samplesMs",
+    ],
+    label,
+  );
+  requireEqual(value.clock, "performance.now", `${label}.clock`);
+  const expectedCount =
+    definition.expectedTermination === "timed_out"
+      ? definition.supervisorTrials
+      : definition.repetitions;
+  requireEqual(value.sampleCount, expectedCount, `${label}.sampleCount`);
+  if (!Array.isArray(value.samplesMs)) {
+    throw new Error(`${label}.samplesMs must be an array`);
+  }
+  const summary = summarizeSamples(value.samplesMs);
+  for (const key of ["sampleCount", "medianMs", "madMs", "minMs", "maxMs"]) {
+    requireEqual(value[key], summary[key], `${label}.${key}`);
+  }
+}
+
+function validateMemory(value, definition, label) {
+  requireRecord(value, label);
+  requireExactKeys(
+    value,
+    ["lowerBound", "peakRssBytes", "peakRssMethod"],
+    label,
+  );
+  const completed = definition.expectedTermination === "completed";
+  requireEqual(
+    value.peakRssMethod,
+    completed
+      ? "process.resourceUsage.maxRSS_kib_to_bytes"
+      : "unavailable_after_forced_termination",
+    `${label}.peakRssMethod`,
+  );
+  if (completed) {
+    requireBoundedInteger(
+      value.peakRssBytes,
+      1,
+      Number.MAX_SAFE_INTEGER,
+      `${label}.peakRssBytes`,
+    );
+  } else {
+    requireEqual(value.peakRssBytes, null, `${label}.peakRssBytes`);
+  }
+
+  const lowerBound = value.lowerBound;
+  requireRecord(lowerBound, `${label}.lowerBound`);
+  requireExactKeys(
+    lowerBound,
+    ["limitation", "maximumObservedBytes", "method", "observationsBytes"],
+    `${label}.lowerBound`,
+  );
+  if (
+    lowerBound.method !== "endpoint_rss_lower_bound" &&
+    lowerBound.method !== "child_start_rss_lower_bound"
+  ) {
+    throw new Error(`${label}.lowerBound.method is unsupported`);
+  }
+  requireEqual(
+    lowerBound.method,
+    completed ? "endpoint_rss_lower_bound" : "child_start_rss_lower_bound",
+    `${label}.lowerBound.method`,
+  );
+  if (
+    typeof lowerBound.limitation !== "string" ||
+    lowerBound.limitation.length === 0
+  ) {
+    throw new Error(`${label}.lowerBound.limitation must be non-empty`);
+  }
+  if (
+    !Array.isArray(lowerBound.observationsBytes) ||
+    lowerBound.observationsBytes.length === 0
+  ) {
+    throw new Error(
+      `${label}.lowerBound.observationsBytes must be a non-empty array`,
+    );
+  }
+  for (const [index, observation] of lowerBound.observationsBytes.entries()) {
+    requireBoundedInteger(
+      observation,
+      1,
+      Number.MAX_SAFE_INTEGER,
+      `${label}.lowerBound.observationsBytes[${index}]`,
+    );
+  }
+  requireEqual(
+    lowerBound.maximumObservedBytes,
+    Math.max(...lowerBound.observationsBytes),
+    `${label}.lowerBound.maximumObservedBytes`,
+  );
+}
+
+function validateProductionTreeBinding(value) {
+  requireRecord(value, "report.productionTreeBinding");
+  requireExactKeys(
+    value,
+    ["gitObjectId", "objectType", "path"],
+    "report.productionTreeBinding",
+  );
+  requireEqual(
+    value.path,
+    BENCHMARK_PRODUCTION_TREE_PATH,
+    "report.productionTreeBinding.path",
+  );
+  requireEqual(
+    value.objectType,
+    "tree",
+    "report.productionTreeBinding.objectType",
+  );
+  requireGitRevision(
+    value.gitObjectId,
+    "report.productionTreeBinding.gitObjectId",
+  );
+}
+
+function validateOperations(value, label) {
+  requireRecord(value, label);
+  const entries = Object.entries(value);
+  if (entries.length === 0) throw new Error(`${label} must not be empty`);
+  for (const [key, count] of entries) {
+    if (!CASE_ID_PATTERN.test(key)) {
+      throw new Error(`${label}.${key} is not a stable operation name`);
+    }
+    requireBoundedInteger(count, 0, Number.MAX_SAFE_INTEGER, `${label}.${key}`);
+  }
+}
+
+function validateCorrectness(value, definition, label) {
+  requireRecord(value, label);
+  requireExactKeys(
+    value,
+    ["expected", "matchesOracle", "observed", "oracle"],
+    label,
+  );
+  for (const key of ["expected", "observed", "oracle"]) {
+    if (typeof value[key] !== "string" || value[key].length === 0) {
+      throw new Error(`${label}.${key} must be a non-empty string`);
+    }
+  }
+  requireEqual(
+    value.matchesOracle,
+    definition.expectedOracleMatch,
+    `${label}.matchesOracle`,
+  );
+}
+
+function validateEnvironment(value) {
+  requireRecord(value, "report.environment");
+  requireExactKeys(
+    value,
+    ["cpu", "filesystems", "memory", "os", "ripgrep", "runtime", "sqlite"],
+    "report.environment",
+  );
+  requireRecord(value.cpu, "report.environment.cpu");
+  requireExactKeys(
+    value.cpu,
+    ["logicalCount", "model"],
+    "report.environment.cpu",
+  );
+  requireBoundedInteger(
+    value.cpu.logicalCount,
+    1,
+    65_536,
+    "report.environment.cpu.logicalCount",
+  );
+  requireNonEmptyString(value.cpu.model, "report.environment.cpu.model");
+
+  requireRecord(value.filesystems, "report.environment.filesystems");
+  requireExactKeys(
+    value.filesystems,
+    ["sourceCheckout", "temporaryFixtures"],
+    "report.environment.filesystems",
+  );
+  for (const filesystemName of ["sourceCheckout", "temporaryFixtures"]) {
+    const filesystem = value.filesystems[filesystemName];
+    const label = `report.environment.filesystems.${filesystemName}`;
+    requireRecord(filesystem, label);
+    requireExactKeys(filesystem, ["blockSizeBytes", "type"], label);
+    requireBoundedInteger(
+      filesystem.blockSizeBytes,
+      1,
+      Number.MAX_SAFE_INTEGER,
+      `${label}.blockSizeBytes`,
+    );
+    requireNonEmptyString(filesystem.type, `${label}.type`);
+  }
+
+  requireRecord(value.memory, "report.environment.memory");
+  requireExactKeys(value.memory, ["totalBytes"], "report.environment.memory");
+  requireBoundedInteger(
+    value.memory.totalBytes,
+    1,
+    Number.MAX_SAFE_INTEGER,
+    "report.environment.memory.totalBytes",
+  );
+
+  requireRecord(value.os, "report.environment.os");
+  requireExactKeys(
+    value.os,
+    ["arch", "platform", "release"],
+    "report.environment.os",
+  );
+  for (const key of ["arch", "platform", "release"]) {
+    requireNonEmptyString(value.os[key], `report.environment.os.${key}`);
+  }
+
+  requireRecord(value.runtime, "report.environment.runtime");
+  requireExactKeys(
+    value.runtime,
+    ["node", "npm", "v8"],
+    "report.environment.runtime",
+  );
+  for (const key of ["node", "npm", "v8"]) {
+    requireNonEmptyString(
+      value.runtime[key],
+      `report.environment.runtime.${key}`,
+    );
+  }
+
+  requireRecord(value.sqlite, "report.environment.sqlite");
+  requireExactKeys(
+    value.sqlite,
+    ["compileOptions", "version"],
+    "report.environment.sqlite",
+  );
+  requireNonEmptyString(
+    value.sqlite.version,
+    "report.environment.sqlite.version",
+  );
+  if (!Array.isArray(value.sqlite.compileOptions)) {
+    throw new Error(
+      "report.environment.sqlite.compileOptions must be an array",
+    );
+  }
+  for (const [index, option] of value.sqlite.compileOptions.entries()) {
+    requireNonEmptyString(
+      option,
+      `report.environment.sqlite.compileOptions[${index}]`,
+    );
+  }
+  const sortedOptions = [...value.sqlite.compileOptions].sort();
+  requireEqual(
+    JSON.stringify(value.sqlite.compileOptions),
+    JSON.stringify(sortedOptions),
+    "report.environment.sqlite.compileOptions order",
+  );
+
+  requireRecord(value.ripgrep, "report.environment.ripgrep");
+  requireExactKeys(
+    value.ripgrep,
+    ["distribution", "version"],
+    "report.environment.ripgrep",
+  );
+  requireEqual(
+    value.ripgrep.distribution,
+    "pinned_package",
+    "report.environment.ripgrep.distribution",
+  );
+  requireNonEmptyString(
+    value.ripgrep.version,
+    "report.environment.ripgrep.version",
+  );
+}
+
+function validateProductionModuleClosures(value) {
+  if (!Array.isArray(value)) {
+    throw new Error("report.productionModuleClosures must be an array");
+  }
+  requireEqual(
+    value.length,
+    BENCHMARK_PLAN.cases.length,
+    "report.productionModuleClosures.length",
+  );
+  BENCHMARK_PLAN.cases.forEach((definition, closureIndex) => {
+    const closure = value[closureIndex];
+    const closureLabel = `report.productionModuleClosures[${closureIndex}]`;
+    requireRecord(closure, closureLabel);
+    requireExactKeys(closure, ["caseId", "modules"], closureLabel);
+    requireEqual(closure.caseId, definition.id, `${closureLabel}.caseId`);
+    if (!Array.isArray(closure.modules) || closure.modules.length === 0) {
+      throw new Error(`${closureLabel}.modules must be a non-empty array`);
+    }
+    if (closure.modules.length > MAX_PRODUCTION_MODULES_PER_CASE) {
+      throw new Error(`${closureLabel}.modules exceeds its named bound`);
+    }
+    const paths = [];
+    closure.modules.forEach((binding, bindingIndex) => {
+      const bindingLabel = `${closureLabel}.modules[${bindingIndex}]`;
+      requireRecord(binding, bindingLabel);
+      requireExactKeys(binding, ["path", "sha256"], bindingLabel);
+      requireProductionModulePath(binding.path, `${bindingLabel}.path`);
+      requireSha(binding.sha256, `${bindingLabel}.sha256`);
+      paths.push(binding.path);
+    });
+    requireEqual(
+      JSON.stringify(paths),
+      JSON.stringify([...new Set(paths)].sort()),
+      `${closureLabel}.modules path order`,
+    );
+  });
+}
+
+function requireProductionModulePath(value, label) {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith(`${BENCHMARK_PRODUCTION_TREE_PATH}/`) ||
+    value.includes("\\") ||
+    value
+      .split("/")
+      .some(
+        (segment) =>
+          segment.length === 0 || segment === "." || segment === "..",
+      )
+  ) {
+    throw new Error(`${label} must stay inside the production tree`);
+  }
+}
+
+function validateEvidenceBindings(value) {
+  if (!Array.isArray(value)) {
+    throw new Error("report.evidenceBindings must be an array");
+  }
+  requireEqual(
+    value.length,
+    BENCHMARK_EVIDENCE_PATHS.length,
+    "report.evidenceBindings.length",
+  );
+  BENCHMARK_EVIDENCE_PATHS.forEach((expectedPath, index) => {
+    const binding = value[index];
+    const label = `report.evidenceBindings[${index}]`;
+    requireRecord(binding, label);
+    requireExactKeys(binding, ["normalization", "path", "sha256"], label);
+    requireEqual(binding.path, expectedPath, `${label}.path`);
+    requireEqual(binding.normalization, "utf8_lf", `${label}.normalization`);
+    requireSha(binding.sha256, `${label}.sha256`);
+  });
+}
+
+function canonicalize(value) {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value))
+      throw new Error("canonical JSON rejects non-finite numbers");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalize);
+  requireRecord(value, "canonical JSON value");
+  const output = {};
+  for (const key of Object.keys(value).sort()) {
+    const child = value[key];
+    if (child === undefined)
+      throw new Error("canonical JSON rejects undefined values");
+    output[key] = canonicalize(child);
+  }
+  return output;
+}
+
+function medianOfSorted(sorted) {
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function roundMetric(value) {
+  return Number(value.toFixed(6));
+}
+
+function compactInput(input) {
+  return Object.entries(input)
+    .filter(([key]) => key !== "generatedUtf8Bytes")
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(",");
+}
+
+function formatMetric(value) {
+  return Number(value).toFixed(3);
+}
+
+function formatOptionalInteger(value) {
+  return value === null ? "n/a" : String(value);
+}
+
+function requireRecord(value, label) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new Error(`${label} must be a plain object`);
+  }
+}
+
+function requireExactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(sortedExpected)) {
+    throw new Error(
+      `${label} keys differ: expected ${sortedExpected.join(",")}; received ${actual.join(",")}`,
+    );
+  }
+}
+
+function requireEqual(actual, expected, label) {
+  if (!Object.is(actual, expected)) {
+    throw new Error(`${label} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+function requireSha(value, label) {
+  if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
+    throw new Error(`${label} must be a lowercase SHA-256 digest`);
+  }
+}
+
+function requireGitRevision(value, label) {
+  if (typeof value !== "string" || !GIT_REVISION_PATTERN.test(value)) {
+    throw new Error(`${label} must be a full Git object ID`);
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+function requireBoundedInteger(value, minimum, maximum, label) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${label} must be an integer in [${minimum}, ${maximum}]`);
+  }
+}

--- a/runtime/benchmarks/fnd/environment.mjs
+++ b/runtime/benchmarks/fnd/environment.mjs
@@ -1,0 +1,255 @@
+import { resolve } from "node:path";
+
+const FIXED_WORKER_ENVIRONMENT = Object.freeze({
+  LANG: "C",
+  LC_ALL: "C",
+  TSX_DISABLE_CACHE: "1",
+  TZ: "UTC",
+});
+const FIXED_WORKER_ENVIRONMENT_NAMES = Object.freeze(
+  Object.keys(FIXED_WORKER_ENVIRONMENT),
+);
+
+const WINDOWS_SYSTEM_ROOT_NAME = "SystemRoot";
+const WINDOWS_INJECTED_ENVIRONMENT_NAMES = Object.freeze([
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LOGONSERVER",
+  "PATH",
+  "SYSTEMDRIVE",
+  "USERDOMAIN",
+  "USERNAME",
+  "USERPROFILE",
+  "WINDIR",
+]);
+const DARWIN_INJECTED_TEXT_ENCODING_NAME = "__CF_USER_TEXT_ENCODING";
+const DARWIN_INJECTED_TEXT_ENCODING_PATTERN =
+  /^0x[0-9A-Fa-f]{1,8}:(?:0x)?[0-9A-Fa-f]{1,8}:(?:0x)?[0-9A-Fa-f]{1,8}$/u;
+const TEMPORARY_WORKER_ENVIRONMENT_NAMES = Object.freeze([
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+]);
+
+export function assertNoBenchmarkExecArguments(execArguments) {
+  if (!Array.isArray(execArguments)) {
+    throw new Error("benchmark Node execArgv must be an array");
+  }
+  if (
+    execArguments.some(
+      (argument) => typeof argument !== "string" || argument.length === 0,
+    )
+  ) {
+    throw new Error("benchmark Node execArgv contains an invalid argument");
+  }
+  if (execArguments.length > 0) {
+    throw new Error("benchmark runner requires empty Node execArgv");
+  }
+}
+
+export function assertNoUnsafeBenchmarkEnvironment(environment) {
+  assertEnvironmentRecord(environment);
+  const unsafeNames = Object.keys(environment)
+    .filter((name) => {
+      const value = environment[name];
+      if (value === undefined || value === "") return false;
+      const normalizedName = name.toUpperCase();
+      return (
+        normalizedName.startsWith("NODE_") || normalizedName.startsWith("TSX_")
+      );
+    })
+    .sort();
+  if (unsafeNames.length > 0) {
+    throw new Error(
+      `unsafe benchmark Node or loader environment override: ${unsafeNames.join(", ")}`,
+    );
+  }
+}
+
+export function removeDarwinInjectedBenchmarkEnvironment(
+  environment,
+  platform = process.platform,
+) {
+  assertEnvironmentRecord(environment);
+  if (platform !== "darwin") return;
+  const value = environment[DARWIN_INJECTED_TEXT_ENCODING_NAME];
+  if (value === undefined) return;
+  if (
+    typeof value !== "string" ||
+    !DARWIN_INJECTED_TEXT_ENCODING_PATTERN.test(value)
+  ) {
+    throw new Error(
+      `macOS injected an invalid ${DARWIN_INJECTED_TEXT_ENCODING_NAME} value`,
+    );
+  }
+  if (!delete environment[DARWIN_INJECTED_TEXT_ENCODING_NAME]) {
+    throw new Error(
+      `benchmark worker could not remove ${DARWIN_INJECTED_TEXT_ENCODING_NAME}`,
+    );
+  }
+}
+
+export function removeWindowsInjectedBenchmarkEnvironment(
+  environment,
+  platform = process.platform,
+) {
+  assertEnvironmentRecord(environment);
+  if (platform !== "win32") return;
+  for (const expectedName of WINDOWS_INJECTED_ENVIRONMENT_NAMES) {
+    const matchingName = Object.keys(environment).find(
+      (name) =>
+        normalizeEnvironmentName(name, platform) ===
+        normalizeEnvironmentName(expectedName, platform),
+    );
+    if (matchingName === undefined) continue;
+    if (!delete environment[matchingName]) {
+      throw new Error(
+        `benchmark worker could not remove Windows-injected ${matchingName}`,
+      );
+    }
+  }
+}
+
+/** @returns {Readonly<Record<string, string>>} */
+export function createBenchmarkWorkerEnvironment(
+  environment,
+  platform = process.platform,
+  ownedTemporaryRoot,
+) {
+  assertNoUnsafeBenchmarkEnvironment(environment);
+  const workerEnvironment = { ...FIXED_WORKER_ENVIRONMENT };
+  const resolvedTemporaryRoot = resolveOwnedTemporaryRoot(ownedTemporaryRoot);
+  for (const name of TEMPORARY_WORKER_ENVIRONMENT_NAMES) {
+    workerEnvironment[name] = resolvedTemporaryRoot;
+  }
+  workerEnvironment.AGENC_HOME = resolvedTemporaryRoot;
+  if (platform === "win32") {
+    const systemRoot = getEnvironmentValue(
+      environment,
+      WINDOWS_SYSTEM_ROOT_NAME,
+      platform,
+    );
+    if (typeof systemRoot !== "string" || systemRoot.length === 0) {
+      throw new Error("Windows benchmark workers require SystemRoot");
+    }
+    workerEnvironment[WINDOWS_SYSTEM_ROOT_NAME] = systemRoot;
+  }
+  return Object.freeze(workerEnvironment);
+}
+
+export function assertBenchmarkWorkerEnvironment(
+  environment,
+  platform = process.platform,
+  expectedOwnedTemporaryRoot,
+) {
+  assertEnvironmentRecord(environment);
+  const resolvedTemporaryRoot = resolveOwnedTemporaryRoot(
+    expectedOwnedTemporaryRoot,
+  );
+  const allowedNames = new Set(
+    FIXED_WORKER_ENVIRONMENT_NAMES.map((name) =>
+      normalizeEnvironmentName(name, platform),
+    ),
+  );
+  allowedNames.add(normalizeEnvironmentName("AGENC_HOME", platform));
+  for (const name of TEMPORARY_WORKER_ENVIRONMENT_NAMES) {
+    allowedNames.add(normalizeEnvironmentName(name, platform));
+  }
+  if (platform === "win32") {
+    allowedNames.add(
+      normalizeEnvironmentName(WINDOWS_SYSTEM_ROOT_NAME, platform),
+    );
+  }
+  const seenNames = new Set();
+  for (const [name, value] of Object.entries(environment)) {
+    if (platform === "win32" && /^=[A-Za-z]:$/u.test(name)) continue;
+    const normalizedName = normalizeEnvironmentName(name, platform);
+    if (seenNames.has(normalizedName)) {
+      throw new Error(
+        `benchmark worker environment repeats a case-insensitive name: ${name}`,
+      );
+    }
+    seenNames.add(normalizedName);
+    if (!allowedNames.has(normalizedName)) {
+      throw new Error(
+        `benchmark worker inherited unexpected environment: ${name}`,
+      );
+    }
+    const fixedName = FIXED_WORKER_ENVIRONMENT_NAMES.find(
+      (candidate) =>
+        normalizeEnvironmentName(candidate, platform) === normalizedName,
+    );
+    if (fixedName !== undefined) {
+      if (value !== FIXED_WORKER_ENVIRONMENT[fixedName]) {
+        throw new Error(`benchmark worker environment differs for ${name}`);
+      }
+    } else if (typeof value !== "string" || value.length === 0) {
+      throw new Error(`benchmark worker environment is empty for ${name}`);
+    }
+  }
+  for (const [name, expected] of Object.entries(FIXED_WORKER_ENVIRONMENT)) {
+    if (getEnvironmentValue(environment, name, platform) !== expected) {
+      throw new Error(`benchmark worker environment is missing ${name}`);
+    }
+  }
+  for (const name of ["AGENC_HOME", ...TEMPORARY_WORKER_ENVIRONMENT_NAMES]) {
+    const value = getEnvironmentValue(environment, name, platform);
+    if (
+      typeof value !== "string" ||
+      value.length === 0 ||
+      resolve(value) !== resolvedTemporaryRoot
+    ) {
+      throw new Error(
+        `benchmark worker environment has an invalid owned root for ${name}`,
+      );
+    }
+  }
+  if (
+    platform === "win32" &&
+    getEnvironmentValue(environment, WINDOWS_SYSTEM_ROOT_NAME, platform) ===
+      undefined
+  ) {
+    throw new Error("benchmark worker environment is missing SystemRoot");
+  }
+}
+
+function getEnvironmentValue(environment, expectedName, platform) {
+  const normalizedExpectedName = normalizeEnvironmentName(
+    expectedName,
+    platform,
+  );
+  const matchingEntries = Object.entries(environment).filter(
+    ([name]) =>
+      normalizeEnvironmentName(name, platform) === normalizedExpectedName,
+  );
+  if (matchingEntries.length > 1) {
+    throw new Error(
+      `benchmark environment repeats a case-insensitive name: ${expectedName}`,
+    );
+  }
+  return matchingEntries[0]?.[1];
+}
+
+function normalizeEnvironmentName(name, platform) {
+  return platform === "win32" ? name.toUpperCase() : name;
+}
+
+function resolveOwnedTemporaryRoot(ownedTemporaryRoot) {
+  if (
+    typeof ownedTemporaryRoot !== "string" ||
+    ownedTemporaryRoot.length === 0
+  ) {
+    throw new Error("benchmark workers require an owned temporary root");
+  }
+  return resolve(ownedTemporaryRoot);
+}
+
+function assertEnvironmentRecord(environment) {
+  if (
+    environment === null ||
+    typeof environment !== "object" ||
+    Array.isArray(environment)
+  ) {
+    throw new Error("benchmark environment must be an object");
+  }
+}

--- a/runtime/benchmarks/fnd/fixtures.mjs
+++ b/runtime/benchmarks/fnd/fixtures.mjs
@@ -1,0 +1,210 @@
+import { BENCHMARK_PLAN, canonicalJson, sha256Hex } from "./contract.mjs";
+
+const GENERATOR_VERSION = 1;
+const CSV_HEADER = "source_id,task\n";
+const PATCH_BEGIN = "*** Begin Patch";
+const PATCH_END = "*** End Patch";
+const REGEX_PATTERN = "(a+)+$";
+
+export function buildFixture(caseId, pointIndex) {
+  const definition = caseDefinition(caseId);
+  const point = definition.inputSeries[pointIndex];
+  if (point === undefined) {
+    throw new Error(`unknown point ${pointIndex} for benchmark case ${caseId}`);
+  }
+
+  let generated;
+  switch (caseId) {
+    case "csv_scheduler_progress_scan":
+      generated = buildCsvFixture(point);
+      break;
+    case "patch_delete_parser_suffix_slicing":
+      generated = buildPatchFixture(point);
+      break;
+    case "regex_fallback_catastrophic_backtracking":
+      generated = buildRegexFixture(point);
+      break;
+    case "fuzzy_daemon_recursive_scaling":
+      generated = buildDaemonFuzzyFixture(point);
+      break;
+    case "fuzzy_tui_query_truncation":
+      generated = buildTuiFuzzyFixture(point);
+      break;
+    default:
+      throw new Error(`no fixture generator for benchmark case ${caseId}`);
+  }
+
+  const input = Object.freeze({
+    ...point,
+    generatedUtf8Bytes: generated.generatedUtf8Bytes,
+  });
+  const descriptor = Object.freeze({
+    caseId,
+    generatorVersion: GENERATOR_VERSION,
+    input,
+    payload: generated.descriptor,
+  });
+  const fixtureDigest = sha256Hex(canonicalJson(descriptor));
+  return Object.freeze({
+    definition,
+    descriptor,
+    fixtureDigest,
+    input,
+    operations: Object.freeze(generated.operations),
+    payload: Object.freeze(generated.payload),
+  });
+}
+
+export function describeFixture(caseId, pointIndex) {
+  const fixture = buildFixture(caseId, pointIndex);
+  return Object.freeze({
+    descriptor: fixture.descriptor,
+    fixtureDigest: fixture.fixtureDigest,
+    operations: fixture.operations,
+  });
+}
+
+function buildCsvFixture(point) {
+  const width = String(point.rowCount - 1).length;
+  const lines = new Array(point.rowCount + 1);
+  lines[0] = CSV_HEADER.slice(0, -1);
+  for (let index = 0; index < point.rowCount; index += 1) {
+    const id = String(index).padStart(width, "0");
+    lines[index + 1] = `row-${id},synthetic-${id}`;
+  }
+  const content = `${lines.join("\n")}\n`;
+  return {
+    generatedUtf8Bytes: Buffer.byteLength(content),
+    descriptor: {
+      contentSha256: sha256Hex(content),
+      dataRows: point.rowCount,
+      header: CSV_HEADER.trimEnd(),
+    },
+    operations: {
+      progress_item_visits: point.rowCount * (point.rowCount + 2),
+      queue_shift_moved_slots: (point.rowCount * (point.rowCount - 1)) / 2,
+      worker_spawns: point.rowCount,
+    },
+    payload: { content },
+  };
+}
+
+function buildPatchFixture(point) {
+  const width = String(point.hunkCount - 1).length;
+  const lines = new Array(point.hunkCount + 2);
+  lines[0] = PATCH_BEGIN;
+  for (let index = 0; index < point.hunkCount; index += 1) {
+    lines[index + 1] =
+      `*** Delete File: generated/file-${String(index).padStart(width, "0")}.txt`;
+  }
+  lines[lines.length - 1] = PATCH_END;
+  const patch = lines.join("\n");
+  return {
+    generatedUtf8Bytes: Buffer.byteLength(patch),
+    descriptor: {
+      contentSha256: sha256Hex(patch),
+      hunkCount: point.hunkCount,
+      inputLineCount: lines.length,
+      kind: "delete_only",
+    },
+    operations: {
+      parsed_hunks: point.hunkCount,
+      remaining_suffix_references_copied:
+        (point.hunkCount * (point.hunkCount - 1)) / 2,
+      source_lines: lines.length,
+    },
+    payload: { patch },
+  };
+}
+
+function buildRegexFixture(point) {
+  const hostileLine = `${"a".repeat(point.repeatedCharacters)}!\n`;
+  const generatedUtf8Bytes =
+    Buffer.byteLength(hostileLine) + Buffer.byteLength(REGEX_PATTERN);
+  return {
+    generatedUtf8Bytes,
+    descriptor: {
+      contentSha256: sha256Hex(hostileLine),
+      patternSha256: sha256Hex(REGEX_PATTERN),
+      terminalMismatch: true,
+    },
+    operations: {
+      backtracking_input_code_units: hostileLine.trimEnd().length,
+      files_scanned: point.fileCount,
+      pattern_code_units: REGEX_PATTERN.length,
+    },
+    payload: { content: hostileLine, pattern: REGEX_PATTERN },
+  };
+}
+
+function buildDaemonFuzzyFixture(point) {
+  const width = String(point.candidateCount - 1).length;
+  const stem = "ax"
+    .repeat(Math.ceil(point.pathStemCodeUnits / 2))
+    .slice(0, point.pathStemCodeUnits);
+  const paths = new Array(point.candidateCount);
+  for (let index = 0; index < point.candidateCount; index += 1) {
+    paths[index] = `${stem}-${String(index).padStart(width, "0")}.txt`;
+  }
+  const query = "a".repeat(point.queryCodeUnits);
+  const generatedUtf8Bytes = paths.reduce(
+    (total, path) => total + Buffer.byteLength(path) + 2,
+    Buffer.byteLength(query),
+  );
+  const candidatePathCodeUnits = paths[0]?.length ?? 0;
+  return {
+    generatedUtf8Bytes,
+    descriptor: {
+      candidatePathListSha256: sha256Hex(paths.join("\n")),
+      fileContentSha256: sha256Hex("x\n"),
+      querySha256: sha256Hex(query),
+    },
+    operations: {
+      candidate_query_code_unit_pairs:
+        point.candidateCount * point.queryCodeUnits * candidatePathCodeUnits,
+      filesystem_entries: point.candidateCount,
+      recursive_comparison_upper_bound:
+        2 *
+        point.candidateCount *
+        point.queryCodeUnits *
+        candidatePathCodeUnits *
+        candidatePathCodeUnits,
+    },
+    payload: { fileContent: "x\n", paths, query },
+  };
+}
+
+function buildTuiFuzzyFixture(point) {
+  const prefix = "a".repeat(point.indexedQueryCodeUnits);
+  const query = `${prefix}RIGHT`;
+  const wrongPath = `${prefix}WRONG`;
+  const rightPath = `${prefix}RIGHT`;
+  const paths = [wrongPath, rightPath];
+  const generatedUtf8Bytes =
+    Buffer.byteLength(query) +
+    paths.reduce((total, path) => total + Buffer.byteLength(path), 0);
+  return {
+    generatedUtf8Bytes,
+    descriptor: {
+      pathListSha256: sha256Hex(paths.join("\n")),
+      querySha256: sha256Hex(query),
+      rightPathSha256: sha256Hex(rightPath),
+      wrongPathSha256: sha256Hex(wrongPath),
+    },
+    operations: {
+      candidate_query_code_unit_pairs:
+        point.candidateCount * point.indexedQueryCodeUnits,
+      discarded_query_code_units:
+        point.queryCodeUnits - point.indexedQueryCodeUnits,
+      indexed_candidates: point.candidateCount,
+    },
+    payload: { paths, query, rightPath, wrongPath },
+  };
+}
+
+function caseDefinition(caseId) {
+  const definition = BENCHMARK_PLAN.cases.find((entry) => entry.id === caseId);
+  if (definition === undefined)
+    throw new Error(`unknown benchmark case ${caseId}`);
+  return definition;
+}

--- a/runtime/benchmarks/fnd/isolation.mjs
+++ b/runtime/benchmarks/fnd/isolation.mjs
@@ -1,0 +1,246 @@
+import { lstatSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+export const OWNED_TEMPORARY_ROOT_PREFIX = "agenc-fnd-bench-";
+
+const HOST_CONTROL_ENTRY_NAMES = Object.freeze([".git", ".ignore"]);
+const OWNED_TEMPORARY_ROOT_CLEANUP_MAX_RETRIES = 12;
+const OWNED_TEMPORARY_ROOT_CLEANUP_RETRY_DELAY_MS = 50;
+const OWNED_TEMPORARY_ROOT_CLEANUP_RETRY_ERROR_CODES = Object.freeze([
+  "EBUSY",
+  "EMFILE",
+  "ENFILE",
+  "ENOTEMPTY",
+  "EPERM",
+]);
+const OWNED_TEMPORARY_ROOT_CLEANUP_WAIT_INDEX = 0;
+const OWNED_TEMPORARY_ROOT_CLEANUP_WAIT_VALUE = 0;
+const ownedTemporaryRootCleanupWait = new Int32Array(
+  new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT),
+);
+const RETAIN_OWNED_TEMPORARY_ROOT = Symbol("retainOwnedTemporaryRoot");
+const RETAINED_OWNED_TEMPORARY_ROOT_PATH = Symbol(
+  "retainedOwnedTemporaryRootPath",
+);
+
+/**
+ * @template Result
+ * @param {(temporaryRoot: string) => Result | Promise<Result>} callback
+ * @returns {Promise<Result>}
+ */
+export async function withOwnedTemporaryRoot(callback) {
+  if (typeof callback !== "function") {
+    throw new Error("owned temporary root callback must be a function");
+  }
+  const temporaryRoot = createOwnedTemporaryRoot();
+  const temporaryRootIdentity =
+    captureOwnedTemporaryRootIdentity(temporaryRoot);
+  let callbackFailure;
+  try {
+    return await callback(temporaryRoot);
+  } catch (error) {
+    callbackFailure = error;
+    throw error;
+  } finally {
+    if (requiresOwnedTemporaryRootRetention(callbackFailure)) {
+      Object.defineProperty(
+        callbackFailure,
+        RETAINED_OWNED_TEMPORARY_ROOT_PATH,
+        { value: temporaryRoot },
+      );
+      if (callbackFailure instanceof Error) {
+        callbackFailure.message += `; owned temporary root retained at ${temporaryRoot}`;
+      }
+    } else {
+      cleanupOwnedTemporaryRoot(temporaryRoot, temporaryRootIdentity);
+    }
+  }
+}
+
+export function markOwnedTemporaryRootForRetention(error) {
+  const retainedError =
+    error instanceof Error ? error : new Error(String(error));
+  Object.defineProperty(retainedError, RETAIN_OWNED_TEMPORARY_ROOT, {
+    value: true,
+  });
+  return retainedError;
+}
+
+export function retainedOwnedTemporaryRootPath(error) {
+  if (error === null || typeof error !== "object") return undefined;
+  return error[RETAINED_OWNED_TEMPORARY_ROOT_PATH];
+}
+
+export function createOwnedTemporaryRoot() {
+  const temporaryRoot = mkdtempSync(
+    join(resolve(tmpdir()), OWNED_TEMPORARY_ROOT_PREFIX),
+  );
+  assertOwnedTemporaryRoot(temporaryRoot, { requireEmpty: true });
+  return temporaryRoot;
+}
+
+export function assertOwnedTemporaryRoot(
+  temporaryRoot,
+  { requireEmpty = false, temporaryDirectory = tmpdir() } = {},
+) {
+  const resolvedRoot = validateOwnedTemporaryRootPath(
+    temporaryRoot,
+    temporaryDirectory,
+  );
+  const metadata = lstatSync(resolvedRoot);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error("benchmark temporary root must be a non-symlink directory");
+  }
+  if (requireEmpty && readdirSync(resolvedRoot).length !== 0) {
+    throw new Error("benchmark temporary root must start empty");
+  }
+  return resolvedRoot;
+}
+
+export function cleanupOwnedTemporaryRoot(
+  temporaryRoot,
+  expectedIdentity = undefined,
+) {
+  const resolvedRoot = validateOwnedTemporaryRootPath(temporaryRoot);
+  let cleanupIdentity = expectedIdentity;
+  for (
+    let retryIndex = 0;
+    retryIndex <= OWNED_TEMPORARY_ROOT_CLEANUP_MAX_RETRIES;
+    retryIndex += 1
+  ) {
+    let metadata;
+    try {
+      metadata = lstatSync(resolvedRoot, { bigint: true });
+    } catch (error) {
+      if (isMissingPathError(error) && cleanupIdentity === undefined) return;
+      if (!isMissingPathError(error)) throw error;
+      throw new Error(
+        `owned temporary root disappeared before identity-checked cleanup: ${resolvedRoot}`,
+        { cause: error },
+      );
+    }
+    cleanupIdentity ??= ownedTemporaryRootIdentity(metadata);
+    if (!ownedTemporaryRootIdentityMatches(metadata, cleanupIdentity)) {
+      throw new Error(
+        `owned temporary root identity changed; refusing recursive cleanup: ${resolvedRoot}`,
+      );
+    }
+    try {
+      rmSync(resolvedRoot, {
+        force: true,
+        recursive: metadata.isDirectory() && !metadata.isSymbolicLink(),
+      });
+      return;
+    } catch (error) {
+      if (
+        retryIndex >= OWNED_TEMPORARY_ROOT_CLEANUP_MAX_RETRIES ||
+        !isRetryableCleanupError(error)
+      ) {
+        throw error;
+      }
+      waitForOwnedTemporaryRootCleanupRetry(retryIndex);
+    }
+  }
+}
+
+export function assertNoAncestorBenchmarkControls(
+  temporaryRoot,
+  temporaryDirectory = tmpdir(),
+) {
+  assertNoBenchmarkControlsAtOrAbove(
+    assertOwnedTemporaryRoot(temporaryRoot, { temporaryDirectory }),
+  );
+}
+
+export function assertNoBenchmarkControlsAtOrAbove(startingDirectory) {
+  let current = resolve(startingDirectory);
+  while (true) {
+    for (const entryName of HOST_CONTROL_ENTRY_NAMES) {
+      try {
+        lstatSync(join(current, entryName));
+      } catch (error) {
+        if (isMissingPathError(error)) continue;
+        throw error;
+      }
+      throw new Error(
+        `benchmark temporary root inherits host ${entryName} control state`,
+      );
+    }
+    const parent = dirname(current);
+    if (parent === current) return;
+    current = parent;
+  }
+}
+
+export function validateOwnedTemporaryRootPath(
+  temporaryRoot,
+  temporaryDirectory = tmpdir(),
+) {
+  if (typeof temporaryRoot !== "string" || temporaryRoot.length === 0) {
+    throw new Error("benchmark temporary root path must be non-empty");
+  }
+  const resolvedTemporaryDirectory = resolve(temporaryDirectory);
+  const resolvedRoot = resolve(temporaryRoot);
+  if (
+    resolvedRoot === resolvedTemporaryDirectory ||
+    dirname(resolvedRoot) !== resolvedTemporaryDirectory ||
+    !basename(resolvedRoot).startsWith(OWNED_TEMPORARY_ROOT_PREFIX)
+  ) {
+    throw new Error("benchmark temporary root is outside the owned namespace");
+  }
+  return resolvedRoot;
+}
+
+function captureOwnedTemporaryRootIdentity(temporaryRoot) {
+  const metadata = lstatSync(temporaryRoot, { bigint: true });
+  return ownedTemporaryRootIdentity(metadata);
+}
+
+function ownedTemporaryRootIdentity(metadata) {
+  return Object.freeze({ device: metadata.dev, inode: metadata.ino });
+}
+
+function ownedTemporaryRootIdentityMatches(metadata, expectedIdentity) {
+  return (
+    metadata.dev === expectedIdentity.device &&
+    metadata.ino === expectedIdentity.inode
+  );
+}
+
+function requiresOwnedTemporaryRootRetention(error) {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    error[RETAIN_OWNED_TEMPORARY_ROOT] === true
+  );
+}
+
+function isMissingPathError(error) {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+function isRetryableCleanupError(error) {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    OWNED_TEMPORARY_ROOT_CLEANUP_RETRY_ERROR_CODES.includes(error.code)
+  );
+}
+
+function waitForOwnedTemporaryRootCleanupRetry(retryIndex) {
+  const delayMs =
+    OWNED_TEMPORARY_ROOT_CLEANUP_RETRY_DELAY_MS * (retryIndex + 1);
+  Atomics.wait(
+    ownedTemporaryRootCleanupWait,
+    OWNED_TEMPORARY_ROOT_CLEANUP_WAIT_INDEX,
+    OWNED_TEMPORARY_ROOT_CLEANUP_WAIT_VALUE,
+    delayMs,
+  );
+}

--- a/runtime/benchmarks/fnd/metadata-command-worker.mjs
+++ b/runtime/benchmarks/fnd/metadata-command-worker.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+import { runSupervisedProcess } from "../../src/utils/supervisedProcess.ts";
+
+const MAX_REQUEST_BYTES = 20_000_000;
+const SETTLEMENT_KEEPALIVE_INTERVAL_MS = 1_000;
+
+try {
+  const requestBytes = readFileSync(0);
+  if (requestBytes.length === 0 || requestBytes.length > MAX_REQUEST_BYTES) {
+    throw new Error("bounded metadata command request exceeds its byte limit");
+  }
+  const request = JSON.parse(requestBytes.toString("utf8"));
+  const keepAlive = setInterval(() => {}, SETTLEMENT_KEEPALIVE_INTERVAL_MS);
+  let result;
+  try {
+    result = await runSupervisedProcess(
+      {
+        args: request.args,
+        cwd: request.cwd,
+        env: request.env,
+        program: request.command,
+      },
+      {
+        maxOutputBytes: request.maxOutputBytes,
+        settleBackstopMs: request.settlementTimeoutMs,
+        terminateGraceMs: 0,
+        timeoutMs: request.timeoutMs,
+      },
+    );
+  } finally {
+    clearInterval(keepAlive);
+  }
+  process.stdout.write(
+    JSON.stringify({
+      backstopExpired: result.backstopExpired,
+      error: result.error?.message,
+      exitCode: result.exitCode,
+      signal: result.signal,
+      stderrBase64: result.stderr.toString("base64"),
+      stdoutBase64: result.stdout.toString("base64"),
+      stopReason: result.stopReason,
+    }),
+  );
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`bounded metadata command worker failed: ${message}\n`);
+  process.exitCode = 1;
+}

--- a/runtime/benchmarks/fnd/module-closure.mjs
+++ b/runtime/benchmarks/fnd/module-closure.mjs
@@ -1,0 +1,86 @@
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { register } from "tsx/esm/api";
+
+import { MAX_PRODUCTION_MODULES_PER_CASE } from "./contract.mjs";
+
+export const PRODUCTION_MODULE_RECORD_PREFIX =
+  "AGENC_FND_BENCH_PRODUCTION_MODULE ";
+
+export function registerProductionModuleTracker(options) {
+  const validated = validateOptions(options);
+  const observedPaths = new Set();
+  const unregister = register({
+    onImport(url) {
+      const path = productionModulePath(url, validated);
+      if (path === undefined || observedPaths.has(path)) return;
+      if (observedPaths.size >= MAX_PRODUCTION_MODULES_PER_CASE) {
+        throw new Error(
+          `production module closure exceeds ${MAX_PRODUCTION_MODULES_PER_CASE} files`,
+        );
+      }
+      observedPaths.add(path);
+      validated.writeRecord(
+        `${PRODUCTION_MODULE_RECORD_PREFIX}${JSON.stringify({ path })}\n`,
+      );
+    },
+    tsconfig: false,
+  });
+  return Object.freeze({
+    async close() {
+      await unregister();
+    },
+    paths() {
+      return [...observedPaths].sort();
+    },
+  });
+}
+
+function productionModulePath(url, options) {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (parsedUrl.protocol !== "file:") return undefined;
+  const absolutePath = realpathSync(fileURLToPath(parsedUrl));
+  const pathWithinProductionTree = relative(
+    options.productionRoot,
+    absolutePath,
+  );
+  if (
+    pathWithinProductionTree.length === 0 ||
+    isAbsolute(pathWithinProductionTree) ||
+    pathWithinProductionTree.split(/[\\/]/u).some((segment) => segment === "..")
+  ) {
+    return undefined;
+  }
+  return relative(options.repositoryRoot, absolutePath).split(sep).join("/");
+}
+
+function validateOptions(options) {
+  if (options === null || typeof options !== "object") {
+    throw new Error("production module tracker options must be an object");
+  }
+  if (typeof options.writeRecord !== "function") {
+    throw new Error("production module tracker requires a record writer");
+  }
+  const repositoryRoot = realpathSync(resolve(options.repositoryRoot));
+  const productionRoot = realpathSync(resolve(options.productionRoot));
+  const relativeProductionRoot = relative(repositoryRoot, productionRoot);
+  if (
+    relativeProductionRoot.length === 0 ||
+    isAbsolute(relativeProductionRoot) ||
+    relativeProductionRoot.split(/[\\/]/u).some((segment) => segment === "..")
+  ) {
+    throw new Error("production module root must be inside the repository");
+  }
+  return {
+    productionRoot,
+    repositoryRoot,
+    writeRecord: options.writeRecord,
+  };
+}

--- a/runtime/benchmarks/fnd/provenance.mjs
+++ b/runtime/benchmarks/fnd/provenance.mjs
@@ -1,0 +1,1017 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstatSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { MAX_PRODUCTION_MODULES_PER_CASE } from "./contract.mjs";
+import { readBoundedRegularFile } from "./bounded-file.mjs";
+
+export const BOUNDED_COMMAND_TIMEOUT_MS = 5_000;
+export const MAX_BOUND_COMMAND_TIMEOUT_MS = 30_000;
+export const MAX_BOUND_FILE_BYTES = 2_097_152;
+export const MAX_BOUND_COMMAND_OUTPUT_BYTES = 4_194_304;
+export const MAX_BOUND_COMMAND_ARGUMENTS = 256;
+export const MAX_BOUND_COMMAND_ARGUMENT_BYTES = 65_536;
+export const TEXT_BINDING_NORMALIZATION = "utf8_lf";
+
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const GIT_REVISION_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+const CASE_ID_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)*$/u;
+const METADATA_COMMAND_WORKER_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "metadata-command-worker.mjs",
+);
+export const METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS = 2_000;
+export const METADATA_COMMAND_WORKER_OVERHEAD_MS = 2_000;
+const METADATA_COMMAND_RESPONSE_OVERHEAD_BYTES = 65_536;
+const MAX_WINDOWS_GIT_SEARCH_PATH_BYTES = 131_072;
+const MAX_WINDOWS_GIT_SEARCH_PATH_ENTRIES = 512;
+const MAX_WINDOWS_GIT_SEARCH_PATH_ENTRY_BYTES = 32_768;
+const WINDOWS_GIT_EXECUTABLE_NAMES = Object.freeze(["git.com", "git.exe"]);
+const WINDOWS_SEARCH_PATH_SEPARATOR = ";";
+const WINDOWS_SEARCH_PATH_QUOTES = Object.freeze(['"', "'"]);
+
+export function captureBenchmarkProvenance(options) {
+  const validated = validateProvenanceOptions(options);
+  const captureHeadRevision = gitText(
+    validated.repositoryRoot,
+    ["rev-parse", "HEAD"],
+    "resolve benchmark capture HEAD",
+  );
+  assertGitRevision(captureHeadRevision);
+  const sourceRevision = gitText(
+    validated.repositoryRoot,
+    [
+      "rev-parse",
+      "--verify",
+      "--end-of-options",
+      `${validated.sourceRevisionSelector}^{commit}`,
+    ],
+    "resolve benchmark source revision",
+  );
+  assertGitRevision(sourceRevision);
+  assertRevisionIsCommit(validated.repositoryRoot, sourceRevision);
+  assertRevisionIsAncestor(validated.repositoryRoot, sourceRevision);
+  assertProductionTreeMatchesRevision(
+    validated.repositoryRoot,
+    sourceRevision,
+    validated.productionTreePath,
+  );
+  const productionTreeBinding = collectGitTreeBinding(
+    validated.repositoryRoot,
+    sourceRevision,
+    validated.productionTreePath,
+  );
+  const evidenceBindings = collectNormalizedFileBindings(
+    validated.repositoryRoot,
+    validated.evidencePaths,
+  );
+
+  return Object.freeze({
+    captureHeadRevision,
+    evidenceBindings,
+    evidencePaths: validated.evidencePaths,
+    productionTreeBinding,
+    productionTreePath: validated.productionTreePath,
+    repositoryRoot: validated.repositoryRoot,
+    sourceRevision,
+  });
+}
+
+export function bindProductionModuleClosures(provenance, observedClosures) {
+  const normalizedClosures = normalizeObservedModuleClosures(
+    observedClosures,
+    provenance.productionTreePath,
+  );
+  return normalizedClosures.map(({ caseId, paths }) => {
+    assertTrackedPathsMatchRevision(
+      provenance.repositoryRoot,
+      provenance.sourceRevision,
+      paths,
+    );
+    const modules = collectGitBlobBindings(
+      provenance.repositoryRoot,
+      provenance.sourceRevision,
+      paths,
+    );
+    assertPathDigestsEqual(
+      modules,
+      collectNormalizedFileBindings(provenance.repositoryRoot, paths),
+      `production module closure for ${caseId} does not match its Git revision`,
+    );
+    return { caseId, modules };
+  });
+}
+
+export function verifyBenchmarkCapture(provenance) {
+  const currentRevision = gitText(
+    provenance.repositoryRoot,
+    ["rev-parse", "HEAD"],
+    "recheck benchmark source revision",
+  );
+  if (currentRevision !== provenance.captureHeadRevision) {
+    throw new Error("Git revision changed while the benchmark was running");
+  }
+  assertProductionTreeMatchesRevision(
+    provenance.repositoryRoot,
+    provenance.sourceRevision,
+    provenance.productionTreePath,
+  );
+  assertBindingsEqual(
+    provenance.productionTreeBinding,
+    collectGitTreeBinding(
+      provenance.repositoryRoot,
+      provenance.sourceRevision,
+      provenance.productionTreePath,
+    ),
+    "production Git tree binding changed during capture",
+  );
+  assertBindingsEqual(
+    provenance.evidenceBindings,
+    collectNormalizedFileBindings(
+      provenance.repositoryRoot,
+      provenance.evidencePaths,
+    ),
+    "benchmark evidence files changed during capture",
+  );
+}
+
+export function verifyCheckedBenchmarkProvenance(report, options) {
+  const validated = validateProvenanceOptions(options);
+  assertGitRevision(report.sourceRevision);
+  assertRevisionIsCommit(validated.repositoryRoot, report.sourceRevision);
+  assertRevisionIsAncestor(validated.repositoryRoot, report.sourceRevision);
+  assertBindingsEqual(
+    report.productionTreeBinding,
+    collectGitTreeBinding(
+      validated.repositoryRoot,
+      report.sourceRevision,
+      validated.productionTreePath,
+    ),
+    "production tree binding does not match its Git revision",
+  );
+  const moduleClosures = normalizeBoundModuleClosures(
+    report.productionModuleClosures,
+    validated.productionTreePath,
+  );
+  for (const closure of moduleClosures) {
+    const paths = closure.modules.map((binding) => binding.path);
+    assertBindingsEqual(
+      closure.modules,
+      collectGitBlobBindings(
+        validated.repositoryRoot,
+        report.sourceRevision,
+        paths,
+      ),
+      `production module closure for ${closure.caseId} does not match its Git revision`,
+    );
+    assertPathDigestsEqual(
+      closure.modules,
+      collectNormalizedFileBindings(validated.repositoryRoot, paths),
+      `current production module closure for ${closure.caseId} is stale`,
+    );
+  }
+  assertBindingsEqual(
+    report.evidenceBindings,
+    collectNormalizedFileBindings(
+      validated.repositoryRoot,
+      validated.evidencePaths,
+    ),
+    "benchmark evidence bindings are stale",
+  );
+}
+
+export function collectNormalizedFileBindings(repositoryRoot, paths) {
+  const canonicalRepositoryRoot = canonicalizeRepositoryRoot(repositoryRoot);
+  return normalizePaths(paths).map((path) => ({
+    normalization: TEXT_BINDING_NORMALIZATION,
+    path,
+    sha256: sha256Hex(readNormalizedTextFile(canonicalRepositoryRoot, path)),
+  }));
+}
+
+export function assertBindingsStable(
+  repositoryRoot,
+  expectedBindings,
+  label = "bounded file bindings changed",
+) {
+  const paths = expectedBindings.map((binding) => binding.path);
+  assertBindingsEqual(
+    expectedBindings,
+    collectNormalizedFileBindings(repositoryRoot, paths),
+    label,
+  );
+}
+
+/**
+ * @param {string} command
+ * @param {readonly string[]} args
+ * @param {{
+ *   cwd?: string,
+ *   env?: NodeJS.ProcessEnv,
+ *   label?: string,
+ *   maxOutputBytes?: number,
+ *   timeoutMs?: number,
+ * }} [options]
+ * @returns {string}
+ */
+export function runBoundedCommandText(
+  command,
+  args,
+  {
+    cwd,
+    env = createBenchmarkSubprocessEnvironment(),
+    label = "bounded command",
+    maxOutputBytes = MAX_BOUND_COMMAND_OUTPUT_BYTES,
+    timeoutMs = BOUNDED_COMMAND_TIMEOUT_MS,
+  } = {},
+) {
+  validateCommand(command, args, cwd, maxOutputBytes, timeoutMs);
+  try {
+    const result = runBoundedCommandResult(command, args, {
+      cwd,
+      env,
+      maxOutputBytes,
+      timeoutMs,
+    });
+    if (result.exitCode !== 0 || result.signal !== null) {
+      const diagnostic = boundedCommandDiagnostic(result.stderr);
+      throw new Error(
+        `bounded command exited with ${String(result.exitCode)} / ${String(result.signal)}` +
+          (diagnostic.length > 0 ? `: ${diagnostic}` : ""),
+      );
+    }
+    return result.stdout.toString("utf8").trim();
+  } catch (error) {
+    throw new Error(
+      `${label} failed or exceeded its ${timeoutMs} ms deadline`,
+      {
+        cause: error,
+      },
+    );
+  }
+}
+
+function boundedCommandDiagnostic(stderr) {
+  const maximumCharacters = 2_000;
+  const value = stderr.toString("utf8").trim();
+  return value.length <= maximumCharacters
+    ? value
+    : `${value.slice(0, maximumCharacters)}…`;
+}
+
+/** @returns {Record<string, string>} */
+export function createSanitizedGitEnvironment(environment = process.env) {
+  const sanitized = {
+    ...createBenchmarkSubprocessEnvironment(environment),
+  };
+  sanitized.GIT_CONFIG_GLOBAL =
+    process.platform === "win32" ? "NUL" : "/dev/null";
+  sanitized.GIT_CONFIG_NOSYSTEM = "1";
+  sanitized.GIT_NO_REPLACE_OBJECTS = "1";
+  return sanitized;
+}
+
+/** @returns {Record<string, string>} */
+export function createBenchmarkSubprocessEnvironment(
+  environment = process.env,
+  platform = process.platform,
+) {
+  if (
+    environment === null ||
+    typeof environment !== "object" ||
+    Array.isArray(environment)
+  ) {
+    throw new Error("benchmark subprocess environment must be an object");
+  }
+  const path = platformEnvironmentValue(environment, "PATH", platform);
+  if (typeof path !== "string" || path.length === 0) {
+    throw new Error("benchmark subprocess environment requires PATH");
+  }
+  const sanitized = {
+    LANG: "C",
+    LC_ALL: "C",
+    PATH: path,
+    TZ: "UTC",
+  };
+  if (platform === "win32") {
+    const systemRoot = platformEnvironmentValue(
+      environment,
+      "SystemRoot",
+      platform,
+    );
+    if (typeof systemRoot !== "string" || systemRoot.length === 0) {
+      throw new Error("Windows benchmark subprocesses require SystemRoot");
+    }
+    sanitized.SystemRoot = systemRoot;
+  }
+  return sanitized;
+}
+
+export function resolveBenchmarkGitExecutable(
+  environment = process.env,
+  platform = process.platform,
+) {
+  if (platform !== "win32") return "git";
+  const searchPath = platformEnvironmentValue(environment, "PATH", platform);
+  const directories = parseBoundedWindowsSearchPath(searchPath);
+  for (const directory of directories) {
+    for (const executableName of WINDOWS_GIT_EXECUTABLE_NAMES) {
+      const candidate = resolve(directory, executableName);
+      try {
+        const metadata = lstatSync(candidate);
+        if (metadata.isSymbolicLink() || !metadata.isFile()) continue;
+        const canonicalPath = realpathSync(candidate);
+        const canonicalMetadata = lstatSync(canonicalPath);
+        if (canonicalMetadata.isSymbolicLink() || !canonicalMetadata.isFile()) {
+          continue;
+        }
+        return canonicalPath;
+      } catch {
+        // A missing or unreadable PATH candidate is not executable.
+      }
+    }
+  }
+  throw new Error("could not resolve a regular Git executable from PATH");
+}
+
+export function resolveBenchmarkNpmCliPath(executablePath = process.execPath) {
+  const executableDirectory = dirname(realpathSync(executablePath));
+  const candidates = [
+    {
+      installationRoot: executableDirectory,
+      path: resolve(executableDirectory, "node_modules/npm/bin/npm-cli.js"),
+    },
+    {
+      installationRoot: resolve(executableDirectory, ".."),
+      path: resolve(
+        executableDirectory,
+        "../lib/node_modules/npm/bin/npm-cli.js",
+      ),
+    },
+  ];
+  for (const candidate of candidates) {
+    try {
+      const metadata = lstatSync(candidate.path);
+      const canonicalPath = realpathSync(candidate.path);
+      if (
+        metadata.isFile() &&
+        !metadata.isSymbolicLink() &&
+        isContainedPath(candidate.installationRoot, canonicalPath)
+      ) {
+        return canonicalPath;
+      }
+    } catch {
+      // Continue through the finite trusted-layout candidates.
+    }
+  }
+  throw new Error("could not resolve the pinned npm CLI entrypoint");
+}
+
+function isContainedPath(root, path) {
+  const relativePath = relative(root, path);
+  return (
+    relativePath.length > 0 &&
+    relativePath !== ".." &&
+    !relativePath.startsWith(
+      `..${process.platform === "win32" ? "\\" : "/"}`,
+    ) &&
+    !isAbsolute(relativePath)
+  );
+}
+
+function parseBoundedWindowsSearchPath(value) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.includes("\0") ||
+    Buffer.byteLength(value, "utf8") > MAX_WINDOWS_GIT_SEARCH_PATH_BYTES
+  ) {
+    throw new Error("Windows Git PATH is malformed or exceeds its byte limit");
+  }
+  const entries = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    if (value[cursor] === WINDOWS_SEARCH_PATH_SEPARATOR) {
+      cursor += 1;
+      continue;
+    }
+    const openingQuote = WINDOWS_SEARCH_PATH_QUOTES.includes(value[cursor])
+      ? value[cursor]
+      : undefined;
+    let end;
+    if (openingQuote === undefined) {
+      end = value.indexOf(WINDOWS_SEARCH_PATH_SEPARATOR, cursor);
+    } else {
+      const closingQuote = value.indexOf(openingQuote, cursor + 1);
+      if (closingQuote < 0) {
+        throw new Error("Windows Git PATH contains an unmatched quote");
+      }
+      end = value.indexOf(WINDOWS_SEARCH_PATH_SEPARATOR, closingQuote + 1);
+    }
+    if (end < 0) end = value.length;
+    let entry = value.slice(cursor, end);
+    if (openingQuote !== undefined) {
+      if (!entry.endsWith(openingQuote)) {
+        throw new Error("Windows Git PATH contains trailing quoted content");
+      }
+      entry = entry.slice(1, -1);
+    } else if (WINDOWS_SEARCH_PATH_QUOTES.includes(entry.at(-1))) {
+      throw new Error("Windows Git PATH contains an unmatched quote");
+    }
+    if (
+      Buffer.byteLength(entry, "utf8") > MAX_WINDOWS_GIT_SEARCH_PATH_ENTRY_BYTES
+    ) {
+      throw new Error("Windows Git PATH entry exceeds its byte limit");
+    }
+    if (entry.length > 0) entries.push(entry);
+    if (entries.length > MAX_WINDOWS_GIT_SEARCH_PATH_ENTRIES) {
+      throw new Error("Windows Git PATH has too many entries");
+    }
+    cursor = end + 1;
+  }
+  if (entries.length === 0) {
+    throw new Error("Windows Git PATH has no search directories");
+  }
+  return entries;
+}
+
+function runBoundedCommandResult(
+  command,
+  args,
+  {
+    cwd,
+    env = createBenchmarkSubprocessEnvironment(),
+    maxOutputBytes = MAX_BOUND_COMMAND_OUTPUT_BYTES,
+    timeoutMs = BOUNDED_COMMAND_TIMEOUT_MS,
+  },
+) {
+  validateCommand(command, args, cwd, maxOutputBytes, timeoutMs);
+  const helperEnvironment = createBenchmarkSubprocessEnvironment();
+  const request = JSON.stringify({
+    args,
+    command,
+    cwd,
+    env,
+    maxOutputBytes,
+    settlementTimeoutMs: METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS,
+    timeoutMs,
+  });
+  const maximumResponseBytes =
+    Math.ceil((maxOutputBytes * 4) / 3) +
+    METADATA_COMMAND_RESPONSE_OVERHEAD_BYTES;
+  const responseText = execFileSync(
+    process.execPath,
+    [METADATA_COMMAND_WORKER_PATH],
+    {
+      cwd,
+      encoding: "utf8",
+      env: helperEnvironment,
+      input: request,
+      killSignal: "SIGKILL",
+      maxBuffer: maximumResponseBytes,
+      timeout:
+        timeoutMs +
+        METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS +
+        METADATA_COMMAND_WORKER_OVERHEAD_MS,
+      windowsHide: true,
+    },
+  );
+  let response;
+  try {
+    response = JSON.parse(responseText);
+  } catch (error) {
+    throw new Error("bounded metadata command returned malformed JSON", {
+      cause: error,
+    });
+  }
+  validateMetadataCommandResponse(response);
+  if (response.backstopExpired) {
+    throw new Error("bounded metadata command containment was not proven");
+  }
+  if (typeof response.error === "string" && response.error.length > 0) {
+    throw new Error(`bounded metadata command failed: ${response.error}`);
+  }
+  if (response.stopReason !== undefined) {
+    throw new Error(
+      `bounded metadata command stopped for ${String(response.stopReason)}`,
+    );
+  }
+  const stdout = decodeCanonicalBase64(response.stdoutBase64, "stdout");
+  const stderr = decodeCanonicalBase64(response.stderrBase64, "stderr");
+  if (stdout.length + stderr.length > maxOutputBytes) {
+    throw new Error("bounded metadata command exceeded its output ceiling");
+  }
+  return {
+    exitCode: response.exitCode,
+    signal: response.signal,
+    stderr,
+    stdout,
+  };
+}
+
+function validateMetadataCommandResponse(response) {
+  if (
+    response === null ||
+    typeof response !== "object" ||
+    Array.isArray(response)
+  ) {
+    throw new Error("bounded metadata command returned an invalid result");
+  }
+  const allowedNames = new Set([
+    "backstopExpired",
+    "error",
+    "exitCode",
+    "signal",
+    "stderrBase64",
+    "stdoutBase64",
+    "stopReason",
+  ]);
+  if (Object.keys(response).some((name) => !allowedNames.has(name))) {
+    throw new Error("bounded metadata command result keys differ");
+  }
+  if (
+    typeof response.backstopExpired !== "boolean" ||
+    (!Number.isInteger(response.exitCode) && response.exitCode !== null) ||
+    (response.signal !== null && typeof response.signal !== "string") ||
+    typeof response.stdoutBase64 !== "string" ||
+    typeof response.stderrBase64 !== "string" ||
+    (response.error !== undefined && typeof response.error !== "string") ||
+    (response.stopReason !== undefined &&
+      typeof response.stopReason !== "string")
+  ) {
+    throw new Error("bounded metadata command returned an invalid result");
+  }
+}
+
+function decodeCanonicalBase64(value, label) {
+  const bytes = Buffer.from(value, "base64");
+  if (bytes.toString("base64") !== value) {
+    throw new Error(
+      `bounded metadata command ${label} is not canonical base64`,
+    );
+  }
+  return bytes;
+}
+
+function platformEnvironmentValue(environment, expectedName, platform) {
+  if (platform !== "win32") return environment[expectedName];
+  const normalizedExpectedName = expectedName.toUpperCase();
+  const matches = Object.entries(environment).filter(
+    ([name]) => name.toUpperCase() === normalizedExpectedName,
+  );
+  if (matches.length > 1) {
+    throw new Error(`benchmark subprocess environment repeats ${expectedName}`);
+  }
+  return matches[0]?.[1];
+}
+
+function collectGitBlobBindings(repositoryRoot, revision, paths) {
+  return normalizePaths(paths).map((path) => ({
+    path,
+    sha256: sha256Hex(
+      gitBuffer(
+        repositoryRoot,
+        ["show", `${revision}:${path}`],
+        `read production source blob ${path}`,
+      ),
+    ),
+  }));
+}
+
+function collectGitTreeBinding(repositoryRoot, revision, path) {
+  const gitObjectId = gitText(
+    repositoryRoot,
+    ["rev-parse", `${revision}:${path}`],
+    `resolve production tree object ${path}`,
+  );
+  assertGitRevision(gitObjectId);
+  const objectType = gitText(
+    repositoryRoot,
+    ["cat-file", "-t", gitObjectId],
+    `inspect production tree object ${path}`,
+  );
+  if (objectType !== "tree") {
+    throw new Error(`bound production path is not a Git tree: ${path}`);
+  }
+  return { gitObjectId, objectType, path };
+}
+
+function assertRevisionIsCommit(repositoryRoot, revision) {
+  const result = gitStatus(repositoryRoot, [
+    "cat-file",
+    "-e",
+    `${revision}^{commit}`,
+  ]);
+  if (result !== 0) {
+    throw new Error("benchmark source revision is not a local Git commit");
+  }
+}
+
+function assertRevisionIsAncestor(repositoryRoot, revision) {
+  const result = gitStatus(repositoryRoot, [
+    "merge-base",
+    "--is-ancestor",
+    revision,
+    "HEAD",
+  ]);
+  if (result !== 0) {
+    throw new Error("benchmark source revision is not an ancestor of HEAD");
+  }
+}
+
+function assertTrackedPathsMatchRevision(repositoryRoot, revision, paths) {
+  const result = gitStatus(repositoryRoot, [
+    "diff",
+    "--no-ext-diff",
+    "--quiet",
+    revision,
+    "--",
+    ...normalizePaths(paths),
+  ]);
+  if (result === 1) {
+    throw new Error(
+      "production source differs from the bound benchmark revision",
+    );
+  }
+  if (result !== 0) {
+    throw new Error("could not compare production source with its revision");
+  }
+}
+
+function assertProductionTreeMatchesRevision(repositoryRoot, revision, path) {
+  const worktreeStatus = gitStatus(repositoryRoot, [
+    "diff",
+    "--no-ext-diff",
+    "--quiet",
+    revision,
+    "--",
+    path,
+  ]);
+  const indexStatus = gitStatus(repositoryRoot, [
+    "diff",
+    "--no-ext-diff",
+    "--cached",
+    "--quiet",
+    revision,
+    "--",
+    path,
+  ]);
+  const indexToWorktreeStatus = gitStatus(repositoryRoot, [
+    "diff-files",
+    "--no-ext-diff",
+    "--quiet",
+    "--",
+    path,
+  ]);
+  if (
+    worktreeStatus === 1 ||
+    indexStatus === 1 ||
+    indexToWorktreeStatus === 1
+  ) {
+    throw new Error(
+      "complete production tree must match the benchmark source revision",
+    );
+  }
+  if (
+    worktreeStatus !== 0 ||
+    indexStatus !== 0 ||
+    indexToWorktreeStatus !== 0
+  ) {
+    throw new Error("could not audit the complete production tree");
+  }
+  const untracked = gitText(
+    repositoryRoot,
+    ["ls-files", "--others", "--", path],
+    "inventory untracked production files",
+  );
+  if (untracked.length > 0) {
+    throw new Error("complete production tree contains untracked files");
+  }
+}
+
+function gitText(repositoryRoot, args, label) {
+  const environment = createSanitizedGitEnvironment();
+  return runBoundedCommandText(
+    resolveBenchmarkGitExecutable(environment),
+    args,
+    {
+      cwd: repositoryRoot,
+      env: environment,
+      label,
+      maxOutputBytes: 65_536,
+    },
+  );
+}
+
+function gitBuffer(repositoryRoot, args, label) {
+  try {
+    const environment = createSanitizedGitEnvironment();
+    const result = runBoundedCommandResult(
+      resolveBenchmarkGitExecutable(environment),
+      args,
+      {
+        cwd: repositoryRoot,
+        env: environment,
+        maxOutputBytes: MAX_BOUND_COMMAND_OUTPUT_BYTES,
+        timeoutMs: BOUNDED_COMMAND_TIMEOUT_MS,
+      },
+    );
+    if (result.exitCode !== 0 || result.signal !== null) {
+      throw new Error("bounded Git command exited unsuccessfully");
+    }
+    return result.stdout;
+  } catch (error) {
+    throw new Error(
+      `${label} failed or exceeded its ${BOUNDED_COMMAND_TIMEOUT_MS} ms deadline`,
+      { cause: error },
+    );
+  }
+}
+
+function gitStatus(repositoryRoot, args) {
+  const environment = createSanitizedGitEnvironment();
+  const result = runBoundedCommandResult(
+    resolveBenchmarkGitExecutable(environment),
+    args,
+    {
+      cwd: repositoryRoot,
+      env: environment,
+      maxOutputBytes: MAX_BOUND_COMMAND_OUTPUT_BYTES,
+      timeoutMs: BOUNDED_COMMAND_TIMEOUT_MS,
+    },
+  );
+  if (result.signal !== null) {
+    throw new Error("bounded Git command ended by signal");
+  }
+  return result.exitCode;
+}
+
+function readNormalizedTextFile(repositoryRoot, path) {
+  const absolutePath = join(repositoryRoot, path);
+  const canonicalPathBefore = realpathSync(absolutePath);
+  assertContainedEvidencePath(repositoryRoot, canonicalPathBefore, path);
+  const bytes = readBoundedRegularFile(
+    absolutePath,
+    MAX_BOUND_FILE_BYTES,
+    `bound evidence file ${path}`,
+  );
+  const canonicalPathAfter = realpathSync(absolutePath);
+  assertContainedEvidencePath(repositoryRoot, canonicalPathAfter, path);
+  if (canonicalPathAfter !== canonicalPathBefore) {
+    throw new Error(`bound evidence file ${path} changed its canonical path`);
+  }
+  const text = UTF8_DECODER.decode(bytes);
+  return text.replace(/\r\n?/gu, "\n");
+}
+
+function assertContainedEvidencePath(repositoryRoot, canonicalPath, path) {
+  if (!isContainedPath(repositoryRoot, canonicalPath)) {
+    throw new Error(`bound evidence file ${path} escapes the repository root`);
+  }
+}
+
+function canonicalizeRepositoryRoot(repositoryRoot) {
+  if (typeof repositoryRoot !== "string" || repositoryRoot.length === 0) {
+    throw new Error("benchmark repository root must be a non-empty string");
+  }
+  return realpathSync(resolve(repositoryRoot));
+}
+
+function validateProvenanceOptions(options) {
+  if (options === null || typeof options !== "object") {
+    throw new Error("benchmark provenance options must be an object");
+  }
+  return {
+    productionTreePath: normalizeProductionTreePath(options.productionTreePath),
+    repositoryRoot: canonicalizeRepositoryRoot(options.repositoryRoot),
+    sourceRevisionSelector: normalizeSourceRevisionSelector(
+      options.sourceRevision,
+    ),
+    evidencePaths: normalizePaths(options.evidencePaths),
+  };
+}
+
+function normalizeObservedModuleClosures(closures, productionTreePath) {
+  if (!Array.isArray(closures) || closures.length === 0) {
+    throw new Error("observed production module closures must be non-empty");
+  }
+  const seenCaseIds = new Set();
+  return closures.map((closure, index) => {
+    const closureLabel = `observed closure ${index}`;
+    assertPlainRecord(closure, closureLabel);
+    assertExactKeys(closure, ["caseId", "paths"], closureLabel);
+    const caseId = normalizeCaseId(closure.caseId, closureLabel);
+    if (seenCaseIds.has(caseId)) {
+      throw new Error(`observed production module closure repeats ${caseId}`);
+    }
+    seenCaseIds.add(caseId);
+    const paths = normalizePaths(closure.paths);
+    assertProductionModulePaths(paths, productionTreePath, caseId);
+    return { caseId, paths };
+  });
+}
+
+function normalizeBoundModuleClosures(closures, productionTreePath) {
+  if (!Array.isArray(closures) || closures.length === 0) {
+    throw new Error("bound production module closures must be non-empty");
+  }
+  const seenCaseIds = new Set();
+  return closures.map((closure, closureIndex) => {
+    const closureLabel = `bound closure ${closureIndex}`;
+    assertPlainRecord(closure, closureLabel);
+    assertExactKeys(closure, ["caseId", "modules"], closureLabel);
+    const caseId = normalizeCaseId(closure.caseId, closureLabel);
+    if (seenCaseIds.has(caseId)) {
+      throw new Error(`bound production module closure repeats ${caseId}`);
+    }
+    seenCaseIds.add(caseId);
+    if (!Array.isArray(closure.modules) || closure.modules.length === 0) {
+      throw new Error(`${closureLabel}.modules must be non-empty`);
+    }
+    if (closure.modules.length > MAX_PRODUCTION_MODULES_PER_CASE) {
+      throw new Error(`${closureLabel}.modules exceeds its bounded size`);
+    }
+    const modules = closure.modules.map((binding, bindingIndex) => {
+      const bindingLabel = `${closureLabel}.modules[${bindingIndex}]`;
+      assertPlainRecord(binding, bindingLabel);
+      assertExactKeys(binding, ["path", "sha256"], bindingLabel);
+      if (
+        typeof binding.sha256 !== "string" ||
+        !SHA256_PATTERN.test(binding.sha256)
+      ) {
+        throw new Error(`${bindingLabel}.sha256 is invalid`);
+      }
+      return { path: binding.path, sha256: binding.sha256 };
+    });
+    const normalizedPaths = normalizePaths(
+      modules.map((binding) => binding.path),
+    );
+    const originalPaths = modules.map((binding) => binding.path);
+    if (JSON.stringify(normalizedPaths) !== JSON.stringify(originalPaths)) {
+      throw new Error(`${closureLabel}.modules must be unique and path-sorted`);
+    }
+    assertProductionModulePaths(normalizedPaths, productionTreePath, caseId);
+    return { caseId, modules };
+  });
+}
+
+function normalizeCaseId(value, label) {
+  if (typeof value !== "string" || !CASE_ID_PATTERN.test(value)) {
+    throw new Error(`${label}.caseId is invalid`);
+  }
+  return value;
+}
+
+function assertProductionModulePaths(paths, productionTreePath, caseId) {
+  if (paths.length > MAX_PRODUCTION_MODULES_PER_CASE) {
+    throw new Error(
+      `production module closure for ${caseId} exceeds its bounded size`,
+    );
+  }
+  const prefix = `${productionTreePath}/`;
+  if (
+    paths.some(
+      (path) =>
+        !path.startsWith(prefix) ||
+        path.includes("\\") ||
+        path
+          .split("/")
+          .some(
+            (segment) =>
+              segment.length === 0 || segment === "." || segment === "..",
+          ),
+    )
+  ) {
+    throw new Error(
+      `production module closure for ${caseId} escapes ${productionTreePath}`,
+    );
+  }
+}
+
+function normalizeSourceRevisionSelector(value) {
+  const selector = value ?? "HEAD";
+  if (
+    typeof selector !== "string" ||
+    selector.length === 0 ||
+    Buffer.byteLength(selector) > 1_024 ||
+    selector.includes("\0")
+  ) {
+    throw new Error("benchmark source revision selector is invalid");
+  }
+  return selector;
+}
+
+function normalizeProductionTreePath(path) {
+  const normalized = normalizePaths([path])[0];
+  if (normalized === undefined) {
+    throw new Error("benchmark production tree path is required");
+  }
+  return normalized;
+}
+
+function normalizePaths(paths) {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error("benchmark binding paths must be a non-empty array");
+  }
+  const normalized = paths.map((path) => {
+    if (
+      typeof path !== "string" ||
+      path.length === 0 ||
+      isAbsolute(path) ||
+      path.split(/[\\/]/u).some((segment) => segment === "..")
+    ) {
+      throw new Error("benchmark binding path must be repository-relative");
+    }
+    return path.replace(/\\/gu, "/");
+  });
+  const sorted = [...new Set(normalized)].sort();
+  if (sorted.length !== normalized.length) {
+    throw new Error("benchmark binding paths must be unique");
+  }
+  return sorted;
+}
+
+function validateCommand(command, args, cwd, maxOutputBytes, timeoutMs) {
+  if (typeof command !== "string" || command.length === 0) {
+    throw new Error("bounded command must be non-empty");
+  }
+  if (
+    !Array.isArray(args) ||
+    args.length > MAX_BOUND_COMMAND_ARGUMENTS ||
+    args.some(
+      (argument) =>
+        typeof argument !== "string" ||
+        Buffer.byteLength(argument) > MAX_BOUND_COMMAND_ARGUMENT_BYTES,
+    )
+  ) {
+    throw new Error("bounded command arguments exceed their named limits");
+  }
+  if (typeof cwd !== "string" || cwd.length === 0) {
+    throw new Error("bounded command cwd must be non-empty");
+  }
+  if (
+    !Number.isSafeInteger(maxOutputBytes) ||
+    maxOutputBytes <= 0 ||
+    maxOutputBytes > MAX_BOUND_COMMAND_OUTPUT_BYTES
+  ) {
+    throw new Error("bounded command output exceeds its named limit");
+  }
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > MAX_BOUND_COMMAND_TIMEOUT_MS
+  ) {
+    throw new Error("bounded command timeout exceeds its named limit");
+  }
+}
+
+function assertGitRevision(revision) {
+  if (!GIT_REVISION_PATTERN.test(revision)) {
+    throw new Error("benchmark source revision must be a full Git object ID");
+  }
+}
+
+function assertBindingsEqual(expected, actual, message) {
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+    throw new Error(message);
+  }
+}
+
+function assertPathDigestsEqual(expected, actual, message) {
+  const expectedDigests = expected.map(({ path, sha256 }) => ({
+    path,
+    sha256,
+  }));
+  const actualDigests = actual.map(({ path, sha256 }) => ({ path, sha256 }));
+  assertBindingsEqual(expectedDigests, actualDigests, message);
+}
+
+function assertPlainRecord(value, label) {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new Error(`${label} must be a plain object`);
+  }
+}
+
+function assertExactKeys(value, expectedKeys, label) {
+  const actualKeys = Object.keys(value).sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(sortedExpectedKeys)) {
+    throw new Error(`${label} keys differ`);
+  }
+}
+
+function sha256Hex(value) {
+  const digest = createHash("sha256").update(value).digest("hex");
+  if (!SHA256_PATTERN.test(digest)) {
+    throw new Error("failed to produce a SHA-256 binding");
+  }
+  return digest;
+}

--- a/runtime/benchmarks/fnd/run-baselines.mjs
+++ b/runtime/benchmarks/fnd/run-baselines.mjs
@@ -1,0 +1,576 @@
+#!/usr/bin/env node
+
+import { cpus, release, tmpdir, totalmem } from "node:os";
+import { randomBytes } from "node:crypto";
+import { statfsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+
+import { rgPath } from "@vscode/ripgrep";
+
+import { publishBenchmarkArtifacts } from "./artifact-output.mjs";
+import { readBoundedRegularFile } from "./bounded-file.mjs";
+
+import {
+  BENCHMARK_ARTIFACT_KIND,
+  BENCHMARK_EVIDENCE_PATHS,
+  BENCHMARK_PLAN,
+  BENCHMARK_PRODUCTION_TREE_PATH,
+  BENCHMARK_SCHEMA_VERSION,
+  BENCHMARK_SUITE_ID,
+  BENCHMARK_WORKER_COMPLETION_PREFIX,
+  MAX_BASELINE_JSON_BYTES,
+  MAX_BASELINE_MARKDOWN_BYTES,
+  MAX_PRODUCTION_MODULES_PER_CASE,
+  MAX_WORKER_OUTPUT_BYTES,
+  benchmarkPlanDigest,
+  canonicalJson,
+  renderBaselineMarkdown,
+  sha256Hex,
+  summarizeSamples,
+  validateBenchmarkReport,
+} from "./contract.mjs";
+import {
+  assertNoBenchmarkExecArguments,
+  assertNoUnsafeBenchmarkEnvironment,
+  createBenchmarkWorkerEnvironment,
+} from "./environment.mjs";
+import { describeFixture } from "./fixtures.mjs";
+import { withOwnedTemporaryRoot } from "./isolation.mjs";
+import {
+  PRODUCTION_MODULE_RECORD_PREFIX,
+  registerProductionModuleTracker,
+} from "./module-closure.mjs";
+import {
+  bindProductionModuleClosures,
+  captureBenchmarkProvenance,
+  resolveBenchmarkNpmCliPath,
+  runBoundedCommandText,
+  verifyBenchmarkCapture,
+  verifyCheckedBenchmarkProvenance,
+} from "./provenance.mjs";
+import { runBoundedChild } from "./supervisor.mjs";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runtimeRoot = resolve(benchmarkRoot, "../..");
+const repositoryRoot = resolve(runtimeRoot, "..");
+const workerPath = join(benchmarkRoot, "case-worker.mjs");
+const baselineJsonPath = join(benchmarkRoot, "baseline.v1.json");
+const baselineMarkdownPath = join(benchmarkRoot, "baseline.v1.md");
+const START_PREFIX = "AGENC_FND_BENCH_START ";
+const RSS_TIMEOUT_LIMITATION =
+  "The child reported RSS immediately before entering synchronous work and was then externally terminated; this is a lower-bound diagnostic, not a process peak.";
+
+assertNoBenchmarkExecArguments(process.execArgv);
+assertNoUnsafeBenchmarkEnvironment(process.env);
+const options = parseArguments(process.argv.slice(2));
+
+if (options.mode === "plan") {
+  const plan = canonicalJson({
+    fixtures: BENCHMARK_PLAN.cases.flatMap((definition) =>
+      definition.inputSeries.map((_, pointIndex) =>
+        describeFixture(definition.id, pointIndex),
+      ),
+    ),
+    plan: BENCHMARK_PLAN,
+    planDigest: benchmarkPlanDigest(),
+  });
+  assertSerializedArtifactWithinBounds(
+    plan,
+    MAX_BASELINE_JSON_BYTES,
+    "benchmark plan",
+  );
+  process.stdout.write(plan);
+} else if (options.mode === "check") {
+  checkBaseline();
+  process.stdout.write("FND benchmark baseline contract is valid.\n");
+} else {
+  const report = await runSuite();
+  validateBenchmarkReport(report);
+  const json = canonicalJson(report);
+  const digest = sha256Hex(json);
+  const markdown = renderBaselineMarkdown(report, digest);
+  assertSerializedArtifactWithinBounds(
+    json,
+    MAX_BASELINE_JSON_BYTES,
+    "baseline JSON",
+  );
+  assertSerializedArtifactWithinBounds(
+    markdown,
+    MAX_BASELINE_MARKDOWN_BYTES,
+    "baseline Markdown",
+  );
+  publishBenchmarkArtifacts({
+    json,
+    jsonPath: options.outputPath,
+    markdown,
+    markdownPath: options.markdownOutputPath,
+  });
+  process.stdout.write(
+    `${JSON.stringify({
+      jsonSha256: digest,
+      markdownOutput: options.markdownOutputPath,
+      output: options.outputPath,
+    })}\n`,
+  );
+}
+
+async function runSuite() {
+  const provenance = captureBenchmarkProvenance({
+    evidencePaths: BENCHMARK_EVIDENCE_PATHS,
+    productionTreePath: BENCHMARK_PRODUCTION_TREE_PATH,
+    repositoryRoot,
+    sourceRevision: options.sourceRevision,
+  });
+  const parentModuleTracker = registerProductionModuleTracker({
+    productionRoot: join(runtimeRoot, "src"),
+    repositoryRoot,
+    writeRecord() {},
+  });
+  const cases = [];
+  const observedModuleClosures = [];
+  try {
+    for (const definition of BENCHMARK_PLAN.cases) {
+      process.stderr.write(`benchmark ${definition.id}\n`);
+      const points = [];
+      const productionModulePaths = new Set();
+      for (
+        let pointIndex = 0;
+        pointIndex < definition.inputSeries.length;
+        pointIndex += 1
+      ) {
+        const observation = await runPoint(definition, pointIndex);
+        points.push(observation.point);
+        for (const path of observation.productionModulePaths) {
+          productionModulePaths.add(path);
+        }
+      }
+      cases.push({
+        assessment: definition.assessment,
+        family: definition.family,
+        id: definition.id,
+        implementation: definition.implementation,
+        measurementKind: definition.measurementKind,
+        points,
+      });
+      observedModuleClosures.push({
+        caseId: definition.id,
+        paths: [...productionModulePaths].sort(),
+      });
+    }
+  } finally {
+    await parentModuleTracker.close();
+  }
+
+  const parentModulePaths = parentModuleTracker.paths();
+  for (const closure of observedModuleClosures) {
+    closure.paths = [
+      ...new Set([...closure.paths, ...parentModulePaths]),
+    ].sort();
+  }
+
+  const environment = collectEnvironment();
+  verifyBenchmarkCapture(provenance);
+  const productionModuleClosures = bindProductionModuleClosures(
+    provenance,
+    observedModuleClosures,
+  );
+  verifyBenchmarkCapture(provenance);
+  return {
+    artifactKind: BENCHMARK_ARTIFACT_KIND,
+    cases,
+    environment,
+    evidenceBindings: provenance.evidenceBindings,
+    planDigest: benchmarkPlanDigest(),
+    productionModuleClosures,
+    productionTreeBinding: provenance.productionTreeBinding,
+    schemaVersion: BENCHMARK_SCHEMA_VERSION,
+    sourceRevision: provenance.sourceRevision,
+    suiteId: BENCHMARK_SUITE_ID,
+  };
+}
+
+async function runPoint(definition, pointIndex) {
+  if (definition.expectedTermination === "timed_out") {
+    const trials = [];
+    for (let trial = 0; trial < definition.supervisorTrials; trial += 1) {
+      trials.push(await runWorker(definition, pointIndex));
+    }
+    const expectedFixture = describeFixture(definition.id, pointIndex);
+    for (const trial of trials) {
+      if (!trial.timedOut) {
+        throw new Error(
+          `${definition.id} completed instead of reproducing its known timeout; review and refresh the baseline policy`,
+        );
+      }
+      validateStartMessage(trial.startMessage, expectedFixture, definition.id);
+    }
+    const rssObservationsBytes = trials.map(
+      (trial) => trial.startMessage.rssBytes,
+    );
+    return {
+      point: {
+        correctness: {
+          expected: "fallback completes without blocking its owner event loop",
+          matchesOracle: false,
+          observed: `externally terminated after ${definition.timeoutMs} ms`,
+          oracle: "externally supervised responsiveness oracle",
+        },
+        elapsed: {
+          clock: "performance.now",
+          ...summarizeSamples(trials.map((trial) => trial.elapsedMs)),
+        },
+        fixtureDigest: expectedFixture.fixtureDigest,
+        input: expectedFixture.descriptor.input,
+        memory: {
+          lowerBound: {
+            limitation: RSS_TIMEOUT_LIMITATION,
+            maximumObservedBytes: Math.max(...rssObservationsBytes),
+            method: "child_start_rss_lower_bound",
+            observationsBytes: rssObservationsBytes,
+          },
+          peakRssBytes: null,
+          peakRssMethod: "unavailable_after_forced_termination",
+        },
+        operations: expectedFixture.operations,
+        status: "timed_out",
+      },
+      productionModulePaths: mergeProductionModulePaths(trials),
+    };
+  }
+
+  const trial = await runWorker(definition, pointIndex);
+  if (trial.timedOut) {
+    throw new Error(
+      `${definition.id} point ${pointIndex} exceeded its ${definition.timeoutMs} ms supervisor bound`,
+    );
+  }
+  if (trial.exitCode !== 0) {
+    throw new Error(
+      `${definition.id} point ${pointIndex} failed with exit ${trial.exitCode}: ${trimDiagnostic(trial.stderr)}`,
+    );
+  }
+  const expectedFixture = describeFixture(definition.id, pointIndex);
+  validateStartMessage(trial.startMessage, expectedFixture, definition.id);
+  let result;
+  try {
+    result = JSON.parse(trial.stdout);
+  } catch (error) {
+    throw new Error(
+      `${definition.id} returned invalid worker JSON: ${trimDiagnostic(trial.stdout)}`,
+      { cause: error },
+    );
+  }
+  if (
+    canonicalJson(result.input) !==
+      canonicalJson(expectedFixture.descriptor.input) ||
+    result.fixtureDigest !== expectedFixture.fixtureDigest ||
+    canonicalJson(result.operations) !==
+      canonicalJson(expectedFixture.operations)
+  ) {
+    throw new Error(
+      `${definition.id} worker result diverged from its fixture plan`,
+    );
+  }
+  return {
+    point: result,
+    productionModulePaths: trial.productionModulePaths,
+  };
+}
+
+function runWorker(definition, pointIndex) {
+  return withOwnedTemporaryRoot(async (temporaryRoot) => {
+    const completionNonce = randomBytes(32).toString("hex");
+    const expectedCompletionRecord = `${BENCHMARK_WORKER_COMPLETION_PREFIX}${completionNonce}`;
+    const trial = await runBoundedChild({
+      args: [
+        workerPath,
+        "--case",
+        definition.id,
+        "--point",
+        String(pointIndex),
+        "--temporary-root",
+        temporaryRoot,
+        "--completion-nonce",
+        completionNonce,
+      ],
+      command: process.execPath,
+      cwd: repositoryRoot,
+      env: createBenchmarkWorkerEnvironment(
+        process.env,
+        process.platform,
+        temporaryRoot,
+      ),
+      expectedCompletionRecord,
+      maxOutputBytes: MAX_WORKER_OUTPUT_BYTES,
+      timeoutMs: definition.timeoutMs,
+    });
+    const startMessage = parseStartMessage(trial.stderr);
+    if (startMessage === undefined) {
+      throw new Error(
+        `${definition.id} did not emit a start record: ${trimDiagnostic(trial.stderr)}`,
+      );
+    }
+    return {
+      ...trial,
+      productionModulePaths: parseProductionModulePaths(trial.stderr),
+      startMessage,
+      stdout: trial.stdout.trim(),
+    };
+  });
+}
+
+function checkBaseline() {
+  const jsonBytes = readBoundedRegularFile(
+    baselineJsonPath,
+    MAX_BASELINE_JSON_BYTES,
+    "baseline JSON",
+  );
+  const markdownBytes = readBoundedRegularFile(
+    baselineMarkdownPath,
+    MAX_BASELINE_MARKDOWN_BYTES,
+    "baseline Markdown",
+  );
+  const jsonText = jsonBytes.toString("utf8");
+  let report;
+  try {
+    report = JSON.parse(jsonText);
+  } catch (error) {
+    throw new Error("baseline JSON is malformed", { cause: error });
+  }
+  validateBenchmarkReport(report);
+  if (canonicalJson(report) !== jsonText) {
+    throw new Error("baseline JSON is not in canonical stable form");
+  }
+  verifyCheckedBenchmarkProvenance(report, {
+    evidencePaths: BENCHMARK_EVIDENCE_PATHS,
+    productionTreePath: BENCHMARK_PRODUCTION_TREE_PATH,
+    repositoryRoot,
+  });
+  verifyFixtureBindings(report.cases);
+  const jsonDigest = sha256Hex(jsonBytes);
+  const expectedMarkdown = renderBaselineMarkdown(report, jsonDigest);
+  if (markdownBytes.toString("utf8") !== expectedMarkdown) {
+    throw new Error("baseline Markdown or embedded JSON digest is stale");
+  }
+}
+
+function collectEnvironment() {
+  const processorList = cpus();
+  const sourceFilesystem = statfsSync(repositoryRoot);
+  const temporaryFilesystem = statfsSync(resolve(tmpdir()));
+  const sqlite = new DatabaseSync(":memory:");
+  let sqliteVersion;
+  let sqliteCompileOptions;
+  try {
+    sqliteVersion = sqlite
+      .prepare("SELECT sqlite_version() AS version")
+      .get().version;
+    sqliteCompileOptions = sqlite
+      .prepare("PRAGMA compile_options")
+      .all()
+      .map((row) => row.compile_options)
+      .sort();
+  } finally {
+    sqlite.close();
+  }
+  const ripgrepVersion = runBoundedCommandText(
+    rgPath,
+    ["--no-config", "--version"],
+    {
+      cwd: repositoryRoot,
+      label: "read pinned ripgrep version",
+      maxOutputBytes: 262_144,
+    },
+  )
+    .split(/\r?\n/u)[0]
+    .trim();
+  return {
+    cpu: {
+      logicalCount: processorList.length,
+      model: processorList[0]?.model ?? "unknown",
+    },
+    filesystems: {
+      sourceCheckout: {
+        blockSizeBytes: sourceFilesystem.bsize,
+        type: String(sourceFilesystem.type),
+      },
+      temporaryFixtures: {
+        blockSizeBytes: temporaryFilesystem.bsize,
+        type: String(temporaryFilesystem.type),
+      },
+    },
+    memory: { totalBytes: totalmem() },
+    os: {
+      arch: process.arch,
+      platform: process.platform,
+      release: release(),
+    },
+    ripgrep: {
+      distribution: "pinned_package",
+      version: ripgrepVersion,
+    },
+    runtime: {
+      node: process.version,
+      npm: runBoundedCommandText(
+        process.execPath,
+        [resolveBenchmarkNpmCliPath(), "--version"],
+        {
+          cwd: repositoryRoot,
+          label: "read npm version",
+          maxOutputBytes: 65_536,
+        },
+      ),
+      v8: process.versions.v8,
+    },
+    sqlite: {
+      compileOptions: sqliteCompileOptions,
+      version: String(sqliteVersion),
+    },
+  };
+}
+
+function verifyFixtureBindings(caseReports) {
+  BENCHMARK_PLAN.cases.forEach((definition, caseIndex) => {
+    definition.inputSeries.forEach((_, pointIndex) => {
+      const expected = describeFixture(definition.id, pointIndex);
+      const point = caseReports[caseIndex].points[pointIndex];
+      if (
+        point.fixtureDigest !== expected.fixtureDigest ||
+        canonicalJson(point.input) !==
+          canonicalJson(expected.descriptor.input) ||
+        canonicalJson(point.operations) !== canonicalJson(expected.operations)
+      ) {
+        throw new Error(
+          `${definition.id} point ${pointIndex} fixture binding is stale`,
+        );
+      }
+    });
+  });
+}
+
+function validateStartMessage(message, expectedFixture, caseId) {
+  if (
+    message.caseId !== caseId ||
+    message.fixtureDigest !== expectedFixture.fixtureDigest ||
+    canonicalJson(message.input) !==
+      canonicalJson(expectedFixture.descriptor.input) ||
+    canonicalJson(message.operations) !==
+      canonicalJson(expectedFixture.operations) ||
+    !Number.isSafeInteger(message.rssBytes) ||
+    message.rssBytes <= 0
+  ) {
+    throw new Error(
+      `${caseId} emitted an invalid or nondeterministic start record`,
+    );
+  }
+}
+
+function parseStartMessage(stderr) {
+  for (const line of stderr.split(/\r?\n/u)) {
+    if (!line.startsWith(START_PREFIX)) continue;
+    try {
+      return JSON.parse(line.slice(START_PREFIX.length));
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function parseProductionModulePaths(stderr) {
+  const paths = [];
+  for (const line of stderr.split(/\r?\n/u)) {
+    if (!line.startsWith(PRODUCTION_MODULE_RECORD_PREFIX)) continue;
+    let record;
+    try {
+      record = JSON.parse(line.slice(PRODUCTION_MODULE_RECORD_PREFIX.length));
+    } catch (error) {
+      throw new Error("worker emitted a malformed production module record", {
+        cause: error,
+      });
+    }
+    if (
+      record === null ||
+      typeof record !== "object" ||
+      Array.isArray(record) ||
+      Object.keys(record).length !== 1 ||
+      typeof record.path !== "string" ||
+      !record.path.startsWith(`${BENCHMARK_PRODUCTION_TREE_PATH}/`) ||
+      record.path.includes("\\") ||
+      record.path
+        .split("/")
+        .some(
+          (segment) =>
+            segment.length === 0 || segment === "." || segment === "..",
+        )
+    ) {
+      throw new Error("worker emitted an invalid production module record");
+    }
+    paths.push(record.path);
+  }
+  const canonicalPaths = [...new Set(paths)].sort();
+  if (canonicalPaths.length !== paths.length) {
+    throw new Error("worker repeated a production module record");
+  }
+  if (canonicalPaths.length === 0) {
+    throw new Error("worker did not report its production module closure");
+  }
+  if (canonicalPaths.length > MAX_PRODUCTION_MODULES_PER_CASE) {
+    throw new Error("worker production module closure exceeds its named bound");
+  }
+  return canonicalPaths;
+}
+
+function mergeProductionModulePaths(trials) {
+  const paths = new Set();
+  for (const trial of trials) {
+    for (const path of trial.productionModulePaths) paths.add(path);
+  }
+  if (paths.size > MAX_PRODUCTION_MODULES_PER_CASE) {
+    throw new Error("case production module closure exceeds its named bound");
+  }
+  return [...paths].sort();
+}
+
+function trimDiagnostic(value) {
+  const maximumCharacters = 2_000;
+  return value.length <= maximumCharacters
+    ? value
+    : `${value.slice(0, maximumCharacters)}…`;
+}
+
+function assertSerializedArtifactWithinBounds(value, maximumBytes, label) {
+  const bytes = Buffer.byteLength(value);
+  if (bytes > maximumBytes) {
+    throw new Error(`${label} exceeds its ${maximumBytes} byte ceiling`);
+  }
+}
+
+function parseArguments(args) {
+  if (args.length === 1 && args[0] === "--check") return { mode: "check" };
+  if (args.length === 1 && args[0] === "--plan") return { mode: "plan" };
+  const hasSourceRevision = args[0] === "--source-revision";
+  const argumentOffset = hasSourceRevision ? 2 : 0;
+  if (
+    args.length === argumentOffset + 4 &&
+    args[argumentOffset] === "--output" &&
+    args[argumentOffset + 2] === "--markdown-output"
+  ) {
+    const outputPath = resolve(args[argumentOffset + 1]);
+    const markdownOutputPath = resolve(args[argumentOffset + 3]);
+    if (outputPath === markdownOutputPath) {
+      throw new Error("JSON and Markdown outputs must use different paths");
+    }
+    return {
+      sourceRevision: hasSourceRevision ? args[1] : "HEAD",
+      mode: "run",
+      outputPath,
+      markdownOutputPath,
+    };
+  }
+  throw new Error(
+    "usage: run-baselines.mjs --check | --plan | [--source-revision REVISION] --output FILE --markdown-output FILE",
+  );
+}

--- a/runtime/benchmarks/fnd/supervisor.mjs
+++ b/runtime/benchmarks/fnd/supervisor.mjs
@@ -1,0 +1,455 @@
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+
+import { markOwnedTemporaryRootForRetention } from "./isolation.mjs";
+
+export const MAX_SUPERVISOR_TIMEOUT_MS = 60_000;
+export const MAX_SUPERVISOR_ARGUMENTS = 64;
+export const MAX_SUPERVISOR_ARGUMENT_BYTES = 16_384;
+export const MAX_SUPERVISOR_OUTPUT_BYTES = 4_194_304;
+export const CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS = 2_000;
+export const CHILD_TERMINATION_POLL_INTERVAL_MS = 20;
+const MAX_COMPLETION_RECORD_BYTES = 256;
+const PRODUCTION_TERMINATE_GRACE_MS = 0;
+const PRODUCTION_SETTLEMENT_KEEPALIVE_INTERVAL_MS = 1_000;
+
+let productionContainmentPromise;
+
+export function runBoundedChild(options) {
+  const validated = validateOptions(options);
+  if (validated.processTreeController === undefined) {
+    return runProductionContainedChild(validated);
+  }
+  return runBoundedChildWithController(validated);
+}
+
+async function runProductionContainedChild(options) {
+  const runSupervisedProcess =
+    options.productionContainmentRunner ??
+    (await loadProductionContainment()).runSupervisedProcess;
+  const startedAt = performance.now();
+  let completionObserved = false;
+  let observedStderr = "";
+  const settlementKeepAlive = setInterval(
+    () => {},
+    PRODUCTION_SETTLEMENT_KEEPALIVE_INTERVAL_MS,
+  );
+  let result;
+  try {
+    try {
+      result = await runSupervisedProcess(
+        {
+          args: options.args,
+          cwd: options.cwd,
+          env: options.env,
+          program: options.command,
+        },
+        {
+          maxOutputBytes: options.maxOutputBytes,
+          onStderr(chunk, control) {
+            if (
+              completionObserved ||
+              options.expectedCompletionRecord === undefined
+            ) {
+              return;
+            }
+            observedStderr += chunk.toString("utf8");
+            if (
+              outputContainsExactLine(
+                observedStderr,
+                options.expectedCompletionRecord,
+              )
+            ) {
+              completionObserved = true;
+              control.stop("consumer_limit");
+            }
+          },
+          settleBackstopMs: CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS,
+          terminateGraceMs: PRODUCTION_TERMINATE_GRACE_MS,
+          timeoutMs: options.timeoutMs,
+        },
+      );
+    } catch (error) {
+      throw markOwnedTemporaryRootForRetention(
+        containmentError(
+          "production process-tree settlement was not proven",
+          error,
+        ),
+      );
+    }
+  } finally {
+    clearInterval(settlementKeepAlive);
+  }
+  if (result.backstopExpired) {
+    throw markOwnedTemporaryRootForRetention(
+      containmentError("production process-tree settlement was not proven"),
+    );
+  }
+  if (result.error !== undefined) {
+    throw markOwnedTemporaryRootForRetention(
+      containmentError(
+        "production process-tree settlement was not proven",
+        result.error,
+      ),
+    );
+  }
+  if (result.stopReason === "output_limit") {
+    throw new Error("child exceeded the bounded output ceiling");
+  }
+  const timedOut = result.stopReason === "timeout";
+  if (
+    result.stopReason !== undefined &&
+    !timedOut &&
+    !(result.stopReason === "consumer_limit" && completionObserved)
+  ) {
+    throw new Error(
+      `child stopped for unexpected reason: ${result.stopReason}`,
+    );
+  }
+  if (
+    options.expectedCompletionRecord !== undefined &&
+    !completionObserved &&
+    !timedOut
+  ) {
+    throw new Error(
+      "child exited before authenticated benchmark completion: " +
+        trimDiagnostic(result.stderr.toString("utf8")),
+    );
+  }
+  return {
+    elapsedMs: performance.now() - startedAt,
+    exitCode: completionObserved && !timedOut ? 0 : result.exitCode,
+    signal: completionObserved && !timedOut ? null : result.signal,
+    stderr: result.stderr.toString("utf8"),
+    stdout: result.stdout.toString("utf8"),
+    timedOut,
+  };
+}
+
+function runBoundedChildWithController(validated) {
+  const processTreeController = validated.processTreeController;
+  return new Promise((resolvePromise, rejectPromise) => {
+    let child;
+    try {
+      child = spawn(validated.command, validated.args, {
+        cwd: validated.cwd,
+        detached: process.platform !== "win32",
+        env: validated.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      rejectPromise(error);
+      return;
+    }
+
+    const startedAt = performance.now();
+    let childFailure;
+    let closeRecord;
+    let outputBytes = 0;
+    let outputOverflow = false;
+    let settled = false;
+    let stderr = "";
+    let stdout = "";
+    let terminationDeadlineAt;
+    let terminationFailure;
+    let terminationPollTimer;
+    let terminationSettlementTimer;
+    let terminationStarted = false;
+    let timedOut = false;
+
+    const deadlineTimer = setTimeout(
+      () => beginTermination("timeout"),
+      validated.timeoutMs,
+    );
+
+    const clearTimers = () => {
+      clearTimeout(deadlineTimer);
+      if (terminationPollTimer !== undefined) {
+        clearTimeout(terminationPollTimer);
+      }
+      if (terminationSettlementTimer !== undefined) {
+        clearTimeout(terminationSettlementTimer);
+      }
+    };
+
+    const destroyChildStreams = () => {
+      child.stdout.destroy();
+      child.stderr.destroy();
+    };
+
+    const rejectOnce = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      destroyChildStreams();
+      rejectPromise(error);
+    };
+
+    const resolveOnce = () => {
+      if (settled || closeRecord === undefined) return;
+      settled = true;
+      clearTimers();
+      resolvePromise({
+        elapsedMs: closeRecord.elapsedMs,
+        exitCode: closeRecord.exitCode,
+        signal: closeRecord.signal,
+        stderr,
+        stdout,
+        timedOut,
+      });
+    };
+
+    function beginTermination(reason, failure) {
+      if (reason === "timeout") timedOut = true;
+      if (reason === "output_overflow") outputOverflow = true;
+      if (failure !== undefined && childFailure === undefined) {
+        childFailure = failure;
+      }
+      if (terminationStarted || settled) return;
+      terminationStarted = true;
+      clearTimeout(deadlineTimer);
+      terminationDeadlineAt =
+        performance.now() + CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS;
+      tryTerminateProcessTree();
+      const remainingMs = Math.max(
+        0,
+        terminationDeadlineAt - performance.now(),
+      );
+      terminationSettlementTimer = setTimeout(
+        finishTerminationAtDeadline,
+        remainingMs,
+      );
+      pollTerminationSettlement();
+    }
+
+    function tryTerminateProcessTree() {
+      try {
+        processTreeController.terminate(child);
+      } catch (error) {
+        if (terminationFailure === undefined) terminationFailure = error;
+      }
+    }
+
+    function processTreeIsAlive() {
+      try {
+        const alive = processTreeController.isAlive(child);
+        if (typeof alive !== "boolean") {
+          throw new Error("process-tree liveness probe must return a boolean");
+        }
+        return alive;
+      } catch (error) {
+        if (terminationFailure === undefined) terminationFailure = error;
+        return undefined;
+      }
+    }
+
+    function pollTerminationSettlement() {
+      if (settled) return;
+      const treeAlive = processTreeIsAlive();
+      if (treeAlive === false && closeRecord !== undefined) {
+        settleAfterForcedTermination();
+        return;
+      }
+      const remainingMs = terminationDeadlineAt - performance.now();
+      if (remainingMs <= 0) return;
+      terminationPollTimer = setTimeout(
+        pollTerminationSettlement,
+        Math.min(CHILD_TERMINATION_POLL_INTERVAL_MS, remainingMs),
+      );
+    }
+
+    function finishTerminationAtDeadline() {
+      if (settled) return;
+      const treeAlive = processTreeIsAlive();
+      if (treeAlive !== false) {
+        rejectOnce(
+          markOwnedTemporaryRootForRetention(
+            containmentError(
+              `process tree did not terminate within ${CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS} ms`,
+              terminationFailure,
+            ),
+          ),
+        );
+        return;
+      }
+      if (closeRecord === undefined) {
+        rejectOnce(
+          containmentError(
+            `child did not settle within ${CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS} ms ` +
+              "after process-tree termination",
+            terminationFailure,
+          ),
+        );
+        return;
+      }
+      settleAfterForcedTermination();
+    }
+
+    function settleAfterForcedTermination() {
+      if (terminationFailure !== undefined) {
+        rejectOnce(
+          containmentError(
+            "process-tree termination failed",
+            terminationFailure,
+          ),
+        );
+        return;
+      }
+      if (childFailure !== undefined) {
+        rejectOnce(childFailure);
+        return;
+      }
+      if (outputOverflow) {
+        rejectOnce(new Error("child exceeded the bounded output ceiling"));
+        return;
+      }
+      resolveOnce();
+    }
+
+    const appendOutput = (stream, chunk) => {
+      outputBytes += Buffer.byteLength(chunk);
+      if (outputBytes > validated.maxOutputBytes) {
+        beginTermination("output_overflow");
+        return stream;
+      }
+      return stream + chunk;
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout = appendOutput(stdout, chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr = appendOutput(stderr, chunk);
+    });
+    child.on("error", (error) => {
+      if (child.pid === undefined) {
+        rejectOnce(error);
+        return;
+      }
+      beginTermination("child_error", error);
+    });
+    child.on("close", (exitCode, signal) => {
+      if (settled) return;
+      closeRecord = {
+        elapsedMs: performance.now() - startedAt,
+        exitCode,
+        signal,
+      };
+      if (terminationStarted) {
+        pollTerminationSettlement();
+      } else {
+        const treeAlive = processTreeIsAlive();
+        if (treeAlive === false) {
+          resolveOnce();
+        } else {
+          beginTermination("normal_exit");
+        }
+      }
+    });
+  });
+}
+
+function loadProductionContainment() {
+  productionContainmentPromise ??=
+    import("../../src/utils/supervisedProcess.ts");
+  return productionContainmentPromise;
+}
+
+function outputContainsExactLine(output, expectedLine) {
+  return output.split(/\r?\n/u).includes(expectedLine);
+}
+
+function trimDiagnostic(value) {
+  const maximumCharacters = 2_000;
+  const trimmed = value.trim();
+  return trimmed.length <= maximumCharacters
+    ? trimmed
+    : `${trimmed.slice(0, maximumCharacters)}…`;
+}
+
+function validateOptions(options) {
+  if (options === null || typeof options !== "object") {
+    throw new Error("bounded child options must be an object");
+  }
+  if (typeof options.command !== "string" || options.command.length === 0) {
+    throw new Error("bounded child command must be non-empty");
+  }
+  if (
+    !Array.isArray(options.args) ||
+    options.args.length > MAX_SUPERVISOR_ARGUMENTS ||
+    options.args.some(
+      (argument) =>
+        typeof argument !== "string" ||
+        Buffer.byteLength(argument) > MAX_SUPERVISOR_ARGUMENT_BYTES,
+    )
+  ) {
+    throw new Error("bounded child arguments exceed their named limits");
+  }
+  if (typeof options.cwd !== "string" || options.cwd.length === 0) {
+    throw new Error("bounded child cwd must be non-empty");
+  }
+  if (
+    options.env === null ||
+    typeof options.env !== "object" ||
+    Array.isArray(options.env)
+  ) {
+    throw new Error("bounded child environment must be an object");
+  }
+  if (
+    !Number.isSafeInteger(options.timeoutMs) ||
+    options.timeoutMs <= 0 ||
+    options.timeoutMs > MAX_SUPERVISOR_TIMEOUT_MS
+  ) {
+    throw new Error("bounded child timeout exceeds its named limit");
+  }
+  if (
+    !Number.isSafeInteger(options.maxOutputBytes) ||
+    options.maxOutputBytes <= 0 ||
+    options.maxOutputBytes > MAX_SUPERVISOR_OUTPUT_BYTES
+  ) {
+    throw new Error("bounded child output ceiling exceeds its named limit");
+  }
+  if (
+    options.expectedCompletionRecord !== undefined &&
+    (typeof options.expectedCompletionRecord !== "string" ||
+      options.expectedCompletionRecord.length === 0 ||
+      /[\r\n]/u.test(options.expectedCompletionRecord) ||
+      Buffer.byteLength(options.expectedCompletionRecord) >
+        MAX_COMPLETION_RECORD_BYTES)
+  ) {
+    throw new Error("bounded child completion record is invalid");
+  }
+  if (options.processTreeController !== undefined) {
+    const controller = options.processTreeController;
+    if (
+      controller === null ||
+      typeof controller !== "object" ||
+      typeof controller.terminate !== "function" ||
+      typeof controller.isAlive !== "function"
+    ) {
+      throw new Error("bounded child process-tree controller is invalid");
+    }
+  }
+  if (
+    options.productionContainmentRunner !== undefined &&
+    typeof options.productionContainmentRunner !== "function"
+  ) {
+    throw new Error("bounded child production containment runner is invalid");
+  }
+  if (
+    options.processTreeController !== undefined &&
+    options.productionContainmentRunner !== undefined
+  ) {
+    throw new Error("bounded child containment seams are mutually exclusive");
+  }
+  return options;
+}
+
+function containmentError(message, cause) {
+  if (cause === undefined) return new Error(message);
+  const causeMessage = cause instanceof Error ? cause.message : String(cause);
+  return new Error(`${message}: ${causeMessage}`, { cause });
+}

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -60,6 +60,8 @@
     "check:eval-contract": "tsx src/eval-contract/cli.ts",
     "check:eval-suites": "tsx src/eval-suites/cli.ts",
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
+    "benchmark:fnd-baseline": "node benchmarks/fnd/run-baselines.mjs",
+    "check:fnd-benchmark-baseline": "node benchmarks/fnd/run-baselines.mjs --check",
     "test": "node scripts/run-hermetic-test-boundary.mjs run",
     "test:host-functional": "node scripts/run-hermetic-vitest.mjs run",
     "test:kernel": "node scripts/run-hermetic-vitest.mjs --require-zero-skips run --config vitest.kernel.config.ts",

--- a/runtime/tests/fnd/README.md
+++ b/runtime/tests/fnd/README.md
@@ -56,9 +56,12 @@ bun test runtime/tests/fnd/portable-repository-path.bun.test.ts \
   runtime/tests/fnd/fnd-fixtures.bun.test.ts
 ```
 
-Red probes, the isolated helper runner, and benchmark harnesses land in their
-separately reviewed foundation PRs. Production parsers must not import these
-test-only helpers or the fixture corpus.
+The isolated benchmark harness and reviewed known-failure baseline live in
+[`../../benchmarks/fnd/`](../../benchmarks/fnd/). Red probes remain separate
+from timing evidence so noisy wall-clock measurements never enter the default
+test suite. The red-probe runner lands in its separately reviewed foundation
+PR. Production parsers must not import these test-only helpers, benchmarks, or
+the fixture corpus.
 
 ## Process and restart helpers
 

--- a/runtime/tests/fnd/benchmark-baselines.contract.test.ts
+++ b/runtime/tests/fnd/benchmark-baselines.contract.test.ts
@@ -1,0 +1,299 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  BENCHMARK_EVIDENCE_PATHS,
+  BENCHMARK_PLAN,
+  BENCHMARK_PRODUCTION_TREE_PATH,
+  MAX_BASELINE_JSON_BYTES,
+  MAX_BASELINE_MARKDOWN_BYTES,
+  benchmarkPlanDigest,
+  canonicalJson,
+  renderBaselineMarkdown,
+  validateBenchmarkReport,
+} from "../../benchmarks/fnd/contract.mjs";
+import { describeFixture } from "../../benchmarks/fnd/fixtures.mjs";
+import {
+  collectNormalizedFileBindings,
+  verifyCheckedBenchmarkProvenance,
+} from "../../benchmarks/fnd/provenance.mjs";
+
+const BENCHMARK_ROOT = fileURLToPath(
+  new URL("../../benchmarks/fnd/", import.meta.url),
+);
+const RUNTIME_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+const BASELINE_JSON_PATH = join(BENCHMARK_ROOT, "baseline.v1.json");
+const BASELINE_MARKDOWN_PATH = join(BENCHMARK_ROOT, "baseline.v1.md");
+const RUNNER_PATH = join(BENCHMARK_ROOT, "run-baselines.mjs");
+const PLAN_RUNNER_TIMEOUT_MS = 5_000;
+
+function readBaseline(): Record<string, any> {
+  return JSON.parse(readFileSync(BASELINE_JSON_PATH, "utf8")) as Record<
+    string,
+    any
+  >;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+describe("FND benchmark baseline contract", () => {
+  test("keeps canonical JSON, generated Markdown, digest, and schema in lockstep", () => {
+    const json = readFileSync(BASELINE_JSON_PATH, "utf8");
+    const report = JSON.parse(json) as Record<string, any>;
+    const digest = sha256(json);
+
+    expect(validateBenchmarkReport(report)).toBe(report);
+    expect(canonicalJson(report)).toBe(json);
+    expect(readFileSync(BASELINE_MARKDOWN_PATH, "utf8")).toBe(
+      renderBaselineMarkdown(report, digest),
+    );
+    expect(Buffer.byteLength(json)).toBeLessThanOrEqual(
+      MAX_BASELINE_JSON_BYTES,
+    );
+    expect(
+      Buffer.byteLength(readFileSync(BASELINE_MARKDOWN_PATH, "utf8")),
+    ).toBeLessThanOrEqual(MAX_BASELINE_MARKDOWN_BYTES);
+  });
+
+  test("pins generated baseline artifacts to LF on every checkout", () => {
+    const paths = [
+      "runtime/benchmarks/fnd/baseline.v1.json",
+      "runtime/benchmarks/fnd/baseline.v1.md",
+    ];
+    const attributes = execFileSync(
+      "git",
+      ["check-attr", "eol", "--", ...paths],
+      {
+        cwd: REPOSITORY_ROOT,
+        encoding: "utf8",
+        maxBuffer: 65_536,
+        timeout: 5_000,
+        windowsHide: true,
+      },
+    );
+    for (const path of paths) {
+      expect(attributes).toContain(`${path}: eol: lf`);
+      expect(readFileSync(join(REPOSITORY_ROOT, path), "utf8")).not.toContain(
+        "\r",
+      );
+    }
+  });
+
+  test("regenerates every fixture descriptor and plan deterministically", () => {
+    for (const definition of BENCHMARK_PLAN.cases) {
+      definition.inputSeries.forEach((_, pointIndex) => {
+        expect(describeFixture(definition.id, pointIndex)).toEqual(
+          describeFixture(definition.id, pointIndex),
+        );
+      });
+    }
+    expect(benchmarkPlanDigest()).toMatch(/^[0-9a-f]{64}$/u);
+
+    const runnerEnvironment = { ...process.env };
+    for (const name of Object.keys(runnerEnvironment)) {
+      const normalizedName = name.toUpperCase();
+      if (
+        normalizedName.startsWith("NODE_") ||
+        normalizedName.startsWith("TSX_")
+      ) {
+        delete runnerEnvironment[name];
+      }
+    }
+    const first = execFileSync(process.execPath, [RUNNER_PATH, "--plan"], {
+      cwd: RUNTIME_ROOT,
+      encoding: "utf8",
+      env: runnerEnvironment,
+      maxBuffer: 2_097_152,
+      timeout: PLAN_RUNNER_TIMEOUT_MS,
+    });
+    const second = execFileSync(process.execPath, [RUNNER_PATH, "--plan"], {
+      cwd: RUNTIME_ROOT,
+      encoding: "utf8",
+      env: runnerEnvironment,
+      maxBuffer: 2_097_152,
+      timeout: PLAN_RUNNER_TIMEOUT_MS,
+    });
+    expect(second).toBe(first);
+  });
+
+  test("binds every measured point to its generated fixture and production source", () => {
+    const report = readBaseline();
+    for (const [caseIndex, definition] of BENCHMARK_PLAN.cases.entries()) {
+      for (const pointIndex of definition.inputSeries.keys()) {
+        const expected = describeFixture(definition.id, pointIndex);
+        const point = report.cases[caseIndex].points[pointIndex];
+        expect(point.fixtureDigest).toBe(expected.fixtureDigest);
+        expect(point.input).toEqual(expected.descriptor.input);
+        expect(point.operations).toEqual(expected.operations);
+      }
+    }
+    expect(report.evidenceBindings).toEqual(
+      collectNormalizedFileBindings(REPOSITORY_ROOT, BENCHMARK_EVIDENCE_PATHS),
+    );
+    expect(() =>
+      verifyCheckedBenchmarkProvenance(report, {
+        evidencePaths: BENCHMARK_EVIDENCE_PATHS,
+        productionTreePath: BENCHMARK_PRODUCTION_TREE_PATH,
+        repositoryRoot: REPOSITORY_ROOT,
+      }),
+    ).not.toThrow();
+    expect(report.productionModuleClosures).toHaveLength(
+      BENCHMARK_PLAN.cases.length,
+    );
+    for (const [index, closure] of report.productionModuleClosures.entries()) {
+      expect(closure.caseId).toBe(BENCHMARK_PLAN.cases[index].id);
+      expect(closure.modules.length).toBeGreaterThan(0);
+    }
+    const patchClosure = report.productionModuleClosures.find(
+      (closure: Record<string, any>) =>
+        closure.caseId === "patch_delete_parser_suffix_slicing",
+    );
+    expect(
+      patchClosure.modules.map((binding: Record<string, any>) => binding.path),
+    ).toContain("runtime/src/tools/apply-patch/types.ts");
+    const regexClosure = report.productionModuleClosures.find(
+      (closure: Record<string, any>) =>
+        closure.caseId === "regex_fallback_catastrophic_backtracking",
+    );
+    expect(
+      regexClosure.modules.map((binding: Record<string, any>) => binding.path),
+    ).toContain("runtime/src/sandbox/execution-broker.ts");
+    expect(report.productionTreeBinding).toMatchObject({
+      objectType: "tree",
+      path: BENCHMARK_PRODUCTION_TREE_PATH,
+    });
+    expect(report.productionTreeBinding.gitObjectId).toMatch(
+      /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u,
+    );
+  });
+
+  test("rejects a missing elapsed metric and additive schema drift", () => {
+    const missingMetric = structuredClone(readBaseline());
+    delete missingMetric.cases[0].points[0].elapsed.madMs;
+    expect(() => validateBenchmarkReport(missingMetric)).toThrow(
+      /keys differ/u,
+    );
+
+    const drifted = structuredClone(readBaseline());
+    drifted.cases[0].points[0].elapsed.p95Ms = 42;
+    expect(() => validateBenchmarkReport(drifted)).toThrow(/keys differ/u);
+
+    const versionDrift = structuredClone(readBaseline());
+    versionDrift.schemaVersion += 1;
+    expect(() => validateBenchmarkReport(versionDrift)).toThrow(
+      /schemaVersion/u,
+    );
+
+    const collapsedFilesystemMetadata = structuredClone(readBaseline());
+    delete collapsedFilesystemMetadata.environment.filesystems
+      .temporaryFixtures;
+    expect(() => validateBenchmarkReport(collapsedFilesystemMetadata)).toThrow(
+      /keys differ/u,
+    );
+  });
+
+  test("never lets a known failure become a passing threshold", () => {
+    const passing = structuredClone(readBaseline());
+    passing.cases[0].assessment.classification = "passing_threshold";
+    expect(() => validateBenchmarkReport(passing)).toThrow(/classification/u);
+
+    const gated = structuredClone(readBaseline());
+    gated.cases[1].assessment.gateEnforced = true;
+    expect(() => validateBenchmarkReport(gated)).toThrow(/gateEnforced/u);
+
+    const thresholded = structuredClone(readBaseline());
+    thresholded.cases[2].assessment.threshold = { elapsedMs: 2_500 };
+    expect(() => validateBenchmarkReport(thresholded)).toThrow(/threshold/u);
+
+    for (const benchmarkCase of readBaseline().cases) {
+      expect(benchmarkCase.assessment).toMatchObject({
+        classification: "known_failure_observation",
+        gateEnforced: false,
+        threshold: null,
+      });
+    }
+  });
+
+  test("rejects fixture dimensions or generated bytes above named bounds", () => {
+    const oversizedDimension = structuredClone(readBaseline());
+    const csvMaxInput = BENCHMARK_PLAN.cases[0].maxInput;
+    if (!("rowCount" in csvMaxInput)) {
+      throw new Error("CSV benchmark maximum is missing rowCount");
+    }
+    oversizedDimension.cases[0].points[0].input.rowCount =
+      csvMaxInput.rowCount + 1;
+    expect(() => validateBenchmarkReport(oversizedDimension)).toThrow(
+      /rowCount/u,
+    );
+
+    const oversizedBytes = structuredClone(readBaseline());
+    oversizedBytes.cases[1].points[0].input.generatedUtf8Bytes =
+      BENCHMARK_PLAN.cases[1].maxInput.generatedUtf8Bytes + 1;
+    expect(() => validateBenchmarkReport(oversizedBytes)).toThrow(
+      /generatedUtf8Bytes/u,
+    );
+
+    for (const definition of BENCHMARK_PLAN.cases) {
+      expect(definition.timeoutMs).toBeGreaterThan(0);
+      expect(definition.repetitions).toBeGreaterThan(0);
+      expect(definition.supervisorTrials).toBeGreaterThan(0);
+      expect(definition.inputSeries.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("requires repeated samples, memory approximation, operations, and oracle result", () => {
+    const report = readBaseline();
+    for (const benchmarkCase of report.cases) {
+      for (const point of benchmarkCase.points) {
+        expect(point.elapsed.sampleCount).toBeGreaterThanOrEqual(3);
+        expect(point.elapsed.samplesMs).toHaveLength(point.elapsed.sampleCount);
+        expect(point.elapsed.medianMs).toBeGreaterThanOrEqual(0);
+        expect(point.elapsed.madMs).toBeGreaterThanOrEqual(0);
+        expect(point.memory.lowerBound.method).toMatch(/rss_lower_bound$/u);
+        expect(
+          point.memory.lowerBound.observationsBytes.length,
+        ).toBeGreaterThan(0);
+        expect(point.memory.lowerBound.maximumObservedBytes).toBe(
+          Math.max(...point.memory.lowerBound.observationsBytes),
+        );
+        if (point.status === "completed") {
+          expect(point.memory.peakRssMethod).toBe(
+            "process.resourceUsage.maxRSS_kib_to_bytes",
+          );
+          expect(point.memory.peakRssBytes).toBeGreaterThan(0);
+        } else {
+          expect(point.memory.peakRssMethod).toBe(
+            "unavailable_after_forced_termination",
+          );
+          expect(point.memory.peakRssBytes).toBeNull();
+        }
+        expect(Object.keys(point.operations).length).toBeGreaterThan(0);
+        expect(point.correctness.oracle.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("contains only relative source bindings and no personal filesystem paths", () => {
+    const json = readFileSync(BASELINE_JSON_PATH, "utf8");
+    expect(json).not.toMatch(/\/(?:home|Users)\//u);
+    expect(json).not.toMatch(/[A-Za-z]:\\Users\\/u);
+    for (const closure of readBaseline().productionModuleClosures) {
+      for (const binding of closure.modules) {
+        expect(binding.path).not.toMatch(/^[/\\]/u);
+        expect(binding.path).not.toContain("..");
+      }
+    }
+    for (const binding of readBaseline().evidenceBindings) {
+      expect(binding.path).not.toMatch(/^[/\\]/u);
+      expect(binding.path).not.toContain("..");
+    }
+  });
+});

--- a/runtime/tests/fnd/benchmark-harness-faults.test.ts
+++ b/runtime/tests/fnd/benchmark-harness-faults.test.ts
@@ -1,0 +1,1874 @@
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+import { publishBenchmarkArtifacts } from "../../benchmarks/fnd/artifact-output.mjs";
+import { readBoundedRegularFile } from "../../benchmarks/fnd/bounded-file.mjs";
+import {
+  BENCHMARK_WORKER_COMPLETION_PREFIX,
+  normalizeResourceUsageMaxRssBytes,
+  summarizeSamples,
+} from "../../benchmarks/fnd/contract.mjs";
+import {
+  assertBenchmarkWorkerEnvironment,
+  assertNoBenchmarkExecArguments,
+  assertNoUnsafeBenchmarkEnvironment,
+  createBenchmarkWorkerEnvironment,
+  removeDarwinInjectedBenchmarkEnvironment,
+  removeWindowsInjectedBenchmarkEnvironment,
+} from "../../benchmarks/fnd/environment.mjs";
+import {
+  assertNoBenchmarkControlsAtOrAbove,
+  cleanupOwnedTemporaryRoot,
+  retainedOwnedTemporaryRootPath,
+  validateOwnedTemporaryRootPath,
+  withOwnedTemporaryRoot,
+} from "../../benchmarks/fnd/isolation.mjs";
+import { PRODUCTION_MODULE_RECORD_PREFIX } from "../../benchmarks/fnd/module-closure.mjs";
+import {
+  assertBindingsStable,
+  bindProductionModuleClosures,
+  captureBenchmarkProvenance,
+  collectNormalizedFileBindings,
+  createBenchmarkSubprocessEnvironment,
+  createSanitizedGitEnvironment,
+  METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS,
+  METADATA_COMMAND_WORKER_OVERHEAD_MS,
+  resolveBenchmarkGitExecutable,
+  resolveBenchmarkNpmCliPath,
+  runBoundedCommandText,
+  verifyBenchmarkCapture,
+  verifyCheckedBenchmarkProvenance,
+} from "../../benchmarks/fnd/provenance.mjs";
+import {
+  CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS,
+  runBoundedChild,
+} from "../../benchmarks/fnd/supervisor.mjs";
+
+const RUNTIME_ROOT = join(import.meta.dirname, "../..");
+const RUNNER_PATH = join(RUNTIME_ROOT, "benchmarks/fnd/run-baselines.mjs");
+const CASE_WORKER_PATH = join(RUNTIME_ROOT, "benchmarks/fnd/case-worker.mjs");
+const MODULE_TRACKER_PATH = join(
+  RUNTIME_ROOT,
+  "benchmarks/fnd/module-closure.mjs",
+);
+const FIXTURE_PRODUCTION_SOURCE = [
+  'import { dependency } from "./dependency.js";',
+  "export const value = dependency;",
+  "",
+].join("\n");
+
+describe("FND benchmark harness fault contracts", () => {
+  test("pins median and median absolute deviation semantics independently", () => {
+    expect(summarizeSamples([9, 1, 5, 3, 7])).toEqual({
+      madMs: 2,
+      maxMs: 9,
+      medianMs: 5,
+      minMs: 1,
+      sampleCount: 5,
+      samplesMs: [9, 1, 5, 3, 7],
+    });
+    expect(summarizeSamples([1, 3, 9, 11])).toMatchObject({
+      madMs: 4,
+      medianMs: 6,
+    });
+  });
+
+  test("normalizes the worker process high-water RSS from KiB to bytes", () => {
+    expect(normalizeResourceUsageMaxRssBytes(42)).toBe(43_008);
+    for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER]) {
+      expect(() => normalizeResourceUsageMaxRssBytes(invalid)).toThrow();
+    }
+  });
+
+  test("rejects all nonempty ambient Node and tsx namespace entries", () => {
+    for (const name of [
+      "NODE_OPTIONS",
+      "NODE_ENV",
+      "NODE_FUTURE_RUNTIME_CONTROL",
+      "node_options",
+      "NoDe_FuTuRe_RuNtImE_CoNtRoL",
+      "TSX_TSCONFIG_PATH",
+      "tsx_future_loader_control",
+    ]) {
+      expect(() =>
+        assertNoUnsafeBenchmarkEnvironment({ [name]: "nonempty" }),
+      ).toThrow(name);
+    }
+    expect(() => assertNoUnsafeBenchmarkEnvironment({})).not.toThrow();
+    expect(() =>
+      assertNoUnsafeBenchmarkEnvironment({
+        node_future_runtime_control: "",
+        TSX_FUTURE_LOADER_CONTROL: "",
+      }),
+    ).not.toThrow();
+  });
+
+  test("binds all worker state directories to its supervisor-owned root", async () => {
+    await withOwnedTemporaryRoot(async (ownedRoot) => {
+      const ambientTemporaryRoot = join(tmpdir(), "agenc-fnd-shared-ambient");
+      const hostEnvironment: Record<string, string> = {
+        AGENC_HOME: ambientTemporaryRoot,
+        AGENC_PRIVATE_TOKEN: "must-not-cross-the-worker-boundary",
+        HOME: "/private/home",
+        PATH: "/unbound/path",
+        TEMP: ambientTemporaryRoot,
+        TMP: ambientTemporaryRoot,
+        TMPDIR: ambientTemporaryRoot,
+      };
+      if (process.platform === "win32") {
+        hostEnvironment.SystemRoot = process.env.SystemRoot ?? "C:\\Windows";
+      }
+      expect(() =>
+        createBenchmarkWorkerEnvironment(hostEnvironment, process.platform),
+      ).toThrow(/require an owned temporary root/u);
+      const workerEnvironment = createBenchmarkWorkerEnvironment(
+        hostEnvironment,
+        process.platform,
+        ownedRoot,
+      );
+      expect(workerEnvironment).not.toHaveProperty("AGENC_PRIVATE_TOKEN");
+      expect(workerEnvironment).not.toHaveProperty("HOME");
+      expect(workerEnvironment).not.toHaveProperty("PATH");
+      expect(() =>
+        assertBenchmarkWorkerEnvironment(workerEnvironment, process.platform),
+      ).toThrow(/require an owned temporary root/u);
+      for (const name of ["AGENC_HOME", "TEMP", "TMP", "TMPDIR"]) {
+        expect(workerEnvironment[name]).toBe(ownedRoot);
+        expect(workerEnvironment[name]).not.toBe(ambientTemporaryRoot);
+      }
+      expect(() =>
+        assertBenchmarkWorkerEnvironment(
+          workerEnvironment,
+          process.platform,
+          ownedRoot,
+        ),
+      ).not.toThrow();
+
+      const darwinWorkerEnvironment = createBenchmarkWorkerEnvironment(
+        hostEnvironment,
+        "darwin",
+        ownedRoot,
+      );
+      const darwinEnvironment = {
+        ...darwinWorkerEnvironment,
+        __CF_USER_TEXT_ENCODING: "0x1F5:0x0:0x0",
+      };
+      removeDarwinInjectedBenchmarkEnvironment(darwinEnvironment, "darwin");
+      expect(darwinEnvironment).not.toHaveProperty("__CF_USER_TEXT_ENCODING");
+      expect(() =>
+        assertBenchmarkWorkerEnvironment(
+          darwinEnvironment,
+          "darwin",
+          ownedRoot,
+        ),
+      ).not.toThrow();
+      const legacyDarwinEnvironment = {
+        ...darwinWorkerEnvironment,
+        __CF_USER_TEXT_ENCODING: "0x1F5:0:0",
+      };
+      removeDarwinInjectedBenchmarkEnvironment(
+        legacyDarwinEnvironment,
+        "darwin",
+      );
+      expect(legacyDarwinEnvironment).not.toHaveProperty(
+        "__CF_USER_TEXT_ENCODING",
+      );
+      expect(() =>
+        removeDarwinInjectedBenchmarkEnvironment(
+          { __CF_USER_TEXT_ENCODING: "host-controlled" },
+          "darwin",
+        ),
+      ).toThrow(/injected an invalid __CF_USER_TEXT_ENCODING value/u);
+
+      const windowsEnvironment = {
+        ...createBenchmarkWorkerEnvironment(
+          { SystemRoot: "C:\\Windows" },
+          "win32",
+          ownedRoot,
+        ),
+        HOMEDRIVE: "C:",
+        HOMEPATH: "\\Users\\runner",
+        LOGONSERVER: "\\\\RUNNER",
+        PATH: "C:\\host-path",
+        SYSTEMDRIVE: "C:",
+        USERDOMAIN: "RUNNER",
+        USERNAME: "runner",
+        USERPROFILE: "C:\\Users\\runner",
+        WINDIR: "C:\\Windows",
+      };
+      removeWindowsInjectedBenchmarkEnvironment(windowsEnvironment, "win32");
+      expect(() =>
+        assertBenchmarkWorkerEnvironment(
+          windowsEnvironment,
+          "win32",
+          ownedRoot,
+        ),
+      ).not.toThrow();
+      const unexpectedWindowsEnvironment = {
+        ...windowsEnvironment,
+        AGENC_PRIVATE_TOKEN: "must-not-cross-the-worker-boundary",
+      };
+      removeWindowsInjectedBenchmarkEnvironment(
+        unexpectedWindowsEnvironment,
+        "win32",
+      );
+      expect(() =>
+        assertBenchmarkWorkerEnvironment(
+          unexpectedWindowsEnvironment,
+          "win32",
+          ownedRoot,
+        ),
+      ).toThrow(/unexpected environment: AGENC_PRIVATE_TOKEN/u);
+
+      expect(() =>
+        assertBenchmarkWorkerEnvironment(
+          { ...workerEnvironment, TEMP: ambientTemporaryRoot },
+          process.platform,
+          ownedRoot,
+        ),
+      ).toThrow(/owned root for TEMP/u);
+    });
+  });
+
+  test("never treats the temporary namespace itself as an owned root", () => {
+    const dangerousTemporaryDirectory = join(
+      tmpdir(),
+      "agenc-fnd-bench-namespace",
+    );
+    expect(() =>
+      validateOwnedTemporaryRootPath(
+        dangerousTemporaryDirectory,
+        dangerousTemporaryDirectory,
+      ),
+    ).toThrow(/outside the owned namespace/u);
+  });
+
+  test("refuses to delete a directory swapped over an owned root", async () => {
+    let movedOwnedRoot: string | undefined;
+    let replacementRoot: string | undefined;
+    try {
+      await expect(
+        withOwnedTemporaryRoot(async (ownedRoot) => {
+          movedOwnedRoot = `${ownedRoot}-moved`;
+          replacementRoot = ownedRoot;
+          renameSync(ownedRoot, movedOwnedRoot);
+          mkdirSync(replacementRoot);
+          writeFileSync(join(replacementRoot, "replacement"), "preserve\n");
+        }),
+      ).rejects.toThrow(/identity changed; refusing recursive cleanup/u);
+      expect(readFileSync(join(replacementRoot!, "replacement"), "utf8")).toBe(
+        "preserve\n",
+      );
+      expect(existsSync(movedOwnedRoot!)).toBe(true);
+    } finally {
+      if (replacementRoot !== undefined && existsSync(replacementRoot)) {
+        rmSync(replacementRoot, { force: true, recursive: true });
+      }
+      if (movedOwnedRoot !== undefined && existsSync(movedOwnedRoot)) {
+        rmSync(movedOwnedRoot, { force: true, recursive: true });
+      }
+    }
+  });
+
+  if (process.platform === "win32") {
+    test("revalidates identity across bounded Windows directory-lock retries", async () => {
+      let delayedChild: ReturnType<typeof spawn> | undefined;
+      let delayedRoot: string | undefined;
+      await withOwnedTemporaryRoot(async (ownedRoot) => {
+        delayedRoot = ownedRoot;
+        delayedChild = spawn(
+          process.execPath,
+          ["-e", "process.stdout.write('ready'); setTimeout(() => {}, 2250)"],
+          {
+            cwd: ownedRoot,
+            env: process.env,
+            stdio: ["ignore", "pipe", "ignore"],
+            windowsHide: true,
+          },
+        );
+        const [ready] = await once(delayedChild.stdout!, "data");
+        expect(String(ready)).toBe("ready");
+      });
+      expect(delayedRoot).toBeDefined();
+      expect(existsSync(delayedRoot!)).toBe(false);
+      if (
+        delayedChild!.exitCode === null &&
+        delayedChild!.signalCode === null
+      ) {
+        await once(delayedChild!, "close");
+      }
+
+      let swappedChild: ReturnType<typeof spawn> | undefined;
+      let swappedRoot: string | undefined;
+      let movedRoot: string | undefined;
+      try {
+        await expect(
+          withOwnedTemporaryRoot(async (ownedRoot) => {
+            swappedRoot = ownedRoot;
+            movedRoot = `${ownedRoot}-moved`;
+            const swapSource = [
+              'const fs = require("node:fs");',
+              'const path = require("node:path");',
+              "const [root, moved] = process.argv.slice(1);",
+              "process.stdout.write('ready');",
+              "setTimeout(() => {",
+              "  process.chdir(path.dirname(root));",
+              "  fs.renameSync(root, moved);",
+              "  fs.mkdirSync(root);",
+              "  fs.writeFileSync(path.join(root, 'replacement'), 'preserve\\n');",
+              "}, 75);",
+            ].join("\n");
+            swappedChild = spawn(
+              process.execPath,
+              ["-e", swapSource, ownedRoot, movedRoot],
+              {
+                cwd: ownedRoot,
+                env: process.env,
+                stdio: ["ignore", "pipe", "ignore"],
+                windowsHide: true,
+              },
+            );
+            const [ready] = await once(swappedChild.stdout!, "data");
+            expect(String(ready)).toBe("ready");
+          }),
+        ).rejects.toThrow(/identity changed; refusing recursive cleanup/u);
+        expect(readFileSync(join(swappedRoot!, "replacement"), "utf8")).toBe(
+          "preserve\n",
+        );
+        expect(existsSync(movedRoot!)).toBe(true);
+      } finally {
+        if (
+          swappedChild !== undefined &&
+          swappedChild.exitCode === null &&
+          swappedChild.signalCode === null
+        ) {
+          await once(swappedChild, "close");
+        }
+        if (swappedRoot !== undefined && existsSync(swappedRoot)) {
+          rmSync(swappedRoot, { force: true, recursive: true });
+        }
+        if (movedRoot !== undefined && existsSync(movedRoot)) {
+          rmSync(movedRoot, { force: true, recursive: true });
+        }
+      }
+
+      let lockedChild: ReturnType<typeof spawn> | undefined;
+      let lockedRoot: string | undefined;
+      try {
+        await expect(
+          withOwnedTemporaryRoot(async (ownedRoot) => {
+            lockedRoot = ownedRoot;
+            lockedChild = spawn(
+              process.execPath,
+              [
+                "-e",
+                "process.stdout.write('ready'); setInterval(() => {}, 1000)",
+              ],
+              {
+                cwd: ownedRoot,
+                env: process.env,
+                stdio: ["ignore", "pipe", "ignore"],
+                windowsHide: true,
+              },
+            );
+            const [ready] = await once(lockedChild.stdout!, "data");
+            expect(String(ready)).toBe("ready");
+          }),
+        ).rejects.toMatchObject({ code: "EPERM" });
+        expect(lockedRoot).toBeDefined();
+        expect(existsSync(lockedRoot!)).toBe(true);
+      } finally {
+        if (
+          lockedChild !== undefined &&
+          lockedChild.exitCode === null &&
+          lockedChild.signalCode === null
+        ) {
+          lockedChild.kill("SIGKILL");
+          await once(lockedChild, "close");
+        }
+        if (lockedRoot !== undefined && existsSync(lockedRoot)) {
+          cleanupOwnedTemporaryRoot(lockedRoot);
+        }
+      }
+    }, 15_000);
+  }
+
+  test("matches the minimal Windows worker allowlist case-insensitively", () => {
+    const ownedRoot = join(tmpdir(), "agenc-fnd-windows-owned-root");
+    const workerEnvironment = createBenchmarkWorkerEnvironment(
+      {
+        cOmSpEc: "C:\\Windows\\System32\\cmd.exe",
+        sYsTeMrOoT: "C:\\Windows",
+        TEMP: "C:\\shared-ambient-temp",
+        wInDiR: "C:\\Windows",
+      },
+      "win32",
+      ownedRoot,
+    );
+    expect(workerEnvironment.SystemRoot).toBe("C:\\Windows");
+    expect(workerEnvironment).not.toHaveProperty("WINDIR");
+    expect(workerEnvironment).not.toHaveProperty("ComSpec");
+
+    const mixedCaseEnvironment = {
+      aGeNc_HoMe: ownedRoot,
+      lAnG: "C",
+      lC_aLl: "C",
+      sYsTeMrOoT: "C:\\Windows",
+      tEmP: ownedRoot,
+      tMp: ownedRoot,
+      tMpDiR: ownedRoot,
+      tSx_DiSaBlE_CaChE: "1",
+      tZ: "UTC",
+    };
+    expect(() =>
+      assertBenchmarkWorkerEnvironment(
+        mixedCaseEnvironment,
+        "win32",
+        ownedRoot,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertBenchmarkWorkerEnvironment(
+        { ...mixedCaseEnvironment, PaTh: "C:\\unbound" },
+        "win32",
+        ownedRoot,
+      ),
+    ).toThrow(/unexpected environment: PaTh/u);
+    expect(() =>
+      assertBenchmarkWorkerEnvironment(
+        { ...mixedCaseEnvironment, SYSTEMROOT: "C:\\duplicate" },
+        "win32",
+        ownedRoot,
+      ),
+    ).toThrow(/repeats a case-insensitive name/u);
+  });
+
+  test("requires empty Node execArgv", () => {
+    expect(() => assertNoBenchmarkExecArguments([])).not.toThrow();
+    for (const execArguments of [
+      ["--import", "no-op.mjs"],
+      ["--require", "no-op.cjs"],
+      ["--loader", "no-op-loader.mjs"],
+      ["--conditions=agenc-fnd-test"],
+      ["--no-warnings"],
+    ]) {
+      expect(() => assertNoBenchmarkExecArguments(execArguments)).toThrow(
+        /requires empty Node execArgv/u,
+      );
+    }
+  });
+
+  test("fails the runner closed for direct Node execution arguments", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "agenc-fnd-exec-argv-"));
+    try {
+      const modulePath = join(temporaryRoot, "no-op.mjs");
+      const commonJsPath = join(temporaryRoot, "no-op.cjs");
+      writeFileSync(modulePath, "export {};\n", "utf8");
+      writeFileSync(commonJsPath, "module.exports = {};\n", "utf8");
+      const moduleUrl = pathToFileURL(modulePath).href;
+      for (const execArguments of [
+        ["--import", moduleUrl],
+        ["--require", commonJsPath],
+        ["--loader", moduleUrl],
+        ["--conditions=agenc-fnd-test"],
+        ["--no-warnings"],
+      ]) {
+        const result = spawnSync(
+          process.execPath,
+          [...execArguments, RUNNER_PATH, "--plan"],
+          {
+            cwd: RUNTIME_ROOT,
+            encoding: "utf8",
+            env: createCleanRunnerEnvironment(),
+            maxBuffer: 2_097_152,
+            timeout: 5_000,
+            windowsHide: true,
+          },
+        );
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toMatch(/requires empty Node execArgv/u);
+      }
+    } finally {
+      rmSync(temporaryRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("detects a visible NODE_OPTIONS override after inert preload initialization", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "agenc-fnd-preload-"));
+    try {
+      const preloadPath = join(temporaryRoot, "preload.mjs");
+      writeFileSync(preloadPath, "export {};\n", "utf8");
+      const result = spawnSync(process.execPath, [RUNNER_PATH, "--plan"], {
+        cwd: RUNTIME_ROOT,
+        encoding: "utf8",
+        env: {
+          ...createCleanRunnerEnvironment(),
+          NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
+        },
+        maxBuffer: 2_097_152,
+        timeout: 5_000,
+        windowsHide: true,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(/unsafe benchmark.*NODE_OPTIONS/u);
+    } finally {
+      rmSync(temporaryRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("publishes baseline artifacts exclusively and cleans a partial pair", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-artifact-pair-"));
+    const jsonPath = join(root, "baseline.json");
+    const markdownPath = join(root, "baseline.md");
+    try {
+      writeFileSync(jsonPath, "reviewed-json", "utf8");
+      expect(() =>
+        publishBenchmarkArtifacts({
+          json: "new-json",
+          jsonPath,
+          markdown: "new-markdown",
+          markdownPath,
+        }),
+      ).toThrow(/without replacing existing files/u);
+      expect(readFileSync(jsonPath, "utf8")).toBe("reviewed-json");
+      expect(existsSync(markdownPath)).toBe(false);
+
+      rmSync(jsonPath);
+      writeFileSync(markdownPath, "reviewed-markdown", "utf8");
+      expect(() =>
+        publishBenchmarkArtifacts({
+          json: "partial-json",
+          jsonPath,
+          markdown: "new-markdown",
+          markdownPath,
+        }),
+      ).toThrow(/without replacing existing files/u);
+      expect(existsSync(jsonPath)).toBe(false);
+      expect(readFileSync(markdownPath, "utf8")).toBe("reviewed-markdown");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("binds bounded file reads to one descriptor and rejects oversize", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-bound-read-"));
+    const targetPath = join(root, "target.txt");
+    const displacedPath = join(root, "displaced.txt");
+    const maximumBytes = 64;
+    let closeCount = 0;
+    try {
+      writeFileSync(targetPath, "reviewed\n", "utf8");
+      let readAllocation: Buffer | undefined;
+      const boundedBytes = readBoundedRegularFile(
+        targetPath,
+        maximumBytes,
+        "allocation probe",
+        {
+          readSync(
+            descriptor: number,
+            buffer: Buffer,
+            offset: number,
+            length: number,
+            position: number,
+          ) {
+            readAllocation ??= buffer;
+            return readSync(descriptor, buffer, offset, length, position);
+          },
+        },
+      );
+      expect(boundedBytes.toString("utf8")).toBe("reviewed\n");
+      expect(readAllocation).toBeDefined();
+      expect(boundedBytes.buffer).toBe(readAllocation!.buffer);
+
+      expect(() =>
+        readBoundedRegularFile(targetPath, maximumBytes, "replacement probe", {
+          closeSync(descriptor: number) {
+            closeCount += 1;
+            closeSync(descriptor);
+          },
+          openSync(path: string, flags: number) {
+            renameSync(targetPath, displacedPath);
+            writeFileSync(targetPath, "replacement\n", "utf8");
+            return openSync(path, flags);
+          },
+        }),
+      ).toThrow(/changed while it was opened/u);
+      expect(closeCount).toBe(1);
+      expect(readFileSync(targetPath, "utf8")).toBe("replacement\n");
+
+      writeFileSync(targetPath, "x".repeat(maximumBytes + 1), "utf8");
+      expect(() =>
+        readBoundedRegularFile(targetPath, maximumBytes, "oversize probe"),
+      ).toThrow(/exceeds 64 bytes/u);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("never removes a replacement swapped over its first artifact", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-artifact-swap-"));
+    const jsonPath = join(root, "baseline.json");
+    const movedJsonPath = join(root, "created-json");
+    const markdownPath = join(root, "baseline.md");
+    let injected = false;
+    try {
+      expect(() =>
+        publishBenchmarkArtifacts(
+          {
+            json: "created-by-publisher",
+            jsonPath,
+            markdown: "markdown",
+            markdownPath,
+          },
+          {
+            openSync(path: string, flags: string, mode: number) {
+              if (path === markdownPath && !injected) {
+                injected = true;
+                renameSync(jsonPath, movedJsonPath);
+                writeFileSync(jsonPath, "replacement", "utf8");
+                throw new Error("injected second-artifact failure");
+              }
+              return openSync(path, flags, mode);
+            },
+          },
+        ),
+      ).toThrow(/cleanup was incomplete/u);
+      expect(readFileSync(jsonPath, "utf8")).toBe("replacement");
+      expect(readFileSync(movedJsonPath, "utf8")).toBe("created-by-publisher");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("reports an owned-artifact cleanup failure without deleting it", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-artifact-cleanup-"));
+    const jsonPath = join(root, "baseline.json");
+    const markdownPath = join(root, "baseline.md");
+    try {
+      writeFileSync(markdownPath, "existing", "utf8");
+      expect(() =>
+        publishBenchmarkArtifacts(
+          {
+            json: "created-json",
+            jsonPath,
+            markdown: "markdown",
+            markdownPath,
+          },
+          {
+            unlinkSync(path: string) {
+              if (path === jsonPath) {
+                throw new Error("injected owned-output cleanup failure");
+              }
+              rmSync(path);
+            },
+          },
+        ),
+      ).toThrow(/cleanup was incomplete/u);
+      expect(readFileSync(jsonPath, "utf8")).toBe("created-json");
+      expect(readFileSync(markdownPath, "utf8")).toBe("existing");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("handles identity, write, and sync failures after exclusive creation", () => {
+    for (const operation of [
+      "fstatSync",
+      "writeFileSync",
+      "fsyncSync",
+    ] as const) {
+      const root = mkdtempSync(join(tmpdir(), `agenc-fnd-${operation}-`));
+      const jsonPath = join(root, "baseline.json");
+      const markdownPath = join(root, "baseline.md");
+      let closeCount = 0;
+      try {
+        expect(() =>
+          publishBenchmarkArtifacts(
+            {
+              json: "json",
+              jsonPath,
+              markdown: "markdown",
+              markdownPath,
+            },
+            {
+              closeSync(descriptor: number) {
+                closeCount += 1;
+                closeSync(descriptor);
+              },
+              [operation]() {
+                throw new Error(`injected ${operation} failure`);
+              },
+            },
+          ),
+        ).toThrow();
+        expect(existsSync(jsonPath)).toBe(operation === "fstatSync");
+        expect(existsSync(markdownPath)).toBe(false);
+        expect(closeCount).toBe(1);
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    }
+  });
+
+  test("removes every ambient Git override before provenance commands", () => {
+    const ambientEnvironment: Record<string, string> = {
+      AWS_SECRET_ACCESS_KEY: "must-not-cross-the-subprocess-boundary",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.hooksPath",
+      GIT_CONFIG_VALUE_0: "/unbound/hooks",
+      GIT_DIR: "/unbound/repository",
+      HOME: "/private/home",
+      git_index_file: "/unbound/index",
+      PATH: "/known/path",
+      XAI_API_KEY: "must-not-cross-the-subprocess-boundary",
+    };
+    if (process.platform === "win32") {
+      ambientEnvironment.sYsTeMrOoT = "C:\\Windows";
+    }
+    const subprocessEnvironment = createBenchmarkSubprocessEnvironment(
+      ambientEnvironment,
+      process.platform,
+    );
+    const sanitized = createSanitizedGitEnvironment(ambientEnvironment);
+    for (const environment of [subprocessEnvironment, sanitized]) {
+      expect(environment).not.toHaveProperty("AWS_SECRET_ACCESS_KEY");
+      expect(environment).not.toHaveProperty("HOME");
+      expect(environment).not.toHaveProperty("XAI_API_KEY");
+    }
+    expect(sanitized.PATH).toBe("/known/path");
+    expect(
+      Object.keys(sanitized).filter((name) =>
+        name.toUpperCase().startsWith("GIT_"),
+      ),
+    ).toEqual([
+      "GIT_CONFIG_GLOBAL",
+      "GIT_CONFIG_NOSYSTEM",
+      "GIT_NO_REPLACE_OBJECTS",
+    ]);
+    expect(sanitized.GIT_NO_REPLACE_OBJECTS).toBe("1");
+  });
+
+  test("resolves Windows Git from bounded PATH in directory order", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-git-path-"));
+    const firstDirectory = join(root, "first directory");
+    const secondDirectory = join(root, "second-directory");
+    const firstExe = join(firstDirectory, "git.exe");
+    const firstCom = join(firstDirectory, "git.com");
+    const secondCom = join(secondDirectory, "git.com");
+    try {
+      mkdirSync(firstDirectory);
+      mkdirSync(secondDirectory);
+      writeFileSync(firstExe, "first exe\n", "utf8");
+      writeFileSync(secondCom, "second com\n", "utf8");
+      const environment = {
+        Path: `"${firstDirectory}";${secondDirectory}`,
+      };
+      expect(resolveBenchmarkGitExecutable(environment, "win32")).toBe(
+        realpathSync(firstExe),
+      );
+
+      writeFileSync(firstCom, "first com\n", "utf8");
+      expect(resolveBenchmarkGitExecutable(environment, "win32")).toBe(
+        realpathSync(firstCom),
+      );
+      expect(resolveBenchmarkGitExecutable({}, "linux")).toBe("git");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects malformed or unbounded Windows Git search paths", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-git-path-invalid-"));
+    try {
+      expect(() => resolveBenchmarkGitExecutable({}, "win32")).toThrow(
+        /PATH is malformed/u,
+      );
+      expect(() =>
+        resolveBenchmarkGitExecutable({ PATH: `"${root}` }, "win32"),
+      ).toThrow(/unmatched quote/u);
+      const excessiveEntries = Array.from({ length: 513 }, (_, index) =>
+        join(root, String(index)),
+      ).join(";");
+      expect(() =>
+        resolveBenchmarkGitExecutable({ PATH: excessiveEntries }, "win32"),
+      ).toThrow(/too many entries/u);
+      expect(() =>
+        resolveBenchmarkGitExecutable({ PATH: root }, "win32"),
+      ).toThrow(/could not resolve a regular Git executable/u);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("ignores ambient npm CLI injection at the metadata boundary", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-fnd-hostile-npm-"));
+    const hostileNpmCliPath = join(root, "hostile-npm-cli.cjs");
+    const executionMarkerPath = join(root, "executed");
+    const fakeExecutablePath = join(root, "bin", "node");
+    const fakeNpmCliPath = join(
+      root,
+      "lib",
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    const previousNpmExecPath = process.env.npm_execpath;
+    mkdirSync(join(root, "bin"), { recursive: true });
+    mkdirSync(join(root, "lib", "node_modules", "npm", "bin"), {
+      recursive: true,
+    });
+    writeFileSync(fakeExecutablePath, "fixture Node executable\n", "utf8");
+    writeFileSync(fakeNpmCliPath, "fixture npm CLI\n", "utf8");
+    writeFileSync(
+      hostileNpmCliPath,
+      `require("node:fs").writeFileSync(${JSON.stringify(executionMarkerPath)}, "executed");\n`,
+      "utf8",
+    );
+    process.env.npm_execpath = hostileNpmCliPath;
+    try {
+      expect(resolveBenchmarkNpmCliPath(fakeExecutablePath)).toBe(
+        realpathSync(fakeNpmCliPath),
+      );
+      const npmCliPath = resolveBenchmarkNpmCliPath();
+      expect(npmCliPath).not.toBe(hostileNpmCliPath);
+      expect(
+        runBoundedCommandText(process.execPath, [npmCliPath, "--version"], {
+          cwd: RUNTIME_ROOT,
+          label: "npm CLI boundary probe",
+          maxOutputBytes: 65_536,
+        }),
+      ).toMatch(/^\d+\.\d+\.\d+(?:[-+].+)?$/u);
+      expect(existsSync(executionMarkerPath)).toBe(false);
+    } finally {
+      if (previousNpmExecPath === undefined) {
+        delete process.env.npm_execpath;
+      } else {
+        process.env.npm_execpath = previousNpmExecPath;
+      }
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects host ignore and Git controls inside the fixture namespace", async () => {
+    await withOwnedTemporaryRoot(async (temporaryRoot) => {
+      const fixtureRoot = join(temporaryRoot, "fixture");
+      mkdirSync(fixtureRoot);
+      const ignorePath = join(temporaryRoot, ".ignore");
+      writeFileSync(ignorePath, "*.txt\n", "utf8");
+      expect(() => assertNoBenchmarkControlsAtOrAbove(fixtureRoot)).toThrow(
+        /inherits host \.ignore control state/u,
+      );
+      rmSync(ignorePath);
+
+      mkdirSync(join(temporaryRoot, ".git"));
+      expect(() => assertNoBenchmarkControlsAtOrAbove(fixtureRoot)).toThrow(
+        /inherits host \.git control state/u,
+      );
+    });
+  });
+
+  test("cleans a parent-owned root when a child times out before its start record", async () => {
+    let temporaryRoot: string | undefined;
+    await expect(
+      withOwnedTemporaryRoot(async (ownedRoot) => {
+        temporaryRoot = ownedRoot;
+        const result = await runBoundedChild({
+          args: ["-e", "setInterval(() => {}, 1_000)"],
+          command: process.execPath,
+          cwd: RUNTIME_ROOT,
+          env: process.env,
+          maxOutputBytes: 1_024,
+          timeoutMs: 100,
+        });
+        expect(result.timedOut).toBe(true);
+        throw new Error("worker did not emit a start record");
+      }),
+    ).rejects.toThrow(/did not emit a start record/u);
+    expect(temporaryRoot).toBeDefined();
+    expect(existsSync(temporaryRoot!)).toBe(false);
+  });
+
+  test("kills output overflow and still removes the owned root", async () => {
+    let temporaryRoot: string | undefined;
+    await expect(
+      withOwnedTemporaryRoot(async (ownedRoot) => {
+        temporaryRoot = ownedRoot;
+        await runBoundedChild({
+          args: ["-e", 'process.stdout.write("x".repeat(4_096))'],
+          command: process.execPath,
+          cwd: RUNTIME_ROOT,
+          env: process.env,
+          maxOutputBytes: 64,
+          timeoutMs: 1_000,
+        });
+      }),
+    ).rejects.toThrow(/bounded output ceiling/u);
+    expect(temporaryRoot).toBeDefined();
+    expect(existsSync(temporaryRoot!)).toBe(false);
+  });
+
+  test("holds an authenticated completed worker until contained teardown", async () => {
+    await withOwnedTemporaryRoot(async (ownedRoot) => {
+      const completionNonce = "a".repeat(64);
+      const result = await runBoundedChild({
+        args: [
+          CASE_WORKER_PATH,
+          "--case",
+          "fuzzy_tui_query_truncation",
+          "--point",
+          "0",
+          "--temporary-root",
+          ownedRoot,
+          "--completion-nonce",
+          completionNonce,
+        ],
+        command: process.execPath,
+        cwd: RUNTIME_ROOT,
+        env: createBenchmarkWorkerEnvironment(
+          process.platform === "win32"
+            ? { SystemRoot: process.env.SystemRoot ?? "C:\\Windows" }
+            : {},
+          process.platform,
+          ownedRoot,
+        ),
+        expectedCompletionRecord: `${BENCHMARK_WORKER_COMPLETION_PREFIX}${completionNonce}`,
+        maxOutputBytes: 1_048_576,
+        timeoutMs: 10_000,
+      });
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(JSON.parse(result.stdout)).toMatchObject({ status: "completed" });
+    });
+  });
+
+  test("contains an ignored-stdio descendant after normal target exit", async () => {
+    let descendantPid: number | undefined;
+    let temporaryRoot: string | undefined;
+    const detached = process.platform !== "darwin";
+    const missingCompletionRecord = `${BENCHMARK_WORKER_COMPLETION_PREFIX}${"b".repeat(64)}`;
+    const expectedContainmentError =
+      process.platform === "win32"
+        ? /before authenticated benchmark completion/u
+        : /residual_process/u;
+    const parentSource = [
+      'const { spawn } = require("node:child_process");',
+      'const { writeFileSync } = require("node:fs");',
+      'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
+      `  detached: ${JSON.stringify(detached)},`,
+      '  stdio: "ignore",',
+      "});",
+      "child.unref();",
+      'writeFileSync("descendant.pid", String(child.pid));',
+    ].join("\n");
+    try {
+      await withOwnedTemporaryRoot(async (ownedRoot) => {
+        temporaryRoot = ownedRoot;
+        try {
+          await expect(
+            runBoundedChild({
+              args: ["-e", parentSource],
+              command: process.execPath,
+              cwd: ownedRoot,
+              env: process.env,
+              expectedCompletionRecord: missingCompletionRecord,
+              maxOutputBytes: 4_096,
+              timeoutMs: 5_000,
+            }),
+          ).rejects.toThrow(expectedContainmentError);
+        } finally {
+          const descendantPidPath = join(ownedRoot, "descendant.pid");
+          if (existsSync(descendantPidPath)) {
+            descendantPid = Number(readFileSync(descendantPidPath));
+          }
+        }
+      });
+      expect(temporaryRoot).toBeDefined();
+      expect(existsSync(temporaryRoot!)).toBe(false);
+      expect(descendantPid).toBeDefined();
+      await expectProcessToExit(descendantPid!, 1_000);
+    } finally {
+      if (descendantPid !== undefined && processIsAlive(descendantPid)) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // Best-effort cleanup after a failed normal-exit containment assertion.
+        }
+      }
+      if (temporaryRoot !== undefined && existsSync(temporaryRoot)) {
+        rmSync(temporaryRoot, { force: true, recursive: true });
+      }
+    }
+  });
+
+  test("keeps standalone settlement alive through descendant cleanup", async () => {
+    const probeRoot = mkdtempSync(
+      join(tmpdir(), "agenc-fnd-standalone-settle-"),
+    );
+    const controlPath = join(probeRoot, "control.txt");
+    let descendantPid: number | undefined;
+    let ownedRoot: string | undefined;
+    const supervisorUrl = pathToFileURL(
+      join(RUNTIME_ROOT, "benchmarks/fnd/supervisor.mjs"),
+    ).href;
+    const isolationUrl = pathToFileURL(
+      join(RUNTIME_ROOT, "benchmarks/fnd/isolation.mjs"),
+    ).href;
+    const probeSource = String.raw`
+      import { appendFileSync } from "node:fs";
+      const [controlPath, supervisorUrl, isolationUrl] = process.argv.slice(1);
+      const { runBoundedChild } = await import(supervisorUrl);
+      const { withOwnedTemporaryRoot } = await import(isolationUrl);
+      const missingCompletionRecord = "AGENC_FND_BENCH_COMPLETE ${"c".repeat(64)}";
+      try {
+        await withOwnedTemporaryRoot(async (ownedRoot) => {
+          appendFileSync(controlPath, "ROOT " + ownedRoot + ";");
+          const parentSource = [
+            'const { appendFileSync } = require("node:fs");',
+            'const { spawn } = require("node:child_process");',
+            'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
+            '  detached: process.platform !== "darwin",',
+            '  stdio: "ignore",',
+            '});',
+            'child.unref();',
+            'appendFileSync(process.argv[1], "PID " + child.pid + ";");',
+          ].join("\n");
+          await runBoundedChild({
+            args: ["-e", parentSource, controlPath],
+            command: process.execPath,
+            cwd: ownedRoot,
+            env: process.env,
+            expectedCompletionRecord: missingCompletionRecord,
+            maxOutputBytes: 4_096,
+            timeoutMs: 5_000,
+          });
+        });
+        throw new Error("standalone containment probe unexpectedly succeeded");
+      } catch (error) {
+        if (!/(?:residual_process|before authenticated benchmark completion)/u.test(error.message)) {
+          throw error;
+        }
+      }
+      process.stdout.write("standalone settlement complete\n");
+    `;
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          probeSource,
+          controlPath,
+          supervisorUrl,
+          isolationUrl,
+        ],
+        {
+          cwd: RUNTIME_ROOT,
+          encoding: "utf8",
+          env: process.env,
+          maxBuffer: 65_536,
+          timeout: 10_000,
+          windowsHide: true,
+        },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("standalone settlement complete\n");
+      const control = readFileSync(controlPath, "utf8");
+      ownedRoot = /ROOT ([^;]+);/u.exec(control)?.[1];
+      descendantPid = Number(/PID (\d+);/u.exec(control)?.[1]);
+      expect(ownedRoot).toBeDefined();
+      expect(existsSync(ownedRoot!)).toBe(false);
+      expect(descendantPid).toBeGreaterThan(1);
+      await expectProcessToExit(descendantPid, 1_000);
+    } finally {
+      if (descendantPid !== undefined && processIsAlive(descendantPid)) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // Best-effort cleanup for a failed standalone regression.
+        }
+      }
+      if (ownedRoot !== undefined && existsSync(ownedRoot)) {
+        rmSync(ownedRoot, { force: true, recursive: true });
+      }
+      rmSync(probeRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("terminates ignored-stdio descendants before parent-owned cleanup", async () => {
+    let temporaryRoot: string | undefined;
+    let descendantPid: number | undefined;
+    const grandchildSource = "setInterval(() => {}, 1_000);";
+    const parentSource = [
+      'const { spawn } = require("node:child_process");',
+      `const child = spawn(process.execPath, ["-e", ${JSON.stringify(grandchildSource)}], { cwd: process.cwd(), stdio: "ignore" });`,
+      "process.stderr.write(`DESCENDANT_PID ${child.pid}\\n`);",
+      "setInterval(() => {}, 1_000);",
+    ].join("\n");
+    const startedAt = Date.now();
+    try {
+      await withOwnedTemporaryRoot(async (ownedRoot) => {
+        temporaryRoot = ownedRoot;
+        const result = await runBoundedChild({
+          args: ["-e", parentSource],
+          command: process.execPath,
+          cwd: ownedRoot,
+          env: process.env,
+          maxOutputBytes: 4_096,
+          timeoutMs: 1_000,
+        });
+        expect(result.timedOut).toBe(true);
+        const match = /DESCENDANT_PID (\d+)/u.exec(result.stderr);
+        expect(match).not.toBeNull();
+        descendantPid = Number(match![1]);
+      });
+      expect(Date.now() - startedAt).toBeLessThan(
+        1_000 + CHILD_TERMINATION_SETTLEMENT_TIMEOUT_MS + 1_000,
+      );
+      expect(temporaryRoot).toBeDefined();
+      expect(existsSync(temporaryRoot!)).toBe(false);
+      expect(descendantPid).toBeDefined();
+      await expectProcessToExit(descendantPid!, 1_000);
+    } finally {
+      if (descendantPid !== undefined && processIsAlive(descendantPid)) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // Best-effort test cleanup after a failed containment assertion.
+        }
+      }
+      if (temporaryRoot !== undefined && existsSync(temporaryRoot)) {
+        rmSync(temporaryRoot, { force: true, recursive: true });
+      }
+    }
+  });
+
+  test("propagates an injected process-tree kill failure", async () => {
+    let terminationAttempts = 0;
+    const processTreeController = {
+      isAlive(child: {
+        exitCode: number | null;
+        signalCode: NodeJS.Signals | null;
+      }) {
+        return child.exitCode === null && child.signalCode === null;
+      },
+      terminate(child: { kill(signal: NodeJS.Signals): boolean }) {
+        terminationAttempts += 1;
+        child.kill("SIGKILL");
+        throw new Error("injected process-tree kill failure");
+      },
+    };
+    await expect(
+      runBoundedChild({
+        args: ["-e", "setInterval(() => {}, 1_000)"],
+        command: process.execPath,
+        cwd: RUNTIME_ROOT,
+        env: process.env,
+        maxOutputBytes: 1_024,
+        processTreeController,
+        timeoutMs: 100,
+      }),
+    ).rejects.toThrow(/injected process-tree kill failure/u);
+    expect(terminationAttempts).toBeGreaterThan(0);
+  });
+
+  test("retains the owned root when process-tree settlement is unproven", async () => {
+    let childPid: number | undefined;
+    let retainedRoot: string | undefined;
+    let rejection: unknown;
+    const processTreeController = {
+      isAlive() {
+        throw new Error("injected liveness proof failure");
+      },
+      terminate(child: { readonly pid?: number }) {
+        childPid = child.pid;
+        throw new Error("injected process-tree kill failure");
+      },
+    };
+    try {
+      await withOwnedTemporaryRoot(async (ownedRoot) => {
+        retainedRoot = ownedRoot;
+        await runBoundedChild({
+          args: ["-e", "setInterval(() => {}, 1_000)"],
+          command: process.execPath,
+          cwd: ownedRoot,
+          env: process.env,
+          maxOutputBytes: 1_024,
+          processTreeController,
+          timeoutMs: 100,
+        });
+      });
+    } catch (error) {
+      rejection = error;
+    }
+    expect(rejection).toMatchObject({
+      message: expect.stringMatching(/process tree did not terminate/u),
+    });
+    expect(retainedOwnedTemporaryRootPath(rejection)).toBe(retainedRoot);
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining(retainedRoot!),
+    });
+    expect(retainedRoot).toBeDefined();
+    expect(existsSync(retainedRoot!)).toBe(true);
+    try {
+      if (childPid !== undefined && processIsAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+        await expectProcessToExit(childPid, 1_000);
+      }
+    } finally {
+      cleanupOwnedTemporaryRoot(retainedRoot!);
+    }
+    expect(existsSync(retainedRoot!)).toBe(false);
+  });
+
+  test("retains the owned root on a production containment result error", async () => {
+    let retainedRoot: string | undefined;
+    let rejection: unknown;
+    try {
+      try {
+        await withOwnedTemporaryRoot(async (ownedRoot) => {
+          retainedRoot = ownedRoot;
+          await runBoundedChild({
+            args: ["--injected"],
+            command: process.execPath,
+            cwd: ownedRoot,
+            env: process.env,
+            maxOutputBytes: 1_024,
+            productionContainmentRunner: async () => ({
+              backstopExpired: false,
+              error: new Error("injected cleanup proof failure"),
+              exitCode: null,
+              forced: true,
+              signal: "SIGKILL" as const,
+              stderr: Buffer.alloc(0),
+              stdout: Buffer.alloc(0),
+              stopReason: "spawn_error" as const,
+            }),
+            timeoutMs: 100,
+          });
+        });
+      } catch (error) {
+        rejection = error;
+      }
+      expect(rejection).toMatchObject({
+        message: expect.stringMatching(/injected cleanup proof failure/u),
+      });
+      expect(retainedOwnedTemporaryRootPath(rejection)).toBe(retainedRoot);
+      expect(retainedRoot).toBeDefined();
+      expect(existsSync(retainedRoot!)).toBe(true);
+    } finally {
+      if (retainedRoot !== undefined && existsSync(retainedRoot)) {
+        cleanupOwnedTemporaryRoot(retainedRoot);
+      }
+    }
+    if (retainedRoot !== undefined) {
+      expect(existsSync(retainedRoot)).toBe(false);
+    }
+  });
+
+  test("hard-kills a signal-resistant metadata process tree by its deadline", async () => {
+    const probeRoot = mkdtempSync(
+      join(tmpdir(), "agenc-fnd-metadata-deadline-"),
+    );
+    const descendantPath = join(probeRoot, "descendant.pid");
+    let descendantPid: number | undefined;
+    const detached = process.platform !== "darwin";
+    const timeoutMs = 1_000;
+    const source = [
+      'const { spawn } = require("node:child_process");',
+      'const { writeFileSync } = require("node:fs");',
+      'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
+      `  detached: ${JSON.stringify(detached)},`,
+      '  stdio: "ignore",',
+      "});",
+      "child.unref();",
+      "writeFileSync(process.argv[1], String(child.pid));",
+      'process.on("SIGTERM", () => {});',
+      "setTimeout(() => process.exit(0), 10_000);",
+    ].join("\n");
+    const startedAt = Date.now();
+    try {
+      expect(() =>
+        runBoundedCommandText(
+          process.execPath,
+          ["-e", source, descendantPath],
+          {
+            cwd: probeRoot,
+            label: "deadline probe",
+            maxOutputBytes: 4_096,
+            timeoutMs,
+          },
+        ),
+      ).toThrow(new RegExp(`${timeoutMs} ms deadline`, "u"));
+      expect(Date.now() - startedAt).toBeLessThan(
+        timeoutMs +
+          METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS +
+          METADATA_COMMAND_WORKER_OVERHEAD_MS,
+      );
+      descendantPid = Number(readFileSync(descendantPath, "utf8"));
+      expect(descendantPid).toBeGreaterThan(1);
+      await expectProcessToExit(descendantPid, 1_000);
+    } finally {
+      if (descendantPid !== undefined && processIsAlive(descendantPid)) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // Best-effort cleanup for a failed containment regression.
+        }
+      }
+      rmSync(probeRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("normalizes checkout line endings in harness evidence bindings", () => {
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "agenc-fnd-binding-review-"),
+    );
+    const repositoryRoot = join(fixtureRoot, "repository");
+    const outsideRoot = join(fixtureRoot, "outside");
+    try {
+      mkdirSync(repositoryRoot);
+      mkdirSync(outsideRoot);
+      const evidencePath = "evidence.mjs";
+      writeFileSync(
+        join(repositoryRoot, evidencePath),
+        "one\r\ntwo\r\n",
+        "utf8",
+      );
+      const bindings = collectNormalizedFileBindings(repositoryRoot, [
+        evidencePath,
+      ]);
+      writeFileSync(join(repositoryRoot, evidencePath), "one\ntwo\n", "utf8");
+      expect(() =>
+        assertBindingsStable(repositoryRoot, bindings),
+      ).not.toThrow();
+
+      writeFileSync(join(outsideRoot, evidencePath), "outside\n", "utf8");
+      symlinkSync(
+        outsideRoot,
+        join(repositoryRoot, "linked"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      expect(() =>
+        collectNormalizedFileBindings(repositoryRoot, [
+          `linked/${evidencePath}`,
+        ]),
+      ).toThrow(/escapes the repository root/u);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("detects source and harness mutation across a capture", () => {
+    const fixture = createProvenanceFixture();
+    try {
+      const options = provenanceOptions(fixture.repositoryRoot);
+      const sourceCapture = captureBenchmarkProvenance(options);
+      writeFileSync(fixture.sourcePath, "export const value = 2;\n", "utf8");
+      expect(() => verifyBenchmarkCapture(sourceCapture)).toThrow(
+        /complete production tree/u,
+      );
+
+      writeFileSync(fixture.sourcePath, FIXTURE_PRODUCTION_SOURCE, "utf8");
+      const evidenceCapture = captureBenchmarkProvenance(options);
+      writeFileSync(
+        fixture.evidencePath,
+        "export const harness = 2;\n",
+        "utf8",
+      );
+      expect(() => verifyBenchmarkCapture(evidenceCapture)).toThrow(
+        /evidence files changed/u,
+      );
+    } finally {
+      rmSync(fixture.repositoryRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects dirty, ordinary untracked, and ignored production dependencies", () => {
+    const fixture = createProvenanceFixture();
+    try {
+      const options = provenanceOptions(fixture.repositoryRoot);
+      writeFileSync(
+        fixture.dependencyPath,
+        "export const dependency = 2;\n",
+        "utf8",
+      );
+      expect(() => captureBenchmarkProvenance(options)).toThrow(
+        /complete production tree/u,
+      );
+      writeFileSync(
+        fixture.dependencyPath,
+        "export const dependency = 1;\n",
+        "utf8",
+      );
+
+      const ordinaryUntrackedPath = join(
+        fixture.repositoryRoot,
+        "source",
+        "ordinary-untracked.ts",
+      );
+      writeFileSync(ordinaryUntrackedPath, "export {};\n", "utf8");
+      expect(() => captureBenchmarkProvenance(options)).toThrow(
+        /contains untracked files/u,
+      );
+      rmSync(ordinaryUntrackedPath);
+
+      const ignoredPath = join(fixture.repositoryRoot, "source", "ignored.ts");
+      writeFileSync(ignoredPath, "export {};\n", "utf8");
+      expect(() => captureBenchmarkProvenance(options)).toThrow(
+        /contains untracked files/u,
+      );
+    } finally {
+      rmSync(fixture.repositoryRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("checks the loaded closure but ignores unrelated committed production changes", () => {
+    const fixture = createProvenanceFixture();
+    try {
+      const options = provenanceOptions(fixture.repositoryRoot);
+      const capture = captureBenchmarkProvenance(options);
+      const productionModuleClosures = bindFixtureModuleClosures(
+        capture,
+        fixture,
+      );
+      const report = {
+        evidenceBindings: capture.evidenceBindings,
+        productionModuleClosures,
+        productionTreeBinding: capture.productionTreeBinding,
+        sourceRevision: capture.sourceRevision,
+      };
+
+      writeFileSync(
+        fixture.unrelatedPath,
+        "export const unrelated = 2;\n",
+        "utf8",
+      );
+      commitFixtureChange(
+        fixture.repositoryRoot,
+        "source/unrelated.ts",
+        "change unrelated production source",
+      );
+      expect(() =>
+        verifyCheckedBenchmarkProvenance(report, options),
+      ).not.toThrow();
+
+      writeFileSync(
+        fixture.dependencyPath,
+        "export const dependency = 2;\n",
+        "utf8",
+      );
+      commitFixtureChange(
+        fixture.repositoryRoot,
+        "source/dependency.ts",
+        "change loaded dependency",
+      );
+      expect(() => verifyCheckedBenchmarkProvenance(report, options)).toThrow(
+        /current production module closure.*stale/u,
+      );
+    } finally {
+      rmSync(fixture.repositoryRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("cannot hide production changes behind Git metadata overrides", () => {
+    const fixture = createProvenanceFixture();
+    const previousIndexFile = process.env.GIT_INDEX_FILE;
+    try {
+      const alternateIndexPath = join(
+        fixture.repositoryRoot,
+        "alternate-index",
+      );
+      copyFileSync(
+        join(fixture.repositoryRoot, ".git", "index"),
+        alternateIndexPath,
+      );
+      writeFileSync(
+        fixture.dependencyPath,
+        "export const dependency = 2;\n",
+        "utf8",
+      );
+      runGit(fixture.repositoryRoot, ["add", "source/dependency.ts"]);
+      writeFileSync(
+        fixture.dependencyPath,
+        "export const dependency = 1;\n",
+        "utf8",
+      );
+      process.env.GIT_INDEX_FILE = alternateIndexPath;
+      expect(() =>
+        captureBenchmarkProvenance(provenanceOptions(fixture.repositoryRoot)),
+      ).toThrow(/complete production tree/u);
+    } finally {
+      if (previousIndexFile === undefined) {
+        delete process.env.GIT_INDEX_FILE;
+      } else {
+        process.env.GIT_INDEX_FILE = previousIndexFile;
+      }
+      rmSync(fixture.repositoryRoot, { force: true, recursive: true });
+    }
+
+    const replacementFixture = createProvenanceFixture();
+    try {
+      const originalRevision = readGitText(replacementFixture.repositoryRoot, [
+        "rev-parse",
+        "HEAD",
+      ]);
+      writeFileSync(
+        replacementFixture.dependencyPath,
+        "export const dependency = 2;\n",
+        "utf8",
+      );
+      commitFixtureChange(
+        replacementFixture.repositoryRoot,
+        "source/dependency.ts",
+        "create replacement production tree",
+      );
+      const replacementRevision = readGitText(
+        replacementFixture.repositoryRoot,
+        ["rev-parse", "HEAD"],
+      );
+      runGit(replacementFixture.repositoryRoot, [
+        "replace",
+        originalRevision,
+        replacementRevision,
+      ]);
+      runGit(replacementFixture.repositoryRoot, [
+        "reset",
+        "--hard",
+        originalRevision,
+      ]);
+
+      expect(readFileSync(replacementFixture.dependencyPath, "utf8")).toBe(
+        "export const dependency = 2;\n",
+      );
+      expect(() =>
+        captureBenchmarkProvenance(
+          provenanceOptions(replacementFixture.repositoryRoot),
+        ),
+      ).toThrow(/complete production tree/u);
+    } finally {
+      rmSync(replacementFixture.repositoryRoot, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
+  test("ties a checked source revision to a real ancestor and its blobs", () => {
+    const fixture = createProvenanceFixture();
+    try {
+      const options = provenanceOptions(fixture.repositoryRoot);
+      const capture = captureBenchmarkProvenance(options);
+      const productionModuleClosures = bindFixtureModuleClosures(
+        capture,
+        fixture,
+      );
+      expect(() =>
+        verifyCheckedBenchmarkProvenance(
+          {
+            evidenceBindings: capture.evidenceBindings,
+            productionModuleClosures,
+            productionTreeBinding: capture.productionTreeBinding,
+            sourceRevision: capture.sourceRevision,
+          },
+          options,
+        ),
+      ).not.toThrow();
+      const wrongClosure = structuredClone(productionModuleClosures);
+      wrongClosure[0]!.modules[0]!.sha256 = "0".repeat(64);
+      expect(() =>
+        verifyCheckedBenchmarkProvenance(
+          {
+            evidenceBindings: capture.evidenceBindings,
+            productionModuleClosures: wrongClosure,
+            productionTreeBinding: capture.productionTreeBinding,
+            sourceRevision: capture.sourceRevision,
+          },
+          options,
+        ),
+      ).toThrow(/does not match its Git revision/u);
+      expect(() =>
+        verifyCheckedBenchmarkProvenance(
+          {
+            evidenceBindings: capture.evidenceBindings,
+            productionModuleClosures,
+            productionTreeBinding: capture.productionTreeBinding,
+            sourceRevision: "0".repeat(40),
+          },
+          options,
+        ),
+      ).toThrow(/not a local Git commit/u);
+
+      const wrongTree = structuredClone(capture.productionTreeBinding);
+      wrongTree.gitObjectId = "0".repeat(40);
+      expect(() =>
+        verifyCheckedBenchmarkProvenance(
+          {
+            evidenceBindings: capture.evidenceBindings,
+            productionModuleClosures,
+            productionTreeBinding: wrongTree,
+            sourceRevision: capture.sourceRevision,
+          },
+          options,
+        ),
+      ).toThrow(/tree binding/u);
+    } finally {
+      rmSync(fixture.repositoryRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+function createCleanRunnerEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...process.env };
+  for (const name of Object.keys(environment)) {
+    const normalizedName = name.toUpperCase();
+    if (
+      normalizedName.startsWith("NODE_") ||
+      normalizedName.startsWith("TSX_")
+    ) {
+      delete environment[name];
+    }
+  }
+  return environment;
+}
+
+function createProvenanceFixture(): {
+  readonly dependencyPath: string;
+  readonly evidencePath: string;
+  readonly repositoryRoot: string;
+  readonly sourcePath: string;
+  readonly unrelatedPath: string;
+} {
+  const repositoryRoot = mkdtempSync(
+    join(tmpdir(), "agenc-fnd-provenance-review-"),
+  );
+  const sourceRelativePath = "source/production.ts";
+  const dependencyRelativePath = "source/dependency.ts";
+  const unrelatedRelativePath = "source/unrelated.ts";
+  const evidenceRelativePath = "harness/runner.mjs";
+  const sourcePath = join(repositoryRoot, sourceRelativePath);
+  const dependencyPath = join(repositoryRoot, dependencyRelativePath);
+  const unrelatedPath = join(repositoryRoot, unrelatedRelativePath);
+  const evidencePath = join(repositoryRoot, evidenceRelativePath);
+  mkdirSync(join(repositoryRoot, "source"));
+  mkdirSync(join(repositoryRoot, "harness"));
+  writeFileSync(sourcePath, FIXTURE_PRODUCTION_SOURCE, "utf8");
+  writeFileSync(dependencyPath, "export const dependency = 1;\n", "utf8");
+  writeFileSync(unrelatedPath, "export const unrelated = 1;\n", "utf8");
+  writeFileSync(evidencePath, "export const harness = 1;\n", "utf8");
+  writeFileSync(
+    join(repositoryRoot, ".gitignore"),
+    "source/ignored.ts\n",
+    "utf8",
+  );
+  runGit(repositoryRoot, ["init"]);
+  runGit(repositoryRoot, [
+    "add",
+    ".gitignore",
+    sourceRelativePath,
+    dependencyRelativePath,
+    unrelatedRelativePath,
+  ]);
+  runGit(repositoryRoot, [
+    "-c",
+    "user.name=AgenC Test",
+    "-c",
+    "user.email=test@agenc.invalid",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "-m",
+    "test fixture",
+  ]);
+  return {
+    dependencyPath,
+    evidencePath,
+    repositoryRoot,
+    sourcePath,
+    unrelatedPath,
+  };
+}
+
+function provenanceOptions(repositoryRoot: string): {
+  readonly evidencePaths: readonly string[];
+  readonly productionTreePath: string;
+  readonly repositoryRoot: string;
+} {
+  return {
+    evidencePaths: ["harness/runner.mjs"],
+    productionTreePath: "source",
+    repositoryRoot,
+  };
+}
+
+function bindFixtureModuleClosures(
+  capture: ReturnType<typeof captureBenchmarkProvenance>,
+  fixture: ReturnType<typeof createProvenanceFixture>,
+): ReturnType<typeof bindProductionModuleClosures> {
+  return bindProductionModuleClosures(capture, [
+    {
+      caseId: "fixture_case",
+      paths: observeFixtureModulePaths(fixture),
+    },
+  ]);
+}
+
+function observeFixtureModulePaths(
+  fixture: ReturnType<typeof createProvenanceFixture>,
+): string[] {
+  const repositoryAlias = `${fixture.repositoryRoot}-module-alias`;
+  const probeSource = [
+    'import { pathToFileURL } from "node:url";',
+    "const trackerModule = await import(pathToFileURL(process.argv[1]).href);",
+    "const tracker = trackerModule.registerProductionModuleTracker({",
+    "  productionRoot: process.argv[3],",
+    "  repositoryRoot: process.argv[2],",
+    "  writeRecord(record) { process.stdout.write(record); },",
+    "});",
+    "await import(pathToFileURL(process.argv[4]).href);",
+    "await new Promise(setImmediate);",
+    "await tracker.close();",
+  ].join("\n");
+  const probeEnvironment: Record<string, string> = {
+    LANG: "C",
+    LC_ALL: "C",
+    TSX_DISABLE_CACHE: "1",
+    TZ: "UTC",
+  };
+  if (process.platform === "win32") {
+    probeEnvironment.SystemRoot = process.env.SystemRoot ?? "C:\\Windows";
+    if (process.env.WINDIR !== undefined) {
+      probeEnvironment.WINDIR = process.env.WINDIR;
+    }
+  }
+  let output: string;
+  try {
+    symlinkSync(
+      fixture.repositoryRoot,
+      repositoryAlias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    output = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        probeSource,
+        MODULE_TRACKER_PATH,
+        repositoryAlias,
+        join(repositoryAlias, "source"),
+        join(repositoryAlias, "source/production.ts"),
+      ],
+      {
+        cwd: fixture.repositoryRoot,
+        encoding: "utf8",
+        env: probeEnvironment,
+        maxBuffer: 65_536,
+        timeout: 5_000,
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(repositoryAlias, { force: true, recursive: true });
+  }
+  return output
+    .trim()
+    .split(/\r?\n/u)
+    .map((line) => {
+      expect(line).toMatch(
+        new RegExp(`^${PRODUCTION_MODULE_RECORD_PREFIX}`, "u"),
+      );
+      return (
+        JSON.parse(line.slice(PRODUCTION_MODULE_RECORD_PREFIX.length)) as {
+          path: string;
+        }
+      ).path;
+    })
+    .sort();
+}
+
+function commitFixtureChange(
+  repositoryRoot: string,
+  path: string,
+  message: string,
+): void {
+  runGit(repositoryRoot, ["add", path]);
+  runGit(repositoryRoot, [
+    "-c",
+    "user.name=AgenC Test",
+    "-c",
+    "user.email=test@agenc.invalid",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "-m",
+    message,
+  ]);
+}
+
+async function expectProcessToExit(
+  pid: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processIsAlive(pid)) return;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+  }
+  throw new Error(`descendant process ${pid} remained alive after containment`);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+}
+
+function runGit(repositoryRoot: string, args: readonly string[]): void {
+  execFileSync("git", args, {
+    cwd: repositoryRoot,
+    maxBuffer: 65_536,
+    stdio: "ignore",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+}
+
+function readGitText(repositoryRoot: string, args: readonly string[]): string {
+  return execFileSync("git", args, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    maxBuffer: 65_536,
+    timeout: 5_000,
+    windowsHide: true,
+  }).trim();
+}

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -61,6 +61,7 @@ const NATIVE_TEST_FILES = [
 ] as const;
 
 const HOSTED_FND_TEST_FILES = [
+  "tests/fnd/benchmark-harness-faults.test.ts",
   "tests/fnd/bounded-file-io.test.ts",
   "tests/fnd/fnd-fixtures.test.ts",
   "tests/fnd/portable-repository-path.test.ts",

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -255,8 +255,10 @@ describe("reproducible install and release contract", () => {
     for (const inventory of [
       "45 passing macOS tests in eight suites across five files",
       "47 passing Windows tests in ten suites across six files",
-      "shared 44-test, seven-suite, four-file FND set",
-      "49 tests, eleven suites, and seven files",
+      "same 44-test, seven-suite, four-file FND set",
+      "shared 80-test, eight-suite, five-file FND set",
+      "81 tests, ten suites, and six files",
+      "86 tests, thirteen suites, and eight files",
     ]) {
       expect(normalizedCiRequiredGates).toContain(inventory);
     }
@@ -407,6 +409,9 @@ describe("reproducible install and release contract", () => {
     expect(macosJob).toContain(
       "Run the exact macOS FND/native capability lane",
     );
+    expect(macosJob).toContain(
+      "tests/fnd/benchmark-harness-faults.test.ts",
+    );
     expect(macosJob).toContain("tests/fnd/bounded-file-io.test.ts");
     expect(macosJob).toContain("tests/fnd/fnd-fixtures.test.ts");
     expect(macosJob).toContain("tests/fnd/portable-repository-path.test.ts");
@@ -415,10 +420,10 @@ describe("reproducible install and release contract", () => {
     );
     expect(macosJob).toContain("tests/tools/runtimes/runtime.darwin.test.ts");
     expect(macosJob).toContain("--config vitest.native.config.ts");
-    expect(macosJob).toContain("numTotalTestSuites: 8");
-    expect(macosJob).toContain("numTotalTests: 45");
+    expect(macosJob).toContain("numTotalTestSuites: 10");
+    expect(macosJob).toContain("numTotalTests: 81");
     expect(macosJob).toContain(
-      "macOS FND/native capability lane passed 45 tests in 5 files with zero skipped",
+      "macOS FND/native capability lane passed 81 tests in 6 files with zero skipped",
     );
 
     const windowsJob = workflow.slice(workflow.indexOf("\n  windows-native:"));
@@ -435,6 +440,9 @@ describe("reproducible install and release contract", () => {
     expect(windowsJob).toContain(
       "tests/durability/atomic-artifact.win32.test.ts",
     );
+    expect(windowsJob).toContain(
+      "tests/fnd/benchmark-harness-faults.test.ts",
+    );
     expect(windowsJob).toContain("tests/fnd/bounded-file-io.test.ts");
     expect(windowsJob).toContain("tests/fnd/fnd-fixtures.test.ts");
     expect(windowsJob).toContain("tests/fnd/portable-repository-path.test.ts");
@@ -443,8 +451,8 @@ describe("reproducible install and release contract", () => {
     );
     expect(windowsJob).toContain("tests/utils/execFileNoThrow.win32.test.ts");
     expect(windowsJob).toContain("--config vitest.native.config.ts");
-    expect(windowsJob).toContain("numTotalTestSuites: 11");
-    expect(windowsJob).toContain("numTotalTests: 49");
+    expect(windowsJob).toContain("numTotalTestSuites: 13");
+    expect(windowsJob).toContain("numTotalTests: 86");
     expect(windowsJob).toContain(
       "npm.cmd ci --ignore-scripts --no-audit --no-fund",
     );
@@ -454,7 +462,7 @@ describe("reproducible install and release contract", () => {
     );
     expect(windowsJob).not.toContain("npm_config_build_from_source");
     expect(windowsJob).toContain(
-      "Windows FND/native capability lane passed 49 tests in 7 files with zero skipped",
+      "Windows FND/native capability lane passed 86 tests in 8 files with zero skipped",
     );
 
     expect(
@@ -491,7 +499,12 @@ describe("reproducible install and release contract", () => {
         join(workspace, target).replaceAll("\\", "/"),
       );
     });
-    const lfSubjects = [...binSubjects, "package-lock.json"];
+    const lfSubjects = [
+      ...binSubjects,
+      "package-lock.json",
+      "runtime/benchmarks/fnd/baseline.v1.json",
+      "runtime/benchmarks/fnd/baseline.v1.md",
+    ];
     const attributes = execFileSync(
       "git",
       ["check-attr", "eol", "--", ...lfSubjects],

--- a/runtime/tsconfig.test-support.json
+++ b/runtime/tsconfig.test-support.json
@@ -50,6 +50,8 @@
     "tests/helpers/seeded-rng.ts",
     "tests/helpers/temp-workspace.ts",
     "tests/helpers/unicode-15-1-repertoire.ts",
+    "tests/fnd/benchmark-baselines.contract.test.ts",
+    "tests/fnd/benchmark-harness-faults.test.ts",
     "tests/fnd/bounded-file-io.test.ts",
     "tests/fnd/bounded-repository-git.test.ts",
     "tests/fnd/bounded-repository-transaction-races.test.ts",

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -125,6 +125,7 @@ export const NATIVE_TEST_INCLUDE = Object.freeze([
 
 /** Portable FND contracts repeated by every supported native builder. */
 export const HOSTED_FND_TEST_INCLUDE = Object.freeze([
+  'tests/fnd/benchmark-harness-faults.test.ts',
   'tests/fnd/bounded-file-io.test.ts',
   'tests/fnd/fnd-fixtures.test.ts',
   'tests/fnd/portable-repository-path.test.ts',


### PR DESCRIPTION
## Summary

- add a deterministic, resource-bounded FND benchmark harness and checked baseline artifacts for critical runtime paths
- bind measurements to exact Git/source/evidence provenance with dirty-tree, mutation, symlink, process, timeout, and output-integrity defenses
- add cross-platform hosted inventory coverage and fail-closed discovery/count tripwires
- canonicalize module-closure roots and loaded URLs so filesystem aliases cannot suppress provenance records
- resolve benchmark Git explicitly on Windows from a bounded sanitized PATH and revalidate owned-root identity across bounded cleanup retries

## Validation

- npm test under Node 26.5.0: 1,930 files and 17,472 tests, all passing
- benchmark contract/fault and reproducible-build set: 60/60 after the substantive fix
- Windows hosted execution: all 86 tests passed; its measured 13-suite inventory is pinned
- full runtime and test-support typechecks
- benchmark baseline validation
- mandatory pre-commit build and all PTY startup smokes
- independent exact-head review: no findings

## Evidence

- reviewed head: 55fb26d40951487ce5cbfd278e5c2a7badf382fc
- production source revision measured: 925f3ec2860abf48e0c6c0830d135da2587a4d69
- baseline JSON SHA-256: 8c72fc88fd10dfde2f91bd7cc3ce8028af552781b7b699db9931529cac0abd07
- baseline Markdown SHA-256: 52e31669f46192c9f99b0ee83737fbe13a53c987fef5f2e25230092753161388
- shared hosted native set: 80 tests; macOS: 81 tests in 10 suites/6 files; Windows: 86 tests in 13 suites/8 files
- all nine hosted jobs, including real macOS and Windows native lanes, must pass on this exact head before merge

No release is part of this change.