### PR TITLE
feat(plugins): add zeroday-hunter — exploit-first 0-day hunting skill

### DIFF
--- a/plugins/zeroday-hunter/README.md
+++ b/plugins/zeroday-hunter/README.md
@@ -1,0 +1,61 @@
+# zeroday-hunter
+
+Exploit-first 0-day hunting plugin for AgenC: a campaign state machine with
+quantitative gates, a planner→dispatcher→expert-agent hierarchy, deterministic PoC
+verification, independent-model falsification, variant-as-query sweeps, watch mode for
+commit deltas, and hashed evidence export.
+
+Built from published methodologies: Project Zero/DeepMind Big Sleep, Sean Heelan's o3
+workflow (CVE-2025-37899), DARPA AIxCC winners (buttercup / atlantis / artiphishell),
+XBOW, oss-fuzz-gen, HPTSA, OpenAI Aardvark, CodeQL variant analysis, CyberGym, EnIGMA,
+CAI/PentestGPT, Fuzz4All/ChatAFL. Full citations and the statistics behind each rule:
+`skills/zeroday-hunter/references/methodology-sources.md`.
+
+## Install
+
+```bash
+agenc plugin install ./plugins/zeroday-hunter --scope user
+# or from a clone: agenc plugin install /path/to/agenc-core/plugins/zeroday-hunter
+```
+
+## What the skill makes the agent do
+
+- Runs **campaigns, not reviews**: `G0 FRAME → G1 MAP → G2 AUDIT → G3 PROVE → G4 FALSIFY
+  → G5 REPORT`, each gate with on-disk artifacts and explicit exit criteria.
+- A finding exists only when a **deterministic verifier** exits 0 (sanitizer crash,
+  response diff, observed auth bypass) **and** an independent reviewer model fails to
+  falsify it. Everything else is labeled HYPOTHESIS.
+- One bug class per campaign; slices ≤ ~10k LoC; mandatory per-conditional attacker-
+  control walkthroughs; pass@k independent audits on high-value slices; hard iteration
+  caps with logged abandon criteria.
+- Confirmed bugs are codified as **variant queries** (`.zdh/queries/`) that run
+  repo-wide and double as regression tests for the fix.
+- **Watch mode** audits only `baseline..HEAD` against the stored threat model — cheap
+  continuous delta auditing instead of full rescans.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `skills/zeroday-hunter/SKILL.md` | doctrine + state machine + quantitative gates |
+| `skills/zeroday-hunter/references/` | campaign manual, 10 bug-class playbooks, exploit-primitive ladder, FP library, toolchain recipes, methodology sources |
+| `templates/` | `campaign.yaml`, hypothesis record, finding report |
+| `scripts/zdh-init.sh` | scaffold a campaign state directory (`.zdh/<id>/`) |
+| `scripts/zdh-slice.sh` | budget-capped call-graph slice around an entry symbol |
+| `scripts/zdh-triage.sh` | dedup/cluster sanitizer crashes by (signal, top frame) |
+| `scripts/zdh-watch.sh` | delta-audit scaffolder (baseline..HEAD, sink-touching hunks) |
+| `scripts/zdh-variant.sh` | codify a confirmed pattern as a semgrep/grep query, run repo-wide |
+| `scripts/poc-check.sh` | deterministic PoC verifier (signal regex, timeout, expect-exit) |
+| `scripts/campaign.sh` | launch via the AgenC daemon: `single` (verified run + reviewer model + evidence) or `swarm` (one background agent per bug class) |
+
+## Field-tested
+
+Validated end-to-end against the `minilang` demo parser: found and **confirmed an
+uncontrolled-recursion stack-exhaustion DoS** (CWE-674) — ASan-verified PoC
+(parens/blocks/unary shapes), crash reproduced on a release build, fixed by a depth-cap
+patch that makes the same PoC fail gracefully (crash pre-patch / clean post-patch).
+
+## Scope guard
+
+For codebases you own or are explicitly authorized to test. PoCs run only inside
+sandboxed worktrees. The skill instructs the agent to refuse third-party targeting.

--- a/plugins/zeroday-hunter/scripts/campaign.sh
+++ b/plugins/zeroday-hunter/scripts/campaign.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# campaign.sh — launch zeroday-hunter campaigns through the AgenC daemon.
+#
+# Modes:
+#   campaign.sh single <repo> <goal-file> <verify-cmd> [max-cost] [reviewer-model]
+#       One verified run: PoC verifier as hard admission gate (--verify),
+#       independent reviewer model for falsification (--reviewer-model),
+#       hashed evidence exported at the end.
+#
+#   campaign.sh swarm <repo> <class1,class2,...> [max-cost-per-agent]
+#       One zdh campaign + one background auditor agent per bug class, each
+#       read-mostly, writing into its own .zdh/<id>/ state dir.
+#
+# Examples:
+#   campaign.sh single ~/src/app goals/uaf.md \
+#     "poc=./poc-check.sh --signal 'heap-use-after-free' -- ./poc" 5 anthropic:claude-sonnet-4-5
+#   campaign.sh swarm ~/src/app uaf,oob,race 5
+set -eu
+
+MODE="${1:?usage: campaign.sh <single|swarm> ...}"
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+shift
+
+case "$MODE" in
+
+single)
+  REPO="${1:?repo dir}"; GOAL="${2:?goal file}"
+  VERIFY="${3:?verify cmd, e.g. poc=./poc-check.sh ... -- ./poc}"
+  MAXCOST="${4:-5}"; REVIEWER="${5:-}"
+  args=(run start --cwd "$REPO" --goal-file "$GOAL" --max-cost "$MAXCOST" --verify "$VERIFY" --follow)
+  [ -n "$REVIEWER" ] && args+=(--reviewer-model "$REVIEWER")
+  echo "campaign[single]: repo=$REPO max-cost=\$$MAXCOST reviewer=${REVIEWER:-none}"
+  out="$(agenc "${args[@]}")"; echo "$out"
+  run_id="$(printf '%s\n' "$out" | grep -Eo 'run[_-][A-Za-z0-9]+' | head -1 || true)"
+  if [ -n "$run_id" ]; then
+    agenc run status "$run_id" || true
+    echo "--- hashed evidence ---"
+    agenc run evidence "$run_id" || true
+  else
+    echo "warning: run id not parsed; export manually: agenc run evidence <run-id>" >&2
+  fi
+  ;;
+
+swarm)
+  REPO="${1:?repo dir}"; CLASSES="${2:?comma-separated bug classes}"
+  MAXCOST="${3:-5}"
+  IFS=',' read -ra cls <<< "$CLASSES"
+  echo "campaign[swarm]: repo=$REPO classes=${#cls[@]} max-cost/agent=\$$MAXCOST"
+  for c in "${cls[@]}"; do
+    c="$(echo "$c" | tr -d ' ')"
+    dir="$("$PLUGIN_DIR/scripts/zdh-init.sh" "$REPO" "$c" "$MAXCOST")"
+    id="$(basename "$dir")"
+    echo "--- $c → $id"
+    agenc agent start \
+      --unattended-allow read,grep,glob,bash \
+      "zeroday-hunter campaign $id in $REPO, bug class: $c. You are the AUDITOR for this class only. Read $dir/campaign.yaml and $dir/logs/bad-attempts.md first. Follow the zeroday-hunter skill state machine: fill the threat model, build surface.md (G1), audit slices (G2) writing hypothesis records under $dir/hypotheses/, and stop at G3 boundaries — PoC execution beyond read-only probes requires the coordinator. Append every action to $dir/logs/decision.log. Abandon criteria: see campaign.yaml. Report hypothesis count and top scores when done." \
+      || echo "warning: agent start failed for class $c" >&2
+  done
+  echo "swarm launched. Track: agenc agent list / agenc agent logs <id>"
+  ;;
+
+*)
+  echo "unknown mode: $MODE (single|swarm)" >&2
+  exit 2
+  ;;
+esac

--- a/plugins/zeroday-hunter/scripts/poc-check.sh
+++ b/plugins/zeroday-hunter/scripts/poc-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# poc-check.sh — deterministic PoC verifier for zeroday-hunter campaigns.
+#
+# A finding is CONFIRMED only when this script exits 0. It runs a command and
+# greps its output for a deterministic signal (ASan report, assertion, canary
+# string, expected response marker). Never edit this script to make a PoC pass.
+#
+# Usage:
+#   poc-check.sh --signal <regex> [--timeout <secs>] [--expect-exit <n>] -- <command...>
+#
+# Examples:
+#   poc-check.sh --signal 'ERROR: AddressSanitizer' -- ./target ./poc.bin
+#   poc-check.sh --signal 'PWNED' --timeout 10 -- python3 gen_payload.py \| nc 127.0.0.1 4444
+set -u
+
+SIGNAL=""
+TIMEOUT=30
+EXPECT_EXIT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --signal) SIGNAL="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    --expect-exit) EXPECT_EXIT="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$SIGNAL" ] || [ $# -eq 0 ]; then
+  echo "usage: poc-check.sh --signal <regex> [--timeout s] [--expect-exit n] -- <command...>" >&2
+  exit 2
+fi
+
+LOG="$(mktemp -t poc-check.XXXXXX.log)"
+trap 'rm -f "$LOG"' EXIT
+
+timeout "$TIMEOUT" "$@" >"$LOG" 2>&1
+rc=$?
+
+confirmed=0
+if grep -Eq "$SIGNAL" "$LOG"; then
+  confirmed=1
+fi
+if [ -n "$EXPECT_EXIT" ] && [ "$rc" != "$EXPECT_EXIT" ]; then
+  confirmed=0
+fi
+# timeout(1) returns 124 on expiry — a hang is not a crash
+if [ "$rc" = "124" ]; then
+  confirmed=0
+  echo "NOTE: command timed out after ${TIMEOUT}s" >&2
+fi
+
+if [ "$confirmed" = "1" ]; then
+  echo "CONFIRMED: signal /$SIGNAL/ observed (exit=$rc)"
+  exit 0
+fi
+
+echo "NOT-REPRODUCED: signal /$SIGNAL/ absent (exit=$rc)"
+exit 1

--- a/plugins/zeroday-hunter/scripts/zdh-init.sh
+++ b/plugins/zeroday-hunter/scripts/zdh-init.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# zdh-init.sh — scaffold a zeroday-hunter campaign state directory.
+#
+# Usage: zdh-init.sh <repo> <bug-class> [max-cost-usd]
+#
+# Creates .zdh/<campaign-id>/ inside the repo with state files from the plugin
+# templates, records the baseline commit, and prints the campaign dir.
+set -eu
+
+REPO="${1:?usage: zdh-init.sh <repo> <bug-class> [max-cost-usd]}"
+CLASS="${2:?bug class required, e.g. uaf, oob, sqli, idor, race, traversal, deser, logic}"
+MAXCOST="${3:-10}"
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="$(cd "$REPO" && pwd)"
+slug="$(printf '%s' "$CLASS" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-\|-$//g')"
+ID="zdh-$(date +%Y%m%d)-${slug}"
+DIR="$REPO/.zdh/$ID"
+
+if [ -e "$DIR" ]; then
+  echo "error: $DIR already exists" >&2
+  exit 1
+fi
+
+mkdir -p "$DIR"/{hypotheses,pocs,crashes,findings,logs}
+cp "$PLUGIN_DIR/templates/campaign.yaml" "$DIR/campaign.yaml"
+cp "$PLUGIN_DIR/templates/hypothesis.md" "$DIR/hypotheses/_template.md"
+cp "$PLUGIN_DIR/templates/finding.md" "$DIR/findings/_template.md"
+
+commit="$(git -C "$REPO" rev-parse HEAD 2>/dev/null || echo 'no-git')"
+
+# fill campaign.yaml fields (portable sed -i)
+sed -i \
+  -e "s|  id: \"\"|  id: \"$ID\"|" \
+  -e "s|  target_repo: \"\"|  target_repo: \"$REPO\"|" \
+  -e "s|  baseline_commit: \"\"|  baseline_commit: \"$commit\"|" \
+  -e "s|  bug_class: \"\"|  bug_class: \"$CLASS\"|" \
+  -e "s|  max_cost_usd: 10|  max_cost_usd: $MAXCOST|" \
+  "$DIR/campaign.yaml"
+
+cat > "$DIR/state.yaml" <<EOF
+gate: G0
+hypotheses: { raised: 0, promoted: 0, confirmed: 0, rejected: 0, demoted: 0 }
+spend_usd: 0
+started: "$(date -Iseconds)"
+EOF
+
+cat > "$DIR/logs/bad-attempts.md" <<'EOF'
+# Bad attempts & FP kills — read before every action, never repeat these.
+
+| ts | gate | attempt/pattern | why it failed |
+| --- | --- | --- | --- |
+EOF
+
+printf '%s | G0 | init | campaign scaffolded, baseline %s | fill threat model in campaign.yaml\n' \
+  "$(date -Iseconds)" "$commit" >> "$DIR/logs/decision.log"
+
+echo "$DIR"

