### PR TITLE
test(fnd): rebind the benchmark baseline to current main

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.696097,
-            "maxMs": 88.222221,
-            "medianMs": 83.505304,
-            "minMs": 78.513819,
+            "madMs": 0.873855,
+            "maxMs": 78.108927,
+            "medianMs": 77.235072,
+            "minMs": 74.171714,
             "sampleCount": 5,
             "samplesMs": [
-              88.222221,
-              79.809207,
-              83.505304,
-              84.813982,
-              78.513819
+              77.969066,
+              74.738454,
+              77.235072,
+              78.108927,
+              74.171714
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 178044928,
+              "maximumObservedBytes": 181444608,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                113250304,
-                132431872,
-                134004736,
-                134004736,
-                136101888,
-                136101888,
-                156549120,
-                156549120,
-                175947776,
-                175947776,
-                178044928
+                115564544,
+                135634944,
+                137994240,
+                137994240,
+                139960320,
+                139960320,
+                162177024,
+                162177024,
+                178888704,
+                178888704,
+                181444608
               ]
             },
-            "peakRssBytes": 178044928,
+            "peakRssBytes": 181444608,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.44142,
-            "maxMs": 179.119328,
-            "medianMs": 160.975787,
-            "minMs": 159.534367,
+            "madMs": 2.636581,
+            "maxMs": 162.953489,
+            "medianMs": 154.684577,
+            "minMs": 150.571725,
             "sampleCount": 5,
             "samplesMs": [
-              160.975787,
-              179.119328,
-              162.927002,
-              160.952591,
-              159.534367
+              156.070738,
+              154.684577,
+              150.571725,
+              152.047996,
+              162.953489
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 194785280,
+              "maximumObservedBytes": 195375104,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                110755840,
-                135016448,
-                138686464,
-                138686464,
-                179580928,
-                179580928,
-                186396672,
-                186396672,
-                191639552,
-                191639552,
-                194785280
+                114442240,
+                137203712,
+                159223808,
+                159223808,
+                182030336,
+                182030336,
+                186748928,
+                186748928,
+                190488576,
+                190488576,
+                195375104
               ]
             },
-            "peakRssBytes": 198877184,
+            "peakRssBytes": 198434816,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 8.295366,
-            "maxMs": 346.834975,
-            "medianMs": 338.539609,
-            "minMs": 320.253152,
+            "madMs": 4.705178,
+            "maxMs": 326.836786,
+            "medianMs": 303.180631,
+            "minMs": 296.967804,
             "sampleCount": 5,
             "samplesMs": [
-              326.375726,
-              320.253152,
-              346.834975,
-              338.539609,
-              342.829758
+              303.180631,
+              326.836786,
+              296.967804,
+              305.228911,
+              298.475453
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 248877056,
+              "maximumObservedBytes": 242114560,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                114810880,
-                158502912,
-                184717312,
-                184717312,
-                195198976,
-                195198976,
-                196341760,
-                196341760,
-                205361152,
-                205361152,
-                248877056
+                116400128,
+                161370112,
+                188108800,
+                188108800,
+                240934912,
+                240934912,
+                242114560,
+                242114560,
+                239804416,
+                239804416,
+                240590848
               ]
             },
-            "peakRssBytes": 248877056,
+            "peakRssBytes": 248799232,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.357633,
-            "maxMs": 3.530965,
-            "medianMs": 2.547501,
-            "minMs": 2.189868,
+            "madMs": 0.277768,
+            "maxMs": 3.336639,
+            "medianMs": 2.621211,
+            "minMs": 2.119243,
             "sampleCount": 5,
             "samplesMs": [
-              3.530965,
-              2.456473,
-              2.90845,
-              2.189868,
-              2.547501
+              3.336639,
+              2.621211,
+              2.706731,
+              2.119243,
+              2.343443
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 88895488,
+              "maximumObservedBytes": 91127808,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                81031168,
-                82604032,
-                84701184,
-                84701184,
-                86274048,
-                86274048,
-                87322624,
-                87322624,
-                88371200,
-                88371200,
-                88895488
+                82477056,
+                84246528,
+                86409216,
+                86409216,
+                87785472,
+                87785472,
+                88965120,
+                88965120,
+                89948160,
+                89948160,
+                91127808
               ]
             },
