### PR TITLE
test(runtime): bind A4 benchmark provenance to merged main

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.301888,
-            "maxMs": 9.232437,
-            "medianMs": 4.948162,
-            "minMs": 4.646274,
+            "madMs": 0.21133,
+            "maxMs": 5.575966,
+            "medianMs": 5.359137,
+            "minMs": 4.983267,
             "sampleCount": 5,
             "samplesMs": [
-              5.593512,
-              4.948162,
-              4.646274,
-              4.885777,
-              9.232437
+              5.575966,
+              4.983267,
+              5.147807,
+              5.359137,
+              5.377255
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92786688,
+              "maximumObservedBytes": 94363648,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82300928,
-                88592384,
-                88592384,
-                88592384,
-                88592384,
-                88592384,
-                89116672,
-                89116672,
-                89116672,
-                89116672,
-                92786688
+                83353600,
+                89120768,
+                90169344,
+                90169344,
+                90693632,
+                90693632,
+                91217920,
+                91217920,
+                91217920,
+                91217920,
+                94363648
               ]
             },
-            "peakRssBytes": 92786688,
+            "peakRssBytes": 94363648,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.689485,
-            "maxMs": 23.438295,
-            "medianMs": 14.560626,
-            "minMs": 12.871141,
+            "madMs": 0.894899,
+            "maxMs": 25.221025,
+            "medianMs": 15.159448,
+            "minMs": 14.264549,
             "sampleCount": 5,
             "samplesMs": [
-              14.560626,
-              23.438295,
-              16.574994,
-              13.815074,
-              12.871141
+              14.622562,
+              15.159448,
+              25.221025,
+              17.445099,
+              14.264549
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 121110528,
+              "maximumObservedBytes": 122712064,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82313216,
-                87556096,
-                92274688,
-                92274688,
-                104857600,
-                104857600,
-                119537664,
-                119537664,
-                120586240,
-                120586240,
-                121110528
+                84439040,
+                91779072,
+                91779072,
+                91779072,
+                98594816,
+                98594816,
+                113274880,
+                113274880,
+                122187776,
+                122187776,
+                122712064
               ]
             },
-            "peakRssBytes": 121110528,
+            "peakRssBytes": 122712064,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 4.468594,
-            "maxMs": 71.315571,
-            "medianMs": 42.42525,
-            "minMs": 37.604661,
+            "madMs": 1.075262,
+            "maxMs": 65.525413,
+            "medianMs": 37.31608,
+            "minMs": 36.240818,
             "sampleCount": 5,
             "samplesMs": [
-              71.315571,
-              42.564792,
-              37.956656,
-              37.604661,
-              42.42525
+              65.525413,
+              41.323976,
+              37.31608,
+              37.312525,
+              36.240818
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 134078464,
+              "maximumObservedBytes": 133107712,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84029440,
-                99758080,
-                129118208,
-                129118208,
-                129642496,
-                129642496,
-                130691072,
-                130691072,
-                132263936,
-                132263936,
-                134078464
+                82329600,
+                97533952,
+                128991232,
+                128991232,
+                129515520,
+                129515520,
+                130564096,
+                130564096,
+                132136960,
+                132136960,
+                133107712
               ]
             },
-            "peakRssBytes": 134078464,
+            "peakRssBytes": 133185536,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.297301,
-            "maxMs": 11.809188,
-            "medianMs": 6.572148,
-            "minMs": 6.274847,
+            "madMs": 0.240886,
+            "maxMs": 10.349415,
+            "medianMs": 5.931397,
+            "minMs": 5.690511,
             "sampleCount": 5,
             "samplesMs": [
-              6.572148,
-              6.307727,
-              11.809188,
-              7.003442,
-              6.274847
+              5.87421,
+              5.690511,
+              10.349415,
+              6.235007,
+              5.931397
             ]
           },
           "fixtureDigest": "20e6f251f058537fb579b40427cfc4c69a025d8da738d498863815d41a88f6b7",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 121704448,
