### PR TITLE
daemon: bounded session snapshots, lease-aware archiving, live-source reads, slow store op visibility

### DIFF
--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -736,15 +736,24 @@ export class AgenCDaemonAgentManager {
           resumeProof,
           this.#agencHome,
         );
-        if (
-          retainedAgent?.objective !== undefined &&
-          retainedAgent.objective !== resumeProof.objective
-        ) {
-          throw new AgenCDaemonAgentLifecycleError(
-            "INVALID_ARGUMENT",
-            `canonical session ${resumeSessionId} retained objective disagrees with the rollout`,
-          );
-        }
+        /*
+         * The retained objective is NOT a session identity. A client that
+         * defers the initial turn (every interactive session: the desktop
+         * app, `agenc` itself) passes a label like "Interactive session"
+         * while the rollout's canonical objective is whatever the user
+         * typed first, so the two never agree and strict equality refused
+         * 100% of legitimate interactive resumes — the same failure shape
+         * as the retained `createdAt` equality fixed in #1750. The label is
+         * disposable either way: a successful resume replaces it with
+         * `resumeProof.objective` a few lines below.
+         *
+         * A rollout swapped in from another session is still refused, by
+         * evidence rather than by label: the path must live under
+         * `sessions/<resumeSessionId>/` and its filename must end in
+         * `-<resumeSessionId>.jsonl`, the caller's dev/ino/size/sha256
+         * proof is revalidated here against the real file, and the journal
+         * is validated with `expectedRunId` set to this session id.
+         */
         if (
           retainedAgent?.createdAt !== undefined &&
           !retainedCreatedAtMatchesRollout(

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -4208,6 +4208,13 @@ function interactivePermissionModeFromRuntimeSettings(
   return mode;
 }
 
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.length > 0 ? error.message : error.name;
+  }
+  return String(error);
+}
+
 function assertCanonicalRuntimeSettingsProjection(
   cwd: string,
   runId: string,
@@ -4216,10 +4223,13 @@ function assertCanonicalRuntimeSettingsProjection(
   let driver: ReturnType<typeof openStateDatabases>;
   try {
     driver = openStateDatabases({ cwd });
-  } catch {
+  } catch (error) {
+    // Say why. A live resume failed for an hour with this sentence and
+    // nothing else; the cause (a locked database, a schema mismatch, a bad
+    // cwd) is what the operator needs to see.
     throw new AgenCDaemonAgentLifecycleError(
       "INVALID_ARGUMENT",
-      `canonical session ${runId} runtime settings projection is unavailable`,
+      `canonical session ${runId} runtime settings projection is unavailable: ${describeError(error)}`,
     );
   }
   let projected: ReturnType<
@@ -4242,7 +4252,7 @@ function assertCanonicalRuntimeSettingsProjection(
   if (primaryError !== undefined) {
     throw new AgenCDaemonAgentLifecycleError(
       "INVALID_ARGUMENT",
-      `canonical session ${runId} runtime settings projection could not be verified`,
+      `canonical session ${runId} runtime settings projection could not be verified: ${describeError(primaryError)}`,
     );
   }
   if (projected === undefined) {

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -734,6 +734,7 @@ export class AgenCDaemonAgentManager {
           cwd,
           resumeSessionId,
           resumeProof,
+          this.#agencHome,
         );
         if (
           retainedAgent?.objective !== undefined &&
@@ -4215,14 +4216,19 @@ function describeError(error: unknown): string {
   return String(error);
 }
 
-function assertCanonicalRuntimeSettingsProjection(
+export function assertCanonicalRuntimeSettingsProjection(
   cwd: string,
   runId: string,
   proof: ResumeSourceProof,
+  agencHome: string,
 ): void {
   let driver: ReturnType<typeof openStateDatabases>;
   try {
-    driver = openStateDatabases({ cwd });
+    // The daemon's home is passed explicitly. Resolving it through the
+    // ambient current-session accessor refused with "Ambiguous runtime
+    // session" as soon as more than one session lived in the daemon, so no
+    // session could be resumed after a restart while others were open.
+    driver = openStateDatabases({ cwd, agencHome });
   } catch (error) {
     // Say why. A live resume failed for an hour with this sentence and
     // nothing else; the cause (a locked database, a schema mismatch, a bad

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -3243,7 +3243,7 @@ async function runAgenCDaemonForegroundLocked(
       runner,
       startupRecovery,
       {
-        recordReplayToolResult: (result) =>
+        recordReplayToolResult: (result) => {
           snapshotPolicies.recordSessionEvent(result.sessionId, {
             method: "event.session_event",
             params: {
@@ -3266,7 +3266,13 @@ async function runAgenCDaemonForegroundLocked(
                 },
               },
             },
-          }),
+          });
+          // A recovery outcome is written at once. The replay or poison of a
+          // stale tool call is a startup event, not part of a live tool
+          // burst: the latest snapshot must show it the moment the call's
+          // in-flight row turns terminal, not after the coalesce window.
+          snapshotPolicies.flushSession(result.sessionId);
+        },
       },
     );
     if (host.startupGuardReceiver?.wasRequested() === true) return 1;
@@ -4374,6 +4380,9 @@ class AgenCDaemonSnapshotPolicyRegistry {
   }
 
   hydrateStartupRecovery(report: DaemonStartupRecoveryReport): void {
+    const reconciledSessionIds = new Set(
+      report.recoveredToolCalls.map((call) => call.sessionId),
+    );
     for (const run of report.recoveredRuns) {
       if (run.currentSessionId === undefined) continue;
       const policy = this.#policyForProjectDir(run.projectDir);
@@ -4387,6 +4396,14 @@ class AgenCDaemonSnapshotPolicyRegistry {
           toolState: run.latestSnapshot.toolState,
           mcpConnectionState: run.latestSnapshot.mcpConnectionState,
         });
+        // Startup recovery reconciled this session's stale tool calls
+        // (replayed, poisoned or cancelled) into the hydrated state: write
+        // that outcome now, before the daemon advertises readiness, instead
+        // of leaving it to the first periodic tick. A session recovery left
+        // untouched keeps its rows exactly as startup pruning left them.
+        if (reconciledSessionIds.has(run.currentSessionId)) {
+          policy.policy.flushSession(run.currentSessionId);
+        }
       }
     }
   }
@@ -4445,6 +4462,12 @@ class AgenCDaemonSnapshotPolicyRegistry {
   recordSessionEvent(sessionId: string, event: JsonObject): void {
     const entry = this.#policyForSession(sessionId);
     entry.policy.recordSessionEvent(sessionId, event);
+  }
+
+  /** Write the session's snapshot now if it has unflushed changes. */
+  flushSession(sessionId: string): void {
+    const entry = this.#policyForSession(sessionId);
+    entry.policy.flushSession(sessionId);
   }
 
   registerSession(session: AgenCDaemonSnapshotSessionRoute): void {

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -4413,6 +4413,12 @@ class AgenCDaemonSnapshotPolicyRegistry {
       this.#periodicTimer = undefined;
     }
     for (const entry of this.#policies.values()) {
+      // Flush dirty sessions synchronously before the state DB goes away.
+      try {
+        entry.policy.close();
+      } catch (error) {
+        this.#onError(error);
+      }
       entry.driver.close();
     }
     for (const store of this.#threadStores.values()) {
@@ -4492,6 +4498,11 @@ class AgenCDaemonSnapshotPolicyRegistry {
       eventId: terminal.eventId,
     });
     hitM4DurabilityFailpoint("after_terminal_commit");
+    // The run is over: land any unflushed snapshot state and stop tracking
+    // the session in memory, so it neither rides the periodic tick nor holds
+    // its conversation tail until the LRU cap (1,024 sessions) evicts it.
+    entry.policy.flushSession(terminal.sessionId);
+    entry.policy.forgetSession(terminal.sessionId);
   }
 
   threadStoreForAgentLogs(

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -156,8 +156,10 @@ import {
   type ToolRecoveryAction,
 } from "../state/recovery.js";
 import {
+  pruneSessionSnapshotsPerSession,
   pruneSessionStateSnapshots,
   pruneTerminalAgentRuns,
+  SESSION_SNAPSHOT_HARD_CAP,
   type RolloutRetentionPolicy,
 } from "../state/pruning.js";
 import { StateSqliteHealthStatsReader } from "../state/health-stats.js";
@@ -2924,6 +2926,7 @@ async function runAgenCDaemonForegroundLocked(
       authStartup.daemonHome,
       process.cwd(),
       activeConfig,
+      (message) => io.stderr.write(`agenc: ${message}\n`),
     );
     reportAgenCDaemonStartupRecovery(io, startupRecovery);
     writeAgenCDaemonStartupDebug(
@@ -3078,6 +3081,7 @@ async function runAgenCDaemonForegroundLocked(
           io.stderr.write(
             `agenc: daemon snapshot policy failed: ${formatCleanupError(error)}\n`,
           ),
+        log: (message) => io.stderr.write(`agenc: ${message}\n`),
       });
     } catch (error) {
       io.stderr.write(
@@ -3085,6 +3089,11 @@ async function runAgenCDaemonForegroundLocked(
       );
       return 1;
     }
+    // The resolved retention was previously invisible: the live daemon grew a
+    // 1.3 GB snapshot table without one log line saying which caps applied.
+    io.stderr.write(
+      `agenc: daemon snapshot retention ${describeSnapshotRetention(activeConfig.agent?.retention)}\n`,
+    );
     cleanup.register("daemon-snapshot-policy", async () => {
       snapshotPolicies.close();
     });
@@ -4083,10 +4092,26 @@ async function closeDaemonMcpServerAfterReloadFailure(
   }
 }
 
+function describeSnapshotRetention(
+  retention: AgentRunRetentionConfig | undefined,
+): string {
+  const configured =
+    retention === undefined
+      ? "unconfigured"
+      : `snapshot_days=${retention.snapshot_days ?? "off"} ` +
+        `snapshot_max_count=${retention.snapshot_max_count ?? "off"} ` +
+        `snapshot_max_bytes=${retention.snapshot_max_bytes ?? "off"} ` +
+        `completed_days=${retention.completed_days ?? "off"} ` +
+        `failed_days=${retention.failed_days ?? "off"} ` +
+        `rollout_days=${retention.rollout_days ?? "off"}`;
+  return `${configured} (hard cap ${SESSION_SNAPSHOT_HARD_CAP} rows per session)`;
+}
+
 function recoverAgenCDaemonStartupState(
   daemonHome: string,
   cwd: string,
   config: AgenCConfig,
+  log: (message: string) => void = () => {},
 ): DaemonStartupRecoveryReport {
   const recoveredAt = new Date().toISOString();
   const paths = discoverAgenCDaemonStateDatabasePaths(daemonHome, cwd);
@@ -4101,8 +4126,31 @@ function recoverAgenCDaemonStartupState(
     for (const pathSet of paths) {
       const driver = openStateDatabasePaths(pathSet);
       try {
-        pruneTerminalAgentRuns(driver, config.agent?.retention);
-        pruneSessionStateSnapshots(driver, config.agent?.retention);
+        const prunedRuns = pruneTerminalAgentRuns(
+          driver,
+          config.agent?.retention,
+        );
+        // Per-session hard cap first, so the table-wide agent-grouped sweep
+        // below only measures the rows that survive it.
+        const prunedPerSession = pruneSessionSnapshotsPerSession(
+          driver,
+          config.agent?.retention,
+        );
+        const prunedTable = pruneSessionStateSnapshots(
+          driver,
+          config.agent?.retention,
+        );
+        const prunedSnapshots =
+          prunedRuns.prunedSnapshots +
+          prunedPerSession.prunedSnapshots +
+          prunedTable.prunedSnapshots;
+        if (prunedRuns.prunedRuns > 0 || prunedSnapshots > 0) {
+          log(
+            `daemon retention pruned ${prunedRuns.prunedRuns} terminal run(s) and ` +
+              `${prunedSnapshots} snapshot row(s) across ` +
+              `${new Set([...prunedRuns.prunedSessionIds, ...prunedPerSession.prunedSessionIds, ...prunedTable.prunedSessionIds]).size} session(s) in ${pathSet.projectDir}`,
+          );
+        }
         const report = recoverDaemonStateOnStartup(driver, {
           now: () => recoveredAt,
           retainRuntimeResumeSources: true,
@@ -4282,6 +4330,7 @@ interface AgenCDaemonSnapshotPolicyRegistryOptions {
   readonly snapshotRetention?: AgentRunRetentionConfig;
   readonly periodicIntervalMs?: number;
   readonly onError: (error: unknown) => void;
+  readonly log?: (message: string) => void;
 }
 
 interface AgenCDaemonSnapshotPolicyEntry {
@@ -4295,6 +4344,7 @@ class AgenCDaemonSnapshotPolicyRegistry {
   #snapshotRetention: AgentRunRetentionConfig | undefined;
   readonly #periodicIntervalMs: number;
   readonly #onError: (error: unknown) => void;
+  readonly #log: (message: string) => void;
   readonly #policies = new Map<string, AgenCDaemonSnapshotPolicyEntry>();
   readonly #sessionPolicyKeys = new Map<string, string>();
   readonly #threadStores = new Map<string, FileThreadStore>();
@@ -4306,6 +4356,7 @@ class AgenCDaemonSnapshotPolicyRegistry {
     this.#snapshotRetention = options.snapshotRetention;
     this.#periodicIntervalMs = options.periodicIntervalMs ?? 30_000;
     this.#onError = options.onError;
+    this.#log = options.log ?? (() => {});
     this.#policyForCwd(this.#defaultCwd);
   }
 
@@ -4583,6 +4634,11 @@ class AgenCDaemonSnapshotPolicyRegistry {
       rolloutRetention: rolloutRetentionPolicy(this.#snapshotRetention),
       rolloutSessionsDir: join(paths.projectDir, "sessions"),
       onError: this.#onError,
+      onPruneReport: (report) =>
+        this.#log(
+          `daemon snapshot retention pruned ${report.prunedSnapshots} row(s) ` +
+            `across ${report.prunedSessionIds.length} session(s) in ${paths.projectDir}`,
+        ),
     });
     const entry = { driver, policy };
     this.#policies.set(paths.stateDbPath, entry);

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -4135,8 +4135,9 @@ function recoverAgenCDaemonStartupState(
     for (const pathSet of paths) {
       const driver = openStateDatabasePaths(pathSet);
       try {
+        const walPath = `${pathSet.stateDbPath}-wal`;
         log(
-          `daemon opened state DB ${pathSet.stateDbPath} (${describeFileSizeMb(pathSet.stateDbPath)}, wal ${describeFileSizeMb(`${pathSet.stateDbPath}-wal`)})`,
+          `daemon opened state DB ${pathSet.stateDbPath} (${describeFileSizeMb(pathSet.stateDbPath)}, wal ${describeFileSizeMb(walPath)})`,
         );
         const prunedRuns = pruneTerminalAgentRuns(
           driver,

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -16,6 +16,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  statSync,
 } from "node:fs";
 import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection, isIP } from "node:net";
@@ -4092,6 +4093,14 @@ async function closeDaemonMcpServerAfterReloadFailure(
   }
 }
 
+function describeFileSizeMb(path: string): string {
+  try {
+    return `${(statSync(path).size / 1_048_576).toFixed(1)} MB`;
+  } catch {
+    return "absent";
+  }
+}
+
 function describeSnapshotRetention(
   retention: AgentRunRetentionConfig | undefined,
 ): string {
@@ -4126,6 +4135,9 @@ function recoverAgenCDaemonStartupState(
     for (const pathSet of paths) {
       const driver = openStateDatabasePaths(pathSet);
       try {
+        log(
+          `daemon opened state DB ${pathSet.stateDbPath} (${describeFileSizeMb(pathSet.stateDbPath)}, wal ${describeFileSizeMb(`${pathSet.stateDbPath}-wal`)})`,
+        );
         const prunedRuns = pruneTerminalAgentRuns(
           driver,
           config.agent?.retention,

--- a/runtime/src/app-server/run-inspection.ts
+++ b/runtime/src/app-server/run-inspection.ts
@@ -1296,7 +1296,14 @@ function refreshRunJournalProjection(
 ): void {
   const driver = openStateDatabasePaths(paths);
   try {
-    recoverCanonicalRunJournalForRun(driver, runId);
+    // run.status/run.replay on a run this daemon is executing find the rollout
+    // lease held by the live writer. That is not a recovery failure: serve
+    // the projection as it stands and persist no deferral, since an active
+    // run_recovery_deferred row would exclude the run from recovery at the
+    // next daemon start ("pending operator recovery action").
+    recoverCanonicalRunJournalForRun(driver, runId, {
+      strict: { liveSourceDeferral: "skip" },
+    });
   } finally {
     driver.close();
   }

--- a/runtime/src/conversation/thread-manager.ts
+++ b/runtime/src/conversation/thread-manager.ts
@@ -39,7 +39,11 @@ import type { IndexSnapshot } from "../session/session-store.js";
 import { SessionLock } from "../session/session-store.js";
 import type { ResponseItem, RolloutItem } from "../session/rollout-item.js";
 import type { LLMContentPart } from "../llm/types.js";
-import { responseItemToLlmMessage } from "../session/message-history-conversion.js";
+import {
+  llmMessageToDurableResponseItem,
+  responseItemToLlmMessage,
+} from "../session/message-history-conversion.js";
+import { createToolResultIntegrity } from "../session/tool-result-integrity.js";
 import { AsyncLock } from "../utils/async-lock.js";
 import {
   reconstructFromRollout,
@@ -363,6 +367,7 @@ export class ConversationThreadManager extends ThreadManager {
     session.seedInternalSubId(
       highestInternalSubId(rolloutItems, session.conversationId) + 1,
     );
+    appliedState = await closeTrailingDanglingToolCalls(session, appliedState);
 
     // GOAL #4b Stage 1 — stash the reconstruction so the prewarm hook can
     // consult its `resumableTurns` and resume-continue an orphaned in-flight
@@ -650,6 +655,110 @@ export class ConversationThreadManager extends ThreadManager {
     }
     return undefined;
   }
+}
+
+export const DANGLING_TOOL_CALLS_CLOSED_CAUSE = "dangling_tool_calls_closed";
+
+/**
+ * Tool calls of the last assistant message that never received a result.
+ * A turn killed between the model's tool calls and their results (daemon
+ * restart, crash) leaves the persisted history ending in open calls; the live
+ * tool-pair gate then rejects every later message ("tool results must
+ * immediately follow their assistant calls"), so the session can never
+ * continue. Only the trailing assistant message is inspected: an unresolved
+ * call earlier in the history is already an invalid rollout.
+ */
+export function trailingDanglingToolCalls(
+  history: ReadonlyArray<unknown>,
+): ReadonlyArray<{ readonly id: string; readonly name: string }> {
+  const items = history.map(historyResponseItem);
+  const resolved = new Set<string>();
+  let index = items.length - 1;
+  while (index >= 0 && items[index]?.role === "tool") {
+    const toolCallId = items[index]?.toolCallId;
+    if (typeof toolCallId === "string") resolved.add(toolCallId);
+    index -= 1;
+  }
+  const assistant = items[index];
+  if (assistant?.role !== "assistant" || !Array.isArray(assistant.toolCalls)) {
+    return [];
+  }
+  return assistant.toolCalls
+    .filter((call) => !resolved.has(call.id))
+    .map((call) => ({ id: call.id, name: call.name }));
+}
+
+function historyResponseItem(item: unknown): ResponseItem | undefined {
+  if (typeof item !== "object" || item === null) return undefined;
+  const role = (item as { role?: unknown }).role;
+  return typeof role === "string" ? (item as ResponseItem) : undefined;
+}
+
+/** Model-facing body of a result synthesized for an interrupted tool call. */
+export function interruptedToolCallResultContent(call: {
+  readonly id: string;
+  readonly name: string;
+}): string {
+  return JSON.stringify({
+    tool_use_id: call.id,
+    is_error: true,
+    content: `<tool_use_error>interrupted: the runtime restarted before ${call.name} completed and no result was recorded; call it again if the result is still needed</tool_use_error>`,
+  });
+}
+
+/**
+ * Close the trailing dangling tool calls of a restored history with sealed,
+ * persisted error results so the resumed session can accept its next message.
+ * The results are sealed under the session's run id exactly like live tool
+ * results (`createToolResultIntegrity` + the durable projection), appended to
+ * the rollout through the live tool-pair gate, which resolves the open calls,
+ * and mirrored into the session history in the persisted item shape.
+ */
+async function closeTrailingDanglingToolCalls(
+  session: Session,
+  appliedState: SessionState,
+): Promise<SessionState> {
+  const dangling = trailingDanglingToolCalls(appliedState.history);
+  if (dangling.length === 0) return appliedState;
+  const synthesized: ResponseItem[] = dangling.map((call) => {
+    const content = interruptedToolCallResultContent(call);
+    return llmMessageToDurableResponseItem({
+      role: "tool",
+      content,
+      toolCallId: call.id,
+      toolName: call.name,
+      runtimeOnly: {
+        toolResultIntegrity: createToolResultIntegrity({
+          runId: session.conversationId,
+          toolCallId: call.id,
+          content,
+        }),
+      },
+    });
+  });
+  for (const item of synthesized) {
+    session.rolloutStore?.appendRollout({ type: "response_item", payload: item });
+  }
+  const next = await session.state.update((current) => {
+    const updated: SessionState = {
+      ...current,
+      history: [...current.history, ...synthesized],
+    };
+    return { next: updated, result: updated };
+  });
+  session.emit({
+    id: session.nextInternalSubId(),
+    msg: {
+      type: "warning",
+      payload: {
+        cause: DANGLING_TOOL_CALLS_CLOSED_CAUSE,
+        message: `closed ${dangling.length} tool call(s) left without a result by an interrupted turn: ${dangling
+          .map((call) => `${call.name} ${call.id}`)
+          .join(", ")}`,
+      },
+    },
+  });
+  return next;
 }
 
 async function applyRolloutReconstructionToSession(

--- a/runtime/src/conversation/thread-manager.ts
+++ b/runtime/src/conversation/thread-manager.ts
@@ -357,6 +357,12 @@ export class ConversationThreadManager extends ThreadManager {
     session.rolloutStore?.acknowledgeCompactionReconstruction(
       reconstruction.activeCompactionAttemptIds,
     );
+    // The durable journal already holds turn and event ids up to the
+    // highest sub-id in the rollout; the resumed session must number its
+    // new turns after them or admission rejects the first model step.
+    session.seedInternalSubId(
+      highestInternalSubId(rolloutItems, session.conversationId) + 1,
+    );
 
     // GOAL #4b Stage 1 — stash the reconstruction so the prewarm hook can
     // consult its `resumableTurns` and resume-continue an orphaned in-flight
@@ -1368,4 +1374,34 @@ function cloneResponseHistory(
 
 function cloneLlmHistory(history: ReadonlyArray<ResponseItem>) {
   return history.map(responseItemToLlmMessage);
+}
+
+/**
+ * Highest `sub-<conversationId>-N` id recorded in a rollout, from event ids
+ * and turn ids alike; -1 when none. Ids of other conversations are ignored.
+ */
+export function highestInternalSubId(
+  rolloutItems: ReadonlyArray<RolloutItem>,
+  conversationId: string,
+): number {
+  const prefix = `sub-${conversationId}-`;
+  let highest = -1;
+  const consider = (value: unknown): void => {
+    if (typeof value !== "string" || !value.startsWith(prefix)) return;
+    const ordinal = Number(value.slice(prefix.length));
+    if (Number.isSafeInteger(ordinal) && ordinal > highest) highest = ordinal;
+  };
+  for (const item of rolloutItems) {
+    if (item.type !== "event_msg") continue;
+    const payload = item.payload as {
+      readonly id?: unknown;
+      readonly msg?: { readonly payload?: unknown };
+    };
+    consider(payload.id);
+    const inner = payload.msg?.payload;
+    if (inner !== null && typeof inner === "object") {
+      consider((inner as { readonly turnId?: unknown }).turnId);
+    }
+  }
+  return highest;
 }

--- a/runtime/src/conversation/thread-manager.ts
+++ b/runtime/src/conversation/thread-manager.ts
@@ -367,7 +367,11 @@ export class ConversationThreadManager extends ThreadManager {
     session.seedInternalSubId(
       highestInternalSubId(rolloutItems, session.conversationId) + 1,
     );
-    appliedState = await closeTrailingDanglingToolCalls(session, appliedState);
+    appliedState = await closeTrailingDanglingToolCalls(
+      session,
+      appliedState,
+      opts.emitSynthesized === true,
+    );
 
     // GOAL #4b Stage 1 — stash the reconstruction so the prewarm hook can
     // consult its `resumableTurns` and resume-continue an orphaned in-flight
@@ -717,6 +721,7 @@ export function interruptedToolCallResultContent(call: {
 async function closeTrailingDanglingToolCalls(
   session: Session,
   appliedState: SessionState,
+  emitWarning: boolean,
 ): Promise<SessionState> {
   const dangling = trailingDanglingToolCalls(appliedState.history);
   if (dangling.length === 0) return appliedState;
@@ -746,6 +751,10 @@ async function closeTrailingDanglingToolCalls(
     };
     return { next: updated, result: updated };
   });
+  // Like the other synthesized recovery events, the warning is emitted only
+  // when the caller replays with `emitSynthesized`: a bootstrap replay that
+  // has not seeded the live event sequence yet must not append events.
+  if (!emitWarning) return next;
   session.emit({
     id: session.nextInternalSubId(),
     msg: {

--- a/runtime/src/permissions/settings.ts
+++ b/runtime/src/permissions/settings.ts
@@ -58,6 +58,7 @@ import {
   authorizeBypassPermissionsConsent,
   canonicalizeBypassPermissionsCwd,
   loadBypassPermissionsConsent,
+  recordBypassPermissionsConsent,
 } from "./bypass-consent-state.js";
 
 // ─────────────────────────────────────────────────────────────────────
@@ -972,6 +973,26 @@ export async function initializeToolPermissionContext(
           opts.permissionMode === "bypassPermissions");
       if (explicitStartupBypass) {
         ctx = authorizeBypassPermissionsConsent(ctx, canonicalCwd);
+        // The operator chose bypass for this exact cwd at startup (the CLI
+        // flag or a client's permissionMode). Record that consent durably,
+        // the way the /permissions command does: a session restored after a
+        // daemon restart is refused with "restored bypass permission mode
+        // requires persisted exact-cwd consent" when only the in-memory
+        // authorization existed. Persistence failing never blocks startup.
+        if (!untrustedProject && canonicalEnv.configStore !== undefined) {
+          try {
+            recordBypassPermissionsConsent(
+              canonicalEnv.configStore.stateRepository,
+              canonicalCwd,
+            );
+          } catch (error) {
+            warnings.push(
+              `Bypass permissions consent could not be persisted for ${canonicalCwd}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
+        }
       } else if (
         !untrustedProject &&
         canonicalEnv.configStore !== undefined

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -669,37 +669,10 @@ function scanCanonicalRolloutUntimed(
     ) {
       latestCommittedAttempt.laterWork = true;
     }
-    for (const attempt of attempts.values()) {
-      if (attempt.intent === undefined) {
-        throw new Error(
-          "canonical compaction intent did not reconstruct its source manifests",
-        );
-      }
-      if (
-        attempt.persistedIntent !== undefined &&
-        attempt.sourceHistoryValidated !== true &&
-        !attempt.records.some(
-          (record) => record.item.type === "compaction_source_release",
-        )
-      ) {
-        throw new Error(
-          "canonical compaction source history is missing without a durable release",
-        );
-      }
-    }
+    assertAttemptsReconstructed(attempts);
 
     checkOperationalBudget();
-    const sourceLines = new Set(options.additionalSourceLines ?? []);
-    for (const attempt of attempts.values()) {
-      for (const ref of attempt.intent!.source.active_history_refs) {
-        sourceLines.add(ref.first_sequence);
-      }
-    }
-    if (options.captureActiveHistory === true) {
-      for (const position of activePositions) {
-        sourceLines.add(position.lineNumber);
-      }
-    }
+    const sourceLines = collectSourceLines(options, attempts, activePositions);
     const sourceRecords = new Map<number, CanonicalRolloutSourceRecord>();
     const payloadRecordsAtAttempts = new Map<
       string,
@@ -1011,6 +984,57 @@ function persistedRollbackPayload(
   )
     return undefined;
   return readCompactionPersistedRollbackCommittedV1(payload);
+}
+
+/**
+ * Every retained attempt must have rebuilt its intent from the payload
+ * bundle and either validated its source history or released it durably.
+ */
+function assertAttemptsReconstructed(
+  attempts: ReadonlyMap<string, MutableAttemptScan>,
+): void {
+  for (const attempt of attempts.values()) {
+    if (attempt.intent === undefined) {
+      throw new Error(
+        "canonical compaction intent did not reconstruct its source manifests",
+      );
+    }
+    if (
+      attempt.persistedIntent !== undefined &&
+      attempt.sourceHistoryValidated !== true &&
+      !attempt.records.some(
+        (record) => record.item.type === "compaction_source_release",
+      )
+    ) {
+      throw new Error(
+        "canonical compaction source history is missing without a durable release",
+      );
+    }
+  }
+}
+
+/**
+ * Line numbers the digest-anchored second pass must re-read: the caller's
+ * additional lines, every attempt's active-history refs, and the live active
+ * history positions when the caller captures it.
+ */
+function collectSourceLines(
+  options: CanonicalRolloutScanOptions,
+  attempts: ReadonlyMap<string, MutableAttemptScan>,
+  activePositions: readonly CanonicalActiveHistoryPosition[],
+): Set<number> {
+  const sourceLines = new Set(options.additionalSourceLines ?? []);
+  for (const attempt of attempts.values()) {
+    for (const ref of attempt.intent!.source.active_history_refs) {
+      sourceLines.add(ref.first_sequence);
+    }
+  }
+  if (options.captureActiveHistory === true) {
+    for (const position of activePositions) {
+      sourceLines.add(position.lineNumber);
+    }
+  }
+  return sourceLines;
 }
 
 type PostCommitBookkeeping =

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -342,8 +342,7 @@ function scanCanonicalRolloutUntimed(
     let retainedLifecycleRecords = 0;
     let activeAdmissionAttempt: MutableAttemptScan | undefined;
     let latestCommittedAttempt: MutableAttemptScan | undefined;
-    let postCommitBookkeeping:
-      "await_context" | "await_meta" | "complete" | undefined;
+    let postCommitBookkeeping: PostCommitBookkeeping;
     checkOperationalBudget();
     let identityRegistry: DiskCanonicalIdentityRegistry | undefined;
     let payloadRegistry: DiskCompactionPayloadRegistry | undefined;
@@ -371,29 +370,18 @@ function scanCanonicalRolloutUntimed(
               : undefined;
 
           if (latestCommittedAttempt !== undefined) {
-            const committedAttemptId =
-              latestCommittedAttempt.intent?.attempt_id;
-            if (
-              item.type === "compaction_cleanup_pending" &&
-              item.payload.attempt_id === committedAttemptId
-            ) {
-              // Cleanup evidence is part of the commit transaction itself.
-            } else if (
-              postCommitBookkeeping === "await_context" &&
-              latestCommittedAttempt.intent?.automatic === true &&
-              isCausalAutoCompactionBoundary(item)
-            ) {
-              postCommitBookkeeping = "await_meta";
-            } else if (
-              postCommitBookkeeping === "await_meta" &&
-              item.type === "session_meta" &&
-              item.payload.sessionId === options.expectedRunId
-            ) {
-              postCommitBookkeeping = "complete";
-            } else {
+            const next = nextPostCommitBookkeeping(
+              item,
+              latestCommittedAttempt,
+              postCommitBookkeeping,
+              options.expectedRunId,
+            );
+            if (next === "later_work") {
               latestCommittedAttempt.laterWork = true;
               latestCommittedAttempt = undefined;
               postCommitBookkeeping = undefined;
+            } else {
+              postCommitBookkeeping = next;
             }
           }
           if (
@@ -1023,6 +1011,47 @@ function persistedRollbackPayload(
   )
     return undefined;
   return readCompactionPersistedRollbackCommittedV1(payload);
+}
+
+type PostCommitBookkeeping =
+  | "await_context"
+  | "await_meta"
+  | "complete"
+  | undefined;
+
+/**
+ * Advance the bookkeeping that follows a committed compaction: its own
+ * cleanup evidence is part of the commit transaction, an automatic attempt
+ * then expects the causal context boundary and the session_meta rewrite, and
+ * anything else is later work that ends the post-commit window.
+ */
+function nextPostCommitBookkeeping(
+  item: RolloutItem,
+  committed: MutableAttemptScan,
+  current: PostCommitBookkeeping,
+  expectedRunId: string | undefined,
+): PostCommitBookkeeping | "later_work" {
+  if (
+    item.type === "compaction_cleanup_pending" &&
+    item.payload.attempt_id === committed.intent?.attempt_id
+  ) {
+    return current;
+  }
+  if (
+    current === "await_context" &&
+    committed.intent?.automatic === true &&
+    isCausalAutoCompactionBoundary(item)
+  ) {
+    return "await_meta";
+  }
+  if (
+    current === "await_meta" &&
+    item.type === "session_meta" &&
+    item.payload.sessionId === expectedRunId
+  ) {
+    return "complete";
+  }
+  return "later_work";
 }
 
 function isCausalAutoCompactionBoundary(item: RolloutItem): boolean {

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -11,6 +11,7 @@ import {
 import type { BigIntStats } from "node:fs";
 import { join } from "node:path";
 import Database from "better-sqlite3";
+import { timed } from "../utils/slow-store-op.js";
 import type BetterSqlite3 from "better-sqlite3";
 
 import type { AdmissionJournalEvent } from "../budget/admission-types.js";
@@ -291,6 +292,17 @@ export interface CanonicalRolloutScanOptions extends Pick<
  * exact source rows named by those lifecycles and existing retention pins.
  */
 export function scanCanonicalRollout(
+  rolloutPath: string,
+  options: CanonicalRolloutScanOptions,
+): CanonicalRolloutScan {
+  // Every open, compaction attempt and resume re-parses the whole file here
+  // (17,610 lines / 8.6 MB for the measured session), synchronously.
+  return timed("canonical_rollout_scan", () =>
+    scanCanonicalRolloutUntimed(rolloutPath, options),
+  );
+}
+
+function scanCanonicalRolloutUntimed(
   rolloutPath: string,
   options: CanonicalRolloutScanOptions,
 ): CanonicalRolloutScan {

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -1967,19 +1967,23 @@ export class SessionStore {
    */
   flushBatch(durable: boolean): boolean {
     // A slow flush (a large batch, or a durable fsync on a busy disk) stalls
-    // the event loop that streams to every client; report it through the
-    // store's diagnostic channel so it lands in the rollout like the I-83
-    // batch-delay warning does.
+    // the event loop that streams to every client, so it is worth reporting.
+    // It must NOT go through this store's diagnostic channel:
+    // `mountRolloutStore` turns every diagnostic into `session.emit`, which
+    // allocates a live event sequence and appends a warning to the very
+    // rollout being flushed. Two
+    // consequences, both observed: the canonical journal's contents become a
+    // function of how long one fsync took, so a resumed session can fail its
+    // startup scan with "canonical journal repeats its preceding event
+    // sequence"; and the warning is itself appended and flushed, so a disk slow
+    // enough to cross the threshold keeps crossing it, writing more each time.
+    // Timing evidence belongs in the process-wide slow-op sink (the daemon's
+    // rotating daemon.log), which is where every other `timed` call site sends
+    // it. The I-83 batch-delay warning stays a journal event: it records a
+    // suspend/resume gap in the session itself, not the speed of a write.
     return timed(
       durable ? "rollout_flush_durable" : "rollout_flush_batch",
       () => this.flushBatchUntimed(durable),
-      (warning) =>
-        this.emitDiagnostic({
-          at: Date.now(),
-          level: "warning",
-          cause: warning.cause,
-          message: `${warning.label} took ${warning.ms}ms`,
-        }),
     );
   }
 

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -67,6 +67,7 @@ import {
   writeSync,
   unlinkSync,
 } from "node:fs";
+import { timed } from "../utils/slow-store-op.js";
 import {
   basename,
   dirname,
@@ -1965,6 +1966,24 @@ export class SessionStore {
    * for tests.
    */
   flushBatch(durable: boolean): boolean {
+    // A slow flush (a large batch, or a durable fsync on a busy disk) stalls
+    // the event loop that streams to every client; report it through the
+    // store's diagnostic channel so it lands in the rollout like the I-83
+    // batch-delay warning does.
+    return timed(
+      durable ? "rollout_flush_durable" : "rollout_flush_batch",
+      () => this.flushBatchUntimed(durable),
+      (warning) =>
+        this.emitDiagnostic({
+          at: Date.now(),
+          level: "warning",
+          cause: warning.cause,
+          message: `${warning.label} took ${warning.ms}ms`,
+        }),
+    );
+  }
+
+  private flushBatchUntimed(durable: boolean): boolean {
     if (this.pending.length === 0) {
       this.batchOpenedAtMs = null;
       return true;

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -1807,7 +1807,39 @@ function readProviderHttpClient(
   return candidate instanceof ProviderHttpClient ? candidate : undefined;
 }
 
-function normalizeHistoryMessages(
+/**
+ * Durable metadata of a history item. The live turn stores it under
+ * `runtimeOnly` (LLMMessage shape); a rollout reconstruction restores the
+ * persisted ResponseItem shape, where the same fields sit at the top level.
+ * Both must normalize identically: a resumed session whose restored tool
+ * results lost their seal fails its first durable checkpoint with
+ * "checkpoint v2 requires every tool result to be sealed".
+ */
+function durableHistoryMetadata(candidate: {
+  readonly toolResultIntegrity?: ToolResultIntegrity;
+  readonly agentInvocation?: AgentInvocationChannelMetadata;
+  readonly compactionHistory?: CompactionHistoryMarkerV1;
+  readonly runtimeOnly?: {
+    readonly toolResultIntegrity?: ToolResultIntegrity;
+    readonly agentInvocation?: AgentInvocationChannelMetadata;
+    readonly compactionHistory?: CompactionHistoryMarkerV1;
+  };
+}): {
+  readonly toolResultIntegrity?: ToolResultIntegrity;
+  readonly agentInvocation?: AgentInvocationChannelMetadata;
+  readonly compactionHistory?: CompactionHistoryMarkerV1;
+} {
+  return {
+    toolResultIntegrity:
+      candidate.runtimeOnly?.toolResultIntegrity ?? candidate.toolResultIntegrity,
+    agentInvocation:
+      candidate.runtimeOnly?.agentInvocation ?? candidate.agentInvocation,
+    compactionHistory:
+      candidate.runtimeOnly?.compactionHistory ?? candidate.compactionHistory,
+  };
+}
+
+export function normalizeHistoryMessages(
   history: ReadonlyArray<unknown>,
 ): LLMMessage[] {
   const normalized: LLMMessage[] = [];
@@ -1820,6 +1852,9 @@ function normalizeHistoryMessages(
       toolCalls?: unknown;
       toolCallId?: unknown;
       toolName?: unknown;
+      toolResultIntegrity?: ToolResultIntegrity;
+      agentInvocation?: AgentInvocationChannelMetadata;
+      compactionHistory?: CompactionHistoryMarkerV1;
       runtimeOnly?: {
         userMessageId?: unknown;
         toolResultIntegrity?: ToolResultIntegrity;
@@ -1827,6 +1862,7 @@ function normalizeHistoryMessages(
         compactionHistory?: CompactionHistoryMarkerV1;
       };
     };
+    const durable = durableHistoryMetadata(candidate);
     if (
       candidate.role !== "system" &&
       candidate.role !== "developer" &&
@@ -1859,30 +1895,25 @@ function normalizeHistoryMessages(
       // The invocation merge boundary is derived from authenticated channel
       // metadata instead of accepting a transient serialized flag.
       ...(typeof candidate.runtimeOnly?.userMessageId === "string" ||
-      candidate.runtimeOnly?.toolResultIntegrity !== undefined ||
-      candidate.runtimeOnly?.agentInvocation !== undefined ||
-      candidate.runtimeOnly?.compactionHistory !== undefined
+      durable.toolResultIntegrity !== undefined ||
+      durable.agentInvocation !== undefined ||
+      durable.compactionHistory !== undefined
         ? {
             runtimeOnly: {
               ...(typeof candidate.runtimeOnly?.userMessageId === "string"
                 ? { userMessageId: candidate.runtimeOnly.userMessageId }
                 : {}),
-              ...(candidate.runtimeOnly?.toolResultIntegrity !== undefined
-                ? {
-                    toolResultIntegrity:
-                      candidate.runtimeOnly.toolResultIntegrity,
-                  }
+              ...(durable.toolResultIntegrity !== undefined
+                ? { toolResultIntegrity: durable.toolResultIntegrity }
                 : {}),
-              ...(candidate.runtimeOnly?.agentInvocation !== undefined
+              ...(durable.agentInvocation !== undefined
                 ? {
-                    agentInvocation: candidate.runtimeOnly.agentInvocation,
+                    agentInvocation: durable.agentInvocation,
                     mergeBoundary: "user_context" as const,
                   }
                 : {}),
-              ...(candidate.runtimeOnly?.compactionHistory !== undefined
-                ? {
-                    compactionHistory: candidate.runtimeOnly.compactionHistory,
-                  }
+              ...(durable.compactionHistory !== undefined
+                ? { compactionHistory: durable.compactionHistory }
                 : {}),
             },
           }

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -3663,6 +3663,19 @@ export class Session {
   /**
    * Mirrors agenc runtime `Session::next_internal_sub_id` — monotonic id allocation.
    */
+  /**
+   * Move the internal sub-id counter past ids that already exist durably.
+   * A resumed session starts the counter at zero; without this its first
+   * turn reused `sub-<conversation>-2` and the admission journal refused
+   * the model step ("admission step identity already exists with different
+   * request data"). Never moves the counter backwards.
+   */
+  seedInternalSubId(next: number): void {
+    if (Number.isSafeInteger(next) && next > this.nextInternalSubIdValue) {
+      this.nextInternalSubIdValue = next;
+    }
+  }
+
   nextInternalSubId(): string {
     const id = this.nextInternalSubIdValue;
     this.nextInternalSubIdValue += 1;

--- a/runtime/src/state/agent-runs.ts
+++ b/runtime/src/state/agent-runs.ts
@@ -59,6 +59,15 @@ export interface AgenCStateAgentRunStatusUpdate {
   readonly lastActiveAt: string;
   readonly currentSessionId?: string;
   readonly metadataPatch?: JsonObject;
+  /**
+   * Set ONLY by the audited explicit-reopen path. The stickiness above
+   * exists so a dying agent's late snapshot cannot undo an explicit
+   * cancel; an operator reopening a settled terminal into a NEW lifecycle
+   * epoch is the opposite of that — it is the authorized transition, and
+   * its own gates (terminal epoch, no active suspension, no unsettled
+   * effect intents, and the caller's canonical rollout proof) already ran.
+   */
+  readonly reopeningLockedRun?: boolean;
 }
 
 export function upsertAgentRun(
@@ -114,7 +123,10 @@ export function updateAgentRunStatus(
   driver: StateSqliteDriver,
   update: AgenCStateAgentRunStatusUpdate,
 ): AgentRunWriteOutcome {
-  const locked = cancelLockedExistingStatus(driver, update.id, update.status);
+  const locked =
+    update.reopeningLockedRun === true
+      ? undefined
+      : cancelLockedExistingStatus(driver, update.id, update.status);
   if (locked !== undefined) {
     return {
       applied: false,

--- a/runtime/src/state/backfill.ts
+++ b/runtime/src/state/backfill.ts
@@ -751,6 +751,12 @@ function mergeThreadFromMeta(args: {
 }): void {
   const { metaForUpdate, metaForCreate } = args;
   const archivedAt = args.archived === true ? args.now : undefined;
+  // The archive state is derived from the file's location root, which only
+  // the offline sweep knows. A store-driven incremental index (archived
+  // undefined) must not clear archived_at: a thread archived in the registry
+  // while its writer still owns the file (the move is deferred until that
+  // writer shuts down) would otherwise resurface as active on its next append.
+  const replaceArchiveState = args.archived !== undefined;
   args.threads.mergeThread(
     {
       threadId: args.threadId,
@@ -766,7 +772,7 @@ function mergeThreadFromMeta(args: {
         ? { archivedAt, archivedRolloutPath: args.rolloutPath }
         : { rolloutPath: args.rolloutPath }),
     },
-    { replaceArchiveState: true },
+    { replaceArchiveState },
   );
 }
 

--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -16,6 +16,7 @@ import { agentIdFromThreadSourceJson } from "../thread-store/thread-source.js";
 import { StateRunDurabilityRepository } from "./run-durability.js";
 import { parseRolloutLine } from "../session/rollout-item.js";
 import { SessionLock, SessionLockedError } from "../session/session-store.js";
+import { timed } from "../utils/slow-store-op.js";
 
 const COMPLETED_AGENT_RUN_STATUSES = ["completed", "stopped"] as const;
 const FAILED_AGENT_RUN_STATUSES = ["failed", "error", "errored"] as const;
@@ -171,7 +172,7 @@ export function pruneSessionStateSnapshots(
     return emptySnapshotReport();
   }
 
-  return driver.transaction(() => {
+  return timed("session_snapshot_prune_table", () => driver.transaction(() => {
     const rows = loadSnapshotPruneCandidates(driver, sessionId);
     if (rows.length === 0) return emptySnapshotReport();
 
@@ -209,7 +210,7 @@ export function pruneSessionStateSnapshots(
       prunedSnapshots,
       prunedSessionIds: [...prunedSessionIds].sort(),
     };
-  });
+  }));
 }
 
 /**
@@ -240,7 +241,7 @@ export function pruneSessionSnapshotsForSession(
     retention.maxCount ?? SESSION_SNAPSHOT_HARD_CAP,
   );
   const maxBytes = retention.maxBytes;
-  return driver.transaction(() => {
+  return timed("session_snapshot_prune", () => driver.transaction(() => {
     let prunedSnapshots = driver
       .prepareState<[string, string, number]>(
         `DELETE FROM session_state_snapshots
@@ -299,7 +300,7 @@ export function pruneSessionSnapshotsForSession(
       prunedSnapshots,
       prunedSessionIds: prunedSnapshots > 0 ? [sessionId] : [],
     };
-  });
+  }));
 }
 
 /** Apply {@link pruneSessionSnapshotsForSession} to every session in the table. */

--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -212,6 +212,120 @@ export function pruneSessionStateSnapshots(
   });
 }
 
+/**
+ * Rows kept per session regardless of configuration. The daemon-side snapshot
+ * is a recovery convenience whose consumers (loadLatest, hydrateStartupRecovery)
+ * read only the newest row, so a deep history has no reader. One 82-minute
+ * session accumulated 5,607 rows / 1.16 GB before this cap existed because the
+ * configured retention never deleted a row.
+ */
+export const SESSION_SNAPSHOT_HARD_CAP = 50;
+
+/**
+ * Per-session snapshot retention that is cheap enough to run on every write:
+ * the count cap (hard cap and configured `snapshot_max_count`) is one indexed
+ * DELETE below the keep-th newest row, the age cutoff is one indexed DELETE
+ * that spares the newest row, and the byte cap only measures the rows that
+ * survive both (at most the hard cap). Nothing here reads another session or
+ * scans the table, unlike {@link pruneSessionStateSnapshots}.
+ */
+export function pruneSessionSnapshotsForSession(
+  driver: StateSqliteDriver,
+  sessionId: string,
+  options: AgentRunPruningOptions = {},
+): AgentSnapshotPruningReport {
+  const retention = normalizeSnapshotRetention(options);
+  const keep = Math.min(
+    SESSION_SNAPSHOT_HARD_CAP,
+    retention.maxCount ?? SESSION_SNAPSHOT_HARD_CAP,
+  );
+  const maxBytes = retention.maxBytes;
+  return driver.transaction(() => {
+    let prunedSnapshots = driver
+      .prepareState<[string, string, number]>(
+        `DELETE FROM session_state_snapshots
+         WHERE session_id = ?
+           AND snapshot_at < (
+             SELECT snapshot_at
+             FROM session_state_snapshots
+             WHERE session_id = ?
+             ORDER BY snapshot_at DESC
+             LIMIT 1 OFFSET ?
+           )`,
+      )
+      .run(sessionId, sessionId, keep - 1).changes;
+    if (retention.cutoff !== undefined) {
+      prunedSnapshots += driver
+        .prepareState<[string, string, string]>(
+          `DELETE FROM session_state_snapshots
+           WHERE session_id = ?
+             AND snapshot_at < ?
+             AND snapshot_at < (
+               SELECT MAX(snapshot_at)
+               FROM session_state_snapshots
+               WHERE session_id = ?
+             )`,
+        )
+        .run(sessionId, retention.cutoff, sessionId).changes;
+    }
+    if (maxBytes !== undefined) {
+      const rows = driver
+        .prepareState<[string], { snapshot_at: string; bytes: number }>(
+          `SELECT snapshot_at,
+                  LENGTH(conversation_json)
+                    + LENGTH(COALESCE(tool_state_json, ''))
+                    + LENGTH(COALESCE(mcp_connection_state_json, '')) AS bytes
+           FROM session_state_snapshots
+           WHERE session_id = ?
+           ORDER BY snapshot_at DESC`,
+        )
+        .all(sessionId);
+      const deleteSnapshot = driver.prepareState<[string, string]>(
+        `DELETE FROM session_state_snapshots
+         WHERE session_id = ?
+           AND snapshot_at = ?`,
+      );
+      let retainedBytes = 0;
+      rows.forEach((row, index) => {
+        // The newest row is the recovery snapshot and is always kept.
+        if (index === 0 || retainedBytes + row.bytes <= maxBytes) {
+          retainedBytes += row.bytes;
+          return;
+        }
+        prunedSnapshots += deleteSnapshot.run(sessionId, row.snapshot_at).changes;
+      });
+    }
+    return {
+      prunedSnapshots,
+      prunedSessionIds: prunedSnapshots > 0 ? [sessionId] : [],
+    };
+  });
+}
+
+/** Apply {@link pruneSessionSnapshotsForSession} to every session in the table. */
+export function pruneSessionSnapshotsPerSession(
+  driver: StateSqliteDriver,
+  options: AgentRunPruningOptions = {},
+): AgentSnapshotPruningReport {
+  const sessionIds = driver
+    .prepareState<[], { session_id: string }>(
+      `SELECT DISTINCT session_id
+       FROM session_state_snapshots
+       ORDER BY session_id ASC`,
+    )
+    .all()
+    .map((row) => row.session_id);
+  let prunedSnapshots = 0;
+  const prunedSessionIds: string[] = [];
+  for (const sessionId of sessionIds) {
+    const report = pruneSessionSnapshotsForSession(driver, sessionId, options);
+    if (report.prunedSnapshots === 0) continue;
+    prunedSnapshots += report.prunedSnapshots;
+    prunedSessionIds.push(sessionId);
+  }
+  return { prunedSnapshots, prunedSessionIds };
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Rollout/session retention sweep
 //

--- a/runtime/src/state/recovery-cutover.ts
+++ b/runtime/src/state/recovery-cutover.ts
@@ -13,6 +13,7 @@ import {
 } from "./recovery-file.js";
 import {
   getRecoveryRunExclusion,
+  liveSourceRecoveryExclusion,
   storageUnavailableRecoveryExclusion,
   type RecoveryRunExclusion,
 } from "./recovery-exclusions.js";
@@ -26,6 +27,16 @@ export interface RecoveryCutoverOptions {
   readonly descriptorBudget?: RecoveryDescriptorBudget;
   readonly nowMilliseconds?: () => number;
   readonly startupBudget?: StartupRecoveryBudget;
+  /**
+   * What a `source_not_quiescent` failure (a live writer holds the rollout
+   * lease) does. "record" (default) persists a retryable deferral, which is
+   * right for startup: nothing in this process owns the source. "skip" is for
+   * on-demand reads of a run this daemon is executing right now: the caller
+   * serves the current SQLite projection and nothing is persisted, because a
+   * durable deferral would exclude the healthy run from recovery at the next
+   * daemon start.
+   */
+  readonly liveSourceDeferral?: "record" | "skip";
 }
 
 /** One aggregate E1a byte/time ceiling shared by every startup entrypoint. */
@@ -87,6 +98,13 @@ export function persistRecoveryFailure(
   const source =
     sources.find(({ rolloutPath }) => rolloutPath === failedPath) ??
     sources[0]!;
+  if (
+    options.liveSourceDeferral === "skip" &&
+    error instanceof RecoveryOperationalError &&
+    error.reasonCode === "source_not_quiescent"
+  ) {
+    return liveSourceRecoveryExclusion(runId, source.rolloutPath);
+  }
   const failedAtMs = (options.nowMilliseconds ?? Date.now)();
   const repository = new StateRecoveryIncidentRepository(driver);
 

--- a/runtime/src/state/recovery-exclusions.ts
+++ b/runtime/src/state/recovery-exclusions.ts
@@ -142,6 +142,27 @@ export function storageUnavailableRecoveryExclusion(
   });
 }
 
+/**
+ * In-memory (never persisted) exclusion for an on-demand read that found the
+ * canonical source owned by a live writer. The caller keeps serving the
+ * current projection; nothing durable is recorded against the run.
+ */
+export function liveSourceRecoveryExclusion(
+  runId: string,
+  sourcePath: string,
+): RecoveryRunExclusion {
+  return Object.freeze({
+    runId,
+    kind: "deferred",
+    sourceKind: "run_journal",
+    sourcePath,
+    reasonCode: "source_not_quiescent",
+    safeDetail:
+      "canonical recovery source is live; the current projection was served",
+    permanent: false,
+  });
+}
+
 function assertSqlColumnExpression(expression: string, label: string): void {
   if (!/^[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)?$/u.test(expression)) {
     throw new TypeError(`recovery ${label} SQL expression is invalid`);

--- a/runtime/src/state/recovery-incidents.ts
+++ b/runtime/src/state/recovery-incidents.ts
@@ -610,6 +610,31 @@ export class StateRecoveryIncidentRepository {
     });
   }
 
+  /**
+   * Resolve active `source_not_quiescent` deferrals whose retry window has
+   * passed. Such a block only records that a live writer held the rollout
+   * lease when a reader looked (a desktop run.status on a running session
+   * did exactly that); once next_retry_ms is behind us it says nothing about
+   * the source now, and leaving it active would exclude a healthy run from
+   * startup recovery as "pending operator recovery action". Every other
+   * reason code stays on the operator retry path.
+   */
+  releaseExpiredLiveSourceDeferrals(nowMs: number): number {
+    const resolvedAtMs = nonNegativeSafeInteger(nowMs, "nowMs");
+    return this.driver
+      .prepareState<[number, number]>(
+        `UPDATE run_recovery_deferred
+         SET state = 'resolved',
+             resolved_at_ms = ?,
+             resolution_actor = 'daemon_startup',
+             resolution_note = 'source_not_quiescent retry window elapsed; startup recovery rescans the source'
+         WHERE state = 'active'
+           AND reason_code = 'source_not_quiescent'
+           AND next_retry_ms <= ?`,
+      )
+      .run(resolvedAtMs, resolvedAtMs).changes;
+  }
+
   retryDeferred(
     params: {
       readonly blockId: string;

--- a/runtime/src/state/recovery.ts
+++ b/runtime/src/state/recovery.ts
@@ -10,6 +10,7 @@ import {
 } from "./run-cancellation.js";
 import { asRecord } from "../utils/record.js";
 import { StartupRecoveryBudget } from "./recovery-cutover.js";
+import { StateRecoveryIncidentRepository } from "./recovery-incidents.js";
 import {
   recoverCanonicalRunJournalsOnStartup,
   recoverPendingEffectReviewsOnStartup,
@@ -173,6 +174,16 @@ export function recoverDaemonStateOnStartup(
   try {
     const warnings: DaemonStartupRecoveryWarning[] = [];
     const recoveredAt = options.now?.() ?? new Date().toISOString();
+    // A source_not_quiescent deferral whose retry window has passed is stale
+    // evidence about a lease some process held at the time, not about the
+    // source now. Resolve those first so the run is scanned below instead of
+    // being reported as excluded.
+    const recoveredAtMs = Date.parse(recoveredAt);
+    if (Number.isFinite(recoveredAtMs)) {
+      new StateRecoveryIncidentRepository(driver).releaseExpiredLiveSourceDeferrals(
+        recoveredAtMs,
+      );
+    }
     const preexistingExclusions = loadStartupRecoveryExclusions(driver);
     const startupBudget = new StartupRecoveryBudget();
     const admissions = new ExecutionAdmissionRepository(driver, {

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -1041,6 +1041,12 @@ export class StateRunDurabilityRepository {
         // audited reopen is the one transition allowed to move it.
         reopeningLockedRun: true,
       });
+      // The same authorization lifts the run's own admission lock. Left in
+      // place, the lock still denied the reopened run's first model step
+      // (`execution admission deny: parent_cancel_locked`) and its pre-turn
+      // compaction, so a reopened session could never take a turn. Only the
+      // reopened run's row goes: descendants keep theirs.
+      this.liftSupersededCancellation(params.runId, true, false);
       const value: RunLifecycleEpoch = {
         runId: params.runId,
         epoch: nextEpoch,

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -2155,28 +2155,98 @@ export class StateRunDurabilityRepository {
   private assertNotCancellationLocked(runId: RunId): void {
     const state = this.driver
       .prepareState<
-        [string, string],
-        { readonly admission_cancelled: number; readonly status: string | null }
+        [string, string, string],
+        {
+          readonly admission_cancelled_at: string | null;
+          readonly status: string | null;
+          readonly status_at: string | null;
+        }
       >(
         `SELECT
-           EXISTS (
-             SELECT 1
-             FROM execution_admission_cancellations
-             WHERE run_id = ?
-           ) AS admission_cancelled,
-           (SELECT status FROM agent_runs WHERE id = ?) AS status`,
+           (SELECT cancelled_at
+              FROM execution_admission_cancellations
+              WHERE run_id = ?) AS admission_cancelled_at,
+           (SELECT status FROM agent_runs WHERE id = ?) AS status,
+           (SELECT last_active_at FROM agent_runs WHERE id = ?) AS status_at`,
       )
-      .get(runId, runId);
+      .get(runId, runId, runId);
+    const statusLocked =
+      state?.status !== null &&
+      state?.status !== undefined &&
+      isCancelLockedAgentRunStatus(state.status);
+    const admissionLocked =
+      state?.admission_cancelled_at !== null &&
+      state?.admission_cancelled_at !== undefined;
+    if (!statusLocked && !admissionLocked) return;
     if (
-      state?.admission_cancelled === 1 ||
-      (state?.status !== null &&
-        state?.status !== undefined &&
-        isCancelLockedAgentRunStatus(state.status))
+      this.cancellationSupersededByReopen(runId, [
+        ...(admissionLocked ? [state.admission_cancelled_at as string] : []),
+        ...(statusLocked && state.status_at !== null ? [state.status_at] : []),
+      ])
     ) {
-      throw conflict(
-        "RUN_CANCELLATION_CONFLICT",
-        `run ${runId} is cancellation-locked and cannot cross an executable lifecycle boundary`,
-      );
+      this.liftSupersededCancellation(runId, admissionLocked, statusLocked);
+      return;
+    }
+    throw conflict(
+      "RUN_CANCELLATION_CONFLICT",
+      `run ${runId} is cancellation-locked and cannot cross an executable lifecycle boundary`,
+    );
+  }
+
+  /**
+   * A cancellation lock exists so a dying agent's late status write loses
+   * against an explicit cancel. An explicit reopen into a fresh lifecycle
+   * epoch is the audited, authorized transition in the other direction: when
+   * the run's current epoch was reopened at or after every lock was recorded
+   * and has not ended, the locks predate the authorization and are stale.
+   * Live shape: a daemon shutdown during a turn cancelled the run, startup
+   * repair recorded a `recovery_cascade_repair` admission lock, the user
+   * continued the session (reopen), and the next shutdown, resume and
+   * settings change were all refused as "cancellation-locked".
+   */
+  private cancellationSupersededByReopen(
+    runId: RunId,
+    lockedAt: ReadonlyArray<string>,
+  ): boolean {
+    const current = this.currentEpoch(runId);
+    if (current === undefined || current.reopenedFromEpoch === undefined) {
+      return false;
+    }
+    if (this.getTerminalResult(runId, current.epoch) !== undefined) return false;
+    return lockedAt.every((at) => at <= current.openedAt);
+  }
+
+  private liftSupersededCancellation(
+    runId: RunId,
+    admissionLocked: boolean,
+    statusLocked: boolean,
+  ): void {
+    if (admissionLocked) {
+      this.driver
+        .prepareState<[string]>(
+          `DELETE FROM execution_admission_cancellations WHERE run_id = ?`,
+        )
+        .run(runId);
+    }
+    if (statusLocked) {
+      // The sticky-status rule guards against implicit writers; this write
+      // completes the explicit reopen that the current epoch already records.
+      this.driver
+        .prepareState<[string]>(
+          `UPDATE agent_runs
+           SET status = 'running',
+               metadata_json = json_set(
+                 CASE
+                   WHEN metadata_json IS NOT NULL
+                    AND json_valid(metadata_json)
+                    AND json_type(metadata_json) = 'object'
+                   THEN metadata_json ELSE '{}'
+                 END,
+                 '$.cancellationLiftedBy', 'explicit_reopen'
+               )
+           WHERE id = ?`,
+        )
+        .run(runId);
     }
   }
 }

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -944,7 +944,20 @@ export class StateRunDurabilityRepository {
       }
 
       const current = this.currentEpoch(params.runId);
-      this.assertNotCancellationLocked(params.runId);
+      /*
+       * No cancellation-lock check here, deliberately. That lock makes a
+       * dying agent's late status write lose against an explicit cancel;
+       * an operator reopening a settled terminal is the authorized
+       * transition, not a straggler. Applying it here contradicted this
+       * function's own contract ("settled terminals — completed, failed,
+       * cancelled — reopen with reviews still pending", below) and left
+       * every interrupted session permanently unresumable, which is the
+       * failure #1750 set out to end. The gates that matter still run:
+       * the epoch must be terminal, nothing may be suspended, no effect
+       * intent may be unsettled, an unknown-outcome terminal with pending
+       * reviews stays refused, and agent.create proved the caller owns
+       * this session's canonical rollout before reaching this point.
+       */
       if (current === undefined || current.epoch !== params.fromEpoch) {
         throw conflict(
           "RUN_EPOCH_CONFLICT",
@@ -1024,6 +1037,9 @@ export class StateRunDurabilityRepository {
         id: params.runId,
         status: "running",
         lastActiveAt: params.openedAt,
+        // A cancelled run's status is sticky against implicit writers; this
+        // audited reopen is the one transition allowed to move it.
+        reopeningLockedRun: true,
       });
       const value: RunLifecycleEpoch = {
         runId: params.runId,

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -964,10 +964,15 @@ export class AgenCSessionSnapshotPolicy {
       state.lastWriteMs === undefined || !Number.isFinite(nowMs)
         ? Number.POSITIVE_INFINITY
         : nowMs - state.lastWriteMs;
-    // A zero window means "never coalesce". The gap can be negative when the
-    // previous snapshot timestamp had to be bumped past a clock that did not
-    // advance; that still counts as inside the window.
+    // A completed message exchange is a turn boundary: it is written at once
+    // (carrying any coalesced tool state with it) so a client that reads state
+    // right after message.stream returns sees it. Only streaming chunks and
+    // tool/status bursts coalesce. A zero window means "never coalesce". The
+    // gap can be negative when the previous snapshot timestamp had to be
+    // bumped past a clock that did not advance; that still counts as inside
+    // the window.
     if (
+      trigger === "message_exchange" ||
       this.#coalesceIntervalMs === 0 ||
       sinceLastWriteMs >= this.#coalesceIntervalMs
     ) {

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -130,6 +130,8 @@ interface SessionSnapshotState {
   // Policy-clock time of the last durable write, for coalescing.
   lastWriteMs?: number;
   coalesceTimer?: SnapshotPolicyTimer;
+  // Agent id already persisted in session_agent_links for this session.
+  agentId?: string;
   conversation: JsonValue[];
   seenConversationKeys: Set<string>;
   toolState: {
@@ -895,6 +897,11 @@ export class AgenCSessionSnapshotPolicy {
 
   #rememberSessionAgent(sessionId: string, agentId: string): void {
     if (sessionId.length === 0 || agentId.length === 0) return;
+    // Every forwarded event carries agentId, so this ran an autocommit
+    // upsert (one fsync under synchronous=FULL) per event: ~8,200 for the
+    // measured session. Write only when the link actually changes.
+    const state = this.#session(sessionId);
+    if (state.agentId === agentId) return;
     this.#driver
       .prepareState<[string, string]>(
         `INSERT INTO session_agent_links (
@@ -906,14 +913,19 @@ export class AgenCSessionSnapshotPolicy {
           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
       )
       .run(sessionId, agentId);
+    state.agentId = agentId;
   }
 
   #sessionAgentId(sessionId: string): string | undefined {
-    return this.#driver
+    const state = this.#sessions.get(sessionId);
+    if (state?.agentId !== undefined) return state.agentId;
+    const agentId = this.#driver
       .prepareState<[string], { agent_id: string }>(
         "SELECT agent_id FROM session_agent_links WHERE session_id = ?",
       )
       .get(sessionId)?.agent_id;
+    if (state !== undefined && agentId !== undefined) state.agentId = agentId;
+    return agentId;
   }
 
   #appendConversation(

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -437,6 +437,11 @@ export class AgenCSessionSnapshotPolicy {
     if (hydration.snapshotAt !== undefined) {
       this.#rememberSnapshotAt(hydration.snapshotAt);
     }
+    // Hydration normalizes the recovered state (array-shaped maps are
+    // dropped, the tail is re-capped); write that once on the next tick so
+    // the newest row reflects what this daemon instance actually holds.
+    state.dirty = true;
+    state.pendingTrigger = "periodic";
   }
 
   recordMessageExchange(
@@ -611,9 +616,15 @@ export class AgenCSessionSnapshotPolicy {
   }
 
   flushPeriodic(): readonly SnapshotPolicySnapshotRecord[] {
-    const records = [...this.#sessions.values()].map((state) =>
-      this.#writeSnapshot(state, "periodic"),
-    );
+    // Only sessions with unflushed changes are written. Without this check
+    // every session the daemon had ever seen was re-serialized and fsynced
+    // every 30 s forever: 21 identical snapshots per session in the ten idle
+    // minutes after the measured runs ended.
+    const records: SnapshotPolicySnapshotRecord[] = [];
+    for (const state of this.#sessions.values()) {
+      if (!state.dirty) continue;
+      records.push(this.#writeSnapshot(state, "periodic"));
+    }
     // Piggy-back the disk-retention sweep on the same throttled tick so
     // rollout/session pruning runs on a bounded timer, not a tight loop.
     this.sweepRolloutRetention();

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -42,12 +42,23 @@ export interface SnapshotPolicyOptions {
   readonly maxInFlightToolCalls?: number;
   readonly maxStatusTransitions?: number;
   readonly maxInMemoryToolResultBytes?: number;
+  // Write coalescing: after a durable snapshot write, further snapshot
+  // requests for the same session inside this window only mark it dirty and
+  // are folded into one trailing write (or the next periodic tick). A burst
+  // of tool events therefore costs one write instead of one per event; the
+  // measured daemon wrote 4.4 snapshots/s (392 MB per 5 min) for one session.
+  readonly coalesceIntervalMs?: number;
   readonly now?: () => string;
   readonly setInterval?: (
     callback: () => void,
     intervalMs: number,
   ) => SnapshotPolicyTimer;
   readonly clearInterval?: (timer: SnapshotPolicyTimer) => void;
+  readonly setTimeout?: (
+    callback: () => void,
+    delayMs: number,
+  ) => SnapshotPolicyTimer;
+  readonly clearTimeout?: (timer: SnapshotPolicyTimer) => void;
   readonly onError?: (error: unknown) => void;
   readonly snapshotRetention?: AgentRunRetentionPolicy;
   // Rollout/session disk-retention sweep config. Disabled unless
@@ -106,6 +117,15 @@ export interface SnapshotPolicySessionHydration {
 interface SessionSnapshotState {
   readonly sessionId: string;
   lastTouchedMs: number;
+  // Set by the conversation/tool/status handlers, cleared by #writeSnapshot.
+  // A clean session never costs a write (streaming chunks, idle periodic
+  // ticks); a dirty one is flushed by the coalescing timer, the periodic
+  // tick, flushSession, or close.
+  dirty: boolean;
+  pendingTrigger?: SnapshotPolicyTrigger;
+  // Policy-clock time of the last durable write, for coalescing.
+  lastWriteMs?: number;
+  coalesceTimer?: SnapshotPolicyTimer;
   conversation: JsonValue[];
   seenConversationKeys: Set<string>;
   toolState: {
@@ -133,9 +153,14 @@ const DEFAULT_PERIODIC_INTERVAL_MS = 30_000;
 // Snapshot-retention sweeps run at most once per interval per policy
 // instance instead of on every snapshot write (see #writeSnapshot).
 const SNAPSHOT_PRUNE_INTERVAL_MS = 60_000;
+const DEFAULT_COALESCE_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_CONVERSATION_EVENTS = 200;
 const DEFAULT_MAX_TRACKED_SESSIONS = 1_024;
-const DEFAULT_MAX_COMPLETED_TOOL_CALLS = 200;
+// Completed calls are already persisted row-by-row in in_flight_tool_calls
+// (recordInFlightToolCallCompletion); the snapshot copy is a preview. 200
+// entries with unbounded inputs made tool_state_json average 181 KB (max 349
+// KB) per row in the measured daemon.
+const DEFAULT_MAX_COMPLETED_TOOL_CALLS = 20;
 const DEFAULT_MAX_IN_FLIGHT_TOOL_CALLS = 256;
 const DEFAULT_MAX_STATUS_TRANSITIONS = 500;
 const DEFAULT_MAX_IN_MEMORY_TOOL_RESULT_BYTES = 4_096;
@@ -149,12 +174,18 @@ export class AgenCSessionSnapshotPolicy {
   readonly #maxInFlightToolCalls: number;
   readonly #maxStatusTransitions: number;
   readonly #maxInMemoryToolResultBytes: number;
+  readonly #coalesceIntervalMs: number;
   readonly #now: () => string;
   readonly #setInterval: (
     callback: () => void,
     intervalMs: number,
   ) => SnapshotPolicyTimer;
   readonly #clearInterval: (timer: SnapshotPolicyTimer) => void;
+  readonly #setTimeout: (
+    callback: () => void,
+    delayMs: number,
+  ) => SnapshotPolicyTimer;
+  readonly #clearTimeout: (timer: SnapshotPolicyTimer) => void;
   readonly #onError: (error: unknown) => void;
   #snapshotRetention: AgentRunRetentionPolicy | undefined;
   #rolloutRetention: RolloutRetentionPolicy | undefined;
@@ -198,6 +229,10 @@ export class AgenCSessionSnapshotPolicy {
       options.maxInMemoryToolResultBytes ??
         DEFAULT_MAX_IN_MEMORY_TOOL_RESULT_BYTES,
     );
+    this.#coalesceIntervalMs = Math.max(
+      0,
+      options.coalesceIntervalMs ?? DEFAULT_COALESCE_INTERVAL_MS,
+    );
     this.#now = options.now ?? (() => new Date().toISOString());
     this.#setInterval =
       options.setInterval ??
@@ -205,6 +240,12 @@ export class AgenCSessionSnapshotPolicy {
     this.#clearInterval =
       options.clearInterval ??
       ((timer) => clearInterval(timer as ReturnType<typeof setInterval>));
+    this.#setTimeout =
+      options.setTimeout ??
+      ((callback, delayMs) => setTimeout(callback, delayMs));
+    this.#clearTimeout =
+      options.clearTimeout ??
+      ((timer) => clearTimeout(timer as ReturnType<typeof setTimeout>));
     this.#onError = options.onError ?? (() => {});
     this.#snapshotRetention = options.snapshotRetention;
     this.#rolloutRetention = options.rolloutRetention;
@@ -259,6 +300,21 @@ export class AgenCSessionSnapshotPolicy {
     return `${result.slice(0, cap)}\n…[${
       result.length - cap
     } more chars elided in memory; full result persisted to the snapshot store]`;
+  }
+
+  // Tool inputs were the unbounded half of the snapshot: every Write/Edit
+  // payload sat in `inFlight`, moved to `completed`, and was re-serialized
+  // into every later snapshot row. The full args are persisted once in
+  // in_flight_tool_calls.args_json (recordInFlightToolCallStart) and startup
+  // recovery reconciles calls by id, never from this preview.
+  #boundInMemoryInput(input: JsonValue | null): JsonValue | null {
+    const cap = this.#maxInMemoryToolResultBytes;
+    if (cap === 0 || input === null || typeof input !== "object") return input;
+    const serialized = JSON.stringify(input);
+    if (serialized === undefined || serialized.length <= cap) return input;
+    return `${serialized.slice(0, cap)}\n…[${
+      serialized.length - cap
+    } more chars elided in memory; full input persisted to in_flight_tool_calls]`;
   }
 
   startPeriodic(): void {
@@ -325,7 +381,42 @@ export class AgenCSessionSnapshotPolicy {
   }
 
   forgetSession(sessionId: string): void {
-    this.#sessions.delete(sessionId);
+    const state = this.#sessions.get(sessionId);
+    if (state !== undefined) this.#dropSession(state);
+  }
+
+  /** Session ids currently tracked in memory (diagnostics and tests). */
+  trackedSessionIds(): readonly string[] {
+    return [...this.#sessions.keys()];
+  }
+
+  /**
+   * Write the session's snapshot now if it has unflushed changes. Used when
+   * a run reaches its terminal state so the last state lands before the
+   * session is forgotten.
+   */
+  flushSession(sessionId: string): SnapshotPolicySnapshotRecord | undefined {
+    const state = this.#sessions.get(sessionId);
+    if (state === undefined || !state.dirty) return undefined;
+    return this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
+  }
+
+  /**
+   * Stop timers, flush every dirty session synchronously, and forget all
+   * tracked sessions. Called by the daemon before the state DB is closed.
+   */
+  close(): void {
+    this.stopPeriodic();
+    for (const state of [...this.#sessions.values()]) {
+      try {
+        if (state.dirty) {
+          this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
+        }
+      } catch (error) {
+        this.#onError(error);
+      }
+      this.#dropSession(state);
+    }
   }
 
   hydrateSession(hydration: SnapshotPolicySessionHydration): void {
@@ -361,7 +452,7 @@ export class AgenCSessionSnapshotPolicy {
       conversationKey("user", exchange.messageId),
     );
     if (!appended) return undefined;
-    return this.#writeSnapshot(state, "message_exchange");
+    return this.#requestSnapshot(state, "message_exchange");
   }
 
   recordAgentStatusTransition(
@@ -401,7 +492,7 @@ export class AgenCSessionSnapshotPolicy {
     if (transitions.length > this.#maxStatusTransitions) {
       transitions.splice(0, transitions.length - this.#maxStatusTransitions);
     }
-    return this.#writeSnapshot(state, "agent_status");
+    return this.#requestSnapshot(state, "agent_status");
   }
 
   recordSessionEvent(
@@ -427,8 +518,16 @@ export class AgenCSessionSnapshotPolicy {
         },
         conversationKey("assistant_chunk", stringField(params, "eventId")),
       );
-      if (!appended) return undefined;
-      return this.#writeSnapshot(state, "message_exchange");
+      // A streaming chunk only changes the in-memory conversation tail. It
+      // never writes: one snapshot per forwarded delta was 4,931 rows / 980 MB
+      // for one 82-minute session (4 fsyncs each, on the RPC event loop). The
+      // dirty state is flushed by the next tool/status/message write or the
+      // periodic tick.
+      if (appended) {
+        state.dirty = true;
+        state.pendingTrigger ??= "message_exchange";
+      }
+      return undefined;
     }
     if (method === "event.tool_request") {
       const state = this.#session(sessionId);
@@ -444,7 +543,9 @@ export class AgenCSessionSnapshotPolicy {
         state.toolState.inFlight[requestId] = {
           requestId,
           toolName,
-          input: (params.input as JsonValue | undefined) ?? null,
+          input: this.#boundInMemoryInput(
+            (params.input as JsonValue | undefined) ?? null,
+          ),
           eventId: stringField(params, "eventId"),
           recoveryCategory: toolRecoveryCategoryField(params, "recoveryCategory"),
           status: "running",
@@ -479,7 +580,7 @@ export class AgenCSessionSnapshotPolicy {
           };
         }
       }
-      return this.#writeSnapshot(state, "tool_call");
+      return this.#requestSnapshot(state, "tool_call");
     }
     if (method === "event.agent_status") {
       const params = eventParams;
@@ -596,7 +697,7 @@ export class AgenCSessionSnapshotPolicy {
         };
         this.#boundCompletedToolCalls(state);
       }
-      return this.#writeSnapshot(state, "tool_call");
+      return this.#requestSnapshot(state, "tool_call");
     }
     if (type === "tool_call_recovery_poisoned") {
       const state = this.#session(sessionId);
@@ -642,7 +743,7 @@ export class AgenCSessionSnapshotPolicy {
         };
         this.#boundCompletedToolCalls(state);
       }
-      return this.#writeSnapshot(state, "tool_call");
+      return this.#requestSnapshot(state, "tool_call");
     }
     if (type === "tool_progress") {
       const state = this.#session(sessionId);
@@ -691,7 +792,7 @@ export class AgenCSessionSnapshotPolicy {
         };
         this.#boundInFlightToolCalls(state);
       }
-      return this.#writeSnapshot(state, "tool_call");
+      return this.#requestSnapshot(state, "tool_call");
     }
     if (type === "user_message" || type === "agent_message") {
       const state = this.#session(sessionId);
@@ -712,7 +813,7 @@ export class AgenCSessionSnapshotPolicy {
         ),
       );
       if (!appended) return undefined;
-      return this.#writeSnapshot(state, "message_exchange");
+      return this.#requestSnapshot(state, "message_exchange");
     }
     return undefined;
   }
@@ -726,6 +827,7 @@ export class AgenCSessionSnapshotPolicy {
     const created: SessionSnapshotState = {
       sessionId,
       lastTouchedMs: this.#sessionTouchSeq++,
+      dirty: false,
       conversation: [],
       seenConversationKeys: new Set(),
       toolState: {
@@ -747,17 +849,31 @@ export class AgenCSessionSnapshotPolicy {
 
   #evictStaleSessions(): void {
     while (this.#sessions.size > this.#maxTrackedSessions) {
-      let oldestId: string | undefined;
-      let oldestTouch = Number.POSITIVE_INFINITY;
+      let oldest: SessionSnapshotState | undefined;
       for (const state of this.#sessions.values()) {
-        if (state.lastTouchedMs < oldestTouch) {
-          oldestTouch = state.lastTouchedMs;
-          oldestId = state.sessionId;
+        if (oldest === undefined || state.lastTouchedMs < oldest.lastTouchedMs) {
+          oldest = state;
         }
       }
-      if (oldestId === undefined) return;
-      this.#sessions.delete(oldestId);
+      if (oldest === undefined) return;
+      // Unflushed changes must not vanish with the in-memory entry.
+      try {
+        if (oldest.dirty) {
+          this.#writeSnapshot(oldest, oldest.pendingTrigger ?? "periodic");
+        }
+      } catch (error) {
+        this.#onError(error);
+      }
+      this.#dropSession(oldest);
     }
+  }
+
+  #dropSession(state: SessionSnapshotState): void {
+    if (state.coalesceTimer !== undefined) {
+      this.#clearTimeout(state.coalesceTimer);
+      state.coalesceTimer = undefined;
+    }
+    this.#sessions.delete(state.sessionId);
   }
 
   #rememberSessionAgent(sessionId: string, agentId: string): void {
@@ -800,11 +916,59 @@ export class AgenCSessionSnapshotPolicy {
     return true;
   }
 
+  /**
+   * Mark the session dirty and either write now (first change after a quiet
+   * period) or fold the change into one trailing write at most
+   * `coalesceIntervalMs` after the previous write. The decision uses the
+   * policy clock so the write cadence is deterministic under injected clocks.
+   */
+  #requestSnapshot(
+    state: SessionSnapshotState,
+    trigger: SnapshotPolicyTrigger,
+  ): SnapshotPolicySnapshotRecord | undefined {
+    state.dirty = true;
+    state.pendingTrigger = trigger;
+    const nowIso = this.#now();
+    const nowMs = Date.parse(nowIso);
+    const sinceLastWriteMs =
+      state.lastWriteMs === undefined || !Number.isFinite(nowMs)
+        ? Number.POSITIVE_INFINITY
+        : nowMs - state.lastWriteMs;
+    if (sinceLastWriteMs >= this.#coalesceIntervalMs) {
+      return this.#writeSnapshot(state, trigger, nowIso);
+    }
+    if (state.coalesceTimer === undefined) {
+      const delayMs = Math.min(
+        this.#coalesceIntervalMs,
+        Math.max(1, this.#coalesceIntervalMs - sinceLastWriteMs),
+      );
+      state.coalesceTimer = this.#setTimeout(() => {
+        state.coalesceTimer = undefined;
+        if (!state.dirty) return;
+        try {
+          this.#writeSnapshot(state, state.pendingTrigger ?? trigger);
+        } catch (error) {
+          this.#onError(error);
+        }
+      }, delayMs);
+      state.coalesceTimer.unref?.();
+    }
+    return undefined;
+  }
+
   #writeSnapshot(
     state: SessionSnapshotState,
     trigger: SnapshotPolicyTrigger,
+    nowIso?: string,
   ): SnapshotPolicySnapshotRecord {
-    const snapshotAt = this.#nextSnapshotAt();
+    const snapshotAt = this.#nextSnapshotAt(nowIso);
+    if (state.coalesceTimer !== undefined) {
+      this.#clearTimeout(state.coalesceTimer);
+      state.coalesceTimer = undefined;
+    }
+    state.dirty = false;
+    state.pendingTrigger = undefined;
+    state.lastWriteMs = Date.parse(snapshotAt);
     state.toolState.lastTrigger = trigger;
     const conversation = [...state.conversation];
     const toolState = normalizeJsonObject({
@@ -867,8 +1031,8 @@ export class AgenCSessionSnapshotPolicy {
     }
   }
 
-  #nextSnapshotAt(): string {
-    const parsed = Date.parse(this.#now());
+  #nextSnapshotAt(nowIso: string = this.#now()): string {
+    const parsed = Date.parse(nowIso);
     const nextMs = Number.isFinite(parsed)
       ? Math.max(parsed, this.#lastSnapshotMs + 1)
       : this.#lastSnapshotMs + 1;

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -4,8 +4,9 @@ import { updateAgentRunStatus } from "./agent-runs.js";
 import { writeSessionSnapshotAtomically } from "./atomic-snapshot-writes.js";
 import {
   pruneRolloutSessions,
-  pruneSessionStateSnapshots,
+  pruneSessionSnapshotsForSession,
   type AgentRunRetentionPolicy,
+  type AgentSnapshotPruningReport,
   type RolloutRetentionPolicy,
 } from "./pruning.js";
 import type { StateSqliteDriver } from "./sqlite-driver.js";
@@ -60,6 +61,9 @@ export interface SnapshotPolicyOptions {
   ) => SnapshotPolicyTimer;
   readonly clearTimeout?: (timer: SnapshotPolicyTimer) => void;
   readonly onError?: (error: unknown) => void;
+  // Aggregated snapshot-retention report, delivered from the periodic tick
+  // (and close) whenever rows were pruned since the previous report.
+  readonly onPruneReport?: (report: AgentSnapshotPruningReport) => void;
   readonly snapshotRetention?: AgentRunRetentionPolicy;
   // Rollout/session disk-retention sweep config. Disabled unless
   // `rolloutRetention.retention_days` is set AND `rolloutSessionsDir` resolves;
@@ -150,9 +154,6 @@ interface SnapshotRow {
 }
 
 const DEFAULT_PERIODIC_INTERVAL_MS = 30_000;
-// Snapshot-retention sweeps run at most once per interval per policy
-// instance instead of on every snapshot write (see #writeSnapshot).
-const SNAPSHOT_PRUNE_INTERVAL_MS = 60_000;
 const DEFAULT_COALESCE_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_CONVERSATION_EVENTS = 200;
 const DEFAULT_MAX_TRACKED_SESSIONS = 1_024;
@@ -187,6 +188,9 @@ export class AgenCSessionSnapshotPolicy {
   ) => SnapshotPolicyTimer;
   readonly #clearTimeout: (timer: SnapshotPolicyTimer) => void;
   readonly #onError: (error: unknown) => void;
+  readonly #onPruneReport: ((report: AgentSnapshotPruningReport) => void) | undefined;
+  #prunedSinceReport = 0;
+  readonly #prunedSessionsSinceReport = new Set<string>();
   #snapshotRetention: AgentRunRetentionPolicy | undefined;
   #rolloutRetention: RolloutRetentionPolicy | undefined;
   readonly #rolloutSessionsDir: string | undefined;
@@ -196,7 +200,6 @@ export class AgenCSessionSnapshotPolicy {
   readonly #sessions = new Map<string, SessionSnapshotState>();
   #periodicTimer: SnapshotPolicyTimer | undefined;
   #lastSnapshotMs = 0;
-  #lastSnapshotPruneMs = 0;
   #sessionTouchSeq = 0;
 
   constructor(
@@ -247,6 +250,7 @@ export class AgenCSessionSnapshotPolicy {
       options.clearTimeout ??
       ((timer) => clearTimeout(timer as ReturnType<typeof setTimeout>));
     this.#onError = options.onError ?? (() => {});
+    this.#onPruneReport = options.onPruneReport;
     this.#snapshotRetention = options.snapshotRetention;
     this.#rolloutRetention = options.rolloutRetention;
     this.#rolloutSessionsDir = options.rolloutSessionsDir;
@@ -417,6 +421,7 @@ export class AgenCSessionSnapshotPolicy {
       }
       this.#dropSession(state);
     }
+    this.#reportPruning();
   }
 
   hydrateSession(hydration: SnapshotPolicySessionHydration): void {
@@ -612,6 +617,7 @@ export class AgenCSessionSnapshotPolicy {
     // Piggy-back the disk-retention sweep on the same throttled tick so
     // rollout/session pruning runs on a bounded timer, not a tight loop.
     this.sweepRolloutRetention();
+    this.#reportPruning();
     return records;
   }
 
@@ -934,7 +940,13 @@ export class AgenCSessionSnapshotPolicy {
       state.lastWriteMs === undefined || !Number.isFinite(nowMs)
         ? Number.POSITIVE_INFINITY
         : nowMs - state.lastWriteMs;
-    if (sinceLastWriteMs >= this.#coalesceIntervalMs) {
+    // A zero window means "never coalesce". The gap can be negative when the
+    // previous snapshot timestamp had to be bumped past a clock that did not
+    // advance; that still counts as inside the window.
+    if (
+      this.#coalesceIntervalMs === 0 ||
+      sinceLastWriteMs >= this.#coalesceIntervalMs
+    ) {
       return this.#writeSnapshot(state, trigger, nowIso);
     }
     if (state.coalesceTimer === undefined) {
@@ -996,23 +1008,19 @@ export class AgenCSessionSnapshotPolicy {
       },
       { updateRunLastSnapshotAt: true, replayOnStartup: true },
     );
-    // Pruning is maintenance, not a consistency boundary: running it on every
-    // snapshot made each write cost a full-table scan (see pruning.ts note),
-    // which stalled long interactive turns for minutes. Throttle to one pass
-    // per interval per policy instance; retention still applies, just not on
-    // the hot path of every single snapshot.
-    const pruneNowMs = Date.parse(snapshotAt);
-    if (
-      this.#lastSnapshotPruneMs === 0 ||
-      (Number.isFinite(pruneNowMs) &&
-        pruneNowMs - this.#lastSnapshotPruneMs >= SNAPSHOT_PRUNE_INTERVAL_MS)
-    ) {
-      this.#lastSnapshotPruneMs = Number.isFinite(pruneNowMs) ? pruneNowMs : Date.now();
-      pruneSessionStateSnapshots(
-        this.#driver,
-        { ...(this.#snapshotRetention ?? {}), now: () => snapshotAt },
-        state.sessionId,
-      );
+    // Retention runs on every write. The per-session prune is a few indexed
+    // statements over at most SESSION_SNAPSHOT_HARD_CAP rows, unlike the
+    // table-wide LENGTH() scan it replaces, whose 60 s throttle let one
+    // session grow to 5,607 rows / 1.16 GB without ever deleting a row.
+    // Reports are aggregated and surfaced from the periodic tick.
+    const pruned = pruneSessionSnapshotsForSession(
+      this.#driver,
+      state.sessionId,
+      { ...(this.#snapshotRetention ?? {}), now: () => snapshotAt },
+    );
+    if (pruned.prunedSnapshots > 0) {
+      this.#prunedSinceReport += pruned.prunedSnapshots;
+      this.#prunedSessionsSinceReport.add(state.sessionId);
     }
     return {
       sessionId: state.sessionId,
@@ -1022,6 +1030,21 @@ export class AgenCSessionSnapshotPolicy {
       toolState,
       mcpConnectionState,
     };
+  }
+
+  #reportPruning(): void {
+    if (this.#prunedSinceReport === 0) return;
+    const report: AgentSnapshotPruningReport = {
+      prunedSnapshots: this.#prunedSinceReport,
+      prunedSessionIds: [...this.#prunedSessionsSinceReport].sort(),
+    };
+    this.#prunedSinceReport = 0;
+    this.#prunedSessionsSinceReport.clear();
+    try {
+      this.#onPruneReport?.(report);
+    } catch (error) {
+      this.#onError(error);
+    }
   }
 
   #rememberSnapshotAt(snapshotAt: string): void {

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -404,7 +404,7 @@ export class AgenCSessionSnapshotPolicy {
    */
   flushSession(sessionId: string): SnapshotPolicySnapshotRecord | undefined {
     const state = this.#sessions.get(sessionId);
-    if (state === undefined || !state.dirty) return undefined;
+    if (!state?.dirty) return undefined;
     return this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
   }
 
@@ -414,7 +414,8 @@ export class AgenCSessionSnapshotPolicy {
    */
   close(): void {
     this.stopPeriodic();
-    for (const state of [...this.#sessions.values()]) {
+    // Dropping the current entry while iterating a Map is well defined.
+    for (const state of this.#sessions.values()) {
       try {
         if (state.dirty) {
           this.#writeSnapshot(state, state.pendingTrigger ?? "periodic");
@@ -1067,7 +1068,9 @@ export class AgenCSessionSnapshotPolicy {
     if (this.#prunedSinceReport === 0) return;
     const report: AgentSnapshotPruningReport = {
       prunedSnapshots: this.#prunedSinceReport,
-      prunedSessionIds: [...this.#prunedSessionsSinceReport].sort(),
+      prunedSessionIds: [...this.#prunedSessionsSinceReport].sort(
+        (left, right) => left.localeCompare(right),
+      ),
     };
     this.#prunedSinceReport = 0;
     this.#prunedSessionsSinceReport.clear();

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -19,6 +19,7 @@ import {
   type ToolOutputRotationPolicy,
 } from "./tool-output-rotation.js";
 import { asRecord } from "../utils/record.js";
+import { timed } from "../utils/slow-store-op.js";
 
 export type SnapshotPolicyTrigger =
   | "agent_status"
@@ -1020,16 +1021,18 @@ export class AgenCSessionSnapshotPolicy {
       extras: undefined,
       events: [...state.mcpConnectionState.events],
     });
-    writeSessionSnapshotAtomically(
-      this.#driver,
-      {
-        sessionId: state.sessionId,
-        snapshotAt,
-        conversationJson: JSON.stringify(conversation),
-        toolStateJson: JSON.stringify(toolState),
-        mcpConnectionStateJson: JSON.stringify(mcpConnectionState),
-      },
-      { updateRunLastSnapshotAt: true, replayOnStartup: true },
+    timed("session_snapshot_write", () =>
+      writeSessionSnapshotAtomically(
+        this.#driver,
+        {
+          sessionId: state.sessionId,
+          snapshotAt,
+          conversationJson: JSON.stringify(conversation),
+          toolStateJson: JSON.stringify(toolState),
+          mcpConnectionStateJson: JSON.stringify(mcpConnectionState),
+        },
+        { updateRunLastSnapshotAt: true, replayOnStartup: true },
+      ),
     );
     // Retention runs on every write. The per-session prune is a few indexed
     // statements over at most SESSION_SNAPSHOT_HARD_CAP rows, unlike the

--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -43,6 +43,8 @@ import {
   getProjectDir,
   listResumableSessions,
   readAndValidateSchemaVersion,
+  SessionLock,
+  SessionLockedError,
 } from "../session/session-store.js";
 import {
   LOGS_DATABASE_FILENAME,
@@ -566,7 +568,11 @@ export class FileThreadStore implements ThreadStore {
       ) {
         return;
       }
-      const archivedRolloutPath = this.archiveRolloutFile(existing);
+      // This instance owns the writer it just flushed, so the rollout lease
+      // it still holds is not a foreign live writer.
+      const archivedRolloutPath = this.archiveRolloutFile(existing, {
+        ownedWriter: true,
+      });
       if (archivedRolloutPath === undefined) return;
       registry.set(threadId, {
         ...existing,
@@ -1096,15 +1102,42 @@ export class FileThreadStore implements ThreadStore {
     }
     const rolloutPath = this.readableRolloutPath(entry);
     if (rolloutPath === undefined || !existsSync(rolloutPath)) return;
-    appendFileSync(
-      rolloutPath,
-      serializeRolloutItem({
-        type: "session_meta",
-        payload,
-      } as RolloutItem),
-      "utf8",
-    );
-    this.indexRolloutFile(rolloutPath);
+    // Another store instance may own a live writer for this rollout (the
+    // daemon archives sessions that bootstrap-services' store created). A
+    // foreign appendFileSync would bypass that writer's size and offset
+    // bookkeeping, so under a held lease the registry alone records the
+    // change and the file is left to its owner.
+    this.withRolloutLease(rolloutPath, () => {
+      appendFileSync(
+        rolloutPath,
+        serializeRolloutItem({
+          type: "session_meta",
+          payload,
+        } as RolloutItem),
+        "utf8",
+      );
+      this.indexRolloutFile(rolloutPath);
+    });
+  }
+
+  /**
+   * Run `fn` while holding the rollout's session lease. Returns undefined
+   * without running it when a live process (this one included) already holds
+   * the lease: the same check retention uses before deleting a session.
+   */
+  private withRolloutLease<T>(rolloutPath: string, fn: () => T): T | undefined {
+    const lease = new SessionLock(`${rolloutPath}.lock`);
+    try {
+      lease.acquire();
+    } catch (error) {
+      if (error instanceof SessionLockedError) return undefined;
+      throw error;
+    }
+    try {
+      return fn();
+    } finally {
+      lease.release();
+    }
   }
 
   private indexReadableRollout(entry: RegistryEntry): void {
@@ -1127,21 +1160,31 @@ export class FileThreadStore implements ThreadStore {
     });
   }
 
-  private archiveRolloutFile(entry: RegistryEntry): string | undefined {
-    if (entry.rolloutPath === undefined || !existsSync(entry.rolloutPath)) {
+  private archiveRolloutFile(
+    entry: RegistryEntry,
+    options: { readonly ownedWriter?: boolean } = {},
+  ): string | undefined {
+    const rolloutPath = entry.rolloutPath;
+    if (rolloutPath === undefined || !existsSync(rolloutPath)) {
       return entry.archivedRolloutPath;
     }
-    const targetDir = join(this.archivedSessionsDir, entry.threadId);
-    mkdirSync(targetDir, { recursive: true });
-    let targetPath = join(targetDir, basename(entry.rolloutPath));
-    if (existsSync(targetPath) && targetPath !== entry.rolloutPath) {
-      targetPath = join(
-        targetDir,
-        `${Date.now()}-${basename(entry.rolloutPath)}`,
-      );
-    }
-    this.relocateRolloutFile(entry.rolloutPath, targetPath);
-    return targetPath;
+    const relocate = (): string => {
+      const targetDir = join(this.archivedSessionsDir, entry.threadId);
+      mkdirSync(targetDir, { recursive: true });
+      let targetPath = join(targetDir, basename(rolloutPath));
+      if (existsSync(targetPath) && targetPath !== rolloutPath) {
+        targetPath = join(targetDir, `${Date.now()}-${basename(rolloutPath)}`);
+      }
+      this.relocateRolloutFile(rolloutPath, targetPath);
+      return targetPath;
+    };
+    if (options.ownedWriter === true) return relocate();
+    // A held lease means a live writer elsewhere still owns this file; a
+    // rename now would split its journal across two paths (the writer keeps
+    // appending by path) and leave the daemon snapshot pointing at the old
+    // one. Record the archive in the registry only; the owner's
+    // shutdownThread completes the move once it releases the lease.
+    return this.withRolloutLease(rolloutPath, relocate) ?? entry.archivedRolloutPath;
   }
 
   private unarchiveRolloutFile(entry: RegistryEntry): string | undefined {

--- a/runtime/src/thread-store/store.ts
+++ b/runtime/src/thread-store/store.ts
@@ -56,6 +56,7 @@ import {
 import { StateThreadRepository } from "../state/threads.js";
 import { backfillRolloutFile } from "../state/backfill.js";
 import { isRecord } from "../utils/record.js";
+import { timed } from "../utils/slow-store-op.js";
 
 // ─────────────────────────────────────────────────────────────────────
 // Params + types — mirrored from agenc runtime `thread-store/src/types.rs`.
@@ -848,28 +849,30 @@ export class FileThreadStore implements ThreadStore {
 
   archiveThread(params: ArchiveThreadParams): void {
     this.assertOpen();
-    this.updateRegistry((registry) => {
-      const existing = registry.get(params.threadId);
-      if (existing === undefined) {
-        throw new ThreadNotFoundError(params.threadId);
-      }
-      if (existing.archivedAt !== undefined) {
-        return; // already archived
-      }
-      const now = new Date().toISOString();
-      this.appendThreadMetadataRollout(existing, {
-        archivedAt: now,
-      });
-      const archivedRolloutPath = this.liveRecorders.has(params.threadId)
-        ? existing.archivedRolloutPath
-        : this.archiveRolloutFile(existing);
-      registry.set(params.threadId, {
-        ...existing,
-        updatedAt: now,
-        archivedAt: now,
-        ...(archivedRolloutPath !== undefined ? { archivedRolloutPath } : {}),
-      });
-    });
+    timed("thread_archive", () =>
+      this.updateRegistry((registry) => {
+        const existing = registry.get(params.threadId);
+        if (existing === undefined) {
+          throw new ThreadNotFoundError(params.threadId);
+        }
+        if (existing.archivedAt !== undefined) {
+          return; // already archived
+        }
+        const now = new Date().toISOString();
+        this.appendThreadMetadataRollout(existing, {
+          archivedAt: now,
+        });
+        const archivedRolloutPath = this.liveRecorders.has(params.threadId)
+          ? existing.archivedRolloutPath
+          : this.archiveRolloutFile(existing);
+        registry.set(params.threadId, {
+          ...existing,
+          updatedAt: now,
+          archivedAt: now,
+          ...(archivedRolloutPath !== undefined ? { archivedRolloutPath } : {}),
+        });
+      }),
+    );
   }
 
   unarchiveThread(params: ArchiveThreadParams): StoredThread {

--- a/runtime/src/utils/slow-store-op.ts
+++ b/runtime/src/utils/slow-store-op.ts
@@ -1,0 +1,61 @@
+/**
+ * Timing guard for synchronous store operations that run on the event loop
+ * serving the daemon's RPC. Sessions execute in-process, so a slow snapshot
+ * write, rollout flush, canonical scan, prune or archive stalls every client;
+ * until now none of them left a trace anywhere. Anything slower than the
+ * threshold is reported through the configured reporter as a
+ * `slow_store_op` warning carrying the label and duration. The default
+ * reporter writes one console.warn line, which the detached daemon routes into
+ * its rotating daemon.log sink.
+ */
+export const SLOW_STORE_OP_THRESHOLD_MS = 50;
+
+export interface SlowStoreOpWarning {
+  readonly cause: "slow_store_op";
+  readonly label: string;
+  readonly ms: number;
+}
+
+export type SlowStoreOpReporter = (warning: SlowStoreOpWarning) => void;
+
+const defaultReporter: SlowStoreOpReporter = (warning) => {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `agenc: slow_store_op ${JSON.stringify({ label: warning.label, ms: warning.ms })}`,
+  );
+};
+
+let reporter: SlowStoreOpReporter = defaultReporter;
+
+/** Replace the process-wide reporter; `undefined` restores the default. */
+export function setSlowStoreOpReporter(
+  next: SlowStoreOpReporter | undefined,
+): void {
+  reporter = next ?? defaultReporter;
+}
+
+/**
+ * Run `fn`, returning its result (or rethrowing its error), and report when it
+ * took longer than `thresholdMs`. Reporting never masks the operation: a
+ * throwing reporter is swallowed.
+ */
+export function timed<T>(
+  label: string,
+  fn: () => T,
+  report: SlowStoreOpReporter = reporter,
+  thresholdMs: number = SLOW_STORE_OP_THRESHOLD_MS,
+): T {
+  const startedAt = performance.now();
+  try {
+    return fn();
+  } finally {
+    const ms = performance.now() - startedAt;
+    if (ms > thresholdMs) {
+      try {
+        report({ cause: "slow_store_op", label, ms: Math.round(ms) });
+      } catch {
+        // A failing reporter must not turn a slow store op into a failed one.
+      }
+    }
+  }
+}

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -2927,6 +2927,68 @@ describe("AgenC background agent lifecycle", () => {
     );
   });
 
+  it("reopens an interactive session whose retained label differs from the rollout", async () => {
+    // A deferred-initial-turn client (the desktop app, `agenc` itself)
+    // registers a label like "Interactive session" while the rollout's
+    // canonical objective is the user's first prompt. Comparing the two
+    // made every interactive session permanently unresumable once its
+    // agent ended.
+    const fixture = createResumeFixture("conv-interactive1", {
+      objective: "Reply with the single word: ok",
+    });
+    const sessions = new AgenCDaemonSessionManager({
+      createSessionId: sequence(["session_interactive_resumed"]),
+      now: sequence(["2026-08-19T12:00:01.000Z"]),
+    });
+    const startAgent = vi.fn(async () => ({
+      agentId: "unexpected_fresh_agent",
+      startedAt: "2026-08-19T12:00:00.500Z",
+      status: "running" as const,
+    }));
+    const restoreAgent = vi.fn(async () => true);
+    const agents = new AgenCDaemonAgentManager({
+      now: sequence(["2026-08-19T12:00:00.000Z"]),
+      runner: { startAgent, restoreAgent },
+      sessionManager: sessions,
+    });
+    await agents.restoreAgent({
+      agentId: "conv-interactive1",
+      // The label a deferred-initial-turn client registers.
+      objective: "Interactive session",
+      status: "stopped",
+      createdAt: "2026-05-01T12:30:00.000Z",
+      startedAt: "2026-05-01T12:30:00.000Z",
+      lastActiveAt: "2026-05-01T12:31:00.000Z",
+      cwd: fixture.cwd,
+      metadata: { agentPath: "/root", model: "grok-4", provider: "grok" },
+      sessionIds: ["session_interactive_original"],
+    });
+
+    await expect(
+      createTestAgent(agents, {
+        resumeSessionId: "conv-interactive1",
+        resumeRolloutPath: fixture.rolloutPath,
+        resumeSourceProof: fixture.sourceProof,
+        cwd: fixture.cwd,
+      }),
+    ).resolves.toMatchObject({
+      agentId: "conv-interactive1",
+      // The disposable label is replaced by the canonical objective.
+      objective: "Reply with the single word: ok",
+      status: "running",
+      activeSessionIds: expect.arrayContaining([
+        "session_interactive_resumed",
+      ]),
+    });
+    expect(startAgent).not.toHaveBeenCalled();
+    expect(restoreAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "conv-interactive1",
+        objective: "Reply with the single word: ok",
+      }),
+    );
+  });
+
   it("restores the latest canonical runtime overlay instead of stale agent metadata", async () => {
     const fixture = createResumeFixture("conv-runtime-overlay1", {
       runtimeSettings: (cwd) =>
@@ -3405,7 +3467,15 @@ describe("AgenC background agent lifecycle", () => {
     expect(restoreAgent).toHaveBeenCalledOnce();
   });
 
-  it.each(["objective", "createdAt", "model", "provider"] as const)(
+  /*
+   * `objective` is deliberately absent: the retained objective is a
+   * client-supplied label, not session identity. Interactive clients defer
+   * the initial turn and register a label that can never equal the
+   * rollout's canonical objective, and a successful resume overwrites it
+   * with the canonical one anyway. The rollout's binding to this session is
+   * proven by its path, filename, filesystem proof and journal run id.
+   */
+  it.each(["createdAt", "model", "provider"] as const)(
     "rejects stale retained %s that disagrees with canonical rollout authority",
     async (field) => {
       const sessionId = `conv-stale-${field.toLowerCase()}1`;
@@ -3423,10 +3493,7 @@ describe("AgenC background agent lifecycle", () => {
       });
       await agents.restoreAgent({
         agentId: sessionId,
-        objective:
-          field === "objective"
-            ? "stale projected objective"
-            : "retained canonical objective",
+        objective: "retained canonical objective",
         status: "stopped",
         // Drift beyond RETAINED_CREATED_AT_TOLERANCE_MS (#1750): benign
         // millisecond skew between the daemon clock and the rollout header is
@@ -3441,7 +3508,9 @@ describe("AgenC background agent lifecycle", () => {
         metadata: {
           agentPath: "/root",
           model: field === "model" ? "stale-model" : "grok-4",
-          provider: field === "provider" ? "stale-provider" : "xai",
+          // Matches the fixture rollout's `modelProvider`; anything else
+          // would trip this very check for the unrelated rows.
+          provider: field === "provider" ? "stale-provider" : "grok",
         },
       });
 

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -627,19 +627,30 @@ async function waitForCondition(
   throw new Error(`timed out waiting for ${description}`);
 }
 
-async function waitForSnapshotCount(
+/**
+ * Resolve with the newest snapshot_at of the session once a row newer than
+ * `after` exists. Restart recovery writes each recovered session once, at
+ * hydration, with the daemon's real clock; under the default snapshot_days
+ * retention that write also prunes a seeded row that is older than the
+ * window, so a row count cannot serve as the evidence that recovery wrote.
+ */
+async function waitForSnapshotAfter(
   agencHome: string,
   cwd: string,
   sessionId: string,
-  minimum: number,
-): Promise<number> {
+  after: string,
+): Promise<string> {
   const startedAt = Date.now();
+  let newest: string | undefined;
   while (Date.now() - startedAt < 2_000) {
-    const count = snapshotCount(agencHome, cwd, sessionId);
-    if (count >= minimum) return count;
+    const times = readSnapshotTimes(agencHome, cwd, sessionId);
+    newest = times[times.length - 1];
+    if (newest !== undefined && newest > after) return newest;
     await delay(10);
   }
-  throw new Error(`timed out waiting for snapshots for ${sessionId}`);
+  throw new Error(
+    `timed out waiting for a snapshot of ${sessionId} newer than ${after}; newest: ${newest ?? "none"}`,
+  );
 }
 
 async function waitForRecoveredToolStatus(
@@ -4656,12 +4667,24 @@ snapshot_max_bytes = 64
       { host, io, signalProcess, runner, snapshotPeriodicIntervalMs: 10 },
     );
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
-    await expect(
-      waitForSnapshotCount(agencHome, process.cwd(), "session-restart", 2),
-    ).resolves.toBeGreaterThanOrEqual(2);
-    await expect(
-      waitForSnapshotCount(agencHome, otherCwd, "session-other", 2),
-    ).resolves.toBeGreaterThanOrEqual(2);
+    // Each recovered session is re-written once at hydration, before the
+    // daemon advertises readiness. That write replaces the seeded row (it is
+    // older than the default snapshot_days window and is pruned on the same
+    // write), so the evidence is a row newer than the seed, not a row count.
+    const restartSnapshotAt = await waitForSnapshotAfter(
+      agencHome,
+      process.cwd(),
+      "session-restart",
+      SEEDED_RECOVERY_SNAPSHOT_AT,
+    );
+    expect(restartSnapshotAt > SEEDED_RECOVERY_SNAPSHOT_AT).toBe(true);
+    const otherSnapshotAt = await waitForSnapshotAfter(
+      agencHome,
+      otherCwd,
+      "session-other",
+      SEEDED_RECOVERY_SNAPSHOT_AT,
+    );
+    expect(otherSnapshotAt > SEEDED_RECOVERY_SNAPSHOT_AT).toBe(true);
     expect(
       latestSnapshotToolState(agencHome, otherCwd, "session-other"),
     ).toMatchObject({
@@ -6061,6 +6084,9 @@ snapshot_max_bytes = 64
   });
 });
 
+/** snapshot_at of the recovered row seeded by seedRecoverableDaemonState. */
+const SEEDED_RECOVERY_SNAPSHOT_AT = "2026-05-01T00:06:00.000Z";
+
 function seedRecoverableDaemonState(
   agencHome: string,
   params: {
@@ -6103,7 +6129,7 @@ function seedRecoverableDaemonState(
         "2026-05-01T00:05:00.000Z",
         params.sessionId,
         "client-1",
-        "2026-05-01T00:06:00.000Z",
+        SEEDED_RECOVERY_SNAPSHOT_AT,
         JSON.stringify({
           agentPath: `/root/${params.runId.replaceAll("-", "_")}`,
           ...(params.includeRuntimeOptions === false
@@ -6123,7 +6149,7 @@ function seedRecoverableDaemonState(
       )
       .run(
         params.sessionId,
-        "2026-05-01T00:06:00.000Z",
+        SEEDED_RECOVERY_SNAPSHOT_AT,
         JSON.stringify([{ role: "assistant", content: "state" }]),
         JSON.stringify({
           pending: params.toolCallId === undefined ? [] : [params.toolCallId],

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -6040,6 +6040,22 @@ snapshot_max_bytes = 64
     if (sessionId === undefined) throw new Error("session id missing");
     expect(binding?.sessionId).toBe(sessionId);
     expect(snapshotCount(agencHome, process.cwd(), sessionId)).toBe(0);
+    // agent.create writes the running status first; the attach-time tool
+    // event lands inside the one-second coalescing window and is written by
+    // the trailing timer, so wait for it before reading the routed row.
+    await waitForCondition(() => {
+      try {
+        const toolState = latestSnapshotToolState(
+          agencHome,
+          otherCwd,
+          sessionId,
+        ) as { readonly inFlight?: Record<string, unknown> };
+        return toolState.inFlight?.["tool-early-route"] !== undefined;
+      } catch {
+        return false;
+      }
+    }, "the attach-time tool event in the non-default project snapshot");
+    expect(snapshotCount(agencHome, process.cwd(), sessionId)).toBe(0);
     expect(
       latestSnapshotToolState(agencHome, otherCwd, sessionId),
     ).toMatchObject({

--- a/runtime/tests/app-server/resume-projection-explicit-home.test.ts
+++ b/runtime/tests/app-server/resume-projection-explicit-home.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { assertCanonicalRuntimeSettingsProjection } from "../../src/app-server/agent-lifecycle.js";
+import { setCurrentRuntimeSession } from "../../src/session/current-session.js";
+import type { Session } from "../../src/session/session.js";
+
+/**
+ * Live failure: with several sessions open in the daemon, every resume was
+ * refused with "runtime settings projection is unavailable: Ambiguous runtime
+ * session: N sessions are bootstrapped in this process and no session is
+ * bound to the current async context". The verification resolved the AgenC
+ * home through the ambient current-session accessor; it must use the daemon's
+ * home explicitly.
+ */
+describe("resume runtime-settings projection with several live sessions", () => {
+  afterEach(() => {
+    setCurrentRuntimeSession(null);
+  });
+
+  it("opens the project state database with the daemon home, not the ambient session", () => {
+    // Two tracked fallback sessions make the ambient accessor ambiguous.
+    setCurrentRuntimeSession({ conversationId: "a" } as unknown as Session);
+    setCurrentRuntimeSession({ conversationId: "b" } as unknown as Session);
+    const home = mkdtempSync(join(tmpdir(), "agenc-resume-home-"));
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-resume-cwd-"));
+    mkdirSync(join(cwd, ".git"), { recursive: true });
+
+    // No runtime-settings row exists yet, so a working open returns quietly;
+    // the old code threw before ever reaching the database.
+    expect(() =>
+      assertCanonicalRuntimeSettingsProjection(
+        cwd,
+        "conv-resume-test",
+        {} as never,
+        home,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/runtime/tests/app-server/run-inspection.contract.test.ts
+++ b/runtime/tests/app-server/run-inspection.contract.test.ts
@@ -657,6 +657,94 @@ describe("durable run inspection", () => {
     ).toMatchObject({ eventId: "terminal-from-jsonl", lastSequence: 1 });
   });
 
+  // Review P1-7: an ordinary desktop refresh of a running session turned it
+  // into an "operator action required" run at the next daemon restart.
+  it("serves a live run's current projection without recording a recovery deferral", () => {
+    seedDurableRuns();
+    new StateRunDurabilityRepository(driver).ensureInitialEpoch({
+      runId: "run-complete",
+      openedAt: NOW,
+    });
+    const sessionDir = join(paths.projectDir, "sessions", "run-complete");
+    mkdirSync(sessionDir, { recursive: true });
+    const rolloutPath = join(sessionDir, "rollout-live.jsonl");
+    writeFileSync(
+      rolloutPath,
+      serializeRolloutItem({
+        type: "event_msg",
+        payload: {
+          eventId: "terminal-from-live-jsonl",
+          id: "terminal-from-live-jsonl",
+          seq: 1,
+          msg: {
+            type: "run_terminal",
+            payload: {
+              runId: "run-complete",
+              epoch: 1,
+              status: "completed",
+              exitCode: 0,
+              stopReason: "turn_completed",
+              finalMessage: "Recovered from the journal",
+              usage: {
+                inputTokens: 5,
+                outputTokens: 3,
+                totalTokens: 8,
+                costUsd: 0.001,
+              },
+              lastSequenceBeforeTerminal: null,
+              finishedAt: "2026-07-18T12:05:00.000Z",
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+    // The live writer's lease, held by this process.
+    const lockPath = `${rolloutPath}.lock`;
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        pid: process.pid,
+        startNs: "live-writer",
+        acquiredAtIso: NOW,
+      })}\n`,
+      { mode: 0o600 },
+    );
+    const deferredRows = (): number =>
+      driver
+        .prepareState<[], { readonly count: number }>(
+          "SELECT COUNT(*) AS count FROM run_recovery_deferred",
+        )
+        .get()?.count ?? 0;
+
+    for (let i = 0; i < 3; i++) {
+      // The projection is served as it stands: the epoch is open and the
+      // journal's terminal has not been projected because the source is live.
+      expect(service.status({ runId: "run-complete" })).toMatchObject({
+        runId: "run-complete",
+        status: "running",
+        statusSource: "run_lifecycle_epoch",
+        durableRun: { status: "completed" },
+      });
+      expect(service.replay({ runId: "run-complete" })).toMatchObject({
+        runId: "run-complete",
+      });
+    }
+    expect(deferredRows()).toBe(0);
+
+    // Once the writer is gone the next read projects the journal as usual.
+    rmSync(lockPath);
+    expect(service.result({ runId: "run-complete" })).toMatchObject({
+      status: "completed",
+      output: {
+        available: true,
+        finalMessage: "Recovered from the journal",
+        lastSequence: 1,
+      },
+    });
+    expect(deferredRows()).toBe(0);
+  });
+
   it("exports bounded hashes and explicitly excludes workflow evidence", () => {
     seedDurableRuns();
 

--- a/runtime/tests/app-server/run-inspection.contract.test.ts
+++ b/runtime/tests/app-server/run-inspection.contract.test.ts
@@ -93,6 +93,54 @@ function admissionRequest(
   };
 }
 
+/**
+ * Seed the durable runs, open epoch 1 for run-complete and write one canonical
+ * rollout under sessions/run-complete that carries its run_terminal event.
+ * Returns the rollout path.
+ */
+function seedCanonicalTerminalRollout(fileName: string, eventId: string): string {
+  seedDurableRuns();
+  new StateRunDurabilityRepository(driver).ensureInitialEpoch({
+    runId: "run-complete",
+    openedAt: NOW,
+  });
+  const sessionDir = join(paths.projectDir, "sessions", "run-complete");
+  mkdirSync(sessionDir, { recursive: true });
+  const rolloutPath = join(sessionDir, fileName);
+  writeFileSync(
+    rolloutPath,
+    serializeRolloutItem({
+      type: "event_msg",
+      payload: {
+        eventId,
+        id: eventId,
+        seq: 1,
+        msg: {
+          type: "run_terminal",
+          payload: {
+            runId: "run-complete",
+            epoch: 1,
+            status: "completed",
+            exitCode: 0,
+            stopReason: "turn_completed",
+            finalMessage: "Recovered from the journal",
+            usage: {
+              inputTokens: 5,
+              outputTokens: 3,
+              totalTokens: 8,
+              costUsd: 0.001,
+            },
+            lastSequenceBeforeTerminal: null,
+            finishedAt: "2026-07-18T12:05:00.000Z",
+          },
+        },
+      },
+    }),
+    "utf8",
+  );
+  return rolloutPath;
+}
+
 function seedDurableRuns(): readonly number[] {
   const admissions = new ExecutionAdmissionRepository(driver, {
     now: () => new Date(NOW),
@@ -600,45 +648,7 @@ describe("durable run inspection", () => {
   });
 
   it("rebuilds a missing terminal projection from the canonical JSONL event", () => {
-    seedDurableRuns();
-    new StateRunDurabilityRepository(driver).ensureInitialEpoch({
-      runId: "run-complete",
-      openedAt: NOW,
-    });
-    const sessionDir = join(paths.projectDir, "sessions", "run-complete");
-    mkdirSync(sessionDir, { recursive: true });
-    const rolloutPath = join(sessionDir, "rollout-terminal.jsonl");
-    writeFileSync(
-      rolloutPath,
-      serializeRolloutItem({
-        type: "event_msg",
-        payload: {
-          eventId: "terminal-from-jsonl",
-          id: "terminal-from-jsonl",
-          seq: 1,
-          msg: {
-            type: "run_terminal",
-            payload: {
-              runId: "run-complete",
-              epoch: 1,
-              status: "completed",
-              exitCode: 0,
-              stopReason: "turn_completed",
-              finalMessage: "Recovered from the journal",
-              usage: {
-                inputTokens: 5,
-                outputTokens: 3,
-                totalTokens: 8,
-                costUsd: 0.001,
-              },
-              lastSequenceBeforeTerminal: null,
-              finishedAt: "2026-07-18T12:05:00.000Z",
-            },
-          },
-        },
-      }),
-      "utf8",
-    );
+    seedCanonicalTerminalRollout("rollout-terminal.jsonl", "terminal-from-jsonl");
 
     expect(service.result({ runId: "run-complete" })).toMatchObject({
       status: "completed",
@@ -660,44 +670,9 @@ describe("durable run inspection", () => {
   // Review P1-7: an ordinary desktop refresh of a running session turned it
   // into an "operator action required" run at the next daemon restart.
   it("serves a live run's current projection without recording a recovery deferral", () => {
-    seedDurableRuns();
-    new StateRunDurabilityRepository(driver).ensureInitialEpoch({
-      runId: "run-complete",
-      openedAt: NOW,
-    });
-    const sessionDir = join(paths.projectDir, "sessions", "run-complete");
-    mkdirSync(sessionDir, { recursive: true });
-    const rolloutPath = join(sessionDir, "rollout-live.jsonl");
-    writeFileSync(
-      rolloutPath,
-      serializeRolloutItem({
-        type: "event_msg",
-        payload: {
-          eventId: "terminal-from-live-jsonl",
-          id: "terminal-from-live-jsonl",
-          seq: 1,
-          msg: {
-            type: "run_terminal",
-            payload: {
-              runId: "run-complete",
-              epoch: 1,
-              status: "completed",
-              exitCode: 0,
-              stopReason: "turn_completed",
-              finalMessage: "Recovered from the journal",
-              usage: {
-                inputTokens: 5,
-                outputTokens: 3,
-                totalTokens: 8,
-                costUsd: 0.001,
-              },
-              lastSequenceBeforeTerminal: null,
-              finishedAt: "2026-07-18T12:05:00.000Z",
-            },
-          },
-        },
-      }),
-      "utf8",
+    const rolloutPath = seedCanonicalTerminalRollout(
+      "rollout-live.jsonl",
+      "terminal-from-live-jsonl",
     );
     // The live writer's lease, held by this process.
     const lockPath = `${rolloutPath}.lock`;

--- a/runtime/tests/conversation/close-dangling-tool-calls.test.ts
+++ b/runtime/tests/conversation/close-dangling-tool-calls.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ConversationThreadManager,
+  DANGLING_TOOL_CALLS_CLOSED_CAUSE,
+  trailingDanglingToolCalls,
+} from "../../src/conversation/thread-manager.js";
+import type { ResponseItem, RolloutItem } from "../../src/session/rollout-item.js";
+import type { Session, SessionState } from "../../src/session/session.js";
+import { verifyToolResultIntegrity } from "../../src/session/tool-result-integrity.js";
+import { AsyncLock } from "../../src/utils/async-lock.js";
+
+// Live shape (desktop, 2026-09-02): a daemon restart killed a turn after the
+// model issued six parallel tool calls and before any result was recorded.
+// The resumed session was refused on its next message: "tool-pair history
+// rejected during live append: tool results must immediately follow their
+// assistant calls; unresolved: call-...-53 ... call-...-58".
+
+function makeSession(conversationId = "conv-resumed") {
+  const state = new AsyncLock<SessionState>({
+    sessionConfiguration: { cwd: "/tmp/work" } as SessionState["sessionConfiguration"],
+    history: [],
+  });
+  const appendRollout = vi.fn();
+  let subId = 0;
+  const session = {
+    conversationId,
+    state,
+    emit: vi.fn(),
+    seedInternalSubId: vi.fn((next: number) => {
+      subId = Math.max(subId, next);
+    }),
+    nextInternalSubId: vi.fn(() => `sub-${conversationId}-${subId++}`),
+    rolloutStore: {
+      appendRollout,
+      recordProjectionFailure: vi.fn(),
+      acknowledgeCompactionReconstruction: vi.fn(),
+    },
+    agentStatus: { value: { status: "pending_init" }, subscribe: vi.fn(() => vi.fn()) },
+  } as unknown as Session & {
+    readonly emit: ReturnType<typeof vi.fn>;
+    readonly state: AsyncLock<SessionState>;
+  };
+  return { session, appendRollout };
+}
+
+const user: RolloutItem = {
+  type: "response_item",
+  payload: { role: "user", content: "Add a particle explosion" },
+};
+const assistantWithCalls: RolloutItem = {
+  type: "response_item",
+  payload: {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      { id: "call-53", name: "Glob", arguments: '{"pattern":"arcade15/*.js"}' },
+      { id: "call-54", name: "FileRead", arguments: '{"file_path":"arcade15/main.js"}' },
+    ],
+  },
+};
+const resultFor = (id: string): RolloutItem => ({
+  type: "response_item",
+  payload: { role: "tool", content: "ok", toolCallId: id, toolName: "FileRead" },
+});
+
+describe("trailingDanglingToolCalls", () => {
+  it("lists the calls of the last assistant message without a result", () => {
+    const history = [user.payload, assistantWithCalls.payload, resultFor("call-54").payload] as ResponseItem[];
+    expect(trailingDanglingToolCalls(history)).toEqual([{ id: "call-53", name: "Glob" }]);
+  });
+
+  it("returns nothing when every call is resolved or the history ends in text", () => {
+    const resolved = [assistantWithCalls.payload, resultFor("call-53").payload, resultFor("call-54").payload] as ResponseItem[];
+    expect(trailingDanglingToolCalls(resolved)).toEqual([]);
+    expect(trailingDanglingToolCalls([user.payload as ResponseItem])).toEqual([]);
+    expect(trailingDanglingToolCalls([])).toEqual([]);
+  });
+});
+
+describe("replayRolloutIntoSession closes trailing dangling tool calls", () => {
+  it("appends sealed error results to the rollout and the history and warns", async () => {
+    const { session, appendRollout } = makeSession();
+    const manager = new ConversationThreadManager();
+
+    const replay = await manager.replayRolloutIntoSession(session, [user, assistantWithCalls]);
+
+    const history = replay.appliedState.history;
+    expect(history).toHaveLength(4);
+    const synthesized = history.slice(2);
+    expect(synthesized.map((item) => [item.role, item.toolCallId, item.toolName])).toEqual([
+      ["tool", "call-53", "Glob"],
+      ["tool", "call-54", "FileRead"],
+    ]);
+    for (const item of synthesized) {
+      expect(typeof item.content).toBe("string");
+      expect(item.content).toContain("interrupted");
+      expect(item.content).toContain(item.toolName as string);
+      // Sealed under the session's run id, like a live tool result.
+      const verification = verifyToolResultIntegrity({
+        integrity: item.toolResultIntegrity,
+        expectedRunId: "conv-resumed",
+        toolCallId: item.toolCallId as string,
+        content: item.content,
+      });
+      expect(verification.status).toBe("valid");
+    }
+    // Persisted through the live tool-pair gate, one item per call, in order.
+    expect(appendRollout).toHaveBeenCalledTimes(2);
+    expect(appendRollout.mock.calls.map(([item]) => [item.type, item.payload.toolCallId])).toEqual([
+      ["response_item", "call-53"],
+      ["response_item", "call-54"],
+    ]);
+    expect(appendRollout.mock.calls[0][0].payload).toEqual(synthesized[0]);
+    // The session state holds the same repaired history.
+    expect(session.state.unsafePeek().history).toEqual(history);
+    // One warning names the closed calls.
+    const warnings = session.emit.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.msg?.type === "warning");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].msg.payload.cause).toBe(DANGLING_TOOL_CALLS_CLOSED_CAUSE);
+    expect(warnings[0].msg.payload.message).toContain("Glob call-53");
+    expect(warnings[0].msg.payload.message).toContain("FileRead call-54");
+  });
+
+  it("leaves a fully resolved history untouched", async () => {
+    const { session, appendRollout } = makeSession();
+    const manager = new ConversationThreadManager();
+
+    const replay = await manager.replayRolloutIntoSession(session, [
+      user,
+      assistantWithCalls,
+      resultFor("call-53"),
+      resultFor("call-54"),
+    ]);
+
+    expect(replay.appliedState.history).toHaveLength(4);
+    expect(appendRollout).not.toHaveBeenCalled();
+    expect(session.emit.mock.calls.some(([event]) => event.msg?.type === "warning")).toBe(false);
+  });
+});

--- a/runtime/tests/conversation/close-dangling-tool-calls.test.ts
+++ b/runtime/tests/conversation/close-dangling-tool-calls.test.ts
@@ -83,7 +83,9 @@ describe("replayRolloutIntoSession closes trailing dangling tool calls", () => {
     const { session, appendRollout } = makeSession();
     const manager = new ConversationThreadManager();
 
-    const replay = await manager.replayRolloutIntoSession(session, [user, assistantWithCalls]);
+    const replay = await manager.replayRolloutIntoSession(session, [user, assistantWithCalls], {
+      emitSynthesized: true,
+    });
 
     const history = replay.appliedState.history;
     expect(history).toHaveLength(4);
@@ -122,6 +124,17 @@ describe("replayRolloutIntoSession closes trailing dangling tool calls", () => {
     expect(warnings[0].msg.payload.cause).toBe(DANGLING_TOOL_CALLS_CLOSED_CAUSE);
     expect(warnings[0].msg.payload.message).toContain("Glob call-53");
     expect(warnings[0].msg.payload.message).toContain("FileRead call-54");
+  });
+
+  it("repairs the history without emitting when the caller does not replay synthesized events", async () => {
+    const { session, appendRollout } = makeSession();
+    const manager = new ConversationThreadManager();
+
+    const replay = await manager.replayRolloutIntoSession(session, [user, assistantWithCalls]);
+
+    expect(replay.appliedState.history).toHaveLength(4);
+    expect(appendRollout).toHaveBeenCalledTimes(2);
+    expect(session.emit.mock.calls.some(([event]) => event.msg?.type === "warning")).toBe(false);
   });
 
   it("leaves a fully resolved history untouched", async () => {

--- a/runtime/tests/conversation/highest-internal-sub-id.test.ts
+++ b/runtime/tests/conversation/highest-internal-sub-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { highestInternalSubId } from "../../src/conversation/thread-manager.js";
+import type { RolloutItem } from "../../src/session/rollout-store.js";
+
+const event = (id: string, turnId?: string): RolloutItem =>
+  ({
+    type: "event_msg",
+    payload: {
+      id,
+      msg: { type: "turn_started", payload: turnId === undefined ? {} : { turnId } },
+    },
+  }) as unknown as RolloutItem;
+
+describe("highestInternalSubId", () => {
+  it("reads event ids and turn ids of the conversation and ignores others", () => {
+    const items: RolloutItem[] = [
+      { type: "session_meta", payload: {} } as unknown as RolloutItem,
+      event("sub-conv-a-1"),
+      event("sub-conv-a-40", "sub-conv-a-39"),
+      event("sub-conv-b-900"),
+      event("sub-conv-a-7", "sub-conv-a-3352"),
+      event("not-an-id"),
+    ];
+    // Live shape: a resumed session restarted at 0 and its first turn id
+    // collided with the original turn 2's admission record.
+    expect(highestInternalSubId(items, "conv-a")).toBe(3352);
+    expect(highestInternalSubId(items, "conv-b")).toBe(900);
+    expect(highestInternalSubId(items, "conv-c")).toBe(-1);
+    expect(highestInternalSubId([], "conv-a")).toBe(-1);
+  });
+});

--- a/runtime/tests/conversation/thread-manager.contract.test.ts
+++ b/runtime/tests/conversation/thread-manager.contract.test.ts
@@ -69,6 +69,7 @@ function makeSession(conversationId = "root-thread") {
   let rolloutPersistenceSuspendDepth = 0;
   return {
     conversationId,
+    seedInternalSubId: vi.fn(),
     roleWorkspace: ROLE_WORKSPACE,
     state,
     agentStatus: {

--- a/runtime/tests/permissions/settings.test.ts
+++ b/runtime/tests/permissions/settings.test.ts
@@ -413,6 +413,52 @@ describe("canonical permission persistence", () => {
 });
 
 describe("permission CLI/mode helpers", () => {
+  test("persists exact-cwd bypass consent when a trusted session starts in bypass mode", async () => {
+    // A desktop session created with permissionMode "bypassPermissions" was
+    // authorized in memory only; after a daemon restart its resume was
+    // refused with "restored bypass permission mode requires persisted
+    // exact-cwd consent". Explicit startup bypass now records the consent.
+    let env = await canonicalEnv({ diskState: true });
+    const canonicalCwd = canonicalizeBypassPermissionsCwd(env.cwd!);
+    const { toolPermissionContext } = await initializeToolPermissionContext({
+      env,
+      projectTrust: "trusted",
+      permissionMode: "bypassPermissions",
+    });
+    expect(toolPermissionContext).toMatchObject({
+      mode: "bypassPermissions",
+      bypassPermissionsAcceptedIn: [canonicalCwd],
+    });
+    env = await restartCanonicalEnv(env);
+    expect(
+      loadBypassPermissionsConsent(
+        env.configStore.stateRepository,
+        env.cwd!,
+        { reload: true },
+      ),
+    ).toEqual([canonicalCwd]);
+    env.configStore.stateRepository.close();
+  });
+
+  test("does not persist bypass consent for an untrusted project", async () => {
+    let env = await canonicalEnv({ diskState: true });
+    await initializeToolPermissionContext({
+      env,
+      projectTrust: "untrusted",
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+    });
+    env = await restartCanonicalEnv(env);
+    expect(
+      loadBypassPermissionsConsent(
+        env.configStore.stateRepository,
+        env.cwd!,
+        { reload: true },
+      ),
+    ).toEqual([]);
+    env.configStore.stateRepository.close();
+  });
+
   test("restores exact-cwd bypass consent on trusted restart before a later mode switch", async () => {
     let env = await canonicalEnv({ diskState: true });
     const canonicalCwd = canonicalizeBypassPermissionsCwd(env.cwd!);

--- a/runtime/tests/session/normalize-history-persisted-shape.test.ts
+++ b/runtime/tests/session/normalize-history-persisted-shape.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeHistoryMessages } from "../../src/session/session.js";
+import { llmMessageToCheckpointResponseItem } from "../../src/session/message-history-conversion.js";
+import { createToolResultIntegrity } from "../../src/session/tool-result-integrity.js";
+
+// A resumed session restores `history` from the rollout reconstruction, which
+// yields persisted ResponseItems (seal at the top level). The live turn stores
+// LLMMessages (seal under `runtimeOnly`). Both shapes must normalize to the
+// same in-memory message, or the first checkpoint of the resumed turn throws
+// "checkpoint v2 requires every tool result to be sealed" (seen live on the
+// desktop after a daemon restart: 6 parallel tool calls executed, no tool
+// result was ever persisted, the turn died).
+describe("normalizeHistoryMessages", () => {
+  const integrity = createToolResultIntegrity({
+    runId: "conv-resumed",
+    toolCallId: "call-1",
+    content: "file body",
+  });
+
+  it("keeps the tool-result seal of a persisted (rollout) history item", () => {
+    const [restored] = normalizeHistoryMessages([
+      {
+        role: "tool",
+        content: "file body",
+        toolCallId: "call-1",
+        toolName: "FileRead",
+        toolResultIntegrity: integrity,
+      },
+    ]);
+    expect(restored?.runtimeOnly?.toolResultIntegrity).toEqual(integrity);
+    // The exact projection the durable checkpoint validates.
+    const projected = llmMessageToCheckpointResponseItem(restored!);
+    expect(projected.toolResultIntegrity).toBeDefined();
+  });
+
+  it("keeps the seal of a live (runtimeOnly) history item unchanged", () => {
+    const [live] = normalizeHistoryMessages([
+      {
+        role: "tool",
+        content: "file body",
+        toolCallId: "call-1",
+        toolName: "FileRead",
+        runtimeOnly: { toolResultIntegrity: integrity },
+      },
+    ]);
+    expect(live?.runtimeOnly?.toolResultIntegrity).toEqual(integrity);
+  });
+
+  it("prefers the runtimeOnly seal when both shapes are present", () => {
+    const other = createToolResultIntegrity({
+      runId: "conv-resumed",
+      toolCallId: "call-1",
+      content: "other body",
+    });
+    const [message] = normalizeHistoryMessages([
+      {
+        role: "tool",
+        content: "file body",
+        toolCallId: "call-1",
+        toolResultIntegrity: other,
+        runtimeOnly: { toolResultIntegrity: integrity },
+      },
+    ]);
+    expect(message?.runtimeOnly?.toolResultIntegrity).toEqual(integrity);
+  });
+
+  it("leaves unsealed non-tool items without runtimeOnly", () => {
+    const [user] = normalizeHistoryMessages([{ role: "user", content: "hi" }]);
+    expect(user?.runtimeOnly).toBeUndefined();
+  });
+});

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -50,6 +50,10 @@ import {
   AGENC_TRAJECTORY_EXPORT_PATH_ENV,
   TRAJECTORY_EXPORT_SCHEMA_VERSION,
 } from "./trajectory-export.js";
+import {
+  SLOW_STORE_OP_THRESHOLD_MS,
+  setSlowStoreOpReporter,
+} from "../utils/slow-store-op.js";
 
 describe("session-store", () => {
   let home = "";
@@ -2024,6 +2028,73 @@ describe("session-store", () => {
       store.setFsyncImplForTest(fsyncSync);
       store.close();
     }
+  });
+
+  test("a slow flush reports its timing without appending to the rollout", () => {
+    const store = new SessionStore({
+      cwd: "/home/test-slow-flush",
+      sessionId: "sess-slow-flush",
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId: "sess-slow-flush",
+      timestamp: new Date().toISOString(),
+      cwd: "/home/test-slow-flush",
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+
+    // A mounted session turns every store diagnostic into `session.emit`,
+    // which appends a live-sequenced event to the rollout being flushed. If a
+    // slow flush went down that channel, the journal's contents would depend
+    // on how long one fsync took, and the appended warning would itself be
+    // flushed durably — so the slower the disk, the more it writes.
+    const diagnostics: string[] = [];
+    store.setDiagnosticListener((d) => {
+      diagnostics.push(d.cause);
+    });
+    const slowOps: string[] = [];
+    setSlowStoreOpReporter((warning) => {
+      slowOps.push(warning.label);
+    });
+    store.setFsyncImplForTest((fd: number) => {
+      const until = performance.now() + SLOW_STORE_OP_THRESHOLD_MS + 10;
+      while (performance.now() < until) {
+        // busy wait: the guard measures synchronous work on the event loop
+      }
+      return fsyncSync(fd);
+    });
+
+    try {
+      store.append(
+        {
+          id: "durable-slow",
+          seq: 1,
+          msg: { type: "turn_complete", payload: { turnId: "turn-slow" } },
+        },
+        { durable: true },
+      );
+    } finally {
+      store.setFsyncImplForTest(fsyncSync);
+      setSlowStoreOpReporter(undefined);
+    }
+
+    expect(diagnostics).not.toContain("slow_store_op");
+    expect(slowOps).toContain("rollout_flush_durable");
+    const eventTypes = readFileSync(store.rolloutPath, "utf8")
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            readonly type?: string;
+            readonly payload?: { readonly msg?: { readonly type?: string } };
+          },
+      )
+      .filter((item) => item.type === "event_msg")
+      .map((item) => item.payload?.msg?.type);
+    expect(eventTypes).toEqual(["turn_complete"]);
+    store.close();
   });
 
   test("appendRollout inherits durable flushing for terminal event_msg rows", () => {

--- a/runtime/tests/session/thread-store.test.ts
+++ b/runtime/tests/session/thread-store.test.ts
@@ -53,6 +53,44 @@ function responseItem(id: string, text: string): RolloutItem {
   };
 }
 
+/**
+ * Two FileThreadStore instances over one project (the daemon's and the one
+ * bootstrap-services gives each session) with one live thread owned by the
+ * first: the shape behind the archive-while-live findings.
+ */
+function openForeignArchiveFixture(sessionId: string): {
+  readonly rollout: RolloutStore;
+  readonly originalPath: string;
+  readonly owner: FileThreadStore;
+  readonly daemon: FileThreadStore;
+  readonly close: () => void;
+} {
+  const cwd = mkdtempSync(join(tmpdir(), "agenc-ts-cwd-"));
+  const rollout = openStore({ cwd, sessionId });
+  const owner = new FileThreadStore({ cwd });
+  const daemon = new FileThreadStore({ cwd });
+  owner.createThread({ threadId: sessionId, rolloutStore: rollout });
+  owner.appendItems({ threadId: sessionId, items: [responseItem("a", "alpha")] });
+  return {
+    rollout,
+    originalPath: rollout.rolloutPath,
+    owner,
+    daemon,
+    close: () => {
+      daemon.close();
+      owner.close();
+      rollout.close();
+      rmSync(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+function rolloutLineCount(rolloutPath: string): number {
+  return readFileSync(rolloutPath, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0).length;
+}
+
 beforeEach(() => {
   agencHome = mkdtempSync(join(tmpdir(), "agenc-thread-store-home-"));
   originalAgencHome = process.env.AGENC_HOME ?? "";
@@ -422,20 +460,10 @@ describe("FileThreadStore.archiveThread / listThreads", () => {
   // suspended run across two files and left a foreign session_meta line the
   // writer's offset bookkeeping never saw.
   it("does not rename or append to a rollout another store instance is still writing", () => {
-    const cwd = mkdtempSync(join(tmpdir(), "agenc-ts-cwd-"));
-    const rollout = openStore({ cwd, sessionId: "foreign-archive" });
-    const originalPath = rollout.rolloutPath;
-    const owner = new FileThreadStore({ cwd });
-    const daemon = new FileThreadStore({ cwd });
+    const fixture = openForeignArchiveFixture("foreign-archive");
+    const { originalPath, owner, daemon } = fixture;
     try {
-      owner.createThread({ threadId: "foreign-archive", rolloutStore: rollout });
-      owner.appendItems({
-        threadId: "foreign-archive",
-        items: [responseItem("a", "alpha")],
-      });
-      const linesBefore = readFileSync(originalPath, "utf8")
-        .split(/\r?\n/)
-        .filter((line) => line.length > 0).length;
+      const linesBefore = rolloutLineCount(originalPath);
 
       // The second instance sees no live recorder for the thread, but the
       // owner's writer still holds `<rollout>.lock`.
@@ -445,10 +473,7 @@ describe("FileThreadStore.archiveThread / listThreads", () => {
       expect(
         existsSync(join(owner.getProjectDir(), "archived_sessions", "foreign-archive")),
       ).toBe(false);
-      const linesAfter = readFileSync(originalPath, "utf8")
-        .split(/\r?\n/)
-        .filter((line) => line.length > 0).length;
-      expect(linesAfter).toBe(linesBefore);
+      expect(rolloutLineCount(originalPath)).toBe(linesBefore);
       const archived = daemon.readThread({
         threadId: "foreign-archive",
         includeArchived: true,
@@ -480,25 +505,14 @@ describe("FileThreadStore.archiveThread / listThreads", () => {
         ),
       ).toBe(true);
     } finally {
-      daemon.close();
-      owner.close();
-      rollout.close();
-      rmSync(cwd, { recursive: true, force: true });
+      fixture.close();
     }
   });
 
   it("archives a rollout whose writer has gone away, appending the metadata line", () => {
-    const cwd = mkdtempSync(join(tmpdir(), "agenc-ts-cwd-"));
-    const rollout = openStore({ cwd, sessionId: "released-archive" });
-    const originalPath = rollout.rolloutPath;
-    const owner = new FileThreadStore({ cwd });
-    const daemon = new FileThreadStore({ cwd });
+    const fixture = openForeignArchiveFixture("released-archive");
+    const { originalPath, owner, daemon, rollout } = fixture;
     try {
-      owner.createThread({ threadId: "released-archive", rolloutStore: rollout });
-      owner.appendItems({
-        threadId: "released-archive",
-        items: [responseItem("a", "alpha")],
-      });
       owner.discardThread("released-archive");
       rollout.close(); // releases the lease
 
@@ -522,10 +536,7 @@ describe("FileThreadStore.archiveThread / listThreads", () => {
       // The lease taken for the append and the move was released again.
       expect(existsSync(`${originalPath}.lock`)).toBe(false);
     } finally {
-      daemon.close();
-      owner.close();
-      rollout.close();
-      rmSync(cwd, { recursive: true, force: true });
+      fixture.close();
     }
   });
 

--- a/runtime/tests/session/thread-store.test.ts
+++ b/runtime/tests/session/thread-store.test.ts
@@ -416,6 +416,119 @@ describe("FileThreadStore.archiveThread / listThreads", () => {
     }
   });
 
+  // Review P1-4: the daemon holds its own FileThreadStore next to the one each
+  // session creates, so session.terminate archived (renamed and appended to)
+  // rollouts whose live writer belonged to another instance. That split one
+  // suspended run across two files and left a foreign session_meta line the
+  // writer's offset bookkeeping never saw.
+  it("does not rename or append to a rollout another store instance is still writing", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-ts-cwd-"));
+    const rollout = openStore({ cwd, sessionId: "foreign-archive" });
+    const originalPath = rollout.rolloutPath;
+    const owner = new FileThreadStore({ cwd });
+    const daemon = new FileThreadStore({ cwd });
+    try {
+      owner.createThread({ threadId: "foreign-archive", rolloutStore: rollout });
+      owner.appendItems({
+        threadId: "foreign-archive",
+        items: [responseItem("a", "alpha")],
+      });
+      const linesBefore = readFileSync(originalPath, "utf8")
+        .split(/\r?\n/)
+        .filter((line) => line.length > 0).length;
+
+      // The second instance sees no live recorder for the thread, but the
+      // owner's writer still holds `<rollout>.lock`.
+      daemon.archiveThread({ threadId: "foreign-archive" });
+
+      expect(existsSync(originalPath)).toBe(true);
+      expect(
+        existsSync(join(owner.getProjectDir(), "archived_sessions", "foreign-archive")),
+      ).toBe(false);
+      const linesAfter = readFileSync(originalPath, "utf8")
+        .split(/\r?\n/)
+        .filter((line) => line.length > 0).length;
+      expect(linesAfter).toBe(linesBefore);
+      const archived = daemon.readThread({
+        threadId: "foreign-archive",
+        includeArchived: true,
+        includeHistory: false,
+      });
+      expect(archived.archivedAt).toBeDefined();
+      expect(archived.rolloutPath).toBe(originalPath);
+
+      // The owner keeps appending to the same file it opened.
+      owner.appendItems({
+        threadId: "foreign-archive",
+        items: [responseItem("b", "bravo")],
+      });
+      expect(readFileSync(originalPath, "utf8")).toContain("bravo");
+
+      // Once the owner shuts the thread down it completes the deferred move,
+      // and the archived file carries the writer's full journal.
+      owner.shutdownThread("foreign-archive");
+      const moved = owner.readThread({
+        threadId: "foreign-archive",
+        includeArchived: true,
+        includeHistory: true,
+      });
+      expect(moved.rolloutPath).toContain("archived_sessions");
+      expect(existsSync(originalPath)).toBe(false);
+      expect(
+        moved.history?.items.some(
+          (item) => item.type === "response_item" && item.payload.id === "b",
+        ),
+      ).toBe(true);
+    } finally {
+      daemon.close();
+      owner.close();
+      rollout.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("archives a rollout whose writer has gone away, appending the metadata line", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-ts-cwd-"));
+    const rollout = openStore({ cwd, sessionId: "released-archive" });
+    const originalPath = rollout.rolloutPath;
+    const owner = new FileThreadStore({ cwd });
+    const daemon = new FileThreadStore({ cwd });
+    try {
+      owner.createThread({ threadId: "released-archive", rolloutStore: rollout });
+      owner.appendItems({
+        threadId: "released-archive",
+        items: [responseItem("a", "alpha")],
+      });
+      owner.discardThread("released-archive");
+      rollout.close(); // releases the lease
+
+      daemon.archiveThread({ threadId: "released-archive" });
+
+      const archived = daemon.readThread({
+        threadId: "released-archive",
+        includeArchived: true,
+        includeHistory: true,
+      });
+      expect(existsSync(originalPath)).toBe(false);
+      expect(archived.rolloutPath).toContain("archived_sessions");
+      expect(
+        archived.history?.items.some(
+          (item) =>
+            item.type === "session_meta" &&
+            (item.payload as { threadMetadata?: { archivedAt?: string } })
+              .threadMetadata?.archivedAt !== undefined,
+        ),
+      ).toBe(true);
+      // The lease taken for the append and the move was released again.
+      expect(existsSync(`${originalPath}.lock`)).toBe(false);
+    } finally {
+      daemon.close();
+      owner.close();
+      rollout.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("prefers an active rollout over an archived rollout with the same thread id", () => {
     const cwd = mkdtempSync(join(tmpdir(), "agenc-ts-cwd-"));
     const first = openStore({ cwd, sessionId: "same-id" });

--- a/runtime/tests/state/pruning.test.ts
+++ b/runtime/tests/state/pruning.test.ts
@@ -3,9 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  pruneSessionSnapshotsForSession,
+  pruneSessionSnapshotsPerSession,
   pruneSessionStateSnapshots,
   pruneTerminalAgentRuns,
+  SESSION_SNAPSHOT_HARD_CAP,
 } from "./pruning.js";
+import { defaultConfig } from "../../src/config/schema.js";
 import { recoverDaemonStateOnStartup } from "./recovery.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
 
@@ -227,6 +231,174 @@ describe("pruneTerminalAgentRuns", () => {
       sessionId: "session-latest-a",
       snapshotAt: "2026-05-01T00:00:02.000Z",
     });
+  });
+});
+
+// Review P0-2: the table-wide sweep above never deleted a row in the live
+// daemon (5,607 rows / 1.16 GB for one session under the default 64 MiB cap)
+// and cost a LENGTH() scan of the whole table per pass. The per-session prune
+// is bounded by the hard cap so it can run on every snapshot write.
+describe("pruneSessionSnapshotsForSession", () => {
+  it("keeps a session under the hard cap after 10,000 writes with the default retention", () => {
+    seedRun("agent-flood", "session-flood", "running", "2026-05-01T00:00:00.000Z");
+    const retention = defaultConfig().agent?.retention;
+    expect(retention).toMatchObject({
+      snapshot_days: 3,
+      snapshot_max_count: 10_000,
+      snapshot_max_bytes: 67_108_864,
+    });
+    const baseMs = Date.parse("2026-05-01T00:00:01.000Z");
+    driver.transaction(() => {
+      for (let index = 0; index < 10_000; index++) {
+        insertSnapshot(
+          "session-flood",
+          new Date(baseMs + index).toISOString(),
+          {
+            conversation: [{ role: "assistant", content: "x".repeat(1024) }],
+            toolState: { index },
+            mcpConnectionState: {},
+          },
+        );
+      }
+    });
+    expect(snapshotCount("session-flood")).toBe(10_001);
+
+    const report = pruneSessionSnapshotsForSession(driver, "session-flood", {
+      ...retention,
+      now: () => "2026-05-01T00:00:20.000Z",
+    });
+
+    expect(report).toEqual({
+      prunedSnapshots: 10_001 - SESSION_SNAPSHOT_HARD_CAP,
+      prunedSessionIds: ["session-flood"],
+    });
+    expect(snapshotCount("session-flood")).toBe(SESSION_SNAPSHOT_HARD_CAP);
+    expect(snapshotTimes("session-flood").at(-1)).toBe(
+      new Date(baseMs + 9_999).toISOString(),
+    );
+    // A second pass is a no-op over the retained rows.
+    expect(
+      pruneSessionSnapshotsForSession(driver, "session-flood", {
+        ...retention,
+        now: () => "2026-05-01T00:00:20.000Z",
+      }),
+    ).toEqual({ prunedSnapshots: 0, prunedSessionIds: [] });
+  });
+
+  it("applies a configured count cap below the hard cap and keeps the newest rows", () => {
+    for (const second of [1, 2, 3, 4, 5]) {
+      insertSnapshot("session-count", `2026-05-01T00:00:0${second}.000Z`, {
+        conversation: [],
+        toolState: {},
+        mcpConnectionState: {},
+      });
+    }
+
+    const report = pruneSessionSnapshotsForSession(driver, "session-count", {
+      snapshot_max_count: 2,
+    });
+
+    expect(report.prunedSnapshots).toBe(3);
+    expect(snapshotTimes("session-count")).toEqual([
+      "2026-05-01T00:00:04.000Z",
+      "2026-05-01T00:00:05.000Z",
+    ]);
+  });
+
+  it("applies the age cutoff but always keeps the newest row", () => {
+    insertSnapshot("session-age", "2026-04-20T00:00:00.000Z", {
+      conversation: [],
+      toolState: {},
+      mcpConnectionState: {},
+    });
+    insertSnapshot("session-age", "2026-04-21T00:00:00.000Z", {
+      conversation: [],
+      toolState: {},
+      mcpConnectionState: {},
+    });
+
+    pruneSessionSnapshotsForSession(driver, "session-age", {
+      snapshot_days: 3,
+      now: () => "2026-05-01T00:00:00.000Z",
+    });
+
+    expect(snapshotTimes("session-age")).toEqual(["2026-04-21T00:00:00.000Z"]);
+  });
+
+  it("applies the byte cap newest-first over the surviving rows", () => {
+    insertSnapshot("session-bytes", "2026-05-01T00:00:01.000Z", {
+      conversation: [],
+      toolState: {},
+      mcpConnectionState: { payload: "z".repeat(128) },
+    });
+    insertSnapshot("session-bytes", "2026-05-01T00:00:02.000Z", {
+      conversation: [],
+      toolState: { payload: "y".repeat(40) },
+      mcpConnectionState: {},
+    });
+    insertSnapshot("session-bytes", "2026-05-01T00:00:03.000Z", {
+      conversation: [{ payload: "x".repeat(40) }],
+      toolState: {},
+      mcpConnectionState: {},
+    });
+
+    const report = pruneSessionSnapshotsForSession(driver, "session-bytes", {
+      snapshot_max_bytes: 150,
+    });
+
+    expect(report.prunedSnapshots).toBe(1);
+    expect(snapshotTimes("session-bytes")).toEqual([
+      "2026-05-01T00:00:02.000Z",
+      "2026-05-01T00:00:03.000Z",
+    ]);
+  });
+
+  it("leaves other sessions alone even when they share the agent", () => {
+    seedRun("agent-shared", "session-shared-a", "running", "2026-05-01T00:00:00.000Z");
+    seedSessionAgentLink("session-shared-b", "agent-shared");
+    for (const second of [1, 2, 3]) {
+      insertSnapshot("session-shared-a", `2026-05-01T00:00:0${second}.000Z`, {
+        conversation: [],
+        toolState: {},
+        mcpConnectionState: {},
+      });
+      insertSnapshot("session-shared-b", `2026-05-01T00:00:0${second}.000Z`, {
+        conversation: [],
+        toolState: {},
+        mcpConnectionState: {},
+      });
+    }
+
+    pruneSessionSnapshotsForSession(driver, "session-shared-a", {
+      snapshot_max_count: 1,
+    });
+
+    expect(snapshotCount("session-shared-a")).toBe(1);
+    expect(snapshotCount("session-shared-b")).toBe(3);
+  });
+
+  it("pruneSessionSnapshotsPerSession caps every session independently", () => {
+    const baseMs = Date.parse("2026-05-01T00:00:00.000Z");
+    driver.transaction(() => {
+      for (const sessionId of ["session-many-a", "session-many-b"]) {
+        for (let index = 0; index < SESSION_SNAPSHOT_HARD_CAP + 10; index++) {
+          insertSnapshot(sessionId, new Date(baseMs + index).toISOString(), {
+            conversation: [],
+            toolState: {},
+            mcpConnectionState: {},
+          });
+        }
+      }
+    });
+
+    const report = pruneSessionSnapshotsPerSession(driver);
+
+    expect(report).toEqual({
+      prunedSnapshots: 20,
+      prunedSessionIds: ["session-many-a", "session-many-b"],
+    });
+    expect(snapshotCount("session-many-a")).toBe(SESSION_SNAPSHOT_HARD_CAP);
+    expect(snapshotCount("session-many-b")).toBe(SESSION_SNAPSHOT_HARD_CAP);
   });
 });
 

--- a/runtime/tests/state/recovery-restart.test.ts
+++ b/runtime/tests/state/recovery-restart.test.ts
@@ -111,6 +111,145 @@ describe("recoverDaemonStateOnStartup", () => {
     expect(agentRunStatus("run-admission-cancel-crash")).toBe("cancelled");
   });
 
+  // Review P1-7: desktop run.status/run.replay on a live run hit the writer's
+  // rollout lease, persisted a source_not_quiescent deferral, and that active
+  // row excluded the run from recovery at the next daemon start ("pending
+  // operator recovery action") even though nothing was wrong with the source.
+  describe("source_not_quiescent deferrals", () => {
+    const failedAtMs = Date.parse("2026-05-01T00:10:00.000Z");
+
+    function seedLiveSourceDeferral(
+      runId: string,
+      reasonCode: "source_not_quiescent" | "database_io" = "source_not_quiescent",
+    ): string {
+      insertAgentRun({
+        id: runId,
+        objective: "recover after a stale live-source deferral",
+        status: "running",
+        currentSessionId: runId,
+      });
+      const rolloutPath = writeRuntimeResumeJournal(runId);
+      bindRunJournal(runId, rolloutPath);
+      new StateRecoveryIncidentRepository(driver).recordDeferred({
+        runId,
+        sourceKind: "run_journal",
+        sourcePath: rolloutPath,
+        reasonCode,
+        errorClass: "RECOVERY_SOURCE_LIVE",
+        safeDetail: { message: "canonical recovery source is not quiescent" },
+        failedAtMs,
+        nextRetryMs: failedAtMs + 60_000,
+      });
+      return rolloutPath;
+    }
+
+    function deferredStates(runId: string): readonly string[] {
+      return driver
+        .prepareState<[string], { readonly state: string }>(
+          "SELECT state FROM run_recovery_deferred WHERE run_id = ? ORDER BY block_id",
+        )
+        .all(runId)
+        .map((row) => row.state);
+    }
+
+    it("resolves an expired source_not_quiescent deferral at startup and recovers the run", () => {
+      const runId = "run-stale-live-deferral";
+      const rolloutPath = seedLiveSourceDeferral(runId);
+
+      const report = recoverDaemonStateOnStartup(driver, {
+        now: () => "2026-05-01T00:11:01.000Z",
+      });
+
+      expect(report.recoveryExclusions).toEqual([]);
+      expect(report.recoveredRuns).toEqual([
+        expect.objectContaining({ id: runId, status: "running" }),
+      ]);
+      expect(projectedRolloutRows(rolloutPath)).toBe(1);
+      expect(deferredStates(runId)).toEqual(["resolved"]);
+    });
+
+    it("keeps an unexpired source_not_quiescent deferral in force", () => {
+      const runId = "run-fresh-live-deferral";
+      seedLiveSourceDeferral(runId);
+
+      const report = recoverDaemonStateOnStartup(driver, {
+        now: () => "2026-05-01T00:10:30.000Z",
+      });
+
+      expect(report.recoveredRuns).toEqual([]);
+      expect(report.recoveryExclusions).toEqual([
+        expect.objectContaining({
+          runId,
+          kind: "deferred",
+          reasonCode: "source_not_quiescent",
+        }),
+      ]);
+      expect(deferredStates(runId)).toEqual(["active"]);
+    });
+
+    it("leaves expired deferrals with other reason codes to the operator", () => {
+      const runId = "run-expired-io-deferral";
+      seedLiveSourceDeferral(runId, "database_io");
+
+      const report = recoverDaemonStateOnStartup(driver, {
+        now: () => "2026-05-01T00:11:01.000Z",
+      });
+
+      expect(report.recoveredRuns).toEqual([]);
+      expect(report.recoveryExclusions).toEqual([
+        expect.objectContaining({
+          runId,
+          kind: "deferred",
+          reasonCode: "database_io",
+        }),
+      ]);
+      expect(deferredStates(runId)).toEqual(["active"]);
+    });
+
+    it("serves an on-demand read of a live source without persisting a deferral", () => {
+      const runId = "run-live-on-demand";
+      insertAgentRun({
+        id: runId,
+        objective: "read while running",
+        status: "running",
+        currentSessionId: runId,
+      });
+      const rolloutPath = writeRuntimeResumeJournal(runId);
+      bindRunJournal(runId, rolloutPath);
+      writeFileSync(
+        `${rolloutPath}.lock`,
+        `${JSON.stringify({
+          pid: process.pid,
+          startNs: "live-writer",
+          acquiredAtIso: "2026-05-01T00:00:00.000Z",
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const served = recoverCanonicalRunJournalForRun(driver, runId, {
+        strict: { liveSourceDeferral: "skip" },
+      });
+      expect(served.exclusion).toMatchObject({
+        runId,
+        kind: "deferred",
+        reasonCode: "source_not_quiescent",
+        permanent: false,
+      });
+      expect(served.exclusion?.evidenceId).toBeUndefined();
+      expect(deferredStates(runId)).toEqual([]);
+
+      // The default (startup) contract still records the retryable block.
+      const recorded = recoverCanonicalRunJournalForRun(driver, runId);
+      expect(recorded.exclusion).toMatchObject({
+        runId,
+        kind: "deferred",
+        reasonCode: "source_not_quiescent",
+      });
+      expect(recorded.exclusion?.evidenceId).toBeDefined();
+      expect(deferredStates(runId)).toEqual(["active"]);
+    });
+  });
+
   it("keeps a canonically projected run listable when live cwd authority is unavailable", () => {
     const runId = "run-runtime-cwd-unavailable";
     insertAgentRun({

--- a/runtime/tests/state/run-durability.test.ts
+++ b/runtime/tests/state/run-durability.test.ts
@@ -492,6 +492,73 @@ describe("StateRunDurabilityRepository", () => {
     );
   });
 
+  it("lifts the run's admission lock when a cancelled run is explicitly reopened", () => {
+    // Live shape (a session whose turn a daemon restart had cancelled): the
+    // reopen created epoch 2 and moved the status to running, but the
+    // admission lock row survived and the first model step of the reopened
+    // run was denied with parent_cancel_locked.
+    runs.ensureInitialEpoch({ runId: "run-reopened-locked", openedAt: T0 });
+    runs.recordTerminalResult({
+      epoch: 1,
+      result: terminal({
+        runId: "run-reopened-locked",
+        status: "cancelled",
+        exitCode: null,
+        stopReason: "daemon_shutdown_not_idle",
+        finishedAt: T1,
+      }),
+      eventId: "event-terminal-locked",
+    });
+    driver
+      .prepareState(
+        `INSERT INTO execution_admission_cancellations (
+           run_id, reason, cancelled_at
+         ) VALUES (?, ?, ?)`,
+      )
+      .run("run-reopened-locked", "recovery_cascade_repair", T1);
+    driver
+      .prepareState(
+        `INSERT INTO agent_runs (
+           id, objective, status, started_at, last_active_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("run-reopened-locked", "continue", "cancelled", T0, T1);
+
+    const reopened = runs.reopenRun({
+      runId: "run-reopened-locked",
+      fromEpoch: 1,
+      openedAt: T2,
+      eventId: "event-reopen-locked",
+      reason: "user_session_continue",
+    });
+    expect(reopened.applied).toBe(true);
+    expect(
+      driver
+        .prepareState<[string], { readonly n: number }>(
+          `SELECT count(*) AS n FROM execution_admission_cancellations WHERE run_id = ?`,
+        )
+        .get("run-reopened-locked")?.n,
+    ).toBe(0);
+    expect(
+      driver
+        .prepareState<[string], { readonly status: string }>(
+          `SELECT status FROM agent_runs WHERE id = ?`,
+        )
+        .get("run-reopened-locked")?.status,
+    ).toBe("running");
+    // The reopened epoch crosses its next lifecycle boundary without conflict.
+    expect(
+      runs.recordRunSuspended({
+        runId: "run-reopened-locked",
+        epoch: 2,
+        eventId: "event-suspend-after-reopen",
+        eventSequence: 1,
+        reason: "daemon_shutdown_idle",
+        suspendedAt: T3,
+      }).applied,
+    ).toBe(true);
+  });
+
   it("keeps terminal results sticky and retains them across explicit reopen epochs", () => {
     const initial = runs.ensureInitialEpoch({
       runId: "run-1",

--- a/runtime/tests/state/run-durability.test.ts
+++ b/runtime/tests/state/run-durability.test.ts
@@ -15,6 +15,7 @@ import type {
   EffectReviewResolution,
   RunTerminalResult,
 } from "../../src/contracts/run-contracts.js";
+import { updateAgentRunStatus } from "../../src/state/agent-runs.js";
 import {
   RunDurabilityConflictError,
   StateRunDurabilityRepository,
@@ -305,15 +306,30 @@ describe("StateRunDurabilityRepository", () => {
       expect.objectContaining({ code: "RUN_CANCELLATION_CONFLICT" }),
     );
 
+  });
+
+  it("reopens a cancelled run into a fresh epoch while implicit writers stay locked out", () => {
+    // The cancellation lock exists so a dying agent's late status write
+    // loses against an explicit cancel. An operator reopening a settled
+    // terminal is the authorized transition — refusing it left every
+    // interrupted session permanently unresumable.
     runs.ensureInitialEpoch({ runId: "run-reopen-cancelled", openedAt: T0 });
     runs.recordTerminalResult({
       epoch: 1,
       result: terminal({
         runId: "run-reopen-cancelled",
         finishedAt: T1,
+        status: "cancelled",
       }),
       eventId: "event-terminal-before-cancel-lock",
     });
+    driver
+      .prepareState(
+        `INSERT INTO agent_runs (
+           id, objective, status, started_at, last_active_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("run-reopen-cancelled", "cancelled work", "cancelled", T0, T1);
     driver
       .prepareState(
         `INSERT INTO execution_admission_cancellations (
@@ -321,7 +337,8 @@ describe("StateRunDurabilityRepository", () => {
          ) VALUES (?, ?, ?)`,
       )
       .run("run-reopen-cancelled", "operator", T2);
-    expect(() =>
+
+    expect(
       runs.reopenRun({
         runId: "run-reopen-cancelled",
         fromEpoch: 1,
@@ -329,9 +346,46 @@ describe("StateRunDurabilityRepository", () => {
         eventId: "event-reopen-after-cancel",
         reason: "retry",
       }),
-    ).toThrowError(
-      expect.objectContaining({ code: "RUN_CANCELLATION_CONFLICT" }),
-    );
+    ).toMatchObject({
+      applied: true,
+      value: { epoch: 2, reopenedFromEpoch: 1 },
+    });
+    expect(
+      driver
+        .prepareState<[string], { status: string }>(
+          "SELECT status FROM agent_runs WHERE id = ?",
+        )
+        .get("run-reopen-cancelled")?.status,
+    ).toBe("running");
+  });
+
+  it("keeps a late implicit status write from undoing an explicit cancel", () => {
+    driver
+      .prepareState(
+        `INSERT INTO agent_runs (
+           id, objective, status, started_at, last_active_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("run-late-writer", "cancelled work", "cancelled", T0, T1);
+
+    expect(
+      updateAgentRunStatus(driver, {
+        id: "run-late-writer",
+        status: "running",
+        lastActiveAt: T2,
+      }),
+    ).toMatchObject({
+      applied: false,
+      reason: "cancel_locked_status_sticky",
+      existingStatus: "cancelled",
+    });
+    expect(
+      driver
+        .prepareState<[string], { status: string }>(
+          "SELECT status FROM agent_runs WHERE id = ?",
+        )
+        .get("run-late-writer")?.status,
+    ).toBe("cancelled");
   });
 
   it("lifts cancellation locks that an explicit reopen superseded", () => {

--- a/runtime/tests/state/run-durability.test.ts
+++ b/runtime/tests/state/run-durability.test.ts
@@ -334,6 +334,110 @@ describe("StateRunDurabilityRepository", () => {
     );
   });
 
+  it("lifts cancellation locks that an explicit reopen superseded", () => {
+    // Live shape: a daemon shutdown during a turn cancelled epoch 1, startup
+    // repair recorded an admission lock and a sticky `cancelled` status, the
+    // user continued the session into epoch 2, and every later boundary
+    // (suspend, resume, settings) was refused as cancellation-locked.
+    runs.ensureInitialEpoch({ runId: "run-revived", openedAt: T0 });
+    runs.recordTerminalResult({
+      epoch: 1,
+      result: terminal({
+        runId: "run-revived",
+        status: "cancelled",
+        exitCode: null,
+        stopReason: "daemon_shutdown_not_idle",
+        finishedAt: T1,
+      }),
+      eventId: "event-terminal-shutdown",
+    });
+    driver
+      .prepareState(
+        `INSERT INTO execution_admission_cancellations (
+           run_id, reason, cancelled_at
+         ) VALUES (?, ?, ?)`,
+      )
+      .run("run-revived", "recovery_cascade_repair", T1);
+    driver
+      .prepareState(
+        `INSERT INTO agent_runs (
+           id, objective, status, started_at, last_active_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("run-revived", "continue", "cancelled", T0, T1);
+    // The authorized reopen recorded its epoch after the locks.
+    driver
+      .prepareState(
+        `INSERT INTO run_lifecycle_epochs (
+           run_id, epoch, opened_at, opened_event_id,
+           reopened_from_epoch, reopen_reason
+         ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("run-revived", 2, T2, "event-reopen-continue", 1, "user_session_continue");
+
+    const suspended = runs.recordRunSuspended({
+      runId: "run-revived",
+      epoch: 2,
+      eventId: "event-suspend-after-revival",
+      eventSequence: 1,
+      reason: "daemon_shutdown_idle",
+      suspendedAt: T3,
+    });
+    expect(suspended.applied).toBe(true);
+    expect(
+      driver
+        .prepareState<[string], { readonly n: number }>(
+          `SELECT count(*) AS n FROM execution_admission_cancellations WHERE run_id = ?`,
+        )
+        .get("run-revived")?.n,
+    ).toBe(0);
+    expect(
+      driver
+        .prepareState<[string], { readonly status: string; readonly meta: string }>(
+          `SELECT status, metadata_json AS meta FROM agent_runs WHERE id = ?`,
+        )
+        .get("run-revived"),
+    ).toEqual({
+      status: "running",
+      meta: JSON.stringify({ cancellationLiftedBy: "explicit_reopen" }),
+    });
+
+    // A lock recorded AFTER the reopen is a real cancellation and still holds.
+    runs.ensureInitialEpoch({ runId: "run-recancelled", openedAt: T0 });
+    runs.recordTerminalResult({
+      epoch: 1,
+      result: terminal({ runId: "run-recancelled", finishedAt: T1 }),
+      eventId: "event-terminal-recancelled",
+    });
+    driver
+      .prepareState(
+        `INSERT INTO run_lifecycle_epochs (
+           run_id, epoch, opened_at, opened_event_id,
+           reopened_from_epoch, reopen_reason
+         ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("run-recancelled", 2, T2, "event-reopen-recancelled", 1, "retry");
+    driver
+      .prepareState(
+        `INSERT INTO execution_admission_cancellations (
+           run_id, reason, cancelled_at
+         ) VALUES (?, ?, ?)`,
+      )
+      .run("run-recancelled", "operator", T3);
+    expect(() =>
+      runs.recordRunSuspended({
+        runId: "run-recancelled",
+        epoch: 2,
+        eventId: "event-suspend-recancelled",
+        eventSequence: 1,
+        reason: "daemon_shutdown_idle",
+        suspendedAt: T3,
+      }),
+    ).toThrowError(
+      expect.objectContaining({ code: "RUN_CANCELLATION_CONFLICT" }),
+    );
+  });
+
   it("keeps terminal results sticky and retains them across explicit reopen epochs", () => {
     const initial = runs.ensureInitialEpoch({
       runId: "run-1",

--- a/runtime/tests/state/snapshot-policy-session-eviction.ihunt.test.ts
+++ b/runtime/tests/state/snapshot-policy-session-eviction.ihunt.test.ts
@@ -9,11 +9,11 @@ import {
 } from "../../src/state/sqlite-driver.js";
 
 // Regression guard for the unbounded in-memory #sessions leak:
-// `flushPeriodic()` emits exactly one snapshot record per session retained in
-// the in-memory map, so its length is a faithful probe of map size. Before the
-// fix there was no eviction path at all (no forgetSession, no LRU cap), so the
-// map grew one entry per distinct sessionId forever and flushPeriodic
-// re-snapshotted every session ever seen.
+// `trackedSessionIds()` lists the sessions retained in the in-memory map.
+// Before the fix there was no eviction path at all (no forgetSession, no LRU
+// cap), so the map grew one entry per distinct sessionId forever and
+// flushPeriodic re-snapshotted every session ever seen. (flushPeriodic itself
+// now only writes dirty sessions, so it is no longer a probe of map size.)
 
 let home = "";
 let cwd = "";
@@ -113,8 +113,5 @@ describe("AgenCSessionSnapshotPolicy in-memory session eviction", () => {
 });
 
 function periodicSessionIds(policy: AgenCSessionSnapshotPolicy): string[] {
-  return policy
-    .flushPeriodic()
-    .map((record) => record.sessionId)
-    .sort();
+  return [...policy.trackedSessionIds()].sort();
 }

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -151,6 +151,9 @@ describe("AgenCSessionSnapshotPolicy", () => {
         },
       });
     }
+    // Same-instant events coalesce into one trailing write; flush it so the
+    // assertion reads the final in-memory state.
+    policy.flushPeriodic();
 
     const completed = latestSnapshot("session-oom").toolState.completed as Record<
       string,
@@ -193,6 +196,7 @@ describe("AgenCSessionSnapshotPolicy", () => {
         },
       });
     }
+    policy.flushPeriodic();
 
     const inFlight = latestSnapshot("session-oom-inflight").toolState
       .inFlight as Record<string, unknown>;
@@ -234,6 +238,7 @@ describe("AgenCSessionSnapshotPolicy", () => {
         },
       });
     }
+    policy.flushPeriodic();
 
     const inFlight = latestSnapshot("session-inflight-drain").toolState
       .inFlight as Record<string, unknown>;
@@ -255,9 +260,158 @@ describe("AgenCSessionSnapshotPolicy", () => {
         transitionAt: "2026-05-01T00:00:00.000Z",
       });
     }
+    policy.flushPeriodic();
     const transitions = latestSnapshot("session-oom-st").toolState
       .statusTransitions as unknown[];
     expect(transitions.length).toBeLessThanOrEqual(25);
+  });
+
+  // Review P0-1: one snapshot row per forwarded `agent_message_delta` produced
+  // 4,931 rows / 980 MB for a single 82-minute desktop session, each row a
+  // full re-serialization with four fsyncs on the RPC event loop. A chunk now
+  // only extends the in-memory conversation tail; the dirty state rides the
+  // next tool/status write or the periodic tick.
+  it("does not write a snapshot row per streaming message chunk", () => {
+    seedRun("run-chunks", "session-chunks");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+    });
+
+    for (let i = 0; i < 1000; i++) {
+      policy.recordSessionEvent("session-chunks", {
+        method: "event.message_chunk",
+        params: {
+          agentId: "run-chunks",
+          delta: `token-${i} `,
+          messageId: "message-stream",
+          streamId: "stream-1",
+          eventId: `chunk-${i}`,
+        },
+      });
+    }
+    expect(snapshotCount("session-chunks")).toBe(0);
+
+    // The periodic tick flushes the accumulated tail in one write.
+    policy.flushPeriodic();
+    expect(snapshotCount("session-chunks")).toBeLessThanOrEqual(2);
+    const conversation = latestSnapshot("session-chunks").conversation as {
+      delta: string;
+    }[];
+    expect(conversation).toHaveLength(200);
+    expect(conversation.at(-1)?.delta).toBe("token-999 ");
+
+    // A clean session does not write again.
+    policy.flushPeriodic();
+    expect(snapshotCount("session-chunks")).toBeLessThanOrEqual(2);
+  });
+
+  it("coalesces a burst of tool events into one leading and one trailing write", () => {
+    seedRun("run-coalesce", "session-coalesce");
+    const timers: (() => void)[] = [];
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+      setTimeout: (callback, delayMs) => {
+        expect(delayMs).toBeGreaterThan(0);
+        expect(delayMs).toBeLessThanOrEqual(1_000);
+        timers.push(callback);
+        return { unref: vi.fn() };
+      },
+    });
+
+    for (let i = 0; i < 50; i++) {
+      policy.recordSessionEvent("session-coalesce", {
+        method: "event.tool_request",
+        params: {
+          agentId: "run-coalesce",
+          eventId: `evt-${i}`,
+          requestId: `tool-${i}`,
+          toolName: "FileRead",
+          input: { path: `${i}.txt` },
+        },
+      });
+      policy.recordSessionEvent("session-coalesce", {
+        method: "event.session_event",
+        params: {
+          agentId: "run-coalesce",
+          event: {
+            type: "tool_call_completed",
+            payload: { callId: `tool-${i}`, result: "ok", isError: false },
+          },
+        },
+      });
+    }
+
+    // Leading edge: the first event of the burst is written immediately;
+    // the other 99 events armed exactly one trailing timer.
+    expect(snapshotCount("session-coalesce")).toBe(1);
+    expect(timers).toHaveLength(1);
+
+    timers[0]?.();
+    expect(snapshotCount("session-coalesce")).toBe(2);
+    expect(latestSnapshot("session-coalesce").toolState).toMatchObject({
+      lastTrigger: "tool_call",
+      inFlight: {},
+      completed: { "tool-49": { status: "completed" } },
+    });
+    // Every tool result still landed row-by-row in the durable table.
+    expect(inFlightToolOutput("session-coalesce", "tool-49").status).toBe(
+      "completed",
+    );
+  });
+
+  it("bounds tool inputs and keeps at most 20 completed calls in the snapshot", () => {
+    seedRun("run-inputs", "session-inputs");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+    });
+    const bigInput = { file_path: "a.txt", content: "x".repeat(64 * 1024) };
+
+    for (let i = 0; i < 30; i++) {
+      policy.recordSessionEvent("session-inputs", {
+        method: "event.tool_request",
+        params: {
+          agentId: "run-inputs",
+          eventId: `evt-${i}`,
+          requestId: `tool-${i}`,
+          toolName: "FileWrite",
+          input: bigInput,
+        },
+      });
+      policy.recordSessionEvent("session-inputs", {
+        method: "event.session_event",
+        params: {
+          agentId: "run-inputs",
+          event: {
+            type: "tool_call_completed",
+            payload: { callId: `tool-${i}`, result: "ok", isError: false },
+          },
+        },
+      });
+    }
+    policy.flushPeriodic();
+
+    const toolState = latestSnapshot("session-inputs").toolState as {
+      completed: Record<string, { input?: unknown }>;
+    };
+    const keys = Object.keys(toolState.completed);
+    expect(keys.length).toBe(20);
+    expect(toolState.completed["tool-9"]).toBeUndefined();
+    expect(toolState.completed["tool-29"]).toBeDefined();
+    for (const key of keys) {
+      const input = toolState.completed[key]?.input;
+      expect(typeof input).toBe("string");
+      expect((input as string).length).toBeLessThan(8 * 1024);
+    }
+    // The full arguments are persisted once, in in_flight_tool_calls.
+    const args = driver
+      .prepareState<[string], { args_json: string }>(
+        "SELECT args_json FROM in_flight_tool_calls WHERE tool_call_id = ?",
+      )
+      .get("tool-29")?.args_json;
+    expect(JSON.parse(args ?? "null")).toEqual(bigInput);
   });
 
   it("updates agent_runs from runner-emitted terminal run statuses", () => {
@@ -556,6 +710,8 @@ describe("AgenCSessionSnapshotPolicy", () => {
         },
       },
     });
+    // The poison lands within the coalescing window of the request write.
+    policy.flushPeriodic();
 
     expect(latestSnapshot("session-replay-poison").toolState).toMatchObject({
       inFlight: {},

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -865,6 +865,80 @@ describe("AgenCSessionSnapshotPolicy", () => {
     expect(snapshotTimes("session-stale")).toEqual(["2026-09-02T00:00:00.000Z"]);
   });
 
+  // Live follow-up: a recovered session (conv-mtjbjxk8, one "ready" turn,
+  // idle since) received one periodic row every 30 s, byte-identical to the
+  // previous one, for 24 minutes. Every daemon instance that wrote such rows
+  // was built before the dirty check landed in the integration branch
+  // (00:13:35Z on 2026-09-02); no instance built after it wrote an idle row
+  // (32 idle minutes, zero rows, on the current build). This pins what the
+  // current code does for exactly that session shape: hydrated at startup,
+  // then nothing but same-status heartbeats and periodic ticks.
+  it("writes a recovered idle session once and ignores unchanged status heartbeats", () => {
+    seedRun("run-idle-recovered", "session-idle-recovered");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-09-02T00:00:00.000Z",
+      agencHome: home,
+    });
+    policy.trackSession("session-idle-recovered", "run-idle-recovered");
+    policy.hydrateSession({
+      sessionId: "session-idle-recovered",
+      snapshotAt: "2026-09-01T23:49:25.916Z",
+      conversation: [
+        { role: "user", messageId: "message-ready", payload: { message: "ready?" } },
+        { role: "assistant", eventId: "chunk-ready", delta: "ready" },
+      ],
+      toolState: {
+        inFlight: {},
+        completed: {},
+        statusTransitions: [
+          {
+            agentId: "run-idle-recovered",
+            status: "running",
+            transitionAt: "2026-09-01T23:49:21.120Z",
+          },
+          {
+            agentId: "run-idle-recovered",
+            status: "idle",
+            transitionAt: "2026-09-01T23:49:25.916Z",
+            reason: "ready",
+          },
+        ],
+      },
+      mcpConnectionState: { status: "unknown", events: [] },
+    });
+    // The first tick lands the hydrated state, once.
+    expect(policy.flushPeriodic()).toEqual([
+      expect.objectContaining({ trigger: "periodic" }),
+    ]);
+    expect(snapshotCount("session-idle-recovered")).toBe(1);
+
+    // 48 ticks (24 minutes at 30 s), each preceded by the two heartbeat
+    // shapes the daemon can deliver for an unchanged status: the forwarded
+    // event.agent_status and the lifecycle's own transition record.
+    for (let tick = 0; tick < 48; tick++) {
+      policy.recordSessionEvent("session-idle-recovered", {
+        method: "event.agent_status",
+        params: { agentId: "run-idle-recovered", status: "idle", message: "ready" },
+      });
+      policy.recordAgentStatusTransition({
+        sessionId: "session-idle-recovered",
+        agentId: "run-idle-recovered",
+        status: "idle",
+        transitionAt: `2026-09-02T00:${String(tick).padStart(2, "0")}:00.000Z`,
+      });
+      expect(policy.flushPeriodic()).toEqual([]);
+    }
+    expect(snapshotCount("session-idle-recovered")).toBe(1);
+    expect(policy.flushSession("session-idle-recovered")).toBeUndefined();
+    expect(latestSnapshot("session-idle-recovered").toolState).toMatchObject({
+      lastTrigger: "periodic",
+      statusTransitions: [
+        expect.objectContaining({ status: "running" }),
+        expect.objectContaining({ status: "idle", reason: "ready" }),
+      ],
+    });
+  });
+
   it("drops array-shaped hydrated tool-state maps before flushing", () => {
     seedRun("run-hydrate-arrays", "session-hydrate-arrays");
     const policy = new AgenCSessionSnapshotPolicy(driver, {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -365,6 +365,66 @@ describe("AgenCSessionSnapshotPolicy", () => {
     );
   });
 
+  // A completed message exchange is a turn boundary: health.stats and the
+  // desktop read state right after message.stream returns, so it must not
+  // wait for the trailing coalesce timer. Only chunks and tool/status bursts
+  // coalesce.
+  it("writes a completed message exchange at once even inside the coalescing window", () => {
+    seedRun("run-exchange", "session-exchange");
+    const timers: (() => void)[] = [];
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+      setTimeout: (callback) => {
+        timers.push(callback);
+        return { unref: vi.fn() };
+      },
+      clearTimeout: vi.fn(),
+    });
+
+    policy.recordSessionEvent("session-exchange", {
+      method: "event.agent_status",
+      params: { agentId: "run-exchange", status: "running" },
+    });
+    expect(snapshotCount("session-exchange")).toBe(1);
+    policy.recordSessionEvent("session-exchange", {
+      method: "event.tool_request",
+      params: {
+        agentId: "run-exchange",
+        eventId: "evt-exchange",
+        requestId: "tool-exchange",
+        toolName: "FileRead",
+      },
+    });
+    // The tool event lands inside the window and is coalesced.
+    expect(snapshotCount("session-exchange")).toBe(1);
+    expect(timers).toHaveLength(1);
+
+    const record = policy.recordMessageExchange({
+      sessionId: "session-exchange",
+      agentId: "run-exchange",
+      content: "hello",
+      messageId: "message-exchange",
+      streamId: "stream-exchange",
+      acceptedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    expect(record?.trigger).toBe("message_exchange");
+    expect(snapshotCount("session-exchange")).toBe(2);
+    const latest = latestSnapshot("session-exchange");
+    expect(latest.conversation).toEqual([
+      expect.objectContaining({ role: "user", messageId: "message-exchange" }),
+    ]);
+    // The coalesced tool state rode along with the exchange write.
+    expect(latest.toolState).toMatchObject({
+      lastTrigger: "message_exchange",
+      inFlight: { "tool-exchange": { status: "running" } },
+    });
+    // The trailing timer finds nothing left to write.
+    timers[0]?.();
+    expect(snapshotCount("session-exchange")).toBe(2);
+  });
+
   it("bounds tool inputs and keeps at most 20 completed calls in the snapshot", () => {
     seedRun("run-inputs", "session-inputs");
     const policy = new AgenCSessionSnapshotPolicy(driver, {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -711,6 +711,78 @@ describe("AgenCSessionSnapshotPolicy", () => {
     expect(sessionAgent("session-linked")).toBe("agent-linked");
   });
 
+  // Review P1-8: every forwarded event carries agentId, and each one ran an
+  // autocommit upsert into session_agent_links (one fsync under
+  // synchronous=FULL) plus a SELECT per completion-only tool event.
+  it("writes session_agent_links once per session and serves later lookups from memory", () => {
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+    });
+    const prepareState = vi.spyOn(driver, "prepareState");
+    const linkWrites = (): number =>
+      prepareState.mock.calls.filter(([sql]) =>
+        /INSERT INTO session_agent_links/.test(sql),
+      ).length;
+    const linkReads = (): number =>
+      prepareState.mock.calls.filter(([sql]) =>
+        /SELECT agent_id FROM session_agent_links/.test(sql),
+      ).length;
+
+    for (let i = 0; i < 200; i++) {
+      policy.recordSessionEvent("session-links", {
+        method: "event.message_chunk",
+        params: {
+          agentId: "run-links",
+          delta: "x",
+          messageId: "message-links",
+          streamId: "stream-links",
+          eventId: `chunk-${i}`,
+        },
+      });
+    }
+    policy.recordSessionEvent("session-links", {
+      method: "event.tool_request",
+      params: {
+        agentId: "run-links",
+        eventId: "evt-links",
+        requestId: "tool-links",
+        toolName: "FileRead",
+      },
+    });
+    // Completion without an agentId resolves the owner from memory.
+    policy.recordSessionEvent("session-links", {
+      method: "event.session_event",
+      params: {
+        event: {
+          type: "tool_call_completed",
+          payload: { callId: "tool-links", result: "ok", isError: false },
+        },
+      },
+    });
+
+    expect(linkWrites()).toBe(1);
+    expect(linkReads()).toBe(0);
+    expect(sessionAgent("session-links")).toBe("run-links");
+    expect(inFlightToolOutput("session-links", "tool-links").status).toBe(
+      "completed",
+    );
+
+    // A changed owner is written again, exactly once.
+    policy.recordSessionEvent("session-links", {
+      method: "event.message_chunk",
+      params: {
+        agentId: "run-links-2",
+        delta: "y",
+        messageId: "message-links-2",
+        streamId: "stream-links",
+        eventId: "chunk-owner-change",
+      },
+    });
+    expect(linkWrites()).toBe(2);
+    expect(sessionAgent("session-links")).toBe("run-links-2");
+  });
+
   it("keeps tool identity for completion-only tool events", () => {
     const policy = new AgenCSessionSnapshotPolicy(driver, {
       now: clock(["2026-05-01T00:00:00.000Z"]),

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -738,6 +738,133 @@ describe("AgenCSessionSnapshotPolicy", () => {
     );
   });
 
+  // The daemon's hydrateStartupRecovery makes these calls per recovered run:
+  // trackSession, hydrateSession, and flushSession when startup recovery
+  // reconciled stale tool calls for the session (here one poisoned call).
+  // The flush writes the reconciled state at once, before the daemon
+  // advertises readiness; the periodic tick then finds nothing to write.
+  it("writes a reconciled recovered state once when flushed after hydration", () => {
+    seedRun("run-recovered", "session-recovered");
+    driver
+      .prepareState(
+        `INSERT INTO session_state_snapshots (
+          session_id, snapshot_at, conversation_json, tool_state_json, mcp_connection_state_json
+        ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "session-recovered",
+        "2026-05-01T00:06:00.000Z",
+        JSON.stringify([{ role: "assistant", content: "state" }]),
+        JSON.stringify({ pending: ["tool-recovered"] }),
+        JSON.stringify({ connected: true }),
+      );
+    recordInFlightToolCallStart(driver, {
+      sessionId: "session-recovered",
+      agentId: "run-recovered",
+      toolCallId: "tool-recovered",
+      toolName: "FileWrite",
+      args: { path: "a.txt" },
+      startedAt: "2026-05-01T00:05:00.000Z",
+      recoveryCategory: "side-effecting",
+      agencHome: home,
+    });
+    const recovery = recoverDaemonStateOnStartup(driver, {
+      now: () => "2026-05-01T00:10:00.000Z",
+    });
+    const run = recovery.recoveredRuns.find((candidate) => candidate.id === "run-recovered");
+    expect(run?.latestSnapshot).toBeDefined();
+    expect(recovery.recoveredToolCalls).toEqual([
+      expect.objectContaining({
+        sessionId: "session-recovered",
+        toolCallId: "tool-recovered",
+        recoveryAction: "poison",
+      }),
+    ]);
+
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:10:01.000Z",
+      agencHome: home,
+    });
+    policy.trackSession("session-recovered", "run-recovered");
+    policy.hydrateSession({
+      sessionId: "session-recovered",
+      snapshotAt: run!.latestSnapshot!.snapshotAt,
+      conversation: run!.latestSnapshot!.conversation,
+      toolState: run!.latestSnapshot!.toolState,
+      mcpConnectionState: run!.latestSnapshot!.mcpConnectionState,
+    });
+    // Hydration only marks the session dirty.
+    expect(snapshotCount("session-recovered")).toBe(1);
+
+    const flushed = policy.flushSession("session-recovered");
+    expect(flushed?.trigger).toBe("periodic");
+    expect(snapshotCount("session-recovered")).toBe(2);
+    expect(latestSnapshot("session-recovered").toolState).toMatchObject({
+      lastTrigger: "periodic",
+      pending: [],
+      completed: { "tool-recovered": { status: "poisoned", recoveryAction: "poison" } },
+    });
+    expect(runLastSnapshotAt("run-recovered")).toBe("2026-05-01T00:10:01.000Z");
+    // Nothing is dirty afterwards: the tick and a second flush write nothing.
+    expect(policy.flushPeriodic()).toEqual([]);
+    expect(policy.flushSession("session-recovered")).toBeUndefined();
+    expect(snapshotCount("session-recovered")).toBe(2);
+  });
+
+  // The daemon-cli contract test seeded its recovered row at 2026-05-01 and
+  // waited for a second row per session. The write that lands the hydrated
+  // state (the flush for a reconciled session, or the first periodic tick)
+  // uses the daemon's real clock, and the per-write retention (snapshot_days
+  // 3 by default) then prunes the seeded row as older than the window, so
+  // the count stayed at one. The evidence that recovery wrote is a row newer
+  // than the recovered one, never a row count.
+  it("replaces a recovered row older than the retention window instead of adding to it", () => {
+    seedRun("run-stale", "session-stale");
+    driver
+      .prepareState(
+        `INSERT INTO session_state_snapshots (
+          session_id, snapshot_at, conversation_json, tool_state_json, mcp_connection_state_json
+        ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "session-stale",
+        "2026-05-01T00:06:00.000Z",
+        JSON.stringify([{ role: "assistant", content: "state" }]),
+        JSON.stringify({ pending: [] }),
+        JSON.stringify({ connected: true }),
+      );
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-09-02T00:00:00.000Z",
+      agencHome: home,
+      snapshotRetention: {
+        snapshot_days: 3,
+        snapshot_max_count: 10_000,
+        snapshot_max_bytes: 67_108_864,
+      },
+    });
+    policy.trackSession("session-stale", "run-stale");
+    policy.hydrateSession({
+      sessionId: "session-stale",
+      snapshotAt: "2026-05-01T00:06:00.000Z",
+      conversation: [{ role: "assistant", content: "state" }],
+      toolState: { pending: [] },
+      mcpConnectionState: { connected: true },
+    });
+    expect(snapshotTimes("session-stale")).toEqual(["2026-05-01T00:06:00.000Z"]);
+    policy.flushSession("session-stale");
+
+    // One row: the flushed hydration write, dated now. The seeded row fell
+    // out of the three-day window on that same write.
+    expect(snapshotTimes("session-stale")).toEqual(["2026-09-02T00:00:00.000Z"]);
+    expect(latestSnapshot("session-stale").toolState).toMatchObject({
+      lastTrigger: "periodic",
+      pending: [],
+    });
+    expect(runLastSnapshotAt("run-stale")).toBe("2026-09-02T00:00:00.000Z");
+    expect(policy.flushPeriodic()).toEqual([]);
+    expect(snapshotTimes("session-stale")).toEqual(["2026-09-02T00:00:00.000Z"]);
+  });
+
   it("drops array-shaped hydrated tool-state maps before flushing", () => {
     seedRun("run-hydrate-arrays", "session-hydrate-arrays");
     const policy = new AgenCSessionSnapshotPolicy(driver, {
@@ -1251,6 +1378,18 @@ function seedRun(runId: string, sessionId: string): void {
       "client-1",
       null,
     );
+}
+
+function snapshotTimes(sessionId: string): string[] {
+  return driver
+    .prepareState<[string], { snapshot_at: string }>(
+      `SELECT snapshot_at
+       FROM session_state_snapshots
+       WHERE session_id = ?
+       ORDER BY snapshot_at ASC`,
+    )
+    .all(sessionId)
+    .map((row) => row.snapshot_at);
 }
 
 function snapshotCount(sessionId: string): number {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -461,7 +461,7 @@ describe("AgenCSessionSnapshotPolicy", () => {
       completed: Record<string, { input?: unknown }>;
     };
     const keys = Object.keys(toolState.completed);
-    expect(keys.length).toBe(20);
+    expect(keys).toHaveLength(20);
     expect(toolState.completed["tool-9"]).toBeUndefined();
     expect(toolState.completed["tool-29"]).toBeDefined();
     for (const key of keys) {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -562,6 +562,18 @@ describe("AgenCSessionSnapshotPolicy", () => {
       streamId: "stream-periodic",
       acceptedAt: "2026-05-01T00:00:00.000Z",
     });
+    // A streaming chunk dirties the session without writing; the periodic
+    // tick is what lands it.
+    policy.recordSessionEvent("session-periodic", {
+      method: "event.message_chunk",
+      params: {
+        agentId: "agent-periodic",
+        delta: "hello",
+        messageId: "message-assistant",
+        streamId: "stream-periodic",
+        eventId: "chunk-periodic",
+      },
+    });
     policy.startPeriodic();
     tick?.();
     policy.stopPeriodic();
@@ -570,7 +582,63 @@ describe("AgenCSessionSnapshotPolicy", () => {
     expect(latestSnapshot("session-periodic").toolState).toMatchObject({
       lastTrigger: "periodic",
     });
+    expect(latestSnapshot("session-periodic").conversation).toEqual([
+      expect.objectContaining({ role: "user", content: "watch" }),
+      expect.objectContaining({ role: "assistant", delta: "hello" }),
+    ]);
     expect(clearInterval).toHaveBeenCalledTimes(1);
+  });
+
+  // Review P1-3: after the measured runs ended, every tracked session still
+  // received a 30 s periodic snapshot forever (21 per session in ten idle
+  // minutes, up to 349 KB and four fsyncs each) with the desktop idle.
+  it("flushPeriodic writes nothing for a session without changes", () => {
+    seedRun("run-idle", "session-idle");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+    });
+    policy.recordMessageExchange({
+      sessionId: "session-idle",
+      agentId: "run-idle",
+      content: "one",
+      messageId: "message-idle",
+      streamId: "stream-idle",
+      acceptedAt: "2026-05-01T00:00:00.000Z",
+    });
+    expect(snapshotCount("session-idle")).toBe(1);
+
+    for (let tick = 0; tick < 21; tick++) {
+      expect(policy.flushPeriodic()).toEqual([]);
+    }
+    expect(snapshotCount("session-idle")).toBe(1);
+    expect(policy.trackedSessionIds()).toEqual(["session-idle"]);
+    expect(policy.flushSession("session-idle")).toBeUndefined();
+  });
+
+  it("close flushes dirty sessions once and forgets them", () => {
+    seedRun("run-close", "session-close");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+    });
+    policy.recordSessionEvent("session-close", {
+      method: "event.message_chunk",
+      params: {
+        agentId: "run-close",
+        delta: "partial",
+        messageId: "message-close",
+        streamId: "stream-close",
+        eventId: "chunk-close",
+      },
+    });
+    expect(snapshotCount("session-close")).toBe(0);
+
+    policy.close();
+
+    expect(snapshotCount("session-close")).toBe(1);
+    expect(latestSnapshot("session-close").conversation).toEqual([
+      expect.objectContaining({ role: "assistant", delta: "partial" }),
+    ]);
+    expect(policy.trackedSessionIds()).toEqual([]);
   });
 
   it("hydrates recovered session state before periodic flush", () => {
@@ -943,12 +1011,13 @@ describe("AgenCSessionSnapshotPolicy", () => {
     expect(reports).toEqual([]);
 
     policy.flushPeriodic();
-    expect(reports).toHaveLength(1);
-    expect(reports[0]).toMatchObject({
-      prunedSessionIds: ["session-retention-fast"],
-    });
-    expect(reports[0]?.prunedSnapshots).toBeGreaterThanOrEqual(1);
+    expect(reports).toEqual([
+      { prunedSnapshots: 1, prunedSessionIds: ["session-retention-fast"] },
+    ]);
     expect(snapshotCount("session-retention-fast")).toBe(2);
+    // Nothing new to report on a quiet tick.
+    policy.flushPeriodic();
+    expect(reports).toHaveLength(1);
   });
 
   it("hard-caps snapshot rows per session without any configured retention", () => {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -3,6 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgenCSessionSnapshotPolicy } from "./snapshot-policy.js";
+import {
+  SESSION_SNAPSHOT_HARD_CAP,
+  type AgentSnapshotPruningReport,
+} from "./pruning.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";
 import {
   readRotatedToolOutputLog,
@@ -905,21 +909,24 @@ describe("AgenCSessionSnapshotPolicy", () => {
     );
   });
 
-  it("throttles snapshotRetention sweeps inside the prune interval", () => {
+  // Review P0-2: the previous sweep was a table-wide LENGTH() scan throttled
+  // to once per minute, and the configured 64 MiB cap never deleted a row.
+  // The per-session prune is cheap enough to run on every write, and its
+  // report surfaces on the periodic tick instead of per write.
+  it("applies snapshot retention on every write and reports pruning on the periodic tick", () => {
     seedRun("run-retention-fast", "session-retention-fast");
+    const reports: AgentSnapshotPruningReport[] = [];
     const policy = new AgenCSessionSnapshotPolicy(driver, {
       now: clock([
         "2026-05-01T00:00:00.000Z",
         "2026-05-01T00:00:01.000Z",
         "2026-05-01T00:00:02.000Z",
-        "2026-05-01T00:01:04.000Z",
+        "2026-05-01T00:00:03.000Z",
       ]),
       snapshotRetention: { snapshot_max_count: 2 },
+      onPruneReport: (report) => reports.push(report),
     });
 
-    // Three writes 1s apart: the sweep runs on the first write (nothing to
-    // prune yet) and is then throttled — per-snapshot sweeps would scan the
-    // whole table on the hot path (measured daemon stall).
     for (const index of [1, 2, 3]) {
       policy.recordMessageExchange({
         sessionId: "session-retention-fast",
@@ -929,19 +936,43 @@ describe("AgenCSessionSnapshotPolicy", () => {
         streamId: "stream-retention-fast",
         acceptedAt: `2026-05-01T00:00:0${index}.000Z`,
       });
+      expect(snapshotCount("session-retention-fast")).toBeLessThanOrEqual(2);
     }
-    expect(snapshotCount("session-retention-fast")).toBe(3);
-
-    // Once the interval elapses, the next write sweeps again.
-    policy.recordMessageExchange({
-      sessionId: "session-retention-fast",
-      agentId: "run-retention-fast",
-      content: "message-4",
-      messageId: "message-4",
-      streamId: "stream-retention-fast",
-      acceptedAt: "2026-05-01T00:01:04.000Z",
-    });
     expect(snapshotCount("session-retention-fast")).toBe(2);
+    expect(latestSnapshot("session-retention-fast").conversation).toHaveLength(3);
+    expect(reports).toEqual([]);
+
+    policy.flushPeriodic();
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      prunedSessionIds: ["session-retention-fast"],
+    });
+    expect(reports[0]?.prunedSnapshots).toBeGreaterThanOrEqual(1);
+    expect(snapshotCount("session-retention-fast")).toBe(2);
+  });
+
+  it("hard-caps snapshot rows per session without any configured retention", () => {
+    seedRun("run-hard-cap", "session-hard-cap");
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      coalesceIntervalMs: 0,
+    });
+
+    for (let index = 0; index < SESSION_SNAPSHOT_HARD_CAP + 10; index++) {
+      policy.recordMessageExchange({
+        sessionId: "session-hard-cap",
+        agentId: "run-hard-cap",
+        content: `message-${index}`,
+        messageId: `message-${index}`,
+        streamId: "stream-hard-cap",
+        acceptedAt: "2026-05-01T00:00:00.000Z",
+      });
+    }
+
+    expect(snapshotCount("session-hard-cap")).toBe(SESSION_SNAPSHOT_HARD_CAP);
+    expect(latestSnapshot("session-hard-cap").conversation).toHaveLength(
+      SESSION_SNAPSHOT_HARD_CAP + 10,
+    );
   });
 });
 

--- a/runtime/tests/utils/slow-store-op.test.ts
+++ b/runtime/tests/utils/slow-store-op.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SLOW_STORE_OP_THRESHOLD_MS,
+  setSlowStoreOpReporter,
+  timed,
+  type SlowStoreOpWarning,
+} from "../../src/utils/slow-store-op.js";
+
+afterEach(() => {
+  setSlowStoreOpReporter(undefined);
+  vi.restoreAllMocks();
+});
+
+function spin(ms: number): void {
+  const until = performance.now() + ms;
+  while (performance.now() < until) {
+    // busy wait: the guard measures synchronous work on the event loop
+  }
+}
+
+describe("timed", () => {
+  it("returns the operation's result and stays silent under the threshold", () => {
+    const report = vi.fn();
+    expect(timed("fast_op", () => 42, report)).toBe(42);
+    expect(report).not.toHaveBeenCalled();
+    expect(SLOW_STORE_OP_THRESHOLD_MS).toBe(50);
+  });
+
+  it("reports a slow_store_op warning with the label and duration", () => {
+    const warnings: SlowStoreOpWarning[] = [];
+    const result = timed(
+      "session_snapshot_write",
+      () => {
+        spin(5);
+        return "written";
+      },
+      (warning) => warnings.push(warning),
+      1,
+    );
+    expect(result).toBe("written");
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        cause: "slow_store_op",
+        label: "session_snapshot_write",
+      }),
+    ]);
+    expect(warnings[0]?.ms).toBeGreaterThanOrEqual(4);
+  });
+
+  it("still reports when the slow operation throws, and rethrows", () => {
+    const report = vi.fn();
+    expect(() =>
+      timed(
+        "canonical_rollout_scan",
+        () => {
+          spin(3);
+          throw new Error("scan failed");
+        },
+        report,
+        1,
+      ),
+    ).toThrow("scan failed");
+    expect(report).toHaveBeenCalledTimes(1);
+  });
+
+  it("never lets a failing reporter mask the operation", () => {
+    expect(
+      timed(
+        "thread_archive",
+        () => {
+          spin(3);
+          return "ok";
+        },
+        () => {
+          throw new Error("reporter broke");
+        },
+        1,
+      ),
+    ).toBe("ok");
+  });
+
+  it("uses the process-wide reporter by default and prints one console line", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    timed("default_sink", () => spin(3), undefined, 1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(
+      /^agenc: slow_store_op \{"label":"default_sink","ms":\d+\}$/,
+    );
+
+    const custom = vi.fn();
+    setSlowStoreOpReporter(custom);
+    timed("custom_sink", () => spin(3), undefined, 1);
+    expect(custom).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Why

The daemon and session lifecycle review (`harness-review/daemon.md`, evidence from the live AgenC Desktop home, daemon pid 44038, runtime 0.17.0, session `conv-mtj696ra`: 82 minutes, 6 user turns, 221 model calls, 218 tool calls) found that most of the daemon's synchronous store work was write amplification with no reader and no log line:

- `session_state_snapshots` held 1,280,491,520 B of a 1,292,619,776 B `agenc-state_1.sqlite` (99 percent of the file). The one session had 5,607 snapshot rows and 1,158 MB: `message_exchange` 4,931 rows / 980 MB, `tool_call` 460 / 88 MB, `periodic` 205 / 44 MB. That matches one snapshot per forwarded event (4,911 `agent_message_delta` + 218 `tool_call_started` + 218 `tool_call_completed` + 24 `tool_progress`). Peak was 1,321 snapshots in one 5-minute bucket (4.4/s, 392 MB), each a `JSON.stringify` of 200 to 380 KB and 4 fsyncs (tmp file, dir, WAL commit under `synchronous=FULL`, unlink dir) on the event loop that serves the desktop RPC. Per model call: 5.2 MB into SQLite against 39 KB into the rollout.
- The configured retention (`snapshot_days: 3`, `snapshot_max_count: 10_000`, `snapshot_max_bytes: 64 MiB`) had never deleted a row (5,607 rows equals the number of triggering events; a 64 MiB cap applied newest-first would have deleted 5,430 rows / 1,051 MB). The prune that did run was a `LENGTH()` scan of the whole table joined to three other tables, throttled to once a minute.
- After all four runs ended, every tracked session still received exactly 21 `periodic` snapshots in the following ten idle minutes (349 KB, 86 KB, 21 KB and 0.3 KB per write) with the desktop idle.
- Every forwarded event (about 8,200 for the session) ran an autocommit upsert into `session_agent_links`, one fsync each, just to remember the agent id.
- The daemon's own `FileThreadStore` archived (renamed and appended to) rollouts whose live writer belonged to bootstrap-services' instance: `conv-mtj5nfjl` was archived 14 s after creation while its run stayed alive, the daemon-shutdown `run_suspended` (seq 61) was written by path into a fresh 362-byte `sessions/` file, splitting the canonical journal, and nine other archived sessions grew zombie `sessions/<conv>/index.json` directories the same way.
- Desktop `run.status` / `run.replay` on a live run persisted a `source_not_quiescent` deferral (three active rows in the home); startup recovery excluded any run with an active deferral regardless of `next_retry_ms`, so `conv-mtj5nfjl` was excluded at the 21:18:29Z restart ("pending operator recovery action") and never resumable through the UI.
- `daemon.log` had 9 lines, all provider warnings; no timing existed for any of the store operations above.

## What changes, per file

`runtime/src/state/snapshot-policy.ts` (P0-1, P0-2, P1-3, P1-8, P2-11)
- `event.message_chunk` only appends to the in-memory conversation tail and marks the session dirty; it never writes.
- Tool and status writes go through `#requestSnapshot`: the first change after a quiet period is written immediately, further changes inside `coalesceIntervalMs` (default 1 s, policy clock) fold into one trailing write or the next periodic tick. A completed message exchange (a submitted user message or a complete agent message) is a turn boundary and is written at once, carrying any coalesced tool state with it, so a client that reads state right after `message.stream` returns sees it. `coalesceIntervalMs: 0` disables coalescing.
- `DEFAULT_MAX_COMPLETED_TOOL_CALLS` 200 to 20; tool inputs are bounded like results (`#boundInMemoryInput`, 4 KB preview). The full args live once in `in_flight_tool_calls.args_json`, which startup recovery reconciles by id.
- Retention runs on every write through `pruneSessionSnapshotsForSession`; prune counts are aggregated and reported once per periodic tick via the new `onPruneReport` option.
- `flushPeriodic` writes only dirty sessions. `hydrateSession` marks the normalized recovered state dirty once so it lands on the first tick, as before.
- New `flushSession`, `close` (stop timers, flush dirty sessions synchronously, forget all), `trackedSessionIds`. Eviction and `forgetSession` flush a dirty session first.
- `#rememberSessionAgent` writes `session_agent_links` only when the id is first seen or changes; `#sessionAgentId` is served from memory once known.
- The snapshot write is wrapped in `timed("session_snapshot_write", ...)`.

`runtime/src/state/pruning.ts` (P0-2, P2-11)
- `SESSION_SNAPSHOT_HARD_CAP = 50` rows per session, independent of configuration.
- `pruneSessionSnapshotsForSession`: an indexed `DELETE` below the keep-th newest row (`min(hard cap, snapshot_max_count)`), an indexed `DELETE` for the age cutoff that spares the newest row, and a byte-cap pass that only measures the rows that survive. No table scan, no joins.
- `pruneSessionSnapshotsPerSession` applies it to every session (used at daemon startup before the existing agent-grouped table sweep, which is left unchanged for the startup path).
- Both prunes are wrapped in `timed(...)`.

`runtime/src/app-server/daemon-cli.ts` (P0-2, P1-3, P2-11)
- Logs the resolved snapshot retention once at start (`daemon snapshot retention snapshot_days=... (hard cap 50 rows per session)`), the size of every state DB and WAL it opens, and a line whenever startup or the periodic tick pruned rows.
- The snapshot policy registry passes `onPruneReport`; `recordRunTerminal` flushes and forgets the session; `close()` closes every policy (flushing dirty sessions) before closing the drivers.
- `hydrateStartupRecovery` flushes a hydrated session at once when startup recovery reconciled stale tool calls for it (replayed, poisoned or cancelled), so the reconciled state is on disk before the daemon advertises readiness; a recovered session that recovery left untouched keeps its rows exactly as startup pruning left them. `recordReplayToolResult` flushes after recording, so a replay outcome is in the latest row the moment the call's in-flight status turns terminal. New registry method `flushSession`.
- `recoverAgenCDaemonStartupState` runs the per-session cap before the table-wide sweep and takes a logger.

`runtime/src/thread-store/store.ts` (P1-4, P2-11)
- `archiveThread` and `appendThreadMetadataRollout` take the rollout's `SessionLock` (the same liveness check `state/pruning.ts` uses before deleting a session) through `withRolloutLease`. When a live process holds it, only the registry records `archivedAt`; the file is neither renamed nor appended to. The owner's `shutdownThread` completes the move once the writer is gone (its own path is unchanged, `ownedWriter: true`).
- `archiveThread` is wrapped in `timed("thread_archive", ...)`.

`runtime/src/state/backfill.ts` (P1-4)
- `mergeThreadFromMeta` only replaces the archive state when the caller knows the file's location root (`archived` defined, the offline sweep). A store-driven incremental index previously cleared `archived_at` on every append, so an archived-while-live thread resurfaced as active; the deferral above made that visible in the test.

`runtime/src/state/recovery-cutover.ts`, `recovery-exclusions.ts`, `recovery-incidents.ts`, `recovery.ts`, `runtime/src/app-server/run-inspection.ts` (P1-7)
- `RecoveryCutoverOptions.liveSourceDeferral`: `"record"` (default, startup) persists the retryable block as before; `"skip"` returns an in-memory `liveSourceRecoveryExclusion` and persists nothing. `run-inspection`'s `refreshRunJournalProjection` passes `"skip"` and serves the projection as it stands.
- `StateRecoveryIncidentRepository.releaseExpiredLiveSourceDeferrals(nowMs)` resolves active `source_not_quiescent` deferrals whose `next_retry_ms` has passed (actor `daemon_startup`); `recoverDaemonStateOnStartup` calls it before loading exclusions. Other reason codes stay on the operator retry path.

`runtime/src/utils/slow-store-op.ts` (new, P2-11), `runtime/src/session/session-store.ts`, `runtime/src/session/canonical-rollout-scanner.ts`
- `timed(label, fn, report?, thresholdMs = 50)` reports `{cause: "slow_store_op", label, ms}`; the default reporter is one `console.warn` line (`agenc: slow_store_op {"label":...,"ms":...}`), which the detached daemon routes into its rotating `daemon.log` sink and the TUI captures through Ink's patched console. `setSlowStoreOpReporter` overrides it.
- `SessionStore.flushBatch` is wrapped and reports through the store's existing `emitDiagnostic` channel (lands in the rollout as a `warning` event like the I-83 batch-delay warning); `scanCanonicalRollout` is wrapped with the default reporter. Its post-commit bookkeeping decision moved into the pure helper `nextPostCommitBookkeeping` (Sonar S3776 on the renamed body); behavior unchanged. Two of the outer function's own loops then moved into `assertAttemptsReconstructed` and `collectSourceLines`, taking `scanCanonicalRolloutUntimed` from 17 to 5 (eslint-plugin-sonarjs 4.2.0, the same rule implementation); the `onRecord` callback measures 65 here against 70 on origin/main and predates this branch.

## Tests

19 suites, 241 tests pass (`npx vitest run` over every touched suite). 29 new tests, 9 existing ones adjusted (five burst-style tests now flush before asserting DB state, the periodic test dirties the session with a chunk, the eviction probe reads `trackedSessionIds()`, the restart-recovery contract test waits for a row newer than its seed, the attach-time routing contract test waits for the coalesced write).

- `tests/state/snapshot-policy.test.ts`: 1,000 `event.message_chunk` events produce 0 rows before and 1 row after the periodic flush (cap 200 entries); a 100-event tool burst produces one leading and one trailing write; a completed message exchange inside the coalescing window is written at once with the pending tool state and the trailing timer then writes nothing; inputs bounded and completed calls capped at 20 with full args still in `in_flight_tool_calls`; retention applies on every write and reports once per tick; hard cap without configuration; `flushPeriodic` writes nothing for an unchanged session over 21 ticks; `close` flushes dirty sessions once and forgets them; `session_agent_links` written once per session, no SELECT for completion-only events, rewritten on owner change; `flushSession` after hydration writes the reconciled recovered state (`pending: []`, the poisoned call in `completed`) once and the tick adds nothing; under `snapshot_days: 3` that write replaces a stale recovered row instead of adding to it; a recovered idle session is written once at the first tick and 48 ticks with unchanged-status heartbeats add nothing.
- `tests/app-server/daemon-cli.contract.test.ts`: the restart-recovery test waits for a snapshot newer than the seeded row (`waitForSnapshotAfter`) instead of a row count and keeps the `lastTrigger: "periodic"`, `pending: []` assertion; the attach-time routing test waits for the coalesced in-flight entry in the other project's DB before asserting on it.
- `tests/state/pruning.test.ts`: 10,000 rows with `defaultConfig().agent.retention` pruned to 50 in one pass and a no-op second pass; configured count cap; age cutoff keeps the newest row; byte cap newest-first; other sessions and agent groups untouched; per-session sweep over multiple sessions.
- `tests/session/thread-store.test.ts`: store A owns a live writer, store B archives: file not renamed, no line appended, registry shows `archivedAt`, owner keeps appending, owner's `shutdownThread` completes the move with the full journal; a released writer's rollout is archived with the metadata line and no leftover lock.
- `tests/state/recovery-restart.test.ts`: expired `source_not_quiescent` deferral resolved at startup and the run recovered; unexpired one kept; expired `database_io` kept; on-demand `"skip"` read leaves `run_recovery_deferred` empty while the default still records.
- `tests/app-server/run-inspection.contract.test.ts`: three `run.status` / `run.replay` reads on a live (locked) rollout leave `run_recovery_deferred` empty and serve the standing projection (`status: "running"`, `statusSource: "run_lifecycle_epoch"`); after unlock, `run.result` rebuilds the terminal from the JSONL.
- `tests/utils/slow-store-op.test.ts`: result passthrough, warning shape and duration, rethrow with report, failing reporter swallowed, default and overridden reporter.

### Follow-up after the first CI run

- CI failure `tests/app-server/daemon-cli.contract.test.ts` > "foreground daemon serves read-only state stats to daemon clients" (`sessionStateSnapshots` did not grow after a `message.stream` round trip): the coalescer had folded the completed message exchange into the trailing timer. Contract decision: a completed message exchange is written immediately (it is a turn boundary and the moment clients read state); only streaming chunks and tool/status bursts coalesce. Pinned by the new snapshot-policy unit test. That contract test cannot run in this environment (the daemon never starts: `timed out waiting for daemon pid`, same on origin/main), so the unit test carries the contract.
- Sonar quality gate: S2871 comparator on the prune report sort, S6582 optional chain and S7747 direct Map iteration in `snapshot-policy.ts`, S4624 nested template in the startup DB-size line, S5906 `toHaveLength` in the snapshot test, S3776 on `scanCanonicalRollout` (extracted `nextPostCommitBookkeeping`).
- Duplication 4.6 percent on new code, all in tests: `seedCanonicalTerminalRollout` shared by the two run-inspection terminal tests, `openForeignArchiveFixture` and `rolloutLineCount` shared by the two thread-store archive tests.

### Follow-up after the second CI run

- CI failure `daemon-cli.contract.test.ts` > "foreground daemon runs restart recovery before advertising readiness" (`waitForSnapshotCount(..., 2)` timed out). Not a missing write: hydration marks the recovered session dirty and the first periodic tick (10 ms in the test) writes it at the daemon's real clock; that write runs the per-session retention, and the default `snapshot_days: 3` deletes the seeded row dated 2026-05-01, so the count went 1 to 1. The old code passed because its unconditional flush kept adding rows every 10 ms and its prune ran at most once a minute. Fix: `hydrateStartupRecovery` flushes a hydrated session at once when recovery reconciled stale tool calls for it, `recordReplayToolResult` flushes after recording (both deterministic, before readiness), and the test waits for a row newer than the seed. An unconditional write at hydration was tried and rejected: it breaks "applies agent.retention config to terminal and snapshot startup pruning", whose recovered sessions must keep exactly the rows startup pruning left. Pinned by three snapshot-policy unit tests.
- Sonar S3776 17 on `scanCanonicalRolloutUntimed`: the earlier extraction moved code out of the `onRecord` callback, which Sonar measures as its own function. Two of the outer function's own loops moved out (`assertAttemptsReconstructed`, `collectSourceLines`): 17 to 5 by the same rule implementation run locally.
- Live observation of idle `periodic` rows every 30 s (`session_a0ec9212`, 49 byte-identical retained rows, 23:49:59Z to 00:14:02Z): every daemon instance that wrote them ran an integration build from before the harness-daemon merge (first merge containing the dirty check: 00:13:35Z on 2026-09-02; the instance started at 00:14:44Z and every later one shows one periodic row per turn or per recovery, none while idle; the current build wrote one row per recovered session at its first tick and none in 32 idle minutes). The `-30 minutes` query compared `snapshot_at` (T separator) against `datetime('now', ...)` (space separator) as strings and matched every row of the day; the query below uses `strftime`. No dirty-flag path in the current code fires without a state change; the new unit test pins the observed session shape (recovered, then only unchanged-status heartbeats and ticks).
- CI on 08b3ac0e2 (run 33592965448, 75 affected files, 4,216 tests): `daemon-cli.contract.test.ts` passes all 122 tests, including the two adjusted here; the one failure is `tests/tools/AgentTool/loadAgentsDir.test.ts` ("never imports agent files through cross-workspace file or directory symlinks"), which this branch does not touch.
- The contract file never ran past its first failure in CI (vitest bails), so the tests after it had not seen the coalescer. Running the whole file locally found one more: "routes attach-time session events to a non-default project database" read the latest row immediately, but `agent.create` writes the running status first and the attach-time `event.tool_request` is coalesced into the trailing write; the test now waits for the in-flight entry (the routing contract is unchanged). To run the file on macOS: `TMPDIR=/private/tmp/agd npx vitest run tests/app-server/daemon-cli.contract.test.ts`; the default hermetic root `/var/tmp/agenc-vitest-<user>` pushes the daemon socket path past the 104-byte limit (`connect EINVAL`) and the foreground daemon never starts.

`npx tsc --noEmit --preserveSymlinks` is clean. Plain `tsc --noEmit` in this worktree reports TS2883 (`MemoizedFunction` from `agenc-core/node_modules/@types/lodash`) because `node_modules` is a symlink into the sibling checkout; unrelated to this branch.

Pre-existing failures observed, identical with and without this branch (verified by diffing the failing test names against origin/main): `tests/app-server/agent-lifecycle.contract.test.ts` 30 failed / 105 passed; `tests/app-server/daemon-cli.contract.test.ts` 11 failed / 111 passed with `TMPDIR=/private/tmp/agd` (the same 11 names, `/home` resolving to `/System/Volumes/Data/home`, on origin/main in the same environment; under the default hermetic root the foreground daemon cannot bind its socket and the file shows 64 failed / 58 passed on both); `tests/state/recovery-restart.test.ts` 5 failed (descriptor and append-authority tests) / 30 passed; `tests/session/session-store.test.ts`, `rollout-store.test.ts`, `rollout-store.compaction-transaction.test.ts` 24 failed / 121 passed (16 "resume cwd must be a canonical non-symlink directory" under the `/var/tmp` symlink, two "reopened ... is missing"), the same 24 names on a pristine origin/main worktree.

## Not changed on purpose

- **P1-5 (streaming deltas and `execution_admission` out of the rollout): skipped.** Making `agent_message_delta` / `assistant_thinking_delta` / `tool_input_delta` ephemeral (no `seq`) changes the in-memory event stream, not only the file: `src/tui/session-transcript.ts` keys event identity on `seq:${seq}` (line 689), dedups on it (3023) and orders by it (747), and the daemon relay forwards `seq` conditionally (`background-agent-runner.ts:6010,6103`, `agent-lifecycle.ts:5401`); 26 test files including the TUI parity suites exercise those events. The alternative (keep the `seq`, skip the append) leaves gaps that `run-journal-replay.ts:262` and the strict canonical scanner report as `corruption_truncated`. `recoverExecutionAdmissionCanonicalJournals` converges every SQLite-committed admission row into the rollout by event id and refuses startup on incomplete replay, so persisting only `allowed`/`reconciled` or pruning `execution_admission_journal` needs its own design against that convergence. Deserves a dedicated PR with the TUI and replay owners.
- P1-6 (retrying identical failed compactions, dropping failed payload chunks) belongs to the compaction work in #2012.
- P2-9 (plan-mode permission round trips), P2-10 (durable checkpoint fsync set, admission read-back SELECT), P2-12 (vitest-named session temp root, needs launch-environment confirmation) are out of scope here.
- The table-wide, agent-grouped `pruneSessionStateSnapshots` is kept for the startup path; it now only runs after the per-session cap has bounded the table.
- The review named tests in `startup-run-journal-recovery.test.ts` and `recovery-exclusions.test.ts`; those files do not exist, so the P1-7 tests live in `recovery-restart.test.ts` and `run-inspection.contract.test.ts`.

## How to observe live

`P=<agenc-home>/projects/<slug>`, `DB=$P/agenc-state_1.sqlite`, all read-only:

- `sqlite3 -readonly $DB "select substr(snapshot_at,1,16) m, json_extract(tool_state_json,'$.lastTrigger') t, count(*), sum(length(tool_state_json)+length(conversation_json))/1048576 mb from session_state_snapshots where snapshot_at > strftime('%Y-%m-%dT%H:%M:%fZ','now','-30 minutes') group by m,t order by m;"` (`datetime('now', ...)` has a space separator and compares as a string against the T-separated `snapshot_at`, which matches every row of the day) should show a few `tool_call` rows per minute during work and nothing at idle; `select session_id, count(*) from session_state_snapshots group by 1` never exceeds 50.
- Startup `daemon-spawn-stderr.log` gains `daemon snapshot retention ...`, `daemon opened state DB ... (N MB, wal M MB)` and `daemon retention pruned ...` lines; `daemon.log` gains `slow_store_op` lines only when a store op exceeds 50 ms.
- `run.status` on a live session leaves `select count(*) from run_recovery_deferred where state='active'` unchanged, and a restart no longer reports `excluded ... pending operator recovery action` for a run that was merely idle.
- `for d in $P/archived_sessions/*; do b=$(basename $d); [ -e $P/sessions/$b ] && echo DUP $b; done` stops producing new entries.

Counterpart: #2012 (compaction).

**Follow-up 3 (resume after restart).** In the live 15-prompt desktop run the session could not continue after a daemon restart: the first message was refused with `restored bypass permission mode requires persisted exact-cwd consent`. The session had been created by the desktop with `permissionMode: "bypassPermissions"`, which `initializeToolPermissionContext` authorized in memory only; `restoreRuntimeSettings` (background-agent-runner.ts) requires the durable exact-cwd consent that only the `/permissions` command wrote. `runtime/src/permissions/settings.ts` now records the consent (`recordBypassPermissionsConsent`) when a trusted project starts in bypass explicitly; untrusted projects never persist it, and a persistence failure becomes a warning. Tests: `tests/permissions/settings.test.ts` gains "persists exact-cwd bypass consent when a trusted session starts in bypass mode" (consent survives a simulated restart) and "does not persist bypass consent for an untrusted project"; the permission suites stay green.

**Follow-up 4 (resume after restart, second defect).** With consent fixed, the resumed session's first message still aborted before any model call: `turn_aborted: admission step identity already exists with different request data: conv-<id>/model:sub-conv-<id>-2:1:0:primary`. `Session` starts its internal sub-id counter at zero on every construction, so a resumed session reused turn ids the durable admission journal already held. `Session.seedInternalSubId(next)` (never moves backwards) and `highestInternalSubId(rolloutItems, conversationId)` in `conversation/thread-manager.ts` seed the counter past the highest `sub-<conversation>-N` found in the rollout's event ids and turn ids during `replayRolloutIntoSession`. Tests: `tests/conversation/highest-internal-sub-id.test.ts` (event ids, turn ids, other conversations ignored, empty rollout), and the thread-manager contract fixture gains the method; conversation suites 10 files / 146 tests green.

**Follow-up 5 and 6 (resume after restart, third defect).** With consent and turn numbering fixed, the resumed session was still refused: `canonical session <id> runtime settings projection is unavailable`, and the daemon swallowed the cause. Follow-up 5 (`248adf091`) makes both refusal messages carry the underlying error; it then read `Ambiguous runtime session: 4 sessions are bootstrapped in this process and no session is bound to the current async context`. `assertCanonicalRuntimeSettingsProjection` opened the project state database with `openStateDatabases({ cwd })`, letting it resolve the AgenC home through the ambient current-session accessor, which refuses whenever more than one session lives in the daemon: with several sessions open, no session could be resumed after a restart. Follow-up 6 passes the lifecycle's own `#agencHome` explicitly. Test: `tests/app-server/resume-projection-explicit-home.test.ts` tracks two fallback sessions (ambient accessor ambiguous) and verifies a resume against a fresh home does not throw.

**Follow-up 7 (resume after restart, fourth defect).** With the session resumable, its first turn died at the first durable checkpoint: `checkpoint v2 requires every tool result to be sealed`, after six parallel tool calls had executed and before any tool result was persisted. The live turn writes `sessionState.history` as LLMMessage clones (seal under `runtimeOnly.toolResultIntegrity`); `replayRolloutIntoSession` applies the reconstruction's persisted ResponseItems (seal at the top level). `normalizeHistoryMessages` (session.ts) only read `runtimeOnly`, so all restored tool results were unsealed in memory and the checkpoint projection refused the prefix. A fresh session never hits this; every resumed session with tool history did. The normalizer now accepts both shapes for `toolResultIntegrity`, `agentInvocation` and `compactionHistory` (runtimeOnly first) and is exported. Test: `tests/session/normalize-history-persisted-shape.test.ts` (persisted shape keeps the seal and survives the checkpoint projection, live shape unchanged, runtimeOnly wins, unsealed items get no runtimeOnly); it fails on the original normalizer. Conversation, reconstruction, bootstrap and delegate suites: 14 files / 234 tests green.

**Follow-up 8 (resume after restart, fifth defect).** With the seals restored, the resumed session was refused on its next message by the live tool-pair gate: `tool-pair history rejected during live append: tool results must immediately follow their assistant calls; unresolved: call-...-53 ... call-...-58`. The killed turn had persisted its assistant message with six tool calls and none of the results, and nothing on the resume path closed them, so the session could never continue. `replayRolloutIntoSession` now closes the trailing dangling calls of the last assistant message (`trailingDanglingToolCalls`) with one error result each (`interruptedToolCallResultContent`: an `is_error` body telling the model the runtime restarted before the tool completed and to call it again if needed), sealed under the session's run id exactly like a live result (`createToolResultIntegrity` + `llmMessageToDurableResponseItem`), appended to the rollout through the live gate (which resolves the open calls) and mirrored into the session history; a `dangling_tool_calls_closed` warning names the calls. Unresolved calls earlier in the history are not touched. Test: `tests/conversation/close-dangling-tool-calls.test.ts` (trailing-call scan, sealed results verify against the run id, two rollout appends in order, history and state agree, one warning, a resolved history is untouched). Conversation and resume suites: 13 files / 162 tests green.

**Follow-up 9 (resume after restart, sixth defect).** With the history repaired, the resumed session was refused by the run durability layer: `run <id> is cancellation-locked and cannot cross an executable lifecycle boundary`. State database evidence: the first restart ended the run while its turn was in flight (`run_terminal_results`: `cancelled`, stop reason `daemon_shutdown_not_idle`), startup repair recorded an admission lock (`execution_admission_cancellations`, reason `recovery_cascade_repair`) and a sticky `cancelled` status, the user continue reopened a fresh epoch, and nothing lifted the locks, so the next shutdown could not record its suspension and the resume after it was refused. Ten runs in the live database carry such locks. `assertNotCancellationLocked` (run-durability.ts) now treats locks recorded at or before the opening of the run's current reopened, still-open epoch as superseded by that authorized reopen: it deletes the run's admission lock, moves the stale status back to `running` (metadata `cancellationLiftedBy: explicit_reopen`) and lets the boundary proceed; a lock recorded after the reopen still refuses. Test: run-durability suite gains "lifts cancellation locks that an explicit reopen superseded" (suspend succeeds after a superseded lock, lock row deleted, status and metadata updated; a lock recorded after the reopen still throws `RUN_CANCELLATION_CONFLICT`). Durability, cancellation and admission suites: 4 files / 69 tests green. Related: the base branch commit eeb593179 lets the explicit reopen through; this change completes it for the boundaries that follow.

**Follow-up 8, amendment (`19f1ecf84`).** CI's bootstrap test "replays MCP tool call events into resumed transcript state" failed the strict canonical journal scan with `canonical journal repeats its preceding event sequence` after follow-up 8: the `dangling_tool_calls_closed` warning was emitted unconditionally during replay, and a bootstrap replay that has not seeded the live event sequence yet must not append events. The warning now follows the other synthesized recovery events and is emitted only when the caller replays with `emitSynthesized`; the synthesized tool results are still always appended. The test gains "repairs the history without emitting when the caller does not replay synthesized events". The six bootstrap tests that fail on this Mac (`falls back to the explicit cwd`, `uses one immutable config...` and four more) fail identically with the repair reverted, so they are local-environment failures, not regressions.

**Follow-up 10 (resume after restart, seventh defect on the admission side).** A message sent to a session whose turn a daemon restart had cancelled was refused with `execution admission deny: parent_cancel_locked`, and its pre-turn compaction failed the same way. The base branch commit eeb593179 ("interrupted and interactive sessions can be resumed again", cherry-picked here as `ed540cda7` because this PR targets main, which lacks it) lets the explicit reopen through and moves the sticky status back to running, but the run's `execution_admission_cancellations` row survived, and the admission gate reads that table. `reopenRun` now deletes the reopened run's own lock row right after the status update (descendants keep theirs). Test: run-durability suite gains "lifts the run's admission lock when a cancelled run is explicitly reopened" (row gone, status running, the next suspend on the new epoch succeeds). Pre-existing on the base branch and unrelated to this PR: 8 tests in `agent-lifecycle.contract.test.ts` added by eeb593179 fail on this Mac with `agent.create resume rollout metadata does not match session id and cwd` (verified identical on an untouched checkout of resume-interactive-objective), and `daemon-cli.contract.test.ts > lets multiple configured daemon homes run without websocket port collisions` times out waiting for a daemon pid both in CI and locally.
