### PR TITLE
fix(runtime): truncate fullscreen labels by grapheme width

### DIFF
--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -15,6 +15,7 @@ import type { Message } from '../../types/message';
 import { openBrowser, openPath } from '../../utils/browser.js';
 import { logError } from '../../utils/log.js';
 import { plural } from '../../utils/stringUtils.js';
+import { truncateMiddleToWidth } from '../../utils/truncate.js';
 import { modelDisplayString } from '../../utils/model/model.js';
 import { getTotalCost } from '../../cost/tracker.js';
 import { formatUsdCost } from '../../session/cost.js';
@@ -527,14 +528,6 @@ export function FullscreenLayout(t0) {
   return t8;
 }
 
-function trimMiddle(value: string, maxWidth: number): string {
-  if (value.length <= maxWidth) return value;
-  if (maxWidth <= 1) return value.slice(0, Math.max(0, maxWidth));
-  const left = Math.ceil((maxWidth - 1) / 2);
-  const right = Math.floor((maxWidth - 1) / 2);
-  return `${value.slice(0, left)}…${value.slice(value.length - right)}`;
-}
-
 const execFileAsync = promisify(execFile);
 
 /** Slow poll cadence for the git chrome probe — covers branch switches made
@@ -673,8 +666,8 @@ export function DesignTopChrome({ columns, noColor }: { columns: number; noColor
     const values = Object.values(tasks ?? {});
     return values.find(task => task?.status === 'running' || task?.status === 'queued') ?? values[0];
   }, [tasks]);
-  const taskPda = activeTask?.id ? trimMiddle(String(activeTask.id), Math.max(12, Math.floor(columns * 0.18))) : '—';
-  const title = trimMiddle(`~/${cwdName}`, Math.max(12, Math.floor(columns * 0.24)));
+  const taskPda = activeTask?.id ? truncateMiddleToWidth(String(activeTask.id), Math.max(12, Math.floor(columns * 0.18))) : '—';
+  const title = truncateMiddleToWidth(`~/${cwdName}`, Math.max(12, Math.floor(columns * 0.24)));
   return <TuiHeader columns={columns} title={title} tabLabel="agenc · orchestrator" tabStatus={activeTask?.status === 'failed' ? 'warn' : 'live'} permissionMode={mode} taskPda={taskPda} />;
 }
 
@@ -688,7 +681,7 @@ export function formatDesignBottomChromeLabels(
   const modeLabel = permissionModeFooterChrome(mode).label;
   const trimmedGitLabel = gitLabel === null
     ? null
-    : trimMiddle(gitLabel, columns >= 100 ? 32 : 18);
+    : truncateMiddleToWidth(gitLabel, columns >= 100 ? 32 : 18);
   return {
     left: `● ${modeLabel} · ${modelLabel}${trimmedGitLabel === null ? '' : ` · ${trimmedGitLabel}`}`,
     right: `spend ${spend}`,
@@ -706,7 +699,7 @@ function DesignBottomChrome({ columns }: { columns: number }): React.ReactNode {
   const spend = useSessionSpendLabel();
   const gitLabel = useGitChromeLabel();
   const { right } = formatDesignBottomChromeLabels(columns, modelLabel, mode, gitLabel, spend);
-  const trimmedGitLabel = gitLabel === null ? null : trimMiddle(gitLabel, columns >= 100 ? 32 : 18);
+  const trimmedGitLabel = gitLabel === null ? null : truncateMiddleToWidth(gitLabel, columns >= 100 ? 32 : 18);
   return <V2StatusBar variant={mode === 'plan' ? 'plan' : mode === 'bypassPermissions' ? 'error' : mode === 'auto' ? 'success' : mode === 'acceptEdits' ? 'accent' : 'neutral'} left={[
       <DesignBottomLeftLabel key="left" gitLabel={trimmedGitLabel} mode={mode} modelLabel={modelLabel} />,
     ]} right={[

--- a/runtime/src/utils/truncate.ts
+++ b/runtime/src/utils/truncate.ts
@@ -77,6 +77,68 @@ export function truncateToWidth(text: string | undefined, maxWidth: number): str
 }
 
 /**
+ * Truncates the middle of a string to a terminal-column budget.
+ * Keeps grapheme clusters intact and gives an unmatched column to the prefix.
+ */
+export function truncateMiddleToWidth(
+  text: string | undefined,
+  maxWidth: number,
+): string {
+  const safeText = text ?? ''
+  const budget = maxWidth === Number.POSITIVE_INFINITY
+    ? Number.POSITIVE_INFINITY
+    : Number.isFinite(maxWidth)
+      ? Math.max(0, Math.trunc(maxWidth))
+      : 0
+
+  if (stringWidth(safeText) <= budget) return safeText
+  if (budget <= 0) return ''
+
+  const ellipsis = '…'
+  const ellipsisWidth = stringWidth(ellipsis)
+  if (ellipsisWidth > budget) return ''
+
+  const segments = [...getGraphemeSegmenter().segment(safeText)].map(
+    ({ segment }) => ({ segment, width: stringWidth(segment) }),
+  )
+  const remainingWidth = budget - ellipsisWidth
+  const prefixBudget = Math.ceil(remainingWidth / 2)
+  const suffixBudget = Math.floor(remainingWidth / 2)
+
+  let prefixEnd = 0
+  let prefixWidth = 0
+  if (prefixBudget > 0) {
+    while (prefixEnd < segments.length) {
+      const next = segments[prefixEnd]!
+      if (prefixWidth + next.width > prefixBudget) break
+      prefixWidth += next.width
+      prefixEnd++
+    }
+  }
+
+  let suffixStart = segments.length
+  let suffixWidth = 0
+  if (suffixBudget > 0) {
+    while (suffixStart > prefixEnd) {
+      const next = segments[suffixStart - 1]!
+      if (suffixWidth + next.width > suffixBudget) break
+      suffixWidth += next.width
+      suffixStart--
+    }
+  }
+
+  const prefix = segments
+    .slice(0, prefixEnd)
+    .map(({ segment }) => segment)
+    .join('')
+  const suffix = segments
+    .slice(suffixStart)
+    .map(({ segment }) => segment)
+    .join('')
+  return `${prefix}${ellipsis}${suffix}`
+}
+
+/**
  * Truncates from the start of a string, keeping the tail end.
  * Prepends '…' when truncation occurs.
  * Width-aware and grapheme-safe.

--- a/runtime/tests/tui/components/FullscreenLayout.test.tsx
+++ b/runtime/tests/tui/components/FullscreenLayout.test.tsx
@@ -134,6 +134,30 @@ describe("FullscreenLayout modal viewport", () => {
     expect(output).toContain("mode · plan");
   });
 
+  test("keeps joined emoji intact when truncating the active task ID", async () => {
+    const state = getDefaultAppState();
+    const taskId = "👩‍💻abcdefghijklmnop✈️";
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...state,
+          tasks: {
+            [taskId]: {
+              id: taskId,
+              type: "local_agent",
+              status: "running",
+            },
+          } as typeof state.tasks,
+        }}
+      >
+        <DesignTopChrome columns={100} noColor={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(output).toContain("👩‍💻abcdefg…klmnop✈️");
+  });
+
   test.each([
     ["plan", true],
     ["default", false],
@@ -190,6 +214,21 @@ describe("FullscreenLayout modal viewport", () => {
       formatDesignBottomChromeLabels(100, "grok-4-fast", "default", null, "$0.00"),
     ).toEqual({
       left: "● default on · grok-4-fast",
+      right: "spend $0.00",
+    });
+  });
+
+  test("truncates wide git labels by terminal display width", () => {
+    expect(
+      formatDesignBottomChromeLabels(
+        60,
+        "grok-4-fast",
+        "default",
+        "界界界界界界界界界界",
+        "$0.00",
+      ),
+    ).toEqual({
+      left: "● default on · grok-4-fast · 界界界界…界界界界",
       right: "spend $0.00",
     });
   });

--- a/runtime/tests/utils/truncate.test.ts
+++ b/runtime/tests/utils/truncate.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import { truncate, truncateToWidth, truncatePathMiddle } from './truncate.js'
+import { stringWidth } from '../../src/tui/ink/stringWidth.js'
+import {
+  truncate,
+  truncateMiddleToWidth,
+  truncatePathMiddle,
+  truncateToWidth,
+} from './truncate.js'
 
 describe('truncate utilities', () => {
   test('truncate returns empty string for undefined input', () => {
@@ -12,5 +18,50 @@ describe('truncate utilities', () => {
 
   test('truncatePathMiddle returns empty string for undefined path', () => {
     expect(truncatePathMiddle(undefined, 20)).toBe('')
+  })
+
+  test.each([
+    [0, ''],
+    [1, '…'],
+    [2, 'a…'],
+    [3, 'a…f'],
+    [4, 'ab…f'],
+    [5, 'ab…ef'],
+  ])('defines middle truncation at a %i-column budget', (maxWidth, expected) => {
+    const result = truncateMiddleToWidth('abcdef', maxWidth)
+
+    expect(result).toBe(expected)
+    expect(stringWidth(result)).toBe(maxWidth)
+  })
+
+  test('returns the original string when it fits the display-width budget', () => {
+    expect(truncateMiddleToWidth('界a', 3)).toBe('界a')
+    expect(truncateMiddleToWidth(undefined, 3)).toBe('')
+  })
+
+  test.each([
+    ['combining marks', 'e\u0301abcdefe\u0301', 5, 'e\u0301a…fe\u0301'],
+    ['joined and variation emoji', '👩‍💻abcdef✈️', 7, '👩‍💻a…f✈️'],
+    ['wide CJK glyphs', '界abcde界', 6, '界a…界'],
+  ])(
+    'keeps %s intact within the exact terminal width',
+    (_name, value, maxWidth, expected) => {
+      const result = truncateMiddleToWidth(value, maxWidth)
+
+      expect(result).toBe(expected)
+      expect(stringWidth(result)).toBe(maxWidth)
+    },
+  )
+
+  test.each([
+    ['界abcdef界', 1],
+    ['界abcdef界', 2],
+    ['👩‍💻abcdef✈️', 3],
+    ['e\u0301abcdefe\u0301', 4],
+    ['abcdef', 5],
+  ])('never exceeds a %i-column budget', (value, maxWidth) => {
+    expect(stringWidth(truncateMiddleToWidth(value, maxWidth))).toBeLessThanOrEqual(
+      maxWidth,
+    )
   })
 })


### PR DESCRIPTION
## What changed

- added a shared terminal-width middle truncator in the runtime utilities
- replaced FullscreenLayout's UTF-16 slicing for task, workspace, and git labels
- covered budgets zero through five, combining marks, joined and variation emoji, CJK text, and fullscreen chrome

## Checks

- focused hermetic truncate and FullscreenLayout tests passed, 45 tests
- `npm run typecheck` passed
- runtime build passed
- TUI runtime startup passed at 148x40, 120x30, and 80x24 in normal and bypass modes
- `npm test` passed 21,153 tests and stopped on the same three failures present on `main`
  - fuzzy benchmark refuses dirty tracked files in the production tree
  - current production module closure for `csv_scheduler_progress_scan` is stale
  - transcript fan-out UUID test expected two messages and received one

Closes #1806

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI label truncation with focused unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes fullscreen TUI chrome (header task ID, workspace title, bottom git segment) that used **UTF-16 length** middle truncation, which could split emoji/CJK and mis-measure wide glyphs.
> 
> Adds shared **`truncateMiddleToWidth`** in `truncate.ts`—same grapheme segmentation and `stringWidth` budget as other truncate helpers, with prefix/suffix split around `…`. **FullscreenLayout** drops its local `trimMiddle` and routes those labels through the new helper. Tests cover narrow column budgets, combining marks, ZWJ emoji, CJK width, and chrome rendering expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795433318fe95ef8e1272387661724cdc6329fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->