### PR TITLE
fix(release): sync native probe counts

### DIFF
--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -1154,7 +1154,7 @@ jobs:
                 "tests/fnd/process-repository-helpers.native.test.ts"
                 "tests/tools/runtimes/runtime.darwin.test.ts"
               )
-              expected_native_tests=46
+              expected_native_tests=47
               expected_native_suites=8
               ;;
             win-x64)
@@ -1167,7 +1167,7 @@ jobs:
                 "tests/utils/execFileNoThrow.win32.test.ts"
                 "tests/workspace/bound-helper-transport.win32.test.ts"
               )
-              expected_native_tests=49
+              expected_native_tests=50
               expected_native_suites=12
               ;;
             *)

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -858,8 +858,8 @@ GitHub-hosted jobs to publish or promote exact reviewed bytes. They do not
 repeat the local verification plan. The candidate phase of
 `release-runtime.yml` runs the exact native-only allowlist after its first clean
 install and
-requires the recorded result to contain 46 passing macOS tests in eight suites
-across five files or 49 passing Windows tests in twelve suites across seven files,
+requires the recorded result to contain 47 passing macOS tests in eight suites
+across five files or 50 passing Windows tests in twelve suites across seven files,
 with zero failed, pending, skipped, or todo tests. Both candidate lanes begin
 with the same 44-test, seven-suite, four-file FND set for bounded file I/O,
 fixture loading, portable paths, and process containment. macOS adds one

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -18,7 +18,8 @@ artifact construction starts unless all three runner images and native
 toolchains match reviewed profiles. The candidate then builds all five native
 artifacts. Its macOS and Windows jobs first run the shared 45-test FND contract
 set, then add one Seatbelt and one volume-sensitive pathname-identity test on
-macOS or three Windows atomic-publication/`.cmd` tests. The tagged workflow
+macOS or three Windows atomic-publication/`.cmd` tests and two bound-helper
+transport tests. The tagged workflow
 later promotes and
 re-attests those exact candidate bytes without rebuilding them. These probes
 gate their artifacts but do not authorize merge or replace the local evidence.
@@ -864,7 +865,8 @@ with zero failed, pending, skipped, or todo tests. Both candidate lanes begin
 with the same 45-test, seven-suite, four-file FND set for bounded file I/O,
 fixture loading, portable paths, and process containment. macOS adds one
 Seatbelt test and one volume-sensitive pathname-identity test; Windows adds
-three atomic-publication and `.cmd` tests. Its
+three atomic-publication and `.cmd` tests plus two bound-helper transport
+tests. Its
 tagged phase only promotes and re-attests the five sealed runtime artifacts.
 Before artifact or promotion work starts, each workflow:
 

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -16,7 +16,7 @@ jobs (macOS arm64, macOS x64, and Windows x64). Every artifact builder depends
 on that complete matrix, so it is a barrier: no Linux, Darwin, or Windows
 artifact construction starts unless all three runner images and native
 toolchains match reviewed profiles. The candidate then builds all five native
-artifacts. Its macOS and Windows jobs first run the shared 44-test FND contract
+artifacts. Its macOS and Windows jobs first run the shared 45-test FND contract
 set, then add one Seatbelt and one volume-sensitive pathname-identity test on
 macOS or three Windows atomic-publication/`.cmd` tests. The tagged workflow
 later promotes and
@@ -861,7 +861,7 @@ install and
 requires the recorded result to contain 47 passing macOS tests in eight suites
 across five files or 50 passing Windows tests in twelve suites across seven files,
 with zero failed, pending, skipped, or todo tests. Both candidate lanes begin
-with the same 44-test, seven-suite, four-file FND set for bounded file I/O,
+with the same 45-test, seven-suite, four-file FND set for bounded file I/O,
 fixture loading, portable paths, and process containment. macOS adds one
 Seatbelt test and one volume-sensitive pathname-identity test; Windows adds
 three atomic-publication and `.cmd` tests. Its
@@ -935,24 +935,24 @@ in its one-file allowlist. Its provider and observed-descendant phase runs an
 exact 63-test, three-file allowlist on every required hosted target. The
 `macos-native` job first runs the 67-test
 red-probe runner contract, including residual-process settlement on Darwin.
-The macOS and Windows native jobs then run a shared 80-test, eight-suite,
-five-file FND set. It combines the 44-test release-builder set with 36
+The macOS and Windows native jobs then run a shared 81-test, eight-suite,
+five-file FND set. It combines the 45-test release-builder set with 36
 benchmark-harness fault contracts for process-tree containment, owned-root
 retention, exclusive artifact publication, minimal subprocess environments,
 bounded metadata commands, and provenance binding. macOS adds one Seatbelt test
