### PR TITLE
test(runtime): cover IPv6 zone-ID SSRF regression

### DIFF
--- a/runtime/tests/utils/ssrf-guard.test.ts
+++ b/runtime/tests/utils/ssrf-guard.test.ts
@@ -32,6 +32,11 @@ describe("expandIPv6Groups", () => {
     expect(expandIPv6Groups("::ffff:01.2.3.4")).toBeNull();
     expect(expandIPv6Groups("::ffff:999.2.3.4")).toBeNull();
   });
+
+  it("rejects malformed zone IDs on mapped private addresses", () => {
+    expect(expandIPv6Groups("::ffff:169.254.169.254%")).toBeNull();
+    expect(expandIPv6Groups("::ffff:10.0.0.1%eth0%extra")).toBeNull();
+  });
 });
 
 describe("isBlockedAddress", () => {
@@ -51,8 +56,21 @@ describe("isBlockedAddress", () => {
     }
   });
 
+  it("blocks scoped mapped private and link-local addresses", () => {
+    for (const address of [
+      "::ffff:169.254.169.254%eth0",
+      "::ffff:10.0.0.1%eth0",
+      "::ffff:172.16.0.1%7",
+      "::ffff:192.168.0.1%en0",
+    ]) {
+      expect(isBlockedAddress(address), address).toBe(true);
+    }
+  });
+
   it("keeps public mapped addresses and scoped loopback allowed", () => {
     expect(isBlockedAddress("::ffff:8.8.8.8")).toBe(false);
     expect(isBlockedAddress("::1%lo0")).toBe(false);
+    expect(isBlockedAddress("0:0:0:0:0:0:0:1%lo0")).toBe(false);
+    expect(isBlockedAddress("::ffff:127.0.0.1%lo0")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add direct regression coverage for scoped IPv4-mapped IPv6 link-local and private addresses, including `::ffff:169.254.169.254%eth0`.
- Reject empty and repeated zone markers at the IPv6 expansion boundary.
- Preserve the intentional scoped native and mapped loopback policy.
- Leave production logic untouched because current main already strips a valid zone ID before parsing the dotted-decimal tail.

Closes #1835

## Validation

Environment: Node v26.5.0 and npm 11.17.0 with a worktree-local, non-symlinked `node_modules`.

- PASS: `npm exec -- vitest run runtime/tests/utils/ssrf-guard.test.ts runtime/tests/browser/ssrf.test.ts runtime/tests/browser/proxy.test.ts runtime/tests/gateway/cron-delivery.test.ts` — 4 files, 48 tests.
- PASS: `npm run typecheck`.
- PARTIAL: `npm test` — required gates 158/158, agent-surface contract 22/22, launcher 191/191, and runtime 21,177 passed / 2 failed across 2,155 files. The changed SSRF guard file passed 7/7. Unrelated baseline failures:
  - `tests/fnd/benchmark-baselines.contract.test.ts`: stale `csv_scheduler_progress_scan` production module closure.
  - `tests/tui/session-transcript.streaming-identity.test.ts`: expected `id:err:1`, received only `id:err:0`.
- PRE-EXISTING FOCUSED FAILURE: `runtime/tests/gateway/cron-webhook-ssrf.test.ts` cannot load because it imports `../gateway/cron-delivery.js`, which does not resolve from the test directory; 0 tests collected.
- GitNexus `detect_changes` against `main`: LOW risk, 1 changed file, 0 indexed symbols, 0 affected processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to SSRF guard behavior assertions; no runtime logic modified.
> 
> **Overview**
> Adds **test-only** regression coverage for IPv6 literals with **zone IDs** (`%interface`) in the SSRF guard utilities—no production changes in this diff.
> 
> New cases assert **`expandIPv6Groups`** returns null for **malformed zone markers** on IPv4-mapped private tails (empty `%` and duplicated `%` segments). **`isBlockedAddress`** is exercised for **scoped mapped** link-local/private targets (e.g. `::ffff:169.254.169.254%eth0`, RFC1918-style `::ffff:10.0.0.1%eth0`). The allowlist test also pins that **scoped loopback** stays permitted, including expanded `::1` and mapped `127.0.0.1` forms with `%lo0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1977a753d2921e5bc31d5c20bdf3e6cef1c7b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->