### PR TITLE
fix(runtime): use canonical MCP secret redaction

### DIFF
--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -16,7 +16,7 @@
  *     Canonical containment rejects symlink escapes, and `readResource`
  *     only serves URIs minted by a fresh listing — it never resolves
  *     client-supplied paths. Only the selected resource body is read,
- *     then its contents pass through the memory secret redactor.
+ *     then its contents pass through the canonical egress secret sanitizer.
  *
  * @module
  */
@@ -25,9 +25,9 @@ import { basename, isAbsolute, join, relative } from "node:path";
 
 import {
   detectSessionFileType,
-  redactSecrets,
   scanMemoryFiles,
 } from "../../memory/index.js";
+import { redactSecrets } from "../../secrets/sanitizer.js";
 import {
   parseBooleanFrontmatter,
   parseFrontmatter,

--- a/runtime/src/memory/privacy.ts
+++ b/runtime/src/memory/privacy.ts
@@ -29,6 +29,8 @@ import {
   windowsPathToPosixPath,
 } from '../utils/windowsPaths.js'
 
+export { redactSecrets } from '../secrets/sanitizer.js'
+
 type SecretRule = {
   id: string
   source: string
@@ -497,23 +499,6 @@ export function scanForSecrets(content: string): SecretMatch[] {
 
 export function getSecretLabel(ruleId: string): string {
   return ruleIdToLabel(ruleId)
-}
-
-let redactRules: RegExp[] | null = null
-
-/**
- * Redact matched secret spans while preserving surrounding boundary text.
- */
-export function redactSecrets(content: string): string {
-  redactRules ??= SECRET_RULES.map(
-    r => new RegExp(r.source, (r.flags ?? '').replace('g', '') + 'g'),
-  )
-  for (const re of redactRules) {
-    content = content.replace(re, (match, g1) =>
-      typeof g1 === 'string' ? match.replace(g1, '[REDACTED]') : '[REDACTED]',
-    )
-  }
-  return content
 }
 
 /**

--- a/runtime/tests/mcp-server/prompts-resources.test.ts
+++ b/runtime/tests/mcp-server/prompts-resources.test.ts
@@ -5,7 +5,7 @@
  * prompt, and reads a memory file as a resource; excluded/secret
  * content stays out.
  */
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +17,7 @@ import {
   createMemoryResourceProvider,
   createSkillPromptProvider,
 } from "../../src/mcp/server/content-providers.js";
+import { canonicalRedactionFixtures } from "../secrets/canonical-redaction-corpus.js";
 
 let root: string;
 
@@ -139,6 +140,17 @@ describe("MCP prompts backed by skills", () => {
 });
 
 describe("MCP resources backed by memory + instruction files", () => {
+  it("imports the canonical secret sanitizer for resource egress", async () => {
+    const source = await readFile(
+      new URL("../../src/mcp/server/content-providers.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      'import { redactSecrets } from "../../secrets/sanitizer.js";',
+    );
+  });
+
   async function makeResourceServer(
     readResourceContent?: (canonicalPath: string) => Promise<string>,
   ): Promise<{
@@ -227,6 +239,33 @@ describe("MCP resources backed by memory + instruction files", () => {
     expect(text).toContain("staging pipeline");
     expect(text).not.toContain("ghp_0123456789abcdef");
   });
+
+  it.each(canonicalRedactionFixtures)(
+    "applies canonical egress redaction to memory and instructions: $name",
+    async ({ input, expected, secretFragments, preservedFragments }) => {
+      const { server } = await makeResourceServer(async () => input);
+      await initialized(server);
+      const list = await request(server, "resources/list");
+
+      for (const name of ["deploy-notes.md", "AGENC.md"]) {
+        const resource = list.result.resources.find(
+          (candidate: any) => candidate.name === name,
+        );
+        const out = await request(server, "resources/read", {
+          uri: resource.uri,
+        });
+        const text = out.result.contents[0].text;
+
+        expect(text).toBe(expected);
+        for (const secret of secretFragments) {
+          expect(text).not.toContain(secret);
+        }
+        for (const preserved of preservedFragments) {
+          expect(text).toContain(preserved);
+        }
+      }
+    },
+  );
 
   it("rejects URIs it did not mint (path bounding)", async () => {
     const { server } = await makeResourceServer();

--- a/runtime/tests/memory/privacy.test.ts
+++ b/runtime/tests/memory/privacy.test.ts
@@ -149,7 +149,7 @@ describe('memory privacy', () => {
     )
   })
 
-  it('scans and redacts high-confidence memory secrets without returning values', () => {
+  it('keeps memory classification independent from canonical egress redaction', () => {
     installMemoryAuthority()
     const content = `token=${fakeGitHubPat}`
 
@@ -159,7 +159,7 @@ describe('memory privacy', () => {
     expect(scanForSecrets(`${content}\nagain=${fakeGitHubPat}`)).toHaveLength(1)
     // branding-scan: allow real provider display name
     expect(getSecretLabel('openai-api-key')).toBe('OpenAI API Key')
-    expect(redactSecrets(content)).toBe('token=[REDACTED]')
+    expect(redactSecrets(content)).toBe('token=[REDACTED_SECRET]')
     expect(redactSecrets(content)).not.toContain(fakeGitHubPat)
   })
 

--- a/runtime/tests/secrets/canonical-redaction-corpus.ts
+++ b/runtime/tests/secrets/canonical-redaction-corpus.ts
@@ -1,0 +1,56 @@
+export interface CanonicalRedactionFixture {
+  readonly name: string;
+  readonly input: string;
+  readonly expected: string;
+  readonly secretFragments: readonly string[];
+  readonly preservedFragments: readonly string[];
+}
+
+const marker = "[REDACTED_SECRET]";
+const xaiKey = `xai-${"A".repeat(24)}`;
+const bearerToken = "abc.DEF_ghi~jkl+/mnop=qrst";
+const walletKey = "3".repeat(88);
+
+export const canonicalRedactionFixtures = [
+  {
+    name: "xAI key beside punctuation",
+    input: `xAI=(${xaiKey}), keep`,
+    expected: `xAI=(${marker}), keep`,
+    secretFragments: [xaiKey],
+    preservedFragments: ["xAI=(", "), keep"],
+  },
+  {
+    name: "opaque bearer token beside punctuation",
+    input: `Authorization: Bearer ${bearerToken}; next`,
+    expected: `Authorization: Bearer ${marker}; next`,
+    secretFragments: [bearerToken],
+    preservedFragments: ["Authorization: Bearer ", "; next"],
+  },
+  {
+    name: "quoted assignment syntax",
+    input: 'config api_key = "opaque-value-12345", timeout=30',
+    expected: `config api_key = "${marker}", timeout=30`,
+    secretFragments: ["opaque-value-12345"],
+    preservedFragments: ['config api_key = "', '", timeout=30'],
+  },
+  {
+    name: "bare wallet key material",
+    input: `wallet (${walletKey}).`,
+    expected: `wallet (${marker}).`,
+    secretFragments: [walletKey],
+    preservedFragments: ["wallet (", ")."],
+  },
+  {
+    name: "ordinary token counters and public-key labels",
+    input:
+      "postCompactTokens=12345678; publicKey=ssh-rsa-example; meeting lasted forty minutes",
+    expected:
+      "postCompactTokens=12345678; publicKey=ssh-rsa-example; meeting lasted forty minutes",
+    secretFragments: [],
+    preservedFragments: [
+      "postCompactTokens=12345678",
+      "publicKey=ssh-rsa-example",
+      "meeting lasted forty minutes",
+    ],
+  },
+] as const satisfies readonly CanonicalRedactionFixture[];

--- a/runtime/tests/secrets/sanitizer.test.ts
+++ b/runtime/tests/secrets/sanitizer.test.ts
@@ -13,6 +13,7 @@ import {
   redactSecretsInValue,
   SecretName,
 } from "./index.js";
+import { canonicalRedactionFixtures } from "./canonical-redaction-corpus.js";
 
 const tempDirs: string[] = [];
 
@@ -29,6 +30,21 @@ afterEach(() => {
 });
 
 describe("secrets sanitizer", () => {
+  it.each(canonicalRedactionFixtures)(
+    "redacts canonical outbound text: $name",
+    ({ input, expected, secretFragments, preservedFragments }) => {
+      const redacted = redactSecrets(input);
+
+      expect(redacted).toBe(expected);
+      for (const secret of secretFragments) {
+        expect(redacted).not.toContain(secret);
+      }
+      for (const preserved of preservedFragments) {
+        expect(redacted).toContain(preserved);
+      }
+    },
+  );
+
   it("redacts common API keys and token forms", () => {
     const input = [
       "openai=sk-proj-abcdefghijklmnopqrstuvwxyz123456",


### PR DESCRIPTION
## Summary

- route MCP memory and instruction resource bodies through the canonical runtime secret sanitizer
- retain the memory privacy export as a compatibility alias while leaving memory secret classification rules independent
- test MCP egress against the shared canonical corpus for xAI keys, bearer tokens, assignment syntax, wallet material, punctuation, and false positives

## Validation

- Node 26.5.0 and npm 11.17.0
- focused MCP, secret, and memory tests: 8 files passed, 67 tests passed
- pre-fix regression proof: the new MCP corpus produced four failures for xAI, bearer, assignment, and wallet secrets
- clean-commit fuzzy benchmark contract: 1 file passed, 8 tests passed
- `npm run typecheck`: passed
- `npm run build`: passed, including the generated SDK type check
- `npm test`: required gates 158/158, agent surface 22/22, launcher 191/191, runtime 21,186 passed and 2 failed
- both runtime failures reproduce on unchanged `main`: stale `csv_scheduler_progress_scan` production closure in `benchmark-baselines.contract.test.ts`, and missing `id:err:1` in `session-transcript.streaming-identity.test.ts`
- GitNexus `detect_changes` against `main`: LOW risk, 6 changed files, 3 mapped test symbols, 0 affected processes
- `git diff --check`: passed

Closes #1795

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret handling on MCP egress paths where sensitive memory/instruction content could leak to external clients; behavior is intentionally stricter and broader than the old memory-only redactor.
> 
> **Overview**
> MCP **memory and instruction** resource bodies (`resources/read`) now run through **`redactSecrets` from `secrets/sanitizer`** instead of the memory-local redactor, so outbound MCP text uses the same egress rules and **`[REDACTED_SECRET]`** marker as the rest of the runtime.
> 
> **`memory/privacy`** drops its duplicate `redactSecrets` implementation and **re-exports** the canonical sanitizer for compatibility; **`scanForSecrets`** and team-memory write blocking stay on the memory rule set and are unchanged in purpose.
> 
> Tests add a **shared `canonical-redaction-corpus`** (xAI keys, bearer tokens, quoted assignments, wallet material, false positives) and wire it into **MCP resource** and **sanitizer** suites, plus a source check that `content-providers` imports the canonical module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9b90252b3a85665d260fecf6a06410cfd336be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->