### PR TITLE
fix(tui): keep tool output minimal and mark every in-flight label with one star

### DIFF
--- a/runtime/src/tools/WebFetchTool/WebFetchTool.ts
+++ b/runtime/src/tools/WebFetchTool/WebFetchTool.ts
@@ -117,6 +117,14 @@ export const WebFetchTool = buildTool({
   // tool for the rest of the run. Observed twice in one afternoon, each time
   // stranding a live hardware-debugging session that could no longer flash.
   recoveryCategory: 'idempotent',
+  // A fetch IS a read, and its result is a whole web page. Without this the
+  // transcript printed every fetched document in full (report: "the webchat is
+  // showing the complete fetch"), because only tools that declare themselves
+  // search/read get folded into the collapsed group summary the way Read and
+  // Grep are.
+  isSearchOrReadCommand() {
+    return { isSearch: false, isRead: true }
+  },
   toAutoClassifierInput(input) {
     return input.prompt ? `${input.url}: ${input.prompt}` : input.url
   },

--- a/runtime/src/tools/WebSearchTool/WebSearchTool.ts
+++ b/runtime/src/tools/WebSearchTool/WebSearchTool.ts
@@ -405,6 +405,11 @@ export const WebSearchTool = buildTool({
   // poison the session. See the note in WebFetchTool for what the
   // side-effecting default costs.
   recoveryCategory: 'idempotent',
+  // A search is a search: fold the result list into the collapsed group
+  // summary instead of printing every hit, matching Grep and Glob.
+  isSearchOrReadCommand() {
+    return { isSearch: true, isRead: false }
+  },
   toAutoClassifierInput(input) {
     return input.query
   },

--- a/runtime/src/tui/components/ToolStateGlyph.tsx
+++ b/runtime/src/tui/components/ToolStateGlyph.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { resolveAgenCTuiGlyphMode } from "../glyphs.js";
-import { Text } from "../ink.js";
+import { Box, Text } from "../ink.js";
 import type { Theme } from "../../utils/theme.js";
 
 export type ToolGlyphState = "queued" | "running" | "done" | "failed";
@@ -93,5 +93,28 @@ export function ToolStateGlyph({
     <Text color={color} dimColor={dim}>
       {glyph}
     </Text>
+  );
+}
+
+/**
+ * A one-line "this is happening right now" label: the running star followed by
+ * the text, dimmed like the rest of the progress chrome.
+ *
+ * Every in-flight thing in the transcript should say so the same way — a tool
+ * call, a permission wait, a classifier check, a wait on other agents — so the
+ * eye learns one mark instead of four.
+ */
+export function RunningLabel({
+  text,
+  color,
+}: {
+  readonly text: string;
+  readonly color?: keyof Theme;
+}): React.ReactElement {
+  return (
+    <Box flexDirection="row" gap={1}>
+      <ToolStateGlyph state="running" color={color} dim />
+      <Text dimColor>{text}</Text>
+    </Box>
   );
 }

--- a/runtime/src/tui/components/ToolStateGlyph.tsx
+++ b/runtime/src/tui/components/ToolStateGlyph.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react";
+
+import { resolveAgenCTuiGlyphMode } from "../glyphs.js";
+import { Text } from "../ink.js";
+import type { Theme } from "../../utils/theme.js";
+
+export type ToolGlyphState = "queued" | "running" | "done" | "failed";
+
+/**
+ * Frames for the star beside a running tool call: the points sweep out from
+ * the centre and back, so a live tool reads as moving without the row jumping.
+ *
+ * The unicode set is drawn from the star family already proven in this TUI
+ * (`glyphs.spinnerFrames`). A bare ASCII `*` mixed among unicode stars renders
+ * as a thin, raised glyph and visibly flickers once per cycle, which is why
+ * `getDefaultCharacters` avoids it too. In ascii mode the arms rotate instead
+ * — `+` axis-aligned, `*` six-armed, `x` diagonal — which is the same idea
+ * with characters every terminal already has.
+ */
+const UNICODE_STAR_FRAMES = ["✢", "✳", "✶", "✻", "✽", "✻", "✶", "✳"] as const;
+const ASCII_STAR_FRAMES = ["+", "*", "x", "*"] as const;
+
+/**
+ * Slower than the composer spinner (90ms): several tool rows can be in flight
+ * at once, and a fast sweep across a column of them reads as noise.
+ */
+export const TOOL_STAR_FRAME_MS = 120;
+
+/**
+ * Resolved states are static. `running` is only used when motion is off —
+ * it must differ from `done` so a reduced-motion user can still tell an
+ * in-flight tool from a finished one.
+ */
+const UNICODE_STATIC: Readonly<Record<ToolGlyphState, string>> = {
+  queued: "·",
+  running: "✳",
+  done: "✶",
+  failed: "✕",
+};
+
+const ASCII_STATIC: Readonly<Record<ToolGlyphState, string>> = {
+  queued: ".",
+  running: "+",
+  done: "*",
+  failed: "X",
+};
+
+export function toolStarFrames(ascii: boolean): readonly string[] {
+  return ascii ? ASCII_STAR_FRAMES : UNICODE_STAR_FRAMES;
+}
+
+export function toolStaticGlyph(
+  state: ToolGlyphState,
+  ascii: boolean,
+): string {
+  return (ascii ? ASCII_STATIC : UNICODE_STATIC)[state];
+}
+
+/**
+ * The glyph beside a tool call. Animates only while the tool is actually
+ * running, so the transcript's finished rows stay off the animation clock.
+ */
+export function ToolStateGlyph({
+  state,
+  color,
+  dim = false,
+  reducedMotion = false,
+}: {
+  readonly state: ToolGlyphState;
+  readonly color?: keyof Theme;
+  readonly dim?: boolean;
+  readonly reducedMotion?: boolean;
+}): React.ReactElement {
+  const ascii = resolveAgenCTuiGlyphMode() === "ascii";
+  const frames = toolStarFrames(ascii);
+  const animating = state === "running" && !reducedMotion;
+  const [frame, setFrame] = useState(0);
+
+  useEffect(() => {
+    if (!animating) return;
+    const timer = setInterval(
+      () => setFrame((value) => (value + 1) % frames.length),
+      TOOL_STAR_FRAME_MS,
+    );
+    return () => clearInterval(timer);
+  }, [animating, frames.length]);
+
+  const glyph = animating
+    ? frames[frame % frames.length] ?? frames[0]!
+    : toolStaticGlyph(state, ascii);
+
+  return (
+    <Text color={color} dimColor={dim}>
+      {glyph}
+    </Text>
+  );
+}

--- a/runtime/src/tui/components/ToolUseLoader.tsx
+++ b/runtime/src/tui/components/ToolUseLoader.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
-import { Box, Text } from '../ink.js';
+import { Box } from '../ink.js';
+import { ToolStateGlyph } from './ToolStateGlyph.js';
 
 type Props = {
   isError: boolean;
@@ -9,12 +10,21 @@ type Props = {
 export function ToolUseLoader({
   isError,
   isUnresolved,
+  shouldAnimate,
 }: Props): React.ReactNode {
   const color = isError ? "error" : isUnresolved ? undefined : "success";
-  const glyph = isError ? "✕" : isUnresolved ? "◐" : "●";
+  const state = isError ? "failed" : isUnresolved ? "running" : "done";
   return (
     <Box minWidth={2}>
-      <Text color={color} dimColor={!isError && isUnresolved}>{glyph}</Text>
+      <ToolStateGlyph
+        state={state}
+        color={color}
+        dim={!isError && isUnresolved}
+        // Callers that already know the row is frozen (replayed history, a
+        // collapsed group that is no longer the active one) pass false, and a
+        // still star costs nothing on the render clock.
+        reducedMotion={!shouldAnimate}
+      />
     </Box>
   );
 }

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import React from 'react'
 import type { PermissionMode } from '../../../permissions/types.js'
-import { AURA_LIFECYCLE_GLYPHS, AURA_PLAN_GLYPHS, type Theme } from '../../../utils/theme.js'
+import { AURA_PLAN_GLYPHS, type Theme } from '../../../utils/theme.js'
 import { useModalOrTerminalSize } from '../../context/modalContext.js'
 import { useQueuedMessage } from '../../context/QueuedMessageContext.js'
 import { ContentWidthProvider, insetContentWidth, useContentWidth } from '../../context/contentWidthContext.js'
@@ -11,6 +11,7 @@ import wrapText from '../../ink/wrap-text.js'
 import { TerminalWriteContext } from '../../ink/useTerminalNotification.js'
 import ThemedBox from '../design-system/ThemedBox.js'
 import ThemedText from '../design-system/ThemedText.js'
+import { ToolStateGlyph } from '../ToolStateGlyph.js'
 import { stringWidth } from '../../ink/stringWidth.js'
 import {
   useAssistantMessageMetadata,
@@ -156,8 +157,6 @@ const toolColor: Record<ToolKind, ThemeColor> = {
   settle: 'success',
   stake: 'worker',
 }
-
-const toolGlyph: Readonly<Record<ToolState, string>> = AURA_LIFECYCLE_GLYPHS
 
 function capitalize(value: string): string {
   return value.length > 0 ? value.slice(0, 1).toUpperCase() + value.slice(1) : value
@@ -1414,7 +1413,7 @@ export function Tool({
           `● Run` intact and forces all shrinkage onto the args text below.
         */}
         <Box flexShrink={0}>
-          <ThemedText color={color}>{toolGlyph[state]}</ThemedText>
+          <ToolStateGlyph state={state} color={color} />
         </Box>
         <Box flexShrink={0}>
           <ThemedText color={toolColor[kind]} bold>

--- a/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
+++ b/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
@@ -14,6 +14,7 @@ import type { AgenCToolUseBlockParam } from '../../types/message.js';
 import { MessageResponse } from '../components/MessageResponse';
 import { useSelectedMessageBg } from '../components/messageActions';
 import { TuiErrorBoundary } from '../components/TuiErrorBoundary';
+import { RunningLabel } from '../components/ToolStateGlyph.js';
 import { HookProgressMessage } from './HookProgressMessage';
 import { Tool as V2Tool, DiffInline, type ToolKind, type ToolState } from '../components/v2/primitives.js';
 import { extractTag } from '../../utils/messages.js';
@@ -180,15 +181,17 @@ export function AssistantToolUseMessage({
   const progressDetail = !isResolved && !isQueued ? (
     isWaitingForPermission ? (
       <MessageResponse height={1}>
-        <Text dimColor={true}>{getAssistantToolUsePendingText('permission')}</Text>
+        <RunningLabel text={getAssistantToolUsePendingText('permission')} />
       </MessageResponse>
     ) : isClassifierChecking ? (
       <MessageResponse height={1}>
-        <Text dimColor={true}>
-          {isAutoClassifier
-            ? getAssistantToolUsePendingText('auto-classifier')
-            : getAssistantToolUsePendingText('bash-classifier')}
-        </Text>
+        <RunningLabel
+          text={
+            isAutoClassifier
+              ? getAssistantToolUsePendingText('auto-classifier')
+              : getAssistantToolUsePendingText('bash-classifier')
+          }
+        />
       </MessageResponse>
     ) : renderToolUseProgressMessage(
       tool,

--- a/runtime/src/tui/message-renderers/SystemTextMessage.tsx
+++ b/runtime/src/tui/message-renderers/SystemTextMessage.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import sample from 'lodash-es/sample.js';
 import { BLACK_CIRCLE, REFERENCE_MARK, TEARDROP_ASTERISK } from '../../constants/figures.js';
+import { ToolStateGlyph } from '../components/ToolStateGlyph.js';
 import figures from 'figures';
 import { basename } from 'path';
 import { MessageResponse } from '../components/MessageResponse';
@@ -373,9 +374,19 @@ function CollabAgentSystemMessage({
   return (
     <Box flexDirection="row" marginTop={marginTop} backgroundColor={bg} width="100%">
       <Box minWidth={2}>
-        <Text color={color} dimColor={state === "info"}>
-          {BLACK_CIRCLE}
-        </Text>
+        {/*
+          A collab row that is still running ("Waiting for agents", "Spawned
+          …") gets the same sweeping star as a running tool call, so every
+          in-flight thing in the transcript reads the same way. Settled rows
+          keep the static mark.
+        */}
+        {state === "running" ? (
+          <ToolStateGlyph state="running" color={color} />
+        ) : (
+          <Text color={color} dimColor={state === "info"}>
+            {BLACK_CIRCLE}
+          </Text>
+        )}
       </Box>
       <Box flexDirection="column" width={width}>
         <Text color={color} bold={state === "running"}>

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1748,7 +1748,35 @@ export function formatStructuredToolResult(
     }
   }
 
-  return [{ type: "text", text: stringResult(result) }];
+  return [{ type: "text", text: clampGenericToolResult(stringResult(result)) }];
+}
+
+/**
+ * Every branch above projects a tool's result down to the few lines worth
+ * reading. Tools with no branch fall through here and printed their raw result
+ * in full, which is how a single fetch or a chatty MCP call could bury a whole
+ * screen of conversation.
+ *
+ * This is the floor, not the mechanism: a tool whose output is routinely long
+ * should declare `isSearchOrReadCommand` so it folds into the collapsed group
+ * summary. The threshold is deliberately high — anything past it is already
+ * unreadable in a chat pane — so short results stay verbatim.
+ */
+const GENERIC_RESULT_MAX_CHARS = 2_000;
+const GENERIC_RESULT_HEAD_LINES = 12;
+
+export function clampGenericToolResult(text: string): string {
+  if (text.length <= GENERIC_RESULT_MAX_CHARS) return text;
+  const lines = text.split("\n");
+  if (lines.length <= GENERIC_RESULT_HEAD_LINES) {
+    return `${text.slice(0, GENERIC_RESULT_MAX_CHARS)}\n… +${
+      text.length - GENERIC_RESULT_MAX_CHARS
+    } more characters (ctrl+o for the full result)`;
+  }
+  const head = lines.slice(0, GENERIC_RESULT_HEAD_LINES).join("\n");
+  return `${head}\n… +${
+    lines.length - GENERIC_RESULT_HEAD_LINES
+  } more lines (ctrl+o for the full result)`;
 }
 
 /**

--- a/runtime/tests/tui/components/ToolStateGlyph.test.tsx
+++ b/runtime/tests/tui/components/ToolStateGlyph.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TOOL_STAR_FRAME_MS,
+  toolStarFrames,
+  toolStaticGlyph,
+} from "./ToolStateGlyph.js";
+
+/**
+ * The glyph beside a tool call used to be a lifecycle circle (`○ ◐ ● ✕`).
+ * User report: "the svg next to the tool is a circle now, I'd like an animated
+ * ascii star whose points move". These assertions pin the two properties that
+ * make that work: the frames are stars that actually change, and every state
+ * stays distinguishable when motion is off.
+ */
+describe("tool star glyphs", () => {
+  it("animates through distinct star frames in both glyph modes", () => {
+    for (const ascii of [false, true]) {
+      const frames = toolStarFrames(ascii);
+      expect(frames.length).toBeGreaterThanOrEqual(4);
+      expect(new Set(frames).size).toBeGreaterThanOrEqual(3);
+      for (const frame of frames) {
+        expect([...frame]).toHaveLength(1);
+      }
+    }
+  });
+
+  it("keeps ascii frames inside 7-bit ascii", () => {
+    for (const frame of toolStarFrames(true)) {
+      expect(frame.codePointAt(0)!).toBeLessThan(128);
+    }
+  });
+
+  it("never renders a circle for a tool state", () => {
+    for (const ascii of [false, true]) {
+      for (const state of ["queued", "running", "done", "failed"] as const) {
+        expect(["●", "◐", "○"]).not.toContain(toolStaticGlyph(state, ascii));
+      }
+    }
+  });
+
+  // Reduced motion freezes `running` on its static glyph. If that matched
+  // `done`, a user with animations off could not tell a live tool from a
+  // finished one — the one thing this column exists to say.
+  it("keeps every static state distinguishable", () => {
+    for (const ascii of [false, true]) {
+      const glyphs = (["queued", "running", "done", "failed"] as const).map(
+        (state) => toolStaticGlyph(state, ascii),
+      );
+      expect(new Set(glyphs).size).toBe(glyphs.length);
+    }
+  });
+
+  it("ticks slower than the composer spinner so a column of rows is calm", () => {
+    expect(TOOL_STAR_FRAME_MS).toBeGreaterThan(90);
+  });
+});

--- a/runtime/tests/tui/components/ToolUseLoader.test.tsx
+++ b/runtime/tests/tui/components/ToolUseLoader.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, expect, test } from 'vitest'
 
 import { renderToString } from '../../utils/staticRender.js'
+import { toolStarFrames, toolStaticGlyph } from './ToolStateGlyph.js'
 import { ToolUseLoader } from './ToolUseLoader.js'
 
 function RerenderLoader() {
@@ -17,13 +18,17 @@ function RerenderLoader() {
 }
 
 describe('ToolUseLoader', () => {
+  // The lifecycle circles (`◐` running, `●` done) were replaced by a star
+  // whose points sweep while a tool is in flight; a static render lands on
+  // whichever frame the animation starts on, so assert against the frame set.
   test('renders pending, failed, and successful glyphs', async () => {
-    await expect(
-      renderToString(
-        <ToolUseLoader isError={false} isUnresolved shouldAnimate />,
-        20,
-      ),
-    ).resolves.toContain('◐')
+    const running = await renderToString(
+      <ToolUseLoader isError={false} isUnresolved shouldAnimate />,
+      20,
+    )
+    expect(toolStarFrames(false).some((frame) => running.includes(frame))).toBe(
+      true,
+    )
 
     await expect(
       renderToString(
@@ -39,6 +44,8 @@ describe('ToolUseLoader', () => {
       ),
     ).resolves.toContain('✕')
 
-    await expect(renderToString(<RerenderLoader />, 20)).resolves.toContain('●')
+    await expect(renderToString(<RerenderLoader />, 20)).resolves.toContain(
+      toolStaticGlyph('done', false),
+    )
   })
 })

--- a/runtime/tests/tui/coverage-swarm/swarm-032-message-renderers-AssistantToolUseMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-032-message-renderers-AssistantToolUseMessage.test.tsx
@@ -5,6 +5,7 @@ import type { Tool } from '../../tools/Tool.js'
 import type { AgenCToolUseBlockParam } from '../../types/message.js'
 import { renderToString } from '../../utils/staticRender.js'
 import { Text } from '../ink.js'
+import { toolStaticGlyph } from '../components/ToolStateGlyph.js'
 import {
   AssistantToolUseMessage,
   getAssistantToolUsePendingText,
@@ -173,7 +174,7 @@ describe('AssistantToolUseMessage swarm 032 coverage', () => {
 
       expect(output).toContain(label)
       expect(output).toContain(expectedArg)
-      expect(output).toContain('●')
+      expect(output).toContain(toolStaticGlyph('done', false))
     }
   })
 
@@ -246,7 +247,7 @@ describe('AssistantToolUseMessage swarm 032 coverage', () => {
     expect(output).toContain('Search Tool')
     expect(output).toContain('queued/path.ts')
     expect(output).toContain('queued as node')
-    expect(output).toContain('○')
+    expect(output).toContain(toolStaticGlyph('queued', false))
   })
 
   it('falls back to empty non-object summaries and default progress detail', async () => {

--- a/runtime/tests/tui/coverage-swarm/swarm-056-message-renderers-AdvisorMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-056-message-renderers-AdvisorMessage.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, test } from 'vitest'
 import type { AdvisorBlock } from '../../utils/advisor.js'
 import { renderToString } from '../../utils/staticRender.js'
 import { AdvisorMessage } from '../message-renderers/AdvisorMessage.js'
+import {
+  toolStarFrames,
+  toolStaticGlyph,
+} from '../components/ToolStateGlyph.js'
 
 function normalize(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
@@ -52,7 +56,10 @@ describe('AdvisorMessage coverage swarm row 056', () => {
     )
 
     expect(output).toContain('Advising')
-    expect(output).toContain('◐')
+    // In flight: a star mid-sweep, whichever frame the static render caught.
+    expect(toolStarFrames(false).some((frame) => output.includes(frame))).toBe(
+      true,
+    )
     expect(output).not.toContain('using')
     expect(output).not.toContain('{}')
   })
@@ -73,7 +80,7 @@ describe('AdvisorMessage coverage swarm row 056', () => {
       ),
     )
 
-    expect(completed).toContain('●')
+    expect(completed).toContain(toolStaticGlyph('done', false))
     expect(completed).toContain('Advising using advisor-model')
     expect(completed).toContain(
       '{"files":["src/tui/message-renderers/AdvisorMessage.tsx"]}',

--- a/runtime/tests/tui/v2-primitives-render.test.tsx
+++ b/runtime/tests/tui/v2-primitives-render.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, expect, test } from 'vitest'
 
 import { Msg, Tool, WelcomeColdPanel } from '../../src/tui/components/v2/primitives.js'
+import { toolStaticGlyph } from '../../src/tui/components/ToolStateGlyph.js'
 import { Box, Text } from '../../src/tui/ink.js'
 import {
   ContentWidthProvider,
@@ -49,6 +50,8 @@ async function probeBodyWidth(node: React.ReactNode): Promise<number> {
   const row = out.split('\n').find(line => line.includes('#')) ?? ''
   return (row.match(/#/g) ?? []).length
 }
+
+const DONE = toolStaticGlyph('done', false)
 
 describe('Msg queued body wrap width (BUG 1)', () => {
   test('non-queued message body width is unchanged (marker inset only)', async () => {
@@ -203,7 +206,7 @@ async function firstToolRow(node: React.ReactNode, contentWidth: number): Promis
 describe('Tool call header under arg overflow (BUG A)', () => {
   test('a fitting arg keeps the canonical `● Run (cmd)` shape', async () => {
     const row = await firstToolRow(<Tool kind="bash" label="Run" args="short cmd" />, 90)
-    expect(row).toBe('● Run (short cmd)')
+    expect(row).toBe(`${DONE} Run (short cmd)`)
   })
 
   test('an overflowing bash arg keeps glyph/space/label/space/open-paren and the closing paren', async () => {
@@ -213,7 +216,7 @@ describe('Tool call header under arg overflow (BUG A)', () => {
     // Against the pre-fix code the row started `●Run  ` (glyph touching label, no
     // space; doubled space after label) and the `(` was missing entirely, so this
     // exact prefix is the revert-sensitive guard.
-    expect(row.startsWith('● Run (')).toBe(true)
+    expect(row.startsWith(`${DONE} Run (`)).toBe(true)
     // The opening paren is present and the args text was truncated in the middle
     // (the ellipsis appears between the open paren and the close paren).
     expect(row).toContain('…')
@@ -222,7 +225,7 @@ describe('Tool call header under arg overflow (BUG A)', () => {
     expect((row.match(/\(/g) ?? []).length).toBe(1)
     expect((row.match(/\)/g) ?? []).length).toBe(1)
     // Revert-sensitivity, negative form: the collapsed defects must be gone.
-    expect(row.startsWith('●Run')).toBe(false)
+    expect(row.startsWith(`${DONE}Run`)).toBe(false)
     expect(row).not.toContain('Run  ')
   })
 
@@ -231,19 +234,19 @@ describe('Tool call header under arg overflow (BUG A)', () => {
     async kind => {
       const expectedLabel = kind.charAt(0).toUpperCase() + kind.slice(1)
       const row = await firstToolRow(<Tool kind={kind} args={LONG_TOOL_ARGS} />, 90)
-      expect(row.startsWith(`● ${expectedLabel} (`)).toBe(true)
+      expect(row.startsWith(`${DONE} ${expectedLabel} (`)).toBe(true)
       expect(row.endsWith(')')).toBe(true)
       expect((row.match(/\(/g) ?? []).length).toBe(1)
       expect((row.match(/\)/g) ?? []).length).toBe(1)
-      // The collapsed `●Edit`/`●Read`/`●Grep` (no glyph space) must not reappear.
-      expect(row.startsWith(`●${expectedLabel}`)).toBe(false)
+      // The collapsed `<glyph>Edit` (no space after the glyph) must not reappear.
+      expect(row.startsWith(`${DONE}${expectedLabel}`)).toBe(false)
     },
   )
 
   test('the defect reproduces across narrow widths and the fix holds at each', async () => {
     for (const width of [70, 60, 50]) {
       const row = await firstToolRow(<Tool kind="bash" label="Run" args={LONG_TOOL_ARGS} />, width)
-      expect(row.startsWith('● Run (')).toBe(true)
+      expect(row.startsWith(`${DONE} Run (`)).toBe(true)
       expect(row.endsWith(')')).toBe(true)
     }
   })


### PR DESCRIPTION
Two reports from a live session, both about the transcript being noisier and
flatter than it needs to be.

### The whole fetched page in the chat

WebFetch printed every fetched document in full. Only tools that declare
`isSearchOrReadCommand` are folded into the collapsed group summary the way
`Read` and `Grep` are, and neither web tool declared it — a fetch IS a read and
a search IS a search. Both now do.

Any tool with no renderer of its own also gets a floor: past 2k characters the
transcript keeps the first 12 lines and says how many it hid, pointing at
ctrl+o for the rest. The floor is not the mechanism — a tool whose output is
routinely long should declare itself — but nothing can bury a screen of
conversation again.

### An animated glyph for a running tool

The mark beside a tool call was a lifecycle circle (`○ ◐ ● ✕`). A running tool
now shows a star whose points sweep.

The unicode frames come from the star family already proven in this TUI: a bare
ASCII `*` among unicode stars renders thin and raised and visibly flickers each
cycle, which is why `getDefaultCharacters` avoids it too. ASCII mode rotates the
arms instead — `+` axis-aligned, `*` six-armed, `x` diagonal — which is the same
idea with characters every terminal has.

Only the `running` state animates, so a transcript full of finished rows stays
off the animation clock, and reduced motion freezes on a glyph distinct from
`done` (otherwise a user with animations off could not tell a live tool from a
finished one — the one thing that column exists to say). It ticks slower than
the composer spinner: several rows can be in flight at once and a fast sweep
down a column reads as noise.

Scoped to the tool-call path only. Plan glyphs, the header tab dot and the
background-tasks panel are untouched.

### Verification

Existing assertions that pinned the old circles were updated, including the
`v2-primitives` shape tests — those are about the glyph/space/label/space/paren
pinning contract, not about which glyph it is, so they now bind to the real
glyph and the shape stays pinned while the mark is free to change.

TUI components, message renderers, coverage swarm and v2 primitives: 1268
passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
