### PR TITLE
Add identity-safe turn admission and transcript snapshots

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -13,7 +13,7 @@ Architecture map: [`../ARCHITECTURE.md`](../ARCHITECTURE.md). Embedding API:
 | ----------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
 | Launcher    | `packages/agenc` (`@tetsuo-ai/agenc`) | Installs `agenc`, ensures runtime tarball, optional daemon autostart, execs runtime |
 | Daemon      | `runtime/src/app-server`              | Owns sessions, agents, tools, permissions, health, recovery                         |
-| Runtime CLI | `runtime/bin/agenc`                   | Subcommands including `daemon start                                                 | stop | status | reload | restart` |
+| Runtime CLI | `runtime/bin/agenc`                   | Daemon subcommands for start, stop, status, reload, and restart                     |
 
 Autostart is **on by default**. Disable with:
 

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -9,11 +9,11 @@ Architecture map: [`../ARCHITECTURE.md`](../ARCHITECTURE.md). Embedding API:
 
 ## Process ownership
 
-| Piece | Package / path | Role |
-| --- | --- | --- |
-| Launcher | `packages/agenc` (`@tetsuo-ai/agenc`) | Installs `agenc`, ensures runtime tarball, optional daemon autostart, execs runtime |
-| Daemon | `runtime/src/app-server` | Owns sessions, agents, tools, permissions, health, recovery |
-| Runtime CLI | `runtime/bin/agenc` | Subcommands including `daemon start|stop|status|reload|restart` |
+| Piece       | Package / path                        | Role                                                                                |
+| ----------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
+| Launcher    | `packages/agenc` (`@tetsuo-ai/agenc`) | Installs `agenc`, ensures runtime tarball, optional daemon autostart, execs runtime |
+| Daemon      | `runtime/src/app-server`              | Owns sessions, agents, tools, permissions, health, recovery                         |
+| Runtime CLI | `runtime/bin/agenc`                   | Subcommands including `daemon start                                                 | stop | status | reload | restart` |
 
 Autostart is **on by default**. Disable with:
 
@@ -24,9 +24,9 @@ AGENC_DAEMON_AUTOSTART=0
 Ready-wait timeout for clients that start the daemon
 (`AGENC_DAEMON_READY_TIMEOUT_MS`):
 
-| Client | Default |
-| --- | --- |
-| Published launcher (`packages/agenc`) | **2000** ms |
+| Client                                                         | Default      |
+| -------------------------------------------------------------- | ------------ |
+| Published launcher (`packages/agenc`)                          | **2000** ms  |
 | Runtime daemon autostart / `agenc daemon` / SDK socket connect | **45000** ms |
 
 ```bash
@@ -61,14 +61,14 @@ Packaging units under `packaging/` (systemd, launchd, Windows service) run
 
 ## Files under `AGENC_HOME` (default `~/.agenc`)
 
-| File | Mode / notes |
-| --- | --- |
-| `daemon.sock` | Unix domain socket path clients connect to; Windows uses a stable per-home named pipe instead |
-| `daemon.cookie` | Shared secret; cookie auth for local clients |
-| `daemon.pid` | Detached process id |
-| `daemon.log` | Size-capped log sink |
-| `daemon-snapshot.json` | Lifecycle / recovery snapshot |
-| runtime-info files | Version/path metadata for attach and doctor |
+| File                   | Mode / notes                                                                                  |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `daemon.sock`          | Unix domain socket path clients connect to; Windows uses a stable per-home named pipe instead |
+| `daemon.cookie`        | Shared secret; cookie auth for local clients                                                  |
+| `daemon.pid`           | Detached process id                                                                           |
+| `daemon.log`           | Size-capped log sink                                                                          |
+| `daemon-snapshot.json` | Lifecycle / recovery snapshot                                                                 |
+| runtime-info files     | Version/path metadata for attach and doctor                                                   |
 
 Override home:
 
@@ -86,16 +86,17 @@ export AGENC_HOME=/var/lib/agenc
   defaults to loopback **`ws://127.0.0.1:7766/`** (see
   `AGENC_PORTAL_DEFAULT_LOCAL_DAEMON_ENDPOINT`). Env knobs:
 
-  | Env | Role |
-  | --- | --- |
-  | `AGENC_DAEMON_WEBSOCKET_HOST` | Bind host (default loopback `127.0.0.1`) |
-  | `AGENC_DAEMON_WEBSOCKET_PORT` | Port (default **7766**) |
-  | `AGENC_DAEMON_WEBSOCKET_PATH` | Path (default `/`) |
+  | Env                                        | Role                                                                               |
+  | ------------------------------------------ | ---------------------------------------------------------------------------------- |
+  | `AGENC_DAEMON_WEBSOCKET_HOST`              | Bind host (default loopback `127.0.0.1`)                                           |
+  | `AGENC_DAEMON_WEBSOCKET_PORT`              | Port (default **7766**)                                                            |
+  | `AGENC_DAEMON_WEBSOCKET_PATH`              | Path (default `/`)                                                                 |
   | `AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK` | Set `1` to allow a non-loopback host; otherwise non-loopback binds are **refused** |
 
   Prefer the local socket/named pipe for TUI/CLI; WebSocket is what remote/phone
   and tunnel docs mean by `ws://127.0.0.1:7766`. Implementation:
   `runtime/src/app-server/daemon-cli.ts` + `transport/`.
+
 - Config block `[daemon]` defaults: `transport = "unix"`, `autostart = true`
   (`runtime/src/config/schema.ts`).
 
@@ -109,7 +110,7 @@ const client = await connect(); // socket + cookie under AGENC_HOME
 ## Protocol
 
 - Envelope: **JSON-RPC 2.0** over newline-delimited messages.
-- Protocol version constant: **`1.1.0`**
+- Protocol version constant: **`1.2.0`**
   (`AGENC_DAEMON_PROTOCOL_VERSION` in `runtime/src/app-server/protocol/index.ts`).
 - Clients send `initialize` with the protocol version. Negotiation compares the
   numeric major and minor versions: the server accepts the same major when the
@@ -117,35 +118,65 @@ const client = await connect(); // socket + cookie under AGENC_HOME
   does not affect compatibility. Malformed versions, different majors, and a
   client minor newer than the server are rejected with
   `PROTOCOL_VERSION_UNSUPPORTED`.
-- Consequently, a 1.1 daemon accepts a 1.0 client, while a current 1.1 TUI is
-  rejected by a still-running 1.0 daemon before it can send the newer Editor
-  recovery fields. Update if necessary, then run `agenc daemon restart` so the
+- Consequently, a 1.2 daemon accepts 1.0 and 1.1 clients, while a client that
+  requires 1.2 is rejected by a still-running 1.0/1.1 daemon. The embedding
+  SDK retries initialization at the reported older server version and uses
+  advertised capabilities for additive fallbacks; Core/TUI callers may still
+  fail closed. Update if necessary, then run `agenc daemon restart` so the
   daemon uses the installed protocol version.
 
 ### Public methods (`AGENC_DAEMON_METHODS`)
 
-| Method | Purpose |
-| --- | --- |
-| `initialize` | Handshake + capability advertisement |
-| `request.cancel` | Cancel an in-flight request |
-| `agent.create` / `agent.list` / `agent.attach` / `agent.stop` / `agent.logs` | Background agents |
-| `run.start` / `run.status` / `run.result` / `run.replay` / `run.evidence` / `run.cancel` | Start a verified-change run; inspect durable state, journal replay/evidence, terminal result, or tree cancellation |
-| `csvJob.review.list` / `csvJob.review.show` / `csvJob.review.resolve` | Inspect and settle durable CSV batch-review items |
-| `session.create` / `session.list` / `session.attach` / `session.detach` | Session lifecycle |
-| `session.terminate` / `session.clear` / `session.snapshot` / `session.transcript` | Session control |
-| `session.cancelTurn` | Abort current turn |
-| `session.resolveToolCall` | Resolve a tool call whose durable outcome requires review |
-| `session.mcp.addServer` | Attach MCP server to a session |
-| `message.send` / `message.stream` | Prompt turns |
-| `thread/realtime/*` | Realtime voice/thread methods |
-| `tool.approve` / `tool.deny` / `tool.cancel` | Permission settlement |
-| `elicitation.respond` | User-input / MCP elicitation reply |
-| `permission.list` | List pending / granted permissions |
-| `fs.fuzzy_search` | Workspace fuzzy file search |
-| `commandExec.start` / `write` / `resize` / `terminate` | Reserved PTY/command-exec protocol; direct starts currently fail closed |
-| `health.ping` / `health.ready` / `health.stats` | Liveness and stats |
-| `daemon.reload` | Reload configuration |
-| `auth.login` / `auth.whoami` / `auth.logout` | Auth backend |
+| Method                                                                                                      | Purpose                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `initialize`                                                                                                | Handshake + capability advertisement                                                                               |
+| `request.cancel`                                                                                            | Cancel an in-flight request                                                                                        |
+| `agent.create` / `agent.list` / `agent.attach` / `agent.stop` / `agent.logs`                                | Background agents                                                                                                  |
+| `run.start` / `run.status` / `run.result` / `run.replay` / `run.evidence` / `run.cancel`                    | Start a verified-change run; inspect durable state, journal replay/evidence, terminal result, or tree cancellation |
+| `csvJob.review.list` / `csvJob.review.show` / `csvJob.review.resolve`                                       | Inspect and settle durable CSV batch-review items                                                                  |
+| `session.create` / `session.list` / `session.attach` / `session.detach`                                     | Session lifecycle                                                                                                  |
+| `session.terminate` / `session.clear` / `session.snapshot` / `session.transcript` / `session.transcript.v2` | Session control and identity-bearing history sync                                                                  |
+| `session.cancelTurn`                                                                                        | Abort the current turn, optionally only when `expectedTurnId` still matches                                        |
+| `session.resolveToolCall`                                                                                   | Resolve a tool call whose durable outcome requires review                                                          |
+| `session.mcp.addServer`                                                                                     | Attach MCP server to a session                                                                                     |
+| `message.send` / `message.stream`                                                                           | Prompt turns                                                                                                       |
+| `thread/realtime/*`                                                                                         | Realtime voice/thread methods                                                                                      |
+| `tool.approve` / `tool.deny` / `tool.cancel`                                                                | Permission settlement                                                                                              |
+| `elicitation.respond`                                                                                       | User-input / MCP elicitation reply                                                                                 |
+| `permission.list`                                                                                           | List pending / granted permissions                                                                                 |
+| `fs.fuzzy_search`                                                                                           | Workspace fuzzy file search                                                                                        |
+| `commandExec.start` / `write` / `resize` / `terminate`                                                      | Reserved PTY/command-exec protocol; direct starts currently fail closed                                            |
+| `health.ping` / `health.ready` / `health.stats`                                                             | Liveness and stats                                                                                                 |
+| `daemon.reload`                                                                                             | Reload configuration                                                                                               |
+| `auth.login` / `auth.whoami` / `auth.logout`                                                                | Auth backend                                                                                                       |
+
+### Race-safe turns and transcript sync (protocol 1.2)
+
+`message.send` and `message.stream` accept a caller-stable
+`clientMessageId`. Reusing it with the same content is idempotent; reusing it
+with different content is rejected. A retry response reports
+`duplicateState: "completed" | "incomplete"` and never invents success for a
+crash tail without a durable terminal event. Callers that require strict
+single-turn admission pass `ifBusy: "reject"`. Without that flag, the legacy
+FIFO/co-driving behavior is unchanged for 1.0/1.1 clients.
+Hidden-user submissions persist a non-rendering `message_submission` marker
+with a SHA-256 content fingerprint, so their idempotency identity also survives
+a process crash without duplicating the hidden prompt in that marker.
+
+`session.transcript.v2` returns `schemaVersion: 2`, `runId`, `historyEpoch`,
+`asOfSequence`, and stable identity-bearing messages. Canonical messages carry
+`messageId`, `commitEventId`, `turnId`/`clientMessageId` when known, and
+`committedSequence`. Migrated `response_item` rows use
+`committedSequence: 0`; this explicitly means they predate the canonical event
+cursor. Compaction, rewind, rollback, and clear each advance `historyEpoch` and
+replace the active projection.
+
+Live notifications carry the same `eventId`, `sequence`, `runId`,
+`historyEpoch`, `turnId`, `clientMessageId`, and `messageId` correlation where
+available. `event.message_chunk` is an assistant delta only; a durable
+`agent_message` is a distinct committed message. Consumers buffer live events
+while loading the snapshot, discard only events at or before
+`asOfSequence` in the same epoch, and resync when the epoch changes.
 
 `session.resolveToolCall` accepts two strict protocol-1.0 request shapes. The
 earlier `{ sessionId, toolCallId?, reviewer? }` shape can settle only a legacy
@@ -271,10 +302,10 @@ Examples: `event.message_chunk`, `event.tool_request`,
 `initialize.capabilities` can opt an authenticated connection into delivery
 outside ordinary session attachment:
 
-| Capability | Behavior |
-| --- | --- |
+| Capability                     | Behavior                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | `portal.mobile.status.push.v1` | Global `event.agent_status` observer feed, deduplicated by physical connection and replayed from bounded session status buffers |
-| `portal.ledger.solana.sign.v1` | Single-consumer `event.user_input_request.clientAction` delivery to the newest capable phone, with bounded live-session replay |
+| `portal.ledger.solana.sign.v1` | Single-consumer `event.user_input_request.clientAction` delivery to the newest capable phone, with bounded live-session replay  |
 
 Generic SDK clients advertise no such capabilities by default. Conversation
 messages and transcripts remain attachment-bound.
@@ -339,16 +370,16 @@ agenc budget status    # cumulative autonomy ledger (not daemon-internal only)
 
 ## Source map
 
-| Concern | Path |
-| --- | --- |
-| CLI | `runtime/src/app-server/daemon-cli.ts` |
-| JSON-RPC dispatch | `runtime/src/app-server/daemon-dispatcher.ts` |
-| Protocol constants | `runtime/src/app-server/protocol/index.ts` |
-| Session lifecycle | `runtime/src/app-server/session-lifecycle.ts` |
-| Agent lifecycle | `runtime/src/app-server/agent-lifecycle.ts` |
-| Background runs | `runtime/src/app-server/background-agent-runner.ts` |
-| Local socket / Windows named pipe | `runtime/src/app-server/transport/unix-socket.ts` |
-| Cookie auth | `runtime/src/app-server/transport/auth.ts` |
-| Health | `runtime/src/app-server/health.ts` |
-| Launcher autostart | `packages/agenc/src/launcher.mjs` |
-| SDK connect | `packages/agenc-sdk/src/socket.ts` |
+| Concern                           | Path                                                |
+| --------------------------------- | --------------------------------------------------- |
+| CLI                               | `runtime/src/app-server/daemon-cli.ts`              |
+| JSON-RPC dispatch                 | `runtime/src/app-server/daemon-dispatcher.ts`       |
+| Protocol constants                | `runtime/src/app-server/protocol/index.ts`          |
+| Session lifecycle                 | `runtime/src/app-server/session-lifecycle.ts`       |
+| Agent lifecycle                   | `runtime/src/app-server/agent-lifecycle.ts`         |
+| Background runs                   | `runtime/src/app-server/background-agent-runner.ts` |
+| Local socket / Windows named pipe | `runtime/src/app-server/transport/unix-socket.ts`   |
+| Cookie auth                       | `runtime/src/app-server/transport/auth.ts`          |
+| Health                            | `runtime/src/app-server/health.ts`                  |
+| Launcher autostart                | `packages/agenc/src/launcher.mjs`                   |
+| SDK connect                       | `packages/agenc-sdk/src/socket.ts`                  |

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -10,14 +10,14 @@ Related: [gateway](gateway.md) · [onboarding](onboarding.md) ·
 
 ## The pieces
 
