### PR TITLE
Let clients carry operator consent for a live bypass switch

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.096843,
-            "maxMs": 89.953568,
-            "medianMs": 79.783875,
-            "minMs": 76.687032,
+            "madMs": 3.112211,
+            "maxMs": 87.219142,
+            "medianMs": 84.106931,
+            "minMs": 77.672376,
             "sampleCount": 5,
             "samplesMs": [
-              79.783875,
-              85.006695,
-              89.953568,
-              79.221202,
-              76.687032
+              84.106931,
+              86.402987,
+              87.219142,
+              79.33216,
+              77.672376
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 191188992,
+              "maximumObservedBytes": 189235200,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                131440640,
-                144965632,
-                148307968,
-                148307968,
-                184483840,
-                184483840,
-                186077184,
-                186077184,
-                189026304,
-                189026304,
-                191188992
+                128409600,
+                144449536,
+                146808832,
+                146808832,
+                182788096,
+                182788096,
+                184123392,
+                184123392,
+                186679296,
+                186679296,
+                189235200
               ]
             },
-            "peakRssBytes": 191188992,
+            "peakRssBytes": 189235200,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.45872,
-            "maxMs": 175.582446,
-            "medianMs": 167.549651,
-            "minMs": 151.297942,
+            "madMs": 2.929059,
+            "maxMs": 158.555737,
+            "medianMs": 152.534485,
+            "minMs": 149.605426,
             "sampleCount": 5,
             "samplesMs": [
-              167.549651,
-              175.582446,
-              168.464571,
-              164.090931,
-              151.297942
+              157.089034,
+              158.555737,
+              151.378863,
+              152.534485,
+              149.605426
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 206114816,
+              "maximumObservedBytes": 210202624,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                129716224,
-                146661376,
-                184213504,
-                184213504,
-                190443520,
-                190443520,
-                196931584,
-                196931584,
-                201789440,
-                201789440,
-                206114816
+                128835584,
+                146288640,
+                184823808,
+                184823808,
+                191705088,
+                191705088,
+                197914624,
+                197914624,
+                205680640,
+                205680640,
+                210202624
               ]
             },
-            "peakRssBytes": 209121280,
+            "peakRssBytes": 210202624,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 2.880948,
-            "maxMs": 334.073591,
-            "medianMs": 308.237276,
-            "minMs": 303.026148,
+            "madMs": 7.702247,
+            "maxMs": 320.779886,
+            "medianMs": 305.264665,
+            "minMs": 297.562418,
             "sampleCount": 5,
             "samplesMs": [
-              308.237276,
-              303.026148,
-              311.118224,
-              334.073591,
-              307.081584
+              320.779886,
+              305.264665,
+              303.312503,
+              316.566856,
+              297.562418
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 219525120,
+              "maximumObservedBytes": 225251328,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                129474560,
-                186068992,
-                199438336,
-                199438336,
-                210972672,
-                210972672,
-                219230208,
-                219230208,
-                218611712,
-                218611712,
-                219525120
+                130285568,
+                185663488,
+                199819264,
+                199819264,
+                213909504,
+                213909504,
+                221577216,
+                221577216,
+                224268288,
+                224268288,
+                225251328
               ]
             },
-            "peakRssBytes": 222502912,
+            "peakRssBytes": 225251328,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.223166,
-            "maxMs": 3.037321,
-            "medianMs": 2.400651,
-            "minMs": 2.019988,
+            "madMs": 0.356157,
+            "maxMs": 3.349034,
+            "medianMs": 2.859639,
+            "minMs": 2.387035,
             "sampleCount": 5,
             "samplesMs": [
-              3.037321,
-              2.400651,
-              2.623817,
-              2.019988,
-              2.340368
+              3.349034,
+              2.859639,
+              3.052349,
+              2.387035,
+              2.503482
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 93474816,
+              "maximumObservedBytes": 92323840,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84627456,
-                85807104,
-                87773184,
-                87773184,
-                89149440,
-                89149440,
-                90722304,
-                90722304,
-                92098560,
-                92098560,
-                93474816
+                84656128,
+                86032384,
+                87998464,
+                87998464,
+                89374720,
+                89374720,
+                90554368,
+                90554368,
+                91734016,
+                91734016,
+                92323840
               ]
             },
