### PR TITLE
fix(launcher): accept a hardlinked stock tar in the npm launcher

### DIFF
--- a/packages/agenc/lib/runtime-manager.mjs
+++ b/packages/agenc/lib/runtime-manager.mjs
@@ -1057,9 +1057,19 @@ async function download(
 function assertRootOwnedSystemExecutable(path) {
   const canonical = realpathSync.native(path);
   const executable = lstatSync(canonical, { bigint: true });
+  // Deliberately no link-count requirement, matching the shell installer's
+  // resolve_system_tool. Stock system tools legitimately ship as several names
+  // for one inode (macOS and Ubuntu both hardlink unzip/zipinfo; some
+  // distributions link tar/gtar), and no user can change that under SIP.
+  // Root ownership plus the fully root-owned, non-group/other-writable
+  // ancestor chain below is what buys the guarantee: a non-root user can
+  // neither add a link inside such a tree nor alter the root-owned inode
+  // through a link made elsewhere. The nlink !== 1n checks on files this
+  // launcher downloads into its own private tree stay, because there a second
+  // link is a genuine TOCTOU signal.
   if (
     !executable.isFile() || executable.isSymbolicLink() ||
-    executable.nlink !== 1n || executable.uid !== 0n ||
+    executable.uid !== 0n ||
     (executable.mode & 0o022n) !== 0n
   ) {
     throw new Error(`agenc: operating-system tar is not a trusted regular file: ${canonical}`);

--- a/packages/agenc/test/runtime-manager.test.mjs
+++ b/packages/agenc/test/runtime-manager.test.mjs
@@ -2075,3 +2075,50 @@ test("isInstalled rejects a symlinked marker even when its bytes match", async (
     rmSync(work, { recursive: true, force: true });
   }
 });
+
+test("resolveTrustedSystemTar accepts the platform's stock tar, whatever its link count", async (t) => {
+  // Regression guard, mirroring the shell installer's resolve_system_tool
+  // (tetsuo-ai/agenc-core#1727). Stock system tools legitimately ship as
+  // several names for one inode -- macOS and Ubuntu both hardlink
+  // unzip/zipinfo, and some distributions link tar/gtar -- and /usr/bin is
+  // immutable under SIP, so a link-count requirement here would strand the
+  // launcher with no user-side fix the day a platform ships a hardlinked tar.
+  if (process.platform !== "linux" && process.platform !== "darwin") {
+    t.skip("POSIX stock-tar resolution only");
+    return;
+  }
+  const { resolveTrustedSystemTar } = await import("../lib/runtime-manager.mjs");
+  const candidates = ["/usr/bin/tar", "/bin/tar"].filter((path) => {
+    if (!existsSync(path)) return false;
+    const stats = statSync(path, { bigint: true });
+    return stats.isFile() && stats.uid === 0n;
+  });
+  if (candidates.length === 0) {
+    t.skip("host has no root-owned stock tar to assert against");
+    return;
+  }
+  const linkCounts = candidates
+    .map((path) => `${path}=${statSync(path, { bigint: true }).nlink}`)
+    .join(", ");
+  const trusted = resolveTrustedSystemTar();
+  assert.ok(
+    trusted.path.length > 0,
+    `stock tar must resolve whatever its link count (${linkCounts})`,
+  );
+
+  // Source contract: the system-tool assertion carries no link-count
+  // rejection, while the checks covering files this launcher downloads into
+  // its own private tree keep theirs -- there a second link is a genuine
+  // TOCTOU signal and must keep failing closed.
+  const source = readFileSync(
+    fileURLToPath(new URL("../lib/runtime-manager.mjs", import.meta.url)),
+    "utf8",
+  );
+  const resolver = source.slice(
+    source.indexOf("function assertRootOwnedSystemExecutable"),
+    source.indexOf("export function resolveTrustedSystemTar"),
+  );
+  assert.ok(resolver.length > 0, "resolver body must be locatable");
+  assert.equal(/\.nlink\s*!==/u.test(resolver), false);
+  assert.equal(source.match(/\.nlink !== 1n/gu)?.length, 2);
+});


### PR DESCRIPTION
Applies #1727's reasoning to the npm launcher, which carries the same latent rule.

`assertRootOwnedSystemExecutable` (`packages/agenc/lib/runtime-manager.mjs`) required `nlink === 1n` of the operating-system tar. That is the rule that broke every macOS install through the shell installer, and the launcher escapes it only because Apple happens not to hardlink `tar` today. A platform shipping `tar`/`gtar` as two names for one inode would fail with `operating-system tar is not a trusted regular file` — under SIP, with no user-side fix.

## Change

Link-count requirement dropped from the **system-tool assertion only**. The guarantee is carried by what remains: root ownership, no group/other write, and the fully root-owned ancestor chain. The `nlink !== 1n` checks on files the launcher downloads into its own private tree are untouched — there a second link is a genuine TOCTOU signal.

## Test

Resolves the host's stock tar whatever its link count, and pins both halves of the contract in source: no link-count rejection in the system-tool assertion, exactly the private-tree rejections elsewhere (count-pinned, so silently dropping one fails).

Falsification-checked: restoring the requirement fails the new test with the host's link counts in the message.

| | |
|---|---|
| packages/agenc | 181 passed |
| update-cli consumer (calls `resolveTrustedSystemTar` for real) | 77 passed |

Ships in the next npm release — this changes the published package, unlike the installer-hotfix lane.