### PR TITLE
fix(runtime): bound reconnect full-jitter policy

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -76,6 +76,7 @@ history; the linked pages below are current product truth.
 | [design/workspace-scoped-agent-roles.md](design/workspace-scoped-agent-roles.md) | Immutable workspace identity for role lookup, spawn, resume, and worktrees |
 | [design/secure-project-instructions.md](design/secure-project-instructions.md) | Live instruction delivery, precedence, descriptor-bound reads, approvals, and threat model |
 | [design/fail-closed-sandbox-execution.md](design/fail-closed-sandbox-execution.md) | Required process isolation boundary, platform probes, failure semantics, and research |
+| [design/reconnect-backoff-policy.md](design/reconnect-backoff-policy.md) | Finite full-jitter reconnect policy, typed Retry-After parsing, elapsed accounting, and A1 replay-safety ordering |
 | [design/execution-admission-kernel.md](design/execution-admission-kernel.md) | M3 daemon admission, durable budgets/queue/cancellation, evidence, rollout, and rollback |
 | [design/provider-aware-token-accounting.md](design/provider-aware-token-accounting.md) | Complete-request native/fallback accounting, bounded cache/single-flight, context enforcement, and calibration |
 | [design/durable-runs-effects-events.md](design/durable-runs-effects-events.md) | M4 canonical run journal, honest effects, terminal results, replay-safe cursors, crash matrix, and rollback |

--- a/docs/design/reconnect-backoff-policy.md
+++ b/docs/design/reconnect-backoff-policy.md
@@ -1,8 +1,9 @@
 # Finite reconnect and Retry-After policy
 
-Status: E2 implementation, based on A1 commit
-`49dac01e515527c18dc2bef220ffdc48f93cda21`. This branch must be rebased after
-A1 lands; the rebase must preserve A1's unknown-physical-effect retry refusal.
+Status: E2 implementation, rebased onto `main` after A1 merged as
+`0024f9e04` ([#1644](https://github.com/tetsuo-ai/agenc-core/pull/1644)).
+A1's replay-admission semantics are already present and remain authoritative;
+E2 preserves their unknown-physical-effect retry refusal.
 
 ## Compatibility contract
 
@@ -51,7 +52,9 @@ another provider request.
 `runtime/src/llm/retry-after.ts` owns RFC 9110 parsing at the provider HTTP
 adapter boundary. It accepts nonnegative decimal delta-seconds and all three
 HTTP-date forms, treating obsolete date forms as UTC independently of the host
-timezone. It rejects partial integers,
+timezone and normalizing their permitted `23:59:60` leap second. Only HTTP
+optional whitespace (space and horizontal tab) is discarded at field edges;
+Unicode whitespace remains invalid syntax. It rejects partial integers,
 negative values, invalid calendar dates, weekday mismatches, non-finite spellings,
 and unsafe integer overflow. The adapter returns one immutable classification:
 `absent`, `invalid`, `valid`, or `over_policy`.
@@ -75,17 +78,19 @@ and after the retry callback, before sleep, during the abortable sleep, and
 immediately after wake. Telemetry contains only bounded numbers and closed reason
 codes; raw provider error or abort text is not copied into reconnect warnings.
 
-## A1 ordering and rollback
+## A1 dependency and rollback
 
 The live run-turn callback checks replay safety before reserving another ladder
 entry. Side-effecting, interactive, or unknown-physical-effect streamed work
 therefore remains non-retryable regardless of Retry-After or jitter. Delay policy
 never decides retry eligibility.
 
-Rebase order is A1, then E2. After rebase, rerun the production run-turn
-side-effect tests and the full host-functional suite. Rollback is the single E2
-commit: it restores the earlier delay implementation without reverting A1 effect
-settlement or changing persisted state.
+The dependency order is merged A1, then E2. Integrate E2 only on a current
+`main` containing #1644; there is no outstanding A1 rebase. Rerun the production
+run-turn side-effect tests and the full host-functional suite after any later
+rebase. Rolling back the E2 production commit restores the earlier delay
+implementation without reverting A1 effect settlement or changing persisted
+state.
 
 The choice of full jitter follows the measured contention results in the
 [AWS Architecture guidance](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)

--- a/docs/design/reconnect-backoff-policy.md
+++ b/docs/design/reconnect-backoff-policy.md
@@ -1,0 +1,97 @@
+# Finite reconnect and Retry-After policy
+
+Status: E2 implementation, based on A1 commit
+`49dac01e515527c18dc2bef220ffdc48f93cda21`. This branch must be rebased after
+A1 lands; the rebase must preserve A1's unknown-physical-effect retry refusal.
+
+## Compatibility contract
+
+The transport reconnect defaults remain:
+
+| Policy | Value |
+| --- | ---: |
+| Initial exponential capacity | 1,000 ms |
+| Maximum exponential capacity | 30,000 ms |
+| Maximum accepted provider floor | 300,000 ms |
+| Live turn recovery reservations | 5 retries after the initial call |
+
+E2 changes only how a permitted retry is delayed and how its finite budget is
+accounted. The previous narrow plus-or-minus 25 percent interval is replaced by
+integer full jitter over the complete exponential window. There is no implicit
+elapsed deadline, but the API now requires at least one explicit finite bound:
+total attempts or elapsed milliseconds. The live turn passes six total provider
+attempts, while the shared A1 recovery reservation remains authoritative and can
+stop it earlier.
+
+## Delay rule
+
+`runtime/src/recovery/reconnect-policy.ts` is a pure O(1) calculator. For retry
+index `attempt`, it computes the exponential capacity with saturating arithmetic:
+
+```text
+expCap = min(maxDelay, baseDelay * 2^attempt)
+```
+
+Without a server directive, it samples an integer uniformly from the inclusive
+range `[0, expCap]`. With a valid provider floor, it samples only the additional
+component:
+
+```text
+jitterCap = min(expCap, remainingBudget - retryFloor)
+delay = retryFloor + floor(rng() * (jitterCap + 1))
+```
+
+An RNG result must be finite and in `[0, 1)`. Invalid directives use ordinary
+jitter. A syntactically valid floor is never shortened: a floor above 300,000 ms
+or above the remaining elapsed budget exhausts with a typed reason before
+another provider request.
+
+## HTTP adapter boundary
+
+`runtime/src/llm/retry-after.ts` owns RFC 9110 parsing at the provider HTTP
+adapter boundary. It accepts nonnegative decimal delta-seconds and all three
+HTTP-date forms, treating obsolete date forms as UTC independently of the host
+timezone. It rejects partial integers,
+negative values, invalid calendar dates, weekday mismatches, non-finite spellings,
+and unsafe integer overflow. The adapter returns one immutable classification:
+`absent`, `invalid`, `valid`, or `over_policy`.
+
+The parser follows [RFC 9110 section 10.2.3](https://www.rfc-editor.org/rfc/rfc9110.html#name-retry-after),
+which defines Retry-After as either HTTP-date or nonnegative integer
+delay-seconds. Valid over-policy values retain their actual floor for downstream
+exhaustion; they are not clamped to an earlier retry.
+
+## Elapsed and abort accounting
+
+One immutable monotonic/wall start pair owns the entire reconnect call. Elapsed
+time is the larger nonnegative delta. Monotonic progress survives ordinary wall
+clock correction; a positive wall gap catches suspend on platforms whose
+monotonic clock pauses; wall rollback cannot restore budget. Provider calls,
+transient classification, the A1 retry-admission callback, timer wait, and timer
+oversleep all consume the same window.
+
+Abort is checked before each provider call, after a transient failure, before
+and after the retry callback, before sleep, during the abortable sleep, and
+immediately after wake. Telemetry contains only bounded numbers and closed reason
+codes; raw provider error or abort text is not copied into reconnect warnings.
+
+## A1 ordering and rollback
+
+The live run-turn callback checks replay safety before reserving another ladder
+entry. Side-effecting, interactive, or unknown-physical-effect streamed work
+therefore remains non-retryable regardless of Retry-After or jitter. Delay policy
+never decides retry eligibility.
+
+Rebase order is A1, then E2. After rebase, rerun the production run-turn
+side-effect tests and the full host-functional suite. Rollback is the single E2
+commit: it restores the earlier delay implementation without reverting A1 effect
+settlement or changing persisted state.
+
+The choice of full jitter follows the measured contention results in the
+[AWS Architecture guidance](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
+and the current [AWS retry behavior specification](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html).
+Run the local distribution and constant-cost evidence with:
+
+```bash
+npx tsx runtime/benchmarks/reconnect-full-jitter.ts --check
+```

--- a/runtime/benchmarks/reconnect-full-jitter.ts
+++ b/runtime/benchmarks/reconnect-full-jitter.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env -S npx tsx
+
+import { performance } from "node:perf_hooks";
+
+import {
+  RECONNECT_INITIAL_MS,
+  RECONNECT_MAX_MS,
+  calculateReconnectDelay,
+  type RetryAfterDirective,
+} from "../src/recovery/reconnect-policy.js";
+
+const SAMPLE_COUNT = 7;
+const WARMUP_COUNT = 2;
+const RETRY_ATTEMPT = 5;
+const DISTRIBUTION_BUCKETS = 20;
+const MINIMUM_BUCKET_FRACTION = 0.03;
+const MINIMUM_INTERVAL_COVERAGE = 0.99;
+const MAX_NANOSECONDS_PER_OPERATION_RATIO = 8;
+const UINT32_RANGE = 0x1_0000_0000;
+const NONZERO_SEED = 0x9e37_79b9;
+const SAMPLE_SIZES = Object.freeze([10_000, 100_000, 1_000_000] as const);
+const ABSENT_DIRECTIVE = Object.freeze({
+  classification: "absent",
+} as const satisfies RetryAfterDirective);
+
+interface BenchmarkPoint {
+  readonly calls: number;
+  readonly checksum: number;
+  readonly madMilliseconds: number;
+  readonly maximumDelayMs: number;
+  readonly medianMilliseconds: number;
+  readonly minimumDelayMs: number;
+  readonly nanosecondsPerCall: number;
+}
+
+function deterministicRng(seed: number): () => number {
+  let state = seed === 0 ? NONZERO_SEED : seed >>> 0;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state / UINT32_RANGE;
+  };
+}
+
+function runCalls(calls: number): {
+  readonly checksum: number;
+  readonly maximumDelayMs: number;
+  readonly minimumDelayMs: number;
+} {
+  const rng = deterministicRng(NONZERO_SEED ^ calls);
+  let checksum = 0;
+  let maximumDelayMs = 0;
+  let minimumDelayMs = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < calls; index += 1) {
+    const decision = calculateReconnectDelay({
+      attempt: RETRY_ATTEMPT,
+      baseDelayMs: RECONNECT_INITIAL_MS,
+      maxDelayMs: RECONNECT_MAX_MS,
+      remainingBudgetMs: undefined,
+      retryAfter: ABSENT_DIRECTIVE,
+      rng,
+    });
+    if (decision.kind !== "delay") {
+      throw new Error(`unexpected benchmark exhaustion: ${decision.reason}`);
+    }
+    checksum = (checksum + decision.delayMs) % UINT32_RANGE;
+    minimumDelayMs = Math.min(minimumDelayMs, decision.delayMs);
+    maximumDelayMs = Math.max(maximumDelayMs, decision.delayMs);
+  }
+  return { checksum, maximumDelayMs, minimumDelayMs };
+}
+
+function benchmarkPoint(calls: number): BenchmarkPoint {
+  for (let index = 0; index < WARMUP_COUNT; index += 1) runCalls(calls);
+  const samples: number[] = [];
+  let evidence = runCalls(calls);
+  for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+    const startedAt = performance.now();
+    evidence = runCalls(calls);
+    samples.push(performance.now() - startedAt);
+  }
+  const medianMilliseconds = median(samples);
+  return {
+    calls,
+    checksum: evidence.checksum,
+    madMilliseconds: median(
+      samples.map((sample) => Math.abs(sample - medianMilliseconds)),
+    ),
+    maximumDelayMs: evidence.maximumDelayMs,
+    medianMilliseconds,
+    minimumDelayMs: evidence.minimumDelayMs,
+    nanosecondsPerCall: (medianMilliseconds * 1_000_000) / calls,
+  };
+}
+
+function distributionEvidence(calls: number): {
+  readonly buckets: readonly number[];
+  readonly calls: number;
+  readonly maximumDelayMs: number;
+  readonly minimumDelayMs: number;
+} {
+  const buckets = new Array<number>(DISTRIBUTION_BUCKETS).fill(0);
+  const rng = deterministicRng(NONZERO_SEED);
+  let maximumDelayMs = 0;
+  let minimumDelayMs = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < calls; index += 1) {
+    const decision = calculateReconnectDelay({
+      attempt: 0,
+      baseDelayMs: RECONNECT_INITIAL_MS,
+      maxDelayMs: RECONNECT_MAX_MS,
+      remainingBudgetMs: undefined,
+      retryAfter: ABSENT_DIRECTIVE,
+      rng,
+    });
+    if (decision.kind !== "delay") {
+      throw new Error(`unexpected distribution exhaustion: ${decision.reason}`);
+    }
+    const bucket = Math.min(
+      buckets.length - 1,
+      Math.floor(
+        (decision.delayMs / (RECONNECT_INITIAL_MS + 1)) * buckets.length,
+      ),
+    );
+    buckets[bucket] += 1;
+    minimumDelayMs = Math.min(minimumDelayMs, decision.delayMs);
+    maximumDelayMs = Math.max(maximumDelayMs, decision.delayMs);
+  }
+  return { buckets, calls, maximumDelayMs, minimumDelayMs };
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)]!;
+}
+
+function assertConstantTime(points: readonly BenchmarkPoint[]): void {
+  const costs = points.map((point) => point.nanosecondsPerCall);
+  const minimum = Math.min(...costs);
+  const maximum = Math.max(...costs);
+  if (
+    !Number.isFinite(minimum) ||
+    !Number.isFinite(maximum) ||
+    maximum / minimum > MAX_NANOSECONDS_PER_OPERATION_RATIO
+  ) {
+    throw new Error(
+      `calculator cost exceeded O(1) envelope: ${(maximum / minimum).toFixed(2)}x`,
+    );
+  }
+}
+
+function assertDistribution(
+  evidence: ReturnType<typeof distributionEvidence>,
+): void {
+  const minimumBucket = evidence.calls * MINIMUM_BUCKET_FRACTION;
+  if (evidence.buckets.some((count) => count < minimumBucket)) {
+    throw new Error("full-jitter distribution left a broad bucket underfilled");
+  }
+  if (
+    evidence.minimumDelayMs >
+      RECONNECT_INITIAL_MS * (1 - MINIMUM_INTERVAL_COVERAGE) ||
+    evidence.maximumDelayMs < RECONNECT_INITIAL_MS * MINIMUM_INTERVAL_COVERAGE
+  ) {
+    throw new Error("full-jitter samples did not cover the allowed interval");
+  }
+}
+
+const points = SAMPLE_SIZES.map(benchmarkPoint);
+const distribution = distributionEvidence(SAMPLE_SIZES.at(-1)!);
+if (process.argv.includes("--check")) {
+  assertConstantTime(points);
+  assertDistribution(distribution);
+}
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      benchmark: "reconnect-full-jitter-v1",
+      distribution,
+      nodeRuntime: process.version,
+      points,
+      samples: SAMPLE_COUNT,
+      warmups: WARMUP_COUNT,
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/runtime/src/llm/client-session.ts
+++ b/runtime/src/llm/client-session.ts
@@ -34,11 +34,17 @@ import {
 } from "./api/fallback-ladder.js";
 import { isFallbackTriggeredError } from "../recovery/api-errors.js";
 import { isProviderCapabilityMismatch } from "./capabilities.js";
