### PR TITLE
test(tui): a bare session error no longer fans out to two messages

### DIFF
--- a/runtime/tests/tui/session-transcript.streaming-identity.test.ts
+++ b/runtime/tests/tui/session-transcript.streaming-identity.test.ts
@@ -102,12 +102,18 @@ describe("session transcript streaming identity (M-TUI-1)", () => {
   });
 
   test("one event fanning out to several messages gets collision-free per-event block indices", () => {
-    // An `error` event mid-stream projects TWO messages from the same source
-    // event: the error row itself and the preserved partial assistant text.
+    // A terminal `error` event mid-stream projects TWO messages from the same
+    // source event: the error row itself and the preserved partial assistant
+    // text. Only the daemon's terminal marker ends the turn; a bare session
+    // error is diagnostic and leaves the stream open (#1978), so it projects
+    // one row and keeps the partial text in the accumulator.
     const events = [
       { id: "turn", msg: { type: "turn_started", payload: { turnId: "t1" } } } as never,
       deltaEvent("delta-0", "partial "),
-      { id: "err", msg: { type: "error", payload: { message: "boom" } } } as never,
+      {
+        id: "err",
+        msg: { type: "error", payload: { message: "boom", terminal: true } },
+      } as never,
     ];
 
     const first = adaptTranscriptEvents(events);


### PR DESCRIPTION
## Why

\`tests/tui/session-transcript.streaming-identity.test.ts > one event fanning out to several messages gets collision-free per-event block indices\` has been red on main since #1978 landed.

#1978 made only a terminal daemon error end the turn and persist the partial assistant text; a raw session error is diagnostic and leaves the stream open. The fixture still used a bare \`error\` event and expected two projected messages, so it fails on a clean checkout of main:

\`\`\`
AssertionError: expected [ 'id:err:0' ] to deeply equal [ 'id:err:0', 'id:err:1' ]
\`\`\`

Because \`pr-fast\` only runs on pull requests, main itself never reports it. Any PR whose diff reaches the TUI transcript through the importer graph inherits the red (#2002 does).

## What

Mark the fixture's error \`terminal: true\` so it exercises the fan-out it was written for, and say why in the comment. No production code changes.

## Check

\`\`\`
node runtime/scripts/run-hermetic-vitest.mjs run tests/tui/session-transcript.streaming-identity.test.ts tests/tui/session-transcript.error-ends-turn.test.ts
Test Files  2 passed (2)   Tests  12 passed (12)
\`\`\`