### PR TITLE
fix(installer): accept hardlinked system tools so macOS installs can verify

### DIFF
--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -1133,6 +1133,51 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
     };
   }
 
+  test("resolve_system_tool accepts the platform's stock tools, including hardlinked ones", () => {
+    // Regression: the resolver required nlink === 1, but macOS ships
+    // /usr/bin/unzip and /usr/bin/zipinfo as two names for a single inode, so
+    // the stock unzip reports nlink 2 and no user can change it (/usr/bin is
+    // immutable under SIP). Every macOS install therefore failed at provenance
+    // verification, because the pinned gh archive is a zip on darwin while
+    // Linux takes the tar branch and never exercised this path.
+    const script = readFileSync(INSTALL_SH, "utf8");
+    const start = script.indexOf("resolve_system_tool() {");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = script.indexOf("\n}\n", start);
+    expect(end).toBeGreaterThan(start);
+    const probe = join(work, "resolve-system-tool.sh");
+    writeFileSync(
+      probe,
+      `${script.slice(start, end + 3)}\nresolve_system_tool "$@"\n`,
+    );
+
+    // Every stock system tool the installer depends on must resolve on the
+    // host it is running on, whatever its link count happens to be.
+    for (const tool of ["tar", "unzip"]) {
+      const candidates = [`/usr/bin/${tool}`, `/bin/${tool}`].filter(
+        (candidate) => {
+          if (!existsSync(candidate)) return false;
+          const stats = lstatSync(candidate);
+          return stats.isFile() && stats.uid === 0;
+        },
+      );
+      // A host without a root-owned copy of the tool has nothing to assert.
+      if (candidates.length === 0) continue;
+
+      const result = spawnSync("sh", [probe, ...candidates], {
+        encoding: "utf8",
+      });
+      expect(
+        result.status,
+        `${tool} must resolve; the installer needs it for official provenance ` +
+          `verification (link counts: ${candidates
+            .map((c) => `${c}=${lstatSync(c).nlink}`)
+            .join(", ")})`,
+      ).toBe(0);
+      expect(candidates).toContain(result.stdout.trim());
+    }
+  });
+
   test("fresh install: downloads, verifies, extracts, writes marker + working wrapper", () => {
     const home = join(work, "home");
     mkdirSync(home, { recursive: true });

--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -2935,7 +2935,25 @@ test("official standalone paths pin gh and bind Sigstore verification to the sou
   expect(powershell).toContain('$env:DO_NOT_TRACK = "1"');
   expect(powershell).toContain('$env:GH_SPINNER_DISABLED = "1"');
   expect(shell).not.toContain("command -v gh");
-  expect(shell).toContain("file.nlink !== 1");
+  // Single-link is required of every artifact the installer downloads into its
+  // own private tree: it creates those files, so a second link is a genuine
+  // TOCTOU signal and must keep failing closed.
+  expect(shell.match(/nlink !== 1n/gu)).toHaveLength(4);
+  // It is deliberately NOT required of stock system tools. macOS and Linux both
+  // ship /usr/bin/unzip and /usr/bin/zipinfo as two names for one inode, so a
+  // legitimate system unzip reports nlink 2 and no user can change it under
+  // SIP. Requiring one link here failed every macOS install at provenance
+  // verification, since the pinned gh archive is a zip on darwin. Root
+  // ownership plus a fully root-owned, non-group/other-writable parent chain
+  // is what buys the guarantee; re-adding a link count would break macOS again.
+  const resolver = shell.slice(
+    shell.indexOf("resolve_system_tool() {"),
+    shell.indexOf("\n}\n", shell.indexOf("resolve_system_tool() {")),
+  );
+  // Matches a link-count rejection, not the comment explaining why there is none.
+  expect(resolver).not.toMatch(/nlink\s*!==/u);
+  expect(resolver).toContain("file.uid !== 0");
+  expect(resolver).toContain("metadata.uid !== 0");
   expect(shell).toContain("(file.mode & 0o022) !== 0");
   expect(powershell).not.toContain("Get-Command gh");
 });

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -350,6 +350,18 @@ case "$NODE_MODULE_ABI" in
   ''|*[!0-9]*) fail "Node.js reported an invalid native module ABI: ${NODE_MODULE_ABI}" ;;
 esac
 resolve_system_tool() {
+  # Deliberately does NOT require nlink === 1, unlike the checks covering
+  # artifacts this installer downloads into its own private tree. macOS ships
+  # /usr/bin/unzip and /usr/bin/zipinfo as two names for a single inode, so a
+  # stock system tool legitimately reports nlink 2 and no user can change it:
+  # /usr/bin is immutable under SIP. Requiring a single link therefore made
+  # every macOS install fail once the pinned gh archive is a zip.
+  #
+  # The guarantee is preserved by the checks that remain: the file is
+  # root-owned, not group/other writable, and every parent directory up to the
+  # root is likewise root-owned and not group/other writable. An extra hard
+  # link cannot be created inside such a tree by a non-root user, and a link
+  # made elsewhere still cannot alter the root-owned inode's contents.
   node -e '
     const { lstatSync, realpathSync, statSync } = require("node:fs");
     const { dirname, isAbsolute } = require("node:path");
@@ -358,7 +370,7 @@ resolve_system_tool() {
       try {
         const path = realpathSync(candidate);
         const file = lstatSync(path);
-        if (!file.isFile() || file.isSymbolicLink() || file.nlink !== 1 ||
+        if (!file.isFile() || file.isSymbolicLink() ||
             (file.mode & 0o111) === 0 || (file.mode & 0o022) !== 0 || file.uid !== 0) continue;
         let parent = dirname(path);
         let trusted = true;


### PR DESCRIPTION
## Impact

`curl -fsSL https://get.agenc.ag/install.sh | sh` fails on **every stock macOS**:

```
agenc-install: downloading runtime 0.16.0 (darwin-arm64/abi147)...
agenc-install: checksum verified
agenc-install: a root-owned, single-link, non-writable unzip executable under trusted system directories is required
agenc-install: ERROR: official runtime provenance verification failed
```

There is no user-side workaround: `/usr/bin` is immutable under SIP.

## Cause

`resolve_system_tool` (`scripts/install/install.sh`) requires `nlink === 1`. Apple ships `unzip` and `zipinfo` as two names for one inode:

```
1152921500312573031  links=2  /usr/bin/unzip
1152921500312573031  links=2  /usr/bin/zipinfo
```

Running the resolver's exact conditions against both tools it needs, on darwin-arm64:

```
/usr/bin/tar    nlink=1  ->  ACCEPTED
/usr/bin/unzip  nlink=2  ->  REJECTED by: nlink===1
```

Every other condition already passes: `isFile`, not a symlink, executable, no group/other write, `uid === 0`, and a fully root-owned parent chain. The link count is the sole failure.

**Why macOS only:** the resolver is reached while extracting the pinned GitHub CLI for official provenance verification. That archive is a zip on darwin; Linux gets a tarball and takes the `SYSTEM_TAR` branch, so this path is never exercised there. `tar` survives on macOS only because Apple happens not to hardlink it.

Present since #1498.

## The change

Drop the link-count requirement for **system tools only**.

The guarantee the check was buying is preserved by what remains: the file is root-owned, not group/other writable, and every parent directory up to the root is likewise root-owned and not group/other writable. A hard link cannot be created inside such a tree by a non-root user, and a link created elsewhere still cannot alter the contents of a root-owned, non-writable inode.

**The four `nlink` checks at lines 548, 564, 577 and 584 are deliberately untouched.** Those cover artifacts the installer downloads into its own private tree. Those files are created by the installer, so a second link is a genuine TOCTOU vector there and must keep failing closed. Only the system-tool resolver changes.

## Verification

End to end on darwin-arm64, using this repo's installer with an isolated `AGENC_HOME` so nothing touched the real install:

**Before** — reproduces the reported failure exactly:
```
agenc-install: checksum verified
agenc-install: a root-owned, single-link, non-writable unzip executable under trusted system directories is required
agenc-install: ERROR: official runtime provenance verification failed
```

**After** — provenance verifies and the runtime installs:
```
agenc-install: verifying native-build provenance for …darwin-arm64-node26-abi147.tar.gz
agenc-install: verifying tag-promotion provenance for …darwin-arm64-node26-abi147.tar.gz
agenc-install: native-build and tag-promotion provenance verified
agenc-install: runtime 0.16.0 installed at …/runtime/0.16.0/darwin-arm64-native-node-abi-147-sha256-b677c6df…
```

(The run then stops at `wrapper belongs to a different AGENC_HOME`, which is the installer correctly refusing to retarget an existing wrapper from my isolated home. Unrelated to this change.)

`sh -n scripts/install/install.sh` clean.

## Test

Adds `resolve_system_tool accepts the platform's stock tools, including hardlinked ones` to the shared installer harness. It extracts the real `resolve_system_tool` from `install.sh` and asserts the host's stock `tar` and `unzip` both resolve, whatever their link count, skipping any tool the host lacks.

Falsification-checked: restoring `nlink !== 1` fails it with the observed count.

```
AssertionError: unzip must resolve; the installer needs it for official provenance
verification (link counts: /usr/bin/unzip=2): expected 1 to be +0
```

On Linux both tools report nlink 1, so the test passes there before and after; its value is that it fails loudly on macOS, which is the platform that had no coverage of this path at all.

## Not done

I did not run the full `install-sh` suite to completion locally. It performs real network work and exceeded a 10-minute budget on this machine, so I stopped rather than report a partial result as a pass. CI covers it.
