### PR TITLE
fix(runtime): stop dead-process state from permanently blocking a workspace

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -1446,12 +1446,14 @@ async function runAgenCDaemonForeground(
       recovery.requeued > 0 ||
       recovery.heldUnknown > 0 ||
       recovery.expired > 0 ||
-      recovery.detachedQueued > 0
+      recovery.detachedQueued > 0 ||
+      recovery.staleRunBindings > 0
     ) {
       io.stderr.write(
         `agenc: admission recovery databases=${recovery.databases} ` +
           `requeued=${recovery.requeued} held_unknown=${recovery.heldUnknown} ` +
-          `expired=${recovery.expired} detached=${recovery.detachedQueued}\n`,
+          `expired=${recovery.expired} detached=${recovery.detachedQueued} ` +
+          `stale_run_bindings=${recovery.staleRunBindings}\n`,
       );
     }
     // A failed project is excluded from admission, not fatal: the daemon

--- a/runtime/src/budget/execution-admission-kernel.ts
+++ b/runtime/src/budget/execution-admission-kernel.ts
@@ -136,6 +136,12 @@ export interface ExecutionAdmissionRecoverySummary {
   readonly heldUnknown: number;
   readonly expired: number;
   readonly detachedQueued: number;
+  /**
+   * Persisted run rows skipped because the same run id is already bound to
+   * another workspace. Stale data, not a live conflict — see the hydration
+   * loop in `#registerPaths`.
+   */
+  readonly staleRunBindings: number;
   /** Project databases whose recovery failed and was excluded from startup. */
   readonly failures: readonly ExecutionAdmissionRecoveryFailure[];
 }
