### PR TITLE
session.transcript.v2 carries per-turn results rebuilt from the rollout

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -178,6 +178,7 @@ import type {
   SessionSnapshotResult,
   SessionTranscriptResult,
   SessionTranscriptV2Result,
+  SessionTranscriptV2TurnResult,
   SessionHookConfigShape,
   SessionHookValidationIssueShape,
   SessionHookRunDiagnosticShape,
@@ -6016,6 +6017,74 @@ interface MutableTranscriptV2Message extends JsonObject {
   committedSequence: number;
 }
 
+/** Running totals for the turn currently open in the canonical scan. */
+interface OpenTurnAccumulator {
+  startedAt?: number;
+  sawUsage: boolean;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  model?: string;
+  provider?: string;
+}
+
+function nonNegativeFinite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+/**
+ * A turn's terminal row: timing from the terminal event itself (falling back
+ * to the started/completed stamps for rollouts written before `durationMs`),
+ * usage summed from the token_count events the turn enclosed.
+ */
+function closedTurnResult(
+  turnId: string,
+  sequence: number,
+  msg: {
+    readonly type: string;
+    readonly payload: {
+      readonly turnId?: string;
+      readonly durationMs?: number;
+      readonly completedAt?: number;
+    };
+  },
+  open: OpenTurnAccumulator,
+): SessionTranscriptV2TurnResult {
+  const outcome =
+    msg.type === "turn_complete"
+      ? "completed"
+      : msg.type === "turn_aborted"
+        ? "aborted"
+        : "errored";
+  let durationMs: number | undefined;
+  if (msg.type === "turn_complete") {
+    durationMs = nonNegativeFinite(msg.payload.durationMs);
+    if (durationMs === undefined) {
+      const completedAt = nonNegativeFinite(msg.payload.completedAt);
+      if (completedAt !== undefined && open.startedAt !== undefined) {
+        durationMs = nonNegativeFinite(completedAt - open.startedAt);
+      }
+    }
+  }
+  return {
+    turnId,
+    committedSequence: sequence,
+    outcome,
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(open.sawUsage
+      ? {
+          inputTokens: open.inputTokens,
+          outputTokens: open.outputTokens,
+          totalTokens: open.totalTokens,
+        }
+      : {}),
+    ...(open.model !== undefined ? { model: open.model } : {}),
+    ...(open.provider !== undefined ? { provider: open.provider } : {}),
+  };
+}
+
 export function sessionTranscriptV2FromRollout(
   items: readonly RolloutItem[],
   sessionId: string,
@@ -6039,8 +6108,10 @@ export function sessionTranscriptV2FromRollout(
   }
 
   const messages: MutableTranscriptV2Message[] = [];
+  const turnResults: SessionTranscriptV2TurnResult[] = [];
   let currentTurnId: string | undefined;
   let currentClientMessageId: string | undefined;
+  let openTurn: OpenTurnAccumulator | undefined;
   let pendingUserIndex: number | undefined;
   let pendingClientMessageId: string | undefined;
   const assistantOrdinals = new Map<string, number>();
@@ -6143,6 +6214,37 @@ export function sessionTranscriptV2FromRollout(
       }
       currentClientMessageId = pendingClientMessageId;
       pendingClientMessageId = undefined;
+      // A dangling previous turn has no terminal event and therefore no
+      // result row; the fresh accumulator simply replaces it.
+      const startedAt = nonNegativeFinite(event.msg.payload.startedAt);
+      openTurn = {
+        sawUsage: false,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        ...(startedAt !== undefined ? { startedAt } : {}),
+      };
+      continue;
+    }
+    if (event.msg.type === "token_count") {
+      if (currentTurnId === undefined || openTurn === undefined) continue;
+      const payload = event.msg.payload;
+      const input = nonNegativeFinite(payload.promptTokens);
+      const output = nonNegativeFinite(payload.completionTokens);
+      const total = nonNegativeFinite(payload.totalTokens);
+      if (input === undefined && output === undefined && total === undefined) {
+        continue;
+      }
+      openTurn.sawUsage = true;
+      openTurn.inputTokens += input ?? 0;
+      openTurn.outputTokens += output ?? 0;
+      openTurn.totalTokens += total ?? 0;
+      if (typeof payload.model === "string" && payload.model.length > 0) {
+        openTurn.model = payload.model;
+      }
+      if (typeof payload.provider === "string" && payload.provider.length > 0) {
+        openTurn.provider = payload.provider;
+      }
       continue;
     }
     if (event.msg.type === "agent_message") {
@@ -6188,8 +6290,14 @@ export function sessionTranscriptV2FromRollout(
       ) {
         continue;
       }
+      if (currentTurnId !== undefined && openTurn !== undefined) {
+        turnResults.push(
+          closedTurnResult(currentTurnId, sequence, event.msg, openTurn),
+        );
+      }
       currentTurnId = undefined;
       currentClientMessageId = undefined;
+      openTurn = undefined;
     }
   }
 
