### PR TITLE
feat(runtime): implement set-based cancellation

### DIFF
--- a/docs/design/execution-admission-kernel.md
+++ b/docs/design/execution-admission-kernel.md
@@ -57,11 +57,11 @@ durable reservation.
 Coverage is enforced at execution boundaries rather than duplicated in each
 caller:
 
-| Boundary | Covered runtime paths | Dispatch evidence |
-| --- | --- | --- |
-| Model | Main streamed turns, startup-prewarm attempts and fallback, compaction, tool-use summaries, permission classification, MCP sampling, and model-facing WebSearch/XSearch/WebFetch work | `provider_wire` |
-| Tool | Direct and turn-routed tool execution, after permission approval and immediately before `tool.execute` | `tool_effect` |
-| Spawn | `AgentControl`, delegate sessions, and legacy agent-hook spawns; child sessions inherit the root allocation and deadline. The dormant pane/team backend is fail-closed because it cannot propagate a parent allocation across processes. | `spawn_commit` |
+| Boundary | Covered runtime paths                                                                                                                                                                                                                    | Dispatch evidence |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| Model    | Main streamed turns, startup-prewarm attempts and fallback, compaction, tool-use summaries, permission classification, MCP sampling, and model-facing WebSearch/XSearch/WebFetch work                                                    | `provider_wire`   |
+| Tool     | Direct and turn-routed tool execution, after permission approval and immediately before `tool.execute`                                                                                                                                   | `tool_effect`     |
+| Spawn    | `AgentControl`, delegate sessions, and legacy agent-hook spawns; child sessions inherit the root allocation and deadline. The dormant pane/team backend is fail-closed because it cannot propagate a parent allocation across processes. | `spawn_commit`    |
 
 TUI, print, socket/SDK, and daemon background-agent entry points share the
 normal runtime bootstrap, which binds a client and sets `admissionRequired`.
@@ -79,15 +79,15 @@ disabled before release.
 
 Common fail-closed reasons include:
 
-| Condition | Result |
-| --- | --- |
-| Required client/kernel is absent or closed | deny (`admission_kernel_unavailable` / `admission_kernel_closed`) |
-| Model output has no finite positive maximum | deny (`unbounded_model_output`) |
-| Hard USD cap with an unpriced model or a provider lacking authoritative usage and output limits | deny before dispatch |
-| Budget exhausted, allocation blocked, parent cancelled, or deadline expired | deny/cancel with a journal reason |
-| Policy requests approval | persist `approval_required`; the current client does not auto-approve or bypass it |
-| Usage is missing or invalid after dispatch | consume the full reservation as `held_unknown` |
-| Provider exceeds the reservation | persist `provider_overrun`, block the allocation, and cancel the run subtree |
+| Condition                                                                                       | Result                                                                             |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Required client/kernel is absent or closed                                                      | deny (`admission_kernel_unavailable` / `admission_kernel_closed`)                  |
+| Model output has no finite positive maximum                                                     | deny (`unbounded_model_output`)                                                    |
+| Hard USD cap with an unpriced model or a provider lacking authoritative usage and output limits | deny before dispatch                                                               |
+| Budget exhausted, allocation blocked, parent cancelled, or deadline expired                     | deny/cancel with a journal reason                                                  |
+| Policy requests approval                                                                        | persist `approval_required`; the current client does not auto-approve or bypass it |
+| Usage is missing or invalid after dispatch                                                      | consume the full reservation as `held_unknown`                                     |
+| Provider exceeds the reservation                                                                | persist `provider_overrun`, block the allocation, and cancel the run subtree       |
 
 Provider-side automatic fallback is not used to make a cap appear satisfied.
 Every deliberate model/provider fallback is a visible `fallback` journal
@@ -105,13 +105,13 @@ $AGENC_HOME/projects/<project-slug>/agenc-state_1.sqlite
 Schema v14 adds nullable admission columns to the existing `agent_jobs` queue
 and the following tables:
 
-| Table | Purpose |
-| --- | --- |
-| `execution_admission_allocations` | Token/USD limits, used amounts, active holds, parent links, overrun block |
-| `execution_admission_reservations` | Unique reservation and exactly-once settlement state |
-| `execution_admission_reservation_allocations` | The allocation closure charged by each reservation |
-| `execution_admission_cancellations` | Durable run cancellation locks |
-| `execution_admission_journal` | Append-only, ordered decision and dispatch evidence |
+| Table                                         | Purpose                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------- |
+| `execution_admission_allocations`             | Token/USD limits, used amounts, active holds, parent links, overrun block |
+| `execution_admission_reservations`            | Unique reservation and exactly-once settlement state                      |
+| `execution_admission_reservation_allocations` | The allocation closure charged by each reservation                        |
+| `execution_admission_cancellations`           | Durable run cancellation locks                                            |
+| `execution_admission_journal`                 | Append-only, ordered decision and dispatch evidence                       |
 
 The normal event path is:
 
@@ -205,13 +205,13 @@ data migration is available.
 
 The defaults are:
 
-| Scope | Default active steps |
-| --- | ---: |
-| Global daemon | 64 |
-| Workspace | 32 |
-| Session | 8 |
-| Immediate parent | 4 |
-| Provider | 16 |
+| Scope            | Default active steps |
+| ---------------- | -------------------: |
+| Global daemon    |                   64 |
+| Workspace        |                   32 |
+| Session          |                    8 |
+| Immediate parent |                    4 |
+| Provider         |                   16 |
 
 An admitted step must have capacity in every applicable scope. Active capacity
 is owned by the one daemon process; durable eligibility and order are owned by
@@ -263,18 +263,69 @@ durable spawn edges and admission parent edges. It then:
 Abort signals and deadlines use the same durable cancellation path. A provider
 overrun additionally marks the allocation blocked and terminates descendants.
 
+### Bounded set-based cancellation
+
+Cancellation materializes reachable identities with an identity-only recursive
+CTE using `UNION`, never a JavaScript queue or one query per descendant. The
+connection-local TEMP set is keyed by a random operation ID and graph kind. It
+is deleted after the outermost transaction commits or rolls back, so nested run
+and admission cancellation can reuse one set without leaking it into a later
+operation.
+
+The two graph contracts are intentionally different:
+
+- the public run-cancellation report follows `thread_spawn_edges` only;
+- admission settlement follows the union of spawn edges and
+  `agent_jobs(admission_parent_run_id, admission_run_id)`.
+
+Both materializations insert a plus-one sentinel before mutation. A set above
+100,000 identities or 1,000,000 distinct graph edges is rejected atomically;
+startup repair also defers before mutation above 4,096 incomplete roots. Run
+updates, edge closure, admission tombstones, job/reservation settlement,
+allocation deltas, and journal insertion are set operations over the same
+materialized membership. Reports put roots first and then use SQLite binary ID
+ordering. A dispatched reservation becomes `held_unknown`; it is never
+silently refunded.
+
+Startup repair materializes all incomplete and possibly overlapping cancelled
+roots as one admission-graph union. The same set drives descendant updates,
+edge closure, durable cancellation locks, reservation/accounting settlement,
+and journal evidence. Reserved work is voided; dispatched work becomes
+`held_unknown` and is never refunded. Quiescent revivable terminal descendants
+remain terminal without receiving a direct repair lock, while roots,
+nonterminal/cancel-locked identities, and identities with active admission work
+are locked. `cascadeComplete` is stamped only after every projection succeeds;
+any error rolls back locks, accounting, run/edge mutations, and markers. An
+oversized repair raises a typed deferred condition for a later bounded recovery
+pass.
+
+Admission proves ancestry with one bounded recursive SQL query. Depth 64 is
+accepted when it reaches a durable root represented by an agent run, admission
+record, or canonical rollout lifecycle epoch. Depth 65, ambiguous parents,
+cycles, and unresolved roots deny with stable machine reasons
+(`ancestor_depth_exceeded`, `ancestor_parent_ambiguous`, `ancestor_cycle`, and
+`ancestor_unresolved`). A cancel lock encountered on a proved path denies as
+`parent_cancel_locked`. Schema v23 provides both directed spawn-edge indexes
+and both directed partial admission-parent indexes required by these walks.
+
+The scaling harness exercises 1,000, 10,000, and 100,000-node chains:
+
+```bash
+npm --workspace=@tetsuo-ai/runtime run benchmark:set-cancellation
+```
+
 ## Configuration
 
 Concurrency is configured by environment; `agent_max_threads` is the fallback
 for the session limit when its dedicated environment variable is absent:
 
-| Environment variable | Scope | Default |
-| --- | --- | ---: |
-| `AGENC_ADMISSION_GLOBAL_CONCURRENCY` | Daemon | 64 |
-| `AGENC_ADMISSION_WORKSPACE_CONCURRENCY` | Workspace | 32 |
-| `AGENC_ADMISSION_SESSION_CONCURRENCY` | Session | 8 / `agent_max_threads` |
-| `AGENC_ADMISSION_PARENT_CONCURRENCY` | Immediate parent | 4 |
-| `AGENC_ADMISSION_PROVIDER_CONCURRENCY` | Provider | 16 |
+| Environment variable                    | Scope            |                 Default |
+| --------------------------------------- | ---------------- | ----------------------: |
+| `AGENC_ADMISSION_GLOBAL_CONCURRENCY`    | Daemon           |                      64 |
+| `AGENC_ADMISSION_WORKSPACE_CONCURRENCY` | Workspace        |                      32 |
+| `AGENC_ADMISSION_SESSION_CONCURRENCY`   | Session          | 8 / `agent_max_threads` |
+| `AGENC_ADMISSION_PARENT_CONCURRENCY`    | Immediate parent |                       4 |
+| `AGENC_ADMISSION_PROVIDER_CONCURRENCY`  | Provider         |                      16 |
 
 Values must be positive safe integers; invalid or non-positive values fall
 back to the configured/default value. Environment changes require a daemon
@@ -333,10 +384,11 @@ State migrations are per-project, ordered, transactional, and idempotent. The
 daemon migrates every existing project database during startup and migrates a
 newly discovered project before its first admission.
 
-| Version | Change | Compatibility |
-| --- | --- | --- |
-| 13 `thread_listing_indexes` | Adds four partial thread-listing indexes | Data shape unchanged; indexes may remain permanently |
-| 14 `execution_admission_schema` | Adds nullable admission columns to `agent_jobs` and five admission tables | Legacy queue rows remain unchanged with `admission_run_id = NULL` |
+| Version                             | Change                                                                    | Compatibility                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| 13 `thread_listing_indexes`         | Adds four partial thread-listing indexes                                  | Data shape unchanged; indexes may remain permanently              |
+| 14 `execution_admission_schema`     | Adds nullable admission columns to `agent_jobs` and five admission tables | Legacy queue rows remain unchanged with `admission_run_id = NULL` |
+| 23 `set_based_cancellation_indexes` | Adds directed spawn and admission graph indexes                           | Data shape unchanged; indexes may remain permanently              |
 
 Upgrading from v13 to v14 is supported directly. The current runtime also
 applies both migrations to older databases in order. An older runtime whose

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -538,7 +538,7 @@
     {
       "normalization": "utf8_lf",
       "path": "runtime/package.json",
-      "sha256": "16cea064750c4f5e4f83686cb4fd903162715f8d9daa3e2e3d7e7a970edd861e"
+      "sha256": "993c84092b177ef42b1fdd01b42fd246c2321d330ae891911bcf70249945159d"
     }
   ],
   "planDigest": "f845a0595da15849f819d413b42f995107befacfc67ef78a2bf96338fda92025",

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,7 +4,7 @@ This artifact records bounded observations of known failures. Every row is
 informational: no current result is a passing performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `de1e702f0efbe5e2a6bdb5def5d8d5e608ad9251d38f843ab1da1eb7203e4300`
+- JSON SHA-256: `fe13e77f870fefb684aa683557bdaeb23200a57fb40366a44f49c54bd87680f1`
 - Source revision: `9449ec84edbb9968f4b6710b224c7ee19b173800`
 - Production tree: `runtime/src` at Git object `08b469162bbac1ed021a6ae08a15e1a9b635d72e`
 - Loaded production closure: `33` module bindings across `2` cases

--- a/runtime/benchmarks/set-based-cancellation.ts
+++ b/runtime/benchmarks/set-based-cancellation.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env -S npx tsx
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+import { upsertAgentRun } from "../src/state/agent-runs.js";
+import {
+  MAX_CANCELLATION_RUNS,
+  cancelAgentRunTree,
+} from "../src/state/run-cancellation.js";
+import { openStateDatabases } from "../src/state/sqlite-driver.js";
+
+const SAMPLE_COUNT = 5;
+const WARMUP_COUNT = 1;
+const MAX_NORMALIZED_GROWTH_MULTIPLIER = 4;
+const NODE_COUNTS = Object.freeze([1_000, 10_000, MAX_CANCELLATION_RUNS]);
+const FIXED_TIME = "2026-08-03T00:00:00.000Z";
+
+interface CancellationBenchmarkPoint {
+  readonly edges: number;
+  readonly madMilliseconds: number;
+  readonly medianMilliseconds: number;
+  readonly microsecondsPerNode: number;
+  readonly nodes: number;
+}
+
+function runSample(nodes: number): number {
+  const home = mkdtempSync(
+    join(tmpdir(), "agenc-cancellation-benchmark-home-"),
+  );
+  const cwd = mkdtempSync(join(tmpdir(), "agenc-cancellation-benchmark-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  const driver = openStateDatabases({ cwd, agencHome: home });
+  try {
+    upsertAgentRun(driver, {
+      id: "benchmark_root",
+      objective: "set cancellation scaling benchmark",
+      status: "running",
+      startedAt: FIXED_TIME,
+      lastActiveAt: FIXED_TIME,
+    });
+    driver
+      .prepareState<[number]>(
+        `WITH RECURSIVE sequence(value) AS (
+           VALUES (1)
+           UNION ALL
+           SELECT value + 1 FROM sequence WHERE value < ?
+         )
+         INSERT INTO thread_spawn_edges (
+           child_thread_id, parent_thread_id, parent_path, metadata_json, status
+         )
+         SELECT printf('benchmark_%06d', value),
+                CASE value WHEN 1 THEN 'benchmark_root'
+                  ELSE printf('benchmark_%06d', value - 1) END,
+                '/root', '{}', 'open'
+         FROM sequence`,
+      )
+      .run(nodes - 1);
+
+    const startedAt = performance.now();
+    const report = cancelAgentRunTree(driver, {
+      runId: "benchmark_root",
+      reason: "benchmark",
+      cancelledAt: FIXED_TIME,
+    });
+    const elapsed = performance.now() - startedAt;
+    if (
+      report.cancellationNodeCount !== nodes ||
+      report.cancellationEdgeCount !== nodes - 1 ||
+      report.subtreeRunIds.length !== nodes
+    ) {
+      throw new Error(
+        `cancellation benchmark cardinality mismatch at ${nodes}`,
+      );
+    }
+    return elapsed;
+  } finally {
+    driver.close();
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+function benchmark(nodes: number): CancellationBenchmarkPoint {
+  for (let index = 0; index < WARMUP_COUNT; index += 1) runSample(nodes);
+  const samples = Array.from({ length: SAMPLE_COUNT }, () => runSample(nodes));
+  const medianMilliseconds = median(samples);
+  return {
+    edges: nodes - 1,
+    madMilliseconds: median(
+      samples.map((sample) => Math.abs(sample - medianMilliseconds)),
+    ),
+    medianMilliseconds,
+    microsecondsPerNode: (medianMilliseconds * 1_000) / nodes,
+    nodes,
+  };
+}
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("median requires a sample");
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+    : (sorted[middle] ?? 0);
+}
+
+const points = NODE_COUNTS.map(benchmark);
+const baselineCost = points[0]?.microsecondsPerNode;
+if (
+  baselineCost === undefined ||
+  points.some(
+    (point) =>
+      point.microsecondsPerNode >
+      baselineCost * MAX_NORMALIZED_GROWTH_MULTIPLIER,
+  )
+) {
+  throw new Error(
+    `set cancellation exceeded ${MAX_NORMALIZED_GROWTH_MULTIPLIER}x ` +
+      "normalized-cost growth",
+  );
+}
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      benchmark: "set-based-cancellation",
+      node: process.version,
+      points,
+      samples: SAMPLE_COUNT,
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -64,6 +64,7 @@
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
     "benchmark:fnd-baseline": "node benchmarks/fnd/run-baselines.mjs",
     "benchmark:fuzzy-search": "node benchmarks/fuzzy-search/run.mjs",
+    "benchmark:set-cancellation": "tsx benchmarks/set-based-cancellation.ts",
     "check:fnd-benchmark-baseline": "node benchmarks/fnd/run-baselines.mjs --check",
     "test": "node scripts/run-hermetic-test-boundary.mjs run",
     "test:host-functional": "node scripts/run-hermetic-vitest.mjs run",

--- a/runtime/src/state/execution-admission.ts
+++ b/runtime/src/state/execution-admission.ts
@@ -19,12 +19,22 @@ import {
   admissionRecordKey,
 } from "../budget/admission-types.js";
 import type { BudgetReservation } from "../contracts/run-contracts.js";
+import {
+  ADMISSION_CANCELLATION_GRAPH,
+  cancellationSetMembershipSql,
+  inspectCancellationAncestors,
+  materializeCancellationSet,
+  materializedCancellationRunIds,
+  withCancellationOperation,
+  type CancellationAncestorDenialReason,
+  type CancellationOperation,
+} from "./run-cancellation.js";
 import { sqlPlaceholders } from "./sql.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 
 export const NANO_USD_PER_USD = 1_000_000_000;
 const MAX_LIST_LIMIT = 1_000;
-const MAX_ANCESTOR_WALK = 64;
+const MAX_ALLOCATION_ANCESTOR_WALK = 64;
 
 const FINAL_RESERVATION_STATUSES = new Set([
   "reconciled",
@@ -260,6 +270,13 @@ interface ReservationRow {
   readonly updated_at: string;
 }
 
+interface CancellationJobPreStateRow {
+  readonly id: string;
+  readonly admission_queue_sequence: number;
+  readonly admission_reservation_id: string | null;
+  readonly reservation_status: string | null;
+}
+
 interface AllocationRow {
   readonly scope_key: string;
   readonly owner_run_id: string;
@@ -381,12 +398,13 @@ export class ExecutionAdmissionRepository {
       ["execution_admission_cancellations", "run_id"],
       ["execution_admission_journal", "run_id"],
     ] as const;
-    return probes.some(([table, column]) =>
-      this.#driver
-        .prepareState<[string], { readonly found: number }>(
-          `SELECT 1 AS found FROM ${table} WHERE ${column} = ? LIMIT 1`,
-        )
-        .get(runId) !== undefined,
+    return probes.some(
+      ([table, column]) =>
+        this.#driver
+          .prepareState<[string], { readonly found: number }>(
+            `SELECT 1 AS found FROM ${table} WHERE ${column} = ? LIMIT 1`,
+          )
+          .get(runId) !== undefined,
     );
   }
 
@@ -416,10 +434,7 @@ export class ExecutionAdmissionRepository {
     const at = this.#timestamp();
     return this.#driver.transactionImmediate(() => {
       const existing = this.#driver
-        .prepareState<
-          [string],
-          { readonly deadline_at: string | null }
-        >(
+        .prepareState<[string], { readonly deadline_at: string | null }>(
           `SELECT deadline_at FROM execution_admission_run_limits
            WHERE run_id = ?`,
         )
@@ -499,10 +514,11 @@ export class ExecutionAdmissionRepository {
       let status: PersistedAdmissionStatus = "queued";
       let event: AdmissionJournalEvent["event"] = "queued";
       let reason: string | undefined;
-      if (this.#isCancellationLocked(request)) {
+      const ancestorDenial = this.#ancestorDenialReason(request);
+      if (ancestorDenial !== undefined) {
         status = "denied";
         event = "denied";
-        reason = "parent_cancel_locked";
+        reason = ancestorDenial;
       } else if (
         request.deadlineAt !== undefined &&
         request.deadlineAt <= now
@@ -640,12 +656,13 @@ export class ExecutionAdmissionRepository {
       }
 
       const request = parseRequest(row.input_json);
-      if (this.#isCancellationLocked(request)) {
+      const ancestorDenial = this.#ancestorDenialReason(request);
+      if (ancestorDenial !== undefined) {
         const denied = this.#finishUnclaimedJobLocked(
           row,
           request,
           "denied",
-          "parent_cancel_locked",
+          ancestorDenial,
           now,
         );
         return { kind: "not_claimed", reason: "cancelled", record: denied };
@@ -807,96 +824,105 @@ export class ExecutionAdmissionRepository {
       options.dispatchedAt === undefined
         ? undefined
         : normalizeTimestamp(options.dispatchedAt, "dispatchedAt");
-    return this.#driver.transactionImmediate(() => {
-      // Sample the repository clock only after BEGIN IMMEDIATE has acquired the
-      // writer lock. Time spent waiting behind another writer cannot become a
-      // loophole that dispatches work after its deadline.
-      const observedAt = this.#timestamp();
-      const at = evidenceAt ?? observedAt;
-      // A caller-provided evidence timestamp may predate the repository's clock,
-      // but it must never extend a deadline. Use the later observation for the
-      // final policy check while preserving `at` as audit evidence.
-      const decisionAt = observedAt < at ? at : observedAt;
-      const reservation = this.#requireReservationLocked(reservationId);
-      const job = this.#requireJobByIdLocked(reservation.job_id);
-      const request = parseRequest(job.input_json);
-      if (reservation.status === "reserved") {
-        const stopReason = this.#isCancellationLocked(request)
-          ? "parent_cancel_locked"
-          : request.deadlineAt !== undefined && request.deadlineAt <= decisionAt
-            ? "deadline_expired"
-            : undefined;
-        if (stopReason !== undefined) {
-          // Linearize cancellation/deadline policy against dispatch under the
-          // same BEGIN IMMEDIATE lock. A winning cancel voids the untouched
-          // hold and permanently locks the run before the caller reaches wire.
-          this.#cancelRunLocked(request.step.runId, stopReason, decisionAt);
-          return this.#recordFromRowLocked(
-            this.#requireJobByIdLocked(job.id),
-          );
-        }
-        this.#driver
-          .prepareState(
-            `UPDATE execution_admission_reservations
-             SET status = 'dispatched', dispatched_at = ?, updated_at = ?,
-                 provider_request_id = COALESCE(?, provider_request_id)
-             WHERE reservation_id = ? AND status = 'reserved'`,
-          )
-          .run(at, at, options.providerRequestId ?? null, reservationId);
-        this.#driver
-          .prepareState(
-            `UPDATE agent_jobs
-             SET admission_dispatched_at = ?, updated_at = ?
-             WHERE id = ? AND admission_reservation_id = ?`,
-          )
-          .run(at, at, job.id, reservationId);
-        this.#appendJournalLocked({
-          timestamp: at,
-          jobId: job.id,
-          reservationId,
-          request,
-          event: "dispatched",
-          reservedTokens: reservation.reserved_tokens,
-          reservedCostNanos: reservation.reserved_cost_nanos,
-          ...(options.details !== undefined ||
-          options.providerRequestId !== undefined
-            ? {
-                details: {
-                  ...options.details,
-                  ...(options.providerRequestId !== undefined
-                    ? { providerRequestId: options.providerRequestId }
-                    : {}),
-                },
-              }
-            : {}),
-        });
-      } else if (reservation.status === "dispatched") {
-        if (
-          options.providerRequestId !== undefined &&
-          reservation.provider_request_id === null
-        ) {
+    return withCancellationOperation(this.#driver, (operation) =>
+      this.#driver.transactionImmediate(() => {
+        // Sample the repository clock only after BEGIN IMMEDIATE has acquired the
+        // writer lock. Time spent waiting behind another writer cannot become a
+        // loophole that dispatches work after its deadline.
+        const observedAt = this.#timestamp();
+        const at = evidenceAt ?? observedAt;
+        // A caller-provided evidence timestamp may predate the repository's clock,
+        // but it must never extend a deadline. Use the later observation for the
+        // final policy check while preserving `at` as audit evidence.
+        const decisionAt = observedAt < at ? at : observedAt;
+        const reservation = this.#requireReservationLocked(reservationId);
+        const job = this.#requireJobByIdLocked(reservation.job_id);
+        const request = parseRequest(job.input_json);
+        if (reservation.status === "reserved") {
+          const ancestorDenial = this.#ancestorDenialReason(request);
+          const stopReason =
+            ancestorDenial ??
+            (request.deadlineAt !== undefined &&
+            request.deadlineAt <= decisionAt
+              ? "deadline_expired"
+              : undefined);
+          if (stopReason !== undefined) {
+            // Linearize cancellation/deadline policy against dispatch under the
+            // same BEGIN IMMEDIATE lock. A winning cancel voids the untouched
+            // hold and permanently locks the run before the caller reaches wire.
+            this.#cancelRunLocked(
+              request.step.runId,
+              stopReason,
+              decisionAt,
+              operation,
+            );
+            return this.#recordFromRowLocked(
+              this.#requireJobByIdLocked(job.id),
+            );
+          }
           this.#driver
             .prepareState(
               `UPDATE execution_admission_reservations
+             SET status = 'dispatched', dispatched_at = ?, updated_at = ?,
+                 provider_request_id = COALESCE(?, provider_request_id)
+             WHERE reservation_id = ? AND status = 'reserved'`,
+            )
+            .run(at, at, options.providerRequestId ?? null, reservationId);
+          this.#driver
+            .prepareState(
+              `UPDATE agent_jobs
+             SET admission_dispatched_at = ?, updated_at = ?
+             WHERE id = ? AND admission_reservation_id = ?`,
+            )
+            .run(at, at, job.id, reservationId);
+          this.#appendJournalLocked({
+            timestamp: at,
+            jobId: job.id,
+            reservationId,
+            request,
+            event: "dispatched",
+            reservedTokens: reservation.reserved_tokens,
+            reservedCostNanos: reservation.reserved_cost_nanos,
+            ...(options.details !== undefined ||
+            options.providerRequestId !== undefined
+              ? {
+                  details: {
+                    ...options.details,
+                    ...(options.providerRequestId !== undefined
+                      ? { providerRequestId: options.providerRequestId }
+                      : {}),
+                  },
+                }
+              : {}),
+          });
+        } else if (reservation.status === "dispatched") {
+          if (
+            options.providerRequestId !== undefined &&
+            reservation.provider_request_id === null
+          ) {
+            this.#driver
+              .prepareState(
+                `UPDATE execution_admission_reservations
                SET provider_request_id = ?, updated_at = ?
                WHERE reservation_id = ? AND provider_request_id IS NULL`,
-            )
-            .run(options.providerRequestId, at, reservationId);
-        } else if (
-          options.providerRequestId !== undefined &&
-          reservation.provider_request_id !== options.providerRequestId
-        ) {
+              )
+              .run(options.providerRequestId, at, reservationId);
+          } else if (
+            options.providerRequestId !== undefined &&
+            reservation.provider_request_id !== options.providerRequestId
+          ) {
+            throw new ExecutionAdmissionStateError(
+              `reservation ${reservationId} was already dispatched with a different provider request id`,
+            );
+          }
+        } else if (!FINAL_RESERVATION_STATUSES.has(reservation.status)) {
           throw new ExecutionAdmissionStateError(
-            `reservation ${reservationId} was already dispatched with a different provider request id`,
+            `invalid reservation status at dispatch: ${reservation.status}`,
           );
         }
-      } else if (!FINAL_RESERVATION_STATUSES.has(reservation.status)) {
-        throw new ExecutionAdmissionStateError(
-          `invalid reservation status at dispatch: ${reservation.status}`,
-        );
-      }
-      return this.#recordFromRowLocked(this.#requireJobByIdLocked(job.id));
-    });
+        return this.#recordFromRowLocked(this.#requireJobByIdLocked(job.id));
+      }),
+    );
   }
 
   reconcile(
@@ -909,9 +935,26 @@ export class ExecutionAdmissionRepository {
       options.at ?? this.#timestamp(),
       "reconcile.at",
     );
-    return this.#driver.transactionImmediate(() =>
-      this.#resolveReservationLocked(reservationId, input, at),
+    return withCancellationOperation(this.#driver, (operation) =>
+      this.#driver.transactionImmediate(() =>
+        this.#resolveReservationLocked(reservationId, input, at, operation),
+      ),
     );
+  }
+
+  /** Composition seam for a caller that already owns operation + writer txn. */
+  reconcileInCancellationOperation(
+    operation: CancellationOperation,
+    reservationId: string,
+    input: AdmissionReconcileInput,
+    options: ReconcileAdmissionOptions = {},
+  ): AdmissionReconcileResult {
+    requireNonEmpty(reservationId, "reservationId");
+    const at = normalizeTimestamp(
+      options.at ?? this.#timestamp(),
+      "reconcile.at",
+    );
+    return this.#resolveReservationLocked(reservationId, input, at, operation);
   }
 
   void(
@@ -964,8 +1007,51 @@ export class ExecutionAdmissionRepository {
       options.cancelledAt ?? this.#timestamp(),
       "cancel.cancelledAt",
     );
-    return this.#driver.transactionImmediate(() =>
-      this.#cancelRunLocked(runId, options.reason, at),
+    return withCancellationOperation(this.#driver, (operation) =>
+      this.#driver.transactionImmediate(() =>
+        this.#cancelRunLocked(runId, options.reason, at, operation),
+      ),
+    );
+  }
+
+  /** Composition seam for a caller that already owns operation + writer txn. */
+  cancelInCancellationOperation(
+    operation: CancellationOperation,
+    runId: string,
+    options: CancelAdmissionOptions,
+  ): AdmissionCancellationReport {
+    requireNonEmpty(runId, "cancel.runId");
+    requireNonEmpty(options.reason, "cancel.reason");
+    const at = normalizeTimestamp(
+      options.cancelledAt ?? this.#timestamp(),
+      "cancel.cancelledAt",
+    );
+    return this.#cancelRunLocked(runId, options.reason, at, operation);
+  }
+
+  /**
+   * Settle the admission identities already materialized for `operation` with
+   * `ADMISSION_CANCELLATION_GRAPH`. The caller owns the writer transaction and
+   * must materialize the complete root union before calling this seam. Repair
+   * scope preserves quiescent revivable terminals while still locking roots,
+   * cancel-locked/nonterminal identities, and active admission work.
+   */
+  settleMaterializedCancellationInOperation(
+    operation: CancellationOperation,
+    options: CancelAdmissionOptions & {
+      readonly lockScope?: "all" | "repair_targets";
+    },
+  ): void {
+    requireNonEmpty(options.reason, "cancel.reason");
+    const at = normalizeTimestamp(
+      options.cancelledAt ?? this.#timestamp(),
+      "cancel.cancelledAt",
+    );
+    this.#settleMaterializedCancellationLocked(
+      options.reason,
+      at,
+      operation,
+      options.lockScope ?? "all",
     );
   }
 
