### PR TITLE
One bad turn must not brick the session

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 4.535824,
-            "maxMs": 89.443085,
-            "medianMs": 82.24538,
-            "minMs": 76.864124,
+            "madMs": 5.220415,
+            "maxMs": 107.972399,
+            "medianMs": 81.531119,
+            "minMs": 75.334548,
             "sampleCount": 5,
             "samplesMs": [
-              77.709556,
-              82.701915,
-              89.443085,
-              76.864124,
-              82.24538
+              81.531119,
+              76.310704,
+              82.538594,
+              75.334548,
+              107.972399
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 188878848,
+              "maximumObservedBytes": 238444544,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                129269760,
-                142712832,
-                145268736,
-                145268736,
-                180854784,
-                180854784,
-                185143296,
-                185143296,
-                186126336,
-                186126336,
-                188878848
+                121040896,
+                141082624,
+                143601664,
+                143601664,
+                145567744,
+                145567744,
+                181940224,
+                181940224,
+                184496128,
+                184496128,
+                238444544
               ]
             },
-            "peakRssBytes": 188878848,
+            "peakRssBytes": 239546368,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 4.261452,
-            "maxMs": 168.786767,
-            "medianMs": 159.302676,
-            "minMs": 150.396976,
+            "madMs": 6.566634,
+            "maxMs": 170.105853,
+            "medianMs": 155.11354,
+            "minMs": 148.546906,
             "sampleCount": 5,
             "samplesMs": [
-              163.564128,
-              168.786767,
-              155.071672,
-              159.302676,
-              150.396976
+              163.720138,
+              170.105853,
+              155.11354,
+              153.026696,
+              148.546906
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 204939264,
+              "maximumObservedBytes": 206004224,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                129605632,
-                147501056,
-                185446400,
-                185446400,
-                190500864,
-                190500864,
-                197578752,
-                197578752,
-                200810496,
-                200810496,
-                204939264
+                127942656,
+                146452480,
+                184397824,
+                184397824,
+                190689280,
+                190689280,
+                197373952,
+                197373952,
+                202072064,
+                202072064,
+                206004224
               ]
             },
-            "peakRssBytes": 207867904,
+            "peakRssBytes": 209313792,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 7.554322,
-            "maxMs": 333.27906,
-            "medianMs": 315.651967,
-            "minMs": 303.40666,
+            "madMs": 0.842556,
+            "maxMs": 322.208049,
+            "medianMs": 300.794965,
+            "minMs": 299.952409,
             "sampleCount": 5,
             "samplesMs": [
-              315.651967,
-              315.693775,
-              308.097645,
-              333.27906,
-              303.40666
+              313.351844,
+              299.952409,
+              300.794965,
+              322.208049,
+              300.232493
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 218628096,
+              "maximumObservedBytes": 221130752,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                130654208,
-                185540608,
-                199106560,
-                199106560,
-                209969152,
-                209969152,
-                218423296,
-                218423296,
-                218038272,
-                218038272,
-                218628096
+                128446464,
+                182296576,
+                197365760,
+                197365760,
+                209592320,
+                209592320,
+                217849856,
+                217849856,
+                220147712,
+                220147712,
+                221130752
               ]
             },
-            "peakRssBytes": 222863360,
+            "peakRssBytes": 222568448,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.266167,
-            "maxMs": 3.344877,
-            "medianMs": 2.549249,
-            "minMs": 2.087005,
+            "madMs": 0.304799,
+            "maxMs": 3.819495,
+            "medianMs": 2.623086,
+            "minMs": 2.171993,
             "sampleCount": 5,
             "samplesMs": [
-              3.344877,
-              2.549249,
-              2.815416,
-              2.087005,
-              2.531515
+              3.819495,
+              2.623086,
+              2.707565,
+              2.171993,
+              2.318287
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92422144,
+              "maximumObservedBytes": 91533312,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84361216,
-                86130688,
-                88096768,
-                88096768,
-                89669632,
-                89669632,
-                90849280,
-                90849280,
-                91635712,
-                91635712,
-                92422144
+                83472384,
+                84652032,
+                87207936,
+                87207936,
+                88584192,
+                88584192,
+                89763840,
+                89763840,
+                90157056,
+                90157056,
+                91533312
               ]
             },
