### PR TITLE
test(tools): make the modified-since-read refusal actually exercise the guard

### DIFF
--- a/runtime/tests/tools/system/file-write.test.ts
+++ b/runtime/tests/tools/system/file-write.test.ts
@@ -229,7 +229,16 @@ describe("Write tool", () => {
     test("modified-since-read refusal", async () => {
       const target = join(root, "drifted.txt");
       await writeFile(target, "alpha\n", "utf8");
-      recordSessionRead(sessionId, target, "stale snapshot\n");
+      // The snapshot must predate the file's mtime for the drift guard to
+      // fire. Passing a bare string spreads into {0:'s',1:'t',...}, leaving
+      // `timestamp` undefined, and `mtime > undefined` is false — so the guard
+      // never ran and this test was writing the file it asserts is untouched.
+      const fileStats = await stat(target);
+      recordSessionRead(sessionId, target, {
+        content: "stale snapshot\n",
+        timestamp: fileStats.mtimeMs - 1,
+        viewKind: "full",
+      });
 
       const tool = createFileWriteTool({ allowedPaths: [root] });
       expectNoEffect(


### PR DESCRIPTION
## What was wrong

`recordSessionRead` takes a `SessionReadSnapshot`. This call passed a bare string:

```js
recordSessionRead(sessionId, target, "stale snapshot\n");
```

Object-spreading a string yields `{0:'s', 1:'t', 2:'a', ...}`, so the recorded snapshot carried no `timestamp`. The drift guard compares:

```js
if (lastWriteTime > readTimestamp.timestamp)
```

and any number compared against `undefined` is `false`. **The guard never fired.** The tool went on to write the file that the test then asserts is untouched, and `result.isError` came back `undefined` instead of `true`.

The two sibling tests in the same `describe` — `read-before-write refusal` and `path outside allowed directories` — pass an object and have been passing all along. That is why only this one was red.

## Why it matters

That `describe` block exists to guard a specific regression, quoted from its own comment:

> the effect boundary is marked crossed before `execute` runs, so a guard refusal reached the settlement supervisor as an errored side-effecting call with no disposition. That poisoned the live effect and blocked every later side-effecting and interactive dispatch for the rest of the session.

One third of that protection was inert.

## The fix

Use the same idiom as the other snapshot-based test in this file: `timestamp: fileStats.mtimeMs - 1`, so the read provably predates the file's mtime without depending on wall-clock timing.

**The production path turns out to be correct.** With the guard reached for the first time, `FileWriteTool` refuses with `isError: true` plus a `confirmed_no_effect` / `boundary_not_crossed` disposition and a valid `evidenceSha256` — exactly what the block was written to protect. No source change needed. 28/28 pass.

## Why nothing caught it

A string passed where an interface is required should be a compile error. `tsconfig.test-support.json` type-checks a hand-maintained allowlist of 57 files, and `tests/tools/system/file-write.test.ts` is not one of them — so the test suite is largely not type-checked at all.

Combined with `platform-tests.yml` running only the 9 hosted capability lanes and no default-suite job, a test can both fail to compile-check and fail at runtime without anything going red. Flagging the pattern; not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)