### PR TITLE
feat(runtime): add bounded mailbox metadata contract

### DIFF
--- a/docs/design/mailbox-metadata-contract.md
+++ b/docs/design/mailbox-metadata-contract.md
@@ -1,0 +1,110 @@
+# Bounded mailbox metadata construction
+
+Status: E3a foundation contract. The decoder, builder, authenticated handle,
+serializer, and accessors are implemented. Mailbox caller cutover is deliberately
+deferred to E3b.
+
+## Boundary
+
+`runtime/src/agents/mailbox-metadata.ts` is the only module allowed to create a
+`ValidatedMailboxMetadata` handle. It authenticates handles through private
+`WeakMap` identity, so checking an unknown value is O(1) and never enumerates
+that value. A TypeScript assertion, copied property, symbol, prototype, getter,
+or proxy cannot manufacture the runtime brand.
+
+E3a does not change `Mailbox.send`, its public `SendResult`, or any caller. Until
+E3b lands, existing raw-object ingress remains unchanged and does not implicitly
+receive the protections described here.
+
+## Fixed limits
+
+| Limit                             |     Value | Accounting convention                                                            |
+| --------------------------------- | --------: | -------------------------------------------------------------------------------- |
+| `MAX_MAILBOX_METADATA_DEPTH`      |        64 | The metadata root object is depth 1; only containers increase depth              |
+| `MAX_MAILBOX_METADATA_NODES`      |    10,000 | Root plus every array element or own object-property value                       |
+| `MAX_MAILBOX_METADATA_UTF8_BYTES` | 1,048,576 | Exact retained serialized metadata bytes; decoder raw bytes use the same ceiling |
+
+These limits are compatibility contracts. They may change only with committed
+boundary tests and scaling evidence. Existing mailbox envelope limits can be
+stricter and remain independently authoritative after E3b.
+
+## Construction paths
+
+There are exactly two paths:
+
+1. `MailboxMetadataDecoder` consumes `Uint8Array` chunks with a fatal streaming
+   UTF-8 decoder. It checks the raw-byte ceiling before parsing a chunk, retains
+   lexical state across chunk boundaries, rejects duplicate keys, and accepts
+   one JSON object with no trailing token. An optional `AbortSignal` is checked
+   between deterministic operations.
+2. `MailboxMetadataBuilder` accepts only `beginObject`, `beginArray`, `key`,
+   `scalar`, `endObject`, and `endArray` operations. `scalar` accepts JSON null,
+   strings, booleans, and finite numbers. It never accepts a prebuilt object or
+   container.
+
+Both paths feed the same iterative construction and serialization state
+machine. It checks depth and node capacity before allocating the next owned
+container. It accounts for punctuation, keys, escaping, canonical number text,
+and UTF-8 bytes while applying each operation.
+
+## Owned representation
+
+Accepted objects have null prototypes. Accepted arrays keep their array exotic
+identity but have their prototype explicitly set to null. Every object key,
+including `__proto__`, `constructor`, and `prototype`, is installed with an own
+data descriptor. Containers are frozen when they close.
+
+The exported array type exposes only its readonly `length` and numeric indexes.
+It intentionally does not promise inherited `Array` methods or iteration,
+because those members do not exist on the null-prototype runtime value.
+
+The state machine serializes metadata iteratively without consulting inherited
+`toJSON` hooks. Canonical bytes use ECMA own-key order: canonical uint32 index
+keys below `2^32 - 1` are emitted numerically, followed by all other strings in
+accepted order. Array element order is unchanged. This makes retained bytes
+agree with the exposed ordinary-object graph while normalizing JSON number and
+escape spellings. Integer-index ordering uses bounded fixed-pass radix work, so
+final serialization remains linear in nodes plus serialized bytes. The private
+record retains those bytes and the immutable graph. `getMailboxMetadataBytes`
+returns a defensive byte copy; `getMailboxMetadataValue` returns the frozen
+graph.
+
+## Diagnostics and aborts
+
+Validation and capacity failures use this closed reason vocabulary:
+
+`unbranded`, `syntax`, `utf8`, `duplicate_key`, `depth`, `nodes`, `bytes`, and
+`non_json`.
+
+Abort is control flow rather than malformed input. It throws
+`MailboxMetadataAbortedError` with stable code `MAILBOX_METADATA_ABORTED`; an
+untrusted `AbortSignal.reason` is not copied into the error.
+
+## E3b cutover and rollback
+
+E3b must migrate protocol decoders and trusted internal callers to one of the
+two constructors, change mailbox metadata input types to the authenticated
+handle, and map rejected/unbranded values to the existing public `"dropped"`
+result plus an internal reason. It must not add a raw-object convenience adapter
+or enumerate an unbranded value.
+
+Rollback before E3b is deletion of this unused foundation module. Rollback after
+cutover is to stop new metadata-producing paths while retaining the bounded
+decoder for already versioned wire/storage inputs; it is never permission to
+restore reflective raw-object validation.
+
+## Verification
+
+The dedicated test covers exact and plus-one byte limits for escaped controls,
+CJK, emoji, and long keys; hostile reflection surfaces; incremental syntax and
+UTF-8 cases; prototype poisoning; integer-index boundary ordering; deterministic
+abort; and seeded differential construction. Run the scaling evidence with:
+
+```bash
+npx tsx runtime/benchmarks/mailbox-metadata-scaling.ts --check
+```
+
+The benchmark reports median and median absolute deviation for named-key and
+reverse-integer-key builders, the decoder, and private-brand checks. `--check`
+enforces each builder/decoder linear envelope and a small-versus-boundary O(1)
+relative-cost envelope for private brand admission with fixed operation counts.

