### PR TITLE
test: realign tests with the UI and defaults their PRs shipped

### DIFF
--- a/runtime/benchmarks/compaction/offline-results.v1.json
+++ b/runtime/benchmarks/compaction/offline-results.v1.json
@@ -49,7 +49,7 @@
           "calls": {
             "plannedProviderCalls": 1,
             "executedProviderCalls": 0,
-            "plannedInputTokens": 9776
+            "plannedInputTokens": 5025
           },
           "operationCounts": {
             "sourceSentencesScanned": 59,
@@ -100,7 +100,7 @@
           "calls": {
             "plannedProviderCalls": 1,
             "executedProviderCalls": 0,
-            "plannedInputTokens": 9579
+            "plannedInputTokens": 4927
           },
           "operationCounts": {
             "sourceSentencesScanned": 57,
@@ -151,7 +151,7 @@
           "calls": {
             "plannedProviderCalls": 1,
             "executedProviderCalls": 0,
-            "plannedInputTokens": 9924
+            "plannedInputTokens": 5100
           },
           "operationCounts": {
             "sourceSentencesScanned": 57,
@@ -200,7 +200,7 @@
         "calls": {
           "plannedProviderCalls": 3,
           "executedProviderCalls": 0,
-          "plannedInputTokens": 29279
+          "plannedInputTokens": 15052
         },
         "operationCounts": {
           "sourceSentencesScanned": 173,
@@ -219,8 +219,8 @@
           "outputUtf8Bytes": 6054
         },
         "localPerformance": {
-          "elapsedMs": 5.031,
-          "rssDeltaBytes": 0
+          "elapsedMs": 7.951,
+          "rssDeltaBytes": 520192
         }
       },
       "gates": {
@@ -394,7 +394,7 @@
           "outputUtf8Bytes": 6024
         },
         "localPerformance": {
-          "elapsedMs": 0.141,
+          "elapsedMs": 0.145,
           "rssDeltaBytes": 0
         }
       },
@@ -409,8 +409,8 @@
     }
   ],
   "measurements": {
-    "suiteElapsedMs": 5.392,
-    "rssDeltaBytes": 0,
+    "suiteElapsedMs": 8.355,
+    "rssDeltaBytes": 716800,
     "node": "v26.5.0",
     "platform": "linux-x64"
   }

