### PR TITLE
fix(runtime): pin descriptor directory paths on darwin by inode identity

### DIFF
--- a/runtime/src/durability/offline-rollout.ts
+++ b/runtime/src/durability/offline-rollout.ts
@@ -537,6 +537,26 @@ function descriptorOperationPath(
       // pathname that can be replaced during offline mutation.
     }
   }
+  // darwin: realpathSync("/dev/fd/N") resolves back to "/dev/fd/N" rather than
+  // the target, so the alias comparison above can never match and the daemon
+  // refuses to recover any existing project state. Fall back to the canonical
+  // pathname only after proving through the retained descriptor that it is the
+  // same directory inode, which is the property the alias check was buying.
+  if (process.platform !== "win32") {
+    try {
+      const viaDescriptor = fstatSync(fd);
+      const viaPath = lstatSync(canonicalPath);
+      if (
+        viaPath.isDirectory() &&
+        viaDescriptor.dev === viaPath.dev &&
+        viaDescriptor.ino === viaPath.ino
+      ) {
+        return canonicalPath;
+      }
+    } catch {
+      // Fall through to the unavailable error below.
+    }
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## The defect

`descriptorOperationPath` (`runtime/src/durability/offline-rollout.ts`) accepts a descriptor alias only when `realpathSync("/dev/fd/N")` equals the canonical path. On darwin that call resolves back to `/dev/fd/N` rather than the target, so the comparison can never match, the function returns `undefined`, and every caller raises `OfflineRolloutDescriptorPathUnavailableError`.

On Linux the first candidate is `/proc/self/fd/N`, which resolves correctly, so the bug is macOS-only.

## Impact

Daemon recovery cannot pin any existing project directory:

```
agenc: daemon recovery excluded 3 run(s) pending operator recovery action
agenc: execution admission recovery excluded …/projects/…:
  offline canonical rollout cannot pin descriptor-relative directory path: …
```

After that every run fails, **including runs in a freshly created project directory**, because recovery of any one project blocks startup. A fresh `AGENC_HOME` works until the first daemon restart, then the home is stuck.

## The change

Fall back to the canonical pathname only after proving through the retained descriptor that it refers to the same directory inode: `fstatSync(fd)` and `lstatSync(canonicalPath)` must agree on `dev` and `ino`, and the path must still be a directory.

That is the property the alias comparison was buying, protection against the path being exchanged between open and use. It is now checked directly rather than inferred from a platform-specific alias that darwin does not implement the way the check assumed.

## Tests

`tests/durability/offline-rollout.test.ts` already covers this. No new test is added because the existing suite is the regression gate:

- On `main`, macOS: **7 failed (7)**
- With this change, macOS: **7 passed (7)**

That includes the cases asserting the swap-resistance property (`rejects an external binding and a source symlink without touching the target`), so the safety behaviour is verified, not just the happy path.

`tsc --noEmit` clean.

## Why CI did not catch it

The `macos-native` lane in `.github/workflows/platform-tests.yml` runs a hardcoded allowlist of test files and asserts exact counts against it. `tests/durability/` is not in that list, so this file is only ever exercised on Linux, where `/proc/self/fd` works. `grep -c offline-rollout .github/workflows/platform-tests.yml` returns 0.

Worth considering separately whether the macOS lane should cover more than the current allowlist, since a whole platform-specific durability path was silently broken.

## Provenance

This same fix has been running as a hand-applied local patch against installed runtimes on macOS since 0.10.0 (2026-07-27) and 0.14.0 (2026-08-05), carrying the note "Upstream fix belongs in agenc-core; re-apply this on every runtime upgrade until then". This upstreams it.
