### PR TITLE
feat(tui): pick permission modes by digit and dismiss the switcher with esc

### DIFF
--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -162,10 +162,12 @@ import {
 } from "../../../utils/model/model.js";
 import { setAutoModeActive } from "../../../utils/permissions/autoModeState.js";
 import {
-  cyclePermissionMode,
   getNextPermissionMode,
 } from "../../../utils/permissions/getNextPermissionMode.js";
-import { transitionPermissionMode } from "../../../utils/permissions/permissionSetup.js";
+import {
+  isAutoModeGateEnabled,
+  transitionPermissionMode,
+} from "../../../utils/permissions/permissionSetup.js";
 import { getPlatform } from "../../../utils/platform.js";
 import type { PromptInputContext } from "../../input/inputContext.js";
 import { editPromptInEditor } from "../../../utils/promptEditor.js";
@@ -227,7 +229,7 @@ import { ThinkingToggle } from "../ThinkingToggle.js";
 import { BackgroundTasksPanel } from "../tasks/BackgroundTasksPanel.js";
 import { shouldHideTasksFooter } from "../tasks/taskStatusUtils.js";
 import { TeamsDialog } from "../teams/TeamsDialog.js";
-import { ModeSwitcher } from "../v2/primitives.js";
+import { ModeSwitcher, visibleUserFacingModes } from "../v2/primitives.js";
 import { ConfiguredPromptTextInput } from "./ConfiguredPromptTextInput.js";
 import {
   detectModeEntry,
@@ -2662,47 +2664,8 @@ function PromptInput({
     }
   }, [helpOpen]);
 