@@ -6201,6 +6309,7 @@ export function sessionTranscriptV2FromRollout(
     asOfSequence,
     messages,
     ...(activeTurn !== undefined ? { activeTurn } : {}),
+    ...(turnResults.length > 0 ? { turnResults } : {}),
   };
 }
 

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -3064,6 +3064,25 @@ export interface SessionTranscriptV2ActiveTurn extends JsonObject {
   readonly clientMessageId?: string;
 }
 
+/**
+ * Closed-turn outcome rebuilt from the durable rollout. Timing comes from
+ * the turn's own terminal event and usage from the token_count events it
+ * enclosed, so a reopened or restored session keeps the per-turn rows a
+ * live client would have shown.
+ */
+export interface SessionTranscriptV2TurnResult extends JsonObject {
+  readonly turnId: string;
+  /** Durable sequence of the turn's terminal event; anchors placement. */
+  readonly committedSequence: number;
+  readonly outcome: "completed" | "aborted" | "errored";
+  readonly durationMs?: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly model?: string;
+  readonly provider?: string;
+}
+
 export interface SessionTranscriptV2Result extends JsonObject {
   readonly schemaVersion: 2;
   readonly sessionId: string;
@@ -3072,6 +3091,7 @@ export interface SessionTranscriptV2Result extends JsonObject {
   readonly asOfSequence: number;
   readonly messages: readonly SessionTranscriptV2Message[];
   readonly activeTurn?: SessionTranscriptV2ActiveTurn;
+  readonly turnResults?: readonly SessionTranscriptV2TurnResult[];
 }
 
 export interface SessionCancelTurnResult extends JsonObject {

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -193,4 +193,125 @@ describe("session.transcript.v2 durable projection", () => {
       sessionTranscriptV2FromRollout([...rewound], "session-1", "run-1"),
     ).toEqual(rewindSnapshot);
   });
+
+  it("rebuilds per-turn results with timing and summed usage", () => {
+    const items: RolloutItem[] = [
+      event(10, "user-1", {
+        type: "user_message",
+        payload: { message: "question", messageId: "client-1" },
+      }),
+      event(11, "turn-1", {
+        type: "turn_started",
+        payload: { turnId: "turn-1", startedAt: 1_000 },
+      }),
+      event(12, "tokens-1a", {
+        type: "token_count",
+        payload: {
+          promptTokens: 100,
+          completionTokens: 40,
+          totalTokens: 140,
+          model: "grok-4.6",
+          provider: "grok",
+        },
+      }),
+      event(13, "tokens-1b", {
+        type: "token_count",
+        payload: { promptTokens: 200, completionTokens: 60, totalTokens: 260 },
+      }),
+      event(14, "answer-1", {
+        type: "agent_message",
+        payload: { message: "answer" },
+      }),
+      event(15, "complete-1", {
+        type: "turn_complete",
+        payload: { turnId: "turn-1", durationMs: 4_137 },
+      }),
+      event(16, "user-2", {
+        type: "user_message",
+        payload: { message: "again", messageId: "client-2" },
+      }),
+      event(17, "turn-2", {
+        type: "turn_started",
+        payload: { turnId: "turn-2", startedAt: 10_000 },
+      }),
+      event(18, "abort-2", {
+        type: "turn_aborted",
+        payload: { turnId: "turn-2", reason: "daemon shutdown" },
+      }),
+    ];
+
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    expect(snapshot.turnResults).toEqual([
+      {
+        turnId: "turn-1",
+        committedSequence: 15,
+        outcome: "completed",
+        durationMs: 4_137,
+        inputTokens: 300,
+        outputTokens: 100,
+        totalTokens: 400,
+        model: "grok-4.6",
+        provider: "grok",
+      },
+      {
+        turnId: "turn-2",
+        committedSequence: 18,
+        outcome: "aborted",
+      },
+    ]);
+  });
+
+  it("falls back to the started/completed stamps and skips mismatched terminals", () => {
+    const items: RolloutItem[] = [
+      event(10, "user-1", {
+        type: "user_message",
+        payload: { message: "question", messageId: "client-1" },
+      }),
+      event(11, "turn-1", {
+        type: "turn_started",
+        payload: { turnId: "turn-1", startedAt: 1_000 },
+      }),
+      // Stale terminal from an unrelated turn must not close this one.
+      event(12, "stale-complete", {
+        type: "turn_complete",
+        payload: { turnId: "turn-0", durationMs: 99 },
+      }),
+      event(13, "complete-1", {
+        type: "turn_complete",
+        payload: { turnId: "turn-1", completedAt: 5_500 },
+      }),
+    ];
+
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+    expect(snapshot.turnResults).toEqual([
+      {
+        turnId: "turn-1",
+        committedSequence: 13,
+        outcome: "completed",
+        durationMs: 4_500,
+      },
+    ]);
+  });
+
+  it("omits turnResults entirely when the rollout closed no turns", () => {
+    const snapshot = sessionTranscriptV2FromRollout(
+      [
+        event(10, "user-1", {
+          type: "user_message",
+          payload: { message: "question", messageId: "client-1" },
+        }),
+        event(11, "turn-1", {
+          type: "turn_started",
+          payload: { turnId: "turn-1", startedAt: 1_000 },
+        }),
+        event(12, "answer-1", {
+          type: "agent_message",
+          payload: { message: "answer" },
+        }),
+      ],
+      "session-1",
+      "run-1",
+    );
+    expect(snapshot.turnResults).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

A reopened or restored session loses every per-turn duration/token row (and any client-side stopgap breaks): the durable transcript snapshot carries role+text messages only, so after a daemon or app restart the UI has nothing to draw the turn markers from. The desktop's localStorage turn-mark ledger also strands its entries when a session's live UUID id is later listed under its short thread id.

## Change

`sessionTranscriptV2FromRollout` now closes each canonical turn into a `turnResults` entry while it scans:

- **outcome** — `completed` / `aborted` / `errored`, with the same mismatched-terminal guards the message scan already applies
- **durationMs** — from `turn_complete.durationMs`, falling back to `completedAt - startedAt` for rollouts written before the field
- **usage** — `promptTokens` / `completionTokens` / `totalTokens` summed across the `token_count` events the turn enclosed, plus the model/provider that served it
- **committedSequence** — the terminal event's durable sequence, so clients can anchor the row exactly where the live marker sat

The field is additive on `SessionTranscriptV2Result`; older clients ignore it. Both the live-runner path and the persisted-thread fallback share this function, so attach-after-reopen and restore-after-restart both gain the rows.

## Tests

`transcript-v2.contract.test.ts`: completed turn with summed usage + model, aborted turn without timing, `completedAt - startedAt` fallback, stale-terminal skip, and no `turnResults` field when no turn closed. 144 runner-adjacent tests green.