-| Piece | Role |
-|---|---|
-| **Daemon** | App-server (`agenc daemon start`, default `ws://127.0.0.1:7766`). Hosts coding agents. Local TUI and remote phones are both clients. |
-| **Connector** | `agenc remote on` (or `/remote on` in the TUI). Bridges the loopback daemon to a phone through the relay. Never holds the relay secret; asks the backend for short-lived signed *host tickets*. |
-| **Relay** | Cloudflare Worker + per-room Durable Object ([`tetsuo-ai/agenc-relay`](https://github.com/tetsuo-ai/agenc-relay)). Routes frames by ticket room; each pairing is an isolated room keyed by `pairingId`. |
-| **Backend** | [`tetsuo-ai/agenc-backend`](https://github.com/tetsuo-ai/agenc-backend) (`id.agenc.ag`). Mints every relay ticket (sole holder of `RELAY_TICKET_SECRET`) and runs device-pairing endpoints. |
-| **iOS app** | [`tetsuo-ai/agenc-ios`](https://github.com/tetsuo-ai/agenc-ios). Pairs with code/QR, then connects through the relay. |
-| **Android app** | [`tetsuo-ai/agenc-android`](https://github.com/tetsuo-ai/agenc-android). Remote session control, background completion delivery, and optional Ledger Flex approval over BLE. |
+| Piece           | Role                                                                                                                                                                                                    |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Daemon**      | App-server (`agenc daemon start`, default `ws://127.0.0.1:7766`). Hosts coding agents. Local TUI and remote phones are both clients.                                                                    |
+| **Connector**   | `agenc remote on` (or `/remote on` in the TUI). Bridges the loopback daemon to a phone through the relay. Never holds the relay secret; asks the backend for short-lived signed _host tickets_.         |
+| **Relay**       | Cloudflare Worker + per-room Durable Object ([`tetsuo-ai/agenc-relay`](https://github.com/tetsuo-ai/agenc-relay)). Routes frames by ticket room; each pairing is an isolated room keyed by `pairingId`. |
+| **Backend**     | [`tetsuo-ai/agenc-backend`](https://github.com/tetsuo-ai/agenc-backend) (`id.agenc.ag`). Mints every relay ticket (sole holder of `RELAY_TICKET_SECRET`) and runs device-pairing endpoints.             |
+| **iOS app**     | [`tetsuo-ai/agenc-ios`](https://github.com/tetsuo-ai/agenc-ios). Pairs with code/QR, then connects through the relay.                                                                                   |
+| **Android app** | [`tetsuo-ai/agenc-android`](https://github.com/tetsuo-ai/agenc-android). Remote session control, background completion delivery, and optional Ledger Flex approval over BLE.                            |
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ agenc remote off       # forget this machine's pairing locally
 
 ## Device pairing flow
 
-Production routing pairs by *device*, not by account room:
+Production routing pairs by _device_, not by account room:
 
 1. Sign in on the computer with `/login` or
    `AGENC_AUTH_BACKEND=remote agenc login`. Google OAuth, when configured, is
@@ -91,6 +91,7 @@ Production routing pairs by *device*, not by account room:
    `/v1/pair/start`; Android stores it for `/v1/auth/me`, ticket refresh, and
    later authenticated operations. Legacy app versions may still send their
    bearer to `/v1/pair/claim`; the additive response remains decodable by them.
+
 6. Both sides share one isolated relay room. The QR surface auto-closes when
    the phone connects.
 
@@ -124,11 +125,16 @@ never calls `process.exit` (that would kill the session).
   agent in the daemon; `message.send` (keyed on `sessionId`) drives it; events
   stream back. TUI and phone are both clients.
 - **Co-driving**: the daemon broadcasts session events to every attached
-  client; `message.send` has no per-client lock, so terminal and phone can
-  drive the same live session together.
+  client. Legacy 1.0/1.1 sends retain FIFO co-driving semantics. Protocol 1.2
+  clients that need strict admission send a stable `clientMessageId` with
+  `ifBusy: "reject"`; the daemon then rejects overlap instead of silently
+  queueing it.
 - **Working directory**: create accepts a `cwd` so a client can start a
   session in any project directory.
-- **History on join**: `session.transcript` returns conversation history.
+- **History on join**: `session.transcript` returns legacy conversation
+  history. Protocol 1.2 clients should use `session.transcript.v2`, buffer live
+  events during the read, and merge by `historyEpoch` + `asOfSequence` and
+  stable message/event IDs.
   When no live agent is attached, it falls back to the persisted thread store
   (read-only). A still-running terminal holds an exclusive rollout lock, so
   those `conv-` sessions stay read-only until the terminal exits.
@@ -138,10 +144,10 @@ never calls `process.exit` (that would kill the session).
 After the relay bridge authenticates `initialize`, a phone may advertise
 capabilities in addition to attaching to individual sessions:
 
-| Capability | Delivery semantics |
-| --- | --- |
+| Capability                     | Delivery semantics                                                                                                            |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | `portal.mobile.status.push.v1` | Observer fan-out for global `event.agent_status` frames, including completion while the phone is not attached to that session |
-| `portal.ledger.solana.sign.v1` | Single-consumer typed Ledger action routing to the newest capable phone |
+| `portal.ledger.solana.sign.v1` | Single-consumer typed Ledger action routing to the newest capable phone                                                       |
 
 The daemon registers capability clients during initialize, before any
 `session.attach`. Logical registrations on one physical socket share a delivery
@@ -234,11 +240,11 @@ flag keeps the older, narrower equivalent-rule cache semantics.
 Capabilities are opt-in and old clients continue to use attachment-bound
 events. Deploy Core before relying on Android background status or `@ledger`:
 
-| Combination | Result |
-| --- | --- |
-| New Core + old phone | Existing pairing/chat works; new capabilities are simply absent |
-| Old Core + new phone | Pairing/chat works, but no global status push, typed Ledger action, or all-tools session promotion |
-| New Core + new Android | Full background notification, identity, permission, and Ledger protocol |
+| Combination            | Result                                                                                             |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| New Core + old phone   | Existing pairing/chat works; new capabilities are simply absent                                    |
+| Old Core + new phone   | Pairing/chat works, but no global status push, typed Ledger action, or all-tools session promotion |
+| New Core + new Android | Full background notification, identity, permission, and Ledger protocol                            |
 
 Provider credentials and model execution remain on the host machine. The phone does not
 receive `XAI_API_KEY` or another provider secret.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -12,14 +12,14 @@ npm run build --workspace=@tetsuo-ai/agenc-sdk   # plain tsc → dist/
 
 ## Two transports
 
-| | daemon transport | subprocess transport |
-|---|---|---|
-| entry                | `connect()` → `AgencClient`            | `promptViaSubprocess()`                                           |
+|                      | daemon transport                                    | subprocess transport                                              |
+| -------------------- | --------------------------------------------------- | ----------------------------------------------------------------- |
+| entry                | `connect()` → `AgencClient`                         | `promptViaSubprocess()`                                           |
 | wire                 | JSON-lines over a Unix socket or Windows named pipe | `agenc -p --output-format stream-json --input-format stream-json` |
-| sessions             | persistent, resumable, multi-turn      | one-shot per spawn                                                |
-| permission callbacks | yes (approve or deny live)             | no — CLI auto-denies (exit code 2 = tool-denied giveup)           |
-| background agents    | spawn / attach / stop / logs           | no                                                                |
-| daemon required      | attaches, or starts one via the CLI    | the CLI manages its own daemon                                    |
+| sessions             | persistent, resumable, multi-turn                   | one-shot per spawn                                                |
+| permission callbacks | yes (approve or deny live)                          | no — CLI auto-denies (exit code 2 = tool-denied giveup)           |
+| background agents    | spawn / attach / stop / logs                        | no                                                                |
+| daemon required      | attaches, or starts one via the CLI                 | the CLI manages its own daemon                                    |
 
 Both produce the same typed event iterable (`AgencPromptEvent`) and the same
 final `AgencPromptResult`, so downstream consumption code is shared.
@@ -48,10 +48,15 @@ const run = session.prompt("Summarize this repo's protocol layer.");
 
 for await (const event of run) {
   switch (event.type) {
-    case "text":               process.stdout.write(event.delta); break;
-    case "tool_call":          /* event.toolName, event.input */ break;
-    case "permission_request": /* also routed to onPermissionRequest */ break;
-    case "status":             /* event.runStatus */ break;
+    case "text":
+      process.stdout.write(event.delta);
+      break;
+    case "tool_call":
+      /* event.toolName, event.input */ break;
+    case "permission_request":
+      /* also routed to onPermissionRequest */ break;
+    case "status":
+      /* event.runStatus */ break;
   }
 }
 
@@ -65,7 +70,7 @@ await client.close();
 Key `AgencClient` methods:
 
 - `createSession(params?)` / `resumeSession(sessionId)` → `AgencSession`
-  (`prompt`, `transcript`, `snapshot`, `cancelTurn`, `terminate`)
+  (`prompt`, `transcript`, `transcriptV2`, `snapshot`, `cancelTurn`, `terminate`)
 - `spawnAgent(params)` → background agent (`agent.create`)
 - `attachAgent(agentId)` → `{ attach, session }` for a running agent
 - `listAgents()` / `stopAgent(id)` / `agentLogs(id)`
@@ -74,7 +79,7 @@ Key `AgencClient` methods:
   `{ runId, specDigest, baseCommit, baseDirty }`)
 - `runStatus(id)` / `runResult(id)` / `replayRun(params)` /
   `reattachRun(options)` / `runEvidence(params)` / `cancelRun(id, reason?)`
-- `request(method, params)` → raw typed JSON-RPC for any of the **51** daemon methods
+- `request(method, params)` → raw typed JSON-RPC for any of the **52** daemon methods
 - `onNotification(cb)` / `onSessionNotification(sessionId, cb)` → raw events
 
 Permission requests with no registered handler are **denied** (never granted)
@@ -99,6 +104,23 @@ capability option must remain opt-in and bind delivery to a concrete handler.
 Usage/cost: after the turn ends the SDK fetches `session.snapshot` and puts
 `tokenUsage`/`cacheStats` on the result (`includeUsage: false` to skip).
 
+Prompt admission is reserved synchronously per session, before attach or send,
+so a second local `prompt()` throws `AgencPromptRunInProgressError`. Every SDK
+prompt supplies a stable `clientMessageId` (callers may provide one for retry)
+and opts into `ifBusy: "reject"` when requested. That strict option fails
+closed before send when protocol 1.2 is unavailable. Stream/status events are
+ignored until the matching durable `user_message` is observed and its turn is
+bound. Abort before dispatch sends nothing; later abort uses `expectedTurnId`
+on protocol 1.2. The SDK never falls back to session-wide prompt cancellation
+on an older daemon because it could hit a later turn.
+
+The SDK distinguishes `text` deltas from `message_committed`, reconciles the
+final result with committed text, and exposes `history_reset` for clear,
+compaction, rewind, and rollback. A duplicate without durable terminal proof
+fails with `AgencDuplicateSubmissionIncompleteError`. Initialization retries a
+1.0/1.1 daemon at its reported version and retains negotiated version and
+capability information for safe feature fallback.
+
 ### Handshake and autostart
 
 The daemon requires the first message on a socket to be `initialize` carrying
@@ -109,7 +131,8 @@ Windows.
 
 When the socket is not accepting connections and `autostart` is enabled
 (default), `connect()` runs `<agencCommand> daemon start` and polls the cookie
-+ socket until ready (45s budget, or `AGENC_DAEMON_READY_TIMEOUT_MS`).
+
+- socket until ready (45s budget, or `AGENC_DAEMON_READY_TIMEOUT_MS`).
 
 Deviation from the launcher: the runtime's internal autostart also handles
 build-skew respawn and orphan-daemon adoption. Those need runtime-internal
@@ -148,7 +171,9 @@ const run = promptViaSubprocess("explain the fee split", {
   agencCommand: "agenc", // or ["/abs/path/agenc"]
   model: "grok-4.5", // optional; also provider/profile/permissionMode
 });
-for await (const event of run) { /* same AgencPromptEvent union */ }
+for await (const event of run) {
+  /* same AgencPromptEvent union */
+}
 const result = await run.result(); // exitCode/finalMessage/usage from the CLI's result line
 ```
 
@@ -253,24 +278,24 @@ other runs. `run.evidence` declares
 that compatibility source, together with an explicit completeness value and
 content hashes.
 
-## Daemon method surface (51 methods)
+## Daemon method surface (52 methods)
 
 Mirrored in `packages/agenc-sdk/src/protocol.ts` as `AGENC_SDK_DAEMON_METHODS`
 (order pinned to the runtime registry):
 
-| Group | Methods |
-| --- | --- |
-| lifecycle | `initialize`, `request.cancel` |
-| agents | `agent.create`, `agent.list`, `agent.attach`, `agent.stop`, `agent.logs` |
-| runs | `run.start`, `run.status`, `run.result`, `run.replay`, `run.evidence`, `run.cancel` |
-| CSV review | `csvJob.review.list`, `csvJob.review.show`, `csvJob.review.resolve` |
-| sessions | `session.create`, `session.list`, `session.attach`, `session.detach`, `session.terminate`, `session.clear`, `session.snapshot`, `session.transcript`, `session.cancelTurn`, `session.resolveToolCall`, `session.mcp.addServer` |
-| messaging | `message.send`, `message.stream` |
-| realtime | `thread/realtime/start`, `thread/realtime/appendAudio`, `thread/realtime/appendText`, `thread/realtime/stop`, `thread/realtime/listVoices` |
-| tools / permissions | `tool.approve`, `tool.deny`, `tool.cancel`, `elicitation.respond`, `permission.list` |
-| exec / fs | `fs.fuzzy_search`, `commandExec.start`, `commandExec.write`, `commandExec.resize`, `commandExec.terminate` |
-| health / daemon | `health.ping`, `health.ready`, `health.stats`, `daemon.reload` |
-| auth | `auth.login`, `auth.whoami`, `auth.logout` |
+| Group               | Methods                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| lifecycle           | `initialize`, `request.cancel`                                                                                                                                                                                                                          |
+| agents              | `agent.create`, `agent.list`, `agent.attach`, `agent.stop`, `agent.logs`                                                                                                                                                                                |
+| runs                | `run.start`, `run.status`, `run.result`, `run.replay`, `run.evidence`, `run.cancel`                                                                                                                                                                     |
+| CSV review          | `csvJob.review.list`, `csvJob.review.show`, `csvJob.review.resolve`                                                                                                                                                                                     |
+| sessions            | `session.create`, `session.list`, `session.attach`, `session.detach`, `session.terminate`, `session.clear`, `session.snapshot`, `session.transcript`, `session.transcript.v2`, `session.cancelTurn`, `session.resolveToolCall`, `session.mcp.addServer` |
+| messaging           | `message.send`, `message.stream`                                                                                                                                                                                                                        |
+| realtime            | `thread/realtime/start`, `thread/realtime/appendAudio`, `thread/realtime/appendText`, `thread/realtime/stop`, `thread/realtime/listVoices`                                                                                                              |
+| tools / permissions | `tool.approve`, `tool.deny`, `tool.cancel`, `elicitation.respond`, `permission.list`                                                                                                                                                                    |
+| exec / fs           | `fs.fuzzy_search`, `commandExec.start`, `commandExec.write`, `commandExec.resize`, `commandExec.terminate`                                                                                                                                              |
+| health / daemon     | `health.ping`, `health.ready`, `health.stats`, `daemon.reload`                                                                                                                                                                                          |
+| auth                | `auth.login`, `auth.whoami`, `auth.logout`                                                                                                                                                                                                              |
 
 `fs.fuzzy_search` accepts an optional `limit` from 1 through 1,000 and an
 optional `refresh` flag that waits for a verified replacement index
@@ -300,13 +325,13 @@ capability map instead of treating registry membership as availability.
 
 Important raw protocol additions:
 
-| Shape | Contract |
-| --- | --- |
-| `EventUserInputRequestParams.clientAction` | Optional trusted JSON action generated by Core, never by generic `request_user_input` model arguments |
-| `RequestUserInputResponse.clientResult` | Typed client result returned through `elicitation.respond`; Ledger receipts are challenge- and field-bound |
-| `ToolApproveParams.allowAllToolsForSession` | Valid only with `scope: "session"`; promotes the daemon session to `bypassPermissions` transactionally |
-| `AuthWhoamiResult.subscriptionTier` | Tier from the latest verified remote `/v1/auth/me` snapshot; identity also carries compatibility `plan` data |
-| `AuthLoginResult` | App-server login result contains non-secret state/identity only; the backend bearer is never returned over daemon RPC |
+| Shape                                       | Contract                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `EventUserInputRequestParams.clientAction`  | Optional trusted JSON action generated by Core, never by generic `request_user_input` model arguments                 |
+| `RequestUserInputResponse.clientResult`     | Typed client result returned through `elicitation.respond`; Ledger receipts are challenge- and field-bound            |
+| `ToolApproveParams.allowAllToolsForSession` | Valid only with `scope: "session"`; promotes the daemon session to `bypassPermissions` transactionally                |
+| `AuthWhoamiResult.subscriptionTier`         | Tier from the latest verified remote `/v1/auth/me` snapshot; identity also carries compatibility `plan` data          |
+| `AuthLoginResult`                           | App-server login result contains non-secret state/identity only; the backend bearer is never returned over daemon RPC |
 
 Plain `scope: "session"` without `allowAllToolsForSession: true` keeps the
 narrower equivalent-rule approval cache. Interactive approval/deny/elicitation

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -131,8 +131,7 @@ Windows.
 
 When the socket is not accepting connections and `autostart` is enabled
 (default), `connect()` runs `<agencCommand> daemon start` and polls the cookie
-
-- socket until ready (45s budget, or `AGENC_DAEMON_READY_TIMEOUT_MS`).
+and socket until ready (45s budget, or `AGENC_DAEMON_READY_TIMEOUT_MS`).
 
 Deviation from the launcher: the runtime's internal autostart also handles
 build-skew respawn and orphan-daemon adoption. Those need runtime-internal

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -6,19 +6,27 @@ Node **>=26.5 <27** · ESM only · plain `tsc` build · no runtime dependencies.
 
 ## Surfaces
 
-| API | What it does |
-| --- | --- |
-| `connect()` | Attach to (or CLI-start) the local daemon over its Unix socket or Windows named pipe. Typed `createSession()` / `prompt()` event streams, permission + elicitation callbacks, background-agent spawn/attach/stop/logs. |
-| `promptViaSubprocess()` | Same event-iterable interface over `agenc -p --output-format stream-json` with no daemon socket access from your process. |
-| `client.runStatus` / `runResult` / `replayRun` / `runEvidence` / `cancelRun` | Read durable run/admission state, replay or hash canonical journal evidence, or cancel a run tree. |
-| `client.reattachRun({ runId, afterSequence })` | Catch up from a durable cursor, suppress and report duplicate delivery, stop on any explicit replay gap, and fetch the durable terminal result after reconnect. |
-| `client.request(method, params)` | Raw typed JSON-RPC for all **51** public daemon methods (mirrored in `./protocol`). |
+| API                                                                          | What it does                                                                                                                                                                                                           |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connect()`                                                                  | Attach to (or CLI-start) the local daemon over its Unix socket or Windows named pipe. Typed `createSession()` / `prompt()` event streams, permission + elicitation callbacks, background-agent spawn/attach/stop/logs. |
+| `promptViaSubprocess()`                                                      | Same event-iterable interface over `agenc -p --output-format stream-json` with no daemon socket access from your process.                                                                                              |
+| `client.runStatus` / `runResult` / `replayRun` / `runEvidence` / `cancelRun` | Read durable run/admission state, replay or hash canonical journal evidence, or cancel a run tree.                                                                                                                     |
+| `client.reattachRun({ runId, afterSequence })`                               | Catch up from a durable cursor, suppress and report duplicate delivery, stop on any explicit replay gap, and fetch the durable terminal result after reconnect.                                                        |
+| `client.request(method, params)`                                             | Raw typed JSON-RPC for all **52** public daemon methods (mirrored in `./protocol`).                                                                                                                                    |
 
 The protocol mirror preserves trusted `event.user_input_request.clientAction`
 objects, typed `elicitation.respond.clientResult` receipts,
 `ToolApproveParams.allowAllToolsForSession`, and remote subscription-tier
 identity fields. `connect()` advertises no mobile capabilities by default: it
 does not opt a generic embedder into global status or Ledger signing delivery.
+
+Daemon prompts reserve one local run per session synchronously and use a
+stable `clientMessageId` for correlation/idempotent retry. Protocol 1.2 adds
+opt-in `ifBusy: "reject"`, turn-scoped cancellation, identity-bearing
+`transcriptV2()`, distinct delta/committed assistant events, and
+`history_reset`. The SDK capability-falls back when initialization discovers a
+1.0/1.1 daemon; legacy queue behavior remains unchanged. Strict admission and
+scoped prompt cancellation fail closed when those guarantees are unavailable.
 
 ```js
 import { connect, promptViaSubprocess } from "@tetsuo-ai/agenc-sdk";

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -46,6 +46,7 @@ import {
   type SessionCreateParams,
   type SessionSnapshotResult,
   type SessionTranscriptResult,
+  type SessionTranscriptV2Result,
 } from "./protocol.js";
 import {
   promptEventFromNotification,
@@ -106,6 +107,48 @@ export class AgencMalformedResponseError extends Error {
   }
 }
 
+export class AgencPromptRunInProgressError extends Error {
+  readonly sessionId: string;
+  readonly clientMessageId: string;
+
+  constructor(sessionId: string, clientMessageId: string) {
+    super(`A prompt run is already active for session ${sessionId}`);
+    this.name = "AgencPromptRunInProgressError";
+    this.sessionId = sessionId;
+    this.clientMessageId = clientMessageId;
+  }
+}
+
+export class AgencDuplicateSubmissionIncompleteError extends Error {
+  readonly sessionId: string;
+  readonly clientMessageId: string;
+
+  constructor(sessionId: string, clientMessageId: string) {
+    super(
+      `The prior submission ${clientMessageId} has no durable terminal outcome`,
+    );
+    this.name = "AgencDuplicateSubmissionIncompleteError";
+    this.sessionId = sessionId;
+    this.clientMessageId = clientMessageId;
+  }
+}
+
+export class AgencCapabilityUnavailableError extends Error {
+  readonly capability: string;
+  readonly negotiatedProtocolVersion?: string;
+
+  constructor(capability: string, negotiatedProtocolVersion?: string) {
+    super(
+      `${capability} is unavailable with negotiated daemon protocol ${negotiatedProtocolVersion ?? "unknown"}`,
+    );
+    this.name = "AgencCapabilityUnavailableError";
+    this.capability = capability;
+    if (negotiatedProtocolVersion !== undefined) {
+      this.negotiatedProtocolVersion = negotiatedProtocolVersion;
+    }
+  }
+}
+
 /** A durable replay cursor cannot be advanced without acknowledging a gap. */
 export class AgencRunReplayGapError extends Error {
   readonly runId: string;
@@ -150,7 +193,10 @@ export class AgencRunReplayProtocolError extends Error {
 
 /** Decision returned by a permission callback. */
 export type AgencPermissionDecision =
-  | { readonly behavior: "allow"; readonly scope?: "once" | "session" | "agent" }
+  | {
+      readonly behavior: "allow";
+      readonly scope?: "once" | "session" | "agent";
+    }
   | { readonly behavior: "deny"; readonly reason?: string };
 
 export type AgencPermissionRequest = Extract<
@@ -188,6 +234,10 @@ export interface AgencClientOptions {
 
 export interface AgencPromptOptions {
   readonly signal?: AbortSignal;
+  /** Stable caller identity used for idempotent retry and event correlation. */
+  readonly clientMessageId?: string;
+  /** Ask protocol-1.2+ daemons to reject cross-client overlap. */
+  readonly ifBusy?: "reject";
   /**
    * Fetch `session.snapshot` after the turn completes so the result carries
    * token usage and cost. Defaults to `true`; snapshot failures are ignored.
@@ -205,8 +255,7 @@ export interface AgencRunReplayCursor {
 }
 
 export type AgencRunReplayDuplicateReason =
-  | "same_identity"
-  | "at_or_before_cursor";
+  "same_identity" | "at_or_before_cursor";
 
 export interface AgencRunReplayDuplicate {
   readonly event: RunReplayEvent;
@@ -331,7 +380,11 @@ function createEventChannel(): EventChannel {
 export interface AgencPromptRun extends AsyncIterable<AgencPromptEvent> {
   readonly sessionId: string;
   /** Resolves once the daemon acknowledged `message.send`. */
-  readonly accepted: Promise<{ messageId: string }>;
+  readonly accepted: Promise<{
+    messageId: string;
+    clientMessageId: string;
+    turnId?: string;
+  }>;
   /** Final outcome; resolves even when the events are never iterated. */
   result(): Promise<AgencPromptResult>;
   /** Interrupt the active turn (`session.cancelTurn`). */
@@ -350,12 +403,21 @@ export class AgencSession {
   }
 
   /** Send one message and stream the turn's events. */
-  prompt(content: MessageContent, options: AgencPromptOptions = {}): AgencPromptRun {
+  prompt(
+    content: MessageContent,
+    options: AgencPromptOptions = {},
+  ): AgencPromptRun {
     return this.#client.runPrompt(this.sessionId, content, options);
   }
 
   transcript(): Promise<SessionTranscriptResult> {
     return this.#client.request("session.transcript", {
+      sessionId: this.sessionId,
+    });
+  }
+
+  transcriptV2(): Promise<SessionTranscriptV2Result> {
+    return this.#client.request("session.transcript.v2", {
       sessionId: this.sessionId,
     });
   }
@@ -366,10 +428,11 @@ export class AgencSession {
     });
   }
 
-  async cancelTurn(reason?: string): Promise<void> {
+  async cancelTurn(reason?: string, expectedTurnId?: string): Promise<void> {
     await this.#client.request("session.cancelTurn", {
       sessionId: this.sessionId,
       ...(reason !== undefined ? { reason } : {}),
+      ...(expectedTurnId !== undefined ? { expectedTurnId } : {}),
     });
   }
 
@@ -426,8 +489,7 @@ class ClientRunAttachment implements AgencRunAttachment {
   readonly #identityWindow: number;
   readonly #signal: AbortSignal | undefined;
   readonly #onDuplicate:
-    | ((duplicate: AgencRunReplayDuplicate) => void)
-    | undefined;
+    ((duplicate: AgencRunReplayDuplicate) => void) | undefined;
   readonly #seenBySequence = new Map<number, SeenReplayEvent>();
   readonly #seenByEventId = new Map<string, SeenReplayEvent>();
   readonly #seenOrder = new Set<SeenReplayEvent>();
@@ -694,13 +756,20 @@ export class AgencClient {
     Set<(message: JsonObject) => void>
   >();
   readonly #attachedSessionIds = new Set<string>();
+  readonly #activePromptRuns = new Map<
+    string,
+    { readonly clientMessageId: string; turnId?: string }
+  >();
+  #initializeResult: InitializeResult | undefined;
+  #negotiatedClientProtocolVersion: string | undefined;
   #initialized = false;
   #closed = false;
 
   constructor(options: AgencClientOptions) {
     this.#transport = options.transport;
     this.#createRequestId = options.createRequestId ?? numericIdFactory();
-    this.#clientId = options.clientId ?? `agenc-sdk-${process.pid}-${randomUUID()}`;
+    this.#clientId =
+      options.clientId ?? `agenc-sdk-${process.pid}-${randomUUID()}`;
     this.#clientName = options.clientName ?? "agenc-sdk";
     this.#onPermissionRequest = options.onPermissionRequest;
     this.#onElicitationRequest = options.onElicitationRequest;
@@ -712,6 +781,23 @@ export class AgencClient {
 
   get initialized(): boolean {
     return this.#initialized;
+  }
+
+  get negotiatedProtocolVersion(): string | undefined {
+    return this.#negotiatedClientProtocolVersion;
+  }
+
+  get serverProtocolVersion(): string | undefined {
+    return this.#initializeResult?.protocol.version;
+  }
+
+  get serverCapabilities(): InitializeResult["capabilities"] | undefined {
+    return this.#initializeResult?.capabilities;
+  }
+
+  #supportsMethod(method: AgencDaemonMethod): boolean {
+    const methods = this.#initializeResult?.capabilities["daemon.methods"];
+    return isJsonObject(methods) && methods[method] === true;
   }
 
   /**
@@ -773,14 +859,41 @@ export class AgencClient {
   }
 
   async initialize(params: InitializeParams = {}): Promise<InitializeResult> {
-    const result = await this.request("initialize", {
-      protocolVersion: AGENC_SDK_DAEMON_PROTOCOL_VERSION,
-      protocol: { version: AGENC_SDK_DAEMON_PROTOCOL_VERSION },
+    const explicitVersion =
+      params.protocol?.version !== undefined ||
+      params.protocolVersion !== undefined;
+    let requestedVersion =
+      params.protocol?.version ??
+      params.protocolVersion ??
+      AGENC_SDK_DAEMON_PROTOCOL_VERSION;
+    const request = {
       clientName: this.#clientName,
       capabilities: {},
       ...params,
-    });
+      protocolVersion: requestedVersion,
+      protocol: { version: requestedVersion },
+    } satisfies InitializeParams;
+    let result: InitializeResult;
+    try {
+      result = await this.request("initialize", request);
+    } catch (error) {
+      const fallbackVersion = explicitVersion
+        ? undefined
+        : compatibleServerVersionFromInitializeError(error);
+      if (fallbackVersion === undefined) throw error;
+      requestedVersion = fallbackVersion;
+      result = await this.request("initialize", {
+        ...request,
+        protocolVersion: fallbackVersion,
+        protocol: { version: fallbackVersion },
+      });
+    }
     this.#initialized = true;
+    this.#initializeResult = result;
+    this.#negotiatedClientProtocolVersion = effectiveNegotiatedVersion(
+      requestedVersion,
+      result.protocol.version,
+    );
     return result;
   }
 
@@ -963,6 +1076,23 @@ export class AgencClient {
     content: MessageContent,
     options: AgencPromptOptions = {},
   ): AgencPromptRun {
+    const clientMessageId = normalizeClientMessageId(options.clientMessageId);
+    const existingRun = this.#activePromptRuns.get(sessionId);
+    if (existingRun !== undefined) {
+      throw new AgencPromptRunInProgressError(
+        sessionId,
+        existingRun.clientMessageId,
+      );
+    }
+    const reservation: { readonly clientMessageId: string; turnId?: string } = {
+      clientMessageId,
+    };
+    this.#activePromptRuns.set(sessionId, reservation);
+    const releaseReservation = (): void => {
+      if (this.#activePromptRuns.get(sessionId) === reservation) {
+        this.#activePromptRuns.delete(sessionId);
+      }
+    };
     const channel = createEventChannel();
     const onPermissionRequest =
       options.onPermissionRequest ?? this.#onPermissionRequest;
@@ -971,16 +1101,66 @@ export class AgencClient {
     const deniedPermissionRequestIds = new Set<string>();
     const handledPermissionRequestIds = new Set<string>();
     let assistantOutput = "";
+    let lastCommittedMessage = "";
     let finishing = false;
+    let submissionDispatched = false;
+    let submissionObserved = false;
+    let cancelBeforeDispatchReason: string | undefined;
+    let deferredCancellationReason: string | undefined;
+    let cancellationPromise: Promise<void> | undefined;
+    let removeAbortListener = (): void => {};
+
+    const flushDeferredCancellation = (): Promise<void> => {
+      if (
+        cancellationPromise !== undefined ||
+        deferredCancellationReason === undefined ||
+        !submissionObserved ||
+        reservation.turnId === undefined
+      ) {
+        return cancellationPromise ?? Promise.resolve();
+      }
+      cancellationPromise = this.request("session.cancelTurn", {
+        sessionId,
+        reason: deferredCancellationReason,
+        ...(this.#supportsMethod("session.transcript.v2")
+          ? { expectedTurnId: reservation.turnId }
+          : {}),
+      }).then(() => {});
+      return cancellationPromise;
+    };
+
+    const requestScopedCancellation = (reason: string): Promise<void> => {
+      if (!submissionDispatched) {
+        cancelBeforeDispatchReason = reason;
+        return Promise.resolve();
+      }
+      if (!this.#supportsMethod("session.transcript.v2")) {
+        // A legacy session-wide cancel can race with the next turn after the
+        // observed turn completes. Never claim scoped cancellation when the
+        // daemon cannot atomically compare expectedTurnId.
+        return Promise.reject(
+          new AgencCapabilityUnavailableError(
+            "turn-scoped prompt cancellation",
+            this.#negotiatedClientProtocolVersion,
+          ),
+        );
+      }
+      deferredCancellationReason = reason;
+      return flushDeferredCancellation();
+    };
 
     const finish = async (status: { code: number; message?: string }) => {
       if (finishing) return;
       finishing = true;
       unsubscribe();
+      removeAbortListener();
+      releaseReservation();
       let usageFields: Pick<AgencPromptResult, "usage" | "cacheStats"> = {};
       if (options.includeUsage !== false) {
         try {
-          const snapshot = await this.request("session.snapshot", { sessionId });
+          const snapshot = await this.request("session.snapshot", {
+            sessionId,
+          });
           usageFields = {
             usage: snapshot.tokenUsage,
             cacheStats: snapshot.cacheStats,
@@ -992,7 +1172,8 @@ export class AgencClient {
       channel.end({
         stopReason: stopReasonFromExitCode(status.code),
         exitCode: status.code,
-        finalMessage: status.message ?? assistantOutput.trimEnd(),
+        finalMessage:
+          status.message ?? (lastCommittedMessage || assistantOutput.trimEnd()),
         deniedPermissionRequestIds: [...deniedPermissionRequestIds],
         ...usageFields,
       });
@@ -1068,11 +1249,60 @@ export class AgencClient {
     };
 
     const unsubscribe = this.onSessionNotification(sessionId, (message) => {
+      const observedClientMessageId =
+        userMessageClientMessageIdFromNotification(message);
+      if (!submissionObserved) {
+        if (observedClientMessageId !== clientMessageId) return;
+        submissionObserved = true;
+      } else if (
+        observedClientMessageId !== null &&
+        observedClientMessageId !== clientMessageId
+      ) {
+        return;
+      }
+
       const event = promptEventFromNotification(message);
+      if (
+        event?.clientMessageId !== undefined &&
+        event.clientMessageId !== clientMessageId
+      ) {
+        return;
+      }
+      const startedTurnId = turnStartedIdFromNotification(message);
+      if (startedTurnId !== null) {
+        if (
+          reservation.turnId !== undefined &&
+          reservation.turnId !== startedTurnId
+        ) {
+          return;
+        }
+        reservation.turnId = startedTurnId;
+        void flushDeferredCancellation().catch(() => {});
+      }
+      if (
+        reservation.turnId === undefined &&
+        observedClientMessageId === null
+      ) {
+        return;
+      }
+      const notificationTurnId =
+        event?.turnId ?? turnIdFromNotification(message);
+      if (
+        reservation.turnId !== undefined &&
+        notificationTurnId !== null &&
+        notificationTurnId !== undefined &&
+        notificationTurnId !== reservation.turnId
+      ) {
+        return;
+      }
       if (event !== null) {
         if (event.type === "text") assistantOutput += event.delta;
+        if (event.type === "message_committed") {
+          lastCommittedMessage = event.text;
+        }
         channel.push(event);
-        if (event.type === "permission_request") void respondToPermission(event);
+        if (event.type === "permission_request")
+          void respondToPermission(event);
         if (event.type === "elicitation_request") {
           void respondToElicitation(event);
         }
@@ -1084,39 +1314,104 @@ export class AgencClient {
     if (options.signal !== undefined) {
       const signal = options.signal;
       const onAbort = () => {
-        void this.request("session.cancelTurn", {
-          sessionId,
-          reason: String(signal.reason ?? "aborted"),
-        }).catch(() => {});
+        void requestScopedCancellation(
+          String(signal.reason ?? "aborted"),
+        ).catch(() => {});
       };
       if (signal.aborted) onAbort();
-      else signal.addEventListener("abort", onAbort, { once: true });
+      else {
+        signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () =>
+          signal.removeEventListener("abort", onAbort);
+      }
     }
 
     const accepted = (async () => {
+      throwIfPromptCancelledBeforeDispatch(cancelBeforeDispatchReason);
+      if (
+        options.ifBusy !== undefined &&
+        !this.#supportsMethod("session.transcript.v2")
+      ) {
+        throw new AgencCapabilityUnavailableError(
+          'ifBusy: "reject" prompt admission',
+          this.#negotiatedClientProtocolVersion,
+        );
+      }
       await this.#attachSession(sessionId);
+      throwIfPromptCancelledBeforeDispatch(cancelBeforeDispatchReason);
+      submissionDispatched = true;
       const sendResult = await this.request("message.send", {
         sessionId,
         content,
-        ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+        clientMessageId,
+        ...(options.ifBusy !== undefined ? { ifBusy: options.ifBusy } : {}),
+        ...(options.metadata !== undefined
+          ? { metadata: options.metadata }
+          : {}),
       });
-      return { messageId: sendResult.messageId };
+      if (sendResult.turnId !== undefined) {
+        reservation.turnId = sendResult.turnId;
+        void flushDeferredCancellation().catch(() => {});
+      }
+      if (sendResult.disposition === "duplicate" && !finishing) {
+        if (sendResult.duplicateState !== "completed") {
+          throw new AgencDuplicateSubmissionIncompleteError(
+            sessionId,
+            clientMessageId,
+          );
+        }
+        try {
+          const snapshot = await this.request("session.transcript.v2", {
+            sessionId,
+          });
+          const finalAssistant = [...snapshot.messages]
+            .reverse()
+            .find(
+              (entry) =>
+                entry.clientMessageId === clientMessageId &&
+                entry.role === "assistant",
+            );
+          if (finalAssistant !== undefined) {
+            lastCommittedMessage = finalAssistant.text;
+          }
+        } catch {
+          /* a legacy daemon cannot provide identity-bearing reconciliation */
+        }
+        void finish({
+          code: sendResult.terminal?.code ?? 0,
+          ...(sendResult.terminal?.message !== undefined
+            ? { message: sendResult.terminal.message }
+            : lastCommittedMessage.length > 0
+              ? { message: lastCommittedMessage }
+              : {}),
+        });
+      } else if (sendResult.terminal !== undefined && !finishing) {
+        // The RPC result is the authoritative terminal fallback when a live
+        // notification was lost or filtered during reconnect. Legacy daemons
+        // omit this field, so their behavior remains notification-driven.
+        void finish(sendResult.terminal);
+      }
+      return {
+        messageId: sendResult.messageId,
+        clientMessageId,
+        ...(sendResult.turnId !== undefined
+          ? { turnId: sendResult.turnId }
+          : {}),
+      };
     })();
     accepted.catch((error: unknown) => {
       unsubscribe();
+      removeAbortListener();
+      releaseReservation();
       channel.fail(error instanceof Error ? error : new Error(String(error)));
     });
 
-    const self = this;
     return {
       sessionId,
       accepted,
       result: () => channel.result,
       cancel: async (reason?: string) => {
-        await self.request("session.cancelTurn", {
-          sessionId,
-          ...(reason !== undefined ? { reason } : {}),
-        });
+        await requestScopedCancellation(reason ?? "cancelled");
       },
       [Symbol.asyncIterator]: () => channel.iterate(),
     };
@@ -1127,6 +1422,7 @@ export class AgencClient {
     this.#closed = true;
     this.#notificationListeners.clear();
     this.#sessionListeners.clear();
+    this.#activePromptRuns.clear();
     await this.#transport.close?.();
   }
 
@@ -1162,6 +1458,95 @@ function safeNotify(
   } catch {
     // Listener failures must not poison notification routing.
   }
+}
+
+function nestedSessionEventFromNotification(
+  message: JsonObject,
+): JsonObject | null {
+  const params = isJsonObject(message.params) ? message.params : message;
+  if (isJsonObject(params.event)) return params.event;
+  if (isJsonObject(params.msg)) return params.msg;
+  return null;
+}
+
+function userMessageClientMessageIdFromNotification(
+  message: JsonObject,
+): string | null {
+  const event = nestedSessionEventFromNotification(message);
+  if (event?.type !== "user_message" || !isJsonObject(event.payload)) {
+    return null;
+  }
+  if (typeof event.payload.messageId === "string") {
+    return event.payload.messageId;
+  }
+  return typeof event.messageId === "string" ? event.messageId : null;
+}
+
+function turnStartedIdFromNotification(message: JsonObject): string | null {
+  const params = isJsonObject(message.params) ? message.params : message;
+  if (
+    message.method === "event.agent_status" &&
+    typeof params.turnId === "string" &&
+    (params.status === "running" || params.runStatus === "running")
+  ) {
+    return params.turnId;
+  }
+  const event = nestedSessionEventFromNotification(message);
+  if (event?.type !== "turn_started" || !isJsonObject(event.payload)) {
+    return null;
+  }
+  return typeof event.payload.turnId === "string" ? event.payload.turnId : null;
+}
+
+function turnIdFromNotification(message: JsonObject): string | null {
+  const params = isJsonObject(message.params) ? message.params : message;
+  if (typeof params.turnId === "string") return params.turnId;
+  const event = nestedSessionEventFromNotification(message);
+  if (event === null) return null;
+  if (typeof event.turnId === "string") return event.turnId;
+  return isJsonObject(event.payload) && typeof event.payload.turnId === "string"
+    ? event.payload.turnId
+    : null;
+}
+
+function throwIfPromptCancelledBeforeDispatch(
+  reason: string | undefined,
+): void {
+  if (reason === undefined) return;
+  const error = new Error(`Prompt cancelled before dispatch: ${reason}`);
+  error.name = "AbortError";
+  throw error;
+}
+
+function effectiveNegotiatedVersion(
+  requestedVersion: string,
+  serverVersion: string,
+): string {
+  const requested = /^(\d+)\.(\d+)(?:\.\d+)?$/.exec(requestedVersion);
+  const server = /^(\d+)\.(\d+)(?:\.\d+)?$/.exec(serverVersion);
+  if (requested === null || server === null || requested[1] !== server[1]) {
+    return requestedVersion;
+  }
+  return Number.parseInt(requested[2]!, 10) <= Number.parseInt(server[2]!, 10)
+    ? requestedVersion
+    : serverVersion;
+}
+
+function compatibleServerVersionFromInitializeError(
+  error: unknown,
+): string | undefined {
+  if (!(error instanceof AgencRpcError) || !isJsonObject(error.data)) {
+    return undefined;
+  }
+  if (error.data.code !== "PROTOCOL_VERSION_UNSUPPORTED") return undefined;
+  const serverVersion = error.data.serverVersion;
+  if (typeof serverVersion !== "string") return undefined;
+  const match = /^(\d+)\.(\d+)(?:\.\d+)?$/.exec(serverVersion);
+  if (match === null) return undefined;
+  const major = Number.parseInt(match[1]!, 10);
+  const minor = Number.parseInt(match[2]!, 10);
+  if (major !== 1 || minor < 0 || minor >= 2) return undefined;
+  return serverVersion;
 }
 
 function parseResponse<Method extends AgencDaemonMethod>(
@@ -1200,8 +1585,11 @@ function parseResponse<Method extends AgencDaemonMethod>(
       response,
     );
   }
-  return (response as AgencDaemonResponse<Method> & { result: AgencResultByMethod[Method] })
-    .result;
+  return (
+    response as AgencDaemonResponse<Method> & {
+      result: AgencResultByMethod[Method];
+    }
+  ).result;
 }
 
 /** Absolute workspace path for daemon create RPCs (DAE-02 client boundary). */
@@ -1212,6 +1600,15 @@ function resolveClientCwd(cwd: string | undefined): string {
     return isAbsolute(trimmed) ? resolve(trimmed) : resolve(base, trimmed);
   }
   return resolve(base);
+}
+
+function normalizeClientMessageId(value: string | undefined): string {
+  if (value === undefined) return `message-${randomUUID()}`;
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new TypeError("clientMessageId must be a non-empty string");
+  }
+  return normalized;
 }
 
 function normalizeReplayRunId(runId: string): string {
@@ -1233,12 +1630,10 @@ function normalizeReplayAfterSequence(afterSequence: number): number {
 
 function normalizeReplayLimit(limit: number | undefined): number {
   const normalized = limit ?? 100;
-  if (
-    !Number.isSafeInteger(normalized) ||
-    normalized < 1 ||
-    normalized > 200
-  ) {
-    throw new TypeError("AgenC run replay limit must be an integer from 1 to 200");
+  if (!Number.isSafeInteger(normalized) || normalized < 1 || normalized > 200) {
+    throw new TypeError(
+      "AgenC run replay limit must be an integer from 1 to 200",
+    );
   }
   return normalized;
 }
@@ -1408,7 +1803,9 @@ function validateReplaySource(
       source.canonical !== "rollout_jsonl" ||
       source.projection !== "thread_rollout_items"
     ) {
-      invalid("AgenC run replay returned malformed run-journal source metadata");
+      invalid(
+        "AgenC run replay returned malformed run-journal source metadata",
+      );
     }
   } else if (source.kind === "execution_admission_journal") {
     if (
@@ -1416,7 +1813,9 @@ function validateReplaySource(
       source.canonical !== undefined ||
       source.projection !== undefined
     ) {
-      invalid("AgenC run replay returned malformed admission-journal source metadata");
+      invalid(
+        "AgenC run replay returned malformed admission-journal source metadata",
+      );
     }
   } else {
     invalid("AgenC run replay returned an unknown source kind");
@@ -1436,7 +1835,9 @@ function validateReplaySource(
       (source.kind === "execution_admission_journal" &&
         response.gap?.reason !== "execution_admission_journal_not_present"))
   ) {
-    invalid("AgenC run replay source kind conflicts with its unavailable reason");
+    invalid(
+      "AgenC run replay source kind conflicts with its unavailable reason",
+    );
   }
 }
 
@@ -1591,8 +1992,7 @@ function replayIdentityHashBits(value: string): readonly number[] {
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
     first = Math.imul(first ^ code, 0x01000193) >>> 0;
-    second =
-      Math.imul(second ^ (code + index), 0x85ebca6b) + 0xc2b2ae35;
+    second = Math.imul(second ^ (code + index), 0x85ebca6b) + 0xc2b2ae35;
     second >>>= 0;
   }
   const bitCount = REPLAY_IDENTITY_FILTER_BYTES * 8;

--- a/packages/agenc-sdk/src/events.ts
+++ b/packages/agenc-sdk/src/events.ts
@@ -22,15 +22,30 @@ export type AgencStopReason = "completed" | "errored" | "stopped";
 export interface AgencPromptEventIdentity {
   readonly eventId?: string;
   readonly sequence?: number;
+  readonly runId?: string;
+  readonly historyEpoch?: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
+  readonly messageId?: string;
 }
 
 /** One streamed event observed while a prompt turn runs. */
 export type AgencPromptEvent = AgencPromptEventIdentity &
-  (| {
+  (
+    | {
         readonly type: "text";
         readonly delta: string;
-        readonly messageId?: string;
         readonly streamId?: string;
+      }
+    | {
+        readonly type: "message_committed";
+        readonly text: string;
+      }
+    | {
+        /** Durable transcript replacement; consumers should fetch v2 anew. */
+        readonly type: "history_reset";
+        readonly reason:
+          "cleared" | "partial_compact" | "rewind" | "compaction_rollback";
       }
     | {
         readonly type: "tool_call";
@@ -144,13 +159,6 @@ export function messageChunkFromNotification(
   ) {
     return payload.delta;
   }
-  if (
-    transcriptEvent.type === "agent_message" &&
-    payload !== null &&
-    typeof payload.message === "string"
-  ) {
-    return `${payload.message}\n`;
-  }
   return null;
 }
 
@@ -166,17 +174,27 @@ export function terminalStatusFromNotification(
   if (message.method === "event.agent_status" && params !== null) {
     const runStatus =
       typeof params.runStatus === "string" ? params.runStatus : undefined;
-    const status = typeof params.status === "string" ? params.status : undefined;
+    const status =
+      typeof params.status === "string" ? params.status : undefined;
     const statusMessage =
       typeof params.message === "string" ? params.message : undefined;
     if (runStatus === "completed" || status === "idle") {
-      return { code: 0, ...(statusMessage !== undefined ? { message: statusMessage } : {}) };
+      return {
+        code: 0,
+        ...(statusMessage !== undefined ? { message: statusMessage } : {}),
+      };
     }
     if (runStatus === "stopped" || status === "stopped") {
-      return { code: 130, ...(statusMessage !== undefined ? { message: statusMessage } : {}) };
+      return {
+        code: 130,
+        ...(statusMessage !== undefined ? { message: statusMessage } : {}),
+      };
     }
     if (runStatus === "errored" || status === "error") {
-      return { code: 1, ...(statusMessage !== undefined ? { message: statusMessage } : {}) };
+      return {
+        code: 1,
+        ...(statusMessage !== undefined ? { message: statusMessage } : {}),
+      };
     }
   }
   const transcriptEvent = nestedTranscriptEvent(message);
@@ -189,14 +207,20 @@ export function terminalStatusFromNotification(
       payload !== null && typeof payload.lastAgentMessage === "string"
         ? payload.lastAgentMessage
         : undefined;
-    return { code: 0, ...(finalMessage !== undefined ? { message: finalMessage } : {}) };
+    return {
+      code: 0,
+      ...(finalMessage !== undefined ? { message: finalMessage } : {}),
+    };
   }
   if (transcriptEvent.type === "error") {
     const errorMessage =
       payload !== null && typeof payload.message === "string"
         ? payload.message
         : undefined;
-    return { code: 1, ...(errorMessage !== undefined ? { message: errorMessage } : {}) };
+    return {
+      code: 1,
+      ...(errorMessage !== undefined ? { message: errorMessage } : {}),
+    };
   }
   return null;
 }
@@ -229,7 +253,9 @@ export function promptEventFromNotification(
       return null;
     }
     const afterSequence = positiveOrZeroInteger(params.afterSequence);
-    const firstAvailableSequence = positiveInteger(params.firstAvailableSequence);
+    const firstAvailableSequence = positiveInteger(
+      params.firstAvailableSequence,
+    );
     return {
       type: "gap",
       kind: "event_gap",
@@ -253,16 +279,41 @@ export function promptEventFromNotification(
         type: "text",
         delta,
         ...identity,
-        ...(typeof chunkParams.messageId === "string"
-          ? { messageId: chunkParams.messageId }
-          : {}),
         ...(typeof chunkParams.streamId === "string"
           ? { streamId: chunkParams.streamId }
           : {}),
       };
     }
     if (method === "event.session_event" && params !== null) {
-      const nested = isJsonObject(params.event) ? params.event : params;
+      const nested = nestedTranscriptEvent(message) ?? params;
+      const payload = isJsonObject(nested.payload) ? nested.payload : null;
+      if (
+        nested.type === "agent_message" &&
+        payload !== null &&
+        typeof payload.message === "string"
+      ) {
+        return {
+          type: "message_committed",
+          text: payload.message,
+          ...identity,
+        };
+      }
+      if (nested.type === "history_cleared") {
+        return { type: "history_reset", reason: "cleared", ...identity };
+      }
+      if (
+        nested.type === "transcript_epoch" &&
+        payload !== null &&
+        (payload.reason === "partial_compact" ||
+          payload.reason === "rewind" ||
+          payload.reason === "compaction_rollback")
+      ) {
+        return {
+          type: "history_reset",
+          reason: payload.reason,
+          ...identity,
+        };
+      }
       return { type: "session_event", event: nested, ...identity };
     }
     return null;
@@ -349,7 +400,9 @@ export function promptEventFromNotification(
       ...(typeof params.runStatus === "string"
         ? { runStatus: params.runStatus }
         : {}),
-      ...(typeof params.message === "string" ? { message: params.message } : {}),
+      ...(typeof params.message === "string"
+        ? { message: params.message }
+        : {}),
     };
   }
 
@@ -366,10 +419,19 @@ function eventIdentityFromParams(
     Number.isSafeInteger(sequence) &&
     sequence > 0;
   return {
-    ...(typeof params.eventId === "string"
-      ? { eventId: params.eventId }
-      : {}),
+    ...(typeof params.eventId === "string" ? { eventId: params.eventId } : {}),
     ...(hasSequence ? { sequence } : {}),
+    ...(typeof params.runId === "string" ? { runId: params.runId } : {}),
+    ...(typeof params.historyEpoch === "string"
+      ? { historyEpoch: params.historyEpoch }
+      : {}),
+    ...(typeof params.turnId === "string" ? { turnId: params.turnId } : {}),
+    ...(typeof params.clientMessageId === "string"
+      ? { clientMessageId: params.clientMessageId }
+      : {}),
+    ...(typeof params.messageId === "string"
+      ? { messageId: params.messageId }
+      : {}),
   };
 }
 

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -21,7 +21,7 @@ import type {
 } from "./csv-jobs.js";
 
 export const AGENC_SDK_JSON_RPC_VERSION = "2.0" as const;
-export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.1.0" as const;
+export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.2.0" as const;
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | readonly JsonValue[] | JsonObject;
@@ -61,6 +61,7 @@ export const AGENC_SDK_DAEMON_METHODS = [
   "session.clear",
   "session.snapshot",
   "session.transcript",
+  "session.transcript.v2",
   "session.cancelTurn",
   "session.resolveToolCall",
   "session.mcp.addServer",
@@ -139,10 +140,7 @@ export interface RequestCancelParams extends JsonObject {
 }
 
 export type PermissionMode =
-  | "default"
-  | "plan"
-  | "acceptEdits"
-  | "bypassPermissions";
+  "default" | "plan" | "acceptEdits" | "bypassPermissions";
 
 export type MessageContentBlock =
   | (JsonObject & { readonly type: "text"; readonly text: string })
@@ -284,9 +282,14 @@ export interface SessionTranscriptParams extends JsonObject {
   readonly sessionId: string;
 }
 
+export interface SessionTranscriptV2Params extends JsonObject {
+  readonly sessionId: string;
+}
+
 export interface SessionCancelTurnParams extends JsonObject {
   readonly sessionId: string;
   readonly reason?: string;
+  readonly expectedTurnId?: string;
 }
 
 /** Protocol-1.0 request shape shipped with agenc-sdk 0.3.0. */
@@ -305,17 +308,14 @@ export interface SessionResolveToolCallEvidenceParams extends JsonObject {
   readonly sessionId: string;
   readonly toolCallId: string;
   readonly disposition:
-    | "confirmed_committed"
-    | "confirmed_no_effect"
-    | "remains_unknown";
+    "confirmed_committed" | "confirmed_no_effect" | "remains_unknown";
   readonly evidenceRef: string;
   readonly evidenceSha256: string;
   readonly reviewer?: string;
 }
 
 export type SessionResolveToolCallParams =
-  | SessionResolveToolCallLegacyParams
-  | SessionResolveToolCallEvidenceParams;
+  SessionResolveToolCallLegacyParams | SessionResolveToolCallEvidenceParams;
 
 export interface SessionMcpServerConfig extends JsonObject {
   readonly name: string;
@@ -336,6 +336,7 @@ export interface MessageSendParams extends JsonObject {
   readonly sessionId: string;
   readonly content: MessageContent;
   readonly clientMessageId?: string;
+  readonly ifBusy?: "reject";
   readonly metadata?: JsonObject;
 }
 
@@ -450,16 +451,17 @@ interface CommandExecStartBase extends JsonObject {
   readonly size?: CommandExecTerminalSize | null;
 }
 
-export type CommandExecStartParams = CommandExecStartBase & (
-  | {
-      readonly permissionProfile: string;
-      readonly sandboxPolicy?: null;
-    }
-  | {
-      readonly sandboxPolicy: JsonObject;
-      readonly permissionProfile?: null;
-    }
-);
+export type CommandExecStartParams = CommandExecStartBase &
+  (
+    | {
+        readonly permissionProfile: string;
+        readonly sandboxPolicy?: null;
+      }
+    | {
+        readonly sandboxPolicy: JsonObject;
+        readonly permissionProfile?: null;
+      }
+  );
 
 export interface CommandExecWriteParams extends JsonObject {
   readonly processId: string;
@@ -513,6 +515,7 @@ export interface AgencParamsByMethod {
   readonly "session.clear": SessionClearParams;
   readonly "session.snapshot": SessionSnapshotParams;
   readonly "session.transcript": SessionTranscriptParams;
+  readonly "session.transcript.v2": SessionTranscriptV2Params;
   readonly "session.cancelTurn": SessionCancelTurnParams;
   readonly "session.resolveToolCall": SessionResolveToolCallParams;
   readonly "session.mcp.addServer": SessionMcpAddServerParams;
@@ -813,8 +816,7 @@ export interface RunTerminalPersistedOutput extends JsonObject {
 /** Compatibility alias for code that names the unavailable branch directly. */
 export type RunTerminalOutputUnavailable = RunTerminalOutputAvailability;
 export type RunTerminalOutput =
-  | RunTerminalPersistedOutput
-  | RunTerminalOutputAvailability;
+  RunTerminalPersistedOutput | RunTerminalOutputAvailability;
 
 export interface RunResultResult extends JsonObject {
   readonly runId: string;
@@ -912,8 +914,7 @@ export type RunReplayEvent = RunJournalEvent | RunAdmissionReplayEvent;
 export interface RunReplaySourceUnavailableGap extends JsonObject {
   readonly kind: "source_unavailable";
   readonly reason:
-    | "execution_admission_journal_not_present"
-    | "run_journal_not_present";
+    "execution_admission_journal_not_present" | "run_journal_not_present";
 }
 
 /** A cursor range was retired or could not be recovered contiguously. */
@@ -955,9 +956,7 @@ export interface RunAdmissionReplaySource extends JsonObject {
   readonly projectDir: string;
 }
 
-export type RunReplaySource =
-  | RunJournalReplaySource
-  | RunAdmissionReplaySource;
+export type RunReplaySource = RunJournalReplaySource | RunAdmissionReplaySource;
 
 export interface RunReplayPage extends JsonObject {
   readonly runId: string;
@@ -982,9 +981,7 @@ export interface RunAdmissionReplayResult extends RunReplayPage {
 }
 
 /** Discriminated by `source.kind`; M3 and M4 event contracts stay precise. */
-export type RunReplayResult =
-  | RunJournalReplayResult
-  | RunAdmissionReplayResult;
+export type RunReplayResult = RunJournalReplayResult | RunAdmissionReplayResult;
 
 export function isRunAdmissionReplayResult(
   result: RunReplayResult,
@@ -999,10 +996,7 @@ export function isRunJournalReplayResult(
 }
 
 export type RunEvidenceCompleteness =
-  | "complete"
-  | "partial"
-  | "admission_source_unavailable"
-  | "journal_gap";
+  "complete" | "partial" | "admission_source_unavailable" | "journal_gap";
 
 export interface RunEvidenceSource extends JsonObject {
   readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
@@ -1113,10 +1107,38 @@ export interface SessionTranscriptResult extends JsonObject {
   readonly messages: readonly SessionTranscriptMessage[];
 }
 
+export interface SessionTranscriptV2Message extends JsonObject {
+  readonly messageId: string;
+  readonly commitEventId: string;
+  readonly role: "user" | "assistant";
+  readonly text: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
+  /** Zero only for migrated response_item rows that predate event sequencing. */
+  readonly committedSequence: number;
+}
+
+export interface SessionTranscriptV2ActiveTurn extends JsonObject {
+  readonly turnId: string;
+  readonly clientMessageId?: string;
+}
+
+export interface SessionTranscriptV2Result extends JsonObject {
+  readonly schemaVersion: 2;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly historyEpoch: string;
+  readonly asOfSequence: number;
+  readonly messages: readonly SessionTranscriptV2Message[];
+  readonly activeTurn?: SessionTranscriptV2ActiveTurn;
+}
+
 export interface SessionCancelTurnResult extends JsonObject {
   readonly sessionId: string;
   readonly cancelled: boolean;
   readonly reason?: string;
+  readonly activeTurnId?: string;
+  readonly stale?: boolean;
 }
 
 export interface SessionResolveToolCallResult extends JsonObject {
@@ -1140,6 +1162,16 @@ export interface SessionMcpAddServerResult extends JsonObject {
 export interface MessageSendResult extends JsonObject {
   readonly messageId: string;
   readonly acceptedAt: string;
+  readonly disposition?: "started" | "duplicate";
+  /** Present for duplicate submissions so callers never guess crash outcomes. */
+  readonly duplicateState?: "completed" | "incomplete";
+  readonly turnId?: string;
+  readonly terminal?: MessageSendTerminalResult;
+}
+
+export interface MessageSendTerminalResult extends JsonObject {
+  readonly code: 0 | 1 | 130;
+  readonly message?: string;
 }
 
 export interface MessageStreamResult extends MessageSendResult {
@@ -1290,6 +1322,7 @@ export interface AgencResultByMethod {
   readonly "session.clear": SessionClearResult;
   readonly "session.snapshot": SessionSnapshotResult;
   readonly "session.transcript": SessionTranscriptResult;
+  readonly "session.transcript.v2": SessionTranscriptV2Result;
   readonly "session.cancelTurn": SessionCancelTurnResult;
   readonly "session.resolveToolCall": SessionResolveToolCallResult;
   readonly "session.mcp.addServer": SessionMcpAddServerResult;
@@ -1325,13 +1358,17 @@ export interface AgencEventBaseParams extends JsonObject {
   readonly sessionId: string;
   readonly eventId: string;
   readonly agentId?: string;
+  readonly runId?: string;
+  readonly historyEpoch?: string;
   readonly sequence?: number;
   readonly acceptedAt?: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
+  readonly messageId?: string;
   readonly metadata?: JsonObject;
 }
 
 export interface EventMessageChunkParams extends AgencEventBaseParams {
-  readonly messageId?: string;
   readonly streamId?: string;
   readonly delta: string;
 }
@@ -1409,12 +1446,7 @@ export interface AgencDaemonRequest<
 }
 
 export type AgencDaemonErrorCode =
-  | -32700
-  | -32600
-  | -32601
-  | -32602
-  | -32603
-  | -32000;
+  -32700 | -32600 | -32601 | -32602 | -32603 | -32000;
 
 export interface AgencDaemonErrorObject extends JsonObject {
   readonly code: AgencDaemonErrorCode;

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -22,10 +22,13 @@ import {
   requireAbsoluteWorkspaceCwd,
   WorkspaceCwdError,
 } from "./workspace-cwd.js";
-import type {
-  AgenCBackgroundAgentSnapshot,
-  AgenCBackgroundAgentTerminalSnapshot,
-  AgenCBackgroundAgentRunner,
+import {
+  AgenCBackgroundAgentMessageError,
+  sessionTranscriptV2FromRollout,
+  type AgenCBackgroundAgentMessageResult,
+  type AgenCBackgroundAgentSnapshot,
+  type AgenCBackgroundAgentTerminalSnapshot,
+  type AgenCBackgroundAgentRunner,
 } from "./background-agent-runner.js";
 import type {
   AgentAttachParams,
@@ -64,6 +67,8 @@ import type {
   SessionSnapshotResult,
   SessionTranscriptParams,
   SessionTranscriptResult,
+  SessionTranscriptV2Params,
+  SessionTranscriptV2Result,
   SessionPartialCompactFromMessageParams,
   SessionPartialCompactFromMessageResult,
   SessionRollbackCompactionParams,
@@ -142,7 +147,9 @@ export type AgenCDaemonAgentLifecycleErrorCode =
   | "INVALID_ARGUMENT"
   | "INVALID_CURSOR"
   | "RUN_NOT_FOUND"
-  | "RUN_CANCEL_UNAVAILABLE";
+  | "RUN_CANCEL_UNAVAILABLE"
+  | "TURN_IN_PROGRESS"
+  | "CLIENT_MESSAGE_ID_CONFLICT";
 
 export class AgenCDaemonAgentLifecycleError extends Error {
   readonly code: AgenCDaemonAgentLifecycleErrorCode;
@@ -1807,6 +1814,30 @@ export class AgenCDaemonAgentManager {
     if (this.#runner.interruptAgentTurn === undefined) {
       return { sessionId: params.sessionId, cancelled: false, reason };
     }
+    if (params.expectedTurnId !== undefined) {
+      if (this.#runner.interruptAgentTurnIfMatches === undefined) {
+        return {
+          sessionId: params.sessionId,
+          cancelled: false,
+          reason,
+          stale: true,
+        };
+      }
+      const result = await this.#runner.interruptAgentTurnIfMatches(
+        session.agentId,
+        reason,
+        params.expectedTurnId,
+      );
+      return {
+        sessionId: params.sessionId,
+        cancelled: result.cancelled,
+        reason,
+        ...(result.activeTurnId !== undefined
+          ? { activeTurnId: result.activeTurnId }
+          : {}),
+        ...(result.stale !== undefined ? { stale: result.stale } : {}),
+      };
+    }
     const cancelled = await this.#runner.interruptAgentTurn(
       session.agentId,
       reason,
@@ -2105,6 +2136,54 @@ export class AgenCDaemonAgentManager {
     }
   }
 
+  async getSessionTranscriptV2(
+    params: SessionTranscriptV2Params,
+  ): Promise<SessionTranscriptV2Result> {
+    if (this.#sessionManager === undefined) {
+      throw new AgenCDaemonAgentLifecycleError(
+        "INVALID_ARGUMENT",
+        "session.transcript.v2 requires a daemon session manager",
+      );
+    }
+    if (this.#runner?.getAgentSessionTranscriptV2 === undefined) {
+      const persisted = this.#readPersistedSessionTranscriptV2(
+        params.sessionId,
+      );
+      if (persisted !== undefined) return persisted;
+      throw new AgenCDaemonAgentLifecycleError(
+        "BACKGROUND_RUNNER_UNAVAILABLE",
+        "session.transcript.v2 requires a background runner",
+      );
+    }
+    let agentId: string;
+    try {
+      agentId = await this.#resolveActiveAgentIdForSession(params.sessionId, {
+        allowSnapshot: true,
+      });
+    } catch (error) {
+      if (isNoLiveAgentError(error)) {
+        const persisted = this.#readPersistedSessionTranscriptV2(
+          params.sessionId,
+        );
+        if (persisted !== undefined) return persisted;
+      }
+      throw error;
+    }
+    try {
+      return await this.#runner.getAgentSessionTranscriptV2(agentId, {
+        sessionId: params.sessionId,
+      });
+    } catch (error) {
+      if (isNoLiveAgentRunnerError(error)) {
+        const persisted = this.#readPersistedSessionTranscriptV2(
+          params.sessionId,
+        );
+        if (persisted !== undefined) return persisted;
+      }
+      throw error;
+    }
+  }
+
   /**
    * Read the persisted conversation for a session straight from the thread
    * store (the same source `agenc agent logs <id>` prints via
@@ -2134,6 +2213,29 @@ export class AgenCDaemonAgentManager {
       thread.history?.items ?? [],
     );
     return { sessionId, messages };
+  }
+
+  #readPersistedSessionTranscriptV2(
+    sessionId: string,
+  ): SessionTranscriptV2Result | undefined {
+    const threadStore = this.#threadStore;
+    if (threadStore === undefined) return undefined;
+    let thread: StoredThread;
+    try {
+      thread = threadStore.readThread({
+        threadId: sessionId,
+        includeArchived: true,
+        includeHistory: true,
+      });
+    } catch (error) {
+      if (isThreadLogReadMiss(error)) return undefined;
+      throw error;
+    }
+    return sessionTranscriptV2FromRollout(
+      thread.history?.items ?? [],
+      sessionId,
+      thread.threadId,
+    );
   }
 
   async partialCompactFromMessage(
@@ -2188,7 +2290,9 @@ export class AgenCDaemonAgentManager {
       sessionId: params.sessionId,
       attemptId: params.attemptId,
       ...(params.reviewedBranchTargetSessionId !== undefined
-        ? { reviewedBranchTargetSessionId: params.reviewedBranchTargetSessionId }
+        ? {
+            reviewedBranchTargetSessionId: params.reviewedBranchTargetSessionId,
+          }
         : {}),
     });
   }
@@ -2476,10 +2580,11 @@ export class AgenCDaemonAgentManager {
     readonly messageId: string;
     readonly streamId: string;
     readonly acceptedAt: string;
+    readonly ifBusy?: "reject";
     readonly displayUserMessage?: string | null;
     readonly editorInteraction?: SessionEditorInteraction;
     readonly methodName?: "message.send" | "message.stream";
-  }): Promise<void> {
+  }): Promise<AgenCBackgroundAgentMessageResult> {
     const methodName = params.methodName ?? "message.stream";
     if (this.#sessionManager === undefined) {
       throw new AgenCDaemonAgentLifecycleError(
@@ -2537,29 +2642,46 @@ export class AgenCDaemonAgentManager {
       );
     }
 
-    await this.#runner.submitAgentMessage(session.agentId, {
-      sessionId: params.sessionId,
-      content: params.content,
-      originalContent: params.content,
-      ...(params.displayUserMessage !== undefined
-        ? { displayUserMessage: params.displayUserMessage }
-        : {}),
-      ...(params.editorInteraction !== undefined
-        ? { editorInteraction: params.editorInteraction }
-        : {}),
-      messageId: params.messageId,
-      streamId: params.streamId,
-      acceptedAt: params.acceptedAt,
-    });
-    await this.#recordMessageExchangeSnapshot({
-      sessionId: params.sessionId,
-      agentId: session.agentId,
-      ...messageTarget.route,
-      content: params.content as JsonValue,
-      messageId: params.messageId,
-      streamId: params.streamId,
-      acceptedAt: params.acceptedAt,
-    });
+    let submission: AgenCBackgroundAgentMessageResult;
+    try {
+      submission = (await this.#runner.submitAgentMessage(session.agentId, {
+        sessionId: params.sessionId,
+        content: params.content,
+        originalContent: params.content,
+        ...(params.displayUserMessage !== undefined
+          ? { displayUserMessage: params.displayUserMessage }
+          : {}),
+        ...(params.editorInteraction !== undefined
+          ? { editorInteraction: params.editorInteraction }
+          : {}),
+        ...(params.ifBusy !== undefined ? { ifBusy: params.ifBusy } : {}),
+        messageId: params.messageId,
+        streamId: params.streamId,
+        acceptedAt: params.acceptedAt,
+      })) ?? {
+        // Compatibility for injected pre-1.2 runners whose submit method
+        // returned void. Production 1.2 runners return the richer result.
+        disposition: "started",
+        acceptedAt: params.acceptedAt,
+      };
+    } catch (error) {
+      if (error instanceof AgenCBackgroundAgentMessageError) {
+        throw new AgenCDaemonAgentLifecycleError(error.code, error.message);
+      }
+      throw error;
+    }
+    if (submission.disposition === "started") {
+      await this.#recordMessageExchangeSnapshot({
+        sessionId: params.sessionId,
+        agentId: session.agentId,
+        ...messageTarget.route,
+        content: params.content as JsonValue,
+        messageId: params.messageId,
+        streamId: params.streamId,
+        acceptedAt: params.acceptedAt,
+      });
+    }
+    return submission;
   }
 
   async #refreshAgentsFromRunner(state: AgentLifecycleState): Promise<void> {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -7,6 +7,8 @@
  * response is returned.
  */
 
+import { createHash } from "node:crypto";
+
 import {
   bootstrapLocalRuntimeSession,
   type BootstrapLocalRuntimeSessionOptions,
@@ -56,6 +58,7 @@ import {
 } from "../tools/untrusted-tool-result-framing.js";
 import type { ToolRegistry } from "../tool-registry.js";
 import { getPlan, getPlanFilePath } from "../utils/plans.js";
+import { stableStringify } from "../utils/stableStringify.js";
 import { EXIT_PLAN_MODE_TOOL_NAME } from "../tools/ExitPlanModeTool/constants.js";
 import type { AgentId } from "../types/ids.js";
 import {
@@ -95,6 +98,8 @@ import {
 import type { AgentStatus as ThreadAgentStatus } from "../agents/status.js";
 import type { McpServerMutationResult, Session } from "../session/session.js";
 import type { Event } from "../session/event-log.js";
+import type { RolloutItem } from "../session/rollout-item.js";
+import { reconstructFromRollout } from "../session/rollout-reconstruction.js";
 import type { TurnContext } from "../session/turn-context.js";
 import type {
   SessionEditorInteraction,
@@ -124,6 +129,7 @@ import type {
   SessionRewindFilesToMessageResult,
   SessionSnapshotResult,
   SessionTranscriptResult,
+  SessionTranscriptV2Result,
   SessionHookConfigShape,
   SessionHookValidationIssueShape,
   SessionHookRunDiagnosticShape,
@@ -234,6 +240,12 @@ export interface AgenCBackgroundAgentCancellationPreparation {
   readonly heldUnknownHolds: number;
 }
 
+export interface AgenCBackgroundAgentTurnCancellationResult {
+  readonly cancelled: boolean;
+  readonly activeTurnId?: string;
+  readonly stale?: boolean;
+}
+
 export interface AgenCBackgroundAgentSessionEventBinding {
   readonly sessionId: string;
   readonly emit: (event: JsonObject) => void | Promise<void>;
@@ -248,6 +260,33 @@ export interface AgenCBackgroundAgentMessageParams {
   readonly messageId: string;
   readonly streamId: string;
   readonly acceptedAt: string;
+  readonly ifBusy?: "reject";
+}
+
+export interface AgenCBackgroundAgentMessageResult {
+  readonly disposition: "started" | "duplicate";
+  readonly acceptedAt: string;
+  readonly duplicateState?: "completed" | "incomplete";
+  readonly turnId?: string;
+  readonly terminal?: AgenCBackgroundAgentMessageTerminal;
+}
+
+export interface AgenCBackgroundAgentMessageTerminal extends JsonObject {
+  readonly code: 0 | 1 | 130;
+  readonly message?: string;
+}
+
+export type AgenCBackgroundAgentMessageErrorCode =
+  "TURN_IN_PROGRESS" | "CLIENT_MESSAGE_ID_CONFLICT";
+
+export class AgenCBackgroundAgentMessageError extends Error {
+  readonly code: AgenCBackgroundAgentMessageErrorCode;
+
+  constructor(code: AgenCBackgroundAgentMessageErrorCode, message: string) {
+    super(message);
+    this.name = "AgenCBackgroundAgentMessageError";
+    this.code = code;
+  }
 }
 
 export interface AgenCBackgroundAgentClearSessionParams {
@@ -389,7 +428,7 @@ export interface AgenCBackgroundAgentRunner {
   submitAgentMessage?(
     agentId: string,
     params: AgenCBackgroundAgentMessageParams,
-  ): Promise<void>;
+  ): Promise<AgenCBackgroundAgentMessageResult>;
   /** Resolve the live route without exposing the primary provider to callers. */
   resolveCodePredictionSource?(
     agentId: string,
@@ -406,6 +445,10 @@ export interface AgenCBackgroundAgentRunner {
     agentId: string,
     params: { readonly sessionId: string },
   ): Promise<SessionTranscriptResult>;
+  getAgentSessionTranscriptV2?(
+    agentId: string,
+    params: { readonly sessionId: string },
+  ): Promise<SessionTranscriptV2Result>;
   resolveLiveEffectReview?(
     agentId: string,
     params: ResolveDurableEffectReviewOptions,
@@ -485,6 +528,11 @@ export interface AgenCBackgroundAgentRunner {
    * also stopped — see {@link AgentControl.interrupt}.
    */
   interruptAgentTurn?(agentId: string, reason: string): Promise<boolean>;
+  interruptAgentTurnIfMatches?(
+    agentId: string,
+    reason: string,
+    expectedTurnId: string,
+  ): Promise<AgenCBackgroundAgentTurnCancellationResult>;
   /**
    * Register a callback invoked once per agent immediately before the
    * runner removes that agent from its `#active` registry on terminal
@@ -562,6 +610,11 @@ interface ActiveBackgroundAgent {
   sessionBinding?: AgenCBackgroundAgentSessionEventBinding;
   bufferedEvents: BackgroundAgentDaemonEvent[];
   activeToolCallIds: Set<string>;
+  historyEpoch: string;
+  messageSubmission?: ActiveMessageSubmission;
+  messageSubmissionQueue: Promise<void>;
+  pendingMessageSubmissionCount: number;
+  readonly messageSubmissionsById: Map<string, ActiveMessageSubmission>;
   /**
    * Per-agent emission serialization chain. `#emitOrBufferEvent` awaits
    * an async-locked broadcast, so two fire-and-forget emits from a
@@ -572,6 +625,19 @@ interface ActiveBackgroundAgent {
    * Mirrors AgenCStdioTransport's #dispatchChain (transport/stdio.ts).
    */
   dispatchChain: Promise<void>;
+}
+
+interface ActiveMessageSubmission {
+  readonly clientMessageId: string;
+  readonly contentFingerprint: string;
+  readonly streamId: string;
+  readonly acceptedAt: string;
+  turnId?: string;
+  assistantMessageOrdinal: number;
+  activeAssistantMessageId?: string;
+  terminal?: AgenCBackgroundAgentMessageTerminal;
+  readonly promise: Promise<AgenCBackgroundAgentMessageResult>;
+  settled: boolean;
 }
 
 interface BackgroundAgentDaemonEvent {
@@ -586,6 +652,10 @@ interface BackgroundAgentDaemonEvent {
   readonly messageId?: string;
   readonly streamId?: string;
   readonly acceptedAt?: string;
+  readonly runId?: string;
+  readonly historyEpoch?: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
 }
 
 interface ActiveAgentBudget {
@@ -980,6 +1050,13 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         activeToolCallIds:
           this.#pendingActiveToolCallIds.get(managedThread.threadId) ??
           new Set(),
+        historyEpoch: historyEpochFromRollout(
+          bootstrap.rolloutStore.readAll(),
+          managedThread.threadId,
+        ),
+        messageSubmissionQueue: Promise.resolve(),
+        pendingMessageSubmissionCount: 0,
+        messageSubmissionsById: new Map(),
         dispatchChain: Promise.resolve(),
       };
       this.#installAgentBudget(active, {
@@ -1255,6 +1332,13 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ),
         activeToolCallIds:
           this.#pendingActiveToolCallIds.get(params.agentId) ?? new Set(),
+        historyEpoch: historyEpochFromRollout(
+          bootstrap.rolloutStore.readAll(),
+          params.agentId,
+        ),
+        messageSubmissionQueue: Promise.resolve(),
+        pendingMessageSubmissionCount: 0,
+        messageSubmissionsById: new Map(),
         dispatchChain: Promise.resolve(),
       };
       this.#installAgentBudget(active, {
@@ -1478,24 +1562,150 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   async submitAgentMessage(
     agentId: string,
     params: AgenCBackgroundAgentMessageParams,
-  ): Promise<void> {
+  ): Promise<AgenCBackgroundAgentMessageResult> {
     const active = this.#active.get(agentId);
     if (active === undefined || !isRunnableActiveAgent(active)) {
       throw new Error(`AgenC daemon agent not running: ${agentId}`);
     }
+    const contentFingerprint = messageContentFingerprint(
+      params.originalContent,
+    );
+    const duplicate = active.messageSubmissionsById.get(params.messageId);
+    if (duplicate !== undefined) {
+      if (duplicate.contentFingerprint !== contentFingerprint) {
+        throw clientMessageIdConflict(params.messageId);
+      }
+      return duplicate.promise.then((result) => ({
+        ...result,
+        disposition: "duplicate" as const,
+        duplicateState: "completed" as const,
+      }));
+    }
+
+    const persisted = findPersistedMessageSubmission(
+      active.bootstrap.rolloutStore.readAll(),
+      params.messageId,
+    );
+    if (persisted !== undefined) {
+      if (persisted.contentFingerprint !== contentFingerprint) {
+        throw clientMessageIdConflict(params.messageId);
+      }
+      return {
+        disposition: "duplicate",
+        duplicateState:
+          persisted.terminal === undefined ? "incomplete" : "completed",
+        acceptedAt: persisted.acceptedAt ?? params.acceptedAt,
+        ...(persisted.turnId !== undefined ? { turnId: persisted.turnId } : {}),
+        ...(persisted.terminal !== undefined
+          ? { terminal: persisted.terminal }
+          : {}),
+      };
+    }
+
+    const threadStatus = active.thread.status().status;
+    if (
+      params.ifBusy === "reject" &&
+      (active.pendingMessageSubmissionCount > 0 ||
+        hasRuntimeActiveTurn(active.bootstrap.session) ||
+        threadStatus === "running" ||
+        threadStatus === "pending_init")
+    ) {
+      throw new AgenCBackgroundAgentMessageError(
+        "TURN_IN_PROGRESS",
+        `session ${params.sessionId} already has an active or queued turn`,
+      );
+    }
+
+    let resolveSubmission!: (result: AgenCBackgroundAgentMessageResult) => void;
+    let rejectSubmission!: (error: unknown) => void;
+    const promise = new Promise<AgenCBackgroundAgentMessageResult>(
+      (resolve, reject) => {
+        resolveSubmission = resolve;
+        rejectSubmission = reject;
+      },
+    );
+    const submission: ActiveMessageSubmission = {
+      clientMessageId: params.messageId,
+      contentFingerprint,
+      streamId: params.streamId,
+      acceptedAt: params.acceptedAt,
+      assistantMessageOrdinal: 0,
+      promise,
+      settled: false,
+    };
+    active.messageSubmissionsById.set(params.messageId, submission);
+    active.pendingMessageSubmissionCount += 1;
+
+    const execute = active.messageSubmissionQueue.then(async () => {
+      if (!isRunnableActiveAgent(active)) {
+        throw new Error(`AgenC daemon agent not running: ${agentId}`);
+      }
+      active.messageSubmission = submission;
+      try {
+        return await this.#executeAgentMessageSubmission(
+          active,
+          agentId,
+          params,
+          submission,
+        );
+      } finally {
+        if (active.messageSubmission === submission) {
+          active.messageSubmission = undefined;
+        }
+      }
+    });
+    active.messageSubmissionQueue = execute.then(
+      () => {},
+      () => {},
+    );
+    void execute.then(resolveSubmission, rejectSubmission).finally(() => {
+      submission.settled = true;
+      active.pendingMessageSubmissionCount = Math.max(
+        0,
+        active.pendingMessageSubmissionCount - 1,
+      );
+      pruneMessageSubmissionCache(active.messageSubmissionsById);
+    });
+    return promise;
+  }
+
+  async #executeAgentMessageSubmission(
+    active: ActiveBackgroundAgent,
+    agentId: string,
+    params: AgenCBackgroundAgentMessageParams,
+    submission: ActiveMessageSubmission,
+  ): Promise<AgenCBackgroundAgentMessageResult> {
     const input = messageContentToAgentInput(params.content);
     active.lastActiveAt = this.#now();
-    if (params.displayUserMessage !== null) {
+    if (params.displayUserMessage === null) {
+      // Hidden editor/internal prompts still need an fsync-durable admission
+      // identity. This marker is intentionally not bridged as a transcript
+      // event, but lets restart retries prove same-content idempotency.
+      active.bootstrap.session.emit(
+        {
+          id: `message-submission:${params.messageId}`,
+          msg: {
+            type: "message_submission",
+            payload: {
+              contentFingerprint: submission.contentFingerprint,
+              messageId: params.messageId,
+              streamId: params.streamId,
+              acceptedAt: params.acceptedAt,
+            },
+          },
+        },
+        { durable: true },
+      );
+    } else {
       const displayText =
         params.displayUserMessage ?? messageContentDisplayText(params.content);
-      // The TUI must see the submitted prompt before assistant deltas;
-      // sendInput can synchronously stream and complete a whole turn.
       await this.#emitPersistedUserMessage(active, {
         id: params.messageId,
         type: "user_message",
         messageId: params.messageId,
         streamId: params.streamId,
         acceptedAt: params.acceptedAt,
+        clientMessageId: params.messageId,
         payload: {
           message: params.originalContent,
           displayText,
@@ -1506,29 +1716,30 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       });
     }
     if (typeof input === "string") {
-      if (params.editorInteraction === undefined) {
-        await active.control.sendInput(agentId, input);
-      } else {
-        await active.control.sendInput(agentId, input, {
-          editorInteraction: params.editorInteraction,
-        });
-      }
+      await active.control.sendInput(
+        agentId,
+        input,
+        ...(params.editorInteraction === undefined
+          ? []
+          : [{ editorInteraction: params.editorInteraction }]),
+      );
     } else {
-      if (params.editorInteraction === undefined) {
-        await submitStructuredAgentInput(
-          active,
-          input,
-          messageContentDisplayText(params.content),
-        );
-      } else {
-        await submitStructuredAgentInput(
-          active,
-          input,
-          messageContentDisplayText(params.content),
-          { editorInteraction: params.editorInteraction },
-        );
-      }
+      await submitStructuredAgentInput(
+        active,
+        input,
+        messageContentDisplayText(params.content),
+        ...(params.editorInteraction === undefined
+          ? []
+          : [{ editorInteraction: params.editorInteraction }]),
+      );
     }
+    await active.dispatchChain;
+    return {
+      disposition: "started",
+      acceptedAt: submission.acceptedAt,
+      ...(submission.turnId !== undefined ? { turnId: submission.turnId } : {}),
+      terminal: submission.terminal ?? { code: 0 },
+    };
   }
 
   resolveCodePredictionSource(agentId: string): CodePredictionSource {
@@ -1563,14 +1774,19 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     this.#assistantTextByAgent.delete(agentId);
     active.lastActiveAt = params.clearedAt;
     const clearedAtMs = Date.parse(params.clearedAt);
-    await this.#emitOrBufferEvent(active, {
-      id: `history-cleared-${params.sessionId}-${params.clearedAt}`,
-      type: "history_cleared",
-      acceptedAt: params.clearedAt,
-      payload: {
-        timestamp: Number.isFinite(clearedAtMs) ? clearedAtMs : Date.now(),
+    active.bootstrap.session.emit(
+      {
+        id: `history-cleared-${params.sessionId}-${params.clearedAt}`,
+        msg: {
+          type: "history_cleared",
+          payload: {
+            timestamp: Number.isFinite(clearedAtMs) ? clearedAtMs : Date.now(),
+          },
+        },
       },
-    });
+      { durable: true },
+    );
+    await active.dispatchChain;
   }
 
   async addMcpServer(
@@ -1741,6 +1957,27 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     return { sessionId: params.sessionId, messages };
   }
 
+  async getAgentSessionTranscriptV2(
+    agentId: string,
+    params: { readonly sessionId: string },
+  ): Promise<SessionTranscriptV2Result> {
+    const active = this.#active.get(agentId);
+    if (active === undefined || !isRunnableActiveAgent(active)) {
+      throw new Error(`AgenC daemon agent not running: ${agentId}`);
+    }
+    return sessionTranscriptV2FromRollout(
+      active.bootstrap.rolloutStore.readAll(),
+      params.sessionId,
+      active.thread.threadId,
+      active.messageSubmission?.turnId === undefined
+        ? undefined
+        : {
+            turnId: active.messageSubmission.turnId,
+            clientMessageId: active.messageSubmission.clientMessageId,
+          },
+    );
+  }
+
   async resolveLiveEffectReview(
     agentId: string,
     params: ResolveDurableEffectReviewOptions,
@@ -1850,6 +2087,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       ...(params.signal !== undefined ? { signal: params.signal } : {}),
     });
     if (result.ok && result.event !== undefined) {
+      await this.#persistTranscriptEpoch(
+        active,
+        result.event as unknown as JsonObject,
+      );
       await this.#emitOrBufferEvent(active, result.event as never);
       return {
         sessionId: params.sessionId,
@@ -1880,10 +2121,16 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     const result = await active.bootstrap.session.rollbackCompaction({
       attemptId: params.attemptId,
       ...(params.reviewedBranchTargetSessionId !== undefined
-        ? { reviewedBranchTargetSessionId: params.reviewedBranchTargetSessionId }
+        ? {
+            reviewedBranchTargetSessionId: params.reviewedBranchTargetSessionId,
+          }
         : {}),
     });
     if (result.ok && result.event !== undefined) {
+      await this.#persistTranscriptEpoch(
+        active,
+        result.event as unknown as JsonObject,
+      );
       await this.#emitOrBufferEvent(active, result.event as never);
     }
     return result.ok
@@ -1943,6 +2190,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       messageOrdinal: params.messageOrdinal,
     });
     if (result.ok && result.event !== undefined) {
+      await this.#persistTranscriptEpoch(
+        active,
+        result.event as unknown as JsonObject,
+      );
       await this.#emitOrBufferEvent(active, result.event as never);
       return {
         sessionId: params.sessionId,
@@ -1960,6 +2211,34 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ? "No replacement event was produced."
         : result.message,
     };
+  }
+
+  async #persistTranscriptEpoch(
+    active: ActiveBackgroundAgent,
+    replacementEvent: JsonObject,
+  ): Promise<void> {
+    const id =
+      typeof replacementEvent.id === "string"
+        ? replacementEvent.id
+        : `history-replaced-${active.thread.threadId}-${Date.now()}`;
+    const payload = isJsonObject(replacementEvent.payload)
+      ? replacementEvent.payload
+      : {};
+    const reason =
+      payload.reason === "rewind" ||
+      payload.reason === "compaction_rollback" ||
+      payload.reason === "partial_compact"
+        ? payload.reason
+        : "partial_compact";
+    active.bootstrap.session.emit(
+      {
+        eventId: `transcript-epoch:${id}`,
+        id: `transcript-epoch:${id}`,
+        msg: { type: "transcript_epoch", payload: { reason } },
+      },
+      { durable: true },
+    );
+    await active.dispatchChain;
   }
 
   async previewFileRewind(
@@ -2505,6 +2784,53 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     return true;
   }
 