--- a/plugins/zeroday-hunter/scripts/zdh-slice.sh
+++ b/plugins/zeroday-hunter/scripts/zdh-slice.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# zdh-slice.sh — extract a budget-capped call-graph slice around an entry symbol.
+#
+# Heuristic for brace-bodied languages (C/C++/Go/JS/Java): BFS from the entry
+# symbol, expanding callee identifiers found inside each definition body plus
+# callers found by grep. Not a parser — verify gaps with ctags/joern/codeql on
+# big targets (see references/toolchain.md). For Python, bodies fall back to
+# whole defining files.
+#
+# Usage: zdh-slice.sh <repo> <symbol> [depth=3] [max-lines=10000]
+set -eu
+
+REPO="${1:?usage: zdh-slice.sh <repo> <symbol> [depth=3] [max-lines=10000]}"
+SYMBOL="${2:?entry symbol required}"
+DEPTH="${3:-3}"
+MAXLINES="${4:-10000}"
+
+SRC_EXT=(c h cc cpp cxx hpp go js ts jsx tsx java rs py)
+inc=(); for e in "${SRC_EXT[@]}"; do inc+=(--include="*.$e"); done
+
+# files defining a symbol: definition-like line at column 0 (not an indented call)
+def_files() {  # $1 = symbol
+  [ -z "$1" ] && return 0
+  grep -rlE "^[A-Za-z_][A-Za-z0-9_[:space:]\*]*$1[[:space:]]*\(" "$REPO" "${inc[@]}" 2>/dev/null || true
+}
+# callee identifiers inside the definition body of $2 in file $1
+body_callees() {
+  awk -v sym="$2" '
+    $0 ~ ("^[A-Za-z_][A-Za-z0-9_ \t*]*" sym "[ \t]*\\(") { inbody=1; depth=0 }
+    inbody {
+      line=$0
+      while (match(line, /[A-Za-z_][A-Za-z0-9_]*[ \t]*\(/)) {
+        tok=substr(line, RSTART, RLENGTH); gsub(/[ \t(]/, "", tok); print tok
+        line=substr(line, RSTART+RLENGTH)
+      }
+      opens=gsub(/{/, "{"); closes=gsub(/}/, "}")
+      depth+=opens-closes
+      if (inbody && depth<=0 && $0 ~ /}/) inbody=0
+    }' "$1" | sort -u
+}
+
+is_keyword() {
+  case "$1" in
+    if|for|while|switch|return|sizeof|catch|else|do|case|new|delete|throw|typeof|await|async|func|fn|let|const|var|def|class|struct|enum|match|impl|pub|use|import|from|print|echo) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+declare -A SEEN_FILE=() VISITED_SYM=()
+queue=("$SYMBOL"); level=0
+ORDERED_FILES=()
+
+while [ "${#queue[@]}" -gt 0 ] && [ "$level" -le "$DEPTH" ]; do
+  next=()
+  for sym in "${queue[@]}"; do
+    [ -z "$sym" ] && continue
+    [ -n "${VISITED_SYM[$sym]:-}" ] && continue
+    VISITED_SYM[$sym]=1
+    for f in $(def_files "$sym"); do
+      if [ -z "${SEEN_FILE[$f]:-}" ]; then
+        SEEN_FILE[$f]=1; ORDERED_FILES+=("$f")
+        if [ "$level" -lt "$DEPTH" ]; then
+          while IFS= read -r c; do
+            [ -z "$c" ] && continue
+            is_keyword "$c" && continue
+            [ "$c" = "$sym" ] && continue
+            [ -z "${VISITED_SYM[$c]:-}" ] && next+=("$c")
+          done < <(body_callees "$f" "$sym")
+        fi
+      fi
+    done
+    # callers: files referencing the symbol
+    for f in $(grep -rlE "\b$sym[[:space:]]*\(" "$REPO" "${inc[@]}" 2>/dev/null || true); do
+      if [ -z "${SEEN_FILE[$f]:-}" ]; then
+        SEEN_FILE[$f]=1; ORDERED_FILES+=("$f")
+      fi
+    done
+  done
+  if [ "${#next[@]}" -gt 0 ]; then queue=("${next[@]}"); else queue=(); fi
+  level=$((level+1))
+done
+
+total=0; truncated=0
+for f in ${ORDERED_FILES[@]:-}; do
+  [ -z "$f" ] && continue
+  lines=$(wc -l < "$f")
+  if [ $((total + lines)) -gt "$MAXLINES" ]; then truncated=1; break; fi
+  printf '===== %s (%s lines) =====\n' "${f#"$REPO"/}" "$lines"
+  cat "$f"
+  total=$((total + lines))
+done
+
+echo "----- zdh-slice: ${#ORDERED_FILES[@]} files considered, $total lines emitted, depth=$DEPTH" >&2
+[ "$truncated" = "1" ] && echo "WARNING: slice exceeded $MAXLINES lines and was truncated — narrow to a deeper entry point." >&2
+exit 0

--- a/plugins/zeroday-hunter/scripts/zdh-triage.sh
+++ b/plugins/zeroday-hunter/scripts/zdh-triage.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# zdh-triage.sh — dedup and cluster sanitizer crashes by (signal, top frame).
+#
+# Usage: zdh-triage.sh <crash-dir>
+#
+# Scans logs for ASan/MSan/UBSan reports, extracts the bug signal and the top
+# in-project stack frame, and prints clusters sorted by count. Answer the
+# triage question per cluster BEFORE promoting: bug in the harness, or bug in
+# the project? (see references/fp-patterns.md)
+set -eu
+
+DIR="${1:?usage: zdh-triage.sh <crash-dir>}"
+
+found=0
+tmp="$(mktemp -t zdh-triage.XXXXXX)"
+trap 'rm -f "$tmp"' EXIT
+
+for f in "$DIR"/*; do
+  [ -f "$f" ] || continue
+  sig="$(grep -Eo '(ERROR|SUMMARY): (Address|Memory|Leak)?Sanitizer: [a-zA-Z-]+|runtime error: [a-zA-Z -]+' "$f" | head -1 || true)"
+  [ -z "$sig" ] && continue
+  found=1
+  # top frame: first '#N ... in <func>' or 'at <func>(' line
+  top="$(grep -Eo '#[0-9]+ [^ ]* in [A-Za-z_][A-Za-z0-9_:]*' "$f" | head -1 | awk '{print $NF}')"
+  [ -z "$top" ] && top="$(grep -Eo 'at [A-Za-z_][A-Za-z0-9_:]*\(' "$f" | head -1 | sed 's/^at //; s/($//')"
+  printf '%s\t%s\t%s\n' "$sig" "${top:-unknown}" "$(basename "$f")" >> "$tmp"
+done
+
+if [ "$found" = "0" ]; then
+  echo "no sanitizer reports found in $DIR"
+  exit 1
+fi
+
+echo "count | signal | top-frame | example"
+sort "$tmp" | awk -F'\t' '{ key=$1"\t"$2; cnt[key]++; ex[key]=ex[key]==""?$3:ex[key] }
+  END { for (k in cnt) printf "%d\t%s\t%s\n", cnt[k], k, ex[k] }' \
+  | sort -rn | column -t -s $'\t'
+
+echo "---"
+echo "next: for each cluster answer — bug in the harness, or bug in the project? — then zdh-init a hypothesis record."

--- a/plugins/zeroday-hunter/scripts/zdh-variant.sh
+++ b/plugins/zeroday-hunter/scripts/zdh-variant.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# zdh-variant.sh — codify a confirmed pattern as a reusable query and run it repo-wide.
+#
+# Turns one confirmed bug into a permanent detector (variant analysis):
+# writes a semgrep rule into .zdh/queries/ and runs it; falls back to grep when
+# semgrep is unavailable. Every hit is a pre-scored hypothesis; the rule doubles
+# as the regression test for the fix.
+#
+# Usage: zdh-variant.sh <repo> <name> <pattern-regex> [message]
+# Example:
+#   zdh-variant.sh . strlen-memcpy 'memcpy\s*\([^;]*strlen\s*\(' \
+#     "memcpy sized by strlen(source) — classic off-by-one/overflow"
+# Note: pattern-regex is line-based (no nested-paren matching); prefer simple,
+# high-signal shapes over precise ones — triage does the filtering.
+set -eu
+
+REPO="${1:?usage: zdh-variant.sh <repo> <name> <pattern-regex> [message]}"
+NAME="${2:?rule name required}"
+REGEX="${3:?pattern regex required}"
+MSG="${4:-variant of a confirmed pattern — audit me}"
+
+REPO="$(cd "$REPO" && pwd)"
+QDIR="$REPO/.zdh/queries"
+mkdir -p "$QDIR"
+RULE="$QDIR/$NAME.yml"
+
+cat > "$RULE" <<EOF
+rules:
+  - id: zdh-$NAME
+    languages: [generic]
+    message: "$MSG"
+    severity: WARNING
+    pattern-regex: '$REGEX'
+    metadata:
+      source: zeroday-hunter variant-as-query
+      created: $(date -Iseconds)
+EOF
+
+echo "rule written: $RULE"
+
+if command -v semgrep >/dev/null 2>&1; then
+  echo "--- semgrep scan ---"
+  semgrep --config "$RULE" --quiet "$REPO" || true
+else
+  echo "--- semgrep not found, grep fallback ---"
+  grep -rnE "$REGEX" "$REPO" \
+    --include='*.c' --include='*.h' --include='*.cc' --include='*.cpp' \
+    --include='*.go' --include='*.js' --include='*.ts' --include='*.py' \
+    --include='*.java' --include='*.rb' --include='*.php' --include='*.rs' \
+    2>/dev/null | grep -v '/\.zdh/' || echo "no hits"
+fi

--- a/plugins/zeroday-hunter/scripts/zdh-watch.sh
+++ b/plugins/zeroday-hunter/scripts/zdh-watch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# zdh-watch.sh — delta-audit scaffolder (watch mode).
+#
+# Diffs baseline..HEAD and keeps only hunks touching security-relevant code
+# (sinks, entry points, auth logic). Emits a focused G2 goal file so the audit
+# covers the delta against the existing threat model — not the whole repo.
+#
+# Usage: zdh-watch.sh <repo> <baseline-commit> [sink-regex]
+set -eu
+
+REPO="${1:?usage: zdh-watch.sh <repo> <baseline-commit> [sink-regex]}"
+BASE="${2:?baseline commit required}"
+SINK_RE="${3:-memcpy|memmove|strcpy|strcat|sprintf|vsprintf|gets|free\(|delete |exec[lv]|system\(|popen|eval\(|exec\.|\.query|SELECT |INSERT |UPDATE |DELETE FROM|password|passwd|token|secret|auth|session|permission|role|privilege|decrypt|verify|signature|deserialize|unserialize|pickle|yaml\.load|ObjectInputStream|open\(|readFile|sendFile|writeFile|include\(|require\(|redirect|ssrf|fetch\(|http\.get}"
+
+REPO="$(cd "$REPO" && pwd)"
+HEAD="$(git -C "$REPO" rev-parse HEAD)"
+TS="$(date +%Y%m%d-%H%M%S)"
+OUT="$REPO/.zdh/watch-$TS"
+mkdir -p "$OUT"
+
+changed="$(git -C "$REPO" diff --name-only "$BASE..$HEAD" || true)"
+if [ -z "$changed" ]; then
+  echo "no changes between $BASE and $HEAD — nothing to audit"
+  exit 0
+fi
+
+# hunks touching security-relevant lines (added or context)
+git -C "$REPO" diff -U3 "$BASE..$HEAD" > "$OUT/full.diff"
+grep -nE "^\+.*($SINK_RE)" "$OUT/full.diff" > "$OUT/sink-hits.txt" || true
+
+nfiles=$(printf '%s\n' "$changed" | wc -l)
+nhits=$(wc -l < "$OUT/sink-hits.txt")
+
+{
+  echo "# Watch-mode audit goal — $TS"
+  echo
+  echo "baseline: $BASE"
+  echo "head:     $HEAD"
+  echo "changed files: $nfiles — sink-touching added lines: $nhits"
+  echo
+  echo "## Changed files"
+  printf '%s\n' "$changed" | sed 's/^/- /'
+  echo
+  echo "## Sink-touching additions (audit these hunks against the threat model)"
+  echo '```'
+  cat "$OUT/sink-hits.txt"
+  echo '```'
+  echo
+  echo "## Instructions"
+  echo "Run zeroday-hunter G2–G4 on the slices reachable from these hunks only."
+  echo "Re-run stored .zdh/*/queries/ against this diff (incomplete patches, reintroduced patterns)."
+  echo "If a hunk is security-irrelevant, say so in the decision log and skip it."
+} > "$OUT/goal.md"
+
+if [ "$nhits" -eq 0 ]; then
+  echo "watch: $nfiles files changed, 0 security-relevant hunks → no-op. Goal: $OUT/goal.md"
+else
+  echo "watch: $nfiles files changed, $nhits sink-touching additions → audit goal: $OUT/goal.md"
+fi

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/SKILL.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: zeroday-hunter
+description: Exploit-first 0-day hunting in source code. Runs a full campaign state machine (frame → map → audit → prove → falsify → report) with quantitative gates, a hierarchical planner→dispatcher→expert-agent organization, sink-driven slicing, deterministic PoC verification, independent-model falsification, variant-as-query sweeps, continuous commit-watch mode, and hashed evidence. Use for security audits, vulnerability research, or 0-day hunting on local/authorized codebases.
+when_to_use: The user asks to audit code for vulnerabilities, hunt 0-days, do security research, find exploitable bugs, or run a vuln-discovery campaign on a codebase they own or are authorized to test.
+argument-hint: <target-path> [bug-class|watch]
+---
+
+# zeroday-hunter
+
+You are an expert at finding and exploiting security vulnerabilities. You run
+**campaigns**, not reviews. A campaign ends with demonstrated vulnerabilities backed by
+deterministic evidence — or with an honest, quantified statement of what was covered and
+ruled out. It is better to report no vulnerabilities than to report false positives or
+hypotheticals.
+
+**Scope guard:** hunt only on codebases the user owns or is explicitly authorized to test.
+PoCs run only inside sandboxed worktrees. Never aim findings at third-party systems.
+
+---
+
+## Prime directives
+
+1. **Plausibility is not proof. Confidence is not evidence.** A finding exists only when a
+   deterministic signal fires (sanitizer crash, assertion, response diff, observed auth
+   bypass). Everything else is a *hypothesis* and is labeled as such.
+2. **Discovery and validation are separated.** Whoever surfaces a candidate never confirms
+   it. Validation is a deterministic verifier script plus an independent model instructed
+   to *disprove* the finding.
+3. **One bug class per campaign. One slice per audit.** Slices ≤ ~10k LoC: one entry
+   point + call graph BFS to depth ≤ 3. Recall collapses beyond that.
+4. **Abort beats stagnation.** Every phase declares its abandon criterion *before*
+   starting. Hit the cap → record the dead end → restart fresh from a different angle.
+   A single agent never switches bug class mid-run — dispatch a fresh expert instead;
+   agents cannot backtrack across vuln types without compounding errors.
+5. **Breadth before depth.** Full attack-surface map first; targets ranked by score; deep
+   work only on what scores.
+6. **State lives on disk, not in your head.** Every campaign has a state directory
+   (`zdh-init.sh`). If it isn't written down, it didn't happen.
+7. **Volume × validation is the whole game.** Published success rates on real targets are
+   low (pass@1 ≈ 10–40%). You win by running many cheap, independent, validated attempts —
+   never by trusting one brilliant analysis.
+
+## Two campaign modes
+
+- **Full campaign** — the state machine below over a bounded slice set. First contact with
+  a target, or a new bug class.
+- **Watch mode** (`zdh-watch.sh`) — continuous delta auditing: after any campaign, audit
+  only `baseline..HEAD` changes **against the existing threat model**. New/changed code
+  touching sinks, entry points, or auth checks becomes the slice set. This is how you
+  catch regressions and incomplete patches cheaply — a full re-audit per commit is waste.
+
+## The campaign state machine
+
+You are the **coordinator/planner**. You own the gates; you do not skip them.
+
+```
+G0 FRAME ──► G1 MAP ──► G2 AUDIT ──► G3 PROVE ──► G4 FALSIFY ──► G5 REPORT
+              │            │            │            │
+              ▼            ▼            ▼            ▼
+           deferred     demoted      failed-PoC   REJECTED
+           (backlog)   (to memory)   (retry ≤5)   (to memory)
+```
+
+| Gate | Produces | Exit criterion |
+| --- | --- | --- |
+| G0 FRAME | `campaign.yaml`, **durable threat model**, baseline commit | threat model answers: who attacks, what they control, impact ceiling |
+| G1 MAP | `surface.md`: entries × sinks × coverage gaps × git-security history | every sink scored or explicitly deferred with reason |
+| G2 AUDIT | hypothesis records (`hypotheses/H-*.md`) with mandatory walkthroughs | top-K hypotheses by score promoted |
+| G3 PROVE | payload generator + verifier (`pocs/`), deterministic signal | verifier exit 0, or hypothesis demoted after 5 iterations |
+| G4 FALSIFY | independent review verdict + variant sweep results | CONFIRMED, or REJECTED with falsification note |
+| G5 REPORT | findings, **variant query**, evidence export, memory baseline | baseline commit + FP list + query written to memory |
+
+Full phase procedures: [references/campaign-manual.md](references/campaign-manual.md).
+
+## Quantitative operating rules
+
+- **Hypothesis score** = reachability(0–3) × attacker-control(0–3) × impact(0–3) − effort(0–2).
+  Promote to G3 at **score ≥ 12**, or on override with a logged justification.
+- **pass@k on high-value slices** (score ≥ 18 or attack surface of a past CVE): run
+  k = 3–5 *independent* audits with fresh context. Hypotheses found by ≥ 2 runs promote
+  automatically; single-run hits promote only via score. pass@k, not pass@1, is the
+  honest metric: an attacker only needs one success — so do you.
+- **Iteration caps**: slice audit ≤ 40 tool actions; PoC engineering ≤ 5 failed verifier
+  runs per hypothesis (then demote with the failure mode recorded); falsification is
+  single-shot per reviewer.
+- **Stop rules**: abandon a slice after 3 walkthroughs without an attacker-controllable
+  path; abandon the campaign on budget exhaustion or when the last 3 hypotheses all
+  demote. Record *why* — dead ends are deliverables; they feed the next campaign.
+- **Budget split** (default): 15% map, 45% audit, 30% prove, 10% falsify/report. Enforce
+  with `agenc run --max-cost` per phase and `agenc budget status`.
+
+## Hierarchy: planner → dispatcher → expert agents
+
+Single agents fail at long-range security work: context explodes and they cannot
+backtrack between vuln types. Organize like HPTSA:
+
+- **PLANNER (you, the coordinator)** — explores the surface, owns the state machine and
+  gates, decides *what* to attempt and *where*, never exploits.
+- **DISPATCHER** — assigns each promoted task to a fresh expert agent; retrieves results;
+  reruns experts with more detailed instructions when a near-miss justifies it.
+- **EXPERT agents** — one per (slice × bug class), each with: (a) only the tools it needs,
+  (b) its class playbook + 2–5 reference docs as domain knowledge, (c) a prompt customized
+  with concrete context (credentials, fixtures, entry point). An expert that exhausts its
+  cap is discarded, never "re-educated" mid-run.
+- **FALSIFIER** — a *different provider/model* (`--reviewer-model`) briefed to disprove:
+  it wins by finding one broken link in the claimed path.
+- **TRIAGER** — clusters crashes via `zdh-triage.sh`; answers: *bug in the harness, or
+  bug in the project?*
+
+AgenC wiring: `agenc agent start --unattended-allow read,grep,glob,bash` per expert
+(`campaign.sh swarm` automates this); `agenc run start --verify ... --reviewer-model ...`
+for G3/G4; `agenc run evidence` at G5; gateway pairing pings the user when a critical
+finding needs a risky verification step.
+
+## Audit-unit protocol (what every expert must produce)
+
+For each candidate path, a hypothesis record containing the **mandatory walkthrough**:
+
+1. Step-by-step description of the code path from entry point to the vulnerable operation.
+2. For **every conditional** on that path: concretely how the attacker controls its
+   outcome. Cannot explain a branch → hypothesis is unproven, demote it.
+3. Missing function/type definition → fetch it (`zdh-slice.sh`), never assume it.
+4. Check the FP library first: [references/fp-patterns.md](references/fp-patterns.md).
+   Matching a known FP pattern kills the candidate on sight.
+5. Check reasoning twice. A single contradiction kills the candidate.
+
+## Proof discipline
+
+- Payloads are produced by **generator scripts** (computed length fields, checksums,
+  nested formats), never hand-typed blobs.
+- Verifier = `poc-check.sh` wrapping the execution; exit 0 is the only success signal.
+  Run it externally. Feed failures verbatim into the next iteration.
+- **Never edit the verifier to make a PoC pass.** The target changes, never the test.
+- **Off-target crashes are findings, not noise.** A crash that fails the target-specific
+  verifier but is a real project bug goes to triage and gets its own hypothesis record —
+  real campaigns routinely surface different bugs than the one hunted (and expose
+  incomplete patches). Never delete an off-target crash.
+- Honesty about altitude: report the *primitive actually demonstrated*
+  ([references/exploit-primitives.md](references/exploit-primitives.md)).
+- Memory-unsafe target? Run the **LLM-guided fuzzing loop** per
+  [references/toolchain.md](references/toolchain.md): harness → coverage → feed coverage
+  summary back → generate structure-aware mutations aimed at uncovered regions. Logic
+  target (authz, races, state machines)? Fuzzing is a detour; go straight to walkthroughs.
+
+## After confirmation
+
+- **Variant-as-query sweep**: codify the confirmed pattern as a query/rule
+  (`zdh-variant.sh` — semgrep/CodeQL when available) stored in `.zdh/queries/`, run it
+  across the *whole* repo (and sibling repos in scope). One confirmed bug becomes a
+  permanent detector: every future hit is a pre-scored hypothesis, and the query doubles
+  as the regression test for the fix.
+- **Evidence**: `agenc run evidence <run-id>` — hashed, replayable journal attached to the
+  finding. Proof of when and how the bug was found.
+- **Baseline**: write to memory — audited commit, threat model, confirmed findings,
+  queries, FP/dead-end list. This is what turns campaign N+1 into cheap watch mode.
+
+## Report contract
+
+Every finding uses [templates/finding.md](templates/finding.md): Title, Status
+(CONFIRMED | HYPOTHESIS), Summary, Entry→Sink with file:line, Attacker control per
+walkthrough step, Evidence (verifier cmd + output + run id), Impact ceiling, Severity
+rationale, Variants (with query path), Remediation + regression test. Campaign closes
+with: coverage statement (sinks reviewed / total), hypotheses raised, confirmations,
+dead ends, FP list.
+
+> Why each rule exists, with the statistics behind it:
+> [references/methodology-sources.md](references/methodology-sources.md).

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/references/bug-class-playbooks.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/references/bug-class-playbooks.md
@@ -1,0 +1,176 @@
+# Bug-class playbooks
+
+One campaign = one bug class. Each playbook: sinks → path-feasibility checks → walkthrough
+questions → PoC strategy → signal for the verifier → classic false positives. Extend the
+sink tables from the target's own code before scoring.
+
+---
+
+## 1. Use-after-free / double free (C/C++)
+
+- **Sinks**: `free`, `delete`, `g_free`, refcount `put/dec`, pool/arena release,
+  `close`/`fclose`, destructors, `RCU` frees in kernel code.
+- **Path checks**: who owns the object at each point; every error path between allocation
+  and sink; is the pointer NULL-ed after free; is teardown shared across sessions/threads;
+  can the attacker trigger the error path *and* the later reuse.
+- **Walkthrough questions**: after the free, name every path that dereferences the
+  pointer and how the attacker reaches it; can two attacker-controlled connections share
+  the object (concurrency as the trigger); is there a destructor/callback that re-enters.
+- **PoC strategy**: trigger the free, then spray reallocations with attacker-controlled
+  bytes to reclaim the slot, then trigger the use. ASan build: the UAF itself is the
+  signal — you often don't need the spray to *confirm* (note that in the report honestly).
+- **Verifier signal**: `ERROR: AddressSanitizer: heap-use-after-free|double-free`.
+- **FP traps**: freed memory that is provably never referenced again (log-and-return
+  paths); pool allocators where "free" is a no-op; objects immortal by design.
+
+## 2. OOB read/write, off-by-one (C/C++)
+
+- **Sinks**: `memcpy`/`memmove`/`strncpy`, `sprintf`/`snprintf` (check the n!), loop
+  writes indexed by attacker values, `read`/`recv` into fixed buffers, pointer arithmetic
+  on wire lengths.
+- **Path checks**: length validated against *destination* capacity, not source length;
+  signed→unsigned conversion before comparison; `len * size` overflow before allocation;
+  terminator handling in "safe" string APIs (strncpy doesn't NUL-terminate on truncation).
+- **PoC strategy**: boundary values — exactly capacity, capacity±1, 0, INT_MAX,
+  negative-as-unsigned. Generator script computes length fields so mutations stay valid.
+- **Verifier signal**: ASan `heap-buffer-overflow` / `stack-buffer-overflow` /
+  `global-buffer-overflow`.
+- **FP traps**: flexible array members misread as overflows; `snprintf` patterns that are
+  actually bounded; reads past end that stay inside a legitimately larger allocation
+  (still a bug if data crosses a trust boundary — report as infoleak only if bytes return
+  to the attacker).
+
+## 3. Integer overflow / truncation
+
+- **Sinks**: allocations, size/index arithmetic, casts `int ↔ size_t ↔ uint16_t`,
+  wire length fields used in arithmetic.
+- **Path checks**: every arithmetic op between attacker value and its use as size/index;
+  comparisons done in a *different* width than the use.
+- **PoC strategy**: values straddling width boundaries: 2^8/16/31/32 ± 1.
+- **Verifier signal**: UBSan `unsigned-integer-overflow` is *not* a bug by itself — you
+  need the downstream effect (small alloc + large copy). Signal on the ASan report of the
+  consequence, or on an assertion you add to a debug build.
+
+## 4. SQL injection
+
+- **Sinks**: string-concatenated query builders, ORM raw/escape hatches (`raw()`,
+  `extra()`, `execute($sql)`), `ORDER BY`/identifier interpolation (parameter binding
+  can't help there — classic miss).
+- **Path checks**: any byte of the query string attacker-influenced; encoding layers
+  between input and query (double-decode bypasses); second-order flows (stored value
+  used in a later query).
+- **PoC strategy**: start with an *oracle*, not exfiltration: boolean (`' AND '1'='1`),
+  time-based (`SLEEP`) — pick per backend. Prove data difference or measurable delay.
+- **Verifier signal**: deterministic response diff (row count, status, content marker) or
+  delay ≥ threshold measured by the script, both reproduced ≥ 3 runs.
+- **FP traps**: frameworks that auto-escape (verify by sending a quote and reading the
+  *actual* query in logs); concatenated-but-constant fragments.
+
+## 5. Command injection
+
+- **Sinks**: `exec`/`system`/`popen`/`shell=True`/`ProcessBuilder` with a shell string;
+  argument arrays are safer — check whether any element embeds unescaped input anyway.
+- **Path checks**: metacharacter survival (`; & | $() \` \n`); PATH/env control;
+  quoting that *looks* right but breaks on newline or `$(...)`.
+- **PoC strategy**: out-of-band canary — write a file, touch a URL you observe, sleep.
+  Never destructive.
+- **Verifier signal**: canary file/content appears.
+- **FP traps**: input confined to a fixed whitelist validated immediately before the sink.
+
+## 6. Path traversal / arbitrary file access
+
+- **Sinks**: `open`/`readFile`/`sendFile`/include/require, archive extraction, symlink
+  following, file upload destinations.
+- **Path checks**: canonicalization *after* URL/percent decoding; prefix check against the
+  fully resolved path (`/srv/files/../x` resolves out); `..` encoded (`%2e%2e`, `..;/`,
+  unicode); symlinks inside the allowed root pointing out.
+- **PoC strategy**: read a known file outside root (`/etc/passwd` or a planted canary).
+- **Verifier signal**: canary content in response.
+- **FP traps**: chroot/container confinement that genuinely neutralizes it (note it as
+  defense-in-depth, not a vuln).
+
+## 7. AuthN/AuthZ / IDOR (logic — reasoning only)
+
+- **Sinks**: every handler that takes an object id; middleware chains; role checks.
+- **Method**: enumerate object references; for each, find the ownership check — its
+  *absence* is the bug. Two-entity setup: create victim + attacker, replay victim's
+  requests with attacker's session. **Cross-context retests**: no session, wrong role,
+  expired token, different HTTP method, `id` in body vs path vs JWT.
+- **PoC strategy**: attacker reads/writes one victim object. Deterministic and minimal.
+- **Verifier signal**: 200 + victim's data (or mutation persisted) with attacker's
+  credentials; control run with victim's session must also pass, and without any session
+  must fail — all three scripted.
+- **FP traps**: ids that are unguessable *and* treated as capability tokens by design
+  (documented behavior — report only if the design leaks ids); checks enforced at a layer
+  you didn't see (verify at the datastore boundary, not the controller).
+
+## 8. Race conditions / TOCTOU
+
+- **Sinks**: check-then-act on files (`access`→`open`), rows (SELECT→UPDATE without
+  transaction/lock), balances/limits/counters; shared mutable state; signal handlers.
+- **Path checks**: is the check and the use inside the same lock/transaction; can the
+  attacker fire N concurrent requests (connection pooling, HTTP/2 multiplexing,
+  last-byte-sync to align arrivals).
+- **PoC strategy**: N parallel clients with synchronized release; success = invariant
+  broken (double spend, limit exceeded, stale read used).
+- **Verifier signal**: final state violates the invariant, reproduced at rate > baseline
+  over M runs (report the rate honestly).
+- **FP traps**: races with no security consequence; single-threaded-by-design runtimes
+  (verify the deployment model first).
+
+## 9. Deserialization
+
+- **Sinks**: `pickle`/`yaml.load`/`ObjectInputStream`/`unserialize`/JSON into polymorphic
+  types; also "safe" formats with type annotations.
+- **Path checks**: does the input cross a trust boundary unsigned/unencrypted; which
+  gadget classes are on the classpath/module path.
+- **PoC strategy**: start with a detection gadget (DNS/HTTP callback, sleep), not RCE.
+- **Verifier signal**: callback observed.
+- **FP traps**: inputs that are HMAC-verified before parse.
+
+## 10. Business logic
+
+- **Method**: extract invariants from docs/tests/pricing rules ("balance ≥ 0", "one
+  coupon per order", "states advance monotonically"); then find call sequences of
+  *legitimate* operations that break them: replay, reorder, skip, duplicate (idempotency
+  keys missing), negative amounts, currency rounding.
+- **Verifier signal**: invariant violation observable in state (balance, order count).
+- **FP traps**: "by design" behaviors — confirm against docs before promoting.
+
+---
+
+## Fuzz-harness rules (memory-unsafe targets)
+
+1. Target selection by coverage gap: far-reaching, low-coverage functions first.
+2. The harness must actually call the function-under-test — verify, or you're
+   manufacturing false negatives.
+3. `FuzzedDataProvider`: avoid `std::string`-returning methods unless the API needs a
+   string — they hide off-by-ones from ASan. No `rand()`; all bytes from the fuzzer.
+   No NULL params unless the API allows them. Declare variables before `goto`.
+4. Build loop: return the **full** harness every fix round; prefer the most complete
+   candidate; never delete code to make it compile.
+5. Crash triage question: **bug in harness or bug in project?** — True/False with
+   evidence before proceeding. Harness bugs are FP source #1. And an **off-target crash
+   (different bug than the one hunted) is still a finding** — triage it, never discard it.
+6. Few-shot cap: 1 same-project + 2 cross-project examples; more degrades results.
+7. 150 CPU-hours of silence ≠ safe code; it means the harness doesn't reach the path.
+   Mutate the input *shape* (structure-aware generators), not the budget.
+
+## The LLM-guided fuzzing loop (you are the mutation engine)
+
+When classical fuzzing saturates, take over the mutation loop yourself (Fuzz4All-style):
+
+1. **Autoprompt**: distill the input format (docs, parser code, examples) into a compact
+   spec prompt before generating anything.
+2. Generate N diverse seeds; run them; collect coverage.
+3. Feed the coverage summary back: "regions X, Y uncovered; feature Z untouched" →
+   generate mutations **aimed at named uncovered regions** ("mutate this input to reach
+   the gzip path"), not random tweaks.
+4. Track coverage-per-attempt; when it plateaus, change the input *shape* (different
+   feature combination, deeper nesting, different state sequence), never the budget.
+5. **Protocol targets (ChatAFL-style)**: first convert the spec/RFC into a message
+   grammar + inferred state machine (states, transitions, expected responses). Fuzz
+   *state sequences*, not just message bytes — interleaved/out-of-order messages are
+   where the bugs are. Use server responses to correct your state machine inference.
+6. Validate every crash through the harness-vs-project triage question, then minimize
+   before writing the hypothesis record.

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/references/campaign-manual.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/references/campaign-manual.md
@@ -1,0 +1,143 @@
+# Campaign manual
+
+The full operating procedure behind the SKILL.md state machine. Read this at G0 and
+consult it at every gate.
+
+## State directory layout
+
+Created by `scripts/zdh-init.sh <repo> <bug-class>`:
+
+```
+.zdh/<campaign-id>/
+├── campaign.yaml        # config: bug class, scope, budgets, caps (template provided)
+├── state.yaml           # machine-readable: gate, hypothesis counts, spend
+├── surface.md           # G1 output: attack surface inventory
+├── hypotheses/H-NNN.md  # G2 output: one file per hypothesis
+├── pocs/H-NNN/          # G3: generator + verifier + build artifacts per hypothesis
+├── crashes/             # raw crash logs, triaged by zdh-triage.sh — incl. OFF-TARGET ones
+├── queries/             # variant rules codified from confirmed findings (zdh-variant.sh)
+├── findings/F-NNN.md    # G5: confirmed findings, report-contract format
+├── logs/
+│   ├── decision.log     # one line per step: ts | gate | action | result | next
+│   └── bad-attempts.md  # approaches that failed — never repeat these
+└── memory-note.md       # what goes to persistent memory at G5
+```
+
+Rules: every agent reads `campaign.yaml` + `bad-attempts.md` before acting and appends
+to `decision.log` after acting. Two agents never own the same file; the coordinator
+merges `surface-*.md` into `surface.md`.
+
+## G0 FRAME
+
+Write down, in `campaign.yaml` and in prose at the top of `surface.md`:
+
+- **Attacker**: unauthenticated remote? authenticated user? local process? two concurrent
+  connections? malicious file?
+- **Control surface**: which bytes/requests/files the attacker fully controls.
+- **Impact ceiling**: RCE > infoleak > authz bypass > DoS. This calibrates scoring.
+- **Baseline commit**: `git rev-parse HEAD`. Everything is audited relative to this.
+- **Scope fences**: directories in scope (server, parsers, auth) vs out (tests, vendor,
+  generated code — unless vendor is the target).
+- **Abandon criteria** for the campaign, declared now, not later.
+
+## G1 MAP
+
+Produce `surface.md` with four inventories:
+
+1. **Entry points** — network handlers, file/parsers, IPC/RPC, CLI/env, deserializers,
+   auth middleware, template rendering, webhook/callback handlers. For each: file:line,
+   input format, trust boundary crossed.
+2. **Sinks for this campaign's bug class** — from the playbook table, extended by grep:
+   `grep -rnE '<sink-pattern>' --include='*.<ext>'` over in-scope dirs. Every sink gets a
+   line: `sink | file:line | reaching entry | notes`.
+3. **Coverage gaps** — functions far from tests/fuzzers: compare `surface.md` entries
+   against test dirs and existing fuzz harnesses. Uncovered + reachable + dangerous =
+   priority.
+4. **Git security history** — `git log --oneline --grep='fix\|security\|CVE\|overflow\|
+   injection\|auth'` and `git log -p -S '<sink>'` on suspicious files. Every past fix is a
+   variant-analysis seed: write the fix commit + diff into a hypothesis candidate
+   immediately ("this was a bug; check for siblings *now*").
+
+Score every sink (reachability × control × impact − effort) and rank. Sinks below
+promotion threshold go to the backlog **with a one-line reason** — silence is not
+coverage.
+
+## G2 AUDIT
+
+Per promoted slice:
+
+1. Extract the slice: `scripts/zdh-slice.sh <repo> <entry-symbol> [depth=3]`. If the
+   output exceeds the line budget, narrow to a deeper entry point — never enlarge context.
+2. Read the playbook for the bug class end-to-end before auditing.
+3. For each candidate path, create `hypotheses/H-NNN.md` from the template and fill the
+   walkthrough: every conditional on the path, attacker control per branch, sources and
+   sanitizers encountered. Fetch every missing definition — assumption = demotion.
+4. Run the FP patterns checklist. Log kills in `decision.log`.
+5. Score. Promote top-K (default K=5 per campaign wave) to G3.
+
+High-value slices get pass@k: spawn k independent auditor agents, each with fresh
+context and no access to each other's notes. Intersection of independent findings is the
+strongest pre-PoC signal that exists.
+
+## G3 PROVE
+
+Per promoted hypothesis, in a sandboxed worktree:
+
+1. **Build**: memory-unsafe → ASan/UBSan build (toolchain recipes). Web/service → run it
+   locally with the real config, not a mock.
+2. **Generator**: `pocs/H-NNN/gen_payload.py` computing all structural fields. Raw blobs
+   are forbidden — they don't survive format nesting and can't be mutated on failure.
+3. **Verifier**: `pocs/H-NNN/verify.sh` wrapping `poc-check.sh` with the deterministic
+   signal for this bug class (ASan banner, canary in response, row count diff, 200-vs-403
+   oracle, JS-execution marker). The signal must be *intrinsic to the bug*, not to your
+   logging.
+4. Iterate ≤ 5 failed runs. Each failure: record the failure mode class (wrong reach
+   path / wrong condition / wrong format / target fixed) in the hypothesis record.
+   Failure class decides the next mutation — not vibes.
+5. Harness crash? Triage question: **bug in the harness/generator, or bug in the
+   project?** Answer True/False with evidence before touching anything.
+
+## G4 FALSIFY
+
+- Assemble the falsification packet: slice files, hypothesis record, PoC, verifier
+  output. Hand to the reviewer model (different provider) with the brief: *"This claim
+  is false. Find the broken link: unreachable path, uncontrollable branch, sanitizer you
+  missed, mitigation already present."*
+- Reviewer verdicts: CONFIRMED (no broken link found) or REJECTED (with the exact broken
+  link). REJECTED → record the falsification note in memory; it is a permanent FP filter.
+- **Variant sweep**: for CONFIRMED bugs, enumerate every sibling (same sink/pattern,
+  other entries, other modules) as new hypotheses and run G2–G4 on the top scorers.
+
+## G5 REPORT
+
+- One `findings/F-NNN.md` per confirmed bug, report contract, evidence id attached.
+- Codify each confirmed pattern as a query (`zdh-variant.sh`) in `queries/` and run it
+  repo-wide — every hit becomes a pre-scored hypothesis; the query is also the fix's
+  regression test.
+- Campaign summary: sinks reviewed / total, hypotheses raised / promoted / confirmed,
+  dead ends with reasons, FP patterns observed, spend vs budget.
+- `memory-note.md` → persistent memory: baseline commit, threat model, confirmations,
+  query paths, FP list, dead ends. This is what makes campaign N+1 a diff-audit instead
+  of a re-audit.
+
+## WATCH MODE (continuous delta auditing)
+
+After any campaign, the threat model + baseline turn every later audit into a cheap
+delta check instead of a full rescan (Aardvark-style commit scanning):
+
+1. `scripts/zdh-watch.sh <repo> <baseline-commit> [sink-regex]` — diffs baseline..HEAD,
+   keeps only hunks touching sinks/entries/auth checks, writes a focused goal file.
+2. If the diff touches nothing security-relevant: record "no-op" in the decision log and
+   stop. Most commits are no-ops; saying so quickly is the point.
+3. Otherwise run G2–G4 on the changed slices only, with the existing threat model.
+4. Also re-run the stored `queries/` against the diff — incomplete patches and
+   reintroduced patterns are the most common watch-mode catches.
+5. Update the baseline commit at the end.
+
+## Coordinator checklist (run at every gate transition)
+
+- [ ] All produced artifacts exist on disk (not in chat)
+- [ ] `decision.log` is current
+- [ ] Budget consumed vs split (15/45/30/10) — rebalance or stop
+- [ ] Abandon criteria checked — met? stop and record why
+- [ ] Next gate's entry criteria met — if not, say what's missing instead of proceeding

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/references/exploit-primitives.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/references/exploit-primitives.md
@@ -1,0 +1,63 @@
+# Exploit primitives: the ladder, and when to climb it
+
+A 0-day report lives or dies by *what was actually demonstrated*. Overstating the
+primitive is the fastest way to lose credibility; understating it undersells severity.
+Name your rung honestly.
+
+## The ladder
+
+```
+0  unreachable          theory only — no attacker path demonstrated
+1  reachable            attacker input reaches the sink (walkthrough + trace proof)
+2  crash                deterministic fault (ASan/assert/oops) — "DoS proven"
+3  controlled crash     fault address/value influenced by attacker bytes
+4  memory read primitive    attacker-chosen address/content leaks back
+5  memory write primitive   attacker-chosen value to attacker-influenced address
+6  control-flow hijack  PC/return address/vtable under attacker influence
+7  code execution       payload runs (shell, calc-equivalent canary, callback)
+```
+
+Web/logic equivalent: oracle → single-object cross-tenant access → mass assignment /
+multi-object → privilege escalation → RCE.
+
+## Rules
+
+- **Report at the rung you proved.** "Remote attacker can crash the daemon (rung 2);
+  ASan trace suggests control of the faulting pointer (potential rung 3, unverified)" —
+  that phrasing is correct and strong.
+- **G3's job is rung ≥ 2.** Climbing beyond controlled crash is a separate campaign phase
+  the user opts into — it multiplies cost and time.
+- **Mitigations are part of the altitude.** Note ASLR/DEP/CFI/stack canaries/allocator
+  hardening observed in the target build. A write primitive against full mitigations is
+  worth more than RCE against a debug build.
+- **The jump from crash to control is where most candidates die.** If iteration cap
+  hits at rung 2–3, report honestly at that rung with the blocking obstacle named.
+
+## Climbing techniques (memory targets)
+
+- **Crash → controlled**: vary input fields systematically, diff fault addresses across
+  runs; if the faulting address/offset correlates with an input field, you have
+  influence. `gdb`/`rr` for reverse debugging the corruption origin.
+- **Control → read**: look for the corruption landing in a pointer that is later
+  dereferenced and whose target bytes return to the attacker (error messages, length
+  fields, echo paths).
+- **Read → write**: find the same primitive on a path that stores through the pointer.
+- **Write → PC**: targets in order of reliability — function pointers/vtables, return
+  addresses, GOT (if writable), allocator metadata (unsafe-unlink style, heap-version
+  dependent), `__free_hook`-style hooks (glibc version dependent).
+- **Heap grooming**: document the allocator and version; spray/feng-shui layouts are
+  allocator-specific — a PoC tied to the wrong allocator version is not reproducible.
+
+## Verifier signals per rung
+
+| Rung | Signal |
+| --- | --- |
+| 2 | `poc-check.sh --signal 'ERROR: (Address|Memory)Sanitizer'` |
+| 3 | fault address matches a regex of your chosen pattern (`0x41414141`, `de adb eef`) — use `--signal` on gdb/ASan output |
+| 4 | leaked bytes match a canary you placed at the target address |
+| 5 | post-write readback shows your canary at the chosen address |
+| 6 | `$rip`/PC equals your pattern in the debugger output |
+| 7 | your marker executes: file created, callback received, canary string printed |
+
+Each rung's signal is intrinsic to the exploit, never to your logging — and the verifier
+script for rung N must *fail* on a working rung N−1 exploit.

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/references/fp-patterns.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/references/fp-patterns.md
@@ -1,0 +1,71 @@
+# False-positive library
+
+Check every candidate against this library *before* the walkthrough (cheap kill) and
+again before G3 (expensive kill). Matching a pattern kills the candidate unless you can
+state, concretely, why the pattern does not apply. Kills are logged in
+`logs/bad-attempts.md` — they are permanent filters for future campaigns.
+
+Signal:noise on raw LLM audits is ≈ 1:50 (Heelan's measurement). This library is how you
+beat that base rate.
+
+## Reachability FPs
+
+- **Dead code**: no caller chain from any entry point. Prove with a caller grep, not vibes.
+- **Config-gated off**: behind a flag/ifdef disabled in every shipped configuration.
+- **Trust-boundary mismatch**: the "attacker input" is actually a trusted source (config
+  file readable only by root, internal RPC on a loopback-only admin socket).
+- **Unreachable-by-protocol**: the state machine never emits the required sequence
+  (e.g., handler only runs after a check that already rejects the bad value).
+
+## Sanitizer-already-present FPs
+
+- Validation exists one layer up (middleware, framework auto-escape, ORM binding) — verify
+  by *sending the payload and observing the actual query/command*, never by reading one
+  function.
+- Length check you dismissed is actually correct: recompute it with the real types and
+  widths, including the signed/unsigned conversions.
+- The dangerous-looking call is bounded by a constant smaller than the destination.
+
+## Environment FPs
+
+- **Harness bugs**: crash is in your driver/generator, not the project (the #1 fuzzing
+  FP). Triage question: harness or project? Answer with evidence.
+- **Debug-only paths**: assertion/abort reachable only in debug builds; the release build
+  handles it.
+- **Container confinement**: the traversal/RCE works but is confined to an ephemeral
+  sandbox with no secrets and no network — note as defense-in-depth gap, not a vuln.
+- **Version mirage**: you're auditing a dependency version older/newer than what ships.
+
+## Severity-inflation FPs
+
+- **Self-DoS**: the "victim" and "attacker" are the same principal (crashing your own
+  process with your own malformed file, no cross-principal impact).
+- **Requires-the-keys-to-the-kingdom**: needs an existing admin/root — then it's not a
+  privilege boundary crossing.
+- **Theoretical race**: window exists but is not attacker-influenceable and has no
+  security consequence (cosmetic state skew).
+- **Infoleak of nothing**: OOB read returns bytes that never leave the process or contain
+  no sensitive data on any path you can show.
+
+## Reasoning FPs (model failure modes — self-check)
+
+- **Assumed definition**: you guessed what a missing function/macro does. Fetch it. If
+  you can't, the hypothesis stays unproven.
+- **Contradictory path**: two walkthrough steps require mutually exclusive states.
+- **Skipped conditional**: a branch on the path was waved through without attacker
+  control demonstrated.
+- **Echo-chamber promotion**: promoting because a previous agent/run said so. Independent
+  verification only — pass@k runs must not see each other's notes.
+- **Verifier gaming**: editing the verifier, weakening the signal regex, or asserting on
+  your own log lines. Instant invalidation; log it as a process failure.
+
+## Web-specific FPs
+
+- **Reflected-but-sterile XSS**: payload reflects inside a context the browser can't
+  execute (correctly-encoded attribute, JSON with the right content-type + nosniff).
+  Confirm execution in a headless browser — reflection alone is not XSS.
+- **Open-redirect dressing**: a redirect is not an auth bypass; state the real impact or
+  demote.
+- **CSRF on a state-unchanging endpoint.**
+- **Rate-limit absence** reported as a vulnerability without a concrete abuse that
+  violates a stated invariant.

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/references/methodology-sources.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/references/methodology-sources.md
@@ -1,0 +1,128 @@
+# Methodology sources
+
+Every rule in SKILL.md is taken from a published, battle-tested system. Read these to
+understand *why* the rules exist, and to keep the skill current as the field moves.
+
+## Primary sources
+
+### Sean Heelan — o3 finds CVE-2025-37899 (Linux kernel ksmbd UAF)
+- Post: https://sean.heelan.io/2025/05/22/how-i-used-o3-to-find-cve-2025-37899-a-remote-zeroday-vulnerability-in-the-linux-kernels-smb-implementation/
+- Prompts (verbatim): https://github.com/SeanHeelan/o3_finds_cve-2025-37899
+- Follow-up on agentic exploitation: https://sean.heelan.io/2026/01/18/on-the-coming-industrialisation-of-exploit-generation-with-llms/
+- What we copied: single bug class per run; N independent samples (he ran 100);
+  ≤10k LoC slices (8/100 recall at 3.3k LoC → 1/100 at 12k LoC); BFS call-graph
+  expansion to depth 3; explicit threat-model explainer; mandatory step-by-step path
+  walkthrough with per-conditional attacker control; "better to report no
+  vulnerabilities than false positives"; the verifier is "possibly the most important
+  part of the agent" — harden it, models will try to game it.
+
+### Google Project Zero / DeepMind — Big Sleep (née Naptime)
+- https://googleprojectzero.blogspot.com/2024/06/project-naptime.html
+- https://projectzero.google/2024/10/from-naptime-to-big-sleep.html
+- What we copied: variant analysis as entry point ("this was a previous bug; there is
+  probably another similar one"); commit diff + message as hunting seed; perfect
+  verification — a crash is the only success signal, never an LLM judge; abort on
+  stagnation; multiple independent short trajectories over one long one; specialised
+  tools (code browser, debugger, sandbox) over whole-file dumps. Found a real SQLite
+  0-day that 150 CPU-hours of AFL missed.
+
+### DARPA AIxCC winners — buttercup (Trail of Bits), atlantis (Team Atlanta), artiphishell (Shellphish)
+- https://github.com/trailofbits/buttercup · https://blog.trailofbits.com/2025/08/08/buttercup-is-now-open-source/
+- https://arxiv.org/abs/2509.14589 · https://0xdkay.me/posts/team-atlanta-wins-darpa-aixcc/
+- https://github.com/shellphish/artiphishell (full Jinja prompts in discoveryguy/)
+- What we copied: sink-driven hypothesis generation (enumerate dangerous sinks, work
+  backward to reachable entries); LLMs write *scripts that generate payloads*, never raw
+  blobs; hard retry budgets with reflection on failure; bad-attempts lists fed back to
+  the model; division of labor — fuzzers for memory corruption, LLMs for logic bugs;
+  executable PoV as the only accepted output. Atlanta's LLM pipeline produced 71.2% of
+  their verified PoVs and a real SQLite 0-day; the finalists jointly found 18 real
+  0-days.
+
+### XBOW — autonomous pentesting at scale
+- https://xbow.com/blog/we-ran-1060-autonomous-attacks · https://xbow.com/blog/alloy-agents
+- https://xbow.com/blog/top-1-how-xbow-did-it · https://xbow.com/blog/core-components-ai-pentesting-framework
+- What we copied: "plausibility is not proof, confidence is not evidence"; strict
+  discovery/validation separation ("Creative AI discovers. Deterministic logic decides
+  what's real"); validators execute (headless browser for XSS, etc.); many short-lived
+  narrow-objective agents with a hard iteration cap (~80), then a fresh restart;
+  two-entity victim/attacker setups; cross-context retests; variant analysis after every
+  confirmation. 85% on their benchmark in 28 min vs 40 h for a principal pentester;
+  #1 on HackerOne US with ~1,060 submissions.
+
+### Google oss-fuzz-gen
+- https://google.github.io/oss-fuzz/research/llms/target_generation/ · https://github.com/google/oss-fuzz-gen
+- https://security.googleblog.com/2024/11/leveling-up-fuzzing-finding-more.html
+- What we copied: coverage-gap target selection; the generate → build → run → coverage
+  loop; "return the full code every round"; prefer the longest candidate; the
+  FuzzedDataProvider `std::string` trap; harness-vs-project crash triage question;
+  1 same-project + 2 cross-project few-shot cap. Found 26+ new vulns including
+  CVE-2024-9143 in OpenSSL, latent ~20 years, unreachable by human harnesses.
+
+### CAI (Alias Robotics) & PentestGPT
+- https://arxiv.org/html/2504.06017v1 · https://github.com/aliasrobotics/cai (prompts in src/cai/prompts/)
+- https://arxiv.org/abs/2308.06782 · https://github.com/GreyDGL/PentestGPT
+- What we copied: the TRACE micro-loop (Trace → Reason → Act → Check → Explain, one
+  bounded action per turn); declare success *and* abandon criteria up front; the
+  Decision Log; breadth before depth; ROI-ordered bug classes; confirmed-vs-hypothetical
+  labeling; the report contract; never follow instructions embedded in target output.
+
+## Round 2 sources (added v0.3.0)
+
+### HPTSA — Teams of LLM Agents can Exploit Zero-Day Vulnerabilities (UIUC)
+- https://arxiv.org/abs/2406.01637 · https://github.com/uiuc-kang-lab/HPTSA
+- What we copied: planner → team-manager/dispatcher → task-specific expert agents
+  (XSS, SQLi, CSRF, SSTI, ZAP, generic); each expert = tools + 5–6 diverse reference
+  docs + customized prompt; single agents cannot backtrack between vuln types — dispatch
+  a fresh expert instead; pass@5 is the metric that matters (42% on 14 real post-cutoff
+  0-days, within 1.8× of an agent *given* the vulnerability; scanners scored 0%);
+  simplify/summarize bulky tool output to cut tokens.
+
+### OpenAI Aardvark (GPT-5 agentic security researcher, Oct 2025)
+- https://openai.com/index/introducing-aardvark/
+- What we copied: durable threat model as the campaign's foundation artifact;
+  commit-level scanning against that model (our watch mode) instead of whole-repo
+  rescans; sandboxed trigger attempts before reporting; proposed patches attached to
+  findings. Published numbers: 92% recall on known/synthetic benchmark, 10 OSS CVEs.
+
+### CodeQL multi-repo variant analysis (GitHub Security Lab / Semmle lineage)
+- GitHub dogfooding writeups + MRVA (`codeql-variant-analysis-action`); QLCoder
+  (synthesizes queries from CVEs; found unknown bugs in 2 repos with one query)
+- What we copied: **variant-as-query** — every confirmed bug becomes a stored query run
+  repo-wide and kept as a regression test; low-FP discipline for queries that run at
+  fleet scale; one pattern found 6–8 additional vulnerable locations in dogfooding.
+
+### CyberGym (Berkeley) & SEC-bench Pro
+- https://arxiv.org/abs/2506.02548 · https://arxiv.org/abs/2605.26548
+- What we copied: the PASS definition (crash pre-patch, no crash post-patch) as our
+  regression-test contract; the **off-target crash rule** — CyberGym's own analysis
+  found agent PoCs hitting *new* 0-days and incomplete patches when judged too narrowly;
+  honest calibration: best agent ≈ 17.9% on the easiest level of 1,507 real CVEs.
+
+### EnIGMA (NYU, SWE-agent for security) & SWE-agent ACI
+- https://arxiv.org/abs/2409.16165 · https://swe-agent.com/latest/background/
+- What we copied: interactive tools via batch wrappers (nested-REPL lesson adapted to
+  one-shot shells); summarization/windows for long output (ACI: ~100-line file views,
+  interface design alone was +10.7pp); 13.5% on NYU CTF, 3× prior SOTA.
+
+### LLM-guided fuzzing: Fuzz4All, ChatAFL, PromptFuzz
+- Fuzz4All (autoprompting distills docs into prompts; coverage-updated prompt loop with
+  natural-language mutation directives; SOTA coverage across 6 languages)
+- ChatAFL (NDSS'24: spec → message grammars + inferred state machine; fuzz state
+  sequences; 9 new vulns in widely-used protocols)
+- PromptFuzz (coverage-guided prompt iteration for fuzz-driver generation)
+- What we copied: the LLM-as-mutation-engine loop and protocol state-machine fuzzing
+  in the playbooks.
+
+## Calibration numbers (set expectations honestly)
+
+- Signal:noise on raw LLM audits ≈ 1:50 (Heelan) — validation is not optional.
+- o3 found the target UAF in 8/100 runs at 3.3k LoC, 1/100 at 12k LoC — slice small.
+- Real-world reproduction is hard: CyberGym's best agent solves ≈ 17.9% of the easiest
+  tier with full description + source; HPTSA reaches 42% *at pass@5*; EnIGMA 13.5% on
+  CTFs. Volume × deterministic validation is the strategy — not one-shot analysis.
+- Big Sleep took CyberSecEval2 buffer-overflow scores from 0.05 → 1.00 with tools +
+  iteration vs zero-shot.
+- A capability floor exists: models that cannot chain tool calls fail regardless of
+  prompting (Big Sleep). Use the strongest available model for discovery.
+- Human experts still win the hardest tier (XBOW vs humans) — this skill finds the bugs
+  humans miss by *coverage and stamina*, not by being smarter.

--- a/plugins/zeroday-hunter/skills/zeroday-hunter/references/toolchain.md
+++ b/plugins/zeroday-hunter/skills/zeroday-hunter/references/toolchain.md
@@ -1,0 +1,99 @@
+# Toolchain recipes
+
+Concrete commands for each campaign task. Detect before use (`which <tool>`); install
+only into isolated environments; never modify the system outside the worktree.
+
+## Slicing & navigation
+
+```bash
+# call-graph slice around an entry symbol (heuristic, budget-capped)
+scripts/zdh-slice.sh <repo> <symbol> [depth=3] [max-lines=10000]
+
+# callers of a function (fast, approximate)
+grep -rn "\b<symbol>\s*(" --include='*.c' --include='*.h' <repo> | grep -v '^\s*\*'
+
+# universal-ctags index for accurate definition lookup
+ctags -R --fields=+n -f .zdh/tags <repo>
+
+# tree-sitter / joern / codeql when available — prefer them over grep on big targets
+joern --script slice.sc --param symbol=<symbol>      # precise CPG slicing
+codeql database analyze db cpp-security-and-quality.qls
+```
+
+## Builds with sanitizers (memory targets)
+
+```bash
+# C/C++ autotools/cmake
+CFLAGS="-g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer" \
+CXXFLAGS="$CFLAGS" LDFLAGS="-fsanitize=address,undefined" ./configure && make -j
+cmake -B build -DCMAKE_C_FLAGS="-g -O1 -fsanitize=address,undefined" && cmake --build build
+
+# keep a clean release build too — some FPs only exist in debug/sanitized builds;
+# confirm reachability on the release build before reporting
+```
+
+ASan options worth setting at runtime:
+`ASAN_OPTIONS=abort_on_error=1:symbolize=1:detect_leaks=0` (leaks are not vulns here).
+UBSan unsigned-overflow is *not* a finding by itself — chase the downstream effect.
+
+## Fuzzing
+
+```bash
+# libFuzzer harness cycle (see playbooks for harness rules)
+clang -g -O1 -fsanitize=address,fuzzer harness.c target.c -o fuzz-target
+./fuzz-target corpus/ -max_total_time=300 -print_final_stats=1
+
+# AFL++ for existing binaries
+afl-fuzz -i seeds/ -o out/ -- ./target @@
+
+# coverage: which lines did we actually reach
+llvm-cov show ./fuzz-target -instr-profile=default.profdata | grep -E '^\s+[0-9]+\|' | wc -l
+```
+
+Crash handling: `zdh-triage.sh <crash-dir>` dedups by (sanitizer signal, top frame);
+minimize with `afl-tmin` / `-minimize_crash=1` *before* writing the hypothesis record.
+
+## Web/service targets
+
+```bash
+# run the real service locally, real config; seed victim + attacker fixtures
+# oracle-first probing: boolean diffs and timing, scripted — never eyeballed
+curl -s -o /dev/null -w '%{http_code} %{size_download} %{time_total}\n' ...
+
+# headless confirmation for JS execution (XSS rung)
+node -e "/* puppeteer: visit URL, hook console/dialog, assert marker fired */"
+```
+
+## Debugging & dynamic tracing
+
+Interactive REPL tools (gdb, netcat, radare2) are essential but this environment runs
+one-shot commands — use **batch wrappers** so every session is scriptable and its output
+capturable for the evidence log (EnIGMA's lesson: interactive access matters; make it
+non-interactive yourself):
+
+```bash
+gdb -batch -ex run -ex bt -ex 'info registers rip' --args ./target poc.bin
+rr record ./target poc.bin && rr replay    # reverse-debug the corruption origin
+uftrace record ./target poc.bin            # function-level trace for path proof
+printf 'GET / HTTP/1.0\r\n\r\n' | timeout 5 nc target 80    # scripted netcat
+python3 -c 'import socket; ...'            # when you need real protocol control
+```
+
+Output discipline: pipe long output to a file, then read it in ~100-line windows
+(`sed -n '1,100p'`); whole-file dumps destroy focus — retrieve, don't dump.
+
+## Payload generators
+
+- Python 3 stdlib is usually enough: `struct.pack` for length fields, `zlib.crc32`,
+  `zipfile`/`xml` for nested formats.
+- Every generator takes `--seed`/`--mutate` knobs so failure-class-driven mutation is a
+  flag, not a rewrite.
+- Never paste blobs into source; generate them.
+
+## Isolation rules
+
+- All builds, PoCs, crashes, and corpuses live under `.zdh/<campaign-id>/` or the
+  campaign worktree — never in the target repo's tree (keeps `git status` clean and the
+  baseline diff honest).
+- Network access only where the sandbox policy allows it; callback servers for
+  SSRF/deserialization detection bind localhost unless the user approves otherwise.

--- a/plugins/zeroday-hunter/templates/campaign.yaml
+++ b/plugins/zeroday-hunter/templates/campaign.yaml
@@ -1,0 +1,31 @@
+# zeroday-hunter campaign definition
+# Created by zdh-init.sh; every agent reads this before acting.
+
+campaign:
+  id: ""                  # zdh-YYYYMMDD-<slug>
+  target_repo: ""
+  baseline_commit: ""     # git rev-parse HEAD at G0
+  bug_class: ""           # ONE class per campaign (see bug-class-playbooks.md)
+  mode: full              # full | watch (watch = delta audit vs baseline, see campaign-manual.md)
+
+threat_model:
+  attacker: ""            # unauth-remote | auth-user | local | concurrent-connections | malicious-file
+  controls: ""            # which bytes/requests/files the attacker fully controls
+  impact_ceiling: ""      # rce | infoleak | authz-bypass | dos
+  scope_dirs: []          # in scope
+  out_of_scope: []        # tests/vendor/generated unless they ARE the target
+
+gates:
+  iteration_cap_per_slice: 40
+  poc_max_failures: 5
+  pass_at_k: 3            # independent audits for high-value slices
+  promote_score_min: 12   # reachability x control x impact - effort
+  promote_top_k: 5
+
+budget:
+  max_cost_usd: 10
+  split: { map: 0.15, audit: 0.45, prove: 0.30, falsify_report: 0.10 }
+
+reviewer_model: ""        # different provider than the auditor — e.g. anthropic:... vs grok:...
+
+abandon_criteria: []      # declared at G0, e.g. "budget exhausted", "last 3 hypotheses demoted"

--- a/plugins/zeroday-hunter/templates/finding.md
+++ b/plugins/zeroday-hunter/templates/finding.md
@@ -1,0 +1,37 @@
+---
+id: F-000
+status: CONFIRMED        # CONFIRMED | HYPOTHESIS
+bug_class: ""
+primitive_rung: 0        # 0-7, see exploit-primitives.md — the rung actually demonstrated
+campaign: ""
+baseline_commit: ""
+---
+
+# <bug class> in <component>: <one-line root cause>
+
+## Summary
+2-3 sentences: the root cause, not the symptoms.
+
+## Entry → Sink
+`file:line` → `file:line`, with the essential path.
+
+## Attacker control
+Per walkthrough step — what the attacker controls and how each branch is satisfied.
+
+## Evidence
+- Verifier: `<exact command>` → exit 0, signal `<deterministic signal>`
+- Primitive demonstrated: rung N (see exploit-primitives.md); mitigations observed: ...
+- AgenC run: `<run-id>` (hashed evidence attached: `agenc run evidence <run-id>`)
+- Reproduction: exact steps + environment (commit, build flags, config)
+
+## Impact
+Ceiling (RCE / infoleak / authz bypass / DoS) and the honest prerequisites.
+
+## Severity rationale
+Reachability × impact; mitigations; what blocks the next primitive rung if not at 7.
+
+## Variants found
+Sibling issues from the sweep (with their own status).
+
+## Remediation
+Minimal fix + the regression test that proves it (the PoC must fail post-fix).

--- a/plugins/zeroday-hunter/templates/hypothesis.md
+++ b/plugins/zeroday-hunter/templates/hypothesis.md
@@ -1,0 +1,43 @@
+---
+id: H-000
+bug_class: ""
+status: draft            # draft | promoted | demoted | confirmed | rejected
+score: 0                 # reachability(0-3) x control(0-3) x impact(0-3) - effort(0-2)
+slice: ""                # entry symbol + depth used
+pass_at_k: 1             # independent runs that found this (k total in notes)
+---
+
+# H-000 — <one-line claim>
+
+## Entry → Sink
+`file:line` entry point → `file:line` dangerous operation. Data flow in 1-3 lines.
+
+## Threat model fit
+Why this path is reachable by the attacker defined in campaign.yaml.
+
+## Mandatory walkthrough
+Step-by-step path from entry to sink. For EVERY conditional on the path:
+how the attacker concretely controls its outcome.
+
+| Step | Location | Condition | Attacker control |
+| --- | --- | --- | --- |
+| 1 |  |  |  |
+
+## Missing definitions fetched
+Functions/types retrieved during the audit (never assumed).
+
+## FP library check
+Patterns from fp-patterns.md evaluated, and why each does not apply.
+
+## PoC plan
+Generator approach + verifier signal (must be intrinsic to the bug).
+
+## Failure log (G3 iterations)
+| Attempt | Mutation tried | Verifier result | Failure class |
+| --- | --- | --- | --- |
+
+## Falsification (G4)
+Reviewer model + verdict + the broken link found (or "none found").
+
+## Variants
+Sibling hypotheses spawned after confirmation.

--- a/runtime/src/commands.ts
+++ b/runtime/src/commands.ts
@@ -484,11 +484,32 @@ export async function getCommands(
     ],
   );
   const commands = [...dynamicCommands.flat(), ...builtInCommands()];
+
+  // Plugin skills are registered both as plugin-scoped commands
+  // (`plugin:skill`) and as local skills (`skill`) when the plugin root is
+  // inside the workspace. Drop the local copy so the TUI shows one entry.
+  const pluginScopedBaseNames = new Set<string>();
+  for (const command of commands) {
+    if (command.source === "plugin" && command.name.includes(":")) {
+      const baseName = command.name.split(":").pop();
+      if (baseName !== undefined && baseName.length > 0) {
+        pluginScopedBaseNames.add(baseName);
+      }
+    }
+  }
+
   const seen = new Set<string>();
   return commands.filter(command => {
     if (!isCommandEnabled(command)) return false;
     const key = command.name.toLowerCase();
     if (seen.has(key)) return false;
+    if (
+      command.loadedFrom === "plugin" &&
+      command.source !== "plugin" &&
+      pluginScopedBaseNames.has(command.name)
+    ) {
+      return false;
+    }
     seen.add(key);
     return true;
   });

--- a/runtime/src/plugins/loader.ts
+++ b/runtime/src/plugins/loader.ts
@@ -395,6 +395,23 @@ async function installedPluginDependencyIdentity(pluginRoot: string): Promise<st
   return pluginDependencyIdentityFromSource(metadata.source);
 }
 
+async function findGitRepoRoot(start: string): Promise<string | undefined> {
+  let current = resolve(start);
+  for (;;) {
+    try {
+      // In worktrees `.git` is a file, in regular checkouts it is a directory.
+      // Either way, its presence marks the project root for plugin discovery.
+      await stat(join(current, ".git"));
+      return current;
+    } catch {
+      // Continue walking.
+    }
+    const parent = resolve(current, "..");
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
 export async function discoverPluginRoots(
   options: PluginLoaderOptions,
 ): Promise<readonly DiscoveredPluginRoot[]> {
@@ -402,6 +419,11 @@ export async function discoverPluginRoots(
   const autoDiscoveryEnabled = pluginAutoDiscoveryEnabled(options.config);
   const featureEnabled = pluginFeatureEnabled(options.config);
   const roots: DiscoveredPluginRoot[] = [];
+  const gitRoot = await findGitRepoRoot(options.workspaceRoot);
+  const workspacePluginDirs = [join(options.workspaceRoot, "plugins")];
+  if (gitRoot !== undefined && gitRoot !== options.workspaceRoot) {
+    workspacePluginDirs.push(join(gitRoot, "plugins"));
+  }
   roots.push(
     ...(await discoverRootsUnder(
       join(options.agencHome, "plugins"),
@@ -418,6 +440,17 @@ export async function discoverPluginRoots(
       enabled: root.enabled && autoDiscoveryEnabled,
     })),
   );
+  for (const workspacePluginDir of workspacePluginDirs) {
+    roots.push(
+      ...(await discoverRootsUnder(
+        workspacePluginDir,
+        "repository-controlled",
+      )).map((root) => ({
+        ...root,
+        enabled: root.enabled && autoDiscoveryEnabled,
+      })),
+    );
+  }
 
   for (const [key, value] of Object.entries(configured).sort(([a], [b]) => a.localeCompare(b))) {
     const path = configEntryPath(value);

--- a/runtime/src/plugins/registration/load-plugin-commands.ts
+++ b/runtime/src/plugins/registration/load-plugin-commands.ts
@@ -244,7 +244,12 @@ function createPluginCommand(
     frontmatter.allowedTools ??
     metadata?.allowedTools;
   const argNames = splitList(frontmatter.arguments ?? frontmatter.argNames);
-  const aliases = namespacedAliases(plugin.name, splitList(frontmatter.aliases));
+  const baseAliases = namespacedAliases(plugin.name, splitList(frontmatter.aliases));
+  const commandBaseName = commandName.split(":").pop();
+  const aliases = commandBaseName === plugin.name &&
+      baseAliases?.includes(commandBaseName) !== true
+    ? [...(baseAliases ?? []), commandBaseName]
+    : baseAliases;
   const userInvocable =
     frontmatter["user-invocable"] === undefined
       ? true
@@ -259,7 +264,7 @@ function createPluginCommand(
     type: "prompt",
     name: commandName,
     description,
-    ...(aliases !== undefined ? { aliases } : {}),
+    ...(aliases !== undefined && aliases.length > 0 ? { aliases } : {}),
     argumentHint: coerceString(frontmatter["argument-hint"] ?? frontmatter.argumentHint),
     argNames: argNames.length > 0 ? argNames : undefined,
     allowedTools: repositoryControlled

--- a/runtime/tests/plugins/loader.test.ts
+++ b/runtime/tests/plugins/loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -1400,11 +1400,13 @@ describe("plugin loader", () => {
       const workspaceRoot = join(root, "workspace");
       const userPlugin = join(agencHome, "plugins", "user");
       const workspacePlugin = join(workspaceRoot, ".agents", "plugins", "workspace");
+      const workspacePluginsDirPlugin = join(workspaceRoot, "plugins", "workspace-plugins");
       const configuredPlugin = join(workspaceRoot, "vendor", "configured");
       const disabledPlugin = join(workspaceRoot, "vendor", "disabled");
       for (const [name, pluginRoot] of [
         ["user", userPlugin],
         ["workspace", workspacePlugin],
+        ["workspace-plugins", workspacePluginsDirPlugin],
         ["configured", configuredPlugin],
         ["disabled", disabledPlugin],
       ] as const) {
@@ -1439,17 +1441,75 @@ describe("plugin loader", () => {
         },
       });
 
-      expect(roots.map((entry) => entry.path).sort()).toEqual([
-        configuredPlugin,
-        disabledPlugin,
-        userPlugin,
-        workspacePlugin,
-      ].sort());
-      expect(skillRoots.sort()).toEqual([
-        join(configuredPlugin, "skills"),
-        join(userPlugin, "skills"),
-        join(workspacePlugin, "skills"),
-      ].sort());
+      const expectedRoots = await Promise.all([
+        realpath(configuredPlugin),
+        realpath(disabledPlugin),
+        realpath(userPlugin),
+        realpath(workspacePlugin),
+        realpath(workspacePluginsDirPlugin),
+      ]);
+      expect(roots.map((entry) => entry.path).sort()).toEqual(expectedRoots.sort());
+      const expectedSkillRoots = await Promise.all([
+        realpath(join(configuredPlugin, "skills")),
+        realpath(join(userPlugin, "skills")),
+        realpath(join(workspacePlugin, "skills")),
+        realpath(join(workspacePluginsDirPlugin, "skills")),
+      ]);
+      expect(skillRoots.sort()).toEqual(expectedSkillRoots.sort());
+    });
+  });
+
+  test("discovers workspace plugins from the git root when running in a subdirectory", async () => {
+    await withTempDir(async (root) => {
+      const agencHome = join(root, "home");
+      const gitRoot = join(root, "repo");
+      const workspaceRoot = join(gitRoot, "runtime");
+      const repoPlugin = join(gitRoot, "plugins", "zeroday-hunter");
+      await mkdir(join(gitRoot, ".git"), { recursive: true });
+      await mkdir(workspaceRoot, { recursive: true });
+      await writePluginManifest(repoPlugin, { name: "zeroday-hunter" });
+      await writeFileAt(join(repoPlugin, "skills", "zeroday-hunter", "SKILL.md"), "---\nname: x\n---\n");
+
+      const roots = await discoverPluginRoots({
+        agencHome,
+        workspaceRoot,
+        config: { plugins: { enabled: true } },
+      });
+      const skillRoots = await discoverPluginSkillRoots({
+        agencHome,
+        workspaceRoot,
+        config: { plugins: { enabled: true } },
+      });
+
+      expect(roots.map((entry) => entry.path)).toContain(await realpath(repoPlugin));
+      expect(skillRoots).toContain(await realpath(join(repoPlugin, "skills")));
+    });
+  });
+
+  test("discovers workspace plugins from a git worktree root", async () => {
+    await withTempDir(async (root) => {
+      const agencHome = join(root, "home");
+      const gitRoot = join(root, "repo");
+      const workspaceRoot = join(gitRoot, "runtime");
+      const repoPlugin = join(gitRoot, "plugins", "zeroday-hunter");
+      await writeFileAt(join(gitRoot, ".git"), "gitdir: /tmp/fake-gitdir\n");
+      await mkdir(workspaceRoot, { recursive: true });
+      await writePluginManifest(repoPlugin, { name: "zeroday-hunter" });
+      await writeFileAt(join(repoPlugin, "skills", "zeroday-hunter", "SKILL.md"), "---\nname: x\n---\n");
+
+      const roots = await discoverPluginRoots({
+        agencHome,
+        workspaceRoot,
+        config: { plugins: { enabled: true } },
+      });
+      const skillRoots = await discoverPluginSkillRoots({
+        agencHome,
+        workspaceRoot,
+        config: { plugins: { enabled: true } },
+      });
+
+      expect(roots.map((entry) => entry.path)).toContain(await realpath(repoPlugin));
+      expect(skillRoots).toContain(await realpath(join(repoPlugin, "skills")));
     });
   });
 


### PR DESCRIPTION
## What

A new installable plugin, `plugins/zeroday-hunter/`: a behavioral skill that turns the agent into an exploit-first 0-day hunter running full **campaigns** instead of code reviews.

```
G0 FRAME → G1 MAP → G2 AUDIT → G3 PROVE → G4 FALSIFY → G5 REPORT
```

Every gate produces on-disk artifacts (`.zdh/<campaign-id>/`) and has explicit exit criteria. A finding only counts as CONFIRMED when a **deterministic verifier** exits 0 (sanitizer crash, response diff, observed auth bypass) **and** an independent reviewer model (`--reviewer-model`, different provider) fails to falsify it.

## Key mechanics

- **Quantitative gates**: hypothesis scoring (reachability × attacker-control × impact − effort), promotion threshold, pass@k independent audits on high-value slices, hard iteration caps with logged abandon criteria, budget split per phase (`--max-cost`).
- **Hierarchy**: planner (coordinator) → dispatcher → per-(slice × bug-class) expert agents — a single agent never switches bug class mid-run (HPTSA lesson).
- **Variant-as-query**: every confirmed bug becomes a stored semgrep/grep query run repo-wide — permanent variant detector + regression test for the fix.
- **Watch mode**: delta audits of `baseline..HEAD` against the stored threat model (Aardvark-style commit scanning) via `zdh-watch.sh`.
- **AgenC-native wiring**: `campaign.sh swarm` launches one background agent per bug class; `campaign.sh single` runs a verified `agenc run` with `--verify` PoC gate + `--reviewer-model` + hashed evidence export (`agenc run evidence`).
- **FP library & exploit-primitive ladder**: ~30 false-positive patterns checked before promotion; findings report the primitive actually demonstrated (crash ≠ controlled crash ≠ RCE).

## Methodology sources

Distilled from published systems, with citations and statistics in `references/methodology-sources.md`: Project Zero/DeepMind **Big Sleep**, Sean Heelan's **o3 workflow** (CVE-2025-37899), DARPA **AIxCC** winners (buttercup/atlantis/artiphishell), **XBOW**, **oss-fuzz-gen**, **HPTSA**, OpenAI **Aardvark**, **CodeQL variant analysis**, **CyberGym**, **EnIGMA**, **CAI/PentestGPT**, **Fuzz4All/ChatAFL**.

## Field test

Ran the full campaign against the `minilang` demo parser (on a copy): **confirmed a real uncontrolled-recursion stack-exhaustion DoS (CWE-674)** — three recursion funnels (parens/blocks/unary), ASan-verified PoC, crash reproduced on a release `-O2` build, and a depth-cap patch validated pre/post-fix (same PoC fails gracefully after patching). The minilang fix itself can follow as a separate PR.

## Install

```bash
agenc plugin install ./plugins/zeroday-hunter --scope user
```

`agenc plugin validate` passes; all seven scripts are syntax-checked and the core ones (init/slice/triage/watch/variant/poc-check) were functionally tested.