### PR TITLE
feat(runtime): add bounded full-corpus memory index

### DIFF
--- a/runtime/benchmarks/memory-index/README.md
+++ b/runtime/benchmarks/memory-index/README.md
@@ -1,0 +1,18 @@
+# Full-corpus memory index benchmark
+
+This benchmark is the C3b scaling and relevance gate. It measures initial
+build, incremental update, query p50/p95, resident memory, derived database
+size, watcher convergence, one bounded audit slice, and an actual two-process
+writer-lease race against generated memory headers. The full profile covers
+10k, 100k, and 1m entries; the quick profile is a bounded local smoke.
+
+```sh
+cd runtime
+node --import tsx benchmarks/memory-index/run.mjs
+node --import tsx benchmarks/memory-index/run.mjs --full
+```
+
+`held-out.v1.json` is the versioned relevance contract. Its deliberately old
+relevant memories are absent from a newest-200 baseline. Changes to tokenizer,
+BM25, RRF, or relevance tolerances require an explicit ranking-contract review
+rather than silent constant tuning.

--- a/runtime/benchmarks/memory-index/held-out.v1.json
+++ b/runtime/benchmarks/memory-index/held-out.v1.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "suiteId": "agenc-memory-relevance-v1",
+  "newestBaselineSize": 200,
+  "minimumFullCorpusTop1Recall": 1,
+  "maximumPrecisionRegression": 0,
+  "cases": [
+    {
+      "id": "old-browser-recovery",
+      "queryTerms": ["uniquebrowserfailure"],
+      "title": "Old browser recovery",
+      "description": "uniquebrowserfailure recovery sequence"
+    },
+    {
+      "id": "old-database-migration",
+      "queryTerms": ["uniquedatabasemigration"],
+      "title": "Old database migration",
+      "description": "uniquedatabasemigration rollback notes"
+    },
+    {
+      "id": "old-unicode-cafe",
+      "queryTerms": ["cafeuniquerecall"],
+      "title": "Café incident",
+      "description": "caféuniquerecall normalization guidance"
+    }
+  ]
+}

