### PR TITLE
fix(release): identify the built image under either Docker image store

### DIFF
--- a/scripts/check-clean-build.mjs
+++ b/scripts/check-clean-build.mjs
@@ -1002,13 +1002,20 @@ async function dockerSmoke({ sources, metadata, work, buildkitHostNetwork }) {
     const inspect = JSON.parse(
       run("docker", ["image", "inspect", tag], { capture: true, env: dockerEnv }),
     )[0];
+    // The reported image id depends on the daemon's image store: the classic
+    // graphdriver store returns the config digest, the containerd store returns
+    // the image manifest digest. Both name the build validated above, and the
+    // manifest digest commits to the config digest, so either one pins it.
+    const acceptedIds = [firstOci.configDigest, firstOci.imageManifestDigest];
     if (
-      inspect?.Id !== firstOci.configDigest ||
+      !acceptedIds.includes(inspect?.Id) ||
       inspect?.Config?.User !== "10001:10001" ||
       inspect?.Architecture !== architecture
     ) {
       throw new Error(
-        `Docker image identity mismatch: user=${inspect?.Config?.User}, architecture=${inspect?.Architecture}`,
+        `Docker image identity mismatch: id=${inspect?.Id} is neither the config digest ` +
+          `${firstOci.configDigest} nor the manifest digest ${firstOci.imageManifestDigest}; ` +
+          `user=${inspect?.Config?.User}, architecture=${inspect?.Architecture}`,
       );
     }
     for (const [name, expected] of Object.entries(expectedLabels)) {


### PR DESCRIPTION
## Problem

The `clean-build` release gate compares `docker image inspect .Id` against the OCI **config** digest. That equality holds only on the classic graphdriver image store. On a daemon using the **containerd image store**, the reported id is the image **manifest** digest, so the gate rejects a build that is bit-identical and fully reproducible.

Observed while running `release-state.mjs verify --lane full` for 0.16.0. All three builds in the gate exported the same digests:

```
#15 exporting manifest sha256:17200cfeb6391432fd74a8286916a6a7a610dd3d14a4c54b22861a839bd5984f
#15 exporting config   sha256:b79ada2e658e3ab75918fa6cddf18c20590f6f7b67ee4434c48b5f0f88087a00
```

The reproducibility comparison passed; only the post-import identity check failed, because `inspect.Id` was the manifest digest.

Reduced to a two-line Dockerfile, same build exported both ways:

| | digest |
|---|---|
| OCI config | `sha256:8cbd1e4b…` |
| `docker image inspect .Id` | `sha256:27146d1a…` (= the manifest digest) |

## Fix

Accept either digest. The manifest digest commits to the config digest, and both name the layout validated immediately above, so this does not loosen what the gate proves — it just stops assuming one of the two image stores.

The error message now prints the observed id next to both accepted digests. It previously reported only `user=` and `architecture=`, which were **correct** in the failing case, pointing the reader away from the one field that actually differed.

## Verification

`npm run check:clean-build -- --buildkit-network=host` on a containerd-image-store daemon (`driver-type: io.containerd.snapshotter.v1`), which failed before this change.