-            "peakRssBytes": 93474816,
+            "peakRssBytes": 92323840,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.526044,
-            "maxMs": 6.217159,
-            "medianMs": 5.691115,
-            "minMs": 4.777506,
+            "madMs": 0.375183,
+            "maxMs": 5.762529,
+            "medianMs": 5.27644,
+            "minMs": 4.74234,
             "sampleCount": 5,
             "samplesMs": [
-              6.217159,
-              5.136838,
-              5.700192,
-              4.777506,
-              5.691115
+              5.762529,
+              5.27644,
+              5.405371,
+              4.901257,
+              4.74234
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 108650496,
+              "maximumObservedBytes": 107540480,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85647360,
-                91742208,
-                94101504,
-                94101504,
-                97640448,
-                97640448,
-                100196352,
-                100196352,
-                106094592,
-                106094592,
-                108650496
+                85520384,
+                91222016,
+                93384704,
+                93384704,
+                97120256,
+                97120256,
+                99479552,
+                99479552,
+                105181184,
+                105181184,
+                107540480
               ]
             },
-            "peakRssBytes": 108847104,
+            "peakRssBytes": 107737088,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.420697,
-            "maxMs": 12.392721,
-            "medianMs": 10.124478,
-            "minMs": 9.703781,
+            "madMs": 0.982507,
+            "maxMs": 12.877787,
+            "medianMs": 11.89528,
+            "minMs": 10.380787,
             "sampleCount": 5,
             "samplesMs": [
-              10.124478,
-              11.03487,
-              10.049378,
-              9.703781,
-              12.392721
+              10.380787,
+              11.89528,
+              10.406596,
+              12.56344,
+              12.877787
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 130105344,
+              "maximumObservedBytes": 130195456,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                88227840,
-                99041280,
-                103759872,
-                103759872,
-                109658112,
-                109658112,
-                115556352,
-                115556352,
-                123617280,
-                123617280,
-                130105344
+                87924736,
+                98541568,
+                104439808,
+                104439808,
+                110141440,
+                110141440,
+                115646464,
+                115646464,
+                123314176,
+                123314176,
+                130195456
               ]
             },
-            "peakRssBytes": 130105344,
+            "peakRssBytes": 130195456,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -935,11 +935,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "8f5480e6114dce29606d1d021f1f2e0d59eb7d56",
+    "gitObjectId": "ff10a51d444ba43f07197e1b3f34bf3757ed1329",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "86681aad4689a357063b97500e567b281c54b469",
+  "sourceRevision": "52d70201102830a267d879a3f430b961ce99f350",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.05332,
-            "maxMs": 93.240375,
-            "medianMs": 78.999999,
-            "minMs": 77.821364,
+            "madMs": 3.096843,
+            "maxMs": 89.953568,
+            "medianMs": 79.783875,
+            "minMs": 76.687032,
             "sampleCount": 5,
             "samplesMs": [
-              79.295541,
-              77.821364,
-              93.240375,
-              77.946679,
-              78.999999
+              79.783875,
+              85.006695,
+              89.953568,
+              79.221202,
+              76.687032
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 190742528,
+              "maximumObservedBytes": 191188992,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                123465728,
-                143360000,
-                146309120,
-                146309120,
-                156336128,
-                156336128,
-                185434112,
-                185434112,
-                188579840,
-                188579840,
-                190742528
+                131440640,
+                144965632,
+                148307968,
+                148307968,
+                184483840,
+                184483840,
+                186077184,
+                186077184,
+                189026304,
+                189026304,
+                191188992
               ]
             },
