### PR TITLE
feat(sandbox): vendor the Landlock launcher and surface its enforcement in doctor

### DIFF
--- a/runtime/build.config.ts
+++ b/runtime/build.config.ts
@@ -45,6 +45,14 @@ const processBrokerDist = resolve(
   runtimeRoot,
   'dist/agenc-process-broker',
 );
+const landlockRunSource = resolve(
+  runtimeRoot,
+  'native/agenc-landlock-run.c',
+);
+const landlockRunDist = resolve(
+  runtimeRoot,
+  'dist/agenc-landlock-run',
+);
 const windowsProcessBrokerSource = resolve(
   runtimeRoot,
   'native/agenc-process-job-broker.cs',
@@ -163,6 +171,44 @@ function compileLinuxProcessBroker(): void {
     );
   }
   chmodSync(processBrokerDist, 0o755);
+}
+
+function compileLinuxLandlockRun(): void {
+  if (process.platform !== 'linux') return;
+  const compiler = process.env.CC?.trim() || 'cc';
+  const result = spawnSync(
+    compiler,
+    [
+      '-O2',
+      '-std=c11',
+      '-Wall',
+      '-Wextra',
+      '-Werror',
+      '-D_FORTIFY_SOURCE=2',
+      '-fstack-protector-strong',
+      '-Wl,-z,relro,-z,now',
+      '-o',
+      landlockRunDist,
+      landlockRunSource,
+    ],
+    {
+      cwd: runtimeRoot,
+      env: {
+        ...process.env,
+        LANG: 'C',
+        LC_ALL: 'C',
+      },
+      encoding: 'utf8',
+    },
+  );
+  if (result.error !== undefined || result.status !== 0) {
+    throw new Error(
+      'Linux landlock-run build failed' +
+        (result.error === undefined ? '' : `: ${result.error.message}`) +
+        (result.stderr ? `\n${result.stderr.trim()}` : ''),
+    );
+  }
+  chmodSync(landlockRunDist, 0o755);
 }
 
 function compileWindowsProcessBroker(): void {
@@ -462,6 +508,7 @@ const agencRuntimeAssets = {
     build.onEnd(() => {
       copyYoloClassifierPrompts();
       compileLinuxProcessBroker();
+      compileLinuxLandlockRun();
       compileWindowsProcessBroker();
     });
   },

--- a/runtime/native/agenc-landlock-run.c
+++ b/runtime/native/agenc-landlock-run.c
@@ -1,0 +1,278 @@
+/*
+ * agenc-landlock-run: self-restrict-then-exec Landlock launcher.
+ *
+ * Vendored from DeepSeek Harness's `landlock-run`
+ * (https://github.com/deepseek-ai/deepseek-harness, native/landlock-run,
+ * commit 47f943859bef60e4160492346772ded9b24f765a, MIT license — see the
+ * repository's THIRD_PARTY_NOTICES entry). The CLI contract — argv grammar,
+ * exit code 125, the exact `landlock-run: ` stderr prefix, and the probe
+ * report lines — is preserved VERBATIM on purpose: the failure classification
+ * in src/sandbox/landlock-run.ts is calibrated against that contract (their
+ * postmortem 0004 documents the misclassification that motivated it), and an
+ * unchanged contract keeps upstream fixes diffable onto this copy.
+ *
+ * Compiled on demand from source with the trusted-compiler pattern used by
+ * runtime/native/agenc-process-broker.c; nothing beyond libc and the stable
+ * kernel UAPI below.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+/*
+ * The Landlock UAPI, defined locally instead of via <linux/landlock.h>: the
+ * kernel's user-space ABI is stable by contract, self-defining it keeps the
+ * build independent of the toolchain's header vintage, and the definitions
+ * double as the audit record of exactly which kernel API this launcher
+ * touches. Layouts and values are verbatim from the kernel header (the
+ * path-beneath struct is packed there, so it must be packed here).
+ */
+struct landlock_ruleset_attr {
+  uint64_t handled_access_fs;
+};
+
+struct landlock_path_beneath_attr {
+  uint64_t allowed_access;
+  int32_t parent_fd;
+} __attribute__((packed));
+
+#define LANDLOCK_CREATE_RULESET_VERSION (1U << 0)
+#define LANDLOCK_RULE_PATH_BENEATH 1
+
+/* Filesystem access bits, grouped by the Landlock ABI that introduced them. */
+#define LL_FS_EXECUTE     (UINT64_C(1) << 0)  /* ABI 1 */
+#define LL_FS_WRITE_FILE  (UINT64_C(1) << 1)
+#define LL_FS_READ_FILE   (UINT64_C(1) << 2)
+#define LL_FS_READ_DIR    (UINT64_C(1) << 3)
+#define LL_FS_REMOVE_DIR  (UINT64_C(1) << 4)
+#define LL_FS_REMOVE_FILE (UINT64_C(1) << 5)
+#define LL_FS_MAKE_CHAR   (UINT64_C(1) << 6)
+#define LL_FS_MAKE_DIR    (UINT64_C(1) << 7)
+#define LL_FS_MAKE_REG    (UINT64_C(1) << 8)
+#define LL_FS_MAKE_SOCK   (UINT64_C(1) << 9)
+#define LL_FS_MAKE_FIFO   (UINT64_C(1) << 10)
+#define LL_FS_MAKE_BLOCK  (UINT64_C(1) << 11)
+#define LL_FS_MAKE_SYM    (UINT64_C(1) << 12)
+#define LL_FS_REFER       (UINT64_C(1) << 13) /* ABI 2 */
+#define LL_FS_TRUNCATE    (UINT64_C(1) << 14) /* ABI 3 (ABI 4 added TCP bits only) */
+#define LL_FS_IOCTL_DEV   (UINT64_C(1) << 15) /* ABI 5 */
+
+#define LL_ABI1_MASK (LL_FS_REFER - 1) /* bits 0..12: every ABI-1 access, nothing newer */
+
+/*
+ * Newest ABI this build knows; the negotiation below scales the actual
+ * ruleset down to what the running kernel supports.
+ */
+#define MAX_ABI 5L
+
+/*
+ * Landlock has no libc wrappers; these are the raw syscalls. The numbers are
+ * identical on every architecture (the post-2011 unified table) — the
+ * fallbacks only matter to a libc older than the feature.
+ */
+#ifndef __NR_landlock_create_ruleset
+#define __NR_landlock_create_ruleset 444
+#define __NR_landlock_add_rule 445
+#define __NR_landlock_restrict_self 446
+#endif
+
+/*
+ * Every fatal launcher error prints `landlock-run: <message>` to stderr
+ * and exits 125 — a code the wrapped command itself is unlikely to use, so
+ * the executor can tell launcher failures from command failures.
+ */
+#define EXIT_LAUNCHER_FAILURE 125
+
+static const char NOT_ENFORCED_MESSAGE[] =
+  "landlock is not enforced by this kernel (ABI unsupported or disabled)";
+
+/* Print one fatal `landlock-run: ...` line; returns the fatal exit code. */
+static int fail(const char *prefix, const char *detail) {
+  if (detail == NULL) {
+    fprintf(stderr, "landlock-run: %s\n", prefix);
+  } else {
+    fprintf(stderr, "landlock-run: %s: %s\n", prefix, detail);
+  }
+  return EXIT_LAUNCHER_FAILURE;
+}
+
+static int fail_usage(const char *message, const char *detail) {
+  fprintf(stderr, "landlock-run: usage error: %s%s\n", message, detail == NULL ? "" : detail);
+  return EXIT_LAUNCHER_FAILURE;
+}
+
+/* Parsed CLI: either a probe, or grants plus the command argv after `--`. */
+struct cli {
+  int probe;
+  const char **ro;
+  size_t ro_count;
+  const char **rw;
+  size_t rw_count;
+  char **command; /* NULL-terminated tail of main's argv */
+};
+
+/*
+ * Hand-rolled argv parsing — four flags do not justify a parsing library.
+ * Returns 0 on success, else the process exit code (message already printed).
+ */
+static int parse(int argc, char **argv, struct cli *cli) {
+  /* argc bounds each grant list; the launcher execs or exits, so no free. */
+  cli->ro = calloc(argc > 0 ? (size_t)argc : 1, sizeof *cli->ro);
+  cli->rw = calloc(argc > 0 ? (size_t)argc : 1, sizeof *cli->rw);
+  if (cli->ro == NULL || cli->rw == NULL) return fail("out of memory", NULL);
+
+  int index = 1;
+  while (index < argc) {
+    const char *arg = argv[index];
+    if (strcmp(arg, "--probe") == 0) {
+      if (argc != 2) {
+        return fail_usage("--probe takes no other arguments", NULL);
+      }
+      cli->probe = 1;
+      index += 1;
+    } else if (strcmp(arg, "--ro") == 0 || strcmp(arg, "--rw") == 0) {
+      if (index + 1 >= argc) {
+        return fail_usage(arg, " requires a path");
+      }
+      if (strcmp(arg, "--ro") == 0) {
+        cli->ro[cli->ro_count++] = argv[index + 1];
+      } else {
+        cli->rw[cli->rw_count++] = argv[index + 1];
+      }
+      index += 2;
+    } else if (strcmp(arg, "--") == 0) {
+      cli->command = &argv[index + 1];
+      break;
+    } else {
+      return fail_usage("unknown argument: ", arg);
+    }
+  }
+  if (!cli->probe && (cli->command == NULL || cli->command[0] == NULL)) {
+    return fail_usage("missing `-- <argv>...` command", NULL);
+  }
+  return 0;
+}
+
+/* The filesystem accesses the running kernel's ABI can govern. */
+static uint64_t fs_mask_for_abi(long abi) {
+  uint64_t mask = LL_ABI1_MASK;
+  if (abi >= 2) mask |= LL_FS_REFER;
+  if (abi >= 3) mask |= LL_FS_TRUNCATE;
+  if (abi >= 5) mask |= LL_FS_IOCTL_DEV;
+  return mask;
+}
+
+/* Add one path-beneath rule; 0 on success, else the exit code. */
+static int add_rule(int ruleset_fd, const char *path, uint64_t access) {
+  int path_fd = open(path, O_PATH | O_CLOEXEC);
+  if (path_fd < 0) {
+    /* Fail closed on an unopenable grant root: silently narrowing the
+     * granted set would be safe, but running with a profile the caller did
+     * not get is not worth the ambiguity. */
+    fprintf(stderr, "landlock-run: cannot open rule path: %s: %s\n", path, strerror(errno));
+    return EXIT_LAUNCHER_FAILURE;
+  }
+  /* The kernel rejects directory-only accesses on a non-directory rule
+   * (EINVAL), so a file grant keeps only the file-compatible bits — how the
+   * `--rw /dev/null` grant works. */
+  struct stat st;
+  if (fstat(path_fd, &st) == 0 && !S_ISDIR(st.st_mode)) {
+    access &= LL_FS_EXECUTE | LL_FS_WRITE_FILE | LL_FS_READ_FILE | LL_FS_TRUNCATE | LL_FS_IOCTL_DEV;
+  }
+  struct landlock_path_beneath_attr attr = { .allowed_access = access, .parent_fd = path_fd };
+  if (syscall(__NR_landlock_add_rule, ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &attr, 0) != 0) {
+    int saved = errno;
+    close(path_fd);
+    return fail("landlock ruleset error", strerror(saved));
+  }
+  close(path_fd);
+  return 0;
+}
+
+/*
+ * Install the ruleset on the current thread, negotiating the kernel's ABI
+ * down from MAX_ABI. `--ro` paths get the read side of the vocabulary (read
+ * file/dir + execute — the wrapped `bash` and everything it spawns must
+ * remain executable); `--rw` paths get every filesystem access the
+ * negotiated ABI can grant. Sets `no_new_privs` first (mandatory for an
+ * unprivileged restrict, and it neutralizes setuid/setgid escalation inside
+ * the sandbox). On success `*partial` reports whether the kernel governs
+ * only a subset of MAX_ABI's accesses. Returns 0, else the exit code.
+ */
+static int restrict_self(const struct cli *cli, int *partial) {
+  long abi = syscall(__NR_landlock_create_ruleset, NULL, 0, LANDLOCK_CREATE_RULESET_VERSION);
+  if (abi < 0) {
+    /* ENOSYS: kernel built without Landlock; EOPNOTSUPP: built but disabled.
+     * Either way: not enforceable — fail CLOSED, never exec unconfined. */
+    return fail(NOT_ENFORCED_MESSAGE, NULL);
+  }
+  *partial = abi < MAX_ABI;
+  uint64_t handled = fs_mask_for_abi(abi < MAX_ABI ? abi : MAX_ABI);
+
+  struct landlock_ruleset_attr attr = { .handled_access_fs = handled };
+  int ruleset_fd = (int)syscall(__NR_landlock_create_ruleset, &attr, sizeof attr, 0);
+  if (ruleset_fd < 0) return fail("landlock ruleset error", strerror(errno));
+
+  const uint64_t read_side = LL_FS_EXECUTE | LL_FS_READ_FILE | LL_FS_READ_DIR;
+  for (size_t i = 0; i < cli->ro_count; i++) {
+    int code = add_rule(ruleset_fd, cli->ro[i], read_side & handled);
+    if (code != 0) return code;
+  }
+  for (size_t i = 0; i < cli->rw_count; i++) {
+    int code = add_rule(ruleset_fd, cli->rw[i], handled);
+    if (code != 0) return code;
+  }
+
+  if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    return fail("landlock ruleset error", strerror(errno));
+  }
+  if (syscall(__NR_landlock_restrict_self, ruleset_fd, 0) != 0) {
+    return fail("landlock ruleset error", strerror(errno));
+  }
+  close(ruleset_fd);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  struct cli cli = { 0 };
+  int code = parse(argc, argv, &cli);
+  if (code != 0) return code;
+
+  if (cli.probe) {
+    /* The functional probe: build and enforce a maximal ruleset in THIS
+     * short-lived process (the probe run exits right after). `--version`
+     * style checks would miss a kernel that has the syscalls but refuses
+     * enforcement; actually restricting is the only honest signal. The one
+     * report line is part of the launcher CLI contract — the executor reads
+     * enforcement completeness from it. */
+    static const char *probe_root = "/";
+    struct cli probe = { .ro = &probe_root, .ro_count = 1 };
+    int partial = 0;
+    code = restrict_self(&probe, &partial);
+    if (code != 0) return code;
+    printf("landlock: %s\n", partial ? "partially enforced (older ABI)" : "fully enforced");
+    return 0;
+  }
+
+  int partial = 0;
+  code = restrict_self(&cli, &partial);
+  if (code != 0) return code;
+  if (partial) {
+    /* Older ABI: some handled accesses are not governed (e.g. truncate
+     * before ABI 3). Still confined for everything the kernel supports —
+     * report, do not refuse. */
+    fprintf(stderr, "landlock-run: partial enforcement (older Landlock ABI)\n");
+  }
+
+  execvp(cli.command[0], cli.command);
+  /* exec only returns on failure. */
+  return fail("exec failed", strerror(errno));
+}

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -25,7 +25,8 @@
   ],
   "agencExecutableFiles": [
     "dist/agenc-process-broker",
-    "dist/agenc-process-job-broker.exe"
+    "dist/agenc-process-job-broker.exe",
+    "dist/agenc-landlock-run"
   ],
   "scripts": {
     "build": "node scripts/sync-shipped-plugins.mjs && node scripts/build-runtime.mjs && node scripts/write-build-version.mjs && npm run check:package-entrypoints && npm run check:sdk-generated-types && node ../scripts/canonicalize-package-modes.mjs .",

--- a/runtime/src/bin/doctor-cli.ts
+++ b/runtime/src/bin/doctor-cli.ts
@@ -132,6 +132,15 @@ export function formatDiagnosticText(
   if (info.sandbox.reason) {
     lines.push(`    reason:   ${info.sandbox.reason}`);
   }
+  if (info.sandbox.landlock !== undefined) {
+    const label =
+      info.sandbox.landlock === "full"
+        ? "fully enforced"
+        : info.sandbox.landlock === "partial"
+          ? "partially enforced (older kernel ABI)"
+          : "unavailable";
+    lines.push(`    landlock: ${label}`);
+  }
 
   if (info.multipleInstallations.length > 0) {
     lines.push("");

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -78,6 +78,13 @@ export interface SandboxExecutionStatus {
   readonly remediation?: string;
   readonly helperPath?: string;
   readonly isolationProgram?: string;
+  /**
+   * Functional Landlock enforcement on this host (Linux only), from the
+   * vendored launcher's `--probe`. Report-only today: it names the
+   * confinement rung available when bubblewrap's user namespace is
+   * restricted, ahead of the execution path learning to use it.
+   */
+  readonly landlock?: "full" | "partial" | "unusable";
 }
 
 export interface SandboxSpawnCommand {

--- a/runtime/src/sandbox/landlock-run.ts
+++ b/runtime/src/sandbox/landlock-run.ts
@@ -1,0 +1,213 @@
+/**
+ * Landlock launcher access — resolve, probe, grant serialization, and outcome
+ * classification for `agenc-landlock-run`, the self-restrict-then-exec
+ * Landlock launcher vendored at `runtime/native/agenc-landlock-run.c`.
+ *
+ * Landlock is an independent kernel syscall family: it needs no user
+ * namespaces, no mount privileges, and no LSM profile, which makes it the
+ * natural confinement rung for hosts where bubblewrap is unusable (Ubuntu
+ * 24.04+ with `apparmor_restrict_unprivileged_userns=1` and no AgenC AppArmor
+ * profile installed). This module only RESOLVES and REPORTS that capability;
+ * wiring it into the execution path is a separate, deliberate change.
+ *
+ * The binary keeps the upstream CLI contract verbatim (DeepSeek Harness
+ * `landlock-run`, MIT): grants via `--ro`/`--rw`, `--probe`, fatal lines
+ * prefixed `landlock-run: `, launcher failures exit 125. Classification below
+ * follows the rule their postmortem 0004 arrived at after misattributing
+ * child exits to the launcher: launcher failure requires BOTH the failure
+ * status AND fatal-line evidence, after excluding the exact informational
+ * partial-enforcement notice. A confined child can still forge that pair on
+ * purpose — stderr is an in-band channel — so classification informs
+ * diagnostics, never a security decision.
+ *
+ * @module
+ */
+
+import { spawnSync, execFileSync } from "node:child_process";
+import {
+  accessSync,
+  chmodSync,
+  constants as fsConstants,
+  lstatSync,
+  mkdtempSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const LANDLOCK_RUN_NAME = "agenc-landlock-run";
+
+/** Every launcher-level failure exits with this code; children pass through. */
+export const LANDLOCK_RUN_FAILURE_EXIT = 125;
+
+/**
+ * The one informational stderr line a successful confined run may print (on
+ * kernels older than the launcher's newest known ABI). Exact-match excluded
+ * from fatal evidence; everything else under the prefix is fatal.
+ */
+export const LANDLOCK_RUN_PARTIAL_NOTICE =
+  "landlock-run: partial enforcement (older Landlock ABI)";
+
+const LANDLOCK_RUN_FATAL_PREFIX = "landlock-run: ";
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+/** Functional enforcement level reported by `--probe`. */
+export type LandlockEnforcement = "full" | "partial" | "unusable";
+
+let compiledLandlockRun: string | undefined;
+
+function isExecutableFile(path: string): boolean {
+  try {
+    if (!lstatSync(path).isFile()) return false;
+    accessSync(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the launcher binary: a bundled sibling of this module when present,
+ * otherwise compiled once per process from the in-tree source with the same
+ * trusted-compiler discovery and hardened flags as the process broker
+ * (fixed absolute compiler paths — never a PATH search). Returns undefined
+ * when unavailable (non-Linux, missing source, or no trusted compiler);
+ * callers treat that as `unusable` and fall closed.
+ */
+export function resolveLandlockRun(): string | undefined {
+  if (process.platform !== "linux") return undefined;
+  if (compiledLandlockRun !== undefined) return compiledLandlockRun;
+
+  const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+  // The build compiles the launcher to the dist ROOT; this module may be
+  // bundled into a root chunk or under dist/bin, so probe both geometries.
+  const bundledCandidates = [
+    join(moduleDirectory, LANDLOCK_RUN_NAME),
+    resolve(moduleDirectory, "..", LANDLOCK_RUN_NAME),
+  ];
+  const bundled = bundledCandidates.find(isExecutableFile);
+  if (bundled !== undefined) {
+    compiledLandlockRun = bundled;
+    return bundled;
+  }
+
+  const sourceCandidates = [
+    resolve(moduleDirectory, "../../native/agenc-landlock-run.c"),
+    resolve(moduleDirectory, "../native/agenc-landlock-run.c"),
+  ];
+  const sourcePath = sourceCandidates.find((candidate) => {
+    try {
+      return lstatSync(candidate).isFile();
+    } catch {
+      return false;
+    }
+  });
+  if (sourcePath === undefined) return undefined;
+
+  const compiler = ["/usr/bin/cc", "/bin/cc"].find((candidate) => {
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (compiler === undefined) return undefined;
+
+  try {
+    const buildRoot = mkdtempSync(join(tmpdir(), "agenc-landlock-run-"));
+    chmodSync(buildRoot, 0o700);
+    const outputPath = join(buildRoot, LANDLOCK_RUN_NAME);
+    execFileSync(
+      compiler,
+      [
+        "-O2",
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-D_FORTIFY_SOURCE=2",
+        "-fstack-protector-strong",
+        "-Wl,-z,relro,-z,now",
+        "-o",
+        outputPath,
+        sourcePath,
+      ],
+      {
+        env: { LANG: "C", LC_ALL: "C", PATH: "/usr/bin:/bin" },
+        stdio: "pipe",
+      },
+    );
+    compiledLandlockRun = outputPath;
+    return outputPath;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Functional enforcement probe. `--probe` builds and enforces a maximal
+ * ruleset in a short-lived process — a version check would miss a kernel
+ * that has the syscalls but refuses enforcement, so actually restricting is
+ * the only honest signal. Unresolvable launcher, non-zero exit, timeout, or
+ * an unrecognized report line all map to `unusable` (fail closed).
+ */
+export function probeLandlock(launcherPath?: string): LandlockEnforcement {
+  const launcher = launcherPath ?? resolveLandlockRun();
+  if (launcher === undefined) return "unusable";
+  const result = spawnSync(launcher, ["--probe"], {
+    encoding: "utf8",
+    timeout: PROBE_TIMEOUT_MS,
+    env: { LANG: "C", LC_ALL: "C", PATH: "/usr/bin:/bin" },
+    windowsHide: true,
+  });
+  if (result.error !== undefined || result.signal !== null || result.status !== 0) {
+    return "unusable";
+  }
+  const line = (result.stdout ?? "").trim();
+  if (line === "landlock: fully enforced") return "full";
+  if (line === "landlock: partially enforced (older ABI)") return "partial";
+  return "unusable";
+}
+
+/** Grant argv for one confined run; everything not granted is denied. */
+export function landlockGrantArgs(grants: {
+  readonly readOnly?: readonly string[];
+  readonly readWrite?: readonly string[];
+}): string[] {
+  const args: string[] = [];
+  for (const path of grants.readOnly ?? []) args.push("--ro", path);
+  for (const path of grants.readWrite ?? []) args.push("--rw", path);
+  return args;
+}
+
+export type LandlockRunOutcome =
+  | { readonly kind: "launcher-failure"; readonly fatalLine: string }
+  | { readonly kind: "command-outcome" };
+
+/**
+ * Attribute one finished confined run to the launcher or to the wrapped
+ * command. Launcher failure requires the conjunction the CLI contract
+ * guarantees: exit status 125 AND at least one `landlock-run: ` stderr line
+ * that is not the exact partial-enforcement notice. Anything else — including
+ * a child that itself exits 125, or the notice followed by an ordinary
+ * non-zero child exit — is the command's own outcome. This is the
+ * status-gated rule from upstream postmortem 0004, where the notice plus
+ * ripgrep's no-match exit 1 was misread as sandbox failure.
+ */
+export function classifyLandlockRunOutcome(run: {
+  readonly status: number | null;
+  readonly stderr: string;
+}): LandlockRunOutcome {
+  if (run.status !== LANDLOCK_RUN_FAILURE_EXIT) return { kind: "command-outcome" };
+  const fatalLine = run.stderr
+    .split(/\r?\n/)
+    .find(
+      (line) =>
+        line.startsWith(LANDLOCK_RUN_FATAL_PREFIX) &&
+        line.trim() !== LANDLOCK_RUN_PARTIAL_NOTICE,
+    );
+  if (fatalLine === undefined) return { kind: "command-outcome" };
+  return { kind: "launcher-failure", fatalLine };
+}

--- a/runtime/src/utils/doctorDiagnostic.ts
+++ b/runtime/src/utils/doctorDiagnostic.ts
@@ -54,6 +54,7 @@ import {
   SandboxExecutionBroker,
   type SandboxExecutionStatus,
 } from '../sandbox/execution-broker.js'
+import { probeLandlock } from '../sandbox/landlock-run.js'
 import { getManagedFilePath } from './settings/managedPath.js'
 import { CUSTOMIZATION_SURFACES } from './settings/types.js'
 import {
@@ -944,13 +945,18 @@ export async function getSandboxDoctorStatus(opts?: {
     : rawMode === 'danger-full-access'
       ? 'danger_full_access'
       : 'workspace_write'
-  return new SandboxExecutionBroker({
+  const status = await new SandboxExecutionBroker({
     mode,
     cwd: opts?.cwd ?? getCwd() ?? process.cwd(),
     env,
     allowGpu: config?.sandbox?.allow_gpu === true,
     ...(opts?.probe !== undefined ? { probe: opts.probe } : {}),
   }).status()
+  if (process.platform !== 'linux') return status
+  // Report the Landlock rung alongside the bubblewrap status: on hosts where
+  // the user namespace is restricted, this is the confinement the kernel can
+  // still enforce without any profile or privilege.
+  return { ...status, landlock: probeLandlock() }
 }
 
 export function buildSandboxWarning(

--- a/runtime/tests/sandbox/landlock-run.test.ts
+++ b/runtime/tests/sandbox/landlock-run.test.ts
@@ -1,0 +1,198 @@
+import { spawnSync } from "node:child_process";
+import { accessSync, constants as fsConstants, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+
+import {
+  classifyLandlockRunOutcome,
+  landlockGrantArgs,
+  LANDLOCK_RUN_FAILURE_EXIT,
+  LANDLOCK_RUN_PARTIAL_NOTICE,
+  probeLandlock,
+  resolveLandlockRun,
+} from "../../src/sandbox/landlock-run.js";
+
+function hasTrustedCompiler(): boolean {
+  return ["/usr/bin/cc", "/bin/cc"].some((candidate) => {
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+const canRunLive =
+  process.platform === "linux" &&
+  hasTrustedCompiler() &&
+  probeLandlock() !== "unusable";
+
+const work: string[] = [];
+afterAll(() => {
+  for (const dir of work) rmSync(dir, { recursive: true, force: true });
+});
+
+function mkWorkDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "landlock-test-"));
+  work.push(dir);
+  return dir;
+}
+
+function runConfined(
+  grants: Parameters<typeof landlockGrantArgs>[0],
+  command: readonly string[],
+) {
+  const launcher = resolveLandlockRun();
+  expect(launcher).toBeDefined();
+  return spawnSync(
+    launcher!,
+    [...landlockGrantArgs(grants), "--", ...command],
+    { encoding: "utf8", timeout: 15_000 },
+  );
+}
+
+describe("landlockGrantArgs", () => {
+  test("serializes grants in declaration order", () => {
+    expect(
+      landlockGrantArgs({ readOnly: ["/usr", "/lib"], readWrite: ["/tmp"] }),
+    ).toEqual(["--ro", "/usr", "--ro", "/lib", "--rw", "/tmp"]);
+    expect(landlockGrantArgs({})).toEqual([]);
+  });
+});
+
+describe("classifyLandlockRunOutcome", () => {
+  test("launcher failure requires status 125 AND a fatal line", () => {
+    expect(
+      classifyLandlockRunOutcome({
+        status: LANDLOCK_RUN_FAILURE_EXIT,
+        stderr: "landlock-run: cannot open rule path: /x: No such file or directory\n",
+      }),
+    ).toMatchObject({ kind: "launcher-failure" });
+  });
+
+  test("a child's own 125 without fatal evidence stays the command's outcome", () => {
+    expect(
+      classifyLandlockRunOutcome({ status: 125, stderr: "" }),
+    ).toEqual({ kind: "command-outcome" });
+  });
+
+  test("the exact partial notice is informational, never fatal evidence", () => {
+    // Upstream postmortem 0004: this notice plus ripgrep's no-match exit 1
+    // was misread as sandbox failure. Status-gating alone is not enough --
+    // the notice must also be excluded when a child exits 125 on its own.
+    expect(
+      classifyLandlockRunOutcome({
+        status: 1,
+        stderr: `${LANDLOCK_RUN_PARTIAL_NOTICE}\n`,
+      }),
+    ).toEqual({ kind: "command-outcome" });
+    expect(
+      classifyLandlockRunOutcome({
+        status: 125,
+        stderr: `${LANDLOCK_RUN_PARTIAL_NOTICE}\n`,
+      }),
+    ).toEqual({ kind: "command-outcome" });
+  });
+
+  test("notice plus a real fatal line is still launcher failure", () => {
+    const outcome = classifyLandlockRunOutcome({
+      status: 125,
+      stderr:
+        `${LANDLOCK_RUN_PARTIAL_NOTICE}\n` +
+        "landlock-run: exec failed: No such file or directory\n",
+    });
+    expect(outcome).toMatchObject({
+      kind: "launcher-failure",
+      fatalLine: "landlock-run: exec failed: No such file or directory",
+    });
+  });
+
+  test("non-125 statuses are never launcher failures", () => {
+    for (const status of [0, 1, 2, 126, 127, null]) {
+      expect(
+        classifyLandlockRunOutcome({
+          status,
+          stderr: "landlock-run: fatal-looking line\n",
+        }),
+      ).toEqual({ kind: "command-outcome" });
+    }
+  });
+});
+
+describe.runIf(canRunLive)("agenc-landlock-run (live kernel)", () => {
+  test("probe reports enforcement on this kernel", () => {
+    expect(["full", "partial"]).toContain(probeLandlock());
+  });
+
+  test("read is denied outside grants and allowed inside them", () => {
+    const denied = runConfined(
+      { readOnly: ["/usr", "/lib", "/lib64"] },
+      ["/usr/bin/cat", "/etc/hostname"],
+    );
+    expect(denied.status).not.toBe(0);
+    expect(denied.status).not.toBe(LANDLOCK_RUN_FAILURE_EXIT);
+    expect(
+      classifyLandlockRunOutcome({ status: denied.status, stderr: denied.stderr }),
+    ).toEqual({ kind: "command-outcome" });
+
+    const allowed = runConfined(
+      { readOnly: ["/usr", "/lib", "/lib64", "/etc"] },
+      ["/usr/bin/cat", "/etc/hostname"],
+    );
+    expect(allowed.status).toBe(0);
+    expect(allowed.stdout.length).toBeGreaterThan(0);
+  });
+
+  test("write is denied under --ro and allowed under --rw", () => {
+    const dir = mkWorkDir();
+    const target = join(dir, "probe.txt");
+    const denied = runConfined({ readOnly: ["/"] }, [
+      "/bin/sh",
+      "-c",
+      `echo confined > ${target}`,
+    ]);
+    expect(denied.status).not.toBe(0);
+    expect(denied.status).not.toBe(LANDLOCK_RUN_FAILURE_EXIT);
+
+    const allowed = runConfined({ readOnly: ["/"], readWrite: [dir] }, [
+      "/bin/sh",
+      "-c",
+      `echo confined > ${target}`,
+    ]);
+    expect(allowed.status).toBe(0);
+    expect(readFileSync(target, "utf8")).toBe("confined\n");
+  });
+
+  test("the ruleset is inherited by descendants", () => {
+    const dir = mkWorkDir();
+    const target = join(dir, "descendant.txt");
+    // The child spawns a grandchild; the grandchild must be equally confined.
+    const denied = runConfined({ readOnly: ["/"] }, [
+      "/bin/sh",
+      "-c",
+      `/bin/sh -c 'echo escaped > ${target}'`,
+    ]);
+    expect(denied.status).not.toBe(0);
+  });
+
+  test("child exit codes pass through unchanged", () => {
+    const seven = runConfined({ readOnly: ["/"] }, ["/bin/sh", "-c", "exit 7"]);
+    expect(seven.status).toBe(7);
+    const one = runConfined({ readOnly: ["/"] }, ["/bin/false"]);
+    expect(one.status).toBe(1);
+    expect(one.stderr).not.toContain("landlock-run:");
+  });
+
+  test("an unopenable grant root fails closed as a launcher failure", () => {
+    const run = runConfined(
+      { readOnly: ["/definitely-not-a-real-path-xyz"] },
+      ["/bin/true"],
+    );
+    expect(run.status).toBe(LANDLOCK_RUN_FAILURE_EXIT);
+    expect(
+      classifyLandlockRunOutcome({ status: run.status, stderr: run.stderr }),
+    ).toMatchObject({ kind: "launcher-failure" });
+  });
+});


### PR DESCRIPTION
Adoption #2 from the deepseek-harness study. **Foundation slice, deliberately report-only**: vendor the launcher, prove it end to end on a real kernel, and tell the user what their machine can enforce. Wiring it into the execution path is a separate, deliberate change.

## Why Landlock

It is an independent kernel syscall family — no user namespaces, no mount privileges, no LSM profile. That is exactly the gap our sandbox has today: on Ubuntu 24.04+ with `apparmor_restrict_unprivileged_userns=1`, bubblewrap is dead on arrival and the only remediation is a sudo-installed AppArmor profile. Landlock enforces without any of that. This host demonstrates the case:

```
  Sandbox:            unavailable (mode: workspace_write, platform: linux)
    reason:   Linux sandbox helper must be outside the writable workspace
    landlock: fully enforced          ← new
```

## What's in the box

- **`runtime/native/agenc-landlock-run.c`** — vendored verbatim from DeepSeek Harness's `landlock-run` (MIT, commit `47f943859`), ~280 lines of C11 over the raw Landlock UAPI, self-defining the ABI so the build is independent of header vintage. Self-restrict-then-exec: installs the ruleset on itself, execs the command; the ruleset is inherited across `execve`, so every descendant is equally confined. Fail-closed when the kernel cannot enforce. The CLI contract (`--ro/--rw` grants, `--probe`, the `landlock-run: ` prefix, exit 125) is preserved **verbatim** so upstream fixes stay diffable and the calibrated classification below holds.
- **Build**: mirrors the process broker exactly — compiled to `dist/` by `build.config.ts` with the same hardened flags, listed in `agencExecutableFiles`, compiled on demand from source with the trusted-compiler pattern (fixed absolute compiler paths, 0700 build dir) when no bundled binary exists.
- **`src/sandbox/landlock-run.ts`** — resolution across both bundle geometries, functional probe (`full`/`partial`/`unusable`; actually restricting a short-lived process is the only honest signal — a version check would miss a kernel that has the syscalls but refuses enforcement), grant serialization, and outcome classification.
- **Classification is postmortem-calibrated**: upstream's postmortem 0004 documents how the partial-ABI notice plus ripgrep's no-match exit 1 got misread as sandbox failure. Launcher failure here requires the conjunction — exit **125** AND a `landlock-run: ` fatal line — after excluding the **exact** informational notice. Falsification-checked: removing the exclusion fails exactly that test.

## Live verification (kernel ABI 8)

| Semantics | |
|---|---|
| Read outside grants denied / inside allowed | ✅ |
| Write denied under `--ro`, allowed under `--rw` | ✅ |
| Descendants inherit the ruleset | ✅ |
| Child exits pass through (7→7, `false`→1, no launcher lines) | ✅ |
| Unopenable grant root fails closed at 125 | ✅ |
| Built `agenc doctor` prints the enforcement line | ✅ |

12 landlock tests (live suite self-skips without linux + trusted cc + enforceable kernel, per the pwsh precedent), supervisedProcess 29, doctor suites 27, typecheck and build clean. `REQUIRED_GATE_RED_PROBE_POLICY_PATHS` untouched — no gate-policy rotation needed.

## Next (separate PRs)

1. Execution-path fallback: when bwrap is unavailable and the probe reports `full`, offer Landlock confinement for `PermissionProfile` mounts (path grants map directly; network stays seccomp's job).
2. Installer note: replace the bare sudo remediation with "or rely on Landlock" once the fallback lands.