### PR TITLE
chore(release): establish 0.14 runtime foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agenc-core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agenc-core",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "workspaces": [
         "packages/agenc",
@@ -9414,7 +9414,7 @@
     },
     "packages/agenc": {
       "name": "@tetsuo-ai/agenc",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9440,7 +9440,7 @@
     },
     "runtime": {
       "name": "@tetsuo-ai/runtime",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenc-core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "MIT",
   "private": true,
   "packageManager": "npm@11.17.0",

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -289,7 +289,19 @@ export interface SessionCancelTurnParams extends JsonObject {
   readonly reason?: string;
 }
 
-export interface SessionResolveToolCallParams extends JsonObject {
+/** Protocol-1.0 request shape shipped with agenc-sdk 0.3.0. */
+export interface SessionResolveToolCallLegacyParams extends JsonObject {
+  readonly sessionId: string;
+  /** When omitted, every eligible legacy effect in the session is reviewed. */
+  readonly toolCallId?: string;
+  readonly reviewer?: string;
+  readonly disposition?: never;
+  readonly evidenceRef?: never;
+  readonly evidenceSha256?: never;
+}
+
+/** Evidence-bearing request required for canonical durable effect records. */
+export interface SessionResolveToolCallEvidenceParams extends JsonObject {
   readonly sessionId: string;
   readonly toolCallId: string;
   readonly disposition:
@@ -300,6 +312,10 @@ export interface SessionResolveToolCallParams extends JsonObject {
   readonly evidenceSha256: string;
   readonly reviewer?: string;
 }
+
+export type SessionResolveToolCallParams =
+  | SessionResolveToolCallLegacyParams
+  | SessionResolveToolCallEvidenceParams;
 
 export interface SessionMcpServerConfig extends JsonObject {
   readonly name: string;

--- a/packages/agenc/package.json
+++ b/packages/agenc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetsuo-ai/agenc",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Public AgenC CLI launcher package",
   "license": "MIT",
   "type": "module",

--- a/packaging/get-agenc-ag/public/index.html
+++ b/packaging/get-agenc-ag/public/index.html
@@ -158,7 +158,7 @@ a:hover{color:var(--muted)}
         <div class="nav-status hide-m">
           <span style="display:inline-flex;align-items:center;gap:8px"><span class="dot"></span>AGENC CORE</span>
           <span class="sep">|</span>
-          <span>V0.13.0</span>
+          <span>V0.14.0</span>
         </div>
       </div>
       <div class="nav-links">
@@ -174,7 +174,7 @@ a:hover{color:var(--muted)}
   <main class="main" aria-label="AgenC Core installer">
     <div class="shell">
 
-      <span class="badge"><span class="dot"></span>AGENC CORE · V0.13.0</span>
+      <span class="badge"><span class="dot"></span>AGENC CORE · V0.14.0</span>
 
       <img class="wordmark" src="assets/agenc-wordmark.svg" alt="AgenC">
 
@@ -211,8 +211,8 @@ a:hover{color:var(--muted)}
   <!-- FOOTER -->
   <footer class="marquee" aria-hidden="true">
     <div class="marquee-track">
-      <span>GET.AGENC.AG&nbsp;&nbsp;·&nbsp;&nbsp;AGENC CORE V0.13.0&nbsp;&nbsp;·&nbsp;&nbsp;TUI + PRINT + AGENTS&nbsp;&nbsp;·&nbsp;&nbsp;MULTI-CHANNEL GATEWAY&nbsp;&nbsp;·&nbsp;&nbsp;BUDGET-BOUNDED AUTONOMY&nbsp;&nbsp;·&nbsp;&nbsp;MCP CLIENT + SERVER&nbsp;&nbsp;·&nbsp;&nbsp;EMBEDDING SDK&nbsp;&nbsp;·&nbsp;&nbsp;<span class="dim">POWERED BY</span>&nbsp;&nbsp;NODE&nbsp;&nbsp;·&nbsp;&nbsp;TYPESCRIPT&nbsp;&nbsp;·&nbsp;&nbsp;GROK&nbsp;&nbsp;·&nbsp;&nbsp;16 PROVIDERS&nbsp;&nbsp;·&nbsp;&nbsp;</span>
-      <span>GET.AGENC.AG&nbsp;&nbsp;·&nbsp;&nbsp;AGENC CORE V0.13.0&nbsp;&nbsp;·&nbsp;&nbsp;TUI + PRINT + AGENTS&nbsp;&nbsp;·&nbsp;&nbsp;MULTI-CHANNEL GATEWAY&nbsp;&nbsp;·&nbsp;&nbsp;BUDGET-BOUNDED AUTONOMY&nbsp;&nbsp;·&nbsp;&nbsp;MCP CLIENT + SERVER&nbsp;&nbsp;·&nbsp;&nbsp;EMBEDDING SDK&nbsp;&nbsp;·&nbsp;&nbsp;<span class="dim">POWERED BY</span>&nbsp;&nbsp;NODE&nbsp;&nbsp;·&nbsp;&nbsp;TYPESCRIPT&nbsp;&nbsp;·&nbsp;&nbsp;GROK&nbsp;&nbsp;·&nbsp;&nbsp;16 PROVIDERS&nbsp;&nbsp;·&nbsp;&nbsp;</span>
+      <span>GET.AGENC.AG&nbsp;&nbsp;·&nbsp;&nbsp;AGENC CORE V0.14.0&nbsp;&nbsp;·&nbsp;&nbsp;TUI + PRINT + AGENTS&nbsp;&nbsp;·&nbsp;&nbsp;MULTI-CHANNEL GATEWAY&nbsp;&nbsp;·&nbsp;&nbsp;BUDGET-BOUNDED AUTONOMY&nbsp;&nbsp;·&nbsp;&nbsp;MCP CLIENT + SERVER&nbsp;&nbsp;·&nbsp;&nbsp;EMBEDDING SDK&nbsp;&nbsp;·&nbsp;&nbsp;<span class="dim">POWERED BY</span>&nbsp;&nbsp;NODE&nbsp;&nbsp;·&nbsp;&nbsp;TYPESCRIPT&nbsp;&nbsp;·&nbsp;&nbsp;GROK&nbsp;&nbsp;·&nbsp;&nbsp;16 PROVIDERS&nbsp;&nbsp;·&nbsp;&nbsp;</span>
+      <span>GET.AGENC.AG&nbsp;&nbsp;·&nbsp;&nbsp;AGENC CORE V0.14.0&nbsp;&nbsp;·&nbsp;&nbsp;TUI + PRINT + AGENTS&nbsp;&nbsp;·&nbsp;&nbsp;MULTI-CHANNEL GATEWAY&nbsp;&nbsp;·&nbsp;&nbsp;BUDGET-BOUNDED AUTONOMY&nbsp;&nbsp;·&nbsp;&nbsp;MCP CLIENT + SERVER&nbsp;&nbsp;·&nbsp;&nbsp;EMBEDDING SDK&nbsp;&nbsp;·&nbsp;&nbsp;<span class="dim">POWERED BY</span>&nbsp;&nbsp;NODE&nbsp;&nbsp;·&nbsp;&nbsp;TYPESCRIPT&nbsp;&nbsp;·&nbsp;&nbsp;GROK&nbsp;&nbsp;·&nbsp;&nbsp;16 PROVIDERS&nbsp;&nbsp;·&nbsp;&nbsp;</span>
     </div>
   </footer>
 

--- a/packaging/homebrew/agenc.rb
+++ b/packaging/homebrew/agenc.rb
@@ -1,13 +1,13 @@
 # Homebrew formula template for the self-contained AgenC runtime.
 #
 # OWNER-PUBLISH STEP — this file remains deliberately unpublishable until the
-# two placeholder digests are replaced from an immutable agenc-v0.13.0
+# two placeholder digests are replaced from an immutable agenc-v0.14.0
 # manifest and the formula is copied to tetsuo-ai/homebrew-agenc.
 class Agenc < Formula
   desc "Daemon-backed, terminal-native coding agent"
   homepage "https://github.com/tetsuo-ai/agenc-core"
-  url "https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.13.0/agenc-runtime-0.13.0-darwin-#{Hardware::CPU.arm? ? "arm64" : "x64"}-node26-abi147.tar.gz"
-  version "0.13.0"
+  url "https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.14.0/agenc-runtime-0.14.0-darwin-#{Hardware::CPU.arm? ? "arm64" : "x64"}-node26-abi147.tar.gz"
+  version "0.14.0"
   arm64_sha256 = "REPLACE_WITH_DARWIN_ARM64_SHA256"
   x64_sha256 = "REPLACE_WITH_DARWIN_X64_SHA256"
   sha256 Hardware::CPU.arm? ? arm64_sha256 : x64_sha256

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -463,7 +463,7 @@
     {
       "normalization": "utf8_lf",
       "path": "package-lock.json",
-      "sha256": "67ff53f2dc79a91cdea325dbf827f41b6c2335f0884d97506cf06d45afc37834"
+      "sha256": "cb25aa61843a593585f5b20988e6c2c52e190642cb91a35845947a0e87c0e440"
     },
     {
       "normalization": "utf8_lf",
@@ -538,7 +538,7 @@
     {
       "normalization": "utf8_lf",
       "path": "runtime/package.json",
-      "sha256": "d325bc7a8039434d31fb31c50dd66c81cde7cc76fd7b1dc8bfa30d191488490e"
+      "sha256": "85c5bd5b00c97499e1a54e5987db4fb3396f29f6316d69621914c64bbe05d956"
     }
   ],
   "planDigest": "f845a0595da15849f819d413b42f995107befacfc67ef78a2bf96338fda92025",

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,7 +4,7 @@ This artifact records bounded observations of known failures. Every row is
 informational: no current result is a passing performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `bcb50ed24e089a81cac5f993058e61e989c472854cc88fdb4c40b3fdf6b19e39`
+- JSON SHA-256: `b59ad2e81d5d16cf5bccfe9892e8becd08f6855b1b9158a46a81c4a312dbd3ca`
 - Source revision: `f6f3105db5daba0023073240aa3cecd815fbe7af`
 - Production tree: `runtime/src` at Git object `14bc1742a431230bc8aa81dec458f88d3d0899da`
 - Loaded production closure: `42` module bindings across `2` cases

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetsuo-ai/runtime",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "description": "AgenC lean coding CLI",
   "type": "module",

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -13,7 +13,11 @@ import {
   createOperatorEffectReviewResolution,
   resolveDurableEffectReview,
 } from "../state/effect-review.js";
-import { listUnresolvedUnknownOutcomeEffects } from "../state/unknown-outcome-gate.js";
+import { StateRunDurabilityRepository } from "../state/run-durability.js";
+import {
+  listUnresolvedUnknownOutcomeEffects,
+  resolveUnknownOutcomeEffect,
+} from "../state/unknown-outcome-gate.js";
 import {
   requireAbsoluteWorkspaceCwd,
   WorkspaceCwdError,
@@ -66,6 +70,7 @@ import type {
   SessionRollbackCompactionResult,
   SessionExtendCompactionRollbackRetentionParams,
   SessionExtendCompactionRollbackRetentionResult,
+  SessionResolveToolCallEvidenceParams,
   SessionResolveToolCallParams,
   SessionResolveToolCallResult,
   SessionRewindConversationToMessageParams,
@@ -337,6 +342,12 @@ interface RunnerTerminationTarget {
   readonly transitionAt: string;
   readonly metadata?: JsonObject;
   readonly terminal?: AgenCBackgroundAgentTerminalSnapshot;
+}
+
+function isEvidenceToolCallResolution(
+  params: SessionResolveToolCallParams,
+): params is SessionResolveToolCallEvidenceParams {
+  return Object.prototype.hasOwnProperty.call(params, "disposition");
 }
 
 export class AgenCDaemonAgentManager {
@@ -1674,6 +1685,55 @@ export class AgenCDaemonAgentManager {
     }
     const driver = openStateDatabases({ cwd: session.cwd });
     try {
+      const candidates =
+        params.toolCallId !== undefined
+          ? [
+              {
+                sessionId: params.sessionId,
+                toolCallId: params.toolCallId,
+                toolName: "",
+                startedAt: "",
+              },
+            ]
+          : [...listUnresolvedUnknownOutcomeEffects(driver, params.sessionId)];
+      const resolved: SessionResolveToolCallResult["resolved"][number][] = [];
+
+      if (!isEvidenceToolCallResolution(params)) {
+        const durableEffects = new StateRunDurabilityRepository(driver);
+        for (const effect of candidates) {
+          // The published 1.0 request carried no disposition or evidence. It
+          // remains valid only for pre-durability poisoned rows; every durable
+          // v1/v2 effect stays pending until an evidence-bearing request arrives.
+          if (
+            durableEffects.getEffectBySessionCall(
+              params.sessionId,
+              effect.toolCallId,
+            ) !== undefined
+          ) {
+            continue;
+          }
+          if (
+            resolveUnknownOutcomeEffect(driver, {
+              sessionId: params.sessionId,
+              toolCallId: effect.toolCallId,
+            })
+          ) {
+            resolved.push({
+              toolCallId: effect.toolCallId,
+              toolName: effect.toolName,
+            });
+          }
+        }
+        return {
+          sessionId: params.sessionId,
+          resolved,
+          remaining: listUnresolvedUnknownOutcomeEffects(
+            driver,
+            params.sessionId,
+          ).length,
+        };
+      }
+
       const reviewedAt = new Date().toISOString();
       const reviewedBy = params.reviewer?.trim() || "tui_operator";
       const resolution = createOperatorEffectReviewResolution({
@@ -1683,15 +1743,6 @@ export class AgenCDaemonAgentManager {
         evidenceSha256: params.evidenceSha256,
         reviewedAt,
       });
-      const candidates = [
-        {
-          sessionId: params.sessionId,
-          toolCallId: params.toolCallId,
-          toolName: "",
-          startedAt: "",
-        },
-      ];
-      const resolved: SessionResolveToolCallResult["resolved"][number][] = [];
       for (const effect of candidates) {
         const reviewOptions = {
           sessionId: params.sessionId,

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -120,6 +120,8 @@ import {
   type SessionAttachParams,
   type SessionAttachResult,
   type SessionCancelTurnParams,
+  type SessionResolveToolCallEvidenceParams,
+  type SessionResolveToolCallLegacyParams,
   type SessionResolveToolCallParams,
   type SessionClearParams,
   type SessionMcpAddServerParams,
@@ -2597,6 +2599,20 @@ function validateSessionResolveToolCallParams(
     ],
   });
   validateRequiredString(validated, "session.resolveToolCall", "sessionId");
+  const hasEvidenceFields = [
+    "disposition",
+    "evidenceRef",
+    "evidenceSha256",
+  ].some((field) => Object.prototype.hasOwnProperty.call(validated, field));
+  if (!hasEvidenceFields) {
+    if (validated.toolCallId !== undefined) {
+      validateRequiredString(validated, "session.resolveToolCall", "toolCallId");
+    }
+    if (validated.reviewer !== undefined) {
+      validateRequiredString(validated, "session.resolveToolCall", "reviewer");
+    }
+    return validated as SessionResolveToolCallLegacyParams;
+  }
   validateRequiredString(validated, "session.resolveToolCall", "toolCallId");
   validateRequiredString(validated, "session.resolveToolCall", "evidenceRef");
   validateRequiredString(
@@ -2619,7 +2635,7 @@ function validateSessionResolveToolCallParams(
       "session.resolveToolCall evidenceSha256 must be lowercase sha256",
     );
   }
-  return validated as SessionResolveToolCallParams;
+  return validated as SessionResolveToolCallEvidenceParams;
 }
 
 function validateSessionMcpAddServerParams(

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -1253,7 +1253,24 @@ export interface SessionClearParams extends JsonObject {
   readonly sessionId: string;
 }
 
-export interface SessionResolveToolCallParams extends JsonObject {
+/**
+ * Protocol-1.0 compatibility request shipped with agenc-sdk 0.3.0.
+ *
+ * This shape may resolve only legacy poisoned rows that have no canonical
+ * durable effect. Durable effect records always require explicit evidence.
+ */
+export interface SessionResolveToolCallLegacyParams extends JsonObject {
+  readonly sessionId: string;
+  /** When omitted, review every eligible legacy effect in the session. */
+  readonly toolCallId?: string;
+  readonly reviewer?: string;
+  readonly disposition?: never;
+  readonly evidenceRef?: never;
+  readonly evidenceSha256?: never;
+}
+
+/** Evidence-bearing resolution required for every durable effect record. */
+export interface SessionResolveToolCallEvidenceParams extends JsonObject {
   readonly sessionId: string;
   readonly toolCallId: string;
   readonly disposition:
@@ -1264,6 +1281,10 @@ export interface SessionResolveToolCallParams extends JsonObject {
   readonly evidenceSha256: string;
   readonly reviewer?: string;
 }
+
+export type SessionResolveToolCallParams =
+  | SessionResolveToolCallLegacyParams
+  | SessionResolveToolCallEvidenceParams;
 
 export interface SessionSnapshotParams extends JsonObject {
   readonly sessionId: string;

--- a/runtime/src/app-server/protocol/schema.json
+++ b/runtime/src/app-server/protocol/schema.json
@@ -773,7 +773,7 @@
         "sessionId"
       ]
     },
-    "SessionResolveToolCallParams": {
+    "SessionResolveToolCallLegacyParams": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -792,6 +792,57 @@
       },
       "required": [
         "sessionId"
+      ]
+    },
+    "SessionResolveToolCallEvidenceParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "toolCallId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "disposition": {
+          "type": "string",
+          "enum": [
+            "confirmed_committed",
+            "confirmed_no_effect",
+            "remains_unknown"
+          ]
+        },
+        "evidenceRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidenceSha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "reviewer": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "sessionId",
+        "toolCallId",
+        "disposition",
+        "evidenceRef",
+        "evidenceSha256"
+      ]
+    },
+    "SessionResolveToolCallParams": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/SessionResolveToolCallLegacyParams"
+        },
+        {
+          "$ref": "#/definitions/SessionResolveToolCallEvidenceParams"
+        }
       ]
     },
     "SessionMcpServerConfig": {
@@ -2200,6 +2251,9 @@
         },
         {
           "$ref": "#/definitions/SessionCancelTurnRequest"
+        },
+        {
+          "$ref": "#/definitions/SessionResolveToolCallRequest"
         },
         {
           "$ref": "#/definitions/SessionMcpAddServerRequest"

--- a/runtime/src/version.ts
+++ b/runtime/src/version.ts
@@ -7,4 +7,4 @@
  * @module
  */
 
-export const VERSION = "0.13.0";
+export const VERSION = "0.14.0";

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -11,6 +11,11 @@ import {
   openStateDatabases,
   type StateSqliteDriver,
 } from "../state/sqlite-driver.js";
+import { StateRunDurabilityRepository } from "../state/run-durability.js";
+import {
+  listUnresolvedUnknownOutcomeEffects,
+} from "../state/unknown-outcome-gate.js";
+import { recordInFlightToolCallUnknownOutcome } from "../state/tool-output-rotation.js";
 import {
   AgenCDaemonAgentLifecycleError,
   AgenCDaemonAgentManager,
@@ -3329,6 +3334,137 @@ describe("AgenC background agent lifecycle", () => {
       code: "BACKGROUND_RUNNER_UNAVAILABLE",
     });
     await expect(agents.listAgents()).resolves.toEqual({ agents: [] });
+  });
+
+  it("limits SDK 0.3.0 tool resolution to pure legacy poisoned rows", async () => {
+    const { cwd, home, restoreEnv } = createThreadStoreTestDirs();
+    const sessions = new AgenCDaemonSessionManager({
+      createSessionId: () => "session_legacy_review",
+      now: () => "2026-08-04T00:00:00.000Z",
+    });
+    let driver: StateSqliteDriver | undefined;
+    try {
+      await sessions.createSession({
+        cwd,
+        agentId: "agent_legacy_review",
+      });
+      const agents = new AgenCDaemonAgentManager({ sessionManager: sessions });
+      driver = openStateDatabases({ cwd });
+      const effects = new StateRunDurabilityRepository(driver);
+
+      const createDurableUnknown = (
+        runId: string,
+        callId: string,
+        effectFormatVersion: 1 | 2,
+      ): void => {
+        effects.ensureInitialEpoch({
+          runId,
+          openedAt: "2026-08-04T00:00:00.000Z",
+          openedEventId: `${runId}:opened`,
+        });
+        effects.beginEffect({
+          runId,
+          epoch: 1,
+          stepId: `${runId}:step`,
+          sessionId: "session_legacy_review",
+          callId,
+          toolName: "Write",
+          recoveryCategory: "side-effecting",
+          intentDigest: `${runId}:intent-digest`,
+          eventId: `${runId}:intent`,
+          eventSequence: 1,
+          intentAt: "2026-08-04T00:00:01.000Z",
+          effectFormatVersion,
+        });
+        effects.markEffectUnknown({
+          runId,
+          stepId: `${runId}:step`,
+          eventId: `${runId}:unknown`,
+          eventSequence: 2,
+          reason: "connection_lost_after_dispatch",
+          observedAt: "2026-08-04T00:00:02.000Z",
+        });
+        recordInFlightToolCallUnknownOutcome(driver!, {
+          sessionId: "session_legacy_review",
+          agentId: "agent_legacy_review",
+          toolCallId: callId,
+          toolName: "Write",
+          observedAt: "2026-08-04T00:00:02.000Z",
+          recoveryCategory: "side-effecting",
+        });
+      };
+
+      createDurableUnknown("run_v1", "call_v1", 1);
+      createDurableUnknown("run_v2", "call_v2", 2);
+      recordInFlightToolCallUnknownOutcome(driver, {
+        sessionId: "session_legacy_review",
+        agentId: "agent_legacy_review",
+        toolCallId: "call_pure_legacy",
+        toolName: "LegacyWrite",
+        observedAt: "2026-08-04T00:00:03.000Z",
+        recoveryCategory: "side-effecting",
+      });
+
+      await expect(
+        agents.resolveSessionToolCall({
+          sessionId: "session_legacy_review",
+          reviewer: "sdk-0.3.0",
+        }),
+      ).resolves.toEqual({
+        sessionId: "session_legacy_review",
+        resolved: [
+          {
+            toolCallId: "call_pure_legacy",
+            toolName: "LegacyWrite",
+          },
+        ],
+        remaining: 2,
+      });
+      expect(
+        effects.getEffect("run_v1", "run_v1:step"),
+      ).toMatchObject({
+        effectFormatVersion: 1,
+        reviewStatus: "pending",
+      });
+      expect(
+        effects.getEffect("run_v2", "run_v2:step"),
+      ).toMatchObject({
+        effectFormatVersion: 2,
+        reviewStatus: "pending",
+      });
+      expect(
+        effects.getEffect("run_v1", "run_v1:step")?.review,
+      ).toBeUndefined();
+      expect(
+        effects.getEffect("run_v2", "run_v2:step")?.review,
+      ).toBeUndefined();
+      expect(
+        listUnresolvedUnknownOutcomeEffects(
+          driver,
+          "session_legacy_review",
+        ).map((effect) => effect.toolCallId),
+      ).toEqual(["call_v1", "call_v2"]);
+
+      await expect(
+        agents.resolveSessionToolCall({
+          sessionId: "session_legacy_review",
+          toolCallId: "call_v2",
+          reviewer: "sdk-0.3.0",
+        }),
+      ).resolves.toEqual({
+        sessionId: "session_legacy_review",
+        resolved: [],
+        remaining: 2,
+      });
+      expect(
+        effects.getEffect("run_v2", "run_v2:step"),
+      ).toMatchObject({ reviewStatus: "pending" });
+    } finally {
+      driver?.close();
+      restoreEnv();
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("stops a launched agent when lifecycle session creation fails", async () => {

--- a/runtime/tests/app-server/daemon-dispatcher.session-control.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.session-control.contract.test.ts
@@ -20,6 +20,92 @@ async function initialize(connection: {
 }
 
 describe("daemon session-control internal method dispatch", () => {
+  it("routes the exact SDK 0.3.0 tool-resolution shape and rejects partial hybrids", async () => {
+    const resolveSessionToolCall = vi.fn(async () => ({
+      sessionId: "session_1",
+      resolved: [],
+      remaining: 0,
+    }));
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: { resolveSessionToolCall } as never,
+    });
+    const connection = dispatcher.createConnection();
+    await initialize(connection);
+
+    await expect(
+      connection.dispatch({
+        jsonrpc: JSON_RPC_VERSION,
+        id: "legacy",
+        method: "session.resolveToolCall",
+        params: {
+          sessionId: "session_1",
+          toolCallId: "call_legacy",
+          reviewer: "sdk-0.3.0",
+        },
+      }),
+    ).resolves.toMatchObject({ result: { sessionId: "session_1" } });
+    expect(resolveSessionToolCall).toHaveBeenLastCalledWith({
+      sessionId: "session_1",
+      toolCallId: "call_legacy",
+      reviewer: "sdk-0.3.0",
+    });
+
+    await expect(
+      connection.dispatch({
+        jsonrpc: JSON_RPC_VERSION,
+        id: "evidence",
+        method: "session.resolveToolCall",
+        params: {
+          sessionId: "session_1",
+          toolCallId: "call_v2",
+          disposition: "confirmed_no_effect",
+          evidenceRef: "ticket:INC-14",
+          evidenceSha256: "a".repeat(64),
+          reviewer: "operator",
+        },
+      }),
+    ).resolves.toMatchObject({ result: { sessionId: "session_1" } });
+    expect(resolveSessionToolCall).toHaveBeenLastCalledWith({
+      sessionId: "session_1",
+      toolCallId: "call_v2",
+      disposition: "confirmed_no_effect",
+      evidenceRef: "ticket:INC-14",
+      evidenceSha256: "a".repeat(64),
+      reviewer: "operator",
+    });
+
+    await expect(
+      connection.dispatch({
+        jsonrpc: JSON_RPC_VERSION,
+        id: "partial-hybrid",
+        method: "session.resolveToolCall",
+        params: {
+          sessionId: "session_1",
+          toolCallId: "call_v2",
+          disposition: "confirmed_no_effect",
+        },
+      }),
+    ).resolves.toMatchObject({ error: { code: -32602 } });
+
+    for (const [id, field] of [
+      ["empty-tool-call", "toolCallId"],
+      ["empty-reviewer", "reviewer"],
+    ] as const) {
+      await expect(
+        connection.dispatch({
+          jsonrpc: JSON_RPC_VERSION,
+          id,
+          method: "session.resolveToolCall",
+          params: {
+            sessionId: "session_1",
+            [field]: "",
+          },
+        }),
+      ).resolves.toMatchObject({ error: { code: -32602 } });
+    }
+    expect(resolveSessionToolCall).toHaveBeenCalledTimes(2);
+  });
+
   it("routes both compaction operator methods", async () => {
     const rollbackCompaction = vi.fn(async () => ({
       sessionId: "session_1",

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -128,6 +128,8 @@ const expectedInternalMethods = [
   "workspace.editor.cancelPrediction",
   "workspace.editor.predictionFeedback",
   "session.partialCompactFromMessage",
+  "session.rollbackCompaction",
+  "session.extendCompactionRollbackRetention",
   "session.rewindConversationToMessage",
   "session.previewFileRewind",
   "session.rewindFilesToMessage",
@@ -261,6 +263,49 @@ describe("AgenC daemon protocol surface", () => {
     // External installed/sibling protocol copies are release artifacts, not
     // build inputs for agenc-core. Exact method drift remains pinned above
     // against this repository's canonical TypeScript registry and schema.
+  });
+
+  it("keeps the published protocol-1.0 tool-resolution request compatible", () => {
+    const validate = compileRequestValidator(readProtocolSchema());
+    const request = (id: string, params: Record<string, unknown>) => ({
+      jsonrpc: JSON_RPC_VERSION,
+      id,
+      method: "session.resolveToolCall",
+      params,
+    });
+
+    expect(
+      validate(
+        request("legacy", {
+          sessionId: "session_1",
+          toolCallId: "call_legacy",
+          reviewer: "sdk-0.3.0",
+        }),
+      ),
+      JSON.stringify(validate.errors),
+    ).toBe(true);
+    expect(
+      validate(
+        request("evidence", {
+          sessionId: "session_1",
+          toolCallId: "call_v2",
+          disposition: "confirmed_no_effect",
+          evidenceRef: "ticket:INC-14",
+          evidenceSha256: "a".repeat(64),
+          reviewer: "operator",
+        }),
+      ),
+      JSON.stringify(validate.errors),
+    ).toBe(true);
+    expect(
+      validate(
+        request("partial-hybrid", {
+          sessionId: "session_1",
+          toolCallId: "call_v2",
+          disposition: "confirmed_no_effect",
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("validates all request-bearing methods through the published schema", () => {

--- a/runtime/tests/sdk-package/protocol-drift.contract.test.ts
+++ b/runtime/tests/sdk-package/protocol-drift.contract.test.ts
@@ -13,15 +13,26 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  AGENC_DAEMON_PROTOCOL_VERSION,
   AGENC_DAEMON_METHODS,
   AGENC_DAEMON_NOTIFICATION_METHODS,
 } from "../../src/app-server/protocol/index.js";
 import { resolveAgenCDaemonSocketPath } from "../../src/app-server/daemon-cli.js";
 import {
+  AGENC_SDK_DAEMON_PROTOCOL_VERSION,
   AGENC_SDK_DAEMON_METHODS,
   AGENC_SDK_DAEMON_NOTIFICATION_METHODS,
+  type AgencParamsByMethod,
 } from "../../../packages/agenc-sdk/src/protocol";
 import { resolveDaemonSocketPath } from "../../../packages/agenc-sdk/src/socket";
+
+// @ts-expect-error A partial evidence request must not match the legacy branch.
+const invalidPartialToolResolution: AgencParamsByMethod["session.resolveToolCall"] = {
+  sessionId: "session_legacy",
+  toolCallId: "call_partial",
+  disposition: "confirmed_no_effect",
+};
+void invalidPartialToolResolution;
 
 const packageProtocolPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -34,6 +45,27 @@ describe("agenc-sdk protocol mirror", () => {
     expect([...AGENC_SDK_DAEMON_NOTIFICATION_METHODS]).toEqual([
       ...AGENC_DAEMON_NOTIFICATION_METHODS,
     ]);
+  });
+
+  it("retains the SDK 0.3.0 tool-resolution request shape", () => {
+    const resolveAllLegacy = {
+      sessionId: "session_legacy",
+      reviewer: "sdk-0.3.0",
+    } satisfies AgencParamsByMethod["session.resolveToolCall"];
+    const resolveOneLegacy = {
+      sessionId: "session_legacy",
+      toolCallId: "call_legacy",
+      reviewer: "sdk-0.3.0",
+    } satisfies AgencParamsByMethod["session.resolveToolCall"];
+
+    expect(AGENC_SDK_DAEMON_PROTOCOL_VERSION).toBe(
+      AGENC_DAEMON_PROTOCOL_VERSION,
+    );
+    expect(resolveAllLegacy).toEqual({
+      sessionId: "session_legacy",
+      reviewer: "sdk-0.3.0",
+    });
+    expect(resolveOneLegacy.toolCallId).toBe("call_legacy");
   });
 
   it("declares params and result mappings for every daemon method", () => {


### PR DESCRIPTION
## Summary

- synchronize the core runtime and launcher identity at 0.14.0 while leaving the SDK at 0.3.0
- preserve legacy SDK tool-call resolution only for legacy in-flight records; durable effects still require disposition and evidence
- stage the 0.14 landing page and unpublishable Homebrew formula template
- rebind the existing benchmark artifact evidence without changing its measurements, retaining a squash-safe ancestor source revision

## Why this is separate

This foundation must merge before the final release-evidence PR. The follow-up will regenerate benchmark measurements against this squash-merged main SHA so provenance remains valid after its own squash merge.

## Validation

- npm test: 2,008 files, 18,655 tests passed
- runtime and SDK typecheck: passed
- focused protocol/version/FND tests: passed
- npm run test:bun: 95 files passed
- build and TUI PTY startup smoke: passed via commit hooks
- release preflight: 0.14.0 absent from all four immutable namespaces
- independent exact-SHA review: approved c3b644bfb02232c8e0684267db9df111acfdd279
