### PR TITLE
fix(runtime): reap superseded daemons serving the same home

### DIFF
--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -82,6 +82,15 @@ export interface AgenCDaemonAutostartOptions {
   readonly findOrphanDaemonPids?: (
     targetHome: string,
   ) => Promise<readonly number[]> | readonly number[];
+  /**
+   * Daemons serving this home from any install, used to reap the ones the pid
+   * file cannot track. Defaults to a /proc scan; when `findOrphanDaemonPids`
+   * is stubbed without this, reaping is skipped so orphan-path tests keep
+   * their exact kill expectations.
+   */
+  readonly findSupersededDaemonPids?: (
+    targetHome: string,
+  ) => Promise<readonly number[]> | readonly number[];
   readonly terminateOrphanDaemonPid?: (pid: number) => Promise<void> | void;
 }
 
@@ -230,6 +239,14 @@ export async function ensureAgenCDaemonAutostart(
     throw new AgenCDaemonAutostartError("AgenC daemon pid file was not written");
   }
 
+  await reapSupersededAgenCDaemons({
+    daemonHome,
+    keepPid: pid,
+    host,
+    options,
+    io,
+  });
+
   const target = { pid, pidPath };
   const ready = await waitForAgenCDaemonReady(target, host, options);
   if (ready === "exited") {
@@ -302,6 +319,54 @@ async function recoverPidlessAgenCDaemon(params: {
   return null;
 }
 
+/**
+ * Terminate daemons serving `daemonHome` that are not the tracked `keepPid`.
+ *
+ * A home has exactly one pid file, so a second live daemon for it is
+ * untracked by construction: nothing will ever stop it, and it competes for
+ * the same state and the fixed websocket port. Upgrades produced these
+ * routinely, because a superseded daemon runs from a version-stamped runtime
+ * directory that no longer matches the current entrypoint.
+ */
+async function reapSupersededAgenCDaemons(params: {
+  readonly daemonHome: string;
+  readonly keepPid: number;
+  readonly host: AgenCDaemonCliHost;
+  readonly options: AgenCDaemonAutostartOptions;
+  readonly io: AgenCDaemonCliIo;
+}): Promise<readonly number[]> {
+  // Tests that stub orphan discovery drive that path explicitly; don't invent
+  // extra kills underneath them unless they opt in.
+  if (
+    params.options.findSupersededDaemonPids === undefined &&
+    params.options.findOrphanDaemonPids !== undefined
+  ) {
+    return [];
+  }
+  const superseded = [
+    ...await Promise.resolve(
+      params.options.findSupersededDaemonPids?.(params.daemonHome) ??
+        findPidlessAgenCDaemonPids(
+          params.host,
+          params.daemonHome,
+          "any-install",
+        ),
+    ),
+  ].filter((pid) => pid !== params.keepPid && params.host.isPidRunning(pid));
+  if (superseded.length === 0) return [];
+
+  params.io.stderr.write(
+    `agenc: stopping ${superseded.length} superseded daemon(s) for this home ` +
+      `(pid ${superseded.join(", ")})\n`,
+  );
+  await Promise.all(
+    superseded.map((pid) =>
+      terminatePidlessAgenCDaemonPid(pid, params.host, params.options),
+    ),
+  );
+  return superseded;
+}
+
 async function terminatePidlessAgenCDaemonPid(
   pid: number,
   host: AgenCDaemonCliHost,
@@ -339,11 +404,37 @@ async function isAgenCDaemonSocketPresent(socketPath: string): Promise<boolean> 
   }
 }
 
+/**
+ * True when `value` looks like an agenc runtime entrypoint from any install.
+ * Superseded daemons live under a version-stamped runtime directory
+ * (`.../.agenc/runtime/<version>/.../bin/agenc`), so their entrypoint never
+ * equals the current one — matching on shape is what makes them visible.
+ */
+function isAgenCDaemonEntrypointPath(value: string): boolean {
+  const base = value.split(/[\\/]/u).pop() ?? "";
+  return base === "agenc" || base === "agenc.js" || base === "agenc-main.js";
+}
+
+/**
+ * Find daemon processes serving `daemonHome` that the pid file does not track.
+ *
+ * `entrypointMatch: "exact"` restricts the result to daemons running this very
+ * runtime build — the only ones safe to ADOPT, since adopting a daemon from
+ * another build reintroduces the missing-chunk hang that runtime-info skew
+ * detection exists to prevent.
+ *
+ * `entrypointMatch: "any-install"` also returns daemons from other installs or
+ * versions of agenc. Those are only ever TERMINATED: a home has exactly one
+ * pid file, so a second daemon serving it is untracked by construction, and
+ * before this it survived every upgrade and accumulated indefinitely.
+ */
 async function findPidlessAgenCDaemonPids(
   host: AgenCDaemonCliHost,
   daemonHome: string,
+  entrypointMatch: "exact" | "any-install" = "exact",
 ): Promise<readonly number[]> {
-  if (process.platform !== "linux" || host.entrypointPath.length === 0) {
+  if (process.platform !== "linux") return [];
+  if (entrypointMatch === "exact" && host.entrypointPath.length === 0) {
     return [];
   }
   let entries: readonly import("node:fs").Dirent[];
@@ -353,7 +444,8 @@ async function findPidlessAgenCDaemonPids(
     return [];
   }
 
-  const expectedEntrypoint = resolve(host.entrypointPath);
+  const expectedEntrypoint =
+    host.entrypointPath.length > 0 ? resolve(host.entrypointPath) : null;
   const expectedHome = resolve(daemonHome);
   const pids: number[] = [];
   for (const entry of entries) {
@@ -370,7 +462,13 @@ async function findPidlessAgenCDaemonPids(
     const argv = await readProcList(join(procDir, "cmdline"));
     const entrypointIndex = argv.findIndex((value) => {
       try {
-        return resolve(value) === expectedEntrypoint;
+        if (expectedEntrypoint !== null && resolve(value) === expectedEntrypoint) {
+          return true;
+        }
+        return (
+          entrypointMatch === "any-install" &&
+          isAgenCDaemonEntrypointPath(value)
+        );
       } catch {
         return false;
       }

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -296,6 +296,67 @@ port = 0
     await rm(agencHome, { recursive: true, force: true });
   });
 
+  it("reaps superseded same-home daemons while keeping the tracked one", async () => {
+    // The accumulation case: upgrades leave daemons running from
+    // version-stamped runtime directories that the pid file cannot track.
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    host.runningPids.add(5300);
+    host.runningPids.add(5401);
+    host.runningPids.add(5402);
+    await writeAgenCDaemonPid(pidPath, 5300);
+    const terminated: number[] = [];
+
+    try {
+      await expect(
+        ensureAgenCDaemonAutostart({
+          host,
+          isReady: ({ pid }) => pid === 5300,
+          findSupersededDaemonPids: () => [5300, 5401, 5402],
+          terminateOrphanDaemonPid: (pid) => {
+            terminated.push(pid);
+            host.runningPids.delete(pid);
+          },
+        }),
+      ).resolves.toMatchObject({ pid: 5300, status: "already-running" });
+
+      // The tracked daemon survives; only the untrackable ones are stopped.
+      expect(terminated.sort()).toEqual([5401, 5402]);
+      expect(host.runningPids.has(5300)).toBe(true);
+      await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(5300);
+      expect(host.spawnedPids).toEqual([]);
+    } finally {
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps orphan-path kill expectations when only orphan discovery is stubbed", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    host.runningPids.add(5300);
+    await writeAgenCDaemonPid(pidPath, 5300);
+    const terminated: number[] = [];
+
+    try {
+      await expect(
+        ensureAgenCDaemonAutostart({
+          host,
+          isReady: ({ pid }) => pid === 5300,
+          findOrphanDaemonPids: () => [9001],
+          terminateOrphanDaemonPid: (pid) => {
+            terminated.push(pid);
+          },
+        }),
+      ).resolves.toMatchObject({ pid: 5300, status: "already-running" });
+
+      expect(terminated).toEqual([]);
+    } finally {
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
   it("adopts a pidless daemon when its socket is present", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);


### PR DESCRIPTION
Dogfood finding: eight agenc daemons across four versions (0.12.0, 0.14.0 x2, 0.14.1 x2, plus dev builds) were running simultaneously on my machine, several serving the same home.

A home has exactly one pid file, so a second live daemon for it is untracked by construction: nothing ever stops it, and it competes for the same state and the fixed websocket port (that stale dev daemon holding 7766 is what motivated #1684 and #1688). They accumulated because orphan discovery matched only the current runtime's entrypoint path, and a superseded daemon runs from a version-stamped runtime directory that never matches it.

Discovery can now also match agenc entrypoints from any install. That wider set is only ever TERMINATED, never adopted: adopting a foreign-build daemon would reintroduce the missing-chunk hang that runtime-info skew detection exists to prevent. The tracked daemon is always kept, and tests that stub orphan discovery keep their exact kill expectations unless they opt into the new hook.

Verified against real processes, not just mocks: orphaned a live daemon the way reality does it (removed its socket so a replacement rebinds), started a second daemon, confirmed both alive, then started the TUI — the orphan was terminated and the tracked daemon survived. A separate run confirmed a normal CLI invocation never touches the tracked daemon. New contract test is revert-sensitive; 705 tests pass across app-server; typecheck and build clean.

https://claude.ai/code/session_01BNuWCAhA3GgUp8vLhqaQmc