+  async interruptAgentTurnIfMatches(
+    agentId: string,
+    reason: string,
+    expectedTurnId: string,
+  ): Promise<AgenCBackgroundAgentTurnCancellationResult> {
+    const active = this.#active.get(agentId);
+    if (active === undefined || !isInterruptibleActiveAgent(active)) {
+      return { cancelled: false };
+    }
+    const activeTurnId =
+      runtimeActiveTurnId(active.bootstrap.session) ??
+      active.messageSubmission?.turnId;
+    if (activeTurnId !== expectedTurnId) {
+      return {
+        cancelled: false,
+        ...(activeTurnId !== undefined ? { activeTurnId } : {}),
+        stale: true,
+      };
+    }
+    let cancelled = false;
+    try {
+      cancelled = await active.bootstrap.session.abortTurnIfActive(
+        expectedTurnId,
+        "interrupted",
+      );
+    } catch {
+      return { cancelled: false, activeTurnId: expectedTurnId };
+    }
+    if (!cancelled) {
+      const turnAfterAttempt = runtimeActiveTurnId(active.bootstrap.session);
+      return {
+        cancelled: false,
+        ...(turnAfterAttempt !== undefined
+          ? { activeTurnId: turnAfterAttempt }
+          : {}),
+        ...(turnAfterAttempt !== expectedTurnId ? { stale: true } : {}),
+      };
+    }
+    for (const [childThreadId] of active.control.openThreadSpawnChildren(
+      active.thread.threadId,
+    )) {
+      active.control.interrupt(childThreadId, reason);
+    }
+    active.lastActiveAt = this.#now();
+    return { cancelled: true, activeTurnId: expectedTurnId };
+  }
+
   async respondToElicitation(
     agentId: string,
     params: AgenCBackgroundAgentElicitationResponseParams,
@@ -2609,8 +2935,9 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     if (typeof eventLog?.subscribe !== "function") return () => {};
     active.canonicalEventBridgeInstalled = true;
     return eventLog.subscribe((event) => {
-      const daemonEvent = daemonEventFromUnboundSessionEvent(event);
-      if (daemonEvent === null) return;
+      const uncorrelated = daemonEventFromUnboundSessionEvent(event);
+      if (uncorrelated === null) return;
+      const daemonEvent = correlateDaemonEvent(active, uncorrelated);
       active.lastActiveAt = this.#now();
       this.#applyCanonicalEventBookkeeping(active, daemonEvent);
       void this.#emitOrBufferEvent(active, daemonEvent);
@@ -3614,11 +3941,604 @@ function hasRuntimeActiveTurn(
   );
 }
 
+function runtimeActiveTurnId(
+  session: LocalRuntimeBootstrap["session"],
+): string | undefined {
+  const activeTurn = (session as unknown as { activeTurn?: ActiveTurnPeek })
+    .activeTurn;
+  if (typeof activeTurn?.unsafePeek !== "function") return undefined;
+  const value = activeTurn.unsafePeek();
+  if (!isJsonObject(value) || typeof value.turnId !== "string") {
+    return undefined;
+  }
+  return value.turnId;
+}
+
 function isClearInFlight(active: ActiveBackgroundAgent): boolean {
   if (hasRuntimeActiveTurn(active.bootstrap.session)) return true;
   if (active.activeToolCallIds.size > 0) return true;
   const status = active.thread.status();
   return status.status === "running" || status.status === "pending_init";
+}
+
+function correlateDaemonEvent(
+  active: ActiveBackgroundAgent,
+  event: BackgroundAgentDaemonEvent,
+): BackgroundAgentDaemonEvent {
+  const runId = active.thread.threadId;
+  if (event.type === "history_cleared" || event.type === "transcript_epoch") {
+    active.historyEpoch = historyEpochForBoundary(
+      runId,
+      event.eventId ?? event.id,
+    );
+    return { ...event, runId, historyEpoch: active.historyEpoch };
+  }
+
+  const submission = active.messageSubmission;
+  const isSubmissionUserMarker =
+    submission !== undefined &&
+    event.type === "user_message" &&
+    (event.messageId === submission.clientMessageId ||
+      event.payload?.messageId === submission.clientMessageId);
+  if (
+    submission !== undefined &&
+    submission.turnId === undefined &&
+    event.type !== "turn_started" &&
+    !isSubmissionUserMarker
+  ) {
+    // The durable user marker is visible before the queued input owns a
+    // runtime turn. Do not stamp tail events from the preceding turn with the
+    // new submission's identity while waiting for its turn_started boundary.
+    return {
+      ...event,
+      runId,
+      historyEpoch: active.historyEpoch,
+      ...(typeof event.payload?.turnId === "string"
+        ? { turnId: event.payload.turnId }
+        : {}),
+    };
+  }
+  if (
+    submission !== undefined &&
+    event.type === "turn_started" &&
+    typeof event.payload?.turnId === "string"
+  ) {
+    submission.turnId = event.payload.turnId;
+  }
+
+  const turnId =
+    submission?.turnId ??
+    (typeof event.payload?.turnId === "string"
+      ? event.payload.turnId
+      : undefined);
+  let messageId = event.messageId;
+  if (
+    submission !== undefined &&
+    (event.type === "agent_message_delta" || event.type === "agent_message")
+  ) {
+    if (submission.activeAssistantMessageId === undefined) {
+      submission.activeAssistantMessageId = assistantMessageId(
+        turnId ?? submission.clientMessageId,
+        submission.assistantMessageOrdinal,
+      );
+    }
+    messageId = submission.activeAssistantMessageId;
+    if (event.type === "agent_message") {
+      submission.activeAssistantMessageId = undefined;
+      submission.assistantMessageOrdinal += 1;
+    }
+  } else if (
+    submission === undefined &&
+    event.type === "agent_message" &&
+    messageId === undefined
+  ) {
+    messageId = `assistant:${event.eventId ?? event.id}`;
+  }
+  if (submission !== undefined) {
+    const terminal = messageTerminalFromDaemonEvent(event, submission.turnId);
+    if (terminal !== undefined) submission.terminal = terminal;
+  }
+
+  return {
+    ...event,
+    runId,
+    historyEpoch: active.historyEpoch,
+    ...(turnId !== undefined ? { turnId } : {}),
+    ...(submission !== undefined
+      ? { clientMessageId: submission.clientMessageId }
+      : {}),
+    ...(messageId !== undefined ? { messageId } : {}),
+  };
+}
+
+function messageTerminalFromDaemonEvent(
+  event: BackgroundAgentDaemonEvent,
+  expectedTurnId: string | undefined,
+): AgenCBackgroundAgentMessageTerminal | undefined {
+  const eventTurnId =
+    event.turnId ??
+    (typeof event.payload?.turnId === "string"
+      ? event.payload.turnId
+      : undefined);
+  if (
+    expectedTurnId !== undefined &&
+    eventTurnId !== undefined &&
+    eventTurnId !== expectedTurnId
+  ) {
+    return undefined;
+  }
+  if (event.type === "turn_complete") {
+    return {
+      code: 0,
+      ...(typeof event.payload?.lastAgentMessage === "string"
+        ? { message: event.payload.lastAgentMessage }
+        : {}),
+    };
+  }
+  if (event.type === "turn_aborted") {
+    return {
+      code: 130,
+      ...(typeof event.payload?.reason === "string"
+        ? { message: event.payload.reason }
+        : {}),
+    };
+  }
+  if (event.type === "error") {
+    return {
+      code: 1,
+      ...(typeof event.payload?.message === "string"
+        ? { message: event.payload.message }
+        : {}),
+    };
+  }
+  return undefined;
+}
+
+function assistantMessageId(turnId: string, ordinal: number): string {
+  return `assistant:${turnId}:${ordinal}`;
+}
+
+function historyEpochForBoundary(runId: string, boundaryId: string): string {
+  return `history:${runId}:${boundaryId}`;
+}
+
+function historyEpochFromRollout(
+  items: readonly RolloutItem[],
+  runId: string,
+): string {
+  return historyEpochForBoundary(
+    runId,
+    latestTranscriptBoundary(items, runId)?.id ?? "initial",
+  );
+}
+
+interface TranscriptBoundary {
+  readonly index: number;
+  readonly id: string;
+  readonly kind: "cleared" | "replaced";
+  readonly sequence?: number;
+}
+
+function latestTranscriptBoundary(
+  items: readonly RolloutItem[],
+  runId: string,
+): TranscriptBoundary | undefined {
+  let latest: TranscriptBoundary | undefined;
+  for (const [index, item] of items.entries()) {
+    if (
+      item.type === "event_msg" &&
+      (item.payload.msg.type === "history_cleared" ||
+        item.payload.msg.type === "transcript_epoch")
+    ) {
+      latest = {
+        index,
+        id: canonicalEventId(item.payload),
+        kind:
+          item.payload.msg.type === "history_cleared" ? "cleared" : "replaced",
+        ...(positiveSequence(item.payload.seq) !== undefined
+          ? { sequence: positiveSequence(item.payload.seq) }
+          : {}),
+      };
+      continue;
+    }
+    if (
+      item.type === "compacted" &&
+      item.payload.replacementHistory !== undefined
+    ) {
+      latest = {
+        index,
+        id: `compacted:${index}:${hashStable(JSON.stringify(item.payload.replacementHistory))}`,
+        kind: "replaced",
+      };
+      continue;
+    }
+    if (item.type === "compaction_committed") {
+      latest = {
+        index,
+        id: `compaction:${item.payload.attempt_id}`,
+        kind: "replaced",
+      };
+      continue;
+    }
+    if (
+      item.type === "compaction_rollback_committed" &&
+      item.payload.target_session_id === runId
+    ) {
+      latest = {
+        index,
+        id: `compaction-rollback:${item.payload.attempt_id}`,
+        kind: "replaced",
+      };
+    }
+  }
+  return latest;
+}
+
+function messageContentFingerprint(content: unknown): string {
+  return createHash("sha256")
+    .update(stableStringify(content) ?? "undefined", "utf8")
+    .digest("hex");
+}
+
+interface PersistedMessageSubmission {
+  readonly contentFingerprint: string;
+  readonly acceptedAt?: string;
+  readonly turnId?: string;
+  readonly terminal?: AgenCBackgroundAgentMessageTerminal;
+}
+
+function findPersistedMessageSubmission(
+  items: readonly RolloutItem[],
+  clientMessageId: string,
+): PersistedMessageSubmission | undefined {
+  let match: PersistedMessageSubmission | undefined;
+  for (const item of items) {
+    if (item.type !== "event_msg") continue;
+    const event = item.payload;
+    if (
+      match === undefined &&
+      ((event.msg.type === "user_message" &&
+        event.msg.payload.messageId === clientMessageId) ||
+        (event.msg.type === "message_submission" &&
+          event.msg.payload.messageId === clientMessageId))
+    ) {
+      const contentFingerprint =
+        event.msg.type === "message_submission"
+          ? event.msg.payload.contentFingerprint
+          : messageContentFingerprint(event.msg.payload.message);
+      const acceptedAt = event.msg.payload.acceptedAt;
+      match = {
+        contentFingerprint,
+        ...(acceptedAt !== undefined ? { acceptedAt } : {}),
+      };
+      continue;
+    }
+    if (match === undefined) continue;
+    // A user_message starts the next admitted submission. Never let a
+    // crash-tail retry inherit that later submission's turn_started or
+    // terminal outcome.
+    if (
+      event.msg.type === "user_message" ||
+      event.msg.type === "message_submission"
+    ) {
+      return match;
+    }
+    if (event.msg.type === "turn_started" && match.turnId === undefined) {
+      match = { ...match, turnId: event.msg.payload.turnId };
+      continue;
+    }
+    if (match.turnId === undefined) continue;
+    const terminal = messageTerminalFromEvent(event.msg, match.turnId);
+    if (terminal !== undefined) {
+      return { ...match, terminal };
+    }
+  }
+  return match;
+}
+
+function messageTerminalFromEvent(
+  event: Event["msg"],
+  expectedTurnId: string | undefined,
+): AgenCBackgroundAgentMessageTerminal | undefined {
+  if (event.type === "turn_complete") {
+    if (
+      expectedTurnId !== undefined &&
+      event.payload.turnId !== expectedTurnId
+    ) {
+      return undefined;
+    }
+    return {
+      code: 0,
+      ...(event.payload.lastAgentMessage !== undefined
+        ? { message: event.payload.lastAgentMessage }
+        : {}),
+    };
+  }
+  if (event.type === "turn_aborted") {
+    if (
+      expectedTurnId !== undefined &&
+      event.payload.turnId !== undefined &&
+      event.payload.turnId !== expectedTurnId
+    ) {
+      return undefined;
+    }
+    return { code: 130, message: event.payload.reason };
+  }
+  if (event.type === "error") {
+    if (
+      expectedTurnId !== undefined &&
+      event.payload.turnId !== undefined &&
+      event.payload.turnId !== expectedTurnId
+    ) {
+      return undefined;
+    }
+    return { code: 1, message: event.payload.message };
+  }
+  return undefined;
+}
+
+function clientMessageIdConflict(
+  clientMessageId: string,
+): AgenCBackgroundAgentMessageError {
+  return new AgenCBackgroundAgentMessageError(
+    "CLIENT_MESSAGE_ID_CONFLICT",
+    `clientMessageId ${clientMessageId} was already used for different content`,
+  );
+}
+
+const MAX_MESSAGE_SUBMISSION_CACHE = 1_024;
+
+function pruneMessageSubmissionCache(
+  submissions: Map<string, ActiveMessageSubmission>,
+): void {
+  if (submissions.size <= MAX_MESSAGE_SUBMISSION_CACHE) return;
+  for (const [clientMessageId, submission] of submissions) {
+    if (!submission.settled) continue;
+    submissions.delete(clientMessageId);
+    if (submissions.size <= MAX_MESSAGE_SUBMISSION_CACHE) return;
+  }
+}
+
+function canonicalEventId(event: Event): string {
+  return (
+    event.eventId ??
+    (event.seq !== undefined
+      ? `legacy-event:${event.seq}:${event.id}`
+      : event.id)
+  );
+}
+
+interface MutableTranscriptV2Message extends JsonObject {
+  messageId: string;
+  commitEventId: string;
+  role: "user" | "assistant";
+  text: string;
+  turnId?: string;
+  clientMessageId?: string;
+  committedSequence: number;
+}
+
+export function sessionTranscriptV2FromRollout(
+  items: readonly RolloutItem[],
+  sessionId: string,
+  runId: string,
+  activeTurn?: { readonly turnId: string; readonly clientMessageId: string },
+): SessionTranscriptV2Result {
+  const boundary = latestTranscriptBoundary(items, runId);
+  const boundaryIndex = boundary?.index ?? -1;
+  const boundaryId = boundary?.id ?? "initial";
+  let asOfSequence = 0;
+  for (const item of items) {
+    if (item.type !== "event_msg") continue;
+    const event = item.payload;
+    if (
+      event.seq !== undefined &&
+      Number.isSafeInteger(event.seq) &&
+      event.seq > asOfSequence
+    ) {
+      asOfSequence = event.seq;
+    }
+  }
+
+  const messages: MutableTranscriptV2Message[] = [];
+  let currentTurnId: string | undefined;
+  let currentClientMessageId: string | undefined;
+  let pendingUserIndex: number | undefined;
+  let pendingClientMessageId: string | undefined;
+  const assistantOrdinals = new Map<string, number>();
+
+  if (boundary?.kind === "replaced") {
+    const replacement = reconstructFromRollout(
+      items.slice(0, boundary.index + 1),
+    ).history;
+    const replacementSequence =
+      boundary.sequence ?? maxEventSequence(items.slice(0, boundary.index + 1));
+    let ordinal = 0;
+    for (const item of replacement) {
+      if (item.role !== "user" && item.role !== "assistant") continue;
+      const text = responseItemDisplayText(item.content);
+      if (text.length === 0) continue;
+      const messageId = `replacement:${boundary.id}:${ordinal}`;
+      messages.push({
+        messageId,
+        commitEventId: messageId,
+        role: item.role,
+        text,
+        committedSequence: replacementSequence,
+      });
+      ordinal += 1;
+    }
+  }
+
+  const transcriptStartIndex = boundaryIndex + 1;
+  const firstCanonicalTranscriptIndex = items.findIndex(
+    (item, index) =>
+      index >= transcriptStartIndex &&
+      item.type === "event_msg" &&
+      (item.payload.msg.type === "user_message" ||
+        item.payload.msg.type === "message_submission" ||
+        item.payload.msg.type === "agent_message"),
+  );
+  const legacyEndIndex =
+    firstCanonicalTranscriptIndex < 0
+      ? items.length
+      : firstCanonicalTranscriptIndex;
+  let legacyOrdinal = 0;
+  for (let index = transcriptStartIndex; index < legacyEndIndex; index += 1) {
+    const item = items[index]!;
+    if (item.type !== "response_item") continue;
+    if (item.payload.role !== "user" && item.payload.role !== "assistant") {
+      continue;
+    }
+    const text = responseItemDisplayText(item.payload.content);
+    if (text.length === 0) continue;
+    const messageId = `legacy:${boundaryId}:${legacyOrdinal}`;
+    messages.push({
+      messageId,
+      commitEventId: messageId,
+      role: item.payload.role,
+      text,
+      committedSequence: 0,
+    });
+    legacyOrdinal += 1;
+  }
+
+  // Scan canonical turn context from the epoch boundary, not merely from the
+  // first visible transcript row. Hidden-user submissions deliberately have
+  // no user_message, so their preceding turn_started is the only durable
+  // source for the assistant message identity.
+  for (let index = transcriptStartIndex; index < items.length; index += 1) {
+    const item = items[index]!;
+    if (item.type !== "event_msg") continue;
+    const event = item.payload;
+    const sequence = positiveSequence(event.seq);
+    if (sequence === undefined) continue;
+    if (event.msg.type === "message_submission") {
+      pendingUserIndex = undefined;
+      pendingClientMessageId = event.msg.payload.messageId;
+      continue;
+    }
+    if (event.msg.type === "user_message") {
+      const text =
+        event.msg.payload.displayText ??
+        unknownMessageContentDisplayText(event.msg.payload.message);
+      if (text.length === 0) continue;
+      const commitEventId = canonicalEventId(event);
+      const clientMessageId = event.msg.payload.messageId;
+      messages.push({
+        messageId: clientMessageId ?? `message:${commitEventId}`,
+        commitEventId,
+        role: "user",
+        text,
+        ...(clientMessageId !== undefined ? { clientMessageId } : {}),
+        committedSequence: sequence,
+      });
+      pendingUserIndex = messages.length - 1;
+      pendingClientMessageId = clientMessageId;
+      continue;
+    }
+    if (event.msg.type === "turn_started") {
+      currentTurnId = event.msg.payload.turnId;
+      if (pendingUserIndex !== undefined) {
+        messages[pendingUserIndex]!.turnId = currentTurnId;
+        pendingUserIndex = undefined;
+      }
+      currentClientMessageId = pendingClientMessageId;
+      pendingClientMessageId = undefined;
+      continue;
+    }
+    if (event.msg.type === "agent_message") {
+      const commitEventId = canonicalEventId(event);
+      const correlationId = currentTurnId ?? commitEventId;
+      const ordinal = assistantOrdinals.get(correlationId) ?? 0;
+      assistantOrdinals.set(correlationId, ordinal + 1);
+      const text = event.msg.payload.message;
+      // Empty durable commits are not transcript rows, but they still occupy
+      // an ordinal because the live identity allocator observes them.
+      if (text.length === 0) continue;
+      messages.push({
+        messageId:
+          currentTurnId === undefined
+            ? `assistant:${commitEventId}`
+            : assistantMessageId(currentTurnId, ordinal),
+        commitEventId,
+        role: "assistant",
+        text,
+        ...(currentTurnId !== undefined ? { turnId: currentTurnId } : {}),
+        ...(currentClientMessageId !== undefined
+          ? { clientMessageId: currentClientMessageId }
+          : {}),
+        committedSequence: sequence,
+      });
+      continue;
+    }
+    if (
+      event.msg.type === "turn_complete" ||
+      event.msg.type === "turn_aborted" ||
+      event.msg.type === "error"
+    ) {
+      const terminalTurnId =
+        "turnId" in event.msg.payload &&
+        typeof event.msg.payload.turnId === "string"
+          ? event.msg.payload.turnId
+          : undefined;
+      if (
+        (currentTurnId === undefined && pendingUserIndex !== undefined) ||
+        (currentTurnId !== undefined &&
+          terminalTurnId !== undefined &&
+          terminalTurnId !== currentTurnId)
+      ) {
+        continue;
+      }
+      currentTurnId = undefined;
+      currentClientMessageId = undefined;
+    }
+  }
+
+  return {
+    schemaVersion: 2,
+    sessionId,
+    runId,
+    historyEpoch: historyEpochForBoundary(runId, boundaryId),
+    asOfSequence,
+    messages,
+    ...(activeTurn !== undefined ? { activeTurn } : {}),
+  };
+}
+
+function maxEventSequence(items: readonly RolloutItem[]): number {
+  let max = 0;
+  for (const item of items) {
+    if (item.type !== "event_msg") continue;
+    const sequence = positiveSequence(item.payload.seq);
+    if (sequence !== undefined) max = Math.max(max, sequence);
+  }
+  return max;
+}
+
+function responseItemDisplayText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      isJsonObject(part) && typeof part.text === "string" ? part.text : "",
+    )
+    .join("");
+}
+
+function unknownMessageContentDisplayText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (!isJsonObject(part)) return "";
+      if (typeof part.text === "string") return part.text;
+      if (part.type === "image") return "[image]";
+      if (part.type === "document") return "[document]";
+      return "";
+    })
+    .filter((part) => part.length > 0)
+    .join("\n");
 }
 
 async function unavailableRealtimeTransport(): Promise<RealtimeTransportConnection> {
@@ -3900,15 +4820,29 @@ function eventBaseParams(
   readonly sessionId: string;
   readonly eventId: string;
   readonly agentId: string;
+  readonly runId?: string;
+  readonly historyEpoch?: string;
   readonly sequence?: number;
   readonly acceptedAt?: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
+  readonly messageId?: string;
 } {
   return {
     sessionId,
     eventId: event.eventId ?? event.id,
     agentId,
+    ...(event.runId !== undefined ? { runId: event.runId } : {}),
+    ...(event.historyEpoch !== undefined
+      ? { historyEpoch: event.historyEpoch }
+      : {}),
     ...(event.sequence !== undefined ? { sequence: event.sequence } : {}),
     ...(event.acceptedAt !== undefined ? { acceptedAt: event.acceptedAt } : {}),
+    ...(event.turnId !== undefined ? { turnId: event.turnId } : {}),
+    ...(event.clientMessageId !== undefined
+      ? { clientMessageId: event.clientMessageId }
+      : {}),
+    ...(event.messageId !== undefined ? { messageId: event.messageId } : {}),
   };
 }
 
@@ -4481,6 +5415,8 @@ const COLLAB_AGENT_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
  * impossible to reconcile with run.replay after reconnect.
  */
 const CANONICAL_CORE_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "history_cleared",
+  "transcript_epoch",
   "agent_message_delta",
   "tool_call_started",
   "tool_call_completed",
@@ -4626,6 +5562,9 @@ export function daemonEventFromUnboundSessionEvent(event: {
       ...(acceptedAt !== undefined ? { acceptedAt } : {}),
       payload: {
         message: payload.message,
+        ...(messageId !== undefined ? { messageId } : {}),
+        ...(streamId !== undefined ? { streamId } : {}),
+        ...(acceptedAt !== undefined ? { acceptedAt } : {}),
         ...(typeof payload.displayText === "string"
           ? { displayText: payload.displayText }
           : {}),

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -120,6 +120,7 @@ import {
   type SessionAttachParams,
   type SessionAttachResult,
   type SessionCancelTurnParams,
+  type SessionTranscriptV2Params,
   type SessionResolveToolCallEvidenceParams,
   type SessionResolveToolCallLegacyParams,
   type SessionResolveToolCallParams,
@@ -289,6 +290,7 @@ function buildServerCapabilities(
     "session.clear": hasMethod(agentManager, "clearSessionHistory"),
     "session.snapshot": hasMethod(agentManager, "snapshotSession"),
     "session.transcript": hasMethod(agentManager, "getSessionTranscript"),
+    "session.transcript.v2": hasMethod(agentManager, "getSessionTranscriptV2"),
     "session.cancelTurn": hasMethod(agentManager, "cancelSessionTurn"),
     "session.resolveToolCall": hasMethod(
       agentManager,
@@ -429,6 +431,7 @@ export interface AgenCDaemonDispatcherOptions {
     | "clearSessionHistory"
     | "snapshotSession"
     | "getSessionTranscript"
+    | "getSessionTranscriptV2"
     | "addMcpServerToSession"
     | "reconnectMcpServerOnSession"
     | "enableMcpServerOnSession"
@@ -519,6 +522,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     | "clearSessionHistory"
     | "snapshotSession"
     | "getSessionTranscript"
+    | "getSessionTranscriptV2"
     | "addMcpServerToSession"
     | "reconnectMcpServerOnSession"
     | "enableMcpServerOnSession"
@@ -758,6 +762,15 @@ export class AgenCDaemonJsonRpcDispatcher {
         });
       }
 
+      if (
+        method === "session.transcript.v2" &&
+        connection.initializeState?.serverCapabilities[
+          AGENC_DAEMON_METHOD_CAPABILITIES_KEY
+        ][method] !== true
+      ) {
+        return methodNotImplementedResponse(id, method);
+      }
+
       if (method === "request.cancel") {
         return successResponse(
           id,
@@ -938,6 +951,13 @@ export class AgenCDaemonJsonRpcDispatcher {
           id,
           await this.#agentManager.getSessionTranscript(
             validateSessionTranscriptParams(params),
+          ),
+        );
+      case "session.transcript.v2":
+        return successResponse(
+          id,
+          await this.#agentManager.getSessionTranscriptV2(
+            validateSessionTranscriptV2Params(params),
           ),
         );
       case "session.cancelTurn":
@@ -1236,9 +1256,23 @@ export class AgenCDaemonJsonRpcDispatcher {
           ),
         );
       case "message.send":
-        return this.#sendMessage(id, params, signal);
+        return this.#sendMessage(
+          id,
+          params,
+          signal,
+          connection.initializeState?.serverCapabilities[
+            AGENC_DAEMON_METHOD_CAPABILITIES_KEY
+          ]["session.transcript.v2"] === true,
+        );
       case "message.stream":
-        return this.#streamMessage(id, params, signal);
+        return this.#streamMessage(
+          id,
+          params,
+          signal,
+          connection.initializeState?.serverCapabilities[
+            AGENC_DAEMON_METHOD_CAPABILITIES_KEY
+          ]["session.transcript.v2"] === true,
+        );
       case "thread/realtime/start":
         return successResponse(
           id,
@@ -1597,24 +1631,51 @@ export class AgenCDaemonJsonRpcDispatcher {
     id: RequestId,
     params: JsonObject,
     signal: AbortSignal,
+    identitySafeCancellation: boolean,
   ): Promise<AgenCDaemonResponse> {
     const sendParams = validateMessageSendParams(params);
     const messageId = sendParams.clientMessageId ?? this.#createMessageId();
     const acceptedAt = this.#now();
-    await this.#runMessageWithCancel(signal, sendParams.sessionId, () =>
-      this.#agentManager.streamAgentMessage({
-        sessionId: sendParams.sessionId,
-        content: sendParams.content,
-        ...displayUserMessageFromMetadata("message.send", sendParams.metadata),
-        messageId,
-        streamId: messageId,
-        acceptedAt,
-        methodName: "message.send",
-      }),
+    const submissionResult = await this.#runMessageWithCancel(
+      signal,
+      sendParams.sessionId,
+      !identitySafeCancellation || sendParams.clientMessageId === undefined,
+      () =>
+        this.#agentManager.streamAgentMessage({
+          sessionId: sendParams.sessionId,
+          content: sendParams.content,
+          ...displayUserMessageFromMetadata(
+            "message.send",
+            sendParams.metadata,
+          ),
+          messageId,
+          streamId: messageId,
+          acceptedAt,
+          methodName: "message.send",
+          ...(sendParams.ifBusy !== undefined
+            ? { ifBusy: sendParams.ifBusy }
+            : {}),
+        }),
     );
