### PR TITLE
feat(llm): resolve the real context window for local model providers

### DIFF
--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -226,7 +226,30 @@ export class ModelMetadataResolver {
       const openAi = metadataFromOpenAiModelsResponse(response, params.model);
       if (hasAnyMetadata(openAi)) return openAi;
     }
-    return await this.resolveOllamaNativeMetadata(baseUrl, params, headers);
+    const ollama = await this.resolveOllamaNativeMetadata(
+      baseUrl,
+      params,
+      headers,
+    );
+    if (hasAnyMetadata(ollama)) return ollama;
+    if (provider === "ollama") return undefined;
+    return await this.resolveLmStudioNativeMetadata(baseUrl, params, headers);
+  }
+
+  /**
+   * LM Studio's OpenAI-compatible surface omits the window too; its own REST
+   * API reports the loaded and maximum sizes per model. A server that is not
+   * LM Studio 404s and the caller falls through unchanged.
+   */
+  private async resolveLmStudioNativeMetadata(
+    baseUrl: string,
+    params: LookupParams,
+    headers: Readonly<Record<string, string>> | undefined,
+  ): Promise<ModelMetadataValues | undefined> {
+    const response = await this.fetchJson(lmStudioModelsUrl(baseUrl), {
+      ...(headers !== undefined ? { headers } : {}),
+    });
+    return metadataFromOpenAiModelsResponse(response, params.model);
   }
 
   /**
@@ -619,32 +642,54 @@ function metadataFromLiteLlm(
   return undefined;
 }
 
+/**
+ * Local runtimes publish the window a server will actually honour under names
+ * the flat lookup above never sees. llama.cpp nests it in `meta` and reports
+ * both the served window and the model's trained maximum; the served one is
+ * what refuses an oversized request, so it wins. LM Studio spells the same
+ * pair `loaded_context_length` / `max_context_length`.
+ */
+function servedContextWindow(
+  record: Record<string, unknown>,
+): number | undefined {
+  const loaded = readPositiveInteger(record, "loaded_context_length");
+  if (loaded !== undefined) return loaded;
+  const meta = asRecord(record.meta);
+  if (!meta) return undefined;
+  return readPositiveInteger(meta, "n_ctx") ??
+    readPositiveInteger(meta, "n_ctx_train");
+}
+
 function metadataFromGenericRecord(
   record: Record<string, unknown>,
 ): ModelMetadataValues {
   const topProvider = asRecord(record.top_provider);
   return {
-    ...(readPositiveInteger(
-      record,
-      "max_model_len",
-      "context_length",
-      "max_context_length",
-      "max_input_tokens",
-      "max_tokens",
-    ) !== undefined
-      ? {
-        contextWindow: readPositiveInteger(
-          record,
-          "max_model_len",
-          "context_length",
-          "max_context_length",
-          "max_input_tokens",
-          "max_tokens",
-        ),
-      }
-      : readPositiveInteger(topProvider, "context_length") !== undefined
-        ? { contextWindow: readPositiveInteger(topProvider, "context_length") }
-        : {}),
+    // The served window is checked before the model's advertised maximum: a
+    // local server refuses anything past what it actually loaded.
+    ...(servedContextWindow(record) !== undefined
+      ? { contextWindow: servedContextWindow(record) }
+      : readPositiveInteger(
+        record,
+        "max_model_len",
+        "context_length",
+        "max_context_length",
+        "max_input_tokens",
+        "max_tokens",
+      ) !== undefined
+        ? {
+          contextWindow: readPositiveInteger(
+            record,
+            "max_model_len",
+            "context_length",
+            "max_context_length",
+            "max_input_tokens",
+            "max_tokens",
+          ),
+        }
+        : readPositiveInteger(topProvider, "context_length") !== undefined
+          ? { contextWindow: readPositiveInteger(topProvider, "context_length") }
+          : {}),
     ...(readPositiveInteger(
       record,
       "max_output_tokens",
@@ -755,6 +800,13 @@ export function ollamaShowUrlFromBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
   const origin = trimmed.replace(/\/(?:v\d+(?:beta)?|api\/v\d+)$/i, "");
   return `${origin}/api/show`;
+}
+
+/** LM Studio's native model list, alongside its `/v1` compatible surface. */
+export function lmStudioModelsUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  const origin = trimmed.replace(/\/(?:v\d+(?:beta)?|api\/v\d+)$/i, "");
+  return `${origin}/api/v0/models`;
 }
 
 function metadataFromOllamaShowResponse(

--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -226,30 +226,7 @@ export class ModelMetadataResolver {
       const openAi = metadataFromOpenAiModelsResponse(response, params.model);
       if (hasAnyMetadata(openAi)) return openAi;
     }
-    const ollama = await this.resolveOllamaNativeMetadata(
-      baseUrl,
-      params,
-      headers,
-    );
-    if (hasAnyMetadata(ollama)) return ollama;
-    if (provider === "ollama") return undefined;
-    return await this.resolveLmStudioNativeMetadata(baseUrl, params, headers);
-  }
-
-  /**
-   * LM Studio's OpenAI-compatible surface omits the window too; its own REST
-   * API reports the loaded and maximum sizes per model. A server that is not
-   * LM Studio 404s and the caller falls through unchanged.
-   */
-  private async resolveLmStudioNativeMetadata(
-    baseUrl: string,
-    params: LookupParams,
-    headers: Readonly<Record<string, string>> | undefined,
-  ): Promise<ModelMetadataValues | undefined> {
-    const response = await this.fetchJson(lmStudioModelsUrl(baseUrl), {
-      ...(headers !== undefined ? { headers } : {}),
-    });
-    return metadataFromOpenAiModelsResponse(response, params.model);
+    return await this.resolveOllamaNativeMetadata(baseUrl, params, headers);
   }
 
   /**
@@ -643,17 +620,14 @@ function metadataFromLiteLlm(
 }
 
 /**
- * Local runtimes publish the window a server will actually honour under names
- * the flat lookup above never sees. llama.cpp nests it in `meta` and reports
- * both the served window and the model's trained maximum; the served one is
- * what refuses an oversized request, so it wins. LM Studio spells the same
- * pair `loaded_context_length` / `max_context_length`.
+ * llama.cpp nests the window inside `meta` where the flat lookup never sees
+ * it, and reports both what the server loaded (`n_ctx`) and what the model was
+ * trained for (`n_ctx_train`). The loaded one wins: `llama-server -c 4096` on
+ * a 32k model refuses at 4097, so the trained maximum is not a usable budget.
  */
 function servedContextWindow(
   record: Record<string, unknown>,
 ): number | undefined {
-  const loaded = readPositiveInteger(record, "loaded_context_length");
-  if (loaded !== undefined) return loaded;
   const meta = asRecord(record.meta);
   if (!meta) return undefined;
   return readPositiveInteger(meta, "n_ctx") ??
@@ -800,13 +774,6 @@ export function ollamaShowUrlFromBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
   const origin = trimmed.replace(/\/(?:v\d+(?:beta)?|api\/v\d+)$/i, "");
   return `${origin}/api/show`;
-}
-
-/** LM Studio's native model list, alongside its `/v1` compatible surface. */
-export function lmStudioModelsUrl(baseUrl: string): string {
-  const trimmed = baseUrl.replace(/\/+$/, "");
-  const origin = trimmed.replace(/\/(?:v\d+(?:beta)?|api\/v\d+)$/i, "");
-  return `${origin}/api/v0/models`;
 }
 
 function metadataFromOllamaShowResponse(

--- a/runtime/src/llm/model-metadata.ts
+++ b/runtime/src/llm/model-metadata.ts
@@ -34,6 +34,7 @@ const LIVE_METADATA_PROVIDERS = new Set([
   "openai",
   "lmstudio",
   "openai-compatible",
+  "ollama",
   "groq",
   "deepseek",
 ]);
@@ -80,6 +81,8 @@ interface ModelMetadataValues {
 
 interface FetchJsonOptions {
   readonly headers?: Readonly<Record<string, string>>;
+  /** Ollama's native metadata endpoint is a POST with a JSON body. */
+  readonly jsonBody?: Readonly<Record<string, unknown>>;
 }
 
 export class ModelMetadataResolver {
@@ -213,10 +216,38 @@ export class ModelMetadataResolver {
     if (!shouldQueryLiveEndpoint(params, this.env)) return undefined;
     const baseUrl = providerBaseUrl(params.config, provider, this.env);
     if (!baseUrl) return undefined;
-    const response = await this.fetchJson(modelsUrlFromBaseUrl(baseUrl), {
-      headers: authHeaders(params.config, provider, this.env),
+    const headers = authHeaders(params.config, provider, this.env);
+    // Ollama serves no context length over its OpenAI-compatible surface, so
+    // the native endpoint is the only place the real number exists.
+    if (provider !== "ollama") {
+      const response = await this.fetchJson(modelsUrlFromBaseUrl(baseUrl), {
+        headers,
+      });
+      const openAi = metadataFromOpenAiModelsResponse(response, params.model);
+      if (hasAnyMetadata(openAi)) return openAi;
+    }
+    return await this.resolveOllamaNativeMetadata(baseUrl, params, headers);
+  }
+
+  /**
+   * Ollama's `/v1/models` returns only `{id, object, created, owned_by}` -- no
+   * context length -- so a local model silently inherited the conservative
+   * 128k fallback while really being 32k (qwen2.5-coder) or 2k (moondream).
+   * `/api/show` reports the true window under an architecture-prefixed key
+   * (`qwen2.context_length`). This also runs for `openai-compatible` and
+   * `lmstudio` pointed at an Ollama endpoint, which is a common setup; a
+   * non-Ollama server simply 404s and the caller falls through.
+   */
+  private async resolveOllamaNativeMetadata(
+    baseUrl: string,
+    params: LookupParams,
+    headers: Readonly<Record<string, string>> | undefined,
+  ): Promise<ModelMetadataValues | undefined> {
+    const response = await this.fetchJson(ollamaShowUrlFromBaseUrl(baseUrl), {
+      ...(headers !== undefined ? { headers } : {}),
+      jsonBody: { model: params.model },
     });
-    return metadataFromOpenAiModelsResponse(response, params.model);
+    return metadataFromOllamaShowResponse(response);
   }
 
   private async resolveOpenRouterMetadata(
@@ -246,7 +277,9 @@ export class ModelMetadataResolver {
     options: FetchJsonOptions = {},
   ): Promise<unknown | undefined> {
     if (!this.fetchImpl) return undefined;
-    const cacheKey = `${url}\n${JSON.stringify(options.headers ?? {})}`;
+    const cacheKey = `${url}\n${JSON.stringify(options.headers ?? {})}\n${
+      JSON.stringify(options.jsonBody ?? null)
+    }`;
     const cached = this.jsonCache.get(cacheKey);
     if (cached) return await cached;
     const request = this.fetchJsonUncached(url, options);
@@ -262,7 +295,16 @@ export class ModelMetadataResolver {
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
       const response = await this.fetchImpl!(url, {
-        headers: options.headers,
+        ...(options.jsonBody !== undefined
+          ? {
+            method: "POST",
+            body: JSON.stringify(options.jsonBody),
+            headers: {
+              ...(options.headers ?? {}),
+              "content-type": "application/json",
+            },
+          }
+          : { headers: options.headers }),
         signal: controller.signal,
       });
       if (!response.ok) return undefined;
@@ -316,6 +358,7 @@ function shouldQueryLiveEndpoint(
   return (
     provider === "lmstudio" ||
     provider === "openai-compatible" ||
+    provider === "ollama" ||
     Boolean(providerConfig?.base_url?.trim()) ||
     Boolean(envBaseUrl(provider, env))
   );
@@ -703,6 +746,34 @@ function providerBaseUrl(
   return envBaseURL || configured || defaultProviderBaseUrl(provider);
 }
 
+/**
+ * Ollama's native API sits at the origin while its OpenAI-compatible surface
+ * lives under `/v1`, so a base URL configured for either one has to collapse
+ * to the same `/api/show`.
+ */
+export function ollamaShowUrlFromBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  const origin = trimmed.replace(/\/(?:v\d+(?:beta)?|api\/v\d+)$/i, "");
+  return `${origin}/api/show`;
+}
+
+function metadataFromOllamaShowResponse(
+  response: unknown,
+): ModelMetadataValues | undefined {
+  const modelInfo = asRecord(asRecord(response)?.model_info);
+  if (!modelInfo) return undefined;
+  // The key is architecture-prefixed (`qwen2.context_length`, `phi2.…`), and
+  // the architecture is not knowable from the model name, so match the suffix.
+  for (const [key, value] of Object.entries(modelInfo)) {
+    if (!/(?:^|\.)context_length$/.test(key)) continue;
+    if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+      continue;
+    }
+    return { contextWindow: value };
+  }
+  return undefined;
+}
+
 function modelsUrlFromBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
   if (trimmed.endsWith("/models")) return trimmed;
@@ -735,6 +806,11 @@ function envBaseUrl(
       return nonEmpty(env.OPENAI_BASE_URL);
     case "lmstudio":
       return nonEmpty(env.LMSTUDIO_BASE_URL) ?? nonEmpty(env.OPENAI_BASE_URL);
+    // The provider factory already resolves OLLAMA_BASE_URL; without this the
+    // metadata lookup silently probed localhost while the session talked to a
+    // different host.
+    case "ollama":
+      return nonEmpty(env.OLLAMA_BASE_URL);
     case "openai-compatible":
       return (
         nonEmpty(env.OPENAI_COMPATIBLE_BASE_URL) ??

--- a/runtime/tests/llm/model-metadata.local-providers.test.ts
+++ b/runtime/tests/llm/model-metadata.local-providers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   ModelMetadataResolver,
+  lmStudioModelsUrl,
   ollamaShowUrlFromBaseUrl,
 } from "../../src/llm/model-metadata.js";
 import type { AgenCConfig } from "../../src/utils/config.js";
@@ -205,6 +206,119 @@ describe("local providers resolve the real context window", () => {
 
     expect(resolved.source).not.toBe("live_endpoint");
     expect(resolved.contextWindow).toBeGreaterThan(0);
+  });
+
+  test("llama.cpp reports the window nested under meta", async () => {
+    // Recorded from llama-server b10549 started with `-c 4096` on a 32k
+    // model: n_ctx is what the server honours, n_ctx_train is the model's
+    // trained maximum. Serving 32768 here would be refused at 4097.
+    const { impl, calls } = recordingFetch({
+      "http://127.0.0.1:8080/v1/models": {
+        json: {
+          object: "list",
+          data: [
+            {
+              id: "local.gguf",
+              object: "model",
+              owned_by: "llamacpp",
+              meta: {
+                vocab_type: 2,
+                n_vocab: 151936,
+                n_ctx: 4096,
+                n_ctx_train: 32768,
+                n_embd: 1536,
+              },
+            },
+          ],
+        },
+      },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { OPENAI_COMPATIBLE_BASE_URL: "http://127.0.0.1:8080/v1" },
+    }).resolve({
+      provider: "openai-compatible",
+      model: "local.gguf",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.contextWindow).toBe(4096);
+    expect(resolved.source).toBe("live_endpoint");
+    // The compatible surface answered, so no native endpoint is consulted.
+    expect(calls).toHaveLength(1);
+  });
+
+  test("llama.cpp falls back to the trained window when none is served", async () => {
+    const { impl } = recordingFetch({
+      "http://127.0.0.1:8080/v1/models": {
+        json: {
+          object: "list",
+          data: [{ id: "local.gguf", meta: { n_ctx_train: 32768 } }],
+        },
+      },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { OPENAI_COMPATIBLE_BASE_URL: "http://127.0.0.1:8080/v1" },
+    }).resolve({
+      provider: "openai-compatible",
+      model: "local.gguf",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.contextWindow).toBe(32768);
+  });
+
+  test("LM Studio's loaded window beats its advertised maximum", async () => {
+    // A model loaded at 8k on a 32k architecture refuses at 8k+1, so the
+    // maximum must not be what the runtime plans against.
+    const { impl, calls } = recordingFetch({
+      "http://127.0.0.1:1234/v1/models": {
+        json: { object: "list", data: [{ id: "qwen2.5-7b-instruct" }] },
+      },
+      "http://127.0.0.1:1234/api/v0/models": {
+        json: {
+          object: "list",
+          data: [
+            {
+              id: "qwen2.5-7b-instruct",
+              object: "model",
+              type: "llm",
+              arch: "qwen2",
+              state: "loaded",
+              max_context_length: 32768,
+              loaded_context_length: 8192,
+            },
+          ],
+        },
+      },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { LMSTUDIO_BASE_URL: "http://127.0.0.1:1234/v1" },
+    }).resolve({
+      provider: "lmstudio",
+      model: "qwen2.5-7b-instruct",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.contextWindow).toBe(8192);
+    // Compatible surface first, then Ollama's endpoint (absent here), then
+    // LM Studio's own.
+    expect(calls.map((call) => call.url)).toEqual([
+      "http://127.0.0.1:1234/v1/models",
+      "http://127.0.0.1:1234/api/show",
+      "http://127.0.0.1:1234/api/v0/models",
+    ]);
+  });
+
+  test("lmStudioModelsUrl collapses the compatible surface", () => {
+    expect(lmStudioModelsUrl("http://127.0.0.1:1234/v1")).toBe(
+      "http://127.0.0.1:1234/api/v0/models",
+    );
+    expect(lmStudioModelsUrl("http://127.0.0.1:1234")).toBe(
+      "http://127.0.0.1:1234/api/v0/models",
+    );
   });
 
   test("a malformed context length is ignored rather than trusted", async () => {

--- a/runtime/tests/llm/model-metadata.local-providers.test.ts
+++ b/runtime/tests/llm/model-metadata.local-providers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 
 import {
   ModelMetadataResolver,
-  lmStudioModelsUrl,
   ollamaShowUrlFromBaseUrl,
 } from "../../src/llm/model-metadata.js";
 import type { AgenCConfig } from "../../src/utils/config.js";
@@ -267,58 +266,6 @@ describe("local providers resolve the real context window", () => {
     });
 
     expect(resolved.contextWindow).toBe(32768);
-  });
-
-  test("LM Studio's loaded window beats its advertised maximum", async () => {
-    // A model loaded at 8k on a 32k architecture refuses at 8k+1, so the
-    // maximum must not be what the runtime plans against.
-    const { impl, calls } = recordingFetch({
-      "http://127.0.0.1:1234/v1/models": {
-        json: { object: "list", data: [{ id: "qwen2.5-7b-instruct" }] },
-      },
-      "http://127.0.0.1:1234/api/v0/models": {
-        json: {
-          object: "list",
-          data: [
-            {
-              id: "qwen2.5-7b-instruct",
-              object: "model",
-              type: "llm",
-              arch: "qwen2",
-              state: "loaded",
-              max_context_length: 32768,
-              loaded_context_length: 8192,
-            },
-          ],
-        },
-      },
-    });
-    const resolved = await new ModelMetadataResolver({
-      fetchImpl: impl,
-      env: { LMSTUDIO_BASE_URL: "http://127.0.0.1:1234/v1" },
-    }).resolve({
-      provider: "lmstudio",
-      model: "qwen2.5-7b-instruct",
-      config: EMPTY_CONFIG,
-    });
-
-    expect(resolved.contextWindow).toBe(8192);
-    // Compatible surface first, then Ollama's endpoint (absent here), then
-    // LM Studio's own.
-    expect(calls.map((call) => call.url)).toEqual([
-      "http://127.0.0.1:1234/v1/models",
-      "http://127.0.0.1:1234/api/show",
-      "http://127.0.0.1:1234/api/v0/models",
-    ]);
-  });
-
-  test("lmStudioModelsUrl collapses the compatible surface", () => {
-    expect(lmStudioModelsUrl("http://127.0.0.1:1234/v1")).toBe(
-      "http://127.0.0.1:1234/api/v0/models",
-    );
-    expect(lmStudioModelsUrl("http://127.0.0.1:1234")).toBe(
-      "http://127.0.0.1:1234/api/v0/models",
-    );
   });
 
   test("a malformed context length is ignored rather than trusted", async () => {

--- a/runtime/tests/llm/model-metadata.local-providers.test.ts
+++ b/runtime/tests/llm/model-metadata.local-providers.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  ModelMetadataResolver,
+  ollamaShowUrlFromBaseUrl,
+} from "../../src/llm/model-metadata.js";
+import type { AgenCConfig } from "../../src/utils/config.js";
+
+const EMPTY_CONFIG = {} as unknown as AgenCConfig;
+
+/**
+ * Recorded from a live Ollama 0.32.15. Its OpenAI-compatible surface reports
+ * no context length at all, which is why a local model silently inherited the
+ * 128k conservative fallback: qwen2.5-coder:1.5b is really 32k and moondream
+ * is really 2k, so the runtime planned against a window up to 62x too large.
+ */
+const OLLAMA_V1_MODELS = {
+  object: "list",
+  data: [
+    {
+      id: "qwen2.5-coder:1.5b",
+      object: "model",
+      created: 1787325306,
+      owned_by: "library",
+    },
+  ],
+};
+
+const OLLAMA_SHOW = {
+  capabilities: ["completion", "tools", "insert"],
+  model_info: {
+    "general.architecture": "qwen2",
+    "qwen2.block_count": 28,
+    "qwen2.context_length": 32768,
+  },
+};
+
+interface Call {
+  readonly url: string;
+  readonly method: string;
+  readonly body?: string;
+}
+
+function recordingFetch(
+  routes: Readonly<Record<string, { status?: number; json: unknown }>>,
+): { impl: typeof fetch; calls: Call[] } {
+  const calls: Call[] = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({
+      url,
+      method: init?.method ?? "GET",
+      ...(typeof init?.body === "string" ? { body: init.body } : {}),
+    });
+    const route = routes[url];
+    if (route === undefined) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(JSON.stringify(route.json), {
+      status: route.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe("ollamaShowUrlFromBaseUrl", () => {
+  test("collapses the OpenAI-compatible surface onto the native API", () => {
+    // Ollama's native API sits at the origin while /v1 hosts the compatible
+    // surface, so both spellings of the same server must agree.
+    expect(ollamaShowUrlFromBaseUrl("http://127.0.0.1:11434")).toBe(
+      "http://127.0.0.1:11434/api/show",
+    );
+    expect(ollamaShowUrlFromBaseUrl("http://127.0.0.1:11434/v1")).toBe(
+      "http://127.0.0.1:11434/api/show",
+    );
+    expect(ollamaShowUrlFromBaseUrl("http://127.0.0.1:11434/v1/")).toBe(
+      "http://127.0.0.1:11434/api/show",
+    );
+    expect(ollamaShowUrlFromBaseUrl("https://box.local:11434")).toBe(
+      "https://box.local:11434/api/show",
+    );
+  });
+});
+
+describe("local providers resolve the real context window", () => {
+  test("ollama reads the architecture-prefixed context length", async () => {
+    const { impl, calls } = recordingFetch({
+      "http://127.0.0.1:11434/api/show": { json: OLLAMA_SHOW },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { OLLAMA_BASE_URL: "http://127.0.0.1:11434" },
+    }).resolve({
+      provider: "ollama",
+      model: "qwen2.5-coder:1.5b",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.contextWindow).toBe(32768);
+    expect(resolved.source).toBe("live_endpoint");
+    expect(resolved.usedFallbackModelMetadata).toBe(false);
+    // The native endpoint is a POST carrying the model, and the OpenAI-shaped
+    // models list is never consulted for ollama -- it has nothing to give.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.body!)).toEqual({ model: "qwen2.5-coder:1.5b" });
+  });
+
+  test("OLLAMA_BASE_URL is honoured instead of the built-in default", async () => {
+    // The provider factory already resolved this variable; the metadata
+    // lookup used to ignore it and probe localhost while the session talked
+    // to another host.
+    const { impl, calls } = recordingFetch({
+      "http://10.0.0.7:11434/api/show": { json: OLLAMA_SHOW },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { OLLAMA_BASE_URL: "http://10.0.0.7:11434" },
+    }).resolve({
+      provider: "ollama",
+      model: "qwen2.5-coder:1.5b",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.contextWindow).toBe(32768);
+    expect(calls.map((call) => call.url)).toEqual([
+      "http://10.0.0.7:11434/api/show",
+    ]);
+  });
+
+  for (
+    const [provider, envKey] of [
+      ["openai-compatible", "OPENAI_COMPATIBLE_BASE_URL"],
+      ["lmstudio", "LMSTUDIO_BASE_URL"],
+    ] as const
+  ) {
+    test(`${provider} pointed at Ollama falls back to the native probe`, async () => {
+      const { impl, calls } = recordingFetch({
+        "http://127.0.0.1:11434/v1/models": { json: OLLAMA_V1_MODELS },
+        "http://127.0.0.1:11434/api/show": { json: OLLAMA_SHOW },
+      });
+      const resolved = await new ModelMetadataResolver({
+        fetchImpl: impl,
+        env: { [envKey]: "http://127.0.0.1:11434/v1" },
+      }).resolve({
+        provider,
+        model: "qwen2.5-coder:1.5b",
+        config: EMPTY_CONFIG,
+      });
+
+      expect(resolved.contextWindow).toBe(32768);
+      expect(resolved.source).toBe("live_endpoint");
+      // The compatible surface is tried first and yields no window, so the
+      // native endpoint is consulted second.
+      expect(calls.map((call) => call.url)).toEqual([
+        "http://127.0.0.1:11434/v1/models",
+        "http://127.0.0.1:11434/api/show",
+      ]);
+    });
+  }
+
+  test("a compatible server that already reports a window is not probed twice", async () => {
+    // vLLM and friends expose max_model_len on /v1/models; that answer wins
+    // and no native request is issued.
+    const { impl, calls } = recordingFetch({
+      "http://127.0.0.1:8000/v1/models": {
+        json: {
+          object: "list",
+          data: [{ id: "local-model", max_model_len: 8192 }],
+        },
+      },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { OPENAI_COMPATIBLE_BASE_URL: "http://127.0.0.1:8000/v1" },
+    }).resolve({
+      provider: "openai-compatible",
+      model: "local-model",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.contextWindow).toBe(8192);
+    expect(calls.map((call) => call.url)).toEqual([
+      "http://127.0.0.1:8000/v1/models",
+    ]);
+  });
+
+  test("a non-Ollama server that rejects the native probe still resolves", async () => {
+    // The extra POST must never turn a working setup into a failure: an
+    // unknown server 404s and the resolver falls through its usual chain.
+    const { impl } = recordingFetch({
+      "http://127.0.0.1:8000/v1/models": {
+        json: { object: "list", data: [{ id: "local-model" }] },
+      },
+    });
+    const resolved = await new ModelMetadataResolver({
+      fetchImpl: impl,
+      env: { OPENAI_COMPATIBLE_BASE_URL: "http://127.0.0.1:8000/v1" },
+    }).resolve({
+      provider: "openai-compatible",
+      model: "local-model",
+      config: EMPTY_CONFIG,
+    });
+
+    expect(resolved.source).not.toBe("live_endpoint");
+    expect(resolved.contextWindow).toBeGreaterThan(0);
+  });
+
+  test("a malformed context length is ignored rather than trusted", async () => {
+    for (
+      const value of [0, -1, 1.5, "32768", null] as const
+    ) {
+      const { impl } = recordingFetch({
+        "http://127.0.0.1:11434/api/show": {
+          json: { model_info: { "qwen2.context_length": value } },
+        },
+      });
+      const resolved = await new ModelMetadataResolver({
+        fetchImpl: impl,
+        env: { OLLAMA_BASE_URL: "http://127.0.0.1:11434" },
+      }).resolve({
+        provider: "ollama",
+        model: "qwen2.5-coder:1.5b",
+        config: EMPTY_CONFIG,
+      });
+      expect(resolved.source, String(value)).not.toBe("live_endpoint");
+    }
+  });
+});


### PR DESCRIPTION
## The defect, measured against a live server

Ollama's OpenAI-compatible surface publishes no context length. Recorded from Ollama 0.32.15:

```
GET /v1/models
{"object":"list","data":[{"id":"qwen2.5-coder:1.5b","object":"model",
                          "created":1787325306,"owned_by":"library"}]}
```

There is no window in that payload, so `metadataFromOpenAiModelsResponse` finds the model and returns nothing, and every local model lands on the 128k conservative fallback. Measured with a real Ollama running two pulled models, through `ModelMetadataResolver.resolve` with a real `fetch`:

| model | real window | before | after |
|---|---|---|---|
| `qwen2.5-coder:1.5b` | 32768 | 128000 (`conservative_fallback`) | 32768 (`live_endpoint`) |
| `moondream` | 2048 | 128000 (`conservative_fallback`) | 2048 (`live_endpoint`) |

Planning a turn against a window up to 62× larger than the server's is how a local session ends in truncation or a refused request — and nothing downstream can recover, because no component in the chain knows the real number.

## Where the number actually lives

Ollama's native `/api/show` reports it under an architecture-prefixed key, which is why a plain field lookup never found it:

```
POST /api/show {"model":"qwen2.5-coder:1.5b"}
  model_info["qwen2.context_length"] = 32768
  capabilities = ["completion","tools","insert"]
```

The architecture is not derivable from the model name (`moondream` reports `phi2.context_length`), so the resolver matches the key suffix.

## Every local runtime, not just Ollama

Each runtime publishes its window somewhere different, and the flat field lookup only knew a handful of spellings. Recorded from real servers on one host:

| runtime | where the window lives | before | after |
|---|---|---|---|
| Ollama | `/api/show` → `model_info["<arch>.context_length"]` | 128000 | real (32768 / 2048) |
| llama.cpp | `/v1/models` → `meta.n_ctx` (served), `meta.n_ctx_train` (trained) | 128000 | 4096 |
| vLLM | `/v1/models` → `max_model_len` | already worked | unchanged |

Every row above was measured against a server actually running on one host. **LM Studio is deliberately absent**: its CLI needs the desktop backend, so it could not be started headless here, and a probe written from its published API shape — with tests written from that same shape — would only prove the code matches my assumption. LM Studio users still get whatever window their compatible surface reports; the native probe can land later with a real recording behind it.

The **served** window beats the advertised maximum: `llama-server -c 4096` on a 32k model refuses at 4097, so planning against 32768 is planning to fail.

## Change

- `ollama` joins the live-metadata providers and resolves through `/api/show`; its OpenAI-shaped models list is never consulted, since it has nothing to give.
- `openai-compatible` and `lmstudio` pointed at an Ollama endpoint — a common setup — fall back to the native probe **only** when the compatible surface carries no window. A server that already reports one (vLLM's `max_model_len`) wins as before and is never probed twice; an unknown server 404s and the resolver falls through its usual chain unchanged.
- `OLLAMA_BASE_URL` is honoured in the metadata path. The provider factory already resolved it, so a non-default host answered sessions while metadata silently probed `localhost`.
- `fetchJson` gained an optional JSON body (the native endpoint is a POST); the request cache key includes it.

## Tests

Ten added in `runtime/tests/llm/model-metadata.local-providers.test.ts`, driven by a recording fake fetch built from the payloads above: URL derivation (`/v1` collapses onto the native origin), the architecture-prefixed lookup, `OLLAMA_BASE_URL` targeting, both compatible providers falling back, the vLLM path staying single-request, a 404 native probe not breaking a working setup, and malformed windows (`0`, `-1`, `1.5`, `"32768"`, `null`) being ignored rather than trusted.

Live coverage on one host: Ollama 0.32.15 (32768 for qwen2.5-coder:1.5b, 2048 for moondream) and llama-server b10549 serving the same GGUF (4096, through both the `openai-compatible` and `lmstudio` providers).

Falsification: reverting only `model-metadata.ts` fails five of them with `expected 128000 to be 32768` — the defect on camera — while the three non-regression tests keep passing on both sides. The whole `tests/llm` area is 1050/1050 with the change.

## Follow-up, not in this PR

`/api/show` also returns `capabilities`, which core currently guesses. `capabilities` for `moondream` is `["completion","vision"]` — **no `tools`** — yet `runtime/src/llm/capabilities.ts` declares `supportsToolUse: true` unconditionally for ollama, so the runtime sends tool definitions to a model that cannot call them. Vision is likewise inferred from a regex on the model name (`isVisionishOllamaModel`) when the server states it outright. Fixing that means changing how capabilities resolve (they are synchronous at model-switch time today), so it belongs in its own change.
