### PR TITLE
refactor(runtime): cut over durable tool-result integrity

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.032399,
-            "maxMs": 7.052466,
-            "medianMs": 5.800425,
-            "minMs": 5.092811,
+            "madMs": 0.227826,
+            "maxMs": 6.188787,
+            "medianMs": 5.735858,
+            "minMs": 5.21648,
             "sampleCount": 5,
             "samplesMs": [
-              5.828728,
-              5.092811,
-              7.052466,
-              5.800425,
-              5.768026
+              6.188787,
+              5.735858,
+              5.604729,
+              5.21648,
+              5.963684
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 93896704,
+              "maximumObservedBytes": 91828224,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82886656,
-                89178112,
-                90226688,
-                90226688,
-                90750976,
-                90750976,
-                90750976,
-                90750976,
-                91275264,
-                91275264,
-                93896704
+                82391040,
+                88158208,
+                88158208,
+                88158208,
+                88158208,
+                88158208,
+                88158208,
+                88158208,
+                88682496,
+                88682496,
+                91828224
               ]
             },
-            "peakRssBytes": 93896704,
+            "peakRssBytes": 91828224,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.524767,
-            "maxMs": 24.649568,
-            "medianMs": 16.71333,
-            "minMs": 15.661213,
+            "madMs": 0.88318,
+            "maxMs": 24.145648,
+            "medianMs": 15.313048,
+            "minMs": 14.429868,
             "sampleCount": 5,
             "samplesMs": [
-              16.71333,
-              24.649568,
-              17.238097,
-              16.404131,
-              15.661213
+              14.429868,
+              24.145648,
+              17.61909,
+              15.313048,
+              14.498121
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 122593280,
+              "maximumObservedBytes": 122052608,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84320256,
-                89038848,
-                93233152,
-                93233152,
-                104767488,
-                104767488,
-                121544704,
-                121544704,
-                122068992,
-                122068992,
-                122593280
+                83255296,
+                88498176,
+                89022464,
+                89022464,
+                104751104,
+                104751104,
+                121004032,
+                121004032,
+                121004032,
+                121004032,
+                122052608
               ]
             },
-            "peakRssBytes": 122593280,
+            "peakRssBytes": 122052608,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 2.141462,
-            "maxMs": 70.03343,
-            "medianMs": 40.798362,
-            "minMs": 38.6569,
+            "madMs": 2.880183,
+            "maxMs": 68.882848,
+            "medianMs": 41.487436,
+            "minMs": 38.607253,
             "sampleCount": 5,
             "samplesMs": [
-              70.03343,
-              45.963062,
-              39.373678,
-              40.798362,
-              38.6569
+              68.882848,
+              44.605601,
+              41.487436,
+              39.470394,
+              38.607253
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 133062656,
+              "maximumObservedBytes": 135512064,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                81874944,
-                97603584,
-                125915136,
-                125915136,
-                127488000,
-                127488000,
-                128012288,
-                128012288,
-                130109440,
-                130109440,
-                133062656
+                83927040,
+                100179968,
+                128491520,
+                128491520,
+                131112960,
+                131112960,
+                131637248,
+                131637248,
+                133734400,
+                133734400,
+                135512064
               ]
             },
-            "peakRssBytes": 133062656,
+            "peakRssBytes": 135512064,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.281746,
-            "maxMs": 9.673635,
-            "medianMs": 5.703038,
-            "minMs": 5.169497,
+            "madMs": 0.13156,
+            "maxMs": 10.536566,
+            "medianMs": 6.104338,
+            "minMs": 5.919367,
             "sampleCount": 5,
             "samplesMs": [
-              5.169497,
-              5.703038,
-              9.673635,
-              5.984784,
-              5.69782
+              5.972778,
+              6.121043,
+              10.536566,
+              6.104338,
+              5.919367
             ]
           },
           "fixtureDigest": "20e6f251f058537fb579b40427cfc4c69a025d8da738d498863815d41a88f6b7",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 118968320,
+              "maximumObservedBytes": 122572800,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                79646720,
-                94326784,
-                95375360,
-                95375360,
-                96948224,
-                96948224,
-                114774016,
-                114774016,
-                116346880,
-                116346880,
-                118968320
+                81678336,
+                96882688,
+                98979840,
+                98979840,
+                100552704,
+                100552704,
+                118378496,
+                118378496,
+                120475648,
+                120475648,
+                122572800
               ]
             },
-            "peakRssBytes": 119492608,
+            "peakRssBytes": 122572800,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -260,17 +260,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.125768,
-            "maxMs": 37.883867,
-            "medianMs": 35.234606,
-            "minMs": 19.746545,
+            "madMs": 5.292476,
+            "maxMs": 36.091535,
+            "medianMs": 30.799059,
+            "minMs": 18.352403,
             "sampleCount": 5,
             "samplesMs": [
-              19.746545,
-              36.360374,
-              37.883867,
-              35.234606,
-              34.282801
+              18.352403,
+              36.091535,
+              32.232035,
+              30.799059,
+              25.18095
             ]
           },
           "fixtureDigest": "b5ed1acf6dcd628542025466c326a7ca14bfc4875684227c66736176561607d5",
@@ -281,23 +281,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 157224960,
+              "maximumObservedBytes": 159735808,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82264064,
-                115818496,
-                118439936,
-                118439936,
-                155664384,
-                155664384,
-                156176384,
-                156176384,
-                156700672,
-                156700672,
-                157224960
+                84881408,
+                117387264,
+                121057280,
+                121057280,
+                158281728,
+                158281728,
+                157638656,
+                157638656,
+                159211520,
+                159211520,
+                159735808
               ]
             },
-            "peakRssBytes": 157224960,
+            "peakRssBytes": 160260096,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -316,17 +316,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 8.040075,
-            "maxMs": 389.45574,
-            "medianMs": 367.010088,
-            "minMs": 354.828396,
+            "madMs": 8.443258,
+            "maxMs": 328.577458,
+            "medianMs": 313.077435,
+            "minMs": 304.634177,
             "sampleCount": 5,
             "samplesMs": [
-              389.45574,
-              354.828396,
-              358.970013,
-              370.542941,
-              367.010088
+              323.414108,
+              313.077435,
+              304.634177,
+              328.577458,
+              312.533269
             ]
           },
           "fixtureDigest": "60598ff316c144a59697d6e13c539f2877b49bdcd1b6f8427c436f9850314509",
@@ -337,23 +337,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 235520000,
+              "maximumObservedBytes": 234500096,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85331968,
-                208826368,
-                191410176,
-                191410176,
-                212094976,
-                212094976,
-                235520000,
-                235520000,
-                203980800,
-                203980800,
-                223649792
+                84275200,
+                208068608,
+                190713856,
+                190713856,
+                211595264,
+                211595264,
+                234500096,
+                234500096,
+                203501568,
+                203501568,
+                224681984
               ]
             },
-            "peakRssBytes": 263073792,
+            "peakRssBytes": 263913472,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -386,17 +386,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.067662,
-            "maxMs": 4.082968,
-            "medianMs": 3.93946,
-            "minMs": 3.871798,
+            "madMs": 0.028604,
+            "maxMs": 3.99192,
+            "medianMs": 3.660477,
+            "minMs": 3.555448,
             "sampleCount": 5,
             "samplesMs": [
-              4.049627,
-              4.082968,
-              3.916505,
-              3.93946,
-              3.871798
+              3.689081,
+              3.660477,
+              3.638184,
+              3.99192,
+              3.555448
             ]
           },
           "fixtureDigest": "6dc2d7033a701cb871275327613ffef173ca251f453a9b586554b9f3ce14811a",
@@ -409,23 +409,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 88780800,
+              "maximumObservedBytes": 92323840,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82681856,
-                84586496,
-                84586496,
-                84586496,
-                84586496,
-                84586496,
-                85635072,
-                85635072,
-                87732224,
-                87732224,
-                88780800
+                84459520,
+                88653824,
+                88653824,
+                88653824,
+                88653824,
+                88653824,
+                88653824,
+                88653824,
+                91799552,
+                91799552,
+                92323840
               ]
             },
-            "peakRssBytes": 88780800,
+            "peakRssBytes": 92323840,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -444,17 +444,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.074473,
-            "maxMs": 12.876116,
-            "medianMs": 12.801643,
-            "minMs": 12.57591,
+            "madMs": 0.206004,
+            "maxMs": 13.23912,
+            "medianMs": 12.014401,
+            "minMs": 11.808397,
             "sampleCount": 5,
             "samplesMs": [
-              12.876116,
-              12.874724,
-              12.801643,
-              12.57591,
-              12.646808
+              13.23912,
+              12.26447,
+              12.014401,
+              11.93499,
+              11.808397
             ]
           },
           "fixtureDigest": "2c4e993a93b588a4e90763225ab10e2c7e80c7e52c006b4ce0d8d042a41d456c",
@@ -467,23 +467,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92938240,
+              "maximumObservedBytes": 91598848,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85536768,
-                92938240,
-                92938240,
-                92938240,
-                92938240,
-                92938240,
-                92938240,
-                92938240,
-                92938240,
-                92938240,
-                92938240
+                84783104,
+                90025984,
+                91598848,
+                91598848,
+                91598848,
+                91598848,
+                91598848,
+                91598848,
+                91598848,
+                91598848,
+                91598848
               ]
             },
-            "peakRssBytes": 92938240,
+            "peakRssBytes": 91598848,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -502,17 +502,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.937403,
-            "maxMs": 52.613126,
-            "medianMs": 49.981592,
-            "minMs": 49.044189,
+            "madMs": 0.928009,
+            "maxMs": 50.553841,
+            "medianMs": 49.625832,
+            "minMs": 46.628842,
             "sampleCount": 5,
             "samplesMs": [
-              49.044189,
-              52.032975,
-              52.613126,
-              49.543226,
-              49.981592
+              50.518718,
+              48.171704,
+              49.625832,
+              50.553841,
+              46.628842
             ]
           },
           "fixtureDigest": "c1a21af75169441df1d4fd0a5c8a99dbe96bbd556db181e064a6f70b83a91cf6",
@@ -525,23 +525,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 98557952,
+              "maximumObservedBytes": 103854080,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84295680,
-                89645056,
-                89645056,
-                89645056,
-                98033664,
-                98033664,
-                98557952,
-                98557952,
-                98557952,
-                98557952,
-                98557952
+                85442560,
+                94416896,
+                94416896,
+                94416896,
+                94941184,
+                94941184,
+                103854080,
+                103854080,
+                103854080,
+                103854080,
+                103854080
               ]
             },
-            "peakRssBytes": 98557952,
+            "peakRssBytes": 103854080,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -574,21 +574,21 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.003085,
-            "maxMs": 0.02606,
-            "medianMs": 0.015043,
-            "minMs": 0.011468,
+            "madMs": 0.003094,
+            "maxMs": 0.031989,
+            "medianMs": 0.017687,
+            "minMs": 0.008333,
             "sampleCount": 9,
             "samplesMs": [
-              0.016885,
-              0.02606,
-              0.018328,
-              0.01935,
-              0.015043,
-              0.011958,
-              0.011468,
-              0.011978,
-              0.012549
+              0.017687,
+              0.031989,
+              0.018218,
+              0.020781,
+              0.014693,
+              0.011948,
+              0.011428,
+              0.01967,
+              0.008333
             ]
           },
           "fixtureDigest": "06964b37b02568fd25e3c7c7788a86751336199f8ae67a29529912d184f6131d",
@@ -601,31 +601,31 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 78041088,
+              "maximumObservedBytes": 81182720,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                76468224,
-                77516800,
-                77516800,
-                77516800,
-                77516800,
-                77516800,
-                77516800,
-                77516800,
-                77516800,
-                77516800,
-                78041088,
-                78041088,
-                78041088,
-                78041088,
-                78041088,
-                78041088,
-                78041088,
-                78041088,
-                78041088
+                79085568,
+                80134144,
+                80134144,
+                80134144,
+                80134144,
+                80134144,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                80658432,
+                81182720,
+                81182720,
+                81182720
               ]
             },
-            "peakRssBytes": 78041088,
+            "peakRssBytes": 81182720,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -881,11 +881,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "ce15d13540397585b28a0f6005825505e216c726",
+    "gitObjectId": "c2b186f28b4585ed308dd1a94a9e6ccf13309b37",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "7b2ae4aba6c86cd6e083c3375ea997c3f25fff31",
+  "sourceRevision": "c445b076b60cd84b18f8e3e497ad820cbca3c6a4",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,9 +4,9 @@ This artifact records bounded observations of known failures. Every row is
 informational: no current result is a passing performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `bce843ef52156adb6fcb98a0e6beebb91bef6601faab2174600def0e65aa04c9`
-- Source revision: `7b2ae4aba6c86cd6e083c3375ea997c3f25fff31`
-- Production tree: `runtime/src` at Git object `ce15d13540397585b28a0f6005825505e216c726`
+- JSON SHA-256: `03d2b14da54c16ca2c2c1f0067e1c50f80e97da94c00f3ca3087dc7ca1d04fc9`
+- Source revision: `c445b076b60cd84b18f8e3e497ad820cbca3c6a4`
+- Production tree: `runtime/src` at Git object `c2b186f28b4585ed308dd1a94a9e6ccf13309b37`
 - Loaded production closure: `11` module bindings across `4` cases
 - Plan SHA-256: `d158a4e11ca943e018af33c0df8ddeaef665dbb56ec0c92b07db76abc61cde46`
 - Node/npm: `v26.5.0` / `11.17.0`
@@ -18,16 +18,16 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 5.800 | 0.032 | 93896704 | 93896704 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 16.713 | 0.525 | 122593280 | 122593280 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 40.798 | 2.141 | 133062656 | 133062656 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 5.703 | 0.282 | 119492608 | 118968320 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 35.235 | 1.126 | 157224960 | 157224960 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 367.010 | 8.040 | 263073792 | 235520000 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 3.939 | 0.068 | 88780800 | 88780800 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.802 | 0.074 | 92938240 | 92938240 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 49.982 | 0.937 | 98557952 | 98557952 |
-| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.015 | 0.003 | 78041088 | 78041088 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 5.736 | 0.228 | 91828224 | 91828224 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 15.313 | 0.883 | 122052608 | 122052608 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 41.487 | 2.880 | 135512064 | 135512064 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 6.104 | 0.132 | 122572800 | 122572800 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 30.799 | 5.292 | 160260096 | 159735808 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 313.077 | 8.443 | 263913472 | 234500096 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 3.660 | 0.029 | 92323840 | 92323840 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.014 | 0.206 | 91598848 | 91598848 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 49.626 | 0.928 | 103854080 | 103854080 |
+| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.018 | 0.003 | 81182720 | 81182720 |
 
 ## Known-failure policy
 
@@ -42,7 +42,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 7b2ae4aba6c86cd6e083c3375ea997c3f25fff31 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision c445b076b60cd84b18f8e3e497ad820cbca3c6a4 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/src/commands/session-compact.ts
+++ b/runtime/src/commands/session-compact.ts
@@ -13,9 +13,12 @@ import {
 } from "../llm/content-conversion.js";
 import { readProviderFactoryOptions } from "../llm/provider.js";
 import type { CompactionResult, RuntimeMessage } from "../services/compact/types.js";
-import type { CompactedItem, ResponseItem } from "../session/rollout-item.js";
+import type { CompactedItem } from "../session/rollout-item.js";
 import type { Session } from "../session/session.js";
