### PR TITLE
fix(install): scale the download deadline with the declared artifact size

### DIFF
--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -7,7 +7,7 @@
 // mirroring packages/agenc/test/runtime-manager.test.mjs.
 
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomFillSync } from "node:crypto";
 import {
   chmodSync,
   cpSync,
@@ -1886,6 +1886,181 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
     }
   }, 15_000);
 
+  test("a stalled connection dies on the stall window, not the full deadline", () => {
+    const fixture = startHttpsFixture(work, {
+      "/stall-headers": { stallHeaders: true },
+      "/stall-body": { bodyText: "{}", contentLength: 32, stallBody: true },
+    });
+    try {
+      for (const route of ["stall-headers", "stall-body"]) {
+        const home = join(work, `stall-${route}`);
+        mkdirSync(home, { recursive: true, mode: 0o700 });
+        const started = Date.now();
+        const result = runInstaller({
+          home,
+          manifestUrl: `${fixture.baseUrl}/${route}`,
+          args: ["--no-daemon"],
+          envOverrides: {
+            NODE_EXTRA_CA_CERTS: fixture.ca,
+            AGENC_INSTALL_TEST_DOWNLOAD_STALL_MS: "200",
+          },
+        });
+        expect(result.status, `${route}: ${result.stderr}`).not.toBe(0);
+        expect(result.stderr, route).toContain(
+          "download stalled: no bytes received for 200ms",
+        );
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expectFailedInstallCleanup(home);
+      }
+    } finally {
+      fixture.stop();
+    }
+  }, 15_000);
+
+  describe("bounded fetch deadline contract (sh and PowerShell copies)", () => {
+    // Both installers embed the same Node bounded-fetch program; extracting
+    // each copy exercises the Windows one on this host too. The contract under
+    // test: the total deadline scales with the declared artifact size
+    // (ceil(bytes / 128 KiB/s) + 30s grace, never below 120s), undeclared
+    // sizes keep the 120s bound, the test override may reach the computed
+    // ceiling but never exceed it, and a stalled connection dies on the stall
+    // window without waiting out the scaled deadline. A fixed 120s ceiling
+    // made any link under ~1 MiB/s permanently unable to install the
+    // ~120 MiB runtime (observed live against 0.17.0: repeated deaths at ~88%
+    // with "download deadline exceeded after 120000ms").
+    const copies = () => {
+      const sh = readFileSync(INSTALL_SH, "utf8")
+        .match(/<<'AGENC_BOUNDED_FETCH'\n([\s\S]*?)\nAGENC_BOUNDED_FETCH\n/);
+      const ps1 = readFileSync(INSTALL_PS1, "utf8")
+        .match(/\$BoundedFetch = @'\n([\s\S]*?)\n'@\n/);
+      expect(sh).not.toBeNull();
+      expect(ps1).not.toBeNull();
+      return { sh: sh![1], ps1: ps1![1] };
+    };
+
+    function runBoundedFetch(
+      script: string,
+      name: string,
+      args: { url: string; maximum: number; exact?: number },
+      env: Record<string, string>,
+      extraEnv: Record<string, string> = {},
+    ): { status: number; stderr: string; destination: string } {
+      const dir = join(work, `bounded-fetch-${name}`);
+      mkdirSync(dir, { recursive: true });
+      const file = join(dir, "bounded-fetch.cjs");
+      writeFileSync(file, script);
+      const destination = join(dir, "artifact.bin");
+      rmSync(destination, { force: true });
+      const res = spawnSync(
+        process.execPath,
+        [
+          file,
+          args.url,
+          destination,
+          String(args.maximum),
+          args.exact === undefined ? "" : String(args.exact),
+          "official",
+        ],
+        { encoding: "utf8", env: { ...env, ...extraEnv }, timeout: 30_000 },
+      );
+      return { status: res.status ?? -1, stderr: res.stderr ?? "", destination };
+    }
+
+    test("the deadline ceiling scales with the declared byte count", () => {
+      const body = randomFillSync(Buffer.alloc(14_000_000));
+      const declared = body.length;
+      const scaledCeilingMs =
+        Math.ceil(declared / 131_072) * 1000 + 30_000;
+      expect(scaledCeilingMs).toBeGreaterThan(120_000);
+      const fixture = startHttpsFixture(work, {
+        "/scaled.bin": { bodyBase64: body.toString("base64") },
+      });
+      const env = { NODE_EXTRA_CA_CERTS: fixture.ca };
+      try {
+        for (const [flavor, script] of Object.entries(copies())) {
+          // Exactly at the computed ceiling: accepted, and the download
+          // completes. The old fixed contract rejected any value over 120s.
+          const accepted = runBoundedFetch(
+            script,
+            `${flavor}-scaled-accepted`,
+            { url: `${fixture.baseUrl}/scaled.bin`, maximum: declared, exact: declared },
+            env,
+            { AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: String(scaledCeilingMs) },
+          );
+          expect(accepted.status, `${flavor}: ${accepted.stderr}`).toBe(0);
+          expect(statSync(accepted.destination).size).toBe(declared);
+
+          // One millisecond past the ceiling: rejected. Together with the
+          // accepted case this pins the scaling formula on both sides.
+          const rejected = runBoundedFetch(
+            script,
+            `${flavor}-scaled-rejected`,
+            { url: `${fixture.baseUrl}/scaled.bin`, maximum: declared, exact: declared },
+            env,
+            { AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: String(scaledCeilingMs + 1) },
+          );
+          expect(rejected.status, flavor).not.toBe(0);
+          expect(rejected.stderr, flavor).toContain(
+            "invalid bounded-download deadline contract",
+          );
+
+          // Undeclared sizes keep the 120s bound.
+          const undeclared = runBoundedFetch(
+            script,
+            `${flavor}-undeclared`,
+            { url: "https://127.0.0.1:1/unused", maximum: 1024 },
+            env,
+            { AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: "120001" },
+          );
+          expect(undeclared.status, flavor).not.toBe(0);
+          expect(undeclared.stderr, flavor).toContain(
+            "invalid bounded-download deadline contract",
+          );
+        }
+      } finally {
+        fixture.stop();
+      }
+    }, 60_000);
+
+    test("the stall window and the shortened deadline stay independent", () => {
+      const fixture = startHttpsFixture(work, {
+        "/stall.bin": { bodyText: "{}", contentLength: 32, stallBody: true },
+      });
+      const env = { NODE_EXTRA_CA_CERTS: fixture.ca };
+      try {
+        for (const [flavor, script] of Object.entries(copies())) {
+          const started = Date.now();
+          const stalled = runBoundedFetch(
+            script,
+            `${flavor}-stalled`,
+            { url: `${fixture.baseUrl}/stall.bin`, maximum: 1024, exact: 32 },
+            env,
+            { AGENC_INSTALL_TEST_DOWNLOAD_STALL_MS: "200" },
+          );
+          expect(stalled.status, flavor).not.toBe(0);
+          expect(stalled.stderr, flavor).toContain(
+            "download stalled: no bytes received for 200ms",
+          );
+          expect(Date.now() - started, flavor).toBeLessThan(10_000);
+
+          const deadline = runBoundedFetch(
+            script,
+            `${flavor}-short-deadline`,
+            { url: `${fixture.baseUrl}/stall.bin`, maximum: 1024, exact: 32 },
+            env,
+            { AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS: "150" },
+          );
+          expect(deadline.status, flavor).not.toBe(0);
+          expect(deadline.stderr, flavor).toContain(
+            "download deadline exceeded after 150ms",
+          );
+        }
+      } finally {
+        fixture.stop();
+      }
+    }, 30_000);
+  });
+
   test("repo-derived manifests bind releaseRepository while explicit manifest URLs remain explicit trust", () => {
     const artifact = makeSyntheticArtifact(work);
     const manifest = remoteManifest(artifact, "linux", "unused");
@@ -2739,7 +2914,14 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
 
   test("PowerShell bootstrap uses one cancellation deadline for headers and every body read", () => {
     const ps1 = readFileSync(INSTALL_PS1, "utf8");
-    expect(ps1).toContain("$deadline.CancelAfter($bootstrapTimeoutMs)");
+    // A single cancellation source guards every network wait; each wait is
+    // armed with the smaller of the stall window and the remaining total
+    // budget, so nothing can extend the size-scaled deadline.
+    expect(ps1).toContain(
+      "$deadline.CancelAfter([int][Math]::Min([double]$bootstrapStallMs, $remainingMs))",
+    );
+    const rearms = ps1.split("& $armDeadline").length - 1;
+    expect(rearms).toBeGreaterThanOrEqual(2);
     expect(ps1).toContain("$client.Timeout = [System.Threading.Timeout]::InfiniteTimeSpan");
     expect(ps1).toMatch(
       /\.SendAsync\(\s*\$request,\s*\[System\.Net\.Http\.HttpCompletionOption\]::ResponseHeadersRead,\s*\$deadline\.Token\s*\)/,

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -74,19 +74,48 @@ function Copy-PinnedBootstrapHttps(
     Fail "Node.js bootstrap URL must be canonical HTTPS"
   }
   [void][System.Reflection.Assembly]::Load("System.Net.Http")
-  [int]$bootstrapTimeoutMs = 120000
+  # The total deadline scales with the pinned byte count so slow links can
+  # finish, mirroring the bounded-fetch contract: minimum sustained rate
+  # 128 KiB/s plus 30s grace, never below 120s, test overrides only shorten.
+  [long]$minimumSustainedBytesPerSecond = 131072
+  [int]$defaultBootstrapTimeoutMs = [Math]::Max(
+    120000,
+    [int]([Math]::Ceiling($ExactBytes / [double]$minimumSustainedBytesPerSecond)) * 1000 + 30000
+  )
+  [int]$bootstrapTimeoutMs = $defaultBootstrapTimeoutMs
   if ($env:AGENC_INSTALL_TEST_BOOTSTRAP_TIMEOUT_MS) {
     [int]$parsedBootstrapTimeout = 0
     if (-not [int]::TryParse(
         $env:AGENC_INSTALL_TEST_BOOTSTRAP_TIMEOUT_MS,
         [ref]$parsedBootstrapTimeout
-      ) -or $parsedBootstrapTimeout -lt 1 -or $parsedBootstrapTimeout -gt 120000) {
+      ) -or $parsedBootstrapTimeout -lt 1 -or
+        $parsedBootstrapTimeout -gt $defaultBootstrapTimeoutMs) {
       Fail "invalid Node.js bootstrap deadline"
     }
     $bootstrapTimeoutMs = $parsedBootstrapTimeout
   }
+  [int]$bootstrapStallMs = 60000
+  if ($env:AGENC_INSTALL_TEST_BOOTSTRAP_STALL_MS) {
+    [int]$parsedBootstrapStall = 0
+    if (-not [int]::TryParse(
+        $env:AGENC_INSTALL_TEST_BOOTSTRAP_STALL_MS,
+        [ref]$parsedBootstrapStall
+      ) -or $parsedBootstrapStall -lt 1 -or $parsedBootstrapStall -gt 60000) {
+      Fail "invalid Node.js bootstrap stall window"
+    }
+    $bootstrapStallMs = $parsedBootstrapStall
+  }
+  $deadlineAt = [DateTime]::UtcNow.AddMilliseconds($bootstrapTimeoutMs)
   $deadline = [System.Threading.CancellationTokenSource]::new()
-  $deadline.CancelAfter($bootstrapTimeoutMs)
+  # One cancellation source covers every network wait: each wait is armed with
+  # the smaller of the stall window and the remaining total budget, delivered
+  # bytes rearm the stall, and nothing can extend the total deadline.
+  $armDeadline = {
+    [double]$remainingMs = ($deadlineAt - [DateTime]::UtcNow).TotalMilliseconds
+    if ($remainingMs -lt 1) { $remainingMs = 1 }
+    $deadline.CancelAfter([int][Math]::Min([double]$bootstrapStallMs, $remainingMs))
+  }
+  & $armDeadline
   $handler = [System.Net.Http.HttpClientHandler]::new()
   $handler.AllowAutoRedirect = $true
   $handler.MaxAutomaticRedirections = 5
@@ -129,6 +158,7 @@ function Copy-PinnedBootstrapHttps(
         $buffer.Length,
         $deadline.Token
       ).GetAwaiter().GetResult()) -gt 0) {
+      & $armDeadline
       $total += $read
       if ($total -gt $ExactBytes) { Fail "Node.js bootstrap exceeds pinned byte count" }
       $outputStream.Write($buffer, 0, $read)
@@ -138,7 +168,10 @@ function Copy-PinnedBootstrapHttps(
       Fail "Node.js bootstrap byte count mismatch (expected $ExactBytes, got $total)"
     }
   } catch [System.OperationCanceledException] {
-    Fail "Node.js bootstrap deadline exceeded after ${bootstrapTimeoutMs}ms"
+    if ([DateTime]::UtcNow -ge $deadlineAt) {
+      Fail "Node.js bootstrap deadline exceeded after ${bootstrapTimeoutMs}ms"
+    }
+    Fail "Node.js bootstrap stalled: no bytes received for ${bootstrapStallMs}ms"
   } finally {
     if ($outputStream) { $outputStream.Dispose() }
     if ($inputStream) { $inputStream.Dispose() }
@@ -168,12 +201,29 @@ const { fileURLToPath, pathToFileURL } = require("node:url");
 const [resource, destination, maximumText, exactText, trustMode] = process.argv.slice(2);
 const maximum = Number(maximumText);
 const exact = exactText === "" ? undefined : Number(exactText);
-const timeoutText = process.env.AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS;
-const timeoutMs = timeoutText === undefined ? 120_000 : Number(timeoutText);
 if (!Number.isSafeInteger(maximum) || maximum < 1 ||
-    (exact !== undefined && (!Number.isSafeInteger(exact) || exact < 1 || exact > maximum)) ||
-    !Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 120_000) {
+    (exact !== undefined && (!Number.isSafeInteger(exact) || exact < 1 || exact > maximum))) {
   throw new Error("invalid bounded-download byte contract");
+}
+// The total deadline scales with the declared artifact size so slow links can
+// finish: a fixed 120s ceiling made any connection under ~1 MiB/s permanently
+// unable to download a ~120 MiB runtime. A byzantine server stays bounded by
+// the declared size at the minimum sustained rate (256 MiB ceiling at
+// 128 KiB/s is ~34 minutes worst case), undeclared sizes (manifests, bundles)
+// keep the 120s bound, and the stall detector below kills dead connections
+// long before either deadline. The test overrides can only shorten.
+const MINIMUM_SUSTAINED_BYTES_PER_SECOND = 131_072;
+const defaultTimeoutMs = exact === undefined ? 120_000 : Math.max(
+  120_000,
+  Math.ceil(exact / MINIMUM_SUSTAINED_BYTES_PER_SECOND) * 1000 + 30_000,
+);
+const timeoutText = process.env.AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS;
+const timeoutMs = timeoutText === undefined ? defaultTimeoutMs : Number(timeoutText);
+const stallText = process.env.AGENC_INSTALL_TEST_DOWNLOAD_STALL_MS;
+const stallMs = stallText === undefined ? 60_000 : Number(stallText);
+if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > defaultTimeoutMs ||
+    !Number.isSafeInteger(stallMs) || stallMs < 1 || stallMs > 60_000) {
+  throw new Error("invalid bounded-download deadline contract");
 }
 function canonicalLocalFileUrlToPath(value, platform = process.platform) {
   if (typeof value !== "string" || value !== value.trim() || /[\0\r\n]/.test(value) ||
@@ -219,11 +269,12 @@ function canonicalLocalFileUrlToPath(value, platform = process.platform) {
   }
   return path;
 }
-function byteLimiter() {
+function byteLimiter(onChunk) {
   let count = 0;
   return new Transform({
     transform(chunk, _encoding, callback) {
       count += chunk.length;
+      if (onChunk !== undefined) onChunk();
       if (count > maximum) callback(new Error(`download exceeds ${maximum} byte limit`));
       else if (exact !== undefined && count > exact) {
         callback(new Error(`download exceeds declared ${exact} bytes`));
@@ -304,11 +355,21 @@ function validateContentLength(response) {
     let current = new URL(resource);
     const controller = new AbortController();
     const timeoutError = new Error(`download deadline exceeded after ${timeoutMs}ms`);
+    const stallError = new Error(`download stalled: no bytes received for ${stallMs}ms`);
+    const abortError = () =>
+      controller.signal.reason instanceof Error ? controller.signal.reason : timeoutError;
     const deadline = performance.now() + timeoutMs;
     const timer = setTimeout(() => controller.abort(timeoutError), timeoutMs);
+    // One stall window covers connect, TLS, headers, every redirect hop, and
+    // each gap between body chunks; only delivered bytes rearm it.
+    let lastProgressAt = performance.now();
+    const stallTimer = setInterval(() => {
+      if (performance.now() - lastProgressAt >= stallMs) controller.abort(stallError);
+    }, Math.min(stallMs, 500));
     const throwIfExpired = () => {
-      if (controller.signal.aborted || performance.now() >= deadline) {
-        if (!controller.signal.aborted) controller.abort(timeoutError);
+      if (controller.signal.aborted) throw abortError();
+      if (performance.now() >= deadline) {
+        controller.abort(timeoutError);
         throw timeoutError;
       }
     };
@@ -316,7 +377,7 @@ function validateContentLength(response) {
       throwIfExpired();
       let rejectOnAbort;
       const aborted = new Promise((_resolve, reject) => {
-        rejectOnAbort = () => reject(timeoutError);
+        rejectOnAbort = () => reject(abortError());
         controller.signal.addEventListener("abort", rejectOnAbort, { once: true });
       });
       try { return await Promise.race([promise, aborted]); }
@@ -334,7 +395,7 @@ function validateContentLength(response) {
             headers: { "accept-encoding": "identity" },
           });
         } catch (error) {
-          if (controller.signal.aborted) throw timeoutError;
+          if (controller.signal.aborted) throw abortError();
           throw error;
         }
         throwIfExpired();
@@ -359,12 +420,12 @@ function validateContentLength(response) {
         try {
           await pipeline(
             Readable.fromWeb(response.body),
-            byteLimiter(),
+            byteLimiter(() => { lastProgressAt = performance.now(); }),
             createWriteStream(destination, { flags: "wx", mode: 0o600 }),
             { signal: controller.signal },
           );
         } catch (error) {
-          if (controller.signal.aborted) throw timeoutError;
+          if (controller.signal.aborted) throw abortError();
           throw error;
         }
         throwIfExpired();
@@ -376,6 +437,7 @@ function validateContentLength(response) {
       throw error;
     } finally {
       clearTimeout(timer);
+      clearInterval(stallTimer);
     }
   } catch (error) {
     try { rmSync(destination, { force: true }); } catch {}

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -509,12 +509,29 @@ const { fileURLToPath, pathToFileURL } = require("node:url");
 const [resource, destination, maximumText, exactText, trustMode] = process.argv.slice(2);
 const maximum = Number(maximumText);
 const exact = exactText === "" ? undefined : Number(exactText);
-const timeoutText = process.env.AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS;
-const timeoutMs = timeoutText === undefined ? 120_000 : Number(timeoutText);
 if (!Number.isSafeInteger(maximum) || maximum < 1 ||
-    (exact !== undefined && (!Number.isSafeInteger(exact) || exact < 1 || exact > maximum)) ||
-    !Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 120_000) {
+    (exact !== undefined && (!Number.isSafeInteger(exact) || exact < 1 || exact > maximum))) {
   throw new Error("invalid bounded-download byte contract");
+}
+// The total deadline scales with the declared artifact size so slow links can
+// finish: a fixed 120s ceiling made any connection under ~1 MiB/s permanently
+// unable to download a ~120 MiB runtime. A byzantine server stays bounded by
+// the declared size at the minimum sustained rate (256 MiB ceiling at
+// 128 KiB/s is ~34 minutes worst case), undeclared sizes (manifests, bundles)
+// keep the 120s bound, and the stall detector below kills dead connections
+// long before either deadline. The test overrides can only shorten.
+const MINIMUM_SUSTAINED_BYTES_PER_SECOND = 131_072;
+const defaultTimeoutMs = exact === undefined ? 120_000 : Math.max(
+  120_000,
+  Math.ceil(exact / MINIMUM_SUSTAINED_BYTES_PER_SECOND) * 1000 + 30_000,
+);
+const timeoutText = process.env.AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS;
+const timeoutMs = timeoutText === undefined ? defaultTimeoutMs : Number(timeoutText);
+const stallText = process.env.AGENC_INSTALL_TEST_DOWNLOAD_STALL_MS;
+const stallMs = stallText === undefined ? 60_000 : Number(stallText);
+if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > defaultTimeoutMs ||
+    !Number.isSafeInteger(stallMs) || stallMs < 1 || stallMs > 60_000) {
+  throw new Error("invalid bounded-download deadline contract");
 }
 
 function canonicalLocalFileUrlToPath(value, platform = process.platform) {
@@ -582,13 +599,14 @@ function renderProgress(count, total, done) {
   process.stderr.write(`\u001b[2K\r${line}${done ? "\n" : ""}`);
 }
 
-function byteLimiter() {
+function byteLimiter(onChunk) {
   let count = 0;
   let lastRender = 0;
   const reportable = progressEnabled && exact !== undefined;
   return new Transform({
     transform(chunk, _encoding, callback) {
       count += chunk.length;
+      if (onChunk !== undefined) onChunk();
       if (count > maximum) {
         callback(new Error(`download exceeds ${maximum} byte limit`));
       } else if (exact !== undefined && count > exact) {
@@ -694,11 +712,21 @@ function contentLength(response) {
     let current = new URL(resource);
     const controller = new AbortController();
     const timeoutError = new Error(`download deadline exceeded after ${timeoutMs}ms`);
+    const stallError = new Error(`download stalled: no bytes received for ${stallMs}ms`);
+    const abortError = () =>
+      controller.signal.reason instanceof Error ? controller.signal.reason : timeoutError;
     const deadline = performance.now() + timeoutMs;
     const timer = setTimeout(() => controller.abort(timeoutError), timeoutMs);
+    // One stall window covers connect, TLS, headers, every redirect hop, and
+    // each gap between body chunks; only delivered bytes rearm it.
+    let lastProgressAt = performance.now();
+    const stallTimer = setInterval(() => {
+      if (performance.now() - lastProgressAt >= stallMs) controller.abort(stallError);
+    }, Math.min(stallMs, 500));
     const throwIfExpired = () => {
-      if (controller.signal.aborted || performance.now() >= deadline) {
-        if (!controller.signal.aborted) controller.abort(timeoutError);
+      if (controller.signal.aborted) throw abortError();
+      if (performance.now() >= deadline) {
+        controller.abort(timeoutError);
         throw timeoutError;
       }
     };
@@ -706,7 +734,7 @@ function contentLength(response) {
       throwIfExpired();
       let rejectOnAbort;
       const aborted = new Promise((_resolve, reject) => {
-        rejectOnAbort = () => reject(timeoutError);
+        rejectOnAbort = () => reject(abortError());
         controller.signal.addEventListener("abort", rejectOnAbort, { once: true });
       });
       try { return await Promise.race([promise, aborted]); }
@@ -724,7 +752,7 @@ function contentLength(response) {
             headers: { "accept-encoding": "identity" },
           });
         } catch (error) {
-          if (controller.signal.aborted) throw timeoutError;
+          if (controller.signal.aborted) throw abortError();
           throw error;
         }
         throwIfExpired();
@@ -749,12 +777,12 @@ function contentLength(response) {
         try {
           await pipeline(
             Readable.fromWeb(response.body),
-            byteLimiter(),
+            byteLimiter(() => { lastProgressAt = performance.now(); }),
             createWriteStream(destination, { flags: "wx", mode: 0o600 }),
             { signal: controller.signal },
           );
         } catch (error) {
-          if (controller.signal.aborted) throw timeoutError;
+          if (controller.signal.aborted) throw abortError();
           throw error;
         }
         throwIfExpired();
@@ -766,6 +794,7 @@ function contentLength(response) {
       throw error;
     } finally {
       clearTimeout(timer);
+      clearInterval(stallTimer);
     }
   } catch (error) {
     try { rmSync(destination, { force: true }); } catch {}


### PR DESCRIPTION
## The failure

Two consecutive live runs of `curl -fsSL https://get.agenc.ag/install.sh | sh` died at 87–88% downloading `agenc-runtime-0.17.0-linux-x64-node26-abi147.tar.gz` (122.5 MiB) with:

```
download deadline exceeded after 120000ms
agenc-install: ERROR: bounded download failed: https://github.com/tetsuo-ai/agenc-releases/releases/download/agenc-v0.17.0/agenc-runtime-0.17.0-linux-x64-node26-abi147.tar.gz
```

The bounded fetch enforced a fixed **120s total deadline**, and the validation rejected any `AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS` above 120000, so the ceiling could only be lowered. A 122.5 MiB artifact therefore requires a sustained ~1.02 MiB/s or the install can never complete — the observed link ran at ~0.9 MiB/s and failed deterministically at the same percentage twice. Every release that grows the artifact raises the minimum viable bandwidth further.

## The fix

The total deadline now scales with the size the manifest declares:

```
deadline = max(120s, ceil(declaredBytes / 128 KiB/s) + 30s grace)
```

- **Slow links finish.** Any connection sustaining ≥128 KiB/s installs the current runtime (~17 min ceiling for 122.5 MiB).
- **The byzantine bound is preserved.** A malicious server is still bounded by the declared size at the minimum sustained rate: with the existing 256 MiB artifact ceiling the worst case is ~34 minutes, and the declared size itself is validated against that ceiling before the deadline is computed.
- **Undeclared sizes keep the 120s bound** (manifest, sigstore bundles — small files with no size contract).
- **A new 60s stall window kills dead connections fast.** One window covers connect, TLS, headers, every redirect hop, and each gap between body chunks; only delivered bytes rearm it. A slowloris trickle can no longer ride the (now larger) total deadline — no bytes for 60s aborts with a distinct `download stalled: no bytes received for 60000ms`.
- **Test overrides can only shorten**, boundary inclusive (`timeoutMs ≤ computed ceiling`, `stallMs ≤ 60000`), via the existing `AGENC_INSTALL_TEST_DOWNLOAD_TIMEOUT_MS` and new `AGENC_INSTALL_TEST_DOWNLOAD_STALL_MS` / `AGENC_INSTALL_TEST_BOOTSTRAP_STALL_MS`.

Applied to all three download paths:

1. `install.sh` embedded bounded fetch (the heredoc),
2. `install.ps1` embedded bounded fetch (the herestring),
3. `install.ps1` PowerShell-native Node bootstrap (`Copy-PinnedBootstrapHttps`), which keeps its single-cancellation-source invariant by rearming each network wait with the smaller of the stall window and the remaining total budget — nothing can extend the scaled deadline.

Abort attribution now flows through `AbortSignal.reason`, so a stall reports as a stall and a deadline as a deadline instead of everything collapsing into the deadline message.

## Tests

- **Extracted-copy contract tests** run both embedded Node programs (sh and ps1) directly on Linux, pinning the scaling formula on both sides of the exact boundary: an override equal to the computed ceiling is accepted and the download completes; one millisecond above is rejected; undeclared sizes reject anything above 120s; a stalled body dies on the stall window in milliseconds, and a shortened total deadline still wins when it is the smaller bound.
- **Integration stall test** through the real installer (`stall-headers` and `stall-body` routes) proves the env plumbing and the failure cleanup.
- The existing "one monotonic download deadline" test passes unchanged (shortening overrides keep their exact semantics), and the PowerShell bootstrap static pins now assert the rearm shape.

Falsification: reverting only the two installer scripts to their previous versions fails exactly the four new/updated tests (the integration stall test burns the full old 120s deadline — the defect on camera) while the other 61 stay green; restoring the fix returns the suite to 65/65 locally.
