### PR TITLE
fix(release): accept a respun runner image revision

### DIFF
--- a/release-toolchain.json
+++ b/release-toolchain.json
@@ -259,17 +259,23 @@
         {
           "archive": "debian",
           "suite": "bookworm",
-          "components": ["main"]
+          "components": [
+            "main"
+          ]
         },
         {
           "archive": "debian",
           "suite": "bookworm-updates",
-          "components": ["main"]
+          "components": [
+            "main"
+          ]
         },
         {
           "archive": "debian-security",
           "suite": "bookworm-security",
-          "components": ["main"]
+          "components": [
+            "main"
+          ]
         }
       ]
     },
@@ -297,7 +303,9 @@
     "rpmContentInventory": {
       "schemaVersion": 1,
       "format": "name|epoch|version|release|arch|sha256header|payloaddigest|payloaddigestalgo|rsaheader-pgpsig",
-      "signatureKeyIds": ["15af5dac6d745a60"],
+      "signatureKeyIds": [
+        "15af5dac6d745a60"
+      ],
       "sha256": {
         "x64": "20da0fd525fe8dbe596068bb896b949fe84c5ede3c2829e9481f6c2c97de0a5e",
         "arm64": "98d1259fca66152fb91e739a15a4fa7f76b0a222369cb34ba853d7d72f02239f"
@@ -373,6 +381,19 @@
       "imageOS": "win25-vs2026",
       "runnerArch": "X64",
       "imageProfiles": [
+        {
+          "imageVersion": "20260810.198.2",
+          "inventoryUrl": "https://raw.githubusercontent.com/actions/runner-images/9669462631cac120f4f558e7dadd31a14d1f1a41/images/windows/Windows2025-VS2026-Readme.md",
+          "inventorySha256": "066f1b0e3f63605a3425bf65a3b9cc9f92d580661d420df81dba69daccf7b01f",
+          "inventoryBytes": 33783,
+          "visualStudioVersion": "18.8.12023.21",
+          "visualStudioInstallPath": "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise",
+          "msvcToolsVersion": "14.51.36231",
+          "msvcCompilerVersion": "19.51.36252",
+          "msvcCompilerSha256": "c94cdac6a780142920110e5cb8b7339817029eead696e0e97700b45e03216a00",
+          "msvcLinkerSha256": "f233b8e337cec96a69868a8cde676808bfa81152493968d0b27b7cd0daac15be",
+          "windowsSdkVersion": "10.0.26100.0"
+        },
         {
           "imageVersion": "20260803.193.1",
           "inventoryUrl": "https://raw.githubusercontent.com/actions/runner-images/e9ca9012a4fd7387f3fea134a2e8f5056da94827/images/windows/Windows2025-VS2026-Readme.md",

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -1012,6 +1012,17 @@ describe("reproducible install and release contract", () => {
         runnerArch: "X64",
         imageProfiles: [
           {
+            imageVersion: "20260810.198.2",
+            visualStudioVersion: "18.8.12023.21",
+            msvcToolsVersion: "14.51.36231",
+            msvcCompilerVersion: "19.51.36252",
+            msvcCompilerSha256:
+              "c94cdac6a780142920110e5cb8b7339817029eead696e0e97700b45e03216a00",
+            msvcLinkerSha256:
+              "f233b8e337cec96a69868a8cde676808bfa81152493968d0b27b7cd0daac15be",
+            windowsSdkVersion: "10.0.26100.0",
+          },
+          {
             imageVersion: "20260803.193.1",
             visualStudioVersion: "18.8.12023.21",
             msvcToolsVersion: "14.51.36231",

--- a/scripts/check-hosted-runner-contract.mjs
+++ b/scripts/check-hosted-runner-contract.mjs
@@ -14,7 +14,10 @@ const RELEASE_INDEX_URL =
   "https://api.github.com/repos/actions/runner-images/releases?per_page=100&page=1";
 const HASH_RE = /^[0-9a-f]{64}$/u;
 const COMMIT_RE = /^[0-9a-f]{40}$/u;
-const IMAGE_VERSION_RE = /^\d{8}\.\d{3,4}\.1$/u;
+// The trailing component is GitHub's image revision, not always 1: a respin
+// of win25-vs2026/20260810.198 ships as 20260810.198.2 and its own inventory
+// readme records that. Accept any revision and keep pinning the exact one.
+const IMAGE_VERSION_RE = /^\d{8}\.\d{3,4}\.\d+$/u;
 
 const TARGET_CONTRACTS = Object.freeze({
   "darwin-arm64": Object.freeze({
@@ -199,7 +202,12 @@ function runnerReleaseVersion(tag, prefix) {
   const match = /^(\d{8})\.(\d{3,4})$/u.exec(suffix);
   if (!match) fail(`official runner release tag is invalid: ${tag}`);
   return {
-    imageVersion: `${suffix}.1`,
+    // GitHub respins an image without cutting a new release, so the deployed
+    // revision is not always `.1`: win25-vs2026/20260810.198 ships
+    // 20260810.198.2. The release tag identifies the build; the trailing
+    // revision is GitHub's, not ours, so match on the build and let the
+    // pinned profile carry whichever revision the fleet actually serves.
+    imageVersionPrefix: `${suffix}.`,
     date: Number(match[1]),
     build: Number(match[2]),
   };
@@ -271,17 +279,17 @@ export function requiredHostedRunnerReleases(contracts, releases) {
       ),
     ].sort(compareReleaseVersion);
     for (const release of active) {
-      const profile = contracts[target].imageProfiles.find(
-        ({ imageVersion }) => imageVersion === release.imageVersion,
+      const profile = contracts[target].imageProfiles.find(({ imageVersion }) =>
+        imageVersion.startsWith(release.imageVersionPrefix),
       );
       if (!profile) {
         fail(
-          `${target} is missing active official runner image ${release.imageVersion} (${release.tag})`,
+          `${target} is missing active official runner image ${release.imageVersionPrefix}* (${release.tag})`,
         );
       }
       if (inventoryCommit(profile, target) !== release.commit) {
         fail(
-          `${target} ${release.imageVersion} inventory commit does not match the official release`,
+          `${target} ${profile.imageVersion} inventory commit does not match the official release`,
         );
       }
     }

--- a/scripts/check-hosted-runner-contract.test.mjs
+++ b/scripts/check-hosted-runner-contract.test.mjs
@@ -225,6 +225,6 @@ test("rejects a newer official rollout image missing from reviewed profiles", as
       toolchain,
       fetchImpl: fixtureFetch(toolchain, releases),
     }),
-    /darwin-x64 is missing active official runner image 20260803\.0400\.1/u,
+    /darwin-x64 is missing active official runner image 20260803\.0400\.\*/u,
   );
 });


### PR DESCRIPTION
The release lane cannot start:

```
hosted runner contract: win-x64 is missing active official runner image
20260810.198.1 (win25-vs2026/20260810.198)
```

## The assumption that broke

The contract synthesised the expected image version from the release tag:

```js
imageVersion: `${suffix}.1`,
```

and enforced that shape in the schema:

```js
const IMAGE_VERSION_RE = /^\d{8}\.\d{3,4}\.1$/u;
```

GitHub does not work that way. `win25-vs2026/20260810.198` is served to the fleet as **20260810.198.2**, and that release's own inventory readme records `Image Version: 20260810.198.2`.

So the contract was demanding an image that has never existed while refusing the one actually running. The pin was not stale — the assumption was.

## Evidence

A probe job ([#1723](https://github.com/tetsuo-ai/agenc-core/pull/1723)) ran the same validator the release preflight runs, on `windows-2025-vs2026`:

```json
"imageVersion": "20260810.198.2",
"visualStudioVersion": "18.8.12023.21",
"msvcToolsVersion": "14.51.36231",
"msvcCompilerSha256": "c94cdac6a780142920110e5cb8b7339817029eead696e0e97700b45e03216a00",
"msvcLinkerSha256": "f233b8e337cec96a69868a8cde676808bfa81152493968d0b27b7cd0daac15be",
"validationError": "ImageVersion drift: '20260810.198.2' not in '20260803.193.1', ..."
```

## The change

Match the release by **build** and let the pinned profile carry whichever revision is deployed. What the contract guarantees is unchanged:

- a profile must still exist for every active official release
- its inventory commit must still equal the release commit
- every digest is still pinned exactly, and drift still fails

Adds the `20260810.198.2` profile with values **read off the runner**, not derived. The compiler and linker digests are byte-identical to the `20260803.193.1` and `20260728.188.1` profiles — the toolchain did not change, only the image tag, which is why this is a labelling fix rather than a toolchain review.

The failing test's expectation moved with the message it asserts.

## Verification

`check-hosted-runner-contract` passes against the live release index and 8 immutable inventories. Its own suite passes 6/6.