### PR TITLE
fix(llm): count tokens, not bytes, in the accounting fallback

### DIFF
--- a/runtime/src/llm/token-accounting.ts
+++ b/runtime/src/llm/token-accounting.ts
@@ -26,8 +26,11 @@ export const TOKEN_ACCOUNTING_METRICS_MAX_PARTITIONS = 4_096;
 export const TOKEN_FALLBACK_MARGIN_RATIO = 0.1;
 export const TOKEN_FALLBACK_MARGIN_TOKENS = 256;
 
+// v2 divides the serialized prompt by a bytes-per-token ratio; v1 reserved its
+// raw byte count. Every reported result carries this, so the two calibrations
+// stay distinguishable in reconciliation and telemetry.
 export const TOKEN_ACCOUNTING_CALIBRATION_VERSION =
-  "token-accounting-fallback-v1";
+  "token-accounting-fallback-v2";
 export const TOKEN_ACCOUNTING_REQUEST_VERSION = 1;
 
 const TOKEN_ACCOUNTING_DIGEST_DOMAIN = "agenc-token-accounting-request-v1\0";
@@ -43,6 +46,29 @@ const TOKEN_ACCOUNTING_TOOL_CHOICE_FRAME_TOKENS = 8;
 const TOKEN_ACCOUNTING_MEDIA_FRAME_TOKENS = 64;
 const TOKEN_ACCOUNTING_MINIMUM_INPUT_TOKENS = 1;
 const TOKEN_ACCOUNTING_UTF8_WORST_CASE_BYTES_PER_TOKEN = 1;
+
+/**
+ * Bytes-per-token divisor the local fallback estimates with.
+ *
+ * The theoretical worst case is 1 byte per token, and the fallback used to
+ * reserve the serialized prompt's raw byte count — that is what 1 means. Only
+ * a pathological input reaches it: every byte its own token. Real prompts are
+ * JSON-framed code and prose, where every catalogued tokenizer averages 3.2
+ * bytes per token or more, so the raw byte count over-reserves by ~4x.
+ *
+ * That is not a harmless over-reservation. `admitted-model-call` compares this
+ * result against the context window, so a 4x estimate denies
+ * `context_window_exceeded` at roughly a quarter of the real window and kills
+ * the run. Observed on grok-4.6 (catalogued at 500k): reservations climbed
+ * 383,853 → 403,222 across four consecutive iterations while the provider
+ * reported 74,634 → 79,048 actual prompt tokens, and the next call was denied
+ * with the real context at 16% of the window.
+ *
+ * 2 keeps a conservative floor — still below every catalogued ratio, so the
+ * estimate stays an upper bound — without gating admission on a bound no
+ * tokenizer can reach.
+ */
+const TOKEN_ACCOUNTING_CONSERVATIVE_BYTES_PER_TOKEN = 2;
 const TOKEN_ACCOUNTING_MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
 const TOKEN_ACCOUNTING_METRICS_OVERFLOW_MODEL = "other";
 const TOKEN_ACCOUNTING_METRICS_OVERFLOW_PROVIDER = "other";
@@ -930,7 +956,10 @@ function conservativeFallbackResult(
     request.provider,
     request.options.promptCacheKey,
   );
-  const promptBytes = normalizedUtf8UpperBound(stableStringify(promptIdentity));
+  const promptTokens = estimateUtf8TokenUnits(
+    stableStringify(promptIdentity),
+    TOKEN_ACCOUNTING_CONSERVATIVE_BYTES_PER_TOKEN,
+  );
   const frameTokens =
     TOKEN_ACCOUNTING_REQUEST_FRAME_TOKENS +
     request.messages.length * TOKEN_ACCOUNTING_MESSAGE_FRAME_TOKENS +
@@ -941,7 +970,7 @@ function conservativeFallbackResult(
       ? 0
       : TOKEN_ACCOUNTING_TOOL_CHOICE_FRAME_TOKENS) +
     inspection.mediaCount * TOKEN_ACCOUNTING_MEDIA_FRAME_TOKENS;
