### PR TITLE
feat(plugins): ship zeroday-hunter and enable it by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ TASK-SYSTEM-PLAN.md
 **/test-results/
 
 __pycache__/
+
+# Build artifact: repo plugins/ copied into the package by sync-shipped-plugins.
+runtime/plugins/

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -20,14 +20,15 @@
   "files": [
     "bin",
     "dist",
-    "README.md"
+    "README.md",
+    "plugins"
   ],
   "agencExecutableFiles": [
     "dist/agenc-process-broker",
     "dist/agenc-process-job-broker.exe"
   ],
   "scripts": {
-    "build": "node scripts/build-runtime.mjs && node scripts/write-build-version.mjs && npm run check:package-entrypoints && npm run check:sdk-generated-types && node ../scripts/canonicalize-package-modes.mjs .",
+    "build": "node scripts/sync-shipped-plugins.mjs && node scripts/build-runtime.mjs && node scripts/write-build-version.mjs && npm run check:package-entrypoints && npm run check:sdk-generated-types && node ../scripts/canonicalize-package-modes.mjs .",
     "daemon": "node bin/agenc daemon start --foreground",
     "daemon:status": "node bin/agenc daemon status",
     "start": "node bin/agenc",

--- a/runtime/scripts/sync-shipped-plugins.mjs
+++ b/runtime/scripts/sync-shipped-plugins.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Copy the repository's first-party `plugins/` into the runtime package so it
+ * ships to installed users.
+ *
+ * `plugins/` deliberately stays at the REPO root: `discoverPluginRoots` looks
+ * under `<workspaceRoot>/plugins` and `<gitRoot>/plugins`, so moving it under
+ * runtime/ would stop it being found by anyone who opens this repo as their
+ * workspace. Copying at build time keeps both audiences working from one
+ * source of truth.
+ *
+ * The copy is a build artifact, not source — it is gitignored, and it is
+ * rebuilt from scratch each time so a plugin deleted upstream cannot linger
+ * inside the package.
+ */
+import { cp, mkdir, readdir, rm, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const runtimeRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const source = resolve(runtimeRoot, "..", "plugins");
+const target = join(runtimeRoot, "plugins");
+
+if (!existsSync(source)) {
+  console.log("[shipped plugins] no repo plugins/ directory — nothing to sync");
+  process.exit(0);
+}
+
+await rm(target, { recursive: true, force: true });
+await mkdir(target, { recursive: true });
+
+const names = [];
+for (const entry of await readdir(source, { withFileTypes: true })) {
+  if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+  await cp(join(source, entry.name), join(target, entry.name), {
+    recursive: true,
+    dereference: true,
+  });
+  names.push(entry.name);
+}
+
+// A plugin that ships without its SKILL.md registers as an empty entry in
+// /plugin, so fail the build rather than publish one.
+for (const name of names) {
+  const skill = join(target, name, "skills", name, "SKILL.md");
+  if (!existsSync(skill)) continue;
+  const info = await stat(skill);
+  if (info.size === 0) {
+    console.error(`[shipped plugins] ${name}: SKILL.md is empty`);
+    process.exit(1);
+  }
+}
+
+console.log(
+  `[shipped plugins] synced ${names.length}: ${names.join(", ") || "(none)"}`,
+);

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2808,11 +2808,29 @@ async function findBundledSkillCommand(name: string): Promise<
     if (typeof getBundledSkills !== "function") return null;
     const commands = (getBundledSkills as () => unknown)();
     if (!Array.isArray(commands)) return null;
-    return (
-      commands.find(
-        (command) => isRecord(command) && command.name === name,
-      ) ?? null
+    const bundled = commands.find(
+      (command) => isRecord(command) && command.name === name,
     );
+    if (bundled !== undefined) return bundled;
+    // Skills contributed by plugins shipped in the runtime package (e.g.
+    // zeroday-hunter) register through the built-in plugin registry, not the
+    // bundled-skills array. Without this fallback the Skill tool rejects them
+    // as unknown even though /skills lists them.
+    const builtin = (await import(
+      "../plugins/builtin/index.js"
+    )) as unknown as Record<string, unknown>;
+    const getBuiltinSkills = builtin.getBuiltinPluginSkillCommands;
+    if (typeof getBuiltinSkills === "function") {
+      const pluginCommands = (getBuiltinSkills as () => unknown)();
+      if (Array.isArray(pluginCommands)) {
+        return (
+          pluginCommands.find(
+            (command) => isRecord(command) && command.name === name,
+          ) ?? null
+        );
+      }
+    }
+    return null;
   } catch {
     return null;
   }
@@ -2828,15 +2846,31 @@ async function listBundledSkillNames(): Promise<string[]> {
     if (typeof getBundledSkills !== "function") return [];
     const commands = (getBundledSkills as () => unknown)();
     if (!Array.isArray(commands)) return [];
-    return commands.flatMap((command) =>
-      isRecord(command) &&
-      typeof command.name === "string" &&
-      command.name.length > 0 &&
-      command.disableModelInvocation !== true &&
-      command.isHidden !== true
-        ? [command.name]
-        : [],
-    );
+    const invocable = (list: unknown): string[] =>
+      Array.isArray(list)
+        ? list.flatMap((command) =>
+            isRecord(command) &&
+            typeof command.name === "string" &&
+            command.name.length > 0 &&
+            command.disableModelInvocation !== true &&
+            command.isHidden !== true
+              ? [command.name]
+              : [],
+          )
+        : [];
+    const names = new Set(invocable(commands));
+    // Also surface skills from plugins shipped in the runtime package, so an
+    // unknown-skill error lists them as available alongside the bundled ones.
+    const builtin = (await import(
+      "../plugins/builtin/index.js"
+    )) as unknown as Record<string, unknown>;
+    const getBuiltinSkills = builtin.getBuiltinPluginSkillCommands;
+    if (typeof getBuiltinSkills === "function") {
+      for (const name of invocable((getBuiltinSkills as () => unknown)())) {
+        names.add(name);
+      }
+    }
+    return [...names];
   } catch {
     return [];
   }

--- a/runtime/src/commands.ts
+++ b/runtime/src/commands.ts
@@ -425,7 +425,7 @@ async function loadProductionCommandSources(
   const loadBundledSkills = () =>
     import("./skills/bundledSkills.js") as unknown as Promise<Record<string, unknown>>;
   const loadBuiltinPlugins = () =>
-    import("./plugins/builtinPlugins.js") as unknown as Promise<Record<string, unknown>>;
+    import("./plugins/builtin/index.js") as unknown as Promise<Record<string, unknown>>;
 
   const [
     skillDirCommands,

--- a/runtime/src/commands/skills.ts
+++ b/runtime/src/commands/skills.ts
@@ -159,8 +159,22 @@ async function bundledSkillsFromRegistry(): Promise<AvailableSkillSnapshot[]> {
     )) as unknown as Record<string, unknown>;
     const getBundledSkills = loaded.getBundledSkills;
     if (typeof getBundledSkills !== "function") return [];
-    const commands = (getBundledSkills as () => unknown)();
-    if (!Array.isArray(commands)) return [];
+    const bundledCommands = (getBundledSkills as () => unknown)();
+    // Skills contributed by plugins shipped in the runtime package register
+    // through a separate registry; fold them in so /skills lists exactly what
+    // the Skill tool can load — the parity the model relies on.
+    const builtin = (await import(
+      "../plugins/builtin/index.js"
+    )) as unknown as Record<string, unknown>;
+    const getBuiltinSkills = builtin.getBuiltinPluginSkillCommands;
+    const builtinCommands =
+      typeof getBuiltinSkills === "function"
+        ? (getBuiltinSkills as () => unknown)()
+        : [];
+    const commands = [
+      ...(Array.isArray(bundledCommands) ? bundledCommands : []),
+      ...(Array.isArray(builtinCommands) ? builtinCommands : []),
+    ];
     return commands.flatMap((command): AvailableSkillSnapshot[] => {
       if (
         !isRecord(command) ||

--- a/runtime/src/plugins/builtin/index.ts
+++ b/runtime/src/plugins/builtin/index.ts
@@ -1,0 +1,67 @@
+import type { Command } from "../../types/command.js";
+import {
+  getBuiltinPluginSkillCommands as readRegisteredSkillCommands,
+  registerBuiltinPlugin,
+} from "../builtinPlugins.js";
+import { shippedPluginSkill } from "./repositoryPluginSkill.js";
+
+let initialized = false;
+
+/**
+ * Register the plugins that ship inside the runtime package.
+ *
+ * These are deliberately NOT subject to `plugins.enabled`. That flag gates
+ * AUTO-DISCOVERY — loading whatever `plugins/` directory the repository you
+ * happen to open contains, which a third party can forge and which can carry
+ * hooks that execute commands. It stays off by default and this does not
+ * change it. A plugin shipped in the runtime package is code we published, so
+ * it is registered here and enabled by default like any other first-party
+ * surface; a user can still turn it off in /plugin, which wins over this.
+ *
+ * Idempotent: the daemon and the CLI both reach startup paths that call it.
+ */
+export function initBuiltinPlugins(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const zerodayHunter = shippedPluginSkill({
+    pluginName: "zeroday-hunter",
+    description:
+      "Exploit-first 0-day hunting in source code: a campaign state machine " +
+      "(frame → map → audit → prove → falsify → report) with quantitative " +
+      "gates, deterministic PoC verification and hashed evidence.",
+    whenToUse:
+      "The user asks to audit code for vulnerabilities, hunt 0-days, do " +
+      "security research, find exploitable bugs, or run a vuln-discovery " +
+      "campaign on a codebase they own or are authorized to test.",
+    argumentHint: "<target-path> [bug-class|watch]",
+  });
+
+  // Null when the plugin directory is absent (a trimmed install). Registering
+  // a plugin with no skills would show an empty entry in /plugin, so skip it
+  // entirely and let the surface simply not be offered.
+  if (zerodayHunter !== null) {
+    registerBuiltinPlugin({
+      name: "zeroday-hunter",
+      description:
+        "Exploit-first 0-day hunting: campaigns with quantitative gates, " +
+        "deterministic proof and hashed evidence.",
+      skills: [zerodayHunter],
+    });
+  }
+}
+
+/** Test seam: allows a suite to re-register against a fresh registry. */
+export function resetBuiltinPluginInit(): void {
+  initialized = false;
+}
+
+/**
+ * Command-source entry point. Registration is lazy and idempotent so the
+ * registry is never read empty — the previous shape left `registerBuiltinPlugin`
+ * with no caller at all, which is why nothing shipped in the package appeared.
+ */
+export function getBuiltinPluginSkillCommands(): Command[] {
+  initBuiltinPlugins();
+  return readRegisteredSkillCommands();
+}

--- a/runtime/src/plugins/builtin/repositoryPluginSkill.ts
+++ b/runtime/src/plugins/builtin/repositoryPluginSkill.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+import { resolveRuntimePackageRootFromUrl } from "../../app-server/daemon-runtime-info.js";
+import type { BundledSkillDefinition } from "../../skills/bundledSkills.js";
+import type { ContentBlockParam } from "@anthropic-ai/sdk/resources/index.mjs";
+
+const MAX_REFERENCE_BYTES = 512 * 1024;
+
+/**
+ * Resolve a plugin that ships INSIDE the runtime package.
+ *
+ * The directory is resolved from the runtime package root, never from the
+ * workspace. That distinction is the whole security argument for enabling
+ * these by default while `plugins.enabled` stays false: workspace discovery
+ * loads whatever `plugins/` the repository you happen to open contains, and a
+ * third party can forge that. The runtime package is what we shipped.
+ */
+export function resolveShippedPluginDir(
+  pluginName: string,
+  moduleUrl = import.meta.url,
+): string | null {
+  const runtimeRoot = resolveRuntimePackageRootFromUrl(moduleUrl);
+  const candidates = [
+    ...(runtimeRoot === null ? [] : [join(runtimeRoot, "plugins", pluginName)]),
+    // Dev checkout: plugins/ lives at the repo root, one level above runtime/.
+    ...(runtimeRoot === null
+      ? []
+      : [join(runtimeRoot, "..", "plugins", pluginName)]),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, "skills", pluginName, "SKILL.md"))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** Read `references/**` next to a SKILL.md into the bundled-skill file map. */
+export function readSkillReferenceFiles(
+  skillDir: string,
+): Record<string, string> {
+  const files: Record<string, string> = {};
+  const walk = (dir: string): void => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const info = statSync(full);
+      if (info.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      // A reference is documentation the model may Read on demand. Anything
+      // oversized is skipped rather than silently truncated, so a half file
+      // can never be mistaken for the whole one.
+      if (!info.isFile() || info.size > MAX_REFERENCE_BYTES) continue;
+      const key = relative(skillDir, full).split(sep).join("/");
+      files[key] = readFileSync(full, "utf8");
+    }
+  };
+  walk(join(skillDir, "references"));
+  return files;
+}
+
+/**
+ * Build a bundled-skill definition from a plugin shipped in the runtime
+ * package. Returns null when the plugin is absent, so a trimmed install
+ * degrades to "the skill is not offered" instead of failing startup.
+ */
+export function shippedPluginSkill(input: {
+  readonly pluginName: string;
+  readonly description: string;
+  readonly whenToUse?: string;
+  readonly argumentHint?: string;
+  readonly moduleUrl?: string;
+}): BundledSkillDefinition | null {
+  const pluginDir = resolveShippedPluginDir(
+    input.pluginName,
+    input.moduleUrl ?? import.meta.url,
+  );
+  if (pluginDir === null) return null;
+  const skillDir = join(pluginDir, "skills", input.pluginName);
+  const prompt = readFileSync(join(skillDir, "SKILL.md"), "utf8");
+  const files = readSkillReferenceFiles(skillDir);
+  return {
+    name: input.pluginName,
+    description: input.description,
+    ...(input.whenToUse !== undefined ? { whenToUse: input.whenToUse } : {}),
+    ...(input.argumentHint !== undefined
+      ? { argumentHint: input.argumentHint }
+      : {}),
+    ...(Object.keys(files).length > 0 ? { files } : {}),
+    getPromptForCommand: async (): Promise<ContentBlockParam[]> => [
+      { type: "text", text: prompt },
+    ],
+  };
+}

--- a/runtime/tests/plugins/builtin-shipped-plugins.test.ts
+++ b/runtime/tests/plugins/builtin-shipped-plugins.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearBuiltinPlugins,
+  getBuiltinPlugins,
+} from "../../src/plugins/builtinPlugins.js";
+import {
+  getBuiltinPluginSkillCommands,
+  initBuiltinPlugins,
+  resetBuiltinPluginInit,
+} from "../../src/plugins/builtin/index.js";
+import {
+  readSkillReferenceFiles,
+  resolveShippedPluginDir,
+} from "../../src/plugins/builtin/repositoryPluginSkill.js";
+
+/**
+ * zeroday-hunter ships in the repo but never loaded: `plugins.enabled` gates
+ * auto-discovery and defaults to false, and the built-in registry — the path
+ * that bypasses that gate — had no caller at all.
+ *
+ * The gate stays off. These plugins are enabled because they ship inside the
+ * runtime package, which a third-party repository cannot forge.
+ */
+describe("plugins shipped in the runtime package", () => {
+  it("resolves zeroday-hunter from the package, not the workspace", () => {
+    const dir = resolveShippedPluginDir("zeroday-hunter");
+    expect(dir).not.toBeNull();
+    expect(dir).toMatch(/plugins[/\\]zeroday-hunter$/u);
+  });
+
+  it("registers it and offers its skill", () => {
+    clearBuiltinPlugins();
+    resetBuiltinPluginInit();
+
+    const commands = getBuiltinPluginSkillCommands();
+    const skill = commands.find((c) => c.name === "zeroday-hunter");
+
+    expect(skill).toBeDefined();
+    expect(skill?.userInvocable).toBe(true);
+    // 'bundled', not 'builtin': 'builtin' means a hardcoded slash command and
+    // would drop the skill from the Skill tool's listing.
+    expect(skill?.source).toBe("bundled");
+    expect(skill?.whenToUse).toMatch(/vulnerabilit|0-day/iu);
+  });
+
+  it("is enabled by default, with no [plugins] config present", () => {
+    clearBuiltinPlugins();
+    resetBuiltinPluginInit();
+    initBuiltinPlugins();
+
+    const { enabled, disabled } = getBuiltinPlugins();
+    expect(enabled.map((p) => p.name)).toContain("zeroday-hunter");
+    expect(disabled.map((p) => p.name)).not.toContain("zeroday-hunter");
+    expect(enabled.find((p) => p.name === "zeroday-hunter")?.isBuiltin).toBe(
+      true,
+    );
+  });
+
+  it("registering twice does not duplicate the skill", () => {
+    clearBuiltinPlugins();
+    resetBuiltinPluginInit();
+
+    initBuiltinPlugins();
+    initBuiltinPlugins();
+
+    const names = getBuiltinPluginSkillCommands().map((c) => c.name);
+    expect(names.filter((n) => n === "zeroday-hunter")).toHaveLength(1);
+  });
+
+  it("carries the skill's reference files for on-demand reading", () => {
+    const dir = resolveShippedPluginDir("zeroday-hunter")!;
+    const files = readSkillReferenceFiles(`${dir}/skills/zeroday-hunter`);
+    const keys = Object.keys(files);
+
+    expect(keys.length).toBeGreaterThan(0);
+    // Relative, forward-slashed, no traversal — the bundled-skill file
+    // contract, since these are extracted to disk on first invocation.
+    for (const key of keys) {
+      expect(key).toMatch(/^references\//u);
+      expect(key).not.toContain("..");
+      expect(key).not.toContain("\\");
+      expect(files[key]!.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
`zeroday-hunter` lives in the repo's `plugins/` but never loaded at startup — unlike `iot-builder`, which is a *bundled skill* compiled into the binary. Two independent reasons, both fixed here, and the `plugins.enabled` security gate stays untouched.

### 1. It never reached an installed user

`plugins/` was not in the runtime package's `files`, so `npm install` never put it on disk — it only existed for people working from a repo clone. A build step now copies the repo's first-party `plugins/` into the package. It **stays at the repo root** (moving it under `runtime/` would break the `<workspaceRoot>/plugins` discovery added in a prior commit for people who open the repo), and the copy is a gitignored build artifact rebuilt from scratch each time, so a plugin deleted upstream cannot linger inside the package.

### 2. Auto-discovery is off by default, and should stay off

`plugins.enabled` gates loading whatever `plugins/` the repository you open contains — including `hooks/hooks.json`, which executes commands — with **no project-trust gate**. Flipping that default would auto-load third-party plugin code from any repo you open. So this does *not* touch it.

A plugin shipped **inside the runtime package** is code we published and a third party cannot forge, so it goes through the **built-in plugin registry** instead. That registry already existed (`registerBuiltinPlugin` / `getBuiltinPlugins`, enabled unless the user opts out in `/plugin`) but had **no caller at all** — `initBuiltinPlugins()` is now that caller.

### Parity the model depends on

The Skill tool resolved names only through the bundled-skills array, so it answered `Unknown skill: zeroday-hunter` for a skill `/skills` would list — and `/skills`' own snapshot had the mirror-image gap. Both now also consult the built-in registry, so the tool loads exactly what the list advertises.

### Degradation

A trimmed install with no `plugins/` returns null from the resolver and the skill is simply not offered, rather than failing startup.

### Verification

New suite (`tests/plugins/builtin-shipped-plugins.test.ts`, 5 tests): resolves from the package not the workspace, enabled with no `[plugins]` config, idempotent registration, and the reference-file contract. Plus the Skill-tool and `/skills` parity suites. **293 passing** across plugins/skills/commands.

Driven live with `plugins.enabled` absent:
```
$ agenc -p "Invoke the zeroday-hunter skill with no arguments. Then reply: LOADED"
LOADED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)