### PR TITLE
feat(sandbox): teach the Landlock launcher to install a seccomp program by fd

### DIFF
--- a/runtime/native/agenc-landlock-run.c
+++ b/runtime/native/agenc-landlock-run.c
@@ -14,6 +14,18 @@
  * Compiled on demand from source with the trusted-compiler pattern used by
  * runtime/native/agenc-process-broker.c; nothing beyond libc and the stable
  * kernel UAPI below.
+ *
+ * AgenC EXTENSION over the upstream contract (everything else is verbatim):
+ *   --seccomp <fd>   read one classic-BPF seccomp program (sock_filter[])
+ *                    fully from the inherited descriptor and install it with
+ *                    prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER) after the
+ *                    Landlock restrict, before exec. This mirrors
+ *                    bubblewrap's `--seccomp FD` so the same network filter
+ *                    AgenC hands bwrap confines the no-userns fallback too.
+ *                    Fatal (exit 125) on a missing, empty, oversized,
+ *                    misaligned, or unloadable program: the caller asked for
+ *                    network confinement, so running without it is not an
+ *                    acceptable degradation.
  */
 #define _GNU_SOURCE
 #include <errno.h>
@@ -91,6 +103,26 @@ struct landlock_path_beneath_attr {
  */
 #define EXIT_LAUNCHER_FAILURE 125
 
+/*
+ * Classic-BPF seccomp UAPI, self-defined like the Landlock structs above.
+ * Layouts are verbatim from <linux/filter.h> / <linux/seccomp.h>.
+ */
+struct sock_filter_local {
+  uint16_t code;
+  uint8_t jt;
+  uint8_t jf;
+  uint32_t k;
+};
+
+struct sock_fprog_local {
+  unsigned short len;
+  struct sock_filter_local *filter;
+};
+
+#define SECCOMP_MODE_FILTER_LOCAL 2
+#define BPF_MAXINSNS_LOCAL 4096
+#define SECCOMP_PROGRAM_MAX_BYTES (BPF_MAXINSNS_LOCAL * sizeof(struct sock_filter_local))
+
 static const char NOT_ENFORCED_MESSAGE[] =
   "landlock is not enforced by this kernel (ABI unsupported or disabled)";
 
@@ -116,6 +148,7 @@ struct cli {
   size_t ro_count;
   const char **rw;
   size_t rw_count;
+  int seccomp_fd; /* -1 when no --seccomp was given */
   char **command; /* NULL-terminated tail of main's argv */
 };
 
@@ -138,6 +171,20 @@ static int parse(int argc, char **argv, struct cli *cli) {
       }
       cli->probe = 1;
       index += 1;
+    } else if (strcmp(arg, "--seccomp") == 0) {
+      if (index + 1 >= argc) {
+        return fail_usage(arg, " requires a descriptor number");
+      }
+      if (cli->seccomp_fd >= 0) {
+        return fail_usage("--seccomp may be given only once", NULL);
+      }
+      char *end = NULL;
+      long fd = strtol(argv[index + 1], &end, 10);
+      if (end == NULL || *end != '\0' || fd < 0 || fd > 1024) {
+        return fail_usage("--seccomp descriptor must be a small non-negative integer", NULL);
+      }
+      cli->seccomp_fd = (int)fd;
+      index += 2;
     } else if (strcmp(arg, "--ro") == 0 || strcmp(arg, "--rw") == 0) {
       if (index + 1 >= argc) {
         return fail_usage(arg, " requires a path");
@@ -241,8 +288,51 @@ static int restrict_self(const struct cli *cli, int *partial) {
   return 0;
 }
 
+/*
+ * Read one classic-BPF program fully from `fd` and install it as this
+ * thread's seccomp filter. no_new_privs is already set by restrict_self().
+ * Every failure is fatal: the caller asked for this confinement.
+ */
+static int install_seccomp_program(int fd) {
+  static uint8_t bytes[SECCOMP_PROGRAM_MAX_BYTES];
+  size_t total = 0;
+  for (;;) {
+    if (total == sizeof bytes) {
+      /* One more byte distinguishes exactly-full from oversized. */
+      uint8_t overflow;
+      ssize_t extra = read(fd, &overflow, 1);
+      if (extra == 0) break;
+      if (extra < 0 && errno == EINTR) continue;
+      return fail("seccomp program exceeds the classic-BPF instruction limit", NULL);
+    }
+    ssize_t got = read(fd, bytes + total, sizeof bytes - total);
+    if (got < 0) {
+      if (errno == EINTR) continue;
+      return fail("cannot read seccomp program", strerror(errno));
+    }
+    if (got == 0) break;
+    total += (size_t)got;
+  }
+  close(fd);
+  if (total == 0) {
+    return fail("seccomp program is empty", NULL);
+  }
+  if (total % sizeof(struct sock_filter_local) != 0) {
+    return fail("seccomp program is not a whole number of BPF instructions", NULL);
+  }
+  struct sock_fprog_local program = {
+    .len = (unsigned short)(total / sizeof(struct sock_filter_local)),
+    .filter = (struct sock_filter_local *)bytes,
+  };
+  if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER_LOCAL, &program) != 0) {
+    return fail("cannot install seccomp program", strerror(errno));
+  }
+  return 0;
+}
+
 int main(int argc, char **argv) {
   struct cli cli = { 0 };
+  cli.seccomp_fd = -1;
   int code = parse(argc, argv, &cli);
   if (code != 0) return code;
 
@@ -265,6 +355,10 @@ int main(int argc, char **argv) {
   int partial = 0;
   code = restrict_self(&cli, &partial);
   if (code != 0) return code;
+  if (cli.seccomp_fd >= 0) {
+    code = install_seccomp_program(cli.seccomp_fd);
+    if (code != 0) return code;
+  }
   if (partial) {
     /* Older ABI: some handled accesses are not governed (e.g. truncate
      * before ABI 3). Still confined for everything the kernel supports —

--- a/runtime/src/sandbox/landlock-run.ts
+++ b/runtime/src/sandbox/landlock-run.ts
@@ -182,6 +182,26 @@ export function landlockGrantArgs(grants: {
   return args;
 }
 
+/**
+ * Full launch argv (grants plus the optional seccomp descriptor), ending with
+ * the `--` separator so callers append the command directly. The descriptor
+ * mirrors bubblewrap's `--seccomp FD` contract: the same classic-BPF network
+ * program AgenC hands bwrap confines the no-userns fallback identically, and
+ * the launcher fails closed (exit 125) on a missing or malformed program.
+ */
+export function landlockLaunchArgs(options: {
+  readonly readOnly?: readonly string[];
+  readonly readWrite?: readonly string[];
+  readonly seccompFd?: number;
+}): string[] {
+  const args = landlockGrantArgs(options);
+  if (options.seccompFd !== undefined) {
+    args.push("--seccomp", String(options.seccompFd));
+  }
+  args.push("--");
+  return args;
+}
+
 export type LandlockRunOutcome =
   | { readonly kind: "launcher-failure"; readonly fatalLine: string }
   | { readonly kind: "command-outcome" };

--- a/runtime/tests/sandbox/landlock-run.test.ts
+++ b/runtime/tests/sandbox/landlock-run.test.ts
@@ -1,5 +1,14 @@
 import { spawnSync } from "node:child_process";
-import { accessSync, constants as fsConstants, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  accessSync,
+  closeSync,
+  constants as fsConstants,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, test } from "vitest";
@@ -7,11 +16,13 @@ import { afterAll, describe, expect, test } from "vitest";
 import {
   classifyLandlockRunOutcome,
   landlockGrantArgs,
+  landlockLaunchArgs,
   LANDLOCK_RUN_FAILURE_EXIT,
   LANDLOCK_RUN_PARTIAL_NOTICE,
   probeLandlock,
   resolveLandlockRun,
 } from "../../src/sandbox/landlock-run.js";
+import { createNetworkSeccompProgram } from "../../src/sandbox/linux-launcher/landlock.js";
 
 function hasTrustedCompiler(): boolean {
   return ["/usr/bin/cc", "/bin/cc"].some((candidate) => {
@@ -196,3 +207,116 @@ describe.runIf(canRunLive)("agenc-landlock-run (live kernel)", () => {
     ).toMatchObject({ kind: "launcher-failure" });
   });
 });
+
+const PYTHON = "/usr/bin/python3";
+const canRunSeccompLive =
+  canRunLive &&
+  (() => {
+    try {
+      accessSync(PYTHON, fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+function runWithSeccomp(
+  program: Buffer | undefined,
+  command: readonly string[],
+  extra?: { readonly readWrite?: readonly string[] },
+) {
+  const launcher = resolveLandlockRun();
+  expect(launcher).toBeDefined();
+  const dir = mkWorkDir();
+  let stdioFd: number | undefined;
+  if (program !== undefined) {
+    const programPath = join(dir, "net.bpf");
+    writeFileSync(programPath, program);
+    stdioFd = openSync(programPath, "r");
+  }
+  try {
+    return spawnSync(
+      launcher!,
+      [
+        ...landlockLaunchArgs({
+          readOnly: ["/"],
+          ...(extra?.readWrite !== undefined ? { readWrite: extra.readWrite } : {}),
+          ...(stdioFd !== undefined ? { seccompFd: 3 } : {}),
+        }),
+        ...command,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+        stdio:
+          stdioFd !== undefined
+            ? ["ignore", "pipe", "pipe", stdioFd]
+            : ["ignore", "pipe", "pipe"],
+      },
+    );
+  } finally {
+    if (stdioFd !== undefined) closeSync(stdioFd);
+  }
+}
+
+describe.runIf(canRunSeccompLive)(
+  "agenc-landlock-run --seccomp (live kernel)",
+  () => {
+    const SOCKET_PROBE = [
+      PYTHON,
+      "-c",
+      "import socket\n" +
+        "try:\n" +
+        "  socket.socket(socket.AF_INET)\n" +
+        "  print('inet-open')\n" +
+        "except PermissionError:\n" +
+        "  print('inet-denied')\n" +
+        "socket.socket(socket.AF_UNIX)\n" +
+        "print('unix-open')",
+    ] as const;
+
+    test("without a program, AF_INET sockets open", () => {
+      const run = runWithSeccomp(undefined, [...SOCKET_PROBE]);
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain("inet-open");
+    });
+
+    test("the same BPF program AgenC hands bwrap denies AF_INET and keeps AF_UNIX", () => {
+      const program = createNetworkSeccompProgram("restricted");
+      const run = runWithSeccomp(program, [...SOCKET_PROBE]);
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain("inet-denied");
+      expect(run.stdout).toContain("unix-open");
+    });
+
+    test("filesystem and network confinement hold in one run", () => {
+      const program = createNetworkSeccompProgram("restricted");
+      const dir = mkWorkDir();
+      const target = join(dir, "combined.txt");
+      const run = runWithSeccomp(program, [
+        "/bin/sh",
+        "-c",
+        `if echo x > ${target} 2>/dev/null; then echo write-open; else echo write-denied; fi; ` +
+          `${PYTHON} -c "import socket\ntry:\n  socket.socket(socket.AF_INET)\n  print('inet-open')\nexcept PermissionError:\n  print('inet-denied')"`,
+      ]);
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain("write-denied");
+      expect(run.stdout).toContain("inet-denied");
+    });
+
+    test("a malformed program fails closed as a launcher failure", () => {
+      const run = runWithSeccomp(Buffer.from("abcdefg"), ["/bin/true"]);
+      expect(run.status).toBe(LANDLOCK_RUN_FAILURE_EXIT);
+      expect(
+        classifyLandlockRunOutcome({ status: run.status, stderr: run.stderr }),
+      ).toMatchObject({ kind: "launcher-failure" });
+      expect(run.stderr).toContain("whole number of BPF instructions");
+    });
+
+    test("an empty program fails closed", () => {
+      const run = runWithSeccomp(Buffer.alloc(0), ["/bin/true"]);
+      expect(run.status).toBe(LANDLOCK_RUN_FAILURE_EXIT);
+      expect(run.stderr).toContain("seccomp program is empty");
+    });
+  },
+);


### PR DESCRIPTION
Second slice of the Landlock adoption, resolving the design fork recorded on #1733: **network confinement parity**.

## The fork

Under bubblewrap, AgenC's network story is `--unshare-net` plus a classic-BPF seccomp program **bwrap itself applies** (`--seccomp <fd>`). The vendored Landlock launcher confined the filesystem only, so a naive fallback would silently stop confining the network on exactly the hosts that fall back — the silent-degradation class this codebase refuses everywhere else.

## Resolution: mirror bwrap's contract in the launcher

`--seccomp <fd>` reads one classic-BPF program fully from the inherited descriptor and installs it via `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER)` **after** the Landlock restrict, before exec (`no_new_privs` is already set by the restrict). One self-restrict-then-exec binary now carries both confinement classes, still with no user namespaces.

Fail-closed by contract: empty, misaligned, oversized (>4096 BPF instructions), unreadable, or kernel-rejected programs are all fatal at exit 125 — the caller asked for network confinement, so running without it is not an acceptable degradation. The extension is documented in the vendored header as **the one divergence** from the upstream contract; everything else stays verbatim so upstream fixes remain diffable.

## Live verification (this kernel, ABI 8)

Using the **exact** program AgenC hands bwrap (`createNetworkSeccompProgram("restricted")`):

| | |
|---|---|
| `socket(AF_INET)` without a program | opens |
| `socket(AF_INET)` under the program | **EPERM** |
| `socket(AF_UNIX)` under the same program | still allowed |
| Write denied + AF_INET denied in ONE run (fs + net together) | ✅ |
| Malformed program (7 bytes) | 125 + `not a whole number of BPF instructions` |
| Empty program | 125 + `seccomp program is empty` |

`landlockLaunchArgs({readOnly, readWrite, seccompFd})` adds the descriptor plumbing the broker integration will consume.

Falsification-checked: removing the alignment check fails exactly the malformed-program test. Suite 17 passed (live seccomp cases self-skip without `/usr/bin/python3`), typecheck and build clean.

## Remaining for the fallback (next PR)

Broker integration: when the bwrap chain fails and the probe reports `full`, return a ready status carrying the Landlock program; spawn path maps `PermissionProfile` mounts to grants and hands over the same seccomp fd. Then the installer note loses its unconditional sudo step.