### PR TITLE
diag: dump loader state when the symlink dedupe test finds no agent

### DIFF
--- a/runtime/tests/tools/AgentTool/loadAgentsDir.test.ts
+++ b/runtime/tests/tools/AgentTool/loadAgentsDir.test.ts
@@ -497,6 +497,42 @@ Only load once.
       const deduped = definitions.allAgents.filter(
         agent => agent.agentType === 'deduped-agent',
       )
+      // TEMPORARY CI INSTRUMENTATION — remove once the failure is understood.
+      if (deduped.length !== 1) {
+        const { existsSync, lstatSync, readdirSync } = await import('node:fs')
+        const safe = (fn: () => unknown): unknown => {
+          try {
+            return fn()
+          } catch (error) {
+            return `ERR:${(error as Error).message}`
+          }
+        }
+        console.error(
+          'AGENTTOOL_DIAG ' +
+            JSON.stringify({
+              platform: process.platform,
+              cwd: process.cwd(),
+              tmpdir: tmpdir(),
+              home: process.env.HOME,
+              configDir: process.env.AGENC_CONFIG_DIR,
+              root,
+              allowedSources: await getAllowedSettingSourcesForTesting(),
+              allAgents: definitions.allAgents.map(a => ({
+                type: a.agentType,
+                source: a.source,
+              })),
+              projectFileExists: safe(() => existsSync(projectFile)),
+              projectDirEntries: safe(() => readdirSync(projectDir)),
+              userDirEntries: safe(() => readdirSync(userDir)),
+              linkIsSymlink: safe(() =>
+                lstatSync(join(userDir, 'dupe.md')).isSymbolicLink(),
+              ),
+              linkTargetReadable: safe(() =>
+                existsSync(join(userDir, 'dupe.md')),
+              ),
+            }),
+        )
+      }
       expect(deduped).toHaveLength(1)
       expect(deduped[0]?.source).toBe('projectSettings')
     } finally {


### PR DESCRIPTION
**Temporary instrumentation. Not for merge** — this exists to get one CI run's worth of facts, then it comes out.

## Why

Thirteen `AgentTool` tests fail **deterministically** on the ubuntu `default-suite` runner and cannot be reproduced locally at any parallelism. Everything passes here: `--maxWorkers=1`, `--maxWorkers=4`, with and without the `runtime/plugins` build artifact.

Three hypotheses tested and **refuted**, each by experiment rather than reading:

| Hypothesis | How it died |
|---|---|
| The `runtime/plugins` build artifact is present locally, absent on CI | Moved it away; 84/84 still pass |
| A test leaks `projectSettings` out of the allowed setting sources | The file has an `afterEach` that restores them |
| Files share a worker process on a 4-vCPU runner | `--maxWorkers=1` forces exactly that; still passes |

The symptom is always the same shape — an empty definition list where one entry is expected:

```
AssertionError: expected [] to have a length of 1 but got +0
  loadAgentsDir.test.ts:500  expect(deduped).toHaveLength(1)
```

## What this dumps

At the moment the assertion would fail, in `skips symlinked markdown agents instead of granting link-tier authority`:

- the allowed setting sources as the loader saw them
- **every** agent it did find, with its `source` — so "found nothing" and "found it under the wrong source" are distinguishable
- `AGENC_CONFIG_DIR`, the resolved temp root, `HOME`, `cwd`, `platform`
- whether the fixture files are on disk, and whether the symlink is still a symlink and resolvable

That last group matters because the fixture builds a symlink across two directories, and the harness redirects `TMPDIR` — a runner whose temp layout differs could change what the loader is allowed to traverse.

## Verification

Forced the branch locally to confirm it prints and does not throw (it uses the already-imported `tmpdir`, not `require`, which would fail in this ESM file). On a passing run it stays silent.

## Next

Read the dump from the `default-suite` job, diagnose, then a real fix in its own PR and this branch is deleted.