### PR TITLE
fix(runtime): fail closed in the sandbox launcher and eval CLIs

### DIFF
--- a/runtime/src/eval-contract/cli.ts
+++ b/runtime/src/eval-contract/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { open } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import {
@@ -11,19 +12,58 @@ import {
 
 const MAX_DOCUMENT_BYTES = 64 * 1024 * 1024;
 
+/**
+ * Read one evaluation document as a regular, non-symlink file of bounded
+ * size. The open never follows a symlink and never blocks on a FIFO or
+ * device, and the object identity is checked before and after the read so a
+ * swapped or growing file is rejected instead of half-read.
+ */
 async function readBoundedJson(file: string): Promise<unknown> {
-  const handle = await open(file, "r");
+  const pathBefore = await lstat(file, { bigint: true });
+  if (pathBefore.isSymbolicLink() || !pathBefore.isFile()) {
+    throw new Error(`${file} must be a regular non-symlink file`);
+  }
+  if (pathBefore.size > BigInt(MAX_DOCUMENT_BYTES)) {
+    throw new Error(`evaluation document exceeds ${MAX_DOCUMENT_BYTES} bytes`);
+  }
+  const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+  const nonBlocking = process.platform === "win32" ? 0 : constants.O_NONBLOCK;
+  const handle = await open(file, constants.O_RDONLY | noFollow | nonBlocking);
   try {
-    const before = await handle.stat();
-    if (!before.isFile() || before.size > MAX_DOCUMENT_BYTES) {
-      throw new Error(`evaluation document exceeds ${MAX_DOCUMENT_BYTES} bytes or is not a regular file`);
+    const before = await handle.stat({ bigint: true });
+    if (
+      !before.isFile() ||
+      before.dev !== pathBefore.dev ||
+      before.ino !== pathBefore.ino ||
+      before.size !== pathBefore.size
+    ) {
+      throw new Error("evaluation document changed before it could be opened");
     }
-    const bytes = await handle.readFile();
-    const after = await handle.stat();
-    if (after.size !== before.size || bytes.byteLength !== before.size) {
+    // Read one byte past the observed size so growth during the read is
+    // detected instead of silently truncated.
+    const expectedBytes = Number(before.size);
+    const buffer = Buffer.allocUnsafe(expectedBytes + 1);
+    let byteLength = 0;
+    while (byteLength < buffer.byteLength) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        byteLength,
+        buffer.byteLength - byteLength,
+        byteLength,
+      );
+      if (bytesRead === 0) break;
+      byteLength += bytesRead;
+    }
+    const after = await handle.stat({ bigint: true });
+    if (
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.size !== before.size ||
+      BigInt(byteLength) !== before.size
+    ) {
       throw new Error("evaluation document changed while it was being read");
     }
-    return JSON.parse(bytes.toString("utf8")) as unknown;
+    return JSON.parse(buffer.subarray(0, byteLength).toString("utf8")) as unknown;
   } finally {
     await handle.close();
   }
@@ -38,11 +78,20 @@ function usage(): never {
 
 async function main(): Promise<void> {
   const arguments_ = process.argv.slice(2);
-  const legacy = arguments_.includes("--legacy");
-  const json = arguments_.includes("--json");
-  const files = arguments_.filter((argument) => !argument.startsWith("--"));
-  if (files.length === 0 || arguments_.some((argument) =>
-    argument.startsWith("--") && argument !== "--legacy" && argument !== "--json")) {
+  // Options end at the first "--"; everything after it is a file name, so a
+  // document whose name starts with a dash can still be checked. Any other
+  // dash-prefixed argument that is not a known flag is a usage error.
+  const separator = arguments_.indexOf("--");
+  const optionArguments = separator === -1 ? arguments_ : arguments_.slice(0, separator);
+  const trailingFiles = separator === -1 ? [] : arguments_.slice(separator + 1);
+  const legacy = optionArguments.includes("--legacy");
+  const json = optionArguments.includes("--json");
+  const files = [
+    ...optionArguments.filter((argument) => !argument.startsWith("-")),
+    ...trailingFiles,
+  ];
+  if (files.length === 0 || optionArguments.some((argument) =>
+    argument.startsWith("-") && argument !== "--legacy" && argument !== "--json")) {
     usage();
   }
   const results: Array<Record<string, unknown>> = [];

--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -1,8 +1,10 @@
 import { randomBytes, randomInt } from "node:crypto";
 import { resolve4 } from "node:dns/promises";
 import { mkdir, writeFile } from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 import { runAgentOnTask, runRealProviderAgentOnTask } from "./agent-run.js";
 import {
@@ -31,6 +33,52 @@ const DEFAULT_LOCK_PATH =
   "eval/suites/competitive-coding/1.0.0/task-sets/pilot/1.0.0/source-lock.json";
 
 const DEFAULT_TRUST_SUITE_DIR = "eval/suites/trust-conformance/1.0.0";
+
+/**
+ * Parse an integer option strictly: decimal digits only, so hexadecimal,
+ * exponent, signed, blank, and empty spellings are rejected instead of being
+ * coerced by Number() into a value the operator did not write.
+ */
+function parseIntegerOption(raw: string, flag: string, minimum: number): number {
+  const message = `${flag} must be a decimal integer of at least ${minimum}`;
+  if (!/^[0-9]+$/u.test(raw)) {
+    throw new EvalExecutorError([message]);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new EvalExecutorError([message]);
+  }
+  return value;
+}
+
+/**
+ * Resolve the provider host to the IPv4 addresses the egress sidecar pins.
+ * An IPv4 literal is pinned as given; an IPv6 literal is refused because the
+ * lane only dials IPv4; a hostname that resolves to nothing fails with the
+ * resolver's reason instead of a bare "could not resolve".
+ */
+async function resolveProviderPins(host: string): Promise<string[]> {
+  if (net.isIPv4(host)) {
+    return [host];
+  }
+  if (net.isIPv6(host)) {
+    throw new EvalExecutorError([
+      `provider host ${host} must be a hostname or IPv4 literal; the egress lane pins IPv4 addresses`,
+    ]);
+  }
+  let addresses: string[];
+  try {
+    addresses = await resolve4(host);
+  } catch (error) {
+    throw new EvalExecutorError([
+      `could not resolve an IPv4 address for ${host}: ${error instanceof Error ? error.message : String(error)}`,
+    ]);
+  }
+  if (addresses.length === 0) {
+    throw new EvalExecutorError([`could not resolve any IPv4 address for ${host}`]);
+  }
+  return addresses;
+}
 
 const USAGE = `Usage:
   eval:executor verify-lock [--lock <source-lock.json>]
@@ -244,10 +292,7 @@ async function runRealProviderAgentTask(
   await runner.environment();
   // Resolve the provider host once, on the host, to a set of pinned IPs the
   // sidecar dials — so a mid-run DNS flip cannot redirect egress.
-  const pinIps = await resolve4(options.allowHost);
-  if (pinIps.length === 0) {
-    throw new EvalExecutorError([`could not resolve any IP for ${options.allowHost}`]);
-  }
+  const pinIps = await resolveProviderPins(options.allowHost);
   const { report, patchBytes, rawAgentResult } = await runRealProviderAgentOnTask(
     runner,
     (request) => runner.createEgressLane(request),
@@ -349,15 +394,11 @@ async function runRealProviderAgentBatch(
   return summary.driverErrors === 0 ? 0 : 1;
 }
 
-export async function main(argv: readonly string[]): Promise<number> {
-  const [command, ...rest] = argv;
-  if (!command || command === "--help" || command === "-h") {
-    process.stdout.write(`${USAGE}\n`);
-    return command ? 0 : 2;
-  }
-  const { values } = parseArgs({
-    args: [...rest],
-    options: {
+function parseCommandOptions(rest: readonly string[]) {
+  try {
+    return parseArgs({
+      args: [...rest],
+      options: {
       lock: { type: "string" },
       task: { type: "string" },
       output: { type: "string" },
@@ -373,10 +414,33 @@ export async function main(argv: readonly string[]): Promise<number> {
       tasks: { type: "string" },
       "suite-dir": { type: "string" },
       "seed-slot": { type: "string" },
-      "repository-commit": { type: "string" },
-    },
-    strict: true,
-  });
+        "repository-commit": { type: "string" },
+      },
+      strict: true,
+    }).values;
+  } catch (error) {
+    throw new EvalExecutorError([
+      `${error instanceof Error ? error.message : String(error)} (run with --help for usage)`,
+    ]);
+  }
+}
+
+export async function main(argv: readonly string[]): Promise<number> {
+  const [command, ...rest] = argv;
+  if (
+    command === "--help" ||
+    command === "-h" ||
+    rest.includes("--help") ||
+    rest.includes("-h")
+  ) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  if (!command) {
+    process.stderr.write(`${USAGE}\n`);
+    return 2;
+  }
+  const values = parseCommandOptions(rest);
   const lockPath = values.lock ?? DEFAULT_LOCK_PATH;
   if (command === "verify-lock") {
     return verifyLock(lockPath);
@@ -402,10 +466,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       throw new EvalExecutorError(["run-agent requires --task <instanceId> and --overlay <dir>"]);
     }
     const timeoutRaw = values["agent-timeout-ms"];
-    const agentTimeoutMs = timeoutRaw === undefined ? undefined : Number(timeoutRaw);
-    if (agentTimeoutMs !== undefined && (!Number.isSafeInteger(agentTimeoutMs) || agentTimeoutMs <= 0)) {
-      throw new EvalExecutorError(["--agent-timeout-ms must be a positive integer"]);
-    }
+    const agentTimeoutMs = timeoutRaw === undefined
+      ? undefined
+      : parseIntegerOption(timeoutRaw, "--agent-timeout-ms", 1);
     return runAgent({
       lockPath,
       taskId: values.task,
@@ -428,10 +491,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       ]);
     }
     const timeoutRaw = values["agent-timeout-ms"];
-    const agentTimeoutMs = timeoutRaw === undefined ? undefined : Number(timeoutRaw);
-    if (agentTimeoutMs !== undefined && (!Number.isSafeInteger(agentTimeoutMs) || agentTimeoutMs <= 0)) {
-      throw new EvalExecutorError(["--agent-timeout-ms must be a positive integer"]);
-    }
+    const agentTimeoutMs = timeoutRaw === undefined
+      ? undefined
+      : parseIntegerOption(timeoutRaw, "--agent-timeout-ms", 1);
     return runRealProviderAgent({
       lockPath,
       taskId: values.task,
@@ -458,15 +520,17 @@ export async function main(argv: readonly string[]): Promise<number> {
       ]);
     }
     const timeoutRaw = values["agent-timeout-ms"];
-    const agentTimeoutMs = timeoutRaw === undefined ? undefined : Number(timeoutRaw);
-    if (agentTimeoutMs !== undefined && (!Number.isSafeInteger(agentTimeoutMs) || agentTimeoutMs <= 0)) {
-      throw new EvalExecutorError(["--agent-timeout-ms must be a positive integer"]);
-    }
+    const agentTimeoutMs = timeoutRaw === undefined
+      ? undefined
+      : parseIntegerOption(timeoutRaw, "--agent-timeout-ms", 1);
     const taskIds = values.tasks === undefined
       ? undefined
       : values.tasks.split(",").map((id) => id.trim()).filter((id) => id.length > 0);
     if (taskIds !== undefined && taskIds.length === 0) {
       throw new EvalExecutorError(["--tasks must name at least one task id"]);
+    }
+    if (taskIds !== undefined && new Set(taskIds).size !== taskIds.length) {
+      throw new EvalExecutorError(["--tasks must not repeat a task id"]);
     }
     return runRealProviderAgentBatch({
       lockPath,
@@ -490,10 +554,9 @@ export async function main(argv: readonly string[]): Promise<number> {
       ]);
     }
     const seedSlotRaw = values["seed-slot"];
-    const seedSlot = seedSlotRaw === undefined ? 0 : Number(seedSlotRaw);
-    if (!Number.isSafeInteger(seedSlot) || seedSlot < 0) {
-      throw new EvalExecutorError(["--seed-slot must be a non-negative integer"]);
-    }
+    const seedSlot = seedSlotRaw === undefined
+      ? 0
+      : parseIntegerOption(seedSlotRaw, "--seed-slot", 0);
     const summary = await runTrustSuiteFromFiles({
       suiteDir: values["suite-dir"] ?? DEFAULT_TRUST_SUITE_DIR,
       seedSlot,
@@ -509,9 +572,48 @@ export async function main(argv: readonly string[]): Promise<number> {
   return 2;
 }
 
-const isDirectInvocation = process.argv[1] !== undefined &&
-  import.meta.url === new URL(`file://${path.resolve(process.argv[1])}`).href;
-if (isDirectInvocation) {
+/**
+ * True when this module is the script Node was asked to run. The comparison
+ * goes through pathToFileURL so a checkout path containing `#`, `%`, or
+ * another URL-significant character still matches; building the URL by
+ * string concatenation made the CLI a silent no-op under such paths.
+ */
+export function isDirectInvocation(
+  moduleUrl: string,
+  scriptPath: string | undefined,
+): boolean {
+  if (scriptPath === undefined) {
+    return false;
+  }
+  try {
+    return moduleUrl === pathToFileURL(path.resolve(scriptPath)).href;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Containers and networks are normally removed by the finally blocks in the
+ * run paths. A termination signal would skip those, so remove everything this
+ * process created before exiting with the conventional signal status. The
+ * handlers are one-shot: a second signal falls back to Node's default.
+ */
+function installSignalCleanup(): void {
+  const onSignal = (signal: NodeJS.Signals): void => {
+    const code = signal === "SIGINT" ? 130 : 143;
+    process.stderr.write(
+      `${signal}: removing eval-executor containers and networks before exit\n`,
+    );
+    void DockerContainerRunner.abortAll().finally(() => {
+      process.exit(code);
+    });
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+}
+
+if (isDirectInvocation(import.meta.url, process.argv[1])) {
+  installSignalCleanup();
   main(process.argv.slice(2)).then(
     (code) => {
       process.exitCode = code;

--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -599,8 +599,15 @@ export function isDirectInvocation(
  * handlers are one-shot: a second signal falls back to Node's default.
  */
 function installSignalCleanup(): void {
+  let cleanupStarted = false;
   const onSignal = (signal: NodeJS.Signals): void => {
     const code = signal === "SIGINT" ? 130 : 143;
+    // A second signal of either kind ends the process at once; the first
+    // one's cleanup is best effort and must never hold an operator hostage.
+    if (cleanupStarted) {
+      process.exit(code);
+    }
+    cleanupStarted = true;
     process.stderr.write(
       `${signal}: removing eval-executor containers and networks before exit\n`,
     );
@@ -608,8 +615,8 @@ function installSignalCleanup(): void {
       process.exit(code);
     });
   };
-  process.once("SIGINT", onSignal);
-  process.once("SIGTERM", onSignal);
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
 }
 
 if (isDirectInvocation(import.meta.url, process.argv[1])) {

--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -595,8 +595,8 @@ export function isDirectInvocation(
 /**
  * Containers and networks are normally removed by the finally blocks in the
  * run paths. A termination signal would skip those, so remove everything this
- * process created before exiting with the conventional signal status. The
- * handlers are one-shot: a second signal falls back to Node's default.
+ * process created before exiting with the conventional signal status. A
+ * second signal of either kind exits immediately without a second sweep.
  */
 function installSignalCleanup(): void {
   let cleanupStarted = false;

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -185,9 +185,9 @@ export class DockerContainerRunner implements ContainerRunner {
 
   /**
    * Force-remove every live container and network of every runner. New
-   * creations are refused from the first call onward, and the sweep runs
-   * twice so anything registered during the first pass is caught by the
-   * second.
+   * creations are refused from the first call onward; the sweep removes what
+   * is live, waits for creates that were already past the check, then sweeps
+   * once more so their results are removed too.
    */
   static async abortAll(): Promise<void> {
     aborting = true;

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -141,6 +141,22 @@ function assertNotAborting(): void {
   }
 }
 
+/**
+ * Creates that passed the shutdown check and have not settled. A create is
+ * registered synchronously, before its first docker call, so a sweep that
+ * starts afterwards can wait for it and then remove what it made.
+ */
+const inFlightCreates = new Set<Promise<unknown>>();
+
+function trackInFlight<T>(work: Promise<T>): Promise<T> {
+  inFlightCreates.add(work);
+  const settle = (): void => {
+    inFlightCreates.delete(work);
+  };
+  void work.then(settle, settle);
+  return work;
+}
+
 export class DockerContainerRunner implements ContainerRunner {
   /** Containers this runner created and has not yet removed. */
   private readonly liveContainers = new Set<string>();
@@ -175,10 +191,14 @@ export class DockerContainerRunner implements ContainerRunner {
    */
   static async abortAll(): Promise<void> {
     aborting = true;
-    for (let pass = 0; pass < 2; pass += 1) {
-      for (const runner of activeRunners) {
-        await runner.abortLive();
-      }
+    for (const runner of activeRunners) {
+      await runner.abortLive();
+    }
+    // A create that passed the shutdown check before the flag was set may
+    // still be issuing docker calls; wait for it, then sweep what it made.
+    await Promise.allSettled([...inFlightCreates]);
+    for (const runner of activeRunners) {
+      await runner.abortLive();
     }
   }
 
@@ -209,6 +229,13 @@ export class DockerContainerRunner implements ContainerRunner {
   async createTaskContainer(
     imageReference: string,
     options: CreateTaskContainerOptions = {},
+  ): Promise<ContainerHandle> {
+    return trackInFlight(this.createTaskContainerNow(imageReference, options));
+  }
+
+  private async createTaskContainerNow(
+    imageReference: string,
+    options: CreateTaskContainerOptions,
   ): Promise<ContainerHandle> {
     assertNotAborting();
     const { dockerReference, imageDigest } = this.resolveImageRef(imageReference);
@@ -295,6 +322,10 @@ export class DockerContainerRunner implements ContainerRunner {
   }
 
   async createAuxiliaryContainer(imageReference: string): Promise<ContainerHandle> {
+    return trackInFlight(this.createAuxiliaryContainerNow(imageReference));
+  }
+
+  private async createAuxiliaryContainerNow(imageReference: string): Promise<ContainerHandle> {
     assertNotAborting();
     const { dockerReference, imageDigest } = this.resolveImageRef(imageReference);
     const created = await spawnBounded(
@@ -330,6 +361,10 @@ export class DockerContainerRunner implements ContainerRunner {
    * `teardown()` in a finally.
    */
   async createEgressLane(request: EgressLaneRequest): Promise<EgressLane> {
+    return trackInFlight(this.createEgressLaneNow(request));
+  }
+
+  private async createEgressLaneNow(request: EgressLaneRequest): Promise<EgressLane> {
     assertNotAborting();
     const { dockerReference, imageDigest } = this.resolveImageRef(request.taskImage);
     const overlayHostDir = request.overlayHostDir;

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -125,8 +125,41 @@ const LOCAL_IMAGE_ID_PATTERN = /^sha256:[0-9a-f]{64}$/u;
  * offline by contract, and a rebuild step that needs egress must fail loudly
  * as QA signal instead of being quietly granted network.
  */
+/** Every runner constructed in this process, for signal-time cleanup. */
+const activeRunners = new Set<DockerContainerRunner>();
+
 export class DockerContainerRunner implements ContainerRunner {
-  constructor(private readonly options: DockerContainerRunnerOptions = {}) {}
+  /** Containers this runner created and has not yet removed. */
+  private readonly liveContainers = new Set<string>();
+  /** Networks this runner created and has not yet removed. */
+  private readonly liveNetworks = new Set<string>();
+
+  constructor(private readonly options: DockerContainerRunnerOptions = {}) {
+    activeRunners.add(this);
+  }
+
+  /**
+   * Force-remove everything this runner still owns. The run paths remove
+   * containers and lanes in finally blocks; this is for the CLI's signal
+   * handler, where those blocks never run. Best effort and bounded per item.
+   */
+  async abortLive(): Promise<void> {
+    for (const id of [...this.liveContainers]) {
+      await spawnBounded("docker", ["rm", "-f", id], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+      this.liveContainers.delete(id);
+    }
+    for (const name of [...this.liveNetworks]) {
+      await spawnBounded("docker", ["network", "rm", name], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+      this.liveNetworks.delete(name);
+    }
+  }
+
+  /** Force-remove every live container and network of every runner. */
+  static async abortAll(): Promise<void> {
+    for (const runner of activeRunners) {
+      await runner.abortLive();
+    }
+  }
 
   async environment(): Promise<ContainerEnvironment> {
     const version = await spawnBounded(
@@ -186,11 +219,13 @@ export class DockerContainerRunner implements ContainerRunner {
       ]);
     }
     const id = created.stdout.trim();
+    this.liveContainers.add(id);
     const started = await spawnBounded("docker", ["start", id], {
       timeoutMs: DOCKER_COMMAND_TIMEOUT_MS,
     });
     if (started.exitCode !== 0) {
       await spawnBounded("docker", ["rm", "-f", id], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+      this.liveContainers.delete(id);
       throw new EvalExecutorError([
         `docker start failed for ${imageReference}: ${started.stderr.trim()}`,
       ]);
@@ -245,11 +280,13 @@ export class DockerContainerRunner implements ContainerRunner {
       ]);
     }
     const id = created.stdout.trim();
+    this.liveContainers.add(id);
     const started = await spawnBounded("docker", ["start", id], {
       timeoutMs: DOCKER_COMMAND_TIMEOUT_MS,
     });
     if (started.exitCode !== 0) {
       await spawnBounded("docker", ["rm", "-f", id], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+      this.liveContainers.delete(id);
       throw new EvalExecutorError([
         `docker start failed for auxiliary image ${imageReference}: ${started.stderr.trim()}`,
       ]);
@@ -287,9 +324,11 @@ export class DockerContainerRunner implements ContainerRunner {
     const teardown = async (): Promise<void> => {
       for (const id of containers) {
         await spawnBounded("docker", ["rm", "-f", id], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+        this.liveContainers.delete(id);
       }
       for (const name of networks) {
         await spawnBounded("docker", ["network", "rm", name], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS });
+        this.liveNetworks.delete(name);
       }
     };
     const requireOk = (result: SpawnResult, what: string): SpawnResult => {
@@ -304,11 +343,13 @@ export class DockerContainerRunner implements ContainerRunner {
         "egress network create",
       );
       networks.push(plan.egressNetName);
+      this.liveNetworks.add(plan.egressNetName);
       requireOk(
         await spawnBounded("docker", [...plan.upstreamCreateArgs], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS }),
         "upstream network create",
       );
       networks.push(plan.upstreamNetName);
+      this.liveNetworks.add(plan.upstreamNetName);
 
       const sidecarArgs = buildSidecarCreateArgs({
         name: `agenc-eval-proxy-${request.runId}`,
@@ -329,6 +370,7 @@ export class DockerContainerRunner implements ContainerRunner {
       const sidecarId = sidecar.stdout.trim();
       if (!sidecarId) throw new EvalExecutorError(["sidecar create returned no id"]);
       containers.push(sidecarId);
+      this.liveContainers.add(sidecarId);
       requireOk(
         await spawnBounded(
           "docker", ["network", "connect", plan.upstreamNetName, sidecarId],
@@ -358,6 +400,7 @@ export class DockerContainerRunner implements ContainerRunner {
       const agentId = agent.stdout.trim();
       if (!agentId) throw new EvalExecutorError(["agent create returned no id"]);
       containers.push(agentId);
+      this.liveContainers.add(agentId);
       requireOk(
         await spawnBounded("docker", ["start", agentId], { timeoutMs: DOCKER_COMMAND_TIMEOUT_MS }),
         "agent container start",
@@ -497,5 +540,6 @@ export class DockerContainerRunner implements ContainerRunner {
     await spawnBounded("docker", ["rm", "-f", handle.id], {
       timeoutMs: DOCKER_COMMAND_TIMEOUT_MS,
     });
+    this.liveContainers.delete(handle.id);
   }
 }

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -128,6 +128,19 @@ const LOCAL_IMAGE_ID_PATTERN = /^sha256:[0-9a-f]{64}$/u;
 /** Every runner constructed in this process, for signal-time cleanup. */
 const activeRunners = new Set<DockerContainerRunner>();
 
+/**
+ * Set once abortAll() starts. Run paths keep executing while the cleanup
+ * removes what exists (a killed docker exec surfaces as a per-task error and
+ * a batch moves on), so every create path refuses new work from this point.
+ */
+let aborting = false;
+
+function assertNotAborting(): void {
+  if (aborting) {
+    throw new EvalExecutorError(["eval-executor is shutting down"]);
+  }
+}
+
 export class DockerContainerRunner implements ContainerRunner {
   /** Containers this runner created and has not yet removed. */
   private readonly liveContainers = new Set<string>();
@@ -154,11 +167,24 @@ export class DockerContainerRunner implements ContainerRunner {
     }
   }
 
-  /** Force-remove every live container and network of every runner. */
+  /**
+   * Force-remove every live container and network of every runner. New
+   * creations are refused from the first call onward, and the sweep runs
+   * twice so anything registered during the first pass is caught by the
+   * second.
+   */
   static async abortAll(): Promise<void> {
-    for (const runner of activeRunners) {
-      await runner.abortLive();
+    aborting = true;
+    for (let pass = 0; pass < 2; pass += 1) {
+      for (const runner of activeRunners) {
+        await runner.abortLive();
+      }
     }
+  }
+
+  /** Test seam: forget the shutdown state between cases. */
+  static resetAbortStateForTesting(): void {
+    aborting = false;
   }
 
   async environment(): Promise<ContainerEnvironment> {
@@ -184,6 +210,7 @@ export class DockerContainerRunner implements ContainerRunner {
     imageReference: string,
     options: CreateTaskContainerOptions = {},
   ): Promise<ContainerHandle> {
+    assertNotAborting();
     const { dockerReference, imageDigest } = this.resolveImageRef(imageReference);
     const mountArguments: string[] = [];
     for (const mount of options.readOnlyMounts ?? []) {
@@ -268,6 +295,7 @@ export class DockerContainerRunner implements ContainerRunner {
   }
 
   async createAuxiliaryContainer(imageReference: string): Promise<ContainerHandle> {
+    assertNotAborting();
     const { dockerReference, imageDigest } = this.resolveImageRef(imageReference);
     const created = await spawnBounded(
       "docker",
@@ -302,6 +330,7 @@ export class DockerContainerRunner implements ContainerRunner {
    * `teardown()` in a finally.
    */
   async createEgressLane(request: EgressLaneRequest): Promise<EgressLane> {
+    assertNotAborting();
     const { dockerReference, imageDigest } = this.resolveImageRef(request.taskImage);
     const overlayHostDir = request.overlayHostDir;
     if (!overlayHostDir.startsWith("/") || overlayHostDir.includes(":") || overlayHostDir.includes(",")) {

--- a/runtime/src/eval-suites/cli.ts
+++ b/runtime/src/eval-suites/cli.ts
@@ -18,10 +18,12 @@ function usage(): never {
 async function main(): Promise<void> {
   const arguments_ = process.argv.slice(2);
   const json = arguments_.includes("--json");
-  const paths = arguments_.filter((argument) => !argument.startsWith("--"));
+  // Anything that looks like an option other than --json is a usage error,
+  // including single-dash spellings, so a typo cannot be read as a path.
+  const paths = arguments_.filter((argument) => !argument.startsWith("-"));
   if (
     paths.length > 1 ||
-    arguments_.some((argument) => argument.startsWith("--") && argument !== "--json")
+    arguments_.some((argument) => argument.startsWith("-") && argument !== "--json")
   ) {
     usage();
   }

--- a/runtime/src/sandbox/linux-launcher/cli.ts
+++ b/runtime/src/sandbox/linux-launcher/cli.ts
@@ -310,7 +310,10 @@ function assertFileSystemPath(value: unknown): asserts value is FileSystemPath {
     throw new LinuxSandboxCliError("permission profile fileSystem entry path must be an object");
   }
   const kind = (value as { kind?: unknown }).kind;
-  const allowedKeys = typeof kind === "string" ? PATH_KEYS[kind] : undefined;
+  // Own-property lookup only: a kind such as "constructor" must not resolve
+  // to an Object.prototype member.
+  const allowedKeys =
+    typeof kind === "string" && Object.hasOwn(PATH_KEYS, kind) ? PATH_KEYS[kind] : undefined;
   if (allowedKeys === undefined) {
     throw new LinuxSandboxCliError("permission profile fileSystem entry path kind is invalid");
   }
@@ -331,7 +334,10 @@ function assertSpecialPath(value: unknown): void {
     throw new LinuxSandboxCliError("permission profile special path must be an object");
   }
   const kind = (value as { kind?: unknown }).kind;
-  const allowedKeys = typeof kind === "string" ? SPECIAL_PATH_KEYS[kind] : undefined;
+  const allowedKeys =
+    typeof kind === "string" && Object.hasOwn(SPECIAL_PATH_KEYS, kind)
+      ? SPECIAL_PATH_KEYS[kind]
+      : undefined;
   if (allowedKeys === undefined) {
     throw new LinuxSandboxCliError("permission profile special path kind is invalid");
   }
@@ -384,9 +390,14 @@ function assertNoNulByte(value: string, label: string): void {
 
 function normalizeCwd(value: string, flag: string): string {
   if (value.length === 0) {
-    throw new LinuxSandboxCliError("cwd argument cannot be empty");
+    throw new LinuxSandboxCliError(`${flag} cannot be empty`);
   }
   assertNoNulByte(value, `${flag} value`);
+  // A relative cwd would be anchored to the launcher's own working
+  // directory, the exact inference the required policy cwd exists to avoid.
+  if (!path.isAbsolute(value)) {
+    throw new LinuxSandboxCliError(`${flag} must be an absolute path`);
+  }
   return path.resolve(value);
 }
 

--- a/runtime/src/sandbox/linux-launcher/cli.ts
+++ b/runtime/src/sandbox/linux-launcher/cli.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   type FileSystemAccessMode,
   type FileSystemPath,
+  type PermissionEnforcement,
   type PermissionProfile,
   permissionProfileToRuntimePermissions,
 } from "../engine/index.js";
@@ -28,6 +29,39 @@ export interface LinuxSandboxLauncherOptions {
   readonly command: readonly string[];
 }
 
+/**
+ * Upper bound for a policy's glob scan depth. The bubblewrap glob expander
+ * walks directories up to this depth for every glob entry, so the launcher
+ * refuses a depth that could turn one policy into an unbounded filesystem
+ * walk. An unbounded scan is expressed by omitting the field.
+ */
+export const MAX_GLOB_SCAN_DEPTH = 128;
+
+const NUL_BYTE = String.fromCharCode(0);
+
+const PROFILE_KEYS: ReadonlySet<string> = new Set(["fileSystem", "network", "enforcement"]);
+const FILE_SYSTEM_KEYS: ReadonlySet<string> = new Set([
+  "kind",
+  "entries",
+  "globScanMaxDepth",
+  "includePlatformDefaults",
+]);
+const ENTRY_KEYS: ReadonlySet<string> = new Set(["path", "access"]);
+const PATH_KEYS: Readonly<Record<string, ReadonlySet<string>>> = {
+  path: new Set(["kind", "path"]),
+  glob: new Set(["kind", "pattern"]),
+  special: new Set(["kind", "value"]),
+};
+const SPECIAL_PATH_KEYS: Readonly<Record<string, ReadonlySet<string>>> = {
+  root: new Set(["kind"]),
+  project_roots: new Set(["kind", "subpath"]),
+  tmpdir: new Set(["kind"]),
+  slash_tmp: new Set(["kind"]),
+  minimal: new Set(["kind"]),
+  unknown: new Set(["kind", "path", "subpath"]),
+};
+const ENFORCEMENT_VALUES: ReadonlySet<string> = new Set(["default", "untrusted", "managed"]);
+
 export function parseLinuxSandboxLauncherArgs(
   argv: readonly string[],
 ): LinuxSandboxLauncherOptions {
@@ -41,6 +75,18 @@ export function parseLinuxSandboxLauncherArgs(
   let proxyRouteSpec: string | null = null;
   let mountProc = true;
   const command: string[] = [];
+  const seenValueFlags = new Set<string>();
+
+  // Every flag that carries a value is accepted once. A repeated flag would
+  // otherwise silently replace the earlier value, hiding a caller bug in the
+  // exact arguments that decide what the sandbox may touch.
+  const takeValue = (flag: string, index: number): string => {
+    if (seenValueFlags.has(flag)) {
+      throw new LinuxSandboxCliError(`${flag} may only be given once`);
+    }
+    seenValueFlags.add(flag);
+    return readValue(argv, index, flag);
+  };
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -50,22 +96,22 @@ export function parseLinuxSandboxLauncherArgs(
     }
     switch (arg) {
       case "--sandbox-policy-cwd":
-        sandboxPolicyCwd = normalizeCwd(readValue(argv, index, arg));
+        sandboxPolicyCwd = normalizeCwd(takeValue(arg, index), arg);
         index += 1;
         break;
       case "--command-cwd":
-        commandCwd = normalizeCwd(readValue(argv, index, arg));
+        commandCwd = normalizeCwd(takeValue(arg, index), arg);
         index += 1;
         break;
       case "--inherited-readonly-command-cwd":
         inheritedCwd = true;
         break;
       case "--permission-profile":
-        permissionProfile = parsePermissionProfile(readValue(argv, index, arg));
+        permissionProfile = parsePermissionProfile(takeValue(arg, index));
         index += 1;
         break;
       case "--session-temp-root":
-        sessionTempRoot = normalizeSessionTempRoot(readValue(argv, index, arg));
+        sessionTempRoot = normalizeSessionTempRoot(takeValue(arg, index));
         index += 1;
         break;
       case "--apply-seccomp-then-exec":
@@ -75,7 +121,7 @@ export function parseLinuxSandboxLauncherArgs(
         allowNetworkForProxy = true;
         break;
       case "--proxy-route-spec":
-        proxyRouteSpec = readValue(argv, index, arg);
+        proxyRouteSpec = normalizeProxyRouteSpec(takeValue(arg, index));
         index += 1;
         break;
       case "--no-proc":
@@ -89,6 +135,7 @@ export function parseLinuxSandboxLauncherArgs(
   if (command.length === 0) {
     throw new LinuxSandboxCliError("Linux sandbox command is missing");
   }
+  assertCommand(command);
   if (permissionProfile === null) {
     throw new LinuxSandboxCliError("Linux sandbox permission profile is missing");
   }
@@ -105,9 +152,17 @@ export function parseLinuxSandboxLauncherArgs(
       "--inherited-readonly-command-cwd is only valid for the outer launcher stage",
     );
   }
+  if (proxyRouteSpec !== null && !allowNetworkForProxy) {
+    throw new LinuxSandboxCliError(
+      "--proxy-route-spec requires --allow-network-for-proxy",
+    );
+  }
+  // The policy cwd anchors every project-root grant, so it is never
+  // inferred from the launcher's own working directory: a missing flag fails
+  // closed instead of widening write access to wherever the launcher started.
   const resolvedSandboxCwd = inheritedCwd
     ? INHERITED_CWD_SANDBOX_PATH
-    : sandboxPolicyCwd ?? process.cwd();
+    : requireProvided(sandboxPolicyCwd, "Linux sandbox policy cwd is missing");
   const resolvedCommandCwd = inheritedCwd
     ? INHERITED_CWD_SANDBOX_PATH
     : commandCwd ?? resolvedSandboxCwd;
@@ -125,6 +180,22 @@ export function parseLinuxSandboxLauncherArgs(
   };
 }
 
+function requireProvided(value: string | null, message: string): string {
+  if (value === null) {
+    throw new LinuxSandboxCliError(message);
+  }
+  return value;
+}
+
+function assertCommand(command: readonly string[]): void {
+  if (command[0] === undefined || command[0].length === 0) {
+    throw new LinuxSandboxCliError("Linux sandbox command program cannot be empty");
+  }
+  for (const argument of command) {
+    assertNoNulByte(argument, "Linux sandbox command argument");
+  }
+}
+
 function parsePermissionProfile(value: string): PermissionProfile {
   let parsed: unknown;
   try {
@@ -139,12 +210,10 @@ function parsePermissionProfile(value: string): PermissionProfile {
 }
 
 function assertPermissionProfile(value: unknown): asserts value is PermissionProfile {
-  if (typeof value !== "object" || value === null) {
-    throw new LinuxSandboxCliError("permission profile must be an object");
-  }
-  const candidate = value as Partial<PermissionProfile>;
+  const candidate = assertPlainObject(value, "permission profile", PROFILE_KEYS) as Partial<PermissionProfile>;
   assertNetwork(candidate.network);
   assertFileSystem(candidate.fileSystem);
+  assertEnforcement(candidate.enforcement);
   try {
     permissionProfileToRuntimePermissions(candidate as PermissionProfile);
   } catch (error) {
@@ -152,11 +221,27 @@ function assertPermissionProfile(value: unknown): asserts value is PermissionPro
       `permission profile has an invalid shape: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  if (candidate.fileSystem === undefined || candidate.network === undefined) {
-    throw new LinuxSandboxCliError(
-      "permission profile must include fileSystem and network permissions",
-    );
+}
+
+/**
+ * Accept only a plain JSON object whose every field is expected. Unknown
+ * fields are rejected rather than carried through to the sandbox engine, so a
+ * policy can never smuggle a setting the launcher did not validate.
+ */
+function assertPlainObject(
+  value: unknown,
+  label: string,
+  allowedKeys: ReadonlySet<string>,
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new LinuxSandboxCliError(`${label} must be an object`);
   }
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      throw new LinuxSandboxCliError(`${label} has an unsupported field: ${key}`);
+    }
+  }
+  return value as Record<string, unknown>;
 }
 
 function assertNetwork(value: unknown): void {
@@ -165,16 +250,16 @@ function assertNetwork(value: unknown): void {
   }
 }
 
-function assertFileSystem(value: unknown): void {
-  if (typeof value !== "object" || value === null) {
-    throw new LinuxSandboxCliError("permission profile fileSystem must be an object");
+function assertEnforcement(value: unknown): asserts value is PermissionEnforcement | undefined {
+  if (value !== undefined && (typeof value !== "string" || !ENFORCEMENT_VALUES.has(value))) {
+    throw new LinuxSandboxCliError(
+      "permission profile enforcement must be default, untrusted, or managed",
+    );
   }
-  const candidate = value as {
-    kind?: unknown;
-    entries?: unknown;
-    globScanMaxDepth?: unknown;
-    includePlatformDefaults?: unknown;
-  };
+}
+
+function assertFileSystem(value: unknown): void {
+  const candidate = assertPlainObject(value, "permission profile fileSystem", FILE_SYSTEM_KEYS);
   if (
     candidate.kind !== "restricted" &&
     candidate.kind !== "unrestricted" &&
@@ -190,9 +275,12 @@ function assertFileSystem(value: unknown): void {
     globScanMaxDepth !== undefined &&
     (typeof globScanMaxDepth !== "number" ||
       !Number.isInteger(globScanMaxDepth) ||
-      globScanMaxDepth < 0)
+      globScanMaxDepth < 0 ||
+      globScanMaxDepth > MAX_GLOB_SCAN_DEPTH)
   ) {
-    throw new LinuxSandboxCliError("permission profile globScanMaxDepth must be a non-negative integer");
+    throw new LinuxSandboxCliError(
+      `permission profile globScanMaxDepth must be an integer between 0 and ${MAX_GLOB_SCAN_DEPTH}`,
+    );
   }
   if (
     candidate.includePlatformDefaults !== undefined &&
@@ -206,10 +294,7 @@ function assertFileSystem(value: unknown): void {
 }
 
 function assertFileSystemEntry(value: unknown): void {
-  if (typeof value !== "object" || value === null) {
-    throw new LinuxSandboxCliError("permission profile fileSystem entry must be an object");
-  }
-  const entry = value as { access?: unknown; path?: unknown };
+  const entry = assertPlainObject(value, "permission profile fileSystem entry", ENTRY_KEYS);
   assertAccess(entry.access);
   assertFileSystemPath(entry.path);
 }
@@ -221,53 +306,46 @@ function assertAccess(value: unknown): asserts value is FileSystemAccessMode {
 }
 
 function assertFileSystemPath(value: unknown): asserts value is FileSystemPath {
-  if (typeof value !== "object" || value === null) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new LinuxSandboxCliError("permission profile fileSystem entry path must be an object");
   }
-  const pathSpec = value as { kind?: unknown; path?: unknown; pattern?: unknown; value?: unknown };
-  if (pathSpec.kind === "path") {
-    if (typeof pathSpec.path !== "string" || pathSpec.path.length === 0) {
-      throw new LinuxSandboxCliError("permission profile path entry must include a non-empty path");
-    }
+  const kind = (value as { kind?: unknown }).kind;
+  const allowedKeys = typeof kind === "string" ? PATH_KEYS[kind] : undefined;
+  if (allowedKeys === undefined) {
+    throw new LinuxSandboxCliError("permission profile fileSystem entry path kind is invalid");
+  }
+  const pathSpec = assertPlainObject(value, "permission profile fileSystem entry path", allowedKeys);
+  if (kind === "path") {
+    assertNonEmptyString(pathSpec.path, "permission profile path entry path");
     return;
   }
-  if (pathSpec.kind === "glob") {
-    if (typeof pathSpec.pattern !== "string" || pathSpec.pattern.length === 0) {
-      throw new LinuxSandboxCliError("permission profile glob entry must include a non-empty pattern");
-    }
+  if (kind === "glob") {
+    assertNonEmptyString(pathSpec.pattern, "permission profile glob entry pattern");
     return;
   }
-  if (pathSpec.kind === "special") {
-    assertSpecialPath(pathSpec.value);
-    return;
-  }
-  throw new LinuxSandboxCliError("permission profile fileSystem entry path kind is invalid");
+  assertSpecialPath(pathSpec.value);
 }
 
 function assertSpecialPath(value: unknown): void {
-  if (typeof value !== "object" || value === null) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new LinuxSandboxCliError("permission profile special path must be an object");
   }
-  const special = value as { kind?: unknown; path?: unknown; subpath?: unknown };
-  switch (special.kind) {
-    case "root":
-    case "project_roots":
-    case "tmpdir":
-    case "slash_tmp":
-    case "minimal":
-      break;
-    case "unknown":
-      if (typeof special.path !== "string" || special.path.length === 0) {
-        throw new LinuxSandboxCliError("permission profile unknown special path must include a path");
-      }
-      break;
-    default:
-      throw new LinuxSandboxCliError("permission profile special path kind is invalid");
+  const kind = (value as { kind?: unknown }).kind;
+  const allowedKeys = typeof kind === "string" ? SPECIAL_PATH_KEYS[kind] : undefined;
+  if (allowedKeys === undefined) {
+    throw new LinuxSandboxCliError("permission profile special path kind is invalid");
   }
-  if (special.subpath !== undefined && typeof special.subpath !== "string") {
-    throw new LinuxSandboxCliError("permission profile special path subpath must be a string");
+  const special = assertPlainObject(value, "permission profile special path", allowedKeys);
+  if (kind === "unknown") {
+    assertNonEmptyString(special.path, "permission profile unknown special path path");
   }
-  if (special.kind === "project_roots" && typeof special.subpath === "string") {
+  if (special.subpath !== undefined) {
+    if (typeof special.subpath !== "string") {
+      throw new LinuxSandboxCliError("permission profile special path subpath must be a string");
+    }
+    assertNoNulByte(special.subpath, "permission profile special path subpath");
+  }
+  if (kind === "project_roots" && typeof special.subpath === "string") {
     assertProjectRootSubpath(special.subpath);
   }
 }
@@ -286,14 +364,34 @@ function assertProjectRootSubpath(value: string): void {
   }
 }
 
-function normalizeCwd(value: string): string {
+function assertNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new LinuxSandboxCliError(`${label} must be a non-empty string`);
+  }
+  assertNoNulByte(value, label);
+}
+
+/**
+ * A NUL byte cannot cross an exec or C-string boundary intact, so a path or
+ * argument carrying one would either fail deep inside the launcher or be
+ * silently truncated. Reject it at the edge with a clear message instead.
+ */
+function assertNoNulByte(value: string, label: string): void {
+  if (value.includes(NUL_BYTE)) {
+    throw new LinuxSandboxCliError(`${label} must not contain a NUL byte`);
+  }
+}
+
+function normalizeCwd(value: string, flag: string): string {
   if (value.length === 0) {
     throw new LinuxSandboxCliError("cwd argument cannot be empty");
   }
+  assertNoNulByte(value, `${flag} value`);
   return path.resolve(value);
 }
 
 function normalizeSessionTempRoot(value: string): string {
+  assertNoNulByte(value, "--session-temp-root value");
   if (value.length === 0 || !path.isAbsolute(value)) {
     throw new LinuxSandboxCliError(
       "Linux sandbox session temp root must be an absolute path",
@@ -302,9 +400,19 @@ function normalizeSessionTempRoot(value: string): string {
   return path.normalize(value);
 }
 
+function normalizeProxyRouteSpec(value: string): string {
+  assertNoNulByte(value, "--proxy-route-spec value");
+  if (value.trim().length === 0) {
+    throw new LinuxSandboxCliError("--proxy-route-spec cannot be empty");
+  }
+  return value;
+}
+
 function readValue(argv: readonly string[], index: number, flag: string): string {
   const value = argv[index + 1];
-  if (value === undefined || value === "--") {
+  // A value that spells another flag is a missing value, not a path: the
+  // caller forgot the argument and the next flag must not be swallowed.
+  if (value === undefined || value.startsWith("--")) {
     throw new LinuxSandboxCliError(`${flag} requires a value`);
   }
   return value;

--- a/runtime/tests/eval/eval-executor-cli.test.ts
+++ b/runtime/tests/eval/eval-executor-cli.test.ts
@@ -1,0 +1,148 @@
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { isDirectInvocation, main } from "../../src/eval-executor/cli.js";
+
+const FORTY_HEX = "0123456789abcdef0123456789abcdef01234567";
+
+describe("eval executor CLI argument handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function silenceOutput(): { stdout: string[]; stderr: string[] } {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    return { stdout, stderr };
+  }
+
+  test("prints usage to stderr with exit 2 when no command is given", async () => {
+    const output = silenceOutput();
+    await expect(main([])).resolves.toBe(2);
+    expect(output.stderr.join("")).toContain("Usage:");
+    expect(output.stdout.join("")).toBe("");
+  });
+
+  test("honors --help before and after a command with exit 0", async () => {
+    const output = silenceOutput();
+    await expect(main(["--help"])).resolves.toBe(0);
+    await expect(main(["preflight", "--help"])).resolves.toBe(0);
+    await expect(main(["run-agent", "--task", "t", "-h"])).resolves.toBe(0);
+    expect(output.stdout.join("")).toContain("Usage:");
+    expect(output.stderr.join("")).toBe("");
+  });
+
+  test("rejects an unknown command with exit 2", async () => {
+    const output = silenceOutput();
+    await expect(main(["bogus"])).resolves.toBe(2);
+    expect(output.stderr.join("")).toContain("Unknown command bogus");
+  });
+
+  test("turns option parser failures into executor errors with a usage hint", async () => {
+    silenceOutput();
+    await expect(main(["verify-lock", "--lock"])).rejects.toThrow(
+      /argument missing.*run with --help for usage/u,
+    );
+    await expect(main(["preflight", "--task", "x", "stray"])).rejects.toThrow(
+      /positional.*run with --help for usage/u,
+    );
+  });
+
+  test("requires the subcommand's mandatory options before touching the lock", async () => {
+    silenceOutput();
+    await expect(main(["preflight"])).rejects.toThrow(/preflight requires --task/u);
+    await expect(main(["run-agent", "--task", "t"])).rejects.toThrow(
+      /run-agent requires --task <instanceId> and --overlay <dir>/u,
+    );
+    await expect(
+      main(["run-agent-real", "--task", "t", "--overlay", "o", "--provider-host", "h"]),
+    ).rejects.toThrow(/requires --provider-host, --provider-base-url, and --provider-model/u);
+  });
+
+  test.each(["0x10", "1e3", "0", "", " 12", "12.0", "+7"])(
+    "rejects --agent-timeout-ms %j instead of coercing it",
+    async (raw) => {
+      silenceOutput();
+      await expect(
+        main(["run-agent", "--task", "t", "--overlay", "o", "--agent-timeout-ms", raw]),
+      ).rejects.toThrow(/--agent-timeout-ms must be a decimal integer of at least 1/u);
+    },
+  );
+
+  test.each(["", "0x1", "1e1", " 0"])(
+    "rejects --seed-slot %j before running the trust suite",
+    async (raw) => {
+      silenceOutput();
+      await expect(
+        main(["trust-run", "--repository-commit", FORTY_HEX, "--seed-slot", raw]),
+      ).rejects.toThrow(/--seed-slot must be a decimal integer of at least 0/u);
+    },
+  );
+
+  test("rejects negative integer options at the option parser", async () => {
+    // node:util parseArgs treats a leading dash as another option, so a
+    // negative number never reaches the integer check; it still fails closed.
+    silenceOutput();
+    await expect(
+      main(["run-agent", "--task", "t", "--overlay", "o", "--agent-timeout-ms", "-5"]),
+    ).rejects.toThrow(/ambiguous[\s\S]*run with --help for usage/u);
+    await expect(
+      main(["trust-run", "--repository-commit", FORTY_HEX, "--seed-slot", "-1"]),
+    ).rejects.toThrow(/ambiguous[\s\S]*run with --help for usage/u);
+  });
+
+  test("rejects a --tasks list that repeats a task id", async () => {
+    silenceOutput();
+    await expect(
+      main([
+        "run-agent-real-batch",
+        "--overlay",
+        "o",
+        "--provider-host",
+        "h",
+        "--provider-base-url",
+        "u",
+        "--provider-model",
+        "m",
+        "--tasks",
+        "a, b ,a",
+      ]),
+    ).rejects.toThrow(/--tasks must not repeat a task id/u);
+    await expect(
+      main([
+        "run-agent-real-batch",
+        "--overlay",
+        "o",
+        "--provider-host",
+        "h",
+        "--provider-base-url",
+        "u",
+        "--provider-model",
+        "m",
+        "--tasks",
+        " , ",
+      ]),
+    ).rejects.toThrow(/--tasks must name at least one task id/u);
+  });
+
+  test("recognizes a direct invocation through a URL-significant checkout path", () => {
+    for (const scriptPath of [
+      "/tmp/agenc#core/runtime/src/eval-executor/cli.ts",
+      "/tmp/agenc%core/cli.ts",
+      "/tmp/agenc core/cli.ts",
+      "/tmp/plain/cli.ts",
+    ]) {
+      expect(isDirectInvocation(pathToFileURL(scriptPath).href, scriptPath)).toBe(true);
+    }
+    expect(isDirectInvocation(pathToFileURL("/tmp/a/cli.ts").href, "/tmp/b/cli.ts")).toBe(false);
+    expect(isDirectInvocation(pathToFileURL("/tmp/a/cli.ts").href, undefined)).toBe(false);
+  });
+});

--- a/runtime/tests/eval/eval-executor-container-runner.test.ts
+++ b/runtime/tests/eval/eval-executor-container-runner.test.ts
@@ -1,0 +1,123 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { DockerContainerRunner } from "../../src/eval-executor/container-runner.js";
+
+const PINNED_IMAGE =
+  "registry.example/task@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/**
+ * A fake `docker` on PATH that records every argv line and answers the
+ * subset of commands the runner issues. Container ids are minted per
+ * `create` so the test can assert which ids the cleanup removes, in order.
+ */
+async function installFakeDocker(root: string): Promise<{ readonly log: string; readonly bin: string }> {
+  const bin = path.join(root, "bin");
+  const log = path.join(root, "docker.log");
+  await rm(bin, { recursive: true, force: true });
+  await (await import("node:fs/promises")).mkdir(bin, { recursive: true });
+  const script = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `printf '%s\\n' "$*" >> ${JSON.stringify(log)}`,
+    'case "$1" in',
+    "  version) echo 0.0.0-fake ;;",
+    "  create) echo \"container-$(( $(grep -c '^create ' " + JSON.stringify(log) + ") ))\" ;;",
+    "  image) echo /work ;;",
+    "  start|rm|network) ;;",
+    "  *) echo \"unexpected docker command: $*\" >&2; exit 64 ;;",
+    "esac",
+    "",
+  ].join("\n");
+  const executable = path.join(bin, "docker");
+  await writeFile(executable, script, { mode: 0o755 });
+  await chmod(executable, 0o755);
+  return { log, bin };
+}
+
+async function loggedCommands(log: string): Promise<string[]> {
+  try {
+    return (await readFile(log, "utf8")).split("\n").filter((line) => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+describe.runIf(process.platform !== "win32")("DockerContainerRunner live tracking", () => {
+  let root = "";
+  let previousPath: string | undefined;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "agenc-eval-runner-"));
+    const fake = await installFakeDocker(root);
+    previousPath = process.env.PATH;
+    process.env.PATH = [fake.bin, previousPath ?? ""].join(path.delimiter);
+    DockerContainerRunner.resetAbortStateForTesting();
+  });
+
+  afterEach(async () => {
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    DockerContainerRunner.resetAbortStateForTesting();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("abortAll force-removes every container this process still owns and refuses new ones", async () => {
+    const log = path.join(root, "docker.log");
+    const runner = new DockerContainerRunner();
+    const task = await runner.createTaskContainer(PINNED_IMAGE, []);
+    const auxiliary = await runner.createAuxiliaryContainer(PINNED_IMAGE);
+    const removedEarly = await runner.createAuxiliaryContainer(PINNED_IMAGE);
+    await runner.remove(removedEarly);
+    expect(task.id).toBe("container-1");
+    expect(auxiliary.id).toBe("container-2");
+
+    await DockerContainerRunner.abortAll();
+
+    const commands = await loggedCommands(log);
+    const removals = commands.filter((line) => line.startsWith("rm -f "));
+    // The explicit remove happened once, before the sweep; the sweep removed
+    // exactly the two containers that were still live, in creation order,
+    // and did not remove the already-removed one a second time.
+    expect(removals).toEqual([
+      `rm -f ${removedEarly.id}`,
+      "rm -f container-1",
+      "rm -f container-2",
+    ]);
+
+    // Once cleanup has started, the run paths cannot create new work that
+    // the sweep would miss.
+    await expect(runner.createTaskContainer(PINNED_IMAGE, [])).rejects.toThrow(
+      /eval-executor is shutting down/u,
+    );
+    await expect(runner.createAuxiliaryContainer(PINNED_IMAGE)).rejects.toThrow(
+      /eval-executor is shutting down/u,
+    );
+    expect((await loggedCommands(log)).filter((line) => line.startsWith("create "))).toHaveLength(3);
+
+    // A repeated sweep has nothing left to remove.
+    await DockerContainerRunner.abortAll();
+    expect((await loggedCommands(log)).filter((line) => line.startsWith("rm -f "))).toHaveLength(3);
+  });
+
+  test("a container whose start fails is removed and never reappears in the sweep", async () => {
+    const log = path.join(root, "docker.log");
+    const bin = path.join(root, "bin", "docker");
+    const failingStart = (await readFile(bin, "utf8")).replace(
+      "  start|rm|network) ;;",
+      "  start) echo 'daemon refused' >&2; exit 1 ;;\n  rm|network) ;;",
+    );
+    await writeFile(bin, failingStart, { mode: 0o755 });
+    const runner = new DockerContainerRunner();
+
+    await expect(runner.createTaskContainer(PINNED_IMAGE, [])).rejects.toThrow(
+      /docker start failed/u,
+    );
+    await DockerContainerRunner.abortAll();
+
+    const removals = (await loggedCommands(log)).filter((line) => line.startsWith("rm -f "));
+    expect(removals).toEqual(["rm -f container-1"]);
+  });
+});

--- a/runtime/tests/eval/eval-executor-container-runner.test.ts
+++ b/runtime/tests/eval/eval-executor-container-runner.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { DockerContainerRunner } from "../../src/eval-executor/container-runner.js";
+import { buildEgressNetworkPlan } from "../../src/eval-executor/egress.js";
 
 const PINNED_IMAGE =
   "registry.example/task@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -26,6 +27,8 @@ async function installFakeDocker(root: string): Promise<{ readonly log: string; 
     "  version) echo 0.0.0-fake ;;",
     "  create) echo \"container-$(( $(grep -c '^create ' " + JSON.stringify(log) + ") ))\" ;;",
     "  image) echo /work ;;",
+    "  logs) echo AGENC_PROXY_READY ;;",
+    "  inspect) echo true ;;",
     "  start|rm|network) ;;",
     "  *) echo \"unexpected docker command: $*\" >&2; exit 64 ;;",
     "esac",
@@ -67,7 +70,7 @@ describe.runIf(process.platform !== "win32")("DockerContainerRunner live trackin
   test("abortAll force-removes every container this process still owns and refuses new ones", async () => {
     const log = path.join(root, "docker.log");
     const runner = new DockerContainerRunner();
-    const task = await runner.createTaskContainer(PINNED_IMAGE, []);
+    const task = await runner.createTaskContainer(PINNED_IMAGE, {});
     const auxiliary = await runner.createAuxiliaryContainer(PINNED_IMAGE);
     const removedEarly = await runner.createAuxiliaryContainer(PINNED_IMAGE);
     await runner.remove(removedEarly);
@@ -89,7 +92,7 @@ describe.runIf(process.platform !== "win32")("DockerContainerRunner live trackin
 
     // Once cleanup has started, the run paths cannot create new work that
     // the sweep would miss.
-    await expect(runner.createTaskContainer(PINNED_IMAGE, [])).rejects.toThrow(
+    await expect(runner.createTaskContainer(PINNED_IMAGE, {})).rejects.toThrow(
       /eval-executor is shutting down/u,
     );
     await expect(runner.createAuxiliaryContainer(PINNED_IMAGE)).rejects.toThrow(
@@ -102,6 +105,60 @@ describe.runIf(process.platform !== "win32")("DockerContainerRunner live trackin
     expect((await loggedCommands(log)).filter((line) => line.startsWith("rm -f "))).toHaveLength(3);
   });
 
+  test("abortAll removes a live egress lane's containers before its networks", async () => {
+    const log = path.join(root, "docker.log");
+    const runner = new DockerContainerRunner();
+    const plan = buildEgressNetworkPlan("test-run", 42);
+    await runner.createEgressLane({
+      runId: "test-run",
+      subnetOctet: 42,
+      taskImage: PINNED_IMAGE,
+      overlayHostDir: "/tmp/agenc-overlay",
+      allowHost: "api.example.com",
+      allowPort: 443,
+      pinIps: ["203.0.113.5"],
+      proxyListenPort: 3128,
+    });
+
+    await DockerContainerRunner.abortAll();
+
+    const commands = await loggedCommands(log);
+    expect(commands.filter((line) => line.startsWith("network create"))).toHaveLength(2);
+    // Containers detach first; a network with attached containers cannot be
+    // removed. The sidecar is created before the agent.
+    expect(
+      commands.filter((line) => line.startsWith("rm -f ") || line.startsWith("network rm ")),
+    ).toEqual([
+      "rm -f container-1",
+      "rm -f container-2",
+      `network rm ${plan.egressNetName}`,
+      `network rm ${plan.upstreamNetName}`,
+    ]);
+  });
+
+  test("abortAll waits for a create that passed the shutdown check before sweeping", async () => {
+    const log = path.join(root, "docker.log");
+    const bin = path.join(root, "bin", "docker");
+    // The fake daemon takes a moment to answer `create`, so the create is in
+    // flight when the sweep starts and nothing is live yet.
+    const slowCreate = (await readFile(bin, "utf8")).replace(
+      "  create) echo",
+      "  create) sleep 1; echo",
+    );
+    await writeFile(bin, slowCreate, { mode: 0o755 });
+    const runner = new DockerContainerRunner();
+
+    const pending = runner.createTaskContainer(PINNED_IMAGE, {});
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await DockerContainerRunner.abortAll();
+    await expect(pending).resolves.toMatchObject({ id: "container-1" });
+
+    // The sweep found nothing on its first pass, waited for the create, then
+    // removed what it produced.
+    const removals = (await loggedCommands(log)).filter((line) => line.startsWith("rm -f "));
+    expect(removals).toEqual(["rm -f container-1"]);
+  });
+
   test("a container whose start fails is removed and never reappears in the sweep", async () => {
     const log = path.join(root, "docker.log");
     const bin = path.join(root, "bin", "docker");
@@ -112,7 +169,7 @@ describe.runIf(process.platform !== "win32")("DockerContainerRunner live trackin
     await writeFile(bin, failingStart, { mode: 0o755 });
     const runner = new DockerContainerRunner();
 
-    await expect(runner.createTaskContainer(PINNED_IMAGE, [])).rejects.toThrow(
+    await expect(runner.createTaskContainer(PINNED_IMAGE, {})).rejects.toThrow(
       /docker start failed/u,
     );
     await DockerContainerRunner.abortAll();

--- a/runtime/tests/eval/evaluation-contract.test.ts
+++ b/runtime/tests/eval/evaluation-contract.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -252,6 +252,27 @@ describe("evaluation contract v1", () => {
       const usage = run();
       expect(usage.status).toBe(2);
       expect(usage.stderr).toContain("Usage:");
+
+      // A single-dash typo is a usage error, not a document name.
+      const dashTypo = run("-legacy", validPath);
+      expect(dashTypo.status).toBe(2);
+      expect(dashTypo.stderr).toContain("Usage:");
+
+      // Documents after "--" are always file names.
+      const separated = run("--", validPath);
+      expect(separated.status).toBe(0);
+      expect(JSON.parse(separated.stdout)).toMatchObject({
+        results: [{ valid: true, file: validPath }],
+      });
+
+      // The reader never follows a symlink to a document.
+      const linkPath = path.join(directory, "link.json");
+      await symlink(validPath, linkPath);
+      const linked = run(linkPath);
+      expect(linked.status).toBe(1);
+      expect(JSON.parse(linked.stdout)).toMatchObject({
+        results: [{ valid: false, error: expect.stringContaining("non-symlink") }],
+      });
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/runtime/tests/eval/evaluation-suite-protocol.test.ts
+++ b/runtime/tests/eval/evaluation-suite-protocol.test.ts
@@ -401,5 +401,10 @@ describe("versioned evaluation suite protocol", () => {
     const usage = run("--unknown");
     expect(usage.status).toBe(2);
     expect(usage.stderr).toContain("Usage:");
+
+    // A single-dash typo is a usage error, not a catalog path.
+    const dashTypo = run("-json");
+    expect(dashTypo.status).toBe(2);
+    expect(dashTypo.stderr).toContain("Usage:");
   });
 });

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -271,6 +271,44 @@ describe("Linux sandbox launcher", () => {
     expect(() =>
       parseLinuxSandboxLauncherArgs(withProfile("[]", "--", "/bin/true")),
     ).toThrow(/permission profile must be an object/u);
+    // A cwd is never anchored to the launcher's own working directory.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(argv("--command-cwd", "relative/dir", "--", "/bin/true")),
+    ).toThrow(/--command-cwd must be an absolute path/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(argv("--command-cwd", "", "--", "/bin/true")),
+    ).toThrow(/--command-cwd cannot be empty/u);
+    // Path kinds are matched as own properties, never through Object.prototype.
+    for (const kind of ["constructor", "__proto__", "hasOwnProperty"]) {
+      expect(() =>
+        parseLinuxSandboxLauncherArgs(
+          withProfile(
+            JSON.stringify({
+              fileSystem: restrictedFileSystemPolicy([
+                { path: { kind, path: "/x" } as never, access: "read" },
+              ]),
+              network: "disabled",
+            }),
+            "--",
+            "/bin/true",
+          ),
+        ),
+      ).toThrow(/fileSystem entry path kind is invalid/u);
+      expect(() =>
+        parseLinuxSandboxLauncherArgs(
+          withProfile(
+            JSON.stringify({
+              fileSystem: restrictedFileSystemPolicy([
+                { path: { kind: "special", value: { kind } } as never, access: "read" },
+              ]),
+              network: "disabled",
+            }),
+            "--",
+            "/bin/true",
+          ),
+        ),
+      ).toThrow(/special path kind is invalid/u);
+    }
     // A proxy route spec only makes sense for the proxy-routed inner stage.
     expect(() =>
       parseLinuxSandboxLauncherArgs(argv("--proxy-route-spec", "{}", "--", "/bin/true")),

--- a/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
+++ b/runtime/tests/sandbox/linux-launcher/linux-launcher.test.ts
@@ -172,6 +172,128 @@ describe("Linux sandbox launcher", () => {
     ).toThrow(/project root subpath must stay within the project root/u);
   });
 
+  it("fails closed on handoff input that would widen or corrupt the sandbox boundary", () => {
+    const nul = String.fromCharCode(0);
+    const profileJson = (
+      overrides: Record<string, unknown> = {},
+      fileSystemOverrides: Record<string, unknown> = {},
+    ): string =>
+      JSON.stringify({
+        fileSystem: {
+          ...restrictedFileSystemPolicy([
+            { path: { kind: "path", path: "/workspace" }, access: "write" },
+          ]),
+          ...fileSystemOverrides,
+        },
+        network: "disabled",
+        ...overrides,
+      });
+    const withProfile = (profile: string, ...rest: string[]): string[] => [
+      "--sandbox-policy-cwd",
+      "/repo",
+      "--permission-profile",
+      profile,
+      "--session-temp-root",
+      TEST_SESSION_TEMP_ROOT,
+      ...rest,
+    ];
+    const argv = (...rest: string[]): string[] => withProfile(profileJson(), ...rest);
+
+    // The policy cwd anchors project-root grants; it is never inferred from
+    // the launcher's own working directory.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs([
+        "--permission-profile",
+        profileJson(),
+        "--session-temp-root",
+        TEST_SESSION_TEMP_ROOT,
+        "--",
+        "/bin/true",
+      ]),
+    ).toThrow(/policy cwd is missing/u);
+
+    // A flag cannot be swallowed as another flag's value.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(argv("--command-cwd", "--no-proc", "--", "/bin/true")),
+    ).toThrow(/--command-cwd requires a value/u);
+    // A value flag is accepted once.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(
+        argv("--command-cwd", "/one", "--command-cwd", "/two", "--", "/bin/true"),
+      ),
+    ).toThrow(/--command-cwd may only be given once/u);
+    // NUL bytes are rejected at the edge, in arguments and inside the profile.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(argv("--command-cwd", `/tmp/a${nul}b`, "--", "/bin/true")),
+    ).toThrow(/must not contain a NUL byte/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(
+        withProfile(
+          JSON.stringify({
+            fileSystem: restrictedFileSystemPolicy([
+              { path: { kind: "path", path: `/work${nul}space` }, access: "write" },
+            ]),
+            network: "disabled",
+          }),
+          "--",
+          "/bin/true",
+        ),
+      ),
+    ).toThrow(/path entry path must not contain a NUL byte/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(argv("--", "/bin/true", `arg${nul}`)),
+    ).toThrow(/command argument must not contain a NUL byte/u);
+    // The command program must exist.
+    expect(() => parseLinuxSandboxLauncherArgs(argv("--", ""))).toThrow(
+      /command program cannot be empty/u,
+    );
+    // Only known enforcement modes and known fields reach the engine.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(
+        withProfile(profileJson({ enforcement: "disabled" }), "--", "/bin/true"),
+      ),
+    ).toThrow(/enforcement must be default, untrusted, or managed/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(
+        withProfile(profileJson({ superuser: true }), "--", "/bin/true"),
+      ),
+    ).toThrow(/permission profile has an unsupported field: superuser/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(
+        withProfile(profileJson({}, { bypass: true }), "--", "/bin/true"),
+      ),
+    ).toThrow(/fileSystem has an unsupported field: bypass/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(
+        withProfile(profileJson({}, { globScanMaxDepth: 129 }), "--", "/bin/true"),
+      ),
+    ).toThrow(/globScanMaxDepth must be an integer between 0 and 128/u);
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(withProfile("[]", "--", "/bin/true")),
+    ).toThrow(/permission profile must be an object/u);
+    // A proxy route spec only makes sense for the proxy-routed inner stage.
+    expect(() =>
+      parseLinuxSandboxLauncherArgs(argv("--proxy-route-spec", "{}", "--", "/bin/true")),
+    ).toThrow(/--proxy-route-spec requires --allow-network-for-proxy/u);
+
+    // The same inputs in their valid form still parse.
+    const parsed = parseLinuxSandboxLauncherArgs(
+      withProfile(
+        profileJson({ enforcement: "managed" }, { globScanMaxDepth: 128 }),
+        "--allow-network-for-proxy",
+        "--proxy-route-spec",
+        "{}",
+        "--",
+        "/bin/true",
+        "arg",
+      ),
+    );
+    expect(parsed.permissionProfile.enforcement).toBe("managed");
+    expect(parsed.permissionProfile.fileSystem.globScanMaxDepth).toBe(128);
+    expect(parsed.proxyRouteSpec).toBe("{}");
+    expect(parsed.command).toEqual(["/bin/true", "arg"]);
+  });
+
   it("builds full-filesystem bubblewrap flags for network-isolated full-write policies", () => {
     const args = createBwrapCommandArgs(
       ["/bin/true"],


### PR DESCRIPTION
## Summary

Robustness pass over the four `cli.ts` entrypoints, driven by an audit of each parser with real inputs.

Linux sandbox launcher (`runtime/src/sandbox/linux-launcher/cli.ts`, a security boundary):
- `--sandbox-policy-cwd` is required (unless `--inherited-readonly-command-cwd`) instead of defaulting to the launcher's own working directory, which anchored project-root grants to wherever the launcher started. Both cwd flags must be absolute.
- A value flag no longer swallows the next flag as its value; each value flag is accepted once; NUL bytes are rejected in every path, argument, and profile string; the command program must be non-empty; `--proxy-route-spec` requires `--allow-network-for-proxy`.
- The permission profile is validated with field allowlists at every level (profile, fileSystem, entry, path, special path), `enforcement` must be a known mode, kinds are matched as own properties (a kind of `constructor` is an invalid kind, not an `Object.prototype` hit), and `globScanMaxDepth` is capped at 128. Error messages name the field.

`eval:executor` (`runtime/src/eval-executor/cli.ts` and `container-runner.ts`):
- The direct-invocation check uses `pathToFileURL`, so a checkout path containing `#` or `%` no longer makes the CLI a silent no-op.
- Integer options are decimal digits only (`0x10`, `1e3`, and an empty `--seed-slot` were coerced before). `--help` works after a command, a missing command prints usage to stderr with exit 2, option parser failures carry a usage hint, `--tasks` rejects repeats, and the provider resolver accepts an IPv4 literal and reports the resolver's reason.
- SIGINT and SIGTERM remove every container and network this process created before exiting 130/143. The runner tracks what it creates, refuses new creates once shutdown starts, waits for creates already past the check, and sweeps again; a second signal exits at once.

`check:eval-contract`: documents are read with `O_NOFOLLOW` and `O_NONBLOCK`, object identity is verified before and after the read, `--` separates options from file names, and single-dash typos are usage errors. `check:eval-suites`: single-dash typos are usage errors.

## Verification

Local verification passed at exact SHA `45afeee32`.

- Full Vitest suite under the Docker hermetic boundary with `--require-zero-skips`: 2,142 files and 20,758 tests passed; required gates 133/133, agent-surface contract 22/22, launcher 191/191, red probes exact.
- Bun suite: 60 isolated files. Runtime typecheck, build, package entrypoints, generated SDK types, PTY startup smoke; agent-surface contract; SBOM (681 packages, 1,075 relationships); SDK build and typecheck.
- Daemon, LLM, and real TUI end-to-end suites: 14/14, 7/7, and 115/115. Hosted-platform PTY scenarios (linux-x64): 2/2. PowerShell 40/40, Neovim platform 65/65 and lifecycle 18/18 (pinned 0.12.1), native/FND subset 89/89. Kernel lane 8/9 locally (the ninth needs the root-loaded AppArmor profile only the hosted lane provisions).
- New and extended tests: launcher parser fail-closed block (every rejection above), `eval-executor-cli.test.ts` (19 cases), `eval-executor-container-runner.test.ts` (fake `docker` on PATH pins removal order, refusal after shutdown, the in-flight wait, and start-failure cleanup), contract and suite CLI cases (symlink refusal, `--`, single-dash usage). Each was shown to fail against the previous sources.
- Independent review in three passes: the one MEDIUM (a shutdown race in the executor) and every LOW were fixed; the final pass reports no defect.
- GitNexus refreshed with PDG and skills at this SHA; against `origin/main`: 10 files, 66 symbols, 0 affected execution flows, low risk.

https://claude.ai/code/session_01C8yhaVpinooyLjiAjRUpGr