-  const beforeMargin = safeTokenSum(promptBytes, frameTokens);
+  const beforeMargin = safeTokenSum(promptTokens, frameTokens);
   const safetyMarginTokens = safetyMarginForTokens(beforeMargin);
   const inputTokens = Math.max(
     TOKEN_ACCOUNTING_MINIMUM_INPUT_TOKENS,

--- a/runtime/tests/llm/fixtures/token-accounting-calibration.v1.json
+++ b/runtime/tests/llm/fixtures/token-accounting-calibration.v1.json
@@ -1,5 +1,5 @@
 {
-  "version": "token-accounting-fallback-v1",
+  "version": "token-accounting-fallback-v2",
   "description": "Offline, non-secret calibration cases. Official observations are copied from the linked provider documentation; tokenizer ceiling cases exercise pathological UTF-8 inputs without claiming a live provider measurement.",
   "sources": {
     "gemini-official-text": "https://ai.google.dev/api/tokens",

--- a/runtime/tests/llm/token-accounting.test.ts
+++ b/runtime/tests/llm/token-accounting.test.ts
@@ -141,6 +141,25 @@ describe("conservative complete-request fallback", () => {
     );
   });
 
+  test("estimates tokens, not raw prompt bytes", () => {
+    // A byte count used as a token count denies `context_window_exceeded` at
+    // roughly a quarter of the real window. Observed on grok-4.6 (500k
+    // window): 403,222 reserved against 79,048 actually reported.
+    const body = "export function handler(request) { return request.body; }\n";
+    const content = body.repeat(2_000);
+    const promptBytes = new TextEncoder().encode(content).byteLength;
+
+    const { inputTokens } = estimateTokenAccountingRequest(
+      accountingRequest(content),
+    );
+
+    // Still an upper bound: comfortably above the ~4 bytes/token an ASCII
+    // code prompt really costs.
+    expect(inputTokens).toBeGreaterThan(promptBytes / 4);
+    // But no longer the raw byte count.
+    expect(inputTokens).toBeLessThan(promptBytes * 0.75);
+  });
+
   test("uses a whole-request ceiling and never loses short-message framing", () => {
     const counts = [0, 1, 2, 100].map((messageCount) => {
       const request = accountingRequest("", {

--- a/runtime/tests/services/compact/plan-packing.test.ts
+++ b/runtime/tests/services/compact/plan-packing.test.ts
@@ -23,7 +23,11 @@ const SOURCE_BINDING = "rollout:/packing-regression#epoch:1";
 const DIGEST = "a".repeat(64);
 const CONTEXT_WINDOW_TOKENS = 65_536;
 const OUTPUT_RESERVE_TOKENS = 256;
-const UNIT_TEXT_BYTES = 53_000;
+// Sized so one semantic unit nearly fills a chunk under the accounting
+// fallback's bytes-per-token divisor. Calibrated in bytes, not tokens: the
+// packing geometry this test pins (one unit per chunk, 63 chunks, 3 levels)
+// only holds while a unit stays just under the per-chunk budget.
+const UNIT_TEXT_BYTES = 106_000;
 const NEAR_MAXIMUM_CHUNKS = MAX_COMPACTION_CHUNKS - 1;
 const STRUCTURED_TRANSCRIPT_VERSION = 1;
 const STRUCTURED_TRANSCRIPT_KIND = "untrusted_compaction_transcript";

--- a/runtime/tests/services/compact/transaction-adversarial.contract.test.ts
+++ b/runtime/tests/services/compact/transaction-adversarial.contract.test.ts
@@ -181,7 +181,13 @@ describe("transactional compaction adversarial contracts", () => {
     });
 
     await withTransactionalStore("semantic-fit-plus1", async (store) => {
-      const source = createSingleToolUnit(store.sessionId, `${"x".repeat(8_192)}x`);
+      // Overflow by more than one estimated token. A single extra byte only
+      // crosses the bound when the estimator treats bytes as tokens; with a
+      // bytes-per-token divisor it rounds away and the unit still fits.
+      const source = createSingleToolUnit(
+        store.sessionId,
+        `${"x".repeat(8_192)}${"x".repeat(64)}`,
+      );
       appendSource(store, source.messages);
       const provider = createProvider((payload) => validBody(source.toolPairs, payload));
 

--- a/runtime/tests/session/mcp-startup.test.ts
+++ b/runtime/tests/session/mcp-startup.test.ts
@@ -241,7 +241,7 @@ describe("mcp-startup.attachMcpManagerToSession", () => {
     expect(providerChat).toHaveBeenCalledWith(
       [{ role: "user", content: "Summarize this" }],
       {
-        accountedInputTokens: 1052,
+        accountedInputTokens: 677,
         contextWindowTokens: 1_000_000,
         model: "grok-4.3-mini",
         systemPrompt: "Be brief",


### PR DESCRIPTION
## The bug

`conservativeFallbackResult` reserved the serialized prompt's raw UTF-8 **byte** count as its **token** count:

```js
const promptBytes = normalizedUtf8UpperBound(stableStringify(promptIdentity));
...
const beforeMargin = safeTokenSum(promptBytes, frameTokens);
```

`estimateUtf8TokenUnits(value, bytesPerToken)` — the helper that converts — sits directly above and was never called from the fallback. The module header requires estimators to use it rather than duplicate its UTF-8 conversion; the service's own "only admission-grade local fallback" skipped the conversion entirely.

`promptIdentity` carries the whole prompt (system + messages + tools), so the estimate ran ~4x high. `admitted-model-call` compares that result against the context window, so admission denied `context_window_exceeded` at roughly a quarter of the real window and killed the run.

It only bit providers **without** a native counter. `anthropic`, `gemini` and `bedrock` define `tokenCountCapability`; `grok`/`xai` does not, so every grok call took the inflated path.

## Observed

Live grok-4.6 session (catalogued at 500k). Reservations and reported usage, interleaved 1:1 in the same turn:

| iteration | reserved | provider reported |
|---|---|---|
| 15 | 383,853 | 74,634 |
| 16 | 388,395 | 76,867 |
| 17 | 393,659 | 77,857 |
| 18 | 403,222 | 79,048 |
| 18 (retry) | **denied — `context_window_exceeded`** | — |

The run died with the real context at **16% of the window**. Measured 4.27 bytes per real token.

## The fix

Divide by a documented conservative floor of 2 bytes/token. That is below every catalogued tokenizer ratio (lowest is minimax at 3.2), so the estimate stays an upper bound, but it no longer gates admission on a bound no tokenizer can reach. The same reservation drops from 403,222 to roughly 218k against a 500k window.

`TOKEN_ACCOUNTING_CALIBRATION_VERSION` bumps to `v2` so the two calibrations stay distinguishable in reported results.

## Trade-off worth reviewing

The old bound was safe but fatal; 2 is realistic with a tail risk. Content that tokenizes worse than 2 bytes/token — long base64 or hex blobs — could in principle undercount, and undercounting has a real failure mode (`provider_overrun` → `blocked_by_provider_overrun` cancels the run). The 10% + 256 safety margin still applies on top, and 2 is well under the 3.2 floor of catalogued ratios. Flagging it rather than burying it.

## Tests

Three tests pinned the old behaviour and are recalibrated **without weakening what they assert**:

- `plan-packing` sized its units in bytes-as-tokens (`UNIT_TEXT_BYTES` 53,000 → 106,000) so the packing geometry it pins — one unit per chunk, 63 chunks, 3 levels — still holds.
- `transaction-adversarial` assumed **one extra byte** always adds a token, which is only true when bytes are tokens. Now overflows by more than one estimated token.
- `mcp-startup` pinned `accountedInputTokens` by hand (1052 → 677).

Adds a regression test that the estimate stays above `bytes/4` but below the raw byte count.

`tsc --noEmit` clean. 3,607 tests pass across `services`, `state`, `llm`, `budget`, `session`. One pre-existing unrelated failure remains (`tests/services/mcp/client-sdk-setup.test.ts`, MCP roots — fails on `main` too).

## Separate finding, not fixed here

The committed calibration corpus behind the *"has zero fallback undercounts"* test has **7 cases, all 16–33 reference tokens**, where fixed framing overhead dominates (estimates 541–551, ratios 16–50x) and the bytes-per-token relationship is never exercised. It passes identically before and after this change — it would not have caught this bug, and would not catch a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)