-            "peakRssBytes": 190742528,
+            "peakRssBytes": 191188992,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 2.629729,
-            "maxMs": 183.505004,
-            "medianMs": 160.682816,
-            "minMs": 158.053087,
+            "madMs": 3.45872,
+            "maxMs": 175.582446,
+            "medianMs": 167.549651,
+            "minMs": 151.297942,
             "sampleCount": 5,
             "samplesMs": [
-              164.233598,
-              183.505004,
-              159.826875,
-              160.682816,
-              158.053087
+              167.549651,
+              175.582446,
+              168.464571,
+              164.090931,
+              151.297942
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 205291520,
+              "maximumObservedBytes": 206114816,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                128847872,
-                147611648,
-                185556992,
-                185556992,
-                191594496,
-                191594496,
-                198082560,
-                198082560,
-                201359360,
-                201359360,
-                205291520
+                129716224,
+                146661376,
+                184213504,
+                184213504,
+                190443520,
+                190443520,
+                196931584,
+                196931584,
+                201789440,
+                201789440,
+                206114816
               ]
             },
-            "peakRssBytes": 209006592,
+            "peakRssBytes": 209121280,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.098075,
-            "maxMs": 320.062224,
-            "medianMs": 316.964149,
-            "minMs": 306.305772,
+            "madMs": 2.880948,
+            "maxMs": 334.073591,
+            "medianMs": 308.237276,
+            "minMs": 303.026148,
             "sampleCount": 5,
             "samplesMs": [
-              320.062224,
-              313.797265,
-              306.305772,
-              318.010787,
-              316.964149
+              308.237276,
+              303.026148,
+              311.118224,
+              334.073591,
+              307.081584
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 221990912,
+              "maximumObservedBytes": 219525120,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                128847872,
-                185171968,
-                199524352,
-                199524352,
-                211406848,
-                211406848,
-                219860992,
-                219860992,
-                220418048,
-                220418048,
-                221990912
+                129474560,
+                186068992,
+                199438336,
+                199438336,
+                210972672,
+                210972672,
+                219230208,
+                219230208,
+                218611712,
+                218611712,
+                219525120
               ]
             },
-            "peakRssBytes": 224579584,
+            "peakRssBytes": 222502912,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.144782,
-            "maxMs": 3.087004,
-            "medianMs": 2.497372,
-            "minMs": 2.145042,
+            "madMs": 0.223166,
+            "maxMs": 3.037321,
+            "medianMs": 2.400651,
+            "minMs": 2.019988,
             "sampleCount": 5,
             "samplesMs": [
-              3.087004,
-              2.497372,
-              2.56048,
-              2.145042,
-              2.35259
+              3.037321,
+              2.400651,
+              2.623817,
+              2.019988,
+              2.340368
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92282880,
+              "maximumObservedBytes": 93474816,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84615168,
-                86581248,
-                88350720,
-                88350720,
-                89923584,
-                89923584,
-                90906624,
-                90906624,
-                91693056,
-                91693056,
-                92282880
+                84627456,
+                85807104,
+                87773184,
+                87773184,
+                89149440,
+                89149440,
+                90722304,
+                90722304,
+                92098560,
+                92098560,
+                93474816
               ]
             },
-            "peakRssBytes": 92282880,
+            "peakRssBytes": 93474816,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.132177,
-            "maxMs": 5.765875,
-            "medianMs": 4.8226,
-            "minMs": 4.690423,
+            "madMs": 0.526044,
+            "maxMs": 6.217159,
+            "medianMs": 5.691115,
+            "minMs": 4.777506,
             "sampleCount": 5,
             "samplesMs": [
-              5.765875,
-              4.8226,
-              5.079552,
-              4.807633,
-              4.690423
+              6.217159,
+              5.136838,
+              5.700192,
+              4.777506,
+              5.691115
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 107376640,
+              "maximumObservedBytes": 108650496,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                85159936,
-                91254784,
-                93220864,
-                93220864,
-                96759808,
-                96759808,
-                99119104,
-                99119104,
-                105017344,
-                105017344,
-                107376640
+                85647360,
+                91742208,
+                94101504,
+                94101504,
+                97640448,
+                97640448,
+                100196352,
+                100196352,
+                106094592,
+                106094592,
+                108650496
               ]
             },
