### PR TITLE
fix(daemon): let a deferred session accept its first message

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -741,6 +741,15 @@ interface ActiveBackgroundAgent {
   pendingMessageSubmissionCount: number;
   readonly messageSubmissionsById: Map<string, ActiveMessageSubmission>;
   /**
+   * True when no initial turn was submitted at spawn (deferInitialTurn
+   * spawns and restored agents). Their thread sits in pending_init until
+   * the first accepted message initializes it, so pending_init must not
+   * count as busy for `ifBusy: "reject"` — rejecting there deadlocks the
+   * session: the message that would initialize the thread is the message
+   * being refused.
+   */
+  readonly initialTurnDeferred: boolean;
+  /**
    * Per-agent emission serialization chain. `#emitOrBufferEvent` awaits
    * an async-locked broadcast, so two fire-and-forget emits from a
    * single callback (e.g. status + budget-usage) can otherwise complete
@@ -1201,6 +1210,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         thread: managedThread,
         status: "running",
         startedAt,
+        initialTurnDeferred: params.deferInitialTurn === true,
         runEpoch: currentRunEpochFromRollout(bootstrap, managedThread.threadId),
         canonicalEventBridgeInstalled: false,
         durableTerminalFinalizerInstalled: false,
@@ -1623,6 +1633,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           thread: managedThread,
           status: "running",
           startedAt,
+          // A restored agent has no initial submission in flight either:
+          // its thread re-initializes on the first post-restore message,
+          // so pending_init must stay sendable after a daemon restart.
+          initialTurnDeferred: true,
           ...(params.restoreAttemptId !== undefined
             ? { restoreAttemptId: params.restoreAttemptId }
             : {}),
@@ -2232,7 +2246,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       (active.pendingMessageSubmissionCount > 0 ||
         hasRuntimeActiveTurn(active.bootstrap.session) ||
         threadStatus === "running" ||
-        threadStatus === "pending_init")
+        // pending_init is busy only while a spawn-submitted initial turn
+        // is still starting. Deferred spawns and restored agents stay
+        // pending_init until their first accepted message initializes the
+        // thread; rejecting that message would deadlock the session.
+        (threadStatus === "pending_init" && !active.initialTurnDeferred))
     ) {
       throw new AgenCBackgroundAgentMessageError(
         "TURN_IN_PROGRESS",

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -199,6 +199,7 @@ function makeTopLevelRunner(opts: {
   readonly executionAdmissionKernel?: ExecutionAdmissionKernel;
   readonly csvAgentJobsRepositories?: CsvAgentJobsRepositoryProvider;
   readonly rolloutItems?: unknown[];
+  readonly threadInitialStatus?: AgentStatus;
   readonly onActiveAgentTerminated?: ReturnType<typeof vi.fn>;
   readonly totalTokenUsage?: () => {
     readonly inputTokens: number;
@@ -240,6 +241,9 @@ function makeTopLevelRunner(opts: {
   };
   const stub = makeStubConversationThreadManager({
     threadId: opts.conversationId,
+    ...(opts.threadInitialStatus !== undefined
+      ? { initialStatus: opts.threadInitialStatus }
+      : {}),
     ...(opts.threadShutdown !== undefined
       ? { shutdown: opts.threadShutdown }
       : {}),
@@ -3494,6 +3498,61 @@ describe("AgenC delegate background-agent runner", () => {
       "session-strict-busy",
       "legacy queued turn",
     );
+  });
+
+  it("[managed-thread] accepts the first opt-in-admission message on a deferred spawn still in pending_init", async () => {
+    const { runner, control } = makeTopLevelRunner({
+      conversationId: "session-deferred-first-send",
+      threadInitialStatus: { status: "pending_init" } as AgentStatus,
+    });
+    await runner.startAgent({
+      objective: "Interactive session",
+      deferInitialTurn: true,
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    // Nothing was submitted at spawn; the first message is what
+    // initializes the thread, so ifBusy=reject must admit it.
+    await expect(
+      runner.submitAgentMessage("session-deferred-first-send", {
+        sessionId: "session_1",
+        content: "first user message",
+        originalContent: "first user message",
+        messageId: "deferred-first",
+        streamId: "deferred-first",
+        acceptedAt: "2026-08-20T00:00:00.000Z",
+        ifBusy: "reject",
+      }),
+    ).resolves.toMatchObject({ disposition: "started" });
+    expect(control.sendInput).toHaveBeenCalledWith(
+      "session-deferred-first-send",
+      "first user message",
+    );
+  });
+
+  it("[managed-thread] still rejects opt-in admission while a spawn-submitted initial turn is in pending_init", async () => {
+    const { runner } = makeTopLevelRunner({
+      conversationId: "session-initial-pending-init",
+      threadInitialStatus: { status: "pending_init" } as AgentStatus,
+    });
+    await runner.startAgent({
+      objective: "initial turn is starting",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+
+    await expect(
+      runner.submitAgentMessage("session-initial-pending-init", {
+        sessionId: "session_1",
+        content: "raced the initial turn",
+        originalContent: "raced the initial turn",
+        messageId: "raced-message",
+        streamId: "raced-message",
+        acceptedAt: "2026-08-20T00:00:00.000Z",
+        ifBusy: "reject",
+      }),
+    ).rejects.toMatchObject({ code: "TURN_IN_PROGRESS" });
   });
 
   it("[managed-thread] reports a persisted crash-tail retry as incomplete", async () => {


### PR DESCRIPTION
Closes #1756.

A session spawned with deferInitialTurn submits nothing to its managed thread, so the thread sits in pending_init until the first user message initializes it. The ifBusy=reject busy check counted pending_init as an active turn, which rejected exactly that first message: every deferred session (the desktop app's only spawn shape) deadlocked with "already has an active or queued turn" forever.

Wire-traced live against the shipped 0.17.0 daemon: the desktop's message.send arrives 14ms after agent.create returns and is rejected; retries every 1.5s are rejected indefinitely because the thread can only leave pending_init via an accepted message.

Fix: pending_init counts as busy only while a spawn-submitted initial turn is starting (new initialTurnDeferred flag on the active agent, false for objective spawns). Deferred spawns and restored agents (which also have no initial submission in flight - this is what made restarted daemons reject sends into restored sessions) accept the message and let the serialized submission queue initialize the thread, the documented intent of deferInitialTurn.

Verification:
- New contract test: deferred spawn in pending_init accepts its first ifBusy=reject message. Confirmed revert-sensitive (fails with the old condition).
- New contract test: spawn-submitted initial turn in pending_init still rejects.
- Full background-agent-runner contract suite: 88/88 green.
- Live: desktop app on this build - first message on a fresh session accepted immediately, Grok reply streamed.

https://claude.ai/code/session_01AWxo3GEmECvb84DUw9nY3s