### PR TITLE
Make MCP stdio work and fail legibly on Landlock-fallback hosts

### DIFF
--- a/docs/daemon-autostart-spin-2026-08-23.md
+++ b/docs/daemon-autostart-spin-2026-08-23.md
@@ -69,6 +69,19 @@ Select tools: mcp.agenc-goal.goal_create, mcp.agenc-goal.goal_update, mcp.agenc-
 
 So the model can never call any plugin MCP tool, and it burns tokens searching, reading plugin source, and trying shell fallbacks (one grok-4.5 session spent >$7 flailing on this). Likely related to the known "live-agent MCP refresh no-op" backlog item: the server connects, but tool registration/refresh into the live catalog never happens for plugin-sourced MCP servers. Plugin slash commands and agents from the same plugin DO register (`/agenc-goal:goal` and the goal-planner agent both worked).
 
+## Platform gap: MCP stdio on Landlock-fallback machines — ADDRESSED (same day, follow-up PR)
+
+Follow-up fixes landed after this report's first version:
+
+- The broker pre-flights the Landlock plan when readiness came through the fallback: unexpressible policies now fail at spawn-preparation with `[sandbox_policy_unexpressible] ... <reason> ... <cause-correct bubblewrap remediation>` instead of spawn-and-die (skipped for inherited-readonly-cwd spawns, which plan cleanly; best-effort with the stderr capture below as backstop).
+- The stdio transport retains a bounded ring of child stderr and attaches the tail to pre-handshake connect failures, so any server death shows its actual reason in /mcp instead of "MCP error -32000: Connection closed".
+- Plugin-declared MCP servers finally consume their `pluginSandbox` metadata: they spawn under a tight profile (root read, writes confined to the plugin data dir + its tmp, TMPDIR pointed there) that is stricter under bubblewrap AND Landlock-expressible — plugin MCP works on fallback machines.
+- `agenc doctor` emits `[sandbox_landlock_fallback]` with the cause-correct remedy (and exits 1) whenever the fallback is active.
+- docs/install.md now states plainly that there is no safe partial waiver under the fallback, and that `[sandbox_policy]` `writable_roots` is a dead config key nothing consumes.
+- A FIFTH root cause surfaced only during live verification: the restricted-network seccomp filter denied `getsockname`/`getpeername`/`getsockopt`, and Node's `child_process` "pipe" stdio are AF_UNIX socketpairs — libuv classifies inherited stdio with `getsockname`, so every node-spawned confined child saw `getsockname(0) => EPERM` and instant EOF on stdin (proved with strace and an in-server fd probe; a shell-driven pipeline worked because shell pipes are real pipes). Read-only socket introspection is now allowed in restricted mode; socket creation stays AF_UNIX-only and connect/bind/listen/accept/send*/setsockopt stay denied. With this, the FULL chain was verified live on this bubblewrap-less machine: plugin server `connected` in /mcp with its tools, tool catalog grew 88 → 97, and a model Tool search returned `mcp.plugin:agenc-goal:agenc-goal.goal_create`.
+
+Original analysis below for the record.
+
 ## Remaining platform gap: MCP stdio is fully broken on Landlock-fallback machines
 
 With the four integration fixes in place, the plugin MCP server is resolved, handed to the live manager, and spawned through `agenc-linux-sandbox`, but on this machine every connect still fails with `MCP error -32000: Connection closed` because the sandbox launcher exits before exec:

--- a/docs/install.md
+++ b/docs/install.md
@@ -220,6 +220,21 @@ sudo apparmor_parser -R /etc/apparmor.d/agenc-native-userns
 sudo rm /etc/apparmor.d/agenc-native-userns
 ```
 
+Until the profile is installed, AgenC runs on its Landlock fallback. Landlock
+is a pure allow-list: it cannot grant write access to a project while keeping
+`.git`, `.agenc`, and `.agents` read-only inside it, so sandboxed spawns that
+need a writable project root (shell in git projects, most stdio MCP servers)
+are refused with a `[sandbox_policy_unexpressible]` error naming the path.
+There is no safe partial waiver for this: any flag that made those paths
+writable would let a confined process install git hooks that execute outside
+the sandbox. The supported options are installing the AppArmor profile above
+(restores full bubblewrap confinement), `sandbox_mode = "read-only"`, or the
+explicit `danger-full-access` posture. Plugin-declared MCP servers are exempt:
+they run under a tighter profile confined to their plugin data directory,
+which the Landlock fallback can express. Note that `[sandbox_policy]`
+`writable_roots` in config is currently not consumed by the runtime and does
+not affect any of this.
+
 ## npm launcher
 
 ```bash

--- a/runtime/src/mcp-client/connection.ts
+++ b/runtime/src/mcp-client/connection.ts
@@ -53,6 +53,9 @@ export async function createMCPConnection(
         ...(config.env_vars !== undefined ? { env_vars: config.env_vars } : {}),
         ...(config.cwd !== undefined ? { cwd: config.cwd } : {}),
         ...(config.timeout !== undefined ? { timeout: config.timeout } : {}),
+        ...(config.pluginSandbox !== undefined
+          ? { pluginSandbox: config.pluginSandbox }
+          : {}),
       },
       logger,
       elicitationHandlers,