@@ -1035,167 +1121,172 @@ export class ExecutionAdmissionRepository {
       "recover.now",
     );
     const activeOwners = options.activeOwnerIds ?? new Set<string>();
-    return this.#driver.transactionImmediate(() => {
-      const requeuedJobIds: string[] = [];
-      const heldUnknownReservationIds: string[] = [];
-      const cancelledExpiredJobIds: string[] = [];
-      const detachedQueuedJobIds: string[] = [];
-      const expiredRuns = this.#driver
-        .prepareState<[string], { readonly run_id: string }>(
-          `SELECT run_id FROM execution_admission_run_limits
+    return withCancellationOperation(this.#driver, (operation) =>
+      this.#driver.transactionImmediate(() => {
+        const requeuedJobIds: string[] = [];
+        const heldUnknownReservationIds: string[] = [];
+        const cancelledExpiredJobIds: string[] = [];
+        const detachedQueuedJobIds: string[] = [];
+        const expiredRuns = this.#driver
+          .prepareState<[string], { readonly run_id: string }>(
+            `SELECT run_id FROM execution_admission_run_limits
            WHERE deadline_at IS NOT NULL AND deadline_at <= ?
            ORDER BY deadline_at ASC, run_id ASC`,
-        )
-        .all(now);
-      for (const { run_id: runId } of expiredRuns) {
-        const cancellation = this.#cancelRunLocked(
-          runId,
-          "deadline_expired_during_recovery",
-          now,
-        );
-        cancelledExpiredJobIds.push(...cancellation.cancelledJobIds);
-      }
-      const candidates = this.#driver
-        .prepareState<[], AgentJobRow>(
-          `SELECT ${JOB_COLUMNS}
+          )
+          .all(now);
+        for (const { run_id: runId } of expiredRuns) {
+          const cancellation = this.#cancelRunLocked(
+            runId,
+            "deadline_expired_during_recovery",
+            now,
+            operation,
+          );
+          cancelledExpiredJobIds.push(...cancellation.cancelledJobIds);
+        }
+        const candidates = this.#driver
+          .prepareState<[], AgentJobRow>(
+            `SELECT ${JOB_COLUMNS}
            FROM agent_jobs
            WHERE admission_run_id IS NOT NULL
              AND status IN ('queued', 'approval_required', 'running')
            ORDER BY admission_queue_sequence ASC`,
-        )
-        .all();
+          )
+          .all();
 
-      for (const row of candidates) {
-        const request = parseRequest(row.input_json);
-        const expired =
-          request.deadlineAt !== undefined && request.deadlineAt <= now;
-        if (row.status === "queued" || row.status === "approval_required") {
-          if (expired) {
-            this.#finishUnclaimedJobLocked(
-              row,
-              request,
-              "cancelled",
-              "deadline_expired_during_recovery",
-              now,
-            );
-            if (!cancelledExpiredJobIds.includes(row.id)) {
-              cancelledExpiredJobIds.push(row.id);
+        for (const row of candidates) {
+          const request = parseRequest(row.input_json);
+          const expired =
+            request.deadlineAt !== undefined && request.deadlineAt <= now;
+          if (row.status === "queued" || row.status === "approval_required") {
+            if (expired) {
+              this.#finishUnclaimedJobLocked(
+                row,
+                request,
+                "cancelled",
+                "deadline_expired_during_recovery",
+                now,
+              );
+              if (!cancelledExpiredJobIds.includes(row.id)) {
+                cancelledExpiredJobIds.push(row.id);
+              }
+              continue;
             }
-            continue;
-          }
-          if (
-            row.admission_owner_id !== null ||
-            row.admission_owner_pid !== null ||
-            row.admission_attached !== 0
-          ) {
-            this.#driver
-              .prepareState(
-                `UPDATE agent_jobs
+            if (
+              row.admission_owner_id !== null ||
+              row.admission_owner_pid !== null ||
+              row.admission_attached !== 0
+            ) {
+              this.#driver
+                .prepareState(
+                  `UPDATE agent_jobs
                  SET worker_id = NULL, admission_owner_id = NULL,
                      admission_owner_pid = NULL, admission_attached = 0,
                      updated_at = ?
                  WHERE id = ?`,
-              )
-              .run(now, row.id);
-            this.#appendJournalLocked({
-              timestamp: now,
-              jobId: row.id,
-              request,
-              event: "recovered",
-              reason: "queued_owner_detached",
-            });
-            detachedQueuedJobIds.push(row.id);
+                )
+                .run(now, row.id);
+              this.#appendJournalLocked({
+                timestamp: now,
+                jobId: row.id,
+                request,
+                event: "recovered",
+                reason: "queued_owner_detached",
+              });
+              detachedQueuedJobIds.push(row.id);
+            }
+            continue;
           }
-          continue;
-        }
 
-        if (
-          row.admission_owner_id !== null &&
-          activeOwners.has(row.admission_owner_id)
-        ) {
-          continue;
-        }
-        const reservation =
-          row.admission_reservation_id === null
-            ? undefined
-            : this.#reservationLocked(row.admission_reservation_id);
-        if (reservation?.status === "dispatched") {
-          this.#resolveReservationLocked(
-            reservation.reservation_id,
-            {
-              kind: "unknown",
-              reason: expired
-                ? "deadline_expired_after_dispatch"
-                : "daemon_restarted_after_dispatch",
-            },
-            now,
-          );
-          heldUnknownReservationIds.push(reservation.reservation_id);
-          if (expired && !cancelledExpiredJobIds.includes(row.id)) {
-            cancelledExpiredJobIds.push(row.id);
+          if (
+            row.admission_owner_id !== null &&
+            activeOwners.has(row.admission_owner_id)
+          ) {
+            continue;
           }
-          continue;
-        }
-        if (expired) {
-          if (reservation?.status === "reserved") {
+          const reservation =
+            row.admission_reservation_id === null
+              ? undefined
+              : this.#reservationLocked(row.admission_reservation_id);
+          if (reservation?.status === "dispatched") {
             this.#resolveReservationLocked(
               reservation.reservation_id,
-              { kind: "void", reason: "deadline_expired_before_dispatch" },
+              {
+                kind: "unknown",
+                reason: expired
+                  ? "deadline_expired_after_dispatch"
+                  : "daemon_restarted_after_dispatch",
+              },
               now,
+              operation,
             );
+            heldUnknownReservationIds.push(reservation.reservation_id);
+            if (expired && !cancelledExpiredJobIds.includes(row.id)) {
+              cancelledExpiredJobIds.push(row.id);
+            }
+            continue;
           }
-          this.#driver
-            .prepareState(
-              `UPDATE agent_jobs
+          if (expired) {
+            if (reservation?.status === "reserved") {
+              this.#resolveReservationLocked(
+                reservation.reservation_id,
+                { kind: "void", reason: "deadline_expired_before_dispatch" },
+                now,
+                operation,
+              );
+            }
+            this.#driver
+              .prepareState(
+                `UPDATE agent_jobs
                SET status = 'cancelled', worker_id = NULL,
                    admission_owner_id = NULL, admission_owner_pid = NULL,
                    admission_attached = 0, admission_completed_at = ?,
                    admission_reason = 'deadline_expired_during_recovery',
                    updated_at = ?
                WHERE id = ?`,
-            )
-            .run(now, now, row.id);
-          this.#appendJournalLocked({
-            timestamp: now,
-            jobId: row.id,
-            request,
-            event: "cancelled",
-            reason: "deadline_expired_during_recovery",
-          });
-          if (!cancelledExpiredJobIds.includes(row.id)) {
-            cancelledExpiredJobIds.push(row.id);
+              )
+              .run(now, now, row.id);
+            this.#appendJournalLocked({
+              timestamp: now,
+              jobId: row.id,
+              request,
+              event: "cancelled",
+              reason: "deadline_expired_during_recovery",
+            });
+            if (!cancelledExpiredJobIds.includes(row.id)) {
+              cancelledExpiredJobIds.push(row.id);
+            }
+            continue;
           }
-          continue;
-        }
-        if (reservation?.status === "reserved") {
-          this.#resolveReservationLocked(
-            reservation.reservation_id,
-            { kind: "void", reason: "daemon_restarted_before_dispatch" },
-            now,
-          );
-        } else if (
-          reservation !== undefined &&
-          FINAL_RESERVATION_STATUSES.has(reservation.status)
-        ) {
-          this.#driver
-            .prepareState(
-              `UPDATE agent_jobs
+          if (reservation?.status === "reserved") {
+            this.#resolveReservationLocked(
+              reservation.reservation_id,
+              { kind: "void", reason: "daemon_restarted_before_dispatch" },
+              now,
+              operation,
+            );
+          } else if (
+            reservation !== undefined &&
+            FINAL_RESERVATION_STATUSES.has(reservation.status)
+          ) {
+            this.#driver
+              .prepareState(
+                `UPDATE agent_jobs
                SET status = ?, admission_completed_at = COALESCE(admission_completed_at, ?),
                    admission_reason = COALESCE(admission_reason, ?), updated_at = ?
                WHERE id = ?`,
-            )
-            .run(
-              reservation.status,
-              now,
-              reservation.resolution_reason ?? "recovered_final_reservation",
-              now,
-              row.id,
-            );
-          continue;
-        }
-        this.#driver
-          .prepareState(
-            `UPDATE agent_jobs
+              )
+              .run(
+                reservation.status,
+                now,
+                reservation.resolution_reason ?? "recovered_final_reservation",
+                now,
+                row.id,
+              );
+            continue;
+          }
+          this.#driver
+            .prepareState(
+              `UPDATE agent_jobs
              SET status = 'queued', worker_id = NULL, result_json = NULL,
                  error = NULL,
                  admission_owner_id = NULL, admission_owner_pid = NULL,
@@ -1204,27 +1295,28 @@ export class ExecutionAdmissionRepository {
                  admission_completed_at = NULL, admission_reason = NULL,
                  admission_reservation_id = NULL, updated_at = ?
              WHERE id = ?`,
-          )
-          .run(now, row.id);
-        this.#appendJournalLocked({
-          timestamp: now,
-          jobId: row.id,
-          request,
-          event: "recovered",
-          reason: "requeued_before_dispatch",
-        });
-        requeuedJobIds.push(row.id);
-      }
+            )
+            .run(now, row.id);
+          this.#appendJournalLocked({
+            timestamp: now,
+            jobId: row.id,
+            request,
+            event: "recovered",
+            reason: "requeued_before_dispatch",
+          });
+          requeuedJobIds.push(row.id);
+        }
 
-      const repairedAllocationKeys = this.#rebuildAllocationsLocked(now);
-      return {
-        requeuedJobIds,
-        heldUnknownReservationIds,
-        cancelledExpiredJobIds,
-        detachedQueuedJobIds,
-        repairedAllocationKeys,
-      };
-    });
+        const repairedAllocationKeys = this.#rebuildAllocationsLocked(now);
+        return {
+          requeuedJobIds,
+          heldUnknownReservationIds,
+          cancelledExpiredJobIds,
+          detachedQueuedJobIds,
+          repairedAllocationKeys,
+        };
+      }),
+    );
   }
 
   get(key: string): PersistedAdmissionRecord | undefined {
@@ -1701,16 +1793,10 @@ export class ExecutionAdmissionRepository {
         );
       return this.#requireAllocationLocked(key);
     }
