### PR TITLE
test(runtime): add authenticated red-probe harness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,10 @@ package-lock.json text eol=lf
 # digest and canonical-JSON checks require LF on every supported checkout.
 runtime/benchmarks/fnd/baseline.v1.json text eol=lf
 runtime/benchmarks/fnd/baseline.v1.md text eol=lf
+
+# The red-probe runner authenticates these exact reviewed source bytes. Keep
+# every digest-bound support file and registered probe stable on Windows.
+runtime/tests/helpers/red-probe-bootstrap.mjs text eol=lf
+runtime/tests/helpers/red-probe.ts text eol=lf
+runtime/tests/fnd/red-probes/*.red-probe.ts text eol=lf
+runtime/tests/fnd/red-probes/**/*.red-probe.ts text eol=lf

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -968,6 +968,65 @@ jobs:
           npm_config_build_from_source=true \
             npm rebuild better-sqlite3 esbuild node-pty
 
+      - name: Run the exact macOS red-probe runner contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="$RUNNER_TEMP/macos-red-probe-runner.json"
+          node runtime/scripts/run-hermetic-vitest.mjs \
+            --require-zero-skips \
+            run \
+            tests/fnd/red-probe-runner.contract.test.ts \
+            --allowOnly=false \
+            --reporter=verbose \
+            --reporter=json \
+            --outputFile.json "$results"
+          node --input-type=module - "$results" <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing macOS red-probe results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const exactCounts = {
+            numTotalTests: 62,
+            numPassedTests: 62,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `macOS red-probe result ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (
+            results.success !== true ||
+            !Array.isArray(results.testResults) ||
+            results.testResults.length !== 1
+          ) {
+            throw new Error("macOS red-probe result did not report one successful file");
+          }
+          const [testResult] = results.testResults;
+          const file = relative(resolve("runtime"), testResult.name)
+            .split("\\").join("/");
+          if (file !== "tests/fnd/red-probe-runner.contract.test.ts") {
+            throw new Error(`unexpected macOS red-probe file: ${file}`);
+          }
+          if (
+            testResult.status !== "passed" ||
+            !Array.isArray(testResult.assertionResults) ||
+            testResult.assertionResults.length !== 62 ||
+            testResult.assertionResults.some(({ status }) => status !== "passed")
+          ) {
+            throw new Error("macOS red-probe assertions were not exactly 62 passes");
+          }
+          console.log("macOS red-probe runner passed 62 tests in 1 file with zero skipped");
+          NODE
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
       - name: Run the exact macOS FND/native capability lane
         shell: bash
         run: |
@@ -1097,6 +1156,93 @@ jobs:
           $ErrorActionPreference = "Stop"
           & npm.cmd run build --workspace=@tetsuo-ai/runtime
           if ($LASTEXITCODE -ne 0) { throw "runtime build failed" }
+
+      - name: Run the exact Windows FND red-probe audit
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $redProbeOutput = & node runtime/scripts/run-fnd-red-probes.mjs
+          if ($LASTEXITCODE -ne 0) { throw "Windows red-probe audit failed" }
+          $expectedRedProbeOutput = `
+            "red probes: files=1 expected-red=1 assertions=1 skipped=0 todo=0"
+          if (($redProbeOutput | Out-String).Trim() -ne $expectedRedProbeOutput) {
+            throw "Windows red-probe result contract failed: $redProbeOutput"
+          }
+          if (-not [string]::IsNullOrWhiteSpace(
+            (git status --porcelain=v1 --untracked-files=all | Out-String)
+          )) {
+            throw "Windows red-probe audit dirtied the checkout"
+          }
+
+      - name: Run the exact Windows FND forced-containment contracts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $results = Join-Path $env:RUNNER_TEMP "windows-red-probe-containment.json"
+          & node runtime/scripts/run-hermetic-vitest.mjs `
+            --require-zero-skips `
+            run `
+            tests/fnd/red-probe-containment.test.ts `
+            --allowOnly=false `
+            --reporter=verbose `
+            --reporter=json `
+            --outputFile.json $results
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows red-probe forced-containment contracts failed"
+          }
+          @'
+          import { readFileSync } from "node:fs";
+          import { relative, resolve } from "node:path";
+
+          const [resultsPath] = process.argv.slice(2);
+          if (!resultsPath) throw new Error("missing red-probe containment results path");
+          const results = JSON.parse(readFileSync(resultsPath, "utf8"));
+          const exactCounts = {
+            numFailedTestSuites: 0,
+            numPendingTestSuites: 0,
+            numTotalTests: 3,
+            numPassedTests: 3,
+            numFailedTests: 0,
+            numPendingTests: 0,
+            numTodoTests: 0,
+          };
+          for (const [field, value] of Object.entries(exactCounts)) {
+            if (results[field] !== value) {
+              throw new Error(
+                `Windows red-probe containment ${field} was ${results[field]}, expected ${value}`,
+              );
+            }
+          }
+          if (results.success !== true || !Array.isArray(results.testResults)) {
+            throw new Error("Windows red-probe containment did not report one successful file");
+          }
+          const expectedFiles = ["tests/fnd/red-probe-containment.test.ts"];
+          const testResults = results.testResults;
+          const files = testResults
+            .map(({ name }) => relative(resolve("runtime"), name).split("\\").join("/"))
+            .sort();
+          if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+            throw new Error(`unexpected Windows red-probe containment files: ${JSON.stringify(files)}`);
+          }
+          const assertions = testResults[0].assertionResults;
+          if (
+            testResults[0].status !== "passed" ||
+            !Array.isArray(assertions) ||
+            assertions.length !== 3 ||
+            assertions.some(({ status }) => status !== "passed")
+          ) {
+            throw new Error("Windows red-probe containment assertions were not exactly three passes");
+          }
+          console.log("Windows red-probe containment passed 3 tests in 1 file with zero skipped");
+          '@ | node --input-type=module - $results
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows red-probe forced-containment result contract failed"
+          }
+          if (-not [string]::IsNullOrWhiteSpace(
+            (git status --porcelain=v1 --untracked-files=all | Out-String)
+          )) {
+            throw "Windows red-probe forced-containment dirtied the checkout"
+          }
 
       - name: Run the exact Windows FND/native capability lane
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ obj/
 /.wallet/
 *.json
 !/runtime/tests/fnd/fixtures/**/*.json
+!/runtime/tests/fnd/red-probes/manifest.json
 !/package-lock.json
 !/release-toolchain.json
 !/runtime/tsconfig.bundle.json

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -45,9 +45,11 @@ npm run check:sbom
 npm run check:tui-runtime-startup --workspace=@tetsuo-ai/runtime
 ```
 
-`npm test` contains the runtime typecheck and stable Vitest suite. The final
-startup command exercises the built TUI/daemon path in real PTYs. Run additional
-task-specific regression tests before this complete final-head sequence.
+`npm test` contains the runtime and test-support typechecks, the separate
+expected-red probe audit, and the stable Vitest suite, in that order. The final
+startup command exercises the built TUI/daemon path in real PTYs. Run
+additional task-specific regression tests before this complete final-head
+sequence.
 
 The evidence must contain:
 
@@ -231,17 +233,17 @@ It requires Linux, Node.js 26.5.0, npm 11.17.0, a clean checkout, and an exact
 lowercase 40-character commit. In this optional design, the authoritative
 deployment runs each gate in its own transient systemd cgroup.
 
-| Order | Gate                                               |  Bound | Candidate write access      |
-| ----: | -------------------------------------------------- | -----: | --------------------------- |
-|     1 | SDK build (includes strict TypeScript compilation) |  5 min | SDK `dist`                  |
-|     2 | Launcher package tests                             |  5 min | private state only          |
-|     3 | Local-gate policy tests                            |  5 min | private state only          |
-|     4 | Agent-surface checker tests                        |  5 min | Vite temp only              |
-|     5 | Hermetic runtime typecheck and stable Vitest suite | 20 min | private state and Vite temp |
-|     6 | Agent-surface structural contract                  |  5 min | private state only          |
-|     7 | Runtime build and declarations                     | 10 min | runtime `dist`              |
-|     8 | Deterministic SPDX SBOM check                      |  5 min | private state only          |
-|     9 | PTY/TUI built-runtime startup smoke                | 10 min | private state only          |
+| Order | Gate                                                                               |  Bound | Candidate write access      |
+| ----: | ---------------------------------------------------------------------------------- | -----: | --------------------------- |
+|     1 | SDK build (includes strict TypeScript compilation)                                 |  5 min | SDK `dist`                  |
+|     2 | Launcher package tests                                                             |  5 min | private state only          |
+|     3 | Local-gate policy tests                                                            |  5 min | private state only          |
+|     4 | Agent-surface checker tests                                                        |  5 min | Vite temp only              |
+|     5 | Hermetic runtime/test-support typechecks, red-probe audit, and stable Vitest suite | 20 min | private state and Vite temp |
+|     6 | Agent-surface structural contract                                                  |  5 min | private state only          |
+|     7 | Runtime build and declarations                                                     | 10 min | runtime `dist`              |
+|     8 | Deterministic SPDX SBOM check                                                      |  5 min | private state only          |
+|     9 | PTY/TUI built-runtime startup smoke                                                | 10 min | private state only          |
 
 The stable suite already runs the agent-surface Vitest files, so gate 6 uses
 `--no-run-commands`; it validates the versioned surface ledger without running
@@ -250,7 +252,8 @@ miss a transitive daemon, launcher, generated-code, or build change.
 
 There are no duplicate compiler passes: the SDK build is its typecheck, and the
 hermetic stable-suite container performs the authoritative runtime `tsc
---noEmit` immediately before Vitest.
+--noEmit`, the dedicated test-support `tsc --noEmit`, and the red-probe audit
+before Vitest.
 
 The SDK output is frozen root-owned immediately after its build. The final
 runtime output is likewise frozen after the runtime build. Every later gate
@@ -276,6 +279,13 @@ release verifiers, App/ruleset policy, systemd sandbox builders, hermetic
 boundary, TUI supervisor, and their policy tests. The root-installed supervisor
 compares a candidate digest with the reviewed root-owned approval before
 `npm ci`. A PR cannot approve its own gate-policy change.
+
+The red-probe portion of that fixed inventory is fail-closed and exact: it
+includes the runner, manifest, helper, bootstrap, supervised-process
+implementation, Linux subreaper broker source, and Windows Job Object broker
+source. Contract tests remove each member in turn and require the policy-closure
+check to fail, so containment or handoff code cannot silently fall outside the
+approved digest.
 
 ## Inactive optional worker and publisher trust boundaries
 
@@ -911,19 +921,25 @@ fixtures, fixed telemetry/update opt-outs, and an asserted no-process-leak
 postcondition; this narrow lane is not an OS egress boundary.
 The `neovim` job similarly provisions the official digest- and byte-pinned
 Neovim 0.12.1 Linux binary and requires all four real-process lifecycle tests
-in its one-file allowlist. The `macos-native` and `windows-native` jobs first
-run a shared 80-test, eight-suite, five-file FND set. It combines the 44-test
-release-builder set with 36 benchmark-harness fault contracts for process-tree
-containment, owned-root retention, exclusive artifact publication, minimal
-subprocess environments, bounded metadata commands, and provenance binding.
-The macOS job adds one Seatbelt test for an exact total of 81 tests, ten
-suites, and six files. The Windows PR job adds its named-pipe and
-atomic-publication/`.cmd` contracts for an exact total of 86 tests, thirteen
-suites, and eight files. Release builders deliberately retain their narrower
-44-test shared set: the Windows release subset excludes the two named-pipe-only
-PR tests and the benchmark fault contract, so it remains 47 tests, ten suites,
-and six files. Every result parser requires its exact reviewed suite, test, and
-file counts with no failed, pending, skipped, or todo tests.
+in its one-file allowlist. The `macos-native` job first runs the 62-test
+red-probe runner contract, including residual-process settlement on Darwin.
+The macOS and Windows native jobs then run a shared 80-test, eight-suite,
+five-file FND set. It combines the 44-test release-builder set with 36
+benchmark-harness fault contracts for process-tree containment, owned-root
+retention, exclusive artifact publication, minimal subprocess environments,
+bounded metadata commands, and provenance binding. macOS adds one Seatbelt test
+for an exact total of 81 tests, ten suites, and six files. Before its native
+allowlist, Windows requires the exact one-file FND red-probe audit summary and
+runs three forced-containment tests in one file. Its named-pipe and
+atomic-publication/`.cmd` contracts bring the native total to 86 tests,
+thirteen suites, and eight files. Release builders deliberately retain their
+narrower 44-test shared set: the Windows release subset excludes the two
+named-pipe-only PR tests and the benchmark fault contract, so it remains 47
+tests, ten suites, and six files. Native result parsers require the exact
+reviewed suite, test, and normalized file inventory with no failed, pending,
+skipped, or todo tests. The red-containment parser additionally requires
+exactly three passing per-file assertions while accepting Vitest's
+reporter-dependent suite aggregation.
 
 This narrow hosted check supplements the local required gate; it does not
 replace or authorize the broader test, typecheck, build, TUI, or release

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:cross-repo": "npm run test:cross-repo --workspace=@tetsuo-ai/runtime",
     "test:live": "npm run test:live --workspace=@tetsuo-ai/runtime --",
     "test:bun": "npm run test:bun:isolated --workspace=@tetsuo-ai/runtime",
+    "test:red-probes": "npm run test:red-probes --workspace=@tetsuo-ai/runtime",
     "test:coverage": "npm run test:coverage --workspace=@tetsuo-ai/runtime",
     "check:unused": "npm run check:unused --workspace=@tetsuo-ai/runtime",
     "typecheck": "npm run typecheck --workspace=@tetsuo-ai/runtime",

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.383903,
-            "maxMs": 10.894199,
-            "medianMs": 5.985377,
-            "minMs": 5.55261,
+            "madMs": 0.711511,
+            "maxMs": 10.544538,
+            "medianMs": 6.947934,
+            "minMs": 5.983129,
             "sampleCount": 5,
             "samplesMs": [
-              5.985377,
-              6.318093,
-              5.55261,
-              5.601474,
-              10.894199
+              6.947934,
+              7.659445,
+              5.983129,
+              6.303465,
+              10.544538
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92852224,
+              "maximumObservedBytes": 90243072,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82366464,
-                86036480,
-                87085056,
-                87085056,
-                88133632,
-                88133632,
-                88657920,
-                88657920,
-                88657920,
-                88657920,
-                92852224
+                79171584,
+                83890176,
+                84414464,
+                84414464,
+                85463040,
+                85463040,
+                85987328,
+                85987328,
+                85987328,
+                85987328,
+                90243072
               ]
             },
-            "peakRssBytes": 92852224,
+            "peakRssBytes": 90243072,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.569425,
-            "maxMs": 23.417776,
-            "medianMs": 16.19761,
-            "minMs": 14.296411,
+            "madMs": 1.824162,
+            "maxMs": 24.748634,
+            "medianMs": 17.554716,
+            "minMs": 13.459926,
             "sampleCount": 5,
             "samplesMs": [
-              15.628185,
-              16.19761,
-              23.417776,
-              16.361469,
-              14.296411
+              19.378878,
+              16.308613,
+              24.748634,
+              17.554716,
+              13.459926
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 122150912,
+              "maximumObservedBytes": 120401920,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82829312,
-                88072192,
-                89645056,
-                89645056,
-                96985088,
-                96985088,
-                112189440,
-                112189440,
-                122150912,
-                122150912,
-                122150912
+                82317312,
+                87560192,
+                88084480,
+                88084480,
+                95236096,
+                95236096,
+                110964736,
+                110964736,
+                119877632,
+                119877632,
+                120401920
               ]
             },
-            "peakRssBytes": 122150912,
+            "peakRssBytes": 120401920,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.025889,
-            "maxMs": 65.404986,
-            "medianMs": 38.80299,
-            "minMs": 37.777101,
+            "madMs": 2.893866,
+            "maxMs": 71.161077,
+            "medianMs": 43.802899,
+            "minMs": 40.906059,
             "sampleCount": 5,
             "samplesMs": [
-              65.404986,
-              42.75011,
-              38.80299,
-              38.383653,
-              37.777101
+              71.161077,
+              46.696765,
+              43.802899,
+              41.833687,
+              40.906059
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 136294400,
+              "maximumObservedBytes": 132947968,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82853888,
-                99106816,
-                131612672,
-                132136960,
-                133185536,
-                133185536,
-                133185536,
-                133185536,
-                134758400,
-                134758400,
-                136294400
+                81768448,
+                98545664,
+                125808640,
+                125808640,
+                126857216,
+                126857216,
+                128954368,
+                128954368,
+                130322432,
+                130322432,
+                132947968
               ]
             },
-            "peakRssBytes": 136331264,
+            "peakRssBytes": 132947968,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.773696,
-            "maxMs": 11.63169,
-            "medianMs": 6.688927,
-            "minMs": 5.594454,
+            "madMs": 0.371324,
+            "maxMs": 12.516423,
+            "medianMs": 6.020956,
+            "minMs": 5.649632,
             "sampleCount": 5,
             "samplesMs": [
-              5.594454,
-              5.915231,
-              11.63169,
-              6.752614,
-              6.688927
+              5.989518,
+              6.020956,
+              12.516423,
+              6.734951,
+              5.649632
             ]
           },
           "fixtureDigest": "20e6f251f058537fb579b40427cfc4c69a025d8da738d498863815d41a88f6b7",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 123228160,
+              "maximumObservedBytes": 121593856,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82333696,
-                97013760,
-                98586624,
-                98586624,
-                99635200,
-                99635200,
-                119033856,
-                119033856,
-                119558144,
-                119558144,
-                123228160
+                83320832,
+                97476608,
+                99049472,
+                99049472,
+                100622336,
+                100622336,
+                118972416,
+                118972416,
+                120545280,
+                120545280,
+                121593856
               ]
             },
-            "peakRssBytes": 123228160,
+            "peakRssBytes": 121593856,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -260,17 +260,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.719763,
-            "maxMs": 34.781248,
-            "medianMs": 30.571399,
-            "minMs": 17.909883,
+            "madMs": 5.291388,
+            "maxMs": 37.140808,
+            "medianMs": 30.595576,
+            "minMs": 21.431405,
             "sampleCount": 5,
             "samplesMs": [
-              17.909883,
-              34.781248,
-              32.291162,
-              29.82185,
-              30.571399
+              21.431405,
+              37.140808,
+              35.886964,
+              30.019621,
+              30.595576
             ]
           },
           "fixtureDigest": "b5ed1acf6dcd628542025466c326a7ca14bfc4875684227c66736176561607d5",
@@ -281,23 +281,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 157253632,
+              "maximumObservedBytes": 157597696,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                81752064,
-                115830784,
-                118976512,
-                118976512,
-                155676672,
-                155676672,
-                155156480,
-                155156480,
-                156205056,
-                156205056,
-                157253632
+                82829312,
+                115859456,
+                119005184,
+                119005184,
+                156753920,
+                156753920,
+                156024832,
+                156024832,
+                157073408,
+                157073408,
+                157597696
               ]
             },
-            "peakRssBytes": 157253632,
+            "peakRssBytes": 158121984,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -316,17 +316,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.343451,
-            "maxMs": 381.456384,
-            "medianMs": 355.764281,
-            "minMs": 352.42083,
+            "madMs": 1.054932,
+            "maxMs": 377.027193,
+            "medianMs": 343.639946,
+            "minMs": 342.585014,
             "sampleCount": 5,
             "samplesMs": [
-              354.870975,
-              352.42083,
-              381.456384,
-              380.364585,
-              355.764281
+              377.027193,
+              342.585014,
+              343.311607,
+              360.931483,
+              343.639946
             ]
           },
           "fixtureDigest": "60598ff316c144a59697d6e13c539f2877b49bdcd1b6f8427c436f9850314509",
@@ -337,23 +337,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 234844160,
+              "maximumObservedBytes": 232443904,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84738048,
-                208912384,
-                191021056,
-                191021056,
-                212361216,
-                212361216,
-                234844160,
-                234844160,
-                201908224,
-                201908224,
-                222085120
+                84656128,
+                208457728,
+                188338176,
+                188338176,
+                209199104,
+                209199104,
+                232443904,
+                232443904,
+                201273344,
+                201273344,
+                222121984
               ]
             },
-            "peakRssBytes": 263548928,
+            "peakRssBytes": 261287936,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -386,15 +386,15 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.564666,
-            "maxMs": 2532.545571,
-            "medianMs": 2520.939856,
-            "minMs": 2520.37519,
+            "madMs": 0.271883,
+            "maxMs": 2530.234,
+            "medianMs": 2524.524868,
+            "minMs": 2524.252985,
             "sampleCount": 3,
             "samplesMs": [
-              2532.545571,
-              2520.37519,
-              2520.939856
+              2524.252985,
+              2530.234,
+              2524.524868
             ]
           },
           "fixtureDigest": "c6d8f7a4a98827903f02f35df08655219e5c22c72e4a8f0a7dc3145e4aba9a69",
@@ -406,12 +406,12 @@
           "memory": {
             "lowerBound": {
               "limitation": "The child reported RSS immediately before entering synchronous work and was then externally terminated; this is a lower-bound diagnostic, not a process peak.",
-              "maximumObservedBytes": 110346240,
+              "maximumObservedBytes": 109490176,
               "method": "child_start_rss_lower_bound",
               "observationsBytes": [
-                107368448,
-                106766336,
-                110346240
+                108634112,
+                106811392,
+                109490176
               ]
             },
             "peakRssBytes": null,
@@ -447,17 +447,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.078779,
-            "maxMs": 4.373377,
-            "medianMs": 4.054893,
-            "minMs": 3.976114,
+            "madMs": 0.082075,
+            "maxMs": 4.336267,
+            "medianMs": 3.684397,
+            "minMs": 3.602322,
             "sampleCount": 5,
             "samplesMs": [
-              3.976114,
-              3.99999,
-              4.18458,
-              4.373377,
-              4.054893
+              3.878712,
+              3.655032,
+              3.602322,
+              3.684397,
+              4.336267
             ]
           },
           "fixtureDigest": "6dc2d7033a701cb871275327613ffef173ca251f453a9b586554b9f3ce14811a",
@@ -470,23 +470,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 93421568,
+              "maximumObservedBytes": 93925376,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85442560,
-                89227264,
-                89227264,
-                89227264,
-                89227264,
-                89227264,
-                89751552,
-                89751552,
-                92372992,
-                92372992,
-                93421568
+                86061056,
+                89206784,
+                89731072,
+                89731072,
+                89731072,
+                89731072,
+                89731072,
+                89731072,
+                90255360,
+                90255360,
+                93925376
               ]
             },
-            "peakRssBytes": 93421568,
+            "peakRssBytes": 93925376,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -505,17 +505,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.129377,
-            "maxMs": 13.068304,
-            "medianMs": 12.929943,
-            "minMs": 12.332896,
+            "madMs": 0.167464,
+            "maxMs": 13.132068,
+            "medianMs": 12.964604,
+            "minMs": 12.773273,
             "sampleCount": 5,
             "samplesMs": [
-              13.068304,
-              13.05932,
-              12.929943,
-              12.805103,
-              12.332896
+              13.067661,
+              12.773273,
+              12.785502,
+              12.964604,
+              13.132068
             ]
           },
           "fixtureDigest": "2c4e993a93b588a4e90763225ab10e2c7e80c7e52c006b4ce0d8d042a41d456c",
@@ -528,23 +528,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92778496,
+              "maximumObservedBytes": 92688384,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84389888,
-                92778496,
-                92778496,
-                92778496,
-                92778496,
-                92778496,
-                92778496,
-                92778496,
-                92778496,
-                92778496,
-                92778496
+                85483520,
+                92688384,
+                92688384,
+                92688384,
+                92688384,
+                92688384,
+                92688384,
+                92688384,
+                92688384,
+                92688384,
+                92688384
               ]
             },
-            "peakRssBytes": 92778496,
+            "peakRssBytes": 92688384,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -563,17 +563,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 2.125711,
-            "maxMs": 52.359767,
-            "medianMs": 49.394879,
-            "minMs": 47.269168,
+            "madMs": 2.520227,
+            "maxMs": 57.45742,
+            "medianMs": 54.937193,
+            "minMs": 50.545632,
             "sampleCount": 5,
             "samplesMs": [
-              48.600382,
-              49.394879,
-              51.657078,
-              52.359767,
-              47.269168
+              52.268619,
+              54.937193,
+              56.854174,
+              50.545632,
+              57.45742
             ]
           },
           "fixtureDigest": "c1a21af75169441df1d4fd0a5c8a99dbe96bbd556db181e064a6f70b83a91cf6",
@@ -586,23 +586,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 102354944,
+              "maximumObservedBytes": 101728256,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                87572480,
-                93966336,
-                93966336,
-                93966336,
-                93966336,
-                93966336,
-                102354944,
-                102354944,
-                102354944,
-                102354944,
-                102354944
+                83902464,
+                93863936,
+                93863936,
+                93863936,
+                97009664,
+                97009664,
+                101728256,
+                101728256,
+                101728256,
+                101728256,
+                101728256
               ]
             },
-            "peakRssBytes": 102354944,
+            "peakRssBytes": 101728256,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -635,21 +635,21 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.002514,
-            "maxMs": 0.031788,
-            "medianMs": 0.015504,
-            "minMs": 0.011988,
+            "madMs": 0.00081,
+            "maxMs": 0.02589,
+            "medianMs": 0.01341,
+            "minMs": 0.012198,
             "sampleCount": 9,
             "samplesMs": [
-              0.0199,
-              0.031788,
-              0.018999,
-              0.014472,
-              0.015504,
-              0.01347,
-              0.011988,
-              0.01299,
-              0.017206
+              0.017136,
+              0.02589,
+              0.018378,
+              0.01325,
+              0.01352,
+              0.01341,
+              0.0126,
+              0.01292,
+              0.012198
             ]
           },
           "fixtureDigest": "06964b37b02568fd25e3c7c7788a86751336199f8ae67a29529912d184f6131d",
@@ -662,31 +662,31 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 80064512,
+              "maximumObservedBytes": 79159296,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                77443072,
-                77967360,
-                78491648,
-                78491648,
-                78491648,
-                78491648,
-                79015936,
-                79015936,
-                79015936,
-                79540224,
-                79540224,
-                80064512,
-                80064512,
-                80064512,
-                80064512,
-                80064512,
-                80064512,
-                80064512,
-                80064512
+                78110720,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                78635008,
+                79159296,
+                79159296,
+                79159296,
+                79159296,
+                79159296,
+                79159296,
+                79159296
               ]
             },
-            "peakRssBytes": 80064512,
+            "peakRssBytes": 79159296,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -791,7 +791,7 @@
     {
       "normalization": "utf8_lf",
       "path": ".gitattributes",
-      "sha256": "292d362f4207092e2a3a697bb9c7c9eb6aff2340de6949d58274d0380242e67a"
+      "sha256": "43e326b1e14350110bd6552661c74d694aca056a15901e5a4cfc7d9fe6d8d216"
     },
     {
       "normalization": "utf8_lf",
@@ -871,7 +871,7 @@
     {
       "normalization": "utf8_lf",
       "path": "runtime/package.json",
-      "sha256": "208bb5eea8c98ed2c253890cc5a44af0d9fd41709b4060f5a0d94e9b5d05cf5d"
+      "sha256": "e66e073c1f6715a0421dea617ff3cb3357a3437f9f0acfca3baf6615c0739260"
     }
   ],
   "planDigest": "c2377e6d378a616f8a8e3169a87687c354e6cf4e5a8c0f233ae6c0207281d4ed",

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,7 +4,7 @@ This artifact records bounded observations of known failures. Every row is
 informational: no current result is a passing performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `8c72fc88fd10dfde2f91bd7cc3ce8028af552781b7b699db9931529cac0abd07`
+- JSON SHA-256: `03c77d2d209972343f72347ac33f60b1582393c566a2893fb995c650283cc07d`
 - Source revision: `925f3ec2860abf48e0c6c0830d135da2587a4d69`
 - Production tree: `runtime/src` at Git object `d802c0cd2dccdfa714252859bcd7e19605a8c8fb`
 - Loaded production closure: `64` module bindings across `5` cases
@@ -18,17 +18,17 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 5.985 | 0.384 | 92852224 | 92852224 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 16.198 | 0.569 | 122150912 | 122150912 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 38.803 | 1.026 | 136331264 | 136294400 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 6.689 | 0.774 | 123228160 | 123228160 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 30.571 | 1.720 | 157253632 | 157253632 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 355.764 | 3.343 | 263548928 | 234844160 |
-| `regex_fallback_catastrophic_backtracking` | `fileCount=1,repeatedCharacters=30` | `timed_out` | 2520.940 | 0.565 | n/a | 110346240 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 4.055 | 0.079 | 93421568 | 93421568 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.930 | 0.129 | 92778496 | 92778496 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 49.395 | 2.126 | 102354944 | 102354944 |
-| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.016 | 0.003 | 80064512 | 80064512 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 6.948 | 0.712 | 90243072 | 90243072 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 17.555 | 1.824 | 120401920 | 120401920 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 43.803 | 2.894 | 132947968 | 132947968 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 6.021 | 0.371 | 121593856 | 121593856 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 30.596 | 5.291 | 158121984 | 157597696 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 343.640 | 1.055 | 261287936 | 232443904 |
+| `regex_fallback_catastrophic_backtracking` | `fileCount=1,repeatedCharacters=30` | `timed_out` | 2524.525 | 0.272 | n/a | 109490176 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 3.684 | 0.082 | 93925376 | 93925376 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.965 | 0.167 | 92688384 | 92688384 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 54.937 | 2.520 | 101728256 | 101728256 |
+| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.013 | 0.001 | 79159296 | 79159296 |
 
 ## Known-failure policy
 

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -42,6 +42,7 @@
     "validate:tui-core-parity": "npm run test:tui-core-parity",
     "test:tui-yolo-parity": "node scripts/run-hermetic-vitest.mjs run tests/tui/components/PromptInput/permissionModeChrome.test.ts tests/tui/components/FullscreenLayout.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.runtime-coverage.test.tsx tests/permissions/permission-mode.test.ts tests/app-server-client/index.test.ts --reporter=dot",
     "test:bun:isolated": "node scripts/run-bun-tests-isolated.mjs",
+    "test:red-probes": "node scripts/run-fnd-red-probes.mjs",
     "check:tui-command-visual-smoke": "node scripts/check-tui-command-visual-smoke.mjs",
     "check:tui-workbench-visual-smoke": "node scripts/check-tui-workbench-visual-smoke.mjs",
     "check:tui-workbench-transcript-scroll": "node scripts/check-tui-workbench-transcript-scroll.mjs",

--- a/runtime/scripts/run-fnd-red-probes.mjs
+++ b/runtime/scripts/run-fnd-red-probes.mjs
@@ -1,0 +1,1525 @@
+#!/usr/bin/env node
+
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  opendirSync,
+  readSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { dirname, isAbsolute, posix, relative, resolve, sep } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { deflateRawSync } from "node:zlib";
+
+import { getNodeValue, parseTree, printParseErrorCode } from "jsonc-parser";
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isElementAccessExpression,
+  isExpressionStatement,
+  isFunctionDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isImportEqualsDeclaration,
+  isNamedImports,
+  isPropertyAccessExpression,
+  isStringLiteralLike,
+  ScriptTarget,
+  SyntaxKind,
+} from "typescript";
+
+import { runSupervisedProcess } from "../src/utils/supervisedProcess.ts";
+
+import {
+  createHermeticLaunchEnv,
+  createHermeticRunRoot,
+  sanitizeHermeticEnv,
+} from "../tests/helpers/hermetic-env.mjs";
+
+export const RED_PROBE_PROTOCOL_VERSION = 1;
+export const RED_PROBE_EXPECTED_EXIT_CODE = 86;
+export const RED_PROBE_PROTOCOL_PREFIX = "AGENC_RED_PROBE_V1 ";
+export const RED_PROBE_HEARTBEAT_PREFIX = "AGENC_RED_PROBE_HEARTBEAT_V1 ";
+
+const MANIFEST_SCHEMA_VERSION = 1;
+const AUDIT_SHA = "d2b228e87ea63bd6a5d93e6f599f36bce88d672b";
+const MANIFEST_FILENAME = "manifest.json";
+const RED_PROBE_SUFFIX = ".red-probe.ts";
+const RED_PROBE_DIRECTORY = "tests/fnd/red-probes";
+const MINIMUM_TIMEOUT_MS = 100;
+const MAXIMUM_TIMEOUT_MS = 30_000;
+const MAXIMUM_MANIFEST_BYTES = 65_536;
+const MAXIMUM_PROBE_BYTES = 65_536;
+const MAXIMUM_BOOTSTRAP_BYTES = 65_536;
+const MAXIMUM_HELPER_BYTES = 65_536;
+const MAXIMUM_CHILD_OUTPUT_BYTES = 16_384;
+const RED_PROBE_AUTHENTICATION_SECRET_BYTES = 32;
+const RED_PROBE_HANDOFF_MAGIC = Buffer.from(
+  "AGENC_RED_PROBE_HANDOFF_V1\0",
+  "ascii",
+);
+const MAXIMUM_HANDOFF_BYTES =
+  RED_PROBE_HANDOFF_MAGIC.byteLength +
+  RED_PROBE_AUTHENTICATION_SECRET_BYTES +
+  MAXIMUM_PROBE_BYTES;
+const MAXIMUM_ID_CHARACTERS = 64;
+const MAXIMUM_PROBE_COUNT = 256;
+const MAXIMUM_INVENTORY_DIRECTORIES = 64;
+const MAXIMUM_INVENTORY_DEPTH = 16;
+const MAXIMUM_INVENTORY_ENTRIES =
+  MAXIMUM_PROBE_COUNT + MAXIMUM_INVENTORY_DIRECTORIES + 1;
+const MAXIMUM_INVENTORY_PATH_BYTES = 64 * 1024;
+const MAXIMUM_JSON_DEPTH = 64;
+const MAXIMUM_JSON_NODES = 16_384;
+const MAXIMUM_SOURCE_AST_DEPTH = 128;
+const MAXIMUM_SOURCE_AST_NODES = 32_768;
+const WINDOWS_CREATE_PROCESS_MAXIMUM_CODE_UNITS = 32_767;
+const WINDOWS_LAUNCH_HEADROOM_CODE_UNITS = 8_192;
+export const WINDOWS_PORTABLE_LAUNCH_MAXIMUM_CODE_UNITS =
+  WINDOWS_CREATE_PROCESS_MAXIMUM_CODE_UNITS -
+  WINDOWS_LAUNCH_HEADROOM_CODE_UNITS;
+const WINDOWS_COMMAND_LINE_TERMINATOR_CODE_UNITS = 1;
+const WINDOWS_ENVIRONMENT_BLOCK_FINAL_TERMINATOR_CODE_UNITS = 1;
+const SUPPORT_SOURCE_COMPRESSION_LEVEL = 9;
+const STDIN_MODULE_FILENAME = "[eval1].ts";
+const RED_PROBE_HEARTBEAT_INTERVAL_MS = 1_000;
+const RED_PROBE_HEARTBEAT_SILENCE_MS = 5_000;
+const SUPERVISOR_SETTLEMENT_KEEPALIVE_INTERVAL_MS = 1_000;
+const MINIMUM_TEST_HEARTBEAT_SILENCE_MS = 50;
+const TERMINATE_GRACE_MS = 500;
+const SETTLE_BACKSTOP_MS = 2_000;
+const PROTOCOL_OUTCOME = "expected-red";
+const HEARTBEAT_PROTOCOL_OUTCOME = "heartbeat";
+const FINAL_AUTHENTICATION_DOMAIN = "AGENC_RED_PROBE_FINAL_V1\0";
+const BOOTSTRAP_ENVIRONMENT_VARIABLE = "AGENC_RED_PROBE_BOOTSTRAP_V1";
+const FINGERPRINT_PATTERN = /^[A-Z0-9][A-Z0-9._:/-]{0,127}$/u;
+const ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const SOURCE_SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const RED_PROBE_AUTHENTICATION_TAG_PATTERN = /^[0-9a-f]{64}$/u;
+export const RED_PROBE_TASK_IDS = Object.freeze([
+  "FND-001",
+  "A1",
+  "A2a",
+  "A2b",
+  "A3",
+  "A4",
+  "B1",
+  "B2",
+  "B3a",
+  "B3b",
+  "C1",
+  "C2",
+  "C3a",
+  "C3b",
+  "D1",
+  "D2",
+  "D3",
+  "E1a",
+  "E1b",
+  "E2",
+  "E3",
+]);
+const RED_PROBE_TASK_ID_SET = new Set(RED_PROBE_TASK_IDS);
+const ALLOWED_CLASSIFICATIONS = new Set(["harness-self-test", "defect"]);
+const MANIFEST_KEYS = Object.freeze([
+  "auditSha",
+  "probeCount",
+  "probes",
+  "schemaVersion",
+]);
+const PROBE_KEYS = Object.freeze([
+  "classification",
+  "file",
+  "fingerprint",
+  "id",
+  "sourceSha256",
+  "task",
+  "timeoutMs",
+]);
+const FORBIDDEN_TEST_METHODS = new Set([
+  "fails",
+  "only",
+  "runIf",
+  "skip",
+  "skipIf",
+  "todo",
+]);
+const FORBIDDEN_GLOBAL_IDENTIFIERS = new Set([
+  "Function",
+  "arguments",
+  "console",
+  "eval",
+  "global",
+  "globalThis",
+  "process",
+  "require",
+]);
+const RED_PROBE_HELPER_PATH = "tests/helpers/red-probe.js";
+const RED_PROBE_HELPER_SOURCE_PATH = "tests/helpers/red-probe.ts";
+const RED_PROBE_BOOTSTRAP_PATH = "tests/helpers/red-probe-bootstrap.mjs";
+const RED_PROBE_HELPER_FUNCTION = "expectDeepStrictEqualRedProbe";
+const RED_PROBE_HELPER_TYPE = "RedProbeAssertion";
+const RED_PROBE_RUNNER_FUNCTION = "runRedProbe";
+const RED_PROBE_BOOTSTRAP_SHA256 =
+  "7b386f69325f0c8d80c5667663bad34a74d9e18fad80ad355ac17a4a4323cd54";
+const RED_PROBE_HELPER_SHA256 =
+  "289471c65f3852d56e5c40ed95883697f8145b2e471b3eb0aab06660d1c1232a";
+
+const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+const defaultRuntimeRoot = resolve(moduleDirectory, "..");
+const tsxLoader = resolve(
+  defaultRuntimeRoot,
+  "../node_modules/tsx/dist/loader.mjs",
+);
+const networkTripwire = resolve(
+  defaultRuntimeRoot,
+  "tests/helpers/network-tripwire.cjs",
+);
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, expectedKeys) {
+  if (!isRecord(value)) return false;
+  const actualKeys = Object.keys(value).sort();
+  return JSON.stringify(actualKeys) === JSON.stringify(expectedKeys);
+}
+
+function isContainedPath(parent, child) {
+  const childRelative = relative(parent, child);
+  return (
+    childRelative === "" ||
+    (!childRelative.startsWith("..") && !isAbsolute(childRelative))
+  );
+}
+
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameStableFileMetadata(left, right) {
+  return (
+    sameFileIdentity(left, right) &&
+    left.size === right.size &&
+    left.nlink === right.nlink &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function assertSingleRegularFile(metadata, label) {
+  if (
+    metadata.isSymbolicLink() ||
+    !metadata.isFile() ||
+    metadata.nlink !== 1n
+  ) {
+    throw new Error(`${label} is not one single-link regular file`);
+  }
+}
+
+function readBoundedRegularFile(path, maximumBytes, label, afterOpenForTest) {
+  const beforePath = lstatSync(path, { bigint: true });
+  assertSingleRegularFile(beforePath, label);
+  const noFollow = fsConstants.O_NOFOLLOW ?? 0;
+  let descriptor;
+  try {
+    descriptor = openSync(path, fsConstants.O_RDONLY | noFollow);
+  } catch (error) {
+    throw new Error(`${label} could not be opened without following links`, {
+      cause: error,
+    });
+  }
+
+  try {
+    const beforeDescriptor = fstatSync(descriptor, { bigint: true });
+    assertSingleRegularFile(beforeDescriptor, label);
+    if (!sameFileIdentity(beforePath, beforeDescriptor)) {
+      throw new Error(`${label} changed identity while it was opened`);
+    }
+    if (beforeDescriptor.size > BigInt(maximumBytes)) {
+      throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+    }
+
+    afterOpenForTest?.(Object.freeze({ label, path }));
+
+    const bytes = Buffer.allocUnsafe(maximumBytes + 1);
+    let bytesRead = 0;
+    while (bytesRead < bytes.length) {
+      const count = readSync(
+        descriptor,
+        bytes,
+        bytesRead,
+        bytes.length - bytesRead,
+        null,
+      );
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    if (bytesRead > maximumBytes) {
+      throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+    }
+
+    const afterDescriptor = fstatSync(descriptor, { bigint: true });
+    const afterPath = lstatSync(path, { bigint: true });
+    assertSingleRegularFile(afterDescriptor, label);
+    assertSingleRegularFile(afterPath, label);
+    if (
+      !sameStableFileMetadata(beforeDescriptor, afterDescriptor) ||
+      !sameStableFileMetadata(afterDescriptor, afterPath) ||
+      afterDescriptor.size !== BigInt(bytesRead)
+    ) {
+      throw new Error(`${label} changed while it was read`);
+    }
+    return bytes.subarray(0, bytesRead);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function decodeUtf8(bytes, label) {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(`${label} is not valid UTF-8`);
+  }
+}
+
+function readVerifiedSupportFile(
+  runtimeRoot,
+  relativePath,
+  maximumBytes,
+  expectedDigest,
+  label,
+) {
+  const path = resolve(runtimeRoot, relativePath);
+  const bytes = readBoundedRegularFile(path, maximumBytes, label);
+  if (sha256(bytes) !== expectedDigest) {
+    throw new Error(`${label} digest does not match the reviewed source`);
+  }
+  return bytes;
+}
+
+function encodeDeflatedSource(bytes) {
+  return deflateRawSync(bytes, {
+    level: SUPPORT_SOURCE_COMPRESSION_LEVEL,
+  }).toString("base64");
+}
+
+function createVerifiedBootstrapImportUrl(bytes, expectedDigest) {
+  const deflatedSource = encodeDeflatedSource(bytes);
+  const wrapper = [
+    'import { Buffer as B } from "node:buffer";',
+    'import { createHash as H } from "node:crypto";',
+    'import { inflateRawSync as I } from "node:zlib";',
+    `const s=I(B.from(${JSON.stringify(deflatedSource)},"base64"),{maxOutputLength:${MAXIMUM_BOOTSTRAP_BYTES}});`,
+    `if(H("sha256").update(s).digest("hex")!==${JSON.stringify(expectedDigest)})throw new Error("red-probe bootstrap transport digest does not match");`,
+    'await import("data:text/javascript;base64,"+s.toString("base64"));',
+  ].join("");
+  return `data:text/javascript;base64,${Buffer.from(wrapper, "utf8").toString("base64")}`;
+}
+
+function loadRedProbeSupportGraph(runtimeRoot) {
+  const bootstrapBytes = readVerifiedSupportFile(
+    runtimeRoot,
+    RED_PROBE_BOOTSTRAP_PATH,
+    MAXIMUM_BOOTSTRAP_BYTES,
+    RED_PROBE_BOOTSTRAP_SHA256,
+    "red-probe bootstrap",
+  );
+  const helperBytes = readVerifiedSupportFile(
+    runtimeRoot,
+    RED_PROBE_HELPER_SOURCE_PATH,
+    MAXIMUM_HELPER_BYTES,
+    RED_PROBE_HELPER_SHA256,
+    "red-probe helper",
+  );
+  return Object.freeze({
+    bootstrapImportUrl: createVerifiedBootstrapImportUrl(
+      bootstrapBytes,
+      RED_PROBE_BOOTSTRAP_SHA256,
+    ),
+    helperRequestUrl: pathToFileURL(resolve(runtimeRoot, RED_PROBE_HELPER_PATH))
+      .href,
+    helperSourceDeflateBase64: encodeDeflatedSource(helperBytes),
+    helperSourceSha256: RED_PROBE_HELPER_SHA256,
+    helperSourceUrl: pathToFileURL(
+      resolve(runtimeRoot, RED_PROBE_HELPER_SOURCE_PATH),
+    ).href,
+    networkTripwireUrl: pathToFileURL(networkTripwire).href,
+    tsxLoaderUrl: pathToFileURL(tsxLoader).href,
+  });
+}
+
+function assertBoundedJsonTree(root, label) {
+  const pending = [{ depth: 1, node: root }];
+  let visitedNodes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    visitedNodes += 1;
+    if (visitedNodes > MAXIMUM_JSON_NODES) {
+      throw new Error(`${label} exceeds the ${MAXIMUM_JSON_NODES}-node limit`);
+    }
+    if (current.depth > MAXIMUM_JSON_DEPTH) {
+      throw new Error(`${label} exceeds the ${MAXIMUM_JSON_DEPTH}-level limit`);
+    }
+
+    const children = current.node.children ?? [];
+    if (current.node.type === "object") {
+      const keys = new Set();
+      for (const property of children) {
+        const keyNode = property.children?.[0];
+        const key = keyNode?.value;
+        if (typeof key !== "string") {
+          throw new Error(`${label} contains a malformed object key`);
+        }
+        if (keys.has(key)) {
+          throw new Error(
+            `${label} contains duplicate object key ${JSON.stringify(key)}`,
+          );
+        }
+        keys.add(key);
+      }
+    }
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      pending.push({ depth: current.depth + 1, node: children[index] });
+    }
+  }
+}
+
+function parseStrictJson(bytes, label) {
+  const source = decodeUtf8(bytes, label);
+  const errors = [];
+  const tree = parseTree(source, errors, {
+    allowEmptyContent: false,
+    allowTrailingComma: false,
+    disallowComments: true,
+  });
+  if (tree === undefined || errors.length > 0) {
+    const detail = errors
+      .map((error) => `${printParseErrorCode(error.error)}@${error.offset}`)
+      .join(", ");
+    throw new Error(
+      `${label} is not strict JSON${detail === "" ? "" : `: ${detail}`}`,
+    );
+  }
+  assertBoundedJsonTree(tree, label);
+  return getNodeValue(tree);
+}
+
+function validateProbeEntry(value, index) {
+  const label = `red-probe manifest entry ${index}`;
+  if (!hasExactKeys(value, PROBE_KEYS)) {
+    throw new Error(`${label} does not match the exact schema`);
+  }
+  if (
+    typeof value.id !== "string" ||
+    value.id.length > MAXIMUM_ID_CHARACTERS ||
+    !ID_PATTERN.test(value.id)
+  ) {
+    throw new Error(`${label} has a noncanonical id`);
+  }
+  if (!ALLOWED_CLASSIFICATIONS.has(value.classification)) {
+    throw new Error(`${label} has an unsupported classification`);
+  }
+  if (
+    typeof value.task !== "string" ||
+    !RED_PROBE_TASK_ID_SET.has(value.task)
+  ) {
+    throw new Error(`${label} has a noncanonical task`);
+  }
+  if (
+    typeof value.sourceSha256 !== "string" ||
+    !SOURCE_SHA256_PATTERN.test(value.sourceSha256)
+  ) {
+    throw new Error(`${label} has a noncanonical sourceSha256`);
+  }
+  if (
+    typeof value.fingerprint !== "string" ||
+    !FINGERPRINT_PATTERN.test(value.fingerprint)
+  ) {
+    throw new Error(`${label} has a noncanonical fingerprint`);
+  }
+  if (
+    typeof value.timeoutMs !== "number" ||
+    !Number.isSafeInteger(value.timeoutMs) ||
+    value.timeoutMs < MINIMUM_TIMEOUT_MS ||
+    value.timeoutMs > MAXIMUM_TIMEOUT_MS
+  ) {
+    throw new Error(`${label} has an invalid timeoutMs`);
+  }
+  if (typeof value.file !== "string" || value.file.includes("\\")) {
+    throw new Error(`${label} has a noncanonical file path`);
+  }
+  if (
+    value.file !== posix.normalize(value.file) ||
+    !value.file.startsWith(`${RED_PROBE_DIRECTORY}/`) ||
+    !value.file.endsWith(RED_PROBE_SUFFIX)
+  ) {
+    throw new Error(`${label} has a noncanonical file path`);
+  }
+  return Object.freeze({ ...value });
+}
+
+export function loadRedProbeManifest(runtimeRoot = defaultRuntimeRoot) {
+  const manifestPath = resolve(
+    runtimeRoot,
+    RED_PROBE_DIRECTORY,
+    MANIFEST_FILENAME,
+  );
+  const bytes = readBoundedRegularFile(
+    manifestPath,
+    MAXIMUM_MANIFEST_BYTES,
+    "red-probe manifest",
+  );
+  const parsed = parseStrictJson(bytes, "red-probe manifest");
+  if (!hasExactKeys(parsed, MANIFEST_KEYS)) {
+    throw new Error("red-probe manifest does not match the exact schema");
+  }
+  if (parsed.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+    throw new Error(
+      `unsupported red-probe manifest schema ${String(parsed.schemaVersion)}`,
+    );
+  }
+  if (parsed.auditSha !== AUDIT_SHA) {
+    throw new Error(`red-probe manifest auditSha must equal ${AUDIT_SHA}`);
+  }
+  if (
+    !Number.isSafeInteger(parsed.probeCount) ||
+    parsed.probeCount < 1 ||
+    parsed.probeCount > MAXIMUM_PROBE_COUNT ||
+    !Array.isArray(parsed.probes) ||
+    parsed.probes.length !== parsed.probeCount
+  ) {
+    throw new Error(
+      "red-probe manifest must declare a nonempty exact probe count",
+    );
+  }
+
+  const probes = parsed.probes.map(validateProbeEntry);
+  for (const [field, values] of [
+    ["id", probes.map((probe) => probe.id)],
+    ["file", probes.map((probe) => probe.file)],
+    ["fingerprint", probes.map((probe) => probe.fingerprint)],
+  ]) {
+    if (new Set(values).size !== values.length) {
+      throw new Error(`red-probe manifest contains duplicate ${field}`);
+    }
+  }
+  const canonicalIds = probes.map((probe) => probe.id).sort();
+  if (probes.some((probe, index) => probe.id !== canonicalIds[index])) {
+    throw new Error("red-probe manifest entries are not in canonical id order");
+  }
+  return Object.freeze({
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    auditSha: AUDIT_SHA,
+    probeCount: probes.length,
+    probes: Object.freeze(probes),
+  });
+}
+
+function walkProbeDirectory(probeRoot, runtimeRoot) {
+  const discovered = [];
+  const pendingDirectories = [{ depth: 0, path: probeRoot }];
+  let directoryCount = 1;
+  let entryCount = 0;
+  let pathBytes = 0;
+
+  while (pendingDirectories.length > 0) {
+    const current = pendingDirectories.pop();
+    const directory = opendirSync(current.path);
+    try {
+      for (
+        let entry = directory.readSync();
+        entry;
+        entry = directory.readSync()
+      ) {
+        entryCount += 1;
+        if (entryCount > MAXIMUM_INVENTORY_ENTRIES) {
+          throw new Error(
+            `red-probe inventory exceeds the ${MAXIMUM_INVENTORY_ENTRIES}-entry limit`,
+          );
+        }
+
+        const path = resolve(current.path, entry.name);
+        const file = relative(runtimeRoot, path).split("\\").join("/");
+        pathBytes += Buffer.byteLength(file, "utf8");
+        if (pathBytes > MAXIMUM_INVENTORY_PATH_BYTES) {
+          throw new Error(
+            `red-probe inventory exceeds the ${MAXIMUM_INVENTORY_PATH_BYTES}-byte path limit`,
+          );
+        }
+        if (entry.isSymbolicLink()) {
+          throw new Error(
+            `red-probe inventory contains a symbolic link: ${file}`,
+          );
+        }
+        if (entry.isDirectory()) {
+          const depth = current.depth + 1;
+          directoryCount += 1;
+          if (depth > MAXIMUM_INVENTORY_DEPTH) {
+            throw new Error(
+              `red-probe inventory exceeds the ${MAXIMUM_INVENTORY_DEPTH}-level directory limit`,
+            );
+          }
+          if (directoryCount > MAXIMUM_INVENTORY_DIRECTORIES) {
+            throw new Error(
+              `red-probe inventory exceeds the ${MAXIMUM_INVENTORY_DIRECTORIES}-directory limit`,
+            );
+          }
+          pendingDirectories.push({ depth, path });
+          continue;
+        }
+        if (!entry.isFile()) {
+          throw new Error(`red-probe inventory contains a non-file: ${file}`);
+        }
+        if (file === `${RED_PROBE_DIRECTORY}/${MANIFEST_FILENAME}`) continue;
+        if (!file.endsWith(RED_PROBE_SUFFIX)) {
+          throw new Error(
+            `red-probe inventory contains an unsupported file: ${file}`,
+          );
+        }
+        discovered.push(file);
+      }
+    } finally {
+      directory.closeSync();
+    }
+  }
+  return discovered;
+}
+
+export function discoverRedProbeFiles(runtimeRoot = defaultRuntimeRoot) {
+  const probeRoot = resolve(runtimeRoot, RED_PROBE_DIRECTORY);
+  const probeRootStat = lstatSync(probeRoot);
+  if (probeRootStat.isSymbolicLink() || !probeRootStat.isDirectory()) {
+    throw new Error("red-probe root is not a regular directory");
+  }
+  return walkProbeDirectory(probeRoot, runtimeRoot).sort();
+}
+
+function assertExactInventory(manifest, discovered) {
+  if (discovered.length < 1) {
+    throw new Error("red-probe discovery was empty");
+  }
+  const registered = manifest.probes.map((probe) => probe.file).sort();
+  if (JSON.stringify(discovered) !== JSON.stringify(registered)) {
+    throw new Error(
+      `red-probe inventory mismatch: discovered=${JSON.stringify(discovered)} registered=${JSON.stringify(registered)}`,
+    );
+  }
+}
+
+function assertProbePath(runtimeRoot, file) {
+  const probeRoot = resolve(runtimeRoot, RED_PROBE_DIRECTORY);
+  const path = resolve(runtimeRoot, file);
+  if (!isContainedPath(probeRoot, path)) {
+    throw new Error(`red-probe path escapes its root: ${file}`);
+  }
+  const realProbeRoot = realpathSync(probeRoot);
+  const realPath = realpathSync(path);
+  if (!isContainedPath(realProbeRoot, realPath)) {
+    throw new Error(`red-probe real path escapes its root: ${file}`);
+  }
+  return path;
+}
+
+function isForbiddenTestModule(moduleName) {
+  return (
+    moduleName === "bun:test" ||
+    moduleName === "jest" ||
+    moduleName === "node:test" ||
+    moduleName.startsWith("node:test/") ||
+    moduleName === "vitest" ||
+    moduleName.startsWith("vitest/") ||
+    moduleName === "@jest/globals" ||
+    moduleName.startsWith("@vitest/")
+  );
+}
+
+function isProcessModule(moduleName) {
+  return moduleName === "node:process" || moduleName === "process";
+}
+
+function canonicalHelperSpecifier(file) {
+  const helper = posix.relative(posix.dirname(file), RED_PROBE_HELPER_PATH);
+  return helper.startsWith(".") ? helper : `./${helper}`;
+}
+
+function importModuleName(node) {
+  return isStringLiteralLike(node.moduleSpecifier)
+    ? node.moduleSpecifier.text
+    : undefined;
+}
+
+function assertCanonicalHelperTypeImport(node, expectedSpecifier, file) {
+  const clause = node.importClause;
+  const bindings = clause?.namedBindings;
+  if (
+    clause === undefined ||
+    !clause.isTypeOnly ||
+    clause.name !== undefined ||
+    !isNamedImports(bindings) ||
+    bindings.elements.length !== 1
+  ) {
+    throw new Error(`${file} has a noncanonical red-probe helper import`);
+  }
+  const [specifier] = bindings.elements;
+  if (
+    specifier.isTypeOnly ||
+    specifier.propertyName !== undefined ||
+    specifier.name.text !== RED_PROBE_HELPER_TYPE ||
+    importModuleName(node) !== expectedSpecifier
+  ) {
+    throw new Error(`${file} has a noncanonical red-probe helper import`);
+  }
+}
+
+function importedBindingName(specifier) {
+  return specifier.propertyName?.text ?? specifier.name.text;
+}
+
+function assertProbeSourcePolicy(source, file) {
+  const sourceFile = createSourceFile(file, source, ScriptTarget.Latest, true);
+  if ((sourceFile.parseDiagnostics ?? []).length > 0) {
+    throw new Error(`${file} contains invalid TypeScript syntax`);
+  }
+
+  const expectedHelperSpecifier = canonicalHelperSpecifier(file);
+  const rootRunners = sourceFile.statements.filter(
+    (statement) =>
+      isFunctionDeclaration(statement) &&
+      statement.modifiers?.some(
+        (modifier) => modifier.kind === SyntaxKind.ExportKeyword,
+      ) === true &&
+      statement.modifiers?.some(
+        (modifier) => modifier.kind === SyntaxKind.DefaultKeyword,
+      ) === true,
+  );
+  if (rootRunners.length !== 1) {
+    throw new Error(`${file} must export one canonical root runner`);
+  }
+  const [rootRunner] = rootRunners;
+  const runnerModifiers = rootRunner.modifiers?.map(
+    (modifier) => modifier.kind,
+  );
+  const expectedRunnerModifiers = [
+    SyntaxKind.ExportKeyword,
+    SyntaxKind.DefaultKeyword,
+    SyntaxKind.AsyncKeyword,
+  ];
+  const [runnerParameter] = rootRunner.parameters;
+  if (
+    rootRunner.name?.text !== RED_PROBE_RUNNER_FUNCTION ||
+    JSON.stringify(runnerModifiers) !==
+      JSON.stringify(expectedRunnerModifiers) ||
+    rootRunner.parameters.length !== 1 ||
+    runnerParameter === undefined ||
+    !isIdentifier(runnerParameter.name) ||
+    runnerParameter.name.text !== RED_PROBE_HELPER_FUNCTION ||
+    runnerParameter.dotDotDotToken !== undefined ||
+    runnerParameter.questionToken !== undefined ||
+    runnerParameter.initializer !== undefined ||
+    rootRunner.body === undefined
+  ) {
+    throw new Error(`${file} has a noncanonical root runner`);
+  }
+
+  let canonicalHelperTypeImports = 0;
+  let helperAssertionCalls = 0;
+  let rootHelperAssertionCalls = 0;
+
+  const inspectNode = (node) => {
+    if (isImportEqualsDeclaration(node)) {
+      throw new Error(`${file} uses forbidden import-equals loading`);
+    }
+    if (isImportDeclaration(node)) {
+      const moduleName = importModuleName(node);
+      if (moduleName !== undefined && isForbiddenTestModule(moduleName)) {
+        throw new Error(`${file} imports a test framework`);
+      }
+      if (moduleName !== undefined && isProcessModule(moduleName)) {
+        throw new Error(`${file} imports process access`);
+      }
+      if (moduleName === expectedHelperSpecifier) {
+        assertCanonicalHelperTypeImport(node, expectedHelperSpecifier, file);
+        canonicalHelperTypeImports += 1;
+      } else if (
+        node.importClause?.namedBindings !== undefined &&
+        isNamedImports(node.importClause.namedBindings) &&
+        node.importClause.namedBindings.elements.some(
+          (specifier) =>
+            importedBindingName(specifier) === RED_PROBE_HELPER_FUNCTION ||
+            importedBindingName(specifier) === RED_PROBE_HELPER_TYPE,
+        )
+      ) {
+        throw new Error(`${file} imports the red-probe helper noncanonically`);
+      }
+    }
+
+    if (isIdentifier(node)) {
+      if (FORBIDDEN_GLOBAL_IDENTIFIERS.has(node.text)) {
+        throw new Error(`${file} uses forbidden global access ${node.text}`);
+      }
+      if (FORBIDDEN_TEST_METHODS.has(node.text)) {
+        throw new Error(`${file} uses forbidden test control ${node.text}`);
+      }
+      if (node.text === RED_PROBE_HELPER_FUNCTION) {
+        if (
+          node.parent?.kind === SyntaxKind.ImportSpecifier ||
+          (node.parent?.kind === SyntaxKind.Parameter &&
+            runnerParameter.name === node) ||
+          (isCallExpression(node.parent) && node.parent.expression === node)
+        ) {
+          // The exact import and direct call are validated separately.
+        } else {
+          throw new Error(`${file} aliases the red-probe assertion helper`);
+        }
+      }
+    }
+
+    if (
+      isStringLiteralLike(node) &&
+      isElementAccessExpression(node.parent) &&
+      node.parent.argumentExpression === node &&
+      FORBIDDEN_TEST_METHODS.has(node.text)
+    ) {
+      throw new Error(`${file} uses forbidden test control ${node.text}`);
+    }
+
+    if (isCallExpression(node)) {
+      const expression = node.expression;
+      if (expression.kind === SyntaxKind.ImportKeyword) {
+        throw new Error(`${file} uses forbidden dynamic import`);
+      }
+      if (isIdentifier(expression) && expression.text === "require") {
+        throw new Error(`${file} uses forbidden require loading`);
+      }
+      if (
+        isPropertyAccessExpression(expression) &&
+        FORBIDDEN_TEST_METHODS.has(expression.name.text)
+      ) {
+        throw new Error(
+          `${file} uses forbidden test control ${expression.name.text}`,
+        );
+      }
+      if (
+        isElementAccessExpression(expression) &&
+        isStringLiteralLike(expression.argumentExpression) &&
+        FORBIDDEN_TEST_METHODS.has(expression.argumentExpression.text)
+      ) {
+        throw new Error(
+          `${file} uses forbidden test control ${expression.argumentExpression.text}`,
+        );
+      }
+      if (
+        isIdentifier(expression) &&
+        expression.text === RED_PROBE_HELPER_FUNCTION
+      ) {
+        helperAssertionCalls += 1;
+        if (
+          node.arguments.length !== 3 ||
+          !isExpressionStatement(node.parent) ||
+          node.parent.parent !== rootRunner.body
+        ) {
+          throw new Error(
+            `${file} must make one direct root-runner red-probe assertion`,
+          );
+        }
+        rootHelperAssertionCalls += 1;
+      }
+    }
+  };
+
+  const pending = [{ depth: 1, node: sourceFile }];
+  let visitedNodes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    visitedNodes += 1;
+    if (visitedNodes > MAXIMUM_SOURCE_AST_NODES) {
+      throw new Error(
+        `${file} exceeds the ${MAXIMUM_SOURCE_AST_NODES}-node source-policy limit`,
+      );
+    }
+    if (current.depth > MAXIMUM_SOURCE_AST_DEPTH) {
+      throw new Error(
+        `${file} exceeds the ${MAXIMUM_SOURCE_AST_DEPTH}-level source-policy limit`,
+      );
+    }
+    inspectNode(current.node);
+    const children = [];
+    forEachChild(current.node, (child) => {
+      children.push(child);
+    });
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      pending.push({ depth: current.depth + 1, node: children[index] });
+    }
+  }
+
+  if (canonicalHelperTypeImports !== 1) {
+    throw new Error(
+      `${file} must import the canonical red-probe helper type exactly once`,
+    );
+  }
+  if (helperAssertionCalls !== 1 || rootHelperAssertionCalls !== 1) {
+    throw new Error(
+      `${file} must make one direct root-runner red-probe assertion`,
+    );
+  }
+}
+
+function assertAuthenticationSecret(authenticationSecret) {
+  if (
+    !Buffer.isBuffer(authenticationSecret) ||
+    authenticationSecret.byteLength !== RED_PROBE_AUTHENTICATION_SECRET_BYTES
+  ) {
+    throw new Error(
+      `red-probe authentication secret must contain exactly ${RED_PROBE_AUTHENTICATION_SECRET_BYTES} bytes`,
+    );
+  }
+}
+
+function canonicalFinalEvidence(entry) {
+  return {
+    protocolVersion: RED_PROBE_PROTOCOL_VERSION,
+    outcome: PROTOCOL_OUTCOME,
+    id: entry.id,
+    task: entry.task,
+    fingerprint: entry.fingerprint,
+    assertions: 1,
+    skipped: 0,
+    todos: 0,
+  };
+}
+
+function finalAuthenticationTag(entry, authenticationSecret) {
+  assertAuthenticationSecret(authenticationSecret);
+  return createHmac("sha256", authenticationSecret)
+    .update(FINAL_AUTHENTICATION_DOMAIN, "utf8")
+    .update(JSON.stringify(canonicalFinalEvidence(entry)), "utf8")
+    .digest("hex");
+}
+
+function expectedProtocolLine(entry, authenticationSecret) {
+  const evidence = canonicalFinalEvidence(entry);
+  return `${RED_PROBE_PROTOCOL_PREFIX}${JSON.stringify({
+    ...evidence,
+    authenticationTag: finalAuthenticationTag(entry, authenticationSecret),
+  })}\n`;
+}
+
+function isExpectedProtocolLine(entry, authenticationSecret, line) {
+  if (!line.startsWith(RED_PROBE_PROTOCOL_PREFIX) || !line.endsWith("\n")) {
+    return false;
+  }
+  let record;
+  try {
+    record = JSON.parse(line.slice(RED_PROBE_PROTOCOL_PREFIX.length, -1));
+  } catch {
+    return false;
+  }
+  const actualTag = record?.authenticationTag;
+  if (
+    typeof actualTag !== "string" ||
+    !RED_PROBE_AUTHENTICATION_TAG_PATTERN.test(actualTag)
+  ) {
+    return false;
+  }
+  const expectedTag = finalAuthenticationTag(entry, authenticationSecret);
+  if (
+    !timingSafeEqual(
+      Buffer.from(actualTag, "hex"),
+      Buffer.from(expectedTag, "hex"),
+    )
+  ) {
+    return false;
+  }
+  return line === expectedProtocolLine(entry, authenticationSecret);
+}
+
+function expectedHeartbeatLine(entry, sequence) {
+  return `${RED_PROBE_HEARTBEAT_PREFIX}${JSON.stringify({
+    protocolVersion: RED_PROBE_PROTOCOL_VERSION,
+    outcome: HEARTBEAT_PROTOCOL_OUTCOME,
+    id: entry.id,
+    task: entry.task,
+    fingerprint: entry.fingerprint,
+    sequence,
+  })}\n`;
+}
+
+function isInitialHeartbeat(entry, line) {
+  return line === expectedHeartbeatLine(entry, 1);
+}
+
+export function createRedProbeProtocolState() {
+  return Object.freeze({
+    expectedSequence: 1,
+    finalRecordObserved: false,
+    protocolInvalid: false,
+    recordsObserved: 0,
+  });
+}
+
+export function observeRedProbeProtocolLine(
+  entry,
+  state,
+  line,
+  authenticationSecret,
+) {
+  const recordsObserved = state.recordsObserved + 1;
+  if (state.protocolInvalid) {
+    return Object.freeze({ ...state, recordsObserved });
+  }
+  if (state.finalRecordObserved) {
+    return Object.freeze({
+      ...state,
+      protocolInvalid: true,
+      recordsObserved,
+    });
+  }
+  if (state.expectedSequence === 1) {
+    if (recordsObserved !== 1 || !isInitialHeartbeat(entry, line)) {
+      return Object.freeze({
+        ...state,
+        protocolInvalid: true,
+        recordsObserved,
+      });
+    }
+    return Object.freeze({
+      ...state,
+      expectedSequence: state.expectedSequence + 1,
+      recordsObserved,
+    });
+  }
+  if (line === expectedHeartbeatLine(entry, state.expectedSequence)) {
+    return Object.freeze({
+      ...state,
+      expectedSequence: state.expectedSequence + 1,
+      recordsObserved,
+    });
+  }
+  if (isExpectedProtocolLine(entry, authenticationSecret, line)) {
+    return Object.freeze({
+      ...state,
+      finalRecordObserved: true,
+      recordsObserved,
+    });
+  }
+  return Object.freeze({
+    ...state,
+    protocolInvalid: true,
+    recordsObserved,
+  });
+}
+
+function createHeartbeatMonitor(entry, authenticationSecret, silenceMs) {
+  const abortController = new AbortController();
+  let bufferedOutput = Buffer.alloc(0);
+  let expired = false;
+  let protocolState = createRedProbeProtocolState();
+  let silenceTimer;
+
+  const disarm = () => {
+    if (silenceTimer === undefined) return;
+    clearTimeout(silenceTimer);
+    silenceTimer = undefined;
+  };
+  const arm = () => {
+    disarm();
+    if (abortController.signal.aborted || protocolState.finalRecordObserved) {
+      return;
+    }
+    silenceTimer = setTimeout(() => {
+      expired = true;
+      abortController.abort();
+    }, silenceMs);
+    silenceTimer.unref?.();
+  };
+  const observe = (chunk) => {
+    bufferedOutput = Buffer.concat([bufferedOutput, chunk]);
+    for (
+      let newline = bufferedOutput.indexOf(0x0a);
+      newline >= 0;
+      newline = bufferedOutput.indexOf(0x0a)
+    ) {
+      const line = bufferedOutput.subarray(0, newline + 1).toString("utf8");
+      bufferedOutput = bufferedOutput.subarray(newline + 1);
+      const previousState = protocolState;
+      protocolState = observeRedProbeProtocolLine(
+        entry,
+        protocolState,
+        line,
+        authenticationSecret,
+      );
+      if (protocolState.protocolInvalid) continue;
+      if (
+        protocolState.expectedSequence ===
+        previousState.expectedSequence + 1
+      ) {
+        arm();
+      } else if (protocolState.finalRecordObserved) {
+        disarm();
+      }
+    }
+  };
+
+  arm();
+  return Object.freeze({
+    close: disarm,
+    observe,
+    signal: abortController.signal,
+    snapshot() {
+      return Object.freeze({
+        expired,
+        finalRecordObserved: protocolState.finalRecordObserved,
+        observedHeartbeats: protocolState.expectedSequence - 1,
+        protocolInvalid: protocolState.protocolInvalid,
+        recordsObserved: protocolState.recordsObserved,
+        silenceMs,
+      });
+    },
+  });
+}
+
+function isCanonicalProbeOutput(entry, bytes, heartbeat, authenticationSecret) {
+  if (heartbeat.protocolInvalid || heartbeat.recordsObserved < 2) {
+    return false;
+  }
+  const output = bytes.toString("utf8");
+  if (!output.endsWith("\n")) return false;
+  const records = output.slice(0, -1).split("\n");
+  if (records.length < 2) return false;
+
+  const finalRecord = records.at(-1);
+  if (
+    !isExpectedProtocolLine(entry, authenticationSecret, `${finalRecord}\n`)
+  ) {
+    return false;
+  }
+  const heartbeatRecords = records.slice(0, -1);
+  if (
+    !heartbeat.finalRecordObserved ||
+    heartbeat.expired ||
+    heartbeat.recordsObserved !== records.length ||
+    heartbeat.observedHeartbeats !== heartbeatRecords.length
+  ) {
+    return false;
+  }
+  return heartbeatRecords.every(
+    (record, index) =>
+      `${record}\n` === expectedHeartbeatLine(entry, index + 1),
+  );
+}
+
+function quoteWindowsCommandLineArgument(value) {
+  if (value.length > 0 && !/[\s"]/u.test(value)) return value;
+  let quoted = '"';
+  let backslashes = 0;
+  for (const character of value) {
+    if (character === "\\") {
+      backslashes += 1;
+      continue;
+    }
+    if (character === '"') {
+      quoted += "\\".repeat(backslashes * 2 + 1);
+      quoted += '"';
+      backslashes = 0;
+      continue;
+    }
+    quoted += "\\".repeat(backslashes);
+    backslashes = 0;
+    quoted += character;
+  }
+  quoted += "\\".repeat(backslashes * 2);
+  return `${quoted}"`;
+}
+
+function windowsEnvironmentBlockCodeUnits(env) {
+  let codeUnits = WINDOWS_ENVIRONMENT_BLOCK_FINAL_TERMINATOR_CODE_UNITS;
+  for (const [name, value] of Object.entries(env)) {
+    codeUnits += name.length + 1 + value.length + 1;
+  }
+  return codeUnits;
+}
+
+export function measurePortableWindowsLaunch(program, args, env) {
+  const commandLine = [program, ...args]
+    .map(quoteWindowsCommandLineArgument)
+    .join(" ");
+  const brokerEnvironment = {
+    ...env,
+    AGENC_PROCESS_JOB_PROGRAM: Buffer.from(program, "utf8").toString("base64"),
+    AGENC_PROCESS_JOB_COMMAND_LINE: Buffer.from(commandLine, "utf8").toString(
+      "base64",
+    ),
+    AGENC_PROCESS_JOB_OWNER_PID: String(process.pid),
+  };
+  return Object.freeze({
+    brokerEnvironmentCodeUnits:
+      windowsEnvironmentBlockCodeUnits(brokerEnvironment),
+    headroomCodeUnits: WINDOWS_LAUNCH_HEADROOM_CODE_UNITS,
+    maximumCodeUnits: WINDOWS_PORTABLE_LAUNCH_MAXIMUM_CODE_UNITS,
+    targetCommandLineCodeUnits:
+      commandLine.length + WINDOWS_COMMAND_LINE_TERMINATOR_CODE_UNITS,
+    targetEnvironmentCodeUnits: windowsEnvironmentBlockCodeUnits(env),
+  });
+}
+
+export function assertPortableWindowsLaunch(program, args, env) {
+  const measurement = measurePortableWindowsLaunch(program, args, env);
+  for (const [label, codeUnits] of [
+    ["target command line", measurement.targetCommandLineCodeUnits],
+    ["target environment", measurement.targetEnvironmentCodeUnits],
+    ["broker environment", measurement.brokerEnvironmentCodeUnits],
+  ]) {
+    if (codeUnits > measurement.maximumCodeUnits) {
+      throw new Error(
+        `red-probe ${label} needs ${codeUnits} UTF-16 code units; portable Windows launches reserve ${measurement.headroomCodeUnits} of ${WINDOWS_CREATE_PROCESS_MAXIMUM_CODE_UNITS} code units`,
+      );
+    }
+  }
+  return measurement;
+}
+
+function stdinModuleUrl(path) {
+  const directoryUrl = pathToFileURL(`${dirname(path)}${sep}`);
+  return new URL(STDIN_MODULE_FILENAME, directoryUrl).href;
+}
+
+function probeCommandArgs(bootstrapImportUrl) {
+  return Object.freeze([
+    "--import",
+    bootstrapImportUrl,
+    "--input-type=module",
+    "--experimental-strip-types",
+    "--eval",
+    "",
+  ]);
+}
+
+function createProbeEnvironment(runRoot, entry, supportGraph, probeSourceUrl) {
+  const home = resolve(runRoot, "home");
+  const attemptLedger = resolve(runRoot, "network-attempts");
+  mkdirSync(home, { mode: 0o700, recursive: true });
+  mkdirSync(attemptLedger, { mode: 0o700, recursive: true });
+  const env = createHermeticLaunchEnv(process.env, runRoot);
+  sanitizeHermeticEnv(env, home);
+  env.AGENC_TEST_HERMETIC_RUN_ROOT = runRoot;
+  env.AGENC_TEST_NETWORK_ATTEMPT_LEDGER = attemptLedger;
+  const bootstrapConfiguration = Object.freeze({
+    fingerprint: entry.fingerprint,
+    heartbeatIntervalMs: RED_PROBE_HEARTBEAT_INTERVAL_MS,
+    helperRequestUrl: supportGraph.helperRequestUrl,
+    helperSourceDeflateBase64: supportGraph.helperSourceDeflateBase64,
+    helperSourceSha256: supportGraph.helperSourceSha256,
+    helperSourceUrl: supportGraph.helperSourceUrl,
+    id: entry.id,
+    networkTripwireUrl: supportGraph.networkTripwireUrl,
+    probeSourceSha256: entry.sourceSha256,
+    probeSourceUrl,
+    task: entry.task,
+    tsxLoaderUrl: supportGraph.tsxLoaderUrl,
+  });
+  env[BOOTSTRAP_ENVIRONMENT_VARIABLE] = JSON.stringify(bootstrapConfiguration);
+  return { attemptLedger, bootstrapConfiguration, env };
+}
+
+function createProbeAuthenticationSecret() {
+  const authenticationSecret = randomBytes(
+    RED_PROBE_AUTHENTICATION_SECRET_BYTES,
+  );
+  assertAuthenticationSecret(authenticationSecret);
+  return authenticationSecret;
+}
+
+function createProbeHandoff(sourceBytes, authenticationSecret) {
+  assertAuthenticationSecret(authenticationSecret);
+  if (
+    !Buffer.isBuffer(sourceBytes) ||
+    sourceBytes.byteLength < 1 ||
+    sourceBytes.byteLength > MAXIMUM_PROBE_BYTES
+  ) {
+    throw new Error("red-probe source exceeds its handoff bound");
+  }
+  const handoff = Buffer.concat([
+    RED_PROBE_HANDOFF_MAGIC,
+    authenticationSecret,
+    sourceBytes,
+  ]);
+  if (handoff.byteLength > MAXIMUM_HANDOFF_BYTES) {
+    throw new Error("red-probe bootstrap handoff exceeds its bound");
+  }
+  return handoff;
+}
+
+function spawnProbe(
+  handoffBytes,
+  path,
+  entry,
+  env,
+  maximumOutputBytes,
+  bootstrapImportUrl,
+  authenticationSecret,
+  heartbeatSilenceMs,
+) {
+  const heartbeat = createHeartbeatMonitor(
+    entry,
+    authenticationSecret,
+    heartbeatSilenceMs,
+  );
+  const args = probeCommandArgs(bootstrapImportUrl);
+  assertPortableWindowsLaunch(process.execPath, args, env);
+  let supervised;
+  try {
+    supervised = runSupervisedProcess(
+      {
+        program: process.execPath,
+        args,
+        cwd: dirname(path),
+        env,
+      },
+      {
+        timeoutMs: entry.timeoutMs,
+        maxOutputBytes: maximumOutputBytes,
+        stdin: handoffBytes,
+        signal: heartbeat.signal,
+        terminateGraceMs: TERMINATE_GRACE_MS,
+        settleBackstopMs: SETTLE_BACKSTOP_MS,
+        onStdout: heartbeat.observe,
+      },
+    );
+  } catch (error) {
+    heartbeat.close();
+    throw error;
+  }
+  // The supervisor's timeout, termination grace, and settlement backstop bound
+  // this promise, but its internal cleanup timers are deliberately unref'd for
+  // library callers. Keep the standalone audit referenced until physical
+  // process-tree settlement completes; clearing earlier can abandon this
+  // top-level await with Node's exit status 13.
+  const settlementKeepalive = setInterval(
+    () => undefined,
+    SUPERVISOR_SETTLEMENT_KEEPALIVE_INTERVAL_MS,
+  );
+  const physicallySettled = supervised.finally(() => {
+    clearInterval(settlementKeepalive);
+  });
+  return physicallySettled.then(
+    (result) => {
+      const heartbeatEvidence = heartbeat.snapshot();
+      heartbeat.close();
+      return Object.freeze({ heartbeat: heartbeatEvidence, result });
+    },
+    (error) => {
+      heartbeat.close();
+      throw error;
+    },
+  );
+}
+
+function formatChildEvidence(result) {
+  return [
+    `exit=${String(result.exitCode)} signal=${String(result.signal)}`,
+    `stop=${String(result.stopReason)}`,
+    `stdout=${JSON.stringify(result.stdout.toString("utf8"))}`,
+    `stderr=${JSON.stringify(result.stderr.toString("utf8"))}`,
+  ].join(" ");
+}
+
+function assertExpectedRedResult(
+  entry,
+  result,
+  heartbeat,
+  authenticationSecret,
+) {
+  if (heartbeat.expired && result.stopReason === "aborted") {
+    throw new Error(
+      `${entry.id} missed a trusted heartbeat for ${heartbeat.silenceMs}ms`,
+    );
+  }
+  if (result.stopReason === "timeout") {
+    throw new Error(`${entry.id} timed out after ${entry.timeoutMs}ms`);
+  }
+  if (result.stopReason === "output_limit") {
+    throw new Error(`${entry.id} exceeded the child-output limit`);
+  }
+  if (
+    result.stopReason !== undefined ||
+    result.error !== undefined ||
+    result.backstopExpired ||
+    result.forced
+  ) {
+    throw new Error(
+      `${entry.id} had a supervisor or containment failure: ${formatChildEvidence(result)}`,
+    );
+  }
+  if (result.signal !== null) {
+    throw new Error(`${entry.id} exited on signal ${result.signal}`);
+  }
+  if (result.exitCode !== RED_PROBE_EXPECTED_EXIT_CODE) {
+    throw new Error(
+      `${entry.id} did not exit expected-red: ${formatChildEvidence(result)}`,
+    );
+  }
+  if (
+    !isCanonicalProbeOutput(
+      entry,
+      result.stdout,
+      heartbeat,
+      authenticationSecret,
+    ) ||
+    result.stderr.byteLength !== 0
+  ) {
+    throw new Error(
+      `${entry.id} emitted unrelated or noncanonical output: ${formatChildEvidence(result)}`,
+    );
+  }
+}
+
+function assertNoNetworkAttempts(attemptLedger) {
+  const directory = opendirSync(attemptLedger);
+  try {
+    if (directory.readSync() !== null) {
+      throw new Error("red probes attempted public network access");
+    }
+  } finally {
+    directory.closeSync();
+  }
+}
+
+export async function auditRedProbes(options = {}) {
+  const runtimeRoot = resolve(options.runtimeRoot ?? defaultRuntimeRoot);
+  const maximumOutputBytes =
+    options.maximumOutputBytes ?? MAXIMUM_CHILD_OUTPUT_BYTES;
+  if (
+    !Number.isSafeInteger(maximumOutputBytes) ||
+    maximumOutputBytes < 1 ||
+    maximumOutputBytes > MAXIMUM_CHILD_OUTPUT_BYTES
+  ) {
+    throw new Error(
+      `maximumOutputBytes must be a safe integer in [1, ${MAXIMUM_CHILD_OUTPUT_BYTES}]`,
+    );
+  }
+  const heartbeatSilenceMs =
+    options.testing?.heartbeatSilenceMs ?? RED_PROBE_HEARTBEAT_SILENCE_MS;
+  if (
+    !Number.isSafeInteger(heartbeatSilenceMs) ||
+    heartbeatSilenceMs < MINIMUM_TEST_HEARTBEAT_SILENCE_MS ||
+    heartbeatSilenceMs > RED_PROBE_HEARTBEAT_SILENCE_MS
+  ) {
+    throw new Error(
+      `testing.heartbeatSilenceMs must be a safe integer in [${MINIMUM_TEST_HEARTBEAT_SILENCE_MS}, ${RED_PROBE_HEARTBEAT_SILENCE_MS}]`,
+    );
+  }
+
+  const manifest = loadRedProbeManifest(runtimeRoot);
+  const discovered = discoverRedProbeFiles(runtimeRoot);
+  assertExactInventory(manifest, discovered);
+  const supportGraph = loadRedProbeSupportGraph(runtimeRoot);
+
+  const runRoot = createHermeticRunRoot("agr-", options.testing?.runBase);
+  try {
+    await options.testing?.afterRunRootCreated?.(Object.freeze({ runRoot }));
+    for (const entry of manifest.probes) {
+      const probeRunRoot = resolve(runRoot, entry.id);
+      const path = assertProbePath(runtimeRoot, entry.file);
+      const probeSourceUrl = stdinModuleUrl(path);
+      const { attemptLedger, bootstrapConfiguration, env } =
+        createProbeEnvironment(
+          probeRunRoot,
+          entry,
+          supportGraph,
+          probeSourceUrl,
+        );
+      await options.testing?.afterProbeEnvironmentCreated?.(
+        Object.freeze({ bootstrapConfiguration, entry }),
+      );
+      const sourceBytes = readBoundedRegularFile(
+        path,
+        MAXIMUM_PROBE_BYTES,
+        entry.file,
+        options.testing?.afterProbeFileOpened,
+      );
+      if (sha256(sourceBytes) !== entry.sourceSha256) {
+        throw new Error(
+          `${entry.id} source digest does not match its manifest`,
+        );
+      }
+      const source = decodeUtf8(sourceBytes, entry.file);
+      assertProbeSourcePolicy(source, entry.file);
+      await options.testing?.afterProbeVerified?.(
+        Object.freeze({ entry, path }),
+      );
+      const authenticationSecret = createProbeAuthenticationSecret();
+      const handoffBytes = createProbeHandoff(
+        sourceBytes,
+        authenticationSecret,
+      );
+      const execution = await spawnProbe(
+        handoffBytes,
+        path,
+        entry,
+        env,
+        maximumOutputBytes,
+        supportGraph.bootstrapImportUrl,
+        authenticationSecret,
+        heartbeatSilenceMs,
+      );
+      assertNoNetworkAttempts(attemptLedger);
+      assertExpectedRedResult(
+        entry,
+        execution.result,
+        execution.heartbeat,
+        authenticationSecret,
+      );
+    }
+    return Object.freeze({
+      files: manifest.probeCount,
+      expectedRed: manifest.probeCount,
+      assertions: manifest.probeCount,
+      skipped: 0,
+      todos: 0,
+    });
+  } finally {
+    rmSync(runRoot, { force: true, recursive: true });
+  }
+}
+
+export async function runRedProbeCli(auditOptions = {}) {
+  if (process.argv.length !== 2) {
+    process.stderr.write("Usage: node scripts/run-fnd-red-probes.mjs\n");
+    return 2;
+  }
+  try {
+    const result = await auditRedProbes(auditOptions);
+    process.stdout.write(
+      `red probes: files=${result.files} expected-red=${result.expectedRed} assertions=${result.assertions} skipped=${result.skipped} todo=${result.todos}\n`,
+    );
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`red-probe audit failed: ${message}\n`);
+    return 1;
+  }
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (invokedAsScript) process.exitCode = await runRedProbeCli();