-and one volume-sensitive pathname-identity test for an exact total of 82 tests,
+and one volume-sensitive pathname-identity test for an exact total of 83 tests,
 ten suites, and six files. Both native lanes also exercise CSV publication on
 the real filesystem and reject a foreign inheritable-read ACL before staging,
-bringing macOS to an exact 84 tests, eleven suites, and seven files. Before its
+bringing macOS to an exact 85 tests, eleven suites, and seven files. Before its
 native allowlist, Windows requires the
 exact one-file FND red-probe audit summary and
 runs three forced-containment tests in one file. Its named-pipe and
 atomic-publication/`.cmd` and bound-helper transport contracts bring the native
-total to 92 tests, eighteen suites, and eleven files. Release builders
-deliberately retain their narrower 44-test shared set: the Windows release
+total to 93 tests, eighteen suites, and eleven files. Release builders
+deliberately retain their narrower 45-test shared set: the Windows release
 subset excludes the two
 named-pipe-only PR tests and the benchmark fault contract, while retaining the
-two bound-helper transport tests, so it remains 49 tests, twelve suites, and
+two bound-helper transport tests, so it remains 50 tests, twelve suites, and
 seven files. Native result parsers require the exact
 reviewed suite, test, and normalized file inventory with no failed, pending,
 skipped, or todo tests. The red-containment parser additionally requires

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -253,8 +253,8 @@ describe("reproducible install and release contract", () => {
     );
     const normalizedCiRequiredGates = ciRequiredGates.replace(/\s+/gu, " ");
     for (const inventory of [
-      "46 passing macOS tests in eight suites across five files",
-      "49 passing Windows tests in twelve suites across seven files",
+      "47 passing macOS tests in eight suites across five files",
+      "50 passing Windows tests in twelve suites across seven files",
       "same 44-test, seven-suite, four-file FND set",
       "shared 80-test, eight-suite, five-file FND set",
       "84 tests, eleven suites, and seven files",
@@ -1532,8 +1532,8 @@ describe("reproducible install and release contract", () => {
     expect(nativeBuild).toContain(
       '"tests/workspace/bound-helper-transport.win32.test.ts"',
     );
-    expect(nativeBuild).toContain("expected_native_tests=46");
-    expect(nativeBuild).toContain("expected_native_tests=49");
+    expect(nativeBuild).toContain("expected_native_tests=47");
+    expect(nativeBuild).toContain("expected_native_tests=50");
     expect(nativeBuild).toContain("expected_native_suites=8");
     expect(nativeBuild).toContain("expected_native_suites=12");
     expect(nativeBuild).toContain('run "${native_tests[@]}"');

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -255,10 +255,10 @@ describe("reproducible install and release contract", () => {
     for (const inventory of [
       "47 passing macOS tests in eight suites across five files",
       "50 passing Windows tests in twelve suites across seven files",
-      "same 44-test, seven-suite, four-file FND set",
-      "shared 80-test, eight-suite, five-file FND set",
-      "84 tests, eleven suites, and seven files",
-      "92 tests, eighteen suites, and eleven files",
+      "same 45-test, seven-suite, four-file FND set",
+      "shared 81-test, eight-suite, five-file FND set",
+      "85 tests, eleven suites, and seven files",
+      "93 tests, eighteen suites, and eleven files",
     ]) {
       expect(normalizedCiRequiredGates).toContain(inventory);
     }


### PR DESCRIPTION
## Summary

- update the release candidate's exact native test counts to the observed macOS 47 and Windows 50 tests
- synchronize derived FND/platform inventory counts in the release gate documentation and regression contract
- document the two Windows bound-helper transport tests in the release subset composition

## Evidence

Candidate run `32319940027` ran every native test successfully before the stale count assertions failed:

- macOS arm64: 47/47 tests passed; validator expected 46
- macOS x64: 47/47 tests passed; validator expected 46
- Windows x64: 50/50 tests passed; validator expected 49

Local verification on Node 26.5.0 / npm 11.17.0:

- `runtime/tests/packaging/reproducible-build.test.ts`: 15/15
- runtime source and test-support typechecks: pass
- Prettier and `git diff --check`: pass
- pre-commit runtime build, SDK generated-type contract, and all PTY startup smokes: pass for every commit
