### PR TITLE
refactor(runtime): share reduction report merging

### DIFF
--- a/runtime/src/session/event-log-reducer.ts
+++ b/runtime/src/session/event-log-reducer.ts
@@ -34,6 +34,12 @@ import {
 } from "./rollout-reconstruction.js";
 import { sha256Hex, canonicalizeJson } from "../services/compact/summary-v1.js";
 import { COMPACTION_HISTORY_MARKER_VERSION } from "./compaction-history-marker.js";
+import {
+  mergeReductionReports,
+  type ReductionReport,
+} from "./reduction-report.js";
+
+export type { ReductionReport } from "./reduction-report.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // Reducer state shape
@@ -68,28 +74,6 @@ export function emptyReducedState(): ReducedSessionState {
     rolledBackTurns: 0,
     lastSeq: 0,
   };
-}
-
-// ─────────────────────────────────────────────────────────────────────
-// Reduction report — diagnostics surfaced post-replay.
-// ─────────────────────────────────────────────────────────────────────
-
-export interface ReductionReport {
-  /** Count of unknown rollout-type variants encountered (I-26). */
-  readonly unknownVariantCount: number;
-  /** Unknown-variant samples for telemetry (max 5). */
-  readonly unknownVariantSamples: ReadonlyArray<string>;
-  /** Count of seq-gap violations (I-27). */
-  readonly seqGapCount: number;
-  /** First seq-gap encountered (useful for reporting). */
-  readonly firstSeqGap?: {
-    readonly expected: EventSeq;
-    readonly actual: EventSeq;
-  };
-  /** Lines that failed to parse and were skipped. */
-  readonly malformedLineCount: number;
-  /** Total rollout items successfully processed. */
-  readonly processed: number;
 }
 
 function emptyReport(): ReductionReport {
@@ -444,7 +428,7 @@ export function reduceAll(items: ReadonlyArray<RolloutItem>): {
   for (const item of items) {
     const step = reduce(state, item);
     state = step.state;
-    report = mergeReports(report, step.report);
+    report = mergeReductionReports(report, step.report);
   }
   report = { ...report, processed: items.length };
   return { state, report };
@@ -495,25 +479,8 @@ export function reduceAllWithEmit(
     }
 
     state = step.state;
-    report = mergeReports(report, step.report);
+    report = mergeReductionReports(report, step.report);
   }
   report = { ...report, processed: items.length };
   return { state, report };
-}
-
-function mergeReports(
-  a: ReductionReport,
-  b: Partial<ReductionReport>,
-): ReductionReport {
-  return {
-    unknownVariantCount: a.unknownVariantCount + (b.unknownVariantCount ?? 0),
-    unknownVariantSamples:
-      b.unknownVariantSamples && b.unknownVariantSamples.length > 0
-        ? [...a.unknownVariantSamples, ...b.unknownVariantSamples].slice(0, 5)
-        : a.unknownVariantSamples,
-    seqGapCount: a.seqGapCount + (b.seqGapCount ?? 0),
-    firstSeqGap: a.firstSeqGap ?? b.firstSeqGap,
-    malformedLineCount: a.malformedLineCount + (b.malformedLineCount ?? 0),
-    processed: a.processed + (b.processed ?? 0),
-  };
 }

