### PR TITLE
fix(runtime): bound reusable-agent summary transcripts

### DIFF
--- a/runtime/src/agents/thread.ts
+++ b/runtime/src/agents/thread.ts
@@ -29,7 +29,10 @@ import {
 } from "./delegate.js";
 import type { RunAgentProgressEvent, RunAgentResult } from "./run-agent.js";
 import type { AgentPath } from "./registry.js";
-import { runAgentProgressEventToAgentSummaryMessage } from "../services/AgentSummary/transcript.js";
+import {
+  AgentSummaryTranscript,
+  type AgentSummaryTranscriptLimitOverrides,
+} from "../services/AgentSummary/transcript-retention.js";
 import { validateAgentInvocationMessageSequence } from "../contracts/agent-invocation-envelope.js";
 
 export type MemoryEntry = AgentMemoryEntry;
@@ -41,6 +44,7 @@ export interface AgentThreadOpts {
   readonly worktree?: WorktreeHandle;
   readonly parentSessionId?: string;
   readonly taskPrompt: string;
+  readonly summaryTranscriptLimits?: AgentSummaryTranscriptLimitOverrides;
 }
 
 /**
@@ -101,7 +105,7 @@ export class AgentThread {
   private readonly summaryCacheSafeParamListeners = new Set<
     (params: CacheSafeParams) => void
   >();
-  private readonly summaryTranscriptMessages: Message[] = [];
+  private readonly summaryTranscript: AgentSummaryTranscript;
   private unsubscribeLiveStatus: (() => void) | null = null;
   private parentPathForChildren: AgentPath;
   private summaryCacheSafeParamsValue: CacheSafeParams | null = null;
@@ -117,6 +121,10 @@ export class AgentThread {
     this.taskPrompt = opts.taskPrompt;
     this.createdAtMs = Date.now();
     this.wiring = wiring;
+    this.summaryTranscript = new AgentSummaryTranscript(
+      opts.initialMessages,
+      opts.summaryTranscriptLimits,
+    );
     this.parentPathForChildren =
       (wiring.parentPath as AgentPath | undefined) ??
       (opts.live.agentPath as AgentPath);
@@ -156,7 +164,11 @@ export class AgentThread {
   }
 
   get summaryMessages(): ReadonlyArray<Message> {
-    return this.summaryTranscriptMessages;
+    return this.summaryTranscript.messages;
+  }
+
+  get summaryRevision(): number {
+    return this.summaryTranscript.revision;
   }
 
   get summaryCacheSafeParams(): CacheSafeParams | undefined {
@@ -184,22 +196,12 @@ export class AgentThread {
 
   /**
    * Record a progress event into this thread's agent-summary
-   * transcript. Initial-replay messages (kind="message" with
-   * isInitialReplay=true) ARE intentionally captured here — the
-   * summary needs the full fork-context history for downstream
-   * consumers to reconstruct what the agent saw at start. Do NOT add
-   * an isInitialReplay filter here; that filter belongs in the
-   * parent-TUI transport (background-agent-runner.ts), not the
-   * summary recorder.
+   * transcript. Immutable fork context is captured once by the transcript
+   * constructor, so replay events are ignored instead of duplicating it on
+   * every reusable-agent turn.
    */
   recordSummaryProgressEvent(event: RunAgentProgressEvent): void {
-    const message = runAgentProgressEventToAgentSummaryMessage(
-      event,
-      this.summaryTranscriptMessages.length,
-    );
-    if (message !== null) {
-      this.summaryTranscriptMessages.push(message);
-    }
+    this.summaryTranscript.record(event);
   }
 
   /** Resume metadata mirror from the current live handle. */

