### PR TITLE
fix(runtime): survive daemon websocket port collisions and correct the login chip

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -351,6 +351,11 @@ export interface AgenCDaemonWebSocketListenOptions {
   readonly host: string;
   readonly port: number;
   readonly path: string;
+  // True only when the port is the implicit fixed default: an AGENC_HOME env
+  // override already selects an ephemeral port, but HOME-based isolation and
+  // multi-user machines resolve the same default and would otherwise collide
+  // fatally with the long-lived daemon that holds it.
+  readonly fallbackToEphemeralPortOnAddrInUse: boolean;
 }
 
 export function defaultAgenCDaemonPidPath(userHome = homedir()): string {
@@ -385,28 +390,26 @@ export function resolveAgenCDaemonWebSocketListenOptions(
   const path =
     env[AGENC_DAEMON_WEBSOCKET_PATH_ENV]?.trim() ||
     AGENC_DAEMON_WEBSOCKET_DEFAULT_PATH;
-  return {
-    host,
-    port: resolveAgenCDaemonWebSocketPort(env),
-    path,
-  };
-}
-
-function resolveAgenCDaemonWebSocketPort(
-  env: NodeJS.ProcessEnv = process.env,
-): number {
-  const configured = env[AGENC_DAEMON_WEBSOCKET_PORT_ENV]?.trim();
-  if (configured !== undefined && configured.length > 0) {
-    return parseAgenCDaemonWebSocketPort(configured);
+  const configuredPort = env[AGENC_DAEMON_WEBSOCKET_PORT_ENV]?.trim();
+  if (configuredPort !== undefined && configuredPort.length > 0) {
+    return {
+      host,
+      port: parseAgenCDaemonWebSocketPort(configuredPort),
+      path,
+      fallbackToEphemeralPortOnAddrInUse: false,
+    };
   }
-
   // The fixed portal endpoint is only safe for the default daemon home. Test
   // and isolated homes must not collide with the user's long-lived daemon.
   if ((env.AGENC_HOME?.trim() ?? "").length > 0) {
-    return 0;
+    return { host, port: 0, path, fallbackToEphemeralPortOnAddrInUse: false };
   }
-
-  return AGENC_DAEMON_WEBSOCKET_DEFAULT_PORT;
+  return {
+    host,
+    port: AGENC_DAEMON_WEBSOCKET_DEFAULT_PORT,
+    path,
+    fallbackToEphemeralPortOnAddrInUse: true,
+  };
 }
 
 function parseAgenCDaemonWebSocketPort(value: string): number {
@@ -2033,6 +2036,16 @@ async function runAgenCDaemonForeground(
     }
     await socketServer.listen();
     const webSocketAddress = await webSocketServer.listen();
+    if (
+      webSocketListenOptions.fallbackToEphemeralPortOnAddrInUse &&
+      webSocketAddress.port !== webSocketListenOptions.port
+    ) {
+      io.stderr.write(
+        `agenc: daemon websocket port ${webSocketListenOptions.port} is in ` +
+          `use by another process; listening on ephemeral port ` +
+          `${webSocketAddress.port} instead\n`,
+      );
+    }
     io.stderr.write(
       `AgenC daemon websocket listening on ${webSocketAddress.url}\n`,
     );

--- a/runtime/src/app-server/transport/websocket.ts
+++ b/runtime/src/app-server/transport/websocket.ts
@@ -63,6 +63,11 @@ export interface AgenCWebSocketMessageContext {
 export interface AgenCWebSocketServerOptions {
   readonly host?: string;
   readonly port?: number;
+  // An implicit default port may already be held by another daemon (isolated
+  // HOME or a second user on the same machine); opting in lets listen() retry
+  // once on an ephemeral port instead of failing daemon startup. Explicitly
+  // configured ports never fall back.
+  readonly fallbackToEphemeralPortOnAddrInUse?: boolean;
   readonly path?: string;
   readonly maxPayloadBytes?: number;
   readonly ready?: () => boolean;
@@ -171,24 +176,40 @@ export class AgenCWebSocketServer {
     httpServer.on("upgrade", (request, socket, head) => {
       this.#handleUpgrade(request, socket, head);
     });
-    httpServer.on("error", (error) => {
-      this.#options.onError?.(error, null);
-    });
     webSocketServer.on("connection", (socket, request) => {
       this.#acceptConnection(socket, request);
     });
 
-    try {
-      await new Promise<void>((resolve, reject) => {
+    const listenOnce = (port: number) =>
+      new Promise<void>((resolve, reject) => {
         const onError = (error: Error) => {
           httpServer.off("error", onError);
           reject(error);
         };
         httpServer.once("error", onError);
-        httpServer.listen(this.port, this.host, () => {
+        httpServer.listen(port, this.host, () => {
           httpServer.off("error", onError);
           resolve();
         });
+      });
+
+    try {
+      try {
+        await listenOnce(this.port);
+      } catch (error) {
+        if (
+          this.port === 0 ||
+          this.#options.fallbackToEphemeralPortOnAddrInUse !== true ||
+          (error as NodeJS.ErrnoException).code !== "EADDRINUSE"
+        ) {
+          throw error;
+        }
+        await listenOnce(0);
+      }
+      // Attached after the listen attempts so a recoverable EADDRINUSE on the
+      // implicit default port does not surface through onError.
+      httpServer.on("error", (error) => {
+        this.#options.onError?.(error, null);
       });
       this.#listenAddress = listenAddressFor(httpServer, this.host, this.path);
       return this.#listenAddress;

--- a/runtime/src/tui/components/PromptInput/Notifications.tsx
+++ b/runtime/src/tui/components/PromptInput/Notifications.tsx
@@ -27,7 +27,7 @@ import { formatDuration } from '../../../utils/format.js';
 import { setEnvHookNotifier } from '../../../utils/hooks/fileChangedWatcher.js';
 import { toIDEDisplayName } from '../../../utils/ide.js';
 import { getMessagesAfterCompactBoundary } from '../../../utils/messages.js';
-import { usesAnthropicAccountFlow } from '../../../utils/model/providers.js';
+import { isRegistryOwnedNonAnthropicModel, usesAnthropicAccountFlow } from '../../../utils/model/providers.js';
 import { tokenCountFromLastAPIResponse } from '../../../utils/tokens.js';
 import { AutoUpdaterWrapper } from '../AutoUpdaterWrapper.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
@@ -148,7 +148,7 @@ export function Notifications(t0: Props) {
   const hasRemoteAuthSession = hasRemoteAuthSessionSync(remoteAuthEnv);
   const remoteSubscriptionTier = remoteAuthSessionSubscriptionTierSync(remoteAuthEnv);
   const hasRemoteManagedKeys = hasEntitledRemoteAuthSessionSync(remoteAuthEnv);
-  const shouldShowRemoteAuthPlan = usesAnthropicAccountFlow() && hasRemoteAuthSession && (apiKeyStatus === 'invalid' || apiKeyStatus === 'missing');
+  const shouldShowRemoteAuthPlan = usesAnthropicAccountFlow() && !isRegistryOwnedNonAnthropicModel(mainLoopModel) && hasRemoteAuthSession && (apiKeyStatus === 'invalid' || apiKeyStatus === 'missing');
   let t8;
   if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
     t8 = getExternalEditor();
@@ -288,7 +288,7 @@ function NotificationContent({
             ({apiKeyHelperSlow})
           </Text>
         </Box>}
-      {usesAnthropicAccountFlow() && !hasRemoteAuthSession && (apiKeyStatus === 'invalid' || apiKeyStatus === 'missing') && <Box>
+      {usesAnthropicAccountFlow() && !isRegistryOwnedNonAnthropicModel(mainLoopModel) && !hasRemoteAuthSession && (apiKeyStatus === 'invalid' || apiKeyStatus === 'missing') && <Box>
           <Text color="error" wrap="truncate">
             {isEnvTruthy(process.env.AGENC_REMOTE) ? 'Authentication error · Try again' : 'Not logged in · Run /login'}
           </Text>

--- a/runtime/src/utils/model/providers.ts
+++ b/runtime/src/utils/model/providers.ts
@@ -1,3 +1,7 @@
+import {
+  REGISTERED_MODEL_CATALOG,
+  resolveRegisteredModelCatalogEntry,
+} from '../../llm/registry/model-catalog.js'
 import { shouldUseProviderCodeTransport } from '../../services/api/providerConfig.js'
 import { isEnvTruthy } from '../envUtils.js'
 
@@ -37,6 +41,31 @@ export function getAPIProvider(): APIProvider {
 
 export function usesAnthropicAccountFlow(): boolean {
   return getAPIProvider() === 'firstParty'
+}
+
+/**
+ * True when `model` is registry-owned by a built-in non-Anthropic provider
+ * (grok, openai, ...; the registered catalog carries no Anthropic entries).
+ * getAPIProvider() only sees env vars, so a session whose provider comes from
+ * config.toml (e.g. grok via OAuth credentials, no XAI_API_KEY set) still
+ * reports 'firstParty'; auth-status UI must not tell such a session it is
+ * "not logged in" for lacking an Anthropic key.
+ */
+export function isRegistryOwnedNonAnthropicModel(model: string): boolean {
+  const trimmed = model.trim()
+  if (trimmed.length === 0) return false
+  const providers = new Set(
+    REGISTERED_MODEL_CATALOG.map(entry => entry.provider),
+  )
+  for (const provider of providers) {
+    if (
+      resolveRegisteredModelCatalogEntry({ provider, model: trimmed }) !==
+      undefined
+    ) {
+      return true
+    }
+  }
+  return false
 }
 
 /**

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -619,18 +619,31 @@ describe("AgenC daemon CLI", () => {
       host: AGENC_DAEMON_WEBSOCKET_DEFAULT_HOST,
       port: AGENC_DAEMON_WEBSOCKET_DEFAULT_PORT,
       path: AGENC_DAEMON_WEBSOCKET_DEFAULT_PATH,
+      // Only the implicit fixed default may fall back on EADDRINUSE: a
+      // HOME-isolated or second-user daemon resolves this same port and must
+      // not die because the long-lived default daemon already holds it.
+      fallbackToEphemeralPortOnAddrInUse: true,
     });
     expect(
       resolveAgenCDaemonWebSocketListenOptions({
         AGENC_HOME: "/tmp/agenc-isolated-home",
-      }).port,
-    ).toBe(0);
+      }),
+    ).toMatchObject({ port: 0, fallbackToEphemeralPortOnAddrInUse: false });
     expect(
       resolveAgenCDaemonWebSocketListenOptions({
         AGENC_HOME: "/tmp/agenc-isolated-home",
         [AGENC_DAEMON_WEBSOCKET_PORT_ENV]: "0",
       }).port,
     ).toBe(0);
+    expect(
+      resolveAgenCDaemonWebSocketListenOptions({
+        [AGENC_DAEMON_WEBSOCKET_PORT_ENV]: "7891",
+      }),
+    ).toMatchObject({
+      port: 7891,
+      // An explicitly configured port must stay fatal on collision.
+      fallbackToEphemeralPortOnAddrInUse: false,
+    });
     expect(
       resolveAgenCDaemonWebSocketListenOptions({
         AGENC_HOME: "/tmp/agenc-isolated-home",

--- a/runtime/tests/app-server/websocket-transport.contract.test.ts
+++ b/runtime/tests/app-server/websocket-transport.contract.test.ts
@@ -709,6 +709,50 @@ describe("AgenC websocket app-server transport", () => {
     await server.close();
   });
 
+  it("falls back to an ephemeral port when the default port is held and fallback is opted in", async () => {
+    const occupant = new AgenCWebSocketServer({});
+    const occupied = await occupant.listen();
+
+    const errors: Error[] = [];
+    const server = new AgenCWebSocketServer({
+      port: occupied.port,
+      fallbackToEphemeralPortOnAddrInUse: true,
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+    const address = await server.listen();
+    expect(address.port).not.toBe(occupied.port);
+    expect(address.port).toBeGreaterThan(0);
+    expect(server.listenAddress).toEqual(address);
+    // A recovered collision must not surface through onError.
+    expect(errors).toEqual([]);
+
+    const client = new WebSocket(address.url);
+    await once(client, "open");
+    client.close();
+    await nextClose(client);
+    await server.close();
+    await occupant.close();
+  });
+
+  it("keeps a held port fatal when fallback is not opted in", async () => {
+    const occupant = new AgenCWebSocketServer({});
+    const occupied = await occupant.listen();
+
+    const server = new AgenCWebSocketServer({ port: occupied.port });
+    await expect(server.listen()).rejects.toMatchObject({
+      code: "EADDRINUSE",
+    });
+    expect(server.listenAddress).toBeNull();
+    // The failed listen must leave the transport reusable for a retry.
+    const retry = new AgenCWebSocketServer({ port: 0 });
+    const retryAddress = await retry.listen();
+    expect(retryAddress.port).toBeGreaterThan(0);
+    await retry.close();
+    await occupant.close();
+  });
+
   it("is reachable through the public runtime barrel", () => {
     expect(PublicAgenCWebSocketServer).toBe(AgenCWebSocketServer);
     expect(publicEncodeJsonPayload).toBe(encodeJsonPayload);

--- a/runtime/tests/tui/byok-login-notice.test.ts
+++ b/runtime/tests/tui/byok-login-notice.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
   getAPIProvider,
+  isRegistryOwnedNonAnthropicModel,
   usesAnthropicAccountFlow,
 } from "../../src/utils/model/providers.js";
 import type { VerificationStatus } from "../../src/tui/hooks/useApiKeyVerification.js";
@@ -24,9 +25,11 @@ import type { VerificationStatus } from "../../src/tui/hooks/useApiKeyVerificati
 function loginNoticeVisible(
   apiKeyStatus: VerificationStatus,
   hasRemoteAuthSession = false,
+  mainLoopModel = "",
 ): boolean {
   return (
     usesAnthropicAccountFlow() &&
+    !isRegistryOwnedNonAnthropicModel(mainLoopModel) &&
     !hasRemoteAuthSession &&
     (apiKeyStatus === "invalid" || apiKeyStatus === "missing")
   );
@@ -112,5 +115,22 @@ describe("byok-login-notice", () => {
     expect(usesAnthropicAccountFlow()).toBe(true);
     expect(loginNoticeVisible("missing", true)).toBe(false);
     expect(loginNoticeVisible("invalid", true)).toBe(false);
+  });
+
+  test("config-selected grok session (no provider env vars): login notice is suppressed", () => {
+    // config.toml `model_provider = "grok"` with OAuth credentials sets no env
+    // var, so getAPIProvider() still reports firstParty; the registry-owned
+    // session model is what proves the session is not on the Anthropic flow.
+    expect(getAPIProvider()).toBe("firstParty");
+    expect(isRegistryOwnedNonAnthropicModel("grok-4.5")).toBe(true);
+    expect(loginNoticeVisible("missing", false, "grok-4.5")).toBe(false);
+    expect(loginNoticeVisible("invalid", false, "grok-4.5")).toBe(false);
+  });
+
+  test("registry ownership: anthropic and unknown models stay on the notice path", () => {
+    expect(isRegistryOwnedNonAnthropicModel("gpt-5")).toBe(true);
+    expect(isRegistryOwnedNonAnthropicModel("claude-opus-5")).toBe(false);
+    expect(isRegistryOwnedNonAnthropicModel("")).toBe(false);
+    expect(loginNoticeVisible("missing", false, "claude-opus-5")).toBe(true);
   });
 });

--- a/runtime/tests/tui/components/PromptInput/Notifications.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/Notifications.test.tsx
@@ -101,6 +101,10 @@ vi.mock('../../../utils/messages.js', () => ({
 
 vi.mock('../../../utils/model/providers.js', () => ({
   usesAnthropicAccountFlow: () => harness.usesAnthropicAccountFlow,
+  // The harness drives auth-flow visibility through usesAnthropicAccountFlow;
+  // the registry gate stays inert so existing cases keep exercising the
+  // Anthropic-flow copy paths.
+  isRegistryOwnedNonAnthropicModel: () => false,
 }))
 
 vi.mock('../../../utils/tokens.js', () => ({


### PR DESCRIPTION
Found while dogfooding a source build of current main in an isolated HOME (tmux-driven TUI, real grok session).

## Fix 1: daemon dies on websocket port collision

A daemon whose home is isolated via HOME override (our own e2e harnesses do this, and any second user on one machine hits it too) resolves the same fixed default websocket port as the long-lived default daemon. The listen failed with EADDRINUSE, the daemon exited 1, and the TUI died at startup. The AGENC_HOME ephemeral-port carve-out never fires for these because it only checks the env var.

Now listen() retries once on an ephemeral port when the port is the implicit default, with a clear stderr line. Explicitly configured ports still fail fatally. Verified live: the isolated daemon now starts with 'daemon websocket port 7766 is in use by another process; listening on ephemeral port 40117 instead'.

Note for follow-up: on this machine port 7766 is currently held by a stale dev daemon, so portal clients using the default URL reach the wrong daemon. Fixed-port ownership/discovery deserves its own pass.

## Fix 2: false 'Not logged in · Run /login' chip

getAPIProvider() only inspects env vars. A session whose provider comes from config.toml (grok via OAuth credentials, no XAI_API_KEY env) reports firstParty, so the footer claimed 'Not logged in' while grok streamed fine. The notice is now also gated on the session model: registry-owned non-Anthropic models suppress it. Extends the existing byok-login-notice regression suite to the config-selected case.

## Verification

- typecheck + typecheck:test-support clean
- 99 tests across the 4 touched files pass; new fallback test proven revert-sensitive (fails on reverted source)
- live TUI session: daemon survives collision, chip gone on a grok config session, full build-and-improve agent run completed in the isolated home

https://claude.ai/code/session_01BNuWCAhA3GgUp8vLhqaQmc