### PR TITLE
fix(runtime): centralize daemon request timeout policy

### DIFF
--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -43,6 +43,7 @@ import {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_READY_TIMEOUT_MS = 45_000;
+const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
 const READY_POLL_MS = 50;
 /** Mirrors the daemon transports' 16 MiB max-line bound. */
 const MAX_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024;
@@ -373,7 +374,7 @@ export async function connect(
     DEFAULT_READY_TIMEOUT_MS;
   const requestTimeoutMs =
     options.requestTimeoutMs ??
-    positiveIntFromEnv(env.AGENC_DAEMON_REQUEST_TIMEOUT_MS) ??
+    requestTimeoutMsFromEnv(env.AGENC_DAEMON_REQUEST_TIMEOUT_MS) ??
     DEFAULT_REQUEST_TIMEOUT_MS;
 
   let authCookie = await readDaemonCookie(cookiePath);
@@ -503,6 +504,14 @@ function positiveIntFromEnv(raw: string | undefined): number | null {
   if (trimmed === undefined || trimmed.length === 0) return null;
   const value = Number.parseInt(trimmed, 10);
   return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function requestTimeoutMsFromEnv(raw: string | undefined): number | null {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return null;
+  if (!/^[1-9]\d*$/u.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isInteger(value) && value <= MAX_TIMER_TIMEOUT_MS ? value : null;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -22,6 +22,7 @@ import {
   resolveAgenCDaemonCookiePath,
   resolveAgenCDaemonSocketPath,
 } from "./daemon-cli.js";
+import { resolveAgenCDaemonRequestTimeoutMs } from "./daemon-request-policy.js";
 import {
   AGENC_DAEMON_PROTOCOL_VERSION,
   JSON_RPC_VERSION,
@@ -168,7 +169,6 @@ export interface AgenCJsonLineDaemonClientOptions {
 // invocation with AGENC_DAEMON_REQUEST_TIMEOUT_MS for read-only smoke checks
 // where a faster failure is preferable.
 const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 30_000;
-const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV = "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
 const MAX_BUFFERED_SESSION_EVENT_SESSIONS = 50;
 // Must hold the full attach-time replay (user_message + early tool/stream
 // events) until the TUI calls subscribeToSessionEvents. The prior cap of 20
@@ -365,7 +365,11 @@ export function createAgenCJsonLineDaemonRequestClient(
     options.userHome,
   );
   const timeoutMs =
-    options.timeoutMs ?? resolveAgenCDaemonRequestTimeoutMs(options.env);
+    options.timeoutMs ??
+    resolveAgenCDaemonRequestTimeoutMs(
+      options.env ?? process.env,
+      DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
+    );
   return {
     request: (method, params = {}, requestOptions = {}) =>
       requestDaemon(
@@ -390,7 +394,11 @@ export async function createConnectedAgenCJsonLineDaemonTuiClient(
     options.userHome,
   );
   const timeoutMs =
-    options.timeoutMs ?? resolveAgenCDaemonRequestTimeoutMs(options.env);
+    options.timeoutMs ??
+    resolveAgenCDaemonRequestTimeoutMs(
+      options.env ?? process.env,
+      DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
+    );
   const authCookie = await (options.authCookie ?? readDaemonCookie(cookiePath));
   return createReconnectableDaemonTuiClient({
     socketPath,
@@ -1456,26 +1464,6 @@ export function defaultEnsureDaemonReady(
       });
     }
   };
-}
-
-function resolveAgenCDaemonRequestTimeoutMs(
-  env: NodeJS.ProcessEnv = process.env,
-): number {
-  const configured = env[AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV]?.trim();
-  if (configured === undefined || configured.length === 0) {
-    return DEFAULT_DAEMON_REQUEST_TIMEOUT_MS;
-  }
-  const timeoutMs = Number.parseInt(configured, 10);
-  if (
-    !Number.isInteger(timeoutMs) ||
-    String(timeoutMs) !== configured ||
-    timeoutMs <= 0
-  ) {
-    throw new Error(
-      `${AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV} must be a positive integer`,
-    );
-  }
-  return timeoutMs;
 }
 
 /**

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -41,6 +41,7 @@ import { AgenCDaemonClientMultiplexer } from "./client-multiplexer.js";
 import { AgenCCommandExecService } from "./command-exec.js";
 import { CsvAgentJobsRepositoryAuthority } from "./csv-agent-jobs-authority.js";
 import { AgenCCsvJobReviewStateService } from "./csv-job-review.js";
+import { resolveAgenCDaemonRequestTimeoutMs } from "./daemon-request-policy.js";
 import { resolveDefaultLinuxSandboxExecutable } from "../sandbox/execution-broker.js";
 import {
   daemonInstanceIdentityFromRuntimeInfo,
@@ -259,7 +260,6 @@ const AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK_ENV =
   "AGENC_DAEMON_WEBSOCKET_ALLOW_NONLOOPBACK";
 export const AGENC_DAEMON_WEBSOCKET_PORT_ENV = "AGENC_DAEMON_WEBSOCKET_PORT";
 const AGENC_DAEMON_WEBSOCKET_PATH_ENV = "AGENC_DAEMON_WEBSOCKET_PATH";
-const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV = "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
 const AGENC_DAEMON_STARTUP_DEBUG_ENV = "TUI_E2E_DEBUG";
 const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 2_000;
 const DEFAULT_DAEMON_STOP_TIMEOUT_MS = 10_000;
@@ -2084,7 +2084,10 @@ async function requestAgenCDaemonHealthStats(
   const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
   const cookiePath = resolveAgenCDaemonCookiePath(host.env, host.userHome);
   const authCookie = await readAgenCDaemonCookie(cookiePath);
-  const timeoutMs = resolveAgenCDaemonRequestTimeoutMs(host.env);
+  const timeoutMs = resolveAgenCDaemonRequestTimeoutMs(
+    host.env,
+    DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
+  );
   const responses = await sendAgenCDaemonJsonLineRequests(
     socketPath,
     timeoutMs,
@@ -2146,7 +2149,10 @@ export async function requestAgenCDaemonInstanceIdentity(
   const authCookie = await readAgenCDaemonCookie(cookiePath);
   const responses = await sendAgenCDaemonJsonLineRequests(
     socketPath,
-    resolveAgenCDaemonRequestTimeoutMs(host.env),
+    resolveAgenCDaemonRequestTimeoutMs(
+      host.env,
+      DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
+    ),
     [
       {
         jsonrpc: JSON_RPC_VERSION,
@@ -2188,7 +2194,10 @@ export async function requestAgenCDaemonShutdown(
   );
   const responses = await sendAgenCDaemonJsonLineRequests(
     socketPath,
-    resolveAgenCDaemonRequestTimeoutMs(host.env),
+    resolveAgenCDaemonRequestTimeoutMs(
+      host.env,
+      DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
+    ),
     [
       {
         jsonrpc: JSON_RPC_VERSION,
@@ -2410,7 +2419,10 @@ async function requestAgenCDaemonReload(
   const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
   const cookiePath = resolveAgenCDaemonCookiePath(host.env, host.userHome);
   const authCookie = await readAgenCDaemonCookie(cookiePath);
-  const timeoutMs = resolveAgenCDaemonRequestTimeoutMs(host.env);
+  const timeoutMs = resolveAgenCDaemonRequestTimeoutMs(
+    host.env,
+    DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
+  );
   const responses = await sendAgenCDaemonJsonLineRequests(
     socketPath,
     timeoutMs,
@@ -2472,26 +2484,6 @@ async function requestAgenCDaemonReload(
     throw new Error("daemon returned a malformed daemon.reload result");
   }
   return result;
-}
-
-function resolveAgenCDaemonRequestTimeoutMs(
-  env: NodeJS.ProcessEnv = process.env,
-): number {
-  const configured = env[AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV]?.trim();
-  if (configured === undefined || configured.length === 0) {
-    return DEFAULT_DAEMON_REQUEST_TIMEOUT_MS;
-  }
-  const timeoutMs = Number.parseInt(configured, 10);
-  if (
-    !Number.isInteger(timeoutMs) ||
-    String(timeoutMs) !== configured ||
-    timeoutMs <= 0
-  ) {
-    throw new Error(
-      `${AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV} must be a positive integer`,
-    );
-  }
-  return timeoutMs;
 }
 
 async function readAgenCDaemonCookie(cookiePath: string): Promise<string> {

--- a/runtime/src/app-server/daemon-request-policy.ts
+++ b/runtime/src/app-server/daemon-request-policy.ts
@@ -1,0 +1,50 @@
+export const AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV =
+  "AGENC_DAEMON_REQUEST_TIMEOUT_MS";
+
+/** Largest delay Node can schedule without clamping it to one millisecond. */
+export const MAX_DAEMON_REQUEST_TIMEOUT_MS = 2_147_483_647;
+
+declare const daemonRequestTimeoutMsBrand: unique symbol;
+
+export type DaemonRequestTimeoutMs = number & {
+  readonly [daemonRequestTimeoutMsBrand]: true;
+};
+
+export function resolveAgenCDaemonRequestTimeoutMs(
+  env: NodeJS.ProcessEnv,
+  defaultTimeoutMs: number,
+): DaemonRequestTimeoutMs {
+  const configured = env[AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV]?.trim();
+  if (configured === undefined || configured.length === 0) {
+    return asDaemonRequestTimeoutMs(defaultTimeoutMs, "default timeout");
+  }
+  if (!/^[1-9]\d*$/u.test(configured)) {
+    throw invalidDaemonRequestTimeoutError();
+  }
+  return asDaemonRequestTimeoutMs(Number(configured), "configured timeout");
+}
+
+function asDaemonRequestTimeoutMs(
+  value: number,
+  source: string,
+): DaemonRequestTimeoutMs {
+  if (
+    !Number.isInteger(value) ||
+    value <= 0 ||
+    value > MAX_DAEMON_REQUEST_TIMEOUT_MS
+  ) {
+    if (source === "configured timeout") {
+      throw invalidDaemonRequestTimeoutError();
+    }
+    throw new Error(
+      `${source} must be an integer between 1 and ${MAX_DAEMON_REQUEST_TIMEOUT_MS}`,
+    );
+  }
+  return value as DaemonRequestTimeoutMs;
+}
+
+function invalidDaemonRequestTimeoutError(): Error {
+  return new Error(
+    `${AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV} must be a positive integer no greater than ${MAX_DAEMON_REQUEST_TIMEOUT_MS}`,
+  );
+}

--- a/runtime/tests/app-server/daemon-request-policy.cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-request-policy.cli.contract.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const timeoutPolicy = vi.hoisted(() => ({
+  resolve: vi.fn(),
+}));
+
+vi.mock("./daemon-request-policy.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("./daemon-request-policy.js")
+  >();
+  timeoutPolicy.resolve.mockImplementation(
+    actual.resolveAgenCDaemonRequestTimeoutMs,
+  );
+  return {
+    ...actual,
+    resolveAgenCDaemonRequestTimeoutMs: timeoutPolicy.resolve,
+  };
+});
+
+import { createAgenCJsonLineDaemonRequestClient } from "./agent-cli.js";
+import {
+  requestAgenCDaemonInstanceIdentity,
+  resolveAgenCDaemonCookiePath,
+  type AgenCDaemonCliHost,
+} from "./daemon-cli.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  timeoutPolicy.resolve.mockClear();
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("daemon request timeout CLI defaults", () => {
+  it("keeps the agent client default at 30 seconds", () => {
+    const env: NodeJS.ProcessEnv = {};
+
+    createAgenCJsonLineDaemonRequestClient({
+      env,
+      socketPath: "/tmp/agenc-timeout-policy-agent.sock",
+      authCookie: "test-cookie",
+    });
+
+    expect(timeoutPolicy.resolve).toHaveBeenCalledWith(env, 30_000);
+  });
+
+  it("keeps daemon control requests at the two-second default", async () => {
+    const agencHome = await mkdtemp(join(tmpdir(), "agenc-timeout-policy-"));
+    roots.push(agencHome);
+    const host = createHost(agencHome);
+    await writeFile(
+      resolveAgenCDaemonCookiePath(host.env, host.userHome),
+      "test-cookie\n",
+      { mode: 0o600 },
+    );
+    const stopBeforeSocket = new Error("timeout policy observed");
+    timeoutPolicy.resolve.mockImplementationOnce(() => {
+      throw stopBeforeSocket;
+    });
+
+    await expect(requestAgenCDaemonInstanceIdentity(host)).rejects.toBe(
+      stopBeforeSocket,
+    );
+    expect(timeoutPolicy.resolve).toHaveBeenCalledWith(host.env, 2_000);
+  });
+});
+
+function createHost(agencHome: string): AgenCDaemonCliHost {
+  return {
+    env: { AGENC_HOME: agencHome },
+    userHome: "/home/test",
+    entrypointPath: "/opt/agenc/bin/agenc.js",
+    execPath: "/usr/bin/node",
+    pid: 4100,
+    spawnDetachedDaemon: () => 4200,
+    isPidRunning: () => false,
+    terminatePid: () => {},
+    sleep: async () => {},
+  };
+}

--- a/runtime/tests/app-server/daemon-request-policy.test.ts
+++ b/runtime/tests/app-server/daemon-request-policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV,
+  MAX_DAEMON_REQUEST_TIMEOUT_MS,
+  resolveAgenCDaemonRequestTimeoutMs,
+} from "./daemon-request-policy.js";
+
+const DAEMON_CLI_DEFAULT_MS = 2_000;
+const AGENT_CLI_DEFAULT_MS = 30_000;
+
+function resolve(raw: string | undefined, defaultTimeoutMs = 2_000): number {
+  return resolveAgenCDaemonRequestTimeoutMs(
+    raw === undefined
+      ? {}
+      : { [AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV]: raw },
+    defaultTimeoutMs,
+  );
+}
+
+describe("daemon request timeout policy", () => {
+  it("uses each caller's explicit default for missing and blank values", () => {
+    expect(resolve(undefined, DAEMON_CLI_DEFAULT_MS)).toBe(
+      DAEMON_CLI_DEFAULT_MS,
+    );
+    expect(resolve(" \t\n", AGENT_CLI_DEFAULT_MS)).toBe(
+      AGENT_CLI_DEFAULT_MS,
+    );
+  });
+
+  it("accepts trimmed canonical positive integers through the timer maximum", () => {
+    expect(resolve(" 42 ")).toBe(42);
+    expect(resolve(String(MAX_DAEMON_REQUEST_TIMEOUT_MS))).toBe(
+      MAX_DAEMON_REQUEST_TIMEOUT_MS,
+    );
+  });
+
+  it.each([
+    ["zero", "0"],
+    ["leading zeros", "01"],
+    ["plus sign", "+1"],
+    ["negative sign", "-1"],
+    ["fraction", "1.5"],
+    ["exponent", "1e3"],
+    ["timer overflow", String(MAX_DAEMON_REQUEST_TIMEOUT_MS + 1)],
+    ["numeric overflow", "9".repeat(400)],
+  ])("rejects %s", (_label, raw) => {
+    expect(() => resolve(raw)).toThrow(
+      `${AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV} must be a positive integer no greater than ${MAX_DAEMON_REQUEST_TIMEOUT_MS}`,
+    );
+  });
+});

--- a/runtime/tests/sdk-package/socket-timeout-policy.contract.test.ts
+++ b/runtime/tests/sdk-package/socket-timeout-policy.contract.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AgencSocketTransport,
+  connect,
+} from "../../../packages/agenc-sdk/src/socket";
+import {
+  AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV,
+  MAX_DAEMON_REQUEST_TIMEOUT_MS,
+  resolveAgenCDaemonRequestTimeoutMs,
+} from "../../src/app-server/daemon-request-policy.js";
+
+const SDK_DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+let root: string | null = null;
+let server: Server | null = null;
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (server !== null) {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = null;
+  }
+  if (root !== null) {
+    await rm(root, { recursive: true, force: true });
+    root = null;
+  }
+});
+
+describe.skipIf(process.platform === "win32")(
+  "SDK daemon request timeout policy parity",
+  () => {
+    it("keeps the SDK mirror aligned with the runtime grammar and timer bound", async () => {
+      root = await mkdtemp(join(tmpdir(), "agenc-sdk-timeout-policy-"));
+      const socketPath = join(root, "daemon.sock");
+      const cookiePath = join(root, "daemon.cookie");
+      await writeFile(cookiePath, "test-cookie\n", { mode: 0o600 });
+      server = createServer();
+      server.listen(socketPath);
+      await new Promise<void>((resolve) => server!.once("listening", resolve));
+
+      const transport = {
+        request: vi.fn(async (request: { readonly id: string | number }) => ({
+          jsonrpc: "2.0" as const,
+          id: request.id,
+          result: {
+            type: "initialized" as const,
+            protocolVersion: "1.9.0",
+            protocol: { version: "1.9.0" },
+            capabilities: {},
+          },
+        })),
+        close: vi.fn(async () => {}),
+      } as unknown as AgencSocketTransport;
+      const connectTransport = vi
+        .spyOn(AgencSocketTransport, "connect")
+        .mockResolvedValue(transport);
+
+      const cases: ReadonlyArray<{
+        readonly label: string;
+        readonly raw: string | undefined;
+      }> = [
+        { label: "missing", raw: undefined },
+        { label: "empty", raw: "" },
+        { label: "blank whitespace", raw: " \t\n" },
+        { label: "trimmed integer", raw: " 42 " },
+        { label: "zero", raw: "0" },
+        { label: "leading zeros", raw: "01" },
+        { label: "plus sign", raw: "+1" },
+        { label: "negative sign", raw: "-1" },
+        { label: "fraction", raw: "1.5" },
+        { label: "exponent", raw: "1e3" },
+        {
+          label: "maximum",
+          raw: String(MAX_DAEMON_REQUEST_TIMEOUT_MS),
+        },
+        {
+          label: "timer overflow",
+          raw: String(MAX_DAEMON_REQUEST_TIMEOUT_MS + 1),
+        },
+        { label: "numeric overflow", raw: "9".repeat(400) },
+      ];
+
+      for (const testCase of cases) {
+        const env =
+          testCase.raw === undefined
+            ? {}
+            : { [AGENC_DAEMON_REQUEST_TIMEOUT_MS_ENV]: testCase.raw };
+        let runtimeValue = SDK_DEFAULT_REQUEST_TIMEOUT_MS;
+        try {
+          runtimeValue = resolveAgenCDaemonRequestTimeoutMs(
+            env,
+            SDK_DEFAULT_REQUEST_TIMEOUT_MS,
+          );
+        } catch {
+          // The SDK keeps its existing invalid-env fallback behavior while
+          // matching the runtime authority's accepted grammar and bound.
+        }
+
+        connectTransport.mockClear();
+        const client = await connect({
+          env,
+          socketPath,
+          cookiePath,
+          autostart: false,
+        });
+        const sdkOptions = connectTransport.mock.calls[0]?.[0];
+        expect(sdkOptions?.requestTimeoutMs, testCase.label).toBe(runtimeValue);
+        await client.close();
+      }
+    });
+  },
+);


### PR DESCRIPTION
Closes #1820

The runtime now has one parser for AGENC_DAEMON_REQUEST_TIMEOUT_MS. Daemon control calls retain a 2 second default. Agent clients retain a 30 second default.

The parser accepts trimmed canonical positive decimal integers and rejects values above Node's timer limit. The SDK keeps an independent parser with parity coverage because it cannot import runtime internals.

Tests:
- Focused runtime and SDK timeout tests: 181 passed
- npm run typecheck
- npm run typecheck --workspace=@tetsuo-ai/agenc-sdk
- npm run build --workspace=@tetsuo-ai/agenc-sdk
- Fuzzy search benchmark contract after commit: 8 passed
- npm test: 21,149 passed and 3 failed during the dirty-tree run. Two failures reproduce on main. The third was the fuzzy benchmark dirty-tree guard and passed after commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to env parsing and shared timeout resolution; defaults are preserved per caller with stricter validation on malformed values.
> 
> **Overview**
> **Centralizes `AGENC_DAEMON_REQUEST_TIMEOUT_MS` parsing** in `daemon-request-policy.ts` and wires `agent-cli.ts` and `daemon-cli.ts` through it instead of duplicate local helpers.
> 
> Callers pass their own default when the env var is unset: **30s** for agent/TUI/SDK-style clients, **2s** for daemon control probes (health, identity, shutdown, reload). Configured values must be trimmed canonical positive decimals (no leading zeros, signs, or floats) and **≤ Node’s `setTimeout` maximum**; invalid values throw in the runtime with a single error message.
> 
> The **SDK** keeps a separate `requestTimeoutMsFromEnv` in `socket.ts` (it cannot import runtime internals) but tightens parsing to the same grammar and cap; invalid env there still **falls back to the 30s default** rather than throwing. New unit and contract tests lock in defaults, rejection cases, and SDK/runtime parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84064afd32ddbf4b33968a4a846c86a34e88ae3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->