### PR TITLE
fix(services): build and compare file URIs instead of interpolating them

### DIFF
--- a/runtime/src/services/diagnosticTracking.ts
+++ b/runtime/src/services/diagnosticTracking.ts
@@ -1,4 +1,5 @@
 import figures from 'figures'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { logError } from 'src/utils/log.js'
 import { callIdeRpc } from './mcp/client.js'
 import type { MCPServerConnection } from './mcp/types.js'
@@ -115,6 +116,18 @@ export class DiagnosticTrackingService {
   }
 
   private normalizeFileUri(fileUri: string): string {
+    // A file:// URI is percent-encoded; decode it back to a path rather than
+    // slicing the scheme off. Slicing leaves "%20" in place, so a workspace
+    // whose path contains a space never compares equal to the URI the IDE
+    // echoes back, and every diagnostic for that file logs a mismatch.
+    if (fileUri.startsWith('file://')) {
+      try {
+        return normalizePathForComparison(fileURLToPath(fileUri))
+      } catch {
+        // Malformed URI: fall through to prefix stripping below.
+      }
+    }
+
     // Remove our protocol prefixes
     const protocolPrefixes = [
       'file://',
@@ -185,7 +198,7 @@ export class DiagnosticTrackingService {
     try {
       const result = await callIdeRpc(
         'getDiagnostics',
-        { uri: `file://${filePath}` },
+        { uri: pathToFileURL(filePath).href },
         mcpClient,
       )
       const diagnosticFile = this.parseDiagnosticResult(result)[0]

--- a/runtime/tests/services/mcp/client-sdk-setup.test.ts
+++ b/runtime/tests/services/mcp/client-sdk-setup.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, test, vi } from 'vitest'
@@ -805,8 +806,11 @@ test('connectToServer creates stdio clients with lifecycle handlers and cleanup'
   })
   assert.equal(result.instructions, 'instructions for stdio-demo')
   assert.equal(fakeClients[0]?.handlers.length, 3)
+  // Build the expected URI the way a file URI is built, not by interpolation:
+  // a checkout path containing a space (or #, ?, or non-ASCII) percent-encodes,
+  // so `file://${cwd}` only matches on paths that happen to need no encoding.
   assert.deepEqual(await fakeClients[0]!.handlers[0]!.handler(), {
-    roots: [{ uri: `file://${process.cwd()}` }],
+    roots: [{ uri: pathToFileURL(process.cwd()).href }],
   })
   assert.deepEqual(await fakeClients[0]!.handlers[1]!.handler({}), {
     role: 'assistant',

--- a/runtime/tests/tui/moved-source-markers.test.ts
+++ b/runtime/tests/tui/moved-source-markers.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
 const files = [
@@ -22,7 +23,10 @@ const files = [
   "runtime/src/tui/components/teams/TeamsDialog.tsx",
 ];
 
-const repoRoot = new URL("../../../", import.meta.url).pathname;
+// `.pathname` keeps the URL percent-encoded, so a checkout path containing a
+// space resolves to a literal "%20" that readFileSync cannot open. Converting
+// the URL back to a path is what makes this work outside CI.
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
 
 describe("moved-source marker cleanup", () => {
   test("audited live TUI render files start with real source", () => {


### PR DESCRIPTION
Three sites built or consumed a `file://` URI by string surgery, so each breaks as soon as the path needs percent-encoding. A checkout under a directory with a space in its name — `agenc core` — fails all three. CI paths need no encoding, so all three stay green there.

## Production: `diagnosticTracking.ts`

Two halves of the same mistake, and fixing either one alone leaves it broken:

```js
{ uri: `file://${filePath}` },        // unencoded → malformed URI on the wire
```

```js
normalized = fileUri.slice(prefix.length)   // leaves %20 in place
```

We asked the IDE for diagnostics using a malformed URI, then compared its reply by slicing the scheme off instead of decoding. A real IDE echoes back a properly encoded URI, so `/home/paul/agenc core/x.ts` was compared against `/home/paul/agenc%20core/x.ts`, never matched, and every diagnostic for that file logged a `DiagnosticsTrackingError`.

Now sends `pathToFileURL(filePath).href` and decodes with `fileURLToPath` when comparing, falling back to the old prefix stripping for the `_agenc_fs_*` schemes and for malformed input.

Incidentally fixes Windows: slicing `file://` off `file:///C:/x` left `/C:/x` with a leading slash, which `fileURLToPath` does not produce.

## Tests: the same bug from both directions

- `client-sdk-setup.test.ts` built its expectation as `file://${process.cwd()}` and compared it against production output that correctly encodes via [`getMcpRootUriForPath`](runtime/src/services/mcp/hostCapabilities.ts). Test wrong, code right.
- `moved-source-markers.test.ts` took `new URL("../../../", import.meta.url).pathname` — which stays percent-encoded — and handed it to `readFileSync`, which opened a literal `%20` and raised `ENOENT`. 4 failures.

## Deliberately not changed

`eval-executor/cli.ts:513` uses the same interpolation but passes the result through `new URL()`, which encodes on construction. Verified it already agrees with `pathToFileURL`, so it is left alone.

`tests/packaging/update-cli.test.ts` has ~20 occurrences of the same pattern, but they build URLs over `tmpdir()`, which normally needs no encoding. Latent, not addressed here.

## Verification

`tsc --noEmit` clean. The three affected files pass: 61 tests, previously 5 failures across them.

Worth noting for reviewers: none of this is exercised by the PR gate. `platform-tests.yml` runs 9 hosted capability lanes (kernel sandbox, native, neovim, powershell) and no default-suite job, so these tests do not run on CI either before or after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)