@@ -169,7 +175,18 @@ export class ExecutionAdmissionKernel {
   readonly #scheduler = new AsyncLock<void>(undefined);
   readonly #byStatePath = new Map<string, WorkspaceBinding>();
   readonly #byWorkspace = new Map<string, WorkspaceBinding>();
-  readonly #runStatePath = new Map<string, string>();
+  /**
+   * runId -> owning workspace. `live` marks a binding made by an actual
+   * admission (bindClient / attach) rather than one replayed from a
+   * persisted row, so a stale claim can be taken over and a real one
+   * cannot.
+   */
+  readonly #runStatePath = new Map<
+    string,
+    { readonly statePath: string; readonly live: boolean }
+  >();
+  /** Monotonic; `initializeExistingState` reports the delta for its own pass. */
+  #staleRunBindingSkips = 0;
   readonly #active = new Map<string, ActiveCapacity>();
   readonly #pending = new Map<string, PendingAdmission>();
   readonly #listeners = new Map<
@@ -230,6 +247,7 @@ export class ExecutionAdmissionKernel {
       detachedQueued: 0,
     };
     const failures: ExecutionAdmissionRecoveryFailure[] = [];
+    const staleRunBindingsBefore = this.#staleRunBindingSkips;
     for (const paths of discoverStateDatabasePaths(this.#agencHome)) {
       try {
         const binding = this.#registerPaths(paths, paths.projectDir, false);
@@ -258,7 +276,11 @@ export class ExecutionAdmissionKernel {
         });
       }
     }
-    return { ...totals, failures };
+    return {
+      ...totals,
+      staleRunBindings: this.#staleRunBindingSkips - staleRunBindingsBefore,
+      failures,
+    };
   }
 
   bindClient(
@@ -654,7 +676,7 @@ export class ExecutionAdmissionKernel {
    */
   sumReconciledUsageByRunId(runId: string): AdmissionRunUsageSummary {
     this.#assertOpen();
-    const statePath = this.#runStatePath.get(runId);
+    const statePath = this.#runStatePath.get(runId)?.statePath;
     const bound =
       statePath === undefined ? undefined : this.#byStatePath.get(statePath);
     if (bound !== undefined) {
@@ -864,7 +886,17 @@ export class ExecutionAdmissionKernel {
     this.#byStatePath.set(paths.stateDbPath, binding);
     for (const alias of binding.aliases) this.#byWorkspace.set(alias, binding);
     for (const runId of binding.repository.listBoundRunIds()) {
-      this.#bindRunWorkspace(runId, binding);
+      // Hydration replays persisted rows; it does not admit anything. A run id
+      // already owned by another workspace here is stale data — the same
+      // conversation opened once under a different cwd leaves its id in two
+      // project databases — and throwing would exclude this whole workspace
+      // from admission for the life of the daemon. The user sees only
+      // "Message not sent: execution admission deny:
+      // admission_run_workspace_conflict" on every turn, with no way back
+      // short of deleting state. Skip the row; live binds still throw.
+      if (!this.#tryBindRunWorkspace(runId, binding, false)) {
+        this.#staleRunBindingSkips += 1;
+      }
     }
     if (recover) {
       // A newly discovered workspace is recovered before its first admission.
@@ -889,8 +921,8 @@ export class ExecutionAdmissionKernel {
         this.#byWorkspace.delete(alias);
       }
     }
-    for (const [runId, statePath] of this.#runStatePath) {
-      if (statePath === binding.paths.stateDbPath) {
+    for (const [runId, bound] of this.#runStatePath) {
+      if (bound.statePath === binding.paths.stateDbPath) {
         this.#runStatePath.delete(runId);
       }
     }
@@ -901,12 +933,39 @@ export class ExecutionAdmissionKernel {
     }
   }
 
+  /** Live bind: a run genuinely executing against two workspaces is a fault. */
   #bindRunWorkspace(runId: string, binding: WorkspaceBinding): void {
-    const existing = this.#runStatePath.get(runId);
-    if (existing !== undefined && existing !== binding.paths.stateDbPath) {
+    if (!this.#tryBindRunWorkspace(runId, binding, true)) {
       throw new AdmissionDeniedError("admission_run_workspace_conflict");
     }
-    this.#runStatePath.set(runId, binding.paths.stateDbPath);
+  }
+
+  /**
+   * Returns false when `runId` already belongs to a different workspace and
+   * that claim cannot be taken over.
+   *
+   * A `live` bind outranks a hydrated one: the hydrated claim is a row left
+   * behind in some other project database, and the run being admitted right
+   * now is, by definition, running here. Two live binds are a genuine fault.
+   */
+  #tryBindRunWorkspace(
+    runId: string,
+    binding: WorkspaceBinding,
+    live: boolean,
+  ): boolean {
+    const existing = this.#runStatePath.get(runId);
+    if (
+      existing !== undefined &&
+      existing.statePath !== binding.paths.stateDbPath &&
+      (existing.live || !live)
+    ) {
+      return false;
+    }
+    this.#runStatePath.set(runId, {
+      statePath: binding.paths.stateDbPath,
+      live: live || (existing?.live ?? false),
+    });
+    return true;
   }
 
   #scheduleDrain(): void {

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -750,8 +750,20 @@ export interface CollabAgentSpawnEndEvent {
   readonly status: AgentStatus;
 }
 
+/**
+ * The lifecycle statuses a collab agent can report on the wire.
+ *
+ * `idle` is not a `TaskStatus`: it is the relabel `registerAgentThreadTask`
+ * applies when a keep-alive worker finishes a turn but its lifecycle record
+ * stays non-terminal (tasks/agent-thread.ts). That relabel reaches this event,
+ * so the wire type has to admit it. It did not, and the value arrived here
+ * through a cast — a `collab_agent_status` carrying `"idle"` then failed
+ * canonical replay, which excluded the whole workspace from execution
+ * admission and made every later message fail with "canonical event_msg
+ * payload does not match the runtime schema".
+ */
 export type CollabAgentTaskStatus =
-  "pending" | "running" | "completed" | "failed" | "killed";
+  "pending" | "running" | "idle" | "completed" | "failed" | "killed";
 
 export interface CollabAgentStatusEvent {
   readonly callId: string;

--- a/runtime/src/state/execution-admission-canonical-recovery.ts
+++ b/runtime/src/state/execution-admission-canonical-recovery.ts
@@ -1,3 +1,5 @@
+import { join, resolve, sep } from "node:path";
+
 import type { AdmissionJournalEvent } from "../budget/admission-types.js";
 import {
   withPinnedOfflineRolloutLease,
@@ -116,6 +118,7 @@ export function recoverExecutionAdmissionCanonicalJournals(
   for (const row of runs) {
     const bindings = retainedBindings(
       durability.listJournalBindings(row.run_id),
+      driver.projectDir,
     );
     if (bindings.length === 0) continue;
     if (bindings.length > maxSources) {
@@ -334,15 +337,41 @@ function withPinnedBindings<T>(
 
 function retainedBindings(
   bindings: readonly RunJournalBinding[],
+  projectDir: string,
 ): readonly RunJournalBinding[] {
   return bindings.filter(
     (binding) =>
+      isBindingInsideProject(binding, projectDir) &&
       !(
         !binding.active &&
         binding.gapReason !== undefined &&
         binding.retiredThroughSequence !== undefined &&
         binding.firstAvailableSequence === undefined
       ),
+  );
+}
+
+/**
+ * A binding may name a rollout in ANOTHER project: resuming one conversation
+ * from a second cwd rebinds it there and leaves this project pointing at a
+ * foreign path. Pinning it raises OfflineRolloutUnsafePathError, which is the
+ * correct containment answer, but it aborts recovery for the whole workspace —
+ * observed as every message failing with "unsafe offline canonical rollout …
+ * path is outside this project's sessions/archived_sessions roots".
+ *
+ * The foreign rollout is not ours to read under any circumstance, so there is
+ * nothing to recover from it and dropping the binding loses nothing this
+ * project owns. The guard in `pinOfflineRollout` stays as the backstop.
+ */
+function isBindingInsideProject(
+  binding: RunJournalBinding,
+  projectDir: string,
+): boolean {
+  const root = resolve(projectDir);
+  const source = resolve(binding.sourcePath);
+  return (
+    source.startsWith(join(root, "sessions") + sep) ||
+    source.startsWith(join(root, "archived_sessions") + sep)
   );
 }
 

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -438,6 +438,9 @@ const isAgentStatus: Validator<AgentStatusPayload> = (
 const isCollabTaskStatus = oneOf<readonly CollabTaskStatus[]>(
   "pending",
   "running",
+  // A keep-alive worker between turns. Emitted as a bare string by
+  // registerAgentThreadTask's relabel, unlike the AgentStatus object form.
+  "idle",
   "completed",
   "failed",
   "killed",

--- a/runtime/src/workspace/mutation-coordinator.ts
+++ b/runtime/src/workspace/mutation-coordinator.ts
@@ -2700,9 +2700,37 @@ export class WorkspaceMutationCoordinator {
     return (
       this.#quarantineHydrationFailed ||
       this.#lease !== null ||
-      this.#buffers.size > 0 ||
+      this.#hasProtectedBuffer() ||
       this.#topologyTokens.size > 0
     );
+  }
+
+  /**
+   * A `disk_authoritative` buffer holds nothing an editor could lose: it says
+   * the file on disk IS the truth, which is exactly what `authorityForPath`
+   * reports for a path with no buffer entry at all. Counting those as
+   * protection meant a TUI that died without releasing its lease left its
+   * quarantine entries behind and, from the next daemon start on, every tool
+   * in that workspace was refused with "Tool 'exec_command' is blocked while
+   * this workspace has protected Editor authority" — with no live editor
+   * anywhere and nothing at risk.
+   *
+   * `editor_dirty` (unsaved editor content) and `stale_dirty` (quarantined,
+   * provenance unknown) still protect: a tool writing over either destroys
+   * state that exists nowhere else. A live lease is handled by the caller.
+   */
+  #hasProtectedBuffer(): boolean {
+    for (const state of this.#buffers.values()) {
+      // Hydration rewrites every persisted entry to `stale_dirty` and keeps
+      // what it actually was in `quarantinedFrom` — the same discriminator
+      // #synchronize uses to decide whether a quarantined path was dirty.
+      if (state.authority === "stale_dirty") {
+        if (state.quarantinedFrom !== "disk_authoritative") return true;
+        continue;
+      }
+      if (state.authority !== "disk_authoritative") return true;
+    }
+    return false;
   }
 
   #bufferConflictForTopologyTarget(

--- a/runtime/tests/budget/execution-admission-kernel.test.ts
+++ b/runtime/tests/budget/execution-admission-kernel.test.ts
@@ -614,6 +614,98 @@ describe("ExecutionAdmissionKernel recovery", () => {
         .some((event) => event.event === "denied"),
     ).toBe(false);
   });
+
+  // Regression: opening the TUI once from a stray cwd left the same run id in
+  // two project databases. On the next daemon start, hydrating the second one
+  // threw admission_run_workspace_conflict, which excluded that whole
+  // workspace from admission — every message in it came back
+  // "Message not sent: execution admission deny:
+  // admission_run_workspace_conflict", with no recovery short of deleting
+  // state. Persisted rows are stale data, not a live double-bind.
+  it("skips a stale cross-workspace run id instead of excluding the workspace", async () => {
+    const seeded = kernel("stale-binding-seed");
+    bind(seeded, "dup-run");
+    seeded.close();
+
+    const otherCwd = mkdtempSync(join(tmpdir(), "agenc-kernel-other-"));
+    mkdirSync(join(otherCwd, ".git"));
+    try {
+      const at = new Date().toISOString();
+      const driver = openStateDatabases({ cwd: otherCwd, agencHome: home });
+      driver
+        .prepareState<[string, null, string, string]>(
+          `INSERT INTO execution_admission_run_limits (
+             run_id, deadline_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?)`,
+        )
+        .run("dup-run", null, at, at);
+      driver.close();
+
+      const restarted = kernel("stale-binding-restart");
+      const summary = restarted.initializeExistingState();
+
+      expect(summary.failures).toEqual([]);
+      expect(summary.staleRunBindings).toBe(1);
+
+      // The workspace still admits work — the point of not excluding it.
+      const lease = await acquire(bind(restarted, "fresh-run"));
+      expect(lease.request.step.runId).toBe("fresh-run");
+    } finally {
+      rmSync(otherCwd, { recursive: true, force: true });
+    }
+  });
+
+  // Skipping the hydrated row is only half the fix: resuming the affected
+  // conversation live-binds the same id, and if the stale claim still owned it
+  // the user would be back to the same wall.
+  it("lets a live bind take over a run id claimed by a hydrated row", async () => {
+    const seeded = kernel("takeover-seed");
+    bind(seeded, "resumed-run");
+    seeded.close();
+
+    const otherCwd = mkdtempSync(join(tmpdir(), "agenc-kernel-takeover-"));
+    mkdirSync(join(otherCwd, ".git"));
+    try {
+      const at = new Date().toISOString();
+      const driver = openStateDatabases({ cwd: otherCwd, agencHome: home });
+      driver
+        .prepareState<[string, null, string, string]>(
+          `INSERT INTO execution_admission_run_limits (
+             run_id, deadline_at, created_at, updated_at
+           ) VALUES (?, ?, ?, ?)`,
+        )
+        .run("resumed-run", null, at, at);
+      driver.close();
+
+      const restarted = kernel("takeover-restart");
+      restarted.initializeExistingState();
+
+      const lease = await acquire(bind(restarted, "resumed-run"));
+      expect(lease.request.step.runId).toBe("resumed-run");
+    } finally {
+      rmSync(otherCwd, { recursive: true, force: true });
+    }
+  });
+
+  // A run genuinely trying to execute against two workspaces at once is still
+  // a fault; only the hydration path is forgiving.
+  it("still rejects a live bind of one run id to two workspaces", () => {
+    const value = kernel("live-conflict");
+    bind(value, "live-run");
+
+    const otherCwd = mkdtempSync(join(tmpdir(), "agenc-kernel-live-"));
+    mkdirSync(join(otherCwd, ".git"));
+    try {
+      expect(() =>
+        value.bindClient({
+          cwd: otherCwd,
+          scope: { runId: "live-run", sessionId: "live-run", autonomous: false },
+        }),
+      ).toThrowError(/admission_run_workspace_conflict/);
+    } finally {
+      rmSync(otherCwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("ExecutionAdmissionKernel active cancellation", () => {

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -260,9 +260,16 @@ describe("strict canonical journal contract", () => {
       ).toBe(true);
     }
 
+    // `idle` is the relabel registerAgentThreadTask applies to a keep-alive
+    // worker between turns (tasks/agent-thread.ts), and spawn.ts forwards it
+    // onto this event. It was missing here, so a real session that spawned a
+    // keep-alive agent wrote a record its own replay rejected: the workspace
+    // was then excluded from execution admission and every later message came
+    // back "canonical event_msg payload does not match the runtime schema".
     for (const status of [
       "pending",
       "running",
+      "idle",
       "completed",
       "failed",
       "killed",
@@ -277,6 +284,25 @@ describe("strict canonical journal contract", () => {
         `collab_agent_status rejected ${status}`,
       ).toBe(true);
     }
+
+    // The exact shape observed on disk: the full emitter payload, not just the
+    // required keys.
+    expect(
+      isCanonicalEventPayload("collab_agent_status", {
+        callId: "call-d402a742-12",
+        senderThreadId: "conv-msnc4pmz",
+        threadId: "1a57950f-c453-4551-a9a6-703fc2b1fe80",
+        agentPath: "/root/probe_usb_board",
+        agentNickname: "Molly",
+        agentRole: "worker",
+        agentRoleDisplayName: "Runner",
+        prompt: "identify the connected board",
+        model: "grok-4.5",
+        status: "idle",
+        toolUseCount: 7,
+        tokenCount: 1234,
+      }),
+    ).toBe(true);
 
     const completed = agentStatuses[3];
     expect(

--- a/runtime/tests/workspace/mutation-coordinator.test.ts
+++ b/runtime/tests/workspace/mutation-coordinator.test.ts
@@ -266,6 +266,110 @@ describe("WorkspaceMutationCoordinator", () => {
     expect(secondRegistry.hasProtectedEditorAuthority(workspaceRoot)).toBe(true);
   });
 
+  // Regression: a TUI that died without releasing its lease left its quarantine
+  // entries on disk, all of them `disk_authoritative`. From the next daemon
+  // start on, every tool in that workspace was refused with "Tool
+  // 'exec_command' is blocked while this workspace has protected Editor
+  // authority", with no editor running and nothing at risk — a
+  // `disk_authoritative` entry says the file on disk is the truth.
+  it("does not treat leftover disk-authoritative entries as protection", async () => {
+    const parent = await tempDirectory("agenc-coherence-stale-disk-");
+    const agencHome = await tempDirectory("agenc-coherence-stale-disk-home-");
+    const workspaceRoot = join(parent, "workspace");
+    await mkdir(workspaceRoot);
+    const content = "saved content\n";
+    const quarantinePath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "quarantine-v1.json",
+    );
+    await mkdir(dirname(quarantinePath), { recursive: true });
+    await writeFile(
+      quarantinePath,
+      `${JSON.stringify({
+        version: 1,
+        workspaceRoot,
+        entries: [
+          {
+            path: `${workspaceRoot}/HARDWARE.md`,
+            contentSha256: sha256(content),
+            contentBytes: Buffer.byteLength(content),
+            changedtick: 2,
+            epoch: 2,
+            editorInstanceId: "tui-editor-that-was-killed",
+            authority: "disk_authoritative",
+          },
+        ],
+        proposalCommitments: [],
+        proposalReceipts: [],
+        mutationIntents: [],
+        topologyIntents: [],
+        changeSequence: 0,
+        changes: [],
+      })}\n`,
+      "utf8",
+    );
+
+    const registry = new WorkspaceMutationCoordinatorRegistry({ agencHome });
+    expect(
+      registry.getOrCreate(workspaceRoot).hasProtectedEditorPaths(),
+    ).toBe(false);
+    expect(registry.hasProtectedEditorAuthority(workspaceRoot)).toBe(false);
+    // The tool barrier is the thing the user actually hits.
+    expect(() =>
+      registry.beginToolOperation(workspaceRoot, "exec_command"),
+    ).not.toThrow();
+  });
+
+  // The other half: unsaved editor content still blocks, because a tool writing
+  // over it destroys state that exists nowhere else.
+  it("still protects a workspace with leftover editor-dirty entries", async () => {
+    const parent = await tempDirectory("agenc-coherence-stale-dirty-");
+    const agencHome = await tempDirectory("agenc-coherence-stale-dirty-home-");
+    const workspaceRoot = join(parent, "workspace");
+    await mkdir(workspaceRoot);
+    const content = "unsaved editor content\n";
+    const quarantinePath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "quarantine-v1.json",
+    );
+    await mkdir(dirname(quarantinePath), { recursive: true });
+    await writeFile(
+      quarantinePath,
+      `${JSON.stringify({
+        version: 1,
+        workspaceRoot,
+        entries: [
+          {
+            path: `${workspaceRoot}/buffer.ts`,
+            contentSha256: sha256(content),
+            contentBytes: Buffer.byteLength(content),
+            changedtick: 3,
+            epoch: 2,
+            editorInstanceId: "tui-editor-that-was-killed",
+            authority: "editor_dirty",
+          },
+        ],
+        proposalCommitments: [],
+        proposalReceipts: [],
+        mutationIntents: [],
+        topologyIntents: [],
+        changeSequence: 0,
+        changes: [],
+      })}\n`,
+      "utf8",
+    );
+
+    const registry = new WorkspaceMutationCoordinatorRegistry({ agencHome });
+    expect(registry.getOrCreate(workspaceRoot).hasProtectedEditorPaths()).toBe(
+      true,
+    );
+    expect(() =>
+      registry.beginToolOperation(workspaceRoot, "exec_command"),
+    ).toThrow(WorkspaceMutationCoordinatorError);
+  });
+
   it.runIf(process.platform === "linux")(
     "does not migrate persisted Darwin state across distinct normalization siblings",
     async () => {


### PR DESCRIPTION
Four independent faults with the same shape: state left behind by a process
that died without releasing it made a live workspace unusable, with an opaque
error and no recovery short of deleting state by hand. They were found stacked
on one workspace, each masking the next — every message came back
`Message not sent: …` and there was no way out.

### What was wrong

**Admission conflict.** Hydrating persisted admission rows threw
`admission_run_workspace_conflict` when a run id appeared in two project
databases (one conversation resumed from a second cwd), excluding the whole
workspace from admission for the life of the daemon. Hydration replays rows; it
does not admit anything. It now skips the stale row and reports the count, and a
live bind takes over a hydrated claim so resuming that conversation works too.
Two *live* binds of one run id remain a hard fault.

**A record the runtime could not read back.** `collab_agent_status` was emitted
with a bare `"idle"` status that its own canonical validator rejected, so replay
refused the journal. Two records out of 47,716 disabled the workspace. `"idle"`
is a real state — a keep-alive worker between turns, relabelled by
`registerAgentThreadTask` — and it reached the event through a cast. It is now
part of the wire type and the validator.

**A binding pointing at another project.** A journal binding naming a rollout
inside a *different* project aborted recovery for the whole workspace. Refusing
to read a foreign rollout is correct and that guard stays; the binding is now
dropped before it is pinned.

**Editor authority with no editor.** A TUI killed without releasing its lease
left `disk_authoritative` quarantine entries behind, and every tool in that
workspace was then refused with *"blocked while this workspace has protected
Editor authority"* — with no editor running and nothing at risk, since
`disk_authoritative` means the file on disk IS the truth. Only `editor_dirty`
and `stale_dirty` entries protect now; a live lease is unchanged.

### Verification

Reproduced and fixed against a real 47k-record journal and a real quarantine
file, not fixtures. After the fix the daemon starts with no workspace excluded
and `beginToolOperation(exec_command)` is allowed; a real prompt in that
workspace completes.

Regression tests added for each: stale cross-workspace run id, live takeover of
a hydrated claim, `idle` in the canonical schema (including the exact on-disk
payload), leftover `disk_authoritative` entries, and the other half — leftover
`editor_dirty` entries must still block.

`tests/budget`, `tests/workspace`, `tests/state`: 593 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
