### PR TITLE
fix(runtime): harden native ESM and Neovim input delivery

### DIFF
--- a/runtime/build.config.ts
+++ b/runtime/build.config.ts
@@ -656,7 +656,6 @@ const external = [
   'axios',
   'fflate',
   'google-auth-library',
-  'semver',
   'sharp',
   'yaml',
   '@mendable/firecrawl-js',

--- a/runtime/build.config.ts
+++ b/runtime/build.config.ts
@@ -535,6 +535,14 @@ const agencBareSrcAlias = {
   },
 };
 
+const noExternal = ['semver', 'supports-hyperlinks'];
+
+function isBundledBareImport(source: string): boolean {
+  return noExternal.some(
+    (packageName) => source === packageName || source.startsWith(`${packageName}/`),
+  );
+}
+
 function resolveRelativeAgenCSource(importer: string, source: string): string | null {
   const absoluteImporter = isAbsolute(importer) ? importer : resolve(runtimeRoot, importer);
   const direct = existingSourceFile(resolve(dirname(absoluteImporter), source));
@@ -568,6 +576,9 @@ const agencOptionalExternal = {
         return null;
       }
       if (args.path === 'bun:bundle' || args.path.startsWith('node:')) {
+        return null;
+      }
+      if (isBundledBareImport(args.path)) {
         return null;
       }
       if (args.path.startsWith('./') || args.path.startsWith('../')) {
@@ -606,8 +617,10 @@ const agencKnownMissingOptionalExternal = {
 };
 
 export const __agencBuildConfigTest = {
+  agencOptionalExternal,
   featureFlagLiteral,
   inlineCopiedTreeFeatureCalls,
+  isBundledBareImport,
   isKnownMissingOptionalModule,
   publicPackageName,
   relocatedTuiSourceRoots,
@@ -680,7 +693,7 @@ export default defineConfig({
   target: 'es2022',
   sourcemap: true,
   external,
-  noExternal: ['supports-hyperlinks'],
+  noExternal,
   esbuildPlugins: [
     agencFeatureFlagInline,
     agencBareSrcAlias,

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -160,6 +160,7 @@ export type NeovimCloseResult =
 const DEFAULT_CLEANUP_TIMEOUT_MS = 1000;
 const DEFAULT_OPERATION_TIMEOUT_MS = 10_000;
 const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
+const INPUT_BUFFER_RETRY_DELAY_MS = 1;
 const DIRTY_CLOSE_REASON =
   "Unsaved Neovim edits. Save or use force quit before closing BUFFER.";
 const DIRTY_STATE_UNAVAILABLE_CLOSE_REASON =
@@ -535,6 +536,13 @@ class NeovimOperationTimeoutError extends Error {
   }
 }
 
+class NeovimInputAcceptanceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NeovimInputAcceptanceError";
+  }
+}
+
 export class NeovimStartupCleanupError extends AggregateError {
   readonly #retryCleanupOperation: () => Promise<void>;
   #cleanupComplete = false;
@@ -634,7 +642,22 @@ export class EmbeddedNeovimSession {
       "Embedded Neovim input",
       true,
       async (signal, timeoutMs) => {
-        await this.#request("nvim_input", [keys], signal, timeoutMs);
+        let remainingKeys = keys;
+        while (remainingKeys.length > 0) {
+          const acceptedBytes = await this.#request(
+            "nvim_input",
+            [remainingKeys],
+            signal,
+            timeoutMs,
+          );
+          const nextKeys = unacceptedInputSuffix(
+            remainingKeys,
+            acceptedBytes,
+          );
+          if (nextKeys.length === 0) break;
+          remainingKeys = nextKeys;
+          await waitForNeovimInputBuffer(signal);
+        }
         return true;
       },
     );
@@ -1477,8 +1500,12 @@ export class EmbeddedNeovimSession {
       captureNeovimProcessDescendants(this.#handle.child);
       return result;
     } catch (error) {
-      if (mutating && isOperationTimeout(error)) {
-        this.#poisonAfterMutatingTimeout(error);
+      if (
+        mutating &&
+        (isOperationTimeout(error) ||
+          error instanceof NeovimInputAcceptanceError)
+      ) {
+        this.#poisonAfterAmbiguousMutation(error);
       }
       throw error;
     } finally {
@@ -1498,14 +1525,14 @@ export class EmbeddedNeovimSession {
     return this.#rpc.request(method, params, { signal, timeoutMs });
   }
 
-  #poisonAfterMutatingTimeout(error: unknown): void {
+  #poisonAfterAmbiguousMutation(error: unknown): void {
     if (this.#closed) return;
     const reason = error instanceof Error ? error : new Error(String(error));
-    // Neovim may have applied a timed-out mutation without delivering its
-    // reply. Continuing would make host and editor state diverge (and a late
-    // mouse press could otherwise advance into its release request), so close
-    // the interactive session but retain the RPC/process boundary until a
-    // queued :preserve proves exact recovery.
+    // Neovim may have applied a mutation without proving exactly how much was
+    // accepted. Continuing would make host and editor state diverge (and a
+    // late mouse press could otherwise advance into its release request), so
+    // close the interactive session but retain the RPC/process boundary until
+    // a queued :preserve proves exact recovery.
     this.#poisoned = true;
     this.#closed = true;
     this.#sessionOperations.abort(reason);
@@ -1839,6 +1866,61 @@ function normalizeTimeout(timeoutMs: number, fallbackMs: number): number {
       ? fallbackMs
       : DEFAULT_OPERATION_TIMEOUT_MS;
   return Math.max(1, Math.floor(candidate));
+}
+
+function unacceptedInputSuffix(
+  keys: string,
+  acceptedBytes: RpcValue,
+): string {
+  const totalBytes = Buffer.byteLength(keys, "utf8");
+  if (
+    typeof acceptedBytes !== "number" ||
+    !Number.isSafeInteger(acceptedBytes) ||
+    acceptedBytes < 0 ||
+    acceptedBytes > totalBytes
+  ) {
+    throw new NeovimInputAcceptanceError(
+      "Neovim returned an invalid nvim_input accepted-byte count.",
+    );
+  }
+  if (acceptedBytes === 0) return keys;
+  if (acceptedBytes === totalBytes) return "";
+
+  const remainingBytes = Buffer.from(keys, "utf8").subarray(acceptedBytes);
+  const remainingKeys = remainingBytes.toString("utf8");
+  if (!Buffer.from(remainingKeys, "utf8").equals(remainingBytes)) {
+    throw new NeovimInputAcceptanceError(
+      "Neovim accepted an nvim_input prefix ending inside a UTF-8 character.",
+    );
+  }
+  return remainingKeys;
+}
+
+function waitForNeovimInputBuffer(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(
+      signal.reason instanceof Error
+        ? signal.reason
+        : new Error("Embedded Neovim input was aborted."),
+    );
+  }
+  return new Promise<void>((resolve, reject) => {
+    const finish = (): void => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    };
+    const abort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", abort);
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error("Embedded Neovim input was aborted."),
+      );
+    };
+    const timer = setTimeout(finish, INPUT_BUFFER_RETRY_DELAY_MS);
+    signal.addEventListener("abort", abort, { once: true });
+  });
 }
 
 function isOperationTimeout(error: unknown): boolean {

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -537,8 +537,8 @@ class NeovimOperationTimeoutError extends Error {
 }
 
 class NeovimInputAcceptanceError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "NeovimInputAcceptanceError";
   }
 }
@@ -644,9 +644,8 @@ export class EmbeddedNeovimSession {
       async (signal, timeoutMs) => {
         let remainingKeys = keys;
         while (remainingKeys.length > 0) {
-          const acceptedBytes = await this.#request(
-            "nvim_input",
-            [remainingKeys],
+          const acceptedBytes = await this.#requestInput(
+            remainingKeys,
             signal,
             timeoutMs,
           );
@@ -1523,6 +1522,24 @@ export class EmbeddedNeovimSession {
     timeoutMs: number,
   ): Promise<RpcValue> {
     return this.#rpc.request(method, params, { signal, timeoutMs });
+  }
+
+  async #requestInput(
+    keys: string,
+    signal: AbortSignal,
+    timeoutMs: number,
+  ): Promise<RpcValue> {
+    try {
+      return await this.#request("nvim_input", [keys], signal, timeoutMs);
+    } catch (error) {
+      // nvim_input does not report execution errors. Any rejected request can
+      // therefore mean that Neovim queued bytes but the acknowledgement was
+      // lost. Fail closed so a caller cannot retry and duplicate that prefix.
+      throw new NeovimInputAcceptanceError(
+        "Neovim did not confirm the nvim_input accepted-byte count.",
+        { cause: error },
+      );
+    }
   }
 
   #poisonAfterAmbiguousMutation(error: unknown): void {

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -1532,6 +1532,7 @@ export class EmbeddedNeovimSession {
     try {
       return await this.#request("nvim_input", [keys], signal, timeoutMs);
     } catch (error) {
+      if (isOperationTimeout(error)) throw error;
       // nvim_input does not report execution errors. Any rejected request can
       // therefore mean that Neovim queued bytes but the acknowledgement was
       // lost. Fail closed so a caller cannot retry and duplicate that prefix.

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -353,6 +353,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   #safeStartupFailure: string | null = null;
   #navigationPromise: Promise<void> | null = null;
   #sessionActionGate: NeovimSessionActionGate | null = null;
+  #sessionActionTail: Promise<void> = Promise.resolve();
   #projectPathMutationLocked = false;
   #workspaceAuthorityRequired = false;
   #workspaceWriteAuthorityHandler: BufferWorkspaceWriteAuthorityHandler | null =
@@ -2404,7 +2405,13 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     const ownership = this.#captureOperationOwnership(session);
     const pendingTransitionGeneration = this.#pendingTransitionGeneration;
     const sessionActionGate = this.#sessionActionGate;
+    const previousAction = this.#sessionActionTail;
+    let releaseAction: () => void = () => {};
+    this.#sessionActionTail = new Promise<void>((resolve) => {
+      releaseAction = resolve;
+    });
     try {
+      await previousAction;
       if (pendingTransitionGeneration !== null) {
         if (
           sessionActionGate === null ||
@@ -2419,6 +2426,8 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       await action();
     } catch (error) {
       if (this.#ownsOperation(ownership)) this.#setInputError(error);
+    } finally {
+      releaseAction();
     }
   }
 

--- a/runtime/src/utils/semver.ts
+++ b/runtime/src/utils/semver.ts
@@ -6,12 +6,15 @@
  * The npm semver fallback always uses { loose: true }.
  */
 
+import { createRequire } from 'node:module'
+
+const requireFromModule = createRequire(import.meta.url)
+
 let _npmSemver: typeof import('semver') | undefined
 
 function getNpmSemver(): typeof import('semver') {
   if (!_npmSemver) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _npmSemver = require('semver') as typeof import('semver')
+    _npmSemver = requireFromModule('semver') as typeof import('semver')
   }
   return _npmSemver
 }

--- a/runtime/src/utils/semver.ts
+++ b/runtime/src/utils/semver.ts
@@ -6,57 +6,53 @@
  * The npm semver fallback always uses { loose: true }.
  */
 
-import { createRequire } from 'node:module'
-
-const requireFromModule = createRequire(import.meta.url)
-
-let _npmSemver: typeof import('semver') | undefined
-
-function getNpmSemver(): typeof import('semver') {
-  if (!_npmSemver) {
-    _npmSemver = requireFromModule('semver') as typeof import('semver')
-  }
-  return _npmSemver
-}
+import {
+  compare as compareSemver,
+  gt as gtSemver,
+  gte as gteSemver,
+  lt as ltSemver,
+  lte as lteSemver,
+  satisfies as satisfiesSemver,
+} from 'semver'
 
 export function gt(a: string, b: string): boolean {
   if (typeof Bun !== 'undefined') {
     return Bun.semver.order(a, b) === 1
   }
-  return getNpmSemver().gt(a, b, { loose: true })
+  return gtSemver(a, b, { loose: true })
 }
 
 export function gte(a: string, b: string): boolean {
   if (typeof Bun !== 'undefined') {
     return Bun.semver.order(a, b) >= 0
   }
-  return getNpmSemver().gte(a, b, { loose: true })
+  return gteSemver(a, b, { loose: true })
 }
 
 export function lt(a: string, b: string): boolean {
   if (typeof Bun !== 'undefined') {
     return Bun.semver.order(a, b) === -1
   }
-  return getNpmSemver().lt(a, b, { loose: true })
+  return ltSemver(a, b, { loose: true })
 }
 
 export function lte(a: string, b: string): boolean {
   if (typeof Bun !== 'undefined') {
     return Bun.semver.order(a, b) <= 0
   }
-  return getNpmSemver().lte(a, b, { loose: true })
+  return lteSemver(a, b, { loose: true })
 }
 
 export function satisfies(version: string, range: string): boolean {
   if (typeof Bun !== 'undefined') {
     return Bun.semver.satisfies(version, range)
   }
-  return getNpmSemver().satisfies(version, range, { loose: true })
+  return satisfiesSemver(version, range, { loose: true })
 }
 
 export function order(a: string, b: string): -1 | 0 | 1 {
   if (typeof Bun !== 'undefined') {
     return Bun.semver.order(a, b)
   }
-  return getNpmSemver().compare(a, b, { loose: true })
+  return compareSemver(a, b, { loose: true })
 }

--- a/runtime/tests/tui/workbench/buffer-neovim-input.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-input.contract.test.ts
@@ -313,6 +313,77 @@ describe("embedded Neovim input translation", () => {
     expect(session.focus).toHaveBeenCalledWith(true);
     expect(session.click).toHaveBeenCalledWith(3, 7);
   });
+
+  it("serializes input RPCs until each preceding mutation settles", async () => {
+    let releaseFirstInput: () => void = () => {};
+    const firstInput = new Promise<void>((resolve) => {
+      releaseFirstInput = resolve;
+    });
+    const received: string[] = [];
+    const session = {
+      pid: 123,
+      input: vi.fn(async (keys: string) => {
+        received.push(keys);
+        if (keys === "<Esc>") await firstInput;
+      }),
+      paste: vi.fn(async () => {}),
+      resize: vi.fn(async () => {}),
+      focus: vi.fn(async () => {}),
+      click: vi.fn(async () => {}),
+      save: vi.fn(async () => true),
+      isDirty: vi.fn(async () => false),
+      quit: vi.fn(async () => ({ closed: true as const })),
+      cleanup: vi.fn(async () => {}),
+    };
+    const provider = new NeovimBufferProvider({
+      discovery: {
+        usable: true,
+        executable: "/usr/bin/nvim",
+        version: { major: 0, minor: 12, patch: 0, raw: "NVIM v0.12.0" },
+        args: ["--embed", "--clean"],
+        useUserInit: false,
+      },
+      readFileSnapshot: vi.fn(async (filePath: string) => ({
+        filePath,
+        absolutePath: `/workspace/${filePath}`,
+        content: "alpha\n",
+        mtimeMs: 1,
+        size: 6,
+        encoding: "utf8",
+        lineEndings: "LF",
+      })),
+      startSession: vi.fn(async (options: StartEmbeddedNeovimOptions) => {
+        options.onSnapshot(
+          createNeovimRenderSnapshot(options.size.rows, options.size.columns),
+        );
+        return session as never;
+      }),
+    });
+
+    await provider.open({ filePath: "target.txt" });
+    expect(
+      provider.handleInput({
+        input: "",
+        key: key({ escape: true }),
+        context: { rows: 8, columns: 40 },
+      }),
+    ).toBe(true);
+    expect(
+      provider.handleInput({
+        input: ":",
+        key: key({}),
+        context: { rows: 8, columns: 40 },
+      }),
+    ).toBe(true);
+
+    await flush();
+    expect(received).toEqual(["<Esc>"]);
+
+    releaseFirstInput();
+    await vi.waitFor(() => {
+      expect(received).toEqual(["<Esc>", ":"]);
+    });
+  });
 });
 
 function createInputEvent(eventKey: Key = baseKey, raw = "") {

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -112,6 +112,9 @@ describe("embedded Neovim lifecycle", () => {
     };
     const rpc = {
       request: vi.fn(async (method: string, args: readonly any[]) => {
+        if (method === "nvim_input") {
+          return Buffer.byteLength(String(args[0]), "utf8");
+        }
         if (method === "nvim_buf_get_option") return true;
         if (method === "nvim_exec_lua") return bufferManifest(true);
         return args[0] ?? true;
@@ -428,6 +431,9 @@ describe("embedded Neovim lifecycle", () => {
           },
         ) => {
           liveSignals.push(options?.signal?.aborted === false);
+          if (method === "nvim_input") {
+            return Buffer.byteLength(String(args[0]), "utf8");
+          }
           if (
             method === "nvim_exec_lua" &&
             String(args[0]).includes("nvim_list_bufs")
@@ -664,6 +670,41 @@ describe("embedded Neovim lifecycle", () => {
         signal: expect.any(AbortSignal),
       },
     );
+    await session.cleanup();
+  });
+
+  it("retries zero and partial nvim_input acceptance without dropping the suffix", async () => {
+    const child = fakeChild({
+      exitCode: 0,
+      pid: syntheticNeovimPid(778),
+    });
+    const handle = {
+      child,
+      pid: syntheticNeovimPid(778),
+      kill: vi.fn(),
+    };
+    const acceptedByteCounts = [0, 2, 1];
+    const rpc = {
+      request: vi.fn(async (method: string) =>
+        method === "nvim_input" ? (acceptedByteCounts.shift() ?? 0) : true
+      ),
+      close: vi.fn(),
+    };
+    const session = new EmbeddedNeovimSession(
+      handle as any,
+      rpc as any,
+      { resize: vi.fn(async () => {}), dispose: vi.fn() } as any,
+      5,
+    );
+
+    await expect(session.input("éK")).resolves.toBe(true);
+
+    expect(
+      rpc.request.mock.calls
+        .filter((call) => call[0] === "nvim_input")
+        .map((call) => call[1]),
+    ).toEqual([["éK"], ["éK"], ["K"]]);
+    expect(acceptedByteCounts).toEqual([]);
     await session.cleanup();
   });
 

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -708,6 +708,53 @@ describe("embedded Neovim lifecycle", () => {
     await session.cleanup();
   });
 
+  it("poisons the session when a suffix acknowledgement fails after partial input", async () => {
+    const child = fakeChild({
+      exitCode: 0,
+      pid: syntheticNeovimPid(779),
+    });
+    const handle = {
+      child,
+      pid: syntheticNeovimPid(779),
+      kill: vi.fn(),
+    };
+    let inputRequestCount = 0;
+    const rpc = {
+      request: vi.fn(async (method: string) => {
+        if (method !== "nvim_input") return true;
+        inputRequestCount += 1;
+        if (inputRequestCount === 1) return 1;
+        throw new Error("transport closed before the suffix acknowledgement");
+      }),
+      close: vi.fn(),
+    };
+    const ui = { resize: vi.fn(async () => {}), dispose: vi.fn() };
+    const onFatalError = vi.fn();
+    const session = new EmbeddedNeovimSession(
+      handle as any,
+      rpc as any,
+      ui as any,
+      5,
+      10_000,
+      null,
+      onFatalError,
+    );
+
+    await expect(session.input("ab")).rejects.toMatchObject({
+      message: "Neovim did not confirm the nvim_input accepted-byte count.",
+      cause: expect.objectContaining({
+        message: "transport closed before the suffix acknowledgement",
+      }),
+    });
+    await expect(session.input("ab")).resolves.toBe(false);
+
+    expect(inputRequestCount).toBe(2);
+    expect(ui.dispose).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(onFatalError).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("retires timed-out read probes so pending RPCs stay bounded and late replies are ignored", async () => {
     const child = fakeChild({ pid: syntheticNeovimPid(792) });
     const handle = {

--- a/runtime/tests/utils/semver.test.ts
+++ b/runtime/tests/utils/semver.test.ts
@@ -7,6 +7,8 @@ import { pathToFileURL } from 'node:url'
 import { build } from 'esbuild'
 import { describe, expect, test } from 'vitest'
 
+import runtimeBuildConfig from '../../build.config'
+
 const runtimeRoot = resolve(import.meta.dirname, '../..')
 
 describe('semver utilities', () => {
@@ -32,7 +34,7 @@ describe('semver utilities', () => {
     ).toBe('')
   })
 
-  test('bundles the Node fallback without an installed semver package', async () => {
+  test('production-bundles the Node fallback without an installed semver package', async () => {
     const artifactRoot = await mkdtemp(join(tmpdir(), 'agenc-semver-bundle-'))
     const artifact = join(artifactRoot, 'semver.mjs')
 
@@ -41,9 +43,10 @@ describe('semver utilities', () => {
         entryPoints: [resolve(runtimeRoot, 'src/utils/semver.ts')],
         outfile: artifact,
         bundle: true,
-        format: 'esm',
-        platform: 'node',
-        target: 'node26',
+        external: runtimeBuildConfig.external,
+        format: runtimeBuildConfig.format[0] as 'esm',
+        platform: runtimeBuildConfig.platform as 'node',
+        target: runtimeBuildConfig.target,
       })
 
       const source = [

--- a/runtime/tests/utils/semver.test.ts
+++ b/runtime/tests/utils/semver.test.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const runtimeRoot = resolve(import.meta.dirname, '../..')
+
+describe('semver utilities', () => {
+  test('loads the npm fallback from a native Node ESM source import', () => {
+    const source = [
+      'import { satisfies } from "./src/utils/semver.ts";',
+      'if (!satisfies("26.5.0", ">=26.5.0 <27.0.0")) process.exitCode = 1;',
+    ].join('\n')
+
+    expect(
+      execFileSync(
+        process.execPath,
+        ['--experimental-strip-types', '--input-type=module', '--eval', source],
+        {
+          cwd: runtimeRoot,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            NODE_OPTIONS: '',
+          },
+        },
+      ),
+    ).toBe('')
+  })
+})

--- a/runtime/tests/utils/semver.test.ts
+++ b/runtime/tests/utils/semver.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'node:url'
 import { build } from 'esbuild'
 import { describe, expect, test } from 'vitest'
 
-import runtimeBuildConfig from '../../build.config'
+import runtimeBuildConfig, { __agencBuildConfigTest } from '../../build.config'
 
 const runtimeRoot = resolve(import.meta.dirname, '../..')
 
@@ -45,6 +45,7 @@ describe('semver utilities', () => {
         bundle: true,
         external: runtimeBuildConfig.external,
         format: runtimeBuildConfig.format[0] as 'esm',
+        plugins: [__agencBuildConfigTest.agencOptionalExternal],
         platform: runtimeBuildConfig.platform as 'node',
         target: runtimeBuildConfig.target,
       })

--- a/runtime/tests/utils/semver.test.ts
+++ b/runtime/tests/utils/semver.test.ts
@@ -1,6 +1,10 @@
 import { execFileSync } from 'node:child_process'
-import { resolve } from 'node:path'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
+import { build } from 'esbuild'
 import { describe, expect, test } from 'vitest'
 
 const runtimeRoot = resolve(import.meta.dirname, '../..')
@@ -26,5 +30,43 @@ describe('semver utilities', () => {
         },
       ),
     ).toBe('')
+  })
+
+  test('bundles the Node fallback without an installed semver package', async () => {
+    const artifactRoot = await mkdtemp(join(tmpdir(), 'agenc-semver-bundle-'))
+    const artifact = join(artifactRoot, 'semver.mjs')
+
+    try {
+      await build({
+        entryPoints: [resolve(runtimeRoot, 'src/utils/semver.ts')],
+        outfile: artifact,
+        bundle: true,
+        format: 'esm',
+        platform: 'node',
+        target: 'node26',
+      })
+
+      const source = [
+        `import { satisfies } from ${JSON.stringify(pathToFileURL(artifact).href)};`,
+        'if (!satisfies("26.5.0", ">=26.5.0 <27.0.0")) process.exitCode = 1;',
+      ].join('\n')
+
+      expect(
+        execFileSync(
+          process.execPath,
+          ['--input-type=module', '--eval', source],
+          {
+            cwd: artifactRoot,
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              NODE_OPTIONS: '',
+            },
+          },
+        ),
+      ).toBe('')
+    } finally {
+      await rm(artifactRoot, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- load the Node semver fallback from native ESM and keep it bundled by the production resolver
- verify an isolated production-configured artifact executes without an undeclared `semver` installation
- serialize embedded-Neovim mutation RPCs and retry only the unaccepted UTF-8 suffix when `nvim_input` reports a partial write
- poison the Neovim session when a suffix retry fails ambiguously, while preserving operation-timeout error identity

## Why

The Windows lanes for #1642 exposed prerequisite defects in two production boundaries. The source tool graph used CommonJS `require` from native ESM, and Neovim input delivery assumed the nonblocking `nvim_input` API accepted every byte. Slow transports can both reorder overlapping mutations and fill the input buffer. This closes those boundaries without weakening the platform checks.

## Exact candidate

- head: `a62daf373d27119030eab52029d43f8ae01b134a`
- base: `cca1a4c1aa9701bc01bd2ac0ca96726b3d06b74e`
- tree: `db383c1ce50f58f3853eb5446b5bb228d014bab2`

## Revert-sensitive evidence

- removing FIFO mutation ordering makes the Neovim contract observe `:` before the deferred Escape RPC settles
- removing the production-resolver exemption makes the isolated artifact fail with `ERR_MODULE_NOT_FOUND: semver`
- ignoring the `nvim_input` byte count leaves a zero/partial acceptance sequence under-delivered
- propagating a generic suffix transport failure without poisoning permits a partially applied mutation to be retried and duplicated

## Verification

- independent exact-SHA review of `a62daf373`: PASS, no findings
- focused Neovim lifecycle/input/provider contracts: 3 files, 103 tests passed
- runtime typecheck: PASS
- full `npm test`: 1,933 runtime test files and 17,542 tests passed
- exact build, package entrypoints, SDK generated types, and every PTY startup viewport: PASS
- Windows platform scenario 131: PASS
- production artifact scan: bundled semver implementation present; no bare semver import or require remains
- `git diff --check`: PASS
- local real-Neovim subprocess checks reached the pinned-version preflight but could not execute because this host has `0.12.0-dev`; the platform lane installs the required `0.12.1`

No release is requested or performed.