+import { parseProviderRetryAfterDirective } from "./retry-after.js";
+import {
+  RECONNECT_RETRY_AFTER_CEILING_MS,
+  classifyRetryAfterMilliseconds,
+  validateRetryAfterDirective,
+  type RetryAfterDirective,
+} from "../recovery/reconnect-policy.js";
 
 const DEFAULT_REQUEST_MAX_RETRIES = 4;
 const DEFAULT_STREAM_MAX_RETRIES = 5;
 const DEFAULT_RETRY_BASE_DELAY_MS = 200;
-const MAX_RETRY_AFTER_MS = 300_000;
 /**
  * Hard cap on the un-delimited SSE remainder buffered while waiting for a frame
  * separator on the responses-continuation accumulation path. A single SSE event
@@ -177,6 +183,7 @@ export class ProviderHttpError extends Error {
   readonly url: string;
   readonly body?: unknown;
   readonly retryAfterMs?: number;
+  readonly retryAfterDirective: RetryAfterDirective;
 
   constructor(args: {
     providerName: string;
@@ -186,6 +193,7 @@ export class ProviderHttpError extends Error {
     message: string;
     body?: unknown;
     retryAfterMs?: number;
+    retryAfterDirective?: RetryAfterDirective;
   }) {
     super(args.message);
     this.name = "ProviderHttpError";
@@ -194,7 +202,16 @@ export class ProviderHttpError extends Error {
     this.headers = args.headers;
     this.url = args.url;
     this.body = args.body;
-    this.retryAfterMs = args.retryAfterMs;
+    this.retryAfterDirective =
+      args.retryAfterDirective === undefined
+        ? classifyRetryAfterMilliseconds(args.retryAfterMs)
+        : validateRetryAfterDirective(args.retryAfterDirective);
+    if (
+      this.retryAfterDirective.classification === "valid" ||
+      this.retryAfterDirective.classification === "over_policy"
+    ) {
+      this.retryAfterMs = this.retryAfterDirective.floorMs;
+    }
   }
 }
 
@@ -412,42 +429,6 @@ function errorMessageFromBody(status: number, body: unknown): string {
   return `HTTP ${status}`;
 }
 
-function parseRetryAfterMs(
-  headers: Headers,
-  emitWarning?: (warning: { cause: string; message: string }) => void,
-  nowMs = Date.now(),
-): { delayMs?: number; exceedsMaxWait: boolean } {
-  const retryAfter = headers.get("retry-after")?.trim();
-  if (!retryAfter) return { exceedsMaxWait: false };
-
-  const seconds = Number.parseInt(retryAfter, 10);
-  if (Number.isFinite(seconds) && seconds >= 0) {
-    const delayMs = seconds * 1000;
-    if (delayMs > MAX_RETRY_AFTER_MS) {
-      return { exceedsMaxWait: true };
-    }
-    return {
-      delayMs: Math.max(100, delayMs),
-      exceedsMaxWait: false,
-    };
-  }
-
-  const absoluteMs = Date.parse(retryAfter);
-  if (!Number.isFinite(absoluteMs)) {
-    emitWarning?.({
-      cause: "retry_after_ambiguous",
-      message: `provider returned an ambiguous Retry-After header (${retryAfter}); falling back to exponential backoff`,
-    });
-    return { exceedsMaxWait: false };
-  }
-
-  const delayMs = Math.max(100, absoluteMs - nowMs);
-  if (delayMs > MAX_RETRY_AFTER_MS) {
-    return { exceedsMaxWait: true };
-  }
-  return { delayMs, exceedsMaxWait: false };
-}
-
 function buildRequestUrl(baseURL: string, path: string): URL {
   const url = new URL(baseURL);
   const basePath = url.pathname.replace(/\/+$/, "");
@@ -529,35 +510,34 @@ function resolveRetryDelayMs(
   retryBudget: NormalizedRetryBudget,
   retryCount: number,
   emitWarning: ((warning: { cause: string; message: string }) => void) | undefined,
-  headers?: Headers,
+  retryAfter: RetryAfterDirective = { classification: "absent" },
 ): { delayMs: number; exceedsMaxWait: boolean } {
   const fallbackDelayMs = Math.max(
     100,
     backoffWithJitter(retryBudget.baseDelayMs, retryCount),
   );
-  if (!headers) {
-    return {
-      delayMs: fallbackDelayMs,
-      exceedsMaxWait: false,
-    };
-  }
-
-  const parsed = parseRetryAfterMs(headers, emitWarning);
-  if (parsed.exceedsMaxWait) {
+  if (retryAfter.classification === "over_policy") {
     emitWarning?.({
       cause: "rate_limit_exceeds_max_wait",
-      message: `${providerName} requested a Retry-After longer than ${MAX_RETRY_AFTER_MS}ms; aborting retry instead of sleeping unbounded`,
+      message: `${providerName} requested a Retry-After longer than ${RECONNECT_RETRY_AFTER_CEILING_MS}ms; aborting retry instead of sleeping unbounded`,
     });
     return {
       delayMs: fallbackDelayMs,
       exceedsMaxWait: true,
     };
   }
+  if (retryAfter.classification === "invalid") {
+    emitWarning?.({
+      cause: "retry_after_ambiguous",
+      message: `provider returned an invalid Retry-After header (${retryAfter.invalidReason}); falling back to exponential backoff`,
+    });
+  }
 
   return {
-    delayMs: parsed.delayMs !== undefined
-      ? Math.max(parsed.delayMs, fallbackDelayMs)
-      : fallbackDelayMs,
+    delayMs:
+      retryAfter.classification === "valid"
+        ? Math.max(retryAfter.floorMs, fallbackDelayMs)
+        : fallbackDelayMs,
     exceedsMaxWait: false,
   };
 }
@@ -724,6 +704,9 @@ async function createProviderHttpError(
   response: Response,
 ): Promise<ProviderHttpError> {
   const errorBody = await readErrorBody(response);
+  const retryAfterDirective = parseProviderRetryAfterDirective(
+    response.headers,
+  );
   return new ProviderHttpError({
     providerName,
     status: response.status,
@@ -731,7 +714,7 @@ async function createProviderHttpError(
     url: response.url,
     body: errorBody,
     message: errorMessageFromBody(response.status, errorBody),
-    retryAfterMs: parseRetryAfterMs(response.headers).delayMs,
+    retryAfterDirective,
   });
 }
 
@@ -1198,7 +1181,7 @@ export class ProviderHttpClientSession {
               retryBudget,
               attempt + 1,
               this.config.emitWarning,
-              error.headers,
+              error.retryAfterDirective,
             );
             if (retryDelay.exceedsMaxWait) {
               throw error;
@@ -1300,7 +1283,7 @@ export class ProviderHttpClientSession {
               retryBudget,
               attempt + 1,
               this.config.emitWarning,
-              error.headers,
+              error.retryAfterDirective,
             );
             if (retryDelay.exceedsMaxWait) {
               throw error;

--- a/runtime/src/llm/retry-after.ts
+++ b/runtime/src/llm/retry-after.ts
@@ -1,0 +1,252 @@
+/** RFC 9110 Retry-After parsing at the provider HTTP adapter boundary. */
+
+import {
+  classifyRetryAfterMilliseconds,
+  type RetryAfterDirective,
+} from "../recovery/reconnect-policy.js";
+
+const IMF_FIXDATE_PATTERN =
+  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), ([0-9]{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4}) ([0-9]{2}):([0-9]{2}):([0-9]{2}) GMT$/u;
+const RFC850_DATE_PATTERN =
+  /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), ([0-9]{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2}) GMT$/u;
+const ASCTIME_DATE_PATTERN =
+  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)( {2}[1-9]| [0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2}) ([0-9]{4})$/u;
+const NONFINITE_RETRY_AFTER_PATTERN = /^(?:NaN|[+-]?Infinity)$/iu;
+const NEGATIVE_DELAY_SECONDS_PATTERN = /^-[0-9]+$/u;
+const DELAY_SECONDS_PATTERN = /^[0-9]+$/u;
+const HTTP_OPTIONAL_WHITESPACE_PATTERN = /^[\t ]+|[\t ]+$/gu;
+const MILLISECONDS_PER_SECOND = 1_000;
+const LAST_HOUR_OF_DAY = 23;
+const LAST_MINUTE_OF_HOUR = 59;
+const LAST_REGULAR_SECOND_OF_MINUTE = 59;
+const LEAP_SECOND = 60;
+const YEARS_PER_CENTURY = 100;
+const OBSOLETE_DATE_FUTURE_YEARS = 50;
+const MAX_SAFE_DELAY_SECONDS = Math.floor(
+  Number.MAX_SAFE_INTEGER / MILLISECONDS_PER_SECOND,
+);
+const SHORT_WEEKDAY_INDEX = Object.freeze({
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+} as const);
+const LONG_WEEKDAY_INDEX = Object.freeze({
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+} as const);
+const MONTH_INDEX = Object.freeze({
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+} as const);
+
+interface HttpDateParts {
+  readonly day: number;
+  readonly hour: number;
+  readonly minute: number;
+  readonly month: number;
+  readonly second: number;
+  readonly weekday: number;
+  readonly year: number;
+}
+
+export function parseProviderRetryAfterDirective(
+  headers: Headers,
+  nowMs = Date.now(),
+): RetryAfterDirective {
+  const rawRetryAfter = headers.get("retry-after");
+  if (rawRetryAfter === null) {
+    return Object.freeze({ classification: "absent" });
+  }
+  const retryAfter = rawRetryAfter.replace(
+    HTTP_OPTIONAL_WHITESPACE_PATTERN,
+    "",
+  );
+  if (retryAfter.length === 0) {
+    return Object.freeze({
+      classification: "invalid",
+      invalidReason: "syntax",
+    });
+  }
+
+  if (NEGATIVE_DELAY_SECONDS_PATTERN.test(retryAfter)) {
+    return Object.freeze({
+      classification: "invalid",
+      invalidReason: "negative",
+    });
+  }
+  if (NONFINITE_RETRY_AFTER_PATTERN.test(retryAfter)) {
+    return Object.freeze({
+      classification: "invalid",
+      invalidReason: "non_finite",
+    });
+  }
+  if (DELAY_SECONDS_PATTERN.test(retryAfter)) {
+    const seconds = Number(retryAfter);
+    if (!Number.isSafeInteger(seconds) || seconds > MAX_SAFE_DELAY_SECONDS) {
+      return Object.freeze({
+        classification: "invalid",
+        invalidReason: "overflow",
+      });
+    }
+    return classifyRetryAfterMilliseconds(seconds * MILLISECONDS_PER_SECOND);
+  }
+
+  if (!Number.isFinite(nowMs)) {
+    return Object.freeze({
+      classification: "invalid",
+      invalidReason: "non_finite",
+    });
+  }
+  const absoluteMs = parseHttpDateMilliseconds(retryAfter, nowMs);
+  if (absoluteMs === undefined) {
+    return Object.freeze({
+      classification: "invalid",
+      invalidReason: "syntax",
+    });
+  }
+  const floorMs = Math.max(0, Math.ceil(absoluteMs - nowMs));
+  if (!Number.isSafeInteger(floorMs)) {
+    return Object.freeze({
+      classification: "invalid",
+      invalidReason: "overflow",
+    });
+  }
+  return classifyRetryAfterMilliseconds(floorMs);
+}
+
+function parseHttpDateMilliseconds(
+  value: string,
+  nowMs: number,
+): number | undefined {
+  const imf = IMF_FIXDATE_PATTERN.exec(value);
+  if (imf !== null) {
+    return validatedHttpDateMilliseconds({
+      weekday: SHORT_WEEKDAY_INDEX[
+        imf[1] as keyof typeof SHORT_WEEKDAY_INDEX
+      ],
+      day: Number(imf[2]),
+      month: MONTH_INDEX[imf[3] as keyof typeof MONTH_INDEX],
+      year: Number(imf[4]),
+      hour: Number(imf[5]),
+      minute: Number(imf[6]),
+      second: Number(imf[7]),
+    });
+  }
+
+  const rfc850 = RFC850_DATE_PATTERN.exec(value);
+  if (rfc850 !== null) {
+    const dateWithoutYear = {
+      weekday: LONG_WEEKDAY_INDEX[
+        rfc850[1] as keyof typeof LONG_WEEKDAY_INDEX
+      ],
+      day: Number(rfc850[2]),
+      month: MONTH_INDEX[rfc850[3] as keyof typeof MONTH_INDEX],
+      hour: Number(rfc850[5]),
+      minute: Number(rfc850[6]),
+      second: Number(rfc850[7]),
+    } as const;
+    return validatedHttpDateMilliseconds({
+      ...dateWithoutYear,
+      year: resolveObsoleteHttpYear(
+        Number(rfc850[4]),
+        dateWithoutYear,
+        nowMs,
+      ),
+    });
+  }
+
+  const asctime = ASCTIME_DATE_PATTERN.exec(value);
+  if (asctime === null) return undefined;
+  return validatedHttpDateMilliseconds({
+    weekday: SHORT_WEEKDAY_INDEX[
+      asctime[1] as keyof typeof SHORT_WEEKDAY_INDEX
+    ],
+    day: Number(asctime[3]?.replace(/^ +/u, "")),
+    month: MONTH_INDEX[asctime[2] as keyof typeof MONTH_INDEX],
+    year: Number(asctime[7]),
+    hour: Number(asctime[4]),
+    minute: Number(asctime[5]),
+    second: Number(asctime[6]),
+  });
+}
+
+function resolveObsoleteHttpYear(
+  twoDigitYear: number,
+  parts: Omit<HttpDateParts, "year">,
+  nowMs: number,
+): number {
+  const currentYear = new Date(nowMs).getUTCFullYear();
+  const currentCentury =
+    Math.floor(currentYear / YEARS_PER_CENTURY) * YEARS_PER_CENTURY;
+  const candidate = currentCentury + twoDigitYear;
+  const candidateMs = unvalidatedHttpDateMilliseconds({
+    ...parts,
+    year: candidate,
+  });
+  const futureThreshold = new Date(nowMs);
+  futureThreshold.setUTCFullYear(currentYear + OBSOLETE_DATE_FUTURE_YEARS);
+  return candidateMs > futureThreshold.getTime()
+    ? candidate - YEARS_PER_CENTURY
+    : candidate;
+}
+
+function validatedHttpDateMilliseconds(
+  parts: HttpDateParts,
+): number | undefined {
+  const isLeapSecond = parts.second === LEAP_SECOND;
+  if (
+    isLeapSecond &&
+    (parts.hour !== LAST_HOUR_OF_DAY ||
+      parts.minute !== LAST_MINUTE_OF_HOUR)
+  ) {
+    return undefined;
+  }
+  const normalizedParts = isLeapSecond
+    ? { ...parts, second: LAST_REGULAR_SECOND_OF_MINUTE }
+    : parts;
+  const milliseconds = unvalidatedHttpDateMilliseconds(normalizedParts);
+  const date = new Date(milliseconds);
+  if (
+    date.getUTCFullYear() !== normalizedParts.year ||
+    date.getUTCMonth() !== normalizedParts.month ||
+    date.getUTCDate() !== normalizedParts.day ||
+    date.getUTCHours() !== normalizedParts.hour ||
+    date.getUTCMinutes() !== normalizedParts.minute ||
+    date.getUTCSeconds() !== normalizedParts.second ||
+    date.getUTCDay() !== normalizedParts.weekday ||
+    !Number.isFinite(milliseconds)
+  ) {
+    return undefined;
+  }
+  if (!isLeapSecond) return milliseconds;
+  const leapSecondMilliseconds = milliseconds + MILLISECONDS_PER_SECOND;
+  return Number.isSafeInteger(leapSecondMilliseconds)
+    ? leapSecondMilliseconds
+    : undefined;
+}
+
+function unvalidatedHttpDateMilliseconds(parts: HttpDateParts): number {
+  const date = new Date(0);
+  date.setUTCFullYear(parts.year, parts.month, parts.day);
+  date.setUTCHours(parts.hour, parts.minute, parts.second, 0);
+  return date.getTime();
+}

