### PR TITLE
fix(tui): wrap blocking error notifications instead of truncating them

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -5312,6 +5312,10 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
               color: "error",
               priority: "immediate",
               timeoutMs: 10_000,
+              // The remediation lives at the tail of these messages
+              // (sandbox setup commands, failing paths); truncating to one
+              // line hides exactly the part the user needs.
+              wrap: true,
             });
             setPendingSubmission(false);
             const rolledBack =
@@ -5540,6 +5544,10 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
               color: "error",
               priority: "immediate",
               timeoutMs: 10_000,
+              // The remediation lives at the tail of these messages
+              // (sandbox setup commands, failing paths); truncating to one
+              // line hides exactly the part the user needs.
+              wrap: true,
             });
             setPendingSubmission(false);
             const rolledBack =
@@ -5642,6 +5650,10 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           color: "error",
           priority: "immediate",
           timeoutMs: 10_000,
+          // The remediation lives at the tail of these messages (sandbox
+          // setup commands, failing paths); truncating to one line hides
+          // exactly the part the user needs.
+          wrap: true,
         });
         // Submit threw before turn_started arrived — clear the
         // pending-submission spinner so the UI doesn't lie about

--- a/runtime/src/tui/components/PromptInput/Notifications.tsx
+++ b/runtime/src/tui/components/PromptInput/Notifications.tsx
@@ -272,7 +272,7 @@ function NotificationContent({
       <IdeStatusIndicator ideSelection={ideSelection} mcpClients={mcpClients} />
       {notifications.current && ('jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
             {notifications.current.jsx}
-          </Text> : <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
+          </Text> : <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap={notifications.current.wrap === true ? "wrap" : "truncate"}>
             {notifications.current.text}
           </Text>)}
       {isInOverageMode && !isTeamOrEnterprise && <Box>

--- a/runtime/src/tui/context/notifications.tsx
+++ b/runtime/src/tui/context/notifications.tsx
@@ -25,6 +25,12 @@ type BaseNotification = {
 type TextNotification = BaseNotification & {
   text: string;
   color?: keyof Theme;
+  /**
+   * Render the text wrapped across lines instead of truncated to one.
+   * For notifications whose tail carries the actionable part (a remediation
+   * command, a failing path), truncation hides exactly what the user needs.
+   */
+  wrap?: boolean;
 };
 type JSXNotification = BaseNotification & {
   jsx: React.ReactNode;

--- a/runtime/tests/tui/components/PromptInput/Notifications.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/Notifications.test.tsx
@@ -15,6 +15,7 @@ const harness = vi.hoisted(() => ({
             color?: string
             key: string
             text?: string
+            wrap?: boolean
             jsx?: React.ReactNode
           },
       queue: [] as unknown[],
@@ -368,6 +369,43 @@ afterEach(() => {
 })
 
 describe('Notifications', () => {
+  test('wraps opted-in notifications so the remediation tail stays readable', async () => {
+    // Terminal is 120 columns; this message is deliberately longer so a
+    // truncating render would drop the trailing remediation.
+    const remediation = 'run `agenc doctor --apparmor-profile` and reload'
+    harness.appState.notifications.current = {
+      color: 'error',
+      key: 'prompt-submit-failed',
+      text: `Message not sent: [sandbox_probe_failed] required sandbox blocked startup: probe failed because the kernel refused the namespace. ${remediation}`,
+      wrap: true,
+    }
+    const rendered = await renderNotifications({})
+
+    try {
+      expect(rendered.output()).toContain('Message not sent:')
+      expect(rendered.output()).toContain(remediation)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('still truncates notifications that do not opt into wrapping', async () => {
+    const tail = 'TAIL_MARKER_THAT_MUST_BE_TRUNCATED_AWAY'
+    harness.appState.notifications.current = {
+      color: 'error',
+      key: 'plain-long',
+      text: `Message not sent: ${'x'.repeat(200)} ${tail}`,
+    }
+    const rendered = await renderNotifications({})
+
+    try {
+      expect(rendered.output()).toContain('Message not sent:')
+      expect(rendered.output()).not.toContain(tail)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('renders status rows and wires env hook notifications', async () => {
     harness.appState.notifications.current = {
       color: 'success',


### PR DESCRIPTION
Dogfood follow-up. When a message fails to send, the footer showed 'Message not sent: [sandbox_probe_failed] required sandbox blocked startup: ... Ubuntu AppArmor…' — truncated exactly where the remediation begins, with no way to read the rest.

Text notifications can now opt into wrapping via a `wrap` flag; the three prompt-submit failure sites in App.tsx set it. Every other notification still truncates, so no other footer row changes height.

Two tests: a long opted-in notification keeps its tail, and a long opted-out one is still truncated. The wrap test is revert-sensitive. 227 tests pass across PromptInput and context; typecheck clean.

https://claude.ai/code/session_01BNuWCAhA3GgUp8vLhqaQmc