### PR TITLE
fix(sandbox): name the home workspace instead of sending operators to reinstall

### DIFF
--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -12,6 +12,7 @@
 import { spawnSync } from "node:child_process";
 import { probeLandlock, resolveLandlockRun } from "./landlock-run.js";
 import { realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import path, { basename, delimiter } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -526,7 +527,7 @@ function probeLinuxSandbox(options: {
     return unavailableStatus(
       options,
       helper.error,
-      "Install AgenC with its executable sandbox helper outside the workspace, then run `agenc doctor` again.",
+      linuxSandboxHelperRemediation(options.cwd, options.env),
     );
   }
   // When any bubblewrap rung fails, the helper falls back to Landlock at
@@ -666,6 +667,36 @@ function unavailableStatus(
     ...(helperPath !== undefined ? { helperPath } : {}),
     ...(isolationProgram !== undefined ? { isolationProgram } : {}),
   };
+}
+
+export const LINUX_SANDBOX_HELPER_REINSTALL_REMEDIATION =
+  "Install AgenC with its executable sandbox helper outside the workspace, then run `agenc doctor` again.";
+
+export const LINUX_SANDBOX_HOME_WORKSPACE_REMEDIATION =
+  "This workspace contains your home directory, where AgenC installs its runtime, " +
+  "so the helper can never sit outside it. Open AgenC in a project directory instead, " +
+  "then run `agenc doctor` again.";
+
+/**
+ * A userland install puts the helper under ~/.agenc, so a workspace that
+ * contains the user's home can never satisfy the containment rule -- and a
+ * bare `agenc` in a fresh terminal opens exactly that workspace. Sending that
+ * user to reinstall the helper "outside the workspace" points at the wrong
+ * thing; the actionable fix is to open a project directory. The refusal itself
+ * is unchanged: a jailed process that can rewrite its own jailer is not jailed.
+ */
+export function linuxSandboxHelperRemediation(
+  workspaceRoot: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const configured = env.HOME;
+  const home = configured !== undefined && path.isAbsolute(configured)
+    ? configured
+    : homedir();
+  if (home.length === 0) return LINUX_SANDBOX_HELPER_REINSTALL_REMEDIATION;
+  return isPathUnder(safeRealpath(home), safeRealpath(workspaceRoot))
+    ? LINUX_SANDBOX_HOME_WORKSPACE_REMEDIATION
+    : LINUX_SANDBOX_HELPER_REINSTALL_REMEDIATION;
 }
 
 export function resolveTrustedLinuxSandboxExecutable(

--- a/runtime/tests/sandbox/execution-broker.test.ts
+++ b/runtime/tests/sandbox/execution-broker.test.ts
@@ -13,9 +13,12 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  LINUX_SANDBOX_HELPER_REINSTALL_REMEDIATION,
+  LINUX_SANDBOX_HOME_WORKSPACE_REMEDIATION,
   SandboxExecutionBroker,
   SandboxExecutionError,
   attachSandboxExecutionBroker,
+  linuxSandboxHelperRemediation,
   linuxSandboxProbeRemediation,
   probeSandboxExecutionStatus,
   readSandboxExecutionBroker,
@@ -435,4 +438,79 @@ describe("SandboxExecutionBroker", () => {
       expect(String(error)).toContain("install the helper");
     }
   });
+});
+
+/**
+ * The default userland install puts the helper under ~/.agenc, and a bare
+ * `agenc` in a fresh terminal opens $HOME as the workspace -- so the helper is
+ * inside the writable workspace and startup fails closed. Observed live on
+ * 0.17.0: the refusal is correct, but it told the operator to reinstall the
+ * helper "outside the workspace", which is not the action that fixes it.
+ */
+describe("Linux sandbox helper remediation", () => {
+  it("names the home workspace instead of sending the operator to reinstall", () => {
+    const home = tempRoot("agenc-sandbox-home-");
+    expect(linuxSandboxHelperRemediation(home, { HOME: home })).toBe(
+      LINUX_SANDBOX_HOME_WORKSPACE_REMEDIATION,
+    );
+    expect(linuxSandboxHelperRemediation(home, { HOME: home })).toContain(
+      "project directory",
+    );
+  });
+
+  it("covers a workspace that merely contains the home directory", () => {
+    const root = tempRoot("agenc-sandbox-above-home-");
+    const home = join(root, "home", "operator");
+    mkdirSync(home, { recursive: true });
+    expect(linuxSandboxHelperRemediation(root, { HOME: home })).toBe(
+      LINUX_SANDBOX_HOME_WORKSPACE_REMEDIATION,
+    );
+  });
+
+  it("keeps the reinstall guidance when the workspace excludes the home", () => {
+    const root = tempRoot("agenc-sandbox-project-");
+    const workspace = join(root, "project");
+    const home = join(root, "home");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    // A helper inside a project workspace is a genuine placement problem, so
+    // the original guidance is the right one to keep.
+    expect(linuxSandboxHelperRemediation(workspace, { HOME: home })).toBe(
+      LINUX_SANDBOX_HELPER_REINSTALL_REMEDIATION,
+    );
+  });
+
+  it("ignores a relative HOME rather than trusting it as a root", () => {
+    const root = tempRoot("agenc-sandbox-relative-home-");
+    // A relative HOME cannot anchor a containment test; the fallback is the
+    // process's real home, which is not under this temporary workspace.
+    expect(linuxSandboxHelperRemediation(root, { HOME: "relative/home" })).toBe(
+      LINUX_SANDBOX_HELPER_REINSTALL_REMEDIATION,
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "reaches the probe status an operator actually sees",
+    () => {
+      const home = tempRoot("agenc-sandbox-home-probe-");
+      const helper = join(home, ".agenc", "agenc-linux-sandbox");
+      mkdirSync(join(home, ".agenc"), { recursive: true });
+      writeFileSync(helper, "#!/bin/sh\nexit 0\n");
+      chmodSync(helper, 0o755);
+
+      const status = probeSandboxExecutionStatus({
+        mode: "workspace_write",
+        cwd: home,
+        env: { HOME: home },
+        platform: "linux",
+        agencLinuxSandboxExe: helper,
+      });
+
+      expect(status.kind).toBe("unavailable");
+      expect(status).toMatchObject({
+        reason: expect.stringContaining("outside the writable workspace"),
+        remediation: LINUX_SANDBOX_HOME_WORKSPACE_REMEDIATION,
+      });
+    },
+  );
 });


### PR DESCRIPTION
## What an operator hits

A userland install puts the sandbox helper under `~/.agenc/runtime/<version>/…/bin/agenc-linux-sandbox`. A bare `agenc` in a fresh terminal opens `$HOME` as the workspace. The helper is therefore inside the writable workspace, and startup fails closed:

```
[sandbox_required_unavailable] required sandbox blocked startup: Linux sandbox helper
must be outside the writable workspace. Install AgenC with its executable sandbox
helper outside the workspace, then run `agenc doctor` again.
```

Reproduced live on 0.17.0 with a stock install.

**The refusal is correct** — a jailed process that can rewrite its own jailer is not jailed, and `resolveTrustedLinuxSandboxExecutable` is a trivially auditable containment test worth keeping exactly as it is.

**The remediation was not.** It sends the operator to reinstall the helper "outside the workspace", but with the default install that is impossible for any workspace containing the home directory. The action that fixes it is to open AgenC in a project directory — which the message never mentions, and it never says the workspace is the home directory, the one fact that explains the failure.

## Change

`probeLinuxSandbox` now selects the remediation from the workspace instead of hardcoding one string:

- workspace contains the user's home (equal to it, or an ancestor such as `/home` or `/`) → name that, and point at a project directory;
- helper misplaced inside an ordinary project workspace → keep the original reinstall guidance, which is the right advice there.

`HOME` is honoured when absolute and ignored otherwise, falling back to `homedir()`; both sides are realpath'd, matching the containment test they explain. Nothing about the refusal, the probe order, or any other path changes — this is remediation text selection only.

## Tests

Five added to `runtime/tests/sandbox/execution-broker.test.ts`: workspace equal to home, workspace above home, project workspace keeping the reinstall text, a relative `HOME` refusing to anchor the containment test, and an end-to-end `probeSandboxExecutionStatus` assertion that the status an operator actually sees carries the new remediation.

Falsification: reverting only `execution-broker.ts` fails exactly those five and leaves the other 14 green; restoring it returns 19/19. Typecheck is clean for the touched files.

## Not done here, deliberately

Carving `~/.agenc` out of the writable workspace so home-as-workspace works was considered and rejected. The Landlock fallback refuses read-only carve-outs inside a writable root ([landlock-fallback.test.ts:133](runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts#L133)), so hosts without bubblewrap would trade one blocked startup for another; and it would replace a one-line path containment guarantee with one that depends on every backend's profile being airtight. Home-as-workspace also hands the agent write access to the entire home directory, so the better outcome is a clear message, not enabling it.
