### PR TITLE
test: resolve the repo root as a path, not a percent-encoded URL

### DIFF
--- a/runtime/tests/meta/license-and-version.test.ts
+++ b/runtime/tests/meta/license-and-version.test.ts
@@ -1,8 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
-const repoRoot = new URL("../../../", import.meta.url).pathname;
+// `.pathname` stays percent-encoded, so a checkout path containing a space
+// resolves to a literal "%20" that no filesystem call can open.
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(`${repoRoot}${relativePath}`, "utf8");

--- a/runtime/tests/tui/screens/orphan-rendering.test.ts
+++ b/runtime/tests/tui/screens/orphan-rendering.test.ts
@@ -1,8 +1,12 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
-const repoRoot = new URL("../../../../", import.meta.url).pathname;
+// `.pathname` stays percent-encoded. This file's assertions are absence checks
+// and directory scans, so an unusable root made `existsSync` return false and
+// the scans return nothing: the suite passed while checking nothing at all.
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
 const startupHelper = ["repl", "Startup", "Gates"].join("");
 const inputHelper = ["repl", "Input", "Suppression"].join("");
 const workerPendingHelper = ["Worker", "Pending", "Permission"].join("");


### PR DESCRIPTION
Both files derived their repo root with:

```js
const repoRoot = new URL("../../../", import.meta.url).pathname;
```

`.pathname` stays percent-encoded. Under a checkout whose path contains a space — `agenc core` — every filesystem call receives a literal `%20`.

## They failed in opposite directions

**`license-and-version.test.ts` fails loudly.** `readFileSync`, `existsSync` and an `execFileSync` cwd all receive an unopenable path: **15 tests** down across repository licensing, runtime manifest dependencies, build-time `MACRO.VERSION` wiring and SDK surface hygiene.

**`orphan-rendering.test.ts` passed while asserting nothing.** Its checks are `existsSync(join(repoRoot, rel))` expecting `false`, plus directory scans over `runtime/src/tui` and `scripts`. An unusable root makes `existsSync` return `false` for the wrong reason and the scans return nothing — the file was green without looking at a single source file.

With the root fixed it scans for real and still passes: there are no orphans, which until now nobody was actually checking.

## Relationship to #1708

Same root cause. That PR repaired the two instances that were visibly failing rather than the pattern itself; grepping for `.pathname` surfaces these two.

The other nine `.pathname` uses in the tree were reviewed and left alone — they operate on HTTP URLs (`services/api/client.ts`, `gemini/index.ts`, `app-server/transport/websocket.ts`, `gateway/x-search.ts`) or on extensions (`plugins/resolution.ts`, `red-probe-markdown-loader.mjs`), where `.pathname` is correct.

## Verification

19 tests pass across both files, previously 15 failing and 4 vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)