### PR TITLE
test(models): follow the grok-4.6 default in the bin catalog tests

### DIFF
--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -592,9 +592,10 @@ describe("initializeCliRuntime", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("PROVIDER_MODEL_CATALOG", () => {
-  it("advertises grok models including the default grok-4.5", () => {
+  it("advertises grok models with grok-4.6 leading", () => {
     // The grok catalog is derived from REGISTERED_MODEL_CATALOG.
     expect(PROVIDER_MODEL_CATALOG.grok).toEqual([
+      "grok-4.6",
       "grok-4.5",
       "grok-build-0.1",
       "grok-4.3",
@@ -820,7 +821,7 @@ describe("I-47: maybeReloadConfigBetweenTurns", () => {
     });
     expect(result.reloaded).toBe(true);
     if (result.reloaded) {
-      expect(result.previous.model).toBe("grok-4.5");
+      expect(result.previous.model).toBe("grok-4.6");
       expect(result.next.model).toBe("grok-4");
     }
     expect(latch.requested).toBe(false);
@@ -855,7 +856,7 @@ describe("I-47: maybeReloadConfigBetweenTurns", () => {
     const arg = emit.mock.calls[0]![0];
     expect(arg.msg.type).toBe("warning");
     expect(arg.msg.payload.cause).toBe("config_reloaded");
-    expect(arg.msg.payload.message).toMatch(/grok-4\.5/);
+    expect(arg.msg.payload.message).toMatch(/grok-4\.6/);
     expect(arg.msg.payload.message).toMatch(/grok-4/);
   });
 
@@ -1261,7 +1262,7 @@ describe("ConfigStore integration shape", () => {
       const store = new ConfigStore({ home, env: {} });
       await store.reload();
       const cur = store.current();
-      expect(cur.model).toBe("grok-4.5");
+      expect(cur.model).toBe("grok-4.6");
       // AgenCConfig is deep-frozen — direct writes should throw in strict.
       expect(Object.isFrozen(cur)).toBe(true);
     } finally {


### PR DESCRIPTION
Follow-up to #1704. Three assertions in `tests/bin/agenc.test.ts` still pinned grok-4.5 as the default and were missed because that suite was not in the set I ran before merging:

- the provider catalog order (4.6 now leads, 4.5 stays second)
- the empty-env `ConfigStore` default
- the config-reload warning's *previous* model

The reload *target* (`grok-4`) is an arbitrary next value and is unchanged. `tests/bin/agenc.test.ts`: 82 passing.