--- a/runtime/src/recovery/reconnect-policy.ts
+++ b/runtime/src/recovery/reconnect-policy.ts
@@ -1,0 +1,263 @@
+/** Pure reconnect delay and provider-floor policy. */
+
+export const RECONNECT_INITIAL_MS = 1_000;
+export const RECONNECT_MAX_MS = 30_000;
+export const RECONNECT_RETRY_AFTER_CEILING_MS = 300_000;
+
+export type RetryAfterClassification =
+  | "absent"
+  | "invalid"
+  | "valid"
+  | "over_policy";
+
+export type RetryAfterInvalidReason =
+  | "negative"
+  | "non_finite"
+  | "overflow"
+  | "syntax";
+
+export type RetryAfterDirective =
+  | { readonly classification: "absent" }
+  | {
+      readonly classification: "invalid";
+      readonly invalidReason: RetryAfterInvalidReason;
+    }
+  | { readonly classification: "valid"; readonly floorMs: number }
+  | { readonly classification: "over_policy"; readonly floorMs: number };
+
+export type ReconnectDelayExhaustionReason =
+  | "retry_after_exceeds_policy"
+  | "retry_after_exceeds_budget";
+
+interface ReconnectDelayDecisionBase {
+  readonly attempt: number;
+  readonly directiveClassification: RetryAfterClassification;
+  readonly directiveInvalidReason: RetryAfterInvalidReason | null;
+  readonly exponentialCapMs: number;
+  readonly remainingBudgetMs: number | null;
+  readonly retryFloorMs: number;
+}
+
+export interface ReconnectDelayScheduled
+  extends ReconnectDelayDecisionBase {
+  readonly kind: "delay";
+  readonly delayMs: number;
+  readonly jitterCapMs: number;
+}
+
+export interface ReconnectDelayExhausted
+  extends ReconnectDelayDecisionBase {
+  readonly kind: "exhausted";
+  readonly reason: ReconnectDelayExhaustionReason;
+}
+
+export type ReconnectDelayDecision =
+  | ReconnectDelayScheduled
+  | ReconnectDelayExhausted;
+
+export interface ReconnectDelayInput {
+  readonly attempt: number;
+  readonly baseDelayMs: number;
+  readonly maxDelayMs: number;
+  readonly remainingBudgetMs: number | undefined;
+  readonly retryAfter: RetryAfterDirective;
+  readonly rng: () => number;
+}
+
+const MAX_INCLUSIVE_JITTER_CAP_MS = Number.MAX_SAFE_INTEGER - 1;
+const FIRST_SATURATING_BINARY_EXPONENT = 53;
+const ABSENT_RETRY_AFTER = Object.freeze({
+  classification: "absent",
+} as const satisfies RetryAfterDirective);
+
+/**
+ * Validate an already-parsed provider millisecond value without shortening it.
+ * Raw Retry-After header parsing remains in the HTTP adapter.
+ */
+export function classifyRetryAfterMilliseconds(
+  value: unknown,
+): RetryAfterDirective {
+  if (value === undefined) return ABSENT_RETRY_AFTER;
+  if (typeof value !== "number") {
+    return invalidDirective("syntax");
+  }
+  if (!Number.isFinite(value)) {
+    return invalidDirective("non_finite");
+  }
+  if (value < 0) {
+    return invalidDirective("negative");
+  }
+  if (!Number.isSafeInteger(value)) {
+    return invalidDirective(
+      Math.abs(value) > Number.MAX_SAFE_INTEGER ? "overflow" : "syntax",
+    );
+  }
+  if (value > RECONNECT_RETRY_AFTER_CEILING_MS) {
+    return Object.freeze({ classification: "over_policy", floorMs: value });
+  }
+  return Object.freeze({ classification: "valid", floorMs: value });
+}
+
+/**
+ * Compute a bounded full-jitter delay in O(1).
+ *
+ * The random source is sampled exactly once only when a delay can be
+ * scheduled. Provider floors are additive: the random component is drawn from
+ * the exponential window remaining after all finite budgets are applied.
+ */
+export function calculateReconnectDelay(
+  input: ReconnectDelayInput,
+): ReconnectDelayDecision {
+  const attempt = safeNonnegativeInteger(input.attempt, "attempt");
+  const baseDelayMs = safePositiveInteger(input.baseDelayMs, "baseDelayMs");
+  const maxDelayMs = safePositiveInteger(input.maxDelayMs, "maxDelayMs");
+  if (maxDelayMs > MAX_INCLUSIVE_JITTER_CAP_MS) {
+    throw new TypeError(
+      `maxDelayMs must not exceed ${MAX_INCLUSIVE_JITTER_CAP_MS}`,
+    );
+  }
+  const remainingBudgetMs =
+    input.remainingBudgetMs === undefined
+      ? undefined
+      : safeNonnegativeInteger(
+          input.remainingBudgetMs,
+          "remainingBudgetMs",
+        );
+  const retryAfter = validateRetryAfterDirective(input.retryAfter);
+  const exponentialCapMs = saturatingExponentialCapMs(
+    baseDelayMs,
+    maxDelayMs,
+    attempt,
+  );
+  const decisionBase = {
+    attempt,
+    directiveClassification: retryAfter.classification,
+    directiveInvalidReason:
+      retryAfter.classification === "invalid"
+        ? retryAfter.invalidReason
+        : null,
+    exponentialCapMs,
+    remainingBudgetMs: remainingBudgetMs ?? null,
+    retryFloorMs:
+      retryAfter.classification === "valid" ||
+      retryAfter.classification === "over_policy"
+        ? retryAfter.floorMs
+        : 0,
+  } as const;
+
+  if (retryAfter.classification === "over_policy") {
+    return {
+      ...decisionBase,
+      kind: "exhausted",
+      reason: "retry_after_exceeds_policy",
+    };
+  }
+
+  const retryFloorMs = decisionBase.retryFloorMs;
+  if (
+    remainingBudgetMs !== undefined &&
+    retryFloorMs > remainingBudgetMs
+  ) {
+    return {
+      ...decisionBase,
+      kind: "exhausted",
+      reason: "retry_after_exceeds_budget",
+    };
+  }
+
+  const budgetJitterCapMs =
+    remainingBudgetMs === undefined
+      ? MAX_INCLUSIVE_JITTER_CAP_MS
+      : remainingBudgetMs - retryFloorMs;
+  const arithmeticJitterCapMs =
+    Number.MAX_SAFE_INTEGER - retryFloorMs;
+  const jitterCapMs = Math.min(
+    exponentialCapMs,
+    budgetJitterCapMs,
+    arithmeticJitterCapMs,
+  );
+  const random = input.rng();
+  if (!Number.isFinite(random) || random < 0 || random >= 1) {
+    throw new TypeError("rng must return a finite value in [0, 1)");
+  }
+  const jitterMs = Math.floor(random * (jitterCapMs + 1));
+  return {
+    ...decisionBase,
+    kind: "delay",
+    delayMs: retryFloorMs + jitterMs,
+    jitterCapMs,
+  };
+}
+
+function saturatingExponentialCapMs(
+  baseDelayMs: number,
+  maxDelayMs: number,
+  attempt: number,
+): number {
+  if (baseDelayMs >= maxDelayMs) return maxDelayMs;
+  if (attempt >= FIRST_SATURATING_BINARY_EXPONENT) return maxDelayMs;
+  const factor = 2 ** attempt;
+  if (baseDelayMs > Math.floor(maxDelayMs / factor)) return maxDelayMs;
+  return baseDelayMs * factor;
+}
+
+export function validateRetryAfterDirective(
+  value: RetryAfterDirective,
+): RetryAfterDirective {
+  if (value === null || typeof value !== "object") {
+    throw new TypeError("retryAfter must be a validated directive");
+  }
+  switch (value.classification) {
+    case "absent":
+      return ABSENT_RETRY_AFTER;
+    case "invalid":
+      if (
+        value.invalidReason !== "negative" &&
+        value.invalidReason !== "non_finite" &&
+        value.invalidReason !== "overflow" &&
+        value.invalidReason !== "syntax"
+      ) {
+        throw new TypeError("retryAfter has an invalid reason code");
+      }
+      return Object.freeze({
+        classification: "invalid",
+        invalidReason: value.invalidReason,
+      });
+    case "valid": {
+      const floorMs = safeNonnegativeInteger(value.floorMs, "retryFloorMs");
+      if (floorMs > RECONNECT_RETRY_AFTER_CEILING_MS) {
+        throw new TypeError("valid retryAfter exceeds the policy ceiling");
+      }
+      return Object.freeze({ classification: "valid", floorMs });
+    }
+    case "over_policy": {
+      const floorMs = safeNonnegativeInteger(value.floorMs, "retryFloorMs");
+      if (floorMs <= RECONNECT_RETRY_AFTER_CEILING_MS) {
+        throw new TypeError("over-policy retryAfter does not exceed the ceiling");
+      }
+      return Object.freeze({ classification: "over_policy", floorMs });
+    }
+    default:
+      throw new TypeError("retryAfter has an unknown classification");
+  }
+}
+
+function invalidDirective(
+  invalidReason: RetryAfterInvalidReason,
+): RetryAfterDirective {
+  return Object.freeze({ classification: "invalid", invalidReason });
+}
+
+function safePositiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${label} must be a finite safe positive integer`);
+  }
+  return value;
+}
+
+function safeNonnegativeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${label} must be a finite safe nonnegative integer`);
+  }
+  return value;
+}

--- a/runtime/src/recovery/reconnection.ts
+++ b/runtime/src/recovery/reconnection.ts
@@ -1,110 +1,52 @@
 /**
- * Reconnection with exponential backoff for transient provider errors.
+ * Finite reconnect orchestration for transient provider failures.
  *
- * Port of agenc reconnection pattern: on transient network /
- * provider errors (ECONNRESET, ECONNREFUSED, 503, stream_idle), the
- * recovery layer sleeps with exponential backoff (1s → 30s cap,
- * ±25% jitter) then resamples. There is no implicit wall-clock give-up
- * budget; callers may provide one explicitly. Pending
- * tool-call re-injection ensures the model sees the same prompt
- * after the reconnect (history is unchanged).
- *
- * Invariants covered:
- *   I-7  (stream abort cascade) — reconnection runs as a recovery
- *        destination, not a terminal exit.
- *   I-42 (recovery re-entry cap) — every reconnect attempt counts
- *        against MAX_RECOVERY_REENTRIES via the ladder.
- *
- * @module
+ * Retry eligibility stays with the caller. This module owns only finite ladder
+ * admission, conservative elapsed accounting, full-jitter delay selection, and
+ * abort-aware sleeping.
  */
 
 import { monotonicMs } from "./_deps/monotonic.js";
