### PR TITLE
fix(process): let a closing tree settle before calling it residual

### DIFF
--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -1584,8 +1584,13 @@ export function runSupervisedProcess(
         });
     };
 
+    let residualVerdictPending = false;
     const maybeFinish = (): void => {
       if (!closed) return;
+      // The residual verdict is decided asynchronously after close. Finishing
+      // while it is in flight would resolve the run with no stop reason at
+      // all, turning a real leak into a clean exit.
+      if (residualVerdictPending) return;
       if (stopReason !== undefined && isProcessTreeAlive(child)) return;
       finish(false);
     };
@@ -1685,7 +1690,9 @@ export function runSupervisedProcess(
       // Give the tree the same bounded settle window the kill paths already
       // use. A genuinely leaked process outlives it and is still reported, so
       // the containment guarantee is unchanged; only the race is removed.
+      residualVerdictPending = true;
       void waitForProcessTreeExit(child, RESIDUAL_SETTLE_MS).then((exited) => {
+        residualVerdictPending = false;
         if (!exited && stopReason === undefined) {
           requestStop("residual_process");
         }

--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -86,6 +86,12 @@ export interface SupervisedProcessResult {
 const DEFAULT_TERMINATE_GRACE_MS = 500;
 const DEFAULT_SETTLE_BACKSTOP_MS = 1_000;
 const PROCESS_TREE_POLL_INTERVAL_MS = 20;
+/**
+ * How long a descendant may still be exiting when the target closes before the
+ * run is called residual. Short enough that a real leak is still reported
+ * promptly, long enough to cover the reap window on a loaded runner.
+ */
+const RESIDUAL_SETTLE_MS = 250;
 const PROCESS_TABLE_TIMEOUT_MS = 2_000;
 const MAX_PROCESS_TABLE_BYTES = 4 * 1024 * 1024;
 const MAX_PROCESS_TABLE_RECORDS = 32_768;
@@ -1655,14 +1661,36 @@ export function runSupervisedProcess(
       exitCode = code;
       exitSignal = signal;
       closed = true;
-      if (stopReason === undefined) {
-        if (linuxSubreaperBoundaries.get(child)?.residual === true) {
-          stopReason = "residual_process";
-        } else if (isProcessTreeAlive(child)) {
+      if (stopReason !== undefined) {
+        maybeFinish();
+        return;
+      }
+      if (linuxSubreaperBoundaries.get(child)?.residual === true) {
+        stopReason = "residual_process";
+        maybeFinish();
+        return;
+      }
+      if (!isProcessTreeAlive(child)) {
+        maybeFinish();
+        return;
+      }
+      // A descendant that is still winding down at the exact instant the
+      // target closes is not a containment failure. `close` can fire while a
+      // short-lived helper is between _exit and reap, and on a slow runner the
+      // cgroup stays populated for a few more milliseconds — long enough for
+      // an instantaneous check to call a clean run residual. Observed in CI as
+      // `exit=0, signal=null, stop=residual_process` on ordinary `git commit`
+      // calls, which then surfaced as WorkflowGitError with empty stderr.
+      //
+      // Give the tree the same bounded settle window the kill paths already
+      // use. A genuinely leaked process outlives it and is still reported, so
+      // the containment guarantee is unchanged; only the race is removed.
+      void waitForProcessTreeExit(child, RESIDUAL_SETTLE_MS).then((exited) => {
+        if (!exited && stopReason === undefined) {
           requestStop("residual_process");
         }
-      }
-      maybeFinish();
+        maybeFinish();
+      });
     });
   });
 }


### PR DESCRIPTION
## The race

The supervised-process `close` handler asked `isProcessTreeAlive` at the exact instant the target exited, and called any survivor a containment failure:

```js
} else if (isProcessTreeAlive(child)) {
  requestStop("residual_process");
}
```

`close` can fire while a short-lived helper sits between `_exit` and reap, and on a loaded runner the cgroup stays populated a few milliseconds past that. An instantaneous check calls a clean run leaked.

## How it showed up

CI reported it as:

```
BoundedRepositoryGitError: failed to commit repository files
  (exit=0, signal=null, stop=residual_process)
```

**`exit=0`** — the `git commit` succeeded. Only the cleanup assertion failed.

Downstream the same root cause surfaced as `WorkflowGitError: workflow git commit failed:` with an **empty** stderr, which is what you get when the harness stopped the process rather than git having anything to report. That empty message is the tell: it sent me looking for a git identity problem first, and the git invocations already pass `-c user.name` / `-c user.email` inline, so it was never that.

Four of the churning `default-suite` failures share this root: `worktree-lifecycle`, `bounded-temp-repository`, and the m5 workflow suites.

## The fix

Give the tree the same bounded settle the kill paths already use, through the existing `waitForProcessTreeExit` helper, capped at 250ms.

A genuinely leaked process outlives that window and is still reported — **the containment guarantee is unchanged, only the race is removed**. The test that proves it, `contains an ignored-stdio descendant after normal target exit`, still passes; it is precisely the case that must keep failing the run.

## Verification

`tsc --noEmit` clean. 1,256 tests pass across `tests/fnd`, `tests/utils` and `tests/workflow` (151 files); the only failure in that sweep is the known `benchmark-baselines` release-evidence staleness, unrelated to this change.

## Scope

This addresses the git/containment cluster. The rest of the churning set — timeouts at 20s/30s on a slower runner, and ENOENT on temp files written by child processes — is the same "CI is slower than the assumption" family but needs its own measurements, and the 13 deterministic AgentTool failures are a separate, still-undiagnosed class.