--- a/runtime/src/session/reduction-report.ts
+++ b/runtime/src/session/reduction-report.ts
@@ -1,0 +1,69 @@
+import type { EventSeq } from "./event-log.js";
+
+export const REDUCTION_REPORT_SAMPLE_CAP = 5;
+
+export interface ReductionReport {
+  /** Count of unknown rollout-type variants encountered (I-26). */
+  readonly unknownVariantCount: number;
+  /** Unknown-variant samples retained for telemetry. */
+  readonly unknownVariantSamples: ReadonlyArray<string>;
+  /** Count of seq-gap violations (I-27). */
+  readonly seqGapCount: number;
+  /** First seq-gap encountered (useful for reporting). */
+  readonly firstSeqGap?: {
+    readonly expected: EventSeq;
+    readonly actual: EventSeq;
+  };
+  /** Lines that failed to parse and were skipped. */
+  readonly malformedLineCount: number;
+  /** Total rollout items successfully processed. */
+  readonly processed: number;
+}
+
+function validCount(value: unknown): number {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+    ? value
+    : 0;
+}
+
+function addCounts(current: unknown, delta: unknown): number {
+  const sum = validCount(current) + validCount(delta);
+  return Number.isSafeInteger(sum) ? sum : Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Merge an incremental report delta without mutating either input.
+ * `processed` is additive here. Callers that own the complete input sequence
+ * assign its exact final length after their fold.
+ */
+export function mergeReductionReports(
+  current: ReductionReport,
+  delta: Partial<ReductionReport>,
+): ReductionReport {
+  const currentSamples = Array.isArray(current.unknownVariantSamples)
+    ? current.unknownVariantSamples
+    : [];
+  const deltaSamples = Array.isArray(delta.unknownVariantSamples)
+    ? delta.unknownVariantSamples
+    : [];
+
+  return {
+    unknownVariantCount: addCounts(
+      current.unknownVariantCount,
+      delta.unknownVariantCount,
+    ),
+    unknownVariantSamples: [...currentSamples, ...deltaSamples].slice(
+      0,
+      REDUCTION_REPORT_SAMPLE_CAP,
+    ),
+    seqGapCount: addCounts(current.seqGapCount, delta.seqGapCount),
+    firstSeqGap: current.firstSeqGap ?? delta.firstSeqGap,
+    malformedLineCount: addCounts(
+      current.malformedLineCount,
+      delta.malformedLineCount,
+    ),
+    processed: addCounts(current.processed, delta.processed),
+  };
+}

--- a/runtime/src/session/rollout-reconstruction.ts
+++ b/runtime/src/session/rollout-reconstruction.ts
@@ -44,8 +44,11 @@ import { isAgentInvocationTurnBoundary } from "../contracts/agent-invocation-env
 import {
   reduce,
   type ReducedSessionState,
-  type ReductionReport,
 } from "./event-log-reducer.js";
+import {
+  mergeReductionReports,
+  type ReductionReport,
+} from "./reduction-report.js";
 import type { IndexSnapshot } from "./session-store.js";
 import {
   capToolResult,
@@ -902,7 +905,9 @@ export function reconstructFromRollout(
         history: buildCompactedHistory(rawUserMessages, item.payload.message),
         lastCompaction: item.payload,
       };
-      reductionReport = mergeReport(reductionReport, { processed: 1 });
+      reductionReport = mergeReductionReports(reductionReport, {
+        processed: 1,
+      });
       continue;
     }
 
@@ -948,7 +953,7 @@ export function reconstructFromRollout(
     const step = reduce(state, toReduce);
     state = step.state;
     rawState = reduce(rawState, item).state;
-    reductionReport = mergeReport(reductionReport, step.report);
+    reductionReport = mergeReductionReports(reductionReport, step.report);
   }
   reductionReport = {
     ...reductionReport,
@@ -1297,24 +1302,6 @@ export function buildCompactedHistory(
     summaryText.length > 0 ? summaryText : "(no summary available)";
   out.push({ role: "user", content: summary });
   return out;
-}
-
-/** Tiny reducer-report merger used during forward replay. */
-function mergeReport(
-  a: ReductionReport,
-  b: Partial<ReductionReport>,
-): ReductionReport {
-  return {
-    unknownVariantCount: a.unknownVariantCount + (b.unknownVariantCount ?? 0),
-    unknownVariantSamples:
-      b.unknownVariantSamples && b.unknownVariantSamples.length > 0
-        ? [...a.unknownVariantSamples, ...b.unknownVariantSamples].slice(0, 5)
-        : a.unknownVariantSamples,
-    seqGapCount: a.seqGapCount + (b.seqGapCount ?? 0),
-    firstSeqGap: a.firstSeqGap ?? b.firstSeqGap,
-    malformedLineCount: a.malformedLineCount + (b.malformedLineCount ?? 0),
-    processed: a.processed + (b.processed ?? 0),
-  };
 }
 
 /**

--- a/runtime/tests/session/event-log-reducer.test.ts
+++ b/runtime/tests/session/event-log-reducer.test.ts
@@ -97,6 +97,18 @@ describe("event-log-reducer (I-26 + I-27)", () => {
     expect(report.unknownVariantSamples).toContain("future");
   });
 
+  test("reduceAll assigns the exact input length after merging reports", () => {
+    const { report } = reduceAll([
+      {
+        type: "unknown",
+        payload: { raw: '{"type":"future"}', originalType: "future" },
+      } as RolloutItem,
+      { type: "response_item", payload: { role: "user", content: "ok" } },
+    ]);
+
+    expect(report.processed).toBe(2);
+  });
+
   test("reduceAllWithEmit emits I-26 warning + I-27 error events", () => {
     const log = new EventLog();
     const seen: string[] = [];

--- a/runtime/tests/session/reduction-report.test.ts
+++ b/runtime/tests/session/reduction-report.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import {
+  REDUCTION_REPORT_SAMPLE_CAP,
+  mergeReductionReports,
+  type ReductionReport,
+} from "./reduction-report.js";
+
+function report(overrides: Partial<ReductionReport> = {}): ReductionReport {
+  return {
+    unknownVariantCount: 0,
+    unknownVariantSamples: [],
+    seqGapCount: 0,
+    malformedLineCount: 0,
+    processed: 0,
+    ...overrides,
+  };
+}
+
+describe("reduction report merger", () => {
+  test("an empty partial preserves every report field", () => {
+    const initial = report({
+      unknownVariantCount: 2,
+      unknownVariantSamples: ["future-a", "future-b"],
+      seqGapCount: 1,
+      firstSeqGap: { expected: 4, actual: 7 },
+      malformedLineCount: 3,
+      processed: 9,
+    });
+
+    expect(mergeReductionReports(initial, {})).toEqual(initial);
+  });
+
+  test("ignores malformed count deltas", () => {
+    const initial = report({
+      unknownVariantCount: 2,
+      seqGapCount: 3,
+      malformedLineCount: 4,
+      processed: 5,
+    });
+
+    expect(
+      mergeReductionReports(initial, {
+        unknownVariantCount: Number.NaN,
+        seqGapCount: -1,
+        malformedLineCount: Number.POSITIVE_INFINITY,
+        processed: 1.5,
+      }),
+    ).toMatchObject({
+      unknownVariantCount: 2,
+      seqGapCount: 3,
+      malformedLineCount: 4,
+      processed: 5,
+    });
+  });
+
+  test("retains the first sequence gap across later deltas", () => {
+    const firstGap = { expected: 2, actual: 5 };
+    const withFirstGap = mergeReductionReports(report(), {
+      seqGapCount: 1,
+      firstSeqGap: firstGap,
+    });
+
+    expect(
+      mergeReductionReports(withFirstGap, {
+        seqGapCount: 1,
+        firstSeqGap: { expected: 6, actual: 9 },
+      }),
+    ).toMatchObject({
+      seqGapCount: 2,
+      firstSeqGap: firstGap,
+    });
+  });
+
+  test("keeps only the first five unknown-variant samples", () => {
+    const merged = mergeReductionReports(
+      report({ unknownVariantSamples: ["a", "b", "c"] }),
+      { unknownVariantSamples: ["d", "e", "f"] },
+    );
+
+    expect(REDUCTION_REPORT_SAMPLE_CAP).toBe(5);
+    expect(merged.unknownVariantSamples).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("repeated merges add every valid count without mutating inputs", () => {
+    const initial = report({ unknownVariantSamples: ["a"] });
+    const deltas: ReadonlyArray<Partial<ReductionReport>> = [
+      {
+        unknownVariantCount: 1,
+        seqGapCount: 1,
+        malformedLineCount: 2,
+        processed: 3,
+      },
+      {
+        unknownVariantCount: 2,
+        seqGapCount: 3,
+        malformedLineCount: 4,
+        processed: 5,
+      },
+    ];
+
+    const merged = deltas.reduce(mergeReductionReports, initial);
+
+    expect(merged).toMatchObject({
+      unknownVariantCount: 3,
+      seqGapCount: 4,
+      malformedLineCount: 6,
+      processed: 8,
+    });
+    expect(initial).toEqual(report({ unknownVariantSamples: ["a"] }));
+    expect(deltas[0]?.processed).toBe(3);
+  });
+});


### PR DESCRIPTION
## What changed

- Added one reduction report type and merger for session replay.
- Kept the five-sample limit and earliest sequence gap in one module.
- Rejected invalid count deltas and kept processed counts additive inside the merger.
- Preserved exact final processed counts in both replay callers.
- Added direct merger tests and retained reducer and reconstruction checks.

## Tests

- Focused session tests passed with 36 tests.
- Typecheck passed.
- The full test run had 21,142 passing tests and three failures. After committing, the fuzzy benchmark passed with 8 tests. The remaining failures are the existing FND stale closure check for `csv_scheduler_progress_scan` and the TUI streaming identity assertion in files unchanged from main.

Closes #1831

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of session replay telemetry aggregation with added input validation; replay callers preserve final processed counts.
> 
> **Overview**
> **Consolidates rollout replay diagnostics** by moving `ReductionReport` and report merging into a dedicated `reduction-report` module, replacing duplicate `mergeReports` / `mergeReport` helpers in the event-log reducer and rollout reconstruction.
> 
> The shared **`mergeReductionReports`** keeps the five-sample cap and earliest sequence gap behavior, and **hardens counting**: non–safe-integer or negative deltas are ignored, sums clamp at `Number.MAX_SAFE_INTEGER`, and merges do not mutate inputs. **`reduceAll` / reconstruction** still set `report.processed` to the exact input length after the fold; the merger treats `processed` as additive only between steps.
> 
> Adds **focused unit tests** for the merger and a reducer test that `reduceAll` reports `processed` equal to item count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d054f2fe6c9a0ac0e0aa1ec6107751384031ceda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->