-import type { Session } from "../session/session.js";
+import {
+  RECONNECT_INITIAL_MS,
+  RECONNECT_MAX_MS,
+  calculateReconnectDelay,
+  classifyRetryAfterMilliseconds,
+  validateRetryAfterDirective,
+  type ReconnectDelayDecision,
+  type ReconnectDelayExhaustionReason,
+  type RetryAfterClassification,
+  type RetryAfterDirective,
+  type RetryAfterInvalidReason,
+} from "./reconnect-policy.js";
 import { emitWarning } from "../session/event-log.js";
+import type { Session } from "../session/session.js";
 
-// ─────────────────────────────────────────────────────────────────────
-// Backoff configuration
-// ─────────────────────────────────────────────────────────────────────
+export {
+  RECONNECT_INITIAL_MS,
+  RECONNECT_MAX_MS,
+  RECONNECT_RETRY_AFTER_CEILING_MS,
+} from "./reconnect-policy.js";
+export type {
+  ReconnectDelayDecision,
+  RetryAfterDirective,
+} from "./reconnect-policy.js";
 
-export const RECONNECT_INITIAL_MS = 1_000;
-export const RECONNECT_MAX_MS = 30_000;
-const RECONNECT_JITTER_FRAC = 0.25; // ±25 %
-export const RECONNECT_SLEEP_DETECTION_THRESHOLD_MS =
-  RECONNECT_MAX_MS * 2;
+export type ReconnectExhaustionReason =
+  | "attempts_exhausted"
+  | "elapsed_budget_exhausted"
+  | "retry_callback_rejected"
+  | ReconnectDelayExhaustionReason;
 
-/**
- * Upper bound on a server-directed Retry-After we will honor before
- * sleeping. A rate-limited provider (429/529) reports `retryAfterMs`,
- * which legitimately exceeds `RECONNECT_MAX_MS` (the cap on the local
- * 2^attempt backoff). We honor the server's cooldown over the local
- * jitter so we stop hammering during its window, but clamp here so a
- * pathological header can't park a turn for an unbounded stretch. Five
- * minutes mirrors the `withRetry` persistent-mode max backoff.
- */
-export const RECONNECT_RETRY_AFTER_CEILING_MS = 5 * 60 * 1_000;
-
-/**
- * Extract a server-directed retry delay (ms) from a transient error, if
- * one is present. `LLMRateLimitError` (429) and the HTTP-level provider
- * error (429/529) both expose `retryAfterMs`; the live loop may also see
- * the error wrapped (e.g. `StreamModelError.cause`), so the immediate
- * `cause` is consulted as a fallback. Returns `undefined` when no usable
- * server directive is found, leaving the caller on pure 2^attempt
- * backoff. Clamped to `RECONNECT_RETRY_AFTER_CEILING_MS`.
- */
-export function serverDirectedRetryAfterMs(err: unknown): number | undefined {
-  const direct = readRetryAfterMs(err);
-  if (direct !== undefined) return direct;
-  if (err && typeof err === "object") {
-    return readRetryAfterMs((err as { readonly cause?: unknown }).cause);
-  }
-  return undefined;
+export interface ReconnectTelemetry {
+  readonly attempt: number;
+  readonly chosenDelayMs: number | null;
+  readonly directiveClassification: RetryAfterClassification;
+  readonly directiveInvalidReason: RetryAfterInvalidReason | null;
+  readonly exhaustionReason: ReconnectExhaustionReason | null;
+  readonly remainingBudgetMs: number | null;
+  readonly retryFloorMs: number;
 }
-
-function readRetryAfterMs(err: unknown): number | undefined {
-  if (!err || typeof err !== "object") return undefined;
-  const value = (err as { readonly retryAfterMs?: unknown }).retryAfterMs;
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-    return undefined;
-  }
-  return Math.min(value, RECONNECT_RETRY_AFTER_CEILING_MS);
-}
-
-/**
- * Compute the backoff delay for a given attempt (0-indexed). Caps at
- * `RECONNECT_MAX_MS`. ±25 % jitter prevents thundering-herd retry
- * storms when many sessions reconnect at once.
- *
- * When the provider returned a server-directed cooldown
- * (`retryAfterMs`, from a 429/529 Retry-After), the result is at least
- * that long: we sleep `max(retryAfterMs, computedBackoff)` so a
- * rate-limited provider is not hammered during its own cooldown window.
- * `retryAfterMs` is already clamped to `RECONNECT_RETRY_AFTER_CEILING_MS`
- * by `serverDirectedRetryAfterMs`.
- */
-export function computeBackoffMs(
-  attempt: number,
-  retryAfterMs?: number,
-): number {
-  const base = Math.min(
-    RECONNECT_MAX_MS,
-    RECONNECT_INITIAL_MS * Math.pow(2, attempt),
-  );
-  const jitter = base * RECONNECT_JITTER_FRAC * (Math.random() * 2 - 1);
-  const computed = Math.max(RECONNECT_INITIAL_MS, Math.round(base + jitter));
-  if (
-    typeof retryAfterMs === "number" &&
-    Number.isFinite(retryAfterMs) &&
-    retryAfterMs > 0
-  ) {
-    return Math.max(computed, retryAfterMs);
-  }
-  return computed;
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Reconnect orchestration
-// ─────────────────────────────────────────────────────────────────────
 
 export type ReconnectOutcome<T> =
   | { readonly kind: "ok"; readonly value: T; readonly attempts: number }
@@ -112,17 +54,31 @@ export type ReconnectOutcome<T> =
       readonly kind: "exhausted";
       readonly attempts: number;
       readonly lastError: unknown;
+      readonly reason: ReconnectExhaustionReason;
+      readonly telemetry: ReconnectTelemetry;
     }