+              "maximumObservedBytes": 121585664,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                81334272,
-                96014336,
-                97587200,
-                97587200,
-                98635776,
-                98635776,
-                116985856,
-                116985856,
-                119083008,
-                119083008,
-                121704448
+                81739776,
+                96944128,
+                98516992,
+                98516992,
+                100089856,
+                100089856,
+                118439936,
+                118439936,
+                119488512,
+                119488512,
+                121585664
               ]
             },
-            "peakRssBytes": 121704448,
+            "peakRssBytes": 121585664,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -260,17 +260,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 2.24626,
-            "maxMs": 36.059606,
-            "medianMs": 31.442947,
-            "minMs": 20.48457,
+            "madMs": 3.942826,
+            "maxMs": 35.077922,
+            "medianMs": 28.610362,
+            "minMs": 18.613352,
             "sampleCount": 5,
             "samplesMs": [
-              20.48457,
-              36.059606,
-              33.689207,
-              30.313632,
-              31.442947
+              18.613352,
+              35.077922,
+              32.553188,
+              28.610362,
+              27.244618
             ]
           },
           "fixtureDigest": "b5ed1acf6dcd628542025466c326a7ca14bfc4875684227c66736176561607d5",
@@ -281,23 +281,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 157474816,
+              "maximumObservedBytes": 159817728,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82767872,
-                115798016,
-                118943744,
-                118943744,
-                156168192,
-                156168192,
-                155901952,
-                155901952,
-                156950528,
-                156950528,
-                157474816
+                83525632,
+                117604352,
+                120225792,
+                120225792,
+                157974528,
+                157974528,
+                157196288,
+                157196288,
+                158769152,
+                158769152,
+                159817728
               ]
             },
-            "peakRssBytes": 157999104,
+            "peakRssBytes": 159817728,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -316,17 +316,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 6.773404,
-            "maxMs": 355.937086,
-            "medianMs": 349.163682,
-            "minMs": 331.163525,
+            "madMs": 7.074913,
+            "maxMs": 352.016197,
+            "medianMs": 330.192641,
+            "minMs": 323.117728,
             "sampleCount": 5,
             "samplesMs": [
-              349.454373,
-              331.163525,
-              334.540241,
-              355.937086,
-              349.163682
+              330.013128,
+              323.117728,
+              341.07163,
+              352.016197,
+              330.192641
             ]
           },
           "fixtureDigest": "60598ff316c144a59697d6e13c539f2877b49bdcd1b6f8427c436f9850314509",
@@ -337,23 +337,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 237056000,
+              "maximumObservedBytes": 232656896,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85721088,
-                210485248,
-                192135168,
-                192135168,
-                213204992,
-                213204992,
-                237056000,
-                237056000,
-                206536704,
-                206536704,
-                225693696
+                83247104,
+                207212544,
+                187654144,
+                187654144,
+                208867328,
+                208867328,
+                232656896,
+                232656896,
+                201302016,
+                201302016,
+                221270016
               ]
             },
-            "peakRssBytes": 265363456,
+            "peakRssBytes": 260960256,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -386,17 +386,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.211421,
-            "maxMs": 4.410486,
-            "medianMs": 3.970598,
-            "minMs": 3.601198,
+            "madMs": 0.129326,
+            "maxMs": 4.285307,
+            "medianMs": 3.863936,
+            "minMs": 3.73461,
             "sampleCount": 5,
             "samplesMs": [
-              4.410486,
-              3.759177,
-              3.970598,
-              4.003318,
-              3.601198
+              3.996899,
+              3.849815,
+              3.73461,
+              4.285307,
+              3.863936
             ]
           },
           "fixtureDigest": "6dc2d7033a701cb871275327613ffef173ca251f453a9b586554b9f3ce14811a",
