### PR TITLE
refactor(runtime): share tool result byte measurement

### DIFF
--- a/runtime/src/session/serialization-size.ts
+++ b/runtime/src/session/serialization-size.ts
@@ -1,0 +1,44 @@
+export type SerializedUtf8SizeResult =
+  | {
+      readonly status: "measured";
+      readonly bytes: number;
+    }
+  | {
+      readonly status: "unserializable";
+      readonly bytes: 0;
+      readonly reason:
+        | "json_stringify_returned_undefined"
+        | "json_stringify_threw";
+    };
+
+/** Measure the compact JSON representation used by rollout persistence. */
+export function measureSerializedUtf8Bytes(
+  value: unknown,
+): SerializedUtf8SizeResult {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    return {
+      status: "unserializable",
+      bytes: 0,
+      reason: "json_stringify_threw",
+    };
+  }
+  if (serialized === undefined) {
+    return {
+      status: "unserializable",
+      bytes: 0,
+      reason: "json_stringify_returned_undefined",
+    };
+  }
+  return {
+    status: "measured",
+    bytes: Buffer.byteLength(serialized, "utf8"),
+  };
+}
+
+/** Preserve the index's zero fallback while keeping failure typed upstream. */
+export function serializedUtf8BytesOrZero(value: unknown): number {
+  return measureSerializedUtf8Bytes(value).bytes;
+}

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -116,6 +116,9 @@ import {
 } from "./trajectory-export.js";
 import { resolveHomeContext } from "../config/home.js";
 import { getAgenCHomeDir } from "../utils/envUtils.js";
+import {
+  serializedUtf8BytesOrZero as measureToolResultBytesFromPayload,
+} from "./serialization-size.js";
 
 export const I4_FSYNC_RETRY_MS = 100;
 const I83_SUSPEND_DETECTION_MS = 10_000;
@@ -3892,17 +3895,6 @@ export class SessionStoreFlushScheduler {
       clearInterval(this.timer);
       this.timer = null;
     }
-  }
-}
-
-function measureToolResultBytesFromPayload(payload: unknown): number {
-  if (typeof payload === "string") {
-    return Buffer.byteLength(payload, "utf8");
-  }
-  try {
-    return Buffer.byteLength(JSON.stringify(payload ?? ""), "utf8");
-  } catch {
-    return 0;
   }
 }
 

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -157,6 +157,9 @@ import type { RolloutStore } from "./rollout-store.js";
 import type { LiveThread } from "../thread-store/live-thread.js";
 import type { RolloutTraceRecorder } from "./rollout-trace.js";
 import type { AppendOptions } from "./session-store.js";
+import {
+  serializedUtf8BytesOrZero as measureToolResultBytes,
+} from "./serialization-size.js";
 import { hitM4DurabilityFailpoint } from "../durability/failpoints.js";
 import {
   cloneLlmMessage,
@@ -5937,17 +5940,6 @@ export class Session {
     this.agentStatus.complete();
     this.lifecycleState = "closed";
     if (durableCloseError !== undefined) throw durableCloseError;
-  }
-}
-
-function measureToolResultBytes(payload: unknown): number {
-  if (typeof payload === "string") {
-    return Buffer.byteLength(payload, "utf8");
-  }
-  try {
-    return Buffer.byteLength(JSON.stringify(payload ?? ""), "utf8");
-  } catch {
-    return 0;
   }
 }
 

