### PR TITLE
feat(runtime): advisory reminder when a tool call loops on identical arguments

### DIFF
--- a/runtime/src/phases/execute-tools.ts
+++ b/runtime/src/phases/execute-tools.ts
@@ -54,6 +54,7 @@ import type { ToolDispatchResult } from "../tool-registry.js";
 import type { Tool } from "../tools/types.js";
 import { emitError as emitErrorEvent } from "../session/event-log.js";
 import { emitWarning as emitWarningEvent } from "../session/event-log.js";
+import { appendRepeatToolAdvisory } from "./repeat-tool-advisory.js";
 import type { Session } from "../session/session.js";
 import type { GuardianApprovalReviewer } from "../permissions/guardian/reviewer.js";
 import type { PermissionAuditEventInput } from "../permissions/permission-audit-log.js";
@@ -969,6 +970,10 @@ export async function executeTools(
     }
   }
   appendHookAdditionalContexts(state, session, additionalContexts);
+  // Advisory loop-breaker: after the batch's results are on the record,
+  // count consecutive identical calls and remind the model at escalating
+  // run lengths. Purely additive context — never blocks or rewrites a call.
+  appendRepeatToolAdvisory(state, session, normalizedToolCalls);
   if (preventContinuation) {
     state.needsFollowUp = false;
     state.preventContinuation = true;

--- a/runtime/src/phases/repeat-tool-advisory.ts
+++ b/runtime/src/phases/repeat-tool-advisory.ts
@@ -1,0 +1,175 @@
+/**
+ * Repeat-tool advisory — an advisory loop-breaker, not a gate.
+ *
+ * Watches each session's stream of dispatched tool calls, counts runs of
+ * consecutive calls to the same tool with identical canonicalized arguments,
+ * and at configured run lengths appends one escalating advisory reminder
+ * telling the model to stop repeating itself, re-read the last result, and
+ * either change approach or conclude. The decision (retry differently, gather
+ * more evidence, or finish) stays entirely with the model: a legitimately
+ * repeated call is delayed by nothing and blocked by nothing.
+ *
+ * Design ported from DeepSeek Harness's `dsh-repeat-tool-reminder` (MIT),
+ * adapted to AgenC's phase pipeline: observation happens in execute-tools
+ * after the batch drains, and the advisory rides the same user-context
+ * channel as hook additionalContexts. Like the continuation nudge
+ * (gaphunt3 #34), the injected message is heuristic-driven and therefore
+ * excluded from durable history, so a false positive never pollutes the
+ * rollout that `--resume` replays.
+ *
+ * @module
+ */
+
+import type { LLMToolCall } from "../llm/types.js";
+import type { Session } from "../session/session.js";
+import type { TurnState } from "../session/turn-state.js";
+import { emitWarning } from "../session/event-log.js";
+import { stableStringify } from "../utils/stableStringify.js";
+
+/**
+ * Consecutive-run lengths that trigger a reminder, in escalation order.
+ * A run longer than the last threshold stays silent: by then the model has
+ * been reminded three times, and repeating the reminder is itself a loop.
+ */
+export const REPEAT_TOOL_THRESHOLDS = [3, 5, 8] as const;
+
+/**
+ * Tools transparent to the chain: they neither extend nor reset a run.
+ * TaskList takes no meaningful arguments, so polling it between steps is an
+ * ordinary harness pattern, not a loop symptom.
+ */
+const TRANSPARENT_TOOLS: ReadonlySet<string> = new Set(["TaskList"]);
+
+/** Cap on the argument preview quoted inside the detailed reminder. */
+const ARGUMENTS_PREVIEW_CHARS = 500;
+
+interface RepeatRun {
+  key: string;
+  toolName: string;
+  argumentsPreview: string;
+  count: number;
+}
+
+/**
+ * Per-session run state. Keyed weakly so a disposed session never retains
+ * advisory bookkeeping — the same idiom as post-sample-recovery's
+ * last-discarded-partial tracking.
+ */
+const repeatRuns = new WeakMap<object, RepeatRun>();
+
+/**
+ * Canonical identity of one call: tool name plus arguments with object keys
+ * sorted, so `{"a":1,"b":2}` and `{"b":2,"a":1}` belong to the same run.
+ * Arguments that fail to parse as JSON participate verbatim — byte-identical
+ * malformed arguments are still the same repeated call.
+ */
+function canonicalCallKey(call: LLMToolCall): string {
+  let canonicalArguments = call.arguments;
+  try {
+    canonicalArguments = stableStringify(JSON.parse(call.arguments));
+  } catch {
+    // Verbatim fallback keeps unparseable-argument repeats detectable.
+  }
+  return `${call.name}\n${canonicalArguments}`;
+}
+
+function advisoryText(run: RepeatRun): string {
+  const preview =
+    run.argumentsPreview.length > ARGUMENTS_PREVIEW_CHARS
+      ? `${run.argumentsPreview.slice(0, ARGUMENTS_PREVIEW_CHARS)}…`
+      : run.argumentsPreview;
+  const observation =
+    `You have now called the tool "${run.toolName}" ${run.count} times in a ` +
+    `row with identical arguments: ${preview}`;
+  if (run.count >= REPEAT_TOOL_THRESHOLDS[2]) {
+    return (
+      `${observation}\nRepeating this exact call again will not produce a ` +
+      `different result. Stop, state in one or two sentences what the ` +
+      `repeated result actually says, and then either take a genuinely ` +
+      `different action or conclude with what you have.`
+    );
+  }
+  if (run.count >= REPEAT_TOOL_THRESHOLDS[1]) {
+    return (
+      `${observation}\nThe result is not going to change on its own. ` +
+      `Re-read the last result carefully; if you are waiting on something ` +
+      `external, say so and how long, otherwise change approach.`
+    );
+  }
+  return (
+    `${observation}\nIf that was intentional (for example, polling), carry ` +
+    `on. Otherwise re-read the last result before calling again — it may ` +
+    `already contain the answer.`
+  );
+}
+
+/**
+ * Feed one dispatched batch, in the model's emission order, into the
+ * session's run tracking. Returns the advisory for the HIGHEST threshold
+ * crossed by this batch, or undefined when none was crossed — at most one
+ * reminder per batch, so a burst from 2 to 9 identical calls produces one
+ * strong reminder rather than three stacked ones.
+ */
+export function observeRepeatToolCalls(
+  session: object,
+  calls: ReadonlyArray<LLMToolCall>,
+): string | undefined {
+  let crossed: RepeatRun | undefined;
+  for (const call of calls) {
+    if (TRANSPARENT_TOOLS.has(call.name)) continue;
+    const key = canonicalCallKey(call);
+    const previous = repeatRuns.get(session);
+    const run: RepeatRun =
+      previous !== undefined && previous.key === key
+        ? previous
+        : {
+            key,
+            toolName: call.name,
+            argumentsPreview: call.arguments,
+            count: 0,
+          };
+    run.count += 1;
+    repeatRuns.set(session, run);
+    if ((REPEAT_TOOL_THRESHOLDS as readonly number[]).includes(run.count)) {
+      // Later crossings in the same batch are necessarily higher counts of
+      // the same run: a different call in between would have reset it.
+      crossed = { ...run };
+    }
+  }
+  return crossed === undefined ? undefined : advisoryText(crossed);
+}
+
+/**
+ * Observe the batch and, when a threshold was crossed, append the advisory
+ * through the same user-context channel hook additionalContexts use, plus a
+ * warning event so transcripts and the TUI show why the context grew.
+ */
+export function appendRepeatToolAdvisory(
+  state: TurnState,
+  session: Session,
+  calls: ReadonlyArray<LLMToolCall>,
+): void {
+  const advisory = observeRepeatToolCalls(session, calls);
+  if (advisory === undefined) return;
+  const modelFacingContext = `<system-reminder>\n${advisory}\n</system-reminder>`;
+  emitWarning(
+    session.eventLog,
+    session.nextInternalSubId(),
+    "repeat_tool_advisory",
+    advisory.split("\n", 1)[0] ?? advisory,
+  );
+  state.toolResults.push({
+    uuid: crypto.randomUUID(),
+    role: "user",
+    kind: "attachment",
+    content: modelFacingContext,
+  });
+  state.messages.push({
+    role: "user",
+    content: modelFacingContext,
+    runtimeOnly: {
+      mergeBoundary: "user_context",
+      excludeFromDurableHistory: true,
+    },
+  });
+}

--- a/runtime/tests/phases/execute-tools.test.ts
+++ b/runtime/tests/phases/execute-tools.test.ts
@@ -1793,10 +1793,13 @@ describe("executeTools — T7 gap #109 pipeline", () => {
     const registry = mkRegistry([tool]);
     const session = mkSession({ log, registry });
 
+    // Distinct arguments per call: six identical calls would (correctly)
+    // trip the repeat-tool advisory and append a seventh message, which is
+    // not this test's subject.
     const calls: LLMToolCall[] = Array.from({ length: 6 }, (_, idx) => ({
       id: `c-${idx}`,
       name: "FileRead",
-      arguments: "{}",
+      arguments: JSON.stringify({ path: `f-${idx}` }),
     }));
     const state = mkState({ toolCalls: calls });
 
@@ -1806,6 +1809,44 @@ describe("executeTools — T7 gap #109 pipeline", () => {
     expect(state.messages.length).toBe(6);
     // Peak in-flight must not exceed 2 when env cap is 2
     expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  test("a run of identical calls appends one escalating repeat advisory", async () => {
+    const tool: Tool = {
+      name: "FileRead",
+      description: "read-only",
+      inputSchema: { type: "object" },
+      execute: async () => ({ content: "same answer" }),
+    };
+    const log = new EventLog();
+    const registry = mkRegistry([tool]);
+    const session = mkSession({ log, registry });
+
+    const repeated: LLMToolCall = {
+      id: "c-0",
+      name: "FileRead",
+      arguments: JSON.stringify({ path: "/tmp/f" }),
+    };
+    // Three single-call batches, as a looping model would produce them.
+    let lastState: TurnState | undefined;
+    for (let i = 0; i < 3; i += 1) {
+      const state = mkState({
+        toolCalls: [{ ...repeated, id: `c-${i}` }],
+      });
+      lastState = await executeTools(state, mkCtx(), session);
+    }
+
+    // The third batch carries its result plus exactly one advisory.
+    expect(lastState!.messages.length).toBe(2);
+    const advisory = lastState!.messages.at(-1)! as {
+      role: string;
+      content: string;
+      runtimeOnly?: { excludeFromDurableHistory?: boolean };
+    };
+    expect(advisory.role).toBe("user");
+    expect(advisory.content).toContain("<system-reminder>");
+    expect(advisory.content).toContain('"FileRead" 3 times in a row');
+    expect(advisory.runtimeOnly?.excludeFromDurableHistory).toBe(true);
   });
 
   test("progress event fires on eventLog when tool calls __onProgress", async () => {

--- a/runtime/tests/phases/repeat-tool-advisory.test.ts
+++ b/runtime/tests/phases/repeat-tool-advisory.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "vitest";
+
+import type { LLMToolCall } from "../../src/llm/types.js";
+import type { Session } from "../../src/session/session.js";
+import type { TurnState } from "../../src/session/turn-state.js";
+import {
+  appendRepeatToolAdvisory,
+  observeRepeatToolCalls,
+  REPEAT_TOOL_THRESHOLDS,
+} from "../../src/phases/repeat-tool-advisory.js";
+
+function call(name: string, args: unknown, id = "c"): LLMToolCall {
+  return {
+    id,
+    name,
+    arguments: typeof args === "string" ? args : JSON.stringify(args),
+  };
+}
+
+describe("observeRepeatToolCalls", () => {
+  test("stays silent below the first threshold and fires exactly at it", () => {
+    const session = {};
+    const repeated = call("Bash", { command: "ls" });
+    expect(observeRepeatToolCalls(session, [repeated])).toBeUndefined();
+    expect(observeRepeatToolCalls(session, [repeated])).toBeUndefined();
+    const advisory = observeRepeatToolCalls(session, [repeated]);
+    expect(advisory).toContain('"Bash" 3 times in a row');
+    expect(advisory).toContain("polling");
+  });
+
+  test("escalates at each configured threshold and then goes quiet", () => {
+    const session = {};
+    const repeated = call("Grep", { pattern: "x" });
+    const fired: number[] = [];
+    for (let count = 1; count <= 12; count += 1) {
+      const advisory = observeRepeatToolCalls(session, [repeated]);
+      if (advisory !== undefined) fired.push(count);
+    }
+    expect(fired).toEqual([...REPEAT_TOOL_THRESHOLDS]);
+  });
+
+  test("uses distinct escalation text per tier", () => {
+    const session = {};
+    const repeated = call("Read", { file_path: "/tmp/a" });
+    const texts: string[] = [];
+    for (let count = 1; count <= 8; count += 1) {
+      const advisory = observeRepeatToolCalls(session, [repeated]);
+      if (advisory !== undefined) texts.push(advisory);
+    }
+    expect(texts).toHaveLength(3);
+    expect(texts[0]).toContain("If that was intentional");
+    expect(texts[1]).toContain("not going to change on its own");
+    expect(texts[2]).toContain("Stop, state in one or two sentences");
+  });
+
+  test("a different call resets the run", () => {
+    const session = {};
+    const first = call("Bash", { command: "ls" });
+    const other = call("Bash", { command: "pwd" });
+    observeRepeatToolCalls(session, [first, first]);
+    observeRepeatToolCalls(session, [other]);
+    // Two more of the original stay below the threshold: the run restarted.
+    expect(observeRepeatToolCalls(session, [first, first])).toBeUndefined();
+    expect(observeRepeatToolCalls(session, [first])).not.toBeUndefined();
+  });
+
+  test("argument key order does not split a run", () => {
+    const session = {};
+    const ab = call("Edit", '{"a":1,"b":2}');
+    const ba = call("Edit", '{"b":2,"a":1}');
+    observeRepeatToolCalls(session, [ab]);
+    observeRepeatToolCalls(session, [ba]);
+    expect(observeRepeatToolCalls(session, [ab])).toContain("3 times");
+  });
+
+  test("byte-identical unparseable arguments still count as a run", () => {
+    const session = {};
+    const malformed = call("Bash", "{not json");
+    observeRepeatToolCalls(session, [malformed]);
+    observeRepeatToolCalls(session, [malformed]);
+    expect(observeRepeatToolCalls(session, [malformed])).toContain("3 times");
+  });
+
+  test("transparent tools neither extend nor reset the run", () => {
+    const session = {};
+    const repeated = call("Bash", { command: "ls" });
+    const transparent = call("TaskList", {});
+    observeRepeatToolCalls(session, [repeated, transparent, repeated]);
+    // TaskList in between did not reset: this is the third consecutive Bash.
+    expect(observeRepeatToolCalls(session, [repeated])).toContain("3 times");
+    // And an all-transparent run of its own never fires.
+    const other = {};
+    for (let i = 0; i < 10; i += 1) {
+      expect(observeRepeatToolCalls(other, [transparent])).toBeUndefined();
+    }
+  });
+
+  test("a burst crossing several thresholds produces one highest reminder", () => {
+    const session = {};
+    const repeated = call("Glob", { pattern: "*" });
+    const batch = Array.from({ length: 9 }, () => repeated);
+    const advisory = observeRepeatToolCalls(session, batch);
+    expect(advisory).toContain("8 times");
+    expect(advisory).toContain("Stop, state in one or two sentences");
+  });
+
+  test("runs are isolated per session", () => {
+    const a = {};
+    const b = {};
+    const repeated = call("Bash", { command: "ls" });
+    observeRepeatToolCalls(a, [repeated, repeated]);
+    // Session b starts from zero even though a is one call from the threshold.
+    expect(observeRepeatToolCalls(b, [repeated])).toBeUndefined();
+    expect(observeRepeatToolCalls(a, [repeated])).toContain("3 times");
+  });
+
+  test("bounds the quoted argument preview", () => {
+    const session = {};
+    const huge = call("Write", { content: "x".repeat(2_000) });
+    observeRepeatToolCalls(session, [huge, huge]);
+    const advisory = observeRepeatToolCalls(session, [huge]);
+    expect(advisory).toBeDefined();
+    const quoted = advisory!.slice(advisory!.indexOf("arguments: ") + 11);
+    const previewLine = quoted.split("\n", 1)[0]!;
+    expect(previewLine.length).toBeLessThanOrEqual(502);
+    expect(previewLine.endsWith("…")).toBe(true);
+  });
+});
+
+describe("appendRepeatToolAdvisory", () => {
+  function mkSessionStub(): {
+    session: Session;
+    warnings: Array<{ cause: string; message: string }>;
+  } {
+    const warnings: Array<{ cause: string; message: string }> = [];
+    let i = 0;
+    const session = {
+      eventLog: {
+        emit(event: {
+          id: string;
+          msg: { type: string; payload?: { cause: string; message: string } };
+        }) {
+          if (event.msg.type === "warning" && event.msg.payload) {
+            warnings.push(event.msg.payload);
+          }
+          return event;
+        },
+      },
+      nextInternalSubId: () => `sub-${(i += 1)}`,
+    } as unknown as Session;
+    return { session, warnings };
+  }
+
+  function mkStateStub(): TurnState {
+    return {
+      messages: [],
+      toolResults: [],
+    } as unknown as TurnState;
+  }
+
+  test("below the threshold it appends nothing at all", () => {
+    const { session, warnings } = mkSessionStub();
+    const state = mkStateStub();
+    appendRepeatToolAdvisory(state, session, [call("Bash", { command: "ls" })]);
+    expect(state.messages).toHaveLength(0);
+    expect(state.toolResults).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("at the threshold it appends one reminder through the user-context channel", () => {
+    const { session, warnings } = mkSessionStub();
+    const state = mkStateStub();
+    const repeated = call("Bash", { command: "ls" });
+    appendRepeatToolAdvisory(state, session, [repeated]);
+    appendRepeatToolAdvisory(state, session, [repeated]);
+    appendRepeatToolAdvisory(state, session, [repeated]);
+
+    expect(state.messages).toHaveLength(1);
+    const message = state.messages[0]! as {
+      role: string;
+      content: string;
+      runtimeOnly?: {
+        mergeBoundary?: string;
+        excludeFromDurableHistory?: boolean;
+      };
+    };
+    expect(message.role).toBe("user");
+    expect(message.content).toContain("<system-reminder>");
+    expect(message.content).toContain('"Bash" 3 times in a row');
+    // Heuristic-driven synthetic context stays out of the durable rollout,
+    // mirroring the continuation nudge (gaphunt3 #34).
+    expect(message.runtimeOnly?.excludeFromDurableHistory).toBe(true);
+    expect(message.runtimeOnly?.mergeBoundary).toBe("user_context");
+
+    expect(state.toolResults).toHaveLength(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.cause).toBe("repeat_tool_advisory");
+  });
+});


### PR DESCRIPTION
First adoption from the deepseek-harness study: an advisory loop-breaker, ported from `dsh-repeat-tool-reminder` (MIT) into AgenC's phase pipeline.

## What it does

Counts runs of **consecutive calls to the same tool with identical canonicalized arguments** per session (keys sorted, so `{"a":1,"b":2}` and `{"b":2,"a":1}` belong to one run; byte-identical unparseable arguments also count). At run lengths **3, 5, 8** it appends one escalating advisory through the same user-context channel hook `additionalContexts` use:

> You have now called the tool "Bash" 3 times in a row with identical arguments: … If that was intentional (for example, polling), carry on. Otherwise re-read the last result before calling again — it may already contain the answer.

Tier 2 firms up; tier 3 asks the model to state what the repeated result actually says and either change approach or conclude. After the third reminder it goes quiet — repeating the reminder would itself be a loop.

## What it deliberately does NOT do

- Never blocks, delays, or rewrites a call. Polling stays possible; it only gets commented on.
- `TaskList` is transparent to the chain (no meaningful arguments; status polling between steps is an ordinary harness pattern) — it neither extends nor resets a run.
- The injected message is heuristic-driven synthetic context, so it is **excluded from durable history**, mirroring the continuation nudge (gaphunt3 #34): a false positive never pollutes the rollout `--resume` replays. A `repeat_tool_advisory` warning event records why the context grew.
- A burst crossing several thresholds in one batch produces **one** highest reminder, not stacked ones.

## Mechanics

- `runtime/src/phases/repeat-tool-advisory.ts` — pure observation + composition; per-session state in a `WeakMap` (same idiom as post-sample-recovery's discarded-partial tracking), so runs span turns and disposed sessions retain nothing.
- Wired at the end of `executeTools`, after the batch drains and hook contexts append, observing the batch in the model's emission order.

## Tests

12 unit cases (threshold boundaries, escalation tiers, reset on different call, key-order insensitivity, malformed-argument runs, transparency, burst collapse, per-session isolation, preview bounding, channel shape) plus an integration case through the **real** `executeTools`.

The existing concurrency-cap test dispatched six identical calls in one batch — the advisory now correctly fires there, which is exactly the behavior shipping; that test now uses distinct per-call arguments so it measures only concurrency.

Falsification-checked: breaking the run-reset comparison fails exactly the reset test (1 failed | 11 passed), restored green.

| | |
|---|---|
| phases suite | 160 passed |
| typecheck | clean |