### PR TITLE
feat(runtime): record the daemon websocket url for client discovery

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -2070,6 +2070,9 @@ async function runAgenCDaemonForeground(
             commit: distVersion.commit,
             buildTime: distVersion.buildTime,
             startedAt: new Date().toISOString(),
+            // Records the port actually bound, which is not the default when
+            // another daemon already holds it and the listener fell back.
+            webSocketUrl: webSocketAddress.url,
           });
           cleanup.register("daemon-runtime-info", async () => {
             removeDaemonRuntimeInfo(runtimeInfoPath);

--- a/runtime/src/app-server/daemon-runtime-info.ts
+++ b/runtime/src/app-server/daemon-runtime-info.ts
@@ -59,6 +59,14 @@ export interface DaemonRuntimeInfo {
   readonly commit: string;
   readonly buildTime: string;
   readonly startedAt: string;
+  /**
+   * The websocket URL this daemon actually bound. Optional: readers must
+   * tolerate its absence (older daemons, and any daemon whose websocket
+   * listener is unavailable). Clients that would otherwise assume the fixed
+   * default port need this, because a daemon whose default port was taken
+   * falls back to an ephemeral one.
+   */
+  readonly webSocketUrl?: string;
 }
 
 const AGENC_DAEMON_RUNTIME_INFO_FILENAME = "daemon-runtime.json";
@@ -124,6 +132,10 @@ export function readDaemonRuntimeInfo(
       commit: parsed.commit,
       buildTime: parsed.buildTime,
       startedAt: parsed.startedAt,
+      ...(typeof parsed.webSocketUrl === "string" &&
+        parsed.webSocketUrl.length > 0
+        ? { webSocketUrl: parsed.webSocketUrl }
+        : {}),
     };
   } catch {
     return null;

--- a/runtime/src/bin/remote-cli.ts
+++ b/runtime/src/bin/remote-cli.ts
@@ -21,6 +21,10 @@ import QRCode from "qrcode";
 import WebSocket from "ws";
 
 import { remoteAuthSessionTokenSync } from "../auth/session-state.js";
+import {
+  readDaemonRuntimeInfo,
+  resolveAgenCDaemonRuntimeInfoPath,
+} from "../app-server/daemon-runtime-info.js";
 
 const DEFAULT_BACKEND = "https://id.agenc.ag";
 const REMOTE_LOGIN_REQUIRED_MESSAGE =
@@ -51,7 +55,8 @@ export function formatAgenCRemoteCliHelpText(): string {
     "",
     "Environment:",
     "  AGENC_BACKEND_URL   Identity backend (default https://id.agenc.ag).",
-    "  AGENC_DAEMON_URL    Local daemon (default ws://127.0.0.1:7766).",
+    "  AGENC_DAEMON_URL    Local daemon (default: the URL the running daemon",
+    "                      recorded, else ws://127.0.0.1:7766).",
   ].join("\n");
 }
 
@@ -84,7 +89,16 @@ function backendUrl(): string {
 }
 function daemonUrl(): string {
   const env = process.env.AGENC_DAEMON_URL;
-  return env && env.trim() ? env.trim() : "ws://127.0.0.1:7766";
+  if (env && env.trim()) return env.trim();
+  // The running daemon records the port it actually bound, which is not the
+  // default when that port was already taken and the listener fell back.
+  // Falling back to the fixed default keeps older daemons reachable.
+  const recorded = readDaemonRuntimeInfo(
+    resolveAgenCDaemonRuntimeInfoPath(resolveAgencHome()),
+  )?.webSocketUrl;
+  return recorded !== undefined && recorded.length > 0
+    ? recorded
+    : "ws://127.0.0.1:7766";
 }
 
 function readPairFile(): PairFile | null {

--- a/runtime/tests/app-server/daemon-runtime-info.contract.test.ts
+++ b/runtime/tests/app-server/daemon-runtime-info.contract.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readDaemonRuntimeInfo,
+  resolveAgenCDaemonRuntimeInfoPath,
+  writeDaemonRuntimeInfo,
+} from "../../src/app-server/daemon-runtime-info.js";
+
+const BASE_INFO = {
+  pid: 4242,
+  runtimeVersion: "0.14.2",
+  commit: "abc123",
+  buildTime: "2026-08-07T00:00:00.000Z",
+  startedAt: "2026-08-07T00:00:01.000Z",
+} as const;
+
+describe("daemon runtime info sidecar", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-runtime-info-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("round-trips the bound websocket url", () => {
+    const path = resolveAgenCDaemonRuntimeInfoPath(home);
+    writeDaemonRuntimeInfo(path, {
+      ...BASE_INFO,
+      webSocketUrl: "ws://127.0.0.1:40117/",
+    });
+
+    expect(readDaemonRuntimeInfo(path)).toEqual({
+      ...BASE_INFO,
+      webSocketUrl: "ws://127.0.0.1:40117/",
+    });
+  });
+
+  it("reads sidecars written by daemons that recorded no websocket url", () => {
+    // Older daemons wrote no webSocketUrl at all; a reader that required it
+    // would treat every pre-upgrade daemon as unreadable and force a respawn.
+    const path = resolveAgenCDaemonRuntimeInfoPath(home);
+    writeFileSync(path, `${JSON.stringify(BASE_INFO, null, 2)}\n`);
+
+    const info = readDaemonRuntimeInfo(path);
+    expect(info).toEqual(BASE_INFO);
+    expect(info?.webSocketUrl).toBeUndefined();
+  });
+
+  it("drops a malformed websocket url instead of failing the whole read", () => {
+    const path = resolveAgenCDaemonRuntimeInfoPath(home);
+    writeFileSync(
+      path,
+      `${JSON.stringify({ ...BASE_INFO, webSocketUrl: 7766 }, null, 2)}\n`,
+    );
+
+    const info = readDaemonRuntimeInfo(path);
+    expect(info).toEqual(BASE_INFO);
+    expect(info?.webSocketUrl).toBeUndefined();
+  });
+
+  it("returns null when required skew fields are missing", () => {
+    const path = resolveAgenCDaemonRuntimeInfoPath(home);
+    writeFileSync(path, `${JSON.stringify({ pid: 1 }, null, 2)}\n`);
+
+    expect(readDaemonRuntimeInfo(path)).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #1684. That PR let a daemon survive a websocket port collision by binding an ephemeral port, which left a gap: clients still assumed the fixed default 7766, so they could reach a different daemon than the one they meant (as happened on my machine, where a stale dev daemon held 7766 while the live daemon sat elsewhere).

The daemon now records the URL it actually bound in daemon-runtime.json, and `agenc remote` prefers that over the hardcoded default. AGENC_DAEMON_URL still wins over both.

The field is optional on read: daemons that predate it parse fine, so a pre-upgrade daemon is not mistaken for a corrupt sidecar and needlessly respawned. A malformed value is dropped rather than failing the whole read.

Verified live: a fresh daemon records `"webSocketUrl": "ws://127.0.0.1:44287/"` matching its listener line. New contract test covers round-trip, the legacy no-URL sidecar, a malformed URL, and missing required fields; 66 tests pass alongside daemon-cli; typecheck and build clean.

https://claude.ai/code/session_01BNuWCAhA3GgUp8vLhqaQmc