@@ -409,23 +409,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 93450240,
+              "maximumObservedBytes": 92975104,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85348352,
-                89255936,
-                89255936,
-                89255936,
-                89255936,
-                89255936,
-                90304512,
-                90304512,
-                92925952,
-                92925952,
-                93450240
+                85868544,
+                88911872,
+                88780800,
+                88780800,
+                88780800,
+                88780800,
+                88780800,
+                88780800,
+                90877952,
+                90877952,
+                92975104
               ]
             },
-            "peakRssBytes": 93450240,
+            "peakRssBytes": 92975104,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -444,17 +444,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.120812,
-            "maxMs": 12.600109,
-            "medianMs": 12.479297,
-            "minMs": 12.272122,
+            "madMs": 0.251192,
+            "maxMs": 12.892135,
+            "medianMs": 12.083327,
+            "minMs": 11.832135,
             "sampleCount": 5,
             "samplesMs": [
-              12.479297,
-              12.600109,
-              12.544645,
-              12.272122,
-              12.287545
+              12.892135,
+              12.083327,
+              12.360158,
+              11.902152,
+              11.832135
             ]
           },
           "fixtureDigest": "2c4e993a93b588a4e90763225ab10e2c7e80c7e52c006b4ce0d8d042a41d456c",
@@ -467,23 +467,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 93229056,
+              "maximumObservedBytes": 93761536,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84316160,
-                93229056,
-                93229056,
-                93229056,
-                93229056,
-                93229056,
-                93229056,
-                93229056,
-                93229056,
-                93229056,
-                93229056
+                87605248,
+                93761536,
+                93761536,
+                93761536,
+                93761536,
+                93761536,
+                93761536,
+                93761536,
+                93761536,
+                93761536,
+                93761536
               ]
             },
-            "peakRssBytes": 93229056,
+            "peakRssBytes": 93761536,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -502,17 +502,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.261697,
-            "maxMs": 50.295399,
-            "medianMs": 49.576868,
-            "minMs": 49.100505,
+            "madMs": 1.57322,
+            "maxMs": 51.735084,
+            "medianMs": 49.701327,
+            "minMs": 47.494906,
             "sampleCount": 5,
             "samplesMs": [
-              49.576868,
-              50.295399,
-              49.827398,
-              49.315171,
-              49.100505
+              49.701327,
+              48.128107,
+              50.596936,
+              47.494906,
+              51.735084
             ]
           },
           "fixtureDigest": "c1a21af75169441df1d4fd0a5c8a99dbe96bbd556db181e064a6f70b83a91cf6",
@@ -525,23 +525,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 99328000,
+              "maximumObservedBytes": 101990400,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                83742720,
-                90415104,
-                90415104,
-                90415104,
-                95133696,
-                95133696,
-                99328000,
-                99328000,
-                99328000,
-                99328000,
-                99328000
+                84975616,
+                92553216,
+                92553216,
+                92553216,
+                93077504,
+                93077504,
+                101466112,
+                101466112,
+                101466112,
+                101466112,
+                101990400
               ]
             },
-            "peakRssBytes": 99328000,
+            "peakRssBytes": 101990400,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -574,21 +574,21 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.001733,
-            "maxMs": 0.030125,
-            "medianMs": 0.01315,
-            "minMs": 0.011417,
+            "madMs": 0.002333,
+            "maxMs": 0.028574,
+            "medianMs": 0.016475,
+            "minMs": 0.011207,
             "sampleCount": 9,
             "samplesMs": [
-              0.016184,
-              0.030125,
-              0.018218,
-              0.015103,
-              0.01315,
-              0.011798,
-              0.011417,
-              0.012029,
-              0.011458
+              0.016525,
+              0.028574,
+              0.017937,
+              0.016144,
+              0.014142,
+              0.01301,
+              0.011207,
+              0.016475,
+              0.021553
             ]
           },
           "fixtureDigest": "06964b37b02568fd25e3c7c7788a86751336199f8ae67a29529912d184f6131d",
