### PR TITLE
fix(release): pin refreshed Rocky inventories

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -567,6 +567,7 @@ jobs:
             libgcc-8.5.0-28.el8_10 \
             gcc-toolset-12-gcc-c++-12.2.1-7.8.el8_10 \
             gcc-toolset-12-binutils-2.38-17.el8 \
+            kernel-headers-4.18.0-553.150.1.el8_10 \
             python3.12-3.12.13-2.el8_10 \
             make-4.2.1-11.el8 \
             git-2.43.7-1.el8_10 \
@@ -652,6 +653,9 @@ jobs:
           inventory_sha = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
           expected_sha = contract["sha256"][architecture]
           if inventory_sha != expected_sha:
+              print("::group::observed signed RPM content inventory")
+              print(canonical, end="")
+              print("::endgroup::")
               raise SystemExit(
                   f"signed RPM content inventory drift for {architecture}: {inventory_sha} != {expected_sha}"
               )

--- a/release-toolchain.json
+++ b/release-toolchain.json
@@ -287,6 +287,7 @@
       "libgcc": "libgcc-8.5.0-28.el8_10",
       "gcc-toolset-12-gcc-c++": "gcc-toolset-12-gcc-c++-12.2.1-7.8.el8_10",
       "gcc-toolset-12-binutils": "gcc-toolset-12-binutils-2.38-17.el8",
+      "kernel-headers": "kernel-headers-4.18.0-553.150.1.el8_10",
       "python3.12": "python3.12-3.12.13-2.el8_10",
       "make": "make-4.2.1-11.el8",
       "git": "git-2.43.7-1.el8_10",
@@ -298,8 +299,8 @@
       "format": "name|epoch|version|release|arch|sha256header|payloaddigest|payloaddigestalgo|rsaheader-pgpsig",
       "signatureKeyIds": ["15af5dac6d745a60"],
       "sha256": {
-        "x64": "a20edbdbf94e00d0e93ce30f04167861f67b3132f388f06d2c5bb44894b6e613",
-        "arm64": "530821a9904c1d9162750d564d89e7556575df1cbec0a54bd5029076dc58731d"
+        "x64": "20da0fd525fe8dbe596068bb896b949fe84c5ede3c2829e9481f6c2c97de0a5e",
+        "arm64": "98d1259fca66152fb91e739a15a4fa7f76b0a222369cb34ba853d7d72f02239f"
       }
     },
     "compilerVersion": "12.2.1",

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -633,12 +633,14 @@ describe("reproducible install and release contract", () => {
     expect(workflow).toContain("libatomic-8.5.0-28.el8_10");
     expect(workflow).toContain("libgcc-8.5.0-28.el8_10");
     expect(workflow).toContain("gcc-toolset-12-gcc-c++-12.2.1-7.8.el8_10");
+    expect(workflow).toContain("kernel-headers-4.18.0-553.150.1.el8_10");
     expect(workflow).toContain("python3.12-3.12.13-2.el8_10");
     expect(workflow).toContain('["rpmContentInventory"]');
     expect(workflow).toContain("%{SHA256HEADER}");
     expect(workflow).toContain("%{PAYLOADDIGEST}");
     expect(workflow).toContain("%{RSAHEADER:pgpsig}");
     expect(workflow).toContain("signed RPM content inventory drift");
+    expect(workflow).toContain("observed signed RPM content inventory");
     expect(workflow).toContain("rpm-content-sha256:");
     expect(workflow).toContain("verify-reproducible-artifacts.mjs");
     expect(workflow).toContain("AGENC_BUILDER_ID=");
@@ -1050,6 +1052,9 @@ describe("reproducible install and release contract", () => {
     expect(nativeContract.linux.builderPackages.libgcc).toBe(
       "libgcc-8.5.0-28.el8_10",
     );
+    expect(nativeContract.linux.builderPackages["kernel-headers"]).toBe(
+      "kernel-headers-4.18.0-553.150.1.el8_10",
+    );
     expect(nativeContract.nodeBootstrap).toMatchObject({
       schemaVersion: 1,
       minimumRuntimeVersion: "0.11.2",
@@ -1138,9 +1143,9 @@ describe("reproducible install and release contract", () => {
         "name|epoch|version|release|arch|sha256header|payloaddigest|payloaddigestalgo|rsaheader-pgpsig",
       signatureKeyIds: ["15af5dac6d745a60"],
       sha256: {
-        x64: "a20edbdbf94e00d0e93ce30f04167861f67b3132f388f06d2c5bb44894b6e613",
+        x64: "20da0fd525fe8dbe596068bb896b949fe84c5ede3c2829e9481f6c2c97de0a5e",
         arm64:
-          "530821a9904c1d9162750d564d89e7556575df1cbec0a54bd5029076dc58731d",
+          "98d1259fca66152fb91e739a15a4fa7f76b0a222369cb34ba853d7d72f02239f",
       },
     });
   });


### PR DESCRIPTION
## Summary

- pin `kernel-headers-4.18.0-553.150.1.el8_10` as an explicit Rocky release-build input
- reseal the authenticated x64 and arm64 RPM inventory digests
- print the complete already-authenticated RPM inventory when a future aggregate mismatch occurs, while remaining fail-closed

## Failure and recovery evidence

Candidate run [30955613061](https://github.com/tetsuo-ai/agenc-core/actions/runs/30955613061) was exact-main attempt 1 and is intentionally not retried. Both Linux jobs stopped before compilation at the signed RPM inventory boundary:

- x64 observed `20da0fd525fe8dbe596068bb896b949fe84c5ede3c2829e9481f6c2c97de0a5e`
- arm64 observed `98d1259fca66152fb91e739a15a4fa7f76b0a222369cb34ba853d7d72f02239f`

Compared with the successful 0.13 candidate, all 105 transaction NEVRAs match except `kernel-headers`, which advanced from `.148.1` to `.150.1` on both architectures. Every package still passed SHA-256 header/payload and Rocky signer validation before the mismatch.

The dispatch-only diagnostic [job 92150977395](https://github.com/tetsuo-ai/agenc-core/actions/runs/30956583530/job/92150977395) independently captured all 244 arm64 RPM identities and reproduced the arm64 digest exactly.

## Validation

- independent exact-SHA review of `91fcb41e5909508ae04c03a8f16f96f20591b476`: approved, no findings
- focused release packaging contract: 15/15
- launcher/manifest/release tests: 59/59
- typecheck: 0 errors
- full Vitest: 2,008 files / 18,655 tests
- build: passed
- TUI PTY startup: all viewports passed
- x64 pinned Rocky container reproduction: exact expected digest

After squash merge, the release verifier, both Rocky bootstrap jobs, and a fresh attempt-1 candidate will run against the new exact main SHA. No release tag exists.