-            "peakRssBytes": 107573248,
+            "peakRssBytes": 108847104,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.884003,
-            "maxMs": 11.55839,
-            "medianMs": 10.208334,
-            "minMs": 9.324331,
+            "madMs": 0.420697,
+            "maxMs": 12.392721,
+            "medianMs": 10.124478,
+            "minMs": 9.703781,
             "sampleCount": 5,
             "samplesMs": [
-              10.208334,
-              11.132263,
-              9.519236,
-              9.324331,
-              11.55839
+              10.124478,
+              11.03487,
+              10.049378,
+              9.703781,
+              12.392721
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 129101824,
+              "maximumObservedBytes": 130105344,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                86831104,
-                97251328,
-                102756352,
-                102756352,
-                108654592,
-                108654592,
-                114749440,
-                114749440,
-                122613760,
-                122613760,
-                129101824
+                88227840,
+                99041280,
+                103759872,
+                103759872,
+                109658112,
+                109658112,
+                115556352,
+                115556352,
+                123617280,
+                123617280,
+                130105344
               ]
             },
-            "peakRssBytes": 129101824,
+            "peakRssBytes": 130105344,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -935,11 +935,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "427bba591fd54f273d3b9fbc4f68bd4eba99a182",
+    "gitObjectId": "8f5480e6114dce29606d1d021f1f2e0d59eb7d56",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "4723c553b96a37ae0c359328db2f6ef7ee2ccec3",
+  "sourceRevision": "86681aad4689a357063b97500e567b281c54b469",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,9 +4,9 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `0fd9beeeb51977be30c5dcb4ae3f3dda32baaa6cbb2f5feb75e984aa53cbd026`
-- Source revision: `4723c553b96a37ae0c359328db2f6ef7ee2ccec3`
-- Production tree: `runtime/src` at Git object `427bba591fd54f273d3b9fbc4f68bd4eba99a182`
+- JSON SHA-256: `f8142ea1f4a480a1232a2f65e28ad407c8e43c475a99c94320017c26979ccd23`
+- Source revision: `86681aad4689a357063b97500e567b281c54b469`
+- Production tree: `runtime/src` at Git object `8f5480e6114dce29606d1d021f1f2e0d59eb7d56`
 - Loaded production closure: `92` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
@@ -18,12 +18,12 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 79.000 | 1.053 | 190742528 | 190742528 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 160.683 | 2.630 | 209006592 | 205291520 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 316.964 | 3.098 | 224579584 | 221990912 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.497 | 0.145 | 92282880 | 92282880 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 4.823 | 0.132 | 107573248 | 107376640 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.208 | 0.884 | 129101824 | 129101824 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 79.784 | 3.097 | 191188992 | 191188992 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 167.550 | 3.459 | 209121280 | 206114816 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 308.237 | 2.881 | 222502912 | 219525120 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.401 | 0.223 | 93474816 | 93474816 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.691 | 0.526 | 108847104 | 108650496 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.124 | 0.421 | 130105344 | 130105344 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 4723c553b96a37ae0c359328db2f6ef7ee2ccec3 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 86681aad4689a357063b97500e567b281c54b469 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,9 +4,9 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `f8142ea1f4a480a1232a2f65e28ad407c8e43c475a99c94320017c26979ccd23`
-- Source revision: `86681aad4689a357063b97500e567b281c54b469`
-- Production tree: `runtime/src` at Git object `8f5480e6114dce29606d1d021f1f2e0d59eb7d56`
+- JSON SHA-256: `bc5437213ed699861355ed5675ebcb85c74a13b978700be44f70767a6961d19c`
+- Source revision: `52d70201102830a267d879a3f430b961ce99f350`
+- Production tree: `runtime/src` at Git object `ff10a51d444ba43f07197e1b3f34bf3757ed1329`
 - Loaded production closure: `92` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
