### PR TITLE
feat(tools): head+tail offload previews and an operator inline threshold

### DIFF
--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -212,6 +212,22 @@ export const LARGE_CONTEXT_WINDOW_TOKENS = 200_000;
  * back to the 0.20 default. Out-of-range / unparseable values are
  * ignored so a bad env var can never disable the guard.
  */
+/**
+ * Optional inline-size threshold for the offload, in bytes
+ * (`AGENC_TOOL_RESULT_OFFLOAD_BYTES`). When set and lower than the
+ * model-aware cap, results above it are offloaded even though they would
+ * have fit inline: the full output is persisted either way, so the only
+ * effect is how much of the context window one tool result may occupy.
+ * Unset or invalid keeps today's behavior (offload only above the cap).
+ */
+function resolveOffloadThresholdBytes(): number | undefined {
+  const raw = process.env.AGENC_TOOL_RESULT_OFFLOAD_BYTES;
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
 function resolveSingleResultWindowFraction(): number {
   const raw = process.env.AGENC_MAX_TOOL_RESULT_WINDOW_FRACTION;
   if (raw === undefined || raw.trim() === "") {
@@ -489,20 +505,36 @@ function buildOffloadReferenceMessage(args: {
     `[full output (~${formatFileSize(originalBytes)} / ~${originalTokens} tokens) ` +
     `saved to ${filepath} — read that file (or a byte/line range with ` +
     `offset+limit) to see more, or narrow your query / run a more specific ` +
-    `search. Head preview follows:]\n`;
-  const footer = `\n[…truncated — full output at ${filepath}]\n`;
+    `search. Head and tail preview follows:]\n`;
+  // The tail routinely carries the verdict — a test run's summary line, an
+  // exit status, the actual error — so the preview keeps BOTH ends and
+  // marks the omitted middle, instead of hoping the head was the useful
+  // part.
+  const middle = `\n[… middle omitted — full output at ${filepath}]\n`;
   const headerBytes = Buffer.byteLength(header, "utf8");
-  const footerBytes = Buffer.byteLength(footer, "utf8");
-  const room = Math.max(0, maxBytes - headerBytes - footerBytes);
-  // Trim the head preview to fit, cutting on a UTF-8 boundary.
-  let head = Buffer.from(content, "utf8").subarray(0, room).toString("utf8");
-  // Prefer a clean line boundary for the preview when one is reasonably
-  // close to the end (mirrors generatePreview in toolResultStorage).
+  const middleBytes = Buffer.byteLength(middle, "utf8");
+  const room = Math.max(0, maxBytes - headerBytes - middleBytes);
+  const contentBuffer = Buffer.from(content, "utf8");
+  const headRoom = Math.floor(room * 0.6);
+  const tailRoom = room - headRoom;
+  // Trim both previews to fit, cutting on UTF-8 boundaries, preferring a
+  // clean line boundary when one is reasonably close (mirrors
+  // generatePreview in toolResultStorage).
+  let head = contentBuffer.subarray(0, headRoom).toString("utf8");
   const lastNewline = head.lastIndexOf("\n");
-  if (lastNewline > room * 0.5) {
+  if (lastNewline > headRoom * 0.5) {
     head = head.slice(0, lastNewline);
   }
-  return `${header}${head}${footer}`;
+  let tail = contentBuffer
+    .subarray(Math.max(0, contentBuffer.length - tailRoom))
+    .toString("utf8");
+  // A byte cut can open mid-code-point; drop the replacement-char prefix.
+  while (tail.startsWith("\uFFFD")) tail = tail.slice(1);
+  const firstNewline = tail.indexOf("\n");
+  if (firstNewline !== -1 && firstNewline < tailRoom * 0.5) {
+    tail = tail.slice(firstNewline + 1);
+  }
+  return `${header}${head}${middle}${tail}`;
 }
 
 /**
@@ -536,18 +568,28 @@ async function offloadOrCapToolResult(args: {
   const { content, toolUseId, maxBytes, bytesPerToken, contextWindowTokens } =
     args;
   const originalBytes = Buffer.byteLength(content, "utf8");
-  if (originalBytes <= maxBytes) {
+  // The offload may fire below the wire cap when the operator sets the
+  // inline threshold; the wire cap itself is unchanged, and the persist
+  // failure fallback below still truncates at the cap, never the
+  // threshold, so a storage problem cannot shrink what stays inline
+  // relative to today.
+  const offloadThreshold = resolveOffloadThresholdBytes();
+  const trigger =
+    offloadThreshold === undefined
+      ? maxBytes
+      : Math.min(maxBytes, offloadThreshold);
+  if (originalBytes <= trigger) {
     return { content, truncated: false, originalBytes };
   }
 
-  // Over the cap: OFFLOAD the full output, then return a reference.
+  // Over the trigger: OFFLOAD the full output, then return a reference.
   const persisted = await persistToolResult(content, toolUseId);
   if (!isPersistError(persisted)) {
     const reference = buildOffloadReferenceMessage({
       content,
       filepath: persisted.filepath,
       originalBytes,
-      maxBytes,
+      maxBytes: trigger,
       bytesPerToken,
     });
     return {

--- a/runtime/src/utils/toolResultStorage.ts
+++ b/runtime/src/utils/toolResultStorage.ts
@@ -4,7 +4,7 @@
 
 import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
 import { createHash } from 'node:crypto'
-import { mkdir } from 'fs/promises'
+import { chmod, mkdir } from 'fs/promises'
 import { join } from 'path'
 import { getOriginalCwd, getSessionId } from '../bootstrap/state.js'
 import {
@@ -132,7 +132,10 @@ function safeToolResultPathSegment(value: string): string {
  */
 export async function ensureToolResultsDir(): Promise<void> {
   try {
-    await mkdir(getToolResultsDir(), { recursive: true })
+    // Private like the rest of AGENC_HOME's sensitive stores: 0700 on the
+    // leaf (recursive mode is umask-filtered, so chmod seals it).
+    await mkdir(getToolResultsDir(), { recursive: true, mode: 0o700 })
+    await chmod(getToolResultsDir(), 0o700)
   } catch {
     // Directory may already exist
   }

--- a/runtime/tests/tools/execution.window-cap.test.ts
+++ b/runtime/tests/tools/execution.window-cap.test.ts
@@ -20,7 +20,7 @@
 
 import { readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import {
   capToolResult,
   computeEffectiveMaxResultBytes,
@@ -313,12 +313,18 @@ describe("runToolUse — model-aware OFFLOAD (Technique D)", () => {
     const persisted = readFileSync(persistedPath, "utf8");
     expect(persisted).toBe(body);
 
-    // (c) The full content is recoverable from the path (head preview is
-    // a strict prefix of the persisted full output).
+    // (c) The preview keeps BOTH ends of the persisted output: the head is
+    // a strict prefix, the tail a strict suffix, and the omitted middle is
+    // marked with the path.
     const headStart = out.content.indexOf("\n") + 1;
-    const head = out.content.slice(headStart).split("\n[…truncated")[0];
-    expect(head.length).toBeGreaterThan(0);
-    expect(persisted.startsWith(head)).toBe(true);
+    const [head, tailWithMarkerTail] = out.content
+      .slice(headStart)
+      .split(/\n\[… middle omitted[^\]]*\]\n/u);
+    expect(head!.length).toBeGreaterThan(0);
+    expect(persisted.startsWith(head!)).toBe(true);
+    expect(tailWithMarkerTail).toBeDefined();
+    expect(tailWithMarkerTail!.length).toBeGreaterThan(0);
+    expect(persisted.endsWith(tailWithMarkerTail!)).toBe(true);
   });
 
   test("(d) tool_use/tool_result pairing stays valid — the result keeps the callId", async () => {
@@ -378,5 +384,87 @@ describe("runToolUse — model-aware OFFLOAD (Technique D)", () => {
     });
     expect(out2.content).toBe(underCeiling);
     expect(out2.content).not.toContain("saved to");
+  });
+});
+
+describe("runToolUse — operator inline-offload threshold", () => {
+  const ENV = "AGENC_TOOL_RESULT_OFFLOAD_BYTES";
+  afterEach(() => {
+    delete process.env[ENV];
+  });
+
+  test("a result under the cap offloads once the operator threshold is set", async () => {
+    process.env[ENV] = "65536";
+    const body = makeGenericText(120_000); // well under the 400 KB ceiling
+    const callId = `c-thresh-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-thresh", body),
+      invocation: makeInvocation(callId, "dump-thresh"),
+      contextWindowTokens: 500_000,
+    });
+    expect(out.isError).toBe(false);
+    // Inline message bounded by the THRESHOLD, not the cap.
+    expect(Buffer.byteLength(out.content, "utf8")).toBeLessThanOrEqual(65_536);
+    expect(out.content).toContain("saved to");
+    const persisted = readFileSync(getToolResultPath(callId, false), "utf8");
+    expect(persisted).toBe(body);
+  });
+
+  test("the same result stays inline without the threshold", async () => {
+    const body = makeGenericText(120_000);
+    const callId = `c-nothresh-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-nothresh", body),
+      invocation: makeInvocation(callId, "dump-nothresh"),
+      contextWindowTokens: 500_000,
+    });
+    expect(out.isError).toBe(false);
+    expect(out.content).toBe(body);
+    expect(out.content).not.toContain("saved to");
+  });
+
+  test("an invalid threshold is ignored", async () => {
+    process.env[ENV] = "not-a-number";
+    const body = makeGenericText(120_000);
+    const callId = `c-badthresh-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-badthresh", body),
+      invocation: makeInvocation(callId, "dump-badthresh"),
+      contextWindowTokens: 500_000,
+    });
+    expect(out.content).toBe(body);
+  });
+
+  test("a threshold above the cap changes nothing: the cap still wins", async () => {
+    process.env[ENV] = String(10_000_000);
+    const body = makeGenericText(420_000);
+    const callId = `c-hithresh-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-hithresh", body),
+      invocation: makeInvocation(callId, "dump-hithresh"),
+      contextWindowTokens: 500_000,
+    });
+    expect(Buffer.byteLength(out.content, "utf8")).toBeLessThanOrEqual(400_000);
+    expect(out.content).toContain("saved to");
+  });
+
+  test("the tail of the preview carries the end of the output", async () => {
+    process.env[ENV] = "32768";
+    const verdict = "FINAL-VERDICT: 3 failed, 17 passed";
+    const body = `${makeGenericText(90_000)}\n${verdict}\n`;
+    const callId = `c-tail-${randomUUID()}`;
+    const out = await runToolUse("{}", {
+      currentTurnId: "t1",
+      tool: echoTool("dump-tail", body),
+      invocation: makeInvocation(callId, "dump-tail"),
+      contextWindowTokens: 500_000,
+    });
+    expect(out.content).toContain("saved to");
+    // The reason head-only previews were wrong: the verdict survives.
+    expect(out.content).toContain(verdict);
   });
 });


### PR DESCRIPTION
Adoption #3 from the deepseek-harness study turned into a **gap analysis**: AgenC already has spill storage — the Technique D offload (persist full + reference) — and ours does the hard parts better than theirs (sha256 artifact identity, temp+fsync+exclusive-link publication, idempotent same-byte replay). This adopts the three things their design got right that ours missed.

## 1. Previews keep BOTH ends

The tail routinely carries the verdict — a test run's summary line, an exit status, the actual error — and our head-only preview hid exactly that. The reference now splits its room 60/40 head/tail around an explicit marker:

```
[full output (~2.1 MB / ~525000 tokens) saved to …/tool-results/c-….txt — read that file …]
<head…>
[… middle omitted — full output at …/tool-results/c-….txt]
<…tail>
```

Both cuts respect UTF-8 boundaries and prefer line breaks; the message stays byte-bounded as before. The dedicated test plants `FINAL-VERDICT: 3 failed, 17 passed` at the end of a 90 KB body and asserts it survives into the preview — reverting to head-only fails exactly that test (falsification-checked).

## 2. `AGENC_TOOL_RESULT_OFFLOAD_BYTES` — the context-saving lever

Today the offload fires only above the model-aware cap (fixed **400 KB** for large windows), so one Bash result can occupy **~100–200K tokens** before anything is persisted. With the env set, results above the threshold are offloaded even though they would fit inline — the full output is persisted either way, so the only change is how much of the window a single result may spend.

Guarantees, each pinned by a test:
- unset/invalid → today's behavior byte-for-byte
- the threshold never raises the wire cap (`min(cap, threshold)`)
- persist-failure fallback still truncates at the **cap**, not the threshold — a storage problem cannot shrink what stays inline relative to today

## 3. `tool-results/` is created 0700

Chmod-sealed against the umask, matching the rest of AGENC_HOME's sensitive stores (the files were already 0600 via the atomic artifact commit). This is the spill-hygiene rule from DeepSeek's defensive patterns.

| | |
|---|---|
| window-cap suite (incl. 5 new cases) | 21 passed |
| execution + run-turn | 244 total |
| typecheck | clean |