-            "peakRssBytes": 92422144,
+            "peakRssBytes": 91533312,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.333554,
-            "maxMs": 5.816611,
-            "medianMs": 4.934771,
-            "minMs": 4.505238,
+            "madMs": 0.374651,
+            "maxMs": 6.028747,
+            "medianMs": 5.109407,
+            "minMs": 4.44269,
             "sampleCount": 5,
             "samplesMs": [
-              5.816611,
-              4.934771,
-              5.268325,
-              4.602158,
-              4.505238
+              6.028747,
+              5.478037,
+              5.109407,
+              4.734756,
+              4.44269
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 106565632,
+              "maximumObservedBytes": 106954752,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                83759104,
-                89853952,
-                92016640,
-                92016640,
-                95752192,
-                95752192,
-                98111488,
-                98111488,
-                104402944,
-                104402944,
-                106565632
+                84541440,
+                90243072,
+                92995584,
+                92995584,
+                96534528,
+                96534528,
+                98893824,
+                98893824,
+                104792064,
+                104792064,
+                106954752
               ]
             },
-            "peakRssBytes": 106762240,
+            "peakRssBytes": 107151360,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.437067,
-            "maxMs": 11.972586,
-            "medianMs": 10.060679,
-            "minMs": 9.623612,
+            "madMs": 1.102872,
+            "maxMs": 12.740442,
+            "medianMs": 10.387651,
+            "minMs": 8.812764,
             "sampleCount": 5,
             "samplesMs": [
-              9.961955,
-              11.145008,
-              9.623612,
-              10.060679,
-              11.972586
+              10.387651,
+              11.490523,
+              9.399322,
+              8.812764,
+              12.740442
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 129093632,
+              "maximumObservedBytes": 128237568,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                86978560,
-                97398784,
-                102707200,
-                102707200,
-                108408832,
-                108408832,
-                114503680,
-                114503680,
-                122368000,
-                122368000,
-                129093632
+                86753280,
+                97370112,
+                103268352,
+                103268352,
+                108380160,
+                108380160,
+                113885184,
+                113885184,
+                121552896,
+                121552896,
+                128237568
               ]
             },
-            "peakRssBytes": 129093632,
+            "peakRssBytes": 128237568,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -935,11 +935,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "f265aa3f89af797700f008f4d7bac3c768aa1ee2",
+    "gitObjectId": "819f3d8806acea2ce69c9a170630eace026758e7",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "2f7e4cdf5016978cfdf133f3cc4a1e66301ec30d",
+  "sourceRevision": "7cd2af76914d8c35ee292544f2de9c74615fca34",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,9 +4,9 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `0ef8dab783284ca56b94ea25ef24f1fa7e3199ba6670fc17ae67b1f8e6692205`
-- Source revision: `2f7e4cdf5016978cfdf133f3cc4a1e66301ec30d`
-- Production tree: `runtime/src` at Git object `f265aa3f89af797700f008f4d7bac3c768aa1ee2`
+- JSON SHA-256: `cd2ea7077a62cc635df3d905070df06ceacac2bcbd622838d2126556c0723574`
+- Source revision: `7cd2af76914d8c35ee292544f2de9c74615fca34`
+- Production tree: `runtime/src` at Git object `819f3d8806acea2ce69c9a170630eace026758e7`
 - Loaded production closure: `92` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
@@ -18,12 +18,12 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 82.245 | 4.536 | 188878848 | 188878848 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 159.303 | 4.261 | 207867904 | 204939264 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 315.652 | 7.554 | 222863360 | 218628096 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.549 | 0.266 | 92422144 | 92422144 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 4.935 | 0.334 | 106762240 | 106565632 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.061 | 0.437 | 129093632 | 129093632 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 81.531 | 5.220 | 239546368 | 238444544 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 155.114 | 6.567 | 209313792 | 206004224 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 300.795 | 0.843 | 222568448 | 221130752 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.623 | 0.305 | 91533312 | 91533312 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.109 | 0.375 | 107151360 | 106954752 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.388 | 1.103 | 128237568 | 128237568 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 2f7e4cdf5016978cfdf133f3cc4a1e66301ec30d --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 7cd2af76914d8c35ee292544f2de9c74615fca34 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -3852,12 +3852,16 @@ export async function* runAgent(
         if (merged.signal.aborted) break;
       }
 
