### PR TITLE
ci: give the default suite the ripgrep it silently needed

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -100,6 +100,27 @@ jobs:
           test "$(node --version)" = "v${NODE_VERSION}"
           test "$(npm --version)" = "$NPM_VERSION"
 
+      - name: Put the pinned ripgrep on PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The agent/markdown config loader shells out to ripgrep, resolving a
+          # vendored copy under dist/ first and falling back to `rg` on PATH.
+          # A source-tree test run has no vendored copy, and this runner has no
+          # system rg, so every markdown scan silently returned nothing and 13
+          # AgentTool tests failed with empty definition lists while the files
+          # sat on disk. `npm ci --ignore-scripts` does install the pinned
+          # platform package -- the binary ships inside it -- so the only thing
+          # missing was making it findable.
+          #
+          # Digest is the one runtime/scripts/run-hermetic-test-boundary.mjs
+          # pins for this architecture; a mismatch must fail the job, not warn.
+          rg_dir="$PWD/node_modules/@vscode/ripgrep-linux-x64/bin"
+          test -x "$rg_dir/rg"
+          expected="193906679498de4d939345b937fa24e0e69a03c244bd70c859f5e41232713f21"
+          test "$(sha256sum "$rg_dir/rg" | awk '{print $1}')" = "$expected"
+          echo "$rg_dir" >> "$GITHUB_PATH"
+
       - name: Typecheck the runtime and its type-checked tests
         shell: bash
         working-directory: runtime


### PR DESCRIPTION
## The cause

The agent/markdown config loader shells out to ripgrep:

```js
files = useNative
  ? await findMarkdownFilesNative(dir, signal)
  : await ripGrep(['--files', '--hidden', '--no-ignore', '--glob', '*.md'], dir, signal)
```

`ripgrepCommand()` resolves a vendored copy under `dist/vendor/ripgrep/<arch>-<platform>/rg` first, then falls back to `rg` on PATH. A source-tree test run has no vendored copy, and a hosted ubuntu runner has no system `rg`, so **every markdown scan returned nothing**.

That is exactly what the failures said. The instrumentation run ([#1717](https://github.com/tetsuo-ai/agenc-core/pull/1717)) dumped what the loader actually saw:

```json
"allowedSources": ["userSettings","projectSettings","localSettings","flagSettings","policySettings"],
"allAgents": [ 5 entries, every one "source":"built-in" ],
"projectFileExists": true,
"projectDirEntries": ["dupe.md"],
"linkIsSymlink": true
```

Sources allowed, fixture files on disk, symlink intact — and zero markdown agents found. Finding nothing while the files are present leaves one explanation.

## Why it never reproduced locally

This machine happens to have `rg` installed. **Removing it from PATH reproduces the CI failure byte for byte** — the same five built-in agents, the same files-present diagnostic, the same tests red.

That also buries three hypotheses I had tested and refuted the slow way: the `runtime/plugins` build artifact, setting-source pollution, and files sharing a worker process. None of them were ever the variable.

## The fix

`npm ci --ignore-scripts` already installs `@vscode/ripgrep-linux-x64` and the binary **ships inside the package**, so nothing needed downloading — the only missing piece was making it findable. One step puts it on PATH after checking its SHA-256 against the digest `runtime/scripts/run-hermetic-test-boundary.mjs` already pins for this architecture, failing the job on a mismatch rather than warning.

The boundary script provisions ripgrep this way for `npm test`; this job calls the inner `run-hermetic-vitest.mjs` directly and skipped that provisioning.

## Verification

With the pinned `rg` on PATH and **no system rg**, all 12 AgentTool files pass — 84 tests.

Simulating the job's environment for the whole suite (`--maxWorkers=4`, only the pinned rg): **1 failure out of 18,756**, and it is the known `benchmark-baselines` release-evidence staleness.

That number will not transfer directly. This machine has 24 threads against the runner's 4, so the contention-sensitive suites cannot fail here the way they do there. What CI measures is the real answer; the claim this PR makes is narrower: the AgentTool cluster was ripgrep, and it is fixed.