### PR TITLE
fix: 0.13 to 0.14 upgrade bricked the daemon; silent TUI failures

### DIFF
--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -18,6 +18,7 @@ import {
 } from "./daemon-autostart.js";
 import {
   createNodeDaemonCliHost,
+  readAgenCDaemonSpawnStderrTail,
   resolveAgenCDaemonCookiePath,
   resolveAgenCDaemonSocketPath,
 } from "./daemon-cli.js";
@@ -656,10 +657,9 @@ async function createReconnectableDaemonTuiClient(options: {
           );
         }
       }
-      const error =
-        lastError instanceof Error
-          ? lastError
-          : new Error(String(lastError ?? "Daemon connection is closed"));
+      const error = withDaemonStartupLogContext(
+        lastError ?? new Error("Daemon connection is closed"),
+      );
       setConnectionState({ status: "disconnected", message: error.message });
       throw error;
     };
@@ -1471,7 +1471,46 @@ function resolveAgenCDaemonRequestTimeoutMs(
   return timeoutMs;
 }
 
+/**
+ * A raw "connect ECONNREFUSED <sock>" tells the operator nothing about WHY
+ * the daemon is not listening. The daemon's spawn stderr usually does
+ * (startup recovery failures land there), so attach its tail to any
+ * connection-shaped failure surfaced to callers.
+ */
+function withDaemonStartupLogContext(error: unknown): Error {
+  const base = error instanceof Error ? error : new Error(String(error));
+  if (!/ECONNREFUSED|ENOENT/.test(base.message)) return base;
+  if (base.message.includes("daemon startup log:")) return base;
+  const stderrTail = readAgenCDaemonSpawnStderrTail();
+  if (stderrTail.length === 0) return base;
+  return new Error(`${base.message} (daemon startup log: ${stderrTail})`, {
+    cause: base,
+  });
+}
+
 async function requestDaemon<Method extends AgenCDaemonMethod>(
+  method: Method,
+  params: JsonObject,
+  socketPath: string,
+  timeoutMs: number,
+  authCookie: string | Promise<string>,
+  signal?: AbortSignal,
+): Promise<AgenCDaemonResultByMethod[Method]> {
+  try {
+    return await requestDaemonInner(
+      method,
+      params,
+      socketPath,
+      timeoutMs,
+      authCookie,
+      signal,
+    );
+  } catch (error) {
+    throw withDaemonStartupLogContext(error);
+  }
+}
+
+async function requestDaemonInner<Method extends AgenCDaemonMethod>(
   method: Method,
   params: JsonObject,
   socketPath: string,

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -1451,6 +1451,15 @@ async function runAgenCDaemonForeground(
           `expired=${recovery.expired} detached=${recovery.detachedQueued}\n`,
       );
     }
