### PR TITLE
fix(daemon): stop reconciled agents outside the lifecycle state lock

### DIFF
--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -3684,21 +3684,48 @@ export class AgenCDaemonAgentManager {
     ]);
     agent.sessionIds = activeSessionIds;
     if (activeSessionIds.length === 0 && isActiveAgent(agent)) {
-      let stopFailed = false;
-      if (!isRecoveredRuntimeUnavailable(agent)) {
-        const stopRunner = this.#runner?.stopAgent?.bind(this.#runner);
-        if (stopRunner !== undefined) {
-          try {
-            await stopRunner(agent.agentId, "session_terminated");
-          } catch {
-            stopFailed = true;
-          }
-        }
-      }
-      agent.status = stopFailed ? "error" : "stopped";
+      const stoppable = !isRecoveredRuntimeUnavailable(agent);
+      agent.status = "stopped";
       agent.lastActiveAt = this.#now();
       agent.runtimeAvailable = false;
+      // The runner stop must NOT be awaited here: every reconcile caller
+      // holds the #state lock, and stopAgent's termination path re-acquires
+      // it (handleRunnerTerminated), so an in-lock await self-deadlocks the
+      // whole daemon the moment a zombie agent exists. The state mutation
+      // above is the observable outcome; the runtime teardown runs after
+      // the lock is released, matching the public stopAgent path.
+      if (stoppable) this.#scheduleReconcileRunnerStop(agent.agentId);
     }
+  }
+
+  /** Deduplicates deferred session_terminated runner stops per agent. */
+  readonly #pendingReconcileRunnerStops = new Set<string>();
+
+  #scheduleReconcileRunnerStop(agentId: string): void {
+    const stopRunner = this.#runner?.stopAgent?.bind(this.#runner);
+    if (stopRunner === undefined) return;
+    if (this.#pendingReconcileRunnerStops.has(agentId)) return;
+    this.#pendingReconcileRunnerStops.add(agentId);
+    void stopRunner(agentId, "session_terminated")
+      .catch(async () => {
+        // The synchronous reconcile already published "stopped"; a failed
+        // runtime teardown downgrades it so operators can see the wreck.
+        await this.#state
+          .with((state) => {
+            const current = state.agents.get(agentId);
+            if (
+              current !== undefined &&
+              current.status === "stopped" &&
+              current.runtimeAvailable === false
+            ) {
+              current.status = "error";
+            }
+          })
+          .catch(() => {});
+      })
+      .finally(() => {
+        this.#pendingReconcileRunnerStops.delete(agentId);
+      });
   }
 
   async #resolveAttachmentTarget(

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -1974,6 +1974,58 @@ describe("AgenC background agent lifecycle", () => {
     });
   });
 
+  it("does not deadlock when the runner stop re-enters the lifecycle state", async () => {
+    const sessions = new AgenCDaemonSessionManager({
+      createSessionId: sequence(["session-reentrant-stop"]),
+      now: sequence(["2026-08-20T12:09:00.000Z", "2026-08-20T12:09:01.000Z"]),
+    });
+    let agentsRef!: AgenCDaemonAgentManager;
+    const stopAgent = vi.fn(async () => {
+      // Mirrors handleRunnerTerminated: the production stop path re-acquires
+      // the lifecycle #state lock, which the reconcile caller used to hold
+      // across this await — a self-deadlock that bricked agent.create
+      // daemon-wide whenever a zombie agent was reconciled.
+      await agentsRef.getAgent("agent-reentrant-stop");
+    });
+    const agents = new AgenCDaemonAgentManager({
+      sessionManager: sessions,
+      now: () => "2026-08-20T12:09:02.000Z",
+      runner: {
+        startAgent: async () => ({
+          agentId: "agent-reentrant-stop",
+          startedAt: "2026-08-20T12:09:00.500Z",
+          status: "running",
+        }),
+        stopAgent,
+      },
+    });
+    agentsRef = agents;
+
+    await agents.createAgent({
+      cwd: process.cwd(),
+      objective: "reentrant stop",
+    });
+    await sessions.terminateSession({
+      sessionId: "session-reentrant-stop",
+      reason: "session.terminate",
+    });
+
+    const listed = await Promise.race([
+      agents.listAgents(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error("listAgents deadlocked on the reconcile runner stop"),
+            ),
+          3000,
+        ),
+      ),
+    ]);
+    expect(listed).toEqual({ agents: [] });
+    await vi.waitFor(() => expect(stopAgent).toHaveBeenCalled());
+  });
+
   it("session.cancelTurn returns cancelled=false for an unknown session (idle no-op)", async () => {
     const sessions = new AgenCDaemonSessionManager();
     const interruptAgentTurn = vi.fn(async () => false);


### PR DESCRIPTION
#reconcileAgentSessions awaited runner.stopAgent while every reconcile
caller (listAgents, getAgentLogs, permission-list and attachment
resolution) holds the exclusive #state AsyncLock. stopAgent's
termination path re-acquires that same non-reentrant lock
(handleRunnerTerminated), so reconciling any zombie agent - one whose
sessions all went inactive while its runtime was wedged, e.g. a hung
provider during thread init - self-deadlocked the daemon: every
subsequent agent.create, send, and even session.cancelTurn queued on
the lock forever. Observed live twice as 'Timed out waiting for daemon
response to agent.create' with the desktop's periodic agent.list as
the trigger.

Reconcile now publishes the terminal state synchronously (status
stopped, runtimeAvailable false - the outcome every caller observes)
and runs the runtime teardown as a deferred, deduplicated stop outside
the lock, matching the public stopAgent path. A failed teardown
downgrades the agent to error status through a normal lock acquisition.

Regression test proves it revert-sensitively: a runner stop that
re-enters the lifecycle state deadlocks listAgents on the old code and
completes on the new code. Full agent-lifecycle contract suite 124/124.

Part of the wedge audit for #1756's sibling failure; remaining
hardening (stop deadlines, resume-prewarm deadline, bounded auth/MCP
bootstrap awaits) tracked separately.

Claude-Session: https://claude.ai/code/session_01AWxo3GEmECvb84DUw9nY3s