-    if (
-      parentKey !== undefined &&
-      existing.parent_scope_key !== parentKey
-    ) {
+    if (parentKey !== undefined && existing.parent_scope_key !== parentKey) {
       throw new AdmissionAllocationConflictError(key, "parentKey");
     }
-    if (
-      maxTokens !== undefined &&
-      existing.max_tokens !== maxTokens
-    ) {
+    if (maxTokens !== undefined && existing.max_tokens !== maxTokens) {
       throw new AdmissionAllocationConflictError(key, "maxTokens");
     }
     if (
@@ -1747,7 +1833,7 @@ export class ExecutionAdmissionRepository {
     const seen = new Set<string>();
     const queue = scopes.map((scope) => scope.key);
     for (let hops = 0; queue.length > 0; hops++) {
-      if (hops >= MAX_ANCESTOR_WALK * Math.max(1, scopes.length)) {
+      if (hops >= MAX_ALLOCATION_ANCESTOR_WALK * Math.max(1, scopes.length)) {
         throw new ExecutionAdmissionStateError(
           "admission allocation hierarchy exceeds cycle/depth bound",
         );
@@ -1768,6 +1854,7 @@ export class ExecutionAdmissionRepository {
     reservationId: string,
     rawInput: AdmissionReconcileInput,
     at: string,
+    operation?: CancellationOperation,
   ): AdmissionReconcileResult {
     const reservation = this.#requireReservationLocked(reservationId);
     const requestedProviderRequestId =
@@ -1875,8 +1962,7 @@ export class ExecutionAdmissionRepository {
           tokens: actualTokens,
           // Unknown provider cost is never treated as free. An explicit or
           // token-detected overrun keeps at least the full monetary reservation.
-          costNanos:
-            actualCostNanos ?? reservation.reserved_cost_nanos,
+          costNanos: actualCostNanos ?? reservation.reserved_cost_nanos,
           blockByProviderOverrun: overrun,
         };
       }
@@ -1960,7 +2046,17 @@ export class ExecutionAdmissionRepository {
     });
 
     if (overrun) {
-      this.#cancelRunLocked(reservation.run_id, "provider_overrun", at);
+      if (operation === undefined) {
+        throw new ExecutionAdmissionStateError(
+          "provider overrun cancellation is missing an operation context",
+        );
+      }
+      this.#cancelRunLocked(
+        reservation.run_id,
+        "provider_overrun",
+        at,
+        operation,
+      );
       return {
         applied: true,
         outcome: "provider_overrun",
@@ -2089,59 +2185,361 @@ export class ExecutionAdmissionRepository {
     runId: string,
     reason: string,
     at: string,
+    operation: CancellationOperation,
   ): AdmissionCancellationReport {
-    const affectedRunIds = this.#collectDescendantRunIdsLocked(runId);
-    for (const affectedRunId of affectedRunIds) {
-      this.#driver
-        .prepareState(
-          `INSERT INTO execution_admission_cancellations (
-            run_id, reason, cancelled_at
-          ) VALUES (?, ?, ?)
-          ON CONFLICT(run_id) DO NOTHING`,
-        )
-        .run(affectedRunId, reason, at);
-    }
+    materializeCancellationSet(
+      this.#driver,
+      operation,
+      ADMISSION_CANCELLATION_GRAPH,
+      [runId],
+    );
+    return {
+      runId,
+      ...this.#settleMaterializedCancellationLocked(
+        reason,
+        at,
+        operation,
+        "all",
+      ),
+    };
+  }
+
+  #settleMaterializedCancellationLocked(
+    reason: string,
+    at: string,
+    operation: CancellationOperation,
+    lockScope: "all" | "repair_targets",
+  ): Omit<AdmissionCancellationReport, "runId"> {
+    const affectedRunIds = materializedCancellationRunIds(
+      this.#driver,
+      operation,
+      ADMISSION_CANCELLATION_GRAPH,
+    );
     if (affectedRunIds.length === 0) {
       return {
-        runId,
         affectedRunIds: [],
         cancelledJobIds: [],
         voidedReservationIds: [],
         heldUnknownReservationIds: [],
       };
     }
+    const membership = cancellationSetMembershipSql("job.admission_run_id");
     const jobs = this.#driver
-      .prepareState<unknown[], AgentJobRow>(
-        `SELECT ${JOB_COLUMNS}
-         FROM agent_jobs
-         WHERE admission_run_id IN (${sqlPlaceholders(affectedRunIds.length)})
-         ORDER BY admission_queue_sequence ASC`,
+      .prepareState<unknown[], CancellationJobPreStateRow>(
+        `SELECT job.id, job.admission_queue_sequence,
+                job.admission_reservation_id,
+                reservation.status AS reservation_status
+         FROM agent_jobs AS job
+         LEFT JOIN execution_admission_reservations AS reservation
+           ON reservation.reservation_id = job.admission_reservation_id
+         WHERE job.status IN ('queued', 'approval_required', 'running')
+           AND ${membership}
+         ORDER BY job.admission_queue_sequence ASC, job.id COLLATE BINARY`,
       )
-      .all(...affectedRunIds);
-    const cancelledJobIds: string[] = [];
-    const voidedReservationIds: string[] = [];
-    const heldUnknownReservationIds: string[] = [];
-    for (const job of jobs) {
-      const before =
-        job.admission_reservation_id === null
-          ? undefined
-          : this.#reservationLocked(job.admission_reservation_id);
-      const changed = this.#cancelJobLocked(job, reason, at);
-      if (!changed) continue;
-      cancelledJobIds.push(job.id);
-      if (before?.status === "reserved") {
-        voidedReservationIds.push(before.reservation_id);
-      } else if (before?.status === "dispatched") {
-        heldUnknownReservationIds.push(before.reservation_id);
-      }
-    }
+      .all(operation.id, ADMISSION_CANCELLATION_GRAPH);
+    const lockEligibilitySql =
+      lockScope === "repair_targets"
+        ? `AND (
+             cancellation_set.is_root = 1
+             OR NOT EXISTS (
+               SELECT 1 FROM agent_runs AS terminal_run
+               WHERE terminal_run.id = cancellation_set.run_id
+                 AND terminal_run.status IN (
+                   'completed', 'failed', 'errored', 'error', 'stopped'
+                 )
+             )
+             OR EXISTS (
+               SELECT 1 FROM agent_jobs AS active_job
+               WHERE active_job.admission_run_id = cancellation_set.run_id
+                 AND active_job.status IN (
+                   'queued', 'approval_required', 'running'
+                 )
+             )
+           )`
+        : "";
+    this.#driver
+      .prepareState<unknown[]>(
+        `INSERT INTO execution_admission_cancellations (
+           run_id, reason, cancelled_at
+         )
+         SELECT cancellation_set.run_id, ?, ?
+         FROM temp.agenc_cancellation_operation_runs AS cancellation_set
+         WHERE cancellation_set.operation_id = ?
+           AND cancellation_set.graph_kind = ?
+           ${lockEligibilitySql}
+         ON CONFLICT(run_id) DO NOTHING`,
+      )
+      .run(reason, at, operation.id, ADMISSION_CANCELLATION_GRAPH);
+    this.#assertBulkCancellationAllocationBounds(operation);
+    this.#insertBulkCancellationJournal(operation, reason, at);
+    this.#applyBulkCancellationAllocationDeltas(operation, at);
+    const changedJobIds = new Set(
+      this.#driver
+        .prepareState<unknown[], { readonly id: string }>(
+          `UPDATE agent_jobs AS job
+           SET status = CASE (
+                 SELECT reservation.status
+                 FROM execution_admission_reservations AS reservation
+                 WHERE reservation.reservation_id = job.admission_reservation_id
+               )
+                 WHEN 'reserved' THEN 'voided'
+                 WHEN 'dispatched' THEN 'held_unknown'
+                 ELSE 'cancelled'
+               END,
+               result_json = NULL,
+               error = CASE (
+                 SELECT reservation.status
+                 FROM execution_admission_reservations AS reservation
+                 WHERE reservation.reservation_id = job.admission_reservation_id
+               )
+                 WHEN 'reserved' THEN 'cancelled_before_dispatch:' || ?
+                 WHEN 'dispatched' THEN 'cancelled_after_dispatch:' || ?
+                 ELSE ?
+               END,
+               worker_id = NULL,
+               updated_at = ?,
+               admission_owner_pid = NULL,
+               admission_owner_id = NULL,
+               admission_attached = 0,
+               admission_completed_at = ?,
+               admission_reason = CASE (
+                 SELECT reservation.status
+                 FROM execution_admission_reservations AS reservation
+                 WHERE reservation.reservation_id = job.admission_reservation_id
+               )
+                 WHEN 'reserved' THEN 'cancelled_before_dispatch:' || ?
+                 WHEN 'dispatched' THEN 'cancelled_after_dispatch:' || ?
+                 ELSE ?
+               END
+           WHERE job.status IN ('queued', 'approval_required', 'running')
+             AND ${membership}
+           RETURNING id`,
+        )
+        .all(
+          reason,
+          reason,
+          reason,
+          at,
+          at,
+          reason,
+          reason,
+          reason,
+          operation.id,
+          ADMISSION_CANCELLATION_GRAPH,
+        )
+        .map((row) => row.id),
+    );
+    this.#driver
+      .prepareState<unknown[]>(
+        `UPDATE execution_admission_reservations AS reservation
+         SET status = CASE reservation.status
+               WHEN 'reserved' THEN 'voided'
+               WHEN 'dispatched' THEN 'held_unknown'
+             END,
+             actual_input_tokens = NULL,
+             actual_output_tokens = NULL,
+             actual_tokens = NULL,
+             actual_cost_nanos = NULL,
+             resolved_at = ?,
+             resolution_reason = CASE reservation.status
+               WHEN 'reserved' THEN 'cancelled_before_dispatch:' || ?
+               WHEN 'dispatched' THEN 'cancelled_after_dispatch:' || ?
+             END,
+             updated_at = ?
+         WHERE reservation.status IN ('reserved', 'dispatched')
+           AND EXISTS (
+             SELECT 1 FROM agent_jobs AS job
+             WHERE job.id = reservation.job_id
+               AND ${membership}
+           )`,
+      )
+      .run(at, reason, reason, at, operation.id, ADMISSION_CANCELLATION_GRAPH);
+    const cancelledJobIds = jobs
+      .filter((job) => changedJobIds.has(job.id))
+      .map((job) => job.id);
+    const voidedReservationIds = jobs.flatMap((job) =>
+      changedJobIds.has(job.id) &&
+      job.admission_reservation_id !== null &&
+      job.reservation_status === "reserved"
+        ? [job.admission_reservation_id]
+        : [],
+    );
+    const heldUnknownReservationIds = jobs.flatMap((job) =>
+      changedJobIds.has(job.id) &&
+      job.admission_reservation_id !== null &&
+      job.reservation_status === "dispatched"
+        ? [job.admission_reservation_id]
+        : [],
+    );
     return {
-      runId,
       affectedRunIds,
       cancelledJobIds,
       voidedReservationIds,
       heldUnknownReservationIds,
     };
+  }
+
+  #assertBulkCancellationAllocationBounds(
+    operation: CancellationOperation,
+  ): void {
+    const membership = cancellationSetMembershipSql("job.admission_run_id");
+    const invalid = this.#driver
+      .prepareState<
+        unknown[],
+        { readonly scope_key: string; readonly failure: string }
+      >(
+        `WITH delta AS (
+           SELECT link.scope_key,
+                  SUM(link.reserved_tokens) AS held_tokens,
+                  SUM(CASE WHEN reservation.status = 'dispatched'
+                           THEN link.reserved_tokens ELSE 0 END) AS used_tokens,
+                  SUM(link.reserved_cost_nanos) AS held_cost_nanos,
+                  SUM(CASE WHEN reservation.status = 'dispatched'
+                           THEN link.reserved_cost_nanos ELSE 0 END) AS used_cost_nanos
+           FROM execution_admission_reservation_allocations AS link
+           JOIN execution_admission_reservations AS reservation
+             ON reservation.reservation_id = link.reservation_id
+           JOIN agent_jobs AS job ON job.id = reservation.job_id
+           WHERE reservation.status IN ('reserved', 'dispatched')
+             AND ${membership}
+           GROUP BY link.scope_key
+         )
+         SELECT allocation.scope_key,
+                CASE
+                  WHEN allocation.held_tokens < delta.held_tokens
+                    OR allocation.held_cost_nanos < delta.held_cost_nanos
+                  THEN 'hold_underflow'
+                  ELSE 'used_overflow'
+                END AS failure
+         FROM delta
+         JOIN execution_admission_allocations AS allocation
+           ON allocation.scope_key = delta.scope_key
+         WHERE allocation.held_tokens < delta.held_tokens
+            OR allocation.held_cost_nanos < delta.held_cost_nanos
+            OR allocation.used_tokens + delta.used_tokens > ${Number.MAX_SAFE_INTEGER}
+            OR allocation.used_cost_nanos + delta.used_cost_nanos > ${Number.MAX_SAFE_INTEGER}
+         ORDER BY allocation.scope_key COLLATE BINARY
+         LIMIT 1`,
+      )
+      .get(operation.id, ADMISSION_CANCELLATION_GRAPH);
+    if (invalid !== undefined) {
+      throw new ExecutionAdmissionStateError(
+        `bulk cancellation allocation ${invalid.failure}: ${invalid.scope_key}`,
+      );
+    }
+  }
+
+  #applyBulkCancellationAllocationDeltas(
+    operation: CancellationOperation,
+    at: string,
+  ): void {
+    const membership = cancellationSetMembershipSql("job.admission_run_id");
+    this.#driver
+      .prepareState<unknown[]>(
+        `WITH delta AS (
+           SELECT link.scope_key,
+                  SUM(link.reserved_tokens) AS held_tokens,
+                  SUM(CASE WHEN reservation.status = 'dispatched'
+                           THEN link.reserved_tokens ELSE 0 END) AS used_tokens,
+                  SUM(link.reserved_cost_nanos) AS held_cost_nanos,
+                  SUM(CASE WHEN reservation.status = 'dispatched'
+                           THEN link.reserved_cost_nanos ELSE 0 END) AS used_cost_nanos
+           FROM execution_admission_reservation_allocations AS link
+           JOIN execution_admission_reservations AS reservation
+             ON reservation.reservation_id = link.reservation_id
+           JOIN agent_jobs AS job ON job.id = reservation.job_id
+           WHERE reservation.status IN ('reserved', 'dispatched')
+             AND ${membership}
+           GROUP BY link.scope_key
+         )
+         UPDATE execution_admission_allocations AS allocation
+         SET held_tokens = held_tokens - (
+               SELECT delta.held_tokens FROM delta
+               WHERE delta.scope_key = allocation.scope_key
+             ),
+             held_cost_nanos = held_cost_nanos - (
+               SELECT delta.held_cost_nanos FROM delta
+               WHERE delta.scope_key = allocation.scope_key
+             ),
+             used_tokens = used_tokens + (
+               SELECT delta.used_tokens FROM delta
+               WHERE delta.scope_key = allocation.scope_key
+             ),
+             used_cost_nanos = used_cost_nanos + (
+               SELECT delta.used_cost_nanos FROM delta
+               WHERE delta.scope_key = allocation.scope_key
+             ),
+             updated_at = ?
+         WHERE allocation.scope_key IN (SELECT scope_key FROM delta)`,
+      )
+      .run(operation.id, ADMISSION_CANCELLATION_GRAPH, at);
+  }
+
+  #insertBulkCancellationJournal(
+    operation: CancellationOperation,
+    reason: string,
+    at: string,
+  ): void {
+    const membership = cancellationSetMembershipSql("job.admission_run_id");
+    this.#driver
+      .prepareState<unknown[]>(
+        `WITH target_jobs AS (
+           SELECT job.*, reservation.status AS reservation_status,
+                  reservation.reservation_id,
+                  reservation.reserved_tokens,
+                  reservation.reserved_cost_nanos
+           FROM agent_jobs AS job
+           LEFT JOIN execution_admission_reservations AS reservation
+             ON reservation.reservation_id = job.admission_reservation_id
+           WHERE job.status IN ('queued', 'approval_required', 'running')
+             AND ${membership}
+         ),
+         events AS (
+           SELECT job.id AS job_id, job.reservation_id,
+                  job.admission_run_id AS run_id,
+                  job.admission_step_id AS step_id,
+                  job.kind, job.admission_model AS model,
+                  job.admission_provider AS provider,
+                  CASE job.reservation_status
+                    WHEN 'reserved' THEN 'voided'
+                    ELSE 'held_unknown'
+                  END AS event,
+                  CASE job.reservation_status
+                    WHEN 'reserved' THEN 'cancelled_before_dispatch:' || ?
+                    ELSE 'cancelled_after_dispatch:' || ?
+                  END AS event_reason,
+                  job.reserved_tokens, job.reserved_cost_nanos,
+                  job.admission_queue_sequence, 0 AS event_order
+           FROM target_jobs AS job
+           WHERE job.reservation_status IN ('reserved', 'dispatched')
+           UNION ALL
+           SELECT job.id, job.reservation_id, job.admission_run_id,
+                  job.admission_step_id, job.kind, job.admission_model,
+                  job.admission_provider, 'cancelled', ?, NULL, NULL,
+                  job.admission_queue_sequence, 1
+           FROM target_jobs AS job
+         )
+         INSERT INTO execution_admission_journal (
+           event_id, timestamp, job_id, reservation_id, run_id, step_id,
+           kind, event, reason, model, provider, reserved_tokens,
+           reserved_cost_nanos, actual_tokens, actual_cost_nanos, details_json
+         )
+         SELECT 'cancel-' || lower(hex(randomblob(16))), ?, job_id,
+                reservation_id, run_id, step_id, kind, event, event_reason,
+                model, provider, reserved_tokens, reserved_cost_nanos,
+                NULL, NULL, '{}'
+         FROM events
+         ORDER BY admission_queue_sequence ASC, event_order ASC,
+                  job_id COLLATE BINARY`,
+      )
+      .run(
+        operation.id,
+        ADMISSION_CANCELLATION_GRAPH,
+        reason,
+        reason,
+        reason,
+        at,
+      );
   }
 
   #cancelJobLocked(row: AgentJobRow, reason: string, at: string): boolean {
@@ -2189,102 +2587,19 @@ export class ExecutionAdmissionRepository {
     return true;
   }
 
-  #collectDescendantRunIdsLocked(rootRunId: string): readonly string[] {
-    const seen = new Set<string>();
-    const ordered: string[] = [];
-    const queue = [rootRunId];
-    const spawnChildren = this.#driver.prepareState<
-      [string],
-      { readonly child_thread_id: string }
-    >(
-      `SELECT child_thread_id FROM thread_spawn_edges
-       WHERE parent_thread_id = ? ORDER BY child_thread_id ASC`,
-    );
-    const admissionChildren = this.#driver.prepareState<
-      [string],
-      { readonly admission_run_id: string }
-    >(
-      `SELECT DISTINCT admission_run_id FROM agent_jobs
-       WHERE admission_parent_run_id = ? AND admission_run_id IS NOT NULL
-       ORDER BY admission_run_id ASC`,
-    );
-    while (queue.length > 0) {
-      const current = queue.shift() as string;
-      if (seen.has(current)) continue;
-      if (seen.size >= 100_000) {
-        throw new ExecutionAdmissionStateError(
-          `admission cancellation subtree exceeds safety bound: ${rootRunId}`,
-        );
-      }
-      seen.add(current);
-      ordered.push(current);
-      for (const child of spawnChildren.all(current)) {
-        if (!seen.has(child.child_thread_id)) queue.push(child.child_thread_id);
-      }
-      for (const child of admissionChildren.all(current)) {
-        if (!seen.has(child.admission_run_id))
-          queue.push(child.admission_run_id);
-      }
-    }
-    return ordered;
-  }
-
-  #isCancellationLocked(request: RuntimeAdmissionRequest): boolean {
-    const seen = new Set<string>();
-    const queue = [
-      request.step.runId,
+  #ancestorDenialReason(
+    request: RuntimeAdmissionRequest,
+  ): CancellationAncestorDenialReason | undefined {
+    return inspectCancellationAncestors(this.#driver, {
+      startRunId: request.step.runId,
+      graphKind: ADMISSION_CANCELLATION_GRAPH,
       ...(request.step.parentRunId !== undefined
-        ? [request.step.parentRunId]
-        : []),
-    ];
-    const cancellation = this.#driver.prepareState<
-      [string],
-      { readonly run_id: string }
-    >(`SELECT run_id FROM execution_admission_cancellations WHERE run_id = ?`);
-    const runStatus = this.#driver.prepareState<
-      [string],
-      { readonly status: string }
-    >("SELECT status FROM agent_runs WHERE id = ?");
-    const spawnParent = this.#driver.prepareState<
-      [string],
-      { readonly parent_thread_id: string }
-    >(
-      `SELECT parent_thread_id FROM thread_spawn_edges
-       WHERE child_thread_id = ?`,
-    );
-    const admissionParent = this.#driver.prepareState<
-      [string],
-      { readonly admission_parent_run_id: string | null }
-    >(
-      `SELECT admission_parent_run_id FROM agent_jobs
-       WHERE admission_run_id = ? AND admission_parent_run_id IS NOT NULL
-       ORDER BY admission_queue_sequence ASC LIMIT 1`,
-    );
-    while (queue.length > 0 && seen.size < MAX_ANCESTOR_WALK) {
-      const current = queue.shift() as string;
-      if (seen.has(current)) continue;
-      seen.add(current);
-      if (cancellation.get(current) !== undefined) return true;
-      const status = runStatus.get(current)?.status;
-      if (
-        status === "cancelled" ||
-        status === "unknown_outcome" ||
-        status === "provider_overrun"
-      ) {
-        return true;
-      }
-      const parent =
-        spawnParent.get(current)?.parent_thread_id ??
-        admissionParent.get(current)?.admission_parent_run_id ??
-        undefined;
-      if (parent !== undefined && !seen.has(parent)) queue.push(parent);
-    }
-    if (queue.length > 0) {
-      throw new ExecutionAdmissionStateError(
-        `admission ancestor walk exceeds safety bound: ${request.step.runId}`,
-      );
-    }
-    return false;
+        ? { explicitParentRunId: request.step.parentRunId }
+        : {}),
+      // A request without a declared/durable parent is itself a root. A
+      // declared parent must resolve to durable identity before admission.
+      allowUnpersistedStartRoot: request.step.parentRunId === undefined,
+    })?.reason;
   }
 
   #rebuildAllocationsLocked(at: string): readonly string[] {
