### PR TITLE
fix(workflow): derive child agent names the registry accepts

### DIFF
--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -219,6 +219,21 @@ export {
 } from "./child-terminals.js";
 
 /**
+ * The agent name a workflow child is registered under.
+ *
+ * `assertValidAgentName` accepts lowercase letters, digits and underscores
+ * only, while a child run id carries dashes, colons and a `#` (for example
+ * `wf-3f78249a-...:plan#1`). Folding those to underscores is what keeps the
+ * two ends agreeing: without it every spawn was rejected as "agent_name
+ * must use only lowercase letters, digits, and underscores", which failed
+ * `workflow.plan` on both attempts and ended the run with
+ * `step_retries_exhausted` before any work was done.
+ */
+export function workflowChildAgentName(childRunId: string): string {
+  return childRunId.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
+}
+
+/**
  * The child usage rollup for a real delegate spawn, resolved from the
  * durable source that already exists: the admission kernel reconciles
  * ACTUAL provider usage per reservation for the child run's admissions.
@@ -776,7 +791,7 @@ export function createWorkflowSessionSeams(
           registry,
           taskPrompt: input.prompt,
           ...(input.kind === "verify_agent" ? { role: "verification" } : {}),
-          agentName: input.childRunId.replace(/[^a-zA-Z0-9._-]/g, "-"),
+          agentName: workflowChildAgentName(input.childRunId),
           ...(input.spec.model !== undefined
             ? { model: input.spec.model }
             : {}),

--- a/runtime/tests/workflow/session-adapters.child-name.test.ts
+++ b/runtime/tests/workflow/session-adapters.child-name.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Workflow child agent names must satisfy the agent registry.
+ *
+ * The spawner derives a child's agent name from its deterministic child run
+ * id, and the registry validates that name. The two disagreed: the derived
+ * name kept the run id's dashes and dots while `assertValidAgentName`
+ * accepts lowercase letters, digits and underscores only. Every workflow
+ * child was therefore rejected on spawn, which failed `workflow.plan` on
+ * both attempts and ended every verified-change run with
+ * `step_retries_exhausted` before any work was done.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { assertValidAgentName } from "../../src/agents/registry.js";
+import { workflowChildAgentName } from "../../src/app-server/workflow/session-adapters.js";
+
+/** Child run ids as the controller mints them, one per workflow stage. */
+const CHILD_RUN_IDS = [
+  "wf-3f78249a-c5e4-42b4-90ac-c89cf87618f5:plan#1",
+  "wf-3f78249a-c5e4-42b4-90ac-c89cf87618f5:plan#2",
+  "wf-da1faa33-5db1-45df-96f2-af57d5fa2273:implement#1",
+  "wf-da1faa33-5db1-45df-96f2-af57d5fa2273:verify-agent#1",
+  "wf-da1faa33-5db1-45df-96f2-af57d5fa2273:review#3",
+] as const;
+
+describe("workflowChildAgentName", () => {
+  it("produces names the agent registry accepts", () => {
+    for (const childRunId of CHILD_RUN_IDS) {
+      expect(() =>
+        assertValidAgentName(workflowChildAgentName(childRunId)),
+      ).not.toThrow();
+    }
+  });
+
+  it("folds every separator a child run id can carry", () => {
+    expect(workflowChildAgentName("wf-ABC.123:plan#1")).toBe("wf_abc_123_plan_1");
+  });
+
+  it("is stable per child, and distinct between stages and attempts", () => {
+    const first = workflowChildAgentName(CHILD_RUN_IDS[0]);
+    expect(workflowChildAgentName(CHILD_RUN_IDS[0])).toBe(first);
+    expect(workflowChildAgentName(CHILD_RUN_IDS[1])).not.toBe(first);
+    expect(new Set(CHILD_RUN_IDS.map(workflowChildAgentName)).size).toBe(
+      CHILD_RUN_IDS.length,
+    );
+  });
+});


### PR DESCRIPTION
## What breaks

Every verified-change run dies at `workflow.plan`, before any work happens:

```
$ agenc run start --goal "add a file called probe.txt containing ok" \
    --verify "check=test -f probe.txt"

run wf-da1faa33-… — failed (terminal)
STAGE                 STATUS       ATTEMPTS
workflow.intake       committed    1
workflow.worktree     committed    1
workflow.plan         failed       2
workflow.implement    blocked      0
workflow.verify       blocked      0
workflow.review       blocked      0
workflow.finalize     blocked      0
stop reason: step_retries_exhausted
```

The daemon records why in `run_terminal_results`:

```
workflow plan spawn rejected: agent_name must use only lowercase letters,
digits, and underscores
workflow.plan failed terminally after 2 attempt(s)
```

## Why

The two ends of the same name disagree.

`session-adapters.ts` derived the child's agent name from its child run id
and kept dashes, dots and uppercase:

```ts
agentName: input.childRunId.replace(/[^a-zA-Z0-9._-]/g, "-")
```

`assertValidAgentName` in `agents/registry.ts` accepts none of those:

```ts
if (!/^[a-z0-9_]+$/u.test(name)) throw new InvalidAgentPathError(...)
```

A child run id looks like `wf-3f78249a-c5e4-42b4-90ac-c89cf87618f5:plan#1`,
so the derived name kept every dash and was rejected on arrival.

## The change

Fold the separators to underscores, behind a named helper so the rule lives
next to the id it transforms, and add a test that runs the derived names
through the registry's own validator rather than restating the pattern.

## How it was checked

Reproduced on 0.16.1 through both `agenc run start` and the daemon RPC, in
three different repositories, with and without an explicit `--model`, so
neither the model string nor the repository name was involved.

With the same change applied to the installed runtime, the rejection is
gone and the plan child spawns: `workflow.plan` no longer reports
`spawn rejected`. Those runs still end at plan on this machine, but for an
unrelated reason — the provider route is returning `HTTP 500
provider_unavailable`, which fails plain sessions too.

New test: `runtime/tests/workflow/session-adapters.child-name.test.ts`.
The old derivation was confirmed to fail the same validator before the fix.