--- a/runtime/benchmarks/mailbox-metadata-scaling.ts
+++ b/runtime/benchmarks/mailbox-metadata-scaling.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env -S npx tsx
+
+import { performance } from "node:perf_hooks";
+
+import {
+  MAX_MAILBOX_METADATA_NODES,
+  MailboxMetadataBuilder,
+  decodeMailboxMetadata,
+  getMailboxMetadataMetrics,
+  isValidatedMailboxMetadata,
+  type ValidatedMailboxMetadata,
+} from "../src/agents/mailbox-metadata.js";
+
+const SAMPLE_COUNT = 7;
+const WARMUP_COUNT = 2;
+const BRAND_CHECK_ITERATIONS = 200_000;
+const BRAND_SAMPLE_COUNT = 7;
+const BRAND_WARMUP_COUNT = 2;
+const MAX_BRAND_COST_GROWTH_MULTIPLIER = 4;
+const MAX_NORMALIZED_GROWTH_MULTIPLIER = 8;
+const NODE_COUNTS = Object.freeze([1_000, 5_000, 10_000] as const);
+
+interface ScalingPoint {
+  readonly bytes: number;
+  readonly madMilliseconds: number;
+  readonly medianMilliseconds: number;
+  readonly nanosecondsPerNode: number;
+  readonly nodes: number;
+}
+
+interface BrandPoint {
+  readonly checks: number;
+  readonly madNanosecondsPerCheck: number;
+  readonly nanosecondsPerCheck: number;
+  readonly nodes: number;
+}
+
+function buildMetadata(nodes: number): ValidatedMailboxMetadata {
+  const builder = new MailboxMetadataBuilder();
+  requireAccepted(builder.beginObject());
+  for (let index = 0; index < nodes - 1; index += 1) {
+    requireAccepted(builder.key(`key_${index}`));
+    requireAccepted(builder.scalar(index));
+  }
+  requireAccepted(builder.endObject());
+  const result = builder.finish();
+  if (!result.ok) {
+    throw new Error(`builder rejected ${nodes} nodes: ${result.reason}`);
+  }
+  assertNodeCount(result.metadata, nodes);
+  return result.metadata;
+}
+
+function buildReverseIndexedMetadata(nodes: number): ValidatedMailboxMetadata {
+  const builder = new MailboxMetadataBuilder();
+  requireAccepted(builder.beginObject());
+  for (let index = nodes - 2; index >= 0; index -= 1) {
+    requireAccepted(builder.key(String(index)));
+    requireAccepted(builder.scalar(index));
+  }
+  requireAccepted(builder.endObject());
+  const result = builder.finish();
+  if (!result.ok) {
+    throw new Error(
+      `indexed builder rejected ${nodes} nodes: ${result.reason}`,
+    );
+  }
+  assertNodeCount(result.metadata, nodes);
+  return result.metadata;
+}
+
+function decodeMetadata(
+  bytes: Uint8Array,
+  nodes: number,
+): ValidatedMailboxMetadata {
+  const result = decodeMailboxMetadata(bytes);
+  if (!result.ok) {
+    throw new Error(`decoder rejected ${nodes} nodes: ${result.reason}`);
+  }
+  assertNodeCount(result.metadata, nodes);
+  return result.metadata;
+}
+
+function metadataJson(nodes: number): Uint8Array {
+  const parts = ["{"];
+  for (let index = 0; index < nodes - 1; index += 1) {
+    if (index > 0) parts.push(",");
+    parts.push(`"key_${index}":${index}`);
+  }
+  parts.push("}");
+  return new TextEncoder().encode(parts.join(""));
+}
+
+function measureScaling(
+  nodes: number,
+  operation: () => ValidatedMailboxMetadata,
+): ScalingPoint {
+  for (let index = 0; index < WARMUP_COUNT; index += 1) operation();
+  const samples: number[] = [];
+  let metadata: ValidatedMailboxMetadata | undefined;
+  for (let index = 0; index < SAMPLE_COUNT; index += 1) {
+    const startedAt = performance.now();
+    metadata = operation();
+    samples.push(performance.now() - startedAt);
+  }
+  if (metadata === undefined) throw new Error("benchmark produced no metadata");
+  const medianMilliseconds = median(samples);
+  return {
+    bytes: getMailboxMetadataMetrics(metadata).utf8Bytes,
+    madMilliseconds: median(
+      samples.map((sample) => Math.abs(sample - medianMilliseconds)),
+    ),
+    medianMilliseconds,
+    nanosecondsPerNode: (medianMilliseconds * 1_000_000) / nodes,
+    nodes,
+  };
+}
+
+function measureBrand(
+  metadata: ValidatedMailboxMetadata,
+  nodes: number,
+): BrandPoint {
+  for (let sample = 0; sample < BRAND_WARMUP_COUNT; sample += 1) {
+    runBrandChecks(metadata);
+  }
+  const samples: number[] = [];
+  for (let sample = 0; sample < BRAND_SAMPLE_COUNT; sample += 1) {
+    samples.push(runBrandChecks(metadata));
+  }
+  const nanosecondsPerCheck = median(samples);
+  return {
+    checks: BRAND_CHECK_ITERATIONS,
+    madNanosecondsPerCheck: median(
+      samples.map((sample) => Math.abs(sample - nanosecondsPerCheck)),
+    ),
+    nanosecondsPerCheck,
+    nodes,
+  };
+}
+
+function runBrandChecks(metadata: ValidatedMailboxMetadata): number {
+  let authenticated = 0;
+  const startedAt = performance.now();
+  for (let index = 0; index < BRAND_CHECK_ITERATIONS; index += 1) {
+    if (isValidatedMailboxMetadata(metadata)) authenticated += 1;
+  }
+  const elapsedMilliseconds = performance.now() - startedAt;
+  if (authenticated !== BRAND_CHECK_ITERATIONS) {
+    throw new Error("brand benchmark failed authentication");
+  }
+  return (elapsedMilliseconds * 1_000_000) / BRAND_CHECK_ITERATIONS;
+}
+
+function requireAccepted(result: {
+  readonly ok: boolean;
+  readonly reason?: string;
+}): void {
+  if (!result.ok)
+    throw new Error(`benchmark operation rejected: ${result.reason}`);
+}
+
+function assertNodeCount(
+  metadata: ValidatedMailboxMetadata,
+  expectedNodes: number,
+): void {
+  const actualNodes = getMailboxMetadataMetrics(metadata).nodes;
+  if (actualNodes !== expectedNodes) {
+    throw new Error(`expected ${expectedNodes} nodes, received ${actualNodes}`);
+  }
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)]!;
+}
+
+function assertLinearEnvelope(
+  label: string,
+  points: readonly ScalingPoint[],
+): void {
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (first === undefined || last === undefined) {
+    throw new Error(`${label} benchmark has no points`);
+  }
+  const inputGrowth = last.nodes / first.nodes;
+  const elapsedGrowth = last.medianMilliseconds / first.medianMilliseconds;
+  if (
+    !Number.isFinite(elapsedGrowth) ||
+    elapsedGrowth > inputGrowth * MAX_NORMALIZED_GROWTH_MULTIPLIER
+  ) {
+    throw new Error(
+      `${label} scaling exceeded the bounded linear envelope: ${elapsedGrowth.toFixed(2)}x`,
+    );
+  }
+}
+
+function assertConstantBrandEnvelope(points: readonly BrandPoint[]): void {
+  const small = points[0];
+  const boundary = points[1];
+  if (small === undefined || boundary === undefined || points.length !== 2) {
+    throw new Error("brand benchmark requires exactly two points");
+  }
+  if (
+    small.checks !== BRAND_CHECK_ITERATIONS ||
+    boundary.checks !== BRAND_CHECK_ITERATIONS
+  ) {
+    throw new Error("brand benchmark operation count drifted");
+  }
+  const costGrowth = boundary.nanosecondsPerCheck / small.nanosecondsPerCheck;
+  if (
+    !Number.isFinite(costGrowth) ||
+    costGrowth > MAX_BRAND_COST_GROWTH_MULTIPLIER
+  ) {
+    throw new Error(
+      `private-brand scaling exceeded the O(1) envelope: ${costGrowth.toFixed(2)}x`,
+    );
+  }
+}
+
+const encodedInputs = new Map(
+  NODE_COUNTS.map((nodes) => [nodes, metadataJson(nodes)] as const),
+);
+const builder = NODE_COUNTS.map((nodes) =>
+  measureScaling(nodes, () => buildMetadata(nodes)),
+);
+const indexedBuilder = NODE_COUNTS.map((nodes) =>
+  measureScaling(nodes, () => buildReverseIndexedMetadata(nodes)),
+);
+const decoder = NODE_COUNTS.map((nodes) =>
+  measureScaling(nodes, () => decodeMetadata(encodedInputs.get(nodes)!, nodes)),
+);
+const smallMetadata = buildMetadata(NODE_COUNTS[0]);
+const boundaryMetadata = buildMetadata(MAX_MAILBOX_METADATA_NODES);
+const brand = [
+  measureBrand(smallMetadata, NODE_COUNTS[0]),
+  measureBrand(boundaryMetadata, MAX_MAILBOX_METADATA_NODES),
+];
+
+if (process.argv.includes("--check")) {
+  assertConstantBrandEnvelope(brand);
+  assertLinearEnvelope("builder", builder);
+  assertLinearEnvelope("indexed builder", indexedBuilder);
+  assertLinearEnvelope("decoder", decoder);
+}
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      benchmark: "mailbox-metadata-scaling-v1",
+      brand,
+      builder,
+      decoder,
+      indexedBuilder,
+      nodeRuntime: process.version,
+      brandSamples: BRAND_SAMPLE_COUNT,
+      brandWarmups: BRAND_WARMUP_COUNT,
+      samples: SAMPLE_COUNT,
+      warmups: WARMUP_COUNT,
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/runtime/src/agents/mailbox-metadata.ts
+++ b/runtime/src/agents/mailbox-metadata.ts
@@ -1,0 +1,1413 @@
+/**
+ * Bounded construction for metadata that may later cross an agent mailbox.
+ *
+ * The only supported inputs are incremental UTF-8 JSON bytes and explicit
+ * builder operations. Arbitrary objects are never enumerated or cloned.
+ */
+
+export const MAX_MAILBOX_METADATA_DEPTH = 64;
+export const MAX_MAILBOX_METADATA_NODES = 10_000;
+export const MAX_MAILBOX_METADATA_UTF8_BYTES = 1_048_576;
+
+export const MAILBOX_METADATA_REJECTION_REASONS = Object.freeze([
+  "unbranded",
+  "syntax",
+  "utf8",
+  "duplicate_key",
+  "depth",
+  "nodes",
+  "bytes",
+  "non_json",
+] as const);
+
+export type MailboxMetadataRejectionReason =
+  (typeof MAILBOX_METADATA_REJECTION_REASONS)[number];
+
+export interface MailboxMetadataRejection {
+  readonly ok: false;
+  readonly reason: MailboxMetadataRejectionReason;
+}
+
+export interface MailboxMetadataOperationAccepted {
+  readonly ok: true;
+}
+
+export type MailboxMetadataOperationResult =
+  MailboxMetadataOperationAccepted | MailboxMetadataRejection;
+
+export type MailboxMetadataScalar = null | string | boolean | number;
+
+export type MailboxMetadataValue =
+  MailboxMetadataScalar | MailboxMetadataObject | MailboxMetadataArray;
+
+export interface MailboxMetadataObject {
+  readonly [key: string]: MailboxMetadataValue;
+}
+
+/**
+ * The owned arrays intentionally have null prototypes, so inherited Array
+ * methods and iteration are not part of their public runtime surface.
+ */
+export interface MailboxMetadataArray {
+  readonly length: number;
+  readonly [index: number]: MailboxMetadataValue;
+}
+
+declare const validatedMailboxMetadataBrand: unique symbol;
+
+/**
+ * An opaque handle authenticated by this module's private WeakMap.
+ *
+ * A type assertion or copied property cannot manufacture the runtime brand.
+ */
+export interface ValidatedMailboxMetadata {
+  readonly [validatedMailboxMetadataBrand]: "ValidatedMailboxMetadata";
+}
+
+export interface MailboxMetadataMetrics {
+  readonly depth: number;
+  readonly nodes: number;
+  readonly utf8Bytes: number;
+}
+
+export interface MailboxMetadataAccepted {
+  readonly ok: true;
+  readonly metadata: ValidatedMailboxMetadata;
+}
+
+export type MailboxMetadataResult =
+  MailboxMetadataAccepted | MailboxMetadataRejection;
+
+export type MailboxMetadataAuthenticationResult = MailboxMetadataResult;
+
+export interface MailboxMetadataDecoderOptions {
+  readonly signal?: AbortSignal;
+}
+
+/** Abort is control flow, not a validation/capacity rejection reason. */
+export class MailboxMetadataAbortedError extends Error {
+  readonly code = "MAILBOX_METADATA_ABORTED" as const;
+
+  constructor() {
+    super("mailbox metadata construction was aborted");
+    this.name = "MailboxMetadataAbortedError";
+  }
+}
+
+interface AuthenticatedMetadataRecord {
+  readonly bytes: Uint8Array;
+  readonly metrics: MailboxMetadataMetrics;
+  readonly value: MailboxMetadataObject;
+}
+
+const AUTHENTICATED_METADATA = new WeakMap<
+  object,
+  AuthenticatedMetadataRecord
+>();
+const OPERATION_ACCEPTED: MailboxMetadataOperationAccepted = Object.freeze({
+  ok: true,
+});
+const JSON_STRING_OUTPUT_BLOCK_CODE_UNITS = 8_192;
+const JSON_HEX_DIGITS = "0123456789abcdef";
+const MAX_ECMA_ARRAY_INDEX = 4_294_967_294;
+const UINT32_BITS = 32;
+const ARRAY_INDEX_RADIX_BITS = 8;
+const ARRAY_INDEX_RADIX_SIZE = 1 << ARRAY_INDEX_RADIX_BITS;
+const ARRAY_INDEX_RADIX_MASK = ARRAY_INDEX_RADIX_SIZE - 1;
+const ASCII_ZERO_CODE_UNIT = 0x30;
+
+/** O(1), non-reflective runtime brand check for the E3b mailbox cutover. */
+export function isValidatedMailboxMetadata(
+  value: unknown,
+): value is ValidatedMailboxMetadata {
+  return isObjectIdentity(value) && AUTHENTICATED_METADATA.has(value);
+}
+
+/** Return a typed diagnostic instead of reflecting over an unbranded value. */
+export function authenticateMailboxMetadata(
+  value: unknown,
+): MailboxMetadataAuthenticationResult {
+  if (!isValidatedMailboxMetadata(value)) return rejection("unbranded");
+  return acceptedMetadata(value);
+}
+
+/** Read the immutable, null-prototype metadata graph owned by this module. */
+export function getMailboxMetadataValue(
+  metadata: ValidatedMailboxMetadata,
+): MailboxMetadataObject {
+  return authenticatedRecord(metadata).value;
+}
+
+/** Return a defensive copy of the retained canonical serialized bytes. */
+export function getMailboxMetadataBytes(
+  metadata: ValidatedMailboxMetadata,
+): Uint8Array {
+  return authenticatedRecord(metadata).bytes.slice();
+}
+
+export function getMailboxMetadataMetrics(
+  metadata: ValidatedMailboxMetadata,
+): MailboxMetadataMetrics {
+  return authenticatedRecord(metadata).metrics;
+}
+
+/**
+ * Trusted TypeScript callers construct metadata one operation at a time.
+ * Prebuilt objects and containers are intentionally not accepted.
+ */
+export class MailboxMetadataBuilder {
+  readonly #machine = new MetadataConstructionMachine();
+
+  beginObject(): MailboxMetadataOperationResult {
+    return this.#machine.beginObject();
+  }
+
+  beginArray(): MailboxMetadataOperationResult {
+    return this.#machine.beginArray();
+  }
+
+  key(value: unknown): MailboxMetadataOperationResult {
+    return this.#machine.key(value);
+  }
+
+  scalar(value: unknown): MailboxMetadataOperationResult {
+    return this.#machine.scalar(value);
+  }
+
+  endObject(): MailboxMetadataOperationResult {
+    return this.#machine.endObject();
+  }
+
+  endArray(): MailboxMetadataOperationResult {
+    return this.#machine.endArray();
+  }
+
+  finish(): MailboxMetadataResult {
+    return this.#machine.finish();
+  }
+}
+
+/** Incremental duplicate-key-aware decoder for untrusted UTF-8 JSON bytes. */
+export class MailboxMetadataDecoder {
+  readonly #signal: AbortSignal | undefined;
+  readonly #textDecoder = new TextDecoder("utf-8", {
+    fatal: true,
+    ignoreBOM: true,
+  });
+  readonly #parser = new IncrementalMetadataJsonParser();
+  #rawBytes = 0;
+  #failure: MailboxMetadataRejection | undefined;
+  #finished: MailboxMetadataResult | undefined;
+
+  constructor(options: MailboxMetadataDecoderOptions = {}) {
+    this.#signal = options.signal;
+  }
+
+  write(chunk: Uint8Array): MailboxMetadataOperationResult {
+    if (this.#finished !== undefined) return rejection("non_json");
+    if (this.#failure !== undefined) return this.#failure;
+    throwIfAborted(this.#signal);
+
+    if (!(chunk instanceof Uint8Array)) {
+      return this.#rememberFailure(rejection("non_json"));
+    }
+    const nextRawBytes = this.#rawBytes + chunk.byteLength;
+    if (nextRawBytes > MAX_MAILBOX_METADATA_UTF8_BYTES) {
+      return this.#rememberFailure(rejection("bytes"));
+    }
+
+    let decoded: string;
+    try {
+      decoded = this.#textDecoder.decode(chunk, { stream: true });
+    } catch {
+      return this.#rememberFailure(rejection("utf8"));
+    }
+    this.#rawBytes = nextRawBytes;
+    throwIfAborted(this.#signal);
+    const parsed = this.#parser.write(decoded);
+    if (!parsed.ok) return this.#rememberFailure(parsed);
+    return OPERATION_ACCEPTED;
+  }
+
+  finish(): MailboxMetadataResult {
+    if (this.#finished !== undefined) return this.#finished;
+    if (this.#failure !== undefined) return this.#failure;
+    throwIfAborted(this.#signal);
+
+    let decoded: string;
+    try {
+      decoded = this.#textDecoder.decode();
+    } catch {
+      return this.#rememberFailure(rejection("utf8"));
+    }
+    const parsed = this.#parser.write(decoded);
+    if (!parsed.ok) return this.#rememberFailure(parsed);
+    throwIfAborted(this.#signal);
+    this.#finished = this.#parser.finish();
+    return this.#finished;
+  }
+
+  #rememberFailure(
+    failure: MailboxMetadataRejection,
+  ): MailboxMetadataRejection {
+    this.#failure = failure;
+    return failure;
+  }
+}
+
+export function decodeMailboxMetadata(
+  bytes: Uint8Array,
+  options: MailboxMetadataDecoderOptions = {},
+): MailboxMetadataResult {
+  const decoder = new MailboxMetadataDecoder(options);
+  const written = decoder.write(bytes);
+  return written.ok ? decoder.finish() : written;
+}
+
+interface MutableObjectFrame {
+  readonly indexedKeys: IndexedObjectKey[];
+  readonly kind: "object";
+  readonly namedKeys: string[];
+  readonly keys: Set<string>;
+  readonly value: Record<string, MailboxMetadataValue>;
+  entries: number;
+  pendingKey?: string;
+}
+
+interface MutableArrayFrame {
+  readonly kind: "array";
+  readonly value: MailboxMetadataValue[];
+  entries: number;
+}
+
+type MutableFrame = MutableObjectFrame | MutableArrayFrame;
+
+interface IndexedObjectKey {
+  readonly index: number;
+  readonly key: string;
+}
+
+interface ObjectKeyOrder {
+  readonly indexedKeys: readonly IndexedObjectKey[];
+  readonly namedKeys: readonly string[];
+}
+
+class MetadataConstructionMachine {
+  readonly #objectKeyOrders = new WeakMap<object, ObjectKeyOrder>();
+  readonly #writer = new BoundedCanonicalJsonWriter();
+  readonly #stack: MutableFrame[] = [];
+  #failure: MailboxMetadataRejection | undefined;
+  #finished: ValidatedMailboxMetadata | undefined;
+  #root: Record<string, MailboxMetadataValue> | undefined;
+  #rootComplete = false;
+  #rootStarted = false;
+  #maxDepth = 0;
+  #nodes = 0;
+
+  beginObject(): MailboxMetadataOperationResult {
+    return this.#beginContainer("object");
+  }
+
+  beginArray(): MailboxMetadataOperationResult {
+    return this.#beginContainer("array");
+  }
+
+  key(value: unknown): MailboxMetadataOperationResult {
+    const unavailable = this.#unavailableOperation();
+    if (unavailable !== undefined) return unavailable;
+    const frame = this.#topFrame();
+    if (
+      frame?.kind !== "object" ||
+      frame.pendingKey !== undefined ||
+      typeof value !== "string"
+    ) {
+      return this.#fail("non_json");
+    }
+    if (frame.keys.has(value)) return this.#fail("duplicate_key");
+
+    if (frame.entries > 0 && !this.#writer.appendAscii(",")) {
+      return this.#fail("bytes");
+    }
+    if (!this.#writer.appendString(value) || !this.#writer.appendAscii(":")) {
+      return this.#fail("bytes");
+    }
+    frame.keys.add(value);
+    const arrayIndex = ecmaArrayIndex(value);
+    if (arrayIndex === undefined) {
+      frame.namedKeys.push(value);
+    } else {
+      frame.indexedKeys.push({ index: arrayIndex, key: value });
+    }
+    frame.pendingKey = value;
+    return OPERATION_ACCEPTED;
+  }
+
+  scalar(value: unknown): MailboxMetadataOperationResult {
+    const unavailable = this.#unavailableOperation();
+    if (unavailable !== undefined) return unavailable;
+    if (!isJsonScalar(value)) return this.#fail("non_json");
+    if (this.#stack.length === 0) return this.#fail("non_json");
+    if (!this.#canAddNode()) return this.#fail("nodes");
+    if (!this.#appendArrayValuePrefix()) return this.#fail("bytes");
+    if (!this.#appendScalar(value)) return this.#fail("bytes");
+
+    this.#nodes += 1;
+    this.#attachValue(value);
+    return OPERATION_ACCEPTED;
+  }
+
+  endObject(): MailboxMetadataOperationResult {
+    return this.#endContainer("object");
+  }
+
+  endArray(): MailboxMetadataOperationResult {
+    return this.#endContainer("array");
+  }
+
+  finish(): MailboxMetadataResult {
+    if (this.#failure !== undefined) return this.#failure;
+    if (this.#finished !== undefined) return acceptedMetadata(this.#finished);
+    if (
+      !this.#rootComplete ||
+      this.#root === undefined ||
+      this.#stack.length !== 0
+    ) {
+      return this.#fail("non_json");
+    }
+
+    const accountedBytes = this.#writer.finish();
+    const bytes = serializeCanonicalMetadata(this.#root, this.#objectKeyOrders);
+    if (bytes.byteLength !== accountedBytes.byteLength) {
+      throw new Error("mailbox metadata byte accounting invariant failed");
+    }
+    const metrics: MailboxMetadataMetrics = Object.freeze({
+      depth: this.#maxDepth,
+      nodes: this.#nodes,
+      utf8Bytes: bytes.byteLength,
+    });
+    const handle = Object.freeze(
+      Object.create(null) as ValidatedMailboxMetadata,
+    );
+    AUTHENTICATED_METADATA.set(handle, {
+      bytes,
+      metrics,
+      value: this.#root,
+    });
+    this.#finished = handle;
+    return acceptedMetadata(handle);
+  }
+
+  #beginContainer(kind: "object" | "array"): MailboxMetadataOperationResult {
+    const unavailable = this.#unavailableOperation();
+    if (unavailable !== undefined) return unavailable;
+    const isRoot = this.#stack.length === 0;
+    if (isRoot && (this.#rootStarted || kind !== "object")) {
+      return this.#fail("non_json");
+    }
+    if (!isRoot && !this.#parentAcceptsValue()) {
+      return this.#fail("non_json");
+    }
+
+    const depth = this.#stack.length + 1;
+    if (depth > MAX_MAILBOX_METADATA_DEPTH) return this.#fail("depth");
+    if (!this.#canAddNode()) return this.#fail("nodes");
+    if (!this.#appendArrayValuePrefix()) return this.#fail("bytes");
+    if (!this.#writer.appendAscii(kind === "object" ? "{" : "[")) {
+      return this.#fail("bytes");
+    }
+
+    const frame = createMutableFrame(kind);
+    this.#nodes += 1;
+    this.#maxDepth = Math.max(this.#maxDepth, depth);
+    this.#attachValue(frame.value);
+    this.#stack.push(frame);
+    if (isRoot) {
+      this.#rootStarted = true;
+      this.#root = frame.value as Record<string, MailboxMetadataValue>;
+    }
+    return OPERATION_ACCEPTED;
+  }
+
+  #endContainer(kind: MutableFrame["kind"]): MailboxMetadataOperationResult {
+    const unavailable = this.#unavailableOperation();
+    if (unavailable !== undefined) return unavailable;
+    const frame = this.#topFrame();
+    if (
+      frame === undefined ||
+      frame.kind !== kind ||
+      (frame.kind === "object" && frame.pendingKey !== undefined)
+    ) {
+      return this.#fail("non_json");
+    }
+    if (!this.#writer.appendAscii(kind === "object" ? "}" : "]")) {
+      return this.#fail("bytes");
+    }
+
+    if (frame.kind === "object") {
+      sortIndexedObjectKeys(frame.indexedKeys);
+      Object.freeze(frame.indexedKeys);
+      Object.freeze(frame.namedKeys);
+      this.#objectKeyOrders.set(
+        frame.value,
+        Object.freeze({
+          indexedKeys: frame.indexedKeys,
+          namedKeys: frame.namedKeys,
+        }),
+      );
+    }
+    Object.freeze(frame.value);
+    this.#stack.pop();
+    if (this.#stack.length === 0) this.#rootComplete = true;
+    return OPERATION_ACCEPTED;
+  }
+
+  #appendScalar(value: MailboxMetadataScalar): boolean {
+    if (value === null) return this.#writer.appendAscii("null");
+    if (typeof value === "string") return this.#writer.appendString(value);
+    if (typeof value === "boolean") {
+      return this.#writer.appendAscii(value ? "true" : "false");
+    }
+    return this.#writer.appendAscii(canonicalNumber(value));
+  }
+
+  #appendArrayValuePrefix(): boolean {
+    const frame = this.#topFrame();
+    return frame?.kind !== "array" || frame.entries === 0
+      ? true
+      : this.#writer.appendAscii(",");
+  }
+
+  #attachValue(value: MailboxMetadataValue): void {
+    const parent = this.#topFrame();
+    if (parent === undefined) return;
+    if (parent.kind === "array") {
+      Object.defineProperty(parent.value, String(parent.entries), {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+      });
+      parent.entries += 1;
+      return;
+    }
+
+    const key = parent.pendingKey;
+    if (key === undefined)
+      throw new Error("mailbox metadata key invariant failed");
+    Object.defineProperty(parent.value, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+    parent.entries += 1;
+    parent.pendingKey = undefined;
+  }
+
+  #parentAcceptsValue(): boolean {
+    const parent = this.#topFrame();
+    return parent?.kind === "array" || parent?.pendingKey !== undefined;
+  }
+
+  #canAddNode(): boolean {
+    return this.#nodes < MAX_MAILBOX_METADATA_NODES;
+  }
+
+  #topFrame(): MutableFrame | undefined {
+    return this.#stack[this.#stack.length - 1];
+  }
+
+  #unavailableOperation(): MailboxMetadataRejection | undefined {
+    if (this.#failure !== undefined) return this.#failure;
+    return this.#finished === undefined ? undefined : rejection("non_json");
+  }
+
+  #fail(reason: MailboxMetadataRejectionReason): MailboxMetadataRejection {
+    this.#failure ??= rejection(reason);
+    return this.#failure;
+  }
+}
+
+class BoundedCanonicalJsonWriter {
+  readonly #parts: string[] = [];
+  #utf8Bytes = 0;
+
+  appendAscii(value: string): boolean {
+    if (this.#utf8Bytes + value.length > MAX_MAILBOX_METADATA_UTF8_BYTES) {
+      return false;
+    }
+    this.#parts.push(value);
+    this.#utf8Bytes += value.length;
+    return true;
+  }
+
+  appendString(value: string): boolean {
+    const encoded = encodeJsonString(
+      value,
+      MAX_MAILBOX_METADATA_UTF8_BYTES - this.#utf8Bytes,
+    );
+    if (encoded === null) return false;
+    this.#parts.push(encoded.text);
+    this.#utf8Bytes += encoded.utf8Bytes;
+    return true;
+  }
+
+  finish(): Uint8Array {
+    const bytes = new TextEncoder().encode(this.#parts.join(""));
+    if (bytes.byteLength !== this.#utf8Bytes) {
+      throw new Error("mailbox metadata UTF-8 accounting invariant failed");
+    }
+    return bytes;
+  }
+}
+
+interface ObjectSerializationFrame {
+  entriesWritten: number;
+  indexedKeyPosition: number;
+  readonly kind: "object";
+  namedKeyPosition: number;
+  readonly order: ObjectKeyOrder;
+  readonly value: MailboxMetadataObject;
+}
+
+interface ArraySerializationFrame {
+  index: number;
+  readonly kind: "array";
+  readonly value: readonly MailboxMetadataValue[];
+}
+
+type SerializationFrame = ObjectSerializationFrame | ArraySerializationFrame;
+
+function serializeCanonicalMetadata(
+  root: MailboxMetadataObject,
+  objectKeyOrders: WeakMap<object, ObjectKeyOrder>,
+): Uint8Array {
+  const writer = new BoundedCanonicalJsonWriter();
+  const stack: SerializationFrame[] = [];
+  appendCanonicalValue(root, writer, stack, objectKeyOrders);
+
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1]!;
+    if (frame.kind === "array") {
+      if (frame.index >= frame.value.length) {
+        requireCanonicalAppend(writer.appendAscii("]"));
+        stack.pop();
+        continue;
+      }
+      if (frame.index > 0) requireCanonicalAppend(writer.appendAscii(","));
+      const value = frame.value[frame.index]!;
+      frame.index += 1;
+      appendCanonicalValue(value, writer, stack, objectKeyOrders);
+      continue;
+    }
+
+    const key = nextCanonicalObjectKey(frame);
+    if (key === undefined) {
+      requireCanonicalAppend(writer.appendAscii("}"));
+      stack.pop();
+      continue;
+    }
+    if (frame.entriesWritten > 0) {
+      requireCanonicalAppend(writer.appendAscii(","));
+    }
+    frame.entriesWritten += 1;
+    requireCanonicalAppend(writer.appendString(key));
+    requireCanonicalAppend(writer.appendAscii(":"));
+    appendCanonicalValue(frame.value[key]!, writer, stack, objectKeyOrders);
+  }
+
+  return writer.finish();
+}
+
+function appendCanonicalValue(
+  value: MailboxMetadataValue,
+  writer: BoundedCanonicalJsonWriter,
+  stack: SerializationFrame[],
+  objectKeyOrders: WeakMap<object, ObjectKeyOrder>,
+): void {
+  if (value === null) {
+    requireCanonicalAppend(writer.appendAscii("null"));
+    return;
+  }
+  if (typeof value === "string") {
+    requireCanonicalAppend(writer.appendString(value));
+    return;
+  }
+  if (typeof value === "boolean") {
+    requireCanonicalAppend(writer.appendAscii(value ? "true" : "false"));
+    return;
+  }
+  if (typeof value === "number") {
+    requireCanonicalAppend(writer.appendAscii(canonicalNumber(value)));
+    return;
+  }
+  if (Array.isArray(value)) {
+    requireCanonicalAppend(writer.appendAscii("["));
+    stack.push({
+      index: 0,
+      kind: "array",
+      value: value as readonly MailboxMetadataValue[],
+    });
+    return;
+  }
+
+  const objectValue = value as MailboxMetadataObject;
+  const order = objectKeyOrders.get(objectValue);
+  if (order === undefined) {
+    throw new Error("mailbox metadata object-order invariant failed");
+  }
+  requireCanonicalAppend(writer.appendAscii("{"));
+  stack.push({
+    entriesWritten: 0,
+    indexedKeyPosition: 0,
+    kind: "object",
+    namedKeyPosition: 0,
+    order,
+    value: objectValue,
+  });
+}
+
+function nextCanonicalObjectKey(
+  frame: ObjectSerializationFrame,
+): string | undefined {
+  const indexed = frame.order.indexedKeys[frame.indexedKeyPosition];
+  if (indexed !== undefined) {
+    frame.indexedKeyPosition += 1;
+    return indexed.key;
+  }
+  const named = frame.order.namedKeys[frame.namedKeyPosition];
+  if (named !== undefined) frame.namedKeyPosition += 1;
+  return named;
+}
+
+function requireCanonicalAppend(appended: boolean): void {
+  if (!appended) {
+    throw new Error("mailbox metadata canonical serialization overflowed");
+  }
+}
+
+interface EncodedJsonString {
+  readonly text: string;
+  readonly utf8Bytes: number;
+}
+
+function encodeJsonString(
+  value: string,
+  maximumBytes: number,
+): EncodedJsonString | null {
+  if (maximumBytes < 2) return null;
+  const output = new BoundedStringBlocks();
+  output.append('"');
+  let utf8Bytes = 2;
+  let rawStart = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    const escape = jsonEscapeForCodeUnit(codeUnit);
+    if (escape !== undefined) {
+      if (rawStart < index) output.append(value.slice(rawStart, index));
+      utf8Bytes += escape.length;
+      if (utf8Bytes > maximumBytes) return null;
+      output.append(escape);
+      rawStart = index + 1;
+      continue;
+    }
+
+    if (isHighSurrogate(codeUnit)) {
+      const trailing = value.charCodeAt(index + 1);
+      if (isLowSurrogate(trailing)) {
+        utf8Bytes += 4;
+        index += 1;
+        continue;
+      }
+      if (rawStart < index) output.append(value.slice(rawStart, index));
+      const surrogateEscape = unicodeEscape(codeUnit);
+      utf8Bytes += surrogateEscape.length;
+      if (utf8Bytes > maximumBytes) return null;
+      output.append(surrogateEscape);
+      rawStart = index + 1;
+      continue;
+    }
+    if (isLowSurrogate(codeUnit)) {
+      if (rawStart < index) output.append(value.slice(rawStart, index));
+      const surrogateEscape = unicodeEscape(codeUnit);
+      utf8Bytes += surrogateEscape.length;
+      if (utf8Bytes > maximumBytes) return null;
+      output.append(surrogateEscape);
+      rawStart = index + 1;
+      continue;
+    }
+
+    utf8Bytes += utf8BytesForCodeUnit(codeUnit);
+    if (utf8Bytes > maximumBytes) return null;
+  }
+
+  if (rawStart < value.length) output.append(value.slice(rawStart));
+  output.append('"');
+  return { text: output.finish(), utf8Bytes };
+}
+
+class BoundedStringBlocks {
+  readonly #blocks: string[] = [];
+  #pending: string[] = [];
+  #pendingCodeUnits = 0;
+
+  append(value: string): void {
+    if (value.length === 0) return;
+    this.#pending.push(value);
+    this.#pendingCodeUnits += value.length;
+    if (this.#pendingCodeUnits >= JSON_STRING_OUTPUT_BLOCK_CODE_UNITS) {
+      this.#flush();
+    }
+  }
+
+  finish(): string {
+    this.#flush();
+    return this.#blocks.join("");
+  }
+
+  #flush(): void {
+    if (this.#pending.length === 0) return;
+    this.#blocks.push(this.#pending.join(""));
+    this.#pending = [];
+    this.#pendingCodeUnits = 0;
+  }
+}
+
+type LexerState =
+  "default" | "string" | "escape" | "unicode" | "number" | "literal";
+
+type NumberLexerState =
+  | "minus"
+  | "zero"
+  | "integer"
+  | "fraction_start"
+  | "fraction"
+  | "exponent_start"
+  | "exponent_sign"
+  | "exponent";
+
+interface ObjectGrammarFrame {
+  readonly kind: "object";
+  state: "first_key_or_end" | "key" | "colon" | "value" | "comma_or_end";
+}
+
+interface ArrayGrammarFrame {
+  readonly kind: "array";
+  state: "first_value_or_end" | "value" | "comma_or_end";
+}
+
+type GrammarFrame = ObjectGrammarFrame | ArrayGrammarFrame;
+
+class IncrementalMetadataJsonParser {
+  readonly #machine = new MetadataConstructionMachine();
+  readonly #grammar: GrammarFrame[] = [];
+  readonly #tokenText = new TextAccumulator();
+  #failure: MailboxMetadataRejection | undefined;
+  #lexerState: LexerState = "default";
+  #numberState: NumberLexerState | undefined;
+  #literalExpected = "";
+  #literalIndex = 0;
+  #unicodeDigits = "";
+  #rootState: "value" | "end" = "value";
+
+  write(text: string): MailboxMetadataOperationResult {
+    if (this.#failure !== undefined) return this.#failure;
+    let index = 0;
+    while (index < text.length && this.#failure === undefined) {
+      switch (this.#lexerState) {
+        case "default":
+          index = this.#consumeDefault(text, index);
+          break;
+        case "string":
+          index = this.#consumeString(text, index);
+          break;
+        case "escape":
+          index = this.#consumeEscape(text, index);
+          break;
+        case "unicode":
+          index = this.#consumeUnicode(text, index);
+          break;
+        case "number":
+          index = this.#consumeNumber(text, index);
+          break;
+        case "literal":
+          index = this.#consumeLiteral(text, index);
+          break;
+      }
+    }
+    return this.#failure ?? OPERATION_ACCEPTED;
+  }
+
+  finish(): MailboxMetadataResult {
+    if (this.#failure !== undefined) return this.#failure;
+    if (this.#lexerState === "number") this.#finishNumber();
+    if (this.#failure !== undefined) return this.#failure;
+    if (
+      this.#lexerState !== "default" ||
+      this.#grammar.length !== 0 ||
+      this.#rootState !== "end"
+    ) {
+      return this.#fail("syntax");
+    }
+    const result = this.#machine.finish();
+    if (!result.ok && result.reason === "non_json") return this.#fail("syntax");
+    return result;
+  }
+
+  #consumeDefault(text: string, index: number): number {
+    const character = text[index]!;
+    if (isJsonWhitespace(character)) return index + 1;
+    if (character === '"') {
+      this.#tokenText.reset();
+      this.#lexerState = "string";
+      return index + 1;
+    }
+    if (character === "{" || character === "[") {
+      this.#beginContainer(character === "{" ? "object" : "array");
+      return index + 1;
+    }
+    if (character === "}" || character === "]") {
+      this.#endContainer(character === "}" ? "object" : "array");
+      return index + 1;
+    }
+    if (character === ":") {
+      this.#consumeColon();
+      return index + 1;
+    }
+    if (character === ",") {
+      this.#consumeComma();
+      return index + 1;
+    }
+    if (character === "-" || isAsciiDigit(character)) {
+      this.#startNumber(character);
+      return index + 1;
+    }
+    if (character === "t" || character === "f" || character === "n") {
+      this.#startLiteral(character);
+      return index + 1;
+    }
+    this.#fail("syntax");
+    return text.length;
+  }
+
+  #consumeString(text: string, index: number): number {
+    const rawStart = index;
+    while (index < text.length) {
+      const codeUnit = text.charCodeAt(index);
+      if (codeUnit === 0x22 || codeUnit === 0x5c || codeUnit < 0x20) break;
+      index += 1;
+    }
+    if (rawStart < index) this.#tokenText.append(text.slice(rawStart, index));
+    if (index === text.length) return index;
+
+    const codeUnit = text.charCodeAt(index);
+    if (codeUnit < 0x20) {
+      this.#fail("syntax");
+      return text.length;
+    }
+    if (codeUnit === 0x5c) {
+      this.#lexerState = "escape";
+      return index + 1;
+    }
+
+    const value = this.#tokenText.take();
+    this.#lexerState = "default";
+    this.#emitString(value);
+    return index + 1;
+  }
+
+  #consumeEscape(text: string, index: number): number {
+    const character = text[index]!;
+    const escaped = decodedSimpleJsonEscape(character);
+    if (escaped !== undefined) {
+      this.#tokenText.append(escaped);
+      this.#lexerState = "string";
+      return index + 1;
+    }
+    if (character === "u") {
+      this.#unicodeDigits = "";
+      this.#lexerState = "unicode";
+      return index + 1;
+    }
+    this.#fail("syntax");
+    return text.length;
+  }
+
+  #consumeUnicode(text: string, index: number): number {
+    const character = text[index]!;
+    if (!isHexDigit(character)) {
+      this.#fail("syntax");
+      return text.length;
+    }
+    this.#unicodeDigits += character;
+    if (this.#unicodeDigits.length === 4) {
+      this.#tokenText.append(
+        String.fromCharCode(Number.parseInt(this.#unicodeDigits, 16)),
+      );
+      this.#unicodeDigits = "";
+      this.#lexerState = "string";
+    }
+    return index + 1;
+  }
+
+  #consumeNumber(text: string, index: number): number {
+    const character = text[index]!;
+    const next = nextNumberState(this.#numberState, character);
+    if (next !== undefined) {
+      this.#numberState = next;
+      this.#tokenText.append(character);
+      return index + 1;
+    }
+    this.#finishNumber();
+    return index;
+  }
+
+  #consumeLiteral(text: string, index: number): number {
+    const character = text[index]!;
+    if (character !== this.#literalExpected[this.#literalIndex]) {
+      this.#fail("syntax");
+      return text.length;
+    }
+    this.#literalIndex += 1;
+    if (this.#literalIndex === this.#literalExpected.length) {
+      const value = literalValue(this.#literalExpected);
+      this.#lexerState = "default";
+      this.#literalExpected = "";
+      this.#literalIndex = 0;
+      this.#emitScalar(value);
+    }
+    return index + 1;
+  }
+
+  #startNumber(character: string): void {
+    this.#tokenText.reset();
+    this.#tokenText.append(character);
+    this.#numberState = initialNumberState(character);
+    this.#lexerState = "number";
+  }
+
+  #finishNumber(): void {
+    const state = this.#numberState;
+    if (state === undefined || !isAcceptingNumberState(state)) {
+      this.#fail("syntax");
+      return;
+    }
+    const token = this.#tokenText.take();
+    const value = Number(token);
+    this.#numberState = undefined;
+    this.#lexerState = "default";
+    if (!Number.isFinite(value)) {
+      this.#fail("syntax");
+      return;
+    }
+    this.#emitScalar(value);
+  }
+
+  #startLiteral(character: "t" | "f" | "n"): void {
+    this.#literalExpected =
+      character === "t" ? "true" : character === "f" ? "false" : "null";
+    this.#literalIndex = 1;
+    this.#lexerState = "literal";
+  }
+
+  #emitString(value: string): void {
+    const frame = this.#topGrammarFrame();
+    if (
+      frame?.kind === "object" &&
+      (frame.state === "first_key_or_end" || frame.state === "key")
+    ) {
+      const result = this.#machine.key(value);
+      if (!result.ok) {
+        this.#failure = result;
+        return;
+      }
+      frame.state = "colon";
+      return;
+    }
+    this.#emitScalar(value);
+  }
+
+  #emitScalar(value: MailboxMetadataScalar): void {
+    if (!this.#expectsValue()) {
+      this.#fail("syntax");
+      return;
+    }
+    const result = this.#machine.scalar(value);
+    if (!result.ok) {
+      this.#failure = result;
+      return;
+    }
+    this.#completeValue();
+  }
+
+  #beginContainer(kind: "object" | "array"): void {
+    if (!this.#expectsValue()) {
+      this.#fail("syntax");
+      return;
+    }
+    const result =
+      kind === "object"
+        ? this.#machine.beginObject()
+        : this.#machine.beginArray();
+    if (!result.ok) {
+      this.#failure = result;
+      return;
+    }
+    this.#completeValue();
+    this.#grammar.push(
+      kind === "object"
+        ? { kind, state: "first_key_or_end" }
+        : { kind, state: "first_value_or_end" },
+    );
+  }
+
+  #endContainer(kind: "object" | "array"): void {
+    const frame = this.#topGrammarFrame();
+    const grammarAllowsEnd =
+      frame?.kind === kind &&
+      (frame.state === "comma_or_end" ||
+        (kind === "object" && frame.state === "first_key_or_end") ||
+        (kind === "array" && frame.state === "first_value_or_end"));
+    if (!grammarAllowsEnd) {
+      this.#fail("syntax");
+      return;
+    }
+    const result =
+      kind === "object" ? this.#machine.endObject() : this.#machine.endArray();
+    if (!result.ok) {
+      this.#failure = result;
+      return;
+    }
+    this.#grammar.pop();
+  }
+
+  #consumeColon(): void {
+    const frame = this.#topGrammarFrame();
+    if (frame?.kind !== "object" || frame.state !== "colon") {
+      this.#fail("syntax");
+      return;
+    }
+    frame.state = "value";
+  }
+
+  #consumeComma(): void {
+    const frame = this.#topGrammarFrame();
+    if (frame?.state !== "comma_or_end") {
+      this.#fail("syntax");
+      return;
+    }
+    frame.state = frame.kind === "object" ? "key" : "value";
+  }
+
+  #expectsValue(): boolean {
+    const frame = this.#topGrammarFrame();
+    if (frame === undefined) return this.#rootState === "value";
+    return frame.kind === "object"
+      ? frame.state === "value"
+      : frame.state === "first_value_or_end" || frame.state === "value";
+  }
+
+  #completeValue(): void {
+    const frame = this.#topGrammarFrame();
+    if (frame === undefined) {
+      this.#rootState = "end";
+      return;
+    }
+    frame.state = "comma_or_end";
+  }
+
+  #topGrammarFrame(): GrammarFrame | undefined {
+    return this.#grammar[this.#grammar.length - 1];
+  }
+
+  #fail(reason: MailboxMetadataRejectionReason): MailboxMetadataRejection {
+    this.#failure ??= rejection(reason);
+    return this.#failure;
+  }
+}
+
+class TextAccumulator {
+  readonly #blocks: string[] = [];
+  #pending: string[] = [];
+  #pendingCodeUnits = 0;
+
+  append(value: string): void {
+    if (value.length === 0) return;
+    this.#pending.push(value);
+    this.#pendingCodeUnits += value.length;
+    if (this.#pendingCodeUnits >= JSON_STRING_OUTPUT_BLOCK_CODE_UNITS) {
+      this.#flush();
+    }
+  }
+
+  take(): string {
+    this.#flush();
+    const value = this.#blocks.join("");
+    this.reset();
+    return value;
+  }
+
+  reset(): void {
+    this.#blocks.length = 0;
+    this.#pending = [];
+    this.#pendingCodeUnits = 0;
+  }
+
+  #flush(): void {
+    if (this.#pending.length === 0) return;
+    this.#blocks.push(this.#pending.join(""));
+    this.#pending = [];
+    this.#pendingCodeUnits = 0;
+  }
+}
+
+function createMutableFrame(kind: "object" | "array"): MutableFrame {
+  if (kind === "object") {
+    return {
+      entries: 0,
+      indexedKeys: [],
+      keys: new Set<string>(),
+      kind,
+      namedKeys: [],
+      value: Object.create(null) as Record<string, MailboxMetadataValue>,
+    };
+  }
+  const value: MailboxMetadataValue[] = [];
+  Object.setPrototypeOf(value, null);
+  return { entries: 0, kind, value };
+}
+
+function sortIndexedObjectKeys(keys: IndexedObjectKey[]): void {
+  if (keys.length < 2) return;
+  let source = keys;
+  let target = new Array<IndexedObjectKey>(keys.length);
+
+  for (let shift = 0; shift < UINT32_BITS; shift += ARRAY_INDEX_RADIX_BITS) {
+    const counts = new Uint32Array(ARRAY_INDEX_RADIX_SIZE);
+    for (const entry of source) {
+      counts[(entry.index >>> shift) & ARRAY_INDEX_RADIX_MASK] += 1;
+    }
+    let offset = 0;
+    for (let bucket = 0; bucket < counts.length; bucket += 1) {
+      const count = counts[bucket]!;
+      counts[bucket] = offset;
+      offset += count;
+    }
+    for (const entry of source) {
+      const bucket = (entry.index >>> shift) & ARRAY_INDEX_RADIX_MASK;
+      target[counts[bucket]!] = entry;
+      counts[bucket] += 1;
+    }
+    const previousSource = source;
+    source = target;
+    target = previousSource;
+  }
+
+  if (source !== keys) {
+    for (let index = 0; index < source.length; index += 1) {
+      keys[index] = source[index]!;
+    }
+  }
+}
+
+function ecmaArrayIndex(value: string): number | undefined {
+  if (value === "0") return 0;
+  if (value.length === 0 || !isNonZeroAsciiDigit(value[0]!)) {
+    return undefined;
+  }
+
+  let index = 0;
+  for (let position = 0; position < value.length; position += 1) {
+    const character = value[position]!;
+    if (!isAsciiDigit(character)) return undefined;
+    index = index * 10 + character.charCodeAt(0) - ASCII_ZERO_CODE_UNIT;
+    if (index > MAX_ECMA_ARRAY_INDEX) return undefined;
+  }
+  return index;
+}
+
+function rejection(
+  reason: MailboxMetadataRejectionReason,
+): MailboxMetadataRejection {
+  return Object.freeze({ ok: false, reason });
+}
+
+function acceptedMetadata(
+  metadata: ValidatedMailboxMetadata,
+): MailboxMetadataAccepted {
+  return Object.freeze({ metadata, ok: true });
+}
+
+function authenticatedRecord(
+  metadata: ValidatedMailboxMetadata,
+): AuthenticatedMetadataRecord {
+  if (!isObjectIdentity(metadata)) {
+    throw new TypeError("unbranded mailbox metadata");
+  }
+  const record = AUTHENTICATED_METADATA.get(metadata);
+  if (record === undefined) throw new TypeError("unbranded mailbox metadata");
+  return record;
+}
+
+function isObjectIdentity(value: unknown): value is object {
+  return (
+    (typeof value === "object" && value !== null) || typeof value === "function"
+  );
+}
+
+function isJsonScalar(value: unknown): value is MailboxMetadataScalar {
+  if (value === null) return true;
+  if (typeof value === "string" || typeof value === "boolean") return true;
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function canonicalNumber(value: number): string {
+  return Object.is(value, -0) ? "0" : String(value);
+}
+
+function jsonEscapeForCodeUnit(codeUnit: number): string | undefined {
+  switch (codeUnit) {
+    case 0x08:
+      return "\\b";
+    case 0x09:
+      return "\\t";
+    case 0x0a:
+      return "\\n";
+    case 0x0c:
+      return "\\f";
+    case 0x0d:
+      return "\\r";
+    case 0x22:
+      return '\\"';
+    case 0x5c:
+      return "\\\\";
+    default:
+      return codeUnit < 0x20 ? unicodeEscape(codeUnit) : undefined;
+  }
+}
+
+function decodedSimpleJsonEscape(character: string): string | undefined {
+  switch (character) {
+    case '"':
+    case "\\":
+    case "/":
+      return character;
+    case "b":
+      return "\b";
+    case "f":
+      return "\f";
+    case "n":
+      return "\n";
+    case "r":
+      return "\r";
+    case "t":
+      return "\t";
+    default:
+      return undefined;
+  }
+}
+
+function unicodeEscape(codeUnit: number): string {
+  return `\\u${
+    JSON_HEX_DIGITS[(codeUnit >>> 12) & 0x0f]
+  }${JSON_HEX_DIGITS[(codeUnit >>> 8) & 0x0f]}${
+    JSON_HEX_DIGITS[(codeUnit >>> 4) & 0x0f]
+  }${JSON_HEX_DIGITS[codeUnit & 0x0f]}`;
+}
+
+function utf8BytesForCodeUnit(codeUnit: number): number {
+  if (codeUnit <= 0x7f) return 1;
+  return codeUnit <= 0x7ff ? 2 : 3;
+}
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+function isJsonWhitespace(character: string): boolean {
+  return (
+    character === " " ||
+    character === "\t" ||
+    character === "\n" ||
+    character === "\r"
+  );
+}
+
+function isAsciiDigit(character: string): boolean {
+  return character >= "0" && character <= "9";
+}
+
+function isNonZeroAsciiDigit(character: string): boolean {
+  return character >= "1" && character <= "9";
+}
+
+function isHexDigit(character: string): boolean {
+  return (
+    (character >= "0" && character <= "9") ||
+    (character >= "a" && character <= "f") ||
+    (character >= "A" && character <= "F")
+  );
+}
+
+function initialNumberState(character: string): NumberLexerState {
+  if (character === "-") return "minus";
+  return character === "0" ? "zero" : "integer";
+}
+
+function nextNumberState(
+  state: NumberLexerState | undefined,
+  character: string,
+): NumberLexerState | undefined {
+  switch (state) {
+    case "minus":
+      if (character === "0") return "zero";
+      return isNonZeroAsciiDigit(character) ? "integer" : undefined;
+    case "zero":
+    case "integer":
+      if (state === "integer" && isAsciiDigit(character)) return "integer";
+      if (character === ".") return "fraction_start";
+      return character === "e" || character === "E"
+        ? "exponent_start"
+        : undefined;
+    case "fraction_start":
+      return isAsciiDigit(character) ? "fraction" : undefined;
+    case "fraction":
+      if (isAsciiDigit(character)) return "fraction";
+      return character === "e" || character === "E"
+        ? "exponent_start"
+        : undefined;
+    case "exponent_start":
+      if (character === "+" || character === "-") return "exponent_sign";
+      return isAsciiDigit(character) ? "exponent" : undefined;
+    case "exponent_sign":
+      return isAsciiDigit(character) ? "exponent" : undefined;
+    case "exponent":
+      return isAsciiDigit(character) ? "exponent" : undefined;
+    default:
+      return undefined;
+  }
+}
+
+function isAcceptingNumberState(state: NumberLexerState): boolean {
+  return (
+    state === "zero" ||
+    state === "integer" ||
+    state === "fraction" ||
+    state === "exponent"
+  );
+}
+
+function literalValue(literal: string): null | boolean {
+  if (literal === "true") return true;
+  if (literal === "false") return false;
+  return null;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) throw new MailboxMetadataAbortedError();
+}