@@ -601,31 +601,31 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 81911808,
+              "maximumObservedBytes": 79613952,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                80338944,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81387520,
-                81911808
+                76992512,
+                79089664,
+                79089664,
+                79089664,
+                79089664,
+                79089664,
+                79089664,
+                79089664,
+                79089664,
+                79089664,
+                79613952,
+                79613952,
+                79613952,
+                79613952,
+                79613952,
+                79613952,
+                79613952,
+                79613952,
+                79613952
               ]
             },
-            "peakRssBytes": 81911808,
+            "peakRssBytes": 79613952,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -886,6 +886,6 @@
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "702d2b6eb0292b2ba99776ba70f49407358c43d8",
+  "sourceRevision": "510fe3d9132d0cd221f3676e492a28de2a2a86bd",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,8 +4,8 @@ This artifact records bounded observations of known failures. Every row is
 informational: no current result is a passing performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `ff38e7e34442d38083a0c582f92160bfdb94a11e90e8fb5f5a388ac7818150db`
-- Source revision: `702d2b6eb0292b2ba99776ba70f49407358c43d8`
+- JSON SHA-256: `9099bb7f2660af1ff90ebb313c1b64c0f97946a5a9fd530168f1f509572a4942`
+- Source revision: `510fe3d9132d0cd221f3676e492a28de2a2a86bd`
 - Production tree: `runtime/src` at Git object `8d6a0075a7f4b2e86367be4e165192c87806b8c7`
 - Loaded production closure: `11` module bindings across `4` cases
 - Plan SHA-256: `d158a4e11ca943e018af33c0df8ddeaef665dbb56ec0c92b07db76abc61cde46`
@@ -18,16 +18,16 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 4.948 | 0.302 | 92786688 | 92786688 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 14.561 | 1.689 | 121110528 | 121110528 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 42.425 | 4.469 | 134078464 | 134078464 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 6.572 | 0.297 | 121704448 | 121704448 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 31.443 | 2.246 | 157999104 | 157474816 |
-| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 349.164 | 6.773 | 265363456 | 237056000 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 3.971 | 0.211 | 93450240 | 93450240 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.479 | 0.121 | 93229056 | 93229056 |
-| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 49.577 | 0.262 | 99328000 | 99328000 |
-| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.013 | 0.002 | 81911808 | 81911808 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 5.359 | 0.211 | 94363648 | 94363648 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 15.159 | 0.895 | 122712064 | 122712064 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 37.316 | 1.075 | 133185536 | 133107712 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=8000` | `completed` | 5.931 | 0.241 | 121585664 | 121585664 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=16000` | `completed` | 28.610 | 3.943 | 159817728 | 159817728 |
+| `patch_delete_parser_suffix_slicing` | `hunkCount=32000` | `completed` | 330.193 | 7.075 | 260960256 | 232656896 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=32,queryCodeUnits=8` | `completed` | 3.864 | 0.129 | 92975104 | 92975104 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=64,queryCodeUnits=8` | `completed` | 12.083 | 0.251 | 93761536 | 93761536 |
+| `fuzzy_daemon_recursive_scaling` | `candidateCount=32,pathStemCodeUnits=128,queryCodeUnits=8` | `completed` | 49.701 | 1.573 | 101990400 | 101990400 |
+| `fuzzy_tui_query_truncation` | `candidateCount=2,indexedQueryCodeUnits=64,queryCodeUnits=69` | `completed` | 0.016 | 0.002 | 79613952 | 79613952 |
 
 ## Known-failure policy
 
@@ -42,7 +42,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 702d2b6eb0292b2ba99776ba70f49407358c43d8 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 510fe3d9132d0cd221f3676e492a28de2a2a86bd --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 


### PR DESCRIPTION
## Summary

- recapture the generated FND benchmark artifacts from merged A4 revision `510fe3d9132d0cd221f3676e492a28de2a2a86bd`
- bind both artifacts to the exact merged `runtime/src` tree
- keep this follow-up generated-only

## Verification

- `npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime`
- normal pre-commit build, generated SDK checks, and PTY startup matrix
- independent exact-SHA review: no blockers

No release or publish is included.