--- a/runtime/scripts/run-hermetic-test-boundary.mjs
+++ b/runtime/scripts/run-hermetic-test-boundary.mjs
@@ -32,6 +32,7 @@ export const HERMETIC_SUITE_COMMAND =
   'umask 077 && mkdir -p "$HOME" && chmod 700 "$HOME" && ' +
   "node ../node_modules/typescript/bin/tsc --noEmit && " +
   "node ../node_modules/typescript/bin/tsc --noEmit --project tsconfig.test-support.json && " +
+  "node scripts/run-fnd-red-probes.mjs && " +
   'exec node scripts/run-hermetic-vitest.mjs --require-zero-skips "$@"';
 const DEFAULT_DOCKER_HOST = "unix:///var/run/docker.sock";
 export function resolveDockerHost(value = process.env.DOCKER_HOST) {

--- a/runtime/tests/fnd/README.md
+++ b/runtime/tests/fnd/README.md
@@ -59,8 +59,8 @@ bun test runtime/tests/fnd/portable-repository-path.bun.test.ts \
 The isolated benchmark harness and reviewed known-failure baseline live in
 [`../../benchmarks/fnd/`](../../benchmarks/fnd/). Red probes remain separate
 from timing evidence so noisy wall-clock measurements never enter the default
-test suite. The red-probe runner lands in its separately reviewed foundation
-PR. Production parsers must not import these test-only helpers, benchmarks, or
+test suite. The authenticated red-probe runner and containment contracts live in this
+foundation layer. Production parsers must not import these test-only helpers, benchmarks, or
 the fixture corpus.
 
 ## Process and restart helpers

--- a/runtime/tests/fnd/red-probe-containment.test.ts
+++ b/runtime/tests/fnd/red-probe-containment.test.ts
@@ -1,0 +1,241 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const runtimeRoot = fileURLToPath(new URL("../../", import.meta.url));
+const redProbeRunnerUrl = new URL(
+  "../../scripts/run-fnd-red-probes.mjs",
+  import.meta.url,
+).href;
+const auditSha = "d2b228e87ea63bd6a5d93e6f599f36bce88d672b";
+const fixtureId = "windows-containment";
+const fixtureFingerprint = "FND-001:HARNESS-SELF-TEST:WINDOWS-CONTAINMENT";
+const fixtureFile = "tests/fnd/red-probes/windows-containment.red-probe.ts";
+const helperTypeImport =
+  'import type { RedProbeAssertion } from "../../helpers/red-probe.js";';
+const standaloneAuditTimeoutMs = 15_000;
+const temporaryRoots: string[] = [];
+const possibleDescendantPids: number[] = [];
+
+interface FixtureOptions {
+  readonly source: string;
+  readonly timeoutMs: number;
+}
+
+function sha256(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function canonicalProbe(
+  beforeAssertion: readonly string[],
+  imports: readonly string[] = [],
+): string {
+  return [
+    helperTypeImport,
+    ...imports,
+    "export default async function runRedProbe(",
+    "  expectDeepStrictEqualRedProbe: RedProbeAssertion,",
+    "): Promise<void> {",
+    `  const identity = ${JSON.stringify({
+      id: fixtureId,
+      task: "FND-001",
+      fingerprint: fixtureFingerprint,
+    })};`,
+    ...beforeAssertion.flatMap((line) =>
+      line.split("\n").map((part) => `  ${part}`),
+    ),
+    "  expectDeepStrictEqualRedProbe(identity, 1, 2);",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function createFixture(options: FixtureOptions): string {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "agenc-red-containment-"));
+  temporaryRoots.push(fixtureRoot);
+  const probeDirectory = join(fixtureRoot, "tests/fnd/red-probes");
+  const helperDirectory = join(fixtureRoot, "tests/helpers");
+  mkdirSync(probeDirectory, { recursive: true });
+  mkdirSync(helperDirectory, { recursive: true });
+  copyFileSync(
+    join(runtimeRoot, "tests/helpers/red-probe.ts"),
+    join(helperDirectory, "red-probe.ts"),
+  );
+  copyFileSync(
+    join(runtimeRoot, "tests/helpers/red-probe-bootstrap.mjs"),
+    join(helperDirectory, "red-probe-bootstrap.mjs"),
+  );
+  writeFileSync(join(fixtureRoot, fixtureFile), options.source, "utf8");
+  writeFileSync(
+    join(probeDirectory, "manifest.json"),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      auditSha,
+      probeCount: 1,
+      probes: [
+        {
+          id: fixtureId,
+          task: "FND-001",
+          classification: "harness-self-test",
+          file: fixtureFile,
+          fingerprint: fixtureFingerprint,
+          sourceSha256: sha256(options.source),
+          timeoutMs: options.timeoutMs,
+        },
+      ],
+    })}\n`,
+    "utf8",
+  );
+  return fixtureRoot;
+}
+
+function runFixtureAudit(fixtureRoot: string): {
+  readonly result: SpawnSyncReturns<string>;
+  readonly runRootMarker: string;
+} {
+  const standaloneAudit = join(fixtureRoot, "standalone-audit.mjs");
+  const runRootMarker = join(fixtureRoot, "audit-run-root.txt");
+  writeFileSync(
+    standaloneAudit,
+    [
+      'import { writeFileSync } from "node:fs";',
+      `import { runRedProbeCli } from ${JSON.stringify(redProbeRunnerUrl)};`,
+      "const fixtureRoot = process.env.AGENC_RED_PROBE_TEST_FIXTURE_ROOT;",
+      "const runRootMarker = process.env.AGENC_RED_PROBE_TEST_RUN_ROOT_MARKER;",
+      "delete process.env.AGENC_RED_PROBE_TEST_FIXTURE_ROOT;",
+      "delete process.env.AGENC_RED_PROBE_TEST_RUN_ROOT_MARKER;",
+      'if (!fixtureRoot || !runRootMarker) throw new Error("missing standalone audit inputs");',
+      "process.exitCode = await runRedProbeCli({",
+      "  runtimeRoot: fixtureRoot,",
+      "  testing: {",
+      "    afterRunRootCreated({ runRoot }) {",
+      '      writeFileSync(runRootMarker, runRoot, "utf8");',
+      "    },",
+      "  },",
+      "});",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  const result = spawnSync(process.execPath, [standaloneAudit], {
+    cwd: runtimeRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENC_RED_PROBE_TEST_FIXTURE_ROOT: fixtureRoot,
+      AGENC_RED_PROBE_TEST_RUN_ROOT_MARKER: runRootMarker,
+    },
+    timeout: standaloneAuditTimeoutMs,
+  });
+  return { result, runRootMarker };
+}
+
+function expectFailedAudit(
+  result: SpawnSyncReturns<string>,
+  expectedMessage: string,
+): void {
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  expect(result.status).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).toContain("red-probe audit failed:");
+  expect(result.stderr).toContain(expectedMessage);
+}
+
+afterEach(() => {
+  for (const pid of possibleDescendantPids.splice(0)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The containment contract normally removes the process first.
+    }
+  }
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("red-probe forced containment", () => {
+  it("enforces the hard deadline after an expected-red assertion", () => {
+    const fixtureRoot = createFixture({
+      source: canonicalProbe(["setInterval(() => undefined, 1_000);"]),
+      timeoutMs: 100,
+    });
+
+    const { result } = runFixtureAudit(fixtureRoot);
+    expectFailedAudit(result, "timed out after 100ms");
+  });
+
+  it("enforces the aggregate child-output limit", () => {
+    const fixtureRoot = createFixture({
+      source: canonicalProbe(
+        ["writeSync(1, Buffer.alloc(32_768, 120));"],
+        ['import { writeSync } from "node:fs";'],
+      ),
+      timeoutMs: 5_000,
+    });
+
+    const { result } = runFixtureAudit(fixtureRoot);
+    expectFailedAudit(result, "exceeded the child-output limit");
+  });
+
+  it("kills a resistant detached descendant and removes the run root", () => {
+    const fixtureRoot = createFixture({
+      source: "",
+      timeoutMs: 500,
+    });
+    const marker = join(fixtureRoot, "descendant.pid");
+    const source = canonicalProbe(
+      [
+        `const child = spawn("node", ["--eval", ${JSON.stringify(
+          "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)",
+        )}], {`,
+        "  detached: true,",
+        '  stdio: "ignore",',
+        "});",
+        'if (child.pid === undefined) throw new Error("missing descendant pid");',
+        `writeFileSync(${JSON.stringify(marker)}, String(child.pid), "utf8");`,
+        "child.unref();",
+        "setInterval(() => undefined, 1_000);",
+      ],
+      [
+        'import { spawn } from "node:child_process";',
+        'import { writeFileSync } from "node:fs";',
+      ],
+    );
+    writeFileSync(join(fixtureRoot, fixtureFile), source, "utf8");
+    const manifestPath = join(
+      fixtureRoot,
+      "tests/fnd/red-probes/manifest.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      probes: Array<{ sourceSha256: string }>;
+    };
+    manifest.probes[0]!.sourceSha256 = sha256(source);
+    writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+    const { result, runRootMarker } = runFixtureAudit(fixtureRoot);
+    expectFailedAudit(result, "timed out after 500ms");
+
+    const descendantPid = Number.parseInt(readFileSync(marker, "utf8"), 10);
+    const runRoot = readFileSync(runRootMarker, "utf8");
+    possibleDescendantPids.push(descendantPid);
+    expect(Number.isSafeInteger(descendantPid)).toBe(true);
+    expect(() => process.kill(descendantPid, 0)).toThrow();
+    possibleDescendantPids.pop();
+    expect(runRoot).not.toBe("");
+    expect(existsSync(runRoot)).toBe(false);
+  });
+});

--- a/runtime/tests/fnd/red-probe-runner.contract.test.ts
+++ b/runtime/tests/fnd/red-probe-runner.contract.test.ts
@@ -1,0 +1,1633 @@
+import { spawnSync } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+import {
+  appendFileSync,
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, matchesGlob, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createRedProbeAssertion,
+  RED_PROBE_EXPECTED_EXIT_CODE as HELPER_EXPECTED_EXIT_CODE,
+  RED_PROBE_PROTOCOL_PREFIX as HELPER_PROTOCOL_PREFIX,
+  RED_PROBE_PROTOCOL_VERSION as HELPER_PROTOCOL_VERSION,
+  RED_PROBE_TASK_IDS as HELPER_TASK_IDS,
+} from "../helpers/red-probe.js";
+import {
+  assertPortableWindowsLaunch,
+  auditRedProbes,
+  createRedProbeProtocolState,
+  loadRedProbeManifest,
+  measurePortableWindowsLaunch,
+  observeRedProbeProtocolLine,
+  RED_PROBE_EXPECTED_EXIT_CODE as RUNNER_EXPECTED_EXIT_CODE,
+  RED_PROBE_HEARTBEAT_PREFIX as RUNNER_HEARTBEAT_PREFIX,
+  RED_PROBE_PROTOCOL_PREFIX as RUNNER_PROTOCOL_PREFIX,
+  RED_PROBE_PROTOCOL_VERSION as RUNNER_PROTOCOL_VERSION,
+  RED_PROBE_TASK_IDS as RUNNER_TASK_IDS,
+  WINDOWS_PORTABLE_LAUNCH_MAXIMUM_CODE_UNITS,
+} from "../../scripts/run-fnd-red-probes.mjs";
+import {
+  DEFAULT_TEST_EXCLUDE,
+  DEFAULT_TEST_INCLUDE,
+  NATIVE_TEST_INCLUDE,
+} from "../../vitest.config.js";
+
+const runtimeRoot = fileURLToPath(new URL("../../", import.meta.url));
+const repositoryRoot = resolve(runtimeRoot, "..");
+const redProbeFile =
+  "tests/fnd/red-probes/intentional-transition-omission.red-probe.ts";
+const fixtureProbeFile = "tests/fnd/red-probes/contract-fixture.red-probe.ts";
+const canonicalHelperTypeImport =
+  'import type { RedProbeAssertion } from "../../helpers/red-probe.js";';
+const auditSha = "d2b228e87ea63bd6a5d93e6f599f36bce88d672b";
+const testId = "contract-fixture";
+const testTask = "FND-001";
+const testFingerprint = "FND-001:HARNESS-SELF-TEST:CONTRACT-FIXTURE";
+const inventoryOverflowFileCount = 320;
+const jsonNodeOverflowCount = 16_384;
+const sourceAstNodeOverflowItems = 16_500;
+const reporterHandoffSymbolKey = "agenc.red-probe.report-expected-failure.v1";
+const finalAuthenticationDomain = "AGENC_RED_PROBE_FINAL_V1\0";
+const protocolAuthenticationSecret = Buffer.alloc(32, 0x11);
+const alternateProtocolAuthenticationSecret = Buffer.alloc(32, 0x22);
+const protocolEntry = Object.freeze({
+  fingerprint: testFingerprint,
+  id: testId,
+  task: testTask,
+});
+const temporaryRoots: string[] = [];
+
+interface FixtureOptions {
+  readonly source?: string;
+  readonly fingerprint?: string;
+  readonly task?: string;
+  readonly timeoutMs?: number;
+}
+
+const expectedTaskIds = [
+  "FND-001",
+  "A1",
+  "A2a",
+  "A2b",
+  "A3",
+  "A4",
+  "B1",
+  "B2",
+  "B3a",
+  "B3b",
+  "C1",
+  "C2",
+  "C3a",
+  "C3b",
+  "D1",
+  "D2",
+  "D3",
+  "E1a",
+  "E1b",
+  "E2",
+  "E3",
+] as const;
+
+interface ProbeSourceOptions {
+  readonly actual?: string;
+  readonly afterAssertion?: readonly string[];
+  readonly beforeAssertion?: readonly string[];
+  readonly expected?: string;
+  readonly fingerprint?: string;
+  readonly imports?: readonly string[];
+  readonly task?: string;
+  readonly id?: string;
+}
+
+function probeSource(options: ProbeSourceOptions = {}): string {
+  const identity = {
+    id: options.id ?? testId,
+    task: options.task ?? testTask,
+    fingerprint: options.fingerprint ?? testFingerprint,
+  };
+  const body = [
+    `const identity = ${JSON.stringify(identity)};`,
+    ...(options.beforeAssertion ?? []),
+    `expectDeepStrictEqualRedProbe(identity, ${options.actual ?? "1"}, ${options.expected ?? "2"});`,
+    ...(options.afterAssertion ?? []),
+  ].flatMap((line) => line.split("\n").map((part) => `  ${part}`));
+  return [
+    canonicalHelperTypeImport,
+    ...(options.imports ?? []),
+    "export default async function runRedProbe(",
+    "  expectDeepStrictEqualRedProbe: RedProbeAssertion,",
+    "): Promise<void> {",
+    ...body,
+    "}",
+    "",
+  ].join("\n");
+}
+
+function createFixture(options: FixtureOptions = {}): string {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "agenc-red-probe-contract-"));
+  temporaryRoots.push(fixtureRoot);
+  const probeDirectory = join(fixtureRoot, "tests/fnd/red-probes");
+  const helperDirectory = join(fixtureRoot, "tests/helpers");
+  mkdirSync(probeDirectory, { recursive: true });
+  mkdirSync(helperDirectory, { recursive: true });
+  copyFileSync(
+    resolve(runtimeRoot, "tests/helpers/red-probe.ts"),
+    join(helperDirectory, "red-probe.ts"),
+  );
+  copyFileSync(
+    resolve(runtimeRoot, "tests/helpers/red-probe-bootstrap.mjs"),
+    join(helperDirectory, "red-probe-bootstrap.mjs"),
+  );
+  const fingerprint = options.fingerprint ?? testFingerprint;
+  const task = options.task ?? testTask;
+  const source = options.source ?? probeSource({ fingerprint, task });
+  const manifest = {
+    schemaVersion: 1,
+    auditSha,
+    probeCount: 1,
+    probes: [
+      {
+        id: testId,
+        classification: "harness-self-test",
+        file: fixtureProbeFile,
+        fingerprint,
+        sourceSha256: sha256(source),
+        task,
+        timeoutMs: options.timeoutMs ?? 1_000,
+      },
+    ],
+  };
+  writeFileSync(
+    join(probeDirectory, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+  writeFileSync(
+    join(probeDirectory, "contract-fixture.red-probe.ts"),
+    source,
+    "utf8",
+  );
+  return fixtureRoot;
+}
+
+function sha256(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function protocolHeartbeatLine(sequence: number): string {
+  return `${RUNNER_HEARTBEAT_PREFIX}${JSON.stringify({
+    protocolVersion: RUNNER_PROTOCOL_VERSION,
+    outcome: "heartbeat",
+    id: testId,
+    task: testTask,
+    fingerprint: testFingerprint,
+    sequence,
+  })}\n`;
+}
+
+function protocolFinalLine(
+  authenticationSecret = protocolAuthenticationSecret,
+): string {
+  const evidence = {
+    protocolVersion: RUNNER_PROTOCOL_VERSION,
+    outcome: "expected-red",
+    id: testId,
+    task: testTask,
+    fingerprint: testFingerprint,
+    assertions: 1,
+    skipped: 0,
+    todos: 0,
+  };
+  const authenticationTag = createHmac("sha256", authenticationSecret)
+    .update(finalAuthenticationDomain, "utf8")
+    .update(JSON.stringify(evidence), "utf8")
+    .digest("hex");
+  return `${RUNNER_PROTOCOL_PREFIX}${JSON.stringify({
+    ...evidence,
+    authenticationTag,
+  })}\n`;
+}
+
+function observeProtocolLines(
+  lines: readonly string[],
+  authenticationSecret = protocolAuthenticationSecret,
+) {
+  return lines.reduce(
+    (state, line) =>
+      observeRedProbeProtocolLine(
+        protocolEntry,
+        state,
+        line,
+        authenticationSecret,
+      ),
+    createRedProbeProtocolState(),
+  );
+}
+
+function replaceManifest(runtimeRootFixture: string, source: string): void {
+  writeFileSync(
+    join(runtimeRootFixture, "tests/fnd/red-probes/manifest.json"),
+    source,
+    "utf8",
+  );
+}
+
+function writeFixtureHelperModule(
+  fixtureRoot: string,
+  name: string,
+  source: string,
+): void {
+  writeFileSync(join(fixtureRoot, "tests/helpers", name), source, "utf8");
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(
+  pid: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processIsAlive(pid)) return true;
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  return !processIsAlive(pid);
+}
+
+function resolveTestOwnedAuditRunRoot(
+  candidate: string,
+  runBase: string,
+): string {
+  const expectedBase = resolve(runBase);
+  const resolvedCandidate = resolve(candidate);
+  if (
+    candidate !== resolvedCandidate ||
+    dirname(resolvedCandidate) !== expectedBase ||
+    !/^agr-[A-Za-z0-9]{6}$/u.test(basename(resolvedCandidate))
+  ) {
+    throw new Error("standalone audit reported an unsafe run root");
+  }
+  return resolvedCandidate;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("FND red-probe supervisor", () => {
+  it("audits the registered nonempty harness self-probe with zero skips and todos", async () => {
+    await expect(auditRedProbes()).resolves.toEqual({
+      files: 1,
+      expectedRed: 1,
+      assertions: 1,
+      skipped: 0,
+      todos: 0,
+    });
+  });
+
+  it("keeps the TypeScript helper and Node supervisor protocol constants exact", () => {
+    expect(RUNNER_PROTOCOL_VERSION).toBe(1);
+    expect(RUNNER_EXPECTED_EXIT_CODE).toBe(86);
+    expect(RUNNER_PROTOCOL_PREFIX).toBe("AGENC_RED_PROBE_V1 ");
+    expect(RUNNER_HEARTBEAT_PREFIX).toBe("AGENC_RED_PROBE_HEARTBEAT_V1 ");
+    expect(RUNNER_TASK_IDS).toEqual(expectedTaskIds);
+    expect(HELPER_PROTOCOL_VERSION).toBe(RUNNER_PROTOCOL_VERSION);
+    expect(HELPER_EXPECTED_EXIT_CODE).toBe(RUNNER_EXPECTED_EXIT_CODE);
+    expect(HELPER_PROTOCOL_PREFIX).toBe(RUNNER_PROTOCOL_PREFIX);
+    expect(HELPER_TASK_IDS).toEqual(RUNNER_TASK_IDS);
+  });
+
+  it("accepts a deterministic multi-heartbeat sequence followed by one final record", () => {
+    const state = observeProtocolLines([
+      protocolHeartbeatLine(1),
+      protocolHeartbeatLine(2),
+      protocolHeartbeatLine(3),
+      protocolFinalLine(),
+    ]);
+    expect(state).toEqual({
+      expectedSequence: 4,
+      finalRecordObserved: true,
+      protocolInvalid: false,
+      recordsObserved: 4,
+    });
+  });
+
+  it.each([
+    {
+      name: "non-one initial sequence",
+      lines: [protocolHeartbeatLine(2)],
+    },
+    {
+      name: "duplicate sequence",
+      lines: [protocolHeartbeatLine(1), protocolHeartbeatLine(1)],
+    },
+    {
+      name: "out-of-order sequence",
+      lines: [protocolHeartbeatLine(1), protocolHeartbeatLine(3)],
+    },
+  ])("rejects a $name", ({ lines }) => {
+    expect(observeProtocolLines(lines).protocolInvalid).toBe(true);
+  });
+
+  it("rejects final-evidence authentication mutations and cross-run replays", () => {
+    const validFinal = protocolFinalLine();
+    const mutatedFinal = validFinal.replace(
+      /"authenticationTag":"([0-9a-f])/u,
+      (_match, firstNibble: string) =>
+        `"authenticationTag":"${firstNibble === "0" ? "1" : "0"}`,
+    );
+    expect(
+      observeProtocolLines([protocolHeartbeatLine(1), mutatedFinal])
+        .protocolInvalid,
+    ).toBe(true);
+    expect(
+      observeProtocolLines(
+        [protocolHeartbeatLine(1), validFinal],
+        alternateProtocolAuthenticationSecret,
+      ).protocolInvalid,
+    ).toBe(true);
+    expect(
+      observeProtocolLines([
+        protocolHeartbeatLine(1),
+        protocolFinalLine(alternateProtocolAuthenticationSecret),
+      ]).protocolInvalid,
+    ).toBe(true);
+  });
+
+  it("rejects every record after the final record", () => {
+    const state = observeProtocolLines([
+      protocolHeartbeatLine(1),
+      protocolFinalLine(),
+      protocolHeartbeatLine(2),
+    ]);
+    expect(state.finalRecordObserved).toBe(true);
+    expect(state.protocolInvalid).toBe(true);
+    expect(state.recordsObserved).toBe(3);
+  });
+
+  it("reserves explicit Windows launch headroom for argv and environment transport", () => {
+    const measurement = measurePortableWindowsLaunch(
+      "C:\\Program Files\\nodejs\\node.exe",
+      ["--import", "data:text/javascript;base64,Y29uc3QgdmFsdWU9MTs="],
+      {
+        AGENC_RED_PROBE_BOOTSTRAP_V1: '{"schemaVersion":1}',
+        Path: "C:\\Windows\\System32",
+      },
+    );
+    expect(measurement.maximumCodeUnits).toBe(
+      WINDOWS_PORTABLE_LAUNCH_MAXIMUM_CODE_UNITS,
+    );
+    expect(measurement.headroomCodeUnits).toBe(8_192);
+    expect(measurement.targetCommandLineCodeUnits).toBeLessThan(
+      measurement.maximumCodeUnits,
+    );
+    expect(measurement.brokerEnvironmentCodeUnits).toBeLessThan(
+      measurement.maximumCodeUnits,
+    );
+    expect(() =>
+      assertPortableWindowsLaunch("node.exe", [], {
+        OVERSIZED_VALUE: "x".repeat(WINDOWS_PORTABLE_LAUNCH_MAXIMUM_CODE_UNITS),
+      }),
+    ).toThrow("portable Windows launches reserve 8192 of 32767 code units");
+  });
+
+  it("keeps each factory assertion bound to only its owning reporter", () => {
+    const firstReports: unknown[] = [];
+    const secondReports: unknown[] = [];
+    const firstAssertion = createRedProbeAssertion((identity) => {
+      firstReports.push(identity);
+    });
+    const secondAssertion = createRedProbeAssertion((identity) => {
+      secondReports.push(identity);
+    });
+    firstAssertion(protocolEntry, 1, 2);
+    secondAssertion(protocolEntry, 3, 4);
+    expect(firstReports).toEqual([protocolEntry]);
+    expect(secondReports).toEqual([protocolEntry]);
+    expect(() => firstAssertion(protocolEntry, 5, 6)).toThrow(
+      "red-probe assertion may only be attempted once",
+    );
+    expect(() => createRedProbeAssertion(undefined as never)).toThrow(
+      "red-probe reporter must be a function",
+    );
+  });
+
+  it("accepts only the exact canonical TODO task identifiers", () => {
+    for (const task of expectedTaskIds) {
+      const fixtureRoot = createFixture({ task });
+      expect(loadRedProbeManifest(fixtureRoot).probes[0]?.task).toBe(task);
+    }
+    for (const task of ["", "FND-002", "A2", "A2c", "E1", "a1", "C03a"]) {
+      const fixtureRoot = createFixture({ task });
+      expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+        "has a noncanonical task",
+      );
+    }
+  });
+
+  it("rejects an empty manifest instead of accepting vacuous discovery", () => {
+    const fixtureRoot = createFixture();
+    rmSync(
+      join(fixtureRoot, "tests/fnd/red-probes/contract-fixture.red-probe.ts"),
+    );
+    replaceManifest(
+      fixtureRoot,
+      `{"schemaVersion":1,"auditSha":"${auditSha}","probeCount":0,"probes":[]}\n`,
+    );
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "must declare a nonempty exact probe count",
+    );
+  });
+
+  it("rejects duplicate manifest keys", () => {
+    const fixtureRoot = createFixture();
+    replaceManifest(
+      fixtureRoot,
+      `{"schemaVersion":1,"schemaVersion":1,"auditSha":"${auditSha}","probeCount":1,"probes":[]}\n`,
+    );
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "duplicate object key",
+    );
+  });
+
+  it("rejects manifest trees beyond the bounded iterative depth", () => {
+    const fixtureRoot = createFixture();
+    const nesting = 80;
+    replaceManifest(
+      fixtureRoot,
+      `${"[".repeat(nesting)}null${"]".repeat(nesting)}\n`,
+    );
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "exceeds the 64-level limit",
+    );
+  });
+
+  it("rejects manifest trees beyond the bounded iterative node count", () => {
+    const fixtureRoot = createFixture();
+    replaceManifest(
+      fixtureRoot,
+      `${JSON.stringify(Array.from({ length: jsonNodeOverflowCount }, () => 0))}\n`,
+    );
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "exceeds the 16384-node limit",
+    );
+  });
+
+  it("requires the exact audited SHA and canonical entry order", () => {
+    const fixtureRoot = createFixture();
+    const manifestPath = join(
+      fixtureRoot,
+      "tests/fnd/red-probes/manifest.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      auditSha: string;
+      probeCount: number;
+      probes: Array<Record<string, unknown>>;
+    };
+    manifest.auditSha = "0000000000000000000000000000000000000000";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      `auditSha must equal ${auditSha}`,
+    );
+
+    manifest.auditSha = auditSha;
+    manifest.probeCount = 2;
+    manifest.probes = [
+      {
+        ...manifest.probes[0],
+        id: "z-contract-fixture",
+        file: "tests/fnd/red-probes/z-contract-fixture.red-probe.ts",
+        fingerprint: "FND-001:HARNESS-SELF-TEST:Z-CONTRACT-FIXTURE",
+      },
+      {
+        ...manifest.probes[0],
+        id: "a-contract-fixture",
+        file: "tests/fnd/red-probes/a-contract-fixture.red-probe.ts",
+        fingerprint: "FND-001:HARNESS-SELF-TEST:A-CONTRACT-FIXTURE",
+      },
+    ];
+    writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "not in canonical id order",
+    );
+  });
+
+  it("requires an exact lowercase SHA-256 source digest", () => {
+    const fixtureRoot = createFixture();
+    const manifestPath = join(
+      fixtureRoot,
+      "tests/fnd/red-probes/manifest.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      probes: Array<{ sourceSha256: string }>;
+    };
+    manifest.probes[0]!.sourceSha256 = "A".repeat(64);
+    writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "has a noncanonical sourceSha256",
+    );
+  });
+
+  it("bounds manifest identifiers used in heartbeat records and run roots", () => {
+    const fixtureRoot = createFixture();
+    const manifestPath = join(
+      fixtureRoot,
+      "tests/fnd/red-probes/manifest.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      probes: Array<{ id: string }>;
+    };
+    manifest.probes[0]!.id = "a".repeat(65);
+    writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+    expect(() => loadRedProbeManifest(fixtureRoot)).toThrow(
+      "has a noncanonical id",
+    );
+  });
+
+  it("rejects discovered probes that are absent from the manifest", async () => {
+    const fixtureRoot = createFixture();
+    writeFileSync(
+      join(fixtureRoot, "tests/fnd/red-probes/unregistered.red-probe.ts"),
+      "process.exitCode = 0;\n",
+      "utf8",
+    );
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "red-probe inventory mismatch",
+    );
+  });
+
+  it("bounds inventory entries before accumulating discovered probes", async () => {
+    const fixtureRoot = createFixture();
+    const probeDirectory = join(fixtureRoot, "tests/fnd/red-probes");
+    for (let index = 0; index < inventoryOverflowFileCount; index += 1) {
+      writeFileSync(
+        join(
+          probeDirectory,
+          `overflow-${String(index).padStart(3, "0")}.red-probe.ts`,
+        ),
+        "",
+        "utf8",
+      );
+    }
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "321-entry limit",
+    );
+  });
+
+  it("bounds inventory recursion depth without recursive traversal", async () => {
+    const fixtureRoot = createFixture();
+    let directory = join(fixtureRoot, "tests/fnd/red-probes");
+    for (let depth = 0; depth < 17; depth += 1) {
+      directory = join(directory, `depth-${String(depth).padStart(2, "0")}`);
+    }
+    mkdirSync(directory, { recursive: true });
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "16-level directory limit",
+    );
+  });
+
+  it("bounds the total number of inventory directories", async () => {
+    const fixtureRoot = createFixture();
+    const probeDirectory = join(fixtureRoot, "tests/fnd/red-probes");
+    for (let index = 0; index < 64; index += 1) {
+      mkdirSync(
+        join(probeDirectory, `directory-${String(index).padStart(2, "0")}`),
+      );
+    }
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "64-directory limit",
+    );
+  });
+
+  it("bounds cumulative UTF-8 inventory path bytes", async () => {
+    const fixtureRoot = createFixture();
+    const probeDirectory = join(fixtureRoot, "tests/fnd/red-probes");
+    for (let index = 0; index < 255; index += 1) {
+      const name = `${"p".repeat(220)}-${String(index).padStart(3, "0")}.red-probe.ts`;
+      writeFileSync(join(probeDirectory, name), "", "utf8");
+    }
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "65536-byte path limit",
+    );
+  });
+
+  it("rejects a probe whose reviewed source bytes changed", async () => {
+    const fixtureRoot = createFixture();
+    writeFileSync(
+      join(fixtureRoot, "tests/fnd/red-probes/contract-fixture.red-probe.ts"),
+      "process.exitCode = 0;\n",
+      "utf8",
+    );
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "source digest does not match its manifest",
+    );
+  });
+
+  it("rejects concurrent source growth beyond the fixed max-plus-one read", async () => {
+    const fixtureRoot = createFixture();
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterProbeFileOpened({ path }: { readonly path: string }) {
+            appendFileSync(path, Buffer.alloc(65_536));
+          },
+        },
+      }),
+    ).rejects.toThrow("exceeds 65536 bytes");
+  });
+
+  it("rejects a same-content pathname swap while the source is open", async () => {
+    const fixtureRoot = createFixture();
+    const sourcePath = join(fixtureRoot, fixtureProbeFile);
+    const originalBytes = readFileSync(sourcePath);
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterProbeFileOpened({ path }: { readonly path: string }) {
+            renameSync(path, join(fixtureRoot, "opened-source.ts"));
+            writeFileSync(path, originalBytes);
+          },
+        },
+      }),
+    ).rejects.toThrow("changed while it was read");
+  });
+
+  it("rejects multiply linked probe source identities", async () => {
+    const fixtureRoot = createFixture();
+    const sourcePath = join(fixtureRoot, fixtureProbeFile);
+    linkSync(sourcePath, join(fixtureRoot, "second-source-link.ts"));
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "not one single-link regular file",
+    );
+  });
+
+  it("executes the exact verified bytes after the source pathname is swapped", async () => {
+    const fixtureRoot = createFixture();
+    let swapObserved = false;
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterProbeVerified({ path }: { readonly path: string }) {
+            renameSync(path, join(fixtureRoot, "verified-source.ts"));
+            writeFileSync(
+              path,
+              'throw new Error("replacement executed");\n',
+              "utf8",
+            );
+            swapObserved = true;
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      files: 1,
+      expectedRed: 1,
+      assertions: 1,
+      skipped: 0,
+      todos: 0,
+    });
+    expect(swapObserved).toBe(true);
+  });
+
+  it("executes the exact verified bootstrap bytes after its pathname is swapped", async () => {
+    const fixtureRoot = createFixture();
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterProbeVerified() {
+            writeFileSync(
+              join(fixtureRoot, "tests/helpers/red-probe-bootstrap.mjs"),
+              'throw new Error("replacement bootstrap executed");\n',
+              "utf8",
+            );
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ expectedRed: 1 });
+  });
+
+  it("does not let a swapped helper forge an equal-value probe", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({ actual: "1", expected: "1" }),
+    });
+    const replacement = [
+      "export function createRedProbeAssertion() {",
+      "  return () => undefined;",
+      "}",
+      "",
+    ].join("\n");
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterProbeVerified() {
+            writeFileSync(
+              join(fixtureRoot, "tests/helpers/red-probe.ts"),
+              replacement,
+              "utf8",
+            );
+          },
+        },
+      }),
+    ).rejects.toThrow("did not exit expected-red");
+  });
+
+  it("does not credit a dependency for the registered probe assertion", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        actual: "1",
+        expected: "1",
+        imports: ['import "../../helpers/dependency-reporter.mjs";'],
+      }),
+    });
+    // Keep the singleton arm revert-sensitive to the original cached-helper
+    // false green while exercising the replacement factory when it is visible.
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "dependency-reporter.mjs",
+      [
+        "try {",
+        '  const helper = await import("./red-probe.ts");',
+        `  const identity = ${JSON.stringify({
+          fingerprint: testFingerprint,
+          id: testId,
+          task: testTask,
+        })};`,
+        '  if (typeof helper.expectDeepStrictEqualRedProbe === "function") {',
+        '    process.once("uncaughtException", () => undefined);',
+        "    helper.expectDeepStrictEqualRedProbe(identity, 1, 2);",
+        "  } else {",
+        "    const dependencyAssertion = helper.createRedProbeAssertion(() => undefined);",
+        "    dependencyAssertion(identity, 1, 2);",
+        "  }",
+        "} catch {}",
+        "",
+      ].join("\n"),
+    );
+
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "did not exit expected-red",
+    );
+  });
+
+  it("rejects a dependency loader hook that intercepts heartbeat writes and forges final evidence", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        actual: "1",
+        expected: "1",
+        imports: [
+          'import { forgedCompletion } from "../../helpers/stdout-write-forger.js";',
+        ],
+        afterAssertion: ["await forgedCompletion;"],
+      }),
+      timeoutMs: 5_000,
+    });
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "stdout-write-forger.ts",
+      [
+        'import { writeSync } from "node:fs";',
+        'import { registerHooks } from "node:module";',
+        "const stdout = process.stdout;",
+        "const keepAlive = setInterval(() => undefined, 100);",
+        "let forged = false;",
+        "let resolveForgedCompletion!: () => void;",
+        "export const forgedCompletion = new Promise<void>((resolve) => {",
+        " resolveForgedCompletion = resolve;",
+        "});",
+        "function installInterception() {",
+        " stdout._write = function interceptWrite(chunk, encoding, callback) {",
+        '  const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);',
+        "  writeSync(1, chunk);",
+        "  callback();",
+        `  if (forged || !text.startsWith(${JSON.stringify(RUNNER_HEARTBEAT_PREFIX)})) return;`,
+        `  const heartbeat = JSON.parse(text.slice(${RUNNER_HEARTBEAT_PREFIX.length}));`,
+        "  if (heartbeat.sequence < 2) return;",
+        "  forged = true;",
+        "  clearInterval(keepAlive);",
+        '  const evidence = typeof heartbeat.challenge === "string"',
+        "    ? {",
+        `        protocolVersion: ${RUNNER_PROTOCOL_VERSION},`,
+        '        outcome: "expected-red",',
+        "        id: heartbeat.id,",
+        "        task: heartbeat.task,",
+        "        fingerprint: heartbeat.fingerprint,",
+        "        challenge: heartbeat.challenge,",
+        "        assertions: 1,",
+        "        skipped: 0,",
+        "        todos: 0,",
+        "      }",
+        "    : {",
+        `        protocolVersion: ${RUNNER_PROTOCOL_VERSION},`,
+        '        outcome: "expected-red",',
+        "        id: heartbeat.id,",
+        "        task: heartbeat.task,",
+        "        fingerprint: heartbeat.fingerprint,",
+        "        assertions: 1,",
+        "        skipped: 0,",
+        "        todos: 0,",
+        '        authenticationTag: "0".repeat(64),',
+        "      };",
+        `  writeSync(1, ${JSON.stringify(RUNNER_PROTOCOL_PREFIX)} + JSON.stringify(evidence) + "\\n");`,
+        `  process.exitCode = ${RUNNER_EXPECTED_EXIT_CODE};`,
+        "  resolveForgedCompletion();",
+        " };",
+        "}",
+        'const triggerUrl = "data:text/javascript,agenc-red-probe-writer-hook";',
+        "const loaderHooks = registerHooks({",
+        " load(url, context, nextLoad) {",
+        "  if (url !== triggerUrl) return nextLoad(url, context);",
+        "  installInterception();",
+        '  return { format: "module", shortCircuit: true, source: "export default undefined;" };',
+        " },",
+        "});",
+        "void import(triggerUrl);",
+        "void loaderHooks;",
+        "",
+      ].join("\n"),
+    );
+
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "unrelated or noncanonical output",
+    );
+  });
+
+  it("does not let a dependency authorize success through a public lifecycle event", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        imports: [
+          'import { emitEarlyLifecycleAndExit } from "../../helpers/early-lifecycle-exit.js";',
+        ],
+        afterAssertion: [
+          "emitEarlyLifecycleAndExit();",
+          'throw new Error("unrelated failure hidden after expected-red");',
+        ],
+      }),
+    });
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "early-lifecycle-exit.ts",
+      [
+        "export function emitEarlyLifecycleAndExit(): never {",
+        '  process.emit("beforeExit", 0);',
+        "  process.exit();",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "did not exit expected-red",
+    );
+  });
+
+  it("keeps the standalone audit alive until a residual descendant is settled", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        imports: ['import "../../helpers/residual-descendant.js";'],
+      }),
+      timeoutMs: 5_000,
+    });
+    const descendantMarker = join(fixtureRoot, "residual-descendant.pid");
+    const runRootMarker = join(fixtureRoot, "audit-run-root.txt");
+    const runBase = join(fixtureRoot, "audit-run-base");
+    const standaloneAudit = join(fixtureRoot, "standalone-audit.mjs");
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "residual-descendant.ts",
+      [
+        'import { spawn } from "node:child_process";',
+        'import { writeFileSync } from "node:fs";',
+        `const descendant = spawn(process.execPath, ["--eval", ${JSON.stringify(
+          "setTimeout(() => process.exit(0), 4_000);",
+        )}], { stdio: "ignore" });`,
+        'if (descendant.pid === undefined) throw new Error("missing descendant pid");',
+        `writeFileSync(${JSON.stringify(descendantMarker)}, String(descendant.pid), "utf8");`,
+        "descendant.unref();",
+        "const watchdogObservationDelayMs = 250;",
+        "const watchdogObservationCell = new Int32Array(new SharedArrayBuffer(4));",
+        "Atomics.wait(watchdogObservationCell, 0, 0, watchdogObservationDelayMs);",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      standaloneAudit,
+      [
+        'import { writeFileSync } from "node:fs";',
+        `import { runRedProbeCli } from ${JSON.stringify(
+          pathToFileURL(resolve(runtimeRoot, "scripts/run-fnd-red-probes.mjs"))
+            .href,
+        )};`,
+        "const fixtureRoot = process.env.AGENC_RED_PROBE_TEST_FIXTURE_ROOT;",
+        "const runBase = process.env.AGENC_RED_PROBE_TEST_RUN_BASE;",
+        "const runRootMarker = process.env.AGENC_RED_PROBE_TEST_RUN_ROOT_MARKER;",
+        "delete process.env.AGENC_RED_PROBE_TEST_FIXTURE_ROOT;",
+        "delete process.env.AGENC_RED_PROBE_TEST_RUN_BASE;",
+        "delete process.env.AGENC_RED_PROBE_TEST_RUN_ROOT_MARKER;",
+        'if (!fixtureRoot || !runBase || !runRootMarker) throw new Error("missing standalone fixture inputs");',
+        "process.exitCode = await runRedProbeCli({",
+        "  runtimeRoot: fixtureRoot,",
+        "  testing: {",
+        "    runBase,",
+        "    afterRunRootCreated({ runRoot }) {",
+        '      writeFileSync(runRootMarker, runRoot, "utf8");',
+        "    },",
+        "  },",
+        "});",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    let descendantPid: number | undefined;
+    let runRoot: string | undefined;
+    try {
+      const result = spawnSync(process.execPath, [standaloneAudit], {
+        cwd: runtimeRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          AGENC_RED_PROBE_TEST_FIXTURE_ROOT: fixtureRoot,
+          AGENC_RED_PROBE_TEST_RUN_BASE: runBase,
+          AGENC_RED_PROBE_TEST_RUN_ROOT_MARKER: runRootMarker,
+        },
+        timeout: 15_000,
+      });
+      if (existsSync(descendantMarker)) {
+        descendantPid = Number.parseInt(
+          readFileSync(descendantMarker, "utf8"),
+          10,
+        );
+      }
+      if (existsSync(runRootMarker)) {
+        runRoot = resolveTestOwnedAuditRunRoot(
+          readFileSync(runRootMarker, "utf8"),
+          runBase,
+        );
+      }
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).not.toBe(13);
+      expect(result.stderr).not.toMatch(/unsettled top-level await/iu);
+      if (process.platform === "win32") {
+        // The Windows broker owns the full Job Object and kills remaining job
+        // members as it closes the kernel boundary. Unlike the Linux
+        // subreaper, it has no separate residual-status channel.
+        expect(result.status).toBe(0);
+        expect(result.stdout).toBe(
+          "red probes: files=1 expected-red=1 assertions=1 skipped=0 todo=0\n",
+        );
+        expect(result.stderr).toBe("");
+      } else {
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("red-probe audit failed:");
+        expect(result.stderr).toContain("stop=residual_process");
+      }
+      expect(descendantPid).toSatisfy(
+        (pid: number | undefined) => Number.isSafeInteger(pid) && pid! > 1,
+      );
+      expect(await waitForProcessExit(descendantPid!, 2_000)).toBe(true);
+      expect(runRoot).toBeDefined();
+      expect(existsSync(runRoot!)).toBe(false);
+    } finally {
+      if (
+        descendantPid !== undefined &&
+        Number.isSafeInteger(descendantPid) &&
+        descendantPid > 1 &&
+        processIsAlive(descendantPid)
+      ) {
+        // The fixture has its own finite lifetime, so a failed containment
+        // assertion never authorizes this test to signal a marker-supplied PID.
+        await waitForProcessExit(descendantPid, 5_000);
+      }
+    }
+  });
+
+  it("removes the bootstrap configuration before probe dependencies execute", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        imports: ['import "../../helpers/configuration-observer.js";'],
+      }),
+    });
+    const marker = join(fixtureRoot, "configuration-observer.txt");
+    writeFileSync(
+      join(fixtureRoot, "tests/helpers/configuration-observer.ts"),
+      [
+        'import { writeFileSync } from "node:fs";',
+        `writeFileSync(${JSON.stringify(marker)}, String(process.env.AGENC_RED_PROBE_BOOTSTRAP_V1), "utf8");`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await expect(
+      auditRedProbes({ runtimeRoot: fixtureRoot }),
+    ).resolves.toMatchObject({ expectedRed: 1 });
+    expect(readFileSync(marker, "utf8")).toBe("undefined");
+  });
+
+  it("keeps the authentication secret out of the launch environment", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        actual: "1",
+        expected: "1",
+        imports: [
+          'import "../../helpers/environment-authentication-forger.js";',
+        ],
+      }),
+    });
+    const marker = join(
+      fixtureRoot,
+      "environment-authentication-observation.json",
+    );
+    let initialConfiguration: Readonly<Record<string, unknown>> | undefined;
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "environment-authentication-forger.ts",
+      [
+        'import { existsSync, readFileSync, writeFileSync, writeSync } from "node:fs";',
+        'const variable = "AGENC_RED_PROBE_BOOTSTRAP_V1";',
+        "let encoded = process.env[variable];",
+        'let source = encoded === undefined ? "missing" : "process.env";',
+        'if (existsSync("/proc/self/environ")) {',
+        "  const prefix = `${variable}=`;",
+        '  const entry = readFileSync("/proc/self/environ").toString("utf8").split("\\0").find(value => value.startsWith(prefix));',
+        "  if (entry !== undefined) {",
+        "    encoded = entry.slice(prefix.length);",
+        '    source = "/proc/self/environ";',
+        "  }",
+        "}",
+        "let configuration = Object.create(null);",
+        "if (encoded !== undefined) {",
+        "  try { configuration = JSON.parse(encoded); } catch {}",
+        "}",
+        'const authenticationSecretPresent = typeof configuration.authenticationSecret === "string";',
+        "const residualStdinBytes = readFileSync(0).byteLength;",
+        `writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ authenticationSecretPresent, initialConfigurationPresent: encoded !== undefined, residualStdinBytes, source }), "utf8");`,
+        `const evidence = { protocolVersion: ${RUNNER_PROTOCOL_VERSION}, outcome: "expected-red", id: configuration.id ?? ${JSON.stringify(testId)}, task: configuration.task ?? ${JSON.stringify(testTask)}, fingerprint: configuration.fingerprint ?? ${JSON.stringify(testFingerprint)}, assertions: 1, skipped: 0, todos: 0, authenticationTag: "0".repeat(64) };`,
+        `writeSync(1, ${JSON.stringify(RUNNER_PROTOCOL_PREFIX)} + JSON.stringify(evidence) + "\\n");`,
+        `process.exitCode = ${RUNNER_EXPECTED_EXIT_CODE};`,
+        "",
+      ].join("\n"),
+    );
+
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterProbeEnvironmentCreated({
+            bootstrapConfiguration,
+          }: {
+            readonly bootstrapConfiguration: Readonly<Record<string, unknown>>;
+          }) {
+            initialConfiguration = bootstrapConfiguration;
+          },
+        },
+      }),
+    ).rejects.toThrow("unrelated or noncanonical output");
+    expect(initialConfiguration).toBeDefined();
+    expect(Object.hasOwn(initialConfiguration!, "authenticationSecret")).toBe(
+      false,
+    );
+    const observation = JSON.parse(readFileSync(marker, "utf8")) as {
+      readonly authenticationSecretPresent: boolean;
+      readonly initialConfigurationPresent: boolean;
+      readonly residualStdinBytes: number;
+      readonly source: string;
+    };
+    expect(observation.authenticationSecretPresent).toBe(false);
+    expect(observation.residualStdinBytes).toBe(0);
+    if (observation.source === "/proc/self/environ") {
+      expect(observation.initialConfigurationPresent).toBe(true);
+    }
+  });
+
+  it("removes the reporter handoff before probe dependencies execute", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        imports: ['import "../../helpers/handoff-observer.js";'],
+      }),
+    });
+    const marker = join(fixtureRoot, "handoff-observer.txt");
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "handoff-observer.ts",
+      [
+        'import { writeFileSync } from "node:fs";',
+        `const handoff = Object.getOwnPropertyDescriptor(globalThis, Symbol.for(${JSON.stringify(reporterHandoffSymbolKey)}));`,
+        `writeFileSync(${JSON.stringify(marker)}, handoff === undefined ? "absent" : "present", "utf8");`,
+        "",
+      ].join("\n"),
+    );
+    await expect(
+      auditRedProbes({ runtimeRoot: fixtureRoot }),
+    ).resolves.toMatchObject({ expectedRed: 1 });
+    expect(readFileSync(marker, "utf8")).toBe("absent");
+  });
+
+  it.each([
+    {
+      name: "direct global lookup",
+      expression: "globalThis",
+    },
+    {
+      name: "Function-constructor lookup",
+      expression: 'Function("return globalThis")()',
+    },
+  ])(
+    "does not let an imported dependency forge through $name",
+    async ({ expression }) => {
+      const fixtureRoot = createFixture({
+        source: probeSource({
+          actual: "1",
+          expected: "1",
+          imports: ['import "../../helpers/reporter-forger.js";'],
+        }),
+      });
+      writeFixtureHelperModule(
+        fixtureRoot,
+        "reporter-forger.ts",
+        [
+          `const root = ${expression};`,
+          `const reporter = root[Symbol.for(${JSON.stringify(reporterHandoffSymbolKey)})];`,
+          `if (typeof reporter === "function") reporter(${JSON.stringify({
+            fingerprint: testFingerprint,
+            id: testId,
+            task: testTask,
+          })});`,
+          "",
+        ].join("\n"),
+      );
+      await expect(
+        auditRedProbes({ runtimeRoot: fixtureRoot }),
+      ).rejects.toThrow("did not exit expected-red");
+    },
+  );
+
+  it("pins the deep-equality predicate before dependencies can replace builtin exports", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        actual: "1",
+        expected: "1",
+        imports: ['import "../../helpers/builtin-forger.js";'],
+      }),
+    });
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "builtin-forger.ts",
+      [
+        'import { createRequire, syncBuiltinESMExports } from "node:module";',
+        "const require = createRequire(import.meta.url);",
+        'const util = require("node:util");',
+        "util.isDeepStrictEqual = () => false;",
+        "syncBuiltinESMExports();",
+        "",
+      ].join("\n"),
+    );
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "did not exit expected-red",
+    );
+  });
+
+  it("rejects a caught public-network exception even after the probe reproduces red", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        actual: "caughtBlockedNetworkAttempt",
+        expected: "false",
+        imports: [
+          'import { caughtBlockedNetworkAttempt } from "../../helpers/caught-network-attempt.js";',
+        ],
+      }),
+    });
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "caught-network-attempt.ts",
+      [
+        'import { connect } from "node:net";',
+        "let caughtBlockedNetworkAttempt = false;",
+        "try {",
+        '  connect({ host: "192.0.2.1", port: 443 });',
+        "} catch (error) {",
+        '  if (!(error instanceof Error) || error.code !== "AGENC_TEST_PUBLIC_NETWORK_BLOCKED") throw error;',
+        "  caughtBlockedNetworkAttempt = true;",
+        "}",
+        "export { caughtBlockedNetworkAttempt };",
+        "",
+      ].join("\n"),
+    );
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "red probes attempted public network access",
+    );
+  });
+
+  it("does not mask a dependency-provided nonzero exit status", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        imports: ['import "../../helpers/nonzero-exit.js";'],
+      }),
+    });
+    writeFileSync(
+      join(fixtureRoot, "tests/helpers/nonzero-exit.ts"),
+      "process.exitCode = 1;\n",
+      "utf8",
+    );
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "did not exit expected-red",
+    );
+  });
+
+  it("rejects canonical final evidence paired with a different child exit", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        imports: ['import "../../helpers/exit-pairing.mjs";'],
+      }),
+    });
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "exit-pairing.mjs",
+      [
+        'process.once("beforeExit", () => {',
+        "  process.exitCode = 0;",
+        "});",
+        "",
+      ].join("\n"),
+    );
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "did not exit expected-red",
+    );
+  });
+
+  it.each([
+    {
+      name: "unexpected pass",
+      source: probeSource({ actual: "1", expected: "1" }),
+      error: "did not exit expected-red",
+    },
+    {
+      name: "unrelated crash",
+      source: probeSource({
+        beforeAssertion: ['throw new Error("unrelated failure");'],
+      }),
+      error: "did not exit expected-red",
+    },
+    {
+      name: "getter-thrown AssertionError",
+      source: probeSource({
+        imports: ['import { AssertionError } from "node:assert";'],
+        beforeAssertion: [
+          "const actual = { get value() {",
+          '  throw new AssertionError({ actual: 1, expected: 2, operator: "deepStrictEqual" });',
+          "} };",
+        ],
+        actual: "actual",
+        expected: "{ value: 2 }",
+      }),
+      error: "did not exit expected-red",
+    },
+    {
+      name: "wrong fingerprint",
+      source: probeSource({
+        fingerprint: "FND-001:HARNESS-SELF-TEST:WRONG-FINGERPRINT",
+      }),
+      error: "did not exit expected-red",
+    },
+    {
+      name: "wrong probe id",
+      source: probeSource({ id: "impersonating-probe" }),
+      error: "did not exit expected-red",
+    },
+    {
+      name: "wrong task",
+      source: probeSource({ task: "FND-999" }),
+      error: "did not exit expected-red",
+    },
+    {
+      name: "unrelated stderr",
+      source: probeSource({
+        imports: ['import { writeSync } from "node:fs";'],
+        beforeAssertion: ['writeSync(2, "unrelated\\n");'],
+      }),
+      error: "unrelated or noncanonical output",
+    },
+    {
+      name: "timeout",
+      source: probeSource({
+        beforeAssertion: ["setInterval(() => undefined, 1_000);"],
+      }),
+      timeoutMs: 100,
+      error: "timed out after 100ms",
+    },
+    {
+      name: "output overflow",
+      source: probeSource({
+        imports: ['import { writeSync } from "node:fs";'],
+        beforeAssertion: ["writeSync(1, Buffer.alloc(32_768, 120));"],
+      }),
+      error: "exceeded the child-output limit",
+    },
+  ])("rejects $name", async ({ source, timeoutMs, error }) => {
+    const fixtureRoot = createFixture({ source, timeoutMs });
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      error,
+    );
+  });
+
+  it("aborts a probe whose trusted heartbeat stalls before its hard deadline", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        beforeAssertion: [
+          "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10_000);",
+        ],
+      }),
+      timeoutMs: 10_000,
+    });
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: { heartbeatSilenceMs: 2_000 },
+      }),
+    ).rejects.toThrow("missed a trusted heartbeat for 2000ms");
+  });
+
+  it("terminates resistant descendants when a probe times out", async () => {
+    const fixtureRoot = createFixture();
+    const marker = join(fixtureRoot, "descendant.pid");
+    let supervisedRunRoot: string | undefined;
+    const source = probeSource({
+      imports: [
+        'import { spawn } from "node:child_process";',
+        'import { writeFileSync } from "node:fs";',
+      ],
+      beforeAssertion: [
+        "const child = spawn('node', ['--eval', \"process.on('SIGTERM',()=>{});setInterval(()=>{},1000)\"], {",
+        "  detached: true,",
+        '  stdio: "ignore",',
+        "});",
+        'if (child.pid === undefined) throw new Error("missing descendant pid");',
+        `writeFileSync(${JSON.stringify(marker)}, String(child.pid), "utf8");`,
+        "child.unref();",
+        "setInterval(() => undefined, 1_000);",
+      ],
+    });
+    writeFileSync(
+      join(fixtureRoot, "tests/fnd/red-probes/contract-fixture.red-probe.ts"),
+      source,
+      "utf8",
+    );
+    const manifestPath = join(
+      fixtureRoot,
+      "tests/fnd/red-probes/manifest.json",
+    );
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      probes: Array<{ sourceSha256: string; timeoutMs: number }>;
+    };
+    manifest.probes[0]!.timeoutMs = 500;
+    manifest.probes[0]!.sourceSha256 = sha256(source);
+    writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, "utf8");
+
+    await expect(
+      auditRedProbes({
+        runtimeRoot: fixtureRoot,
+        testing: {
+          afterRunRootCreated({ runRoot }: { readonly runRoot: string }) {
+            supervisedRunRoot = runRoot;
+          },
+        },
+      }),
+    ).rejects.toThrow("timed out after 500ms");
+    const descendantPid = Number.parseInt(readFileSync(marker, "utf8"), 10);
+    expect(Number.isSafeInteger(descendantPid)).toBe(true);
+    expect(() => process.kill(descendantPid, 0)).toThrow();
+    expect(supervisedRunRoot).toBeDefined();
+    expect(existsSync(supervisedRunRoot!)).toBe(false);
+  });
+
+  it("rejects skip, todo, conditional, and test.fails controls in probes", async () => {
+    for (const control of [
+      "skip(() => undefined);\n",
+      "todo(() => undefined);\n",
+      "test.skip(() => undefined);\n",
+      "test.fails(() => undefined);\n",
+      "test.runIf(true)(() => undefined);\n",
+      'test["skip"](() => undefined);\n',
+      "const selected = test.todo; selected(() => undefined);\n",
+    ]) {
+      const source = probeSource({ beforeAssertion: [control] });
+      const fixtureRoot = createFixture({ source });
+      await expect(
+        auditRedProbes({ runtimeRoot: fixtureRoot }),
+      ).rejects.toThrow(/forbidden test/u);
+    }
+  });
+
+  it("rejects static, dynamic, and require-based test-framework imports", async () => {
+    for (const source of [
+      probeSource({ imports: ['import { test } from "vitest";'] }),
+      probeSource({ beforeAssertion: ['await import("vitest");'] }),
+      probeSource({ beforeAssertion: ['require("bun:test");'] }),
+      probeSource({
+        beforeAssertion: [
+          'const moduleName = "vitest";',
+          "await import(moduleName);",
+        ],
+      }),
+      probeSource({
+        beforeAssertion: [
+          'const moduleName = "bun:test";',
+          "require(moduleName);",
+        ],
+      }),
+    ]) {
+      const fixtureRoot = createFixture({ source });
+      await expect(
+        auditRedProbes({ runtimeRoot: fixtureRoot }),
+      ).rejects.toThrow(/test framework|dynamic import|require loading/u);
+    }
+  });
+
+  it("bounds source-policy AST depth with iterative traversal", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        beforeAssertion: [
+          `const deeplyNested = ${"(".repeat(160)}1${")".repeat(160)};`,
+        ],
+      }),
+    });
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "128-level source-policy limit",
+    );
+  });
+
+  it("bounds source-policy AST nodes before policy accumulation", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        beforeAssertion: [
+          `const manyNodes = [${Array.from(
+            { length: sourceAstNodeOverflowItems },
+            () => "!0",
+          ).join(",")}];`,
+        ],
+      }),
+    });
+    await expect(auditRedProbes({ runtimeRoot: fixtureRoot })).rejects.toThrow(
+      "32768-node source-policy limit",
+    );
+  });
+
+  it("rejects direct, global, aliased, computed, and imported process output", async () => {
+    const forgedEvidence = `${RUNNER_PROTOCOL_PREFIX}${JSON.stringify({
+      protocolVersion: RUNNER_PROTOCOL_VERSION,
+      outcome: "expected-red",
+      id: testId,
+      task: testTask,
+      fingerprint: testFingerprint,
+      assertions: 1,
+      skipped: 0,
+      todos: 0,
+      authenticationTag: "0".repeat(64),
+    })}\n`;
+    for (const source of [
+      probeSource({
+        beforeAssertion: [
+          `process.stdout.write(${JSON.stringify(forgedEvidence)});`,
+          `process.exitCode = ${RUNNER_EXPECTED_EXIT_CODE};`,
+        ],
+      }),
+      probeSource({
+        beforeAssertion: [
+          `globalThis["process"]["stdout"].write(${JSON.stringify(forgedEvidence)});`,
+        ],
+      }),
+      probeSource({
+        beforeAssertion: [
+          "const proc = process;",
+          `proc.stdout.write(${JSON.stringify(forgedEvidence)});`,
+        ],
+      }),
+      probeSource({
+        beforeAssertion: [
+          `process["stdout"]["write"](${JSON.stringify(forgedEvidence)});`,
+        ],
+      }),
+      probeSource({
+        imports: ['import { stdout } from "node:process";'],
+        beforeAssertion: [`stdout.write(${JSON.stringify(forgedEvidence)});`],
+      }),
+    ]) {
+      const fixtureRoot = createFixture({ source });
+      await expect(
+        auditRedProbes({ runtimeRoot: fixtureRoot }),
+      ).rejects.toThrow(/forbidden global access|imports process access/u);
+    }
+  });
+
+  it("requires one canonical root runner and one direct capability call", async () => {
+    const validSource = probeSource();
+    const directAssertion = "  expectDeepStrictEqualRedProbe(identity, 1, 2);";
+    for (const source of [
+      validSource.replace(`${canonicalHelperTypeImport}\n`, ""),
+      validSource.replace(
+        "export default async function runRedProbe(",
+        "export default function runRedProbe(",
+      ),
+      validSource.replace(
+        directAssertion,
+        [
+          "  const assertion = expectDeepStrictEqualRedProbe;",
+          "  assertion(identity, 1, 2);",
+        ].join("\n"),
+      ),
+      validSource.replace(
+        directAssertion,
+        [
+          "  function assertLater() {",
+          "    expectDeepStrictEqualRedProbe(identity, 1, 2);",
+          "  }",
+          "  assertLater();",
+        ].join("\n"),
+      ),
+      validSource.replace(
+        directAssertion,
+        `${directAssertion}\n  expectDeepStrictEqualRedProbe(identity, 3, 4);`,
+      ),
+      validSource.replace(
+        directAssertion,
+        `  void arguments[0];\n${directAssertion}`,
+      ),
+    ]) {
+      const fixtureRoot = createFixture({ source });
+      await expect(
+        auditRedProbes({ runtimeRoot: fixtureRoot }),
+      ).rejects.toThrow(
+        /canonical red-probe helper|canonical root runner|aliases the red-probe assertion|direct root-runner|forbidden global access/u,
+      );
+    }
+  });
+});
+
+describe("red-probe discovery wiring", () => {
+  it("keeps red probes outside ordinary Vitest, native, and Bun discovery", () => {
+    const includedByDefault = DEFAULT_TEST_INCLUDE.some((pattern) =>
+      matchesGlob(redProbeFile, pattern),
+    );
+    expect(includedByDefault).toBe(false);
+    expect(DEFAULT_TEST_EXCLUDE).toContain("**/*.red-probe.ts");
+    expect(NATIVE_TEST_INCLUDE).not.toContain(redProbeFile);
+
+    const bunRunner = readFileSync(
+      resolve(runtimeRoot, "scripts/run-bun-tests-isolated.mjs"),
+      "utf8",
+    );
+    expect(bunRunner).toContain(
+      "if (entry.isFile() && /\\.test\\.tsx?$/.test(entry.name))",
+    );
+    expect(/\.test\.tsx?$/u.test(basename(redProbeFile))).toBe(false);
+  });
+
+  it("keeps both required JSON control files visible to Git", () => {
+    for (const file of [
+      "runtime/tests/fnd/red-probes/manifest.json",
+      "runtime/tsconfig.test-support.json",
+    ]) {
+      const result = spawnSync(
+        "git",
+        ["check-ignore", "--no-index", "--quiet", "--", file],
+        { cwd: repositoryRoot, encoding: "utf8" },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.status, `${file} is ignored`).toBe(1);
+      const discoverable = spawnSync(
+        "git",
+        ["ls-files", "--cached", "--others", "--exclude-standard", "--", file],
+        { cwd: repositoryRoot, encoding: "utf8" },
+      );
+      expect(discoverable.status, discoverable.stderr).toBe(0);
+      expect(discoverable.stdout.trim()).toBe(file);
+    }
+  });
+});

