### PR TITLE
refactor(runtime): remove message render import cycle

### DIFF
--- a/runtime/src/tui/components/MessageRow.tsx
+++ b/runtime/src/tui/components/MessageRow.tsx
@@ -9,7 +9,7 @@ import { getDisplayMessageFromCollapsed, getToolSearchOrReadInfo, getToolUseIdsF
 import { type buildMessageLookups, EMPTY_STRING_SET, getProgressMessagesFromLookup, getSiblingToolUseIDsFromLookup, getToolUseID } from '../../utils/messages.js';
 import { hasThinkingContent, Message } from './Message.js';
 import { MessageModel } from './MessageModel.js';
-import { shouldRenderStatically } from './Messages.js';
+import { shouldRenderStatically } from './messageRenderPolicy.js';
 import { MessageTimestamp } from './MessageTimestamp.js';
 import { OffscreenFreeze } from './OffscreenFreeze.js';
 export type Props = {

--- a/runtime/src/tui/components/Messages.tsx
+++ b/runtime/src/tui/components/Messages.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RuntimeStateRepository } from '../../config/runtime-state-repository.js';
 import type { StreamingToolUse } from '../../llm/types.js';
-import { every } from '../../utils/set.js';
 import { getIsRemoteMode } from '../../bootstrap/state.js';
 import type { Command } from '../../commands.js';
 import { useContentWidth } from '../context/contentWidthContext.js';
@@ -29,13 +28,14 @@ import { collapseReadSearchGroups } from '../../utils/collapseReadSearch.js';
 import { collapseTeammateShutdowns } from '../../utils/collapseTeammateShutdowns.js';
 import { isEnvTruthy } from '../../utils/envUtils.js';
 import { applyGrouping } from '../../utils/groupToolUses.js';
-import { buildMessageLookups, createAssistantMessage, deriveUUID, getMessagesAfterCompactBoundary, getToolUseID, getToolUseIDs, hasUnresolvedHooksFromLookup, isNotEmptyMessage, normalizeMessages, reorderMessagesInUI, type StreamingThinking, shouldShowUserMessage } from '../../utils/messages.js';
+import { buildMessageLookups, createAssistantMessage, deriveUUID, getMessagesAfterCompactBoundary, getToolUseID, getToolUseIDs, isNotEmptyMessage, normalizeMessages, reorderMessagesInUI, type StreamingThinking, shouldShowUserMessage } from '../../utils/messages.js';
 import { plural } from '../../utils/stringUtils.js';
 import { renderableSearchText } from '../history/transcriptSearch.js';
 import { Divider } from './design-system/Divider.js';
 import type { UnseenDivider } from './FullscreenLayout.js';
 import { StreamingMarkdown } from './markdown/Markdown.js';
 import { hasContentAfterIndex, MessageRow } from './MessageRow.js';
+import { shouldRenderStatically } from './messageRenderPolicy.js';
 import { InVirtualListContext, type MessageActionsNav, MessageActionsSelectedContext, type MessageActionsState } from './messageActions.js';
 import { ThinkingMessage as AssistantThinkingMessage } from './v2/messagePrimitives.js';
 import { Msg, WelcomeColdPanel } from './v2/primitives.js';
@@ -750,59 +750,4 @@ export const Messages = React.memo(MessagesImpl, (prev, next) => {
   }
   return true;
 });