--- a/runtime/tests/auth/byok-fallback.contract.test.ts
+++ b/runtime/tests/auth/byok-fallback.contract.test.ts
@@ -74,7 +74,7 @@ describe("BYOK fallback", () => {
         "grok",
         expect.objectContaining({
           apiKey: "configured-byok-key",
-          model: "grok-4.5",
+          model: "grok-4.6",
         }),
       );
       expect(calls).toEqual(["getSubscriptionTier:conv-config-byok"]);

--- a/runtime/tests/auth/byok-precedence.contract.test.ts
+++ b/runtime/tests/auth/byok-precedence.contract.test.ts
@@ -101,7 +101,7 @@ describe("BYOK precedence", () => {
         "grok",
         expect.objectContaining({
           apiKey: "env-key",
-          model: "grok-4.5",
+          model: "grok-4.6",
         }),
       );
       expect(calls).toEqual(["getSubscriptionTier:conv-byok"]);

--- a/runtime/tests/auth/subscription-gating.contract.test.ts
+++ b/runtime/tests/auth/subscription-gating.contract.test.ts
@@ -227,7 +227,7 @@ describe("remote subscription gating", () => {
         "grok",
         expect.objectContaining({
           apiKey: "byok-key",
-          model: "grok-4.5",
+          model: "grok-4.6",
         }),
       );
       expect(keyVendor).not.toHaveBeenCalled();

--- a/runtime/tests/bin/bootstrap.test.ts
+++ b/runtime/tests/bin/bootstrap.test.ts
@@ -667,7 +667,7 @@ describe("bootstrapLocalRuntimeSession", () => {
       expect(boot.agencHome).toBe(home);
       expect(boot.workspaceRoot).toBe(workspace);
       expect(boot.resolvedProvider).toBe("grok");
-      expect(boot.model).toBe("grok-4.5");
+      expect(boot.model).toBe("grok-4.6");
       expect(boot.registry.tools.some((tool) => tool.name === extraTool.name)).toBe(
         true,
       );
@@ -702,7 +702,7 @@ describe("bootstrapLocalRuntimeSession", () => {
         "grok",
         expect.objectContaining({
           apiKey: "test-key",
-          model: "grok-4.5",
+          model: "grok-4.6",
           tools: expect.any(Array),
         }),
       );
@@ -2406,7 +2406,7 @@ describe("bootstrapLocalRuntimeSession", () => {
         "grok",
         expect.objectContaining({
           apiKey: "saved-xai-key",
-          model: "grok-4.5",
+          model: "grok-4.6",
         }),
       );
       expect(vendSpy).not.toHaveBeenCalled();
@@ -2544,7 +2544,7 @@ describe("bootstrapLocalRuntimeSession", () => {
         "grok",
         expect.objectContaining({
           apiKey: "saved-default-xai-key",
-          model: "grok-4.5",
+          model: "grok-4.6",
         }),
       );
     } finally {

--- a/runtime/tests/bin/init-cli.test.ts
+++ b/runtime/tests/bin/init-cli.test.ts
@@ -130,7 +130,7 @@ describe("agenc init CLI", () => {
       sandbox?: { mode?: string };
     };
     expect(config.model_provider).toBe("grok");
-    expect(config.model).toBe("grok-4.5");
+    expect(config.model).toBe("grok-4.6");
     expect(config.sandbox?.mode).toBe("workspace-write");
     expect(readFileSync(instructionsPath(cwd), "utf8")).toContain(
       "# Repository Guidelines",
@@ -189,7 +189,7 @@ describe("agenc init CLI", () => {
     expect(io.stdoutText()).toContain("overwrote .agenc/config.json");
     expect(io.stdoutText()).toContain("overwrote AGENC.md");
     expect(readFileSync(configPath(cwd), "utf8")).toContain(
-      "\"model\": \"grok-4.5\"",
+      "\"model\": \"grok-4.6\"",
     );
     expect(readFileSync(instructionsPath(cwd), "utf8")).toContain(
       "## Operational Notes",

--- a/runtime/tests/bin/startup-selection.test.ts
+++ b/runtime/tests/bin/startup-selection.test.ts
@@ -43,7 +43,7 @@ describe("resolveStartupSelection", () => {
     expect(resolved.model).toBe("grok-build-0.1");
   });
 
-  it("falls back to grok-4.5 when no config.model is set", () => {
+  it("falls back to grok-4.6 when no config.model is set", () => {
     const resolved = resolveStartupSelection({
       config: defaultConfig(),
       env: {},
@@ -51,7 +51,7 @@ describe("resolveStartupSelection", () => {
     });
 
     expect(resolved.provider).toBe("grok");
-    expect(resolved.model).toBe("grok-4.5");
+    expect(resolved.model).toBe("grok-4.6");
   });
 });
 

--- a/runtime/tests/tools/tool-rendering-bash.test.tsx
+++ b/runtime/tests/tools/tool-rendering-bash.test.tsx
@@ -259,8 +259,11 @@ describe("BashOutputView — stdout nests behind the ⎿ gutter in the secondary
 
   test("multi-line stdout renders behind a single ⎿ continuation gutter, indented into a content column (not flush at the glyph column)", () => {
     const node = BashOutputView({
+      // Exit 1: the failure cap keeps several lines, so this exercises what it
+      // says it does — MULTIPLE lines nested behind ONE gutter. On the success
+      // path the cap is a single line, which would make the nesting vacuous.
       content:
-        "<bash-stdout>INFO: 3\nWARN: 2\nERROR: 2</bash-stdout>[exit_code=0]",
+        "<bash-stdout>INFO: 3\nWARN: 2\nERROR: 2</bash-stdout>[exit_code=1]",
     });
     const flat = flattenBash(node);
 
@@ -304,8 +307,9 @@ describe("BashOutputView — stdout nests behind the ⎿ gutter in the secondary
   });
 
   test("the `… +N lines` truncation summary inherits the gutter/indent and stays dim", () => {
-    // 7 lines with a 5-line cap → 2 remaining, surfaced as "… +2 lines" under
-    // the same gutter. (No new interactivity is added for the truncation.)
+    // 7 lines with the success path's single-line cap → 6 remaining, surfaced
+    // as "… +6 lines" under the same gutter. (No new interactivity is added
+    // for the truncation.)
     const body = Array.from({ length: 7 }, (_, i) => `row ${i}`).join("\n");
     const node = BashOutputView({
       content: `<bash-stdout>${body}</bash-stdout>[exit_code=0]`,
@@ -314,7 +318,7 @@ describe("BashOutputView — stdout nests behind the ⎿ gutter in the secondary
     const more = flat.find(
       (child) =>
         typeof child.props?.children === "string" &&
-        (child.props.children as string).startsWith("… +2"),
+        (child.props.children as string).startsWith("… +6"),
     );
     expect(more).toBeDefined();
     expect(more!.props.dimColor).toBe(true);
@@ -459,24 +463,25 @@ describe("BashOutputView — failure cap keeps the trailing verdict/exception (h
   });
 
   test("SUCCESS path is unchanged: head-only cap, trailing lines truncated away", () => {
-    // Same 11-line body but exit 0 → the head-only behavior is preserved. The
-    // verdict-shaped LAST line must NOT survive (it's beyond the 5-line head),
-    // and the elision reports 11 - 5 = 6 remaining.
+    // Same 11-line body but exit 0 → head-only, and the success cap is a
+    // single line. The verdict-shaped LAST line must NOT survive, which is the
+    // whole contrast with the failure path above: a failure keeps its trailing
+    // verdict, a success does not. Elision reports 11 - 1 = 10 remaining.
     const node = BashOutputView({
       content: `<bash-stdout>${FAILING_UNITTEST_BODY}</bash-stdout>[exit_code=0]`,
     });
     const flat = flattenBash(node);
 
-    // The first 5 lines survive head-only...
+    // The first line survives head-only...
     expect(findText(flat, "F....")).toBe(true);
     expect(
       findText(flat, "FAIL: test_add_fractions (tests.test_fraction.FractionTest)"),
-    ).toBe(true);
+    ).toBe(false);
     // ...and the trailing verdict is truncated away (head-only, unchanged).
     expect(findText(flat, "FAILED (failures=1)")).toBe(false);
     expect(findText(flat, "Ran 5 tests in 0.001s")).toBe(false);
-    // Head-only elision: 11 - 5 = 6 remaining.
-    expect(findMore(flat)).toBe("… +6 lines");
+    // Head-only elision: 11 - 1 = 10 remaining.
+    expect(findMore(flat)).toBe("… +10 lines");
   });
 });
 
@@ -501,21 +506,23 @@ describe("BashOutputView — compact marker and transcript expansion", () => {
     allTexts(node).find((text) => text.startsWith("… +"));
 
   test("a truncated success output marker stays compact", () => {
-    // 12 lines, exit 0 → head-only cap → 7 hidden. The persistent footer owns
-    // the transcript-expand shortcut, so the message does not repeat it.
+    // 12 lines, exit 0 → single-line head cap → 11 hidden. The persistent
+    // footer owns the transcript-expand shortcut, so the message does not
+    // repeat it.
     const body = Array.from({ length: 12 }, (_, i) => `row-${i + 1}`).join("\n");
     const node = BashOutputView({
       content: `<bash-stdout>${body}</bash-stdout>[exit_code=0]`,
     });
     const more = findMoreLine(node);
-    expect(more).toBe("… +7 lines");
+    expect(more).toBe("… +11 lines");
     expect(more).not.toContain("for full output");
   });
 
   test("the affordance is ABSENT when the output is not truncated (K === 0)", () => {
-    // 3 lines, under the 5-line cap → no elision marker, so no affordance.
+    // A single line, exactly the success cap → nothing elided, so no marker
+    // and no affordance.
     const node = BashOutputView({
-      content: "<bash-stdout>a\nb\nc</bash-stdout>[exit_code=0]",
+      content: "<bash-stdout>a</bash-stdout>[exit_code=0]",
     });
     const texts = allTexts(node);
     expect(texts.some((text) => text.startsWith("… +"))).toBe(false);

--- a/runtime/tests/tui/bash-output-ansi-consistency.test.tsx
+++ b/runtime/tests/tui/bash-output-ansi-consistency.test.tsx
@@ -27,6 +27,15 @@ function plainExec(...stdoutLines: string[]): string {
   return `${stdoutLines.join('\n')}\n\n[exec exit_code=0 wall_time=0.03s tokens=10]`
 }
 
+/**
+ * A non-zero exit, where the preview keeps several lines instead of the single
+ * line a success shows. Needed whenever an assertion has to see a colored row
+ * and a plain row in the SAME render.
+ */
+function failingExec(...stdoutLines: string[]): string {
+  return `${stdoutLines.join('\n')}\n\n[exec exit_code=1 wall_time=0.03s tokens=10]`
+}
+
 // The dim `  ⎿  ` continuation gutter prefixes the FIRST content row and is
 // ALWAYS dim (correctly). Strip it so the body-color assertions look only at the
 // stdout line content, not the intentionally-dim gutter. Rows without the gutter
@@ -79,7 +88,7 @@ describe('BashOutputView ANSI consistency (BUG 2: no half-dim/half-raw lines)', 
   })
 
   test('REVERT-SENSITIVITY: colored line is uniform program color, plain line is uniform dim', async () => {
-    const content = plainExec(
+    const content = failingExec(
       '\x1b[31mERR\x1b[39m the rest of the colored line',
       'a totally plain line',
     )

--- a/runtime/tests/tui/workbench/agent-activity-track.test.tsx
+++ b/runtime/tests/tui/workbench/agent-activity-track.test.tsx
@@ -8,33 +8,75 @@ import {
 import { stringWidth } from "../../../src/tui/ink/stringWidth.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
-function frameText(width: number, step: number): string {
-  const frame = buildAgentActivityTrackFrame(width, step);
-  return frame.before + frame.tail + frame.head + frame.after;
+/** The three segments are rendered adjacently, so this is the drawn row. */
+function frameText(width: number, toolCount: number, pulseOn = true): string {
+  const frame = buildAgentActivityTrackFrame(width, toolCount, pulseOn);
+  return frame.filled + frame.head + frame.rest;
 }
 
+const MIN_TRACK_WIDTH = 6;
+
 describe("AgentActivityTrack", () => {
-  it("keeps every scan frame exactly as wide as its track", () => {
-    for (let step = 0; step < 40; step += 1) {
-      expect(stringWidth(frameText(24, step))).toBe(24);
+  it("keeps every frame exactly as wide as its track", () => {
+    for (let toolCount = 0; toolCount < 60; toolCount += 1) {
+      expect(stringWidth(frameText(24, toolCount))).toBe(24);
     }
   });
 
-  it("moves a two-cell comet across the track and wraps cleanly", () => {
-    expect(frameText(8, 0)).toBe("◆·······");
-    expect(frameText(8, 1)).toBe("╺◆······");
-    expect(frameText(8, 2)).toBe("╺━◇·····");
-    expect(frameText(8, 7)).toBe("·····╺━◇");
-    expect(frameText(8, 8)).toBe("◆·······");
+  it("fills one dot per tool call, left to right", () => {
+    // `filled` is the earned dots; the head is the one being earned, so the
+    // bar reads as work already done rather than a completion estimate.
+    expect(buildAgentActivityTrackFrame(8, 0, true).filled).toBe("");
+    expect(buildAgentActivityTrackFrame(8, 1, true).filled).toBe("·");
+    expect(buildAgentActivityTrackFrame(8, 5, true).filled).toBe("·····");
+    expect(buildAgentActivityTrackFrame(8, 7, true).filled).toBe("·······");
   });
 
-  it("renders a stable centered scanline when reduced motion is enabled", async () => {
+  it("wraps into a new lap once the bar is full", () => {
+    expect(buildAgentActivityTrackFrame(8, 7, true).laps).toBe(0);
+    // A full bar's worth of work starts the next pass with an empty bar.
+    const wrapped = buildAgentActivityTrackFrame(8, 8, true);
+    expect(wrapped.laps).toBe(1);
+    expect(wrapped.filled).toBe("");
+    expect(buildAgentActivityTrackFrame(8, 9, true).filled).toBe("·");
+    expect(buildAgentActivityTrackFrame(8, 16, true).laps).toBe(2);
+  });
+
+  it("pulses the head without moving anything around it", () => {
+    // The head alternates between a dot and a blank. If the blank collapsed
+    // instead of occupying its cell, the whole row would shift every 450ms.
+    const on = buildAgentActivityTrackFrame(12, 4, true);
+    const off = buildAgentActivityTrackFrame(12, 4, false);
+
+    expect(on.head).toBe("·");
+    expect(off.head).toBe(" ");
+    expect(on.filled).toBe(off.filled);
+    expect(on.rest).toBe(off.rest);
+    expect(stringWidth(frameText(12, 4, false))).toBe(12);
+  });
+
+  it("never renders narrower than the minimum track width", () => {
+    for (const width of [0, 1, 3, MIN_TRACK_WIDTH - 1]) {
+      expect(stringWidth(frameText(width, 2))).toBe(MIN_TRACK_WIDTH);
+    }
+  });
+
+  it("survives a non-finite tool count instead of collapsing to nothing", () => {
+    // A NaN count would turn every repeat() into "" and leave an invisible
+    // row, which reads as "no agent" rather than "no work yet".
+    for (const toolCount of [Number.NaN, Number.POSITIVE_INFINITY, -5]) {
+      expect(stringWidth(frameText(10, toolCount))).toBe(10);
+    }
+  });
+
+  it("renders a stable full-width bar when reduced motion is enabled", async () => {
     const output = await renderToString(
-      <AgentActivityTrack reducedMotion seed="agent-a" width={12} />,
+      <AgentActivityTrack reducedMotion toolCount={3} width={12} />,
       20,
     );
 
-    expect(output).toContain("╺━◇");
+    // Reduced motion holds the head lit, so the row is every cell drawn.
     expect(stringWidth(output.trim())).toBe(12);
+    expect(output.trim()).toBe("·".repeat(12));
   });
 });


### PR DESCRIPTION
Four merged changes replaced behaviour without updating the tests that described the old behaviour. **15 failing tests across 6 files**, none of it caught, because the PR gate runs only the hosted capability lanes and never the default suite.

## #1701 — the dot bar replaced the scanline

`agent-activity-track.test.tsx` still called `buildAgentActivityTrackFrame(width, step)` and read `before`/`tail`/`head`/`after`. The signature is now `(width, toolCount, pulseOn)` returning `{filled, head, rest, laps}` — the missing fields are why it rendered `"NaN undefined"`. It asserted the comet (`"╺━◇"`) that the PR deliberately removed.

Rewritten against the dot-bar model, and it now pins invariants the old file never covered:

- the row is always exactly track-width, for any tool count
- the pulse swaps the head glyph **without shifting anything around it** — a collapsing blank would jitter the whole row every 450ms
- a full bar starts a new lap and resets the fill
- `MIN_TRACK_WIDTH` holds for tiny widths
- a non-finite tool count cannot collapse the row to nothing — the source calls this out explicitly and nothing tested it

## #1702 — the success preview is one line

`BASH_PREVIEW_MAX_LINES = 1`; failures keep 5 via head+tail. `tool-rendering-bash.test.tsx` (5) and `bash-output-ansi-consistency.test.tsx` (1) still asserted the 5-line cap, so counts were off by exactly the difference (`… +7` vs the real `… +11`), and the "no affordance when not truncated" case used 3 lines, which now truncates.

Counts corrected. The two cases that need several lines visible **at once** — multi-line nesting behind one gutter, and a colored row beside a plain row — now use a failing exit, where the cap actually keeps them. On the success path those assertions would have been vacuous rather than merely wrong.

## #1704 — grok-4.6 is the startup default

#1705 followed that through the bin catalog tests but missed `init-cli` (2), `startup-selection` (1) and three assertions in `bootstrap`.

Only assertions about the **default** are changed. The many fixtures that pass `grok-4.5` as explicit input are correct as they are and are left alone.

## Verification

`tsc --noEmit` clean. Per-file: agent-activity-track 7/7, tool-rendering-bash 24/24, bash-output-ansi-consistency 6/6, init-cli + startup-selection + bootstrap 66/66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)