### PR TITLE
fix(runtime): bound agent MCP tool output

### DIFF
--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -119,6 +119,7 @@ import {
   sanitizeMcpSearchHint,
   sanitizeOptionalMcpModelFacingText,
 } from '../../mcp-client/model-facing-sanitization.js'
+import { normalizeMcpToolOutput } from '../../mcp-client/tool-output.js'
 import {
   buildMcpHostClientCapabilities,
   configureMcpHostRequestHandlers,
@@ -2699,14 +2700,78 @@ async function callMCPTool({
       signal.removeEventListener('abort', forwardCallerAbort)
     }
 
-    if ('isError' in result && result.isError) {
+    let boundedResult = result
+    if (name !== 'ide') {
+      const hasLegacyToolResult = 'toolResult' in result
+      const legacyToolResult = hasLegacyToolResult
+        ? typeof result.toolResult === 'string'
+          ? result.toolResult
+          : result.toolResult === null ||
+              typeof result.toolResult === 'boolean' ||
+              typeof result.toolResult === 'number' ||
+              typeof result.toolResult === 'bigint' ||
+              typeof result.toolResult === 'undefined'
+            ? String(result.toolResult)
+            : '[Unsupported MCP toolResult value omitted]'
+        : undefined
+      const normalized = await normalizeMcpToolOutput({
+        raw: hasLegacyToolResult
+          ? {
+              content: [{ type: 'text', text: legacyToolResult }],
+              isError: result.isError === true,
+              ...(result.structuredContent !== undefined
+                ? { structuredContent: result.structuredContent }
+                : {}),
+              ...(result._meta !== undefined ? { _meta: result._meta } : {}),
+            }
+          : result,
+        serverName: name,
+        toolName: tool,
+        callId: `mcp-${normalizeNameForMCP(name)}-${normalizeNameForMCP(tool)}-${toolStartTime}`,
+        // The canonical pass owns the hard work envelope. The legacy result
+        // processor below still owns the configured token persistence policy.
+        environment: {
+          ...environment,
+          MAX_MCP_OUTPUT_TOKENS: String(Number.MAX_SAFE_INTEGER),
+        },
+        logger: {
+          debug: message => logMCPDebug(name, message),
+          info: message => logMCPDebug(name, message),
+          warn: message => logMCPError(name, message),
+          error: message => logMCPError(name, message),
+        },
+      })
+      const codeModeResult = normalized.codeModeResult as Record<
+        string,
+        unknown
+      >
+      const firstCodeModeBlock = Array.isArray(codeModeResult.content)
+        ? codeModeResult.content[0]
+        : undefined
+      boundedResult = {
+        ...codeModeResult,
+        ...(hasLegacyToolResult
+          ? {
+              toolResult:
+                firstCodeModeBlock &&
+                typeof firstCodeModeBlock === 'object' &&
+                'text' in firstCodeModeBlock &&
+                typeof firstCodeModeBlock.text === 'string'
+                  ? firstCodeModeBlock.text
+                  : normalized.content,
+            }
+          : {}),
+      } as Awaited<ReturnType<typeof client.callTool>>
+    }
+
+    if ('isError' in boundedResult && boundedResult.isError) {
       let errorDetails = 'Unknown error'
       if (
-        'content' in result &&
-        Array.isArray(result.content) &&
-        result.content.length > 0
+        'content' in boundedResult &&
+        Array.isArray(boundedResult.content) &&
+        boundedResult.content.length > 0
       ) {
-        const firstContent = result.content[0]
+        const firstContent = boundedResult.content[0]
         if (
           firstContent &&
           typeof firstContent === 'object' &&
@@ -2714,9 +2779,9 @@ async function callMCPTool({
         ) {
           errorDetails = firstContent.text
         }
-      } else if ('error' in result) {
+      } else if ('error' in boundedResult) {
         // Fallback for compatibility error format
-        errorDetails = String(result.error)
+        errorDetails = String(boundedResult.error)
       }
       logMCPError(name, errorDetails)
       // Include server and tool name in logs for debugging, but keep
@@ -2725,7 +2790,9 @@ async function callMCPTool({
       throw new McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS(
         errorDetails,
         `MCP tool [${name}] ${tool}: ${errorDetails}`,
-        '_meta' in result && result._meta ? { _meta: result._meta } : undefined,
+        '_meta' in boundedResult && boundedResult._meta
+          ? { _meta: boundedResult._meta }
+          : undefined,
       )
     }
     const elapsed = Date.now() - toolStartTime
@@ -2738,11 +2805,16 @@ async function callMCPTool({
 
     logMCPDebug(name, `Tool '${tool}' completed successfully in ${duration}`)
 
-    const content = await processMCPResult(result, tool, name, environment)
+    const content = await processMCPResult(
+      boundedResult,
+      tool,
+      name,
+      environment,
+    )
     return {
       content,
-      _meta: result._meta as Record<string, unknown> | undefined,
-      structuredContent: result.structuredContent as
+      _meta: boundedResult._meta as Record<string, unknown> | undefined,
+      structuredContent: boundedResult.structuredContent as
         | Record<string, unknown>
         | undefined,
     }

--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type {
   Base64ImageSource,
   ContentBlockParam,
@@ -2714,6 +2715,20 @@ async function callMCPTool({
             ? String(result.toolResult)
             : '[Unsupported MCP toolResult value omitted]'
         : undefined
+      const rawToolUseId = meta?.['agenccode/toolUseId']
+      const artifactToolUseId =
+        typeof rawToolUseId === 'string' &&
+        /^[a-zA-Z0-9._-]{1,64}$/u.test(rawToolUseId)
+          ? rawToolUseId
+          : undefined
+      const artifactCallId = [
+        'mcp',
+        normalizeNameForMCP(name),
+        normalizeNameForMCP(tool),
+        ...(artifactToolUseId === undefined ? [] : [artifactToolUseId]),
+        String(toolStartTime),
+        randomUUID(),
+      ].join('-')
       const normalized = await normalizeMcpToolOutput({
         raw: hasLegacyToolResult
           ? {
@@ -2727,7 +2742,7 @@ async function callMCPTool({
           : result,
         serverName: name,
         toolName: tool,
-        callId: `mcp-${normalizeNameForMCP(name)}-${normalizeNameForMCP(tool)}-${toolStartTime}`,
+        callId: artifactCallId,
         // The canonical pass owns the hard work envelope. The legacy result
         // processor below still owns the configured token persistence policy.
         environment: {

--- a/runtime/tests/services/mcp/client-transports.test.ts
+++ b/runtime/tests/services/mcp/client-transports.test.ts
@@ -2393,15 +2393,18 @@ test('MCP tool calls persist large non-image output and fall back when disabled'
   const persisted: Array<{ content: unknown; id: string }> = []
   const needsTruncationEnvironments: Array<Readonly<Record<string, string | undefined>>> = []
   const truncationEnvironments: Array<Readonly<Record<string, string | undefined>>> = []
-  const pngBase64 =
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
   vi.doMock('../../../src/utils/mcpValidation.js', () => ({
     mcpContentNeedsTruncation: async (
-      _content: unknown,
+      content: unknown,
       environment: Readonly<Record<string, string | undefined>>,
     ) => {
       needsTruncationEnvironments.push(environment)
-      return true
+      if (
+        environment.MAX_MCP_OUTPUT_TOKENS === String(Number.MAX_SAFE_INTEGER)
+      ) {
+        return false
+      }
+      return JSON.stringify(content).includes('huge result')
     },
     truncateMcpContentIfNeeded: async (
       _content: unknown,
@@ -2451,7 +2454,6 @@ test('MCP tool calls persist large non-image output and fall back when disabled'
 	          { name: 'dump', inputSchema: { type: 'object' } },
 	          { name: 'plain', inputSchema: { type: 'object' } },
 	          { name: 'empty', inputSchema: { type: 'object' } },
-	          { name: 'image', inputSchema: { type: 'object' } },
 	          { name: 'fail-persist', inputSchema: { type: 'object' } },
 	        ],
 	      }),
@@ -2462,17 +2464,6 @@ test('MCP tool calls persist large non-image output and fall back when disabled'
 	        if (request.name === 'empty') {
 	          return { toolResult: '' }
 	        }
-	        if (request.name === 'image') {
-	          return {
-	            content: [
-              {
-                type: 'image',
-                data: pngBase64,
-                mimeType: 'image/png',
-              },
-            ],
-          }
-        }
         return {
           content: [{ type: 'text', text: 'huge result' }],
         }
@@ -2530,17 +2521,6 @@ test('MCP tool calls persist large non-image output and fall back when disabled'
     { message: { content: [] } } as never,
   )
   assert.deepEqual(emptyResult, { data: '' })
-
-  const imageResult = await toolByName.get('image')!.call(
-    {},
-    {
-      abortController: new AbortController(),
-      setAppState: value => value({ elicitation: { queue: [] } } as never),
-    } as never,
-    undefined as never,
-    { message: { content: [] } } as never,
-  )
-  assert.deepEqual(imageResult, { data: 'truncated fallback' })
 
   const persistErrorResult = await toolByName.get('fail-persist')!.call(
     {},

--- a/runtime/tests/services/mcp/client.test.ts
+++ b/runtime/tests/services/mcp/client.test.ts
@@ -14,6 +14,10 @@ import {
 import { resolveHomeContext } from '../../../src/config/home.js'
 import { secureStorageIdentityKey } from '../../../src/utils/secureStorage/home.js'
 import { resolveSessionTempRoot } from '../../../src/session/runtime-options.js'
+import {
+  MAX_MCP_TOOL_RESULT_CONTENT_BLOCKS,
+  MCP_TOOL_RESULT_HARD_LIMIT_BYTES,
+} from '../../../src/mcp-client/tool-output.js'
 import { resetProjectForTesting } from '../../../src/utils/sessionStorage.js'
 import { getToolResultsDir } from '../../../src/utils/toolResultStorage.js'
 import {
@@ -187,6 +191,41 @@ async function configureIsolatedSession(): Promise<{ toolResultsDir: string }> {
   switchSession(isolatedSessionId as never, null)
 
   return { toolResultsDir: getToolResultsDir() }
+}
+
+async function callAgentMcpTool(
+  serverName: string,
+  rawResult: unknown,
+): Promise<unknown> {
+  const config = {
+    type: 'stdio',
+    command: serverName,
+    scope: 'local',
+  } as const
+  const client = connectedClient({
+    name: serverName,
+    capabilities: { tools: {} },
+    config,
+    client: {
+      request: async () => ({
+        tools: [{ name: 'adversarial', inputSchema: { type: 'object' } }],
+      }),
+      callTool: async () => rawResult,
+    } as never,
+  })
+  seedConnectionCache(serverName, config, client)
+
+  const [tool] = await fetchToolsForClient(client)
+  assert.ok(tool)
+  return await tool.call(
+    {},
+    {
+      abortController: new AbortController(),
+      setAppState: value => value({ elicitation: { queue: [] } } as never),
+    } as never,
+    undefined as never,
+    { message: { content: [] } } as never,
+  )
 }
 
 test('cleanupFailedConnection awaits transport close before resolving', async () => {
@@ -785,6 +824,96 @@ test('MCP tool call passes metadata, progress, structured content, and result me
       progressMessage: 'working',
     },
   })
+})
+
+test('agent MCP tool rejects oversized base64 before legacy binary transformation', async () => {
+  const { toolResultsDir } = await configureIsolatedSession()
+  await mkdir(toolResultsDir, { recursive: true })
+  const oversizedBase64 = 'A'.repeat(MCP_TOOL_RESULT_HARD_LIMIT_BYTES + 4)
+
+  const result = await callAgentMcpTool('oversized-binary-server', {
+    content: [
+      {
+        type: 'image',
+        data: oversizedBase64,
+        mimeType: 'image/png',
+      },
+    ],
+  })
+  const serialized = JSON.stringify(result)
+
+  assert.match(serialized, /Invalid or oversized MCP binary content omitted/)
+  assert.equal(serialized.includes(oversizedBase64.slice(0, 1_024)), false)
+  assert.deepEqual(await readdir(toolResultsDir), [])
+})
+
+test('agent MCP tool caps aggregate content blocks before legacy transformation', async () => {
+  const result = (await callAgentMcpTool('many-blocks-server', {
+    content: Array.from(
+      { length: MAX_MCP_TOOL_RESULT_CONTENT_BLOCKS + 1 },
+      () => ({ type: 'text', text: 'bounded-block' }),
+    ),
+  })) as { data: Array<{ type: string; text?: string }> }
+
+  assert.ok(Array.isArray(result.data))
+  assert.equal(
+    result.data.filter(block => block.text === 'bounded-block').length,
+    MAX_MCP_TOOL_RESULT_CONTENT_BLOCKS,
+  )
+  assert.match(
+    result.data.at(-1)?.text ?? '',
+    /aggregate safety budget exhausted/,
+  )
+})
+
+test('agent MCP tool bounds deep structured content and oversized metadata before egress', async () => {
+  let structuredContent: Record<string, unknown> = {
+    value: 'deep-structured-sentinel',
+  }
+  for (let depth = 0; depth < 80; depth++) {
+    structuredContent = { nested: structuredContent }
+  }
+
+  const result = (await callAgentMcpTool('deep-json-server', {
+    content: [{ type: 'text', text: 'visible' }],
+    structuredContent,
+    _meta: {
+      value: `deep-meta-sentinel-${'m'.repeat(65 * 1_024)}`,
+    },
+  })) as {
+    data: unknown
+    mcpMeta?: Record<string, unknown>
+  }
+  const serialized = JSON.stringify(result)
+
+  assert.equal(serialized.includes('deep-structured-sentinel'), false)
+  assert.equal(serialized.includes('deep-meta-sentinel'), false)
+  assert.ok(result.mcpMeta)
+  assert.equal('_meta' in result.mcpMeta, false)
+  assert.ok('structuredContent' in result.mcpMeta)
+})
+
+test('agent MCP tool bounds error metadata before throwing', async () => {
+  await assert.rejects(
+    callAgentMcpTool('error-metadata-server', {
+      isError: true,
+      content: [{ type: 'text', text: 'bounded failure' }],
+      _meta: { value: 'm'.repeat(65 * 1_024) },
+    }),
+    (error: unknown) => {
+      assert.equal(
+        error instanceof McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        true,
+      )
+      assert.equal((error as Error).message, 'bounded failure')
+      assert.equal(
+        (error as McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS)
+          .mcpMeta,
+        undefined,
+      )
+      return true
+    },
+  )
 })
 
 test('MCP tool call wraps generic and protocol errors with log-safe errors', async () => {

--- a/runtime/tests/services/mcp/client.test.ts
+++ b/runtime/tests/services/mcp/client.test.ts
@@ -193,10 +193,10 @@ async function configureIsolatedSession(): Promise<{ toolResultsDir: string }> {
   return { toolResultsDir: getToolResultsDir() }
 }
 
-async function callAgentMcpTool(
+async function createAgentMcpTool(
   serverName: string,
-  rawResult: unknown,
-): Promise<unknown> {
+  resultForArgs: (args: Record<string, unknown>) => unknown,
+) {
   const config = {
     type: 'stdio',
     command: serverName,
@@ -210,13 +210,24 @@ async function callAgentMcpTool(
       request: async () => ({
         tools: [{ name: 'adversarial', inputSchema: { type: 'object' } }],
       }),
-      callTool: async () => rawResult,
+      callTool: async request =>
+        resultForArgs(
+          (request as { arguments?: Record<string, unknown> }).arguments ?? {},
+        ),
     } as never,
   })
   seedConnectionCache(serverName, config, client)
 
   const [tool] = await fetchToolsForClient(client)
   assert.ok(tool)
+  return tool
+}
+
+async function callAgentMcpTool(
+  serverName: string,
+  rawResult: unknown,
+): Promise<unknown> {
+  const tool = await createAgentMcpTool(serverName, () => rawResult)
   return await tool.call(
     {},
     {
@@ -845,6 +856,64 @@ test('agent MCP tool rejects oversized base64 before legacy binary transformatio
   assert.match(serialized, /Invalid or oversized MCP binary content omitted/)
   assert.equal(serialized.includes(oversizedBase64.slice(0, 1_024)), false)
   assert.deepEqual(await readdir(toolResultsDir), [])
+})
+
+test('concurrent agent MCP binary calls use distinct artifact namespaces', async () => {
+  const { toolResultsDir } = await configureIsolatedSession()
+  const firstBytes = Buffer.from([0x00, 0x11, 0x22, 0x33])
+  const secondBytes = Buffer.from([0x44, 0x55, 0x66, 0x77])
+  const serverName = 'concurrent-binary-server'
+  const tool = await createAgentMcpTool(serverName, args => {
+    const bytes = args.variant === 'first' ? firstBytes : secondBytes
+    return {
+      content: [
+        {
+          type: 'audio',
+          data: bytes.toString('base64'),
+          mimeType: 'audio/wav',
+        },
+      ],
+    }
+  })
+  vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+
+  const invoke = (variant: 'first' | 'second') =>
+    tool.call(
+      { variant },
+      {
+        abortController: new AbortController(),
+        setAppState: value =>
+          value({ elicitation: { queue: [] } } as never),
+      } as never,
+      undefined as never,
+      { message: { content: [] } } as never,
+    )
+  const results = await Promise.all([invoke('first'), invoke('second')])
+
+  const files = (await readdir(toolResultsDir)).sort()
+  assert.equal(files.length, 2)
+  assert.notEqual(files[0], files[1])
+
+  const referencedFiles = results.map(result => {
+    const text = (result as { data: Array<{ text?: string }> }).data
+      .map(block => block.text ?? '')
+      .join('\n')
+    assert.doesNotMatch(text, /could not be persisted|conflict|error/iu)
+    const referencedFile = files.find(file =>
+      text.includes(join(toolResultsDir, file)),
+    )
+    assert.ok(referencedFile)
+    return referencedFile
+  })
+  assert.notEqual(referencedFiles[0], referencedFiles[1])
+  assert.deepEqual(
+    await readFile(join(toolResultsDir, referencedFiles[0]!)),
+    firstBytes,
+  )
+  assert.deepEqual(
+    await readFile(join(toolResultsDir, referencedFiles[1]!)),
+    secondBytes,
+  )
 })
 
 test('agent MCP tool caps aggregate content blocks before legacy transformation', async () => {


### PR DESCRIPTION
## Summary

- Normalize agent-facing MCP tool results with the canonical 5 MiB work bound before legacy transformation.
- Keep the IDE route and the existing configured token persistence policy unchanged.
- Cover oversized base64, aggregate block count, deep structured content, oversized metadata, and error metadata.

## Validation

- Node.js v26.5.0 and npm 11.17.0.
- Focused MCP and sanitizer tests passed 123 tests across 6 files.
- The post-commit fuzzy-search benchmark contract passed 8 tests in 1 file.
- `npm run typecheck` passed.
- `npm run build` passed, including SDK generated-type checks and package entrypoint verification.
- `npm test` passed required gates 158/158, agent surface contract 22/22, launcher tests 191/191, and runtime tests 21,178/21,181. The dirty-tree benchmark refusal passed 8/8 after commit. The other two failures reproduce on unchanged `main`. They are the stale `csv_scheduler_progress_scan` production-module closure and missing `id:err:1` in the transcript fan-out test.
- `git diff --check` passed.
- GitNexus `detect_changes` against `main` reports LOW risk, 3 changed files, 4 indexed touched symbols, and no affected indexed processes.

Closes #1791

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes untrusted MCP egress on the hot agent tool path (size limits, binary handling, metadata on errors) while deliberately excluding IDE; mis-bounding could truncate valid tool output or affect persistence behavior.
> 
> **Overview**
> Agent-facing MCP tool calls (everything except the **IDE** server) now run through **`normalizeMcpToolOutput`** immediately after `callTool`, applying the canonical **5 MiB** work envelope before the existing `processMCPResult` path (token limits, large-output file persistence).
> 
> The integration maps legacy **`toolResult`** responses into normalized content, builds **per-call artifact IDs** (server, tool, optional tool-use id, timestamp, UUID) so concurrent binary persists do not collide, and temporarily sets **`MAX_MCP_OUTPUT_TOKENS`** to unlimited so sizing is owned by normalization while configured truncation/persistence behavior stays in the legacy processor. Error handling and success returns use the **bounded** result; oversized error **`_meta`** is stripped when throwing.
> 
> Tests add helpers and cases for oversized base64, concurrent binary artifacts, content-block caps, deep structured content/metadata, and bounded error metadata; transport persistence tests drop the separate image-truncation scenario in favor of the new normalization path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d33abeccf2a106cc7633bdd2a75c84fba71ed2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->