### PR TITLE
fix(runtime): stabilize hosted cleanup and retention gates

### DIFF
--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -7,6 +7,7 @@ import { renderPtyRows } from "../harness.mjs";
 
 const execFileAsync = promisify(execFile);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const CSI_U_ESCAPE = "\x1b[27u";
 
 export async function anchorWorkbenchProjectRoot(cwd) {
   // Project trust resolves the nearest ancestor marker. Pin each generated
@@ -101,7 +102,13 @@ export async function runEmbeddedNeovimCommand(
     );
   }
   await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
-  session.send("\x1b");
+  // A lone ESC is intentionally buffered by the TUI parser so a following
+  // byte can complete an Alt/meta sequence. A parent-side delay cannot prove
+  // that a render-stalled child flushed that byte first: ESC and ':' can be
+  // read together, dropping the Escape normalization that transient native
+  // modes require. CSI-u encodes Escape as one complete key, so it remains
+  // distinct from the colon even when both writes reach the same stdin read.
+  session.send(CSI_U_ESCAPE);
   await sleep(80);
   session.send(":");
   // Neovim's provider footer remains in CMDLINE_NORMAL for the lifetime of

--- a/runtime/scripts/check-tui-runtime-startup.test.mjs
+++ b/runtime/scripts/check-tui-runtime-startup.test.mjs
@@ -28,6 +28,7 @@ import {
   teardownTuiGateState,
   TUI_GATE_TRUST_TIMESTAMP,
   tuiGateEnvironment,
+  tuiGateRootRemoveOptions,
   writeTuiGateDefaultConfig,
   writeTuiGateTrust,
 } from "./tui-gate-state.mjs";
@@ -339,6 +340,32 @@ test("private gate teardown removes only an owned root and proves it absent", as
   } finally {
     rmSync(state.root, { recursive: true, force: true });
   }