-  | { readonly kind: "aborted"; readonly reason: string };
+  | {
+      readonly kind: "aborted";
+      readonly reason: "aborted";
+      readonly attempts: number;
+    };
+
+export type ReconnectSleeper = (
+  delayMs: number,
+  signal: AbortSignal | undefined,
+) => Promise<void>;
 
 export interface ReconnectOpts<T> {
   readonly session: Session;
   readonly signal?: AbortSignal;
+  /** Total provider calls, including the first attempt. */
   readonly maxAttempts?: number;
-  /** Optional operator/caller deadline. Unset retries without a time ceiling. */
+  /** Total elapsed retry window, including callbacks and sleeps. */
   readonly giveUpMs?: number;
-  readonly sleepDetectionThresholdMs?: number;
-  readonly now?: () => number;
+  readonly rng?: () => number;
+  readonly monotonicNow?: () => number;
+  readonly wallNow?: () => number;
+  readonly sleeper?: ReconnectSleeper;
   readonly attempt: (attempt: number) => Promise<T>;
   readonly isTransient: (err: unknown) => boolean;
   readonly onTransientRetry?: (
@@ -131,158 +87,426 @@ export interface ReconnectOpts<T> {
   ) => Promise<boolean> | boolean;
 }
 
+interface RetryWindowSnapshot {
+  readonly elapsedMs: number;
+  readonly remainingBudgetMs: number | undefined;
+}
+
+interface RetryWindow {
+  snapshot(): RetryWindowSnapshot;
+}
+
+interface ExhaustedOutcomeInput {
+  readonly attempts: number;
+  readonly directive: RetryAfterDirective;
+  readonly lastError: unknown;
+  readonly reason: ReconnectExhaustionReason;
+  readonly remainingBudgetMs: number | undefined;
+  readonly session: Session;
+}
+
 /**
- * Retry `opts.attempt(n)` until either a transient error succeeds,
- * the optional `maxAttempts` cap trips, or the reconnect give-up
- * budget expires. Returns early on non-transient errors + surfaces
- * them.
+ * Read an adapter-produced directive from an error or its immediate wrapper.
+ * Numeric compatibility fields are validated and never clamped.
+ */
+export function serverDirectedRetryAfter(err: unknown): RetryAfterDirective {
+  const direct = retryAfterOnError(err);
+  if (direct !== undefined) return direct;
+  if (err !== null && typeof err === "object") {
+    const wrapped = retryAfterOnError(
+      (err as { readonly cause?: unknown }).cause,
+    );
+    if (wrapped !== undefined) return wrapped;
+  }
+  return classifyRetryAfterMilliseconds(undefined);
+}
+
+/**
+ * Retry until success or a finite attempt/elapsed policy exhausts.
  *
- * Emits `warning:'reconnecting'` with attempt + backoff + reason so
- * the event log captures every retry cycle.
+ * At least one cap is mandatory. One immutable monotonic/wall start pair owns
+ * the full call, so process suspension, callback work, and timer oversleep can
+ * never restart or extend the ladder.
  */
 export async function reconnectWithBackoff<T>(
   opts: ReconnectOpts<T>,
 ): Promise<ReconnectOutcome<T>> {
-  const maxAttempts = opts.maxAttempts;
-  const giveUpMs = opts.giveUpMs;
-  const sleepDetectionThresholdMs =
-    opts.sleepDetectionThresholdMs ?? RECONNECT_SLEEP_DETECTION_THRESHOLD_MS;
-  const now = opts.now ?? monotonicMs;
+  const maxAttempts = optionalPositiveInteger(
+    opts.maxAttempts,
+    "maxAttempts",
+  );
+  const giveUpMs = optionalPositiveInteger(opts.giveUpMs, "giveUpMs");
+  if (maxAttempts === undefined && giveUpMs === undefined) {
+    throw new TypeError(
+      "reconnectWithBackoff requires maxAttempts or giveUpMs",
+    );
+  }
+
+  const retryWindow = createRetryWindow(
+    opts.monotonicNow ?? monotonicMs,
+    opts.wallNow ?? Date.now,
+    giveUpMs,
+  );
+  const sleeper = opts.sleeper ?? abortableSleep;
+  const rng = opts.rng ?? Math.random;
+  let attempts = 0;
   let lastError: unknown = undefined;
-  let reconnectAttempts = 0;
-  let reconnectStartedAt: number | null = null;
-  let lastReconnectAttemptAt: number | null = null;
-  for (let attempt = 0; ; attempt += 1) {
-    if (opts.signal?.aborted) {
-      return {
-        kind: "aborted",
-        reason: String(opts.signal.reason ?? "aborted"),
-      };
+
+  for (;;) {
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    const beforeAttempt = retryWindow.snapshot();
+    if (budgetExhausted(beforeAttempt)) {
+      return exhaustedOutcome({
+        attempts,
+        directive: { classification: "absent" },
+        lastError,
+        reason: "elapsed_budget_exhausted",
+        remainingBudgetMs: beforeAttempt.remainingBudgetMs,
+        session: opts.session,
+      });
     }
+    if (maxAttempts !== undefined && attempts >= maxAttempts) {
+      return exhaustedOutcome({
+        attempts,
+        directive: { classification: "absent" },
+        lastError,
+        reason: "attempts_exhausted",
+        remainingBudgetMs: beforeAttempt.remainingBudgetMs,
+        session: opts.session,
+      });
+    }
+
+    attempts += 1;
+    let transientError: unknown;
     try {
-      const value = await opts.attempt(attempt);
-      return { kind: "ok", value, attempts: attempt + 1 };
+      const value = await opts.attempt(attempts - 1);
+      return { kind: "ok", value, attempts };
     } catch (err) {
+      if (!opts.isTransient(err)) throw err;
+      transientError = err;
       lastError = err;
-      if (!opts.isTransient(err)) {
-        // Non-transient — bubble. Caller classifies + emits the
-        // appropriate error/stream_error event.
-        throw err;
-      }
-      const currentNow = now();
-      if (reconnectStartedAt === null) {
-        reconnectStartedAt = currentNow;
-      }
-      if (
-        lastReconnectAttemptAt !== null &&
-        currentNow - lastReconnectAttemptAt > sleepDetectionThresholdMs
-      ) {
-        reconnectStartedAt = currentNow;
-        reconnectAttempts = 0;
-      }
-      lastReconnectAttemptAt = currentNow;
-      if (maxAttempts !== undefined && attempt + 1 >= maxAttempts) {
-        return {
-          kind: "exhausted",
-          attempts: attempt + 1,
-          lastError,
-        };
-      }
-      if (
-        giveUpMs !== undefined &&
-        currentNow - reconnectStartedAt >= giveUpMs
-      ) {
-        return {
-          kind: "exhausted",
-          attempts: attempt + 1,
-          lastError,
-        };
-      }
-      if ((await opts.onTransientRetry?.(attempt + 1, err)) === false) {
-        return {
-          kind: "exhausted",
-          attempts: attempt + 1,
-          lastError,
-        };
-      }
-      // Honor a server-directed cooldown (429/529 Retry-After) when the
-      // transient error carries one: sleep at least that long so a
-      // rate-limited provider is not hammered during its own window.
-      const retryAfterMs = serverDirectedRetryAfterMs(err);
-      const delay = computeBackoffMs(reconnectAttempts, retryAfterMs);
-      reconnectAttempts += 1;
-      emitWarning(
-        opts.session.eventLog,
-        opts.session.nextInternalSubId(),
-        "reconnecting",
-        `transient provider error (attempt ${attempt + 1}${
-          maxAttempts !== undefined ? `/${maxAttempts}` : ""
-        }); sleeping ${delay}ms: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+    }
+
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    // Sample after the provider failure even though the failure callback must
+    // still run for A1 cleanup/replay-safety classification before any delay
+    // policy can win.
+    retryWindow.snapshot();
+    const directive = serverDirectedRetryAfter(transientError);
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    const callbackAccepted =
+      (await opts.onTransientRetry?.(attempts, transientError)) !== false;
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    const afterCallback = retryWindow.snapshot();
+    if (!callbackAccepted) {
+      return exhaustedOutcome({
+        attempts,
+        directive,
+        lastError,
+        reason: "retry_callback_rejected",
+        remainingBudgetMs: afterCallback.remainingBudgetMs,
+        session: opts.session,
+      });
+    }
+    if (budgetExhausted(afterCallback)) {
+      return exhaustedOutcome({
+        attempts,
+        directive,
+        lastError,
+        reason: "elapsed_budget_exhausted",
+        remainingBudgetMs: afterCallback.remainingBudgetMs,
+        session: opts.session,
+      });
+    }
+    if (maxAttempts !== undefined && attempts >= maxAttempts) {
+      return exhaustedOutcome({
+        attempts,
+        directive,
+        lastError,
+        reason: "attempts_exhausted",
+        remainingBudgetMs: afterCallback.remainingBudgetMs,
+        session: opts.session,
+      });
+    }
+
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    const beforeSleep = retryWindow.snapshot();
+    if (budgetExhausted(beforeSleep)) {
+      return exhaustedOutcome({
+        attempts,
+        directive,
+        lastError,
+        reason: "elapsed_budget_exhausted",
+        remainingBudgetMs: beforeSleep.remainingBudgetMs,
+        session: opts.session,
+      });
+    }
+    const delayDecision = calculateReconnectDelay({
+      attempt: attempts - 1,
+      baseDelayMs: RECONNECT_INITIAL_MS,
+      maxDelayMs: RECONNECT_MAX_MS,
+      remainingBudgetMs: beforeSleep.remainingBudgetMs,
+      retryAfter: directive,
+      rng,
+    });
+    if (delayDecision.kind === "exhausted") {
+      return exhaustedFromDelayDecision(
+        opts.session,
+        attempts,
+        lastError,
+        delayDecision,
       );
-      await sleep(delay, opts.signal);
-      if (opts.signal?.aborted) {
-        return {
-          kind: "aborted",
-          reason: String(opts.signal.reason ?? "aborted"),
-        };
-      }
+    }
+
+    emitScheduledRetry(opts.session, maxAttempts, delayDecision);
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    try {
+      await sleeper(delayDecision.delayMs, opts.signal);
+    } catch (error) {
+      if (isReconnectAborted(opts.signal)) return aborted(attempts);
+      throw error;
+    }
+    if (isReconnectAborted(opts.signal)) return aborted(attempts);
+    const afterWake = retryWindow.snapshot();
+    if (budgetExhausted(afterWake)) {
+      return exhaustedOutcome({
+        attempts,
+        directive,
+        lastError,
+        reason: "elapsed_budget_exhausted",
+        remainingBudgetMs: afterWake.remainingBudgetMs,
+        session: opts.session,
+      });
     }
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// sleep with abort support
-// ─────────────────────────────────────────────────────────────────────
+function retryAfterOnError(err: unknown): RetryAfterDirective | undefined {
+  if (err === null || typeof err !== "object") return undefined;
+  const candidate = err as {
+    readonly retryAfterDirective?: unknown;
+    readonly retryAfterMs?: unknown;
+  };
+  if (candidate.retryAfterDirective !== undefined) {
+    try {
+      return validateRetryAfterDirective(
+        candidate.retryAfterDirective as RetryAfterDirective,
+      );
+    } catch {
+      return classifyRetryAfterMilliseconds(candidate.retryAfterDirective);
+    }
+  }
+  if ("retryAfterMs" in candidate) {
+    return classifyRetryAfterMilliseconds(candidate.retryAfterMs);
+  }
+  return undefined;
+}
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  if (ms <= 0) return Promise.resolve();
-  return new Promise<void>((resolve) => {
-    // gaphunt3 #45: detach onAbort on the normal timeout path too. `{ once: true }`
-    // only auto-removes a listener AFTER abort fires; on the common (non-aborted)
-    // timeout path the listener would otherwise leak on the long-lived turn signal,
-    // accumulating one dead closure per retry across a reconnect storm.
-    const onAbort = () => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    if (typeof (timer as { unref?: () => void }).unref === "function") {
-      (timer as { unref: () => void }).unref();
-    }
-    if (signal) {
-      if (signal.aborted) {
-        onAbort();
-      } else {
-        signal.addEventListener("abort", onAbort, { once: true });
-      }
-    }
+function createRetryWindow(
+  monotonicNow: () => number,
+  wallNow: () => number,
+  giveUpMs: number | undefined,
+): RetryWindow {
+  const startedMonotonicMs = clockSample(monotonicNow(), "monotonicNow");
+  const startedWallMs = clockSample(wallNow(), "wallNow");
+  let maximumElapsedMs = 0;
+  return Object.freeze({
+    snapshot(): RetryWindowSnapshot {
+      const monotonicElapsedMs = conservativeElapsed(
+        startedMonotonicMs,
+        clockSample(monotonicNow(), "monotonicNow"),
+      );
+      const wallElapsedMs = conservativeElapsed(
+        startedWallMs,
+        clockSample(wallNow(), "wallNow"),
+      );
+      maximumElapsedMs = Math.max(
+        maximumElapsedMs,
+        monotonicElapsedMs,
+        wallElapsedMs,
+      );
+      return {
+        elapsedMs: maximumElapsedMs,
+        remainingBudgetMs:
+          giveUpMs === undefined
+            ? undefined
+            : Math.max(0, giveUpMs - maximumElapsedMs),
+      };
+    },
   });
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Suspend-aware elapsed detection (wall-clock sanity check)
-// ─────────────────────────────────────────────────────────────────────
+function conservativeElapsed(startedAtMs: number, currentMs: number): number {
+  if (currentMs <= startedAtMs) return 0;
+  const elapsed = currentMs - startedAtMs;
+  if (!Number.isFinite(elapsed) || elapsed > Number.MAX_SAFE_INTEGER) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Math.ceil(elapsed);
+}
 
-/**
- * Detects a wall-clock gap > 60s between two monotonic samples,
- * which AgenC treats as "process likely sleeping" and resets
- * the backoff budget. Exposed for callers orchestrating multiple
- * reconnect cycles.
- */
-export function detectSuspend(lastMonotonicMs: number): {
-  readonly suspended: boolean;
-  readonly gapMs: number;
-} {
-  const now = monotonicMs();
-  const gapMs = now - lastMonotonicMs;
+function clockSample(value: number, label: string): number {
+  if (!Number.isFinite(value)) {
+    throw new TypeError(`${label} must return a finite number`);
+  }
+  return value;
+}
+
+function budgetExhausted(snapshot: RetryWindowSnapshot): boolean {
+  return snapshot.remainingBudgetMs === 0;
+}
+
+function optionalPositiveInteger(
+  value: number | undefined,
+  label: string,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${label} must be a finite safe positive integer`);
+  }
+  return value;
+}
+
+function aborted(attempts: number): ReconnectOutcome<never> {
+  return { kind: "aborted", reason: "aborted", attempts };
+}
+
+function exhaustedFromDelayDecision(
+  session: Session,
+  attempts: number,
+  lastError: unknown,
+  decision: Extract<ReconnectDelayDecision, { readonly kind: "exhausted" }>,
+): ReconnectOutcome<never> {
+  return exhaustedOutcome({
+    attempts,
+    directive:
+      decision.directiveClassification === "over_policy"
+        ? {
+            classification: "over_policy",
+            floorMs: decision.retryFloorMs,
+          }
+        : {
+            classification: "valid",
+            floorMs: decision.retryFloorMs,
+          },
+    lastError,
+    reason: decision.reason,
+    remainingBudgetMs: decision.remainingBudgetMs ?? undefined,
+    session,
+  });
+}
+
+function exhaustedOutcome(
+  input: ExhaustedOutcomeInput,
+): ReconnectOutcome<never> {
+  const telemetry = telemetryFor({
+    attempt: input.attempts,
+    chosenDelayMs: null,
+    directive: input.directive,
+    exhaustionReason: input.reason,
+    remainingBudgetMs: input.remainingBudgetMs,
+  });
+  emitWarning(
+    input.session.eventLog,
+    input.session.nextInternalSubId(),
+    "reconnect_exhausted",
+    telemetryMessage(telemetry),
+  );
   return {
-    suspended: gapMs > RECONNECT_SLEEP_DETECTION_THRESHOLD_MS,
-    gapMs,
+    kind: "exhausted",
+    attempts: input.attempts,
+    lastError: input.lastError,
+    reason: input.reason,
+    telemetry,
   };
+}
+
+function emitScheduledRetry(
+  session: Session,
+  maxAttempts: number | undefined,
+  decision: Extract<ReconnectDelayDecision, { readonly kind: "delay" }>,
+): void {
+  const telemetry = telemetryFor({
+    attempt: decision.attempt + 1,
+    chosenDelayMs: decision.delayMs,
+    directive:
+      decision.directiveClassification === "valid"
+        ? { classification: "valid", floorMs: decision.retryFloorMs }
+        : decision.directiveClassification === "invalid"
+          ? {
+              classification: "invalid",
+              invalidReason: decision.directiveInvalidReason ?? "syntax",
+            }
+          : { classification: "absent" },
+    exhaustionReason: null,
+    remainingBudgetMs: decision.remainingBudgetMs ?? undefined,
+  });
+  emitWarning(
+    session.eventLog,
+    session.nextInternalSubId(),
+    "reconnecting",
+    `${telemetryMessage(telemetry)} maxAttempts=${maxAttempts ?? "elapsed"}`,
+  );
+}
+
+function telemetryFor(input: {
+  readonly attempt: number;
+  readonly chosenDelayMs: number | null;
+  readonly directive: RetryAfterDirective;
+  readonly exhaustionReason: ReconnectExhaustionReason | null;
+  readonly remainingBudgetMs: number | undefined;
+}): ReconnectTelemetry {
+  return Object.freeze({
+    attempt: input.attempt,
+    chosenDelayMs: input.chosenDelayMs,
+    directiveClassification: input.directive.classification,
+    directiveInvalidReason:
+      input.directive.classification === "invalid"
+        ? input.directive.invalidReason
+        : null,
+    exhaustionReason: input.exhaustionReason,
+    remainingBudgetMs: input.remainingBudgetMs ?? null,
+    retryFloorMs:
+      input.directive.classification === "valid" ||
+      input.directive.classification === "over_policy"
+        ? input.directive.floorMs
+        : 0,
+  });
+}
+
+function telemetryMessage(telemetry: ReconnectTelemetry): string {
+  return [
+    `attempt=${telemetry.attempt}`,
+    `delayMs=${telemetry.chosenDelayMs ?? "none"}`,
+    `retryAfter=${telemetry.directiveClassification}`,
+    `retryFloorMs=${telemetry.retryFloorMs}`,
+    `remainingBudgetMs=${telemetry.remainingBudgetMs ?? "unbounded"}`,
+    `exhaustion=${telemetry.exhaustionReason ?? "none"}`,
+  ].join(" ");
+}
+
+function isReconnectAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+function abortableSleep(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (delayMs <= 0 || signal?.aborted === true) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const onAbort = () => {
+      clearTimeout(timer);
+      finish();
+    };
+    const timer = setTimeout(finish, delayMs);
+    if (typeof (timer as { unref?: () => void }).unref === "function") {
+      (timer as { unref: () => void }).unref();
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -142,7 +142,10 @@ import {
   isWithheldMaxOutputTokens,
 } from "../recovery/api-errors.js";
 import { reconnectWithBackoff } from "../recovery/reconnection.js";
-import { reserveRecoveryReentry } from "../recovery/fallback-ladder.js";
+import {
+  MAX_RECOVERY_REENTRIES,
+  reserveRecoveryReentry,
+} from "../recovery/fallback-ladder.js";
 import * as planModeHelpers from "./plan-mode.js";
 import type { CompactedItem, ResponseItem } from "./rollout-item.js";
 import type { IdleInputOwnership, Session } from "./session.js";
@@ -3274,6 +3277,10 @@ async function runSamplingRequest(
   const outcome = await reconnectWithBackoff<SamplingRequestResult>({
     session,
     signal,
+    // One initial provider call plus the five recovery-ladder reservations.
+    // The reservation hook remains authoritative when another recovery path
+    // has already consumed part of the shared A1 ladder.
+    maxAttempts: MAX_RECOVERY_REENTRIES + 1,
     attempt: () =>
       tryRunSamplingRequest(
         state,

--- a/runtime/tests/llm/client-session.retry-after.test.ts
+++ b/runtime/tests/llm/client-session.retry-after.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+import { parseProviderRetryAfterDirective } from "../../src/llm/retry-after.js";
+
+interface RetryAfterFixtureCase {
+  readonly name: string;
+  readonly header: string | null;
+  readonly classification: "absent" | "invalid" | "valid" | "over_policy";
+  readonly floorMs?: number;
+  readonly invalidReason?: "negative" | "non_finite" | "overflow" | "syntax";
+  readonly nowMs?: number;
+}
+
+interface RetryAfterFixture {
+  readonly version: 1;
+  readonly nowMs: number;
+  readonly cases: readonly RetryAfterFixtureCase[];
+}
+
+const TEST_DIRECTORY = fileURLToPath(new URL(".", import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(
+    join(
+      TEST_DIRECTORY,
+      "..",
+      "recovery",
+      "fixtures",
+      "retry-after-v1.json",
+    ),
+    "utf8",
+  ),
+) as RetryAfterFixture;
+
+describe("parseProviderRetryAfterDirective", () => {
+  test("keeps the fixture schema version explicit", () => {
+    expect(fixture.version).toBe(1);
+  });
+
+  test.each(fixture.cases)("classifies $name", (entry) => {
+    const headers = new Headers();
+    if (entry.header !== null) headers.set("retry-after", entry.header);
+    const actual = parseProviderRetryAfterDirective(
+      headers,
+      entry.nowMs ?? fixture.nowMs,
+    );
+    expect(Object.isFrozen(actual)).toBe(true);
+    expect(actual).toEqual({
+      classification: entry.classification,
+      ...(entry.floorMs !== undefined ? { floorMs: entry.floorMs } : {}),
+      ...(entry.invalidReason !== undefined
+        ? { invalidReason: entry.invalidReason }
+        : {}),
+    });
+  });
+
+  test("treats obsolete asctime dates as UTC independent of host timezone", () => {
+    const priorTimezone = process.env.TZ;
+    try {
+      process.env.TZ = "America/Edmonton";
+      const headers = new Headers({
+        "retry-after": "Tue Apr 21 12:00:05 2026",
+      });
+      expect(
+        parseProviderRetryAfterDirective(headers, fixture.nowMs),
+      ).toEqual({ classification: "valid", floorMs: 5_000 });
+    } finally {
+      if (priorTimezone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = priorTimezone;
+      }
+    }
+  });
+});

--- a/runtime/tests/llm/client-session.test.ts
+++ b/runtime/tests/llm/client-session.test.ts
@@ -531,6 +531,67 @@ describe("ProviderHttpClientSession", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  test.each([
+    { label: "fractional", retryAfter: "1.5" },
+    { label: "non-HTTP Unicode whitespace", retryAfter: "\u00a01\u00a0" },
+  ])(
+    "rejects $label Retry-After syntax and uses the warned fallback delay",
+    async ({ retryAfter }) => {
+      const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const warnings: Array<{ cause: string; message: string }> = [];
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ error: { message: "slow down" } }), {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "retry-after": retryAfter,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      const session = new ProviderHttpClientSession({
+        providerName: "openai",
+        baseURL: "https://example.test/v1",
+        wireApi: "responses",
+        requestRetry: {
+          maxRetries: 1,
+          retry429: true,
+          baseDelayMs: 200,
+        },
+        fetchImpl,
+        emitWarning: (warning) => warnings.push(warning),
+      });
+
+      const pending = session.requestJson<{ ok: boolean }>({
+        body: { ping: "pong" },
+      });
+
+      await vi.advanceTimersByTimeAsync(199);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(warnings).toEqual([
+        {
+          cause: "retry_after_ambiguous",
+          message:
+            "provider returned an invalid Retry-After header (syntax); falling back to exponential backoff",
+        },
+      ]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const response = await pending;
+
+      expect(response.data.ok).toBe(true);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(random).toHaveBeenCalledTimes(1);
+    },
+  );
+
   test("aborts retry when an HTTP-date Retry-After exceeds the documented T13 ceiling", async () => {
     vi.setSystemTime(new Date("2026-04-21T12:00:00Z"));
     const warnings: Array<{ cause: string; message: string }> = [];

--- a/runtime/tests/recovery/fixtures/retry-after-v1.json
+++ b/runtime/tests/recovery/fixtures/retry-after-v1.json
@@ -1,0 +1,171 @@
+{
+  "version": 1,
+  "nowMs": 1776772800000,
+  "cases": [
+    {
+      "name": "absent",
+      "header": null,
+      "classification": "absent"
+    },
+    {
+      "name": "empty field value",
+      "header": "",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "zero delta",
+      "header": "0",
+      "classification": "valid",
+      "floorMs": 0
+    },
+    {
+      "name": "delta seconds",
+      "header": "2",
+      "classification": "valid",
+      "floorMs": 2000
+    },
+    {
+      "name": "ASCII optional whitespace around delta seconds",
+      "header": " \t2\t ",
+      "classification": "valid",
+      "floorMs": 2000
+    },
+    {
+      "name": "non-breaking spaces around delta seconds",
+      "header": " 2 ",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "exact policy ceiling",
+      "header": "300",
+      "classification": "valid",
+      "floorMs": 300000
+    },
+    {
+      "name": "delta over policy",
+      "header": "301",
+      "classification": "over_policy",
+      "floorMs": 301000
+    },
+    {
+      "name": "future IMF-fixdate",
+      "header": "Tue, 21 Apr 2026 12:00:05 GMT",
+      "classification": "valid",
+      "floorMs": 5000
+    },
+    {
+      "name": "future obsolete RFC 850 date",
+      "header": "Tuesday, 21-Apr-26 12:00:05 GMT",
+      "classification": "valid",
+      "floorMs": 5000
+    },
+    {
+      "name": "RFC 850 date exactly 50 years in the future",
+      "header": "Tuesday, 21-Apr-76 12:00:00 GMT",
+      "classification": "over_policy",
+      "floorMs": 1577923200000
+    },
+    {
+      "name": "RFC 850 date more than 50 years in the future resolves to the past",
+      "header": "Thursday, 22-Apr-76 12:00:00 GMT",
+      "classification": "valid",
+      "floorMs": 0
+    },
+    {
+      "name": "future ANSI C asctime date",
+      "header": "Tue Apr 21 12:00:05 2026",
+      "classification": "valid",
+      "floorMs": 5000
+    },
+    {
+      "name": "IMF-fixdate leap second",
+      "header": "Sat, 31 Dec 2016 23:59:60 GMT",
+      "nowMs": 1483228798000,
+      "classification": "valid",
+      "floorMs": 2000
+    },
+    {
+      "name": "obsolete RFC 850 leap second",
+      "header": "Saturday, 31-Dec-16 23:59:60 GMT",
+      "nowMs": 1483228798000,
+      "classification": "valid",
+      "floorMs": 2000
+    },
+    {
+      "name": "ANSI C asctime leap second",
+      "header": "Sat Dec 31 23:59:60 2016",
+      "nowMs": 1483228798000,
+      "classification": "valid",
+      "floorMs": 2000
+    },
+    {
+      "name": "leap second outside the final minute of the day",
+      "header": "Sat, 31 Dec 2016 12:34:60 GMT",
+      "nowMs": 1483228798000,
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "past date",
+      "header": "Tue, 21 Apr 2026 11:59:00 GMT",
+      "classification": "valid",
+      "floorMs": 0
+    },
+    {
+      "name": "future date over policy",
+      "header": "Tue, 21 Apr 2026 13:00:00 GMT",
+      "classification": "over_policy",
+      "floorMs": 3600000
+    },
+    {
+      "name": "negative delta",
+      "header": "-1",
+      "classification": "invalid",
+      "invalidReason": "negative"
+    },
+    {
+      "name": "fractional delta",
+      "header": "1.5",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "trailing delta text",
+      "header": "2seconds",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "non-finite spelling",
+      "header": "Infinity",
+      "classification": "invalid",
+      "invalidReason": "non_finite"
+    },
+    {
+      "name": "integer overflow",
+      "header": "999999999999999999999999999999999999999",
+      "classification": "invalid",
+      "invalidReason": "overflow"
+    },
+    {
+      "name": "ambiguous text",
+      "header": "soon-ish",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "invalid calendar date",
+      "header": "Tue, 31 Feb 2026 12:00:00 GMT",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    },
+    {
+      "name": "mismatched weekday",
+      "header": "Mon, 21 Apr 2026 12:00:05 GMT",
+      "classification": "invalid",
+      "invalidReason": "syntax"
+    }
+  ]
+}

--- a/runtime/tests/recovery/reconnect-policy.test.ts
+++ b/runtime/tests/recovery/reconnect-policy.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  RECONNECT_INITIAL_MS,
+  RECONNECT_MAX_MS,
+  RECONNECT_RETRY_AFTER_CEILING_MS,
+  calculateReconnectDelay,
+  classifyRetryAfterMilliseconds,
+  type RetryAfterDirective,
+} from "../../src/recovery/reconnect-policy.js";
+import {
+  createSeededRng,
+  createSequenceRng,
+} from "../helpers/seeded-rng.js";
+
+const ABSENT = Object.freeze({
+  classification: "absent",
+} as const satisfies RetryAfterDirective);
+const LAST_EXACT_BINARY_FACTOR = 2 ** 52;
+
+function calculate(
+  rng: () => number,
+  overrides: Partial<Parameters<typeof calculateReconnectDelay>[0]> = {},
+) {
+  return calculateReconnectDelay({
+    attempt: 0,
+    baseDelayMs: RECONNECT_INITIAL_MS,
+    maxDelayMs: RECONNECT_MAX_MS,
+    remainingBudgetMs: undefined,
+    retryAfter: ABSENT,
+    rng,
+    ...overrides,
+  });
+}
+
+describe("calculateReconnectDelay", () => {
+  test("uses exact full-jitter lower, midpoint, and inclusive upper boundaries", () => {
+    const sequence = createSequenceRng(
+      [0, 0.5, 1 - Number.EPSILON],
+      "E2 exact jitter boundaries",
+    );
+
+    expect(calculate(() => sequence.nextFloat())).toMatchObject({
+      kind: "delay",
+      delayMs: 0,
+      exponentialCapMs: 1_000,
+      jitterCapMs: 1_000,
+    });
+    expect(calculate(() => sequence.nextFloat())).toMatchObject({
+      kind: "delay",
+      delayMs: 500,
+    });
+    expect(calculate(() => sequence.nextFloat())).toMatchObject({
+      kind: "delay",
+      delayMs: 1_000,
+    });
+    sequence.assertConsumed();
+  });
+
+  test("saturates exponential arithmetic for very large attempts", () => {
+    expect(
+      calculate(() => 1 - Number.EPSILON, {
+        attempt: Number.MAX_SAFE_INTEGER,
+      }),
+    ).toMatchObject({
+      kind: "delay",
+      delayMs: RECONNECT_MAX_MS,
+      exponentialCapMs: RECONNECT_MAX_MS,
+    });
+  });
+
+  test("keeps the last safe binary boundary exact before saturation", () => {
+    const maxDelayMs = LAST_EXACT_BINARY_FACTOR + 1;
+    expect(
+      calculate(() => 0, {
+        attempt: 52,
+        baseDelayMs: 1,
+        maxDelayMs,
+      }),
+    ).toMatchObject({ exponentialCapMs: LAST_EXACT_BINARY_FACTOR });
+    expect(
+      calculate(() => 0, {
+        attempt: 53,
+        baseDelayMs: 1,
+        maxDelayMs,
+      }),
+    ).toMatchObject({ exponentialCapMs: maxDelayMs });
+    expect(
+      calculate(() => 0, {
+        attempt: 52,
+        baseDelayMs: 2,
+        maxDelayMs,
+      }),
+    ).toMatchObject({ exponentialCapMs: maxDelayMs });
+  });
+
+  test("treats a valid directive as a floor plus additional jitter", () => {
+    expect(
+      calculate(() => 0.5, {
+        retryAfter: { classification: "valid", floorMs: 5_000 },
+      }),
+    ).toMatchObject({
+      kind: "delay",
+      delayMs: 5_500,
+      retryFloorMs: 5_000,
+      jitterCapMs: 1_000,
+    });
+  });
+
+  test("bounds additional jitter by the remaining elapsed budget", () => {
+    expect(
+      calculate(() => 1 - Number.EPSILON, {
+        remainingBudgetMs: 5_500,
+        retryAfter: { classification: "valid", floorMs: 5_000 },
+      }),
+    ).toMatchObject({
+      kind: "delay",
+      delayMs: 5_500,
+      jitterCapMs: 500,
+      remainingBudgetMs: 5_500,
+    });
+  });
+
+  test("exhausts valid floors above policy or remaining budget without drawing RNG", () => {
+    const rng = vi.fn(() => 0.5);
+    expect(
+      calculate(rng, {
+        retryAfter: {
+          classification: "over_policy",
+          floorMs: RECONNECT_RETRY_AFTER_CEILING_MS + 1,
+        },
+      }),
+    ).toMatchObject({
+      kind: "exhausted",
+      reason: "retry_after_exceeds_policy",
+    });
+    expect(
+      calculate(rng, {
+        remainingBudgetMs: 4_999,
+        retryAfter: { classification: "valid", floorMs: 5_000 },
+      }),
+    ).toMatchObject({
+      kind: "exhausted",
+      reason: "retry_after_exceeds_budget",
+    });
+    expect(rng).not.toHaveBeenCalled();
+  });
+
+  test("invalid directives fall back to ordinary full jitter", () => {
+    expect(
+      calculate(() => 0.25, {
+        retryAfter: {
+          classification: "invalid",
+          invalidReason: "non_finite",
+        },
+      }),
+    ).toMatchObject({
+      kind: "delay",
+      delayMs: 250,
+      retryFloorMs: 0,
+      directiveClassification: "invalid",
+    });
+  });
+
+  test.each([Number.NaN, Number.NEGATIVE_INFINITY, -0.01, 1, 2])(
+    "rejects RNG output outside finite [0, 1): %s",
+    (value) => {
+      expect(() => calculate(() => value)).toThrowError(/finite.*\[0, 1\)/u);
+    },
+  );
+
+  test("validates numeric directives without clamping", () => {
+    expect(classifyRetryAfterMilliseconds(undefined)).toEqual({
+      classification: "absent",
+    });
+    expect(classifyRetryAfterMilliseconds(-1)).toEqual({
+      classification: "invalid",
+      invalidReason: "negative",
+    });
+    expect(classifyRetryAfterMilliseconds(Number.POSITIVE_INFINITY)).toEqual({
+      classification: "invalid",
+      invalidReason: "non_finite",
+    });
+    expect(classifyRetryAfterMilliseconds(Number.MAX_SAFE_INTEGER + 1)).toEqual({
+      classification: "invalid",
+      invalidReason: "overflow",
+    });
+    expect(
+      classifyRetryAfterMilliseconds(
+        RECONNECT_RETRY_AFTER_CEILING_MS + 1,
+      ),
+    ).toEqual({
+      classification: "over_policy",
+      floorMs: RECONNECT_RETRY_AFTER_CEILING_MS + 1,
+    });
+  });
+
+  test("seeded samples stay bounded and occupy every broad full-jitter bucket", () => {
+    const rng = createSeededRng({
+      domain: "E2 full-jitter distribution v1",
+      seed: "fixed-reconnect-seed",
+    });
+    const buckets = new Array<number>(10).fill(0);
+    const samples = 20_000;
+    for (let index = 0; index < samples; index += 1) {
+      const decision = calculate(() => rng.nextFloat(), { attempt: 5 });
+      expect(decision.kind).toBe("delay");
+      if (decision.kind !== "delay") continue;
+      expect(decision.delayMs).toBeGreaterThanOrEqual(0);
+      expect(decision.delayMs).toBeLessThanOrEqual(RECONNECT_MAX_MS);
+      const bucket = Math.min(
+        buckets.length - 1,
+        Math.floor((decision.delayMs / (RECONNECT_MAX_MS + 1)) * buckets.length),
+      );
+      buckets[bucket] += 1;
+    }
+    for (const occupancy of buckets) {
+      expect(occupancy).toBeGreaterThan(samples * 0.07);
+    }
+  });
+});

--- a/runtime/tests/recovery/reconnection.test.ts
+++ b/runtime/tests/recovery/reconnection.test.ts
@@ -1,334 +1,579 @@
 import { describe, expect, test, vi } from "vitest";
-import { EventLog } from "../session/event-log.js";
-import type { Session } from "../session/session.js";
+
+import { LLMRateLimitError } from "../../src/llm/errors.js";
 import {
-  computeBackoffMs,
-  detectSuspend,
   RECONNECT_INITIAL_MS,
   RECONNECT_MAX_MS,
   RECONNECT_RETRY_AFTER_CEILING_MS,
-  RECONNECT_SLEEP_DETECTION_THRESHOLD_MS,
   reconnectWithBackoff,
-  serverDirectedRetryAfterMs,
-} from "./reconnection.js";
-import { LLMRateLimitError } from "../llm/errors.js";
+  serverDirectedRetryAfter,
+  type ReconnectOpts,
+  type ReconnectSleeper,
+} from "../../src/recovery/reconnection.js";
+import { EventLog } from "../../src/session/event-log.js";
+import type { Session } from "../../src/session/session.js";
 
-function mkSession(log: EventLog): Session {
-  let i = 0;
+function sessionWithLog(log = new EventLog()): Session {
+  let subId = 0;
   return {
     eventLog: log,
-    nextInternalSubId: () => `s-${++i}`,
+    nextInternalSubId: () => `reconnect-${++subId}`,
   } as unknown as Session;
 }
 
-describe("computeBackoffMs", () => {
-  test("grows exponentially, capped at RECONNECT_MAX_MS", () => {
-    expect(computeBackoffMs(0)).toBeGreaterThanOrEqual(RECONNECT_INITIAL_MS * 0.7);
-    expect(computeBackoffMs(0)).toBeLessThanOrEqual(RECONNECT_INITIAL_MS * 1.3);
-    const large = computeBackoffMs(20);
-    expect(large).toBeLessThanOrEqual(RECONNECT_MAX_MS * 1.3);
-  });
+class ManualClocks {
+  monotonicMs = 0;
+  wallMs = 1_000_000;
 
-  test("honors a server-directed Retry-After over the 2^attempt backoff", () => {
-    // attempt 0 backoff is ~1s, far below the 5s server directive — the
-    // server cooldown must win so we don't hammer during its window.
-    expect(computeBackoffMs(0, 5_000)).toBeGreaterThanOrEqual(5_000);
-  });
+  readonly monotonicNow = (): number => this.monotonicMs;
+  readonly wallNow = (): number => this.wallMs;
 
-  test("uses the larger of computed backoff and Retry-After", () => {
-    // A tiny Retry-After must not shrink the normal escalating backoff.
-    const computed = computeBackoffMs(20, 1);
-    expect(computed).toBeGreaterThanOrEqual(RECONNECT_MAX_MS * 0.7);
-  });
+  advanceBoth(milliseconds: number): void {
+    this.monotonicMs += milliseconds;
+    this.wallMs += milliseconds;
+  }
+}
 
-  test("no Retry-After leaves the normal path unchanged", () => {
-    expect(computeBackoffMs(0, undefined)).toBeLessThanOrEqual(
-      RECONNECT_INITIAL_MS * 1.3,
-    );
-  });
-});
+function reconnectOptions<T>(
+  overrides: Partial<ReconnectOpts<T>> & Pick<ReconnectOpts<T>, "attempt">,
+): ReconnectOpts<T> {
+  return {
+    session: sessionWithLog(),
+    maxAttempts: 3,
+    isTransient: () => true,
+    rng: () => 0,
+    sleeper: async () => {},
+    ...overrides,
+  };
+}
 
-describe("serverDirectedRetryAfterMs", () => {
-  test("reads retryAfterMs off an LLMRateLimitError (429)", () => {
-    const err = new LLMRateLimitError("grok", 5_000);
-    expect(serverDirectedRetryAfterMs(err)).toBe(5_000);
-  });
-
-  test("reads retryAfterMs off a wrapped (cause-chain) error", () => {
-    const wrapped = new Error("stream disconnected");
-    (wrapped as { cause?: unknown }).cause = new LLMRateLimitError(
-      "grok",
-      7_000,
-    );
-    expect(serverDirectedRetryAfterMs(wrapped)).toBe(7_000);
-  });
-
-  test("clamps a pathological Retry-After to the ceiling", () => {
-    const err = new LLMRateLimitError("grok", 60 * 60 * 1_000);
-    expect(serverDirectedRetryAfterMs(err)).toBe(
-      RECONNECT_RETRY_AFTER_CEILING_MS,
-    );
-  });
-
-  test("returns undefined when no server directive is present", () => {
-    expect(serverDirectedRetryAfterMs(new Error("ECONNRESET"))).toBeUndefined();
-    expect(serverDirectedRetryAfterMs(new LLMRateLimitError("grok"))).toBeUndefined();
-  });
-});
-
-describe("reconnectWithBackoff", () => {
-  test("success on first try", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
-    const out = await reconnectWithBackoff({
-      session,
-      attempt: async () => "ok",
-      isTransient: () => true,
+describe("serverDirectedRetryAfter", () => {
+  test("preserves typed valid, invalid, over-policy, wrapped, and absent directives", () => {
+    expect(serverDirectedRetryAfter(new LLMRateLimitError("grok", 5_000))).toEqual({
+      classification: "valid",
+      floorMs: 5_000,
     });
-    expect(out.kind).toBe("ok");
-    if (out.kind === "ok") expect(out.value).toBe("ok");
-  });
-
-  test("retries transient, eventually succeeds", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
-    let calls = 0;
-    const out = await reconnectWithBackoff({
-      session,
-      maxAttempts: 3,
-      attempt: async () => {
-        calls += 1;
-        if (calls < 2) throw new Error("ECONNRESET");
-        return "got-it";
-      },
-      isTransient: () => true,
+    expect(
+      serverDirectedRetryAfter({ retryAfterMs: Number.POSITIVE_INFINITY }),
+    ).toEqual({ classification: "invalid", invalidReason: "non_finite" });
+    expect(
+      serverDirectedRetryAfter({
+        retryAfterMs: RECONNECT_RETRY_AFTER_CEILING_MS + 1,
+      }),
+    ).toEqual({
+      classification: "over_policy",
+      floorMs: RECONNECT_RETRY_AFTER_CEILING_MS + 1,
     });
-    expect(out.kind).toBe("ok");
-    expect(calls).toBe(2);
-  });
-
-  test("exhausted after maxAttempts transient errors", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
-    const out = await reconnectWithBackoff({
-      session,
-      maxAttempts: 2,
-      attempt: async () => {
-        throw new Error("stream_idle");
-      },
-      isTransient: () => true,
-    });
-    expect(out.kind).toBe("exhausted");
-  });
-
-  test("stops retrying when the recovery-cap hook rejects another re-entry", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
-    const gate = vi.fn().mockResolvedValue(false);
-
-    const out = await reconnectWithBackoff({
-      session,
-      attempt: async () => {
-        throw new Error("stream_idle");
-      },
-      isTransient: () => true,
-      onTransientRetry: gate,
-    });
-
-    expect(out.kind).toBe("exhausted");
-    expect(gate).toHaveBeenCalledTimes(1);
-  });
-
-  test("exhausts once the reconnect give-up budget elapses", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
-    const out = await reconnectWithBackoff({
-      session,
-      now: () => 0,
-      giveUpMs: 0,
-      attempt: async () => {
-        throw new Error("stream_idle");
-      },
-      isTransient: () => true,
-    });
-
-    expect(out.kind).toBe("exhausted");
-    if (out.kind === "exhausted") {
-      expect(out.attempts).toBe(1);
-    }
-  });
-
-  test("has no implicit give-up deadline after six hours", async () => {
-    vi.useFakeTimers();
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
-    try {
-      const log = new EventLog();
-      const session = mkSession(log);
-      let now = 0;
-      let calls = 0;
-      const promise = reconnectWithBackoff({
-        session,
-        now: () => now,
-        sleepDetectionThresholdMs: Number.POSITIVE_INFINITY,
-        maxAttempts: 3,
-        attempt: async () => {
-          calls += 1;
-          if (calls < 3) throw new Error("stream_idle");
-          return "recovered";
+    expect(
+      serverDirectedRetryAfter({
+        cause: {
+          retryAfterDirective: {
+            classification: "invalid",
+            invalidReason: "overflow",
+          },
         },
-        isTransient: () => true,
-      });
-
-      await Promise.resolve();
-      now = 6 * 60 * 60_000;
-      await vi.advanceTimersByTimeAsync(1_000);
-      await vi.advanceTimersByTimeAsync(2_000);
-
-      await expect(promise).resolves.toMatchObject({
-        kind: "ok",
-        value: "recovered",
-      });
-      expect(calls).toBe(3);
-    } finally {
-      randomSpy.mockRestore();
-      vi.useRealTimers();
-    }
+      }),
+    ).toEqual({ classification: "invalid", invalidReason: "overflow" });
+    expect(serverDirectedRetryAfter(new Error("ECONNRESET"))).toEqual({
+      classification: "absent",
+    });
+    expect(Object.isFrozen(serverDirectedRetryAfter(new Error("ECONNRESET")))).toBe(
+      true,
+    );
   });
+});
 
-  test("non-transient error bubbles immediately", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
+describe("reconnectWithBackoff policy validation", () => {
+  test("requires at least one explicit finite ladder cap", async () => {
     await expect(
       reconnectWithBackoff({
-        session,
-        attempt: async () => {
-          throw new Error("401 unauthorized");
-        },
-        isTransient: () => false,
+        session: sessionWithLog(),
+        attempt: async () => "unused",
+        isTransient: () => true,
       }),
-    ).rejects.toThrow("401");
+    ).rejects.toThrowError(/maxAttempts.*giveUpMs/u);
   });
 
-  test("aborted signal short-circuits", async () => {
-    const log = new EventLog();
-    const session = mkSession(log);
-    const ctl = new AbortController();
-    ctl.abort("test");
-    const out = await reconnectWithBackoff({
-      session,
-      signal: ctl.signal,
-      attempt: async () => "x",
-      isTransient: () => true,
-    });
-    expect(out.kind).toBe("aborted");
-  });
+  test.each([0, -1, 1.5, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid maxAttempts %s",
+    async (maxAttempts) => {
+      await expect(
+        reconnectWithBackoff({
+          session: sessionWithLog(),
+          maxAttempts,
+          attempt: async () => "unused",
+          isTransient: () => true,
+        }),
+      ).rejects.toThrowError(/maxAttempts.*positive integer/u);
+    },
+  );
 
-  test("resets the reconnect budget after a long suspend gap", async () => {
-    vi.useFakeTimers();
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const log = new EventLog();
-    const session = mkSession(log);
-    let now = 0;
-    let calls = 0;
+  test.each([0, -1, 1.5, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid giveUpMs %s",
+    async (giveUpMs) => {
+      await expect(
+        reconnectWithBackoff({
+          session: sessionWithLog(),
+          giveUpMs,
+          attempt: async () => "unused",
+          isTransient: () => true,
+        }),
+      ).rejects.toThrowError(/giveUpMs.*positive integer/u);
+    },
+  );
 
-    const promise = reconnectWithBackoff({
-      session,
-      now: () => now,
-      giveUpMs: 1_500,
-      sleepDetectionThresholdMs: 60_000,
-      attempt: async () => {
-        calls += 1;
-        if (calls < 3) {
-          throw new Error("stream_idle");
-        }
-        return "recovered";
-      },
-      isTransient: () => true,
-    });
-
-    await Promise.resolve();
-    now = 1_000;
-    await vi.advanceTimersByTimeAsync(1_000);
-    now = 120_000;
-    await vi.advanceTimersByTimeAsync(2_000);
-
-    const out = await promise;
-    expect(out.kind).toBe("ok");
-    expect(calls).toBe(3);
-    randomSpy.mockRestore();
-    vi.useRealTimers();
-  });
-
-  test("honors a 429 Retry-After: sleeps >= 5000ms before the next attempt", async () => {
-    vi.useFakeTimers();
-    // Pin jitter to 0 so the local attempt-0 backoff is exactly
-    // RECONNECT_INITIAL_MS (1000ms) — far below the 5000ms the provider
-    // directs. Without the fix the retry fires at ~1000ms; with the fix it
-    // must wait for the full 5000ms Retry-After window.
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
-    const log = new EventLog();
-    const session = mkSession(log);
-    let calls = 0;
-    let resolved = false;
-
-    const promise = reconnectWithBackoff({
-      session,
-      attempt: async () => {
-        calls += 1;
-        if (calls < 2) {
-          // grok's default 429 maps to LLMRateLimitError carrying the
-          // server-directed cooldown (5s here).
-          throw new LLMRateLimitError("grok", 5_000);
-        }
-        return "recovered";
-      },
-      isTransient: () => true,
-    }).then((out) => {
-      resolved = true;
-      return out;
-    });
-
-    // Let the first attempt run and enter the backoff sleep.
-    await Promise.resolve();
-    expect(calls).toBe(1);
-
-    // At 4999ms the server cooldown has NOT elapsed: the second attempt
-    // must not have fired yet. (Pre-fix this would already be the 2nd call
-    // because the sleep was only ~1000ms.)
-    await vi.advanceTimersByTimeAsync(4_999);
-    expect(calls).toBe(1);
-    expect(resolved).toBe(false);
-
-    // Crossing 5000ms total releases the sleep and the retry succeeds.
-    await vi.advanceTimersByTimeAsync(2);
-    const out = await promise;
-
-    expect(out.kind).toBe("ok");
-    if (out.kind === "ok") expect(out.value).toBe("recovered");
-    expect(calls).toBe(2);
-
-    randomSpy.mockRestore();
-    vi.useRealTimers();
+  test("keeps the named compatibility defaults", () => {
+    expect(RECONNECT_INITIAL_MS).toBe(1_000);
+    expect(RECONNECT_MAX_MS).toBe(30_000);
+    expect(RECONNECT_RETRY_AFTER_CEILING_MS).toBe(300_000);
   });
 });
 
-describe("detectSuspend", () => {
-  test("gap < 60s → not suspended", () => {
-    const now = performance.now();
-    const d = detectSuspend(now - 10_000);
-    expect(d.suspended).toBe(false);
-  });
-  test("gap > sleep threshold → suspended", () => {
-    const now = performance.now();
-    const d = detectSuspend(
-      now - (RECONNECT_SLEEP_DETECTION_THRESHOLD_MS + 1_000),
+describe("reconnectWithBackoff orchestration", () => {
+  test("returns first-attempt success without drawing or sleeping", async () => {
+    const rng = vi.fn(() => 0);
+    const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: 1,
+        attempt: async () => "ok",
+        rng,
+        sleeper,
+      }),
     );
-    expect(d.suspended).toBe(true);
+    expect(outcome).toEqual({ kind: "ok", value: "ok", attempts: 1 });
+    expect(rng).not.toHaveBeenCalled();
+    expect(sleeper).not.toHaveBeenCalled();
   });
 
-  test("defaults match the transport reconnection contract", () => {
-    expect(RECONNECT_INITIAL_MS).toBe(1_000);
-    expect(RECONNECT_MAX_MS).toBe(30_000);
-    expect(RECONNECT_SLEEP_DETECTION_THRESHOLD_MS).toBe(60_000);
+  test("retries transient failures and preserves total-attempt numbering", async () => {
+    let calls = 0;
+    const callback = vi.fn(async () => true);
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: 3,
+        attempt: async (attempt) => {
+          calls += 1;
+          if (calls < 3) throw new Error("temporary");
+          return attempt;
+        },
+        onTransientRetry: callback,
+      }),
+    );
+    expect(outcome).toEqual({ kind: "ok", value: 2, attempts: 3 });
+    expect(callback.mock.calls.map(([attempt]) => attempt)).toEqual([1, 2]);
+  });
+
+  test("runs the final safety callback before typed attempt exhaustion", async () => {
+    const callback = vi.fn(async () => true);
+    const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: 2,
+        attempt: async () => {
+          throw new Error("temporary");
+        },
+        onTransientRetry: callback,
+        sleeper,
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      attempts: 2,
+      reason: "attempts_exhausted",
+      telemetry: {
+        attempt: 2,
+        chosenDelayMs: null,
+        exhaustionReason: "attempts_exhausted",
+      },
+    });
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(sleeper).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps retry eligibility separate and bubbles non-transient failures", async () => {
+    const callback = vi.fn(async () => true);
+    await expect(
+      reconnectWithBackoff(
+        reconnectOptions({
+          attempt: async () => {
+            throw new Error("permanent authorization failure");
+          },
+          isTransient: () => false,
+          onTransientRetry: callback,
+        }),
+      ),
+    ).rejects.toThrow("permanent authorization failure");
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("treats callback refusal as a typed non-retryable exhaustion", async () => {
+    const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        attempt: async () => {
+          throw new Error("unknown physical effect");
+        },
+        onTransientRetry: async () => false,
+        sleeper,
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      attempts: 1,
+      reason: "retry_callback_rejected",
+      telemetry: { exhaustionReason: "retry_callback_rejected" },
+    });
+    expect(sleeper).not.toHaveBeenCalled();
+  });
+
+  test("keeps A1 unknown-effect refusal authoritative over Retry-After policy", async () => {
+    const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        attempt: async () => {
+          throw {
+            retryAfterMs: RECONNECT_RETRY_AFTER_CEILING_MS + 1,
+          };
+        },
+        // Production run-turn performs its A1 physical-effect check here.
+        onTransientRetry: async () => false,
+        sleeper,
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      attempts: 1,
+      reason: "retry_callback_rejected",
+    });
+    expect(sleeper).not.toHaveBeenCalled();
+  });
+
+  test("exhausts over-policy and over-budget valid floors without retrying early", async () => {
+    for (const scenario of [
+      {
+        error: { retryAfterMs: RECONNECT_RETRY_AFTER_CEILING_MS + 1 },
+        giveUpMs: undefined,
+        reason: "retry_after_exceeds_policy",
+      },
+      {
+        error: { retryAfterMs: 5_000 },
+        giveUpMs: 4_000,
+        reason: "retry_after_exceeds_budget",
+      },
+    ] as const) {
+      const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+      const callback = vi.fn(async () => true);
+      let calls = 0;
+      const outcome = await reconnectWithBackoff(
+        reconnectOptions({
+          ...(scenario.giveUpMs === undefined
+            ? { maxAttempts: 3 }
+            : { maxAttempts: undefined, giveUpMs: scenario.giveUpMs }),
+          attempt: async () => {
+            calls += 1;
+            throw scenario.error;
+          },
+          onTransientRetry: callback,
+          sleeper,
+        }),
+      );
+      expect(outcome).toMatchObject({
+        kind: "exhausted",
+        attempts: 1,
+        reason: scenario.reason,
+      });
+      expect(calls).toBe(1);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(sleeper).not.toHaveBeenCalled();
+    }
+  });
+
+  test("invalid directives diagnose and fall back to ordinary jitter", async () => {
+    const sleeps: number[] = [];
+    let calls = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        attempt: async () => {
+          calls += 1;
+          if (calls === 1) {
+            throw { retryAfterMs: Number.POSITIVE_INFINITY };
+          }
+          return "recovered";
+        },
+        rng: () => 0.5,
+        sleeper: async (delayMs) => {
+          sleeps.push(delayMs);
+        },
+      }),
+    );
+    expect(outcome).toMatchObject({ kind: "ok", value: "recovered" });
+    expect(sleeps).toEqual([500]);
+  });
+
+  test("callback execution consumes the immutable elapsed budget", async () => {
+    const clocks = new ManualClocks();
+    const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+    let calls = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: undefined,
+        giveUpMs: 1_000,
+        monotonicNow: clocks.monotonicNow,
+        wallNow: clocks.wallNow,
+        attempt: async () => {
+          calls += 1;
+          throw new Error("temporary");
+        },
+        onTransientRetry: async () => {
+          clocks.advanceBoth(1_000);
+          return true;
+        },
+        sleeper,
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      reason: "elapsed_budget_exhausted",
+      attempts: 1,
+      telemetry: { remainingBudgetMs: 0 },
+    });
+    expect(calls).toBe(1);
+    expect(sleeper).not.toHaveBeenCalled();
+  });
+
+  test("checks elapsed budget before the first provider attempt", async () => {
+    let monotonicReads = 0;
+    const attempt = vi.fn(async () => "unused");
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: undefined,
+        giveUpMs: 1_000,
+        monotonicNow: () => (monotonicReads++ === 0 ? 0 : 1_000),
+        wallNow: () => 0,
+        attempt,
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      attempts: 0,
+      reason: "elapsed_budget_exhausted",
+    });
+    expect(attempt).not.toHaveBeenCalled();
+  });
+
+  test("provider attempt time consumes budget after the safety callback", async () => {
+    const clocks = new ManualClocks();
+    const callback = vi.fn(async () => true);
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: undefined,
+        giveUpMs: 1_000,
+        monotonicNow: clocks.monotonicNow,
+        wallNow: clocks.wallNow,
+        attempt: async () => {
+          clocks.advanceBoth(1_000);
+          throw new Error("temporary");
+        },
+        onTransientRetry: callback,
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      attempts: 1,
+      reason: "elapsed_budget_exhausted",
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("timer oversleep consumes budget before another provider call", async () => {
+    const clocks = new ManualClocks();
+    let calls = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: undefined,
+        giveUpMs: 1_000,
+        monotonicNow: clocks.monotonicNow,
+        wallNow: clocks.wallNow,
+        attempt: async () => {
+          calls += 1;
+          throw new Error("temporary");
+        },
+        rng: () => 0.5,
+        sleeper: async () => {
+          clocks.advanceBoth(1_100);
+        },
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      reason: "elapsed_budget_exhausted",
+      attempts: 1,
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("a wall-clock suspend gap exhausts even when monotonic time pauses", async () => {
+    const clocks = new ManualClocks();
+    let calls = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: undefined,
+        giveUpMs: 1_000,
+        monotonicNow: clocks.monotonicNow,
+        wallNow: clocks.wallNow,
+        attempt: async () => {
+          calls += 1;
+          throw new Error("temporary");
+        },
+        rng: () => 0.5,
+        sleeper: async () => {
+          clocks.wallMs += 120_000;
+        },
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      reason: "elapsed_budget_exhausted",
+      attempts: 1,
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("wall rollback never erases monotonic elapsed time", async () => {
+    const clocks = new ManualClocks();
+    let calls = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: undefined,
+        giveUpMs: 1_000,
+        monotonicNow: clocks.monotonicNow,
+        wallNow: clocks.wallNow,
+        attempt: async () => {
+          calls += 1;
+          if (calls === 2) clocks.advanceBoth(500);
+          throw new Error("temporary");
+        },
+        rng: () => 0.5,
+        sleeper: async () => {
+          clocks.monotonicMs += 500;
+          clocks.wallMs -= 10_000;
+        },
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      reason: "elapsed_budget_exhausted",
+      attempts: 2,
+    });
+    expect(calls).toBe(2);
+  });
+
+  test("wall rollback cannot restore a previously observed wall-clock gap", async () => {
+    const clocks = new ManualClocks();
+    let calls = 0;
+    let sleeps = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        maxAttempts: 3,
+        giveUpMs: 1_000,
+        monotonicNow: clocks.monotonicNow,
+        wallNow: clocks.wallNow,
+        attempt: async () => {
+          calls += 1;
+          if (calls === 2) {
+            clocks.wallMs -= 500;
+            throw { retryAfterMs: 500 };
+          }
+          if (calls === 3) return "rollback incorrectly restored budget";
+          throw new Error("temporary");
+        },
+        sleeper: async () => {
+          sleeps += 1;
+          clocks.wallMs += 600;
+        },
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "exhausted",
+      attempts: 2,
+      reason: "retry_after_exceeds_budget",
+      telemetry: { remainingBudgetMs: 400 },
+    });
+    expect(calls).toBe(2);
+    expect(sleeps).toBe(1);
+  });
+
+  test("safe warning telemetry omits raw provider error text", async () => {
+    const log = new EventLog();
+    const events: unknown[] = [];
+    log.subscribe((event) => events.push(event));
+    let calls = 0;
+    await reconnectWithBackoff(
+      reconnectOptions({
+        session: sessionWithLog(log),
+        attempt: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error("secret-provider-payload");
+          return "ok";
+        },
+      }),
+    );
+    const serialized = JSON.stringify(events);
+    expect(serialized).toContain("reconnecting");
+    expect(serialized).toContain("delayMs");
+    expect(serialized).not.toContain("secret-provider-payload");
+  });
+});
+
+describe("reconnectWithBackoff abort checkpoints", () => {
+  test("aborts before the first attempt", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("private abort reason"));
+    const attempt = vi.fn(async () => "unused");
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({ signal: controller.signal, attempt }),
+    );
+    expect(outcome).toEqual({ kind: "aborted", reason: "aborted", attempts: 0 });
+    expect(attempt).not.toHaveBeenCalled();
+  });
+
+  test("aborts immediately after the retry callback", async () => {
+    const controller = new AbortController();
+    const sleeper = vi.fn<ReconnectSleeper>(async () => {});
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        signal: controller.signal,
+        attempt: async () => {
+          throw new Error("temporary");
+        },
+        onTransientRetry: async () => {
+          controller.abort("callback abort");
+          return true;
+        },
+        sleeper,
+      }),
+    );
+    expect(outcome).toEqual({ kind: "aborted", reason: "aborted", attempts: 1 });
+    expect(sleeper).not.toHaveBeenCalled();
+  });
+
+  test("aborts during sleep and checks again immediately after wake", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const outcome = await reconnectWithBackoff(
+      reconnectOptions({
+        signal: controller.signal,
+        attempt: async () => {
+          calls += 1;
+          throw new Error("temporary");
+        },
+        sleeper: async () => {
+          controller.abort("sleep abort");
+        },
+      }),
+    );
+    expect(outcome).toEqual({ kind: "aborted", reason: "aborted", attempts: 1 });
+    expect(calls).toBe(1);
   });
 });

--- a/runtime/tests/session/plan-mode.test.ts
+++ b/runtime/tests/session/plan-mode.test.ts
@@ -29,6 +29,7 @@ vi.mock("axios", () => {
   };
 });
 import { createAgentRoleWorkspace } from "../agents/role.js";
+import { MAX_RECOVERY_REENTRIES } from "../recovery/fallback-ladder.js";
 import { EventLog, type Event } from "./event-log.js";
 import {
   type AssistantMessageStreamParsersLike,
@@ -676,9 +677,10 @@ describe("runSamplingRequest — reconnectWithBackoff wiring", () => {
     expect(call).toBeDefined();
     expect(typeof call!.attempt).toBe("function");
     expect(typeof call!.isTransient).toBe("function");
-    // run-turn should rely on the reconnection helper's default
-    // 10-minute budget rather than pinning the old 5-attempt policy.
-    expect(call!.maxAttempts).toBeUndefined();
+    // The provider loop has one initial call plus the shared ladder's finite
+    // recovery reservations. The reservation callback still stops earlier if
+    // another A1 recovery path has already consumed capacity.
+    expect(call!.maxAttempts).toBe(MAX_RECOVERY_REENTRIES + 1);
     spy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- replace clustered reconnect delays with a finite, deterministic full-jitter policy
- parse and classify RFC 9110 Retry-After values at the provider boundary, including strict OWS and HTTP-date handling
- preserve retry eligibility and ladder caps while accounting for callbacks, sleep, suspension, and clock rollback in one immutable budget
- add deterministic integration tests, policy documentation, and a million-sample distribution benchmark

## Validation
- focused hermetic suite: 6 files / 252 tests
- canonical npm test: runtime 1,969 files / 18,276 tests; launcher 180/180; required and agent-surface groups green
- typecheck and test-support typecheck
- FND baseline checker and red probes: 7/7 expected-red
- million-sample reconnect benchmark
- validate:runtime: build/package/generated SDK checks and PTY 4/4
- explicit SDK build and typecheck
- independent exact-SHA review: approved `a5138705069c96d574fb64f73fcc10fa2900c154` after three corrected findings

No release or publication is included.