-export function shouldRenderStatically(message: RenderableMessage, streamingToolUseIDs: Set<string>, inProgressToolUseIDs: Set<string>, siblingToolUseIDs: ReadonlySet<string>, screen: Screen, lookups: ReturnType<typeof buildMessageLookups>): boolean {
-  if (screen === 'transcript') {
-    return true;
-  }
-  switch (message.type) {
-    case 'attachment':
-    case 'user':
-    case 'assistant':
-      {
-        if (message.type === 'assistant') {
-          const block = message.message.content[0];
-          if (block?.type === 'server_tool_use') {
-            return lookups.resolvedToolUseIDs.has(block.id);
-          }
-        }
-        const toolUseID = getToolUseID(message);
-        if (!toolUseID) {
-          return true;
-        }
-        if (streamingToolUseIDs.has(toolUseID)) {
-          return false;
-        }
-        if (inProgressToolUseIDs.has(toolUseID)) {
-          return false;
-        }
-
-        // Check if there are any unresolved PostToolUse hooks for this tool use
-        // If so, keep the message transient so the HookProgressMessage can update
-        if (hasUnresolvedHooksFromLookup(toolUseID, 'PostToolUse', lookups)) {
-          return false;
-        }
-        return every(siblingToolUseIDs, lookups.resolvedToolUseIDs);
-      }
-    case 'system':
-      {
-        // api errors always render dynamically, since we hide
-        // them as soon as we see another non-error message.
-        return message.subtype !== 'api_error';
-      }
-    case 'grouped_tool_use':
-      {
-        const allResolved = message.messages.every((msg: any) => {
-          const content = msg.message.content[0];
-          return content?.type === 'tool_use' && lookups.resolvedToolUseIDs.has(content.id);
-        });
-        return allResolved;
-      }
-    case 'collapsed_read_search':
-      {
-        // In prompt mode, never mark as static to prevent flicker between API turns
-        // (In transcript mode, we already returned true at the top of this function)
-        return false;
-      }
-  }
-  return true;
-}
+export { shouldRenderStatically };

--- a/runtime/src/tui/components/messageRenderPolicy.ts
+++ b/runtime/src/tui/components/messageRenderPolicy.ts
@@ -1,0 +1,61 @@
+import type { RenderableMessage } from '../../types/message.js';
+import { type buildMessageLookups, getToolUseID, hasUnresolvedHooksFromLookup } from '../../utils/messages.js';
+import { every } from '../../utils/set.js';
+import type { Screen } from '../types/screen.js';
+
+export function shouldRenderStatically(message: RenderableMessage, streamingToolUseIDs: Set<string>, inProgressToolUseIDs: Set<string>, siblingToolUseIDs: ReadonlySet<string>, screen: Screen, lookups: ReturnType<typeof buildMessageLookups>): boolean {
+  if (screen === 'transcript') {
+    return true;
+  }
+  switch (message.type) {
+    case 'attachment':
+    case 'user':
+    case 'assistant':
+      {
+        if (message.type === 'assistant') {
+          const block = message.message.content[0];
+          if (block?.type === 'server_tool_use') {
+            return lookups.resolvedToolUseIDs.has(block.id);
+          }
+        }
+        const toolUseID = getToolUseID(message);
+        if (!toolUseID) {
+          return true;
+        }
+        if (streamingToolUseIDs.has(toolUseID)) {
+          return false;
+        }
+        if (inProgressToolUseIDs.has(toolUseID)) {
+          return false;
+        }
+
+        // Check if there are any unresolved PostToolUse hooks for this tool use
+        // If so, keep the message transient so the HookProgressMessage can update
+        if (hasUnresolvedHooksFromLookup(toolUseID, 'PostToolUse', lookups)) {
+          return false;
+        }
+        return every(siblingToolUseIDs, lookups.resolvedToolUseIDs);
+      }
+    case 'system':
+      {
+        // api errors always render dynamically, since we hide
+        // them as soon as we see another non-error message.
+        return message.subtype !== 'api_error';
+      }
+    case 'grouped_tool_use':
+      {
+        const allResolved = message.messages.every((msg: any) => {
+          const content = msg.message.content[0];
+          return content?.type === 'tool_use' && lookups.resolvedToolUseIDs.has(content.id);
+        });
+        return allResolved;
+      }
+    case 'collapsed_read_search':
+      {
+        // In prompt mode, never mark as static to prevent flicker between API turns
+        // (In transcript mode, we already returned true at the top of this function)
+        return false;
+      }
+  }
+  return true;
+}

--- a/runtime/tests/tui/components/MessageRow.logic.test.tsx
+++ b/runtime/tests/tui/components/MessageRow.logic.test.tsx
@@ -49,7 +49,7 @@ vi.mock("./Message.js", () => ({
     ) ?? false,
 }));
 
