### PR TITLE
fix(runtime): reserve the context window for provider-native server tool turns

### DIFF
--- a/runtime/src/budget/admitted-model-call.ts
+++ b/runtime/src/budget/admitted-model-call.ts
@@ -436,7 +436,27 @@ export async function runAdmittedModelCall(
     }
     accountingFailureReason = "token_accounting_unavailable";
   }
-  const maxInputTokens = accountingResult?.inputTokens ?? 0;
+  const countedInputTokens = accountingResult?.inputTokens ?? 0;
+  // Provider-native server tools (web_search, x_search, code_interpreter,
+  // file_search, mcp) execute on the provider side and feed their results back
+  // into the same turn's context. Token accounting can only count the messages
+  // this process sends, so the counted total systematically under-states the
+  // real input for these turns: an observed web_search reserved 2,565 tokens
+  // and reported 10,104, and reservations of ~2.6k against reported 48k-53k
+  // are routine. Reconciliation then sees actualTokens > reserved_tokens,
+  // flags provider_overrun, and sets blocked_by_provider_overrun on the
+  // allocation, which cancels every later step in the run. A single search
+  // takes down the whole session.
+  //
+  // The provider cannot feed back more than the context window, so that is the
+  // true upper bound for these turns. Reserve it instead of the uncountable
+  // estimate. This only widens the reservation; the authoritative reported
+  // usage is still what gets charged at reconciliation.
+  const maxInputTokens =
+    hasUnboundedPaidServerTool(accountingOptions) &&
+    contextWindowTokens > countedInputTokens
+      ? contextWindowTokens
+      : countedInputTokens;
   const unboundedPaidServerTool =
     hasHardCostCap && hasUnboundedPaidServerTool(accountingOptions);
   const maximumCost = maximumTokenCostUsd(

--- a/runtime/tests/budget/admitted-model-call.test.ts
+++ b/runtime/tests/budget/admitted-model-call.test.ts
@@ -465,6 +465,78 @@ describe("runAdmittedModelCall", () => {
     });
   });
 
