### PR TITLE
fix(tui): show one line of tool output, not a wall of it

### DIFF
--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1757,13 +1757,17 @@ export function formatStructuredToolResult(
  * in full, which is how a single fetch or a chatty MCP call could bury a whole
  * screen of conversation.
  *
- * This is the floor, not the mechanism: a tool whose output is routinely long
- * should declare `isSearchOrReadCommand` so it folds into the collapsed group
- * summary. The threshold is deliberately high — anything past it is already
- * unreadable in a chat pane — so short results stay verbatim.
+ * One line. A tool call is a receipt: the operator does not read a wall of
+ * fetched page or command output in the chat, and every extra line pushes the
+ * conversation off screen. The `… +N more` note keeps the volume visible and
+ * ctrl+o still has every byte.
+ *
+ * Text and code MODIFICATIONS are the deliberate exception and never reach
+ * here: Edit/MultiEdit/Write render their compact diff on the call row, which
+ * is the one tool output worth reading inline.
  */
-const GENERIC_RESULT_MAX_CHARS = 2_000;
-const GENERIC_RESULT_HEAD_LINES = 12;
+const GENERIC_RESULT_MAX_CHARS = 200;
+const GENERIC_RESULT_HEAD_LINES = 1;
 
 export function clampGenericToolResult(text: string): string {
   if (text.length <= GENERIC_RESULT_MAX_CHARS) return text;

--- a/runtime/src/tui/tool-rendering.tsx
+++ b/runtime/src/tui/tool-rendering.tsx
@@ -349,8 +349,21 @@ export function ToolErrorView({
   );
 }
 
-/** Default number of stdout lines shown inline under a Run/Bash call row. */
-const BASH_PREVIEW_MAX_LINES = 5;
+/**
+ * Stdout lines shown inline under a SUCCEEDED Run/Bash call row.
+ *
+ * One. A tool call that worked is a receipt, not a document: the operator
+ * asked for the transcript to stop being a scroll of command output they never
+ * read ("run — what a lot of lines I see, nooo"). The `… +N lines` note keeps
+ * the volume visible and ctrl+o still has every byte.
+ *
+ * Failures keep more (BASH_PREVIEW_FAILURE_MAX_LINES): there the output IS the
+ * answer, and hiding the reason behind a keystroke would trade noise for a
+ * worse problem.
+ */
+const BASH_PREVIEW_MAX_LINES = 1;
+/** A failed command shows head + tail, so the trailing verdict survives. */
+const BASH_PREVIEW_FAILURE_MAX_LINES = 5;
 /** Width cap for an individual previewed line (keeps the gutter tidy). */
 const MAX_PREVIEW_LINE_WIDTH = 200;
 
@@ -605,7 +618,7 @@ export function BashOutputView({
   const stdoutCap = isFailure
     ? capPreviewLinesHeadTail(
         stdoutTrimmed,
-        BASH_PREVIEW_MAX_LINES,
+        BASH_PREVIEW_FAILURE_MAX_LINES,
         BASH_PREVIEW_FAILURE_HEAD_LINES,
         verbose,
       )
@@ -614,7 +627,7 @@ export function BashOutputView({
   const stderrCap = showStderr
     ? capPreviewLinesHeadTail(
         stderrTrimmed,
-        BASH_PREVIEW_MAX_LINES,
+        BASH_PREVIEW_FAILURE_MAX_LINES,
         BASH_PREVIEW_FAILURE_HEAD_LINES,
         verbose,
       )

--- a/runtime/tests/tui/message-renderers/liveRawToolResult.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/liveRawToolResult.render.test.tsx
@@ -199,11 +199,12 @@ describe('LIVE raw daemon tool results (no envelope) — capped industry-standar
     })
     const combined = `${row}\n${body}`
 
-    // Capped stdout: first 5 lines shown, rest collapsed.
+    // A succeeded command is a receipt: one line of stdout, the rest collapsed
+    // behind the count. (Failures keep head+tail so the verdict survives — see
+    // the non-zero-exit case below.)
     expect(body).toContain('out 0')
-    expect(body).toContain('out 4')
-    expect(body).not.toContain('out 5')
-    expect(body).toContain('+4 lines')
+    expect(body).not.toContain('out 1')
+    expect(body).toContain('+8 lines')
     // The [exec ...] trailer line must be stripped from the visible output.
     expect(combined).not.toContain('[exec exit_code')
     expect(combined).not.toContain('wall_time')

--- a/runtime/tests/tui/message-renderers/toolRowPreview.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/toolRowPreview.render.test.tsx
@@ -269,11 +269,11 @@ describe('live daemon TUI tool output (real createTuiTools render path)', () => 
     expect(row).toContain('cmake --build build')
 
     const combined = `${row}\n${body}`
-    // Capped stdout: first 5 lines shown, rest collapsed to "… +4 lines".
+    // A succeeded command is a receipt: one line of stdout, the rest collapsed
+    // behind the count. Failures still show head+tail (next case).
     expect(body).toContain('out 0')
-    expect(body).toContain('out 4')
-    expect(body).not.toContain('out 5')
-    expect(body).toContain('+4 lines')
+    expect(body).not.toContain('out 1')
+    expect(body).toContain('+8 lines')
     expect(countOccurrences(combined, 'out 0')).toBe(1)
   })
 


### PR DESCRIPTION
Follow-up to #1699, which did not go far enough. A tool call is a receipt: the transcript was still printing whole fetched pages and screens of command output that nobody reads, pushing the actual conversation off the top of the terminal.

- The **generic result clamp** went from 12 lines / 2k characters to **one line / 200 characters**. 12 lines is not "minimal", it is a paragraph — and this is the path every tool without a renderer of its own falls through, a fetched document among them.
- A **succeeded** Run/Bash row shows **one line** of stdout instead of five.

Both keep their `… +N lines` note, so the volume stays visible, and ctrl+o still has every byte.

### Two deliberate exceptions

**Failed commands keep the head+tail cap.** There the output IS the answer — the traceback, the trailing verdict. Hiding it behind a keystroke would trade noise for a worse problem.

**Text and code modifications are untouched.** Edit/MultiEdit/Write still render their compact diff on the call row. That is the one tool output worth reading inline, and it is exactly what the operator asked to keep.

### Verification

Two assertions pinned the old five-line budget (`out 4`, `+4 lines`) and now pin the new one. `tests/tui/message-renderers`, `tests/tui/tool-rendering`, `tests/tui/session-transcript`: 242 passing. Typecheck clean. Driven live in a real TUI against the workspace before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)