### PR TITLE
feat(runtime): add SDK transcript generator write mode

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -133,10 +133,12 @@ not change their public shapes independently:
 
 - `packages/agenc-sdk/src/transcript-v2.generated.ts` mirrors the daemon
   `SessionTranscriptV2*` result interfaces and is re-exported from `protocol.ts`.
-  Verify its exact content with
+  Refresh it with
+  `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write`,
+  then verify its exact content with
   `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types`. See
   [Transcript v2 generated mirror](#transcript-v2-generated-mirror) for the
-  manual refresh steps.
+  refresh rules.
 - `packages/agenc-sdk/src/workflow-result.generated.ts` mirrors workflow result
   contracts whose source schemas live under `runtime/src/agents/`. The same
   generated-type command checks selected version and outcome markers. See
@@ -521,21 +523,19 @@ interfaces, which must `extend JsonObject`:
 - `SessionTranscriptV2Result`
 
 It rewrites the heritage to a local `TranscriptV2JsonObject` so the SDK
-stays zero-dependency, then compares against
-`packages/agenc-sdk/src/transcript-v2.generated.ts`. The checker does **not**
-write the file. The current refresh is a synchronized manual replacement from
-the runtime authority. The generated header's `Do not edit` instruction means
-that its public shapes must not change independently of that authority.
+stays zero-dependency. The default command compares the rendered text against
+`packages/agenc-sdk/src/transcript-v2.generated.ts` without writing. The
+explicit `--write` mode uses the same renderer and atomically replaces only
+that generated file with LF line endings.
 
 Refresh after a protocol edit:
 
 1. Keep those four interfaces `extends JsonObject`. Any other heritage fails
    the check.
-2. Manually replace the committed generated module from the updated runtime
-   declaration text. Keep the three-line `@generated` header and the local
-   `TranscriptV2Json*` aliases; copy the four declarations in that order,
-   changing `extends JsonObject` to `extends TranscriptV2JsonObject`. Preserve
-   property order, member comments, optionality, and unions.
+2. Run
+   `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write`.
+   The command renders the complete module, including the generated header,
+   local aliases, and the four declarations in their fixed order.
 3. Run `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types`.
 4. `runtime/tests/sdk-package/transcript-v2.contract.test.ts` also compares
    property names/types of `SessionTranscriptV2TurnResult` and
@@ -544,9 +544,11 @@ Refresh after a protocol edit:
 
 Constraints:
 
-- Comparison is exact after a single `CRLF` / bare `CR` to `LF` pass on both
-  the runtime authority and the committed file. Windows checkouts must pass
-  the same content. Do not change line endings solely to satisfy the check.
+- Check mode compares content after one `CRLF` or bare `CR` to `LF` pass on
+  both the runtime authority and the committed file. Check mode never writes.
+- Write mode normalizes the runtime authority before rendering and writes LF
+  bytes. Running write mode again produces the same bytes and reports that the
+  file is already current.
 - Changes to fields, optionality, unions, member comments, or ordering inside
   the extracted interface declarations fail until the generated file is
   refreshed. Leading interface JSDoc is outside the extracted declaration

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -96,7 +96,9 @@ node packages/agenc-sdk/examples/one-shot.mjs --transport subprocess "say hello"
 Protocol drift is pinned by `runtime/tests/sdk-package/protocol-drift.contract.test.ts`
 against the runtime's canonical method registry.
 `session.transcript.v2` result shapes are generated from the daemon protocol
-into `src/transcript-v2.generated.ts` and checked by
+into `src/transcript-v2.generated.ts`. Refresh the file with
+`npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write`,
+then check it with
 `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types`
 (see [`docs/sdk.md`](../../docs/sdk.md#transcript-v2-generated-mirror)).
 Workflow-result types in `src/workflow-result.generated.ts` are marker-checked

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { lstat, open, readFile, rename, unlink } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -42,6 +43,14 @@ function expectCondition(failures, condition, message) {
 
 function normalizeLineEndings(source) {
   return source.replace(/\r\n?/g, "\n");
+}
+
+export function parseSdkGeneratedTypesMode(args) {
+  if (args.length === 0) return "check";
+  if (args.length === 1 && args[0] === "--write") return "write";
+  throw new Error(
+    "usage: check-sdk-generated-types.mjs [--write]",
+  );
 }
 
 const transcriptV2InterfaceNames = [
@@ -105,22 +114,99 @@ function renderTranscriptV2Generated(runtimeProtocol) {
   ].join("\n")}`;
 }
 
+async function existingFileMode(filePath) {
+  try {
+    const metadata = await lstat(filePath);
+    return metadata.isFile() ? metadata.mode & 0o777 : 0o666;
+  } catch (error) {
+    if (error?.code === "ENOENT") return 0o666;
+    throw error;
+  }
+}
+
+async function writeFileAtomically(filePath, contents) {
+  const mode = await existingFileMode(filePath);
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  let handle;
+  try {
+    handle = await open(temporaryPath, "wx", mode);
+    await handle.writeFile(contents, { encoding: "utf8" });
+    await handle.chmod(mode);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    await unlink(temporaryPath).catch(() => {});
+    throw error;
+  }
+}
+
+export async function synchronizeTranscriptV2Generated({
+  runtimeProtocolPath,
+  generatedPath,
+  write = false,
+}) {
+  const runtimeProtocol = await readFile(runtimeProtocolPath, "utf8");
+  const expected = renderTranscriptV2Generated(runtimeProtocol);
+  let current;
+  try {
+    current = await readFile(generatedPath, "utf8");
+  } catch (error) {
+    if (!write || error?.code !== "ENOENT") throw error;
+  }
+
+  if (!write) {
+    return {
+      changed: false,
+      matches: normalizeLineEndings(current) === expected,
+      expected,
+    };
+  }
+
+  if (current === expected) {
+    return { changed: false, matches: true, expected };
+  }
+
+  await writeFileAtomically(generatedPath, expected);
+  return { changed: true, matches: true, expected };
+}
+
 async function main() {
+  const mode = parseSdkGeneratedTypesMode(process.argv.slice(2));
+  const transcriptV2Path = path.join(
+    runtimeRoot,
+    paths.packageTranscriptV2,
+  );
   const [
     schemas,
     coreTypes,
     generated,
-    runtimeProtocol,
-    packageTranscriptV2,
     packageWorkflowResult,
+    transcriptV2,
   ] = await Promise.all([
     readRuntimeFile(paths.schemas),
     readRuntimeFile(paths.coreTypes),
     readRuntimeFile(paths.generated),
-    readRuntimeFile(paths.runtimeProtocol),
-    readRuntimeFile(paths.packageTranscriptV2),
     readRuntimeFile(paths.packageWorkflowResult),
+    synchronizeTranscriptV2Generated({
+      runtimeProtocolPath: path.join(runtimeRoot, paths.runtimeProtocol),
+      generatedPath: transcriptV2Path,
+      write: mode === "write",
+    }),
   ]);
+  if (mode === "write") {
+    const displayPath = path
+      .relative(path.dirname(runtimeRoot), transcriptV2Path)
+      .split(path.sep)
+      .join("/");
+    process.stdout.write(
+      transcriptV2.changed
+        ? `[sdk generated types] wrote ${displayPath}\n`
+        : `[sdk generated types] ${displayPath} is already current\n`,
+    );
+  }
   const failures = [];
   const sources = [
     [paths.schemas, schemas],
@@ -252,10 +338,9 @@ async function main() {
     "committed SDK types reintroduced removed MCP surface McpSdkServerConfig",
   );
 
-  const expectedTranscriptV2 = renderTranscriptV2Generated(runtimeProtocol);
   expectCondition(
     failures,
-    normalizeLineEndings(packageTranscriptV2) === expectedTranscriptV2,
+    transcriptV2.matches,
     `${paths.packageTranscriptV2} is not the exact generated transcript.v2 mirror; regenerate it from ${paths.runtimeProtocol}`,
   );
 
@@ -270,4 +355,9 @@ async function main() {
   process.stdout.write("[sdk generated types] verified committed SDK types\n");
 }
 
-await main();
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main();
+}

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -117,21 +117,23 @@ function renderTranscriptV2Generated(runtimeProtocol) {
 async function existingFileMode(filePath) {
   try {
     const metadata = await lstat(filePath);
-    return metadata.isFile() ? metadata.mode & 0o777 : 0o666;
+    return metadata.isFile() ? metadata.mode & 0o777 : undefined;
   } catch (error) {
-    if (error?.code === "ENOENT") return 0o666;
+    if (error?.code === "ENOENT") return undefined;
     throw error;
   }
 }
 
 async function writeFileAtomically(filePath, contents) {
-  const mode = await existingFileMode(filePath);
+  const existingMode = await existingFileMode(filePath);
   const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
   let handle;
   try {
-    handle = await open(temporaryPath, "wx", mode);
+    handle = await open(temporaryPath, "wx", existingMode ?? 0o666);
     await handle.writeFile(contents, { encoding: "utf8" });
-    await handle.chmod(mode);
+    if (existingMode !== undefined) {
+      await handle.chmod(existingMode);
+    }
     await handle.sync();
     await handle.close();
     handle = undefined;

--- a/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
+++ b/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
@@ -1,4 +1,7 @@
+import { execFile } from "node:child_process";
 import {
+  chmod,
+  lstat,
   mkdtemp,
   readFile,
   readdir,
@@ -7,6 +10,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -15,6 +19,8 @@ import {
 } from "../../scripts/check-sdk-generated-types.mjs";
 
 const temporaryRoots: string[] = [];
+const execFileAsync = promisify(execFile);
+const repositoryRoot = join(import.meta.dirname, "../../..");
 
 afterEach(async () => {
   await Promise.all(
@@ -85,6 +91,24 @@ describe("SDK generated transcript v2 script", () => {
     expect(() => parseSdkGeneratedTypesMode(["--check"])).toThrow(/usage/);
     expect(() => parseSdkGeneratedTypesMode(["--write", "extra"])).toThrow(
       /usage/,
+    );
+  });
+
+  it("accepts the documented npm write entrypoint", async () => {
+    const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm";
+    const { stdout } = await execFileAsync(
+      npmExecutable,
+      [
+        "--workspace=@tetsuo-ai/runtime",
+        "run",
+        "check:sdk-generated-types",
+        "--",
+        "--write",
+      ],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    );
+    expect(stdout).toContain(
+      "packages/agenc-sdk/src/transcript-v2.generated.ts is already current",
     );
   });
 
@@ -209,6 +233,35 @@ describe("SDK generated transcript v2 script", () => {
     expect(canonicalized.changed).toBe(true);
     expect(await readFile(fixture.generatedPath, "utf8")).toBe(generated);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves existing permissions and respects the umask for a missing target",
+    async () => {
+      const fixture = await createFixture();
+      await chmod(fixture.generatedPath, 0o640);
+
+      await synchronizeTranscriptV2Generated({
+        runtimeProtocolPath: fixture.protocolPath,
+        generatedPath: fixture.generatedPath,
+        write: true,
+      });
+      expect((await lstat(fixture.generatedPath)).mode & 0o777).toBe(0o640);
+
+      await rm(fixture.generatedPath);
+      const previousUmask = process.umask(0o007);
+      try {
+        await synchronizeTranscriptV2Generated({
+          runtimeProtocolPath: fixture.protocolPath,
+          generatedPath: fixture.generatedPath,
+          write: true,
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect((await lstat(fixture.generatedPath)).mode & 0o777).toBe(0o660);
+    },
+  );
 
   it("rejects missing interfaces and invalid runtime heritage before writing", async () => {
     const missingResult = runtimeProtocol().replace(

--- a/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
+++ b/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -21,6 +21,42 @@ import {
 const temporaryRoots: string[] = [];
 const execFileAsync = promisify(execFile);
 const repositoryRoot = join(import.meta.dirname, "../../..");
+const npmWriteArgs = [
+  "--workspace=@tetsuo-ai/runtime",
+  "run",
+  "check:sdk-generated-types",
+  "--",
+  "--write",
+] as const;
+
+function npmWriteCommand({
+  nodeExecutable,
+  npmExecPath,
+  windows,
+}: {
+  readonly nodeExecutable: string;
+  readonly npmExecPath: string | undefined;
+  readonly windows: boolean;
+}): { readonly executable: string; readonly args: readonly string[] } {
+  const path = windows ? win32 : posix;
+  const nodeDirectory = path.dirname(nodeExecutable);
+  const npmCliPath =
+    npmExecPath?.trim() ||
+    (windows
+      ? path.join(nodeDirectory, "node_modules", "npm", "bin", "npm-cli.js")
+      : path.join(
+          path.dirname(nodeDirectory),
+          "lib",
+          "node_modules",
+          "npm",
+          "bin",
+          "npm-cli.js",
+        ));
+  return {
+    executable: nodeExecutable,
+    args: [npmCliPath, ...npmWriteArgs],
+  };
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -95,22 +131,51 @@ describe("SDK generated transcript v2 script", () => {
   });
 
   it("accepts the documented npm write entrypoint", async () => {
-    const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm";
+    const command = npmWriteCommand({
+      nodeExecutable: process.execPath,
+      npmExecPath: process.env.npm_execpath,
+      windows: process.platform === "win32",
+    });
+    expect(command.executable).toMatch(/node(?:\.exe)?$/i);
+    expect(command.executable).not.toMatch(/\.cmd$/i);
+    expect(command.args[0]).toMatch(/npm-cli\.js$/);
+
     const { stdout } = await execFileAsync(
-      npmExecutable,
-      [
-        "--workspace=@tetsuo-ai/runtime",
-        "run",
-        "check:sdk-generated-types",
-        "--",
-        "--write",
-      ],
+      command.executable,
+      [...command.args],
       { cwd: repositoryRoot, encoding: "utf8" },
     );
     expect(stdout).toContain(
       "packages/agenc-sdk/src/transcript-v2.generated.ts is already current",
     );
   });
+
+  it.each([
+    [
+      "POSIX",
+      "/opt/node/bin/node",
+      false,
+      "/opt/node/lib/node_modules/npm/bin/npm-cli.js",
+    ],
+    [
+      "Windows",
+      "C:\\Program Files\\nodejs\\node.exe",
+      true,
+      "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+    ],
+  ] as const)(
+    "uses the Node executable for the %s npm command",
+    (_label, nodeExecutable, windows, expectedNpmCliPath) => {
+      const command = npmWriteCommand({
+        nodeExecutable,
+        npmExecPath: undefined,
+        windows,
+      });
+
+      expect(command.executable).toBe(nodeExecutable);
+      expect(command.args).toEqual([expectedNpmCliPath, ...npmWriteArgs]);
+    },
+  );
 
   it("accepts LF and CRLF inputs without writing in check mode", async () => {
     const fixture = await createCanonicalFixture();

--- a/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
+++ b/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
@@ -1,0 +1,266 @@
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseSdkGeneratedTypesMode,
+  synchronizeTranscriptV2Generated,
+} from "../../scripts/check-sdk-generated-types.mjs";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+function runtimeProtocol(): string {
+  return `interface JsonObject {}
+
+/** Leading interface documentation is not mirrored. */
+export interface SessionTranscriptV2Message extends JsonObject {
+  /** Member documentation is mirrored. */
+  readonly id: string;
+  readonly text?: string;
+}
+
+export interface SessionTranscriptV2ActiveTurn extends JsonObject {
+  readonly turnId: string;
+}
+
+export interface SessionTranscriptV2TurnResult extends JsonObject {
+  readonly turnId: string;
+  readonly outcome: "completed" | "aborted";
+}
+
+export interface SessionTranscriptV2Result extends JsonObject {
+  readonly messages: readonly SessionTranscriptV2Message[];
+}
+`;
+}
+
+async function createFixture(
+  protocol = runtimeProtocol(),
+  generated = "stale generated output\n",
+): Promise<{
+  readonly root: string;
+  readonly protocolPath: string;
+  readonly generatedPath: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "agenc-sdk-generator-"));
+  temporaryRoots.push(root);
+  const protocolPath = join(root, "protocol.ts");
+  const generatedPath = join(root, "transcript-v2.generated.ts");
+  await Promise.all([
+    writeFile(protocolPath, protocol, "utf8"),
+    writeFile(generatedPath, generated, "utf8"),
+  ]);
+  return { root, protocolPath, generatedPath };
+}
+
+async function createCanonicalFixture() {
+  const fixture = await createFixture();
+  const result = await synchronizeTranscriptV2Generated({
+    runtimeProtocolPath: fixture.protocolPath,
+    generatedPath: fixture.generatedPath,
+    write: true,
+  });
+  return { ...fixture, expected: result.expected };
+}
+
+describe("SDK generated transcript v2 script", () => {
+  it("keeps check mode as the default and requires an explicit write flag", () => {
+    expect(parseSdkGeneratedTypesMode([])).toBe("check");
+    expect(parseSdkGeneratedTypesMode(["--write"])).toBe("write");
+    expect(() => parseSdkGeneratedTypesMode(["--check"])).toThrow(/usage/);
+    expect(() => parseSdkGeneratedTypesMode(["--write", "extra"])).toThrow(
+      /usage/,
+    );
+  });
+
+  it("accepts LF and CRLF inputs without writing in check mode", async () => {
+    const fixture = await createCanonicalFixture();
+    const crlfProtocol = runtimeProtocol().replace(/\n/g, "\r\n");
+    const crlfGenerated = fixture.expected.replace(/\n/g, "\r\n");
+    await Promise.all([
+      writeFile(fixture.protocolPath, crlfProtocol, "utf8"),
+      writeFile(fixture.generatedPath, crlfGenerated, "utf8"),
+    ]);
+
+    const result = await synchronizeTranscriptV2Generated({
+      runtimeProtocolPath: fixture.protocolPath,
+      generatedPath: fixture.generatedPath,
+    });
+
+    expect(result).toMatchObject({ changed: false, matches: true });
+    expect(await readFile(fixture.generatedPath, "utf8")).toBe(crlfGenerated);
+  });
+
+  it("leaves stale output untouched and rejects every exact-mirror drift", async () => {
+    const fixture = await createCanonicalFixture();
+    const propertyBlock = `  /** Member documentation is mirrored. */
+  readonly id: string;
+  readonly text?: string;`;
+    const drifts = [
+      [
+        "header",
+        fixture.expected.replace("// @generated", "// stale generated"),
+      ],
+      [
+        "alias",
+        fixture.expected.replace(
+          "type TranscriptV2JsonPrimitive",
+          "type StaleJsonPrimitive",
+        ),
+      ],
+      [
+        "heritage",
+        fixture.expected.replace(
+          "extends TranscriptV2JsonObject",
+          "extends OtherJsonObject",
+        ),
+      ],
+      [
+        "field",
+        fixture.expected.replace("readonly id: string", "readonly key: string"),
+      ],
+      [
+        "type",
+        fixture.expected.replace("readonly id: string", "readonly id: number"),
+      ],
+      [
+        "order",
+        fixture.expected.replace(
+          propertyBlock,
+          `  readonly text?: string;
+  /** Member documentation is mirrored. */
+  readonly id: string;`,
+        ),
+      ],
+      [
+        "member comment",
+        fixture.expected.replace(
+          "Member documentation is mirrored.",
+          "Changed member documentation.",
+        ),
+      ],
+    ] as const;
+
+    for (const [label, stale] of drifts) {
+      expect(stale, label).not.toBe(fixture.expected);
+      await writeFile(fixture.generatedPath, stale, "utf8");
+      const result = await synchronizeTranscriptV2Generated({
+        runtimeProtocolPath: fixture.protocolPath,
+        generatedPath: fixture.generatedPath,
+      });
+      expect(result.matches, label).toBe(false);
+      expect(await readFile(fixture.generatedPath, "utf8"), label).toBe(stale);
+    }
+  });
+
+  it("atomically writes canonical LF output and is idempotent", async () => {
+    const protocol = runtimeProtocol().replace(/\n/g, "\r\n");
+    const fixture = await createFixture(protocol, "stale\r\noutput\r\n");
+    const protocolBefore = await readFile(fixture.protocolPath, "utf8");
+
+    const first = await synchronizeTranscriptV2Generated({
+      runtimeProtocolPath: fixture.protocolPath,
+      generatedPath: fixture.generatedPath,
+      write: true,
+    });
+    const generated = await readFile(fixture.generatedPath, "utf8");
+    expect(first).toMatchObject({ changed: true, matches: true });
+    expect(generated).toBe(first.expected);
+    expect(generated).not.toContain("\r");
+    expect(await readFile(fixture.protocolPath, "utf8")).toBe(protocolBefore);
+    expect((await readdir(fixture.root)).sort()).toEqual([
+      "protocol.ts",
+      "transcript-v2.generated.ts",
+    ]);
+
+    const second = await synchronizeTranscriptV2Generated({
+      runtimeProtocolPath: fixture.protocolPath,
+      generatedPath: fixture.generatedPath,
+      write: true,
+    });
+    expect(second).toMatchObject({ changed: false, matches: true });
+    expect(await readFile(fixture.generatedPath, "utf8")).toBe(generated);
+
+    await writeFile(
+      fixture.generatedPath,
+      generated.replace(/\n/g, "\r\n"),
+      "utf8",
+    );
+    const canonicalized = await synchronizeTranscriptV2Generated({
+      runtimeProtocolPath: fixture.protocolPath,
+      generatedPath: fixture.generatedPath,
+      write: true,
+    });
+    expect(canonicalized.changed).toBe(true);
+    expect(await readFile(fixture.generatedPath, "utf8")).toBe(generated);
+  });
+
+  it("rejects missing interfaces and invalid runtime heritage before writing", async () => {
+    const missingResult = runtimeProtocol().replace(
+      `
+
+export interface SessionTranscriptV2Result extends JsonObject {
+  readonly messages: readonly SessionTranscriptV2Message[];
+}`,
+      "",
+    );
+    const invalidHeritage = runtimeProtocol().replace(
+      "SessionTranscriptV2Message extends JsonObject",
+      "SessionTranscriptV2Message extends Record<string, unknown>",
+    );
+
+    for (const [protocol, message] of [
+      [missingResult, /missing runtime interface SessionTranscriptV2Result/],
+      [
+        invalidHeritage,
+        /SessionTranscriptV2Message must extend JsonObject/,
+      ],
+    ] as const) {
+      const fixture = await createFixture(protocol);
+      await expect(
+        synchronizeTranscriptV2Generated({
+          runtimeProtocolPath: fixture.protocolPath,
+          generatedPath: fixture.generatedPath,
+          write: true,
+        }),
+      ).rejects.toThrow(message);
+      expect(await readFile(fixture.generatedPath, "utf8")).toBe(
+        "stale generated output\n",
+      );
+    }
+  });
+
+  it("mirrors member comments but deliberately excludes leading JSDoc", async () => {
+    const fixture = await createCanonicalFixture();
+    expect(fixture.expected).toContain("Member documentation is mirrored.");
+    expect(fixture.expected).not.toContain(
+      "Leading interface documentation is not mirrored.",
+    );
+
+    const changedLeadingJsdoc = runtimeProtocol().replace(
+      "Leading interface documentation is not mirrored.",
+      "Changed leading interface documentation is still not mirrored.",
+    );
+    await writeFile(fixture.protocolPath, changedLeadingJsdoc, "utf8");
+    const result = await synchronizeTranscriptV2Generated({
+      runtimeProtocolPath: fixture.protocolPath,
+      generatedPath: fixture.generatedPath,
+    });
+    expect(result).toMatchObject({ changed: false, matches: true });
+  });
+});


### PR DESCRIPTION
## Summary

- add an explicit `--write` mode to the SDK generated-types checker while keeping the default mode read-only
- replace only the transcript-v2 generated module through a same-directory atomic rename with canonical LF output
- preserve an existing regular file's mode while allowing a new file to keep its process-umask-adjusted creation mode
- cover stale output, LF and CRLF inputs, idempotence, invalid source declarations, permissions, atomic cleanup, and the documented npm write command
- run the npm write test through the Node executable and npm CLI JavaScript path, with pure POSIX and Windows command-path cases
- document the supported refresh and verification commands

## Validation

All commands ran with Node 26.5.0 and npm 11.17.0.

- `npm exec -- vitest run runtime/tests/sdk-package/sdk-generated-types-script.test.ts runtime/tests/sdk-package/transcript-v2.contract.test.ts runtime/tests/meta/license-and-version.test.ts --maxWorkers=1`: 3 files passed, 29 tests passed
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/sdk-package/sdk-generated-types-script.test.ts`: 1 file passed, 10 tests passed in the hermetic runner
- `npm run build --workspace=@tetsuo-ai/agenc-sdk`: passed
- `npm run typecheck --workspace=@tetsuo-ai/agenc-sdk`: passed
- `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types`: passed
- `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write`: passed and reported the transcript module already current
- `npm run typecheck`: passed
- `git diff --check`: passed
- GitNexus `detect_changes` against `main`: low risk, 4 changed files, 9 indexed symbols, 0 affected execution processes
- `npm test`: required gates 158/158 passed, agent-surface contract 22/22 passed, launcher 191/191 passed; runtime finished with 2,154 files and 21,183 tests passing, plus the two current-main baseline failures below. The latest commit changes only the test file, so this full-suite result remains current for production behavior.
  - `tests/fnd/benchmark-baselines.contract.test.ts`: stale `csv_scheduler_progress_scan` production module closure
  - `tests/tui/session-transcript.streaming-identity.test.ts`: expected `id:err:0` and `id:err:1`, received only `id:err:0`

Closes #1940