+});
+
+test("private gate root removal bounds Windows handle retries only", () => {
+  assert.deepEqual(tuiGateRootRemoveOptions("win32"), {
+    recursive: true,
+    maxRetries: 10,
+    retryDelay: 50,
+  });
+  assert.deepEqual(tuiGateRootRemoveOptions("linux"), { recursive: true });
+  assert.deepEqual(tuiGateRootRemoveOptions("darwin"), { recursive: true });
+
+  const source = readFileSync(
+    new URL("./tui-gate-state.mjs", import.meta.url),
+    "utf8",
+  );
+  const teardownStart = source.indexOf("async function performTeardown(state)");
+  const teardownEnd = source.indexOf(
+    "async function settlePendingDaemonStarts(state)",
+    teardownStart,
+  );
+  assert.ok(teardownStart >= 0);
+  assert.ok(teardownEnd > teardownStart);
+  assert.match(
+    source.slice(teardownStart, teardownEnd),
+    /await rm\(state\.root, tuiGateRootRemoveOptions\(\)\);/u,
+  );
 });
 
 test("private gate project fixtures are deterministic and can expose real diffs", async () => {

--- a/runtime/scripts/tui-gate-state.mjs
+++ b/runtime/scripts/tui-gate-state.mjs
@@ -27,6 +27,8 @@ const DAEMON_FORCE_KILL_GRACE_MS = 2_000;
 const DAEMON_POLL_MS = 100;
 const MAX_DAEMON_OUTPUT_BYTES = 64 * 1024;
 const SHORT_ROOT_PREFIX = "agt-";
+const WINDOWS_ROOT_REMOVE_MAX_RETRIES = 10;
+const WINDOWS_ROOT_REMOVE_RETRY_DELAY_MS = 50;
 const PROJECT_FIXTURE_FILES = Object.freeze({
   "README.md": "# AgenC TUI gate fixture\n",
   "package.json": '{"private":true}\n',
@@ -94,6 +96,17 @@ const ACTIVE_STATES_BY_HOME = new Map();
 
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export function tuiGateRootRemoveOptions(platform = process.platform) {
+  if (platform !== "win32") return { recursive: true };
+  // ConPTY/process exit can precede release of the final directory handle.
+  // Bound fs.rm's native EBUSY retry path without weakening absence proof.
+  return {
+    recursive: true,
+    maxRetries: WINDOWS_ROOT_REMOVE_MAX_RETRIES,
+    retryDelay: WINDOWS_ROOT_REMOVE_RETRY_DELAY_MS,
+  };
 }
 
 function systemEnvironment(baseEnv) {
@@ -788,7 +801,7 @@ async function performTeardown(state) {
   }
 
   await assertOwnedState(state);
-  await rm(state.root, { recursive: true });
+  await rm(state.root, tuiGateRootRemoveOptions());
   if (await pathExists(state.root)) {
     throw new Error(`private TUI gate root survived cleanup: ${state.root}`);
   }

--- a/runtime/tests/fnd/benchmark-harness-faults.test.ts
+++ b/runtime/tests/fnd/benchmark-harness-faults.test.ts
@@ -68,6 +68,9 @@ const RUNTIME_ROOT = join(import.meta.dirname, "../..");
 const RUNNER_PATH = join(RUNTIME_ROOT, "benchmarks/fnd/run-baselines.mjs");
 const CASE_WORKER_PATH = join(RUNTIME_ROOT, "benchmarks/fnd/case-worker.mjs");
 const NPM_CLI_BOUNDARY_PROBE_TIMEOUT_MS = 15_000;
+// The Windows-native lane runs this fixture alongside process and ACL probes;
+// keep setup bounded while allowing for hosted process-startup contention.
+const FIXTURE_GIT_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 5_000;
 const MODULE_TRACKER_PATH = join(
   RUNTIME_ROOT,
   "benchmarks/fnd/module-closure.mjs",
@@ -1383,6 +1386,13 @@ describe("FND benchmark harness fault contracts", () => {
   });
 
   test("detects source and harness mutation across a capture", () => {
+    expect(fixtureGitArguments(["status"])).toEqual([
+      "-c",
+      "gc.auto=0",
+      "-c",
+      "maintenance.auto=false",
+      "status",
+    ]);
     const fixture = createProvenanceFixture();
     try {
       const options = provenanceOptions(fixture.repositoryRoot);
@@ -1856,21 +1866,31 @@ function processIsAlive(pid: number): boolean {
 }
 
 function runGit(repositoryRoot: string, args: readonly string[]): void {
-  execFileSync("git", args, {
+  execFileSync("git", fixtureGitArguments(args), {
     cwd: repositoryRoot,
     maxBuffer: 65_536,
     stdio: "ignore",
-    timeout: 5_000,
+    timeout: FIXTURE_GIT_TIMEOUT_MS,
     windowsHide: true,
   });
 }
 
 function readGitText(repositoryRoot: string, args: readonly string[]): string {
-  return execFileSync("git", args, {
+  return execFileSync("git", fixtureGitArguments(args), {
     cwd: repositoryRoot,
     encoding: "utf8",
     maxBuffer: 65_536,
-    timeout: 5_000,
+    timeout: FIXTURE_GIT_TIMEOUT_MS,
     windowsHide: true,
   }).trim();
+}
+
+function fixtureGitArguments(args: readonly string[]): string[] {
+  return [
+    "-c",
+    "gc.auto=0",
+    "-c",
+    "maintenance.auto=false",
+    ...args,
+  ];
 }

--- a/runtime/tests/memory/store.test.ts
+++ b/runtime/tests/memory/store.test.ts
@@ -106,7 +106,7 @@ describe("MemoryStore", () => {
     expect(store.recordStage1OutputUsage(["thread-1", "missing"])).toBe(1);
     expect(store.listStage1OutputsForGlobal(5)).toHaveLength(1);
     expect(store.getPhase2InputSelection(5, 36_500)).toHaveLength(1);
-    expect(store.pruneStage1OutputsForRetention(0, 10)).toBeGreaterThanOrEqual(0);
+    expect(store.pruneStage1OutputsForRetention(1, 10)).toBe(0);
     driver
       .prepareState("DELETE FROM memory_jobs WHERE kind = 'memory_consolidate_global'")
       .run();

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -2,6 +2,10 @@ import { readFile } from "node:fs/promises";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  INITIAL_STATE,
+  parseMultipleKeypresses,
+} from "../../../src/tui/ink/parse-keypress.js";
 import { runEmbeddedNeovimCommand } from "../../../scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs";
 
 // NOTE: This is a STATIC contract check that the PTY gate scripts exist and
@@ -12,14 +16,16 @@ import { runEmbeddedNeovimCommand } from "../../../scripts/check-tui-e2e/helpers
 // Neovim lane covers four lower-level real-process lifecycle tests; the full
 // PTY scenario remains local, so do not treat this file as e2e coverage.
 describe("embedded Neovim BUFFER PTY gate files", () => {
-  it("enters command mode only after committed provider-state acknowledgements", async () => {
+  it("enters command mode with an unambiguous Escape before provider-state acknowledgements", async () => {
     const events: string[] = [];
+    const sentInputs: string[] = [];
     const session = {
       cols: 80,
       rows: 24,
       raw: "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
       send(input: string) {
         events.push(`send:${JSON.stringify(input)}`);
+        sentInputs.push(input);
         if (input === ":") {
           this.raw =
             "target.txt [embedded Neovim NVIM v0.11.4, normal, ready] CMDLINE_NORMAL";
@@ -43,17 +49,31 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
 
     expect(events).toEqual([
       "idle:200",
-      'send:"\\u001b"',
+      'send:"\\u001b[27u"',
       'send:":"',
       'send:"\\u001b[200~write\\u001b[201~"',
       'send:"\\r"',
       "idle:500",
       "idle:200",
-      'send:"\\u001b"',
+      'send:"\\u001b[27u"',
       'send:":"',
       'send:"\\u001b[200~q!\\u001b[201~"',
       'send:"\\r"',
       "idle:500",
+    ]);
+    const [parsedCommandModeInputs] = parseMultipleKeypresses(
+      INITIAL_STATE,
+      sentInputs.slice(0, 2).join(""),
+    );
+    expect(
+      parsedCommandModeInputs.map((input) =>
+        input.kind === "key"
+          ? { kind: input.kind, name: input.name, sequence: input.sequence }
+          : { kind: input.kind },
+      ),
+    ).toEqual([
+      { kind: "key", name: "escape", sequence: "\x1b[27u" },
+      { kind: "key", name: "", sequence: ":" },
     ]);
   });
 


### PR DESCRIPTION
Hardens four hosted-test lifecycle boundaries without changing product semantics.

- Private TUI gate-root removal now uses the bounded Windows-only `EBUSY` retry path after the existing ownership, process, daemon-socket, and path checks have passed. Cleanup remains non-forced and fails after 10 retries with 50 ms linear backoff (2.75 seconds maximum added wait); Linux and Darwin retain one-shot behavior.
- Embedded-Neovim command entry now encodes Escape as complete CSI-u input, preventing a render-stalled child from coalescing raw Escape with `:` and losing the normalization key. The regression drives the real key parser and proves ordered Escape/colon events.
- The memory-store retention test gives a just-used row a one-day retention window and asserts that pruning removes exactly zero rows, eliminating an accidental dependency on both operations landing in the same epoch second.
- FND provenance fixtures disable optional Git auto-GC/maintenance for every command and use a bounded 15-second Windows setup limit while preserving the 5-second limit elsewhere.

Validation:
- TUI startup contracts 28/28 and focused hosted scenario 131
- embedded-Neovim contract/parser coverage 41/41; hosted scenarios 130+131 2/2
- memory-store target 50/50 repetitions and full file 7/7
- FND harness target 5/5 repetitions and full file 36/36
- runtime source and test-support typechecks
- `npm run check:tui-runtime-startup --workspace=@tetsuo-ai/runtime`
- pre-commit runtime build and PTY startup smoke
- independent reviews: no P0-P2 findings