+  test("reserves the context window for provider-native server tool turns", async () => {
+    // Regression: provider-native server tools run on the provider side and
+    // feed their results back into the same turn's context, so the counted
+    // input systematically under-states the real usage. Reserving the counted
+    // value made reconciliation see actualTokens > reserved_tokens, flag
+    // provider_overrun, and set blocked_by_provider_overrun on the allocation,
+    // which cancels every later step in the run. Observed live: a web_search
+    // turn reserved 2,565 and reported 10,104; reservations near 2.6k against
+    // 48k-53k reported were routine, and one search took down the session.
+    const state = harness({});
+    (state.provider as unknown as {
+      tokenCountCapability?: ProviderTokenCountCapability;
+    }).tokenCountCapability = {
+      capabilityVersion: "server-tool-count-v1",
+      adapterRevision: "server-tool-adapter-v1",
+      configurationRevision: "server-tool-config-v1",
+      countTokens: async () => ({
+        inputTokens: 40,
+        complete: true as const,
+        confidence: "exact" as const,
+        countedComponents: ["messages" as const, "provider_framing" as const],
+      }),
+    };
+
+    await callOptions(
+      state,
+      {
+        maxOutputTokens: 200,
+        contextWindowTokens: 90_000,
+        toolRouting: { allowedToolNames: ["web_search"] },
+      },
+      async () => response(),
+    );
+
+    // The provider cannot feed back more than the context window, so that is
+    // the honest upper bound for the turn, not the 40 counted tokens.
+    expect(state.acquire).toHaveBeenCalledWith(
+      expect.objectContaining({ maxInputTokens: 90_000 }),
+      undefined,
+    );
+  });
+
+  test("reserves only the counted input when no server tool is routed", async () => {
+    // The widened reservation must stay scoped to provider-native server
+    // tools; ordinary turns keep the tight counted bound.
+    const state = harness({});
+    (state.provider as unknown as {
+      tokenCountCapability?: ProviderTokenCountCapability;
+    }).tokenCountCapability = {
+      capabilityVersion: "plain-count-v1",
+      adapterRevision: "plain-adapter-v1",
+      configurationRevision: "plain-config-v1",
+      countTokens: async () => ({
+        inputTokens: 40,
+        complete: true as const,
+        confidence: "exact" as const,
+        countedComponents: ["messages" as const, "provider_framing" as const],
+      }),
+    };
+
+    await callOptions(
+      state,
+      { maxOutputTokens: 200, contextWindowTokens: 90_000 },
+      async () => response(),
+    );
+
+    expect(state.acquire).toHaveBeenCalledWith(
+      expect.objectContaining({ maxInputTokens: 40 }),
+      undefined,
+    );
+  });
+
   test("requires an authoritative bounded provider for token-only hard caps", async () => {
     const state = harness({ maxTokens: 1_000, authoritative: false });
 


### PR DESCRIPTION
## The defect

A model turn's token reservation is the client-side count of the messages being sent (`maxInputTokens = accountingResult.inputTokens`, `runtime/src/budget/admitted-model-call.ts`).

Provider-native server tools (`web_search`, `x_search`, `code_interpreter`, `file_search`, `mcp` — the set already enumerated by `paidServerToolNames`) execute **on the provider side** and feed their results back into that same turn's context. The client cannot count what the provider fetches, so for these turns the reservation systematically under-states the real input.

Reconciliation then computes overrun as `actualTokens > reservation.reserved_tokens` (`runtime/src/state/execution-admission.ts`), marks the reservation `provider_overrun`, and sets `blockByProviderOverrun`. From that point `blocked_by_provider_overrun === 1` makes every later admission in the run resolve to `allocation_blocked`.

**One search cancels the rest of the session**, including unrelated tool calls and model turns. The user-visible failure is an unrelated later step dying with:

```
AdmissionDeniedError: execution admission cancelled: provider_overrun
```

## Observed

Live on grok-4.5, from the run ledgers:

| step | reserved | actual |
|---|---|---|
| `web_search:…-407` | 2,657 | 48,070 |
| `web_search:…-154` | 2,618 | 53,361 |
| `web_search:…-75` | 2,565 | 10,104 |

Every one of them cancelled its run. This is not an edge case; a native web_search overruns essentially every time, because the gap is structural rather than a bad estimate.

Not a hard-cap issue either: these runs had no hard cost cap. Under a hard cost cap the call is already denied earlier by `unbounded_provider_tool_under_hard_cap`, so capped runs never reached this path.

## The change

When the turn routes an unbounded paid server tool, reserve `contextWindowTokens` instead of the counted input. The provider cannot feed back more than the context window, so that is the true upper bound for these turns.

This only ever **widens** the reservation. Authoritative reported usage is still what gets charged at reconciliation, so accounting accuracy is unchanged; what changes is that the reservation stops being an under-estimate that trips the overrun detector.

`maximumCost` derives from the same value, so the cost reservation widens consistently. Hard-capped runs are unaffected per the note above.

## Tests

Two new cases in `tests/budget/admitted-model-call.test.ts`:

- `reserves the context window for provider-native server tool turns` — the positive case
- `reserves only the counted input when no server tool is routed` — pins the scope so the widening cannot leak into ordinary turns

Falsification-checked: with the source change reverted, exactly the positive test fails (1 failed / 18 passed) and the scoping test still passes.

- `tsc --noEmit` clean
- `tests/budget/admitted-model-call.test.ts`: 19 passed, against a baseline of 17 passed on `main`
- The pre-existing suite passes identically before and after, so no regression

## End-to-end verification

Driven through the real interactive TUI over a pty, answering the actual permission dialogs rather than using headless print mode. The same search that previously cancelled the run:

```
web_search:sub-conv-msltpctw-50   reserved=501200  actual=53275  → reconciled
WebSearch     isError=False
exec_command  isError=False
overruns: 0    cancelled: 0
```

The 53,275 there is larger than the 48,070 that killed an earlier run, and the tool call after the search now executes, which is the behaviour that was lost.
