### PR TITLE
feat(tui): replace the agent scanline with a dot bar that fills with work

### DIFF
--- a/runtime/src/tui/workbench/agents/AgentActivityTrack.tsx
+++ b/runtime/src/tui/workbench/agents/AgentActivityTrack.tsx
@@ -2,77 +2,89 @@ import React, { useEffect, useState } from "react";
 
 import { Text } from "../../ink.js";
 
-const ACTIVITY_TRACK_FRAME_MS = 80;
+const ACTIVITY_PULSE_FRAME_MS = 450;
 const MIN_TRACK_WIDTH = 6;
 
 export type AgentActivityTrackFrame = {
-  readonly after: string;
-  readonly before: string;
-  readonly head: "◆" | "◇";
-  readonly tail: string;
+  /** Dots for work already done, drawn bright. */
+  readonly filled: string;
+  /** The dot about to be earned; pulses so the row reads as alive. */
+  readonly head: string;
+  /** Work not done yet, drawn grey. */
+  readonly rest: string;
+  /** Completed laps of the bar — real work beyond one bar's width. */
+  readonly laps: number;
 };
 
 /**
- * Pure frame builder for the indeterminate agent activity track. AgenC does
- * not receive a trustworthy completion percentage from a running agent, so a
- * moving scanline is honest where a fixed "58%" fill is not.
+ * Pure frame builder for the agent activity bar.
+ *
+ * The bar measures WORK DONE, not percent complete: AgenC receives no
+ * trustworthy completion estimate from a running agent, so one dot per tool
+ * call is a fact where a "58%" fill would be an invention. It fills left to
+ * right and wraps, and the `N tools` counter beside it makes the lap
+ * unambiguous. (The previous design walked a marker along the line for the
+ * same honesty reason; this keeps the honesty and adds real information.)
  */
 export function buildAgentActivityTrackFrame(
   width: number,
-  step: number,
+  toolCount: number,
+  pulseOn: boolean,
 ): AgentActivityTrackFrame {
   const trackWidth = Math.max(MIN_TRACK_WIDTH, Math.floor(width));
-  const headIndex = ((Math.floor(step) % trackWidth) + trackWidth) % trackWidth;
-  const tail = headIndex === 0 ? "" : headIndex === 1 ? "╺" : "╺━";
-  const before = "·".repeat(Math.max(0, headIndex - tail.length));
-  const after = "·".repeat(Math.max(0, trackWidth - headIndex - 1));
-  const head = Math.floor(step / 2) % 2 === 0 ? "◆" : "◇";
-  return { after, before, head, tail };
+  // A non-finite count would poison every downstream `repeat()` into "" and
+  // collapse the bar to zero cells — an invisible row rather than an empty one.
+  const done = Number.isFinite(toolCount)
+    ? Math.max(0, Math.floor(toolCount))
+    : 0;
+  const laps = Math.floor(done / trackWidth);
+  const filledCount = done % trackWidth;
+  // A dot is spent on the head, so it only exists while the bar has room.
+  const headCount = filledCount < trackWidth ? 1 : 0;
+  return {
+    filled: "·".repeat(filledCount),
+    head: headCount === 1 && pulseOn ? "·" : headCount === 1 ? " " : "",
+    rest: "·".repeat(Math.max(0, trackWidth - filledCount - headCount)),
+    laps,
+  };
 }
 
 export function AgentActivityTrack({
   reducedMotion,
-  seed,
+  toolCount = 0,
   width,
 }: {
   readonly reducedMotion: boolean;
-  readonly seed: string;
+  readonly toolCount?: number;
   readonly width: number;
 }): React.ReactElement {
-  const trackWidth = Math.max(MIN_TRACK_WIDTH, Math.floor(width));
-  const [step, setStep] = useState(() =>
-    reducedMotion ? Math.floor(trackWidth / 2) : phaseForSeed(seed, trackWidth),
-  );
+  const [pulseOn, setPulseOn] = useState(true);
 
   useEffect(() => {
     if (reducedMotion) return;
     const timer = setInterval(
-      () => setStep((value) => (value + 1) % trackWidth),
-      ACTIVITY_TRACK_FRAME_MS,
+      () => setPulseOn((value) => !value),
+      ACTIVITY_PULSE_FRAME_MS,
     );
     return () => clearInterval(timer);
-  }, [reducedMotion, trackWidth]);
+  }, [reducedMotion]);
 
   const frame = buildAgentActivityTrackFrame(
-    trackWidth,
-    reducedMotion ? Math.floor(trackWidth / 2) : step,
+    width,
+    toolCount,
+    reducedMotion ? true : pulseOn,
   );
 
   return (
     <Text wrap="truncate-end">
-      <Text color="lineSoft">{frame.before}</Text>
-      <Text color="inactive">{frame.tail}</Text>
-      <Text color="text">{frame.head}</Text>
-      <Text color="lineSoft">{frame.after}</Text>
+      <Text color="text">{frame.filled}</Text>
+      <Text color={frame.laps > 0 ? "inactive" : "text"}>{frame.head}</Text>
+      {/*
+        After a full lap the remaining dots brighten one step, so a second pass
+        over the bar is visibly a second pass instead of looking like the agent
+        started over.
+      */}
+      <Text color={frame.laps > 0 ? "inactive" : "lineSoft"}>{frame.rest}</Text>
     </Text>
   );
