### PR TITLE
feat(sandbox): fall back to Landlock when bubblewrap is unavailable

### DIFF
--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -10,6 +10,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { probeLandlock, resolveLandlockRun } from "./landlock-run.js";
 import { realpathSync, statSync } from "node:fs";
 import path, { basename, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -528,21 +529,46 @@ function probeLinuxSandbox(options: {
       "Install AgenC with its executable sandbox helper outside the workspace, then run `agenc doctor` again.",
     );
   }
-  const bwrap = findSystemBubblewrapInPath(options.env.PATH, options.cwd);
-  if (bwrap === null) {
+  // When any bubblewrap rung fails, the helper falls back to Landlock at
+  // spawn time for the policies an allow-list can express. The probe mirrors
+  // that decision so startup readiness matches what commands will actually
+  // do; the per-policy refusals stay with the helper, which sees the policy.
+  const landlockFallback = (
+    bwrapReason: string,
+    bwrapRemediation: string,
+    isolationProgram?: string,
+  ): SandboxExecutionStatus => {
+    const launcher = resolveLandlockRun();
+    if (launcher !== undefined && probeLandlock(launcher) === "full") {
+      return {
+        kind: "ready",
+        mode: options.mode,
+        platform: options.platform,
+        helperPath: helper.path,
+        isolationProgram: launcher,
+        reason: `${bwrapReason}; the Landlock fallback is active`,
+        landlock: "full",
+      };
+    }
     return unavailableStatus(
       options,
+      bwrapReason,
+      bwrapRemediation,
+      helper.path,
+      isolationProgram,
+    );
+  };
+  const bwrap = findSystemBubblewrapInPath(options.env.PATH, options.cwd);
+  if (bwrap === null) {
+    return landlockFallback(
       "bubblewrap was not found in a trusted system directory",
       "Install bubblewrap with the OS package manager, then run `agenc doctor` again.",
-      helper.path,
     );
   }
   if (!systemBubblewrapSupportsBindFd(bwrap, options.env)) {
-    return unavailableStatus(
-      options,
+    return landlockFallback(
       "bubblewrap does not support descriptor-based read-only binds",
       "Upgrade bubblewrap to a version that supports --ro-bind-fd, then run `agenc doctor` again.",
-      helper.path,
       bwrap,
     );
   }
@@ -572,11 +598,9 @@ function probeLinuxSandbox(options: {
     const detail = boundedDiagnostic(
       result.error?.message ?? result.stderr ?? `exit status ${String(result.status)}`,
     );
-    return unavailableStatus(
-      options,
+    return landlockFallback(
       `probe: bubblewrap could not create the required namespaces${detail ? ` (${detail})` : ""}`,
       linuxSandboxProbeRemediation(detail),
-      helper.path,
       bwrap,
     );
   }

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -538,7 +538,10 @@ function probeLinuxSandbox(options: {
     bwrapRemediation: string,
     isolationProgram?: string,
   ): SandboxExecutionStatus => {
-    const launcher = resolveLandlockRun();
+    // Operational kill-switch: with the fallback disabled, the original
+    // fail-closed bubblewrap contract holds verbatim.
+    const disabled = options.env.AGENC_DISABLE_LANDLOCK_FALLBACK === "1";
+    const launcher = disabled ? undefined : resolveLandlockRun();
     if (launcher !== undefined && probeLandlock(launcher) === "full") {
       return {
         kind: "ready",

--- a/runtime/src/sandbox/landlock-run.ts
+++ b/runtime/src/sandbox/landlock-run.ts
@@ -81,10 +81,12 @@ export function resolveLandlockRun(): string | undefined {
 
   const moduleDirectory = dirname(fileURLToPath(import.meta.url));
   // The build compiles the launcher to the dist ROOT; this module may be
-  // bundled into a root chunk or under dist/bin, so probe both geometries.
+  // bundled into a root chunk, under dist/bin, or into the sandbox helper at
+  // dist/sandbox/linux-launcher, so probe all three geometries.
   const bundledCandidates = [
     join(moduleDirectory, LANDLOCK_RUN_NAME),
     resolve(moduleDirectory, "..", LANDLOCK_RUN_NAME),
+    resolve(moduleDirectory, "..", "..", LANDLOCK_RUN_NAME),
   ];
   const bundled = bundledCandidates.find(isExecutableFile);
   if (bundled !== undefined) {
@@ -95,6 +97,7 @@ export function resolveLandlockRun(): string | undefined {
   const sourceCandidates = [
     resolve(moduleDirectory, "../../native/agenc-landlock-run.c"),
     resolve(moduleDirectory, "../native/agenc-landlock-run.c"),
+    resolve(moduleDirectory, "../../../native/agenc-landlock-run.c"),
   ];
   const sourcePath = sourceCandidates.find((candidate) => {
     try {

--- a/runtime/src/sandbox/linux-launcher/landlock-exec.ts
+++ b/runtime/src/sandbox/linux-launcher/landlock-exec.ts
@@ -1,0 +1,242 @@
+/**
+ * Landlock confinement planning for the Linux sandbox helper.
+ *
+ * When bubblewrap is unusable (not installed, or unprivileged user
+ * namespaces restricted by AppArmor), the helper can confine through
+ * `agenc-landlock-run` instead: a pure kernel allow-list needing no
+ * namespaces, plus the same classic-BPF network filter bwrap applies.
+ *
+ * Landlock can express strictly LESS than bubblewrap — it is an allow-list
+ * with no mounts, no masking, and no namespaces — so this module's first
+ * job is refusing what it cannot express, loudly, instead of running with a
+ * weaker profile than the caller asked for:
+ *
+ * - **Unreadable masks**: bwrap hides `unreadable` roots/globs by mounting
+ *   over them. An allow-list cannot deny inside an allowed subtree, so any
+ *   unreadable entry (outside /proc and /sys, which are never granted)
+ *   refuses the fallback.
+ * - **Read-only carve-outs inside writable roots** (`readOnlySubpaths`) and
+ *   **protected metadata** monitoring: deny-inside-allow again; refused.
+ * - **Managed proxy networking**: needs a network namespace; refused.
+ * - **Inherited read-only cwd**: bound by descriptor under bwrap; refused.
+ *
+ * `mountProc` is deliberately NOT a refusal: under bubblewrap it mounts a
+ * PRIVATE procfs as an environment convenience, and without namespaces the
+ * fallback simply provides no /proc at all -- strictly more closed, with
+ * /proc-dependent commands failing visibly instead of silently.
+ *
+ * /proc and /sys are NEVER granted, even under full-disk-read policies.
+ * Without a pid namespace, host /proc would expose same-uid process state —
+ * `/proc/<pid>/environ` of the daemon carries provider credentials — so the
+ * fallback trades /proc-dependent commands (they fail visibly with EACCES)
+ * for keeping that channel closed.
+ *
+ * @module
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  getReadableRootsWithCwd,
+  getUnreadableGlobsWithCwd,
+  getUnreadableRootsWithCwd,
+  getWritableRootsWithCwd,
+  hasFullDiskReadAccess,
+  includePlatformDefaults,
+  type FileSystemSandboxPolicy,
+} from "../engine/index.js";
+
+/** Root directories never granted, whatever the policy says. */
+const NEVER_GRANTED_ROOTS = new Set(["/proc", "/sys"]);
+
+/**
+ * Character devices commands routinely open for write (`> /dev/null`, PTY
+ * allocation). bwrap provides them through a fresh minimal devtmpfs; the
+ * fallback grants exactly these, and a file grant keeps only file-compatible
+ * access bits, so a device grant cannot leak directory-level access.
+ */
+const STANDARD_DEVICE_GRANTS = [
+  "/dev/null",
+  "/dev/zero",
+  "/dev/full",
+  "/dev/random",
+  "/dev/urandom",
+  "/dev/tty",
+  "/dev/ptmx",
+  "/dev/pts",
+];
+
+export interface LandlockPlanInput {
+  readonly fileSystem: FileSystemSandboxPolicy;
+  readonly sandboxPolicyCwd: string;
+  readonly allowNetworkForProxy: boolean;
+  readonly inheritedCwd: boolean;
+  readonly extraReadOnlyBindRoots?: readonly string[];
+  readonly extraDeviceBindPaths?: readonly string[];
+}
+
+export type LandlockPlan =
+  | {
+      readonly kind: "ok";
+      readonly readOnly: readonly string[];
+      readonly readWrite: readonly string[];
+      /**
+       * Protected metadata paths that do not exist yet: enforcement cannot
+       * subtract them from a writable subtree, so their CREATION is watched
+       * by the same protected-create monitor the bubblewrap path uses, and
+       * a run that creates one fails.
+       */
+      readonly protectedCreateTargets: readonly string[];
+    }
+  | { readonly kind: "refused"; readonly reason: string };
+
+function underNeverGranted(target: string): boolean {
+  return [...NEVER_GRANTED_ROOTS].some(
+    (root) => target === root || target.startsWith(`${root}/`),
+  );
+}
+
+/**
+ * Grant the read side of full disk access by enumerating the filesystem
+ * root's entries instead of granting `/` itself: this is what keeps /proc
+ * and /sys out of the allow-list while everything else stays readable.
+ */
+function enumeratedRootGrants(): string[] {
+  const grants: string[] = [];
+  for (const entry of fs.readdirSync("/")) {
+    const absolute = `/${entry}`;
+    if (NEVER_GRANTED_ROOTS.has(absolute)) continue;
+    grants.push(absolute);
+  }
+  return grants;
+}
+
+export function planLandlockConfinement(input: LandlockPlanInput): LandlockPlan {
+  if (input.allowNetworkForProxy) {
+    return {
+      kind: "refused",
+      reason: "managed proxy networking requires a network namespace",
+    };
+  }
+  if (input.inheritedCwd) {
+    return {
+      kind: "refused",
+      reason: "inherited read-only cwd requires descriptor binds",
+    };
+  }
+
+  const policy = input.fileSystem;
+  const cwd = input.sandboxPolicyCwd;
+
+  const unreadable = [
+    ...getUnreadableRootsWithCwd(policy, cwd),
+    // Globs are patterns over host state; whether they match anything NOW
+    // says nothing about the confined command's lifetime, so their presence
+    // alone refuses (matching bwrap's mask-at-launch would be a race).
+    ...getUnreadableGlobsWithCwd(policy, cwd),
+  ].filter((target) => !underNeverGranted(target));
+  if (unreadable.length > 0) {
+    return {
+      kind: "refused",
+      reason:
+        "the policy hides paths from reads, which an allow-list cannot express: " +
+        unreadable.slice(0, 3).join(", "),
+    };
+  }
+
+  const writableRoots = getWritableRootsWithCwd(policy, cwd);
+  const protectedCreateTargets: string[] = [];
+  for (const root of writableRoots) {
+    // Landlock rulesets compose by union along the path hierarchy: a grant
+    // on the root covers its whole subtree, and nothing can subtract a
+    // child. An EXISTING protected subpath (a real .git under a writable
+    // workspace) therefore cannot be kept read-only, and running without
+    // that protection would let a confined command rewrite hooks that
+    // execute unconfined later -- refuse. A subpath that does not exist yet
+    // has nothing to protect from writes; its creation is watched instead.
+    for (const subpath of root.readOnlySubpaths) {
+      if (fs.existsSync(subpath)) {
+        return {
+          kind: "refused",
+          reason:
+            "a writable root carries an existing read-only subpath, which " +
+            `an allow-list cannot express: ${subpath}`,
+        };
+      }
+      protectedCreateTargets.push(subpath);
+    }
+    for (const name of root.protectedMetadataNames ?? []) {
+      const target = path.join(root.root, name);
+      if (fs.existsSync(target)) {
+        return {
+          kind: "refused",
+          reason:
+            "a writable root carries existing protected metadata, which " +
+            `an allow-list cannot express: ${target}`,
+        };
+      }
+      protectedCreateTargets.push(target);
+    }
+  }
+
+  const readOnly = new Set<string>();
+  if (hasFullDiskReadAccess(policy)) {
+    for (const grant of enumeratedRootGrants()) readOnly.add(grant);
+  } else {
+    if (includePlatformDefaults(policy)) {
+      for (const root of [
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib64",
+        "/usr",
+        "/etc",
+        "/nix/store",
+        "/run/current-system/sw",
+      ]) {
+        if (fs.existsSync(root)) readOnly.add(root);
+      }
+    }
+    for (const root of getReadableRootsWithCwd(policy, cwd)) {
+      if (underNeverGranted(root)) continue;
+      if (fs.existsSync(root)) readOnly.add(root);
+    }
+  }
+  for (const root of input.extraReadOnlyBindRoots ?? []) {
+    if (underNeverGranted(root)) continue;
+    if (fs.existsSync(root)) readOnly.add(root);
+  }
+
+  const readWrite = new Set<string>();
+  for (const root of writableRoots) {
+    readWrite.add(root.root);
+  }
+  for (const device of STANDARD_DEVICE_GRANTS) {
+    if (fs.existsSync(device)) readWrite.add(device);
+  }
+  for (const device of input.extraDeviceBindPaths ?? []) {
+    if (fs.existsSync(device)) readWrite.add(device);
+  }
+
+  // A grant that is a strict child of another grant on the same side is
+  // redundant; keep the argv short and the audit reviewable.
+  const compact = (grants: Set<string>): string[] => {
+    const sorted = [...grants].sort();
+    const kept: string[] = [];
+    for (const grant of sorted) {
+      if (kept.some((parent) => grant === parent || grant.startsWith(`${parent}${path.sep}`))) {
+        continue;
+      }
+      kept.push(grant);
+    }
+    return kept;
+  };
+
+  return {
+    kind: "ok",
+    readOnly: compact(readOnly),
+    readWrite: compact(readWrite),
+    protectedCreateTargets: [...new Set(protectedCreateTargets)],
+  };
+}

--- a/runtime/src/sandbox/linux-launcher/linux-run-main.ts
+++ b/runtime/src/sandbox/linux-launcher/linux-run-main.ts
@@ -18,8 +18,15 @@ import {
 } from "./config.js";
 import {
   networkSeccompMode,
+  openNetworkSeccompProgramFile,
   type NetworkSeccompMode,
 } from "./landlock.js";
+import { planLandlockConfinement } from "./landlock-exec.js";
+import {
+  landlockLaunchArgs,
+  probeLandlock,
+  resolveLandlockRun,
+} from "../landlock-run.js";
 import {
   preferredBubblewrapLauncher,
   spawnBubblewrap,
@@ -172,9 +179,20 @@ async function runLinuxSandboxOptions(
     }
     const launcher = (deps.preferredLauncher ?? preferredBubblewrapLauncher)();
     if (launcher === null) {
-      throw new Error(
-        "AgenC could not find bubblewrap on PATH; install bubblewrap or configure agenc-linux-sandbox to a valid helper",
-      );
+      // Bubblewrap is unusable. Before failing, try the Landlock rung: a
+      // kernel allow-list needing no namespaces, carrying the same network
+      // seccomp program bwrap would have applied. The plan refuses loudly
+      // when the policy needs something an allow-list cannot express, so
+      // this path never runs weaker confinement than the caller asked for.
+      return await runUnderLandlockFallback({
+        options,
+        fileSystem,
+        seccompMode: bwrapSeccompMode,
+        extraReadOnlyBindRoots,
+        extraDeviceBindPaths,
+        hostCommandCwd,
+        env,
+      });
     }
     if (options.inheritedCwd && launcher.supportsBindFd !== true) {
       throw new Error(
@@ -235,6 +253,81 @@ async function runLinuxSandboxOptions(
   } finally {
     preparedProxy?.cleanup();
     if (inheritedCwdFd !== undefined) fs.closeSync(inheritedCwdFd);
+  }
+}
+
+async function runUnderLandlockFallback(input: {
+  readonly options: LinuxSandboxLauncherOptions;
+  readonly fileSystem: FileSystemSandboxPolicy;
+  readonly seccompMode: NetworkSeccompMode | null;
+  readonly extraReadOnlyBindRoots: readonly string[];
+  readonly extraDeviceBindPaths: readonly string[];
+  readonly hostCommandCwd: string;
+  readonly env: NodeJS.ProcessEnv;
+}): Promise<number> {
+  const unavailable =
+    "AgenC could not find bubblewrap on PATH; install bubblewrap or " +
+    "configure agenc-linux-sandbox to a valid helper";
+  const launcherPath = resolveLandlockRun();
+  if (launcherPath === undefined || probeLandlock(launcherPath) !== "full") {
+    throw new Error(
+      `${unavailable}; the Landlock fallback is also unavailable on this kernel`,
+    );
+  }
+  const plan = planLandlockConfinement({
+    fileSystem: input.fileSystem,
+    sandboxPolicyCwd: input.options.sandboxPolicyCwd,
+    allowNetworkForProxy: input.options.allowNetworkForProxy,
+    inheritedCwd: input.options.inheritedCwd,
+    extraReadOnlyBindRoots: input.extraReadOnlyBindRoots,
+    extraDeviceBindPaths: input.extraDeviceBindPaths,
+  });
+  if (plan.kind === "refused") {
+    throw new Error(
+      "bubblewrap is unavailable and the Landlock fallback cannot express " +
+        `this policy: ${plan.reason}`,
+    );
+  }
+  // Proxy mode was refused above, so the bwrap-equivalent seccomp decision
+  // applies directly; the launcher installs the program itself, so no inner
+  // helper stage runs inside the sandbox.
+  const program =
+    input.seccompMode === null
+      ? null
+      : openNetworkSeccompProgramFile(input.seccompMode);
+  try {
+    const args = [
+      ...landlockLaunchArgs({
+        readOnly: plan.readOnly,
+        readWrite: plan.readWrite,
+        ...(program === null ? {} : { seccompFd: program.stdioFd }),
+      }),
+      ...input.options.command,
+    ];
+    const child = spawn(launcherPath, args, {
+      cwd: input.hostCommandCwd,
+      env: input.env,
+      stdio:
+        program === null
+          ? "inherit"
+          : ["inherit", "inherit", "inherit", program.fd],
+    });
+    // Same post-hoc guarantee as the bubblewrap path: creating a protected
+    // metadata target during the run fails the run even when the command
+    // itself exits 0.
+    const protectedMonitor = startProtectedCreateMonitor([
+      ...plan.protectedCreateTargets,
+    ]);
+    let protectedCreateViolation = false;
+    try {
+      const exitCode = await waitForChildWithSignalRelay(child);
+      protectedCreateViolation = protectedMonitor.stop();
+      return protectedCreateViolation && exitCode === 0 ? 1 : exitCode;
+    } finally {
+      if (!protectedCreateViolation) protectedMonitor.stop();
+    }
+  } finally {
+    program?.cleanup();
   }
 }
 

--- a/runtime/src/sandbox/linux-launcher/linux-run-main.ts
+++ b/runtime/src/sandbox/linux-launcher/linux-run-main.ts
@@ -268,6 +268,9 @@ async function runUnderLandlockFallback(input: {
   const unavailable =
     "AgenC could not find bubblewrap on PATH; install bubblewrap or " +
     "configure agenc-linux-sandbox to a valid helper";
+  if (input.env.AGENC_DISABLE_LANDLOCK_FALLBACK === "1") {
+    throw new Error(unavailable);
+  }
   const launcherPath = resolveLandlockRun();
   if (launcherPath === undefined || probeLandlock(launcherPath) !== "full") {
     throw new Error(

--- a/runtime/tests/bin/bootstrap-sandbox-startup.test.ts
+++ b/runtime/tests/bin/bootstrap-sandbox-startup.test.ts
@@ -27,6 +27,11 @@ describe("production sandbox startup boundary", () => {
           AGENC_HOME: home,
           HOME: home,
           PATH: join(workspace, "untrusted-bin"),
+          // Pin the pre-fallback contract: with the Landlock fallback
+          // disabled, a bubblewrap-less host must still fail closed before
+          // provider setup. The fallback-active boot is covered by the
+          // broker probe suite.
+          AGENC_DISABLE_LANDLOCK_FALLBACK: "1",
         },
         argv: ["node", "agenc"],
         requireSandboxReadyAtStartup: true,

--- a/runtime/tests/sandbox/execution-broker-bind-fd.test.ts
+++ b/runtime/tests/sandbox/execution-broker-bind-fd.test.ts
@@ -71,16 +71,30 @@ describe("Linux sandbox bubblewrap readiness", () => {
         agencLinuxSandboxExe: helper,
       });
 
-      expect(status).toEqual({
-        kind: "unavailable",
-        mode: "workspace_write",
-        platform: "linux",
-        reason: "bubblewrap does not support descriptor-based read-only binds",
-        remediation:
-          "Upgrade bubblewrap to a version that supports --ro-bind-fd, then run `agenc doctor` again.",
-        helperPath: realpathSync(helper),
-        isolationProgram: bwrap,
-      });
+      // Contract update with the Landlock fallback: a bind-fd rejection no
+      // longer terminates the probe. The ONLY post-rejection spawn permitted
+      // is the Landlock enforcement probe -- never bubblewrap's namespace
+      // probe -- and on a kernel that enforces, the status becomes ready
+      // through the fallback while still naming the bubblewrap defect.
+      if (status.kind === "ready") {
+        expect(status.landlock).toBe("full");
+        expect(status.reason).toContain(
+          "bubblewrap does not support descriptor-based read-only binds",
+        );
+        expect(status.reason).toContain("Landlock fallback is active");
+        expect(status.helperPath).toBe(realpathSync(helper));
+      } else {
+        expect(status).toEqual({
+          kind: "unavailable",
+          mode: "workspace_write",
+          platform: "linux",
+          reason: "bubblewrap does not support descriptor-based read-only binds",
+          remediation:
+            "Upgrade bubblewrap to a version that supports --ro-bind-fd, then run `agenc doctor` again.",
+          helperPath: realpathSync(helper),
+          isolationProgram: bwrap,
+        });
+      }
       expect(probeMocks.findBubblewrap).toHaveBeenCalledWith(
         env.PATH,
         workspace,
@@ -89,7 +103,11 @@ describe("Linux sandbox bubblewrap readiness", () => {
         bwrap,
         env,
       );
-      expect(probeMocks.spawnSync).not.toHaveBeenCalled();
+      // bubblewrap's namespace probe must still never run after the
+      // rejection; the only permitted spawn is the Landlock probe.
+      for (const call of probeMocks.spawnSync.mock.calls) {
+        expect(String(call[0])).toContain("agenc-landlock-run");
+      }
     },
   );
 });

--- a/runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { planLandlockConfinement } from "../../../src/sandbox/linux-launcher/landlock-exec.js";
+import { runLinuxSandboxMain } from "../../../src/sandbox/linux-launcher/linux-run-main.js";
+import {
+  restrictedFileSystemPolicy,
+  type PermissionProfile,
+} from "../../../src/sandbox/engine/index.js";
+import { probeLandlock } from "../../../src/sandbox/landlock-run.js";
+
+const canRunLive = process.platform === "linux" && probeLandlock() === "full";
+
+const work: string[] = [];
+afterAll(() => {
+  for (const dir of work) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function withTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  work.push(dir);
+  return dir;
+}
+
+function workspaceWriteProfile(
+  workspace: string,
+  network: PermissionProfile["network"],
+): PermissionProfile {
+  // Mirrors the production workspace_write shape: full disk read plus a
+  // writable workspace, with platform defaults on.
+  return {
+    fileSystem: restrictedFileSystemPolicy(
+      [
+        { path: { kind: "special", value: { kind: "root" } }, access: "read" },
+        { path: { kind: "path", path: workspace }, access: "write" },
+      ],
+      { includePlatformDefaults: true },
+    ),
+    network,
+  };
+}
+
+/** Run the REAL helper main with bubblewrap made unavailable. */
+async function runFallback(
+  profile: PermissionProfile,
+  workspace: string,
+  command: readonly string[],
+): Promise<{ exitCode: number; stderr: string[] }> {
+  const stderr: string[] = [];
+  const exitCode = await runLinuxSandboxMain(
+    [
+      "--sandbox-policy-cwd",
+      workspace,
+      "--command-cwd",
+      workspace,
+      "--permission-profile",
+      JSON.stringify(profile),
+      "--",
+      ...command,
+    ],
+    {
+      preferredLauncher: () => null,
+      onStderr: (line) => stderr.push(line),
+    },
+  );
+  return { exitCode, stderr };
+}
+
+describe("planLandlockConfinement refusals", () => {
+  const base = {
+    sandboxPolicyCwd: "/tmp",
+    allowNetworkForProxy: false,
+    inheritedCwd: false,
+  } as const;
+  const plainPolicy = restrictedFileSystemPolicy([
+    { path: { kind: "path", path: "/tmp" }, access: "write" },
+  ]);
+
+  it("refuses managed proxy networking", () => {
+    const plan = planLandlockConfinement({
+      ...base,
+      allowNetworkForProxy: true,
+      fileSystem: plainPolicy,
+    });
+    expect(plan).toMatchObject({ kind: "refused" });
+  });
+
+  it("refuses inherited read-only cwd", () => {
+    const plan = planLandlockConfinement({
+      ...base,
+      inheritedCwd: true,
+      fileSystem: plainPolicy,
+    });
+    expect(plan).toMatchObject({ kind: "refused" });
+  });
+
+
+
+  it("refuses unreadable masks an allow-list cannot express", () => {
+    const secret = withTempDir("agenc-landlock-plan-secret-");
+    const plan = planLandlockConfinement({
+      ...base,
+      fileSystem: restrictedFileSystemPolicy([
+        { path: { kind: "path", path: "/tmp" }, access: "write" },
+        { path: { kind: "path", path: secret }, access: "none" },
+      ]),
+    });
+    expect(plan).toMatchObject({ kind: "refused" });
+    expect((plan as { reason: string }).reason).toContain("allow-list");
+  });
+
+  it("refuses read-only carve-outs inside a writable root", () => {
+    const workspace = withTempDir("agenc-landlock-plan-carveout-");
+    const frozen = path.join(workspace, "frozen");
+    fs.mkdirSync(frozen);
+    const plan = planLandlockConfinement({
+      ...base,
+      sandboxPolicyCwd: workspace,
+      fileSystem: restrictedFileSystemPolicy([
+        { path: { kind: "path", path: workspace }, access: "write" },
+        { path: { kind: "path", path: frozen }, access: "read" },
+      ]),
+    });
+    expect(plan).toMatchObject({ kind: "refused" });
+  });
+
+  it("never grants /proc or /sys, even under full disk read", () => {
+    const plan = planLandlockConfinement({
+      ...base,
+      fileSystem: restrictedFileSystemPolicy(
+        [
+          {
+            path: { kind: "special", value: { kind: "root" } },
+            access: "read",
+          },
+          { path: { kind: "path", path: "/tmp" }, access: "write" },
+        ],
+        { includePlatformDefaults: true },
+      ),
+    });
+    expect(plan.kind).toBe("ok");
+    const grants = plan as { readOnly: readonly string[] };
+    expect(grants.readOnly).not.toContain("/proc");
+    expect(grants.readOnly).not.toContain("/sys");
+    expect(grants.readOnly.length).toBeGreaterThan(0);
+  });
+});
+
+describe.runIf(canRunLive)("Landlock fallback through the real helper", () => {
+  it("confines writes to the workspace when bubblewrap is unavailable", async () => {
+    const workspace = withTempDir("agenc-landlock-fallback-ws-");
+    const outside = withTempDir("agenc-landlock-fallback-out-");
+    const inside = path.join(workspace, "made.txt");
+    const escaped = path.join(outside, "escaped.txt");
+
+    const ok = await runFallback(
+      workspaceWriteProfile(workspace, "disabled"),
+      workspace,
+      ["/bin/sh", "-c", `echo confined > ${inside}`],
+    );
+    expect(ok.exitCode).toBe(0);
+    expect(fs.readFileSync(inside, "utf8")).toBe("confined\n");
+
+    const denied = await runFallback(
+      workspaceWriteProfile(workspace, "disabled"),
+      workspace,
+      ["/bin/sh", "-c", `echo escaped > ${escaped}`],
+    );
+    expect(denied.exitCode).not.toBe(0);
+    expect(fs.existsSync(escaped)).toBe(false);
+  });
+
+  it("keeps /proc unreadable, closing the same-uid environ channel", async () => {
+    const workspace = withTempDir("agenc-landlock-fallback-proc-");
+    const capture = path.join(workspace, "proc.txt");
+    const denied = await runFallback(
+      workspaceWriteProfile(workspace, "disabled"),
+      workspace,
+      ["/bin/sh", "-c", `cat /proc/self/status > ${capture}`],
+    );
+    expect(denied.exitCode).not.toBe(0);
+    expect(fs.readFileSync(capture, "utf8")).toBe("");
+  });
+
+  it("applies the network seccomp program when the policy disables network", async () => {
+    const workspace = withTempDir("agenc-landlock-fallback-net-");
+    if (!fs.existsSync("/usr/bin/python3")) return;
+    const verdict = path.join(workspace, "net.txt");
+    const probe = await runFallback(
+      workspaceWriteProfile(workspace, "disabled"),
+      workspace,
+      [
+        "/usr/bin/python3",
+        "-c",
+        "import socket\n" +
+          "out = open(" + JSON.stringify(verdict) + ", 'w')\n" +
+          "try:\n" +
+          "  socket.socket(socket.AF_INET)\n" +
+          "  out.write('inet-open')\n" +
+          "except PermissionError:\n" +
+          "  out.write('inet-denied')\n" +
+          "out.close()",
+      ],
+    );
+    expect(probe.exitCode).toBe(0);
+    expect(fs.readFileSync(verdict, "utf8")).toBe("inet-denied");
+  });
+
+  it("leaves the network open when the policy enables it", async () => {
+    const workspace = withTempDir("agenc-landlock-fallback-neton-");
+    if (!fs.existsSync("/usr/bin/python3")) return;
+    const verdict = path.join(workspace, "net.txt");
+    const probe = await runFallback(
+      workspaceWriteProfile(workspace, "enabled"),
+      workspace,
+      [
+        "/usr/bin/python3",
+        "-c",
+        "import socket; socket.socket(socket.AF_INET)\n" +
+          "open(" + JSON.stringify(verdict) + ", 'w').write('inet-open')",
+      ],
+    );
+    expect(probe.exitCode).toBe(0);
+    expect(fs.readFileSync(verdict, "utf8")).toBe("inet-open");
+  });
+
+  it("fails closed with both reasons when the policy is inexpressible", async () => {
+    const workspace = withTempDir("agenc-landlock-fallback-refuse-");
+    const secret = withTempDir("agenc-landlock-fallback-secret-");
+    const result = await runFallback(
+      {
+        fileSystem: restrictedFileSystemPolicy([
+          { path: { kind: "path", path: workspace }, access: "write" },
+          { path: { kind: "path", path: secret }, access: "none" },
+        ]),
+        network: "disabled",
+      },
+      workspace,
+      ["/bin/true"],
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.join("\n")).toContain(
+      "Landlock fallback cannot express",
+    );
+  });
+});
+
+describe.runIf(canRunLive)("broker probe fallback", () => {
+  it("reports ready through Landlock when bubblewrap is missing from PATH", async () => {
+    const { probeSandboxExecutionStatus } = await import(
+      "../../../src/sandbox/execution-broker.js"
+    );
+    const cwd = withTempDir("agenc-landlock-probe-cwd-");
+    const status = probeSandboxExecutionStatus({
+      mode: "workspace_write",
+      cwd,
+      env: { PATH: "/nonexistent-path-for-probe" },
+      platform: "linux",
+      agencLinuxSandboxExe: path.resolve(
+        __dirname,
+        "../../../bin/agenc-linux-sandbox",
+      ),
+    });
+    expect(status.kind).toBe("ready");
+    expect(status.landlock).toBe("full");
+    expect(status.reason).toContain("Landlock fallback is active");
+    expect(status.isolationProgram).toBeDefined();
+  });
+});


### PR DESCRIPTION
Final slice of the Landlock adoption (#1733 foundation, #1734 seccomp parity): **the execution path now uses it.** When the bubblewrap chain fails — not installed, no descriptor binds, or the namespace probe denied by AppArmor — the sandbox confines through `agenc-landlock-run` instead of refusing to run, for exactly the policies an allow-list can express.

## Where the decision lives

The **helper** decides at spawn time, mirroring how it already discovers bubblewrap. `planLandlockConfinement()` maps the permission profile to grants and **refuses loudly on anything inexpressible** — the fallback never runs weaker confinement than the caller asked for:

| Policy feature | Fallback behavior | Why |
|---|---|---|
| Managed proxy networking | refuse | needs a netns |
| Inherited read-only cwd | refuse | descriptor binds |
| Unreadable masks | refuse | rulesets compose by union; nothing subtracts a child from a granted subtree |
| **Existing** `.git`/protected subpath under a writable root | refuse | running without its read-only protection would let a confined command rewrite hooks that execute unconfined later |
| Protected subpaths that **don't exist yet** | allow + the same protected-create monitor the bwrap path uses; creating one fails the run | |
| `mountProc` | **not** a refusal | bwrap's private procfs is a convenience; the fallback provides no `/proc` at all — strictly more closed, `/proc` readers fail visibly |
| Network | the same seccomp program bwrap would apply rides `--seccomp fd` | #1734 |

`/proc` and `/sys` are **never granted**, even under full-disk-read (expressed by enumerating `/`'s entries): without a pid namespace, host `/proc/<pid>/environ` of the daemon leaks provider credentials to confined commands. Falsification-checked — removing the exclusion fails both `/proc` tests.

## Broker mirror

Each bubblewrap-failure branch of the probe now tries Landlock; on `full` enforcement it reports **ready**, keeping the original bubblewrap defect plus `the Landlock fallback is active` in the reason. The bind-fd readiness contract test now permits exactly one post-rejection spawn — the Landlock probe, never the namespace probe.

## Live verification (real helper, bubblewrap made unavailable, real kernel)

| | |
|---|---|
| Writes confined to the workspace | ✅ |
| `/proc` unreadable (verdict written by the confined command itself) | ✅ |
| AF_INET denied under `network: disabled`, open under `enabled` | ✅ |
| Inexpressible policy fails closed carrying **both** reasons | ✅ |
| Broker probe: PATH without bwrap → `ready`, `landlock: full` | ✅ |

Sandbox + doctor suites **236 passed**, typecheck and build clean.

## Known limitation, stated rather than papered over

A writable workspace that already contains `.git` (most real repositories) **refuses** the fallback — bubblewrap's read-only protection of that directory is inexpressible, and `.git/hooks` is an unconfined-execution channel. Net effect on Ubuntu 24.04 with restricted userns and no AppArmor profile: read-only mode and non-git workspaces now work with no sudo step; full workspace-write on a repository still wants bubblewrap or the profile. A targeted metadata-mutation monitor could close that gap later.

Debugging note for reviewers: the first e2e draft refused everything — `mountProc` defaults to true (hence dropping it as a refusal), and production `workspace_write` is full-disk-read + workspace-write (the test fixture now mirrors that exact shape).