### PR TITLE
fix(runtime): bind compaction baseline to merged main

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -728,6 +728,6 @@
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "d1f1ff756de8e75a4601f21eb19d9dbc2327cb58",
+  "sourceRevision": "f6f3105db5daba0023073240aa3cecd815fbe7af",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,8 +4,8 @@ This artifact records bounded observations of known failures. Every row is
 informational: no current result is a passing performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `d0080e523e56ba36e30b7024fc0ca47bb544703edc79e4707294514330797eae`
-- Source revision: `d1f1ff756de8e75a4601f21eb19d9dbc2327cb58`
+- JSON SHA-256: `bcb50ed24e089a81cac5f993058e61e989c472854cc88fdb4c40b3fdf6b19e39`
+- Source revision: `f6f3105db5daba0023073240aa3cecd815fbe7af`
 - Production tree: `runtime/src` at Git object `14bc1742a431230bc8aa81dec458f88d3d0899da`
 - Loaded production closure: `42` module bindings across `2` cases
 - Plan SHA-256: `f845a0595da15849f819d413b42f995107befacfc67ef78a2bf96338fda92025`
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision d1f1ff756de8e75a4601f21eb19d9dbc2327cb58 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision f6f3105db5daba0023073240aa3cecd815fbe7af --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 


### PR DESCRIPTION
## Summary

- bind the C2 FND baseline to the squash-merged main commit
- update only the generated JSON source revision and matching Markdown digest/reproduction metadata
- preserve every benchmark measurement, production-tree binding, closure, and evidence hash

## Regression

Merged-main aggregate verification previously failed because the pre-squash feature SHA was not an ancestor of main. The recorded revision is now the merged C2 main commit, which is an ancestor of this correction.

## Validation

- independent exact-SHA review: f699cd64f2b6cab99f29105b5d851d35e90c8dec approved
- npm test: 2,008 files / 18,652 tests passed
- FND baseline check and contract: 9 tests passed
- pre-commit build, SDK generated types, and PTY startup passed

No release is included or requested.