--- a/runtime/benchmarks/memory-index/run.mjs
+++ b/runtime/benchmarks/memory-index/run.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { PersistentMemoryIndex } from "../../src/memory/full-corpus-index.ts";
+import { MemoryQueryProcessPool } from "../../src/memory/memory-query-pool.ts";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runtimeRoot = join(benchmarkRoot, "../..");
+const execFileAsync = promisify(execFile);
+const helperEntrypoint = join(
+  benchmarkRoot,
+  "../../src/memory/memory-query-helper.mjs",
+);
+const full = process.argv.includes("--full");
+const sizes = full ? [10_000, 100_000, 1_000_000] : [1_000];
+const querySamples = full ? 100 : 10;
+const points = [];
+
+for (const size of sizes) {
+  points.push(await benchmarkSize(size, querySamples));
+}
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      suiteId: "agenc-memory-index-scaling-v1",
+      profile: full ? "full" : "quick",
+      points,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+async function benchmarkSize(size, samples) {
+  const temporaryRoot = await mkdtemp(
+    join(tmpdir(), "agenc-memory-benchmark-"),
+  );
+  const memoryRoot = join(temporaryRoot, "memory");
+  const stateRoot = join(temporaryRoot, "state");
+  await mkdir(memoryRoot, { recursive: true });
+  await mkdir(stateRoot, { recursive: true });
+  const index = new PersistentMemoryIndex({
+    databasePath: join(stateRoot, "memory.sqlite"),
+    queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+  });
+  let indexClosed = false;
+  const roots = [{ path: memoryRoot, role: "global" }];
+  try {
+    const generationStarted = performance.now();
+    await generateCorpus(memoryRoot, size);
+    const generationMs = performance.now() - generationStarted;
+    const buildStarted = performance.now();
+    let refresh = await index.refresh(roots, new AbortController().signal, {
+      explicit: true,
+    });
+    while (refresh.kind === "refresh_pending") {
+      refresh = await index.refresh(roots, new AbortController().signal, {
+        explicit: true,
+      });
+    }
+    if (refresh.kind !== "complete") {
+      throw new Error(
+        `memory benchmark build did not complete: ${refresh.kind}`,
+      );
+    }
+    const buildMs = performance.now() - buildStarted;
+
+    const queryDurations = [];
+    for (let sample = 0; sample < samples; sample += 1) {
+      const started = performance.now();
+      const result = await index.query(
+        roots,
+        [`needle${sample % Math.max(1, Math.min(size, 100))}`],
+        new AbortController().signal,
+      );
+      if (result.kind !== "complete" && result.kind !== "stale") {
+        throw new Error(`memory benchmark query failed: ${result.kind}`);
+      }
+      queryDurations.push(performance.now() - started);
+    }
+
+    const updatePath = join(memoryRoot, "shard-0000", "memory-00000000.md");
+    const incrementalStarted = performance.now();
+    await writeFile(
+      updatePath,
+      memoryDocument("Updated benchmark memory", "incrementalneedle"),
+    );
+    index.recordChange({
+      rootPath: memoryRoot,
+      relativePath: join("shard-0000", "memory-00000000.md"),
+      kind: "update",
+    });
+    const incremental = await index.refresh(
+      roots,
+      new AbortController().signal,
+      { explicit: false },
+    );
+    if (incremental.kind !== "complete") {
+      throw new Error(
+        `incremental memory build did not complete: ${incremental.kind}`,
+      );
+    }
+    const incrementalUpdateMs = performance.now() - incrementalStarted;
+
+    const watchedPath = join(memoryRoot, "shard-0000", "memory-00000001.md");
+    const watcherStarted = performance.now();
+    await writeFile(
+      watchedPath,
+      memoryDocument("Watched benchmark memory", "watcherneedle"),
+    );
+    await waitForQuery(index, roots, "watcherneedle");
+    const watcherEventMs = performance.now() - watcherStarted;
+
+    const auditStarted = performance.now();
+    await index.auditSlice(roots[0], new AbortController().signal);
+    const auditSliceMs = performance.now() - auditStarted;
+
+    const contentionChanges = Math.min(size, 1_000);
+    for (let ordinal = 0; ordinal < contentionChanges; ordinal += 1) {
+      index.recordChange({
+        rootPath: memoryRoot,
+        relativePath: join(
+          "shard-0000",
+          `memory-${ordinal.toString().padStart(8, "0")}.md`,
+        ),
+        kind: "update",
+      });
+    }
+    index.close();
+    indexClosed = true;
+    const contentionStarted = performance.now();
+    const contention = await Promise.all([
+      runWriterContender(index.databasePath, memoryRoot),
+      runWriterContender(index.databasePath, memoryRoot),
+    ]);
+    const writerContentionMs = performance.now() - contentionStarted;
+    const writerContentionPendingCount = contention.filter(
+      (result) => result.kind === "refresh_pending",
+    ).length;
+
+    queryDurations.sort((left, right) => left - right);
+    return {
+      size,
+      generationMs,
+      buildMs,
+      incrementalUpdateMs,
+      watcherEventMs,
+      auditSliceMs,
+      writerContentionMs,
+      writerContentionPendingCount,
+      queryP50Ms: percentile(queryDurations, 0.5),
+      queryP95Ms: percentile(queryDurations, 0.95),
+      rssBytes: process.memoryUsage().rss,
+      databaseBytes: (await stat(join(stateRoot, "memory.sqlite"))).size,
+    };
+  } finally {
+    if (!indexClosed) index.close();
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+async function runWriterContender(databasePath, memoryRoot) {
+  const contender = join(benchmarkRoot, "writer-contender.mjs");
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", contender, databasePath, memoryRoot, helperEntrypoint],
+    {
+      cwd: runtimeRoot,
+      encoding: "utf8",
+      maxBuffer: 1_048_576,
+      timeout: 60_000,
+    },
+  );
+  return JSON.parse(stdout);
+}
+
+async function waitForQuery(index, roots, term) {
+  const deadline = performance.now() + 5_000;
+  while (performance.now() < deadline) {
+    const result = await index.query(
+      roots,
+      [term],
+      new AbortController().signal,
+    );
+    if (result.candidates.length > 0) return;
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+  }
+  throw new Error("memory benchmark watcher did not converge");
+}
+
+async function generateCorpus(memoryRoot, size) {
+  const shardSize = 1_000;
+  for (let start = 0; start < size; start += shardSize) {
+    const shard = join(
+      memoryRoot,
+      `shard-${Math.floor(start / shardSize)
+        .toString()
+        .padStart(4, "0")}`,
+    );
+    await mkdir(shard, { recursive: true });
+    const writes = [];
+    for (
+      let index = start;
+      index < Math.min(size, start + shardSize);
+      index += 1
+    ) {
+      writes.push(
+        writeFile(
+          join(shard, `memory-${index.toString().padStart(8, "0")}.md`),
+          memoryDocument(`Benchmark memory ${index}`, `needle${index % 100}`),
+        ),
+      );
+    }
+    await Promise.all(writes);
+  }
+}
+
+function memoryDocument(title, description) {
+  return `---\ntitle: ${title}\ndescription: ${description}\ntype: reference\n---\nBody.\n`;
+}
+
+function percentile(values, fraction) {
+  if (values.length === 0) return 0;
+  return values[
+    Math.min(values.length - 1, Math.floor(values.length * fraction))
+  ];
+}

--- a/runtime/benchmarks/memory-index/writer-contender.mjs
+++ b/runtime/benchmarks/memory-index/writer-contender.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+
+import { PersistentMemoryIndex } from "../../src/memory/full-corpus-index.ts";
+import { MemoryQueryProcessPool } from "../../src/memory/memory-query-pool.ts";
+
+const [databasePath, memoryRoot, helperEntrypoint] = process.argv.slice(2);
+if (!databasePath || !memoryRoot || !helperEntrypoint) {
+  throw new Error(
+    "writer contender requires database, root, and query helper paths",
+  );
+}
+
+const index = new PersistentMemoryIndex({
+  databasePath,
+  backgroundRefresh: false,
+  queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+});
+
+try {
+  const result = await index.refresh(
+    [{ path: memoryRoot, role: "global" }],
+    new AbortController().signal,
+  );
+  process.stdout.write(
+    `${JSON.stringify({
+      kind: result.kind,
+      reasons: result.roots.flatMap((root) =>
+        root.reason === undefined ? [] : [root.reason],
+      ),
+    })}\n`,
+  );
+} finally {
+  index.close();
+}

--- a/runtime/build.config.ts
+++ b/runtime/build.config.ts
@@ -20,6 +20,7 @@ const entry = [
   'src/bin/agenc.ts',
   'src/bin/agenc-main.ts',
   'src/bin/tui-trust-prompt.tsx',
+  'src/memory/memory-query-helper.mjs',
   'src/sandbox/linux-launcher/main.ts',
   'src/sandbox/linux-launcher/main-impl.ts',
   'src/tui/main.tsx',
@@ -618,6 +619,7 @@ const agencKnownMissingOptionalExternal = {
 
 export const __agencBuildConfigTest = {
   agencOptionalExternal,
+  entry,
   featureFlagLiteral,
   inlineCopiedTreeFeatureCalls,
   isBundledBareImport,

--- a/runtime/src/memory/find-relevant.ts
+++ b/runtime/src/memory/find-relevant.ts
@@ -10,6 +10,10 @@ import {
   type RankedMemoryHeader,
 } from "./recall-contract.js";
 import {
+  PersistentMemoryIndex,
+  type MemoryIndexRootSpec,
+} from "./full-corpus-index.js";
+import {
   scanMemoryRoots,
   type MemoryHeader,
 } from "./scan.js";
@@ -18,6 +22,7 @@ export interface RelevantMemory {
   readonly path: string;
   readonly mtimeMs: number;
   readonly header: MemoryHeader;
+  readonly selectionSource: "lexical" | "reranked";
 }
 
 export interface FindRelevantMemoriesOptions {
@@ -28,6 +33,25 @@ export interface FindRelevantMemoriesOptions {
   readonly alreadySurfaced?: ReadonlySet<string>;
   readonly mode?: MemoryRecallMode;
   readonly admittedMemorySelector?: AdmittedMemorySelector;
+  readonly memoryIndexDatabasePath?: string;
+}
+
+type NormalizedFindRelevantMemoriesOptions = Required<
+  Omit<
+    FindRelevantMemoriesOptions,
+    "admittedMemorySelector" | "memoryIndexDatabasePath"
+  >
+> &
+  Pick<
+    FindRelevantMemoriesOptions,
+    "admittedMemorySelector" | "memoryIndexDatabasePath"
+  >;
+
+const fullCorpusIndexes = new Map<string, PersistentMemoryIndex>();
+
+export function closeFullCorpusMemoryIndexes(): void {
+  for (const index of fullCorpusIndexes.values()) index.close();
+  fullCorpusIndexes.clear();
 }
 
 export function findRelevantMemories(
@@ -55,17 +79,23 @@ export async function findRelevantMemories(
     alreadySurfaced,
   );
   throwIfMemoryRecallAborted(options.signal);
-  const scan = await scanMemoryRoots(options.memoryDirs, options.signal);
-  if (scan.kind !== "complete") return [];
-  const headers = scan.headers.filter(
-    (header) => !options.alreadySurfaced.has(header.filePath),
-  );
-  const ranked = rankMemoryHeaders(
-    normalizeMemoryQuery(options.query),
-    headers,
-    options.mode,
-    options.signal,
-  );
+  const indexed = await tryFullCorpusRanking(options);
+  let ranked: RankedMemoryHeader[];
+  if (indexed !== null) {
+    ranked = indexed;
+  } else {
+    const scan = await scanMemoryRoots(options.memoryDirs, options.signal);
+    if (scan.kind !== "complete") return [];
+    const headers = scan.headers.filter(
+      (header) => !options.alreadySurfaced.has(header.filePath),
+    );
+    ranked = rankMemoryHeaders(
+      normalizeMemoryQuery(options.query),
+      headers,
+      options.mode,
+      options.signal,
+    );
+  }
   if (ranked.length === 0) return [];
 
   const lexicalFallback = selectLexicalFallback(ranked);
@@ -99,7 +129,10 @@ export async function findRelevantMemories(
       seen.add(candidateId);
       selected.push(entry);
     }
-    return toRelevantMemories(selected.slice(0, MAX_RELEVANT_MEMORIES));
+    return toRelevantMemories(
+      selected.slice(0, MAX_RELEVANT_MEMORIES),
+      "reranked",
+    );
   } catch (error) {
     if (isMemoryRecallAbort(error, options.signal)) {
       throw options.signal.reason ?? error;
@@ -114,10 +147,7 @@ function normalizeFindOptions(
   signal: AbortSignal | undefined,
   recentTools: readonly string[],
   alreadySurfaced: ReadonlySet<string>,
-): Required<
-  Omit<FindRelevantMemoriesOptions, "admittedMemorySelector">
-> &
-  Pick<FindRelevantMemoriesOptions, "admittedMemorySelector"> {
+): NormalizedFindRelevantMemoriesOptions {
   if (typeof queryOrOptions !== "string") {
     return {
       query: queryOrOptions.query,
@@ -128,6 +158,9 @@ function normalizeFindOptions(
       mode: queryOrOptions.mode ?? "query",
       ...(queryOrOptions.admittedMemorySelector !== undefined
         ? { admittedMemorySelector: queryOrOptions.admittedMemorySelector }
+        : {}),
+      ...(queryOrOptions.memoryIndexDatabasePath !== undefined
+        ? { memoryIndexDatabasePath: queryOrOptions.memoryIndexDatabasePath }
         : {}),
     };
   }
@@ -147,15 +180,76 @@ function normalizeFindOptions(
 function selectLexicalFallback(
   ranked: readonly RankedMemoryHeader[],
 ): RelevantMemory[] {
-  return toRelevantMemories(ranked.slice(0, MAX_RELEVANT_MEMORIES));
+  return toRelevantMemories(
+    ranked.slice(0, MAX_RELEVANT_MEMORIES),
+    "lexical",
+  );
 }
 
 function toRelevantMemories(
   ranked: readonly RankedMemoryHeader[],
+  selectionSource: RelevantMemory["selectionSource"],
 ): RelevantMemory[] {
   return ranked.map(({ header }) => ({
     path: header.filePath,
     mtimeMs: header.mtimeMs,
     header,
+    selectionSource,
   }));
+}
+
+async function tryFullCorpusRanking(
+  options: NormalizedFindRelevantMemoriesOptions,
+): Promise<RankedMemoryHeader[] | null> {
+  if (
+    options.memoryIndexDatabasePath === undefined ||
+    options.mode === "session_start"
+  ) {
+    return null;
+  }
+  const normalizedQuery = normalizeMemoryQuery(options.query);
+  if (normalizedQuery.terms.length === 0) return [];
+  const index = getFullCorpusIndex(options.memoryIndexDatabasePath);
+  const roots: MemoryIndexRootSpec[] = options.memoryDirs.map((path, rootIndex) => ({
+    path,
+    role: rootIndex === 0 ? "global" : "project",
+  }));
+  try {
+    await index.refresh(roots, options.signal);
+    const result = await index.query(roots, normalizedQuery.terms, options.signal);
+    throwIfMemoryRecallAborted(options.signal);
+    if (
+      result.kind === "unavailable" ||
+      result.kind === "query_resource_limited"
+    ) {
+      return null;
+    }
+    const ranked: RankedMemoryHeader[] = [];
+    for (const candidate of result.candidates) {
+      throwIfMemoryRecallAborted(options.signal);
+      if (options.alreadySurfaced.has(candidate.canonicalPath)) continue;
+      const header = index.readHeader(candidate);
+      if (header === null) continue;
+      ranked.push({
+        header,
+        exactPhrase: false,
+        distinctTermCoverage: 1,
+        cappedTermOccurrences: 1,
+      });
+    }
+    return ranked;
+  } catch (error) {
+    if (isMemoryRecallAbort(error, options.signal)) {
+      throw options.signal.reason ?? error;
+    }
+    return null;
+  }
+}
+
+function getFullCorpusIndex(databasePath: string): PersistentMemoryIndex {
+  const existing = fullCorpusIndexes.get(databasePath);
+  if (existing !== undefined) return existing;
+  const index = new PersistentMemoryIndex({ databasePath });
+  fullCorpusIndexes.set(databasePath, index);
+  return index;
 }

--- a/runtime/src/memory/full-corpus-contract.ts
+++ b/runtime/src/memory/full-corpus-contract.ts
@@ -1,0 +1,283 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+
+export const MEMORY_INDEX_SCHEMA_VERSION = 1;
+export const MEMORY_INDEX_POLICY_ID = "agenc-memory-index-v1";
+export const MEMORY_INDEX_DIRECTORY = "derived-indexes";
+export const MEMORY_INDEX_FILENAME = "memory-v1.sqlite";
+
+export const MAX_MEMORY_INDEX_ROOTS = 64;
+export const MAX_MEMORY_FILES_PER_ROOT = 1_000_000;
+export const MAX_MEMORY_HEADER_UTF8_BYTES = 65_536;
+export const MAX_MEMORY_PATH_UTF8_BYTES = 16_384;
+export const MAX_MEMORY_RECENT_UNION = 32;
+export const MAX_MEMORY_FTS_CANDIDATES = 200;
+export { MAX_MEMORY_SELECTOR_CANDIDATES } from "./recall-contract.js";
+export const MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE = 10_000;
+export const MAX_MEMORY_INDEX_BUILD_SLICE_MS = 30_000;
+export const MAX_MEMORY_INDEX_TOTAL_BUILD_MS = 3_600_000;
+export const MAX_MEMORY_EXPLICIT_REFRESH_WAIT_MS = 300_000;
+export const MAX_MEMORY_QUERY_TERMS = 128;
+export const MAX_MEMORY_QUERY_MS = 500;
+export const MAX_MEMORY_QUERY_RESULT_BYTES = 1_048_576;
+export const MAX_MEMORY_QUERY_PROCESSES = 4;
+export const MAX_MEMORY_QUERY_QUEUE = 64;
+export const MAX_MEMORY_INDEX_BYTES = 536_870_912;
+export const MAX_MEMORY_INDEX_WATCHERS = 64;
+export const MAX_MEMORY_INDEX_CONCURRENT_BUILDS = 2;
+export const MAX_MEMORY_INDEX_CHANGE_LOG_EVENTS = 100_000;
+export const MEMORY_INDEX_ROOT_IDLE_TTL_MS = 2_592_000_000;
+export const MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH = 64;
+export const MAX_MEMORY_INDEX_CLEANUP_MS_PER_SLICE = 1_000;
+export const MEMORY_WATCH_DEBOUNCE_MS = 100;
+export const MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE = 10_000;
+export const MAX_MEMORY_AUDIT_MS_PER_SLICE = 50;
+export const MAX_MEMORY_BUILD_OPEN_DIRECTORIES = 32;
+export const MEMORY_INDEX_BUILD_LEASE_MS = 60_000;
+export const MEMORY_AUDIT_MIN_INTERVAL_MS = 60_000;
+export const MEMORY_AUDIT_MAX_INTERVAL_MS = 86_400_000;
+export const MEMORY_AUDIT_BACKOFF_MULTIPLIER = 100;
+
+export const MEMORY_FTS_TOKENIZER = "unicode61 remove_diacritics 2";
+export const MEMORY_FTS_TERM_OPERATOR = "OR";
+export const MEMORY_BM25_TITLE_WEIGHT = 5.0;
+export const MEMORY_BM25_DESCRIPTION_WEIGHT = 2.0;
+
+export const MEMORY_RRF_K = 60;
+export const MEMORY_RRF_PROJECT_WEIGHT = 1.25;
+export const MEMORY_RRF_GLOBAL_WEIGHT = 1.0;
+export const MEMORY_RRF_RECENT_WEIGHT = 0.25;
+
+const MEMORY_FINGERPRINT_DOMAIN = Buffer.from(
+  `${MEMORY_INDEX_POLICY_ID}:header-fingerprint\0`,
+  "utf8",
+);
+const MEMORY_ID_DOMAIN = Buffer.from(
+  `${MEMORY_INDEX_POLICY_ID}:stable-memory-id\0`,
+  "utf8",
+);
+const MEMORY_ROOT_ID_DOMAIN = Buffer.from(
+  `${MEMORY_INDEX_POLICY_ID}:canonical-root-id\0`,
+  "utf8",
+);
+const LENGTH_PREFIX_BYTES = 8;
+
+export type MemoryIndexRootRole = "global" | "project";
+
+export interface MemoryFingerprintMetadata {
+  readonly title: string;
+  readonly description: string;
+  readonly type: string | null;
+}
+
+export interface MemoryRankCandidate {
+  readonly memoryId: string;
+  readonly canonicalPath: string;
+  readonly title: string;
+  readonly description: string;
+  readonly type: string | null;
+  readonly mtimeMs: number;
+  readonly size: number;
+  readonly fingerprint: string;
+  readonly rootId: string;
+  readonly rootRole: MemoryIndexRootRole;
+  readonly bm25Score?: number;
+}
+
+export interface MemoryFusedCandidate extends MemoryRankCandidate {
+  readonly fusedScore: number;
+  readonly projectPresent: boolean;
+  readonly bestRank: number;
+}
+
+export class MemoryIndexBoundaryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MemoryIndexBoundaryError";
+  }
+}
+
+export class MemoryIndexQueryResourceLimitedError extends Error {
+  readonly code = "query_resource_limited" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "MemoryIndexQueryResourceLimitedError";
+  }
+}
+
+export function memoryIndexRootId(canonicalRoot: string): string {
+  return domainSeparatedDigest(MEMORY_ROOT_ID_DOMAIN, [
+    Buffer.from(canonicalRoot.normalize("NFC"), "utf8"),
+  ]);
+}
+
+export function stableMemoryId(canonicalPath: string): string {
+  return domainSeparatedDigest(MEMORY_ID_DOMAIN, [
+    Buffer.from(canonicalPath.normalize("NFC"), "utf8"),
+  ]);
+}
+
+export function computeMemoryHeaderFingerprint(
+  boundedHeaderBytes: Uint8Array,
+  metadata: MemoryFingerprintMetadata,
+): string {
+  if (boundedHeaderBytes.byteLength > MAX_MEMORY_HEADER_UTF8_BYTES) {
+    throw new MemoryIndexBoundaryError("memory header exceeds its byte limit");
+  }
+  const normalizedMetadata = Buffer.from(
+    JSON.stringify({
+      schemaVersion: MEMORY_INDEX_SCHEMA_VERSION,
+      title: normalizeSearchableMetadata(metadata.title),
+      description: normalizeSearchableMetadata(metadata.description),
+      type:
+        metadata.type === null
+          ? null
+          : normalizeSearchableMetadata(metadata.type),
+    }),
+    "utf8",
+  );
+  return domainSeparatedDigest(MEMORY_FINGERPRINT_DOMAIN, [
+    Buffer.from(boundedHeaderBytes),
+    normalizedMetadata,
+  ]);
+}
+
+export function normalizeSearchableMetadata(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLowerCase()
+    .replaceAll("ß", "ss")
+    .replaceAll("ς", "σ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+export function buildMemoryFtsMatch(terms: readonly string[]): string {
+  if (terms.length > MAX_MEMORY_QUERY_TERMS) {
+    throw new MemoryIndexBoundaryError("memory query term count exceeds limit");
+  }
+  return terms
+    .map((term) => normalizeSearchableMetadata(term))
+    .filter((term) => term.length > 0)
+    .map((term) => `"${term.replaceAll('"', '""')}"`)
+    .join(` ${MEMORY_FTS_TERM_OPERATOR} `);
+}
+
+export function fuseMemoryRanks(input: {
+  readonly project: readonly MemoryRankCandidate[];
+  readonly global: readonly MemoryRankCandidate[];
+  readonly recent: readonly MemoryRankCandidate[];
+}): MemoryFusedCandidate[] {
+  const fused = new Map<
+    string,
+    {
+      candidate: MemoryRankCandidate;
+      score: number;
+      projectPresent: boolean;
+      bestRank: number;
+    }
+  >();
+  addRankedList(fused, input.project, MEMORY_RRF_PROJECT_WEIGHT, true, true);
+  addRankedList(fused, input.global, MEMORY_RRF_GLOBAL_WEIGHT, false, true);
+  addRankedList(
+    fused,
+    input.recent.slice(0, MAX_MEMORY_RECENT_UNION),
+    MEMORY_RRF_RECENT_WEIGHT,
+    false,
+    false,
+  );
+  return [...fused.values()]
+    .map(({ candidate, score, projectPresent, bestRank }) => ({
+      ...candidate,
+      fusedScore: score,
+      projectPresent,
+      bestRank,
+    }))
+    .sort(compareFusedCandidates);
+}
+
+function addRankedList(
+  fused: Map<
+    string,
+    {
+      candidate: MemoryRankCandidate;
+      score: number;
+      projectPresent: boolean;
+      bestRank: number;
+    }
+  >,
+  candidates: readonly MemoryRankCandidate[],
+  weight: number,
+  projectList: boolean,
+  allowNewCandidates: boolean,
+): void {
+  const seen = new Set<string>();
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index]!;
+    const identity = canonicalCandidateIdentity(candidate);
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    const rank = index + 1;
+    const prior = fused.get(identity);
+    if (prior === undefined) {
+      if (!allowNewCandidates) continue;
+      fused.set(identity, {
+        candidate,
+        score: weight / (MEMORY_RRF_K + rank),
+        projectPresent: projectList,
+        bestRank: rank,
+      });
+      continue;
+    }
+    prior.score += weight / (MEMORY_RRF_K + rank);
+    prior.projectPresent ||= projectList;
+    prior.bestRank = Math.min(prior.bestRank, rank);
+    if (projectList && prior.candidate.rootRole !== "project") {
+      prior.candidate = candidate;
+    }
+  }
+}
+
+function canonicalCandidateIdentity(candidate: MemoryRankCandidate): string {
+  return Buffer.from(candidate.canonicalPath.normalize("NFC"), "utf8").toString(
+    "base64",
+  );
+}
+
+function compareFusedCandidates(
+  left: MemoryFusedCandidate,
+  right: MemoryFusedCandidate,
+): number {
+  if (left.fusedScore !== right.fusedScore) {
+    return right.fusedScore - left.fusedScore;
+  }
+  if (left.projectPresent !== right.projectPresent) {
+    return left.projectPresent ? -1 : 1;
+  }
+  if (left.bestRank !== right.bestRank) return left.bestRank - right.bestRank;
+  const pathOrder = Buffer.compare(
+    Buffer.from(left.canonicalPath, "utf8"),
+    Buffer.from(right.canonicalPath, "utf8"),
+  );
+  if (pathOrder !== 0) return pathOrder;
+  return Buffer.compare(
+    Buffer.from(left.memoryId, "utf8"),
+    Buffer.from(right.memoryId, "utf8"),
+  );
+}
+
+function domainSeparatedDigest(
+  domain: Buffer,
+  fields: readonly Buffer[],
+): string {
+  const hash = createHash("sha256");
+  hash.update(domain);
+  for (const field of fields) {
+    const length = Buffer.alloc(LENGTH_PREFIX_BYTES);
+    length.writeBigUInt64BE(BigInt(field.byteLength));
+    hash.update(length);
+    hash.update(field);
+  }
+  return hash.digest("hex");
+}

--- a/runtime/src/memory/full-corpus-index.ts
+++ b/runtime/src/memory/full-corpus-index.ts
@@ -1,0 +1,2992 @@
+import { Buffer } from "node:buffer";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  lstatSync,
+  realpathSync,
+  statSync,
+  watch,
+  type Dir,
+  type FSWatcher,
+} from "node:fs";
+import {
+  lstat,
+  open,
+  opendir,
+  realpath,
+  type FileHandle,
+} from "node:fs/promises";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
+import { performance } from "node:perf_hooks";
+
+import type BetterSqlite3 from "better-sqlite3";
+
+import { parseFrontmatter } from "../utils/frontmatterParser.js";
+import {
+  MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE,
+  MAX_MEMORY_AUDIT_MS_PER_SLICE,
+  MAX_MEMORY_BUILD_OPEN_DIRECTORIES,
+  MAX_MEMORY_EXPLICIT_REFRESH_WAIT_MS,
+  MAX_MEMORY_FILES_PER_ROOT,
+  MAX_MEMORY_FTS_CANDIDATES,
+  MAX_MEMORY_HEADER_UTF8_BYTES,
+  MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE,
+  MAX_MEMORY_INDEX_BUILD_SLICE_MS,
+  MAX_MEMORY_INDEX_TOTAL_BUILD_MS,
+  MAX_MEMORY_INDEX_BYTES,
+  MAX_MEMORY_INDEX_CHANGE_LOG_EVENTS,
+  MAX_MEMORY_INDEX_CLEANUP_MS_PER_SLICE,
+  MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH,
+  MAX_MEMORY_INDEX_CONCURRENT_BUILDS,
+  MAX_MEMORY_INDEX_ROOTS,
+  MAX_MEMORY_INDEX_WATCHERS,
+  MAX_MEMORY_PATH_UTF8_BYTES,
+  MAX_MEMORY_RECENT_UNION,
+  MEMORY_AUDIT_BACKOFF_MULTIPLIER,
+  MEMORY_AUDIT_MAX_INTERVAL_MS,
+  MEMORY_AUDIT_MIN_INTERVAL_MS,
+  MEMORY_INDEX_DIRECTORY,
+  MEMORY_INDEX_FILENAME,
+  MEMORY_INDEX_BUILD_LEASE_MS,
+  MEMORY_INDEX_ROOT_IDLE_TTL_MS,
+  MEMORY_WATCH_DEBOUNCE_MS,
+  MemoryIndexBoundaryError,
+  MemoryIndexQueryResourceLimitedError,
+  buildMemoryFtsMatch,
+  computeMemoryHeaderFingerprint,
+  fuseMemoryRanks,
+  memoryIndexRootId,
+  normalizeSearchableMetadata,
+  stableMemoryId,
+  type MemoryFusedCandidate,
+  type MemoryIndexRootRole,
+  type MemoryRankCandidate,
+} from "./full-corpus-contract.js";
+import { MemoryQueryProcessPool } from "./memory-query-pool.js";
+import {
+  MemoryIndexCorruptionError,
+  openMemoryIndexDatabase,
+} from "./full-corpus-storage.js";
+import { parseMemoryType } from "./types.js";
+import type { FileIdentity, MemoryHeader, MemoryRootBinding } from "./scan.js";
+
+export {
+  MemoryIndexCorruptionError,
+  MemoryIndexSchemaError,
+} from "./full-corpus-storage.js";
+
+const FRONTMATTER_MAX_LINES = 30;
+const MAX_COMPLETE_GENERATIONS_PER_ROOT = 1;
+const SHA256_DIGEST_BYTES = 32;
+const DIGEST_LENGTH_PREFIX_BYTES = 8;
+const EMPTY_MEMORY_GENERATION_DIGEST = "00".repeat(SHA256_DIGEST_BYTES);
+const MEMORY_INDEX_OWNER_HEARTBEAT_MS = 60_000;
+const MEMORY_INDEX_OWNER_LEASE_MS = 180_000;
+const CHANGE_KIND_VALUES = new Set(["create", "update", "delete", "rename"]);
+
+type MemoryIndexGenerationState =
+  "staging" | "complete" | "failed" | "superseded";
+type MemoryIndexWatcherHealth = "healthy" | "degraded" | "overflow";
+
+export interface MemoryIndexRootSpec {
+  readonly path: string;
+  readonly role: MemoryIndexRootRole;
+}
+
+export interface MemoryIndexRefreshOptions {
+  readonly explicit?: boolean;
+}
+
+export interface MemoryIndexGenerationStatus {
+  readonly rootId: string;
+  readonly canonicalRoot: string;
+  readonly role: MemoryIndexRootRole;
+  readonly generationId: number | null;
+  readonly generationToken: string | null;
+  readonly state: "complete" | "refresh_pending" | "failed" | "unavailable";
+  readonly ageMs: number | null;
+  readonly watcherHealth: MemoryIndexWatcherHealth;
+  readonly auditCursor: string | null;
+  readonly reason?: string;
+}
+
+export interface MemoryIndexRefreshResult {
+  readonly kind: "complete" | "refresh_pending" | "degraded";
+  readonly roots: readonly MemoryIndexGenerationStatus[];
+}
+
+export type MemoryFullCorpusQueryResult =
+  | {
+      readonly kind: "complete" | "stale";
+      readonly candidates: readonly MemoryFusedCandidate[];
+      readonly freshness: readonly MemoryIndexGenerationStatus[];
+    }
+  | {
+      readonly kind: "unavailable" | "query_resource_limited";
+      readonly candidates: readonly [];
+      readonly freshness: readonly MemoryIndexGenerationStatus[];
+      readonly reason: string;
+    };
+
+export interface PersistentMemoryIndexOptions {
+  readonly databasePath: string;
+  readonly queryPool?: MemoryQueryProcessPool;
+  readonly now?: () => number;
+  readonly backgroundRefresh?: boolean;
+}
+
+interface RootRow {
+  readonly root_id: string;
+  readonly canonical_path: string;
+  readonly root_role: MemoryIndexRootRole;
+  readonly current_generation_id: number | null;
+  readonly last_used_at_ms: number;
+  readonly watcher_health: MemoryIndexWatcherHealth;
+  readonly audit_cursor: string | null;
+}
+
+interface GenerationRow {
+  readonly id: number;
+  readonly root_id: string;
+  readonly state: MemoryIndexGenerationState;
+  readonly generation_token: string;
+  readonly started_at_ms: number;
+  readonly completed_at_ms: number | null;
+  readonly elapsed_active_ms: number;
+  readonly discovery_operations: number;
+  readonly entry_count: number;
+  readonly indexed_bytes: number;
+  readonly digest: string | null;
+  readonly change_cursor: number;
+  readonly change_overflow: number;
+  readonly error: string | null;
+  readonly builder_owner: string | null;
+  readonly builder_lease_expires_at_ms: number | null;
+}
+
+interface WorkDirectoryRow {
+  readonly relative_path: string;
+  readonly state: "pending" | "enumerating" | "complete";
+  readonly dev: string;
+  readonly ino: string;
+  readonly mtime_ns: string;
+}
+
+interface DiscoveredFileRow {
+  readonly relative_path: string;
+}
+
+interface EntryRow {
+  readonly root_id: string;
+  readonly generation_id: number;
+  readonly memory_id: string;
+  readonly relative_path: string;
+  readonly canonical_path: string;
+  readonly title: string;
+  readonly description: string;
+  readonly memory_type: string | null;
+  readonly mtime_ms: number;
+  readonly file_size: number;
+  readonly fingerprint: string;
+  readonly file_dev: string;
+  readonly file_ino: string;
+  readonly file_mode: string;
+  readonly file_mtime_ns: string;
+  readonly file_ctime_ns: string;
+  readonly root_dev: string;
+  readonly root_ino: string;
+  readonly root_mode: string;
+  readonly root_size: string;
+  readonly root_mtime_ns: string;
+  readonly root_ctime_ns: string;
+}
+
+interface BoundRoot {
+  readonly rootId: string;
+  readonly canonicalRoot: string;
+  readonly role: MemoryIndexRootRole;
+  readonly identity: FileIdentity;
+}
+
+interface OpenDirectoryState {
+  readonly directory: Dir;
+  readonly absolutePath: string;
+  readonly beforeIdentity: DirectoryIdentity;
+}
+
+interface DirectoryIdentity {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mtimeNs: bigint;
+}
+
+interface IndexedMemoryHeader {
+  readonly memoryId: string;
+  readonly canonicalPath: string;
+  readonly title: string;
+  readonly description: string;
+  readonly type: string | null;
+  readonly mtimeMs: number;
+  readonly fileSize: number;
+  readonly fingerprint: string;
+  readonly fileIdentity: FileIdentity;
+}
+
+interface BuildSliceBudget {
+  readonly startedAt: number;
+  newEntries: number;
+  operations: number;
+}
+
+interface IncrementalChangeRow {
+  readonly sequence: number;
+  readonly relative_path: string;
+  readonly change_kind: "create" | "update" | "delete" | "rename";
+}
+
+interface PreparedIncrementalChange {
+  readonly sequence: number;
+  readonly relativePath: string;
+  readonly indexed: IndexedMemoryHeader | null | undefined;
+}
+
+type MemoryAuditPhase = "entries" | "directories";
+
+interface MemoryAuditCursor {
+  readonly phase: MemoryAuditPhase;
+  readonly relativePath: string;
+}
+
+const activeBuilds = new Set<string>();
+let activeMemoryIndexWatchers = 0;
+let activeMemoryBuildOpenDirectories = 0;
+
+export class PersistentMemoryIndex {
+  readonly databasePath: string;
+  readonly #db: BetterSqlite3.Database;
+  readonly #queryPool: MemoryQueryProcessPool;
+  readonly #now: () => number;
+  readonly #openDirectories = new Map<string, OpenDirectoryState>();
+  readonly #watchers = new Map<string, FSWatcher>();
+  readonly #watchDebounceTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  readonly #auditTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  readonly #backgroundRefreshes = new Map<string, AbortController>();
+  readonly #activeQueryRoots = new Map<string, number>();
+  readonly #sliceLocks = new Set<string>();
+  readonly #ftsAvailable: boolean;
+  readonly #backgroundRefreshEnabled: boolean;
+  readonly #builderOwner = randomUUID();
+  #ownerHeartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  #closed = false;
+
+  constructor(options: PersistentMemoryIndexOptions) {
+    this.databasePath = resolve(options.databasePath);
+    this.#queryPool = options.queryPool ?? new MemoryQueryProcessPool();
+    this.#now = options.now ?? Date.now;
+    this.#backgroundRefreshEnabled = options.backgroundRefresh ?? true;
+    const { database, ftsAvailable } = openMemoryIndexDatabase(
+      this.databasePath,
+    );
+    this.#db = database;
+    this.#ftsAvailable = ftsAvailable;
+    if (ftsAvailable) this.#recoverInterruptedEnumeration();
+  }
+
+  get ftsAvailable(): boolean {
+    return this.#ftsAvailable;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const state of this.#openDirectories.values()) {
+      void state.directory.close().catch(() => undefined);
+    }
+    activeMemoryBuildOpenDirectories -= this.#openDirectories.size;
+    this.#openDirectories.clear();
+    for (const watcher of this.#watchers.values()) watcher.close();
+    activeMemoryIndexWatchers -= this.#watchers.size;
+    this.#watchers.clear();
+    if (this.#ownerHeartbeatTimer !== null) {
+      clearTimeout(this.#ownerHeartbeatTimer);
+      this.#ownerHeartbeatTimer = null;
+    }
+    for (const timer of this.#watchDebounceTimers.values()) clearTimeout(timer);
+    this.#watchDebounceTimers.clear();
+    for (const timer of this.#auditTimers.values()) clearTimeout(timer);
+    this.#auditTimers.clear();
+    for (const controller of this.#backgroundRefreshes.values()) {
+      controller.abort(new DOMException("Memory index closed", "AbortError"));
+    }
+    this.#backgroundRefreshes.clear();
+    for (const buildKey of activeBuilds) {
+      if (buildKey.startsWith(`${this.databasePath}:`)) {
+        activeBuilds.delete(buildKey);
+      }
+    }
+    if (this.#ftsAvailable) {
+      this.#db
+        .prepare("DELETE FROM memory_index_owners WHERE owner_id = ?")
+        .run(this.#builderOwner);
+    }
+    if (this.#db.open) this.#db.close();
+  }
+
+  pollRefresh(generationToken: string): MemoryIndexGenerationStatus | null {
+    const row = this.#db
+      .prepare<
+        [string],
+        GenerationRow & {
+          canonical_path: string;
+          root_role: MemoryIndexRootRole;
+          watcher_health: MemoryIndexWatcherHealth;
+          audit_cursor: string | null;
+        }
+      >(
+        `SELECT g.*, r.canonical_path, r.root_role,
+                r.watcher_health, r.audit_cursor
+           FROM memory_index_generations g
+           JOIN memory_index_roots r ON r.root_id = g.root_id
+          WHERE g.generation_token = ?`,
+      )
+      .get(generationToken);
+    if (row === undefined) return null;
+    return {
+      rootId: row.root_id,
+      canonicalRoot: row.canonical_path,
+      role: row.root_role,
+      generationId: row.id,
+      generationToken: row.generation_token,
+      state:
+        row.state === "complete"
+          ? "complete"
+          : row.state === "staging"
+            ? "refresh_pending"
+            : "failed",
+      ageMs:
+        row.completed_at_ms === null
+          ? null
+          : Math.max(0, this.#now() - row.completed_at_ms),
+      watcherHealth: row.watcher_health,
+      auditCursor: row.audit_cursor,
+      ...(row.error === null ? {} : { reason: row.error }),
+    };
+  }
+
+  async cancelRefresh(generationToken: string): Promise<boolean> {
+    const generation = this.#db
+      .prepare<[string], GenerationRow>(
+        `SELECT * FROM memory_index_generations
+          WHERE generation_token = ? AND state = 'staging'`,
+      )
+      .get(generationToken);
+    if (generation === undefined) return false;
+    this.#backgroundRefreshes
+      .get(generation.root_id)
+      ?.abort(new DOMException("Memory refresh cancelled", "AbortError"));
+    await this.#closeGenerationDirectories(generation.root_id, generation.id);
+    this.#releaseBuildLease(generation.id);
+    this.#failGeneration(
+      generation.id,
+      new DOMException("Memory refresh cancelled", "AbortError"),
+    );
+    activeBuilds.delete(`${this.databasePath}:${generation.root_id}`);
+    return true;
+  }
+
+  async refresh(
+    rootSpecs: readonly MemoryIndexRootSpec[],
+    signal: AbortSignal,
+    options: MemoryIndexRefreshOptions = {},
+  ): Promise<MemoryIndexRefreshResult> {
+    throwIfAborted(signal);
+    validateRootSpecsBeforeIo(rootSpecs);
+    if (!this.#ftsAvailable) {
+      return {
+        kind: "degraded",
+        roots: rootSpecs.map((spec) => unavailableRootStatus(spec)),
+      };
+    }
+    const roots = await bindRoots(rootSpecs, signal);
+    for (const root of roots) this.#upsertRoot(root);
+    this.#ensureWatchers(roots);
+    const deadline =
+      performance.now() +
+      (options.explicit
+        ? MAX_MEMORY_EXPLICIT_REFRESH_WAIT_MS
+        : MAX_MEMORY_INDEX_BUILD_SLICE_MS);
+    const statuses: MemoryIndexGenerationStatus[] = [];
+    for (const root of roots) {
+      throwIfAborted(signal);
+      let status = await this.#refreshRootSlice(
+        root,
+        signal,
+        options.explicit === true,
+      );
+      while (
+        options.explicit === true &&
+        status.state === "refresh_pending" &&
+        performance.now() < deadline
+      ) {
+        await yieldToEventLoop();
+        status = await this.#refreshRootSlice(root, signal, false);
+      }
+      statuses.push(status);
+    }
+    if (options.explicit !== true && this.#backgroundRefreshEnabled) {
+      for (let index = 0; index < roots.length; index += 1) {
+        if (statuses[index]?.state === "refresh_pending") {
+          this.#scheduleBackgroundRefresh(roots[index]!);
+        }
+      }
+    }
+    this.cleanupUnusedRoots();
+    if (
+      statuses.every(
+        (status) =>
+          status.state === "complete" && status.watcherHealth === "healthy",
+      )
+    ) {
+      return { kind: "complete", roots: statuses };
+    }
+    if (statuses.some((status) => status.state === "refresh_pending")) {
+      return { kind: "refresh_pending", roots: statuses };
+    }
+    return { kind: "degraded", roots: statuses };
+  }
+
+  async query(
+    rootSpecs: readonly MemoryIndexRootSpec[],
+    terms: readonly string[],
+    signal: AbortSignal,
+  ): Promise<MemoryFullCorpusQueryResult> {
+    throwIfAborted(signal);
+    validateRootSpecsBeforeIo(rootSpecs);
+    if (!this.#ftsAvailable) {
+      return {
+        kind: "unavailable",
+        candidates: [],
+        freshness: rootSpecs.map((spec) => unavailableRootStatus(spec)),
+        reason: "SQLite FTS5 unicode61 capability is unavailable",
+      };
+    }
+    const match = buildMemoryFtsMatch(terms);
+    if (match.length === 0) {
+      return { kind: "complete", candidates: [], freshness: [] };
+    }
+    const roots = await bindRoots(rootSpecs, signal);
+    const snapshots = roots
+      .map((root) => this.#currentGeneration(root))
+      .filter(
+        (
+          snapshot,
+        ): snapshot is { root: BoundRoot; generation: GenerationRow } =>
+          snapshot !== null,
+      );
+    const freshness = roots.map((root) => this.#rootStatus(root));
+    if (snapshots.length === 0) {
+      return {
+        kind: "unavailable",
+        candidates: [],
+        freshness,
+        reason: "no complete full-corpus memory generation is available",
+      };
+    }
+    for (const { root } of snapshots) this.#acquireQueryRoot(root.rootId);
+    try {
+      const rankedByRoot = await Promise.all(
+        snapshots.map(async ({ root, generation }) => ({
+          role: root.role,
+          candidates: await this.#queryPool.query(
+            {
+              databasePath: this.databasePath,
+              rootId: root.rootId,
+              generationId: generation.id,
+              rootRole: root.role,
+              match,
+              limit: MAX_MEMORY_FTS_CANDIDATES,
+            },
+            signal,
+          ),
+        })),
+      );
+      const project = rankedByRoot
+        .filter((result) => result.role === "project")
+        .flatMap((result) => result.candidates);
+      const global = rankedByRoot
+        .filter((result) => result.role === "global")
+        .flatMap((result) => result.candidates);
+      const recent = this.#readRecentCandidates(snapshots);
+      const candidates = fuseMemoryRanks({ project, global, recent });
+      return {
+        kind: freshness.every(
+          (status) =>
+            status.state === "complete" && status.watcherHealth === "healthy",
+        )
+          ? "complete"
+          : "stale",
+        candidates,
+        freshness,
+      };
+    } catch (error) {
+      if (signal.aborted) throw abortReason(signal);
+      return {
+        kind:
+          error instanceof MemoryIndexQueryResourceLimitedError
+            ? "query_resource_limited"
+            : "unavailable",
+        candidates: [],
+        freshness,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      for (const { root } of snapshots) this.#releaseQueryRoot(root.rootId);
+    }
+  }
+
+  readHeader(candidate: MemoryRankCandidate): MemoryHeader | null {
+    const row = this.#db
+      .prepare<[string, string], EntryRow>(
+        `SELECT e.*
+           FROM memory_index_roots r
+           JOIN memory_index_entries e
+             ON e.root_id = r.root_id
+            AND e.generation_id = r.current_generation_id
+          WHERE e.root_id = ? AND e.memory_id = ?`,
+      )
+      .get(candidate.rootId, candidate.memoryId);
+    if (row === undefined) return null;
+    return entryRowToMemoryHeader(row);
+  }
+
+  recordChange(input: {
+    readonly rootPath: string;
+    readonly relativePath: string;
+    readonly kind: "create" | "update" | "delete" | "rename";
+  }): void {
+    if (!CHANGE_KIND_VALUES.has(input.kind)) {
+      throw new MemoryIndexBoundaryError("memory change kind is invalid");
+    }
+    if (input.relativePath.length > 0) {
+      validatePortableRelativePath(input.relativePath);
+    }
+    validateMemoryRootPathBeforeIo(input.rootPath);
+    const canonicalRoot = realpathSyncExisting(input.rootPath);
+    const rootId = memoryIndexRootId(canonicalRoot);
+    const root = this.#db
+      .prepare<[string], RootRow>(
+        "SELECT * FROM memory_index_roots WHERE root_id = ?",
+      )
+      .get(rootId);
+    if (root === undefined) return;
+    const count = this.#db
+      .prepare<[string], { count: number }>(
+        "SELECT COUNT(*) AS count FROM memory_index_change_log WHERE root_id = ?",
+      )
+      .get(rootId)!.count;
+    if (count >= MAX_MEMORY_INDEX_CHANGE_LOG_EVENTS) {
+      this.#db
+        .prepare(
+          "UPDATE memory_index_roots SET watcher_health = 'overflow' WHERE root_id = ?",
+        )
+        .run(rootId);
+      this.#db
+        .prepare(
+          `UPDATE memory_index_generations
+              SET change_overflow = 1
+            WHERE root_id = ? AND state = 'staging'`,
+        )
+        .run(rootId);
+      return;
+    }
+    this.#db
+      .prepare(
+        `INSERT INTO memory_index_change_log(
+           root_id, relative_path, change_kind, observed_at_ms
+         ) VALUES (?, ?, ?, ?)`,
+      )
+      .run(rootId, input.relativePath, input.kind, this.#now());
+  }
+
+  async auditSlice(
+    rootSpec: MemoryIndexRootSpec,
+    signal: AbortSignal,
+  ): Promise<MemoryIndexGenerationStatus> {
+    validateRootSpecsBeforeIo([rootSpec]);
+    const [root] = await bindRoots([rootSpec], signal);
+    if (root === undefined) return unavailableRootStatus(rootSpec);
+    const current = this.#currentGeneration(root);
+    if (current === null) return this.#rootStatus(root);
+    const rootRow = this.#db
+      .prepare<[string], RootRow>(
+        "SELECT * FROM memory_index_roots WHERE root_id = ?",
+      )
+      .get(root.rootId)!;
+    const started = performance.now();
+    const persistedCursor = decodeAuditCursor(rootRow.audit_cursor);
+    let phase = persistedCursor.phase;
+    let cursor = persistedCursor.relativePath;
+    let inspected = 0;
+    let nextCursor: string | null = null;
+    let directoryChanged = false;
+
+    if (phase === "entries") {
+      const rows = this.#db
+        .prepare<[string, number, string, number], EntryRow>(
+          `SELECT * FROM memory_index_entries
+            WHERE root_id = ? AND generation_id = ? AND relative_path > ?
+            ORDER BY CAST(relative_path AS BLOB)
+            LIMIT ?`,
+        )
+        .all(
+          root.rootId,
+          current.generation.id,
+          cursor,
+          MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE,
+        );
+      let processedAllRows = true;
+      for (const row of rows) {
+        throwIfAborted(signal);
+        if (performance.now() - started >= MAX_MEMORY_AUDIT_MS_PER_SLICE) {
+          processedAllRows = false;
+          break;
+        }
+        cursor = row.relative_path;
+        inspected += 1;
+        const path = join(root.canonicalRoot, row.relative_path);
+        try {
+          const indexed = await readIndexedHeader(
+            root,
+            row.relative_path,
+            path,
+            signal,
+          );
+          if (indexed === null || indexed.fingerprint !== row.fingerprint) {
+            this.recordChange({
+              rootPath: root.canonicalRoot,
+              relativePath: row.relative_path,
+              kind: "update",
+            });
+          }
+        } catch {
+          throwIfAborted(signal);
+          this.recordChange({
+            rootPath: root.canonicalRoot,
+            relativePath: row.relative_path,
+            kind: "delete",
+          });
+        }
+      }
+      if (
+        !processedAllRows ||
+        rows.length === MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE
+      ) {
+        nextCursor = encodeAuditCursor("entries", cursor);
+      } else {
+        phase = "directories";
+        cursor = "";
+      }
+    }
+
+    if (
+      phase === "directories" &&
+      nextCursor === null &&
+      inspected < MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE &&
+      performance.now() - started < MAX_MEMORY_AUDIT_MS_PER_SLICE
+    ) {
+      const remaining = MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE - inspected;
+      const rows = this.#db
+        .prepare<[string, number, string, string, number], WorkDirectoryRow>(
+          `SELECT relative_path, state, dev, ino, mtime_ns
+             FROM memory_index_directory_work
+            WHERE root_id = ? AND generation_id = ?
+              AND (? = '' OR relative_path > ?)
+            ORDER BY CAST(relative_path AS BLOB)
+            LIMIT ?`,
+        )
+        .all(root.rootId, current.generation.id, cursor, cursor, remaining);
+      let processedAllRows = true;
+      for (const row of rows) {
+        throwIfAborted(signal);
+        if (performance.now() - started >= MAX_MEMORY_AUDIT_MS_PER_SLICE) {
+          processedAllRows = false;
+          break;
+        }
+        cursor = row.relative_path;
+        inspected += 1;
+        try {
+          const identity = await readDirectoryIdentity(
+            join(root.canonicalRoot, row.relative_path),
+            signal,
+          );
+          if (
+            identity.dev.toString() !== row.dev ||
+            identity.ino.toString() !== row.ino ||
+            identity.mtimeNs.toString() !== row.mtime_ns
+          ) {
+            directoryChanged = true;
+          }
+        } catch {
+          throwIfAborted(signal);
+          directoryChanged = true;
+        }
+      }
+      if (!processedAllRows || rows.length === remaining) {
+        nextCursor = encodeAuditCursor("directories", cursor);
+      }
+    }
+    if (
+      phase === "directories" &&
+      nextCursor === null &&
+      (inspected >= MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE ||
+        performance.now() - started >= MAX_MEMORY_AUDIT_MS_PER_SLICE)
+    ) {
+      nextCursor = encodeAuditCursor("directories", cursor);
+    }
+    this.#db
+      .prepare(
+        `UPDATE memory_index_roots
+            SET audit_cursor = ?,
+                watcher_health = CASE
+                  WHEN ? = 1 THEN 'degraded'
+                  ELSE watcher_health
+                END
+          WHERE root_id = ?`,
+      )
+      .run(nextCursor, directoryChanged ? 1 : 0, root.rootId);
+    return this.#rootStatus(root);
+  }
+
+  cleanupUnusedRoots(): number {
+    const started = performance.now();
+    const now = this.#now();
+    const cutoff = now - MEMORY_INDEX_ROOT_IDLE_TTL_MS;
+    const rows = this.#db
+      .prepare<[number, number, string, number, number], RootRow>(
+        `SELECT * FROM memory_index_roots
+          WHERE last_used_at_ms <= ?
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_index_generations g
+               WHERE g.root_id = memory_index_roots.root_id
+                 AND g.state = 'staging'
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_index_owners o
+               WHERE o.root_id = memory_index_roots.root_id
+                 AND o.lease_expires_at_ms > ?
+                 AND o.owner_id <> ?
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_index_generations g
+               WHERE g.root_id = memory_index_roots.root_id
+                 AND g.builder_owner IS NOT NULL
+                 AND g.builder_lease_expires_at_ms > ?
+            )
+          ORDER BY last_used_at_ms, root_id
+          LIMIT ?`,
+      )
+      .all(
+        cutoff,
+        now,
+        this.#builderOwner,
+        now,
+        MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH,
+      );
+    let removed = 0;
+    for (const row of rows) {
+      if (
+        performance.now() - started >=
+        MAX_MEMORY_INDEX_CLEANUP_MS_PER_SLICE
+      ) {
+        break;
+      }
+      if (this.#rootHasActiveLocalWork(row.root_id)) continue;
+      if (this.#deleteIndexedRoot(row.root_id, now)) removed += 1;
+    }
+    return removed;
+  }
+
+  #ensureWatchers(roots: readonly BoundRoot[]): void {
+    for (const root of roots) {
+      if (this.#watchers.has(root.rootId)) {
+        this.#renewWatcherOwner(root.rootId);
+        continue;
+      }
+      if (activeMemoryIndexWatchers >= MAX_MEMORY_INDEX_WATCHERS) {
+        this.#db
+          .prepare(
+            "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+          )
+          .run(root.rootId);
+        continue;
+      }
+      try {
+        const watcher = watch(
+          root.canonicalRoot,
+          { persistent: false, recursive: true },
+          (_eventType, filename) => {
+            const relativePath =
+              filename === null ? "" : String(filename).normalize("NFC");
+            this.#recordWatcherChange(root, relativePath);
+          },
+        );
+        watcher.on("error", () => {
+          if (this.#closed) return;
+          if (this.#watchers.get(root.rootId) === watcher) {
+            watcher.close();
+            this.#watchers.delete(root.rootId);
+            activeMemoryIndexWatchers -= 1;
+            try {
+              this.#releaseWatcherOwner(root.rootId);
+            } catch {
+              // The bounded lease expires if SQLite is temporarily unavailable.
+            }
+            const auditTimer = this.#auditTimers.get(root.rootId);
+            if (auditTimer !== undefined) {
+              clearTimeout(auditTimer);
+              this.#auditTimers.delete(root.rootId);
+            }
+          }
+          try {
+            this.#db
+              .prepare(
+                "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+              )
+              .run(root.rootId);
+          } catch {
+            // A watcher error must never escape an EventEmitter callback.
+          }
+        });
+        this.#watchers.set(root.rootId, watcher);
+        activeMemoryIndexWatchers += 1;
+        try {
+          this.#renewWatcherOwner(root.rootId);
+        } catch (error) {
+          watcher.close();
+          this.#watchers.delete(root.rootId);
+          activeMemoryIndexWatchers -= 1;
+          throw error;
+        }
+        this.#ensureOwnerHeartbeat();
+        this.#scheduleAudit(root, MEMORY_AUDIT_MIN_INTERVAL_MS);
+      } catch {
+        this.#db
+          .prepare(
+            "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+          )
+          .run(root.rootId);
+      }
+    }
+  }
+
+  #renewWatcherOwner(rootId: string): void {
+    this.#db
+      .prepare(
+        `INSERT INTO memory_index_owners(
+           root_id, owner_id, kind, lease_expires_at_ms
+         ) VALUES (?, ?, 'watcher', ?)
+         ON CONFLICT(root_id, owner_id, kind) DO UPDATE SET
+           lease_expires_at_ms = excluded.lease_expires_at_ms`,
+      )
+      .run(
+        rootId,
+        this.#builderOwner,
+        this.#now() + MEMORY_INDEX_OWNER_LEASE_MS,
+      );
+  }
+
+  #releaseWatcherOwner(rootId: string): void {
+    this.#db
+      .prepare(
+        `DELETE FROM memory_index_owners
+          WHERE root_id = ? AND owner_id = ? AND kind = 'watcher'`,
+      )
+      .run(rootId, this.#builderOwner);
+  }
+
+  #ensureOwnerHeartbeat(): void {
+    if (this.#closed || this.#ownerHeartbeatTimer !== null) return;
+    const timer = setTimeout(() => {
+      this.#ownerHeartbeatTimer = null;
+      if (this.#closed) return;
+      for (const rootId of this.#watchers.keys()) {
+        try {
+          this.#renewWatcherOwner(rootId);
+        } catch {
+          try {
+            this.#db
+              .prepare(
+                "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+              )
+              .run(rootId);
+          } catch {
+            // The next heartbeat retries both ownership and health persistence.
+          }
+        }
+      }
+      if (this.#watchers.size > 0) this.#ensureOwnerHeartbeat();
+    }, MEMORY_INDEX_OWNER_HEARTBEAT_MS);
+    timer.unref?.();
+    this.#ownerHeartbeatTimer = timer;
+  }
+
+  #recordWatcherChange(root: BoundRoot, relativePath: string): void {
+    try {
+      this.recordChange({
+        rootPath: root.canonicalRoot,
+        relativePath,
+        kind: "update",
+      });
+    } catch {
+      this.#db
+        .prepare(
+          "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+        )
+        .run(root.rootId);
+      return;
+    }
+    const key = `${root.rootId}:${relativePath}`;
+    const prior = this.#watchDebounceTimers.get(key);
+    if (prior !== undefined) clearTimeout(prior);
+    const timer = setTimeout(() => {
+      this.#watchDebounceTimers.delete(key);
+      this.#scheduleBackgroundRefresh(root);
+    }, MEMORY_WATCH_DEBOUNCE_MS);
+    timer.unref?.();
+    this.#watchDebounceTimers.set(key, timer);
+  }
+
+  #scheduleAudit(root: BoundRoot, delayMs: number): void {
+    if (this.#closed || this.#auditTimers.has(root.rootId)) return;
+    const timer = setTimeout(() => {
+      this.#auditTimers.delete(root.rootId);
+      const startedAt = performance.now();
+      void this.auditSlice(
+        { path: root.canonicalRoot, role: root.role },
+        new AbortController().signal,
+      )
+        .then((status) => {
+          if (status.watcherHealth !== "healthy") {
+            this.#scheduleBackgroundRefresh(root);
+          }
+        })
+        .catch(() => {
+          this.#db
+            .prepare(
+              "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+            )
+            .run(root.rootId);
+        })
+        .finally(() => {
+          const duration = Math.max(1, performance.now() - startedAt);
+          const nextDelay = Math.max(
+            MEMORY_AUDIT_MIN_INTERVAL_MS,
+            Math.min(
+              MEMORY_AUDIT_MAX_INTERVAL_MS,
+              Math.ceil(duration * MEMORY_AUDIT_BACKOFF_MULTIPLIER),
+            ),
+          );
+          this.#scheduleAudit(root, nextDelay);
+        });
+    }, delayMs);
+    timer.unref?.();
+    this.#auditTimers.set(root.rootId, timer);
+  }
+
+  #scheduleBackgroundRefresh(root: BoundRoot): void {
+    if (this.#closed || this.#backgroundRefreshes.has(root.rootId)) return;
+    const controller = new AbortController();
+    this.#backgroundRefreshes.set(root.rootId, controller);
+    void this.#continueBackgroundRefresh(root, controller).finally(() => {
+      if (this.#backgroundRefreshes.get(root.rootId) === controller) {
+        this.#backgroundRefreshes.delete(root.rootId);
+      }
+    });
+  }
+
+  async #continueBackgroundRefresh(
+    root: BoundRoot,
+    controller: AbortController,
+  ): Promise<void> {
+    while (!controller.signal.aborted) {
+      const status = await this.#refreshRootSlice(
+        root,
+        controller.signal,
+        false,
+      ).catch(() => null);
+      if (status === null || status.state !== "refresh_pending") return;
+      await yieldToEventLoop();
+    }
+  }
+
+  async #refreshRootSlice(
+    root: BoundRoot,
+    signal: AbortSignal,
+    forceRebuild: boolean,
+  ): Promise<MemoryIndexGenerationStatus> {
+    const buildKey = `${this.databasePath}:${root.rootId}`;
+    this.#upsertRoot(root);
+    const staging = this.#stagingGeneration(root.rootId);
+    const current = this.#currentGeneration(root);
+    const persistedRoot = this.#db
+      .prepare<[string], RootRow>(
+        "SELECT * FROM memory_index_roots WHERE root_id = ?",
+      )
+      .get(root.rootId)!;
+    const latestChangeCursor = this.#latestChangeCursor(root.rootId);
+    if (
+      !forceRebuild &&
+      staging === null &&
+      current !== null &&
+      persistedRoot.watcher_health === "healthy" &&
+      latestChangeCursor <= current.generation.change_cursor
+    ) {
+      return this.#rootStatus(root);
+    }
+    if (this.#sliceLocks.has(buildKey)) {
+      return {
+        ...this.#rootStatus(root),
+        state: "refresh_pending",
+        reason: "memory index build slice is already active",
+      };
+    }
+    if (!activeBuilds.has(buildKey)) {
+      if (activeBuilds.size >= MAX_MEMORY_INDEX_CONCURRENT_BUILDS) {
+        return {
+          ...this.#rootStatus(root),
+          state: "refresh_pending",
+          reason: "global memory index build concurrency limit reached",
+        };
+      }
+      activeBuilds.add(buildKey);
+    }
+    this.#sliceLocks.add(buildKey);
+    try {
+      if (
+        !forceRebuild &&
+        staging === null &&
+        current !== null &&
+        latestChangeCursor > current.generation.change_cursor &&
+        persistedRoot.watcher_health === "healthy"
+      ) {
+        if (!this.#claimBuildLease(current.generation.id)) {
+          activeBuilds.delete(buildKey);
+          return {
+            ...this.#rootStatus(root),
+            state: "refresh_pending",
+            reason: "another daemon owns the memory index writer lease",
+          };
+        }
+        try {
+          const status = await this.#applyIncrementalChanges(
+            root,
+            current.generation,
+            signal,
+          );
+          if (status.state !== "refresh_pending") activeBuilds.delete(buildKey);
+          return status;
+        } finally {
+          this.#releaseBuildLease(current.generation.id);
+        }
+      }
+      const generation = this.#beginOrResumeGeneration(root);
+      if (!this.#claimBuildLease(generation.id)) {
+        activeBuilds.delete(buildKey);
+        return {
+          ...this.#rootStatus(root),
+          state: "refresh_pending",
+          reason: "another daemon owns the bounded memory index writer lease",
+        };
+      }
+      try {
+        const status = await this.#runBuildSlice(root, generation, signal);
+        if (status.state !== "refresh_pending") activeBuilds.delete(buildKey);
+        return status;
+      } finally {
+        this.#releaseBuildLease(generation.id);
+      }
+    } catch (error) {
+      activeBuilds.delete(buildKey);
+      if (signal.aborted) throw abortReason(signal);
+      const generation = this.#stagingGeneration(root.rootId);
+      if (generation !== null) {
+        await this.#closeGenerationDirectories(root.rootId, generation.id);
+        this.#failGeneration(generation.id, error);
+      }
+      return {
+        ...this.#rootStatus(root),
+        state: "failed",
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      this.#sliceLocks.delete(buildKey);
+    }
+  }
+
+  async #applyIncrementalChanges(
+    root: BoundRoot,
+    generation: GenerationRow,
+    signal: AbortSignal,
+  ): Promise<MemoryIndexGenerationStatus> {
+    const startedAt = performance.now();
+    const changes = this.#db
+      .prepare<[string, number, number], IncrementalChangeRow>(
+        `SELECT sequence, relative_path, change_kind
+           FROM memory_index_change_log
+          WHERE root_id = ? AND sequence > ?
+          ORDER BY sequence
+          LIMIT ?`,
+      )
+      .all(
+        root.rootId,
+        generation.change_cursor,
+        MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE,
+      );
+    if (
+      changes.some(
+        (change) =>
+          change.relative_path.length === 0 ||
+          !change.relative_path.endsWith(".md"),
+      )
+    ) {
+      this.#db
+        .prepare(
+          "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+        )
+        .run(root.rootId);
+      return {
+        ...this.#rootStatus(root),
+        state: "refresh_pending",
+        reason: "directory watcher change requires a bounded full rebuild",
+      };
+    }
+    const coalesced = new Map<string, IncrementalChangeRow>();
+    for (const change of changes) coalesced.set(change.relative_path, change);
+    const prepared: PreparedIncrementalChange[] = [];
+    let incrementalReadFailed = false;
+    let lastSequence = generation.change_cursor;
+    const orderedChanges = [...coalesced.values()].sort(
+      (left, right) => left.sequence - right.sequence,
+    );
+    for (const change of orderedChanges) {
+      throwIfAborted(signal);
+      if (performance.now() - startedAt >= MAX_MEMORY_INDEX_BUILD_SLICE_MS)
+        break;
+      lastSequence = Math.max(lastSequence, change.sequence);
+      if (change.change_kind === "delete") {
+        prepared.push({
+          sequence: change.sequence,
+          relativePath: change.relative_path,
+          indexed: null,
+        });
+        continue;
+      }
+      try {
+        const indexed = await readIndexedHeader(
+          root,
+          change.relative_path,
+          join(root.canonicalRoot, change.relative_path),
+          signal,
+        );
+        prepared.push({
+          sequence: change.sequence,
+          relativePath: change.relative_path,
+          indexed,
+        });
+      } catch (error) {
+        throwIfAborted(signal);
+        if (errnoCode(error) !== "ENOENT") incrementalReadFailed = true;
+        prepared.push({
+          sequence: change.sequence,
+          relativePath: change.relative_path,
+          indexed: errnoCode(error) === "ENOENT" ? null : undefined,
+        });
+      }
+    }
+    if (incrementalReadFailed) {
+      this.#db
+        .prepare(
+          "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+        )
+        .run(root.rootId);
+    }
+    const changedDirectories = new Map<string, DirectoryIdentity>();
+    for (const change of prepared) {
+      const directoryPath = dirname(change.relativePath);
+      const relativeDirectory = directoryPath === "." ? "" : directoryPath;
+      if (changedDirectories.has(relativeDirectory)) continue;
+      try {
+        changedDirectories.set(
+          relativeDirectory,
+          await readDirectoryIdentity(
+            join(root.canonicalRoot, relativeDirectory),
+            signal,
+          ),
+        );
+      } catch {
+        throwIfAborted(signal);
+        incrementalReadFailed = true;
+        this.#db
+          .prepare(
+            "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+          )
+          .run(root.rootId);
+      }
+    }
+    if (prepared.length === 0 && changes.length > 0) {
+      return {
+        ...this.#rootStatus(root),
+        state: "refresh_pending",
+      };
+    }
+    this.#db
+      .transaction(() => {
+        for (const change of prepared) {
+          if (change.indexed === undefined) continue;
+          if (change.indexed === null) {
+            this.#removeStagingPath(
+              root.rootId,
+              generation.id,
+              change.relativePath,
+            );
+          } else {
+            this.#upsertIndexedEntry(
+              root,
+              generation.id,
+              change.relativePath,
+              change.indexed,
+            );
+          }
+        }
+        for (const [relativePath, identity] of changedDirectories) {
+          this.#db
+            .prepare(
+              `UPDATE memory_index_directory_work
+                  SET dev = ?, ino = ?, mtime_ns = ?
+                WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+            )
+            .run(
+              identity.dev.toString(),
+              identity.ino.toString(),
+              identity.mtimeNs.toString(),
+              root.rootId,
+              generation.id,
+              relativePath,
+            );
+        }
+        this.#db
+          .prepare(
+            `UPDATE memory_index_generations
+                SET change_cursor = ?, completed_at_ms = ?,
+                    elapsed_active_ms = elapsed_active_ms + ?
+              WHERE id = ? AND state = 'complete'`,
+          )
+          .run(
+            lastSequence,
+            this.#now(),
+            Math.ceil(Math.max(0, performance.now() - startedAt)),
+            generation.id,
+          );
+        this.#db
+          .prepare(
+            "UPDATE memory_index_roots SET last_used_at_ms = ? WHERE root_id = ?",
+          )
+          .run(this.#now(), root.rootId);
+        this.#db
+          .prepare(
+            "DELETE FROM memory_index_change_log WHERE root_id = ? AND sequence <= ?",
+          )
+          .run(root.rootId, lastSequence);
+      })
+      .immediate();
+    if (incrementalReadFailed) {
+      return {
+        ...this.#rootStatus(root),
+        state: "refresh_pending",
+        reason: "incremental memory update requires a bounded full rebuild",
+      };
+    }
+    const remaining = this.#latestChangeCursor(root.rootId) > lastSequence;
+    return remaining
+      ? { ...this.#rootStatus(root), state: "refresh_pending" }
+      : this.#rootStatus(root);
+  }
+
+  #beginOrResumeGeneration(root: BoundRoot): GenerationRow {
+    const existing = this.#stagingGeneration(root.rootId);
+    if (existing !== null) return existing;
+    const changeCursor = this.#latestChangeCursor(root.rootId);
+    const generationId = Number(
+      this.#db
+        .prepare(
+          `INSERT INTO memory_index_generations(
+             root_id, state, generation_token, started_at_ms,
+             completed_at_ms, elapsed_active_ms, entry_count, indexed_bytes,
+             discovery_operations, digest, change_cursor, change_overflow, error,
+             builder_owner, builder_lease_expires_at_ms
+           ) VALUES (?, 'staging', ?, ?, NULL, 0, 0, 0, 0, NULL, ?, 0, NULL, NULL, NULL)`,
+        )
+        .run(root.rootId, randomUUID(), this.#now(), changeCursor)
+        .lastInsertRowid,
+    );
+    this.#db
+      .prepare(
+        `INSERT INTO memory_index_directory_work(
+           root_id, generation_id, relative_path, state, dev, ino, mtime_ns
+         ) VALUES (?, ?, '', 'pending', ?, ?, ?)`,
+      )
+      .run(
+        root.rootId,
+        generationId,
+        root.identity.dev.toString(),
+        root.identity.ino.toString(),
+        root.identity.mtimeNs.toString(),
+      );
+    return this.#generationById(generationId)!;
+  }
+
+  async #runBuildSlice(
+    root: BoundRoot,
+    generation: GenerationRow,
+    signal: AbortSignal,
+  ): Promise<MemoryIndexGenerationStatus> {
+    const budget: BuildSliceBudget = {
+      startedAt: performance.now(),
+      newEntries: 0,
+      operations: 0,
+    };
+    while (!sliceExhausted(budget)) {
+      throwIfAborted(signal);
+      const directory = this.#nextDirectory(root.rootId, generation.id);
+      if (directory !== null) {
+        const advanced = await this.#enumerateDirectory(
+          root,
+          generation,
+          directory,
+          budget,
+          signal,
+        );
+        if (!advanced) break;
+        continue;
+      }
+      const file = this.#nextDiscoveredFile(root.rootId, generation.id);
+      if (file !== null) {
+        await this.#indexDiscoveredFile(root, generation, file, signal);
+        budget.newEntries += 1;
+        budget.operations += 1;
+        continue;
+      }
+      const currentGeneration = this.#generationById(generation.id);
+      if (currentGeneration === null) {
+        throw new Error("memory staging generation disappeared");
+      }
+      if (currentGeneration.change_overflow !== 0) {
+        throw new MemoryIndexBoundaryError(
+          "memory change log overflowed during staging generation",
+        );
+      }
+      const replayed = this.#replayChanges(root, currentGeneration);
+      if (replayed > 0) continue;
+      this.#recordSliceElapsed(
+        generation.id,
+        budget.startedAt,
+        budget.operations,
+      );
+      this.#publishGeneration(root, generation.id);
+      return this.#rootStatus(root);
+    }
+    this.#recordSliceElapsed(
+      generation.id,
+      budget.startedAt,
+      budget.operations,
+    );
+    const updated = this.#generationById(generation.id)!;
+    if (updated.elapsed_active_ms > MAX_MEMORY_INDEX_TOTAL_BUILD_MS) {
+      throw new MemoryIndexBoundaryError(
+        "memory index total active build time exceeds limit",
+      );
+    }
+    while (
+      databaseBytes(this.#db) > MAX_MEMORY_INDEX_BYTES &&
+      this.#evictLeastRecentlyUsedRoot(root.rootId)
+    ) {
+      // Evict only inactive, non-building roots before rejecting this build.
+    }
+    if (databaseBytes(this.#db) > MAX_MEMORY_INDEX_BYTES) {
+      throw new MemoryIndexBoundaryError(
+        "memory index database byte limit crossed",
+      );
+    }
+    return {
+      ...this.#rootStatus(root),
+      state: "refresh_pending",
+      generationId: generation.id,
+      generationToken: generation.generation_token,
+    };
+  }
+
+  async #enumerateDirectory(
+    root: BoundRoot,
+    generation: GenerationRow,
+    work: WorkDirectoryRow,
+    budget: BuildSliceBudget,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const key = openDirectoryKey(
+      root.rootId,
+      generation.id,
+      work.relative_path,
+    );
+    let openState = this.#openDirectories.get(key);
+    if (openState === undefined) {
+      if (
+        activeMemoryBuildOpenDirectories >= MAX_MEMORY_BUILD_OPEN_DIRECTORIES
+      ) {
+        return false;
+      }
+      const absolutePath = join(root.canonicalRoot, work.relative_path);
+      const before = await readDirectoryIdentity(absolutePath, signal);
+      if (
+        before.dev.toString() !== work.dev ||
+        before.ino.toString() !== work.ino
+      ) {
+        this.#requeueDirectory(root, generation.id, work.relative_path, before);
+        return true;
+      }
+      const directory = await opendir(absolutePath);
+      openState = { directory, absolutePath, beforeIdentity: before };
+      this.#openDirectories.set(key, openState);
+      activeMemoryBuildOpenDirectories += 1;
+      this.#db
+        .prepare(
+          `UPDATE memory_index_directory_work
+              SET state = 'enumerating', dev = ?, ino = ?, mtime_ns = ?
+            WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+        )
+        .run(
+          before.dev.toString(),
+          before.ino.toString(),
+          before.mtimeNs.toString(),
+          root.rootId,
+          generation.id,
+          work.relative_path,
+        );
+    }
+    while (!sliceExhausted(budget)) {
+      throwIfAborted(signal);
+      const entry = await openState.directory.read();
+      if (entry === null) {
+        await openState.directory.close().catch(() => undefined);
+        this.#openDirectories.delete(key);
+        activeMemoryBuildOpenDirectories -= 1;
+        const after = await readDirectoryIdentity(
+          openState.absolutePath,
+          signal,
+        );
+        if (!sameDirectoryIdentity(openState.beforeIdentity, after)) {
+          this.#requeueDirectory(
+            root,
+            generation.id,
+            work.relative_path,
+            after,
+          );
+          this.recordChange({
+            rootPath: root.canonicalRoot,
+            relativePath: work.relative_path,
+            kind: "update",
+          });
+          return true;
+        }
+        this.#db
+          .prepare(
+            `UPDATE memory_index_directory_work SET state = 'complete'
+              WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+          )
+          .run(root.rootId, generation.id, work.relative_path);
+        return true;
+      }
+      budget.operations += 1;
+      if (entry.isSymbolicLink()) continue;
+      const relativePath = work.relative_path
+        ? join(work.relative_path, entry.name)
+        : entry.name;
+      validatePortableRelativePath(relativePath);
+      if (entry.isDirectory()) {
+        const identity = await readDirectoryIdentity(
+          join(root.canonicalRoot, relativePath),
+          signal,
+        );
+        const result = this.#db
+          .prepare(
+            `INSERT OR IGNORE INTO memory_index_directory_work(
+               root_id, generation_id, relative_path, state, dev, ino, mtime_ns
+             ) VALUES (?, ?, ?, 'pending', ?, ?, ?)`,
+          )
+          .run(
+            root.rootId,
+            generation.id,
+            relativePath,
+            identity.dev.toString(),
+            identity.ino.toString(),
+            identity.mtimeNs.toString(),
+          );
+        budget.newEntries += result.changes;
+        continue;
+      }
+      if (
+        entry.isFile() &&
+        entry.name.endsWith(".md") &&
+        basename(entry.name) !== "MEMORY.md"
+      ) {
+        const result = this.#db
+          .prepare(
+            `INSERT OR IGNORE INTO memory_index_discovered_files(
+               root_id, generation_id, relative_path, state, error
+             ) VALUES (?, ?, ?, 'pending', NULL)`,
+          )
+          .run(root.rootId, generation.id, relativePath);
+        budget.newEntries += result.changes;
+        const count = this.#db
+          .prepare<[string, number], { count: number }>(
+            `SELECT COUNT(*) AS count FROM memory_index_discovered_files
+              WHERE root_id = ? AND generation_id = ?`,
+          )
+          .get(root.rootId, generation.id)!.count;
+        if (count > MAX_MEMORY_FILES_PER_ROOT) {
+          throw new MemoryIndexBoundaryError(
+            "memory file count per root exceeds limit",
+          );
+        }
+      }
+    }
+    return true;
+  }
+
+  async #indexDiscoveredFile(
+    root: BoundRoot,
+    generation: GenerationRow,
+    discovered: DiscoveredFileRow,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const absolutePath = join(root.canonicalRoot, discovered.relative_path);
+    try {
+      const indexed = await readIndexedHeader(
+        root,
+        discovered.relative_path,
+        absolutePath,
+        signal,
+      );
+      if (indexed === null) {
+        this.#removeStagingPath(
+          root.rootId,
+          generation.id,
+          discovered.relative_path,
+        );
+        this.#markDiscoveredComplete(
+          root.rootId,
+          generation.id,
+          discovered.relative_path,
+        );
+        return;
+      }
+      this.#db
+        .transaction(() => {
+          this.#upsertIndexedEntry(
+            root,
+            generation.id,
+            discovered.relative_path,
+            indexed,
+          );
+          this.#markDiscoveredComplete(
+            root.rootId,
+            generation.id,
+            discovered.relative_path,
+          );
+        })
+        .immediate();
+    } catch (error) {
+      if (signal.aborted) throw abortReason(signal);
+      if (errnoCode(error) === "ENOENT") {
+        this.#removeStagingPath(
+          root.rootId,
+          generation.id,
+          discovered.relative_path,
+        );
+        this.#markDiscoveredComplete(
+          root.rootId,
+          generation.id,
+          discovered.relative_path,
+        );
+        return;
+      }
+      this.#db
+        .prepare(
+          `UPDATE memory_index_discovered_files
+              SET state = 'diagnosed', error = ?
+            WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+        )
+        .run(
+          error instanceof Error ? error.message : String(error),
+          root.rootId,
+          generation.id,
+          discovered.relative_path,
+        );
+    }
+  }
+
+  #upsertIndexedEntry(
+    root: BoundRoot,
+    generationId: number,
+    relativePath: string,
+    indexed: IndexedMemoryHeader,
+  ): void {
+    const prior = this.#db
+      .prepare<
+        [string, number, string],
+        { canonical_path: string; fingerprint: string }
+      >(
+        `SELECT canonical_path, fingerprint FROM memory_index_entries
+          WHERE root_id = ? AND generation_id = ? AND memory_id = ?`,
+      )
+      .get(root.rootId, generationId, indexed.memoryId);
+    this.#db
+      .prepare(
+        `INSERT OR REPLACE INTO memory_index_entries(
+           root_id, generation_id, memory_id, relative_path,
+           canonical_path, title, description, memory_type, mtime_ms,
+           file_size, fingerprint, last_seen_generation,
+           file_dev, file_ino, file_mode, file_mtime_ns, file_ctime_ns,
+           root_dev, root_ino, root_mode, root_size, root_mtime_ns,
+           root_ctime_ns
+         ) VALUES (
+           ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+         )`,
+      )
+      .run(
+        root.rootId,
+        generationId,
+        indexed.memoryId,
+        relativePath,
+        indexed.canonicalPath,
+        indexed.title,
+        indexed.description,
+        indexed.type,
+        indexed.mtimeMs,
+        indexed.fileSize,
+        indexed.fingerprint,
+        generationId,
+        indexed.fileIdentity.dev.toString(),
+        indexed.fileIdentity.ino.toString(),
+        indexed.fileIdentity.mode.toString(),
+        indexed.fileIdentity.mtimeNs.toString(),
+        indexed.fileIdentity.ctimeNs.toString(),
+        root.identity.dev.toString(),
+        root.identity.ino.toString(),
+        root.identity.mode.toString(),
+        root.identity.size.toString(),
+        root.identity.mtimeNs.toString(),
+        root.identity.ctimeNs.toString(),
+      );
+    this.#db
+      .prepare(
+        `DELETE FROM memory_fts
+          WHERE root_id = ? AND generation_id = ? AND memory_id = ?`,
+      )
+      .run(root.rootId, generationId, indexed.memoryId);
+    this.#db
+      .prepare(
+        `INSERT INTO memory_fts(
+           root_id, generation_id, memory_id, title, description
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        root.rootId,
+        generationId,
+        indexed.memoryId,
+        normalizeSearchableMetadata(indexed.title),
+        normalizeSearchableMetadata(indexed.description),
+      );
+    this.#advanceGenerationProgress({
+      generationId,
+      ...(prior === undefined
+        ? {}
+        : {
+            previous: {
+              canonicalPath: prior.canonical_path,
+              fingerprint: prior.fingerprint,
+            },
+          }),
+      next: {
+        canonicalPath: indexed.canonicalPath,
+        fingerprint: indexed.fingerprint,
+      },
+      entryDelta: prior === undefined ? 1 : 0,
+      byteDelta:
+        indexedEntryBytes(indexed.canonicalPath, indexed.fingerprint) -
+        (prior === undefined
+          ? 0
+          : indexedEntryBytes(prior.canonical_path, prior.fingerprint)),
+    });
+  }
+
+  #replayChanges(root: BoundRoot, generation: GenerationRow): number {
+    const changes = this.#db
+      .prepare<
+        [string, number, number],
+        { sequence: number; relative_path: string; change_kind: string }
+      >(
+        `SELECT sequence, relative_path, change_kind
+           FROM memory_index_change_log
+          WHERE root_id = ? AND sequence > ?
+          ORDER BY sequence
+          LIMIT ?`,
+      )
+      .all(
+        root.rootId,
+        generation.change_cursor,
+        MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE,
+      );
+    if (changes.length === 0) return 0;
+    if (
+      changes.some(
+        (change) =>
+          change.relative_path.length === 0 ||
+          !change.relative_path.endsWith(".md"),
+      )
+    ) {
+      this.#db
+        .transaction(() => {
+          this.#db
+            .prepare(
+              "UPDATE memory_index_roots SET watcher_health = 'degraded' WHERE root_id = ?",
+            )
+            .run(root.rootId);
+          this.#db
+            .prepare(
+              "UPDATE memory_index_generations SET change_overflow = 1 WHERE id = ?",
+            )
+            .run(generation.id);
+        })
+        .immediate();
+      throw new MemoryIndexBoundaryError(
+        "directory watcher change invalidated the staging generation",
+      );
+    }
+    this.#db
+      .transaction(() => {
+        let cursor = generation.change_cursor;
+        for (const change of changes) {
+          cursor = change.sequence;
+          if (change.change_kind === "delete") {
+            this.#removeStagingPath(
+              root.rootId,
+              generation.id,
+              change.relative_path,
+            );
+          } else if (change.relative_path.endsWith(".md")) {
+            this.#db
+              .prepare(
+                `INSERT INTO memory_index_discovered_files(
+                   root_id, generation_id, relative_path, state, error
+                 ) VALUES (?, ?, ?, 'pending', NULL)
+                 ON CONFLICT(root_id, generation_id, relative_path)
+                 DO UPDATE SET state = 'pending', error = NULL`,
+              )
+              .run(root.rootId, generation.id, change.relative_path);
+          }
+        }
+        this.#db
+          .prepare(
+            "UPDATE memory_index_generations SET change_cursor = ? WHERE id = ?",
+          )
+          .run(cursor, generation.id);
+      })
+      .immediate();
+    return changes.length;
+  }
+
+  #publishGeneration(root: BoundRoot, generationId: number): void {
+    const integrity = this.#generationIntegrity(root.rootId, generationId);
+    if (databaseBytes(this.#db) > MAX_MEMORY_INDEX_BYTES) {
+      throw new MemoryIndexBoundaryError(
+        "memory index database byte limit crossed",
+      );
+    }
+    const now = this.#now();
+    this.#db
+      .transaction(() => {
+        const pendingDirectories = this.#db
+          .prepare<[string, number], { count: number }>(
+            `SELECT COUNT(*) AS count FROM memory_index_directory_work
+              WHERE root_id = ? AND generation_id = ? AND state <> 'complete'`,
+          )
+          .get(root.rootId, generationId)!.count;
+        const pendingFiles = this.#db
+          .prepare<[string, number], { count: number }>(
+            `SELECT COUNT(*) AS count FROM memory_index_discovered_files
+              WHERE root_id = ? AND generation_id = ? AND state = 'pending'`,
+          )
+          .get(root.rootId, generationId)!.count;
+        if (pendingDirectories !== 0 || pendingFiles !== 0) {
+          throw new Error("memory index generation is not converged");
+        }
+        this.#db
+          .prepare(
+            "DELETE FROM memory_index_discovered_files WHERE generation_id = ?",
+          )
+          .run(generationId);
+        const previous = this.#db
+          .prepare<[string], { current_generation_id: number | null }>(
+            "SELECT current_generation_id FROM memory_index_roots WHERE root_id = ?",
+          )
+          .get(root.rootId)!.current_generation_id;
+        this.#db
+          .prepare(
+            `UPDATE memory_index_generations
+                SET state = 'complete', completed_at_ms = ?, entry_count = ?,
+                    indexed_bytes = ?, digest = ?, error = NULL
+              WHERE id = ? AND state = 'staging'`,
+          )
+          .run(
+            now,
+            integrity.entryCount,
+            integrity.indexedBytes,
+            integrity.digest,
+            generationId,
+          );
+        this.#db
+          .prepare(
+            `UPDATE memory_index_roots
+                SET current_generation_id = ?, last_used_at_ms = ?,
+                    audit_cursor = NULL
+              WHERE root_id = ?`,
+          )
+          .run(generationId, now, root.rootId);
+        if (previous !== null && previous !== generationId) {
+          this.#db
+            .prepare(
+              "UPDATE memory_index_generations SET state = 'superseded' WHERE id = ?",
+            )
+            .run(previous);
+        }
+        this.#db
+          .prepare(
+            `DELETE FROM memory_index_change_log
+              WHERE root_id = ? AND sequence <= (
+                SELECT change_cursor FROM memory_index_generations WHERE id = ?
+              )`,
+          )
+          .run(root.rootId, generationId);
+        this.#deleteOldGenerations(root.rootId);
+      })
+      .immediate();
+  }
+
+  #generationIntegrity(
+    rootId: string,
+    generationId: number,
+  ): {
+    readonly entryCount: number;
+    readonly indexedBytes: number;
+    readonly digest: string;
+  } {
+    const rows = this.#db
+      .prepare<
+        [string, number],
+        { canonical_path: string; fingerprint: string }
+      >(
+        `SELECT canonical_path, fingerprint FROM memory_index_entries
+          WHERE root_id = ? AND generation_id = ?
+          ORDER BY CAST(canonical_path AS BLOB), CAST(memory_id AS BLOB)`,
+      )
+      .iterate(rootId, generationId);
+    const digest = Buffer.from(EMPTY_MEMORY_GENERATION_DIGEST, "hex");
+    let entryCount = 0;
+    let indexedBytes = 0;
+    for (const row of rows) {
+      entryCount += 1;
+      const path = Buffer.from(row.canonical_path, "utf8");
+      const fingerprint = Buffer.from(row.fingerprint, "hex");
+      xorDigest(
+        digest,
+        memoryEntryDigest({
+          canonicalPath: row.canonical_path,
+          fingerprint: row.fingerprint,
+        }),
+      );
+      indexedBytes += path.byteLength + fingerprint.byteLength;
+    }
+    return {
+      entryCount,
+      indexedBytes,
+      digest: digest.toString("hex"),
+    };
+  }
+
+  #recordSliceElapsed(
+    generationId: number,
+    startedAt: number,
+    operations: number,
+  ): void {
+    const elapsed = Math.max(0, performance.now() - startedAt);
+    this.#db
+      .prepare(
+        `UPDATE memory_index_generations
+            SET elapsed_active_ms = elapsed_active_ms + ?,
+                discovery_operations = discovery_operations + ?
+          WHERE id = ? AND state = 'staging'`,
+      )
+      .run(Math.ceil(elapsed), operations, generationId);
+  }
+
+  #readRecentCandidates(
+    snapshots: readonly { root: BoundRoot; generation: GenerationRow }[],
+  ): MemoryRankCandidate[] {
+    const recent: MemoryRankCandidate[] = [];
+    for (const { root, generation } of snapshots) {
+      const rows = this.#db
+        .prepare<[string, number, number], EntryRow>(
+          `SELECT * FROM memory_index_entries
+            WHERE root_id = ? AND generation_id = ?
+            ORDER BY mtime_ms DESC, CAST(canonical_path AS BLOB), CAST(memory_id AS BLOB)
+            LIMIT ?`,
+        )
+        .all(root.rootId, generation.id, MAX_MEMORY_RECENT_UNION);
+      recent.push(
+        ...rows.map((row) => entryRowToRankCandidate(row, root.role)),
+      );
+    }
+    recent.sort((left, right) => {
+      if (left.mtimeMs !== right.mtimeMs) return right.mtimeMs - left.mtimeMs;
+      return Buffer.compare(
+        Buffer.from(left.canonicalPath, "utf8"),
+        Buffer.from(right.canonicalPath, "utf8"),
+      );
+    });
+    return recent.slice(0, MAX_MEMORY_RECENT_UNION);
+  }
+
+  #upsertRoot(root: BoundRoot): void {
+    let count = this.#db
+      .prepare<[], { count: number }>(
+        "SELECT COUNT(*) AS count FROM memory_index_roots",
+      )
+      .get()!.count;
+    const existing = this.#db
+      .prepare<[string], RootRow>(
+        "SELECT * FROM memory_index_roots WHERE root_id = ?",
+      )
+      .get(root.rootId);
+    if (existing === undefined && count >= MAX_MEMORY_INDEX_ROOTS) {
+      this.cleanupUnusedRoots();
+      count = this.#db
+        .prepare<[], { count: number }>(
+          "SELECT COUNT(*) AS count FROM memory_index_roots",
+        )
+        .get()!.count;
+      if (
+        count >= MAX_MEMORY_INDEX_ROOTS &&
+        !this.#evictLeastRecentlyUsedRoot(root.rootId)
+      ) {
+        throw new MemoryIndexBoundaryError(
+          "global memory index root limit reached",
+        );
+      }
+    }
+    this.#db
+      .prepare(
+        `INSERT INTO memory_index_roots(
+           root_id, canonical_path, root_role, current_generation_id,
+           last_used_at_ms, watcher_health, audit_cursor
+         ) VALUES (?, ?, ?, NULL, ?, 'healthy', NULL)
+         ON CONFLICT(root_id) DO UPDATE SET
+           canonical_path = excluded.canonical_path,
+           root_role = excluded.root_role,
+           last_used_at_ms = excluded.last_used_at_ms`,
+      )
+      .run(root.rootId, root.canonicalRoot, root.role, this.#now());
+  }
+
+  #currentGeneration(
+    root: BoundRoot,
+  ): { root: BoundRoot; generation: GenerationRow } | null {
+    const row = this.#db
+      .prepare<[string], GenerationRow>(
+        `SELECT g.* FROM memory_index_roots r
+          JOIN memory_index_generations g ON g.id = r.current_generation_id
+          WHERE r.root_id = ? AND g.state = 'complete'`,
+      )
+      .get(root.rootId);
+    if (row === undefined) return null;
+    this.#db
+      .prepare(
+        "UPDATE memory_index_roots SET last_used_at_ms = ? WHERE root_id = ?",
+      )
+      .run(this.#now(), root.rootId);
+    return { root, generation: row };
+  }
+
+  #rootStatus(root: BoundRoot): MemoryIndexGenerationStatus {
+    const rootRow = this.#db
+      .prepare<[string], RootRow>(
+        "SELECT * FROM memory_index_roots WHERE root_id = ?",
+      )
+      .get(root.rootId);
+    const staging = this.#stagingGeneration(root.rootId);
+    const current =
+      rootRow?.current_generation_id === null ||
+      rootRow?.current_generation_id === undefined
+        ? null
+        : this.#generationById(rootRow.current_generation_id);
+    if (staging !== null) {
+      return {
+        rootId: root.rootId,
+        canonicalRoot: root.canonicalRoot,
+        role: root.role,
+        generationId: staging.id,
+        generationToken: staging.generation_token,
+        state: "refresh_pending",
+        ageMs:
+          current?.completed_at_ms === null || current === null
+            ? null
+            : Math.max(0, this.#now() - current.completed_at_ms),
+        watcherHealth: rootRow?.watcher_health ?? "degraded",
+        auditCursor: rootRow?.audit_cursor ?? null,
+      };
+    }
+    if (current !== null && current.state === "complete") {
+      return {
+        rootId: root.rootId,
+        canonicalRoot: root.canonicalRoot,
+        role: root.role,
+        generationId: current.id,
+        generationToken: current.generation_token,
+        state: "complete",
+        ageMs:
+          current.completed_at_ms === null
+            ? null
+            : Math.max(0, this.#now() - current.completed_at_ms),
+        watcherHealth: rootRow?.watcher_health ?? "degraded",
+        auditCursor: rootRow?.audit_cursor ?? null,
+      };
+    }
+    return {
+      rootId: root.rootId,
+      canonicalRoot: root.canonicalRoot,
+      role: root.role,
+      generationId: null,
+      generationToken: null,
+      state: "unavailable",
+      ageMs: null,
+      watcherHealth: rootRow?.watcher_health ?? "degraded",
+      auditCursor: rootRow?.audit_cursor ?? null,
+    };
+  }
+
+  #nextDirectory(
+    rootId: string,
+    generationId: number,
+  ): WorkDirectoryRow | null {
+    return (
+      this.#db
+        .prepare<[string, number], WorkDirectoryRow>(
+          `SELECT relative_path, state, dev, ino, mtime_ns
+             FROM memory_index_directory_work
+            WHERE root_id = ? AND generation_id = ? AND state <> 'complete'
+            ORDER BY CASE state WHEN 'enumerating' THEN 0 ELSE 1 END,
+                     CAST(relative_path AS BLOB)
+            LIMIT 1`,
+        )
+        .get(rootId, generationId) ?? null
+    );
+  }
+
+  #nextDiscoveredFile(
+    rootId: string,
+    generationId: number,
+  ): DiscoveredFileRow | null {
+    return (
+      this.#db
+        .prepare<[string, number], DiscoveredFileRow>(
+          `SELECT relative_path FROM memory_index_discovered_files
+            WHERE root_id = ? AND generation_id = ? AND state = 'pending'
+            ORDER BY CAST(relative_path AS BLOB)
+            LIMIT 1`,
+        )
+        .get(rootId, generationId) ?? null
+    );
+  }
+
+  #markDiscoveredComplete(
+    rootId: string,
+    generationId: number,
+    relativePath: string,
+  ): void {
+    this.#db
+      .prepare(
+        `UPDATE memory_index_discovered_files SET state = 'complete', error = NULL
+          WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+      )
+      .run(rootId, generationId, relativePath);
+  }
+
+  #removeStagingPath(
+    rootId: string,
+    generationId: number,
+    relativePath: string,
+  ): void {
+    const existing = this.#db
+      .prepare<
+        [string, number, string],
+        { memory_id: string; canonical_path: string; fingerprint: string }
+      >(
+        `SELECT memory_id, canonical_path, fingerprint FROM memory_index_entries
+          WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+      )
+      .get(rootId, generationId, relativePath);
+    if (existing === undefined) return;
+    this.#db
+      .prepare(
+        `DELETE FROM memory_fts
+          WHERE root_id = ? AND generation_id = ? AND memory_id = ?`,
+      )
+      .run(rootId, generationId, existing.memory_id);
+    this.#db
+      .prepare(
+        `DELETE FROM memory_index_entries
+          WHERE root_id = ? AND generation_id = ? AND memory_id = ?`,
+      )
+      .run(rootId, generationId, existing.memory_id);
+    this.#advanceGenerationProgress({
+      generationId,
+      previous: {
+        canonicalPath: existing.canonical_path,
+        fingerprint: existing.fingerprint,
+      },
+      entryDelta: -1,
+      byteDelta: -indexedEntryBytes(
+        existing.canonical_path,
+        existing.fingerprint,
+      ),
+    });
+  }
+
+  #advanceGenerationProgress(input: {
+    readonly generationId: number;
+    readonly previous?: {
+      readonly canonicalPath: string;
+      readonly fingerprint: string;
+    };
+    readonly next?: {
+      readonly canonicalPath: string;
+      readonly fingerprint: string;
+    };
+    readonly entryDelta: number;
+    readonly byteDelta: number;
+  }): void {
+    const generation = this.#generationById(input.generationId);
+    if (generation === null) {
+      throw new Error(
+        "memory generation disappeared during progress checkpoint",
+      );
+    }
+    const digest = Buffer.from(
+      generation.digest ?? EMPTY_MEMORY_GENERATION_DIGEST,
+      "hex",
+    );
+    if (input.previous !== undefined) {
+      xorDigest(digest, memoryEntryDigest(input.previous));
+    }
+    if (input.next !== undefined) {
+      xorDigest(digest, memoryEntryDigest(input.next));
+    }
+    this.#db
+      .prepare(
+        `UPDATE memory_index_generations
+            SET entry_count = entry_count + ?,
+                indexed_bytes = indexed_bytes + ?,
+                digest = ?
+          WHERE id = ?`,
+      )
+      .run(
+        input.entryDelta,
+        input.byteDelta,
+        digest.toString("hex"),
+        input.generationId,
+      );
+  }
+
+  #requeueDirectory(
+    root: BoundRoot,
+    generationId: number,
+    relativePath: string,
+    identity: DirectoryIdentity,
+  ): void {
+    this.#db
+      .prepare(
+        `UPDATE memory_index_directory_work
+            SET state = 'pending', dev = ?, ino = ?, mtime_ns = ?
+          WHERE root_id = ? AND generation_id = ? AND relative_path = ?`,
+      )
+      .run(
+        identity.dev.toString(),
+        identity.ino.toString(),
+        identity.mtimeNs.toString(),
+        root.rootId,
+        generationId,
+        relativePath,
+      );
+  }
+
+  #stagingGeneration(rootId: string): GenerationRow | null {
+    return (
+      this.#db
+        .prepare<[string], GenerationRow>(
+          `SELECT * FROM memory_index_generations
+            WHERE root_id = ? AND state = 'staging'
+            ORDER BY id DESC LIMIT 1`,
+        )
+        .get(rootId) ?? null
+    );
+  }
+
+  #generationById(id: number): GenerationRow | null {
+    return (
+      this.#db
+        .prepare<[number], GenerationRow>(
+          "SELECT * FROM memory_index_generations WHERE id = ?",
+        )
+        .get(id) ?? null
+    );
+  }
+
+  #latestChangeCursor(rootId: string): number {
+    return this.#db
+      .prepare<[string], { cursor: number }>(
+        "SELECT COALESCE(MAX(sequence), 0) AS cursor FROM memory_index_change_log WHERE root_id = ?",
+      )
+      .get(rootId)!.cursor;
+  }
+
+  #claimBuildLease(generationId: number): boolean {
+    const now = this.#now();
+    const result = this.#db
+      .prepare(
+        `UPDATE memory_index_generations
+            SET builder_owner = ?, builder_lease_expires_at_ms = ?
+          WHERE id = ? AND state IN ('staging', 'complete')
+            AND (
+              builder_owner IS NULL OR builder_owner = ? OR
+              builder_lease_expires_at_ms IS NULL OR builder_lease_expires_at_ms <= ?
+            )`,
+      )
+      .run(
+        this.#builderOwner,
+        now + MEMORY_INDEX_BUILD_LEASE_MS,
+        generationId,
+        this.#builderOwner,
+        now,
+      );
+    return result.changes === 1;
+  }
+
+  #releaseBuildLease(generationId: number): void {
+    this.#db
+      .prepare(
+        `UPDATE memory_index_generations
+            SET builder_owner = NULL, builder_lease_expires_at_ms = NULL
+          WHERE id = ? AND builder_owner = ?`,
+      )
+      .run(generationId, this.#builderOwner);
+  }
+
+  #failGeneration(generationId: number, error: unknown): void {
+    this.#db
+      .transaction(() => {
+        this.#db
+          .prepare(
+            `UPDATE memory_index_generations
+                SET state = 'failed', error = ?
+              WHERE id = ? AND state = 'staging'`,
+          )
+          .run(
+            error instanceof Error ? error.message : String(error),
+            generationId,
+          );
+        this.#db
+          .prepare("DELETE FROM memory_fts WHERE generation_id = ?")
+          .run(generationId);
+        this.#db
+          .prepare("DELETE FROM memory_index_entries WHERE generation_id = ?")
+          .run(generationId);
+        this.#db
+          .prepare(
+            "DELETE FROM memory_index_directory_work WHERE generation_id = ?",
+          )
+          .run(generationId);
+        this.#db
+          .prepare(
+            "DELETE FROM memory_index_discovered_files WHERE generation_id = ?",
+          )
+          .run(generationId);
+      })
+      .immediate();
+  }
+
+  async #closeGenerationDirectories(
+    rootId: string,
+    generationId: number,
+  ): Promise<void> {
+    const prefix = `${rootId}:${generationId}:`;
+    const closes: Promise<void>[] = [];
+    for (const [key, state] of this.#openDirectories) {
+      if (!key.startsWith(prefix)) continue;
+      this.#openDirectories.delete(key);
+      closes.push(
+        state.directory
+          .close()
+          .catch(() => undefined)
+          .then(() => {
+            activeMemoryBuildOpenDirectories -= 1;
+          }),
+      );
+    }
+    await Promise.all(closes);
+  }
+
+  #evictLeastRecentlyUsedRoot(excludedRootId: string): boolean {
+    const now = this.#now();
+    const rows = this.#db
+      .prepare<[string, number, string, number, number], RootRow>(
+        `SELECT * FROM memory_index_roots
+          WHERE root_id <> ?
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_index_generations g
+               WHERE g.root_id = memory_index_roots.root_id
+                 AND g.state = 'staging'
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_index_owners o
+               WHERE o.root_id = memory_index_roots.root_id
+                 AND o.lease_expires_at_ms > ?
+                 AND o.owner_id <> ?
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_index_generations g
+               WHERE g.root_id = memory_index_roots.root_id
+                 AND g.builder_owner IS NOT NULL
+                 AND g.builder_lease_expires_at_ms > ?
+            )
+          ORDER BY last_used_at_ms, root_id
+          LIMIT ?`,
+      )
+      .all(
+        excludedRootId,
+        now,
+        this.#builderOwner,
+        now,
+        MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH,
+      );
+    for (const row of rows) {
+      if (this.#rootHasActiveLocalWork(row.root_id)) continue;
+      if (this.#deleteIndexedRoot(row.root_id, now)) return true;
+    }
+    return false;
+  }
+
+  #deleteIndexedRoot(rootId: string, now: number): boolean {
+    let deleted = false;
+    this.#db
+      .transaction(() => {
+        const foreignOwner = this.#db
+          .prepare<[string, number, string], { present: number }>(
+            `SELECT 1 AS present FROM memory_index_owners
+              WHERE root_id = ? AND lease_expires_at_ms > ?
+                AND owner_id <> ?
+              LIMIT 1`,
+          )
+          .get(rootId, now, this.#builderOwner);
+        const activeGeneration = this.#db
+          .prepare<[string, number], { present: number }>(
+            `SELECT 1 AS present FROM memory_index_generations
+              WHERE root_id = ?
+                AND (
+                  state = 'staging' OR (
+                    builder_owner IS NOT NULL AND
+                    builder_lease_expires_at_ms > ?
+                  )
+                )
+              LIMIT 1`,
+          )
+          .get(rootId, now);
+        if (foreignOwner !== undefined || activeGeneration !== undefined) {
+          return;
+        }
+        this.#db
+          .prepare("DELETE FROM memory_fts WHERE root_id = ?")
+          .run(rootId);
+        deleted =
+          this.#db
+            .prepare("DELETE FROM memory_index_roots WHERE root_id = ?")
+            .run(rootId).changes === 1;
+      })
+      .immediate();
+    if (deleted) this.#retireLocalWatcher(rootId);
+    return deleted;
+  }
+
+  #retireLocalWatcher(rootId: string): void {
+    const watcher = this.#watchers.get(rootId);
+    if (watcher !== undefined) {
+      watcher.close();
+      this.#watchers.delete(rootId);
+      activeMemoryIndexWatchers -= 1;
+    }
+    for (const [key, timer] of this.#watchDebounceTimers) {
+      if (!key.startsWith(`${rootId}:`)) continue;
+      clearTimeout(timer);
+      this.#watchDebounceTimers.delete(key);
+    }
+    const auditTimer = this.#auditTimers.get(rootId);
+    if (auditTimer !== undefined) {
+      clearTimeout(auditTimer);
+      this.#auditTimers.delete(rootId);
+    }
+    this.#releaseWatcherOwner(rootId);
+    if (this.#watchers.size === 0 && this.#ownerHeartbeatTimer !== null) {
+      clearTimeout(this.#ownerHeartbeatTimer);
+      this.#ownerHeartbeatTimer = null;
+    }
+  }
+
+  #rootHasActiveLocalWork(rootId: string): boolean {
+    const buildKey = `${this.databasePath}:${rootId}`;
+    return (
+      activeBuilds.has(buildKey) ||
+      this.#sliceLocks.has(buildKey) ||
+      this.#backgroundRefreshes.has(rootId) ||
+      (this.#activeQueryRoots.get(rootId) ?? 0) > 0
+    );
+  }
+
+  #acquireQueryRoot(rootId: string): void {
+    this.#activeQueryRoots.set(
+      rootId,
+      (this.#activeQueryRoots.get(rootId) ?? 0) + 1,
+    );
+  }
+
+  #releaseQueryRoot(rootId: string): void {
+    const count = this.#activeQueryRoots.get(rootId) ?? 0;
+    if (count <= 1) {
+      this.#activeQueryRoots.delete(rootId);
+      return;
+    }
+    this.#activeQueryRoots.set(rootId, count - 1);
+  }
+
+  #deleteOldGenerations(rootId: string): void {
+    const old = this.#db
+      .prepare<[string, number], { id: number }>(
+        `SELECT id FROM memory_index_generations
+          WHERE root_id = ? AND state IN ('complete', 'superseded', 'failed')
+          ORDER BY CASE state WHEN 'complete' THEN 0 ELSE 1 END, id DESC
+          LIMIT -1 OFFSET ?`,
+      )
+      .all(rootId, MAX_COMPLETE_GENERATIONS_PER_ROOT);
+    for (const { id } of old) {
+      this.#db
+        .prepare("DELETE FROM memory_fts WHERE generation_id = ?")
+        .run(id);
+      this.#db
+        .prepare("DELETE FROM memory_index_generations WHERE id = ?")
+        .run(id);
+    }
+  }
+
+  #recoverInterruptedEnumeration(): void {
+    this.#db
+      .transaction(() => {
+        this.#db
+          .prepare(
+            `UPDATE memory_index_directory_work SET state = 'pending'
+              WHERE state = 'enumerating'`,
+          )
+          .run();
+        this.#db
+          .prepare(
+            "DELETE FROM memory_index_owners WHERE lease_expires_at_ms <= ?",
+          )
+          .run(this.#now());
+      })
+      .immediate();
+  }
+}
+
+export function resolveMemoryIndexDatabasePath(agencHome: string): string {
+  if (agencHome.trim().length === 0 || !isAbsolute(agencHome)) {
+    throw new MemoryIndexBoundaryError(
+      "memory index state requires an absolute AgenC home",
+    );
+  }
+  return join(agencHome, MEMORY_INDEX_DIRECTORY, MEMORY_INDEX_FILENAME);
+}
+
+function validateRootSpecsBeforeIo(
+  rootSpecs: readonly MemoryIndexRootSpec[],
+): void {
+  if (rootSpecs.length > MAX_MEMORY_INDEX_ROOTS) {
+    throw new MemoryIndexBoundaryError("memory root count exceeds limit");
+  }
+  for (const root of rootSpecs) {
+    if (root.role !== "global" && root.role !== "project") {
+      throw new MemoryIndexBoundaryError("memory root role is invalid");
+    }
+    validateMemoryRootPathBeforeIo(root.path);
+  }
+}
+
+function validateMemoryRootPathBeforeIo(path: string): void {
+  if (!isAbsolute(path)) {
+    throw new MemoryIndexBoundaryError("memory root must be absolute");
+  }
+  if (Buffer.byteLength(path, "utf8") > MAX_MEMORY_PATH_UTF8_BYTES) {
+    throw new MemoryIndexBoundaryError("memory root path exceeds limit");
+  }
+}
+
+async function bindRoots(
+  rootSpecs: readonly MemoryIndexRootSpec[],
+  signal: AbortSignal,
+): Promise<BoundRoot[]> {
+  const roots: BoundRoot[] = [];
+  const seen = new Set<string>();
+  for (const spec of rootSpecs) {
+    throwIfAborted(signal);
+    try {
+      const requested = resolve(spec.path);
+      const metadata = await lstat(requested, { bigint: true });
+      throwIfAborted(signal);
+      if (!metadata.isDirectory() || metadata.isSymbolicLink()) continue;
+      const canonicalRoot = (await realpath(requested)).normalize("NFC");
+      throwIfAborted(signal);
+      if (
+        Buffer.byteLength(canonicalRoot, "utf8") > MAX_MEMORY_PATH_UTF8_BYTES
+      ) {
+        throw new MemoryIndexBoundaryError(
+          "canonical memory root path exceeds limit",
+        );
+      }
+      const rootId = memoryIndexRootId(canonicalRoot);
+      if (seen.has(rootId)) continue;
+      seen.add(rootId);
+      roots.push({
+        rootId,
+        canonicalRoot,
+        role: spec.role,
+        identity: identityFromStats(metadata),
+      });
+    } catch (error) {
+      throwIfAborted(signal);
+      if (error instanceof MemoryIndexBoundaryError) throw error;
+    }
+  }
+  return roots;
+}
+
+async function readIndexedHeader(
+  root: BoundRoot,
+  relativePath: string,
+  absolutePath: string,
+  signal: AbortSignal,
+): Promise<IndexedMemoryHeader | null> {
+  throwIfAborted(signal);
+  const relativeToRoot = relative(root.canonicalRoot, absolutePath);
+  if (
+    relativeToRoot.startsWith("..") ||
+    isAbsolute(relativeToRoot) ||
+    relativeToRoot !== relativePath
+  ) {
+    throw new MemoryIndexBoundaryError(
+      "memory candidate escaped its canonical root",
+    );
+  }
+  const before = await lstat(absolutePath, { bigint: true });
+  throwIfAborted(signal);
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1n)
+    return null;
+  if (before.size > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new MemoryIndexBoundaryError(
+      "memory file size is not safely representable",
+    );
+  }
+  const handle = await open(absolutePath, "r");
+  try {
+    const opened = await handle.stat({ bigint: true });
+    if (
+      !sameFileIdentity(identityFromStats(before), identityFromStats(opened))
+    ) {
+      throw new Error("memory file changed before bounded header read");
+    }
+    const bytes = await readBoundedHeader(handle, signal);
+    const after = await handle.stat({ bigint: true });
+    if (
+      !sameFileIdentity(identityFromStats(opened), identityFromStats(after))
+    ) {
+      throw new Error("memory file changed during bounded header read");
+    }
+    const text = bytes.toString("utf8");
+    const { frontmatter } = parseFrontmatter(
+      firstLines(text, FRONTMATTER_MAX_LINES),
+      absolutePath,
+    );
+    const title =
+      typeof frontmatter.title === "string"
+        ? frontmatter.title
+        : typeof frontmatter.name === "string"
+          ? frontmatter.name
+          : basename(relativePath, ".md");
+    const description =
+      typeof frontmatter.description === "string"
+        ? frontmatter.description
+        : "";
+    const type = parseMemoryType(frontmatter.type) ?? null;
+    const canonicalPath = join(root.canonicalRoot, relativePath).normalize(
+      "NFC",
+    );
+    return {
+      memoryId: stableMemoryId(canonicalPath),
+      canonicalPath,
+      title,
+      description,
+      type,
+      mtimeMs: Number(opened.mtimeNs / 1_000_000n),
+      fileSize: Number(opened.size),
+      fingerprint: computeMemoryHeaderFingerprint(bytes, {
+        title,
+        description,
+        type,
+      }),
+      fileIdentity: identityFromStats(opened),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readBoundedHeader(
+  handle: FileHandle,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(MAX_MEMORY_HEADER_UTF8_BYTES);
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    throwIfAborted(signal);
+    const result = await handle.read(
+      buffer,
+      offset,
+      buffer.byteLength - offset,
+      offset,
+    );
+    if (result.bytesRead === 0) break;
+    offset += result.bytesRead;
+  }
+  throwIfAborted(signal);
+  return buffer.subarray(0, offset);
+}
+
+async function readDirectoryIdentity(
+  path: string,
+  signal: AbortSignal,
+): Promise<DirectoryIdentity> {
+  const metadata = await lstat(path, { bigint: true });
+  throwIfAborted(signal);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error("memory directory identity is not stable");
+  }
+  return {
+    dev: metadata.dev,
+    ino: metadata.ino,
+    mtimeNs: metadata.mtimeNs,
+  };
+}
+
+function sameDirectoryIdentity(
+  left: DirectoryIdentity,
+  right: DirectoryIdentity,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mtimeNs === right.mtimeNs
+  );
+}
+
+function identityFromStats(stats: {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+}): FileIdentity {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    size: stats.size,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+  };
+}
+
+function sameFileIdentity(left: FileIdentity, right: FileIdentity): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+function entryRowToRankCandidate(
+  row: EntryRow,
+  rootRole: MemoryIndexRootRole,
+): MemoryRankCandidate {
+  return {
+    memoryId: row.memory_id,
+    canonicalPath: row.canonical_path,
+    title: row.title,
+    description: row.description,
+    type: row.memory_type,
+    mtimeMs: row.mtime_ms,
+    size: row.file_size,
+    fingerprint: row.fingerprint,
+    rootId: row.root_id,
+    rootRole,
+  };
+}
+
+function entryRowToMemoryHeader(row: EntryRow): MemoryHeader {
+  const storedRootIdentity: FileIdentity = {
+    dev: BigInt(row.root_dev),
+    ino: BigInt(row.root_ino),
+    mode: BigInt(row.root_mode),
+    size: BigInt(row.root_size),
+    mtimeNs: BigInt(row.root_mtime_ns),
+    ctimeNs: BigInt(row.root_ctime_ns),
+  };
+  const rootPath = dirnameFromRelative(row.canonical_path, row.relative_path);
+  let rootIdentity = storedRootIdentity;
+  try {
+    const current = lstatSync(rootPath, { bigint: true });
+    if (current.isDirectory() && !current.isSymbolicLink()) {
+      rootIdentity = identityFromStats(current);
+    }
+  } catch {
+    // The subsequent descriptor-bound read rejects the stored stale identity.
+  }
+  const root: MemoryRootBinding = {
+    requestedPath: rootPath,
+    canonicalPath: rootPath,
+    identity: rootIdentity,
+  };
+  return {
+    filename: row.relative_path,
+    relativePath: row.relative_path,
+    filePath: row.canonical_path,
+    pathBytes: Buffer.from(row.canonical_path, "utf8"),
+    mtimeMs: row.mtime_ms,
+    title: row.title,
+    description: row.description || null,
+    type: parseMemoryType(row.memory_type),
+    root,
+    identity: {
+      dev: BigInt(row.file_dev),
+      ino: BigInt(row.file_ino),
+      mode: BigInt(row.file_mode),
+      size: BigInt(row.file_size),
+      mtimeNs: BigInt(row.file_mtime_ns),
+      ctimeNs: BigInt(row.file_ctime_ns),
+    },
+  };
+}
+
+function dirnameFromRelative(
+  canonicalPath: string,
+  relativePath: string,
+): string {
+  let root = canonicalPath;
+  for (const segment of relativePath.split(/[/\\]/u)) {
+    if (segment.length > 0) root = dirname(root);
+  }
+  return root;
+}
+
+function firstLines(value: string, maximumLines: number): string {
+  return value.split("\n").slice(0, maximumLines).join("\n");
+}
+
+function encodeAuditCursor(
+  phase: MemoryAuditPhase,
+  relativePath: string,
+): string {
+  return JSON.stringify([phase, relativePath]);
+}
+
+function decodeAuditCursor(cursor: string | null): MemoryAuditCursor {
+  if (cursor === null) return { phase: "entries", relativePath: "" };
+  try {
+    const decoded = JSON.parse(cursor) as unknown;
+    if (
+      Array.isArray(decoded) &&
+      decoded.length === 2 &&
+      (decoded[0] === "entries" || decoded[0] === "directories") &&
+      typeof decoded[1] === "string"
+    ) {
+      return { phase: decoded[0], relativePath: decoded[1] };
+    }
+  } catch {
+    // A malformed derived cursor safely restarts the bounded audit.
+  }
+  return { phase: "entries", relativePath: "" };
+}
+
+function validatePortableRelativePath(path: string): void {
+  if (
+    path.length === 0 ||
+    isAbsolute(path) ||
+    path.split(/[/\\]/u).some((segment) => segment === "..")
+  ) {
+    throw new MemoryIndexBoundaryError("memory relative path is invalid");
+  }
+  if (Buffer.byteLength(path, "utf8") > MAX_MEMORY_PATH_UTF8_BYTES) {
+    throw new MemoryIndexBoundaryError("memory path exceeds limit");
+  }
+}
+
+function sliceExhausted(budget: BuildSliceBudget): boolean {
+  return (
+    budget.newEntries >= MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE ||
+    performance.now() - budget.startedAt >= MAX_MEMORY_INDEX_BUILD_SLICE_MS
+  );
+}
+
+function openDirectoryKey(
+  rootId: string,
+  generationId: number,
+  relativePath: string,
+): string {
+  return `${rootId}:${generationId}:${relativePath}`;
+}
+
+function databaseBytes(database: BetterSqlite3.Database): number {
+  const pageCount = database.pragma("page_count", { simple: true });
+  const pageSize = database.pragma("page_size", { simple: true });
+  if (typeof pageCount !== "number" || typeof pageSize !== "number") {
+    throw new Error("memory index database byte accounting is unavailable");
+  }
+  return pageCount * pageSize;
+}
+
+function indexedEntryBytes(canonicalPath: string, fingerprint: string): number {
+  return Buffer.byteLength(canonicalPath, "utf8") + fingerprint.length / 2;
+}
+
+function memoryEntryDigest(input: {
+  readonly canonicalPath: string;
+  readonly fingerprint: string;
+}): Buffer {
+  if (!/^[0-9a-f]{64}$/u.test(input.fingerprint)) {
+    throw new MemoryIndexCorruptionError(
+      "memory index entry has an invalid content fingerprint",
+    );
+  }
+  const hash = createHash("sha256");
+  hash.update("agenc-memory-index-entry-v1\0");
+  for (const field of [
+    Buffer.from(input.canonicalPath, "utf8"),
+    Buffer.from(input.fingerprint, "hex"),
+  ]) {
+    const length = Buffer.alloc(DIGEST_LENGTH_PREFIX_BYTES);
+    length.writeBigUInt64BE(BigInt(field.byteLength));
+    hash.update(length);
+    hash.update(field);
+  }
+  return hash.digest();
+}
+
+function xorDigest(target: Buffer, contribution: Buffer): void {
+  if (
+    target.byteLength !== SHA256_DIGEST_BYTES ||
+    contribution.byteLength !== SHA256_DIGEST_BYTES
+  ) {
+    throw new MemoryIndexCorruptionError(
+      "memory index generation digest has an invalid length",
+    );
+  }
+  for (let index = 0; index < SHA256_DIGEST_BYTES; index += 1) {
+    target[index] = target[index]! ^ contribution[index]!;
+  }
+}
+
+function realpathSyncExisting(path: string): string {
+  if (!statSync(path).isDirectory()) {
+    throw new MemoryIndexBoundaryError("memory change root is not a directory");
+  }
+  const canonical = realpathSync(path);
+  if (Buffer.byteLength(canonical, "utf8") > MAX_MEMORY_PATH_UTF8_BYTES) {
+    throw new MemoryIndexBoundaryError(
+      "canonical memory root path exceeds limit",
+    );
+  }
+  return canonical.normalize("NFC");
+}
+
+function unavailableRootStatus(
+  spec: MemoryIndexRootSpec,
+): MemoryIndexGenerationStatus {
+  return {
+    rootId: "",
+    canonicalRoot: spec.path,
+    role: spec.role,
+    generationId: null,
+    generationToken: null,
+    state: "unavailable",
+    ageMs: null,
+    watcherHealth: "degraded",
+    auditCursor: null,
+    reason: "memory root or FTS5 capability is unavailable",
+  };
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortReason(signal);
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ?? new DOMException("Memory indexing aborted", "AbortError")
+  );
+}
+
+function errnoCode(error: unknown): string | undefined {
+  return error !== null && typeof error === "object" && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolvePromise) => setImmediate(resolvePromise));
+}

--- a/runtime/src/memory/full-corpus-protocol.ts
+++ b/runtime/src/memory/full-corpus-protocol.ts
@@ -1,0 +1,124 @@
+import { Buffer } from "node:buffer";
+
+import {
+  MAX_MEMORY_FTS_CANDIDATES,
+  MAX_MEMORY_QUERY_RESULT_BYTES,
+  type MemoryIndexRootRole,
+  type MemoryRankCandidate,
+} from "./full-corpus-contract.js";
+
+export const MEMORY_QUERY_HELPER_PROTOCOL_VERSION = 1;
+export const MEMORY_QUERY_FRAME_HEADER_BYTES = 4;
+export const MAX_MEMORY_QUERY_REQUEST_BYTES = 1_048_576;
+
+export interface MemoryQueryHelperRequest {
+  readonly protocolVersion: typeof MEMORY_QUERY_HELPER_PROTOCOL_VERSION;
+  readonly databasePath: string;
+  readonly rootId: string;
+  readonly generationId: number;
+  readonly rootRole: MemoryIndexRootRole;
+  readonly match: string;
+  readonly limit: number;
+}
+
+export type MemoryQueryHelperResponse =
+  | {
+      readonly protocolVersion: typeof MEMORY_QUERY_HELPER_PROTOCOL_VERSION;
+      readonly kind: "ok";
+      readonly candidates: readonly MemoryRankCandidate[];
+    }
+  | {
+      readonly protocolVersion: typeof MEMORY_QUERY_HELPER_PROTOCOL_VERSION;
+      readonly kind: "error";
+      readonly code:
+        | "capability_unavailable"
+        | "invalid_request"
+        | "query_failed"
+        | "query_resource_limited";
+      readonly message: string;
+    };
+
+export function encodeMemoryQueryFrame(value: object): Buffer {
+  const payload = Buffer.from(JSON.stringify(value), "utf8");
+  if (payload.byteLength > MAX_MEMORY_QUERY_REQUEST_BYTES) {
+    throw new RangeError("memory query request frame exceeds its byte limit");
+  }
+  const frame = Buffer.allocUnsafe(
+    MEMORY_QUERY_FRAME_HEADER_BYTES + payload.byteLength,
+  );
+  frame.writeUInt32BE(payload.byteLength, 0);
+  payload.copy(frame, MEMORY_QUERY_FRAME_HEADER_BYTES);
+  return frame;
+}
+
+export function decodeMemoryQueryResponseFrame(
+  frame: Uint8Array,
+): MemoryQueryHelperResponse {
+  if (
+    frame.byteLength < MEMORY_QUERY_FRAME_HEADER_BYTES ||
+    frame.byteLength >
+      MEMORY_QUERY_FRAME_HEADER_BYTES + MAX_MEMORY_QUERY_RESULT_BYTES
+  ) {
+    throw new Error("memory query response frame has invalid length");
+  }
+  const bytes = Buffer.from(frame);
+  const payloadLength = bytes.readUInt32BE(0);
+  if (
+    payloadLength !== bytes.byteLength - MEMORY_QUERY_FRAME_HEADER_BYTES ||
+    payloadLength > MAX_MEMORY_QUERY_RESULT_BYTES
+  ) {
+    throw new Error(
+      "memory query response frame length does not match payload",
+    );
+  }
+  const parsed = JSON.parse(
+    bytes.subarray(MEMORY_QUERY_FRAME_HEADER_BYTES).toString("utf8"),
+  ) as unknown;
+  if (!isRecord(parsed))
+    throw new Error("memory query response is not an object");
+  if (parsed.protocolVersion !== MEMORY_QUERY_HELPER_PROTOCOL_VERSION) {
+    throw new Error("memory query response protocol version is incompatible");
+  }
+  if (parsed.kind === "error") {
+    if (typeof parsed.code !== "string" || typeof parsed.message !== "string") {
+      throw new Error("memory query error response is malformed");
+    }
+    return parsed as MemoryQueryHelperResponse;
+  }
+  if (parsed.kind !== "ok" || !Array.isArray(parsed.candidates)) {
+    throw new Error("memory query success response is malformed");
+  }
+  if (parsed.candidates.length > MAX_MEMORY_FTS_CANDIDATES) {
+    throw new Error("memory query response candidate count exceeds limit");
+  }
+  for (const candidate of parsed.candidates) {
+    if (!isMemoryRankCandidate(candidate)) {
+      throw new Error("memory query response contains a malformed candidate");
+    }
+  }
+  return parsed as unknown as MemoryQueryHelperResponse;
+}
+
+function isMemoryRankCandidate(value: unknown): value is MemoryRankCandidate {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.memoryId === "string" &&
+    typeof value.canonicalPath === "string" &&
+    typeof value.title === "string" &&
+    typeof value.description === "string" &&
+    (typeof value.type === "string" || value.type === null) &&
+    typeof value.mtimeMs === "number" &&
+    Number.isFinite(value.mtimeMs) &&
+    typeof value.size === "number" &&
+    Number.isSafeInteger(value.size) &&
+    typeof value.fingerprint === "string" &&
+    typeof value.rootId === "string" &&
+    (value.rootRole === "global" || value.rootRole === "project") &&
+    typeof value.bm25Score === "number" &&
+    Number.isFinite(value.bm25Score)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/runtime/src/memory/full-corpus-storage.ts
+++ b/runtime/src/memory/full-corpus-storage.ts
@@ -1,0 +1,315 @@
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import { dirname } from "node:path";
+
+import Database from "better-sqlite3";
+import type BetterSqlite3 from "better-sqlite3";
+
+import {
+  MEMORY_FTS_TOKENIZER,
+  MEMORY_INDEX_SCHEMA_VERSION,
+} from "./full-corpus-contract.js";
+
+const INDEX_DIRECTORY_MODE = 0o700;
+const INDEX_FILE_MODE = 0o600;
+const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+const MEMORY_INDEX_SCHEMA_SIGNATURE =
+  "agenc-memory-index-schema-v1-generational-fts5-sliced-audit-owners";
+
+export interface OpenMemoryIndexDatabaseResult {
+  readonly database: BetterSqlite3.Database;
+  readonly ftsAvailable: boolean;
+}
+
+export class MemoryIndexSchemaError extends Error {
+  constructor(readonly foundVersion: number) {
+    super(
+      `memory index schema ${foundVersion} is incompatible with ${MEMORY_INDEX_SCHEMA_VERSION}`,
+    );
+    this.name = "MemoryIndexSchemaError";
+  }
+}
+
+export class MemoryIndexCorruptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MemoryIndexCorruptionError";
+  }
+}
+
+export function openMemoryIndexDatabase(
+  databasePath: string,
+): OpenMemoryIndexDatabaseResult {
+  const directory = dirname(databasePath);
+  mkdirSync(directory, { recursive: true, mode: INDEX_DIRECTORY_MODE });
+  chmodSync(directory, INDEX_DIRECTORY_MODE);
+  let database: BetterSqlite3.Database | undefined;
+  let ftsAvailable: boolean;
+  try {
+    database = new Database(databasePath);
+    configureDatabase(database);
+    assertDatabaseIntegrity(database);
+    ftsAvailable = probeFtsCapability(database);
+    initializeSchema(database, ftsAvailable);
+    chmodSync(databasePath, INDEX_FILE_MODE);
+  } catch (error) {
+    database?.close();
+    const recoverable = classifyRecoverableDatabaseError(error);
+    if (recoverable === null) throw error;
+    rotateIncompatibleDatabase(databasePath, recoverable);
+    database = new Database(databasePath);
+    configureDatabase(database);
+    ftsAvailable = probeFtsCapability(database);
+    initializeSchema(database, ftsAvailable);
+    chmodSync(databasePath, INDEX_FILE_MODE);
+  }
+  if (database === undefined) {
+    throw new Error("memory index database initialization did not complete");
+  }
+  return { database, ftsAvailable };
+}
+
+function configureDatabase(database: BetterSqlite3.Database): void {
+  database.pragma("journal_mode = WAL");
+  database.pragma("synchronous = FULL");
+  database.pragma("foreign_keys = ON");
+  database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+  database.pragma("temp_store = MEMORY");
+}
+
+function assertDatabaseIntegrity(database: BetterSqlite3.Database): void {
+  let result: unknown;
+  try {
+    result = database.pragma("quick_check", { simple: true });
+  } catch (error) {
+    throw new MemoryIndexCorruptionError(
+      `memory index integrity check failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (result !== "ok") {
+    throw new MemoryIndexCorruptionError(
+      "memory index integrity check reported corruption",
+    );
+  }
+}
+
+function classifyRecoverableDatabaseError(
+  error: unknown,
+): MemoryIndexSchemaError | MemoryIndexCorruptionError | null {
+  if (
+    error instanceof MemoryIndexSchemaError ||
+    error instanceof MemoryIndexCorruptionError
+  ) {
+    return error;
+  }
+  const code =
+    error !== null && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code)
+      : "";
+  if (code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB") {
+    return new MemoryIndexCorruptionError(
+      `memory index database is corrupt: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  return null;
+}
+
+function rotateIncompatibleDatabase(
+  databasePath: string,
+  error: MemoryIndexSchemaError | MemoryIndexCorruptionError,
+): void {
+  const reason =
+    error instanceof MemoryIndexSchemaError
+      ? `schema-${error.foundVersion}`
+      : "corrupt";
+  const backupBase = `${databasePath}.${reason}-${Date.now()}-${randomUUID()}`;
+  for (const suffix of ["", "-wal", "-shm"] as const) {
+    const source = `${databasePath}${suffix}`;
+    if (!existsSync(source)) continue;
+    renameSync(source, `${backupBase}${suffix}`);
+  }
+}
+
+function probeFtsCapability(database: BetterSqlite3.Database): boolean {
+  try {
+    database.exec(
+      `CREATE VIRTUAL TABLE temp.agenc_memory_fts_probe
+         USING fts5(title, description, tokenize='${MEMORY_FTS_TOKENIZER}')`,
+    );
+    database
+      .prepare(
+        "INSERT INTO temp.agenc_memory_fts_probe(title, description) VALUES (?, ?)",
+      )
+      .run("café", "probe");
+    const row = database
+      .prepare(
+        "SELECT rowid FROM temp.agenc_memory_fts_probe WHERE title MATCH ?",
+      )
+      .get('"cafe"');
+    database.exec("DROP TABLE temp.agenc_memory_fts_probe");
+    return row !== undefined;
+  } catch {
+    try {
+      database.exec("DROP TABLE IF EXISTS temp.agenc_memory_fts_probe");
+    } catch {
+      // Capability probing is best effort and must not alter the last good index.
+    }
+    return false;
+  }
+}
+
+function initializeSchema(
+  database: BetterSqlite3.Database,
+  ftsAvailable: boolean,
+): void {
+  const version = database.pragma("user_version", { simple: true });
+  if (!ftsAvailable) return;
+  if (version !== 0 && version !== MEMORY_INDEX_SCHEMA_VERSION) {
+    throw new MemoryIndexSchemaError(Number(version));
+  }
+  if (
+    version === MEMORY_INDEX_SCHEMA_VERSION &&
+    readMemorySchemaSignature(database) !== MEMORY_INDEX_SCHEMA_SIGNATURE
+  ) {
+    throw new MemoryIndexSchemaError(Number(version));
+  }
+  database
+    .transaction(() => {
+      database.exec(`
+        CREATE TABLE IF NOT EXISTS memory_index_metadata(
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        ) WITHOUT ROWID;
+        CREATE TABLE IF NOT EXISTS memory_index_roots(
+          root_id TEXT PRIMARY KEY,
+          canonical_path TEXT NOT NULL UNIQUE,
+          root_role TEXT NOT NULL CHECK(root_role IN ('global', 'project')),
+          current_generation_id INTEGER,
+          last_used_at_ms INTEGER NOT NULL,
+          watcher_health TEXT NOT NULL CHECK(watcher_health IN ('healthy', 'degraded', 'overflow')),
+          audit_cursor TEXT
+        );
+        CREATE TABLE IF NOT EXISTS memory_index_generations(
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          root_id TEXT NOT NULL REFERENCES memory_index_roots(root_id) ON DELETE CASCADE,
+          state TEXT NOT NULL CHECK(state IN ('staging', 'complete', 'failed', 'superseded')),
+          generation_token TEXT NOT NULL UNIQUE,
+          started_at_ms INTEGER NOT NULL,
+          completed_at_ms INTEGER,
+          elapsed_active_ms INTEGER NOT NULL,
+          discovery_operations INTEGER NOT NULL,
+          entry_count INTEGER NOT NULL,
+          indexed_bytes INTEGER NOT NULL,
+          digest TEXT,
+          change_cursor INTEGER NOT NULL,
+          change_overflow INTEGER NOT NULL CHECK(change_overflow IN (0, 1)),
+          error TEXT,
+          builder_owner TEXT,
+          builder_lease_expires_at_ms INTEGER
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS memory_one_staging_generation
+          ON memory_index_generations(root_id) WHERE state = 'staging';
+        CREATE TABLE IF NOT EXISTS memory_index_directory_work(
+          root_id TEXT NOT NULL,
+          generation_id INTEGER NOT NULL REFERENCES memory_index_generations(id) ON DELETE CASCADE,
+          relative_path TEXT NOT NULL,
+          state TEXT NOT NULL CHECK(state IN ('pending', 'enumerating', 'complete')),
+          dev TEXT NOT NULL,
+          ino TEXT NOT NULL,
+          mtime_ns TEXT NOT NULL,
+          PRIMARY KEY(root_id, generation_id, relative_path)
+        ) WITHOUT ROWID;
+        CREATE TABLE IF NOT EXISTS memory_index_discovered_files(
+          root_id TEXT NOT NULL,
+          generation_id INTEGER NOT NULL REFERENCES memory_index_generations(id) ON DELETE CASCADE,
+          relative_path TEXT NOT NULL,
+          state TEXT NOT NULL CHECK(state IN ('pending', 'complete', 'diagnosed')),
+          error TEXT,
+          PRIMARY KEY(root_id, generation_id, relative_path)
+        ) WITHOUT ROWID;
+        CREATE TABLE IF NOT EXISTS memory_index_entries(
+          root_id TEXT NOT NULL,
+          generation_id INTEGER NOT NULL REFERENCES memory_index_generations(id) ON DELETE CASCADE,
+          memory_id TEXT NOT NULL,
+          relative_path TEXT NOT NULL,
+          canonical_path TEXT NOT NULL,
+          title TEXT NOT NULL,
+          description TEXT NOT NULL,
+          memory_type TEXT,
+          mtime_ms INTEGER NOT NULL,
+          file_size INTEGER NOT NULL,
+          fingerprint TEXT NOT NULL,
+          last_seen_generation INTEGER NOT NULL,
+          file_dev TEXT NOT NULL,
+          file_ino TEXT NOT NULL,
+          file_mode TEXT NOT NULL,
+          file_mtime_ns TEXT NOT NULL,
+          file_ctime_ns TEXT NOT NULL,
+          root_dev TEXT NOT NULL,
+          root_ino TEXT NOT NULL,
+          root_mode TEXT NOT NULL,
+          root_size TEXT NOT NULL,
+          root_mtime_ns TEXT NOT NULL,
+          root_ctime_ns TEXT NOT NULL,
+          PRIMARY KEY(root_id, generation_id, memory_id),
+          UNIQUE(root_id, generation_id, canonical_path)
+        ) WITHOUT ROWID;
+        CREATE TABLE IF NOT EXISTS memory_index_change_log(
+          sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+          root_id TEXT NOT NULL REFERENCES memory_index_roots(root_id) ON DELETE CASCADE,
+          relative_path TEXT NOT NULL,
+          change_kind TEXT NOT NULL CHECK(change_kind IN ('create', 'update', 'delete', 'rename')),
+          observed_at_ms INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS memory_change_log_root_sequence
+          ON memory_index_change_log(root_id, sequence);
+        CREATE TABLE IF NOT EXISTS memory_index_owners(
+          root_id TEXT NOT NULL REFERENCES memory_index_roots(root_id) ON DELETE CASCADE,
+          owner_id TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK(kind IN ('watcher')),
+          lease_expires_at_ms INTEGER NOT NULL,
+          PRIMARY KEY(root_id, owner_id, kind)
+        ) WITHOUT ROWID;
+        CREATE INDEX IF NOT EXISTS memory_index_owner_lease
+          ON memory_index_owners(lease_expires_at_ms, root_id);
+      `);
+      database.exec(
+        `CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+           root_id UNINDEXED,
+           generation_id UNINDEXED,
+           memory_id UNINDEXED,
+           title,
+           description,
+           tokenize='${MEMORY_FTS_TOKENIZER}'
+         )`,
+      );
+      database
+        .prepare(
+          `INSERT OR REPLACE INTO memory_index_metadata(key, value)
+           VALUES ('schema_signature', ?)`,
+        )
+        .run(MEMORY_INDEX_SCHEMA_SIGNATURE);
+      database.pragma(`user_version = ${MEMORY_INDEX_SCHEMA_VERSION}`);
+    })
+    .immediate();
+}
+
+function readMemorySchemaSignature(
+  database: BetterSqlite3.Database,
+): string | null {
+  try {
+    const row = database
+      .prepare<[], { value: string }>(
+        `SELECT value FROM memory_index_metadata
+          WHERE key = 'schema_signature'`,
+      )
+      .get();
+    return row?.value ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -23,10 +23,19 @@ export {
 } from './age.js'
 
 export {
+  closeFullCorpusMemoryIndexes,
   findRelevantMemories,
   type FindRelevantMemoriesOptions,
   type RelevantMemory,
 } from './find-relevant.js'
+export {
+  PersistentMemoryIndex,
+  resolveMemoryIndexDatabasePath,
+  type MemoryFullCorpusQueryResult,
+  type MemoryIndexGenerationStatus,
+  type MemoryIndexRefreshResult,
+  type MemoryIndexRootSpec,
+} from './full-corpus-index.js'
 export {
   type AdmittedMemorySelector,
   type MemoryRecallMode,

--- a/runtime/src/memory/memory-query-helper.mjs
+++ b/runtime/src/memory/memory-query-helper.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import process from "node:process";
+
+import Database from "better-sqlite3";
+
+const PROTOCOL_VERSION = 1;
+const FRAME_HEADER_BYTES = 4;
+const MAX_REQUEST_BYTES = 1_048_576;
+const MAX_RESULT_BYTES = 1_048_576;
+const MAX_CANDIDATES = 200;
+const TITLE_WEIGHT = 5.0;
+const DESCRIPTION_WEIGHT = 2.0;
+
+let input = Buffer.alloc(0);
+for await (const chunk of process.stdin) {
+  input = Buffer.concat([input, Buffer.from(chunk)]);
+  if (input.byteLength > FRAME_HEADER_BYTES + MAX_REQUEST_BYTES) {
+    writeResponse(
+      errorResponse("invalid_request", "request frame exceeds limit"),
+    );
+    process.exitCode = 2;
+    break;
+  }
+}
+
+if (process.exitCode === undefined) {
+  try {
+    writeResponse(runQuery(decodeRequest(input)));
+  } catch (error) {
+    writeResponse(
+      errorResponse(
+        sqliteCapabilityError(error)
+          ? "capability_unavailable"
+          : "query_failed",
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+    process.exitCode = 1;
+  }
+}
+
+function decodeRequest(frame) {
+  if (frame.byteLength < FRAME_HEADER_BYTES) {
+    throw new Error("request frame is truncated");
+  }
+  const payloadLength = frame.readUInt32BE(0);
+  if (
+    payloadLength > MAX_REQUEST_BYTES ||
+    payloadLength !== frame.byteLength - FRAME_HEADER_BYTES
+  ) {
+    throw new Error("request frame length does not match payload");
+  }
+  const request = JSON.parse(
+    frame.subarray(FRAME_HEADER_BYTES).toString("utf8"),
+  );
+  if (
+    request === null ||
+    typeof request !== "object" ||
+    request.protocolVersion !== PROTOCOL_VERSION ||
+    typeof request.databasePath !== "string" ||
+    typeof request.rootId !== "string" ||
+    !Number.isSafeInteger(request.generationId) ||
+    (request.rootRole !== "global" && request.rootRole !== "project") ||
+    typeof request.match !== "string" ||
+    !Number.isSafeInteger(request.limit) ||
+    request.limit < 1 ||
+    request.limit > MAX_CANDIDATES
+  ) {
+    throw new Error("request fields are invalid");
+  }
+  return request;
+}
+
+function runQuery(request) {
+  const database = new Database(request.databasePath, {
+    readonly: true,
+    fileMustExist: true,
+  });
+  try {
+    database.pragma("query_only = ON");
+    database.pragma("trusted_schema = OFF");
+    const rows = database
+      .prepare(
+        `SELECT e.memory_id AS memoryId,
+                e.canonical_path AS canonicalPath,
+                e.title,
+                e.description,
+                e.memory_type AS type,
+                e.mtime_ms AS mtimeMs,
+                e.file_size AS size,
+                e.fingerprint,
+                e.root_id AS rootId,
+                bm25(memory_fts, 0.0, 0.0, 0.0, ${TITLE_WEIGHT}, ${DESCRIPTION_WEIGHT}) AS bm25Score
+           FROM memory_fts
+           JOIN memory_index_entries e
+             ON e.root_id = memory_fts.root_id
+            AND e.generation_id = memory_fts.generation_id
+            AND e.memory_id = memory_fts.memory_id
+          WHERE memory_fts MATCH ?
+            AND e.root_id = ?
+            AND e.generation_id = ?
+          ORDER BY bm25Score ASC,
+                   CAST(e.canonical_path AS BLOB) ASC,
+                   CAST(e.memory_id AS BLOB) ASC
+          LIMIT ?`,
+      )
+      .all(request.match, request.rootId, request.generationId, request.limit);
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      kind: "ok",
+      candidates: rows.map((row) => ({
+        ...row,
+        rootRole: request.rootRole,
+      })),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function writeResponse(response) {
+  let payload = Buffer.from(JSON.stringify(response), "utf8");
+  if (payload.byteLength > MAX_RESULT_BYTES) {
+    payload = Buffer.from(
+      JSON.stringify(
+        errorResponse("query_resource_limited", "query result exceeds limit"),
+      ),
+      "utf8",
+    );
+    process.exitCode = 3;
+  }
+  const frame = Buffer.allocUnsafe(FRAME_HEADER_BYTES + payload.byteLength);
+  frame.writeUInt32BE(payload.byteLength, 0);
+  payload.copy(frame, FRAME_HEADER_BYTES);
+  process.stdout.write(frame);
+}
+
+function errorResponse(code, message) {
+  return {
+    protocolVersion: PROTOCOL_VERSION,
+    kind: "error",
+    code,
+    message,
+  };
+}
+
+function sqliteCapabilityError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /fts5|no such module|malformed MATCH/iu.test(message);
+}

--- a/runtime/src/memory/memory-query-pool.ts
+++ b/runtime/src/memory/memory-query-pool.ts
@@ -1,0 +1,191 @@
+import { basename, dirname, join, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { scrubEnvForChildProcess } from "../unified-exec/scrub-env.js";
+import { runSupervisedProcess } from "../utils/supervisedProcess.js";
+import {
+  MAX_MEMORY_QUERY_MS,
+  MAX_MEMORY_QUERY_PROCESSES,
+  MAX_MEMORY_QUERY_QUEUE,
+  MAX_MEMORY_QUERY_RESULT_BYTES,
+  MemoryIndexQueryResourceLimitedError,
+  type MemoryRankCandidate,
+} from "./full-corpus-contract.js";
+import {
+  decodeMemoryQueryResponseFrame,
+  encodeMemoryQueryFrame,
+  MEMORY_QUERY_FRAME_HEADER_BYTES,
+  MEMORY_QUERY_HELPER_PROTOCOL_VERSION,
+  type MemoryQueryHelperRequest,
+} from "./full-corpus-protocol.js";
+
+interface WaitingQuerySlot {
+  readonly signal: AbortSignal;
+  readonly resolve: (release: () => void) => void;
+  readonly reject: (error: unknown) => void;
+  readonly onAbort: () => void;
+}
+
+const waitingQuerySlots: WaitingQuerySlot[] = [];
+let activeQueryProcesses = 0;
+
+export interface MemoryQueryProcessPoolOptions {
+  readonly helperEntrypoint?: string;
+  readonly timeoutMs?: number;
+}
+
+export class MemoryQueryProcessPool {
+  readonly #helperEntrypoint: string;
+  readonly #timeoutMs: number;
+
+  constructor(options: MemoryQueryProcessPoolOptions = {}) {
+    this.#helperEntrypoint =
+      options.helperEntrypoint ?? resolveDefaultMemoryQueryHelperEntrypoint();
+    this.#timeoutMs = options.timeoutMs ?? MAX_MEMORY_QUERY_MS;
+  }
+
+  async query(
+    request: Omit<MemoryQueryHelperRequest, "protocolVersion">,
+    signal: AbortSignal,
+  ): Promise<readonly MemoryRankCandidate[]> {
+    throwIfAborted(signal);
+    const release = await acquireQuerySlot(signal);
+    try {
+      return await this.#runQuery(request, signal);
+    } finally {
+      release();
+    }
+  }
+
+  async #runQuery(
+    request: Omit<MemoryQueryHelperRequest, "protocolVersion">,
+    signal: AbortSignal,
+  ): Promise<readonly MemoryRankCandidate[]> {
+    const frame = encodeMemoryQueryFrame({
+      ...request,
+      protocolVersion: MEMORY_QUERY_HELPER_PROTOCOL_VERSION,
+    });
+    const result = await runSupervisedProcess(
+      {
+        program: process.execPath,
+        args: [this.#helperEntrypoint],
+        cwd: dirname(this.#helperEntrypoint),
+        env: scrubEnvForChildProcess(process.env),
+      },
+      {
+        stdin: frame,
+        signal,
+        timeoutMs: this.#timeoutMs,
+        maxOutputBytes:
+          MAX_MEMORY_QUERY_RESULT_BYTES + MEMORY_QUERY_FRAME_HEADER_BYTES,
+        terminateGraceMs: 100,
+        settleBackstopMs: 1_000,
+      },
+    );
+    throwIfAborted(signal);
+    if (
+      result.stopReason === "timeout" ||
+      result.stopReason === "output_limit" ||
+      result.stopReason === "consumer_limit" ||
+      result.backstopExpired
+    ) {
+      throw new MemoryIndexQueryResourceLimitedError(
+        `memory query helper crossed ${result.stopReason ?? "settlement"} limit`,
+      );
+    }
+    if (result.error !== undefined) throw result.error;
+    let response;
+    try {
+      response = decodeMemoryQueryResponseFrame(result.stdout);
+    } catch (error) {
+      throw new MemoryIndexQueryResourceLimitedError(
+        `memory query helper returned an invalid bounded frame: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    if (response.kind === "error") {
+      if (response.code === "query_resource_limited") {
+        throw new MemoryIndexQueryResourceLimitedError(response.message);
+      }
+      throw new Error(`${response.code}: ${response.message}`);
+    }
+    return response.candidates;
+  }
+}
+
+export function resolveDefaultMemoryQueryHelperEntrypoint(
+  moduleUrl: string = import.meta.url,
+): string {
+  const moduleDirectory = dirname(fileURLToPath(moduleUrl));
+  if (basename(moduleDirectory) === "dist") {
+    return join(moduleDirectory, "memory", "memory-query-helper.js");
+  }
+  if (basename(dirname(moduleDirectory)) === "dist") {
+    return join(dirname(moduleDirectory), "memory", "memory-query-helper.js");
+  }
+  const candidates = [
+    join(moduleDirectory, "memory-query-helper.js"),
+    join(moduleDirectory, "memory-query-helper.mjs"),
+    join(moduleDirectory, "memory", "memory-query-helper.js"),
+    resolve(moduleDirectory, "../memory/memory-query-helper.js"),
+  ];
+  return (
+    candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]!
+  );
+}
+
+async function acquireQuerySlot(signal: AbortSignal): Promise<() => void> {
+  throwIfAborted(signal);
+  if (activeQueryProcesses < MAX_MEMORY_QUERY_PROCESSES) {
+    activeQueryProcesses += 1;
+    return releaseQuerySlot;
+  }
+  if (waitingQuerySlots.length >= MAX_MEMORY_QUERY_QUEUE) {
+    throw new MemoryIndexQueryResourceLimitedError(
+      "memory query helper queue is full",
+    );
+  }
+  return await new Promise<() => void>((resolve, reject) => {
+    const waiter: WaitingQuerySlot = {
+      signal,
+      resolve,
+      reject,
+      onAbort: () => {
+        const index = waitingQuerySlots.indexOf(waiter);
+        if (index >= 0) waitingQuerySlots.splice(index, 1);
+        reject(abortReason(signal));
+      },
+    };
+    signal.addEventListener("abort", waiter.onAbort, { once: true });
+    waitingQuerySlots.push(waiter);
+    if (signal.aborted) waiter.onAbort();
+  });
+}
+
+function releaseQuerySlot(): void {
+  activeQueryProcesses -= 1;
+  while (waitingQuerySlots.length > 0) {
+    const waiter = waitingQuerySlots.shift()!;
+    waiter.signal.removeEventListener("abort", waiter.onAbort);
+    if (waiter.signal.aborted) {
+      waiter.reject(abortReason(waiter.signal));
+      continue;
+    }
+    activeQueryProcesses += 1;
+    waiter.resolve(releaseQuerySlot);
+    return;
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortReason(signal);
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ?? new DOMException("Memory query aborted", "AbortError")
+  );
+}

--- a/runtime/src/memory/recall-contract.ts
+++ b/runtime/src/memory/recall-contract.ts
@@ -15,7 +15,7 @@ export const MAX_C3A_TOTAL_HEADER_BYTES = 4_194_304;
 export const MAX_C3A_QUERY_CODEPOINTS = 1_024;
 export const MAX_C3A_QUERY_TERMS = 128;
 export const MAX_C3A_TERM_OCCURRENCES_PER_TERM = 8;
-export const MAX_C3A_SELECTOR_CANDIDATES = 50;
+export const MAX_MEMORY_SELECTOR_CANDIDATES = 50;
 export const MAX_MEMORY_SELECTOR_EXTRACT_UTF8_BYTES_PER_CANDIDATE = 4_096;
 export const MAX_MEMORY_SELECTOR_TOTAL_UTF8_BYTES = 262_144;
 export const MAX_MEMORY_SELECTOR_INPUT_TOKENS = 32_768;
@@ -83,7 +83,9 @@ export interface AdmittedMemorySelector {
 
 export function throwIfMemoryRecallAborted(signal: AbortSignal): void {
   if (!signal.aborted) return;
-  throw signal.reason ?? new DOMException("Memory recall aborted", "AbortError");
+  throw (
+    signal.reason ?? new DOMException("Memory recall aborted", "AbortError")
+  );
 }
 
 export function isMemoryRecallAbort(
@@ -91,11 +93,9 @@ export function isMemoryRecallAbort(
   signal?: AbortSignal,
 ): boolean {
   if (signal?.aborted === true) return true;
-  return (
-    error instanceof DOMException
-      ? error.name === "AbortError"
-      : error instanceof Error && error.name === "AbortError"
-  );
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
 }
 
 export function normalizeMemoryText(value: string): string {
@@ -164,11 +164,7 @@ export function rankMemoryHeaders(
     const exactPhrase =
       query.phrase.length > 0 && haystack.includes(query.phrase);
     const distinctTermCoverage = counts.size;
-    if (
-      mode === "query" &&
-      !exactPhrase &&
-      distinctTermCoverage === 0
-    ) {
+    if (mode === "query" && !exactPhrase && distinctTermCoverage === 0) {
       continue;
     }
     let cappedTermOccurrences = 0;
@@ -217,7 +213,7 @@ export function buildMemorySelectorRequest(
     type: string | null;
     mtimeMs: number;
     omitted: { titleUtf8Bytes: number; descriptionUtf8Bytes: number };
-  }> = ranked.slice(0, MAX_C3A_SELECTOR_CANDIDATES).map((entry, index) => ({
+  }> = ranked.slice(0, MAX_MEMORY_SELECTOR_CANDIDATES).map((entry, index) => ({
     id: `candidate-${index + 1}`,
     title: "",
     description: "",
@@ -304,7 +300,8 @@ function fitSelectorField(
   const sourceBytes = Buffer.byteLength(value, "utf8");
   for (const codepoint of value) {
     const codepointBytes = Buffer.byteLength(codepoint, "utf8");
-    const encodedBytes = Buffer.byteLength(JSON.stringify(codepoint), "utf8") - 2;
+    const encodedBytes =
+      Buffer.byteLength(JSON.stringify(codepoint), "utf8") - 2;
     if (
       utf8Bytes + codepointBytes > rawByteLimit ||
       serializedDeltaBytes + encodedBytes > serializedByteLimit

--- a/runtime/src/prompts/attachments/relevant-memories.ts
+++ b/runtime/src/prompts/attachments/relevant-memories.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { join, normalize, sep } from "node:path";
+import { isAbsolute, join, normalize, sep } from "node:path";
 
 import {
   findRelevantMemories,
@@ -8,6 +8,7 @@ import {
   MEMORY_DIRNAME,
   PROJECT_MEMORY_DIR,
   readMemoryContent,
+  resolveMemoryIndexDatabasePath,
   type MemoryRecallMode,
   type RelevantMemory,
 } from "../../memory/index.js";
@@ -53,6 +54,13 @@ export const relevantMemoriesProducer: AttachmentProducer = async (
     alreadySurfaced: trackingState.surfacedRelevantMemoryPaths,
     ...(opts.admittedMemorySelector !== undefined
       ? { admittedMemorySelector: opts.admittedMemorySelector }
+      : {}),
+    ...(opts.agencHome !== undefined && isAbsolute(opts.agencHome)
+      ? {
+          memoryIndexDatabasePath: resolveMemoryIndexDatabasePath(
+            opts.agencHome,
+          ),
+        }
       : {}),
   });
   if (selected.length === 0) return [];
@@ -163,6 +171,7 @@ async function readMemoriesForAttachment(
           selectedMemory.mtimeMs,
         ),
         ...(result.truncated ? { limit: result.lineCount } : {}),
+        selectionSource: selectedMemory.selectionSource,
         citation: {
           path: selectedMemory.path,
           lineStart: 1,

--- a/runtime/src/prompts/attachments/types.ts
+++ b/runtime/src/prompts/attachments/types.ts
@@ -52,6 +52,8 @@ export interface RelevantMemoriesAttachment {
     readonly header?: string;
     /** Truncation marker line count. Undefined for full reads. */
     readonly limit?: number;
+    /** Selection path used for this memory; absent only in legacy transcripts. */
+    readonly selectionSource?: "lexical" | "reranked";
     /** Structured citation metadata for audit/usage tracking. */
     readonly citation?: {
       readonly path: string;

--- a/runtime/tests/memory/full-corpus-contract.test.ts
+++ b/runtime/tests/memory/full-corpus-contract.test.ts
@@ -1,0 +1,225 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE,
+  MAX_MEMORY_AUDIT_MS_PER_SLICE,
+  MAX_MEMORY_BUILD_OPEN_DIRECTORIES,
+  MAX_MEMORY_EXPLICIT_REFRESH_WAIT_MS,
+  MAX_MEMORY_FILES_PER_ROOT,
+  MAX_MEMORY_FTS_CANDIDATES,
+  MAX_MEMORY_HEADER_UTF8_BYTES,
+  MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE,
+  MAX_MEMORY_INDEX_BUILD_SLICE_MS,
+  MAX_MEMORY_INDEX_BYTES,
+  MAX_MEMORY_INDEX_CHANGE_LOG_EVENTS,
+  MAX_MEMORY_INDEX_CLEANUP_MS_PER_SLICE,
+  MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH,
+  MAX_MEMORY_INDEX_CONCURRENT_BUILDS,
+  MAX_MEMORY_INDEX_ROOTS,
+  MAX_MEMORY_INDEX_TOTAL_BUILD_MS,
+  MAX_MEMORY_INDEX_WATCHERS,
+  MAX_MEMORY_PATH_UTF8_BYTES,
+  MAX_MEMORY_QUERY_MS,
+  MAX_MEMORY_QUERY_PROCESSES,
+  MAX_MEMORY_QUERY_QUEUE,
+  MAX_MEMORY_QUERY_RESULT_BYTES,
+  MAX_MEMORY_QUERY_TERMS,
+  MAX_MEMORY_RECENT_UNION,
+  MAX_MEMORY_SELECTOR_CANDIDATES,
+  MEMORY_BM25_DESCRIPTION_WEIGHT,
+  MEMORY_BM25_TITLE_WEIGHT,
+  MEMORY_AUDIT_BACKOFF_MULTIPLIER,
+  MEMORY_AUDIT_MAX_INTERVAL_MS,
+  MEMORY_AUDIT_MIN_INTERVAL_MS,
+  MEMORY_FTS_TERM_OPERATOR,
+  MEMORY_FTS_TOKENIZER,
+  MEMORY_INDEX_ROOT_IDLE_TTL_MS,
+  MEMORY_INDEX_BUILD_LEASE_MS,
+  MEMORY_RRF_GLOBAL_WEIGHT,
+  MEMORY_RRF_K,
+  MEMORY_RRF_PROJECT_WEIGHT,
+  MEMORY_RRF_RECENT_WEIGHT,
+  MEMORY_WATCH_DEBOUNCE_MS,
+  buildMemoryFtsMatch,
+  computeMemoryHeaderFingerprint,
+  fuseMemoryRanks,
+  type MemoryRankCandidate,
+} from "../../src/memory/full-corpus-contract.js";
+
+describe("C3b full-corpus memory contract", () => {
+  it("freezes every resource, tokenizer, BM25, and RRF constant", () => {
+    expect({
+      MAX_MEMORY_INDEX_ROOTS,
+      MAX_MEMORY_FILES_PER_ROOT,
+      MAX_MEMORY_HEADER_UTF8_BYTES,
+      MAX_MEMORY_PATH_UTF8_BYTES,
+      MAX_MEMORY_RECENT_UNION,
+      MAX_MEMORY_FTS_CANDIDATES,
+      MAX_MEMORY_SELECTOR_CANDIDATES,
+      MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE,
+      MAX_MEMORY_INDEX_BUILD_SLICE_MS,
+      MAX_MEMORY_INDEX_TOTAL_BUILD_MS,
+      MAX_MEMORY_EXPLICIT_REFRESH_WAIT_MS,
+      MAX_MEMORY_QUERY_TERMS,
+      MAX_MEMORY_QUERY_MS,
+      MAX_MEMORY_QUERY_RESULT_BYTES,
+      MAX_MEMORY_QUERY_PROCESSES,
+      MAX_MEMORY_QUERY_QUEUE,
+      MAX_MEMORY_INDEX_BYTES,
+      MAX_MEMORY_INDEX_WATCHERS,
+      MAX_MEMORY_INDEX_CONCURRENT_BUILDS,
+      MAX_MEMORY_INDEX_CHANGE_LOG_EVENTS,
+      MEMORY_INDEX_ROOT_IDLE_TTL_MS,
+      MEMORY_INDEX_BUILD_LEASE_MS,
+      MEMORY_AUDIT_MIN_INTERVAL_MS,
+      MEMORY_AUDIT_MAX_INTERVAL_MS,
+      MEMORY_AUDIT_BACKOFF_MULTIPLIER,
+      MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH,
+      MAX_MEMORY_INDEX_CLEANUP_MS_PER_SLICE,
+      MEMORY_WATCH_DEBOUNCE_MS,
+      MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE,
+      MAX_MEMORY_AUDIT_MS_PER_SLICE,
+      MAX_MEMORY_BUILD_OPEN_DIRECTORIES,
+      MEMORY_FTS_TOKENIZER,
+      MEMORY_FTS_TERM_OPERATOR,
+      MEMORY_BM25_TITLE_WEIGHT,
+      MEMORY_BM25_DESCRIPTION_WEIGHT,
+      MEMORY_RRF_K,
+      MEMORY_RRF_PROJECT_WEIGHT,
+      MEMORY_RRF_GLOBAL_WEIGHT,
+      MEMORY_RRF_RECENT_WEIGHT,
+    }).toEqual({
+      MAX_MEMORY_INDEX_ROOTS: 64,
+      MAX_MEMORY_FILES_PER_ROOT: 1_000_000,
+      MAX_MEMORY_HEADER_UTF8_BYTES: 65_536,
+      MAX_MEMORY_PATH_UTF8_BYTES: 16_384,
+      MAX_MEMORY_RECENT_UNION: 32,
+      MAX_MEMORY_FTS_CANDIDATES: 200,
+      MAX_MEMORY_SELECTOR_CANDIDATES: 50,
+      MAX_MEMORY_INDEX_BUILD_ENTRIES_PER_SLICE: 10_000,
+      MAX_MEMORY_INDEX_BUILD_SLICE_MS: 30_000,
+      MAX_MEMORY_INDEX_TOTAL_BUILD_MS: 3_600_000,
+      MAX_MEMORY_EXPLICIT_REFRESH_WAIT_MS: 300_000,
+      MAX_MEMORY_QUERY_TERMS: 128,
+      MAX_MEMORY_QUERY_MS: 500,
+      MAX_MEMORY_QUERY_RESULT_BYTES: 1_048_576,
+      MAX_MEMORY_QUERY_PROCESSES: 4,
+      MAX_MEMORY_QUERY_QUEUE: 64,
+      MAX_MEMORY_INDEX_BYTES: 536_870_912,
+      MAX_MEMORY_INDEX_WATCHERS: 64,
+      MAX_MEMORY_INDEX_CONCURRENT_BUILDS: 2,
+      MAX_MEMORY_INDEX_CHANGE_LOG_EVENTS: 100_000,
+      MEMORY_INDEX_ROOT_IDLE_TTL_MS: 2_592_000_000,
+      MEMORY_INDEX_BUILD_LEASE_MS: 60_000,
+      MEMORY_AUDIT_MIN_INTERVAL_MS: 60_000,
+      MEMORY_AUDIT_MAX_INTERVAL_MS: 86_400_000,
+      MEMORY_AUDIT_BACKOFF_MULTIPLIER: 100,
+      MAX_MEMORY_INDEX_CLEANUP_ROOTS_PER_BATCH: 64,
+      MAX_MEMORY_INDEX_CLEANUP_MS_PER_SLICE: 1_000,
+      MEMORY_WATCH_DEBOUNCE_MS: 100,
+      MAX_MEMORY_AUDIT_ENTRIES_PER_SLICE: 10_000,
+      MAX_MEMORY_AUDIT_MS_PER_SLICE: 50,
+      MAX_MEMORY_BUILD_OPEN_DIRECTORIES: 32,
+      MEMORY_FTS_TOKENIZER: "unicode61 remove_diacritics 2",
+      MEMORY_FTS_TERM_OPERATOR: "OR",
+      MEMORY_BM25_TITLE_WEIGHT: 5,
+      MEMORY_BM25_DESCRIPTION_WEIGHT: 2,
+      MEMORY_RRF_K: 60,
+      MEMORY_RRF_PROJECT_WEIGHT: 1.25,
+      MEMORY_RRF_GLOBAL_WEIGHT: 1,
+      MEMORY_RRF_RECENT_WEIGHT: 0.25,
+    });
+  });
+
+  it("quotes every already-bounded term as an FTS literal", () => {
+    expect(
+      buildMemoryFtsMatch([
+        'quote"inside',
+        "*",
+        "NEAR",
+        "title:escape",
+        "e\u0301",
+        "東京",
+      ]),
+    ).toBe(
+      '"quote""inside" OR "*" OR "near" OR "title:escape" OR "é" OR "東京"',
+    );
+    expect(buildMemoryFtsMatch([])).toBe("");
+    expect(() =>
+      buildMemoryFtsMatch(
+        Array.from({ length: 129 }, (_, index) => String(index)),
+      ),
+    ).toThrow(/term count/u);
+  });
+
+  it("changes the bounded content identity for equal-length substitutions", () => {
+    const metadata = {
+      title: "Database recovery",
+      description: "Known issue",
+      type: "project",
+    };
+    const first = computeMemoryHeaderFingerprint(
+      Buffer.from("same-size-body-a", "utf8"),
+      metadata,
+    );
+    const second = computeMemoryHeaderFingerprint(
+      Buffer.from("same-size-body-b", "utf8"),
+      metadata,
+    );
+    expect(Buffer.byteLength("same-size-body-a")).toBe(
+      Buffer.byteLength("same-size-body-b"),
+    );
+    expect(first).not.toBe(second);
+  });
+
+  it("sums one-based weighted RRF contributions and freezes every tie-breaker", () => {
+    const sharedProject = candidate("shared", "/project/shared.md", "project");
+    const sharedGlobal = candidate(
+      "shared-global",
+      "/project/shared.md",
+      "global",
+    );
+    const projectOnly = candidate("project", "/project/only.md", "project");
+    const globalOnly = candidate("global", "/global/only.md", "global");
+    const fused = fuseMemoryRanks({
+      project: [sharedProject, projectOnly],
+      global: [globalOnly, sharedGlobal],
+      recent: [sharedGlobal],
+    });
+
+    expect(fused.map((entry) => entry.memoryId)).toEqual([
+      "shared",
+      "project",
+      "global",
+    ]);
+    expect(fused[0]?.fusedScore).toBeCloseTo(
+      1.25 / 61 + 1 / 62 + 0.25 / 61,
+      12,
+    );
+    expect(fused[0]).toMatchObject({
+      projectPresent: true,
+      bestRank: 1,
+      rootRole: "project",
+    });
+  });
+});
+
+function candidate(
+  memoryId: string,
+  canonicalPath: string,
+  rootRole: "global" | "project",
+): MemoryRankCandidate {
+  return {
+    memoryId,
+    canonicalPath,
+    title: memoryId,
+    description: "",
+    type: null,
+    mtimeMs: 1,
+    size: 1,
+    fingerprint: memoryId.padEnd(64, "0"),
+    rootId: `${rootRole}-root`,
+    rootRole,
+  };
+}

--- a/runtime/tests/memory/full-corpus-held-out.test.ts
+++ b/runtime/tests/memory/full-corpus-held-out.test.ts
@@ -1,0 +1,110 @@
+import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PersistentMemoryIndex } from "../../src/memory/full-corpus-index.js";
+import { MemoryQueryProcessPool } from "../../src/memory/memory-query-pool.js";
+
+interface HeldOutContract {
+  readonly schemaVersion: 1;
+  readonly suiteId: string;
+  readonly newestBaselineSize: number;
+  readonly minimumFullCorpusTop1Recall: number;
+  readonly maximumPrecisionRegression: number;
+  readonly cases: readonly {
+    readonly id: string;
+    readonly queryTerms: readonly string[];
+    readonly title: string;
+    readonly description: string;
+  }[];
+}
+
+const heldOutPath = fileURLToPath(
+  new URL("../../benchmarks/memory-index/held-out.v1.json", import.meta.url),
+);
+const helperEntrypoint = fileURLToPath(
+  new URL("../../src/memory/memory-query-helper.mjs", import.meta.url),
+);
+
+let temporaryRoot = "";
+let index: PersistentMemoryIndex | undefined;
+
+afterEach(async () => {
+  index?.close();
+  index = undefined;
+  if (temporaryRoot !== "") {
+    await rm(temporaryRoot, { recursive: true, force: true });
+    temporaryRoot = "";
+  }
+});
+
+describe("C3b held-out full-corpus relevance gate", () => {
+  it("dominates newest-200 old-memory recall without precision regression", async () => {
+    const contract = JSON.parse(
+      await readFile(heldOutPath, "utf8"),
+    ) as HeldOutContract;
+    expect(contract).toMatchObject({
+      schemaVersion: 1,
+      suiteId: "agenc-memory-relevance-v1",
+      newestBaselineSize: 200,
+    });
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-memory-held-out-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    const relevantPaths = new Map<string, string>();
+    for (const testCase of contract.cases) {
+      const path = join(memoryRoot, `${testCase.id}.md`);
+      await writeFile(
+        path,
+        memoryDocument(testCase.title, testCase.description),
+      );
+      await utimes(path, oldTime, oldTime);
+      relevantPaths.set(testCase.id, path);
+    }
+    for (let distractor = 0; distractor < 220; distractor += 1) {
+      await writeFile(
+        join(memoryRoot, `recent-${distractor.toString().padStart(3, "0")}.md`),
+        memoryDocument(`Recent ${distractor}`, "unrelated compiler note"),
+      );
+    }
+    index = new PersistentMemoryIndex({
+      databasePath: join(stateRoot, "memory.sqlite"),
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    const roots = [{ path: memoryRoot, role: "global" as const }];
+    await index.refresh(roots, new AbortController().signal, {
+      explicit: true,
+    });
+
+    let fullCorpusHits = 0;
+    let preciseHits = 0;
+    for (const testCase of contract.cases) {
+      const result = await index.query(
+        roots,
+        testCase.queryTerms,
+        new AbortController().signal,
+      );
+      const expected = relevantPaths.get(testCase.id);
+      if (result.candidates[0]?.canonicalPath === expected) fullCorpusHits += 1;
+      if (result.candidates.length === 1) preciseHits += 1;
+    }
+    const recall = fullCorpusHits / contract.cases.length;
+    const precision = preciseHits / contract.cases.length;
+    const newest200Recall = 0;
+    expect(recall).toBeGreaterThan(newest200Recall);
+    expect(recall).toBeGreaterThanOrEqual(contract.minimumFullCorpusTop1Recall);
+    expect(1 - precision).toBeLessThanOrEqual(
+      contract.maximumPrecisionRegression,
+    );
+  });
+});
+
+function memoryDocument(title: string, description: string): string {
+  return `---\ntitle: ${title}\ndescription: ${description}\ntype: reference\n---\nBody.\n`;
+}

--- a/runtime/tests/memory/full-corpus-index.test.ts
+++ b/runtime/tests/memory/full-corpus-index.test.ts
@@ -1,0 +1,911 @@
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  rename,
+  rm,
+  stat,
+  unlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+
+import {
+  PersistentMemoryIndex,
+  type MemoryIndexRootSpec,
+} from "../../src/memory/full-corpus-index.js";
+import { MemoryQueryProcessPool } from "../../src/memory/memory-query-pool.js";
+import {
+  MEMORY_INDEX_BUILD_LEASE_MS,
+  MAX_MEMORY_INDEX_ROOTS,
+  MEMORY_INDEX_ROOT_IDLE_TTL_MS,
+} from "../../src/memory/full-corpus-contract.js";
+
+const helperEntrypoint = fileURLToPath(
+  new URL("../../src/memory/memory-query-helper.mjs", import.meta.url),
+);
+
+let temporaryRoot = "";
+let index: PersistentMemoryIndex | undefined;
+
+afterEach(async () => {
+  index?.close();
+  index = undefined;
+  if (temporaryRoot !== "") {
+    await rm(temporaryRoot, { recursive: true, force: true });
+    temporaryRoot = "";
+  }
+});
+
+describe("C3b persistent full-corpus index", () => {
+  it("retrieves a uniquely relevant memory older than the newest 200", async () => {
+    const fixture = await createFixture();
+    const oldPath = join(fixture.globalRoot, "old-browser-recovery.md");
+    await writeMemory(
+      oldPath,
+      "Old browser recovery",
+      "uniquebrowserfailure recovery sequence",
+    );
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    await utimes(oldPath, oldTime, oldTime);
+    for (let memory = 0; memory < 220; memory += 1) {
+      await writeMemory(
+        join(
+          fixture.globalRoot,
+          `recent-${memory.toString().padStart(3, "0")}.md`,
+        ),
+        `Recent irrelevant ${memory}`,
+        "unrelated compiler note",
+      );
+    }
+
+    const refresh = await index!.refresh(
+      fixture.rootSpecs,
+      new AbortController().signal,
+      { explicit: true },
+    );
+    expect(refresh.kind).toBe("complete");
+
+    const result = await index!.query(
+      fixture.rootSpecs,
+      ["uniquebrowserfailure"],
+      new AbortController().signal,
+    );
+    expect(result.kind).toBe("complete");
+    expect(result.candidates[0]?.canonicalPath).toBe(oldPath);
+    expect(result.candidates).toHaveLength(1);
+    expect(index!.readHeader(result.candidates[0]!)).toMatchObject({
+      filePath: oldPath,
+      title: "Old browser recovery",
+    });
+  });
+
+  it("changes results after an equal-size, equal-mtime bounded header replacement", async () => {
+    const fixture = await createFixture();
+    const memoryPath = join(fixture.projectRoot, "replacement.md");
+    const first = memoryDocument("Replacement", "alpha_marker");
+    const second = memoryDocument("Replacement", "bravo_marker");
+    expect(Buffer.byteLength(first)).toBe(Buffer.byteLength(second));
+    await writeFile(memoryPath, first);
+    const fixedTime = new Date("2024-01-01T00:00:00.000Z");
+    await utimes(memoryPath, fixedTime, fixedTime);
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    const before = await index!.query(
+      fixture.rootSpecs,
+      ["alpha_marker"],
+      new AbortController().signal,
+    );
+    expect(before.candidates).toHaveLength(1);
+
+    await writeFile(memoryPath, second);
+    await utimes(memoryPath, fixedTime, fixedTime);
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    const staleTerm = await index!.query(
+      fixture.rootSpecs,
+      ["alpha_marker"],
+      new AbortController().signal,
+    );
+    const replacementTerm = await index!.query(
+      fixture.rootSpecs,
+      ["bravo_marker"],
+      new AbortController().signal,
+    );
+    expect(staleTerm.candidates).toHaveLength(0);
+    expect(replacementTerm.candidates).toHaveLength(1);
+  });
+
+  it("reconciles an equal-size, equal-mtime replacement during the initial build", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-build-race-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    const racedPath = join(memoryRoot, "00000-raced.md");
+    const first = memoryDocument("Build race", "build_race_alpha");
+    const second = memoryDocument("Build race", "build_race_bravo");
+    expect(Buffer.byteLength(first)).toBe(Buffer.byteLength(second));
+    await writeFile(racedPath, first);
+    const fixedTime = new Date("2024-01-01T00:00:00.000Z");
+    await utimes(racedPath, fixedTime, fixedTime);
+    for (let start = 1; start <= 10_000; start += 500) {
+      await Promise.all(
+        Array.from({ length: Math.min(500, 10_001 - start) }, (_, offset) => {
+          const ordinal = start + offset;
+          return writeMemory(
+            join(memoryRoot, `${ordinal.toString().padStart(5, "0")}.md`),
+            `Memory ${ordinal}`,
+            "ordinary build-race filler",
+          );
+        }),
+      );
+    }
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+
+    const refreshPromise = index.refresh(
+      [{ path: memoryRoot, role: "project" }],
+      new AbortController().signal,
+      { explicit: true },
+    );
+    const inspection = new Database(databasePath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      await expectEventually(async () => {
+        const row = inspection
+          .prepare(
+            `SELECT f.description
+               FROM memory_fts f
+               JOIN memory_index_entries e
+                 ON e.root_id = f.root_id
+                AND e.generation_id = f.generation_id
+                AND e.memory_id = f.memory_id
+              WHERE e.canonical_path = ? AND f.description = ?`,
+          )
+          .get(racedPath, "build_race_alpha");
+        return row !== undefined;
+      });
+    } finally {
+      inspection.close();
+    }
+    await writeFile(racedPath, second);
+    await utimes(racedPath, fixedTime, fixedTime);
+    await expect(refreshPromise).resolves.toMatchObject({ kind: "complete" });
+
+    const stale = await index.query(
+      [{ path: memoryRoot, role: "project" }],
+      ["build_race_alpha"],
+      new AbortController().signal,
+    );
+    const replacement = await index.query(
+      [{ path: memoryRoot, role: "project" }],
+      ["build_race_bravo"],
+      new AbortController().signal,
+    );
+    expect(stale.candidates).toHaveLength(0);
+    expect(replacement.candidates).toHaveLength(1);
+  }, 30_000);
+
+  it("keeps generation counts and the commutative digest exact across incremental replacement", async () => {
+    const fixture = await createFixture();
+    const memoryPath = join(fixture.globalRoot, "digest.md");
+    const first = memoryDocument("Digest", "digest_alpha");
+    const second = memoryDocument("Digest", "digest_bravo");
+    expect(Buffer.byteLength(first)).toBe(Buffer.byteLength(second));
+    await writeFile(memoryPath, first);
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    const initial = readCurrentGenerationProgress(index!.databasePath);
+
+    await writeFile(memoryPath, second);
+    index!.recordChange({
+      rootPath: fixture.globalRoot,
+      relativePath: "digest.md",
+      kind: "update",
+    });
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal);
+    const changed = readCurrentGenerationProgress(index!.databasePath);
+    expect(changed).toMatchObject({
+      entryCount: initial.entryCount,
+      indexedBytes: initial.indexedBytes,
+    });
+    expect(changed.digest).not.toBe(initial.digest);
+
+    await writeFile(memoryPath, first);
+    index!.recordChange({
+      rootPath: fixture.globalRoot,
+      relativePath: "digest.md",
+      kind: "update",
+    });
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal);
+    const restored = readCurrentGenerationProgress(index!.databasePath);
+    expect(restored.digest).toBe(initial.digest);
+    expect(restored.discoveryOperations).toBeGreaterThan(0);
+  });
+
+  it("repairs a missed equal-size/equal-mtime external change through the bounded audit", async () => {
+    const fixture = await createFixture();
+    const databasePath = join(temporaryRoot, "state", "memory.sqlite");
+    const memoryPath = join(fixture.globalRoot, "missed-watch.md");
+    const first = memoryDocument("Missed watch", "audit_alpha");
+    const second = memoryDocument("Missed watch", "audit_bravo");
+    expect(Buffer.byteLength(first)).toBe(Buffer.byteLength(second));
+    const fixedTime = new Date("2024-02-02T00:00:00.000Z");
+    await writeFile(memoryPath, first);
+    await utimes(memoryPath, fixedTime, fixedTime);
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    index!.close();
+    index = undefined;
+
+    await writeFile(memoryPath, second);
+    await utimes(memoryPath, fixedTime, fixedTime);
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    await index.auditSlice(
+      { path: fixture.globalRoot, role: "global" },
+      new AbortController().signal,
+    );
+    await index.refresh(fixture.rootSpecs, new AbortController().signal);
+    const oldResult = await index.query(
+      fixture.rootSpecs,
+      ["audit_alpha"],
+      new AbortController().signal,
+    );
+    const repaired = await index.query(
+      fixture.rootSpecs,
+      ["audit_bravo"],
+      new AbortController().signal,
+    );
+    expect(oldResult.candidates).toHaveLength(0);
+    expect(repaired.candidates).toHaveLength(1);
+  });
+
+  it("publishes project and global roots once and fuses duplicate paths deterministically", async () => {
+    const fixture = await createFixture();
+    await writeMemory(
+      join(fixture.globalRoot, "global.md"),
+      "Shared query global",
+      "crossrootterm",
+    );
+    await writeMemory(
+      join(fixture.projectRoot, "project.md"),
+      "Shared query project",
+      "crossrootterm",
+    );
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    const result = await index!.query(
+      fixture.rootSpecs,
+      ["crossrootterm"],
+      new AbortController().signal,
+    );
+    expect(result.candidates.map((candidate) => candidate.rootRole)).toEqual([
+      "project",
+      "global",
+    ]);
+    expect(
+      new Set(result.candidates.map((candidate) => candidate.rootId)).size,
+    ).toBe(2);
+  });
+
+  it("propagates abort instead of returning a partial or empty success", async () => {
+    const fixture = await createFixture();
+    const controller = new AbortController();
+    controller.abort(new Error("stop-memory-build"));
+    await expect(
+      index!.refresh(fixture.rootSpecs, controller.signal, { explicit: true }),
+    ).rejects.toThrow("stop-memory-build");
+  });
+
+  it("rotates an incompatible derived schema and recreates secure state", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-schema-"));
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(stateRoot, { recursive: true });
+    const incompatible = new Database(databasePath);
+    incompatible.pragma("user_version = 99");
+    incompatible.close();
+
+    index = new PersistentMemoryIndex({ databasePath });
+    expect(index.ftsAvailable).toBe(true);
+    expect(
+      (await readdir(stateRoot)).some((name) => name.includes("schema-99")),
+    ).toBe(true);
+    if (process.platform !== "win32") {
+      expect((await stat(stateRoot)).mode & 0o777).toBe(0o700);
+      expect((await stat(databasePath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("rotates a corrupt derived database without touching memory sources", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-corrupt-"));
+    const sourceRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(sourceRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    const sourcePath = join(sourceRoot, "preserved.md");
+    await writeMemory(sourcePath, "Preserved", "corruptrotationterm");
+    await writeFile(databasePath, "this is not a SQLite database");
+
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    expect(index.ftsAvailable).toBe(true);
+    expect(
+      (await readdir(stateRoot)).some((name) => name.includes(".corrupt-")),
+    ).toBe(true);
+    await expect(stat(sourcePath)).resolves.toMatchObject({});
+  });
+
+  it("rotates a same-version database whose schema contract is incomplete", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-signature-"));
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(stateRoot, { recursive: true });
+    const incomplete = new Database(databasePath);
+    incomplete.exec("CREATE TABLE unrelated(value TEXT)");
+    incomplete.pragma("user_version = 1");
+    incomplete.close();
+
+    index = new PersistentMemoryIndex({ databasePath });
+    expect(index.ftsAvailable).toBe(true);
+    expect(
+      (await readdir(stateRoot)).some((name) => name.includes(".schema-1-")),
+    ).toBe(true);
+  });
+
+  it("marks a missed create stale when the bounded directory audit sees mutation", async () => {
+    const fixture = await createFixture();
+    await writeMemory(
+      join(fixture.globalRoot, "existing.md"),
+      "Existing",
+      "existingterm",
+    );
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    await writeMemory(
+      join(fixture.globalRoot, "missed-create.md"),
+      "Missed create",
+      "missedcreateterm",
+    );
+
+    const status = await index!.auditSlice(
+      { path: fixture.globalRoot, role: "global" },
+      new AbortController().signal,
+    );
+    expect(status.watcherHealth).toBe("degraded");
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    const repaired = await index!.query(
+      fixture.rootSpecs,
+      ["missedcreateterm"],
+      new AbortController().signal,
+    );
+    expect(repaired.candidates).toHaveLength(1);
+  });
+
+  it("serializes two daemon writers through the bounded SQLite lease", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-writers-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    for (let ordinal = 0; ordinal < 100; ordinal += 1) {
+      await writeMemory(
+        join(memoryRoot, `${ordinal}.md`),
+        `Writer ${ordinal}`,
+        "writerleaseterm",
+      );
+    }
+    const roots = [{ path: memoryRoot, role: "global" as const }];
+    const first = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    const second = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    index = first;
+    try {
+      const outcomes = await Promise.all([
+        first.refresh(roots, new AbortController().signal),
+        second.refresh(roots, new AbortController().signal),
+      ]);
+      expect(outcomes.some((outcome) => outcome.kind === "complete")).toBe(
+        true,
+      );
+      expect(
+        outcomes.some((outcome) =>
+          outcome.roots.some((root) => root.reason?.includes("writer lease")),
+        ),
+      ).toBe(true);
+      await expect(
+        second.refresh(roots, new AbortController().signal),
+      ).resolves.toMatchObject({ kind: "complete" });
+    } finally {
+      second.close();
+    }
+  });
+
+  it("evicts the deterministic LRU root at the exact 64/65 global boundary without deleting sources", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-root-cap-"));
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(stateRoot, { recursive: true });
+    let clock = 1;
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      now: () => clock++,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    const sourceRoots: string[] = [];
+    for (let ordinal = 0; ordinal < MAX_MEMORY_INDEX_ROOTS; ordinal += 1) {
+      const sourceRoot = join(
+        temporaryRoot,
+        `memory-${ordinal.toString().padStart(2, "0")}`,
+      );
+      await mkdir(sourceRoot);
+      sourceRoots.push(sourceRoot);
+      await index.refresh(
+        [{ path: sourceRoot, role: "project" }],
+        new AbortController().signal,
+        { explicit: true },
+      );
+    }
+    const newestRoot = join(temporaryRoot, "memory-64");
+    await mkdir(newestRoot);
+    sourceRoots.push(newestRoot);
+    const leaseDatabase = new Database(databasePath);
+    try {
+      leaseDatabase
+        .prepare(
+          `UPDATE memory_index_generations
+              SET builder_owner = ?, builder_lease_expires_at_ms = ?
+            WHERE id = (
+              SELECT current_generation_id FROM memory_index_roots
+               WHERE canonical_path = ?
+            )`,
+        )
+        .run(
+          "other-daemon",
+          clock + MEMORY_INDEX_BUILD_LEASE_MS,
+          sourceRoots[0],
+        );
+    } finally {
+      leaseDatabase.close();
+    }
+    await expect(
+      index.refresh(
+        [{ path: newestRoot, role: "project" }],
+        new AbortController().signal,
+        { explicit: true },
+      ),
+    ).resolves.toMatchObject({ kind: "complete" });
+    const inspection = new Database(databasePath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      const row = inspection
+        .prepare("SELECT COUNT(*) AS count FROM memory_index_roots")
+        .get() as { count: number };
+      expect(row.count).toBe(MAX_MEMORY_INDEX_ROOTS);
+      const leased = inspection
+        .prepare(
+          "SELECT COUNT(*) AS count FROM memory_index_roots WHERE canonical_path = ?",
+        )
+        .get(sourceRoots[0]) as { count: number };
+      expect(leased.count).toBe(1);
+      const evicted = inspection
+        .prepare(
+          "SELECT COUNT(*) AS count FROM memory_index_roots WHERE canonical_path = ?",
+        )
+        .get(sourceRoots[1]) as { count: number };
+      expect(evicted.count).toBe(0);
+    } finally {
+      inspection.close();
+    }
+    for (const sourceRoot of sourceRoots) {
+      await expect(stat(sourceRoot)).resolves.toMatchObject({});
+    }
+  });
+
+  it("honors the exact root idle-TTL boundary and preserves source memory", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-root-ttl-"));
+    const sourceRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    await mkdir(sourceRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    let now = 1_000;
+    index = new PersistentMemoryIndex({
+      databasePath: join(stateRoot, "memory.sqlite"),
+      backgroundRefresh: false,
+      now: () => now,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    await index.refresh(
+      [{ path: sourceRoot, role: "project" }],
+      new AbortController().signal,
+      { explicit: true },
+    );
+    now += MEMORY_INDEX_ROOT_IDLE_TTL_MS - 1;
+    expect(index.cleanupUnusedRoots()).toBe(0);
+    now += 1;
+    expect(index.cleanupUnusedRoots()).toBe(1);
+    const inspection = new Database(join(stateRoot, "memory.sqlite"), {
+      readonly: true,
+      fileMustExist: true,
+    });
+    try {
+      const roots = inspection
+        .prepare("SELECT COUNT(*) AS count FROM memory_index_roots")
+        .get() as { count: number };
+      const owners = inspection
+        .prepare("SELECT COUNT(*) AS count FROM memory_index_owners")
+        .get() as { count: number };
+      expect(roots.count).toBe(0);
+      expect(owners.count).toBe(0);
+    } finally {
+      inspection.close();
+    }
+    await expect(stat(sourceRoot)).resolves.toMatchObject({});
+  });
+
+  it("keeps an idle root while another daemon holds its watcher lease", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-owner-lease-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    let now = 1_000;
+    const owner = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      now: () => now,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    const cleaner = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      now: () => now,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    index = owner;
+    await owner.refresh(
+      [{ path: memoryRoot, role: "project" }],
+      new AbortController().signal,
+      { explicit: true },
+    );
+    now += MEMORY_INDEX_ROOT_IDLE_TTL_MS;
+    const heartbeatDatabase = new Database(databasePath);
+    try {
+      heartbeatDatabase
+        .prepare("UPDATE memory_index_owners SET lease_expires_at_ms = ?")
+        .run(now + MEMORY_INDEX_BUILD_LEASE_MS);
+    } finally {
+      heartbeatDatabase.close();
+    }
+    expect(cleaner.cleanupUnusedRoots()).toBe(0);
+    owner.close();
+    index = cleaner;
+    expect(cleaner.cleanupUnusedRoots()).toBe(1);
+  });
+
+  it("does not retire an idle watcher while its root has an in-flight query", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-query-owner-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    await writeMemory(
+      join(memoryRoot, "query.md"),
+      "Query ownership",
+      "queryownershipterm",
+    );
+    let now = 1_000;
+    const queryPool = new MemoryQueryProcessPool({ helperEntrypoint });
+    let markStarted!: () => void;
+    let releaseQuery!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      releaseQuery = resolve;
+    });
+    vi.spyOn(queryPool, "query").mockImplementation(async () => {
+      markStarted();
+      await blocked;
+      return [];
+    });
+    index = new PersistentMemoryIndex({
+      databasePath: join(stateRoot, "memory.sqlite"),
+      backgroundRefresh: false,
+      now: () => now,
+      queryPool,
+    });
+    const roots = [{ path: memoryRoot, role: "project" as const }];
+    await index.refresh(roots, new AbortController().signal, {
+      explicit: true,
+    });
+    const query = index.query(
+      roots,
+      ["queryownershipterm"],
+      new AbortController().signal,
+    );
+    await started;
+    now += MEMORY_INDEX_ROOT_IDLE_TTL_MS;
+    try {
+      expect(index.cleanupUnusedRoots()).toBe(0);
+    } finally {
+      releaseQuery();
+    }
+    await query;
+    expect(index.cleanupUnusedRoots()).toBe(1);
+  });
+
+  it("observes an external update through the debounced watcher and atomically replaces the generation", async () => {
+    const fixture = await createFixture();
+    const memoryPath = join(fixture.globalRoot, "watched.md");
+    await writeMemory(memoryPath, "Watched", "watcher_alpha");
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+    expect(
+      (
+        await index!.query(
+          fixture.rootSpecs,
+          ["watcher_alpha"],
+          new AbortController().signal,
+        )
+      ).candidates,
+    ).toHaveLength(1);
+
+    await writeMemory(memoryPath, "Watched", "watcher_bravo");
+    await expectEventually(async () => {
+      const result = await index!.query(
+        fixture.rootSpecs,
+        ["watcher_bravo"],
+        new AbortController().signal,
+      );
+      return result.candidates.length === 1;
+    });
+    const oldResult = await index!.query(
+      fixture.rootSpecs,
+      ["watcher_alpha"],
+      new AbortController().signal,
+    );
+    expect(oldResult.candidates).toHaveLength(0);
+    const audited = await index!.auditSlice(
+      { path: fixture.globalRoot, role: "global" },
+      new AbortController().signal,
+    );
+    expect(audited.watcherHealth).toBe("healthy");
+  });
+
+  it("applies rename and delete changes through an invisible incremental generation", async () => {
+    const fixture = await createFixture();
+    const oldPath = join(fixture.projectRoot, "old-name.md");
+    const newPath = join(fixture.projectRoot, "new-name.md");
+    await writeMemory(oldPath, "Rename", "atomicrenameterm");
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal, {
+      explicit: true,
+    });
+
+    await rename(oldPath, newPath);
+    index!.recordChange({
+      rootPath: fixture.projectRoot,
+      relativePath: "old-name.md",
+      kind: "delete",
+    });
+    index!.recordChange({
+      rootPath: fixture.projectRoot,
+      relativePath: "new-name.md",
+      kind: "rename",
+    });
+    const renamed = await index!.refresh(
+      fixture.rootSpecs,
+      new AbortController().signal,
+    );
+    expect(renamed.kind).toBe("complete");
+    const afterRename = await index!.query(
+      fixture.rootSpecs,
+      ["atomicrenameterm"],
+      new AbortController().signal,
+    );
+    expect(
+      afterRename.candidates.map((candidate) => candidate.canonicalPath),
+    ).toEqual([newPath]);
+
+    await unlink(newPath);
+    index!.recordChange({
+      rootPath: fixture.projectRoot,
+      relativePath: "new-name.md",
+      kind: "delete",
+    });
+    await index!.refresh(fixture.rootSpecs, new AbortController().signal);
+    const afterDelete = await index!.query(
+      fixture.rootSpecs,
+      ["atomicrenameterm"],
+      new AbortController().signal,
+    );
+    expect(afterDelete.candidates).toHaveLength(0);
+  });
+
+  it("never exposes a sliced prefix and resumes a single large directory after restart", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-resume-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    for (let start = 0; start < 10_001; start += 500) {
+      await Promise.all(
+        Array.from({ length: Math.min(500, 10_001 - start) }, (_, offset) => {
+          const ordinal = start + offset;
+          return writeMemory(
+            join(memoryRoot, `${ordinal.toString().padStart(5, "0")}.md`),
+            `Memory ${ordinal}`,
+            ordinal === 10_000 ? "lastuniqueterm" : "ordinaryterm",
+          );
+        }),
+      );
+    }
+    const roots = [{ path: memoryRoot, role: "global" as const }];
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    const firstSlice = await index.refresh(roots, new AbortController().signal);
+    expect(firstSlice.kind).toBe("refresh_pending");
+    const generationToken = firstSlice.roots[0]?.generationToken;
+    expect(generationToken).toBeTypeOf("string");
+    expect(index.pollRefresh(generationToken!)).toMatchObject({
+      state: "refresh_pending",
+      generationToken,
+    });
+    const invisiblePrefix = await index.query(
+      roots,
+      ["ordinaryterm"],
+      new AbortController().signal,
+    );
+    expect(invisiblePrefix.kind).toBe("unavailable");
+    expect(invisiblePrefix.candidates).toEqual([]);
+
+    index.close();
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    let refresh = await index.refresh(roots, new AbortController().signal);
+    for (
+      let slice = 0;
+      slice < 4 && refresh.kind === "refresh_pending";
+      slice += 1
+    ) {
+      refresh = await index.refresh(roots, new AbortController().signal);
+    }
+    expect(refresh.kind).toBe("complete");
+    const complete = await index.query(
+      roots,
+      ["lastuniqueterm"],
+      new AbortController().signal,
+    );
+    expect(complete.candidates).toHaveLength(1);
+    expect(complete.candidates[0]?.canonicalPath).toBe(
+      join(memoryRoot, "10000.md"),
+    );
+  }, 30_000);
+});
+
+async function createFixture(): Promise<{
+  readonly globalRoot: string;
+  readonly projectRoot: string;
+  readonly rootSpecs: readonly MemoryIndexRootSpec[];
+}> {
+  temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-index-"));
+  const stateRoot = join(temporaryRoot, "state");
+  const globalRoot = join(temporaryRoot, "global-memory");
+  const projectRoot = join(temporaryRoot, "project-memory");
+  await mkdir(stateRoot, { recursive: true });
+  await mkdir(globalRoot, { recursive: true });
+  await mkdir(projectRoot, { recursive: true });
+  index = new PersistentMemoryIndex({
+    databasePath: join(stateRoot, "memory.sqlite"),
+    queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+  });
+  return {
+    globalRoot,
+    projectRoot,
+    rootSpecs: [
+      { path: globalRoot, role: "global" },
+      { path: projectRoot, role: "project" },
+    ],
+  };
+}
+
+function writeMemory(
+  path: string,
+  title: string,
+  description: string,
+): Promise<void> {
+  return writeFile(path, memoryDocument(title, description));
+}
+
+function memoryDocument(title: string, description: string): string {
+  return `---\ntitle: ${title}\ndescription: ${description}\ntype: project\n---\nBody.\n`;
+}
+
+function readCurrentGenerationProgress(databasePath: string): {
+  readonly entryCount: number;
+  readonly indexedBytes: number;
+  readonly digest: string;
+  readonly discoveryOperations: number;
+} {
+  const database = new Database(databasePath, {
+    readonly: true,
+    fileMustExist: true,
+  });
+  try {
+    return database
+      .prepare(
+        `SELECT g.entry_count AS entryCount,
+                g.indexed_bytes AS indexedBytes,
+                g.digest,
+                g.discovery_operations AS discoveryOperations
+           FROM memory_index_roots r
+           JOIN memory_index_generations g ON g.id = r.current_generation_id
+          WHERE r.root_role = 'global'`,
+      )
+      .get() as {
+      entryCount: number;
+      indexedBytes: number;
+      digest: string;
+      discoveryOperations: number;
+    };
+  } finally {
+    database.close();
+  }
+}
+
+async function expectEventually(check: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("memory watcher did not converge before the test deadline");
+}

--- a/runtime/tests/memory/memory-query-pool.test.ts
+++ b/runtime/tests/memory/memory-query-pool.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_MEMORY_QUERY_PROCESSES,
+  MAX_MEMORY_QUERY_QUEUE,
+  MemoryIndexQueryResourceLimitedError,
+} from "../../src/memory/full-corpus-contract.js";
+import { MemoryQueryProcessPool } from "../../src/memory/memory-query-pool.js";
+
+let temporaryRoot = "";
+
+afterEach(async () => {
+  if (temporaryRoot !== "") {
+    await rm(temporaryRoot, { recursive: true, force: true });
+    temporaryRoot = "";
+  }
+});
+
+describe("C3b bounded memory query process pool", () => {
+  it("kills a nonreturning helper at the wall deadline", async () => {
+    const helper = await writeHelper(
+      `process.stdin.resume();\nfor await (const _chunk of process.stdin) {}\nsetInterval(() => {}, 1000);\n`,
+    );
+    const pool = new MemoryQueryProcessPool({
+      helperEntrypoint: helper,
+      timeoutMs: 25,
+    });
+
+    await expect(
+      pool.query(queryRequest(), new AbortController().signal),
+    ).rejects.toBeInstanceOf(MemoryIndexQueryResourceLimitedError);
+  });
+
+  it("fails the exact first request beyond the four-process and 64-waiter bounds", async () => {
+    const helper = await writeHelper(
+      `process.stdin.resume();\nfor await (const _chunk of process.stdin) {}\nsetInterval(() => {}, 1000);\n`,
+    );
+    const pool = new MemoryQueryProcessPool({
+      helperEntrypoint: helper,
+      timeoutMs: 5_000,
+    });
+    const controller = new AbortController();
+    const admitted = Array.from(
+      { length: MAX_MEMORY_QUERY_PROCESSES + MAX_MEMORY_QUERY_QUEUE },
+      () =>
+        pool.query(queryRequest(), controller.signal).catch((error) => error),
+    );
+
+    await expect(pool.query(queryRequest(), controller.signal)).rejects.toThrow(
+      "queue is full",
+    );
+    controller.abort(new Error("release bounded query fixture"));
+    await Promise.all(admitted);
+  });
+
+  it("rejects an output overrun without parsing a timing-dependent prefix", async () => {
+    const helper = await writeHelper(
+      `process.stdin.resume();\nfor await (const _chunk of process.stdin) {}\nprocess.stdout.write(Buffer.alloc(1_048_581, 97));\n`,
+    );
+    const pool = new MemoryQueryProcessPool({ helperEntrypoint: helper });
+
+    await expect(
+      pool.query(queryRequest(), new AbortController().signal),
+    ).rejects.toBeInstanceOf(MemoryIndexQueryResourceLimitedError);
+  });
+});
+
+async function writeHelper(source: string): Promise<string> {
+  if (temporaryRoot === "") {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-memory-helper-"));
+  }
+  const path = join(
+    temporaryRoot,
+    `helper-${Math.random().toString(16).slice(2)}.mjs`,
+  );
+  await writeFile(path, source, "utf8");
+  return path;
+}
+
+function queryRequest() {
+  return {
+    databasePath: "/bounded/test.sqlite",
+    rootId: "root",
+    generationId: 1,
+    rootRole: "global" as const,
+    match: '"term"',
+    limit: 1,
+  };
+}

--- a/runtime/tests/memory/production-recall.integration.test.ts
+++ b/runtime/tests/memory/production-recall.integration.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../src/budget/admission-client.js";
 import type { AdmissionLease } from "../../src/budget/admission-types.js";
 import { createAdmittedMemorySelector } from "../../src/memory/admitted-selector.js";
+import { closeFullCorpusMemoryIndexes } from "../../src/memory/find-relevant.js";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -24,9 +25,11 @@ let previousAgenCHome: string | undefined;
 let previousDisableMemory: string | undefined;
 
 afterEach(async () => {
+  closeFullCorpusMemoryIndexes();
   if (previousAgenCHome === undefined) delete process.env.AGENC_HOME;
   else process.env.AGENC_HOME = previousAgenCHome;
-  if (previousDisableMemory === undefined) delete process.env.AGENC_DISABLE_AUTO_MEMORY;
+  if (previousDisableMemory === undefined)
+    delete process.env.AGENC_DISABLE_AUTO_MEMORY;
   else process.env.AGENC_DISABLE_AUTO_MEMORY = previousDisableMemory;
   if (temporaryRoot !== "") {
     await rm(temporaryRoot, { recursive: true, force: true });
@@ -34,8 +37,8 @@ afterEach(async () => {
   }
 });
 
-describe("C3a production memory recall wiring", () => {
-  it("runs the real producer through admission and a provider before injection", async () => {
+describe("C3b production memory recall wiring", () => {
+  it("runs full-corpus recall older than 200 through admission and a provider", async () => {
     previousAgenCHome = process.env.AGENC_HOME;
     previousDisableMemory = process.env.AGENC_DISABLE_AUTO_MEMORY;
     temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3a-production-"));
@@ -46,7 +49,15 @@ describe("C3a production memory recall wiring", () => {
     const memoryPath = join(agencHome, "memory", "browser.md");
     await writeFile(
       memoryPath,
-      "---\nname: Browser warning\ndescription: Browser automation failure recovery\ntype: user\n---\nUse the safe browser recovery sequence.\n",
+      "---\nname: Browser warning\ndescription: uniquebrowserfailure recovery\ntype: user\n---\nUse the safe browser recovery sequence.\n",
+    );
+    await Promise.all(
+      Array.from({ length: 220 }, (_, index) =>
+        writeFile(
+          join(agencHome, "memory", `recent-${index}.md`),
+          `---\nname: Recent ${index}\ndescription: unrelated compiler note\ntype: user\n---\nRecent.\n`,
+        ),
+      ),
     );
     process.env.AGENC_HOME = agencHome;
     delete process.env.AGENC_DISABLE_AUTO_MEMORY;
@@ -96,7 +107,10 @@ describe("C3a production memory recall wiring", () => {
       subscribe: vi.fn(() => () => undefined),
     } as unknown as ExecutionAdmissionClient;
     const chat = vi.fn(
-      async (_messages: LLMMessage[], _options?: LLMChatOptions): Promise<LLMResponse> => ({
+      async (
+        _messages: LLMMessage[],
+        _options?: LLMChatOptions,
+      ): Promise<LLMResponse> => ({
         content: JSON.stringify({ selected_candidate_ids: ["candidate-1"] }),
         structuredOutput: {
           type: "json_schema",
@@ -143,7 +157,7 @@ describe("C3a production memory recall wiring", () => {
     const attachments = await relevantMemoriesProducer(
       {
         sessionKey,
-        userInput: "browser automation",
+        userInput: "uniquebrowserfailure",
         loadedTools: [],
         messages: [],
         permissionContext: { mode: "default" } as never,
@@ -159,10 +173,11 @@ describe("C3a production memory recall wiring", () => {
     expect(acquire).toHaveBeenCalledTimes(1);
     expect(acquire.mock.calls[0]?.[0].stepId).toBe("memory-selector:0");
     expect(chat).toHaveBeenCalledTimes(1);
+    expect(chat.mock.calls[0]?.[0][0]?.content).toContain("Browser warning");
     expect(attachments).toHaveLength(1);
     expect(attachments[0]).toMatchObject({
       kind: "relevant_memories",
-      memories: [{ path: memoryPath }],
+      memories: [{ path: memoryPath, selectionSource: "reranked" }],
     });
   });
 });

--- a/runtime/tests/memory/recall-contract.test.ts
+++ b/runtime/tests/memory/recall-contract.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_C3A_QUERY_CODEPOINTS,
   MAX_C3A_QUERY_TERMS,
-  MAX_C3A_SELECTOR_CANDIDATES,
+  MAX_MEMORY_SELECTOR_CANDIDATES,
   MAX_C3A_TERM_OCCURRENCES_PER_TERM,
   MAX_MEMORY_SELECTOR_TOTAL_UTF8_BYTES,
   buildMemorySelectorRequest,
@@ -44,9 +44,10 @@ describe("C3a lexical recall contract", () => {
     expect(query.truncated).toBe(true);
 
     const terms = normalizeMemoryQuery(
-      Array.from({ length: MAX_C3A_QUERY_TERMS + 1 }, (_, index) => `t${index}`).join(
-        " ",
-      ),
+      Array.from(
+        { length: MAX_C3A_QUERY_TERMS + 1 },
+        (_, index) => `t${index}`,
+      ).join(" "),
     );
     expect(terms.terms).toHaveLength(MAX_C3A_QUERY_TERMS);
     expect(normalizeMemoryQuery("STRASSE Straße ΟΣ ος").terms).toEqual([
@@ -56,9 +57,7 @@ describe("C3a lexical recall contract", () => {
   });
 
   it("ranks exact phrase, coverage, capped occurrences, mtime, then path", () => {
-    const repeated = "alpha ".repeat(
-      MAX_C3A_TERM_OCCURRENCES_PER_TERM + 20,
-    );
+    const repeated = "alpha ".repeat(MAX_C3A_TERM_OCCURRENCES_PER_TERM + 20);
     const ranked = rankMemoryHeaders(
       normalizeMemoryQuery("alpha beta"),
       [
@@ -90,7 +89,12 @@ describe("C3a lexical recall contract", () => {
   it("returns no normal-query result without terms or overlap", () => {
     const candidates = [header("recent.md", "unrelated", "", 10_000)];
     expect(
-      rankMemoryHeaders(normalizeMemoryQuery("!!!"), candidates, "query", SIGNAL),
+      rankMemoryHeaders(
+        normalizeMemoryQuery("!!!"),
+        candidates,
+        "query",
+        SIGNAL,
+      ),
     ).toEqual([]);
     expect(
       rankMemoryHeaders(
@@ -113,7 +117,7 @@ describe("C3a lexical recall contract", () => {
   it("builds at most fifty structured candidates under the exact byte cap", () => {
     const ranked = rankMemoryHeaders(
       normalizeMemoryQuery("memory"),
-      Array.from({ length: MAX_C3A_SELECTOR_CANDIDATES + 10 }, (_, index) =>
+      Array.from({ length: MAX_MEMORY_SELECTOR_CANDIDATES + 10 }, (_, index) =>
         header(
           `${index}.md`,
           `memory ${"\u0000😀".repeat(4_000)}`,
@@ -124,19 +128,16 @@ describe("C3a lexical recall contract", () => {
       "query",
       SIGNAL,
     );
-    const request = buildMemorySelectorRequest(
-      "memory",
-      "query",
-      ranked,
-      [],
-    );
+    const request = buildMemorySelectorRequest("memory", "query", ranked, []);
 
-    expect(request.candidates).toHaveLength(MAX_C3A_SELECTOR_CANDIDATES);
-    expect(Buffer.byteLength(JSON.stringify(request), "utf8")).toBeLessThanOrEqual(
-      MAX_MEMORY_SELECTOR_TOTAL_UTF8_BYTES,
-    );
+    expect(request.candidates).toHaveLength(MAX_MEMORY_SELECTOR_CANDIDATES);
+    expect(
+      Buffer.byteLength(JSON.stringify(request), "utf8"),
+    ).toBeLessThanOrEqual(MAX_MEMORY_SELECTOR_TOTAL_UTF8_BYTES);
     expect(request.candidates[0]?.id).toBe("candidate-1");
-    expect(request.candidates[0]?.omitted.descriptionUtf8Bytes).toBeGreaterThan(0);
+    expect(request.candidates[0]?.omitted.descriptionUtf8Bytes).toBeGreaterThan(
+      0,
+    );
   });
 
   it("propagates the original abort reason during lexical scoring", () => {

--- a/runtime/tests/packaging/memory-query-helper.test.ts
+++ b/runtime/tests/packaging/memory-query-helper.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { __agencBuildConfigTest } from "../../build.config.js";
+import { resolveDefaultMemoryQueryHelperEntrypoint } from "../../src/memory/memory-query-pool.js";
+
+describe("C3b memory query helper packaging", () => {
+  it("ships the killable helper as its own runtime entrypoint", () => {
+    expect(__agencBuildConfigTest.entry).toContain(
+      "src/memory/memory-query-helper.mjs",
+    );
+  });
+
+  it("resolves both source and root-chunk packaged layouts", () => {
+    expect(resolveDefaultMemoryQueryHelperEntrypoint()).toMatch(
+      /memory-query-helper\.mjs$/u,
+    );
+    expect(
+      resolveDefaultMemoryQueryHelperEntrypoint(
+        new URL("../../dist/chunk-memory-index.js", import.meta.url).href,
+      ),
+    ).toMatch(/dist[/\\]memory[/\\]memory-query-helper\.js$/u);
+  });
+});

--- a/runtime/tests/prompts/attachments/relevant-memories.test.ts
+++ b/runtime/tests/prompts/attachments/relevant-memories.test.ts
@@ -11,6 +11,7 @@ import type {
   AdmittedMemorySelector,
   MemorySelectorRequest,
 } from "../../memory/recall-contract.js";
+import { closeFullCorpusMemoryIndexes } from "../../memory/find-relevant.js";
 import type { GetAttachmentsOptions } from "./orchestrator.js";
 import { relevantMemoriesProducer } from "./relevant-memories.js";
 
@@ -20,14 +21,12 @@ let agencHome: string;
 let savedAgencHome: string | undefined;
 let savedDisableAutoMemory: string | undefined;
 let selectedMemoryTitle = "";
-const selectorCall = vi.fn(
-  async (request: MemorySelectorRequest) => ({
-    kind: "selected" as const,
-    candidateIds: request.candidates
-      .filter((candidate) => candidate.title === selectedMemoryTitle)
-      .map((candidate) => candidate.id),
-  }),
-);
+const selectorCall = vi.fn(async (request: MemorySelectorRequest) => ({
+  kind: "selected" as const,
+  candidateIds: request.candidates
+    .filter((candidate) => candidate.title === selectedMemoryTitle)
+    .map((candidate) => candidate.id),
+}));
 const admittedMemorySelector: AdmittedMemorySelector = {
   select: selectorCall,
 };
@@ -47,6 +46,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  closeFullCorpusMemoryIndexes();
   if (savedAgencHome === undefined) {
     delete process.env.AGENC_HOME;
   } else {
@@ -87,8 +87,14 @@ function writeMemory(
   const path = join(dir, name);
   writeFileSync(
     path,
-    ["---", `description: ${description}`, "type: usage", "---", "", content]
-      .join("\n"),
+    [
+      "---",
+      `description: ${description}`,
+      "type: usage",
+      "---",
+      "",
+      content,
+    ].join("\n"),
     "utf8",
   );
   return path;
@@ -123,7 +129,10 @@ describe("relevantMemoriesProducer", () => {
       trackingState,
     );
     expect(out).toMatchObject([
-      { kind: "relevant_memories", memories: [{ path: memoryPath }] },
+      {
+        kind: "relevant_memories",
+        memories: [{ path: memoryPath, selectionSource: "reranked" }],
+      },
     ]);
     expect(selectorCall).toHaveBeenCalledTimes(1);
   });
@@ -174,7 +183,9 @@ describe("relevantMemoriesProducer", () => {
     );
     expect(out[0].memories[0]?.header).toContain("Memory");
     expect(out[0].memories[0]?.citation?.path).toBe(memoryPath);
-    expect(trackingState.surfacedRelevantMemoryPaths.has(memoryPath)).toBe(true);
+    expect(trackingState.surfacedRelevantMemoryPaths.has(memoryPath)).toBe(
+      true,
+    );
     expect(trackingState.surfacedRelevantMemoryBytes).toBeGreaterThan(0);
     expect(selectorCall.mock.calls[0]?.[0].recentTools).toEqual(["browser"]);
   });
@@ -238,6 +249,9 @@ describe("relevantMemoriesProducer", () => {
     expect(
       out[0].memories.find((memory) => memory.path === projectPath)?.content,
     ).toContain("Run the runtime build twice.");
+    expect(
+      out[0].memories.every((memory) => memory.selectionSource === "lexical"),
+    ).toBe(true);
     expect(trackingState.surfacedRelevantMemoryPaths.has(projectPath)).toBe(
       true,
     );
@@ -332,8 +346,9 @@ describe("relevantMemoriesProducer", () => {
       memoryDir,
       "large.md",
       "Large browser guidance",
-      Array.from({ length: 260 }, (_, i) => `line ${i} ${"x".repeat(40)}`)
-        .join("\n"),
+      Array.from({ length: 260 }, (_, i) => `line ${i} ${"x".repeat(40)}`).join(
+        "\n",
+      ),
     );
     selectMemory("large.md");
     const trackingState = getAttachmentTrackingState({});


### PR DESCRIPTION
## Summary

- add a bounded full-corpus SQLite FTS5/BM25 memory index with deterministic RRF ranking
- add staged generations, restart-safe leases, watcher/audit reconciliation, and bounded helper-process execution
- integrate indexed recall with the existing admitted-memory fallback and preserve selection provenance

## Validation

- Node 26.5.0 / npm 11.17.0
- focused memory-index/retrieval tests: 11 files, 63 tests
- `npm test`: required gates 130/130; agent contract 22/22; launcher 180/180; runtime 1,988 files / 18,497 tests
- runtime and test-support typechecks
- `npm run validate:runtime`
- SDK build and typecheck
- agent-surface contract including TUI scenarios
- FND inventory: 2 expected-red probes, 0 skips/todos
- bounded 1,000-item memory benchmark

Exact reviewed SHA: `507ffc0af3512ef4d4bbda5765db0c22cad49246`.