+    // A failed project is excluded from admission, not fatal: the daemon
+    // must keep serving every other project (a legacy or damaged journal
+    // in one old workspace used to brick startup globally).
+    for (const failure of recovery.failures) {
+      io.stderr.write(
+        `agenc: execution admission recovery excluded ${failure.projectDir} ` +
+          `(${failure.stateDbPath}): ${failure.message}\n`,
+      );
+    }
   } catch (error) {
     io.stderr.write(
       `agenc: execution admission recovery failed: ${formatCleanupError(error)}\n`,

--- a/runtime/src/budget/execution-admission-kernel.ts
+++ b/runtime/src/budget/execution-admission-kernel.ts
@@ -136,6 +136,14 @@ export interface ExecutionAdmissionRecoverySummary {
   readonly heldUnknown: number;
   readonly expired: number;
   readonly detachedQueued: number;
+  /** Project databases whose recovery failed and was excluded from startup. */
+  readonly failures: readonly ExecutionAdmissionRecoveryFailure[];
+}
+
+export interface ExecutionAdmissionRecoveryFailure {
+  readonly projectDir: string;
+  readonly stateDbPath: string;
+  readonly message: string;
 }
 
 export interface ExecutionAdmissionCancellationSummary {
@@ -203,7 +211,15 @@ export class ExecutionAdmissionKernel {
     return this.#pending.size;
   }
 
-  /** Open and recover every existing project DB before daemon readiness. */
+  /**
+   * Open and recover every existing project DB before daemon readiness.
+   *
+   * A project whose recovery fails is excluded (unregistered and reported in
+   * `failures`) instead of aborting daemon startup: one damaged or legacy
+   * journal must not prevent the daemon from serving every other project.
+   * The excluded workspace is never served partially recovered — its next
+   * bind re-runs recovery and surfaces the same failure to that caller.
+   */
   initializeExistingState(): ExecutionAdmissionRecoverySummary {
     this.#assertOpen();
     const totals = {
@@ -213,25 +229,36 @@ export class ExecutionAdmissionKernel {
       expired: 0,
       detachedQueued: 0,
     };
+    const failures: ExecutionAdmissionRecoveryFailure[] = [];
     for (const paths of discoverStateDatabasePaths(this.#agencHome)) {
-      const binding = this.#registerPaths(paths, paths.projectDir, false);
-      const report = binding.repository.recover({
-        now: this.#timestamp(),
-        activeOwnerIds: new Set(),
-      });
-      totals.databases += 1;
-      totals.requeued += report.requeuedJobIds.length;
-      totals.heldUnknown += report.heldUnknownReservationIds.length;
-      totals.expired += report.cancelledExpiredJobIds.length;
-      totals.detachedQueued += report.detachedQueuedJobIds.length;
-      recoverExecutionAdmissionCanonicalJournals(
-        binding.driver,
-        binding.repository,
-      );
-      this.#hydrateQueued(binding);
-      this.#publishNewJournal(binding);
+      try {
+        const binding = this.#registerPaths(paths, paths.projectDir, false);
+        const report = binding.repository.recover({
+          now: this.#timestamp(),
+          activeOwnerIds: new Set(),
+        });
+        recoverExecutionAdmissionCanonicalJournals(
+          binding.driver,
+          binding.repository,
+        );
+        this.#hydrateQueued(binding);
+        this.#publishNewJournal(binding);
+        totals.databases += 1;
+        totals.requeued += report.requeuedJobIds.length;
+        totals.heldUnknown += report.heldUnknownReservationIds.length;
+        totals.expired += report.cancelledExpiredJobIds.length;
+        totals.detachedQueued += report.detachedQueuedJobIds.length;
+      } catch (error) {
+        const binding = this.#byStatePath.get(paths.stateDbPath);
+        if (binding !== undefined) this.#unregisterBinding(binding);
+        failures.push({
+          projectDir: paths.projectDir,
+          stateDbPath: paths.stateDbPath,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
-    return totals;
+    return { ...totals, failures };
   }
 
   bindClient(
@@ -853,6 +880,25 @@ export class ExecutionAdmissionKernel {
       this.#publishNewJournal(binding);
     }
     return binding;
+  }
+
+  #unregisterBinding(binding: WorkspaceBinding): void {
+    this.#byStatePath.delete(binding.paths.stateDbPath);
+    for (const alias of binding.aliases) {
+      if (this.#byWorkspace.get(alias) === binding) {
+        this.#byWorkspace.delete(alias);
+      }
+    }
+    for (const [runId, statePath] of this.#runStatePath) {
+      if (statePath === binding.paths.stateDbPath) {
+        this.#runStatePath.delete(runId);
+      }
+    }
+    try {
+      binding.driver.close();
+    } catch {
+      // The driver may already be unusable; exclusion must still complete.
+    }
   }
 
   #bindRunWorkspace(runId: string, binding: WorkspaceBinding): void {

--- a/runtime/src/state/recovery-journal-contract.ts
+++ b/runtime/src/state/recovery-journal-contract.ts
@@ -852,14 +852,19 @@ export class StrictCanonicalJournalValidator {
         );
       }
     }
+    // I-49: only rollouts NEWER than this runtime are unreadable. Legacy
+    // v1 sessions (0.13 and earlier) must stay recoverable — session-store
+    // accepts them and upgrades in place, so recovery must not refuse them.
     if (
       !Number.isSafeInteger(payload.rolloutSchemaVersion) ||
-      (payload.rolloutSchemaVersion as number) < 2 ||
+      (payload.rolloutSchemaVersion as number) < 1 ||
       (payload.rolloutSchemaVersion as number) > ROLLOUT_SCHEMA_VERSION
     ) {
       this.#fail(
         "unsupported_format_version",
-        "canonical rollout schema version is not supported by this runtime",
+        `canonical rollout schema version ${String(
+          payload.rolloutSchemaVersion,
+        )} is not supported by this runtime (supported: 1..${ROLLOUT_SCHEMA_VERSION})`,
         facts,
       );
     }

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -5306,6 +5306,13 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
                 ? err_slash_prompt.message
                 : String(err_slash_prompt);
             showTransientResult(message_slash_prompt, { display: "error" });
+            addNotification({
+              key: "prompt-submit-failed",
+              text: `Message not sent: ${message_slash_prompt}`,
+              color: "error",
+              priority: "immediate",
+              timeoutMs: 10_000,
+            });
             setPendingSubmission(false);
             const rolledBack =
               admissionToken !== null &&
@@ -5527,6 +5534,13 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
             showTransientResult(message_0, {
               display: "error",
             });
+            addNotification({
+              key: "prompt-submit-failed",
+              text: `Message not sent: ${message_0}`,
+              color: "error",
+              priority: "immediate",
+              timeoutMs: 10_000,
+            });
             setPendingSubmission(false);
             const rolledBack =
               admissionToken !== null &&
@@ -5618,6 +5632,17 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         showTransientResult(message_0, {
           display: "error",
         });
+        // The transient box auto-clears after 3s and is skipped entirely
+        // while a local-JSX overlay is pinned, so a failed submit used to
+        // look like the composer silently ate the prompt. The footer
+        // notification lane renders regardless of overlays.
+        addNotification({
+          key: "prompt-submit-failed",
+          text: `Message not sent: ${message_0}`,
+          color: "error",
+          priority: "immediate",
+          timeoutMs: 10_000,
+        });
         // Submit threw before turn_started arrived — clear the
         // pending-submission spinner so the UI doesn't lie about
         // waiting for a turn that will never start.
@@ -5642,6 +5667,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       appStateStore,
       setToolJSX,
       showTransientResult,
+      addNotification,
       commandRegistry,
       submitToSession,
       workbenchEnabled,

--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "../ink.js";
 import { stringWidth } from "../ink/stringWidth.js";
 import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { useShortcutDisplay } from "../keybindings/useShortcutDisplay.js";
+import { useAppState } from "../state/AppState.js";
 import { useWorkbenchState } from "./state.js";
 import { useBufferStore } from "./buffer/useBufferStore.js";
 
@@ -73,6 +74,15 @@ export function WorkbenchFooter(): React.ReactElement {
     "Global",
     "ctrl+o",
   );
+  // The workbench frame clips the classic footer notification lane (its
+  // bottom-anchored layout drops rows from the top), which made failed
+  // submits look silently swallowed. Surface the current notification in
+  // the always-visible hint row instead.
+  const currentNotification = useAppState((s) => s.notifications.current);
+  const footerNotification =
+    currentNotification !== null && "text" in currentNotification
+      ? currentNotification
+      : null;
   const bufferOwnsKeys =
     workbench.activeSurfaceMode === "buffer" &&
     workbench.focusedPane === "surface";
@@ -104,9 +114,15 @@ export function WorkbenchFooter(): React.ReactElement {
       borderTop
       borderTopColor="lineSoft"
     >
-      <Text color="inactive" wrap="truncate-end">
-        {fitFooterHints(hints, Math.max(1, columns - 6))}
-      </Text>
+      {footerNotification !== null ? (
+        <Text color={footerNotification.color ?? "text"} wrap="truncate-end">
+          {footerNotification.text}
+        </Text>
+      ) : (
+        <Text color="inactive" wrap="truncate-end">
+          {fitFooterHints(hints, Math.max(1, columns - 6))}
+        </Text>
+      )}
     </Box>
   );
 }

--- a/runtime/tests/budget/execution-admission-kernel.test.ts
+++ b/runtime/tests/budget/execution-admission-kernel.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,8 +8,13 @@ import type { AdmissionLease } from "../../src/budget/admission-types.js";
 import type { ExecutionAdmissionClient } from "../../src/budget/admission-client.js";
 import { ExecutionAdmissionKernel } from "../../src/budget/execution-admission-kernel.js";
 import { upsertAgentRun } from "../../src/state/agent-runs.js";
+import { ExecutionAdmissionRepository } from "../../src/state/execution-admission.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
 import { ThreadSpawnEdgeRepository } from "../../src/state/spawn-edges.js";
-import { openStateDatabases } from "../../src/state/sqlite-driver.js";
+import {
+  STATE_DATABASE_FILENAME,
+  openStateDatabases,
+} from "../../src/state/sqlite-driver.js";
 
 const LIMITS = {
   global: 1,
@@ -328,6 +333,107 @@ describe("ExecutionAdmissionKernel recovery", () => {
       outputTokens: 0,
       costUsd: 0,
     });
+  });
+
+  it("excludes a project with an unreadable state database instead of aborting startup", async () => {
+    await leaveDetachedQueue("healthy-run");
+    const poisonedDir = join(home, "projects", "poisoned-project");
+    mkdirSync(poisonedDir, { recursive: true });
+    writeFileSync(
+      join(poisonedDir, STATE_DATABASE_FILENAME),
+      "this is not a sqlite database\n",
+    );
+
+    const after = kernel("poisoned-db-restart");
+    const recovery = after.initializeExistingState();
+
+    expect(recovery).toMatchObject({ databases: 1, detachedQueued: 1 });
+    expect(recovery.failures).toHaveLength(1);
+    expect(recovery.failures[0]?.projectDir).toBe(poisonedDir);
+    expect(recovery.failures[0]?.message.length).toBeGreaterThan(0);
+
+    const client = bind(after, "healthy-run");
+    const lease = await acquire(client);
+    expect(lease.request.step.runId).toBe("healthy-run");
+    client.reconcile(lease.reservation.reservationId, {
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+  });
+
+  it("excludes a project whose canonical journal is damaged instead of aborting startup", async () => {
+    await leaveDetachedQueue("healthy-run");
+
+    // A second project whose SQLite state is valid but whose bound rollout
+    // journal is garbage: the exact shape that used to brick daemon startup.
+    const poisonedCwd = mkdtempSync(join(tmpdir(), "agenc-kernel-poisoned-"));
+    try {
+      mkdirSync(join(poisonedCwd, ".git"));
+      const poisonedDriver = openStateDatabases({
+        cwd: poisonedCwd,
+        agencHome: home,
+      });
+      const poisonedRunId = "poisoned-journal-run";
+      const admissions = new ExecutionAdmissionRepository(poisonedDriver, {
+        now: () => new Date("2026-08-03T00:00:00.000Z"),
+        id: () => "poisoned-admission-id",
+        ownerId: "crashed-daemon",
+        ownerPid: process.pid,
+      });
+      admissions.enqueue({
+        step: { runId: poisonedRunId, stepId: "step-1" },
+        kind: "model_turn",
+        estimate: { maxInputTokens: 1, maxOutputTokens: 1, maxCostUsd: 0 },
+        model: "test-model",
+        provider: "test-provider",
+        workspaceId: "poisoned-workspace",
+        sessionId: poisonedRunId,
+        parentScopeId: poisonedRunId,
+        autonomous: false,
+      });
+      const sessionsDir = join(
+        poisonedDriver.projectDir,
+        "sessions",
+        poisonedRunId,
+      );
+      mkdirSync(sessionsDir, { recursive: true });
+      const sourcePath = join(sessionsDir, `rollout-${poisonedRunId}.jsonl`);
+      writeFileSync(sourcePath, "{malformed json\n", { mode: 0o600 });
+      const durability = new StateRunDurabilityRepository(poisonedDriver);
+      durability.ensureInitialEpoch({
+        runId: poisonedRunId,
+        openedAt: "2026-08-03T00:00:00.000Z",
+      });
+      durability.bindJournalSource({
+        runId: poisonedRunId,
+        epoch: 1,
+        childRunId: poisonedRunId,
+        sessionId: poisonedRunId,
+        sourcePath,
+        boundAt: "2026-08-03T00:00:00.000Z",
+      });
+      const poisonedProjectDir = poisonedDriver.projectDir;
+      poisonedDriver.close();
+
+      const after = kernel("poisoned-journal-restart");
+      const recovery = after.initializeExistingState();
+
+      expect(recovery).toMatchObject({ databases: 1, detachedQueued: 1 });
+      expect(recovery.failures).toHaveLength(1);
+      expect(recovery.failures[0]?.projectDir).toBe(poisonedProjectDir);
+
+      const client = bind(after, "healthy-run");
+      const lease = await acquire(client);
+      expect(lease.request.step.runId).toBe("healthy-run");
+      client.reconcile(lease.reservation.reservationId, {
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+      });
+    } finally {
+      rmSync(poisonedCwd, { recursive: true, force: true });
+    }
   });
 
   it("hydrates a detached queue before the first client binds", async () => {

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { openFndFixtureCatalog } from "../helpers/fnd-fixtures.js";
-import { KNOWN_EVENT_TYPES } from "../../src/session/event-log.js";
+import {
+  KNOWN_EVENT_TYPES,
+  ROLLOUT_SCHEMA_VERSION,
+} from "../../src/session/event-log.js";
 import { backfillPinnedRolloutContent } from "./backfill.js";
 import { CanonicalJournalIntegrityError } from "./recovery-contract.js";
 import {
@@ -74,6 +77,29 @@ describe("strict canonical journal contract", () => {
       );
     },
   );
+
+  it("accepts a legacy v1 rollout written by a 0.13 runtime", () => {
+    // Exact session_meta shape 0.13.0 wrote on disk. Rejecting it bricked
+    // daemon startup for every upgrader; only NEWER versions are unreadable.
+    const journal = validateCanonicalJournalText(
+      `${legacySessionMeta(1)}${validEvent(1, "turn_started")}`,
+    );
+    expect(journal.recordCount).toBe(2);
+    expect(journal.records[0]?.item.type).toBe("session_meta");
+  });
+
+  it("rejects a rollout schema version newer than this runtime", () => {
+    expect(() =>
+      validateCanonicalJournalText(
+        `${legacySessionMeta(ROLLOUT_SCHEMA_VERSION + 1)}${validEvent(
+          1,
+          "turn_started",
+        )}`,
+      ),
+    ).toThrow(
+      expect.objectContaining({ reasonCode: "unsupported_format_version" }),
+    );
+  });
 
   it("retains exact byte facts across CRLF and chunk boundaries", () => {
     const first = validEvent(1, "turn_started").trimEnd();
@@ -501,6 +527,23 @@ describe("strict pinned rollout projection", () => {
     }
   });
 });
+
+function legacySessionMeta(rolloutSchemaVersion: number): string {
+  return `${JSON.stringify({
+    type: "session_meta",
+    payload: {
+      sessionId: "conv-legacy013",
+      timestamp: "2026-08-03T06:47:50.000Z",
+      cwd: "/home/user/project",
+      originator: "agenc-cli",
+      agencVersion: "0.13.0",
+      model: "grok-4.5",
+      modelProvider: "grok",
+      rolloutSchemaVersion,
+    },
+    eventVersion: 1,
+  })}\n`;
+}
 
 function validEvent(
   sequence: number,


### PR DESCRIPTION
Upgrading from 0.13 to 0.14 left the daemon unable to start on any machine with pre-0.14 sessions, and the TUI silently swallowed every prompt while it happened.

Root cause chain, all verified live:

1. 0.13 wrote session rollouts with rolloutSchemaVersion 1. The 0.14 strict recovery contract rejected anything below 2, contradicting the documented I-49 policy (only rollouts newer than the runtime are unreadable) and the session-store open path, which accepts v1 and upgrades in place.
2. ExecutionAdmissionKernel.initializeExistingState walks every project DB under ~/.agenc, and one failing journal threw all the way out.
3. daemon-cli treated any admission recovery error as fatal, so the daemon exited before binding its socket. One legacy session in one old project bricked the daemon for every project.
4. The TUI rendered a healthy workbench anyway, and a failed submit only flashed a 3-second transient box that the workbench frame usually clips, then restored the composer draft. Headless -p printed a bare "connect ECONNREFUSED".

Fixes:

- recovery-journal-contract accepts rolloutSchemaVersion 1 again and reports the found version and supported range on rejection.
- initializeExistingState excludes a failing project (unregistered, reported in a new failures field) instead of throwing; daemon-cli logs each exclusion with project dir, DB path, and reason, and keeps starting. The excluded workspace is never served partially recovered: its next bind re-runs recovery and surfaces the same failure to that caller.
- Every submit catch posts a durable "Message not sent" error notification; WorkbenchFooter renders the current notification in the always-visible hint row (the workbench frame clips the classic notification lane); agent-cli attaches the daemon spawn-stderr tail to connection-shaped failures in both daemon clients.

Verification:

- 3 new revert-sensitive tests (v1 acceptance, two poisoned-project exclusion tests); each goes red with its fix reverted.
- Full state, budget, tui, and app-server suites green (5309 tests). tsc clean.
- Live A/B on a copy of a real ~/.agenc containing ten v1 rollouts: installed 0.14.0 reproduces the fatal startup error; this branch boots to "daemon running".
- Live tmux: submit against a dead socket now shows "Message not sent: connect ECONNREFUSED ... (daemon startup log: agenc: execution admission recovery failed: ...)" in the footer; headless -p prints the same enriched reason.

https://claude.ai/code/session_01VPXCz6ToT2qpobETCSTTAK