-vi.mock("./Messages.js", () => ({
+vi.mock("./messageRenderPolicy.js", () => ({
   shouldRenderStatically: () => true,
 }));
 

--- a/runtime/tests/tui/components/MessageRow.render.test.tsx
+++ b/runtime/tests/tui/components/MessageRow.render.test.tsx
@@ -82,7 +82,7 @@ vi.mock("./MessageModel.js", async () => {
   };
 });
 
-vi.mock("./Messages.js", () => ({
+vi.mock("./messageRenderPolicy.js", () => ({
   shouldRenderStatically: (message: { uuid: string }) =>
     harness.staticMessages.has(message.uuid),
 }));

--- a/runtime/tests/tui/components/MessageRow.wave200-094.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageRow.wave200-094.coverage.test.tsx
@@ -71,7 +71,7 @@ vi.mock("./MessageTimestamp.js", async () => {
   };
 });
 
-vi.mock("./Messages.js", () => ({
+vi.mock("./messageRenderPolicy.js", () => ({
   shouldRenderStatically: () => {
     harness.staticCalls++;
     return false;

--- a/runtime/tests/tui/components/Messages.coverage2.test.tsx
+++ b/runtime/tests/tui/components/Messages.coverage2.test.tsx
@@ -4,7 +4,7 @@ vi.mock('bun:bundle', () => ({
   feature: () => false,
 }))
 
-import { shouldRenderStatically } from './Messages.js'
+import { shouldRenderStatically } from './messageRenderPolicy.js'
 
 function lookups(
   resolvedToolUseIDs: string[] = [],

--- a/runtime/tests/tui/components/message-render-policy-import-boundary.test.ts
+++ b/runtime/tests/tui/components/message-render-policy-import-boundary.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+const RUNTIME_SOURCE = resolve(import.meta.dirname, "../../../src");
+const MESSAGES = resolve(RUNTIME_SOURCE, "tui/components/Messages.tsx");
+const MESSAGE_ROW = resolve(RUNTIME_SOURCE, "tui/components/MessageRow.tsx");
+const RENDER_POLICY = resolve(
+  RUNTIME_SOURCE,
+  "tui/components/messageRenderPolicy.ts",
+);
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = resolve(directory, entry);
+    return statSync(path).isDirectory()
+      ? sourceFiles(path)
+      : /\.(?:ts|tsx)$/u.test(entry)
+        ? [path]
+        : [];
+  });
+}
+
+const sourceFileSet = new Set(sourceFiles(RUNTIME_SOURCE));
+
+function importCarriesRuntimeValue(node: ts.ImportDeclaration): boolean {
+  const clause = node.importClause;
+  if (clause === undefined) return true;
+  if (clause.isTypeOnly) return false;
+  if (clause.name !== undefined) return true;
+  const bindings = clause.namedBindings;
+  if (bindings === undefined || ts.isNamespaceImport(bindings)) return true;
+  return bindings.elements.some((element) => !element.isTypeOnly);
+}
+
+function exportCarriesRuntimeValue(node: ts.ExportDeclaration): boolean {
+  if (node.isTypeOnly) return false;
+  const clause = node.exportClause;
+  if (clause === undefined || ts.isNamespaceExport(clause)) return true;
+  return clause.elements.some((element) => !element.isTypeOnly);
+}
+
+function runtimeModuleSpecifiers(path: string): string[] {
+  const source = ts.createSourceFile(
+    path,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const specifiers: string[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      importCarriesRuntimeValue(node) &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    } else if (
+      ts.isExportDeclaration(node) &&
+      exportCarriesRuntimeValue(node) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0]!)
+    ) {
+      specifiers.push(node.arguments[0]!.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return specifiers;
+}
+
+function resolveRuntimeImport(from: string, specifier: string): string | undefined {
+  if (!specifier.startsWith(".")) return undefined;
+  const emittedPath = resolve(dirname(from), specifier);
+  const sourcePath = emittedPath.endsWith(".js")
+    ? emittedPath.slice(0, -3)
+    : emittedPath;
+  return [
+    `${sourcePath}.ts`,
+    `${sourcePath}.tsx`,
+    resolve(sourcePath, "index.ts"),
+    resolve(sourcePath, "index.tsx"),
+  ].find((candidate) => sourceFileSet.has(candidate));
+}
+
+function runtimeImports(path: string): string[] {
+  return runtimeModuleSpecifiers(path).flatMap((specifier) => {
+    const imported = resolveRuntimeImport(path, specifier);
+    return imported === undefined ? [] : [imported];
+  });
+}
+
+function findRuntimePath(start: string, target: string): string[] | undefined {
+  const pending: Array<{ path: string; trail: string[] }> = [
+    { path: start, trail: [start] },
+  ];
+  const visited = new Set<string>();
+
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (visited.has(current.path)) continue;
+    visited.add(current.path);
+
+    for (const imported of runtimeImports(current.path)) {
+      const trail = [...current.trail, imported];
+      if (imported === target) return trail;
+      if (!visited.has(imported)) pending.push({ path: imported, trail });
+    }
+  }
+  return undefined;
+}
+
+describe("message render policy import boundary", () => {
+  test("keeps the policy in a leaf shared by Messages and MessageRow", () => {
+    expect(runtimeImports(MESSAGES)).toContain(RENDER_POLICY);
+    expect(runtimeImports(MESSAGE_ROW)).toContain(RENDER_POLICY);
+    expect(runtimeModuleSpecifiers(RENDER_POLICY).sort()).toEqual([
+      "../../utils/messages.js",
+      "../../utils/set.js",
+    ]);
+  });
+
+  test("has no runtime path from MessageRow back to Messages", () => {
+    const path = findRuntimePath(MESSAGE_ROW, MESSAGES)?.map((entry) =>
+      relative(RUNTIME_SOURCE, entry),
+    );
+    expect(
+      path,
+      path === undefined
+        ? undefined
+        : `Runtime import path reintroduced: ${path.join(" -> ")}`,
+    ).toBeUndefined();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-121-components-MessageRow.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-121-components-MessageRow.test.tsx
@@ -83,7 +83,7 @@ vi.mock("../../../src/tui/components/Message.js", async () => {
   };
 });
 
-vi.mock("../../../src/tui/components/Messages.js", () => ({
+vi.mock("../../../src/tui/components/messageRenderPolicy.js", () => ({
   shouldRenderStatically: (message: { uuid: string }) =>
     harness.staticMessages.has(message.uuid),
 }));


### PR DESCRIPTION
## Summary

- Move the static message render policy into a small leaf module shared by `Messages` and `MessageRow`.
- Keep the existing `Messages` export while removing the runtime import from `MessageRow` back to `Messages`.
- Update MessageRow test mocks to target the policy module.
- Add a narrow runtime import graph test that rejects any path from `MessageRow` back to `Messages` and ignores type-only edges.

## Validation

- Focused policy, Messages, MessageRow, and import boundary tests: 36 passed.
- `npm run typecheck`: passed.
- Runtime build: passed.
- TUI runtime startup smoke: passed.
- Full test suite: 21,138 passed and the same three failures seen on `main` remained:
  - fuzzy benchmark refuses dirty tracked files in production tree
  - current production module closure for csv_scheduler_progress_scan is stale
  - session transcript streaming identity expected two block IDs and received one

Closes #1807

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving module split with import-boundary tests; no changes to rendering rules themselves.
> 
> **Overview**
> Breaks the **Messages ↔ MessageRow** import cycle by moving **`shouldRenderStatically`** into a new leaf module **`messageRenderPolicy.ts`**. Both components import the policy from there; **`Messages` still re-exports** `shouldRenderStatically` so existing callers keep the same public API.
> 
> **`MessageRow`** no longer imports **`Messages`** (it previously pulled in the whole list component just for static-vs-dynamic rendering). Policy logic is unchanged—only module placement.
> 
> Tests now mock **`messageRenderPolicy.js`** instead of **`Messages.js`**, and **`message-render-policy-import-boundary.test.ts`** asserts the policy is shared by both parents, stays a thin leaf (only `messages` + `set` utils), and that no runtime import path runs from **`MessageRow`** back to **`Messages`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc43d9bfc86bd7c7c1e0e8e24cbddc46973a6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->