### PR TITLE
fix(recovery): stop re-rolling a byte-identical streaming fallback

### DIFF
--- a/runtime/src/phases/post-sample-recovery.ts
+++ b/runtime/src/phases/post-sample-recovery.ts
@@ -22,6 +22,8 @@
  * @module
  */
 
+import { createHash } from "node:crypto";
+
 import { emitError, emitWarning } from "../session/event-log.js";
 import type { LLMMessage } from "../llm/types.js";
 import {
@@ -400,6 +402,36 @@ export async function postSampleRecovery(
       async onStreamingFallback(c) {
         const executor = c.state
           .streamingToolExecutor as StreamingToolExecutor | null;
+        // A streaming fallback discards the partial answer and asks the model
+        // for it again. That only helps when the next attempt differs, and
+        // sampling is not guaranteed to make it differ: an observed grok-4.6
+        // turn degenerated into repeating one token until it hit the output
+        // cap, and attempts 3 and 4 came back byte-for-byte identical --
+        // 36,879 characters each. The ladder then burned its remaining
+        // re-entries reproducing the same failure, ~2M prompt tokens for no
+        // output at all.
+        //
+        // Identical partials mean regeneration is deterministic here, so the
+        // retries left cannot produce anything new. Surface the failure on the
+        // repeat instead of paying for it five times.
+        const digest = partialAnswerDigest(c.state);
+        const previous = lastDiscardedPartial.get(c.state);
+        lastDiscardedPartial.set(c.state, digest);
+        if (previous !== undefined && previous === digest) {
+          tombstoneOrphans(c.state, {
+            reason: "streaming_fallback",
+            executor,
+          });
+          const reason =
+            "streaming fallback regenerated a byte-identical partial answer; " +
+            "retrying cannot change a deterministic result";
+          emitError(c.session.eventLog, c.session.nextInternalSubId(), {
+            cause: "streaming_fallback_deterministic",
+            message: reason,
+          });
+          lastDiscardedPartial.delete(c.state);
+          return { kind: "surface", reason };
+        }
         tombstoneOrphans(c.state, {
           reason: "streaming_fallback",
           executor,
@@ -471,6 +503,20 @@ export async function postSampleRecovery(
 // which stops emitting `pendingBudgetDecision` once the target is met or
 // progress stalls; this counter is only a runaway backstop sized far
 // above any realistic continuation count for a single turn.
+/**
+ * Digest of the partial answer a streaming fallback is about to discard, kept
+ * per turn so the next fallback can tell "the model produced something new"
+ * from "the model produced exactly what it produced last time".
+ */
+const lastDiscardedPartial = new WeakMap<TurnState, string>();
+
+function partialAnswerDigest(state: TurnState): string {
+  const text = state.assistantMessages
+    .map((message) => message.text ?? "")
+    .join(" ");
+  return `${state.assistantMessages.length}:${text.length}:${createHash("sha256").update(text).digest("hex")}`;
+}
+
 const MAX_BUDGET_CONTINUATIONS = 10_000;
 const budgetContinuationCounts = new WeakMap<TurnState, number>();
 

--- a/runtime/tests/phases/post-sample-recovery.streaming-fallback-determinism.test.ts
+++ b/runtime/tests/phases/post-sample-recovery.streaming-fallback-determinism.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+
+import { buildInitialTurnState } from "../session/turn-state.js";
+import { postSampleRecovery } from "./post-sample-recovery.js";
+import { mkCtx, mkSession } from "../../tests/fixtures.js";
+import type { TurnState } from "../session/turn-state.js";
+
+/**
+ * Puts the turn in the state `isStreamingFallbackOccured` recognises: a
+ * partial assistant answer plus a recoverable stream error.
+ */
+function stageStreamingFallback(state: TurnState, text: string): void {
+  state.transition = undefined;
+  state.assistantMessages = [
+    {
+      uuid: `assistant-${state.assistantMessages.length}`,
+      text,
+      apiError: "provider_error",
+      toolCalls: [],
+    },
+  ] as unknown as TurnState["assistantMessages"];
+  (state as TurnState & { lastStreamError?: unknown }).lastStreamError =
+    new Error("stream closed before completion");
+}
+
+describe("streaming fallback determinism guard", () => {
+  test("retries once when the regenerated partial differs", async () => {
+    const ctx = mkCtx();
+    const { session } = mkSession();
+    const state = buildInitialTurnState(ctx, {
+      role: "user",
+      content: "write the inventory",
+    });
+
+    stageStreamingFallback(state, "first attempt, partial answer");
+    await postSampleRecovery(state, ctx, session);
+    expect(state.transition).toEqual({ reason: "streaming_fallback_retry" });
+
+    // A different partial means sampling is still moving; keep retrying.
+    stageStreamingFallback(state, "second attempt, a DIFFERENT partial");
+    await postSampleRecovery(state, ctx, session);
+    expect(state.transition).toEqual({ reason: "streaming_fallback_retry" });
+  });
+
+  test("stops instead of re-rolling a byte-identical partial", async () => {
+    const ctx = mkCtx();
+    const { session } = mkSession();
+    const state = buildInitialTurnState(ctx, {
+      role: "user",
+      content: "write the inventory",
+    });
+
+    // Observed on grok-4.6: the turn degenerated into repeating one token
+    // until it hit the output cap, and consecutive attempts came back
+    // byte-for-byte identical (36,879 characters each). Re-rolling that
+    // burned the remaining re-entries for no output at all.
+    const degenerate = ` leftover`.repeat(4_094);
+
+    stageStreamingFallback(state, degenerate);
+    await postSampleRecovery(state, ctx, session);
+    expect(state.transition).toEqual({ reason: "streaming_fallback_retry" });
+
+    stageStreamingFallback(state, degenerate);
+    await postSampleRecovery(state, ctx, session);
+
+    // No further retry: an identical partial proves regeneration is
+    // deterministic, so the remaining re-entries cannot produce anything new.
+    expect(state.transition).not.toEqual({
+      reason: "streaming_fallback_retry",
+    });
+  });
+});


### PR DESCRIPTION
## What happened

A streaming fallback discards the partial answer and asks the model for it again. That only helps if the next attempt differs, and sampling does not guarantee that it will.

Observed live on grok-4.6: a subagent turn degenerated into repeating a single token until it hit the 4k output cap — 33 characters of real content (`I'll inspect \`VerboseToolUse\` and `) followed by **4,094 repetitions of `" leftover"`**. The ladder discarded it and retried. Attempts 3 and 4 came back **byte-for-byte identical, 36,879 characters each**:

| attempt | streamed characters |
|---|---|
| 1 | 42,064 |
| 2 | 36,886 |
| 3 | **36,879** |
| 4 | **36,879** |

The turn then died on `MAX_RECOVERY_REENTRIES=5` having produced nothing, at a cost of roughly **2M prompt tokens**.

## The fix

The retry budget exists for transient stream drops. An identical partial is proof that this one is not transient — regeneration is deterministic, so the attempts left cannot produce anything new.

`onStreamingFallback` now digests the partial answer before discarding it and compares against the previous discard for that turn. On a repeat it surfaces with a `streaming_fallback_deterministic` error instead of paying four more times.

Only **consecutive** identical partials trip it, so a genuinely flapping stream still gets the full ladder.

## Tests

New `post-sample-recovery.streaming-fallback-determinism.test.ts` pins both directions:

- a differing partial still transitions to `streaming_fallback_retry`
- a byte-identical partial (the real 4,094-repetition payload) stops instead

`tsc --noEmit` clean; 244 tests pass across `tests/phases` and `tests/recovery`, 1,341 across `phases`/`recovery`/`session`.

## Not addressed here

The model-side degeneration itself. This change stops the runtime paying for it five times; it does not stop grok-4.6 falling into the loop. A separate guard — aborting a stream that repeats one token past some threshold — would cut the first 37k too.