### PR TITLE
Bound daemon-autostart restarts and register plugin MCP servers

### DIFF
--- a/docs/daemon-autostart-spin-2026-08-23.md
+++ b/docs/daemon-autostart-spin-2026-08-23.md
@@ -1,0 +1,88 @@
+# TUI startup spin: unbounded daemon-autostart retry with blank screen
+
+Found 2026-08-23 while live-testing the agenc-goal plugin. Severity: high (session-blocking, silent, CPU-burning).
+
+**Status: FIXED same day.** Root cause was unbounded tail self-recursion in `ensureAgenCDaemonAutostart` (the legacy identity-less restart and build-skew restart both re-entered the whole cycle with no cap or backoff). Fix: restart cycles are now capped at 3 with escalating backoff, giving up with a typed `AgenCDaemonAutostartError` naming the repeating reason; the default CLI route passes real stderr into autostart (respawn reasons were previously swallowed by `silentIo()`) and, on failure in a TTY, boots the TUI anyway with a `daemon-autostart-failed` error notice instead of a blank exit. Live-verified against the deterministic repro below: the formerly infinite spin now prints four visible respawn lines and fails cleanly in 3 seconds. The plugin MCP catalog gap (second finding below) turned out to be a three-link chain, all fixed: (1) plugin-declared servers were never merged into the session MCP source list (now merged in `resolveSessionMcpConfigFromSources` and the refresh path, with the session config and env threaded through so enablement and AGENC_HOME resolve correctly — without the config every plugin loads as disabled; without the env the loader falls back to process.env); (2) `${CLAUDE_PLUGIN_ROOT}` templates from Claude-Code-ecosystem plugins were not aliased to `${AGENC_PLUGIN_ROOT}` and fell through to env-var expansion, dropping the server with "Missing environment variables: CLAUDE_PLUGIN_ROOT" (CLAUDE_* aliases now resolve). The project-scope silent component strip (3) now warns at install time.
+
+## Symptom
+
+When the daemon is not running and autostart cannot bring one up, `agenc` (TUI) burns ~200% CPU indefinitely with a completely blank screen. No error text, no status notice, no project state created, no stderr output. Observed for 12+ minutes with no change. In one instance the process appeared to die via the heap-limit path (`--heapsnapshot-near-heap-limit=1`), taking the terminal window with it.
+
+The same environment renders fine within seconds once any TUI instance manages to start the daemon: the failure mode only exists while autostart keeps failing.
+
+## Deterministic repro
+
+1. Build an isolated AGENC_HOME (must be a short path: `daemon.sock` hits the 108-char AF_UNIX limit):
+   - copy `config.toml`, `auth.json`, `onboarding.json`, `.credentials.json`, `trusted-projects.json`, `daemon.cookie` from a real home
+   - copy the real `daemon-lifecycle.lock.sqlite`
+   - create a dead `daemon.sock` (bind a unix socket, close it, leave the file)
+   - write a `daemon-snapshot.json` with `{"reason":"daemon_shutdown", ...}`
+   - `chmod 700` the dir (group-writable homes are refused cleanly with "protected directory chain permits untrusted mutation", which is the good, graceful path)
+2. `AGENC_HOME=<that dir> agenc` in a trusted project.
+3. Blank screen, ~194% CPU, `daemon.pid` in the home keeps being rewritten for minutes.
+
+First seen organically: `~/.agenc` daemon dead since a prior shutdown, stale `daemon.sock`, and the first TUI launched from an environment that could not complete daemon spawn (a sandbox that blocks `~/.agenc` writes). Orphaned spinners then kept later launches failing too.
+
+## Root cause (profiled)
+
+4s CPU profile of the spinning process (inspector attach via `kill -USR1`, samples: 15543):
+
+```
+2.9%  mutate                                   bin/agenc-main.js:9695
+2.9%  readBoundedLinuxProcIdentityFile         dist/chunk-SIYD475Q.js:931
+2.9%  findLinuxAgenCDaemonProcesses            dist/chunk-SIYD475Q.js:679
+2.8%  spawnDetachedDaemon                      bin/agenc-main.js:13447 / 13100
+1.9%  inspectLinuxAgenCDaemonProcessWithTracker dist/chunk-SIYD475Q.js:746
+1.8%  readAgenCDaemonProcessStart              dist/chunk-SIYD475Q.js:609
+0.8%  acquireSqliteDatabase                    dist/chunk-AGZJ7IH3.js:3119
+0.3%  ensureAgenCDaemonAutostart               bin/agenc-main.js:13377
+```
+
+Plus 24% of samples in the garbage collector (allocation churn) and ~50% idle (the loop yields constantly but never stops). Source: `runtime/src/app-server/daemon-autostart.ts` and `daemon-instance-identity.ts`.
+
+`ensureAgenCDaemonAutostart` is re-entered continuously. Each attempt:
+
+- spawns a detached daemon (`spawnDetachedDaemon`)
+- scans the entire `/proc` list for daemon identity (`findLinuxAgenCDaemonProcesses` → `readProcList` → `readBoundedLinuxProcIdentityFile` / `readProcEnv` per PID)
+- opens and validates the SQLite lifecycle lock (`acquireSqliteDatabase`, `beginAndValidateLock`)
+- repairs `daemon.pid` (file keeps being rewritten)
+
+The inner wait loops in `daemon-autostart.ts` do have `host.sleep(...)` polling, but the overall ensure cycle has no backoff, no attempt cap, and no terminal failure state that reaches the TUI. When every attempt fails fast (identity mismatch against a stale lifecycle record, spawn dying immediately, lock contention with another spinner), the cycle rate is bounded only by how fast one attempt fails, i.e. hundreds per minute, each doing a full /proc sweep and a process spawn.
+
+Meanwhile the TUI renders nothing until the daemon connection exists, so the user sees a dead blank terminal.
+
+## Suggested fix shape
+
+1. Exponential backoff + attempt cap in the ensure/autostart cycle (e.g. 1s, 2s, 4s ... cap 30s; give up after N minutes into a terminal error state).
+2. On terminal failure, surface a status notice (precedent exists: `statusNoticeDefinitions.tsx` `daemon-autostart-disabled`) and render the TUI shell regardless — the TUI should paint before daemon readiness, with a "daemon unavailable" banner, instead of staying blank.
+3. `daemon-spawn-stderr.log` stayed empty through all of this; the spawn failure reason should be captured somewhere inspectable.
+4. Orphan protection: two TUIs both stuck in this loop compound each other via the lifecycle lock; a backoff plus jitter also mitigates that.
+
+## Second high-severity finding: plugin MCP servers spawn but their tools never reach the catalog
+
+With the agenc-goal plugin installed at USER scope (authority-controlled, so MCP is allowed), the TUI spawns the plugin's MCP server process (`node .../bin/goal-server.mjs` visible in ps), but the server's tools are absent from the model's tool catalog. Tool search with explicit selections returns:
+
+```
+Select tools: mcp.agenc-goal.goal_create, mcp.agenc-goal.goal_update, mcp.agenc-goal.goal_get
+{"totalCatalogSize":88,"loaded":[],"missingSelections":["mcp.agenc-goal.goal_create","mcp.agenc-goal.goal_update","mcp.agenc-goal.goal_get"]}
+```
+
+So the model can never call any plugin MCP tool, and it burns tokens searching, reading plugin source, and trying shell fallbacks (one grok-4.5 session spent >$7 flailing on this). Likely related to the known "live-agent MCP refresh no-op" backlog item: the server connects, but tool registration/refresh into the live catalog never happens for plugin-sourced MCP servers. Plugin slash commands and agents from the same plugin DO register (`/agenc-goal:goal` and the goal-planner agent both worked).
+
+## Remaining platform gap: MCP stdio is fully broken on Landlock-fallback machines
+
+With the four integration fixes in place, the plugin MCP server is resolved, handed to the live manager, and spawned through `agenc-linux-sandbox`, but on this machine every connect still fails with `MCP error -32000: Connection closed` because the sandbox launcher exits before exec:
+
+```
+bubblewrap is unavailable and the Landlock fallback cannot express this policy:
+a writable root carries an existing read-only subpath, which an allow-list
+cannot express: <project>/.agenc   (or <project>/.git in git projects)
+```
+
+The mcp_stdio permission profile is `root: read, project_roots: write, tmpdir: write` with platform defaults that carve `<project>/.agenc` (and `.git`) out as read-only. A writable root with a read-only subpath is exactly what a Landlock allow-list cannot express, and agenc always creates `<project>/.agenc`, so on machines where bubblewrap is unusable (here: bwrap is installed but blocked by the Ubuntu AppArmor unprivileged-userns restriction, the same condition the installer already warns about) EVERY stdio MCP server fails — plugin-sourced or user-configured. Fail-closed is the intended posture (#1516), so this is a deliberate-tradeoff decision, not a patch: either teach the Landlock fallback to drop the read-only carve-outs with a warning, or surface a specific "MCP unavailable without bubblewrap" error instead of the generic connection-closed. On bubblewrap-capable machines the plugin MCP chain should now work end to end.
+
+## Related smaller findings from the same session
+
+- Sandbox policy: in /tmp-rooted projects, "bubblewrap is unavailable and the Landlock fallback cannot express this policy: a writable root carries an existing read-only subpath (.git)" blocks ALL model shell in the project. May be worth a friendlier degradation.
+- AF_UNIX 108-char limit: an AGENC_HOME under a deep path cannot create `daemon.sock` at all; worth an explicit error (the generic autostart failure message does fire, at least on the perms path).
+- Plugin scopes: project-scope plugin installs are `repository-controlled` (`plugins/loader.ts` `contentProvenanceForPath`) and silently drop hooks + MCP servers. Correct security posture, but "silently" is rough: `agenc plugin install --scope project` on a plugin that ships MCP/hooks should warn that those components will not load at this scope.

--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -69,6 +69,18 @@ const AGENC_DAEMON_BUILD_SKEW_STOP_TIMEOUT_MS = 5_000;
 const AGENC_DAEMON_ORPHAN_STOP_TIMEOUT_MS = 1_000;
 const AGENC_DAEMON_FORCE_STOP_GRACE_MS = 2_000;
 const AGENC_DAEMON_STOP_POLL_MS = 50;
+/**
+ * Restart-cycle bound for the two self-restart paths (legacy identity-less
+ * daemon, build-identity skew). When the condition that forced a restart is a
+ * permanent property of the environment — e.g. the spawned daemon resolves a
+ * different dist/VERSION than the CLI — an unbounded retry respawns a daemon
+ * and rescans /proc forever at ~200% CPU behind a blank screen. Three cycles
+ * with backoff is enough for every transient case (an old daemon finishing
+ * shutdown, a race with a concurrent CLI); after that the environment is
+ * broken and the operator needs the error.
+ */
+const AGENC_DAEMON_AUTOSTART_MAX_RESTART_CYCLES = 3;
+const AGENC_DAEMON_AUTOSTART_RESTART_BACKOFF_MS = [250, 1_000, 4_000] as const;
 
 export interface AgenCDaemonConnectionTarget {
   readonly pid: number;
@@ -199,6 +211,48 @@ export async function resolveAgenCDaemonAutostartConfig(
 
 export async function ensureAgenCDaemonAutostart(
   options: AgenCDaemonAutostartOptions = {},
+): Promise<AgenCDaemonAutostartResult> {
+  return ensureAgenCDaemonAutostartCycle(options, 0);
+}
+
+/**
+ * Bounded restart-and-retry for the self-restart paths inside the ensure
+ * cycle. `restartCycle` counts how many times the whole cycle has already
+ * re-entered itself; past the cap the environment is treated as broken and a
+ * typed error carries the repeating reason to the caller instead of spinning.
+ */
+async function retryAutostartAfterRestart(
+  options: AgenCDaemonAutostartOptions,
+  restartCycle: number,
+  host: AgenCDaemonAutostartHost,
+  reason: string,
+): Promise<AgenCDaemonAutostartResult> {
+  if (restartCycle >= AGENC_DAEMON_AUTOSTART_MAX_RESTART_CYCLES) {
+    throw new AgenCDaemonAutostartError(
+      `AgenC daemon autostart gave up after ${restartCycle} restart cycles: ${reason} on every attempt. ` +
+        `Inspect the daemon with \`agenc daemon status\`, stop it with \`agenc daemon stop\`, and check that the ` +
+        `installed runtime and the daemon entrypoint resolve the same build before retrying.`,
+    );
+  }
+  // The first restart is the common legitimate case (e.g. a runtime upgrade
+  // replacing a skewed daemon) and stays immediate; backoff only applies once
+  // the condition repeats, which is where the historical spin lived.
+  if (restartCycle > 0) {
+    await host.sleep(
+      AGENC_DAEMON_AUTOSTART_RESTART_BACKOFF_MS[
+        Math.min(
+          restartCycle - 1,
+          AGENC_DAEMON_AUTOSTART_RESTART_BACKOFF_MS.length - 1,
+        )
+      ],
+    );
+  }
+  return ensureAgenCDaemonAutostartCycle(options, restartCycle + 1);
+}
+
+async function ensureAgenCDaemonAutostartCycle(
+  options: AgenCDaemonAutostartOptions,
+  restartCycle: number,
 ): Promise<AgenCDaemonAutostartResult> {
   const host: AgenCDaemonAutostartHost =
     options.host ?? createNodeDaemonCliHost();
@@ -465,7 +519,12 @@ export async function ensureAgenCDaemonAutostart(
           removeDaemonRuntimeInfo(runtimeInfoPath);
         }
       });
-      return ensureAgenCDaemonAutostart(options);
+      return retryAutostartAfterRestart(
+        options,
+        restartCycle,
+        host,
+        "the recorded daemon lacked a portable instance identity and had to be restarted",
+      );
     }
 
     let verifiedInstance: BoundAgenCDaemonInstance | null;
@@ -525,7 +584,12 @@ export async function ensureAgenCDaemonAutostart(
       } catch (error) {
         throw error;
       }
-      return ensureAgenCDaemonAutostart(options);
+      return retryAutostartAfterRestart(
+        options,
+        restartCycle,
+        host,
+        "the daemon build identity differed from the on-disk runtime and it was restarted",
+      );
     }
     try {
       await reapSupersededAgenCDaemons({

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -5445,12 +5445,28 @@ async function runDefaultAgenCCliRoute(
     (await resolveAgenCDaemonAutostartEnabled(process.env))
   ) {
     try {
-      await ensureAgenCDaemonAutostart();
+      // Surface respawn reasons on stderr instead of the historical
+      // silentIo(): a failing autostart used to look like a frozen blank
+      // terminal. Keep stdout quiet so the daemon CLI banner stays out of
+      // interactive TUI rendering (mirrors defaultEnsureDaemonReady).
+      const silentStdout = { write: () => true } as Pick<
+        NodeJS.WriteStream,
+        "write"
+      >;
+      await ensureAgenCDaemonAutostart({
+        io: { stdout: silentStdout, stderr: process.stderr },
+      });
     } catch (error) {
-      process.stderr.write(
-        `agenc: daemon autostart failed: ${error instanceof Error ? error.message : String(error)}\n`,
-      );
-      return 1;
+      const message =
+        error instanceof Error ? error.message : String(error);
+      process.stderr.write(`agenc: daemon autostart failed: ${message}\n`);
+      if (!process.stdout.isTTY) {
+        return 1;
+      }
+      // Interactive sessions still get a working (daemon-less) TUI with a
+      // visible error notice rather than an exit back to the shell. The
+      // notice reads this env var at render time (StatusNotices).
+      process.env.AGENC_DAEMON_AUTOSTART_FAILURE = message;
     }
   }
   return routeCLI({

--- a/runtime/src/plugins/cli/pluginCliCommands.ts
+++ b/runtime/src/plugins/cli/pluginCliCommands.ts
@@ -1,3 +1,5 @@
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
 import type { ValidationResult } from "../validation.js";
 import {
   disableAllPluginsOp,
@@ -107,6 +109,49 @@ export function parseAgenCPluginCliArgs(
   }
 }
 
+/**
+ * Names the plugin components a non-user-scope (repository-controlled)
+ * install will silently strip: hooks and MCP servers. Checks both the
+ * conventional component files and the manifest declarations.
+ */
+async function detectProvenanceStrippedComponents(
+  pluginRoot: string,
+): Promise<string[]> {
+  const exists = async (path: string): Promise<boolean> => {
+    try {
+      await stat(path);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  let manifest: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(
+      await readFile(join(pluginRoot, ".agenc-plugin", "plugin.json"), "utf8"),
+    );
+    if (parsed !== null && typeof parsed === "object") {
+      manifest = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // No readable manifest: fall back to the conventional file checks.
+  }
+  const stripped: string[] = [];
+  if (
+    (await exists(join(pluginRoot, "hooks", "hooks.json"))) ||
+    manifest.hooks !== undefined
+  ) {
+    stripped.push("hooks");
+  }
+  if (
+    (await exists(join(pluginRoot, ".mcp.json"))) ||
+    manifest.mcpServers !== undefined
+  ) {
+    stripped.push("MCP servers");
+  }
+  return stripped;
+}
+
 export async function runAgenCPluginCli(
   command: AgenCPluginCliCommand,
   options: AgenCPluginCliOptions = {},
@@ -148,6 +193,22 @@ export async function runAgenCPluginCli(
         io.stdout.write(
           `Installed plugin ${result.plugin.name} to ${result.scope} scope: ${result.destination}\n`,
         );
+        // Workspace-resident plugin content is repository-controlled, which
+        // strips hooks and MCP servers at load time (plugins/loader.ts). Say
+        // so at install time instead of letting those components vanish
+        // silently.
+        if (result.scope !== "user") {
+          const stripped = await detectProvenanceStrippedComponents(
+            result.destination,
+          );
+          if (stripped.length > 0) {
+            io.stderr.write(
+              `Warning: this plugin ships ${stripped.join(" and ")}, which do NOT load from ` +
+                `${result.scope} scope (workspace content is repository-controlled). ` +
+                `Install with --scope user to enable them.\n`,
+            );
+          }
+        }
         return 0;
       }
       case "uninstall": {

--- a/runtime/src/plugins/registration/common.ts
+++ b/runtime/src/plugins/registration/common.ts
@@ -316,10 +316,16 @@ function resolvePluginTemplate(
     pluginDataDir ??= formatTemplatePath(getPluginDataDir(plugin.source));
     return pluginDataDir;
   };
+  // CLAUDE_* forms are accepted as aliases: plugins written for Claude Code
+  // (the ecosystem agenc installs from) template with ${CLAUDE_PLUGIN_ROOT}
+  // et al., and an unconsumed template previously fell through to env-var
+  // expansion and killed the component with "Missing environment variables".
   let out = value
-    .replace(/\$\{AGENC_PLUGIN_ROOT\}/g, () => formatTemplatePath(plugin.root))
-    .replace(/\$\{AGENC_PLUGIN_DATA\}/g, () => dataDir())
-    .replace(/\$\{AGENC_SESSION_ID\}/g, () => options.sessionId ?? "");
+    .replace(/\$\{(?:AGENC|CLAUDE)_PLUGIN_ROOT\}/g, () =>
+      formatTemplatePath(plugin.root),
+    )
+    .replace(/\$\{(?:AGENC|CLAUDE)_PLUGIN_DATA\}/g, () => dataDir())
+    .replace(/\$\{(?:AGENC|CLAUDE)_SESSION_ID\}/g, () => options.sessionId ?? "");
   out = out.replace(/\$\{user_config\.([A-Za-z_][\w.-]*)\}/g, (_match, key: string) => {
     const value = pluginSettingValue(plugin, key, {
       exposeSensitive: options.exposeSensitive,

--- a/runtime/src/session/mcp-startup.ts
+++ b/runtime/src/session/mcp-startup.ts
@@ -48,6 +48,7 @@ import {
 import { runAdmittedModelCall } from "../budget/admitted-model-call.js";
 import type { AgenCConfig, McpServerConfig as AgenCMcpServerConfig } from "../config/schema.js";
 import { McpJsonConfigSchema, type McpServerConfig as ServiceMcpServerConfig } from "../services/mcp/types.js";
+import { loadPluginMcpServers } from "../plugins/registration/mcp-plugin-integration.js";
 import {
   createUnavailableSamplingResult,
   type McpSamplingHandlers,
@@ -84,6 +85,15 @@ export interface CreateSessionMcpServiceOptions {
 export interface ResolveSessionMcpConfigSourcesOptions {
   readonly cwd?: string;
   readonly includeProjectMcpServers?: boolean;
+  /**
+   * Merge MCP servers declared by enabled (authority-controlled) plugins.
+   * Default true: plugin MCP servers were historically loaded and sandboxed
+   * by the plugin registration pipeline but never handed to the live
+   * MCPManager, so their tools silently never reached the tool catalog.
+   */
+  readonly includePluginMcpServers?: boolean;
+  /** Test seam for the plugin MCP server source. */
+  readonly pluginMcpServerSource?: typeof loadPluginMcpServers;
   readonly sandboxExecutionBroker?: import("../sandbox/execution-broker.js").SandboxExecutionBrokerLike;
 }
 
@@ -694,8 +704,40 @@ export function resolveSessionMcpConfig(
   return getMcpConfigFromConfig(config);
 }
 
+/**
+ * MCP servers declared by enabled plugins, already scoped
+ * (`plugin:<plugin>:<server>`), env-substituted, and sandbox-annotated by
+ * the plugin registration pipeline. Failure-safe: a broken plugin must not
+ * take the whole session's MCP startup down with it.
+ */
+async function getPluginMcpConfig(
+  config: Pick<AgenCConfig, "plugins" | "enabledPlugins"> | undefined,
+  env: NodeJS.ProcessEnv,
+  options: ResolveSessionMcpConfigSourcesOptions,
+): Promise<MCPServerConfig[]> {
+  try {
+    const source = options.pluginMcpServerSource ?? loadPluginMcpServers;
+    // The loader needs the config's plugins section to know what is
+    // enabled (without it every plugin resolves as disabled) and the
+    // caller's env so AGENC_HOME resolution matches the session, not
+    // whatever process.env happens to hold.
+    const servers = await source({
+      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+      ...(config !== undefined ? { config } : {}),
+      env,
+    });
+    return Object.entries(servers).map(([name, server]) =>
+      toRuntimeMcpServerConfig(name, server),
+    );
+  } catch {
+    return [];
+  }
+}
+
 export async function resolveSessionMcpConfigFromSources(
-  config: Pick<AgenCConfig, "mcp_servers"> | undefined,
+  config:
+    | Pick<AgenCConfig, "mcp_servers" | "plugins" | "enabledPlugins">
+    | undefined,
   env: NodeJS.ProcessEnv = process.env,
   options: ResolveSessionMcpConfigSourcesOptions = {},
 ): Promise<MCPServerConfig[]> {
@@ -709,6 +751,15 @@ export async function resolveSessionMcpConfigFromSources(
   if (options.includeProjectMcpServers === true && options.cwd !== undefined) {
     for (const server of getProjectMcpConfigFromCwd(options.cwd)) {
       byName.set(server.name, server);
+    }
+  }
+  if (options.includePluginMcpServers !== false) {
+    // Plugin-scoped names never clobber config/project entries: an explicit
+    // config entry under the same scoped name is a deliberate override.
+    for (const server of await getPluginMcpConfig(config, env, options)) {
+      if (!byName.has(server.name)) {
+        byName.set(server.name, server);
+      }
     }
   }
   return [...byName.values()];
@@ -730,7 +781,9 @@ export function createSessionMcpManagerFromConfig(
 }
 
 export async function createSessionMcpManagerFromSources(
-  config: Pick<AgenCConfig, "mcp_servers"> | undefined,
+  config:
+    | Pick<AgenCConfig, "mcp_servers" | "plugins" | "enabledPlugins">
+    | undefined,
   env: NodeJS.ProcessEnv = process.env,
   options: ResolveSessionMcpConfigSourcesOptions = {},
 ): Promise<MCPManager> {
@@ -786,11 +839,31 @@ function withConfiguredRequiredServers(
 
 export async function refreshMcpManagerFromConfig(params: {
   readonly manager: MCPManager;
-  readonly config: Pick<AgenCConfig, "mcp_servers"> | undefined;
+  readonly config:
+    | Pick<AgenCConfig, "mcp_servers" | "plugins" | "enabledPlugins">
+    | undefined;
   readonly env?: NodeJS.ProcessEnv;
   readonly opts?: MCPManagerStartOpts;
+  readonly cwd?: string;
+  readonly includePluginMcpServers?: boolean;
+  /** Test seam for the plugin MCP server source. */
+  readonly pluginMcpServerSource?: typeof loadPluginMcpServers;
 }): Promise<McpRefreshResult> {
-  const configs = resolveSessionMcpConfig(params.config, params.env);
+  // Merge plugin-declared servers exactly like session startup does —
+  // otherwise a refresh would evict every plugin server the manager holds.
+  const configs = await resolveSessionMcpConfigFromSources(
+    params.config,
+    params.env,
+    {
+      ...(params.cwd !== undefined ? { cwd: params.cwd } : {}),
+      ...(params.includePluginMcpServers !== undefined
+        ? { includePluginMcpServers: params.includePluginMcpServers }
+        : {}),
+      ...(params.pluginMcpServerSource !== undefined
+        ? { pluginMcpServerSource: params.pluginMcpServerSource }
+        : {}),
+    },
+  );
   const requiredServers = requiredMcpServerNames(configs);
   await params.manager.refreshServers(
     configs,

--- a/runtime/src/tui/startup/StatusNotices.tsx
+++ b/runtime/src/tui/startup/StatusNotices.tsx
@@ -35,6 +35,13 @@ function isDaemonAutostartDisabled(): boolean {
   return value === '0' || value === 'false' || value === 'off';
 }
 
+// Set by the CLI entrypoint when ensureAgenCDaemonAutostart failed but the
+// interactive TUI boots anyway (agenc-main runDefaultAgenCCliRoute).
+function daemonAutostartFailure(): string | undefined {
+  const value = process.env.AGENC_DAEMON_AUTOSTART_FAILURE?.trim();
+  return value !== undefined && value.length > 0 ? value : undefined;
+}
+
 const noticeChrome: Record<StatusNoticeType, {
   readonly backgroundColor: 'agencWash' | 'workerWash' | 'successWash' | 'errorWash';
   readonly color: 'agenc' | 'worker';
@@ -122,7 +129,8 @@ export function StatusNotices(t0: Props = {}) {
     agentDefinitions,
     memoryDiagnostics,
     daemonStatus: {
-      autostartDisabled: isDaemonAutostartDisabled()
+      autostartDisabled: isDaemonAutostartDisabled(),
+      autostartFailure: daemonAutostartFailure()
     }
   };
   const activeNotices = getActiveNotices(context);

--- a/runtime/src/tui/startup/statusNoticeDefinitions.tsx
+++ b/runtime/src/tui/startup/statusNoticeDefinitions.tsx
@@ -17,6 +17,8 @@ export type StatusNoticeContext = {
   memoryDiagnostics: string[];
   daemonStatus: {
     autostartDisabled: boolean;
+    /** Set when daemon autostart failed at CLI startup (message text). */
+    autostartFailure?: string;
   };
 };
 export type StatusNoticeDefinition = {
@@ -158,6 +160,14 @@ const daemonAutostartNotice: StatusNoticeDefinition = {
     return 'AgenC daemon autostart is disabled. Background agents and reconnectable sessions require a running daemon. · agenc daemon start';
   }
 };
+const daemonAutostartFailedNotice: StatusNoticeDefinition = {
+  id: 'daemon-autostart-failed',
+  type: 'error',
+  isActive: context => Boolean(context.daemonStatus.autostartFailure),
+  render: context => {
+    return `AgenC daemon autostart failed: ${context.daemonStatus.autostartFailure}. Background agents and reconnectable sessions are unavailable. · agenc daemon start`;
+  }
+};
 const jetbrainsPluginNotice: StatusNoticeDefinition = {
   id: 'jetbrains-plugin-install',
   type: 'info',
@@ -183,7 +193,7 @@ const jetbrainsPluginNotice: StatusNoticeDefinition = {
 };
 
 // All notice definitions
-export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, daemonAutostartNotice, agencAccountExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice];
+export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, daemonAutostartNotice, daemonAutostartFailedNotice, agencAccountExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice];
 
 // Helper functions for external use
 export function getActiveNotices(context: StatusNoticeContext): StatusNoticeDefinition[] {

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -582,6 +582,59 @@ port = 0
     }
   });
 
+  it("gives up with a typed error when build skew persists across every restart cycle", async () => {
+    // Permanent-skew environment: every daemon this host spawns publishes a
+    // build identity that differs from the CLI's on-disk runtime, so the
+    // skew branch fires on every ensure cycle. Before the restart-cycle cap
+    // this recursed forever: respawn + full /proc scan + lifecycle lock at
+    // ~200% CPU behind a blank screen.
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    const skewedBuild = {
+      runtimeVersion: "0.0.0-skewed",
+      commit: "skewed-commit",
+      buildTime: "1970-01-01T00:00:00.000Z",
+    };
+    const baseSpawn = host.spawnDetachedDaemon;
+    host.spawnDetachedDaemon = () => {
+      const pid = baseSpawn();
+      host.recordDaemon(pid, skewedBuild);
+      return pid;
+    };
+    const oldPid = 5480;
+    host.runningPids.add(oldPid);
+    await writeAgenCDaemonPid(pidPath, oldPid);
+    host.recordDaemon(oldPid, skewedBuild);
+    const sleeps: number[] = [];
+    host.sleep = async (ms: number) => {
+      sleeps.push(ms);
+    };
+
+    try {
+      await expect(
+        ensureAgenCDaemonAutostart({
+          host,
+          findOrphanDaemonPids: () => [],
+          findSupersededDaemonPids: () => [],
+          isReady: ({ pid }) => host.runningPids.has(pid),
+        }),
+      ).rejects.toThrowError(
+        expect.objectContaining({
+          name: "AgenCDaemonAutostartError",
+          message: expect.stringMatching(/gave up after 3 restart cycles/),
+        }),
+      );
+      // Bounded work: one spawn per cycle, never an unbounded respawn storm.
+      expect(host.spawnedPids.length).toBeLessThanOrEqual(4);
+      // Backoff between repeated restart cycles (the first restart stays
+      // immediate; escalation starts when the condition repeats).
+      expect(sleeps.filter((ms) => ms >= 250).length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
   it("replaces a different commit even when buildTime is unchanged", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);

--- a/runtime/tests/plugins/cli/pluginCliCommands.test.ts
+++ b/runtime/tests/plugins/cli/pluginCliCommands.test.ts
@@ -222,6 +222,42 @@ describe("agenc plugin CLI", () => {
     });
   });
 
+  it("warns when a project-scope install ships hooks or MCP servers", async () => {
+    // Workspace-resident plugin content is repository-controlled, which
+    // strips hooks and MCP servers at load time; the install must say so
+    // instead of letting those components vanish silently.
+    const { agencHome, workspaceRoot, root } = await tempRuntime();
+    const source = await writePlugin(root, "withmcp");
+    await writeFile(
+      join(source, ".mcp.json"),
+      JSON.stringify({ mcpServers: { local: { command: "node", args: ["s.js"] } } }),
+    );
+    await mkdir(join(source, "hooks"), { recursive: true });
+    await writeFile(join(source, "hooks", "hooks.json"), JSON.stringify({ hooks: {} }));
+
+    const io = createIo();
+    const exit = await runAgenCPluginCli({
+      kind: "install",
+      source,
+      scope: "project",
+      force: false,
+    }, options(agencHome, workspaceRoot, io));
+    expect(exit).toBe(0);
+    expect(io.stderrText()).toContain("hooks and MCP servers");
+    expect(io.stderrText()).toContain("--scope user");
+
+    // The same plugin at user scope loads everything: no warning.
+    const userIo = createIo();
+    const userExit = await runAgenCPluginCli({
+      kind: "install",
+      source,
+      scope: "user",
+      force: true,
+    }, options(agencHome, workspaceRoot, userIo));
+    expect(userExit).toBe(0);
+    expect(userIo.stderrText()).toBe("");
+  });
+
   it("adds, upgrades, lists, and removes a local marketplace", async () => {
     const { agencHome, workspaceRoot, root } = await tempRuntime();
     const marketplaceRoot = join(root, "marketplace");

--- a/runtime/tests/plugins/registration.test.ts
+++ b/runtime/tests/plugins/registration.test.ts
@@ -227,6 +227,39 @@ describe("plugin registration", () => {
     }
   });
 
+  test("resolves CLAUDE_* template aliases for Claude Code ecosystem plugins", async () => {
+    // Plugins written for Claude Code template with ${CLAUDE_PLUGIN_ROOT};
+    // an unconsumed template used to fall through to env-var expansion and
+    // drop the MCP server with "Missing environment variables".
+    const root = await mkdtemp(join(tmpdir(), "agenc-plugin-claude-alias-"));
+    const agencHome = join(root, "home");
+    const workspaceRoot = join(root, "workspace");
+    const pluginRoot = join(agencHome, "plugins", "ccplugin");
+    try {
+      await writeJson(join(pluginRoot, ".agenc-plugin", "plugin.json"), {
+        name: "ccplugin",
+        mcpServers: {
+          goal: {
+            command: "node",
+            args: ["${CLAUDE_PLUGIN_ROOT}/server.mjs"],
+          },
+        },
+      });
+      const mcpServers = await loadPluginMcpServers({
+        cwd: workspaceRoot,
+        agencHome,
+        workspaceRoot,
+        extraPluginDirs: [pluginRoot],
+      });
+      expect(mcpServers["plugin:ccplugin:goal"]).toMatchObject({
+        command: "node",
+        args: [`${pluginRoot}/server.mjs`],
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("normalizes plugin output style identifiers before prompt headers use them", async () => {
     await withTempPlugin(async ({ pluginRoot, options }) => {
       await rm(join(pluginRoot, "output-styles", "terse.md"), { force: true });

--- a/runtime/tests/session/mcp-startup.test.ts
+++ b/runtime/tests/session/mcp-startup.test.ts
@@ -679,6 +679,115 @@ describe("mcp-startup session-owned manager helpers", () => {
     }
   });
 
+  it("merges plugin-declared MCP servers into the session source list", async () => {
+    // The historical gap: plugin MCP servers were loaded and sandboxed by
+    // the plugin registration pipeline but never handed to the MCPManager,
+    // so their tools silently never reached the tool catalog.
+    const source = vi.fn().mockResolvedValue({
+      "plugin:sample:goal": {
+        command: "node",
+        args: ["goal-server.mjs"],
+      },
+    });
+    const config = {
+      mcp_servers: {
+        github: { command: "github-mcp" },
+      },
+      plugins: { enabled: true },
+    };
+    await expect(
+      resolveSessionMcpConfigFromSources(config, {} as NodeJS.ProcessEnv, {
+        cwd: "/workspace",
+        pluginMcpServerSource: source,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ name: "github", command: "github-mcp" }),
+      expect.objectContaining({
+        name: "plugin:sample:goal",
+        command: "node",
+        args: ["goal-server.mjs"],
+      }),
+    ]);
+    // The loader needs the config's plugins section to know what is
+    // enabled (else every plugin resolves as disabled) and the caller's
+    // env so AGENC_HOME resolution matches the session.
+    expect(source).toHaveBeenCalledWith({
+      cwd: "/workspace",
+      config,
+      env: {},
+    });
+  });
+
+  it("lets an explicit config entry override a plugin server of the same name", async () => {
+    await expect(
+      resolveSessionMcpConfigFromSources(
+        {
+          mcp_servers: {
+            "plugin:sample:goal": { command: "config-override" },
+          },
+        },
+        {} as NodeJS.ProcessEnv,
+        {
+          pluginMcpServerSource: async () => ({
+            "plugin:sample:goal": { command: "plugin-declared" },
+          }),
+        },
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        name: "plugin:sample:goal",
+        command: "config-override",
+      }),
+    ]);
+  });
+
+  it("excludes plugin servers when includePluginMcpServers is false", async () => {
+    await expect(
+      resolveSessionMcpConfigFromSources(undefined, {} as NodeJS.ProcessEnv, {
+        includePluginMcpServers: false,
+        pluginMcpServerSource: async () => ({
+          "plugin:sample:goal": { command: "plugin-declared" },
+        }),
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("keeps AGENC_MCP_SERVERS as a complete override over plugin servers", async () => {
+    await expect(
+      resolveSessionMcpConfigFromSources(
+        undefined,
+        {
+          AGENC_MCP_SERVERS: JSON.stringify([
+            { name: "envOnly", command: "env-mcp" },
+          ]),
+        } as NodeJS.ProcessEnv,
+        {
+          pluginMcpServerSource: async () => ({
+            "plugin:sample:goal": { command: "plugin-declared" },
+          }),
+        },
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ name: "envOnly", command: "env-mcp" }),
+    ]);
+  });
+
+  it("tolerates a broken plugin MCP source without failing session startup", async () => {
+    await expect(
+      resolveSessionMcpConfigFromSources(
+        { mcp_servers: { github: { command: "github-mcp" } } },
+        {} as NodeJS.ProcessEnv,
+        {
+          pluginMcpServerSource: async () => {
+            throw new Error("plugin loader exploded");
+          },
+        },
+      ),
+    ).resolves.toEqual([
+      expect.objectContaining({ name: "github", command: "github-mcp" }),
+    ]);
+  });
+
   it("keeps AGENC_MCP_SERVERS as a complete override over project .mcp.json", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-project-mcp-"));
     try {
@@ -921,6 +1030,40 @@ describe("mcp-startup session-owned manager helpers", () => {
       configuredServers: ["github", "filesystem"],
       requiredServers: ["github"],
     });
+  });
+
+  it("refresh keeps plugin servers instead of evicting them", async () => {
+    // Refresh used to rebuild the manager's list from config only, so any
+    // plugin server the manager held would be evicted on the first refresh.
+    const refreshServers = vi.fn().mockResolvedValue(undefined);
+    const manager = {
+      refreshServers,
+    } as unknown as MCPManager;
+
+    const result = await refreshMcpManagerFromConfig({
+      manager,
+      env: {} as NodeJS.ProcessEnv,
+      config: {
+        mcp_servers: {
+          github: { command: "github-mcp" },
+        },
+      },
+      pluginMcpServerSource: async () => ({
+        "plugin:sample:goal": { command: "node", args: ["goal-server.mjs"] },
+      }),
+    });
+
+    expect(refreshServers).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ name: "github" }),
+        expect.objectContaining({ name: "plugin:sample:goal" }),
+      ],
+      {},
+    );
+    expect(result.configuredServers).toEqual([
+      "github",
+      "plugin:sample:goal",
+    ]);
   });
 
   it("service refreshFromConfig preserves env override semantics", async () => {


### PR DESCRIPTION
Two high-severity bugs found by live-testing the agenc-goal plugin end to end, plus one install-time UX gap. Full investigation (CPU profiles, deterministic repros, strace evidence) in `docs/daemon-autostart-spin-2026-08-23.md`.

## 1. Daemon-autostart spin (blank screen, ~200% CPU, forever)

`ensureAgenCDaemonAutostart` tail-recursed into itself from two restart paths (legacy identity-less daemon at the old `daemon-autostart.ts:468`, build skew at `:528`) with no cap or backoff. A permanent restart condition meant: respawn a daemon + full /proc scan + SQLite lifecycle lock, per cycle, forever, behind a blank screen (the CLI passed `silentIo()` so even the respawn reasons were swallowed, and the TUI never boots until autostart resolves).

Fix: restart cycles capped at 3 with escalating backoff after the first (single-restart upgrade flows stay immediate), typed give-up error naming the repeating reason; real stderr wired into the default route's autostart; on TTY failure the TUI boots anyway with a new `daemon-autostart-failed` error notice.

Live-verified: the repro (stale daemon.sock + copied lifecycle sqlite in an isolated AGENC_HOME) went from a 12+ minute spin to four visible respawn lines and a clean failure in 3 seconds; a TUI send in the broken state now shows "Message not sent: AgenC daemon autostart gave up after 3 restart cycles: ...".

## 2. Plugin MCP servers never reached the tool catalog

The registration pipeline fully resolved plugin `.mcp.json` servers (scoped names, env substitution, sandbox metadata) but nothing handed them to the live `MCPManager` - the `pluginReconnectKey` refresh mechanism had writers and no readers. Three integration links fixed:

- `resolveSessionMcpConfigFromSources` and `refreshMcpManagerFromConfig` now merge plugin-declared servers (refresh previously would also have evicted them).
- The session config and env are threaded into plugin resolution: without the `plugins` config section every plugin loads as disabled, and without the env the loader resolved AGENC_HOME from `process.env` instead of the session.
- `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}` / `${CLAUDE_SESSION_ID}` now alias to their AGENC_* equivalents; unconsumed templates fell through to env-var expansion and dropped the server with "Missing environment variables: CLAUDE_PLUGIN_ROOT".

Verified live to the point this machine allows: the plugin server resolves, registers in `/mcp`, and spawns through `agenc-linux-sandbox`. The remaining blocker here is pre-existing and documented as its own decision: without usable bubblewrap (AppArmor userns block), the Landlock fallback cannot express the mcp_stdio policy (writable project root with read-only `.agenc`/`.git` subpath), so every stdio MCP server fails closed on such machines.

## 3. Install-time warning

`agenc plugin install --scope project|local` now warns when the plugin ships hooks or MCP servers, which repository-controlled provenance silently strips.

## Verification

- 128 tests across the touched suites pass (`daemon-autostart.contract`, `mcp-startup`, `plugins/registration`, `plugins/cli`, `statusNoticeDefinitions`); `npm run typecheck` clean; `npm run build` clean.
- Revert-sensitivity: stashing `runtime/src` turns exactly the new assertions red (the bounded-restart test visibly hangs ~9s against the old recursion before failing).

https://claude.ai/code/session_01Aij5FrVBscsow7WRSfiQE6