-      if (
-        stopReason === "error" ||
+      const boundedStop =
         stopReason === "max_turns" ||
         stopReason === "max_budget_usd" ||
-        stopReason === "no_progress"
-      ) {
+        stopReason === "no_progress";
+      // A bounded stop in a keep-alive (interactive) run is a per-turn
+      // outcome: the backstop's message already reached the transcript,
+      // and the user must be able to keep prompting. Ending the run here
+      // bricked the whole session after one capped turn. One-shot agents
+      // keep failing the run — there is nobody left to continue them.
+      if (stopReason === "error" || (boundedStop && !params.keepAlive)) {
         let message: string;
         if (stopReason === "max_turns") {
           message = `subagent exceeded maxTurns${params.maxTurns !== undefined ? ` (${params.maxTurns})` : ""}`;

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -405,6 +405,11 @@ interface MutableAgent {
   status: AgentStatus;
   createdAt: string;
   startedAt: string;
+  /** When the runner first stopped answering for this agent; cleared on
+   *  the next successful snapshot. The reaper only acts once this has
+   *  persisted past the grace window — a transient null (registration
+   *  race, post-turn blip) must never error a live run. */
+  runtimeUnavailableSince?: string;
   lastActiveAt: string;
   cwd?: string;
   stateProjectDir?: string;
@@ -2236,7 +2241,7 @@ export class AgenCDaemonAgentManager {
     const reason = options.reason ?? "stale_runner";
     const candidates = await this.#state.with(async (state) => {
       await this.#refreshAgentsFromRunner(state);
-      return [...state.agents.values()].filter(isStaleAgent);
+      return [...state.agents.values()].filter((agent) => isStaleAgent(agent));
     });
     if (candidates.length === 0) return [];
     const reaped: string[] = [];
@@ -3940,12 +3945,14 @@ export class AgenCDaemonAgentManager {
       // returns a real snapshot (or an explicit stop event) will
       // reconcile.
       agent.runtimeAvailable = false;
+      agent.runtimeUnavailableSince ??= this.#now();
       return;
     }
     const previousStatus = agent.status;
     const sessionIds = [...agent.sessionIds];
     agent.recovered = false;
     agent.runtimeAvailable = true;
+    agent.runtimeUnavailableSince = undefined;
     applyAgentSnapshot(agent, snapshot);
     if (agent.status !== previousStatus) {
       await this.#recordAgentStatusSnapshots(
@@ -5058,9 +5065,22 @@ function isRecoveredRuntimeUnavailable(agent: MutableAgent): boolean {
  * runtime. Either way the agent can no longer make progress and is a
  * reaper target.
  */
-function isStaleAgent(agent: MutableAgent): boolean {
+/** How long the runner must stay silent before an agent is reapable. */
+const RUNTIME_UNAVAILABLE_GRACE_MS = 60_000;
+
+// Exported as a test seam: reap eligibility is load-bearing for live runs.
+export function isStaleAgent(agent: MutableAgent, nowIso?: string): boolean {
   if (!isActiveAgent(agent)) return false;
-  return agent.runtimeAvailable === false;
+  if (agent.runtimeAvailable !== false) return false;
+  // A daemon-restart recovery restored the record without a runtime; it
+  // can never come back on its own, so it is reapable immediately.
+  if (agent.recovered === true) return true;
+  const since = agent.runtimeUnavailableSince;
+  if (since === undefined) return false;
+  const now = nowIso !== undefined ? Date.parse(nowIso) : Date.now();
+  const start = Date.parse(since);
+  if (!Number.isFinite(now) || !Number.isFinite(start)) return true;
+  return now - start >= RUNTIME_UNAVAILABLE_GRACE_MS;
 }
 
 function compareAgentsForList(left: MutableAgent, right: MutableAgent): number {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -7565,7 +7565,9 @@ export function managedTokenUsage(
 // Translate Session PhaseEvents only for runner-local status/tool bookkeeping.
 // Live delivery is owned by the canonical Session.EventLog bridge above; using
 // this phase shape for delivery would invent competing IDs without sequences.
-function phaseEventToProgressEvent(
+// Exported as a test seam: the stop-reason mapping decides whether a turn
+// outcome ends the turn or the whole run.
+export function phaseEventToProgressEvent(
   event: import("../phases/events.js").PhaseEvent,
 ): RunAgentProgressEvent | null {
   switch (event.type) {
@@ -7612,23 +7614,30 @@ function phaseEventToProgressEvent(
           error: event.error?.message ?? "turn errored",
         };
       }
-      if (event.stopReason === "max_turns") {
+      // Bounded stops — the backstop, a turn cap, the cost cap — are
+      // per-TURN outcomes, not run deaths. Mapping them to run_error
+      // bricked the whole session: the user saw "no longer running
+      // (status: error)" and could never prompt again after one bad
+      // turn. The turn ends honestly with its message; the session
+      // stays available for the next prompt, exactly like "completed".
+      if (
+        event.stopReason === "max_turns" ||
+        event.stopReason === "max_budget_usd" ||
+        event.stopReason === "no_progress"
+      ) {
+        const message =
+          event.content.length > 0
+            ? event.content
+            : event.stopReason === "max_turns"
+              ? "Turn stopped: the agent exceeded maxTurns."
+              : event.stopReason === "max_budget_usd"
+                ? "Turn stopped: the canonical session cost cap was reached."
+                : "Turn stopped by the no-progress backstop (semantic non-termination).";
         return {
-          kind: "run_error",
-          error: "Agent exceeded maxTurns",
-        };
-      }
-      if (event.stopReason === "max_budget_usd") {
-        return {
-          kind: "run_error",
-          error: "Agent reached the canonical session cost cap",
-        };
-      }
-      if (event.stopReason === "no_progress") {
-        return {
-          kind: "run_error",
-          error:
-            "Agent stopped by the no-progress backstop (semantic non-termination)",
+          kind: "turn_complete",
+          turnId,
+          toolCallCount: 0,
+          finalMessage: message,
         };
       }
       // "completed" | "empty_response" — a per-turn completion. Emit

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -7620,24 +7620,18 @@ export function phaseEventToProgressEvent(
       // (status: error)" and could never prompt again after one bad
       // turn. The turn ends honestly with its message; the session
       // stays available for the next prompt, exactly like "completed".
-      if (
-        event.stopReason === "max_turns" ||
-        event.stopReason === "max_budget_usd" ||
-        event.stopReason === "no_progress"
-      ) {
-        const message =
-          event.content.length > 0
-            ? event.content
-            : event.stopReason === "max_turns"
-              ? "Turn stopped: the agent exceeded maxTurns."
-              : event.stopReason === "max_budget_usd"
-                ? "Turn stopped: the canonical session cost cap was reached."
-                : "Turn stopped by the no-progress backstop (semantic non-termination).";
+      const boundedStopFallback: Partial<Record<string, string>> = {
+        max_turns: "Turn capped: iteration limit hit; send a new prompt to continue.",
+        max_budget_usd: "Turn capped: cost ceiling hit; send a new prompt to continue.",
+        no_progress: "Turn halted by the progress backstop; send a new prompt to continue.",
+      };
+      const boundedFallback = boundedStopFallback[event.stopReason];
+      if (boundedFallback !== undefined) {
         return {
           kind: "turn_complete",
           turnId,
           toolCallCount: 0,
-          finalMessage: message,
+          finalMessage: event.content.length > 0 ? event.content : boundedFallback,
         };
       }
       // "completed" | "empty_response" — a per-turn completion. Emit

--- a/runtime/src/tools/TaskCreateTool/TaskCreateTool.ts
+++ b/runtime/src/tools/TaskCreateTool/TaskCreateTool.ts
@@ -18,7 +18,10 @@ import { DESCRIPTION, getPrompt } from './prompt.js'
 const inputSchema = lazySchema(() =>
   z.strictObject({
     subject: z.string().describe('A brief title for the task'),
-    description: z.string().describe('What needs to be done'),
+    description: z
+      .string()
+      .optional()
+      .describe('What needs to be done. Defaults to the subject when omitted.'),
     activeForm: z
       .string()
       .optional()
@@ -76,7 +79,7 @@ export const TaskCreateTool = buildTool({
   renderToolUseMessage() {
     return null
   },
-  async call({ subject, description, activeForm, metadata }, context) {
+  async call({ subject, description = subject, activeForm, metadata }, context) {
     const taskId = await createTask(getTaskListId(), {
       subject,
       description,

--- a/runtime/src/tools/tasks/task-board.ts
+++ b/runtime/src/tools/tasks/task-board.ts
@@ -208,31 +208,29 @@ export function createTaskBoardTools(opts: TaskToolOptions): readonly Tool[] {
         type: "object",
         properties: {
           subject: { type: "string" },
-          description: { type: "string" },
+          description: {
+            type: "string",
+            description: "Defaults to the subject when omitted.",
+          },
           activeForm: { type: "string" },
           metadata: { type: "object" },
         },
-        required: ["subject", "description"],
+        required: ["subject"],
         additionalProperties: false,
       },
       execute: async (args) => {
         const strict = taskStrictArgs(args, {
           allowed: new Set(["subject", "description", "activeForm", "metadata"]),
-          required: ["subject", "description"],
+          required: ["subject"],
         });
         if (strict) return strict;
         const subject = stringValue(args.subject);
         if (!subject) {
           return taskTextResult("subject is required", { error: "subject is required" }, true);
         }
-        const description = stringValue(args.description);
-        if (!description) {
-          return taskTextResult(
-            "description is required",
-            { error: "description is required" },
-            true,
-          );
-        }
+        // Models routinely send only a subject — that is how the tool
+        // reads. The description is display copy layered over it.
+        const description = stringValue(args.description) ?? subject;
         const activeForm = stringValue(args.activeForm);
         const parsedMetadata = parseTaskMetadata(args.metadata);
         if (parsedMetadata.error) return parsedMetadata.error;

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -4857,13 +4857,9 @@ describe("AgenC background agent lifecycle", () => {
     };
     const agents = new AgenCDaemonAgentManager({
       defaultCwd: () => "/workspace",
-      now: sequence([
-        "2026-05-01T12:00:00.000Z",
-        "2026-05-01T12:00:01.000Z",
-        // The runner-missing refresh stamps runtimeUnavailableSince now.
-        "2026-05-01T12:00:02.000Z",
-        "2026-05-01T12:00:03.000Z",
-      ]),
+      // Two extra ticks: the runner-missing refresh stamps
+      // runtimeUnavailableSince through #now.
+      now: sequence(["2026-05-01T12:00:00.000Z", "2026-05-01T12:00:01.000Z", "2026-05-01T12:00:02.000Z", "2026-05-01T12:00:03.000Z"]),
       runner,
     });
 
@@ -4942,16 +4938,8 @@ describe("AgenC background agent lifecycle", () => {
     };
     const agents = new AgenCDaemonAgentManager({
       defaultCwd: () => "/workspace",
-      now: sequence([
-        "2026-05-01T12:00:00.000Z",
-        "2026-05-01T12:00:01.000Z",
-        "2026-05-01T12:00:02.000Z",
-        // Runner-missing refreshes stamp runtimeUnavailableSince now.
-        "2026-05-01T12:00:03.000Z",
-        "2026-05-01T12:00:04.000Z",
-        "2026-05-01T12:00:05.000Z",
-        "2026-05-01T12:00:06.000Z",
-      ]),
+      // Four extra ticks for the runner-missing refresh stamps.
+      now: sequence(["2026-05-01T12:00:00.000Z", "2026-05-01T12:00:01.000Z", "2026-05-01T12:00:02.000Z", "2026-05-01T12:00:03.000Z", "2026-05-01T12:00:04.000Z", "2026-05-01T12:00:05.000Z", "2026-05-01T12:00:06.000Z"]),
       runner,
     });
 
@@ -5835,12 +5823,7 @@ describe("AgenC background agent lifecycle", () => {
     };
     const agents = new AgenCDaemonAgentManager({
       defaultCwd: () => "/workspace",
-      now: sequence([
-        "2026-05-01T12:00:00.000Z",
-        "2026-05-01T12:00:01.000Z",
-        "2026-05-01T12:00:02.125Z",
-        "2026-05-01T12:00:03.875Z",
-      ]),
+      now: sequence(["2026-05-01T12:00:00.000Z", "2026-05-01T12:00:01.000Z", "2026-05-01T12:00:02.125Z", "2026-05-01T12:00:03.875Z"]),
       runner,
     });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -4857,7 +4857,13 @@ describe("AgenC background agent lifecycle", () => {
     };
     const agents = new AgenCDaemonAgentManager({
       defaultCwd: () => "/workspace",
-      now: sequence(["2026-05-01T12:00:00.000Z", "2026-05-01T12:00:01.000Z"]),
+      now: sequence([
+        "2026-05-01T12:00:00.000Z",
+        "2026-05-01T12:00:01.000Z",
+        // The runner-missing refresh stamps runtimeUnavailableSince now.
+        "2026-05-01T12:00:02.000Z",
+        "2026-05-01T12:00:03.000Z",
+      ]),
       runner,
     });
 
@@ -4940,6 +4946,11 @@ describe("AgenC background agent lifecycle", () => {
         "2026-05-01T12:00:00.000Z",
         "2026-05-01T12:00:01.000Z",
         "2026-05-01T12:00:02.000Z",
+        // Runner-missing refreshes stamp runtimeUnavailableSince now.
+        "2026-05-01T12:00:03.000Z",
+        "2026-05-01T12:00:04.000Z",
+        "2026-05-01T12:00:05.000Z",
+        "2026-05-01T12:00:06.000Z",
       ]),
       runner,
     });
@@ -5824,7 +5835,13 @@ describe("AgenC background agent lifecycle", () => {
     };
     const agents = new AgenCDaemonAgentManager({
       defaultCwd: () => "/workspace",
-      now: sequence(["2026-05-01T12:00:00.000Z", "2026-05-01T12:00:01.000Z"]),
+      now: sequence([
+        "2026-05-01T12:00:00.000Z",
+        "2026-05-01T12:00:01.000Z",
+        // The runner-missing refresh stamps runtimeUnavailableSince now.
+        "2026-05-01T12:00:02.000Z",
+        "2026-05-01T12:00:03.000Z",
+      ]),
       runner,
     });
     const dispatcher = new AgenCDaemonJsonRpcDispatcher({

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -5838,9 +5838,8 @@ describe("AgenC background agent lifecycle", () => {
       now: sequence([
         "2026-05-01T12:00:00.000Z",
         "2026-05-01T12:00:01.000Z",
-        // The runner-missing refresh stamps runtimeUnavailableSince now.
-        "2026-05-01T12:00:02.000Z",
-        "2026-05-01T12:00:03.000Z",
+        "2026-05-01T12:00:02.125Z",
+        "2026-05-01T12:00:03.875Z",
       ]),
       runner,
     });

--- a/runtime/tests/app-server/agent-stale-grace.test.ts
+++ b/runtime/tests/app-server/agent-stale-grace.test.ts
@@ -8,45 +8,48 @@ const base = {
 } as never;
 
 describe("stale-agent grace window", () => {
-  test("a transient null snapshot never reaps a live agent", () => {
-    expect(
-      isStaleAgent(
-        { ...base, runtimeUnavailableSince: "2026-08-31T10:00:00.000Z" } as never,
-        "2026-08-31T10:00:05.000Z",
-      ),
-    ).toBe(false);
-  });
+  const cases: readonly {
+    readonly name: string;
+    readonly agent: Record<string, unknown>;
+    readonly at: string;
+    readonly stale: boolean;
+  }[] = [
+    {
+      name: "a transient null snapshot never reaps a live agent",
+      agent: { runtimeUnavailableSince: "2026-08-31T10:00:00.000Z" },
+      at: "2026-08-31T10:00:05.000Z",
+      stale: false,
+    },
+    {
+      name: "unavailability without a start stamp is not reapable",
+      agent: {},
+      at: "2026-08-31T10:10:00.000Z",
+      stale: false,
+    },
+    {
+      name: "persistent unavailability past the grace window is reapable",
+      agent: { runtimeUnavailableSince: "2026-08-31T10:00:00.000Z" },
+      at: "2026-08-31T10:01:30.000Z",
+      stale: true,
+    },
+    {
+      name: "a recovery without runtime stays immediately reapable",
+      agent: { recovered: true },
+      at: "2026-08-31T10:00:00.500Z",
+      stale: true,
+    },
+    {
+      name: "an available runtime is never stale",
+      agent: { runtimeAvailable: true },
+      at: "2026-08-31T10:10:00.000Z",
+      stale: false,
+    },
+  ];
 
-  test("unavailability without a start stamp is not reapable", () => {
-    expect(isStaleAgent({ ...base } as never, "2026-08-31T10:10:00.000Z")).toBe(
-      false,
-    );
-  });
-
-  test("persistent unavailability past the grace window is reapable", () => {
-    expect(
-      isStaleAgent(
-        { ...base, runtimeUnavailableSince: "2026-08-31T10:00:00.000Z" } as never,
-        "2026-08-31T10:01:30.000Z",
-      ),
-    ).toBe(true);
-  });
-
-  test("a recovery without runtime stays immediately reapable", () => {
-    expect(
-      isStaleAgent(
-        { ...base, recovered: true } as never,
-        "2026-08-31T10:00:00.500Z",
-      ),
-    ).toBe(true);
-  });
-
-  test("an available runtime is never stale", () => {
-    expect(
-      isStaleAgent(
-        { ...base, runtimeAvailable: true } as never,
-        "2026-08-31T10:10:00.000Z",
-      ),
-    ).toBe(false);
-  });
+  for (const item of cases) {
+    test(item.name, () => {
+      const agent = { ...(base as object), ...item.agent } as never;
+      expect(isStaleAgent(agent, item.at)).toBe(item.stale);
+    });
+  }
 });

--- a/runtime/tests/app-server/agent-stale-grace.test.ts
+++ b/runtime/tests/app-server/agent-stale-grace.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { isStaleAgent } from "../../src/app-server/agent-lifecycle.js";
+
+const base = {
+  status: "working",
+  recovered: false,
+  runtimeAvailable: false,
+} as never;
+
+describe("stale-agent grace window", () => {
+  test("a transient null snapshot never reaps a live agent", () => {
+    expect(
+      isStaleAgent(
+        { ...base, runtimeUnavailableSince: "2026-08-31T10:00:00.000Z" } as never,
+        "2026-08-31T10:00:05.000Z",
+      ),
+    ).toBe(false);
+  });
+
+  test("unavailability without a start stamp is not reapable", () => {
+    expect(isStaleAgent({ ...base } as never, "2026-08-31T10:10:00.000Z")).toBe(
+      false,
+    );
+  });
+
+  test("persistent unavailability past the grace window is reapable", () => {
+    expect(
+      isStaleAgent(
+        { ...base, runtimeUnavailableSince: "2026-08-31T10:00:00.000Z" } as never,
+        "2026-08-31T10:01:30.000Z",
+      ),
+    ).toBe(true);
+  });
+
+  test("a recovery without runtime stays immediately reapable", () => {
+    expect(
+      isStaleAgent(
+        { ...base, recovered: true } as never,
+        "2026-08-31T10:00:00.500Z",
+      ),
+    ).toBe(true);
+  });
+
+  test("an available runtime is never stale", () => {
+    expect(
+      isStaleAgent(
+        { ...base, runtimeAvailable: true } as never,
+        "2026-08-31T10:10:00.000Z",
+      ),
+    ).toBe(false);
+  });
+});

--- a/runtime/tests/app-server/background-agent-runner.stop-mapping.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.stop-mapping.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { phaseEventToProgressEvent } from "../../src/app-server/background-agent-runner.js";
+
+const usage = { inputTokens: 1, outputTokens: 2, totalTokens: 3 } as never;
+
+function turnComplete(stopReason: string, content = ""): never {
+  return {
+    type: "turn_complete",
+    content,
+    usage,
+    stopReason,
+    turnId: "turn-1",
+  } as never;
+}
+
+describe("stop-reason mapping decides turn versus run scope", () => {
+  test("bounded stops end the turn, never the run", () => {
+    for (const reason of ["no_progress", "max_turns", "max_budget_usd"]) {
+      const mapped = phaseEventToProgressEvent(turnComplete(reason));
+      expect(mapped?.kind, reason).toBe("turn_complete");
+      expect(
+        (mapped as { finalMessage?: string }).finalMessage,
+        reason,
+      ).toBeTruthy();
+    }
+  });
+
+  test("the backstop's own message travels as the turn's final message", () => {
+    const mapped = phaseEventToProgressEvent(
+      turnComplete("no_progress", "Turn stopped by the no-progress backstop."),
+    );
+    expect((mapped as { finalMessage?: string }).finalMessage).toBe(
+      "Turn stopped by the no-progress backstop.",
+    );
+  });
+
+  test("a genuine error still ends the run", () => {
+    const mapped = phaseEventToProgressEvent(turnComplete("error"));
+    expect(mapped?.kind).toBe("run_error");
+  });
+
+  test("completed stays a plain turn completion", () => {
+    const mapped = phaseEventToProgressEvent(turnComplete("completed", "done"));
+    expect(mapped?.kind).toBe("turn_complete");
+  });
+});

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -570,7 +570,9 @@ describe("model-facing tools", () => {
     expect(
       registry.tools.find((tool) => tool.name === "TaskCreate")?.inputSchema,
     ).toMatchObject({
-      required: ["subject", "description"],
+      // Subject-only is the canonical contract: description is display
+      // copy that defaults to the subject when omitted.
+      required: ["subject"],
       additionalProperties: false,
     });
     expect(


### PR DESCRIPTION
## What happened (live)

A model called TaskCreate with just a `subject`; the required `description` made every call an InputValidationError; the model retried in place; the no-progress backstop stopped the turn — and the whole RUN died with it. From then on every prompt answered "AgenC daemon agent … is no longer running (status: error)": the desktop shell looked bricked after one bad turn.

## Root causes fixed (four layers, found live)

1. **TaskCreate (zod tool)**: `description` optional, defaults to the subject.
2. **TaskCreate (daemon task-board — the tool app sessions actually get)**: same fix; the zod-side default alone never reached the model.
3. **Runner stop mapping (daemon)**: `no_progress` / `max_turns` / `max_budget_usd` were mapped to `run_error`. They are per-turn outcomes and now complete the turn carrying their honest message; a genuine `error` still ends the run.
4. **Run generator (`runAgent`)**: bounded stops ended the whole run even on keep-alive (interactive) runs. They now fall through to normal turn completion when `keepAlive` is set; one-shot agents still fail their run — nobody is left to continue them.

Plus: **transient runner blips no longer reap live agents** — unavailability carries a start stamp and the reaper only acts after a 60s persistent window; a recovery without runtime stays immediately reapable.

## Verified end to end

Live desktop session, grok-4.6: a subject-only TaskCreate turn completes ("DONE"), and a second prompt in the same session answers ("SESSION-ALIVE") — previously impossible. tsc clean; agents (636), app-server runner (164+), tasks/tools (1737), session backstop suites green (remaining reds are pre-existing environmental: worktree-outside-git, bash byte-cap). FND baseline rebound.