### PR TITLE
fix(runtime): admit local provider models with provider-local slugs and zero cost

### DIFF
--- a/runtime/src/budget/admitted-model-call.ts
+++ b/runtime/src/budget/admitted-model-call.ts
@@ -132,6 +132,26 @@ function providerNativeToolsForAccounting(
   }).map(({ name, toolType, payload }) => ({ name, toolType, payload }));
 }
 
+/**
+ * Strip a cross-provider "provider:model" prefix down to the provider-local
+ * model slug. Only an exact, case-insensitive match of the resolved provider
+ * name is stripped; colons inside provider-local ids are preserved.
+ */
+export function providerLocalModelSlug(
+  model: string,
+  provider: string,
+): string {
+  const prefix = `${provider}:`;
+  if (
+    provider.length > 0 &&
+    model.length > prefix.length &&
+    model.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+  ) {
+    return model.slice(prefix.length);
+  }
+  return model;
+}
+
 function pricedEntry(model: string, provider: string): ModelCostEntry | null {
   const resolved = resolveModelCostEntry(
     { model, provider },
@@ -139,6 +159,12 @@ function pricedEntry(model: string, provider: string): ModelCostEntry | null {
   );
   if (resolved === null) return null;
   const entry = resolved.entry;
+  // Entries explicitly declared localZeroCost are the registry's statement
+  // that this provider bills nothing. Treating them as unpriced held every
+  // successful ollama/lmstudio response in
+  // `held_unknown(unpriced_provider_response)` and denied local model calls
+  // under hard USD caps (#1752).
+  if (entry.localZeroCost === true) return entry;
   const rates = [
     entry.inputUsdPer1K,
     entry.outputUsdPer1K,
@@ -147,8 +173,8 @@ function pricedEntry(model: string, provider: string): ModelCostEntry | null {
     entry.reasoningOutputUsdPer1K ?? 0,
     entry.webSearchUsdPerRequest ?? 0,
   ];
-  // A zero-rate local entry does not prove that an arbitrary provider/model
-  // alias is free. Keep hard USD caps fail-closed for that case.
+  // A zero-rate entry without the explicit local label does not prove that an
+  // arbitrary provider/model alias is free. Keep hard USD caps fail-closed.
   return rates.some((rate) => rate > 0) ? entry : null;
 }
 
@@ -291,12 +317,21 @@ export async function runAdmittedModelCall(
     nonBlankString(params.provider.name) ??
     "unknown";
   const sessionModel = nonBlankString(params.session.modelInfo?.slug);
-  const requestedModel =
+  // Config and recovery surfaces reference models in cross-provider
+  // "provider:model" form. The admitted identity must be the provider-local
+  // slug: it is what reaches the provider wire (ollama rejects a
+  // "ollama:"-prefixed name outright), and it is the key for session
+  // context-window and pricing lookups. Only an exact provider-name prefix is
+  // stripped, so provider-local ids that legitimately contain colons (for
+  // example "amazon.nova-pro-v1:0" or "qwen3-coder:30b") pass through.
+  const requestedModel = providerLocalModelSlug(
     nonBlankString(params.model) ??
-    nonBlankString(params.options.model) ??
-    nonBlankString(providerFactoryOptions.model) ??
-    sessionModel ??
-    "unknown";
+      nonBlankString(params.options.model) ??
+      nonBlankString(providerFactoryOptions.model) ??
+      sessionModel ??
+      "unknown",
+    requestedProvider,
+  );
 
   const stagedFallbackEvent =
     params.fallback === undefined
@@ -344,7 +379,7 @@ export async function runAdmittedModelCall(
     : requestedProvider;
   const effectiveModel =
     usesConcreteExecutionIdentity && profile?.model?.trim()
-      ? profile.model.trim()
+      ? providerLocalModelSlug(profile.model.trim(), effectiveProvider)
       : requestedModel;
   const configuredMaxOutputTokens =
     positiveInteger(params.options.maxOutputTokens) ??

--- a/runtime/src/session/cost.ts
+++ b/runtime/src/session/cost.ts
@@ -52,6 +52,13 @@ export interface ModelCostEntry {
   readonly webSearchUsdPerRequest?: number;
   /** Free-form label for display. */
   readonly label?: string;
+  /**
+   * Explicitly declares a zero-rate entry as genuinely free (local runtime,
+   * no metered billing). Budget admission treats such entries as priced at
+   * $0 instead of unknown-cost; zero-rate entries WITHOUT this flag stay
+   * fail-closed under hard USD caps.
+   */
+  readonly localZeroCost?: boolean;
 }
 
 export interface CostSummaryProcessLike {
@@ -380,12 +387,23 @@ export const DEFAULT_MODEL_COSTS: Readonly<Record<string, ModelCostEntry>> =
     "amazon.nova-pro-v1:0": DEFAULT_UNKNOWN_MODEL_COST,
     "agenc:agenc": DEFAULT_UNKNOWN_MODEL_COST,
     agenc: DEFAULT_UNKNOWN_MODEL_COST,
-    ollama: { inputUsdPer1K: 0, outputUsdPer1K: 0, label: "local" },
-    lmstudio: { inputUsdPer1K: 0, outputUsdPer1K: 0, label: "local" },
+    ollama: {
+      inputUsdPer1K: 0,
+      outputUsdPer1K: 0,
+      label: "local",
+      localZeroCost: true,
+    },
+    lmstudio: {
+      inputUsdPer1K: 0,
+      outputUsdPer1K: 0,
+      label: "local",
+      localZeroCost: true,
+    },
     "openai-compatible": {
       inputUsdPer1K: 0,
       outputUsdPer1K: 0,
       label: "local",
+      localZeroCost: true,
     },
   });
 

--- a/runtime/tests/budget/admitted-model-call.test.ts
+++ b/runtime/tests/budget/admitted-model-call.test.ts
@@ -826,3 +826,103 @@ describe("runAdmittedModelCall", () => {
     );
   });
 });
