### PR TITLE
fix(runtime): settle Write guard refusals as confirmed_no_effect

### DIFF
--- a/runtime/src/tools/system/file-write.ts
+++ b/runtime/src/tools/system/file-write.ts
@@ -59,6 +59,7 @@ import {
   isAgentNamespacePath,
 } from "./agent-path-hints.js";
 import { checkToolPathPermission } from "../../permissions/path-validation.js";
+import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 import { notifyLspFileChanged } from "../../services/lsp/fileNotifications.js";
 import {
   prepareWorkspaceMutation,
@@ -118,6 +119,50 @@ const NOTEBOOK_REDIRECT_MESSAGE =
  */
 const SESSION_ID_MISSING_ERROR =
   "Write was invoked without a session id for an existing file. The runtime injects this automatically; if you are calling the tool from a unit test, pass __testBypassSessionGuard:true to opt out of read-before-write enforcement.";
+
+/**
+ * Brand a guard refusal that happens strictly before any byte is written.
+ *
+ * The effect boundary is marked crossed the moment dispatch hands control to
+ * `tool.execute` (tools/execution.ts), so every refusal below — argument
+ * validation, path admission, read-before-write, drift detection, size caps —
+ * reaches the settlement supervisor as an errored side-effecting call. Without
+ * an authoritative disposition the supervisor cannot tell "refused before
+ * touching the file" from "may have half-written it", so it poisons the live
+ * effect and blocks all further side-effecting and interactive dispatch for the
+ * rest of the session (budget/admitted-tool-call.ts).
+ *
+ * These paths provably wrote nothing, so they carry `confirmed_no_effect` and
+ * settle cleanly. Mirrors `preMutationErrorResult` in file-edit.ts.
+ *
+ * Deliberately NOT used for failures raised once the write transaction is
+ * under way: a partially committed write is genuinely unknown, and poisoning
+ * is the correct outcome there.
+ */
+function preMutationErrorResult(message: string): ToolResult {
+  return {
+    ...errorResult(message),
+    effectDisposition: createToolEffectDispositionEvidence({
+      disposition: "confirmed_no_effect",
+      evidenceKind: "boundary_not_crossed",
+      evidenceRef: `tool:${FILE_WRITE_TOOL_NAME}:pre-mutation`,
+      evidenceMaterial: message,
+    }),
+  };
+}
+
+/** Attach pre-mutation no-effect evidence to an already-built refusal. */
+function asPreMutationRefusal(result: ToolResult): ToolResult {
+  return {
+    ...result,
+    effectDisposition: createToolEffectDispositionEvidence({
+      disposition: "confirmed_no_effect",
+      evidenceKind: "boundary_not_crossed",
+      evidenceRef: `tool:${FILE_WRITE_TOOL_NAME}:admission-rejected`,
+      evidenceMaterial: String(result.content ?? ""),
+    }),
+  };
+}
 
 /**
  * Test-only opt-out of the read-before-write session guard. Production
@@ -274,24 +319,24 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
 
       const filePath = asNonEmptyString(args.file_path);
       if (!filePath) {
-        return errorResult("file_path must be a non-empty string");
+        return preMutationErrorResult("file_path must be a non-empty string");
       }
       const content = asString(args.content);
       if (content === undefined) {
-        return errorResult("content must be a string");
+        return preMutationErrorResult("content must be a string");
       }
 
       const cwdArg = asNonEmptyString(args.cwd);
       const cwd = cwdArg ?? allowedPaths[0] ?? process.cwd();
       if (isAgentNamespacePath(filePath)) {
-        return errorResult(agentNamespacePathHint(filePath, cwd));
+        return preMutationErrorResult(agentNamespacePathHint(filePath, cwd));
       }
 
       // Notebook redirect — AgenC routes `.ipynb` to NotebookEdit
       // instead of allowing a raw text write that would corrupt the
       // notebook's JSON envelope.
       if (filePath.toLowerCase().endsWith(".ipynb")) {
-        return errorResult(NOTEBOOK_REDIRECT_MESSAGE);
+        return preMutationErrorResult(NOTEBOOK_REDIRECT_MESSAGE);
       }
 
       const absoluteInput = resolve(cwd, filePath);
@@ -302,7 +347,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
         rawArgs,
       );
       if (!safe.safe) {
-        return errorResult(
+        return preMutationErrorResult(
           `file_path is outside allowed directories: ${filePath}` +
             (safe.reason ? ` (${safe.reason})` : ""),
         );
@@ -328,14 +373,16 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
       try {
         const result = await stat(absolutePath);
         if (result.isDirectory()) {
-          return errorResult(`file_path resolves to a directory: ${filePath}`);
+          return preMutationErrorResult(
+            `file_path resolves to a directory: ${filePath}`,
+          );
         }
         existed = true;
         existingStat = { mtimeMs: result.mtimeMs };
       } catch (err) {
         const code = (err as NodeJS.ErrnoException)?.code;
         if (code !== "ENOENT") {
-          return errorResult(
+          return preMutationErrorResult(
             code
               ? `${code}: stat failed for ${filePath}`
               : `stat failed for ${filePath}`,
@@ -350,7 +397,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
       // `Edit`'s gate.
       if (existed && sessionId !== undefined) {
         if (!hasSessionRead(sessionId, absolutePath)) {
-          return errorResult(READ_REQUIRED_MESSAGE);
+          return preMutationErrorResult(READ_REQUIRED_MESSAGE);
         }
 
         // Modification-since-read drift check. A FULL read carries the
@@ -382,14 +429,14 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
             existingContentForUi = onDisk;
           } catch (err) {
             const code = (err as NodeJS.ErrnoException)?.code;
-            return errorResult(
+            return preMutationErrorResult(
               code
                 ? `${code}: failed to re-read ${filePath} before overwrite`
                 : `failed to re-read ${filePath} before overwrite`,
             );
           }
           if (onDisk !== normalizeNewlines(snapshotContent as string)) {
-            return errorResult(FILE_UNEXPECTEDLY_MODIFIED_MESSAGE);
+            return preMutationErrorResult(FILE_UNEXPECTEDLY_MODIFIED_MESSAGE);
           }
         } else {
           // Partial-read fallback: reject only when the on-disk mtime
@@ -402,7 +449,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
             Number.isFinite(recordedTs) &&
             existingStat.mtimeMs > recordedTs
           ) {
-            return errorResult(FILE_UNEXPECTEDLY_MODIFIED_MESSAGE);
+            return preMutationErrorResult(FILE_UNEXPECTEDLY_MODIFIED_MESSAGE);
           }
           // Populate the UI snapshot from disk best-effort.
           try {
@@ -424,7 +471,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
         // overwriting and clobbering concurrent external modifications.
         // Tests opt out explicitly via __testBypassSessionGuard:true.
         if (!shouldBypassSessionGuard(rawArgs)) {
-          return errorResult(SESSION_ID_MISSING_ERROR);
+          return preMutationErrorResult(SESSION_ID_MISSING_ERROR);
         }
         if (existingStat !== null) {
           try {
@@ -438,7 +485,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
 
       const data = Buffer.from(content, "utf-8");
       if (data.length > maxWriteBytes) {
-        return errorResult(
+        return preMutationErrorResult(
           `Content size ${data.length} bytes exceeds limit of ${maxWriteBytes} bytes`,
         );
       }
@@ -455,7 +502,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
           ...(toolCallId !== undefined ? { toolCallId } : {}),
         });
         const rejection = workspaceMutationAdmissionToolResult(admission);
-        if (rejection !== null) return rejection;
+        if (rejection !== null) return asPreMutationRefusal(rejection);
         await executeWorkspaceFileMutation({
           admission,
           path: absolutePath,

--- a/runtime/tests/tools/system/file-write.test.ts
+++ b/runtime/tests/tools/system/file-write.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../services/lsp/fileNotifications.js", () => ({
   notifyLspFileChanged: vi.fn(),
 }));
 
+import type { ToolResult } from "../types.js";
 import { createFileWriteTool } from "./file-write.js";
 import {
   clearSessionReadState,
@@ -191,6 +192,138 @@ describe("Write tool", () => {
     );
     // The original content must be untouched.
     await expect(readFile(target, "utf8")).resolves.toBe("alpha\nbeta\n");
+  });
+
+  describe("pre-mutation refusals settle as confirmed_no_effect", () => {
+    // Regression: the effect boundary is marked crossed before `execute` runs,
+    // so a guard refusal reached the settlement supervisor as an errored
+    // side-effecting call with no disposition. That poisoned the live effect
+    // and blocked every later side-effecting and interactive dispatch for the
+    // rest of the session. Guards that provably wrote nothing must say so.
+    const expectNoEffect = (result: ToolResult) => {
+      expect(result.isError).toBe(true);
+      expect(result.effectDisposition).toMatchObject({
+        disposition: "confirmed_no_effect",
+        evidenceKind: "boundary_not_crossed",
+      });
+      expect(result.effectDisposition?.evidenceSha256).toMatch(
+        /^[0-9a-f]{64}$/u,
+      );
+    };
+
+    test("read-before-write refusal", async () => {
+      const target = join(root, "unread.txt");
+      await writeFile(target, "alpha\n", "utf8");
+
+      const tool = createFileWriteTool({ allowedPaths: [root] });
+      expectNoEffect(
+        await tool.execute({
+          file_path: target,
+          content: "DIFFERENT\n",
+          __agencSessionId: sessionId,
+        }),
+      );
+      await expect(readFile(target, "utf8")).resolves.toBe("alpha\n");
+    });
+
+    test("modified-since-read refusal", async () => {
+      const target = join(root, "drifted.txt");
+      await writeFile(target, "alpha\n", "utf8");
+      recordSessionRead(sessionId, target, "stale snapshot\n");
+
+      const tool = createFileWriteTool({ allowedPaths: [root] });
+      expectNoEffect(
+        await tool.execute({
+          file_path: target,
+          content: "DIFFERENT\n",
+          __agencSessionId: sessionId,
+        }),
+      );
+      await expect(readFile(target, "utf8")).resolves.toBe("alpha\n");
+    });
+
+    test("path outside allowed directories", async () => {
+      const tool = createFileWriteTool({ allowedPaths: [root] });
+      expectNoEffect(
+        await tool.execute({
+          file_path: join(tmpdir(), "agenc-outside-allowed.txt"),
+          content: "nope\n",
+          __agencSessionId: sessionId,
+        }),
+      );
+    });
+
+    test("target resolves to a directory", async () => {
+      const dir = join(root, "a-directory");
+      await mkdir(dir);
+
+      const tool = createFileWriteTool({ allowedPaths: [root] });
+      expectNoEffect(
+        await tool.execute({
+          file_path: dir,
+          content: "nope\n",
+          __agencSessionId: sessionId,
+        }),
+      );
+    });
+
+    test("notebook redirect", async () => {
+      const tool = createFileWriteTool({ allowedPaths: [root] });
+      expectNoEffect(
+        await tool.execute({
+          file_path: join(root, "book.ipynb"),
+          content: "nope\n",
+          __agencSessionId: sessionId,
+        }),
+      );
+    });
+
+    test("content over the size cap", async () => {
+      const tool = createFileWriteTool({
+        allowedPaths: [root],
+        maxWriteBytes: 4,
+      });
+      expectNoEffect(
+        await tool.execute({
+          file_path: join(root, "too-big.txt"),
+          content: "far too much content\n",
+          __agencSessionId: sessionId,
+        }),
+      );
+      await expect(stat(join(root, "too-big.txt"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+
+    test("invalid arguments", async () => {
+      const tool = createFileWriteTool({ allowedPaths: [root] });
+      expectNoEffect(await tool.execute({ file_path: "", content: "x" }));
+      expectNoEffect(
+        await tool.execute({ file_path: join(root, "x.txt"), content: 42 }),
+      );
+    });
+
+    test("a failure raised mid-write does NOT claim no-effect", async () => {
+      // The write transaction is under way, so the outcome is genuinely
+      // unknown and must stay poisonable. Asserting the negative keeps the
+      // fix from being widened into "never poison on Write".
+      const target = join(root, "mid-write-failure.txt");
+      const tool = createFileWriteTool({
+        allowedPaths: [root],
+        __testAfterPreWriteCheck: async () => {
+          throw new Error("disk exploded mid-write");
+        },
+      });
+
+      const result = await tool.execute({
+        file_path: target,
+        content: "half a file\n",
+        __agencSessionId: sessionId,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.effectDisposition).toBeUndefined();
+    });
   });
 
   test("authorizes overwrite after a partial session read", async () => {


### PR DESCRIPTION
Fixes #1693.

## The defect

`AdmittedToolCall` poisons the live-effect supervisor whenever a non-idempotent tool returns `isError: true` without an explicit `effectDisposition` (`budget/admitted-tool-call.ts`). `recoveryCategory` defaults to `"side-effecting"`, so every tool is opted in unless it says otherwise.

The trap is that the effect boundary is marked crossed the moment dispatch hands control to `tool.execute` (`tools/execution.ts:2286`), before the tool runs a single line of its own logic. So the `!boundaryCrossed` branch that correctly settles as `not_crossed` can never fire for a tool's internal guard, and a refusal that touched nothing arrives looking exactly like a write that may have half-committed.

`file-write.ts` attached no dispositions anywhere. An ordinary `File has not been read yet. Read it first before writing to it.` therefore poisoned the session, and every later `Write`, `Edit`, `exec_command`, `spawn_agent`, and `WebSearch` failed with:

```
live effect settlement is unresolved for call-<id> (Write); side-effecting and interactive dispatch remain blocked
```

Observed locally across 7 sessions on 3 days, median 74 seconds from session start to unusable. Restarting clears the in-memory poison and then the next ordinary error re-triggers it, so it reads as the product breaking at random.

## The change

Refusals that provably wrote nothing now carry `confirmed_no_effect` with `boundary_not_crossed` evidence: argument validation, agent namespace, notebook redirect, path admission, directory target, stat failure, read-before-write, drift detection, size cap, and the workspace-coordinator admission rejection (which returns `blocked`/`proposal` before `commitMutation`, so no bytes are written).

This mirrors patterns already in the tree: `preMutationErrorResult` in `file-edit.ts` and `errorResult` in `system/bash.ts`. `exec-command.ts` was fixed the same way earlier. `file-write.ts` was the remaining gap on a mutation tool.

Failures raised once the write transaction is under way keep no disposition and stay poisonable. A partially committed write is genuinely unknown and that is precisely what the gate is for.

## Tests

Eight new cases in `tests/tools/system/file-write.test.ts`, including a negative test asserting a mid-write failure does **not** claim no-effect, so the fix cannot be widened into "never poison on Write".

Falsification-checked: with the source change reverted, 7 of the 8 fail. The 8th is the negative test, which correctly holds either way since nothing carries a disposition without the fix.

- `tsc --noEmit`: clean
- New block: 8 passed
- `tests/tools/system/file-write.test.ts`: 19 passed / 9 failed, against a baseline of 11 passed / 9 failed on `main`
- `tests/tools/system/file-edit.test.ts`, `file-write-session-guard.ihunt.test.ts`, `tests/budget`: 118 passed / 30 failed, byte-identical failure list before and after

## Note on the pre-existing failures

Those 9 and 30 failures reproduce unchanged on unmodified `main` on macOS, and the failing test names are identical before and after this change. Cause is the hermetic runner: `createHermeticRunRoot` hardcodes `base = '/tmp'` (`tests/helpers/hermetic-env.mjs:547`), and on macOS `/tmp` is a symlink to `/private/tmp`. Tests build paths under `/tmp/agv-…` while the tool canonicalizes to `/private/tmp/…`, so the session-read bookkeeping never matches. That produces exactly the observed family: "File has not been read yet", "modified since read", and ENOENT on the symlinked path. Out of scope here, worth its own issue.

## Not covered

- `services/Ledger/walletCli.ts` poisons on version-verification failure, but there the download and extraction already happened, so `confirmed_no_effect` would be wrong. It needs its own decision (clean up and report no-effect, or report `confirmed_committed`).
- Read-only tools (`file-read`, `grep`, `glob`, `orient`, `symbol-tools`) still default to `side-effecting`. They should be marked `idempotent` rather than given dispositions.
- `git-tools`, `filesystem`, `worktree`, `write-stdin`, `apply-patch` are side-effecting with no dispositions.
- The recovery path itself: `resolveLiveEffectPoison` is reachable only via the daemon RPC `resolveLiveEffectReview`. The TUI exposes nothing that reaches it, so a `requiresReview: true` record is written that the user has no way to review.