--- a/runtime/tests/session/serialization-size.test.ts
+++ b/runtime/tests/session/serialization-size.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  measureSerializedUtf8Bytes,
+  serializedUtf8BytesOrZero,
+} from "./serialization-size.js";
+import { SessionStore } from "./session-store.js";
+
+describe("serialized UTF-8 size", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["ASCII string", "plain text"],
+    ["multibyte string", "雪だるま"],
+    ["object", { ok: true, count: 2 }],
+    ["null", null],
+  ])("measures the compact JSON bytes for %s", (_label, value) => {
+    const serialized = JSON.stringify(value);
+    expect(serialized).toBeDefined();
+    expect(measureSerializedUtf8Bytes(value)).toEqual({
+      status: "measured",
+      bytes: Buffer.byteLength(serialized!, "utf8"),
+    });
+  });
+
+  test("classifies undefined without confusing it with a zero-byte value", () => {
+    expect(measureSerializedUtf8Bytes(undefined)).toEqual({
+      status: "unserializable",
+      bytes: 0,
+      reason: "json_stringify_returned_undefined",
+    });
+    expect(serializedUtf8BytesOrZero(undefined)).toBe(0);
+    expect(measureSerializedUtf8Bytes("")).toEqual({
+      status: "measured",
+      bytes: 2,
+    });
+  });
+
+  test("classifies circular data without throwing", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(measureSerializedUtf8Bytes(circular)).toEqual({
+      status: "unserializable",
+      bytes: 0,
+      reason: "json_stringify_threw",
+    });
+    expect(serializedUtf8BytesOrZero(circular)).toBe(0);
+  });
+
+  test.each([
+    ["string", "line one\n雪 \"quoted\""],
+    ["object", { text: "雪", nested: { ok: true } }],
+  ])("matches the persisted tool-result bytes for a %s", (_label, result) => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-size-persistence-"));
+    temporaryDirectories.push(cwd);
+    const sessionId = `session-${temporaryDirectories.length}`;
+    const turnId = `turn-${temporaryDirectories.length}`;
+    const store = new SessionStore({
+      cwd,
+      sessionId,
+      agencVersion: "0.2.0",
+      agencHome: cwd,
+    });
+    store.open({
+      sessionId,
+      timestamp: "2026-09-01T00:00:00.000Z",
+      cwd,
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    store.append(
+      {
+        id: `event-${temporaryDirectories.length}`,
+        seq: 2,
+        msg: {
+          type: "tool_call_completed",
+          payload: {
+            callId: `call-${temporaryDirectories.length}`,
+            result: result as string,
+            isError: false,
+          },
+        },
+      },
+      { turnId },
+    );
+
+    const serializedResult = JSON.stringify(result);
+    const measured = measureSerializedUtf8Bytes(result);
+    expect(measured).toEqual({
+      status: "measured",
+      bytes: Buffer.byteLength(serializedResult, "utf8"),
+    });
+    expect(store.getToolResultBytes(turnId)).toBe(measured.bytes);
+    store.close();
+
+    const eventLine = readFileSync(store.rolloutPath, "utf8")
+      .split("\n")
+      .find((line) => line.includes('"type":"tool_call_completed"'));
+    expect(eventLine).toContain(`"result":${serializedResult}`);
+  });
+});

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -1378,7 +1378,7 @@ describe("session-store", () => {
       Buffer.byteLength("tool output", "utf8"),
     );
     expect(rolloutStore.getTokenEstimate("turn-emit")).toBe(
-      Math.ceil(Buffer.byteLength("tool output", "utf8") / 4),
+      Math.ceil(Buffer.byteLength(JSON.stringify("tool output"), "utf8") / 4),
     );
     rolloutStore.close();
   });


### PR DESCRIPTION
## What changed

- Added one JSON UTF-8 size helper for session persistence.
- Kept unserializable values distinct from measured values.
- Made Session and SessionStore call the shared helper.
- Added tests for strings, objects, null, undefined, circular values, and persisted byte counts.

## Tests

- Focused session tests: 148 passed.
- Typecheck passed.
- Full test run: 21,144 passed and 3 checks failed. The fuzzy benchmark failed only while the production tree was dirty and passed after commit. The FND baseline check reports the changed production closure as stale. An existing TUI identity assertion also fails in untouched files that match main byte for byte.

Closes #1830

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of advisory compaction sizing only; the main behavioral shift is string results including JSON quote bytes, which is intentional alignment with rollout persistence.
> 
> **Overview**
> **Introduces a shared helper** that measures tool-result payload size as the UTF-8 length of compact `JSON.stringify` output—the same representation written to rollout JSONL—and replaces duplicate logic in `Session` and `SessionStore`.
> 
> The helper returns a typed result for unserializable values (`undefined`, circular references) while `serializedUtf8BytesOrZero` keeps the existing **0-byte fallback** for the per-turn `toolResultBytes` index. **String tool results now count JSON quoting** (e.g. `"tool output"`) instead of raw string bytes, so in-memory estimates align with persisted events.
> 
> Adds unit tests for measured vs unserializable cases and a persistence check that `getToolResultBytes` matches the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b0095a5458eb3f4037407e8fb38b619ac708c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->