-import { llmMessageToResponseItem } from "../session/message-history-conversion.js";
+import {
+  llmMessageToReplacementResponseItem,
+  responseItemToLlmMessage,
+} from "../session/message-history-conversion.js";
 import type { TurnContext } from "../session/turn-context.js";
 import { modelContextWindow } from "../session/turn-context.js";
 import {
@@ -676,6 +679,7 @@ interface AgenCMessage {
   readonly toolCallId?: string;
   readonly toolName?: string;
   readonly phase?: string;
+  readonly runtimeOnly?: LLMMessage["runtimeOnly"];
 }
 
 type AgenCRuntimeWireRole = NonNullable<RuntimeMessage["role"]>;
@@ -768,18 +772,19 @@ async function runManualCompact(params: {
     compactionResultWithSlashMessages,
     toolUseContext,
   );
-  const compacted = compactionResult.replacementHistory.map(cloneLLMMessage);
+  const compactedRollout = buildAgenCCompactedRolloutItem(compactionResult);
+  const rolloutStore = params.session.rolloutStore;
+  rolloutStore?.appendRollout(
+    { type: "compacted", payload: compactedRollout },
+    { durable: true },
+  );
+  const compacted = (compactedRollout.replacementHistory ?? []).map(
+    responseItemToLlmMessage,
+  );
   await params.session.state.with((sessionState) => {
     sessionState.history = compacted.map(cloneLLMMessage);
   });
   params.session.clearProviderResponseId();
-  params.session.rolloutStore?.appendRollout(
-    {
-      type: "compacted",
-      payload: buildAgenCCompactedRolloutItem(compactionResult),
-    },
-    { durable: true },
-  );
   return {
     displayText: typeof result.displayText === "string"
       ? result.displayText
@@ -1021,11 +1026,14 @@ function toAgenCMessage(message: LLMMessage): AgenCMessage {
     ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
     ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
     ...(message.phase !== undefined ? { phase: message.phase } : {}),
+    ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+      ? {
+          runtimeOnly: {
+            toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+          },
+        }
+      : {}),
   };
-}
-
-function toResponseItem(message: LLMMessage): ResponseItem {
-  return llmMessageToResponseItem(message);
 }
 
 function buildCompactedRolloutPayload(params: {
@@ -1037,7 +1045,11 @@ function buildCompactedRolloutPayload(params: {
   return {
     message: params.message,
     ...(params.replacementHistory !== undefined
-      ? { replacementHistory: params.replacementHistory.map(toResponseItem) }
+      ? {
+          replacementHistory: params.replacementHistory.map((message) =>
+            llmMessageToReplacementResponseItem(message, "compacted"),
+          ),
+        }
       : {}),
     ...(params.preCompactTokens !== undefined
       ? { preCompactTokens: params.preCompactTokens }
@@ -1486,6 +1498,13 @@ function fromAgenCRuntimeMessage(
       ...(message.phase === "commentary" || message.phase === "final_answer"
         ? { phase: message.phase }
         : {}),
+      ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+        ? {
+            runtimeOnly: {
+              toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+            },
+          }
+        : {}),
     };
   }
   const role = normalizeRole(message.message?.role ?? message.type);
@@ -1493,6 +1512,29 @@ function fromAgenCRuntimeMessage(
   return {
     role,
     content: fromRuntimeMessageContent(readContent(message)),
+    ...(message.toolCalls !== undefined
+      ? {
+          toolCalls: message.toolCalls.map((call) => ({
+            id: call.id,
+            name: call.name,
+            arguments: call.arguments ?? "",
+          })),
+        }
+      : {}),
+    ...(message.toolCallId !== undefined
+      ? { toolCallId: message.toolCallId }
+      : {}),
+    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
+    ...(message.phase === "commentary" || message.phase === "final_answer"
+      ? { phase: message.phase }
+      : {}),
+    ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+      ? {
+          runtimeOnly: {
+            toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+          },
+        }
+      : {}),
   };
 }
 
@@ -1534,6 +1576,9 @@ function cloneLLMMessage(message: LLMMessage): LLMMessage {
   return {
     ...message,
     content: cloneContent(message.content),
+    ...(message.runtimeOnly !== undefined
+      ? { runtimeOnly: { ...message.runtimeOnly } }
+      : {}),
   };
 }
 

--- a/runtime/src/conversation/thread-manager.ts
+++ b/runtime/src/conversation/thread-manager.ts
@@ -44,6 +44,7 @@ import { AsyncLock } from "../utils/async-lock.js";
 import {
   reconstructFromRollout,
   type RolloutReconstruction,
+  type RolloutCheckpointProjectionOptions,
 } from "../session/rollout-reconstruction.js";
 import {
   classifyDanglingToolUses,
@@ -260,7 +261,10 @@ export class ConversationThreadManager extends ThreadManager {
       sourceRollout,
       snapshot ?? { kind: "interrupted" },
     );
-    const reconstruction = reconstructFromRollout(forkedRollout);
+    const checkpointProjection = checkpointProjectionFor(session, "fork");
+    const reconstruction = reconstructFromRollout(forkedRollout, {
+      ...(checkpointProjection === undefined ? {} : { checkpointProjection }),
+    });
     const threadId = this.nextForkThreadId(session.conversationId);
     const thread = new ForkedConversationThread({
       threadId,
@@ -328,10 +332,15 @@ export class ConversationThreadManager extends ThreadManager {
     rolloutItems: ReadonlyArray<RolloutItem>,
     opts: ConversationReplayOptions = {},
   ): Promise<ConversationReplayResult> {
+    const checkpointProjection = checkpointProjectionFor(
+      session,
+      "root-reconstruction",
+    );
     const reconstruction = reconstructFromRollout(rolloutItems, {
       ...(opts.indexSnapshot !== undefined
         ? { indexSnapshot: opts.indexSnapshot }
         : {}),
+      ...(checkpointProjection === undefined ? {} : { checkpointProjection }),
     });
     const appliedState = await applyRolloutReconstructionToSession(
       session,
@@ -376,10 +385,16 @@ export class ConversationThreadManager extends ThreadManager {
       throw new Error(`managed thread ${threadId} does not support replay`);
     }
 
+    const sourceSession = sourceSessionForManagedThread(thread);
+    const checkpointProjection =
+      sourceSession === undefined
+        ? undefined
+        : checkpointProjectionFor(sourceSession, "managed-reconstruction");
     const reconstruction = reconstructFromRollout(rolloutItems, {
       ...(opts.indexSnapshot !== undefined
         ? { indexSnapshot: opts.indexSnapshot }
         : {}),
+      ...(checkpointProjection === undefined ? {} : { checkpointProjection }),
     });
     thread.replaceConversationHistory(reconstruction.history);
     if (opts.emitSynthesized === true) {
@@ -679,6 +694,8 @@ export interface DurableResumeAttempt {
     | "no-checkpoint"
     | "build-mismatch"
     | "prefix-mismatch"
+    | "integrity-invalid"
+    | "integrity-deferred"
     | "lease-unavailable";
   /** Tool names the safe policy halted on (surfaced, not retried). */
   readonly halted?: ReadonlyArray<string>;
@@ -703,6 +720,15 @@ function selectResumableTurn(
   if (cfg.buildPinning && !turn.buildMatches) {
     return { turn, reason: "build-mismatch" };
   }
+  if (turn.checkpointIntegrityStatus !== "valid") {
+    return {
+      turn,
+      reason:
+        turn.checkpointIntegrityStatus === "invalid"
+          ? "integrity-invalid"
+          : "integrity-deferred",
+    };
+  }
   if (!turn.historyPrefixValid) {
     return { turn, reason: "prefix-mismatch" };
   }
@@ -714,9 +740,9 @@ function selectResumableTurn(
  * checkpoint instead of discarding it and starting fresh.
  *
  * Safety gates (ALL must hold; any failure → caller falls back to today's
- * fresh turn): config enables resume, the build pin matches (§3.6), the
- * content prefix hash matches (§5), and the single-writer resume lease is
- * acquired (§3.5). Dangling `tool_use` blocks are classified by the
+ * fresh turn): config enables resume, the build pin matches (§3.6), the raw
+ * persisted checkpoint passes the A3 integrity gate, and the single-writer
+ * resume lease is acquired (§3.5). Dangling `tool_use` blocks are classified by the
  * EXISTING `recoveryCategory` via `isResumeReplaySafe`: side-effecting /
  * interactive dangling tools HALT and surface (never auto-re-dispatch) —
  * the on-chain-safety property — while read-only ones re-run on the fresh
@@ -1052,6 +1078,24 @@ class ForkedConversationThread implements ManagedThread {
       listener(status);
     }
   }
+}
+
+function checkpointProjectionFor(
+  session: Session,
+  purpose: string,
+): RolloutCheckpointProjectionOptions | undefined {
+  const rolloutStore = session.rolloutStore as
+    | {
+        checkpointProjectionContext?: (
+          projectionPurpose: string,
+        ) => RolloutCheckpointProjectionOptions;
+      }
+    | null
+    | undefined;
+  if (typeof rolloutStore?.checkpointProjectionContext !== "function") {
+    return undefined;
+  }
+  return rolloutStore.checkpointProjectionContext(purpose);
 }
 
 function sourceSessionForManagedThread(thread: ManagedThread): Session | undefined {

--- a/runtime/src/llm/messages.ts
+++ b/runtime/src/llm/messages.ts
@@ -140,11 +140,23 @@ export function normalizeMessagesForAPI(
   // We mutate the final array in-place by replacing up to three
   // messages with copies that carry the tag. Providers that do not
   // support cache_control strip the tag silently.
-  return applyCacheControlBreakpoints(final, {
+  const cachePrepared = applyCacheControlBreakpoints(final, {
     ...(options?.skipCacheWrite !== undefined
       ? { skipCacheWrite: options.skipCacheWrite }
       : {}),
   });
+  return cachePrepared.map(stripDurableIntegrityForProvider);
+}
+
+/** Remove A3 integrity evidence at the final provider-wire boundary. */
+function stripDurableIntegrityForProvider(message: LLMMessage): LLMMessage {
+  if (message.runtimeOnly?.toolResultIntegrity === undefined) return message;
+  const { toolResultIntegrity: _integrity, ...retainedRuntimeOnly } =
+    message.runtimeOnly;
+  const { runtimeOnly: _runtimeOnly, ...providerMessage } = message;
+  return Object.keys(retainedRuntimeOnly).length === 0
+    ? providerMessage
+    : { ...providerMessage, runtimeOnly: retainedRuntimeOnly };
 }
 
 /**

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -11,6 +11,7 @@ import type { ProviderFallbackLadderOptions } from "./api/fallback-ladder.js";
 import { isRecord } from "../utils/record.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import type { ProviderTokenCountCapability } from "./token-accounting.js";
+import type { ToolResultIntegrity } from "../session/tool-result-integrity.js";
 
 /**
  * Message role in a conversation
@@ -92,6 +93,11 @@ export interface LLMMessage {
         | "mcp_tool_not_shell_command"
         | "shell_workspace_write_policy";
     };
+    /**
+     * Durable tool-result identity. This is runtime-only state: provider wire
+     * preparation must remove it after local history transformations finish.
+     */
+    readonly toolResultIntegrity?: ToolResultIntegrity;
   };
   /** For assistant messages that request tool execution */
   toolCalls?: LLMToolCall[];

--- a/runtime/src/phases/execute-tools.ts
+++ b/runtime/src/phases/execute-tools.ts
@@ -92,22 +92,35 @@ import {
   validateEditorProposalResultForInteraction,
 } from "../session/editor-interaction.js";
 import { EDITOR_PROPOSAL_TOOL_NAME } from "../tools/system/editor-proposal.js";
+import { createToolResultIntegrity } from "../session/tool-result-integrity.js";
 
 function toolResultMessage(
+  runId: string,
   callId: string,
   toolName: string,
   result: ToolDispatchResult,
   untrustedKind: UntrustedToolResultKind,
 ): LLMMessage {
+  // Seal the exact model-facing body at the result boundary, before any
+  // budgeting, microcompaction, in-memory bounding, or durable serialization.
+  const content = modelFacingToolResultContent(toolName, result, untrustedKind);
   const message: LLMMessage = {
     role: "tool",
     toolCallId: callId,
     toolName,
-    content: modelFacingToolResultContent(toolName, result, untrustedKind),
+    content,
+    runtimeOnly: {
+      toolResultIntegrity: createToolResultIntegrity({
+        runId,
+        toolCallId: callId,
+        content,
+      }),
+    },
   };
   const failureKind = recoverableFailureKind(result.metadata);
   if (failureKind !== null) {
     message.runtimeOnly = {
+      ...message.runtimeOnly,
       recoverableToolFailure: {
         hiddenFromTranscript: true,
         kind: failureKind,
@@ -651,7 +664,13 @@ function recordCompletedToolCall(
     toolResultUserRecord(toolCall.id, toolCall.name, result, untrustedKind),
   );
   state.messages.push(
-    toolResultMessage(toolCall.id, toolCall.name, result, untrustedKind),
+    toolResultMessage(
+      session.conversationId,
+      toolCall.id,
+      toolCall.name,
+      result,
+      untrustedKind,
+    ),
   );
   return completed;
 }

--- a/runtime/src/services/compact/types.ts
+++ b/runtime/src/services/compact/types.ts
@@ -10,6 +10,7 @@
 
 import type { LLMProvider, LLMTool, LLMToolChoice } from "../../llm/types.js";
 import type { Session } from "../../session/session.js";
+import type { ToolResultIntegrity } from "../../session/tool-result-integrity.js";
 
 export type RuntimeMessage = {
   readonly role?: "system" | "user" | "assistant" | "tool";
@@ -32,6 +33,9 @@ export type RuntimeMessage = {
   readonly uuid?: string;
   readonly timestamp?: string;
   readonly isMeta?: boolean;
+  readonly runtimeOnly?: {
+    readonly toolResultIntegrity?: ToolResultIntegrity;
+  };
 };
 
 export type CompactContext = {

--- a/runtime/src/session/durable-checkpoint-reader.ts
+++ b/runtime/src/session/durable-checkpoint-reader.ts
@@ -15,6 +15,7 @@ import {
 } from "./tool-result-integrity.js";
 import {
   validateToolPairSequence,
+  type ToolPairDanglingUse,
   type ToolPairIntegrityFailure,
   type ToolPairOperationalDeferral,
   type ToolPairProjection,
@@ -115,6 +116,8 @@ export type DurableCheckpointPrefixValidation =
       readonly status: "valid";
       readonly prefixHash: string;
       readonly toolPairs: ToolPairProjectionSummary;
+      readonly danglingToolCalls: number;
+      readonly danglingToolUses: ReadonlyArray<ToolPairDanglingUse>;
     }
   | {
       readonly status: "invalid";
@@ -362,9 +365,12 @@ export function validateCheckpointPrefixV2(params: {
       sourceKey: params.sourceKey,
       requireResultIntegrity: true,
       expectedRunId: params.expectedRunId,
+      allowDanglingAtEnd: params.checkpoint.boundary === "postAssistant",
     },
   );
-  if (toolPairs.status !== "valid") return toolPairs;
+  if (toolPairs.status === "invalid" || toolPairs.status === "deferred") {
+    return toolPairs;
+  }
 
   let prefixHash: string;
   try {
@@ -426,7 +432,15 @@ export function validateCheckpointPrefixV2(params: {
       },
     };
   }
-  return { status: "valid", prefixHash, toolPairs: toolPairs.summary };
+  return {
+    status: "valid",
+    prefixHash,
+    toolPairs: toolPairs.summary,
+    danglingToolCalls:
+      toolPairs.status === "dangling" ? toolPairs.summary.openCallCount : 0,
+    danglingToolUses:
+      toolPairs.status === "dangling" ? toolPairs.danglingToolUses : [],
+  };
 }
 
 function parseCheckpointBase(

--- a/runtime/src/session/durable-turns.ts
+++ b/runtime/src/session/durable-turns.ts
@@ -378,6 +378,9 @@ export interface ResumableTurn {
   readonly buildId?: string;
   readonly buildMatches: boolean;
   readonly historyPrefixValid: boolean;
+  /** A3 raw-prefix gate evaluated before replay truncation. */
+  readonly checkpointIntegrityStatus: "valid" | "invalid" | "deferred";
+  readonly checkpointIntegrityReason?: string;
   readonly lastCheckpoint: {
     readonly iterationIndex: number;
     readonly checkpointSeq: number;

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -51,10 +51,11 @@ import type {
 /**
  * Incremented on any breaking change to the rollout JSONL format.
  * - v1: initial T6 shape (18 event variants, 6 rollout wrappers).
+ * - v2: exact tool-result seals and version-2 durable checkpoints.
  * On open, if rollout.schemaVersion > runtime.ROLLOUT_SCHEMA_VERSION,
  * hard-fail with migration message (I-49).
  */
-export const ROLLOUT_SCHEMA_VERSION = 1;
+export const ROLLOUT_SCHEMA_VERSION = 2;
 
 // ─────────────────────────────────────────────────────────────────────
 // Event envelope: { eventId, id, msg, seq }
@@ -199,7 +200,7 @@ export interface TurnAbortedEvent {
  * DERIVED budget, never a raw turn-start clock — restoring a stale clock
  * would silently corrupt budget accounting on resume.
  */
-export interface TurnCheckpointEvent {
+interface TurnCheckpointBase {
   readonly turnId: string;
   /** Monotonic per-turn iteration index this checkpoint closes. */
   readonly iterationIndex: number;
@@ -220,7 +221,7 @@ export interface TurnCheckpointEvent {
 }
 
 /** Existing checkpoint shape. A missing discriminator is legacy version 1. */
-export interface TurnCheckpointV1Event extends TurnCheckpointEvent {
+export interface TurnCheckpointV1Event extends TurnCheckpointBase {
   readonly checkpointVersion?: 1;
 }
 
@@ -228,10 +229,14 @@ export interface TurnCheckpointV1Event extends TurnCheckpointEvent {
  * A3 checkpoint shape whose prefix hash authenticates every persisted tool
  * result body through `ResponseItem.toolResultIntegrity`.
  */
-export interface TurnCheckpointV2Event extends TurnCheckpointEvent {
+export interface TurnCheckpointV2Event extends TurnCheckpointBase {
   readonly checkpointVersion: 2;
   readonly toolResultIntegrityVersion: 1;
 }
+
+export type TurnCheckpointEvent =
+  | TurnCheckpointV1Event
+  | TurnCheckpointV2Event;
 
 /**
  * Serialized, JSON-safe projection of the resumable `TurnState` counters.

--- a/runtime/src/session/message-history-conversion.ts
+++ b/runtime/src/session/message-history-conversion.ts
@@ -1,5 +1,13 @@
 import type { LLMContentPart, LLMMessage } from "../llm/types.js";
+import { redactSecretsInValue } from "../secrets/index.js";
 import type { ResponseItem } from "./rollout-item.js";
+import {
+  deterministicToolResultId,
+  verifyToolResultIntegrity,
+  withPersistedToolResultRepresentation,
+  type ToolResultIntegrity,
+  type ToolResultRepresentation,
+} from "./tool-result-integrity.js";
 
 type RolloutContentPart = Extract<
   ResponseItem["content"],
@@ -22,7 +30,51 @@ export function llmMessageToResponseItem(message: LLMMessage): ResponseItem {
     ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
     ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
     ...(message.phase !== undefined ? { phase: message.phase } : {}),
+    ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+      ? { toolResultIntegrity: message.runtimeOnly.toolResultIntegrity }
+      : {}),
   };
+}
+
+/**
+ * Convert a newly produced message to the exact representation that the
+ * rollout serializer will write. Integrity is checked against the unredacted
+ * model-facing tool result first, then rebound to the redacted durable body.
+ */
+export function llmMessageToDurableResponseItem(
+  message: LLMMessage,
+): ResponseItem {
+  const item = llmMessageToResponseItem(message);
+  const integrity = currentIntegrity(message, false);
+  return redactResponseItemForPersistence(item, integrity, "authenticate");
+}
+
+/**
+ * Recreate the already-persisted projection used by checkpoint hashing.
+ * Tool-result bodies may have since been bounded in memory, so their sealed
+ * persisted identity is retained while all other fields are redacted exactly
+ * as they are at the JSONL sink.
+ */
+export function llmMessageToCheckpointResponseItem(
+  message: LLMMessage,
+): ResponseItem {
+  const item = llmMessageToResponseItem(message);
+  const integrity = currentIntegrity(message, true);
+  return redactResponseItemForPersistence(item, integrity, "preserve");
+}
+
+/**
+ * Convert replacement history that a compaction/rewind is about to persist.
+ * If a controlled history transformation changed the current tool-result
+ * body, retain its immutable original identity and authenticate the new body.
+ */
+export function llmMessageToReplacementResponseItem(
+  message: LLMMessage,
+  representation: Exclude<ToolResultRepresentation, "original"> = "compacted",
+): ResponseItem {
+  const item = llmMessageToResponseItem(message);
+  const integrity = replacementIntegrity(message, representation);
+  return redactResponseItemForPersistence(item, integrity, "authenticate");
 }
 
 export function responseItemToLlmMessage(item: ResponseItem): LLMMessage {
@@ -43,6 +95,9 @@ export function responseItemToLlmMessage(item: ResponseItem): LLMMessage {
       : {}),
     ...(item.toolCallId !== undefined ? { toolCallId: item.toolCallId } : {}),
     ...(item.toolName !== undefined ? { toolName: item.toolName } : {}),
+    ...(item.toolResultIntegrity !== undefined
+      ? { runtimeOnly: { toolResultIntegrity: item.toolResultIntegrity } }
+      : {}),
   };
 }
 
@@ -53,6 +108,120 @@ export function cloneLlmMessage(message: LLMMessage): LLMMessage {
     ...(message.toolCalls !== undefined
       ? { toolCalls: message.toolCalls.map((call) => ({ ...call })) }
       : {}),
+    ...(message.runtimeOnly !== undefined
+      ? { runtimeOnly: { ...message.runtimeOnly } }
+      : {}),
+  };
+}
+
+function replacementIntegrity(
+  message: LLMMessage,
+  representation: Exclude<ToolResultRepresentation, "original">,
+): ToolResultIntegrity | undefined {
+  const integrity = message.runtimeOnly?.toolResultIntegrity;
+  if (integrity === undefined) return undefined;
+  if (message.role !== "tool" || message.toolCallId === undefined) {
+    throw new Error("tool-result integrity metadata is attached to a non-tool message");
+  }
+  const verification = verifyToolResultIntegrity({
+    integrity,
+    toolCallId: message.toolCallId,
+    content: message.content,
+  });
+  if (verification.status === "valid") return verification.integrity;
+  if (
+    verification.status === "invalid" &&
+    (verification.failure.code === "persisted_body_digest_mismatch" ||
+      verification.failure.code === "persisted_body_length_mismatch")
+  ) {
+    return withPersistedToolResultRepresentation(
+      integrity,
+      representation,
+      message.content,
+    );
+  }
+  throw new Error(`cannot persist transformed tool result: ${verification.failure.reason}`);
+}
+
+function currentIntegrity(
+  message: LLMMessage,
+  allowControlledBodyMismatch: boolean,
+): ToolResultIntegrity | undefined {
+  const integrity = message.runtimeOnly?.toolResultIntegrity;
+  if (integrity === undefined) return undefined;
+  if (message.role !== "tool" || message.toolCallId === undefined) {
+    throw new Error("tool-result integrity metadata is attached to a non-tool message");
+  }
+  const verification = verifyToolResultIntegrity({
+    integrity,
+    toolCallId: message.toolCallId,
+    content: message.content,
+  });
+  if (verification.status === "valid") return verification.integrity;
+  if (
+    allowControlledBodyMismatch &&
+    verification.status === "invalid" &&
+    (verification.failure.code === "persisted_body_digest_mismatch" ||
+      verification.failure.code === "persisted_body_length_mismatch")
+  ) {
+    return integrity;
+  }
+  throw new Error(`cannot persist tool result: ${verification.failure.reason}`);
+}
+
+function redactResponseItemForPersistence(
+  item: ResponseItem,
+  integrity: ToolResultIntegrity | undefined,
+  bodyMode: "authenticate" | "preserve",
+): ResponseItem {
+  const { toolResultIntegrity: _omittedIntegrity, ...unsealedItem } = item;
+  const redacted = redactSecretsInValue(unsealedItem) as ResponseItem;
+  if (integrity === undefined) return redacted;
+  if (redacted.role !== "tool" || redacted.toolCallId === undefined) {
+    throw new Error("redaction removed a durable tool-result identity");
+  }
+
+  let durableIntegrity = rebindRedactedIdentity(integrity, redacted.toolCallId);
+  if (bodyMode === "authenticate") {
+    const redactedBody = verifyToolResultIntegrity({
+      integrity: durableIntegrity,
+      toolCallId: redacted.toolCallId,
+      content: redacted.content,
+    });
+    if (redactedBody.status !== "valid") {
+      if (
+        redactedBody.status !== "invalid" ||
+        (redactedBody.failure.code !== "persisted_body_digest_mismatch" &&
+          redactedBody.failure.code !== "persisted_body_length_mismatch")
+      ) {
+        throw new Error(
+          `cannot persist redacted tool result: ${redactedBody.failure.reason}`,
+        );
+      }
+      const representation =
+        durableIntegrity.persisted.representation === "original"
+          ? "redacted"
+          : durableIntegrity.persisted.representation;
+      durableIntegrity = withPersistedToolResultRepresentation(
+        durableIntegrity,
+        representation,
+        redacted.content,
+      );
+    }
+  }
+  return { ...redacted, toolResultIntegrity: durableIntegrity };
+}
+
+function rebindRedactedIdentity(
+  integrity: ToolResultIntegrity,
+  toolCallId: string,
+): ToolResultIntegrity {
+  const runId = redactSecretsInValue(integrity.runId);
+  return {
+    ...integrity,
+    runId,
+    toolCallId,
+    resultId: deterministicToolResultId(runId, toolCallId),
   };
 }
 

--- a/runtime/src/session/rollout-item.ts
+++ b/runtime/src/session/rollout-item.ts
@@ -46,16 +46,14 @@ export interface ResponseItem {
   }>;
   readonly toolCallId?: string;
   readonly toolName?: string;
+  /** Checkpoint-v2 identity for the exact durable tool-result body. */
+  readonly toolResultIntegrity?: ToolResultIntegrity;
   readonly id?: string;
   readonly endTurn?: boolean;
   readonly phase?: string;
 }
 
-/**
- * Checkpoint-v2 view of a response item. Keeping the dormant integrity field
- * out of the v1 `RolloutItem` contract lets the strict recovery reader retain
- * its exact legacy key witness until the writer cutover changes that schema.
- */
+/** Checkpoint-v2 reader view retained for narrow reader signatures. */
 export interface ToolResultIntegrityResponseItem extends ResponseItem {
   readonly toolResultIntegrity?: ToolResultIntegrity;
 }

--- a/runtime/src/session/rollout-reconstruction.ts
+++ b/runtime/src/session/rollout-reconstruction.ts
@@ -51,9 +51,7 @@ import {
   DEFAULT_MAX_TOOL_RESULT_BYTES,
 } from "./_deps/tool-execution.js";
 import {
-  computePrefixHash,
   currentBuildId,
-  findDanglingToolUses,
   type ResumableTurn,
 } from "./durable-turns.js";
 import type {
@@ -67,6 +65,34 @@ import {
   startsWithPersonalitySpecOpenTag,
   type Personality,
 } from "../context/personality-spec-instructions.js";
+import {
+  readTurnCheckpoint,
+  validateCheckpointPrefixV2,
+} from "./durable-checkpoint-reader.js";
+import type {
+  ToolPairDanglingUse,
+  ToolPairProjection,
+} from "./tool-pair-validator.js";
+
+export interface RolloutCheckpointProjectionOptions {
+  readonly projection: ToolPairProjection;
+  readonly projectionId: string;
+  readonly sourceKey: string;
+  readonly expectedRunId: string;
+}
+
+export interface RolloutReconstructionOptions {
+  readonly indexSnapshot?: IndexSnapshot;
+  readonly checkpointProjection?: RolloutCheckpointProjectionOptions;
+}
+
+type RawCheckpointValidation =
+  | {
+      readonly status: "valid";
+      readonly danglingToolUses: ReadonlyArray<ToolPairDanglingUse>;
+    }
+  | { readonly status: "invalid"; readonly reason: string }
+  | { readonly status: "deferred"; readonly reason: string };
 
 /**
  * Verbatim port of agenc runtime `core/templates/compact/summary_prefix.md`
@@ -161,6 +187,60 @@ function emptySegment(): ActiveReplaySegment {
   return {
     countsAsUserTurn: false,
     referenceContextItem: { kind: "never_set" },
+  };
+}
+
+function turnCheckpointPayload(item: RolloutItem): unknown | undefined {
+  if (item.type !== "event_msg" || item.payload.msg.type !== "turn_checkpoint") {
+    return undefined;
+  }
+  return item.payload.msg.payload;
+}
+
+/** Authenticate canonical persisted bodies before replay applies truncation. */
+function validateRawCheckpointBeforeReplay(params: {
+  readonly payload: unknown;
+  readonly messages: ReadonlyArray<ResponseItem>;
+  readonly projection?: RolloutCheckpointProjectionOptions;
+}): RawCheckpointValidation {
+  let readable;
+  try {
+    readable = readTurnCheckpoint(params.payload);
+  } catch (error) {
+    return {
+      status: "invalid",
+      reason: error instanceof Error ? error.message : "checkpoint is malformed",
+    };
+  }
+  if (readable.version === 1) {
+    return {
+      status: "deferred",
+      reason: "legacy checkpoint requires an atomic schema-v2 upgrade",
+    };
+  }
+  if (params.projection === undefined) {
+    return {
+      status: "deferred",
+      reason: "exact tool-pair projection is unavailable",
+    };
+  }
+  const validation = validateCheckpointPrefixV2({
+    checkpoint: readable.checkpoint,
+    messages: params.messages,
+    projection: params.projection.projection,
+    projectionId: params.projection.projectionId,
+    sourceKey: params.projection.sourceKey,
+    expectedRunId: params.projection.expectedRunId,
+  });
+  if (validation.status === "valid") {
+    return {
+      status: "valid",
+      danglingToolUses: validation.danglingToolUses,
+    };
+  }
+  return {
+    status: validation.status,
+    reason: validation.failure.reason,
   };
 }
 
@@ -468,7 +548,7 @@ function finalizeActiveSegment(
 
 export function reconstructFromRollout(
   rolloutItems: ReadonlyArray<RolloutItem>,
-  opts: { readonly indexSnapshot?: IndexSnapshot } = {},
+  opts: RolloutReconstructionOptions = {},
 ): RolloutReconstruction {
   // I-25: consult the optional index.json snapshot. The reconstruction
   // itself still walks the rollout (rollout is truth per I-25), but a
@@ -485,6 +565,7 @@ export function reconstructFromRollout(
     pendingRollbackTurns: 0,
   };
   let rolloutSuffix: ReadonlyArray<RolloutItem> = rolloutItems;
+  let rolloutSuffixStartIndex = 0;
   let active: ActiveReplaySegment | null = null;
 
   // Track orphan turn ids for I-48. A TurnStarted with no matching
@@ -507,6 +588,7 @@ export function reconstructFromRollout(
         ) {
           active.baseReplacementHistory = item.payload.replacementHistory;
           rolloutSuffix = rolloutItems.slice(idx + 1);
+          rolloutSuffixStartIndex = idx + 1;
         }
         break;
       }
@@ -638,6 +720,51 @@ export function reconstructFromRollout(
     finalizeActiveSegment(active, pending);
   }
 
+  // Collect lifecycle/build metadata and only the highest checkpoint for each
+  // turn before replay. The reverse metadata scan may terminate early, and
+  // validating every superseded checkpoint would repeatedly rescan growing
+  // prefixes. Only an orphan's highest checkpoint can authorize execution.
+  const turnBuildIds = new Map<string, string | undefined>();
+  const highestCheckpointByTurn = new Map<
+    string,
+    { readonly checkpoint: TurnCheckpointEvent; readonly rolloutIndex: number }
+  >();
+  for (let rolloutIndex = 0; rolloutIndex < rolloutItems.length; rolloutIndex += 1) {
+    const item = rolloutItems[rolloutIndex];
+    if (item?.type !== "event_msg") continue;
+    const inner = item.payload.msg as { type?: string; payload?: unknown };
+    if (inner.type === "turn_started") {
+      const payload = inner.payload as { turnId?: string; buildId?: string };
+      if (typeof payload?.turnId === "string") {
+        seenStarted.add(payload.turnId);
+        turnBuildIds.set(payload.turnId, payload.buildId);
+      }
+      continue;
+    }
+    if (inner.type === "turn_complete" || inner.type === "turn_aborted") {
+      const payload = inner.payload as { turnId?: string };
+      if (typeof payload?.turnId === "string") {
+        seenTerminated.add(payload.turnId);
+      }
+      continue;
+    }
+    if (inner.type !== "turn_checkpoint") continue;
+    const checkpoint = inner.payload as TurnCheckpointEvent | undefined;
+    if (checkpoint === undefined || typeof checkpoint.turnId !== "string") {
+      continue;
+    }
+    const previous = highestCheckpointByTurn.get(checkpoint.turnId);
+    if (
+      previous === undefined ||
+      checkpoint.checkpointSeq > previous.checkpoint.checkpointSeq
+    ) {
+      highestCheckpointByTurn.set(checkpoint.turnId, {
+        checkpoint,
+        rolloutIndex,
+      });
+    }
+  }
+
   // Forward replay over the suffix using the reducer. We apply three
   // extra agenc runtime-parity steps inline so forward replay reproduces the
   // runtime state the writer saw at that seq:
@@ -654,6 +781,14 @@ export function reconstructFromRollout(
     rolledBackTurns: 0,
     lastSeq: 0,
   };
+  let rawState: ReducedSessionState = {
+    history: pending.baseReplacementHistory
+      ? [...pending.baseReplacementHistory]
+      : [],
+    rolledBackTurns: 0,
+    lastSeq: 0,
+  };
+  const rawCheckpointValidations = new Map<number, RawCheckpointValidation>();
   let reductionReport: ReductionReport = {
     unknownVariantCount: 0,
     unknownVariantSamples: [],
@@ -663,7 +798,10 @@ export function reconstructFromRollout(
   };
   let sawLegacyCompactionWithoutReplacement = false;
 
-  for (const item of rolloutSuffix) {
+  for (let suffixIndex = 0; suffixIndex < rolloutSuffix.length; suffixIndex += 1) {
+    const item = rolloutSuffix[suffixIndex];
+    if (item === undefined) continue;
+    const rolloutIndex = rolloutSuffixStartIndex + suffixIndex;
     // (b) Compatibility compaction: rebuild history in place via the inline
     // `buildCompactedHistory` helper instead of deferring to the
     // reducer (which would just clear the reference). This matches
@@ -676,8 +814,43 @@ export function reconstructFromRollout(
       const userMessages = collectUserMessages(state.history);
       const rebuilt = buildCompactedHistory(userMessages, item.payload.message);
       state = { ...state, history: rebuilt, lastCompaction: item.payload };
+      const rawUserMessages = collectUserMessages(rawState.history);
+      rawState = {
+        ...rawState,
+        history: buildCompactedHistory(rawUserMessages, item.payload.message),
+        lastCompaction: item.payload,
+      };
       reductionReport = mergeReport(reductionReport, { processed: 1 });
       continue;
+    }
+
+    const checkpointPayload = turnCheckpointPayload(item);
+    const checkpointTurnId =
+      checkpointPayload !== undefined &&
+      typeof checkpointPayload === "object" &&
+      checkpointPayload !== null &&
+      "turnId" in checkpointPayload &&
+      typeof checkpointPayload.turnId === "string"
+        ? checkpointPayload.turnId
+        : undefined;
+    const highestCheckpoint =
+      checkpointTurnId === undefined
+        ? undefined
+        : highestCheckpointByTurn.get(checkpointTurnId);
+    if (
+      checkpointPayload !== undefined &&
+      checkpointTurnId !== undefined &&
+      !seenTerminated.has(checkpointTurnId) &&
+      highestCheckpoint?.rolloutIndex === rolloutIndex
+    ) {
+      rawCheckpointValidations.set(
+        rolloutIndex,
+        validateRawCheckpointBeforeReplay({
+          payload: checkpointPayload,
+          messages: rawState.history,
+          projection: opts.checkpointProjection,
+        }),
+      );
     }
 
     // (a) Truncation policy: apply I-15 cap to response_item text
@@ -692,37 +865,13 @@ export function reconstructFromRollout(
 
     const step = reduce(state, toReduce);
     state = step.state;
+    rawState = reduce(rawState, item).state;
     reductionReport = mergeReport(reductionReport, step.report);
   }
   reductionReport = {
     ...reductionReport,
     processed: rolloutSuffix.length,
   };
-
-  // GOAL #4b Stage 1 — collect per-turn build pin + highest-seq durable
-  // checkpoint via a dedicated forward pass over ALL rollout items (the
-  // reverse scan above early-terminates, so it is NOT a reliable place to
-  // gather every checkpoint). A turn with NO checkpoint contributes nothing
-  // here → it falls back to EXACTLY today's process_killed path below.
-  const turnBuildIds = new Map<string, string | undefined>();
-  const highestCheckpointByTurn = new Map<string, TurnCheckpointEvent>();
-  for (const item of rolloutItems) {
-    if (item.type !== "event_msg") continue;
-    const inner = item.payload.msg as { type?: string; payload?: unknown };
-    if (inner.type === "turn_started") {
-      const p = inner.payload as { turnId?: string; buildId?: string };
-      if (typeof p?.turnId === "string") {
-        turnBuildIds.set(p.turnId, p.buildId);
-      }
-    } else if (inner.type === "turn_checkpoint") {
-      const p = inner.payload as TurnCheckpointEvent | undefined;
-      if (p === undefined || typeof p.turnId !== "string") continue;
-      const prev = highestCheckpointByTurn.get(p.turnId);
-      if (prev === undefined || p.checkpointSeq > prev.checkpointSeq) {
-        highestCheckpointByTurn.set(p.turnId, p);
-      }
-    }
-  }
 
   // I-48: orphan-TurnStarted recovery. For each started-but-not-terminated
   // turn, synthesize a TurnAborted{reason:'process_killed'} event so
@@ -742,25 +891,25 @@ export function reconstructFromRollout(
       // is still emitted, so an orphan with no checkpoint (or a failing
       // gate) is byte-identical to today; only the resume CONSUMER acts on
       // a descriptor whose gates pass.
-      const checkpoint = highestCheckpointByTurn.get(turnId);
-      if (checkpoint !== undefined) {
+      const checkpointRecord = highestCheckpointByTurn.get(turnId);
+      if (checkpointRecord !== undefined) {
+        const { checkpoint, rolloutIndex } = checkpointRecord;
         const buildId = turnBuildIds.get(turnId);
         const buildMatches = buildId === expectedBuildId;
-        const reconstructedPrefix = state.history.slice(
-          0,
-          checkpoint.persistedMessageCount,
-        );
-        const historyPrefixValid =
-          reconstructedPrefix.length === checkpoint.persistedMessageCount &&
-          computePrefixHash(
-            reconstructedPrefix,
-            checkpoint.persistedMessageCount,
-          ) === checkpoint.prefixHash;
+        const integrity = rawCheckpointValidations.get(rolloutIndex) ?? {
+          status: "deferred" as const,
+          reason: "checkpoint was outside the raw replay validation window",
+        };
+        const historyPrefixValid = integrity.status === "valid";
         resumableTurns.push({
           turnId,
           ...(buildId !== undefined ? { buildId } : {}),
           buildMatches,
           historyPrefixValid,
+          checkpointIntegrityStatus: integrity.status,
+          ...(integrity.status === "valid"
+            ? {}
+            : { checkpointIntegrityReason: integrity.reason }),
           lastCheckpoint: {
             iterationIndex: checkpoint.iterationIndex,
             checkpointSeq: checkpoint.checkpointSeq,
@@ -769,7 +918,8 @@ export function reconstructFromRollout(
             resumableState:
               checkpoint.resumableState as TurnCheckpointSliceLine,
           },
-          danglingToolUses: findDanglingToolUses(reconstructedPrefix),
+          danglingToolUses:
+            integrity.status === "valid" ? integrity.danglingToolUses : [],
         });
       }
       synthesized.push({

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -32,7 +32,10 @@ import {
   type ThreadId,
 } from "../agents/registry.js";
 import type { Event, EventMsg } from "./event-log.js";
-import { parseRolloutLine, type RolloutItem } from "./rollout-item.js";
+import {
+  parseRolloutLine,
+  type RolloutItem,
+} from "./rollout-item.js";
 import {
   getProjectDir,
   SessionStore,
@@ -62,12 +65,73 @@ import {
   EFFECT_EVIDENCE_MINIMUM_READER_RUNTIME,
   type EffectNoEffectProof,
 } from "../contracts/run-contracts.js";
+import {
+  planLegacyDurableCheckpointUpgrade,
+  type DurableCheckpointUpgradeDeferral,
+  type DurableCheckpointUpgradeFailure,
+} from "./durable-checkpoint-upgrade.js";
+import { StateToolPairProjection } from "../state/tool-pair-projection.js";
+import { DURABLE_ROLLOUT_SCHEMA_V2 } from "./durable-checkpoint-reader.js";
+import {
+  StreamingToolPairValidator,
+  validateToolPairSequence,
+  type ToolPairMessage,
+  type ToolPairIntegrityFailure,
+  type ToolPairOperationalDeferral,
+  type ToolPairProjection,
+  type ToolPairValidationOutcome,
+} from "./tool-pair-validator.js";
+import { formatIdentityForLog } from "./tool-result-integrity.js";
 
 export interface RolloutStoreOpts extends SessionStoreOpts {
   /** Flush interval in ms. Default 100. */
   readonly flushIntervalMs?: number;
   /** Whether to auto-start the background flush scheduler. Default true. */
   readonly autoStartScheduler?: boolean;
+  /** Test-only crash seam immediately before the atomic v2 inode swap. */
+  readonly beforeCheckpointUpgradePublishForTestingOnly?: () => void;
+}
+
+export class DurableCheckpointUpgradeBlockedError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly outcome:
+      | DurableCheckpointUpgradeFailure
+      | DurableCheckpointUpgradeDeferral
+      | ToolPairIntegrityFailure
+      | ToolPairOperationalDeferral,
+  ) {
+    super(
+      `durable checkpoint upgrade blocked for run ${formatIdentityForLog(runId)}: ${outcome.reason}. Resume remains disabled; preserve the rollout, then restore intact source bytes from backup or start a new session`,
+    );
+    this.name = "DurableCheckpointUpgradeBlockedError";
+  }
+}
+
+export interface DurableCheckpointProjectionContext {
+  readonly projection: ToolPairProjection;
+  readonly projectionId: string;
+  readonly sourceKey: string;
+  readonly expectedRunId: string;
+}
+
+export class ToolPairHistoryBlockedError extends Error {
+  constructor(
+    readonly purpose: string,
+    readonly outcome: Exclude<
+      ToolPairValidationOutcome,
+      { readonly status: "valid" }
+    >,
+  ) {
+    super(
+      `tool-pair history rejected during ${purpose}: ${
+        outcome.status === "dangling"
+          ? "tool calls remain unresolved"
+          : outcome.failure.reason
+      }`,
+    );
+    this.name = "ToolPairHistoryBlockedError";
+  }
 }
 
 export class TerminalRunEpochOpenError extends Error {
@@ -121,6 +185,27 @@ function rolloutContentContainsTerminal(
   return rolloutItemsContainTerminal(items, runId, epoch);
 }
 
+function checkpointProjectionIdentity(
+  rolloutPath: string,
+  purpose: string,
+): string {
+  const hash = createHash("sha256");
+  hash.update("agenc.checkpoint-projection.v1");
+  hash.update("\0");
+  hash.update(rolloutPath);
+  hash.update("\0");
+  hash.update(purpose);
+  return hash.digest("hex");
+}
+
+function* responseItemsForToolPairValidation(
+  items: Iterable<RolloutItem>,
+): Iterable<ToolPairMessage> {
+  for (const item of items) {
+    if (item.type === "response_item") yield item.payload;
+  }
+}
+
 export class RolloutStore {
   readonly store: SessionStore;
   private readonly scheduler: SessionStoreFlushScheduler;
@@ -132,6 +217,9 @@ export class RolloutStore {
   private readonly threadSpawnEdgeRepo: ThreadSpawnEdgeRepository;
   private readonly runDurabilityRepo: StateRunDurabilityRepository;
   private readonly retrySafeDeferredEffectSteps = new Set<string>();
+  private readonly beforeCheckpointUpgradePublishForTestingOnly?: () => void;
+  private liveToolPairProjection: ToolPairProjection | undefined;
+  private liveToolPairValidator: StreamingToolPairValidator | undefined;
   private openedAt: string | undefined;
   private openedEpoch: number | undefined;
 
@@ -154,6 +242,8 @@ export class RolloutStore {
     });
     this.threadSpawnEdgeRepo = new ThreadSpawnEdgeRepository(this.stateDriver);
     this.runDurabilityRepo = new StateRunDurabilityRepository(this.stateDriver);
+    this.beforeCheckpointUpgradePublishForTestingOnly =
+      opts.beforeCheckpointUpgradePublishForTestingOnly;
     this.loadThreadSpawnEdges();
   }
 
@@ -172,6 +262,8 @@ export class RolloutStore {
       }
 
       this.store.open(meta);
+      this.promoteDurableCheckpointSchema(meta);
+      this.rebuildLiveToolPairProjection();
       // Re-check under the canonical rollout lease. Retention can retire the
       // binding between the optimistic check above and lock acquisition; a
       // source carrying an inactive binding is historical and must never be
@@ -380,6 +472,17 @@ export class RolloutStore {
   }
 
   appendRollout(item: RolloutItem, opts: AppendOptions = {}): void {
+    if (item.type === "response_item") {
+      this.validateLiveResponseItem(item.payload);
+    } else if (item.type === "compacted") {
+      this.assertLiveToolPairBoundary("compaction append");
+      if (item.payload.replacementHistory !== undefined) {
+        this.assertValidToolPairHistory(
+          item.payload.replacementHistory,
+          "compaction append",
+        );
+      }
+    }
     this.store.appendRollout(item, opts);
   }
 
@@ -393,6 +496,177 @@ export class RolloutStore {
 
   get sessionId(): string {
     return this.store.sessionId;
+  }
+
+  /** Fresh exact projection namespace for raw-prefix validation. */
+  checkpointProjectionContext(purpose: string): DurableCheckpointProjectionContext {
+    return this.toolPairProjectionContext(purpose, true);
+  }
+
+  private toolPairProjectionContext(
+    purpose: string,
+    discardOnTerminal: boolean,
+  ): DurableCheckpointProjectionContext {
+    const identity = checkpointProjectionIdentity(this.rolloutPath, purpose);
+    return {
+      projection: new StateToolPairProjection(this.stateDriver, {
+        discardOnTerminal,
+      }),
+      projectionId: `checkpoint:${identity}`,
+      sourceKey: `rollout:${checkpointProjectionIdentity(this.rolloutPath, "source")}`,
+      expectedRunId: this.sessionId,
+    };
+  }
+
+  /** Validate a complete durable history at a semantic replacement boundary. */
+  assertValidToolPairHistory(
+    messages: Iterable<ToolPairMessage>,
+    purpose: string,
+  ): void {
+    const projectionContext = this.checkpointProjectionContext(
+      `history:${purpose}`,
+    );
+    const outcome = validateToolPairSequence(messages, projectionContext.projection, {
+      projectionId: projectionContext.projectionId,
+      sourceKey: projectionContext.sourceKey,
+      requireResultIntegrity: true,
+      expectedRunId: this.sessionId,
+    });
+    if (outcome.status !== "valid") {
+      throw new ToolPairHistoryBlockedError(purpose, outcome);
+    }
+  }
+
+  private promoteDurableCheckpointSchema(
+    meta: Parameters<SessionStore["open"]>[0],
+  ): void {
+    const items = this.store.readAll();
+    const projectionContext = this.checkpointProjectionContext("upgrade");
+    const outcome = planLegacyDurableCheckpointUpgrade({
+      items,
+      runId: meta.sessionId,
+      ...projectionContext,
+    });
+    if (outcome.status !== "planned") {
+      throw new DurableCheckpointUpgradeBlockedError(
+        meta.sessionId,
+        outcome.failure,
+      );
+    }
+    const { plan } = outcome;
+    if (!plan.changed && !plan.sessionMetaPromotionRequired) return;
+    this.assertUpgradeableToolPairSequence(
+      meta.sessionId,
+      responseItemsForToolPairValidation(plan.upgradedItems),
+      "canonical-response-stream",
+      true,
+    );
+    for (let itemIndex = 0; itemIndex < plan.upgradedItems.length; itemIndex += 1) {
+      const item = plan.upgradedItems[itemIndex];
+      if (
+        item?.type !== "compacted" ||
+        item.payload.replacementHistory === undefined
+      ) {
+        continue;
+      }
+      this.assertUpgradeableToolPairSequence(
+        meta.sessionId,
+        item.payload.replacementHistory,
+        `replacement-history:${itemIndex}`,
+        false,
+      );
+    }
+    const upgradedItems = plan.sessionMetaPromotionRequired
+      ? [
+          {
+            type: "session_meta" as const,
+            payload: {
+              ...meta,
+              rolloutSchemaVersion: DURABLE_ROLLOUT_SCHEMA_V2,
+            },
+          },
+          ...plan.upgradedItems,
+        ]
+      : plan.upgradedItems;
+    this.beforeCheckpointUpgradePublishForTestingOnly?.();
+    this.store.rewriteRolloutItemsAtomically(upgradedItems);
+  }
+
+  private assertUpgradeableToolPairSequence(
+    runId: string,
+    messages: Iterable<ToolPairMessage>,
+    purpose: string,
+    allowDanglingAtEnd: boolean,
+  ): void {
+    const context = this.checkpointProjectionContext(`upgrade-history:${purpose}`);
+    const outcome = validateToolPairSequence(messages, context.projection, {
+      projectionId: context.projectionId,
+      sourceKey: context.sourceKey,
+      requireResultIntegrity: true,
+      expectedRunId: runId,
+      allowDanglingAtEnd,
+    });
+    if (outcome.status === "invalid" || outcome.status === "deferred") {
+      throw new DurableCheckpointUpgradeBlockedError(runId, outcome.failure);
+    }
+  }
+
+  private rebuildLiveToolPairProjection(): void {
+    const context = this.toolPairProjectionContext("live-append", false);
+    let validator: StreamingToolPairValidator | undefined;
+    context.projection.runAtomically(() => {
+      validator = new StreamingToolPairValidator(context.projection, {
+        projectionId: context.projectionId,
+        sourceKey: context.sourceKey,
+        requireResultIntegrity: true,
+        expectedRunId: this.sessionId,
+      });
+      for (const item of this.store.readAll()) {
+        if (item.type !== "response_item") continue;
+        const outcome = validator.push(item.payload);
+        if (outcome !== undefined) {
+          throw new ToolPairHistoryBlockedError("live projection rebuild", outcome);
+        }
+      }
+      const outcome = validator.finish({
+        allowDanglingAtEnd: true,
+        persistSuccess: false,
+      });
+      if (outcome.status === "invalid" || outcome.status === "deferred") {
+        throw new ToolPairHistoryBlockedError("live projection rebuild", outcome);
+      }
+    });
+    if (validator === undefined) {
+      throw new Error("live tool-pair projection did not initialize");
+    }
+    this.liveToolPairProjection = context.projection;
+    this.liveToolPairValidator = validator;
+  }
+
+  private validateLiveResponseItem(message: ToolPairMessage): void {
+    const projection = this.liveToolPairProjection;
+    const validator = this.liveToolPairValidator;
+    if (projection === undefined || validator === undefined) {
+      throw new Error("live tool-pair projection is unavailable");
+    }
+    const outcome = projection.runAtomically(() => validator.push(message));
+    if (outcome !== undefined) {
+      throw new ToolPairHistoryBlockedError("live append", outcome);
+    }
+  }
+
+  private assertLiveToolPairBoundary(purpose: string): void {
+    const projection = this.liveToolPairProjection;
+    const validator = this.liveToolPairValidator;
+    if (projection === undefined || validator === undefined) {
+      throw new Error("live tool-pair projection is unavailable");
+    }
+    const outcome = projection.runAtomically(() =>
+      validator.finish({ persistSuccess: false }),
+    );
+    if (outcome.status !== "valid") {
+      throw new ToolPairHistoryBlockedError(purpose, outcome);
+    }
   }
 
   /** M3 pre-dispatch gate backed by the same project state database. */

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -145,7 +145,12 @@ import { reserveRecoveryReentry } from "../recovery/fallback-ladder.js";
 import * as planModeHelpers from "./plan-mode.js";
 import type { CompactedItem, ResponseItem } from "./rollout-item.js";
 import type { IdleInputOwnership, Session } from "./session.js";
-import { llmMessageToResponseItem } from "./message-history-conversion.js";
+import {
+  llmMessageToCheckpointResponseItem,
+  llmMessageToDurableResponseItem,
+  llmMessageToReplacementResponseItem,
+  responseItemToLlmMessage,
+} from "./message-history-conversion.js";
 import {
   modelContextWindow,
   toTurnContextItem,
@@ -184,11 +189,15 @@ import {
   type TurnState,
 } from "./turn-state.js";
 import {
-  computePrefixHash,
   currentBuildId,
   resolveDurableTurnsConfig,
   sideEffectHaltMessage,
 } from "./durable-turns.js";
+import { computeCheckpointPrefixHashV2 } from "./durable-checkpoint-reader.js";
+import {
+  createToolResultIntegrity,
+  verifyToolResultIntegrity,
+} from "./tool-result-integrity.js";
 import {
   evaluateBehavioralBackstop,
   recordBehavioralStep,
@@ -343,6 +352,7 @@ interface AgenCMessage {
   readonly toolCallId?: string;
   readonly toolName?: string;
   readonly phase?: string;
+  readonly runtimeOnly?: LLMMessage["runtimeOnly"];
 }
 
 type AgenCRuntimeWireRole = NonNullable<RuntimeMessage["role"]>;
@@ -508,9 +518,9 @@ function buildAgenCCompactedRolloutItem(
 }
 
 function buildAgenCPostCompactMessages(
-  result: NonNullable<AgenCAutoCompactResult["compactionResult"]>,
+  result: CompactedItem,
 ): LLMMessage[] {
-  return result.replacementHistory.map((message) => ({ ...message }));
+  return (result.replacementHistory ?? []).map(responseItemToLlmMessage);
 }
 
 function toAgenCMessage(message: LLMMessage): AgenCMessage {
@@ -522,6 +532,13 @@ function toAgenCMessage(message: LLMMessage): AgenCMessage {
       : {}),
     ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
     ...(message.phase !== undefined ? { phase: message.phase } : {}),
+    ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+      ? {
+          runtimeOnly: {
+            toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+          },
+        }
+      : {}),
   };
 }
 
@@ -534,7 +551,11 @@ function buildCompactedRolloutPayload(params: {
   return {
     message: params.message,
     ...(params.replacementHistory !== undefined
-      ? { replacementHistory: params.replacementHistory.map(toResponseItem) }
+      ? {
+          replacementHistory: params.replacementHistory.map((message) =>
+            llmMessageToReplacementResponseItem(message, "compacted"),
+          ),
+        }
       : {}),
     ...(params.preCompactTokens !== undefined
       ? { preCompactTokens: params.preCompactTokens }
@@ -892,6 +913,13 @@ function fromAgenCRuntimeMessage(
       ...(message.phase === "commentary" || message.phase === "final_answer"
         ? { phase: message.phase }
         : {}),
+      ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+        ? {
+            runtimeOnly: {
+              toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+            },
+          }
+        : {}),
     };
   }
   const role = normalizeRole(message.message?.role ?? message.type);
@@ -906,6 +934,20 @@ function fromAgenCRuntimeMessage(
             name: call.name,
             arguments: call.arguments ?? "",
           })),
+        }
+      : {}),
+    ...(message.toolCallId !== undefined
+      ? { toolCallId: message.toolCallId }
+      : {}),
+    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
+    ...(message.phase === "commentary" || message.phase === "final_answer"
+      ? { phase: message.phase }
+      : {}),
+    ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+      ? {
+          runtimeOnly: {
+            toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+          },
         }
       : {}),
   };
@@ -1865,8 +1907,57 @@ function isAutoCompactEnabledForNotices(): boolean {
   return !TRUTHY_ENV.has(raw.trim().toLowerCase());
 }
 
-function toResponseItem(message: LLMMessage): ResponseItem {
-  return llmMessageToResponseItem(message);
+function sealToolResultMessage(
+  message: LLMMessage,
+  runId: string,
+): LLMMessage {
+  if (message.role !== "tool") {
+    if (message.runtimeOnly?.toolResultIntegrity !== undefined) {
+      throw new Error(
+        "tool-result integrity metadata is attached to a non-tool message",
+      );
+    }
+    return message;
+  }
+  const toolCallId = message.toolCallId;
+  if (toolCallId === undefined || toolCallId.trim().length === 0) {
+    throw new Error("durable tool result is missing its tool-call identity");
+  }
+  const existing = message.runtimeOnly?.toolResultIntegrity;
+  if (existing !== undefined) {
+    const verification = verifyToolResultIntegrity({
+      integrity: existing,
+      expectedRunId: runId,
+      toolCallId,
+      content: message.content,
+    });
+    if (verification.status !== "valid") {
+      throw new Error(
+        `durable tool-result integrity refused: ${verification.failure.reason}`,
+      );
+    }
+    return message;
+  }
+  return {
+    ...message,
+    runtimeOnly: {
+      ...message.runtimeOnly,
+      toolResultIntegrity: createToolResultIntegrity({
+        runId,
+        toolCallId,
+        content: message.content,
+      }),
+    },
+  };
+}
+
+function requireSealedToolResult(message: ResponseItem): void {
+  if (
+    message.role === "tool" &&
+    message.toolResultIntegrity === undefined
+  ) {
+    throw new Error("checkpoint v2 requires every tool result to be sealed");
+  }
 }
 
 function terminalToStopReason(
@@ -2129,6 +2220,7 @@ async function runAutoCompact(
         );
       }
       const cr = result.compactionResult;
+      const compactedRollout = buildAgenCCompactedRolloutItem(cr);
       // Honor the rollout-persistence suspension invariant. Every other
       // durable write in the turn engine is gated on this flag
       // (session.emit at session.ts, persistTurnRolloutBaseline /
@@ -2139,16 +2231,18 @@ async function runAutoCompact(
       // replacementHistory into the source session's durable rollout —
       // doing so makes the fork's summarized history the baseline on a
       // later --resume and silently destroys the user's real conversation.
-      if (cr && !session.isRolloutPersistenceSuspended?.()) {
-        session.rolloutStore?.appendRollout(
-          {
-            type: "compacted",
-            payload: buildAgenCCompactedRolloutItem(cr),
-          },
+      if (
+        cr &&
+        !session.isRolloutPersistenceSuspended?.() &&
+        session.rolloutStore !== null &&
+        session.rolloutStore !== undefined
+      ) {
+        session.rolloutStore.appendRollout(
+          { type: "compacted", payload: compactedRollout },
           { durable: true },
         );
       }
-      const compacted = buildAgenCPostCompactMessages(cr);
+      const compacted = buildAgenCPostCompactMessages(compactedRollout);
       const unsentImageTurn = shouldKeepUnsentImageTurn
         ? state.messages.at(-1)
         : undefined;
@@ -3883,12 +3977,40 @@ async function* runTurnKernelInner(
     if (state.messages.length < persistedMessageCount) {
       persistedMessageCount = state.messages.length;
     }
-    const nextItems = state.messages.slice(persistedMessageCount);
-    for (const message of nextItems) {
+    for (
+      let messageIndex = persistedMessageCount;
+      messageIndex < state.messages.length;
+      messageIndex += 1
+    ) {
+      const sourceMessage = state.messages[messageIndex];
+      if (sourceMessage === undefined) continue;
+      const message = sealToolResultMessage(
+        sourceMessage,
+        session.conversationId,
+      );
+      state.messages[messageIndex] = message;
       if (excludeFromDurableHistory(message)) continue;
+      const durableItem = llmMessageToDurableResponseItem(message);
+      if (
+        message.runtimeOnly?.toolResultIntegrity !== undefined &&
+        durableItem.toolResultIntegrity !== undefined
+      ) {
+        state.messages[messageIndex] = {
+          ...message,
+          runtimeOnly: {
+            ...message.runtimeOnly,
+            toolResultIntegrity: {
+              ...message.runtimeOnly.toolResultIntegrity,
+              persisted: durableItem.toolResultIntegrity.persisted,
+            },
+          },
+        };
+      } else {
+        state.messages[messageIndex] = message;
+      }
       session.rolloutStore.appendRollout({
         type: "response_item",
-        payload: toResponseItem(message),
+        payload: durableItem,
       });
     }
     persistedMessageCount = state.messages.length;
@@ -3989,14 +4111,18 @@ async function* runTurnKernelInner(
     // and any runtime-only messages, mirroring `syncSessionState`'s
     // `durableHistory`. `persistedMessageCount` is the LENGTH of that
     // projection (== reconstructed history length), NOT a `state.messages`
-    // index. The hash is bound/truncation-stable (tool-output bodies are
-    // excluded — see canonicalMessage), so in-memory bounding cannot make a
-    // resumed prefix spuriously mismatch.
+    // index. Tool-result entries contribute their authenticated persisted-body
+    // identity, so the hash still represents the exact durable body even after
+    // the corresponding in-memory content has been bounded.
     const durablePrefix = state.messages
       .slice(durableHistoryStartIndex(state.messages))
       .filter((message) => !excludeFromDurableHistory(message))
-      .map((message) => toResponseItem(message));
-    const prefixHash = computePrefixHash(durablePrefix, durablePrefix.length);
+      .map((message) => llmMessageToCheckpointResponseItem(message));
+    for (const message of durablePrefix) requireSealedToolResult(message);
+    const prefixHash = computeCheckpointPrefixHashV2(
+      durablePrefix,
+      durablePrefix.length,
+    );
     session.emit({
       id: session.nextInternalSubId(),
       msg: {
@@ -4008,6 +4134,8 @@ async function* runTurnKernelInner(
           checkpointSeq,
           persistedMessageCount: durablePrefix.length,
           prefixHash,
+          checkpointVersion: 2,
+          toolResultIntegrityVersion: 1,
           resumableState: toCheckpointSlice(state),
         },
       },

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -1565,13 +1565,50 @@ export class SessionStore {
       throw new Error("rewriteRolloutAtomically called on unopened store");
     }
     rewriteAtomically(this.rolloutPath, bytes);
-    // Reset the in-memory file size + offset index so subsequent
-    // appends know the new EOF. Offsets are rebuilt lazily as new
-    // events are appended; any caller doing a compaction rewrite is
-    // expected to also reset lastSeqWritten if needed.
+    // Refresh the in-memory EOF for subsequent appends. Callers using raw
+    // bytes own any semantic index changes; rewriteRolloutItemsAtomically()
+    // rebuilds offsets and sequence state from its typed item sequence.
     this.fileSize = typeof bytes === "string"
       ? Buffer.byteLength(bytes, "utf8")
       : bytes.byteLength;
+  }
+
+  /**
+   * Publish a complete canonical RolloutItem sequence in one inode swap and
+   * refresh the metadata cached by future tail re-appends. This is the only
+   * supported publication seam for the A3 legacy-to-v2 upgrade.
+   */
+  rewriteRolloutItemsAtomically(items: ReadonlyArray<RolloutItem>): void {
+    if (this.pending.length > 0) {
+      throw new Error("cannot atomically replace rollout with pending appends");
+    }
+    const lines = items.map(serializeRolloutItem);
+    const nextOffsetsBySeq = new Map<EventSeq, number>();
+    let nextLastSeq: EventSeq = 0;
+    let offset = 0;
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+      const line = lines[index];
+      if (item === undefined || line === undefined) continue;
+      if (item.type === "event_msg" && item.payload.seq !== undefined) {
+        nextOffsetsBySeq.set(item.payload.seq, offset);
+        nextLastSeq = Math.max(nextLastSeq, item.payload.seq);
+      }
+      offset += Buffer.byteLength(line, "utf8");
+    }
+    const bytes = lines.join("");
+    this.rewriteRolloutAtomically(bytes);
+    this.offsetsBySeq.clear();
+    for (const [seq, byteOffset] of nextOffsetsBySeq) {
+      this.offsetsBySeq.set(seq, byteOffset);
+    }
+    this.boundIndexMap(this.offsetsBySeq);
+    this.lastSeqWritten = nextLastSeq;
+    let latestMeta: SessionMetaLine | undefined;
+    for (const item of items) {
+      if (item.type === "session_meta") latestMeta = item.payload;
+    }
+    this.lastSessionMeta = latestMeta ?? null;
   }
 
   /**

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -141,8 +141,10 @@ import type { AppendOptions } from "./session-store.js";
 import { hitM4DurabilityFailpoint } from "../durability/failpoints.js";
 import {
   cloneLlmMessage,
-  llmMessageToResponseItem,
+  llmMessageToReplacementResponseItem,
+  responseItemToLlmMessage,
 } from "./message-history-conversion.js";
+import type { ToolResultIntegrity } from "./tool-result-integrity.js";
 import {
   createHistoryReplacedEvent,
   type HistoryReplacedEvent,
@@ -1845,14 +1847,17 @@ function normalizeHistoryMessages(
   const normalized: LLMMessage[] = [];
   for (const item of history) {
     if (!item || typeof item !== "object") continue;
-    const candidate = item as Partial<LLMMessage> & {
+    const candidate = item as {
       role?: unknown;
       content?: unknown;
       phase?: unknown;
       toolCalls?: unknown;
       toolCallId?: unknown;
       toolName?: unknown;
-      runtimeOnly?: { userMessageId?: unknown };
+      runtimeOnly?: {
+        userMessageId?: unknown;
+        toolResultIntegrity?: ToolResultIntegrity;
+      };
     };
     if (
       candidate.role !== "system" &&
@@ -1882,14 +1887,22 @@ function normalizeHistoryMessages(
       ...(typeof candidate.toolName === "string"
         ? { toolName: candidate.toolName }
         : {}),
-      // Preserve ONLY the file-history join key from runtimeOnly —
-      // conversation rewind resolves the sidecar's barrier snapshot
-      // through it. The rest of the runtimeOnly bag stays dropped so
-      // normalized snapshots don't resurrect merge/durability flags.
-      ...(typeof candidate.runtimeOnly?.userMessageId === "string"
+      // Preserve the file-history join key and A3 durable tool-result seal.
+      // Other transient flags stay dropped so normalized snapshots cannot
+      // resurrect merge/exclusion semantics.
+      ...(typeof candidate.runtimeOnly?.userMessageId === "string" ||
+      candidate.runtimeOnly?.toolResultIntegrity !== undefined
         ? {
             runtimeOnly: {
-              userMessageId: candidate.runtimeOnly.userMessageId,
+              ...(typeof candidate.runtimeOnly?.userMessageId === "string"
+                ? { userMessageId: candidate.runtimeOnly.userMessageId }
+                : {}),
+              ...(candidate.runtimeOnly?.toolResultIntegrity !== undefined
+                ? {
+                    toolResultIntegrity:
+                      candidate.runtimeOnly.toolResultIntegrity,
+                  }
+                : {}),
             },
           }
         : {}),
@@ -2005,6 +2018,13 @@ function toCompactRuntimeMessages(
         : {}),
       ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
       ...(message.phase !== undefined ? { phase: message.phase } : {}),
+      ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+        ? {
+            runtimeOnly: {
+              toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+            },
+          }
+        : {}),
       ...(message.role === "tool" ? { isMeta: true } : {}),
     };
   });
@@ -2065,6 +2085,13 @@ function fromCompactRuntimeMessage(message: RuntimeMessage): LLMMessage | null {
     ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
     ...(message.phase === "commentary" || message.phase === "final_answer"
       ? { phase: message.phase }
+      : {}),
+    ...(message.runtimeOnly?.toolResultIntegrity !== undefined
+      ? {
+          runtimeOnly: {
+            toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
+          },
+        }
       : {}),
   };
 }
@@ -3774,14 +3801,15 @@ export class Session {
       const postCompactTokens =
         params.compactionResult.truePostCompactTokenCount ??
         params.compactionResult.postCompactTokenCount;
+      const replacementItems = params.replacementHistory.map((message) =>
+        llmMessageToReplacementResponseItem(message, "compacted"),
+      );
       params.rolloutStore.appendRollout(
         {
           type: "compacted",
           payload: {
             message: compactionMessage(params.compactionResult),
-            replacementHistory: params.replacementHistory.map(
-              llmMessageToResponseItem,
-            ),
+            replacementHistory: replacementItems,
             ...(params.compactionResult.preCompactTokenCount !== undefined
               ? {
                   preCompactTokens:
@@ -3794,7 +3822,7 @@ export class Session {
         { durable: true },
       );
       await this.state.with((sessionState) => {
-        sessionState.history = params.replacementHistory.map(cloneLlmMessage);
+        sessionState.history = replacementItems.map(responseItemToLlmMessage);
       });
       this.clearProviderResponseId();
     });
@@ -3825,20 +3853,21 @@ export class Session {
         );
         return;
       }
+      const replacementItems = params.replacementHistory.map((message) =>
+        llmMessageToReplacementResponseItem(message, "truncated"),
+      );
       params.rolloutStore.appendRollout(
         {
           type: "compacted",
           payload: {
             message: "Conversation rewound",
-            replacementHistory: params.replacementHistory.map(
-              llmMessageToResponseItem,
-            ),
+            replacementHistory: replacementItems,
           },
         },
         { durable: true },
       );
       await this.state.with((sessionState) => {
-        sessionState.history = params.replacementHistory.map(cloneLlmMessage);
+        sessionState.history = replacementItems.map(responseItemToLlmMessage);
       });
       this.clearProviderResponseId();
     });

--- a/runtime/src/session/tool-pair-validator.ts
+++ b/runtime/src/session/tool-pair-validator.ts
@@ -43,6 +43,11 @@ export interface ToolPairProjectionSummary {
   readonly logicalIndexBytes: number;
 }
 
+export interface ToolPairDanglingUse {
+  readonly callId: string;
+  readonly toolName: string;
+}
+
 /**
  * Exact index used by the ordered scanner. The production implementation is
  * SQLite-backed; this interface keeps the session-layer state machine free of
@@ -67,6 +72,10 @@ export interface ToolPairProjection {
     readonly originalResultDigest?: string;
   }): "resolved" | "already_resolved" | "missing";
   complete(projectionId: string, summary: ToolPairProjectionSummary): void;
+  completeDangling(
+    projectionId: string,
+    summary: ToolPairProjectionSummary,
+  ): void;
   fail(
     projectionId: string,
     summary: ToolPairProjectionSummary,
@@ -117,6 +126,12 @@ export type ToolPairValidationOutcome =
       readonly summary: ToolPairProjectionSummary;
     }
   | {
+      /** Structurally valid prefix ending at an explicitly permitted call boundary. */
+      readonly status: "dangling";
+      readonly summary: ToolPairProjectionSummary;
+      readonly danglingToolUses: ReadonlyArray<ToolPairDanglingUse>;
+    }
+  | {
       readonly status: "invalid";
       readonly failure: ToolPairIntegrityFailure;
       readonly summary: ToolPairProjectionSummary;
@@ -134,6 +149,7 @@ interface ToolPairValidationLimits {
   readonly maxOpenToolCalls?: number;
   readonly maxToolCallIdBytes?: number;
   readonly maxIndexBytes?: number;
+  readonly allowDanglingAtEnd?: boolean;
 }
 
 export type ToolPairValidationOptions = ToolPairValidationLimits &
@@ -153,6 +169,410 @@ interface OpenToolCall {
   readonly assistantIndex: number;
 }
 
+type ToolPairFailureOutcome =
+  | { readonly status: "invalid"; readonly failure: ToolPairIntegrityFailure }
+  | {
+      readonly status: "deferred";
+      readonly failure: ToolPairOperationalDeferral;
+    };
+
+type ToolPairTerminalFailureOutcome = Extract<
+  ToolPairValidationOutcome,
+  { readonly status: "invalid" | "deferred" }
+>;
+
+interface FinishToolPairValidationOptions {
+  readonly allowDanglingAtEnd?: boolean;
+  readonly persistSuccess?: boolean;
+}
+
+/**
+ * Stateful ordered validator shared by offline scans and the live append path.
+ * Resolved IDs live only in the exact projection; the JS heap retains the
+ * bounded unresolved set and scalar counters.
+ */
+export class StreamingToolPairValidator {
+  private readonly limits: ReturnType<typeof resolveLimits>;
+  private readonly openCalls = new Map<string, OpenToolCall>();
+  private callCount = 0;
+  private resolvedCount = 0;
+  private maximumOpenCallCount = 0;
+  private logicalIndexBytes = 0;
+  private index = 0;
+  private terminalFailure: ToolPairTerminalFailureOutcome | undefined;
+
+  constructor(
+    private readonly projection: ToolPairProjection,
+    private readonly options: ToolPairValidationOptions,
+  ) {
+    this.limits = resolveLimits(options);
+    projection.reset({
+      projectionId: options.projectionId,
+      sourceKey: options.sourceKey,
+    });
+  }
+
+  push(message: ToolPairMessage): ToolPairTerminalFailureOutcome | undefined {
+    if (this.terminalFailure !== undefined) return this.terminalFailure;
+    if (
+      message.role === "assistant" &&
+      message.toolCalls !== undefined &&
+      message.toolCalls.length > 0
+    ) {
+      return this.pushAssistantToolCalls(message.toolCalls);
+    }
+    if (message.role === "tool") return this.pushToolResult(message);
+    if (this.openCalls.size > 0) {
+      return this.finishFailure(
+        invalid(
+          "tool_result_missing",
+          this.index,
+          `tool results must immediately follow their assistant calls; unresolved: ${summarizeOpenIds(this.openCalls)}`,
+        ),
+      );
+    }
+    this.index += 1;
+    return undefined;
+  }
+
+  finish(
+    options: FinishToolPairValidationOptions = {},
+  ): ToolPairValidationOutcome {
+    if (this.terminalFailure !== undefined) return this.terminalFailure;
+    const allowDanglingAtEnd =
+      options.allowDanglingAtEnd ??
+      this.options.allowDanglingAtEnd ??
+      false;
+    if (this.openCalls.size > 0) {
+      if (!allowDanglingAtEnd) {
+        return this.finishFailure(
+          invalid(
+            "tool_result_missing",
+            null,
+            `tool-pair stream ended with unresolved calls: ${summarizeOpenIds(this.openCalls)}`,
+          ),
+        );
+      }
+      const summary = this.summary();
+      if (options.persistSuccess !== false) {
+        this.projection.completeDangling(this.options.projectionId, summary);
+      }
+      return {
+        status: "dangling",
+        summary,
+        danglingToolUses: Array.from(
+          this.openCalls,
+          ([callId, call]) => ({ callId, toolName: call.toolName }),
+        ),
+      };
+    }
+    const summary = this.summary();
+    if (options.persistSuccess !== false) {
+      this.projection.complete(this.options.projectionId, summary);
+    }
+    return { status: "valid", summary };
+  }
+
+  summary(): ToolPairProjectionSummary {
+    return {
+      callCount: this.callCount,
+      resolvedCount: this.resolvedCount,
+      openCallCount: this.openCalls.size,
+      maximumOpenCallCount: this.maximumOpenCallCount,
+      logicalIndexBytes: this.logicalIndexBytes,
+    };
+  }
+
+  private pushAssistantToolCalls(
+    toolCalls: NonNullable<ToolPairMessage["toolCalls"]>,
+  ): ToolPairTerminalFailureOutcome | undefined {
+    if (this.openCalls.size > 0) {
+      return this.finishFailure(
+        invalid(
+          "assistant_tool_calls_before_results",
+          this.index,
+          `assistant tool calls started before resolving: ${summarizeOpenIds(this.openCalls)}`,
+        ),
+      );
+    }
+    if (toolCalls.length > this.limits.maxOpenToolCalls) {
+      return this.finishFailure(
+        deferred(
+          "tool_pair_open_call_limit",
+          this.index,
+          `assistant message opens ${toolCalls.length} tool calls; limit is ${this.limits.maxOpenToolCalls}`,
+        ),
+      );
+    }
+    for (const call of toolCalls) {
+      if (typeof call.id !== "string" || call.id.trim().length === 0) {
+        return this.finishFailure(
+          invalid(
+            "assistant_tool_call_id_missing",
+            this.index,
+            "assistant tool call has an empty identity",
+          ),
+        );
+      }
+      if (typeof call.name !== "string" || call.name.trim().length === 0) {
+        return this.finishFailure(
+          invalid(
+            "assistant_tool_call_name_missing",
+            this.index,
+            `assistant tool call ${formatIdentityForLog(call.id)} has an empty tool name`,
+          ),
+        );
+      }
+      const callIdBytes = Buffer.byteLength(call.id, "utf8");
+      if (callIdBytes > this.limits.maxToolCallIdBytes) {
+        return this.finishFailure(
+          deferred(
+            "tool_call_id_limit",
+            this.index,
+            `tool call identity is ${callIdBytes} UTF-8 bytes; limit is ${this.limits.maxToolCallIdBytes}`,
+          ),
+        );
+      }
+
+      // Exact duplicate lookup intentionally precedes the count limit.
+      if (
+        this.projection.find(this.options.projectionId, call.id) !== undefined
+      ) {
+        return this.finishFailure(
+          invalid(
+            "assistant_tool_call_id_duplicate",
+            this.index,
+            `assistant tool call repeats ${formatIdentityForLog(call.id)}`,
+          ),
+        );
+      }
+      if (this.callCount >= this.limits.maxToolCalls) {
+        return this.finishFailure(
+          deferred(
+            "tool_pair_call_limit",
+            this.index,
+            `tool-pair scan exceeds ${this.limits.maxToolCalls} distinct calls`,
+          ),
+        );
+      }
+      const addedIndexBytes =
+        callIdBytes + Buffer.byteLength(call.name, "utf8");
+      if (
+        this.logicalIndexBytes + addedIndexBytes >
+        this.limits.maxIndexBytes
+      ) {
+        return this.finishFailure(
+          deferred(
+            "tool_pair_index_byte_limit",
+            this.index,
+            `tool-pair projection exceeds ${this.limits.maxIndexBytes} logical UTF-8 bytes`,
+          ),
+        );
+      }
+      const inserted = this.projection.insertCall(this.options.projectionId, {
+        callId: call.id,
+        toolName: call.name,
+        assistantIndex: this.index,
+      });
+      if (!inserted) {
+        return this.finishFailure(
+          invalid(
+            "assistant_tool_call_id_duplicate",
+            this.index,
+            `assistant tool call repeats ${formatIdentityForLog(call.id)}`,
+          ),
+        );
+      }
+      this.openCalls.set(call.id, {
+        toolName: call.name,
+        assistantIndex: this.index,
+      });
+      this.callCount += 1;
+      this.logicalIndexBytes += addedIndexBytes;
+    }
+    this.maximumOpenCallCount = Math.max(
+      this.maximumOpenCallCount,
+      this.openCalls.size,
+    );
+    this.index += 1;
+    return undefined;
+  }
+
+  private pushToolResult(
+    message: ToolPairMessage,
+  ): ToolPairTerminalFailureOutcome | undefined {
+    if (
+      typeof message.toolCallId !== "string" ||
+      message.toolCallId.trim().length === 0
+    ) {
+      return this.finishFailure(
+        invalid(
+          "tool_result_id_missing",
+          this.index,
+          "tool result has an empty tool-call identity",
+        ),
+      );
+    }
+    const toolCallIdBytes = Buffer.byteLength(message.toolCallId, "utf8");
+    if (toolCallIdBytes > this.limits.maxToolCallIdBytes) {
+      return this.finishFailure(
+        deferred(
+          "tool_call_id_limit",
+          this.index,
+          `tool result identity is ${toolCallIdBytes} UTF-8 bytes; limit is ${this.limits.maxToolCallIdBytes}`,
+        ),
+      );
+    }
+    const openCall = this.openCalls.get(message.toolCallId);
+    if (openCall === undefined) {
+      const exact = this.projection.find(
+        this.options.projectionId,
+        message.toolCallId,
+      );
+      if (exact?.resultIndex !== undefined) {
+        return this.finishFailure(
+          invalid(
+            "tool_result_duplicate",
+            this.index,
+            `tool result repeats ${formatIdentityForLog(message.toolCallId)}`,
+          ),
+        );
+      }
+      return this.finishFailure(
+        invalid(
+          exact === undefined
+            ? this.callCount === 0
+              ? "tool_result_without_call"
+              : "tool_result_unknown_id"
+            : "tool_result_unknown_id",
+          this.index,
+          `tool result references unknown ${formatIdentityForLog(message.toolCallId)}`,
+        ),
+      );
+    }
+    if (
+      message.toolName !== undefined &&
+      message.toolName !== openCall.toolName
+    ) {
+      return this.finishFailure(
+        invalid(
+          "tool_result_name_mismatch",
+          this.index,
+          `tool result ${formatIdentityForLog(message.toolCallId)} names ${formatIdentityForLog(message.toolName)}, expected ${formatIdentityForLog(openCall.toolName)}`,
+        ),
+      );
+    }
+
+    const integrity = this.verifyResultIntegrity(message);
+    if (integrity.status !== "valid") return integrity.outcome;
+    const addedIndexBytes =
+      integrity.integrity === undefined
+        ? 0
+        : Buffer.byteLength(integrity.integrity.resultId, "utf8") +
+          Buffer.byteLength(integrity.integrity.original.digest, "utf8");
+    if (
+      this.logicalIndexBytes + addedIndexBytes >
+      this.limits.maxIndexBytes
+    ) {
+      return this.finishFailure(
+        deferred(
+          "tool_pair_index_byte_limit",
+          this.index,
+          `tool-pair projection exceeds ${this.limits.maxIndexBytes} logical UTF-8 bytes`,
+        ),
+      );
+    }
+    const resolution = this.projection.resolveCall({
+      projectionId: this.options.projectionId,
+      callId: message.toolCallId,
+      resultIndex: this.index,
+      ...(integrity.integrity === undefined
+        ? {}
+        : {
+            resultId: integrity.integrity.resultId,
+            originalResultDigest: integrity.integrity.original.digest,
+          }),
+    });
+    if (resolution !== "resolved") {
+      return this.finishFailure(
+        invalid(
+          resolution === "already_resolved"
+            ? "tool_result_duplicate"
+            : "tool_result_unknown_id",
+          this.index,
+          `tool result could not resolve ${formatIdentityForLog(message.toolCallId)}`,
+        ),
+      );
+    }
+    this.openCalls.delete(message.toolCallId);
+    this.resolvedCount += 1;
+    this.logicalIndexBytes += addedIndexBytes;
+    this.index += 1;
+    return undefined;
+  }
+
+  private verifyResultIntegrity(message: ToolPairMessage):
+    | { readonly status: "valid"; readonly integrity?: ToolResultIntegrity }
+    | {
+        readonly status: "invalid";
+        readonly outcome: ToolPairTerminalFailureOutcome;
+      } {
+    if (this.options.requireResultIntegrity !== true) {
+      return { status: "valid" };
+    }
+    const verified = verifyToolResultIntegrity({
+      integrity: message.toolResultIntegrity,
+      expectedRunId: this.options.expectedRunId,
+      toolCallId: message.toolCallId as string,
+      content: message.content,
+    });
+    if (verified.status === "invalid") {
+      return {
+        status: "invalid",
+        outcome: this.finishFailure({
+          status: "invalid",
+          failure: {
+            kind: "integrity_failure",
+            code: "tool_result_integrity_invalid",
+            index: this.index,
+            reason: verified.failure.reason,
+            cause: verified.failure,
+          },
+        }),
+      };
+    }
+    if (verified.status === "deferred") {
+      return {
+        status: "invalid",
+        outcome: this.finishFailure({
+          status: "deferred",
+          failure: {
+            kind: "operational_deferral",
+            code: "tool_result_integrity_deferred",
+            index: this.index,
+            reason: verified.failure.reason,
+            cause: verified.failure,
+          },
+        }),
+      };
+    }
+    return { status: "valid", integrity: verified.integrity };
+  }
+
+  private finishFailure(
+    outcome: ToolPairFailureOutcome,
+  ): ToolPairTerminalFailureOutcome {
+    const terminal = { ...outcome, summary: this.summary() };
+    this.projection.fail(
+      this.options.projectionId,
+      terminal.summary,
+      outcome.failure,
+    );
+    this.terminalFailure = terminal;
+    return terminal;
+  }
+}
+
 /**
  * Validate a message stream without retaining every historical ID in the JS
  * heap. Only the bounded open-call set is resident; exact duplicate identity
@@ -163,324 +583,15 @@ export function validateToolPairSequence(
   projection: ToolPairProjection,
   options: ToolPairValidationOptions,
 ): ToolPairValidationOutcome {
-  const limits = resolveLimits(options);
-  let latestSummary = emptySummary();
+  let validator: StreamingToolPairValidator | undefined;
   try {
     return projection.runAtomically(() => {
-      projection.reset({
-        projectionId: options.projectionId,
-        sourceKey: options.sourceKey,
-      });
-      const openCalls = new Map<string, OpenToolCall>();
-      let callCount = 0;
-      let resolvedCount = 0;
-      let maximumOpenCallCount = 0;
-      let logicalIndexBytes = 0;
-      let index = 0;
-
-      const summary = (): ToolPairProjectionSummary => ({
-        callCount,
-        resolvedCount,
-        openCallCount: openCalls.size,
-        maximumOpenCallCount,
-        logicalIndexBytes,
-      });
-      const finishFailure = (
-        outcome:
-          | {
-              readonly status: "invalid";
-              readonly failure: ToolPairIntegrityFailure;
-            }
-          | {
-              readonly status: "deferred";
-              readonly failure: ToolPairOperationalDeferral;
-            },
-      ): ToolPairValidationOutcome => {
-        latestSummary = summary();
-        projection.fail(options.projectionId, latestSummary, outcome.failure);
-        return { ...outcome, summary: latestSummary };
-      };
-
+      validator = new StreamingToolPairValidator(projection, options);
       for (const message of messages) {
-        if (
-          message.role === "assistant" &&
-          message.toolCalls !== undefined &&
-          message.toolCalls.length > 0
-        ) {
-          if (openCalls.size > 0) {
-            return finishFailure(
-              invalid(
-                "assistant_tool_calls_before_results",
-                index,
-                `assistant tool calls started before resolving: ${summarizeOpenIds(openCalls)}`,
-              ),
-            );
-          }
-          if (message.toolCalls.length > limits.maxOpenToolCalls) {
-            return finishFailure(
-              deferred(
-                "tool_pair_open_call_limit",
-                index,
-                `assistant message opens ${message.toolCalls.length} tool calls; limit is ${limits.maxOpenToolCalls}`,
-              ),
-            );
-          }
-          for (const call of message.toolCalls) {
-            if (typeof call.id !== "string" || call.id.trim().length === 0) {
-              return finishFailure(
-                invalid(
-                  "assistant_tool_call_id_missing",
-                  index,
-                  "assistant tool call has an empty identity",
-                ),
-              );
-            }
-            if (
-              typeof call.name !== "string" ||
-              call.name.trim().length === 0
-            ) {
-              return finishFailure(
-                invalid(
-                  "assistant_tool_call_name_missing",
-                  index,
-                  `assistant tool call ${formatIdentityForLog(call.id)} has an empty tool name`,
-                ),
-              );
-            }
-            const callIdBytes = Buffer.byteLength(call.id, "utf8");
-            if (callIdBytes > limits.maxToolCallIdBytes) {
-              return finishFailure(
-                deferred(
-                  "tool_call_id_limit",
-                  index,
-                  `tool call identity is ${callIdBytes} UTF-8 bytes; limit is ${limits.maxToolCallIdBytes}`,
-                ),
-              );
-            }
-
-            // Exact duplicate lookup intentionally precedes the count limit:
-            // after exactly one million distinct calls, replaying the first ID
-            // is still diagnosed as a duplicate rather than hidden by a limit.
-            if (projection.find(options.projectionId, call.id) !== undefined) {
-              return finishFailure(
-                invalid(
-                  "assistant_tool_call_id_duplicate",
-                  index,
-                  `assistant tool call repeats ${formatIdentityForLog(call.id)}`,
-                ),
-              );
-            }
-            if (callCount >= limits.maxToolCalls) {
-              return finishFailure(
-                deferred(
-                  "tool_pair_call_limit",
-                  index,
-                  `tool-pair scan exceeds ${limits.maxToolCalls} distinct calls`,
-                ),
-              );
-            }
-            const addedIndexBytes =
-              callIdBytes + Buffer.byteLength(call.name, "utf8");
-            if (logicalIndexBytes + addedIndexBytes > limits.maxIndexBytes) {
-              return finishFailure(
-                deferred(
-                  "tool_pair_index_byte_limit",
-                  index,
-                  `tool-pair projection exceeds ${limits.maxIndexBytes} logical UTF-8 bytes`,
-                ),
-              );
-            }
-            const inserted = projection.insertCall(options.projectionId, {
-              callId: call.id,
-              toolName: call.name,
-              assistantIndex: index,
-            });
-            if (!inserted) {
-              return finishFailure(
-                invalid(
-                  "assistant_tool_call_id_duplicate",
-                  index,
-                  `assistant tool call repeats ${formatIdentityForLog(call.id)}`,
-                ),
-              );
-            }
-            openCalls.set(call.id, {
-              toolName: call.name,
-              assistantIndex: index,
-            });
-            callCount += 1;
-            logicalIndexBytes += addedIndexBytes;
-          }
-          maximumOpenCallCount = Math.max(maximumOpenCallCount, openCalls.size);
-          index += 1;
-          continue;
-        }
-
-        if (message.role === "tool") {
-          if (
-            typeof message.toolCallId !== "string" ||
-            message.toolCallId.trim().length === 0
-          ) {
-            return finishFailure(
-              invalid(
-                "tool_result_id_missing",
-                index,
-                "tool result has an empty tool-call identity",
-              ),
-            );
-          }
-          const toolCallIdBytes = Buffer.byteLength(message.toolCallId, "utf8");
-          if (toolCallIdBytes > limits.maxToolCallIdBytes) {
-            return finishFailure(
-              deferred(
-                "tool_call_id_limit",
-                index,
-                `tool result identity is ${toolCallIdBytes} UTF-8 bytes; limit is ${limits.maxToolCallIdBytes}`,
-              ),
-            );
-          }
-          const openCall = openCalls.get(message.toolCallId);
-          if (openCall === undefined) {
-            const exact = projection.find(
-              options.projectionId,
-              message.toolCallId,
-            );
-            if (exact?.resultIndex !== undefined) {
-              return finishFailure(
-                invalid(
-                  "tool_result_duplicate",
-                  index,
-                  `tool result repeats ${formatIdentityForLog(message.toolCallId)}`,
-                ),
-              );
-            }
-            return finishFailure(
-              invalid(
-                exact === undefined
-                  ? callCount === 0
-                    ? "tool_result_without_call"
-                    : "tool_result_unknown_id"
-                  : "tool_result_unknown_id",
-                index,
-                `tool result references unknown ${formatIdentityForLog(message.toolCallId)}`,
-              ),
-            );
-          }
-          if (
-            message.toolName !== undefined &&
-            message.toolName !== openCall.toolName
-          ) {
-            return finishFailure(
-              invalid(
-                "tool_result_name_mismatch",
-                index,
-                `tool result ${formatIdentityForLog(message.toolCallId)} names ${formatIdentityForLog(message.toolName)}, expected ${formatIdentityForLog(openCall.toolName)}`,
-              ),
-            );
-          }
-
-          let integrity: ToolResultIntegrity | undefined;
-          if (options.requireResultIntegrity === true) {
-            const verified = verifyToolResultIntegrity({
-              integrity: message.toolResultIntegrity,
-              expectedRunId: options.expectedRunId,
-              toolCallId: message.toolCallId,
-              content: message.content,
-            });
-            if (verified.status === "invalid") {
-              return finishFailure({
-                status: "invalid",
-                failure: {
-                  kind: "integrity_failure",
-                  code: "tool_result_integrity_invalid",
-                  index,
-                  reason: verified.failure.reason,
-                  cause: verified.failure,
-                },
-              });
-            }
-            if (verified.status === "deferred") {
-              return finishFailure({
-                status: "deferred",
-                failure: {
-                  kind: "operational_deferral",
-                  code: "tool_result_integrity_deferred",
-                  index,
-                  reason: verified.failure.reason,
-                  cause: verified.failure,
-                },
-              });
-            }
-            integrity = verified.integrity;
-          }
-
-          const addedIndexBytes =
-            integrity === undefined
-              ? 0
-              : Buffer.byteLength(integrity.resultId, "utf8") +
-                Buffer.byteLength(integrity.original.digest, "utf8");
-          if (logicalIndexBytes + addedIndexBytes > limits.maxIndexBytes) {
-            return finishFailure(
-              deferred(
-                "tool_pair_index_byte_limit",
-                index,
-                `tool-pair projection exceeds ${limits.maxIndexBytes} logical UTF-8 bytes`,
-              ),
-            );
-          }
-          const resolution = projection.resolveCall({
-            projectionId: options.projectionId,
-            callId: message.toolCallId,
-            resultIndex: index,
-            ...(integrity === undefined
-              ? {}
-              : {
-                  resultId: integrity.resultId,
-                  originalResultDigest: integrity.original.digest,
-                }),
-          });
-          if (resolution !== "resolved") {
-            return finishFailure(
-              invalid(
-                resolution === "already_resolved"
-                  ? "tool_result_duplicate"
-                  : "tool_result_unknown_id",
-                index,
-                `tool result could not resolve ${formatIdentityForLog(message.toolCallId)}`,
-              ),
-            );
-          }
-          openCalls.delete(message.toolCallId);
-          resolvedCount += 1;
-          logicalIndexBytes += addedIndexBytes;
-          index += 1;
-          continue;
-        }
-
-        if (openCalls.size > 0) {
-          return finishFailure(
-            invalid(
-              "tool_result_missing",
-              index,
-              `tool results must immediately follow their assistant calls; unresolved: ${summarizeOpenIds(openCalls)}`,
-            ),
-          );
-        }
-        index += 1;
+        const failure = validator.push(message);
+        if (failure !== undefined) return failure;
       }
-
-      if (openCalls.size > 0) {
-        return finishFailure(
-          invalid(
-            "tool_result_missing",
-            null,
-            `tool-pair stream ended with unresolved calls: ${summarizeOpenIds(openCalls)}`,
-          ),
-        );
-      }
-      latestSummary = summary();
-      projection.complete(options.projectionId, latestSummary);
-      return { status: "valid", summary: latestSummary };
+      return validator.finish();
     });
   } catch (error) {
     return {
@@ -491,7 +602,7 @@ export function validateToolPairSequence(
         index: null,
         reason: projectionFailureReason(error),
       },
-      summary: latestSummary,
+      summary: validator?.summary() ?? emptySummary(),
     };
   }
 }

--- a/runtime/src/session/tool-result-integrity.ts
+++ b/runtime/src/session/tool-result-integrity.ts
@@ -44,7 +44,11 @@ const enum CanonicalTag {
   ObjectKey = 0x07,
 }
 
-export type ToolResultRepresentation = "original" | "compacted" | "truncated";
+export type ToolResultRepresentation =
+  | "original"
+  | "redacted"
+  | "compacted"
+  | "truncated";
 
 export interface ToolResultBodyIdentity {
   readonly digest: string;
@@ -409,6 +413,7 @@ function isPersistedBodyIdentity(
   const representation = value.representation;
   return (
     representation === "original" ||
+    representation === "redacted" ||
     representation === "compacted" ||
     representation === "truncated"
   );

--- a/runtime/src/state/migrations/020_tool_pair_projection_schema.ts
+++ b/runtime/src/state/migrations/020_tool_pair_projection_schema.ts
@@ -16,7 +16,7 @@ export const toolPairProjectionSchemaMigration: SqlMigration = {
 CREATE TABLE IF NOT EXISTS tool_pair_projection_runs (
   projection_id TEXT PRIMARY KEY,
   source_key TEXT NOT NULL,
-  status TEXT NOT NULL CHECK (status IN ('building', 'valid', 'invalid', 'deferred')),
+  status TEXT NOT NULL CHECK (status IN ('building', 'valid', 'dangling', 'invalid', 'deferred')),
   call_count INTEGER NOT NULL DEFAULT 0 CHECK (call_count >= 0),
   resolved_count INTEGER NOT NULL DEFAULT 0 CHECK (resolved_count >= 0),
   open_call_count INTEGER NOT NULL DEFAULT 0 CHECK (open_call_count >= 0),
@@ -30,8 +30,9 @@ CREATE TABLE IF NOT EXISTS tool_pair_projection_runs (
   CHECK (open_call_count = call_count - resolved_count),
   CHECK (maximum_open_call_count >= open_call_count),
   CHECK (status <> 'valid' OR open_call_count = 0),
+  CHECK (status <> 'dangling' OR open_call_count > 0),
   CHECK (
-    (status IN ('building', 'valid') AND failure_kind IS NULL AND failure_code IS NULL AND failure_index IS NULL AND failure_reason IS NULL)
+    (status IN ('building', 'valid', 'dangling') AND failure_kind IS NULL AND failure_code IS NULL AND failure_index IS NULL AND failure_reason IS NULL)
     OR
     (status = 'invalid' AND failure_kind = 'integrity_failure' AND failure_code IS NOT NULL AND failure_reason IS NOT NULL)
     OR

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -146,7 +146,7 @@ const isToolCall = objectShape(
   { arguments: isString },
 );
 
-const isResponseItem = objectShape(
+const isResponseItemShape = objectShape(
   {
     role: oneOf("system", "developer", "user", "assistant", "tool"),
     content: isMessageContent,
@@ -155,11 +155,20 @@ const isResponseItem = objectShape(
     toolCalls: arrayOf(isToolCall),
     toolCallId: isString,
     toolName: isString,
+    // The recovery envelope is additive. The checkpoint-v2 reader validates
+    // the exact integrity shape, body digest, and owning run before replay.
+    toolResultIntegrity: isUnknown,
     id: isString,
     endTurn: isBoolean,
     phase: isString,
   },
 );
+
+type ResponseItemPayload = RolloutPayload<"response_item">;
+const isResponseItem: Validator<
+  ResponseItemPayload,
+  AllKeys<ResponseItemPayload>
+> = (value): value is ResponseItemPayload => isResponseItemShape(value);
 
 const isSessionAgentTask = objectShape({
   agentRuntimeId: isString,
@@ -536,6 +545,29 @@ const isReviewOutput = objectShape({
   overallConfidenceScore: isNumber,
 });
 
+const turnCheckpointRequiredFields = {
+  turnId: isString,
+  iterationIndex: isNonNegativeInteger,
+  boundary: oneOf("iteration", "postAssistant"),
+  checkpointSeq: isPositiveInteger,
+  persistedMessageCount: isNonNegativeInteger,
+  prefixHash: isString,
+  resumableState: isCheckpointSlice,
+} as const;
+
+const isTurnCheckpointShape = objectShape(turnCheckpointRequiredFields, {
+  // These fields are additive at the recovery-envelope layer. The durable
+  // checkpoint reader performs strict version dispatch and shape validation.
+  checkpointVersion: isUnknown,
+  toolResultIntegrityVersion: isUnknown,
+});
+
+type TurnCheckpointPayload = EventPayload<"turn_checkpoint">;
+const isTurnCheckpoint: Validator<
+  TurnCheckpointPayload,
+  AllKeys<TurnCheckpointPayload>
+> = (value): value is TurnCheckpointPayload => isTurnCheckpointShape(value);
+
 const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
   session_meta: objectShape(
     {
@@ -795,15 +827,7 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
     },
   ),
   turn_aborted: objectShape({ reason: isString }, { turnId: isString }),
-  turn_checkpoint: objectShape({
-    turnId: isString,
-    iterationIndex: isNonNegativeInteger,
-    boundary: oneOf("iteration", "postAssistant"),
-    checkpointSeq: isPositiveInteger,
-    persistedMessageCount: isNonNegativeInteger,
-    prefixHash: isString,
-    resumableState: isCheckpointSlice,
-  }),
+  turn_checkpoint: isTurnCheckpoint,
   turn_resumed: objectShape(
     {
       turnId: isString,

--- a/runtime/src/state/tool-pair-projection.ts
+++ b/runtime/src/state/tool-pair-projection.ts
@@ -21,7 +21,13 @@ interface ProjectionEntryRow {
 
 /** SQLite implementation of the rebuildable exact tool-pair projection. */
 export class StateToolPairProjection implements ToolPairProjection {
-  constructor(private readonly driver: StateSqliteDriver) {}
+  constructor(
+    private readonly driver: StateSqliteDriver,
+    private readonly options: {
+      /** Offline staging projections are deleted before their transaction commits. */
+      readonly discardOnTerminal?: boolean;
+    } = {},
+  ) {}
 
   runAtomically<T>(operation: () => T): T {
     return this.driver.transactionImmediate(operation);
@@ -124,6 +130,13 @@ export class StateToolPairProjection implements ToolPairProjection {
     this.updateTerminalStatus(projectionId, "valid", summary);
   }
 
+  completeDangling(
+    projectionId: string,
+    summary: ToolPairProjectionSummary,
+  ): void {
+    this.updateTerminalStatus(projectionId, "dangling", summary);
+  }
+
   fail(
     projectionId: string,
     summary: ToolPairProjectionSummary,
@@ -158,11 +171,12 @@ export class StateToolPairProjection implements ToolPairProjection {
     if (result.changes !== 1) {
       throw new Error(`tool-pair projection ${projectionId} is not building`);
     }
+    this.discardIfEphemeral(projectionId);
   }
 
   private updateTerminalStatus(
     projectionId: string,
-    status: "valid",
+    status: "valid" | "dangling",
     summary: ToolPairProjectionSummary,
   ): void {
     const result = this.driver
@@ -187,6 +201,16 @@ export class StateToolPairProjection implements ToolPairProjection {
     if (result.changes !== 1) {
       throw new Error(`tool-pair projection ${projectionId} is not building`);
     }
+    this.discardIfEphemeral(projectionId);
+  }
+
+  private discardIfEphemeral(projectionId: string): void {
+    if (this.options.discardOnTerminal !== true) return;
+    this.driver
+      .prepareState<[string]>(
+        "DELETE FROM tool_pair_projection_runs WHERE projection_id = ?",
+      )
+      .run(projectionId);
   }
 }
 

--- a/runtime/tests/phases/execute-tools.test.ts
+++ b/runtime/tests/phases/execute-tools.test.ts
@@ -51,6 +51,7 @@ import { SHARED_READ, ToolCallRuntime } from "../tools/concurrency.js";
 import { routerFromRegistry } from "../tools/router.js";
 import { readToolRuntimeContext } from "../tools/runtimes/context.js";
 import { SESSION_ALLOWED_ROOTS_ARG } from "../tools/system/filesystem.js";
+import { verifyToolResultIntegrity } from "../session/tool-result-integrity.js";
 
 const UNTRUSTED_TOOL_RESULT_BOUNDARY =
   "===== AGENC UNTRUSTED TOOL RESULT DATA =====";
@@ -361,6 +362,42 @@ function editorProposalArgs(): Record<string, unknown> {
 }
 
 describe("executeTools — T7 gap #109 pipeline", () => {
+  test("seals the exact tool-result body before later history transformations", async () => {
+    const tool: Tool = {
+      name: "IntegrityProbe",
+      description: "returns deterministic content",
+      inputSchema: { type: "object" },
+      isReadOnly: true,
+      execute: async () => ({ content: "integrity payload" }),
+    };
+    const session = mkSession({
+      log: new EventLog(),
+      registry: mkRegistry([tool]),
+    });
+    const state = mkState({
+      toolCalls: [{ id: "integrity-call", name: tool.name, arguments: "{}" }],
+    });
+
+    await executeTools(state, mkCtx(), session);
+
+    const result = state.messages.find(
+      (message) => message.role === "tool" && message.toolCallId === "integrity-call",
+    );
+    expect(result?.runtimeOnly?.toolResultIntegrity).toMatchObject({
+      version: 1,
+      runId: "conv-1",
+      toolCallId: "integrity-call",
+      persisted: { representation: "original" },
+    });
+    expect(
+      verifyToolResultIntegrity({
+        integrity: result?.runtimeOnly?.toolResultIntegrity,
+        toolCallId: "integrity-call",
+        content: result?.content,
+      }),
+    ).toMatchObject({ status: "valid" });
+  });
+
   test("rejects oversized and ambiguously overlapping editor proposals before staging", () => {
     expect(
       validateEditorProposalPayload({

--- a/runtime/tests/session/a3b-tool-result-cutover.test.ts
+++ b/runtime/tests/session/a3b-tool-result-cutover.test.ts
@@ -1,0 +1,622 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeMessagesForAPI } from "../../src/llm/messages.js";
+import type { LLMMessage } from "../../src/llm/types.js";
+import { resumeTurnFromCheckpoint } from "../../src/conversation/thread-manager.js";
+import {
+  computeCheckpointPrefixHashV2,
+} from "../../src/session/durable-checkpoint-reader.js";
+import {
+  currentBuildId,
+  resetBuildIdForTestingOnly,
+} from "../../src/session/durable-turns.js";
+import {
+  llmMessageToCheckpointResponseItem,
+  llmMessageToDurableResponseItem,
+  llmMessageToReplacementResponseItem,
+  llmMessageToResponseItem,
+  responseItemToLlmMessage,
+} from "../../src/session/message-history-conversion.js";
+import { reconstructFromRollout } from "../../src/session/rollout-reconstruction.js";
+import {
+  DurableCheckpointUpgradeBlockedError,
+  RolloutStore,
+  ToolPairHistoryBlockedError,
+} from "../../src/session/rollout-store.js";
+import type { Session } from "../../src/session/session.js";
+import {
+  parseRolloutLine,
+  serializeRolloutItem,
+  type ResponseItem,
+  type RolloutItem,
+} from "../../src/session/rollout-item.js";
+import { rewriteAtomically } from "../../src/session/session-store.js";
+import {
+  createToolResultIntegrity,
+  verifyToolResultIntegrity,
+} from "../../src/session/tool-result-integrity.js";
+import {
+  openStateDatabases,
+  type StateSqliteDriver,
+} from "../../src/state/sqlite-driver.js";
+import { StateToolPairProjection } from "../../src/state/tool-pair-projection.js";
+
+const FIXTURE_ROOT = fileURLToPath(
+  new URL("../fnd/fixtures/checkpoints/", import.meta.url),
+);
+
+let agencHome: string;
+let cwd: string;
+let originalAgencHome: string | undefined;
+let driver: StateSqliteDriver;
+
+beforeEach(() => {
+  agencHome = mkdtempSync(join(tmpdir(), "agenc-a3b-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-a3b-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  originalAgencHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = agencHome;
+  process.env.AGENC_BUILD_ID = "a3b-test-build";
+  resetBuildIdForTestingOnly();
+  driver = openStateDatabases({ cwd, agencHome });
+});
+
+afterEach(() => {
+  driver.close();
+  if (originalAgencHome === undefined) delete process.env.AGENC_HOME;
+  else process.env.AGENC_HOME = originalAgencHome;
+  delete process.env.AGENC_BUILD_ID;
+  resetBuildIdForTestingOnly();
+  rmSync(agencHome, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("A3b history and provider boundary", () => {
+  it("preserves original identity across replacement history and strips it from provider wire", () => {
+    const originalContent = "full tool output";
+    const integrity = createToolResultIntegrity({
+      runId: "session-a3b",
+      toolCallId: "call-a3b",
+      content: originalContent,
+    });
+    const original: LLMMessage = {
+      role: "tool",
+      toolCallId: "call-a3b",
+      toolName: "FileRead",
+      content: originalContent,
+      runtimeOnly: { toolResultIntegrity: integrity },
+    };
+
+    const roundTripped = responseItemToLlmMessage(
+      llmMessageToResponseItem(original),
+    );
+    expect(roundTripped.runtimeOnly?.toolResultIntegrity).toEqual(integrity);
+
+    const compacted = { ...roundTripped, content: "[compacted result]" };
+    const replacement = llmMessageToReplacementResponseItem(
+      compacted,
+      "compacted",
+    );
+    expect(replacement.toolResultIntegrity?.original).toEqual(
+      integrity.original,
+    );
+    expect(replacement.toolResultIntegrity?.persisted.representation).toBe(
+      "compacted",
+    );
+    expect(
+      verifyToolResultIntegrity({
+        integrity: replacement.toolResultIntegrity,
+        toolCallId: "call-a3b",
+        content: replacement.content,
+      }),
+    ).toMatchObject({ status: "valid" });
+
+    const providerMessages = normalizeMessagesForAPI([
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "call-a3b", name: "FileRead", arguments: "{}" }],
+      },
+      roundTripped,
+    ]);
+    const providerJson = JSON.stringify(providerMessages);
+    expect(providerJson).not.toContain("toolResultIntegrity");
+    expect(providerJson).not.toContain(integrity.resultId);
+    expect(providerJson).not.toContain(integrity.original.digest);
+  });
+
+  it("authenticates the exact redacted body written to disk without changing the provider body", () => {
+    const rawSecret = `sk-proj-${"abcdefghijklmnopqrstuvwxyz123456"}`;
+    const rawContent = `tool output: ${rawSecret}`;
+    const sourceIntegrity = createToolResultIntegrity({
+      runId: "session-redaction",
+      toolCallId: "call-redaction",
+      content: rawContent,
+    });
+    const message: LLMMessage = {
+      role: "tool",
+      toolCallId: "call-redaction",
+      toolName: "exec_command",
+      content: rawContent,
+      runtimeOnly: { toolResultIntegrity: sourceIntegrity },
+    };
+
+    const durable = llmMessageToDurableResponseItem(message);
+    expect(durable.content).not.toContain(rawSecret);
+    expect(durable.toolResultIntegrity?.original).toEqual(
+      sourceIntegrity.original,
+    );
+    expect(durable.toolResultIntegrity?.persisted.representation).toBe(
+      "redacted",
+    );
+    expect(
+      verifyToolResultIntegrity({
+        integrity: durable.toolResultIntegrity,
+        toolCallId: "call-redaction",
+        content: durable.content,
+      }),
+    ).toMatchObject({ status: "valid" });
+
+    const inMemoryAfterPersistence: LLMMessage = {
+      ...message,
+      runtimeOnly: {
+        toolResultIntegrity: {
+          ...sourceIntegrity,
+          persisted: durable.toolResultIntegrity!.persisted,
+        },
+      },
+    };
+    expect(
+      llmMessageToCheckpointResponseItem(inMemoryAfterPersistence),
+    ).toEqual(durable);
+
+    const serialized = serializeRolloutItem({
+      type: "response_item",
+      payload: durable,
+    });
+    const parsed = parseRolloutLine(serialized);
+    expect(parsed?.type).toBe("response_item");
+    if (parsed?.type !== "response_item") throw new Error("response item missing");
+    expect(
+      verifyToolResultIntegrity({
+        integrity: parsed.payload.toolResultIntegrity,
+        toolCallId: parsed.payload.toolCallId!,
+        content: parsed.payload.content,
+      }),
+    ).toMatchObject({ status: "valid" });
+
+    const providerMessages = normalizeMessagesForAPI([
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "call-redaction", name: "exec_command", arguments: "{}" },
+        ],
+      },
+      message,
+    ]);
+    expect(providerMessages[1]?.content).toBe(rawContent);
+    expect(JSON.stringify(providerMessages)).not.toContain(
+      "toolResultIntegrity",
+    );
+  });
+});
+
+describe("A3b raw checkpoint validation", () => {
+  it("authenticates before truncation and never executes invalid or deferred resume", async () => {
+    const largeBody = `head:${"x".repeat(450_000)}:tail`;
+    const prefix: ResponseItem[] = [
+      { role: "user", content: "read it" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "large-call", name: "FileRead", arguments: "{}" }],
+      },
+      {
+        role: "tool",
+        content: largeBody,
+        toolCallId: "large-call",
+        toolName: "FileRead",
+        toolResultIntegrity: createToolResultIntegrity({
+          runId: "large-session",
+          toolCallId: "large-call",
+          content: largeBody,
+        }),
+      },
+    ];
+    const rollout = v2OrphanRollout("large-turn", prefix);
+    const reconstruction = reconstructFromRollout(rollout, {
+      checkpointProjection: {
+        projection: new StateToolPairProjection(driver),
+        projectionId: "raw-before-truncation",
+        sourceKey: "large-rollout",
+        expectedRunId: "large-session",
+      },
+    });
+
+    expect(reconstruction.resumableTurns[0]).toMatchObject({
+      historyPrefixValid: true,
+      checkpointIntegrityStatus: "valid",
+    });
+    expect(reconstruction.history[2]?.content).not.toBe(largeBody);
+
+    const substituted = rollout.map((item) =>
+      item.type === "response_item" && item.payload.role === "tool"
+        ? { ...item, payload: { ...item.payload, content: `${largeBody}!` } }
+        : item,
+    );
+    const rejected = reconstructFromRollout(substituted, {
+      checkpointProjection: {
+        projection: new StateToolPairProjection(driver),
+        projectionId: "raw-substitution",
+        sourceKey: "large-rollout-substituted",
+        expectedRunId: "large-session",
+      },
+    });
+    expect(rejected.resumableTurns[0]).toMatchObject({
+      historyPrefixValid: false,
+      checkpointIntegrityStatus: "invalid",
+    });
+    expect(rejected.resumableTurns[0]?.checkpointIntegrityReason).toContain(
+      "persisted body digest",
+    );
+
+    const runTurn = vi.fn();
+    const session = {
+      config: { durableTurns: { resume: { onRestart: true } } },
+      runTurn,
+    } as unknown as Session;
+    await expect(resumeTurnFromCheckpoint(session, rejected)).resolves.toEqual({
+      resumed: false,
+      reason: "integrity-invalid",
+    });
+
+    const deferred = reconstructFromRollout(rollout);
+    expect(deferred.resumableTurns[0]).toMatchObject({
+      checkpointIntegrityStatus: "deferred",
+    });
+    await expect(resumeTurnFromCheckpoint(session, deferred)).resolves.toEqual({
+      resumed: false,
+      reason: "integrity-deferred",
+    });
+    expect(runTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe("A3b shared ordered validator cutover", () => {
+  it("enforces exact resolved-ID uniqueness on live append and compaction", () => {
+    const sessionId = "ordered-live-session";
+    const meta = {
+      sessionId,
+      timestamp: "2026-08-01T00:00:00.000Z",
+      cwd,
+      originator: "a3b-test",
+      agencVersion: "0.13.0",
+    } as const;
+    const store = openRollout({ sessionId, meta });
+    const assistant: ResponseItem = {
+      role: "assistant",
+      content: "",
+      toolCalls: [{ id: "ordered-call", name: "FileRead", arguments: "{}" }],
+    };
+    const tool: ResponseItem = {
+      role: "tool",
+      content: "ordered result",
+      toolCallId: "ordered-call",
+      toolName: "FileRead",
+      toolResultIntegrity: createToolResultIntegrity({
+        runId: sessionId,
+        toolCallId: "ordered-call",
+        content: "ordered result",
+      }),
+    };
+
+    expect(() => {
+      store.appendRollout({ type: "response_item", payload: assistant });
+      store.appendRollout({ type: "response_item", payload: tool });
+    }).not.toThrow();
+    store.flushDurable();
+
+    expect(() =>
+      store.appendRollout(
+        {
+          type: "compacted",
+          payload: {
+            message: "invalid compaction",
+            replacementHistory: [tool, assistant],
+          },
+        },
+        { durable: true },
+      ),
+    ).toThrowError(
+      expect.objectContaining<ToolPairHistoryBlockedError>({
+        outcome: expect.objectContaining({
+          status: "invalid",
+          failure: expect.objectContaining({ code: "tool_result_without_call" }),
+        }),
+      }),
+    );
+
+    expect(() =>
+      store.appendRollout({ type: "response_item", payload: assistant }),
+    ).toThrowError(
+      expect.objectContaining<ToolPairHistoryBlockedError>({
+        outcome: expect.objectContaining({
+          status: "invalid",
+          failure: expect.objectContaining({
+            code: "assistant_tool_call_id_duplicate",
+          }),
+        }),
+      }),
+    );
+
+    store.close();
+
+    const restarted = openRollout({ sessionId, meta, resume: true });
+    const nextAssistant: ResponseItem = {
+      role: "assistant",
+      content: "",
+      toolCalls: [{ id: "ordered-call-next", name: "FileRead", arguments: "{}" }],
+    };
+    const nextTool: ResponseItem = {
+      role: "tool",
+      content: "next result",
+      toolCallId: "ordered-call-next",
+      toolName: "FileRead",
+      toolResultIntegrity: createToolResultIntegrity({
+        runId: sessionId,
+        toolCallId: "ordered-call-next",
+        content: "next result",
+      }),
+    };
+    expect(() => {
+      restarted.appendRollout({ type: "response_item", payload: nextAssistant });
+      restarted.appendRollout({ type: "response_item", payload: nextTool });
+    }).not.toThrow();
+    expect(() =>
+      restarted.appendRollout({ type: "response_item", payload: assistant }),
+    ).toThrowError(
+      expect.objectContaining<ToolPairHistoryBlockedError>({
+        outcome: expect.objectContaining({
+          status: "invalid",
+          failure: expect.objectContaining({
+            code: "assistant_tool_call_id_duplicate",
+          }),
+        }),
+      }),
+    );
+    restarted.close();
+  });
+});
+
+describe("A3b atomic legacy publication", () => {
+  it("leaves v1 intact on a pre-publish crash, then upgrades once and restarts idempotently", () => {
+    const sessionId = "atomic-upgrade-session";
+    const meta = {
+      sessionId,
+      timestamp: "2026-08-01T00:00:00.000Z",
+      cwd,
+      originator: "a3b-test",
+      agencVersion: "0.13.0",
+    } as const;
+    const seed = openRollout({ sessionId, meta });
+    const rolloutPath = seed.rolloutPath;
+    seed.close();
+
+    const legacyItems: RolloutItem[] = [
+      {
+        type: "session_meta",
+        payload: { ...meta, rolloutSchemaVersion: 1 },
+      },
+      ...loadFixture("legacy-v1-tool-result-a.jsonl"),
+    ];
+    const legacyBytes = legacyItems.map(serializeRolloutItem).join("");
+    rewriteAtomically(rolloutPath, legacyBytes);
+
+    const crashed = new RolloutStore({
+      cwd,
+      sessionId,
+      agencVersion: "0.13.0",
+      resume: true,
+      autoStartScheduler: false,
+      beforeCheckpointUpgradePublishForTestingOnly: () => {
+        throw new Error("simulated upgrade crash");
+      },
+    });
+    expect(() => crashed.open(meta)).toThrow("simulated upgrade crash");
+    expect(readFileSync(rolloutPath, "utf8")).toBe(legacyBytes);
+    expect(existsSync(`${rolloutPath}.tmp`)).toBe(false);
+
+    const upgraded = openRollout({ sessionId, meta, resume: true });
+    const upgradedItems = upgraded.readAll();
+    expect(
+      upgradedItems
+        .filter((item) => item.type === "session_meta")
+        .every((item) => item.payload.rolloutSchemaVersion === 2),
+    ).toBe(true);
+    expect(
+      upgradedItems.find(
+        (item) =>
+          item.type === "event_msg" &&
+          item.payload.msg.type === "turn_checkpoint",
+      ),
+    ).toMatchObject({
+      payload: {
+        msg: {
+          payload: {
+            checkpointVersion: 2,
+            toolResultIntegrityVersion: 1,
+          },
+        },
+      },
+    });
+    expect(
+      upgradedItems.find(
+        (item) => item.type === "response_item" && item.payload.role === "tool",
+      ),
+    ).toMatchObject({
+      payload: { toolResultIntegrity: { version: 1, runId: sessionId } },
+    });
+    const upgradedBytes = readFileSync(rolloutPath, "utf8");
+    const checkpointOffset = upgraded.store.getByteOffsetForSeq(2);
+    expect(checkpointOffset).toBeTypeOf("number");
+    const checkpointLine = upgradedBytes
+      .slice(checkpointOffset)
+      .split("\n", 1)[0];
+    expect(parseRolloutLine(checkpointLine ?? "")).toMatchObject({
+      type: "event_msg",
+      payload: { seq: 2 },
+    });
+    upgraded.close();
+
+    const restarted = openRollout({ sessionId, meta, resume: true });
+    expect(readFileSync(rolloutPath, "utf8")).toBe(upgradedBytes);
+    restarted.close();
+  });
+
+  it("fails a malformed legacy sequence closed without publishing v2", () => {
+    const sessionId = "invalid-upgrade-session";
+    const meta = {
+      sessionId,
+      timestamp: "2026-08-01T00:00:00.000Z",
+      cwd,
+      originator: "a3b-test",
+      agencVersion: "0.13.0",
+    } as const;
+    const seed = openRollout({ sessionId, meta });
+    const rolloutPath = seed.rolloutPath;
+    seed.close();
+    const fixture = loadFixture("legacy-v1-tool-result-a.jsonl").filter(
+      (item) =>
+        item.type !== "event_msg" ||
+        item.payload.msg.type !== "turn_checkpoint",
+    );
+    const assistantIndex = fixture.findIndex(
+      (item) => item.type === "response_item" && item.payload.role === "assistant",
+    );
+    const resultIndex = fixture.findIndex(
+      (item) => item.type === "response_item" && item.payload.role === "tool",
+    );
+    const reordered = [...fixture];
+    [reordered[assistantIndex], reordered[resultIndex]] = [
+      reordered[resultIndex]!,
+      reordered[assistantIndex]!,
+    ];
+    const legacyItems: RolloutItem[] = [
+      {
+        type: "session_meta",
+        payload: { ...meta, rolloutSchemaVersion: 1 },
+      },
+      ...reordered,
+    ];
+    const legacyBytes = legacyItems.map(serializeRolloutItem).join("");
+    rewriteAtomically(rolloutPath, legacyBytes);
+
+    const invalid = new RolloutStore({
+      cwd,
+      sessionId,
+      agencVersion: "0.13.0",
+      resume: true,
+      autoStartScheduler: false,
+    });
+    let blocked: unknown;
+    try {
+      invalid.open(meta);
+    } catch (error) {
+      blocked = error;
+    }
+    expect(blocked).toBeInstanceOf(DurableCheckpointUpgradeBlockedError);
+    const blockedError = blocked as DurableCheckpointUpgradeBlockedError;
+    expect(blockedError.runId).toBe(sessionId);
+    expect(blockedError.outcome).toMatchObject({ kind: "integrity_failure" });
+    expect(blockedError.message).toContain(sessionId);
+    expect(blockedError.message).toContain("start a new session");
+    expect(readFileSync(rolloutPath, "utf8")).toBe(legacyBytes);
+  });
+});
+
+function v2OrphanRollout(
+  turnId: string,
+  prefix: ReadonlyArray<ResponseItem>,
+): RolloutItem[] {
+  return [
+    {
+      type: "event_msg",
+      payload: {
+        id: `${turnId}-started`,
+        seq: 1,
+        msg: {
+          type: "turn_started",
+          payload: { turnId, buildId: currentBuildId() },
+        },
+      },
+    },
+    ...prefix.map((payload) => ({ type: "response_item" as const, payload })),
+    {
+      type: "event_msg",
+      payload: {
+        id: `${turnId}-checkpoint`,
+        seq: 2,
+        msg: {
+          type: "turn_checkpoint",
+          payload: {
+            turnId,
+            iterationIndex: 1,
+            boundary: "iteration",
+            checkpointSeq: 1,
+            persistedMessageCount: prefix.length,
+            prefixHash: computeCheckpointPrefixHashV2(prefix, prefix.length),
+            checkpointVersion: 2,
+            toolResultIntegrityVersion: 1,
+            resumableState: {
+              turnCount: 1,
+              recoveryReentryCount: 0,
+              maxOutputTokensRecoveryCount: 0,
+              continuationNudgeCount: 0,
+              stopHookBlockingCount: 0,
+            },
+          },
+        },
+      },
+    },
+  ];
+}
+
+function openRollout(params: {
+  readonly sessionId: string;
+  readonly meta: {
+    readonly sessionId: string;
+    readonly timestamp: string;
+    readonly cwd: string;
+    readonly originator: string;
+    readonly agencVersion: string;
+  };
+  readonly resume?: boolean;
+}): RolloutStore {
+  const store = new RolloutStore({
+    cwd,
+    sessionId: params.sessionId,
+    agencVersion: params.meta.agencVersion,
+    autoStartScheduler: false,
+    ...(params.resume === true ? { resume: true } : {}),
+  });
+  store.open(params.meta);
+  return store;
+}
+
+function loadFixture(filename: string): RolloutItem[] {
+  return readFileSync(join(FIXTURE_ROOT, filename), "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => parseRolloutLine(line))
+    .filter((item): item is RolloutItem => item !== null);
+}

--- a/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
+++ b/runtime/tests/session/durable-checkpoint-reader-upgrade.test.ts
@@ -248,6 +248,51 @@ describe("durable checkpoint v2 reader", () => {
     });
   });
 
+  it("accepts dangling calls only at the post-assistant crash boundary", () => {
+    const messages: ResponseItem[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "pending-call", name: "FileRead", arguments: "{}" }],
+      },
+    ];
+    const checkpoint: TurnCheckpointV2Event = {
+      ...legacyCheckpoint(
+        computeCheckpointPrefixHashV2(messages, messages.length),
+      ),
+      boundary: "postAssistant",
+      persistedMessageCount: messages.length,
+      checkpointVersion: 2,
+      toolResultIntegrityVersion: 1,
+    };
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint,
+        messages,
+        projection,
+        projectionId: "post-assistant-dangling",
+        sourceKey: "post-assistant-dangling",
+      }),
+    ).toMatchObject({
+      status: "valid",
+      danglingToolCalls: 1,
+      danglingToolUses: [{ callId: "pending-call", toolName: "FileRead" }],
+    });
+
+    expect(
+      validateCheckpointPrefixV2({
+        checkpoint: { ...checkpoint, boundary: "iteration" },
+        messages,
+        projection,
+        projectionId: "iteration-dangling",
+        sourceKey: "iteration-dangling",
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      failure: { code: "tool_result_missing" },
+    });
+  });
+
   it("rejects unversioned response and tool-call fields", () => {
     const upgraded = upgradedFixture(
       "legacy-v1-tool-result-a.jsonl",
@@ -391,8 +436,8 @@ describe("durable checkpoint v2 reader", () => {
 });
 
 describe("legacy durable checkpoint upgrade planner", () => {
-  it("keeps the live rollout writer on v1 until the A3b cutover", () => {
-    expect(ROLLOUT_SCHEMA_VERSION).toBe(1);
+  it("cuts the live rollout writer over to schema v2", () => {
+    expect(ROLLOUT_SCHEMA_VERSION).toBe(2);
   });
 
   it("makes equal-length fixture substitutions produce distinct v2 identities", () => {

--- a/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
+++ b/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
@@ -12,10 +12,62 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { reconstructFromRollout } from "./rollout-reconstruction.js";
 import type { RolloutItem, ResponseItem } from "./rollout-item.js";
-import {
-  computePrefixHash,
-  resetBuildIdForTestingOnly,
-} from "./durable-turns.js";
+import { resetBuildIdForTestingOnly } from "./durable-turns.js";
+import { computeCheckpointPrefixHashV2 } from "./durable-checkpoint-reader.js";
+import type {
+  ToolPairIntegrityFailure,
+  ToolPairOperationalDeferral,
+  ToolPairProjection,
+  ToolPairProjectionRecord,
+  ToolPairProjectionSummary,
+} from "./tool-pair-validator.js";
+
+class TestToolPairProjection implements ToolPairProjection {
+  private records = new Map<string, ToolPairProjectionRecord>();
+  runAtomically<T>(operation: () => T): T { return operation(); }
+  reset(): void { this.records.clear(); }
+  find(_projectionId: string, callId: string): ToolPairProjectionRecord | undefined {
+    return this.records.get(callId);
+  }
+  insertCall(_projectionId: string, record: ToolPairProjectionRecord): boolean {
+    if (this.records.has(record.callId)) return false;
+    this.records.set(record.callId, record);
+    return true;
+  }
+  resolveCall(params: {
+    readonly callId: string;
+    readonly resultIndex: number;
+    readonly resultId?: string;
+    readonly originalResultDigest?: string;
+  }): "resolved" | "already_resolved" | "missing" {
+    const record = this.records.get(params.callId);
+    if (record === undefined) return "missing";
+    if (record.resultIndex !== undefined) return "already_resolved";
+    this.records.set(params.callId, { ...record, ...params });
+    return "resolved";
+  }
+  complete(): void {}
+  completeDangling(): void {}
+  fail(
+    _projectionId: string,
+    _summary: ToolPairProjectionSummary,
+    _failure: ToolPairIntegrityFailure | ToolPairOperationalDeferral,
+  ): void {}
+}
+
+let projectionOrdinal = 0;
+
+function reconstruct(items: ReadonlyArray<RolloutItem>) {
+  projectionOrdinal += 1;
+  return reconstructFromRollout(items, {
+    checkpointProjection: {
+      projection: new TestToolPairProjection(),
+      projectionId: `test-projection-${projectionOrdinal}`,
+      sourceKey: `test-rollout-${projectionOrdinal}`,
+      expectedRunId: "test-run",
+    },
+  });
+}
 
 afterEach(() => {
   delete process.env.AGENC_BUILD_ID;
@@ -35,6 +87,7 @@ interface CheckpointArgs {
   readonly prefixHash?: string; // override to force a mismatch
   readonly iterationIndex?: number;
   readonly checkpointSeq?: number;
+  readonly boundary?: "iteration" | "postAssistant";
 }
 
 /** Build a started-but-not-terminated turn with a trailing checkpoint. */
@@ -68,11 +121,14 @@ function orphanWithCheckpoint(args: CheckpointArgs): RolloutItem[] {
         payload: {
           turnId: args.turnId,
           iterationIndex: args.iterationIndex ?? 1,
-          boundary: "iteration",
+          boundary: args.boundary ?? "iteration",
           checkpointSeq: args.checkpointSeq ?? 1,
           persistedMessageCount: args.prefix.length,
           prefixHash:
-            args.prefixHash ?? computePrefixHash(args.prefix, args.prefix.length),
+            args.prefixHash ??
+            computeCheckpointPrefixHashV2(args.prefix, args.prefix.length),
+          checkpointVersion: 2,
+          toolResultIntegrityVersion: 1,
           resumableState: {
             turnCount: 2,
             recoveryReentryCount: 1,
@@ -95,7 +151,7 @@ describe("reconstruction durable resume descriptors", () => {
       { role: "user", content: "do the thing" },
       { role: "assistant", content: "on it" },
     ];
-    const r = reconstructFromRollout(
+    const r = reconstruct(
       orphanWithCheckpoint({ turnId: "t1", buildId, prefix }),
     );
     expect(r.orphanedTurnIds).toContain("t1");
@@ -116,12 +172,12 @@ describe("reconstruction durable resume descriptors", () => {
   test("prefix-hash mismatch → historyPrefixValid=false (refuses silent resume)", () => {
     const buildId = pinBuild("build-A");
     const prefix: ResponseItem[] = [{ role: "user", content: "original" }];
-    const r = reconstructFromRollout(
+    const r = reconstruct(
       orphanWithCheckpoint({
         turnId: "t1",
         buildId,
         prefix,
-        prefixHash: "deadbeef-not-the-real-hash",
+        prefixHash: "d".repeat(64),
       }),
     );
     expect(r.resumableTurns).toHaveLength(1);
@@ -131,7 +187,7 @@ describe("reconstruction durable resume descriptors", () => {
   test("build-pin mismatch → buildMatches=false (refuses cross-build resume)", () => {
     pinBuild("build-CURRENT");
     const prefix: ResponseItem[] = [{ role: "user", content: "x" }];
-    const r = reconstructFromRollout(
+    const r = reconstruct(
       orphanWithCheckpoint({ turnId: "t1", buildId: "build-OLD", prefix }),
     );
     expect(r.resumableTurns).toHaveLength(1);
@@ -152,7 +208,7 @@ describe("reconstruction durable resume descriptors", () => {
       },
       { type: "response_item", payload: { role: "user", content: "mid-turn" } },
     ];
-    const r = reconstructFromRollout(items);
+    const r = reconstruct(items);
     expect(r.orphanedTurnIds).toContain("t-orphan");
     expect(r.resumableTurns).toHaveLength(0);
     const synthTypes = r.synthesizedEvents.map((ev) =>
@@ -172,8 +228,13 @@ describe("reconstruction durable resume descriptors", () => {
         toolCalls: [{ id: "danger-1", name: "send", arguments: "{}" }],
       },
     ];
-    const r = reconstructFromRollout(
-      orphanWithCheckpoint({ turnId: "t1", buildId, prefix }),
+    const r = reconstruct(
+      orphanWithCheckpoint({
+        turnId: "t1",
+        buildId,
+        prefix,
+        boundary: "postAssistant",
+      }),
     );
     expect(r.resumableTurns[0]!.danglingToolUses).toEqual([
       { callId: "danger-1", toolName: "send" },
@@ -210,7 +271,9 @@ describe("reconstruction durable resume descriptors", () => {
               boundary: "iteration",
               checkpointSeq: 1,
               persistedMessageCount: 1,
-              prefixHash: computePrefixHash(prefix1, 1),
+              prefixHash: computeCheckpointPrefixHashV2(prefix1, 1),
+              checkpointVersion: 2,
+              toolResultIntegrityVersion: 1,
               resumableState: {
                 turnCount: 2,
                 recoveryReentryCount: 0,
@@ -236,7 +299,9 @@ describe("reconstruction durable resume descriptors", () => {
               boundary: "iteration",
               checkpointSeq: 2,
               persistedMessageCount: 2,
-              prefixHash: computePrefixHash(prefix2, 2),
+              prefixHash: computeCheckpointPrefixHashV2(prefix2, 2),
+              checkpointVersion: 2,
+              toolResultIntegrityVersion: 1,
               resumableState: {
                 turnCount: 3,
                 recoveryReentryCount: 0,
@@ -249,7 +314,7 @@ describe("reconstruction durable resume descriptors", () => {
         },
       },
     ];
-    const r = reconstructFromRollout(items);
+    const r = reconstruct(items);
     expect(r.resumableTurns).toHaveLength(1);
     expect(r.resumableTurns[0]!.lastCheckpoint.checkpointSeq).toBe(2);
     expect(r.resumableTurns[0]!.lastCheckpoint.iterationIndex).toBe(2);

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -59,6 +59,7 @@ import {
 } from "../utils/messageQueueManager.js";
 import type { QueuedCommand } from "../types/textInputTypes.js";
 import { setCommandLifecycleListener } from "../utils/commandLifecycle.js";
+import { createToolResultIntegrity } from "./tool-result-integrity.js";
 
 function enqueue(command: QueuedCommand): void {
   enqueueCommand({
@@ -7128,11 +7129,36 @@ describe("runTurn — runAutoCompact dispatcher", () => {
       role: "assistant",
       content: "KEPT TAIL",
     };
+    const compactedToolIntegrity = createToolResultIntegrity({
+      runId: "conv-test",
+      toolCallId: "compacted-call",
+      content: "FULL TOOL RESULT",
+    });
+    const keptToolCall: LLMMessage = {
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        { id: "compacted-call", name: "FileRead", arguments: "{}" },
+      ],
+    };
+    const keptCompactedToolResult: LLMMessage = {
+      role: "tool",
+      content: "[compacted tool result]",
+      toolCallId: "compacted-call",
+      toolName: "FileRead",
+      runtimeOnly: { toolResultIntegrity: compactedToolIntegrity },
+    };
     const fakeImpl: AutoCompactImpl = async () => ({
       wasCompacted: true,
       compactionResult: {
         message: "POST-COMPACT SUMMARY",
-        replacementHistory: [compactBoundary, compactSummary, keptTail],
+        replacementHistory: [
+          compactBoundary,
+          compactSummary,
+          keptTail,
+          keptToolCall,
+          keptCompactedToolResult,
+        ],
         preCompactTokens: 999,
         postCompactTokens: 100,
       },
@@ -7196,12 +7222,33 @@ describe("runTurn — runAutoCompact dispatcher", () => {
       }),
       { durable: true },
     );
+    const compactedAppend = appendRollout.mock.calls.find(
+      (call) => call[0]?.type === "compacted",
+    )?.[0];
+    const persistedToolResult = compactedAppend?.payload?.replacementHistory?.find(
+      (message: { readonly role?: string; readonly toolCallId?: string }) =>
+        message.role === "tool" && message.toolCallId === "compacted-call",
+    );
+    expect(persistedToolResult?.toolResultIntegrity).toMatchObject({
+      original: compactedToolIntegrity.original,
+      persisted: { representation: "compacted" },
+    });
 
     expect(
       seenMessages.some(
         (m) => typeof m.content === "string" && m.content.includes("KEPT TAIL"),
       ),
     ).toBe(true);
+    expect(
+      seenMessages.find(
+        (message) =>
+          message.role === "tool" &&
+          message.toolCallId === "compacted-call",
+      )?.runtimeOnly?.toolResultIntegrity,
+    ).toMatchObject({
+      original: compactedToolIntegrity.original,
+      persisted: { representation: "compacted" },
+    });
     expect(seenSystemPrompt).toContain("POST-COMPACT SUMMARY");
     expect(seenSystemPrompt).toContain("<durable_system_history>");
     expect(seenSystemPrompt).toContain("untrusted historical context");
@@ -7533,6 +7580,8 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       turnCount?: number;
       recoveryReentryCount?: number;
       taskBudgetRemaining?: number;
+      checkpointVersion?: number;
+      toolResultIntegrityVersion?: number;
     }> = [];
     const append = vi.fn((event: unknown) => {
       const ev = event as { msg?: { type?: string; payload?: unknown } };
@@ -7544,7 +7593,17 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
             taskBudgetRemaining?: number;
           };
         };
-        if (p.resumableState) observedCheckpoints.push(p.resumableState);
+        if (p.resumableState) {
+          observedCheckpoints.push({
+            ...p.resumableState,
+            checkpointVersion: (
+              ev.msg.payload as { checkpointVersion?: number }
+            ).checkpointVersion,
+            toolResultIntegrityVersion: (
+              ev.msg.payload as { toolResultIntegrityVersion?: number }
+            ).toolResultIntegrityVersion,
+          });
+        }
       }
     });
     // Provider drives one tool iteration (so a CB-Iteration checkpoint
@@ -7587,9 +7646,10 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       dispatch: async () => ({ content: "ok", isError: false }),
     } as unknown as ToolRegistry;
     const { session, events } = mkSession({ provider, registry });
+    const appendRollout = vi.fn();
     session.rolloutStore = {
       append,
-      appendRollout: vi.fn(),
+      appendRollout,
       rolloutPath: "/tmp/does-not-matter.jsonl",
     } as unknown as Session["rolloutStore"];
 
@@ -7636,6 +7696,25 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
     // Non-per-iteration counters hold their EXACT restored pre-crash values.
     expect(cp.recoveryReentryCount).toBe(3);
     expect(cp.taskBudgetRemaining).toBe(9999);
+    expect(cp.checkpointVersion).toBe(2);
+    expect(cp.toolResultIntegrityVersion).toBe(1);
+    expect(
+      appendRollout.mock.calls
+        .map((call) => call[0])
+        .find(
+          (item) =>
+            item?.type === "response_item" && item.payload?.role === "tool",
+        ),
+    ).toMatchObject({
+      payload: {
+        toolCallId: "k1",
+        toolResultIntegrity: {
+          version: 1,
+          runId: session.conversationId,
+          toolCallId: "k1",
+        },
+      },
+    });
   });
 
   test("idempotent re-run: a read-only dangling tool is paired and the resumed turn completes cleanly", async () => {

--- a/runtime/tests/state/tool-pair-projection.test.ts
+++ b/runtime/tests/state/tool-pair-projection.test.ts
@@ -85,6 +85,38 @@ describe("StateToolPairProjection", () => {
     ).toEqual({ status: "valid", call_count: 2 });
   });
 
+  it("discards private offline staging rows before validation commits", () => {
+    const stagingProjection = new StateToolPairProjection(driver, {
+      discardOnTerminal: true,
+    });
+    const outcome = validateToolPairSequence(
+      [
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "offline-call", name: "read" }],
+        },
+        { role: "tool", content: "ok", toolCallId: "offline-call" },
+      ],
+      stagingProjection,
+      {
+        projectionId: "offline-staging",
+        sourceKey: "/rollouts/offline.jsonl",
+      },
+    );
+
+    expect(outcome.status).toBe("valid");
+    expect(stagingProjection.find("offline-staging", "offline-call")).toBeUndefined();
+    expect(
+      driver
+        .prepareState<[string], { readonly found: number }>(
+          `SELECT 1 AS found FROM tool_pair_projection_runs
+           WHERE projection_id = ?`,
+        )
+        .get("offline-staging"),
+    ).toBeUndefined();
+  });
+
   it("distinguishes duplicate, orphan, unknown, and ordering failures", () => {
     expect(
       validate([


### PR DESCRIPTION
## Summary
- cut checkpoint writes to version 2 with exact persisted tool-result body seals
- enforce ordered, exact tool-call/result pairing through one SQLite-backed validator in live append, reconstruction, compaction, and resume
- atomically upgrade eligible legacy checkpoints and fail closed when source integrity cannot be proven
- refresh the generated FND benchmark provenance against the clean functional commit

## Validation
- independent exact-SHA review: no findings at ba6fa4923bcac831061ae99d635a45bb26c55660
- focused A3: 8 files, 284 tests passed
- independent focused review gate: 4 files, 59 tests passed
- root typecheck and test-support typecheck passed
- full hermetic Vitest: 1,947 files, 17,906 tests, zero failures
- FND red audit: files=9 expected-red=9 assertions=9 skipped=0 todo=0
- build, package entrypoints, SDK generated types, and PTY startup smoke passed

## Provenance
Functional commit: c445b076b60cd84b18f8e3e497ad820cbca3c6a4
Generated baseline commit: ba6fa4923bcac831061ae99d635a45bb26c55660
Baseline JSON SHA-256: 03d2b14da54c16ca2c2c1f0067e1c50f80e97da94c00f3ca3087dc7ca1d04fc9

No release is included.