-  // Handler for chat:cycleMode - cycle through permission modes
-  const handleCycleMode = useCallback(() => {
-    // When viewing a teammate, cycle their mode instead of the leader's
-    if (isAgentSwarmsEnabled() && viewedTeammate && viewingAgentTaskId) {
-      const teammateContext: ToolPermissionContext = {
-        ...toolPermissionContext,
-        mode: viewedTeammate.permissionMode,
-      };
-      // Pass undefined for teamContext (unused but kept for API compatibility)
-      const nextMode = getNextPermissionMode(teammateContext, undefined);
-      const teammateTaskId = viewingAgentTaskId;
-      setAppState((prev) => {
-        const task = prev.tasks[teammateTaskId];
-        if (!task || task.type !== "in_process_teammate") {
-          return prev;
-        }
-        if (task.permissionMode === nextMode) {
-          return prev;
-        }
-        return {
-          ...prev,
-          tasks: {
-            ...prev.tasks,
-            [teammateTaskId]: {
-              ...task,
-              permissionMode: nextMode,
-            },
-          },
-        };
-      });
-      if (helpOpen) {
-        setHelpOpen(false);
-      }
-      return;
-    }
-
-    // Compute the next mode without triggering side effects first
-    logForDebugging(
-      `[auto-mode] handleCycleMode: currentMode=${toolPermissionContext.mode} isAutoModeAvailable=${toolPermissionContext.isAutoModeAvailable} showAutoModeOptIn=${showAutoModeOptIn} timeoutPending=${!!autoModeOptInTimeoutRef.current}`,
-    );
-    const nextMode = getNextPermissionMode(toolPermissionContext, teamContext);
+  // Shows the mode-switcher toast and (re)arms its auto-dismiss timer.
+  const showModeSwitcherToast = useCallback(() => {
     setShowModeSwitcher(true);
     if (modeSwitcherTimeoutRef.current) {
       clearTimeout(modeSwitcherTimeoutRef.current);
@@ -2716,6 +2679,51 @@ function PromptInput({
       setShowModeSwitcher,
       modeSwitcherTimeoutRef,
     );
+  }, []);
+
+  const dismissModeSwitcherToast = useCallback(() => {
+    if (modeSwitcherTimeoutRef.current) {
+      clearTimeout(modeSwitcherTimeoutRef.current);
+      modeSwitcherTimeoutRef.current = null;
+    }
+    setShowModeSwitcher(false);
+  }, []);
+
+  // Applies one specific permission mode. Shared by shift+tab cycling and
+  // digit picks in the mode-switcher toast.
+  const selectPermissionMode = useCallback((targetMode: PermissionMode) => {
+    // When viewing a teammate, set their mode instead of the leader's
+    if (isAgentSwarmsEnabled() && viewedTeammate && viewingAgentTaskId) {
+      const teammateTaskId = viewingAgentTaskId;
+      setAppState((prev) => {
+        const task = prev.tasks[teammateTaskId];
+        if (!task || task.type !== "in_process_teammate") {
+          return prev;
+        }
+        if (task.permissionMode === targetMode) {
+          return prev;
+        }
+        return {
+          ...prev,
+          tasks: {
+            ...prev.tasks,
+            [teammateTaskId]: {
+              ...task,
+              permissionMode: targetMode,
+            },
+          },
+        };
+      });
+      if (helpOpen) {
+        setHelpOpen(false);
+      }
+      return;
+    }
+
+    logForDebugging(
+      `[auto-mode] selectPermissionMode: currentMode=${toolPermissionContext.mode} targetMode=${targetMode} isAutoModeAvailable=${toolPermissionContext.isAutoModeAvailable} showAutoModeOptIn=${showAutoModeOptIn} timeoutPending=${!!autoModeOptInTimeoutRef.current}`,
+    );
+    showModeSwitcherToast();
 
     // Check if user is entering auto mode for the first time. Gated on the
     // persistent settings flag (hasAutoModeOptIn) rather than the broader
@@ -2725,7 +2733,7 @@ function PromptInput({
     let isEnteringAutoModeFirstTime = false;
     if (feature("TRANSCRIPT_CLASSIFIER")) {
       isEnteringAutoModeFirstTime =
-        nextMode === "auto" &&
+        targetMode === "auto" &&
         toolPermissionContext.mode !== "auto" &&
         !hasAutoModeOptIn() &&
         !viewingAgentTaskId; // Only show for primary agent, not subagents
@@ -2769,10 +2777,19 @@ function PromptInput({
       }
     }
 
-    // Dismiss auto mode opt-in dialog if showing or pending (user is cycling away).
-    // Do NOT revert to previousModeBeforeAuto here — shift+tab means "advance the
-    // carousel", not "decline". Reverting causes a ping-pong loop: auto reverts to
-    // the prior mode, whose next mode is auto again, forever.
+    // Re-selecting auto while its opt-in dialog is pending: the dialog owns
+    // the decision; applying the transition here would bypass the consent.
+    if (
+      targetMode === "auto" &&
+      (showAutoModeOptIn || autoModeOptInTimeoutRef.current)
+    ) {
+      return;
+    }
+
+    // Dismiss auto mode opt-in dialog if showing or pending (user is moving away).
+    // Do NOT revert to previousModeBeforeAuto here — cycling or picking means
+    // "select another mode", not "decline". Reverting causes a ping-pong loop:
+    // auto reverts to the prior mode, whose next mode is auto again, forever.
     // The dialog's own decline button (handleAutoModeOptInDecline) handles revert.
     if (feature("TRANSCRIPT_CLASSIFIER")) {
       if (showAutoModeOptIn || autoModeOptInTimeoutRef.current) {
@@ -2782,18 +2799,21 @@ function PromptInput({
           autoModeOptInTimeoutRef.current = null;
         }
         setPreviousModeBeforeAuto(null);
-        // Fall through — mode is 'auto', cyclePermissionMode below goes to 'default'.
+        // Fall through — the transition below applies the picked target.
       }
     }
 
-    // Now that we know this is NOT the first-time auto mode path,
-    // call cyclePermissionMode to apply side effects (e.g. strip
-    // dangerous permissions, activate classifier)
-    const { nextMode: preparedNextMode, context: preparedContext } =
-      cyclePermissionMode(toolPermissionContext, teamContext);
+    // Now that we know this is NOT the first-time auto mode path, apply the
+    // transition side effects (e.g. strip dangerous permissions, activate
+    // classifier) for the picked target.
+    const preparedContext = transitionPermissionMode(
+      toolPermissionContext.mode,
+      targetMode,
+      toolPermissionContext,
+    );
 
     // Track when user enters plan mode
-    if (preparedNextMode === "plan") {
+    if (targetMode === "plan") {
       saveGlobalConfig((current) => ({
         ...current,
         lastPlanModeUse: Date.now(),
@@ -2808,18 +2828,18 @@ function PromptInput({
       ...prev,
       toolPermissionContext: {
         ...preparedContext,
-        mode: preparedNextMode,
+        mode: targetMode,
       },
     }));
     setToolPermissionContext({
       ...preparedContext,
-      mode: preparedNextMode,
+      mode: targetMode,
     });
 
     // If this is a teammate, update config.json so team lead sees the change
-    syncTeammateMode(preparedNextMode, teamContext?.teamName);
+    syncTeammateMode(targetMode, teamContext?.teamName);
 
-    // Close help tips if they're open when mode is cycled
+    // Close help tips if they're open when mode is selected
     if (helpOpen) {
       setHelpOpen(false);
     }
@@ -2832,7 +2852,55 @@ function PromptInput({
     setToolPermissionContext,
     helpOpen,
     showAutoModeOptIn,
+    showModeSwitcherToast,
   ]);
+
+  // Handler for chat:cycleMode - cycle through permission modes
+  const handleCycleMode = useCallback(() => {
+    // When viewing a teammate, cycle from their mode instead of the leader's
+    if (isAgentSwarmsEnabled() && viewedTeammate && viewingAgentTaskId) {
+      const teammateContext: ToolPermissionContext = {
+        ...toolPermissionContext,
+        mode: viewedTeammate.permissionMode,
+      };
+      // Pass undefined for teamContext (unused but kept for API compatibility)
+      selectPermissionMode(getNextPermissionMode(teammateContext, undefined));
+      return;
+    }
+    selectPermissionMode(
+      getNextPermissionMode(toolPermissionContext, teamContext),
+    );
+  }, [
+    toolPermissionContext,
+    teamContext,
+    viewedTeammate,
+    viewingAgentTaskId,
+    selectPermissionMode,
+  ]);
+
+  // Digit picks and esc-dismiss for the mode-switcher toast. Active only
+  // while the toast is visible; digits index into the same visible-mode
+  // order the ModeSwitcher renders, so display and picking cannot drift.
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        dismissModeSwitcherToast();
+        return;
+      }
+      if (!/^[1-9]$/u.test(input)) return;
+      const modes = visibleUserFacingModes(
+        effectiveToolPermissionContext.isBypassPermissionsModeAvailable,
+        effectiveToolPermissionContext.isAutoModeAvailable,
+      );
+      const targetMode = modes[Number.parseInt(input, 10) - 1];
+      if (targetMode === undefined) return;
+      // The live gate can lag the startup availability flag; picking auto
+      // without the gate would make transitionPermissionMode throw.
+      if (targetMode === "auto" && !isAutoModeGateEnabled()) return;
+      selectPermissionMode(targetMode);
+    },
+    { isActive: showModeSwitcher },
+  );
 
   // Handler for auto mode opt-in dialog acceptance
   const handleAutoModeOptInAccept = useCallback(() => {

--- a/runtime/src/tui/components/v2/designBrowserTextFixture.ts
+++ b/runtime/src/tui/components/v2/designBrowserTextFixture.ts
@@ -4542,7 +4542,7 @@ export const BROWSER_TEXT_FIXTURE = {
       column: 56
     },
     {
-      marker: "⇧⇥ cycle",
+      marker: "1–5 pick · ⇧⇥ cycle · esc",
       row: 14,
       column: 80
     },
@@ -4605,7 +4605,7 @@ export const BROWSER_TEXT_FIXTURE = {
       column: 38
     },
     {
-      marker: "switching mode · ⇧⇥",
+      marker: "switching mode · keys 1–5",
       row: 33,
       column: 5,
       family: "accent"

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -268,6 +268,22 @@ const userFacingModeOrder: readonly PermissionMode[] = [
   'bypassPermissions',
 ]
 
+/**
+ * The modes the switcher displays, in display order. The digit-pick handler
+ * in PromptInput indexes into this same list, so display and picking can
+ * never drift apart.
+ */
+export function visibleUserFacingModes(
+  bypassAvailable: boolean,
+  autoAvailable: boolean,
+): readonly PermissionMode[] {
+  return userFacingModeOrder.filter(
+    mode =>
+      (mode !== 'bypassPermissions' || bypassAvailable) &&
+      (mode !== 'auto' || autoAvailable),
+  )
+}
+
 function modeDescription(mode: PermissionMode): string {
   switch (mode) {
     case 'default':
@@ -300,11 +316,7 @@ export function ModeSwitcher({
   readonly autoAvailable?: boolean
   readonly spacious?: boolean
 }): React.ReactNode {
-  const modes = userFacingModeOrder.filter(
-    mode =>
-      (mode !== 'bypassPermissions' || bypassAvailable) &&
-      (mode !== 'auto' || autoAvailable),
-  )
+  const modes = visibleUserFacingModes(bypassAvailable, autoAvailable)
 
   return (
     <Box flexDirection="row" justifyContent="center" width="100%">
@@ -323,9 +335,7 @@ export function ModeSwitcher({
           <ThemedText color="inactive" wrap="truncate-end">{`current · ${currentMode}`}</ThemedText>
         </Box>
         <Box flexGrow={1} />
-        {/* Only advertise keys that are actually handled: the switcher is a
-            timed toast, and no digit-pick or esc-dismiss handler exists. */}
-        <ThemedText color="inactive" wrap="truncate-end">⇧⇥ cycle</ThemedText>
+        <ThemedText color="inactive" wrap="truncate-end">{`1–${modes.length} pick · ⇧⇥ cycle · esc`}</ThemedText>
       </ThemedBox>
       <Box flexDirection="column">
         {modes.map((mode, index) => {

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -120,6 +120,7 @@ const harness = vi.hoisted(() => {
     modelPickerProps: undefined as undefined | Record<string, unknown>,
     nextPermissionMode: "plan",
     cyclePermissionModeNextMode: null as null | string,
+    autoModeGateEnabled: true,
     platform: "linux",
     quickOpenProps: undefined as undefined | Record<string, unknown>,
     runningTeammates: [] as unknown[],
@@ -227,6 +228,7 @@ const harness = vi.hoisted(() => {
       harness.modelPickerProps = undefined;
       harness.nextPermissionMode = "plan";
       harness.cyclePermissionModeNextMode = null;
+      harness.autoModeGateEnabled = true;
       harness.platform = "linux";
       harness.quickOpenProps = undefined;
       harness.runningTeammates = [];
@@ -601,6 +603,7 @@ vi.mock("../../../utils/permissions/getNextPermissionMode.js", () => ({
 vi.mock("../../../utils/permissions/permissionSetup.js", () => ({
   transitionPermissionMode: (_from: unknown, _to: unknown, context: unknown) =>
     context,
+  isAutoModeGateEnabled: () => harness.autoModeGateEnabled,
 }));
 
 vi.mock("../../../utils/platform.js", () => ({
@@ -750,9 +753,13 @@ vi.mock("../teams/TeamsDialog.js", () => ({
   },
 }));
 
-vi.mock("../v2/primitives.js", () => ({
-  ModeSwitcher: () => null,
-}));
+vi.mock("../v2/primitives.js", async (importOriginal) => {
+  // The real visibleUserFacingModes is the contract the digit-pick handler
+  // indexes into; mocking it would let display and picking drift apart in
+  // exactly the way sharing this helper is meant to prevent.
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, ModeSwitcher: () => null };
+});
 
 vi.mock("./ConfiguredPromptTextInput.js", async () => {
   const ReactModule = await import("react");
@@ -1358,9 +1365,8 @@ describe("PromptInput render surface", () => {
     }
   });
 
-  test("commits the permission mode returned with the cycled context", async () => {
-    harness.nextPermissionMode = "plan";
-    harness.cyclePermissionModeNextMode = "default";
+  test("commits the permission mode returned by the cycle helper", async () => {
+    harness.nextPermissionMode = "default";
     const setToolPermissionContext = vi.fn();
     const rendered = await renderPromptInput({ setToolPermissionContext });
 
@@ -1374,6 +1380,75 @@ describe("PromptInput render surface", () => {
       );
       expect(harness.appState.toolPermissionContext.mode).toBe("default");
       expect(harness.saveGlobalConfig).not.toHaveBeenCalled();
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("picks a permission mode by digit while the mode switcher is open", async () => {
+    const setToolPermissionContext = vi.fn();
+    const rendered = await renderPromptInput({ setToolPermissionContext });
+
+    try {
+      await waitForPromptInputProps();
+
+      // Digits do nothing until the switcher is open.
+      const beforeOpen = harness.inputHandlers.filter(
+        (entry) => entry.options?.isActive === true,
+      );
+      for (const entry of beforeOpen) {
+        entry.handler("3", {});
+      }
+      expect(setToolPermissionContext).not.toHaveBeenCalled();
+
+      // Shift+tab opens the switcher toast; wait for the re-render that
+      // arms the digit handler.
+      const handlersBefore = harness.inputHandlers.length;
+      harness.keybindings["chat:cycleMode"]?.();
+      await waitForInputHandlerCount(handlersBefore + 1);
+      setToolPermissionContext.mockClear();
+
+      const active = harness.inputHandlers
+        .slice(handlersBefore)
+        .filter((entry) => entry.options?.isActive === true);
+      expect(active.length).toBeGreaterThan(0);
+      for (const entry of active) {
+        // [3] is 'plan' in the visible-mode order with both gates available.
+        entry.handler("3", {});
+      }
+
+      expect(setToolPermissionContext).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "plan" }),
+      );
+      expect(harness.appState.toolPermissionContext.mode).toBe("plan");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("ignores digits outside the visible mode range and refuses auto when its gate is off", async () => {
+    harness.autoModeGateEnabled = false;
+    const setToolPermissionContext = vi.fn();
+    const rendered = await renderPromptInput({ setToolPermissionContext });
+
+    try {
+      await waitForPromptInputProps();
+      const handlersBefore = harness.inputHandlers.length;
+      harness.keybindings["chat:cycleMode"]?.();
+      await waitForInputHandlerCount(handlersBefore + 1);
+      setToolPermissionContext.mockClear();
+
+      const active = harness.inputHandlers
+        .slice(handlersBefore)
+        .filter((entry) => entry.options?.isActive === true);
+      for (const entry of active) {
+        entry.handler("9", {});
+        // [4] is 'auto'; the live gate is off, so it must be refused rather
+        // than throwing out of the input handler.
+        entry.handler("4", {});
+      }
+
+      expect(setToolPermissionContext).not.toHaveBeenCalled();
     } finally {
       await rendered.dispose();
     }

--- a/runtime/tests/tui/components/v2/designStateSmoke.test.tsx
+++ b/runtime/tests/tui/components/v2/designStateSmoke.test.tsx
@@ -4034,7 +4034,7 @@ const DESIGN_STATES: readonly DesignState[] = [
       <Frame
         viewport={viewport}
         permissionMode="acceptEdits"
-        contextLeft={<ThemedText color="agenc">switching mode · ⇧⇥</ThemedText>}
+        contextLeft={<ThemedText color="agenc">switching mode · keys 1–5</ThemedText>}
         contextRight={<KeyHint k="esc" label="cancel" />}
         statusLeftItems={[
           <StatusSegment key="model" label="model" value="haiku-4.5" color="agenc" />,

--- a/runtime/tests/tui/components/v2/primitives.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.test.tsx
@@ -108,11 +108,8 @@ describe('v2 primitives', () => {
     expect(output).toContain('read-only · propose plans')
     expect(output).toContain('bypassPermissions')
     expect(output).toContain('shift+tab')
-    // The switcher is a timed toast with no digit-pick or esc handler; the
-    // header must not advertise keys that do nothing.
-    expect(output).toContain('⇧⇥ cycle')
-    expect(output).not.toContain('pick')
-    expect(output).not.toContain('esc')
+    // The advertised digit range must match the number of visible modes.
+    expect(output).toContain('1–5 pick · ⇧⇥ cycle · esc')
   })
 
   it('hides unavailable cycle targets', async () => {
@@ -129,6 +126,8 @@ describe('v2 primitives', () => {
     expect(output).toContain('auto-accept file edits')
     expect(output).not.toContain('auto-approve everything')
     expect(output).not.toContain('bypassPermissions')
+    // The advertised digit range shrinks with the hidden modes.
+    expect(output).toContain('1–3 pick')
   })
 
   it('renders body overlays without requiring modal content in chat flow', async () => {


### PR DESCRIPTION
Implements the keys the mode-switcher toast has been advertising (the hint text was corrected to match reality in #1685; this restores the full hint by making it true).

Digits now index into the same visible-mode list the switcher renders, exported as visibleUserFacingModes so the display and the picker cannot drift. The handler is active only while the toast is visible, so digits no longer leak into a non-empty composer. Esc dismisses the toast early.

Mode application moved out of handleCycleMode into a shared selectPermissionMode, so shift+tab and digit picks run the same auto-mode opt-in gate and transitionPermissionMode side effects. Two safety cases: picking auto while its opt-in dialog is pending is a no-op (the dialog owns that consent), and picks refuse auto when the live gate is off, which would otherwise throw out of the input handler.

Verified live in a real TUI: pressing 3 jumps to PLAN, pressing 1 with 'hello world' in the composer selects DEFAULT and leaves the text untouched, esc closes the overlay immediately. 246 tests pass across the PromptInput and v2 primitives surface; the new digit-pick test is revert-sensitive (fails when the handler is neutered); typecheck clean.

https://claude.ai/code/session_01BNuWCAhA3GgUp8vLhqaQmc