@@ -18,12 +18,12 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 79.784 | 3.097 | 191188992 | 191188992 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 167.550 | 3.459 | 209121280 | 206114816 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 308.237 | 2.881 | 222502912 | 219525120 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.401 | 0.223 | 93474816 | 93474816 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.691 | 0.526 | 108847104 | 108650496 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.124 | 0.421 | 130105344 | 130105344 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 84.107 | 3.112 | 189235200 | 189235200 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 152.534 | 2.929 | 210202624 | 210202624 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 305.265 | 7.702 | 225251328 | 225251328 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.860 | 0.356 | 92323840 | 92323840 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.276 | 0.375 | 107737088 | 107540480 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 11.895 | 0.983 | 130195456 | 130195456 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 86681aad4689a357063b97500e567b281c54b469 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 52d70201102830a267d879a3f430b961ce99f350 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -3323,6 +3323,12 @@ export class AgenCDaemonAgentManager {
     const result = await this.#runner.setAgentPermissionMode(agentId, {
       sessionId: params.sessionId,
       mode: params.mode,
+      // Operator consent for a live switch to bypassPermissions. The
+      // runner has always honored this; the RPC route dropped it, so no
+      // client could ever switch a running session into bypass.
+      ...(params.bypassAuthority === "operator_tool_approval"
+        ? { bypassAuthority: params.bypassAuthority }
+        : {}),
     });
     return {
       sessionId: params.sessionId,

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -3446,10 +3446,18 @@ function validateSessionSetPermissionModeParams(
 ): SessionSetPermissionModeParams {
   const validated = validateObjectShape(params, {
     methodName: "session.setPermissionMode",
-    stringFields: ["sessionId", "mode"],
+    stringFields: ["sessionId", "mode", "bypassAuthority"],
   });
   validateRequiredString(validated, "session.setPermissionMode", "sessionId");
   validateRequiredString(validated, "session.setPermissionMode", "mode");
+  if (
+    validated.bypassAuthority !== undefined &&
+    validated.bypassAuthority !== "operator_tool_approval"
+  ) {
+    throw invalidParams(
+      "session.setPermissionMode param 'bypassAuthority' accepts only 'operator_tool_approval'",
+    );
+  }
   return validated as SessionSetPermissionModeParams;
 }
 

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -1682,6 +1682,15 @@ export type WorkspaceEditorPredictionFeedbackSessionParams = Pick<
 export interface SessionSetPermissionModeParams extends JsonObject {
   readonly sessionId: string;
   readonly mode: string;
+  /**
+   * Explicit operator consent to run bypassPermissions in this session's
+   * exact workspace. Without it a live session can never switch to
+   * bypass: the transition gate refuses unless the workspace is already
+   * consent-bound, and only creation-time bypass binds it. The runner has
+   * honored this field all along — it was never declared on the wire, so
+   * no client could send it.
+   */
+  readonly bypassAuthority?: "operator_tool_approval";
 }
 
 export type SessionPermissionRuleMutationOperation = "add" | "remove";


### PR DESCRIPTION
The permission-mode runner honors `bypassAuthority: "operator_tool_approval"` as explicit consent to enter bypassPermissions in the session's exact workspace (the same authority `tool.approve` uses internally) — but the field was never declared on `session.setPermissionMode` and the RPC route dropped it. Net effect: no client could ever switch a RUNNING session into bypass; every attempt was refused with "Switching to bypassPermissions requires explicit consent for this exact cwd". Only sessions CREATED in bypass worked.

- `SessionSetPermissionModeParams` declares `bypassAuthority?: "operator_tool_approval"`
- the route forwards it, validated to the single legal value
- FND baseline rebound to the branch

The desktop now sends the field when the user explicitly picks bypass from the permission menu.