### PR TITLE
fix(runtime): restore editor access and stale workspace recovery

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1009,8 +1009,8 @@ jobs:
             "tests/tui/workbench/buffer-neovim-provider.contract.test.ts",
           ];
           const exactCounts = {
-            numTotalTests: 63,
-            numPassedTests: 63,
+            numTotalTests: 65,
+            numPassedTests: 65,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
             numFailedTests: 0,
@@ -1038,7 +1038,7 @@ jobs:
             );
           }
           console.log(
-            "Neovim provider/observed-descendant platform lane passed 63 tests in 3 files with zero skipped",
+            "Neovim provider/observed-descendant platform lane passed 65 tests in 3 files with zero skipped",
           );
           NODE
 

--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -32,6 +32,8 @@ The important operator model is:
 - `Alt+Z` maximizes or restores BUFFER. Maximize hides workbench side rails,
   composer, and footer without resizing against the global terminal geometry;
   the embedded grid follows the actual center-pane size.
+- `Alt+H` focuses the project explorer, including from a fresh Editor that
+  still shows **No file selected** and has not started a provider.
 - `Ctrl+R` remains Neovim's native redo. `Alt+R` moves the current file to the
   workbench review rail.
 - `Alt+L` focuses the Editor's open AI/proposal panel. Page Up, Page Down,
@@ -393,6 +395,30 @@ Coordinated file writes use a fail-closed admission protocol:
 - A dirty path whose editor lease expired, crashed, or stopped reporting is
   quarantined as stale and all reads/writes are blocked until the editor
   reconnects and proves its revision or the user deliberately resolves it.
+
+On reconnect, orphaned Editor authority replaces the Editor surface with a
+recovery card. This includes dirty revisions and last-known-clean buffers whose
+disk path changed while the daemon was stopped. Prefer **Recover** from a
+matching private Neovim swap when one is offered; durable quarantine retains
+revision fingerprints, not the previous source text. The card reviews one path
+at a time. Press `E` to enter the loaded Recovery Editor when you first need
+`:edit!` to reload it or `:bd!`/`:bdelete!` to unload a missing path. This is a
+host-owned hard-quarantine command surface: arbitrary native input, mappings,
+shell/Lua commands, paste, mouse input, and tab selection are not forwarded to
+Neovim. `Ctrl+G` returns to the review. Ordinary embedded Neovim and user
+configuration remain intentionally unsandboxed outside this recovery surface.
+
+If no usable revision remains, **Use Disk** is the explicit destructive
+choice: press `D` (or click) once to arm it and again to confirm. The daemon
+re-reads that disk path and requires its exact reviewed hash and byte count to
+still match. That final descriptor-bound read is the decision point; a later
+external write is treated as a new disk revision. A changed or unavailable
+path rejects the operation and keeps the card active; after restoring or
+removing an unavailable path, press `R` to re-read only its disk evidence; the
+refresh does not synchronize the loaded buffer or resolve its quarantine.
+Success permanently discards that orphaned revision and any pending proposals
+based on it. Remaining paths are reviewed separately, and Agent and shell
+operations resume only after protected Editor authority is resolved.
 
 Heartbeats renew the lease; editor close and TUI cleanup release it without
 silently abandoning dirty authority. The same coordinator covers direct file

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -109,9 +109,18 @@ const client = await connect(); // socket + cookie under AGENC_HOME
 ## Protocol
 
 - Envelope: **JSON-RPC 2.0** over newline-delimited messages.
-- Protocol version constant: **`1.0.0`**
+- Protocol version constant: **`1.1.0`**
   (`AGENC_DAEMON_PROTOCOL_VERSION` in `runtime/src/app-server/protocol/index.ts`).
-- Clients send `initialize` with the protocol version; mismatch → error.
+- Clients send `initialize` with the protocol version. Negotiation compares the
+  numeric major and minor versions: the server accepts the same major when the
+  client minor is less than or equal to the server minor; the patch component
+  does not affect compatibility. Malformed versions, different majors, and a
+  client minor newer than the server are rejected with
+  `PROTOCOL_VERSION_UNSUPPORTED`.
+- Consequently, a 1.1 daemon accepts a 1.0 client, while a current 1.1 TUI is
+  rejected by a still-running 1.0 daemon before it can send the newer Editor
+  recovery fields. Update if necessary, then run `agenc daemon restart` so the
+  daemon uses the installed protocol version.
 
 ### Public methods (`AGENC_DAEMON_METHODS`)
 

--- a/docs/reference/tui-workbench.md
+++ b/docs/reference/tui-workbench.md
@@ -106,7 +106,7 @@ cannot replace or submit Agent-tab context.
 | `Ctrl+S`               | Save the active buffer with AgenC's disk/agent conflict checks                        |
 | `Ctrl+R`               | Redo the last Neovim change natively                                                  |
 | `Alt+R`                | Move the current file to the review rail and return to chat                           |
-| `Alt+H`                | Focus the project explorer                                                            |
+| `Alt+H`                | Focus the project explorer, including from a fresh **No file selected** Editor        |
 | `Alt+L`                | Focus the open Editor AI/proposal panel; pass through to Neovim when no panel is open |
 | `Alt+E`                | Open the configured external editor, only when every Neovim buffer is confirmed clean |
 
@@ -151,6 +151,23 @@ preflights the complete buffer set before it writes. The same gate covers
 blocked during a proposal-only Editor turn, asynchronous proposal staging, and
 shadow review; AgenC focuses the proposal panel so the user can accept or
 reject it before retrying the transition.
+
+After a crash leaves orphaned dirty authority—or a last-known-clean Editor path
+changes during downtime—BUFFER shows a recovery card instead of leaving the
+workspace silently blocked. It reviews one path at a time. Prefer a matching
+Neovim swap when available; press `E` to open the loaded Recovery Editor. Its
+hard-quarantine command surface is host-owned: only exact `:edit!`/`:bd!`
+(`:bdelete!`) recovery actions are accepted, and native Neovim input, mappings,
+paste, mouse input, and tab selection are not forwarded. Press `Ctrl+G` to
+return. This narrow recovery restriction does not sandbox ordinary embedded
+Neovim or user configuration outside quarantine. Otherwise **Use Disk**
+requires two
+`D` presses (or clicks), warns that the reviewed revision and proposals will be
+discarded, and succeeds only if the daemon revalidates its exact disk
+fingerprint (hash and byte count). Changed or unavailable disk state keeps the
+recovery card and workspace protection in place. After restoring or removing
+an unavailable path, press `R` to re-read only the card's disk evidence; this
+does not synchronize the loaded buffer or resolve its quarantine.
 
 Providers are `auto`, `neovim`, `inline`, and `external`. Configure them from
 `/config`, `[buffer]` in `config.toml`, or temporary `AGENC_BUFFER_*`

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -21,7 +21,7 @@ import type {
 } from "./csv-jobs.js";
 
 export const AGENC_SDK_JSON_RPC_VERSION = "2.0" as const;
-export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.0.0" as const;
+export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.1.0" as const;
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | readonly JsonValue[] | JsonObject;

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -149,6 +149,11 @@ describe("hosted Neovim platform gate contract", () => {
     expect(source).toContain(
       "platform-tests/neovim-process-tree.real.test.ts",
     );
+    expect(source).toContain("numTotalTests: 65");
+    expect(source).toContain("numPassedTests: 65");
+    expect(source).toContain(
+      "Neovim provider/observed-descendant platform lane passed 65 tests in 3 files with zero skipped",
+    );
     expect(source).toContain(
       "scripts/check-tui-e2e/runner.mjs --platform",
     );

--- a/runtime/scripts/check-tui-e2e/scenarios/132-unified-agent-editor-workspace.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/132-unified-agent-editor-workspace.mjs
@@ -49,11 +49,9 @@ export default async function (session) {
   );
   let openedReadmeFromExplorer = false;
   if (/No file selected/u.test(frameText(session))) {
-    // A fresh workspace has no active buffer. Focus the shared explorer,
-    // select README.md (the second fixture file), and open it in Editor.
-    session.send("\x18");
-    await sleep(80);
-    session.send("h");
+    // A fresh workspace has no active buffer. Exercise the documented Alt+H
+    // chord, select README.md (the second fixture file), and open it in Editor.
+    session.send("\x1bh");
     await sleep(100);
     session.send("\x1b[B");
     session.send("\r");

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -141,6 +141,7 @@ import {
   type WorkspaceEditorReleaseParams,
   type WorkspaceEditorRecoveredTopologyListParams,
   type WorkspaceEditorRecoveredTopologyResolveParams,
+  type WorkspaceEditorStaleAuthorityEntry,
   type WorkspaceEditorSyncParams,
   type WorkspaceEditorTopologyCompleteParams,
   type WorkspaceEditorTopologyFinalizeParams,
@@ -326,6 +327,7 @@ function buildServerCapabilities(
     "auth.logout": inputs.authHandlers !== undefined,
     "workspace.editor.acquire": true,
     "workspace.editor.sync": true,
+    "workspace.editor.staleAuthority.refresh": true,
     "workspace.editor.heartbeat": true,
     "workspace.editor.release": true,
     "workspace.editor.topology.reserve": true,
@@ -1000,6 +1002,16 @@ export class AgenCDaemonJsonRpcDispatcher {
         return internalSuccessResponse(
           id,
           await syncWorkspaceEditor(validateWorkspaceEditorSyncParams(params)),
+        );
+      case "workspace.editor.staleAuthority.refresh":
+        return internalSuccessResponse(
+          id,
+          await refreshWorkspaceEditorStaleAuthority(
+            validateWorkspaceEditorHeartbeatParams(
+              params,
+              "workspace.editor.staleAuthority.refresh",
+            ),
+          ),
         );
       case "workspace.editor.heartbeat":
         return internalSuccessResponse(
@@ -1958,6 +1970,17 @@ function negotiateInitializeProtocol(
   ) {
     return { supported: false, clientVersion };
   }
+  const clientProtocol = parseProtocolVersion(clientVersion)!;
+  const negotiatedCapabilities =
+    clientProtocol.minor < 1
+      ? ({
+          ...serverCapabilities,
+          [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: {
+            ...serverCapabilities[AGENC_DAEMON_METHOD_CAPABILITIES_KEY],
+            "workspace.editor.topology.recovered.resolve": false,
+          },
+        } satisfies AgenCDaemonServerCapabilities)
+      : serverCapabilities;
   return {
     supported: true,
     state: {
@@ -1965,7 +1988,7 @@ function negotiateInitializeProtocol(
       clientProtocol: { version: clientVersion },
       serverProtocol: { version: AGENC_DAEMON_PROTOCOL_VERSION },
       clientCapabilities: cloneJsonObject(params.capabilities),
-      serverCapabilities,
+      serverCapabilities: negotiatedCapabilities,
     },
   };
 }
@@ -2606,7 +2629,11 @@ function validateSessionResolveToolCallParams(
   ].some((field) => Object.prototype.hasOwnProperty.call(validated, field));
   if (!hasEvidenceFields) {
     if (validated.toolCallId !== undefined) {
-      validateRequiredString(validated, "session.resolveToolCall", "toolCallId");
+      validateRequiredString(
+        validated,
+        "session.resolveToolCall",
+        "toolCallId",
+      );
     }
     if (validated.reviewer !== undefined) {
       validateRequiredString(validated, "session.resolveToolCall", "reviewer");
@@ -2729,11 +2756,7 @@ function validateSessionRollbackCompactionParams(
 ): SessionRollbackCompactionParams {
   const validated = validateObjectShape(params, {
     methodName: "session.rollbackCompaction",
-    stringFields: [
-      "sessionId",
-      "attemptId",
-      "reviewedBranchTargetSessionId",
-    ],
+    stringFields: ["sessionId", "attemptId", "reviewedBranchTargetSessionId"],
   });
   validateRequiredString(validated, "session.rollbackCompaction", "sessionId");
   validateRequiredString(validated, "session.rollbackCompaction", "attemptId");
@@ -3487,7 +3510,7 @@ function validateWorkspaceEditorSyncParams(
     methodName: "workspace.editor.sync",
     stringFields: ["workspaceRoot", "editorInstanceId", "leaseToken"],
     numberFields: ["epoch", "sequence"],
-    valueFields: ["buffers"],
+    valueFields: ["buffers", "abandonStaleAuthority"],
   });
   for (const field of [
     "workspaceRoot",
@@ -3514,7 +3537,112 @@ function validateWorkspaceEditorSyncParams(
   const buffers = validated.buffers.map((value, index) =>
     validateWorkspaceEditorBuffer(value, index),
   );
-  return { ...validated, buffers } as unknown as WorkspaceEditorSyncParams;
+  const abandonStaleAuthority =
+    validated.abandonStaleAuthority === undefined
+      ? undefined
+      : validateWorkspaceEditorStaleAuthorityEntries(
+          validated.abandonStaleAuthority,
+        );
+  return {
+    ...validated,
+    buffers,
+    ...(abandonStaleAuthority !== undefined ? { abandonStaleAuthority } : {}),
+  } as unknown as WorkspaceEditorSyncParams;
+}
+
+function validateWorkspaceEditorStaleAuthorityEntries(
+  value: unknown,
+): readonly WorkspaceEditorStaleAuthorityEntry[] {
+  const field = "workspace.editor.sync param 'abandonStaleAuthority'";
+  if (!Array.isArray(value) || value.length === 0 || value.length > 512) {
+    throw invalidParams(`${field} must contain between 1 and 512 entries`);
+  }
+  return value.map((candidate, index) => {
+    const methodName = `workspace.editor.sync.abandonStaleAuthority[${index}]`;
+    if (!isPlainJsonObject(candidate)) {
+      throw invalidParams(`${methodName} must be an object`);
+    }
+    const validated = validateObjectShape(candidate, {
+      methodName,
+      stringFields: [
+        "path",
+        "editorContentSha256",
+        "editorInstanceId",
+        "editorState",
+        "diskState",
+        "diskContentSha256",
+      ],
+      numberFields: [
+        "editorContentBytes",
+        "changedtick",
+        "epoch",
+        "diskContentBytes",
+      ],
+    });
+    for (const required of [
+      "path",
+      "editorContentSha256",
+      "editorInstanceId",
+      "editorState",
+      "diskState",
+    ] as const) {
+      validateRequiredString(validated, methodName, required);
+    }
+    if (!/^[a-f0-9]{64}$/u.test(validated.editorContentSha256 as string)) {
+      throw invalidParams(
+        `${methodName} param 'editorContentSha256' must be a SHA-256 digest`,
+      );
+    }
+    if (
+      validated.editorState !== "dirty" &&
+      validated.editorState !== "clean"
+    ) {
+      throw invalidParams(
+        `${methodName} param 'editorState' must be dirty or clean`,
+      );
+    }
+    for (const numberField of [
+      "editorContentBytes",
+      "changedtick",
+      "epoch",
+    ] as const) {
+      if (
+        !Number.isSafeInteger(validated[numberField]) ||
+        (validated[numberField] as number) < (numberField === "epoch" ? 1 : 0)
+      ) {
+        throw invalidParams(
+          `${methodName} param '${numberField}' must be a ${numberField === "epoch" ? "positive" : "non-negative"} safe integer`,
+        );
+      }
+    }
+    if (validated.diskState === "content") {
+      if (
+        typeof validated.diskContentSha256 !== "string" ||
+        !/^[a-f0-9]{64}$/u.test(validated.diskContentSha256) ||
+        !Number.isSafeInteger(validated.diskContentBytes) ||
+        (validated.diskContentBytes as number) < 0
+      ) {
+        throw invalidParams(
+          `${methodName} content disk state requires a SHA-256 digest and non-negative byte length`,
+        );
+      }
+    } else if (
+      validated.diskState !== "missing" &&
+      validated.diskState !== "unavailable"
+    ) {
+      throw invalidParams(
+        `${methodName} param 'diskState' must be content, missing, or unavailable`,
+      );
+    } else if (
+      validated.diskContentSha256 !== undefined ||
+      validated.diskContentBytes !== undefined
+    ) {
+      throw invalidParams(
+        `${methodName} non-content disk state must not include disk content evidence`,
+      );
+    }
+    return validated as WorkspaceEditorStaleAuthorityEntry;
+  });
 }
 
 function validateWorkspaceEditorBuffer(
@@ -3558,6 +3686,7 @@ function validateWorkspaceEditorBuffer(
 function validateWorkspaceEditorHeartbeatParams(
   params: JsonObject,
   methodName:
+    | "workspace.editor.staleAuthority.refresh"
     | "workspace.editor.heartbeat"
     | "workspace.editor.release"
     | "workspace.editor.proposal.get"
@@ -3666,7 +3795,9 @@ function validateWorkspaceEditorTopologyTarget(
 function validateWorkspaceEditorTopologyFinalizeParams(
   params: JsonObject,
   methodName:
-    "workspace.editor.topology.complete" | "workspace.editor.topology.release",
+    | "workspace.editor.topology.complete"
+    | "workspace.editor.topology.release"
+    | "workspace.editor.topology.recovered.resolve",
   extraStringFields: readonly string[] = [],
 ): WorkspaceEditorTopologyFinalizeParams {
   const validated = validateWorkspaceEditorHeartbeatParams(
@@ -3720,12 +3851,10 @@ function validateWorkspaceEditorTopologyCompleteParams(
 function validateWorkspaceEditorRecoveredTopologyResolveParams(
   params: JsonObject,
 ): WorkspaceEditorRecoveredTopologyResolveParams {
-  const methodName = "workspace.editor.topology.recovered.resolve";
-  const validated = validateWorkspaceEditorHeartbeatParams(params, methodName, [
-    "tokenId",
-  ]);
-  validateRequiredString(validated, methodName, "tokenId");
-  return validated as WorkspaceEditorRecoveredTopologyResolveParams;
+  return validateWorkspaceEditorTopologyFinalizeParams(
+    params,
+    "workspace.editor.topology.recovered.resolve",
+  );
 }
 
 function validateWorkspaceEditorReleaseParams(
@@ -4053,7 +4182,7 @@ function validateWorkspaceEditorPredictionFeedbackParams(
 async function acquireWorkspaceEditor(params: WorkspaceEditorAcquireParams) {
   try {
     const workspaceRoot = await canonicalWorkspaceRoot(params.workspaceRoot);
-    return workspaceMutationCoordinators.acquireEditor(workspaceRoot, {
+    const lease = workspaceMutationCoordinators.acquireEditor(workspaceRoot, {
       workspaceRoot,
       editorInstanceId: params.editorInstanceId,
       ...(params.takeover !== undefined ? { takeover: params.takeover } : {}),
@@ -4063,6 +4192,14 @@ async function acquireWorkspaceEditor(params: WorkspaceEditorAcquireParams) {
           }
         : {}),
     });
+    // A stale-authority transaction commits its replacement quarantine before
+    // projecting terminal audit entries. If that append failed, acquiring the
+    // same in-process coordinator is the client's retry boundary: do not
+    // acknowledge the lease until the append-once outbox is durably drained.
+    await workspaceMutationCoordinators
+      .getOrCreate(workspaceRoot)
+      .flushPendingAuditOutbox();
+    return lease;
   } catch (error) {
     throw invalidParams(error instanceof Error ? error.message : String(error));
   }
@@ -4073,14 +4210,21 @@ async function syncWorkspaceEditor(params: WorkspaceEditorSyncParams) {
   try {
     const workspaceRoot = await canonicalWorkspaceRoot(params.workspaceRoot);
     coordinator = workspaceMutationCoordinators.getOrCreate(workspaceRoot);
-    const result = coordinator.sync({
+    const input = {
       workspaceRoot,
       editorInstanceId: params.editorInstanceId,
       leaseToken: params.leaseToken,
       epoch: params.epoch,
       sequence: params.sequence,
       buffers: params.buffers,
-    });
+      ...(params.abandonStaleAuthority !== undefined
+        ? { abandonStaleAuthority: params.abandonStaleAuthority }
+        : {}),
+    };
+    if (params.abandonStaleAuthority !== undefined) {
+      return await coordinator.syncAbandoningStaleAuthority(input);
+    }
+    const result = coordinator.sync(input);
     await coordinator.flushQuarantinePersistence();
     return result;
   } catch (error) {
@@ -4088,6 +4232,24 @@ async function syncWorkspaceEditor(params: WorkspaceEditorSyncParams) {
     // contention. Do not let the client retry after the fence disappears
     // until that record is safely on disk.
     await coordinator?.flushQuarantinePersistence().catch(() => {});
+    throw invalidParams(error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function refreshWorkspaceEditorStaleAuthority(
+  params: WorkspaceEditorHeartbeatParams,
+) {
+  try {
+    const workspaceRoot = await canonicalWorkspaceRoot(params.workspaceRoot);
+    return workspaceMutationCoordinators
+      .getOrCreate(workspaceRoot)
+      .refreshStaleAuthority({
+        workspaceRoot,
+        editorInstanceId: params.editorInstanceId,
+        leaseToken: params.leaseToken,
+        epoch: params.epoch,
+      });
+  } catch (error) {
     throw invalidParams(error instanceof Error ? error.message : String(error));
   }
 }
@@ -4232,6 +4394,8 @@ async function resolveRecoveredWorkspaceEditorTopology(
       leaseToken: params.leaseToken,
       epoch: params.epoch,
       tokenId: params.tokenId,
+      sequence: params.sequence,
+      buffers: params.buffers,
     });
   } catch (error) {
     await coordinator?.flushQuarantinePersistence().catch(() => {});

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -12,7 +12,12 @@
  */
 
 export const JSON_RPC_VERSION = "2.0" as const;
-export const AGENC_DAEMON_PROTOCOL_VERSION = "1.0.0" as const;
+// 1.1 adds exact stale-Editor authority review/abandonment fields and its
+// read-only disk-evidence refresh request. A newer TUI must not negotiate with
+// a 1.0 daemon that would reject those requests after initialization; the
+// existing minor-version negotiation then produces the normal actionable
+// daemon-restart error instead.
+export const AGENC_DAEMON_PROTOCOL_VERSION = "1.1.0" as const;
 export const AGENC_DAEMON_PROTOCOL_SCHEMA_ID =
   "urn:agenc:app-server:protocol" as const;
 export const AGENC_DAEMON_PROTOCOL_PACKAGE_NAME =
@@ -97,6 +102,7 @@ export type AgenCDaemonMethod = (typeof AGENC_DAEMON_METHODS)[number];
 export const AGENC_DAEMON_INTERNAL_METHODS = [
   "workspace.editor.acquire",
   "workspace.editor.sync",
+  "workspace.editor.staleAuthority.refresh",
   "workspace.editor.heartbeat",
   "workspace.editor.release",
   "workspace.editor.topology.reserve",
@@ -614,6 +620,14 @@ export const AGENC_DAEMON_INTERNAL_METHOD_SPECS = defineInternalMethodSpecs({
     result: "object",
     description:
       "TUI-internal request to synchronize revisioned clean and dirty editor-buffer authority.",
+  },
+  "workspace.editor.staleAuthority.refresh": {
+    method: "workspace.editor.staleAuthority.refresh",
+    direction: "client-to-server",
+    params: "required",
+    result: "object",
+    description:
+      "TUI-internal read-only request to refresh exact disk evidence for quarantined Editor authority.",
   },
   "workspace.editor.heartbeat": {
     method: "workspace.editor.heartbeat",
@@ -1176,14 +1190,10 @@ export interface RunStartParams extends JsonObject {
 }
 
 export type CsvJobReviewDisposition =
-  | "confirmed_committed"
-  | "confirmed_no_effect"
-  | "remains_unknown";
+  "confirmed_committed" | "confirmed_no_effect" | "remains_unknown";
 
 export type CsvJobReviewDomainAction =
-  | "mark_completed"
-  | "retry_new_attempt"
-  | "abandon_item";
+  "mark_completed" | "retry_new_attempt" | "abandon_item";
 
 export type CsvJobReviewStatus = "pending" | "resolved" | "abandoned";
 
@@ -1274,17 +1284,14 @@ export interface SessionResolveToolCallEvidenceParams extends JsonObject {
   readonly sessionId: string;
   readonly toolCallId: string;
   readonly disposition:
-    | "confirmed_committed"
-    | "confirmed_no_effect"
-    | "remains_unknown";
+    "confirmed_committed" | "confirmed_no_effect" | "remains_unknown";
   readonly evidenceRef: string;
   readonly evidenceSha256: string;
   readonly reviewer?: string;
 }
 
 export type SessionResolveToolCallParams =
-  | SessionResolveToolCallLegacyParams
-  | SessionResolveToolCallEvidenceParams;
+  SessionResolveToolCallLegacyParams | SessionResolveToolCallEvidenceParams;
 
 export interface SessionSnapshotParams extends JsonObject {
   readonly sessionId: string;
@@ -1368,6 +1375,25 @@ export interface WorkspaceEditorBufferSync extends JsonObject {
   readonly content?: string;
 }
 
+/**
+ * Content-free evidence for an Editor revision that survived its owning
+ * process. It may be dirty or last-known-clean; the disk fingerprint binds an
+ * explicit "use disk" choice to the exact filesystem state the user reviewed.
+ * Source text is never exposed or persisted through this record.
+ */
+export interface WorkspaceEditorStaleAuthorityEntry extends JsonObject {
+  readonly path: string;
+  readonly editorContentSha256: string;
+  readonly editorContentBytes: number;
+  readonly changedtick: number;
+  readonly editorInstanceId: string;
+  readonly epoch: number;
+  readonly editorState: "dirty" | "clean";
+  readonly diskState: "content" | "missing" | "unavailable";
+  readonly diskContentSha256?: string;
+  readonly diskContentBytes?: number;
+}
+
 export interface WorkspaceEditorSyncParams extends JsonObject {
   readonly workspaceRoot: string;
   readonly editorInstanceId: string;
@@ -1375,6 +1401,11 @@ export interface WorkspaceEditorSyncParams extends JsonObject {
   readonly epoch: number;
   readonly sequence: number;
   readonly buffers: readonly WorkspaceEditorBufferSync[];
+  /**
+   * Exact evidence echoed only after an explicit user confirmation to abandon
+   * orphaned Editor revisions and keep the reviewed disk state instead.
+   */
+  readonly abandonStaleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[];
 }
 
 export interface WorkspaceEditorHeartbeatParams extends JsonObject {
@@ -1383,6 +1414,8 @@ export interface WorkspaceEditorHeartbeatParams extends JsonObject {
   readonly leaseToken: string;
   readonly epoch: number;
 }
+
+export interface WorkspaceEditorStaleAuthorityRefreshParams extends WorkspaceEditorHeartbeatParams {}
 
 export interface WorkspaceEditorTopologyTarget extends JsonObject {
   readonly path: string;
@@ -1406,9 +1439,7 @@ export interface WorkspaceEditorTopologyCompleteParams extends WorkspaceEditorTo
 
 export interface WorkspaceEditorRecoveredTopologyListParams extends WorkspaceEditorHeartbeatParams {}
 
-export interface WorkspaceEditorRecoveredTopologyResolveParams extends WorkspaceEditorHeartbeatParams {
-  readonly tokenId: string;
-}
+export interface WorkspaceEditorRecoveredTopologyResolveParams extends WorkspaceEditorTopologyFinalizeParams {}
 
 export interface WorkspaceEditorReleaseParams extends WorkspaceEditorHeartbeatParams {
   readonly abandonDirty?: boolean;
@@ -2059,14 +2090,8 @@ export type AgenCDaemonRequest =
   | AgenCDaemonRequestWithParams<"run.evidence", RunEvidenceParams>
   | AgenCDaemonRequestWithParams<"run.cancel", RunCancelParams>
   | AgenCDaemonRequestWithParams<"run.start", RunStartParams>
-  | AgenCDaemonRequestWithParams<
-      "csvJob.review.list",
-      CsvJobReviewListParams
-    >
-  | AgenCDaemonRequestWithParams<
-      "csvJob.review.show",
-      CsvJobReviewShowParams
-    >
+  | AgenCDaemonRequestWithParams<"csvJob.review.list", CsvJobReviewListParams>
+  | AgenCDaemonRequestWithParams<"csvJob.review.show", CsvJobReviewShowParams>
   | AgenCDaemonRequestWithParams<
       "csvJob.review.resolve",
       CsvJobReviewResolveParams
@@ -2253,9 +2278,7 @@ export interface CsvJobReviewDetail extends JsonObject {
     | "unknown_outcome";
   readonly attemptCount: number;
   readonly resultAvailability:
-    | "not_produced"
-    | "available"
-    | "unavailable_after_review";
+    "not_produced" | "available" | "unavailable_after_review";
   readonly resultSizeBytes: number;
   readonly resultDigest?: string;
   readonly reviewStatus: CsvJobReviewStatus;
@@ -2835,6 +2858,8 @@ export interface WorkspaceEditorLeaseResult extends JsonObject {
   readonly epoch: number;
   readonly sequence: number;
   readonly expiresAt: number;
+  /** Present on acquire so a reconnecting Editor can offer recovery. */
+  readonly staleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[];
 }
 
 export interface WorkspaceEditorSyncResult extends JsonObject {
@@ -2843,6 +2868,12 @@ export interface WorkspaceEditorSyncResult extends JsonObject {
   readonly expiresAt: number;
   readonly dirtyPaths: readonly string[];
   readonly stalePaths: readonly string[];
+  readonly staleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[];
+}
+
+export interface WorkspaceEditorStaleAuthorityRefreshResult extends JsonObject {
+  readonly refreshed: true;
+  readonly staleAuthority: readonly WorkspaceEditorStaleAuthorityEntry[];
 }
 
 export interface WorkspaceEditorReleaseResult extends JsonObject {
@@ -2884,6 +2915,7 @@ export interface WorkspaceEditorRecoveredTopologyResolveResult extends JsonObjec
   readonly resolved: true;
   readonly tokenId: string;
   readonly status: "unknown_outcome";
+  readonly sync: WorkspaceEditorSyncResult;
 }
 
 export interface WorkspaceEditorProposalResult extends JsonObject {
@@ -2952,11 +2984,14 @@ export interface WorkspaceEditorChangeResult extends JsonObject {
   readonly workspaceRoot: string;
   readonly path: string;
   readonly source: string;
+  readonly kind?: "path" | "topology";
   readonly status:
     "applied" | "proposed" | "blocked" | "discarded" | "unknown_outcome";
-  readonly beforeSha256: string;
+  readonly beforeSha256?: string;
   readonly afterSha256?: string;
   readonly proposalId?: string;
+  readonly topologyTokenId?: string;
+  readonly includeDescendants?: boolean;
 }
 
 export interface WorkspaceEditorChangesListResult extends JsonObject {
@@ -3351,6 +3386,7 @@ export interface AgenCDaemonResultByMethod {
 export interface AgenCDaemonInternalResultByMethod {
   readonly "workspace.editor.acquire": WorkspaceEditorLeaseResult;
   readonly "workspace.editor.sync": WorkspaceEditorSyncResult;
+  readonly "workspace.editor.staleAuthority.refresh": WorkspaceEditorStaleAuthorityRefreshResult;
   readonly "workspace.editor.heartbeat": WorkspaceEditorLeaseResult;
   readonly "workspace.editor.release": WorkspaceEditorReleaseResult;
   readonly "workspace.editor.topology.reserve": WorkspaceEditorTopologyReserveResult;

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -2779,6 +2779,7 @@ type DeferredWorkspaceEditorSessionSurface = Pick<
   AgenCTuiBridgeSession,
   | "acquireWorkspaceEditor"
   | "syncWorkspaceEditor"
+  | "refreshWorkspaceEditorStaleAuthority"
   | "heartbeatWorkspaceEditor"
   | "releaseWorkspaceEditor"
   | "reserveWorkspaceEditorTopology"
@@ -3508,6 +3509,11 @@ async function createDeferredDaemonPromptTuiSession(params: {
     syncWorkspaceEditor: async (editorParams) =>
       (await ensureWorkspaceEditorControlClient()).request(
         "workspace.editor.sync",
+        editorParams,
+      ),
+    refreshWorkspaceEditorStaleAuthority: async (editorParams) =>
+      (await ensureWorkspaceEditorControlClient()).request(
+        "workspace.editor.staleAuthority.refresh",
         editorParams,
       ),
     heartbeatWorkspaceEditor: async (editorParams) =>

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -48,8 +48,12 @@ import type {
 import type {
   WorkspaceEditorProposalResult,
   WorkspaceEditorProposalStatusResult,
+  WorkspaceEditorStaleAuthorityEntry,
 } from "../../app-server/protocol/index.js";
-import type { BufferCodePredictionUi } from "../workbench/surfaces/BufferSurface.js";
+import type {
+  BufferCodePredictionUi,
+  BufferStaleAuthorityRecoveryUi,
+} from "../workbench/surfaces/BufferSurface.js";
 import { installPrivateNeovimRecovery } from "../workbench/buffer/neovim/NeovimRecovery.js";
 import {
   applyWorkbenchCommand,
@@ -74,9 +78,11 @@ import {
 } from "../workbench/uiStatePersistence.js";
 import {
   bufferSnapshotRequiresWorkspaceEditorAuthority,
+  abandonWorkspaceEditorStaleAuthority,
   createOrderedWorkspaceEditorTeardown,
   isValidAcceptedEditorProposalResolution,
   isValidRejectedEditorProposalResolution,
+  refreshWorkspaceEditorStaleAuthority,
   resolveWorkspaceEditorRecoveredTopologyMutation,
   settleWorkspaceEditorTeardown,
   WorkspaceEditorLeaseSynchronizer,
@@ -3135,10 +3141,66 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       },
     };
   }, [addNotification, bufferWorkspaceRoot, workspaceEditorAuthority]);
+  const editorStaleAuthorityRecovery = useMemo<
+    BufferStaleAuthorityRecoveryUi | undefined
+  >(() => {
+    const entries: readonly WorkspaceEditorStaleAuthorityEntry[] | undefined =
+      workspaceEditorAuthority.status === "blocked"
+        ? workspaceEditorAuthority.staleAuthority
+        : undefined;
+    if (entries === undefined || entries.length === 0) return undefined;
+    return {
+      entries,
+      onRefresh: async (): Promise<void> => {
+        try {
+          await refreshWorkspaceEditorStaleAuthority(bufferWorkspaceRoot);
+        } catch (cause) {
+          const error =
+            cause instanceof Error ? cause : new Error(String(cause));
+          addNotification({
+            key: "workspace-editor-stale-authority-refresh-failed",
+            text: `Could not refresh disk evidence for the orphaned Editor revision: ${error.message}`,
+            color: "error",
+            priority: "high",
+          });
+          throw error;
+        }
+      },
+      onUseDisk: async (
+        reviewedEntries: readonly WorkspaceEditorStaleAuthorityEntry[],
+      ): Promise<void> => {
+        try {
+          await abandonWorkspaceEditorStaleAuthority(
+            bufferWorkspaceRoot,
+            reviewedEntries,
+          );
+          addNotification({
+            key: `workspace-editor-stale-authority-abandoned:${reviewedEntries
+              .map((entry) => entry.editorContentSha256)
+              .join(":")}`,
+            text: `${reviewedEntries.length} orphaned Editor revision${reviewedEntries.length === 1 ? "" : "s"} abandoned after exact disk-state confirmation. Editor authority was resynchronized.`,
+            color: "warning",
+            priority: "high",
+          });
+        } catch (cause) {
+          const error =
+            cause instanceof Error ? cause : new Error(String(cause));
+          addNotification({
+            key: "workspace-editor-stale-authority-abandon-failed",
+            text: `Could not use disk for the orphaned Editor revision: ${error.message}`,
+            color: "error",
+            priority: "high",
+          });
+          throw error;
+        }
+      },
+    };
+  }, [addNotification, bufferWorkspaceRoot, workspaceEditorAuthority]);
   const workspaceEditorAuthoritySupported =
     workbenchEnabled &&
     props.session.acquireWorkspaceEditor !== undefined &&
     props.session.syncWorkspaceEditor !== undefined &&
+    props.session.refreshWorkspaceEditorStaleAuthority !== undefined &&
     props.session.heartbeatWorkspaceEditor !== undefined &&
     props.session.releaseWorkspaceEditor !== undefined &&
     props.session.reserveWorkspaceEditorTopology !== undefined &&
@@ -3216,6 +3278,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     }
     const acquireWorkspaceEditor = props.session.acquireWorkspaceEditor;
     const syncWorkspaceEditor = props.session.syncWorkspaceEditor;
+    const refreshWorkspaceEditorStaleAuthority =
+      props.session.refreshWorkspaceEditorStaleAuthority;
     const heartbeatWorkspaceEditor = props.session.heartbeatWorkspaceEditor;
     const releaseWorkspaceEditor = props.session.releaseWorkspaceEditor;
     const reserveWorkspaceEditorTopology =
@@ -3243,6 +3307,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       client: {
         acquireWorkspaceEditor: (params) => acquireWorkspaceEditor(params),
         syncWorkspaceEditor: (params) => syncWorkspaceEditor(params),
+        refreshWorkspaceEditorStaleAuthority: (params) =>
+          refreshWorkspaceEditorStaleAuthority(params),
         heartbeatWorkspaceEditor: (params) => heartbeatWorkspaceEditor(params),
         releaseWorkspaceEditor: (params) => releaseWorkspaceEditor(params),
         reserveWorkspaceEditorTopology: (params) =>
@@ -3295,6 +3361,9 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           : {}),
       },
       onWorkspaceChange: async (change) => {
+        // Target-scoped topology invalidations are reconciled under the
+        // synchronizer's provider lock before this callback is acknowledged.
+        if (change.kind === "topology") return;
         if (change.status === "proposed") {
           const reference = workspaceMutationProposalFromChange(change);
           if (reference === null) {
@@ -4503,7 +4572,9 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         // plugins) reporting "Unknown command" on submit.
         logForDebugging(
           `dynamic TUI command load failed; palette degraded to built-ins: ${
-            error instanceof Error ? (error.stack ?? error.message) : String(error)
+            error instanceof Error
+              ? (error.stack ?? error.message)
+              : String(error)
           }`,
           { level: "warn" },
         );
@@ -7003,6 +7074,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           codePrediction={codePrediction}
           editorMutationBlockedReason={workspaceEditorBlockers.editor}
           editorTopologyRecovery={editorTopologyRecovery}
+          editorStaleAuthorityRecovery={editorStaleAuthorityRecovery}
         />
       ) : (
         <FullscreenLayout

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -71,6 +71,8 @@ import type {
   WorkspaceEditorRecoveredTopologyListResult,
   WorkspaceEditorRecoveredTopologyResolveParams,
   WorkspaceEditorRecoveredTopologyResolveResult,
+  WorkspaceEditorStaleAuthorityRefreshParams,
+  WorkspaceEditorStaleAuthorityRefreshResult,
   WorkspaceEditorSyncParams,
   WorkspaceEditorSyncResult,
   WorkspaceEditorTopologyCompleteParams,
@@ -232,6 +234,9 @@ export interface AgenCTuiBridgeSession extends AgenCCompactProgressControls {
   syncWorkspaceEditor?(
     params: WorkspaceEditorSyncParams,
   ): Promise<WorkspaceEditorSyncResult>;
+  refreshWorkspaceEditorStaleAuthority?(
+    params: WorkspaceEditorStaleAuthorityRefreshParams,
+  ): Promise<WorkspaceEditorStaleAuthorityRefreshResult>;
   heartbeatWorkspaceEditor?(
     params: WorkspaceEditorHeartbeatParams,
   ): Promise<WorkspaceEditorLeaseResult>;
@@ -484,6 +489,10 @@ interface AgenCDaemonEditorCoherenceClient {
     method: "workspace.editor.sync",
     params: WorkspaceEditorSyncParams,
   ): Promise<WorkspaceEditorSyncResult>;
+  request(
+    method: "workspace.editor.staleAuthority.refresh",
+    params: WorkspaceEditorStaleAuthorityRefreshParams,
+  ): Promise<WorkspaceEditorStaleAuthorityRefreshResult>;
   request(
     method: "workspace.editor.heartbeat",
     params: WorkspaceEditorHeartbeatParams,
@@ -1215,6 +1224,11 @@ export function createDaemonTuiSession<
       editorCoherenceClient.request("workspace.editor.acquire", params),
     syncWorkspaceEditor: async (params) =>
       editorCoherenceClient.request("workspace.editor.sync", params),
+    refreshWorkspaceEditorStaleAuthority: async (params) =>
+      editorCoherenceClient.request(
+        "workspace.editor.staleAuthority.refresh",
+        params,
+      ),
     heartbeatWorkspaceEditor: async (params) =>
       editorCoherenceClient.request("workspace.editor.heartbeat", params),
     releaseWorkspaceEditor: async (params) =>

--- a/runtime/src/tui/session-types.ts
+++ b/runtime/src/tui/session-types.ts
@@ -48,6 +48,8 @@ import type {
   WorkspaceEditorRecoveredTopologyListResult,
   WorkspaceEditorRecoveredTopologyResolveParams,
   WorkspaceEditorRecoveredTopologyResolveResult,
+  WorkspaceEditorStaleAuthorityRefreshParams,
+  WorkspaceEditorStaleAuthorityRefreshResult,
   WorkspaceEditorSyncParams,
   WorkspaceEditorSyncResult,
   WorkspaceEditorTopologyCompleteParams,
@@ -243,6 +245,9 @@ export interface AgenCBridgeSession extends AgenCCompactProgressControls {
   syncWorkspaceEditor?(
     params: WorkspaceEditorSyncParams,
   ): Promise<WorkspaceEditorSyncResult>;
+  refreshWorkspaceEditorStaleAuthority?(
+    params: WorkspaceEditorStaleAuthorityRefreshParams,
+  ): Promise<WorkspaceEditorStaleAuthorityRefreshResult>;
   heartbeatWorkspaceEditor?(
     params: WorkspaceEditorHeartbeatParams,
   ): Promise<WorkspaceEditorLeaseResult>;

--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -7,6 +7,7 @@ import { useShortcutDisplay } from "../keybindings/useShortcutDisplay.js";
 import { useAppState } from "../state/AppState.js";
 import { useWorkbenchState } from "./state.js";
 import { useBufferStore } from "./buffer/useBufferStore.js";
+import { bufferKeybindingContext } from "./buffer/keybindingContext.js";
 
 // Hints are `<label>: <segment>  <segment>  …` with double-space separators.
 // On narrow terminals whole trailing segments are dropped instead of
@@ -28,27 +29,26 @@ export function WorkbenchFooter(): React.ReactElement {
   const { columns } = useTerminalSize();
   const workbench = useWorkbenchState();
   const buffer = useBufferStore();
-  const bufferKeybindingContext = buffer.provider.capabilities.terminalUi
-    ? "BufferHost"
-    : "Buffer";
+  const activeBufferKeybindingContext = bufferKeybindingContext(buffer);
+  const usesHostKeybindings = activeBufferKeybindingContext === "BufferHost";
   const composerShortcut = useShortcutDisplay(
     "workbench:focusComposer",
-    bufferKeybindingContext,
+    activeBufferKeybindingContext,
     "shift+tab",
   );
   const panelShortcut = useShortcutDisplay(
     "workbench:focusRail",
-    bufferKeybindingContext,
-    buffer.provider.capabilities.terminalUi ? "alt+l" : "ctrl+x l",
+    activeBufferKeybindingContext,
+    usesHostKeybindings ? "alt+l" : "ctrl+x l",
   );
   const maximizeShortcut = useShortcutDisplay(
     "workbench:toggleSurfaceMaximized",
-    bufferKeybindingContext,
-    buffer.provider.capabilities.terminalUi ? "alt+z" : "ctrl+x z",
+    activeBufferKeybindingContext,
+    usesHostKeybindings ? "alt+z" : "ctrl+x z",
   );
   const saveShortcut = useShortcutDisplay(
     "buffer:save",
-    bufferKeybindingContext,
+    activeBufferKeybindingContext,
     "ctrl+s",
   );
   const configuredRedoShortcut = useShortcutDisplay(
@@ -56,13 +56,11 @@ export function WorkbenchFooter(): React.ReactElement {
     "Buffer",
     "ctrl+x y",
   );
-  const redoShortcut = buffer.provider.capabilities.terminalUi
-    ? "ctrl+r"
-    : configuredRedoShortcut;
+  const redoShortcut = usesHostKeybindings ? "ctrl+r" : configuredRedoShortcut;
   const closeShortcut = useShortcutDisplay(
     "buffer:close",
-    bufferKeybindingContext,
-    buffer.provider.capabilities.terminalUi ? "alt+q" : "ctrl+x q",
+    activeBufferKeybindingContext,
+    usesHostKeybindings ? "alt+q" : "ctrl+x q",
   );
   const modeShortcut = useShortcutDisplay(
     "chat:cycleMode",

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -22,6 +22,7 @@ import { ProjectExplorer } from "./project-tree/ProjectExplorer.js";
 import { ActiveWorkSurface } from "./surfaces/ActiveWorkSurface.js";
 import type {
   BufferCodePredictionUi,
+  BufferStaleAuthorityRecoveryUi,
   BufferTopologyRecoveryUi,
 } from "./surfaces/BufferSurface.js";
 import { WorkbenchComposerFocusProvider } from "./composerFocusContext.js";
@@ -75,6 +76,7 @@ type Props = {
   readonly codePrediction?: BufferCodePredictionUi;
   readonly editorMutationBlockedReason?: string | null;
   readonly editorTopologyRecovery?: BufferTopologyRecoveryUi;
+  readonly editorStaleAuthorityRecovery?: BufferStaleAuthorityRecoveryUi;
 };
 
 export function WorkbenchLayout({
@@ -94,6 +96,7 @@ export function WorkbenchLayout({
   codePrediction,
   editorMutationBlockedReason = null,
   editorTopologyRecovery,
+  editorStaleAuthorityRecovery,
 }: Props): React.ReactElement {
   const { columns, rows } = useTerminalSize();
   const workbench = useWorkbenchState();
@@ -290,6 +293,7 @@ export function WorkbenchLayout({
               codePrediction={codePrediction}
               editorMutationBlockedReason={editorMutationBlockedReason}
               editorTopologyRecovery={editorTopologyRecovery}
+              editorStaleAuthorityRecovery={editorStaleAuthorityRecovery}
             />
           </ContentWidthProvider>
           {showRail ? (

--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -108,7 +108,9 @@ type Listener = () => void;
 export type BufferVimCommand =
   | { readonly type: "save"; readonly force: boolean }
   | { readonly type: "quit"; readonly discard: boolean; readonly all: boolean }
-  | { readonly type: "saveQuit"; readonly force: boolean; readonly all: boolean };
+  | { readonly type: "saveQuit"; readonly force: boolean; readonly all: boolean }
+  | { readonly type: "reload"; readonly force: true }
+  | { readonly type: "closeBuffer"; readonly discard: true };
 
 type BufferVimCommandHandler = (command: BufferVimCommand) => void;
 export type WorkbenchBufferStoreOptions = {
@@ -1070,6 +1072,12 @@ function parseVimCommand(rawCommand: string): BufferVimCommand | null {
     case "xa!":
     case "xall!":
       return { type: "saveQuit", force: true, all: true };
+    case "e!":
+    case "edit!":
+      return { type: "reload", force: true };
+    case "bd!":
+    case "bdelete!":
+      return { type: "closeBuffer", discard: true };
     default:
       return null;
   }

--- a/runtime/src/tui/workbench/buffer/keybindingContext.ts
+++ b/runtime/src/tui/workbench/buffer/keybindingContext.ts
@@ -1,0 +1,29 @@
+import type { KeybindingContextName } from "../../keybindings/types.js";
+
+import type { BufferProviderSnapshot } from "./providers/types.js";
+
+export type BufferKeybindingContext = Extract<
+  KeybindingContextName,
+  "Buffer" | "BufferHost"
+>;
+
+/**
+ * Select the keybinding vocabulary for the current BUFFER input owner.
+ *
+ * Before any provider has opened a file, the empty Editor surface is host UI:
+ * the controller's initial inline identity is only a placeholder and must not
+ * make the empty surface advertise or require inline-editor chords. Once a
+ * provider owns a file, its terminal capability selects between Neovim host
+ * escape hatches and the inline fallback's existing key vocabulary.
+ */
+export function bufferKeybindingContext(
+  snapshot: Pick<
+    BufferProviderSnapshot,
+    "filePath" | "provider" | "providerStatus"
+  >,
+): BufferKeybindingContext {
+  const emptyHostSurface = snapshot.filePath === null;
+  return snapshot.provider.capabilities.terminalUi || emptyHostSurface
+    ? "BufferHost"
+    : "Buffer";
+}

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -256,6 +256,45 @@ const DISCARD_ALL_BUFFERS = [
   "return true",
 ].join("\n");
 
+const RELOAD_BUFFER_FOR_STALE_AUTHORITY = [
+  "local buffer, expected_path = ...",
+  "if not vim.api.nvim_buf_is_valid(buffer) or not vim.api.nvim_buf_is_loaded(buffer) then",
+  "  error('stale-authority buffer is no longer loaded: ' .. tostring(buffer))",
+  "end",
+  "if vim.api.nvim_get_option_value('buftype', { buf = buffer }) ~= '' then",
+  "  error('stale-authority recovery requires a file buffer: ' .. tostring(buffer))",
+  "end",
+  "local actual_path = vim.api.nvim_buf_get_name(buffer)",
+  "if actual_path ~= expected_path then",
+  "  error('stale-authority buffer path changed before reload: ' .. actual_path)",
+  "end",
+  "local ok, failure = pcall(vim.api.nvim_buf_call, buffer, function()",
+  "  vim.cmd('silent keepalt noautocmd edit!')",
+  "end)",
+  "if not ok then error('stale-authority reload failed: ' .. tostring(failure)) end",
+  "return true",
+].join("\n");
+
+const UNLOAD_BUFFER_FOR_STALE_AUTHORITY = [
+  "local buffer, expected_path = ...",
+  "if not vim.api.nvim_buf_is_valid(buffer) or not vim.api.nvim_buf_is_loaded(buffer) then",
+  "  error('stale-authority buffer is no longer loaded: ' .. tostring(buffer))",
+  "end",
+  "if vim.api.nvim_get_option_value('buftype', { buf = buffer }) ~= '' then",
+  "  error('stale-authority recovery requires a file buffer: ' .. tostring(buffer))",
+  "end",
+  "local actual_path = vim.api.nvim_buf_get_name(buffer)",
+  "if actual_path ~= expected_path then",
+  "  error('stale-authority buffer path changed before unload: ' .. actual_path)",
+  "end",
+  "local ok, failure = pcall(vim.cmd, 'silent noautocmd bdelete! ' .. tostring(buffer))",
+  "if not ok then error('stale-authority unload failed: ' .. tostring(failure)) end",
+  "if vim.api.nvim_buf_is_valid(buffer) and vim.api.nvim_buf_is_loaded(buffer) then",
+  "  error('stale-authority buffer remained loaded: ' .. tostring(buffer))",
+  "end",
+  "return true",
+].join("\n");
+
 const REBASE_FILE_BUFFERS = [
   "local changes = ...",
   "local moving = {}",
@@ -796,6 +835,54 @@ export class EmbeddedNeovimSession {
         await this.#request(
           "nvim_set_current_buf",
           [normalizedHandle],
+          signal,
+          timeoutMs,
+        );
+      },
+    );
+    return true;
+  }
+
+  async reloadBufferForStaleAuthority(
+    handle: number,
+    expectedPath: string,
+  ): Promise<boolean> {
+    if (this.#closed) return false;
+    const normalizedHandle = normalizeBufferHandle(handle);
+    if (expectedPath.length === 0) {
+      throw new Error("Stale-authority recovery requires a named file buffer.");
+    }
+    await this.#runRpcOperation(
+      `Embedded Neovim buffer ${handle} stale-authority reload`,
+      true,
+      async (signal, timeoutMs) => {
+        await this.#request(
+          "nvim_exec_lua",
+          [RELOAD_BUFFER_FOR_STALE_AUTHORITY, [normalizedHandle, expectedPath]],
+          signal,
+          timeoutMs,
+        );
+      },
+    );
+    return true;
+  }
+
+  async unloadBufferForStaleAuthority(
+    handle: number,
+    expectedPath: string,
+  ): Promise<boolean> {
+    if (this.#closed) return false;
+    const normalizedHandle = normalizeBufferHandle(handle);
+    if (expectedPath.length === 0) {
+      throw new Error("Stale-authority recovery requires a named file buffer.");
+    }
+    await this.#runRpcOperation(
+      `Embedded Neovim buffer ${handle} stale-authority unload`,
+      true,
+      async (signal, timeoutMs) => {
+        await this.#request(
+          "nvim_exec_lua",
+          [UNLOAD_BUFFER_FOR_STALE_AUTHORITY, [normalizedHandle, expectedPath]],
           signal,
           timeoutMs,
         );

--- a/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
+++ b/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
@@ -43,6 +43,7 @@ import type {
   BufferProviderSaveAllResult,
   BufferProviderShutdownOptions,
   BufferProviderSnapshot,
+  BufferStaleAuthorityEditorAction,
   BufferWorkspaceBufferCapture,
   BufferWorkspaceWriteAuthorityHandler,
 } from "./types.js";
@@ -684,6 +685,14 @@ export class BufferProviderController {
       this.#provider?.resolveRecovery?.(action) ??
       Promise.resolve({ ok: false, reason: "No BUFFER recovery is pending." })
     );
+  }
+
+  async performStaleAuthorityEditorAction(
+    action: BufferStaleAuthorityEditorAction,
+  ): Promise<boolean> {
+    const provider = this.#provider;
+    if (!provider?.performStaleAuthorityEditorAction) return false;
+    return provider.performStaleAuthorityEditorAction(action);
   }
 
   subscribeIntegrationIntents(

--- a/runtime/src/tui/workbench/buffer/providers/inline/InlineBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/inline/InlineBufferProvider.ts
@@ -13,6 +13,7 @@ import type {
   BufferProviderResize,
   BufferProviderSaveOptions,
   BufferProviderSnapshot,
+  BufferStaleAuthorityEditorAction,
 } from "../types.js";
 import { INLINE_BUFFER_CAPABILITIES, withProviderSnapshot } from "../types.js";
 
@@ -58,6 +59,21 @@ export class InlineBufferProvider implements BufferEditorProvider {
 
   async revert(): Promise<void> {
     await this.#store.revert();
+  }
+
+  async performStaleAuthorityEditorAction(
+    action: BufferStaleAuthorityEditorAction,
+  ): Promise<boolean> {
+    const before = this.#store.getSnapshot();
+    if (before.absolutePath === null || before.absolutePath !== action.path) {
+      return false;
+    }
+    if (action.type === "reload") {
+      await this.#store.revert();
+      const after = this.#store.getSnapshot();
+      return after.absolutePath === action.path && after.status === "ready";
+    }
+    return this.#store.close({ discard: true });
   }
 
   async prepareDiscardAll(): Promise<string | null> {

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -67,12 +67,14 @@ import type {
   BufferProviderSaveAllResult,
   BufferProviderShutdownOptions,
   BufferProviderSnapshot,
+  BufferStaleAuthorityEditorAction,
   BufferWorkspaceBufferCapture,
   BufferWorkspaceWriteAuthorityHandler,
   BufferWorkspaceWriteDecision,
   BufferWorkspaceWriteRequest,
 } from "../types.js";
 import {
+  BufferWorkspaceCaptureUnstableError,
   emptyProviderSnapshot,
   NEOVIM_BUFFER_CAPABILITIES,
   positionFromNeovimCursor,
@@ -465,9 +467,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       }));
     }
 
-    throw new Error(
-      "Neovim buffers changed during workspace synchronization; retry.",
-    );
+    throw new BufferWorkspaceCaptureUnstableError();
   }
 
   setWorkspaceWriteAuthorityHandler(
@@ -1980,6 +1980,81 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     if (!this.#ownsOperation(ownership)) return;
     await this.#refreshFileSnapshot(this.#captureFileOwnership());
     this.#setSnapshot("ready", null);
+  }
+
+  async performStaleAuthorityEditorAction(
+    action: BufferStaleAuthorityEditorAction,
+  ): Promise<boolean> {
+    if (this.#projectPathMutationLocked) {
+      this.#setSnapshot(
+        "conflict",
+        "Wait for the current project rename or delete before recovering this buffer.",
+      );
+      return false;
+    }
+    const session = this.#session;
+    if (!session) return false;
+    const ownership = this.#captureOperationOwnership(session);
+    try {
+      await this.#refreshWorkspace(ownership);
+      if (!this.#ownsOperation(ownership)) return false;
+      const target = this.#buffers.find(
+        (buffer) =>
+          buffer.loaded &&
+          buffer.bufferType === "" &&
+          buffer.name.length > 0 &&
+          buffer.absolutePath !== null &&
+          sameNeovimFilePath(buffer.absolutePath, action.path),
+      );
+      if (!target) {
+        this.#setSnapshot(
+          "error",
+          `The reviewed stale-authority path is not loaded in Neovim: ${action.path}`,
+        );
+        return false;
+      }
+      const recoverySession = session as EmbeddedNeovimSession & {
+        reloadBufferForStaleAuthority?: EmbeddedNeovimSession["reloadBufferForStaleAuthority"];
+        unloadBufferForStaleAuthority?: EmbeddedNeovimSession["unloadBufferForStaleAuthority"];
+      };
+      const completed =
+        action.type === "reload"
+          ? await recoverySession.reloadBufferForStaleAuthority?.(
+              target.handle,
+              target.name,
+            )
+          : await recoverySession.unloadBufferForStaleAuthority?.(
+              target.handle,
+              target.name,
+            );
+      if (completed !== true) {
+        throw new Error(
+          "The active Neovim session does not support restricted stale-authority recovery.",
+        );
+      }
+      if (!this.#ownsOperation(ownership)) return false;
+      if (target.absolutePath !== null) {
+        this.#fileSnapshots.delete(
+          neovimFileSnapshotKey(target.absolutePath),
+        );
+      }
+      await this.#refreshWorkspace(ownership);
+      if (!this.#ownsOperation(ownership)) return false;
+      if (action.type === "reload") {
+        await this.#refreshFileSnapshot(this.#captureFileOwnership());
+        if (!this.#ownsOperation(ownership)) return false;
+      }
+      this.#setSnapshot("ready", null);
+      return true;
+    } catch (error) {
+      if (this.#ownsOperation(ownership)) {
+        this.#setSnapshot(
+          "error",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      return false;
+    }
   }
 
   async close(options: BufferProviderCloseOptions = {}): Promise<boolean> {

--- a/runtime/src/tui/workbench/buffer/providers/types.ts
+++ b/runtime/src/tui/workbench/buffer/providers/types.ts
@@ -121,6 +121,17 @@ export type BufferProviderCleanupOptions = {
 export type BufferRecoveryAction =
   "recover" | "compare" | "save-copy" | "discard";
 
+/**
+ * The only buffer mutations exposed by the hard stale-authority inspector.
+ * Native providers implement these as host-directed operations rather than
+ * replaying user input through their command surface.
+ */
+export type BufferStaleAuthorityEditorAction = {
+  readonly type: "reload" | "unload";
+  /** Exact reviewed quarantine path this action is allowed to affect. */
+  readonly path: string;
+};
+
 export type BufferRecoveryResult =
   | { readonly ok: true; readonly copyPath?: string }
   | { readonly ok: false; readonly reason: string };
@@ -278,6 +289,18 @@ export type BufferWorkspaceBufferCapture = {
 };
 
 /**
+ * The provider observed a valid workspace manifest, but it changed while the
+ * corresponding buffer contents were being copied. Nothing is unsafe or
+ * malformed; the caller must keep mutations fenced and retry the capture.
+ */
+export class BufferWorkspaceCaptureUnstableError extends Error {
+  constructor() {
+    super("Neovim buffers changed during workspace synchronization; retry.");
+    this.name = "BufferWorkspaceCaptureUnstableError";
+  }
+}
+
+/**
  * Exact in-memory workspace state captured synchronously by Neovim before a
  * native write. The target is repeated explicitly so a malformed or stale
  * manifest can never authorize a different buffer's `:write`.
@@ -380,6 +403,9 @@ export interface BufferEditorProvider {
   ): void;
   reloadCleanPath?(path: string): Promise<BufferExternalChangeResolution>;
   resolveRecovery?(action: BufferRecoveryAction): Promise<BufferRecoveryResult>;
+  performStaleAuthorityEditorAction?(
+    action: BufferStaleAuthorityEditorAction,
+  ): Promise<boolean>;
   subscribeIntegrationIntents?(
     listener: BufferIntegrationIntentListener,
   ): () => void;

--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -13,6 +13,7 @@ import { AgentSurface } from "./AgentSurface.js";
 import {
   BufferSurface,
   type BufferCodePredictionUi,
+  type BufferStaleAuthorityRecoveryUi,
   type BufferTopologyRecoveryUi,
 } from "./BufferSurface.js";
 import { DiffSurface } from "./DiffSurface.js";
@@ -33,6 +34,7 @@ export type WorkbenchSurfaceRenderProps = {
   readonly codePrediction?: BufferCodePredictionUi;
   readonly editorMutationBlockedReason?: string | null;
   readonly editorTopologyRecovery?: BufferTopologyRecoveryUi;
+  readonly editorStaleAuthorityRecovery?: BufferStaleAuthorityRecoveryUi;
 };
 
 export type WorkbenchSurfaceDescriptor = {
@@ -88,6 +90,7 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
       codePrediction,
       editorMutationBlockedReason,
       editorTopologyRecovery,
+      editorStaleAuthorityRecovery,
     }) => (
       <BufferSurface
         focused={focused}
@@ -95,6 +98,7 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
         codePrediction={codePrediction}
         mutationBlockedReason={editorMutationBlockedReason}
         topologyRecovery={editorTopologyRecovery}
+        staleAuthorityRecovery={editorStaleAuthorityRecovery}
       />
     ),
   },
@@ -163,6 +167,7 @@ export function ActiveWorkSurface({
   codePrediction,
   editorMutationBlockedReason,
   editorTopologyRecovery,
+  editorStaleAuthorityRecovery,
 }: {
   readonly focused: boolean;
   readonly transcript: React.ReactNode;
@@ -173,6 +178,7 @@ export function ActiveWorkSurface({
   readonly codePrediction?: BufferCodePredictionUi;
   readonly editorMutationBlockedReason?: string | null;
   readonly editorTopologyRecovery?: BufferTopologyRecoveryUi;
+  readonly editorStaleAuthorityRecovery?: BufferStaleAuthorityRecoveryUi;
 }): React.ReactElement {
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
@@ -234,6 +240,7 @@ export function ActiveWorkSurface({
               codePrediction,
               editorMutationBlockedReason,
               editorTopologyRecovery,
+              editorStaleAuthorityRecovery,
             })}
           </WorkbenchTranscriptLayoutProvider>
         ) : (
@@ -247,6 +254,7 @@ export function ActiveWorkSurface({
             codePrediction,
             editorMutationBlockedReason,
             editorTopologyRecovery,
+            editorStaleAuthorityRecovery,
           })
         )}
       </Box>

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -8,7 +8,10 @@ import React, {
 } from "react";
 import { basename, relative } from "node:path";
 
-import type { WorkspaceEditorRecoveredTopologyMutation } from "../../../app-server/protocol/index.js";
+import type {
+  WorkspaceEditorRecoveredTopologyMutation,
+  WorkspaceEditorStaleAuthorityEntry,
+} from "../../../app-server/protocol/index.js";
 import { peekLSPDiagnosticsForFile } from "../../../services/lsp/LSPDiagnosticRegistry.js";
 import { peekAmbientRuntimeSession } from "../../../session/current-session.js";
 import type { DiagnosticEntry } from "../../../services/lsp/types.js";
@@ -34,6 +37,7 @@ import { highlightBufferVisibleLines } from "../buffer/highlight.js";
 import { getWorkbenchBufferProviderController } from "../buffer/providers/BufferProviderController.js";
 import { BufferLine, NeovimGridView } from "../buffer/render.js";
 import { useBufferStore } from "../buffer/useBufferStore.js";
+import { bufferKeybindingContext } from "../buffer/keybindingContext.js";
 import { bufferIntegrationIntentCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
@@ -50,6 +54,7 @@ import type {
 
 const EMPTY_HIGHLIGHTS: ReadonlyMap<number, string> = new Map();
 const INITIAL_CONTENT_SIZE = { rows: 1, columns: 1 } as const;
+const STALE_AUTHORITY_REVIEW_BATCH_SIZE = 1;
 
 export type BufferCodePredictionUi = {
   readonly enabled: boolean;
@@ -68,18 +73,28 @@ export type BufferTopologyRecoveryUi = {
   readonly onResolveUnknown: () => Promise<void>;
 };
 
+export type BufferStaleAuthorityRecoveryUi = {
+  readonly entries: readonly WorkspaceEditorStaleAuthorityEntry[];
+  readonly onRefresh: () => Promise<void>;
+  readonly onUseDisk: (
+    entries: readonly WorkspaceEditorStaleAuthorityEntry[],
+  ) => Promise<void>;
+};
+
 export function BufferSurface({
   focused,
   onEditorInteraction,
   codePrediction,
   mutationBlockedReason = null,
   topologyRecovery,
+  staleAuthorityRecovery,
 }: {
   readonly focused: boolean;
   readonly onEditorInteraction?: (intent: BufferIntegrationIntent) => void;
   readonly codePrediction?: BufferCodePredictionUi;
   readonly mutationBlockedReason?: string | null;
   readonly topologyRecovery?: BufferTopologyRecoveryUi;
+  readonly staleAuthorityRecovery?: BufferStaleAuthorityRecoveryUi;
 }): React.ReactElement {
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
@@ -114,6 +129,18 @@ export function BufferSurface({
   const [topologyRecoveryArmed, setTopologyRecoveryArmed] = useState(false);
   const [topologyRecoveryWorking, setTopologyRecoveryWorking] = useState(false);
   const topologyRecoveryArmedRef = useRef(false);
+  const [staleAuthorityArmedSignature, setStaleAuthorityArmedSignature] =
+    useState<string | null>(null);
+  const [staleAuthorityWorking, setStaleAuthorityWorking] = useState(false);
+  const [staleAuthorityEditorVisible, setStaleAuthorityEditorVisible] =
+    useState(false);
+  const [staleAuthorityEditorWorking, setStaleAuthorityEditorWorking] =
+    useState(false);
+  const [staleAuthorityNativeCommandLine, setStaleAuthorityNativeCommandLine] =
+    useState<string | null>(null);
+  const [staleAuthorityNativeCommandError, setStaleAuthorityNativeCommandError] =
+    useState<string | null>(null);
+  const staleAuthorityArmedSignatureRef = useRef<string | null>(null);
   const [predictionFeedbackRevision, setPredictionFeedbackRevision] =
     useState(0);
   const predictionGenerationRef = useRef(0);
@@ -178,6 +205,12 @@ export function BufferSurface({
   const recoveryPending =
     snapshot.recovery?.status === "pending" ||
     snapshot.recovery?.status === "working";
+  const nativeStaleAuthorityEditorVisible =
+    staleAuthorityEditorVisible &&
+    snapshot.provider.capabilities.terminalUi;
+  const inlineStaleAuthorityEditorVisible =
+    staleAuthorityEditorVisible &&
+    !snapshot.provider.capabilities.terminalUi;
   const attemptHostOpen = useCallback(
     (request: NonNullable<typeof pendingHostOpen.current>): void => {
       if (request.inFlight) return;
@@ -204,6 +237,35 @@ export function BufferSurface({
     setTopologyRecoveryArmed(false);
     setTopologyRecoveryWorking(false);
   }, [topologyRecovery?.mutation.tokenId]);
+  const staleAuthorityRecoverySignature = useMemo(
+    () =>
+      JSON.stringify(
+        staleAuthorityRecovery?.entries.map((entry) => [
+          entry.path,
+          entry.editorContentSha256,
+          entry.editorContentBytes,
+          entry.changedtick,
+          entry.editorInstanceId,
+          entry.epoch,
+          entry.editorState,
+          entry.diskState,
+          entry.diskContentSha256 ?? null,
+          entry.diskContentBytes ?? null,
+        ]) ?? [],
+      ),
+    [staleAuthorityRecovery?.entries],
+  );
+  const staleAuthorityArmed =
+    staleAuthorityArmedSignature === staleAuthorityRecoverySignature;
+  useLayoutEffect(() => {
+    staleAuthorityArmedSignatureRef.current = null;
+    setStaleAuthorityArmedSignature(null);
+    setStaleAuthorityWorking(false);
+    setStaleAuthorityEditorVisible(false);
+    setStaleAuthorityEditorWorking(false);
+    setStaleAuthorityNativeCommandLine(null);
+    setStaleAuthorityNativeCommandError(null);
+  }, [staleAuthorityRecoverySignature]);
   const resolveRecovery = useCallback(
     (action: "recover" | "compare" | "save-copy" | "discard"): void => {
       if (snapshot.recovery?.status !== "pending") return;
@@ -239,6 +301,88 @@ export function BufferSurface({
         setTopologyRecoveryWorking(false);
       });
   }, [topologyRecovery, topologyRecoveryWorking]);
+  const useDiskForStaleAuthority = useCallback((): void => {
+    if (
+      staleAuthorityRecovery === undefined ||
+      staleAuthorityWorking ||
+      staleAuthorityRecovery.entries
+        .slice(0, STALE_AUTHORITY_REVIEW_BATCH_SIZE)
+        .some((entry) => entry.diskState === "unavailable")
+    ) {
+      return;
+    }
+    if (
+      staleAuthorityArmedSignatureRef.current !==
+      staleAuthorityRecoverySignature
+    ) {
+      staleAuthorityArmedSignatureRef.current =
+        staleAuthorityRecoverySignature;
+      setStaleAuthorityArmedSignature(staleAuthorityRecoverySignature);
+      return;
+    }
+    staleAuthorityArmedSignatureRef.current = null;
+    setStaleAuthorityArmedSignature(null);
+    setStaleAuthorityWorking(true);
+    void staleAuthorityRecovery
+      .onUseDisk(
+        staleAuthorityRecovery.entries.slice(
+          0,
+          STALE_AUTHORITY_REVIEW_BATCH_SIZE,
+        ),
+      )
+      .catch(logError)
+      .finally(() => {
+        setStaleAuthorityWorking(false);
+      });
+  }, [
+    staleAuthorityRecovery,
+    staleAuthorityRecoverySignature,
+    staleAuthorityWorking,
+  ]);
+  const refreshStaleAuthority = useCallback((): void => {
+    if (staleAuthorityRecovery === undefined || staleAuthorityWorking) return;
+    setStaleAuthorityWorking(true);
+    void staleAuthorityRecovery
+      .onRefresh()
+      .catch(logError)
+      .finally(() => {
+        setStaleAuthorityWorking(false);
+      });
+  }, [staleAuthorityRecovery, staleAuthorityWorking]);
+  const performStaleAuthorityEditorAction = useCallback(
+    (action: "reload" | "unload"): void => {
+      const reviewedEntry = staleAuthorityRecovery?.entries[0];
+      if (reviewedEntry === undefined || staleAuthorityEditorWorking) {
+        return;
+      }
+      setStaleAuthorityEditorWorking(true);
+      setStaleAuthorityNativeCommandLine(null);
+      setStaleAuthorityNativeCommandError(null);
+      void store
+        .performStaleAuthorityEditorAction({
+          type: action,
+          path: reviewedEntry.path,
+        })
+        .then((completed) => {
+          if (!completed) {
+            setStaleAuthorityNativeCommandError(
+              `Recovery ${action} was not completed; review the Editor error and retry.`,
+            );
+            return;
+          }
+          if (action === "unload") setStaleAuthorityEditorVisible(false);
+        })
+        .catch((error: unknown) => {
+          logError(error);
+          setStaleAuthorityNativeCommandError(
+            `Recovery ${action} failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        })
+        .finally(() => {
+          setStaleAuthorityEditorWorking(false);
+        });
+    }, [staleAuthorityEditorWorking, staleAuthorityRecovery, store],
+  );
 
   useEffect(() => {
     if (!activePath) return;
@@ -517,9 +661,7 @@ export function BufferSurface({
     workbench.activeWorkspaceView,
   ]);
 
-  const keybindingContext = snapshot.provider.capabilities.terminalUi
-    ? "BufferHost"
-    : "Buffer";
+  const keybindingContext = bufferKeybindingContext(snapshot);
   useRegisterKeybindingContext(keybindingContext, focused);
   const hasInFlightAgent = Boolean(inFlightAgent);
   const keyHandlers = useMemo(
@@ -548,14 +690,36 @@ export function BufferSurface({
 
   const executeVimCommand = useCallback(
     (command: BufferVimCommand): void => {
-      if (mutationBlockedReason !== null && command.type !== "quit") return;
+      const deliberateRecoveryDiskAction =
+        staleAuthorityEditorVisible &&
+        (command.type === "reload" || command.type === "closeBuffer");
+      if (
+        mutationBlockedReason !== null &&
+        command.type !== "quit" &&
+        !deliberateRecoveryDiskAction
+      ) {
+        return;
+      }
+      if (deliberateRecoveryDiskAction) {
+        performStaleAuthorityEditorAction(
+          command.type === "reload" ? "reload" : "unload",
+        );
+        return;
+      }
       executeBufferVimCommand(command, {
         store,
         dispatch,
         hasInFlightAgent,
       });
     },
-    [dispatch, hasInFlightAgent, mutationBlockedReason, store],
+    [
+      dispatch,
+      hasInFlightAgent,
+      mutationBlockedReason,
+      performStaleAuthorityEditorAction,
+      staleAuthorityEditorVisible,
+      store,
+    ],
   );
 
   useInputCapture(
@@ -587,9 +751,95 @@ export function BufferSurface({
             copyCrashDetails();
             return true;
           }
+          // The crash card owns input while visible. Do not let an
+          // unrecognized key trigger a lower-priority recovery action that is
+          // currently hidden behind it.
+          return true;
         }
         if (topologyRecovery !== undefined) {
           if (input.toLowerCase() === "u") resolveTopologyRecovery();
+          return true;
+        }
+        if (staleAuthorityRecovery !== undefined) {
+          if (staleAuthorityEditorVisible) {
+            if (key.ctrl && input.toLowerCase() === "g") {
+              setStaleAuthorityEditorVisible(false);
+              setStaleAuthorityNativeCommandLine(null);
+              setStaleAuthorityNativeCommandError(null);
+              return true;
+            }
+            if (nativeStaleAuthorityEditorVisible) {
+              if (staleAuthorityEditorWorking) return true;
+              if (event.keypress.isPasted) {
+                setStaleAuthorityNativeCommandError(
+                  "Paste is disabled in the restricted Recovery Editor.",
+                );
+                return true;
+              }
+              if (staleAuthorityNativeCommandLine === null) {
+                if (
+                  input === ":" &&
+                  !key.ctrl &&
+                  !key.meta &&
+                  !key.super
+                ) {
+                  setStaleAuthorityNativeCommandLine("");
+                  setStaleAuthorityNativeCommandError(null);
+                }
+                return true;
+              }
+              if (key.escape || (key.ctrl && input.toLowerCase() === "c")) {
+                setStaleAuthorityNativeCommandLine(null);
+                setStaleAuthorityNativeCommandError(null);
+                return true;
+              }
+              if (key.return) {
+                const action = staleAuthorityEditorActionFromCommand(
+                  staleAuthorityNativeCommandLine,
+                );
+                setStaleAuthorityNativeCommandLine(null);
+                if (action === null) {
+                  setStaleAuthorityNativeCommandError(
+                    "Restricted Recovery Editor allows only :edit! and :bd!.",
+                  );
+                  return true;
+                }
+                performStaleAuthorityEditorAction(action);
+                return true;
+              }
+              if (key.backspace || key.delete) {
+                setStaleAuthorityNativeCommandLine((command) =>
+                  command === null
+                    ? null
+                    : removeLastRecoveryCommandChar(command),
+                );
+                return true;
+              }
+              if (key.ctrl || key.meta || key.super) return true;
+              if (/^[\x20-\x7e]+$/u.test(input)) {
+                setStaleAuthorityNativeCommandLine((command) =>
+                  command === null
+                    ? null
+                    : `${command}${input}`.slice(0, 64),
+                );
+              }
+              return true;
+            }
+            return store.handleInput(
+              input,
+              key,
+              inputContentSize.current,
+              executeVimCommand,
+              event.keypress.isPasted,
+            );
+          }
+          if (input.toLowerCase() === "d") useDiskForStaleAuthority();
+          if (input.toLowerCase() === "r") refreshStaleAuthority();
+          if (input.toLowerCase() === "e") {
+            setStaleAuthorityEditorVisible(true);
+            setStaleAuthorityNativeCommandLine(null);
+            setStaleAuthorityNativeCommandError(null);
+          }
           return true;
         }
         if (mutationBlockedReason !== null) return true;
@@ -625,13 +875,21 @@ export function BufferSurface({
         executeVimCommand,
         hasInFlightAgent,
         mutationBlockedReason,
+        nativeStaleAuthorityEditorVisible,
+        performStaleAuthorityEditorAction,
         recoveryPending,
+        refreshStaleAuthority,
         resolveRecovery,
         resolveTopologyRecovery,
         restartAfterCrash,
         snapshot.provider.capabilities.terminalUi,
+        staleAuthorityEditorVisible,
+        staleAuthorityEditorWorking,
+        staleAuthorityNativeCommandLine,
         store,
+        staleAuthorityRecovery,
         topologyRecovery,
+        useDiskForStaleAuthority,
       ],
     ),
     { context: keybindingContext, isActive: focused },
@@ -640,7 +898,8 @@ export function BufferSurface({
   if (
     !activePath &&
     snapshot.status === "idle" &&
-    topologyRecovery === undefined
+    topologyRecovery === undefined &&
+    staleAuthorityRecovery === undefined
   ) {
     return <EmptySurface title="BUFFER" message="No file selected" />;
   }
@@ -722,7 +981,11 @@ export function BufferSurface({
               onClick={(event) => {
                 event.stopImmediatePropagation();
                 dispatch({ type: "focus", pane: "surface" });
-                if (mutationBlockedReason !== null) return;
+                if (
+                  mutationBlockedReason !== null &&
+                  !inlineStaleAuthorityEditorVisible
+                )
+                  return;
                 void store.selectBuffer(buffer.handle).catch(logError);
               }}
             >
@@ -751,7 +1014,12 @@ export function BufferSurface({
         onClick={(event) => {
           event.stopImmediatePropagation();
           dispatch({ type: "focus", pane: "surface" });
-          if (recoveryPending || crashed || mutationBlockedReason !== null)
+          if (
+            recoveryPending ||
+            crashed ||
+            (mutationBlockedReason !== null &&
+              !inlineStaleAuthorityEditorVisible)
+          )
             return;
           store.click(event.localRow, event.localCol);
         }}
@@ -782,15 +1050,34 @@ export function BufferSurface({
             working={topologyRecoveryWorking}
             onResolve={resolveTopologyRecovery}
           />
+        ) : staleAuthorityRecovery && !staleAuthorityEditorVisible ? (
+          <StaleAuthorityRecoveryCard
+            entries={staleAuthorityRecovery.entries}
+            armed={staleAuthorityArmed}
+            working={staleAuthorityWorking}
+            onRefresh={refreshStaleAuthority}
+            onOpenEditor={() => setStaleAuthorityEditorVisible(true)}
+            onUseDisk={useDiskForStaleAuthority}
+          />
         ) : snapshot.status === "loading" ? (
           <Text dimColor>Loading...</Text>
         ) : null}
-        {!recoveryPending && !crashed && !topologyRecovery && terminal ? (
+        {!recoveryPending &&
+        !crashed &&
+        !topologyRecovery &&
+        (!staleAuthorityRecovery || staleAuthorityEditorVisible) &&
+        terminal ? (
           <NeovimGridView
             terminal={terminal}
-            focused={focused && mutationBlockedReason === null}
+            focused={
+              focused &&
+              mutationBlockedReason === null
+            }
           />
-        ) : !recoveryPending && !crashed && !topologyRecovery ? (
+        ) : !recoveryPending &&
+          !crashed &&
+          !topologyRecovery &&
+          (!staleAuthorityRecovery || staleAuthorityEditorVisible) ? (
           visibleLines.map((line) => (
             <BufferLine
               key={line.number}
@@ -817,17 +1104,36 @@ export function BufferSurface({
                   : topologyRecoveryArmed
                     ? "Press U again to mark outcome unknown and resynchronize"
                     : "U review and resolve interrupted path operation"
-                : mutationBlockedReason !== null
-                  ? "EDITOR READ-ONLY  alt+h explorer  shift+tab composer  alt+q hide"
-                  : terminal
-                    ? `${terminal.mode.toUpperCase()}  ctrl+s save  ctrl+r redo${workbench.rail !== null ? "  alt+l AI" : ""}  alt+r rail  shift+tab composer  alt+z ${workbench.surfaceMaximized ? "restore" : "maximize"}  alt+h explorer  alt+e external`
-                    : snapshot.vimCommandLine !== null
-                      ? `:${snapshot.vimCommandLine}`
-                      : snapshot.vimMode === "VISUAL"
-                        ? "VISUAL  h/j/k/l move  y yank  d delete  c change  p paste  esc normal"
-                        : snapshot.vimMode === "NORMAL"
-                          ? "BASIC FALLBACK  v visual  y/p register  : command  i/a/o insert  ctrl+r rail  esc composer"
-                          : "INSERT  esc normal"}
+                : staleAuthorityRecovery
+                  ? staleAuthorityEditorVisible
+                    ? nativeStaleAuthorityEditorVisible &&
+                      staleAuthorityNativeCommandLine !== null
+                      ? `RECOVERY COMMAND :${staleAuthorityNativeCommandLine}`
+                      : staleAuthorityEditorWorking
+                        ? "RECOVERY EDITOR — APPLYING RESTRICTED ACTION…"
+                        : staleAuthorityNativeCommandError !== null
+                          ? staleAuthorityNativeCommandError
+                          : "RESTRICTED RECOVERY EDITOR  :edit! reload  :bd! unload reviewed path  ctrl+g review"
+                    : staleAuthorityWorking
+                      ? "CONFIRMING DISK STATE AND RESYNCHRONIZING…"
+                      : staleAuthorityRecovery.entries
+                            .slice(0, STALE_AUTHORITY_REVIEW_BATCH_SIZE)
+                            .some((entry) => entry.diskState === "unavailable")
+                        ? "DISK STATE UNAVAILABLE — restore/remove the path, then R refresh"
+                        : staleAuthorityArmed
+                          ? "Press D again to permanently abandon orphaned edits and use disk"
+                          : "D review and use exact disk state"
+                  : mutationBlockedReason !== null
+                    ? "EDITOR READ-ONLY  alt+h explorer  shift+tab composer  alt+q hide"
+                    : terminal
+                      ? `${terminal.mode.toUpperCase()}  ctrl+s save  ctrl+r redo${workbench.rail !== null ? "  alt+l AI" : ""}  alt+r rail  shift+tab composer  alt+z ${workbench.surfaceMaximized ? "restore" : "maximize"}  alt+h explorer  alt+e external`
+                      : snapshot.vimCommandLine !== null
+                        ? `:${snapshot.vimCommandLine}`
+                        : snapshot.vimMode === "VISUAL"
+                          ? "VISUAL  h/j/k/l move  y yank  d delete  c change  p paste  esc normal"
+                          : snapshot.vimMode === "NORMAL"
+                            ? "BASIC FALLBACK  v visual  y/p register  : command  i/a/o insert  ctrl+r rail  esc composer"
+                            : "INSERT  esc normal"}
         </Text>
       </Box>
     </Box>
@@ -837,6 +1143,25 @@ export function BufferSurface({
 export function isCodePredictionInsertMode(mode: string): boolean {
   const normalized = mode.trim().toLowerCase();
   return normalized === "i" || normalized.startsWith("insert");
+}
+
+export function staleAuthorityEditorActionFromCommand(
+  rawCommand: string,
+): "reload" | "unload" | null {
+  switch (rawCommand.trim().toLowerCase()) {
+    case "e!":
+    case "edit!":
+      return "reload";
+    case "bd!":
+    case "bdelete!":
+      return "unload";
+    default:
+      return null;
+  }
+}
+
+function removeLastRecoveryCommandChar(value: string): string {
+  return Array.from(value).slice(0, -1).join("");
 }
 
 export function bufferTabLabels(
@@ -949,6 +1274,100 @@ function NeovimCrashCard({
         <Box borderStyle="single" paddingX={1} onClick={onCopy}>
           <Text>C Copy details</Text>
         </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function StaleAuthorityRecoveryCard({
+  entries,
+  armed,
+  working,
+  onRefresh,
+  onOpenEditor,
+  onUseDisk,
+}: {
+  readonly entries: readonly WorkspaceEditorStaleAuthorityEntry[];
+  readonly armed: boolean;
+  readonly working: boolean;
+  readonly onRefresh: () => void;
+  readonly onOpenEditor: () => void;
+  readonly onUseDisk: () => void;
+}): React.ReactElement {
+  const visibleEntries = entries.slice(0, STALE_AUTHORITY_REVIEW_BATCH_SIZE);
+  const diskUnavailable = visibleEntries.some(
+    (entry) => entry.diskState === "unavailable",
+  );
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1}>
+      <Text color="warning" bold>
+        Orphaned Editor revisions need a decision
+      </Text>
+      {visibleEntries.map((entry) => (
+        <Text key={entry.path} dimColor wrap="truncate-middle">
+          {entry.path} — Editor {entry.editorContentBytes} B (
+          {entry.editorState === "dirty" ? "dirty" : "last known clean"}), disk{" "}
+          {entry.diskState === "content"
+            ? `${entry.diskContentBytes} B`
+            : entry.diskState}
+        </Text>
+      ))}
+      {entries.length > visibleEntries.length ? (
+        <Text dimColor>
+          {entries.length - visibleEntries.length} more affected path
+          {entries.length - visibleEntries.length === 1
+            ? " remains"
+            : "s remain"}{" "}
+          for a later review
+        </Text>
+      ) : null}
+      {working ? (
+        <Text>Verifying the exact disk fingerprints and resynchronizing…</Text>
+      ) : diskUnavailable ? (
+        <Text color="error" wrap="wrap">
+          At least one disk path is unreadable, not a regular file, or too
+          large. Restore it to a readable file or remove it before choosing
+          disk, then refresh the evidence.
+        </Text>
+      ) : armed ? (
+        <Text color="error" wrap="wrap">
+          Press D again to permanently abandon the orphaned revision shown
+          above. AgenC will proceed only if its disk fingerprint still matches
+          this review.
+        </Text>
+      ) : (
+        <Text dimColor wrap="wrap">
+          AgenC retained fingerprints, not the previous source text. Recover a
+          Neovim swap if one is offered. Use Disk deliberately discards the
+          orphaned revision and any proposals based on it. Open Recovery Editor
+          to run :edit! or :bd! when the path is still loaded.
+        </Text>
+      )}
+      <Box
+        borderStyle="single"
+        paddingX={1}
+        marginTop={1}
+        onClick={onOpenEditor}
+      >
+        <Text>E Open Recovery Editor</Text>
+      </Box>
+      <Box
+        borderStyle="single"
+        paddingX={1}
+        marginTop={1}
+        onClick={working ? undefined : diskUnavailable ? onRefresh : onUseDisk}
+      >
+        <Text color={armed ? "error" : undefined}>
+          {working
+            ? diskUnavailable
+              ? "Refreshing…"
+              : "Confirming…"
+            : diskUnavailable
+              ? "R Refresh Disk State"
+              : armed
+                ? "D Confirm Use Disk"
+                : "D Use Disk"}
+        </Text>
       </Box>
     </Box>
   );
@@ -1122,6 +1541,8 @@ type BufferSurfaceStore = Pick<
   ReturnType<typeof getWorkbenchBufferProviderController>,
   | "save"
   | "revert"
+  | "performStaleAuthorityEditorAction"
+  | "close"
   | "openExternalEditor"
   | "undo"
   | "redo"
@@ -1247,10 +1668,11 @@ export function executeBufferVimCommand(
     store,
     dispatch,
     hasInFlightAgent,
+    onBufferClosed,
   }: Pick<
     BufferSurfaceActionOptions,
     "store" | "dispatch" | "hasInFlightAgent"
-  >,
+  > & { readonly onBufferClosed?: () => void },
 ): void {
   switch (command.type) {
     case "save":
@@ -1269,6 +1691,17 @@ export function executeBufferVimCommand(
         });
         if (saved) dispatch({ type: "closeSurface" });
       })().catch(logError);
+      break;
+    case "reload":
+      void store.revert().catch(logError);
+      break;
+    case "closeBuffer":
+      void store
+        .close({ discard: command.discard })
+        .then((closed) => {
+          if (closed) onBufferClosed?.();
+        })
+        .catch(logError);
       break;
   }
 }

--- a/runtime/src/tui/workbench/workspaceEditorLeaseSync.ts
+++ b/runtime/src/tui/workbench/workspaceEditorLeaseSync.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 
 import type {
   WorkspaceEditorAcquireParams,
@@ -23,6 +23,9 @@ import type {
   WorkspaceEditorRecoveredTopologyResolveResult,
   WorkspaceEditorReleaseParams,
   WorkspaceEditorReleaseResult,
+  WorkspaceEditorStaleAuthorityEntry,
+  WorkspaceEditorStaleAuthorityRefreshParams,
+  WorkspaceEditorStaleAuthorityRefreshResult,
   WorkspaceEditorSyncParams,
   WorkspaceEditorSyncResult,
   WorkspaceEditorTopologyCompleteParams,
@@ -36,11 +39,13 @@ import type {
 import type {
   BufferProviderSnapshot,
   BufferEditorProposalResolution,
+  BufferProviderPathMutationResult,
   BufferWorkspaceBufferCapture,
   BufferWorkspaceWriteAuthorityHandler,
   BufferWorkspaceWriteDecision,
   BufferWorkspaceWriteRequest,
 } from "./buffer/providers/types.js";
+import { BufferWorkspaceCaptureUnstableError } from "./buffer/providers/types.js";
 
 const DEFAULT_SYNC_DEBOUNCE_MS = 80;
 const DEFAULT_HEARTBEAT_MS = 3_000;
@@ -95,6 +100,9 @@ export type WorkspaceEditorLeaseClient = {
   syncWorkspaceEditor(
     params: WorkspaceEditorSyncParams,
   ): Promise<WorkspaceEditorSyncResult>;
+  refreshWorkspaceEditorStaleAuthority(
+    params: WorkspaceEditorStaleAuthorityRefreshParams,
+  ): Promise<WorkspaceEditorStaleAuthorityRefreshResult>;
   heartbeatWorkspaceEditor(
     params: WorkspaceEditorHeartbeatParams,
   ): Promise<WorkspaceEditorLeaseResult>;
@@ -137,6 +145,11 @@ export type WorkspaceEditorBufferSource = {
   subscribe(listener: () => void): () => void;
   getSnapshot(): BufferProviderSnapshot;
   captureWorkspaceBuffers(): Promise<readonly BufferWorkspaceBufferCapture[]>;
+  beginProjectPathMutation?(): boolean;
+  endProjectPathMutation?(): void;
+  synchronizePathDelete?(
+    path: string,
+  ): Promise<BufferProviderPathMutationResult>;
   setWorkspaceWriteAuthorityHandler?(
     handler: BufferWorkspaceWriteAuthorityHandler | null,
   ): void;
@@ -166,6 +179,7 @@ export type WorkspaceEditorAuthorityState =
       readonly status: "blocked";
       readonly reason: string;
       readonly recoveredTopologyMutations?: readonly WorkspaceEditorRecoveredTopologyMutation[];
+      readonly staleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[];
     };
 
 export function bufferSnapshotRequiresWorkspaceEditorAuthority(
@@ -212,6 +226,31 @@ export async function resolveWorkspaceEditorRecoveredTopologyMutation(
     throw new Error("The authoritative Editor recovery session is not active.");
   }
   await synchronizer.resolveRecoveredTopologyMutation(tokenId);
+}
+
+export async function abandonWorkspaceEditorStaleAuthority(
+  workspaceRoot: string,
+  entries: readonly WorkspaceEditorStaleAuthorityEntry[],
+): Promise<void> {
+  const synchronizer = topologySynchronizers.get(
+    workspaceTopologyKey(workspaceRoot),
+  );
+  if (synchronizer === undefined) {
+    throw new Error("The authoritative Editor recovery session is not active.");
+  }
+  await synchronizer.abandonStaleAuthority(entries);
+}
+
+export async function refreshWorkspaceEditorStaleAuthority(
+  workspaceRoot: string,
+): Promise<void> {
+  const synchronizer = topologySynchronizers.get(
+    workspaceTopologyKey(workspaceRoot),
+  );
+  if (synchronizer === undefined) {
+    throw new Error("The authoritative Editor recovery session is not active.");
+  }
+  await synchronizer.refreshStaleAuthority();
 }
 
 type PendingWorkspaceProposalAcceptance = {
@@ -289,6 +328,7 @@ export class WorkspaceEditorLeaseSynchronizer {
   #recoveredTopologyMutations: readonly WorkspaceEditorRecoveredTopologyMutation[] =
     [];
   #recoveredTopologyResolvePromise: Promise<void> | null = null;
+  #staleAuthority: readonly WorkspaceEditorStaleAuthorityEntry[] = [];
   #pendingProposalAcceptance: PendingWorkspaceProposalAcceptance | null = null;
   #pendingProposalRejection: PendingWorkspaceProposalRejection | null = null;
   #stopPreparationPromise: Promise<void> | null = null;
@@ -453,48 +493,121 @@ export class WorkspaceEditorLeaseSynchronizer {
     }
     const resolveRecovered =
       this.#client.resolveRecoveredWorkspaceEditorTopology;
-    const lease = this.#lease;
-    if (resolveRecovered === undefined || lease === null) {
+    if (resolveRecovered === undefined || this.#lease === null) {
       throw new Error(
         "The connected daemon cannot reconcile the recovered Editor project-path fence. Restart the daemon with this AgenC version.",
       );
     }
     const operation = (async () => {
+      if (this.#heartbeatPromise !== null) {
+        await this.#heartbeatPromise;
+      }
+      const lease = this.#lease;
+      if (lease === null) {
+        throw new Error(
+          "The authoritative Editor lease was lost before recovered mutation reconciliation could start.",
+        );
+      }
       this.#publishRecoveredTopologyBlock(
         "Reconciling the interrupted Editor path operation as an audited unknown outcome…",
       );
-      const result = await resolveRecovered({
-        workspaceRoot: this.#workspaceRoot,
-        editorInstanceId: this.#editorInstanceId,
-        leaseToken: lease.leaseToken,
-        epoch: lease.epoch,
-        tokenId,
-      });
+      const beginProviderMutation = this.#buffers.beginProjectPathMutation;
+      const endProviderMutation = this.#buffers.endProjectPathMutation;
       if (
-        result.resolved !== true ||
-        result.tokenId !== tokenId ||
-        result.status !== "unknown_outcome"
+        beginProviderMutation === undefined ||
+        endProviderMutation === undefined ||
+        !beginProviderMutation.call(this.#buffers)
       ) {
         throw new Error(
-          "The daemon returned a malformed recovered project-path reconciliation.",
+          "The active Editor provider cannot freeze project paths for recovered mutation reconciliation.",
         );
       }
-      this.#recoveredTopologyMutations =
-        this.#recoveredTopologyMutations.filter(
-          (mutation) => mutation.tokenId !== tokenId,
+      try {
+        await this.#unloadRecoveredTopologyCleanTargets(recovered);
+        const otherRecoveredTargets = this.#recoveredTopologyMutations
+          .filter((mutation) => mutation.tokenId !== tokenId)
+          .flatMap((mutation) => mutation.targets);
+        const captures = (await this.#buffers.captureWorkspaceBuffers()).filter(
+          (capture) =>
+            !otherRecoveredTargets.some((target) =>
+              recoveredTopologyTargetContainsPath(target, capture.path),
+            ),
         );
-      const stillBlocked = await this.#discoverRecoveredTopologyMutations();
-      if (stillBlocked) return;
-      this.#lastObservedManifest = null;
-      this.#lastSyncedManifest = null;
-      this.#initialSynchronizationComplete = false;
-      this.#publishAuthority({ status: "securing" });
-      await this.#synchronize(true);
+        const prepared = captures.map(workspaceBufferSync);
+        const sequence = this.#sequence + 1;
+        const result = await resolveRecovered({
+          workspaceRoot: this.#workspaceRoot,
+          editorInstanceId: this.#editorInstanceId,
+          leaseToken: lease.leaseToken,
+          epoch: lease.epoch,
+          tokenId,
+          sequence,
+          buffers: prepared,
+        });
+        if (
+          result.resolved !== true ||
+          result.tokenId !== tokenId ||
+          result.status !== "unknown_outcome" ||
+          result.sync.accepted !== true ||
+          result.sync.sequence !== sequence
+        ) {
+          throw new Error(
+            "The daemon returned a malformed recovered project-path reconciliation.",
+          );
+        }
+        this.#sequence = result.sync.sequence;
+        this.#lastSyncedManifest =
+          synchronizedBufferManifestSignature(prepared);
+        this.#lease = {
+          ...lease,
+          sequence: result.sync.sequence,
+          expiresAt: result.sync.expiresAt,
+        };
+        this.#recoveredTopologyMutations =
+          this.#recoveredTopologyMutations.filter(
+            (mutation) => mutation.tokenId !== tokenId,
+          );
+        const stillBlocked = await this.#discoverRecoveredTopologyMutations();
+        if (stillBlocked) return;
+        this.#lastObservedManifest = null;
+        this.#initialSynchronizationComplete = false;
+        this.#publishAuthority({ status: "securing" });
+        await this.#synchronize(true);
+      } finally {
+        endProviderMutation.call(this.#buffers);
+      }
     })();
     this.#recoveredTopologyResolvePromise = operation;
     try {
       await operation;
     } catch (cause) {
+      try {
+        const stillBlocked = await this.#discoverRecoveredTopologyMutations();
+        const tokenStillDurable = this.#recoveredTopologyMutations.some(
+          (mutation) => mutation.tokenId === tokenId,
+        );
+        if (!tokenStillDurable) {
+          // The daemon may have durably installed the combined manifest/token
+          // terminal and then lost the reply (or failed only while draining
+          // its append-once audit outbox). Re-listing is the idempotent receipt.
+          const acquired = await this.#client.acquireWorkspaceEditor({
+            workspaceRoot: this.#workspaceRoot,
+            editorInstanceId: this.#editorInstanceId,
+          });
+          this.#acceptAcquiredLease(acquired);
+          if (!stillBlocked) {
+            this.#lastObservedManifest = null;
+            this.#lastSyncedManifest = null;
+            this.#initialSynchronizationComplete = false;
+            this.#publishAuthority({ status: "securing" });
+            await this.#synchronize(true);
+          }
+          return;
+        }
+      } catch {
+        // Preserve the original reconciliation failure when its durable state
+        // cannot be queried safely.
+      }
       this.#publishRecoveredTopologyBlock(errorMessage(cause));
       this.#report(cause);
       throw cause;
@@ -502,6 +615,233 @@ export class WorkspaceEditorLeaseSynchronizer {
       if (this.#recoveredTopologyResolvePromise === operation) {
         this.#recoveredTopologyResolvePromise = null;
       }
+    }
+  }
+
+  async #unloadRecoveredTopologyCleanTargets(
+    mutation: WorkspaceEditorRecoveredTopologyMutation,
+  ): Promise<void> {
+    const unloadCleanPath = this.#buffers.synchronizePathDelete;
+    if (unloadCleanPath === undefined) {
+      throw new Error(
+        "The active Editor provider cannot safely close clean buffers for recovered mutation reconciliation.",
+      );
+    }
+    for (;;) {
+      const snapshot = this.#buffers.getSnapshot();
+      const candidate = snapshot.buffers.find((buffer) => {
+        if (
+          !buffer.loaded ||
+          buffer.bufferType !== "" ||
+          buffer.absolutePath === null ||
+          buffer.changedtick === null ||
+          buffer.modified
+        ) {
+          return false;
+        }
+        return mutation.targets.some((target) =>
+          recoveredTopologyTargetContainsPath(target, buffer.absolutePath!),
+        );
+      });
+      if (candidate === undefined) return;
+      const path = candidate.absolutePath!;
+      const unloaded = await unloadCleanPath.call(this.#buffers, path);
+      if (!unloaded.ok) {
+        const racedDirty = this.#buffers
+          .getSnapshot()
+          .buffers.some(
+            (buffer) =>
+              buffer.loaded &&
+              buffer.modified &&
+              buffer.absolutePath !== null &&
+              workspaceTopologyKey(buffer.absolutePath) ===
+                workspaceTopologyKey(path),
+          );
+        if (racedDirty) {
+          // A buffer that raced dirty remains Editor authority and is carried
+          // in the final exact manifest; recovery must never unload it.
+          continue;
+        }
+        throw new Error(
+          `Editor could not safely close recovered clean path ${path}: ${unloaded.reason}`,
+        );
+      }
+      const stillLoadedClean = this.#buffers
+        .getSnapshot()
+        .buffers.some(
+          (buffer) =>
+            buffer.loaded &&
+            !buffer.modified &&
+            buffer.absolutePath !== null &&
+            workspaceTopologyKey(buffer.absolutePath) ===
+              workspaceTopologyKey(path),
+        );
+      if (stillLoadedClean) {
+        throw new Error(
+          `The Editor still reports clean path ${path} after its safe unload completed.`,
+        );
+      }
+    }
+  }
+
+  async abandonStaleAuthority(
+    entries: readonly WorkspaceEditorStaleAuthorityEntry[],
+  ): Promise<void> {
+    if (this.#stopRequested || this.#stopped) {
+      throw new Error("Editor workspace synchronization is stopping.");
+    }
+    if (entries.length === 0) {
+      throw new Error("No stale Editor revisions were selected for recovery.");
+    }
+    if (
+      this.#recoveredTopologyMutations.length > 0 ||
+      this.#recoveredTopologyResolvePromise !== null ||
+      this.#topologyOperationStarting ||
+      this.#topologyOperation !== null ||
+      this.#workspaceWriteAuthorizationPromise !== null ||
+      this.#proposalOperationActive
+    ) {
+      throw new Error(
+        "Another authoritative Editor operation must finish before stale revisions can be abandoned.",
+      );
+    }
+    if (this.#syncTimer !== null) {
+      clearTimeout(this.#syncTimer);
+      this.#syncTimer = null;
+    }
+    if (this.#retryTimer !== null) {
+      clearTimeout(this.#retryTimer);
+      this.#retryTimer = null;
+    }
+    if (this.#heartbeatPromise !== null) await this.#heartbeatPromise;
+    if (this.#syncPromise !== null) await this.#syncPromise;
+    this.#publishAuthority({
+      status: "blocked",
+      reason:
+        "Confirming the reviewed disk state and abandoning the selected orphaned Editor revisions…",
+      staleAuthority: entries,
+    });
+    await this.#synchronize(true, entries);
+    const remainingPaths = new Set(
+      this.#staleAuthority.map((entry) => entry.path),
+    );
+    if (entries.some((entry) => remainingPaths.has(entry.path))) {
+      throw new Error(
+        "The selected orphaned Editor revisions are still protected. Review the current recovery evidence before trying again.",
+      );
+    }
+  }
+
+  async refreshStaleAuthority(): Promise<void> {
+    if (this.#stopRequested || this.#stopped) {
+      throw new Error("Editor workspace synchronization is stopping.");
+    }
+    if (this.#staleAuthority.length === 0) return;
+    if (
+      this.#recoveredTopologyMutations.length > 0 ||
+      this.#recoveredTopologyResolvePromise !== null ||
+      this.#topologyOperationStarting ||
+      this.#topologyOperation !== null ||
+      this.#workspaceWriteAuthorizationPromise !== null ||
+      this.#proposalOperationActive
+    ) {
+      throw new Error(
+        "Another authoritative Editor operation must finish before stale disk evidence can be refreshed.",
+      );
+    }
+    if (this.#syncTimer !== null) {
+      clearTimeout(this.#syncTimer);
+      this.#syncTimer = null;
+    }
+    if (this.#retryTimer !== null) {
+      clearTimeout(this.#retryTimer);
+      this.#retryTimer = null;
+    }
+    if (this.#heartbeatPromise !== null) await this.#heartbeatPromise;
+    if (this.#syncPromise !== null) await this.#syncPromise;
+    const operation = this.#performStaleAuthorityRefresh();
+    this.#syncPromise = operation;
+    try {
+      await operation;
+    } finally {
+      if (this.#syncPromise === operation) this.#syncPromise = null;
+      if (this.#syncQueued && !this.#stopped && !this.#stopRequested) {
+        this.#syncQueued = false;
+        this.#scheduleSync(0);
+      }
+    }
+  }
+
+  async #performStaleAuthorityRefresh(): Promise<void> {
+    this.#publishAuthority({
+      status: "blocked",
+      reason:
+        "Refreshing the current disk evidence for orphaned Editor revisions…",
+      staleAuthority: this.#staleAuthority,
+    });
+    let lease = this.#lease;
+    try {
+      if (lease === null) {
+        const acquired = await this.#client.acquireWorkspaceEditor({
+          workspaceRoot: this.#workspaceRoot,
+          editorInstanceId: this.#editorInstanceId,
+        });
+        this.#acceptAcquiredLease(acquired);
+        lease = this.#lease;
+      }
+      if (lease === null) {
+        throw new Error("The authoritative Editor lease is unavailable.");
+      }
+      const result = await this.#client.refreshWorkspaceEditorStaleAuthority({
+        workspaceRoot: this.#workspaceRoot,
+        editorInstanceId: this.#editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      });
+      if (
+        result.refreshed !== true ||
+        !isValidStaleAuthorityList(result.staleAuthority)
+      ) {
+        throw new Error(
+          "The daemon returned malformed stale Editor recovery evidence.",
+        );
+      }
+      if (
+        this.#lease?.leaseToken !== lease.leaseToken ||
+        this.#lease.epoch !== lease.epoch
+      ) {
+        throw new Error(
+          "The authoritative Editor lease changed while disk evidence was refreshed.",
+        );
+      }
+      this.#staleAuthority = result.staleAuthority;
+      this.#lastErrorMessage = null;
+      if (this.#staleAuthority.length > 0) {
+        this.#initialSynchronizationComplete = false;
+        this.#publishAuthority({
+          status: "blocked",
+          reason: staleAuthorityBlockReason(this.#staleAuthority),
+          staleAuthority: this.#staleAuthority,
+        });
+        return;
+      }
+      this.#initialSynchronizationComplete = false;
+      this.#lastObservedManifest = null;
+      this.#lastSyncedManifest = null;
+      this.#publishAuthority({ status: "syncing" });
+      this.#syncQueued = true;
+    } catch (cause) {
+      if (this.#lease?.leaseToken === lease?.leaseToken) {
+        this.#lease = null;
+      }
+      this.#initialSynchronizationComplete = false;
+      this.#publishAuthority({
+        status: "blocked",
+        reason: errorMessage(cause),
+        staleAuthority: this.#staleAuthority,
+      });
+      this.#report(cause);
+      throw cause;
     }
   }
 
@@ -779,6 +1119,9 @@ export class WorkspaceEditorLeaseSynchronizer {
       );
     }
     const operation = (async () => {
+      if (this.#heartbeatPromise !== null) {
+        await this.#heartbeatPromise;
+      }
       const lease = this.#lease;
       if (lease === null) {
         throw new Error(
@@ -1118,7 +1461,10 @@ export class WorkspaceEditorLeaseSynchronizer {
     }
   }
 
-  async #synchronize(force = false): Promise<void> {
+  async #synchronize(
+    force = false,
+    abandonStaleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[],
+  ): Promise<void> {
     if ((this.#stopped || this.#stopRequested) && !force) return;
     if (this.#hasPendingProposalAcknowledgement() && !force) return;
     if (this.#workspaceWriteAuthorizationPromise !== null && !force) {
@@ -1141,7 +1487,7 @@ export class WorkspaceEditorLeaseSynchronizer {
       await this.#syncPromise;
       return;
     }
-    const operation = this.#performSync(force);
+    const operation = this.#performSync(force, abandonStaleAuthority);
     this.#syncPromise = operation;
     try {
       await operation;
@@ -1154,7 +1500,10 @@ export class WorkspaceEditorLeaseSynchronizer {
     }
   }
 
-  async #performSync(force: boolean): Promise<void> {
+  async #performSync(
+    force: boolean,
+    abandonStaleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[],
+  ): Promise<void> {
     try {
       if (this.#lease === null) {
         this.#publishAuthority({ status: "securing" });
@@ -1184,10 +1533,24 @@ export class WorkspaceEditorLeaseSynchronizer {
       );
       const manifest = synchronizedBufferManifestSignature(prepared);
       if (!force && manifest === this.#lastSyncedManifest) {
-        this.#initialSynchronizationComplete = true;
-        this.#publishAuthority({ status: "ready" });
+        if (this.#staleAuthority.length > 0) {
+          this.#initialSynchronizationComplete = false;
+          this.#publishAuthority({
+            status: "blocked",
+            reason: staleAuthorityBlockReason(this.#staleAuthority),
+            staleAuthority: this.#staleAuthority,
+          });
+        } else {
+          this.#initialSynchronizationComplete = true;
+          this.#publishAuthority({ status: "ready" });
+        }
         return;
       }
+      const effectiveAbandonStaleAuthority =
+        reconcileStaleAuthorityConfirmation(
+          abandonStaleAuthority,
+          this.#staleAuthority,
+        );
       const sequence = this.#sequence + 1;
       const result = await this.#client.syncWorkspaceEditor({
         workspaceRoot: this.#workspaceRoot,
@@ -1196,10 +1559,17 @@ export class WorkspaceEditorLeaseSynchronizer {
         epoch: lease.epoch,
         sequence,
         buffers: prepared,
+        ...(effectiveAbandonStaleAuthority !== undefined
+          ? { abandonStaleAuthority: effectiveAbandonStaleAuthority }
+          : {}),
       });
+      const returnedStaleAuthority =
+        result.staleAuthority ?? this.#staleAuthority;
       if (
+        result.accepted !== true ||
         !Number.isSafeInteger(result.sequence) ||
-        result.sequence !== sequence
+        result.sequence !== sequence ||
+        !isValidStaleAuthorityList(returnedStaleAuthority)
       ) {
         throw new Error(
           `The daemon returned malformed editor sync sequence ${String(result.sequence)}; expected ${sequence}.`,
@@ -1207,14 +1577,24 @@ export class WorkspaceEditorLeaseSynchronizer {
       }
       this.#sequence = result.sequence;
       this.#lastSyncedManifest = manifest;
+      this.#staleAuthority = returnedStaleAuthority;
       this.#lease = {
         ...lease,
         sequence: result.sequence,
         expiresAt: result.expiresAt,
       };
       this.#pollWorkspaceChangesInBackground();
-      this.#initialSynchronizationComplete = true;
       this.#lastErrorMessage = null;
+      if (this.#staleAuthority.length > 0) {
+        this.#initialSynchronizationComplete = false;
+        this.#publishAuthority({
+          status: "blocked",
+          reason: staleAuthorityBlockReason(this.#staleAuthority),
+          staleAuthority: this.#staleAuthority,
+        });
+        return;
+      }
+      this.#initialSynchronizationComplete = true;
       const currentManifest = workspaceBufferManifestSignature(
         this.#buffers.getSnapshot(),
       );
@@ -1226,12 +1606,40 @@ export class WorkspaceEditorLeaseSynchronizer {
         this.#observe();
       }
     } catch (cause) {
+      if (cause instanceof BufferWorkspaceCaptureUnstableError) {
+        // Ordinary insert-mode input can advance changedtick faster than the
+        // multi-RPC background snapshot can settle. Keep the existing lease
+        // and its daemon-side fence: native writes still pass through the
+        // synchronous BufWritePre authority gate, while another background
+        // capture can retry without turning normal keystrokes into read-only
+        // input. A pre-existing stale-authority quarantine remains hard.
+        if (this.#staleAuthority.length > 0) {
+          this.#initialSynchronizationComplete = false;
+          this.#publishAuthority({
+            status: "blocked",
+            reason: staleAuthorityBlockReason(this.#staleAuthority),
+            staleAuthority: this.#staleAuthority,
+          });
+        } else {
+          // Acquisition already established the daemon-side workspace fence,
+          // and Neovim's native write gate stays installed while capture
+          // retries. Keep provider input live even when the first snapshot is
+          // unstable so no part of a command or insert is silently discarded.
+          this.#publishAuthority({ status: "syncing" });
+        }
+        this.#scheduleRetry();
+        if (force) throw cause;
+        return;
+      }
       this.#report(cause);
       this.#lease = null;
       this.#initialSynchronizationComplete = false;
       this.#publishAuthority({
         status: "blocked",
         reason: errorMessage(cause),
+        ...(this.#staleAuthority.length > 0
+          ? { staleAuthority: this.#staleAuthority }
+          : {}),
       });
       this.#scheduleRetry();
       // Background synchronization remains retryable and reports through the
@@ -1244,6 +1652,14 @@ export class WorkspaceEditorLeaseSynchronizer {
 
   #acceptAcquiredLease(lease: WorkspaceEditorLeaseResult): void {
     assertValidLeaseSequence(lease.sequence);
+    if (
+      lease.staleAuthority !== undefined &&
+      !isValidStaleAuthorityList(lease.staleAuthority)
+    ) {
+      throw new Error(
+        "The daemon returned malformed stale Editor recovery evidence.",
+      );
+    }
     const sameLease =
       this.#knownLeaseIdentity?.epoch === lease.epoch &&
       this.#knownLeaseIdentity.leaseToken === lease.leaseToken;
@@ -1262,6 +1678,9 @@ export class WorkspaceEditorLeaseSynchronizer {
       epoch: lease.epoch,
       leaseToken: lease.leaseToken,
     };
+    if (lease.staleAuthority !== undefined) {
+      this.#staleAuthority = lease.staleAuthority;
+    }
     this.#lease = lease;
   }
 
@@ -1287,13 +1706,18 @@ export class WorkspaceEditorLeaseSynchronizer {
         mutation.tokenId.length === 0 ||
         tokenIds.has(mutation.tokenId) ||
         typeof mutation.workspaceRoot !== "string" ||
-        mutation.workspaceRoot.length === 0 ||
+        workspaceTopologyKey(mutation.workspaceRoot) !==
+          workspaceTopologyKey(this.#workspaceRoot) ||
         !Array.isArray(mutation.targets) ||
         mutation.targets.length === 0 ||
         mutation.targets.some(
           (target) =>
             typeof target?.path !== "string" ||
             target.path.length === 0 ||
+            !recoveredTopologyTargetWithinWorkspace(
+              this.#workspaceRoot,
+              target.path,
+            ) ||
             (target.includeDescendants !== undefined &&
               typeof target.includeDescendants !== "boolean"),
         ) ||
@@ -1332,6 +1756,8 @@ export class WorkspaceEditorLeaseSynchronizer {
       this.#proposalOperationActive ||
       this.#syncPromise !== null ||
       this.#workspaceWriteAuthorizationPromise !== null ||
+      this.#topologyFinalizePromise !== null ||
+      this.#recoveredTopologyResolvePromise !== null ||
       this.#heartbeatPromise !== null
     ) {
       return;
@@ -1364,6 +1790,9 @@ export class WorkspaceEditorLeaseSynchronizer {
         this.#publishAuthority({
           status: "blocked",
           reason: errorMessage(cause),
+          ...(this.#staleAuthority.length > 0
+            ? { staleAuthority: this.#staleAuthority }
+            : {}),
         });
         this.#report(cause);
         this.#scheduleRetry();
@@ -1404,6 +1833,7 @@ export class WorkspaceEditorLeaseSynchronizer {
       });
       this.#lastSyncedManifest = null;
       this.#knownLeaseIdentity = null;
+      this.#staleAuthority = [];
       this.#initialSynchronizationComplete = false;
       this.#lastErrorMessage = null;
     } catch (cause) {
@@ -1505,7 +1935,9 @@ export class WorkspaceEditorLeaseSynchronizer {
           this.#authorityState.reason === state.reason &&
           recoveredTopologySignature(
             this.#authorityState.recoveredTopologyMutations,
-          ) === recoveredTopologySignature(state.recoveredTopologyMutations)))
+          ) === recoveredTopologySignature(state.recoveredTopologyMutations) &&
+          staleAuthoritySignature(this.#authorityState.staleAuthority) ===
+            staleAuthoritySignature(state.staleAuthority)))
     ) {
       return;
     }
@@ -1541,12 +1973,91 @@ export class WorkspaceEditorLeaseSynchronizer {
       this.#workspaceChangeCallbackProposalId =
         change.status === "proposed" ? (change.proposalId ?? null) : null;
       try {
+        if (change.kind === "topology") {
+          await this.#reconcileTopologyInvalidation(change);
+        }
         await this.#onWorkspaceChange?.(change);
       } finally {
         this.#workspaceChangeCallbackProposalId = null;
       }
     }
     this.#changeSequence = result.sequence;
+  }
+
+  async #reconcileTopologyInvalidation(
+    change: WorkspaceEditorChangeResult,
+  ): Promise<void> {
+    if (
+      change.kind !== "topology" ||
+      typeof change.topologyTokenId !== "string" ||
+      typeof change.includeDescendants !== "boolean" ||
+      (change.status !== "applied" && change.status !== "unknown_outcome") ||
+      !recoveredTopologyTargetWithinWorkspace(this.#workspaceRoot, change.path)
+    ) {
+      throw new Error(
+        "The daemon returned a malformed project-path invalidation.",
+      );
+    }
+    const beginProviderMutation = this.#buffers.beginProjectPathMutation;
+    const endProviderMutation = this.#buffers.endProjectPathMutation;
+    if (
+      beginProviderMutation === undefined ||
+      endProviderMutation === undefined ||
+      !beginProviderMutation.call(this.#buffers)
+    ) {
+      throw new Error(
+        "The active Editor provider cannot freeze project paths while applying a durable path invalidation.",
+      );
+    }
+    try {
+      const target: WorkspaceEditorTopologyTarget = {
+        path: change.path,
+        includeDescendants: change.includeDescendants,
+      };
+      const dirty = this.#buffers
+        .getSnapshot()
+        .buffers.find(
+          (buffer) =>
+            buffer.loaded &&
+            buffer.modified &&
+            buffer.bufferType === "" &&
+            buffer.absolutePath !== null &&
+            recoveredTopologyTargetContainsPath(target, buffer.absolutePath),
+        );
+      if (dirty !== undefined) {
+        throw new Error(
+          `Editor buffer ${dirty.absolutePath} has unsaved changes under a completed project-path operation. Save or discard it before acknowledging the disk invalidation.`,
+        );
+      }
+      await this.#unloadRecoveredTopologyCleanTargets({
+        tokenId: change.topologyTokenId,
+        workspaceRoot: this.#workspaceRoot,
+        targets: [target],
+        source: change.source,
+        createdAt: 0,
+      });
+      const racedDirty = this.#buffers
+        .getSnapshot()
+        .buffers.find(
+          (buffer) =>
+            buffer.loaded &&
+            buffer.modified &&
+            buffer.bufferType === "" &&
+            buffer.absolutePath !== null &&
+            recoveredTopologyTargetContainsPath(target, buffer.absolutePath),
+        );
+      if (racedDirty !== undefined) {
+        throw new Error(
+          `Editor buffer ${racedDirty.absolutePath} became dirty while applying a completed project-path operation. Save or discard it before acknowledging the disk invalidation.`,
+        );
+      }
+      this.#lastObservedManifest = null;
+      this.#lastSyncedManifest = null;
+      this.#initialSynchronizationComplete = false;
+      await this.#synchronize(true);
+    } finally {
+      endProviderMutation.call(this.#buffers);
+    }
   }
 
   #pollWorkspaceChangesInBackground(): void {
@@ -1888,6 +2399,40 @@ function workspaceTopologyKey(workspaceRoot: string): string {
   return resolve(workspaceRoot).normalize("NFC");
 }
 
+function isSameOrDescendantPath(parent: string, candidate: string): boolean {
+  const bounded = relative(parent, candidate);
+  return (
+    bounded === "" ||
+    (bounded !== ".." &&
+      !bounded.startsWith(`..${sep}`) &&
+      !isAbsolute(bounded))
+  );
+}
+
+function recoveredTopologyTargetWithinWorkspace(
+  workspaceRoot: string,
+  targetPath: string,
+): boolean {
+  if (!isAbsolute(targetPath)) return false;
+  return isSameOrDescendantPath(
+    workspaceTopologyKey(workspaceRoot),
+    workspaceTopologyKey(targetPath),
+  );
+}
+
+function recoveredTopologyTargetContainsPath(
+  target: WorkspaceEditorTopologyTarget,
+  path: string,
+): boolean {
+  const targetPath = workspaceTopologyKey(target.path);
+  const candidatePath = workspaceTopologyKey(path);
+  return (
+    targetPath === candidatePath ||
+    (target.includeDescendants === true &&
+      isSameOrDescendantPath(targetPath, candidatePath))
+  );
+}
+
 function recoveredTopologySignature(
   mutations: readonly WorkspaceEditorRecoveredTopologyMutation[] | undefined,
 ): string {
@@ -1902,6 +2447,117 @@ function recoveredTopologySignature(
         target.includeDescendants === true,
       ]),
     ]),
+  );
+}
+
+function isValidStaleAuthorityList(
+  value: unknown,
+): value is readonly WorkspaceEditorStaleAuthorityEntry[] {
+  if (!Array.isArray(value) || value.length > 512) return false;
+  const paths = new Set<string>();
+  for (const entry of value) {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof entry.path !== "string" ||
+      entry.path.length === 0 ||
+      paths.has(entry.path) ||
+      typeof entry.editorContentSha256 !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(entry.editorContentSha256) ||
+      !Number.isSafeInteger(entry.editorContentBytes) ||
+      entry.editorContentBytes < 0 ||
+      !Number.isSafeInteger(entry.changedtick) ||
+      entry.changedtick < 0 ||
+      typeof entry.editorInstanceId !== "string" ||
+      entry.editorInstanceId.length === 0 ||
+      !Number.isSafeInteger(entry.epoch) ||
+      entry.epoch < 1 ||
+      (entry.editorState !== "dirty" && entry.editorState !== "clean") ||
+      (entry.diskState !== "content" &&
+        entry.diskState !== "missing" &&
+        entry.diskState !== "unavailable")
+    ) {
+      return false;
+    }
+    if (entry.diskState === "content") {
+      if (
+        typeof entry.diskContentSha256 !== "string" ||
+        !/^[a-f0-9]{64}$/u.test(entry.diskContentSha256) ||
+        !Number.isSafeInteger(entry.diskContentBytes) ||
+        (entry.diskContentBytes as number) < 0
+      ) {
+        return false;
+      }
+    } else if (
+      entry.diskContentSha256 !== undefined ||
+      entry.diskContentBytes !== undefined
+    ) {
+      return false;
+    }
+    paths.add(entry.path);
+  }
+  return true;
+}
+
+function staleAuthoritySignature(
+  entries: readonly WorkspaceEditorStaleAuthorityEntry[] | undefined,
+): string {
+  return JSON.stringify(
+    (entries ?? []).map((entry) => [
+      entry.path,
+      entry.editorContentSha256,
+      entry.editorContentBytes,
+      entry.changedtick,
+      entry.editorInstanceId,
+      entry.epoch,
+      entry.editorState,
+      entry.diskState,
+      entry.diskContentSha256 ?? null,
+      entry.diskContentBytes ?? null,
+    ]),
+  );
+}
+
+function staleAuthorityEntriesEqual(
+  left: WorkspaceEditorStaleAuthorityEntry,
+  right: WorkspaceEditorStaleAuthorityEntry,
+): boolean {
+  return staleAuthoritySignature([left]) === staleAuthoritySignature([right]);
+}
+
+function reconcileStaleAuthorityConfirmation(
+  requested: readonly WorkspaceEditorStaleAuthorityEntry[] | undefined,
+  current: readonly WorkspaceEditorStaleAuthorityEntry[],
+): readonly WorkspaceEditorStaleAuthorityEntry[] | undefined {
+  if (requested === undefined) return undefined;
+  if (!isValidStaleAuthorityList(requested) || requested.length === 0) {
+    throw new Error("The stale Editor recovery confirmation is malformed.");
+  }
+  const currentByPath = new Map(current.map((entry) => [entry.path, entry]));
+  const matching = requested.filter((entry) => {
+    const latest = currentByPath.get(entry.path);
+    return latest !== undefined && staleAuthorityEntriesEqual(entry, latest);
+  });
+  if (matching.length === requested.length) return requested;
+  if (requested.every((entry) => !currentByPath.has(entry.path))) {
+    // The previous exact sync may have committed before its response was lost.
+    // Reacquire is authoritative; continue with an ordinary sync instead of
+    // turning an already-completed explicit choice into a permanent error.
+    return undefined;
+  }
+  throw new Error(
+    "The stale Editor or disk recovery evidence changed. Review it again before choosing Use Disk.",
+  );
+}
+
+function staleAuthorityBlockReason(
+  entries: readonly WorkspaceEditorStaleAuthorityEntry[],
+): string {
+  const count = entries.length;
+  return (
+    `${count} orphaned Editor revision${count === 1 ? "" : "s"} ` +
+    `${count === 1 ? "still owns" : "still own"} workspace authority. ` +
+    "Recover a matching Neovim swap if offered, or explicitly choose Use Disk after reviewing the affected paths."
   );
 }
 

--- a/runtime/src/workspace/file-mutation-transaction.ts
+++ b/runtime/src/workspace/file-mutation-transaction.ts
@@ -1712,7 +1712,10 @@ try {
           code: "INVALID_COMMAND",
         });
       }
-      const sampleBuffer = Buffer.alloc(Math.min(8192, opened.stats.size));
+      const sampleBytes = Number(
+        opened.stats.size < 8192n ? opened.stats.size : 8192n,
+      );
+      const sampleBuffer = Buffer.alloc(sampleBytes);
       const sampleRead =
         sampleBuffer.length === 0
           ? { bytesRead: 0 }
@@ -3480,7 +3483,9 @@ export async function bindWorkspaceDirectoryMutation(input: {
   readonly targetPath: string;
 }): Promise<WorkspaceBoundDirectoryMutation> {
   const targetPath = resolveFilesystemPathIdentity(input.targetPath);
-  if (dirname(targetPath) !== resolveFilesystemPathIdentity(input.parent.path)) {
+  if (
+    dirname(targetPath) !== resolveFilesystemPathIdentity(input.parent.path)
+  ) {
     throw new WorkspaceFileMutationPathBindingUnavailableError(targetPath);
   }
   const pathIdentity: WorkspacePathIdentity = {

--- a/runtime/src/workspace/mutation-coordinator.ts
+++ b/runtime/src/workspace/mutation-coordinator.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
+  constants as fsConstants,
   existsSync,
   fstatSync,
   fsyncSync,
@@ -16,6 +17,7 @@ import {
   appendFile,
   mkdir,
   open,
+  readFile,
   realpath,
   rename,
   stat,
@@ -31,6 +33,7 @@ import {
   resolve,
   sep,
 } from "node:path";
+import { createInterface as createReadlineInterface } from "node:readline";
 
 import { resolveAgencHome } from "../config/env.js";
 
@@ -46,6 +49,7 @@ const MAX_CHANGE_EVENTS = 64;
 // TUI's bounded review store.
 const MAX_PENDING_PROPOSALS = 32;
 const MAX_PROPOSAL_RECEIPTS = 512;
+const MAX_AUDIT_OUTBOX_ENTRIES = MAX_SYNCED_BUFFERS + MAX_PENDING_PROPOSALS;
 const MAX_QUARANTINE_BYTES = 512 * 1024;
 const MAX_PERSISTED_QUARANTINE_DIRECTORIES = 4_096;
 const MAX_QUARANTINE_ROOT_PREFIX_BYTES = 64 * 1024;
@@ -95,6 +99,20 @@ export interface WorkspaceEditorLease {
   readonly epoch: number;
   readonly sequence: number;
   readonly expiresAt: number;
+  readonly staleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[];
+}
+
+export interface WorkspaceEditorStaleAuthorityEntry {
+  readonly path: string;
+  readonly editorContentSha256: string;
+  readonly editorContentBytes: number;
+  readonly changedtick: number;
+  readonly editorInstanceId: string;
+  readonly epoch: number;
+  readonly editorState: "dirty" | "clean";
+  readonly diskState: "content" | "missing" | "unavailable";
+  readonly diskContentSha256?: string;
+  readonly diskContentBytes?: number;
 }
 
 export interface WorkspaceEditorSyncInput {
@@ -104,6 +122,7 @@ export interface WorkspaceEditorSyncInput {
   readonly epoch: number;
   readonly sequence: number;
   readonly buffers: readonly EditorBufferSync[];
+  readonly abandonStaleAuthority?: readonly WorkspaceEditorStaleAuthorityEntry[];
 }
 
 export interface WorkspaceEditorHeartbeatInput {
@@ -133,11 +152,15 @@ export interface WorkspaceChangeEvent {
   readonly workspaceRoot: string;
   readonly path: string;
   readonly source: WorkspaceMutationSource;
+  /** Omitted by legacy exact-path events. */
+  readonly kind?: "path" | "topology";
   readonly status:
     "applied" | "proposed" | "blocked" | "discarded" | "unknown_outcome";
-  readonly beforeSha256: string;
+  readonly beforeSha256?: string;
   readonly afterSha256?: string;
   readonly proposalId?: string;
+  readonly topologyTokenId?: string;
+  readonly includeDescendants?: boolean;
 }
 
 export interface WorkspaceEditorSyncResult {
@@ -146,6 +169,12 @@ export interface WorkspaceEditorSyncResult {
   readonly expiresAt: number;
   readonly dirtyPaths: readonly string[];
   readonly stalePaths: readonly string[];
+  readonly staleAuthority: readonly WorkspaceEditorStaleAuthorityEntry[];
+}
+
+export interface WorkspaceEditorStaleAuthorityRefreshResult {
+  readonly refreshed: true;
+  readonly staleAuthority: readonly WorkspaceEditorStaleAuthorityEntry[];
 }
 
 export interface WorkspaceAuthoritativeRead {
@@ -323,9 +352,7 @@ export interface WorkspaceRecoveredEditorTopologyMutation {
   readonly createdAt: number;
 }
 
-export interface WorkspaceRecoveredEditorTopologyMutationResolveInput extends WorkspaceEditorHeartbeatInput {
-  readonly tokenId: string;
-}
+export interface WorkspaceRecoveredEditorTopologyMutationResolveInput extends WorkspaceEditorTopologyMutationFinalizeInput {}
 
 export type WorkspaceMutationAdmission =
   | {
@@ -349,13 +376,16 @@ export interface WorkspaceChangeLedgerEntry {
   readonly workspaceRoot: string;
   readonly path: string;
   readonly source: WorkspaceMutationSource;
+  readonly kind?: "path" | "topology";
   readonly status:
     "applied" | "proposed" | "blocked" | "discarded" | "unknown_outcome";
-  readonly beforeSha256: string;
+  readonly beforeSha256?: string;
   readonly afterSha256?: string;
   readonly sessionId?: string;
   readonly toolCallId?: string;
   readonly proposalId?: string;
+  readonly topologyTokenId?: string;
+  readonly includeDescendants?: boolean;
 }
 
 export type WorkspaceChangeLedgerAppendInput = Omit<
@@ -438,6 +468,40 @@ interface WorkspaceQuarantineSnapshot {
   readonly topologyIntents: readonly WorkspaceTopologyMutationIntent[];
   readonly changeSequence: number;
   readonly changes: readonly WorkspaceChangeEvent[];
+  readonly auditOutbox: readonly WorkspaceChangeLedgerEntry[];
+}
+
+interface WorkspaceQuarantineStateOverrides {
+  readonly buffers?: ReadonlyMap<string, EditorBufferState>;
+  readonly proposalCommitments?: ReadonlyMap<
+    string,
+    WorkspaceProposalCommitment
+  >;
+  readonly proposalReceipts?: ReadonlyMap<string, WorkspaceProposalReceipt>;
+  readonly auditOutbox?: ReadonlyMap<string, WorkspaceChangeLedgerEntry>;
+  readonly mutationIntents?: ReadonlyMap<string, WorkspaceMutationIntent>;
+  readonly topologyIntents?: ReadonlyMap<
+    string,
+    WorkspaceTopologyMutationIntent
+  >;
+  readonly changes?: readonly WorkspaceChangeEvent[];
+  readonly changeSequence?: number;
+}
+
+interface WorkspaceEditorSyncPlan {
+  readonly lease: ActiveLease;
+  readonly sequence: number;
+  readonly buffers: ReadonlyMap<string, EditorBufferState>;
+  readonly proposalCommitments: ReadonlyMap<
+    string,
+    WorkspaceProposalCommitment
+  >;
+  readonly proposalReceipts: ReadonlyMap<string, WorkspaceProposalReceipt>;
+  readonly auditOutbox: ReadonlyMap<string, WorkspaceChangeLedgerEntry>;
+  readonly abandonedPaths: ReadonlySet<string>;
+  readonly changes: readonly WorkspaceChangeEvent[];
+  readonly changeSequence: number;
+  readonly quarantineSnapshot: WorkspaceQuarantineSnapshot;
 }
 
 export class WorkspaceMutationCoordinatorError extends Error {
@@ -536,6 +600,12 @@ export interface WorkspaceMutationCoordinatorOptions {
   readonly appendLedger?: (
     input: WorkspaceChangeLedgerAppendInput,
   ) => Promise<void>;
+  /** Optional append-once projection seam used by crash/race harnesses. */
+  readonly appendLedgerOnce?: (
+    entries: readonly WorkspaceChangeLedgerEntry[],
+  ) => Promise<void>;
+  /** Optional pre-write durability seam used by fault/race harnesses. */
+  readonly beforePersistQuarantine?: () => Promise<void>;
 }
 
 export interface WorkspaceToolOperationToken {
@@ -568,6 +638,10 @@ export class WorkspaceMutationCoordinator {
   readonly #appendLedger: (
     input: WorkspaceChangeLedgerAppendInput,
   ) => Promise<void>;
+  readonly #appendLedgerOnce: (
+    entries: readonly WorkspaceChangeLedgerEntry[],
+  ) => Promise<void>;
+  readonly #beforePersistQuarantine: (() => Promise<void>) | undefined;
   readonly #buffers = new Map<string, EditorBufferState>();
   readonly #tokens = new Map<
     string,
@@ -590,6 +664,7 @@ export class WorkspaceMutationCoordinator {
     WorkspaceProposalCommitment
   >();
   readonly #proposalReceipts = new Map<string, WorkspaceProposalReceipt>();
+  readonly #auditOutbox = new Map<string, WorkspaceChangeLedgerEntry>();
   readonly #proposalResolutionOperations = new Map<string, Promise<unknown>>();
   readonly #changes: WorkspaceChangeEvent[] = [];
   #lease: ActiveLease | null = null;
@@ -597,6 +672,9 @@ export class WorkspaceMutationCoordinator {
   #authorityVersion = 0;
   #changeSequence = 0;
   #quarantineHydrationFailed = false;
+  #staleAuthorityResolutionPending = false;
+  #proposalTerminalPersistencePending = false;
+  #topologyFinalizationPending = false;
   #pendingQuarantinePersistence: Promise<void> = Promise.resolve();
   #mutationAdmissionTail: Promise<void> = Promise.resolve();
 
@@ -630,21 +708,47 @@ export class WorkspaceMutationCoordinator {
     });
     this.#appendLedger =
       options.appendLedger ?? ((input) => this.#ledger.append(input));
+    this.#appendLedgerOnce =
+      options.appendLedgerOnce ??
+      ((entries) => this.#ledger.appendOnce(entries));
+    this.#beforePersistQuarantine = options.beforePersistQuarantine;
     try {
       const quarantine = this.#ledger.readQuarantine();
-      if (quarantine !== null && this.#hydrateQuarantine(quarantine)) {
-        this.#scheduleQuarantinePersistence();
+      if (quarantine !== null) {
+        if (this.#hydrateQuarantine(quarantine)) {
+          this.#scheduleQuarantinePersistence();
+        }
+        if (this.#auditOutbox.size > 0) {
+          void this.#serializeProposalState(() =>
+            this.#drainAuditOutbox(),
+          ).catch(() => {});
+        }
       }
     } catch {
       // The durable record exists specifically to prevent a daemon restart
       // from forgetting unresolved unsaved editor state. If it cannot be
       // trusted, block workspace reads/writes until an editor explicitly
       // abandons the quarantine rather than silently falling back to disk.
+      this.#buffers.clear();
+      this.#tokens.clear();
+      this.#topologyTokens.clear();
+      this.#recoveredTopologyTokens.clear();
+      this.#editorTopologyOwners.clear();
+      this.#mutationIntents.clear();
+      this.#topologyIntents.clear();
+      this.#proposals.clear();
+      this.#proposalCommitments.clear();
+      this.#proposalReceipts.clear();
+      this.#auditOutbox.clear();
+      this.#changes.splice(0);
+      this.#authorityVersion = 0;
+      this.#changeSequence = 0;
       this.#quarantineHydrationFailed = true;
     }
   }
 
   acquire(input: WorkspaceEditorAcquireInput): WorkspaceEditorLease {
+    this.#assertNoStaleAuthorityResolution();
     this.#expireLeaseIfNeeded();
     const editorInstanceId = requiredIdentifier(
       input.editorInstanceId,
@@ -668,26 +772,138 @@ export class WorkspaceMutationCoordinator {
         ...this.#lease,
         expiresAt: this.#now() + this.#leaseTtlMs,
       };
-      return this.#leaseResult(this.#lease);
+      return this.#leaseResult(this.#lease, true);
     }
 
-    if (this.#lease !== null) this.#quarantineLoadedBuffers(false);
     const lease: ActiveLease = {
       editorInstanceId,
       leaseToken: randomUUID(),
-      epoch: this.#nextEpoch++,
+      epoch: this.#nextEpoch,
       sequence: -1,
       expiresAt: this.#now() + this.#leaseTtlMs,
     };
+    // Revalidate recovered proposal capacity before publishing a new owner.
+    // The invariant reserves a worst-case future identity, so this exact
+    // lease can never require more durable terminal space.
+    if (!this.#quarantineHydrationFailed) {
+      this.#assertQuarantineTransitionFits();
+    }
+    if (this.#lease !== null) this.#quarantineLoadedBuffers(false);
+    this.#nextEpoch += 1;
     this.#lease = lease;
-    return this.#leaseResult(lease);
+    return this.#leaseResult(lease, true);
   }
 
   sync(
     input: WorkspaceEditorSyncInput,
     options: { readonly allowTopologyTokenId?: string } = {},
   ): WorkspaceEditorSyncResult {
-    const lease = this.#assertLease(input);
+    if (input.abandonStaleAuthority !== undefined) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "stale Editor authority abandonment requires the durable asynchronous sync transaction",
+      );
+    }
+    const plan = this.#prepareEditorSync(input, options);
+    const result = this.#commitEditorSync(plan);
+    this.#scheduleQuarantinePersistence();
+    return result;
+  }
+
+  async syncAbandoningStaleAuthority(
+    input: WorkspaceEditorSyncInput,
+    options: { readonly allowTopologyTokenId?: string } = {},
+  ): Promise<WorkspaceEditorSyncResult> {
+    if (input.abandonStaleAuthority === undefined) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "durable stale Editor authority abandonment requires exact confirmation evidence",
+      );
+    }
+    return this.#serializeProposalState(async () => {
+      if (this.#staleAuthorityResolutionPending) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          "another stale Editor authority resolution is already in progress",
+        );
+      }
+      // Validate and expire the lease before freezing coordinator state for
+      // the durability boundary. Once a valid transaction starts, its fsync
+      // may legitimately run past the ordinary heartbeat deadline.
+      this.#assertLease(input);
+      this.#staleAuthorityResolutionPending = true;
+      try {
+        await this.#clearPendingAuditFence("resolve stale Editor authority");
+        // Drain any older write, then establish a freshly fsynced conservative
+        // checkpoint before installing the destructive replacement. If the
+        // replacement's directory fsync is ambiguous, a crash can therefore
+        // reveal only this protected checkpoint or the exact replacement.
+        await this.flushQuarantinePersistence().catch(() => {});
+        const conservativePersistence = this.#scheduleQuarantineSnapshot(
+          this.#quarantineSnapshot(),
+        );
+        await conservativePersistence;
+        const plan = this.#prepareEditorSync(input, options, true);
+        const proposalTerminalEntries = [...plan.auditOutbox.values()].filter(
+          (entry) => workspaceProposalTerminalKey(entry) !== null,
+        );
+        try {
+          await this.#ledger.assertAppendOnceCompatible(
+            proposalTerminalEntries,
+          );
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Editor authority was not resolved because a proposal already has a conflicting terminal audit outcome (${error instanceof Error ? error.message : String(error)}). Reconnect and reconcile the recorded proposal decision.`,
+          );
+        }
+        const persistence = this.#scheduleQuarantineSnapshot(
+          plan.quarantineSnapshot,
+          { acceptInstalledWithDurableFallback: true },
+        );
+        await persistence;
+        const result = this.#commitEditorSync(plan);
+        try {
+          await this.#drainAuditOutbox();
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Editor authority was resolved, but its durable audit projection is pending (${error instanceof Error ? error.message : String(error)}). Reconnect to retry the audit safely.`,
+          );
+        }
+        return result;
+      } finally {
+        this.#staleAuthorityResolutionPending = false;
+      }
+    });
+  }
+
+  #prepareEditorSync(
+    input: WorkspaceEditorSyncInput,
+    options: {
+      readonly allowTopologyTokenId?: string;
+      readonly topologyFinalization?: {
+        readonly tokenId: string;
+        readonly changes: readonly Omit<
+          WorkspaceChangeEvent,
+          "sequence" | "timestamp" | "workspaceRoot"
+        >[];
+        readonly auditEntries: readonly WorkspaceChangeLedgerEntry[];
+      };
+    },
+    allowStaleAuthorityResolution = false,
+  ): WorkspaceEditorSyncPlan {
+    if (this.#quarantineHydrationFailed) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "workspace quarantine is unreadable or unsafe; explicitly abandon dirty quarantine before synchronizing Editor authority",
+      );
+    }
+    const lease = this.#assertLease(
+      input,
+      allowStaleAuthorityResolution,
+      options.topologyFinalization !== undefined,
+    );
     if (!Number.isSafeInteger(input.sequence) || input.sequence < 0) {
       throw new WorkspaceMutationCoordinatorError(
         "INVALID_EDITOR_SYNC",
@@ -707,13 +923,77 @@ export class WorkspaceMutationCoordinator {
       );
     }
 
+    const abandonedStaleAuthority = this.#validateStaleAuthorityAbandonments(
+      input.abandonStaleAuthority,
+    );
+
     let totalBytes = 0;
     const next = new Map<string, EditorBufferState>();
     const nextProposalCommitments = new Map(this.#proposalCommitments);
+    const nextProposalReceipts = new Map(this.#proposalReceipts);
+    const nextAuditOutbox = new Map(this.#auditOutbox);
+    for (const entry of options.topologyFinalization?.auditEntries ?? []) {
+      rememberAuditOutboxEntry(nextAuditOutbox, entry);
+    }
     const recoveryChanges: Omit<
       WorkspaceChangeEvent,
       "sequence" | "timestamp" | "workspaceRoot"
     >[] = [];
+    const auditTimestamp = new Date(this.#now()).toISOString();
+    for (const entry of abandonedStaleAuthority.values()) {
+      const change = {
+        path: entry.path,
+        source: "editor" as const,
+        status: "discarded" as const,
+        beforeSha256: entry.editorContentSha256,
+        ...(entry.diskContentSha256 !== undefined
+          ? { afterSha256: entry.diskContentSha256 }
+          : {}),
+      };
+      recoveryChanges.push(change);
+      rememberAuditOutboxEntry(
+        nextAuditOutbox,
+        staleAuthorityDiscardLedgerEntry(
+          this.workspaceRoot,
+          entry,
+          change,
+          auditTimestamp,
+        ),
+      );
+    }
+    for (const [proposalId, commitment] of nextProposalCommitments) {
+      if (!abandonedStaleAuthority.has(commitment.path)) continue;
+      nextProposalCommitments.delete(proposalId);
+      const result = {
+        discarded: true as const,
+        proposalId,
+        path: commitment.path,
+      };
+      nextProposalReceipts.delete(proposalId);
+      nextProposalReceipts.set(proposalId, { action: "discarded", result });
+      recoveryChanges.push({
+        path: commitment.path,
+        source: commitment.source,
+        status: "discarded",
+        beforeSha256: commitment.baseContentSha256,
+        afterSha256: commitment.afterContentSha256,
+        proposalId,
+      });
+      rememberAuditOutboxEntry(
+        nextAuditOutbox,
+        proposalTerminalLedgerEntry(
+          this.workspaceRoot,
+          commitment,
+          "discarded",
+          auditTimestamp,
+        ),
+      );
+    }
+    while (nextProposalReceipts.size > MAX_PROPOSAL_RECEIPTS) {
+      const oldest = nextProposalReceipts.keys().next().value;
+      if (typeof oldest !== "string") break;
+      nextProposalReceipts.delete(oldest);
+    }
     for (const buffer of input.buffers) {
       const path = this.resolvePath(buffer.path);
       if (
@@ -792,7 +1072,20 @@ export class WorkspaceMutationCoordinator {
         );
       }
       const quarantined = this.#buffers.get(path);
-      if (quarantined?.authority === "stale_dirty") {
+      const abandoned = abandonedStaleAuthority.get(path);
+      if (abandoned !== undefined) {
+        if (
+          buffer.dirty ||
+          abandoned.diskState !== "content" ||
+          buffer.contentSha256 !== abandoned.diskContentSha256 ||
+          contentBytes !== abandoned.diskContentBytes
+        ) {
+          throw new WorkspaceMutationCoordinatorError(
+            "EDITOR_LEASE_MISMATCH",
+            `Cannot use disk for quarantined editor buffer ${path}: the loaded Editor buffer is not the exact reviewed disk revision. Reload or close that buffer, then confirm again.`,
+          );
+        }
+      } else if (quarantined?.authority === "stale_dirty") {
         const sameEditor =
           quarantined.editorInstanceId === lease.editorInstanceId;
         const crossInstanceRecoveryAllowed =
@@ -949,8 +1242,11 @@ export class WorkspaceMutationCoordinator {
 
     // Omitted clean paths stop being tracked. Omitted dirty paths become
     // quarantined: omission is not proof that their unsaved state was saved or
-    // deliberately abandoned.
+    // deliberately abandoned. Exact, user-confirmed stale abandonments are the
+    // sole exception and are committed atomically with this replacement
+    // manifest.
     for (const previous of this.#buffers.values()) {
+      if (abandonedStaleAuthority.has(previous.path)) continue;
       if (!next.has(previous.path) && previous.authority === "editor_dirty") {
         next.set(previous.path, {
           ...previous,
@@ -978,36 +1274,81 @@ export class WorkspaceMutationCoordinator {
         `editor sync exceeds ${MAX_SYNC_BYTES} content bytes`,
       );
     }
-    const projectedChanges = this.#projectChanges(recoveryChanges);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        buffers: next,
-        proposalCommitments: nextProposalCommitments,
-        changes: projectedChanges.changes,
-        changeSequence: projectedChanges.sequence,
-      }),
-    );
+    // Buffer validation above can be comparatively expensive. This final
+    // descriptor-bound re-read is the filesystem linearization point for the
+    // user's decision: an external write before it invalidates confirmation;
+    // one after it is a later disk revision. Coordinator-owned writers remain
+    // frozen until the replacement authority manifest is durable.
+    this.#assertStaleAuthorityStillMatches(abandonedStaleAuthority);
+    const projectedChanges = this.#projectChanges([
+      ...recoveryChanges,
+      ...(options.topologyFinalization?.changes ?? []),
+    ]);
+    const nextTopologyIntents = new Map(this.#topologyIntents);
+    if (options.topologyFinalization !== undefined) {
+      nextTopologyIntents.delete(options.topologyFinalization.tokenId);
+    }
+    const quarantineSnapshot = this.#assertQuarantineTransitionFits({
+      buffers: next,
+      proposalCommitments: nextProposalCommitments,
+      proposalReceipts: nextProposalReceipts,
+      auditOutbox: nextAuditOutbox,
+      topologyIntents: nextTopologyIntents,
+      changes: projectedChanges.changes,
+      changeSequence: projectedChanges.sequence,
+    });
+    return {
+      lease: {
+        ...lease,
+        sequence: input.sequence,
+        expiresAt: this.#now() + this.#leaseTtlMs,
+      },
+      sequence: input.sequence,
+      buffers: next,
+      proposalCommitments: nextProposalCommitments,
+      proposalReceipts: nextProposalReceipts,
+      auditOutbox: nextAuditOutbox,
+      abandonedPaths: new Set(abandonedStaleAuthority.keys()),
+      changes: projectedChanges.changes,
+      changeSequence: projectedChanges.sequence,
+      quarantineSnapshot,
+    };
+  }
+
+  #commitEditorSync(plan: WorkspaceEditorSyncPlan): WorkspaceEditorSyncResult {
     this.#buffers.clear();
-    for (const [path, state] of next) this.#buffers.set(path, state);
+    for (const [path, state] of plan.buffers) this.#buffers.set(path, state);
     this.#proposalCommitments.clear();
-    for (const [proposalId, commitment] of nextProposalCommitments) {
+    for (const [proposalId, commitment] of plan.proposalCommitments) {
       this.#proposalCommitments.set(proposalId, commitment);
     }
-    this.#changes.splice(0, this.#changes.length, ...projectedChanges.changes);
-    this.#changeSequence = projectedChanges.sequence;
-
-    this.#lease = {
-      ...lease,
-      sequence: input.sequence,
+    this.#proposalReceipts.clear();
+    for (const [proposalId, receipt] of plan.proposalReceipts) {
+      this.#proposalReceipts.set(proposalId, receipt);
+    }
+    this.#auditOutbox.clear();
+    for (const [entryId, entry] of plan.auditOutbox) {
+      this.#auditOutbox.set(entryId, entry);
+    }
+    for (const [proposalId, proposal] of this.#proposals) {
+      if (plan.abandonedPaths.has(proposal.path)) {
+        this.#proposals.delete(proposalId);
+      }
+    }
+    this.#changes.splice(0, this.#changes.length, ...plan.changes);
+    this.#changeSequence = plan.changeSequence;
+    const committedLease = {
+      ...plan.lease,
       expiresAt: this.#now() + this.#leaseTtlMs,
     };
-    this.#scheduleQuarantinePersistence();
+    this.#lease = committedLease;
     return {
       accepted: true,
-      sequence: input.sequence,
-      expiresAt: this.#lease.expiresAt,
+      sequence: plan.sequence,
+      expiresAt: committedLease.expiresAt,
       dirtyPaths: this.dirtyPaths(),
       stalePaths: this.stalePaths(),
+      staleAuthority: this.#currentStaleAuthority(),
     };
   }
 
@@ -1020,47 +1361,64 @@ export class WorkspaceMutationCoordinator {
     return this.#leaseResult(this.#lease);
   }
 
+  /**
+   * Re-read only the external disk evidence shown by stale-authority recovery.
+   * This deliberately does not synchronize Editor buffers, advance the lease
+   * sequence, renew the lease, or alter any quarantined authority.
+   */
+  refreshStaleAuthority(
+    input: WorkspaceEditorHeartbeatInput,
+  ): WorkspaceEditorStaleAuthorityRefreshResult {
+    this.#assertLease(input);
+    return {
+      refreshed: true,
+      staleAuthority: this.#currentStaleAuthority(),
+    };
+  }
+
   async release(input: WorkspaceEditorReleaseInput): Promise<{
     readonly released: true;
     readonly stalePaths: readonly string[];
   }> {
-    let lease = this.#assertLease(input);
     if (input.abandonDirty === true) {
+      this.#assertLease(input);
       for (const tokenId of [...this.#recoveredTopologyTokens]) {
         const token = this.#topologyTokens.get(tokenId);
-        if (token !== undefined) {
-          await this.releaseTopologyMutation(token);
-        }
+        if (token !== undefined) await this.releaseTopologyMutation(token);
       }
-      lease = this.#assertLease(input);
-      this.#buffers.clear();
-      this.#proposals.clear();
-      this.#proposalCommitments.clear();
-      this.#quarantineHydrationFailed = false;
-    } else {
-      for (const [path, state] of this.#buffers) {
-        if (state.authority === "disk_authoritative") {
-          this.#buffers.delete(path);
-        } else if (state.authority === "editor_dirty") {
-          this.#buffers.set(path, {
-            ...state,
-            authority: "stale_dirty",
-            content: undefined,
-            quarantinedFrom: "editor_dirty",
-            crossInstanceRecoveryAllowed: true,
-            version: ++this.#authorityVersion,
-          });
-        } else if (
-          state.epoch === lease.epoch &&
-          state.editorInstanceId === lease.editorInstanceId &&
-          state.crossInstanceRecoveryAllowed !== true
-        ) {
-          this.#buffers.set(path, {
-            ...state,
-            crossInstanceRecoveryAllowed: true,
-            version: ++this.#authorityVersion,
-          });
-        }
+      return this.#serializeProposalState(() =>
+        this.#releaseAbandoningDirty(input),
+      );
+    }
+    if (this.#quarantineHydrationFailed) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "workspace quarantine is unreadable or unsafe; release requires explicit dirty-authority abandonment",
+      );
+    }
+    const lease = this.#assertLease(input);
+    for (const [path, state] of this.#buffers) {
+      if (state.authority === "disk_authoritative") {
+        this.#buffers.delete(path);
+      } else if (state.authority === "editor_dirty") {
+        this.#buffers.set(path, {
+          ...state,
+          authority: "stale_dirty",
+          content: undefined,
+          quarantinedFrom: "editor_dirty",
+          crossInstanceRecoveryAllowed: true,
+          version: ++this.#authorityVersion,
+        });
+      } else if (
+        state.epoch === lease.epoch &&
+        state.editorInstanceId === lease.editorInstanceId &&
+        state.crossInstanceRecoveryAllowed !== true
+      ) {
+        this.#buffers.set(path, {
+          ...state,
+          crossInstanceRecoveryAllowed: true,
+          version: ++this.#authorityVersion,
+        });
       }
     }
     this.#orphanEditorTopologyTokens(lease);
@@ -1068,6 +1426,53 @@ export class WorkspaceMutationCoordinator {
     this.#scheduleQuarantinePersistence();
     await this.flushQuarantinePersistence();
     return { released: true, stalePaths: this.stalePaths() };
+  }
+
+  async #releaseAbandoningDirty(input: WorkspaceEditorReleaseInput): Promise<{
+    readonly released: true;
+    readonly stalePaths: readonly string[];
+  }> {
+    this.#assertLease(input);
+    if (this.#staleAuthorityResolutionPending) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "another stale Editor authority resolution is already in progress",
+      );
+    }
+    this.#assertLease(input);
+    if (this.#tokens.size > 0 || this.#topologyTokens.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "dirty Editor authority cannot be abandoned while another workspace mutation is committing",
+      );
+    }
+
+    this.#staleAuthorityResolutionPending = true;
+    try {
+      await this.#clearPendingAuditFence("abandon dirty Editor authority");
+      await this.flushQuarantinePersistence().catch(() => {});
+      const conservativePersistence = this.#scheduleQuarantineSnapshot(
+        this.#quarantineSnapshot(),
+      );
+      await conservativePersistence;
+      const replacement = this.#quarantineSnapshot({
+        buffers: new Map(),
+        proposalCommitments: new Map(),
+      });
+      const persistence = this.#scheduleQuarantineSnapshot(replacement, {
+        acceptInstalledWithDurableFallback: true,
+      });
+      await persistence;
+
+      this.#buffers.clear();
+      this.#proposals.clear();
+      this.#proposalCommitments.clear();
+      this.#quarantineHydrationFailed = false;
+      this.#lease = null;
+      return { released: true, stalePaths: [] };
+    } finally {
+      this.#staleAuthorityResolutionPending = false;
+    }
   }
 
   authorityForPath(path: string): WorkspacePathAuthority {
@@ -1131,7 +1536,6 @@ export class WorkspaceMutationCoordinator {
         `Cannot scan ${target}: Editor quarantine is unreadable and must be reconciled before AgenC can use workspace contents.`,
       );
     }
-
     const snapshots: WorkspaceAuthoritativeDirtySnapshot[] = [];
     for (const state of this.#buffers.values()) {
       if (!isSameOrDescendantPath(target, state.path)) continue;
@@ -1189,9 +1593,19 @@ export class WorkspaceMutationCoordinator {
     },
     options: { readonly allowTopologyTokenId?: string },
   ): Promise<WorkspaceMutationAdmission> {
+    this.#assertNoStaleAuthorityResolution();
     this.#expireLeaseIfNeeded();
     await this.flushQuarantinePersistence();
+    await this.#clearPendingAuditFence("prepare another workspace mutation");
+    this.#assertNoStaleAuthorityResolution();
+    this.#expireLeaseIfNeeded();
     const path = this.resolvePath(input.path);
+    if (this.#topologyInvalidationConflictForPath(path) !== null) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        `Cannot modify ${path} until Editor acknowledges the completed workspace path operation`,
+      );
+    }
     const topologyConflict = this.#topologyConflictForPath(path);
     if (
       topologyConflict !== null &&
@@ -1232,6 +1646,12 @@ export class WorkspaceMutationCoordinator {
       return { decision: "blocked", code: "STALE_EDITOR_BUFFER", message };
     }
     if (state !== undefined && lease !== null && state.epoch === lease.epoch) {
+      if (this.#topologyTokens.size > 0) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `Cannot propose a change for ${path} while a workspace path operation is committing`,
+        );
+      }
       const beforeContentSha256 = sha256(input.beforeText);
       if (beforeContentSha256 !== state.contentSha256) {
         const message =
@@ -1326,67 +1746,11 @@ export class WorkspaceMutationCoordinator {
           proposalId: proposal.proposalId,
         },
       ]);
-      this.#ledger.assertQuarantineFits(
-        this.#quarantineSnapshot({
-          proposalCommitments: projectedCommitments,
-          changes: projectedChanges.changes,
-          changeSequence: projectedChanges.sequence,
-        }),
-      );
-      const projectedAppliedCommitments = new Map(projectedCommitments);
-      projectedAppliedCommitments.delete(commitment.proposalId);
-      const projectedAppliedReceipts = new Map(this.#proposalReceipts);
-      projectedAppliedReceipts.set(commitment.proposalId, {
-        action: "applied",
-        changedtick: Number.MAX_SAFE_INTEGER,
-        contentSha256: afterContentSha256,
-        result: {
-          applied: true,
-          proposalId: commitment.proposalId,
-          path,
-          changedtick: Number.MAX_SAFE_INTEGER,
-          contentSha256: afterContentSha256,
-        },
+      this.#assertQuarantineTransitionFits({
+        proposalCommitments: projectedCommitments,
+        changes: projectedChanges.changes,
+        changeSequence: projectedChanges.sequence,
       });
-      while (projectedAppliedReceipts.size > MAX_PROPOSAL_RECEIPTS) {
-        const oldest = projectedAppliedReceipts.keys().next().value;
-        if (typeof oldest !== "string") break;
-        projectedAppliedReceipts.delete(oldest);
-      }
-      const projectedAppliedBuffers = new Map(this.#buffers);
-      projectedAppliedBuffers.set(path, {
-        ...state,
-        changedtick: Number.MAX_SAFE_INTEGER,
-        contentSha256: afterContentSha256,
-        contentBytes: Buffer.byteLength(input.afterText, "utf8"),
-        authority: "editor_dirty",
-        content: input.afterText,
-      });
-      const projectedAppliedChanges = this.#projectChanges(
-        [
-          {
-            path,
-            source: input.source,
-            status: "applied",
-            beforeSha256: state.contentSha256,
-            afterSha256: afterContentSha256,
-            proposalId: proposal.proposalId,
-          },
-        ],
-        {
-          changes: projectedChanges.changes,
-          sequence: projectedChanges.sequence,
-        },
-      );
-      this.#ledger.assertQuarantineFits(
-        this.#quarantineSnapshot({
-          buffers: projectedAppliedBuffers,
-          proposalCommitments: projectedAppliedCommitments,
-          proposalReceipts: projectedAppliedReceipts,
-          changes: projectedAppliedChanges.changes,
-          changeSequence: projectedAppliedChanges.sequence,
-        }),
-      );
       const previousProposals = new Map(this.#proposals);
       const previousCommitments = new Map(this.#proposalCommitments);
       const previousChanges = [...this.#changes];
@@ -1478,28 +1842,12 @@ export class WorkspaceMutationCoordinator {
     };
     const projectedIntents = new Map(this.#mutationIntents);
     projectedIntents.set(intent.tokenId, intent);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        mutationIntents: projectedIntents,
-      }),
-    );
-    // Admission also reserves enough durable space for the eventual reload
-    // event. This is the last pre-effect boundary available to callers.
-    const projectedChanges = this.#projectChanges([
-      {
-        path: token.path,
-        source: token.source,
-        status: "unknown_outcome",
-        beforeSha256: token.beforeSha256,
-        afterSha256: token.intendedAfterSha256,
-      },
-    ]);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        changes: projectedChanges.changes,
-        changeSequence: projectedChanges.sequence,
-      }),
-    );
+    // This is the last pre-effect boundary. Reserve both the durable intent
+    // and its largest crash/completion event without consuming any proposal's
+    // terminal receipt capacity.
+    this.#assertQuarantineTransitionFits({
+      mutationIntents: projectedIntents,
+    });
     this.#tokens.set(token.tokenId, { token, executing: false });
     this.#mutationIntents.set(token.tokenId, intent);
     this.#scheduleQuarantinePersistence();
@@ -1516,6 +1864,7 @@ export class WorkspaceMutationCoordinator {
   }
 
   beginMutation(token: WorkspaceMutationToken): void {
+    this.#assertNoStaleAuthorityResolution();
     const current = this.#tokens.get(token.tokenId);
     if (current === undefined || current.token.path !== token.path) {
       throw new WorkspaceMutationCoordinatorError(
@@ -1621,13 +1970,11 @@ export class WorkspaceMutationCoordinator {
     const projectedIntents = new Map(this.#mutationIntents);
     projectedIntents.delete(token.tokenId);
     try {
-      this.#ledger.assertQuarantineFits(
-        this.#quarantineSnapshot({
-          mutationIntents: projectedIntents,
-          changes: projectedChanges.changes,
-          changeSequence: projectedChanges.sequence,
-        }),
-      );
+      this.#assertQuarantineTransitionFits({
+        mutationIntents: projectedIntents,
+        changes: projectedChanges.changes,
+        changeSequence: projectedChanges.sequence,
+      });
     } catch (error) {
       return markUnknownOutcome(
         error instanceof Error ? error.message : String(error),
@@ -1671,11 +2018,11 @@ export class WorkspaceMutationCoordinator {
         "workspace mutation token is missing or already consumed",
       );
     }
-    // Release authority first and never put the token back: this API exists
-    // for a filesystem effect whose exact transactional outcome is no longer
-    // provable.
-    this.#tokens.delete(token.tokenId);
-    this.#mutationIntents.delete(token.tokenId);
+    // This API follows a filesystem effect whose exact transactional outcome
+    // is no longer provable. Keep the executing token as a coordinator-wide
+    // fence until both audit writes settle: stale-authority resolution must
+    // not snapshot pre-reconciliation buffers or proposal state in between
+    // those writes and then report a destructive decision as durable.
     const afterSha256 =
       observed.kind === "content" ? sha256(observed.content) : undefined;
     const projectedChanges = this.#projectChanges([
@@ -1687,13 +2034,14 @@ export class WorkspaceMutationCoordinator {
         ...(afterSha256 !== undefined ? { afterSha256 } : {}),
       },
     ]);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        mutationIntents: this.#mutationIntents,
-        changes: projectedChanges.changes,
-        changeSequence: projectedChanges.sequence,
-      }),
-    );
+    const projectedIntents = new Map(this.#mutationIntents);
+    projectedIntents.delete(token.tokenId);
+    this.#assertQuarantineTransitionFits({
+      mutationIntents: projectedIntents,
+      changes: projectedChanges.changes,
+      changeSequence: projectedChanges.sequence,
+    });
+    this.#mutationIntents.delete(token.tokenId);
     this.#changes.splice(0, this.#changes.length, ...projectedChanges.changes);
     this.#changeSequence = projectedChanges.sequence;
     let ledgerError: unknown;
@@ -1721,6 +2069,10 @@ export class WorkspaceMutationCoordinator {
     } catch (error) {
       quarantineError = error;
     }
+    // Never put a consumed post-effect token back. At this point the in-memory
+    // unknown-outcome state is complete and every durability attempt has
+    // settled, so opening the fence cannot race a stale-authority snapshot.
+    this.#tokens.delete(token.tokenId);
     if (ledgerError !== undefined || quarantineError !== undefined) {
       const details = [ledgerError, quarantineError]
         .filter((error) => error !== undefined)
@@ -1746,35 +2098,39 @@ export class WorkspaceMutationCoordinator {
     targets: readonly WorkspaceTopologyMutationTarget[],
     source: WorkspaceMutationSource = "unknown",
   ): Promise<WorkspaceTopologyMutationToken> {
-    return this.#reserveTopologyMutation(targets, source, null);
+    return this.#serializeProposalState(() =>
+      this.#reserveTopologyMutation(targets, source, null),
+    );
   }
 
   async reserveEditorTopologyMutation(
     input: WorkspaceEditorTopologyMutationInput,
   ): Promise<WorkspaceTopologyMutationToken> {
-    const lease = this.#assertLease(input);
-    const token = await this.#reserveTopologyMutation(
-      input.targets,
-      input.source ?? "editor",
-      lease,
-    );
-    try {
-      const activeLease = this.#assertLease(input);
-      if (activeLease.epoch !== lease.epoch) {
-        throw new WorkspaceMutationCoordinatorError(
-          "EDITOR_LEASE_MISMATCH",
-          "editor lease changed while reserving the workspace path operation",
-        );
+    return this.#serializeProposalState(async () => {
+      const lease = this.#assertLease(input);
+      const token = await this.#reserveTopologyMutation(
+        input.targets,
+        input.source ?? "editor",
+        lease,
+      );
+      try {
+        const activeLease = this.#assertLease(input);
+        if (activeLease.epoch !== lease.epoch) {
+          throw new WorkspaceMutationCoordinatorError(
+            "EDITOR_LEASE_MISMATCH",
+            "editor lease changed while reserving the workspace path operation",
+          );
+        }
+        this.#editorTopologyOwners.set(token.tokenId, {
+          editorInstanceId: lease.editorInstanceId,
+          epoch: lease.epoch,
+        });
+        return token;
+      } catch (error) {
+        await this.releaseTopologyMutation(token).catch(() => {});
+        throw error;
       }
-      this.#editorTopologyOwners.set(token.tokenId, {
-        editorInstanceId: lease.editorInstanceId,
-        epoch: lease.epoch,
-      });
-      return token;
-    } catch (error) {
-      await this.releaseTopologyMutation(token).catch(() => {});
-      throw error;
-    }
+    });
   }
 
   listRecoveredEditorTopologyMutations(
@@ -1808,40 +2164,211 @@ export class WorkspaceMutationCoordinator {
     readonly resolved: true;
     readonly tokenId: string;
     readonly status: "unknown_outcome";
+    readonly sync: WorkspaceEditorSyncResult;
+  }> {
+    const finalized = await this.#finalizeEditorTopologyMutation(
+      input,
+      "unknown_outcome",
+      true,
+    );
+    return {
+      resolved: true,
+      tokenId: finalized.token.tokenId,
+      status: "unknown_outcome",
+      sync: finalized.sync,
+    };
+  }
+
+  #assertRecoveredTopologyCleanBuffersMatchDisk(
+    token: WorkspaceTopologyMutationToken,
+    buffers: readonly EditorBufferSync[],
+  ): void {
+    for (const buffer of buffers) {
+      if (
+        buffer.dirty ||
+        !token.targets.some((target) =>
+          topologyTargetContainsPath(target, this.resolvePath(buffer.path)),
+        )
+      ) {
+        continue;
+      }
+      const path = this.resolvePath(buffer.path);
+      const disk = boundedDiskAuthorityStateSync(path);
+      if (
+        disk.diskState !== "content" ||
+        disk.diskContentSha256 !== buffer.contentSha256 ||
+        disk.diskContentBytes !== buffer.contentBytes
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `Cannot reconcile recovered workspace path ${path}: the loaded clean Editor buffer does not match the descriptor-verified disk revision. Reload or unload it and retry.`,
+        );
+      }
+    }
+  }
+
+  async #finalizeEditorTopologyMutation(
+    input: WorkspaceEditorTopologyMutationFinalizeInput,
+    status: "applied" | "unknown_outcome" | null,
+    recovered: boolean,
+  ): Promise<{
+    readonly token: WorkspaceTopologyMutationToken;
+    readonly sync: WorkspaceEditorSyncResult;
   }> {
     const lease = this.#assertLease(input);
     const token = this.#topologyTokens.get(input.tokenId);
+    const intent = this.#topologyIntents.get(input.tokenId);
     if (
       token === undefined ||
-      this.#topologyIntents.get(input.tokenId) === undefined ||
-      !this.#recoveredTopologyTokens.has(input.tokenId) ||
-      this.#editorTopologyOwners.has(input.tokenId)
+      intent === undefined ||
+      (recovered
+        ? !this.#recoveredTopologyTokens.has(input.tokenId) ||
+          this.#editorTopologyOwners.has(input.tokenId)
+        : this.#recoveredTopologyTokens.has(input.tokenId) ||
+          this.#editorTopologyOwners.get(input.tokenId)?.editorInstanceId !==
+            lease.editorInstanceId ||
+          this.#editorTopologyOwners.get(input.tokenId)?.epoch !== lease.epoch)
     ) {
       throw new WorkspaceMutationCoordinatorError(
         "EDITOR_LEASE_MISMATCH",
-        "workspace path recovery token is not a durable orphan owned by the active editor recovery flow",
+        recovered
+          ? "workspace path recovery token is not a durable orphan owned by the active editor recovery flow"
+          : "workspace path operation does not belong to the active editor lease",
       );
     }
-
-    // Claim the orphan synchronously so two recovery clicks cannot both
-    // consume it. This owner is only a retry lock: the durable intent remains
-    // fenced until completeTopologyMutation first persists the explicit
-    // unknown_outcome reconciliation and then consumes the token.
+    if (this.#topologyFinalizationPending || this.#tokens.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "workspace path operation cannot finalize while another filesystem effect is committing",
+      );
+    }
     const recoveryOwner = {
       editorInstanceId: lease.editorInstanceId,
       epoch: lease.epoch,
     };
-    this.#editorTopologyOwners.set(token.tokenId, recoveryOwner);
+    if (recovered) {
+      this.#editorTopologyOwners.set(token.tokenId, recoveryOwner);
+    }
+    // Close the sync/contention race synchronously, before the first durable
+    // wait. The final snapshot below carries the exact post-operation Editor
+    // manifest and consumes the target intent in one filesystem transaction.
+    this.#topologyFinalizationPending = true;
     try {
-      await this.completeTopologyMutation(token, "unknown_outcome");
-      return {
-        resolved: true,
-        tokenId: token.tokenId,
-        status: "unknown_outcome",
-      };
+      return await this.#serializeProposalState(async () => {
+        await this.flushQuarantinePersistence().catch(() => {});
+        await this.#clearPendingAuditFence(
+          "finalize another workspace path operation",
+        );
+        const currentIntent = this.#topologyIntents.get(token.tokenId);
+        if (currentIntent === undefined) {
+          throw new WorkspaceMutationCoordinatorError(
+            "INVALID_EDITOR_SYNC",
+            "workspace topology mutation intent is missing or already consumed",
+          );
+        }
+        const conservativeIntents = new Map(this.#topologyIntents);
+        conservativeIntents.set(token.tokenId, {
+          ...currentIntent,
+          contentions: [],
+        });
+        await this.#scheduleQuarantineSnapshot(
+          this.#quarantineSnapshot({ topologyIntents: conservativeIntents }),
+        );
+        if (recovered) {
+          this.#assertRecoveredTopologyCleanBuffersMatchDisk(
+            token,
+            input.buffers,
+          );
+        }
+        const terminalTimestamp = new Date(this.#now()).toISOString();
+        const targetChanges =
+          status === null
+            ? []
+            : token.targets.map((target) => ({
+                kind: "topology" as const,
+                topologyTokenId: token.tokenId,
+                path: target.path,
+                includeDescendants: target.includeDescendants,
+                source: currentIntent.source,
+                status,
+              }));
+        const pathChanges =
+          status === null
+            ? []
+            : currentIntent.contentions.map((contention) => {
+                const afterSha256 = boundedDiskSha256Sync(contention.path);
+                return {
+                  path: contention.path,
+                  source: currentIntent.source,
+                  status,
+                  beforeSha256: contention.beforeSha256,
+                  ...(afterSha256 !== null ? { afterSha256 } : {}),
+                } satisfies Omit<
+                  WorkspaceChangeEvent,
+                  "sequence" | "timestamp" | "workspaceRoot"
+                >;
+              });
+        const changes = [...targetChanges, ...pathChanges];
+        const auditEntries =
+          status === null
+            ? []
+            : token.targets.map((target) =>
+                topologyTerminalLedgerEntry(
+                  this.workspaceRoot,
+                  token,
+                  target,
+                  status,
+                  terminalTimestamp,
+                ),
+              );
+        try {
+          await this.#ledger.assertAppendOnceCompatible(auditEntries);
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace path operation was not finalized because its durable audit identity conflicts with an existing outcome (${error instanceof Error ? error.message : String(error)}).`,
+          );
+        }
+        const plan = this.#prepareEditorSync(
+          {
+            workspaceRoot: input.workspaceRoot,
+            editorInstanceId: input.editorInstanceId,
+            leaseToken: input.leaseToken,
+            epoch: input.epoch,
+            sequence: input.sequence,
+            buffers: input.buffers,
+          },
+          {
+            allowTopologyTokenId: token.tokenId,
+            topologyFinalization: {
+              tokenId: token.tokenId,
+              changes,
+              auditEntries,
+            },
+          },
+        );
+        await this.#scheduleQuarantineSnapshot(plan.quarantineSnapshot, {
+          acceptInstalledWithDurableFallback: true,
+        });
+        const sync = this.#commitEditorSync(plan);
+        this.#topologyIntents.delete(token.tokenId);
+        this.#topologyTokens.delete(token.tokenId);
+        this.#editorTopologyOwners.delete(token.tokenId);
+        this.#recoveredTopologyTokens.delete(token.tokenId);
+        try {
+          await this.#drainAuditOutbox();
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace path operation completed, but its durable audit projection remains pending (${error instanceof Error ? error.message : String(error)}). Reconnect to retry safely.`,
+          );
+        }
+        return { token, sync };
+      });
     } catch (error) {
       const activeOwner = this.#editorTopologyOwners.get(token.tokenId);
       if (
+        recovered &&
         this.#topologyTokens.has(token.tokenId) &&
         activeOwner?.editorInstanceId === recoveryOwner.editorInstanceId &&
         activeOwner.epoch === recoveryOwner.epoch
@@ -1849,6 +2376,8 @@ export class WorkspaceMutationCoordinator {
         this.#editorTopologyOwners.delete(token.tokenId);
       }
       throw error;
+    } finally {
+      this.#topologyFinalizationPending = false;
     }
   }
 
@@ -1857,12 +2386,42 @@ export class WorkspaceMutationCoordinator {
     source: WorkspaceMutationSource,
     editorLease: ActiveLease | null,
   ): Promise<WorkspaceTopologyMutationToken> {
+    this.#assertNoStaleAuthorityResolution();
     this.#expireLeaseIfNeeded();
     await this.flushQuarantinePersistence();
+    await this.#clearPendingAuditFence("reserve a workspace path operation");
+    this.#assertNoStaleAuthorityResolution();
+    this.#expireLeaseIfNeeded();
+    if (editorLease !== null) {
+      const activeLease = this.#lease;
+      if (
+        activeLease === null ||
+        activeLease.editorInstanceId !== editorLease.editorInstanceId ||
+        activeLease.leaseToken !== editorLease.leaseToken ||
+        activeLease.epoch !== editorLease.epoch
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          "editor lease changed while reserving the workspace path operation",
+        );
+      }
+    }
     if (this.#quarantineHydrationFailed) {
       throw new WorkspaceMutationCoordinatorError(
         "EDITOR_LEASE_MISMATCH",
         "Cannot reserve a workspace path operation while editor quarantine is unreadable",
+      );
+    }
+    if (this.#recoveredTopologyTokens.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "Cannot reserve another workspace path operation until recovered path fences are reconciled",
+      );
+    }
+    if (this.#proposalCommitments.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "Cannot reserve a workspace path operation while Editor proposals are awaiting review",
       );
     }
     if (targets.length === 0) {
@@ -1883,6 +2442,12 @@ export class WorkspaceMutationCoordinator {
       allowOwnedClean: target.allowOwnedClean === true,
     }));
     for (const target of resolvedTargets) {
+      if (this.#topologyInvalidationConflictForTarget(target) !== null) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `Cannot mutate ${target.path}: Editor has not acknowledged an overlapping completed workspace path operation`,
+        );
+      }
       const editorConflict = this.#bufferConflictForTopologyTarget(
         target,
         editorLease,
@@ -1931,13 +2496,27 @@ export class WorkspaceMutationCoordinator {
         }
       }
     }
+    const mergedTargets = new Map<string, boolean>();
+    for (const target of resolvedTargets) {
+      mergedTargets.set(
+        target.path,
+        (mergedTargets.get(target.path) ?? false) || target.includeDescendants,
+      );
+    }
+    const durableTargets = [...mergedTargets].map(
+      ([path, includeDescendants]) => ({ path, includeDescendants }),
+    );
     const token: WorkspaceTopologyMutationToken = {
       tokenId: randomUUID(),
       workspaceRoot: this.workspaceRoot,
-      targets: resolvedTargets.map(({ path, includeDescendants }) => ({
-        path,
-        includeDescendants,
-      })),
+      targets: durableTargets.filter(
+        (target) =>
+          !durableTargets.some(
+            (other) =>
+              other.path !== target.path &&
+              topologyTargetContainsPath(other, target.path),
+          ),
+      ),
       source,
       createdAt: this.#now(),
     };
@@ -1949,15 +2528,14 @@ export class WorkspaceMutationCoordinator {
     };
     const projectedIntents = new Map(this.#topologyIntents);
     projectedIntents.set(intent.tokenId, intent);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        topologyIntents: projectedIntents,
-      }),
-    );
+    this.#assertQuarantineTransitionFits({
+      topologyIntents: projectedIntents,
+    });
     const pendingDeliveryCount =
       this.#changes.filter(isEditorReloadChange).length;
     const projectedTopologyReloadCount = [...projectedIntents.values()].reduce(
-      (total, projected) => total + projected.contentions.length,
+      (total, projected) =>
+        total + projected.targets.length + projected.contentions.length,
       0,
     );
     if (
@@ -1987,52 +2565,163 @@ export class WorkspaceMutationCoordinator {
   async releaseTopologyMutation(
     token: WorkspaceTopologyMutationToken,
   ): Promise<void> {
-    for (;;) {
-      await this.flushQuarantinePersistence();
-      const activeToken = this.#topologyTokens.get(token.tokenId);
-      if (activeToken === undefined) {
-        this.#editorTopologyOwners.delete(token.tokenId);
-        this.#recoveredTopologyTokens.delete(token.tokenId);
-        return;
-      }
-      if (
-        token.workspaceRoot !== this.workspaceRoot ||
-        activeToken.workspaceRoot !== token.workspaceRoot
-      ) {
-        throw new WorkspaceMutationCoordinatorError(
-          "INVALID_EDITOR_SYNC",
-          "workspace topology mutation token belongs to another workspace",
+    await this.#finalizeTopologyMutation(token, null);
+  }
+
+  async #finalizeTopologyMutation(
+    token: WorkspaceTopologyMutationToken,
+    status: "applied" | "unknown_outcome" | null,
+  ): Promise<void> {
+    const activeToken = this.#topologyTokens.get(token.tokenId);
+    if (activeToken === undefined) {
+      if (status === null) return;
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "workspace topology mutation token is missing or already consumed",
+      );
+    }
+    if (
+      token.workspaceRoot !== this.workspaceRoot ||
+      activeToken.workspaceRoot !== token.workspaceRoot
+    ) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "workspace topology mutation token belongs to another workspace",
+      );
+    }
+    if (this.#topologyFinalizationPending || this.#tokens.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "workspace path operation cannot finalize while another filesystem effect is committing",
+      );
+    }
+    this.#topologyFinalizationPending = true;
+    try {
+      await this.#serializeProposalState(async () => {
+        await this.flushQuarantinePersistence().catch(() => {});
+        await this.#clearPendingAuditFence(
+          "finalize another workspace path operation",
         );
-      }
-      const intent = this.#topologyIntents.get(token.tokenId);
-      if (intent === undefined) {
-        // No durable intent means there is no crash-recovery fence left to
-        // preserve. Clear the matching in-memory token idempotently.
+        const intent = this.#topologyIntents.get(token.tokenId);
+        if (intent === undefined) {
+          if (status === null) return;
+          throw new WorkspaceMutationCoordinatorError(
+            "INVALID_EDITOR_SYNC",
+            "workspace topology mutation intent is missing or already consumed",
+          );
+        }
+        const conservativeIntents = new Map(this.#topologyIntents);
+        conservativeIntents.set(token.tokenId, {
+          ...intent,
+          contentions: [],
+        });
+        await this.#scheduleQuarantineSnapshot(
+          this.#quarantineSnapshot({ topologyIntents: conservativeIntents }),
+        );
+        const targetChanges =
+          status === null
+            ? []
+            : token.targets.map((target) => ({
+                kind: "topology" as const,
+                topologyTokenId: token.tokenId,
+                path: target.path,
+                includeDescendants: target.includeDescendants,
+                source: intent.source,
+                status,
+              }));
+        const pathChanges =
+          status === null
+            ? []
+            : intent.contentions.map((contention) => {
+                const afterSha256 = boundedDiskSha256Sync(contention.path);
+                return {
+                  path: contention.path,
+                  source: intent.source,
+                  status,
+                  beforeSha256: contention.beforeSha256,
+                  ...(afterSha256 !== null ? { afterSha256 } : {}),
+                } satisfies Omit<
+                  WorkspaceChangeEvent,
+                  "sequence" | "timestamp" | "workspaceRoot"
+                >;
+              });
+        let projectedChanges;
+        try {
+          projectedChanges = this.#projectChanges([
+            ...targetChanges,
+            ...pathChanges,
+          ]);
+        } catch {
+          // Exact contention events are an optimization; target-scoped
+          // invalidations are the bounded, durable correctness record.
+          projectedChanges = this.#projectChanges(targetChanges);
+        }
+        const auditTimestamp = new Date(this.#now()).toISOString();
+        const auditEntries =
+          status === null
+            ? []
+            : token.targets.map((target) =>
+                topologyTerminalLedgerEntry(
+                  this.workspaceRoot,
+                  token,
+                  target,
+                  status,
+                  auditTimestamp,
+                ),
+              );
+        await this.#ledger.assertAppendOnceCompatible(auditEntries);
+        const projectedOutbox = new Map(this.#auditOutbox);
+        for (const entry of auditEntries) {
+          rememberAuditOutboxEntry(projectedOutbox, entry);
+        }
+        const projectedIntents = new Map(this.#topologyIntents);
+        projectedIntents.delete(token.tokenId);
+        let snapshot: WorkspaceQuarantineSnapshot;
+        try {
+          snapshot = this.#assertQuarantineTransitionFits({
+            topologyIntents: projectedIntents,
+            auditOutbox: projectedOutbox,
+            changes: projectedChanges.changes,
+            changeSequence: projectedChanges.sequence,
+          });
+        } catch (error) {
+          if (pathChanges.length === 0) throw error;
+          projectedChanges = this.#projectChanges(targetChanges);
+          snapshot = this.#assertQuarantineTransitionFits({
+            topologyIntents: projectedIntents,
+            auditOutbox: projectedOutbox,
+            changes: projectedChanges.changes,
+            changeSequence: projectedChanges.sequence,
+          });
+        }
+        await this.#scheduleQuarantineSnapshot(snapshot, {
+          acceptInstalledWithDurableFallback: true,
+        });
+        this.#changes.splice(
+          0,
+          this.#changes.length,
+          ...projectedChanges.changes,
+        );
+        this.#changeSequence = projectedChanges.sequence;
+        this.#auditOutbox.clear();
+        for (const [entryId, entry] of projectedOutbox) {
+          this.#auditOutbox.set(entryId, entry);
+        }
+        this.#topologyIntents.delete(token.tokenId);
         this.#topologyTokens.delete(token.tokenId);
         this.#editorTopologyOwners.delete(token.tokenId);
         this.#recoveredTopologyTokens.delete(token.tokenId);
-        return;
-      }
-      const projectedIntents = new Map(this.#topologyIntents);
-      projectedIntents.delete(token.tokenId);
-      const persistence = this.#scheduleQuarantineSnapshot(
-        this.#quarantineSnapshot({ topologyIntents: projectedIntents }),
-      );
-      await persistence;
-      // A rejected concurrent sync may have expanded the intent while the
-      // deletion snapshot was queued. Persist deletion of that exact latest
-      // intent before opening the fence.
-      if (
-        this.#pendingQuarantinePersistence !== persistence ||
-        this.#topologyIntents.get(token.tokenId) !== intent
-      ) {
-        continue;
-      }
-      this.#topologyIntents.delete(token.tokenId);
-      this.#topologyTokens.delete(token.tokenId);
-      this.#editorTopologyOwners.delete(token.tokenId);
-      this.#recoveredTopologyTokens.delete(token.tokenId);
-      return;
+        try {
+          await this.#drainAuditOutbox();
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace path operation completed, but its durable audit projection remains pending (${error instanceof Error ? error.message : String(error)}). Reconnect to retry safely.`,
+          );
+        }
+      });
+    } finally {
+      this.#topologyFinalizationPending = false;
     }
   }
 
@@ -2043,23 +2732,16 @@ export class WorkspaceMutationCoordinator {
     readonly tokenId: string;
     readonly sync: WorkspaceEditorSyncResult;
   }> {
-    const token = this.#assertEditorTopologyToken(input);
-    const sync = this.sync(
-      {
-        workspaceRoot: input.workspaceRoot,
-        editorInstanceId: input.editorInstanceId,
-        leaseToken: input.leaseToken,
-        epoch: input.epoch,
-        sequence: input.sequence,
-        buffers: input.buffers,
-      },
-      { allowTopologyTokenId: token.tokenId },
+    const finalized = await this.#finalizeEditorTopologyMutation(
+      input,
+      null,
+      false,
     );
-    // The final Editor manifest must be durable while the topology fence still
-    // exists. Only then may an aborted pre-effect transaction release it.
-    await this.flushQuarantinePersistence();
-    await this.releaseTopologyMutation(token);
-    return { released: true, tokenId: token.tokenId, sync };
+    return {
+      released: true,
+      tokenId: finalized.token.tokenId,
+      sync: finalized.sync,
+    };
   }
 
   async completeEditorTopologyMutation(
@@ -2072,28 +2754,16 @@ export class WorkspaceMutationCoordinator {
     readonly status: "applied" | "unknown_outcome";
     readonly sync: WorkspaceEditorSyncResult;
   }> {
-    const token = this.#assertEditorTopologyToken(input);
-    const sync = this.sync(
-      {
-        workspaceRoot: input.workspaceRoot,
-        editorInstanceId: input.editorInstanceId,
-        leaseToken: input.leaseToken,
-        epoch: input.epoch,
-        sequence: input.sequence,
-        buffers: input.buffers,
-      },
-      { allowTopologyTokenId: token.tokenId },
+    const finalized = await this.#finalizeEditorTopologyMutation(
+      input,
+      input.status,
+      false,
     );
-    // Publish Neovim's post-operation manifest without opening a destination
-    // path race: the topology token remains visible to all other writers until
-    // completeTopologyMutation consumes it below.
-    await this.flushQuarantinePersistence();
-    await this.completeTopologyMutation(token, input.status);
     return {
       completed: true,
-      tokenId: token.tokenId,
+      tokenId: finalized.token.tokenId,
       status: input.status,
-      sync,
+      sync: finalized.sync,
     };
   }
 
@@ -2101,92 +2771,7 @@ export class WorkspaceMutationCoordinator {
     token: WorkspaceTopologyMutationToken,
     status: "applied" | "unknown_outcome",
   ): Promise<void> {
-    if (
-      token.workspaceRoot !== this.workspaceRoot ||
-      this.#topologyTokens.get(token.tokenId) === undefined
-    ) {
-      throw new WorkspaceMutationCoordinatorError(
-        "INVALID_EDITOR_SYNC",
-        "workspace topology mutation token is missing or already consumed",
-      );
-    }
-    for (;;) {
-      await this.flushQuarantinePersistence();
-      const intent = this.#topologyIntents.get(token.tokenId);
-      if (intent === undefined) {
-        throw new WorkspaceMutationCoordinatorError(
-          "INVALID_EDITOR_SYNC",
-          "workspace topology mutation intent is missing or already consumed",
-        );
-      }
-      const changeInputs = intent.contentions.map((contention) => {
-        const afterSha256 = boundedDiskSha256Sync(contention.path);
-        return {
-          path: contention.path,
-          source: intent.source,
-          status,
-          beforeSha256: contention.beforeSha256,
-          ...(afterSha256 !== null ? { afterSha256 } : {}),
-        } satisfies Omit<
-          WorkspaceChangeEvent,
-          "sequence" | "timestamp" | "workspaceRoot"
-        >;
-      });
-      const projectedChanges = this.#projectChanges(changeInputs);
-      const projectedIntents = new Map(this.#topologyIntents);
-      projectedIntents.delete(token.tokenId);
-      const snapshot = this.#quarantineSnapshot({
-        topologyIntents: projectedIntents,
-        changes: projectedChanges.changes,
-        changeSequence: projectedChanges.sequence,
-      });
-      this.#ledger.assertQuarantineFits(snapshot);
-      const persistence = this.#scheduleQuarantineSnapshot(snapshot);
-      await persistence;
-      // A concurrent rejected sync queues a newer intent snapshot. Let it
-      // finish, then rebuild completion with that exact-path contention too.
-      if (
-        this.#pendingQuarantinePersistence !== persistence ||
-        this.#topologyIntents.get(token.tokenId) !== intent
-      ) {
-        continue;
-      }
-      this.#changes.splice(
-        0,
-        this.#changes.length,
-        ...projectedChanges.changes,
-      );
-      this.#changeSequence = projectedChanges.sequence;
-      this.#topologyIntents.delete(token.tokenId);
-      this.#topologyTokens.delete(token.tokenId);
-      this.#editorTopologyOwners.delete(token.tokenId);
-      this.#recoveredTopologyTokens.delete(token.tokenId);
-      let ledgerError: unknown;
-      for (const change of projectedChanges.changes.slice(
-        projectedChanges.changes.length - changeInputs.length,
-      )) {
-        try {
-          await this.#appendLedger({
-            path: change.path,
-            source: change.source,
-            status: change.status,
-            beforeSha256: change.beforeSha256,
-            ...(change.afterSha256 !== undefined
-              ? { afterSha256: change.afterSha256 }
-              : {}),
-          });
-        } catch (error) {
-          ledgerError ??= error;
-        }
-      }
-      if (ledgerError !== undefined) {
-        throw new WorkspaceMutationCoordinatorError(
-          "MUTATION_AUDIT_FAILED",
-          `Workspace path operation completed, but AgenC could not append its audit ledger (${ledgerError instanceof Error ? ledgerError.message : String(ledgerError)}). Reload affected Editor buffers before continuing.`,
-        );
-      }
-      return;
-    }
+    await this.#finalizeTopologyMutation(token, status);
   }
 
   getProposal(proposalId: string): WorkspaceMutationProposal | null {
@@ -2194,6 +2779,7 @@ export class WorkspaceMutationCoordinator {
   }
 
   discardProposal(proposalId: string): boolean {
+    this.#assertNoStaleAuthorityResolution();
     const deleted =
       this.#proposals.delete(proposalId) ||
       this.#proposalCommitments.delete(proposalId);
@@ -2327,9 +2913,21 @@ export class WorkspaceMutationCoordinator {
             );
           }
           this.#scheduleQuarantinePersistence();
-          await this.flushQuarantinePersistence();
+          try {
+            await this.#drainAuditOutbox();
+          } catch (error) {
+            throw new WorkspaceMutationCoordinatorError(
+              "MUTATION_AUDIT_FAILED",
+              `Workspace mutation proposal ${input.proposalId} is applied, but its durable audit transaction is still pending (${error instanceof Error ? error.message : String(error)}). Retry the exact acknowledgement to complete it safely.`,
+            );
+          }
+          this.#assertLease(input);
           return receipt.result;
         }
+        await this.#clearPendingAuditFence(
+          `apply workspace mutation proposal ${input.proposalId}`,
+        );
+        const activeLease = this.#assertLease(input);
         const proposal = this.#proposals.get(input.proposalId);
         const commitment = this.#proposalCommitments.get(input.proposalId);
         if (proposal === undefined && commitment === undefined) {
@@ -2421,53 +3019,16 @@ export class WorkspaceMutationCoordinator {
           changedtick: input.changedtick,
           contentSha256: input.contentSha256,
         };
-        // Append before consuming the proposal. A durable-ledger failure leaves
-        // the original proposal retryable instead of creating an unreceipted
-        // in-memory commit.
-        await this.#appendLedger({
-          path: resolvedCommitment.path,
-          source: resolvedCommitment.source,
-          status: "applied",
-          beforeSha256: resolvedCommitment.baseContentSha256,
-          afterSha256: input.contentSha256,
-          proposalId: resolvedCommitment.proposalId,
-        });
-        const activeLease = this.#assertLease(input);
-        const latest = this.#buffers.get(resolvedCommitment.path);
-        const latestAtBaseRevision =
-          latest !== undefined &&
-          latest.contentSha256 === resolvedCommitment.baseContentSha256 &&
-          latest.changedtick === resolvedCommitment.baseChangedtick;
-        const latestAtAcceptedRevision =
-          latest !== undefined &&
-          latest.authority === "editor_dirty" &&
-          latest.contentSha256 === resolvedCommitment.afterContentSha256 &&
-          latest.changedtick === input.changedtick &&
-          latest.epoch === activeLease.epoch;
-        const latestIsNewerEditorRevision =
-          latest !== undefined &&
-          latest.authority === "editor_dirty" &&
-          latest.changedtick > input.changedtick &&
-          latest.epoch === activeLease.epoch;
-        if (
-          !latestAtBaseRevision &&
-          !latestAtAcceptedRevision &&
-          !latestIsNewerEditorRevision
-        ) {
-          throw new WorkspaceMutationCoordinatorError(
-            "EDITOR_LEASE_MISMATCH",
-            `workspace mutation proposal authority changed while its acknowledgement was being committed: ${input.proposalId}`,
-          );
-        }
         const nextBuffers = new Map(this.#buffers);
-        if (latestAtBaseRevision) {
+        let nextAuthorityVersion = this.#authorityVersion;
+        if (atBaseRevision) {
           nextBuffers.set(resolvedCommitment.path, {
-            ...latest,
+            ...previous,
             path: resolvedCommitment.path,
             bufferHandle:
-              latest.bufferHandle === 0
+              previous.bufferHandle === 0
                 ? resolvedCommitment.bufferHandle
-                : latest.bufferHandle,
+                : previous.bufferHandle,
             changedtick: input.changedtick,
             contentSha256: input.contentSha256,
             contentBytes: Buffer.byteLength(input.content, "utf8"),
@@ -2476,7 +3037,7 @@ export class WorkspaceMutationCoordinator {
             epoch: activeLease.epoch,
             editorInstanceId: activeLease.editorInstanceId,
             crossInstanceRecoveryAllowed: false,
-            version: ++this.#authorityVersion,
+            version: ++nextAuthorityVersion,
           });
         }
         const nextCommitments = new Map(this.#proposalCommitments);
@@ -2504,30 +3065,74 @@ export class WorkspaceMutationCoordinator {
             proposalId: resolvedCommitment.proposalId,
           },
         ]);
-        this.#ledger.assertQuarantineFits(
-          this.#quarantineSnapshot({
-            buffers: nextBuffers,
-            proposalCommitments: nextCommitments,
-            proposalReceipts: nextReceipts,
-            changes: nextChanges.changes,
-            changeSequence: nextChanges.sequence,
-          }),
+        const nextAuditOutbox = new Map(this.#auditOutbox);
+        const terminalEntry = proposalTerminalLedgerEntry(
+          this.workspaceRoot,
+          resolvedCommitment,
+          "applied",
+          new Date(this.#now()).toISOString(),
         );
-        this.#buffers.clear();
-        for (const [path, state] of nextBuffers) this.#buffers.set(path, state);
-        this.#proposals.delete(resolvedCommitment.proposalId);
-        this.#proposalCommitments.clear();
-        for (const [id, next] of nextCommitments) {
-          this.#proposalCommitments.set(id, next);
+        rememberAuditOutboxEntry(nextAuditOutbox, terminalEntry);
+        const terminalSnapshot = this.#assertQuarantineTransitionFits({
+          buffers: nextBuffers,
+          proposalCommitments: nextCommitments,
+          proposalReceipts: nextReceipts,
+          auditOutbox: nextAuditOutbox,
+          changes: nextChanges.changes,
+          changeSequence: nextChanges.sequence,
+        });
+        this.#assertProposalTerminalPersistenceCanStart();
+        this.#proposalTerminalPersistencePending = true;
+        try {
+          // Establish a durable retryable checkpoint, then replace it with the
+          // complete terminal state. During these fsyncs all Editor mutations
+          // retry, while reads continue to observe the checkpoint state.
+          await this.flushQuarantinePersistence().catch(() => {});
+          await this.#scheduleQuarantineSnapshot(this.#quarantineSnapshot());
+          await this.#ledger.assertAppendOnceCompatible([terminalEntry]);
+          await this.#scheduleQuarantineSnapshot(terminalSnapshot, {
+            acceptInstalledWithDurableFallback: true,
+          });
+
+          // Only after the terminal snapshot is installed do live structures
+          // move together. Ledger projection happens later from its outbox.
+          this.#buffers.clear();
+          for (const [path, state] of nextBuffers) {
+            this.#buffers.set(path, state);
+          }
+          this.#authorityVersion = nextAuthorityVersion;
+          this.#proposals.delete(resolvedCommitment.proposalId);
+          this.#proposalCommitments.clear();
+          for (const [id, next] of nextCommitments) {
+            this.#proposalCommitments.set(id, next);
+          }
+          this.#proposalReceipts.clear();
+          for (const [id, next] of nextReceipts) {
+            this.#proposalReceipts.set(id, next);
+          }
+          this.#auditOutbox.clear();
+          for (const [entryId, entry] of nextAuditOutbox) {
+            this.#auditOutbox.set(entryId, entry);
+          }
+          this.#changes.splice(0, this.#changes.length, ...nextChanges.changes);
+          this.#changeSequence = nextChanges.sequence;
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace mutation proposal ${input.proposalId} could not persist its applied decision (${error instanceof Error ? error.message : String(error)}). The live proposal remains retryable.`,
+          );
+        } finally {
+          this.#proposalTerminalPersistencePending = false;
         }
-        this.#proposalReceipts.clear();
-        for (const [id, next] of nextReceipts) {
-          this.#proposalReceipts.set(id, next);
+        try {
+          await this.#drainAuditOutbox();
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace mutation proposal ${input.proposalId} is durably applied, but its append-only audit projection is pending (${error instanceof Error ? error.message : String(error)}). Retry the exact acknowledgement to complete it safely.`,
+          );
         }
-        this.#changes.splice(0, this.#changes.length, ...nextChanges.changes);
-        this.#changeSequence = nextChanges.sequence;
-        this.#scheduleQuarantinePersistence();
-        await this.flushQuarantinePersistence();
+        this.#assertLease(input);
         return result;
       }),
     );
@@ -2551,9 +3156,21 @@ export class WorkspaceMutationCoordinator {
         }
         if (receipt?.action === "discarded") {
           this.#scheduleQuarantinePersistence();
-          await this.flushQuarantinePersistence();
+          try {
+            await this.#drainAuditOutbox();
+          } catch (error) {
+            throw new WorkspaceMutationCoordinatorError(
+              "MUTATION_AUDIT_FAILED",
+              `Workspace mutation proposal ${input.proposalId} is discarded, but its durable audit transaction is still pending (${error instanceof Error ? error.message : String(error)}). Retry the exact acknowledgement to complete it safely.`,
+            );
+          }
+          this.#assertLease(input);
           return receipt.result;
         }
+        await this.#clearPendingAuditFence(
+          `discard workspace mutation proposal ${input.proposalId}`,
+        );
+        this.#assertLease(input);
         const proposal = this.#proposals.get(input.proposalId);
         const commitment = this.#proposalCommitments.get(input.proposalId);
         if (proposal === undefined && commitment === undefined) {
@@ -2586,18 +3203,6 @@ export class WorkspaceMutationCoordinator {
           proposalId: resolvedCommitment.proposalId,
           path: resolvedCommitment.path,
         };
-        await this.#appendLedger({
-          path: resolvedCommitment.path,
-          source: resolvedCommitment.source,
-          status: "discarded",
-          beforeSha256: resolvedCommitment.baseContentSha256,
-          afterSha256: resolvedCommitment.afterContentSha256,
-          proposalId: resolvedCommitment.proposalId,
-        });
-        // The ledger append is asynchronous. A release or takeover during it
-        // invalidates this acknowledgement; leave the commitment intact so the
-        // surviving editor can retry under its new lease.
-        this.#assertLease(input);
         const nextCommitments = new Map(this.#proposalCommitments);
         nextCommitments.delete(resolvedCommitment.proposalId);
         const nextReceipts = new Map(this.#proposalReceipts);
@@ -2621,27 +3226,63 @@ export class WorkspaceMutationCoordinator {
             proposalId: resolvedCommitment.proposalId,
           },
         ]);
-        this.#ledger.assertQuarantineFits(
-          this.#quarantineSnapshot({
-            proposalCommitments: nextCommitments,
-            proposalReceipts: nextReceipts,
-            changes: nextChanges.changes,
-            changeSequence: nextChanges.sequence,
-          }),
+        const nextAuditOutbox = new Map(this.#auditOutbox);
+        const terminalEntry = proposalTerminalLedgerEntry(
+          this.workspaceRoot,
+          resolvedCommitment,
+          "discarded",
+          new Date(this.#now()).toISOString(),
         );
-        this.#proposals.delete(resolvedCommitment.proposalId);
-        this.#proposalCommitments.clear();
-        for (const [id, next] of nextCommitments) {
-          this.#proposalCommitments.set(id, next);
+        rememberAuditOutboxEntry(nextAuditOutbox, terminalEntry);
+        const terminalSnapshot = this.#assertQuarantineTransitionFits({
+          proposalCommitments: nextCommitments,
+          proposalReceipts: nextReceipts,
+          auditOutbox: nextAuditOutbox,
+          changes: nextChanges.changes,
+          changeSequence: nextChanges.sequence,
+        });
+        this.#assertProposalTerminalPersistenceCanStart();
+        this.#proposalTerminalPersistencePending = true;
+        try {
+          await this.flushQuarantinePersistence().catch(() => {});
+          await this.#scheduleQuarantineSnapshot(this.#quarantineSnapshot());
+          await this.#ledger.assertAppendOnceCompatible([terminalEntry]);
+          await this.#scheduleQuarantineSnapshot(terminalSnapshot, {
+            acceptInstalledWithDurableFallback: true,
+          });
+
+          this.#proposals.delete(resolvedCommitment.proposalId);
+          this.#proposalCommitments.clear();
+          for (const [id, next] of nextCommitments) {
+            this.#proposalCommitments.set(id, next);
+          }
+          this.#proposalReceipts.clear();
+          for (const [id, next] of nextReceipts) {
+            this.#proposalReceipts.set(id, next);
+          }
+          this.#auditOutbox.clear();
+          for (const [entryId, entry] of nextAuditOutbox) {
+            this.#auditOutbox.set(entryId, entry);
+          }
+          this.#changes.splice(0, this.#changes.length, ...nextChanges.changes);
+          this.#changeSequence = nextChanges.sequence;
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace mutation proposal ${input.proposalId} could not persist its discarded decision (${error instanceof Error ? error.message : String(error)}). The live proposal remains retryable.`,
+          );
+        } finally {
+          this.#proposalTerminalPersistencePending = false;
         }
-        this.#proposalReceipts.clear();
-        for (const [id, next] of nextReceipts) {
-          this.#proposalReceipts.set(id, next);
+        try {
+          await this.#drainAuditOutbox();
+        } catch (error) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `Workspace mutation proposal ${input.proposalId} is durably discarded, but its append-only audit projection is pending (${error instanceof Error ? error.message : String(error)}). Retry the exact acknowledgement to complete it safely.`,
+          );
         }
-        this.#changes.splice(0, this.#changes.length, ...nextChanges.changes);
-        this.#changeSequence = nextChanges.sequence;
-        this.#scheduleQuarantinePersistence();
-        await this.flushQuarantinePersistence();
+        this.#assertLease(input);
         return result;
       }),
     );
@@ -2662,6 +3303,114 @@ export class WorkspaceMutationCoordinator {
     return this.#quarantineHydrationFailed && paths.length === 0
       ? [this.workspaceRoot]
       : paths;
+  }
+
+  staleAuthority(): readonly WorkspaceEditorStaleAuthorityEntry[] {
+    this.#expireLeaseIfNeeded();
+    return this.#currentStaleAuthority();
+  }
+
+  #currentStaleAuthority(): readonly WorkspaceEditorStaleAuthorityEntry[] {
+    const states = [...this.#buffers.values()]
+      .filter((state) => state.authority === "stale_dirty")
+      .sort((left, right) => left.path.localeCompare(right.path));
+    let remainingDiskBytes = MAX_SYNC_BYTES;
+    return states.map((state) => {
+      const entry = workspaceEditorStaleAuthorityEntry(
+        state,
+        remainingDiskBytes,
+      );
+      if (
+        entry.diskState === "content" &&
+        entry.diskContentBytes !== undefined
+      ) {
+        remainingDiskBytes -= entry.diskContentBytes;
+      }
+      return entry;
+    });
+  }
+
+  #validateStaleAuthorityAbandonments(
+    candidates: readonly WorkspaceEditorStaleAuthorityEntry[] | undefined,
+  ): ReadonlyMap<string, WorkspaceEditorStaleAuthorityEntry> {
+    if (candidates === undefined) return new Map();
+    if (candidates.length === 0 || candidates.length > MAX_SYNCED_BUFFERS) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        `stale Editor authority confirmation must contain between 1 and ${MAX_SYNCED_BUFFERS} entries`,
+      );
+    }
+    if (this.#quarantineHydrationFailed) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "unreadable Editor quarantine cannot be abandoned through a revision-specific confirmation",
+      );
+    }
+    if (this.#tokens.size > 0 || this.#topologyTokens.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "stale Editor authority cannot be abandoned while another workspace mutation is committing",
+      );
+    }
+
+    const confirmed = new Map<string, WorkspaceEditorStaleAuthorityEntry>();
+    for (const candidate of candidates) {
+      if (!isWorkspaceEditorStaleAuthorityEntry(candidate)) {
+        throw new WorkspaceMutationCoordinatorError(
+          "INVALID_EDITOR_SYNC",
+          "stale Editor authority confirmation is malformed",
+        );
+      }
+      const path = this.resolvePath(candidate.path);
+      if (candidate.path !== path || confirmed.has(path)) {
+        throw new WorkspaceMutationCoordinatorError(
+          "INVALID_EDITOR_SYNC",
+          `stale Editor authority confirmation contains a duplicate or non-canonical path: ${candidate.path}`,
+        );
+      }
+      const state = this.#buffers.get(path);
+      if (state?.authority !== "stale_dirty") {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `stale Editor authority changed before confirmation: ${path}`,
+        );
+      }
+      const current = workspaceEditorStaleAuthorityEntry(state);
+      if (!workspaceEditorStaleAuthorityEntriesEqual(candidate, current)) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `stale Editor or disk authority changed before confirmation: ${path}. Review the current recovery evidence and confirm again.`,
+        );
+      }
+      if (current.diskState === "unavailable") {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `Cannot use disk for quarantined editor buffer ${path}: the disk path is not a readable bounded regular file. Restore it or remove it, then review again.`,
+        );
+      }
+      confirmed.set(path, current);
+    }
+    return confirmed;
+  }
+
+  #assertStaleAuthorityStillMatches(
+    confirmed: ReadonlyMap<string, WorkspaceEditorStaleAuthorityEntry>,
+  ): void {
+    for (const [path, reviewed] of confirmed) {
+      const state = this.#buffers.get(path);
+      if (
+        state?.authority !== "stale_dirty" ||
+        !workspaceEditorStaleAuthorityEntriesEqual(
+          reviewed,
+          workspaceEditorStaleAuthorityEntry(state),
+        )
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "EDITOR_LEASE_MISMATCH",
+          `stale Editor or disk authority changed while confirming: ${path}. Review the current recovery evidence and confirm again.`,
+        );
+      }
+    }
   }
 
   loadedEditorPathConflict(
@@ -2706,28 +3455,14 @@ export class WorkspaceMutationCoordinator {
   }
 
   /**
-   * A `disk_authoritative` buffer holds nothing an editor could lose: it says
-   * the file on disk IS the truth, which is exactly what `authorityForPath`
-   * reports for a path with no buffer entry at all. Counting those as
-   * protection meant a TUI that died without releasing its lease left its
-   * quarantine entries behind and, from the next daemon start on, every tool
-   * in that workspace was refused with "Tool 'exec_command' is blocked while
-   * this workspace has protected Editor authority" — with no live editor
-   * anywhere and nothing at risk.
-   *
-   * `editor_dirty` (unsaved editor content) and `stale_dirty` (quarantined,
-   * provenance unknown) still protect: a tool writing over either destroys
-   * state that exists nowhere else. A live lease is handled by the caller.
+   * A live `disk_authoritative` buffer holds nothing an editor could lose.
+   * Hydration deliberately rewrites persisted entries to `stale_dirty`,
+   * including entries that were last known clean: disk may have changed while
+   * the daemon was stopped, so those entries stay protected until the user
+   * resolves their exact recovery evidence.
    */
   #hasProtectedBuffer(): boolean {
     for (const state of this.#buffers.values()) {
-      // Hydration rewrites every persisted entry to `stale_dirty` and keeps
-      // what it actually was in `quarantinedFrom` — the same discriminator
-      // #synchronize uses to decide whether a quarantined path was dirty.
-      if (state.authority === "stale_dirty") {
-        if (state.quarantinedFrom !== "disk_authoritative") return true;
-        continue;
-      }
       if (state.authority !== "disk_authoritative") return true;
     }
     return false;
@@ -2789,6 +3524,45 @@ export class WorkspaceMutationCoordinator {
     return null;
   }
 
+  #topologyInvalidationConflictForPath(
+    path: string,
+  ): WorkspaceChangeEvent | null {
+    return (
+      this.#changes.find(
+        (change) =>
+          change.kind === "topology" &&
+          topologyTargetContainsPath(
+            {
+              path: change.path,
+              includeDescendants: change.includeDescendants === true,
+            },
+            path,
+          ),
+      ) ?? null
+    );
+  }
+
+  #topologyInvalidationConflictForTarget(
+    target: WorkspaceTopologyMutationTarget & { readonly path: string },
+  ): WorkspaceChangeEvent | null {
+    return (
+      this.#changes.find(
+        (change) =>
+          change.kind === "topology" &&
+          topologyTargetsOverlap(
+            {
+              path: change.path,
+              includeDescendants: change.includeDescendants === true,
+            },
+            {
+              path: target.path,
+              includeDescendants: target.includeDescendants === true,
+            },
+          ),
+      ) ?? null
+    );
+  }
+
   #recordTopologyContention(
     token: WorkspaceTopologyMutationToken,
     path: string,
@@ -2801,53 +3575,55 @@ export class WorkspaceMutationCoordinator {
     ) {
       return;
     }
-    const intent: WorkspaceTopologyMutationIntent = {
+    const expandedIntent: WorkspaceTopologyMutationIntent = {
       ...current,
       contentions: [...current.contentions, { path, beforeSha256 }],
     };
-    const projectedIntents = new Map(this.#topologyIntents);
-    projectedIntents.set(token.tokenId, intent);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        topologyIntents: projectedIntents,
-      }),
-    );
-    // Persist the expanded fail-closed intent before checking whether all
-    // completion events currently fit. If delivery capacity is exhausted,
-    // the topology fence must remain unresolved rather than forgetting this
-    // rejected Editor path.
-    this.#topologyIntents.set(token.tokenId, intent);
+    const expandedIntents = new Map(this.#topologyIntents);
+    expandedIntents.set(token.tokenId, expandedIntent);
+    try {
+      this.#assertQuarantineTransitionFits({
+        topologyIntents: expandedIntents,
+      });
+    } catch (error) {
+      if (
+        error instanceof WorkspaceMutationCoordinatorError &&
+        (error.code === "INVALID_EDITOR_SYNC" ||
+          error.code === "MUTATION_AUDIT_FAILED")
+      ) {
+        // Exact contention evidence is an optimization. The durable target
+        // fence is the conservative correctness record, and finalization
+        // replaces it with an unacknowledged target-scoped invalidation. Do
+        // not let an exact path consume capacity reserved for that terminal.
+        return;
+      }
+      throw error;
+    }
+    this.#topologyIntents.set(token.tokenId, expandedIntent);
     this.#scheduleQuarantinePersistence();
-    // A topology effect can happen immediately after the rejected sync is
-    // delivered, so reserve the exact reload-event representation now too.
-    const projectedChanges = this.#projectChanges(
-      intent.contentions.map((contention) => ({
-        path: contention.path,
-        source: intent.source,
-        status: "unknown_outcome" as const,
-        beforeSha256: contention.beforeSha256,
-      })),
-    );
-    const completionIntents = new Map(projectedIntents);
-    completionIntents.delete(token.tokenId);
-    this.#ledger.assertQuarantineFits(
-      this.#quarantineSnapshot({
-        topologyIntents: completionIntents,
-        changes: projectedChanges.changes,
-        changeSequence: projectedChanges.sequence,
-      }),
-    );
   }
 
   #pendingTopologyReloadCount(): number {
     return [...this.#topologyIntents.values()].reduce(
-      (total, intent) => total + intent.contentions.length,
+      (total, intent) =>
+        total + intent.targets.length + intent.contentions.length,
       0,
     );
   }
 
   flushQuarantinePersistence(): Promise<void> {
     return this.#pendingQuarantinePersistence;
+  }
+
+  async flushPendingAuditOutbox(): Promise<void> {
+    try {
+      await this.#serializeProposalState(() => this.#drainAuditOutbox());
+    } catch (error) {
+      throw new WorkspaceMutationCoordinatorError(
+        "MUTATION_AUDIT_FAILED",
+        `The pending workspace audit could not be completed (${error instanceof Error ? error.message : String(error)}). Editor authority remains fenced; reconnect to retry safely.`,
+      );
+    }
   }
 
   listChanges(
@@ -2935,37 +3711,6 @@ export class WorkspaceMutationCoordinator {
     return running;
   }
 
-  #assertEditorTopologyToken(
-    input: WorkspaceEditorTopologyMutationFinalizeInput,
-  ): WorkspaceTopologyMutationToken {
-    const lease = this.#assertLease(input);
-    const token = this.#topologyTokens.get(input.tokenId);
-    let owner = this.#editorTopologyOwners.get(input.tokenId);
-    if (
-      token !== undefined &&
-      owner === undefined &&
-      this.#recoveredTopologyTokens.has(input.tokenId)
-    ) {
-      owner = {
-        editorInstanceId: lease.editorInstanceId,
-        epoch: lease.epoch,
-      };
-      this.#editorTopologyOwners.set(input.tokenId, owner);
-    }
-    if (
-      token === undefined ||
-      owner === undefined ||
-      owner.editorInstanceId !== lease.editorInstanceId ||
-      owner.epoch !== lease.epoch
-    ) {
-      throw new WorkspaceMutationCoordinatorError(
-        "EDITOR_LEASE_MISMATCH",
-        "workspace path operation does not belong to the active editor lease",
-      );
-    }
-    return token;
-  }
-
   #rememberProposalCommitment(commitment: WorkspaceProposalCommitment): void {
     if (
       !this.#proposalCommitments.has(commitment.proposalId) &&
@@ -2980,7 +3725,22 @@ export class WorkspaceMutationCoordinator {
     this.#proposalCommitments.set(commitment.proposalId, commitment);
   }
 
-  #assertLease(input: WorkspaceEditorHeartbeatInput): ActiveLease {
+  #assertLease(
+    input: WorkspaceEditorHeartbeatInput,
+    allowStaleAuthorityResolution = false,
+    allowTopologyFinalization = false,
+  ): ActiveLease {
+    if (
+      this.#proposalTerminalPersistencePending ||
+      (this.#staleAuthorityResolutionPending &&
+        !allowStaleAuthorityResolution) ||
+      (this.#topologyFinalizationPending && !allowTopologyFinalization)
+    ) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "a durable Editor resolution is committing; retry after it finishes",
+      );
+    }
     this.#expireLeaseIfNeeded();
     if (canonicalizePathSync(input.workspaceRoot) !== this.workspaceRoot) {
       throw new WorkspaceMutationCoordinatorError(
@@ -3009,11 +3769,40 @@ export class WorkspaceMutationCoordinator {
   }
 
   #expireLeaseIfNeeded(): void {
+    if (
+      this.#staleAuthorityResolutionPending ||
+      this.#proposalTerminalPersistencePending ||
+      this.#topologyFinalizationPending
+    ) {
+      return;
+    }
     if (this.#lease !== null && this.#now() >= this.#lease.expiresAt) {
       this.#quarantineLoadedBuffers(true);
       this.#orphanEditorTopologyTokens(this.#lease);
       this.#lease = null;
       this.#scheduleQuarantinePersistence();
+    }
+  }
+
+  #assertNoStaleAuthorityResolution(): void {
+    if (
+      this.#staleAuthorityResolutionPending ||
+      this.#proposalTerminalPersistencePending ||
+      this.#topologyFinalizationPending
+    ) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "a durable Editor resolution is committing; retry after it finishes",
+      );
+    }
+  }
+
+  #assertProposalTerminalPersistenceCanStart(): void {
+    if (this.#tokens.size > 0 || this.#topologyTokens.size > 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "EDITOR_LEASE_MISMATCH",
+        "workspace mutation proposal cannot be resolved while another filesystem effect is committing",
+      );
     }
   }
 
@@ -3066,7 +3855,10 @@ export class WorkspaceMutationCoordinator {
     }
   }
 
-  #leaseResult(lease: ActiveLease): WorkspaceEditorLease {
+  #leaseResult(
+    lease: ActiveLease,
+    includeStaleAuthority = false,
+  ): WorkspaceEditorLease {
     return {
       workspaceRoot: this.workspaceRoot,
       editorInstanceId: lease.editorInstanceId,
@@ -3074,6 +3866,9 @@ export class WorkspaceMutationCoordinator {
       epoch: lease.epoch,
       sequence: lease.sequence,
       expiresAt: lease.expiresAt,
+      ...(includeStaleAuthority
+        ? { staleAuthority: this.#currentStaleAuthority() }
+        : {}),
     };
   }
 
@@ -3084,6 +3879,19 @@ export class WorkspaceMutationCoordinator {
     >,
   ): void {
     const projected = this.#projectChanges([input]);
+    try {
+      this.#assertQuarantineTransitionFits({
+        changes: projected.changes,
+        changeSequence: projected.sequence,
+      });
+    } catch (error) {
+      // Blocked/terminal informational events are disposable delivery-cache
+      // entries backed by the permanent ledger. Omit one that would consume a
+      // live proposal's resolution reserve instead of changing the caller's
+      // already-audited blocked result.
+      if (!isEditorReloadChange(input) && input.status !== "proposed") return;
+      throw error;
+    }
     this.#changes.splice(0, this.#changes.length, ...projected.changes);
     this.#changeSequence = projected.sequence;
   }
@@ -3160,6 +3968,451 @@ export class WorkspaceMutationCoordinator {
     );
   }
 
+  /**
+   * Validate both the candidate durable snapshot and the state from which all
+   * surviving proposals can eventually resolve. Proposal terminals first
+   * drain the audit outbox and cannot start until mutation/topology fences are
+   * gone, so their capacity base is the candidate after every pending effect
+   * has produced its largest possible reload event.
+   */
+  #assertQuarantineTransitionFits(
+    overrides: WorkspaceQuarantineStateOverrides = {},
+  ): WorkspaceQuarantineSnapshot {
+    const snapshot = this.#quarantineSnapshot(overrides);
+    this.#ledger.assertQuarantineFits(snapshot);
+
+    const proposalCommitments =
+      overrides.proposalCommitments ?? this.#proposalCommitments;
+    const buffers = overrides.buffers ?? this.#buffers;
+    const proposalReceipts =
+      overrides.proposalReceipts ?? this.#proposalReceipts;
+    const mutationIntents = overrides.mutationIntents ?? this.#mutationIntents;
+    const topologyIntents = overrides.topologyIntents ?? this.#topologyIntents;
+    const changes = overrides.changes ?? this.#changes;
+    const changeSequence = overrides.changeSequence ?? this.#changeSequence;
+    const pendingEffectChanges: Omit<
+      WorkspaceChangeEvent,
+      "sequence" | "timestamp" | "workspaceRoot"
+    >[] = [];
+    const terminalReadyAuditOutbox = new Map<
+      string,
+      WorkspaceChangeLedgerEntry
+    >();
+    for (const intent of mutationIntents.values()) {
+      pendingEffectChanges.push({
+        path: intent.path,
+        source: intent.source,
+        status: "unknown_outcome",
+        beforeSha256: intent.beforeSha256,
+        afterSha256: intent.intendedAfterSha256,
+      });
+    }
+    for (const intent of topologyIntents.values()) {
+      const token = this.#topologyTokens.get(intent.tokenId) ?? {
+        tokenId: intent.tokenId,
+        workspaceRoot: this.workspaceRoot,
+        targets: intent.targets,
+        source: intent.source,
+        createdAt: 0,
+      };
+      for (const target of intent.targets) {
+        pendingEffectChanges.push({
+          kind: "topology",
+          topologyTokenId: intent.tokenId,
+          path: target.path,
+          includeDescendants: target.includeDescendants,
+          source: intent.source,
+          status: "unknown_outcome",
+        });
+        rememberAuditOutboxEntry(
+          terminalReadyAuditOutbox,
+          topologyTerminalLedgerEntry(
+            this.workspaceRoot,
+            token,
+            target,
+            "unknown_outcome",
+            new Date(this.#now()).toISOString(),
+          ),
+        );
+      }
+      for (const contention of intent.contentions) {
+        pendingEffectChanges.push({
+          path: contention.path,
+          source: intent.source,
+          status: "unknown_outcome",
+          beforeSha256: contention.beforeSha256,
+          // A completion may discover readable disk content. Reserve the
+          // digest field even when the current path is absent or unreadable.
+          afterSha256: contention.beforeSha256,
+        });
+      }
+    }
+    const terminalReadyChanges = this.#projectChanges(pendingEffectChanges, {
+      changes,
+      sequence: changeSequence,
+    });
+    const terminalReadySnapshot = this.#quarantineSnapshot({
+      buffers,
+      proposalCommitments,
+      proposalReceipts,
+      auditOutbox: terminalReadyAuditOutbox,
+      mutationIntents: new Map(),
+      topologyIntents: new Map(),
+      changes: terminalReadyChanges.changes,
+      changeSequence: terminalReadyChanges.sequence,
+    });
+    this.#ledger.assertQuarantineFits(terminalReadySnapshot);
+    if (proposalCommitments.size === 0) return snapshot;
+    // Admission must remain valid after a hard restart, when proposal source
+    // text and the next Editor identity are unavailable. Reserve the largest
+    // valid serialized identity, epoch, changedtick, and content-byte width;
+    // source contents themselves are never written to quarantine.
+    const terminalLease = {
+      editorInstanceId: "\u0000".repeat(256),
+      leaseToken: "",
+      epoch: Number.MAX_SAFE_INTEGER,
+      sequence: -1,
+      expiresAt: 0,
+    } satisfies ActiveLease;
+    this.#assertAllProposalTerminalOutcomesFit({
+      buffers,
+      proposalCommitments,
+      proposalReceipts,
+      auditOutbox: new Map(),
+      mutationIntents: new Map(),
+      topologyIntents: new Map(),
+      changes: terminalReadyChanges.changes,
+      changeSequence: terminalReadyChanges.sequence,
+      appliedContentBytes: new Map(),
+      activeLease: terminalLease,
+    });
+    return snapshot;
+  }
+
+  #repairHydratedProposalTerminalCapacity(): boolean {
+    let pruned = false;
+    for (;;) {
+      try {
+        this.#assertQuarantineTransitionFits();
+        return pruned;
+      } catch (error) {
+        // Older snapshots predate terminal-capacity reservation. The review
+        // feed is a bounded cache backed by the append-only ledger, and these
+        // are the same disposable events ordinary projection evicts. Preserve
+        // proposal discovery and Editor reload events; if those alone cannot
+        // satisfy the invariant, hydration remains fail-closed.
+        const disposableIndex = this.#changes.findIndex(
+          (change) =>
+            !isEditorReloadChange(change) && change.status !== "proposed",
+        );
+        if (disposableIndex >= 0) {
+          this.#changes.splice(disposableIndex, 1);
+          pruned = true;
+          continue;
+        }
+        const optionalContention = [...this.#topologyIntents.values()].find(
+          (intent) => intent.contentions.length > 0,
+        );
+        if (optionalContention === undefined) throw error;
+        // Pre-target-invalidation snapshots could spend their remaining byte
+        // budget on exact contention hints. The target scope is the durable
+        // correctness fence in the current schema, so discard only those
+        // optional hints during migration and preserve every target/token.
+        this.#topologyIntents.set(optionalContention.tokenId, {
+          ...optionalContention,
+          contentions: [],
+        });
+        pruned = true;
+      }
+    }
+  }
+
+  #assertAllProposalTerminalOutcomesFit(input: {
+    readonly buffers: ReadonlyMap<string, EditorBufferState>;
+    readonly proposalCommitments: ReadonlyMap<
+      string,
+      WorkspaceProposalCommitment
+    >;
+    readonly proposalReceipts: ReadonlyMap<string, WorkspaceProposalReceipt>;
+    readonly auditOutbox: ReadonlyMap<string, WorkspaceChangeLedgerEntry>;
+    readonly mutationIntents: ReadonlyMap<string, WorkspaceMutationIntent>;
+    readonly topologyIntents: ReadonlyMap<
+      string,
+      WorkspaceTopologyMutationIntent
+    >;
+    readonly changes: readonly WorkspaceChangeEvent[];
+    readonly changeSequence: number;
+    readonly appliedContentBytes: ReadonlyMap<string, number>;
+    readonly activeLease: ActiveLease;
+  }): void {
+    const terminalTimestamp = new Date(this.#now()).toISOString();
+    const projectWorstAppliedTerminal = (
+      commitment: WorkspaceProposalCommitment,
+      state: {
+        readonly buffers: ReadonlyMap<string, EditorBufferState>;
+        readonly proposalCommitments: ReadonlyMap<
+          string,
+          WorkspaceProposalCommitment
+        >;
+        readonly proposalReceipts: ReadonlyMap<
+          string,
+          WorkspaceProposalReceipt
+        >;
+        readonly changes: readonly WorkspaceChangeEvent[];
+        readonly changeSequence: number;
+      },
+    ) => {
+      const proposalCommitments = new Map(state.proposalCommitments);
+      proposalCommitments.delete(commitment.proposalId);
+      const existingBuffer = state.buffers.get(commitment.path);
+      const buffers = new Map(state.buffers);
+      buffers.set(commitment.path, {
+        path: commitment.path,
+        bufferHandle: existingBuffer?.bufferHandle ?? commitment.bufferHandle,
+        changedtick: Number.MAX_SAFE_INTEGER,
+        contentSha256: commitment.afterContentSha256,
+        contentBytes:
+          input.appliedContentBytes.get(commitment.proposalId) ??
+          MAX_BUFFER_BYTES,
+        authority: "editor_dirty",
+        epoch: input.activeLease.epoch,
+        editorInstanceId: input.activeLease.editorInstanceId,
+        crossInstanceRecoveryAllowed: false,
+        version: existingBuffer?.version ?? this.#authorityVersion,
+      });
+      const proposalReceipts = new Map(state.proposalReceipts);
+      proposalReceipts.set(commitment.proposalId, {
+        action: "applied",
+        changedtick: Number.MAX_SAFE_INTEGER,
+        contentSha256: commitment.afterContentSha256,
+        result: {
+          applied: true,
+          proposalId: commitment.proposalId,
+          path: commitment.path,
+          changedtick: Number.MAX_SAFE_INTEGER,
+          contentSha256: commitment.afterContentSha256,
+        },
+      });
+      evictOldestProposalReceipts(proposalReceipts);
+      const projectedChanges = this.#projectChanges(
+        [
+          {
+            path: commitment.path,
+            source: commitment.source,
+            status: "applied",
+            beforeSha256: commitment.baseContentSha256,
+            afterSha256: commitment.afterContentSha256,
+            proposalId: commitment.proposalId,
+          },
+        ],
+        { changes: state.changes, sequence: state.changeSequence },
+      );
+      return {
+        buffers,
+        proposalCommitments,
+        proposalReceipts,
+        changes: projectedChanges.changes,
+        changeSequence: projectedChanges.sequence,
+      };
+    };
+    const projectAppliedEnvelope = (
+      commitment: WorkspaceProposalCommitment,
+      state: {
+        readonly buffers: ReadonlyMap<string, EditorBufferState>;
+        readonly proposalCommitments: ReadonlyMap<
+          string,
+          WorkspaceProposalCommitment
+        >;
+        readonly proposalReceipts: ReadonlyMap<
+          string,
+          WorkspaceProposalReceipt
+        >;
+        readonly changes: readonly WorkspaceChangeEvent[];
+        readonly changeSequence: number;
+      },
+      removeCommitment: boolean,
+    ) => {
+      const proposalCommitments = new Map(state.proposalCommitments);
+      if (removeCommitment) {
+        proposalCommitments.delete(commitment.proposalId);
+      }
+      const existingBuffer = state.buffers.get(commitment.path);
+      const buffers = new Map(state.buffers);
+      buffers.set(commitment.path, {
+        path: commitment.path,
+        bufferHandle: existingBuffer?.bufferHandle ?? commitment.bufferHandle,
+        changedtick: Number.MAX_SAFE_INTEGER,
+        contentSha256: commitment.afterContentSha256,
+        contentBytes:
+          input.appliedContentBytes.get(commitment.proposalId) ??
+          MAX_BUFFER_BYTES,
+        authority: "editor_dirty",
+        epoch: input.activeLease.epoch,
+        editorInstanceId: input.activeLease.editorInstanceId,
+        crossInstanceRecoveryAllowed: false,
+        version: existingBuffer?.version ?? this.#authorityVersion,
+      });
+      const proposalReceipts = new Map(state.proposalReceipts);
+      proposalReceipts.set(commitment.proposalId, {
+        action: "applied",
+        changedtick: Number.MAX_SAFE_INTEGER,
+        contentSha256: commitment.afterContentSha256,
+        result: {
+          applied: true,
+          proposalId: commitment.proposalId,
+          path: commitment.path,
+          changedtick: Number.MAX_SAFE_INTEGER,
+          contentSha256: commitment.afterContentSha256,
+        },
+      });
+      const changeSequence = state.changeSequence + 1;
+      const changes = [
+        ...state.changes,
+        {
+          sequence: changeSequence,
+          timestamp: terminalTimestamp,
+          workspaceRoot: this.workspaceRoot,
+          path: commitment.path,
+          source: commitment.source,
+          // `discarded` is the longest terminal status spelling. The phantom
+          // receipt above remains the larger applied representation.
+          status: "discarded" as const,
+          beforeSha256: commitment.baseContentSha256,
+          afterSha256: commitment.afterContentSha256,
+          proposalId: commitment.proposalId,
+        },
+      ];
+      return {
+        buffers,
+        proposalCommitments,
+        proposalReceipts,
+        changes,
+        changeSequence,
+      };
+    };
+
+    for (const commitment of input.proposalCommitments.values()) {
+      const immediateBase = {
+        buffers: input.buffers,
+        proposalCommitments: input.proposalCommitments,
+        proposalReceipts: input.proposalReceipts,
+        changes: input.changes,
+        changeSequence: input.changeSequence,
+      };
+      let terminalBase = immediateBase;
+      // Proposal terminals are serialized and drain their outbox between
+      // decisions. Reserve the target after every other live commitment has
+      // already reached its larger applied steady state; checking each one
+      // against the shared unresolved base misses cumulative receipt/buffer
+      // growth across a sequence of terminals and can strand the last review.
+      for (const prior of input.proposalCommitments.values()) {
+        if (prior.proposalId === commitment.proposalId) continue;
+        terminalBase = projectAppliedEnvelope(prior, terminalBase, false);
+      }
+      for (const [candidateBase, envelope] of [
+        [immediateBase, false] as const,
+        [terminalBase, true] as const,
+      ]) {
+        const applied = envelope
+          ? projectAppliedEnvelope(commitment, candidateBase, true)
+          : projectWorstAppliedTerminal(commitment, candidateBase);
+        const appliedAuditOutbox = new Map(input.auditOutbox);
+        rememberAuditOutboxEntry(
+          appliedAuditOutbox,
+          proposalTerminalLedgerEntry(
+            this.workspaceRoot,
+            commitment,
+            "applied",
+            terminalTimestamp,
+          ),
+        );
+        this.#ledger.assertQuarantineFits(
+          this.#quarantineSnapshot({
+            buffers: applied.buffers,
+            proposalCommitments: applied.proposalCommitments,
+            proposalReceipts: applied.proposalReceipts,
+            auditOutbox: appliedAuditOutbox,
+            mutationIntents: input.mutationIntents,
+            topologyIntents: input.topologyIntents,
+            changes: applied.changes,
+            changeSequence: applied.changeSequence,
+          }),
+          { allowProjectedShapeOverflow: envelope },
+        );
+
+        const remainingCommitments = new Map(candidateBase.proposalCommitments);
+        remainingCommitments.delete(commitment.proposalId);
+        const discardedReceipts = new Map(candidateBase.proposalReceipts);
+        discardedReceipts.set(commitment.proposalId, {
+          action: "discarded",
+          result: {
+            discarded: true,
+            proposalId: commitment.proposalId,
+            path: commitment.path,
+          },
+        });
+        if (!envelope) evictOldestProposalReceipts(discardedReceipts);
+        const discardedChanges = envelope
+          ? {
+              changes: [
+                ...candidateBase.changes,
+                {
+                  sequence: candidateBase.changeSequence + 1,
+                  timestamp: terminalTimestamp,
+                  workspaceRoot: this.workspaceRoot,
+                  path: commitment.path,
+                  source: commitment.source,
+                  status: "discarded" as const,
+                  beforeSha256: commitment.baseContentSha256,
+                  afterSha256: commitment.afterContentSha256,
+                  proposalId: commitment.proposalId,
+                },
+              ],
+              sequence: candidateBase.changeSequence + 1,
+            }
+          : this.#projectChanges(
+              [
+                {
+                  path: commitment.path,
+                  source: commitment.source,
+                  status: "discarded",
+                  beforeSha256: commitment.baseContentSha256,
+                  afterSha256: commitment.afterContentSha256,
+                  proposalId: commitment.proposalId,
+                },
+              ],
+              {
+                changes: candidateBase.changes,
+                sequence: candidateBase.changeSequence,
+              },
+            );
+        const discardedAuditOutbox = new Map(input.auditOutbox);
+        rememberAuditOutboxEntry(
+          discardedAuditOutbox,
+          proposalTerminalLedgerEntry(
+            this.workspaceRoot,
+            commitment,
+            "discarded",
+            terminalTimestamp,
+          ),
+        );
+        this.#ledger.assertQuarantineFits(
+          this.#quarantineSnapshot({
+            buffers: candidateBase.buffers,
+            proposalCommitments: remainingCommitments,
+            proposalReceipts: discardedReceipts,
+            auditOutbox: discardedAuditOutbox,
+            mutationIntents: input.mutationIntents,
+            topologyIntents: input.topologyIntents,
+            changes: discardedChanges.changes,
+            changeSequence: discardedChanges.sequence,
+          }),
+          { allowProjectedShapeOverflow: envelope },
+        );
+      }
+    }
+  }
+
   #assertProposalSize(path: string, content: string): void {
     const candidateBytes = Buffer.byteLength(content, "utf8");
     if (candidateBytes > MAX_BUFFER_BYTES) {
@@ -3183,27 +4436,14 @@ export class WorkspaceMutationCoordinator {
   }
 
   #quarantineSnapshot(
-    overrides: {
-      readonly buffers?: ReadonlyMap<string, EditorBufferState>;
-      readonly proposalCommitments?: ReadonlyMap<
-        string,
-        WorkspaceProposalCommitment
-      >;
-      readonly proposalReceipts?: ReadonlyMap<string, WorkspaceProposalReceipt>;
-      readonly mutationIntents?: ReadonlyMap<string, WorkspaceMutationIntent>;
-      readonly topologyIntents?: ReadonlyMap<
-        string,
-        WorkspaceTopologyMutationIntent
-      >;
-      readonly changes?: readonly WorkspaceChangeEvent[];
-      readonly changeSequence?: number;
-    } = {},
+    overrides: WorkspaceQuarantineStateOverrides = {},
   ): WorkspaceQuarantineSnapshot {
     const buffers = overrides.buffers ?? this.#buffers;
     const proposalCommitments =
       overrides.proposalCommitments ?? this.#proposalCommitments;
     const proposalReceipts =
       overrides.proposalReceipts ?? this.#proposalReceipts;
+    const auditOutbox = overrides.auditOutbox ?? this.#auditOutbox;
     const mutationIntents = overrides.mutationIntents ?? this.#mutationIntents;
     const topologyIntents = overrides.topologyIntents ?? this.#topologyIntents;
     return {
@@ -3244,30 +4484,106 @@ export class WorkspaceMutationCoordinator {
       topologyIntents: [...topologyIntents.values()],
       changeSequence: overrides.changeSequence ?? this.#changeSequence,
       changes: overrides.changes ?? this.#changes,
+      auditOutbox: [...auditOutbox.values()],
     };
   }
 
-  async #persistQuarantine(): Promise<void> {
-    if (this.#quarantineHydrationFailed) {
+  async #drainAuditOutbox(): Promise<void> {
+    await this.flushQuarantinePersistence();
+    if (this.#auditOutbox.size === 0) return;
+    const entries = [...this.#auditOutbox.values()];
+    await this.#appendLedgerOnce(entries);
+
+    for (const entry of entries) {
+      const current = this.#auditOutbox.get(entry.entryId);
+      if (
+        current !== undefined &&
+        workspaceChangeLedgerEntriesSemanticallyEqual(current, entry)
+      ) {
+        this.#auditOutbox.delete(entry.entryId);
+      }
+    }
+    this.#scheduleQuarantinePersistence();
+    try {
+      await this.flushQuarantinePersistence();
+    } catch (error) {
+      // The append-only ledger is already durable. Restore the outbox in
+      // memory so a later retry proves append-once and retries cleanup; a
+      // concurrently installed cleanup snapshot is also safe because it can
+      // only omit entries already present in the permanent ledger.
+      for (const entry of entries) {
+        if (!this.#auditOutbox.has(entry.entryId)) {
+          this.#auditOutbox.set(entry.entryId, entry);
+        }
+      }
+      throw error;
+    }
+  }
+
+  async #clearPendingAuditFence(action: string): Promise<void> {
+    if (this.#auditOutbox.size === 0) return;
+    try {
+      await this.#drainAuditOutbox();
+    } catch (error) {
       throw new WorkspaceMutationCoordinatorError(
-        "INVALID_EDITOR_SYNC",
-        "workspace quarantine is unreadable or unsafe; explicitly abandon dirty quarantine before replacing it",
+        "MUTATION_AUDIT_FAILED",
+        `Cannot ${action} while a previous durable workspace audit is still pending (${error instanceof Error ? error.message : String(error)}). Retry after audit projection recovers.`,
       );
     }
-    await this.#ledger.writeQuarantine(this.#quarantineSnapshot());
+    if (this.#auditOutbox.size !== 0) {
+      throw new WorkspaceMutationCoordinatorError(
+        "MUTATION_AUDIT_FAILED",
+        `Cannot ${action} while a previous durable workspace audit is still pending.`,
+      );
+    }
+  }
+
+  async #writeQuarantine(
+    snapshot: WorkspaceQuarantineSnapshot,
+    options: {
+      readonly acceptInstalledWithDurableFallback?: boolean;
+    } = {},
+  ): Promise<void> {
+    if (this.#beforePersistQuarantine !== undefined) {
+      await this.#beforePersistQuarantine();
+    }
+    await this.#ledger.writeQuarantine(snapshot, options);
   }
 
   #scheduleQuarantineSnapshot(
     snapshot: WorkspaceQuarantineSnapshot,
+    options: {
+      readonly acceptInstalledWithDurableFallback?: boolean;
+    } = {},
   ): Promise<void> {
-    const pending = this.#ledger.writeQuarantine(snapshot);
+    let pending: Promise<void>;
+    try {
+      // Transaction callers already validate terminal headroom from their
+      // map projections. Keep a non-recursive raw-size guard at the final
+      // scheduling boundary as defense in depth.
+      this.#ledger.assertQuarantineFits(snapshot);
+      pending = this.#writeQuarantine(snapshot, options);
+    } catch (error) {
+      pending = Promise.reject(error);
+    }
     this.#pendingQuarantinePersistence = pending;
     void pending.catch(() => {});
     return pending;
   }
 
   #scheduleQuarantinePersistence(): void {
-    const pending = this.#persistQuarantine();
+    let pending: Promise<void>;
+    try {
+      if (this.#quarantineHydrationFailed) {
+        throw new WorkspaceMutationCoordinatorError(
+          "INVALID_EDITOR_SYNC",
+          "workspace quarantine is unreadable or unsafe; explicitly abandon dirty quarantine before replacing it",
+        );
+      }
+      pending = this.#writeQuarantine(this.#assertQuarantineTransitionFits());
+    } catch (error) {
+      pending = Promise.reject(error);
+    }
     this.#pendingQuarantinePersistence = pending;
     // Preserve the rejected promise for the next daemon/mutation boundary,
     // while preventing an unhandled rejection if no boundary arrives before
@@ -3278,7 +4594,7 @@ export class WorkspaceMutationCoordinator {
   #hydrateQuarantine(value: unknown): boolean {
     if (
       !isRecord(value) ||
-      value.version !== 1 ||
+      (value.version !== 1 && value.version !== 2) ||
       typeof value.workspaceRoot !== "string" ||
       canonicalizePathSync(value.workspaceRoot) !== this.workspaceRoot ||
       !Array.isArray(value.entries) ||
@@ -3299,7 +4615,11 @@ export class WorkspaceMutationCoordinator {
         !isNonNegativeSafeInteger(value.changeSequence)) ||
       (value.changes !== undefined &&
         (!Array.isArray(value.changes) ||
-          value.changes.length > MAX_CHANGE_EVENTS))
+          value.changes.length > MAX_CHANGE_EVENTS)) ||
+      (value.version === 1 && value.auditOutbox !== undefined) ||
+      (value.version === 2 &&
+        (!Array.isArray(value.auditOutbox) ||
+          value.auditOutbox.length > MAX_AUDIT_OUTBOX_ENTRIES))
     ) {
       throw new Error("invalid workspace quarantine");
     }
@@ -3439,6 +4759,8 @@ export class WorkspaceMutationCoordinator {
     const changes = value.changes ?? [];
     let previousSequence = 0;
     for (const candidate of changes) {
+      const topologyChange =
+        isRecord(candidate) && candidate.kind === "topology";
       if (
         !isRecord(candidate) ||
         !isPositiveSafeInteger(candidate.sequence) ||
@@ -3452,7 +4774,18 @@ export class WorkspaceMutationCoordinator {
         !isAbsolute(candidate.path) ||
         !isWorkspaceMutationSource(candidate.source) ||
         !isWorkspaceChangeStatus(candidate.status) ||
-        !isSha256Digest(candidate.beforeSha256) ||
+        (topologyChange
+          ? (candidate.status !== "applied" &&
+              candidate.status !== "unknown_outcome") ||
+            !isValidPersistedIdentifier(candidate.topologyTokenId) ||
+            typeof candidate.includeDescendants !== "boolean" ||
+            candidate.beforeSha256 !== undefined ||
+            candidate.afterSha256 !== undefined ||
+            candidate.proposalId !== undefined
+          : (candidate.kind !== undefined && candidate.kind !== "path") ||
+            !isSha256Digest(candidate.beforeSha256) ||
+            candidate.topologyTokenId !== undefined ||
+            candidate.includeDescendants !== undefined) ||
         (candidate.afterSha256 !== undefined &&
           !isSha256Digest(candidate.afterSha256)) ||
         (candidate.proposalId !== undefined &&
@@ -3467,20 +4800,78 @@ export class WorkspaceMutationCoordinator {
         workspaceRoot: this.workspaceRoot,
         path,
         source: candidate.source,
+        ...(topologyChange
+          ? { kind: "topology" as const }
+          : candidate.kind === "path"
+            ? { kind: "path" as const }
+            : {}),
         status: candidate.status,
-        beforeSha256: candidate.beforeSha256,
+        ...(candidate.beforeSha256 !== undefined
+          ? { beforeSha256: candidate.beforeSha256 as string }
+          : {}),
         ...(candidate.afterSha256 !== undefined
           ? { afterSha256: candidate.afterSha256 }
           : {}),
         ...(candidate.proposalId !== undefined
           ? { proposalId: candidate.proposalId }
           : {}),
+        ...(topologyChange
+          ? { topologyTokenId: candidate.topologyTokenId as string }
+          : {}),
+        ...(topologyChange
+          ? { includeDescendants: candidate.includeDescendants as boolean }
+          : {}),
       });
       previousSequence = candidate.sequence;
     }
     this.#changeSequence = changeSequence;
 
+    const auditOutbox =
+      value.version === 2 && Array.isArray(value.auditOutbox)
+        ? value.auditOutbox
+        : [];
+    for (const candidate of auditOutbox) {
+      const entry = persistedWorkspaceChangeLedgerEntry(
+        candidate,
+        this.workspaceRoot,
+      );
+      if (entry === null) {
+        throw new Error("invalid workspace audit outbox entry");
+      }
+      if (
+        entry.proposalId !== undefined &&
+        (entry.status === "applied" || entry.status === "discarded")
+      ) {
+        const receipt = this.#proposalReceipts.get(entry.proposalId);
+        if (
+          receipt === undefined ||
+          this.#proposalCommitments.has(entry.proposalId) ||
+          receipt.action !== entry.status ||
+          receipt.result.path !== entry.path ||
+          entry.afterSha256 === undefined ||
+          (receipt.action === "applied" &&
+            receipt.contentSha256 !== entry.afterSha256)
+        ) {
+          throw new Error(
+            "workspace proposal receipt conflicts with its terminal audit outbox entry",
+          );
+        }
+      }
+      const existing = this.#auditOutbox.get(entry.entryId);
+      if (existing !== undefined) {
+        if (!workspaceChangeLedgerEntriesSemanticallyEqual(existing, entry)) {
+          throw new Error("conflicting workspace audit outbox entry");
+        }
+        continue;
+      }
+      this.#auditOutbox.set(entry.entryId, entry);
+    }
+
     const mutationIntents = value.mutationIntents ?? [];
+    const recoveredMutationChanges: Omit<
+      WorkspaceChangeEvent,
+      "sequence" | "timestamp" | "workspaceRoot"
+    >[] = [];
     for (const candidate of mutationIntents) {
       if (
         !isRecord(candidate) ||
@@ -3493,7 +4884,7 @@ export class WorkspaceMutationCoordinator {
       ) {
         throw new Error("invalid workspace mutation intent");
       }
-      this.#recordChange({
+      recoveredMutationChanges.push({
         path: this.resolvePath(candidate.path),
         source: candidate.source,
         status: "unknown_outcome",
@@ -3501,6 +4892,9 @@ export class WorkspaceMutationCoordinator {
         afterSha256: candidate.intendedAfterSha256,
       });
     }
+    const recoveredChanges = this.#projectChanges(recoveredMutationChanges);
+    this.#changes.splice(0, this.#changes.length, ...recoveredChanges.changes);
+    this.#changeSequence = recoveredChanges.sequence;
 
     const topologyIntents = value.topologyIntents ?? [];
     for (const candidate of topologyIntents) {
@@ -3577,7 +4971,9 @@ export class WorkspaceMutationCoordinator {
       this.#topologyTokens.set(token.tokenId, token);
       this.#recoveredTopologyTokens.add(token.tokenId);
     }
-    return mutationIntents.length > 0;
+    const prunedDisposableChanges =
+      this.#repairHydratedProposalTerminalCapacity();
+    return mutationIntents.length > 0 || prunedDisposableChanges;
   }
 }
 
@@ -3918,8 +5314,7 @@ export class WorkspaceMutationCoordinatorRegistry {
     // all new Editor authority during that short operation window so no
     // topology exchange can create an unobserved nested coordinator.
     const crossingOperation = this.#toolOperations.values().next().value as
-      | WorkspaceToolOperationToken
-      | undefined;
+      WorkspaceToolOperationToken | undefined;
     if (crossingOperation !== undefined) {
       throw new WorkspaceMutationCoordinatorError(
         "EDITOR_LEASE_CONFLICT",
@@ -3977,8 +5372,7 @@ export class WorkspaceMutationCoordinatorRegistry {
     toolName: string,
   ): WorkspaceReadToolOperation {
     const root = canonicalizePathSync(workspaceRoot);
-    const requiresStrictCandidateReads =
-      this.hasProtectedEditorAuthority(root);
+    const requiresStrictCandidateReads = this.hasProtectedEditorAuthority(root);
     const token: WorkspaceToolOperationToken = {
       tokenId: randomUUID(),
       workspacePath: normalizePathIdentity(workspaceRoot),
@@ -4163,11 +5557,300 @@ class WorkspaceChangeLedger {
     });
   }
 
-  assertQuarantineFits(input: WorkspaceQuarantineSnapshot): void {
-    this.#serializeQuarantine(input);
+  assertAppendOnceCompatible(
+    entries: readonly WorkspaceChangeLedgerEntry[],
+  ): Promise<void> {
+    if (entries.length === 0) return Promise.resolve();
+    const requestedIds = new Set<string>();
+    const requestedProposalTerminals = new Map<
+      string,
+      WorkspaceChangeLedgerEntry
+    >();
+    for (const entry of entries) {
+      if (
+        entry.workspaceRoot !== this.#workspaceRoot ||
+        persistedWorkspaceChangeLedgerEntry(entry, this.#workspaceRoot) === null
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "MUTATION_AUDIT_FAILED",
+          "invalid workspace audit outbox entry",
+        );
+      }
+      requestedIds.add(entry.entryId);
+      const terminalKey = workspaceProposalTerminalKey(entry);
+      if (terminalKey === null) continue;
+      const previous = requestedProposalTerminals.get(terminalKey);
+      if (
+        previous !== undefined &&
+        !workspaceProposalTerminalEntriesSemanticallyEqual(previous, entry)
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "MUTATION_AUDIT_FAILED",
+          `conflicting terminal workspace audit outcomes for proposal ${entry.proposalId}`,
+        );
+      }
+      requestedProposalTerminals.set(terminalKey, entry);
+    }
+
+    return this.#serialize(async () => {
+      const existing = await this.#readLedgerEntries(
+        requestedIds,
+        new Set(requestedProposalTerminals.keys()),
+      );
+      for (const entry of entries) {
+        const previous = existing.byEntryId.get(entry.entryId);
+        if (
+          previous !== undefined &&
+          !workspaceChangeLedgerEntriesSemanticallyEqual(previous, entry)
+        ) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `workspace audit entry id has a different terminal payload: ${entry.entryId}`,
+          );
+        }
+        const terminalKey = workspaceProposalTerminalKey(entry);
+        const previousTerminal =
+          terminalKey === null
+            ? undefined
+            : existing.byProposalTerminal.get(terminalKey);
+        if (
+          previousTerminal !== undefined &&
+          !workspaceProposalTerminalEntriesSemanticallyEqual(
+            previousTerminal,
+            entry,
+          )
+        ) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `workspace proposal ${entry.proposalId} already has a different terminal audit outcome`,
+          );
+        }
+      }
+    });
   }
 
-  writeQuarantine(input: WorkspaceQuarantineSnapshot): Promise<void> {
+  appendOnce(entries: readonly WorkspaceChangeLedgerEntry[]): Promise<void> {
+    if (entries.length === 0) return Promise.resolve();
+    const requested = new Map<string, WorkspaceChangeLedgerEntry>();
+    const requestedProposalTerminals = new Map<
+      string,
+      WorkspaceChangeLedgerEntry
+    >();
+    for (const entry of entries) {
+      if (
+        entry.workspaceRoot !== this.#workspaceRoot ||
+        persistedWorkspaceChangeLedgerEntry(entry, this.#workspaceRoot) === null
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "MUTATION_AUDIT_FAILED",
+          "invalid workspace audit outbox entry",
+        );
+      }
+      const previous = requested.get(entry.entryId);
+      if (
+        previous !== undefined &&
+        !workspaceChangeLedgerEntriesSemanticallyEqual(previous, entry)
+      ) {
+        throw new WorkspaceMutationCoordinatorError(
+          "MUTATION_AUDIT_FAILED",
+          `conflicting workspace audit entry id: ${entry.entryId}`,
+        );
+      }
+      requested.set(entry.entryId, entry);
+      const terminalKey = workspaceProposalTerminalKey(entry);
+      if (terminalKey !== null) {
+        const previousTerminal = requestedProposalTerminals.get(terminalKey);
+        if (
+          previousTerminal !== undefined &&
+          !workspaceProposalTerminalEntriesSemanticallyEqual(
+            previousTerminal,
+            entry,
+          )
+        ) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `conflicting terminal workspace audit outcomes for proposal ${entry.proposalId}`,
+          );
+        }
+        requestedProposalTerminals.set(terminalKey, entry);
+      }
+    }
+
+    return this.#serialize(async () => {
+      await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+      const existing = await this.#readLedgerEntries(
+        new Set(requested.keys()),
+        new Set(requestedProposalTerminals.keys()),
+      );
+      const missing: WorkspaceChangeLedgerEntry[] = [];
+      for (const entry of requested.values()) {
+        const previous = existing.byEntryId.get(entry.entryId);
+        if (
+          previous !== undefined &&
+          !workspaceChangeLedgerEntriesSemanticallyEqual(previous, entry)
+        ) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `workspace audit entry id has a different terminal payload: ${entry.entryId}`,
+          );
+        }
+        const terminalKey = workspaceProposalTerminalKey(entry);
+        const previousTerminal =
+          terminalKey === null
+            ? undefined
+            : existing.byProposalTerminal.get(terminalKey);
+        if (
+          previousTerminal !== undefined &&
+          !workspaceProposalTerminalEntriesSemanticallyEqual(
+            previousTerminal,
+            entry,
+          )
+        ) {
+          throw new WorkspaceMutationCoordinatorError(
+            "MUTATION_AUDIT_FAILED",
+            `workspace proposal ${entry.proposalId} already has a different terminal audit outcome`,
+          );
+        }
+        if (previous === undefined && previousTerminal === undefined) {
+          missing.push(entry);
+        }
+      }
+      if (missing.length > 0) {
+        await appendFile(
+          this.#ledgerPath,
+          missing.map((entry) => `${JSON.stringify(entry)}\n`).join(""),
+          { encoding: "utf8", mode: 0o600 },
+        );
+      }
+      const handle = await open(this.#ledgerPath, "r+");
+      try {
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      await fsyncDirectory(this.#directory);
+    });
+  }
+
+  async #readLedgerEntries(
+    requestedIds: ReadonlySet<string>,
+    requestedProposalTerminals: ReadonlySet<string>,
+  ): Promise<{
+    readonly byEntryId: ReadonlyMap<string, WorkspaceChangeLedgerEntry>;
+    readonly byProposalTerminal: ReadonlyMap<
+      string,
+      WorkspaceChangeLedgerEntry
+    >;
+  }> {
+    let handle;
+    try {
+      handle = await open(this.#ledgerPath, "r");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { byEntryId: new Map(), byProposalTerminal: new Map() };
+      }
+      throw error;
+    }
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) {
+        throw new Error("workspace mutation ledger is not a regular file");
+      }
+      if (stats.size > 0) {
+        const lastByte = Buffer.allocUnsafe(1);
+        const { bytesRead } = await handle.read(lastByte, 0, 1, stats.size - 1);
+        if (bytesRead !== 1 || lastByte[0] !== 0x0a) {
+          throw new Error("workspace mutation ledger has an incomplete record");
+        }
+      }
+      const byEntryId = new Map<string, WorkspaceChangeLedgerEntry>();
+      const byProposalTerminal = new Map<string, WorkspaceChangeLedgerEntry>();
+      const stream = handle.createReadStream({
+        encoding: "utf8",
+        autoClose: false,
+        start: 0,
+      });
+      const lines = createReadlineInterface({
+        input: stream,
+        crlfDelay: Infinity,
+      });
+      try {
+        for await (const line of lines) {
+          if (line.length === 0) {
+            throw new Error(
+              "workspace mutation ledger contains an empty record",
+            );
+          }
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(line) as unknown;
+          } catch {
+            throw new Error("workspace mutation ledger contains invalid JSON");
+          }
+          const entry = persistedWorkspaceChangeLedgerEntry(
+            parsed,
+            this.#workspaceRoot,
+          );
+          if (entry === null) {
+            throw new Error(
+              "workspace mutation ledger contains an invalid record",
+            );
+          }
+          if (requestedIds.has(entry.entryId)) {
+            const previous = byEntryId.get(entry.entryId);
+            if (
+              previous !== undefined &&
+              !workspaceChangeLedgerEntriesSemanticallyEqual(previous, entry)
+            ) {
+              throw new Error(
+                `workspace mutation ledger contains conflicting entry id ${entry.entryId}`,
+              );
+            }
+            byEntryId.set(entry.entryId, entry);
+          }
+          const terminalKey = workspaceProposalTerminalKey(entry);
+          if (
+            terminalKey !== null &&
+            requestedProposalTerminals.has(terminalKey)
+          ) {
+            const previousTerminal = byProposalTerminal.get(terminalKey);
+            if (
+              previousTerminal !== undefined &&
+              !workspaceProposalTerminalEntriesSemanticallyEqual(
+                previousTerminal,
+                entry,
+              )
+            ) {
+              throw new Error(
+                `workspace mutation ledger contains conflicting terminal outcomes for proposal ${entry.proposalId}`,
+              );
+            }
+            byProposalTerminal.set(terminalKey, entry);
+          }
+        }
+      } finally {
+        lines.close();
+        stream.destroy();
+      }
+      return { byEntryId, byProposalTerminal };
+    } finally {
+      await handle.close();
+    }
+  }
+
+  assertQuarantineFits(
+    input: WorkspaceQuarantineSnapshot,
+    options: { readonly allowProjectedShapeOverflow?: boolean } = {},
+  ): void {
+    this.#serializeQuarantine(input, options);
+  }
+
+  writeQuarantine(
+    input: WorkspaceQuarantineSnapshot,
+    options: {
+      readonly acceptInstalledWithDurableFallback?: boolean;
+    } = {},
+  ): Promise<void> {
     const serialized = this.#serializeQuarantine(input);
     return this.#serialize(async () => {
       await mkdir(this.#directory, { recursive: true, mode: 0o700 });
@@ -4180,13 +5863,48 @@ class WorkspaceChangeLedger {
         await fileHandle.close();
       }
       await rename(temp, this.#quarantinePath);
-      await fsyncDirectory(this.#directory);
+      try {
+        await fsyncDirectory(this.#directory);
+      } catch (error) {
+        if (options.acceptInstalledWithDurableFallback !== true) throw error;
+        // The caller fsynced a conservative snapshot at this pathname before
+        // this rename. The replacement file was also fsynced before rename, so
+        // a crash can expose either the protected fallback or this exact new
+        // snapshot. Accept the installed replacement in the live process only
+        // after proving that it is byte-for-byte the requested snapshot.
+        let installed: string;
+        try {
+          installed = await readFile(this.#quarantinePath, "utf8");
+        } catch {
+          throw error;
+        }
+        if (installed !== serialized) throw error;
+      }
     });
   }
 
-  #serializeQuarantine(input: WorkspaceQuarantineSnapshot): string {
+  #serializeQuarantine(
+    input: WorkspaceQuarantineSnapshot,
+    options: { readonly allowProjectedShapeOverflow?: boolean } = {},
+  ): string {
+    if (
+      options.allowProjectedShapeOverflow !== true &&
+      (input.entries.length > MAX_SYNCED_BUFFERS ||
+        input.proposalCommitments.length > MAX_PENDING_PROPOSALS ||
+        input.proposalReceipts.length > MAX_PROPOSAL_RECEIPTS ||
+        input.mutationIntents.length > MAX_CHANGE_EVENTS ||
+        input.topologyIntents.length > MAX_CHANGE_EVENTS ||
+        input.changes.length > MAX_CHANGE_EVENTS ||
+        input.auditOutbox.length > MAX_AUDIT_OUTBOX_ENTRIES)
+    ) {
+      throw new WorkspaceMutationCoordinatorError(
+        "INVALID_EDITOR_SYNC",
+        "workspace quarantine exceeds persisted collection limits",
+      );
+    }
+    const version = input.auditOutbox.length > 0 ? 2 : 1;
     const serialized = `${JSON.stringify({
-      version: 1,
+      version,
       workspaceRoot: this.#workspaceRoot,
       entries: input.entries,
       proposalCommitments: input.proposalCommitments,
@@ -4195,6 +5913,7 @@ class WorkspaceChangeLedger {
       topologyIntents: input.topologyIntents,
       changeSequence: input.changeSequence,
       changes: input.changes,
+      ...(version === 2 ? { auditOutbox: input.auditOutbox } : {}),
     })}\n`;
     if (Buffer.byteLength(serialized, "utf8") > MAX_QUARANTINE_BYTES) {
       throw new WorkspaceMutationCoordinatorError(
@@ -4256,16 +5975,328 @@ export function sha256(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");
 }
 
-function boundedDiskSha256Sync(path: string): string | null {
-  let descriptor: number;
+function evictOldestProposalReceipts(
+  receipts: Map<string, WorkspaceProposalReceipt>,
+): void {
+  while (receipts.size > MAX_PROPOSAL_RECEIPTS) {
+    const oldest = receipts.keys().next().value;
+    if (typeof oldest !== "string") break;
+    receipts.delete(oldest);
+  }
+}
+
+function rememberAuditOutboxEntry(
+  outbox: Map<string, WorkspaceChangeLedgerEntry>,
+  entry: WorkspaceChangeLedgerEntry,
+): void {
+  const previous = outbox.get(entry.entryId);
+  if (previous !== undefined) {
+    if (!workspaceChangeLedgerEntriesSemanticallyEqual(previous, entry)) {
+      throw new WorkspaceMutationCoordinatorError(
+        "MUTATION_AUDIT_FAILED",
+        `workspace audit entry id has a different terminal payload: ${entry.entryId}`,
+      );
+    }
+    return;
+  }
+  if (outbox.size >= MAX_AUDIT_OUTBOX_ENTRIES) {
+    throw new WorkspaceMutationCoordinatorError(
+      "MUTATION_AUDIT_FAILED",
+      "workspace audit outbox is full; retry after pending audit records are projected",
+    );
+  }
+  outbox.set(entry.entryId, entry);
+}
+
+function staleAuthorityDiscardLedgerEntry(
+  workspaceRoot: string,
+  evidence: WorkspaceEditorStaleAuthorityEntry,
+  change: WorkspaceChangeLedgerAppendInput,
+  timestamp: string,
+): WorkspaceChangeLedgerEntry {
+  const entryId = createHash("sha256")
+    .update(
+      JSON.stringify([
+        "stale-editor-authority-discard-v1",
+        workspaceRoot,
+        evidence.path,
+        evidence.editorContentSha256,
+        evidence.editorContentBytes,
+        evidence.changedtick,
+        evidence.editorInstanceId,
+        evidence.epoch,
+        evidence.editorState,
+        evidence.diskState,
+        evidence.diskContentSha256 ?? null,
+        evidence.diskContentBytes ?? null,
+      ]),
+      "utf8",
+    )
+    .digest("hex");
+  return {
+    version: 1,
+    entryId,
+    timestamp,
+    workspaceRoot,
+    ...change,
+  };
+}
+
+function proposalTerminalLedgerEntry(
+  workspaceRoot: string,
+  commitment: WorkspaceProposalCommitment,
+  status: "applied" | "discarded",
+  timestamp: string,
+): WorkspaceChangeLedgerEntry {
+  // Applied and discarded terminal outcomes deliberately share this semantic
+  // id namespace. If opposite outcomes are ever projected for one proposal,
+  // appendOnce rejects the collision instead of recording a contradiction.
+  const entryId = createHash("sha256")
+    .update(
+      JSON.stringify([
+        "workspace-proposal-terminal-v1",
+        workspaceRoot,
+        commitment.proposalId,
+      ]),
+      "utf8",
+    )
+    .digest("hex");
+  return {
+    version: 1,
+    entryId,
+    timestamp,
+    workspaceRoot,
+    path: commitment.path,
+    source: commitment.source,
+    status,
+    beforeSha256: commitment.baseContentSha256,
+    afterSha256: commitment.afterContentSha256,
+    proposalId: commitment.proposalId,
+  };
+}
+
+function topologyTerminalLedgerEntry(
+  workspaceRoot: string,
+  token: WorkspaceTopologyMutationToken,
+  target: WorkspaceTopologyMutationToken["targets"][number],
+  status: "applied" | "unknown_outcome",
+  timestamp: string,
+): WorkspaceChangeLedgerEntry {
+  const entryId = createHash("sha256")
+    .update(
+      JSON.stringify([
+        "workspace-topology-terminal-v1",
+        workspaceRoot,
+        token.tokenId,
+        target.path,
+        target.includeDescendants,
+      ]),
+    )
+    .digest("hex");
+  return {
+    version: 1,
+    entryId,
+    timestamp,
+    workspaceRoot,
+    path: target.path,
+    source: token.source,
+    kind: "topology",
+    status,
+    topologyTokenId: token.tokenId,
+    includeDescendants: target.includeDescendants,
+  };
+}
+
+function workspaceProposalTerminalKey(
+  entry: WorkspaceChangeLedgerEntry,
+): string | null {
+  if (
+    entry.proposalId === undefined ||
+    (entry.status !== "applied" && entry.status !== "discarded")
+  ) {
+    return null;
+  }
+  return JSON.stringify([entry.workspaceRoot, entry.proposalId]);
+}
+
+function workspaceProposalTerminalEntriesSemanticallyEqual(
+  left: WorkspaceChangeLedgerEntry,
+  right: WorkspaceChangeLedgerEntry,
+): boolean {
+  return (
+    workspaceProposalTerminalKey(left) !== null &&
+    workspaceProposalTerminalKey(left) ===
+      workspaceProposalTerminalKey(right) &&
+    left.version === right.version &&
+    left.workspaceRoot === right.workspaceRoot &&
+    left.path === right.path &&
+    left.source === right.source &&
+    left.kind === right.kind &&
+    left.status === right.status &&
+    left.beforeSha256 === right.beforeSha256 &&
+    left.afterSha256 === right.afterSha256 &&
+    left.sessionId === right.sessionId &&
+    left.toolCallId === right.toolCallId &&
+    left.proposalId === right.proposalId &&
+    left.topologyTokenId === right.topologyTokenId &&
+    left.includeDescendants === right.includeDescendants
+  );
+}
+
+function workspaceChangeLedgerEntriesSemanticallyEqual(
+  left: WorkspaceChangeLedgerEntry,
+  right: WorkspaceChangeLedgerEntry,
+): boolean {
+  return (
+    left.version === right.version &&
+    left.entryId === right.entryId &&
+    left.workspaceRoot === right.workspaceRoot &&
+    left.path === right.path &&
+    left.source === right.source &&
+    left.kind === right.kind &&
+    left.status === right.status &&
+    left.beforeSha256 === right.beforeSha256 &&
+    left.afterSha256 === right.afterSha256 &&
+    left.sessionId === right.sessionId &&
+    left.toolCallId === right.toolCallId &&
+    left.proposalId === right.proposalId &&
+    left.topologyTokenId === right.topologyTokenId &&
+    left.includeDescendants === right.includeDescendants
+  );
+}
+
+function persistedWorkspaceChangeLedgerEntry(
+  value: unknown,
+  workspaceRoot: string,
+): WorkspaceChangeLedgerEntry | null {
+  const topologyEntry = isRecord(value) && value.kind === "topology";
+  if (
+    !isRecord(value) ||
+    value.version !== 1 ||
+    !isValidPersistedIdentifier(value.entryId) ||
+    typeof value.timestamp !== "string" ||
+    Number.isNaN(Date.parse(value.timestamp)) ||
+    typeof value.workspaceRoot !== "string" ||
+    !isAbsolute(value.workspaceRoot) ||
+    typeof value.path !== "string" ||
+    !isAbsolute(value.path) ||
+    !isWorkspaceMutationSource(value.source) ||
+    !isWorkspaceChangeStatus(value.status) ||
+    (topologyEntry
+      ? (value.status !== "applied" && value.status !== "unknown_outcome") ||
+        !isValidPersistedIdentifier(value.topologyTokenId) ||
+        typeof value.includeDescendants !== "boolean" ||
+        value.beforeSha256 !== undefined ||
+        value.afterSha256 !== undefined ||
+        value.proposalId !== undefined
+      : (value.kind !== undefined && value.kind !== "path") ||
+        !isSha256Digest(value.beforeSha256) ||
+        value.topologyTokenId !== undefined ||
+        value.includeDescendants !== undefined) ||
+    (value.afterSha256 !== undefined && !isSha256Digest(value.afterSha256)) ||
+    (value.sessionId !== undefined &&
+      !isValidPersistedIdentifier(value.sessionId)) ||
+    (value.toolCallId !== undefined &&
+      !isValidPersistedIdentifier(value.toolCallId)) ||
+    (value.proposalId !== undefined &&
+      !isValidPersistedIdentifier(value.proposalId))
+  ) {
+    return null;
+  }
+  let persistedWorkspaceRoot: string;
+  let path: string;
   try {
-    descriptor = openSync(path, "r");
+    persistedWorkspaceRoot = canonicalizePathSync(value.workspaceRoot);
+    const persistedRootSpelling = normalizePathIdentity(
+      resolve(value.workspaceRoot),
+    );
+    const persistedPathSpelling = normalizePathIdentity(resolve(value.path));
+    const relativePath = relative(persistedRootSpelling, persistedPathSpelling);
+    if (
+      relativePath === ".." ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      return null;
+    }
+    // Ledger paths are historical identities. Resolve only the persisted root
+    // alias against today's filesystem, then preserve its lexical suffix so a
+    // descendant symlink changing or disappearing cannot poison old records.
+    path = normalizePathIdentity(resolve(workspaceRoot, relativePath));
   } catch {
     return null;
   }
+  if (persistedWorkspaceRoot !== workspaceRoot) return null;
+  if (!isAbsolute(path) || !isSameOrDescendantPath(workspaceRoot, path)) {
+    return null;
+  }
+  return {
+    version: 1,
+    entryId: value.entryId,
+    timestamp: value.timestamp,
+    workspaceRoot,
+    path,
+    source: value.source,
+    ...(topologyEntry
+      ? { kind: "topology" as const }
+      : value.kind === "path"
+        ? { kind: "path" as const }
+        : {}),
+    status: value.status,
+    ...(value.beforeSha256 !== undefined
+      ? { beforeSha256: value.beforeSha256 as string }
+      : {}),
+    ...(value.afterSha256 !== undefined
+      ? { afterSha256: value.afterSha256 }
+      : {}),
+    ...(value.sessionId !== undefined ? { sessionId: value.sessionId } : {}),
+    ...(value.toolCallId !== undefined ? { toolCallId: value.toolCallId } : {}),
+    ...(value.proposalId !== undefined ? { proposalId: value.proposalId } : {}),
+    ...(topologyEntry
+      ? { topologyTokenId: value.topologyTokenId as string }
+      : {}),
+    ...(topologyEntry
+      ? { includeDescendants: value.includeDescendants as boolean }
+      : {}),
+  };
+}
+
+type WorkspaceEditorDiskAuthorityState =
+  | {
+      readonly diskState: "content";
+      readonly diskContentSha256: string;
+      readonly diskContentBytes: number;
+    }
+  | { readonly diskState: "missing" }
+  | { readonly diskState: "unavailable" };
+
+function boundedDiskAuthorityStateSync(
+  path: string,
+  maxContentBytes = MAX_BUFFER_BYTES,
+): WorkspaceEditorDiskAuthorityState {
+  let descriptor: number;
+  try {
+    // A quarantined path is external state and may have been replaced while
+    // the daemon was stopped. O_NONBLOCK lets fstat classify FIFOs/devices as
+    // unavailable without ever blocking the daemon event loop on open().
+    descriptor = openSync(
+      path,
+      fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK ?? 0),
+    );
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+      ? { diskState: "missing" }
+      : { diskState: "unavailable" };
+  }
   try {
     const before = fstatSync(descriptor);
-    if (!before.isFile() || before.size > MAX_BUFFER_BYTES) return null;
+    if (
+      !before.isFile() ||
+      before.size > MAX_BUFFER_BYTES ||
+      before.size > maxContentBytes
+    ) {
+      return { diskState: "unavailable" };
+    }
     const content = Buffer.allocUnsafe(before.size);
     let offset = 0;
     while (offset < content.byteLength) {
@@ -4280,15 +6311,50 @@ function boundedDiskSha256Sync(path: string): string | null {
       offset += bytesRead;
     }
     const after = fstatSync(descriptor);
-    if (offset !== before.size || after.size !== before.size) return null;
-    return createHash("sha256")
-      .update(content.subarray(0, offset))
-      .digest("hex");
+    if (
+      offset !== before.size ||
+      after.size !== before.size ||
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.mtimeMs !== before.mtimeMs ||
+      after.ctimeMs !== before.ctimeMs
+    ) {
+      return { diskState: "unavailable" };
+    }
+    return {
+      diskState: "content",
+      diskContentSha256: createHash("sha256")
+        .update(content.subarray(0, offset))
+        .digest("hex"),
+      diskContentBytes: offset,
+    };
   } catch {
-    return null;
+    return { diskState: "unavailable" };
   } finally {
     closeSync(descriptor);
   }
+}
+
+function boundedDiskSha256Sync(path: string): string | null {
+  const state = boundedDiskAuthorityStateSync(path);
+  return state.diskState === "content" ? state.diskContentSha256 : null;
+}
+
+function workspaceEditorStaleAuthorityEntry(
+  state: EditorBufferState,
+  maxDiskBytes = MAX_BUFFER_BYTES,
+): WorkspaceEditorStaleAuthorityEntry {
+  return {
+    path: state.path,
+    editorContentSha256: state.contentSha256,
+    editorContentBytes: state.contentBytes,
+    changedtick: state.changedtick,
+    editorInstanceId: state.editorInstanceId,
+    epoch: state.epoch,
+    editorState:
+      state.quarantinedFrom === "disk_authoritative" ? "clean" : "dirty",
+    ...boundedDiskAuthorityStateSync(state.path, maxDiskBytes),
+  };
 }
 
 function canonicalizePathSync(path: string): string {
@@ -4505,6 +6571,54 @@ function isSha256Digest(value: unknown): value is string {
   return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
 }
 
+function isWorkspaceEditorStaleAuthorityEntry(
+  value: unknown,
+): value is WorkspaceEditorStaleAuthorityEntry {
+  if (!isRecord(value)) return false;
+  if (
+    typeof value.path !== "string" ||
+    !isSha256Digest(value.editorContentSha256) ||
+    !isNonNegativeSafeInteger(value.editorContentBytes) ||
+    !isNonNegativeSafeInteger(value.changedtick) ||
+    !isValidPersistedIdentifier(value.editorInstanceId) ||
+    !isPositiveSafeInteger(value.epoch) ||
+    (value.editorState !== "dirty" && value.editorState !== "clean") ||
+    (value.diskState !== "content" &&
+      value.diskState !== "missing" &&
+      value.diskState !== "unavailable")
+  ) {
+    return false;
+  }
+  if (value.diskState === "content") {
+    return (
+      isSha256Digest(value.diskContentSha256) &&
+      isNonNegativeSafeInteger(value.diskContentBytes)
+    );
+  }
+  return (
+    value.diskContentSha256 === undefined &&
+    value.diskContentBytes === undefined
+  );
+}
+
+function workspaceEditorStaleAuthorityEntriesEqual(
+  left: WorkspaceEditorStaleAuthorityEntry,
+  right: WorkspaceEditorStaleAuthorityEntry,
+): boolean {
+  return (
+    left.path === right.path &&
+    left.editorContentSha256 === right.editorContentSha256 &&
+    left.editorContentBytes === right.editorContentBytes &&
+    left.changedtick === right.changedtick &&
+    left.editorInstanceId === right.editorInstanceId &&
+    left.epoch === right.epoch &&
+    left.editorState === right.editorState &&
+    left.diskState === right.diskState &&
+    left.diskContentSha256 === right.diskContentSha256 &&
+    left.diskContentBytes === right.diskContentBytes
+  );
+}
+
 function isNonNegativeSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
@@ -4526,11 +6640,12 @@ function isWorkspaceChangeStatus(
 }
 
 function isEditorReloadChange(
-  change: Pick<WorkspaceChangeEvent, "status" | "proposalId">,
+  change: Pick<WorkspaceChangeEvent, "kind" | "status" | "proposalId">,
 ): boolean {
   return (
-    change.proposalId === undefined &&
-    (change.status === "applied" || change.status === "unknown_outcome")
+    change.kind === "topology" ||
+    (change.proposalId === undefined &&
+      (change.status === "applied" || change.status === "unknown_outcome"))
   );
 }
 
@@ -4723,8 +6838,7 @@ export function captureWorkspaceAuthoritativeDirtySnapshots(
       return {
         coordinator,
         scope,
-        snapshots:
-          coordinator.authoritativeDirtySnapshotsUnderIdentity(scope),
+        snapshots: coordinator.authoritativeDirtySnapshotsUnderIdentity(scope),
       };
     });
   const snapshots = captures

--- a/runtime/tests/app-server-protocol/portal.contract.test.ts
+++ b/runtime/tests/app-server-protocol/portal.contract.test.ts
@@ -129,8 +129,8 @@ describe("AgenC portal protocol contract", () => {
       id: "initialize",
       method: "initialize",
       params: {
-        protocolVersion: "1.0.0",
-        protocol: { version: "1.0.0" },
+        protocolVersion: "1.1.0",
+        protocol: { version: "1.1.0" },
         clientName: "agenc-portal",
         capabilities: AGENC_PORTAL_CLIENT_CAPABILITY_FLAGS,
       },

--- a/runtime/tests/app-server/agent-cli.contract.test.ts
+++ b/runtime/tests/app-server/agent-cli.contract.test.ts
@@ -1110,7 +1110,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1182,7 +1182,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1255,7 +1255,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1316,7 +1316,7 @@ autostart = false
           id: message.id,
           result: {
             type: "initialized",
-            protocolVersion: "1.0.0",
+            protocolVersion: "1.1.0",
             capabilities: {},
           },
         });
@@ -1394,7 +1394,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1485,7 +1485,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           })}\n`,
@@ -1527,7 +1527,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1570,7 +1570,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1633,7 +1633,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1688,7 +1688,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1749,7 +1749,7 @@ autostart = false
               id: message.id,
               result: {
                 type: "initialized",
-                protocolVersion: "1.0.0",
+                protocolVersion: "1.1.0",
                 capabilities: {},
               },
             });
@@ -1817,7 +1817,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1876,7 +1876,7 @@ autostart = false
             id: message.id,
             result: {
               type: "initialized",
-              protocolVersion: "1.0.0",
+              protocolVersion: "1.1.0",
               capabilities: {},
             },
           });
@@ -1934,7 +1934,7 @@ autostart = false
               id: message.id,
               result: {
                 type: "initialized",
-                protocolVersion: "1.0.0",
+                protocolVersion: "1.1.0",
                 capabilities: {},
               },
             });

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -12,9 +12,7 @@ import {
   type StateSqliteDriver,
 } from "../state/sqlite-driver.js";
 import { StateRunDurabilityRepository } from "../state/run-durability.js";
-import {
-  listUnresolvedUnknownOutcomeEffects,
-} from "../state/unknown-outcome-gate.js";
+import { listUnresolvedUnknownOutcomeEffects } from "../state/unknown-outcome-gate.js";
 import { recordInFlightToolCallUnknownOutcome } from "../state/tool-output-rotation.js";
 import {
   AgenCDaemonAgentLifecycleError,
@@ -23,6 +21,7 @@ import {
 import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
 import {
+  AGENC_DAEMON_PROTOCOL_VERSION,
   AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
   JSON_RPC_VERSION,
 } from "./protocol/index.js";
@@ -3420,15 +3419,11 @@ describe("AgenC background agent lifecycle", () => {
         ],
         remaining: 2,
       });
-      expect(
-        effects.getEffect("run_v1", "run_v1:step"),
-      ).toMatchObject({
+      expect(effects.getEffect("run_v1", "run_v1:step")).toMatchObject({
         effectFormatVersion: 1,
         reviewStatus: "pending",
       });
-      expect(
-        effects.getEffect("run_v2", "run_v2:step"),
-      ).toMatchObject({
+      expect(effects.getEffect("run_v2", "run_v2:step")).toMatchObject({
         effectFormatVersion: 2,
         reviewStatus: "pending",
       });
@@ -3456,9 +3451,9 @@ describe("AgenC background agent lifecycle", () => {
         resolved: [],
         remaining: 2,
       });
-      expect(
-        effects.getEffect("run_v2", "run_v2:step"),
-      ).toMatchObject({ reviewStatus: "pending" });
+      expect(effects.getEffect("run_v2", "run_v2:step")).toMatchObject({
+        reviewStatus: "pending",
+      });
     } finally {
       driver?.close();
       restoreEnv();
@@ -3586,7 +3581,7 @@ describe("AgenC background agent lifecycle", () => {
         id: "future-protocol",
         method: "initialize",
         params: {
-          protocol: { version: "1.1.0" },
+          protocol: { version: "1.2.0" },
           clientName: "contract-test",
         },
       }),
@@ -3598,8 +3593,8 @@ describe("AgenC background agent lifecycle", () => {
         message: "Unsupported protocol version",
         data: {
           code: "PROTOCOL_VERSION_UNSUPPORTED",
-          clientVersion: "1.1.0",
-          serverVersion: "1.0.0",
+          clientVersion: "1.2.0",
+          serverVersion: "1.1.0",
         },
       },
     });
@@ -3661,15 +3656,16 @@ describe("AgenC background agent lifecycle", () => {
       id: 1,
       result: {
         type: "initialized",
-        protocolVersion: "1.0.0",
-        protocol: { version: "1.0.0" },
+        protocolVersion: "1.1.0",
+        protocol: { version: "1.1.0" },
         capabilities: {},
       },
     });
+    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.1.0");
     expect(connection.initializeState).toMatchObject({
-      protocol: { version: "1.0.0" },
+      protocol: { version: "1.1.0" },
       clientProtocol: { version: "1.0.0" },
-      serverProtocol: { version: "1.0.0" },
+      serverProtocol: { version: "1.1.0" },
       clientCapabilities: { experimentalApi: true },
     });
     expect(
@@ -4173,7 +4169,7 @@ describe("AgenC background agent lifecycle", () => {
       id: "initialize",
       result: {
         type: "initialized",
-        protocolVersion: "1.0.0",
+        protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
       },
     });
     expect(connection.initializeState?.clientCapabilities).toEqual(

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -2058,8 +2058,8 @@ backend = "local"
         id: "missing-cookie-init",
         method: "initialize",
         params: {
-          protocolVersion: "1.0.0",
-          protocol: { version: "1.0.0" },
+          protocolVersion: "1.1.0",
+          protocol: { version: "1.1.0" },
           clientName: "agenc-portal",
           capabilities: { "portal.dashboard.read": true },
         },
@@ -2083,8 +2083,8 @@ backend = "local"
         id: "initialize",
         method: "initialize",
         params: {
-          protocolVersion: "1.0.0",
-          protocol: { version: "1.0.0" },
+          protocolVersion: "1.1.0",
+          protocol: { version: "1.1.0" },
           clientName: "agenc-portal",
           authCookie,
           capabilities: { "portal.dashboard.read": true },
@@ -2095,8 +2095,8 @@ backend = "local"
       id: "initialize",
       result: {
         type: "initialized",
-        protocolVersion: "1.0.0",
-        protocol: { version: "1.0.0" },
+        protocolVersion: "1.1.0",
+        protocol: { version: "1.1.0" },
       },
     });
 

--- a/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
@@ -8,6 +8,7 @@ import {
   TEST_ONLY_ALLOW_UNADMITTED_COMMAND_EXEC_START,
 } from "./daemon-dispatcher.js";
 import {
+  AGENC_DAEMON_PROTOCOL_VERSION,
   AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
   AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY,
   JSON_RPC_VERSION,
@@ -39,11 +40,7 @@ function sequence(values: readonly string[]): () => string {
   };
 }
 
-function request(
-  id: string,
-  method: string,
-  params?: JsonObject,
-): JsonObject {
+function request(id: string, method: string, params?: JsonObject): JsonObject {
   return {
     jsonrpc: JSON_RPC_VERSION,
     id,
@@ -60,7 +57,10 @@ async function initialize(connection: {
       request("init", "initialize", { protocol: { version: "1.0.0" } }),
     ),
   ).resolves.toMatchObject({
-    result: { type: "initialized", protocolVersion: "1.0.0" },
+    result: {
+      type: "initialized",
+      protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+    },
   });
 }
 
@@ -99,7 +99,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
       agentId: "agent_ledger",
       cwd: await workspaces.create(),
     });
-    const clientMultiplexer = new AgenCDaemonClientMultiplexer({ sessionManager });
+    const clientMultiplexer = new AgenCDaemonClientMultiplexer({
+      sessionManager,
+    });
     const notifications: JsonObject[] = [];
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: new AgenCDaemonAgentManager(),
@@ -157,7 +159,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
       agentId: "agent_mobile_status",
       cwd: await workspaces.create(),
     });
-    const clientMultiplexer = new AgenCDaemonClientMultiplexer({ sessionManager });
+    const clientMultiplexer = new AgenCDaemonClientMultiplexer({
+      sessionManager,
+    });
     const notifications: JsonObject[] = [];
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: new AgenCDaemonAgentManager(),
@@ -290,18 +294,20 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
       resolveStarted = resolve;
     });
     const fuzzyFileSearch = {
-      search: vi.fn(async (_params: unknown, options?: { signal?: AbortSignal }) => {
-        resolveStarted();
-        await new Promise<void>((resolve, reject) => {
-          releaseSearch = resolve;
-          options?.signal?.addEventListener(
-            "abort",
-            () => reject(options.signal?.reason ?? new Error("cancelled")),
-            { once: true },
-          );
-        });
-        return { files: [] };
-      }),
+      search: vi.fn(
+        async (_params: unknown, options?: { signal?: AbortSignal }) => {
+          resolveStarted();
+          await new Promise<void>((resolve, reject) => {
+            releaseSearch = resolve;
+            options?.signal?.addEventListener(
+              "abort",
+              () => reject(options.signal?.reason ?? new Error("cancelled")),
+              { once: true },
+            );
+          });
+          return { files: [] };
+        },
+      ),
     };
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({
       agentManager: new AgenCDaemonAgentManager(),
@@ -470,8 +476,7 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     const connections = new Map<string, AgenCDaemonJsonRpcConnection>();
     const closedConnectionKeys: string[] = [];
     let destroyEvictedClientConnection:
-      | ((clientId: string) => void)
-      | undefined;
+      ((clientId: string) => void) | undefined;
 
     const multiplexer = new AgenCDaemonClientMultiplexer({
       sessionManager,
@@ -517,7 +522,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     // clientId is a distinct multiplexer client with its OWN send closure, so
     // their pending-backlog accounting is independent (the slow one stalls, the
     // healthy one drains).
-    const connection = dispatcher.createConnection({ sendNotification: () => {} });
+    const connection = dispatcher.createConnection({
+      sendNotification: () => {},
+    });
     connections.set("conn_1", connection);
     await sessionManager.createSession({
       agentId: "agent_1",
@@ -643,7 +650,10 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
         }),
       ),
     ).resolves.toMatchObject({
-      result: { type: "initialized", protocolVersion: "1.0.0" },
+      result: {
+        type: "initialized",
+        protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+      },
     });
 
     await expect(
@@ -712,9 +722,7 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     const cwd = await workspaces.create();
 
     await expect(
-      connection.dispatch(
-        request("create-default", "session.create", { cwd }),
-      ),
+      connection.dispatch(request("create-default", "session.create", { cwd })),
     ).resolves.toEqual({
       jsonrpc: JSON_RPC_VERSION,
       id: "create-default",
@@ -747,7 +755,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
       clientMultiplexer,
       sessionManager: sessions,
     });
-    const connection = dispatcher.createConnection({ sendNotification: () => {} });
+    const connection = dispatcher.createConnection({
+      sendNotification: () => {},
+    });
     await initialize(connection);
     const cwd = await workspaces.create();
 
@@ -778,9 +788,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
     ).resolves.toMatchObject({
       result: { attachmentId: "attachment_1", clientId: "client_1" },
     });
-    await expect(clientMultiplexer.attachedClientIds("session_1")).resolves.toEqual(
-      ["client_1"],
-    );
+    await expect(
+      clientMultiplexer.attachedClientIds("session_1"),
+    ).resolves.toEqual(["client_1"]);
 
     await expect(
       connection.dispatch(
@@ -799,9 +809,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
         remainingAttachmentIds: [],
       },
     });
-    await expect(clientMultiplexer.attachedClientIds("session_1")).resolves.toEqual(
-      [],
-    );
+    await expect(
+      clientMultiplexer.attachedClientIds("session_1"),
+    ).resolves.toEqual([]);
 
     await connection.dispatch(
       request("attach-two", "session.attach", {
@@ -827,13 +837,15 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
         reason: "done",
       },
     });
-    await expect(clientMultiplexer.attachedClientIds("session_1")).resolves.toEqual(
-      [],
-    );
+    await expect(
+      clientMultiplexer.attachedClientIds("session_1"),
+    ).resolves.toEqual([]);
     await expect(sessions.getSession("session_1")).resolves.not.toHaveProperty(
       "activeAttachmentIds",
     );
-    await expect(clientMultiplexer.removeClient("client_2")).resolves.toEqual([]);
+    await expect(clientMultiplexer.removeClient("client_2")).resolves.toEqual(
+      [],
+    );
     await expect(
       connection.dispatch(
         request("terminate-again", "session.terminate", {
@@ -970,10 +982,12 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
         remainingAttachmentIds: ["attachment_2"],
       },
     });
-    await expect(clientMultiplexer.attachedClientIds("session_1")).resolves.toEqual(
-      ["client_2"],
+    await expect(
+      clientMultiplexer.attachedClientIds("session_1"),
+    ).resolves.toEqual(["client_2"]);
+    await expect(clientMultiplexer.removeClient("client_1")).resolves.toEqual(
+      [],
     );
-    await expect(clientMultiplexer.removeClient("client_1")).resolves.toEqual([]);
     await clientMultiplexer.broadcastSessionEvent("session_1", {
       type: "session.delta",
       sessionId: "session_1",
@@ -1225,7 +1239,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
       clientMultiplexer,
       sessionManager: sessions,
     });
-    const connection = dispatcher.createConnection({ sendNotification: () => {} });
+    const connection = dispatcher.createConnection({
+      sendNotification: () => {},
+    });
     await initialize(connection);
 
     await connection.dispatch(
@@ -1261,9 +1277,9 @@ describe("AgenC daemon session lifecycle dispatcher", () => {
         remainingAttachmentIds: [],
       },
     });
-    await expect(clientMultiplexer.attachedClientIds("session_1")).resolves.toEqual(
-      ["client_1"],
-    );
+    await expect(
+      clientMultiplexer.attachedClientIds("session_1"),
+    ).resolves.toEqual(["client_1"]);
   });
 
   it("validates newly routed session lifecycle params", async () => {

--- a/runtime/tests/app-server/daemon-dispatcher.editor-coherence.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.editor-coherence.contract.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -42,6 +49,32 @@ function request(id: string, method: string, params: JsonObject): JsonObject {
 }
 
 describe("daemon editor coherence protocol", () => {
+  it("advertises recovered topology resolution only to protocol 1.1 clients", async () => {
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+    });
+    for (const [version, expected] of [
+      ["1.0.0", false],
+      ["1.1.0", true],
+    ] as const) {
+      const initialized = await dispatcher.createConnection().dispatch(
+        request(`initialize-${version}`, "initialize", {
+          protocol: { version },
+        }),
+      );
+      expect(
+        (
+          (initialized.result as JsonObject).capabilities as Record<
+            string,
+            Record<string, boolean>
+          >
+        )[AGENC_DAEMON_METHOD_CAPABILITIES_KEY]?.[
+          "workspace.editor.topology.recovered.resolve"
+        ],
+      ).toBe(expected);
+    }
+  });
+
   it("does not acknowledge a dirty sync whose quarantine cannot be persisted", async () => {
     const workspaceRoot = await tempDirectory("agenc-editor-rpc-workspace-");
     const agencHome = await tempDirectory("agenc-editor-rpc-home-");
@@ -96,6 +129,304 @@ describe("daemon editor coherence protocol", () => {
     });
   });
 
+  it("refreshes stale disk evidence without asking a new Editor to prove orphaned bytes", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-editor-refresh-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-editor-refresh-home-");
+    process.env.AGENC_HOME = agencHome;
+    const path = join(workspaceRoot, "refresh.ts");
+    const initialDiskContent = "initial disk revision\n";
+    const refreshedDiskContent = "refreshed disk revision\n";
+    const orphanedContent = "orphaned Editor revision\n";
+    await writeFile(path, initialDiskContent, "utf8");
+
+    const firstDispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+    });
+    const firstConnection = firstDispatcher.createConnection();
+    await firstConnection.dispatch(
+      request("initialize-first", "initialize", {
+        protocol: { version: "1.1.0" },
+      }),
+    );
+    const firstAcquired = await firstConnection.dispatch(
+      request("acquire-first", "workspace.editor.acquire", {
+        workspaceRoot,
+        editorInstanceId: "editor-before-refresh",
+      }),
+    );
+    const firstLease = firstAcquired.result as {
+      readonly leaseToken: string;
+      readonly epoch: number;
+    };
+    await expect(
+      firstConnection.dispatch(
+        request("sync-first", "workspace.editor.sync", {
+          workspaceRoot,
+          editorInstanceId: "editor-before-refresh",
+          leaseToken: firstLease.leaseToken,
+          epoch: firstLease.epoch,
+          sequence: 0,
+          buffers: [
+            {
+              path,
+              bufferHandle: 1,
+              changedtick: 9,
+              contentSha256: sha256(orphanedContent),
+              contentBytes: Buffer.byteLength(orphanedContent),
+              dirty: true,
+              content: orphanedContent,
+            },
+          ],
+        }),
+      ),
+    ).resolves.toMatchObject({ result: { accepted: true } });
+    await workspaceMutationCoordinators
+      .getOrCreate(workspaceRoot)
+      .flushQuarantinePersistence();
+    await firstConnection.close();
+    workspaceMutationCoordinators.clearForTests();
+
+    const restartedDispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+    });
+    const connection = restartedDispatcher.createConnection();
+    await connection.dispatch(
+      request("initialize-restarted", "initialize", {
+        protocol: { version: "1.1.0" },
+      }),
+    );
+    const acquired = await connection.dispatch(
+      request("acquire-restarted", "workspace.editor.acquire", {
+        workspaceRoot,
+        editorInstanceId: "editor-reviewing-refresh",
+      }),
+    );
+    const lease = acquired.result as {
+      readonly leaseToken: string;
+      readonly epoch: number;
+    };
+    expect(acquired).toMatchObject({
+      result: {
+        sequence: -1,
+        staleAuthority: [
+          {
+            path,
+            editorContentSha256: sha256(orphanedContent),
+            diskContentSha256: sha256(initialDiskContent),
+          },
+        ],
+      },
+    });
+
+    await writeFile(path, refreshedDiskContent, "utf8");
+    const leaseParams = {
+      workspaceRoot,
+      editorInstanceId: "editor-reviewing-refresh",
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    await expect(
+      connection.dispatch(
+        request(
+          "refresh",
+          "workspace.editor.staleAuthority.refresh",
+          leaseParams,
+        ),
+      ),
+    ).resolves.toMatchObject({
+      result: {
+        refreshed: true,
+        staleAuthority: [
+          {
+            path,
+            editorContentSha256: sha256(orphanedContent),
+            editorInstanceId: "editor-before-refresh",
+            diskState: "content",
+            diskContentSha256: sha256(refreshedDiskContent),
+            diskContentBytes: Buffer.byteLength(refreshedDiskContent),
+          },
+        ],
+      },
+    });
+    await expect(
+      connection.dispatch(
+        request(
+          "refresh-cannot-resolve",
+          "workspace.editor.staleAuthority.refresh",
+          {
+            ...leaseParams,
+            abandonStaleAuthority: [],
+          },
+        ),
+      ),
+    ).resolves.toMatchObject({
+      error: {
+        code: -32602,
+        message: expect.stringContaining("abandonStaleAuthority"),
+      },
+    });
+
+    const coordinator =
+      workspaceMutationCoordinators.getOrCreate(workspaceRoot);
+    expect(coordinator.authorityForPath(path)).toBe("stale_dirty");
+    expect(coordinator.stalePaths()).toEqual([path]);
+
+    await expect(
+      connection.dispatch(
+        request("ordinary-sync", "workspace.editor.sync", {
+          ...leaseParams,
+          sequence: 0,
+          buffers: [
+            {
+              path,
+              bufferHandle: 2,
+              changedtick: 1,
+              contentSha256: sha256(refreshedDiskContent),
+              contentBytes: Buffer.byteLength(refreshedDiskContent),
+              dirty: false,
+            },
+          ],
+        }),
+      ),
+    ).resolves.toMatchObject({
+      error: {
+        code: -32602,
+        message: expect.stringContaining("belongs to a different editor"),
+      },
+    });
+    await expect(
+      connection.dispatch(
+        request(
+          "heartbeat-after-refresh",
+          "workspace.editor.heartbeat",
+          leaseParams,
+        ),
+      ),
+    ).resolves.toMatchObject({
+      result: {
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+        sequence: -1,
+      },
+    });
+    expect(coordinator.authorityForPath(path)).toBe("stale_dirty");
+  });
+
+  it("retries a pending audit projection on same-daemon acquire exactly once", async () => {
+    const workspaceRoot = await tempDirectory("agenc-editor-audit-workspace-");
+    const agencHome = await tempDirectory("agenc-editor-audit-home-");
+    process.env.AGENC_HOME = agencHome;
+    const path = join(workspaceRoot, "pending-audit.ts");
+    const before = "orphaned editor state\n";
+    const after = "reviewed disk state\n";
+    await writeFile(path, after, "utf8");
+    const auditEntry = {
+      version: 1,
+      entryId: sha256("same-daemon-pending-audit"),
+      timestamp: "2026-08-17T18:00:00.000Z",
+      workspaceRoot,
+      path,
+      source: "editor",
+      status: "discarded",
+      beforeSha256: sha256(before),
+      afterSha256: sha256(after),
+    };
+    const stateDirectory = join(
+      agencHome,
+      "workspace-mutations",
+      sha256(workspaceRoot).slice(0, 32),
+    );
+    const quarantinePath = join(stateDirectory, "quarantine-v1.json");
+    const ledgerPath = join(stateDirectory, "ledger-v1.jsonl");
+    await mkdir(stateDirectory, { recursive: true });
+    await writeFile(
+      quarantinePath,
+      `${JSON.stringify({
+        version: 2,
+        workspaceRoot,
+        entries: [],
+        proposalCommitments: [],
+        proposalReceipts: [],
+        mutationIntents: [],
+        topologyIntents: [],
+        changeSequence: 0,
+        changes: [],
+        auditOutbox: [auditEntry],
+      })}\n`,
+      "utf8",
+    );
+    await mkdir(ledgerPath);
+
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: new AgenCDaemonAgentManager(),
+    });
+    const connection = dispatcher.createConnection();
+    await connection.dispatch(
+      request("initialize", "initialize", {
+        protocol: { version: "1.0.0" },
+      }),
+    );
+    const acquireParams = {
+      workspaceRoot,
+      editorInstanceId: "editor-same-daemon-audit-retry",
+    };
+
+    await expect(
+      connection.dispatch(
+        request(
+          "acquire-failed-audit",
+          "workspace.editor.acquire",
+          acquireParams,
+        ),
+      ),
+    ).resolves.toMatchObject({
+      error: {
+        code: -32602,
+        message: expect.stringContaining(
+          "pending workspace audit could not be completed",
+        ),
+      },
+    });
+
+    await rm(ledgerPath, { recursive: true });
+    await expect(
+      connection.dispatch(
+        request(
+          "acquire-retry-audit",
+          "workspace.editor.acquire",
+          acquireParams,
+        ),
+      ),
+    ).resolves.toMatchObject({
+      result: {
+        editorInstanceId: acquireParams.editorInstanceId,
+        sequence: -1,
+      },
+    });
+    await expect(
+      connection.dispatch(
+        request(
+          "acquire-again-audit",
+          "workspace.editor.acquire",
+          acquireParams,
+        ),
+      ),
+    ).resolves.toMatchObject({ result: { sequence: -1 } });
+
+    const ledgerEntries = (await readFile(ledgerPath, "utf8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line) as unknown);
+    expect(ledgerEntries).toEqual([auditEntry]);
+    const cleanedQuarantine = JSON.parse(
+      await readFile(quarantinePath, "utf8"),
+    ) as { readonly version?: number; readonly auditOutbox?: unknown };
+    expect(cleanedQuarantine).toMatchObject({ version: 1 });
+    expect(cleanedQuarantine.auditOutbox).toBeUndefined();
+  });
+
   it("acquires, syncs, inspects, applies, and discards in-memory proposals", async () => {
     const workspaceRoot = await tempDirectory("agenc-editor-rpc-workspace-");
     const agencHome = await tempDirectory("agenc-editor-rpc-home-");
@@ -108,7 +439,7 @@ describe("daemon editor coherence protocol", () => {
     const connection = dispatcher.createConnection();
     const initialized = await connection.dispatch(
       request("initialize", "initialize", {
-        protocol: { version: "1.0.0" },
+        protocol: { version: "1.1.0" },
       }),
     );
     expect(
@@ -121,6 +452,7 @@ describe("daemon editor coherence protocol", () => {
     ).toMatchObject({
       "workspace.editor.acquire": true,
       "workspace.editor.sync": true,
+      "workspace.editor.staleAuthority.refresh": true,
       "workspace.editor.heartbeat": true,
       "workspace.editor.release": true,
       "workspace.editor.topology.reserve": true,

--- a/runtime/tests/app-server/daemon-dispatcher.editor-interaction.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.editor-interaction.contract.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
 import type { AgenCBackgroundAgentRunner } from "./background-agent-runner.js";
 import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
-import { JSON_RPC_VERSION, type JsonObject } from "./protocol/index.js";
+import {
+  AGENC_DAEMON_PROTOCOL_VERSION,
+  JSON_RPC_VERSION,
+  type JsonObject,
+} from "./protocol/index.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 
 function request(
@@ -78,7 +82,10 @@ async function createHarness(
       params: { protocol: { version: "1.0.0" } },
     }),
   ).resolves.toMatchObject({
-    result: { type: "initialized", protocolVersion: "1.0.0" },
+    result: {
+      type: "initialized",
+      protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+    },
   });
   if (options.skipCreate !== true) {
     await expect(

--- a/runtime/tests/app-server/in-process-transport.contract.test.ts
+++ b/runtime/tests/app-server/in-process-transport.contract.test.ts
@@ -13,6 +13,7 @@ import {
   TEST_ONLY_ALLOW_UNADMITTED_COMMAND_EXEC_START,
 } from "./daemon-dispatcher.js";
 import {
+  AGENC_DAEMON_PROTOCOL_VERSION,
   JSON_RPC_VERSION,
   type AgenCDaemonRequest,
   type JsonObject,
@@ -100,8 +101,8 @@ describe("AgenC in-process app-server transport", () => {
     await expect(transport.initialize()).resolves.toMatchObject({
       result: {
         type: "initialized",
-        protocolVersion: "1.0.0",
-        protocol: { version: "1.0.0" },
+        protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+        protocol: { version: AGENC_DAEMON_PROTOCOL_VERSION },
       },
     });
     expect(transport.initialized).toBe(true);
@@ -283,7 +284,7 @@ describe("AgenC in-process app-server transport", () => {
       id: 1,
       method: "initialize",
       params: {
-        protocolVersion: "1.0.0",
+        protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
         clientName: "sdk-shape-test",
       },
     } satisfies AgenCDaemonRequest;
@@ -293,7 +294,7 @@ describe("AgenC in-process app-server transport", () => {
       id: 1,
       result: {
         type: "initialized",
-        protocol: { version: "1.0.0" },
+        protocol: { version: AGENC_DAEMON_PROTOCOL_VERSION },
       },
     });
     await transport.close();
@@ -322,8 +323,8 @@ describe("AgenC in-process app-server transport", () => {
       }),
     ).resolves.toMatchObject({
       type: "initialized",
-      protocolVersion: "1.0.0",
-      protocol: { version: "1.0.0" },
+      protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+      protocol: { version: AGENC_DAEMON_PROTOCOL_VERSION },
     });
     await transport.close();
   });

--- a/runtime/tests/app-server/protocol.contract.test.ts
+++ b/runtime/tests/app-server/protocol.contract.test.ts
@@ -112,6 +112,7 @@ const expectedNotifications = [
 const expectedInternalMethods = [
   "workspace.editor.acquire",
   "workspace.editor.sync",
+  "workspace.editor.staleAuthority.refresh",
   "workspace.editor.heartbeat",
   "workspace.editor.release",
   "workspace.editor.topology.reserve",

--- a/runtime/tests/gaphunt3/app-server-agent-cli.test.ts
+++ b/runtime/tests/gaphunt3/app-server-agent-cli.test.ts
@@ -55,7 +55,7 @@ describe("gaphunt3 #2 reconnectable daemon TUI client re-attaches sessions", () 
         id: message.id,
         result: {
           type: "initialized",
-          protocolVersion: "1.0.0",
+          protocolVersion: "1.1.0",
           capabilities: {},
         },
       });
@@ -220,7 +220,7 @@ describe("gaphunt3 #2 reconnectable daemon TUI client re-attaches sessions", () 
         id: message.id,
         result: {
           type: "initialized",
-          protocolVersion: "1.0.0",
+          protocolVersion: "1.1.0",
           capabilities: {},
         },
       });

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -280,7 +280,7 @@ describe("agenc-sdk client over the in-process transport", () => {
     const initialized = await daemon.client.initialize();
     expect(initialized).toMatchObject({
       type: "initialized",
-      protocol: { version: "1.0.0" },
+      protocol: { version: "1.1.0" },
     });
 
     const session = await daemon.client.createSession({

--- a/runtime/tests/tools/system/file-read.test.ts
+++ b/runtime/tests/tools/system/file-read.test.ts
@@ -145,6 +145,33 @@ describe("FileRead tool", () => {
     expect(tool.name).toBe(FILE_READ_TOOL_NAME);
   });
 
+  test("reads a bounded text window through protected Editor authority", async () => {
+    const workspace = join(root, "workspace");
+    const file = join(workspace, "window.txt");
+    await mkdir(workspace);
+    await writeFile(file, "alpha\nbeta\ngamma\ndelta\n", "utf8");
+    workspaceMutationCoordinators.getOrCreate(workspace).acquire({
+      workspaceRoot: workspace,
+      editorInstanceId: "file-read-window-editor",
+    });
+    const tool = createFileReadTool({ allowedPaths: [workspace] });
+
+    const result = await tool.execute({
+      file_path: file,
+      offset: 2,
+      limit: 2,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toBe("2→beta\n3→gamma");
+    expect(result.metadata).toMatchObject({
+      startLine: 2,
+      endLine: 3,
+      numLines: 2,
+      isPartial: true,
+    });
+  });
+
   test("never reads outside text bytes after a final ancestor exchange", async () => {
     const workspace = join(root, "workspace");
     const displaced = join(root, "workspace-displaced");

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -2415,6 +2415,10 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         dirtyPaths: [path],
         stalePaths: [],
       })),
+      refreshWorkspaceEditorStaleAuthority: vi.fn(async () => ({
+        refreshed: true as const,
+        staleAuthority: [],
+      })),
       heartbeatWorkspaceEditor: vi.fn(async (params) => ({
         ...lease,
         editorInstanceId: params.editorInstanceId,
@@ -2712,6 +2716,10 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           stalePaths: [],
         };
       }),
+      refreshWorkspaceEditorStaleAuthority: vi.fn(async () => ({
+        refreshed: true as const,
+        staleAuthority: [],
+      })),
       heartbeatWorkspaceEditor: vi.fn(async (params) => ({
         ...lease,
         editorInstanceId: params.editorInstanceId,

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -278,6 +278,12 @@ function createClient(): AgenCDaemonTuiClient & {
           stalePaths: [],
         } as never;
       }
+      if (method === "workspace.editor.staleAuthority.refresh") {
+        return {
+          refreshed: true,
+          staleAuthority: [],
+        } as never;
+      }
       if (method === "workspace.editor.release") {
         return {
           released: true,
@@ -1311,6 +1317,12 @@ describe("AgenC TUI daemon session adapter", () => {
       stalePaths: [],
     });
     await expect(
+      session.refreshWorkspaceEditorStaleAuthority?.(lease),
+    ).resolves.toEqual({
+      refreshed: true,
+      staleAuthority: [],
+    });
+    await expect(
       session.heartbeatWorkspaceEditor?.(lease),
     ).resolves.toMatchObject({
       ...lease,
@@ -1504,6 +1516,10 @@ describe("AgenC TUI daemon session adapter", () => {
             },
           ],
         },
+      },
+      {
+        method: "workspace.editor.staleAuthority.refresh",
+        params: lease,
       },
       {
         method: "workspace.editor.heartbeat",

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -538,6 +538,59 @@ describe("embedded Neovim lifecycle", () => {
     await session.cleanup();
   });
 
+  it("uses exact path-bound noautocmd RPCs for stale-authority recovery", async () => {
+    const child = fakeChild({
+      exitCode: 0,
+      pid: syntheticNeovimPid(793),
+    });
+    const rpc = {
+      request: vi.fn(async () => true),
+      close: vi.fn(),
+    };
+    const session = new EmbeddedNeovimSession(
+      { child, pid: syntheticNeovimPid(793), kill: vi.fn() } as any,
+      rpc as any,
+      { resize: vi.fn(), dispose: vi.fn() } as any,
+      5,
+      25,
+    );
+    const reviewedPath = "/workspace/reviewed.ts";
+
+    await expect(
+      session.reloadBufferForStaleAuthority(7, reviewedPath),
+    ).resolves.toBe(true);
+    await expect(
+      session.unloadBufferForStaleAuthority(7, reviewedPath),
+    ).resolves.toBe(true);
+
+    expect(rpc.request).toHaveBeenNthCalledWith(
+      1,
+      "nvim_exec_lua",
+      [
+        expect.stringMatching(
+          /actual_path ~= expected_path[\s\S]*silent keepalt noautocmd edit!/u,
+        ),
+        [7, reviewedPath],
+      ],
+      { timeoutMs: 25, signal: expect.any(AbortSignal) },
+    );
+    expect(rpc.request).toHaveBeenNthCalledWith(
+      2,
+      "nvim_exec_lua",
+      [
+        expect.stringMatching(
+          /actual_path ~= expected_path[\s\S]*silent noautocmd bdelete!/u,
+        ),
+        [7, reviewedPath],
+      ],
+      { timeoutMs: 25, signal: expect.any(AbortSignal) },
+    );
+    expect(rpc.request).toHaveBeenCalledTimes(2);
+    await expect(
+      session.reloadBufferForStaleAuthority(7, ""),
+    ).rejects.toThrow("requires a named file buffer");
+  });
+
   it("reloads a clean loaded path through a guarded Neovim buffer call", async () => {
     const child = fakeChild({
       exitCode: 0,

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
@@ -484,6 +484,10 @@ describe("real embedded Neovim lifecycle", () => {
           stalePaths: [],
         };
       },
+      refreshWorkspaceEditorStaleAuthority: async () => ({
+        refreshed: true as const,
+        staleAuthority: [],
+      }),
       heartbeatWorkspaceEditor: async () => lease(),
       releaseWorkspaceEditor: async () => ({
         released: true as const,

--- a/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
@@ -30,6 +30,7 @@ import type {
   BufferWorkspaceWriteDecision,
   BufferWorkspaceWriteRequest,
 } from "../../../src/tui/workbench/buffer/providers/types.js";
+import { BufferWorkspaceCaptureUnstableError } from "../../../src/tui/workbench/buffer/providers/types.js";
 import {
   NeovimStartupCleanupError,
   type EmbeddedNeovimSession,
@@ -445,6 +446,27 @@ describe("embedded Neovim BUFFER provider", () => {
     expect(harness.session.inspectBuffers).toHaveBeenCalledTimes(4);
 
     await controller.cleanup();
+  });
+
+  it("classifies continuously changing workspace captures as retryable instability", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider({
+      ...harness.options,
+      workspaceRoot: TEST_WORKSPACE_ROOT,
+    });
+    await provider.open({ filePath: "target.txt" });
+    harness.setBufferTextReader(async () => {
+      harness.mutateBuffer();
+      return "latest text\n";
+    });
+    harness.session.inspectBuffers.mockClear();
+
+    await expect(provider.captureWorkspaceBuffers()).rejects.toBeInstanceOf(
+      BufferWorkspaceCaptureUnstableError,
+    );
+    expect(harness.session.inspectBuffers).toHaveBeenCalledTimes(6);
+
+    await provider.cleanup();
   });
 
   it("authorizes only exact full-buffer workspace write destinations", async () => {
@@ -1103,6 +1125,59 @@ describe("embedded Neovim BUFFER provider", () => {
       filePath: "next.txt",
       dirty: false,
     });
+  });
+
+  it("binds restricted stale-authority actions to the reviewed loaded path", async () => {
+    const harness = createHarness();
+    const provider = new NeovimBufferProvider(harness.options);
+    const reviewedPath = workspacePath("target.txt");
+    const unrelatedPath = workspacePath("unrelated.txt");
+    await provider.open({ filePath: "target.txt" });
+    await provider.open({ filePath: "unrelated.txt" });
+    expect(provider.getSnapshot()).toMatchObject({
+      absolutePath: unrelatedPath,
+      activeBufferHandle: 2,
+    });
+
+    harness.session.input.mockClear();
+    await expect(
+      provider.performStaleAuthorityEditorAction({
+        type: "reload",
+        path: reviewedPath,
+      }),
+    ).resolves.toBe(true);
+    expect(harness.session.reloadBufferForStaleAuthority).toHaveBeenCalledWith(
+      1,
+      reviewedPath,
+    );
+    expect(provider.getSnapshot().absolutePath).toBe(unrelatedPath);
+    expect(harness.session.input).not.toHaveBeenCalled();
+
+    await expect(
+      provider.performStaleAuthorityEditorAction({
+        type: "unload",
+        path: reviewedPath,
+      }),
+    ).resolves.toBe(true);
+    expect(harness.session.unloadBufferForStaleAuthority).toHaveBeenCalledWith(
+      1,
+      reviewedPath,
+    );
+    expect(provider.getSnapshot().absolutePath).toBe(unrelatedPath);
+    expect(harness.session.input).not.toHaveBeenCalled();
+
+    await expect(
+      provider.performStaleAuthorityEditorAction({
+        type: "unload",
+        path: workspacePath("missing.txt"),
+      }),
+    ).resolves.toBe(false);
+    expect(harness.session.unloadBufferForStaleAuthority).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(provider.getSnapshot().error).toContain(
+      "reviewed stale-authority path is not loaded",
+    );
   });
 
   it.each(["changedtick", "new-dirty-buffer"] as const)(
@@ -2682,6 +2757,30 @@ function createHarness(
         if (deletions.some((deletion) => deletion.path === currentPath)) {
           currentPath = buffers.keys().next().value ?? "";
         }
+      },
+    ),
+    reloadBufferForStaleAuthority: vi.fn(
+      async (handle: number, expectedPath: string) => {
+        const target = buffers.get(expectedPath);
+        if (!target || target.handle !== handle) {
+          throw new Error(`cannot reload stale buffer ${handle}`);
+        }
+        target.dirty = false;
+        target.changedtick += 1;
+        return true;
+      },
+    ),
+    unloadBufferForStaleAuthority: vi.fn(
+      async (handle: number, expectedPath: string) => {
+        const target = buffers.get(expectedPath);
+        if (!target || target.handle !== handle) {
+          throw new Error(`cannot unload stale buffer ${handle}`);
+        }
+        buffers.delete(expectedPath);
+        if (currentPath === expectedPath) {
+          currentPath = buffers.keys().next().value ?? "";
+        }
+        return true;
       },
     ),
     saveAll: vi.fn(async (force: boolean) => {

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -1119,6 +1119,10 @@ describe("WorkbenchBufferStore", () => {
       ["wqall!", { type: "saveQuit", force: true, all: true }],
       ["xa!", { type: "saveQuit", force: true, all: true }],
       ["xall!", { type: "saveQuit", force: true, all: true }],
+      ["e!", { type: "reload", force: true }],
+      ["edit!", { type: "reload", force: true }],
+      ["bd!", { type: "closeBuffer", discard: true }],
+      ["bdelete!", { type: "closeBuffer", discard: true }],
     ] as const) {
       sendCommand(raw);
       expect(commands.pop()).toEqual(expected);

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import stripAnsi from "strip-ansi";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { WorkspaceEditorStaleAuthorityEntry } from "../../../src/app-server/protocol/index.js";
 import {
   registerPendingLSPDiagnostic,
   resetAllLSPDiagnosticState,
@@ -422,13 +423,23 @@ describe("BufferSurface", () => {
       { type: "saveQuit", force: false, all: false },
       { store, dispatch, hasInFlightAgent: false },
     );
+    executeBufferVimCommand(
+      { type: "reload", force: true },
+      { store, dispatch, hasInFlightAgent: false },
+    );
+    executeBufferVimCommand(
+      { type: "closeBuffer", discard: true },
+      { store, dispatch, hasInFlightAgent: false },
+    );
     await flush();
 
     expect(store.save).toHaveBeenCalledWith({
       hasInFlightAgent: true,
       force: true,
     });
-    expect(store.close).not.toHaveBeenCalled();
+    expect(store.revert).toHaveBeenCalledTimes(1);
+    expect(store.close).toHaveBeenCalledWith({ discard: true });
+    expect(dispatch).toHaveBeenCalledTimes(2);
     expect(dispatch).toHaveBeenCalledWith({ type: "closeSurface" });
 
     const blockedStore = createActionStore({
@@ -516,7 +527,6 @@ describe("BufferSurface", () => {
       stdin: stdin as any as NodeJS.ReadStream,
       stdout: stdout as any as NodeJS.WriteStream,
     });
-
     try {
       root.render(
         <AppStateProvider
@@ -553,7 +563,6 @@ describe("BufferSurface", () => {
       stdin: stdin as any as NodeJS.ReadStream,
       stdout: stdout as any as NodeJS.WriteStream,
     });
-
     try {
       await runWithCwdOverride(dir, async () => {
         root.render(
@@ -2169,6 +2178,693 @@ describe("BufferSurface", () => {
       ).toBe(true);
       expect(provider.handleInput).not.toHaveBeenCalled();
     } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("focuses the explorer with Alt+H before the first Editor provider opens", async () => {
+    const changes: ReturnType<typeof getDefaultAppState>[] = [];
+    const controller = getWorkbenchBufferProviderController();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+
+    try {
+      expect(controller.getSnapshot()).toMatchObject({
+        filePath: null,
+        providerStatus: "idle",
+      });
+
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: null,
+                focusedPane: "surface",
+              },
+            }}
+            onChangeAppState={({ newState }) => {
+              changes.push(newState);
+            }}
+          >
+            <KeybindingSetup>
+              <WorkbenchLayout
+                transcript={<Text>transcript</Text>}
+                composer={<Text>composer</Text>}
+              />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      stdin.write("\x1bh");
+      await sleep();
+
+      expect(
+        changes.some((state) => state.workbench.focusedPane === "explorer"),
+      ).toBe(true);
+      expect(controller.getSnapshot()).toMatchObject({
+        filePath: null,
+        providerStatus: "idle",
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("requires a second confirmation before abandoning stale Editor authority", async () => {
+    const entry: WorkspaceEditorStaleAuthorityEntry = {
+      path: "/workspace/file.ts",
+      editorContentSha256: "a".repeat(64),
+      editorContentBytes: 23,
+      changedtick: 9,
+      editorInstanceId: "orphaned-editor",
+      epoch: 4,
+      editorState: "dirty",
+      diskState: "content",
+      diskContentSha256: "b".repeat(64),
+      diskContentBytes: 19,
+    };
+    const laterEntry: WorkspaceEditorStaleAuthorityEntry = {
+      ...entry,
+      path: "/workspace/later.ts",
+      editorContentSha256: "c".repeat(64),
+      diskContentSha256: "d".repeat(64),
+    };
+    const onRefresh = vi.fn(async () => {});
+    const onUseDisk = vi.fn(async () => {});
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "buffer",
+              activeFilePath: null,
+              focusedPane: "surface",
+            },
+          }}
+        >
+          <KeybindingSetup>
+            <BufferSurface
+              focused={true}
+              mutationBlockedReason="Editor safety is paused."
+              staleAuthorityRecovery={{
+                entries: [entry, laterEntry],
+                onRefresh,
+                onUseDisk,
+              }}
+            />
+          </KeybindingSetup>
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      const instance = instances.get(
+        stdout as any as NodeJS.WriteStream,
+      ) as any;
+      if (!instance?.rootNode) throw new Error("Ink instance not found");
+      expect(nodeText(instance.rootNode)).toContain(
+        "Orphaned Editor revisions need a decision",
+      );
+      expect(nodeText(instance.rootNode)).toContain("/workspace/file.ts");
+      expect(nodeText(instance.rootNode)).not.toContain("/workspace/later.ts");
+      expect(nodeText(instance.rootNode)).toContain(
+        "1 more affected path remains for a later review",
+      );
+      expect(nodeText(instance.rootNode)).toContain(
+        "Editor 23 B (dirty), disk 19 B",
+      );
+
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).not.toHaveBeenCalled();
+      expect(nodeText(instance.rootNode)).toContain(
+        "Press D again to permanently abandon orphaned edits and use disk",
+      );
+
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).toHaveBeenCalledTimes(1);
+      expect(onUseDisk).toHaveBeenCalledWith([entry]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("disables stale-authority abandonment when disk evidence is unavailable", async () => {
+    const entry: WorkspaceEditorStaleAuthorityEntry = {
+      path: "/workspace/unreadable.ts",
+      editorContentSha256: "c".repeat(64),
+      editorContentBytes: 31,
+      changedtick: 12,
+      editorInstanceId: "orphaned-editor",
+      epoch: 4,
+      editorState: "dirty",
+      diskState: "unavailable",
+    };
+    const onRefresh = vi.fn(async () => {});
+    const onUseDisk = vi.fn(async () => {});
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "buffer",
+              activeFilePath: null,
+              focusedPane: "surface",
+            },
+          }}
+        >
+          <KeybindingSetup>
+            <BufferSurface
+              focused={true}
+              mutationBlockedReason="Editor safety is paused."
+              staleAuthorityRecovery={{
+                entries: [entry],
+                onRefresh,
+                onUseDisk,
+              }}
+            />
+          </KeybindingSetup>
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(output()).toContain("/workspace/unreadable.ts");
+      expect(output()).toContain("RRefreshDiskState");
+      expect(output()).toContain(
+        "Atleastonediskpathisunreadable,notaregularfile,ortoolarge",
+      );
+
+      stdin.write("d");
+      await sleep();
+      stdin.write("d");
+      await sleep();
+
+      expect(onUseDisk).not.toHaveBeenCalled();
+      expect(output()).not.toContain("DConfirmUseDisk");
+
+      stdin.write("r");
+      await sleep();
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("binds Use Disk arming to exact evidence before passive effects run", async () => {
+    const originalEntry: WorkspaceEditorStaleAuthorityEntry = {
+      path: "/workspace/review.ts",
+      editorContentSha256: "e".repeat(64),
+      editorContentBytes: 41,
+      changedtick: 15,
+      editorInstanceId: "orphaned-editor-a",
+      epoch: 4,
+      editorState: "dirty",
+      diskState: "content",
+      diskContentSha256: "f".repeat(64),
+      diskContentBytes: 37,
+    };
+    const onRefresh = vi.fn(async () => {});
+    const onUseDisk = vi.fn(async () => {});
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+    const renderEvidence = (
+      entry: WorkspaceEditorStaleAuthorityEntry,
+    ): void => {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "buffer",
+              activeFilePath: null,
+              focusedPane: "surface",
+            },
+          }}
+        >
+          <KeybindingSetup>
+            <BufferSurface
+              focused={true}
+              mutationBlockedReason="Editor safety is paused."
+              staleAuthorityRecovery={{
+                entries: [entry],
+                onRefresh,
+                onUseDisk,
+              }}
+            />
+          </KeybindingSetup>
+        </AppStateProvider>,
+      );
+    };
+
+    try {
+      renderEvidence(originalEntry);
+      await sleep();
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).not.toHaveBeenCalled();
+
+      const cleanEntry: WorkspaceEditorStaleAuthorityEntry = {
+        ...originalEntry,
+        editorState: "clean",
+      };
+      renderEvidence(cleanEntry);
+      // Input can arrive after the new layout capture commits but before
+      // passive effects. The old arm must not authorize the new evidence.
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).not.toHaveBeenCalled();
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).toHaveBeenLastCalledWith([cleanEntry]);
+
+      const replacementIdentity: WorkspaceEditorStaleAuthorityEntry = {
+        ...cleanEntry,
+        editorInstanceId: "orphaned-editor-b",
+        epoch: 5,
+      };
+      renderEvidence(replacementIdentity);
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).toHaveBeenCalledTimes(1);
+      stdin.write("d");
+      await sleep();
+      expect(onUseDisk).toHaveBeenCalledTimes(2);
+      expect(onUseDisk).toHaveBeenLastCalledWith([replacementIdentity]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("keeps native Recovery Editor input restricted to path-bound reload and unload", async () => {
+    const targetPath = join(dir, "target.ts");
+    await writeFile(targetPath, "const value = 1;\n", "utf8");
+    const identity = {
+      kind: "neovim" as const,
+      label: "embedded Neovim test",
+      fallbackReason: null,
+      capabilities: NEOVIM_BUFFER_CAPABILITIES,
+    };
+    const provider = {
+      identity,
+      subscribe: vi.fn(() => () => {}),
+      getSnapshot: vi.fn(() => ({
+        ...emptyProviderSnapshot(identity),
+        status: "ready" as const,
+        providerStatus: "ready" as const,
+        filePath: "target.ts",
+        absolutePath: targetPath,
+        terminal: {
+          ...createNeovimRenderSnapshot(4, 24),
+          lines: ["recovery buffer", "", "", ""],
+          mode: "normal" as const,
+          commandLine: null,
+          cursor: { grid: 1, row: 0, column: 0 },
+        },
+        vimMode: "NORMAL" as const,
+        position: { line: 1, column: 0, offset: 0 },
+        buffers: [
+          {
+            handle: 1,
+            changedtick: 7,
+            endOfLine: true,
+            name: targetPath,
+            filePath: "target.ts",
+            absolutePath: targetPath,
+            listed: true,
+            loaded: true,
+            modified: true,
+            current: true,
+            bufferType: "",
+            modifiable: true,
+            readOnly: false,
+            saveable: true,
+          },
+          {
+            handle: 2,
+            changedtick: 1,
+            endOfLine: true,
+            name: join(dir, "other.ts"),
+            filePath: "other.ts",
+            absolutePath: join(dir, "other.ts"),
+            listed: true,
+            loaded: true,
+            modified: false,
+            current: false,
+            bufferType: "",
+            modifiable: true,
+            readOnly: false,
+            saveable: true,
+          },
+        ],
+        activeBufferHandle: 1,
+      })),
+      getVisibleLines: vi.fn(() => []),
+      open: vi.fn(async () => {}),
+      save: vi.fn(async () => true),
+      selectBuffer: vi.fn(async () => true),
+      revert: vi.fn(async () => {}),
+      performStaleAuthorityEditorAction: vi.fn(async () => true),
+      close: vi.fn(async () => true),
+      openExternalEditor: vi.fn(async () => false),
+      undo: vi.fn(() => false),
+      redo: vi.fn(() => false),
+      move: vi.fn(() => false),
+      requestHover: vi.fn(async () => null),
+      goToDefinition: vi.fn(async () => false),
+      handleInput: vi.fn(() => true),
+      click: vi.fn(() => true),
+      resize: vi.fn(),
+      focus: vi.fn(),
+      cleanup: vi.fn(async () => {}),
+    };
+    getWorkbenchBufferProviderController().setSelectionFactoryForTesting(
+      async () => ({
+        kind: "neovim",
+        provider,
+        discovery: {
+          usable: true,
+          executable: "nvim",
+          version: { major: 0, minor: 12, patch: 0, raw: "NVIM v0.12.0" },
+          args: ["--embed", "--clean"],
+          useUserInit: false,
+        },
+      }),
+    );
+    const entry: WorkspaceEditorStaleAuthorityEntry = {
+      path: targetPath,
+      editorContentSha256: "1".repeat(64),
+      editorContentBytes: 17,
+      changedtick: 7,
+      editorInstanceId: "orphaned-loaded-editor",
+      epoch: 3,
+      editorState: "clean",
+      diskState: "content",
+      diskContentSha256: "2".repeat(64),
+      diskContentBytes: 17,
+    };
+    const onRefresh = vi.fn(async () => {});
+    const onUseDisk = vi.fn(async () => {});
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 1,
+                focusedPane: "surface",
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface
+                focused={true}
+                mutationBlockedReason="Editor safety is paused."
+                staleAuthorityRecovery={{
+                  entries: [entry],
+                  onRefresh,
+                  onUseDisk,
+                }}
+              />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const instance = instances.get(
+        stdout as any as NodeJS.WriteStream,
+      ) as any;
+      if (!instance?.rootNode) throw new Error("Ink instance not found");
+      expect(nodeText(instance.rootNode)).toContain("E Open Recovery Editor");
+
+      const sendNativeCommand = async (command: string): Promise<void> => {
+        stdin.write(":");
+        await sleep();
+        stdin.write(command);
+        await sleep();
+        stdin.write("\r");
+        await sleep();
+      };
+      provider.handleInput.mockClear();
+      stdin.write("e");
+      await sleep();
+      expect(nodeText(instance.rootNode)).toContain("RECOVERY EDITOR");
+      expect(output()).toContain("recoverybuffer");
+      expect(provider.handleInput).not.toHaveBeenCalled();
+      expect(onUseDisk).not.toHaveBeenCalled();
+
+      stdin.write("i");
+      await sleep();
+      stdin.write(
+        "\x1b[200~:lua vim.fn.writefile({'paste'}, '/tmp/bypass')\x1b[201~",
+      );
+      await sleep();
+      await sendNativeCommand("!touch /tmp/agenc-recovery-bypass");
+      await sendNativeCommand("terminal");
+      await sendNativeCommand("lua vim.fn.writefile({'x'}, '/tmp/bypass')");
+      expect(provider.handleInput).not.toHaveBeenCalled();
+      expect(provider.performStaleAuthorityEditorAction).not.toHaveBeenCalled();
+      expect(nodeText(instance.rootNode)).toContain(
+        "Restricted Recovery Editor allows only :edit! and :bd!.",
+      );
+
+      const otherTab = findClickableBoxes(instance.rootNode).find(
+        (box) => nodeText(box) === "other.ts",
+      );
+      const contentBox = findClickableBoxes(instance.rootNode).find(
+        (box) => nodeText(box) === "",
+      );
+      if (!otherTab?._eventHandlers?.onClick || !contentBox?._eventHandlers?.onClick) {
+        throw new Error(
+          `Expected native Recovery Editor tab and content click handlers: ${JSON.stringify(
+            findClickableBoxes(instance.rootNode).map((box) => nodeText(box)),
+          )}`,
+        );
+      }
+      otherTab._eventHandlers.onClick({
+        stopImmediatePropagation: vi.fn(),
+      });
+      contentBox._eventHandlers.onClick({
+        stopImmediatePropagation: vi.fn(),
+        localRow: 1,
+        localCol: 1,
+      });
+      await sleep();
+      expect(provider.selectBuffer).not.toHaveBeenCalled();
+      expect(provider.click).not.toHaveBeenCalled();
+
+      await sendNativeCommand("edit!");
+      expect(provider.performStaleAuthorityEditorAction).toHaveBeenCalledWith({
+        type: "reload",
+        path: targetPath,
+      });
+      expect(provider.handleInput).not.toHaveBeenCalled();
+
+      await sendNativeCommand("bd!");
+      expect(provider.performStaleAuthorityEditorAction).toHaveBeenLastCalledWith(
+        { type: "unload", path: targetPath },
+      );
+      expect(nodeText(instance.rootNode)).toContain(
+        "Orphaned Editor revisions need a decision",
+      );
+
+      stdin.write("e");
+      await sleep();
+      stdin.write("\x07");
+      await sleep();
+      expect(nodeText(instance.rootNode)).toContain(
+        "Orphaned Editor revisions need a decision",
+      );
+      expect(nodeText(instance.rootNode)).toContain("E Open Recovery Editor");
+      expect(provider.handleInput).not.toHaveBeenCalled();
+      expect(onUseDisk).not.toHaveBeenCalled();
+      expect(onRefresh).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("lets inline Recovery Editor force-reload or unload while keeping writes blocked", async () => {
+    const targetPath = join(dir, "inline-recovery.ts");
+    const originalDisk = "const value = 1;\n";
+    const replacementDisk = "const value = 2;\n";
+    await writeFile(targetPath, originalDisk, "utf8");
+    const entry: WorkspaceEditorStaleAuthorityEntry = {
+      path: targetPath,
+      editorContentSha256: "3".repeat(64),
+      editorContentBytes: Buffer.byteLength(originalDisk),
+      changedtick: 8,
+      editorInstanceId: "orphaned-inline-editor",
+      epoch: 4,
+      editorState: "dirty",
+      diskState: "content",
+      diskContentSha256: "4".repeat(64),
+      diskContentBytes: Buffer.byteLength(originalDisk),
+    };
+    const onRefresh = vi.fn(async () => {});
+    const onUseDisk = vi.fn(async () => {});
+    const controller = getWorkbenchBufferProviderController();
+    const recoveryAction = vi.spyOn(
+      controller,
+      "performStaleAuthorityEditorAction",
+    );
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as any as NodeJS.ReadStream,
+      stdout: stdout as any as NodeJS.WriteStream,
+    });
+    const sendCommand = async (command: string): Promise<void> => {
+      stdin.write(":");
+      await sleep();
+      stdin.write(command);
+      await sleep();
+      stdin.write("\r");
+      await sleep();
+    };
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "inline-recovery.ts",
+                activeFileLine: 1,
+                focusedPane: "surface",
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface
+                focused={true}
+                mutationBlockedReason="Editor safety is paused."
+                staleAuthorityRecovery={{
+                  entries: [entry],
+                  onRefresh,
+                  onUseDisk,
+                }}
+              />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const store = getWorkbenchBufferStore();
+      expect(store.getText()).toBe(originalDisk);
+      stdin.write("e");
+      await sleep();
+
+      stdin.write("i");
+      await sleep();
+      stdin.write("draft ");
+      await sleep();
+      stdin.write("\x1b");
+      await sleep();
+      expect(store.getSnapshot().dirty).toBe(true);
+
+      await sendCommand("w!");
+      expect(await readFile(targetPath, "utf8")).toBe(originalDisk);
+      expect(store.getSnapshot().dirty).toBe(true);
+
+      await writeFile(targetPath, replacementDisk, "utf8");
+      await sendCommand("e!");
+      expect(recoveryAction).toHaveBeenCalledWith({
+        type: "reload",
+        path: targetPath,
+      });
+      expect(store.getText()).toBe(replacementDisk);
+      expect(store.getSnapshot().dirty).toBe(false);
+
+      stdin.write("i");
+      await sleep();
+      stdin.write("discarded ");
+      await sleep();
+      stdin.write("\x1b");
+      await sleep();
+      expect(store.getSnapshot().dirty).toBe(true);
+
+      await sendCommand("bd!");
+      expect(recoveryAction).toHaveBeenLastCalledWith({
+        type: "unload",
+        path: targetPath,
+      });
+      expect(controller.getSnapshot()).toMatchObject({
+        status: "idle",
+        filePath: null,
+        dirty: false,
+      });
+      const instance = instances.get(
+        stdout as any as NodeJS.WriteStream,
+      ) as any;
+      if (!instance?.rootNode) throw new Error("Ink instance not found");
+      expect(nodeText(instance.rootNode)).toContain(
+        "Orphaned Editor revisions need a decision",
+      );
+      expect(await readFile(targetPath, "utf8")).toBe(replacementDisk);
+      expect(onUseDisk).not.toHaveBeenCalled();
+      expect(onRefresh).not.toHaveBeenCalled();
+    } finally {
+      recoveryAction.mockRestore();
       root.unmount();
       stdin.end();
       stdout.end();

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -8,6 +8,11 @@ import {
   type KeybindingContextName,
 } from "../../../src/tui/keybindings/types.js";
 import { descriptorForSurface } from "../../../src/tui/workbench/surfaces/ActiveWorkSurface.js";
+import { bufferKeybindingContext } from "../../../src/tui/workbench/buffer/keybindingContext.js";
+import {
+  INLINE_BUFFER_CAPABILITIES,
+  NEOVIM_BUFFER_CAPABILITIES,
+} from "../../../src/tui/workbench/buffer/providers/types.js";
 
 const WORKBENCH_CONTEXTS = [
   "WorkspaceTabs",
@@ -97,6 +102,47 @@ const WORKBENCH_ACTIONS = [
 ] as const satisfies readonly KeybindingAction[];
 
 describe("workbench keybinding contract", () => {
+  it("uses host navigation only until a provider owns the first file", () => {
+    expect(
+      bufferKeybindingContext({
+        filePath: null,
+        providerStatus: "idle",
+        provider: {
+          kind: "inline",
+          label: "unopened BUFFER placeholder",
+          fallbackReason: null,
+          capabilities: INLINE_BUFFER_CAPABILITIES,
+        },
+      }),
+    ).toBe("BufferHost");
+
+    expect(
+      bufferKeybindingContext({
+        filePath: "src/app.ts",
+        providerStatus: "ready",
+        provider: {
+          kind: "inline",
+          label: "basic inline BUFFER fallback",
+          fallbackReason: null,
+          capabilities: INLINE_BUFFER_CAPABILITIES,
+        },
+      }),
+    ).toBe("Buffer");
+
+    expect(
+      bufferKeybindingContext({
+        filePath: "src/app.ts",
+        providerStatus: "ready",
+        provider: {
+          kind: "neovim",
+          label: "embedded Neovim",
+          fallbackReason: null,
+          capabilities: NEOVIM_BUFFER_CAPABILITIES,
+        },
+      }),
+    ).toBe("BufferHost");
+  });
+
   it("registers every workbench context and action with the global keybinding schema", () => {
     for (const context of WORKBENCH_CONTEXTS) {
       expect(KEYBINDING_CONTEXT_NAMES).toContain(context);

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -704,10 +704,10 @@ describe("workbench render contract", () => {
       .find((line) => line.includes("BUFFER:"));
     expect(hintLine).toBeDefined();
     expect(hintLine).toContain("ctrl+s save");
-    expect(hintLine).toContain("ctrl+x y redo");
+    expect(hintLine).toContain("ctrl+r redo");
     expect(hintLine).toContain("shift+tab composer");
-    expect(hintLine).toContain("ctrl+x z maximize");
-    expect(hintLine).toContain("ctrl+x q hide");
+    expect(hintLine).toContain("alt+z maximize");
+    expect(hintLine).toContain("alt+q hide");
     expect(hintLine).not.toContain("/ commands");
   });
 

--- a/runtime/tests/tui/workbench/workspace-editor-lease-sync.test.ts
+++ b/runtime/tests/tui/workbench/workspace-editor-lease-sync.test.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
 
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -9,6 +11,7 @@ import type {
   WorkspaceEditorProposalParams,
   WorkspaceEditorRecoveredTopologyMutation,
   WorkspaceEditorRecoveredTopologyResolveParams,
+  WorkspaceEditorStaleAuthorityEntry,
   WorkspaceEditorSyncParams,
   WorkspaceEditorTopologyCompleteParams,
   WorkspaceEditorTopologyFinalizeParams,
@@ -24,6 +27,7 @@ import {
   type WorkspaceEditorLeaseClient,
 } from "../../../src/tui/workbench/workspaceEditorLeaseSync.js";
 import {
+  BufferWorkspaceCaptureUnstableError,
   emptyProviderSnapshot,
   NEOVIM_BUFFER_CAPABILITIES,
   type BufferProviderSnapshot,
@@ -32,6 +36,7 @@ import {
   type BufferWorkspaceWriteDecision,
 } from "../../../src/tui/workbench/buffer/providers/types.js";
 import { TuiTeardownBarrier } from "../../../src/tui/teardownBarrier.js";
+import { WorkspaceMutationCoordinator } from "../../../src/workspace/mutation-coordinator.js";
 
 const WORKSPACE = "/workspace";
 const EDITOR_ID = "tui-editor-test";
@@ -61,6 +66,7 @@ describe("workspace editor lease synchronization", () => {
           .filter((buffer) => buffer.dirty)
           .map((buffer) => buffer.path),
         stalePaths: [],
+        staleAuthority: [],
       };
     });
     const authority = vi.fn();
@@ -117,6 +123,284 @@ describe("workspace editor lease synchronization", () => {
 
     expect(authority).toHaveBeenLastCalledWith({ status: "ready" });
     expect(client.syncWorkspaceEditor).toHaveBeenCalledTimes(syncCount);
+    await synchronizer.stop();
+  });
+
+  test("keeps typing live and the daemon lease fenced across transient capture instability", async () => {
+    vi.useFakeTimers();
+    const source = new FakeBufferSource();
+    const client = new FakeLeaseClient();
+    const authority = vi.fn();
+    const onError = vi.fn();
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      onAuthorityChange: authority,
+      onError,
+      syncDebounceMs: 0,
+      retryMs: 20,
+      heartbeatMs: 100,
+    });
+
+    synchronizer.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(authority).toHaveBeenLastCalledWith({ status: "ready" });
+
+    vi.spyOn(source, "captureWorkspaceBuffers").mockRejectedValueOnce(
+      new BufferWorkspaceCaptureUnstableError(),
+    );
+    source.update({
+      changedtick: 2,
+      content: "const value = 'still typing';\n",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(authority).toHaveBeenLastCalledWith({ status: "syncing" });
+    expect(client.acquireWorkspaceEditor).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(40);
+    expect(client.acquireWorkspaceEditor).toHaveBeenCalledTimes(1);
+    expect(client.syncs.at(-1)).toMatchObject({
+      sequence: 1,
+      buffers: [
+        expect.objectContaining({
+          changedtick: 2,
+          content: "const value = 'still typing';\n",
+        }),
+      ],
+    });
+    expect(authority).toHaveBeenLastCalledWith({ status: "ready" });
+
+    await synchronizer.stop();
+  });
+
+  test("keeps initial input live after acquisition while the first capture retries", async () => {
+    vi.useFakeTimers();
+    const source = new FakeBufferSource();
+    vi.spyOn(source, "captureWorkspaceBuffers").mockRejectedValueOnce(
+      new BufferWorkspaceCaptureUnstableError(),
+    );
+    const client = new FakeLeaseClient();
+    const authority = vi.fn();
+    const onError = vi.fn();
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      onAuthorityChange: authority,
+      onError,
+      syncDebounceMs: 0,
+      retryMs: 20,
+      heartbeatMs: 100,
+    });
+
+    synchronizer.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(authority).toHaveBeenLastCalledWith({ status: "syncing" });
+    expect(client.acquireWorkspaceEditor).toHaveBeenCalledTimes(1);
+    expect(client.syncWorkspaceEditor).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    const writeDecision = await source.requestWorkspaceWrite();
+    expect(writeDecision).toEqual({ allowed: true });
+    expect(client.acquireWorkspaceEditor).toHaveBeenCalledTimes(1);
+    expect(client.syncs).toEqual([
+      expect.objectContaining({
+        leaseToken: "lease-1",
+        epoch: 1,
+        buffers: [
+          expect.objectContaining({
+            changedtick: 1,
+            content: "const value = 1;\n",
+          }),
+        ],
+      }),
+    ]);
+
+    await synchronizer.stop();
+  });
+
+  test("keeps stale evidence blocked until the exact disk confirmation is acknowledged", async () => {
+    vi.useFakeTimers();
+    const diskContent = "const value = 1;\n";
+    const staleAuthority: WorkspaceEditorStaleAuthorityEntry = {
+      path: "/workspace/file.ts",
+      editorContentSha256: sha256("const orphaned = true;\n"),
+      editorContentBytes: Buffer.byteLength("const orphaned = true;\n"),
+      changedtick: 9,
+      editorInstanceId: "orphaned-editor",
+      epoch: 1,
+      editorState: "dirty",
+      diskState: "content",
+      diskContentSha256: sha256(diskContent),
+      diskContentBytes: Buffer.byteLength(diskContent),
+    };
+    const source = new FakeBufferSource();
+    source.loadClean(diskContent, 2);
+    const client = new FakeLeaseClient();
+    client.acquireWorkspaceEditor.mockResolvedValue({
+      ...client.lease,
+      staleAuthority: [staleAuthority],
+    });
+    client.refreshWorkspaceEditorStaleAuthority.mockResolvedValue({
+      refreshed: true,
+      staleAuthority: [staleAuthority],
+    });
+    let staleAuthorityOutstanding = true;
+    client.syncWorkspaceEditor.mockImplementation(async (params) => {
+      client.syncs.push(params);
+      client.leaseSequence = params.sequence;
+      if (params.abandonStaleAuthority !== undefined) {
+        staleAuthorityOutstanding = false;
+      }
+      return {
+        accepted: true,
+        sequence: params.sequence,
+        expiresAt: 10_000,
+        dirtyPaths: [],
+        stalePaths: staleAuthorityOutstanding ? [staleAuthority.path] : [],
+        staleAuthority: staleAuthorityOutstanding ? [staleAuthority] : [],
+      };
+    });
+    const authority = vi.fn();
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      onAuthorityChange: authority,
+      syncDebounceMs: 0,
+      heartbeatMs: 100,
+    });
+
+    synchronizer.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(authority).toHaveBeenLastCalledWith({
+      status: "blocked",
+      reason: expect.stringContaining(
+        "1 orphaned Editor revision still owns workspace authority",
+      ),
+      staleAuthority: [staleAuthority],
+    });
+    expect(client.syncs[0]).not.toHaveProperty("abandonStaleAuthority");
+
+    const syncCountBeforeRefresh = client.syncs.length;
+    await synchronizer.refreshStaleAuthority();
+
+    expect(client.refreshWorkspaceEditorStaleAuthority).toHaveBeenCalledWith({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      leaseToken: "lease-1",
+      epoch: 1,
+    });
+    expect(client.syncs).toHaveLength(syncCountBeforeRefresh);
+    expect(authority).toHaveBeenLastCalledWith({
+      status: "blocked",
+      reason: expect.stringContaining(
+        "1 orphaned Editor revision still owns workspace authority",
+      ),
+      staleAuthority: [staleAuthority],
+    });
+
+    await synchronizer.abandonStaleAuthority([staleAuthority]);
+
+    expect(client.syncs.at(-1)?.abandonStaleAuthority).toEqual([
+      staleAuthority,
+    ]);
+    expect(client.syncs.at(-1)?.buffers).toEqual([
+      expect.objectContaining({
+        path: staleAuthority.path,
+        changedtick: 2,
+        dirty: false,
+        contentSha256: staleAuthority.diskContentSha256,
+        contentBytes: staleAuthority.diskContentBytes,
+      }),
+    ]);
+    expect(client.syncs.at(-1)?.buffers[0]).not.toHaveProperty("content");
+    expect(authority).toHaveBeenLastCalledWith({ status: "ready" });
+    await synchronizer.stop();
+  });
+
+  test("refreshes through the read-only RPC after rejected reconciliation clears the local lease", async () => {
+    vi.useFakeTimers();
+    const diskContent = "const value = 1;\n";
+    const refreshedDiskContent = "const value = 2;\n";
+    const staleAuthority: WorkspaceEditorStaleAuthorityEntry = {
+      path: "/workspace/file.ts",
+      editorContentSha256: sha256("const orphaned = true;\n"),
+      editorContentBytes: Buffer.byteLength("const orphaned = true;\n"),
+      changedtick: 9,
+      editorInstanceId: "orphaned-editor",
+      epoch: 1,
+      editorState: "dirty",
+      diskState: "content",
+      diskContentSha256: sha256(diskContent),
+      diskContentBytes: Buffer.byteLength(diskContent),
+    };
+    const refreshedAuthority: WorkspaceEditorStaleAuthorityEntry = {
+      ...staleAuthority,
+      diskContentSha256: sha256(refreshedDiskContent),
+      diskContentBytes: Buffer.byteLength(refreshedDiskContent),
+    };
+    const source = new FakeBufferSource();
+    source.loadClean(diskContent, 2);
+    const client = new FakeLeaseClient();
+    client.acquireWorkspaceEditor.mockResolvedValue({
+      ...client.lease,
+      staleAuthority: [staleAuthority],
+    });
+    client.syncWorkspaceEditor.mockRejectedValueOnce(
+      new Error(
+        "Cannot reconcile quarantined editor buffer: it belongs to a different editor instance.",
+      ),
+    );
+    client.refreshWorkspaceEditorStaleAuthority.mockResolvedValue({
+      refreshed: true,
+      staleAuthority: [refreshedAuthority],
+    });
+    const authority = vi.fn();
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      onAuthorityChange: authority,
+      syncDebounceMs: 0,
+      retryMs: 1_500,
+      heartbeatMs: 100,
+    });
+
+    synchronizer.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(client.syncWorkspaceEditor).toHaveBeenCalledTimes(1);
+    expect(authority).toHaveBeenLastCalledWith({
+      status: "blocked",
+      reason: expect.stringContaining("different editor instance"),
+      staleAuthority: [staleAuthority],
+    });
+
+    await synchronizer.refreshStaleAuthority();
+
+    expect(client.acquireWorkspaceEditor).toHaveBeenCalledTimes(2);
+    expect(client.syncWorkspaceEditor).toHaveBeenCalledTimes(1);
+    expect(client.refreshWorkspaceEditorStaleAuthority).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(authority).toHaveBeenLastCalledWith({
+      status: "blocked",
+      reason: expect.stringContaining(
+        "1 orphaned Editor revision still owns workspace authority",
+      ),
+      staleAuthority: [refreshedAuthority],
+    });
+
     await synchronizer.stop();
   });
 
@@ -1983,6 +2267,288 @@ describe("workspace editor lease synchronization", () => {
     expect(authority).toHaveBeenLastCalledWith({ status: "ready" });
     await synchronizer.stop();
   });
+
+  test.each([
+    { dirty: false, expectedBuffers: 0, expectedUnloads: 1 },
+    { dirty: true, expectedBuffers: 1, expectedUnloads: 0 },
+  ])(
+    "closes matching clean buffers and preserves matching dirty buffers during recovered topology resolution ($dirty)",
+    async ({ dirty, expectedBuffers, expectedUnloads }) => {
+      vi.useFakeTimers();
+      const source = new FakeBufferSource();
+      if (!dirty) source.loadClean("const value = 1;\n", 1);
+      source.allowCleanUnload();
+      const client = new FakeLeaseClient();
+      client.recoveredTopologies = [
+        {
+          tokenId: "recovered-topology-buffer-policy",
+          workspaceRoot: WORKSPACE,
+          targets: [{ path: "/workspace/file.ts" }],
+          source: "editor",
+          createdAt: 123,
+        },
+      ];
+      const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+        workspaceRoot: WORKSPACE,
+        editorInstanceId: EDITOR_ID,
+        client,
+        buffers: source,
+        syncDebounceMs: 0,
+        heartbeatMs: 100,
+      });
+
+      synchronizer.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await synchronizer.resolveRecoveredTopologyMutation(
+        "recovered-topology-buffer-policy",
+      );
+
+      expect(source.cleanUnloadPaths).toHaveLength(expectedUnloads);
+      expect(
+        client.resolveRecoveredWorkspaceEditorTopology.mock.calls[0]?.[0]
+          .buffers,
+      ).toHaveLength(expectedBuffers);
+      if (dirty) {
+        expect(
+          client.resolveRecoveredWorkspaceEditorTopology.mock.calls[0]?.[0]
+            .buffers,
+        ).toContainEqual(
+          expect.objectContaining({ path: "/workspace/file.ts", dirty: true }),
+        );
+      }
+      await synchronizer.stop();
+    },
+  );
+
+  test("keeps recovered topology blocked when the provider cannot close a matching clean buffer", async () => {
+    vi.useFakeTimers();
+    const source = new FakeBufferSource();
+    source.loadClean("const value = 1;\n", 1);
+    const unload = source.synchronizePathDelete.bind(source);
+    Object.defineProperty(source, "synchronizePathDelete", {
+      configurable: true,
+      value: undefined,
+    });
+    const client = new FakeLeaseClient();
+    client.recoveredTopologies = [
+      {
+        tokenId: "recovered-topology-missing-cleanup",
+        workspaceRoot: WORKSPACE,
+        targets: [{ path: "/workspace/file.ts" }],
+        source: "editor",
+        createdAt: 123,
+      },
+    ];
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      syncDebounceMs: 0,
+      heartbeatMs: 100,
+    });
+
+    synchronizer.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(
+      synchronizer.resolveRecoveredTopologyMutation(
+        "recovered-topology-missing-cleanup",
+      ),
+    ).rejects.toThrow(/cannot safely close clean buffers/u);
+    expect(
+      client.resolveRecoveredWorkspaceEditorTopology,
+    ).not.toHaveBeenCalled();
+
+    Object.defineProperty(source, "synchronizePathDelete", {
+      configurable: true,
+      value: unload,
+    });
+    source.allowCleanUnload();
+    await synchronizer.resolveRecoveredTopologyMutation(
+      "recovered-topology-missing-cleanup",
+    );
+    await synchronizer.stop();
+  });
+
+  test("does not acknowledge a topology invalidation when a clean buffer races dirty during unload", async () => {
+    vi.useFakeTimers();
+    const source = new FakeBufferSource();
+    source.loadClean("const value = 1;\n", 1);
+    source.allowCleanUnload();
+    source.raceNextCleanUnloadDirty();
+    const client = new FakeLeaseClient();
+    const topologyChange: WorkspaceEditorChangeResult = {
+      kind: "topology",
+      topologyTokenId: "completed-topology-1",
+      path: "/workspace/file.ts",
+      includeDescendants: false,
+      sequence: 1,
+      timestamp: "2026-08-17T00:00:00.000Z",
+      workspaceRoot: WORKSPACE,
+      source: "editor",
+      status: "applied",
+    };
+    client.changes = [topologyChange];
+    client.listWorkspaceEditorChanges.mockImplementation(async (params) => ({
+      sequence: 1,
+      changes: params.afterSequence === 1 ? [] : [topologyChange],
+    }));
+    const onError = vi.fn();
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot: WORKSPACE,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      onError,
+      syncDebounceMs: 0,
+      heartbeatMs: 100,
+    });
+
+    synchronizer.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(/became dirty/u),
+        }),
+      );
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(
+      client.listWorkspaceEditorChanges.mock.calls.at(-1)?.[0].afterSequence,
+    ).toBe(0);
+
+    client.changes = [];
+    client.listWorkspaceEditorChanges.mockImplementation(async () => ({
+      sequence: 1,
+      changes: [],
+    }));
+    await vi.advanceTimersByTimeAsync(100);
+    await synchronizer.stop();
+  });
+
+  test("reacquires the authoritative sequence after one of two recovered topology commits loses its response", async () => {
+    const workspaceRoot = await mkdtemp(
+      "/tmp/agenc-topology-lost-response-workspace-",
+    );
+    const agencHome = await mkdtemp("/tmp/agenc-topology-lost-response-home-");
+    const firstDirectory = join(workspaceRoot, "renamed-a");
+    const secondDirectory = join(workspaceRoot, "renamed-b");
+    await mkdir(firstDirectory);
+    await mkdir(secondDirectory);
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstToken = await first.reserveTopologyMutation(
+      [{ path: firstDirectory, includeDescendants: true }],
+      "editor",
+    );
+    const secondToken = await first.reserveTopologyMutation(
+      [{ path: secondDirectory, includeDescendants: true }],
+      "editor",
+    );
+    await first.flushQuarantinePersistence();
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    let acquireCount = 0;
+    let loseResolveResponse = true;
+    const resolveSequences: number[] = [];
+    const syncSequences: number[] = [];
+    const client: WorkspaceEditorLeaseClient = {
+      acquireWorkspaceEditor: async (params) => {
+        acquireCount += 1;
+        return restarted.acquire(params);
+      },
+      syncWorkspaceEditor: async (params) => {
+        syncSequences.push(params.sequence);
+        return restarted.sync(params);
+      },
+      refreshWorkspaceEditorStaleAuthority: async (params) =>
+        restarted.refreshStaleAuthority(params),
+      heartbeatWorkspaceEditor: async (params) => restarted.heartbeat(params),
+      releaseWorkspaceEditor: async (params) => restarted.release(params),
+      listRecoveredWorkspaceEditorTopologies: async (params) => ({
+        mutations: restarted.listRecoveredEditorTopologyMutations(params),
+      }),
+      resolveRecoveredWorkspaceEditorTopology: async (params) => {
+        resolveSequences.push(params.sequence);
+        const result =
+          await restarted.resolveRecoveredEditorTopologyMutation(params);
+        if (loseResolveResponse) {
+          loseResolveResponse = false;
+          throw new Error("simulated lost recovered-topology response");
+        }
+        return result;
+      },
+    };
+    const source: WorkspaceEditorBufferSource = {
+      subscribe: () => () => {},
+      getSnapshot: () => ({
+        ...emptyProviderSnapshot({
+          kind: "neovim",
+          label: "embedded Neovim",
+          fallbackReason: null,
+          capabilities: NEOVIM_BUFFER_CAPABILITIES,
+        }),
+        providerStatus: "ready",
+        workspaceAuthorityRequired: true,
+      }),
+      captureWorkspaceBuffers: async () => [],
+      beginProjectPathMutation: () => true,
+      endProjectPathMutation: () => {},
+      synchronizePathDelete: async (path) => ({
+        ok: false as const,
+        path,
+        reason: "path is not loaded",
+      }),
+    };
+    const authority = vi.fn();
+    const synchronizer = new WorkspaceEditorLeaseSynchronizer({
+      workspaceRoot,
+      editorInstanceId: EDITOR_ID,
+      client,
+      buffers: source,
+      onAuthorityChange: authority,
+      syncDebounceMs: 0,
+      heartbeatMs: 10_000,
+    });
+
+    try {
+      synchronizer.start();
+      await vi.waitFor(() => {
+        expect(authority).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            status: "blocked",
+            recoveredTopologyMutations: [
+              expect.objectContaining({ tokenId: firstToken.tokenId }),
+              expect.objectContaining({ tokenId: secondToken.tokenId }),
+            ],
+          }),
+        );
+      });
+
+      await expect(
+        synchronizer.resolveRecoveredTopologyMutation(firstToken.tokenId),
+      ).resolves.toBeUndefined();
+      expect(acquireCount).toBeGreaterThanOrEqual(2);
+      expect(syncSequences).toEqual([]);
+      await expect(
+        synchronizer.resolveRecoveredTopologyMutation(secondToken.tokenId),
+      ).resolves.toBeUndefined();
+      expect(resolveSequences).toEqual([0, 1]);
+      expect(syncSequences).toContain(2);
+      await vi.waitFor(() => {
+        expect(authority).toHaveBeenLastCalledWith({ status: "ready" });
+      });
+      await synchronizer.stop();
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
 });
 
 class FakeBufferSource implements WorkspaceEditorBufferSource {
@@ -1995,6 +2561,12 @@ class FakeBufferSource implements WorkspaceEditorBufferSource {
   #workspaceWriteAuthorityHandler: BufferWorkspaceWriteAuthorityHandler | null =
     null;
   #column = 1;
+  #dirty = true;
+  #loaded = true;
+  #allowCleanUnload = false;
+  #raceNextUnloadDirty = false;
+  #projectPathMutationLocked = false;
+  readonly cleanUnloadPaths: string[] = [];
 
   subscribe(listener: () => void): () => void {
     this.#listeners.add(listener);
@@ -2013,47 +2585,110 @@ class FakeBufferSource implements WorkspaceEditorBufferSource {
       providerStatus: this.#status,
       workspaceAuthorityRequired: this.#workspaceAuthorityRequired,
       position: { line: 1, column: this.#column },
-      buffers: [
-        {
-          handle: 1,
-          changedtick: this.#changedtick,
-          endOfLine: this.#endOfLine,
-          name: "/workspace/file.ts",
-          filePath: "file.ts",
-          absolutePath: "/workspace/file.ts",
-          listed: true,
-          loaded: true,
-          modified: true,
-          current: true,
-          bufferType: "",
-          modifiable: true,
-          readOnly: false,
-          saveable: true,
-        },
-      ],
-      activeBufferHandle: 1,
-      dirtyBufferCount: 1,
-      dirty: true,
+      buffers: this.#loaded
+        ? [
+            {
+              handle: 1,
+              changedtick: this.#changedtick,
+              endOfLine: this.#endOfLine,
+              name: "/workspace/file.ts",
+              filePath: "file.ts",
+              absolutePath: "/workspace/file.ts",
+              listed: true,
+              loaded: true,
+              modified: this.#dirty,
+              current: true,
+              bufferType: "",
+              modifiable: true,
+              readOnly: false,
+              saveable: true,
+            },
+          ]
+        : [],
+      activeBufferHandle: this.#loaded ? 1 : null,
+      dirtyBufferCount: this.#loaded && this.#dirty ? 1 : 0,
+      dirty: this.#loaded && this.#dirty,
     };
   }
 
   captureWorkspaceBuffers(): Promise<readonly BufferWorkspaceBufferCapture[]> {
-    return Promise.resolve([
-      {
-        path: "/workspace/file.ts",
-        bufferHandle: 1,
-        changedtick: this.#changedtick,
-        endOfLine: this.#endOfLine,
-        dirty: true,
-        content: this.#content,
-      },
-    ]);
+    return Promise.resolve(
+      this.#loaded
+        ? [
+            {
+              path: "/workspace/file.ts",
+              bufferHandle: 1,
+              changedtick: this.#changedtick,
+              endOfLine: this.#endOfLine,
+              dirty: this.#dirty,
+              content: this.#content,
+            },
+          ]
+        : [],
+    );
   }
 
   setWorkspaceWriteAuthorityHandler(
     handler: BufferWorkspaceWriteAuthorityHandler | null,
   ): void {
     this.#workspaceWriteAuthorityHandler = handler;
+  }
+
+  beginProjectPathMutation(): boolean {
+    if (this.#projectPathMutationLocked) return false;
+    this.#projectPathMutationLocked = true;
+    return true;
+  }
+
+  endProjectPathMutation(): void {
+    this.#projectPathMutationLocked = false;
+  }
+
+  reloadCleanPath(path: string) {
+    if (path !== "/workspace/file.ts") {
+      return Promise.resolve({
+        ok: false as const,
+        path,
+        reason: "path is not loaded",
+      });
+    }
+    if (this.#dirty) {
+      return Promise.resolve({
+        ok: false as const,
+        path,
+        reason: "path is dirty",
+        dirty: true as const,
+      });
+    }
+    return Promise.resolve({ ok: true as const, path, reloaded: true });
+  }
+
+  synchronizePathDelete(path: string) {
+    if (this.#raceNextUnloadDirty) {
+      this.#raceNextUnloadDirty = false;
+      this.#dirty = true;
+      return Promise.resolve({
+        ok: false as const,
+        reason: `path raced dirty: ${path}`,
+      });
+    }
+    if (
+      this.#allowCleanUnload &&
+      this.#loaded &&
+      !this.#dirty &&
+      path === "/workspace/file.ts"
+    ) {
+      this.#loaded = false;
+      this.cleanUnloadPaths.push(path);
+      return Promise.resolve({
+        ok: true as const,
+        affectedBufferHandles: [1],
+      });
+    }
+    return Promise.resolve({
+      ok: false as const,
+      reason: `cannot unload ${path}`,
+    });
   }
 
   requestWorkspaceWrite(): Promise<BufferWorkspaceWriteDecision> {
@@ -2100,12 +2735,30 @@ class FakeBufferSource implements WorkspaceEditorBufferSource {
     this.#changedtick = next.changedtick ?? this.#changedtick;
     this.#content = next.content ?? this.#content;
     this.#endOfLine = next.endOfLine ?? this.#endOfLine;
+    this.#dirty = true;
     this.emit();
+  }
+
+  loadClean(content: string, changedtick: number): void {
+    this.#loaded = true;
+    this.#content = content;
+    this.#changedtick = changedtick;
+    this.#dirty = false;
+    this.emit();
+  }
+
+  allowCleanUnload(): void {
+    this.#allowCleanUnload = true;
+  }
+
+  raceNextCleanUnloadDirty(): void {
+    this.#raceNextUnloadDirty = true;
   }
 
   apply(content: string): number {
     this.#changedtick += 1;
     this.#content = content;
+    this.#dirty = true;
     this.emit();
     return this.#changedtick;
   }
@@ -2165,9 +2818,14 @@ class FakeLeaseClient implements WorkspaceEditorLeaseClient {
           .filter((buffer) => buffer.dirty)
           .map((buffer) => buffer.path),
         stalePaths: [],
+        staleAuthority: [],
       };
     },
   );
+  readonly refreshWorkspaceEditorStaleAuthority = vi.fn(async () => ({
+    refreshed: true as const,
+    staleAuthority: [],
+  }));
   readonly heartbeatWorkspaceEditor = vi.fn(async () => this.lease);
   readonly releaseWorkspaceEditor = vi.fn(async () => ({
     released: true as const,
@@ -2194,6 +2852,7 @@ class FakeLeaseClient implements WorkspaceEditorLeaseClient {
             .filter((buffer) => buffer.dirty)
             .map((buffer) => buffer.path),
           stalePaths: [],
+          staleAuthority: [],
         },
       };
     },
@@ -2212,6 +2871,7 @@ class FakeLeaseClient implements WorkspaceEditorLeaseClient {
             .filter((buffer) => buffer.dirty)
             .map((buffer) => buffer.path),
           stalePaths: [],
+          staleAuthority: [],
         },
       };
     },
@@ -2225,10 +2885,21 @@ class FakeLeaseClient implements WorkspaceEditorLeaseClient {
       this.recoveredTopologies = this.recoveredTopologies.filter(
         (mutation) => mutation.tokenId !== params.tokenId,
       );
+      this.leaseSequence = params.sequence;
       return {
         resolved: true as const,
         tokenId: params.tokenId,
         status: "unknown_outcome" as const,
+        sync: {
+          accepted: true as const,
+          sequence: params.sequence,
+          expiresAt: 10_000,
+          dirtyPaths: params.buffers
+            .filter((buffer) => buffer.dirty)
+            .map((buffer) => buffer.path),
+          stalePaths: [],
+          staleAuthority: [],
+        },
       };
     },
   );

--- a/runtime/tests/workspace/file-bound-read-capability.test.ts
+++ b/runtime/tests/workspace/file-bound-read-capability.test.ts
@@ -226,6 +226,35 @@ describe("descriptor-bound file reads", () => {
     }
   });
 
+  test("reads a text window while preserving the bounded binary sample", async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-bound-read-window-"));
+    const target = join(root, "target.txt");
+    const content = Array.from(
+      { length: 2_000 },
+      (_, index) => `line-${index + 1}`,
+    ).join("\n");
+    await writeFile(target, content, "utf8");
+    const capability = await bindWorkspaceFileReadCapability(target);
+
+    try {
+      const result = await capability.readTextWindow(2, 2, 4_096);
+
+      expect(result.content).toBe("line-2\nline-3");
+      expect(result.binarySample).toEqual(
+        Buffer.from(content, "utf8").subarray(0, 8_192),
+      );
+      expect(result.stats.size).toBe(Buffer.byteLength(content, "utf8"));
+      expect(result).toMatchObject({
+        startLine: 2,
+        endLine: 3,
+        numLines: 2,
+        isPartial: true,
+      });
+    } finally {
+      await capability.dispose();
+    }
+  });
+
   test.runIf(process.platform === "linux")(
     "keeps NFC and NFD siblings distinct on a normalization-sensitive Darwin mount",
     async () => {
@@ -249,8 +278,7 @@ describe("descriptor-bound file reads", () => {
         | Awaited<ReturnType<typeof bindWorkspaceDirectoryReadCapability>>
         | undefined;
       let fileCapability:
-        | Awaited<ReturnType<typeof bindWorkspaceFileReadCapability>>
-        | undefined;
+        Awaited<ReturnType<typeof bindWorkspaceFileReadCapability>> | undefined;
       Object.defineProperty(process, "platform", {
         ...platformDescriptor,
         value: "darwin",
@@ -296,9 +324,7 @@ describe("descriptor-bound file reads", () => {
         throw new Error("process.platform is not configurable for this test");
       }
       let guard:
-        | Awaited<
-            ReturnType<typeof captureWorkspaceFilePathTransactionGuard>
-          >
+        | Awaited<ReturnType<typeof captureWorkspaceFilePathTransactionGuard>>
         | undefined;
       Object.defineProperty(process, "platform", {
         ...platformDescriptor,

--- a/runtime/tests/workspace/mutation-coordinator.test.ts
+++ b/runtime/tests/workspace/mutation-coordinator.test.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import { spawn, spawnSync } from "node:child_process";
 import {
+  appendFile,
   mkdir,
   mkdtemp,
   readFile,
@@ -10,7 +12,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -51,6 +53,52 @@ function workspaceMutationStatePath(
     .digest("hex")
     .slice(0, 32);
   return join(agencHome, "workspace-mutations", key, fileName);
+}
+
+function relativePathOfLength(length: number, label: string): string {
+  const components: string[] = [];
+  let remaining = length;
+  let index = 0;
+  while (remaining > 120) {
+    const componentLength = Math.min(120, remaining - 2);
+    const prefix = index === 0 ? label : `segment-${index}`;
+    components.push(prefix.padEnd(componentLength, "x"));
+    remaining -= componentLength + 1;
+    index += 1;
+  }
+  const finalPrefix = index === 0 ? label : `tail-${index}`;
+  components.push(finalPrefix.slice(0, remaining).padEnd(remaining, "y"));
+  const relativePath = components.join(sep);
+  expect(relativePath.length).toBe(length);
+  return relativePath;
+}
+
+interface PersistedWorkspaceLedgerEntry {
+  readonly version: number;
+  readonly entryId: string;
+  readonly timestamp: string;
+  readonly workspaceRoot: string;
+  readonly path: string;
+  readonly source: string;
+  readonly status: string;
+  readonly beforeSha256: string;
+  readonly afterSha256?: string;
+  readonly proposalId?: string;
+}
+
+async function readWorkspaceMutationLedger(
+  workspaceRoot: string,
+  agencHome: string,
+): Promise<readonly PersistedWorkspaceLedgerEntry[]> {
+  const serialized = await readFile(
+    workspaceMutationStatePath(workspaceRoot, agencHome, "ledger-v1.jsonl"),
+    "utf8",
+  );
+  return serialized
+    .trimEnd()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as PersistedWorkspaceLedgerEntry);
 }
 
 afterEach(async () => {
@@ -263,16 +311,16 @@ describe("WorkspaceMutationCoordinator", () => {
     expect(
       secondRegistry.getOrCreate(workspaceRoot).hasProtectedEditorPaths(),
     ).toBe(true);
-    expect(secondRegistry.hasProtectedEditorAuthority(workspaceRoot)).toBe(true);
+    expect(secondRegistry.hasProtectedEditorAuthority(workspaceRoot)).toBe(
+      true,
+    );
   });
 
-  // Regression: a TUI that died without releasing its lease left its quarantine
-  // entries on disk, all of them `disk_authoritative`. From the next daemon
-  // start on, every tool in that workspace was refused with "Tool
-  // 'exec_command' is blocked while this workspace has protected Editor
-  // authority", with no editor running and nothing at risk — a
-  // `disk_authoritative` entry says the file on disk is the truth.
-  it("does not treat leftover disk-authoritative entries as protection", async () => {
+  // A persisted entry that was last known clean is not equivalent to a live
+  // disk-authoritative buffer: disk may have changed while the daemon was
+  // stopped. Keep every workspace-wide write fence closed until exact recovery
+  // evidence is reviewed.
+  it("protects persisted last-known-clean entries until exact recovery", async () => {
     const parent = await tempDirectory("agenc-coherence-stale-disk-");
     const agencHome = await tempDirectory("agenc-coherence-stale-disk-home-");
     const workspaceRoot = join(parent, "workspace");
@@ -311,14 +359,26 @@ describe("WorkspaceMutationCoordinator", () => {
     );
 
     const registry = new WorkspaceMutationCoordinatorRegistry({ agencHome });
-    expect(
-      registry.getOrCreate(workspaceRoot).hasProtectedEditorPaths(),
-    ).toBe(false);
-    expect(registry.hasProtectedEditorAuthority(workspaceRoot)).toBe(false);
-    // The tool barrier is the thing the user actually hits.
+    const restarted = registry.getOrCreate(workspaceRoot);
+    expect(restarted.hasProtectedEditorPaths()).toBe(true);
+    expect(restarted.staleAuthority()).toEqual([
+      expect.objectContaining({
+        path: `${workspaceRoot}/HARDWARE.md`,
+        editorState: "clean",
+        diskState: "missing",
+      }),
+    ]);
+    expect(registry.hasProtectedEditorAuthority(workspaceRoot)).toBe(true);
     expect(() =>
       registry.beginToolOperation(workspaceRoot, "exec_command"),
-    ).not.toThrow();
+    ).toThrow(/protected Editor authority/u);
+    expect(() =>
+      registry.acquireEditor(workspaceRoot, {
+        workspaceRoot,
+        editorInstanceId: "shell-requiring-unprotected-clean-workspace",
+        requireUnprotectedWorkspace: true,
+      }),
+    ).toThrow(/protected Editor authority/u);
   });
 
   // The other half: unsaved editor content still blocks, because a tool writing
@@ -431,7 +491,9 @@ describe("WorkspaceMutationCoordinator", () => {
         value: "darwin",
       });
       try {
-        const registry = new WorkspaceMutationCoordinatorRegistry({ agencHome });
+        const registry = new WorkspaceMutationCoordinatorRegistry({
+          agencHome,
+        });
         expect(
           registry.getOrCreate(nfcWorkspaceRoot).hasProtectedEditorPaths(),
         ).toBe(false);
@@ -967,6 +1029,1277 @@ describe("WorkspaceMutationCoordinator", () => {
       changedtick: 17,
     });
   });
+
+  it("durably audits exact stale-authority and automatic proposal abandonment once", async () => {
+    const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
+    const agencHome = await tempDirectory("agenc-coherence-home-");
+    const path = join(workspaceRoot, "abandon-stale-dirty.ts");
+    const diskContent = "reviewed disk state\n";
+    const editorContent = "orphaned unsaved state\n";
+    const proposalContent = "proposed replacement state\n";
+    await writeFile(path, diskContent, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-abandonment",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 3,
+          changedtick: 17,
+          contentSha256: sha256(editorContent),
+          contentBytes: Buffer.byteLength(editorContent),
+          dirty: true,
+          content: editorContent,
+        },
+      ],
+    });
+    const admission = await first.prepareMutation({
+      path,
+      source: "file_edit",
+      beforeText: editorContent,
+      afterText: proposalContent,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected an Editor proposal");
+    }
+    await first.flushQuarantinePersistence();
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-reviewing-stale-authority",
+    });
+    expect(lease.staleAuthority).toEqual([
+      {
+        path,
+        editorContentSha256: sha256(editorContent),
+        editorContentBytes: Buffer.byteLength(editorContent),
+        changedtick: 17,
+        editorInstanceId: firstLease.editorInstanceId,
+        epoch: firstLease.epoch,
+        editorState: "dirty",
+        diskState: "content",
+        diskContentSha256: sha256(diskContent),
+        diskContentBytes: Buffer.byteLength(diskContent),
+      },
+    ]);
+
+    const synchronized = await restarted.syncAbandoningStaleAuthority({
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+      sequence: 0,
+      buffers: [],
+      abandonStaleAuthority: lease.staleAuthority,
+    });
+
+    expect(synchronized).toMatchObject({
+      accepted: true,
+      dirtyPaths: [],
+      stalePaths: [],
+      staleAuthority: [],
+    });
+    expect(restarted.authorityForPath(path)).toBe("disk_authoritative");
+    const delivered = restarted.listChanges({
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    });
+    expect(delivered.changes).toContainEqual(
+      expect.objectContaining({
+        path,
+        source: "editor",
+        status: "discarded",
+        beforeSha256: sha256(editorContent),
+        afterSha256: sha256(diskContent),
+      }),
+    );
+    expect(delivered.changes).toContainEqual(
+      expect.objectContaining({
+        path,
+        source: "file_edit",
+        status: "discarded",
+        beforeSha256: sha256(editorContent),
+        afterSha256: sha256(proposalContent),
+        proposalId: admission.proposal.proposalId,
+      }),
+    );
+
+    const ledgerBeforeAcknowledgement = await readWorkspaceMutationLedger(
+      workspaceRoot,
+      agencHome,
+    );
+    const staleAuthorityTerminals = ledgerBeforeAcknowledgement.filter(
+      (entry) =>
+        entry.path === path &&
+        entry.source === "editor" &&
+        entry.status === "discarded" &&
+        entry.proposalId === undefined,
+    );
+    expect(staleAuthorityTerminals).toEqual([
+      expect.objectContaining({
+        version: 1,
+        workspaceRoot,
+        beforeSha256: sha256(editorContent),
+        afterSha256: sha256(diskContent),
+      }),
+    ]);
+    const proposalTerminals = ledgerBeforeAcknowledgement.filter(
+      (entry) =>
+        entry.proposalId === admission.proposal.proposalId &&
+        entry.status === "discarded",
+    );
+    expect(proposalTerminals).toEqual([
+      expect.objectContaining({
+        version: 1,
+        workspaceRoot,
+        path,
+        source: "file_edit",
+        beforeSha256: sha256(editorContent),
+        afterSha256: sha256(proposalContent),
+      }),
+    ]);
+
+    restarted.listChanges({
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+      afterSequence: delivered.sequence,
+    });
+    await restarted.flushQuarantinePersistence();
+    expect(await readWorkspaceMutationLedger(workspaceRoot, agencHome)).toEqual(
+      ledgerBeforeAcknowledgement,
+    );
+
+    const persisted = JSON.parse(
+      await readFile(
+        workspaceMutationStatePath(
+          workspaceRoot,
+          agencHome,
+          "quarantine-v1.json",
+        ),
+        "utf8",
+      ),
+    ) as { entries?: unknown[] };
+    expect(persisted.entries).toEqual([]);
+
+    const rehydratedRegistry = new WorkspaceMutationCoordinatorRegistry({
+      agencHome,
+    });
+    const rehydrated = rehydratedRegistry.getOrCreate(workspaceRoot);
+    expect(rehydrated.stalePaths()).toEqual([]);
+    expect(rehydrated.authorityForPath(path)).toBe("disk_authoritative");
+    expect(rehydrated.hasProtectedEditorPaths()).toBe(false);
+    const operation = rehydratedRegistry.beginToolOperation(
+      workspaceRoot,
+      "exec_command",
+    );
+    rehydratedRegistry.endToolOperation(operation);
+    expect(await readWorkspaceMutationLedger(workspaceRoot, agencHome)).toEqual(
+      ledgerBeforeAcknowledgement,
+    );
+  });
+
+  it("retries a failed stale-authority audit in the same coordinator exactly once", async () => {
+    const workspaceRoot = await tempDirectory("agenc-audit-retry-workspace-");
+    const agencHome = await tempDirectory("agenc-audit-retry-home-");
+    const path = join(workspaceRoot, "same-daemon-retry.ts");
+    const diskContent = "reviewed disk state\n";
+    const editorContent = "orphaned editor state\n";
+    await writeFile(path, diskContent, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-audit-retry",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 7,
+          changedtick: 3,
+          contentSha256: sha256(editorContent),
+          contentBytes: Buffer.byteLength(editorContent),
+          dirty: true,
+          content: editorContent,
+        },
+      ],
+    });
+    await first.flushQuarantinePersistence();
+
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-retrying-audit",
+    });
+    const ledgerPath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "ledger-v1.jsonl",
+    );
+    await mkdir(ledgerPath);
+
+    await expect(
+      coordinator.syncAbandoningStaleAuthority({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+        sequence: 0,
+        buffers: [],
+        abandonStaleAuthority: lease.staleAuthority,
+      }),
+    ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+    expect(coordinator.authorityForPath(path)).toBe("disk_authoritative");
+
+    const pendingQuarantine = JSON.parse(
+      await readFile(
+        workspaceMutationStatePath(
+          workspaceRoot,
+          agencHome,
+          "quarantine-v1.json",
+        ),
+        "utf8",
+      ),
+    ) as { readonly version?: number; readonly auditOutbox?: unknown[] };
+    expect(pendingQuarantine).toMatchObject({
+      version: 2,
+      auditOutbox: [expect.objectContaining({ path, status: "discarded" })],
+    });
+
+    await rm(ledgerPath, { recursive: true });
+    await coordinator.flushPendingAuditOutbox();
+    await coordinator.flushPendingAuditOutbox();
+
+    expect(await readWorkspaceMutationLedger(workspaceRoot, agencHome)).toEqual(
+      [
+        expect.objectContaining({
+          path,
+          source: "editor",
+          status: "discarded",
+          beforeSha256: sha256(editorContent),
+          afterSha256: sha256(diskContent),
+        }),
+      ],
+    );
+    const cleanedQuarantine = JSON.parse(
+      await readFile(
+        workspaceMutationStatePath(
+          workspaceRoot,
+          agencHome,
+          "quarantine-v1.json",
+        ),
+        "utf8",
+      ),
+    ) as { readonly version?: number; readonly auditOutbox?: unknown };
+    expect(cleanedQuarantine).toMatchObject({ version: 1 });
+    expect(cleanedQuarantine.auditOutbox).toBeUndefined();
+  });
+
+  it("drains a v2 audit outbox once and keeps the cleaned legacy v1 quarantine readable", async () => {
+    const workspaceRoot = await tempDirectory("agenc-audit-outbox-workspace-");
+    const agencHome = await tempDirectory("agenc-audit-outbox-home-");
+    const path = join(workspaceRoot, "outbox-recovery.ts");
+    const before = "orphaned editor identity\n";
+    const after = "reviewed disk identity\n";
+    await writeFile(path, after, "utf8");
+
+    const auditEntry: PersistedWorkspaceLedgerEntry = {
+      version: 1,
+      entryId: sha256("pending-audit-outbox-fixture"),
+      timestamp: "2026-08-17T12:00:00.000Z",
+      workspaceRoot,
+      path,
+      source: "editor",
+      status: "discarded",
+      beforeSha256: sha256(before),
+      afterSha256: sha256(after),
+    };
+    const quarantinePath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "quarantine-v1.json",
+    );
+    await mkdir(dirname(quarantinePath), { recursive: true });
+    await writeFile(
+      quarantinePath,
+      `${JSON.stringify({
+        version: 2,
+        workspaceRoot,
+        entries: [],
+        proposalCommitments: [],
+        proposalReceipts: [],
+        mutationIntents: [],
+        topologyIntents: [],
+        changeSequence: 0,
+        changes: [],
+        auditOutbox: [auditEntry],
+      })}\n`,
+      "utf8",
+    );
+
+    const firstRestart = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = firstRestart.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-draining-audit-outbox",
+    });
+    // This resolver is serialized behind constructor recovery, giving the
+    // durable outbox drain and its cleanup checkpoint a public completion
+    // boundary without relying on timers or private test seams.
+    await expect(
+      firstRestart.discardProposalForEditor({
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+        proposalId: "missing-after-audit-drain",
+      }),
+    ).rejects.toThrow(/proposal not found/u);
+    await firstRestart.flushQuarantinePersistence();
+
+    expect(await readWorkspaceMutationLedger(workspaceRoot, agencHome)).toEqual(
+      [auditEntry],
+    );
+    const cleanedQuarantine = JSON.parse(
+      await readFile(quarantinePath, "utf8"),
+    ) as { readonly version?: number; readonly auditOutbox?: unknown };
+    expect(cleanedQuarantine).toMatchObject({ version: 1 });
+    expect(cleanedQuarantine.auditOutbox).toBeUndefined();
+
+    const secondRestart = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    expect(secondRestart.authorityForPath(path)).toBe("disk_authoritative");
+    expect(secondRestart.hasProtectedEditorPaths()).toBe(false);
+    expect(await readWorkspaceMutationLedger(workspaceRoot, agencHome)).toEqual(
+      [auditEntry],
+    );
+  });
+
+  it("fences a contradictory proposal receipt and terminal audit outbox during hydration", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-audit-outbox-conflict-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-audit-outbox-conflict-home-");
+    const path = join(workspaceRoot, "contradictory-terminal.ts");
+    const proposalId = "proposal-with-contradictory-terminal";
+    const base = "proposal base\n";
+    const candidate = "applied proposal candidate\n";
+    await writeFile(path, base, "utf8");
+
+    const quarantinePath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "quarantine-v1.json",
+    );
+    await mkdir(dirname(quarantinePath), { recursive: true });
+    await writeFile(
+      quarantinePath,
+      `${JSON.stringify({
+        version: 2,
+        workspaceRoot,
+        entries: [
+          {
+            path,
+            contentSha256: sha256(candidate),
+            contentBytes: Buffer.byteLength(candidate),
+            changedtick: 2,
+            epoch: 1,
+            editorInstanceId: "editor-before-terminal-corruption",
+            authority: "editor_dirty",
+          },
+        ],
+        proposalCommitments: [],
+        proposalReceipts: [
+          {
+            proposalId,
+            action: "applied",
+            path,
+            changedtick: 2,
+            contentSha256: sha256(candidate),
+          },
+        ],
+        mutationIntents: [],
+        topologyIntents: [],
+        changeSequence: 0,
+        changes: [],
+        auditOutbox: [
+          {
+            version: 1,
+            entryId: sha256("contradictory-proposal-terminal"),
+            timestamp: "2026-08-17T12:00:00.000Z",
+            workspaceRoot,
+            path,
+            source: "file_edit",
+            status: "discarded",
+            beforeSha256: sha256(base),
+            afterSha256: sha256(candidate),
+            proposalId,
+          },
+        ],
+      })}\n`,
+      "utf8",
+    );
+
+    let appendOnceCalls = 0;
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+      appendLedgerOnce: async () => {
+        appendOnceCalls += 1;
+      },
+    });
+
+    expect(coordinator.authorityForPath(path)).toBe("stale_dirty");
+    expect(() => coordinator.authoritativeRead(path)).toThrow(
+      /may contain unsaved changes/u,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(appendOnceCalls).toBe(0);
+    await expect(
+      stat(
+        workspaceMutationStatePath(workspaceRoot, agencHome, "ledger-v1.jsonl"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "classifies a persisted stale path replaced by a FIFO without blocking",
+    async () => {
+      const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
+      const agencHome = await tempDirectory("agenc-coherence-home-");
+      const path = join(workspaceRoot, "stale-path-fifo.ts");
+      const diskContent = "disk before fifo replacement\n";
+      const editorContent = "orphaned unsaved state\n";
+      await writeFile(path, diskContent, "utf8");
+
+      const first = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const firstLease = first.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-before-fifo-replacement",
+      });
+      first.sync({
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 13,
+            changedtick: 29,
+            contentSha256: sha256(editorContent),
+            contentBytes: Buffer.byteLength(editorContent),
+            dirty: true,
+            content: editorContent,
+          },
+        ],
+      });
+      await first.flushQuarantinePersistence();
+
+      await rm(path);
+      const mkfifo = spawnSync("mkfifo", [path], { encoding: "utf8" });
+      expect(mkfifo.error).toBeUndefined();
+      expect(mkfifo.status, mkfifo.stderr).toBe(0);
+
+      // If the descriptor loses O_NONBLOCK, the delayed writer releases both
+      // synchronous probes so this regression fails on elapsed time instead
+      // of hanging the entire test process indefinitely.
+      const delayedWriter = spawn(
+        process.execPath,
+        [
+          "-e",
+          [
+            'const fs = require("node:fs");',
+            "setTimeout(() => {",
+            "  for (let index = 0; index < 2; index += 1) {",
+            "    const descriptor = fs.openSync(process.argv[1], fs.constants.O_WRONLY);",
+            "    fs.closeSync(descriptor);",
+            "  }",
+            "}, 1250);",
+          ].join("\n"),
+          path,
+        ],
+        { stdio: "ignore" },
+      );
+      const writerExited = new Promise<void>((resolve) => {
+        delayedWriter.once("exit", () => resolve());
+        delayedWriter.once("error", () => resolve());
+      });
+      try {
+        const startedAt = performance.now();
+        const restarted = new WorkspaceMutationCoordinator({
+          workspaceRoot,
+          agencHome,
+        });
+        const lease = restarted.acquire({
+          workspaceRoot,
+          editorInstanceId: "editor-reviewing-fifo-replacement",
+        });
+        const staleAuthority = restarted.staleAuthority();
+        const elapsedMs = performance.now() - startedAt;
+
+        expect(elapsedMs).toBeLessThan(750);
+        expect(lease.staleAuthority).toEqual([
+          expect.objectContaining({
+            path,
+            editorContentSha256: sha256(editorContent),
+            editorState: "dirty",
+            diskState: "unavailable",
+          }),
+        ]);
+        expect(staleAuthority).toEqual(lease.staleAuthority);
+      } finally {
+        if (
+          delayedWriter.exitCode === null &&
+          delayedWriter.signalCode === null
+        ) {
+          delayedWriter.kill("SIGKILL");
+        }
+        await writerExited;
+      }
+    },
+  );
+
+  it("atomically rejects stale-authority abandonment when disk changes after review", async () => {
+    const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
+    const agencHome = await tempDirectory("agenc-coherence-home-");
+    const path = join(workspaceRoot, "changed-after-review.ts");
+    const reviewedDiskContent = "disk state at review\n";
+    const changedDiskContent = "disk state changed after review\n";
+    const editorContent = "orphaned unsaved state\n";
+    await writeFile(path, reviewedDiskContent, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-disk-race",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 7,
+          changedtick: 23,
+          contentSha256: sha256(editorContent),
+          contentBytes: Buffer.byteLength(editorContent),
+          dirty: true,
+          content: editorContent,
+        },
+      ],
+    });
+    await first.flushQuarantinePersistence();
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-reviewing-before-disk-race",
+    });
+    const reviewedEvidence = lease.staleAuthority;
+    expect(reviewedEvidence).toMatchObject([
+      {
+        path,
+        editorContentSha256: sha256(editorContent),
+        diskState: "content",
+        diskContentSha256: sha256(reviewedDiskContent),
+      },
+    ]);
+    await writeFile(path, changedDiskContent, "utf8");
+
+    await expect(
+      restarted.syncAbandoningStaleAuthority({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+        sequence: 0,
+        buffers: [],
+        abandonStaleAuthority: reviewedEvidence,
+      }),
+    ).rejects.toThrow(
+      /stale Editor or disk authority changed before confirmation/u,
+    );
+
+    expect(restarted.authorityForPath(path)).toBe("stale_dirty");
+    expect(restarted.stalePaths()).toEqual([path]);
+    expect(
+      restarted.listChanges({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      }).changes,
+    ).not.toContainEqual(
+      expect.objectContaining({ path, status: "discarded" }),
+    );
+    expect(
+      restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+      }),
+    ).toMatchObject({
+      sequence: -1,
+      staleAuthority: [
+        {
+          path,
+          editorContentSha256: sha256(editorContent),
+          editorState: "dirty",
+          diskState: "content",
+          diskContentSha256: sha256(changedDiskContent),
+        },
+      ],
+    });
+
+    const rehydrated = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    expect(rehydrated.authorityForPath(path)).toBe("stale_dirty");
+    expect(rehydrated.hasProtectedEditorPaths()).toBe(true);
+  });
+
+  it("refreshes stale disk evidence without reconciling the new Editor buffer", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-coherence-refresh-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-coherence-refresh-home-");
+    const path = join(workspaceRoot, "refresh.ts");
+    const initialDiskContent = "disk state at acquisition\n";
+    const refreshedDiskContent = "disk state at refresh\n";
+    const editorContent = "orphaned unsaved state\n";
+    await writeFile(path, initialDiskContent, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-refresh",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 7,
+          changedtick: 23,
+          contentSha256: sha256(editorContent),
+          contentBytes: Buffer.byteLength(editorContent),
+          dirty: true,
+          content: editorContent,
+        },
+      ],
+    });
+    await first.flushQuarantinePersistence();
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-reviewing-refresh",
+    });
+    expect(lease.staleAuthority).toMatchObject([
+      {
+        path,
+        editorContentSha256: sha256(editorContent),
+        diskContentSha256: sha256(initialDiskContent),
+      },
+    ]);
+
+    await writeFile(path, refreshedDiskContent, "utf8");
+    const refreshed = restarted.refreshStaleAuthority({
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    });
+
+    expect(refreshed).toEqual({
+      refreshed: true,
+      staleAuthority: [
+        {
+          path,
+          editorContentSha256: sha256(editorContent),
+          editorContentBytes: Buffer.byteLength(editorContent),
+          changedtick: 23,
+          editorInstanceId: firstLease.editorInstanceId,
+          epoch: firstLease.epoch,
+          editorState: "dirty",
+          diskState: "content",
+          diskContentSha256: sha256(refreshedDiskContent),
+          diskContentBytes: Buffer.byteLength(refreshedDiskContent),
+        },
+      ],
+    });
+    expect(restarted.authorityForPath(path)).toBe("stale_dirty");
+    expect(restarted.stalePaths()).toEqual([path]);
+    expect(
+      restarted.heartbeat({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      }),
+    ).toMatchObject({
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+      sequence: -1,
+    });
+
+    expect(() =>
+      restarted.sync({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 8,
+            changedtick: 1,
+            contentSha256: sha256(refreshedDiskContent),
+            contentBytes: Buffer.byteLength(refreshedDiskContent),
+            dirty: false,
+          },
+        ],
+      }),
+    ).toThrow(/belongs to a different editor instance/u);
+    expect(restarted.authorityForPath(path)).toBe("stale_dirty");
+  });
+
+  it("keeps stale authority and proposals intact when abandonment persistence fails", async () => {
+    const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
+    const agencHome = await tempDirectory("agenc-coherence-home-");
+    const path = join(workspaceRoot, "abandonment-persistence-failure.ts");
+    const diskContent = "disk state\n";
+    const editorContent = "orphaned unsaved state\n";
+    const candidate = "reviewed proposal\n";
+    await writeFile(path, diskContent, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-persistence-failure",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 31,
+          changedtick: 9,
+          contentSha256: sha256(editorContent),
+          contentBytes: Buffer.byteLength(editorContent),
+          dirty: true,
+          content: editorContent,
+        },
+      ],
+    });
+    const admission = await first.prepareMutation({
+      path,
+      source: "file_edit",
+      beforeText: editorContent,
+      afterText: candidate,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected an editor proposal");
+    }
+    await first.flushQuarantinePersistence();
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-abandonment-persistence-failure",
+    });
+    expect(lease.staleAuthority).toHaveLength(1);
+
+    const quarantineDirectory = dirname(
+      workspaceMutationStatePath(
+        workspaceRoot,
+        agencHome,
+        "quarantine-v1.json",
+      ),
+    );
+    const preservedQuarantineDirectory = join(
+      agencHome,
+      "preserved-abandonment-persistence-state",
+    );
+    await rename(quarantineDirectory, preservedQuarantineDirectory);
+    await writeFile(quarantineDirectory, "persistence blocked", "utf8");
+    try {
+      await expect(
+        restarted.syncAbandoningStaleAuthority({
+          workspaceRoot,
+          editorInstanceId: lease.editorInstanceId,
+          leaseToken: lease.leaseToken,
+          epoch: lease.epoch,
+          sequence: 0,
+          buffers: [],
+          abandonStaleAuthority: lease.staleAuthority,
+        }),
+      ).rejects.toBeDefined();
+    } finally {
+      await rm(quarantineDirectory, { force: true });
+      await rename(preservedQuarantineDirectory, quarantineDirectory);
+    }
+
+    expect(restarted.authorityForPath(path)).toBe("stale_dirty");
+    expect(restarted.stalePaths()).toEqual([path]);
+    expect(
+      restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+      }),
+    ).toMatchObject({ sequence: -1 });
+    const inMemoryProposalChanges = restarted
+      .listChanges({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      })
+      .changes.filter(
+        (change) => change.proposalId === admission.proposal.proposalId,
+      );
+    expect(inMemoryProposalChanges.map((change) => change.status)).toEqual([
+      "proposed",
+    ]);
+
+    const rehydrated = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const rehydratedLease = rehydrated.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-after-persistence-failure",
+    });
+    expect(rehydratedLease).toMatchObject({
+      sequence: -1,
+      staleAuthority: [expect.objectContaining({ path })],
+    });
+    expect(rehydrated.authorityForPath(path)).toBe("stale_dirty");
+    expect(rehydrated.stalePaths()).toEqual([path]);
+    await expect(
+      rehydrated.proposalStatus({
+        workspaceRoot,
+        editorInstanceId: rehydratedLease.editorInstanceId,
+        leaseToken: rehydratedLease.leaseToken,
+        epoch: rehydratedLease.epoch,
+        proposalId: admission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({
+      status: "committed",
+      proposalId: admission.proposal.proposalId,
+      path,
+    });
+    expect(
+      rehydrated
+        .listChanges({
+          workspaceRoot,
+          editorInstanceId: rehydratedLease.editorInstanceId,
+          leaseToken: rehydratedLease.leaseToken,
+          epoch: rehydratedLease.epoch,
+        })
+        .changes.filter(
+          (change) => change.proposalId === admission.proposal.proposalId,
+        )
+        .map((change) => change.status),
+    ).toEqual(["proposed"]);
+  });
+
+  it("keeps live dirty authority and proposals intact when abandon-dirty release persistence fails", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-release-abandon-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-release-abandon-home-");
+    const path = join(workspaceRoot, "release-abandon-failure.ts");
+    const diskContent = "disk state\n";
+    const editorContent = "live unsaved Editor state\n";
+    const proposalContent = "reviewed proposal state\n";
+    await writeFile(path, diskContent, "utf8");
+
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-release-abandon-failure",
+    });
+    coordinator.sync({
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 37,
+          changedtick: 11,
+          contentSha256: sha256(editorContent),
+          contentBytes: Buffer.byteLength(editorContent),
+          dirty: true,
+          content: editorContent,
+        },
+      ],
+    });
+    const admission = await coordinator.prepareMutation({
+      path,
+      source: "file_edit",
+      beforeText: editorContent,
+      afterText: proposalContent,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected an Editor proposal");
+    }
+    await coordinator.flushQuarantinePersistence();
+
+    const quarantineDirectory = dirname(
+      workspaceMutationStatePath(
+        workspaceRoot,
+        agencHome,
+        "quarantine-v1.json",
+      ),
+    );
+    const preservedQuarantineDirectory = join(
+      agencHome,
+      "preserved-release-abandon-state",
+    );
+    await rename(quarantineDirectory, preservedQuarantineDirectory);
+    await writeFile(quarantineDirectory, "persistence blocked", "utf8");
+    try {
+      await expect(
+        coordinator.release({
+          workspaceRoot,
+          editorInstanceId: lease.editorInstanceId,
+          leaseToken: lease.leaseToken,
+          epoch: lease.epoch,
+          abandonDirty: true,
+        }),
+      ).rejects.toBeDefined();
+    } finally {
+      await rm(quarantineDirectory, { force: true });
+      await rename(preservedQuarantineDirectory, quarantineDirectory);
+    }
+
+    expect(coordinator.authorityForPath(path)).toBe("editor_dirty");
+    expect(coordinator.authoritativeRead(path)).toMatchObject({
+      authority: "editor_dirty",
+      path,
+      content: editorContent,
+      changedtick: 11,
+    });
+    expect(
+      coordinator
+        .listChanges({
+          workspaceRoot,
+          editorInstanceId: lease.editorInstanceId,
+          leaseToken: lease.leaseToken,
+          epoch: lease.epoch,
+        })
+        .changes.filter(
+          (change) => change.proposalId === admission.proposal.proposalId,
+        )
+        .map((change) => change.status),
+    ).toEqual(["proposed"]);
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const restartedLease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-after-release-abandon-failure",
+    });
+    expect(restartedLease.staleAuthority).toEqual([
+      expect.objectContaining({
+        path,
+        editorContentSha256: sha256(editorContent),
+      }),
+    ]);
+    await expect(
+      restarted.proposalStatus({
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+        proposalId: admission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({
+      status: "committed",
+      proposalId: admission.proposal.proposalId,
+      path,
+    });
+  });
+
+  it.each([
+    { action: "apply" as const, terminalStatus: "applied" as const },
+    { action: "discard" as const, terminalStatus: "discarded" as const },
+  ])(
+    "waits for an in-flight proposal $action durability seam before abandoning stale authority",
+    async ({ action, terminalStatus }) => {
+      const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
+      const agencHome = await tempDirectory("agenc-coherence-home-");
+      const path = join(workspaceRoot, `abandonment-${action}-race.ts`);
+      const base = "dirty proposal base\n";
+      const candidate = "reviewed proposal candidate\n";
+      await writeFile(path, base, "utf8");
+      let releaseTerminalAppend!: () => void;
+      let reportTerminalAppendStarted!: () => void;
+      const terminalAppendStarted = new Promise<void>((resolve) => {
+        reportTerminalAppendStarted = resolve;
+      });
+      const terminalAppendGate = new Promise<void>((resolve) => {
+        releaseTerminalAppend = resolve;
+      });
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+        appendLedgerOnce: async (entries) => {
+          if (
+            entries.some(
+              (entry) =>
+                entry.status === terminalStatus &&
+                entry.proposalId !== undefined,
+            )
+          ) {
+            reportTerminalAppendStarted();
+            await terminalAppendGate;
+          }
+        },
+      });
+      const firstLease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-before-${action}-race`,
+      });
+      coordinator.sync({
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 41,
+            changedtick: 1,
+            contentSha256: sha256(base),
+            contentBytes: Buffer.byteLength(base),
+            dirty: true,
+            content: base,
+          },
+        ],
+      });
+      const admission = await coordinator.prepareMutation({
+        path,
+        source: "file_edit",
+        beforeText: base,
+        afterText: candidate,
+      });
+      if (admission.decision !== "proposal") {
+        throw new Error("expected an editor proposal");
+      }
+      await coordinator.release({
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-during-${action}-race`,
+      });
+      expect(lease.staleAuthority).toHaveLength(1);
+
+      const resolution =
+        action === "apply"
+          ? coordinator.applyProposal({
+              workspaceRoot,
+              editorInstanceId: lease.editorInstanceId,
+              leaseToken: lease.leaseToken,
+              epoch: lease.epoch,
+              proposalId: admission.proposal.proposalId,
+              changedtick: 2,
+              contentSha256: sha256(candidate),
+              content: candidate,
+            })
+          : coordinator.discardProposalForEditor({
+              workspaceRoot,
+              editorInstanceId: lease.editorInstanceId,
+              leaseToken: lease.leaseToken,
+              epoch: lease.epoch,
+              proposalId: admission.proposal.proposalId,
+            });
+      await terminalAppendStarted;
+
+      let abandonmentSettled = false;
+      const abandonment = coordinator
+        .syncAbandoningStaleAuthority({
+          workspaceRoot,
+          editorInstanceId: lease.editorInstanceId,
+          leaseToken: lease.leaseToken,
+          epoch: lease.epoch,
+          sequence: 0,
+          buffers: [],
+          abandonStaleAuthority: lease.staleAuthority,
+        })
+        .then(
+          (value) => ({ status: "fulfilled" as const, value }),
+          (reason: unknown) => ({ status: "rejected" as const, reason }),
+        )
+        .finally(() => {
+          abandonmentSettled = true;
+        });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(abandonmentSettled).toBe(false);
+
+      releaseTerminalAppend();
+      await expect(resolution).resolves.toMatchObject(
+        action === "apply" ? { applied: true } : { discarded: true },
+      );
+      const abandonmentOutcome = await abandonment;
+      if (action === "apply") {
+        expect(abandonmentOutcome).toMatchObject({ status: "rejected" });
+        if (abandonmentOutcome.status === "rejected") {
+          expect(abandonmentOutcome.reason).toBeInstanceOf(
+            WorkspaceMutationCoordinatorError,
+          );
+          expect(String(abandonmentOutcome.reason)).toMatch(
+            /stale Editor authority changed before confirmation/u,
+          );
+        }
+        expect(coordinator.authorityForPath(path)).toBe("editor_dirty");
+      } else {
+        expect(abandonmentOutcome).toMatchObject({
+          status: "fulfilled",
+          value: {
+            accepted: true,
+            sequence: 0,
+            stalePaths: [],
+          },
+        });
+        expect(coordinator.authorityForPath(path)).toBe("disk_authoritative");
+      }
+
+      const proposalStatuses = coordinator
+        .listChanges({
+          workspaceRoot,
+          editorInstanceId: lease.editorInstanceId,
+          leaseToken: lease.leaseToken,
+          epoch: lease.epoch,
+        })
+        .changes.filter(
+          (change) => change.proposalId === admission.proposal.proposalId,
+        )
+        .map((change) => change.status);
+      expect(proposalStatuses).toEqual([terminalStatus]);
+      expect(proposalStatuses).not.toContain(
+        terminalStatus === "applied" ? "discarded" : "applied",
+      );
+
+      const rehydrated = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const rehydratedLease = rehydrated.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-after-${action}-race`,
+      });
+      await expect(
+        rehydrated.proposalStatus({
+          workspaceRoot,
+          editorInstanceId: rehydratedLease.editorInstanceId,
+          leaseToken: rehydratedLease.leaseToken,
+          epoch: rehydratedLease.epoch,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        status: terminalStatus,
+        proposalId: admission.proposal.proposalId,
+        path,
+      });
+      const rehydratedProposalStatuses = rehydrated
+        .listChanges({
+          workspaceRoot,
+          editorInstanceId: rehydratedLease.editorInstanceId,
+          leaseToken: rehydratedLease.leaseToken,
+          epoch: rehydratedLease.epoch,
+        })
+        .changes.filter(
+          (change) => change.proposalId === admission.proposal.proposalId,
+        )
+        .map((change) => change.status);
+      expect(rehydratedProposalStatuses).toEqual([terminalStatus]);
+    },
+  );
 
   it("lets a restarted TUI adopt only the exact quarantined dirty revision under its new instance", async () => {
     const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
@@ -1579,9 +2912,8 @@ describe("WorkspaceMutationCoordinator", () => {
       const dirtyPath = join(workspaceRoot, "dirty.ts");
       const dirtyContent = "authoritative editor bytes\n";
       await writeFile(dirtyPath, "stale disk bytes\n", "utf8");
-      const coordinator = workspaceMutationCoordinators.getOrCreate(
-        workspaceRoot,
-      );
+      const coordinator =
+        workspaceMutationCoordinators.getOrCreate(workspaceRoot);
       const lease = coordinator.acquire({
         workspaceRoot,
         editorInstanceId: "captured-root-editor",
@@ -1678,6 +3010,136 @@ describe("WorkspaceMutationCoordinator", () => {
       code: "STALE_EDITOR_BUFFER",
     });
   });
+
+  it.each(["changed", "deleted"] as const)(
+    "reviews and durably resolves a last-known-clean path %s during downtime",
+    async (diskOutcome) => {
+      const workspaceRoot = await tempDirectory(
+        "agenc-coherence-clean-drift-workspace-",
+      );
+      const agencHome = await tempDirectory(
+        "agenc-coherence-clean-drift-home-",
+      );
+      const path = join(workspaceRoot, `clean-${diskOutcome}.ts`);
+      const editorContent = "export const beforeDowntime = true;\n";
+      const changedDiskContent = "export const changedDuringDowntime = true;\n";
+      await writeFile(path, editorContent, "utf8");
+
+      const first = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const firstLease = first.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-before-clean-${diskOutcome}`,
+      });
+      first.sync({
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 4,
+            changedtick: 2,
+            contentSha256: sha256(editorContent),
+            contentBytes: Buffer.byteLength(editorContent),
+            dirty: false,
+          },
+        ],
+      });
+      await first.flushQuarantinePersistence();
+
+      if (diskOutcome === "changed") {
+        await writeFile(path, changedDiskContent, "utf8");
+      } else {
+        await rm(path);
+      }
+
+      const restarted = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const lease = restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-reviewing-clean-${diskOutcome}`,
+      });
+      const expectedDiskEvidence =
+        diskOutcome === "changed"
+          ? {
+              diskState: "content" as const,
+              diskContentSha256: sha256(changedDiskContent),
+              diskContentBytes: Buffer.byteLength(changedDiskContent),
+            }
+          : { diskState: "missing" as const };
+      expect(lease.staleAuthority).toEqual([
+        {
+          path,
+          editorContentSha256: sha256(editorContent),
+          editorContentBytes: Buffer.byteLength(editorContent),
+          changedtick: 2,
+          editorInstanceId: firstLease.editorInstanceId,
+          epoch: firstLease.epoch,
+          editorState: "clean",
+          ...expectedDiskEvidence,
+        },
+      ]);
+
+      const reviewedEvidence = lease.staleAuthority;
+      if (reviewedEvidence === undefined) {
+        throw new Error("expected stale clean-buffer authority evidence");
+      }
+      const resolution = restarted.syncAbandoningStaleAuthority({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+        sequence: 0,
+        buffers:
+          diskOutcome === "changed"
+            ? [
+                {
+                  path,
+                  bufferHandle: 5,
+                  changedtick: 3,
+                  contentSha256: sha256(changedDiskContent),
+                  contentBytes: Buffer.byteLength(changedDiskContent),
+                  dirty: false,
+                },
+              ]
+            : [],
+        abandonStaleAuthority: reviewedEvidence,
+      });
+
+      await expect(resolution).resolves.toMatchObject({
+        accepted: true,
+        dirtyPaths: [],
+        stalePaths: [],
+        staleAuthority: [],
+      });
+      expect(restarted.authorityForPath(path)).toBe("disk_authoritative");
+      expect(restarted.stalePaths()).toEqual([]);
+
+      await restarted.release({
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      });
+      await restarted.flushQuarantinePersistence();
+      expect(restarted.hasProtectedEditorPaths()).toBe(false);
+
+      const rehydrated = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      expect(rehydrated.stalePaths()).toEqual([]);
+      expect(rehydrated.authorityForPath(path)).toBe("disk_authoritative");
+      expect(rehydrated.hasProtectedEditorPaths()).toBe(false);
+    },
+  );
 
   it("fails closed when durable quarantine contains an unsafe entry", async () => {
     const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
@@ -2045,8 +3507,8 @@ describe("WorkspaceMutationCoordinator", () => {
     const coordinator = new WorkspaceMutationCoordinator({
       workspaceRoot,
       agencHome,
-      appendLedger: async (entry) => {
-        if (entry.status !== "applied") return;
+      appendLedgerOnce: async (entries) => {
+        if (!entries.some((entry) => entry.status === "applied")) return;
         reportAppliedStarted();
         await appliedGate;
       },
@@ -2235,6 +3697,945 @@ describe("WorkspaceMutationCoordinator", () => {
     expect(quarantine).not.toContain(candidate);
     expect(quarantine).toContain(sha256(candidate));
     expect(quarantine).toContain(admission.proposal.proposalId);
+  });
+
+  it.each([
+    { action: "apply" as const, terminalStatus: "applied" as const },
+    { action: "discard" as const, terminalStatus: "discarded" as const },
+  ])(
+    "rehydrates exactly one $terminalStatus proposal outcome after a crash at the audit projection seam",
+    async ({ action, terminalStatus }) => {
+      const workspaceRoot = await tempDirectory(
+        `agenc-proposal-${action}-outbox-workspace-`,
+      );
+      const agencHome = await tempDirectory(
+        `agenc-proposal-${action}-outbox-home-`,
+      );
+      const path = join(workspaceRoot, `${action}-projection-crash.ts`);
+      const base = "dirty proposal base\n";
+      const candidate = "reviewed proposal replacement\n";
+      await writeFile(path, base, "utf8");
+
+      const first = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+        appendLedgerOnce: async () => {
+          throw new Error("injected terminal projection crash seam");
+        },
+      });
+      const firstLease = first.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-before-${action}-projection-crash`,
+      });
+      const firstLeaseInput = {
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+      };
+      first.sync({
+        ...firstLeaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 61,
+            changedtick: 4,
+            contentSha256: sha256(base),
+            dirty: true,
+            content: base,
+          },
+        ],
+      });
+      const admission = await first.prepareMutation({
+        path,
+        source: "file_edit",
+        beforeText: base,
+        afterText: candidate,
+      });
+      if (admission.decision !== "proposal") {
+        throw new Error("expected an editor proposal");
+      }
+
+      const resolution =
+        action === "apply"
+          ? first.applyProposal({
+              ...firstLeaseInput,
+              proposalId: admission.proposal.proposalId,
+              changedtick: 5,
+              contentSha256: sha256(candidate),
+              content: candidate,
+            })
+          : first.discardProposalForEditor({
+              ...firstLeaseInput,
+              proposalId: admission.proposal.proposalId,
+            });
+      await expect(resolution).rejects.toMatchObject({
+        code: "MUTATION_AUDIT_FAILED",
+      });
+
+      const pending = JSON.parse(
+        await readFile(
+          workspaceMutationStatePath(
+            workspaceRoot,
+            agencHome,
+            "quarantine-v1.json",
+          ),
+          "utf8",
+        ),
+      ) as {
+        readonly version?: number;
+        readonly proposalCommitments?: unknown[];
+        readonly proposalReceipts?: readonly Record<string, unknown>[];
+        readonly auditOutbox?: readonly PersistedWorkspaceLedgerEntry[];
+      };
+      expect(pending).toMatchObject({
+        version: 2,
+        proposalCommitments: [],
+        proposalReceipts: [
+          expect.objectContaining({
+            proposalId: admission.proposal.proposalId,
+            action: terminalStatus,
+          }),
+        ],
+        auditOutbox: [
+          expect.objectContaining({
+            proposalId: admission.proposal.proposalId,
+            status: terminalStatus,
+          }),
+        ],
+      });
+
+      // Simulate process loss after the terminal snapshot but before its
+      // append-only projection. A new coordinator must drain that outbox.
+      const restarted = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      await restarted.flushPendingAuditOutbox();
+      const restartedLease = restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-after-${action}-projection-crash`,
+      });
+      const restartedLeaseInput = {
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+      };
+      await expect(
+        restarted.proposalStatus({
+          ...restartedLeaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        status: terminalStatus,
+        proposalId: admission.proposal.proposalId,
+      });
+      expect(restartedLease.staleAuthority).toHaveLength(1);
+
+      await expect(
+        restarted.syncAbandoningStaleAuthority({
+          ...restartedLeaseInput,
+          sequence: 0,
+          buffers: [],
+          abandonStaleAuthority: restartedLease.staleAuthority,
+        }),
+      ).resolves.toMatchObject({ accepted: true, stalePaths: [] });
+
+      const terminalEntries = (
+        await readWorkspaceMutationLedger(workspaceRoot, agencHome)
+      ).filter(
+        (entry) =>
+          entry.proposalId === admission.proposal.proposalId &&
+          (entry.status === "applied" || entry.status === "discarded"),
+      );
+      expect(terminalEntries).toEqual([
+        expect.objectContaining({
+          entryId: sha256(
+            JSON.stringify([
+              "workspace-proposal-terminal-v1",
+              workspaceRoot,
+              admission.proposal.proposalId,
+            ]),
+          ),
+          status: terminalStatus,
+        }),
+      ]);
+    },
+  );
+
+  it.each([
+    { action: "apply" as const, terminalStatus: "applied" as const },
+    { action: "discard" as const, terminalStatus: "discarded" as const },
+  ])(
+    "keeps the old proposal live and durable when $action terminal persistence fails",
+    async ({ action, terminalStatus }) => {
+      const workspaceRoot = await tempDirectory(
+        `agenc-proposal-${action}-persistence-workspace-`,
+      );
+      const agencHome = await tempDirectory(
+        `agenc-proposal-${action}-persistence-home-`,
+      );
+      const path = join(workspaceRoot, `${action}-persistence.ts`);
+      const base = "dirty base before failed persistence\n";
+      const candidate = "reviewed replacement after retry\n";
+      await writeFile(path, base, "utf8");
+
+      const first = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const firstLease = first.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-before-${action}-persistence-failure`,
+      });
+      const firstLeaseInput = {
+        workspaceRoot,
+        editorInstanceId: firstLease.editorInstanceId,
+        leaseToken: firstLease.leaseToken,
+        epoch: firstLease.epoch,
+      };
+      first.sync({
+        ...firstLeaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 66,
+            changedtick: 8,
+            contentSha256: sha256(base),
+            dirty: true,
+            content: base,
+          },
+        ],
+      });
+      const admission = await first.prepareMutation({
+        path,
+        source: "file_write",
+        beforeText: base,
+        afterText: candidate,
+      });
+      if (admission.decision !== "proposal") {
+        throw new Error("expected an editor proposal");
+      }
+      await first.flushQuarantinePersistence();
+
+      const quarantinePath = workspaceMutationStatePath(
+        workspaceRoot,
+        agencHome,
+        "quarantine-v1.json",
+      );
+      const quarantineBackupPath = `${quarantinePath}.retryable`;
+      await rename(quarantinePath, quarantineBackupPath);
+      await mkdir(quarantinePath);
+      const resolution =
+        action === "apply"
+          ? first.applyProposal({
+              ...firstLeaseInput,
+              proposalId: admission.proposal.proposalId,
+              changedtick: 9,
+              contentSha256: sha256(candidate),
+              content: candidate,
+            })
+          : first.discardProposalForEditor({
+              ...firstLeaseInput,
+              proposalId: admission.proposal.proposalId,
+            });
+      await expect(resolution).rejects.toMatchObject({
+        code: "MUTATION_AUDIT_FAILED",
+      });
+      expect(first.getProposal(admission.proposal.proposalId)).not.toBeNull();
+
+      await rm(quarantinePath, { recursive: true });
+      await rename(quarantineBackupPath, quarantinePath);
+      const restarted = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const restartedLease = restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-after-${action}-persistence-failure`,
+      });
+      const restartedLeaseInput = {
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+      };
+      await expect(
+        restarted.proposalStatus({
+          ...restartedLeaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        status: "committed",
+        proposalId: admission.proposal.proposalId,
+      });
+
+      const retry =
+        action === "apply"
+          ? restarted.applyProposal({
+              ...restartedLeaseInput,
+              proposalId: admission.proposal.proposalId,
+              changedtick: 9,
+              contentSha256: sha256(candidate),
+              content: candidate,
+            })
+          : restarted.discardProposalForEditor({
+              ...restartedLeaseInput,
+              proposalId: admission.proposal.proposalId,
+            });
+      await expect(retry).resolves.toMatchObject({
+        proposalId: admission.proposal.proposalId,
+      });
+      expect(
+        (await readWorkspaceMutationLedger(workspaceRoot, agencHome)).filter(
+          (entry) =>
+            entry.proposalId === admission.proposal.proposalId &&
+            (entry.status === "applied" || entry.status === "discarded"),
+        ),
+      ).toEqual([expect.objectContaining({ status: terminalStatus })]);
+    },
+  );
+
+  it("keeps a proposal retryable until every admitted mutation token is cancelled", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-token-gate-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-proposal-token-gate-home-");
+    const proposalPath = join(workspaceRoot, "proposal.ts");
+    const diskPath = join(workspaceRoot, "admitted-disk-write.ts");
+    const base = "dirty proposal base\n";
+    const candidate = "reviewed proposal replacement\n";
+    const diskBefore = "disk before\n";
+    const diskAfter = "disk after\n";
+    await writeFile(proposalPath, base, "utf8");
+    await writeFile(diskPath, diskBefore, "utf8");
+
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-proposal-token-gate",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    coordinator.sync({
+      ...leaseInput,
+      sequence: 0,
+      buffers: [
+        {
+          path: proposalPath,
+          bufferHandle: 67,
+          changedtick: 3,
+          contentSha256: sha256(base),
+          dirty: true,
+          content: base,
+        },
+      ],
+    });
+    const proposalAdmission = await coordinator.prepareMutation({
+      path: proposalPath,
+      source: "file_edit",
+      beforeText: base,
+      afterText: candidate,
+    });
+    if (proposalAdmission.decision !== "proposal") {
+      throw new Error("expected an editor proposal");
+    }
+    const diskAdmission = await coordinator.prepareMutation({
+      path: diskPath,
+      source: "file_write",
+      beforeText: diskBefore,
+      afterText: diskAfter,
+    });
+    if (diskAdmission.decision !== "allow") {
+      throw new Error("expected an admitted disk mutation");
+    }
+    const applyInput = {
+      ...leaseInput,
+      proposalId: proposalAdmission.proposal.proposalId,
+      changedtick: 4,
+      contentSha256: sha256(candidate),
+      content: candidate,
+    };
+
+    await expect(coordinator.applyProposal(applyInput)).rejects.toMatchObject({
+      code: "EDITOR_LEASE_MISMATCH",
+    });
+    await expect(
+      coordinator.proposalStatus({
+        ...leaseInput,
+        proposalId: proposalAdmission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({ status: "reviewable" });
+
+    coordinator.cancelMutation(diskAdmission.token);
+    await expect(coordinator.applyProposal(applyInput)).resolves.toMatchObject({
+      applied: true,
+      proposalId: proposalAdmission.proposal.proposalId,
+    });
+  });
+
+  it.each(["apply", "discard"] as const)(
+    "rejects topology reservation behind an in-flight checkpoint while proposal $action remains pending",
+    async (action) => {
+      const workspaceRoot = await tempDirectory(
+        `agenc-proposal-${action}-topology-race-workspace-`,
+      );
+      const agencHome = await tempDirectory(
+        `agenc-proposal-${action}-topology-race-home-`,
+      );
+      const proposalPath = join(workspaceRoot, "proposal.ts");
+      const topologyPath = join(workspaceRoot, "topology-target.ts");
+      const base = "dirty proposal base\n";
+      const candidate = "reviewed proposal replacement\n";
+      const diskBefore = "disk before reservation\n";
+      const diskAfter = "disk after reservation\n";
+      await writeFile(proposalPath, base, "utf8");
+      await writeFile(topologyPath, diskBefore, "utf8");
+
+      let gateNextQuarantineWrite = false;
+      let releaseQuarantineWrite!: () => void;
+      let reportQuarantineWriteStarted!: () => void;
+      const quarantineWriteStarted = new Promise<void>((resolve) => {
+        reportQuarantineWriteStarted = resolve;
+      });
+      const quarantineWriteGate = new Promise<void>((resolve) => {
+        releaseQuarantineWrite = resolve;
+      });
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+        beforePersistQuarantine: async () => {
+          if (!gateNextQuarantineWrite) return;
+          gateNextQuarantineWrite = false;
+          reportQuarantineWriteStarted();
+          await quarantineWriteGate;
+        },
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-${action}-topology-race`,
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path: proposalPath,
+            bufferHandle: 68,
+            changedtick: 3,
+            contentSha256: sha256(base),
+            dirty: true,
+            content: base,
+          },
+        ],
+      });
+      const proposalAdmission = await coordinator.prepareMutation({
+        path: proposalPath,
+        source: "file_edit",
+        beforeText: base,
+        afterText: candidate,
+      });
+      if (proposalAdmission.decision !== "proposal") {
+        throw new Error("expected an editor proposal");
+      }
+      const diskAdmission = await coordinator.prepareMutation({
+        path: topologyPath,
+        source: "file_write",
+        beforeText: diskBefore,
+        afterText: diskAfter,
+      });
+      if (diskAdmission.decision !== "allow") {
+        throw new Error("expected an admitted disk mutation");
+      }
+
+      gateNextQuarantineWrite = true;
+      coordinator.cancelMutation(diskAdmission.token);
+      await quarantineWriteStarted;
+      const reservation = coordinator.reserveTopologyMutation([
+        { path: topologyPath },
+      ]);
+      const resolution =
+        action === "apply"
+          ? coordinator.applyProposal({
+              ...leaseInput,
+              proposalId: proposalAdmission.proposal.proposalId,
+              changedtick: 4,
+              contentSha256: sha256(candidate),
+              content: candidate,
+            })
+          : coordinator.discardProposalForEditor({
+              ...leaseInput,
+              proposalId: proposalAdmission.proposal.proposalId,
+            });
+      let resolutionSettled = false;
+      void resolution.then(
+        () => {
+          resolutionSettled = true;
+        },
+        () => {
+          resolutionSettled = true;
+        },
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(resolutionSettled).toBe(false);
+
+      releaseQuarantineWrite();
+      await expect(reservation).rejects.toMatchObject({
+        code: "EDITOR_LEASE_MISMATCH",
+      });
+      await expect(resolution).resolves.toMatchObject({
+        proposalId: proposalAdmission.proposal.proposalId,
+      });
+      const topologyToken = await coordinator.reserveTopologyMutation([
+        { path: topologyPath },
+      ]);
+      await coordinator.releaseTopologyMutation(topologyToken);
+    },
+  );
+
+  it("rejects Use Disk before persistence when a legacy ledger already records the proposal as applied", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-legacy-terminal-workspace-",
+    );
+    const agencHome = await tempDirectory(
+      "agenc-proposal-legacy-terminal-home-",
+    );
+    const path = join(workspaceRoot, "legacy-terminal.ts");
+    const base = "dirty proposal base\n";
+    const candidate = "historically applied replacement\n";
+    await writeFile(path, base, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-legacy-terminal",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 71,
+          changedtick: 6,
+          contentSha256: sha256(base),
+          dirty: true,
+          content: base,
+        },
+      ],
+    });
+    const admission = await first.prepareMutation({
+      path,
+      source: "file_edit",
+      beforeText: base,
+      afterText: candidate,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected an editor proposal");
+    }
+    await first.flushQuarantinePersistence();
+
+    await appendFile(
+      workspaceMutationStatePath(workspaceRoot, agencHome, "ledger-v1.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        entryId: sha256("legacy-random-proposal-terminal-id"),
+        timestamp: "2026-08-17T12:00:00.000Z",
+        workspaceRoot,
+        path,
+        source: "file_edit",
+        status: "applied",
+        beforeSha256: sha256(base),
+        afterSha256: sha256(candidate),
+        proposalId: admission.proposal.proposalId,
+      })}\n`,
+      "utf8",
+    );
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-after-legacy-terminal",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    await expect(
+      restarted.syncAbandoningStaleAuthority({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [],
+        abandonStaleAuthority: lease.staleAuthority,
+      }),
+    ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+    await expect(
+      restarted.proposalStatus({
+        ...leaseInput,
+        proposalId: admission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({
+      status: "committed",
+      proposalId: admission.proposal.proposalId,
+    });
+
+    const persisted = JSON.parse(
+      await readFile(
+        workspaceMutationStatePath(
+          workspaceRoot,
+          agencHome,
+          "quarantine-v1.json",
+        ),
+        "utf8",
+      ),
+    ) as {
+      readonly proposalCommitments?: readonly Record<string, unknown>[];
+      readonly proposalReceipts?: unknown[];
+      readonly auditOutbox?: unknown[];
+    };
+    expect(persisted.proposalCommitments).toEqual([
+      expect.objectContaining({ proposalId: admission.proposal.proposalId }),
+    ]);
+    expect(persisted.proposalReceipts).toEqual([]);
+    expect(persisted.auditOutbox).toBeUndefined();
+    expect(
+      (await readWorkspaceMutationLedger(workspaceRoot, agencHome)).filter(
+        (entry) =>
+          entry.proposalId === admission.proposal.proposalId &&
+          (entry.status === "applied" || entry.status === "discarded"),
+      ),
+    ).toEqual([expect.objectContaining({ status: "applied" })]);
+  });
+
+  it("recognizes a legacy proposal terminal recorded with equivalent root and path spellings", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-legacy-path-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-proposal-legacy-path-home-");
+    const fileName = "legacy-equivalent.ts";
+    const path = join(workspaceRoot, fileName);
+    const base = "dirty proposal base\n";
+    const candidate = "historically applied replacement\n";
+    await writeFile(path, base, "utf8");
+
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-legacy-path-terminal",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 72,
+          changedtick: 6,
+          contentSha256: sha256(base),
+          dirty: true,
+          content: base,
+        },
+      ],
+    });
+    const admission = await first.prepareMutation({
+      path,
+      source: "file_edit",
+      beforeText: base,
+      afterText: candidate,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected an editor proposal");
+    }
+    await first.flushQuarantinePersistence();
+
+    const legacyEntryId = sha256("legacy-equivalent-proposal-terminal-id");
+    await appendFile(
+      workspaceMutationStatePath(workspaceRoot, agencHome, "ledger-v1.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        entryId: legacyEntryId,
+        timestamp: "2026-08-17T12:00:00.000Z",
+        workspaceRoot: `${workspaceRoot}${sep}.`,
+        path: `${workspaceRoot}${sep}.${sep}${fileName}`,
+        source: "file_edit",
+        status: "applied",
+        beforeSha256: sha256(base),
+        afterSha256: sha256(candidate),
+        proposalId: admission.proposal.proposalId,
+      })}\n`,
+      "utf8",
+    );
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-after-legacy-path-terminal",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    expect(
+      restarted.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 73,
+            changedtick: 2,
+            contentSha256: sha256(candidate),
+            dirty: true,
+            content: candidate,
+          },
+        ],
+      }),
+    ).toMatchObject({ accepted: true, dirtyPaths: [path] });
+
+    await expect(
+      restarted.applyProposal({
+        ...leaseInput,
+        proposalId: admission.proposal.proposalId,
+        changedtick: 2,
+        contentSha256: sha256(candidate),
+        content: candidate,
+      }),
+    ).resolves.toMatchObject({
+      applied: true,
+      proposalId: admission.proposal.proposalId,
+    });
+    expect(
+      (await readWorkspaceMutationLedger(workspaceRoot, agencHome)).filter(
+        (entry) =>
+          entry.proposalId === admission.proposal.proposalId &&
+          (entry.status === "applied" || entry.status === "discarded"),
+      ),
+    ).toEqual([
+      expect.objectContaining({ entryId: legacyEntryId, status: "applied" }),
+    ]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps historical audit validation independent of changed descendant symlinks",
+    async () => {
+      const workspaceRoot = await tempDirectory(
+        "agenc-proposal-legacy-symlink-workspace-",
+      );
+      const agencHome = await tempDirectory(
+        "agenc-proposal-legacy-symlink-home-",
+      );
+      const externalDirectory = await tempDirectory(
+        "agenc-proposal-legacy-symlink-external-",
+      );
+      const originalDirectory = join(workspaceRoot, "original-audit-target");
+      const linkPath = join(workspaceRoot, "historical-link");
+      const path = join(workspaceRoot, "proposal-after-symlink-change.ts");
+      const base = "dirty proposal base\n";
+      const candidate = "proposal independent of old symlink\n";
+      await mkdir(originalDirectory);
+      await symlink(originalDirectory, linkPath, "dir");
+      await writeFile(path, base, "utf8");
+
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-after-historical-symlink-change",
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path,
+            bufferHandle: 75,
+            changedtick: 3,
+            contentSha256: sha256(base),
+            dirty: true,
+            content: base,
+          },
+        ],
+      });
+      const admission = await coordinator.prepareMutation({
+        path,
+        source: "file_edit",
+        beforeText: base,
+        afterText: candidate,
+      });
+      if (admission.decision !== "proposal") {
+        throw new Error("expected an editor proposal");
+      }
+
+      await appendFile(
+        workspaceMutationStatePath(workspaceRoot, agencHome, "ledger-v1.jsonl"),
+        `${JSON.stringify({
+          version: 1,
+          entryId: sha256("historical-descendant-symlink-audit"),
+          timestamp: "2026-08-17T12:00:00.000Z",
+          workspaceRoot,
+          path: join(linkPath, "historical.ts"),
+          source: "editor",
+          status: "discarded",
+          beforeSha256: sha256("historical editor state"),
+        })}\n`,
+        "utf8",
+      );
+      await rm(linkPath, { force: true });
+      await symlink(externalDirectory, linkPath, "dir");
+
+      await expect(
+        coordinator.discardProposalForEditor({
+          ...leaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        discarded: true,
+        proposalId: admission.proposal.proposalId,
+      });
+    },
+  );
+
+  it("rejects a legacy audit path that escapes its canonical workspace", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-legacy-escape-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-proposal-legacy-escape-home-");
+    const path = join(workspaceRoot, "legacy-escape.ts");
+    const base = "dirty proposal base\n";
+    const candidate = "candidate blocked by invalid legacy audit\n";
+    await writeFile(path, base, "utf8");
+
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-with-legacy-escape",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    coordinator.sync({
+      ...leaseInput,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 74,
+          changedtick: 3,
+          contentSha256: sha256(base),
+          dirty: true,
+          content: base,
+        },
+      ],
+    });
+    const admission = await coordinator.prepareMutation({
+      path,
+      source: "file_edit",
+      beforeText: base,
+      afterText: candidate,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected an editor proposal");
+    }
+
+    await appendFile(
+      workspaceMutationStatePath(workspaceRoot, agencHome, "ledger-v1.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        entryId: sha256("legacy-escaping-audit-entry"),
+        timestamp: "2026-08-17T12:00:00.000Z",
+        workspaceRoot: `${workspaceRoot}${sep}.`,
+        path: `${workspaceRoot}${sep}..${sep}outside.ts`,
+        source: "editor",
+        status: "discarded",
+        beforeSha256: sha256("escaped editor state"),
+      })}\n`,
+      "utf8",
+    );
+
+    await expect(
+      coordinator.discardProposalForEditor({
+        ...leaseInput,
+        proposalId: admission.proposal.proposalId,
+      }),
+    ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+    await expect(
+      coordinator.proposalStatus({
+        ...leaseInput,
+        proposalId: admission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({ status: "reviewable" });
+
+    const persisted = JSON.parse(
+      await readFile(
+        workspaceMutationStatePath(
+          workspaceRoot,
+          agencHome,
+          "quarantine-v1.json",
+        ),
+        "utf8",
+      ),
+    ) as {
+      readonly proposalCommitments?: readonly Record<string, unknown>[];
+      readonly proposalReceipts?: unknown[];
+      readonly auditOutbox?: unknown[];
+    };
+    expect(persisted.proposalCommitments).toEqual([
+      expect.objectContaining({ proposalId: admission.proposal.proposalId }),
+    ]);
+    expect(persisted.proposalReceipts).toEqual([]);
+    expect(persisted.auditOutbox).toBeUndefined();
   });
 
   it("reconciles exact accepted proposal bytes under a fresh Editor process tick", async () => {
@@ -2533,9 +4934,15 @@ describe("WorkspaceMutationCoordinator", () => {
     const coordinator = new WorkspaceMutationCoordinator({
       workspaceRoot,
       agencHome,
-      appendLedger: async (entry) => {
-        if (entry.status !== "applied" || entry.proposalId === undefined)
+      appendLedgerOnce: async (entries) => {
+        if (
+          !entries.some(
+            (entry) =>
+              entry.status === "applied" && entry.proposalId !== undefined,
+          )
+        ) {
           return;
+        }
         appliedAttempts += 1;
         if (appliedAttempts === 1) throw new Error("injected ledger failure");
         if (appliedAttempts === 2) {
@@ -2636,7 +5043,14 @@ describe("WorkspaceMutationCoordinator", () => {
               await secondProposalGate;
             }
           }
-          if (entry.status === "applied" || entry.status === "discarded") {
+        },
+        appendLedgerOnce: async (entries) => {
+          if (
+            entries.some(
+              (entry) =>
+                entry.status === "applied" || entry.status === "discarded",
+            )
+          ) {
             resolutionAppendStarted = true;
           }
         },
@@ -2834,6 +5248,1263 @@ describe("WorkspaceMutationCoordinator", () => {
     expect(proposedAppends).toBe(1);
   });
 
+  it("rejects proposal admission when neither terminal audit outcome fits the durable outbox", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-terminal-capacity-workspace-",
+    );
+    const agencHome = await tempDirectory(
+      "agenc-proposal-terminal-capacity-home-",
+    );
+    const path = join(workspaceRoot, "terminal-capacity.ts");
+    const base = "dirty base at terminal capacity\n";
+    const candidate = "candidate that must remain uncommitted\n";
+    await writeFile(path, base, "utf8");
+
+    // The persisted maximum is MAX_SYNCED_BUFFERS + MAX_PENDING_PROPOSALS.
+    // Keep projection unavailable so constructor recovery cannot drain the
+    // exact-boundary fixture before proposal admission runs.
+    const auditOutbox = Array.from({ length: 512 + 32 }, (_, index) => ({
+      version: 1,
+      entryId: sha256(`terminal-capacity-audit-${index}`),
+      timestamp: "2026-08-17T12:00:00.000Z",
+      workspaceRoot,
+      path,
+      source: "editor",
+      status: "discarded",
+      beforeSha256: sha256(`discarded-editor-state-${index}`),
+    }));
+    const quarantinePath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "quarantine-v1.json",
+    );
+    await mkdir(dirname(quarantinePath), { recursive: true });
+    await writeFile(
+      quarantinePath,
+      `${JSON.stringify({
+        version: 2,
+        workspaceRoot,
+        entries: [],
+        proposalCommitments: [],
+        proposalReceipts: [],
+        mutationIntents: [],
+        topologyIntents: [],
+        changeSequence: 0,
+        changes: [],
+        auditOutbox,
+      })}\n`,
+      "utf8",
+    );
+
+    let proposedAppends = 0;
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+      appendLedger: async (entry) => {
+        if (entry.status === "proposed") proposedAppends += 1;
+      },
+      appendLedgerOnce: async () => {
+        throw new Error("audit projection remains unavailable");
+      },
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-at-terminal-capacity",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    coordinator.sync({
+      ...leaseInput,
+      sequence: 0,
+      buffers: [
+        {
+          path,
+          bufferHandle: 113,
+          changedtick: 1,
+          contentSha256: sha256(base),
+          dirty: true,
+          content: base,
+        },
+      ],
+    });
+
+    await expect(
+      coordinator.prepareMutation({
+        path,
+        source: "file_edit",
+        beforeText: base,
+        afterText: candidate,
+      }),
+    ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+    expect(proposedAppends).toBe(0);
+    expect(
+      coordinator
+        .listChanges(leaseInput)
+        .changes.filter((change) => change.status === "proposed"),
+    ).toEqual([]);
+
+    const persisted = JSON.parse(await readFile(quarantinePath, "utf8")) as {
+      readonly proposalCommitments?: unknown[];
+      readonly proposalReceipts?: unknown[];
+      readonly auditOutbox?: unknown[];
+    };
+    expect(persisted.proposalCommitments).toEqual([]);
+    expect(persisted.proposalReceipts).toEqual([]);
+    expect(persisted.auditOutbox).toHaveLength(512 + 32);
+  });
+
+  it("rejects a 512-buffer sync that would retain an omitted dirty quarantine entry", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-sync-shape-cap-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-sync-shape-cap-home-");
+    const omittedPath = join(workspaceRoot, "omitted-dirty.ts");
+    const omittedContent = "unsaved authority\n";
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-sync-shape-cap",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    coordinator.sync({
+      ...leaseInput,
+      sequence: 0,
+      buffers: [
+        {
+          path: omittedPath,
+          bufferHandle: 1,
+          changedtick: 1,
+          contentSha256: sha256(omittedContent),
+          dirty: true,
+          content: omittedContent,
+        },
+      ],
+    });
+    const replacement = Array.from({ length: 512 }, (_, index) => {
+      const content = `replacement dirty ${index}\n`;
+      return {
+        path: join(workspaceRoot, `replacement-${index}.ts`),
+        bufferHandle: index + 2,
+        changedtick: 1,
+        contentSha256: sha256(content),
+        dirty: true as const,
+        content,
+      };
+    });
+
+    expect(() =>
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 1,
+        buffers: replacement,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_EDITOR_SYNC" }));
+    await coordinator.flushQuarantinePersistence();
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    expect(restarted.stalePaths()).toContain(omittedPath);
+  });
+
+  it("rejects a full replacement manifest that would make a surviving proposal apply persist 513 buffers", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-shape-cap-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-proposal-shape-cap-home-");
+    const proposalPath = join(workspaceRoot, "omitted-proposal.ts");
+    const base = "clean proposal base\n";
+    const candidate = "reviewed proposal candidate\n";
+    await writeFile(proposalPath, base, "utf8");
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-proposal-shape-cap",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    coordinator.sync({
+      ...leaseInput,
+      sequence: 0,
+      buffers: [
+        {
+          path: proposalPath,
+          bufferHandle: 1,
+          changedtick: 1,
+          contentSha256: sha256(base),
+          contentBytes: Buffer.byteLength(base, "utf8"),
+          dirty: false,
+        },
+      ],
+    });
+    const admission = await coordinator.prepareMutation({
+      path: proposalPath,
+      source: "file_edit",
+      beforeText: base,
+      afterText: candidate,
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected a clean loaded-buffer proposal");
+    }
+    const replacement = Array.from({ length: 512 }, (_, index) => {
+      const content = `replacement dirty ${index}\n`;
+      return {
+        path: join(workspaceRoot, `replacement-${index}.ts`),
+        bufferHandle: index + 2,
+        changedtick: 1,
+        contentSha256: sha256(content),
+        dirty: true as const,
+        content,
+      };
+    });
+
+    expect(() =>
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 1,
+        buffers: replacement,
+      }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_EDITOR_SYNC" }));
+    await coordinator.flushQuarantinePersistence();
+
+    const restarted = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const restartedLease = restarted.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-proposal-shape-cap-restart",
+    });
+    await expect(
+      restarted.proposalStatus({
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+        proposalId: admission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({
+      status: "committed",
+      proposalId: admission.proposal.proposalId,
+    });
+  });
+
+  it("keeps an irreducible legacy terminal overflow blocked but explicitly abandonable", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-legacy-shape-overflow-workspace-",
+    );
+    const agencHome = await tempDirectory("agenc-legacy-shape-overflow-home-");
+    const proposalPath = join(workspaceRoot, "legacy-proposal.ts");
+    const base = "legacy proposal base\n";
+    await writeFile(proposalPath, base, "utf8");
+    const first = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    const firstLease = first.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-before-legacy-overflow",
+    });
+    first.sync({
+      workspaceRoot,
+      editorInstanceId: firstLease.editorInstanceId,
+      leaseToken: firstLease.leaseToken,
+      epoch: firstLease.epoch,
+      sequence: 0,
+      buffers: [
+        {
+          path: proposalPath,
+          bufferHandle: 1,
+          changedtick: 1,
+          contentSha256: sha256(base),
+          contentBytes: Buffer.byteLength(base, "utf8"),
+          dirty: false,
+        },
+      ],
+    });
+    const admission = await first.prepareMutation({
+      path: proposalPath,
+      source: "file_edit",
+      beforeText: base,
+      afterText: "legacy reviewed candidate\n",
+    });
+    if (admission.decision !== "proposal") {
+      throw new Error("expected a durable proposal commitment");
+    }
+    await first.flushQuarantinePersistence();
+    const quarantinePath = workspaceMutationStatePath(
+      workspaceRoot,
+      agencHome,
+      "quarantine-v1.json",
+    );
+    const legacySnapshot = JSON.parse(
+      await readFile(quarantinePath, "utf8"),
+    ) as {
+      entries: Record<string, unknown>[];
+    } & Record<string, unknown>;
+    const template = legacySnapshot.entries[0];
+    if (template === undefined) throw new Error("expected persisted authority");
+    legacySnapshot.entries = Array.from({ length: 512 }, (_, index) => ({
+      ...template,
+      path: join(workspaceRoot, `legacy-buffer-${index}.ts`),
+    }));
+    const serializedLegacySnapshot = `${JSON.stringify(legacySnapshot)}\n`;
+    expect(Buffer.byteLength(serializedLegacySnapshot, "utf8")).toBeLessThan(
+      524_288,
+    );
+    await writeFile(quarantinePath, serializedLegacySnapshot, "utf8");
+
+    const blocked = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    expect(() => blocked.authoritativeRead(proposalPath)).toThrow(
+      /may contain unsaved changes/u,
+    );
+    const recoveryLease = blocked.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-abandoning-legacy-overflow",
+    });
+    expect(() =>
+      blocked.sync({
+        workspaceRoot,
+        editorInstanceId: recoveryLease.editorInstanceId,
+        leaseToken: recoveryLease.leaseToken,
+        epoch: recoveryLease.epoch,
+        sequence: 0,
+        buffers: [],
+      }),
+    ).toThrow(/explicitly abandon dirty quarantine/u);
+    await expect(
+      blocked.release({
+        workspaceRoot,
+        editorInstanceId: recoveryLease.editorInstanceId,
+        leaseToken: recoveryLease.leaseToken,
+        epoch: recoveryLease.epoch,
+        abandonDirty: true,
+      }),
+    ).resolves.toEqual({ released: true, stalePaths: [] });
+
+    const recovered = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+    expect(recovered.authoritativeRead(proposalPath)).toBeNull();
+  });
+
+  it.runIf(process.platform === "linux")(
+    "rejects an admission that would strand an existing proposal terminal at the quarantine byte boundary",
+    async () => {
+      const workspaceRoot = await mkdtemp("/tmp/agenc-capmulti-root-");
+      const agencHome = await mkdtemp("/tmp/agenc-capmulti-home-");
+      temporaryPaths.push(workspaceRoot, agencHome);
+      const firstPath = join(
+        workspaceRoot,
+        relativePathOfLength(3_400, "proposal-a"),
+      );
+      const secondPath = join(
+        workspaceRoot,
+        relativePathOfLength(12, "proposal-b"),
+      );
+      const firstBase = "proposal A dirty base\n";
+      const secondBase = "proposal B dirty base\n";
+      const otherBuffers = Array.from({ length: 510 }, (_, index) => {
+        const content = `other dirty base ${index}\n`;
+        return {
+          path: join(
+            workspaceRoot,
+            relativePathOfLength(748, `other-${index}`),
+          ),
+          bufferHandle: index + 3,
+          changedtick: 1,
+          contentSha256: sha256(content),
+          dirty: true as const,
+          content,
+        };
+      });
+      let proposedAppends = 0;
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+        appendLedger: async (entry) => {
+          if (entry.status === "proposed") proposedAppends += 1;
+        },
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-cap-boundary",
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path: firstPath,
+            bufferHandle: 1,
+            changedtick: 1,
+            contentSha256: sha256(firstBase),
+            dirty: true,
+            content: firstBase,
+          },
+          {
+            path: secondPath,
+            bufferHandle: 2,
+            changedtick: 1,
+            contentSha256: sha256(secondBase),
+            dirty: true,
+            content: secondBase,
+          },
+          ...otherBuffers,
+        ],
+      });
+
+      const firstAdmission = await coordinator.prepareMutation({
+        path: firstPath,
+        source: "file_edit",
+        beforeText: firstBase,
+        afterText: "proposal A candidate\n",
+      });
+      if (firstAdmission.decision !== "proposal") {
+        throw new Error("expected proposal A to fit before proposal B");
+      }
+      await expect(
+        coordinator.prepareMutation({
+          path: secondPath,
+          source: "file_edit",
+          beforeText: secondBase,
+          afterText: "proposal B candidate\n",
+        }),
+      ).rejects.toMatchObject({ code: "INVALID_EDITOR_SYNC" });
+
+      expect(proposedAppends).toBe(1);
+      expect(
+        coordinator
+          .listChanges(leaseInput)
+          .changes.filter((change) => change.status === "proposed"),
+      ).toEqual([
+        expect.objectContaining({
+          proposalId: firstAdmission.proposal.proposalId,
+          path: firstPath,
+        }),
+      ]);
+      await expect(
+        coordinator.discardProposalForEditor({
+          ...leaseInput,
+          proposalId: firstAdmission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        discarded: true,
+        proposalId: firstAdmission.proposal.proposalId,
+      });
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "reserves cumulative terminal growth across three near-capacity proposals",
+    async () => {
+      const workspaceRoot = await mkdtemp("/tmp/agenc-capmulti-root-");
+      const agencHome = await mkdtemp("/tmp/agenc-capmulti-home-");
+      temporaryPaths.push(workspaceRoot, agencHome);
+      const proposalSpecs = [
+        { label: "a", length: 3_400 },
+        { label: "b", length: 3_200 },
+        { label: "c", length: 3_000 },
+      ] as const;
+      const paths = proposalSpecs.map((spec) =>
+        join(
+          workspaceRoot,
+          relativePathOfLength(spec.length, `proposal-${spec.label}`),
+        ),
+      );
+      const bases = proposalSpecs.map(
+        (spec) => `proposal ${spec.label} dirty base\n`,
+      );
+      const candidates = proposalSpecs.map(
+        (spec) => `proposal ${spec.label} reviewed candidate\n`,
+      );
+      const fillers = Array.from({ length: 509 }, (_, index) => {
+        const content = `filler ${index}\n`;
+        return {
+          path: join(
+            workspaceRoot,
+            relativePathOfLength(590, `filler-${index}`),
+          ),
+          bufferHandle: index + 4,
+          changedtick: 1,
+          contentSha256: sha256(content),
+          dirty: true as const,
+          content,
+        };
+      });
+      const buffers = [
+        ...paths.map((path, index) => ({
+          path,
+          bufferHandle: index + 1,
+          changedtick: 1,
+          contentSha256: sha256(bases[index]!),
+          dirty: true as const,
+          content: bases[index]!,
+        })),
+        ...fillers,
+      ];
+      const seed = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const seedLease = seed.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-cap-boundary-seed",
+      });
+      seed.sync({
+        workspaceRoot,
+        editorInstanceId: seedLease.editorInstanceId,
+        leaseToken: seedLease.leaseToken,
+        epoch: seedLease.epoch,
+        sequence: 0,
+        buffers,
+      });
+      await seed.flushQuarantinePersistence();
+      const quarantinePath = workspaceMutationStatePath(
+        workspaceRoot,
+        agencHome,
+        "quarantine-v1.json",
+      );
+      const saturatedSnapshot = JSON.parse(
+        await readFile(quarantinePath, "utf8"),
+      ) as Record<string, unknown>;
+      saturatedSnapshot.proposalReceipts = Array.from(
+        { length: 510 },
+        (_, index) => ({
+          proposalId: `legacy-receipt-${index}`,
+          action: "discarded",
+          path: join(workspaceRoot, "receipt.ts"),
+        }),
+      );
+      const serializedSaturatedSnapshot = `${JSON.stringify(saturatedSnapshot)}\n`;
+      expect(
+        Buffer.byteLength(serializedSaturatedSnapshot, "utf8"),
+      ).toBeLessThan(524_288);
+      await writeFile(quarantinePath, serializedSaturatedSnapshot, "utf8");
+
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-cap-boundary",
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers,
+      });
+      const first = await coordinator.prepareMutation({
+        path: paths[0]!,
+        source: "file_edit",
+        beforeText: bases[0]!,
+        afterText: candidates[0]!,
+      });
+      const second = await coordinator.prepareMutation({
+        path: paths[1]!,
+        source: "file_edit",
+        beforeText: bases[1]!,
+        afterText: candidates[1]!,
+      });
+      if (first.decision !== "proposal" || second.decision !== "proposal") {
+        throw new Error("expected the first two proposals to fit");
+      }
+      // A projection that resolves every other proposal before checking the
+      // target incorrectly sees their removed commitments as free space and
+      // admits C. The monotone envelope must retain that cumulative growth.
+      await expect(
+        coordinator.prepareMutation({
+          path: paths[2]!,
+          source: "file_edit",
+          beforeText: bases[2]!,
+          afterText: candidates[2]!,
+        }),
+      ).rejects.toMatchObject({ code: "INVALID_EDITOR_SYNC" });
+
+      await expect(
+        coordinator.applyProposal({
+          ...leaseInput,
+          proposalId: first.proposal.proposalId,
+          changedtick: 2,
+          contentSha256: sha256(candidates[0]!),
+          content: candidates[0]!,
+        }),
+      ).resolves.toMatchObject({
+        applied: true,
+        proposalId: first.proposal.proposalId,
+      });
+      const restarted = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const restartedLease = restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-cap-boundary-restart",
+      });
+      await expect(
+        restarted.discardProposalForEditor({
+          workspaceRoot,
+          editorInstanceId: restartedLease.editorInstanceId,
+          leaseToken: restartedLease.leaseToken,
+          epoch: restartedLease.epoch,
+          proposalId: second.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        discarded: true,
+        proposalId: second.proposal.proposalId,
+      });
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "rejects Editor sync growth that would strand an existing proposal terminal",
+    async () => {
+      const workspaceRoot = await mkdtemp("/tmp/agenc-capmulti-root-");
+      const agencHome = await mkdtemp("/tmp/agenc-capmulti-home-");
+      temporaryPaths.push(workspaceRoot, agencHome);
+      const proposalPath = join(
+        workspaceRoot,
+        relativePathOfLength(3_400, "proposal-a"),
+      );
+      const shortCleanPath = join(
+        workspaceRoot,
+        relativePathOfLength(12, "short-clean"),
+      );
+      const grownCleanPath = join(
+        workspaceRoot,
+        relativePathOfLength(600, "grown-clean"),
+      );
+      const proposalBase = "proposal A dirty base\n";
+      const cleanBase = "clean disk revision\n";
+      const otherBuffers = Array.from({ length: 510 }, (_, index) => {
+        const content = `other dirty base ${index}\n`;
+        if (index === 0) {
+          return {
+            path: join(
+              workspaceRoot,
+              relativePathOfLength(748, `other-${index}`),
+            ),
+            bufferHandle: index + 3,
+            changedtick: 1,
+            contentSha256: sha256(content),
+            contentBytes: Buffer.byteLength(content, "utf8"),
+            dirty: false as const,
+          };
+        }
+        return {
+          path: join(
+            workspaceRoot,
+            relativePathOfLength(748, `other-${index}`),
+          ),
+          bufferHandle: index + 3,
+          changedtick: 1,
+          contentSha256: sha256(content),
+          dirty: true as const,
+          content,
+        };
+      });
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-cap-boundary",
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      const proposalBuffer = {
+        path: proposalPath,
+        bufferHandle: 1,
+        changedtick: 1,
+        contentSha256: sha256(proposalBase),
+        dirty: true as const,
+        content: proposalBase,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          proposalBuffer,
+          {
+            path: shortCleanPath,
+            bufferHandle: 2,
+            changedtick: 1,
+            contentSha256: sha256(cleanBase),
+            contentBytes: Buffer.byteLength(cleanBase, "utf8"),
+            dirty: false,
+          },
+          ...otherBuffers,
+        ],
+      });
+
+      const admission = await coordinator.prepareMutation({
+        path: proposalPath,
+        source: "file_edit",
+        beforeText: proposalBase,
+        afterText: "proposal A candidate\n",
+      });
+      if (admission.decision !== "proposal") {
+        throw new Error("expected proposal A to fit before Editor sync growth");
+      }
+
+      await expect(
+        coordinator.prepareMutation({
+          path: proposalPath,
+          source: "file_edit",
+          beforeText: "stale planner input\n",
+          afterText: "blocked replacement\n",
+        }),
+      ).resolves.toMatchObject({
+        decision: "blocked",
+        code: "STALE_EDITOR_BUFFER",
+      });
+      await expect(
+        coordinator.reserveEditorTopologyMutation({
+          ...leaseInput,
+          targets: [
+            {
+              path: otherBuffers[0]!.path,
+              allowOwnedClean: true,
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ code: "EDITOR_LEASE_MISMATCH" });
+      await expect(
+        coordinator.prepareMutation({
+          path: join(
+            workspaceRoot,
+            relativePathOfLength(120, "pending-disk-effect"),
+          ),
+          source: "file_write",
+          beforeText: "",
+          afterText: "disk replacement\n",
+        }),
+      ).rejects.toMatchObject({ code: "INVALID_EDITOR_SYNC" });
+
+      expect(() =>
+        coordinator.sync({
+          ...leaseInput,
+          sequence: 1,
+          buffers: [
+            proposalBuffer,
+            {
+              path: grownCleanPath,
+              bufferHandle: 2,
+              changedtick: 2,
+              contentSha256: sha256(cleanBase),
+              contentBytes: Buffer.byteLength(cleanBase, "utf8"),
+              dirty: false,
+            },
+            ...otherBuffers,
+          ],
+        }),
+      ).toThrowError(expect.objectContaining({ code: "INVALID_EDITOR_SYNC" }));
+      await coordinator.flushQuarantinePersistence();
+      const restarted = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const restartedLease = restarted.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-after-capacity-restart",
+      });
+      const restartedLeaseInput = {
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+      };
+      await expect(
+        restarted.proposalStatus({
+          ...restartedLeaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        status: "committed",
+        proposalId: admission.proposal.proposalId,
+      });
+      await expect(
+        restarted.discardProposalForEditor({
+          ...restartedLeaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({
+        discarded: true,
+        proposalId: admission.proposal.proposalId,
+      });
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "falls back to a scoped topology invalidation when exact contention cannot fit quarantine",
+    async () => {
+      const workspaceRoot = await mkdtemp("/tmp/agenc-capmulti-root-");
+      const agencHome = await mkdtemp("/tmp/agenc-capmulti-home-");
+      temporaryPaths.push(workspaceRoot, agencHome);
+      const shortCleanPath = join(
+        workspaceRoot,
+        relativePathOfLength(12, "short-clean"),
+      );
+      const topologyRoot = join(workspaceRoot, "newdir");
+      const contendedPath = join(
+        topologyRoot,
+        relativePathOfLength(300 - "newdir/".length, "contended"),
+      );
+      expect(contendedPath.slice(workspaceRoot.length + 1).length).toBe(300);
+      const cleanContent = "clean disk revision\n";
+      const dirtyBuffers = Array.from({ length: 511 }, (_, index) => {
+        const content = `topology dirty base ${index}\n`;
+        return {
+          path: join(
+            workspaceRoot,
+            relativePathOfLength(784, `dirty-${index}`),
+          ),
+          bufferHandle: index + 2,
+          changedtick: 1,
+          contentSha256: sha256(content),
+          dirty: true as const,
+          content,
+        };
+      });
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: "editor-cap-boundary",
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path: shortCleanPath,
+            bufferHandle: 1,
+            changedtick: 1,
+            contentSha256: sha256(cleanContent),
+            contentBytes: Buffer.byteLength(cleanContent, "utf8"),
+            dirty: false,
+          },
+          ...dirtyBuffers,
+        ],
+      });
+      const token = await coordinator.reserveTopologyMutation([
+        { path: topologyRoot, includeDescendants: true },
+      ]);
+      await coordinator.flushQuarantinePersistence();
+
+      expect(() =>
+        coordinator.sync({
+          ...leaseInput,
+          sequence: 1,
+          buffers: [
+            {
+              path: contendedPath,
+              bufferHandle: 1,
+              changedtick: 2,
+              contentSha256: sha256(cleanContent),
+              contentBytes: Buffer.byteLength(cleanContent, "utf8"),
+              dirty: false,
+            },
+            ...dirtyBuffers,
+          ],
+        }),
+      ).toThrowError(
+        expect.objectContaining({ code: "EDITOR_LEASE_MISMATCH" }),
+      );
+      await expect(
+        coordinator.flushQuarantinePersistence(),
+      ).resolves.toBeUndefined();
+      const quarantinePath = workspaceMutationStatePath(
+        workspaceRoot,
+        agencHome,
+        "quarantine-v1.json",
+      );
+      const boundedQuarantine = JSON.parse(
+        await readFile(quarantinePath, "utf8"),
+      ) as {
+        readonly topologyIntents?: readonly {
+          readonly tokenId?: string;
+          readonly source?: string;
+          readonly targets?: readonly unknown[];
+          readonly contentions?: readonly unknown[];
+        }[];
+      };
+      expect(boundedQuarantine.topologyIntents?.[0]?.contentions).toEqual([]);
+      const persistedIntent = boundedQuarantine.topologyIntents?.[0];
+      if (persistedIntent === undefined) {
+        throw new Error("expected a durable topology intent");
+      }
+      const legacySnapshot = {
+        ...boundedQuarantine,
+        topologyIntents: [
+          {
+            ...persistedIntent,
+            contentions: [
+              { path: contendedPath, beforeSha256: sha256(cleanContent) },
+            ],
+          },
+        ],
+      };
+      const serializedLegacySnapshot = `${JSON.stringify(legacySnapshot)}\n`;
+      expect(
+        Buffer.byteLength(serializedLegacySnapshot, "utf8"),
+      ).toBeLessThanOrEqual(524_288);
+      await writeFile(quarantinePath, serializedLegacySnapshot, "utf8");
+      const migrated = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+      });
+      await migrated.flushQuarantinePersistence();
+      const repaired = JSON.parse(await readFile(quarantinePath, "utf8")) as {
+        readonly topologyIntents?: readonly {
+          readonly contentions?: readonly unknown[];
+        }[];
+      };
+      expect(repaired.topologyIntents?.[0]?.contentions).toEqual([]);
+      await expect(
+        coordinator.completeTopologyMutation(token, "applied"),
+      ).resolves.toBeUndefined();
+      expect(coordinator.listChanges(leaseInput).changes).toContainEqual(
+        expect.objectContaining({
+          kind: "topology",
+          topologyTokenId: token.tokenId,
+          path: topologyRoot,
+          includeDescendants: true,
+          status: "applied",
+        }),
+      );
+    },
+  );
+
+  it("widens duplicate topology targets before removing descendant scopes", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-topology-target-normalization-workspace-",
+    );
+    const agencHome = await tempDirectory(
+      "agenc-topology-target-normalization-home-",
+    );
+    const directory = join(workspaceRoot, "tree");
+    const child = join(directory, "child");
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+    });
+
+    for (const duplicateOrder of [
+      [
+        { path: directory, includeDescendants: false },
+        { path: directory, includeDescendants: true },
+      ],
+      [
+        { path: directory, includeDescendants: true },
+        { path: directory, includeDescendants: false },
+      ],
+    ]) {
+      const token = await coordinator.reserveTopologyMutation([
+        ...duplicateOrder,
+        { path: child, includeDescendants: true },
+      ]);
+      expect(token.targets).toEqual([
+        { path: directory, includeDescendants: true },
+      ]);
+      await coordinator.releaseTopologyMutation(token);
+    }
+  });
+
+  it("drains one proposal terminal audit before resolving an unrelated proposal", async () => {
+    const workspaceRoot = await tempDirectory(
+      "agenc-proposal-shared-audit-fence-workspace-",
+    );
+    const agencHome = await tempDirectory(
+      "agenc-proposal-shared-audit-fence-home-",
+    );
+    const firstPath = join(workspaceRoot, "first-reviewable.ts");
+    const secondPath = join(workspaceRoot, "second-terminal.ts");
+    const firstBase = "first dirty base\n";
+    const secondBase = "second dirty base\n";
+    await writeFile(firstPath, firstBase, "utf8");
+    await writeFile(secondPath, secondBase, "utf8");
+
+    let projectionAvailable = false;
+    const projectedProposalIds: string[] = [];
+    const coordinator = new WorkspaceMutationCoordinator({
+      workspaceRoot,
+      agencHome,
+      appendLedgerOnce: async (entries) => {
+        if (!projectionAvailable) {
+          throw new Error("audit projection is offline");
+        }
+        for (const entry of entries) {
+          if (entry.proposalId !== undefined) {
+            projectedProposalIds.push(entry.proposalId);
+          }
+        }
+      },
+    });
+    const lease = coordinator.acquire({
+      workspaceRoot,
+      editorInstanceId: "editor-with-shared-audit-fence",
+    });
+    const leaseInput = {
+      workspaceRoot,
+      editorInstanceId: lease.editorInstanceId,
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    };
+    coordinator.sync({
+      ...leaseInput,
+      sequence: 0,
+      buffers: [
+        {
+          path: firstPath,
+          bufferHandle: 114,
+          changedtick: 1,
+          contentSha256: sha256(firstBase),
+          dirty: true,
+          content: firstBase,
+        },
+        {
+          path: secondPath,
+          bufferHandle: 115,
+          changedtick: 1,
+          contentSha256: sha256(secondBase),
+          dirty: true,
+          content: secondBase,
+        },
+      ],
+    });
+    const firstAdmission = await coordinator.prepareMutation({
+      path: firstPath,
+      source: "file_edit",
+      beforeText: firstBase,
+      afterText: "first proposal candidate\n",
+    });
+    const secondAdmission = await coordinator.prepareMutation({
+      path: secondPath,
+      source: "file_edit",
+      beforeText: secondBase,
+      afterText: "second proposal candidate\n",
+    });
+    if (
+      firstAdmission.decision !== "proposal" ||
+      secondAdmission.decision !== "proposal"
+    ) {
+      throw new Error("expected two editor proposals");
+    }
+
+    await expect(
+      coordinator.discardProposalForEditor({
+        ...leaseInput,
+        proposalId: secondAdmission.proposal.proposalId,
+      }),
+    ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+    await expect(
+      coordinator.proposalStatus({
+        ...leaseInput,
+        proposalId: secondAdmission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({ status: "discarded" });
+
+    await expect(
+      coordinator.discardProposalForEditor({
+        ...leaseInput,
+        proposalId: firstAdmission.proposal.proposalId,
+      }),
+    ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+    await expect(
+      coordinator.proposalStatus({
+        ...leaseInput,
+        proposalId: firstAdmission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({ status: "reviewable" });
+
+    const fenced = JSON.parse(
+      await readFile(
+        workspaceMutationStatePath(
+          workspaceRoot,
+          agencHome,
+          "quarantine-v1.json",
+        ),
+        "utf8",
+      ),
+    ) as {
+      readonly proposalCommitments?: readonly {
+        readonly proposalId?: string;
+      }[];
+      readonly proposalReceipts?: readonly { readonly proposalId?: string }[];
+      readonly auditOutbox?: readonly { readonly proposalId?: string }[];
+    };
+    expect(fenced.proposalCommitments).toEqual([
+      expect.objectContaining({
+        proposalId: firstAdmission.proposal.proposalId,
+      }),
+    ]);
+    expect(fenced.proposalReceipts).toEqual([
+      expect.objectContaining({
+        proposalId: secondAdmission.proposal.proposalId,
+      }),
+    ]);
+    expect(fenced.auditOutbox).toEqual([
+      expect.objectContaining({
+        proposalId: secondAdmission.proposal.proposalId,
+      }),
+    ]);
+
+    projectionAvailable = true;
+    await expect(
+      coordinator.discardProposalForEditor({
+        ...leaseInput,
+        proposalId: firstAdmission.proposal.proposalId,
+      }),
+    ).resolves.toMatchObject({
+      discarded: true,
+      proposalId: firstAdmission.proposal.proposalId,
+    });
+    expect(projectedProposalIds).toEqual([
+      secondAdmission.proposal.proposalId,
+      firstAdmission.proposal.proposalId,
+    ]);
+  });
+
+  it.each(["ordinary", "editor"] as const)(
+    "fences %s topology reservation behind a pending proposal terminal audit",
+    async (reservationKind) => {
+      const workspaceRoot = await tempDirectory(
+        `agenc-topology-audit-fence-${reservationKind}-workspace-`,
+      );
+      const agencHome = await tempDirectory(
+        `agenc-topology-audit-fence-${reservationKind}-home-`,
+      );
+      const proposalPath = join(workspaceRoot, "proposal.ts");
+      const topologyPath = join(workspaceRoot, "topology-target.ts");
+      const base = "dirty proposal base\n";
+      await writeFile(proposalPath, base, "utf8");
+      await writeFile(topologyPath, "topology disk state\n", "utf8");
+
+      let projectionAvailable = false;
+      const coordinator = new WorkspaceMutationCoordinator({
+        workspaceRoot,
+        agencHome,
+        appendLedgerOnce: async () => {
+          if (!projectionAvailable) {
+            throw new Error("audit projection is offline");
+          }
+        },
+      });
+      const lease = coordinator.acquire({
+        workspaceRoot,
+        editorInstanceId: `editor-topology-audit-${reservationKind}`,
+      });
+      const leaseInput = {
+        workspaceRoot,
+        editorInstanceId: lease.editorInstanceId,
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+      };
+      coordinator.sync({
+        ...leaseInput,
+        sequence: 0,
+        buffers: [
+          {
+            path: proposalPath,
+            bufferHandle: 116,
+            changedtick: 1,
+            contentSha256: sha256(base),
+            dirty: true,
+            content: base,
+          },
+        ],
+      });
+      const admission = await coordinator.prepareMutation({
+        path: proposalPath,
+        source: "file_edit",
+        beforeText: base,
+        afterText: "proposal candidate\n",
+      });
+      if (admission.decision !== "proposal") {
+        throw new Error("expected an editor proposal");
+      }
+      await expect(
+        coordinator.discardProposalForEditor({
+          ...leaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).rejects.toMatchObject({ code: "MUTATION_AUDIT_FAILED" });
+
+      const reserve = () =>
+        reservationKind === "ordinary"
+          ? coordinator.reserveTopologyMutation([{ path: topologyPath }])
+          : coordinator.reserveEditorTopologyMutation({
+              ...leaseInput,
+              targets: [{ path: topologyPath }],
+              source: "editor",
+            });
+      await expect(reserve()).rejects.toMatchObject({
+        code: "MUTATION_AUDIT_FAILED",
+      });
+
+      projectionAvailable = true;
+      const token = await reserve();
+      await coordinator.releaseTopologyMutation(token);
+      await expect(
+        coordinator.proposalStatus({
+          ...leaseInput,
+          proposalId: admission.proposal.proposalId,
+        }),
+      ).resolves.toMatchObject({ status: "discarded" });
+    },
+  );
+
   it("keeps every admitted unresolved proposal discoverable and discardable after restart", async () => {
     const workspaceRoot = await tempDirectory(
       "agenc-proposal-discovery-capacity-",
@@ -2979,8 +6650,13 @@ describe("WorkspaceMutationCoordinator", () => {
     const coordinator = new WorkspaceMutationCoordinator({
       workspaceRoot,
       agencHome,
-      appendLedger: async (entry) => {
-        if (entry.status === "applied" && entry.proposalId !== undefined) {
+      appendLedgerOnce: async (entries) => {
+        if (
+          entries.some(
+            (entry) =>
+              entry.status === "applied" && entry.proposalId !== undefined,
+          )
+        ) {
           reportAppliedAppend();
           await appliedAppendGate;
         }
@@ -3074,8 +6750,13 @@ describe("WorkspaceMutationCoordinator", () => {
     const coordinator = new WorkspaceMutationCoordinator({
       workspaceRoot,
       agencHome,
-      appendLedger: async (entry) => {
-        if (entry.status === "applied" && entry.proposalId !== undefined) {
+      appendLedgerOnce: async (entries) => {
+        if (
+          entries.some(
+            (entry) =>
+              entry.status === "applied" && entry.proposalId !== undefined,
+          )
+        ) {
           reportAppliedAppend();
           await appliedAppendGate;
         }
@@ -3811,7 +7492,7 @@ describe("filesystem-tool editor coherence", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("changed files on disk");
     expect(result.content).toContain(
-      "2 workspace audit outcome(s) are unknown",
+      "3 workspace audit outcome(s) are unknown",
     );
     expect(await readFile(firstPath, "utf8")).toBe(firstAfter);
     expect(await readFile(secondPath, "utf8")).toBe(secondAfter);
@@ -3851,7 +7532,7 @@ describe("filesystem-tool editor coherence", () => {
           },
         ],
       }),
-    ).not.toThrow();
+    ).toThrow(/path operation is committing/u);
   });
 
   it("returns honest Write and NotebookEdit errors when bytes changed but auditing failed", async () => {
@@ -4395,6 +8076,27 @@ describe("filesystem-tool editor coherence", () => {
     expect(
       await readFile(join(destination, "nested", "clean.ts"), "utf8"),
     ).toBe(diskContent);
+    const delivered = coordinator.listChanges({
+      workspaceRoot,
+      editorInstanceId: "editor-a",
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    });
+    expect(delivered.changes).toContainEqual(
+      expect.objectContaining({
+        kind: "topology",
+        status: "applied",
+      }),
+    );
+    expect(
+      coordinator.listChanges({
+        workspaceRoot,
+        editorInstanceId: "editor-a",
+        leaseToken: lease.leaseToken,
+        epoch: lease.epoch,
+        afterSequence: delivered.sequence,
+      }).changes,
+    ).toEqual([]);
     const unloadedDelete = await deleteTool.execute({
       path: destination,
       recursive: true,
@@ -5004,12 +8706,52 @@ describe("filesystem-tool editor coherence", () => {
         buffers: [],
         status: "unknown_outcome",
       }),
+    ).rejects.toThrow(/does not belong/u);
+    await expect(
+      restarted.resolveRecoveredEditorTopologyMutation({
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+        tokenId: token.tokenId,
+        sequence: 0,
+        buffers: [],
+      }),
     ).resolves.toMatchObject({
-      completed: true,
+      resolved: true,
       tokenId: token.tokenId,
       status: "unknown_outcome",
       sync: { accepted: true, sequence: 0 },
     });
+    const delivered = restarted.listChanges({
+      workspaceRoot,
+      editorInstanceId: restartedLease.editorInstanceId,
+      leaseToken: restartedLease.leaseToken,
+      epoch: restartedLease.epoch,
+    });
+    expect(delivered.changes).toContainEqual(
+      expect.objectContaining({
+        kind: "topology",
+        topologyTokenId: token.tokenId,
+        path: directory,
+        includeDescendants: true,
+        status: "unknown_outcome",
+      }),
+    );
+    await expect(
+      restarted.reserveTopologyMutation([
+        { path: directory, includeDescendants: true },
+      ]),
+    ).rejects.toMatchObject({ code: "EDITOR_LEASE_MISMATCH" });
+    expect(
+      restarted.listChanges({
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+        afterSequence: delivered.sequence,
+      }).changes,
+    ).toEqual([]);
     await expect(
       restarted.reserveTopologyMutation([
         { path: directory, includeDescendants: true },
@@ -5106,6 +8848,8 @@ describe("filesystem-tool editor coherence", () => {
       restarted.resolveRecoveredEditorTopologyMutation({
         ...leaseInput,
         tokenId: "not-the-durable-token",
+        sequence: 0,
+        buffers: [],
       }),
     ).rejects.toThrow(/not a durable orphan/u);
 
@@ -5113,11 +8857,14 @@ describe("filesystem-tool editor coherence", () => {
       restarted.resolveRecoveredEditorTopologyMutation({
         ...leaseInput,
         tokenId: token.tokenId,
+        sequence: 0,
+        buffers: [],
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       resolved: true,
       tokenId: token.tokenId,
       status: "unknown_outcome",
+      sync: { accepted: true, sequence: 0 },
     });
     expect(restarted.listRecoveredEditorTopologyMutations(leaseInput)).toEqual(
       [],
@@ -5666,7 +9413,7 @@ describe("filesystem-tool editor coherence", () => {
       restarted.reserveTopologyMutation([
         { path: directory, includeDescendants: true },
       ]),
-    ).rejects.toThrow(/overlapping workspace path operation/u);
+    ).rejects.toThrow(/recovered path fences/u);
     expect(
       restarted.listChanges({
         workspaceRoot,
@@ -5682,14 +9429,13 @@ describe("filesystem-tool editor coherence", () => {
     );
 
     await restarted.completeTopologyMutation(reservation, "unknown_outcome");
-    expect(
-      restarted.listChanges({
-        workspaceRoot,
-        editorInstanceId: restartedLease.editorInstanceId,
-        leaseToken: restartedLease.leaseToken,
-        epoch: restartedLease.epoch,
-      }).changes,
-    ).toContainEqual(
+    const delivered = restarted.listChanges({
+      workspaceRoot,
+      editorInstanceId: restartedLease.editorInstanceId,
+      leaseToken: restartedLease.leaseToken,
+      epoch: restartedLease.epoch,
+    });
+    expect(delivered.changes).toContainEqual(
       expect.objectContaining({
         path,
         source: "rewind",
@@ -5698,6 +9444,15 @@ describe("filesystem-tool editor coherence", () => {
         afterSha256: sha256(after),
       }),
     );
+    expect(
+      restarted.listChanges({
+        workspaceRoot,
+        editorInstanceId: restartedLease.editorInstanceId,
+        leaseToken: restartedLease.leaseToken,
+        epoch: restartedLease.epoch,
+        afterSequence: delivered.sequence,
+      }).changes,
+    ).toEqual([]);
     await restarted.flushQuarantinePersistence();
     const afterReconciliation = await restarted.prepareMutation({
       path,
@@ -5767,7 +9522,7 @@ describe("filesystem-tool editor coherence", () => {
     });
   });
 
-  it("keeps a topology fence and its durable intent when reload delivery is full", async () => {
+  it("uses a scoped topology invalidation when exact reload delivery is full", async () => {
     const workspaceRoot = await tempDirectory("agenc-coherence-workspace-");
     const agencHome = await tempDirectory("agenc-coherence-home-");
     const coordinator = new WorkspaceMutationCoordinator({
@@ -5834,7 +9589,7 @@ describe("filesystem-tool editor coherence", () => {
     );
     await coordinator.flushQuarantinePersistence();
     expect(() => syncPath(secondPath, secondContent)).toThrow(
-      /pending workspace change queue/u,
+      /path operation is committing/u,
     );
     await coordinator.flushQuarantinePersistence();
     const quarantine = JSON.parse(
@@ -5855,13 +9610,33 @@ describe("filesystem-tool editor coherence", () => {
       quarantine.topologyIntents?.[0]?.contentions?.map(
         (contention) => contention.path,
       ),
-    ).toEqual([firstPath, secondPath]);
+    ).toEqual([]);
     await expect(
       coordinator.completeTopologyMutation(reservation, "applied"),
-    ).rejects.toThrow(/pending workspace change queue/u);
-    expect(() => syncPath(firstPath, firstContent)).toThrow(
-      /path operation is committing/u,
+    ).resolves.toBeUndefined();
+    const delivered = coordinator.listChanges({
+      workspaceRoot,
+      editorInstanceId: "full-delivery-editor",
+      leaseToken: lease.leaseToken,
+      epoch: lease.epoch,
+    });
+    expect(delivered.changes).toContainEqual(
+      expect.objectContaining({
+        kind: "topology",
+        topologyTokenId: reservation.tokenId,
+        path: directory,
+        includeDescendants: true,
+        status: "applied",
+      }),
     );
+    await expect(
+      coordinator.prepareMutation({
+        path: firstPath,
+        source: "file_write",
+        beforeText: firstContent,
+        afterText: "stale provider write\n",
+      }),
+    ).rejects.toThrow(/acknowledges the completed workspace path operation/u);
   });
 
   it("declares every editor-coherence RPC as an internal capability", () => {


### PR DESCRIPTION
## Summary

- Restore fresh Editor navigation through the documented Alt+H shortcut and keep Neovim input live through retryable workspace-capture races.
- Add exact, user-reviewable recovery for orphaned Editor revisions so stale authority can be refreshed or reconciled without unsafe shell and file access.
- Fix descriptor-bound partial FileRead failures caused by mixed BigInt and number arithmetic.
- Make Editor recovery, topology finalization, and proposal decisions crash-safe, capacity-bounded, permanently audited, and protocol-version gated.

## Safety and compatibility

- Bumps the daemon protocol to 1.1.0 while retaining 1.0 client negotiation; the new manifest-bearing recovery capability is advertised only to 1.1 clients.
- Recovery uses exact fingerprints, double confirmation, provider path locks, descriptor verification, durable audit outboxes, and target-scoped write fences.
- Legacy quarantine snapshots migrate conservatively and remain fail-closed when they cannot be repaired safely.
- No user configuration migration is required.

## Verification

- Runtime typecheck, test-support typecheck, build, package entrypoints, SDK drift, and real-PTY startup: passed.
- Conflict-sensitive Editor, daemon, FileRead, and Neovim tests: 449/449 passed.
- Mutation coordinator 115/115, Editor synchronizer 51/51, dispatcher contracts 31/31.
- Embedded Neovim gate 7/7; exact E2E scenarios 120 and 132 passed after rebase.
- Agent surface contract and SDK typecheck passed.
- Full host runtime suite: 18,809 passed; the five remaining failures are existing clean-main failures (dirty-tree benchmark refusal, stale FND baseline hash, and three full-corpus-index failures).
- The Docker-isolated umbrella runtime gate could not start because this account lacks permission to access /var/run/docker.sock; its host-functional fallback and all changed-path gates were run directly.