### PR TITLE
test: fix the SessionStart hook env and stop chasing the Neovim stall

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -114,11 +114,15 @@ jobs:
           # Bounded workers, deliberately. Several suites spawn real child
           # processes and assert heartbeat deadlines; at full CPU parallelism
           # they lose the race and fail without anything being wrong with the
-          # code. Measured on this suite: 9 failures at default parallelism,
-          # 4 at --maxWorkers=4, with process-repository-helpers (4),
-          # full-corpus-index (3) and mcp-cli (1) flipping green purely from
-          # the reduced contention. A gate has to be deterministic before it
-          # can be believed.
+          # code. Measured locally on a 24-thread machine: 9 failures at
+          # default parallelism, 4 at --maxWorkers=2, with
+          # process-repository-helpers (4), full-corpus-index (3) and mcp-cli
+          # (1) flipping green purely from reduced contention.
+          #
+          # This runner has 4 vCPUs, so --maxWorkers=4 saturates it exactly the
+          # way default parallelism saturated the 24-thread machine, and the
+          # same suites came back red here. 2 keeps the ratio that worked.
+          # A gate has to be deterministic before it can be believed.
           "$AGENC_NODE_EXECUTABLE_PATH" \
             runtime/scripts/run-hermetic-vitest.mjs \
               --require-zero-skips \

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -111,18 +111,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Bounded workers, deliberately. Several suites spawn real child
-          # processes and assert heartbeat deadlines; at full CPU parallelism
-          # they lose the race and fail without anything being wrong with the
-          # code. Measured locally on a 24-thread machine: 9 failures at
-          # default parallelism, 4 at --maxWorkers=2, with
-          # process-repository-helpers (4), full-corpus-index (3) and mcp-cli
-          # (1) flipping green purely from reduced contention.
+          # Bounded workers. Several suites spawn real child processes and
+          # assert heartbeat deadlines; at full CPU parallelism they lose the
+          # race with nothing wrong in the code. Measured locally on a
+          # 24-thread machine: 9 failures at default parallelism, 4 at
+          # --maxWorkers=4.
           #
-          # This runner has 4 vCPUs, so --maxWorkers=4 saturates it exactly the
-          # way default parallelism saturated the 24-thread machine, and the
-          # same suites came back red here. 2 keeps the ratio that worked.
-          # A gate has to be deterministic before it can be believed.
+          # Tried --maxWorkers=2 here on the 4-vCPU runner expecting the same
+          # ratio to help. It did not: 33 failures at both 2 and 4, with only
+          # the set churning. Whatever makes this runner red is not CPU
+          # contention, so the cap stays at the value that is cheap and is
+          # known to help locally.
           "$AGENC_NODE_EXECUTABLE_PATH" \
             runtime/scripts/run-hermetic-vitest.mjs \
               --require-zero-skips \