--- a/runtime/tests/agents/mailbox-metadata.test.ts
+++ b/runtime/tests/agents/mailbox-metadata.test.ts
@@ -1,0 +1,961 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MAILBOX_METADATA_REJECTION_REASONS,
+  MAX_MAILBOX_METADATA_DEPTH,
+  MAX_MAILBOX_METADATA_NODES,
+  MAX_MAILBOX_METADATA_UTF8_BYTES,
+  MailboxMetadataAbortedError,
+  MailboxMetadataBuilder,
+  MailboxMetadataDecoder,
+  authenticateMailboxMetadata,
+  decodeMailboxMetadata,
+  getMailboxMetadataBytes,
+  getMailboxMetadataMetrics,
+  getMailboxMetadataValue,
+  isValidatedMailboxMetadata,
+  type MailboxMetadataAccepted,
+  type MailboxMetadataArray,
+  type MailboxMetadataObject,
+  type MailboxMetadataResult,
+  type MailboxMetadataValue,
+  type ValidatedMailboxMetadata,
+} from "../../src/agents/mailbox-metadata.js";
+import { createSeededRng, type SeededRng } from "../helpers/seeded-rng.js";
+
+const TEST_DIRECTORY = fileURLToPath(new URL(".", import.meta.url));
+const MAILBOX_FIXTURE_DIRECTORY = join(
+  TEST_DIRECTORY,
+  "..",
+  "fnd",
+  "fixtures",
+  "mailbox",
+);
+const MODULE_PATH = join(
+  TEST_DIRECTORY,
+  "..",
+  "..",
+  "src",
+  "agents",
+  "mailbox-metadata.ts",
+);
+const UTF8 = new TextEncoder();
+const UTF8_DECODER = new TextDecoder();
+const BYTE_BOUNDARY_CASES = Object.freeze([
+  {
+    key: "control",
+    label: "control escape expansion",
+    prefix: "\u0000\b\f\n\r\t",
+  },
+  { key: "cjk", label: "CJK UTF-8", prefix: "郵箱" },
+  { key: "emoji", label: "emoji surrogate pairs", prefix: "😀" },
+  {
+    key: `long_${"鍵".repeat(512)}`,
+    label: "long multibyte keys",
+    prefix: "value",
+  },
+] as const);
+
+function accepted(result: MailboxMetadataResult): MailboxMetadataAccepted {
+  expect(result).toMatchObject({ ok: true });
+  if (!result.ok)
+    throw new Error(`expected metadata, received ${result.reason}`);
+  return result;
+}
+
+function canonicalText(metadata: ValidatedMailboxMetadata): string {
+  return UTF8_DECODER.decode(getMailboxMetadataBytes(metadata));
+}
+
+function fixtureBytes(name: string): Uint8Array {
+  return readFileSync(join(MAILBOX_FIXTURE_DIRECTORY, name));
+}
+
+function buildWideObject(properties: number): MailboxMetadataResult {
+  const builder = new MailboxMetadataBuilder();
+  expect(builder.beginObject()).toEqual({ ok: true });
+  for (let index = 0; index < properties; index += 1) {
+    expect(builder.key(`key_${index}`)).toEqual({ ok: true });
+    const result = builder.scalar(index);
+    if (!result.ok) return result;
+  }
+  const ended = builder.endObject();
+  if (!ended.ok) return ended;
+  return builder.finish();
+}
+
+function buildWideArray(elements: number): MailboxMetadataResult {
+  const builder = new MailboxMetadataBuilder();
+  expect(builder.beginObject()).toEqual({ ok: true });
+  expect(builder.key("items")).toEqual({ ok: true });
+  expect(builder.beginArray()).toEqual({ ok: true });
+  for (let index = 0; index < elements; index += 1) {
+    const result = builder.scalar(index);
+    if (!result.ok) return result;
+  }
+  const arrayEnd = builder.endArray();
+  if (!arrayEnd.ok) return arrayEnd;
+  const objectEnd = builder.endObject();
+  if (!objectEnd.ok) return objectEnd;
+  return builder.finish();
+}
+
+function wideObjectJson(properties: number): Uint8Array {
+  const parts = ["{"];
+  for (let index = 0; index < properties; index += 1) {
+    if (index > 0) parts.push(",");
+    parts.push(`"key_${index}":${index}`);
+  }
+  parts.push("}");
+  return UTF8.encode(parts.join(""));
+}
+
+function wideArrayJson(elements: number): Uint8Array {
+  const parts = ['{"items":['];
+  for (let index = 0; index < elements; index += 1) {
+    if (index > 0) parts.push(",");
+    parts.push(String(index));
+  }
+  parts.push("]}");
+  return UTF8.encode(parts.join(""));
+}
+
+function boundaryObject(
+  key: string,
+  prefix: string,
+  targetBytes: number,
+): { readonly text: string; readonly value: string } {
+  const source = Object.create(null) as Record<string, string>;
+  source[key] = prefix;
+  const base = JSON.stringify(source);
+  const fillerBytes = targetBytes - UTF8.encode(base).byteLength;
+  if (fillerBytes < 0) throw new Error("boundary fixture exceeds its target");
+  const value = `${prefix}${"a".repeat(fillerBytes)}`;
+  source[key] = value;
+  const text = JSON.stringify(source);
+  if (UTF8.encode(text).byteLength !== targetBytes) {
+    throw new Error("boundary fixture byte accounting drifted");
+  }
+  return { text, value };
+}
+
+describe("mailbox metadata limits and authentication", () => {
+  it("freezes the compatibility limits and exact rejection vocabulary", () => {
+    expect(MAX_MAILBOX_METADATA_DEPTH).toBe(64);
+    expect(MAX_MAILBOX_METADATA_NODES).toBe(10_000);
+    expect(MAX_MAILBOX_METADATA_UTF8_BYTES).toBe(1_048_576);
+    expect(MAILBOX_METADATA_REJECTION_REASONS).toEqual([
+      "unbranded",
+      "syntax",
+      "utf8",
+      "duplicate_key",
+      "depth",
+      "nodes",
+      "bytes",
+      "non_json",
+    ]);
+  });
+
+  it("authenticates only private handles in O(1) without touching traps", () => {
+    const builder = new MailboxMetadataBuilder();
+    builder.beginObject();
+    builder.key("safe");
+    builder.scalar(true);
+    builder.endObject();
+    const metadata = accepted(builder.finish()).metadata;
+    expect(isValidatedMailboxMetadata(metadata)).toBe(true);
+    expect(authenticateMailboxMetadata(metadata)).toEqual({
+      ok: true,
+      metadata,
+    });
+
+    let traps = 0;
+    const hostile = new Proxy(Object.create(null) as object, {
+      get: () => {
+        traps += 1;
+        throw new Error("get trap must remain untouched");
+      },
+      getOwnPropertyDescriptor: () => {
+        traps += 1;
+        throw new Error("descriptor trap must remain untouched");
+      },
+      getPrototypeOf: () => {
+        traps += 1;
+        throw new Error("prototype trap must remain untouched");
+      },
+      ownKeys: () => {
+        traps += 1;
+        throw new Error("ten-million-key trap must remain untouched");
+      },
+    });
+    expect(isValidatedMailboxMetadata(hostile)).toBe(false);
+    expect(authenticateMailboxMetadata(hostile)).toEqual({
+      ok: false,
+      reason: "unbranded",
+    });
+    expect(traps).toBe(0);
+
+    const copied = Object.assign(Object.create(null) as object, metadata);
+    expect(isValidatedMailboxMetadata(copied)).toBe(false);
+    expect(
+      authenticateMailboxMetadata(
+        Object.freeze(Object.create(null)) as ValidatedMailboxMetadata,
+      ),
+    ).toEqual({ ok: false, reason: "unbranded" });
+  });
+
+  it("returns defensive bytes and a deeply frozen null-prototype graph", () => {
+    const result = accepted(
+      decodeMailboxMetadata(
+        UTF8.encode('{"nested":[{"value":1}],"label":"safe"}'),
+      ),
+    );
+    const root = getMailboxMetadataValue(result.metadata);
+    const nested = root.nested;
+    expect(Object.getPrototypeOf(root)).toBeNull();
+    expect(Object.isFrozen(root)).toBe(true);
+    expect(Array.isArray(nested)).toBe(true);
+    if (!Array.isArray(nested)) throw new Error("expected owned array");
+    const typedNested: MailboxMetadataArray = nested;
+    const mapIsExcluded: "map" extends keyof MailboxMetadataArray
+      ? false
+      : true = true;
+    const iteratorIsExcluded: typeof Symbol.iterator extends keyof MailboxMetadataArray
+      ? false
+      : true = true;
+    const valueUnionExcludesArrayMethods: Extract<
+      MailboxMetadataValue,
+      readonly unknown[]
+    > extends never
+      ? true
+      : false = true;
+    expect(typedNested.length).toBe(1);
+    expect(typedNested[0]).toBe(nested[0]);
+    expect(mapIsExcluded).toBe(true);
+    expect(iteratorIsExcluded).toBe(true);
+    expect(valueUnionExcludesArrayMethods).toBe(true);
+    expect("map" in typedNested).toBe(false);
+    expect(Symbol.iterator in typedNested).toBe(false);
+    expect(Object.getPrototypeOf(nested)).toBeNull();
+    expect(Object.isFrozen(nested)).toBe(true);
+    const child = nested[0];
+    expect(typeof child).toBe("object");
+    if (child === null || Array.isArray(child))
+      throw new Error("expected object");
+    expect(Object.getPrototypeOf(child)).toBeNull();
+    expect(Object.isFrozen(child)).toBe(true);
+
+    const first = getMailboxMetadataBytes(result.metadata);
+    first[0] = 0;
+    expect(canonicalText(result.metadata)).toBe(
+      '{"nested":[{"value":1}],"label":"safe"}',
+    );
+  });
+});
+
+describe("mailbox metadata structural boundaries", () => {
+  it("accepts depth 64, rejects depth 65, and stops a huge depth iteratively", () => {
+    const atLimit = accepted(
+      decodeMailboxMetadata(fixtureBytes("depth-64-v1.json")),
+    );
+    expect(getMailboxMetadataMetrics(atLimit.metadata).depth).toBe(
+      MAX_MAILBOX_METADATA_DEPTH,
+    );
+    expect(decodeMailboxMetadata(fixtureBytes("depth-65-v1.json"))).toEqual({
+      ok: false,
+      reason: "depth",
+    });
+
+    const hostileDepth = 8_000;
+    const hostile = `${'{"next":'.repeat(hostileDepth)}null${"}".repeat(
+      hostileDepth,
+    )}`;
+    expect(() => decodeMailboxMetadata(UTF8.encode(hostile))).not.toThrow();
+    expect(decodeMailboxMetadata(UTF8.encode(hostile))).toEqual({
+      ok: false,
+      reason: "depth",
+    });
+  });
+
+  it("rejects the overflowing builder container before depth 65 is accepted", () => {
+    const builder = new MailboxMetadataBuilder();
+    expect(builder.beginObject()).toEqual({ ok: true });
+    for (let depth = 2; depth <= MAX_MAILBOX_METADATA_DEPTH; depth += 1) {
+      expect(builder.key("next")).toEqual({ ok: true });
+      expect(builder.beginObject()).toEqual({ ok: true });
+    }
+    expect(builder.key("overflow")).toEqual({ ok: true });
+    const overflow = builder.beginObject();
+    expect(overflow).toEqual({ ok: false, reason: "depth" });
+    expect(builder.endObject()).toBe(overflow);
+    expect(builder.finish()).toBe(overflow);
+  });
+
+  it("accepts node 10,000 and rejects 10,001 for wide objects and arrays", () => {
+    const objectAtLimit = accepted(
+      buildWideObject(MAX_MAILBOX_METADATA_NODES - 1),
+    );
+    expect(getMailboxMetadataMetrics(objectAtLimit.metadata).nodes).toBe(
+      MAX_MAILBOX_METADATA_NODES,
+    );
+    expect(buildWideObject(MAX_MAILBOX_METADATA_NODES)).toEqual({
+      ok: false,
+      reason: "nodes",
+    });
+
+    const arrayAtLimit = accepted(
+      buildWideArray(MAX_MAILBOX_METADATA_NODES - 2),
+    );
+    expect(getMailboxMetadataMetrics(arrayAtLimit.metadata).nodes).toBe(
+      MAX_MAILBOX_METADATA_NODES,
+    );
+    expect(buildWideArray(MAX_MAILBOX_METADATA_NODES - 1)).toEqual({
+      ok: false,
+      reason: "nodes",
+    });
+
+    const decodedObject = accepted(
+      decodeMailboxMetadata(wideObjectJson(MAX_MAILBOX_METADATA_NODES - 1)),
+    );
+    expect(getMailboxMetadataMetrics(decodedObject.metadata).nodes).toBe(
+      MAX_MAILBOX_METADATA_NODES,
+    );
+    expect(
+      decodeMailboxMetadata(wideObjectJson(MAX_MAILBOX_METADATA_NODES)),
+    ).toEqual({ ok: false, reason: "nodes" });
+
+    const decodedArray = accepted(
+      decodeMailboxMetadata(wideArrayJson(MAX_MAILBOX_METADATA_NODES - 2)),
+    );
+    expect(getMailboxMetadataMetrics(decodedArray.metadata).nodes).toBe(
+      MAX_MAILBOX_METADATA_NODES,
+    );
+    expect(
+      decodeMailboxMetadata(wideArrayJson(MAX_MAILBOX_METADATA_NODES - 1)),
+    ).toEqual({ ok: false, reason: "nodes" });
+  });
+
+  it("accepts the exact canonical byte limit and rejects limit plus one", () => {
+    const envelopeBytes = UTF8.encode('{"x":""}').byteLength;
+    const builder = new MailboxMetadataBuilder();
+    builder.beginObject();
+    builder.key("x");
+    builder.scalar("a".repeat(MAX_MAILBOX_METADATA_UTF8_BYTES - envelopeBytes));
+    expect(builder.endObject()).toEqual({ ok: true });
+    const atLimit = accepted(builder.finish());
+    expect(getMailboxMetadataMetrics(atLimit.metadata).utf8Bytes).toBe(
+      MAX_MAILBOX_METADATA_UTF8_BYTES,
+    );
+
+    const overflow = new MailboxMetadataBuilder();
+    overflow.beginObject();
+    overflow.key("x");
+    overflow.scalar(
+      "a".repeat(MAX_MAILBOX_METADATA_UTF8_BYTES - envelopeBytes + 1),
+    );
+    expect(overflow.endObject()).toEqual({ ok: false, reason: "bytes" });
+    expect(overflow.finish()).toEqual({ ok: false, reason: "bytes" });
+  });
+
+  it.each(BYTE_BOUNDARY_CASES)(
+    "counts $label at the exact byte ceiling and ceiling plus one",
+    ({ key, prefix }) => {
+      const atLimit = boundaryObject(
+        key,
+        prefix,
+        MAX_MAILBOX_METADATA_UTF8_BYTES,
+      );
+      const decoded = accepted(
+        decodeMailboxMetadata(UTF8.encode(atLimit.text)),
+      );
+      expect(getMailboxMetadataMetrics(decoded.metadata).utf8Bytes).toBe(
+        MAX_MAILBOX_METADATA_UTF8_BYTES,
+      );
+
+      const builder = new MailboxMetadataBuilder();
+      expect(builder.beginObject()).toEqual({ ok: true });
+      expect(builder.key(key)).toEqual({ ok: true });
+      expect(builder.scalar(atLimit.value)).toEqual({ ok: true });
+      expect(builder.endObject()).toEqual({ ok: true });
+      const built = accepted(builder.finish());
+      expect(getMailboxMetadataMetrics(built.metadata).utf8Bytes).toBe(
+        MAX_MAILBOX_METADATA_UTF8_BYTES,
+      );
+      expect(canonicalText(built.metadata)).toBe(atLimit.text);
+
+      const overLimit = boundaryObject(
+        key,
+        prefix,
+        MAX_MAILBOX_METADATA_UTF8_BYTES + 1,
+      );
+      expect(decodeMailboxMetadata(UTF8.encode(overLimit.text))).toEqual({
+        ok: false,
+        reason: "bytes",
+      });
+      const overflowingBuilder = new MailboxMetadataBuilder();
+      expect(overflowingBuilder.beginObject()).toEqual({ ok: true });
+      expect(overflowingBuilder.key(key)).toEqual({ ok: true });
+      expect(overflowingBuilder.scalar(overLimit.value)).toEqual({ ok: true });
+      expect(overflowingBuilder.endObject()).toEqual({
+        ok: false,
+        reason: "bytes",
+      });
+    },
+  );
+
+  it("enforces the raw byte ceiling before parsing an overflowing chunk", () => {
+    const body = UTF8.encode('{"x":null}');
+    const atLimit = new Uint8Array(MAX_MAILBOX_METADATA_UTF8_BYTES);
+    atLimit.fill(0x20);
+    atLimit.set(body, atLimit.byteLength - body.byteLength);
+    expect(decodeMailboxMetadata(atLimit)).toMatchObject({ ok: true });
+
+    const overLimit = new Uint8Array(MAX_MAILBOX_METADATA_UTF8_BYTES + 1);
+    overLimit.fill(0x20);
+    overLimit.set(body, overLimit.byteLength - body.byteLength);
+    const decoder = new MailboxMetadataDecoder();
+    expect(decoder.write(overLimit)).toEqual({ ok: false, reason: "bytes" });
+    expect(decoder.finish()).toEqual({ ok: false, reason: "bytes" });
+  });
+
+  it("accounts for controls, long keys, CJK, emoji, and canonical number text", () => {
+    const source = Object.create(null) as Record<string, unknown>;
+    const longKey = `long_${"鍵".repeat(128)}`;
+    source[longKey] = "\u0000\b\f\n\r\t";
+    source.emoji = "😀";
+    source.cjk = "郵箱";
+    source.negativeZero = -0;
+    const reference = JSON.stringify(source);
+
+    const decoded = accepted(decodeMailboxMetadata(UTF8.encode(reference)));
+    expect(canonicalText(decoded.metadata)).toBe(reference);
+    expect(getMailboxMetadataMetrics(decoded.metadata).utf8Bytes).toBe(
+      UTF8.encode(reference).byteLength,
+    );
+  });
+
+  it("matches ECMA own-key order for index boundaries at every depth", () => {
+    const nestedEntries = [
+      ["4294967295", "nested max"],
+      ["2", "nested two"],
+      ["1", "nested one"],
+      ["01", "nested leading"],
+      ["4294967294", "nested last index"],
+      ["-0", "nested negative zero"],
+      ["00", "nested double zero"],
+      ["1e0", "nested exponent"],
+      ["0", "nested zero"],
+    ] as const;
+    const topEntries = [
+      ["2", "two"],
+      ["1", "one"],
+      ["01", "leading"],
+      ["4294967294", "last index"],
+      ["4294967295", "max is named"],
+      ["00", "double zero"],
+      ["-0", "negative zero"],
+      ["1e0", "exponent"],
+      ["0", "zero"],
+    ] as const;
+    const input = `{"2":"two","1":"one","01":"leading","4294967294":"last index","4294967295":"max is named","00":"double zero","-0":"negative zero","1e0":"exponent","0":"zero","nested":{"4294967295":"nested max","2":"nested two","1":"nested one","01":"nested leading","4294967294":"nested last index","-0":"nested negative zero","00":"nested double zero","1e0":"nested exponent","0":"nested zero"}}`;
+    const expected = JSON.stringify(JSON.parse(input));
+    const decoded = accepted(decodeMailboxMetadata(UTF8.encode(input)));
+
+    const builder = new MailboxMetadataBuilder();
+    expect(builder.beginObject()).toEqual({ ok: true });
+    for (const [key, value] of topEntries) {
+      expect(builder.key(key)).toEqual({ ok: true });
+      expect(builder.scalar(value)).toEqual({ ok: true });
+    }
+    expect(builder.key("nested")).toEqual({ ok: true });
+    expect(builder.beginObject()).toEqual({ ok: true });
+    for (const [key, value] of nestedEntries) {
+      expect(builder.key(key)).toEqual({ ok: true });
+      expect(builder.scalar(value)).toEqual({ ok: true });
+    }
+    expect(builder.endObject()).toEqual({ ok: true });
+    expect(builder.endObject()).toEqual({ ok: true });
+    const built = accepted(builder.finish());
+
+    expect(canonicalText(decoded.metadata)).toBe(expected);
+    expect(canonicalText(built.metadata)).toBe(expected);
+    expect(JSON.stringify(getMailboxMetadataValue(decoded.metadata))).toBe(
+      expected,
+    );
+    expect(JSON.stringify(getMailboxMetadataValue(built.metadata))).toBe(
+      expected,
+    );
+  });
+
+  it("canonicalizes lone surrogates safely", () => {
+    const builder = new MailboxMetadataBuilder();
+    builder.beginObject();
+    builder.key("high");
+    builder.scalar("\ud800");
+    builder.key("low");
+    builder.scalar("\udc00");
+    builder.key("pair");
+    builder.scalar("😀");
+    builder.endObject();
+    const built = accepted(builder.finish());
+    expect(canonicalText(built.metadata)).toBe(
+      JSON.stringify({ high: "\ud800", low: "\udc00", pair: "😀" }),
+    );
+  });
+});
+
+describe("mailbox metadata decoder rejection and safety", () => {
+  it("rejects duplicate keys before construction and preserves inert special keys", () => {
+    expect(
+      decodeMailboxMetadata(fixtureBytes("duplicate-key-v1.json")),
+    ).toEqual({
+      ok: false,
+      reason: "duplicate_key",
+    });
+    expect(
+      decodeMailboxMetadata(UTF8.encode('{"nested":{"same":1,"same":2}}')),
+    ).toEqual({ ok: false, reason: "duplicate_key" });
+
+    delete (Object.prototype as { polluted?: boolean }).polluted;
+    const inert = accepted(
+      decodeMailboxMetadata(fixtureBytes("inert-keys-v1.json")),
+    );
+    const value = getMailboxMetadataValue(inert.metadata);
+    expect(Object.getPrototypeOf(value)).toBeNull();
+    expect(value.constructor).toBe("inert constructor metadata");
+    expect(value.prototype).toBe("inert prototype metadata");
+    expect(value.__proto__).toEqual(
+      expect.objectContaining({ polluted: true }),
+    );
+    expect(
+      (Object.prototype as { polluted?: boolean }).polluted,
+    ).toBeUndefined();
+    for (const key of ["__proto__", "constructor", "prototype"]) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      expect(descriptor).toMatchObject({
+        configurable: false,
+        enumerable: true,
+        writable: false,
+      });
+      expect(descriptor?.get).toBeUndefined();
+      expect(descriptor?.set).toBeUndefined();
+    }
+  });
+
+  it.each([
+    ['{"x":1} trailing', "syntax"],
+    ['{"x":01}', "syntax"],
+    ['{"x":1.}', "syntax"],
+    ['{"x":1e}', "syntax"],
+    ['{"x":1e999}', "syntax"],
+    ['{"x":NaN}', "syntax"],
+    ['{"x":Infinity}', "syntax"],
+    ['{"x":+1}', "syntax"],
+    ['{"x":"raw\u0000control"}', "syntax"],
+    ['{"x":}', "syntax"],
+    ['{"x":1,}', "syntax"],
+    ["[1,2,3]", "non_json"],
+  ] as const)("rejects invalid JSON %j as %s", (text, reason) => {
+    expect(decodeMailboxMetadata(UTF8.encode(text))).toEqual({
+      ok: false,
+      reason,
+    });
+  });
+
+  it("rejects invalid and incomplete UTF-8 independently of JSON syntax", () => {
+    expect(
+      decodeMailboxMetadata(Uint8Array.of(0x7b, 0xc3, 0x28, 0x7d)),
+    ).toEqual({
+      ok: false,
+      reason: "utf8",
+    });
+    const decoder = new MailboxMetadataDecoder();
+    expect(decoder.write(Uint8Array.of(0x7b, 0xc3))).toEqual({ ok: true });
+    expect(decoder.finish()).toEqual({ ok: false, reason: "utf8" });
+  });
+
+  it("decodes byte-split multibyte characters and escape tokens incrementally", () => {
+    const expected = '{"emoji":"😀","nul":"\\u0000","n":1.25e+3}';
+    const bytes = UTF8.encode(expected);
+    const decoder = new MailboxMetadataDecoder();
+    for (const byte of bytes) {
+      expect(decoder.write(Uint8Array.of(byte))).toEqual({ ok: true });
+    }
+    const result = accepted(decoder.finish());
+    expect(canonicalText(result.metadata)).toBe(
+      '{"emoji":"😀","nul":"\\u0000","n":1250}',
+    );
+    expect(getMailboxMetadataValue(result.metadata).nul).toBe("\u0000");
+  });
+
+  it("aborts deterministically between chunks without changing reason vocabulary", () => {
+    const controller = new AbortController();
+    const decoder = new MailboxMetadataDecoder({ signal: controller.signal });
+    expect(decoder.write(UTF8.encode('{"value":'))).toEqual({ ok: true });
+    controller.abort(new Error("untrusted abort reason"));
+    for (const operation of [
+      () => decoder.write(UTF8.encode("1}")),
+      () => decoder.finish(),
+    ]) {
+      expect(operation).toThrowError(MailboxMetadataAbortedError);
+      try {
+        operation();
+      } catch (error) {
+        expect(error).toMatchObject({
+          code: "MAILBOX_METADATA_ABORTED",
+          message: "mailbox metadata construction was aborted",
+          name: "MailboxMetadataAbortedError",
+        });
+      }
+    }
+    expect(MAILBOX_METADATA_REJECTION_REASONS).not.toContain("aborted");
+  });
+});
+
+describe("mailbox metadata operation builder", () => {
+  it("rejects non-JSON and prebuilt values without enumeration or user code", () => {
+    class CustomValue {}
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const shared = { value: 1 };
+    let getterCalls = 0;
+    const getterValue = Object.create(null) as object;
+    Object.defineProperty(getterValue, "danger", {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1;
+        throw new Error("getter must remain untouched");
+      },
+    });
+    const sparse: unknown[] = [];
+    sparse.length = 1_000_001;
+    sparse[0] = "first";
+    sparse[1_000_000] = "last";
+    const arrayWithAccessor: unknown[] = [];
+    Object.defineProperty(arrayWithAccessor, "extra", {
+      get: () => {
+        getterCalls += 1;
+        throw new Error("array getter must remain untouched");
+      },
+    });
+    let proxyTraps = 0;
+    const proxy = new Proxy(Object.create(null) as object, {
+      getPrototypeOf: () => {
+        proxyTraps += 1;
+        throw new Error("proxy trap must remain untouched");
+      },
+      ownKeys: () => {
+        proxyTraps += 1;
+        throw new Error("proxy trap must remain untouched");
+      },
+    });
+
+    const invalidValues: readonly unknown[] = [
+      undefined,
+      1n,
+      Symbol("value"),
+      () => undefined,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      new CustomValue(),
+      new Date(),
+      new Map(),
+      new Set(),
+      new Uint8Array(1),
+      cyclic,
+      shared,
+      shared,
+      getterValue,
+      sparse,
+      arrayWithAccessor,
+      proxy,
+      {},
+      [],
+    ];
+    for (const value of invalidValues) {
+      const builder = new MailboxMetadataBuilder();
+      builder.beginObject();
+      builder.key("value");
+      const failure = builder.scalar(value);
+      expect(failure).toEqual({ ok: false, reason: "non_json" });
+      expect(builder.finish()).toBe(failure);
+    }
+    const symbolKey = new MailboxMetadataBuilder();
+    symbolKey.beginObject();
+    expect(symbolKey.key(Symbol("key"))).toEqual({
+      ok: false,
+      reason: "non_json",
+    });
+    expect(getterCalls).toBe(0);
+    expect(proxyTraps).toBe(0);
+  });
+
+  it("rejects malformed operation ordering and duplicate builder keys", () => {
+    const missingRoot = new MailboxMetadataBuilder();
+    expect(missingRoot.scalar("value")).toEqual({
+      ok: false,
+      reason: "non_json",
+    });
+
+    const duplicate = new MailboxMetadataBuilder();
+    duplicate.beginObject();
+    duplicate.key("same");
+    duplicate.scalar(1);
+    expect(duplicate.key("same")).toEqual({
+      ok: false,
+      reason: "duplicate_key",
+    });
+
+    const missingValue = new MailboxMetadataBuilder();
+    missingValue.beginObject();
+    missingValue.key("value");
+    expect(missingValue.endObject()).toEqual({
+      ok: false,
+      reason: "non_json",
+    });
+  });
+
+  it("does not call poisoned Object or Array toJSON hooks", () => {
+    const priorObjectToJson = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "toJSON",
+    );
+    const priorArrayToJson = Object.getOwnPropertyDescriptor(
+      Array.prototype,
+      "toJSON",
+    );
+    let built: MailboxMetadataResult | undefined;
+    let decoded: MailboxMetadataResult | undefined;
+    try {
+      Object.defineProperty(Object.prototype, "toJSON", {
+        configurable: true,
+        value: () => {
+          throw new Error("Object.prototype.toJSON must not run");
+        },
+      });
+      Object.defineProperty(Array.prototype, "toJSON", {
+        configurable: true,
+        value: () => {
+          throw new Error("Array.prototype.toJSON must not run");
+        },
+      });
+
+      const builder = new MailboxMetadataBuilder();
+      builder.beginObject();
+      builder.key("items");
+      builder.beginArray();
+      builder.beginObject();
+      builder.key("safe");
+      builder.scalar(true);
+      builder.endObject();
+      builder.endArray();
+      builder.endObject();
+      built = builder.finish();
+      decoded = decodeMailboxMetadata(UTF8.encode('{"items":[{"safe":true}]}'));
+    } finally {
+      restoreProperty(Object.prototype, "toJSON", priorObjectToJson);
+      restoreProperty(Array.prototype, "toJSON", priorArrayToJson);
+    }
+
+    const builtMetadata = accepted(built!);
+    const decodedMetadata = accepted(decoded!);
+    expect(canonicalText(builtMetadata.metadata)).toBe(
+      '{"items":[{"safe":true}]}',
+    );
+    expect(canonicalText(decodedMetadata.metadata)).toBe(
+      '{"items":[{"safe":true}]}',
+    );
+    expect(Object.getOwnPropertyDescriptor(Object.prototype, "toJSON")).toEqual(
+      priorObjectToJson,
+    );
+    expect(Object.getOwnPropertyDescriptor(Array.prototype, "toJSON")).toEqual(
+      priorArrayToJson,
+    );
+  });
+
+  it("contains no recursive/stringify/reflection shortcut in production", () => {
+    const source = readFileSync(MODULE_PATH, "utf8");
+    expect(source).not.toMatch(
+      /\b(?:JSON\.stringify|Reflect\.ownKeys|Object\.keys)\s*\(/u,
+    );
+    expect(source).toMatch(
+      /type MailboxMetadataValue\s*=\s*MailboxMetadataScalar\s*\|\s*MailboxMetadataObject\s*\|\s*MailboxMetadataArray/u,
+    );
+    expect(source).not.toMatch(
+      /type MailboxMetadataValue\s*=[\s\S]{0,160}readonly MailboxMetadataValue\[\]/u,
+    );
+  });
+});
+
+describe("mailbox metadata differential construction", () => {
+  it("matches the ECMA serializer for seeded accepted JSON and builder streams", () => {
+    const rng = createSeededRng({
+      domain: "mailbox-metadata-differential-v1",
+      seed: "fixed-e3a-seed",
+    });
+    const cases = 256;
+    for (let caseIndex = 0; caseIndex < cases; caseIndex += 1) {
+      const reference = randomMetadataObject(rng, 0);
+      const expected = JSON.stringify(reference);
+      const decoded = accepted(decodeMailboxMetadata(UTF8.encode(expected)));
+
+      const builder = new MailboxMetadataBuilder();
+      emitBuilderObject(builder, reference);
+      const built = accepted(builder.finish());
+      expect(canonicalText(decoded.metadata), `decoder case ${caseIndex}`).toBe(
+        expected,
+      );
+      expect(canonicalText(built.metadata), `builder case ${caseIndex}`).toBe(
+        expected,
+      );
+      expect(
+        normalizeOwnedValue(getMailboxMetadataValue(decoded.metadata)),
+        `value case ${caseIndex}`,
+      ).toEqual(
+        normalizeOwnedValue(JSON.parse(expected) as MailboxMetadataObject),
+      );
+    }
+  });
+
+  it("rejects seeded duplicate/trailing mutations deterministically", () => {
+    const rng = createSeededRng({
+      domain: "mailbox-metadata-invalid-differential-v1",
+      seed: "fixed-e3a-invalid-seed",
+    });
+    for (let caseIndex = 0; caseIndex < 128; caseIndex += 1) {
+      const key = `key_${rng.nextInt(1_000_000)}`;
+      const value = rng.nextInt(1_000_000);
+      const duplicate = `{"${key}":${value},"${key}":${value + 1}}`;
+      expect(decodeMailboxMetadata(UTF8.encode(duplicate))).toEqual({
+        ok: false,
+        reason: "duplicate_key",
+      });
+      expect(
+        decodeMailboxMetadata(UTF8.encode(`{"${key}":${value}} trailing`)),
+      ).toEqual({ ok: false, reason: "syntax" });
+    }
+  });
+});
+
+function restoreProperty(
+  target: object,
+  key: PropertyKey,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor === undefined) {
+    Reflect.deleteProperty(target, key);
+  } else {
+    Object.defineProperty(target, key, descriptor);
+  }
+}
+
+function randomMetadataObject(
+  rng: SeededRng,
+  depth: number,
+): Record<string, unknown> {
+  const object = Object.create(null) as Record<string, unknown>;
+  const entries = rng.nextInt(4);
+  for (let index = 0; index < entries; index += 1) {
+    const key = `key_${depth}_${index}_${rng.nextInt(10_000)}`;
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      value: randomMetadataValue(rng, depth + 1),
+      writable: true,
+    });
+  }
+  if (depth === 0 && rng.nextInt(4) === 0) {
+    Object.defineProperty(object, "__proto__", {
+      configurable: true,
+      enumerable: true,
+      value: "inert",
+      writable: true,
+    });
+  }
+  return object;
+}
+
+function randomMetadataValue(rng: SeededRng, depth: number): unknown {
+  const kind = depth >= 4 ? rng.nextInt(5) : rng.nextInt(7);
+  switch (kind) {
+    case 0:
+      return null;
+    case 1:
+      return rng.nextInt(2) === 0;
+    case 2:
+      return rng.nextInt(2) === 0 ? -0 : rng.nextInt(1_000_000) / 10;
+    case 3:
+      return ["plain", 'quote"', "slash\\", "nul\u0000", "emoji😀"][
+        rng.nextInt(5)
+      ];
+    case 4:
+      return `text_${rng.nextInt(1_000_000)}`;
+    case 5: {
+      const length = rng.nextInt(4);
+      const array: unknown[] = [];
+      for (let index = 0; index < length; index += 1) {
+        array.push(randomMetadataValue(rng, depth + 1));
+      }
+      return array;
+    }
+    default:
+      return randomMetadataObject(rng, depth);
+  }
+}
+
+function emitBuilderObject(
+  builder: MailboxMetadataBuilder,
+  value: Record<string, unknown>,
+): void {
+  expect(builder.beginObject()).toEqual({ ok: true });
+  for (const [key, entry] of Object.entries(value)) {
+    expect(builder.key(key)).toEqual({ ok: true });
+    emitBuilderValue(builder, entry);
+  }
+  expect(builder.endObject()).toEqual({ ok: true });
+}
+
+function emitBuilderValue(
+  builder: MailboxMetadataBuilder,
+  value: unknown,
+): void {
+  if (Array.isArray(value)) {
+    expect(builder.beginArray()).toEqual({ ok: true });
+    for (const entry of value) emitBuilderValue(builder, entry);
+    expect(builder.endArray()).toEqual({ ok: true });
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    emitBuilderObject(builder, value as Record<string, unknown>);
+    return;
+  }
+  expect(builder.scalar(value)).toEqual({ ok: true });
+}
+
+function normalizeOwnedValue(value: MailboxMetadataValue): unknown {
+  if (Array.isArray(value)) {
+    const normalized: unknown[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      normalized.push(normalizeOwnedValue(value[index]!));
+    }
+    return normalized;
+  }
+  if (value !== null && typeof value === "object") {
+    const normalized = Object.create(null) as Record<string, unknown>;
+    for (const [key, entry] of Object.entries(value)) {
+      Object.defineProperty(normalized, key, {
+        configurable: true,
+        enumerable: true,
+        value: normalizeOwnedValue(entry),
+        writable: true,
+      });
+    }
+    return normalized;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
- add an iterative, abort-aware mailbox-metadata decoder and builder with explicit raw-byte, canonical-byte, depth, and node limits
- expose branded, deeply frozen null-prototype metadata values with truthful array typing and canonical ECMA own-key ordering
- add deterministic hostile-input, differential, exact-boundary, serializer, and brand-admission tests
- add contract documentation and a scaling benchmark that gates linear parsing and O(1) branded admission

## Validation
- focused mailbox metadata suite: 37/37
- canonical npm test: runtime 1,970 files / 18,313 tests; required 130/130; agent-surface 180/180; launcher green
- typecheck and test-support typecheck
- FND baseline and red probes: 7/7
- mailbox metadata scaling benchmark --check
- explicit agent-surface contract including TUI scenarios
- validate:runtime: build/package/generated SDK checks and PTY 4/4
- independent exact-SHA review: approved b9eaf437183f05482095eefef598ca2072a26cfe / tree 8cbcaf9699b7aa1c5d6b608e4e4ac4694fa31e26

This is E3a foundation scope only; mailbox caller/protocol cutover remains E3b. No release or publication is included.