### PR TITLE
fix(runtime): restore release verification

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -245,7 +245,7 @@ jobs:
           test "$(node --version)" = "v${NODE_VERSION}"
           test "$(npm --version)" = "$NPM_VERSION"
 
-      - name: Run the exact real-kernel bubblewrap lane
+      - name: Run the exact real-kernel sandbox lane
         shell: bash
         run: |
           set -euo pipefail
@@ -458,15 +458,17 @@ jobs:
           const [resultsPath] = process.argv.slice(2);
           if (!resultsPath) throw new Error("missing kernel-test results path");
           const results = JSON.parse(readFileSync(resultsPath, "utf8"));
-          const expectedFile =
-            "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts";
+          const expectedFiles = [
+            "tests/sandbox/landlock-seccomp.kernel.test.ts",
+            "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
+          ];
           const exactCounts = {
-            numTotalTestSuites: 1,
-            numPassedTestSuites: 1,
+            numTotalTestSuites: 3,
+            numPassedTestSuites: 3,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 2,
-            numPassedTests: 2,
+            numTotalTests: 9,
+            numPassedTests: 9,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -481,21 +483,26 @@ jobs:
           if (
             results.success !== true ||
             !Array.isArray(results.testResults) ||
-            results.testResults.length !== 1
+            results.testResults.length !== expectedFiles.length
           ) {
-            throw new Error("kernel-test result did not report one successful file");
-          }
-          const file = relative(
-            resolve("runtime"),
-            results.testResults[0].name,
-          ).split("\\").join("/");
-          if (file !== expectedFile) {
             throw new Error(
-              `kernel-test file was ${JSON.stringify(file)}, expected ${expectedFile}`,
+              "kernel-test result did not report two successful files",
+            );
+          }
+          const files = results.testResults
+            .map((result) =>
+              relative(resolve("runtime"), result.name)
+                .split("\\")
+                .join("/"),
+            )
+            .sort();
+          if (JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+            throw new Error(
+              `kernel-test files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
             );
           }
           console.log(
-            "real-kernel bubblewrap lane passed 2 tests in 1 file with zero skipped",
+            "real-kernel sandbox lane passed 9 tests in 2 files with zero skipped",
           );
           NODE
 

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -906,15 +906,21 @@ Linux local gate. Its `linux-kernel-sandbox` job installs the digest- and
 byte-pinned Ubuntu bubblewrap package from
 [`release-toolchain.json`](../release-toolchain.json), keeps Ubuntu's global
 AppArmor user-namespace restriction enabled, and loads the narrow profile
-rendered by AgenC for a root-owned generated wrapper. The two-test allowlist
-then exercises the production broker, manager, packaged launcher, bubblewrap,
-user/PID/mount/network namespaces, network seccomp, filesystem mounts, and
-descendant cleanup as an unprivileged process with no effective capabilities.
-Linux readiness requires bubblewrap's descriptor-based `--ro-bind-fd` mount;
-older builds fail closed with an upgrade diagnostic before namespace setup.
-The job proves host loopback reachability before the sandbox, requires the
-sandboxed socket syscall to fail with `EPERM`, and unloads the profile with
-process- and checkout-cleanliness postconditions.
+rendered by AgenC for a root-owned generated wrapper. Its exact nine-test,
+two-file allowlist includes seven tests that exercise the native
+Landlock launcher's valid nested seccomp program and the production fallback
+when network access is disabled; these cannot run beneath the ordinary local
+gate's ptrace observer because that observer deliberately rejects nested
+filter installation. The remaining two tests exercise the production broker,
+manager, packaged launcher, bubblewrap, user/PID/mount/network namespaces,
+network seccomp, filesystem mounts, and descendant cleanup as an unprivileged
+process with no effective capabilities. Every test asserts its required kernel
+capabilities instead of conditionally declining to run. Linux readiness
+requires bubblewrap's descriptor-based `--ro-bind-fd` mount; older builds fail
+closed with an upgrade diagnostic before namespace setup. The job proves host
+loopback reachability before the sandbox, requires the sandboxed socket syscall
+to fail with `EPERM`, and unloads the profile with process- and
+checkout-cleanliness postconditions.
 
 The `powershell` job installs the digest- and byte-pinned
 PowerShell runtime from [`release-toolchain.json`](../release-toolchain.json),

--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -490,8 +490,11 @@ export async function ensureAgenCDaemonAutostart(
     // Compare builds only after the complete identity proof. A PID and mutable
     // sidecar alone are never authority to stop a process.
     const runtimeRoot = resolveRuntimePackageRootFromUrl(import.meta.url);
-    const currentVersion =
-      runtimeRoot !== null ? readDistVersion(runtimeRoot) : null;
+    const currentVersion = host.readCurrentRuntimeBuild
+      ? host.readCurrentRuntimeBuild()
+      : runtimeRoot !== null
+        ? readDistVersion(runtimeRoot)
+        : null;
     if (
       currentVersion !== null &&
       (verifiedInstance.identity.runtimeVersion !==

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -337,6 +337,11 @@ export interface AgenCDaemonCliHost {
   readonly execPath: string;
   readonly pid: number;
   readonly platform?: NodeJS.Platform;
+  /** @internal Build identity seam for build-artifact-independent contracts. */
+  readonly readCurrentRuntimeBuild?: () => Pick<
+    AgenCDaemonInstanceIdentity,
+    "runtimeVersion" | "commit" | "buildTime"
+  > | null;
   spawnDetachedDaemon(env: NodeJS.ProcessEnv): number;
   /** Exact child capability retained only for this detached start invocation. */
   cancelSpawnedDaemon?(pid: number): Promise<void> | void;
@@ -2810,8 +2815,11 @@ async function runAgenCDaemonForegroundLocked(
   );
   const cookieAuthenticator = new AgenCDaemonCookieAuthenticator(daemonCookie);
   const runtimeRoot = resolveRuntimePackageRootFromUrl(import.meta.url);
-  const distVersion =
-    runtimeRoot !== null ? readDistVersion(runtimeRoot) : null;
+  const distVersion = host.readCurrentRuntimeBuild
+    ? host.readCurrentRuntimeBuild()
+    : runtimeRoot !== null
+      ? readDistVersion(runtimeRoot)
+      : null;
   const processStart = await readAgenCDaemonProcessStart(
     host.pid,
     host.readProcessIdentity,

--- a/runtime/src/app-server/daemon-instance-identity.ts
+++ b/runtime/src/app-server/daemon-instance-identity.ts
@@ -368,17 +368,21 @@ async function inspectLinuxAgenCDaemonProcessWithTracker(
     const expectedEntrypointBasename =
       expectedEntrypoint === null ? null : basename(expectedEntrypoint);
     // An unrelated process may legitimately hide its cwd from this user. A
-    // basename match is only a cheap necessary condition: it authorizes no
-    // action, but lets us avoid cwd I/O when no argv token could resolve to
-    // either the exact entrypoint or a canonical <package>/bin/agenc path.
+    // basename plus exact daemon invocation tail is only a cheap necessary
+    // condition: it authorizes no action, but lets us avoid cwd and canonical
+    // entrypoint I/O when no argv token could represent a foreground daemon.
     // Candidate-shaped argv still receives the complete fail-closed proof.
     if (
-      !argv.some((value) => {
+      !argv.some((value, index) => {
         const candidateBasename = basename(resolve("/", value));
         return (
-          (expectedEntrypointBasename !== null &&
+          ((expectedEntrypointBasename !== null &&
             candidateBasename === expectedEntrypointBasename) ||
-          (entrypointMatch === "any-install" && candidateBasename === "agenc")
+            (entrypointMatch === "any-install" &&
+              candidateBasename === "agenc")) &&
+          argv[index + 1] === "daemon" &&
+          argv[index + 2] === "start" &&
+          argv[index + 3] === "--foreground"
         );
       })
     ) {

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -29,7 +29,6 @@ import {
 import {
   daemonInstanceIdentityFromRuntimeInfo,
   readDaemonRuntimeInfo,
-  readDistVersion,
   resolveAgenCDaemonRuntimeInfoPath,
   writeDaemonRuntimeInfo,
 } from "./daemon-runtime-info.js";
@@ -39,10 +38,17 @@ import {
   type AgenCDaemonProcessIdentity,
 } from "./daemon-instance-identity.js";
 
+const TEST_CURRENT_RUNTIME_BUILD = {
+  runtimeVersion: "0.17.0-test",
+  commit: "test-current-commit",
+  buildTime: "2026-08-19T00:00:00.000Z",
+} as const;
+
 function createHost(agencHome: string): AgenCDaemonCliHost & {
   readonly runningPids: Set<number>;
   readonly spawnedPids: number[];
   platform: NodeJS.Platform;
+  readCurrentRuntimeBuild(): typeof TEST_CURRENT_RUNTIME_BUILD;
   readProcessIdentity(pid: number): string | null;
   requestDaemonInstanceIdentity(): AgenCDaemonInstanceIdentity;
   requestDaemonShutdown(expected: AgenCDaemonInstanceIdentity): void;
@@ -56,11 +62,7 @@ function createHost(agencHome: string): AgenCDaemonCliHost & {
   let nextInstance = 0;
   const runningPids = new Set<number>();
   const spawnedPids: number[] = [];
-  const build = readDistVersion(process.cwd()) ?? {
-    runtimeVersion: "development",
-    commit: "unknown",
-    buildTime: "unknown",
-  };
+  const build = TEST_CURRENT_RUNTIME_BUILD;
   const runtimeInfoPath = resolveAgenCDaemonRuntimeInfoPath(agencHome);
   const host = {
     env: { AGENC_HOME: agencHome },
@@ -69,6 +71,7 @@ function createHost(agencHome: string): AgenCDaemonCliHost & {
     execPath: "/usr/bin/node",
     pid: 5100,
     platform: process.platform,
+    readCurrentRuntimeBuild: () => TEST_CURRENT_RUNTIME_BUILD,
     runningPids,
     spawnedPids,
     spawnDetachedDaemon: () => {
@@ -583,14 +586,13 @@ port = 0
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);
     const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
-    const currentBuild = readDistVersion(process.cwd());
-    expect(currentBuild).not.toBeNull();
+    const currentBuild = TEST_CURRENT_RUNTIME_BUILD;
     const pid = 5309;
     host.runningPids.add(pid);
     await writeAgenCDaemonPid(pidPath, pid);
     host.recordDaemon(pid, {
-      ...currentBuild!,
-      commit: `${currentBuild!.commit}-different`,
+      ...currentBuild,
+      commit: `${currentBuild.commit}-different`,
     });
 
     try {
@@ -667,8 +669,7 @@ port = 0
     const host = createHost(agencHome);
     const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
     const runtimeInfoPath = resolveAgenCDaemonRuntimeInfoPath(agencHome);
-    const currentBuild = readDistVersion(process.cwd());
-    expect(currentBuild).not.toBeNull();
+    const currentBuild = TEST_CURRENT_RUNTIME_BUILD;
     const pid = 5307;
     let processStart = `test-process:${pid}:old`;
     host.runningPids.add(pid);
@@ -711,7 +712,7 @@ port = 0
                 // does, then commit the new sidecar generation.
                 await writeAgenCDaemonPid(pidPath, pid);
                 replacementIdentity = host.recordDaemon(pid, {
-                  ...currentBuild!,
+                  ...currentBuild,
                   instanceId: "replacement-after-metadata-lock",
                   processStart,
                 });

--- a/runtime/tests/app-server/daemon-instance-identity.contract.test.ts
+++ b/runtime/tests/app-server/daemon-instance-identity.contract.test.ts
@@ -167,6 +167,91 @@ describe("daemon instance identity", () => {
   );
 
   it.skipIf(process.platform !== "linux")(
+    "ignores a missing agenc path without the foreground daemon tail",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "agenc-nondaemon-argv-"));
+      const missingEntrypoint = join(root, "missing", "bin", "agenc");
+      const child = spawn(
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1_000)", missingEntrypoint, "status"],
+        { stdio: "ignore" },
+      );
+      const readProcessCwdPath = vi.fn(async () => process.cwd());
+
+      try {
+        await once(child, "spawn");
+        await expect(
+          findLinuxAgenCDaemonProcesses(
+            {
+              entrypointPath: join(process.cwd(), "bin", "agenc"),
+              pid: process.pid,
+              platform: "linux",
+              isPidRunning: (pid) =>
+                pid === child.pid && child.exitCode === null,
+            },
+            join(root, "daemon-home"),
+            "any-install",
+            { readProcessCwdPath },
+          ),
+        ).resolves.toEqual([]);
+        expect(readProcessCwdPath).not.toHaveBeenCalled();
+      } finally {
+        const exited = once(child, "exit");
+        child.kill("SIGKILL");
+        await exited.catch(() => {});
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "fails closed for a missing agenc path with the foreground daemon tail",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "agenc-daemon-argv-"));
+      const missingEntrypoint = join(root, "missing", "bin", "agenc");
+      const child = spawn(
+        process.execPath,
+        [
+          "-e",
+          "setInterval(() => {}, 1_000)",
+          missingEntrypoint,
+          "daemon",
+          "start",
+          "--foreground",
+        ],
+        { stdio: "ignore" },
+      );
+      const readProcessCwdPath = vi.fn(async () => process.cwd());
+
+      try {
+        await once(child, "spawn");
+        await expect(
+          findLinuxAgenCDaemonProcesses(
+            {
+              entrypointPath: join(process.cwd(), "bin", "agenc"),
+              pid: process.pid,
+              platform: "linux",
+              isPidRunning: (pid) =>
+                pid === child.pid && child.exitCode === null,
+            },
+            join(root, "daemon-home"),
+            "any-install",
+            { readProcessCwdPath },
+          ),
+        ).rejects.toBeInstanceOf(AgenCDaemonProcessScanIncompleteError);
+        expect(readProcessCwdPath).toHaveBeenCalledExactlyOnceWith(
+          `/proc/${child.pid}`,
+        );
+      } finally {
+        const exited = once(child, "exit");
+        child.kill("SIGKILL");
+        await exited.catch(() => {});
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
     "matches a relative daemon entrypoint and fails closed when its cwd proof fails",
     async () => {
       const root = await mkdtemp(join(tmpdir(), "agenc-candidate-cwd-"));

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -71,6 +71,7 @@ const HOSTED_FND_TEST_FILES = [
 ] as const;
 
 const KERNEL_TEST_FILES = [
+  "tests/sandbox/landlock-seccomp.kernel.test.ts",
   "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
 ] as const;
 
@@ -219,34 +220,66 @@ describe("hermetic test discovery", () => {
     }
   });
 
-  it("kernel discovery is an exact fail-closed real-bubblewrap allowlist", () => {
+  it("kernel discovery is an exact fail-closed sandbox allowlist", () => {
     expect(listTestFiles("vitest.kernel.config.ts")).toEqual([
       ...KERNEL_TEST_FILES,
     ]);
-    const source = readFileSync(
-      resolve(runtimeRoot, KERNEL_TEST_FILES[0]),
+    for (const file of KERNEL_TEST_FILES) {
+      const source = readFileSync(resolve(runtimeRoot, file), "utf8");
+      expect(source).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
+    }
+
+    const landlockSource = readFileSync(
+      resolve(runtimeRoot, "tests/sandbox/landlock-seccomp.kernel.test.ts"),
       "utf8",
     );
-    expect(source).not.toMatch(/\b(?:runIf|skip|skipIf)\b/u);
-    expect(source).toContain("new SandboxExecutionBroker({");
-    expect(source).toContain("const status = broker.status()");
-    expect(source).toContain('broker.prepareSpawn("tool"');
-    expect(source).toContain("agenc-native-userns (unconfined)");
-    expect(source).toContain("tcpRoundTrip(address.port, baselineToken)");
-    expect(source).toContain('error: "EPERM"');
-    expect(source).toContain("evidence.namespaces.mnt");
-    expect(source).toContain("evidence.namespaces.net");
-    expect(source).toContain("evidence.namespaces.pid");
-    expect(source).toContain("evidence.namespaces.user");
-    expect(source).toContain("expect(hostConnections).toBe(0)");
-    expect(source).toContain(
+    expect(landlockSource).toContain("assertKernelLaneCapabilities()");
+    expect(landlockSource).toContain(
+      "expect(process.env.AGENC_TEST_OS_BOUNDARY).toBeUndefined()",
+    );
+    expect(landlockSource).toContain(
+      'expect(probeLandlock(launcher)).toBe("full")',
+    );
+    for (const testName of [
+      "the same BPF program AgenC hands bwrap denies AF_INET and keeps AF_UNIX",
+      "filesystem and network confinement hold in one run",
+      "runs a descriptor-bound read in a git workspace with writes and network removed",
+      "uses Landlock when installed bubblewrap cannot create namespaces",
+      "confines writes to the workspace when bubblewrap is unavailable",
+      "keeps /proc unreadable, closing the same-uid environ channel",
+      "applies the network seccomp program when the policy disables network",
+    ]) {
+      expect(landlockSource).toContain(`it("${testName}"`);
+    }
+
+    const bubblewrapSource = readFileSync(
+      resolve(
+        runtimeRoot,
+        "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
+      ),
+      "utf8",
+    );
+    expect(bubblewrapSource).toContain("new SandboxExecutionBroker({");
+    expect(bubblewrapSource).toContain("const status = broker.status()");
+    expect(bubblewrapSource).toContain('broker.prepareSpawn("tool"');
+    expect(bubblewrapSource).toContain("agenc-native-userns (unconfined)");
+    expect(bubblewrapSource).toContain(
+      "tcpRoundTrip(address.port, baselineToken)",
+    );
+    expect(bubblewrapSource).toContain('error: "EPERM"');
+    expect(bubblewrapSource).toContain("evidence.namespaces.mnt");
+    expect(bubblewrapSource).toContain("evidence.namespaces.net");
+    expect(bubblewrapSource).toContain("evidence.namespaces.pid");
+    expect(bubblewrapSource).toContain("evidence.namespaces.user");
+    expect(bubblewrapSource).toContain("expect(hostConnections).toBe(0)");
+    expect(bubblewrapSource).toContain(
       "expect(existsSync(descendantLeakMarker)).toBe(false)",
     );
-    expect(source).toContain("visibleInProc: true");
-    expect(source).toContain(
+    expect(bubblewrapSource).toContain("visibleInProc: true");
+    expect(bubblewrapSource).toContain(
       'expect(readFileSync(hostSentinel, "utf8")).toBe(',
     );
-    expect(source).toContain(
+    expect(bubblewrapSource).toContain(
       'expect(readFileSync(launcherSentinel, "utf8")).toBe(',
     );
   });

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -280,6 +280,7 @@ describe("reproducible install and release contract", () => {
       workflow.indexOf("\n  powershell:"),
     );
     expect(linuxKernelJob).toContain("runs-on: ubuntu-24.04");
+    expect(linuxKernelJob).toContain("Run the exact real-kernel sandbox lane");
     expect(linuxKernelJob).toContain(
       '["bubblewrapTestRuntime"]["ubuntu-24.04-x64"]',
     );
@@ -299,14 +300,18 @@ describe("reproducible install and release contract", () => {
     expect(linuxKernelJob).toContain("--require-zero-skips");
     expect(linuxKernelJob).toContain("--config vitest.kernel.config.ts");
     expect(linuxKernelJob).toContain(
+      "tests/sandbox/landlock-seccomp.kernel.test.ts",
+    );
+    expect(linuxKernelJob).toContain(
       "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
     );
-    expect(linuxKernelJob).toContain("numTotalTestSuites: 1");
-    expect(linuxKernelJob).toContain("numTotalTests: 2");
-    expect(linuxKernelJob).toContain("numPassedTests: 2");
+    expect(linuxKernelJob).toContain("numTotalTestSuites: 3");
+    expect(linuxKernelJob).toContain("numTotalTests: 9");
+    expect(linuxKernelJob).toContain("numPassedTests: 9");
     expect(linuxKernelJob).toContain(
-      'bwrap_help="$(bwrap --help)"',
+      "real-kernel sandbox lane passed 9 tests in 2 files with zero skipped",
     );
+    expect(linuxKernelJob).toContain('bwrap_help="$(bwrap --help)"');
     expect(linuxKernelJob).toContain("grep -Fq -- '--ro-bind-fd'");
     expect(linuxKernelJob).toContain("/proc/[0-9]*/exe");
     expect(linuxKernelJob).toContain("pgrep -x bwrap");
@@ -485,9 +490,7 @@ describe("reproducible install and release contract", () => {
     expect(windowsJob).toContain(
       "tests/app-server/windows-named-pipe.win32.test.ts",
     );
-    expect(windowsJob).toContain(
-      "tests/agents/jobs/csv-output.native.test.ts",
-    );
+    expect(windowsJob).toContain("tests/agents/jobs/csv-output.native.test.ts");
     expect(windowsJob).toContain(
       "tests/durability/atomic-artifact.win32.test.ts",
     );

--- a/runtime/tests/sandbox/landlock-run.test.ts
+++ b/runtime/tests/sandbox/landlock-run.test.ts
@@ -22,7 +22,6 @@ import {
   probeLandlock,
   resolveLandlockRun,
 } from "../../src/sandbox/landlock-run.js";
-import { createNetworkSeccompProgram } from "../../src/sandbox/linux-launcher/landlock.js";
 
 function hasTrustedCompiler(): boolean {
   return ["/usr/bin/cc", "/bin/cc"].some((candidate) => {
@@ -78,15 +77,16 @@ describe("classifyLandlockRunOutcome", () => {
     expect(
       classifyLandlockRunOutcome({
         status: LANDLOCK_RUN_FAILURE_EXIT,
-        stderr: "landlock-run: cannot open rule path: /x: No such file or directory\n",
+        stderr:
+          "landlock-run: cannot open rule path: /x: No such file or directory\n",
       }),
     ).toMatchObject({ kind: "launcher-failure" });
   });
 
   test("a child's own 125 without fatal evidence stays the command's outcome", () => {
-    expect(
-      classifyLandlockRunOutcome({ status: 125, stderr: "" }),
-    ).toEqual({ kind: "command-outcome" });
+    expect(classifyLandlockRunOutcome({ status: 125, stderr: "" })).toEqual({
+      kind: "command-outcome",
+    });
   });
 
   test("the exact partial notice is informational, never fatal evidence", () => {
@@ -138,14 +138,17 @@ describe.runIf(canRunLive)("agenc-landlock-run (live kernel)", () => {
   });
 
   test("read is denied outside grants and allowed inside them", () => {
-    const denied = runConfined(
-      { readOnly: ["/usr", "/lib", "/lib64"] },
-      ["/usr/bin/cat", "/etc/hostname"],
-    );
+    const denied = runConfined({ readOnly: ["/usr", "/lib", "/lib64"] }, [
+      "/usr/bin/cat",
+      "/etc/hostname",
+    ]);
     expect(denied.status).not.toBe(0);
     expect(denied.status).not.toBe(LANDLOCK_RUN_FAILURE_EXIT);
     expect(
-      classifyLandlockRunOutcome({ status: denied.status, stderr: denied.stderr }),
+      classifyLandlockRunOutcome({
+        status: denied.status,
+        stderr: denied.stderr,
+      }),
     ).toEqual({ kind: "command-outcome" });
 
     const allowed = runConfined(
@@ -197,10 +200,9 @@ describe.runIf(canRunLive)("agenc-landlock-run (live kernel)", () => {
   });
 
   test("an unopenable grant root fails closed as a launcher failure", () => {
-    const run = runConfined(
-      { readOnly: ["/definitely-not-a-real-path-xyz"] },
-      ["/bin/true"],
-    );
+    const run = runConfined({ readOnly: ["/definitely-not-a-real-path-xyz"] }, [
+      "/bin/true",
+    ]);
     expect(run.status).toBe(LANDLOCK_RUN_FAILURE_EXIT);
     expect(
       classifyLandlockRunOutcome({ status: run.status, stderr: run.stderr }),
@@ -240,7 +242,9 @@ function runWithSeccomp(
       [
         ...landlockLaunchArgs({
           readOnly: ["/"],
-          ...(extra?.readWrite !== undefined ? { readWrite: extra.readWrite } : {}),
+          ...(extra?.readWrite !== undefined
+            ? { readWrite: extra.readWrite }
+            : {}),
           ...(stdioFd !== undefined ? { seccompFd: 3 } : {}),
         }),
         ...command,
@@ -279,29 +283,6 @@ describe.runIf(canRunSeccompLive)(
       const run = runWithSeccomp(undefined, [...SOCKET_PROBE]);
       expect(run.status).toBe(0);
       expect(run.stdout).toContain("inet-open");
-    });
-
-    test("the same BPF program AgenC hands bwrap denies AF_INET and keeps AF_UNIX", () => {
-      const program = createNetworkSeccompProgram("restricted");
-      const run = runWithSeccomp(program, [...SOCKET_PROBE]);
-      expect(run.status).toBe(0);
-      expect(run.stdout).toContain("inet-denied");
-      expect(run.stdout).toContain("unix-open");
-    });
-
-    test("filesystem and network confinement hold in one run", () => {
-      const program = createNetworkSeccompProgram("restricted");
-      const dir = mkWorkDir();
-      const target = join(dir, "combined.txt");
-      const run = runWithSeccomp(program, [
-        "/bin/sh",
-        "-c",
-        `if echo x > ${target} 2>/dev/null; then echo write-open; else echo write-denied; fi; ` +
-          `${PYTHON} -c "import socket\ntry:\n  socket.socket(socket.AF_INET)\n  print('inet-open')\nexcept PermissionError:\n  print('inet-denied')"`,
-      ]);
-      expect(run.status).toBe(0);
-      expect(run.stdout).toContain("write-denied");
-      expect(run.stdout).toContain("inet-denied");
     });
 
     test("a malformed program fails closed as a launcher failure", () => {

--- a/runtime/tests/sandbox/landlock-seccomp.kernel.test.ts
+++ b/runtime/tests/sandbox/landlock-seccomp.kernel.test.ts
@@ -1,0 +1,368 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  landlockLaunchArgs,
+  probeLandlock,
+  resolveLandlockRun,
+} from "../../src/sandbox/landlock-run.js";
+import {
+  restrictedFileSystemPolicy,
+  type PermissionProfile,
+} from "../../src/sandbox/engine/index.js";
+import { createNetworkSeccompProgram } from "../../src/sandbox/linux-launcher/landlock.js";
+import { runLinuxSandboxMain } from "../../src/sandbox/linux-launcher/linux-run-main.js";
+import { preferredBubblewrapLauncher } from "../../src/sandbox/linux-launcher/launcher.js";
+
+const PYTHON = "/usr/bin/python3";
+const work: string[] = [];
+
+afterAll(() => {
+  for (const dir of work) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function withTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  work.push(dir);
+  return dir;
+}
+
+function hasTrustedCompiler(): boolean {
+  return ["/usr/bin/cc", "/bin/cc"].some((candidate) => {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function effectiveCapabilities(): bigint {
+  const status = fs.readFileSync("/proc/self/status", "utf8");
+  const value = /^CapEff:\s*([0-9a-f]+)$/imu.exec(status)?.[1];
+  if (value === undefined) {
+    throw new Error("/proc/self/status did not report CapEff");
+  }
+  return BigInt(`0x${value}`);
+}
+
+function assertKernelLaneCapabilities(): void {
+  expect(process.platform).toBe("linux");
+  expect(typeof process.getuid).toBe("function");
+  expect(process.getuid!()).toBeGreaterThan(0);
+  expect(effectiveCapabilities()).toBe(0n);
+  expect(process.env.AGENC_TEST_OS_BOUNDARY).toBeUndefined();
+  expect(hasTrustedCompiler()).toBe(true);
+  expect(fs.existsSync(PYTHON)).toBe(true);
+
+  const launcher = resolveLandlockRun();
+  expect(launcher).toBeDefined();
+  if (launcher === undefined) {
+    throw new Error("the Landlock launcher is unavailable");
+  }
+  expect(probeLandlock(launcher)).toBe("full");
+}
+
+function runWithSeccomp(program: Buffer, command: readonly string[]) {
+  const launcher = resolveLandlockRun();
+  expect(launcher).toBeDefined();
+  if (launcher === undefined) {
+    throw new Error("the Landlock launcher is unavailable");
+  }
+
+  const dir = withTempDir("landlock-seccomp-kernel-");
+  const programPath = path.join(dir, "network.bpf");
+  fs.writeFileSync(programPath, program);
+  const programFd = fs.openSync(programPath, "r");
+  try {
+    return spawnSync(
+      launcher,
+      [...landlockLaunchArgs({ readOnly: ["/"], seccompFd: 3 }), ...command],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+        stdio: ["ignore", "pipe", "pipe", programFd],
+      },
+    );
+  } finally {
+    fs.closeSync(programFd);
+  }
+}
+
+function workspaceWriteProfile(workspace: string): PermissionProfile {
+  return {
+    fileSystem: restrictedFileSystemPolicy(
+      [
+        { path: { kind: "special", value: { kind: "root" } }, access: "read" },
+        { path: { kind: "path", path: workspace }, access: "write" },
+      ],
+      { includePlatformDefaults: true },
+    ),
+    network: "disabled",
+  };
+}
+
+function readOnlyProfile(): PermissionProfile {
+  return {
+    fileSystem: restrictedFileSystemPolicy(
+      [
+        {
+          path: { kind: "special", value: { kind: "root" } },
+          access: "read",
+        },
+      ],
+      { includePlatformDefaults: true },
+    ),
+    network: "disabled",
+  };
+}
+
+async function runFallback(
+  profile: PermissionProfile,
+  workspace: string,
+  command: readonly string[],
+): Promise<{ exitCode: number; stderr: string[] }> {
+  const stderr: string[] = [];
+  const exitCode = await runLinuxSandboxMain(
+    [
+      "--sandbox-policy-cwd",
+      workspace,
+      "--command-cwd",
+      workspace,
+      "--permission-profile",
+      JSON.stringify(profile),
+      "--",
+      ...command,
+    ],
+    {
+      preferredLauncher: () => null,
+      onStderr: (line) => stderr.push(line),
+    },
+  );
+  return { exitCode, stderr };
+}
+
+async function runInheritedFallback(
+  profile: PermissionProfile,
+  command: readonly string[],
+): Promise<{ exitCode: number; stderr: string[] }> {
+  const stderr: string[] = [];
+  const exitCode = await runLinuxSandboxMain(
+    [
+      "--inherited-readonly-command-cwd",
+      "--permission-profile",
+      JSON.stringify(profile),
+      "--no-proc",
+      "--",
+      ...command,
+    ],
+    {
+      preferredLauncher: () => null,
+      onStderr: (line) => stderr.push(line),
+    },
+  );
+  return { exitCode, stderr };
+}
+
+describe("Landlock and seccomp on the native kernel", () => {
+  const SOCKET_PROBE = [
+    PYTHON,
+    "-c",
+    "import socket\n" +
+      "try:\n" +
+      "  socket.socket(socket.AF_INET)\n" +
+      "  print('inet-open')\n" +
+      "except PermissionError:\n" +
+      "  print('inet-denied')\n" +
+      "socket.socket(socket.AF_UNIX)\n" +
+      "print('unix-open')",
+  ] as const;
+
+  it("the same BPF program AgenC hands bwrap denies AF_INET and keeps AF_UNIX", () => {
+    assertKernelLaneCapabilities();
+    const program = createNetworkSeccompProgram("restricted");
+    const run = runWithSeccomp(program, [...SOCKET_PROBE]);
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("inet-denied");
+    expect(run.stdout).toContain("unix-open");
+  });
+
+  it("filesystem and network confinement hold in one run", () => {
+    assertKernelLaneCapabilities();
+    const program = createNetworkSeccompProgram("restricted");
+    const dir = withTempDir("landlock-seccomp-combined-");
+    const target = path.join(dir, "combined.txt");
+    const run = runWithSeccomp(program, [
+      "/bin/sh",
+      "-c",
+      `if echo x > ${target} 2>/dev/null; then echo write-open; else echo write-denied; fi; ` +
+        `${PYTHON} -c "import socket\ntry:\n  socket.socket(socket.AF_INET)\n  print('inet-open')\nexcept PermissionError:\n  print('inet-denied')"`,
+    ]);
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("write-denied");
+    expect(run.stdout).toContain("inet-denied");
+  });
+
+  it("runs a descriptor-bound read in a git workspace with writes and network removed", async () => {
+    assertKernelLaneCapabilities();
+    const root = withTempDir("agenc-landlock-bound-read-");
+    const workspace = path.join(root, "workspace");
+    const unexpectedWrite = path.join(workspace, "unexpected.txt");
+    fs.mkdirSync(workspace);
+    fs.mkdirSync(path.join(workspace, ".git"));
+    fs.writeFileSync(path.join(workspace, "sentinel.txt"), "bound-read\n");
+    const savedCwd = process.cwd();
+    process.chdir(workspace);
+    try {
+      const read = await runInheritedFallback(readOnlyProfile(), [
+        "/bin/sh",
+        "-c",
+        'test "$(cat sentinel.txt)" = bound-read',
+      ]);
+      expect(read).toEqual({ exitCode: 0, stderr: [] });
+
+      const write = await runInheritedFallback(readOnlyProfile(), [
+        "/bin/sh",
+        "-c",
+        `printf unexpected > ${unexpectedWrite}`,
+      ]);
+      expect(write.exitCode).not.toBe(0);
+      expect(fs.existsSync(unexpectedWrite)).toBe(false);
+
+      const network = await runInheritedFallback(readOnlyProfile(), [
+        PYTHON,
+        "-c",
+        "import socket, sys\n" +
+          "try:\n" +
+          "  socket.socket(socket.AF_INET)\n" +
+          "except PermissionError:\n" +
+          "  sys.exit(0)\n" +
+          "sys.exit(9)",
+      ]);
+      expect(network.exitCode).toBe(0);
+    } finally {
+      process.chdir(savedCwd);
+    }
+  });
+
+  it("uses Landlock when installed bubblewrap cannot create namespaces", async () => {
+    assertKernelLaneCapabilities();
+    const root = withTempDir("agenc-landlock-bwrap-denied-");
+    const workspace = path.join(root, "workspace");
+    const trusted = path.join(root, "trusted-bin");
+    fs.mkdirSync(workspace);
+    fs.mkdirSync(trusted);
+    const fakeBwrap = path.join(trusted, "bwrap");
+    fs.writeFileSync(
+      fakeBwrap,
+      [
+        "#!/bin/sh",
+        'if [ "$1" = "--help" ]; then',
+        "  echo '--argv0 --ro-bind-fd'",
+        "  exit 0",
+        "fi",
+        "echo 'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted' >&2",
+        "exit 1",
+      ].join("\n") + "\n",
+      { mode: 0o755 },
+    );
+    const capture = path.join(workspace, "result.txt");
+    const stderr: string[] = [];
+
+    const exitCode = await runLinuxSandboxMain(
+      [
+        "--sandbox-policy-cwd",
+        workspace,
+        "--command-cwd",
+        workspace,
+        "--permission-profile",
+        JSON.stringify(workspaceWriteProfile(workspace)),
+        "--",
+        "/bin/sh",
+        "-c",
+        `printf fallback-ok > ${capture}`,
+      ],
+      {
+        preferredLauncher: (options = {}) =>
+          preferredBubblewrapLauncher({
+            ...options,
+            searchPath: trusted,
+            trustedDirectories: [trusted],
+          }),
+        onStderr: (line) => stderr.push(line),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(fs.readFileSync(capture, "utf8")).toBe("fallback-ok");
+  });
+
+  it("confines writes to the workspace when bubblewrap is unavailable", async () => {
+    assertKernelLaneCapabilities();
+    const workspace = withTempDir("agenc-landlock-fallback-ws-");
+    const outside = withTempDir("agenc-landlock-fallback-out-");
+    const inside = path.join(workspace, "made.txt");
+    const escaped = path.join(outside, "escaped.txt");
+
+    const ok = await runFallback(workspaceWriteProfile(workspace), workspace, [
+      "/bin/sh",
+      "-c",
+      `echo confined > ${inside}`,
+    ]);
+    expect(ok.exitCode).toBe(0);
+    expect(fs.readFileSync(inside, "utf8")).toBe("confined\n");
+
+    const denied = await runFallback(
+      workspaceWriteProfile(workspace),
+      workspace,
+      ["/bin/sh", "-c", `echo escaped > ${escaped}`],
+    );
+    expect(denied.exitCode).not.toBe(0);
+    expect(fs.existsSync(escaped)).toBe(false);
+  });
+
+  it("keeps /proc unreadable, closing the same-uid environ channel", async () => {
+    assertKernelLaneCapabilities();
+    const workspace = withTempDir("agenc-landlock-fallback-proc-");
+    const capture = path.join(workspace, "proc.txt");
+    const denied = await runFallback(
+      workspaceWriteProfile(workspace),
+      workspace,
+      ["/bin/sh", "-c", `cat /proc/self/status > ${capture}`],
+    );
+    expect(denied.exitCode).not.toBe(0);
+    expect(fs.readFileSync(capture, "utf8")).toBe("");
+  });
+
+  it("applies the network seccomp program when the policy disables network", async () => {
+    assertKernelLaneCapabilities();
+    const workspace = withTempDir("agenc-landlock-fallback-net-");
+    const verdict = path.join(workspace, "net.txt");
+    const probe = await runFallback(
+      workspaceWriteProfile(workspace),
+      workspace,
+      [
+        PYTHON,
+        "-c",
+        "import socket\n" +
+          "out = open(" +
+          JSON.stringify(verdict) +
+          ", 'w')\n" +
+          "try:\n" +
+          "  socket.socket(socket.AF_INET)\n" +
+          "  out.write('inet-open')\n" +
+          "except PermissionError:\n" +
+          "  out.write('inet-denied')\n" +
+          "out.close()",
+      ],
+    );
+    expect(probe.exitCode).toBe(0);
+    expect(fs.readFileSync(verdict, "utf8")).toBe("inet-denied");
+  });
+});

--- a/runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts
@@ -10,7 +10,6 @@ import {
   type PermissionProfile,
 } from "../../../src/sandbox/engine/index.js";
 import { probeLandlock } from "../../../src/sandbox/landlock-run.js";
-import { preferredBubblewrapLauncher } from "../../../src/sandbox/linux-launcher/launcher.js";
 
 const canRunLive = process.platform === "linux" && probeLandlock() === "full";
 
@@ -43,23 +42,6 @@ function workspaceWriteProfile(
   };
 }
 
-function readOnlyProfile(
-  network: PermissionProfile["network"] = "disabled",
-): PermissionProfile {
-  return {
-    fileSystem: restrictedFileSystemPolicy(
-      [
-        {
-          path: { kind: "special", value: { kind: "root" } },
-          access: "read",
-        },
-      ],
-      { includePlatformDefaults: true },
-    ),
-    network,
-  };
-}
-
 /** Run the REAL helper main with bubblewrap made unavailable. */
 async function runFallback(
   profile: PermissionProfile,
@@ -75,28 +57,6 @@ async function runFallback(
       workspace,
       "--permission-profile",
       JSON.stringify(profile),
-      "--",
-      ...command,
-    ],
-    {
-      preferredLauncher: () => null,
-      onStderr: (line) => stderr.push(line),
-    },
-  );
-  return { exitCode, stderr };
-}
-
-async function runInheritedFallback(
-  profile: PermissionProfile,
-  command: readonly string[],
-): Promise<{ exitCode: number; stderr: string[] }> {
-  const stderr: string[] = [];
-  const exitCode = await runLinuxSandboxMain(
-    [
-      "--inherited-readonly-command-cwd",
-      "--permission-profile",
-      JSON.stringify(profile),
-      "--no-proc",
       "--",
       ...command,
     ],
@@ -157,8 +117,6 @@ describe("planLandlockConfinement refusals", () => {
     });
   });
 
-
-
   it("refuses unreadable masks an allow-list cannot express", () => {
     const secret = withTempDir("agenc-landlock-plan-secret-");
     const plan = planLandlockConfinement({
@@ -210,161 +168,6 @@ describe("planLandlockConfinement refusals", () => {
 });
 
 describe.runIf(canRunLive)("Landlock fallback through the real helper", () => {
-  it("runs a descriptor-bound read in a git workspace with writes and network removed", async () => {
-    const root = withTempDir("agenc-landlock-bound-read-");
-    const workspace = path.join(root, "workspace");
-    const unexpectedWrite = path.join(workspace, "unexpected.txt");
-    fs.mkdirSync(workspace);
-    fs.mkdirSync(path.join(workspace, ".git"));
-    fs.writeFileSync(path.join(workspace, "sentinel.txt"), "bound-read\n");
-    const savedCwd = process.cwd();
-    process.chdir(workspace);
-    try {
-      const read = await runInheritedFallback(
-        readOnlyProfile(),
-        ["/bin/sh", "-c", 'test "$(cat sentinel.txt)" = bound-read'],
-      );
-      expect(read).toEqual({ exitCode: 0, stderr: [] });
-
-      const write = await runInheritedFallback(
-        readOnlyProfile(),
-        ["/bin/sh", "-c", `printf unexpected > ${unexpectedWrite}`],
-      );
-      expect(write.exitCode).not.toBe(0);
-      expect(fs.existsSync(unexpectedWrite)).toBe(false);
-
-      if (fs.existsSync("/usr/bin/python3")) {
-        const network = await runInheritedFallback(
-          readOnlyProfile(),
-          [
-            "/usr/bin/python3",
-            "-c",
-            "import socket, sys\n" +
-              "try:\n" +
-              "  socket.socket(socket.AF_INET)\n" +
-              "except PermissionError:\n" +
-              "  sys.exit(0)\n" +
-              "sys.exit(9)",
-          ],
-        );
-        expect(network.exitCode).toBe(0);
-      }
-    } finally {
-      process.chdir(savedCwd);
-    }
-  });
-
-  it("uses Landlock when installed bubblewrap cannot create namespaces", async () => {
-    const root = withTempDir("agenc-landlock-bwrap-denied-");
-    const workspace = path.join(root, "workspace");
-    const trusted = path.join(root, "trusted-bin");
-    fs.mkdirSync(workspace);
-    fs.mkdirSync(trusted);
-    const fakeBwrap = path.join(trusted, "bwrap");
-    fs.writeFileSync(
-      fakeBwrap,
-      [
-        "#!/bin/sh",
-        'if [ "$1" = "--help" ]; then',
-        "  echo '--argv0 --ro-bind-fd'",
-        "  exit 0",
-        "fi",
-        "echo 'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted' >&2",
-        "exit 1",
-      ].join("\n") + "\n",
-      { mode: 0o755 },
-    );
-    const capture = path.join(workspace, "result.txt");
-    const stderr: string[] = [];
-
-    const exitCode = await runLinuxSandboxMain(
-      [
-        "--sandbox-policy-cwd",
-        workspace,
-        "--command-cwd",
-        workspace,
-        "--permission-profile",
-        JSON.stringify(workspaceWriteProfile(workspace, "disabled")),
-        "--",
-        "/bin/sh",
-        "-c",
-        `printf fallback-ok > ${capture}`,
-      ],
-      {
-        preferredLauncher: (options = {}) =>
-          preferredBubblewrapLauncher({
-            ...options,
-            searchPath: trusted,
-            trustedDirectories: [trusted],
-          }),
-        onStderr: (line) => stderr.push(line),
-      },
-    );
-
-    expect(exitCode).toBe(0);
-    expect(stderr).toEqual([]);
-    expect(fs.readFileSync(capture, "utf8")).toBe("fallback-ok");
-  });
-
-  it("confines writes to the workspace when bubblewrap is unavailable", async () => {
-    const workspace = withTempDir("agenc-landlock-fallback-ws-");
-    const outside = withTempDir("agenc-landlock-fallback-out-");
-    const inside = path.join(workspace, "made.txt");
-    const escaped = path.join(outside, "escaped.txt");
-
-    const ok = await runFallback(
-      workspaceWriteProfile(workspace, "disabled"),
-      workspace,
-      ["/bin/sh", "-c", `echo confined > ${inside}`],
-    );
-    expect(ok.exitCode).toBe(0);
-    expect(fs.readFileSync(inside, "utf8")).toBe("confined\n");
-
-    const denied = await runFallback(
-      workspaceWriteProfile(workspace, "disabled"),
-      workspace,
-      ["/bin/sh", "-c", `echo escaped > ${escaped}`],
-    );
-    expect(denied.exitCode).not.toBe(0);
-    expect(fs.existsSync(escaped)).toBe(false);
-  });
-
-  it("keeps /proc unreadable, closing the same-uid environ channel", async () => {
-    const workspace = withTempDir("agenc-landlock-fallback-proc-");
-    const capture = path.join(workspace, "proc.txt");
-    const denied = await runFallback(
-      workspaceWriteProfile(workspace, "disabled"),
-      workspace,
-      ["/bin/sh", "-c", `cat /proc/self/status > ${capture}`],
-    );
-    expect(denied.exitCode).not.toBe(0);
-    expect(fs.readFileSync(capture, "utf8")).toBe("");
-  });
-
-  it("applies the network seccomp program when the policy disables network", async () => {
-    const workspace = withTempDir("agenc-landlock-fallback-net-");
-    if (!fs.existsSync("/usr/bin/python3")) return;
-    const verdict = path.join(workspace, "net.txt");
-    const probe = await runFallback(
-      workspaceWriteProfile(workspace, "disabled"),
-      workspace,
-      [
-        "/usr/bin/python3",
-        "-c",
-        "import socket\n" +
-          "out = open(" + JSON.stringify(verdict) + ", 'w')\n" +
-          "try:\n" +
-          "  socket.socket(socket.AF_INET)\n" +
-          "  out.write('inet-open')\n" +
-          "except PermissionError:\n" +
-          "  out.write('inet-denied')\n" +
-          "out.close()",
-      ],
-    );
-    expect(probe.exitCode).toBe(0);
-    expect(fs.readFileSync(verdict, "utf8")).toBe("inet-denied");
-  });
-
   it("leaves the network open when the policy enables it", async () => {
     const workspace = withTempDir("agenc-landlock-fallback-neton-");
     if (!fs.existsSync("/usr/bin/python3")) return;
@@ -376,7 +179,9 @@ describe.runIf(canRunLive)("Landlock fallback through the real helper", () => {
         "/usr/bin/python3",
         "-c",
         "import socket; socket.socket(socket.AF_INET)\n" +
-          "open(" + JSON.stringify(verdict) + ", 'w').write('inet-open')",
+          "open(" +
+          JSON.stringify(verdict) +
+          ", 'w').write('inet-open')",
       ],
     );
     expect(probe.exitCode).toBe(0);
@@ -406,9 +211,8 @@ describe.runIf(canRunLive)("Landlock fallback through the real helper", () => {
 
 describe.runIf(canRunLive)("broker probe fallback", () => {
   it("reports ready through Landlock when bubblewrap is missing from PATH", async () => {
-    const { probeSandboxExecutionStatus } = await import(
-      "../../../src/sandbox/execution-broker.js"
-    );
+    const { probeSandboxExecutionStatus } =
+      await import("../../../src/sandbox/execution-broker.js");
     const cwd = withTempDir("agenc-landlock-probe-cwd-");
     const status = probeSandboxExecutionStatus({
       mode: "workspace_write",

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -136,6 +136,7 @@ export const HOSTED_FND_TEST_INCLUDE = Object.freeze([
 
 /** Real Linux-kernel sandbox coverage executed on a disposable hosted runner. */
 export const KERNEL_TEST_INCLUDE = Object.freeze([
+  "tests/sandbox/landlock-seccomp.kernel.test.ts",
   "tests/sandbox/linux-launcher/linux-launcher.kernel.test.ts",
 ]);
 

--- a/runtime/vitest.kernel.config.ts
+++ b/runtime/vitest.kernel.config.ts
@@ -1,6 +1,6 @@
-import { createAgenCVitestConfig } from './vitest.config.ts';
+import { createAgenCVitestConfig } from "./vitest.config.ts";
 
-// Exact real-kernel bubblewrap allowlist for the disposable hosted Linux lane.
-// The test fails closed unless the runner can create real user, PID, mount,
-// and network namespaces.
-export default createAgenCVitestConfig('kernel');
+// Exact real-kernel sandbox allowlist for the disposable hosted Linux lane.
+// Tests fail closed unless the runner exposes their required Landlock,
+// seccomp, user/PID/mount/network namespace, and AppArmor capabilities.
+export default createAgenCVitestConfig("kernel");


### PR DESCRIPTION
## Summary

- prevent Linux daemon discovery from treating non-daemon argv as an AgenC daemon candidate before bounded identity proof
- route the seven real nested-seccomp enforcement cases to the no-skip Linux kernel lane
- bind CI, discovery, reproducible-build, and gate documentation to the exact two-file / nine-test kernel inventory

## Verification

- `npm test` — 2,041 files / 19,271 tests passed
- daemon identity contract — 12/12
- durability failure matrix — 15/15
- ordinary Landlock boundary — 23/23
- native kernel seccomp suite — 7/7, zero skips
- discovery/reproducible-build contracts — 39/39
- runtime source and test-support typechecks
- pre-commit runtime build and PTY startup smoke

This is the single combined release-gate repair for AgenC 0.17.0.