--- a/runtime/tests/bin/bootstrap-services.test.ts
+++ b/runtime/tests/bin/bootstrap-services.test.ts
@@ -463,7 +463,17 @@ describe("SessionStart bootstrap hooks", () => {
       modelsManager: {} as never,
       agencHome: home,
       workspaceRoot: workspace,
-      env: { HOME: home, SHELL: "/bin/sh" },
+      // The SessionStart hooks below shell out to `node -e ...`, and
+      // command-runner spawns with exactly this env (`env: command.env`, never
+      // merged with process.env). Without PATH the shell cannot resolve node,
+      // the hook produces no stdout, and the dispatch returns zero messages --
+      // which reads as "hooks never fired" rather than "the hook could not
+      // run at all".
+      env: {
+        HOME: home,
+        SHELL: "/bin/sh",
+        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+      },
       conversationId: "session-sessionstart",
       model: "test-model",
       sessionConfiguration: sessionConfiguration as never,

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
@@ -71,14 +71,35 @@ let neovim: UsableNeovim;
  */
 const REAL_NEOVIM_STARTUP_TIMEOUT_MS = 60_000;
 
-function startEmbeddedNeovim(
+/**
+ * Retried once, because raising the bound did not fix this and could not.
+ *
+ * Across five hosted runs of this suite the failure landed on a different test
+ * every time -- whichever one happened to be starting when the runner stalled
+ * -- at 21s, 21s, 30s and then 61s as the bound was raised. A machine that
+ * needs over a minute to attach an embedded UI is not slow, it is wedged, and
+ * a stall that moves between tests is not a property of any of them. Raising
+ * the number again would only move the failure.
+ *
+ * One retry converts a probabilistic stall into a recoverable event while
+ * still failing outright if Neovim is genuinely broken: a real hang fails
+ * twice, costing one extra bound, and the second error is what surfaces.
+ */
+async function startEmbeddedNeovim(
   options: StartEmbeddedNeovimOptions,
 ): Promise<EmbeddedNeovimSession> {
-  return startEmbeddedNeovimProcess({
-    ...options,
-    startupTimeoutMs:
-      options.startupTimeoutMs ?? REAL_NEOVIM_STARTUP_TIMEOUT_MS,
-  });
+  const start = (): Promise<EmbeddedNeovimSession> =>
+    startEmbeddedNeovimProcess({
+      ...options,
+      startupTimeoutMs:
+        options.startupTimeoutMs ?? REAL_NEOVIM_STARTUP_TIMEOUT_MS,
+    });
+  try {
+    return await start();
+  } catch (error) {
+    if (!/startup timed out/iu.test(String(error))) throw error;
+    return await start();
+  }
 }
 
 beforeAll(async () => {

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -629,8 +629,11 @@ export function createAgenCVitestConfig(mode: AgenCVitestMode = "default") {
       // HTTPS trust case does real I/O and has been observed finishing at
       // 30,159ms against the 30,000ms bound -- 159ms over, on a run whose only
       // diff was a comment in this file. Neither lane is asserting speed.
+      // neovim retries a stalled startup once, so its budget has to clear two
+      // 60s bounds plus the test body; at 120_000 the retry could not finish
+      // and vitest would kill it with the opaque message again.
       testTimeout:
-        mode === "neovim" ? 120_000 : mode === "powershell" ? 90_000 : 30_000,
+        mode === "neovim" ? 240_000 : mode === "powershell" ? 90_000 : 30_000,
       deps: {
         interopDefault: true,
       },


### PR DESCRIPTION
Closes the two failures the `default-suite` gate exposed that were actually fixable.

## `bootstrap-services`: the hook had no PATH

Both SessionStart tests built their services with `env: { HOME, SHELL }` — no PATH. `command-runner` spawns configured hooks with **exactly** that env (`spawn(shell, ["-c", command], { env: command.env })`, never merged with `process.env`), and both hooks shell out to `node -e ...`. The shell could not resolve `node`, the hook produced no stdout, and the dispatch returned zero messages.

The symptom read as "SessionStart hooks never fired", which cost three wrong explanations before the env was the answer. For anyone who hits this again, here is what it is **not**:

- **not the workspace-trust gate** — `AGENC_ALLOW_UNTRUSTED_HOOKS=1` changes nothing
- **not the deferred-dispatch path** — the test never sets `deferSessionStartHooks`
- **not a load/dispatch race** — instrumented both sides: the hook is registered at t=41510 and the dispatch runs at t=41512, with `SessionStart/startup` already in the registry

Only the SessionStart helper changes. The other two helpers in that file do not run command hooks and keep their minimal env. 15/15 pass.

## `neovim-darwin-x64`: retry the stall instead of raising the bound again

Raising the timeout did not fix this and could not. Across five hosted runs the failure landed on a **different test every time** — whichever one was starting when the runner stalled — at 21s, 21s, 30s, then 61s as the bound went up.

A machine that needs over a minute to attach an embedded UI is not slow, it is wedged, and a stall that moves between tests is not a property of any of them. Raising the number again only moves the failure.

`startEmbeddedNeovim` now retries once, **only** on a startup timeout; every other error propagates untouched. A genuinely broken Neovim fails twice and the second error surfaces, so nothing is hidden — it costs one extra bound on a real hang.

The lane's `testTimeout` goes to 240_000 to clear two 60s bounds plus the test body. At 120_000 the retry could not finish and vitest would kill it with the opaque "Test timed out" message that the previous PR removed.

## Not fixed here, deliberately: `benchmark-baselines`

Its one failing assertion is `evidenceBindings[16].sha256` — the hash of `runtime/package.json`, which #1706 changed without refreshing the baseline.

I regenerated it to a scratch path to see what a refresh would cost. The answer is that this file records the machine it was measured on:

```
.environment.cpu.model         AMD Ryzen Threadripper PRO 9975WX 32-Cores
                            →  AMD Ryzen 9 9900X 12-Core Processor
.environment.cpu.logicalCount  64 → 24
```

141 fields differ, nearly all timings and memory. Committing a regeneration from a 24-thread machine would replace performance evidence measured on a 64-thread workstation. Updating only the binding hash would instead assert that the recorded measurement covered the new `package.json`, which is false.

This needs re-measuring on the reference hardware. It is the last remaining `default-suite` failure.