### PR TITLE
fix(tools): offload into the conversation's store, visibly, with a compact reference

### DIFF
--- a/runtime/src/tools/execution.ts
+++ b/runtime/src/tools/execution.ts
@@ -213,6 +213,17 @@ export const LARGE_CONTEXT_WINDOW_TOKENS = 200_000;
  * ignored so a bad env var can never disable the guard.
  */
 /**
+ * Byte bound for the offload REFERENCE message itself. A reference is a
+ * pointer, not a payload: sizing the preview to fill the wire cap produced
+ * ~400 KB reference messages that history compaction cleared before the
+ * model ever used them -- observed live as the model reading only
+ * "[Old tool result content cleared]" where the pointer used to be. A small
+ * reference keeps its context cost trivial and survives compaction rules,
+ * while still carrying the path plus actionable head and tail slices.
+ */
+const OFFLOAD_REFERENCE_MAX_BYTES = 4_000;
+
+/**
  * Optional inline-size threshold for the offload, in bytes
  * (`AGENC_TOOL_RESULT_OFFLOAD_BYTES`). When set and lower than the
  * model-aware cap, results above it are offloaded even though they would
@@ -564,6 +575,8 @@ async function offloadOrCapToolResult(args: {
   readonly truncated: boolean;
   readonly originalBytes: number;
   readonly persistedPath?: string;
+  /** Set when the offload was attempted and persistence failed (the error). */
+  readonly persistFailed?: string;
 }> {
   const { content, toolUseId, maxBytes, bytesPerToken, contextWindowTokens } =
     args;
@@ -589,7 +602,7 @@ async function offloadOrCapToolResult(args: {
       content,
       filepath: persisted.filepath,
       originalBytes,
-      maxBytes: trigger,
+      maxBytes: Math.min(trigger, OFFLOAD_REFERENCE_MAX_BYTES),
       bytesPerToken,
     });
     return {
@@ -602,6 +615,10 @@ async function offloadOrCapToolResult(args: {
 
   // Persist failed → fall back to the legacy blind truncation so the hard
   // model-aware cap is still enforced (the wire message can never overflow).
+  // The failure surfaces to the caller: an offload that silently degrades is
+  // how the daemon-session breakage stayed invisible — the fallback passes
+  // sub-cap content through untouched, so nothing downstream could tell an
+  // offload was ever attempted.
   const capped = capToolResult(content, maxBytes, {
     bytesPerToken,
     contextWindowTokens,
@@ -610,6 +627,7 @@ async function offloadOrCapToolResult(args: {
     content: capped.capped,
     truncated: capped.truncated,
     originalBytes: capped.originalBytes,
+    persistFailed: persisted.error,
   };
 }
 
@@ -2302,6 +2320,16 @@ export async function runToolUse(
         subId,
         "tool_result_truncated",
         `tool ${toolNameDisplay(invocation.toolName)} output ${capped.originalBytes}B ${disposition} (I-15)`,
+      );
+    }
+    if (capped.persistFailed !== undefined && opts.eventLog) {
+      emitWarningEvent(
+        opts.eventLog,
+        subId,
+        "tool_result_offload_failed",
+        `tool ${toolNameDisplay(invocation.toolName)} output ` +
+          `${capped.originalBytes}B could not be offloaded ` +
+          `(${capped.persistFailed}); kept inline under the wire cap`,
       );
     }
 

--- a/runtime/src/utils/toolResultStorage.ts
+++ b/runtime/src/utils/toolResultStorage.ts
@@ -86,8 +86,21 @@ function getSessionDir(): string {
 
 /**
  * Get the tool results directory for this session (projectDir/sessionId/tool-results)
+ *
+ * Prefers the AMBIENT session's rollout store, whose sessionDir names the
+ * conversation actually running the tool. The bootstrap globals below are a
+ * process-wide identity: correct in single-session processes, but in the
+ * multi-session daemon they name the daemon's boot identity, which sent
+ * offloaded artifacts to an orphan store no consumer could associate with
+ * the conversation — outside both trusted artifact roots the rollout
+ * store's recovery validates against.
  */
 export function getToolResultsDir(): string {
+  const session = peekAmbientRuntimeSession()
+  const sessionDir = session?.rolloutStore?.store.sessionDir
+  if (sessionDir !== undefined && sessionDir.length > 0) {
+    return join(sessionDir, TOOL_RESULTS_SUBDIR)
+  }
   return join(getSessionDir(), TOOL_RESULTS_SUBDIR)
 }
 

--- a/runtime/tests/durability/artifact-journal-recovery.test.ts
+++ b/runtime/tests/durability/artifact-journal-recovery.test.ts
@@ -92,6 +92,18 @@ function openStore(cwd: string, runId: string, resume = false): RolloutStore {
   return rollout;
 }
 
+/**
+ * The store-scoped tool-results directory persistToolResult targets when the
+ * ambient session carries this rollout store — the same trusted artifact
+ * root its recovery validates. The module-level getToolResultsDir() helper
+ * resolves the process-global fallback when called OUTSIDE the ambient
+ * context, which is exactly the daemon-session divergence the session-aware
+ * persistence fixed.
+ */
+function sessionToolResultsDir(rollout: RolloutStore): string {
+  return join(rollout.store.sessionDir, "tool-results");
+}
+
 function sessionFor(rollout: RolloutStore): Session {
   const eventLog = new EventLog();
   return {
@@ -188,7 +200,7 @@ describe("M4 artifact journal recovery", () => {
         },
       });
       expect(
-        readFileSync(getToolResultPath("call-normal", false), "utf8"),
+        readFileSync(join(sessionToolResultsDir(rollout), "call-normal.txt"), "utf8"),
       ).toBe("durable bytes");
       rollout.close();
     },
@@ -269,7 +281,7 @@ describe("M4 artifact journal recovery", () => {
         "artifact_committed",
       ]);
       expect(
-        readFileSync(getToolResultPath("call-conflict", false), "utf8"),
+        readFileSync(join(sessionToolResultsDir(rollout), "call-conflict.txt"), "utf8"),
       ).toBe("first bytes");
       rollout.close();
     },
@@ -287,7 +299,7 @@ describe("M4 artifact journal recovery", () => {
       );
       if ("error" in result) throw new Error(result.error);
 
-      expect(dirname(result.filepath)).toBe(getToolResultsDir());
+      expect(dirname(result.filepath)).toBe(sessionToolResultsDir(rollout));
       expect(readFileSync(result.filepath, "utf8")).toBe("contained bytes");
       expect(artifactEvents(rollout)[0]).toMatchObject({
         msg: {

--- a/runtime/tests/tools/execution.window-cap.test.ts
+++ b/runtime/tests/tools/execution.window-cap.test.ts
@@ -214,8 +214,20 @@ describe("runToolUse — end-to-end model-aware cap", () => {
       invocation: makeInvocation("c-text-fixed", "dump-fixed"),
       contextWindowTokens: LOCAL_WINDOW,
     });
+    // The wire message is now a compact offload REFERENCE (bounded to a few
+    // KB), never the cap-sized payload: cap-sized references were cleared by
+    // history compaction before the model could use the pointer. The
+    // magnitude the cap governs still shows in what was persisted.
     const tokens = estimateTokens(out.content, TEXT_BYTES_PER_TOKEN);
-    expect(tokens).toBeGreaterThan(90_000);
+    expect(tokens).toBeLessThanOrEqual(1_000);
+    expect(out.content).toContain("saved to");
+    const persisted = readFileSync(
+      getToolResultPath("c-text-fixed", false),
+      "utf8",
+    );
+    expect(estimateTokens(persisted, TEXT_BYTES_PER_TOKEN)).toBeGreaterThan(
+      90_000,
+    );
   });
 
   test("131K window: a 420 KB JSON result is capped tighter (~half the text bytes)", async () => {
@@ -235,11 +247,20 @@ describe("runToolUse — end-to-end model-aware cap", () => {
       contextWindowTokens: LOCAL_WINDOW,
     });
 
-    const textBytes = Buffer.byteLength(textOut.content, "utf8");
-    const jsonBytes = Buffer.byteLength(jsonOut.content, "utf8");
-    // JSON byte cap ≈ half the text byte cap (same token target, 2 B/tok).
-    expect(jsonBytes).toBeLessThan(textBytes);
-    expect(jsonBytes).toBeCloseTo(textBytes / 2, -3);
+    // Both overflow their caps and come back as compact references; the
+    // JSON-tighter relationship is the CAP's property, asserted directly.
+    expect(textOut.content).toContain("saved to");
+    expect(jsonOut.content).toContain("saved to");
+    const textCap = computeEffectiveMaxResultBytes({
+      content: textBody,
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    const jsonCap = computeEffectiveMaxResultBytes({
+      content: jsonBody,
+      contextWindowTokens: LOCAL_WINDOW,
+    });
+    expect(jsonCap).toBeLessThan(textCap);
+    expect(jsonCap).toBeCloseTo(textCap / 2, -3);
   });
 
   test("200K window (or undefined): cap stays 400 KB — Claude untouched", async () => {
@@ -251,12 +272,21 @@ describe("runToolUse — end-to-end model-aware cap", () => {
       invocation: makeInvocation("c-large", "dump-large"),
       contextWindowTokens: LARGE_WINDOW,
     });
-    // Truncated to the 400 KB ceiling, not the window-relative value.
+    // Over the 400 KB ceiling: offloaded with a compact reference. The
+    // ceiling (not the window-relative value) is what triggered — pinned by
+    // the cap function — and the full body is preserved on disk.
     expect(Buffer.byteLength(largeOut.content, "utf8")).toBeLessThanOrEqual(
       DEFAULT_MAX_TOOL_RESULT_BYTES,
     );
-    expect(Buffer.byteLength(largeOut.content, "utf8")).toBeGreaterThan(
-      Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN),
+    expect(largeOut.content).toContain("saved to");
+    expect(
+      computeEffectiveMaxResultBytes({
+        content: body,
+        contextWindowTokens: LARGE_WINDOW,
+      }),
+    ).toBe(DEFAULT_MAX_TOOL_RESULT_BYTES);
+    expect(readFileSync(getToolResultPath("c-large", false), "utf8")).toBe(
+      body,
     );
 
     const noWindowOut = await runToolUse("{}", {
@@ -265,9 +295,12 @@ describe("runToolUse — end-to-end model-aware cap", () => {
       invocation: makeInvocation("c-nowin", "dump-nowin"),
       // contextWindowTokens omitted → fixed 400 KB cap.
     });
-    expect(Buffer.byteLength(noWindowOut.content, "utf8")).toBeGreaterThan(
-      Math.floor(LOCAL_WINDOW * 0.2 * TEXT_BYTES_PER_TOKEN),
-    );
+    // Same compact-reference contract with no window: the fixed ceiling is
+    // the trigger, the wire message is the bounded reference.
+    expect(noWindowOut.content).toContain("saved to");
+    expect(
+      computeEffectiveMaxResultBytes({ content: body }),
+    ).toBe(DEFAULT_MAX_TOOL_RESULT_BYTES);
   });
 });
 

--- a/runtime/tests/utils/toolResultStorage.session-dir.test.ts
+++ b/runtime/tests/utils/toolResultStorage.session-dir.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { getToolResultsDir } from "../../src/utils/toolResultStorage.js";
+import {
+  clearCurrentRuntimeSession,
+  setCurrentRuntimeSession,
+} from "../../src/session/current-session.js";
+import type { Session } from "../../src/session/session.js";
+
+/**
+ * Regression: persistence derived its target from process-global bootstrap
+ * identity. In the multi-session daemon that names the daemon's BOOT
+ * identity, so offloaded artifacts landed in an orphan store
+ * (projects/-home-paul/<bootstrap-uuid>/) that no consumer could associate
+ * with the conversation — outside both trusted artifact roots the rollout
+ * store's recovery validates. Observed live before the fix; the correct
+ * store afterward.
+ */
+describe("getToolResultsDir session identity", () => {
+  const work: string[] = [];
+  afterEach(() => {
+    clearCurrentRuntimeSession();
+    for (const dir of work.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("prefers the ambient session's rollout-store sessionDir", () => {
+    const sessionDir = mkdtempSync(join(tmpdir(), "agenc-conv-dir-"));
+    work.push(sessionDir);
+    const session = {
+      rolloutStore: { store: { sessionDir } },
+    } as unknown as Session;
+    setCurrentRuntimeSession(session);
+    expect(getToolResultsDir()).toBe(join(sessionDir, "tool-results"));
+  });
+
+  test("falls back to the bootstrap globals without an ambient session", () => {
+    clearCurrentRuntimeSession();
+    const dir = getToolResultsDir();
+    expect(dir.endsWith(join("tool-results"))).toBe(true);
+    // The fallback derives from process-global identity, never the ambient
+    // session (there is none) — it must still return a usable path.
+    expect(dir.length).toBeGreaterThan("tool-results".length);
+  });
+
+  test("an ambient session without a rollout store falls back too", () => {
+    const session = {} as unknown as Session;
+    setCurrentRuntimeSession(session);
+    const dir = getToolResultsDir();
+    expect(dir.endsWith(join("tool-results"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Live testing of #1736 in the real TUI/daemon topology proved the Technique D offload **broken end to end in daemon sessions — three defects deep**, at least one of them present since Technique D shipped. All three fixed; the full chain is now verified live: the model answered the tail line of an 800 KB result AND quoted the persisted path inside its own conversation's store.

## 1. Wrong store (the daemon-session breakage)

`persistToolResult` derived its target from **process-global bootstrap identity** — `getSessionId()` names the daemon's *boot* identity in a multi-session daemon — landing artifacts in an orphan store:

```
projects/-home-paul/ac692bf1-…/tool-results/   ← before (orphan: wrong slug + bootstrap uuid)
projects/home-paul-17777b5d/sessions/conv-…/tool-results/   ← after (the conversation's own store)
```

The orphan path sits **outside both trusted artifact roots** the rollout store's recovery validates (`rollout-store.ts` ~3463). `getToolResultsDir()` now prefers the ambient session's rollout-store `sessionDir` — the exact directory recovery already trusts — with the globals as the single-process fallback.

## 2. Silent failure (why nobody ever saw it)

On persist failure the fallback passed sub-cap content through untouched: `truncated=false`, no event, no file — nothing recorded that an offload was attempted. `offloadOrCapToolResult` now returns `persistFailed` and the caller emits a `tool_result_offload_failed` warning naming the error.

## 3. Cap-sized references (the last broken link)

The reference sized its preview to fill the wire cap — ~400 KB "pointers" that history compaction cleared before the model used them, observed live as the model reading only `[Old tool result content cleared]`. A reference is a pointer, not a payload: bounded to **4 KB** (path + head/tail slices, ~1K tokens), it survives compaction. The three window-cap tests that pinned reference==cap now pin the cap through `computeEffectiveMaxResultBytes` plus the compact-reference contract, with the persisted file asserted byte-identical.

## Live verification (real daemon, grok-4.6, `find /usr` at 800 KB via `max_output_tokens`)

| Stage | Before | After |
|---|---|---|
| Artifact location | orphan store | conversation's `tool-results/`, 0600/0700 |
| Persist failure | invisible | `tool_result_offload_failed` warning |
| Model's view | `[content cleared]` | **`FINAL-COUNT: done` + the persisted path, quoted back** |

Falsification-checked: reverting the ambient-session preference fails exactly the identity test. window-cap 21, execution 99, identity suite 3, typecheck and build clean.

Remaining (chip filed): the config-file knob for the inline threshold (`AGENC_TOOL_RESULT_OFFLOAD_BYTES` can't cross the daemon's sanitized spawn), and a daemon-boundary CI test — the class whose absence hid all of this.