+    const submission = submissionResult ?? {
+      disposition: "started" as const,
+      acceptedAt,
+    };
     return successResponse(id, {
       messageId,
-      acceptedAt,
+      acceptedAt: submission.acceptedAt,
+      ...(identitySafeCancellation
+        ? { disposition: submission.disposition }
+        : {}),
+      ...(identitySafeCancellation && submission.duplicateState !== undefined
+        ? { duplicateState: submission.duplicateState }
+        : {}),
+      ...(identitySafeCancellation && submission.turnId !== undefined
+        ? { turnId: submission.turnId }
+        : {}),
+      ...(identitySafeCancellation && submission.terminal !== undefined
+        ? { terminal: submission.terminal }
+        : {}),
     });
   }
 
@@ -1622,28 +1683,52 @@ export class AgenCDaemonJsonRpcDispatcher {
     id: RequestId,
     params: JsonObject,
     signal: AbortSignal,
+    identitySafeCancellation: boolean,
   ): Promise<AgenCDaemonResponse> {
     const streamParams = validateMessageStreamParams(params);
     const messageId = streamParams.clientMessageId ?? this.#createMessageId();
     const streamId = streamParams.streamId ?? messageId;
     const acceptedAt = this.#now();
-    await this.#runMessageWithCancel(signal, streamParams.sessionId, () =>
-      this.#agentManager.streamAgentMessage({
-        sessionId: streamParams.sessionId,
-        content: streamParams.content,
-        ...displayUserMessageFromMetadata(
-          "message.stream",
-          streamParams.metadata,
-        ),
-        messageId,
-        streamId,
-        acceptedAt,
-      }),
+    const submissionResult = await this.#runMessageWithCancel(
+      signal,
+      streamParams.sessionId,
+      !identitySafeCancellation || streamParams.clientMessageId === undefined,
+      () =>
+        this.#agentManager.streamAgentMessage({
+          sessionId: streamParams.sessionId,
+          content: streamParams.content,
+          ...displayUserMessageFromMetadata(
+            "message.stream",
+            streamParams.metadata,
+          ),
+          messageId,
+          streamId,
+          acceptedAt,
+          ...(streamParams.ifBusy !== undefined
+            ? { ifBusy: streamParams.ifBusy }
+            : {}),
+        }),
     );
