### PR TITLE
fix(tui): honest mode-switcher hints and actionable apparmor-profile refusal

### DIFF
--- a/runtime/src/bin/doctor-cli.ts
+++ b/runtime/src/bin/doctor-cli.ts
@@ -180,7 +180,12 @@ export async function runAgenCDoctorCli(
       const wrapper = await findActiveGeneratedWrapper();
       if (wrapper === null) {
         process.stderr.write(
-          "agenc: --apparmor-profile requires a verified standalone-installer wrapper for this exact runtime\n",
+          "agenc: --apparmor-profile requires a verified standalone-installer wrapper for this exact runtime\n" +
+            "agenc: the profile grants the user-namespace exception to one exact binary path, so it is only\n" +
+            "agenc: generated for the byte-verified wrapper the standalone installer manages. This runtime was\n" +
+            "agenc: started from a source checkout or npm install, which has no such wrapper.\n" +
+            "agenc: To sandbox on this machine, install the standalone build and run the command there, or see\n" +
+            "agenc: your distribution's documentation for kernel.apparmor_restrict_unprivileged_userns.\n",
         );
         return 1;
       }

--- a/runtime/src/tui/components/v2/designBrowserTextFixture.ts
+++ b/runtime/src/tui/components/v2/designBrowserTextFixture.ts
@@ -4542,7 +4542,7 @@ export const BROWSER_TEXT_FIXTURE = {
       column: 56
     },
     {
-      marker: "1–5 pick · ⇧⇥ cycle · esc",
+      marker: "⇧⇥ cycle",
       row: 14,
       column: 80
     },
@@ -4605,7 +4605,7 @@ export const BROWSER_TEXT_FIXTURE = {
       column: 38
     },
     {
-      marker: "switching mode · keys 1–5",
+      marker: "switching mode · ⇧⇥",
       row: 33,
       column: 5,
       family: "accent"

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -323,7 +323,9 @@ export function ModeSwitcher({
           <ThemedText color="inactive" wrap="truncate-end">{`current · ${currentMode}`}</ThemedText>
         </Box>
         <Box flexGrow={1} />
-        <ThemedText color="inactive" wrap="truncate-end">1–5 pick · ⇧⇥ cycle · esc</ThemedText>
+        {/* Only advertise keys that are actually handled: the switcher is a
+            timed toast, and no digit-pick or esc-dismiss handler exists. */}
+        <ThemedText color="inactive" wrap="truncate-end">⇧⇥ cycle</ThemedText>
       </ThemedBox>
       <Box flexDirection="column">
         {modes.map((mode, index) => {

--- a/runtime/tests/tui/components/v2/designStateSmoke.test.tsx
+++ b/runtime/tests/tui/components/v2/designStateSmoke.test.tsx
@@ -4034,7 +4034,7 @@ const DESIGN_STATES: readonly DesignState[] = [
       <Frame
         viewport={viewport}
         permissionMode="acceptEdits"
-        contextLeft={<ThemedText color="agenc">switching mode · keys 1–5</ThemedText>}
+        contextLeft={<ThemedText color="agenc">switching mode · ⇧⇥</ThemedText>}
         contextRight={<KeyHint k="esc" label="cancel" />}
         statusLeftItems={[
           <StatusSegment key="model" label="model" value="haiku-4.5" color="agenc" />,

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -108,6 +108,11 @@ describe('v2 primitives', () => {
     expect(output).toContain('read-only · propose plans')
     expect(output).toContain('bypassPermissions')
     expect(output).toContain('shift+tab')
+    // The switcher is a timed toast with no digit-pick or esc handler; the
+    // header must not advertise keys that do nothing.
+    expect(output).toContain('⇧⇥ cycle')
+    expect(output).not.toContain('pick')
+    expect(output).not.toContain('esc')
   })
 
   it('hides unavailable cycle targets', async () => {


### PR DESCRIPTION
Dogfood follow-ups from the session behind #1684.

The permission-mode switcher toast advertised '1-5 pick' and 'esc' with no digit-pick or esc handler anywhere in the codebase (digits leak into the composer), and said 1-5 when at most 4 modes are visible in common configs. The header now advertises only what works (shift+tab cycling); real digit picking is coming separately.

'agenc doctor --apparmor-profile' refused non-standalone installs with an unexplained one-liner; it now says why the profile only attaches to the byte-verified installer wrapper and what a source/npm user can do instead.

Verified: primitives + swarm-065 suites pass; typecheck clean; design-lane failures are pre-existing on main (state 01a stale fixture, A/B-verified identical 7/104 with and without this change; fix tracked separately).

https://claude.ai/code/session_01BNuWCAhA3GgUp8vLhqaQmc