+
+import { providerLocalModelSlug } from "../../src/budget/admitted-model-call.js";
+
+describe("providerLocalModelSlug", () => {
+  test("strips only an exact provider prefix and keeps provider-local colons", () => {
+    expect(providerLocalModelSlug("ollama:qwen3-coder:30b", "ollama")).toBe(
+      "qwen3-coder:30b",
+    );
+    expect(providerLocalModelSlug("OLLAMA:qwen3-coder:30b", "ollama")).toBe(
+      "qwen3-coder:30b",
+    );
+    expect(providerLocalModelSlug("qwen3-coder:30b", "ollama")).toBe(
+      "qwen3-coder:30b",
+    );
+    expect(
+      providerLocalModelSlug("amazon.nova-pro-v1:0", "amazon-bedrock"),
+    ).toBe("amazon.nova-pro-v1:0");
+    expect(providerLocalModelSlug("grok-4.5", "grok")).toBe("grok-4.5");
+    expect(providerLocalModelSlug("ollama:", "ollama")).toBe("ollama:");
+  });
+});
+
+describe("runAdmittedModelCall local providers (#1752)", () => {
+  function ollamaCall(
+    state: ReturnType<typeof harness>,
+    invoke: (options: LLMChatOptions) => Promise<LLMResponse>,
+  ) {
+    const provider = {
+      name: "ollama",
+      getExecutionProfile: async () => ({
+        provider: "ollama",
+        model: "qwen3-coder:30b",
+        usageReporting: "authoritative",
+        supportsMaxOutputTokens: true,
+      }),
+    } as unknown as LLMProvider;
+    return runAdmittedModelCall({
+      session: state.session,
+      provider,
+      messages: [{ role: "user", content: "hello" }],
+      options: { maxOutputTokens: 512, contextWindowTokens: 32768 },
+      stepId: "model:ollama:1",
+      // The cross-provider "provider:model" reference form as stored in
+      // config `model =` keys; the wire and admission identity must be the
+      // provider-local slug.
+      model: "ollama:qwen3-coder:30b",
+      providerName: "ollama",
+      invoke,
+    });
+  }
+
+  function ollamaResponse(): LLMResponse {
+    return response({
+      model: "qwen3-coder:30b",
+      usage: {
+        promptTokens: 20,
+        completionTokens: 5,
+        totalTokens: 25,
+        availability: "reported",
+        provenance: "provider",
+      },
+    });
+  }
+
+  test("strips the provider prefix from the wire and admission identity", async () => {
+    const state = harness({});
+    const seen: string[] = [];
+    await ollamaCall(state, async (options) => {
+      seen.push(String(options.model));
+      return ollamaResponse();
+    });
+    expect(seen).toEqual(["qwen3-coder:30b"]);
+    expect(state.admission.markDispatched).toHaveBeenCalledWith(
+      "reservation-1",
+      expect.objectContaining({
+        details: expect.objectContaining({ model: "qwen3-coder:30b" }),
+      }),
+    );
+  });
+
+  test("reconciles a zero-cost local response instead of holding it unknown", async () => {
+    const state = harness({});
+    await ollamaCall(state, async () => ollamaResponse());
+    expect(state.reconcile).toHaveBeenCalledWith(
+      "reservation-1",
+      expect.objectContaining({ costUsd: 0 }),
+    );
+    expect(state.holdUnknown).not.toHaveBeenCalled();
+  });
+
+  test("admits a local model call under a hard USD cap", async () => {
+    const state = harness({ maxCostUsd: 1, hasHardCostCap: true });
+    await ollamaCall(state, async () => ollamaResponse());
+    const acquireInput = state.acquire.mock.calls[0]?.[0] as
+      | AdmissionAcquireInput
+      | undefined;
+    expect(acquireInput?.denialReason).toBeUndefined();
+    expect(state.reconcile).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #1752.

Root cause found by live instrumentation against the exact home from the issue: the primary sampling path hands the raw config model reference ("ollama:qwen3-coder:30b") to admission and the provider wire. Ollama parses the "ollama:" prefix as a registry scheme and rejects the call with "model is required" in about 15ms. The same prefixed id also breaks the session context-window lookup (sessionModel no longer matches effectiveModel, so conservative fallback estimates trip context_window_exceeded denials) and the pricing lookup. The startup prewarm path resolves the slug correctly, which is why the bug only surfaced on SDK/desktop-created sessions and looked home-dependent.

Second defect in the same chain: pricedEntry treated all-zero-rate registry entries as unpriced, so every successful ollama/lmstudio response was held as `held_unknown(unpriced_provider_response)` and local model calls were denied under hard USD caps. Those holds are the `held_unknown` entries that piled up in the issue's admission recovery logs.

Changes:
- `providerLocalModelSlug` normalizes the admitted identity at the runAdmittedModelCall boundary: an exact, case-insensitive provider-name prefix is stripped; provider-local ids containing colons ("qwen3-coder:30b", "amazon.nova-pro-v1:0") pass through. Applied to the requested model and profile-routed model.
- `ModelCostEntry.localZeroCost` explicitly declares the ollama/lmstudio/openai-compatible entries as genuinely free. pricedEntry accepts them; zero-rate entries without the flag stay fail-closed under hard caps.

Verified live: the desktop's failing capture home now completes message.send end to end on local ollama (assistant reply returned), reconciles at $0 instead of holding unknown, and admits under a hard cost cap. New tests are revert-sensitive (each fails with its fix reverted).

The desktop app's double-submit and stale provider default from the issue are client-side and tracked separately.

https://claude.ai/code/session_01AWxo3GEmECvb84DUw9nY3s
