### PR TITLE
diag: read the observed Windows toolchain off the runner

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -20,6 +20,40 @@ jobs:
   # other lane here runs a hosted capability slice (kernel sandbox, native,
   # Neovim, PowerShell), so a change could break the unit suite outright and
   # still show nine green checks. Four merged PRs did exactly that.
+  # TEMPORARY. Not for merge: emits the observed Windows toolchain so the new
+  # official image can be pinned in release-toolchain.json. The release lane
+  # refuses to run while an active image is unpinned, and the MSVC compiler and
+  # linker digests it needs can only be read on the runner itself.
+  windows-image-probe:
+    name: windows-image-probe
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 10
+    env:
+      AGENC_RELEASE_SLUG: win-x64
+      AGENC_RUNNER_LABEL: windows-2025-vs2026
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Validate the reviewed Windows image and native toolchain
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          scripts/validate-hosted-windows-runner.ps1 `
+            -ReportPath "$env:RUNNER_TEMP/agenc-hosted-toolchain-$env:AGENC_RELEASE_SLUG.json"
+      - name: Print the observed Windows toolchain report
+        if: always()
+        shell: pwsh
+        run: |
+          $report = "$env:RUNNER_TEMP/agenc-hosted-toolchain-$env:AGENC_RELEASE_SLUG.json"
+          if (Test-Path -LiteralPath $report -PathType Leaf) {
+            Write-Host "AGENC_WINDOWS_IMAGE_REPORT_BEGIN"
+            Get-Content -LiteralPath $report -Raw
+            Write-Host "AGENC_WINDOWS_IMAGE_REPORT_END"
+          } else {
+            Write-Host "validator produced no report at $report"
+          }
+
   default-suite:
     name: default-suite ${{ matrix.shard }}/4
     runs-on: ubuntu-24.04


### PR DESCRIPTION
**Temporary. Not for merge** — this exists to read one runner's toolchain, then it comes out.

## Why

The release lane refuses to start while an active official runner image is unpinned:

```
hosted runner contract: win-x64 is missing active official runner image
20260810.198.1 (win25-vs2026/20260810.198)
```

GitHub activated that image on 10 August. `release-toolchain.json` pins three `win-x64` profiles and none of them is it, so `release-state.mjs verify --lane full` stops before anything is built. 0.16.0 cannot be cut until the pin catches up.

## Why it cannot be written by hand

A profile is not just a version string. It carries `visualStudioVersion`, `msvcToolsVersion`, `msvcCompilerVersion`, `windowsSdkVersion`, the inventory URL with its sha256 and byte count, and the **SHA-256 of the MSVC compiler and linker binaries**.

Those digests are precisely what the contract exists to verify. Deriving them from anywhere other than a runner carrying the image would hollow out the guarantee — the check would then be confirming a number I made up.

## What this does

Runs the same validator the release preflight runs (`scripts/validate-hosted-windows-runner.ps1`) with the same `-ReportPath`, and prints the observed report between markers.

The validator throws on drift by design, so the step is `continue-on-error` and the print step is `if: always()`. The drift is the expected outcome here; the report is what we came for.

## Next

Read the report, add the profile to `release-toolchain.json` in its own PR, delete this branch, and resume the release at `verify`.