### PR TITLE
test: stop three deadlines from asserting how fast the runner is

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -33,6 +33,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # The FND benchmark provenance resolves the revision its baseline was
+          # measured at with `git cat-file -e <rev>^{commit}`, which needs that
+          # commit present. A depth-1 clone has only the tip, so the check threw
+          # "benchmark source revision is not a local Git commit" the moment the
+          # earlier binding assertion stopped failing first and let it run.
+          fetch-depth: 0
 
       - name: Bind the checkout
         shell: bash

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -1421,7 +1421,10 @@ token_cap = 123
       await rm(agencHome, { recursive: true, force: true });
       updateRuntimeConfig.mockRestore();
     }
-  });
+    // Starts a real daemon and reloads its config; on a loaded runner that
+    // does not fit in the shared 30s default. DEFAULT_DAEMON_READY_TIMEOUT_MS
+    // is already >= 30s on its own, so the test bound has to clear it.
+  }, 90_000);
 
   it("reload reuses a fixed MCP listener, revokes old sessions, and keeps direct tools fail-closed", async () => {
     const agencHome = await tempAgencHome();

--- a/runtime/tests/eval/evaluation-power-analysis.test.ts
+++ b/runtime/tests/eval/evaluation-power-analysis.test.ts
@@ -191,7 +191,7 @@ describe("evaluation pilot power analysis", () => {
     } else {
       expect(document.decision.status).toBe("no_candidate_meets_target");
     }
-  }, 20_000);
+  }, 60_000);
 
   test("aggregates unequal repetitions within task before equal task weighting", () => {
     const input = makeInput();
@@ -271,7 +271,7 @@ describe("evaluation pilot power analysis", () => {
       }
     }
     expect(strictRepeatPowerImprovements).toBeGreaterThan(0);
-  }, 20_000);
+  }, 60_000);
 
   test("matches the intercept-only CR2 and Satterthwaite closed forms", () => {
     const clusters = Array.from({ length: 20 }, (_, repositoryIndex) =>
@@ -364,7 +364,7 @@ describe("evaluation pilot power analysis", () => {
     expect(document.documentDigest).toBe(
       "sha256:bab8a86951a46543d17c675d38db198347ca7982f9adc77c393d4c5f8d3f66c2",
     );
-  }, 20_000);
+  }, 60_000);
 
   test("requires exact planning-effect membership before simulation", () => {
     const startedAt = performance.now();
@@ -389,7 +389,7 @@ describe("evaluation pilot power analysis", () => {
       cell.assumedPairedDifference === planningEffect
       && cell.heterogeneityMultiplier === heterogeneity)).toHaveLength(2);
     expect(validatePowerAnalysisDocument(document)).toEqual(document);
-  }, 20_000);
+  }, 60_000);
 
   test("fails closed on incomplete pairing, duplicate trials, and insufficient pilot coverage", () => {
     const outcomes = makePilotOutcomes();
@@ -544,7 +544,7 @@ describe("evaluation pilot power analysis", () => {
     }
     expect(error).toBeInstanceOf(PowerAnalysisDocumentValidationError);
     expect((error as PowerAnalysisDocumentValidationError).issues.length).toBeLessThanOrEqual(100);
-  }, 20_000);
+  }, 60_000);
 
   test("rejects accessors without invoking them during fail-fast preflight", () => {
     let getterCalls = 0;
@@ -572,7 +572,7 @@ describe("evaluation pilot power analysis", () => {
       /document\.sensitivityGrid must be an own enumerable data property/u,
     );
     expect(getterCalls).toBe(0);
-  }, 20_000);
+  }, 60_000);
 
   test("bounds nested unknown I-JSON before canonicalization without invoking accessors", () => {
     const outcomes = makePilotOutcomes();
@@ -626,5 +626,5 @@ describe("evaluation pilot power analysis", () => {
       pilot: { ...document.pilot, comparisons: accessorComparisons },
     })).toThrow(/must be an own enumerable data property/u);
     expect(getterCalls).toBe(0);
-  }, 20_000);
+  }, 60_000);
 });

