### PR TITLE
fix(daemon): session.setPermissionMode to bypass binds workspace consent

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -3107,7 +3107,24 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       target,
       current,
     );
-    const nextCtx: ToolPermissionContext = { ...transitioned, mode: target };
+    let nextCtx: ToolPermissionContext = { ...transitioned, mode: target };
+    if (target === "bypassPermissions") {
+      // An explicit session.setPermissionMode to bypass carries the same
+      // operator authority as `--yolo` / permissionMode at agent.create
+      // (see startAgent's identical binding): grant consent for this exact
+      // workspace so canonical runtime-settings persistence accepts the
+      // transition instead of refusing with the workspace-consent error.
+      const workspaceRoot = runtimeWorkspaceRoot(active.bootstrap);
+      if (!nextCtx.bypassPermissionsAcceptedIn?.includes(workspaceRoot)) {
+        nextCtx = {
+          ...nextCtx,
+          bypassPermissionsAcceptedIn: [
+            ...(nextCtx.bypassPermissionsAcceptedIn ?? []),
+            workspaceRoot,
+          ],
+        };
+      }
+    }
     await registry.update(nextCtx, {
       runtimeSettings: {
         reason: "permission_mode_changed",

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -2493,6 +2493,30 @@ describe("AgenC delegate background-agent runner", () => {
     expect(permissionUpdates[0]).toMatchObject({ mode: "plan" });
   });
 
+  it("setAgentPermissionMode to bypass binds exact-workspace consent so canonical persistence accepts it", async () => {
+    const { runner, permissionUpdates } = makeTopLevelRunner({
+      conversationId: "parent-session",
+      argv: ["node", "agenc"],
+      canonicalRuntimeSettings: true,
+    });
+    await runner.startAgent({ objective: "work", cwd: "/workspace" });
+    permissionUpdates.length = 0;
+
+    // The explicit RPC is the operator's authority, same as --yolo at
+    // spawn: the runner binds consent for this exact workspace instead of
+    // refusing with the workspace-consent persistence error.
+    const result = await runner.setAgentPermissionMode("parent-session", {
+      sessionId: "session_1",
+      mode: "bypassPermissions",
+    });
+
+    expect(result).toMatchObject({ applied: true, mode: "bypassPermissions" });
+    expect(permissionUpdates.at(-1)).toMatchObject({
+      mode: "bypassPermissions",
+      bypassPermissionsAcceptedIn: ["/workspace"],
+    });
+  });
+
   it("getAgentHooksStatus maps the daemon session's real hooks runtime snapshot", async () => {
     const { runner, session } = makeTopLevelRunner({
       conversationId: "parent-session",


### PR DESCRIPTION
Switching a live session to bypassPermissions over RPC always failed with 'cannot persist bypass permission authority without exact workspace consent': the canonical runtime-settings pre-commit requires the exact workspace in bypassPermissionsAcceptedIn, but no RPC surface could add it. The only grant path was the TUI's /permissions accept-bypass, so desktop users were locked out of bypass entirely.

The spawn path already settles the doctrine: --yolo / permissionMode at agent.create is explicit operator authority, and startAgent binds the consent to the exact startup workspace itself. setAgentPermissionMode now applies the identical binding for the explicit RPC transition. Implicit transitions still hit the gate.

Verification: new contract test (revert-sensitive - fails with the consent error on old code), full background-agent-runner contract suite 89/89, reproduced the exact user-facing error live via session.setPermissionMode before the fix.

https://claude.ai/code/session_01AWxo3GEmECvb84DUw9nY3s