-            "peakRssBytes": 88895488,
+            "peakRssBytes": 91127808,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.102205,
-            "maxMs": 6.926565,
-            "medianMs": 5.3629,
-            "minMs": 4.821377,
+            "madMs": 0.359663,
+            "maxMs": 5.480428,
+            "medianMs": 4.873193,
+            "minMs": 4.298398,
             "sampleCount": 5,
             "samplesMs": [
-              6.926565,
-              5.465105,
-              5.3629,
-              4.821377,
-              5.308577
+              5.480428,
+              4.873193,
+              5.078737,
+              4.51353,
+              4.298398
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 104792064,
+              "maximumObservedBytes": 106479616,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82771968,
-                87490560,
-                90112000,
-                90112000,
-                93782016,
-                93782016,
-                96403456,
-                96403456,
-                102170624,
-                102170624,
-                104792064
+                84066304,
+                89964544,
+                92127232,
+                92127232,
+                95862784,
+                95862784,
+                98418688,
+                98418688,
+                104316928,
+                104316928,
+                106479616
               ]
             },
-            "peakRssBytes": 104792064,
+            "peakRssBytes": 106676224,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.545869,
-            "maxMs": 15.923968,
-            "medianMs": 10.565235,
-            "minMs": 9.313653,
+            "madMs": 1.003066,
+            "maxMs": 11.841272,
+            "medianMs": 10.832967,
+            "minMs": 9.381884,
             "sampleCount": 5,
             "samplesMs": [
-              10.557723,
-              11.111104,
-              10.565235,
-              9.313653,
-              15.923968
+              10.832967,
+              11.841272,
+              9.829901,
+              9.381884,
+              11.385751
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 127737856,
+              "maximumObservedBytes": 128036864,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                86319104,
-                96804864,
-                102572032,
-                102572032,
-                107290624,
-                107290624,
-                113057792,
-                113057792,
-                121446400,
-                121446400,
-                127737856
+                86355968,
+                96776192,
+                101888000,
+                101888000,
+                107982848,
+                107982848,
+                114077696,
+                114077696,
+                121548800,
+                121548800,
+                128036864
               ]
             },