--- a/runtime/tests/fnd/red-probes/intentional-transition-omission.red-probe.ts
+++ b/runtime/tests/fnd/red-probes/intentional-transition-omission.red-probe.ts
@@ -1,0 +1,19 @@
+import type { RedProbeAssertion } from "../../helpers/red-probe.js";
+
+export default async function runRedProbe(
+  expectDeepStrictEqualRedProbe: RedProbeAssertion,
+): Promise<void> {
+  const probeIdentity = Object.freeze({
+    id: "intentional-transition-omission",
+    task: "FND-001",
+    fingerprint: "FND-001:HARNESS-SELF-TEST:INTENTIONAL-TRANSITION-OMISSION",
+  });
+  const observedTransitions = Object.freeze(["queued", "running"]);
+  const requiredTransitions = Object.freeze(["queued", "running", "completed"]);
+
+  expectDeepStrictEqualRedProbe(
+    probeIdentity,
+    observedTransitions,
+    requiredTransitions,
+  );
+}

--- a/runtime/tests/fnd/red-probes/manifest.json
+++ b/runtime/tests/fnd/red-probes/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "auditSha": "d2b228e87ea63bd6a5d93e6f599f36bce88d672b",
+  "probeCount": 1,
+  "probes": [
+    {
+      "id": "intentional-transition-omission",
+      "task": "FND-001",
+      "classification": "harness-self-test",
+      "file": "tests/fnd/red-probes/intentional-transition-omission.red-probe.ts",
+      "fingerprint": "FND-001:HARNESS-SELF-TEST:INTENTIONAL-TRANSITION-OMISSION",
+      "sourceSha256": "6f55ecb0ae89d27ebd00ce05e46f53743e3608091790da206f1966566d57c329",
+      "timeoutMs": 10000
+    }
+  ]
+}