-}
-
-function phaseForSeed(seed: string, width: number): number {
-  let hash = 2166136261;
-  for (const character of seed) {
-    hash ^= character.codePointAt(0) ?? 0;
-    hash = Math.imul(hash, 16777619);
-  }
-  return (hash >>> 0) % width;
 }

--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -286,7 +286,7 @@ function AgentRailRow({
         <Box paddingLeft={2}>
           <AgentActivityTrack
             width={trackWidth}
-            seed={taskIdOf(task) ?? label}
+            toolCount={toolCount}
             reducedMotion={reducedMotion}
           />
           {showStats ? <Text color="inactive"> {stats}</Text> : null}

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -256,7 +256,7 @@ describe("AgentsRail", () => {
 
     expect(output).toContain("› stale running");
     expect(output).toContain("running");
-    expect(output).toMatch(/[◆◇]/u);
+    expect(output).toMatch(/·{4,}/u);
     expect(output).not.toContain("x stop");
   });
 
@@ -397,7 +397,7 @@ describe("AgentsRail lifecycle legibility", () => {
     ).output;
 
     expect(output).toContain("needs you");
-    expect(output).not.toMatch(/[◆◇]/u);
+    expect(output).not.toMatch(/·{4,}/u);
   });
 
   it("labels rows with the friendly title (+ role), never the raw prompt", async () => {

--- a/runtime/tests/tui/workbench/agents/agentActivityTrack.test.ts
+++ b/runtime/tests/tui/workbench/agents/agentActivityTrack.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAgentActivityTrackFrame } from "../../../../src/tui/workbench/agents/AgentActivityTrack.js";
+
+const WIDTH = 10;
+
+describe("agent activity bar", () => {
+  it("starts empty and fills one dot per tool call", () => {
+    expect(buildAgentActivityTrackFrame(WIDTH, 0, true)).toMatchObject({
+      filled: "",
+      laps: 0,
+    });
+    expect(buildAgentActivityTrackFrame(WIDTH, 3, true).filled).toHaveLength(3);
+    expect(buildAgentActivityTrackFrame(WIDTH, 7, true).filled).toHaveLength(7);
+  });
+
+  it("keeps the bar exactly `width` cells wide at every fill level", () => {
+    for (const toolCount of [0, 1, 5, 9, 10, 11, 25]) {
+      const frame = buildAgentActivityTrackFrame(WIDTH, toolCount, true);
+      expect(
+        frame.filled.length + frame.head.length + frame.rest.length,
+      ).toBe(WIDTH);
+    }
+  });
+
+  // The bar measures work done, not percent complete — there is no trustworthy
+  // completion estimate from a running agent. Past a full bar it wraps, and the
+  // lap count is what tells the renderer to brighten the remainder so a second
+  // pass does not read as "the agent started over".
+  it("wraps into laps instead of saturating", () => {
+    expect(buildAgentActivityTrackFrame(WIDTH, 10, true)).toMatchObject({
+      filled: "",
+      laps: 1,
+    });
+    expect(buildAgentActivityTrackFrame(WIDTH, 23, true)).toMatchObject({
+      laps: 2,
+    });
+    expect(buildAgentActivityTrackFrame(WIDTH, 23, true).filled).toHaveLength(3);
+  });
+
+  it("pulses only the next dot, and never loses a cell doing it", () => {
+    const on = buildAgentActivityTrackFrame(WIDTH, 4, true);
+    const off = buildAgentActivityTrackFrame(WIDTH, 4, false);
+    expect(on.head).toBe("·");
+    expect(off.head).toBe(" ");
+    expect(on.filled).toBe(off.filled);
+    expect(on.rest).toBe(off.rest);
+  });
+
+  it("never renders a negative or fractional fill", () => {
+    for (const toolCount of [-5, 0.4, Number.NaN]) {
+      const frame = buildAgentActivityTrackFrame(WIDTH, toolCount, true);
+      expect(frame.filled).toBe("");
+      expect(frame.rest.length + frame.head.length).toBe(WIDTH);
+    }
+  });
+
+  it("honours a floor width so a narrow rail still shows a bar", () => {
+    const frame = buildAgentActivityTrackFrame(2, 0, true);
+    expect(frame.filled.length + frame.head.length + frame.rest.length).toBe(6);
+  });
+});


### PR DESCRIPTION
The running-agent row drew a marker walking back and forth along a line:

```
› Cyberia · Scanner
  running · 3m24s
  ·······—◇·············  14 tools · 355.4k tok
```

It said "alive" and nothing else, and it reads as a figure pacing rather than as progress.

It is now a bar of dots that fills left to right, one dot per tool call, grey to bright.

### Why dots and not a percentage

What it measures is **work done, not percent complete**. AgenC gets no trustworthy completion estimate from a running agent, so a dot per real tool call is a fact where a `58%` fill would be an invention. That honesty was the whole reason for the scanline; this keeps it and adds real information, since the driving count is the same one already printed beside the bar.

Past a full bar it wraps, and the remainder brightens one step so a second pass is visibly a second pass rather than looking like the agent started over — the `N tools` counter beside it makes the lap unambiguous. The next dot pulses slowly so the row still reads as alive between tool calls; reduced motion freezes it.

### Verification

The bar keeps exactly `width` cells at every fill level. A test for that caught a real defect while writing it: a non-finite tool count poisoned every `repeat()` into `""` and collapsed the bar to zero cells — an invisible row rather than an empty one. Guarded in the source, not weakened in the test.

`tests/tui/workbench/agents`: 36 passing. The rail's own assertion moved from the walking marker to the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)