-            "peakRssBytes": 127737856,
+            "peakRssBytes": 128036864,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -365,8 +365,8 @@
   ],
   "environment": {
     "cpu": {
-      "logicalCount": 64,
-      "model": "AMD Ryzen Threadripper PRO 9975WX 32-Cores"
+      "logicalCount": 24,
+      "model": "AMD Ryzen 9 9900X 12-Core Processor"
     },
     "filesystems": {
       "sourceCheckout": {
@@ -379,12 +379,12 @@
       }
     },
     "memory": {
-      "totalBytes": 1081089339392
+      "totalBytes": 32214454272
     },
     "os": {
       "arch": "x64",
       "platform": "linux",
-      "release": "7.0.0-28-generic"
+      "release": "7.0.0-29-generic"
     },
     "ripgrep": {
       "distribution": "pinned_package",
@@ -669,7 +669,7 @@
         },
         {
           "path": "runtime/src/state/run-durability.ts",
-          "sha256": "e6636ffabd213419feb4ab9ed55a8b56dc7a4f6d0ae4ee5503f281a837f2f72b"
+          "sha256": "d23eb2db30016f1f9a44e0ef9b79bf5b94f6981bfc523668ee3fee5481003fdc"
         },
         {
           "path": "runtime/src/state/unknown-outcome-gate.ts",
@@ -748,11 +748,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "e6e6ac0d127635190806e6ecadc80de72e345f67",
+    "gitObjectId": "39d9ddff396eb8fbf661898886e1da91783f133d",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "b62609675f33c291e7046b71c74d71ac262f60f9",
+  "sourceRevision": "e871a8b783effecde82440be6388bbe355689a98",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,26 +4,26 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `ebbc01239a7df720bcf785a16a37f217971d9b8535423e7cf75b925ffc3bcffb`
-- Source revision: `b62609675f33c291e7046b71c74d71ac262f60f9`
-- Production tree: `runtime/src` at Git object `e6e6ac0d127635190806e6ecadc80de72e345f67`
+- JSON SHA-256: `880756eb083de312c1397f779b79e4943a96aca7c4b5072ff0accb914586c457`
+- Source revision: `e871a8b783effecde82440be6388bbe355689a98`
+- Production tree: `runtime/src` at Git object `39d9ddff396eb8fbf661898886e1da91783f133d`
 - Loaded production closure: `49` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
-- OS/CPU: `linux 7.0.0-28-generic x64` / `AMD Ryzen Threadripper PRO 9975WX 32-Cores` (64 logical)
-- RAM: `1081089339392` bytes
+- OS/CPU: `linux 7.0.0-29-generic x64` / `AMD Ryzen 9 9900X 12-Core Processor` (24 logical)
+- RAM: `32214454272` bytes
 - Source filesystem: type `61267`, block `4096` bytes
 - Fixture filesystem: type `16914836`, block `4096` bytes
 - SQLite/ripgrep: `3.53.3` / `ripgrep 15.0.0 (rev 3a612f88b8)`
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 83.505 | 3.696 | 178044928 | 178044928 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 160.976 | 1.441 | 198877184 | 194785280 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 338.540 | 8.295 | 248877056 | 248877056 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.548 | 0.358 | 88895488 | 88895488 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.363 | 0.102 | 104792064 | 104792064 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.565 | 0.546 | 127737856 | 127737856 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 77.235 | 0.874 | 181444608 | 181444608 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 154.685 | 2.637 | 198434816 | 195375104 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 303.181 | 4.705 | 248799232 | 242114560 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.621 | 0.278 | 91127808 | 91127808 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 4.873 | 0.360 | 106676224 | 106479616 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.833 | 1.003 | 128036864 | 128036864 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision b62609675f33c291e7046b71c74d71ac262f60f9 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision e871a8b783effecde82440be6388bbe355689a98 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 


### PR DESCRIPTION
## main has been red since 2026-08-20

`tests/fnd/benchmark-baselines.contract.test.ts` fails on a clean checkout of main:

```
current production module closure for csv_scheduler_progress_scan is stale
```

The baseline pinned `sourceRevision: b62609675`. Commit a4ee49531 (#1754) then changed `runtime/src/state/run-durability.ts`, one of the 43 modules in that case's production closure, without regenerating the baseline. `verifyCheckedBenchmarkProvenance` compares the recorded closure digests against the current working tree (`assertPathDigestsEqual`, `runtime/benchmarks/fnd/provenance.mjs:170`), so the mismatch reddens every branch cut from main. It surfaced on an unrelated installer PR and reproduced identically at main with zero local changes.

## Fix

Regenerated through the sanctioned path, pinned to current main:

```
env -u NODE_USE_SYSTEM_CA node runtime/benchmarks/fnd/run-baselines.mjs \
  --source-revision e871a8b78 --output <fresh>.json --markdown-output <fresh>.md
```

This is a provenance rebind, not a performance shift. Re-measured on the same host, every point moved within ±10% and peak RSS is unchanged:

| point | before | after |
|---|---|---|
| csv_scheduler_progress_scan#0 | 83.51 ms | 77.24 ms |
| csv_scheduler_progress_scan#1 | 160.98 ms | 154.68 ms |
| csv_scheduler_progress_scan#2 | 338.54 ms | 303.18 ms |
| patch_delete_parser_historical_comparison#0 | 2.55 ms | 2.62 ms |
| patch_delete_parser_historical_comparison#1 | 5.36 ms | 4.87 ms |
| patch_delete_parser_historical_comparison#2 | 10.57 ms | 10.83 ms |

Verified: `run-baselines.mjs --check` reports the contract valid, and the contract suite is 9/9.
