### PR TITLE
refactor(runtime): add checkpoint v2 reader barrier

### DIFF
--- a/runtime/src/session/durable-checkpoint-reader.ts
+++ b/runtime/src/session/durable-checkpoint-reader.ts
@@ -3,7 +3,7 @@ import type {
   TurnCheckpointV1Event,
   TurnCheckpointV2Event,
 } from "./event-log.js";
-import type { ResponseItem } from "./rollout-item.js";
+import type { ToolResultIntegrityResponseItem } from "./rollout-item.js";
 import {
   CanonicalSha256Writer,
   TOOL_RESULT_DIGEST_PREFIX,
@@ -74,8 +74,7 @@ export type ReadableTurnCheckpoint =
     };
 
 export type DurableCheckpointReadFailureCode =
-  | "checkpoint_shape_invalid"
-  | "checkpoint_version_unsupported";
+  "checkpoint_shape_invalid" | "checkpoint_version_unsupported";
 
 export class DurableCheckpointReadError extends Error {
   readonly kind = "integrity_failure" as const;
@@ -105,8 +104,7 @@ export interface DurableCheckpointPrefixFailure {
 export interface DurableCheckpointPrefixDeferral {
   readonly kind: "operational_deferral";
   readonly code:
-    | "checkpoint_prefix_message_limit"
-    | "checkpoint_prefix_body_deferred";
+    "checkpoint_prefix_message_limit" | "checkpoint_prefix_body_deferred";
   readonly index: number | null;
   readonly reason: string;
   readonly cause?: ToolResultIntegrityDeferral;
@@ -121,14 +119,12 @@ export type DurableCheckpointPrefixValidation =
   | {
       readonly status: "invalid";
       readonly failure:
-        | DurableCheckpointPrefixFailure
-        | ToolPairIntegrityFailure;
+        DurableCheckpointPrefixFailure | ToolPairIntegrityFailure;
     }
   | {
       readonly status: "deferred";
       readonly failure:
-        | DurableCheckpointPrefixDeferral
-        | ToolPairOperationalDeferral;
+        DurableCheckpointPrefixDeferral | ToolPairOperationalDeferral;
     };
 
 /** Strictly dispatch a durable checkpoint. Unknown versions fail closed. */
@@ -138,9 +134,7 @@ export function readTurnCheckpoint(payload: unknown): ReadableTurnCheckpoint {
   }
   const rawVersion = payload.checkpointVersion;
   const version =
-    rawVersion === undefined
-      ? LEGACY_DURABLE_CHECKPOINT_VERSION
-      : rawVersion;
+    rawVersion === undefined ? LEGACY_DURABLE_CHECKPOINT_VERSION : rawVersion;
   if (
     version !== LEGACY_DURABLE_CHECKPOINT_VERSION &&
     version !== DURABLE_CHECKPOINT_READ_VERSION
@@ -199,7 +193,7 @@ export function readTurnCheckpoint(payload: unknown): ReadableTurnCheckpoint {
  * representation. A3b must invoke this before replay truncation.
  */
 export function computeCheckpointPrefixHashV2(
-  messages: ReadonlyArray<ResponseItem>,
+  messages: ReadonlyArray<ToolResultIntegrityResponseItem>,
   count: number,
 ): string {
   if (!Number.isSafeInteger(count) || count < 0 || count > messages.length) {
@@ -237,19 +231,28 @@ export function computeCheckpointPrefixHashV2(
     writeOptionalString(writer, "tool-result-name", message.toolName);
     writeOptionalString(writer, "response-id", message.id);
     writeOptionalString(writer, "phase", message.phase);
-    writer.writeString("end-turn-present", String(message.endTurn !== undefined));
+    writer.writeString(
+      "end-turn-present",
+      String(message.endTurn !== undefined),
+    );
     if (message.endTurn !== undefined) {
       writer.writeString("end-turn", String(message.endTurn));
     }
 
-    writer.writeString("tool-result-integrity-present", String(integrity !== undefined));
+    writer.writeString(
+      "tool-result-integrity-present",
+      String(integrity !== undefined),
+    );
     if (integrity !== undefined) {
       writer.writeCount("tool-result-integrity-version", integrity.version);
       writer.writeString("tool-result-algorithm", integrity.algorithm);
       writer.writeString("tool-result-run-id", integrity.runId);
       writer.writeString("tool-result-call-id", integrity.toolCallId);
       writer.writeString("tool-result-id", integrity.resultId);
-      writer.writeString("tool-result-original-digest", integrity.original.digest);
+      writer.writeString(
+        "tool-result-original-digest",
+        integrity.original.digest,
+      );
       writer.writeCount(
         "tool-result-original-byte-length",
         integrity.original.byteLength,
@@ -278,7 +281,7 @@ export function computeCheckpointPrefixHashV2(
  */
 export function validateCheckpointPrefixV2(params: {
   readonly checkpoint: TurnCheckpointV2Event;
-  readonly messages: ReadonlyArray<ResponseItem>;
+  readonly messages: ReadonlyArray<ToolResultIntegrityResponseItem>;
   readonly projection: ToolPairProjection;
   readonly projectionId: string;
   readonly sourceKey: string;
@@ -343,7 +346,8 @@ export function validateCheckpointPrefixV2(params: {
           kind: "integrity_failure",
           code: "misplaced_tool_result_integrity",
           index,
-          reason: "tool-result integrity metadata is attached to a non-tool message",
+          reason:
+            "tool-result integrity metadata is attached to a non-tool message",
         },
       };
     }
@@ -438,11 +442,16 @@ function parseCheckpointBase(
   }
   const prefixHash = requiredText(payload.prefixHash, "prefixHash");
   if (!SHA256_HEX_PATTERN.test(prefixHash)) {
-    throw malformed("checkpoint prefixHash must be a lowercase SHA-256 hex digest");
+    throw malformed(
+      "checkpoint prefixHash must be a lowercase SHA-256 hex digest",
+    );
   }
   return {
     turnId,
-    iterationIndex: nonNegativeInteger(payload.iterationIndex, "iterationIndex"),
+    iterationIndex: nonNegativeInteger(
+      payload.iterationIndex,
+      "iterationIndex",
+    ),
     boundary,
     checkpointSeq: nonNegativeInteger(payload.checkpointSeq, "checkpointSeq"),
     persistedMessageCount: nonNegativeInteger(
@@ -454,7 +463,10 @@ function parseCheckpointBase(
   };
 }
 
-function assertResponseItemShape(item: ResponseItem, index: number): void {
+function assertResponseItemShape(
+  item: ToolResultIntegrityResponseItem,
+  index: number,
+): void {
   if (!isRecord(item) || !hasOnlyKnownKeys(item, RESPONSE_ITEM_KEYS)) {
     throw malformed(
       `checkpoint response item ${index} contains unversioned fields`,
@@ -483,7 +495,9 @@ function assertResponseItemShape(item: ResponseItem, index: number): void {
   }
   if (item.toolCalls !== undefined) {
     if (!Array.isArray(item.toolCalls) || item.role !== "assistant") {
-      throw malformed(`checkpoint response item ${index} has invalid toolCalls`);
+      throw malformed(
+        `checkpoint response item ${index} has invalid toolCalls`,
+      );
     }
     for (const call of item.toolCalls) {
       if (
@@ -506,9 +520,7 @@ function assertResponseItemShape(item: ResponseItem, index: number): void {
     ["phase", item.phase],
   ] as const) {
     if (value !== undefined && typeof value !== "string") {
-      throw malformed(
-        `checkpoint response item ${index} has invalid ${field}`,
-      );
+      throw malformed(`checkpoint response item ${index} has invalid ${field}`);
     }
   }
   if (item.endTurn !== undefined && typeof item.endTurn !== "boolean") {
@@ -589,7 +601,9 @@ function parseCheckpointSlice(value: unknown): TurnCheckpointSliceLine {
       );
     }
     if (typeof tracking.compacted !== "boolean") {
-      throw malformed("resumableState.autoCompactTracking.compacted is invalid");
+      throw malformed(
+        "resumableState.autoCompactTracking.compacted is invalid",
+      );
     }
     result.autoCompactTracking = {
       compacted: tracking.compacted,
@@ -660,9 +674,9 @@ function parseCheckpointSlice(value: unknown): TurnCheckpointSliceLine {
 }
 
 function* prefixMessages(
-  messages: ReadonlyArray<ResponseItem>,
+  messages: ReadonlyArray<ToolResultIntegrityResponseItem>,
   count: number,
-): Iterable<ResponseItem> {
+): Iterable<ToolResultIntegrityResponseItem> {
   for (let index = 0; index < count; index += 1) {
     const message = messages[index];
     if (message !== undefined) yield message;

--- a/runtime/src/session/durable-checkpoint-reader.ts
+++ b/runtime/src/session/durable-checkpoint-reader.ts
@@ -1,0 +1,728 @@
+import type {
+  TurnCheckpointSliceLine,
+  TurnCheckpointV1Event,
+  TurnCheckpointV2Event,
+} from "./event-log.js";
+import type { ResponseItem } from "./rollout-item.js";
+import {
+  CanonicalSha256Writer,
+  TOOL_RESULT_DIGEST_PREFIX,
+  ToolResultCanonicalizationError,
+  constantTimeDigestEqual,
+  digestToolResultBody,
+  type ToolResultIntegrityDeferral,
+  type ToolResultIntegrityFailure,
+} from "./tool-result-integrity.js";
+import {
+  validateToolPairSequence,
+  type ToolPairIntegrityFailure,
+  type ToolPairOperationalDeferral,
+  type ToolPairProjection,
+  type ToolPairProjectionSummary,
+} from "./tool-pair-validator.js";
+
+export const LEGACY_DURABLE_CHECKPOINT_VERSION = 1 as const;
+export const DURABLE_CHECKPOINT_READ_VERSION = 2 as const;
+export const DURABLE_ROLLOUT_SCHEMA_V2 = 2 as const;
+export const MAX_CHECKPOINT_PREFIX_MESSAGES = 2_000_000;
+
+const CHECKPOINT_PREFIX_DIGEST_DOMAIN = "agenc.checkpoint-prefix.v2";
+const MAX_CHECKPOINT_TURN_ID_BYTES = 4_096;
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+const CHECKPOINT_BASE_KEYS = Object.freeze([
+  "boundary",
+  "checkpointSeq",
+  "iterationIndex",
+  "persistedMessageCount",
+  "prefixHash",
+  "resumableState",
+  "turnId",
+]);
+const CHECKPOINT_SLICE_KEYS = Object.freeze([
+  "autoCompactTracking",
+  "continuationNudgeCount",
+  "maxOutputTokensRecoveryCount",
+  "pendingBudgetDecision",
+  "planToolRequiredRetryCount",
+  "recoveryReentryCount",
+  "stopHookBlockingCount",
+  "taskBudgetRemaining",
+  "transition",
+  "turnCount",
+]);
+const RESPONSE_ITEM_KEYS = Object.freeze([
+  "content",
+  "endTurn",
+  "id",
+  "phase",
+  "role",
+  "toolCallId",
+  "toolCalls",
+  "toolName",
+  "toolResultIntegrity",
+]);
+const TOOL_CALL_KEYS = Object.freeze(["arguments", "id", "name"]);
+
+export type ReadableTurnCheckpoint =
+  | {
+      readonly version: typeof LEGACY_DURABLE_CHECKPOINT_VERSION;
+      readonly checkpoint: TurnCheckpointV1Event;
+    }
+  | {
+      readonly version: typeof DURABLE_CHECKPOINT_READ_VERSION;
+      readonly checkpoint: TurnCheckpointV2Event;
+    };
+
+export type DurableCheckpointReadFailureCode =
+  | "checkpoint_shape_invalid"
+  | "checkpoint_version_unsupported";
+
+export class DurableCheckpointReadError extends Error {
+  readonly kind = "integrity_failure" as const;
+
+  constructor(
+    readonly code: DurableCheckpointReadFailureCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DurableCheckpointReadError";
+  }
+}
+
+export interface DurableCheckpointPrefixFailure {
+  readonly kind: "integrity_failure";
+  readonly code:
+    | "checkpoint_prefix_missing"
+    | "checkpoint_prefix_digest_mismatch"
+    | "misplaced_tool_result_integrity"
+    | "checkpoint_response_shape_invalid"
+    | "checkpoint_prefix_body_invalid";
+  readonly index: number | null;
+  readonly reason: string;
+  readonly cause?: ToolResultIntegrityFailure;
+}
+
+export interface DurableCheckpointPrefixDeferral {
+  readonly kind: "operational_deferral";
+  readonly code:
+    | "checkpoint_prefix_message_limit"
+    | "checkpoint_prefix_body_deferred";
+  readonly index: number | null;
+  readonly reason: string;
+  readonly cause?: ToolResultIntegrityDeferral;
+}
+
+export type DurableCheckpointPrefixValidation =
+  | {
+      readonly status: "valid";
+      readonly prefixHash: string;
+      readonly toolPairs: ToolPairProjectionSummary;
+    }
+  | {
+      readonly status: "invalid";
+      readonly failure:
+        | DurableCheckpointPrefixFailure
+        | ToolPairIntegrityFailure;
+    }
+  | {
+      readonly status: "deferred";
+      readonly failure:
+        | DurableCheckpointPrefixDeferral
+        | ToolPairOperationalDeferral;
+    };
+
+/** Strictly dispatch a durable checkpoint. Unknown versions fail closed. */
+export function readTurnCheckpoint(payload: unknown): ReadableTurnCheckpoint {
+  if (!isRecord(payload)) {
+    throw malformed("checkpoint payload must be an object");
+  }
+  const rawVersion = payload.checkpointVersion;
+  const version =
+    rawVersion === undefined
+      ? LEGACY_DURABLE_CHECKPOINT_VERSION
+      : rawVersion;
+  if (
+    version !== LEGACY_DURABLE_CHECKPOINT_VERSION &&
+    version !== DURABLE_CHECKPOINT_READ_VERSION
+  ) {
+    throw new DurableCheckpointReadError(
+      "checkpoint_version_unsupported",
+      `durable checkpoint version ${safeVersion(version)} is not readable; maximum is ${DURABLE_CHECKPOINT_READ_VERSION}`,
+    );
+  }
+
+  const expectedKeys =
+    version === LEGACY_DURABLE_CHECKPOINT_VERSION
+      ? rawVersion === undefined
+        ? CHECKPOINT_BASE_KEYS
+        : [...CHECKPOINT_BASE_KEYS, "checkpointVersion"]
+      : [
+          ...CHECKPOINT_BASE_KEYS,
+          "checkpointVersion",
+          "toolResultIntegrityVersion",
+        ];
+  if (!hasExactKeys(payload, expectedKeys)) {
+    throw malformed("checkpoint payload contains unversioned fields");
+  }
+
+  const common = parseCheckpointBase(payload);
+  if (version === LEGACY_DURABLE_CHECKPOINT_VERSION) {
+    if (
+      payload.toolResultIntegrityVersion !== undefined ||
+      (rawVersion !== undefined && rawVersion !== 1)
+    ) {
+      throw malformed("legacy checkpoint carries incompatible v2 metadata");
+    }
+    return {
+      version,
+      checkpoint: {
+        ...common,
+        ...(rawVersion === 1 ? { checkpointVersion: 1 as const } : {}),
+      },
+    };
+  }
+  if (payload.toolResultIntegrityVersion !== 1) {
+    throw malformed("checkpoint v2 requires toolResultIntegrityVersion 1");
+  }
+  return {
+    version,
+    checkpoint: {
+      ...common,
+      checkpointVersion: DURABLE_CHECKPOINT_READ_VERSION,
+      toolResultIntegrityVersion: 1,
+    },
+  };
+}
+
+/**
+ * Compute the version-2 prefix digest over the complete persisted
+ * representation. A3b must invoke this before replay truncation.
+ */
+export function computeCheckpointPrefixHashV2(
+  messages: ReadonlyArray<ResponseItem>,
+  count: number,
+): string {
+  if (!Number.isSafeInteger(count) || count < 0 || count > messages.length) {
+    throw new Error("checkpoint prefix count is outside the available history");
+  }
+  const writer = new CanonicalSha256Writer(CHECKPOINT_PREFIX_DIGEST_DOMAIN);
+  writer.writeCount("message-count", count);
+  for (let index = 0; index < count; index += 1) {
+    const message = messages[index];
+    if (message === undefined) {
+      throw new Error(`checkpoint prefix message ${index} is missing`);
+    }
+    assertResponseItemShape(message, index);
+    writer.writeCount("message-index", index);
+    writer.writeString("role", message.role);
+    const integrity = message.toolResultIntegrity;
+    const bodyIdentity =
+      message.role === "tool" && integrity !== undefined
+        ? integrity.persisted
+        : digestToolResultBody(message.content);
+    writer.writeString("content-digest", bodyIdentity.digest);
+    writer.writeCount("content-byte-length", bodyIdentity.byteLength);
+
+    const calls = message.toolCalls ?? [];
+    writer.writeCount("tool-call-count", calls.length);
+    for (let callIndex = 0; callIndex < calls.length; callIndex += 1) {
+      const call = calls[callIndex];
+      if (call === undefined) continue;
+      writer.writeCount("tool-call-index", callIndex);
+      writer.writeString("tool-call-id", call.id);
+      writer.writeString("tool-call-name", call.name);
+      writeOptionalString(writer, "tool-call-arguments", call.arguments);
+    }
+    writeOptionalString(writer, "tool-result-call-id", message.toolCallId);
+    writeOptionalString(writer, "tool-result-name", message.toolName);
+    writeOptionalString(writer, "response-id", message.id);
+    writeOptionalString(writer, "phase", message.phase);
+    writer.writeString("end-turn-present", String(message.endTurn !== undefined));
+    if (message.endTurn !== undefined) {
+      writer.writeString("end-turn", String(message.endTurn));
+    }
+
+    writer.writeString("tool-result-integrity-present", String(integrity !== undefined));
+    if (integrity !== undefined) {
+      writer.writeCount("tool-result-integrity-version", integrity.version);
+      writer.writeString("tool-result-algorithm", integrity.algorithm);
+      writer.writeString("tool-result-run-id", integrity.runId);
+      writer.writeString("tool-result-call-id", integrity.toolCallId);
+      writer.writeString("tool-result-id", integrity.resultId);
+      writer.writeString("tool-result-original-digest", integrity.original.digest);
+      writer.writeCount(
+        "tool-result-original-byte-length",
+        integrity.original.byteLength,
+      );
+      writer.writeString(
+        "tool-result-persisted-representation",
+        integrity.persisted.representation,
+      );
+      writer.writeString(
+        "tool-result-persisted-digest",
+        integrity.persisted.digest,
+      );
+      writer.writeCount(
+        "tool-result-persisted-byte-length",
+        integrity.persisted.byteLength,
+      );
+    }
+  }
+  return writer.digest().slice(TOOL_RESULT_DIGEST_PREFIX.length);
+}
+
+/**
+ * Validate v2 body metadata, exact call/result order, and the checkpoint hash.
+ * Only `status: "valid"` is executable; invalid and deferred outcomes fail
+ * closed for the A3b resume gate.
+ */
+export function validateCheckpointPrefixV2(params: {
+  readonly checkpoint: TurnCheckpointV2Event;
+  readonly messages: ReadonlyArray<ResponseItem>;
+  readonly projection: ToolPairProjection;
+  readonly projectionId: string;
+  readonly sourceKey: string;
+  readonly maxPrefixMessages?: number;
+}): DurableCheckpointPrefixValidation {
+  const count = params.checkpoint.persistedMessageCount;
+  if (count > params.messages.length) {
+    return {
+      status: "invalid",
+      failure: {
+        kind: "integrity_failure",
+        code: "checkpoint_prefix_missing",
+        index: null,
+        reason: `checkpoint requires ${count} messages but only ${params.messages.length} are available`,
+      },
+    };
+  }
+  const maxPrefixMessages =
+    params.maxPrefixMessages ?? MAX_CHECKPOINT_PREFIX_MESSAGES;
+  if (!Number.isSafeInteger(maxPrefixMessages) || maxPrefixMessages <= 0) {
+    throw new Error("maxPrefixMessages must be a positive safe integer");
+  }
+  if (count > maxPrefixMessages) {
+    return {
+      status: "deferred",
+      failure: {
+        kind: "operational_deferral",
+        code: "checkpoint_prefix_message_limit",
+        index: null,
+        reason: `checkpoint prefix has ${count} messages; limit is ${maxPrefixMessages}`,
+      },
+    };
+  }
+  for (let index = 0; index < count; index += 1) {
+    const message = params.messages[index];
+    if (message !== undefined) {
+      try {
+        assertResponseItemShape(message, index);
+      } catch (error) {
+        if (error instanceof DurableCheckpointReadError) {
+          return {
+            status: "invalid",
+            failure: {
+              kind: "integrity_failure",
+              code: "checkpoint_response_shape_invalid",
+              index,
+              reason: error.message,
+            },
+          };
+        }
+        throw error;
+      }
+    }
+    if (
+      message !== undefined &&
+      message.role !== "tool" &&
+      message.toolResultIntegrity !== undefined
+    ) {
+      return {
+        status: "invalid",
+        failure: {
+          kind: "integrity_failure",
+          code: "misplaced_tool_result_integrity",
+          index,
+          reason: "tool-result integrity metadata is attached to a non-tool message",
+        },
+      };
+    }
+  }
+
+  const toolPairs = validateToolPairSequence(
+    prefixMessages(params.messages, count),
+    params.projection,
+    {
+      projectionId: params.projectionId,
+      sourceKey: params.sourceKey,
+      requireResultIntegrity: true,
+    },
+  );
+  if (toolPairs.status !== "valid") return toolPairs;
+
+  let prefixHash: string;
+  try {
+    prefixHash = computeCheckpointPrefixHashV2(params.messages, count);
+  } catch (error) {
+    if (error instanceof DurableCheckpointReadError) {
+      return {
+        status: "invalid",
+        failure: {
+          kind: "integrity_failure",
+          code: "checkpoint_response_shape_invalid",
+          index: null,
+          reason: error.message,
+        },
+      };
+    }
+    if (error instanceof ToolResultCanonicalizationError) {
+      if (error.kind === "operational_deferral") {
+        return {
+          status: "deferred",
+          failure: {
+            kind: "operational_deferral",
+            code: "checkpoint_prefix_body_deferred",
+            index: null,
+            reason: error.message,
+            cause: {
+              kind: "operational_deferral",
+              code: error.code as ToolResultIntegrityDeferral["code"],
+              reason: error.message,
+            },
+          },
+        };
+      }
+      return {
+        status: "invalid",
+        failure: {
+          kind: "integrity_failure",
+          code: "checkpoint_prefix_body_invalid",
+          index: null,
+          reason: error.message,
+          cause: {
+            kind: "integrity_failure",
+            code: error.code as ToolResultIntegrityFailure["code"],
+            reason: error.message,
+          },
+        },
+      };
+    }
+    throw error;
+  }
+  if (!constantTimeDigestEqual(prefixHash, params.checkpoint.prefixHash)) {
+    return {
+      status: "invalid",
+      failure: {
+        kind: "integrity_failure",
+        code: "checkpoint_prefix_digest_mismatch",
+        index: null,
+        reason: "checkpoint prefix digest does not match persisted history",
+      },
+    };
+  }
+  return { status: "valid", prefixHash, toolPairs: toolPairs.summary };
+}
+
+function parseCheckpointBase(
+  payload: Record<string, unknown>,
+): Omit<TurnCheckpointV1Event, "checkpointVersion"> {
+  const turnId = requiredText(payload.turnId, "turnId");
+  if (Buffer.byteLength(turnId, "utf8") > MAX_CHECKPOINT_TURN_ID_BYTES) {
+    throw malformed(
+      `turnId exceeds ${MAX_CHECKPOINT_TURN_ID_BYTES} UTF-8 bytes`,
+    );
+  }
+  const boundary = payload.boundary;
+  if (boundary !== "iteration" && boundary !== "postAssistant") {
+    throw malformed("checkpoint boundary is invalid");
+  }
+  const prefixHash = requiredText(payload.prefixHash, "prefixHash");
+  if (!SHA256_HEX_PATTERN.test(prefixHash)) {
+    throw malformed("checkpoint prefixHash must be a lowercase SHA-256 hex digest");
+  }
+  return {
+    turnId,
+    iterationIndex: nonNegativeInteger(payload.iterationIndex, "iterationIndex"),
+    boundary,
+    checkpointSeq: nonNegativeInteger(payload.checkpointSeq, "checkpointSeq"),
+    persistedMessageCount: nonNegativeInteger(
+      payload.persistedMessageCount,
+      "persistedMessageCount",
+    ),
+    prefixHash,
+    resumableState: parseCheckpointSlice(payload.resumableState),
+  };
+}
+
+function assertResponseItemShape(item: ResponseItem, index: number): void {
+  if (!isRecord(item) || !hasOnlyKnownKeys(item, RESPONSE_ITEM_KEYS)) {
+    throw malformed(
+      `checkpoint response item ${index} contains unversioned fields`,
+    );
+  }
+  if (
+    item.role !== "system" &&
+    item.role !== "developer" &&
+    item.role !== "user" &&
+    item.role !== "assistant" &&
+    item.role !== "tool"
+  ) {
+    throw malformed(`checkpoint response item ${index} has an invalid role`);
+  }
+  if (typeof item.content !== "string" && !Array.isArray(item.content)) {
+    throw malformed(`checkpoint response item ${index} has invalid content`);
+  }
+  if (Array.isArray(item.content)) {
+    for (const part of item.content) {
+      if (!isRecord(part) || typeof part.type !== "string") {
+        throw malformed(
+          `checkpoint response item ${index} has an invalid content part`,
+        );
+      }
+    }
+  }
+  if (item.toolCalls !== undefined) {
+    if (!Array.isArray(item.toolCalls) || item.role !== "assistant") {
+      throw malformed(`checkpoint response item ${index} has invalid toolCalls`);
+    }
+    for (const call of item.toolCalls) {
+      if (
+        !isRecord(call) ||
+        !hasOnlyKnownKeys(call, TOOL_CALL_KEYS) ||
+        (call.id !== undefined && typeof call.id !== "string") ||
+        (call.name !== undefined && typeof call.name !== "string") ||
+        (call.arguments !== undefined && typeof call.arguments !== "string")
+      ) {
+        throw malformed(
+          `checkpoint response item ${index} has an invalid tool call`,
+        );
+      }
+    }
+  }
+  for (const [field, value] of [
+    ["toolCallId", item.toolCallId],
+    ["toolName", item.toolName],
+    ["id", item.id],
+    ["phase", item.phase],
+  ] as const) {
+    if (value !== undefined && typeof value !== "string") {
+      throw malformed(
+        `checkpoint response item ${index} has invalid ${field}`,
+      );
+    }
+  }
+  if (item.endTurn !== undefined && typeof item.endTurn !== "boolean") {
+    throw malformed(`checkpoint response item ${index} has invalid endTurn`);
+  }
+  if (
+    item.toolResultIntegrity !== undefined &&
+    !isRecord(item.toolResultIntegrity)
+  ) {
+    throw malformed(
+      `checkpoint response item ${index} has invalid tool-result integrity metadata`,
+    );
+  }
+}
+
+function parseCheckpointSlice(value: unknown): TurnCheckpointSliceLine {
+  if (!isRecord(value)) throw malformed("resumableState must be an object");
+  if (!hasOnlyKnownKeys(value, CHECKPOINT_SLICE_KEYS)) {
+    throw malformed("resumableState contains unversioned fields");
+  }
+  const result: {
+    turnCount: number;
+    recoveryReentryCount: number;
+    maxOutputTokensRecoveryCount: number;
+    continuationNudgeCount: number;
+    stopHookBlockingCount: number;
+    planToolRequiredRetryCount?: number;
+    taskBudgetRemaining?: number;
+    autoCompactTracking?: TurnCheckpointSliceLine["autoCompactTracking"];
+    transition?: TurnCheckpointSliceLine["transition"];
+    pendingBudgetDecision?: TurnCheckpointSliceLine["pendingBudgetDecision"];
+  } = {
+    turnCount: nonNegativeInteger(value.turnCount, "resumableState.turnCount"),
+    recoveryReentryCount: nonNegativeInteger(
+      value.recoveryReentryCount,
+      "resumableState.recoveryReentryCount",
+    ),
+    maxOutputTokensRecoveryCount: nonNegativeInteger(
+      value.maxOutputTokensRecoveryCount,
+      "resumableState.maxOutputTokensRecoveryCount",
+    ),
+    continuationNudgeCount: nonNegativeInteger(
+      value.continuationNudgeCount,
+      "resumableState.continuationNudgeCount",
+    ),
+    stopHookBlockingCount: nonNegativeInteger(
+      value.stopHookBlockingCount,
+      "resumableState.stopHookBlockingCount",
+    ),
+  };
+  if (value.planToolRequiredRetryCount !== undefined) {
+    result.planToolRequiredRetryCount = nonNegativeInteger(
+      value.planToolRequiredRetryCount,
+      "resumableState.planToolRequiredRetryCount",
+    );
+  }
+  if (value.taskBudgetRemaining !== undefined) {
+    result.taskBudgetRemaining = nonNegativeInteger(
+      value.taskBudgetRemaining,
+      "resumableState.taskBudgetRemaining",
+    );
+  }
+  if (value.autoCompactTracking !== undefined) {
+    if (!isRecord(value.autoCompactTracking)) {
+      throw malformed("resumableState.autoCompactTracking must be an object");
+    }
+    const tracking = value.autoCompactTracking;
+    if (
+      !hasExactKeys(tracking, [
+        "compacted",
+        "consecutiveFailures",
+        "turnCounter",
+        "turnId",
+      ])
+    ) {
+      throw malformed(
+        "resumableState.autoCompactTracking contains unversioned fields",
+      );
+    }
+    if (typeof tracking.compacted !== "boolean") {
+      throw malformed("resumableState.autoCompactTracking.compacted is invalid");
+    }
+    result.autoCompactTracking = {
+      compacted: tracking.compacted,
+      turnId: requiredText(
+        tracking.turnId,
+        "resumableState.autoCompactTracking.turnId",
+      ),
+      turnCounter: nonNegativeInteger(
+        tracking.turnCounter,
+        "resumableState.autoCompactTracking.turnCounter",
+      ),
+      consecutiveFailures: nonNegativeInteger(
+        tracking.consecutiveFailures,
+        "resumableState.autoCompactTracking.consecutiveFailures",
+      ),
+    };
+  }
+  if (value.transition !== undefined) {
+    if (!isRecord(value.transition)) {
+      throw malformed("resumableState.transition must be an object");
+    }
+    if (!hasExactKeys(value.transition, ["reason"])) {
+      throw malformed("resumableState.transition contains unversioned fields");
+    }
+    result.transition = {
+      reason: requiredText(
+        value.transition.reason,
+        "resumableState.transition.reason",
+      ),
+    };
+  }
+  if (value.pendingBudgetDecision !== undefined) {
+    if (!isRecord(value.pendingBudgetDecision)) {
+      throw malformed("resumableState.pendingBudgetDecision must be an object");
+    }
+    const decision = value.pendingBudgetDecision;
+    if (decision.kind === "continue") {
+      if (!hasExactKeys(decision, ["kind", "remaining"])) {
+        throw malformed(
+          "resumableState.pendingBudgetDecision contains unversioned fields",
+        );
+      }
+      result.pendingBudgetDecision = {
+        kind: "continue",
+        remaining: nonNegativeInteger(
+          decision.remaining,
+          "resumableState.pendingBudgetDecision.remaining",
+        ),
+      };
+    } else if (decision.kind === "stop") {
+      if (!hasExactKeys(decision, ["kind", "reason"])) {
+        throw malformed(
+          "resumableState.pendingBudgetDecision contains unversioned fields",
+        );
+      }
+      result.pendingBudgetDecision = {
+        kind: "stop",
+        reason: requiredText(
+          decision.reason,
+          "resumableState.pendingBudgetDecision.reason",
+        ),
+      };
+    } else {
+      throw malformed("resumableState.pendingBudgetDecision.kind is invalid");
+    }
+  }
+  return result;
+}
+
+function* prefixMessages(
+  messages: ReadonlyArray<ResponseItem>,
+  count: number,
+): Iterable<ResponseItem> {
+  for (let index = 0; index < count; index += 1) {
+    const message = messages[index];
+    if (message !== undefined) yield message;
+  }
+}
+
+function writeOptionalString(
+  writer: CanonicalSha256Writer,
+  label: string,
+  value: string | undefined,
+): void {
+  writer.writeString(`${label}-present`, String(value !== undefined));
+  if (value !== undefined) writer.writeString(label, value);
+}
+
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw malformed(`${field} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function requiredText(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw malformed(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function malformed(message: string): DurableCheckpointReadError {
+  return new DurableCheckpointReadError("checkpoint_shape_invalid", message);
+}
+
+function safeVersion(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") {
+    return JSON.stringify(value);
+  }
+  return `<${typeof value}>`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  return (
+    actual.length === sortedExpected.length &&
+    actual.every((key, index) => key === sortedExpected[index])
+  );
+}
+
+function hasOnlyKnownKeys(
+  value: Record<string, unknown>,
+  known: readonly string[],
+): boolean {
+  const allowed = new Set(known);
+  return Object.keys(value).every((key) => allowed.has(key));
+}

--- a/runtime/src/session/durable-checkpoint-reader.ts
+++ b/runtime/src/session/durable-checkpoint-reader.ts
@@ -281,6 +281,7 @@ export function computeCheckpointPrefixHashV2(
  */
 export function validateCheckpointPrefixV2(params: {
   readonly checkpoint: TurnCheckpointV2Event;
+  readonly expectedRunId: string;
   readonly messages: ReadonlyArray<ToolResultIntegrityResponseItem>;
   readonly projection: ToolPairProjection;
   readonly projectionId: string;
@@ -360,6 +361,7 @@ export function validateCheckpointPrefixV2(params: {
       projectionId: params.projectionId,
       sourceKey: params.sourceKey,
       requireResultIntegrity: true,
+      expectedRunId: params.expectedRunId,
     },
   );
   if (toolPairs.status !== "valid") return toolPairs;
@@ -453,7 +455,7 @@ function parseCheckpointBase(
       "iterationIndex",
     ),
     boundary,
-    checkpointSeq: nonNegativeInteger(payload.checkpointSeq, "checkpointSeq"),
+    checkpointSeq: positiveInteger(payload.checkpointSeq, "checkpointSeq"),
     persistedMessageCount: nonNegativeInteger(
       payload.persistedMessageCount,
       "persistedMessageCount",
@@ -695,6 +697,13 @@ function writeOptionalString(
 function nonNegativeInteger(value: unknown, field: string): number {
   if (!Number.isSafeInteger(value) || (value as number) < 0) {
     throw malformed(`${field} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw malformed(`${field} must be a positive safe integer`);
   }
   return value as number;
 }

--- a/runtime/src/session/durable-checkpoint-upgrade.ts
+++ b/runtime/src/session/durable-checkpoint-upgrade.ts
@@ -1,0 +1,552 @@
+import { createHash } from "node:crypto";
+import { computePrefixHash } from "./durable-turns.js";
+import { emptyReducedState, reduce } from "./event-log-reducer.js";
+import type { TurnCheckpointV2Event } from "./event-log.js";
+import type { ResponseItem, RolloutItem } from "./rollout-item.js";
+import {
+  DURABLE_CHECKPOINT_READ_VERSION,
+  DURABLE_ROLLOUT_SCHEMA_V2,
+  DurableCheckpointReadError,
+  computeCheckpointPrefixHashV2,
+  readTurnCheckpoint,
+  validateCheckpointPrefixV2,
+  type DurableCheckpointPrefixDeferral,
+  type DurableCheckpointPrefixFailure,
+} from "./durable-checkpoint-reader.js";
+import {
+  ToolResultCanonicalizationError,
+  constantTimeDigestEqual,
+  createToolResultIntegrity,
+  verifyToolResultIntegrity,
+  type ToolResultIntegrityDeferral,
+  type ToolResultIntegrityFailure,
+} from "./tool-result-integrity.js";
+import type {
+  ToolPairIntegrityFailure,
+  ToolPairOperationalDeferral,
+  ToolPairProjection,
+} from "./tool-pair-validator.js";
+
+const UPGRADE_PROJECTION_ID_DOMAIN = "agenc.checkpoint-upgrade-projection.v1";
+
+export interface DurableCheckpointUpgradePlan {
+  readonly sourceSchemaVersion: number;
+  readonly targetSchemaVersion: typeof DURABLE_ROLLOUT_SCHEMA_V2;
+  readonly sessionMetaPromotionRequired: boolean;
+  readonly changed: boolean;
+  readonly toolResultsSealed: number;
+  readonly checkpointsUpgraded: number;
+  readonly checkpointsValidated: number;
+  readonly upgradedItems: ReadonlyArray<RolloutItem>;
+}
+
+export interface DurableCheckpointUpgradeFailure {
+  readonly kind: "integrity_failure";
+  readonly code:
+    | "rollout_schema_unsupported"
+    | "rollout_schema_mixed"
+    | "tool_result_call_id_missing"
+    | "tool_result_integrity_invalid"
+    | "checkpoint_invalid";
+  readonly itemIndex: number | null;
+  readonly reason: string;
+  readonly cause?:
+    | ToolResultIntegrityFailure
+    | DurableCheckpointPrefixFailure
+    | ToolPairIntegrityFailure;
+}
+
+export interface DurableCheckpointUpgradeDeferral {
+  readonly kind: "operational_deferral";
+  readonly code:
+    | "tool_result_integrity_deferred"
+    | "checkpoint_validation_deferred";
+  readonly itemIndex: number | null;
+  readonly reason: string;
+  readonly cause?:
+    | ToolResultIntegrityDeferral
+    | DurableCheckpointPrefixDeferral
+    | ToolPairOperationalDeferral;
+}
+
+export type DurableCheckpointUpgradeOutcome =
+  | { readonly status: "planned"; readonly plan: DurableCheckpointUpgradePlan }
+  | { readonly status: "invalid"; readonly failure: DurableCheckpointUpgradeFailure }
+  | { readonly status: "deferred"; readonly failure: DurableCheckpointUpgradeDeferral };
+
+/**
+ * Build (but never apply) an atomic legacy-to-v2 rollout transformation.
+ * The caller owns publication in A3b. Running the planner over its own output
+ * is deterministic and yields `changed: false`.
+ */
+export function planLegacyDurableCheckpointUpgrade(params: {
+  readonly items: ReadonlyArray<RolloutItem>;
+  readonly runId: string;
+  readonly projection: ToolPairProjection;
+  readonly projectionId: string;
+  readonly sourceKey: string;
+}): DurableCheckpointUpgradeOutcome {
+  const sourceSchemaInfo = findSourceSchemaVersion(params.items);
+  if (sourceSchemaInfo.mixed) {
+    return invalid(
+      "rollout_schema_mixed",
+      null,
+      "rollout without session metadata mixes legacy and v2 checkpoints",
+    );
+  }
+  const sourceSchema = sourceSchemaInfo.version;
+  if (sourceSchema > DURABLE_ROLLOUT_SCHEMA_V2 || sourceSchema < 1) {
+    return invalid(
+      "rollout_schema_unsupported",
+      null,
+      `rollout schema ${sourceSchema} cannot be upgraded to ${DURABLE_ROLLOUT_SCHEMA_V2}`,
+    );
+  }
+
+  const transformed: RolloutItem[] = [];
+  let state = emptyReducedState();
+  let toolResultsSealed = 0;
+  let checkpointsUpgraded = 0;
+  let checkpointsValidated = 0;
+  let changed = false;
+  let sawSessionMeta = false;
+
+  for (let itemIndex = 0; itemIndex < params.items.length; itemIndex += 1) {
+    const sourceItem = params.items[itemIndex];
+    if (sourceItem === undefined) continue;
+    let item = sourceItem;
+
+    if (item.type === "session_meta") {
+      sawSessionMeta = true;
+      const schema = item.payload.rolloutSchemaVersion;
+      if (schema !== sourceSchema) {
+        return invalid(
+          "rollout_schema_mixed",
+          itemIndex,
+          `rollout metadata mixes schema ${sourceSchema} and ${schema}`,
+        );
+      }
+      if (schema === 1) {
+        item = {
+          ...item,
+          payload: {
+            ...item.payload,
+            rolloutSchemaVersion: DURABLE_ROLLOUT_SCHEMA_V2,
+          },
+        };
+        changed = true;
+      }
+    } else if (item.type === "response_item") {
+      const sealed = sealResponseItem(item.payload, params.runId, sourceSchema);
+      if (sealed.status !== "sealed") {
+        return withItemIndex(sealed, itemIndex);
+      }
+      if (sealed.changed) {
+        item = { ...item, payload: sealed.item };
+        toolResultsSealed += 1;
+        changed = true;
+      }
+    } else if (
+      item.type === "compacted" &&
+      item.payload.replacementHistory !== undefined
+    ) {
+      const replacementHistory: ResponseItem[] = [];
+      let replacementChanged = false;
+      for (const response of item.payload.replacementHistory) {
+        const sealed = sealResponseItem(response, params.runId, sourceSchema);
+        if (sealed.status !== "sealed") {
+          return withItemIndex(sealed, itemIndex);
+        }
+        replacementHistory.push(sealed.item);
+        if (sealed.changed) {
+          replacementChanged = true;
+          toolResultsSealed += 1;
+        }
+      }
+      if (replacementChanged) {
+        item = {
+          ...item,
+          payload: { ...item.payload, replacementHistory },
+        };
+        changed = true;
+      }
+    }
+
+    if (
+      item.type === "event_msg" &&
+      item.payload.msg.type === "turn_checkpoint"
+    ) {
+      let readable;
+      try {
+        readable = readTurnCheckpoint(item.payload.msg.payload);
+      } catch (error) {
+        return invalid(
+          "checkpoint_invalid",
+          itemIndex,
+          error instanceof Error ? error.message : "checkpoint is malformed",
+        );
+      }
+      if (
+        (sourceSchema === 1 && readable.version !== 1) ||
+        (sourceSchema === DURABLE_ROLLOUT_SCHEMA_V2 &&
+          readable.version !== DURABLE_CHECKPOINT_READ_VERSION)
+      ) {
+        return invalid(
+          "rollout_schema_mixed",
+          itemIndex,
+          `rollout schema ${sourceSchema} contains checkpoint version ${readable.version}`,
+        );
+      }
+
+      let checkpoint: TurnCheckpointV2Event;
+      if (readable.version === 1) {
+        if (readable.checkpoint.persistedMessageCount > state.history.length) {
+          return invalid(
+            "checkpoint_invalid",
+            itemIndex,
+            `checkpoint requires ${readable.checkpoint.persistedMessageCount} messages but only ${state.history.length} precede it`,
+          );
+        }
+        let prefixHash: string;
+        try {
+          prefixHash = computeCheckpointPrefixHashV2(
+            state.history,
+            readable.checkpoint.persistedMessageCount,
+          );
+        } catch (error) {
+          const mapped = canonicalizationOutcome(error, itemIndex);
+          if (mapped !== undefined) return mapped;
+          if (error instanceof DurableCheckpointReadError) {
+            return invalid(
+              "checkpoint_invalid",
+              itemIndex,
+              error.message,
+            );
+          }
+          throw error;
+        }
+        checkpoint = {
+          ...readable.checkpoint,
+          checkpointVersion: DURABLE_CHECKPOINT_READ_VERSION,
+          toolResultIntegrityVersion: 1,
+          prefixHash,
+        };
+        item = {
+          ...item,
+          payload: {
+            ...item.payload,
+            msg: { type: "turn_checkpoint", payload: checkpoint },
+          },
+        };
+        checkpointsUpgraded += 1;
+        changed = true;
+      } else {
+        checkpoint = readable.checkpoint;
+      }
+
+      const validation = validateCheckpointPrefixV2({
+        checkpoint,
+        messages: state.history,
+        projection: params.projection,
+        projectionId: checkpointProjectionId(params.projectionId),
+        sourceKey: params.sourceKey,
+      });
+      if (validation.status === "invalid") {
+        return invalid(
+          "checkpoint_invalid",
+          itemIndex,
+          validation.failure.reason,
+          validation.failure,
+        );
+      }
+      if (validation.status === "deferred") {
+        return {
+          status: "deferred",
+          failure: {
+            kind: "operational_deferral",
+            code: "checkpoint_validation_deferred",
+            itemIndex,
+            reason: validation.failure.reason,
+            cause: validation.failure,
+          },
+        };
+      }
+      if (readable.version === 1) {
+        const legacyPrefixHash = computePrefixHash(
+          state.history,
+          readable.checkpoint.persistedMessageCount,
+        );
+        if (
+          !constantTimeDigestEqual(
+            legacyPrefixHash,
+            readable.checkpoint.prefixHash,
+          )
+        ) {
+          return invalid(
+            "checkpoint_invalid",
+            itemIndex,
+            "legacy checkpoint prefix digest does not match its persisted history",
+          );
+        }
+      }
+      checkpointsValidated += 1;
+    }
+
+    transformed.push(item);
+    state = reduce(state, item).state;
+  }
+
+  return {
+    status: "planned",
+    plan: {
+      sourceSchemaVersion: sourceSchema,
+      targetSchemaVersion: DURABLE_ROLLOUT_SCHEMA_V2,
+      sessionMetaPromotionRequired: !sawSessionMeta,
+      changed,
+      toolResultsSealed,
+      checkpointsUpgraded,
+      checkpointsValidated,
+      upgradedItems: transformed,
+    },
+  };
+}
+
+type SealResponseOutcome =
+  | {
+      readonly status: "sealed";
+      readonly item: ResponseItem;
+      readonly changed: boolean;
+    }
+  | {
+      readonly status: "invalid";
+      readonly failure: Omit<DurableCheckpointUpgradeFailure, "itemIndex">;
+    }
+  | {
+      readonly status: "deferred";
+      readonly failure: Omit<DurableCheckpointUpgradeDeferral, "itemIndex">;
+    };
+
+function sealResponseItem(
+  item: ResponseItem,
+  runId: string,
+  sourceSchemaVersion: number,
+): SealResponseOutcome {
+  if (item.role !== "tool") {
+    if (item.toolResultIntegrity !== undefined) {
+      return {
+        status: "invalid",
+        failure: {
+          kind: "integrity_failure",
+          code: "tool_result_integrity_invalid",
+          reason: "tool-result integrity metadata is attached to a non-tool message",
+        },
+      };
+    }
+    return { status: "sealed", item, changed: false };
+  }
+  if (typeof item.toolCallId !== "string" || item.toolCallId.trim().length === 0) {
+    return {
+      status: "invalid",
+      failure: {
+        kind: "integrity_failure",
+        code: "tool_result_call_id_missing",
+        reason: "tool result cannot be upgraded without a toolCallId",
+      },
+    };
+  }
+  if (item.toolResultIntegrity !== undefined) {
+    const verified = verifyToolResultIntegrity({
+      integrity: item.toolResultIntegrity,
+      expectedRunId: runId,
+      toolCallId: item.toolCallId,
+      content: item.content,
+    });
+    if (verified.status === "invalid") {
+      return {
+        status: "invalid",
+        failure: {
+          kind: "integrity_failure",
+          code: "tool_result_integrity_invalid",
+          reason: verified.failure.reason,
+          cause: verified.failure,
+        },
+      };
+    }
+    if (verified.status === "deferred") {
+      return {
+        status: "deferred",
+        failure: {
+          kind: "operational_deferral",
+          code: "tool_result_integrity_deferred",
+          reason: verified.failure.reason,
+          cause: verified.failure,
+        },
+      };
+    }
+    return { status: "sealed", item, changed: false };
+  }
+  if (sourceSchemaVersion !== 1) {
+    return {
+      status: "invalid",
+      failure: {
+        kind: "integrity_failure",
+        code: "tool_result_integrity_invalid",
+        reason: "schema-v2 tool result is missing integrity metadata",
+      },
+    };
+  }
+  try {
+    return {
+      status: "sealed",
+      changed: true,
+      item: {
+        ...item,
+        toolResultIntegrity: createToolResultIntegrity({
+          runId,
+          toolCallId: item.toolCallId,
+          content: item.content,
+        }),
+      },
+    };
+  } catch (error) {
+    if (error instanceof ToolResultCanonicalizationError) {
+      if (error.kind === "operational_deferral") {
+        return {
+          status: "deferred",
+          failure: {
+            kind: "operational_deferral",
+            code: "tool_result_integrity_deferred",
+            reason: error.message,
+            cause: {
+              kind: "operational_deferral",
+              code: error.code as ToolResultIntegrityDeferral["code"],
+              reason: error.message,
+            },
+          },
+        };
+      }
+      return {
+        status: "invalid",
+        failure: {
+          kind: "integrity_failure",
+          code: "tool_result_integrity_invalid",
+          reason: error.message,
+          cause: {
+            kind: "integrity_failure",
+            code: error.code as ToolResultIntegrityFailure["code"],
+            reason: error.message,
+          },
+        },
+      };
+    }
+    throw error;
+  }
+}
+
+function findSourceSchemaVersion(items: ReadonlyArray<RolloutItem>): {
+  readonly version: number;
+  readonly mixed: boolean;
+} {
+  for (const item of items) {
+    if (item.type === "session_meta") {
+      return { version: item.payload.rolloutSchemaVersion, mixed: false };
+    }
+  }
+  let sawLegacy = false;
+  let sawV2 = false;
+  for (const item of items) {
+    if (
+      item.type !== "event_msg" ||
+      item.payload.msg.type !== "turn_checkpoint"
+    ) {
+      continue;
+    }
+    const payload = item.payload.msg.payload as { checkpointVersion?: unknown };
+    if (payload.checkpointVersion === DURABLE_CHECKPOINT_READ_VERSION) {
+      sawV2 = true;
+    } else {
+      sawLegacy = true;
+    }
+  }
+  return {
+    version: sawV2 && !sawLegacy ? DURABLE_ROLLOUT_SCHEMA_V2 : 1,
+    mixed: sawV2 && sawLegacy,
+  };
+}
+
+function checkpointProjectionId(
+  base: string,
+): string {
+  const hash = createHash("sha256");
+  hash.update(UPGRADE_PROJECTION_ID_DOMAIN);
+  hash.update("\0");
+  hash.update(base);
+  return `checkpoint-upgrade:${hash.digest("hex")}`;
+}
+
+function canonicalizationOutcome(
+  error: unknown,
+  itemIndex: number,
+): DurableCheckpointUpgradeOutcome | undefined {
+  if (!(error instanceof ToolResultCanonicalizationError)) return undefined;
+  if (error.kind === "operational_deferral") {
+    return {
+      status: "deferred",
+      failure: {
+        kind: "operational_deferral",
+        code: "tool_result_integrity_deferred",
+        itemIndex,
+        reason: error.message,
+        cause: {
+          kind: "operational_deferral",
+          code: error.code as ToolResultIntegrityDeferral["code"],
+          reason: error.message,
+        },
+      },
+    };
+  }
+  return invalid(
+    "tool_result_integrity_invalid",
+    itemIndex,
+    error.message,
+    {
+      kind: "integrity_failure",
+      code: error.code as ToolResultIntegrityFailure["code"],
+      reason: error.message,
+    },
+  );
+}
+
+function withItemIndex(
+  outcome: Exclude<SealResponseOutcome, { readonly status: "sealed" }>,
+  itemIndex: number,
+): DurableCheckpointUpgradeOutcome {
+  if (outcome.status === "invalid") {
+    return {
+      status: "invalid",
+      failure: { ...outcome.failure, itemIndex },
+    };
+  }
+  return {
+    status: "deferred",
+    failure: { ...outcome.failure, itemIndex },
+  };
+}
+
+function invalid(
+  code: DurableCheckpointUpgradeFailure["code"],
+  itemIndex: number | null,
+  reason: string,
+  cause?: DurableCheckpointUpgradeFailure["cause"],
+): { readonly status: "invalid"; readonly failure: DurableCheckpointUpgradeFailure } {
+  return {
+    status: "invalid",
+    failure: {
+      kind: "integrity_failure",
+      code,
+      itemIndex,
+      reason,
+      ...(cause === undefined ? {} : { cause }),
+    },
+  };
+}

--- a/runtime/src/session/durable-checkpoint-upgrade.ts
+++ b/runtime/src/session/durable-checkpoint-upgrade.ts
@@ -2,7 +2,10 @@ import { createHash } from "node:crypto";
 import { computePrefixHash } from "./durable-turns.js";
 import { emptyReducedState, reduce } from "./event-log-reducer.js";
 import type { TurnCheckpointV2Event } from "./event-log.js";
-import type { ResponseItem, RolloutItem } from "./rollout-item.js";
+import type {
+  RolloutItem,
+  ToolResultIntegrityResponseItem,
+} from "./rollout-item.js";
 import {
   DURABLE_CHECKPOINT_READ_VERSION,
   DURABLE_ROLLOUT_SCHEMA_V2,
@@ -59,8 +62,7 @@ export interface DurableCheckpointUpgradeFailure {
 export interface DurableCheckpointUpgradeDeferral {
   readonly kind: "operational_deferral";
   readonly code:
-    | "tool_result_integrity_deferred"
-    | "checkpoint_validation_deferred";
+    "tool_result_integrity_deferred" | "checkpoint_validation_deferred";
   readonly itemIndex: number | null;
   readonly reason: string;
   readonly cause?:
@@ -71,8 +73,14 @@ export interface DurableCheckpointUpgradeDeferral {
 
 export type DurableCheckpointUpgradeOutcome =
   | { readonly status: "planned"; readonly plan: DurableCheckpointUpgradePlan }
-  | { readonly status: "invalid"; readonly failure: DurableCheckpointUpgradeFailure }
-  | { readonly status: "deferred"; readonly failure: DurableCheckpointUpgradeDeferral };
+  | {
+      readonly status: "invalid";
+      readonly failure: DurableCheckpointUpgradeFailure;
+    }
+  | {
+      readonly status: "deferred";
+      readonly failure: DurableCheckpointUpgradeDeferral;
+    };
 
 /**
  * Build (but never apply) an atomic legacy-to-v2 rollout transformation.
@@ -150,7 +158,7 @@ export function planLegacyDurableCheckpointUpgrade(params: {
       item.type === "compacted" &&
       item.payload.replacementHistory !== undefined
     ) {
-      const replacementHistory: ResponseItem[] = [];
+      const replacementHistory: ToolResultIntegrityResponseItem[] = [];
       let replacementChanged = false;
       for (const response of item.payload.replacementHistory) {
         const sealed = sealResponseItem(response, params.runId, sourceSchema);
@@ -217,11 +225,7 @@ export function planLegacyDurableCheckpointUpgrade(params: {
           const mapped = canonicalizationOutcome(error, itemIndex);
           if (mapped !== undefined) return mapped;
           if (error instanceof DurableCheckpointReadError) {
-            return invalid(
-              "checkpoint_invalid",
-              itemIndex,
-              error.message,
-            );
+            return invalid("checkpoint_invalid", itemIndex, error.message);
           }
           throw error;
         }
@@ -314,7 +318,7 @@ export function planLegacyDurableCheckpointUpgrade(params: {
 type SealResponseOutcome =
   | {
       readonly status: "sealed";
-      readonly item: ResponseItem;
+      readonly item: ToolResultIntegrityResponseItem;
       readonly changed: boolean;
     }
   | {
@@ -327,7 +331,7 @@ type SealResponseOutcome =
     };
 
 function sealResponseItem(
-  item: ResponseItem,
+  item: ToolResultIntegrityResponseItem,
   runId: string,
   sourceSchemaVersion: number,
 ): SealResponseOutcome {
@@ -338,13 +342,17 @@ function sealResponseItem(
         failure: {
           kind: "integrity_failure",
           code: "tool_result_integrity_invalid",
-          reason: "tool-result integrity metadata is attached to a non-tool message",
+          reason:
+            "tool-result integrity metadata is attached to a non-tool message",
         },
       };
     }
     return { status: "sealed", item, changed: false };
   }
-  if (typeof item.toolCallId !== "string" || item.toolCallId.trim().length === 0) {
+  if (
+    typeof item.toolCallId !== "string" ||
+    item.toolCallId.trim().length === 0
+  ) {
     return {
       status: "invalid",
       failure: {
@@ -474,9 +482,7 @@ function findSourceSchemaVersion(items: ReadonlyArray<RolloutItem>): {
   };
 }
 
-function checkpointProjectionId(
-  base: string,
-): string {
+function checkpointProjectionId(base: string): string {
   const hash = createHash("sha256");
   hash.update(UPGRADE_PROJECTION_ID_DOMAIN);
   hash.update("\0");
@@ -505,16 +511,11 @@ function canonicalizationOutcome(
       },
     };
   }
-  return invalid(
-    "tool_result_integrity_invalid",
-    itemIndex,
-    error.message,
-    {
-      kind: "integrity_failure",
-      code: error.code as ToolResultIntegrityFailure["code"],
-      reason: error.message,
-    },
-  );
+  return invalid("tool_result_integrity_invalid", itemIndex, error.message, {
+    kind: "integrity_failure",
+    code: error.code as ToolResultIntegrityFailure["code"],
+    reason: error.message,
+  });
 }
 
 function withItemIndex(
@@ -538,7 +539,10 @@ function invalid(
   itemIndex: number | null,
   reason: string,
   cause?: DurableCheckpointUpgradeFailure["cause"],
-): { readonly status: "invalid"; readonly failure: DurableCheckpointUpgradeFailure } {
+): {
+  readonly status: "invalid";
+  readonly failure: DurableCheckpointUpgradeFailure;
+} {
   return {
     status: "invalid",
     failure: {

--- a/runtime/src/session/durable-checkpoint-upgrade.ts
+++ b/runtime/src/session/durable-checkpoint-upgrade.ts
@@ -36,7 +36,12 @@ const UPGRADE_PROJECTION_ID_DOMAIN = "agenc.checkpoint-upgrade-projection.v1";
 const V2_CHECKPOINT_PREFIX_PASSES = 3;
 // Legacy promotion additionally computes the new and legacy prefix digests.
 const LEGACY_CHECKPOINT_PREFIX_PASSES = 5;
-export const MAX_CHECKPOINT_UPGRADE_PREFIX_WORK =
+// Canonical rollback reduction can scan the history, scan backward across
+// contextual pre-turn rows, and copy the retained prefix. Reserve all three
+// possible passes before invoking it so adversarial rollback streams cannot
+// escape the aggregate history-derivation work ceiling.
+const ROLLBACK_HISTORY_PASSES = 3;
+export const MAX_CHECKPOINT_UPGRADE_HISTORY_WORK =
   MAX_CHECKPOINT_PREFIX_MESSAGES * LEGACY_CHECKPOINT_PREFIX_PASSES;
 
 export interface DurableCheckpointUpgradePlan {
@@ -55,6 +60,7 @@ export interface DurableCheckpointUpgradeFailure {
   readonly code:
     | "rollout_schema_unsupported"
     | "rollout_schema_mixed"
+    | "rollback_invalid"
     | "tool_result_call_id_missing"
     | "tool_result_integrity_invalid"
     | "checkpoint_invalid";
@@ -71,7 +77,7 @@ export interface DurableCheckpointUpgradeDeferral {
   readonly code:
     | "tool_result_integrity_deferred"
     | "checkpoint_validation_deferred"
-    | "checkpoint_prefix_work_limit";
+    | "history_derivation_work_limit";
   readonly itemIndex: number | null;
   readonly reason: string;
   readonly cause?:
@@ -102,10 +108,10 @@ export function planLegacyDurableCheckpointUpgrade(params: {
   readonly projection: ToolPairProjection;
   readonly projectionId: string;
   readonly sourceKey: string;
-  readonly maxCheckpointPrefixWork?: number;
+  readonly maxHistoryDerivationWork?: number;
 }): DurableCheckpointUpgradeOutcome {
-  const maxCheckpointPrefixWork = positiveWorkLimit(
-    params.maxCheckpointPrefixWork ?? MAX_CHECKPOINT_UPGRADE_PREFIX_WORK,
+  const maxHistoryDerivationWork = positiveWorkLimit(
+    params.maxHistoryDerivationWork ?? MAX_CHECKPOINT_UPGRADE_HISTORY_WORK,
   );
   const sourceSchemaInfo = findSourceSchemaVersion(params.items);
   if (sourceSchemaInfo.mixed) {
@@ -126,7 +132,7 @@ export function planLegacyDurableCheckpointUpgrade(params: {
 
   const transformed: RolloutItem[] = [];
   let history: ToolResultIntegrityResponseItem[] = [];
-  let checkpointPrefixWork = 0;
+  let historyDerivationWork = 0;
   let toolResultsSealed = 0;
   let checkpointsUpgraded = 0;
   let checkpointsValidated = 0;
@@ -232,24 +238,24 @@ export function planLegacyDurableCheckpointUpgrade(params: {
         readable.version === 1
           ? LEGACY_CHECKPOINT_PREFIX_PASSES
           : V2_CHECKPOINT_PREFIX_PASSES;
-      const reservedWork = reserveCheckpointPrefixWork(
-        checkpointPrefixWork,
+      const reservedWork = reserveHistoryDerivationWork(
+        historyDerivationWork,
         persistedMessageCount,
         prefixPasses,
-        maxCheckpointPrefixWork,
+        maxHistoryDerivationWork,
       );
       if (reservedWork === undefined) {
         return {
           status: "deferred",
           failure: {
             kind: "operational_deferral",
-            code: "checkpoint_prefix_work_limit",
+            code: "history_derivation_work_limit",
             itemIndex,
-            reason: `checkpoint validation would exceed the aggregate prefix-work limit of ${maxCheckpointPrefixWork} message visits`,
+            reason: `checkpoint validation would exceed the aggregate history-derivation work limit of ${maxHistoryDerivationWork} message visits`,
           },
         };
       }
-      checkpointPrefixWork = reservedWork;
+      historyDerivationWork = reservedWork;
 
       let checkpoint: TurnCheckpointV2Event;
       if (readable.version === 1) {
@@ -336,7 +342,16 @@ export function planLegacyDurableCheckpointUpgrade(params: {
     }
 
     transformed.push(item);
-    history = updateUpgradeHistory(history, item);
+    const historyUpdate = updateUpgradeHistory({
+      history,
+      item,
+      itemIndex,
+      historyDerivationWork,
+      maxHistoryDerivationWork,
+    });
+    if (historyUpdate.status !== "updated") return historyUpdate;
+    history = historyUpdate.history;
+    historyDerivationWork = historyUpdate.historyDerivationWork;
   }
 
   return {
@@ -354,48 +369,113 @@ export function planLegacyDurableCheckpointUpgrade(params: {
   };
 }
 
-function updateUpgradeHistory(
-  history: ToolResultIntegrityResponseItem[],
-  item: RolloutItem,
-): ToolResultIntegrityResponseItem[] {
+type UpgradeHistoryOutcome =
+  | {
+      readonly status: "updated";
+      readonly history: ToolResultIntegrityResponseItem[];
+      readonly historyDerivationWork: number;
+    }
+  | {
+      readonly status: "invalid";
+      readonly failure: DurableCheckpointUpgradeFailure;
+    }
+  | {
+      readonly status: "deferred";
+      readonly failure: DurableCheckpointUpgradeDeferral;
+    };
+
+function updateUpgradeHistory(params: {
+  readonly history: ToolResultIntegrityResponseItem[];
+  readonly item: RolloutItem;
+  readonly itemIndex: number;
+  readonly historyDerivationWork: number;
+  readonly maxHistoryDerivationWork: number;
+}): UpgradeHistoryOutcome {
+  const { history, item } = params;
   if (item.type === "response_item") {
     history.push(item.payload);
-    return history;
+    return updatedHistory(history, params.historyDerivationWork);
   }
   if (
     item.type === "compacted" &&
     item.payload.replacementHistory !== undefined
   ) {
-    return Array.from(item.payload.replacementHistory);
+    return updatedHistory(
+      Array.from(item.payload.replacementHistory),
+      params.historyDerivationWork,
+    );
   }
   if (
     item.type === "event_msg" &&
     item.payload.msg.type === "thread_rolled_back"
   ) {
+    const numTurns = validRollbackTurnCount(item.payload.msg.payload);
+    if (numTurns === undefined) {
+      return invalid(
+        "rollback_invalid",
+        params.itemIndex,
+        "thread_rolled_back numTurns must be a non-negative safe integer",
+      );
+    }
+    if (numTurns === 0 || history.length === 0) {
+      return updatedHistory(history, params.historyDerivationWork);
+    }
+    const reservedWork = reserveHistoryDerivationWork(
+      params.historyDerivationWork,
+      history.length,
+      ROLLBACK_HISTORY_PASSES,
+      params.maxHistoryDerivationWork,
+    );
+    if (reservedWork === undefined) {
+      return {
+        status: "deferred",
+        failure: {
+          kind: "operational_deferral",
+          code: "history_derivation_work_limit",
+          itemIndex: params.itemIndex,
+          reason: `rollback history derivation would exceed the aggregate history-derivation work limit of ${params.maxHistoryDerivationWork} message visits`,
+        },
+      };
+    }
     // Rollback is the only event variant that mutates replay history. Keep its
     // canonical trimming semantics without running the immutable reducer for
-    // every response item (the former quadratic path).
+    // every response item. The complete worst-case visit/copy cost was
+    // reserved above before the reducer can allocate or traverse the history.
     const state = emptyReducedState();
     state.history = history;
-    return reduce(state, item).state.history;
+    return updatedHistory(reduce(state, item).state.history, reservedWork);
   }
-  return history;
+  return updatedHistory(history, params.historyDerivationWork);
+}
+
+function validRollbackTurnCount(payload: unknown): number | undefined {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const numTurns = (payload as { readonly numTurns?: unknown }).numTurns;
+  if (typeof numTurns !== "number") return undefined;
+  return Number.isSafeInteger(numTurns) && numTurns >= 0 ? numTurns : undefined;
+}
+
+function updatedHistory(
+  history: ToolResultIntegrityResponseItem[],
+  historyDerivationWork: number,
+): UpgradeHistoryOutcome {
+  return { status: "updated", history, historyDerivationWork };
 }
 
 function positiveWorkLimit(value: number): number {
   if (
     !Number.isSafeInteger(value) ||
     value <= 0 ||
-    value > MAX_CHECKPOINT_UPGRADE_PREFIX_WORK
+    value > MAX_CHECKPOINT_UPGRADE_HISTORY_WORK
   ) {
     throw new Error(
-      `maxCheckpointPrefixWork must be a positive safe integer no greater than ${MAX_CHECKPOINT_UPGRADE_PREFIX_WORK}`,
+      `maxHistoryDerivationWork must be a positive safe integer no greater than ${MAX_CHECKPOINT_UPGRADE_HISTORY_WORK}`,
     );
   }
   return value;
 }
 
-function reserveCheckpointPrefixWork(
+function reserveHistoryDerivationWork(
   used: number,
   messageCount: number,
   passCount: number,

--- a/runtime/src/session/durable-checkpoint-upgrade.ts
+++ b/runtime/src/session/durable-checkpoint-upgrade.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { computePrefixHash } from "./durable-turns.js";
+import { emptyReducedState, reduce } from "./event-log-reducer.js";
 import type { TurnCheckpointV2Event } from "./event-log.js";
 import type {
   RolloutItem,
@@ -366,6 +367,17 @@ function updateUpgradeHistory(
     item.payload.replacementHistory !== undefined
   ) {
     return Array.from(item.payload.replacementHistory);
+  }
+  if (
+    item.type === "event_msg" &&
+    item.payload.msg.type === "thread_rolled_back"
+  ) {
+    // Rollback is the only event variant that mutates replay history. Keep its
+    // canonical trimming semantics without running the immutable reducer for
+    // every response item (the former quadratic path).
+    const state = emptyReducedState();
+    state.history = history;
+    return reduce(state, item).state.history;
   }
   return history;
 }

--- a/runtime/src/session/durable-checkpoint-upgrade.ts
+++ b/runtime/src/session/durable-checkpoint-upgrade.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import { computePrefixHash } from "./durable-turns.js";
-import { emptyReducedState, reduce } from "./event-log-reducer.js";
 import type { TurnCheckpointV2Event } from "./event-log.js";
 import type {
   RolloutItem,
@@ -10,6 +9,7 @@ import {
   DURABLE_CHECKPOINT_READ_VERSION,
   DURABLE_ROLLOUT_SCHEMA_V2,
   DurableCheckpointReadError,
+  MAX_CHECKPOINT_PREFIX_MESSAGES,
   computeCheckpointPrefixHashV2,
   readTurnCheckpoint,
   validateCheckpointPrefixV2,
@@ -31,6 +31,12 @@ import type {
 } from "./tool-pair-validator.js";
 
 const UPGRADE_PROJECTION_ID_DOMAIN = "agenc.checkpoint-upgrade-projection.v1";
+// V2 validation visits the prefix for shape, tool-pair, and digest checks.
+const V2_CHECKPOINT_PREFIX_PASSES = 3;
+// Legacy promotion additionally computes the new and legacy prefix digests.
+const LEGACY_CHECKPOINT_PREFIX_PASSES = 5;
+export const MAX_CHECKPOINT_UPGRADE_PREFIX_WORK =
+  MAX_CHECKPOINT_PREFIX_MESSAGES * LEGACY_CHECKPOINT_PREFIX_PASSES;
 
 export interface DurableCheckpointUpgradePlan {
   readonly sourceSchemaVersion: number;
@@ -62,7 +68,9 @@ export interface DurableCheckpointUpgradeFailure {
 export interface DurableCheckpointUpgradeDeferral {
   readonly kind: "operational_deferral";
   readonly code:
-    "tool_result_integrity_deferred" | "checkpoint_validation_deferred";
+    | "tool_result_integrity_deferred"
+    | "checkpoint_validation_deferred"
+    | "checkpoint_prefix_work_limit";
   readonly itemIndex: number | null;
   readonly reason: string;
   readonly cause?:
@@ -93,7 +101,11 @@ export function planLegacyDurableCheckpointUpgrade(params: {
   readonly projection: ToolPairProjection;
   readonly projectionId: string;
   readonly sourceKey: string;
+  readonly maxCheckpointPrefixWork?: number;
 }): DurableCheckpointUpgradeOutcome {
+  const maxCheckpointPrefixWork = positiveWorkLimit(
+    params.maxCheckpointPrefixWork ?? MAX_CHECKPOINT_UPGRADE_PREFIX_WORK,
+  );
   const sourceSchemaInfo = findSourceSchemaVersion(params.items);
   if (sourceSchemaInfo.mixed) {
     return invalid(
@@ -112,7 +124,8 @@ export function planLegacyDurableCheckpointUpgrade(params: {
   }
 
   const transformed: RolloutItem[] = [];
-  let state = emptyReducedState();
+  let history: ToolResultIntegrityResponseItem[] = [];
+  let checkpointPrefixWork = 0;
   let toolResultsSealed = 0;
   let checkpointsUpgraded = 0;
   let checkpointsValidated = 0;
@@ -206,20 +219,44 @@ export function planLegacyDurableCheckpointUpgrade(params: {
         );
       }
 
+      const persistedMessageCount = readable.checkpoint.persistedMessageCount;
+      if (persistedMessageCount > history.length) {
+        return invalid(
+          "checkpoint_invalid",
+          itemIndex,
+          `checkpoint requires ${persistedMessageCount} messages but only ${history.length} precede it`,
+        );
+      }
+      const prefixPasses =
+        readable.version === 1
+          ? LEGACY_CHECKPOINT_PREFIX_PASSES
+          : V2_CHECKPOINT_PREFIX_PASSES;
+      const reservedWork = reserveCheckpointPrefixWork(
+        checkpointPrefixWork,
+        persistedMessageCount,
+        prefixPasses,
+        maxCheckpointPrefixWork,
+      );
+      if (reservedWork === undefined) {
+        return {
+          status: "deferred",
+          failure: {
+            kind: "operational_deferral",
+            code: "checkpoint_prefix_work_limit",
+            itemIndex,
+            reason: `checkpoint validation would exceed the aggregate prefix-work limit of ${maxCheckpointPrefixWork} message visits`,
+          },
+        };
+      }
+      checkpointPrefixWork = reservedWork;
+
       let checkpoint: TurnCheckpointV2Event;
       if (readable.version === 1) {
-        if (readable.checkpoint.persistedMessageCount > state.history.length) {
-          return invalid(
-            "checkpoint_invalid",
-            itemIndex,
-            `checkpoint requires ${readable.checkpoint.persistedMessageCount} messages but only ${state.history.length} precede it`,
-          );
-        }
         let prefixHash: string;
         try {
           prefixHash = computeCheckpointPrefixHashV2(
-            state.history,
-            readable.checkpoint.persistedMessageCount,
+            history,
+            persistedMessageCount,
           );
         } catch (error) {
           const mapped = canonicalizationOutcome(error, itemIndex);
@@ -250,7 +287,8 @@ export function planLegacyDurableCheckpointUpgrade(params: {
 
       const validation = validateCheckpointPrefixV2({
         checkpoint,
-        messages: state.history,
+        expectedRunId: params.runId,
+        messages: history,
         projection: params.projection,
         projectionId: checkpointProjectionId(params.projectionId),
         sourceKey: params.sourceKey,
@@ -277,8 +315,8 @@ export function planLegacyDurableCheckpointUpgrade(params: {
       }
       if (readable.version === 1) {
         const legacyPrefixHash = computePrefixHash(
-          state.history,
-          readable.checkpoint.persistedMessageCount,
+          history,
+          persistedMessageCount,
         );
         if (
           !constantTimeDigestEqual(
@@ -297,7 +335,7 @@ export function planLegacyDurableCheckpointUpgrade(params: {
     }
 
     transformed.push(item);
-    state = reduce(state, item).state;
+    history = updateUpgradeHistory(history, item);
   }
 
   return {
@@ -313,6 +351,47 @@ export function planLegacyDurableCheckpointUpgrade(params: {
       upgradedItems: transformed,
     },
   };
+}
+
+function updateUpgradeHistory(
+  history: ToolResultIntegrityResponseItem[],
+  item: RolloutItem,
+): ToolResultIntegrityResponseItem[] {
+  if (item.type === "response_item") {
+    history.push(item.payload);
+    return history;
+  }
+  if (
+    item.type === "compacted" &&
+    item.payload.replacementHistory !== undefined
+  ) {
+    return Array.from(item.payload.replacementHistory);
+  }
+  return history;
+}
+
+function positiveWorkLimit(value: number): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_CHECKPOINT_UPGRADE_PREFIX_WORK
+  ) {
+    throw new Error(
+      `maxCheckpointPrefixWork must be a positive safe integer no greater than ${MAX_CHECKPOINT_UPGRADE_PREFIX_WORK}`,
+    );
+  }
+  return value;
+}
+
+function reserveCheckpointPrefixWork(
+  used: number,
+  messageCount: number,
+  passCount: number,
+  limit: number,
+): number | undefined {
+  const remaining = limit - used;
+  if (messageCount > Math.floor(remaining / passCount)) return undefined;
+  return used + messageCount * passCount;
 }
 
 type SealResponseOutcome =

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -199,7 +199,7 @@ export interface TurnAbortedEvent {
  * DERIVED budget, never a raw turn-start clock — restoring a stale clock
  * would silently corrupt budget accounting on resume.
  */
-export interface TurnCheckpointEvent {
+interface TurnCheckpointBase {
   readonly turnId: string;
   /** Monotonic per-turn iteration index this checkpoint closes. */
   readonly iterationIndex: number;
@@ -218,6 +218,24 @@ export interface TurnCheckpointEvent {
   /** The TurnState subset that is lost today and must survive a crash. */
   readonly resumableState: TurnCheckpointSliceLine;
 }
+
+/** Existing checkpoint shape. A missing discriminator is legacy version 1. */
+export interface TurnCheckpointV1Event extends TurnCheckpointBase {
+  readonly checkpointVersion?: 1;
+}
+
+/**
+ * A3 checkpoint shape whose prefix hash authenticates every persisted tool
+ * result body through `ResponseItem.toolResultIntegrity`.
+ */
+export interface TurnCheckpointV2Event extends TurnCheckpointBase {
+  readonly checkpointVersion: 2;
+  readonly toolResultIntegrityVersion: 1;
+}
+
+export type TurnCheckpointEvent =
+  | TurnCheckpointV1Event
+  | TurnCheckpointV2Event;
 
 /**
  * Serialized, JSON-safe projection of the resumable `TurnState` counters.

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -199,7 +199,7 @@ export interface TurnAbortedEvent {
  * DERIVED budget, never a raw turn-start clock — restoring a stale clock
  * would silently corrupt budget accounting on resume.
  */
-interface TurnCheckpointBase {
+export interface TurnCheckpointEvent {
   readonly turnId: string;
   /** Monotonic per-turn iteration index this checkpoint closes. */
   readonly iterationIndex: number;
@@ -220,7 +220,7 @@ interface TurnCheckpointBase {
 }
 
 /** Existing checkpoint shape. A missing discriminator is legacy version 1. */
-export interface TurnCheckpointV1Event extends TurnCheckpointBase {
+export interface TurnCheckpointV1Event extends TurnCheckpointEvent {
   readonly checkpointVersion?: 1;
 }
 
@@ -228,14 +228,10 @@ export interface TurnCheckpointV1Event extends TurnCheckpointBase {
  * A3 checkpoint shape whose prefix hash authenticates every persisted tool
  * result body through `ResponseItem.toolResultIntegrity`.
  */
-export interface TurnCheckpointV2Event extends TurnCheckpointBase {
+export interface TurnCheckpointV2Event extends TurnCheckpointEvent {
   readonly checkpointVersion: 2;
   readonly toolResultIntegrityVersion: 1;
 }
-
-export type TurnCheckpointEvent =
-  | TurnCheckpointV1Event
-  | TurnCheckpointV2Event;
 
 /**
  * Serialized, JSON-safe projection of the resumable `TurnState` counters.

--- a/runtime/src/session/rollout-item.ts
+++ b/runtime/src/session/rollout-item.ts
@@ -16,6 +16,7 @@
 
 import type { Event, EventMsg, SessionMetaLine } from "./event-log.js";
 import type { SessionAgentTask } from "./agent-task-lifecycle.js";
+import type { ToolResultIntegrity } from "./tool-result-integrity.js";
 import { redactSecretsInValue } from "../secrets/index.js";
 
 // ─────────────────────────────────────────────────────────────────────
@@ -39,6 +40,8 @@ export interface ResponseItem {
   }>;
   readonly toolCallId?: string;
   readonly toolName?: string;
+  /** A3 checkpoint-v2 metadata; dormant until the A3b writer cutover. */
+  readonly toolResultIntegrity?: ToolResultIntegrity;
   readonly id?: string;
   readonly endTurn?: boolean;
   readonly phase?: string;

--- a/runtime/src/session/rollout-item.ts
+++ b/runtime/src/session/rollout-item.ts
@@ -32,7 +32,13 @@ export interface SessionStateUpdate {
  *  message the model sent/received lives here. */
 export interface ResponseItem {
   readonly role: "system" | "developer" | "user" | "assistant" | "tool";
-  readonly content: string | ReadonlyArray<{ readonly type: string; readonly text?: string; readonly [k: string]: unknown }>;
+  readonly content:
+    | string
+    | ReadonlyArray<{
+        readonly type: string;
+        readonly text?: string;
+        readonly [k: string]: unknown;
+      }>;
   readonly toolCalls?: ReadonlyArray<{
     readonly id: string;
     readonly name: string;
@@ -40,11 +46,18 @@ export interface ResponseItem {
   }>;
   readonly toolCallId?: string;
   readonly toolName?: string;
-  /** A3 checkpoint-v2 metadata; dormant until the A3b writer cutover. */
-  readonly toolResultIntegrity?: ToolResultIntegrity;
   readonly id?: string;
   readonly endTurn?: boolean;
   readonly phase?: string;
+}
+
+/**
+ * Checkpoint-v2 view of a response item. Keeping the dormant integrity field
+ * out of the v1 `RolloutItem` contract lets the strict recovery reader retain
+ * its exact legacy key witness until the writer cutover changes that schema.
+ */
+export interface ToolResultIntegrityResponseItem extends ResponseItem {
+  readonly toolResultIntegrity?: ToolResultIntegrity;
 }
 
 /** agenc runtime `CompactedItem` — when the conversation was compacted, this
@@ -186,7 +199,10 @@ export function parseRolloutLine(line: string): RolloutItem | null {
   if (parsed.type === "event_msg" && parsed.payload?.msg) {
     const inner = parsed.payload.msg as { type?: string };
     if (inner?.type && ROLLOUT_LEGACY_TYPE_ALIASES[inner.type]) {
-      const newInner = { ...inner, type: ROLLOUT_LEGACY_TYPE_ALIASES[inner.type] };
+      const newInner = {
+        ...inner,
+        type: ROLLOUT_LEGACY_TYPE_ALIASES[inner.type],
+      };
       return {
         type: "event_msg",
         payload: {

--- a/runtime/src/session/tool-pair-validator.ts
+++ b/runtime/src/session/tool-pair-validator.ts
@@ -50,8 +50,14 @@ export interface ToolPairProjectionSummary {
  */
 export interface ToolPairProjection {
   runAtomically<T>(operation: () => T): T;
-  reset(params: { readonly projectionId: string; readonly sourceKey: string }): void;
-  find(projectionId: string, callId: string): ToolPairProjectionRecord | undefined;
+  reset(params: {
+    readonly projectionId: string;
+    readonly sourceKey: string;
+  }): void;
+  find(
+    projectionId: string,
+    callId: string,
+  ): ToolPairProjectionRecord | undefined;
   insertCall(projectionId: string, record: ToolPairProjectionRecord): boolean;
   resolveCall(params: {
     readonly projectionId: string;
@@ -121,15 +127,26 @@ export type ToolPairValidationOutcome =
       readonly summary: ToolPairProjectionSummary;
     };
 
-export interface ToolPairValidationOptions {
+interface ToolPairValidationLimits {
   readonly projectionId: string;
   readonly sourceKey: string;
-  readonly requireResultIntegrity?: boolean;
   readonly maxToolCalls?: number;
   readonly maxOpenToolCalls?: number;
   readonly maxToolCallIdBytes?: number;
   readonly maxIndexBytes?: number;
 }
+
+export type ToolPairValidationOptions = ToolPairValidationLimits &
+  (
+    | {
+        readonly requireResultIntegrity: true;
+        readonly expectedRunId: string;
+      }
+    | {
+        readonly requireResultIntegrity?: false;
+        readonly expectedRunId?: never;
+      }
+  );
 
 interface OpenToolCall {
   readonly toolName: string;
@@ -170,8 +187,14 @@ export function validateToolPairSequence(
       });
       const finishFailure = (
         outcome:
-          | { readonly status: "invalid"; readonly failure: ToolPairIntegrityFailure }
-          | { readonly status: "deferred"; readonly failure: ToolPairOperationalDeferral },
+          | {
+              readonly status: "invalid";
+              readonly failure: ToolPairIntegrityFailure;
+            }
+          | {
+              readonly status: "deferred";
+              readonly failure: ToolPairOperationalDeferral;
+            },
       ): ToolPairValidationOutcome => {
         latestSummary = summary();
         projection.fail(options.projectionId, latestSummary, outcome.failure);
@@ -212,7 +235,10 @@ export function validateToolPairSequence(
                 ),
               );
             }
-            if (typeof call.name !== "string" || call.name.trim().length === 0) {
+            if (
+              typeof call.name !== "string" ||
+              call.name.trim().length === 0
+            ) {
               return finishFailure(
                 invalid(
                   "assistant_tool_call_name_missing",
@@ -315,7 +341,10 @@ export function validateToolPairSequence(
           }
           const openCall = openCalls.get(message.toolCallId);
           if (openCall === undefined) {
-            const exact = projection.find(options.projectionId, message.toolCallId);
+            const exact = projection.find(
+              options.projectionId,
+              message.toolCallId,
+            );
             if (exact?.resultIndex !== undefined) {
               return finishFailure(
                 invalid(
@@ -354,6 +383,7 @@ export function validateToolPairSequence(
           if (options.requireResultIntegrity === true) {
             const verified = verifyToolResultIntegrity({
               integrity: message.toolResultIntegrity,
+              expectedRunId: options.expectedRunId,
               toolCallId: message.toolCallId,
               content: message.content,
             });
@@ -509,7 +539,9 @@ function emptySummary(): ToolPairProjectionSummary {
   };
 }
 
-function summarizeOpenIds(openCalls: ReadonlyMap<string, OpenToolCall>): string {
+function summarizeOpenIds(
+  openCalls: ReadonlyMap<string, OpenToolCall>,
+): string {
   const values: string[] = [];
   for (const callId of openCalls.keys()) {
     values.push(formatIdentityForLog(callId));

--- a/runtime/src/session/tool-pair-validator.ts
+++ b/runtime/src/session/tool-pair-validator.ts
@@ -1,0 +1,554 @@
+import {
+  MAX_TOOL_CALL_ID_UTF8_BYTES,
+  formatIdentityForLog,
+  verifyToolResultIntegrity,
+  type ToolResultIntegrity,
+  type ToolResultIntegrityDeferral,
+  type ToolResultIntegrityFailure,
+} from "./tool-result-integrity.js";
+
+export { MAX_TOOL_CALL_ID_UTF8_BYTES } from "./tool-result-integrity.js";
+
+export const MAX_TOOL_CALL_IDS_PER_RUN = 1_000_000;
+export const MAX_OPEN_TOOL_CALLS_PER_RUN = 4_096;
+export const MAX_TOOL_CALL_ID_INDEX_BYTES_PER_RUN = 268_435_456;
+export const MAX_TOOL_PAIR_IDS_IN_ERROR = 8;
+
+export interface ToolPairMessage {
+  readonly role: string;
+  readonly content: unknown;
+  readonly toolCalls?: ReadonlyArray<{
+    readonly id?: string;
+    readonly name?: string;
+  }>;
+  readonly toolCallId?: string;
+  readonly toolName?: string;
+  readonly toolResultIntegrity?: unknown;
+}
+
+export interface ToolPairProjectionRecord {
+  readonly callId: string;
+  readonly toolName: string;
+  readonly assistantIndex: number;
+  readonly resultIndex?: number;
+  readonly resultId?: string;
+  readonly originalResultDigest?: string;
+}
+
+export interface ToolPairProjectionSummary {
+  readonly callCount: number;
+  readonly resolvedCount: number;
+  readonly openCallCount: number;
+  readonly maximumOpenCallCount: number;
+  readonly logicalIndexBytes: number;
+}
+
+/**
+ * Exact index used by the ordered scanner. The production implementation is
+ * SQLite-backed; this interface keeps the session-layer state machine free of
+ * a state-store dependency and makes operational failure semantics explicit.
+ */
+export interface ToolPairProjection {
+  runAtomically<T>(operation: () => T): T;
+  reset(params: { readonly projectionId: string; readonly sourceKey: string }): void;
+  find(projectionId: string, callId: string): ToolPairProjectionRecord | undefined;
+  insertCall(projectionId: string, record: ToolPairProjectionRecord): boolean;
+  resolveCall(params: {
+    readonly projectionId: string;
+    readonly callId: string;
+    readonly resultIndex: number;
+    readonly resultId?: string;
+    readonly originalResultDigest?: string;
+  }): "resolved" | "already_resolved" | "missing";
+  complete(projectionId: string, summary: ToolPairProjectionSummary): void;
+  fail(
+    projectionId: string,
+    summary: ToolPairProjectionSummary,
+    failure: ToolPairIntegrityFailure | ToolPairOperationalDeferral,
+  ): void;
+}
+
+export type ToolPairIntegrityFailureCode =
+  | "assistant_tool_calls_before_results"
+  | "assistant_tool_call_id_missing"
+  | "assistant_tool_call_name_missing"
+  | "assistant_tool_call_id_duplicate"
+  | "tool_result_id_missing"
+  | "tool_result_without_call"
+  | "tool_result_unknown_id"
+  | "tool_result_duplicate"
+  | "tool_result_name_mismatch"
+  | "tool_result_missing"
+  | "tool_result_integrity_invalid";
+
+export type ToolPairOperationalDeferralCode =
+  | "tool_call_id_limit"
+  | "tool_pair_call_limit"
+  | "tool_pair_open_call_limit"
+  | "tool_pair_index_byte_limit"
+  | "tool_result_integrity_deferred"
+  | "tool_pair_projection_unavailable";
+
+export interface ToolPairIntegrityFailure {
+  readonly kind: "integrity_failure";
+  readonly code: ToolPairIntegrityFailureCode;
+  readonly index: number | null;
+  readonly reason: string;
+  readonly cause?: ToolResultIntegrityFailure;
+}
+
+export interface ToolPairOperationalDeferral {
+  readonly kind: "operational_deferral";
+  readonly code: ToolPairOperationalDeferralCode;
+  readonly index: number | null;
+  readonly reason: string;
+  readonly cause?: ToolResultIntegrityDeferral;
+}
+
+export type ToolPairValidationOutcome =
+  | {
+      readonly status: "valid";
+      readonly summary: ToolPairProjectionSummary;
+    }
+  | {
+      readonly status: "invalid";
+      readonly failure: ToolPairIntegrityFailure;
+      readonly summary: ToolPairProjectionSummary;
+    }
+  | {
+      readonly status: "deferred";
+      readonly failure: ToolPairOperationalDeferral;
+      readonly summary: ToolPairProjectionSummary;
+    };
+
+export interface ToolPairValidationOptions {
+  readonly projectionId: string;
+  readonly sourceKey: string;
+  readonly requireResultIntegrity?: boolean;
+  readonly maxToolCalls?: number;
+  readonly maxOpenToolCalls?: number;
+  readonly maxToolCallIdBytes?: number;
+  readonly maxIndexBytes?: number;
+}
+
+interface OpenToolCall {
+  readonly toolName: string;
+  readonly assistantIndex: number;
+}
+
+/**
+ * Validate a message stream without retaining every historical ID in the JS
+ * heap. Only the bounded open-call set is resident; exact duplicate identity
+ * is delegated to the projection.
+ */
+export function validateToolPairSequence(
+  messages: Iterable<ToolPairMessage>,
+  projection: ToolPairProjection,
+  options: ToolPairValidationOptions,
+): ToolPairValidationOutcome {
+  const limits = resolveLimits(options);
+  let latestSummary = emptySummary();
+  try {
+    return projection.runAtomically(() => {
+      projection.reset({
+        projectionId: options.projectionId,
+        sourceKey: options.sourceKey,
+      });
+      const openCalls = new Map<string, OpenToolCall>();
+      let callCount = 0;
+      let resolvedCount = 0;
+      let maximumOpenCallCount = 0;
+      let logicalIndexBytes = 0;
+      let index = 0;
+
+      const summary = (): ToolPairProjectionSummary => ({
+        callCount,
+        resolvedCount,
+        openCallCount: openCalls.size,
+        maximumOpenCallCount,
+        logicalIndexBytes,
+      });
+      const finishFailure = (
+        outcome:
+          | { readonly status: "invalid"; readonly failure: ToolPairIntegrityFailure }
+          | { readonly status: "deferred"; readonly failure: ToolPairOperationalDeferral },
+      ): ToolPairValidationOutcome => {
+        latestSummary = summary();
+        projection.fail(options.projectionId, latestSummary, outcome.failure);
+        return { ...outcome, summary: latestSummary };
+      };
+
+      for (const message of messages) {
+        if (
+          message.role === "assistant" &&
+          message.toolCalls !== undefined &&
+          message.toolCalls.length > 0
+        ) {
+          if (openCalls.size > 0) {
+            return finishFailure(
+              invalid(
+                "assistant_tool_calls_before_results",
+                index,
+                `assistant tool calls started before resolving: ${summarizeOpenIds(openCalls)}`,
+              ),
+            );
+          }
+          if (message.toolCalls.length > limits.maxOpenToolCalls) {
+            return finishFailure(
+              deferred(
+                "tool_pair_open_call_limit",
+                index,
+                `assistant message opens ${message.toolCalls.length} tool calls; limit is ${limits.maxOpenToolCalls}`,
+              ),
+            );
+          }
+          for (const call of message.toolCalls) {
+            if (typeof call.id !== "string" || call.id.trim().length === 0) {
+              return finishFailure(
+                invalid(
+                  "assistant_tool_call_id_missing",
+                  index,
+                  "assistant tool call has an empty identity",
+                ),
+              );
+            }
+            if (typeof call.name !== "string" || call.name.trim().length === 0) {
+              return finishFailure(
+                invalid(
+                  "assistant_tool_call_name_missing",
+                  index,
+                  `assistant tool call ${formatIdentityForLog(call.id)} has an empty tool name`,
+                ),
+              );
+            }
+            const callIdBytes = Buffer.byteLength(call.id, "utf8");
+            if (callIdBytes > limits.maxToolCallIdBytes) {
+              return finishFailure(
+                deferred(
+                  "tool_call_id_limit",
+                  index,
+                  `tool call identity is ${callIdBytes} UTF-8 bytes; limit is ${limits.maxToolCallIdBytes}`,
+                ),
+              );
+            }
+
+            // Exact duplicate lookup intentionally precedes the count limit:
+            // after exactly one million distinct calls, replaying the first ID
+            // is still diagnosed as a duplicate rather than hidden by a limit.
+            if (projection.find(options.projectionId, call.id) !== undefined) {
+              return finishFailure(
+                invalid(
+                  "assistant_tool_call_id_duplicate",
+                  index,
+                  `assistant tool call repeats ${formatIdentityForLog(call.id)}`,
+                ),
+              );
+            }
+            if (callCount >= limits.maxToolCalls) {
+              return finishFailure(
+                deferred(
+                  "tool_pair_call_limit",
+                  index,
+                  `tool-pair scan exceeds ${limits.maxToolCalls} distinct calls`,
+                ),
+              );
+            }
+            const addedIndexBytes =
+              callIdBytes + Buffer.byteLength(call.name, "utf8");
+            if (logicalIndexBytes + addedIndexBytes > limits.maxIndexBytes) {
+              return finishFailure(
+                deferred(
+                  "tool_pair_index_byte_limit",
+                  index,
+                  `tool-pair projection exceeds ${limits.maxIndexBytes} logical UTF-8 bytes`,
+                ),
+              );
+            }
+            const inserted = projection.insertCall(options.projectionId, {
+              callId: call.id,
+              toolName: call.name,
+              assistantIndex: index,
+            });
+            if (!inserted) {
+              return finishFailure(
+                invalid(
+                  "assistant_tool_call_id_duplicate",
+                  index,
+                  `assistant tool call repeats ${formatIdentityForLog(call.id)}`,
+                ),
+              );
+            }
+            openCalls.set(call.id, {
+              toolName: call.name,
+              assistantIndex: index,
+            });
+            callCount += 1;
+            logicalIndexBytes += addedIndexBytes;
+          }
+          maximumOpenCallCount = Math.max(maximumOpenCallCount, openCalls.size);
+          index += 1;
+          continue;
+        }
+
+        if (message.role === "tool") {
+          if (
+            typeof message.toolCallId !== "string" ||
+            message.toolCallId.trim().length === 0
+          ) {
+            return finishFailure(
+              invalid(
+                "tool_result_id_missing",
+                index,
+                "tool result has an empty tool-call identity",
+              ),
+            );
+          }
+          const toolCallIdBytes = Buffer.byteLength(message.toolCallId, "utf8");
+          if (toolCallIdBytes > limits.maxToolCallIdBytes) {
+            return finishFailure(
+              deferred(
+                "tool_call_id_limit",
+                index,
+                `tool result identity is ${toolCallIdBytes} UTF-8 bytes; limit is ${limits.maxToolCallIdBytes}`,
+              ),
+            );
+          }
+          const openCall = openCalls.get(message.toolCallId);
+          if (openCall === undefined) {
+            const exact = projection.find(options.projectionId, message.toolCallId);
+            if (exact?.resultIndex !== undefined) {
+              return finishFailure(
+                invalid(
+                  "tool_result_duplicate",
+                  index,
+                  `tool result repeats ${formatIdentityForLog(message.toolCallId)}`,
+                ),
+              );
+            }
+            return finishFailure(
+              invalid(
+                exact === undefined
+                  ? callCount === 0
+                    ? "tool_result_without_call"
+                    : "tool_result_unknown_id"
+                  : "tool_result_unknown_id",
+                index,
+                `tool result references unknown ${formatIdentityForLog(message.toolCallId)}`,
+              ),
+            );
+          }
+          if (
+            message.toolName !== undefined &&
+            message.toolName !== openCall.toolName
+          ) {
+            return finishFailure(
+              invalid(
+                "tool_result_name_mismatch",
+                index,
+                `tool result ${formatIdentityForLog(message.toolCallId)} names ${formatIdentityForLog(message.toolName)}, expected ${formatIdentityForLog(openCall.toolName)}`,
+              ),
+            );
+          }
+
+          let integrity: ToolResultIntegrity | undefined;
+          if (options.requireResultIntegrity === true) {
+            const verified = verifyToolResultIntegrity({
+              integrity: message.toolResultIntegrity,
+              toolCallId: message.toolCallId,
+              content: message.content,
+            });
+            if (verified.status === "invalid") {
+              return finishFailure({
+                status: "invalid",
+                failure: {
+                  kind: "integrity_failure",
+                  code: "tool_result_integrity_invalid",
+                  index,
+                  reason: verified.failure.reason,
+                  cause: verified.failure,
+                },
+              });
+            }
+            if (verified.status === "deferred") {
+              return finishFailure({
+                status: "deferred",
+                failure: {
+                  kind: "operational_deferral",
+                  code: "tool_result_integrity_deferred",
+                  index,
+                  reason: verified.failure.reason,
+                  cause: verified.failure,
+                },
+              });
+            }
+            integrity = verified.integrity;
+          }
+
+          const addedIndexBytes =
+            integrity === undefined
+              ? 0
+              : Buffer.byteLength(integrity.resultId, "utf8") +
+                Buffer.byteLength(integrity.original.digest, "utf8");
+          if (logicalIndexBytes + addedIndexBytes > limits.maxIndexBytes) {
+            return finishFailure(
+              deferred(
+                "tool_pair_index_byte_limit",
+                index,
+                `tool-pair projection exceeds ${limits.maxIndexBytes} logical UTF-8 bytes`,
+              ),
+            );
+          }
+          const resolution = projection.resolveCall({
+            projectionId: options.projectionId,
+            callId: message.toolCallId,
+            resultIndex: index,
+            ...(integrity === undefined
+              ? {}
+              : {
+                  resultId: integrity.resultId,
+                  originalResultDigest: integrity.original.digest,
+                }),
+          });
+          if (resolution !== "resolved") {
+            return finishFailure(
+              invalid(
+                resolution === "already_resolved"
+                  ? "tool_result_duplicate"
+                  : "tool_result_unknown_id",
+                index,
+                `tool result could not resolve ${formatIdentityForLog(message.toolCallId)}`,
+              ),
+            );
+          }
+          openCalls.delete(message.toolCallId);
+          resolvedCount += 1;
+          logicalIndexBytes += addedIndexBytes;
+          index += 1;
+          continue;
+        }
+
+        if (openCalls.size > 0) {
+          return finishFailure(
+            invalid(
+              "tool_result_missing",
+              index,
+              `tool results must immediately follow their assistant calls; unresolved: ${summarizeOpenIds(openCalls)}`,
+            ),
+          );
+        }
+        index += 1;
+      }
+
+      if (openCalls.size > 0) {
+        return finishFailure(
+          invalid(
+            "tool_result_missing",
+            null,
+            `tool-pair stream ended with unresolved calls: ${summarizeOpenIds(openCalls)}`,
+          ),
+        );
+      }
+      latestSummary = summary();
+      projection.complete(options.projectionId, latestSummary);
+      return { status: "valid", summary: latestSummary };
+    });
+  } catch (error) {
+    return {
+      status: "deferred",
+      failure: {
+        kind: "operational_deferral",
+        code: "tool_pair_projection_unavailable",
+        index: null,
+        reason: projectionFailureReason(error),
+      },
+      summary: latestSummary,
+    };
+  }
+}
+
+function resolveLimits(options: ToolPairValidationOptions): {
+  readonly maxToolCalls: number;
+  readonly maxOpenToolCalls: number;
+  readonly maxToolCallIdBytes: number;
+  readonly maxIndexBytes: number;
+} {
+  return {
+    maxToolCalls: positiveIntegerLimit(
+      options.maxToolCalls ?? MAX_TOOL_CALL_IDS_PER_RUN,
+      "maxToolCalls",
+    ),
+    maxOpenToolCalls: positiveIntegerLimit(
+      options.maxOpenToolCalls ?? MAX_OPEN_TOOL_CALLS_PER_RUN,
+      "maxOpenToolCalls",
+    ),
+    maxToolCallIdBytes: positiveIntegerLimit(
+      options.maxToolCallIdBytes ?? MAX_TOOL_CALL_ID_UTF8_BYTES,
+      "maxToolCallIdBytes",
+    ),
+    maxIndexBytes: positiveIntegerLimit(
+      options.maxIndexBytes ?? MAX_TOOL_CALL_ID_INDEX_BYTES_PER_RUN,
+      "maxIndexBytes",
+    ),
+  };
+}
+
+function positiveIntegerLimit(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function emptySummary(): ToolPairProjectionSummary {
+  return {
+    callCount: 0,
+    resolvedCount: 0,
+    openCallCount: 0,
+    maximumOpenCallCount: 0,
+    logicalIndexBytes: 0,
+  };
+}
+
+function summarizeOpenIds(openCalls: ReadonlyMap<string, OpenToolCall>): string {
+  const values: string[] = [];
+  for (const callId of openCalls.keys()) {
+    values.push(formatIdentityForLog(callId));
+    if (values.length === MAX_TOOL_PAIR_IDS_IN_ERROR) break;
+  }
+  const remaining = openCalls.size - values.length;
+  return remaining > 0
+    ? `${values.join(", ")} … (+${remaining} more)`
+    : values.join(", ");
+}
+
+function invalid(
+  code: ToolPairIntegrityFailureCode,
+  index: number | null,
+  reason: string,
+): { readonly status: "invalid"; readonly failure: ToolPairIntegrityFailure } {
+  return {
+    status: "invalid",
+    failure: { kind: "integrity_failure", code, index, reason },
+  };
+}
+
+function deferred(
+  code: ToolPairOperationalDeferralCode,
+  index: number | null,
+  reason: string,
+): {
+  readonly status: "deferred";
+  readonly failure: ToolPairOperationalDeferral;
+} {
+  return {
+    status: "deferred",
+    failure: { kind: "operational_deferral", code, index, reason },
+  };
+}
+
+function projectionFailureReason(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) {
+    return `tool-pair projection is unavailable: ${error.message}`;
+  }
+  return "tool-pair projection is unavailable";
+}

--- a/runtime/src/session/tool-result-integrity.ts
+++ b/runtime/src/session/tool-result-integrity.ts
@@ -1,0 +1,587 @@
+import { createHash, timingSafeEqual, type Hash } from "node:crypto";
+
+export const TOOL_RESULT_INTEGRITY_VERSION = 1 as const;
+export const TOOL_RESULT_DIGEST_ALGORITHM = "sha256" as const;
+export const TOOL_RESULT_DIGEST_PREFIX = `${TOOL_RESULT_DIGEST_ALGORITHM}:`;
+export const MAX_TOOL_CALL_ID_UTF8_BYTES = 4_096;
+export const MAX_TOOL_RESULT_SCOPE_ID_BYTES = 4_096;
+export const MAX_CANONICAL_BODY_DEPTH = 64;
+export const MAX_CANONICAL_BODY_NODES = 1_000_000;
+
+const TOOL_RESULT_BODY_DIGEST_DOMAIN = "agenc.tool-result-body.v1";
+const TOOL_RESULT_ID_DOMAIN = "agenc.tool-result-id.v1";
+const MAX_SAFE_LOG_ID_CODE_POINTS = 96;
+const SHA256_HEX_LENGTH = 64;
+const LENGTH_PREFIX_BYTES = 8;
+const SHA256_DIGEST_PATTERN = new RegExp(
+  `^${TOOL_RESULT_DIGEST_PREFIX}[0-9a-f]{${SHA256_HEX_LENGTH}}$`,
+);
+const TOOL_RESULT_ID_PATTERN = /^tool-result:[0-9a-f]{64}$/;
+const INTEGRITY_KEYS = Object.freeze([
+  "algorithm",
+  "original",
+  "persisted",
+  "resultId",
+  "runId",
+  "toolCallId",
+  "version",
+]);
+const BODY_IDENTITY_KEYS = Object.freeze(["byteLength", "digest"]);
+const PERSISTED_IDENTITY_KEYS = Object.freeze([
+  "byteLength",
+  "digest",
+  "representation",
+]);
+
+const enum CanonicalTag {
+  Null = 0x00,
+  False = 0x01,
+  True = 0x02,
+  Number = 0x03,
+  String = 0x04,
+  Array = 0x05,
+  Object = 0x06,
+  ObjectKey = 0x07,
+}
+
+export type ToolResultRepresentation =
+  | "original"
+  | "compacted"
+  | "truncated";
+
+export interface ToolResultBodyIdentity {
+  readonly digest: string;
+  /** UTF-8 bytes in the canonical scalar payload, excluding framing. */
+  readonly byteLength: number;
+}
+
+export interface PersistedToolResultIdentity extends ToolResultBodyIdentity {
+  readonly representation: ToolResultRepresentation;
+}
+
+/**
+ * Integrity metadata that remains attached to a tool result while its body is
+ * compacted or truncated. `original` is immutable; `persisted` authenticates
+ * the representation currently stored in the rollout.
+ */
+export interface ToolResultIntegrity {
+  readonly version: typeof TOOL_RESULT_INTEGRITY_VERSION;
+  readonly algorithm: typeof TOOL_RESULT_DIGEST_ALGORITHM;
+  readonly runId: string;
+  readonly toolCallId: string;
+  readonly resultId: string;
+  readonly original: ToolResultBodyIdentity;
+  readonly persisted: PersistedToolResultIdentity;
+}
+
+export type ToolResultIntegrityFailureCode =
+  | "invalid_integrity_metadata"
+  | "run_id_mismatch"
+  | "tool_call_id_mismatch"
+  | "result_id_mismatch"
+  | "persisted_body_digest_mismatch"
+  | "persisted_body_length_mismatch"
+  | "original_representation_mismatch"
+  | "unsupported_body_value";
+
+export type ToolResultIntegrityDeferralCode =
+  | "canonical_body_depth_limit"
+  | "canonical_body_node_limit";
+
+export interface ToolResultIntegrityFailure {
+  readonly kind: "integrity_failure";
+  readonly code: ToolResultIntegrityFailureCode;
+  readonly reason: string;
+}
+
+export interface ToolResultIntegrityDeferral {
+  readonly kind: "operational_deferral";
+  readonly code: ToolResultIntegrityDeferralCode;
+  readonly reason: string;
+}
+
+export type ToolResultIntegrityVerification =
+  | {
+      readonly status: "valid";
+      readonly integrity: ToolResultIntegrity;
+      readonly bodyIdentity: ToolResultBodyIdentity;
+    }
+  | {
+      readonly status: "invalid";
+      readonly failure: ToolResultIntegrityFailure;
+    }
+  | {
+      readonly status: "deferred";
+      readonly failure: ToolResultIntegrityDeferral;
+    };
+
+export class ToolResultCanonicalizationError extends Error {
+  constructor(
+    readonly code:
+      | ToolResultIntegrityFailureCode
+      | ToolResultIntegrityDeferralCode,
+    readonly kind: "integrity_failure" | "operational_deferral",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ToolResultCanonicalizationError";
+  }
+}
+
+/**
+ * Small streaming writer used by both body identities and checkpoint-v2
+ * hashes. Every field is domain-separated and length-prefixed; callers never
+ * need to materialize one giant JSON string solely to hash it.
+ */
+export class CanonicalSha256Writer {
+  readonly #hash: Hash;
+  #payloadByteLength = 0;
+
+  constructor(domain: string) {
+    this.#hash = createHash(TOOL_RESULT_DIGEST_ALGORITHM);
+    this.writeString("domain", domain, false);
+  }
+
+  get payloadByteLength(): number {
+    return this.#payloadByteLength;
+  }
+
+  writeTag(tag: number): void {
+    const encoded = Buffer.allocUnsafe(1);
+    encoded.writeUInt8(tag);
+    this.#hash.update(encoded);
+  }
+
+  writeCount(label: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new ToolResultCanonicalizationError(
+        "unsupported_body_value",
+        "integrity_failure",
+        `${label} must be a non-negative safe integer`,
+      );
+    }
+    this.writeString("count-label", label, false);
+    this.#hash.update(encodeUnsignedLength(value));
+  }
+
+  writeString(label: string, value: string, countPayload = true): void {
+    const labelBytes = Buffer.from(label, "utf8");
+    const valueByteLength = Buffer.byteLength(value, "utf8");
+    this.#hash.update(encodeUnsignedLength(labelBytes.length));
+    this.#hash.update(labelBytes);
+    this.#hash.update(encodeUnsignedLength(valueByteLength));
+    this.#hash.update(value, "utf8");
+    if (countPayload) this.#payloadByteLength += valueByteLength;
+  }
+
+  digest(): string {
+    return `${TOOL_RESULT_DIGEST_PREFIX}${this.#hash.digest("hex")}`;
+  }
+}
+
+export function digestToolResultBody(content: unknown): ToolResultBodyIdentity {
+  const writer = new CanonicalSha256Writer(TOOL_RESULT_BODY_DIGEST_DOMAIN);
+  const activeObjects = new WeakSet<object>();
+  const visited = { nodes: 0 };
+  writeCanonicalValue(writer, content, 0, activeObjects, visited);
+  return {
+    digest: writer.digest(),
+    byteLength: writer.payloadByteLength,
+  };
+}
+
+export function deterministicToolResultId(
+  runId: string,
+  toolCallId: string,
+): string {
+  assertBoundedIdentity(runId, "runId", MAX_TOOL_RESULT_SCOPE_ID_BYTES);
+  assertBoundedIdentity(
+    toolCallId,
+    "toolCallId",
+    MAX_TOOL_CALL_ID_UTF8_BYTES,
+  );
+  const writer = new CanonicalSha256Writer(TOOL_RESULT_ID_DOMAIN);
+  writer.writeString("run-id", runId);
+  writer.writeString("tool-call-id", toolCallId);
+  return `tool-result:${writer.digest().slice(TOOL_RESULT_DIGEST_PREFIX.length)}`;
+}
+
+export function createToolResultIntegrity(params: {
+  readonly runId: string;
+  readonly toolCallId: string;
+  readonly content: unknown;
+}): ToolResultIntegrity {
+  const resultId = deterministicToolResultId(params.runId, params.toolCallId);
+  const original = digestToolResultBody(params.content);
+  return {
+    version: TOOL_RESULT_INTEGRITY_VERSION,
+    algorithm: TOOL_RESULT_DIGEST_ALGORITHM,
+    runId: params.runId,
+    toolCallId: params.toolCallId,
+    resultId,
+    original,
+    persisted: {
+      representation: "original",
+      ...original,
+    },
+  };
+}
+
+export function withPersistedToolResultRepresentation(
+  integrity: ToolResultIntegrity,
+  representation: Exclude<ToolResultRepresentation, "original">,
+  content: unknown,
+): ToolResultIntegrity {
+  const persisted = digestToolResultBody(content);
+  return {
+    ...integrity,
+    persisted: { representation, ...persisted },
+  };
+}
+
+export function verifyToolResultIntegrity(params: {
+  readonly integrity: unknown;
+  /** Expected durable scope when the caller knows the owning run/session. */
+  readonly expectedRunId?: string;
+  readonly toolCallId: string;
+  readonly content: unknown;
+}): ToolResultIntegrityVerification {
+  const parsed = parseToolResultIntegrity(params.integrity);
+  if (parsed.status !== "valid") return parsed;
+  const integrity = parsed.integrity;
+  if (integrity.toolCallId !== params.toolCallId) {
+    return invalid(
+      "tool_call_id_mismatch",
+      `tool result metadata identifies ${formatIdentityForLog(integrity.toolCallId)}, not ${formatIdentityForLog(params.toolCallId)}`,
+    );
+  }
+  if (
+    params.expectedRunId !== undefined &&
+    integrity.runId !== params.expectedRunId
+  ) {
+    return invalid(
+      "run_id_mismatch",
+      `tool result ${formatIdentityForLog(params.toolCallId)} belongs to a different durable run`,
+    );
+  }
+  const expectedResultId = deterministicToolResultId(
+    integrity.runId,
+    integrity.toolCallId,
+  );
+  if (!constantTimeDigestEqual(integrity.resultId, expectedResultId)) {
+    return invalid(
+      "result_id_mismatch",
+      `tool result ${formatIdentityForLog(params.toolCallId)} has a non-canonical result identity`,
+    );
+  }
+
+  let bodyIdentity: ToolResultBodyIdentity;
+  try {
+    bodyIdentity = digestToolResultBody(params.content);
+  } catch (error) {
+    return canonicalizationFailure(error);
+  }
+  if (!constantTimeDigestEqual(bodyIdentity.digest, integrity.persisted.digest)) {
+    return invalid(
+      "persisted_body_digest_mismatch",
+      `persisted body digest does not match tool result ${formatIdentityForLog(params.toolCallId)}`,
+    );
+  }
+  if (bodyIdentity.byteLength !== integrity.persisted.byteLength) {
+    return invalid(
+      "persisted_body_length_mismatch",
+      `persisted body length does not match tool result ${formatIdentityForLog(params.toolCallId)}`,
+    );
+  }
+  if (
+    integrity.persisted.representation === "original" &&
+    (!constantTimeDigestEqual(
+      integrity.original.digest,
+      integrity.persisted.digest,
+    ) ||
+      integrity.original.byteLength !== integrity.persisted.byteLength)
+  ) {
+    return invalid(
+      "original_representation_mismatch",
+      `original representation identity is inconsistent for tool result ${formatIdentityForLog(params.toolCallId)}`,
+    );
+  }
+  return { status: "valid", integrity, bodyIdentity };
+}
+
+export function constantTimeDigestEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, "utf8");
+  const rightBytes = Buffer.from(right, "utf8");
+  if (leftBytes.length !== rightBytes.length) return false;
+  return timingSafeEqual(leftBytes, rightBytes);
+}
+
+export function isSha256Digest(value: unknown): value is string {
+  return typeof value === "string" && SHA256_DIGEST_PATTERN.test(value);
+}
+
+export function formatIdentityForLog(value: string): string {
+  let shortened = "";
+  let count = 0;
+  let truncated = false;
+  for (const codePoint of value) {
+    if (count === MAX_SAFE_LOG_ID_CODE_POINTS) {
+      truncated = true;
+      break;
+    }
+    shortened += codePoint;
+    count += 1;
+  }
+  if (truncated) shortened += "…";
+  return `${JSON.stringify(shortened)} (${Buffer.byteLength(value, "utf8")} UTF-8 bytes)`;
+}
+
+function parseToolResultIntegrity(
+  value: unknown,
+):
+  | { readonly status: "valid"; readonly integrity: ToolResultIntegrity }
+  | { readonly status: "invalid"; readonly failure: ToolResultIntegrityFailure } {
+  if (!isRecord(value) || !hasExactKeys(value, INTEGRITY_KEYS)) {
+    return invalid("invalid_integrity_metadata", "tool result integrity metadata is missing");
+  }
+  if (
+    value.version !== TOOL_RESULT_INTEGRITY_VERSION ||
+    value.algorithm !== TOOL_RESULT_DIGEST_ALGORITHM ||
+    typeof value.runId !== "string" ||
+    typeof value.toolCallId !== "string" ||
+    typeof value.resultId !== "string" ||
+    !TOOL_RESULT_ID_PATTERN.test(value.resultId) ||
+    !isBodyIdentity(value.original) ||
+    !isPersistedBodyIdentity(value.persisted)
+  ) {
+    return invalid(
+      "invalid_integrity_metadata",
+      "tool result integrity metadata has an unsupported or malformed shape",
+    );
+  }
+  try {
+    assertBoundedIdentity(value.runId, "runId", MAX_TOOL_RESULT_SCOPE_ID_BYTES);
+    assertBoundedIdentity(
+      value.toolCallId,
+      "toolCallId",
+      MAX_TOOL_CALL_ID_UTF8_BYTES,
+    );
+  } catch {
+    return invalid(
+      "invalid_integrity_metadata",
+      "tool result integrity metadata contains an invalid identity",
+    );
+  }
+  return {
+    status: "valid",
+    integrity: value as unknown as ToolResultIntegrity,
+  };
+}
+
+function isBodyIdentity(value: unknown): value is ToolResultBodyIdentity {
+  return (
+    isRecord(value) &&
+    hasExactKeys(value, BODY_IDENTITY_KEYS) &&
+    isSha256Digest(value.digest) &&
+    Number.isSafeInteger(value.byteLength) &&
+    (value.byteLength as number) >= 0
+  );
+}
+
+function isPersistedBodyIdentity(
+  value: unknown,
+): value is PersistedToolResultIdentity {
+  if (!isRecord(value) || !hasExactKeys(value, PERSISTED_IDENTITY_KEYS)) {
+    return false;
+  }
+  if (
+    !isSha256Digest(value.digest) ||
+    !Number.isSafeInteger(value.byteLength) ||
+    (value.byteLength as number) < 0
+  ) {
+    return false;
+  }
+  const representation = value.representation;
+  return (
+    representation === "original" ||
+    representation === "compacted" ||
+    representation === "truncated"
+  );
+}
+
+function writeCanonicalValue(
+  writer: CanonicalSha256Writer,
+  value: unknown,
+  depth: number,
+  activeObjects: WeakSet<object>,
+  visited: { nodes: number },
+): void {
+  if (depth > MAX_CANONICAL_BODY_DEPTH) {
+    throw new ToolResultCanonicalizationError(
+      "canonical_body_depth_limit",
+      "operational_deferral",
+      `tool result canonicalization exceeds depth ${MAX_CANONICAL_BODY_DEPTH}`,
+    );
+  }
+  visited.nodes += 1;
+  if (visited.nodes > MAX_CANONICAL_BODY_NODES) {
+    throw new ToolResultCanonicalizationError(
+      "canonical_body_node_limit",
+      "operational_deferral",
+      `tool result canonicalization exceeds ${MAX_CANONICAL_BODY_NODES} values`,
+    );
+  }
+
+  if (value === null) {
+    writer.writeTag(CanonicalTag.Null);
+    writer.writeString("null", "null");
+    return;
+  }
+  if (typeof value === "boolean") {
+    writer.writeTag(value ? CanonicalTag.True : CanonicalTag.False);
+    writer.writeString("boolean", value ? "true" : "false");
+    return;
+  }
+  if (typeof value === "number") {
+    writer.writeTag(CanonicalTag.Number);
+    writer.writeString(
+      "number",
+      Number.isFinite(value) ? JSON.stringify(value) : "null",
+    );
+    return;
+  }
+  if (typeof value === "string") {
+    writer.writeTag(CanonicalTag.String);
+    writer.writeString("string", value);
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new ToolResultCanonicalizationError(
+      "unsupported_body_value",
+      "integrity_failure",
+      `tool result body contains unsupported ${typeof value} content`,
+    );
+  }
+  if (activeObjects.has(value)) {
+    throw new ToolResultCanonicalizationError(
+      "unsupported_body_value",
+      "integrity_failure",
+      "tool result body contains a cyclic value",
+    );
+  }
+  activeObjects.add(value);
+  try {
+    if (Array.isArray(value)) {
+      writer.writeTag(CanonicalTag.Array);
+      writer.writeCount("array-length", value.length);
+      for (const element of value) {
+        writeCanonicalValue(
+          writer,
+          element === undefined ? null : element,
+          depth + 1,
+          activeObjects,
+          visited,
+        );
+      }
+      return;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new ToolResultCanonicalizationError(
+        "unsupported_body_value",
+        "integrity_failure",
+        "tool result body must contain only JSON-compatible plain objects",
+      );
+    }
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort();
+    writer.writeTag(CanonicalTag.Object);
+    writer.writeCount("object-key-count", keys.length);
+    for (const key of keys) {
+      writer.writeTag(CanonicalTag.ObjectKey);
+      writer.writeString("object-key", key);
+      writeCanonicalValue(
+        writer,
+        record[key],
+        depth + 1,
+        activeObjects,
+        visited,
+      );
+    }
+  } finally {
+    activeObjects.delete(value);
+  }
+}
+
+function encodeUnsignedLength(value: number): Buffer {
+  const encoded = Buffer.allocUnsafe(LENGTH_PREFIX_BYTES);
+  encoded.writeBigUInt64BE(BigInt(value));
+  return encoded;
+}
+
+function assertBoundedIdentity(
+  value: string,
+  field: string,
+  maxBytes: number,
+): void {
+  const byteLength = Buffer.byteLength(value, "utf8");
+  if (value.length === 0 || value.trim().length === 0) {
+    throw new Error(`${field} must not be empty`);
+  }
+  if (byteLength > maxBytes) {
+    throw new Error(`${field} exceeds ${maxBytes} UTF-8 bytes`);
+  }
+}
+
+function canonicalizationFailure(
+  error: unknown,
+): ToolResultIntegrityVerification {
+  if (error instanceof ToolResultCanonicalizationError) {
+    if (error.kind === "operational_deferral") {
+      return {
+        status: "deferred",
+        failure: {
+          kind: error.kind,
+          code: error.code as ToolResultIntegrityDeferralCode,
+          reason: error.message,
+        },
+      };
+    }
+    return invalid(
+      error.code as ToolResultIntegrityFailureCode,
+      error.message,
+    );
+  }
+  throw error;
+}
+
+function invalid(
+  code: ToolResultIntegrityFailureCode,
+  reason: string,
+): {
+  readonly status: "invalid";
+  readonly failure: ToolResultIntegrityFailure;
+} {
+  return {
+    status: "invalid",
+    failure: { kind: "integrity_failure", code, reason },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+}

--- a/runtime/src/session/tool-result-integrity.ts
+++ b/runtime/src/session/tool-result-integrity.ts
@@ -44,10 +44,7 @@ const enum CanonicalTag {
   ObjectKey = 0x07,
 }
 
-export type ToolResultRepresentation =
-  | "original"
-  | "compacted"
-  | "truncated";
+export type ToolResultRepresentation = "original" | "compacted" | "truncated";
 
 export interface ToolResultBodyIdentity {
   readonly digest: string;
@@ -85,8 +82,7 @@ export type ToolResultIntegrityFailureCode =
   | "unsupported_body_value";
 
 export type ToolResultIntegrityDeferralCode =
-  | "canonical_body_depth_limit"
-  | "canonical_body_node_limit";
+  "canonical_body_depth_limit" | "canonical_body_node_limit";
 
 export interface ToolResultIntegrityFailure {
   readonly kind: "integrity_failure";
@@ -118,8 +114,7 @@ export type ToolResultIntegrityVerification =
 export class ToolResultCanonicalizationError extends Error {
   constructor(
     readonly code:
-      | ToolResultIntegrityFailureCode
-      | ToolResultIntegrityDeferralCode,
+      ToolResultIntegrityFailureCode | ToolResultIntegrityDeferralCode,
     readonly kind: "integrity_failure" | "operational_deferral",
     message: string,
   ) {
@@ -165,6 +160,8 @@ export class CanonicalSha256Writer {
   }
 
   writeString(label: string, value: string, countPayload = true): void {
+    assertWellFormedUtf16(label, "canonical field label");
+    assertWellFormedUtf16(value, label);
     const labelBytes = Buffer.from(label, "utf8");
     const valueByteLength = Buffer.byteLength(value, "utf8");
     this.#hash.update(encodeUnsignedLength(labelBytes.length));
@@ -179,11 +176,15 @@ export class CanonicalSha256Writer {
   }
 }
 
-export function digestToolResultBody(content: unknown): ToolResultBodyIdentity {
+export function digestToolResultBody(
+  content: unknown,
+  limits: { readonly maxNodes?: number } = {},
+): ToolResultBodyIdentity {
+  const maxNodes = boundedCanonicalNodeLimit(limits.maxNodes);
   const writer = new CanonicalSha256Writer(TOOL_RESULT_BODY_DIGEST_DOMAIN);
   const activeObjects = new WeakSet<object>();
   const visited = { nodes: 0 };
-  writeCanonicalValue(writer, content, 0, activeObjects, visited);
+  writeCanonicalValue(writer, content, 0, activeObjects, visited, maxNodes);
   return {
     digest: writer.digest(),
     byteLength: writer.payloadByteLength,
@@ -195,11 +196,7 @@ export function deterministicToolResultId(
   toolCallId: string,
 ): string {
   assertBoundedIdentity(runId, "runId", MAX_TOOL_RESULT_SCOPE_ID_BYTES);
-  assertBoundedIdentity(
-    toolCallId,
-    "toolCallId",
-    MAX_TOOL_CALL_ID_UTF8_BYTES,
-  );
+  assertBoundedIdentity(toolCallId, "toolCallId", MAX_TOOL_CALL_ID_UTF8_BYTES);
   const writer = new CanonicalSha256Writer(TOOL_RESULT_ID_DOMAIN);
   writer.writeString("run-id", runId);
   writer.writeString("tool-call-id", toolCallId);
@@ -281,7 +278,9 @@ export function verifyToolResultIntegrity(params: {
   } catch (error) {
     return canonicalizationFailure(error);
   }
-  if (!constantTimeDigestEqual(bodyIdentity.digest, integrity.persisted.digest)) {
+  if (
+    !constantTimeDigestEqual(bodyIdentity.digest, integrity.persisted.digest)
+  ) {
     return invalid(
       "persisted_body_digest_mismatch",
       `persisted body digest does not match tool result ${formatIdentityForLog(params.toolCallId)}`,
@@ -340,9 +339,15 @@ function parseToolResultIntegrity(
   value: unknown,
 ):
   | { readonly status: "valid"; readonly integrity: ToolResultIntegrity }
-  | { readonly status: "invalid"; readonly failure: ToolResultIntegrityFailure } {
+  | {
+      readonly status: "invalid";
+      readonly failure: ToolResultIntegrityFailure;
+    } {
   if (!isRecord(value) || !hasExactKeys(value, INTEGRITY_KEYS)) {
-    return invalid("invalid_integrity_metadata", "tool result integrity metadata is missing");
+    return invalid(
+      "invalid_integrity_metadata",
+      "tool result integrity metadata is missing",
+    );
   }
   if (
     value.version !== TOOL_RESULT_INTEGRITY_VERSION ||
@@ -415,6 +420,7 @@ function writeCanonicalValue(
   depth: number,
   activeObjects: WeakSet<object>,
   visited: { nodes: number },
+  maxNodes: number,
 ): void {
   if (depth > MAX_CANONICAL_BODY_DEPTH) {
     throw new ToolResultCanonicalizationError(
@@ -424,11 +430,11 @@ function writeCanonicalValue(
     );
   }
   visited.nodes += 1;
-  if (visited.nodes > MAX_CANONICAL_BODY_NODES) {
+  if (visited.nodes > maxNodes) {
     throw new ToolResultCanonicalizationError(
       "canonical_body_node_limit",
       "operational_deferral",
-      `tool result canonicalization exceeds ${MAX_CANONICAL_BODY_NODES} values`,
+      `tool result canonicalization exceeds ${maxNodes} values`,
     );
   }
 
@@ -443,11 +449,15 @@ function writeCanonicalValue(
     return;
   }
   if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new ToolResultCanonicalizationError(
+        "unsupported_body_value",
+        "integrity_failure",
+        "tool result body contains a non-finite number",
+      );
+    }
     writer.writeTag(CanonicalTag.Number);
-    writer.writeString(
-      "number",
-      Number.isFinite(value) ? JSON.stringify(value) : "null",
-    );
+    writer.writeString("number", JSON.stringify(value));
     return;
   }
   if (typeof value === "string") {
@@ -481,6 +491,7 @@ function writeCanonicalValue(
           depth + 1,
           activeObjects,
           visited,
+          maxNodes,
         );
       }
       return;
@@ -495,6 +506,7 @@ function writeCanonicalValue(
       );
     }
     const record = value as Record<string, unknown>;
+    assertEnumerableOwnKeyBudget(record, maxNodes - visited.nodes);
     const keys = Object.keys(record)
       .filter((key) => record[key] !== undefined)
       .sort();
@@ -509,6 +521,7 @@ function writeCanonicalValue(
         depth + 1,
         activeObjects,
         visited,
+        maxNodes,
       );
     }
   } finally {
@@ -527,12 +540,70 @@ function assertBoundedIdentity(
   field: string,
   maxBytes: number,
 ): void {
+  assertWellFormedUtf16(value, field);
   const byteLength = Buffer.byteLength(value, "utf8");
   if (value.length === 0 || value.trim().length === 0) {
     throw new Error(`${field} must not be empty`);
   }
   if (byteLength > maxBytes) {
     throw new Error(`${field} exceeds ${maxBytes} UTF-8 bytes`);
+  }
+}
+
+function assertWellFormedUtf16(value: string, field: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        index += 1;
+        continue;
+      }
+      throw illFormedString(field);
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw illFormedString(field);
+    }
+  }
+}
+
+function illFormedString(field: string): ToolResultCanonicalizationError {
+  return new ToolResultCanonicalizationError(
+    "unsupported_body_value",
+    "integrity_failure",
+    `${field} must contain well-formed UTF-16`,
+  );
+}
+
+function boundedCanonicalNodeLimit(value: number | undefined): number {
+  if (value === undefined) return MAX_CANONICAL_BODY_NODES;
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_CANONICAL_BODY_NODES
+  ) {
+    throw new Error(
+      `maxNodes must be a positive safe integer no greater than ${MAX_CANONICAL_BODY_NODES}`,
+    );
+  }
+  return value;
+}
+
+function assertEnumerableOwnKeyBudget(
+  value: Record<string, unknown>,
+  remainingNodes: number,
+): void {
+  let keyCount = 0;
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+    keyCount += 1;
+    if (keyCount > remainingNodes) {
+      throw new ToolResultCanonicalizationError(
+        "canonical_body_node_limit",
+        "operational_deferral",
+        "tool result canonicalization exceeds the remaining object-key budget",
+      );
+    }
   }
 }
 
@@ -550,10 +621,7 @@ function canonicalizationFailure(
         },
       };
     }
-    return invalid(
-      error.code as ToolResultIntegrityFailureCode,
-      error.message,
-    );
+    return invalid(error.code as ToolResultIntegrityFailureCode, error.message);
   }
   throw error;
 }

--- a/runtime/src/state/migrations/020_tool_pair_projection_schema.ts
+++ b/runtime/src/state/migrations/020_tool_pair_projection_schema.ts
@@ -1,0 +1,71 @@
+import type { SqlMigration } from "./types.js";
+
+/** Version 19 is reserved for the independently integrated B1 migration. */
+export const TOOL_PAIR_PROJECTION_SCHEMA_VERSION = 20;
+
+/**
+ * Exact, rebuildable tool-call/result index for bounded durable-rollout reads.
+ * This is deliberately separate from `in_flight_tool_calls`: the latter is
+ * mutable execution state, while these rows are a derived integrity
+ * projection that can be deleted and rebuilt from canonical rollout bytes.
+ */
+export const toolPairProjectionSchemaMigration: SqlMigration = {
+  version: TOOL_PAIR_PROJECTION_SCHEMA_VERSION,
+  name: "tool_pair_projection_schema",
+  sql: `
+CREATE TABLE IF NOT EXISTS tool_pair_projection_runs (
+  projection_id TEXT PRIMARY KEY,
+  source_key TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('building', 'valid', 'invalid', 'deferred')),
+  call_count INTEGER NOT NULL DEFAULT 0 CHECK (call_count >= 0),
+  resolved_count INTEGER NOT NULL DEFAULT 0 CHECK (resolved_count >= 0),
+  open_call_count INTEGER NOT NULL DEFAULT 0 CHECK (open_call_count >= 0),
+  maximum_open_call_count INTEGER NOT NULL DEFAULT 0 CHECK (maximum_open_call_count >= 0),
+  logical_index_bytes INTEGER NOT NULL DEFAULT 0 CHECK (logical_index_bytes >= 0),
+  failure_kind TEXT CHECK (failure_kind IN ('integrity_failure', 'operational_deferral')),
+  failure_code TEXT,
+  failure_index INTEGER CHECK (failure_index IS NULL OR failure_index >= 0),
+  failure_reason TEXT,
+  CHECK (resolved_count <= call_count),
+  CHECK (open_call_count = call_count - resolved_count),
+  CHECK (maximum_open_call_count >= open_call_count),
+  CHECK (status <> 'valid' OR open_call_count = 0),
+  CHECK (
+    (status IN ('building', 'valid') AND failure_kind IS NULL AND failure_code IS NULL AND failure_index IS NULL AND failure_reason IS NULL)
+    OR
+    (status = 'invalid' AND failure_kind = 'integrity_failure' AND failure_code IS NOT NULL AND failure_reason IS NOT NULL)
+    OR
+    (status = 'deferred' AND failure_kind = 'operational_deferral' AND failure_code IS NOT NULL AND failure_reason IS NOT NULL)
+  )
+);
+
+CREATE TABLE IF NOT EXISTS tool_pair_projection_entries (
+  projection_id TEXT NOT NULL,
+  call_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  assistant_index INTEGER NOT NULL CHECK (assistant_index >= 0),
+  result_index INTEGER CHECK (result_index IS NULL OR result_index > assistant_index),
+  result_id TEXT,
+  original_result_digest TEXT,
+  PRIMARY KEY (projection_id, call_id),
+  FOREIGN KEY (projection_id)
+    REFERENCES tool_pair_projection_runs(projection_id)
+    ON DELETE CASCADE,
+  CHECK (
+    (result_index IS NULL AND result_id IS NULL AND original_result_digest IS NULL)
+    OR
+    (result_index IS NOT NULL AND (
+      (result_id IS NULL AND original_result_digest IS NULL)
+      OR (result_id IS NOT NULL AND original_result_digest IS NOT NULL)
+    ))
+  )
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS idx_tool_pair_projection_source
+  ON tool_pair_projection_runs(source_key, projection_id);
+
+CREATE INDEX IF NOT EXISTS idx_tool_pair_projection_unresolved
+  ON tool_pair_projection_entries(projection_id, assistant_index)
+  WHERE result_index IS NULL;
+`,
+};

--- a/runtime/src/state/migrations/index.ts
+++ b/runtime/src/state/migrations/index.ts
@@ -17,6 +17,7 @@ import { runDurabilitySchemaMigration } from "./015_run_durability_schema.js";
 import { runEffectsSessionCallStepIndexMigration } from "./016_run_effects_session_call_step_index.js";
 import { effectEvidenceV2Migration } from "./017_effect_evidence_v2.js";
 import { runRecoverySchemaMigration } from "./018_run_recovery_schema.js";
+import { toolPairProjectionSchemaMigration } from "./020_tool_pair_projection_schema.js";
 import type { SqlMigration } from "./types.js";
 
 /**
@@ -41,6 +42,7 @@ export const STATE_DB_MIGRATIONS: readonly SqlMigration[] = [
   runEffectsSessionCallStepIndexMigration,
   effectEvidenceV2Migration,
   runRecoverySchemaMigration,
+  toolPairProjectionSchemaMigration,
 ];
 
 export const LOGS_DB_MIGRATIONS: readonly SqlMigration[] = [

--- a/runtime/src/state/tool-pair-projection.ts
+++ b/runtime/src/state/tool-pair-projection.ts
@@ -1,0 +1,218 @@
+import type {
+  ToolPairIntegrityFailure,
+  ToolPairOperationalDeferral,
+  ToolPairProjection,
+  ToolPairProjectionRecord,
+  ToolPairProjectionSummary,
+} from "../session/tool-pair-validator.js";
+import type { StateSqliteDriver } from "./sqlite-driver.js";
+
+export const MAX_TOOL_PAIR_PROJECTION_ID_BYTES = 4_096;
+export const MAX_TOOL_PAIR_SOURCE_KEY_BYTES = 4_096;
+
+interface ProjectionEntryRow {
+  readonly call_id: string;
+  readonly tool_name: string;
+  readonly assistant_index: number;
+  readonly result_index: number | null;
+  readonly result_id: string | null;
+  readonly original_result_digest: string | null;
+}
+
+/** SQLite implementation of the rebuildable exact tool-pair projection. */
+export class StateToolPairProjection implements ToolPairProjection {
+  constructor(private readonly driver: StateSqliteDriver) {}
+
+  runAtomically<T>(operation: () => T): T {
+    return this.driver.transactionImmediate(operation);
+  }
+
+  reset(params: {
+    readonly projectionId: string;
+    readonly sourceKey: string;
+  }): void {
+    requireBoundedText(
+      params.projectionId,
+      "projectionId",
+      MAX_TOOL_PAIR_PROJECTION_ID_BYTES,
+    );
+    requireBoundedText(
+      params.sourceKey,
+      "sourceKey",
+      MAX_TOOL_PAIR_SOURCE_KEY_BYTES,
+    );
+    this.driver
+      .prepareState<[string]>(
+        "DELETE FROM tool_pair_projection_runs WHERE projection_id = ?",
+      )
+      .run(params.projectionId);
+    this.driver
+      .prepareState<[string, string]>(
+        `INSERT INTO tool_pair_projection_runs (
+           projection_id, source_key, status
+         ) VALUES (?, ?, 'building')`,
+      )
+      .run(params.projectionId, params.sourceKey);
+  }
+
+  find(
+    projectionId: string,
+    callId: string,
+  ): ToolPairProjectionRecord | undefined {
+    const row = this.driver
+      .prepareState<[string, string], ProjectionEntryRow>(
+        `SELECT call_id, tool_name, assistant_index, result_index,
+                result_id, original_result_digest
+         FROM tool_pair_projection_entries
+         WHERE projection_id = ? AND call_id = ?`,
+      )
+      .get(projectionId, callId);
+    return row === undefined ? undefined : recordFromRow(row);
+  }
+
+  insertCall(
+    projectionId: string,
+    record: ToolPairProjectionRecord,
+  ): boolean {
+    const result = this.driver
+      .prepareState<[string, string, string, number]>(
+        `INSERT OR IGNORE INTO tool_pair_projection_entries (
+           projection_id, call_id, tool_name, assistant_index
+         ) VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        projectionId,
+        record.callId,
+        record.toolName,
+        record.assistantIndex,
+      );
+    return result.changes === 1;
+  }
+
+  resolveCall(params: {
+    readonly projectionId: string;
+    readonly callId: string;
+    readonly resultIndex: number;
+    readonly resultId?: string;
+    readonly originalResultDigest?: string;
+  }): "resolved" | "already_resolved" | "missing" {
+    const result = this.driver
+      .prepareState<
+        [number, string | null, string | null, string, string]
+      >(
+        `UPDATE tool_pair_projection_entries
+         SET result_index = ?, result_id = ?, original_result_digest = ?
+         WHERE projection_id = ? AND call_id = ? AND result_index IS NULL`,
+      )
+      .run(
+        params.resultIndex,
+        params.resultId ?? null,
+        params.originalResultDigest ?? null,
+        params.projectionId,
+        params.callId,
+      );
+    if (result.changes === 1) return "resolved";
+    const existing = this.find(params.projectionId, params.callId);
+    if (existing === undefined) return "missing";
+    return existing.resultIndex === undefined ? "missing" : "already_resolved";
+  }
+
+  complete(
+    projectionId: string,
+    summary: ToolPairProjectionSummary,
+  ): void {
+    this.updateTerminalStatus(projectionId, "valid", summary);
+  }
+
+  fail(
+    projectionId: string,
+    summary: ToolPairProjectionSummary,
+    failure: ToolPairIntegrityFailure | ToolPairOperationalDeferral,
+  ): void {
+    const status =
+      failure.kind === "integrity_failure" ? "invalid" : "deferred";
+    const result = this.driver
+      .prepareState<
+        [string, number, number, number, number, number, string, string, number | null, string, string]
+      >(
+        `UPDATE tool_pair_projection_runs
+         SET status = ?, call_count = ?, resolved_count = ?,
+             open_call_count = ?, maximum_open_call_count = ?,
+             logical_index_bytes = ?, failure_kind = ?, failure_code = ?,
+             failure_index = ?, failure_reason = ?
+         WHERE projection_id = ? AND status = 'building'`,
+      )
+      .run(
+        status,
+        summary.callCount,
+        summary.resolvedCount,
+        summary.openCallCount,
+        summary.maximumOpenCallCount,
+        summary.logicalIndexBytes,
+        failure.kind,
+        failure.code,
+        failure.index,
+        failure.reason,
+        projectionId,
+      );
+    if (result.changes !== 1) {
+      throw new Error(`tool-pair projection ${projectionId} is not building`);
+    }
+  }
+
+  private updateTerminalStatus(
+    projectionId: string,
+    status: "valid",
+    summary: ToolPairProjectionSummary,
+  ): void {
+    const result = this.driver
+      .prepareState<
+        [string, number, number, number, number, number, string]
+      >(
+        `UPDATE tool_pair_projection_runs
+         SET status = ?, call_count = ?, resolved_count = ?,
+             open_call_count = ?, maximum_open_call_count = ?,
+             logical_index_bytes = ?
+         WHERE projection_id = ? AND status = 'building'`,
+      )
+      .run(
+        status,
+        summary.callCount,
+        summary.resolvedCount,
+        summary.openCallCount,
+        summary.maximumOpenCallCount,
+        summary.logicalIndexBytes,
+        projectionId,
+      );
+    if (result.changes !== 1) {
+      throw new Error(`tool-pair projection ${projectionId} is not building`);
+    }
+  }
+}
+
+function recordFromRow(row: ProjectionEntryRow): ToolPairProjectionRecord {
+  return {
+    callId: row.call_id,
+    toolName: row.tool_name,
+    assistantIndex: row.assistant_index,
+    ...(row.result_index === null ? {} : { resultIndex: row.result_index }),
+    ...(row.result_id === null ? {} : { resultId: row.result_id }),
+    ...(row.original_result_digest === null
+      ? {}
+      : { originalResultDigest: row.original_result_digest }),
+  };
+}
+
+function requireBoundedText(
+  value: string,
+  field: string,
+  maxBytes: number,
+): void {
+  if (value.length === 0 || value.trim().length === 0) {
+    throw new Error(`${field} must not be empty`);
+  }
+  const byteLength = Buffer.byteLength(value, "utf8");
+  if (byteLength > maxBytes) {
+    throw new Error(`${field} exceeds ${maxBytes} UTF-8 bytes`);
+  }
+}

--- a/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
+++ b/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
@@ -1,9 +1,4 @@
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,15 +17,18 @@ import {
   parseRolloutLine,
   type ResponseItem,
   type RolloutItem,
+  type ToolResultIntegrityResponseItem,
 } from "../../src/session/rollout-item.js";
-import {
-  createToolResultIntegrity,
-} from "../../src/session/tool-result-integrity.js";
+import { createToolResultIntegrity } from "../../src/session/tool-result-integrity.js";
 import {
   openStateDatabases,
   type StateSqliteDriver,
 } from "../../src/state/sqlite-driver.js";
 import { StateToolPairProjection } from "../../src/state/tool-pair-projection.js";
+import {
+  isCanonicalEventPayload,
+  isCanonicalRolloutPayload,
+} from "../../src/state/recovery-journal-schema.js";
 
 const FIXTURE_ROOT = fileURLToPath(
   new URL("../fnd/fixtures/checkpoints/", import.meta.url),
@@ -56,10 +54,43 @@ afterEach(() => {
 });
 
 describe("durable checkpoint v2 reader", () => {
+  it("layers strict checkpoint validation over the additive recovery envelope", () => {
+    const checkpoint = {
+      ...legacyCheckpoint("a".repeat(64)),
+      checkpointVersion: 2,
+      toolResultIntegrityVersion: 1,
+    };
+    const integrity = createToolResultIntegrity({
+      runId: "recovery-envelope-run",
+      toolCallId: "recovery-envelope-call",
+      content: "sealed result",
+    });
+    const response = {
+      role: "tool" as const,
+      content: "sealed result",
+      toolCallId: "recovery-envelope-call",
+      toolResultIntegrity: integrity,
+    };
+
+    expect(isCanonicalEventPayload("turn_checkpoint", checkpoint)).toBe(true);
+    expect(isCanonicalRolloutPayload("response_item", response)).toBe(true);
+    expect(readTurnCheckpoint(checkpoint)).toMatchObject({ version: 2 });
+
+    const malformed = { ...checkpoint, toolResultIntegrityVersion: "1" };
+    expect(isCanonicalEventPayload("turn_checkpoint", malformed)).toBe(true);
+    expect(() => readTurnCheckpoint(malformed)).toThrowError(
+      expect.objectContaining<DurableCheckpointReadError>({
+        code: "checkpoint_shape_invalid",
+      }),
+    );
+  });
+
   it("strictly dispatches legacy and v2 checkpoints and rejects unknown versions", () => {
     const legacy = legacyCheckpoint("a".repeat(64));
     expect(readTurnCheckpoint(legacy)).toMatchObject({ version: 1 });
-    expect(readTurnCheckpoint({ ...legacy, checkpointVersion: 1 })).toMatchObject({
+    expect(
+      readTurnCheckpoint({ ...legacy, checkpointVersion: 1 }),
+    ).toMatchObject({
       version: 1,
     });
     expect(
@@ -246,9 +277,7 @@ describe("legacy durable checkpoint upgrade planner", () => {
       loadFixture("legacy-v1-tool-result-a.jsonl"),
     );
     const omegaSource = deepFreeze(
-      loadFixture(
-        "legacy-v1-tool-result-body-substitution.jsonl",
-      ),
+      loadFixture("legacy-v1-tool-result-body-substitution.jsonl"),
     );
     const alphaBefore = JSON.stringify(alphaSource);
     const omegaBefore = JSON.stringify(omegaSource);
@@ -436,7 +465,8 @@ describe("legacy durable checkpoint upgrade planner", () => {
   it("refuses a legacy checkpoint whose tool result precedes its call", () => {
     const source = loadFixture("legacy-v1-tool-result-a.jsonl");
     const assistantIndex = source.findIndex(
-      (item) => item.type === "response_item" && item.payload.role === "assistant",
+      (item) =>
+        item.type === "response_item" && item.payload.role === "assistant",
     );
     const toolIndex = source.findIndex(
       (item) => item.type === "response_item" && item.payload.role === "tool",
@@ -495,9 +525,7 @@ describe("legacy durable checkpoint upgrade planner", () => {
 
   it("leaves the legacy prefix hash behavior untouched for the A3b cutover", () => {
     const alpha = loadFixture("legacy-v1-tool-result-a.jsonl");
-    const omega = loadFixture(
-      "legacy-v1-tool-result-body-substitution.jsonl",
-    );
+    const omega = loadFixture("legacy-v1-tool-result-body-substitution.jsonl");
     const alphaCheckpoint = alpha.find(
       (item) =>
         item.type === "event_msg" &&
@@ -509,21 +537,26 @@ describe("legacy durable checkpoint upgrade planner", () => {
         item.payload.msg.type === "turn_checkpoint",
     );
 
-    expect(alphaCheckpoint).toEqual(expect.objectContaining({
-      payload: expect.objectContaining({
-        msg: expect.objectContaining({
-          payload: expect.objectContaining({
-            prefixHash:
-              "68cb16728e869cd1b8392c333db38adf714d4eaaf1969e4e25617ecf634326ae",
+    expect(alphaCheckpoint).toEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              prefixHash:
+                "68cb16728e869cd1b8392c333db38adf714d4eaaf1969e4e25617ecf634326ae",
+            }),
           }),
         }),
       }),
-    }));
+    );
     expect(omegaCheckpoint).toEqual(alphaCheckpoint);
   });
 });
 
-function upgradedFixture(filename: string, projectionId: string): RolloutItem[] {
+function upgradedFixture(
+  filename: string,
+  projectionId: string,
+): RolloutItem[] {
   const outcome = planLegacyDurableCheckpointUpgrade({
     items: loadFixture(filename),
     runId: "checkpoint-pair-v1",
@@ -545,13 +578,17 @@ function loadFixture(filename: string): RolloutItem[] {
     .filter((item): item is RolloutItem => item !== null);
 }
 
-function responseHistory(items: ReadonlyArray<RolloutItem>): ResponseItem[] {
+function responseHistory(
+  items: ReadonlyArray<RolloutItem>,
+): ToolResultIntegrityResponseItem[] {
   return items.flatMap((item) =>
     item.type === "response_item" ? [item.payload] : [],
   );
 }
 
-function v2Checkpoint(items: ReadonlyArray<RolloutItem>): TurnCheckpointV2Event {
+function v2Checkpoint(
+  items: ReadonlyArray<RolloutItem>,
+): TurnCheckpointV2Event {
   for (const item of items) {
     if (
       item.type === "event_msg" &&

--- a/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
+++ b/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
@@ -13,8 +13,10 @@ import {
   MAX_CHECKPOINT_UPGRADE_PREFIX_WORK,
   planLegacyDurableCheckpointUpgrade,
 } from "../../src/session/durable-checkpoint-upgrade.js";
+import { computePrefixHash } from "../../src/session/durable-turns.js";
 import {
   ROLLOUT_SCHEMA_VERSION,
+  type TurnCheckpointEvent,
   type TurnCheckpointV2Event,
 } from "../../src/session/event-log.js";
 import {
@@ -706,6 +708,56 @@ describe("legacy durable checkpoint upgrade planner", () => {
     },
   );
 
+  it("preserves rollback history semantics without reducing every response", () => {
+    const survivingHistory: ToolResultIntegrityResponseItem[] = [
+      { role: "user", content: "first request" },
+      { role: "assistant", content: "first answer" },
+      { role: "user", content: "replacement request" },
+    ];
+    const checkpoint = readTurnCheckpoint({
+      ...legacyCheckpoint(
+        computePrefixHash(survivingHistory, survivingHistory.length),
+      ),
+      persistedMessageCount: survivingHistory.length,
+    });
+    if (checkpoint.version !== 1) throw new Error("checkpoint is not legacy");
+    const items: RolloutItem[] = [
+      { type: "response_item", payload: survivingHistory[0]! },
+      { type: "response_item", payload: survivingHistory[1]! },
+      {
+        type: "response_item",
+        payload: { role: "user", content: "rolled-back request" },
+      },
+      {
+        type: "response_item",
+        payload: { role: "assistant", content: "rolled-back answer" },
+      },
+      {
+        type: "event_msg",
+        payload: {
+          id: "rollback-event",
+          seq: 1,
+          msg: { type: "thread_rolled_back", payload: { numTurns: 1 } },
+        },
+      },
+      { type: "response_item", payload: survivingHistory[2]! },
+      checkpointItem(checkpoint.checkpoint),
+    ];
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items,
+        runId: "rollback-run",
+        projection,
+        projectionId: "plan-rollback-history",
+        sourceKey: "rollback-history",
+      }),
+    ).toMatchObject({
+      status: "planned",
+      plan: { checkpointsUpgraded: 1, checkpointsValidated: 1 },
+    });
+  });
+
   it("defers repeated checkpoints at the aggregate prefix-work bound", () => {
     const firstMessage: ToolResultIntegrityResponseItem = {
       role: "user",
@@ -868,7 +920,7 @@ function checkpointForHistory(
   return readable.checkpoint;
 }
 
-function checkpointItem(checkpoint: TurnCheckpointV2Event): RolloutItem {
+function checkpointItem(checkpoint: TurnCheckpointEvent): RolloutItem {
   return {
     type: "event_msg",
     payload: {

--- a/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
+++ b/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
@@ -4,11 +4,15 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  computeCheckpointPrefixHashV2,
   DurableCheckpointReadError,
   readTurnCheckpoint,
   validateCheckpointPrefixV2,
 } from "../../src/session/durable-checkpoint-reader.js";
-import { planLegacyDurableCheckpointUpgrade } from "../../src/session/durable-checkpoint-upgrade.js";
+import {
+  MAX_CHECKPOINT_UPGRADE_PREFIX_WORK,
+  planLegacyDurableCheckpointUpgrade,
+} from "../../src/session/durable-checkpoint-upgrade.js";
 import {
   ROLLOUT_SCHEMA_VERSION,
   type TurnCheckpointV2Event,
@@ -138,6 +142,24 @@ describe("durable checkpoint v2 reader", () => {
     ).toThrowError(/unversioned fields/);
   });
 
+  it("rejects checkpoint sequence zero for every readable version", () => {
+    const legacy = { ...legacyCheckpoint("a".repeat(64)), checkpointSeq: 0 };
+    const explicitV1 = { ...legacy, checkpointVersion: 1 };
+    const v2 = {
+      ...legacy,
+      checkpointVersion: 2,
+      toolResultIntegrityVersion: 1,
+    };
+
+    for (const checkpoint of [legacy, explicitV1, v2]) {
+      expect(() => readTurnCheckpoint(checkpoint)).toThrowError(
+        expect.objectContaining<DurableCheckpointReadError>({
+          code: "checkpoint_shape_invalid",
+        }),
+      );
+    }
+  });
+
   it("authenticates an upgraded prefix and rejects body substitution", () => {
     const upgraded = upgradedFixture(
       "legacy-v1-tool-result-a.jsonl",
@@ -148,6 +170,7 @@ describe("durable checkpoint v2 reader", () => {
     expect(
       validateCheckpointPrefixV2({
         checkpoint,
+        expectedRunId: "checkpoint-pair-v1",
         messages: history,
         projection,
         projectionId: "validate-alpha",
@@ -161,6 +184,7 @@ describe("durable checkpoint v2 reader", () => {
     expect(
       validateCheckpointPrefixV2({
         checkpoint,
+        expectedRunId: "checkpoint-pair-v1",
         messages: substituted,
         projection,
         projectionId: "validate-substitution",
@@ -183,6 +207,7 @@ describe("durable checkpoint v2 reader", () => {
     expect(
       validateCheckpointPrefixV2({
         checkpoint: v2Checkpoint(upgraded),
+        expectedRunId: "checkpoint-pair-v1",
         messages: responseHistory(upgraded),
         projection,
         projectionId: "validate-bounded",
@@ -208,6 +233,7 @@ describe("durable checkpoint v2 reader", () => {
     expect(
       validateCheckpointPrefixV2({
         checkpoint: v2Checkpoint(upgraded),
+        expectedRunId: "checkpoint-pair-v1",
         messages: malformed as unknown as ResponseItem[],
         projection,
         projectionId: "validate-malformed-response",
@@ -231,6 +257,7 @@ describe("durable checkpoint v2 reader", () => {
     expect(
       validateCheckpointPrefixV2({
         checkpoint: v2Checkpoint(upgraded),
+        expectedRunId: "checkpoint-pair-v1",
         messages: withResponseExtension as ResponseItem[],
         projection,
         projectionId: "validate-unversioned-response",
@@ -255,6 +282,7 @@ describe("durable checkpoint v2 reader", () => {
     expect(
       validateCheckpointPrefixV2({
         checkpoint: v2Checkpoint(upgraded),
+        expectedRunId: "checkpoint-pair-v1",
         messages: withCallExtension as ResponseItem[],
         projection,
         projectionId: "validate-unversioned-call",
@@ -263,6 +291,98 @@ describe("durable checkpoint v2 reader", () => {
     ).toMatchObject({
       status: "invalid",
       failure: { code: "checkpoint_response_shape_invalid" },
+    });
+  });
+
+  it("rejects UTF-8 replacement aliases in a v2 checkpoint prefix", () => {
+    const replacementHistory: ToolResultIntegrityResponseItem[] = [
+      { role: "user", content: "\ufffd" },
+    ];
+    const checkpoint = checkpointForHistory(replacementHistory);
+
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint,
+        expectedRunId: "unicode-run",
+        messages: replacementHistory,
+        projection,
+        projectionId: "validate-unicode-replacement",
+        sourceKey: "unicode-replacement",
+      }),
+    ).toMatchObject({ status: "valid" });
+
+    for (const malformed of ["\ud800", "\udc00"]) {
+      expect(() =>
+        computeCheckpointPrefixHashV2(
+          [{ role: "user", content: malformed }],
+          1,
+        ),
+      ).toThrowError(
+        expect.objectContaining({ code: "unsupported_body_value" }),
+      );
+      expect(
+        validateCheckpointPrefixV2({
+          checkpoint,
+          expectedRunId: "unicode-run",
+          messages: [{ role: "user", content: malformed }],
+          projection,
+          projectionId: `validate-unicode-${malformed.charCodeAt(0)}`,
+          sourceKey: "unicode-malformed",
+        }),
+      ).toMatchObject({
+        status: "invalid",
+        failure: {
+          code: "checkpoint_prefix_body_invalid",
+          cause: { code: "unsupported_body_value" },
+        },
+      });
+    }
+  });
+
+  it("binds a wholly cross-run v2 prefix to its expected durable run", () => {
+    const history = toolPairHistory([
+      { callId: "cross-run-call", integrityRunId: "another-run" },
+    ]);
+
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: checkpointForHistory(history),
+        expectedRunId: "owning-run",
+        messages: history,
+        projection,
+        projectionId: "validate-cross-run-prefix",
+        sourceKey: "cross-run-prefix",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "tool_result_integrity_invalid",
+        cause: { code: "run_id_mismatch" },
+      },
+    });
+  });
+
+  it("rejects mixed integrity run IDs inside one v2 prefix", () => {
+    const history = toolPairHistory([
+      { callId: "owning-call", integrityRunId: "owning-run" },
+      { callId: "foreign-call", integrityRunId: "another-run" },
+    ]);
+
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: checkpointForHistory(history),
+        expectedRunId: "owning-run",
+        messages: history,
+        projection,
+        projectionId: "validate-mixed-run-prefix",
+        sourceKey: "mixed-run-prefix",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "tool_result_integrity_invalid",
+        cause: { code: "run_id_mismatch" },
+      },
     });
   });
 });
@@ -523,6 +643,139 @@ describe("legacy durable checkpoint upgrade planner", () => {
     });
   });
 
+  it("rejects non-finite tool results before they can be persisted", () => {
+    for (const content of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      expect(
+        planLegacyDurableCheckpointUpgrade({
+          items: [
+            {
+              type: "response_item",
+              payload: {
+                role: "tool",
+                toolCallId: "non-finite-call",
+                content,
+              },
+            },
+          ],
+          runId: "non-finite-run",
+          projection,
+          projectionId: "plan-non-finite",
+          sourceKey: "non-finite",
+        }),
+      ).toMatchObject({
+        status: "invalid",
+        failure: {
+          code: "tool_result_integrity_invalid",
+          cause: { code: "unsupported_body_value" },
+        },
+      });
+    }
+  });
+
+  it(
+    "accumulates large response histories in linear time",
+    { timeout: 5_000 },
+    () => {
+      const responseCount = 50_000;
+      const items: RolloutItem[] = Array.from(
+        { length: responseCount },
+        (_, index) => ({
+          type: "response_item" as const,
+          payload: { role: "user" as const, content: `message-${index}` },
+        }),
+      );
+
+      const outcome = planLegacyDurableCheckpointUpgrade({
+        items,
+        runId: "linear-history-run",
+        projection,
+        projectionId: "plan-linear-history",
+        sourceKey: "linear-history",
+      });
+
+      expect(outcome).toMatchObject({
+        status: "planned",
+        plan: {
+          upgradedItems: expect.objectContaining({ length: responseCount }),
+        },
+      });
+    },
+  );
+
+  it("defers repeated checkpoints at the aggregate prefix-work bound", () => {
+    const firstMessage: ToolResultIntegrityResponseItem = {
+      role: "user",
+      content: "first",
+    };
+    const secondMessage: ToolResultIntegrityResponseItem = {
+      role: "assistant",
+      content: "second",
+    };
+    const firstHistory = [firstMessage];
+    const secondHistory = [firstMessage, secondMessage];
+    const items: RolloutItem[] = [
+      {
+        type: "session_meta",
+        payload: {
+          sessionId: "aggregate-run",
+          timestamp: "2026-08-01T00:00:00.000Z",
+          cwd: "/workspace",
+          originator: "test",
+          agencVersion: "0.13.0",
+          rolloutSchemaVersion: 2,
+        },
+      },
+      { type: "response_item", payload: firstMessage },
+      checkpointItem(checkpointForHistory(firstHistory)),
+      { type: "response_item", payload: secondMessage },
+      checkpointItem(checkpointForHistory(secondHistory)),
+    ];
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items,
+        runId: "aggregate-run",
+        projection,
+        projectionId: "plan-aggregate-bound",
+        sourceKey: "aggregate-bound",
+        maxCheckpointPrefixWork: 3,
+      }),
+    ).toMatchObject({
+      status: "deferred",
+      failure: {
+        code: "checkpoint_prefix_work_limit",
+        itemIndex: 4,
+      },
+    });
+  });
+
+  it("does not allow callers to disable or widen the prefix-work bound", () => {
+    const base = {
+      items: [] as RolloutItem[],
+      runId: "bounded-run",
+      projection,
+      projectionId: "plan-invalid-bound",
+      sourceKey: "invalid-bound",
+    };
+
+    expect(() =>
+      planLegacyDurableCheckpointUpgrade({
+        ...base,
+        maxCheckpointPrefixWork: 0,
+      }),
+    ).toThrowError(/positive safe integer/);
+    expect(() =>
+      planLegacyDurableCheckpointUpgrade({
+        ...base,
+        maxCheckpointPrefixWork: MAX_CHECKPOINT_UPGRADE_PREFIX_WORK + 1,
+      }),
+    ).toThrowError(/no greater than/);
+  });
+
   it("leaves the legacy prefix hash behavior untouched for the A3b cutover", () => {
     const alpha = loadFixture("legacy-v1-tool-result-a.jsonl");
     const omega = loadFixture("legacy-v1-tool-result-body-substitution.jsonl");
@@ -600,6 +853,60 @@ function v2Checkpoint(
     }
   }
   throw new Error("checkpoint is missing");
+}
+
+function checkpointForHistory(
+  history: ReadonlyArray<ToolResultIntegrityResponseItem>,
+): TurnCheckpointV2Event {
+  const readable = readTurnCheckpoint({
+    ...legacyCheckpoint(computeCheckpointPrefixHashV2(history, history.length)),
+    checkpointVersion: 2,
+    toolResultIntegrityVersion: 1,
+    persistedMessageCount: history.length,
+  });
+  if (readable.version !== 2) throw new Error("checkpoint is not v2");
+  return readable.checkpoint;
+}
+
+function checkpointItem(checkpoint: TurnCheckpointV2Event): RolloutItem {
+  return {
+    type: "event_msg",
+    payload: {
+      eventId: `checkpoint:${checkpoint.checkpointSeq}`,
+      id: "checkpoint-event",
+      seq: checkpoint.checkpointSeq,
+      msg: { type: "turn_checkpoint", payload: checkpoint },
+    },
+  };
+}
+
+function toolPairHistory(
+  calls: ReadonlyArray<{
+    readonly callId: string;
+    readonly integrityRunId: string;
+  }>,
+): ToolResultIntegrityResponseItem[] {
+  return [
+    {
+      role: "assistant",
+      content: "",
+      toolCalls: calls.map(({ callId }) => ({
+        id: callId,
+        name: "read",
+      })),
+    },
+    ...calls.map(({ callId, integrityRunId }) => ({
+      role: "tool" as const,
+      content: `result-${callId}`,
+      toolCallId: callId,
+      toolName: "read",
+      toolResultIntegrity: createToolResultIntegrity({
+        runId: integrityRunId,
+        toolCallId: callId,
+        content: `result-${callId}`,
+      }),
+    })),
+  ];
 }
 
 function legacyCheckpoint(prefixHash: string): Record<string, unknown> {

--- a/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
+++ b/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -10,7 +11,7 @@ import {
   validateCheckpointPrefixV2,
 } from "../../src/session/durable-checkpoint-reader.js";
 import {
-  MAX_CHECKPOINT_UPGRADE_PREFIX_WORK,
+  MAX_CHECKPOINT_UPGRADE_HISTORY_WORK,
   planLegacyDurableCheckpointUpgrade,
 } from "../../src/session/durable-checkpoint-upgrade.js";
 import { computePrefixHash } from "../../src/session/durable-turns.js";
@@ -758,7 +759,128 @@ describe("legacy durable checkpoint upgrade planner", () => {
     });
   });
 
-  it("defers repeated checkpoints at the aggregate prefix-work bound", () => {
+  it.each([
+    { numTurns: -1 },
+    { numTurns: 0.5 },
+    { numTurns: Number.NaN },
+    { numTurns: Number.POSITIVE_INFINITY },
+    { numTurns: Number.MAX_SAFE_INTEGER + 1 },
+    {},
+    null,
+  ])("rejects an invalid rollback payload %#", (payload) => {
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items: [rollbackItem(payload)],
+        runId: "invalid-rollback-run",
+        projection,
+        projectionId: "plan-invalid-rollback",
+        sourceKey: "invalid-rollback",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "rollback_invalid", itemIndex: 0 },
+    });
+  });
+
+  it(
+    "keeps repeated zero-turn rollbacks constant-time in history size",
+    { timeout: 2_000 },
+    () => {
+      const historyLength = 50_000;
+      const rollbackCount = 50_000;
+      const items: RolloutItem[] = [
+        ...Array.from({ length: historyLength }, () => ({
+          type: "response_item" as const,
+          payload: { role: "assistant" as const, content: "history" },
+        })),
+        ...Array.from({ length: rollbackCount }, (_, index) =>
+          rollbackItem({ numTurns: 0 }, index + 1),
+        ),
+      ];
+
+      const startedAt = performance.now();
+      const outcome = planLegacyDurableCheckpointUpgrade({
+        items,
+        runId: "zero-rollback-run",
+        projection,
+        projectionId: "plan-zero-rollback-scaling",
+        sourceKey: "zero-rollback-scaling",
+        maxHistoryDerivationWork: 1,
+      });
+      const elapsedMs = performance.now() - startedAt;
+
+      expect(outcome).toMatchObject({
+        status: "planned",
+        plan: {
+          upgradedItems: expect.objectContaining({
+            length: historyLength + rollbackCount,
+          }),
+        },
+      });
+      expect(elapsedMs).toBeLessThan(1_000);
+    },
+  );
+
+  it("charges repeated one-turn rollback scans to one aggregate bound", () => {
+    const items: RolloutItem[] = [
+      ...["first", "second", "third"].map((content) => ({
+        type: "response_item" as const,
+        payload: { role: "user" as const, content },
+      })),
+      rollbackItem({ numTurns: 1 }, 1),
+      rollbackItem({ numTurns: 1 }, 2),
+    ];
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items,
+        runId: "bounded-rollback-run",
+        projection,
+        projectionId: "plan-bounded-rollbacks",
+        sourceKey: "bounded-rollbacks",
+        // The first 3-row rollback reserves 9 visits. The second would
+        // reserve another 6 after trimming and must be rejected before work.
+        maxHistoryDerivationWork: 14,
+      }),
+    ).toMatchObject({
+      status: "deferred",
+      failure: {
+        code: "history_derivation_work_limit",
+        itemIndex: 4,
+        reason: expect.stringContaining("rollback history derivation"),
+      },
+    });
+  });
+
+  it("bounds repeated rollbacks when history has no user boundary", () => {
+    const items: RolloutItem[] = [
+      {
+        type: "response_item",
+        payload: { role: "assistant", content: "unchanged" },
+      },
+      rollbackItem({ numTurns: 1 }, 1),
+      rollbackItem({ numTurns: 1 }, 2),
+    ];
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items,
+        runId: "no-boundary-rollback-run",
+        projection,
+        projectionId: "plan-no-boundary-rollbacks",
+        sourceKey: "no-boundary-rollbacks",
+        maxHistoryDerivationWork: 5,
+      }),
+    ).toMatchObject({
+      status: "deferred",
+      failure: {
+        code: "history_derivation_work_limit",
+        itemIndex: 2,
+      },
+    });
+  });
+
+  it("defers repeated checkpoints at the aggregate history-work bound", () => {
     const firstMessage: ToolResultIntegrityResponseItem = {
       role: "user",
       content: "first",
@@ -794,18 +916,18 @@ describe("legacy durable checkpoint upgrade planner", () => {
         projection,
         projectionId: "plan-aggregate-bound",
         sourceKey: "aggregate-bound",
-        maxCheckpointPrefixWork: 3,
+        maxHistoryDerivationWork: 3,
       }),
     ).toMatchObject({
       status: "deferred",
       failure: {
-        code: "checkpoint_prefix_work_limit",
+        code: "history_derivation_work_limit",
         itemIndex: 4,
       },
     });
   });
 
-  it("does not allow callers to disable or widen the prefix-work bound", () => {
+  it("does not allow callers to disable or widen the history-work bound", () => {
     const base = {
       items: [] as RolloutItem[],
       runId: "bounded-run",
@@ -817,13 +939,13 @@ describe("legacy durable checkpoint upgrade planner", () => {
     expect(() =>
       planLegacyDurableCheckpointUpgrade({
         ...base,
-        maxCheckpointPrefixWork: 0,
+        maxHistoryDerivationWork: 0,
       }),
     ).toThrowError(/positive safe integer/);
     expect(() =>
       planLegacyDurableCheckpointUpgrade({
         ...base,
-        maxCheckpointPrefixWork: MAX_CHECKPOINT_UPGRADE_PREFIX_WORK + 1,
+        maxHistoryDerivationWork: MAX_CHECKPOINT_UPGRADE_HISTORY_WORK + 1,
       }),
     ).toThrowError(/no greater than/);
   });
@@ -930,6 +1052,17 @@ function checkpointItem(checkpoint: TurnCheckpointEvent): RolloutItem {
       msg: { type: "turn_checkpoint", payload: checkpoint },
     },
   };
+}
+
+function rollbackItem(payload: unknown, seq = 1): RolloutItem {
+  return {
+    type: "event_msg",
+    payload: {
+      id: `rollback-event:${seq}`,
+      seq,
+      msg: { type: "thread_rolled_back", payload },
+    },
+  } as RolloutItem;
 }
 
 function toolPairHistory(

--- a/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
+++ b/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
@@ -1,0 +1,592 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DurableCheckpointReadError,
+  readTurnCheckpoint,
+  validateCheckpointPrefixV2,
+} from "../../src/session/durable-checkpoint-reader.js";
+import { planLegacyDurableCheckpointUpgrade } from "../../src/session/durable-checkpoint-upgrade.js";
+import {
+  ROLLOUT_SCHEMA_VERSION,
+  type TurnCheckpointV2Event,
+} from "../../src/session/event-log.js";
+import {
+  parseRolloutLine,
+  type ResponseItem,
+  type RolloutItem,
+} from "../../src/session/rollout-item.js";
+import {
+  createToolResultIntegrity,
+} from "../../src/session/tool-result-integrity.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+import { StateToolPairProjection } from "../../src/state/tool-pair-projection.js";
+
+const FIXTURE_ROOT = fileURLToPath(
+  new URL("../fnd/fixtures/checkpoints/", import.meta.url),
+);
+
+let agencHome: string;
+let cwd: string;
+let driver: StateSqliteDriver;
+let projection: StateToolPairProjection;
+
+beforeEach(() => {
+  agencHome = mkdtempSync(join(tmpdir(), "agenc-checkpoint-reader-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-checkpoint-reader-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome });
+  projection = new StateToolPairProjection(driver);
+});
+
+afterEach(() => {
+  driver.close();
+  rmSync(agencHome, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("durable checkpoint v2 reader", () => {
+  it("strictly dispatches legacy and v2 checkpoints and rejects unknown versions", () => {
+    const legacy = legacyCheckpoint("a".repeat(64));
+    expect(readTurnCheckpoint(legacy)).toMatchObject({ version: 1 });
+    expect(readTurnCheckpoint({ ...legacy, checkpointVersion: 1 })).toMatchObject({
+      version: 1,
+    });
+    expect(
+      readTurnCheckpoint({
+        ...legacy,
+        checkpointVersion: 2,
+        toolResultIntegrityVersion: 1,
+      }),
+    ).toMatchObject({ version: 2 });
+    expect(() =>
+      readTurnCheckpoint({ ...legacy, checkpointVersion: 3 }),
+    ).toThrowError(
+      expect.objectContaining<DurableCheckpointReadError>({
+        code: "checkpoint_version_unsupported",
+        kind: "integrity_failure",
+      }),
+    );
+    expect(() =>
+      readTurnCheckpoint({ ...legacy, checkpointVersion: 2 }),
+    ).toThrowError(
+      expect.objectContaining<DurableCheckpointReadError>({
+        code: "checkpoint_shape_invalid",
+      }),
+    );
+    expect(() =>
+      readTurnCheckpoint({
+        ...legacy,
+        checkpointVersion: 1,
+        toolResultIntegrityVersion: 1,
+      }),
+    ).toThrowError(
+      expect.objectContaining<DurableCheckpointReadError>({
+        code: "checkpoint_shape_invalid",
+      }),
+    );
+    expect(() =>
+      readTurnCheckpoint({ ...legacy, prefixHash: "not-a-digest" }),
+    ).toThrowError(
+      expect.objectContaining<DurableCheckpointReadError>({
+        code: "checkpoint_shape_invalid",
+      }),
+    );
+    expect(() =>
+      readTurnCheckpoint({ ...legacy, unversionedField: true }),
+    ).toThrowError(/unversioned fields/);
+  });
+
+  it("authenticates an upgraded prefix and rejects body substitution", () => {
+    const upgraded = upgradedFixture(
+      "legacy-v1-tool-result-a.jsonl",
+      "upgrade-alpha",
+    );
+    const history = responseHistory(upgraded);
+    const checkpoint = v2Checkpoint(upgraded);
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint,
+        messages: history,
+        projection,
+        projectionId: "validate-alpha",
+        sourceKey: "fixture-alpha",
+      }),
+    ).toMatchObject({ status: "valid" });
+
+    const substituted = history.map((message) =>
+      message.role === "tool" ? { ...message, content: "omega" } : message,
+    );
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint,
+        messages: substituted,
+        projection,
+        projectionId: "validate-substitution",
+        sourceKey: "fixture-alpha-substituted",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "tool_result_integrity_invalid",
+        cause: { code: "persisted_body_digest_mismatch" },
+      },
+    });
+  });
+
+  it("returns an operational deferral when a prefix exceeds its reader bound", () => {
+    const upgraded = upgradedFixture(
+      "legacy-v1-tool-result-a.jsonl",
+      "upgrade-bounded",
+    );
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: v2Checkpoint(upgraded),
+        messages: responseHistory(upgraded),
+        projection,
+        projectionId: "validate-bounded",
+        sourceKey: "fixture-bounded",
+        maxPrefixMessages: 2,
+      }),
+    ).toMatchObject({
+      status: "deferred",
+      failure: { code: "checkpoint_prefix_message_limit" },
+    });
+  });
+
+  it("fails malformed response shapes closed before canonical hashing", () => {
+    const upgraded = upgradedFixture(
+      "legacy-v1-tool-result-a.jsonl",
+      "upgrade-malformed-response",
+    );
+    const malformed = responseHistory(upgraded) as unknown as Array<
+      Record<string, unknown>
+    >;
+    malformed[0] = { role: 42, content: "invalid" };
+
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: v2Checkpoint(upgraded),
+        messages: malformed as unknown as ResponseItem[],
+        projection,
+        projectionId: "validate-malformed-response",
+        sourceKey: "fixture-malformed-response",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "checkpoint_response_shape_invalid" },
+    });
+  });
+
+  it("rejects unversioned response and tool-call fields", () => {
+    const upgraded = upgradedFixture(
+      "legacy-v1-tool-result-a.jsonl",
+      "upgrade-unversioned-response",
+    );
+    const history = responseHistory(upgraded);
+    const withResponseExtension = history.map((message, index) =>
+      index === 0 ? { ...message, futureField: true } : message,
+    );
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: v2Checkpoint(upgraded),
+        messages: withResponseExtension as ResponseItem[],
+        projection,
+        projectionId: "validate-unversioned-response",
+        sourceKey: "fixture-unversioned-response",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "checkpoint_response_shape_invalid" },
+    });
+
+    const withCallExtension = history.map((message) =>
+      message.role === "assistant" && message.toolCalls !== undefined
+        ? {
+            ...message,
+            toolCalls: message.toolCalls.map((call) => ({
+              ...call,
+              futureField: true,
+            })),
+          }
+        : message,
+    );
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: v2Checkpoint(upgraded),
+        messages: withCallExtension as ResponseItem[],
+        projection,
+        projectionId: "validate-unversioned-call",
+        sourceKey: "fixture-unversioned-call",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "checkpoint_response_shape_invalid" },
+    });
+  });
+});
+
+describe("legacy durable checkpoint upgrade planner", () => {
+  it("keeps the live rollout writer on v1 until the A3b cutover", () => {
+    expect(ROLLOUT_SCHEMA_VERSION).toBe(1);
+  });
+
+  it("makes equal-length fixture substitutions produce distinct v2 identities", () => {
+    const alphaSource = deepFreeze(
+      loadFixture("legacy-v1-tool-result-a.jsonl"),
+    );
+    const omegaSource = deepFreeze(
+      loadFixture(
+        "legacy-v1-tool-result-body-substitution.jsonl",
+      ),
+    );
+    const alphaBefore = JSON.stringify(alphaSource);
+    const omegaBefore = JSON.stringify(omegaSource);
+
+    const alpha = planLegacyDurableCheckpointUpgrade({
+      items: alphaSource,
+      runId: "checkpoint-pair-v1",
+      projection,
+      projectionId: "plan-alpha",
+      sourceKey: "fixture-alpha",
+    });
+    const omega = planLegacyDurableCheckpointUpgrade({
+      items: omegaSource,
+      runId: "checkpoint-pair-v1",
+      projection,
+      projectionId: "plan-omega",
+      sourceKey: "fixture-omega",
+    });
+    if (alpha.status !== "planned" || omega.status !== "planned") {
+      throw new Error("fixture upgrade unexpectedly failed");
+    }
+
+    const alphaTool = responseHistory(alpha.plan.upgradedItems).find(
+      (message) => message.role === "tool",
+    );
+    const omegaTool = responseHistory(omega.plan.upgradedItems).find(
+      (message) => message.role === "tool",
+    );
+    expect(alphaTool?.toolResultIntegrity?.original.digest).not.toBe(
+      omegaTool?.toolResultIntegrity?.original.digest,
+    );
+    expect(v2Checkpoint(alpha.plan.upgradedItems).prefixHash).not.toBe(
+      v2Checkpoint(omega.plan.upgradedItems).prefixHash,
+    );
+    expect(alpha.plan).toMatchObject({
+      changed: true,
+      toolResultsSealed: 1,
+      checkpointsUpgraded: 1,
+      checkpointsValidated: 1,
+      sessionMetaPromotionRequired: true,
+    });
+    expect(JSON.stringify(alphaSource)).toBe(alphaBefore);
+    expect(JSON.stringify(omegaSource)).toBe(omegaBefore);
+  });
+
+  it("is deterministic, non-mutating, and idempotent over planned output", () => {
+    const source = deepFreeze(loadFixture("legacy-v1-tool-result-a.jsonl"));
+    const first = planLegacyDurableCheckpointUpgrade({
+      items: source,
+      runId: "checkpoint-pair-v1",
+      projection,
+      projectionId: "plan-first",
+      sourceKey: "fixture-first",
+    });
+    if (first.status !== "planned") throw new Error("first plan failed");
+    const second = planLegacyDurableCheckpointUpgrade({
+      items: first.plan.upgradedItems,
+      runId: "checkpoint-pair-v1",
+      projection,
+      projectionId: "plan-second",
+      sourceKey: "fixture-first",
+    });
+    if (second.status !== "planned") throw new Error("second plan failed");
+
+    expect(second.plan.changed).toBe(false);
+    expect(second.plan.toolResultsSealed).toBe(0);
+    expect(second.plan.checkpointsUpgraded).toBe(0);
+    expect(second.plan.checkpointsValidated).toBe(1);
+    expect(second.plan.upgradedItems).toEqual(first.plan.upgradedItems);
+  });
+
+  it("promotes schema metadata in the plan without changing the live writer", () => {
+    const source: RolloutItem[] = [
+      {
+        type: "session_meta",
+        payload: {
+          sessionId: "session-1",
+          timestamp: "2026-08-01T00:00:00.000Z",
+          cwd: "/workspace",
+          originator: "test",
+          agencVersion: "0.13.0",
+          rolloutSchemaVersion: 1,
+        },
+      },
+      ...loadFixture("legacy-v1-tool-result-a.jsonl"),
+    ];
+    const planned = planLegacyDurableCheckpointUpgrade({
+      items: source,
+      runId: "checkpoint-pair-v1",
+      projection,
+      projectionId: "plan-meta",
+      sourceKey: "fixture-meta",
+    });
+    if (planned.status !== "planned") throw new Error("metadata plan failed");
+
+    expect(planned.plan.sessionMetaPromotionRequired).toBe(false);
+    expect(planned.plan.upgradedItems[0]).toMatchObject({
+      type: "session_meta",
+      payload: { rolloutSchemaVersion: 2 },
+    });
+    expect(source[0]).toMatchObject({
+      type: "session_meta",
+      payload: { rolloutSchemaVersion: 1 },
+    });
+  });
+
+  it("refuses to bless missing or cross-run integrity in schema-v2 history", () => {
+    const assistant: RolloutItem = {
+      type: "response_item",
+      payload: {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "call-v2", name: "read" }],
+      },
+    };
+    const toolResult: ResponseItem = {
+      role: "tool",
+      content: "alpha",
+      toolCallId: "call-v2",
+      toolName: "read",
+    };
+    const metadata: RolloutItem = {
+      type: "session_meta",
+      payload: {
+        sessionId: "run-v2",
+        timestamp: "2026-08-01T00:00:00.000Z",
+        cwd: "/workspace",
+        originator: "test",
+        agencVersion: "0.13.0",
+        rolloutSchemaVersion: 2,
+      },
+    };
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items: [
+          metadata,
+          assistant,
+          { type: "response_item", payload: toolResult },
+        ],
+        runId: "run-v2",
+        projection,
+        projectionId: "plan-v2-missing-integrity",
+        sourceKey: "fixture-v2-missing-integrity",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "tool_result_integrity_invalid",
+        reason: expect.stringContaining("missing integrity metadata"),
+      },
+    });
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items: [
+          metadata,
+          assistant,
+          {
+            type: "response_item",
+            payload: {
+              ...toolResult,
+              toolResultIntegrity: createToolResultIntegrity({
+                runId: "another-run",
+                toolCallId: "call-v2",
+                content: "alpha",
+              }),
+            },
+          },
+        ],
+        runId: "run-v2",
+        projection,
+        projectionId: "plan-v2-cross-run-integrity",
+        sourceKey: "fixture-v2-cross-run-integrity",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "tool_result_integrity_invalid",
+        cause: { code: "run_id_mismatch" },
+      },
+    });
+  });
+
+  it("refuses a legacy checkpoint whose tool result precedes its call", () => {
+    const source = loadFixture("legacy-v1-tool-result-a.jsonl");
+    const assistantIndex = source.findIndex(
+      (item) => item.type === "response_item" && item.payload.role === "assistant",
+    );
+    const toolIndex = source.findIndex(
+      (item) => item.type === "response_item" && item.payload.role === "tool",
+    );
+    const reordered = [...source];
+    [reordered[assistantIndex], reordered[toolIndex]] = [
+      reordered[toolIndex]!,
+      reordered[assistantIndex]!,
+    ];
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items: reordered,
+        runId: "checkpoint-pair-v1",
+        projection,
+        projectionId: "plan-reordered",
+        sourceKey: "fixture-reordered",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "checkpoint_invalid",
+        cause: { code: "tool_result_without_call" },
+      },
+    });
+  });
+
+  it("refuses to bless a legacy prefix that fails its existing digest gate", () => {
+    const source = loadFixture("legacy-v1-tool-result-a.jsonl");
+    const userIndex = source.findIndex(
+      (item) => item.type === "response_item" && item.payload.role === "user",
+    );
+    const user = source[userIndex];
+    if (user?.type !== "response_item") throw new Error("user fixture missing");
+    source[userIndex] = {
+      ...user,
+      payload: { ...user.payload, content: "tampered instruction" },
+    };
+
+    expect(
+      planLegacyDurableCheckpointUpgrade({
+        items: source,
+        runId: "checkpoint-pair-v1",
+        projection,
+        projectionId: "plan-tampered-legacy-prefix",
+        sourceKey: "fixture-tampered-legacy-prefix",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: {
+        code: "checkpoint_invalid",
+        reason: expect.stringContaining("legacy checkpoint prefix digest"),
+      },
+    });
+  });
+
+  it("leaves the legacy prefix hash behavior untouched for the A3b cutover", () => {
+    const alpha = loadFixture("legacy-v1-tool-result-a.jsonl");
+    const omega = loadFixture(
+      "legacy-v1-tool-result-body-substitution.jsonl",
+    );
+    const alphaCheckpoint = alpha.find(
+      (item) =>
+        item.type === "event_msg" &&
+        item.payload.msg.type === "turn_checkpoint",
+    );
+    const omegaCheckpoint = omega.find(
+      (item) =>
+        item.type === "event_msg" &&
+        item.payload.msg.type === "turn_checkpoint",
+    );
+
+    expect(alphaCheckpoint).toEqual(expect.objectContaining({
+      payload: expect.objectContaining({
+        msg: expect.objectContaining({
+          payload: expect.objectContaining({
+            prefixHash:
+              "68cb16728e869cd1b8392c333db38adf714d4eaaf1969e4e25617ecf634326ae",
+          }),
+        }),
+      }),
+    }));
+    expect(omegaCheckpoint).toEqual(alphaCheckpoint);
+  });
+});
+
+function upgradedFixture(filename: string, projectionId: string): RolloutItem[] {
+  const outcome = planLegacyDurableCheckpointUpgrade({
+    items: loadFixture(filename),
+    runId: "checkpoint-pair-v1",
+    projection,
+    projectionId,
+    sourceKey: filename,
+  });
+  if (outcome.status !== "planned") {
+    throw new Error(`fixture upgrade failed: ${outcome.failure.reason}`);
+  }
+  return [...outcome.plan.upgradedItems];
+}
+
+function loadFixture(filename: string): RolloutItem[] {
+  return readFileSync(join(FIXTURE_ROOT, filename), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => parseRolloutLine(line))
+    .filter((item): item is RolloutItem => item !== null);
+}
+
+function responseHistory(items: ReadonlyArray<RolloutItem>): ResponseItem[] {
+  return items.flatMap((item) =>
+    item.type === "response_item" ? [item.payload] : [],
+  );
+}
+
+function v2Checkpoint(items: ReadonlyArray<RolloutItem>): TurnCheckpointV2Event {
+  for (const item of items) {
+    if (
+      item.type === "event_msg" &&
+      item.payload.msg.type === "turn_checkpoint"
+    ) {
+      const readable = readTurnCheckpoint(item.payload.msg.payload);
+      if (readable.version !== 2) throw new Error("checkpoint is not v2");
+      return readable.checkpoint;
+    }
+  }
+  throw new Error("checkpoint is missing");
+}
+
+function legacyCheckpoint(prefixHash: string): Record<string, unknown> {
+  return {
+    turnId: "turn-1",
+    iterationIndex: 1,
+    boundary: "iteration",
+    checkpointSeq: 1,
+    persistedMessageCount: 0,
+    prefixHash,
+    resumableState: {
+      turnCount: 1,
+      recoveryReentryCount: 0,
+      maxOutputTokensRecoveryCount: 0,
+      continuationNudgeCount: 0,
+      stopHookBlockingCount: 0,
+    },
+  };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object") {
+    Object.freeze(value);
+    for (const nested of Object.values(value)) deepFreeze(nested);
+  }
+  return value;
+}

--- a/runtime/tests/session/tool-result-integrity.test.ts
+++ b/runtime/tests/session/tool-result-integrity.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CANONICAL_BODY_DEPTH,
+  ToolResultCanonicalizationError,
+  createToolResultIntegrity,
+  deterministicToolResultId,
+  digestToolResultBody,
+  verifyToolResultIntegrity,
+  withPersistedToolResultRepresentation,
+} from "../../src/session/tool-result-integrity.js";
+
+describe("tool-result integrity", () => {
+  it("binds equal-length body substitutions to different canonical digests", () => {
+    const alpha = digestToolResultBody("alpha");
+    const omega = digestToolResultBody("omega");
+
+    expect(alpha.byteLength).toBe(5);
+    expect(omega.byteLength).toBe(5);
+    expect(alpha.digest).not.toBe(omega.digest);
+  });
+
+  it("canonicalizes structured JSON independently of object insertion order", () => {
+    const left = Object.freeze({
+      type: "tool_result",
+      nested: Object.freeze({ b: 2, a: 1 }),
+    });
+    const right = {
+      nested: { a: 1, b: 2 },
+      type: "tool_result",
+    };
+
+    expect(digestToolResultBody(left)).toEqual(digestToolResultBody(right));
+    expect(left.nested).toEqual({ b: 2, a: 1 });
+  });
+
+  it("derives result identity from the complete run and call identities", () => {
+    const sharedPrefix = "call-".repeat(700);
+    const left = deterministicToolResultId("run-a", `${sharedPrefix}a`);
+    const right = deterministicToolResultId("run-a", `${sharedPrefix}b`);
+
+    expect(left).not.toBe(right);
+    expect(left).toBe(
+      deterministicToolResultId("run-a", `${sharedPrefix}a`),
+    );
+    expect(left).not.toBe(
+      deterministicToolResultId("run-b", `${sharedPrefix}a`),
+    );
+  });
+
+  it("rejects persisted body substitution without exposing the body", () => {
+    const integrity = createToolResultIntegrity({
+      runId: "run-1",
+      toolCallId: "call-1",
+      content: "alpha-secret-body",
+    });
+    const verified = verifyToolResultIntegrity({
+      integrity,
+      toolCallId: "call-1",
+      content: "omega-secret-body",
+    });
+
+    expect(verified).toMatchObject({
+      status: "invalid",
+      failure: { code: "persisted_body_digest_mismatch" },
+    });
+    expect(JSON.stringify(verified)).not.toContain("alpha-secret-body");
+    expect(JSON.stringify(verified)).not.toContain("omega-secret-body");
+  });
+
+  it("rejects substituted run, call, and result identities", () => {
+    const integrity = createToolResultIntegrity({
+      runId: "run-1",
+      toolCallId: "call-1",
+      content: "alpha",
+    });
+
+    expect(
+      verifyToolResultIntegrity({
+        integrity,
+        expectedRunId: "run-2",
+        toolCallId: "call-1",
+        content: "alpha",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "run_id_mismatch" },
+    });
+    expect(
+      verifyToolResultIntegrity({
+        integrity,
+        expectedRunId: "run-1",
+        toolCallId: "call-2",
+        content: "alpha",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_call_id_mismatch" },
+    });
+    expect(
+      verifyToolResultIntegrity({
+        integrity: {
+          ...integrity,
+          resultId: `tool-result:${"0".repeat(64)}`,
+        },
+        expectedRunId: "run-1",
+        toolCallId: "call-1",
+        content: "alpha",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "result_id_mismatch" },
+    });
+  });
+
+  it.each([
+    ["bit flip", "alphb"],
+    ["truncation", "alph"],
+    ["array reorder", ["omega", "alpha"]],
+  ])("detects %s corruption of a persisted body", (_label, corrupted) => {
+    const content = Array.isArray(corrupted)
+      ? ["alpha", "omega"]
+      : "alpha";
+    const integrity = createToolResultIntegrity({
+      runId: "run-corruption",
+      toolCallId: "call-corruption",
+      content,
+    });
+
+    expect(
+      verifyToolResultIntegrity({
+        integrity,
+        toolCallId: "call-corruption",
+        content: corrupted,
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "persisted_body_digest_mismatch" },
+    });
+  });
+
+  it("keeps original identity immutable across a compacted representation", () => {
+    const original = createToolResultIntegrity({
+      runId: "run-1",
+      toolCallId: "call-1",
+      content: "the complete original result",
+    });
+    const compacted = withPersistedToolResultRepresentation(
+      original,
+      "compacted",
+      "[compacted tool result]",
+    );
+
+    expect(compacted.original).toEqual(original.original);
+    expect(compacted.persisted).not.toEqual(original.persisted);
+    expect(
+      verifyToolResultIntegrity({
+        integrity: compacted,
+        toolCallId: "call-1",
+        content: "[compacted tool result]",
+      }),
+    ).toMatchObject({ status: "valid" });
+  });
+
+  it("rejects metadata whose original representation launders its identity", () => {
+    const integrity = createToolResultIntegrity({
+      runId: "run-1",
+      toolCallId: "call-1",
+      content: "alpha",
+    });
+    const laundered = {
+      ...integrity,
+      original: digestToolResultBody("omega"),
+    };
+
+    expect(
+      verifyToolResultIntegrity({
+        integrity: laundered,
+        toolCallId: "call-1",
+        content: "alpha",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "original_representation_mismatch" },
+    });
+  });
+
+  it("rejects unversioned extension fields instead of hashing an ambiguous shape", () => {
+    const integrity = createToolResultIntegrity({
+      runId: "run-1",
+      toolCallId: "call-1",
+      content: "alpha",
+    });
+    expect(
+      verifyToolResultIntegrity({
+        integrity: { ...integrity, unversionedField: true },
+        toolCallId: "call-1",
+        content: "alpha",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "invalid_integrity_metadata" },
+    });
+  });
+
+  it("defers canonicalization beyond the explicit depth bound", () => {
+    let value: unknown = "leaf";
+    for (let depth = 0; depth <= MAX_CANONICAL_BODY_DEPTH; depth += 1) {
+      value = [value];
+    }
+
+    expect(() => digestToolResultBody(value)).toThrowError(
+      expect.objectContaining<ToolResultCanonicalizationError>({
+        kind: "operational_deferral",
+        code: "canonical_body_depth_limit",
+      }),
+    );
+  });
+});

--- a/runtime/tests/session/tool-result-integrity.test.ts
+++ b/runtime/tests/session/tool-result-integrity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   MAX_CANONICAL_BODY_DEPTH,
+  MAX_CANONICAL_BODY_NODES,
   ToolResultCanonicalizationError,
   createToolResultIntegrity,
   deterministicToolResultId,
@@ -33,15 +34,117 @@ describe("tool-result integrity", () => {
     expect(left.nested).toEqual({ b: 2, a: 1 });
   });
 
+  it("rejects ill-formed UTF-16 instead of aliasing it to the replacement character", () => {
+    const replacementCharacter = "\ufffd";
+    const malformedStrings = ["\ud800", "\udc00"];
+
+    expect(digestToolResultBody(replacementCharacter)).toMatchObject({
+      byteLength: 3,
+    });
+    expect(
+      deterministicToolResultId("run-unicode", replacementCharacter),
+    ).toMatch(/^tool-result:[0-9a-f]{64}$/);
+
+    for (const malformed of malformedStrings) {
+      expect(() => digestToolResultBody(malformed)).toThrowError(
+        expect.objectContaining<ToolResultCanonicalizationError>({
+          kind: "integrity_failure",
+          code: "unsupported_body_value",
+        }),
+      );
+      expect(() => digestToolResultBody({ [malformed]: "value" })).toThrowError(
+        expect.objectContaining<ToolResultCanonicalizationError>({
+          code: "unsupported_body_value",
+        }),
+      );
+      expect(() =>
+        deterministicToolResultId("run-unicode", malformed),
+      ).toThrowError(
+        expect.objectContaining<ToolResultCanonicalizationError>({
+          code: "unsupported_body_value",
+        }),
+      );
+    }
+
+    const replacementIntegrity = createToolResultIntegrity({
+      runId: "run-unicode",
+      toolCallId: replacementCharacter,
+      content: "body",
+    });
+    for (const malformed of malformedStrings) {
+      expect(
+        verifyToolResultIntegrity({
+          integrity: {
+            ...replacementIntegrity,
+            toolCallId: malformed,
+          },
+          expectedRunId: "run-unicode",
+          toolCallId: malformed,
+          content: "body",
+        }),
+      ).toMatchObject({
+        status: "invalid",
+        failure: { code: "invalid_integrity_metadata" },
+      });
+    }
+  });
+
+  it("rejects non-finite values instead of aliasing their persisted identity to null", () => {
+    const nullIntegrity = createToolResultIntegrity({
+      runId: "run-number",
+      toolCallId: "call-number",
+      content: null,
+    });
+
+    for (const nonFinite of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      expect(() => digestToolResultBody(nonFinite)).toThrowError(
+        expect.objectContaining<ToolResultCanonicalizationError>({
+          kind: "integrity_failure",
+          code: "unsupported_body_value",
+        }),
+      );
+      expect(
+        verifyToolResultIntegrity({
+          integrity: nullIntegrity,
+          expectedRunId: "run-number",
+          toolCallId: "call-number",
+          content: nonFinite,
+        }),
+      ).toMatchObject({
+        status: "invalid",
+        failure: { code: "unsupported_body_value" },
+      });
+    }
+  });
+
+  it("preflights object width against the remaining canonical node budget", () => {
+    expect(digestToolResultBody({ a: 1, b: 2 }, { maxNodes: 3 })).toEqual(
+      digestToolResultBody({ b: 2, a: 1 }, { maxNodes: 3 }),
+    );
+    expect(() =>
+      digestToolResultBody({ a: 1, b: 2, c: 3 }, { maxNodes: 3 }),
+    ).toThrowError(
+      expect.objectContaining<ToolResultCanonicalizationError>({
+        kind: "operational_deferral",
+        code: "canonical_body_node_limit",
+      }),
+    );
+    expect(() =>
+      digestToolResultBody({}, { maxNodes: MAX_CANONICAL_BODY_NODES + 1 }),
+    ).toThrowError(/maxNodes/);
+  });
+
   it("derives result identity from the complete run and call identities", () => {
     const sharedPrefix = "call-".repeat(700);
     const left = deterministicToolResultId("run-a", `${sharedPrefix}a`);
     const right = deterministicToolResultId("run-a", `${sharedPrefix}b`);
 
     expect(left).not.toBe(right);
-    expect(left).toBe(
-      deterministicToolResultId("run-a", `${sharedPrefix}a`),
-    );
+    expect(left).toBe(deterministicToolResultId("run-a", `${sharedPrefix}a`));
     expect(left).not.toBe(
       deterministicToolResultId("run-b", `${sharedPrefix}a`),
     );
@@ -117,9 +220,7 @@ describe("tool-result integrity", () => {
     ["truncation", "alph"],
     ["array reorder", ["omega", "alpha"]],
   ])("detects %s corruption of a persisted body", (_label, corrupted) => {
-    const content = Array.isArray(corrupted)
-      ? ["alpha", "omega"]
-      : "alpha";
+    const content = Array.isArray(corrupted) ? ["alpha", "omega"] : "alpha";
     const integrity = createToolResultIntegrity({
       runId: "run-corruption",
       toolCallId: "call-corruption",

--- a/runtime/tests/state/execution-admission.test.ts
+++ b/runtime/tests/state/execution-admission.test.ts
@@ -12,6 +12,9 @@ import {
   ExecutionAdmissionRepository,
   NANO_USD_PER_USD,
 } from "../../src/state/execution-admission.js";
+import {
+  TOOL_PAIR_PROJECTION_SCHEMA_VERSION,
+} from "../../src/state/migrations/020_tool_pair_projection_schema.js";
 import { STATE_DB_MIGRATIONS } from "../../src/state/migrations/index.js";
 import { cancelAgentRunTree } from "../../src/state/run-cancellation.js";
 import {
@@ -161,7 +164,7 @@ describe("execution admission schema migration", () => {
         db
           .prepare("SELECT MAX(version) AS version FROM schema_migrations")
           .get(),
-      ).toEqual({ version: 18 });
+      ).toEqual({ version: TOOL_PAIR_PROJECTION_SCHEMA_VERSION });
     } finally {
       db.close();
     }

--- a/runtime/tests/state/migrations.test.ts
+++ b/runtime/tests/state/migrations.test.ts
@@ -8,6 +8,9 @@ import {
   STATE_DB_MIGRATIONS,
   type SqlMigration,
 } from "./migrations/index.js";
+import {
+  TOOL_PAIR_PROJECTION_SCHEMA_VERSION,
+} from "./migrations/020_tool_pair_projection_schema.js";
 import { applyMigrations } from "./sqlite-driver.js";
 import { StateSchemaMismatchError } from "./errors.js";
 
@@ -55,7 +58,7 @@ describe("state migration registry", () => {
 
   it("loads state migrations from numbered migration files in order", () => {
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.version)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20,
     ]);
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.name)).toEqual([
       "initial_state_schema",
@@ -76,6 +79,7 @@ describe("state migration registry", () => {
       "run_effects_session_call_step_index",
       "effect_evidence_v2",
       "run_recovery_schema",
+      "tool_pair_projection_schema",
     ]);
     expectMigrationVersionsAreUnique(STATE_DB_MIGRATIONS);
   });
@@ -112,6 +116,7 @@ describe("state migration registry", () => {
       "016_run_effects_session_call_step_index.ts",
       "017_effect_evidence_v2.ts",
       "018_run_recovery_schema.ts",
+      "020_tool_pair_projection_schema.ts",
     ]);
   });
 
@@ -168,6 +173,63 @@ describe("state migration registry", () => {
           )
           .get(),
       ).toEqual({ name: "run_recovery_quarantine" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("upgrades persisted v18 state to the reserved tool-pair schema v20 additively", () => {
+    const db = new Database(":memory:");
+    try {
+      applyMigrations(
+        db,
+        STATE_DB_MIGRATIONS.filter((migration) => migration.version <= 18),
+      );
+      db.prepare(
+        `INSERT INTO run_lifecycle_epochs (run_id, epoch, opened_at)
+         VALUES ('pre-tool-pair-run', 1, '2026-08-01T00:00:00.000Z')`,
+      ).run();
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'tool_pair_projection_runs'",
+          )
+          .get(),
+      ).toBeUndefined();
+
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+      applyMigrations(db, STATE_DB_MIGRATIONS);
+
+      expect(
+        db
+          .prepare(
+            "SELECT run_id, epoch FROM run_lifecycle_epochs WHERE run_id = 'pre-tool-pair-run'",
+          )
+          .get(),
+      ).toEqual({ run_id: "pre-tool-pair-run", epoch: 1 });
+      expect(
+        db
+          .prepare(
+            "SELECT version, name FROM schema_migrations WHERE version = ?",
+          )
+          .get(TOOL_PAIR_PROJECTION_SCHEMA_VERSION),
+      ).toEqual({
+        version: TOOL_PAIR_PROJECTION_SCHEMA_VERSION,
+        name: "tool_pair_projection_schema",
+      });
+      expect(
+        db
+          .prepare<{ type: string }, { name: string }>(
+            `SELECT name FROM sqlite_master
+             WHERE type = :type AND name LIKE 'tool_pair_projection_%'
+             ORDER BY name`,
+          )
+          .all({ type: "table" })
+          .map((row) => row.name),
+      ).toEqual([
+        "tool_pair_projection_entries",
+        "tool_pair_projection_runs",
+      ]);
     } finally {
       db.close();
     }

--- a/runtime/tests/state/sqlite-driver.test.ts
+++ b/runtime/tests/state/sqlite-driver.test.ts
@@ -11,6 +11,9 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { StateSchemaMismatchError } from "./errors.js";
 import {
+  TOOL_PAIR_PROJECTION_SCHEMA_VERSION,
+} from "./migrations/020_tool_pair_projection_schema.js";
+import {
   applyMigrations,
   openStateDatabases,
   resolveStateDatabasePaths,
@@ -200,7 +203,7 @@ describe("openStateDatabases", () => {
             "SELECT MAX(version) AS version FROM schema_migrations",
           )
           .get()?.version,
-      ).toBe(18);
+      ).toBe(TOOL_PAIR_PROJECTION_SCHEMA_VERSION);
     } finally {
       driver.close();
     }

--- a/runtime/tests/state/tool-pair-projection.test.ts
+++ b/runtime/tests/state/tool-pair-projection.test.ts
@@ -1,0 +1,391 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_OPEN_TOOL_CALLS_PER_RUN,
+  MAX_TOOL_CALL_IDS_PER_RUN,
+  validateToolPairSequence,
+  type ToolPairMessage,
+} from "../../src/session/tool-pair-validator.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+import { StateToolPairProjection } from "../../src/state/tool-pair-projection.js";
+
+let agencHome: string;
+let cwd: string;
+let driver: StateSqliteDriver;
+let projection: StateToolPairProjection;
+
+beforeEach(() => {
+  agencHome = mkdtempSync(join(tmpdir(), "agenc-tool-pair-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-tool-pair-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  driver = openStateDatabases({ cwd, agencHome });
+  projection = new StateToolPairProjection(driver);
+});
+
+afterEach(() => {
+  if (driver.state.open) driver.close();
+  rmSync(agencHome, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function validate(
+  messages: Iterable<ToolPairMessage>,
+  overrides: Partial<Parameters<typeof validateToolPairSequence>[2]> = {},
+) {
+  return validateToolPairSequence(messages, projection, {
+    projectionId: "projection-1",
+    sourceKey: "/rollouts/session.jsonl",
+    ...overrides,
+  });
+}
+
+describe("StateToolPairProjection", () => {
+  it("validates ordered many-call turns and persists exact resolution rows", () => {
+    const outcome = validate([
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "call-a", name: "read" },
+          { id: "call-b", name: "grep" },
+        ],
+      },
+      { role: "tool", content: "b", toolCallId: "call-b", toolName: "grep" },
+      { role: "tool", content: "a", toolCallId: "call-a", toolName: "read" },
+      { role: "assistant", content: "done" },
+    ]);
+
+    expect(outcome).toMatchObject({
+      status: "valid",
+      summary: {
+        callCount: 2,
+        resolvedCount: 2,
+        openCallCount: 0,
+        maximumOpenCallCount: 2,
+      },
+    });
+    expect(projection.find("projection-1", "call-a")).toEqual({
+      callId: "call-a",
+      toolName: "read",
+      assistantIndex: 0,
+      resultIndex: 2,
+    });
+    expect(
+      driver
+        .prepareState<[string], { status: string; call_count: number }>(
+          `SELECT status, call_count
+           FROM tool_pair_projection_runs WHERE projection_id = ?`,
+        )
+        .get("projection-1"),
+    ).toEqual({ status: "valid", call_count: 2 });
+  });
+
+  it("distinguishes duplicate, orphan, unknown, and ordering failures", () => {
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-a", name: "read" }],
+        },
+        { role: "tool", content: "a", toolCallId: "call-a" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-a", name: "read" }],
+        },
+      ]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "assistant_tool_call_id_duplicate" },
+    });
+    expect(
+      validate([{ role: "tool", content: "a", toolCallId: "call-a" }]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_without_call" },
+    });
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-a", name: "read" }],
+        },
+        { role: "tool", content: "b", toolCallId: "call-b" },
+      ]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_unknown_id" },
+    });
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-a", name: "read" }],
+        },
+        { role: "user", content: "interleaved" },
+      ]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_missing" },
+    });
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-dangling", name: "read" }],
+        },
+      ]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_missing", index: null },
+      summary: { openCallCount: 1 },
+    });
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-a", name: "read" }],
+        },
+        { role: "tool", content: "a", toolCallId: "call-a" },
+        { role: "tool", content: "a", toolCallId: "call-a" },
+      ]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_duplicate" },
+    });
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-a", name: "read" }],
+        },
+        {
+          role: "tool",
+          content: "a",
+          toolCallId: "call-a",
+          toolName: "write",
+        },
+      ]),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_name_mismatch" },
+    });
+  });
+
+  it("returns typed operational deferrals for every configured bound", () => {
+    expect(
+      validate(
+        [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "abcdef", name: "read" }],
+          },
+        ],
+        { maxToolCallIdBytes: 5 },
+      ),
+    ).toMatchObject({
+      status: "deferred",
+      failure: { code: "tool_call_id_limit" },
+    });
+
+    const tooManyOpen = Array.from(
+      { length: MAX_OPEN_TOOL_CALLS_PER_RUN + 1 },
+      (_, index) => ({ id: `call-${index}`, name: "read" }),
+    );
+    expect(
+      validate([
+        { role: "assistant", content: "", toolCalls: tooManyOpen },
+      ]),
+    ).toMatchObject({
+      status: "deferred",
+      failure: { code: "tool_pair_open_call_limit" },
+    });
+
+    expect(
+      validate(
+        [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "call-a", name: "read" }],
+          },
+        ],
+        { maxIndexBytes: 4 },
+      ),
+    ).toMatchObject({
+      status: "deferred",
+      failure: { code: "tool_pair_index_byte_limit" },
+    });
+
+    expect(
+      validate(
+        [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "call-a", name: "read" }],
+          },
+          { role: "tool", content: "a", toolCallId: "call-a" },
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "call-b", name: "read" }],
+          },
+        ],
+        { maxToolCalls: 1 },
+      ),
+    ).toMatchObject({
+      status: "deferred",
+      failure: { code: "tool_pair_call_limit" },
+    });
+  });
+
+  it("keeps the derived projection separate and restart-readable", () => {
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-restart", name: "read" }],
+        },
+        { role: "tool", content: "ok", toolCallId: "call-restart" },
+      ]).status,
+    ).toBe("valid");
+    const tableNames = driver
+      .prepareState<[], { name: string }>(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table'
+           AND name IN ('in_flight_tool_calls', 'tool_pair_projection_entries')
+         ORDER BY name`,
+      )
+      .all()
+      .map((row) => row.name);
+    expect(tableNames).toContain("in_flight_tool_calls");
+    expect(tableNames).toContain("tool_pair_projection_entries");
+
+    driver.close();
+    driver = openStateDatabases({ cwd, agencHome });
+    projection = new StateToolPairProjection(driver);
+    expect(projection.find("projection-1", "call-restart")).toMatchObject({
+      callId: "call-restart",
+      resultIndex: 1,
+    });
+  });
+
+  it("rolls back a failed rebuild without destroying the last valid projection", () => {
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-stable", name: "read" }],
+        },
+        { role: "tool", content: "ok", toolCallId: "call-stable" },
+      ]).status,
+    ).toBe("valid");
+    driver.state.exec(`
+      CREATE TEMP TRIGGER reject_tool_pair_insert
+      BEFORE INSERT ON tool_pair_projection_entries
+      BEGIN
+        SELECT RAISE(ABORT, 'forced projection failure');
+      END;
+    `);
+
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-replacement", name: "grep" }],
+        },
+        { role: "tool", content: "new", toolCallId: "call-replacement" },
+      ]),
+    ).toMatchObject({
+      status: "deferred",
+      failure: { code: "tool_pair_projection_unavailable" },
+    });
+    expect(projection.find("projection-1", "call-stable")).toMatchObject({
+      callId: "call-stable",
+      resultIndex: 1,
+    });
+    expect(projection.find("projection-1", "call-replacement")).toBeUndefined();
+    expect(
+      driver
+        .prepareState<[string], { status: string }>(
+          "SELECT status FROM tool_pair_projection_runs WHERE projection_id = ?",
+        )
+        .get("projection-1"),
+    ).toEqual({ status: "valid" });
+  });
+
+  it("enforces terminal-status and failure-kind consistency in SQLite", () => {
+    expect(
+      validate([
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-valid", name: "read" }],
+        },
+        { role: "tool", content: "ok", toolCallId: "call-valid" },
+      ]).status,
+    ).toBe("valid");
+
+    expect(() =>
+      driver
+        .prepareState<[string]>(
+          `UPDATE tool_pair_projection_runs
+           SET status = 'invalid', failure_kind = 'operational_deferral',
+               failure_code = 'wrong-kind', failure_reason = 'wrong kind'
+           WHERE projection_id = ?`,
+        )
+        .run("projection-1"),
+    ).toThrow();
+  });
+
+  it(
+    "finds an exact duplicate separated by one million resolved calls",
+    () => {
+      const outcome = validate(millionResolvedCallsThenDuplicate());
+
+      expect(outcome).toMatchObject({
+        status: "invalid",
+        failure: { code: "assistant_tool_call_id_duplicate" },
+        summary: {
+          callCount: MAX_TOOL_CALL_IDS_PER_RUN,
+          resolvedCount: MAX_TOOL_CALL_IDS_PER_RUN,
+          openCallCount: 0,
+        },
+      });
+    },
+    180_000,
+  );
+});
+
+function* millionResolvedCallsThenDuplicate(): Iterable<ToolPairMessage> {
+  for (let index = 0; index < MAX_TOOL_CALL_IDS_PER_RUN; index += 1) {
+    const callId = `call-${String(index).padStart(6, "0")}`;
+    yield {
+      role: "assistant",
+      content: "",
+      toolCalls: [{ id: callId, name: "read" }],
+    };
+    yield { role: "tool", content: "ok", toolCallId: callId };
+  }
+  yield {
+    role: "assistant",
+    content: "",
+    toolCalls: [{ id: "call-000000", name: "read" }],
+  };
+}


### PR DESCRIPTION
Implements the A3a durable-checkpoint v2 reader and exact ordered tool-pair integrity barrier. This PR adds the reader/projection/migration contract only; production writer/caller cutover remains in A3b.

- authenticates complete persisted tool-result bodies with versioned, domain-separated identities
- validates exact call/result ordering and uniqueness through a bounded SQLite projection
- reads legacy, explicit-v1, and v2 checkpoints with strict version dispatch and A2a schema compatibility
- plans atomic legacy upgrades while preserving compaction and rollback history semantics
- binds strict v2 validation to the owning run and rejects cross-run/mixed-run evidence
- rejects ill-formed UTF-16 and non-finite JSON values before hashing
- bounds canonical object work, checkpoint-prefix work, and rollback derivation under non-widenable limits
- keeps ordinary response accumulation linear and detects a duplicate separated by one million resolved calls

Validation at exact SHA 105c1a51e7364c031c8929700c2e6b74e8876e9c (tree d74413a8fa1df2931d65ea06e5fa5386373be51c), Node 26.5.0 / npm 11.17.0:
- focused recovery/migration/projection matrix: 6 files / 100 tests
- independent exact-SHA review: PASS; 63 focused + 47 legacy checks; no findings
- corrected red-probe audit: 10/10, zero skipped/todo
- full npm test: runtime 1,941 files / 17,731 tests; root 130/130; checker 22/22; launcher 180/180
- build, package modes/import proofs, generated SDK types, and PTY normal/yolo smoke: green
- agent-surface contract: 1,098 Vitest assertions + 2 TUI E2E scenarios = 1,100 checks
- SDK build/typecheck: green
- Bun: 95 files, 0 failed
- SBOM: 684 packages / 1,107 relationships