@@ -2458,7 +2773,10 @@ export function usdToNanos(value: number): number {
   // binary floating point. `nanosToUsd(n)` must round-trip to exactly `n`;
   // otherwise a retried durable request can gain a nano on each parse and
   // conflict with its own `(runId, stepId)` identity.
-  const nanos = decimalToScaledIntegerCeil(Object.is(value, -0) ? "0" : value.toString(), 9);
+  const nanos = decimalToScaledIntegerCeil(
+    Object.is(value, -0) ? "0" : value.toString(),
+    9,
+  );
   if (nanos > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new ExecutionAdmissionStateError(
       "USD value exceeds the safe nano-USD range",
@@ -2470,13 +2788,17 @@ export function usdToNanos(value: number): number {
 function decimalToScaledIntegerCeil(value: string, scale: number): bigint {
   const match = /^(\d+)(?:\.(\d*))?(?:e([+-]?\d+))?$/i.exec(value);
   if (match === null) {
-    throw new ExecutionAdmissionStateError("USD value has an invalid decimal representation");
+    throw new ExecutionAdmissionStateError(
+      "USD value has an invalid decimal representation",
+    );
   }
   const whole = match[1] ?? "0";
   const fraction = match[2] ?? "";
   const exponent = Number.parseInt(match[3] ?? "0", 10);
   if (!Number.isSafeInteger(exponent)) {
-    throw new ExecutionAdmissionStateError("USD value exponent is outside the safe range");
+    throw new ExecutionAdmissionStateError(
+      "USD value exponent is outside the safe range",
+    );
   }
   const digits = BigInt(`${whole}${fraction}`);
   const power = exponent - fraction.length + scale;

--- a/runtime/src/state/migrations/023_set_based_cancellation_indexes.ts
+++ b/runtime/src/state/migrations/023_set_based_cancellation_indexes.ts
@@ -1,0 +1,57 @@
+import type { SqlMigration } from "./types.js";
+
+export const SET_BASED_CANCELLATION_SCHEMA_VERSION = 23;
+
+/** Index every directed lookup used by bounded cancellation/ancestor CTEs. */
+export const setBasedCancellationIndexesMigration: SqlMigration = {
+  version: SET_BASED_CANCELLATION_SCHEMA_VERSION,
+  name: "set_based_cancellation_indexes",
+  apply: (db) => {
+    if (tableExists(db, "thread_spawn_edges")) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_thread_spawn_edges_parent_child
+          ON thread_spawn_edges(parent_thread_id, child_thread_id);
+        CREATE INDEX IF NOT EXISTS idx_thread_spawn_edges_child_parent
+          ON thread_spawn_edges(child_thread_id, parent_thread_id);
+      `);
+    }
+    if (
+      tableExists(db, "agent_jobs") &&
+      columnExists(db, "agent_jobs", "admission_run_id") &&
+      columnExists(db, "agent_jobs", "admission_parent_run_id")
+    ) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_agent_jobs_admission_parent_run
+          ON agent_jobs(admission_parent_run_id, admission_run_id)
+          WHERE admission_parent_run_id IS NOT NULL
+            AND admission_run_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_agent_jobs_admission_run_parent
+          ON agent_jobs(admission_run_id, admission_parent_run_id)
+          WHERE admission_run_id IS NOT NULL
+            AND admission_parent_run_id IS NOT NULL;
+      `);
+    }
+  },
+};
+
+function tableExists(
+  db: Parameters<NonNullable<SqlMigration["apply"]>>[0],
+  table: string,
+): boolean {
+  return (
+    db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(table) !== undefined
+  );
+}
+
+function columnExists(
+  db: Parameters<NonNullable<SqlMigration["apply"]>>[0],
+  table: string,
+  column: string,
+): boolean {
+  return db
+    .prepare<[], { readonly name: string }>(`PRAGMA table_info(${table})`)
+    .all()
+    .some((row) => row.name === column);
+}

--- a/runtime/src/state/migrations/index.ts
+++ b/runtime/src/state/migrations/index.ts
@@ -21,6 +21,7 @@ import { csvJobIdentityReplayMigration } from "./019_csv_job_identity_replay.js"
 import { toolPairProjectionSchemaMigration } from "./020_tool_pair_projection_schema.js";
 import { csvJobSchedulerMigration } from "./021_csv_job_scheduler.js";
 import { workflowHandoffArtifactsMigration } from "./022_workflow_handoff_artifacts.js";
+import { setBasedCancellationIndexesMigration } from "./023_set_based_cancellation_indexes.js";
 import type { SqlMigration } from "./types.js";
 
 /**
@@ -49,6 +50,7 @@ export const STATE_DB_MIGRATIONS: readonly SqlMigration[] = [
   toolPairProjectionSchemaMigration,
   csvJobSchedulerMigration,
   workflowHandoffArtifactsMigration,
+  setBasedCancellationIndexesMigration,
 ];
 
 export const LOGS_DB_MIGRATIONS: readonly SqlMigration[] = [

--- a/runtime/src/state/recovery.ts
+++ b/runtime/src/state/recovery.ts
@@ -1,6 +1,7 @@
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 import type { JsonObject } from "../app-server/protocol/index.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
+import { ExecutionAdmissionRepository } from "./execution-admission.js";
 import { sqlPlaceholders } from "./sql.js";
 import { normalizeToolRecoveryCategory } from "./tool-output-rotation.js";
 import {
@@ -159,6 +160,9 @@ export function recoverDaemonStateOnStartup(
   const recoveredAt = options.now?.() ?? new Date().toISOString();
   const preexistingExclusions = loadStartupRecoveryExclusions(driver);
   const startupBudget = new StartupRecoveryBudget();
+  const admissions = new ExecutionAdmissionRepository(driver, {
+    now: () => new Date(recoveredAt),
+  });
   // The rollout JSONL is the M4 authority. Rebuild its SQLite projection
   // before stale tool classification or the recoverable-run load so a crash
   // after fsyncing `run_terminal`/`effect_result` cannot resurrect or replay
@@ -213,7 +217,7 @@ export function recoverDaemonStateOnStartup(
     // Crash-mid-cascade repair MUST precede the recoverable-run load: a
     // surviving descendant of a cancelled parent is finished off here so
     // the restore loop never resurrects it.
-    repairCancelledSubtrees(driver, { now: recoveredAt });
+    repairCancelledSubtrees(driver, admissions, { now: recoveredAt });
     const recoveredToolCalls = recoverStaleToolCalls(
       driver,
       warnings,

--- a/runtime/src/state/run-admission-cancellation.ts
+++ b/runtime/src/state/run-admission-cancellation.ts
@@ -5,7 +5,8 @@ import type {
 } from "../budget/admission-types.js";
 import type { ExecutionAdmissionRepository } from "./execution-admission.js";
 import {
-  cancelAgentRunTree,
+  cancelAgentRunTreeInOperation,
+  withCancellationOperation,
   type CancelAgentRunTreeReport,
 } from "./run-cancellation.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
@@ -40,32 +41,35 @@ export function reconcileAdmissionAndRunTree(
     readonly reconciledAt: string;
   },
 ): AtomicAdmissionReconcileReport {
-  return driver.transactionImmediate(() => {
-    const reservation = admissions.getReservation(options.reservationId);
-    const admission = admissions.reconcile(
-      options.reservationId,
-      options.input,
-      { at: options.reconciledAt },
-    );
-    const isProviderOverrun =
-      admission.outcome === "provider_overrun" ||
-      (admission.outcome === "duplicate" &&
-        admission.existingStatus === "provider_overrun");
-    if (!isProviderOverrun) return { admission };
-    if (reservation === undefined) {
-      // `admissions.reconcile` normally throws first; retain a fail-closed
-      // invariant if repository behavior ever changes.
-      throw new Error(
-        `provider-overrun reservation disappeared: ${options.reservationId}`,
+  return withCancellationOperation(driver, (operation) =>
+    driver.transactionImmediate(() => {
+      const reservation = admissions.getReservation(options.reservationId);
+      const admission = admissions.reconcileInCancellationOperation(
+        operation,
+        options.reservationId,
+        options.input,
+        { at: options.reconciledAt },
       );
-    }
-    const run = cancelAgentRunTree(driver, {
-      runId: reservation.reservation.step.runId,
-      reason: "provider_overrun",
-      cancelledAt: options.reconciledAt,
-    });
-    return { admission, run };
-  });
+      const isProviderOverrun =
+        admission.outcome === "provider_overrun" ||
+        (admission.outcome === "duplicate" &&
+          admission.existingStatus === "provider_overrun");
+      if (!isProviderOverrun) return { admission };
+      if (reservation === undefined) {
+        // Reconciliation normally throws first; retain a fail-closed invariant
+        // if repository behavior ever changes.
+        throw new Error(
+          `provider-overrun reservation disappeared: ${options.reservationId}`,
+        );
+      }
+      const run = cancelAgentRunTreeInOperation(driver, operation, {
+        runId: reservation.reservation.step.runId,
+        reason: "provider_overrun",
+        cancelledAt: options.reconciledAt,
+      });
+      return { admission, run };
+    }),
+  );
 }
 
 /**
@@ -82,51 +86,62 @@ export function cancelRunTreeAndAdmission(
     readonly cancelledAt: string;
   },
 ): AtomicRunAdmissionCancellationReport {
-  return driver.transactionImmediate(() => {
-    const hasAgentRun =
-      driver
-        .prepareState<[string], { readonly found: number }>(
-          "SELECT 1 AS found FROM agent_runs WHERE id = ? LIMIT 1",
-        )
-        .get(options.runId) !== undefined;
-    const hasAdmissionState = admissions.hasRunState(options.runId);
-    const admissionAlreadyTerminal =
-      admissions.isRunCancellationLocked(options.runId);
-    if (!hasAgentRun && !hasAdmissionState) {
-      return {
-        run: {
-          runId: options.runId,
-          missing: true,
-          alreadyTerminal: false,
-          rootStatusBefore: null,
-          subtreeRunIds: [],
-          cancelledRunIds: [],
-          priorStatusById: {},
-          closedEdgeChildIds: [],
-        },
-      admission: emptyAdmissionCancellationReport(options.runId),
-      };
-    }
-
-    const agentRun = cancelAgentRunTree(driver, options);
-    const admission = admissions.cancel(options.runId, {
-      reason: options.reason,
-      cancelledAt: options.cancelledAt,
-    });
-    return {
-      run: hasAgentRun
-        ? agentRun
-        : {
-            ...agentRun,
-            missing: false,
-            admissionOnly: true,
-            alreadyTerminal: admissionAlreadyTerminal,
-            rootStatusBefore: admissionAlreadyTerminal ? "cancelled" : null,
-            subtreeRunIds: admission.affectedRunIds,
+  return withCancellationOperation(driver, (operation) =>
+    driver.transactionImmediate(() => {
+      const hasAgentRun =
+        driver
+          .prepareState<[string], { readonly found: number }>(
+            "SELECT 1 AS found FROM agent_runs WHERE id = ? LIMIT 1",
+          )
+          .get(options.runId) !== undefined;
+      const hasAdmissionState = admissions.hasRunState(options.runId);
+      const admissionAlreadyTerminal = admissions.isRunCancellationLocked(
+        options.runId,
+      );
+      if (!hasAgentRun && !hasAdmissionState) {
+        return {
+          run: {
+            runId: options.runId,
+            missing: true,
+            alreadyTerminal: false,
+            rootStatusBefore: null,
+            subtreeRunIds: [],
+            cancelledRunIds: [],
+            priorStatusById: {},
+            closedEdgeChildIds: [],
           },
-      admission,
-    };
-  });
+          admission: emptyAdmissionCancellationReport(options.runId),
+        };
+      }
+
+      const agentRun = cancelAgentRunTreeInOperation(
+        driver,
+        operation,
+        options,
+      );
+      const admission = admissions.cancelInCancellationOperation(
+        operation,
+        options.runId,
+        {
+          reason: options.reason,
+          cancelledAt: options.cancelledAt,
+        },
+      );
+      return {
+        run: hasAgentRun
+          ? agentRun
+          : {
+              ...agentRun,
+              missing: false,
+              admissionOnly: true,
+              alreadyTerminal: admissionAlreadyTerminal,
+              rootStatusBefore: admissionAlreadyTerminal ? "cancelled" : null,
+              subtreeRunIds: admission.affectedRunIds,
+            },
+        admission,
+      };
+    }),
+  );
 }
 
 function emptyAdmissionCancellationReport(

--- a/runtime/src/state/run-cancellation.ts
+++ b/runtime/src/state/run-cancellation.ts
@@ -2,9 +2,9 @@
  * Tree-scoped run cancellation + spawn admission gate (M3 final slice;
  * design: docs/design/execution-admission-kernel.md).
  *
- * `cancelAgentRunTree` walks the spawn tree in ONE transaction and moves
- * every non-terminal descendant (queued AND running) to `cancelled`, closing
- * open edges, without touching
+ * `cancelAgentRunTree` materializes the spawn tree with one bounded recursive
+ * SQL set in ONE transaction and moves every non-terminal descendant (queued
+ * AND running) to `cancelled`, closing open edges, without touching
  * `in_flight_tool_calls` (partial evidence is preserved and later
  * classified by the existing recovery category rules). Live daemon runs seal
  * their canonical rollout terminal before this rebuildable projection;
@@ -22,6 +22,9 @@
  * to `running` via the snapshot writer.
  */
 
+import { randomUUID } from "node:crypto";
+
+import type { ExecutionAdmissionRepository } from "./execution-admission.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
 
 /**
@@ -44,8 +47,54 @@ const TERMINAL_AGENT_RUN_STATUSES = new Set([
   "stopped",
 ]);
 
-/** Hard bound on ancestor walks; matches any realistic spawn depth cap. */
-const MAX_ANCESTOR_WALK = 64;
+export const MAX_CANCELLATION_RUNS = 100_000;
+export const MAX_CANCELLATION_EDGES = 1_000_000;
+export const MAX_CANCELLATION_REPAIR_ROOTS = 4_096;
+export const MAX_ANCESTOR_WALK = 64;
+
+const CANCELLATION_SET_TABLE = "agenc_cancellation_operation_runs";
+const CANCELLATION_GRAPH_SPAWN = "spawn";
+const CANCELLATION_GRAPH_ADMISSION = "spawn_admission";
+
+export type CancellationGraphKind =
+  typeof CANCELLATION_GRAPH_SPAWN | typeof CANCELLATION_GRAPH_ADMISSION;
+
+export interface CancellationOperation {
+  readonly id: string;
+}
+
+export class CancellationSetLimitError extends Error {
+  readonly code = "CANCELLATION_SET_LIMIT" as const;
+
+  constructor(
+    readonly graphKind: CancellationGraphKind,
+    readonly dimension: "runs" | "edges",
+    readonly observed: number,
+    readonly limit: number,
+  ) {
+    super(
+      `cancellation ${graphKind} ${dimension} exceed safety bound: ` +
+        `${observed} > ${limit}`,
+    );
+    this.name = "CancellationSetLimitError";
+  }
+}
+
+export class CancellationRepairDeferredError extends Error {
+  readonly code = "CANCELLATION_REPAIR_DEFERRED" as const;
+
+  constructor(
+    readonly reason:
+      | "repair_root_limit"
+      | "cancellation_run_limit"
+      | "cancellation_edge_limit",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "CancellationRepairDeferredError";
+  }
+}
 
 export function isCancelLockedAgentRunStatus(status: string): boolean {
   return (CANCEL_LOCKED_AGENT_RUN_STATUSES as readonly string[]).includes(
@@ -57,6 +106,13 @@ export function isTerminalAgentRunStatus(status: string): boolean {
   return TERMINAL_AGENT_RUN_STATUSES.has(status);
 }
 
+export type CancellationAncestorDenialReason =
+  | "parent_cancel_locked"
+  | "ancestor_parent_ambiguous"
+  | "ancestor_cycle"
+  | "ancestor_depth_exceeded"
+  | "ancestor_unresolved";
+
 export type SpawnAdmissionDecision =
   | { readonly allowed: true }
   | {
@@ -64,7 +120,7 @@ export type SpawnAdmissionDecision =
       /** Frozen AdmissionDecision vocabulary member. */
       readonly decision: "deny";
       /** Machine-readable refusal reason (no prose-only reasons). */
-      readonly reason: "parent_cancel_locked";
+      readonly reason: CancellationAncestorDenialReason;
       readonly parentRunId: string;
       readonly parentStatus: string;
     };
@@ -74,65 +130,331 @@ export class SpawnAdmissionBlockedError extends Error {
   readonly childThreadId: string;
   readonly parentRunId: string;
   readonly parentStatus: string;
+  readonly reason: CancellationAncestorDenialReason;
 
   constructor(
     childThreadId: string,
     parentRunId: string,
     parentStatus: string,
+    reason: CancellationAncestorDenialReason = "parent_cancel_locked",
   ) {
     super(
       `spawn admission denied for child ${childThreadId}: ancestor run ` +
-        `${parentRunId} is ${parentStatus}; new descendants cannot be ` +
-        `admitted under a cancel-locked run (admission decision: deny, ` +
-        `reason: parent_cancel_locked)`,
+        `${parentRunId} is ${parentStatus}; ancestry was not safely proved ` +
+        `(admission decision: deny, reason: ${reason})`,
     );
     this.name = "SpawnAdmissionBlockedError";
     this.childThreadId = childThreadId;
     this.parentRunId = parentRunId;
     this.parentStatus = parentStatus;
+    this.reason = reason;
   }
 }
 
 /**
- * Walk the ENTIRE ancestor chain of `parentThreadId` (inclusive) UP
+ * Prove the bounded ancestor chain of `parentThreadId` (inclusive) UP
  * `thread_spawn_edges`, regardless of edge status — a closed edge still
- * defines ancestry. Refuse when ANY ancestor with an `agent_runs` row is
- * cancel-locked: cancellation poisons the whole tree for new admissions,
- * so a terminal-but-revivable intermediate (e.g. a `completed` child of a
- * cancelled root) must not shield spawns below it. Allow when no run row
- * up the chain is cancel-locked (nothing durable forbids the admission).
+ * defines ancestry. A root is proved by an agent-run row, an admission row,
+ * or its canonical rollout lifecycle epoch. Refuse when ANY ancestor is
+ * cancel-locked: cancellation poisons the whole tree for new admissions, so
+ * a terminal-but-revivable intermediate (e.g. a `completed` child of a
+ * cancelled root) must not shield spawns below it.
  */
 export function checkSpawnAdmissionGate(
   driver: StateSqliteDriver,
   options: { readonly parentThreadId: string },
 ): SpawnAdmissionDecision {
-  const runStatusStmt = driver.prepareState<[string], { status?: string }>(
-    "SELECT status FROM agent_runs WHERE id = ?",
-  );
-  const parentEdgeStmt = driver.prepareState<
-    [string],
-    { parent_thread_id?: string }
-  >("SELECT parent_thread_id FROM thread_spawn_edges WHERE child_thread_id = ?");
+  const denial = inspectCancellationAncestors(driver, {
+    startRunId: options.parentThreadId,
+    graphKind: CANCELLATION_GRAPH_SPAWN,
+    allowUnpersistedStartRoot: false,
+  });
+  return denial === undefined
+    ? { allowed: true }
+    : { allowed: false, decision: "deny", ...denial };
+}
 
-  const seen = new Set<string>();
-  let current: string | undefined = options.parentThreadId;
-  for (let hop = 0; current !== undefined && hop < MAX_ANCESTOR_WALK; hop++) {
-    if (seen.has(current)) break;
-    seen.add(current);
-    const status = runStatusStmt.get(current)?.status;
-    if (status !== undefined && isCancelLockedAgentRunStatus(status)) {
+interface AncestorInspectionRow {
+  readonly run_id: string;
+  readonly status: string | null;
+  readonly cancelled: number;
+  readonly durable_identity: number;
+  readonly parents_json: string;
+}
+
+export interface CancellationAncestorDenial {
+  readonly reason: CancellationAncestorDenialReason;
+  readonly parentRunId: string;
+  readonly parentStatus: string;
+}
+
+/**
+ * Prove a bounded ancestor set with one indexed SQL walk. JavaScript only
+ * classifies the at-most-65 returned identities; it never performs graph I/O.
+ */
+export function inspectCancellationAncestors(
+  driver: StateSqliteDriver,
+  options: {
+    readonly startRunId: string;
+    readonly graphKind: CancellationGraphKind;
+    readonly explicitParentRunId?: string;
+    readonly allowUnpersistedStartRoot: boolean;
+  },
+): CancellationAncestorDenial | undefined {
+  const includeAdmission = options.graphKind === CANCELLATION_GRAPH_ADMISSION;
+  const parentEdgesSql = includeAdmission
+    ? `SELECT child_thread_id AS child_run_id,
+              parent_thread_id AS parent_run_id
+       FROM thread_spawn_edges
+       UNION
+       SELECT admission_run_id, admission_parent_run_id
+       FROM agent_jobs
+       WHERE admission_run_id IS NOT NULL
+         AND admission_parent_run_id IS NOT NULL
+       UNION
+       SELECT ?, ? WHERE ? IS NOT NULL`
+    : `SELECT child_thread_id AS child_run_id,
+              parent_thread_id AS parent_run_id
+       FROM thread_spawn_edges`;
+  const params: unknown[] = [];
+  if (includeAdmission) {
+    params.push(
+      options.startRunId,
+      options.explicitParentRunId ?? null,
+      options.explicitParentRunId ?? null,
+    );
+  }
+  params.push(options.startRunId, MAX_ANCESTOR_WALK + 1);
+  const rows = driver
+    .prepareState<unknown[], AncestorInspectionRow>(
+      `WITH RECURSIVE
+         parent_edges(child_run_id, parent_run_id) AS (
+           ${parentEdgesSql}
+         ),
+         ancestors(run_id) AS (
+           VALUES (?)
+           UNION
+           SELECT edge.parent_run_id
+           FROM parent_edges AS edge
+           JOIN ancestors AS child ON child.run_id = edge.child_run_id
+           LIMIT ?
+         )
+       SELECT ancestor.run_id,
+              run.status,
+              EXISTS (
+                SELECT 1 FROM execution_admission_cancellations AS locked
+                WHERE locked.run_id = ancestor.run_id
+              ) AS cancelled,
+              (
+                run.id IS NOT NULL OR EXISTS (
+                  SELECT 1 FROM agent_jobs AS identity_job
+                  WHERE identity_job.admission_run_id = ancestor.run_id
+                  LIMIT 1
+                ) OR EXISTS (
+                  SELECT 1 FROM run_lifecycle_epochs AS lifecycle
+                  WHERE lifecycle.run_id = ancestor.run_id
+                  LIMIT 1
+                )
+              ) AS durable_identity,
+              COALESCE(
+                json_group_array(edge.parent_run_id)
+                  FILTER (WHERE edge.parent_run_id IS NOT NULL),
+                '[]'
+              ) AS parents_json
+       FROM ancestors AS ancestor
+       LEFT JOIN agent_runs AS run ON run.id = ancestor.run_id
+       LEFT JOIN parent_edges AS edge ON edge.child_run_id = ancestor.run_id
+       GROUP BY ancestor.run_id
+       ORDER BY ancestor.run_id COLLATE BINARY`,
+    )
+    .all(...params);
+  const ancestorIds = new Set(rows.map((row) => row.run_id));
+  const parentsById = new Map<string, readonly string[]>();
+  for (const row of rows) {
+    const parents = parseAncestorParents(row.parents_json);
+    parentsById.set(row.run_id, parents);
+    if (
+      row.cancelled !== 0 ||
+      (row.status !== null &&
+        (isCancelLockedAgentRunStatus(row.status) ||
+          row.status === "provider_overrun"))
+    ) {
       return {
-        allowed: false,
-        decision: "deny",
         reason: "parent_cancel_locked",
-        parentRunId: current,
-        parentStatus: status,
+        parentRunId: row.run_id,
+        parentStatus: row.status ?? "cancelled",
       };
     }
-    current = parentEdgeStmt.get(current)?.parent_thread_id;
   }
-  return { allowed: true };
+  for (const row of rows) {
+    const parents = parentsById.get(row.run_id) ?? [];
+    if (parents.length > 1) {
+      return {
+        reason: "ancestor_parent_ambiguous",
+        parentRunId: row.run_id,
+        parentStatus: "unproved",
+      };
+    }
+  }
+  if (ancestorGraphHasCycle(parentsById)) {
+    return {
+      reason: "ancestor_cycle",
+      parentRunId: options.startRunId,
+      parentStatus: "unproved",
+    };
+  }
+  for (const row of rows) {
+    const outsideParent = (parentsById.get(row.run_id) ?? []).find(
+      (parentRunId) => !ancestorIds.has(parentRunId),
+    );
+    if (outsideParent !== undefined) {
+      return {
+        reason: "ancestor_depth_exceeded",
+        parentRunId: outsideParent,
+        parentStatus: "unproved",
+      };
+    }
+  }
+  for (const row of rows) {
+    const parents = parentsById.get(row.run_id) ?? [];
+    const unpersistedDeclaredRoot =
+      (row.run_id === options.startRunId &&
+        options.explicitParentRunId === undefined &&
+        options.allowUnpersistedStartRoot) ||
+      row.run_id === options.explicitParentRunId;
+    if (
+      parents.length === 0 &&
+      row.durable_identity === 0 &&
+      !unpersistedDeclaredRoot
+    ) {
+      return {
+        reason: "ancestor_unresolved",
+        parentRunId: row.run_id,
+        parentStatus: "unproved",
+      };
+    }
+  }
+  return undefined;
 }
+
+export function withCancellationOperation<T>(
+  driver: StateSqliteDriver,
+  operation: (context: CancellationOperation) => T,
+): T {
+  ensureCancellationSetTable(driver);
+  const context = Object.freeze({ id: randomUUID() });
+  try {
+    return operation(context);
+  } finally {
+    driver
+      .prepareState<[string]>(
+        `DELETE FROM temp.${CANCELLATION_SET_TABLE} WHERE operation_id = ?`,
+      )
+      .run(context.id);
+  }
+}
+
+export function materializeCancellationSet(
+  driver: StateSqliteDriver,
+  operation: CancellationOperation,
+  graphKind: CancellationGraphKind,
+  rootRunIds: readonly string[],
+): { readonly runCount: number; readonly edgeCount: number } {
+  const roots = [...new Set(rootRunIds)].sort(binaryCompare);
+  if (roots.length === 0) return { runCount: 0, edgeCount: 0 };
+  const graphSql =
+    graphKind === CANCELLATION_GRAPH_SPAWN
+      ? `SELECT edge.child_thread_id
+         FROM thread_spawn_edges AS edge
+         JOIN reachable AS parent ON parent.run_id = edge.parent_thread_id`
+      : `SELECT edge.child_thread_id
+         FROM thread_spawn_edges AS edge
+         JOIN reachable AS parent ON parent.run_id = edge.parent_thread_id
+         UNION
+         SELECT job.admission_run_id
+         FROM agent_jobs AS job
+         JOIN reachable AS parent
+           ON parent.run_id = job.admission_parent_run_id
+         WHERE job.admission_run_id IS NOT NULL`;
+  const rootValues = roots.map(() => "(?)").join(", ");
+  driver
+    .prepareState<[string, CancellationGraphKind]>(
+      `DELETE FROM temp.${CANCELLATION_SET_TABLE}
+       WHERE operation_id = ? AND graph_kind = ?`,
+    )
+    .run(operation.id, graphKind);
+  driver
+    .prepareState<unknown[]>(
+      `WITH RECURSIVE
+         roots(run_id) AS (VALUES ${rootValues}),
+         reachable(run_id) AS (
+           SELECT run_id FROM roots
+           UNION
+           ${graphSql}
+           LIMIT ?
+         )
+       INSERT INTO temp.${CANCELLATION_SET_TABLE} (
+         operation_id, graph_kind, run_id, is_root
+       )
+       SELECT ?, ?, reachable.run_id,
+              EXISTS (SELECT 1 FROM roots WHERE roots.run_id = reachable.run_id)
+       FROM reachable`,
+    )
+    .run(...roots, MAX_CANCELLATION_RUNS + 1, operation.id, graphKind);
+  const runCount = materializedCancellationCount(driver, operation, graphKind);
+  if (runCount > MAX_CANCELLATION_RUNS) {
+    throw new CancellationSetLimitError(
+      graphKind,
+      "runs",
+      runCount,
+      MAX_CANCELLATION_RUNS,
+    );
+  }
+  const edgeCount = countMaterializedCancellationEdges(
+    driver,
+    operation,
+    graphKind,
+  );
+  if (edgeCount > MAX_CANCELLATION_EDGES) {
+    throw new CancellationSetLimitError(
+      graphKind,
+      "edges",
+      edgeCount,
+      MAX_CANCELLATION_EDGES,
+    );
+  }
+  return { runCount, edgeCount };
+}
+
+export function materializedCancellationRunIds(
+  driver: StateSqliteDriver,
+  operation: CancellationOperation,
+  graphKind: CancellationGraphKind,
+): readonly string[] {
+  return driver
+    .prepareState<[string, CancellationGraphKind], { readonly run_id: string }>(
+      `SELECT run_id FROM temp.${CANCELLATION_SET_TABLE}
+       WHERE operation_id = ? AND graph_kind = ?
+       ORDER BY is_root DESC, run_id COLLATE BINARY`,
+    )
+    .all(operation.id, graphKind)
+    .map((row) => row.run_id);
+}
+
+export function cancellationSetMembershipSql(runIdExpression: string): string {
+  if (!/^[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)?$/u.test(runIdExpression)) {
+    throw new TypeError("cancellation run-id SQL expression is invalid");
+  }
+  return `EXISTS (
+    SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS cancellation_set
+    WHERE cancellation_set.operation_id = ?
+      AND cancellation_set.graph_kind = ?
+      AND cancellation_set.run_id = ${runIdExpression}
+  )`;
+}
+
+export const SPAWN_CANCELLATION_GRAPH = CANCELLATION_GRAPH_SPAWN;
+export const ADMISSION_CANCELLATION_GRAPH = CANCELLATION_GRAPH_ADMISSION;
 
 export interface CancelAgentRunTreeReport {
   readonly runId: string;
@@ -162,6 +484,10 @@ export interface CancelAgentRunTreeReport {
   readonly admissionVoidedReservations?: number;
   /** Dispatched reservations conservatively held atomically with the cascade. */
   readonly admissionHeldUnknownReservations?: number;
+  /** Set cardinality captured before mutation for cancellation telemetry. */
+  readonly cancellationNodeCount?: number;
+  /** Reachable graph-edge count captured from the same materialized set. */
+  readonly cancellationEdgeCount?: number;
 }
 
 /**
@@ -184,21 +510,31 @@ export function cancelAgentRunTree(
     readonly cancelledAt: string;
   },
 ): CancelAgentRunTreeReport {
-  return driver.transaction(() =>
-    cancelSubtreeLocked(driver, options.runId, options.reason, options.cancelledAt),
+  return withCancellationOperation(driver, (operation) =>
+    driver.transactionImmediate(() =>
+      cancelAgentRunTreeInOperation(driver, operation, options),
+    ),
   );
 }
 
-function cancelSubtreeLocked(
+/** Atomic-composition seam; the caller owns the surrounding operation/txn. */
+export function cancelAgentRunTreeInOperation(
   driver: StateSqliteDriver,
-  runId: string,
-  reason: string,
-  cancelledAt: string,
+  operation: CancellationOperation,
+  options: {
+    readonly runId: string;
+    readonly reason: string;
+    readonly cancelledAt: string;
+  },
 ): CancelAgentRunTreeReport {
-  const runStatusStmt = driver.prepareState<[string], { status?: string }>(
-    "SELECT status FROM agent_runs WHERE id = ?",
-  );
-  const rootStatus = runStatusStmt.get(runId)?.status;
+  const { runId, reason, cancelledAt } = options;
+  const root = driver
+    .prepareState<
+      [string],
+      { readonly status: string; readonly metadata_json: string | null }
+    >("SELECT status, metadata_json FROM agent_runs WHERE id = ?")
+    .get(runId);
+  const rootStatus = root?.status;
   if (rootStatus === undefined) {
     return {
       runId,
@@ -209,16 +545,22 @@ function cancelSubtreeLocked(
       cancelledRunIds: [],
       priorStatusById: {},
       closedEdgeChildIds: [],
+      cancellationNodeCount: 0,
+      cancellationEdgeCount: 0,
     };
   }
-  const subtree = collectSubtreeThreadIds(driver, runId);
-  const metadataStmt = driver.prepareState<
-    [string],
-    { metadata_json: string | null }
-  >("SELECT metadata_json FROM agent_runs WHERE id = ?");
-  const rootMetadata = parseJsonObjectOrEmpty(
-    metadataStmt.get(runId)?.metadata_json,
+  const materialized = materializeCancellationSet(
+    driver,
+    operation,
+    CANCELLATION_GRAPH_SPAWN,
+    [runId],
   );
+  const subtree = materializedCancellationRunIds(
+    driver,
+    operation,
+    CANCELLATION_GRAPH_SPAWN,
+  );
+  const rootMetadata = parseJsonObjectOrEmpty(root!.metadata_json);
   const repairIncompleteCancelledRoot =
     rootStatus === "cancelled" && rootMetadata.cascadeComplete !== true;
   if (isTerminalAgentRunStatus(rootStatus) && !repairIncompleteCancelledRoot) {
@@ -231,74 +573,104 @@ function cancelSubtreeLocked(
       cancelledRunIds: [],
       priorStatusById: {},
       closedEdgeChildIds: [],
+      cancellationNodeCount: materialized.runCount,
+      cancellationEdgeCount: materialized.edgeCount,
     };
   }
-
-  const cancelledRunIds: string[] = [];
-  const priorStatusById: Record<string, string> = {};
-  const closedEdgeChildIds: string[] = [];
-
-  // Status predicate is the CAS: the row is only cancelled from the exact
-  // non-terminal status read above, inside the same transaction.
-  const cancelStmt = driver.prepareState<[string, string, string, string]>(
-    `UPDATE agent_runs
-     SET status = 'cancelled',
-         last_active_at = ?,
-         metadata_json = ?
-     WHERE id = ? AND status = ?`,
+  const preState = readCancellationRunPreState(
+    driver,
+    operation,
+    CANCELLATION_GRAPH_SPAWN,
   );
-  const closeEdgeStmt = driver.prepareState<[string]>(
-    `UPDATE thread_spawn_edges
-     SET status = 'closed',
-         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-     WHERE child_thread_id = ? AND status = 'open'`,
-  );
-
-  for (const threadId of subtree) {
-    const status = runStatusStmt.get(threadId)?.status;
-    if (status !== undefined && !isTerminalAgentRunStatus(status)) {
-      const merged = JSON.stringify({
-        ...parseJsonObjectOrEmpty(metadataStmt.get(threadId)?.metadata_json),
-        cancelReason: reason,
-        cancelledBy: runId,
-        cancelledAt,
-        // The cascade is one transaction: when the root row says
-        // cascadeComplete, the whole subtree was handled — startup repair
-        // must never re-police this tree (it would re-kill descendants
-        // that were legitimately revived later).
-        ...(threadId === runId ? { cascadeComplete: true } : {}),
-      });
-      const result = cancelStmt.run(cancelledAt, merged, threadId, status);
-      if (result.changes > 0) {
-        cancelledRunIds.push(threadId);
-        priorStatusById[threadId] = status;
-      }
-    }
-    if (threadId !== runId) {
-      const closed = closeEdgeStmt.run(threadId);
-      if (closed.changes > 0) closedEdgeChildIds.push(threadId);
-    }
-  }
-
-  if (repairIncompleteCancelledRoot) {
+  const changedIds = new Set(
     driver
-      .prepareState<[string, string, string]>(
+      .prepareState<
+        [string, string, string, string, string, CancellationGraphKind],
+        { readonly id: string }
+      >(
         `UPDATE agent_runs
-         SET last_active_at = ?, metadata_json = ?
-         WHERE id = ? AND status = 'cancelled'`,
+         SET status = 'cancelled',
+             last_active_at = ?,
+             metadata_json = json_set(
+               CASE
+                 WHEN metadata_json IS NOT NULL
+                  AND json_valid(metadata_json)
+                  AND json_type(metadata_json) = 'object'
+                 THEN metadata_json ELSE '{}'
+               END,
+               '$.cancelReason', ?,
+               '$.cancelledBy', ?,
+               '$.cancelledAt', ?
+             )
+         WHERE status NOT IN (
+                 'completed', 'failed', 'cancelled', 'unknown_outcome',
+                 'errored', 'error', 'stopped'
+               )
+           AND EXISTS (
+             SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS cancellation_set
+             WHERE cancellation_set.operation_id = ?
+               AND cancellation_set.graph_kind = ?
+               AND cancellation_set.run_id = agent_runs.id
+           )
+         RETURNING id`,
       )
-      .run(
+      .all(
         cancelledAt,
-        JSON.stringify({
-          ...rootMetadata,
-          cancelReason: reason,
-          cancelledBy: runId,
-          cancelledAt,
-          cascadeComplete: true,
-        }),
+        reason,
         runId,
-      );
+        cancelledAt,
+        operation.id,
+        CANCELLATION_GRAPH_SPAWN,
+      )
+      .map((row) => row.id),
+  );
+  const closedIds = new Set(
+    driver
+      .prepareState<
+        [string, string, string, CancellationGraphKind],
+        { readonly child_thread_id: string }
+      >(
+        `UPDATE thread_spawn_edges
+         SET status = 'closed', updated_at = ?
+         WHERE child_thread_id <> ?
+           AND status = 'open'
+           AND EXISTS (
+             SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS cancellation_set
+             WHERE cancellation_set.operation_id = ?
+               AND cancellation_set.graph_kind = ?
+               AND cancellation_set.run_id = thread_spawn_edges.child_thread_id
+           )
+         RETURNING child_thread_id`,
+      )
+      .all(cancelledAt, runId, operation.id, CANCELLATION_GRAPH_SPAWN)
+      .map((row) => row.child_thread_id),
+  );
+  // The marker lands last, after every bulk mutation succeeds.
+  driver
+    .prepareState<[string, string, string, string, string]>(
+      `UPDATE agent_runs
+       SET last_active_at = ?,
+           metadata_json = json_set(
+             CASE
+               WHEN metadata_json IS NOT NULL
+                AND json_valid(metadata_json)
+                AND json_type(metadata_json) = 'object'
+               THEN metadata_json ELSE '{}'
+             END,
+             '$.cancelReason', ?,
+             '$.cancelledBy', ?,
+             '$.cancelledAt', ?,
+             '$.cascadeComplete', json('true')
+           )
+       WHERE id = ? AND status = 'cancelled'`,
+    )
+    .run(cancelledAt, reason, runId, cancelledAt, runId);
+  const cancelledRunIds = subtree.filter((id) => changedIds.has(id));
+  const priorStatusById: Record<string, string> = {};
+  for (const row of preState) {
+    if (changedIds.has(row.id)) priorStatusById[row.id] = row.status;
   }
+  const closedEdgeChildIds = subtree.filter((id) => closedIds.has(id));
 
   return {
     runId,
@@ -309,35 +681,9 @@ function cancelSubtreeLocked(
     cancelledRunIds,
     priorStatusById,
     closedEdgeChildIds,
+    cancellationNodeCount: materialized.runCount,
+    cancellationEdgeCount: materialized.edgeCount,
   };
-}
-
-/** BFS over thread_spawn_edges (any status), root first, cycle-guarded. */
-function collectSubtreeThreadIds(
-  driver: StateSqliteDriver,
-  rootThreadId: string,
-): readonly string[] {
-  const childrenStmt = driver.prepareState<
-    [string],
-    { child_thread_id: string }
-  >(
-    `SELECT child_thread_id FROM thread_spawn_edges
-     WHERE parent_thread_id = ?
-     ORDER BY child_thread_id ASC`,
-  );
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  const queue: string[] = [rootThreadId];
-  while (queue.length > 0) {
-    const current = queue.shift() as string;
-    if (seen.has(current)) continue;
-    seen.add(current);
-    ordered.push(current);
-    for (const row of childrenStmt.all(current)) {
-      if (!seen.has(row.child_thread_id)) queue.push(row.child_thread_id);
-    }
-  }
-  return ordered;
 }
 
 export interface RepairCancelledSubtreesReport {
@@ -348,57 +694,169 @@ export interface RepairCancelledSubtreesReport {
 /**
  * One-shot repair for cancelled roots whose cascade never ran, executed
  * inside the startup-recovery transaction BEFORE recoverable runs are
- * loaded. `cancelAgentRunTree` is a single transaction and stamps
- * `cascadeComplete` on the root, so cascade-cancelled trees are never
- * touched here. What remains is a root that became `cancelled` via a
- * non-cascade writer (e.g. a relayed status transition): its surviving
- * non-terminal descendants are finished off ONCE, then the root is
- * stamped `cascadeComplete` so later startups never re-police the tree —
- * a descendant legitimately revived afterwards (completed → running via a
- * follow-up message) must not be re-killed forever. Scoped to `cancelled`
- * ancestors only — descendants of completed/errored parents are
- * legitimate survivors.
+ * loaded. One admission-union set drives run/edge repair plus durable
+ * admission locking and settlement. `cascadeComplete` lands only after every
+ * projection succeeds. A quiescent revivable terminal descendant is not
+ * given a direct cancellation lock, so a later explicit revival is not
+ * re-killed by startup repair; an active admission beneath that same identity
+ * is still settled and locked. Scoped to `cancelled` ancestors only —
+ * descendants of completed/errored parents are legitimate survivors.
  */
 export function repairCancelledSubtrees(
   driver: StateSqliteDriver,
+  admissions: ExecutionAdmissionRepository,
   options: { readonly now: string },
 ): RepairCancelledSubtreesReport {
-  const cancelledRoots = driver
-    .prepareState<[], { id: string; metadata_json: string | null }>(
-      `SELECT id, metadata_json FROM agent_runs
-       WHERE status = 'cancelled'
-       ORDER BY id ASC`,
-    )
-    .all();
-  const repairedRunIds: string[] = [];
-  const statusStmt = driver.prepareState<[string], { status?: string }>(
-    "SELECT status FROM agent_runs WHERE id = ?",
-  );
-  const stampStmt = driver.prepareState<[string, string]>(
-    "UPDATE agent_runs SET metadata_json = ? WHERE id = ? AND status = 'cancelled'",
-  );
-  for (const root of cancelledRoots) {
-    const metadata = parseJsonObjectOrEmpty(root.metadata_json);
-    if (metadata.cascadeComplete === true) continue;
-    const subtree = collectSubtreeThreadIds(driver, root.id);
-    for (const threadId of subtree) {
-      if (threadId === root.id) continue;
-      const status = statusStmt.get(threadId)?.status;
-      if (status === undefined || isTerminalAgentRunStatus(status)) continue;
-      const report = cancelSubtreeLocked(
-        driver,
-        threadId,
-        "recovery_cascade_repair",
-        options.now,
-      );
-      repairedRunIds.push(...report.cancelledRunIds);
-    }
-    stampStmt.run(
-      JSON.stringify({ ...metadata, cascadeComplete: true }),
-      root.id,
+  try {
+    return withCancellationOperation(driver, (operation) =>
+      driver.transactionImmediate(() => {
+        const cancelledRoots = driver
+          .prepareState<[], { readonly id: string }>(
+            `SELECT id FROM agent_runs
+             WHERE status = 'cancelled'
+               AND (
+                 metadata_json IS NULL OR NOT json_valid(metadata_json)
+                 OR COALESCE(
+                   json_extract(metadata_json, '$.cascadeComplete'), 0
+                 ) <> 1
+               )
+             ORDER BY id COLLATE BINARY
+             LIMIT ${MAX_CANCELLATION_REPAIR_ROOTS + 1}`,
+          )
+          .all();
+        if (cancelledRoots.length > MAX_CANCELLATION_REPAIR_ROOTS) {
+          throw new CancellationRepairDeferredError(
+            "repair_root_limit",
+            `cancelled-subtree repair roots exceed safety bound: ` +
+              `${cancelledRoots.length} > ${MAX_CANCELLATION_REPAIR_ROOTS}`,
+          );
+        }
+        if (cancelledRoots.length === 0) return { repairedRunIds: [] };
+        materializeCancellationSet(
+          driver,
+          operation,
+          CANCELLATION_GRAPH_ADMISSION,
+          cancelledRoots.map((root) => root.id),
+        );
+        const ordered = materializedCancellationRunIds(
+          driver,
+          operation,
+          CANCELLATION_GRAPH_ADMISSION,
+        );
+        admissions.settleMaterializedCancellationInOperation(operation, {
+          reason: "recovery_cascade_repair",
+          cancelledAt: options.now,
+          lockScope: "repair_targets",
+        });
+        const changed = new Set(
+          driver
+            .prepareState<
+              [string, string, string, CancellationGraphKind],
+              { readonly id: string }
+            >(
+              `UPDATE agent_runs
+               SET status = 'cancelled', last_active_at = ?,
+                   metadata_json = json_set(
+                     CASE
+                       WHEN metadata_json IS NOT NULL
+                        AND json_valid(metadata_json)
+                        AND json_type(metadata_json) = 'object'
+                       THEN metadata_json ELSE '{}'
+                     END,
+                     '$.cancelReason', 'recovery_cascade_repair',
+                     '$.cancelledBy', 'recovery_cascade_repair',
+                     '$.cancelledAt', ?
+                   )
+               WHERE status NOT IN (
+                       'completed', 'failed', 'cancelled', 'unknown_outcome',
+                       'errored', 'error', 'stopped'
+                     )
+                 AND EXISTS (
+                   SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS cancellation_set
+                   WHERE cancellation_set.operation_id = ?
+                     AND cancellation_set.graph_kind = ?
+                     AND cancellation_set.run_id = agent_runs.id
+                 )
+               RETURNING id`,
+            )
+            .all(
+              options.now,
+              options.now,
+              operation.id,
+              CANCELLATION_GRAPH_ADMISSION,
+            )
+            .map((row) => row.id),
+        );
+        driver
+          .prepareState<
+            [
+              string,
+              string,
+              CancellationGraphKind,
+              string,
+              CancellationGraphKind,
+            ]
+          >(
+            `UPDATE thread_spawn_edges
+             SET status = 'closed', updated_at = ?
+             WHERE status = 'open'
+               AND EXISTS (
+                 SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS child_set
+                 WHERE child_set.operation_id = ?
+                   AND child_set.graph_kind = ?
+                   AND child_set.run_id = thread_spawn_edges.child_thread_id
+               )
+               AND EXISTS (
+                 SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS parent_set
+                 WHERE parent_set.operation_id = ?
+                   AND parent_set.graph_kind = ?
+                   AND parent_set.run_id = thread_spawn_edges.parent_thread_id
+               )`,
+          )
+          .run(
+            options.now,
+            operation.id,
+            CANCELLATION_GRAPH_ADMISSION,
+            operation.id,
+            CANCELLATION_GRAPH_ADMISSION,
+          );
+        // Stamp every incomplete root together, and only after both bulk
+        // mutations and admission settlement have succeeded.
+        driver
+          .prepareState<[string, CancellationGraphKind]>(
+            `UPDATE agent_runs
+             SET metadata_json = json_set(
+               CASE
+                 WHEN metadata_json IS NOT NULL
+                  AND json_valid(metadata_json)
+                  AND json_type(metadata_json) = 'object'
+                 THEN metadata_json ELSE '{}'
+               END,
+               '$.cascadeComplete', json('true')
+             )
+             WHERE status = 'cancelled'
+               AND EXISTS (
+                 SELECT 1 FROM temp.${CANCELLATION_SET_TABLE} AS cancellation_set
+                 WHERE cancellation_set.operation_id = ?
+                   AND cancellation_set.graph_kind = ?
+                   AND cancellation_set.is_root = 1
+                   AND cancellation_set.run_id = agent_runs.id
+               )`,
+          )
+          .run(operation.id, CANCELLATION_GRAPH_ADMISSION);
+        return { repairedRunIds: ordered.filter((id) => changed.has(id)) };
+      }),
+    );
+  } catch (error) {
+    if (!(error instanceof CancellationSetLimitError)) throw error;
+    throw new CancellationRepairDeferredError(
+      error.dimension === "runs"
+        ? "cancellation_run_limit"
+        : "cancellation_edge_limit",
+      error.message,
+      { cause: error },
     );
   }
-  return { repairedRunIds };
 }
 
 function parseJsonObjectOrEmpty(
@@ -409,10 +867,155 @@ function parseJsonObjectOrEmpty(
   }
   try {
     const parsed: unknown = JSON.parse(value);
-    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    return typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : {};
   } catch {
     return {};
   }
+}
+
+interface CancellationRunPreStateRow {
+  readonly id: string;
+  readonly status: string;
+}
+
+function readCancellationRunPreState(
+  driver: StateSqliteDriver,
+  operation: CancellationOperation,
+  graphKind: CancellationGraphKind,
+): readonly CancellationRunPreStateRow[] {
+  return driver
+    .prepareState<[string, CancellationGraphKind], CancellationRunPreStateRow>(
+      `SELECT run.id, run.status
+       FROM temp.${CANCELLATION_SET_TABLE} AS cancellation_set
+       JOIN agent_runs AS run ON run.id = cancellation_set.run_id
+       WHERE cancellation_set.operation_id = ?
+         AND cancellation_set.graph_kind = ?
+       ORDER BY cancellation_set.is_root DESC, run.id COLLATE BINARY`,
+    )
+    .all(operation.id, graphKind);
+}
+
+function ensureCancellationSetTable(driver: StateSqliteDriver): void {
+  driver
+    .prepareState(
+      `CREATE TEMP TABLE IF NOT EXISTS ${CANCELLATION_SET_TABLE} (
+       operation_id TEXT NOT NULL,
+       graph_kind TEXT NOT NULL,
+       run_id TEXT COLLATE BINARY NOT NULL,
+       is_root INTEGER NOT NULL CHECK (is_root IN (0, 1)),
+       PRIMARY KEY (operation_id, graph_kind, run_id)
+     ) WITHOUT ROWID`,
+    )
+    .run();
+}
+
+function materializedCancellationCount(
+  driver: StateSqliteDriver,
+  operation: CancellationOperation,
+  graphKind: CancellationGraphKind,
+): number {
+  return (
+    driver
+      .prepareState<
+        [string, CancellationGraphKind],
+        { readonly count: number }
+      >(
+        `SELECT COUNT(*) AS count
+         FROM temp.${CANCELLATION_SET_TABLE}
+         WHERE operation_id = ? AND graph_kind = ?`,
+      )
+      .get(operation.id, graphKind)?.count ?? 0
+  );
+}
+
+function countMaterializedCancellationEdges(
+  driver: StateSqliteDriver,
+  operation: CancellationOperation,
+  graphKind: CancellationGraphKind,
+): number {
+  const admissionEdges =
+    graphKind === CANCELLATION_GRAPH_ADMISSION
+      ? `UNION
+         SELECT job.admission_parent_run_id, job.admission_run_id
+         FROM agent_jobs AS job
+         JOIN temp.${CANCELLATION_SET_TABLE} AS parent_set
+           ON parent_set.operation_id = ?
+          AND parent_set.graph_kind = ?
+          AND parent_set.run_id = job.admission_parent_run_id
+         JOIN temp.${CANCELLATION_SET_TABLE} AS child_set
+           ON child_set.operation_id = parent_set.operation_id
+          AND child_set.graph_kind = parent_set.graph_kind
+          AND child_set.run_id = job.admission_run_id
+         WHERE job.admission_parent_run_id IS NOT NULL
+           AND job.admission_run_id IS NOT NULL`
+      : "";
+  const params: unknown[] = [operation.id, graphKind];
+  if (graphKind === CANCELLATION_GRAPH_ADMISSION) {
+    params.push(operation.id, graphKind);
+  }
+  params.push(MAX_CANCELLATION_EDGES + 1);
+  return (
+    driver
+      .prepareState<unknown[], { readonly count: number }>(
+        `SELECT COUNT(*) AS count FROM (
+           SELECT edge.parent_thread_id, edge.child_thread_id
+           FROM thread_spawn_edges AS edge
+           JOIN temp.${CANCELLATION_SET_TABLE} AS parent_set
+             ON parent_set.operation_id = ?
+            AND parent_set.graph_kind = ?
+            AND parent_set.run_id = edge.parent_thread_id
+           JOIN temp.${CANCELLATION_SET_TABLE} AS child_set
+             ON child_set.operation_id = parent_set.operation_id
+            AND child_set.graph_kind = parent_set.graph_kind
+            AND child_set.run_id = edge.child_thread_id
+           ${admissionEdges}
+           LIMIT ?
+         )`,
+      )
+      .get(...params)?.count ?? 0
+  );
+}
+
+function parseAncestorParents(value: string): readonly string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("ancestor SQL returned invalid parent JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("ancestor SQL returned a non-array parent set");
+  }
+  return [
+    ...new Set(
+      parsed.filter((item): item is string => typeof item === "string"),
+    ),
+  ].sort(binaryCompare);
+}
+
+function ancestorGraphHasCycle(
+  parentsById: ReadonlyMap<string, readonly string[]>,
+): boolean {
+  const complete = new Set<string>();
+  for (const start of parentsById.keys()) {
+    if (complete.has(start)) continue;
+    const path = new Set<string>();
+    let current: string | undefined = start;
+    while (current !== undefined && parentsById.has(current)) {
+      if (path.has(current)) return true;
+      if (complete.has(current)) break;
+      path.add(current);
+      current = parentsById.get(current)?.[0];
+    }
+    for (const visited of path) complete.add(visited);
+  }
+  return false;
+}
+
+function binaryCompare(left: string, right: string): number {
+  return Buffer.from(left).compare(Buffer.from(right));
 }

--- a/runtime/src/state/spawn-edges.ts
+++ b/runtime/src/state/spawn-edges.ts
@@ -65,6 +65,7 @@ export class ThreadSpawnEdgeRepository {
             normalized.childThreadId,
             decision.parentRunId,
             decision.parentStatus,
+            decision.reason,
           );
         }
       }

--- a/runtime/tests/agents/control.test.ts
+++ b/runtime/tests/agents/control.test.ts
@@ -27,7 +27,11 @@ import {
   SimpleMailbox,
   type InterAgentCommunication,
 } from "../session/session.js";
-import { resolveStateDatabasePaths } from "../state/sqlite-driver.js";
+import { upsertAgentRun } from "../state/agent-runs.js";
+import {
+  openStateDatabases,
+  resolveStateDatabasePaths,
+} from "../state/sqlite-driver.js";
 import type { ExecutionAdmissionClient } from "../budget/admission-client.js";
 import {
   createMailboxMetadataRecord,
@@ -37,6 +41,8 @@ import {
 
 let agencHome = "";
 let originalAgencHome = "";
+
+const TEST_RUN_TIMESTAMP = "2026-08-03T00:00:00.000Z";
 
 function stubSession(
   opts: {
@@ -102,6 +108,30 @@ function openRolloutStore(opts: {
     modelProvider: "test-provider",
   });
   return store;
+}
+
+function seedRunningAgentRun(cwd: string, runId: string): void {
+  const driver = openStateDatabases({ cwd });
+  try {
+    upsertAgentRun(driver, {
+      id: runId,
+      objective: "agent-control spawn-edge test fixture",
+      status: "running",
+      startedAt: TEST_RUN_TIMESTAMP,
+      lastActiveAt: TEST_RUN_TIMESTAMP,
+    });
+  } finally {
+    driver.close();
+  }
+}
+
+function registerDurableSessionRoot(
+  control: AgentControl,
+  cwd: string,
+  threadId: string,
+): void {
+  seedRunningAgentRun(cwd, threadId);
+  control.registerSessionRoot(threadId);
 }
 
 function roleProvenance(control: AgentControl, roleName: string) {
@@ -330,7 +360,7 @@ describe("AgentControl", () => {
         session: sessionA,
         registry: registryA,
       });
-      controlA.registerSessionRoot("root-a");
+      registerDurableSessionRoot(controlA, cwd, "root-a");
       const existing = await controlA.spawn({
         parentPath: "/root",
         threadId: "duplicate-thread",
@@ -378,7 +408,7 @@ describe("AgentControl", () => {
         session: sessionB,
         registry: registryB,
       });
-      controlB.registerSessionRoot("root-b");
+      registerDurableSessionRoot(controlB, cwd, "root-b");
       await expect(
         controlB.spawn({
           parentPath: "/root",
@@ -415,7 +445,7 @@ describe("AgentControl", () => {
       });
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry });
-      control.registerSessionRoot("nickname-root");
+      registerDurableSessionRoot(control, cwd, "nickname-root");
       registerAgentRole(control.roleWorkspace, {
         name: "single-nickname",
         config: { nicknameCandidates: ["only-nickname"] },
@@ -515,7 +545,7 @@ describe("AgentControl", () => {
       });
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry });
-      control.registerSessionRoot("reconcile-root");
+      registerDurableSessionRoot(control, cwd, "reconcile-root");
 
       const child = await control.spawn({
         parentPath: "/root",
@@ -629,7 +659,7 @@ describe("AgentControl", () => {
       });
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry });
-      control.registerSessionRoot("settlement-root");
+      registerDurableSessionRoot(control, cwd, "settlement-root");
 
       await expect(
         control.spawn({
@@ -670,7 +700,7 @@ describe("AgentControl", () => {
       });
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry, maxDepth: 2 });
-      control.registerSessionRoot("cancel-root");
+      registerDurableSessionRoot(control, cwd, "cancel-root");
       const parent = await control.spawn({
         parentPath: "/root",
         threadId: "cancel-parent",
@@ -727,7 +757,7 @@ describe("AgentControl", () => {
       const control = new AgentControl({ session, registry, maxDepth: 2 });
       const threadManager = new ThreadManager({ control, registry });
       control.bindThreadManager(threadManager);
-      control.registerSessionRoot("close-failure-root");
+      registerDurableSessionRoot(control, cwd, "close-failure-root");
       const parent = await control.spawn({
         parentPath: "/root",
         threadId: "close-failure-parent",
@@ -876,7 +906,7 @@ describe("AgentControl", () => {
       });
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry });
-      control.registerSessionRoot("root-close-failure");
+      registerDurableSessionRoot(control, cwd, "root-close-failure");
       const live = await control.spawn({
         parentPath: "/root",
         agentName: "durable_child",
@@ -1816,6 +1846,7 @@ describe("AgentControl", () => {
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry, maxDepth: 3 });
       const root = await control.spawn({ parentPath: "/root" });
+      seedRunningAgentRun(cwd, root.agentId);
       const child = await control.spawn({ parentPath: root.agentPath });
       const grandchild = await control.spawn({ parentPath: child.agentPath });
       await control.shutdownAll("manager_shutdown");
@@ -1859,6 +1890,7 @@ describe("AgentControl", () => {
         maxDepth: 3,
       });
       const root = await originalControl.spawn({ parentPath: "/root" });
+      seedRunningAgentRun(cwd, root.agentId);
       const child = await originalControl.spawn({ parentPath: root.agentPath });
       const grandchild = await originalControl.spawn({
         parentPath: child.agentPath,
@@ -1915,6 +1947,7 @@ describe("AgentControl", () => {
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry, maxDepth: 3 });
       const root = await control.spawn({ parentPath: "/root" });
+      seedRunningAgentRun(cwd, root.agentId);
       const child = await control.spawn({ parentPath: root.agentPath });
       const grandchild = await control.spawn({ parentPath: child.agentPath });
 
@@ -1947,6 +1980,7 @@ describe("AgentControl", () => {
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry, maxDepth: 3 });
       const root = await control.spawn({ parentPath: "/root" });
+      seedRunningAgentRun(cwd, root.agentId);
       const child = await control.spawn({ parentPath: root.agentPath });
       const grandchild = await control.spawn({ parentPath: child.agentPath });
       const expectedPath = grandchild.agentPath;
@@ -1987,6 +2021,7 @@ describe("AgentControl", () => {
       const registry = new AgentRegistry();
       const control = new AgentControl({ session, registry, maxDepth: 3 });
       const root = await control.spawn({ parentPath: "/root" });
+      seedRunningAgentRun(cwd, root.agentId);
       const child = await control.spawn({ parentPath: root.agentPath });
       const grandchild = await control.spawn({ parentPath: child.agentPath });
 
@@ -2032,6 +2067,7 @@ describe("AgentControl", () => {
         threadId: "real-root-child",
         agentName: "real_parent",
       });
+      seedRunningAgentRun(cwd, root.agentId);
       rolloutStore.createThreadSpawnEdge({
         childThreadId: "orphan-child",
         parentThreadId: root.agentId,

--- a/runtime/tests/agents/delegate.test.ts
+++ b/runtime/tests/agents/delegate.test.ts
@@ -102,14 +102,15 @@ function makeRealDelegateHarness(label: string) {
   const cwd = mkdtempSync(join(tmpdir(), `agenc-delegate-${label}-`));
   const priorAgencHome = process.env.AGENC_HOME;
   process.env.AGENC_HOME = cwd;
+  const parentConversationId = `${label}-parent`;
   const rolloutStore = new RolloutStore({
     cwd,
-    sessionId: label,
+    sessionId: parentConversationId,
     agencVersion: "0.6.0",
     autoStartScheduler: false,
   });
   rolloutStore.open({
-    sessionId: label,
+    sessionId: parentConversationId,
     timestamp: new Date().toISOString(),
     cwd,
     originator: "delegate-test",
@@ -120,7 +121,7 @@ function makeRealDelegateHarness(label: string) {
   const roleWorkspace = createAgentRoleWorkspace(cwd);
   const parent = {
     ...makeParentSession(),
-    conversationId: `${label}-parent`,
+    conversationId: parentConversationId,
     sessionConfiguration: { cwd },
     config: { cwd },
     roleWorkspace,

--- a/runtime/tests/session/rollout-store.test.ts
+++ b/runtime/tests/session/rollout-store.test.ts
@@ -12,9 +12,15 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import Database from "better-sqlite3";
 import type { AgentMetadata } from "../agents/registry.js";
-import { resolveStateDatabasePaths } from "../state/sqlite-driver.js";
+import { upsertAgentRun } from "../state/agent-runs.js";
+import {
+  openStateDatabases,
+  resolveStateDatabasePaths,
+} from "../state/sqlite-driver.js";
 import { RolloutStore } from "./rollout-store.js";
 import { getProjectDir, getSessionDir } from "./session-store.js";
+
+const TEST_RUN_TIMESTAMP = "2026-08-03T00:00:00.000Z";
 
 let agencHome = "";
 let originalAgencHome = "";
@@ -40,6 +46,30 @@ function openStore(opts: {
     modelProvider: "test-provider",
   });
   return store;
+}
+
+function seedRunningAgentRun(cwd: string, runId: string): void {
+  const driver = openStateDatabases({ cwd });
+  try {
+    upsertAgentRun(driver, {
+      id: runId,
+      objective: "rollout-store spawn-edge test fixture",
+      status: "running",
+      startedAt: TEST_RUN_TIMESTAMP,
+      lastActiveAt: TEST_RUN_TIMESTAMP,
+    });
+  } finally {
+    driver.close();
+  }
+}
+
+function createAdmittedThreadSpawnEdge(
+  store: RolloutStore,
+  cwd: string,
+  edge: Parameters<RolloutStore["createThreadSpawnEdge"]>[0],
+): void {
+  seedRunningAgentRun(cwd, edge.parentThreadId);
+  store.createThreadSpawnEdge(edge);
 }
 
 function metadata(
@@ -146,7 +176,7 @@ describe("RolloutStore thread-spawn edges", () => {
     };
 
     try {
-      original.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(original, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-1",
         parentPath: "/root",
@@ -252,7 +282,7 @@ describe("RolloutStore thread-spawn edges", () => {
     const sessionId = "thread-spawn-invalid-status";
     const original = openStore({ cwd, sessionId });
     try {
-      original.createThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(original, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-invalid-status",
         parentPath: "/root",
@@ -292,7 +322,7 @@ describe("RolloutStore thread-spawn edges", () => {
     const sessionId = "thread-spawn-legacy-rewrite";
     const original = openStore({ cwd, sessionId });
     try {
-      original.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(original, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-legacy",
         parentPath: "/root",
@@ -351,7 +381,7 @@ describe("RolloutStore thread-spawn edges", () => {
       agentRoleFingerprint: "default-role-fingerprint",
     };
     try {
-      store.createThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-immutable",
         parentPath: "/root",
@@ -382,7 +412,7 @@ describe("RolloutStore thread-spawn edges", () => {
         const inMemoryBefore = store.getThreadSpawnEdge("child-immutable");
 
         expect(() =>
-          store.createThreadSpawnEdge({
+          createAdmittedThreadSpawnEdge(store, cwd, {
             parentThreadId: "attacker-root",
             childThreadId: "child-immutable",
             parentPath: "/root",
@@ -408,7 +438,7 @@ describe("RolloutStore thread-spawn edges", () => {
         ).toEqual(before);
 
         expect(() =>
-          store.createThreadSpawnEdge({
+          createAdmittedThreadSpawnEdge(store, cwd, {
             parentThreadId: "root-1",
             childThreadId: "child-immutable",
             parentPath: "/root",
@@ -425,7 +455,7 @@ describe("RolloutStore thread-spawn edges", () => {
         );
 
         expect(() =>
-          store.createThreadSpawnEdge({
+          createAdmittedThreadSpawnEdge(store, cwd, {
             parentThreadId: "root-1",
             childThreadId: "child-immutable",
             parentPath: "/root",
@@ -438,7 +468,7 @@ describe("RolloutStore thread-spawn edges", () => {
         );
 
         expect(() =>
-          store.createThreadSpawnEdge({
+          createAdmittedThreadSpawnEdge(store, cwd, {
             parentThreadId: "root-1",
             childThreadId: "edge-key",
             parentPath: "/root",
@@ -449,7 +479,7 @@ describe("RolloutStore thread-spawn edges", () => {
         expect(store.getThreadSpawnEdge("edge-key")).toBeUndefined();
 
         expect(() =>
-          store.createThreadSpawnEdge({
+          createAdmittedThreadSpawnEdge(store, cwd, {
             parentThreadId: "root-1",
             childThreadId: "invalid-status-edge",
             parentPath: "/root",
@@ -470,7 +500,7 @@ describe("RolloutStore thread-spawn edges", () => {
             .get("invalid-status-edge"),
         ).toBeUndefined();
 
-        store.createThreadSpawnEdge({
+        createAdmittedThreadSpawnEdge(store, cwd, {
           parentThreadId: "root-1",
           childThreadId: "status-failure-child",
           parentPath: "/root",
@@ -517,7 +547,7 @@ describe("RolloutStore thread-spawn edges", () => {
     const first = openStore({ cwd, sessionId: "create-race-first" });
     const second = openStore({ cwd, sessionId: "create-race-second" });
     try {
-      first.createThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(first, cwd, {
         parentThreadId: "root-first",
         childThreadId: "race-child",
         parentPath: "/root",
@@ -527,7 +557,7 @@ describe("RolloutStore thread-spawn edges", () => {
       const winner = first.getThreadSpawnEdge("race-child");
 
       expect(() =>
-        second.createThreadSpawnEdge({
+        createAdmittedThreadSpawnEdge(second, cwd, {
           parentThreadId: "root-second",
           childThreadId: "race-child",
           parentPath: "/root",
@@ -547,7 +577,7 @@ describe("RolloutStore thread-spawn edges", () => {
   it("publishes a monotonic close across live stores", () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
     const first = openStore({ cwd, sessionId: "close-coherence-first" });
-    first.createThreadSpawnEdge({
+    createAdmittedThreadSpawnEdge(first, cwd, {
       parentThreadId: "root-1",
       childThreadId: "close-coherence-child",
       parentPath: "/root",
@@ -591,7 +621,7 @@ describe("RolloutStore thread-spawn edges", () => {
   it("reads current direct and descendant lists across live stores", () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
     const first = openStore({ cwd, sessionId: "list-coherence-first" });
-    first.createThreadSpawnEdge({
+    createAdmittedThreadSpawnEdge(first, cwd, {
       parentThreadId: "root-1",
       childThreadId: "list-coherence-existing",
       parentPath: "/root",
@@ -606,7 +636,7 @@ describe("RolloutStore thread-spawn edges", () => {
 
     try {
       first.setThreadSpawnEdgeStatus("list-coherence-existing", "closed");
-      first.createThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(first, cwd, {
         parentThreadId: "root-1",
         childThreadId: "list-coherence-late",
         parentPath: "/root",
@@ -660,28 +690,28 @@ describe("RolloutStore thread-spawn edges", () => {
     const store = openStore({ cwd, sessionId });
 
     try {
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-z",
         parentPath: "/root",
         metadata: metadata("child-z", "/root/alpha", 1),
         status: "closed",
       });
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-a",
         parentPath: "/root",
         metadata: metadata("child-a", "/root/zulu", 1),
         status: "open",
       });
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "child-z",
         childThreadId: "grandchild-a",
         parentPath: "/root/alpha",
         metadata: metadata("grandchild-a", "/root/alpha/scout", 2),
         status: "open",
       });
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "child-a",
         childThreadId: "grandchild-b",
         parentPath: "/root/zulu",
@@ -716,21 +746,21 @@ describe("RolloutStore thread-spawn edges", () => {
     const store = openStore({ cwd, sessionId });
 
     try {
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-open",
         parentPath: "/root",
         metadata: metadata("child-open", "/root/open", 1),
         status: "open",
       });
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-closed",
         parentPath: "/root",
         metadata: metadata("child-closed", "/root/closed", 1),
         status: "closed",
       });
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "child-closed",
         childThreadId: "grandchild-open",
         parentPath: "/root/closed",
@@ -762,14 +792,14 @@ describe("RolloutStore thread-spawn edges", () => {
     const store = openStore({ cwd, sessionId });
 
     try {
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-a",
         parentPath: "/root",
         metadata: metadata("child-a", "/root/duplicate", 1),
         status: "open",
       });
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-b",
         parentPath: "/root",
@@ -839,7 +869,7 @@ describe("RolloutStore thread-spawn edges", () => {
       expect(backups).toHaveLength(1);
       expect(existsSync(snapshotPath)).toBe(true);
 
-      store.upsertThreadSpawnEdge({
+      createAdmittedThreadSpawnEdge(store, cwd, {
         parentThreadId: "root-1",
         childThreadId: "child-after-corrupt",
         parentPath: "/root",

--- a/runtime/tests/state/csv-job-scheduler.test.ts
+++ b/runtime/tests/state/csv-job-scheduler.test.ts
@@ -13,7 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runtimeRootPath } from "../helpers/source-path.ts";
 import { MAX_CSV_JOB_REGISTRATION_HOLD_MS } from "../../src/contracts/csv-job-contract.js";
 import { CsvAgentJobsRepository } from "./csv-agent-jobs.js";
-import { WORKFLOW_HANDOFF_ARTIFACTS_SCHEMA_VERSION } from "./migrations/022_workflow_handoff_artifacts.js";
+import { SET_BASED_CANCELLATION_SCHEMA_VERSION } from "./migrations/023_set_based_cancellation_indexes.js";
 import { STATE_DB_MIGRATIONS } from "./migrations/index.js";
 import {
   STATE_PRE_V21_BACKUP_FILENAME,
@@ -598,7 +598,7 @@ describe("CSV scheduler migration", () => {
           "SELECT MAX(version) AS version FROM schema_migrations",
         )
         .get()?.version,
-    ).toBe(WORKFLOW_HANDOFF_ARTIFACTS_SCHEMA_VERSION);
+    ).toBe(SET_BASED_CANCELLATION_SCHEMA_VERSION);
     expect(
       driver
         .prepareState<[], { readonly name: string }>(

--- a/runtime/tests/state/execution-admission.test.ts
+++ b/runtime/tests/state/execution-admission.test.ts
@@ -12,9 +12,10 @@ import {
   ExecutionAdmissionRepository,
   NANO_USD_PER_USD,
 } from "../../src/state/execution-admission.js";
-import { WORKFLOW_HANDOFF_ARTIFACTS_SCHEMA_VERSION } from "../../src/state/migrations/022_workflow_handoff_artifacts.js";
+import { SET_BASED_CANCELLATION_SCHEMA_VERSION } from "../../src/state/migrations/023_set_based_cancellation_indexes.js";
 import { STATE_DB_MIGRATIONS } from "../../src/state/migrations/index.js";
 import { cancelAgentRunTree } from "../../src/state/run-cancellation.js";
+import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
 import {
   applyMigrations,
   openStateDatabases,
@@ -158,11 +159,31 @@ describe("execution admission schema migration", () => {
         "execution_admission_reservations",
         "execution_admission_run_limits",
       ]);
+      const cancellationIndexes = db
+        .prepare<[], { readonly name: string }>(
+          `SELECT name FROM sqlite_master
+           WHERE type = 'index'
+             AND name IN (
+               'idx_thread_spawn_edges_parent_child',
+               'idx_thread_spawn_edges_child_parent',
+               'idx_agent_jobs_admission_parent_run',
+               'idx_agent_jobs_admission_run_parent'
+             )
+           ORDER BY name COLLATE BINARY`,
+        )
+        .all()
+        .map((row) => row.name);
+      expect(cancellationIndexes).toEqual([
+        "idx_agent_jobs_admission_parent_run",
+        "idx_agent_jobs_admission_run_parent",
+        "idx_thread_spawn_edges_child_parent",
+        "idx_thread_spawn_edges_parent_child",
+      ]);
       expect(
         db
           .prepare("SELECT MAX(version) AS version FROM schema_migrations")
           .get(),
-      ).toEqual({ version: WORKFLOW_HANDOFF_ARTIFACTS_SCHEMA_VERSION });
+      ).toEqual({ version: SET_BASED_CANCELLATION_SCHEMA_VERSION });
     } finally {
       db.close();
     }
@@ -203,6 +224,66 @@ describe("ExecutionAdmissionRepository", () => {
     expect(admissions.listJournal({ runId: "run-denied" })).toMatchObject([
       { event: "denied", reason: "unbounded_model_output" },
     ]);
+  });
+
+  it("denies ambiguous and unresolved admission ancestry with stable reasons", () => {
+    for (const id of ["spawn_parent", "declared_parent", "linked_parent"]) {
+      upsertAgentRun(driver, {
+        id,
+        objective: "ancestor proof",
+        status: "running",
+        startedAt: T0,
+        lastActiveAt: T0,
+      });
+    }
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    edges.create(
+      {
+        childThreadId: "ambiguous_child",
+        parentThreadId: "spawn_parent",
+        parentPath: "/root",
+        metadata: {
+          agentId: "ambiguous_child",
+          agentPath: "/root/ambiguous_child",
+          depth: 1,
+        },
+        status: "open",
+      },
+      { admissionGate: "import" },
+    );
+    const ambiguous = admissions.enqueue(
+      request("ambiguous_child", "turn-1", {
+        parentRunId: "declared_parent",
+      }),
+    );
+    expect(ambiguous.record).toMatchObject({
+      status: "denied",
+      reason: "ancestor_parent_ambiguous",
+    });
+
+    edges.create(
+      {
+        childThreadId: "linked_parent",
+        parentThreadId: "missing_grandparent",
+        parentPath: "/root",
+        metadata: {
+          agentId: "linked_parent",
+          agentPath: "/root/linked_parent",
+          depth: 1,
+        },
+        status: "open",
+      },
+      { admissionGate: "import" },
+    );
+    const unresolved = admissions.enqueue(
+      request("unresolved_child", "turn-1", {
+        parentRunId: "linked_parent",
+      }),
+    );
+    expect(unresolved.record).toMatchObject({
+      status: "denied",
+      reason: "ancestor_unresolved",
+    });
   });
 
   it("persists deterministic priority order, idempotent enqueue, and fallback evidence", () => {
@@ -247,9 +328,7 @@ describe("ExecutionAdmissionRepository", () => {
   it("keeps nano-USD normalization idempotent across durable retries", () => {
     const original = request("fractional-cost", "turn-1", {
       cost: 0.000489528,
-      scopes: [
-        { key: "fractional-cost-budget", maxCostUsd: 0.0004895281 },
-      ],
+      scopes: [{ key: "fractional-cost-budget", maxCostUsd: 0.0004895281 }],
     });
 
     const first = admissions.enqueue(original);

--- a/runtime/tests/state/migrations.test.ts
+++ b/runtime/tests/state/migrations.test.ts
@@ -8,9 +8,7 @@ import {
   STATE_DB_MIGRATIONS,
   type SqlMigration,
 } from "./migrations/index.js";
-import {
-  TOOL_PAIR_PROJECTION_SCHEMA_VERSION,
-} from "./migrations/020_tool_pair_projection_schema.js";
+import { TOOL_PAIR_PROJECTION_SCHEMA_VERSION } from "./migrations/020_tool_pair_projection_schema.js";
 import { applyMigrations } from "./sqlite-driver.js";
 import { StateSchemaMismatchError } from "./errors.js";
 
@@ -59,7 +57,7 @@ describe("state migration registry", () => {
   it("loads state migrations from numbered migration files in order", () => {
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.version)).toEqual([
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-      20, 21, 22,
+      20, 21, 22, 23,
     ]);
     expect(STATE_DB_MIGRATIONS.map((migration) => migration.name)).toEqual([
       "initial_state_schema",
@@ -84,6 +82,7 @@ describe("state migration registry", () => {
       "tool_pair_projection_schema",
       "csv_job_scheduler",
       "workflow_handoff_artifacts",
+      "set_based_cancellation_indexes",
     ]);
     expectMigrationVersionsAreUnique(STATE_DB_MIGRATIONS);
   });
@@ -124,6 +123,7 @@ describe("state migration registry", () => {
       "020_tool_pair_projection_schema.ts",
       "021_csv_job_scheduler.ts",
       "022_workflow_handoff_artifacts.ts",
+      "023_set_based_cancellation_indexes.ts",
     ]);
   });
 
@@ -313,10 +313,7 @@ describe("state migration registry", () => {
           )
           .all({ type: "table" })
           .map((row) => row.name),
-      ).toEqual([
-        "tool_pair_projection_entries",
-        "tool_pair_projection_runs",
-      ]);
+      ).toEqual(["tool_pair_projection_entries", "tool_pair_projection_runs"]);
     } finally {
       db.close();
     }

--- a/runtime/tests/state/run-admission-cancellation.test.ts
+++ b/runtime/tests/state/run-admission-cancellation.test.ts
@@ -6,12 +6,20 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { RuntimeAdmissionRequest } from "../../src/budget/admission-types.js";
 import { admissionRecordKey } from "../../src/budget/admission-types.js";
-import { upsertAgentRun } from "../../src/state/agent-runs.js";
+import {
+  upsertAgentRun,
+  updateAgentRunStatus,
+} from "../../src/state/agent-runs.js";
 import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
 import {
   cancelRunTreeAndAdmission,
   reconcileAdmissionAndRunTree,
 } from "../../src/state/run-admission-cancellation.js";
+import {
+  cancelAgentRunTree,
+  repairCancelledSubtrees,
+} from "../../src/state/run-cancellation.js";
+import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
 import {
   openStateDatabases,
   type StateSqliteDriver,
@@ -52,9 +60,17 @@ function seedRun(runId: string): void {
   });
 }
 
-function request(runId: string, stepId: string): RuntimeAdmissionRequest {
+function request(
+  runId: string,
+  stepId: string,
+  parentRunId?: string,
+): RuntimeAdmissionRequest {
   return {
-    step: { runId, stepId },
+    step: {
+      runId,
+      stepId,
+      ...(parentRunId === undefined ? {} : { parentRunId }),
+    },
     kind: "model_turn",
     estimate: {
       maxInputTokens: 5,
@@ -170,19 +186,55 @@ describe("atomic run/admission cancellation", () => {
     ).toBe("voided");
   });
 
+  it("keeps spawn reporting spawn-only while admission cancellation uses the graph union", () => {
+    seedRun("graph-root");
+    const admissionChild = request(
+      "admission-only-child",
+      "turn-1",
+      "graph-root",
+    );
+    expect(admissions.enqueue(admissionChild).record.status).toBe("queued");
+
+    const spawnOnly = cancelAgentRunTree(driver, {
+      runId: "graph-root",
+      reason: "spawn-only-contract",
+      cancelledAt: NOW,
+    });
+    expect(spawnOnly.subtreeRunIds).toEqual(["graph-root"]);
+    expect(
+      admissions.get(admissionRecordKey(admissionChild.step))?.status,
+    ).toBe("queued");
+
+    const combined = cancelRunTreeAndAdmission(driver, admissions, {
+      runId: "graph-root",
+      reason: "admission-union-contract",
+      cancelledAt: NOW,
+    });
+    expect(combined.run.subtreeRunIds).toEqual(["graph-root"]);
+    expect(combined.admission.affectedRunIds).toEqual([
+      "graph-root",
+      "admission-only-child",
+    ]);
+    expect(
+      admissions.get(admissionRecordKey(admissionChild.step))?.status,
+    ).toBe("cancelled");
+  });
+
   it("rolls the agent-run cascade back when admission settlement fails", () => {
     seedRun("rollback-run");
     const admission = request("rollback-run", "turn-1");
     admissions.enqueue(admission);
     const claim = admissions.claim({ key: admissionRecordKey(admission.step) });
     if (claim.kind !== "claimed") throw new Error("expected admission claim");
-    driver.prepareState(
-      `CREATE TRIGGER reject_admission_cancel
+    driver
+      .prepareState(
+        `CREATE TRIGGER reject_admission_cancel
        BEFORE UPDATE ON execution_admission_reservations
        BEGIN
          SELECT RAISE(ABORT, 'fault-injected admission failure');
        END`,
-    ).run();
+      )
+      .run();
 
     expect(() =>
       cancelRunTreeAndAdmission(driver, admissions, {
@@ -201,6 +253,205 @@ describe("atomic run/admission cancellation", () => {
     expect(
       admissions.getReservation(claim.lease.reservation.reservationId)?.status,
     ).toBe("reserved");
+  });
+
+  it("repairs overlapping roots, locks the admission union, and rolls every projection back on a late failure", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    for (const runId of ["repair_root", "repair_nested", "repair_leaf"]) {
+      seedRun(runId);
+    }
+    edges.create(
+      {
+        childThreadId: "repair_nested",
+        parentThreadId: "repair_root",
+        parentPath: "/root",
+        metadata: {
+          agentId: "repair_nested",
+          agentPath: "/root/repair_nested",
+          depth: 1,
+        },
+        status: "open",
+      },
+      { admissionGate: "import" },
+    );
+    edges.create(
+      {
+        childThreadId: "repair_leaf",
+        parentThreadId: "repair_nested",
+        parentPath: "/root/repair_nested",
+        metadata: {
+          agentId: "repair_leaf",
+          agentPath: "/root/repair_nested/repair_leaf",
+          depth: 2,
+        },
+        status: "open",
+      },
+      { admissionGate: "import" },
+    );
+
+    const reservedRequest = request(
+      "repair_leaf",
+      "reserved-step",
+      "repair_nested",
+    );
+    const dispatchedRequest = request(
+      "repair_admission_only",
+      "dispatched-step",
+      "repair_nested",
+    );
+    admissions.enqueue(reservedRequest);
+    admissions.enqueue(dispatchedRequest);
+    const reservedClaim = admissions.claim({
+      key: admissionRecordKey(reservedRequest.step),
+    });
+    const dispatchedClaim = admissions.claim({
+      key: admissionRecordKey(dispatchedRequest.step),
+    });
+    if (reservedClaim.kind !== "claimed") {
+      throw new Error("expected reserved repair claim");
+    }
+    if (dispatchedClaim.kind !== "claimed") {
+      throw new Error("expected dispatched repair claim");
+    }
+    admissions.markDispatched(
+      dispatchedClaim.lease.reservation.reservationId,
+    );
+    for (const runId of ["repair_root", "repair_nested"]) {
+      updateAgentRunStatus(driver, {
+        id: runId,
+        status: "cancelled",
+        lastActiveAt: NOW,
+      });
+    }
+    driver
+      .prepareState(
+        `CREATE TRIGGER reject_final_repair_marker
+         BEFORE UPDATE OF metadata_json ON agent_runs
+         WHEN OLD.id = 'repair_root'
+          AND json_extract(NEW.metadata_json, '$.cascadeComplete') = 1
+         BEGIN
+           SELECT RAISE(ABORT, 'fault-injected final repair failure');
+         END`,
+      )
+      .run();
+
+    expect(() =>
+      repairCancelledSubtrees(driver, admissions, { now: NOW }),
+    ).toThrow(/fault-injected final repair failure/u);
+    expect(
+      driver
+        .prepareState<[], { readonly count: number }>(
+          `SELECT COUNT(*) AS count
+           FROM execution_admission_cancellations
+           WHERE run_id IN (
+             'repair_root', 'repair_nested', 'repair_leaf',
+             'repair_admission_only'
+           )`,
+        )
+        .get()?.count,
+    ).toBe(0);
+    expect(
+      admissions.getReservation(
+        reservedClaim.lease.reservation.reservationId,
+      )?.status,
+    ).toBe("reserved");
+    expect(
+      admissions.getReservation(
+        dispatchedClaim.lease.reservation.reservationId,
+      )?.status,
+    ).toBe("dispatched");
+    expect(
+      admissions.get(admissionRecordKey(reservedRequest.step))?.status,
+    ).toBe("running");
+    expect(
+      admissions.get(admissionRecordKey(dispatchedRequest.step))?.status,
+    ).toBe("running");
+    for (const runId of ["repair_root", "repair_nested"]) {
+      const metadata = driver
+        .prepareState<[string], { readonly metadata_json: string | null }>(
+          "SELECT metadata_json FROM agent_runs WHERE id = ?",
+        )
+        .get(runId)?.metadata_json;
+      expect(JSON.parse(metadata ?? "{}").cascadeComplete).not.toBe(true);
+    }
+    expect(
+      driver
+        .prepareState<[string], { readonly status: string }>(
+          "SELECT status FROM agent_runs WHERE id = ?",
+        )
+        .get("repair_leaf")?.status,
+    ).toBe("running");
+    expect(edges.get("repair_leaf")?.status).toBe("open");
+    expect(
+      driver
+        .prepareState<[], { readonly count: number }>(
+          "SELECT COUNT(*) AS count FROM temp.agenc_cancellation_operation_runs",
+        )
+        .get()?.count,
+    ).toBe(0);
+
+    driver.prepareState("DROP TRIGGER reject_final_repair_marker").run();
+    expect(
+      repairCancelledSubtrees(driver, admissions, { now: NOW }),
+    ).toEqual({ repairedRunIds: ["repair_leaf"] });
+    expect(
+      driver
+        .prepareState<
+          [],
+          { readonly run_id: string; readonly reason: string }
+        >(
+          `SELECT run_id, reason FROM execution_admission_cancellations
+           WHERE run_id IN (
+             'repair_root', 'repair_nested', 'repair_leaf',
+             'repair_admission_only'
+           )
+           ORDER BY run_id COLLATE BINARY`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        run_id: "repair_admission_only",
+        reason: "recovery_cascade_repair",
+      },
+      { run_id: "repair_leaf", reason: "recovery_cascade_repair" },
+      { run_id: "repair_nested", reason: "recovery_cascade_repair" },
+      { run_id: "repair_root", reason: "recovery_cascade_repair" },
+    ]);
+    expect(
+      admissions.getReservation(
+        reservedClaim.lease.reservation.reservationId,
+      )?.status,
+    ).toBe("voided");
+    expect(
+      admissions.getReservation(
+        dispatchedClaim.lease.reservation.reservationId,
+      )?.status,
+    ).toBe("held_unknown");
+    expect(
+      admissions.get(admissionRecordKey(reservedRequest.step))?.status,
+    ).toBe("voided");
+    expect(
+      admissions.get(admissionRecordKey(dispatchedRequest.step))?.status,
+    ).toBe("held_unknown");
+    expect(
+      admissions.listAllocations().find(
+        (allocation) => allocation.key === "run:repair_admission_only",
+      ),
+    ).toMatchObject({
+      heldTokens: 0,
+      usedTokens: 10,
+      heldCostUsd: 0,
+      usedCostUsd: 0.01,
+    });
+    expect(edges.get("repair_leaf")?.status).toBe("closed");
+    for (const runId of ["repair_root", "repair_nested"]) {
+      const metadata = driver
+        .prepareState<[string], { readonly metadata_json: string | null }>(
+          "SELECT metadata_json FROM agent_runs WHERE id = ?",
+        )
+        .get(runId)?.metadata_json;
+      expect(JSON.parse(metadata ?? "{}").cascadeComplete).toBe(true);
+    }
   });
 
   it("repairs a previously committed provider overrun on duplicate reconciliation", () => {

--- a/runtime/tests/state/run-cancellation.test.ts
+++ b/runtime/tests/state/run-cancellation.test.ts
@@ -10,8 +10,13 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  CancellationSetLimitError,
+  CancellationRepairDeferredError,
+  MAX_ANCESTOR_WALK,
+  MAX_CANCELLATION_REPAIR_ROOTS,
+  MAX_CANCELLATION_RUNS,
   cancelAgentRunTree,
   checkSpawnAdmissionGate,
   repairCancelledSubtrees,
@@ -21,6 +26,7 @@ import {
   upsertAgentRun,
   updateAgentRunStatus,
 } from "../../src/state/agent-runs.js";
+import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
 import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
 import { recordInFlightToolCallStart } from "../../src/state/tool-output-rotation.js";
 import {
@@ -28,6 +34,7 @@ import {
   importAgentState,
 } from "../../src/state/export-import.js";
 import { recoverDaemonStateOnStartup } from "../../src/state/recovery.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
 import {
   openStateDatabases,
   type StateSqliteDriver,
@@ -36,6 +43,7 @@ import {
 let home: string;
 let cwd: string;
 let driver: StateSqliteDriver;
+let admissions: ExecutionAdmissionRepository;
 
 const T0 = "2026-07-18T00:00:00.000Z";
 const T1 = "2026-07-18T00:05:00.000Z";
@@ -45,6 +53,9 @@ beforeEach(() => {
   cwd = mkdtempSync(join(tmpdir(), "agenc-run-cancel-cwd-"));
   mkdirSync(join(cwd, ".git"));
   driver = openStateDatabases({ cwd, agencHome: home });
+  admissions = new ExecutionAdmissionRepository(driver, {
+    now: () => new Date(T1),
+  });
 });
 
 afterEach(() => {
@@ -76,7 +87,11 @@ function edge(
       childThreadId: childId,
       parentThreadId: parentId,
       parentPath,
-      metadata: { agentId: childId, agentPath: `${parentPath}/${childId}`, depth },
+      metadata: {
+        agentId: childId,
+        agentPath: `${parentPath}/${childId}`,
+        depth,
+      },
       status: "open",
     },
     opts,
@@ -143,7 +158,12 @@ describe("cancelAgentRunTree", () => {
       child_queued: "pending",
       grandchild: "working",
     });
-    for (const id of ["parent", "child_running", "child_queued", "grandchild"]) {
+    for (const id of [
+      "parent",
+      "child_running",
+      "child_queued",
+      "grandchild",
+    ]) {
       expect(statusOf(id)).toBe("cancelled");
     }
     // Terminal history is never rewritten.
@@ -246,6 +266,133 @@ describe("cancelAgentRunTree", () => {
     });
     expect([...report.cancelledRunIds].sort()).toEqual(["a", "b"]);
   });
+
+  it("reports roots first and every other identity in binary order", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    for (const id of ["zz_root", "z_child", "a0_child", "a_child"]) {
+      run(id, "running");
+    }
+    edge(edges, "z_child", "zz_root", "/root");
+    edge(edges, "a0_child", "zz_root", "/root");
+    edge(edges, "a_child", "zz_root", "/root");
+
+    const report = cancelAgentRunTree(driver, {
+      runId: "zz_root",
+      reason: "ordered-report",
+      cancelledAt: T1,
+    });
+
+    expect(report.subtreeRunIds).toEqual([
+      "zz_root",
+      "a0_child",
+      "a_child",
+      "z_child",
+    ]);
+    expect(report.cancelledRunIds).toEqual(report.subtreeRunIds);
+    expect(report.cancellationNodeCount).toBe(4);
+    expect(report.cancellationEdgeCount).toBe(3);
+  });
+
+  it("uses a fixed SQL statement budget independent of subtree cardinality", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("small_root", "running");
+    run("small_child", "running");
+    edge(edges, "small_child", "small_root", "/root");
+    run("large-root", "running");
+    driver
+      .prepareState(
+        `WITH RECURSIVE sequence(value) AS (
+           VALUES (1)
+           UNION ALL
+           SELECT value + 1 FROM sequence WHERE value < 1_000
+         )
+         INSERT INTO thread_spawn_edges (
+           child_thread_id, parent_thread_id, parent_path, metadata_json, status
+         )
+         SELECT printf('large-%04d', value),
+                CASE value WHEN 1 THEN 'large-root'
+                  ELSE printf('large-%04d', value - 1) END,
+                '/root', '{}', 'open'
+         FROM sequence`,
+      )
+      .run();
+    const prepare = vi.spyOn(driver, "prepareState");
+    prepare.mockClear();
+
+    cancelAgentRunTree(driver, {
+      runId: "small_root",
+      reason: "statement-count",
+      cancelledAt: T1,
+    });
+    const smallStatementCount = prepare.mock.calls.length;
+    prepare.mockClear();
+    const large = cancelAgentRunTree(driver, {
+      runId: "large-root",
+      reason: "statement-count",
+      cancelledAt: T1,
+    });
+
+    expect(large.subtreeRunIds).toHaveLength(1_001);
+    expect(prepare.mock.calls).toHaveLength(smallStatementCount);
+  });
+
+  it("accepts exactly the run bound and rejects the plus-one sentinel before mutation", () => {
+    const seedChain = (prefix: string, nodeCount: number): void => {
+      run(`${prefix}-000000`, "running");
+      driver
+        .prepareState<[number]>(
+          `WITH RECURSIVE sequence(value) AS (
+             VALUES (1)
+             UNION ALL
+             SELECT value + 1 FROM sequence WHERE value < ?
+           )
+           INSERT INTO thread_spawn_edges (
+             child_thread_id, parent_thread_id, parent_path,
+             metadata_json, status
+           )
+           SELECT printf('${prefix}-%06d', value),
+                  CASE value WHEN 1 THEN '${prefix}-000000'
+                    ELSE printf('${prefix}-%06d', value - 1) END,
+                  '/root', '{}', 'open'
+           FROM sequence`,
+        )
+        .run(nodeCount - 1);
+    };
+    seedChain("at-max", MAX_CANCELLATION_RUNS);
+    const atMax = cancelAgentRunTree(driver, {
+      runId: "at-max-000000",
+      reason: "bound",
+      cancelledAt: T1,
+    });
+    expect(atMax.subtreeRunIds).toHaveLength(MAX_CANCELLATION_RUNS);
+    expect(atMax.cancellationNodeCount).toBe(MAX_CANCELLATION_RUNS);
+
+    seedChain("over-max", MAX_CANCELLATION_RUNS + 1);
+    expect(() =>
+      cancelAgentRunTree(driver, {
+        runId: "over-max-000000",
+        reason: "bound",
+        cancelledAt: T1,
+      }),
+    ).toThrow(
+      expect.objectContaining<Partial<CancellationSetLimitError>>({
+        code: "CANCELLATION_SET_LIMIT",
+        dimension: "runs",
+        observed: MAX_CANCELLATION_RUNS + 1,
+        limit: MAX_CANCELLATION_RUNS,
+      }),
+    );
+    expect(statusOf("over-max-000000")).toBe("running");
+    expect(edgeStatusOf("over-max-000001")).toBe("open");
+    expect(
+      driver
+        .prepareState<[], { readonly count: number }>(
+          `SELECT COUNT(*) AS count
+           FROM temp.agenc_cancellation_operation_runs`,
+        )
+        .get()?.count,
+    ).toBe(0);
+  }, 30_000);
 });
 
 describe("spawn admission gate", () => {
@@ -253,7 +400,11 @@ describe("spawn admission gate", () => {
     const edges = new ThreadSpawnEdgeRepository(driver);
     run("parent", "running");
     edge(edges, "ok_child", "parent", "/root");
-    cancelAgentRunTree(driver, { runId: "parent", reason: "r", cancelledAt: T1 });
+    cancelAgentRunTree(driver, {
+      runId: "parent",
+      reason: "r",
+      cancelledAt: T1,
+    });
 
     run("late_child", "running");
     expect(() => edge(edges, "late_child", "parent", "/root")).toThrow(
@@ -308,14 +459,16 @@ describe("spawn admission gate", () => {
     );
   });
 
-  it("allows spawns under live parents, unknown parents, and in import mode", () => {
+  it("allows live/import parents but rejects an unresolved parent", () => {
     const edges = new ThreadSpawnEdgeRepository(driver);
     run("live_parent", "running");
     edge(edges, "child_ok", "live_parent", "/root");
     expect(edgeStatusOf("child_ok")).toBe("open");
-    // No run row anywhere up the chain: nothing durable to gate on.
-    edge(edges, "orphan_child", "unknown_thread", "/root");
-    expect(edgeStatusOf("orphan_child")).toBe("open");
+    // No run row anywhere up the chain: ancestry remains unproved.
+    expect(() =>
+      edge(edges, "orphan_child", "unknown_thread", "/root"),
+    ).toThrow(expect.objectContaining({ reason: "ancestor_unresolved" }));
+    expect(edgeStatusOf("orphan_child")).toBeUndefined();
     // Import mode records historical topology even under a cancelled run.
     cancelAgentRunTree(driver, {
       runId: "live_parent",
@@ -327,12 +480,83 @@ describe("spawn admission gate", () => {
     });
     expect(edgeStatusOf("historic_child")).toBe("open");
   });
+
+  it("accepts a canonical rollout lifecycle root as durable identity", () => {
+    const durability = new StateRunDurabilityRepository(driver);
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    durability.ensureInitialEpoch({
+      runId: "rollout_root",
+      openedAt: T0,
+    });
+
+    expect(
+      checkSpawnAdmissionGate(driver, { parentThreadId: "rollout_root" }),
+    ).toEqual({ allowed: true });
+    edge(edges, "rollout_child", "rollout_root", "/root");
+    expect(edgeStatusOf("rollout_child")).toBe("open");
+  });
+
+  it("allows depth 64 but denies depth 65 with a stable fail-closed reason", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    const seedDepth = (prefix: string, depth: number): string => {
+      const rootId = `${prefix}_0`;
+      run(rootId, "running");
+      let parentId = rootId;
+      for (let index = 1; index <= depth; index++) {
+        const childId = `${prefix}_${index}`;
+        edge(edges, childId, parentId, `/root/${parentId}`, {
+          admissionGate: "import",
+        });
+        parentId = childId;
+      }
+      return parentId;
+    };
+    const atBound = seedDepth("depth_ok", MAX_ANCESTOR_WALK);
+    expect(
+      checkSpawnAdmissionGate(driver, { parentThreadId: atBound }),
+    ).toEqual({ allowed: true });
+    const overBound = seedDepth("depth_deny", MAX_ANCESTOR_WALK + 1);
+    expect(
+      checkSpawnAdmissionGate(driver, { parentThreadId: overBound }),
+    ).toMatchObject({
+      allowed: false,
+      decision: "deny",
+      reason: "ancestor_depth_exceeded",
+      parentStatus: "unproved",
+    });
+  });
+
+  it("denies corrupt ancestor cycles instead of treating deduplication as proof", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("cycle_a", "running");
+    run("cycle_b", "running");
+    edge(edges, "cycle_b", "cycle_a", "/root", {
+      admissionGate: "import",
+    });
+    edge(edges, "cycle_a", "cycle_b", "/root/cycle_b", {
+      admissionGate: "import",
+    });
+
+    expect(
+      checkSpawnAdmissionGate(driver, { parentThreadId: "cycle_a" }),
+    ).toEqual({
+      allowed: false,
+      decision: "deny",
+      reason: "ancestor_cycle",
+      parentRunId: "cycle_a",
+      parentStatus: "unproved",
+    });
+  });
 });
 
 describe("cancel-lock stickiness", () => {
   it("refuses to move a cancelled run to a different status via update or upsert", () => {
     run("victim", "running");
-    cancelAgentRunTree(driver, { runId: "victim", reason: "r", cancelledAt: T1 });
+    cancelAgentRunTree(driver, {
+      runId: "victim",
+      reason: "r",
+      cancelledAt: T1,
+    });
 
     const updated = updateAgentRunStatus(driver, {
       id: "victim",
@@ -402,7 +626,11 @@ describe("recovery interplay", () => {
     run("done_child", "completed");
     edge(edges, "done_child", "parent", "/root");
     // Cascade cancel: parent stamped cascadeComplete, completed child kept.
-    cancelAgentRunTree(driver, { runId: "parent", reason: "r", cancelledAt: T1 });
+    cancelAgentRunTree(driver, {
+      runId: "parent",
+      reason: "r",
+      cancelledAt: T1,
+    });
     // The completed child is later legitimately revived (follow-up message).
     expect(
       updateAgentRunStatus(driver, {
@@ -432,12 +660,15 @@ describe("recovery interplay", () => {
     // First startup: survivor finished off, root stamped.
     recoverDaemonStateOnStartup(driver, { now: () => T1 });
     expect(statusOf("survivor")).toBe("cancelled");
+    expect(admissions.isRunCancellationLocked("parent")).toBe(true);
+    expect(admissions.isRunCancellationLocked("survivor")).toBe(true);
     // Completed child revived after the one-shot repair...
     updateAgentRunStatus(driver, {
       id: "done_child",
       status: "running",
       lastActiveAt: T1,
     });
+    expect(admissions.isRunCancellationLocked("done_child")).toBe(false);
     // ...survives every subsequent startup.
     recoverDaemonStateOnStartup(driver, { now: () => T1 });
     expect(statusOf("done_child")).toBe("running");
@@ -448,11 +679,133 @@ describe("recovery interplay", () => {
     run("done_parent", "completed");
     run("legit_child", "running");
     edge(edges, "legit_child", "done_parent", "/root");
-    const repair = repairCancelledSubtrees(driver, { now: T1 });
+    const repair = repairCancelledSubtrees(driver, admissions, { now: T1 });
     expect(repair.repairedRunIds).toEqual([]);
     expect(statusOf("legit_child")).toBe("running");
     const report = recoverDaemonStateOnStartup(driver, { now: () => T1 });
     expect(report.recoveredRuns.map((r) => r.id)).toContain("legit_child");
+  });
+
+  it("repairs overlapping roots as one union and stamps markers only after success", () => {
+    const edges = new ThreadSpawnEdgeRepository(driver);
+    run("repair_root", "running");
+    run("repair_nested_root", "running");
+    run("repair_leaf", "running");
+    edge(edges, "repair_nested_root", "repair_root", "/root");
+    edge(
+      edges,
+      "repair_leaf",
+      "repair_nested_root",
+      "/root/repair_nested_root",
+    );
+    updateAgentRunStatus(driver, {
+      id: "repair_root",
+      status: "cancelled",
+      lastActiveAt: T1,
+    });
+    updateAgentRunStatus(driver, {
+      id: "repair_nested_root",
+      status: "cancelled",
+      lastActiveAt: T1,
+    });
+    driver
+      .prepareState(
+        `CREATE TRIGGER fail_repair_leaf
+         BEFORE UPDATE OF status ON agent_runs
+         WHEN OLD.id = 'repair_leaf'
+         BEGIN
+           SELECT RAISE(ABORT, 'fault-injected repair failure');
+         END`,
+      )
+      .run();
+
+    expect(() => repairCancelledSubtrees(driver, admissions, { now: T1 })).toThrow(
+      /fault-injected repair failure/u,
+    );
+    for (const rootId of ["repair_root", "repair_nested_root"]) {
+      const metadata = driver
+        .prepareState<[string], { readonly metadata_json: string | null }>(
+          "SELECT metadata_json FROM agent_runs WHERE id = ?",
+        )
+        .get(rootId)?.metadata_json;
+      expect(JSON.parse(metadata ?? "{}").cascadeComplete).not.toBe(true);
+    }
+    expect(statusOf("repair_leaf")).toBe("running");
+    expect(
+      driver
+        .prepareState<[], { readonly count: number }>(
+          `SELECT COUNT(*) AS count
+           FROM temp.agenc_cancellation_operation_runs`,
+        )
+        .get()?.count,
+    ).toBe(0);
+
+    driver.prepareState("DROP TRIGGER fail_repair_leaf").run();
+    expect(repairCancelledSubtrees(driver, admissions, { now: T1 })).toEqual({
+      repairedRunIds: ["repair_leaf"],
+    });
+    expect(statusOf("repair_leaf")).toBe("cancelled");
+    for (const rootId of ["repair_root", "repair_nested_root"]) {
+      const metadata = driver
+        .prepareState<[string], { readonly metadata_json: string | null }>(
+          "SELECT metadata_json FROM agent_runs WHERE id = ?",
+        )
+        .get(rootId)?.metadata_json;
+      expect(JSON.parse(metadata ?? "{}").cascadeComplete).toBe(true);
+    }
+    expect(repairCancelledSubtrees(driver, admissions, { now: T1 })).toEqual({
+      repairedRunIds: [],
+    });
+  });
+
+  it("stamps exactly the repair-root bound and defers plus one before mutation", () => {
+    const seedCancelledRoots = (prefix: string, count: number): void => {
+      driver
+        .prepareState<[number, string, string]>(
+          `WITH RECURSIVE sequence(value) AS (
+             VALUES (1)
+             UNION ALL
+             SELECT value + 1 FROM sequence WHERE value < ?
+           )
+           INSERT INTO agent_runs (
+             id, objective, status, started_at, last_active_at, metadata_json
+           )
+           SELECT printf('${prefix}_%05d', value), 'repair bound',
+                  'cancelled', ?, ?, NULL
+           FROM sequence`,
+        )
+        .run(count, T0, T0);
+    };
+    seedCancelledRoots("at_repair_bound", MAX_CANCELLATION_REPAIR_ROOTS);
+    expect(repairCancelledSubtrees(driver, admissions, { now: T1 })).toEqual({
+      repairedRunIds: [],
+    });
+    expect(
+      driver
+        .prepareState<[], { readonly count: number }>(
+          `SELECT COUNT(*) AS count FROM agent_runs
+           WHERE id LIKE 'at_repair_bound_%'
+             AND json_extract(metadata_json, '$.cascadeComplete') = 1`,
+        )
+        .get()?.count,
+    ).toBe(MAX_CANCELLATION_REPAIR_ROOTS);
+
+    seedCancelledRoots("over_repair_bound", MAX_CANCELLATION_REPAIR_ROOTS + 1);
+    expect(() => repairCancelledSubtrees(driver, admissions, { now: T1 })).toThrow(
+      expect.objectContaining<Partial<CancellationRepairDeferredError>>({
+        code: "CANCELLATION_REPAIR_DEFERRED",
+        reason: "repair_root_limit",
+      }),
+    );
+    expect(
+      driver
+        .prepareState<[], { readonly count: number }>(
+          `SELECT COUNT(*) AS count FROM agent_runs
+           WHERE id LIKE 'over_repair_bound_%'
+             AND metadata_json IS NOT NULL`,
+        )
+        .get()?.count,
+    ).toBe(0);
   });
 });
 
@@ -465,9 +818,9 @@ describe("state import over a cancel-locked run", () => {
       reason: "r",
       cancelledAt: T1,
     });
-    expect(() => importAgentState(driver, payload, { agencHome: home })).toThrow(
-      /review-locked/,
-    );
+    expect(() =>
+      importAgentState(driver, payload, { agencHome: home }),
+    ).toThrow(/review-locked/);
     // The refusal rolled the whole transaction back: run row untouched.
     expect(statusOf("locked_run")).toBe("cancelled");
   });

--- a/runtime/tests/state/sqlite-driver.test.ts
+++ b/runtime/tests/state/sqlite-driver.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { StateSchemaMismatchError } from "./errors.js";
-import { WORKFLOW_HANDOFF_ARTIFACTS_SCHEMA_VERSION } from "./migrations/022_workflow_handoff_artifacts.js";
+import { SET_BASED_CANCELLATION_SCHEMA_VERSION } from "./migrations/023_set_based_cancellation_indexes.js";
 import {
   applyMigrations,
   openStateDatabases,
@@ -202,7 +202,7 @@ describe("openStateDatabases", () => {
             "SELECT MAX(version) AS version FROM schema_migrations",
           )
           .get()?.version,
-      ).toBe(WORKFLOW_HANDOFF_ARTIFACTS_SCHEMA_VERSION);
+      ).toBe(SET_BASED_CANCELLATION_SCHEMA_VERSION);
     } finally {
       driver.close();
     }


### PR DESCRIPTION
Implements TODO E1b set-based cancellation and admission ancestry hardening.

- replaces recursive per-node cancellation work with bounded set-based SQL materialization
- adds indexed, cycle-safe ancestry proof and canonical rollout lifecycle identities
- makes startup repair and durable admission cancellation settle in bounded batches
- adds schema v23 indexes, revert-sensitive tests, documentation, and a 1k/10k/100k benchmark

Validation:
- full npm test: 18,468 passed
- validate:runtime and agent-surface contract
- SDK build/typecheck and FND baseline
- benchmark:set-cancellation through 100,000 nodes
- exact SHA 7a21e131b240bab728e8daaa0ddcddbfe9607afc independently reviewed with no findings