### PR TITLE
fix(release): bind refreshed Windows compiler payload

### DIFF
--- a/release-toolchain.json
+++ b/release-toolchain.json
@@ -389,9 +389,9 @@
           "visualStudioVersion": "18.9.12112.369",
           "visualStudioInstallPath": "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise",
           "msvcToolsVersion": "14.51.36231",
-          "msvcCompilerVersion": "19.51.36252",
-          "msvcCompilerSha256": "c94cdac6a780142920110e5cb8b7339817029eead696e0e97700b45e03216a00",
-          "msvcLinkerSha256": "f233b8e337cec96a69868a8cde676808bfa81152493968d0b27b7cd0daac15be",
+          "msvcCompilerVersion": "19.51.36256",
+          "msvcCompilerSha256": "e6d57100c82ae0310c18b16abfe52bc0df8fbb272ca6c5fb287d485807cfce91",
+          "msvcLinkerSha256": "3ef8fcf80d409fab22ddd89ee19249f31a26ad9914d3e3e48573c30998fa24de",
           "windowsSdkVersion": "10.0.26100.0"
         },
         {

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -1019,11 +1019,11 @@ describe("reproducible install and release contract", () => {
             imageVersion: "20260818.207.1",
             visualStudioVersion: "18.9.12112.369",
             msvcToolsVersion: "14.51.36231",
-            msvcCompilerVersion: "19.51.36252",
+            msvcCompilerVersion: "19.51.36256",
             msvcCompilerSha256:
-              "c94cdac6a780142920110e5cb8b7339817029eead696e0e97700b45e03216a00",
+              "e6d57100c82ae0310c18b16abfe52bc0df8fbb272ca6c5fb287d485807cfce91",
             msvcLinkerSha256:
-              "f233b8e337cec96a69868a8cde676808bfa81152493968d0b27b7cd0daac15be",
+              "3ef8fcf80d409fab22ddd89ee19249f31a26ad9914d3e3e48573c30998fa24de",
             windowsSdkVersion: "10.0.26100.0",
           },
           {


### PR DESCRIPTION
## Summary

Correct the `20260818.207.1` hosted Windows profile to the exact compiler and linker payload shipped by Visual Studio `18.9.12112.369`.

The prior profile was fail-closed—it still expected the old binary hashes, so it could not authorize changed compiler bytes—but would have rejected the new runner once rollout reached the scheduling pool.

## Evidence

The official VS 18 stable channel resolves to the exact 18.9 manifest, which binds `Microsoft.VC.14.51.Tools.HostX64.TargetX64.base` v14.51.36256 to a digest-addressed VSIX (`sha256:5f9aad4517addfab7a4193e7f00b8556481e8a90e3fca5dac7a63ebc1291f0ae`). Extracting its installed `Hostx64/x64` payload gives:

- toolset directory: `14.51.36231`
- compiler identity: `19.51.36256`
- `cl.exe`: `e6d57100c82ae0310c18b16abfe52bc0df8fbb272ca6c5fb287d485807cfce91`
- `link.exe`: `3ef8fcf80d409fab22ddd89ee19249f31a26ad9914d3e3e48573c30998fa24de`

## Validation

- online hosted-runner contract: 9/9 immutable inventories
- reproducible-build release contract: 15/15
- pre-commit runtime build, package entrypoints, SDK generated-type drift, and real PTY startup smoke
- `git diff --check`