--- a/runtime/src/services/AgentSummary/agentSummary.ts
+++ b/runtime/src/services/AgentSummary/agentSummary.ts
@@ -51,6 +51,8 @@ export function toSummaryCacheSafeParams(
 
 export interface AgentTranscript {
   readonly messages: readonly Message[];
+  /** Monotonic activity revision for bounded rolling transcripts. */
+  readonly revision?: number;
 }
 
 export interface AgentSummaryHandle {
@@ -223,10 +225,9 @@ export function startAgentSummarization(
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
   let previousSummary: string | null = null;
-  // Message count at the last successful summary. Lets the periodic sweep skip
-  // a redundant LLM call when nothing new was produced since — the common case
-  // for a keep-alive worker sitting idle between turns, where re-summarizing
-  // the same transcript just burns tokens and an admission slot.
+  let lastSummarizedRevision: number | null = null;
+  // Fallback for transcript providers that do not expose a revision. Lets the
+  // periodic sweep skip a redundant LLM call while a keep-alive worker is idle.
   let lastSummarizedMessageCount = 0;
 
   function scheduleNext(): void {
@@ -250,10 +251,21 @@ export function startAgentSummarization(
         );
         return;
       }
-      // No new messages since the last summary — nothing to condense. This is
-      // what stops an idle keep-alive worker from re-forking its whole
-      // transcript into an LLM call every interval.
-      if (transcript.messages.length <= lastSummarizedMessageCount) {
+      const revision = transcript.revision;
+      const transcriptRevision =
+        typeof revision === "number" &&
+        Number.isSafeInteger(revision) &&
+        revision >= 0
+          ? revision
+          : null;
+      // Bounded transcripts eventually keep a stable message count, so prefer
+      // their monotonic revision. Callers without one retain the historical
+      // message-count behavior.
+      const hasNewActivity = transcriptRevision !== null
+        ? lastSummarizedRevision === null ||
+          transcriptRevision > lastSummarizedRevision
+        : transcript.messages.length > lastSummarizedMessageCount;
+      if (!hasNewActivity) {
         options.logDebug?.(
           `Skipping agent summary for ${options.taskId}: no new messages since last summary`,
         );
@@ -284,6 +296,7 @@ export function startAgentSummarization(
       if (!summaryText) return;
       previousSummary = summaryText;
       lastSummarizedMessageCount = transcript.messages.length;
+      lastSummarizedRevision = transcriptRevision;
       options.updateAgentSummary(options.taskId, summaryText);
     } catch (error) {
       if (!stopped) options.logError?.(error);

--- a/runtime/src/services/AgentSummary/transcript-retention.ts
+++ b/runtime/src/services/AgentSummary/transcript-retention.ts
@@ -11,7 +11,7 @@ export interface AgentSummaryTranscriptLimits {
   readonly maxBytes: number;
   /** Maximum retained rolling messages, including the omission marker. */
   readonly maxMessages: number;
-  /** Maximum UTF-8 bytes retained inline for one raw tool result. */
+  /** Maximum UTF-8 bytes retained for one final AgentSummary tool result. */
   readonly maxToolResultBytes: number;
 }
 
@@ -28,6 +28,19 @@ const MIN_TRANSCRIPT_BYTES = 512;
 const MIN_TRANSCRIPT_MESSAGES = 3;
 const MIN_TOOL_RESULT_BYTES = 128;
 const EPOCH_TIMESTAMP = new Date(0).toISOString();
+const TOOL_RESULT_SAFETY_FRAME_OMISSION =
+  "[tool result omitted: safety frame exceeds configured UTF-8 limit]";
+
+type ToolResultProgressEvent = Extract<
+  RunAgentProgressEvent,
+  { readonly kind: "tool_result" }
+>;
+
+type BoundedRawToolResult = {
+  readonly originalBytes: number;
+  readonly prefix: string;
+  readonly reference: string | null;
+};
 
 type ToolMessageIds = {
   readonly uses: ReadonlySet<string>;
@@ -173,24 +186,41 @@ function durableToolResultReference(text: string): string | null {
   );
 }
 
-function clampRawToolResult(text: string, maxBytes: number): string {
-  const originalBytes = Buffer.byteLength(text, "utf8");
-  if (originalBytes <= maxBytes) return text;
+function composeRawToolResult(
+  bounded: BoundedRawToolResult,
+  maxBytes: number,
+): string {
+  if (bounded.originalBytes <= maxBytes) return bounded.prefix;
   const rawMarker =
-    `\n[tool result truncated; original UTF-8 size: ${originalBytes} bytes]`;
+    `\n[tool result truncated; original UTF-8 size: ${bounded.originalBytes} bytes]`;
   const marker = utf8Prefix(rawMarker, maxBytes);
   const markerBytes = Buffer.byteLength(marker, "utf8");
-  const reference = durableToolResultReference(text);
   const referenceBudget = Math.max(0, maxBytes - markerBytes - 1);
-  const boundedReference =
-    reference === null ? "" : utf8Suffix(reference, referenceBudget);
+  const boundedReference = bounded.reference === null
+    ? ""
+    : utf8Suffix(bounded.reference, referenceBudget);
   const separator = boundedReference.length === 0 ? "" : "\n";
   const reservedBytes =
     markerBytes +
     Buffer.byteLength(separator, "utf8") +
     Buffer.byteLength(boundedReference, "utf8");
-  const prefix = utf8Prefix(text, Math.max(0, maxBytes - reservedBytes));
+  const prefix = utf8Prefix(
+    bounded.prefix,
+    Math.max(0, maxBytes - reservedBytes),
+  );
   return `${prefix}${marker}${separator}${boundedReference}`;
+}
+
+function boundRawToolResult(
+  text: string,
+  maxBytes: number,
+): BoundedRawToolResult {
+  const originalBytes = Buffer.byteLength(text, "utf8");
+  return {
+    originalBytes,
+    prefix: utf8Prefix(text, maxBytes),
+    reference: durableToolResultReference(text),
+  };
 }
 
 function oldestLinkedMessageIndexes(
@@ -213,13 +243,114 @@ function oldestLinkedMessageIndexes(
   return indexes;
 }
 
-function boundedProgressEvent(
+function convertedToolResultMessage(
+  event: ToolResultProgressEvent,
+  result: string,
+  index: number,
+): Message {
+  const message = runAgentProgressEventToAgentSummaryMessage(
+    result === event.result ? event : { ...event, result },
+    index,
+  );
+  if (message === null) {
+    throw new Error("AgentSummary tool result conversion returned no message");
+  }
+  return message;
+}
+
+function toolResultText(message: Message): string {
+  for (const block of messageContent(message)) {
+    if (typeof block !== "object" || block === null) continue;
+    const record = block as {
+      readonly type?: unknown;
+      readonly content?: unknown;
+    };
+    if (record.type !== "tool_result") continue;
+    if (typeof record.content === "string") return record.content;
+    if (!Array.isArray(record.content)) continue;
+    return record.content
+      .map((part) => {
+        if (typeof part !== "object" || part === null) return "";
+        const text = (part as { readonly text?: unknown }).text;
+        return typeof text === "string" ? text : "";
+      })
+      .join("\n");
+  }
+  throw new Error("AgentSummary tool result conversion lost its text content");
+}
+
+function toolResultTextBytes(message: Message): number {
+  return Buffer.byteLength(toolResultText(message), "utf8");
+}
+
+function replaceToolResultText(message: Message, text: string): Message {
+  const envelope = (message as {
+    readonly message: {
+      readonly content: ReadonlyArray<unknown>;
+    };
+  }).message;
+  return {
+    ...message,
+    message: {
+      ...envelope,
+      content: envelope.content.map((block) => {
+        if (typeof block !== "object" || block === null) return block;
+        const record = block as { readonly type?: unknown };
+        return record.type === "tool_result"
+          ? { ...record, content: [{ type: "text", text }] }
+          : block;
+      }),
+    },
+  } as Message;
+}
+
+function boundedToolResultMessage(
+  event: ToolResultProgressEvent,
+  index: number,
+  maxBytes: number,
+): Message {
+  const bounded = boundRawToolResult(event.result, maxBytes);
+  const rawResult = composeRawToolResult(bounded, maxBytes);
+  const initial = convertedToolResultMessage(event, rawResult, index);
+  if (toolResultTextBytes(initial) <= maxBytes) return initial;
+
+  const empty = convertedToolResultMessage(event, "", index);
+  if (toolResultTextBytes(empty) > maxBytes) {
+    return replaceToolResultText(
+      initial,
+      utf8Prefix(TOOL_RESULT_SAFETY_FRAME_OMISSION, maxBytes),
+    );
+  }
+
+  let best = empty;
+  let low = 1;
+  let high = maxBytes;
+  while (low <= high) {
+    const candidateBudget = low + Math.floor((high - low) / 2);
+    const candidateResult = composeRawToolResult(bounded, candidateBudget);
+    const candidate = convertedToolResultMessage(
+      event,
+      candidateResult,
+      index,
+    );
+    if (toolResultTextBytes(candidate) <= maxBytes) {
+      best = candidate;
+      low = candidateBudget + 1;
+    } else {
+      high = candidateBudget - 1;
+    }
+  }
+  return best;
+}
+
+function boundedProgressMessage(
   event: RunAgentProgressEvent,
+  index: number,
   maxToolResultBytes: number,
-): RunAgentProgressEvent {
-  if (event.kind !== "tool_result") return event;
-  const result = clampRawToolResult(event.result, maxToolResultBytes);
-  return result === event.result ? event : { ...event, result };
+): Message | null {
+  return event.kind === "tool_result"
+    ? boundedToolResultMessage(event, index, maxToolResultBytes)
+    : runAgentProgressEventToAgentSummaryMessage(event, index);
 }
 
 function omissionMarker(
@@ -287,9 +418,10 @@ export class AgentSummaryTranscript {
 
   record(event: RunAgentProgressEvent): void {
     if (event.kind === "message" && event.isInitialReplay === true) return;
-    const message = runAgentProgressEventToAgentSummaryMessage(
-      boundedProgressEvent(event, this.limits.maxToolResultBytes),
+    const message = boundedProgressMessage(
+      event,
       this.nextMessageIndex,
+      this.limits.maxToolResultBytes,
     );
     if (message === null) return;
     this.nextMessageIndex += 1;

--- a/runtime/src/services/AgentSummary/transcript-retention.ts
+++ b/runtime/src/services/AgentSummary/transcript-retention.ts
@@ -5,6 +5,7 @@ import {
   llmMessageToAgentSummaryMessage,
   runAgentProgressEventToAgentSummaryMessage,
 } from "./transcript.js";
+import { WEB_FETCH_TOOL_NAME } from "../../tools/WebFetchTool/prompt.js";
 
 export interface AgentSummaryTranscriptLimits {
   /** Maximum JSON-serialized UTF-8 bytes retained for rolling activity. */
@@ -41,6 +42,8 @@ type BoundedRawToolResult = {
   readonly prefix: string;
   readonly reference: string | null;
 };
+
+type ToolResultMessageFactory = (result: string) => Message;
 
 type ToolMessageIds = {
   readonly uses: ReadonlySet<string>;
@@ -178,11 +181,16 @@ function webFetchOutputReference(text: string): string | null {
   );
 }
 
-function durableToolResultReference(text: string): string | null {
+function durableToolResultReference(
+  text: string,
+  producingToolName: string,
+): string | null {
   return (
     persistedOutputReference(text) ??
     offloadedOutputReference(text) ??
-    webFetchOutputReference(text)
+    (producingToolName === WEB_FETCH_TOOL_NAME
+      ? webFetchOutputReference(text)
+      : null)
   );
 }
 
@@ -213,13 +221,14 @@ function composeRawToolResult(
 
 function boundRawToolResult(
   text: string,
+  producingToolName: string,
   maxBytes: number,
 ): BoundedRawToolResult {
   const originalBytes = Buffer.byteLength(text, "utf8");
   return {
     originalBytes,
     prefix: utf8Prefix(text, maxBytes),
-    reference: durableToolResultReference(text),
+    reference: durableToolResultReference(text, producingToolName),
   };
 }
 
@@ -305,16 +314,21 @@ function replaceToolResultText(message: Message, text: string): Message {
 }
 
 function boundedToolResultMessage(
-  event: ToolResultProgressEvent,
-  index: number,
+  sourceResult: string,
+  producingToolName: string,
   maxBytes: number,
+  createMessage: ToolResultMessageFactory,
 ): Message {
-  const bounded = boundRawToolResult(event.result, maxBytes);
-  const rawResult = composeRawToolResult(bounded, maxBytes);
-  const initial = convertedToolResultMessage(event, rawResult, index);
+  const bounded = boundRawToolResult(
+    sourceResult,
+    producingToolName,
+    maxBytes,
+  );
+  const boundedResult = composeRawToolResult(bounded, maxBytes);
+  const initial = createMessage(boundedResult);
   if (toolResultTextBytes(initial) <= maxBytes) return initial;
 
-  const empty = convertedToolResultMessage(event, "", index);
+  const empty = createMessage("");
   if (toolResultTextBytes(empty) > maxBytes) {
     return replaceToolResultText(
       initial,
@@ -328,11 +342,7 @@ function boundedToolResultMessage(
   while (low <= high) {
     const candidateBudget = low + Math.floor((high - low) / 2);
     const candidateResult = composeRawToolResult(bounded, candidateBudget);
-    const candidate = convertedToolResultMessage(
-      event,
-      candidateResult,
-      index,
-    );
+    const candidate = createMessage(candidateResult);
     if (toolResultTextBytes(candidate) <= maxBytes) {
       best = candidate;
       low = candidateBudget + 1;
@@ -343,13 +353,61 @@ function boundedToolResultMessage(
   return best;
 }
 
+function initialToolResultText(message: LLMMessage): string {
+  return typeof message.content === "string"
+    ? message.content
+    : message.content
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n");
+}
+
+function boundedInitialMessage(
+  message: LLMMessage,
+  index: number,
+  maxToolResultBytes: number,
+  toolNamesByCallId: ReadonlyMap<string, string>,
+): Message {
+  if (message.role !== "tool" || !message.toolCallId) {
+    return llmMessageToAgentSummaryMessage(message, index);
+  }
+  const recordedToolName = message.toolName?.trim();
+  const producingToolName =
+    toolNamesByCallId.get(message.toolCallId) ??
+    (recordedToolName && recordedToolName.length > 0
+      ? recordedToolName
+      : "unknown_tool");
+  const normalizedMessage =
+    message.toolName === producingToolName
+      ? message
+      : { ...message, toolName: producingToolName };
+  const rawResult = initialToolResultText(normalizedMessage);
+  return boundedToolResultMessage(
+    rawResult,
+    producingToolName,
+    maxToolResultBytes,
+    (result) =>
+      llmMessageToAgentSummaryMessage(
+        result === rawResult
+          ? normalizedMessage
+          : { ...normalizedMessage, content: result },
+        index,
+      ),
+  );
+}
+
 function boundedProgressMessage(
   event: RunAgentProgressEvent,
   index: number,
   maxToolResultBytes: number,
 ): Message | null {
   return event.kind === "tool_result"
-    ? boundedToolResultMessage(event, index, maxToolResultBytes)
+    ? boundedToolResultMessage(
+        event.result,
+        event.toolName,
+        maxToolResultBytes,
+        (result) => convertedToolResultMessage(event, result, index),
+      )
     : runAgentProgressEventToAgentSummaryMessage(event, index);
 }
 
@@ -397,10 +455,19 @@ export class AgentSummaryTranscript {
     limitOverrides: AgentSummaryTranscriptLimitOverrides = {},
   ) {
     this.limits = resolveLimits(limitOverrides);
+    const toolNamesByCallId = new Map<string, string>();
     this.forkContextMessages = Object.freeze(
-      initialMessages.map((message, index) =>
-        llmMessageToAgentSummaryMessage(message, index),
-      ),
+      initialMessages.map((message, index) => {
+        for (const toolCall of message.toolCalls ?? []) {
+          toolNamesByCallId.set(toolCall.id, toolCall.name);
+        }
+        return boundedInitialMessage(
+          message,
+          index,
+          this.limits.maxToolResultBytes,
+          toolNamesByCallId,
+        );
+      }),
     );
     this.nextMessageIndex = this.forkContextMessages.length;
   }

--- a/runtime/src/services/AgentSummary/transcript-retention.ts
+++ b/runtime/src/services/AgentSummary/transcript-retention.ts
@@ -1,0 +1,329 @@
+import type { LLMMessage } from "../../llm/types.js";
+import type { Message } from "../../types/message.js";
+import type { RunAgentProgressEvent } from "../../agents/run-agent.js";
+import {
+  llmMessageToAgentSummaryMessage,
+  runAgentProgressEventToAgentSummaryMessage,
+} from "./transcript.js";
+
+export interface AgentSummaryTranscriptLimits {
+  /** Maximum JSON-serialized UTF-8 bytes retained for rolling activity. */
+  readonly maxBytes: number;
+  /** Maximum retained rolling messages, including the omission marker. */
+  readonly maxMessages: number;
+  /** Maximum UTF-8 bytes retained inline for one raw tool result. */
+  readonly maxToolResultBytes: number;
+}
+
+export type AgentSummaryTranscriptLimitOverrides =
+  Partial<AgentSummaryTranscriptLimits>;
+
+export const DEFAULT_AGENT_SUMMARY_TRANSCRIPT_LIMITS = Object.freeze({
+  maxBytes: 512 * 1024,
+  maxMessages: 256,
+  maxToolResultBytes: 64 * 1024,
+}) satisfies AgentSummaryTranscriptLimits;
+
+const MIN_TRANSCRIPT_BYTES = 512;
+const MIN_TRANSCRIPT_MESSAGES = 3;
+const MIN_TOOL_RESULT_BYTES = 128;
+const EPOCH_TIMESTAMP = new Date(0).toISOString();
+
+type ToolMessageIds = {
+  readonly uses: ReadonlySet<string>;
+  readonly results: ReadonlySet<string>;
+  readonly all: ReadonlySet<string>;
+};
+
+function resolvedLimit(
+  name: keyof AgentSummaryTranscriptLimits,
+  value: number,
+  minimum: number,
+): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new RangeError(
+      `AgentSummary transcript ${name} must be a safe integer >= ${minimum}`,
+    );
+  }
+  return value;
+}
+
+function resolveLimits(
+  overrides: AgentSummaryTranscriptLimitOverrides,
+): AgentSummaryTranscriptLimits {
+  const maxBytes = resolvedLimit(
+    "maxBytes",
+    overrides.maxBytes ?? DEFAULT_AGENT_SUMMARY_TRANSCRIPT_LIMITS.maxBytes,
+    MIN_TRANSCRIPT_BYTES,
+  );
+  const maxMessages = resolvedLimit(
+    "maxMessages",
+    overrides.maxMessages ??
+      DEFAULT_AGENT_SUMMARY_TRANSCRIPT_LIMITS.maxMessages,
+    MIN_TRANSCRIPT_MESSAGES,
+  );
+  const maxToolResultBytes = resolvedLimit(
+    "maxToolResultBytes",
+    overrides.maxToolResultBytes ??
+      DEFAULT_AGENT_SUMMARY_TRANSCRIPT_LIMITS.maxToolResultBytes,
+    MIN_TOOL_RESULT_BYTES,
+  );
+  if (maxToolResultBytes > maxBytes) {
+    throw new RangeError(
+      "AgentSummary transcript maxToolResultBytes must not exceed maxBytes",
+    );
+  }
+  return { maxBytes, maxMessages, maxToolResultBytes };
+}
+
+function messageContent(message: Message): readonly unknown[] {
+  if (typeof message !== "object" || message === null) return [];
+  const envelope = (message as { readonly message?: unknown }).message;
+  if (typeof envelope !== "object" || envelope === null) return [];
+  const content = (envelope as { readonly content?: unknown }).content;
+  return Array.isArray(content) ? content : [];
+}
+
+function toolMessageIds(message: Message): ToolMessageIds {
+  const uses = new Set<string>();
+  const results = new Set<string>();
+  for (const block of messageContent(message)) {
+    if (typeof block !== "object" || block === null) continue;
+    const record = block as {
+      readonly type?: unknown;
+      readonly id?: unknown;
+      readonly tool_use_id?: unknown;
+    };
+    if (
+      record.type === "tool_use" &&
+      typeof record.id === "string" &&
+      record.id.length > 0
+    ) {
+      uses.add(record.id);
+    }
+    if (
+      record.type === "tool_result" &&
+      typeof record.tool_use_id === "string" &&
+      record.tool_use_id.length > 0
+    ) {
+      results.add(record.tool_use_id);
+    }
+  }
+  return { uses, results, all: new Set([...uses, ...results]) };
+}
+
+function serializedMessageBytes(message: Message): number {
+  return Buffer.byteLength(JSON.stringify(message), "utf8");
+}
+
+function serializedArrayBytes(payloadBytes: number, count: number): number {
+  return 2 + payloadBytes + Math.max(0, count - 1);
+}
+
+function utf8Prefix(text: string, maxBytes: number): string {
+  const buffer = Buffer.from(text, "utf8");
+  if (buffer.byteLength <= maxBytes) return text;
+  let end = maxBytes;
+  while (end > 0 && (buffer[end]! & 0xc0) === 0x80) end -= 1;
+  return buffer.subarray(0, end).toString("utf8");
+}
+
+function isDurableToolResultReference(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith("<persisted-output>") ||
+    trimmed.startsWith("[full output (")
+  );
+}
+
+function clampRawToolResult(text: string, maxBytes: number): string {
+  const originalBytes = Buffer.byteLength(text, "utf8");
+  if (originalBytes <= maxBytes || isDurableToolResultReference(text)) {
+    return text;
+  }
+  const marker =
+    `\n[tool result truncated; original UTF-8 size: ${originalBytes} bytes]`;
+  const markerBytes = Buffer.byteLength(marker, "utf8");
+  const prefix = utf8Prefix(text, Math.max(0, maxBytes - markerBytes));
+  return `${prefix}${marker}`;
+}
+
+function boundedProgressEvent(
+  event: RunAgentProgressEvent,
+  maxToolResultBytes: number,
+): RunAgentProgressEvent {
+  if (event.kind !== "tool_result") return event;
+  const result = clampRawToolResult(event.result, maxToolResultBytes);
+  return result === event.result ? event : { ...event, result };
+}
+
+function omissionMarker(
+  omittedMessages: number,
+  omittedBytes: number,
+): Message {
+  return {
+    type: "user",
+    uuid: "agent-summary-rolling-omission",
+    timestamp: EPOCH_TIMESTAMP,
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text:
+            `[Earlier rolling agent activity omitted: ${omittedMessages} ` +
+            `messages / ${omittedBytes} serialized UTF-8 bytes.]`,
+        },
+      ],
+    },
+  } as Message;
+}
+
+/**
+ * Immutable fork context plus a bounded rolling activity window.
+ *
+ * The rolling window is measured as a JSON array in serialized UTF-8 bytes.
+ * Tool-linked messages are evicted as a connected unit, so interleaved calls
+ * and results cannot leave either half of a completed pair behind.
+ */
+export class AgentSummaryTranscript {
+  private readonly forkContextMessages: ReadonlyArray<Message>;
+  private readonly limits: AgentSummaryTranscriptLimits;
+  private rollingMessages: Message[] = [];
+  private rollingPayloadBytes = 0;
+  private omittedMessages = 0;
+  private omittedBytes = 0;
+  private nextMessageIndex: number;
+  private revisionValue = 0;
+
+  constructor(
+    initialMessages: ReadonlyArray<LLMMessage>,
+    limitOverrides: AgentSummaryTranscriptLimitOverrides = {},
+  ) {
+    this.limits = resolveLimits(limitOverrides);
+    this.forkContextMessages = Object.freeze(
+      initialMessages.map(llmMessageToAgentSummaryMessage),
+    );
+    this.nextMessageIndex = this.forkContextMessages.length;
+  }
+
+  get revision(): number {
+    return this.revisionValue;
+  }
+
+  get messages(): ReadonlyArray<Message> {
+    const marker = this.currentOmissionMarker();
+    return marker === null
+      ? [...this.forkContextMessages, ...this.rollingMessages]
+      : [...this.forkContextMessages, marker, ...this.rollingMessages];
+  }
+
+  record(event: RunAgentProgressEvent): void {
+    if (event.kind === "message" && event.isInitialReplay === true) return;
+    const message = runAgentProgressEventToAgentSummaryMessage(
+      boundedProgressEvent(event, this.limits.maxToolResultBytes),
+      this.nextMessageIndex,
+    );
+    if (message === null) return;
+    this.nextMessageIndex += 1;
+    this.revisionValue += 1;
+
+    const ids = toolMessageIds(message);
+    if (
+      ids.results.size > 0 &&
+      [...ids.results].some((id) => !this.hasRollingToolUse(id))
+    ) {
+      this.noteOmitted([message]);
+      this.enforceLimits();
+      return;
+    }
+
+    this.rollingMessages.push(message);
+    this.rollingPayloadBytes += serializedMessageBytes(message);
+    this.enforceLimits();
+  }
+
+  private hasRollingToolUse(id: string): boolean {
+    return this.rollingMessages.some((message) =>
+      toolMessageIds(message).uses.has(id),
+    );
+  }
+
+  private currentOmissionMarker(): Message | null {
+    return this.omittedMessages === 0
+      ? null
+      : omissionMarker(this.omittedMessages, this.omittedBytes);
+  }
+
+  private retainedRollingSize(): {
+    readonly bytes: number;
+    readonly messages: number;
+  } {
+    const marker = this.currentOmissionMarker();
+    const markerCount = marker === null ? 0 : 1;
+    const markerBytes = marker === null ? 0 : serializedMessageBytes(marker);
+    const messages = this.rollingMessages.length + markerCount;
+    return {
+      bytes: serializedArrayBytes(
+        this.rollingPayloadBytes + markerBytes,
+        messages,
+      ),
+      messages,
+    };
+  }
+
+  private enforceLimits(): void {
+    while (true) {
+      const retained = this.retainedRollingSize();
+      if (
+        retained.bytes <= this.limits.maxBytes &&
+        retained.messages <= this.limits.maxMessages
+      ) {
+        return;
+      }
+      if (this.rollingMessages.length === 0) {
+        throw new Error("AgentSummary omission marker exceeds transcript limits");
+      }
+      this.noteOmitted(this.removeOldestLinkedUnit());
+    }
+  }
+
+  private removeOldestLinkedUnit(): Message[] {
+    const indexes = new Set<number>([0]);
+    const linkedIds = new Set(toolMessageIds(this.rollingMessages[0]!).all);
+    let changed = linkedIds.size > 0;
+    while (changed) {
+      changed = false;
+      for (let index = 1; index < this.rollingMessages.length; index += 1) {
+        if (indexes.has(index)) continue;
+        const ids = toolMessageIds(this.rollingMessages[index]!).all;
+        if (![...ids].some((id) => linkedIds.has(id))) continue;
+        indexes.add(index);
+        for (const id of ids) linkedIds.add(id);
+        changed = true;
+      }
+    }
+
+    const removed: Message[] = [];
+    const retained: Message[] = [];
+    for (let index = 0; index < this.rollingMessages.length; index += 1) {
+      const message = this.rollingMessages[index]!;
+      if (indexes.has(index)) {
+        removed.push(message);
+        this.rollingPayloadBytes -= serializedMessageBytes(message);
+      } else {
+        retained.push(message);
+      }
+    }
+    this.rollingMessages = retained;
+    return removed;
+  }
+
+  private noteOmitted(messages: ReadonlyArray<Message>): void {
+    this.omittedMessages += messages.length;
+    this.omittedBytes += messages.reduce(
+      (total, message) => total + serializedMessageBytes(message),
+      0,
+    );
+  }
+}

--- a/runtime/src/services/AgentSummary/transcript-retention.ts
+++ b/runtime/src/services/AgentSummary/transcript-retention.ts
@@ -128,24 +128,89 @@ function utf8Prefix(text: string, maxBytes: number): string {
   return buffer.subarray(0, end).toString("utf8");
 }
 
-function isDurableToolResultReference(text: string): boolean {
-  const trimmed = text.trimStart();
+function utf8Suffix(text: string, maxBytes: number): string {
+  const buffer = Buffer.from(text, "utf8");
+  if (buffer.byteLength <= maxBytes) return text;
+  let start = buffer.byteLength - maxBytes;
+  while (start < buffer.byteLength && (buffer[start]! & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return buffer.subarray(start).toString("utf8");
+}
+
+function persistedOutputReference(text: string): string | null {
+  const match =
+    /^<persisted-output>\r?\n(?<reference>Output too large \([^\r\n]+\)\. Full output saved to: [^\r\n]+)(?:\r?\n[\s\S]*)?<\/persisted-output>\s*$/u.exec(
+      text,
+    );
+  const reference = match?.groups?.reference;
+  return reference === undefined
+    ? null
+    : `<persisted-output>\n${reference}\n</persisted-output>`;
+}
+
+function offloadedOutputReference(text: string): string | null {
   return (
-    trimmed.startsWith("<persisted-output>") ||
-    trimmed.startsWith("[full output (")
+    /^(\[full output \(~[^\r\n]+ saved to [^\r\n]+:\])(?:\r?\n|$)/u.exec(
+      text,
+    )?.[1] ?? null
+  );
+}
+
+function webFetchOutputReference(text: string): string | null {
+  return (
+    /(?:^|\r?\n\r?\n)(\[Binary content \([^\r\n]+\) also saved to [^\r\n]+\])$/u.exec(
+      text,
+    )?.[1] ?? null
+  );
+}
+
+function durableToolResultReference(text: string): string | null {
+  return (
+    persistedOutputReference(text) ??
+    offloadedOutputReference(text) ??
+    webFetchOutputReference(text)
   );
 }
 
 function clampRawToolResult(text: string, maxBytes: number): string {
   const originalBytes = Buffer.byteLength(text, "utf8");
-  if (originalBytes <= maxBytes || isDurableToolResultReference(text)) {
-    return text;
-  }
-  const marker =
+  if (originalBytes <= maxBytes) return text;
+  const rawMarker =
     `\n[tool result truncated; original UTF-8 size: ${originalBytes} bytes]`;
+  const marker = utf8Prefix(rawMarker, maxBytes);
   const markerBytes = Buffer.byteLength(marker, "utf8");
-  const prefix = utf8Prefix(text, Math.max(0, maxBytes - markerBytes));
-  return `${prefix}${marker}`;
+  const reference = durableToolResultReference(text);
+  const referenceBudget = Math.max(0, maxBytes - markerBytes - 1);
+  const boundedReference =
+    reference === null ? "" : utf8Suffix(reference, referenceBudget);
+  const separator = boundedReference.length === 0 ? "" : "\n";
+  const reservedBytes =
+    markerBytes +
+    Buffer.byteLength(separator, "utf8") +
+    Buffer.byteLength(boundedReference, "utf8");
+  const prefix = utf8Prefix(text, Math.max(0, maxBytes - reservedBytes));
+  return `${prefix}${marker}${separator}${boundedReference}`;
+}
+
+function oldestLinkedMessageIndexes(
+  messages: ReadonlyArray<Message>,
+): ReadonlySet<number> {
+  const indexes = new Set<number>([0]);
+  const linkedIds = new Set(toolMessageIds(messages[0]!).all);
+  let changed = linkedIds.size > 0;
+  while (changed) {
+    changed = false;
+    for (let index = 1; index < messages.length; index += 1) {
+      if (indexes.has(index)) continue;
+      const ids = toolMessageIds(messages[index]!).all;
+      if (![...ids].some((id) => linkedIds.has(id))) continue;
+      indexes.add(index);
+      for (const id of ids) linkedIds.add(id);
+      changed = true;
+    }
+  }
+  return indexes;
 }
 
 function boundedProgressEvent(
@@ -202,7 +267,9 @@ export class AgentSummaryTranscript {
   ) {
     this.limits = resolveLimits(limitOverrides);
     this.forkContextMessages = Object.freeze(
-      initialMessages.map(llmMessageToAgentSummaryMessage),
+      initialMessages.map((message, index) =>
+        llmMessageToAgentSummaryMessage(message, index),
+      ),
     );
     this.nextMessageIndex = this.forkContextMessages.length;
   }
@@ -289,33 +356,17 @@ export class AgentSummaryTranscript {
   }
 
   private removeOldestLinkedUnit(): Message[] {
-    const indexes = new Set<number>([0]);
-    const linkedIds = new Set(toolMessageIds(this.rollingMessages[0]!).all);
-    let changed = linkedIds.size > 0;
-    while (changed) {
-      changed = false;
-      for (let index = 1; index < this.rollingMessages.length; index += 1) {
-        if (indexes.has(index)) continue;
-        const ids = toolMessageIds(this.rollingMessages[index]!).all;
-        if (![...ids].some((id) => linkedIds.has(id))) continue;
-        indexes.add(index);
-        for (const id of ids) linkedIds.add(id);
-        changed = true;
-      }
-    }
-
-    const removed: Message[] = [];
-    const retained: Message[] = [];
-    for (let index = 0; index < this.rollingMessages.length; index += 1) {
-      const message = this.rollingMessages[index]!;
-      if (indexes.has(index)) {
-        removed.push(message);
-        this.rollingPayloadBytes -= serializedMessageBytes(message);
-      } else {
-        retained.push(message);
-      }
-    }
-    this.rollingMessages = retained;
+    const indexes = oldestLinkedMessageIndexes(this.rollingMessages);
+    const removed = this.rollingMessages.filter((_message, index) =>
+      indexes.has(index),
+    );
+    this.rollingMessages = this.rollingMessages.filter(
+      (_message, index) => !indexes.has(index),
+    );
+    this.rollingPayloadBytes -= removed.reduce(
+      (total, message) => total + serializedMessageBytes(message),
+      0,
+    );
     return removed;
   }
 

--- a/runtime/src/services/AgentSummary/transcript-retention.ts
+++ b/runtime/src/services/AgentSummary/transcript-retention.ts
@@ -6,6 +6,10 @@ import {
   runAgentProgressEventToAgentSummaryMessage,
 } from "./transcript.js";
 import { WEB_FETCH_TOOL_NAME } from "../../tools/WebFetchTool/prompt.js";
+import {
+  frameUntrustedToolResultContent,
+  type UntrustedToolResultKind,
+} from "../../tools/untrusted-tool-result-framing.js";
 
 export interface AgentSummaryTranscriptLimits {
   /** Maximum JSON-serialized UTF-8 bytes retained for rolling activity. */
@@ -31,6 +35,12 @@ const MIN_TOOL_RESULT_BYTES = 128;
 const EPOCH_TIMESTAMP = new Date(0).toISOString();
 const TOOL_RESULT_SAFETY_FRAME_OMISSION =
   "[tool result omitted: safety frame exceeds configured UTF-8 limit]";
+const CANONICAL_FRAME_BODY_SENTINEL =
+  "agenc-canonical-frame-body-sentinel-7f4d6b17";
+const UNTRUSTED_TOOL_RESULT_KINDS = [
+  "external",
+  "workspace",
+] as const satisfies readonly UntrustedToolResultKind[];
 
 type ToolResultProgressEvent = Extract<
   RunAgentProgressEvent,
@@ -362,6 +372,39 @@ function initialToolResultText(message: LLMMessage): string {
         .join("\n");
 }
 
+function canonicalWebFetchResultBody(
+  content: LLMMessage["content"],
+  pairedToolName: string | undefined,
+): string | null {
+  if (pairedToolName !== WEB_FETCH_TOOL_NAME || typeof content !== "string") {
+    return null;
+  }
+  for (const kind of UNTRUSTED_TOOL_RESULT_KINDS) {
+    const template = frameUntrustedToolResultContent(
+      pairedToolName,
+      CANONICAL_FRAME_BODY_SENTINEL,
+      kind,
+    );
+    if (typeof template !== "string") continue;
+    const bodyOffset = template.indexOf(CANONICAL_FRAME_BODY_SENTINEL);
+    if (bodyOffset < 0) continue;
+    const prefix = template.slice(0, bodyOffset);
+    const suffix = template.slice(
+      bodyOffset + CANONICAL_FRAME_BODY_SENTINEL.length,
+    );
+    if (!content.startsWith(prefix) || !content.endsWith(suffix)) continue;
+    const body = content.slice(prefix.length, content.length - suffix.length);
+    // Canonical framing remains owned by the shared framing layer: only an
+    // exact round trip can unwrap, so nested and lookalike frames fail closed.
+    if (
+      frameUntrustedToolResultContent(pairedToolName, body, kind) === content
+    ) {
+      return body;
+    }
+  }
+  return null;
+}
+
 function boundedInitialMessage(
   message: LLMMessage,
   index: number,
@@ -371,9 +414,10 @@ function boundedInitialMessage(
   if (message.role !== "tool" || !message.toolCallId) {
     return llmMessageToAgentSummaryMessage(message, index);
   }
+  const pairedToolName = toolNamesByCallId.get(message.toolCallId);
   const recordedToolName = message.toolName?.trim();
   const producingToolName =
-    toolNamesByCallId.get(message.toolCallId) ??
+    pairedToolName ??
     (recordedToolName && recordedToolName.length > 0
       ? recordedToolName
       : "unknown_tool");
@@ -381,7 +425,14 @@ function boundedInitialMessage(
     message.toolName === producingToolName
       ? message
       : { ...message, toolName: producingToolName };
-  const rawResult = initialToolResultText(normalizedMessage);
+  const canonicalBody = canonicalWebFetchResultBody(
+    normalizedMessage.content,
+    pairedToolName,
+  );
+  const sourceMessage = canonicalBody === null
+    ? normalizedMessage
+    : { ...normalizedMessage, content: canonicalBody };
+  const rawResult = initialToolResultText(sourceMessage);
   return boundedToolResultMessage(
     rawResult,
     producingToolName,
@@ -389,8 +440,8 @@ function boundedInitialMessage(
     (result) =>
       llmMessageToAgentSummaryMessage(
         result === rawResult
-          ? normalizedMessage
-          : { ...normalizedMessage, content: result },
+          ? sourceMessage
+          : { ...sourceMessage, content: result },
         index,
       ),
   );

--- a/runtime/src/tasks/agent-thread.ts
+++ b/runtime/src/tasks/agent-thread.ts
@@ -68,6 +68,7 @@ export interface AgentThreadTaskHandle {
   readonly worktreeBranch?: string;
   readonly messages?: ReadonlyArray<LLMMessage>;
   readonly summaryMessages?: ReadonlyArray<Message>;
+  readonly summaryRevision?: number;
   readonly summaryCacheSafeParams?: CacheSafeParams;
   onSummaryCacheSafeParams?(
     listener: (params: CacheSafeParams) => void,
@@ -471,9 +472,15 @@ export function registerAgentThreadTask(
 
 function agentTranscriptFromThread(thread: AgentThreadTaskHandle): {
   readonly messages: readonly Message[];
+  readonly revision?: number;
 } {
   if (thread.summaryMessages !== undefined) {
-    return { messages: [...thread.summaryMessages] };
+    return {
+      messages: [...thread.summaryMessages],
+      ...(thread.summaryRevision !== undefined
+        ? { revision: thread.summaryRevision }
+        : {}),
+    };
   }
   return {
     messages: (thread.messages ?? []).map(llmMessageToAgentSummaryMessage),

--- a/runtime/tests/agents/delegate.test.ts
+++ b/runtime/tests/agents/delegate.test.ts
@@ -276,15 +276,18 @@ describe("delegate lifecycle recovery", () => {
     expect(outcome.thread.summaryCacheSafeParams).toBe(cacheSafeParams);
     expect(
       outcome.thread.summaryMessages.map((message) => message.type),
-    ).toEqual(["assistant", "user"]);
-    expect(outcome.thread.summaryMessages[0]?.message.content).toEqual([
+    ).toEqual(["user", "assistant", "user"]);
+    expect(outcome.thread.summaryMessages[0]?.message.content).toBe(
+      "seed prompt",
+    );
+    expect(outcome.thread.summaryMessages[1]?.message.content).toEqual([
       expect.objectContaining({
         type: "tool_use",
         id: "call-1",
         input: { file_path: "x.ts" },
       }),
     ]);
-    expect(outcome.thread.summaryMessages[1]?.message.content).toEqual([
+    expect(outcome.thread.summaryMessages[2]?.message.content).toEqual([
       expect.objectContaining({
         type: "tool_result",
         tool_use_id: "call-1",

--- a/runtime/tests/agents/thread.summary-retention.test.ts
+++ b/runtime/tests/agents/thread.summary-retention.test.ts
@@ -197,7 +197,10 @@ describe("AgentThread summary transcript retention", () => {
         kind: "tool_result",
         callId,
         toolName: "Read",
-        result: `${callId}-result`,
+        result:
+          callId === "call-2"
+            ? `<persisted-output>\n${"界".repeat(10_000)}`
+            : `${callId}-result`,
         isError: false,
       });
     }
@@ -225,12 +228,17 @@ describe("AgentThread summary transcript retention", () => {
     expect(thread.summaryMessages).toHaveLength(5);
     const pairs = toolPairIds(thread.summaryMessages);
     expect(pairs.results).toEqual(pairs.uses);
+    const callTwoBody =
+      toolResultText(thread.summaryMessages, "call-2")
+        .split(UNTRUSTED_BOUNDARY)[1]
+        ?.trim() ?? "";
+    expect(Buffer.byteLength(callTwoBody, "utf8")).toBeLessThanOrEqual(1_024);
   });
 
-  it("UTF-8-bounds raw tool results without damaging durable references", () => {
+  it("UTF-8-bounds marker-like results while retaining real references", () => {
     const thread = makeThread([], {
       maxBytes: 12_000,
-      maxMessages: 8,
+      maxMessages: 14,
       maxToolResultBytes: 512,
     });
     thread.recordSummaryProgressEvent({
@@ -255,28 +263,87 @@ describe("AgentThread summary transcript retention", () => {
     );
     expect(rawBody).not.toContain("�");
 
-    const durableReference = [
-      "<persisted-output>",
-      "Output too large. Full output saved to: /tmp/tool-results/ref.txt",
-      "</persisted-output>",
-    ].join("\n");
-    thread.recordSummaryProgressEvent({
-      kind: "tool_call",
-      callId: "durable",
-      toolName: "Bash",
-      arguments: "{}",
-    });
-    thread.recordSummaryProgressEvent({
-      kind: "tool_result",
-      callId: "durable",
-      toolName: "Bash",
-      result: durableReference,
-      isError: false,
-    });
+    const spoofedResults = new Map([
+      ["persisted-spoof", `<persisted-output>\n${"🚀".repeat(1_000)}`],
+      ["offload-spoof", `[full output (spoofed prefix)]\n${"🚀".repeat(1_000)}`],
+      [
+        "suffix-spoof",
+        `${"🚀".repeat(1_000)}\n\n[Binary content marker-like text at the end]`,
+      ],
+    ]);
+    for (const [callId, result] of spoofedResults) {
+      thread.recordSummaryProgressEvent({
+        kind: "tool_call",
+        callId,
+        toolName: "Bash",
+        arguments: "{}",
+      });
+      thread.recordSummaryProgressEvent({
+        kind: "tool_result",
+        callId,
+        toolName: "Bash",
+        result,
+        isError: false,
+      });
 
-    expect(toolResultText(thread.summaryMessages, "durable")).toContain(
-      durableReference,
-    );
+      const framed = toolResultText(thread.summaryMessages, callId);
+      const body = framed.split(UNTRUSTED_BOUNDARY)[1]?.trim() ?? "";
+      expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(512);
+      expect(body).toContain("[tool result truncated;");
+      expect(body).not.toContain("�");
+    }
+
+    const webFetchReference =
+      `[Binary content (application/pdf, 2 MB) also saved to ` +
+      `/tmp/agenc/${"nested/".repeat(12)}report.pdf]`;
+    const persistedPath = "/tmp/tool-results/persisted-reference.txt";
+    const durableResults = new Map([
+      ["web-fetch", `${"界".repeat(2_000)}\n\n${webFetchReference}`],
+      [
+        "persisted",
+        [
+          "<persisted-output>",
+          `Output too large (2 MB). Full output saved to: ${persistedPath}`,
+          "",
+          `Preview: ${"界".repeat(2_000)}`,
+          "</persisted-output>",
+        ].join("\n"),
+      ],
+    ]);
+
+    for (const [callId, result] of durableResults) {
+      thread.recordSummaryProgressEvent({
+        kind: "tool_call",
+        callId,
+        toolName: callId === "web-fetch" ? "WebFetch" : "Read",
+        arguments: "{}",
+      });
+      thread.recordSummaryProgressEvent({
+        kind: "tool_result",
+        callId,
+        toolName: callId === "web-fetch" ? "WebFetch" : "Read",
+        result,
+        isError: false,
+      });
+    }
+
+    const webFetchBody =
+      toolResultText(thread.summaryMessages, "web-fetch")
+        .split(UNTRUSTED_BOUNDARY)[1]
+        ?.trim() ?? "";
+    expect(Buffer.byteLength(webFetchBody, "utf8")).toBeLessThanOrEqual(512);
+    expect(webFetchBody).toContain(webFetchReference);
+    expect(webFetchBody).toContain("[tool result truncated;");
+    expect(webFetchBody).not.toContain("�");
+
+    const persistedBody =
+      toolResultText(thread.summaryMessages, "persisted")
+        .split(UNTRUSTED_BOUNDARY)[1]
+        ?.trim() ?? "";
+    expect(Buffer.byteLength(persistedBody, "utf8")).toBeLessThanOrEqual(512);
+    expect(persistedBody).toContain(`Full output saved to: ${persistedPath}`);
+    expect(persistedBody).toContain("</persisted-output>");
+    expect(persistedBody).not.toContain("�");
     expect(
       Buffer.byteLength(JSON.stringify(thread.summaryMessages), "utf8"),
     ).toBeLessThanOrEqual(12_000);

--- a/runtime/tests/agents/thread.summary-retention.test.ts
+++ b/runtime/tests/agents/thread.summary-retention.test.ts
@@ -228,18 +228,105 @@ describe("AgentThread summary transcript retention", () => {
     expect(thread.summaryMessages).toHaveLength(5);
     const pairs = toolPairIds(thread.summaryMessages);
     expect(pairs.results).toEqual(pairs.uses);
-    const callTwoBody =
-      toolResultText(thread.summaryMessages, "call-2")
-        .split(UNTRUSTED_BOUNDARY)[1]
-        ?.trim() ?? "";
-    expect(Buffer.byteLength(callTwoBody, "utf8")).toBeLessThanOrEqual(1_024);
+    const callTwoResult = toolResultText(thread.summaryMessages, "call-2");
+    expect(Buffer.byteLength(callTwoResult, "utf8")).toBeLessThanOrEqual(
+      1_024,
+    );
   });
 
-  it("UTF-8-bounds marker-like results while retaining real references", () => {
+  it("bounds sanitizer-expanded final results at tiny and normal caps", () => {
+    const tinyThread = makeThread([], {
+      maxBytes: 2_000,
+      maxMessages: 4,
+      maxToolResultBytes: 128,
+    });
+    tinyThread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: "tiny-tags",
+      toolName: "Bash",
+      arguments: "{}",
+    });
+    tinyThread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: "tiny-tags",
+      toolName: "Bash",
+      result: "<system>".repeat(64),
+      isError: false,
+    });
+
+    const tinyResult = toolResultText(
+      tinyThread.summaryMessages,
+      "tiny-tags",
+    );
+    expect(Buffer.byteLength(tinyResult, "utf8")).toBeLessThanOrEqual(128);
+    expect(tinyResult).toContain("tool result omitted: safety frame");
+    expect(tinyResult).not.toContain("<system>");
+
+    const normalThread = makeThread([], {
+      maxBytes: 8_000,
+      maxMessages: 6,
+      maxToolResultBytes: 640,
+    });
+    normalThread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: "normal-tags",
+      toolName: "Bash",
+      arguments: "{}",
+    });
+    normalThread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: "normal-tags",
+      toolName: "Bash",
+      result:
+        "<system><system-reminder><workspace_instructions>".repeat(64),
+      isError: false,
+    });
+    normalThread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: "multibyte-tags",
+      toolName: "Bash",
+      arguments: "{}",
+    });
+    normalThread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: "multibyte-tags",
+      toolName: "Bash",
+      result: "🚀<system>".repeat(200),
+      isError: false,
+    });
+
+    const normalResult = toolResultText(
+      normalThread.summaryMessages,
+      "normal-tags",
+    );
+    expect(Buffer.byteLength(normalResult, "utf8")).toBeLessThanOrEqual(640);
+    expect(normalResult.split(UNTRUSTED_BOUNDARY)).toHaveLength(3);
+    expect(normalResult).toContain("<neutralized-system-tag>");
+    expect(normalResult).toContain("<neutralized-system-reminder-tag>");
+    expect(normalResult).toContain("<neutralized-workspace-instructions-tag>");
+    expect(normalResult).not.toContain("<system>");
+    expect(normalResult).not.toContain("<system-reminder>");
+    expect(normalResult).not.toContain("<workspace_instructions>");
+
+    const multibyteResult = toolResultText(
+      normalThread.summaryMessages,
+      "multibyte-tags",
+    );
+    expect(Buffer.byteLength(multibyteResult, "utf8")).toBeLessThanOrEqual(
+      640,
+    );
+    expect(multibyteResult.split(UNTRUSTED_BOUNDARY)).toHaveLength(3);
+    expect(multibyteResult).not.toContain("�");
+    expect(toolPairIds(normalThread.summaryMessages).results).toEqual(
+      toolPairIds(normalThread.summaryMessages).uses,
+    );
+  });
+
+  it("UTF-8-bounds framed marker-like results while retaining real references", () => {
     const thread = makeThread([], {
-      maxBytes: 12_000,
+      maxBytes: 20_000,
       maxMessages: 14,
-      maxToolResultBytes: 512,
+      maxToolResultBytes: 1_024,
     });
     thread.recordSummaryProgressEvent({
       kind: "tool_call",
@@ -257,7 +344,7 @@ describe("AgentThread summary transcript retention", () => {
 
     const rawFramed = toolResultText(thread.summaryMessages, "raw");
     const rawBody = rawFramed.split(UNTRUSTED_BOUNDARY)[1]?.trim() ?? "";
-    expect(Buffer.byteLength(rawBody, "utf8")).toBeLessThanOrEqual(512);
+    expect(Buffer.byteLength(rawFramed, "utf8")).toBeLessThanOrEqual(1_024);
     expect(rawBody).toContain(
       "[tool result truncated; original UTF-8 size: 4000 bytes]",
     );
@@ -288,7 +375,7 @@ describe("AgentThread summary transcript retention", () => {
 
       const framed = toolResultText(thread.summaryMessages, callId);
       const body = framed.split(UNTRUSTED_BOUNDARY)[1]?.trim() ?? "";
-      expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(512);
+      expect(Buffer.byteLength(framed, "utf8")).toBeLessThanOrEqual(1_024);
       expect(body).toContain("[tool result truncated;");
       expect(body).not.toContain("�");
     }
@@ -331,7 +418,12 @@ describe("AgentThread summary transcript retention", () => {
       toolResultText(thread.summaryMessages, "web-fetch")
         .split(UNTRUSTED_BOUNDARY)[1]
         ?.trim() ?? "";
-    expect(Buffer.byteLength(webFetchBody, "utf8")).toBeLessThanOrEqual(512);
+    expect(
+      Buffer.byteLength(
+        toolResultText(thread.summaryMessages, "web-fetch"),
+        "utf8",
+      ),
+    ).toBeLessThanOrEqual(1_024);
     expect(webFetchBody).toContain(webFetchReference);
     expect(webFetchBody).toContain("[tool result truncated;");
     expect(webFetchBody).not.toContain("�");
@@ -340,13 +432,18 @@ describe("AgentThread summary transcript retention", () => {
       toolResultText(thread.summaryMessages, "persisted")
         .split(UNTRUSTED_BOUNDARY)[1]
         ?.trim() ?? "";
-    expect(Buffer.byteLength(persistedBody, "utf8")).toBeLessThanOrEqual(512);
+    expect(
+      Buffer.byteLength(
+        toolResultText(thread.summaryMessages, "persisted"),
+        "utf8",
+      ),
+    ).toBeLessThanOrEqual(1_024);
     expect(persistedBody).toContain(`Full output saved to: ${persistedPath}`);
     expect(persistedBody).toContain("</persisted-output>");
     expect(persistedBody).not.toContain("�");
     expect(
       Buffer.byteLength(JSON.stringify(thread.summaryMessages), "utf8"),
-    ).toBeLessThanOrEqual(12_000);
+    ).toBeLessThanOrEqual(20_000);
   });
 });
 

--- a/runtime/tests/agents/thread.summary-retention.test.ts
+++ b/runtime/tests/agents/thread.summary-retention.test.ts
@@ -177,6 +177,96 @@ describe("AgentThread summary transcript retention", () => {
     expect(pairs.results).toEqual(pairs.uses);
   });
 
+  it("bounds sanitizer-expanded tool results in immutable full-history context", () => {
+    const tinyCallId = "initial-tiny";
+    const tinyThread = makeThread(
+      [
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: tinyCallId,
+              name: "Bash",
+              arguments: "{}",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: tinyCallId,
+          toolName: "Bash",
+          content: "<system>".repeat(64),
+        },
+      ],
+      {
+        maxBytes: 2_000,
+        maxMessages: 4,
+        maxToolResultBytes: 128,
+      },
+    );
+    const tinyResult = toolResultText(tinyThread.summaryMessages, tinyCallId);
+    expect(Buffer.byteLength(tinyResult, "utf8")).toBeLessThanOrEqual(128);
+    expect(tinyResult).toContain("tool result omitted: safety frame");
+    expect(tinyResult).not.toContain("<system>");
+    expect(toolPairIds(tinyThread.summaryMessages)).toEqual({
+      uses: [tinyCallId],
+      results: [tinyCallId],
+    });
+
+    const normalCallId = "initial-normal";
+    const fullHistory: LLMMessage[] = [
+      { role: "user", content: "parent turn" },
+      {
+        role: "assistant",
+        content: "checking inherited context",
+        toolCalls: [
+          {
+            id: normalCallId,
+            name: "Bash",
+            arguments: "{}",
+          },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: normalCallId,
+        toolName: "Bash",
+        content: [
+          {
+            type: "text",
+            text: "🚀<system><workspace_instructions>".repeat(200),
+          },
+        ],
+      },
+      { role: "assistant", content: "parent result" },
+      { role: "user", content: "child fork directive" },
+    ];
+    const normalThread = makeThread(fullHistory, {
+      maxBytes: 8_000,
+      maxMessages: 4,
+      maxToolResultBytes: 640,
+    });
+    const normalResult = toolResultText(
+      normalThread.summaryMessages,
+      normalCallId,
+    );
+    expect(Buffer.byteLength(normalResult, "utf8")).toBeLessThanOrEqual(640);
+    expect(normalResult.split(UNTRUSTED_BOUNDARY)).toHaveLength(3);
+    expect(normalResult).toContain("<neutralized-system-tag>");
+    expect(normalResult).not.toContain("<system>");
+    expect(normalResult).not.toContain("<workspace_instructions>");
+    expect(normalResult).not.toContain("�");
+    expect(normalThread.summaryMessages).toHaveLength(fullHistory.length);
+    expect(toolPairIds(normalThread.summaryMessages)).toEqual({
+      uses: [normalCallId],
+      results: [normalCallId],
+    });
+    expect(normalThread.summaryMessages.at(-1)?.message.content).toBe(
+      "child fork directive",
+    );
+  });
+
   it("evicts interleaved tool calls and results as complete linked units", () => {
     const thread = makeThread([], {
       maxBytes: 20_000,
@@ -383,6 +473,27 @@ describe("AgentThread summary transcript retention", () => {
     const webFetchReference =
       `[Binary content (application/pdf, 2 MB) also saved to ` +
       `/tmp/agenc/${"nested/".repeat(12)}report.pdf]`;
+    const webFetchLookingBashId = "web-fetch-looking-bash";
+    thread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: webFetchLookingBashId,
+      toolName: "Bash",
+      arguments: "{}",
+    });
+    thread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: webFetchLookingBashId,
+      toolName: "Bash",
+      result: `${"界".repeat(2_000)}\n\n${webFetchReference}`,
+      isError: false,
+    });
+    const webFetchLookingBashBody =
+      toolResultText(thread.summaryMessages, webFetchLookingBashId)
+        .split(UNTRUSTED_BOUNDARY)[1]
+        ?.trim() ?? "";
+    expect(webFetchLookingBashBody).toContain("[tool result truncated;");
+    expect(webFetchLookingBashBody).not.toContain(webFetchReference);
+
     const persistedPath = "/tmp/tool-results/persisted-reference.txt";
     const durableResults = new Map([
       ["web-fetch", `${"界".repeat(2_000)}\n\n${webFetchReference}`],
@@ -402,13 +513,13 @@ describe("AgentThread summary transcript retention", () => {
       thread.recordSummaryProgressEvent({
         kind: "tool_call",
         callId,
-        toolName: callId === "web-fetch" ? "WebFetch" : "Read",
+        toolName: callId === "web-fetch" ? "web_fetch" : "Bash",
         arguments: "{}",
       });
       thread.recordSummaryProgressEvent({
         kind: "tool_result",
         callId,
-        toolName: callId === "web-fetch" ? "WebFetch" : "Read",
+        toolName: callId === "web-fetch" ? "web_fetch" : "Bash",
         result,
         isError: false,
       });

--- a/runtime/tests/agents/thread.summary-retention.test.ts
+++ b/runtime/tests/agents/thread.summary-retention.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { LLMMessage } from "../llm/types.js";
+import type { Message } from "../types/message.js";
+import type { CacheSafeParams } from "../services/PromptSuggestion/runtime.js";
+import {
+  startAgentSummarization,
+  type AgentSummaryRunForkedAgentParams,
+} from "../services/AgentSummary/agentSummary.js";
+import { registerAgentThreadTask } from "../tasks/agent-thread.js";
+import { BackgroundTaskLifecycle } from "../tasks/lifecycle.js";
+import { AgentThread } from "./thread.js";
+import type { LiveAgent } from "./control.js";
+import { AgentStatusTracker } from "./status.js";
+import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
+import { Mailbox } from "./mailbox.js";
+
+const ROLE_WORKSPACE = createAgentRoleWorkspace(process.cwd());
+const UNTRUSTED_BOUNDARY = "===== AGENC UNTRUSTED TOOL RESULT DATA =====";
+const OMISSION_TEXT = "Earlier rolling agent activity omitted";
+
+function makeLive(): LiveAgent {
+  return {
+    agentId: "thread-retention",
+    agentPath: "/root/retention",
+    role: resolveAgentRole(ROLE_WORKSPACE, undefined),
+    depth: 1,
+    nickname: "retention",
+    status: new AgentStatusTracker(),
+    upInbox: new Mailbox({ threadId: "thread-retention" }),
+    downInbox: new Mailbox({ threadId: "thread-retention-down" }),
+    abortController: new AbortController(),
+    metadata: {
+      agentId: "thread-retention",
+      agentPath: "/root/retention",
+      agentNickname: "retention",
+      agentRole: "default",
+      agentRoleWorkspaceId: ROLE_WORKSPACE.id,
+      depth: 1,
+    },
+    messages: [],
+    memoryEntries: [],
+    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+  };
+}
+
+function makeThread(
+  initialMessages: ReadonlyArray<LLMMessage> = [],
+  summaryTranscriptLimits = {
+    maxBytes: 6_000,
+    maxMessages: 7,
+    maxToolResultBytes: 512,
+  },
+): AgentThread {
+  return new AgentThread({
+    live: makeLive(),
+    initialMessages,
+    taskPrompt: "retain a bounded summary transcript",
+    summaryTranscriptLimits,
+  });
+}
+
+function contentBlocks(message: Message): readonly Record<string, unknown>[] {
+  const content = message?.message?.content;
+  return Array.isArray(content)
+    ? content.filter(
+        (block): block is Record<string, unknown> =>
+          typeof block === "object" && block !== null,
+      )
+    : [];
+}
+
+function toolPairIds(messages: readonly Message[]): {
+  readonly uses: string[];
+  readonly results: string[];
+} {
+  const uses: string[] = [];
+  const results: string[] = [];
+  for (const message of messages) {
+    for (const block of contentBlocks(message)) {
+      if (block.type === "tool_use" && typeof block.id === "string") {
+        uses.push(block.id);
+      }
+      if (
+        block.type === "tool_result" &&
+        typeof block.tool_use_id === "string"
+      ) {
+        results.push(block.tool_use_id);
+      }
+    }
+  }
+  return { uses: uses.sort(), results: results.sort() };
+}
+
+function toolResultText(messages: readonly Message[], callId: string): string {
+  for (const message of messages) {
+    for (const block of contentBlocks(message)) {
+      if (block.type !== "tool_result" || block.tool_use_id !== callId) continue;
+      if (typeof block.content === "string") return block.content;
+      if (Array.isArray(block.content)) {
+        return block.content
+          .map((part) =>
+            typeof part === "object" &&
+            part !== null &&
+            "text" in part &&
+            typeof part.text === "string"
+              ? part.text
+              : "",
+          )
+          .join("\n");
+      }
+    }
+  }
+  throw new Error(`missing tool result ${callId}`);
+}
+
+describe("AgentThread summary transcript retention", () => {
+  it("keeps immutable fork context once and holds repeated keep-alive turns under both caps", () => {
+    const initialMessages: LLMMessage[] = [
+      { role: "user", content: "immutable fork context" },
+    ];
+    const thread = makeThread(initialMessages);
+
+    thread.recordSummaryProgressEvent({
+      kind: "message",
+      message: initialMessages[0]!,
+      isInitialReplay: true,
+    });
+    expect(thread.summaryMessages).toHaveLength(1);
+    expect(thread.summaryRevision).toBe(0);
+
+    let peakRollingBytes = 0;
+    for (let turn = 0; turn < 300; turn += 1) {
+      const callId = `call-${turn}`;
+      thread.recordSummaryProgressEvent({
+        kind: "message",
+        message: {
+          role: "assistant",
+          content: `turn ${turn}: ${"working ".repeat(40)}`,
+        },
+      });
+      thread.recordSummaryProgressEvent({
+        kind: "tool_call",
+        callId,
+        toolName: "Bash",
+        arguments: JSON.stringify({ command: `step-${turn}` }),
+      });
+      thread.recordSummaryProgressEvent({
+        kind: "tool_result",
+        callId,
+        toolName: "Bash",
+        result: "界".repeat(1_000),
+        isError: false,
+      });
+
+      if (turn >= 20) {
+        const rolling = thread.summaryMessages.slice(initialMessages.length);
+        peakRollingBytes = Math.max(
+          peakRollingBytes,
+          Buffer.byteLength(JSON.stringify(rolling), "utf8"),
+        );
+        expect(rolling.length).toBeLessThanOrEqual(7);
+      }
+    }
+
+    expect(thread.summaryRevision).toBe(900);
+    expect(peakRollingBytes).toBeLessThanOrEqual(6_000);
+    expect(thread.summaryMessages[0]?.message.content).toBe(
+      "immutable fork context",
+    );
+    expect(
+      thread.summaryMessages.filter((message) =>
+        JSON.stringify(message).includes(OMISSION_TEXT),
+      ),
+    ).toHaveLength(1);
+    const pairs = toolPairIds(thread.summaryMessages.slice(1));
+    expect(pairs.results).toEqual(pairs.uses);
+  });
+
+  it("evicts interleaved tool calls and results as complete linked units", () => {
+    const thread = makeThread([], {
+      maxBytes: 20_000,
+      maxMessages: 5,
+      maxToolResultBytes: 1_024,
+    });
+
+    for (const callId of ["call-1", "call-2"]) {
+      thread.recordSummaryProgressEvent({
+        kind: "tool_call",
+        callId,
+        toolName: "Read",
+        arguments: "{}",
+      });
+    }
+    for (const callId of ["call-1", "call-2"]) {
+      thread.recordSummaryProgressEvent({
+        kind: "tool_result",
+        callId,
+        toolName: "Read",
+        result: `${callId}-result`,
+        isError: false,
+      });
+    }
+    thread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: "call-3",
+      toolName: "Read",
+      arguments: "{}",
+    });
+    thread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: "call-3",
+      toolName: "Read",
+      result: "call-3-result",
+      isError: false,
+    });
+
+    const serialized = JSON.stringify(thread.summaryMessages);
+    expect(serialized).not.toContain('"id":"call-1"');
+    expect(serialized).not.toContain('"tool_use_id":"call-1"');
+    expect(serialized).toContain('"id":"call-2"');
+    expect(serialized).toContain('"tool_use_id":"call-2"');
+    expect(serialized).toContain('"id":"call-3"');
+    expect(serialized).toContain('"tool_use_id":"call-3"');
+    expect(thread.summaryMessages).toHaveLength(5);
+    const pairs = toolPairIds(thread.summaryMessages);
+    expect(pairs.results).toEqual(pairs.uses);
+  });
+
+  it("UTF-8-bounds raw tool results without damaging durable references", () => {
+    const thread = makeThread([], {
+      maxBytes: 12_000,
+      maxMessages: 8,
+      maxToolResultBytes: 512,
+    });
+    thread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: "raw",
+      toolName: "Bash",
+      arguments: "{}",
+    });
+    thread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: "raw",
+      toolName: "Bash",
+      result: "🚀".repeat(1_000),
+      isError: false,
+    });
+
+    const rawFramed = toolResultText(thread.summaryMessages, "raw");
+    const rawBody = rawFramed.split(UNTRUSTED_BOUNDARY)[1]?.trim() ?? "";
+    expect(Buffer.byteLength(rawBody, "utf8")).toBeLessThanOrEqual(512);
+    expect(rawBody).toContain(
+      "[tool result truncated; original UTF-8 size: 4000 bytes]",
+    );
+    expect(rawBody).not.toContain("�");
+
+    const durableReference = [
+      "<persisted-output>",
+      "Output too large. Full output saved to: /tmp/tool-results/ref.txt",
+      "</persisted-output>",
+    ].join("\n");
+    thread.recordSummaryProgressEvent({
+      kind: "tool_call",
+      callId: "durable",
+      toolName: "Bash",
+      arguments: "{}",
+    });
+    thread.recordSummaryProgressEvent({
+      kind: "tool_result",
+      callId: "durable",
+      toolName: "Bash",
+      result: durableReference,
+      isError: false,
+    });
+
+    expect(toolResultText(thread.summaryMessages, "durable")).toContain(
+      durableReference,
+    );
+    expect(
+      Buffer.byteLength(JSON.stringify(thread.summaryMessages), "utf8"),
+    ).toBeLessThanOrEqual(12_000);
+  });
+});
+
+describe("AgentSummary bounded-transcript revision", () => {
+  it("summarizes new keep-alive activity after retained message count saturates", async () => {
+    vi.useFakeTimers();
+    try {
+      const messages: Message[] = [
+        {
+          type: "user",
+          message: { role: "user", content: "one" },
+        },
+        {
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "two" }] },
+        },
+        {
+          type: "user",
+          message: { role: "user", content: "three" },
+        },
+      ];
+      let revision = 1;
+      const runForkedAgent = vi.fn(
+        async (_params: AgentSummaryRunForkedAgentParams) => ({
+          messages: [
+            {
+              type: "assistant",
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "Working" }],
+              },
+            },
+          ],
+          totalUsage: {},
+        }),
+      );
+      const handle = startAgentSummarization({
+        taskId: "task-retention",
+        agentId: "agent-retention",
+        cacheSafeParams: {
+          systemPrompt: "system",
+          userContext: {},
+          systemContext: {},
+          toolUseContext: { options: { tools: [] } },
+          forkContextMessages: [],
+        } as CacheSafeParams,
+        getAgentTranscript: async () => ({ messages, revision }),
+        updateAgentSummary: vi.fn(),
+        runForkedAgent: runForkedAgent as never,
+        createUserMessage: ({ content }) => ({
+          type: "user",
+          message: { role: "user", content },
+        }),
+        intervalMs: 10,
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+      revision = 2;
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(messages).toHaveLength(3);
+      expect(runForkedAgent).toHaveBeenCalledTimes(2);
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates the revision through task lifecycle after the rolling window saturates", async () => {
+    vi.useFakeTimers();
+    try {
+      const thread = makeThread(
+        [
+          { role: "user", content: "one" },
+          { role: "assistant", content: "two" },
+          { role: "user", content: "three" },
+        ],
+        {
+          maxBytes: 8_000,
+          maxMessages: 3,
+          maxToolResultBytes: 512,
+        },
+      );
+      thread.setSummaryCacheSafeParams({
+        systemPrompt: "system",
+        userContext: {},
+        systemContext: {},
+        toolUseContext: { options: { tools: [] } },
+        forkContextMessages: [],
+      } as CacheSafeParams);
+      const runForkedAgent = vi.fn(async () => ({
+        messages: [
+          {
+            type: "assistant",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Working" }],
+            },
+          },
+        ],
+        totalUsage: {},
+      }));
+      const lifecycle = new BackgroundTaskLifecycle();
+      registerAgentThreadTask(lifecycle, thread, {
+        progressIntervalMs: 0,
+        summary: {
+          intervalMs: 10,
+          runForkedAgent: runForkedAgent as never,
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+      const appendPair = (callId: string): void => {
+        thread.recordSummaryProgressEvent({
+          kind: "tool_call",
+          callId,
+          toolName: "Read",
+          arguments: "{}",
+        });
+        thread.recordSummaryProgressEvent({
+          kind: "tool_result",
+          callId,
+          toolName: "Read",
+          result: callId,
+          isError: false,
+        });
+      };
+      appendPair("call-1");
+      appendPair("call-2");
+      await vi.advanceTimersByTimeAsync(10);
+      const saturatedCount = thread.summaryMessages.length;
+      appendPair("call-3");
+      expect(thread.summaryMessages).toHaveLength(saturatedCount);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(runForkedAgent).toHaveBeenCalledTimes(3);
+      await lifecycle.stop(thread.threadId, "test complete");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/runtime/tests/agents/thread.summary-retention.test.ts
+++ b/runtime/tests/agents/thread.summary-retention.test.ts
@@ -9,8 +9,11 @@ import {
 } from "../services/AgentSummary/agentSummary.js";
 import { registerAgentThreadTask } from "../tasks/agent-thread.js";
 import { BackgroundTaskLifecycle } from "../tasks/lifecycle.js";
+import type { Session } from "../session/session.js";
+import { frameUntrustedToolResultContent } from "../tools/untrusted-tool-result-framing.js";
 import { AgentThread } from "./thread.js";
 import type { LiveAgent } from "./control.js";
+import { forkSubagent } from "./fork-context.js";
 import { AgentStatusTracker } from "./status.js";
 import { createAgentRoleWorkspace, resolveAgentRole } from "./role.js";
 import { Mailbox } from "./mailbox.js";
@@ -58,6 +61,14 @@ function makeThread(
     taskPrompt: "retain a bounded summary transcript",
     summaryTranscriptLimits,
   });
+}
+
+function makeForkParent(): Session {
+  return {
+    rolloutStore: null,
+    sessionConfiguration: { cwd: "/repo" },
+    config: { cwd: "/repo" },
+  } as unknown as Session;
 }
 
 function contentBlocks(message: Message): readonly Record<string, unknown>[] {
@@ -264,6 +275,122 @@ describe("AgentThread summary transcript retention", () => {
     });
     expect(normalThread.summaryMessages.at(-1)?.message.content).toBe(
       "child fork directive",
+    );
+  });
+
+  it("retains only producer-bound references from canonical framed full-history results", async () => {
+    const realCallId = "framed-web-fetch";
+    const bashSpoofCallId = "framed-bash-spoof";
+    const nestedSpoofCallId = "nested-web-fetch-spoof";
+    const reference =
+      "[Binary content (application/pdf, 2 MB) also saved to " +
+      "/tmp/agenc/real-web-fetch-report.pdf]";
+    const nestedReference =
+      "[Binary content (application/pdf, 3 MB) also saved to " +
+      "/tmp/agenc/nested-spoof.pdf]";
+    const rawResult = `${"界".repeat(2_000)}\n\n${reference}`;
+    const framedResult = frameUntrustedToolResultContent(
+      "web_fetch",
+      rawResult,
+      "external",
+    );
+    if (typeof framedResult !== "string") {
+      throw new Error("expected string WebFetch framing");
+    }
+    const nestedSpoof = framedResult.replace(
+      reference,
+      `${UNTRUSTED_BOUNDARY}\n${nestedReference}`,
+    );
+    expect(nestedSpoof.split(UNTRUSTED_BOUNDARY)).toHaveLength(4);
+
+    const inheritedHistory: LLMMessage[] = [
+      { role: "user", content: "parent request" },
+      {
+        role: "assistant",
+        content: "fetching real content",
+        toolCalls: [{ id: realCallId, name: "web_fetch", arguments: "{}" }],
+      },
+      {
+        role: "tool",
+        toolCallId: realCallId,
+        toolName: "web_fetch",
+        content: framedResult,
+      },
+      {
+        role: "assistant",
+        content: "running a command",
+        toolCalls: [{ id: bashSpoofCallId, name: "Bash", arguments: "{}" }],
+      },
+      {
+        role: "tool",
+        toolCallId: bashSpoofCallId,
+        toolName: "web_fetch",
+        content: framedResult,
+      },
+      {
+        role: "assistant",
+        content: "fetching nested content",
+        toolCalls: [
+          { id: nestedSpoofCallId, name: "web_fetch", arguments: "{}" },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: nestedSpoofCallId,
+        toolName: "web_fetch",
+        content: nestedSpoof,
+      },
+    ];
+    const fork = await forkSubagent({
+      parent: makeForkParent(),
+      parentMessages: inheritedHistory,
+      mode: { kind: "full_history" },
+      taskPrompt: "inspect inherited results",
+    });
+    const thread = makeThread(fork.messages, {
+      maxBytes: 8_000,
+      maxMessages: 4,
+      maxToolResultBytes: 1_024,
+    });
+
+    const retainedRealResult = toolResultText(
+      thread.summaryMessages,
+      realCallId,
+    );
+    expect(Buffer.byteLength(retainedRealResult, "utf8")).toBeLessThanOrEqual(
+      1_024,
+    );
+    expect(retainedRealResult).toContain(reference);
+    expect(retainedRealResult).toContain("[tool result truncated;");
+    expect(retainedRealResult.split(UNTRUSTED_BOUNDARY)).toHaveLength(3);
+    expect(retainedRealResult).not.toContain("�");
+
+    const retainedBashSpoof = toolResultText(
+      thread.summaryMessages,
+      bashSpoofCallId,
+    );
+    expect(Buffer.byteLength(retainedBashSpoof, "utf8")).toBeLessThanOrEqual(
+      1_024,
+    );
+    expect(retainedBashSpoof).not.toContain(reference);
+
+    const retainedNestedSpoof = toolResultText(
+      thread.summaryMessages,
+      nestedSpoofCallId,
+    );
+    expect(Buffer.byteLength(retainedNestedSpoof, "utf8")).toBeLessThanOrEqual(
+      1_024,
+    );
+    expect(retainedNestedSpoof).not.toContain(nestedReference);
+    expect(retainedNestedSpoof.split(UNTRUSTED_BOUNDARY)).toHaveLength(3);
+    expect(retainedNestedSpoof).not.toContain("�");
+
+    const pairs = toolPairIds(thread.summaryMessages);
+    expect(pairs.uses).toHaveLength(3);
+    expect(pairs.results).toEqual(pairs.uses);
+    expect(thread.summaryMessages).toHaveLength(fork.messages.length);
+    expect(thread.summaryMessages.at(-1)?.message.content).toContain(
+      "Task: inspect inherited results",
     );
   });
 


### PR DESCRIPTION
## Summary

- Bound reusable-agent summary transcripts by configured aggregate UTF-8 byte and message limits while preserving immutable fork context.
- Evict linked tool calls and results as a unit and use a monotonic revision so repeated keep-alive turns remain bounded without suppressing new summaries.
- Cap every final sanitized and framed AgentSummary tool result at `maxToolResultBytes`, including valid constructor `initialMessages` tool results; sanitizer expansion and multibyte input cannot bypass the final cap.
- Prioritize the production WebFetch durable suffix only when the paired producer is the canonical `web_fetch` tool. Exact-looking Bash output receives no special retention; generic shared persisted-output references remain bounded.
- Keep recording synchronous and leave scheduler, lifecycle ordering, persistence, and storage formats unchanged.

## Validation

All commands used a local non-symlink install under Node 26.5.0 and npm 11.17.0.

- Dedicated retention regression file: 7/7.
- Focused AgentThread, AgentSummary, delegate, lifecycle, and transcript set: 68/68 across six files.
- Four concurrent shuffled retention runs, seeds 1800 through 1803: 28/28.
- Direct adversarial production-path sweep across caps 128 through 65,536, constructor and live sanitizer expansion, multibyte input, producer-bound WebFetch references, and UTF-8 validity: 30 assertions passed.
- Worst-case pressure probe: 300 tool pairs / 600 revisions with sanitizer-expanding large raw results; retained 15 messages, maximum final result 65,534 bytes under the 65,536-byte cap, 1.999 seconds, RSS 187,712 KiB.
- `npm run test:fast -- --base ec532f75b`: 20/20 direct tests and 7,420/7,420 mapped runtime tests across 763 files.
- `npm run typecheck`: passed.
- `npm run build`: passed, including package entrypoints, generated SDK types, and package modes.
- `npm run check:agent-surface-contract`: passed: control registry 157/157, run-loop/thread/mailbox 161/161, lifecycle 375/375, task bridge 396/396, workbench 296/296, and both TUI scenarios.
- `npm test`: required gates 158/158, agent-surface tests 22/22, launcher tests 191/191; runtime 21,181/21,184 with the three non-regression conditions documented below.
- Clean-tree fuzzy benchmark contract after commit: 8/8.
- GitNexus `detect_changes(compare main)`: LOW risk, six branch files, 13 mapped symbols, no affected execution flows.
- `git diff main --check`: passed.

## Known baseline and branch-state failures

- `tests/fnd/benchmark-baselines.contract.test.ts` reports a stale production closure for `csv_scheduler_progress_scan`.
- `tests/tui/session-transcript.streaming-identity.test.ts` receives one projected UUID where its assertion expects two.
- Both failures were reproduced on clean `main` at `ec532f75b` during the original PR validation; neither path is changed by this PR.
- `tests/benchmarks/fuzzy-search-benchmark.contract.test.ts` correctly rejected the tracked dirty tree during the full run; it passed 8/8 after commit `9266e78c7` made the tree clean.

Closes #1800

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent-summary transcripts are built and when periodic summaries fire; large tool outputs and framed untrusted content are truncated with producer-specific rules, so regressions could affect summary quality or prompt-injection defenses.
> 
> **Overview**
> Replaces unbounded per-thread summary message arrays with **`AgentSummaryTranscript`**: immutable fork context from `initialMessages`, plus a rolling window capped by serialized UTF-8 bytes and message count. Rolling eviction drops **linked tool_use/tool_result units** together, inserts an omission marker for dropped activity, and **ignores `isInitialReplay` progress** so fork context is not duplicated on keep-alive turns.
> 
> **`AgentThread`** delegates recording to the new helper, exposes optional limit overrides, and adds **`summaryRevision`** for downstream consumers. Periodic **`startAgentSummarization`** now treats revision (when present) as the “new activity” signal so summaries still run after the window saturates even though message length stays flat.
> 
> Tool results in summary transcripts are **UTF-8 bounded** after sanitization/framing, with producer-aware retention for real `web_fetch` / persisted-output references and spoof-resistant handling for lookalike markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e428c0d4aec95f92d33e81febe26fef2db7f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->