+    const submission = submissionResult ?? {
+      disposition: "started" as const,
+      acceptedAt,
+    };
     return successResponse(id, {
       messageId,
       streamId,
-      acceptedAt,
+      acceptedAt: submission.acceptedAt,
+      ...(identitySafeCancellation
+        ? { disposition: submission.disposition }
+        : {}),
+      ...(identitySafeCancellation && submission.duplicateState !== undefined
+        ? { duplicateState: submission.duplicateState }
+        : {}),
+      ...(identitySafeCancellation && submission.turnId !== undefined
+        ? { turnId: submission.turnId }
+        : {}),
+      ...(identitySafeCancellation && submission.terminal !== undefined
+        ? { terminal: submission.terminal }
+        : {}),
     });
   }
 
@@ -1651,12 +1736,19 @@ export class AgenCDaemonJsonRpcDispatcher {
    * Await a full-turn message RPC while honoring request.cancel (todo-107).
    * On abort, interrupt the session turn so tools/model work stop promptly.
    */
-  async #runMessageWithCancel(
+  async #runMessageWithCancel<T>(
     signal: AbortSignal,
     sessionId: string,
-    run: () => Promise<void>,
-  ): Promise<void> {
+    allowUnscopedCancel: boolean,
+    run: () => Promise<T>,
+  ): Promise<T> {
     const cancelTurn = async (): Promise<void> => {
+      // Protocol 1.2 identity-bearing submissions deliberately fail closed
+      // until their durable user_message + turnId are correlated. A
+      // connection abort must never turn into a session-wide cancellation of
+      // somebody else's active turn. The client issues expectedTurnId cancel
+      // separately once it owns that correlation.
+      if (!allowUnscopedCancel) return;
       // Mocks and partial managers may omit cancelSessionTurn — never throw
       // from the abort path (connection teardown aborts in-flight signals).
       const cancel = (
@@ -1684,14 +1776,15 @@ export class AgenCDaemonJsonRpcDispatcher {
     };
     signal.addEventListener("abort", onAbort, { once: true });
     try {
-      await run();
+      const result = await run();
+      if (signal.aborted) {
+        throw Object.assign(new Error("request cancelled"), {
+          name: "AbortError",
+        });
+      }
+      return result;
     } finally {
       signal.removeEventListener("abort", onAbort);
-    }
-    if (signal.aborted) {
-      throw Object.assign(new Error("request cancelled"), {
-        name: "AbortError",
-      });
     }
   }
 }
@@ -1971,14 +2064,18 @@ function negotiateInitializeProtocol(
     return { supported: false, clientVersion };
   }
   const clientProtocol = parseProtocolVersion(clientVersion)!;
+  const methodCapabilities = {
+    ...serverCapabilities[AGENC_DAEMON_METHOD_CAPABILITIES_KEY],
+    ...(clientProtocol.minor < 1
+      ? { "workspace.editor.topology.recovered.resolve": false }
+      : {}),
+    ...(clientProtocol.minor < 2 ? { "session.transcript.v2": false } : {}),
+  };
   const negotiatedCapabilities =
-    clientProtocol.minor < 1
+    clientProtocol.minor < 2
       ? ({
           ...serverCapabilities,
-          [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: {
-            ...serverCapabilities[AGENC_DAEMON_METHOD_CAPABILITIES_KEY],
-            "workspace.editor.topology.recovered.resolve": false,
-          },
+          [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: methodCapabilities,
         } satisfies AgenCDaemonServerCapabilities)
       : serverCapabilities;
   return {
@@ -2596,12 +2693,23 @@ function validateSessionTranscriptParams(
   return validated as SessionTranscriptParams;
 }
 
+function validateSessionTranscriptV2Params(
+  params: JsonObject,
+): SessionTranscriptV2Params {
+  const validated = validateObjectShape(params, {
+    methodName: "session.transcript.v2",
+    stringFields: ["sessionId"],
+  });
+  validateRequiredString(validated, "session.transcript.v2", "sessionId");
+  return validated as SessionTranscriptV2Params;
+}
+
 function validateSessionCancelTurnParams(
   params: JsonObject,
 ): SessionCancelTurnParams {
   const validated = validateObjectShape(params, {
     methodName: "session.cancelTurn",
-    stringFields: ["sessionId", "reason"],
+    stringFields: ["sessionId", "reason", "expectedTurnId"],
   });
   validateRequiredString(validated, "session.cancelTurn", "sessionId");
   return validated as SessionCancelTurnParams;
@@ -2927,19 +3035,22 @@ function validateSessionApplyConfigParams(
 function validateMessageSendParams(params: JsonObject): MessageSendParams {
   const validated = validateObjectShape(params, {
     methodName: "message.send",
-    stringFields: ["sessionId", "clientMessageId"],
+    stringFields: ["sessionId", "clientMessageId", "ifBusy"],
     objectFields: ["metadata"],
     valueFields: ["content"],
   });
   validateRequiredString(validated, "message.send", "sessionId");
   validateMessageContent("message.send", "content", validated.content);
+  if (validated.ifBusy !== undefined && validated.ifBusy !== "reject") {
+    throw invalidParams("message.send param 'ifBusy' must be 'reject'");
+  }
   return validated as MessageSendParams;
 }
 
 function validateMessageStreamParams(params: JsonObject): MessageStreamParams {
   const validated = validateObjectShape(params, {
     methodName: "message.stream",
-    stringFields: ["sessionId", "clientMessageId", "streamId"],
+    stringFields: ["sessionId", "clientMessageId", "streamId", "ifBusy"],
     objectFields: ["metadata"],
     valueFields: ["content"],
   });
@@ -2950,6 +3061,9 @@ function validateMessageStreamParams(params: JsonObject): MessageStreamParams {
     throw invalidParams("message.stream requires sessionId");
   }
   validateMessageContent("message.stream", "content", validated.content);
+  if (validated.ifBusy !== undefined && validated.ifBusy !== "reject") {
+    throw invalidParams("message.stream param 'ifBusy' must be 'reject'");
+  }
   return validated as MessageStreamParams;
 }
 

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -12,12 +12,10 @@
  */
 
 export const JSON_RPC_VERSION = "2.0" as const;
-// 1.1 adds exact stale-Editor authority review/abandonment fields and its
-// read-only disk-evidence refresh request. A newer TUI must not negotiate with
-// a 1.0 daemon that would reject those requests after initialization; the
-// existing minor-version negotiation then produces the normal actionable
-// daemon-restart error instead.
-export const AGENC_DAEMON_PROTOCOL_VERSION = "1.1.0" as const;
+// 1.2 adds an identity-bearing transcript projection and turn-scoped
+// cancellation. Clients that depend on those race-free semantics must not
+// negotiate with an older daemon that cannot provide them.
+export const AGENC_DAEMON_PROTOCOL_VERSION = "1.2.0" as const;
 export const AGENC_DAEMON_PROTOCOL_SCHEMA_ID =
   "urn:agenc:app-server:protocol" as const;
 export const AGENC_DAEMON_PROTOCOL_PACKAGE_NAME =
@@ -68,6 +66,7 @@ export const AGENC_DAEMON_METHODS = [
   "session.clear",
   "session.snapshot",
   "session.transcript",
+  "session.transcript.v2",
   "session.cancelTurn",
   "session.resolveToolCall",
   "session.mcp.addServer",
@@ -409,6 +408,14 @@ export const AGENC_DAEMON_METHOD_SPECS = defineMethodSpecs({
     result: "object",
     description:
       "Read a daemon-owned session's conversation history (user/assistant messages) so a client joining an existing session (e.g. one started in another client) can render the prior transcript.",
+  },
+  "session.transcript.v2": {
+    method: "session.transcript.v2",
+    direction: "client-to-server",
+    params: "required",
+    result: "object",
+    description:
+      "Read an identity-bearing, sequence-watermarked transcript projection suitable for atomic snapshot-plus-live reconciliation.",
   },
   "session.cancelTurn": {
     method: "session.cancelTurn",
@@ -1300,6 +1307,8 @@ export interface SessionSnapshotParams extends JsonObject {
 export interface SessionCancelTurnParams extends JsonObject {
   readonly sessionId: string;
   readonly reason?: string;
+  /** Cancel only when this exact turn is still active. */
+  readonly expectedTurnId?: string;
 }
 
 export interface SessionMcpServerConfig extends JsonObject {
@@ -1619,6 +1628,8 @@ export interface MessageSendParams extends JsonObject {
   readonly sessionId: string;
   readonly content: MessageContent;
   readonly clientMessageId?: string;
+  /** Opt in to fail-fast admission instead of the legacy session queue. */
+  readonly ifBusy?: "reject";
   readonly metadata?: JsonObject;
 }
 
@@ -1840,13 +1851,17 @@ export interface AgenCEventBaseParams extends JsonObject {
   readonly sessionId: string;
   readonly eventId: string;
   readonly agentId?: string;
+  readonly runId?: string;
+  readonly historyEpoch?: string;
   readonly sequence?: number;
   readonly acceptedAt?: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
+  readonly messageId?: string;
   readonly metadata?: JsonObject;
 }
 
 export interface EventMessageChunkParams extends AgenCEventBaseParams {
-  readonly messageId?: string;
   readonly streamId?: string;
   readonly delta: string;
 }
@@ -2104,6 +2119,10 @@ export type AgenCDaemonRequest =
   | AgenCDaemonRequestWithParams<"session.clear", SessionClearParams>
   | AgenCDaemonRequestWithParams<"session.snapshot", SessionSnapshotParams>
   | AgenCDaemonRequestWithParams<"session.transcript", SessionTranscriptParams>
+  | AgenCDaemonRequestWithParams<
+      "session.transcript.v2",
+      SessionTranscriptV2Params
+    >
   | AgenCDaemonRequestWithParams<"session.cancelTurn", SessionCancelTurnParams>
   | AgenCDaemonRequestWithParams<
       "session.resolveToolCall",
@@ -2814,6 +2833,10 @@ export interface SessionTranscriptParams extends JsonObject {
   readonly sessionId: string;
 }
 
+export interface SessionTranscriptV2Params extends JsonObject {
+  readonly sessionId: string;
+}
+
 export interface SessionTranscriptMessage extends JsonObject {
   readonly role: string; // "user" | "assistant"
   readonly text: string;
@@ -2822,6 +2845,32 @@ export interface SessionTranscriptMessage extends JsonObject {
 export interface SessionTranscriptResult extends JsonObject {
   readonly sessionId: string;
   readonly messages: readonly SessionTranscriptMessage[];
+}
+
+export interface SessionTranscriptV2Message extends JsonObject {
+  readonly messageId: string;
+  readonly commitEventId: string;
+  readonly role: "user" | "assistant";
+  readonly text: string;
+  readonly turnId?: string;
+  readonly clientMessageId?: string;
+  /** Zero only for migrated response_item rows that predate event sequencing. */
+  readonly committedSequence: number;
+}
+
+export interface SessionTranscriptV2ActiveTurn extends JsonObject {
+  readonly turnId: string;
+  readonly clientMessageId?: string;
+}
+
+export interface SessionTranscriptV2Result extends JsonObject {
+  readonly schemaVersion: 2;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly historyEpoch: string;
+  readonly asOfSequence: number;
+  readonly messages: readonly SessionTranscriptV2Message[];
+  readonly activeTurn?: SessionTranscriptV2ActiveTurn;
 }
 
 export interface SessionCancelTurnResult extends JsonObject {
@@ -2833,6 +2882,8 @@ export interface SessionCancelTurnResult extends JsonObject {
    */
   readonly cancelled: boolean;
   readonly reason?: string;
+  readonly activeTurnId?: string;
+  readonly stale?: boolean;
 }
 
 export interface SessionMcpAddServerResult extends JsonObject {
@@ -3164,6 +3215,16 @@ export interface SessionApplyConfigResult extends JsonObject {
 export interface MessageSendResult extends JsonObject {
   readonly messageId: string;
   readonly acceptedAt: string;
+  readonly disposition?: "started" | "duplicate";
+  /** Present for duplicate submissions so callers never guess crash outcomes. */
+  readonly duplicateState?: "completed" | "incomplete";
+  readonly turnId?: string;
+  readonly terminal?: MessageSendTerminalResult;
+}
+
+export interface MessageSendTerminalResult extends JsonObject {
+  readonly code: 0 | 1 | 130;
+  readonly message?: string;
 }
 
 export interface MessageStreamResult extends MessageSendResult {
@@ -3354,6 +3415,7 @@ export interface AgenCDaemonResultByMethod {
   readonly "session.clear": SessionClearResult;
   readonly "session.snapshot": SessionSnapshotResult;
   readonly "session.transcript": SessionTranscriptResult;
+  readonly "session.transcript.v2": SessionTranscriptV2Result;
   readonly "session.cancelTurn": SessionCancelTurnResult;
   readonly "session.resolveToolCall": SessionResolveToolCallResult;
   readonly "session.mcp.addServer": SessionMcpAddServerResult;

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -234,9 +234,7 @@ export interface TurnCheckpointV2Event extends TurnCheckpointBase {
   readonly toolResultIntegrityVersion: 1;
 }
 
-export type TurnCheckpointEvent =
-  | TurnCheckpointV1Event
-  | TurnCheckpointV2Event;
+export type TurnCheckpointEvent = TurnCheckpointV1Event | TurnCheckpointV2Event;
 
 /**
  * Serialized, JSON-safe projection of the resumable `TurnState` counters.
@@ -291,6 +289,17 @@ export interface UserMessageEvent {
   readonly messageId?: string;
   readonly streamId?: string;
   readonly acceptedAt?: string;
+}
+
+/**
+ * Durable idempotency identity for a daemon submission whose user content is
+ * intentionally hidden from transcript clients.
+ */
+export interface MessageSubmissionEvent {
+  readonly contentFingerprint: string;
+  readonly messageId: string;
+  readonly streamId: string;
+  readonly acceptedAt: string;
 }
 
 export interface TokenCountEvent {
@@ -930,6 +939,16 @@ export type EventMsg =
       readonly type: "session_configured";
       readonly payload: SessionConfiguredEvent;
     }
+  | {
+      readonly type: "history_cleared";
+      readonly payload: { readonly timestamp: number };
+    }
+  | {
+      readonly type: "transcript_epoch";
+      readonly payload: {
+        readonly reason: "partial_compact" | "rewind" | "compaction_rollback";
+      };
+    }
   | { readonly type: "turn_started"; readonly payload: TurnStartedEvent }
   | { readonly type: "turn_context"; readonly payload: TurnContextItem }
   | { readonly type: "agent_message"; readonly payload: AgentMessageEvent }
@@ -969,6 +988,10 @@ export type EventMsg =
       };
     }
   | { readonly type: "user_message"; readonly payload: UserMessageEvent }
+  | {
+      readonly type: "message_submission";
+      readonly payload: MessageSubmissionEvent;
+    }
   | { readonly type: "token_count"; readonly payload: TokenCountEvent }
   | {
       readonly type: "mcp_tool_call_begin";
@@ -1297,6 +1320,9 @@ export const KNOWN_EVENT_TYPES = Object.freeze(
   new Set<string>([
     "session_meta",
     "session_configured",
+    "history_cleared",
+    "transcript_epoch",
+    "message_submission",
     "turn_started",
     "turn_context",
     "agent_message",
@@ -1384,6 +1410,9 @@ export function isKnownEventType(type: string): boolean {
  */
 const DURABLE_EVENT_TYPES = Object.freeze(
   new Set<string>([
+    "history_cleared",
+    "transcript_epoch",
+    "message_submission",
     "turn_complete",
     "turn_aborted",
     "error",

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -626,6 +626,10 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
       rolloutPath: isString,
     },
   ),
+  history_cleared: objectShape({ timestamp: isNumber }),
+  transcript_epoch: objectShape({
+    reason: oneOf("partial_compact", "rewind", "compaction_rollback"),
+  }),
   turn_started: objectShape(
     { turnId: isString },
     {
@@ -668,6 +672,12 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
       acceptedAt: isString,
     },
   ),
+  message_submission: objectShape({
+    contentFingerprint: isString,
+    messageId: isString,
+    streamId: isString,
+    acceptedAt: isString,
+  }),
   token_count: objectShape(
     {},
     {

--- a/runtime/tests/app-server-protocol/portal.contract.test.ts
+++ b/runtime/tests/app-server-protocol/portal.contract.test.ts
@@ -129,8 +129,8 @@ describe("AgenC portal protocol contract", () => {
       id: "initialize",
       method: "initialize",
       params: {
-        protocolVersion: "1.1.0",
-        protocol: { version: "1.1.0" },
+        protocolVersion: "1.2.0",
+        protocol: { version: "1.2.0" },
         clientName: "agenc-portal",
         capabilities: AGENC_PORTAL_CLIENT_CAPABILITY_FLAGS,
       },

--- a/runtime/tests/app-server/agent-cli.contract.test.ts
+++ b/runtime/tests/app-server/agent-cli.contract.test.ts
@@ -977,6 +977,7 @@ autostart = false
           messageId: "message_socket",
           streamId: "stream_socket",
           acceptedAt: "2026-05-01T12:00:03.500Z",
+          disposition: "started",
         });
         unsubscribe();
       } finally {

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -948,7 +948,10 @@ describe("AgenC background agent lifecycle", () => {
         streamId: "stream-runtime-restored",
         acceptedAt: "2026-05-01T12:06:00.000Z",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({
+      disposition: "started",
+      acceptedAt: "2026-05-01T12:06:00.000Z",
+    });
     expect(submitted).toEqual([
       {
         agentId: "agent-runtime-restored",
@@ -3253,7 +3256,10 @@ describe("AgenC background agent lifecycle", () => {
         streamId: "stream_snapshot_error",
         acceptedAt: "2026-05-01T12:00:01.000Z",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({
+      disposition: "started",
+      acceptedAt: "2026-05-01T12:00:01.000Z",
+    });
 
     expect(submitted).toHaveLength(1);
     expect(errors.map((error) => (error as Error).message)).toEqual([
@@ -3581,7 +3587,7 @@ describe("AgenC background agent lifecycle", () => {
         id: "future-protocol",
         method: "initialize",
         params: {
-          protocol: { version: "1.2.0" },
+          protocol: { version: "1.3.0" },
           clientName: "contract-test",
         },
       }),
@@ -3593,8 +3599,8 @@ describe("AgenC background agent lifecycle", () => {
         message: "Unsupported protocol version",
         data: {
           code: "PROTOCOL_VERSION_UNSUPPORTED",
-          clientVersion: "1.2.0",
-          serverVersion: "1.1.0",
+          clientVersion: "1.3.0",
+          serverVersion: "1.2.0",
         },
       },
     });
@@ -3656,16 +3662,16 @@ describe("AgenC background agent lifecycle", () => {
       id: 1,
       result: {
         type: "initialized",
-        protocolVersion: "1.1.0",
-        protocol: { version: "1.1.0" },
+        protocolVersion: "1.2.0",
+        protocol: { version: "1.2.0" },
         capabilities: {},
       },
     });
-    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.1.0");
+    expect(AGENC_DAEMON_PROTOCOL_VERSION).toBe("1.2.0");
     expect(connection.initializeState).toMatchObject({
-      protocol: { version: "1.1.0" },
+      protocol: { version: "1.2.0" },
       clientProtocol: { version: "1.0.0" },
-      serverProtocol: { version: "1.1.0" },
+      serverProtocol: { version: "1.2.0" },
       clientCapabilities: { experimentalApi: true },
     });
     expect(
@@ -3674,6 +3680,7 @@ describe("AgenC background agent lifecycle", () => {
       ],
     ).toMatchObject({
       "agent.create": true,
+      "session.transcript.v2": false,
       "session.create": false,
       "daemon.reload": false,
       "auth.login": false,

--- a/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
@@ -82,8 +82,13 @@ function makeTopLevelRunner(opts: { readonly conversationId: string }) {
     interrupt: vi.fn(),
     clearConversationHistory: vi.fn(async () => {}),
   };
+  const rolloutStore = {
+    rolloutPath: `/tmp/${opts.conversationId}.jsonl`,
+    readAll: () => [],
+  };
   const bootstrap = vi.fn(async () => ({
     session,
+    rolloutStore,
     registry: { tools: [], toLLMTools: () => [], dispatch: vi.fn() },
     shutdown: vi.fn(async () => {}),
   })) as unknown as ReturnType<typeof vi.fn> & AgenCBootstrapFunction;

--- a/runtime/tests/app-server/background-agent-runner.config-model-state.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.config-model-state.test.ts
@@ -131,8 +131,13 @@ function makeRunnerHarness(opts: {
     openThreadSpawnChildren: vi.fn(() => []),
     clearConversationHistory: vi.fn(async () => {}),
   };
+  const rolloutStore = {
+    rolloutPath: `/tmp/${conversationId}.jsonl`,
+    readAll: () => [],
+  };
   const bootstrap = vi.fn(async () => ({
     session,
+    rolloutStore,
     registry: { tools: [], toLLMTools: () => [], dispatch: vi.fn() },
     shutdown: vi.fn(async () => {}),
   })) as unknown as ReturnType<typeof vi.fn> & AgenCBootstrapFunction;

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -5,6 +5,7 @@ import { transformSync } from "esbuild";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  AgenCBackgroundAgentMessageError,
   AgenCDelegateBackgroundAgentRunner,
   daemonEventFromUnboundSessionEvent,
   notificationFromDaemonEvent,
@@ -103,6 +104,7 @@ function makeStubConversationThreadManager(opts: {
     readonly outputTokens: number;
     readonly totalTokens: number;
   };
+  readonly scopedTurnCancellation?: boolean;
 }) {
   let listeners: ((status: AgentStatus) => void)[] = [];
   let currentStatus: AgentStatus =
@@ -231,6 +233,15 @@ function makeTopLevelRunner(opts: {
     rolloutPath: `/tmp/${opts.conversationId}.jsonl`,
     readAll: () => [...rolloutItems],
   };
+  let activeTurnValue: { readonly turnId: string } | null = null;
+  const abortTurnIfActive = vi.fn(async (turnId: string) => {
+    if (activeTurnValue?.turnId !== turnId) return false;
+    activeTurnValue = null;
+    return true;
+  });
+  const activeTurn = {
+    unsafePeek: () => activeTurnValue,
+  };
   const session = {
     conversationId: opts.conversationId,
     permissionModeRegistry,
@@ -291,6 +302,9 @@ function makeTopLevelRunner(opts: {
     rolloutStore,
     services: { conversationThreadManager: stub },
   };
+  if (opts.scopedTurnCancellation === true) {
+    Object.assign(session, { abortTurnIfActive, activeTurn });
+  }
   const shutdown = vi.fn(async () => {
     await shutdownImpl();
     while (durableOperations.size > 0) {
@@ -352,6 +366,11 @@ function makeTopLevelRunner(opts: {
     permissionUpdates,
     permissionModeRegistry,
     rolloutItems,
+    abortTurnIfActive,
+    activeTurn,
+    setActiveTurn(turnId: string | null) {
+      activeTurnValue = turnId === null ? null : { turnId };
+    },
   };
 }
 
@@ -626,16 +645,26 @@ describe("AgenC delegate background-agent runner", () => {
     });
     emitted.length = 0;
 
-    await expect(runner.rollbackCompaction?.(started.agentId, {
-      sessionId: "session-rollback-replacement",
-      attemptId: "attempt-rollback",
-    })).resolves.toMatchObject({
+    await expect(
+      runner.rollbackCompaction?.(started.agentId, {
+        sessionId: "session-rollback-replacement",
+        attemptId: "attempt-rollback",
+      }),
+    ).resolves.toMatchObject({
       ok: true,
       eventAlreadyEmitted: true,
       event: replacementEvent,
     });
-    expect(emitted).toHaveLength(1);
+    expect(emitted).toHaveLength(2);
     expect(emitted[0]).toMatchObject({
+      params: {
+        event: {
+          type: "transcript_epoch",
+          payload: { reason: "compaction_rollback" },
+        },
+      },
+    });
+    expect(emitted[1]).toMatchObject({
       params: {
         event: {
           type: "history_replaced",
@@ -2091,6 +2120,630 @@ describe("AgenC delegate background-agent runner", () => {
     expect(emitted).toHaveLength(1);
   });
 
+  it("[managed-thread] correlates every live turn surface to one admitted message", async () => {
+    const { runner, control, session } = makeTopLevelRunner({
+      conversationId: "session-correlated-events",
+    });
+    const emitted: JsonObject[] = [];
+    await runner.startAgent({
+      objective: "hi",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-correlated-events", {
+      sessionId: "session_1",
+      emit: (notification) => emitted.push(notification),
+    });
+    emitted.length = 0;
+    control.sendInput.mockImplementationOnce(async () => {
+      session.emit({
+        id: "stale-complete",
+        msg: {
+          type: "turn_complete",
+          payload: { turnId: "turn-before", lastAgentMessage: "older answer" },
+        },
+      });
+      session.emit({
+        id: "turn-correlated",
+        msg: {
+          type: "turn_started",
+          payload: { turnId: "turn-correlated" },
+        },
+      });
+      session.emit({
+        id: "delta-correlated",
+        msg: { type: "agent_message_delta", payload: { delta: "hello" } },
+      });
+      session.emit({
+        id: "permission-correlated",
+        msg: {
+          type: "request_permissions",
+          payload: {
+            callId: "permission-correlated",
+            toolName: "Read",
+            turnId: "turn-correlated",
+            permissions: ["read"],
+          },
+        },
+      });
+      session.emit({
+        id: "input-correlated",
+        msg: {
+          type: "request_user_input",
+          payload: {
+            callId: "input-correlated",
+            turnId: "turn-correlated",
+            questions: [],
+          },
+        },
+      });
+      session.emit({
+        id: "elicitation-correlated",
+        msg: {
+          type: "mcp_elicitation_request",
+          payload: {
+            serverName: "server",
+            requestId: "elicitation-correlated",
+            turnId: "turn-correlated",
+            request: {},
+          },
+        },
+      });
+      session.emit({
+        id: "empty-committed-correlated",
+        msg: {
+          type: "agent_message",
+          payload: { message: "" },
+        },
+      });
+      session.emit({
+        id: "committed-correlated",
+        msg: {
+          type: "agent_message",
+          payload: { message: "hello" },
+        },
+      });
+      session.emit({
+        id: "complete-correlated",
+        msg: {
+          type: "turn_complete",
+          payload: { turnId: "turn-correlated", lastAgentMessage: "hello" },
+        },
+      });
+    });
+
+    await runner.submitAgentMessage("session-correlated-events", {
+      sessionId: "session_1",
+      content: "correlate me",
+      originalContent: "correlate me",
+      messageId: "client-correlated",
+      streamId: "client-correlated",
+      acceptedAt: "2026-08-17T00:00:00.000Z",
+    });
+
+    expect(
+      emitted.find((notification) => {
+        const params = notification.params as JsonObject | undefined;
+        const event = params?.event as JsonObject | undefined;
+        return event?.type === "user_message";
+      })?.params,
+    ).toMatchObject({
+      clientMessageId: "client-correlated",
+      messageId: "client-correlated",
+      event: {
+        messageId: "client-correlated",
+        payload: { messageId: "client-correlated" },
+      },
+    });
+    expect(
+      (
+        emitted.find((notification) => {
+          const params = notification.params as JsonObject | undefined;
+          return params?.eventId === "stale-complete";
+        })?.params as JsonObject | undefined
+      )?.clientMessageId,
+    ).toBeUndefined();
+
+    const turnNotifications = emitted.filter((notification) => {
+      const params = notification.params as JsonObject | undefined;
+      return params?.turnId === "turn-correlated";
+    });
+    expect(turnNotifications).toHaveLength(8);
+    for (const notification of turnNotifications) {
+      expect(notification.params).toMatchObject({
+        runId: "session-correlated-events",
+        historyEpoch: "history:session-correlated-events:initial",
+        turnId: "turn-correlated",
+        clientMessageId: "client-correlated",
+      });
+    }
+    expect(
+      turnNotifications.find(
+        (notification) => notification.method === "event.message_chunk",
+      )?.params,
+    ).toMatchObject({ messageId: "assistant:turn-correlated:0" });
+    expect(
+      turnNotifications.find(
+        (notification) =>
+          notification.method === "event.session_event" &&
+          (
+            (notification.params as JsonObject | undefined)?.event as
+              JsonObject | undefined
+          )?.id === "committed-correlated",
+      )?.params,
+    ).toMatchObject({ messageId: "assistant:turn-correlated:1" });
+
+    await expect(
+      runner.getAgentSessionTranscriptV2("session-correlated-events", {
+        sessionId: "session_1",
+      }),
+    ).resolves.toMatchObject({
+      runId: "session-correlated-events",
+      historyEpoch: "history:session-correlated-events:initial",
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          messageId: "client-correlated",
+          clientMessageId: "client-correlated",
+          turnId: "turn-correlated",
+        }),
+        expect.objectContaining({
+          messageId: "assistant:turn-correlated:1",
+          clientMessageId: "client-correlated",
+          turnId: "turn-correlated",
+        }),
+      ]),
+    });
+  });
+
+  it("[managed-thread] gives an uncorrelated committed message the same live and snapshot id", async () => {
+    const { runner, session } = makeTopLevelRunner({
+      conversationId: "session-background-commit-id",
+    });
+    const emitted: JsonObject[] = [];
+    await runner.startAgent({
+      objective: "hi",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-background-commit-id", {
+      sessionId: "session_1",
+      emit: (notification) => emitted.push(notification),
+    });
+    emitted.length = 0;
+
+    session.emit({
+      id: "background-commit",
+      msg: {
+        type: "agent_message",
+        payload: { message: "background answer" },
+      },
+    });
+    await vi.waitFor(() => expect(emitted).toHaveLength(1));
+
+    const liveParams = emitted[0]?.params as JsonObject | undefined;
+    const liveMessageId = liveParams?.messageId;
+    const snapshot = await runner.getAgentSessionTranscriptV2(
+      "session-background-commit-id",
+      { sessionId: "session_1" },
+    );
+    const committed = snapshot.messages.find(
+      (message) => message.text === "background answer",
+    );
+    expect(liveMessageId).toBe(`assistant:${String(liveParams?.eventId)}`);
+    expect(committed?.messageId).toBe(liveMessageId);
+  });
+
+  it("[managed-thread] retains turn identity for a hidden-user assistant commit", async () => {
+    const { runner, control, session, rolloutItems } = makeTopLevelRunner({
+      conversationId: "session-hidden-user-id",
+    });
+    const emitted: JsonObject[] = [];
+    await runner.startAgent({
+      objective: "passive",
+      initialContent: [],
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await runner.attachAgentSessionEvents("session-hidden-user-id", {
+      sessionId: "session_1",
+      emit: (notification) => emitted.push(notification),
+    });
+    emitted.length = 0;
+    control.sendInput.mockImplementationOnce(async () => {
+      session.emit({
+        id: "turn-hidden",
+        msg: {
+          type: "turn_started",
+          payload: { turnId: "turn-hidden" },
+        },
+      });
+      session.emit({
+        id: "assistant-hidden",
+        msg: {
+          type: "agent_message",
+          payload: { message: "hidden answer" },
+        },
+      });
+      session.emit({
+        id: "complete-hidden",
+        msg: {
+          type: "turn_complete",
+          payload: {
+            turnId: "turn-hidden",
+            lastAgentMessage: "hidden answer",
+          },
+        },
+      });
+    });
+
+    await runner.submitAgentMessage("session-hidden-user-id", {
+      sessionId: "session_1",
+      content: "internal prompt",
+      originalContent: "internal prompt",
+      displayUserMessage: null,
+      messageId: "client-hidden",
+      streamId: "client-hidden",
+      acceptedAt: "2026-08-18T00:00:00.000Z",
+    });
+
+    expect(
+      emitted.some((notification) => {
+        const params = notification.params as JsonObject | undefined;
+        const event = params?.event as JsonObject | undefined;
+        return event?.type === "user_message";
+      }),
+    ).toBe(false);
+    const liveCommit = emitted.find((notification) => {
+      const params = notification.params as JsonObject | undefined;
+      const event = params?.event as JsonObject | undefined;
+      return event?.id === "assistant-hidden";
+    });
+    expect(liveCommit?.params).toMatchObject({
+      turnId: "turn-hidden",
+      clientMessageId: "client-hidden",
+      messageId: "assistant:turn-hidden:0",
+    });
+
+    const snapshot = await runner.getAgentSessionTranscriptV2(
+      "session-hidden-user-id",
+      { sessionId: "session_1" },
+    );
+    expect(snapshot.messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        text: "hidden answer",
+        turnId: "turn-hidden",
+        clientMessageId: "client-hidden",
+        messageId: "assistant:turn-hidden:0",
+      }),
+    ]);
+    expect(snapshot.messages[0]?.messageId).toBe(
+      (liveCommit?.params as JsonObject | undefined)?.messageId,
+    );
+    expect(
+      rolloutItems.some((item) => {
+        const event = item as {
+          type?: unknown;
+          payload?: { msg?: { type?: unknown } };
+        };
+        return (
+          event.type === "event_msg" &&
+          event.payload?.msg?.type === "message_submission"
+        );
+      }),
+    ).toBe(true);
+  });
+
+  it("[managed-thread] keeps a hidden submission idempotent across a crash", async () => {
+    const rolloutItems: unknown[] = [];
+    const firstRuntime = makeTopLevelRunner({
+      conversationId: "session-hidden-crash-retry",
+      rolloutItems,
+    });
+    let releaseFirst!: () => void;
+    firstRuntime.control.sendInput.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+    await firstRuntime.runner.startAgent({
+      objective: "passive",
+      initialContent: [],
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    const acceptedThenCrashed = firstRuntime.runner.submitAgentMessage(
+      "session-hidden-crash-retry",
+      {
+        sessionId: "session_1",
+        content: "internal crash prompt",
+        originalContent: "internal crash prompt",
+        displayUserMessage: null,
+        messageId: "client-hidden-crash",
+        streamId: "client-hidden-crash",
+        acceptedAt: "2026-08-18T00:00:00.000Z",
+      },
+    );
+    await vi.waitFor(() => {
+      expect(
+        rolloutItems.some((item) => {
+          const event = item as {
+            type?: unknown;
+            payload?: {
+              msg?: { type?: unknown; payload?: Record<string, unknown> };
+            };
+          };
+          return (
+            event.type === "event_msg" &&
+            event.payload?.msg?.type === "message_submission" &&
+            event.payload.msg.payload?.messageId === "client-hidden-crash"
+          );
+        }),
+      ).toBe(true);
+    });
+
+    const restarted = makeTopLevelRunner({
+      conversationId: "session-hidden-crash-retry",
+      rolloutItems,
+    });
+    await restarted.runner.startAgent({
+      objective: "passive",
+      initialContent: [],
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    await expect(
+      restarted.runner.submitAgentMessage("session-hidden-crash-retry", {
+        sessionId: "session_1",
+        content: "different internal prompt",
+        originalContent: "different internal prompt",
+        displayUserMessage: null,
+        messageId: "client-hidden-crash",
+        streamId: "client-hidden-crash",
+        acceptedAt: "2026-08-18T00:30:00.000Z",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_MESSAGE_ID_CONFLICT" });
+    await expect(
+      restarted.runner.submitAgentMessage("session-hidden-crash-retry", {
+        sessionId: "session_1",
+        content: "internal crash prompt",
+        originalContent: "internal crash prompt",
+        displayUserMessage: null,
+        messageId: "client-hidden-crash",
+        streamId: "client-hidden-crash",
+        acceptedAt: "2026-08-18T01:00:00.000Z",
+      }),
+    ).resolves.toMatchObject({
+      disposition: "duplicate",
+      duplicateState: "incomplete",
+      acceptedAt: "2026-08-18T00:00:00.000Z",
+    });
+    expect(restarted.control.sendInput).not.toHaveBeenCalled();
+    await expect(
+      restarted.runner.getAgentSessionTranscriptV2(
+        "session-hidden-crash-retry",
+        { sessionId: "session_1" },
+      ),
+    ).resolves.toMatchObject({ messages: [] });
+
+    releaseFirst();
+    await acceptedThenCrashed;
+  });
+
+  it("[managed-thread] joins a concurrent idempotent retry and rejects conflicting content", async () => {
+    const { runner, control } = makeTopLevelRunner({
+      conversationId: "session-idempotent-submit",
+    });
+    let releaseSend!: () => void;
+    control.sendInput.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSend = resolve;
+        }),
+    );
+    await runner.startAgent({
+      objective: "hi",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    const first = runner.submitAgentMessage("session-idempotent-submit", {
+      sessionId: "session_1",
+      content: "same prompt",
+      originalContent: "same prompt",
+      messageId: "client-message-1",
+      streamId: "client-message-1",
+      acceptedAt: "2026-08-17T00:00:00.000Z",
+    });
+    const retry = runner.submitAgentMessage("session-idempotent-submit", {
+      sessionId: "session_1",
+      content: "same prompt",
+      originalContent: "same prompt",
+      messageId: "client-message-1",
+      streamId: "client-message-1",
+      acceptedAt: "2026-08-17T00:00:01.000Z",
+    });
+    await expect(
+      runner.submitAgentMessage("session-idempotent-submit", {
+        sessionId: "session_1",
+        content: "different prompt",
+        originalContent: "different prompt",
+        messageId: "client-message-1",
+        streamId: "client-message-1",
+        acceptedAt: "2026-08-17T00:00:02.000Z",
+      }),
+    ).rejects.toMatchObject({
+      name: AgenCBackgroundAgentMessageError.name,
+      code: "CLIENT_MESSAGE_ID_CONFLICT",
+    });
+
+    await vi.waitFor(() => expect(control.sendInput).toHaveBeenCalledOnce());
+    releaseSend();
+    await expect(first).resolves.toMatchObject({
+      disposition: "started",
+      terminal: { code: 0 },
+    });
+    await expect(retry).resolves.toMatchObject({
+      disposition: "duplicate",
+      duplicateState: "completed",
+      terminal: { code: 0 },
+    });
+    expect(control.sendInput).toHaveBeenCalledOnce();
+  });
+
+  it("[managed-thread] rejects opt-in admission during the initial turn without changing legacy FIFO", async () => {
+    const { runner, control } = makeTopLevelRunner({
+      conversationId: "session-strict-busy",
+    });
+    await runner.startAgent({
+      objective: "initial turn is running",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    await expect(
+      runner.submitAgentMessage("session-strict-busy", {
+        sessionId: "session_1",
+        content: "strict second turn",
+        originalContent: "strict second turn",
+        messageId: "strict-message",
+        streamId: "strict-message",
+        acceptedAt: "2026-08-17T00:00:00.000Z",
+        ifBusy: "reject",
+      }),
+    ).rejects.toMatchObject({ code: "TURN_IN_PROGRESS" });
+
+    await expect(
+      runner.submitAgentMessage("session-strict-busy", {
+        sessionId: "session_1",
+        content: "legacy queued turn",
+        originalContent: "legacy queued turn",
+        messageId: "legacy-message",
+        streamId: "legacy-message",
+        acceptedAt: "2026-08-17T00:00:01.000Z",
+      }),
+    ).resolves.toMatchObject({ disposition: "started" });
+    expect(control.sendInput).toHaveBeenCalledWith(
+      "session-strict-busy",
+      "legacy queued turn",
+    );
+  });
+
+  it("[managed-thread] reports a persisted crash-tail retry as incomplete", async () => {
+    const { runner, control } = makeTopLevelRunner({
+      conversationId: "session-crash-tail",
+      rolloutItems: [
+        {
+          type: "event_msg",
+          payload: {
+            id: "persisted-user",
+            eventId: "persisted-user",
+            seq: 1,
+            msg: {
+              type: "user_message",
+              payload: {
+                message: "retry me",
+                messageId: "crashed-message",
+                acceptedAt: "2026-08-17T00:00:00.000Z",
+              },
+            },
+          },
+        },
+        {
+          type: "event_msg",
+          payload: {
+            id: "persisted-turn",
+            eventId: "persisted-turn",
+            seq: 2,
+            msg: {
+              type: "turn_started",
+              payload: { turnId: "crashed-turn" },
+            },
+          },
+        },
+      ],
+    });
+    await runner.startAgent({
+      objective: "restored",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    await expect(
+      runner.submitAgentMessage("session-crash-tail", {
+        sessionId: "session_1",
+        content: "retry me",
+        originalContent: "retry me",
+        messageId: "crashed-message",
+        streamId: "crashed-message",
+        acceptedAt: "2026-08-17T01:00:00.000Z",
+      }),
+    ).resolves.toMatchObject({
+      disposition: "duplicate",
+      duplicateState: "incomplete",
+      turnId: "crashed-turn",
+    });
+    expect(control.sendInput).not.toHaveBeenCalled();
+  });
+
+  it("[managed-thread] never attributes a later completed turn to a crashed submission", async () => {
+    const event = (id: string, seq: number, msg: Record<string, unknown>) => ({
+      type: "event_msg",
+      payload: { id, eventId: id, seq, msg },
+    });
+    const { runner, control } = makeTopLevelRunner({
+      conversationId: "session-crash-before-next-turn",
+      rolloutItems: [
+        event("user-a", 1, {
+          type: "user_message",
+          payload: {
+            message: "prompt A",
+            messageId: "message-A",
+            acceptedAt: "2026-08-17T00:00:00.000Z",
+          },
+        }),
+        event("user-b", 2, {
+          type: "user_message",
+          payload: {
+            message: "prompt B",
+            messageId: "message-B",
+            acceptedAt: "2026-08-17T00:01:00.000Z",
+          },
+        }),
+        event("turn-b", 3, {
+          type: "turn_started",
+          payload: { turnId: "turn-B" },
+        }),
+        event("complete-b", 4, {
+          type: "turn_complete",
+          payload: { turnId: "turn-B", lastAgentMessage: "answer B" },
+        }),
+      ],
+    });
+    await runner.startAgent({
+      objective: "restored",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    await expect(
+      runner.submitAgentMessage("session-crash-before-next-turn", {
+        sessionId: "session_1",
+        content: "prompt A",
+        originalContent: "prompt A",
+        messageId: "message-A",
+        streamId: "message-A",
+        acceptedAt: "2026-08-17T01:00:00.000Z",
+      }),
+    ).resolves.toMatchObject({
+      disposition: "duplicate",
+      duplicateState: "incomplete",
+    });
+    expect(control.sendInput).not.toHaveBeenCalled();
+  });
+
   it("[managed-thread] persists daemon-visible user prompts without duplicate live rows", async () => {
     const { runner, control, session } = makeTopLevelRunner({
       conversationId: "session-user-durable",
@@ -2448,7 +3101,10 @@ describe("AgenC delegate background-agent runner", () => {
         streamId: "stream-after-cancel",
         acceptedAt: "2026-05-09T00:00:01.000Z",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({
+      disposition: "started",
+      terminal: { code: 0 },
+    });
     expect(control.sendInput).toHaveBeenCalledWith(
       "session-cancelled-turn-status",
       "continue after cancel",
@@ -2663,6 +3319,39 @@ describe("AgenC delegate background-agent runner", () => {
       "child-agent",
       "user_cancel",
     );
+  });
+
+  it("[managed-thread] scoped cancellation cannot interrupt a replacement turn", async () => {
+    const { runner, stub, setActiveTurn, abortTurnIfActive, activeTurn } =
+      makeTopLevelRunner({
+        conversationId: "session-scoped-interrupt",
+        scopedTurnCancellation: true,
+      });
+    await runner.startAgent({
+      objective: "hi",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    stub.thread.submit.mockClear();
+    setActiveTurn("turn-old");
+    abortTurnIfActive.mockImplementationOnce(async (turnId: string) => {
+      expect(turnId).toBe("turn-old");
+      // Simulate the exact TOCTOU boundary: the scoped session operation has
+      // removed the old turn, then a new turn starts while abort cleanup awaits.
+      setActiveTurn("turn-new");
+      return true;
+    });
+
+    await expect(
+      runner.interruptAgentTurnIfMatches(
+        "session-scoped-interrupt",
+        "cancel old only",
+        "turn-old",
+      ),
+    ).resolves.toEqual({ cancelled: true, activeTurnId: "turn-old" });
+    expect(abortTurnIfActive).toHaveBeenCalledWith("turn-old", "interrupted");
+    expect(activeTurn.unsafePeek()).toEqual({ turnId: "turn-new" });
+    expect(stub.thread.submit).not.toHaveBeenCalled();
   });
 
   it("[managed-thread] stopAgent uses bootstrap lifecycle shutdown", async () => {

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -2095,8 +2095,8 @@ backend = "local"
       id: "initialize",
       result: {
         type: "initialized",
-        protocolVersion: "1.1.0",
-        protocol: { version: "1.1.0" },
+        protocolVersion: "1.2.0",
+        protocol: { version: "1.2.0" },
       },
     });
 

--- a/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.contract.test.ts
@@ -91,6 +91,67 @@ function daemonMethodCapabilities(
 }
 
 describe("AgenC daemon session lifecycle dispatcher", () => {
+  it("does not turn an aborted v1.2 identity-bearing send into session-wide cancellation", async () => {
+    let resolveSubmission!: (value: {
+      disposition: "started";
+      acceptedAt: string;
+      terminal: { code: 0 };
+    }) => void;
+    const streamAgentMessage = vi.fn(
+      () =>
+        new Promise<{
+          disposition: "started";
+          acceptedAt: string;
+          terminal: { code: 0 };
+        }>((resolve) => {
+          resolveSubmission = resolve;
+        }),
+    );
+    const cancelSessionTurn = vi.fn(async () => ({
+      sessionId: "session_external_turn",
+      cancelled: true,
+    }));
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+      agentManager: {
+        streamAgentMessage,
+        cancelSessionTurn,
+        getSessionTranscriptV2: vi.fn(),
+      } as never,
+    });
+    const connection = dispatcher.createConnection();
+    await connection.dispatch(
+      request("init-safe-send", "initialize", {
+        protocol: { version: "1.2.0" },
+      }),
+    );
+
+    const pendingSend = connection.dispatch(
+      request("send-second-client", "message.send", {
+        sessionId: "session_external_turn",
+        content: "must not cancel the external turn",
+        clientMessageId: "second-client-message",
+        ifBusy: "reject",
+      }),
+    );
+    await vi.waitFor(() => expect(streamAgentMessage).toHaveBeenCalledOnce());
+    await expect(
+      connection.dispatch(
+        request("cancel-second-send", "request.cancel", {
+          requestId: "send-second-client",
+        }),
+      ),
+    ).resolves.toMatchObject({ result: { cancelled: true } });
+    expect(cancelSessionTurn).not.toHaveBeenCalled();
+
+    resolveSubmission({
+      disposition: "started",
+      acceptedAt: "2026-08-17T00:00:00.000Z",
+      terminal: { code: 0 },
+    });
+    await expect(pendingSend).resolves.toHaveProperty("error");
+    expect(cancelSessionTurn).not.toHaveBeenCalled();
+  });
+
   it("registers an initialized Ledger-capable client before any session attach", async () => {
     const sessionManager = new AgenCDaemonSessionManager({
       createSessionId: () => "session_ledger",

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionTranscriptV2FromRollout } from "../../src/app-server/background-agent-runner.js";
+import type { Event, EventMsg } from "../../src/session/event-log.js";
+import type { RolloutItem } from "../../src/session/rollout-item.js";
+
+function event(seq: number, eventId: string, msg: EventMsg): RolloutItem {
+  const payload: Event = { id: eventId, eventId, seq, msg };
+  return { type: "event_msg", payload };
+}
+
+describe("session.transcript.v2 durable projection", () => {
+  it("keeps a migrated response_item prefix when canonical events are appended", () => {
+    const prefix: RolloutItem[] = [
+      {
+        type: "response_item",
+        payload: { role: "user", content: "legacy question" },
+      },
+      {
+        type: "response_item",
+        payload: { role: "assistant", content: "legacy answer" },
+      },
+      event(10, "user-new", {
+        type: "user_message",
+        payload: {
+          message: "new question",
+          messageId: "client-new",
+          acceptedAt: "2026-08-17T00:00:00.000Z",
+        },
+      }),
+      event(11, "turn-new", {
+        type: "turn_started",
+        payload: { turnId: "turn-new" },
+      }),
+      event(12, "assistant-one", {
+        type: "agent_message",
+        payload: { message: "ok" },
+      }),
+      event(13, "assistant-two", {
+        type: "agent_message",
+        payload: { message: "ok" },
+      }),
+    ];
+
+    const first = sessionTranscriptV2FromRollout(prefix, "session-1", "run-1");
+    expect(first).toMatchObject({
+      schemaVersion: 2,
+      sessionId: "session-1",
+      runId: "run-1",
+      historyEpoch: "history:run-1:initial",
+      asOfSequence: 13,
+    });
+    expect(first.messages.map(({ role, text }) => ({ role, text }))).toEqual([
+      { role: "user", text: "legacy question" },
+      { role: "assistant", text: "legacy answer" },
+      { role: "user", text: "new question" },
+      { role: "assistant", text: "ok" },
+      { role: "assistant", text: "ok" },
+    ]);
+    expect(first.messages.slice(0, 2)).toEqual([
+      expect.objectContaining({
+        messageId: "legacy:initial:0",
+        committedSequence: 0,
+      }),
+      expect.objectContaining({
+        messageId: "legacy:initial:1",
+        committedSequence: 0,
+      }),
+    ]);
+    expect(first.messages.slice(2)).toEqual([
+      expect.objectContaining({
+        messageId: "client-new",
+        clientMessageId: "client-new",
+        turnId: "turn-new",
+        committedSequence: 10,
+      }),
+      expect.objectContaining({
+        messageId: "assistant:turn-new:0",
+        clientMessageId: "client-new",
+        committedSequence: 12,
+      }),
+      expect.objectContaining({
+        messageId: "assistant:turn-new:1",
+        clientMessageId: "client-new",
+        committedSequence: 13,
+      }),
+    ]);
+
+    const afterAppend = sessionTranscriptV2FromRollout(
+      [
+        ...prefix,
+        event(14, "turn-complete", {
+          type: "turn_complete",
+          payload: { turnId: "turn-new", lastAgentMessage: "ok" },
+        }),
+      ],
+      "session-1",
+      "run-1",
+    );
+    expect(afterAppend.asOfSequence).toBe(14);
+    expect(afterAppend.messages).toEqual(first.messages);
+  });
+
+  it("rebuilds from each compact/rewind replacement and advances a stable epoch", () => {
+    const compacted: RolloutItem[] = [
+      {
+        type: "response_item",
+        payload: { role: "user", content: "discarded branch" },
+      },
+      {
+        type: "compacted",
+        payload: {
+          message: "summary",
+          replacementHistory: [
+            { role: "user", content: "kept question" },
+            { role: "assistant", content: "summary answer" },
+          ],
+        },
+      },
+      event(20, "epoch-compact", {
+        type: "transcript_epoch",
+        payload: { reason: "partial_compact" },
+      }),
+      event(21, "user-after-compact", {
+        type: "user_message",
+        payload: {
+          message: "after compact",
+          messageId: "client-after-compact",
+        },
+      }),
+      event(22, "turn-after-compact", {
+        type: "turn_started",
+        payload: { turnId: "turn-after-compact" },
+      }),
+      event(23, "answer-after-compact", {
+        type: "agent_message",
+        payload: { message: "fresh answer" },
+      }),
+    ];
+
+    const compactSnapshot = sessionTranscriptV2FromRollout(
+      compacted,
+      "session-1",
+      "run-1",
+    );
+    expect(compactSnapshot.historyEpoch).toBe("history:run-1:epoch-compact");
+    expect(compactSnapshot.messages.map((message) => message.text)).toEqual([
+      "kept question",
+      "summary answer",
+      "after compact",
+      "fresh answer",
+    ]);
+    expect(compactSnapshot.messages[0]).toMatchObject({
+      messageId: "replacement:epoch-compact:0",
+      committedSequence: 20,
+    });
+    expect(
+      compactSnapshot.messages.some(
+        (message) => message.text === "discarded branch",
+      ),
+    ).toBe(false);
+
+    const rewound: RolloutItem[] = [
+      ...compacted,
+      {
+        type: "compacted",
+        payload: {
+          message: "Conversation rewound",
+          replacementHistory: [{ role: "user", content: "kept question" }],
+        },
+      },
+      event(30, "epoch-rewind", {
+        type: "transcript_epoch",
+        payload: { reason: "rewind" },
+      }),
+    ];
+    const rewindSnapshot = sessionTranscriptV2FromRollout(
+      rewound,
+      "session-1",
+      "run-1",
+    );
+    expect(rewindSnapshot.historyEpoch).toBe("history:run-1:epoch-rewind");
+    expect(rewindSnapshot.asOfSequence).toBe(30);
+    expect(rewindSnapshot.messages).toEqual([
+      expect.objectContaining({
+        messageId: "replacement:epoch-rewind:0",
+        text: "kept question",
+        committedSequence: 30,
+      }),
+    ]);
+
+    expect(
+      sessionTranscriptV2FromRollout([...rewound], "session-1", "run-1"),
+    ).toEqual(rewindSnapshot);
+  });
+});

--- a/runtime/tests/app-server/windows-named-pipe.win32.test.ts
+++ b/runtime/tests/app-server/windows-named-pipe.win32.test.ts
@@ -6,13 +6,12 @@ import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 
 import { connect as connectSdk } from "../../../packages/agenc-sdk/src/socket.js";
+import { createAgenCJsonLineDaemonClient } from "../../src/app-server/agent-cli.js";
+import { resolveAgenCDaemonSocketPath } from "../../src/app-server/daemon-cli.js";
 import {
-  createAgenCJsonLineDaemonClient,
-} from "../../src/app-server/agent-cli.js";
-import {
-  resolveAgenCDaemonSocketPath,
-} from "../../src/app-server/daemon-cli.js";
-import { JSON_RPC_VERSION } from "../../src/app-server/protocol/index.js";
+  AGENC_DAEMON_PROTOCOL_VERSION,
+  JSON_RPC_VERSION,
+} from "../../src/app-server/protocol/index.js";
 import {
   AgenCUnixSocketServer,
   canConnectToUnixSocket,
@@ -41,7 +40,12 @@ test("the authenticated daemon client round-trips over a private Windows named p
         await connection.send({
           jsonrpc: JSON_RPC_VERSION,
           id: message.id ?? null,
-          result: { accepted: true },
+          result: {
+            type: "initialized",
+            protocolVersion: AGENC_DAEMON_PROTOCOL_VERSION,
+            protocol: { version: AGENC_DAEMON_PROTOCOL_VERSION },
+            capabilities: {},
+          },
         });
         return;
       }
@@ -73,6 +77,9 @@ test("the authenticated daemon client round-trips over a private Windows named p
       requestTimeoutMs: 2_000,
     });
     try {
+      expect(sdkClient.serverProtocolVersion).toBe(
+        AGENC_DAEMON_PROTOCOL_VERSION,
+      );
       await expect(sdkClient.listAgents()).resolves.toEqual({ agents: [] });
     } finally {
       await sdkClient.close();

--- a/runtime/tests/sdk-package/client-inprocess.contract.test.ts
+++ b/runtime/tests/sdk-package/client-inprocess.contract.test.ts
@@ -64,19 +64,21 @@ interface FakeDaemon {
  * hosted on the real in-process transport, with an agent runtime whose turn
  * behavior is provided by `onStreamMessage`.
  */
-async function createFakeDaemon(options: {
-  readonly onStreamMessage?: (
-    daemon: FakeDaemon,
-    params: JsonObject,
-  ) => Promise<void> | void;
-  readonly onApproveTool?: (daemon: FakeDaemon, params: JsonObject) => void;
-  readonly onDenyTool?: (daemon: FakeDaemon, params: JsonObject) => void;
-  readonly onPermissionRequest?: (
-    request: AgencPermissionRequest,
-  ) =>
-    | { behavior: "allow"; scope?: "once" | "session" | "agent" }
-    | { behavior: "deny"; reason?: string };
-} = {}): Promise<FakeDaemon> {
+async function createFakeDaemon(
+  options: {
+    readonly onStreamMessage?: (
+      daemon: FakeDaemon,
+      params: JsonObject,
+    ) => Promise<void> | void;
+    readonly onApproveTool?: (daemon: FakeDaemon, params: JsonObject) => void;
+    readonly onDenyTool?: (daemon: FakeDaemon, params: JsonObject) => void;
+    readonly onPermissionRequest?: (
+      request: AgencPermissionRequest,
+    ) =>
+      | { behavior: "allow"; scope?: "once" | "session" | "agent" }
+      | { behavior: "deny"; reason?: string };
+  } = {},
+): Promise<FakeDaemon> {
   const sessionManager = new AgenCDaemonSessionManager({
     createSessionId: sequence(["session_1", "session_2"]),
     createAttachmentId: sequence(["attachment_1", "attachment_2"]),
@@ -141,7 +143,40 @@ async function createFakeDaemon(options: {
       }),
       streamAgentMessage: async (params: JsonObject) => {
         calls.streamed.push(params);
+        const sessionId = String(params.sessionId);
+        const messageId = String(params.messageId);
+        const turnId = `turn_${messageId}`;
+        await daemon.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.session_event",
+          params: {
+            sessionId,
+            eventId: `evt_user_${messageId}`,
+            event: {
+              id: `evt_user_${messageId}`,
+              type: "user_message",
+              payload: { message: params.content, messageId },
+            },
+          },
+        });
+        await daemon.broadcast(sessionId, {
+          jsonrpc: JSON_RPC_VERSION,
+          method: "event.agent_status",
+          params: {
+            sessionId,
+            eventId: `evt_started_${messageId}`,
+            status: "running",
+            runStatus: "running",
+            turnId,
+          },
+        });
         await options.onStreamMessage?.(daemon, params);
+        return {
+          disposition: "started" as const,
+          acceptedAt: String(params.acceptedAt),
+          turnId,
+          terminal: { code: 0 as const },
+        };
       },
       approveTool: async (params: JsonObject) => {
         calls.approved.push(params);
@@ -280,7 +315,7 @@ describe("agenc-sdk client over the in-process transport", () => {
     const initialized = await daemon.client.initialize();
     expect(initialized).toMatchObject({
       type: "initialized",
-      protocol: { version: "1.1.0" },
+      protocol: { version: "1.2.0" },
     });
 
     const session = await daemon.client.createSession({
@@ -304,8 +339,9 @@ describe("agenc-sdk client over the in-process transport", () => {
       sessionId: "session_1",
       content: "hi there",
     });
-    await expect(run.accepted).resolves.toEqual({
+    await expect(run.accepted).resolves.toMatchObject({
       messageId: expect.any(String),
+      clientMessageId: expect.any(String),
     });
 
     expect(

--- a/runtime/tests/sdk-package/events.contract.test.ts
+++ b/runtime/tests/sdk-package/events.contract.test.ts
@@ -90,4 +90,57 @@ describe("agenc-sdk prompt event mapping", () => {
       firstAvailableSequence: 11,
     });
   });
+
+  it.each([
+    ["history_cleared", {}, "cleared"],
+    ["transcript_epoch", { reason: "rewind" }, "rewind"],
+  ] as const)(
+    "surfaces %s as an identity-bearing transcript reset",
+    (type, payload, reason) => {
+      expect(
+        promptEventFromNotification({
+          jsonrpc: "2.0",
+          method: "event.session_event",
+          params: {
+            sessionId: "session_1",
+            eventId: "epoch_event",
+            sequence: 44,
+            runId: "run_1",
+            historyEpoch: "history:run_1:epoch_event",
+            event: { id: "epoch_event", type, payload },
+          },
+        }),
+      ).toEqual({
+        type: "history_reset",
+        reason,
+        eventId: "epoch_event",
+        sequence: 44,
+        runId: "run_1",
+        historyEpoch: "history:run_1:epoch_event",
+      });
+    },
+  );
+
+  it("maps a legacy params.msg history reset envelope", () => {
+    expect(
+      promptEventFromNotification({
+        jsonrpc: "2.0",
+        method: "event.session_event",
+        params: {
+          sessionId: "session_1",
+          eventId: "legacy_epoch",
+          historyEpoch: "history:run_1:legacy_epoch",
+          msg: {
+            type: "transcript_epoch",
+            payload: { reason: "compaction_rollback" },
+          },
+        },
+      }),
+    ).toEqual({
+      type: "history_reset",
+      reason: "compaction_rollback",
+      eventId: "legacy_epoch",
+      historyEpoch: "history:run_1:legacy_epoch",
+    });
+  });
 });

--- a/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
+++ b/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
@@ -1,0 +1,506 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AgencCapabilityUnavailableError,
+  AgencDuplicateSubmissionIncompleteError,
+  AgencPromptRunInProgressError,
+  createAgencClient,
+  type AgencClient,
+  type AgencDaemonMethod,
+  type AgencDaemonRequest,
+  type AgencDaemonResponse,
+  type AgencPromptEvent,
+  type AgencTransport,
+  type JsonObject,
+} from "../../../packages/agenc-sdk/src/index";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function success<Method extends AgencDaemonMethod>(
+  request: AgencDaemonRequest<Method>,
+  result: unknown,
+): AgencDaemonResponse<Method> {
+  return {
+    jsonrpc: "2.0",
+    id: request.id,
+    result,
+  } as AgencDaemonResponse<Method>;
+}
+
+class PromptTransport implements AgencTransport {
+  readonly requests: AgencDaemonRequest[] = [];
+  readonly sends: Array<{
+    readonly request: AgencDaemonRequest<"message.send">;
+    readonly response: Deferred<AgencDaemonResponse<"message.send">>;
+  }> = [];
+  client?: AgencClient;
+  initializeVersion = "1.2.0";
+  initializeFailures = 0;
+  duplicateIncomplete = false;
+
+  async request<Method extends AgencDaemonMethod>(
+    request: AgencDaemonRequest<Method>,
+  ): Promise<AgencDaemonResponse<Method>> {
+    this.requests.push(request as AgencDaemonRequest);
+    if (request.method === "initialize") {
+      if (this.initializeFailures > 0) {
+        this.initializeFailures -= 1;
+        return {
+          jsonrpc: "2.0",
+          id: request.id,
+          error: {
+            code: -32000,
+            message: "unsupported protocol",
+            data: {
+              code: "PROTOCOL_VERSION_UNSUPPORTED",
+              serverVersion: this.initializeVersion,
+            },
+          },
+        } as AgencDaemonResponse<Method>;
+      }
+      return success(request, {
+        type: "initialized",
+        protocolVersion: this.initializeVersion,
+        protocol: { version: this.initializeVersion },
+        capabilities: {
+          "daemon.methods": {
+            "session.transcript.v2": this.initializeVersion === "1.2.0",
+          },
+        },
+      });
+    }
+    if (request.method === "session.attach") {
+      return success(request, {
+        attachmentId: "attachment_1",
+        sessionId: String((request.params as JsonObject).sessionId),
+      });
+    }
+    if (request.method === "message.send") {
+      if (this.duplicateIncomplete) {
+        return success(request, {
+          messageId: String((request.params as JsonObject).clientMessageId),
+          acceptedAt: "2026-08-17T00:00:00.000Z",
+          disposition: "duplicate",
+          duplicateState: "incomplete",
+          turnId: "turn_crashed",
+        });
+      }
+      const response = deferred<AgencDaemonResponse<"message.send">>();
+      this.sends.push({
+        request: request as AgencDaemonRequest<"message.send">,
+        response,
+      });
+      return (await response.promise) as AgencDaemonResponse<Method>;
+    }
+    if (request.method === "session.cancelTurn") {
+      return success(request, {
+        sessionId: String((request.params as JsonObject).sessionId),
+        cancelled: true,
+      });
+    }
+    if (request.method === "session.transcript.v2") {
+      return success(request, {
+        schemaVersion: 2,
+        sessionId: "session_1",
+        runId: "run_1",
+        historyEpoch: "history:run_1:initial",
+        asOfSequence: 0,
+        messages: [],
+      });
+    }
+    throw new Error(`unexpected method: ${request.method}`);
+  }
+
+  emit(message: JsonObject): void {
+    this.client?.dispatchNotification(message);
+  }
+}
+
+async function initializedClient(
+  transport: PromptTransport,
+): Promise<AgencClient> {
+  const client = createAgencClient({
+    transport,
+    clientId: "race-test-client",
+  });
+  transport.client = client;
+  await client.initialize();
+  return client;
+}
+
+function userMessage(clientMessageId: string): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    method: "event.session_event",
+    params: {
+      sessionId: "session_1",
+      eventId: `user_${clientMessageId}`,
+      event: {
+        id: `user_${clientMessageId}`,
+        type: "user_message",
+        payload: { message: clientMessageId, messageId: clientMessageId },
+      },
+    },
+  };
+}
+
+function turnStarted(turnId: string): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    method: "event.agent_status",
+    params: {
+      sessionId: "session_1",
+      eventId: `started_${turnId}`,
+      status: "running",
+      runStatus: "running",
+      turnId,
+    },
+  };
+}
+
+function terminal(turnId: string, message?: string): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    method: "event.agent_status",
+    params: {
+      sessionId: "session_1",
+      eventId: `terminal_${turnId}_${message ?? "none"}`,
+      status: "idle",
+      runStatus: "completed",
+      turnId,
+      ...(message !== undefined ? { message } : {}),
+    },
+  };
+}
+
+function text(turnId: string, delta: string): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    method: "event.message_chunk",
+    params: {
+      sessionId: "session_1",
+      eventId: `delta_${turnId}_${Math.random().toString(36)}`,
+      turnId,
+      delta,
+    },
+  };
+}
+
+function committed(turnId: string, value: string): JsonObject {
+  return {
+    jsonrpc: "2.0",
+    method: "event.session_event",
+    params: {
+      sessionId: "session_1",
+      eventId: `committed_${turnId}`,
+      turnId,
+      event: {
+        id: `committed_${turnId}`,
+        type: "agent_message",
+        payload: { message: value },
+      },
+    },
+  };
+}
+
+async function waitForSend(
+  transport: PromptTransport,
+  index: number,
+): Promise<PromptTransport["sends"][number]> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const send = transport.sends[index];
+    if (send !== undefined) return send;
+    await Promise.resolve();
+  }
+  throw new Error(`message.send ${String(index)} was not observed`);
+}
+
+function resolveSend(
+  send: PromptTransport["sends"][number],
+  turnId: string,
+): void {
+  const clientMessageId = String(
+    (send.request.params as JsonObject).clientMessageId,
+  );
+  send.response.resolve(
+    success(send.request, {
+      messageId: clientMessageId,
+      acceptedAt: "2026-08-17T00:00:00.000Z",
+      disposition: "started",
+      turnId,
+      terminal: { code: 0 },
+    }),
+  );
+}
+
+describe("agenc-sdk prompt race safety", () => {
+  it.each(["1.0.0", "1.1.0"])(
+    "downgrades capability discovery to an older %s daemon",
+    async (version) => {
+      const transport = new PromptTransport();
+      transport.initializeVersion = version;
+      transport.initializeFailures = 1;
+      const client = await initializedClient(transport);
+
+      const initializes = transport.requests.filter(
+        (request) => request.method === "initialize",
+      );
+      expect(initializes).toHaveLength(2);
+      expect(initializes.map((request) => request.params)).toEqual([
+        expect.objectContaining({ protocol: { version: "1.2.0" } }),
+        expect.objectContaining({ protocol: { version } }),
+      ]);
+      expect(client.negotiatedProtocolVersion).toBe(version);
+      expect(client.serverProtocolVersion).toBe(version);
+      expect(client.serverCapabilities).toBeDefined();
+    },
+  );
+
+  it("recognizes an older daemon that accepts a higher-minor initialize", async () => {
+    const transport = new PromptTransport();
+    transport.initializeVersion = "1.1.0";
+    const client = await initializedClient(transport);
+
+    expect(
+      transport.requests.filter((request) => request.method === "initialize"),
+    ).toHaveLength(1);
+    expect(client.negotiatedProtocolVersion).toBe("1.1.0");
+    expect(client.serverProtocolVersion).toBe("1.1.0");
+  });
+
+  it("reserves synchronously, binds on its durable user marker, and ignores an older terminal", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+
+    const runA = client.runPrompt("session_1", "A", {
+      clientMessageId: "message_A",
+      includeUsage: false,
+    });
+    expect(() =>
+      client.runPrompt("session_1", "B-too-soon", {
+        clientMessageId: "message_B_early",
+      }),
+    ).toThrow(AgencPromptRunInProgressError);
+
+    const sendA = await waitForSend(transport, 0);
+    transport.emit(userMessage("message_A"));
+    transport.emit(turnStarted("turn_A"));
+    transport.emit(terminal("turn_A", "answer A"));
+    resolveSend(sendA, "turn_A");
+    await expect(runA.result()).resolves.toMatchObject({
+      finalMessage: "answer A",
+    });
+
+    const runB = client.runPrompt("session_1", "B", {
+      clientMessageId: "message_B",
+      includeUsage: false,
+    });
+    const events: AgencPromptEvent[] = [];
+    const consumeB = (async () => {
+      for await (const event of runB) events.push(event);
+    })();
+    const sendB = await waitForSend(transport, 1);
+
+    transport.emit(terminal("turn_A", "stale answer A"));
+    const stillPending = await Promise.race([
+      runB.result().then(() => false),
+      new Promise<true>((resolve) => setTimeout(() => resolve(true), 10)),
+    ]);
+    expect(stillPending).toBe(true);
+
+    transport.emit(userMessage("message_B"));
+    transport.emit(turnStarted("turn_B"));
+    transport.emit(text("turn_B", "ha"));
+    transport.emit(text("turn_B", "ha"));
+    transport.emit(committed("turn_B", "haha"));
+    transport.emit(terminal("turn_B"));
+    resolveSend(sendB, "turn_B");
+
+    await consumeB;
+    await expect(runB.result()).resolves.toMatchObject({
+      finalMessage: "haha",
+    });
+    expect(
+      events
+        .filter(
+          (event): event is Extract<AgencPromptEvent, { type: "text" }> =>
+            event.type === "text",
+        )
+        .map((event) => event.delta),
+    ).toEqual(["ha", "ha"]);
+    expect(
+      events.filter((event) => event.type === "message_committed"),
+    ).toEqual([expect.objectContaining({ text: "haha" })]);
+  });
+
+  it("never sends or cancels when an AbortSignal is already aborted", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+    const controller = new AbortController();
+    controller.abort("never dispatch");
+
+    const run = client.runPrompt("session_1", "do not send", {
+      clientMessageId: "message_aborted",
+      signal: controller.signal,
+    });
+    await expect(run.accepted).rejects.toMatchObject({ name: "AbortError" });
+    expect(
+      transport.requests.filter(
+        (request) =>
+          request.method === "message.send" ||
+          request.method === "session.cancelTurn",
+      ),
+    ).toEqual([]);
+  });
+
+  it("defers post-dispatch abort until its own turn id is bound", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+    const controller = new AbortController();
+    const run = client.runPrompt("session_1", "cancel me", {
+      clientMessageId: "message_cancel",
+      signal: controller.signal,
+      includeUsage: false,
+    });
+    const send = await waitForSend(transport, 0);
+
+    controller.abort("stop this turn");
+    expect(
+      transport.requests.filter(
+        (request) => request.method === "session.cancelTurn",
+      ),
+    ).toEqual([]);
+
+    transport.emit(userMessage("message_cancel"));
+    expect(
+      transport.requests.filter(
+        (request) => request.method === "session.cancelTurn",
+      ),
+    ).toEqual([]);
+    transport.emit(turnStarted("turn_cancel"));
+    await Promise.resolve();
+    expect(
+      transport.requests.find(
+        (request) => request.method === "session.cancelTurn",
+      )?.params,
+    ).toMatchObject({
+      sessionId: "session_1",
+      expectedTurnId: "turn_cancel",
+      reason: "stop this turn",
+    });
+
+    transport.emit(terminal("turn_cancel"));
+    resolveSend(send, "turn_cancel");
+    await run.result();
+  });
+
+  it("never issues an unscoped prompt cancellation on a legacy daemon", async () => {
+    const transport = new PromptTransport();
+    transport.initializeVersion = "1.1.0";
+    transport.initializeFailures = 1;
+    const client = await initializedClient(transport);
+    const controller = new AbortController();
+    const run = client.runPrompt("session_1", "legacy cancel", {
+      clientMessageId: "message_legacy_cancel",
+      signal: controller.signal,
+      includeUsage: false,
+    });
+    const send = await waitForSend(transport, 0);
+
+    controller.abort("legacy stop");
+    expect(
+      transport.requests.filter(
+        (request) => request.method === "session.cancelTurn",
+      ),
+    ).toHaveLength(0);
+    transport.emit(userMessage("message_legacy_cancel"));
+    transport.emit(turnStarted("turn_legacy_cancel"));
+    await Promise.resolve();
+    expect(
+      transport.requests.filter(
+        (request) => request.method === "session.cancelTurn",
+      ),
+    ).toEqual([]);
+
+    transport.emit(terminal("turn_legacy_cancel"));
+    resolveSend(send, "turn_legacy_cancel");
+    await run.result();
+  });
+
+  it("fails closed before send when strict admission is unavailable", async () => {
+    const transport = new PromptTransport();
+    transport.initializeVersion = "1.1.0";
+    transport.initializeFailures = 1;
+    const client = await initializedClient(transport);
+    const run = client.runPrompt("session_1", "must reject overlap", {
+      clientMessageId: "message_strict_legacy",
+      ifBusy: "reject",
+    });
+
+    await expect(run.accepted).rejects.toBeInstanceOf(
+      AgencCapabilityUnavailableError,
+    );
+    await expect(run.result()).rejects.toBeInstanceOf(
+      AgencCapabilityUnavailableError,
+    );
+    expect(
+      transport.requests.filter(
+        (request) =>
+          request.method === "session.attach" ||
+          request.method === "message.send",
+      ),
+    ).toEqual([]);
+  });
+
+  it("fails closed when a duplicate has no durable terminal proof", async () => {
+    const transport = new PromptTransport();
+    transport.duplicateIncomplete = true;
+    const client = await initializedClient(transport);
+    const run = client.runPrompt("session_1", "retry", {
+      clientMessageId: "message_crashed",
+      includeUsage: false,
+    });
+
+    await expect(run.accepted).rejects.toBeInstanceOf(
+      AgencDuplicateSubmissionIncompleteError,
+    );
+    await expect(run.result()).rejects.toBeInstanceOf(
+      AgencDuplicateSubmissionIncompleteError,
+    );
+  });
+
+  it("uses the identity-bearing send result when the terminal notification is lost", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+    const run = client.runPrompt("session_1", "finish from result", {
+      clientMessageId: "message_terminal_fallback",
+      includeUsage: false,
+    });
+    const send = await waitForSend(transport, 0);
+
+    transport.emit(userMessage("message_terminal_fallback"));
+    transport.emit(turnStarted("turn_terminal_fallback"));
+    transport.emit(text("turn_terminal_fallback", "answer"));
+    transport.emit(committed("turn_terminal_fallback", "answer"));
+    resolveSend(send, "turn_terminal_fallback");
+
+    await expect(run.result()).resolves.toMatchObject({
+      stopReason: "completed",
+      finalMessage: "answer",
+    });
+  });
+});


### PR DESCRIPTION
Summary:
- add protocol 1.2 strict turn admission, durable idempotency, and scoped cancellation
- add versioned transcript snapshots with stable message and event identities
- preserve retry safety across crash tails, hidden prompts, compaction, rewind, and reconnects

Verification:
- 253 focused protocol, runtime, and SDK tests pass
- runtime and SDK typechecks pass
- runtime production build and generated-type checks pass
- formatting and diff checks pass