--- a/runtime/src/mcp-client/transports/stdio.ts
+++ b/runtime/src/mcp-client/transports/stdio.ts
@@ -15,7 +15,7 @@
 
 import { VERSION } from "../../version.js";
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, statSync } from "node:fs";
 import { delimiter, isAbsolute, join, resolve } from "node:path";
 import {
   deserializeMessage,
@@ -27,6 +27,8 @@ import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "../_deps/logger.js";
 import { silentLogger } from "../_deps/logger.js";
 import type { MCPElicitationHandlers } from "../types.js";
+import type { PluginMcpSandboxMetadata } from "../../config/schema.js";
+import { pluginMcpPermissionProfile } from "../../tools/runtimes/sandboxing.js";
 import { configureMcpElicitationClient } from "../../elicitation/mcp.js";
 import {
   buildMcpHostClientCapabilities,
@@ -58,6 +60,15 @@ export const AGENC_MCP_STDIO_MAX_FRAME_BYTES = 16 * 1024 * 1024;
  * preserving the existing newline-delimited line-splitting behavior.
  */
 const STDERR_BUFFER_MAX_BYTES = 1024 * 1024;
+
+/**
+ * Bounded ring of recent child stderr lines. The production manager runs
+ * with a silent logger, so without this the precise failure reason a dying
+ * server prints (e.g. the sandbox launcher's policy refusal) is discarded
+ * and the caller only ever sees the SDK's generic "Connection closed".
+ */
+const RECENT_STDERR_MAX_LINES = 8;
+const RECENT_STDERR_LINE_MAX_CHARS = 400;
 
 export const DEFAULT_STDIO_ENV_VARS: readonly string[] =
   process.platform === "win32"
@@ -98,6 +109,8 @@ export interface MCPServerStdioConfig {
   readonly env_vars?: readonly string[];
   readonly cwd?: string;
   readonly timeout?: number;
+  /** Plugin confinement metadata: selects the tight plugin spawn profile. */
+  readonly pluginSandbox?: PluginMcpSandboxMetadata;
 }
 
 export interface StdioTransportServerParameters {
@@ -105,6 +118,8 @@ export interface StdioTransportServerParameters {
   readonly args?: readonly string[];
   readonly env?: Readonly<Record<string, string>>;
   readonly cwd?: string;
+  /** Plugin confinement metadata: selects the tight plugin spawn profile. */
+  readonly pluginSandbox?: PluginMcpSandboxMetadata;
 }
 
 type NodeProcessEnv = Readonly<Record<string, string | undefined>>;
@@ -184,6 +199,7 @@ export class AgenCStdioClientTransport implements Transport {
   private stdoutChunks: Buffer[] = [];
   private stdoutFrameBytes = 0;
   private stderrBuffer = Buffer.alloc(0);
+  private recentStderrLines: string[] = [];
   private closedNotified = false;
   private stdoutProtocolFailed = false;
   private shutdownState:
@@ -219,11 +235,35 @@ export class AgenCStdioClientTransport implements Transport {
           ? this.server.cwd
           : resolve(broker.cwd, this.server.cwd);
     const command = resolveStdioProgram(this.server.command, env, cwd);
+    // Plugin-declared servers run under their intended tight profile: write
+    // access confined to the plugin data dir instead of the project root.
+    // Stricter under bubblewrap, and Landlock-expressible so plugin servers
+    // keep working on hosts where bubblewrap is unusable. TMPDIR points at
+    // a data-dir tmp because the profile deliberately has no writable /tmp
+    // and the `tmpdir` special silently vanishes when TMPDIR is unset.
+    let permissionProfileOverride:
+      | ReturnType<typeof pluginMcpPermissionProfile>
+      | undefined;
+    if (this.server.pluginSandbox?.mode === "stdio-child-process") {
+      const pluginTmpDir = join(this.server.pluginSandbox.pluginDataDir, "tmp");
+      try {
+        mkdirSync(pluginTmpDir, { recursive: true });
+      } catch {
+        // Non-fatal: the server just falls back to the host tmpdir grant.
+      }
+      env.TMPDIR ??= pluginTmpDir;
+      permissionProfileOverride = pluginMcpPermissionProfile(
+        this.server.pluginSandbox,
+      );
+    }
     const spawnCommand = broker.prepareSpawn("mcp_stdio", {
       program: command,
       args: this.server.args ?? [],
       cwd,
       env,
+      ...(permissionProfileOverride !== undefined
+        ? { permissionProfileOverride }
+        : {}),
     });
 
     this.resetStdoutFrame();
@@ -364,6 +404,7 @@ export class AgenCStdioClientTransport implements Transport {
         .toString("utf8")
         .replace(/\r$/, "");
       this.stderrBuffer = this.stderrBuffer.subarray(index + 1);
+      this.noteStderrLine(line);
       this.logger.info(`MCP server stderr (${this.server.command}): ${line}`);
     }
     // Defense-in-depth: a child that streams stderr without a newline would
@@ -386,7 +427,28 @@ export class AgenCStdioClientTransport implements Transport {
     if (this.stderrBuffer.length === 0) return;
     const line = this.stderrBuffer.toString("utf8").replace(/\r$/, "");
     this.stderrBuffer = Buffer.alloc(0);
+    this.noteStderrLine(line);
     this.logger.info(`MCP server stderr (${this.server.command}): ${line}`);
+  }
+
+  private noteStderrLine(line: string): void {
+    const cleaned = line
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "")
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x08\x0b-\x1f\x7f]/g, "")
+      .slice(0, RECENT_STDERR_LINE_MAX_CHARS)
+      .trim();
+    if (cleaned.length === 0) return;
+    this.recentStderrLines.push(cleaned);
+    if (this.recentStderrLines.length > RECENT_STDERR_MAX_LINES) {
+      this.recentStderrLines.shift();
+    }
+  }
+
+  /** Recent child stderr, oldest first, for attaching to connect failures. */
+  recentStderr(): string {
+    return this.recentStderrLines.join(" | ");
   }
 
   private handleUnexpectedChildClose(child: ChildProcess): void {
@@ -474,6 +536,9 @@ function createStdioMCPTransport(
       args: config.args,
       env,
       cwd: config.cwd,
+      ...(config.pluginSandbox !== undefined
+        ? { pluginSandbox: config.pluginSandbox }
+        : {}),
     },
     logger,
     sandboxExecutionBroker,
@@ -516,10 +581,26 @@ export async function createStdioMCPConnection(
     ...(config.cwd !== undefined ? { cwd: config.cwd } : {}),
   });
 
-  await connectMCPClientWithCleanup(client, transport, {
-    description: `MCP stdio connect to "${config.name}"`,
-    timeoutMs: timeout,
-  });
+  try {
+    await connectMCPClientWithCleanup(client, transport, {
+      description: `MCP stdio connect to "${config.name}"`,
+      timeoutMs: timeout,
+    });
+  } catch (error) {
+    // A server that dies before the handshake surfaces as the SDK's generic
+    // "Connection closed"; the actual reason (sandbox launcher refusal,
+    // missing dependency, crash) is on the child's stderr. Attach the
+    // retained tail so /mcp and logs show the root cause. Covers reconnects
+    // too: every stdio (re)connect funnels through this factory.
+    const stderrTail = transport.recentStderr();
+    if (stderrTail.length > 0) {
+      const base = error instanceof Error ? error.message : String(error);
+      throw new Error(`${base}; server stderr: ${stderrTail}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
 
   logger.info(`Connected to MCP stdio server "${config.name}"`);
   return client;

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -23,6 +23,7 @@ import {
   type SandboxType,
 } from "./engine/index.js";
 import { effectivePermissionProfile } from "./engine/policy-transforms.js";
+import { planLandlockConfinement } from "./linux-launcher/landlock-exec.js";
 import {
   findSystemBubblewrapInPath,
   probeSystemBubblewrapNamespaces,
@@ -65,7 +66,8 @@ export type SandboxExecutionErrorCode =
   | "sandbox_required_unavailable"
   | "sandbox_probe_failed"
   | "sandbox_transform_failed"
-  | "sandbox_surface_uncovered";
+  | "sandbox_surface_uncovered"
+  | "sandbox_policy_unexpressible";
 
 export type SandboxExecutionStatusKind =
   | "ready"
@@ -87,6 +89,18 @@ export interface SandboxExecutionStatus {
    * bubblewrap namespace probe and selects this fallback rung when needed.
    */
   readonly landlock?: "full" | "partial" | "unusable";
+  /**
+   * Present when this ready-status was reached through the Landlock
+   * fallback because bubblewrap is unusable. Carries the bubblewrap
+   * failure cause and its cause-correct remediation (AppArmor profile vs
+   * install/upgrade bubblewrap vs enable user namespaces) so consumers
+   * (doctor warning, per-policy pre-flight errors) never have to
+   * recompute or string-sniff it.
+   */
+  readonly landlockFallback?: {
+    readonly reason: string;
+    readonly remediation: string;
+  };
 }
 
 export interface SandboxSpawnCommand {
@@ -101,6 +115,13 @@ export interface SandboxSpawnCommand {
   readonly additionalPermissions?: AdditionalPermissionProfile;
   /** Require the executable itself to be outside every sandbox-writable root. */
   readonly trustedExecutable?: boolean;
+  /**
+   * Replace the mode-derived permission profile for this spawn. Honored only
+   * under workspace-write (a surface may TIGHTEN its own boundary — e.g.
+   * plugin MCP servers confined to their data dir — never widen a stricter
+   * global mode). `additionalPermissions` still merge additively on top.
+   */
+  readonly permissionProfileOverride?: UnifiedExecRuntimeSandbox["permissionProfile"];
 }
 
 export type SandboxExecutionManager = Pick<
@@ -139,12 +160,15 @@ export class SandboxExecutionError extends Error {
     readonly surface: SandboxExecutionSurface;
     readonly status: SandboxExecutionStatus;
     readonly cause?: unknown;
+    /** Full pre-formatted message; overrides the blocked-surface template. */
+    readonly message?: string;
   }) {
     const reason = options.status.reason ?? "platform isolation is unavailable";
     const remediation = options.status.remediation ??
       "Run `agenc doctor`; select danger-full-access explicitly only when host execution is intended.";
     super(
-      `[${options.code}] required sandbox blocked ${options.surface}: ${reason}. ${remediation}`,
+      options.message ??
+        `[${options.code}] required sandbox blocked ${options.surface}: ${reason}. ${remediation}`,
       options.cause === undefined ? undefined : { cause: options.cause },
     );
     this.name = "SandboxExecutionError";
@@ -205,6 +229,8 @@ export interface SandboxExecutionBrokerOptions {
     readonly platform: NodeJS.Platform;
     readonly agencLinuxSandboxExe?: string;
   }) => SandboxExecutionStatus;
+  /** Injectable Landlock plan seam for deterministic pre-flight tests. */
+  readonly planLandlockPolicy?: typeof planLandlockConfinement;
 }
 
 const defaultSandboxManager = new SandboxManager();
@@ -225,6 +251,7 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
   readonly #windowsSandboxPrivateDesktop: boolean;
   readonly #allowGpu: boolean;
   readonly #probe: NonNullable<SandboxExecutionBrokerOptions["probe"]>;
+  readonly #planLandlockPolicy: typeof planLandlockConfinement;
   #status: SandboxExecutionStatus | undefined;
 
   constructor(options: SandboxExecutionBrokerOptions) {
@@ -244,6 +271,8 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
       options.windowsSandboxPrivateDesktop ?? false;
     this.#allowGpu = options.allowGpu ?? false;
     this.#probe = options.probe ?? probeSandboxExecutionStatus;
+    this.#planLandlockPolicy =
+      options.planLandlockPolicy ?? planLandlockConfinement;
   }
 
   get cwd(): string {
@@ -272,6 +301,7 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
       platform: this.#platform,
       sandboxManager: this.#sandboxManager,
       probe: this.#probe,
+      planLandlockPolicy: this.#planLandlockPolicy,
       forkDepth: this.forkDepth + 1,
     });
   }
@@ -324,7 +354,19 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
       // Establish the required boundary before examining or transforming the
       // command. When the sandbox probe failed, that is the primary failure;
       // no executable resolution or policy projection should mask it.
-      const runtimeSandbox = this.runtimeSandbox(surface);
+      const modeSandbox = this.runtimeSandbox(surface);
+      // A surface may TIGHTEN its own boundary (plugin MCP servers confined
+      // to their data dir) — never widen a stricter global mode, so the
+      // override applies only under workspace_write.
+      const runtimeSandbox =
+        modeSandbox !== undefined &&
+        command.permissionProfileOverride !== undefined &&
+        this.mode === "workspace_write"
+          ? {
+              ...modeSandbox,
+              permissionProfile: command.permissionProfileOverride,
+            }
+          : modeSandbox;
       const resolvedProgram = resolveSpawnExecutable({
         program: command.program,
         cwd: command.cwd,
@@ -336,9 +378,11 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
           command.additionalPermissions !== undefined) &&
         this.required
       ) {
-        const baseProfile = permissionProfileForSandboxMode(this.mode, {
-          cwd: this.#cwd,
-        });
+        const baseProfile =
+          runtimeSandbox?.permissionProfile ??
+          permissionProfileForSandboxMode(this.mode, {
+            cwd: this.#cwd,
+          });
         const effectiveProfile = effectivePermissionProfile(
           baseProfile,
           command.additionalPermissions,
@@ -356,6 +400,7 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
           );
         }
       }
+      this.#preflightLandlockPlan(surface, command, runtimeSandbox);
       const resolvedCommand: SandboxSpawnCommand = {
         ...command,
         program: resolvedProgram,
@@ -384,6 +429,56 @@ export class SandboxExecutionBroker implements SandboxExecutionBrokerLike {
           reason: error instanceof Error ? error.message : String(error),
         },
         cause: error,
+      });
+    }
+  }
+
+  /**
+   * When this host reached readiness only through the Landlock fallback,
+   * check whether the fallback can actually express this spawn's policy —
+   * the launcher would otherwise refuse at exec time with the reason buried
+   * in child stderr and the caller seeing a generic connection/exit failure.
+   *
+   * Best-effort by design: the launcher re-probes bubblewrap with the
+   * child's environment at spawn time, and `tmpdir` specials resolve from
+   * the resolving process's env, so verdicts can diverge on exotic
+   * environments; the stdio transport's stderr capture remains the backstop.
+   * No memoization: carve-out refusals hinge on path existence the launcher
+   * rechecks per spawn, so we do too (the plan is cheap and only runs on
+   * fallback machines).
+   */
+  #preflightLandlockPlan(
+    surface: SandboxExecutionSurface,
+    command: SandboxSpawnCommand,
+    runtimeSandbox: UnifiedExecRuntimeSandbox | undefined,
+  ): void {
+    if (runtimeSandbox === undefined) return;
+    if (this.#platform !== "linux") return;
+    // Glob/Grep-style spawns replace the profile with an inherited
+    // read-only policy in the engine — pre-flighting the workspace profile
+    // here would falsely refuse spawns that plan cleanly.
+    if (command.cwdBinding === "inherited_readonly") return;
+    if (command.env.AGENC_DISABLE_LANDLOCK_FALLBACK === "1") return;
+    const fallback = this.status().landlockFallback;
+    if (fallback === undefined) return;
+    const effectiveProfile = effectivePermissionProfile(
+      runtimeSandbox.permissionProfile,
+      command.additionalPermissions,
+    );
+    const plan = this.#planLandlockPolicy({
+      fileSystem: effectiveProfile.fileSystem,
+      sandboxPolicyCwd: this.#cwd,
+      allowNetworkForProxy: false,
+      inheritedCwd: false,
+    });
+    if (plan.kind === "refused") {
+      throw new SandboxExecutionError({
+        code: "sandbox_policy_unexpressible",
+        surface,
+        status: this.status(),
+        message:
+          `[sandbox_policy_unexpressible] required sandbox cannot express the ${surface} policy ` +
+          `without bubblewrap: ${plan.reason}. ${fallback.remediation}`,
       });
     }
   }
@@ -552,6 +647,10 @@ function probeLinuxSandbox(options: {
         isolationProgram: launcher,
         reason: `${bwrapReason}; the Landlock fallback is active`,
         landlock: "full",
+        landlockFallback: {
+          reason: bwrapReason,
+          remediation: bwrapRemediation,
+        },
       };
     }
     return unavailableStatus(

--- a/runtime/src/sandbox/linux-launcher/landlock.ts
+++ b/runtime/src/sandbox/linux-launcher/landlock.ts
@@ -147,19 +147,24 @@ export function createNetworkSeccompProgram(
 }
 
 function restrictedNetworkDeniedSyscalls(table: SyscallTable): number[] {
+  // getsockname/getpeername/getsockopt are deliberately NOT denied: they are
+  // read-only introspection of already-open sockets and grant no
+  // connectivity (socket creation stays AF_UNIX-only above; connect/bind/
+  // listen/accept/send* stay denied). Node's libuv classifies inherited
+  // stdio with getsockname, and child_process "pipe" stdio are AF_UNIX
+  // socketpairs — denying it made every node-spawned confined child see
+  // instant EOF on stdin (getsockname(0) => EPERM), which broke stdio MCP
+  // servers under the Landlock fallback.
   return [
     table.connect,
     table.accept,
     table.accept4,
     table.bind,
     table.listen,
-    table.getpeername,
-    table.getsockname,
     table.shutdown,
     table.sendto,
     table.sendmmsg,
     table.recvmmsg,
-    table.getsockopt,
     table.setsockopt,
   ];
 }

--- a/runtime/src/tools/runtimes/sandboxing.ts
+++ b/runtime/src/tools/runtimes/sandboxing.ts
@@ -114,6 +114,35 @@ export function permissionProfileForSandboxMode(
   void options.cwd;
 }
 
+/**
+ * Tight profile for plugin-declared MCP stdio servers: read-everything plus
+ * write confined to the plugin's data dir (and its `tmp/` subdir, which the
+ * transport points TMPDIR at) and the host tmpdir. Deliberately NO writable
+ * project root: stricter than the workspace profile under bubblewrap, and —
+ * because the writable roots carry no existing `.git`/`.agenc` carve-outs —
+ * fully expressible by the Landlock fallback, so plugin MCP servers keep
+ * working on hosts where bubblewrap is unusable.
+ */
+export function pluginMcpPermissionProfile(metadata: {
+  readonly pluginDataDir: string;
+}): PermissionProfile {
+  return permissionProfileFromRuntimePermissions(
+    restrictedFileSystemPolicy(
+      [
+        rootEntry("read"),
+        { path: { kind: "path", path: metadata.pluginDataDir }, access: "write" },
+        {
+          path: { kind: "path", path: path.join(metadata.pluginDataDir, "tmp") },
+          access: "write",
+        },
+        tmpdirEntry(),
+      ],
+      { includePlatformDefaults: true },
+    ),
+    defaultNetworkForSandboxMode("workspace_write"),
+  );
+}
+
 function defaultNetworkForSandboxMode(mode: SandboxMode): NetworkSandboxPolicy {
   switch (mode) {
     case "danger_full_access":

--- a/runtime/src/utils/doctorDiagnostic.ts
+++ b/runtime/src/utils/doctorDiagnostic.ts
@@ -970,6 +970,28 @@ export function buildSandboxWarning(
   }
 }
 
+/**
+ * Ready-via-Landlock-fallback is degraded readiness: the fallback cannot
+ * express sandbox policies that protect .git/.agenc inside writable project
+ * roots, so shell in git projects and MCP stdio servers are refused
+ * per-spawn even though the probe reports ready. Surface that loudly with
+ * the cause-correct bubblewrap remedy computed at probe time.
+ */
+export function buildLandlockFallbackWarning(
+  status: SandboxExecutionStatus,
+): { issue: string; fix: string } | null {
+  if (status.kind !== 'ready' || status.landlockFallback === undefined) {
+    return null
+  }
+  return {
+    issue:
+      `[sandbox_landlock_fallback] bubblewrap is unusable (${status.landlockFallback.reason}); ` +
+      'the Landlock fallback cannot run sandbox policies that protect .git/.agenc inside ' +
+      'writable project roots (shell in git projects, MCP stdio servers)',
+    fix: status.landlockFallback.remediation,
+  }
+}
+
 export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
   const activeGeneratedWrapper = await findActiveGeneratedWrapper()
   const installationType = await getCurrentInstallationType({
@@ -1087,6 +1109,10 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
   const sandboxWarning = buildSandboxWarning(sandbox)
   if (sandboxWarning) {
     warnings.push(sandboxWarning)
+  }
+  const landlockFallbackWarning = buildLandlockFallbackWarning(sandbox)
+  if (landlockFallbackWarning) {
+    warnings.push(landlockFallbackWarning)
   }
 
   // Get package manager info if running from package manager

--- a/runtime/tests/mcp-client/transports/stdio.test.ts
+++ b/runtime/tests/mcp-client/transports/stdio.test.ts
@@ -518,3 +518,119 @@ async function waitFor(
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }
+
+describe("stdio connect failure diagnostics", () => {
+  it("attaches the child's stderr tail to a pre-handshake connect failure", async () => {
+    await expect(
+      createStdioMCPConnection(
+        {
+          name: "dies-before-handshake",
+          command: process.execPath,
+          args: [
+            "-e",
+            "process.stderr.write('helper refused: policy unexpressible at /proj/.agenc\\n'); process.exit(2);",
+          ],
+          env: createStdioMCPEnvironment(undefined, undefined),
+          timeout: 5_000,
+        },
+        undefined,
+        undefined,
+        undefined,
+        explicitDangerBroker,
+      ),
+    ).rejects.toThrowError(
+      expect.objectContaining({
+        message: expect.stringMatching(
+          /server stderr: .*helper refused: policy unexpressible at \/proj\/\.agenc/,
+        ),
+      }),
+    );
+  });
+
+  it("routes plugin sandbox metadata into the spawn as a tight profile override", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "agenc-mcp-stdio-plugin-"));
+    tempDirs.add(dir);
+    const dataDir = join(dir, "plugin-data");
+    await mkdir(dataDir);
+    const recorded: unknown[] = [];
+    const recordingBroker = {
+      mode: "workspace_write" as const,
+      required: true,
+      cwd: dir,
+      rebase: () => {},
+      forkForCwd: () => recordingBroker,
+      status: () => ({
+        kind: "ready" as const,
+        mode: "workspace_write" as const,
+        platform: process.platform,
+      }),
+      assertReady: () => ({
+        kind: "ready" as const,
+        mode: "workspace_write" as const,
+        platform: process.platform,
+      }),
+      runtimeSandbox: () => undefined,
+      prepareSpawn: (
+        _surface: string,
+        command: Record<string, unknown>,
+      ): Record<string, unknown> => {
+        recorded.push(command);
+        return command;
+      },
+    };
+    const transport = new AgenCStdioClientTransport(
+      {
+        command: process.execPath,
+        args: ["-e", "setTimeout(() => {}, 1000);"],
+        // No inherited TMPDIR: the transport must point the server at the
+        // data-dir tmp (an inherited TMPDIR would win and stays writable
+        // through the profile's tmpdir grant).
+        env: createStdioMCPEnvironment(undefined, undefined, {
+          PATH: process.env.PATH,
+        }),
+        pluginSandbox: {
+          mode: "stdio-child-process",
+          pluginName: "sample",
+          pluginRoot: dir,
+          pluginDataDir: dataDir,
+          serverName: "goal",
+          scopedServerName: "plugin:sample:goal",
+        },
+      },
+      undefined,
+      recordingBroker as never,
+    );
+
+    try {
+      await transport.start();
+    } finally {
+      await transport.close();
+    }
+
+    expect(recorded).toHaveLength(1);
+    const command = recorded[0] as {
+      env: Record<string, string>;
+      permissionProfileOverride?: {
+        fileSystem: { entries: ReadonlyArray<{ path: unknown }> };
+      };
+    };
+    // TMPDIR points into the data dir and the dir exists.
+    expect(command.env.TMPDIR).toBe(join(dataDir, "tmp"));
+    expect(existsSyncFor(join(dataDir, "tmp"))).toBe(true);
+    // The override confines writes to the plugin data dir.
+    const entryPaths = JSON.stringify(
+      command.permissionProfileOverride?.fileSystem.entries ?? [],
+    );
+    expect(entryPaths).toContain(dataDir);
+    expect(entryPaths).not.toContain('"project_roots"');
+  });
+});
+
+function existsSyncFor(path: string): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require("node:fs").existsSync(path) as boolean;
+  } catch {
+    return false;
+  }
+}

--- a/runtime/tests/sandbox/execution-broker.test.ts
+++ b/runtime/tests/sandbox/execution-broker.test.ts
@@ -223,6 +223,201 @@ describe("SandboxExecutionBroker", () => {
     expect(transform).toHaveBeenCalledOnce();
   });
 
+  describe("Landlock-fallback pre-flight", () => {
+    function fallbackStatus(): SandboxExecutionStatus {
+      return {
+        ...readyStatus("workspace_write"),
+        platform: "linux",
+        landlock: "full",
+        landlockFallback: {
+          reason: "probe: bubblewrap could not create the required namespaces",
+          remediation:
+            "Install AgenC's narrow per-command profile with: agenc doctor --apparmor-profile | sudo tee ...",
+        },
+      };
+    }
+    const fakeManager = {
+      selectInitial: vi.fn(() => "linux_seccomp" as const),
+      transform: vi.fn(() => ({
+        command: ["/sandbox/helper", "/bin/echo", "ok"],
+        cwd: "/",
+        env: {},
+        arg0: "sandbox-helper",
+      })),
+    } as never;
+
+    it("refuses an unexpressible policy with the precise reason and the probe-time remediation", () => {
+      const root = tempRoot("agenc-broker-preflight-");
+      mkdirSync(join(root, ".agenc"));
+      const broker = new SandboxExecutionBroker({
+        mode: "workspace_write",
+        cwd: root,
+        platform: "linux",
+        sandboxManager: fakeManager,
+        probe: fallbackStatus,
+      });
+
+      expect(() =>
+        broker.prepareSpawn("mcp_stdio", {
+          program: "/bin/echo",
+          args: ["ok"],
+          cwd: root,
+          env: {},
+        }),
+      ).toThrowError(
+        expect.objectContaining({
+          code: "sandbox_policy_unexpressible",
+          surface: "mcp_stdio",
+          message: expect.stringMatching(
+            /read-only subpath.*\.agenc.*agenc doctor --apparmor-profile/s,
+          ),
+        }),
+      );
+    });
+
+    it("rechecks carve-out existence on every spawn instead of memoizing", () => {
+      const root = tempRoot("agenc-broker-preflight-recheck-");
+      const broker = new SandboxExecutionBroker({
+        mode: "workspace_write",
+        cwd: root,
+        platform: "linux",
+        sandboxManager: fakeManager,
+        probe: fallbackStatus,
+      });
+      const command = {
+        program: "/bin/echo",
+        args: ["ok"],
+        cwd: root,
+        env: {},
+      };
+
+      expect(() => broker.prepareSpawn("tool", command)).not.toThrow();
+      mkdirSync(join(root, ".agenc"));
+      expect(() => broker.prepareSpawn("tool", command)).toThrowError(
+        expect.objectContaining({ code: "sandbox_policy_unexpressible" }),
+      );
+    });
+
+    it("skips the pre-flight for inherited read-only cwd spawns", () => {
+      const root = tempRoot("agenc-broker-preflight-inherited-");
+      mkdirSync(join(root, ".agenc"));
+      const broker = new SandboxExecutionBroker({
+        mode: "workspace_write",
+        cwd: root,
+        platform: "linux",
+        sandboxManager: fakeManager,
+        probe: fallbackStatus,
+      });
+
+      expect(() =>
+        broker.prepareSpawn("tool", {
+          program: "/bin/echo",
+          args: ["ok"],
+          cwd: root,
+          env: {},
+          cwdBinding: "inherited_readonly",
+        }),
+      ).not.toThrow();
+    });
+
+    it("never invokes the planner on a healthy bubblewrap host", () => {
+      const root = tempRoot("agenc-broker-preflight-healthy-");
+      mkdirSync(join(root, ".agenc"));
+      const planSpy = vi.fn(() => ({
+        kind: "refused" as const,
+        reason: "should never be consulted",
+      }));
+      const broker = new SandboxExecutionBroker({
+        mode: "workspace_write",
+        cwd: root,
+        platform: "linux",
+        sandboxManager: fakeManager,
+        probe: () => ({ ...readyStatus("workspace_write"), platform: "linux" }),
+        planLandlockPolicy: planSpy,
+      });
+
+      expect(() =>
+        broker.prepareSpawn("tool", {
+          program: "/bin/echo",
+          args: ["ok"],
+          cwd: root,
+          env: {},
+        }),
+      ).not.toThrow();
+      expect(planSpy).not.toHaveBeenCalled();
+    });
+
+    it("a tight profile override makes the same spawn expressible, and additionalPermissions still merge", () => {
+      const root = tempRoot("agenc-broker-preflight-override-");
+      mkdirSync(join(root, ".agenc"));
+      const dataDir = join(root, "plugin-data");
+      mkdirSync(dataDir);
+      const broker = new SandboxExecutionBroker({
+        mode: "workspace_write",
+        cwd: root,
+        platform: "linux",
+        sandboxManager: fakeManager,
+        probe: fallbackStatus,
+      });
+      const override = {
+        fileSystem: {
+          kind: "restricted",
+          entries: [
+            {
+              path: { kind: "special", value: { kind: "root" } },
+              access: "read",
+            },
+            { path: { kind: "path", path: dataDir }, access: "write" },
+          ],
+          includePlatformDefaults: true,
+        },
+        network: "disabled",
+      } as never;
+
+      // Default workspace profile refuses (existing .agenc carve-out) …
+      expect(() =>
+        broker.prepareSpawn("mcp_stdio", {
+          program: "/bin/echo",
+          args: ["ok"],
+          cwd: root,
+          env: {},
+        }),
+      ).toThrowError(
+        expect.objectContaining({ code: "sandbox_policy_unexpressible" }),
+      );
+      // … the tight override plans cleanly …
+      expect(() =>
+        broker.prepareSpawn("mcp_stdio", {
+          program: "/bin/echo",
+          args: ["ok"],
+          cwd: root,
+          env: {},
+          permissionProfileOverride: override,
+        }),
+      ).not.toThrow();
+      // … and additive surface grants still merge on top of the override:
+      // granting the project root back re-introduces the carve-out refusal.
+      expect(() =>
+        broker.prepareSpawn("mcp_stdio", {
+          program: "/bin/echo",
+          args: ["ok"],
+          cwd: root,
+          env: {},
+          permissionProfileOverride: override,
+          additionalPermissions: {
+            fileSystem: {
+              entries: [
+                { path: { kind: "path", path: root }, access: "write" },
+              ],
+            },
+          } as never,
+        }),
+      ).toThrowError(
+        expect.objectContaining({ code: "sandbox_policy_unexpressible" }),
+      );
+    });
+  });
+
   it("rebases captured boundaries and forks independent child roots", async () => {
     const root = tempRoot("agenc-sandbox-broker-root-");
     const child = tempRoot("agenc-sandbox-broker-child-");

--- a/runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/landlock-fallback.test.ts
@@ -78,6 +78,61 @@ describe("planLandlockConfinement refusals", () => {
     { path: { kind: "path", path: "/tmp" }, access: "write" },
   ]);
 
+  it("accepts the plugin MCP profile shape (root read + data-dir writes)", () => {
+    // The tight plugin-server profile: no writable project root, so no
+    // existing .git/.agenc carve-outs — the fallback must express it, which
+    // is what keeps plugin MCP servers working on bubblewrap-less hosts.
+    const dataDir = withTempDir("agenc-landlock-plan-plugindata-");
+    fs.mkdirSync(path.join(dataDir, "tmp"));
+    const plan = planLandlockConfinement({
+      ...base,
+      fileSystem: restrictedFileSystemPolicy(
+        [
+          {
+            path: { kind: "special", value: { kind: "root" } },
+            access: "read",
+          },
+          { path: { kind: "path", path: dataDir }, access: "write" },
+          {
+            path: { kind: "path", path: path.join(dataDir, "tmp") },
+            access: "write",
+          },
+        ],
+        { includePlatformDefaults: true },
+      ),
+    });
+    expect(plan).toMatchObject({
+      kind: "ok",
+      readWrite: expect.arrayContaining([dataDir]),
+    });
+  });
+
+  it("still refuses the workspace profile over an existing .agenc (regression guard)", () => {
+    const project = withTempDir("agenc-landlock-plan-project-");
+    fs.mkdirSync(path.join(project, ".agenc"));
+    const plan = planLandlockConfinement({
+      ...base,
+      sandboxPolicyCwd: project,
+      fileSystem: restrictedFileSystemPolicy(
+        [
+          {
+            path: { kind: "special", value: { kind: "root" } },
+            access: "read",
+          },
+          {
+            path: { kind: "special", value: { kind: "project_roots" } },
+            access: "write",
+          },
+        ],
+        { includePlatformDefaults: true },
+      ),
+    });
+    expect(plan).toMatchObject({
+      kind: "refused",
+      reason: expect.stringContaining(".agenc"),
+    });
+  });
+
   it("refuses managed proxy networking", () => {
     const plan = planLandlockConfinement({
       ...base,

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -409,6 +409,21 @@ describe("Linux sandbox launcher", () => {
     const program = createNetworkSeccompProgram("restricted", "x64");
     expect(program.length).toBeGreaterThan(8 * 10);
     expect(program.length % 8).toBe(0);
+    const restrictedDenied = deniedSyscalls(program);
+    // Connectivity stays closed …
+    expect(restrictedDenied).toContain(42); // connect
+    expect(restrictedDenied).toContain(49); // bind
+    expect(restrictedDenied).toContain(50); // listen
+    expect(restrictedDenied).toContain(44); // sendto
+    expect(restrictedDenied).toContain(54); // setsockopt
+    // … but read-only socket introspection must stay ALLOWED: node's libuv
+    // classifies inherited stdio with getsockname, and child_process "pipe"
+    // stdio are AF_UNIX socketpairs — denying it gave every node-spawned
+    // confined child (stdio MCP servers under the Landlock fallback)
+    // instant EOF on stdin.
+    expect(restrictedDenied).not.toContain(51); // getsockname
+    expect(restrictedDenied).not.toContain(52); // getpeername
+    expect(restrictedDenied).not.toContain(55); // getsockopt
     expect(networkSeccompMode("disabled", false, false)).toBe("restricted");
     expect(networkSeccompMode("enabled", false, false)).toBeNull();
     expect(networkSeccompMode("enabled", true, true)).toBe("proxy-routed");

--- a/runtime/tests/utils/doctorDiagnostic.sandbox.test.ts
+++ b/runtime/tests/utils/doctorDiagnostic.sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildLandlockFallbackWarning,
   buildSandboxWarning,
   getSandboxDoctorStatus,
 } from "../../src/utils/doctorDiagnostic.js";
@@ -29,6 +30,50 @@ describe("sandbox doctor diagnostic", () => {
         "[sandbox_required_unavailable] probe: user namespaces are disabled",
       fix: "enable unprivileged user namespaces",
     });
+  });
+
+  it("warns loudly when readiness came through the Landlock fallback", async () => {
+    const status = await getSandboxDoctorStatus({
+      config: { sandbox_mode: "workspace-write" },
+      cwd: process.cwd(),
+      probe: ({ mode, platform }) => ({
+        kind: "ready",
+        mode,
+        platform,
+        landlock: "full",
+        reason:
+          "probe: bubblewrap could not create the required namespaces; the Landlock fallback is active",
+        landlockFallback: {
+          reason: "probe: bubblewrap could not create the required namespaces",
+          remediation:
+            "Install AgenC's narrow per-command profile with: agenc doctor --apparmor-profile | sudo tee /etc/apparmor.d/agenc-native-userns >/dev/null && sudo apparmor_parser -r /etc/apparmor.d/agenc-native-userns; then run `agenc doctor` again.",
+        },
+      }),
+    });
+
+    const warning = buildLandlockFallbackWarning(status);
+    expect(warning).toMatchObject({
+      issue: expect.stringMatching(
+        /\[sandbox_landlock_fallback\] bubblewrap is unusable .*\.git\/\.agenc.*MCP stdio servers/s,
+      ),
+      fix: expect.stringContaining("agenc doctor --apparmor-profile"),
+    });
+    // The plain unavailable warning must NOT double-fire on ready status.
+    expect(buildSandboxWarning(status)).toBeNull();
+  });
+
+  it("does not emit the fallback warning on a healthy bubblewrap host", async () => {
+    const status = await getSandboxDoctorStatus({
+      config: { sandbox_mode: "workspace-write" },
+      cwd: process.cwd(),
+      probe: ({ mode, platform }) => ({
+        kind: "ready",
+        mode,
+        platform,
+      }),
+    });
+
+    expect(buildLandlockFallbackWarning(status)).toBeNull();
   });
 
   it("does not warn for an explicit danger-full-access selection", async () => {


### PR DESCRIPTION
Deep fixes for the sandbox/MCP fail-closed gap found while live-testing the agenc-goal plugin (follow-up to #1768). Five root causes; full investigation with syscall-level evidence in `docs/daemon-autostart-spin-2026-08-23.md`. Design went through two full code maps plus an adversarial review (14 findings, all folded in).

## The chain (all links fixed)

1. **Guaranteed-generic failures at spawn**: the probe reports ready via the Landlock fallback while every workspace-write policy is refused at spawn (Landlock cannot express read-only `.git`/`.agenc` carve-outs inside a writable root, and agenc always creates `<project>/.agenc`). The broker now pre-flights `planLandlockConfinement` on fallback hosts and throws a typed `sandbox_policy_unexpressible` error with the plan reason plus the cause-correct bubblewrap remediation. Skips inherited-readonly-cwd spawns (Glob/Grep, whose profile is replaced with root-read); no memoization (carve-out existence is rechecked per spawn like the launcher does); best-effort by design with the stderr capture as backstop.
2. **Discarded diagnostics**: the stdio transport now retains a bounded ring of child stderr and attaches the tail to pre-handshake connect failures, so /mcp shows root causes instead of bare "MCP error -32000: Connection closed" (the production manager runs a silent logger).
3. **Dead pluginSandbox metadata**: plugin-declared MCP servers now spawn under their intended tight profile (root read; writes confined to the plugin data dir + its `tmp/`, TMPDIR pointed there) via a new `permissionProfileOverride` on `SandboxSpawnCommand`, honored only under workspace_write (tighten, never widen). Stricter under bubblewrap AND Landlock-expressible.
4. **Seccomp vs socketpair stdio** (found only in live verification): the restricted-network filter denied `getsockname`/`getpeername`/`getsockopt`; Node's `child_process` "pipe" stdio are AF_UNIX socketpairs and libuv classifies inherited stdio with `getsockname`, so every node-spawned confined child hit `getsockname(0) => EPERM` and instant stdin EOF. Read-only socket introspection is now allowed; creation stays AF_UNIX-only, connect/bind/listen/accept/send*/setsockopt stay denied.
5. **Silent degraded readiness**: `agenc doctor` now emits `[sandbox_landlock_fallback]` (exit 1) with the probe-time remediation via a structured `landlockFallback` status field. `docs/install.md` states there is no safe partial waiver under the fallback and flags `[sandbox_policy] writable_roots` as a dead config key.

## Live verification (AppArmor-restricted host, bwrap unusable)

- `agenc doctor` warns with the exact `agenc doctor --apparmor-profile | sudo tee ...` commands.
- Plugin MCP server: `connected` in /mcp with its tools bridged under the Landlock fallback; tool catalog grew 88 -> 97; a model Tool search returned `mcp.plugin:agenc-goal:agenc-goal.goal_create` (the same probe returned zero matches before).
- A raw workspace-write mcp_stdio spawn on the same host fails with the full `[sandbox_policy_unexpressible] ... <project>/.agenc ...` message.

## Tests

405 across sandbox + mcp-client + doctor suites (hermetic runner), including: pre-flight refusal/recheck/skip/override cases with an injectable planner seam, Landlock plan acceptance of the plugin profile + `.agenc` refusal regression guard, stderr-tail attachment, pluginSandbox-to-override routing, seccomp allow/deny assertions, and the doctor fallback warning. Revert-sensitivity verified by stashing `runtime/src`.

https://claude.ai/code/session_01Aij5FrVBscsow7WRSfiQE6