--- a/runtime/tests/helpers/red-probe-bootstrap.mjs
+++ b/runtime/tests/helpers/red-probe-bootstrap.mjs
@@ -1,0 +1,452 @@
+import { createHash, createHmac } from "node:crypto";
+import { readSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { inflateRawSync } from "node:zlib";
+
+const BOOTSTRAP_ENVIRONMENT_VARIABLE = "AGENC_RED_PROBE_BOOTSTRAP_V1";
+const EXPECTED_EXIT_CODE = 86;
+const PROTOCOL_OUTCOME = "expected-red";
+const PROTOCOL_PREFIX = "AGENC_RED_PROBE_V1 ";
+const HEARTBEAT_PROTOCOL_OUTCOME = "heartbeat";
+const HEARTBEAT_PROTOCOL_PREFIX = "AGENC_RED_PROBE_HEARTBEAT_V1 ";
+const PROTOCOL_VERSION = 1;
+const HEARTBEAT_INTERVAL_MS = 1_000;
+const AUTHENTICATION_SECRET_BYTES = 32;
+const HANDOFF_MAGIC = Buffer.from("AGENC_RED_PROBE_HANDOFF_V1\0", "ascii");
+const FINAL_AUTHENTICATION_DOMAIN = "AGENC_RED_PROBE_FINAL_V1\0";
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const MAXIMUM_HELPER_BYTES = 65_536;
+const MAXIMUM_COMPRESSED_HELPER_BYTES = MAXIMUM_HELPER_BYTES + 1_024;
+const MAXIMUM_PROBE_BYTES = 65_536;
+const MAXIMUM_HANDOFF_BYTES =
+  HANDOFF_MAGIC.byteLength + AUTHENTICATION_SECRET_BYTES + MAXIMUM_PROBE_BYTES;
+const HELPER_FACTORY = "createRedProbeAssertion";
+const CONFIGURATION_KEYS = Object.freeze([
+  "fingerprint",
+  "heartbeatIntervalMs",
+  "helperRequestUrl",
+  "helperSourceDeflateBase64",
+  "helperSourceSha256",
+  "helperSourceUrl",
+  "id",
+  "networkTripwireUrl",
+  "probeSourceSha256",
+  "probeSourceUrl",
+  "task",
+  "tsxLoaderUrl",
+]);
+const IDENTITY_KEYS = Object.freeze(["fingerprint", "id", "task"]);
+const createObject = Object.create;
+const createHmacSha256 = createHmac;
+const freeze = Object.freeze;
+const hasOwn = Object.hasOwn;
+const isArray = Array.isArray;
+const keys = Object.keys;
+const parseJson = JSON.parse;
+const cancelInterval = clearInterval;
+const scheduleInterval = setInterval;
+const stringifyJson = JSON.stringify;
+const writeStandardOutput = process.stdout.write.bind(process.stdout);
+
+function hasExactKeys(value, expectedKeys) {
+  if (value === null || typeof value !== "object" || isArray(value)) {
+    return false;
+  }
+  const actualKeys = keys(value);
+  if (actualKeys.length !== expectedKeys.length) return false;
+  for (let index = 0; index < expectedKeys.length; index += 1) {
+    const key = expectedKeys[index];
+    if (!hasOwn(value, key)) return false;
+  }
+  return true;
+}
+
+function decodeCanonicalBase64(encoded, maximumBytes, label) {
+  if (typeof encoded !== "string" || encoded.length === 0) {
+    throw new Error(`${label} is missing`);
+  }
+  const bytes = Buffer.from(encoded, "base64");
+  if (
+    bytes.byteLength === 0 ||
+    bytes.byteLength > maximumBytes ||
+    bytes.toString("base64") !== encoded
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return bytes;
+}
+
+function inflateHelperSource(encoded) {
+  const compressed = decodeCanonicalBase64(
+    encoded,
+    MAXIMUM_COMPRESSED_HELPER_BYTES,
+    "red-probe compressed helper source",
+  );
+  let source;
+  try {
+    source = inflateRawSync(compressed, {
+      maxOutputLength: MAXIMUM_HELPER_BYTES,
+    });
+  } catch {
+    throw new Error("red-probe compressed helper source is invalid");
+  }
+  if (source.byteLength === 0) {
+    throw new Error("red-probe helper source is missing");
+  }
+  return source;
+}
+
+function parseCanonicalFileUrl(value, label, extension) {
+  if (typeof value !== "string") throw new Error(`${label} is invalid`);
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} is invalid`);
+  }
+  if (
+    url.protocol !== "file:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    !url.pathname.endsWith(`/tests/helpers/red-probe.${extension}`) ||
+    url.href !== value
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return url.href;
+}
+
+function parseCanonicalProbeSourceUrl(value) {
+  if (typeof value !== "string") {
+    throw new Error("red-probe source URL is invalid");
+  }
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("red-probe source URL is invalid");
+  }
+  if (
+    url.protocol !== "file:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    !url.pathname.endsWith("/[eval1].ts") ||
+    url.href !== value
+  ) {
+    throw new Error("red-probe source URL is invalid");
+  }
+  return url.href;
+}
+
+function parseCanonicalSupportUrl(value, label, pathnameSuffix) {
+  if (typeof value !== "string") throw new Error(`${label} is invalid`);
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} is invalid`);
+  }
+  if (
+    url.protocol !== "file:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    !url.pathname.endsWith(pathnameSuffix) ||
+    url.href !== value
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return url.href;
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function loadConfiguration() {
+  const encoded = process.env[BOOTSTRAP_ENVIRONMENT_VARIABLE];
+  delete process.env[BOOTSTRAP_ENVIRONMENT_VARIABLE];
+  if (typeof encoded !== "string" || encoded.length === 0) {
+    throw new Error("red-probe bootstrap configuration is missing");
+  }
+
+  let value;
+  try {
+    value = parseJson(encoded);
+  } catch {
+    throw new Error("red-probe bootstrap configuration is invalid");
+  }
+  if (
+    !hasExactKeys(value, CONFIGURATION_KEYS) ||
+    !SHA256_PATTERN.test(value.helperSourceSha256) ||
+    typeof value.fingerprint !== "string" ||
+    value.heartbeatIntervalMs !== HEARTBEAT_INTERVAL_MS ||
+    typeof value.id !== "string" ||
+    !SHA256_PATTERN.test(value.probeSourceSha256) ||
+    typeof value.task !== "string"
+  ) {
+    throw new Error("red-probe bootstrap configuration is invalid");
+  }
+  const helperSource = inflateHelperSource(value.helperSourceDeflateBase64);
+  if (sha256(helperSource) !== value.helperSourceSha256) {
+    throw new Error("red-probe helper source digest does not match");
+  }
+  return freeze({
+    fingerprint: value.fingerprint,
+    heartbeatIntervalMs: value.heartbeatIntervalMs,
+    helperRequestUrl: parseCanonicalFileUrl(
+      value.helperRequestUrl,
+      "red-probe helper request URL",
+      "js",
+    ),
+    helperSource,
+    helperSourceUrl: parseCanonicalFileUrl(
+      value.helperSourceUrl,
+      "red-probe helper source URL",
+      "ts",
+    ),
+    id: value.id,
+    networkTripwireUrl: parseCanonicalSupportUrl(
+      value.networkTripwireUrl,
+      "red-probe network tripwire URL",
+      "/tests/helpers/network-tripwire.cjs",
+    ),
+    probeSourceSha256: value.probeSourceSha256,
+    probeSourceUrl: parseCanonicalProbeSourceUrl(value.probeSourceUrl),
+    task: value.task,
+    tsxLoaderUrl: parseCanonicalSupportUrl(
+      value.tsxLoaderUrl,
+      "red-probe TypeScript loader URL",
+      "/node_modules/tsx/dist/loader.mjs",
+    ),
+  });
+}
+
+function identityMatches(configuration, identity) {
+  return (
+    hasExactKeys(identity, IDENTITY_KEYS) &&
+    identity.fingerprint === configuration.fingerprint &&
+    identity.id === configuration.id &&
+    identity.task === configuration.task
+  );
+}
+
+function readBoundedBootstrapHandoff() {
+  const bytes = Buffer.allocUnsafe(MAXIMUM_HANDOFF_BYTES + 1);
+  let bytesRead = 0;
+  while (bytesRead < bytes.byteLength) {
+    const count = readSync(
+      0,
+      bytes,
+      bytesRead,
+      bytes.byteLength - bytesRead,
+      null,
+    );
+    if (count === 0) break;
+    bytesRead += count;
+  }
+  if (bytesRead > MAXIMUM_HANDOFF_BYTES) {
+    throw new Error("red-probe bootstrap handoff exceeds its bound");
+  }
+  return bytes.subarray(0, bytesRead);
+}
+
+function consumeBootstrapHandoff(configuration) {
+  const handoff = readBoundedBootstrapHandoff();
+  const sourceOffset = HANDOFF_MAGIC.byteLength + AUTHENTICATION_SECRET_BYTES;
+  if (
+    handoff.byteLength <= sourceOffset ||
+    !handoff.subarray(0, HANDOFF_MAGIC.byteLength).equals(HANDOFF_MAGIC)
+  ) {
+    throw new Error("red-probe bootstrap handoff is invalid");
+  }
+  const authenticationSecret = Buffer.from(
+    handoff.subarray(HANDOFF_MAGIC.byteLength, sourceOffset),
+  );
+  const probeSource = Buffer.from(handoff.subarray(sourceOffset));
+  handoff.fill(0);
+  if (authenticationSecret.byteLength !== AUTHENTICATION_SECRET_BYTES) {
+    throw new Error("red-probe authentication secret is invalid");
+  }
+  if (
+    probeSource.byteLength === 0 ||
+    probeSource.byteLength > MAXIMUM_PROBE_BYTES
+  ) {
+    throw new Error("red-probe source exceeds its bootstrap bound");
+  }
+  if (sha256(probeSource) !== configuration.probeSourceSha256) {
+    throw new Error("red-probe source digest does not match its bootstrap");
+  }
+  return freeze({ authenticationSecret, probeSource });
+}
+
+const configuration = loadConfiguration();
+// Consume the supervisor-owned authentication secret before any
+// filesystem-backed module, external loader, or probe dependency runs. The
+// pipe is at EOF before that module graph is admitted, and the secret remains
+// only in this closure.
+const { authenticationSecret, probeSource } =
+  consumeBootstrapHandoff(configuration);
+await import(configuration.networkTripwireUrl);
+await import(configuration.tsxLoaderUrl);
+let expectedFailureReported = false;
+
+function reportExpectedFailure(identity) {
+  if (expectedFailureReported) {
+    throw new Error("red-probe expected failure may only be reported once");
+  }
+  if (!identityMatches(configuration, identity)) {
+    throw new Error(
+      "red-probe assertion identity does not match its bootstrap",
+    );
+  }
+  expectedFailureReported = true;
+}
+
+function isExactHelperUrl(url) {
+  return (
+    url === configuration.helperRequestUrl ||
+    url === configuration.helperSourceUrl
+  );
+}
+
+function assertAuthorizedHelperParent(parentUrl) {
+  if (parentUrl !== import.meta.url) {
+    throw new Error("red-probe helper import has an unauthorized parent");
+  }
+}
+
+const helperHooks = registerHooks({
+  load(url, context, nextLoad) {
+    if (url === configuration.helperSourceUrl) {
+      return {
+        format: "module-typescript",
+        shortCircuit: true,
+        source: configuration.helperSource,
+      };
+    }
+    if (url === configuration.probeSourceUrl) {
+      return {
+        format: "module-typescript",
+        shortCircuit: true,
+        source: probeSource,
+      };
+    }
+    return nextLoad(url, context);
+  },
+  resolve(specifier, context, nextResolve) {
+    let requestedUrl;
+    try {
+      requestedUrl = context.parentURL
+        ? new URL(specifier, context.parentURL).href
+        : new URL(specifier).href;
+    } catch {
+      requestedUrl = undefined;
+    }
+    if (requestedUrl === configuration.probeSourceUrl) {
+      if (context.parentURL !== import.meta.url) {
+        throw new Error("red-probe source import has an unauthorized parent");
+      }
+      return {
+        shortCircuit: true,
+        url: configuration.probeSourceUrl,
+      };
+    }
+    if (requestedUrl !== undefined && isExactHelperUrl(requestedUrl)) {
+      assertAuthorizedHelperParent(context.parentURL);
+      return {
+        shortCircuit: true,
+        url: configuration.helperSourceUrl,
+      };
+    }
+    const resolved = nextResolve(specifier, context);
+    if (isExactHelperUrl(resolved.url)) {
+      assertAuthorizedHelperParent(context.parentURL);
+      return {
+        ...resolved,
+        shortCircuit: true,
+        url: configuration.helperSourceUrl,
+      };
+    }
+    return resolved;
+  },
+});
+
+let helperModule;
+try {
+  helperModule = await import(configuration.helperSourceUrl);
+} catch (error) {
+  throw error;
+}
+if (typeof helperModule[HELPER_FACTORY] !== "function") {
+  throw new Error("red-probe helper does not export its canonical factory");
+}
+const probeAssertion = helperModule[HELPER_FACTORY](reportExpectedFailure);
+
+let heartbeatSequence = 0;
+function writeHeartbeat() {
+  heartbeatSequence += 1;
+  const evidence = createObject(null);
+  evidence.protocolVersion = PROTOCOL_VERSION;
+  evidence.outcome = HEARTBEAT_PROTOCOL_OUTCOME;
+  evidence.id = configuration.id;
+  evidence.task = configuration.task;
+  evidence.fingerprint = configuration.fingerprint;
+  evidence.sequence = heartbeatSequence;
+  writeStandardOutput(
+    `${HEARTBEAT_PROTOCOL_PREFIX}${stringifyJson(evidence)}\n`,
+  );
+}
+
+writeHeartbeat();
+const heartbeatTimer = scheduleInterval(
+  writeHeartbeat,
+  configuration.heartbeatIntervalMs,
+);
+heartbeatTimer.unref();
+
+function emitAuthenticatedExpectedRedResult() {
+  cancelInterval(heartbeatTimer);
+  if (!expectedFailureReported) return;
+  if (process.exitCode !== undefined && process.exitCode !== 0) return;
+  const evidence = createObject(null);
+  evidence.protocolVersion = PROTOCOL_VERSION;
+  evidence.outcome = PROTOCOL_OUTCOME;
+  evidence.id = configuration.id;
+  evidence.task = configuration.task;
+  evidence.fingerprint = configuration.fingerprint;
+  evidence.assertions = 1;
+  evidence.skipped = 0;
+  evidence.todos = 0;
+  const authenticationTag = createHmacSha256("sha256", authenticationSecret)
+    .update(FINAL_AUTHENTICATION_DOMAIN, "utf8")
+    .update(stringifyJson(evidence), "utf8")
+    .digest("hex");
+  const authenticatedEvidence = createObject(null);
+  for (const key of keys(evidence)) authenticatedEvidence[key] = evidence[key];
+  authenticatedEvidence.authenticationTag = authenticationTag;
+  writeStandardOutput(
+    `${PROTOCOL_PREFIX}${stringifyJson(authenticatedEvidence)}\n`,
+  );
+  process.exitCode = EXPECTED_EXIT_CODE;
+}
+
+const probeModule = await import(configuration.probeSourceUrl);
+if (
+  keys(probeModule).length !== 1 ||
+  !hasOwn(probeModule, "default") ||
+  typeof probeModule.default !== "function"
+) {
+  throw new Error("red-probe source does not export one canonical root runner");
+}
+await probeModule.default(probeAssertion);
+emitAuthenticatedExpectedRedResult();
+
+void helperHooks;
+
+//# sourceURL=agenc-red-probe-bootstrap.mjs

--- a/runtime/tests/helpers/red-probe.ts
+++ b/runtime/tests/helpers/red-probe.ts
@@ -1,0 +1,113 @@
+import { isDeepStrictEqual as nodeIsDeepStrictEqual } from "node:util";
+
+export const RED_PROBE_PROTOCOL_VERSION = 1 as const;
+export const RED_PROBE_EXPECTED_EXIT_CODE = 86 as const;
+export const RED_PROBE_PROTOCOL_PREFIX = "AGENC_RED_PROBE_V1 " as const;
+
+const FINGERPRINT_PATTERN = /^[A-Z0-9][A-Z0-9._:/-]{0,127}$/u;
+const ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const MAXIMUM_ID_CHARACTERS = 64;
+const freeze = Object.freeze;
+const isDeepStrictEqual = nodeIsDeepStrictEqual;
+export const RED_PROBE_TASK_IDS = Object.freeze([
+  "FND-001",
+  "A1",
+  "A2a",
+  "A2b",
+  "A3",
+  "A4",
+  "B1",
+  "B2",
+  "B3a",
+  "B3b",
+  "C1",
+  "C2",
+  "C3a",
+  "C3b",
+  "D1",
+  "D2",
+  "D3",
+  "E1a",
+  "E1b",
+  "E2",
+  "E3",
+] as const);
+const RED_PROBE_TASK_ID_SET: ReadonlySet<string> = new Set(RED_PROBE_TASK_IDS);
+
+export interface RedProbeIdentity {
+  readonly id: string;
+  readonly task: string;
+  readonly fingerprint: string;
+}
+
+export interface RedProbeEvidence {
+  readonly protocolVersion: typeof RED_PROBE_PROTOCOL_VERSION;
+  readonly outcome: "expected-red";
+  readonly id: string;
+  readonly task: string;
+  readonly fingerprint: string;
+  readonly authenticationTag: string;
+  readonly assertions: 1;
+  readonly skipped: 0;
+  readonly todos: 0;
+}
+
+export type RedProbeAssertion = (
+  identity: RedProbeIdentity,
+  actual: unknown,
+  expected: unknown,
+) => void;
+
+type ExpectedFailureReporter = (identity: RedProbeIdentity) => void;
+
+function validateIdentity(identity: RedProbeIdentity): void {
+  if (
+    identity.id.length > MAXIMUM_ID_CHARACTERS ||
+    !ID_PATTERN.test(identity.id)
+  ) {
+    throw new TypeError("red-probe id is not canonical");
+  }
+  if (!RED_PROBE_TASK_ID_SET.has(identity.task)) {
+    throw new TypeError("red-probe task is not canonical");
+  }
+  if (!FINGERPRINT_PATTERN.test(identity.fingerprint)) {
+    throw new TypeError("red-probe fingerprint is not canonical");
+  }
+}
+
+/**
+ * Create one assertion capability for the bootstrap-owned root invocation.
+ *
+ * The reporter is retained only in this closure. Imported dependencies may
+ * load this factory, but they cannot obtain the bootstrap's reporter or its
+ * assertion instance. Getters, proxies, and every other exception escape
+ * normally so unrelated crashes cannot be mistaken for a reproduced defect.
+ */
+export function createRedProbeAssertion(
+  reportToBootstrap: ExpectedFailureReporter,
+): RedProbeAssertion {
+  if (typeof reportToBootstrap !== "function") {
+    throw new TypeError("red-probe reporter must be a function");
+  }
+  let assertionAttempted = false;
+  return freeze(function expectDeepStrictEqualRedProbe(
+    identity: RedProbeIdentity,
+    actual: unknown,
+    expected: unknown,
+  ): void {
+    if (assertionAttempted) {
+      throw new Error("red-probe assertion may only be attempted once");
+    }
+    assertionAttempted = true;
+    validateIdentity(identity);
+    if (!isDeepStrictEqual(actual, expected)) {
+      reportToBootstrap(
+        freeze({
+          fingerprint: identity.fingerprint,
+          id: identity.id,
+          task: identity.task,
+        }),
+      );
+    }
+  });
+}

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -532,6 +532,9 @@ describe("hermetic test discovery", () => {
     expect(pkg.scripts?.["typecheck:test-support"]).toBe(
       "tsc --noEmit --project tsconfig.test-support.json",
     );
+    expect(pkg.scripts?.["test:red-probes"]).toBe(
+      "node scripts/run-fnd-red-probes.mjs",
+    );
     expect(pkg.scripts?.["test:host-functional"]).toBe(
       "node scripts/run-hermetic-vitest.mjs run",
     );
@@ -543,7 +546,7 @@ describe("hermetic test discovery", () => {
     );
   });
 
-  it("runs test-support typechecking inside the authoritative boundary", async () => {
+  it("runs test-support typechecking and red probes inside the authoritative boundary", async () => {
     const boundaryUrl = new URL(
       "../scripts/run-hermetic-test-boundary.mjs",
       import.meta.url,
@@ -560,6 +563,7 @@ describe("hermetic test discovery", () => {
       "node ../node_modules/typescript/bin/tsc --noEmit";
     const supportTypecheck =
       "node ../node_modules/typescript/bin/tsc --noEmit --project tsconfig.test-support.json";
+    const redProbes = "node scripts/run-fnd-red-probes.mjs";
     const vitest =
       'exec node scripts/run-hermetic-vitest.mjs --require-zero-skips "$@"';
 
@@ -567,9 +571,10 @@ describe("hermetic test discovery", () => {
     expect(command.indexOf(supportTypecheck)).toBeGreaterThan(
       command.indexOf(productionTypecheck),
     );
-    expect(command.indexOf(vitest)).toBeGreaterThan(
+    expect(command.indexOf(redProbes)).toBeGreaterThan(
       command.indexOf(supportTypecheck),
     );
+    expect(command.indexOf(vitest)).toBeGreaterThan(command.indexOf(redProbes));
   });
 
   it("ignores ambient Git repository overrides when resolving its readonly metadata mount", async () => {

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -406,12 +406,18 @@ describe("reproducible install and release contract", () => {
       workflow.indexOf("\n  windows-native:"),
     );
     expect(macosJob).toContain("runs-on: macos-15");
+    expect(macosJob).toContain("Run the exact macOS red-probe runner contract");
+    expect(macosJob).toContain("tests/fnd/red-probe-runner.contract.test.ts");
+    expect(macosJob).toContain("numTotalTests: 62");
+    expect(macosJob).toContain("numPassedTests: 62");
+    expect(macosJob).toContain("testResult.assertionResults.length !== 62");
+    expect(macosJob).toContain(
+      "macOS red-probe runner passed 62 tests in 1 file with zero skipped",
+    );
     expect(macosJob).toContain(
       "Run the exact macOS FND/native capability lane",
     );
-    expect(macosJob).toContain(
-      "tests/fnd/benchmark-harness-faults.test.ts",
-    );
+    expect(macosJob).toContain("tests/fnd/benchmark-harness-faults.test.ts");
     expect(macosJob).toContain("tests/fnd/bounded-file-io.test.ts");
     expect(macosJob).toContain("tests/fnd/fnd-fixtures.test.ts");
     expect(macosJob).toContain("tests/fnd/portable-repository-path.test.ts");
@@ -434,18 +440,51 @@ describe("reproducible install and release contract", () => {
     expect(windowsJob).toContain(
       "npm.cmd run build --workspace=@tetsuo-ai/runtime",
     );
+    expect(windowsJob).toContain("Run the exact Windows FND red-probe audit");
+    expect(windowsJob).toContain("node runtime/scripts/run-fnd-red-probes.mjs");
+    expect(windowsJob).toContain(
+      "red probes: files=1 expected-red=1 assertions=1 skipped=0 todo=0",
+    );
+    expect(windowsJob).toContain(
+      'if ($LASTEXITCODE -ne 0) { throw "Windows red-probe audit failed" }',
+    );
+    expect(windowsJob).toContain(
+      'throw "Windows red-probe audit dirtied the checkout"',
+    );
+    expect(windowsJob).toContain(
+      "Run the exact Windows FND forced-containment contracts",
+    );
+    expect(windowsJob).toContain("tests/fnd/red-probe-containment.test.ts");
+    expect(windowsJob).toContain(
+      'throw "Windows red-probe forced-containment contracts failed"',
+    );
+    expect(windowsJob).not.toMatch(
+      /^\s*num(?:Total|Passed)TestSuites:\s*1\s*$/gmu,
+    );
+    expect(windowsJob).toContain("numTotalTests: 3");
+    expect(windowsJob).toContain(
+      'const expectedFiles = ["tests/fnd/red-probe-containment.test.ts"]',
+    );
+    expect(windowsJob).toContain("assertions.length !== 3");
+    expect(windowsJob).toContain(
+      'assertions.some(({ status }) => status !== "passed")',
+    );
+    expect(windowsJob).toContain(
+      "Windows red-probe containment passed 3 tests in 1 file with zero skipped",
+    );
+    expect(windowsJob).toContain(
+      'throw "Windows red-probe forced-containment dirtied the checkout"',
+    );
     expect(windowsJob).toContain(
       "tests/app-server/windows-named-pipe.win32.test.ts",
     );
     expect(windowsJob).toContain(
       "tests/durability/atomic-artifact.win32.test.ts",
     );
-    expect(windowsJob).toContain(
-      "tests/fnd/benchmark-harness-faults.test.ts",
-    );
     expect(windowsJob).toContain("tests/fnd/bounded-file-io.test.ts");
     expect(windowsJob).toContain("tests/fnd/fnd-fixtures.test.ts");
     expect(windowsJob).toContain("tests/fnd/portable-repository-path.test.ts");
+    expect(windowsJob).toContain("tests/fnd/benchmark-harness-faults.test.ts");
     expect(windowsJob).toContain(
       "tests/fnd/process-repository-helpers.native.test.ts",
     );
@@ -475,7 +514,7 @@ describe("reproducible install and release contract", () => {
         /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/g,
       ),
     ).toHaveLength(4);
-    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(6);
+    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(8);
     expect(workflow).not.toMatch(/uses:\s+actions\/[\w-]+@v\d/);
     expect(workflow).not.toContain("cache: npm");
     expect(workflow).not.toContain("--passWithNoTests");
@@ -499,18 +538,31 @@ describe("reproducible install and release contract", () => {
         join(workspace, target).replaceAll("\\", "/"),
       );
     });
+    const redProbeManifest = JSON.parse(
+      readFileSync(
+        join(REPO_ROOT, "runtime/tests/fnd/red-probes/manifest.json"),
+        "utf8",
+      ),
+    ) as { probes: Array<{ file: string }> };
+    const digestBoundRedProbeSubjects = [
+      "runtime/tests/helpers/red-probe-bootstrap.mjs",
+      "runtime/tests/helpers/red-probe.ts",
+      ...redProbeManifest.probes.map(({ file }) => `runtime/${file}`),
+    ];
     const lfSubjects = [
       ...binSubjects,
       "package-lock.json",
       "runtime/benchmarks/fnd/baseline.v1.json",
       "runtime/benchmarks/fnd/baseline.v1.md",
+      ...digestBoundRedProbeSubjects,
     ];
     const attributes = execFileSync(
       "git",
-      ["check-attr", "eol", "--", ...lfSubjects],
+      ["check-attr", "text", "eol", "--", ...lfSubjects],
       { cwd: REPO_ROOT, encoding: "utf8" },
     );
     for (const subject of lfSubjects) {
+      expect(attributes).toContain(`${subject}: text: set`);
       expect(attributes).toContain(`${subject}: eol: lf`);
     }
   });

--- a/runtime/tsconfig.test-support.json
+++ b/runtime/tsconfig.test-support.json
@@ -46,6 +46,8 @@
     "tests/helpers/process-evidence-contract.mjs",
     "tests/helpers/process-harness-contract.ts",
     "tests/helpers/process-workspace.ts",
+    "tests/helpers/red-probe-bootstrap.mjs",
+    "tests/helpers/red-probe.ts",
     "tests/helpers/restart-harness.ts",
     "tests/helpers/seeded-rng.ts",
     "tests/helpers/temp-workspace.ts",
@@ -64,7 +66,10 @@
     "tests/fnd/process-fixtures/crash-child.ts",
     "tests/fnd/process-repository-helpers.bun.test.ts",
     "tests/fnd/process-repository-helpers.native.test.ts",
-    "tests/fnd/process-repository-helpers.test.ts"
+    "tests/fnd/process-repository-helpers.test.ts",
+    "tests/fnd/red-probe-containment.test.ts",
+    "tests/fnd/red-probe-runner.contract.test.ts",
+    "tests/fnd/red-probes/**/*.red-probe.ts"
   ],
   "exclude": ["node_modules", "dist"]
 }

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -1,47 +1,47 @@
-import { configDefaults, defineConfig } from 'vitest/config';
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { dirname, isAbsolute, relative, resolve } from 'path';
-import { createScanner, ScriptTarget, SyntaxKind } from 'typescript';
+import { configDefaults, defineConfig } from "vitest/config";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { dirname, isAbsolute, relative, resolve } from "path";
+import { createScanner, ScriptTarget, SyntaxKind } from "typescript";
 
-const agencRoot = resolve(__dirname, 'src/agenc');
-const agencUpstreamRoot = resolve(agencRoot, 'upstream');
-const runtimeSourceRoot = resolve(__dirname, 'src');
-const runtimeTestRoot = resolve(__dirname, 'tests');
+const agencRoot = resolve(__dirname, "src/agenc");
+const agencUpstreamRoot = resolve(agencRoot, "upstream");
+const runtimeSourceRoot = resolve(__dirname, "src");
+const runtimeTestRoot = resolve(__dirname, "tests");
 const relocatedUpstreamRoots = [
   {
-    runtimeRoot: resolve(runtimeSourceRoot, 'utils'),
-    upstreamRoot: resolve(agencUpstreamRoot, 'utils'),
+    runtimeRoot: resolve(runtimeSourceRoot, "utils"),
+    upstreamRoot: resolve(agencUpstreamRoot, "utils"),
   },
   {
-    runtimeRoot: resolve(runtimeSourceRoot, 'constants'),
-    upstreamRoot: resolve(agencUpstreamRoot, 'constants'),
+    runtimeRoot: resolve(runtimeSourceRoot, "constants"),
+    upstreamRoot: resolve(agencUpstreamRoot, "constants"),
   },
   {
-    runtimeRoot: resolve(runtimeSourceRoot, 'memdir'),
-    upstreamRoot: resolve(agencUpstreamRoot, 'memdir'),
+    runtimeRoot: resolve(runtimeSourceRoot, "memdir"),
+    upstreamRoot: resolve(agencUpstreamRoot, "memdir"),
   },
 ];
 const sourceFileBaseAliases = [
   {
-    runtimeBase: resolve(runtimeSourceRoot, 'tools/Tool'),
-    upstreamBase: resolve(agencUpstreamRoot, 'Tool'),
+    runtimeBase: resolve(runtimeSourceRoot, "tools/Tool"),
+    upstreamBase: resolve(agencUpstreamRoot, "Tool"),
   },
   {
-    runtimeBase: resolve(agencUpstreamRoot, 'tools/Tool'),
-    upstreamBase: resolve(agencUpstreamRoot, 'Tool'),
+    runtimeBase: resolve(agencUpstreamRoot, "tools/Tool"),
+    upstreamBase: resolve(agencUpstreamRoot, "Tool"),
   },
   {
-    runtimeBase: resolve(agencUpstreamRoot, 'tasks/Task'),
-    upstreamBase: resolve(agencUpstreamRoot, 'Task'),
+    runtimeBase: resolve(agencUpstreamRoot, "tasks/Task"),
+    upstreamBase: resolve(agencUpstreamRoot, "Task"),
   },
 ];
 const relocatedTuiSourceRoots = [
-  resolve(runtimeSourceRoot, 'tui/components'),
-  resolve(runtimeSourceRoot, 'tui/context'),
-  resolve(runtimeSourceRoot, 'tui/hooks'),
+  resolve(runtimeSourceRoot, "tui/components"),
+  resolve(runtimeSourceRoot, "tui/context"),
+  resolve(runtimeSourceRoot, "tui/hooks"),
 ];
 function normalizeConfigPath(file: string): string {
-  return file.split(/[/\\]+/).join('/');
+  return file.split(/[/\\]+/).join("/");
 }
 
 function walkTestFiles(dir: string): string[] {
@@ -54,11 +54,11 @@ function walkTestFiles(dir: string): string[] {
 }
 
 const bunTestFiles = walkTestFiles(runtimeTestRoot)
-  .filter((file) => readFileSync(file, 'utf8').includes('bun:test'))
+  .filter((file) => readFileSync(file, "utf8").includes("bun:test"))
   .map((file) => normalizeConfigPath(relative(__dirname, file)));
 
 function isVitestCompatibleBunTestFile(file: string): boolean {
-  const source = readFileSync(resolve(__dirname, file), 'utf8');
+  const source = readFileSync(resolve(__dirname, file), "utf8");
   const sourceWithoutComments = stripCommentsForCompatibilityScan(source);
   return (
     !/\bmock\.module\b/.test(sourceWithoutComments) &&
@@ -71,7 +71,7 @@ function isVitestCompatibleBunTestFile(file: string): boolean {
 }
 
 function stripCommentsForCompatibilityScan(source: string): string {
-  const chars = source.split('');
+  const chars = source.split("");
   const scanner = createScanner(ScriptTarget.Latest, false, undefined, source);
   let token = scanner.scan();
 
@@ -80,12 +80,12 @@ function stripCommentsForCompatibilityScan(source: string): string {
       token === SyntaxKind.SingleLineCommentTrivia ||
       token === SyntaxKind.MultiLineCommentTrivia
     ) {
-      chars.fill(' ', scanner.getTokenPos(), scanner.getTextPos());
+      chars.fill(" ", scanner.getTokenPos(), scanner.getTextPos());
     }
     token = scanner.scan();
   }
 
-  return chars.join('');
+  return chars.join("");
 }
 
 const bunOnlyTestFiles = bunTestFiles.filter(
@@ -93,59 +93,59 @@ const bunOnlyTestFiles = bunTestFiles.filter(
 );
 
 export const DEFAULT_TEST_INCLUDE = Object.freeze([
-  'tests/**/*.test.ts',
-  'tests/**/*.test.tsx',
+  "tests/**/*.test.ts",
+  "tests/**/*.test.tsx",
   // This hosted-lane contract is static and hermetic. Keep it in the ordinary
   // local suite so workflow/scenario drift fails before a platform dispatch.
-  'platform-tests/neovim-platform-gate.contract.test.ts',
+  "platform-tests/neovim-platform-gate.contract.test.ts",
 ]);
 
 export const DESIGN_TEST_INCLUDE = Object.freeze([
-  'tests/design-hermetic-env.test.ts',
-  'tests/tui/components/v2/designStateSmoke.test.tsx',
+  "tests/design-hermetic-env.test.ts",
+  "tests/tui/components/v2/designStateSmoke.test.tsx",
 ]);
 
 /** Contracts owned by separately installed AgenC repositories. */
 export const CROSS_REPO_TEST_INCLUDE = Object.freeze([
-  'tests/app-server-protocol/ide-extension.repo.contract.test.ts',
-  'tests/app-server/protocol.contract.test.ts',
-  'tests/app-server/sdk-client.contract.test.ts',
-  'tests/app-server/sdk-hello-world-example.contract.test.ts',
-  'tests/app-server/sdk-tui-coattach-example.contract.test.ts',
+  "tests/app-server-protocol/ide-extension.repo.contract.test.ts",
+  "tests/app-server/protocol.contract.test.ts",
+  "tests/app-server/sdk-client.contract.test.ts",
+  "tests/app-server/sdk-hello-world-example.contract.test.ts",
+  "tests/app-server/sdk-tui-coattach-example.contract.test.ts",
 ]);
 
 /** Native integration tests executed only by their matching hosted builder. */
 export const NATIVE_TEST_INCLUDE = Object.freeze([
-  'tests/app-server/windows-named-pipe.win32.test.ts',
-  'tests/durability/atomic-artifact.win32.test.ts',
-  'tests/fnd/process-repository-helpers.native.test.ts',
-  'tests/tools/runtimes/runtime.darwin.test.ts',
-  'tests/utils/execFileNoThrow.win32.test.ts',
+  "tests/app-server/windows-named-pipe.win32.test.ts",
+  "tests/durability/atomic-artifact.win32.test.ts",
+  "tests/fnd/process-repository-helpers.native.test.ts",
+  "tests/tools/runtimes/runtime.darwin.test.ts",
+  "tests/utils/execFileNoThrow.win32.test.ts",
 ]);
 
 /** Portable FND contracts repeated by every supported native builder. */
 export const HOSTED_FND_TEST_INCLUDE = Object.freeze([
-  'tests/fnd/benchmark-harness-faults.test.ts',
-  'tests/fnd/bounded-file-io.test.ts',
-  'tests/fnd/fnd-fixtures.test.ts',
-  'tests/fnd/portable-repository-path.test.ts',
+  "tests/fnd/benchmark-harness-faults.test.ts",
+  "tests/fnd/bounded-file-io.test.ts",
+  "tests/fnd/fnd-fixtures.test.ts",
+  "tests/fnd/portable-repository-path.test.ts",
 ]);
 
 /** Real Linux-kernel sandbox coverage executed on a disposable hosted runner. */
 export const KERNEL_TEST_INCLUDE = Object.freeze([
-  'tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts',
+  "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
 ]);
 
 /** PowerShell integration tests executed by the pinned hosted capability lane. */
 export const POWERSHELL_TEST_INCLUDE = Object.freeze([
-  'tests/budget/admitted-legacy-powershell.powershell.test.ts',
-  'tests/packaging/install-ps1.powershell.test.ts',
-  'tests/tools/PowerShellTool.execution.powershell.test.ts',
+  "tests/budget/admitted-legacy-powershell.powershell.test.ts",
+  "tests/packaging/install-ps1.powershell.test.ts",
+  "tests/tools/PowerShellTool.execution.powershell.test.ts",
 ]);
 
 /** Real-Neovim integration tests executed by the pinned hosted capability lane. */
 export const NEOVIM_TEST_INCLUDE = Object.freeze([
-  'tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts',
+  "tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts",
 ]);
 
 /**
@@ -156,17 +156,18 @@ export const NEOVIM_TEST_INCLUDE = Object.freeze([
  */
 export const DEFAULT_TEST_EXCLUDE = Object.freeze([
   ...configDefaults.exclude,
-  'dist/**',
-  'tests/agenc/**/*.test.ts',
-  'tests/agenc/**/*.test.tsx',
+  "dist/**",
+  "**/*.red-probe.ts",
+  "tests/agenc/**/*.test.ts",
+  "tests/agenc/**/*.test.tsx",
   ...bunOnlyTestFiles,
-  'tests/integration.test.ts',
-  'tests/eval-replay.integration.test.ts',
-  'tests/live/**',
-  '**/*.live.test.*',
-  'tests/browser/live-e2e.test.ts',
-  'tests/llm/provider.integration.test.ts',
-  'tests/transaction-guard/devnet-live.e2e.test.ts',
+  "tests/integration.test.ts",
+  "tests/eval-replay.integration.test.ts",
+  "tests/live/**",
+  "**/*.live.test.*",
+  "tests/browser/live-e2e.test.ts",
+  "tests/llm/provider.integration.test.ts",
+  "tests/transaction-guard/devnet-live.e2e.test.ts",
   ...DESIGN_TEST_INCLUDE,
   ...CROSS_REPO_TEST_INCLUDE,
   ...NATIVE_TEST_INCLUDE,
@@ -177,28 +178,31 @@ export const DEFAULT_TEST_EXCLUDE = Object.freeze([
 
 /** Explicit allowlist for credential-preserving, operator-invoked live runs. */
 export const LIVE_TEST_INCLUDE = Object.freeze([
-  'tests/live/**/*.test.ts',
-  'tests/live/**/*.test.tsx',
-  'tests/**/*.live.test.ts',
-  'tests/**/*.live.test.tsx',
-  'tests/browser/live-e2e.test.ts',
-  'tests/llm/provider.integration.test.ts',
-  'tests/transaction-guard/devnet-live.e2e.test.ts',
+  "tests/live/**/*.test.ts",
+  "tests/live/**/*.test.tsx",
+  "tests/**/*.live.test.ts",
+  "tests/**/*.live.test.tsx",
+  "tests/browser/live-e2e.test.ts",
+  "tests/llm/provider.integration.test.ts",
+  "tests/transaction-guard/devnet-live.e2e.test.ts",
 ]);
 
 export type AgenCVitestMode =
-  | 'default'
-  | 'live'
-  | 'design'
-  | 'cross-repo'
-  | 'native'
-  | 'kernel'
-  | 'powershell'
-  | 'neovim';
+  | "default"
+  | "live"
+  | "design"
+  | "cross-repo"
+  | "native"
+  | "kernel"
+  | "powershell"
+  | "neovim";
 
-function splitModuleId(id: string): { readonly path: string; readonly suffix: string } {
+function splitModuleId(id: string): {
+  readonly path: string;
+  readonly suffix: string;
+} {
   const index = id.search(/[?#]/);
-  if (index === -1) return { path: id, suffix: '' };
+  if (index === -1) return { path: id, suffix: "" };
   return {
     path: id.slice(0, index),
     suffix: id.slice(index),
@@ -206,11 +210,11 @@ function splitModuleId(id: string): { readonly path: string; readonly suffix: st
 }
 
 function aliasedSourceBases(base: string): string[] {
-  const slash = base.lastIndexOf('/');
+  const slash = base.lastIndexOf("/");
   const file = slash === -1 ? base : base.slice(slash + 1);
   const extMatch = /^(.*?)(\.(?:js|jsx|ts|tsx))?$/.exec(file);
-  const ext = extMatch?.[2] ?? '';
-  const extensionlessBase = ext === '' ? base : base.slice(0, -ext.length);
+  const ext = extMatch?.[2] ?? "";
+  const extensionlessBase = ext === "" ? base : base.slice(0, -ext.length);
   const fileBaseAliases = sourceFileBaseAliases
     .filter(({ runtimeBase }) => runtimeBase === extensionlessBase)
     .map(({ upstreamBase }) => `${upstreamBase}${ext}`);
@@ -225,9 +229,9 @@ function existingSourceFile(base: string): string | null {
         hasExtension
           ? [
               sourceBase,
-              sourceBase.replace(/\.js$/, '.ts'),
-              sourceBase.replace(/\.js$/, '.tsx'),
-              sourceBase.replace(/\.jsx$/, '.tsx'),
+              sourceBase.replace(/\.js$/, ".ts"),
+              sourceBase.replace(/\.js$/, ".tsx"),
+              sourceBase.replace(/\.jsx$/, ".tsx"),
             ]
           : [
               sourceBase,
@@ -235,21 +239,23 @@ function existingSourceFile(base: string): string | null {
               `${sourceBase}.tsx`,
               `${sourceBase}.mts`,
               `${sourceBase}.cts`,
-              resolve(sourceBase, 'index.ts'),
-              resolve(sourceBase, 'index.tsx'),
-              resolve(sourceBase, 'index.js'),
+              resolve(sourceBase, "index.ts"),
+              resolve(sourceBase, "index.tsx"),
+              resolve(sourceBase, "index.js"),
             ],
       ),
     ),
   ];
-  return candidates.find((candidate) => {
-    if (!existsSync(candidate)) return false;
-    try {
-      return statSync(candidate).isFile();
-    } catch {
-      return false;
-    }
-  }) ?? null;
+  return (
+    candidates.find((candidate) => {
+      if (!existsSync(candidate)) return false;
+      try {
+        return statSync(candidate).isFile();
+      } catch {
+        return false;
+      }
+    }) ?? null
+  );
 }
 
 function existingRuntimeTestFile(base: string): string | null {
@@ -257,9 +263,9 @@ function existingRuntimeTestFile(base: string): string | null {
   const candidates = hasExtension
     ? [
         base,
-        base.replace(/\.js$/, '.ts'),
-        base.replace(/\.js$/, '.tsx'),
-        base.replace(/\.jsx$/, '.tsx'),
+        base.replace(/\.js$/, ".ts"),
+        base.replace(/\.js$/, ".tsx"),
+        base.replace(/\.jsx$/, ".tsx"),
       ]
     : [
         base,
@@ -267,27 +273,29 @@ function existingRuntimeTestFile(base: string): string | null {
         `${base}.tsx`,
         `${base}.mts`,
         `${base}.cts`,
-        resolve(base, 'index.ts'),
-        resolve(base, 'index.tsx'),
-        resolve(base, 'index.js'),
+        resolve(base, "index.ts"),
+        resolve(base, "index.tsx"),
+        resolve(base, "index.js"),
       ];
-  return candidates.find((candidate) => {
-    if (!existsSync(candidate)) return false;
-    try {
-      return statSync(candidate).isFile();
-    } catch {
-      return false;
-    }
-  }) ?? null;
+  return (
+    candidates.find((candidate) => {
+      if (!existsSync(candidate)) return false;
+      try {
+        return statSync(candidate).isFile();
+      } catch {
+        return false;
+      }
+    }) ?? null
+  );
 }
 
 function isWithin(root: string, file: string): boolean {
   const rel = relative(root, file);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
 function sourceRootForImporter(importer: string): string | null {
-  const cleanImporter = importer.split('?')[0] ?? importer;
+  const cleanImporter = importer.split("?")[0] ?? importer;
   const absoluteImporter = isAbsolute(cleanImporter)
     ? cleanImporter
     : resolve(__dirname, cleanImporter);
@@ -299,13 +307,13 @@ function sourceRootForImporter(importer: string): string | null {
 }
 
 function relocatedUpstreamImporter(importer: string): string | null {
-  const cleanImporter = importer.split('?')[0] ?? importer;
+  const cleanImporter = importer.split("?")[0] ?? importer;
   const absoluteImporter = isAbsolute(cleanImporter)
     ? cleanImporter
     : resolve(__dirname, cleanImporter);
   for (const { runtimeRoot, upstreamRoot } of relocatedUpstreamRoots) {
     const rel = relative(runtimeRoot, absoluteImporter);
-    if (rel !== '' && !rel.startsWith('..')) {
+    if (rel !== "" && !rel.startsWith("..")) {
       return resolve(upstreamRoot, rel);
     }
   }
@@ -313,10 +321,14 @@ function relocatedUpstreamImporter(importer: string): string | null {
 }
 
 function resolveAgenCBareSrc(source: string): string | null {
-  const sourceRelative = source.slice('src/'.length);
-  const relocatedTuiRelative = /^(components|context|hooks)\//.exec(sourceRelative);
+  const sourceRelative = source.slice("src/".length);
+  const relocatedTuiRelative = /^(components|context|hooks)\//.exec(
+    sourceRelative,
+  );
   if (relocatedTuiRelative) {
-    const found = existingSourceFile(resolve(runtimeSourceRoot, 'tui', sourceRelative));
+    const found = existingSourceFile(
+      resolve(runtimeSourceRoot, "tui", sourceRelative),
+    );
     if (found) return found;
   }
   for (const root of [agencUpstreamRoot, runtimeSourceRoot]) {
@@ -327,64 +339,83 @@ function resolveAgenCBareSrc(source: string): string | null {
 }
 
 function normalizeRuntimePath(file: string): string {
-  return file.split(/[/\\]+/).join('/');
+  return file.split(/[/\\]+/).join("/");
 }
 
 function topKey(logical: string): string {
-  return logical.split('/')[0]?.replace(/\.(?:jsx?|tsx?)$/, '') ?? '';
+  return logical.split("/")[0]?.replace(/\.(?:jsx?|tsx?)$/, "") ?? "";
 }
 
-function relocatedLogicalCandidates(importer: string, source: string): string[] {
+function relocatedLogicalCandidates(
+  importer: string,
+  source: string,
+): string[] {
   const candidates: string[] = [];
   let logical: string | null = null;
-  if (source.startsWith('src/')) {
-    logical = source.slice('src/'.length);
-  } else if (source.startsWith('./') || source.startsWith('../')) {
+  if (source.startsWith("src/")) {
+    logical = source.slice("src/".length);
+  } else if (source.startsWith("./") || source.startsWith("../")) {
     const absolute = resolve(dirname(importer), source);
-    const relSource = normalizeRuntimePath(relative(runtimeSourceRoot, absolute));
-    if (relSource !== '' && !relSource.startsWith('..')) {
+    const relSource = normalizeRuntimePath(
+      relative(runtimeSourceRoot, absolute),
+    );
+    if (relSource !== "" && !relSource.startsWith("..")) {
       logical = relSource;
     } else {
-      const relRuntime = normalizeRuntimePath(relative(resolve(__dirname), absolute));
-      if (relRuntime !== '' && !relRuntime.startsWith('..')) logical = relRuntime;
+      const relRuntime = normalizeRuntimePath(
+        relative(resolve(__dirname), absolute),
+      );
+      if (relRuntime !== "" && !relRuntime.startsWith(".."))
+        logical = relRuntime;
     }
   }
   if (!logical) return candidates;
   candidates.push(logical);
-  if (logical.startsWith('tui/tui/')) candidates.push(logical.slice('tui/'.length));
-  if (logical.startsWith('tui/')) candidates.push(logical.slice('tui/'.length));
+  if (logical.startsWith("tui/tui/"))
+    candidates.push(logical.slice("tui/".length));
+  if (logical.startsWith("tui/")) candidates.push(logical.slice("tui/".length));
   const first = topKey(logical);
-  if (first === 'components' || first === 'context' || first === 'hooks') {
+  if (first === "components" || first === "context" || first === "hooks") {
     candidates.push(`tui/${logical}`);
   }
   return [...new Set(candidates)];
 }
 
-function resolveRelocatedTuiSource(importer: string, source: string): string | null {
+function resolveRelocatedTuiSource(
+  importer: string,
+  source: string,
+): string | null {
   for (const logical of relocatedLogicalCandidates(importer, source)) {
     const direct = existingSourceFile(resolve(runtimeSourceRoot, logical));
     if (direct) return direct;
 
     const first = topKey(logical);
-    if (first === 'components' || first === 'context' || first === 'hooks') {
-      const moved = existingSourceFile(resolve(runtimeSourceRoot, 'tui', logical));
+    if (first === "components" || first === "context" || first === "hooks") {
+      const moved = existingSourceFile(
+        resolve(runtimeSourceRoot, "tui", logical),
+      );
       if (moved) return moved;
     }
 
     const upstream = existingSourceFile(resolve(agencUpstreamRoot, logical));
     if (upstream) return upstream;
 
-    if (logical.startsWith('tui/')) {
-      const stripped = logical.slice('tui/'.length);
-      const strippedUpstream = existingSourceFile(resolve(agencUpstreamRoot, stripped));
+    if (logical.startsWith("tui/")) {
+      const stripped = logical.slice("tui/".length);
+      const strippedUpstream = existingSourceFile(
+        resolve(agencUpstreamRoot, stripped),
+      );
       if (strippedUpstream) return strippedUpstream;
     }
   }
   return null;
 }
 
-function resolveRelativeAgenCSource(importer: string, source: string): string | null {
-  const cleanImporter = importer.split('?')[0] ?? importer;
+function resolveRelativeAgenCSource(
+  importer: string,
+  source: string,
+): string | null {
+  const cleanImporter = importer.split("?")[0] ?? importer;
   const absoluteImporter = isAbsolute(cleanImporter)
     ? cleanImporter
     : resolve(__dirname, cleanImporter);
@@ -406,23 +437,30 @@ function resolveRelativeAgenCSource(importer: string, source: string): string | 
   return null;
 }
 
-function resolveMovedRuntimeTestSource(importer: string, source: string): string | null {
-  if (!source.startsWith('./') && !source.startsWith('../')) return null;
+function resolveMovedRuntimeTestSource(
+  importer: string,
+  source: string,
+): string | null {
+  if (!source.startsWith("./") && !source.startsWith("../")) return null;
   const { path: sourcePath, suffix } = splitModuleId(source);
-  const cleanImporter = importer.split('?')[0] ?? importer;
+  const cleanImporter = importer.split("?")[0] ?? importer;
   const absoluteImporter = isAbsolute(cleanImporter)
     ? cleanImporter
     : resolve(__dirname, cleanImporter);
   if (!isWithin(runtimeTestRoot, absoluteImporter)) return null;
 
-  const directTestTarget = existingRuntimeTestFile(resolve(dirname(absoluteImporter), sourcePath));
+  const directTestTarget = existingRuntimeTestFile(
+    resolve(dirname(absoluteImporter), sourcePath),
+  );
   if (directTestTarget !== null) return null;
 
   const sourceImporter = resolve(
     runtimeSourceRoot,
     relative(runtimeTestRoot, absoluteImporter),
   );
-  const mirrored = existingSourceFile(resolve(dirname(sourceImporter), sourcePath));
+  const mirrored = existingSourceFile(
+    resolve(dirname(sourceImporter), sourcePath),
+  );
   if (mirrored !== null) return `${mirrored}${suffix}`;
 
   const relocated = resolveRelativeAgenCSource(sourceImporter, sourcePath);
@@ -434,141 +472,148 @@ function resolveMovedRuntimeTestSource(importer: string, source: string): string
  * directly because Vitest/Vite merges arrays; merging setup-file arrays can
  * accidentally retain or remove security setup.
  */
-export function createAgenCVitestConfig(mode: AgenCVitestMode = 'default') {
-  const discovery = mode === 'live'
-    ? {
-        // Live tests deliberately preserve provider credentials and external
-        // I/O opt-ins. Keep this empty and do not merge configs.
-        setupFiles: [] as string[],
-        include: [...LIVE_TEST_INCLUDE],
-        exclude: [...configDefaults.exclude],
-      }
-    : mode === 'design'
+export function createAgenCVitestConfig(mode: AgenCVitestMode = "default") {
+  const discovery =
+    mode === "live"
       ? {
-          // Design audits preserve only their dedicated inputs while stripping
-          // credentials, live-provider gates, and real home state. The Node
-          // process retains the JS tripwire; an explicitly requested external
-          // browser is defense-in-depth hardened but is not an OS egress gate.
-          setupFiles: ['./vitest.design.setup.ts'],
-          include: [...DESIGN_TEST_INCLUDE],
+          // Live tests deliberately preserve provider credentials and external
+          // I/O opt-ins. Keep this empty and do not merge configs.
+          setupFiles: [] as string[],
+          include: [...LIVE_TEST_INCLUDE],
           exclude: [...configDefaults.exclude],
         }
-      : mode === 'cross-repo'
+      : mode === "design"
         ? {
-            // These tests inspect separately checked-out AgenC repositories.
-            // They retain the default credential stripping and JS tripwire,
-            // but are intentionally absent from the clean-checkout gate.
-            setupFiles: ['./vitest.setup.ts'],
-            include: [...CROSS_REPO_TEST_INCLUDE],
+            // Design audits preserve only their dedicated inputs while stripping
+            // credentials, live-provider gates, and real home state. The Node
+            // process retains the JS tripwire; an explicitly requested external
+            // browser is defense-in-depth hardened but is not an OS egress gate.
+            setupFiles: ["./vitest.design.setup.ts"],
+            include: [...DESIGN_TEST_INCLUDE],
             exclude: [...configDefaults.exclude],
           }
-        : mode === 'native'
+        : mode === "cross-repo"
           ? {
-              // Platform integration probes and portable FND contracts run on
-              // every matching hosted native builder, with normal credential
-              // stripping and the JS network tripwire.
-              setupFiles: ['./vitest.setup.ts'],
-              include: [
-                ...HOSTED_FND_TEST_INCLUDE,
-                ...NATIVE_TEST_INCLUDE,
-              ],
+              // These tests inspect separately checked-out AgenC repositories.
+              // They retain the default credential stripping and JS tripwire,
+              // but are intentionally absent from the clean-checkout gate.
+              setupFiles: ["./vitest.setup.ts"],
+              include: [...CROSS_REPO_TEST_INCLUDE],
               exclude: [...configDefaults.exclude],
             }
-          : mode === 'kernel'
+          : mode === "native"
             ? {
-                // The disposable hosted lane loads the narrow AppArmor profile
-                // and fails closed on missing kernel facilities, while the
-                // ordinary hermetic environment still strips credentials and
-                // isolates AgenC state.
-                setupFiles: ['./vitest.setup.ts'],
-                include: [...KERNEL_TEST_INCLUDE],
+                // Platform integration probes and portable FND contracts run on
+                // every matching hosted native builder, with normal credential
+                // stripping and the JS network tripwire.
+                setupFiles: ["./vitest.setup.ts"],
+                include: [...HOSTED_FND_TEST_INCLUDE, ...NATIVE_TEST_INCLUDE],
                 exclude: [...configDefaults.exclude],
               }
-          : mode === 'powershell'
-            ? {
-                // The hosted capability lane provisions an exact PowerShell
-                // runtime before entering the ordinary hermetic test boundary.
-                setupFiles: ['./vitest.setup.ts'],
-                include: [...POWERSHELL_TEST_INCLUDE],
-                exclude: [...configDefaults.exclude],
-                env: {
-                  DOTNET_CLI_TELEMETRY_OPTOUT: '1',
-                  DOTNET_NOLOGO: '1',
-                  POWERSHELL_TELEMETRY_OPTOUT: '1',
-                  POWERSHELL_UPDATECHECK: 'Off',
-                },
-              }
-            : mode === 'neovim'
+            : mode === "kernel"
               ? {
-                  // The hosted capability lane provisions a digest-pinned
-                  // Neovim before entering the ordinary hermetic boundary.
-                  setupFiles: ['./vitest.setup.ts'],
-                  include: [...NEOVIM_TEST_INCLUDE],
+                  // The disposable hosted lane loads the narrow AppArmor profile
+                  // and fails closed on missing kernel facilities, while the
+                  // ordinary hermetic environment still strips credentials and
+                  // isolates AgenC state.
+                  setupFiles: ["./vitest.setup.ts"],
+                  include: [...KERNEL_TEST_INCLUDE],
                   exclude: [...configDefaults.exclude],
                 }
-            : {
-                setupFiles: ['./vitest.setup.ts'],
-                include: [...DEFAULT_TEST_INCLUDE],
-                exclude: [...DEFAULT_TEST_EXCLUDE],
-              };
+              : mode === "powershell"
+                ? {
+                    // The hosted capability lane provisions an exact PowerShell
+                    // runtime before entering the ordinary hermetic test boundary.
+                    setupFiles: ["./vitest.setup.ts"],
+                    include: [...POWERSHELL_TEST_INCLUDE],
+                    exclude: [...configDefaults.exclude],
+                    env: {
+                      DOTNET_CLI_TELEMETRY_OPTOUT: "1",
+                      DOTNET_NOLOGO: "1",
+                      POWERSHELL_TELEMETRY_OPTOUT: "1",
+                      POWERSHELL_UPDATECHECK: "Off",
+                    },
+                  }
+                : mode === "neovim"
+                  ? {
+                      // The hosted capability lane provisions a digest-pinned
+                      // Neovim before entering the ordinary hermetic boundary.
+                      setupFiles: ["./vitest.setup.ts"],
+                      include: [...NEOVIM_TEST_INCLUDE],
+                      exclude: [...configDefaults.exclude],
+                    }
+                  : {
+                      setupFiles: ["./vitest.setup.ts"],
+                      include: [...DEFAULT_TEST_INCLUDE],
+                      exclude: [...DEFAULT_TEST_EXCLUDE],
+                    };
 
   return defineConfig({
     plugins: [
-    {
-      name: 'agenc-markdown-text-loader',
-      enforce: 'pre',
-      load(id) {
-        const cleanId = id.split('?')[0] ?? id;
-        if (!cleanId.endsWith('.md')) return null;
-        return `export default ${JSON.stringify(readFileSync(cleanId, 'utf8'))};`;
+      {
+        name: "agenc-markdown-text-loader",
+        enforce: "pre",
+        load(id) {
+          const cleanId = id.split("?")[0] ?? id;
+          if (!cleanId.endsWith(".md")) return null;
+          return `export default ${JSON.stringify(readFileSync(cleanId, "utf8"))};`;
+        },
       },
-    },
-    {
-      name: 'agenc-bare-src-alias',
-      enforce: 'pre',
-      resolveId(source, importer) {
-        if (source.startsWith('src/')) {
-          if (
-            importer === undefined ||
-            (!importer.includes('/src/agenc/') &&
-              sourceRootForImporter(importer) === null &&
-              relocatedUpstreamImporter(importer) === null)
-          ) {
-            return null;
+      {
+        name: "agenc-bare-src-alias",
+        enforce: "pre",
+        resolveId(source, importer) {
+          if (source.startsWith("src/")) {
+            if (
+              importer === undefined ||
+              (!importer.includes("/src/agenc/") &&
+                sourceRootForImporter(importer) === null &&
+                relocatedUpstreamImporter(importer) === null)
+            ) {
+              return null;
+            }
+            return resolveAgenCBareSrc(source);
           }
-          return resolveAgenCBareSrc(source);
-        }
-        if (
-          (source.startsWith('./') || source.startsWith('../')) &&
-          importer !== undefined
-        ) {
-          const movedRuntimeTestSource = resolveMovedRuntimeTestSource(importer, source);
-          if (movedRuntimeTestSource !== null) return movedRuntimeTestSource;
-        }
-        if (
-          (source.startsWith('./') || source.startsWith('../')) &&
-          importer !== undefined &&
-          (importer.includes('/src/agenc/') ||
-            sourceRootForImporter(importer) !== null ||
-            relocatedUpstreamImporter(importer) !== null)
-        ) {
-          return resolveRelativeAgenCSource(importer, source);
-        }
-        return null;
+          if (
+            (source.startsWith("./") || source.startsWith("../")) &&
+            importer !== undefined
+          ) {
+            const movedRuntimeTestSource = resolveMovedRuntimeTestSource(
+              importer,
+              source,
+            );
+            if (movedRuntimeTestSource !== null) return movedRuntimeTestSource;
+          }
+          if (
+            (source.startsWith("./") || source.startsWith("../")) &&
+            importer !== undefined &&
+            (importer.includes("/src/agenc/") ||
+              sourceRootForImporter(importer) !== null ||
+              relocatedUpstreamImporter(importer) !== null)
+          ) {
+            return resolveRelativeAgenCSource(importer, source);
+          }
+          return null;
+        },
       },
-    },
     ],
     resolve: {
       alias: [
-        { find: 'bun:test', replacement: resolve(__dirname, 'tests/helpers/bun-test-shim.ts') },
-        { find: 'bun:bundle', replacement: resolve(__dirname, 'src/build/feature.ts') },
-        { find: /^src\/(.*)$/, replacement: resolve(__dirname, 'src/$1') },
+        {
+          find: "bun:test",
+          replacement: resolve(__dirname, "tests/helpers/bun-test-shim.ts"),
+        },
+        {
+          find: "bun:bundle",
+          replacement: resolve(__dirname, "src/build/feature.ts"),
+        },
+        { find: /^src\/(.*)$/, replacement: resolve(__dirname, "src/$1") },
       ],
     },
     test: {
       globals: false,
-      environment: 'node',
-      pool: 'forks',
+      environment: "node",
+      pool: "forks",
       // Default mode strips ambient credentials/state and installs the public
       // network tripwire before test modules load. Live mode has no setup.
       ...discovery,
@@ -577,11 +622,11 @@ export function createAgenCVitestConfig(mode: AgenCVitestMode = 'default') {
         interopDefault: true,
       },
       coverage: {
-        provider: 'v8',
-        include: ['src/**/*.{ts,tsx,mts,cts}'],
-        exclude: ['src/**/*.d.ts'],
-        reporter: ['text-summary', 'json-summary', 'json'],
-        reportsDirectory: 'coverage/runtime',
+        provider: "v8",
+        include: ["src/**/*.{ts,tsx,mts,cts}"],
+        exclude: ["src/**/*.d.ts"],
+        reporter: ["text-summary", "json-summary", "json"],
+        reportsDirectory: "coverage/runtime",
         thresholds: {
           statements: 100,
           branches: 100,

--- a/scripts/required-gate-contract.mjs
+++ b/scripts/required-gate-contract.mjs
@@ -126,6 +126,16 @@ export const REQUIRED_GATES = Object.freeze([
 // gatekeeper independently hashes this fixed inventory and compares it with a
 // root-owned approved digest before candidate code runs. Ordinary product and
 // test files remain reviewable without requiring a gate-policy rotation.
+export const REQUIRED_GATE_RED_PROBE_POLICY_PATHS = Object.freeze([
+  "runtime/native/agenc-process-broker.c",
+  "runtime/native/agenc-process-job-broker.cs",
+  "runtime/scripts/run-fnd-red-probes.mjs",
+  "runtime/src/utils/supervisedProcess.ts",
+  "runtime/tests/fnd/red-probes/manifest.json",
+  "runtime/tests/helpers/red-probe-bootstrap.mjs",
+  "runtime/tests/helpers/red-probe.ts",
+]);
+
 export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   ".npmrc",
   ".github/workflows/platform-tests.yml",
@@ -168,6 +178,7 @@ export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   "runtime/scripts/tui-gate-state.mjs",
   "runtime/scripts/hermetic-docker-seccomp.json",
   "runtime/scripts/hermetic-network-boundary.c",
+  ...REQUIRED_GATE_RED_PROBE_POLICY_PATHS,
   "runtime/scripts/run-hermetic-test-boundary.mjs",
   "runtime/scripts/run-hermetic-vitest.mjs",
   "runtime/scripts/write-build-version.mjs",
@@ -198,6 +209,24 @@ export const REQUIRED_GATE_POLICY_PATHS = Object.freeze([
   "scripts/systemd-worker-sandbox.mjs",
   "scripts/verify-required-gate-check.mjs",
 ]);
+
+export function assertRequiredGateRedProbePolicyClosure(policyPaths) {
+  if (!Array.isArray(policyPaths)) {
+    throw new Error("required-gate policy paths must be an array");
+  }
+  for (const requiredPath of REQUIRED_GATE_RED_PROBE_POLICY_PATHS) {
+    const occurrences = policyPaths.filter(
+      (candidatePath) => candidatePath === requiredPath,
+    ).length;
+    if (occurrences !== 1) {
+      throw new Error(
+        `required-gate red-probe policy closure must contain ${requiredPath} exactly once`,
+      );
+    }
+  }
+}
+
+assertRequiredGateRedProbePolicyClosure(REQUIRED_GATE_POLICY_PATHS);
 
 export const REQUIRED_GATE_REPOSITORY_ROOT = realpathSync(
   path.dirname(path.dirname(fileURLToPath(import.meta.url))),

--- a/scripts/run-required-gates.test.mjs
+++ b/scripts/run-required-gates.test.mjs
@@ -42,9 +42,11 @@ import {
   LOCAL_GATE_COMBINED_LIMITS,
 } from "./systemd-worker-sandbox.mjs";
 import {
+  assertRequiredGateRedProbePolicyClosure,
   computeRequiredGateContract,
   REQUIRED_GATE_CONTEXT,
   REQUIRED_GATE_POLICY_PATHS,
+  REQUIRED_GATE_RED_PROBE_POLICY_PATHS,
 } from "./required-gate-contract.mjs";
 import { proveDockerDaemonQuiescence } from "./docker-quiescence.mjs";
 
@@ -122,9 +124,46 @@ test("required gate inventory is complete, ordered, and bounded", () => {
       !path.isAbsolute(relativePath) && !relativePath.includes("..")
     ))
   ));
-  assert.ok(
-    REQUIRED_GATE_POLICY_PATHS.includes("runtime/tsconfig.test-support.json"),
-    "runtime/tsconfig.test-support.json is not hashed",
+  const exactRedProbePolicyClosure = [
+    "runtime/native/agenc-process-broker.c",
+    "runtime/native/agenc-process-job-broker.cs",
+    "runtime/scripts/run-fnd-red-probes.mjs",
+    "runtime/src/utils/supervisedProcess.ts",
+    "runtime/tests/fnd/red-probes/manifest.json",
+    "runtime/tests/helpers/red-probe-bootstrap.mjs",
+    "runtime/tests/helpers/red-probe.ts",
+  ];
+  assert.deepEqual(
+    REQUIRED_GATE_RED_PROBE_POLICY_PATHS,
+    exactRedProbePolicyClosure,
+  );
+  for (const policyPath of [
+    "runtime/tsconfig.test-support.json",
+    ...exactRedProbePolicyClosure,
+  ]) {
+    assert.ok(
+      REQUIRED_GATE_POLICY_PATHS.includes(policyPath),
+      `${policyPath} is not hashed`,
+    );
+  }
+  for (const omittedPath of exactRedProbePolicyClosure) {
+    assert.throws(
+      () =>
+        assertRequiredGateRedProbePolicyClosure(
+          REQUIRED_GATE_POLICY_PATHS.filter(
+            (policyPath) => policyPath !== omittedPath,
+          ),
+        ),
+      new RegExp(`${omittedPath.replaceAll(".", "\\.")} exactly once`, "u"),
+    );
+  }
+  assert.throws(
+    () =>
+      assertRequiredGateRedProbePolicyClosure([
+        ...REQUIRED_GATE_POLICY_PATHS,
+        exactRedProbePolicyClosure[0],
+      ]),
+    /agenc-process-broker\.c exactly once/u,
   );
   const npm = spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", ["--version"], {
     encoding: "utf8",


### PR DESCRIPTION
## Summary

- add a manifest-authenticated expected-red probe runner with bounded parsing, exact source digests, and fail-closed discovery
- contain every probe in a supervised child tree with authenticated completion, heartbeat, output, deadline, and residual-process settlement contracts
- include runtime test-support typechecking and the red audit in the authoritative required-gate boundary
- add explicit macOS runner and Windows audit/forced-containment hosted gates while preserving the benchmark/native capability inventories
- exercise Windows containment through a bounded plain-Node audit child, avoiding a platform-specific Vitest import failure while retaining the production runner path and run-root evidence
- recapture checked benchmark evidence after the authenticated .gitattributes and runtime manifest inputs changed

## Validation

- exact-head npm test under Node 26.5.0: required gates 130/130, agent-surface contract 22/22, launcher 180/180, runtime 1,932 files and 17,537 tests, all passing
- exact red audit: 1 file, 1 expected-red result, 1 assertion, zero skipped/todo
- runner and forced-containment contracts: 65/65
- runtime and SDK typechecks
- benchmark contract/fault set: 45/45
- benchmark baseline validation
- mandatory commit hook: production build and all real-PTY startup smokes
- hosted platform matrix run 30721824864: all 9 jobs green, including Windows audit, forced containment, and native capability coverage
- independent exact-head review: hard-gate pass with no correctness, security, containment, portability, gate-wiring, evidence, authenticity, packaging, or discovery findings

## Evidence

- candidate head: e45efbd23d554c0fb3ba8bd88a8a97bd81786bcf
- base: 3431a40eaae98f33b84f034dfa2cdcd95b7c42f6
- baseline production source revision: 925f3ec2860abf48e0c6c0830d135da2587a4d69
- baseline JSON SHA-256: 03c77d2d209972343f72347ac33f60b1582393c566a2893fb995c650283cc07d
- baseline Markdown SHA-256: 9b7adbae345ab0942a64e312472d84283ccb6b85c93b6a66b9c11c19b35fb7dc
- hosted native inventory remains macOS 81 tests/10 suites/6 files and Windows 86/13/8; red gates are separate
- FND-001 remains open until the separate real P0 defect-probe inventory lands

No release is part of this change.
