### PR TITLE
fix(runtime): prevent memory index writer starvation

### DIFF
--- a/runtime/src/memory/full-corpus-index.ts
+++ b/runtime/src/memory/full-corpus-index.ts
@@ -48,6 +48,7 @@ import {
   MAX_MEMORY_INDEX_ROOTS,
   MAX_MEMORY_INDEX_WATCHERS,
   MAX_MEMORY_PATH_UTF8_BYTES,
+  MAX_MEMORY_QUERY_MS,
   MAX_MEMORY_RECENT_UNION,
   MEMORY_AUDIT_BACKOFF_MULTIPLIER,
   MEMORY_AUDIT_MAX_INTERVAL_MS,
@@ -93,6 +94,7 @@ const MEMORY_INDEX_READER_PIN_HEARTBEAT_MS = 10_000;
 const MEMORY_INDEX_READER_PIN_LEASE_MS = 60_000;
 const MEMORY_INDEX_INCREMENTAL_CONTENTION_REASON =
   "memory index update is waiting for an active reader or writer";
+const MEMORY_INDEX_INCREMENTAL_READER_DRAIN_MS = MAX_MEMORY_QUERY_MS * 2;
 const CHANGE_KIND_VALUES = new Set(["create", "update", "delete", "rename"]);
 
 type MemoryIndexGenerationState =
@@ -1336,6 +1338,14 @@ export class PersistentMemoryIndex {
     generation: GenerationRow,
     signal: AbortSignal,
   ): Promise<MemoryIndexGenerationStatus> {
+    if (!(await this.#waitForIncrementalReaderDrain(generation.id, signal))) {
+      return {
+        ...this.#rootStatus(root),
+        state: "refresh_pending",
+        reason: MEMORY_INDEX_INCREMENTAL_CONTENTION_REASON,
+      };
+    }
+    throwIfAborted(signal);
     const startedAt = performance.now();
     const changes = this.#db
       .prepare<[string, number, number], IncrementalChangeRow>(
@@ -2745,6 +2755,33 @@ export class PersistentMemoryIndex {
       .get(rootId)!.cursor;
   }
 
+  async #waitForIncrementalReaderDrain(
+    generationId: number,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    const deadline =
+      performance.now() + MEMORY_INDEX_INCREMENTAL_READER_DRAIN_MS;
+    while (this.#hasLiveReaderPin(generationId)) {
+      throwIfAborted(signal);
+      if (performance.now() >= deadline) return false;
+      await waitForIncrementalRetry(signal);
+    }
+    return true;
+  }
+
+  #hasLiveReaderPin(generationId: number): boolean {
+    const now = this.#now();
+    return (
+      this.#db
+        .prepare<[number, number], { present: number }>(
+          `SELECT 1 AS present FROM memory_index_reader_pins
+            WHERE generation_id = ? AND lease_expires_at_ms > ?
+            LIMIT 1`,
+        )
+        .get(generationId, now) !== undefined
+    );
+  }
+
   #claimBuildLease(generationId: number): boolean {
     const now = this.#now();
     return this.#db
@@ -2759,13 +2796,6 @@ export class PersistentMemoryIndex {
                   builder_owner IS NULL OR builder_owner = ? OR
                   builder_lease_expires_at_ms IS NULL OR
                   builder_lease_expires_at_ms <= ?
-                )
-                AND (
-                  state = 'staging' OR NOT EXISTS (
-                    SELECT 1 FROM memory_index_reader_pins p
-                     WHERE p.generation_id = memory_index_generations.id
-                       AND p.lease_expires_at_ms > ?
-                  )
                 )`,
           )
           .run(
@@ -2773,7 +2803,6 @@ export class PersistentMemoryIndex {
             now + MEMORY_INDEX_BUILD_LEASE_MS,
             generationId,
             this.#builderOwner,
-            now,
             now,
           );
         return result.changes === 1;

--- a/runtime/src/memory/full-corpus-index.ts
+++ b/runtime/src/memory/full-corpus-index.ts
@@ -48,7 +48,6 @@ import {
   MAX_MEMORY_INDEX_ROOTS,
   MAX_MEMORY_INDEX_WATCHERS,
   MAX_MEMORY_PATH_UTF8_BYTES,
-  MAX_MEMORY_QUERY_MS,
   MAX_MEMORY_RECENT_UNION,
   MEMORY_AUDIT_BACKOFF_MULTIPLIER,
   MEMORY_AUDIT_MAX_INTERVAL_MS,
@@ -94,7 +93,6 @@ const MEMORY_INDEX_READER_PIN_HEARTBEAT_MS = 10_000;
 const MEMORY_INDEX_READER_PIN_LEASE_MS = 60_000;
 const MEMORY_INDEX_INCREMENTAL_CONTENTION_REASON =
   "memory index update is waiting for an active reader or writer";
-const MEMORY_INDEX_INCREMENTAL_READER_DRAIN_MS = MAX_MEMORY_QUERY_MS * 2;
 const CHANGE_KIND_VALUES = new Set(["create", "update", "delete", "rename"]);
 
 type MemoryIndexGenerationState =
@@ -147,6 +145,7 @@ export interface PersistentMemoryIndexOptions {
   readonly now?: () => number;
   readonly backgroundRefresh?: boolean;
   readonly resourceLimitsForTesting?: {
+    readonly incrementalReaderDrainMs?: number;
     readonly maxDatabaseBytes?: number;
     readonly maxFilesPerRoot?: number;
   };
@@ -317,6 +316,7 @@ export class PersistentMemoryIndex {
   readonly #closeController = new AbortController();
   readonly #ftsAvailable: boolean;
   readonly #backgroundRefreshEnabled: boolean;
+  readonly #incrementalReaderDrainMs: number;
   readonly #maxDatabaseBytes: number;
   readonly #maxFilesPerRoot: number;
   readonly #beforeIncrementalReadForTesting?: () => void | Promise<void>;
@@ -330,6 +330,21 @@ export class PersistentMemoryIndex {
     this.#queryPool = options.queryPool ?? new MemoryQueryProcessPool();
     this.#now = options.now ?? Date.now;
     this.#backgroundRefreshEnabled = options.backgroundRefresh ?? true;
+    if (
+      options.resourceLimitsForTesting?.incrementalReaderDrainMs !==
+        undefined &&
+      (!Number.isSafeInteger(
+        options.resourceLimitsForTesting.incrementalReaderDrainMs,
+      ) ||
+        options.resourceLimitsForTesting.incrementalReaderDrainMs < 1 ||
+        options.resourceLimitsForTesting.incrementalReaderDrainMs >
+          MAX_MEMORY_INDEX_BUILD_SLICE_MS)
+    ) {
+      throw new RangeError("memory index test reader-drain limit is invalid");
+    }
+    this.#incrementalReaderDrainMs =
+      options.resourceLimitsForTesting?.incrementalReaderDrainMs ??
+      MAX_MEMORY_INDEX_BUILD_SLICE_MS;
     if (
       options.resourceLimitsForTesting?.maxDatabaseBytes !== undefined &&
       (!Number.isSafeInteger(
@@ -1346,6 +1361,13 @@ export class PersistentMemoryIndex {
       };
     }
     throwIfAborted(signal);
+    if (!this.#claimBuildLease(generation.id)) {
+      return {
+        ...this.#rootStatus(root),
+        state: "refresh_pending",
+        reason: MEMORY_INDEX_INCREMENTAL_CONTENTION_REASON,
+      };
+    }
     const startedAt = performance.now();
     const changes = this.#db
       .prepare<[string, number, number], IncrementalChangeRow>(
@@ -2759,8 +2781,7 @@ export class PersistentMemoryIndex {
     generationId: number,
     signal: AbortSignal,
   ): Promise<boolean> {
-    const deadline =
-      performance.now() + MEMORY_INDEX_INCREMENTAL_READER_DRAIN_MS;
+    const deadline = performance.now() + this.#incrementalReaderDrainMs;
     while (this.#hasLiveReaderPin(generationId)) {
       throwIfAborted(signal);
       if (performance.now() >= deadline) return false;

--- a/runtime/tests/memory/full-corpus-index.test.ts
+++ b/runtime/tests/memory/full-corpus-index.test.ts
@@ -414,7 +414,7 @@ describe("C3b persistent full-corpus index", () => {
     expect(restored.discoveryOperations).toBeGreaterThan(0);
   });
 
-  it("updates one file at a compacted page ceiling and rolls back growth without advancing its cursor", async () => {
+  it("updates one file with bounded SQLite maintenance headroom and rolls back growth without advancing its cursor", async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-page-cap-"));
     const memoryRoot = join(temporaryRoot, "memory");
     const stateRoot = join(temporaryRoot, "state");
@@ -447,6 +447,7 @@ describe("C3b persistent full-corpus index", () => {
     index = undefined;
 
     const ceilingDatabase = new Database(databasePath);
+    let compactedPageCount = 0;
     let pageCeiling = 0;
     let byteCeiling = 0;
     try {
@@ -455,9 +456,13 @@ describe("C3b persistent full-corpus index", () => {
       expect(
         ceilingDatabase.pragma("freelist_count", { simple: true }),
       ).toBe(0);
-      pageCeiling = Number(
+      compactedPageCount = Number(
         ceilingDatabase.pragma("page_count", { simple: true }),
       );
+      // FTS5 may append one maintenance page when replacing terms even when
+      // the indexed header has the same logical size. Keep that bounded
+      // storage headroom while still exercising rollback at the hard limit.
+      pageCeiling = compactedPageCount + 1;
       byteCeiling =
         pageCeiling *
         Number(ceilingDatabase.pragma("page_size", { simple: true }));
@@ -489,14 +494,17 @@ describe("C3b persistent full-corpus index", () => {
     });
     expect(after.digest).not.toBe(before.digest);
 
+    let committedPageCount = 0;
     const inspection = new Database(databasePath, {
       readonly: true,
       fileMustExist: true,
     });
     try {
-      expect(Number(inspection.pragma("page_count", { simple: true }))).toBe(
-        pageCeiling,
+      committedPageCount = Number(
+        inspection.pragma("page_count", { simple: true }),
       );
+      expect(committedPageCount).toBeGreaterThanOrEqual(compactedPageCount);
+      expect(committedPageCount).toBeLessThanOrEqual(pageCeiling);
       expect(
         (
           inspection
@@ -534,7 +542,7 @@ describe("C3b persistent full-corpus index", () => {
     );
     expect(rejectedState.changeCursor).toBe(committedState.changeCursor);
     expect(rejectedState.pendingChanges).toBeGreaterThan(0);
-    expect(readDatabasePageCount(databasePath)).toBe(pageCeiling);
+    expect(readDatabasePageCount(databasePath)).toBe(committedPageCount);
   });
 
   it("rejects the exact 512-to-513 incremental create and recovers after a deletion", async () => {
@@ -1506,6 +1514,99 @@ describe("C3b persistent full-corpus index", () => {
       releaseQuery();
       writer.close();
     }
+  });
+
+  it("lands an incremental update while overlapping readers keep the generation pinned", async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-reader-stream-"));
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    const memoryPath = join(memoryRoot, "streamed.md");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    await writeMemory(
+      memoryPath,
+      "Reader stream",
+      "readerstreamterm alpha",
+    );
+
+    const queryPool = new MemoryQueryProcessPool({ helperEntrypoint });
+    const runQuery = queryPool.query.bind(queryPool);
+    const releaseReaders = Promise.withResolvers<void>();
+    vi.spyOn(queryPool, "query").mockImplementation(
+      async (request, signal) => {
+        await releaseReaders.promise;
+        return await runQuery(request, signal);
+      },
+    );
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool,
+    });
+    const writer = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+      beforeIncrementalReadForTesting: async () => {
+        releaseReaders.resolve();
+      },
+    });
+    const roots = [{ path: memoryRoot, role: "project" as const }];
+    await index.refresh(roots, new AbortController().signal, {
+      explicit: true,
+    });
+    const generationId = readCurrentGenerationId(databasePath);
+
+    const readers: Promise<unknown>[] = [];
+    let streaming = true;
+    const stream = (async () => {
+      while (streaming) {
+        readers.push(
+          index!.query(
+            roots,
+            ["readerstreamterm"],
+            new AbortController().signal,
+          ),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    })();
+    try {
+      await expectEventually(async () =>
+        readReaderPinState(databasePath, generationId).pinCount >= 2,
+      );
+      await writeMemory(
+        memoryPath,
+        "Reader stream",
+        "readerstreamterm bravo",
+      );
+      writer.recordChange({
+        rootPath: memoryRoot,
+        relativePath: "streamed.md",
+        kind: "update",
+      });
+      await expect(
+        writer.refresh(roots, new AbortController().signal),
+      ).resolves.toMatchObject({ kind: "complete" });
+      expect(readCurrentGenerationId(databasePath)).toBe(generationId);
+    } finally {
+      streaming = false;
+      releaseReaders.resolve();
+      await stream;
+      await Promise.allSettled(readers);
+      writer.close();
+    }
+
+    const refreshed = await index.query(
+      roots,
+      ["readerstreamterm"],
+      new AbortController().signal,
+    );
+    expect(refreshed.candidates).toHaveLength(1);
+    expect(refreshed.candidates[0]).toMatchObject({
+      description: "readerstreamterm bravo",
+    });
   });
 
   it("atomically refuses every requested root while one current generation has a writer lease", async () => {

--- a/runtime/tests/memory/full-corpus-index.test.ts
+++ b/runtime/tests/memory/full-corpus-index.test.ts
@@ -1379,7 +1379,7 @@ describe("C3b persistent full-corpus index", () => {
     }
   });
 
-  it("defers an incremental second writer while a queued query pins the generation", async () => {
+  it("returns refresh pending when a reader outlives the incremental drain bound", async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-query-race-"));
     const memoryRoot = join(temporaryRoot, "memory");
     const stateRoot = join(temporaryRoot, "state");
@@ -1419,6 +1419,7 @@ describe("C3b persistent full-corpus index", () => {
       databasePath,
       backgroundRefresh: false,
       queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+      resourceLimitsForTesting: { incrementalReaderDrainMs: 50 },
     });
     const roots = [{ path: memoryRoot, role: "project" as const }];
     await index.refresh(roots, new AbortController().signal, {
@@ -1516,7 +1517,7 @@ describe("C3b persistent full-corpus index", () => {
     }
   });
 
-  it("lands an incremental update while overlapping readers keep the generation pinned", async () => {
+  it("lands an incremental update after overlapping readers outlive the prior drain bound", async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), "agenc-c3b-reader-stream-"));
     const memoryRoot = join(temporaryRoot, "memory");
     const stateRoot = join(temporaryRoot, "state");
@@ -1533,6 +1534,7 @@ describe("C3b persistent full-corpus index", () => {
     const queryPool = new MemoryQueryProcessPool({ helperEntrypoint });
     const runQuery = queryPool.query.bind(queryPool);
     const releaseReaders = Promise.withResolvers<void>();
+    let releaseTimer: ReturnType<typeof setTimeout> | undefined;
     vi.spyOn(queryPool, "query").mockImplementation(
       async (request, signal) => {
         await releaseReaders.promise;
@@ -1548,8 +1550,8 @@ describe("C3b persistent full-corpus index", () => {
       databasePath,
       backgroundRefresh: false,
       queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
-      beforeIncrementalReadForTesting: async () => {
-        releaseReaders.resolve();
+      beforeIncrementalReadForTesting: () => {
+        releaseTimer = setTimeout(() => releaseReaders.resolve(), 1_100);
       },
     });
     const roots = [{ path: memoryRoot, role: "project" as const }];
@@ -1592,6 +1594,7 @@ describe("C3b persistent full-corpus index", () => {
       expect(readCurrentGenerationId(databasePath)).toBe(generationId);
     } finally {
       streaming = false;
+      if (releaseTimer !== undefined) clearTimeout(releaseTimer);
       releaseReaders.resolve();
       await stream;
       await Promise.allSettled(readers);
@@ -1607,6 +1610,70 @@ describe("C3b persistent full-corpus index", () => {
     expect(refreshed.candidates[0]).toMatchObject({
       description: "readerstreamterm bravo",
     });
+  });
+
+  it("renews an expired builder lease after reader drain before incremental preparation", async () => {
+    temporaryRoot = await mkdtemp(
+      join(tmpdir(), "agenc-c3b-lease-renewal-"),
+    );
+    const memoryRoot = join(temporaryRoot, "memory");
+    const stateRoot = join(temporaryRoot, "state");
+    const databasePath = join(stateRoot, "memory.sqlite");
+    const memoryPath = join(memoryRoot, "renewed.md");
+    await mkdir(memoryRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    await writeMemory(memoryPath, "Lease renewal", "leaserenewalterm alpha");
+
+    let now = 1_000;
+    index = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      now: () => now,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+    });
+    const writer = new PersistentMemoryIndex({
+      databasePath,
+      backgroundRefresh: false,
+      now: () => now,
+      queryPool: new MemoryQueryProcessPool({ helperEntrypoint }),
+      beforeIncrementalReadForTesting: () => {
+        now += MEMORY_INDEX_BUILD_LEASE_MS;
+      },
+    });
+    const roots = [{ path: memoryRoot, role: "project" as const }];
+    await index.refresh(roots, new AbortController().signal, {
+      explicit: true,
+    });
+    const generationId = readCurrentGenerationId(databasePath);
+
+    try {
+      await writeMemory(
+        memoryPath,
+        "Lease renewal",
+        "leaserenewalterm bravo",
+      );
+      writer.recordChange({
+        rootPath: memoryRoot,
+        relativePath: "renewed.md",
+        kind: "update",
+      });
+      await expect(
+        writer.refresh(roots, new AbortController().signal),
+      ).resolves.toMatchObject({ kind: "complete" });
+      expect(readCurrentGenerationId(databasePath)).toBe(generationId);
+
+      const refreshed = await writer.query(
+        roots,
+        ["leaserenewalterm"],
+        new AbortController().signal,
+      );
+      expect(refreshed.candidates[0]).toMatchObject({
+        description: "leaserenewalterm bravo",
+        generationId,
+      });
+    } finally {
+      writer.close();
+    }
   });
 
   it("atomically refuses every requested root while one current generation has a writer lease", async () => {


### PR DESCRIPTION
## Summary

- Prevents incremental memory index writers from starving when queries keep the current generation pinned.
- Gives existing readers a bounded drain window, blocks new pins while the writer holds its lease, and renews that lease before filesystem preparation.
- Keeps the hard database-size rollback check while allowing one SQLite maintenance page in the compacted-page test.
- Adds revert-sensitive coverage for sustained reader pressure, lease renewal, watcher updates, and database growth rollback.

## Validation

- `npm test` passed 2,142 files and 20,760 tests.
- `npm run test:bun` passed.
- Runtime validation, agent-surface parity, SBOM, SDK build and typecheck, and PTY startup checks passed.
- Daemon, LLM pipeline, and TUI E2E checks passed, including all 115 TUI scenarios.
- The exact hosted shard passed 535 files and 5,152 tests with `--shard=3/4 --maxWorkers=2`.
- PowerShell, native cross-platform, Linux Neovim, and Neovim lifecycle lanes passed.
- The local kernel lane passed 8 of 9 tests. The remaining AppArmor label check expects `agenc-native-userns`, while this host reports `unconfined`; the sandbox enforcement tests passed.
- Independent review found no remaining issues.

No configuration or schema migration is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency between memory index queries and incremental writers on shared SQLite state; behavior is heavily tested but race timing affects production refresh latency.
> 
> **Overview**
> Fixes **incremental memory index updates** stalling forever when queries keep the current generation pinned. Instead of refusing the builder lease while reader pins exist, the writer now **waits up to a bounded drain window** (default build slice; configurable via `incrementalReaderDrainMs` in tests) for live pins to clear, then renews the lease and applies changes. If pins outlive that window, refresh returns **`refresh_pending`** with the existing contention reason rather than blocking indefinitely.
> 
> **`#claimBuildLease`** no longer requires an empty reader-pin set on complete generations; safety stays in the drain step and the incremental commit transaction (which still rejects active pins). **`#pinCurrentGenerations`** continues to block new queries while a builder lease is held.
> 
> Tests add coverage for drain timeout, overlapping readers past the drain bound, lease renewal after simulated expiry during preparation, and relaxed **SQLite page-count** expectations (+1 page for FTS5 maintenance) in the byte-limit rollback scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5322f29391e097265516b06cf0aba757254477f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->