--- a/runtime/tests/memory/full-corpus-index.test.ts
+++ b/runtime/tests/memory/full-corpus-index.test.ts
@@ -902,7 +902,11 @@ function readCurrentGenerationProgress(databasePath: string): {
 }
 
 async function expectEventually(check: () => Promise<boolean>): Promise<void> {
-  const deadline = Date.now() + 5_000;
+  // A filesystem watcher converging is not a fast operation on a loaded
+  // runner, and 5s was tight enough that CI reported "did not converge" on a
+  // healthy index. The bound still exists to catch a watcher that never fires;
+  // it is not a performance assertion.
+  const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     if (await check()) return;
     await new Promise((resolve) => setTimeout(resolve, 25));

--- a/runtime/tests/memory/full-corpus-index.test.ts
+++ b/runtime/tests/memory/full-corpus-index.test.ts
@@ -198,7 +198,7 @@ describe("C3b persistent full-corpus index", () => {
     );
     expect(stale.candidates).toHaveLength(0);
     expect(replacement.candidates).toHaveLength(1);
-  }, 30_000);
+  }, 120_000);
 
   it("keeps generation counts and the commutative digest exact across incremental replacement", async () => {
     const fixture = await createFixture();
@@ -236,7 +236,7 @@ describe("C3b persistent full-corpus index", () => {
     const restored = readCurrentGenerationProgress(index!.databasePath);
     expect(restored.digest).toBe(initial.digest);
     expect(restored.discoveryOperations).toBeGreaterThan(0);
-  }, 120_000);
+  });
 
   it("repairs a missed equal-size/equal-mtime external change through the bounded audit", async () => {
     const fixture = await createFixture();
@@ -846,7 +846,7 @@ async function createFixture(): Promise<{
   index = new PersistentMemoryIndex({
     databasePath: join(stateRoot, "memory.sqlite"),
     queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
-  }, 120_000);
+  });
   return {
     globalRoot,
     projectRoot,
@@ -878,7 +878,7 @@ function readCurrentGenerationProgress(databasePath: string): {
   const database = new Database(databasePath, {
     readonly: true,
     fileMustExist: true,
-  });
+  }, 120_000);
   try {
     return database
       .prepare(

--- a/runtime/tests/memory/full-corpus-index.test.ts
+++ b/runtime/tests/memory/full-corpus-index.test.ts
@@ -236,7 +236,7 @@ describe("C3b persistent full-corpus index", () => {
     const restored = readCurrentGenerationProgress(index!.databasePath);
     expect(restored.digest).toBe(initial.digest);
     expect(restored.discoveryOperations).toBeGreaterThan(0);
-  });
+  }, 120_000);
 
   it("repairs a missed equal-size/equal-mtime external change through the bounded audit", async () => {
     const fixture = await createFixture();
@@ -846,7 +846,7 @@ async function createFixture(): Promise<{
   index = new PersistentMemoryIndex({
     databasePath: join(stateRoot, "memory.sqlite"),
     queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
-  });
+  }, 120_000);
   return {
     globalRoot,
     projectRoot,


### PR DESCRIPTION
Sharding took the gate from 28 failures to 9 and, more usefully, left a population small enough to read one by one. Classified by error rather than by file, four of them are deadlines:

| error | count |
|---|---|
| `Test timed out in 20000ms` | 2 |
| `memory watcher did not converge before the test deadline` | 1 |
| `Test timed out in 30000ms` | 1 |

Each bound was sized on a developer machine and is tight enough that a loaded 4-vCPU runner misses it while the code under test is fine.

## The three

**`full-corpus-index`** polls a filesystem watcher for 5s before declaring it never converged:

```js
const deadline = Date.now() + 5_000;
```

Watchers are not fast under load. The bound exists to catch one that never fires, so 30s keeps that meaning without asserting throughput.

**`evaluation-power-analysis`** gives its statistical passes 20s each. They are CPU-bound and were the first thing to lose when the box was saturated — 60s.

**`daemon-cli`**'s reload case starts a real daemon and reloads its config with no bound of its own, so it inherited the shared 30s default. That file already asserts `DEFAULT_DAEMON_READY_TIMEOUT_MS >= 30_000` — with a comment saying the old value "produced false 'did not become ready before timeout' failures on healthy" runs. So the test bound has to *clear* the readiness bound rather than race it: 90s.

## What this does not change

None of these changes what a test proves. A hung watcher, a wedged daemon or a runaway computation still fails — just not on a healthy run that was merely slow.

This is the same disease already fixed twice in this repo: the Neovim startup bound and the PowerShell lane were both timing the runner instead of the thing under test.

## What is left after this

Of the nine, four are these. The rest are one `residual_process` — diagnosed in [#1715](https://github.com/tetsuo-ai/agenc-core/pull/1715), where the fix was withdrawn for breaking macOS — and a handful of assertions that look load-ordering dependent (`{recovered: 1, deferred: 0}` where `{recovered: 0, deferred: 1}` was expected). Those need their own reading; they are not deadlines and are not touched here.

## Verification

`full-corpus-index` + `evaluation-power-analysis`: 35 tests pass. `daemon-cli.contract`: 62 tests pass.