### PR TITLE
a sandbox denial ends the loop instead of feeding it (#2021)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -23,7 +23,14 @@ jobs:
   affected-tests:
     name: affected-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # `vitest related` walks the import graph, so a change to a widely imported
+    # module (a util, a config loader) selects most of the suite, not a handful
+    # of files. At the runner's two workers that is ~20 minutes of tests, and
+    # the old 15-minute cap cancelled the job mid-run: the gate reported
+    # `cancelled` with zero failures, so a correct change could never go green
+    # and the module was effectively unmergeable. Other jobs in this repo
+    # already allow 30-60 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -5667,7 +5667,7 @@ function historyEpochFromRollout(
 ): string {
   return historyEpochForBoundary(
     runId,
-    latestTranscriptBoundary(items, runId)?.id ?? "initial",
+    latestTranscriptBoundary(items)?.id ?? "initial",
   );
 }
 
@@ -5680,7 +5680,6 @@ interface TranscriptBoundary {
 
 function latestTranscriptBoundary(
   items: readonly RolloutItem[],
-  runId: string,
 ): TranscriptBoundary | undefined {
   let latest: TranscriptBoundary | undefined;
   for (const [index, item] of items.entries()) {
@@ -5700,35 +5699,19 @@ function latestTranscriptBoundary(
       };
       continue;
     }
-    if (
-      item.type === "compacted" &&
-      item.payload.replacementHistory !== undefined
-    ) {
-      latest = {
-        index,
-        id: `compacted:${index}:${hashStable(JSON.stringify(item.payload.replacementHistory))}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (item.type === "compaction_committed") {
-      latest = {
-        index,
-        id: `compaction:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (
-      item.type === "compaction_rollback_committed" &&
-      item.payload.target_session_id === runId
-    ) {
-      latest = {
-        index,
-        id: `compaction-rollback:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-    }
+    // Compaction is deliberately NOT a transcript boundary.
+    //
+    // It changes what the MODEL sees; the person reading the transcript still
+    // sent every earlier message and expects to find them. Treating a commit
+    // as a boundary truncated the reloaded transcript to the compacted view
+    // and rendered the summary itself as a user message: live, a 13-turn
+    // session came back as two turns after an app relaunch, because that
+    // rollout contained two compaction commits and no explicit epoch event.
+    //
+    // A user-facing reset still truncates, and is still the only thing that
+    // does: `history_cleared` and `transcript_epoch` above. A partial compact
+    // or a rewind that means to reset the transcript emits `transcript_epoch`
+    // alongside its `compacted` item, so those keep working unchanged.
   }
   return latest;
 }
@@ -6092,7 +6075,7 @@ export function sessionTranscriptV2FromRollout(
   runId: string,
   activeTurn?: { readonly turnId: string; readonly clientMessageId: string },
 ): SessionTranscriptV2Result {
-  const boundary = latestTranscriptBoundary(items, runId);
+  const boundary = latestTranscriptBoundary(items);
   const boundaryIndex = boundary?.index ?? -1;
   const boundaryId = boundary?.id ?? "initial";
   let asOfSequence = 0;

--- a/runtime/src/phases/repeat-tool-advisory.ts
+++ b/runtime/src/phases/repeat-tool-advisory.ts
@@ -83,19 +83,88 @@ interface RepeatRun {
 const repeatRuns = new WeakMap<object, RepeatRun>();
 
 /**
+ * Argument fields that do not change what a call DOES. Two calls differing
+ * only in these are the same repeated call, so they are dropped from the
+ * identity key. `justification` is free text addressed to a human and
+ * `prefix_rule` is a suggested approval rule: neither reaches the command.
+ * Live shape: a model retried one denied `npm start` 13 times, rewording the
+ * justification and nudging the timeouts each round, and the guard saw 13
+ * different calls.
+ */
+const NON_SEMANTIC_ARGUMENT_KEYS: ReadonlySet<string> = new Set([
+  "justification",
+  "prefix_rule",
+]);
+
+/** Per-tool additions to {@link NON_SEMANTIC_ARGUMENT_KEYS}. */
+const TOOL_NON_SEMANTIC_ARGUMENT_KEYS: ReadonlyMap<
+  string,
+  ReadonlySet<string>
+> = new Map([
+  // How long the runtime waits for the process, not what it runs.
+  ["exec_command", new Set(["timeoutMs", "yield_time_ms"])],
+  ["write_stdin", new Set(["yield_time_ms"])],
+]);
+
+function semanticArguments(
+  toolName: string,
+  parsed: unknown,
+): unknown {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return parsed;
+  }
+  const perTool = TOOL_NON_SEMANTIC_ARGUMENT_KEYS.get(toolName);
+  const semantic: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (NON_SEMANTIC_ARGUMENT_KEYS.has(name)) continue;
+    if (perTool?.has(name) === true) continue;
+    semantic[name] = value;
+  }
+  return semantic;
+}
+
+/**
  * Canonical identity of one call: tool name plus arguments with object keys
- * sorted, so `{"a":1,"b":2}` and `{"b":2,"a":1}` belong to the same run.
- * Arguments that fail to parse as JSON participate verbatim — byte-identical
- * malformed arguments are still the same repeated call.
+ * sorted and non-semantic fields dropped, so `{"a":1,"b":2}` and
+ * `{"b":2,"a":1}` belong to the same run, and so do two calls that differ
+ * only in their justification or timeout. Arguments that fail to parse as
+ * JSON participate verbatim — byte-identical malformed arguments are still
+ * the same repeated call.
  */
 function canonicalCallKey(call: LLMToolCall): string {
   let canonicalArguments = call.arguments;
   try {
-    canonicalArguments = stableStringify(JSON.parse(call.arguments));
+    canonicalArguments = stableStringify(
+      semanticArguments(call.name, JSON.parse(call.arguments)),
+    );
   } catch {
     // Verbatim fallback keeps unparseable-argument repeats detectable.
   }
   return `${call.name}\n${canonicalArguments}`;
+}
+
+/**
+ * Values a runtime writes into every tool result that differ between two
+ * otherwise identical runs. Compared raw, they make every failure look new:
+ * `exec_command` closes each result with
+ * `[exec exit_code=1 wall_time=0.2630s tokens=212]`, and the live incident's
+ * 14 identical `npm start` denials produced 13 distinct bodies, differing
+ * only in that wall time. Used for comparison only; the model is always
+ * shown the raw error.
+ */
+const VOLATILE_RESULT_PATTERNS: readonly RegExp[] = [
+  /\bwall_time=\d+(?:\.\d+)?s/g,
+  /\bsession_id=\d+/g,
+  /\bprocess_id=\d+/g,
+];
+
+/** Comparison form of a failing result: volatile runtime values elided. */
+export function failureSignature(content: string): string {
+  let signature = content;
+  for (const pattern of VOLATILE_RESULT_PATTERNS) {
+    signature = signature.replace(pattern, "");
+  }
+  return signature;
 }
 
 function completedRecordKey(record: CompletedToolResultRecord): string {
@@ -120,6 +189,7 @@ export function identicalFailureRun(
   const key = canonicalCallKey(call);
   let count = 0;
   let lastError = "";
+  let lastSignature = "";
   for (const record of state.completedToolResults) {
     if (record.metadata?.[REPEATED_FAILURE_BLOCKED_METADATA_KEY] === true) {
       continue;
@@ -128,14 +198,18 @@ export function identicalFailureRun(
     if (!record.isError) {
       count = 0;
       lastError = "";
+      lastSignature = "";
       continue;
     }
-    if (count > 0 && record.content === lastError) {
+    const signature = failureSignature(record.content);
+    if (count > 0 && signature === lastSignature) {
       count += 1;
     } else {
       count = 1;
-      lastError = record.content;
     }
+    // The model is shown the raw error; only the comparison is normalized.
+    lastError = record.content;
+    lastSignature = signature;
   }
   return { count, lastError };
 }

--- a/runtime/src/sandbox/escalation/sandboxing.ts
+++ b/runtime/src/sandbox/escalation/sandboxing.ts
@@ -81,23 +81,77 @@ export function normalizeSandboxPermissionsRequest(
   return input;
 }
 
-export function sandboxPermissionsFromArgs(
+/** The accepted values of `sandbox_permissions`, for error messages. */
+export const SANDBOX_PERMISSIONS_ACCEPTED_VALUES =
+  '"default", "require_escalated" or "with_additional_permissions"';
+
+/**
+ * Outcome of reading an escalation request off tool arguments. An
+ * unrecognized shape is reported, never silently downgraded: the live
+ * incident's model sent `sandbox_permissions: {"network":"full"}` — a shape
+ * the exec_command schema invites and this parser used to discard — so its
+ * twelve escalation requests were neither honored nor refused, and the
+ * command re-ran under the same sandbox with no sign the request had been
+ * dropped.
+ */
+export type SandboxPermissionsParse =
+  | { readonly kind: "ok"; readonly request: SandboxPermissionsRequest }
+  | { readonly kind: "invalid"; readonly reason: string };
+
+export function parseSandboxPermissionsArgs(
   args: Record<string, unknown>,
-): SandboxPermissionsRequest {
+): SandboxPermissionsParse {
   const raw = args["sandbox_permissions"];
-  const additionalPermissions = isAdditionalSandboxPermissions(
-    args["additional_permissions"],
-  )
-    ? args["additional_permissions"]
+  const rawAdditional = args["additional_permissions"];
+  if (
+    rawAdditional !== undefined &&
+    rawAdditional !== null &&
+    !isAdditionalSandboxPermissions(rawAdditional)
+  ) {
+    return {
+      kind: "invalid",
+      reason:
+        "additional_permissions has an unsupported shape; it must be " +
+        '{"network":{"enabled":true}} and/or ' +
+        '{"file_system":{"read":[...],"write":[...]}}',
+    };
+  }
+  const additionalPermissions = isAdditionalSandboxPermissions(rawAdditional)
+    ? rawAdditional
     : null;
+  if (raw === undefined || raw === null) {
+    return { kind: "ok", request: { kind: "default" } };
+  }
   if (
     raw === "default" ||
     raw === "require_escalated" ||
     raw === "with_additional_permissions"
   ) {
-    return normalizeSandboxPermissionsRequest(raw, additionalPermissions);
+    return {
+      kind: "ok",
+      request: normalizeSandboxPermissionsRequest(raw, additionalPermissions),
+    };
   }
-  return { kind: "default" };
+  return {
+    kind: "invalid",
+    reason:
+      `sandbox_permissions must be one of ${SANDBOX_PERMISSIONS_ACCEPTED_VALUES}; ` +
+      `received ${JSON.stringify(raw)}`,
+  };
+}
+
+/**
+ * Escalation request for the approval layer. Retains the historical
+ * "unknown shape means no request" behavior for callers that have no way to
+ * report a malformed argument; callers that can reject the call should use
+ * {@link parseSandboxPermissionsArgs} so the model learns its request was
+ * not understood.
+ */
+export function sandboxPermissionsFromArgs(
+  args: Record<string, unknown>,
+): SandboxPermissionsRequest {
+  const parsed = parseSandboxPermissionsArgs(args);
+  return parsed.kind === "ok" ? parsed.request : { kind: "default" };
 }
 
 export function hasAdditionalSandboxPermissions(
@@ -238,15 +292,38 @@ export function toolWantsNoSandboxApproval(
   }
 }
 
+/** The only keys `additional_permissions` and its members may carry. */
+const ADDITIONAL_PERMISSION_KEYS: ReadonlySet<string> = new Set([
+  "network",
+  "file_system",
+]);
+const NETWORK_PERMISSION_KEYS: ReadonlySet<string> = new Set(["enabled"]);
+const FILE_SYSTEM_PERMISSION_KEYS: ReadonlySet<string> = new Set([
+  "read",
+  "write",
+]);
+
+function hasOnlyKeys(value: object, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+/**
+ * Unknown keys are refused rather than ignored, so this agrees with the
+ * exec_command schema instead of quietly honoring half of a request the
+ * schema rejects. Silently dropping part of an escalation request is the
+ * defect this file's parser was fixed for.
+ */
 function isAdditionalSandboxPermissions(
   value: unknown,
 ): value is AdditionalSandboxPermissions {
   if (typeof value !== "object" || value === null) return false;
+  if (!hasOnlyKeys(value, ADDITIONAL_PERMISSION_KEYS)) return false;
   const candidate = value as AdditionalSandboxPermissions;
   if (candidate.network !== undefined) {
     if (typeof candidate.network !== "object" || candidate.network === null) {
       return false;
     }
+    if (!hasOnlyKeys(candidate.network, NETWORK_PERMISSION_KEYS)) return false;
     const enabled = (candidate.network as { readonly enabled?: unknown })
       .enabled;
     if (enabled !== undefined && typeof enabled !== "boolean") {
@@ -264,6 +341,9 @@ function isAdditionalSandboxPermissions(
       readonly read?: unknown;
       readonly write?: unknown;
     };
+    if (!hasOnlyKeys(candidate.file_system, FILE_SYSTEM_PERMISSION_KEYS)) {
+      return false;
+    }
     if (fs.read !== undefined && !isStringArray(fs.read)) return false;
     if (fs.write !== undefined && !isStringArray(fs.write)) return false;
   }

--- a/runtime/src/tools/schema-errors.ts
+++ b/runtime/src/tools/schema-errors.ts
@@ -126,10 +126,41 @@ const SKILL_TOOL_NAMES: ReadonlySet<string> = new Set([
  * `Skill` tool's missing-`skill` case. Additional overrides can be added here
  * as new tools gain specific bad-input guidance.
  */
+/**
+ * Tools whose `sandbox_permissions` field a model reliably guesses wrong.
+ * Its schema is an enum of three strings, and the default enum prose does
+ * not say what to send instead — the live incident's model sent
+ * `{"network":"full"}` twelve times.
+ */
+const SANDBOX_PERMISSION_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "exec_command",
+]);
+
+const SANDBOX_PERMISSION_VALUES: readonly string[] = [
+  "default",
+  "require_escalated",
+  "with_additional_permissions",
+];
+
 export function getSchemaValidationErrorOverride(
   tool: Tool,
   input: unknown,
 ): string | null {
+  if (SANDBOX_PERMISSION_TOOL_NAMES.has(tool.name) && input && typeof input === "object") {
+    const raw = (input as { sandbox_permissions?: unknown }).sandbox_permissions;
+    if (
+      raw !== undefined &&
+      !(typeof raw === "string" && SANDBOX_PERMISSION_VALUES.includes(raw))
+    ) {
+      return (
+        'sandbox_permissions must be the plain string "default", ' +
+        '"require_escalated" or "with_additional_permissions" — not an object. ' +
+        'Scoped permissions belong in additional_permissions alongside ' +
+        '"with_additional_permissions", for example ' +
+        '{"network":{"enabled":true}}. The command was not run.'
+      );
+    }
+  }
   if (!SKILL_TOOL_NAMES.has(tool.name)) return null;
   if (!input || typeof input !== "object") return null;
   const skill = (input as { skill?: unknown }).skill;

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -34,6 +34,11 @@ import { nonEmptyString as asString } from "../../utils/stringUtils.js";
 import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 import { readToolRuntimeContext } from "../runtimes/context.js";
 import {
+  execSandboxDenialNotice,
+  sandboxEscalationAvailable,
+} from "./exec-sandbox-denial.js";
+import { parseSandboxPermissionsArgs } from "../../sandbox/escalation/sandboxing.js";
+import {
   permissionProfileForRuntimeContext,
   runtimePlatformSandboxStatus,
   sandboxModeRequiresPlatformIsolation,
@@ -399,24 +404,38 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
             "Shell executable to run the command through. Defaults to the user's shell.",
         },
         sandbox_permissions: {
-          anyOf: [
-            {
-              type: "string",
-              enum: [
-                "default",
-                "require_escalated",
-                "with_additional_permissions",
-              ],
-            },
-            { type: "object" },
+          // Only the three documented modes. The former `{type:"object"}`
+          // alternative invited a shape no parser accepted, so a model could
+          // send an escalation request that was discarded without a word.
+          type: "string",
+          enum: [
+            "default",
+            "require_escalated",
+            "with_additional_permissions",
           ],
           description:
-            "Sandbox escalation mode or scoped permission request.",
+            "Sandbox escalation mode. Scoped permissions go in additional_permissions.",
         },
         additional_permissions: {
           type: "object",
+          properties: {
+            network: {
+              type: "object",
+              properties: { enabled: { type: "boolean" } },
+              additionalProperties: false,
+            },
+            file_system: {
+              type: "object",
+              properties: {
+                read: { type: "array", items: { type: "string" } },
+                write: { type: "array", items: { type: "string" } },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
           description:
-            "Additional permissions field accepted for request shape parity.",
+            "Scoped permissions to request alongside sandbox_permissions \"with_additional_permissions\".",
         },
         justification: {
           type: "string",
@@ -445,6 +464,22 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
             ),
           };
         }
+      }
+      // An escalation request the runtime cannot parse must be refused, not
+      // dropped: the schema invites an object here, and silently treating an
+      // unknown one as "no escalation requested" left the live incident's
+      // model re-sending the same request twelve times with no sign it had
+      // never been read.
+      const permissionsParse = parseSandboxPermissionsArgs(args);
+      if (permissionsParse.kind === "invalid") {
+        return {
+          content: safeStringify({ error: permissionsParse.reason }),
+          isError: true,
+          effectDisposition: confirmedNoEffectDisposition(
+            "tool:system.exec-command:invalid-input",
+            permissionsParse.reason,
+          ),
+        };
       }
       const cmd = asString(args.cmd);
       if (!cmd) {
@@ -610,8 +645,23 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
         const isError =
           (output.exitCode !== null && output.exitCode !== 0) ||
           (output.exitCode === null && !stillAlive);
+        // An OS-level sandbox refusal reaches us only as the child's own
+        // errno text. Say plainly that the sandbox did it and whether
+        // escalation can change the answer, so a denial reads as a verdict
+        // instead of an invitation to retry with a longer timeout.
+        const execContent = formatUnifiedExecToolContent(output);
+        const runtimeContext = readToolRuntimeContext(args);
+        const denial = execSandboxDenialNotice({
+          output: execContent,
+          exitCode: output.exitCode,
+          sandboxApplied: runtimeSandbox !== undefined,
+          escalationAvailable:
+            runtimeContext === undefined ||
+            sandboxEscalationAvailable(runtimeContext.approvalPolicy),
+        });
         return {
-          content: formatUnifiedExecToolContent(output),
+          content:
+            denial === null ? execContent : `${execContent}\n\n${denial.notice}`,
           isError: isError || undefined,
           codeModeResult: unifiedExecCodeModeResult(output),
           effectDisposition: processObservationDisposition(

--- a/runtime/src/tools/system/exec-sandbox-denial.ts
+++ b/runtime/src/tools/system/exec-sandbox-denial.ts
@@ -1,0 +1,104 @@
+/**
+ * Turn an OS-level sandbox refusal into a statement the model can act on.
+ *
+ * A sandbox denial that happens at syscall time inside a running child never
+ * reaches the runtime as a denial: the child simply exits non-zero and its
+ * own errno text is the only thing the tool result carries. The model sees
+ * `Error: listen EPERM: operation not permitted 0.0.0.0:8080` and nothing
+ * that says the sandbox did it, that the command itself is fine, or that
+ * retrying is pointless. Live incident (session conv-mtjdmlfc, 2026-09-02):
+ * a model retried one denied `npm start` 21 times over 412 seconds, raising
+ * the timeout and rewording a justification nobody could answer, because
+ * nothing in the transcript told it the retry could not work.
+ *
+ * This module classifies that one case — a listening socket the sandbox
+ * refused — and returns a frozen sentence to append to the tool result. The
+ * text is deliberately constant: the repeated-failure guard compares failure
+ * signatures, so a notice that embedded a timing or a port would defeat the
+ * very guard that catches a model which keeps going anyway.
+ *
+ * @module
+ */
+
+/** The denial classes this module recognizes. */
+export type ExecSandboxDenialKind = "network_bind";
+
+/**
+ * Signatures of "the OS refused to bind or listen", across the runtimes a
+ * coding agent actually starts a server with. Each requires BOTH a bind or
+ * listen verb and a permission errno on the same line: a bare EPERM (a
+ * chmod, a kill, a write) is a different failure and must not be labelled a
+ * network denial.
+ */
+const BIND_DENIED_SIGNATURES: readonly RegExp[] = [
+  // Node: "Error: listen EPERM: operation not permitted 0.0.0.0:8080"
+  /\b(?:listen|bind)\s+(?:EPERM|EACCES)\b/u,
+  // Go / Rust / Python: "bind: operation not permitted",
+  // "listen tcp 0.0.0.0:8080: bind: permission denied"
+  /\b(?:bind|binding|listen|listening)\b[^\n]{0,80}?(?:operation not permitted|permission denied)/iu,
+  // Reversed order: "... PermissionDenied ... binding 0.0.0.0:3000"
+  /(?:operation not permitted|permission denied)[^\n]{0,80}?\b(?:bind|binding|listen|listening)\b/iu,
+];
+
+/**
+ * Escalation cannot be granted by anyone in this session, so the only honest
+ * next step is to hand the command to the user.
+ */
+export const SANDBOX_BIND_DENIED_NO_ESCALATION =
+  "[sandbox] The OS sandbox denied this command permission to bind a " +
+  "listening socket. The command and the port are fine; the sandbox blocks " +
+  "the bind. Escalation is unavailable in this session: the approval policy " +
+  "is never, so nobody is present to approve running outside the sandbox, " +
+  "and sandbox_permissions and justification have no effect under it. " +
+  "Retrying will fail the same way, with any timeout. Do not run this " +
+  "command again. Tell the user the server cannot be started from here and " +
+  "give them the exact command to run in their own terminal.";
+
+/**
+ * A human can still approve, so one escalated retry is the correct move —
+ * and exactly one, because a second identical request answers nothing.
+ */
+export const SANDBOX_BIND_DENIED_ESCALATION_AVAILABLE =
+  "[sandbox] The OS sandbox denied this command permission to bind a " +
+  "listening socket. The command and the port are fine; the sandbox blocks " +
+  "the bind. Retrying it unchanged will fail the same way, with any " +
+  "timeout. Send this exact command once more with sandbox_permissions " +
+  'set to "require_escalated" and a one-line justification. Extra network ' +
+  "permissions do not help: only running outside the sandbox grants a " +
+  "listening socket. If that request is refused, tell the user the server " +
+  "cannot be started from here and give them the exact command to run in " +
+  "their own terminal.";
+
+/**
+ * The notice for a finished exec, or null when this was not a sandbox
+ * denial. Requires that a sandbox was actually applied: without one the
+ * same errno means the OS itself refused (a privileged port, a taken
+ * address), which is the user's problem, not the sandbox's, and mislabeling
+ * it would send the model down the wrong path.
+ */
+export function execSandboxDenialNotice(params: {
+  readonly output: string;
+  readonly exitCode: number | null;
+  readonly sandboxApplied: boolean;
+  readonly escalationAvailable: boolean;
+}): { readonly kind: ExecSandboxDenialKind; readonly notice: string } | null {
+  if (!params.sandboxApplied) return null;
+  if (params.exitCode === 0) return null;
+  if (!BIND_DENIED_SIGNATURES.some((pattern) => pattern.test(params.output))) {
+    return null;
+  }
+  return {
+    kind: "network_bind",
+    notice: params.escalationAvailable
+      ? SANDBOX_BIND_DENIED_ESCALATION_AVAILABLE
+      : SANDBOX_BIND_DENIED_NO_ESCALATION,
+  };
+}
+
+/**
+ * Approval policies under which asking a human to lift the sandbox can still
+ * produce an answer. `never` cannot: the policy states that nobody is there.
+ */
+export function sandboxEscalationAvailable(approvalPolicy: string): boolean {
+  return approvalPolicy !== "never";
+}

--- a/runtime/src/tools/system/kill-process.ts
+++ b/runtime/src/tools/system/kill-process.ts
@@ -47,6 +47,21 @@ export function createKillProcessTool(config?: KillProcessToolConfig): Tool {
       hiddenByDefault: false,
       mutating: true,
       deferred: false,
+      /**
+       * Audited per the ToolMetadata.virtualNoFsWrites contract: execute()
+       * below validates `session_id` as a number, rejects the removed
+       * `process_id` alias, and calls `terminateProcess` — it sends a signal
+       * and writes no file. The schema is `{session_id: number}` with
+       * `additionalProperties: false`, so no path argument exists for the
+       * model to steer, and this tool neither executes shell nor runs
+       * arbitrary code. Without the exemption the sandbox classified it as a
+       * mutating tool with indeterminate write targets and denied every call
+       * ("sandbox workspace_write could not verify write targets for
+       * kill_process"), leaving a model unable to stop a background process
+       * it had started. Which process may be signalled stays enforced where
+       * it belongs, by the ownership check in `terminateProcess`.
+       */
+      virtualNoFsWrites: true,
     },
     // TOOL-02 / TOOL-11: kill is side-effecting and must not opt out of approval.
     requiresApproval: true,

--- a/runtime/src/utils/markdownConfigLoader.ts
+++ b/runtime/src/utils/markdownConfigLoader.ts
@@ -12,7 +12,7 @@ import type { FrontmatterData } from './frontmatterParser.js'
 import { parseFrontmatter } from './frontmatterParser.js'
 import { findCanonicalGitRoot, findGitRoot } from './git.js'
 import { parseToolListFromCLI } from './permissions/toolListParser.js'
-import { ripGrep } from './ripgrep.js'
+import { isRipgrepUnavailable, ripGrep } from './ripgrep.js'
 import {
   isSettingSourceEnabled,
   type SettingSource,
@@ -623,13 +623,25 @@ async function loadMarkdownFiles(dir: string): Promise<
           signal,
         )
   } catch (e: unknown) {
-    // Handle missing/inaccessible dir directly instead of pre-checking
-    // existence (TOCTOU). findMarkdownFilesNative already catches internally;
-    // ripGrep rejects on inaccessible target paths.
-    if (isFsInaccessible(e)) return []
-    throw e
+    // A search tool that cannot start is not an empty directory. `ripGrep`
+    // reports an unavailable binary with `code: "ENOENT"`, which errno alone
+    // cannot tell apart from "the directory is gone", so the check below
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently disappeared wherever ripgrep could not run — a machine with
+    // no `rg` on PATH, a build without the packaged binary, a container that
+    // cannot spawn it. The native walk is documented above as the fallback
+    // for exactly this and needs no external binary, so use it.
+    if (!useNative && isRipgrepUnavailable(e)) {
+      files = await findMarkdownFilesNative(dir, signal)
+    } else if (isFsInaccessible(e)) {
+      // Handle missing/inaccessible dir directly instead of pre-checking
+      // existence (TOCTOU). findMarkdownFilesNative already catches
+      // internally; ripGrep rejects on inaccessible target paths.
+      return []
+    } else {
+      throw e
+    }
   }
-
   const results = await Promise.all(
     files.map(async filePath => {
       let handle: Awaited<ReturnType<typeof open>> | undefined

--- a/runtime/src/utils/ripgrep.ts
+++ b/runtime/src/utils/ripgrep.ts
@@ -182,6 +182,11 @@ export function getRipgrepInstallHint(platform = process.platform): string {
   }
 }
 
+/** True when the failure means the search binary could not run at all. */
+export function isRipgrepUnavailable(error: unknown): boolean {
+  return error instanceof RipgrepUnavailableError
+}
+
 export function wrapRipgrepUnavailableError(
   error: RipgrepErrorLike,
   config = getRipgrepConfig(),

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -101,6 +101,121 @@ describe("session.transcript.v2 durable projection", () => {
     expect(afterAppend.messages).toEqual(first.messages);
   });
 
+  it("keeps the whole conversation when a compaction commits without an epoch", () => {
+
+    // Compaction changes what the model sees, not what the person reading
+
+    // the transcript sent. Live: a 13-turn session came back as two turns
+
+    // after an app relaunch, because its rollout carried two compaction
+
+    // commits and no explicit epoch event, and the summary itself was
+
+    // rendered as one of those turns.
+
+    const items: RolloutItem[] = [
+
+      event(10, "user-1", {
+
+        type: "user_message",
+
+        payload: { message: "first question", messageId: "client-1" },
+
+      }),
+
+      event(11, "turn-1", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-1" },
+
+      }),
+
+      event(12, "answer-1", {
+
+        type: "agent_message",
+
+        payload: { message: "first answer" },
+
+      }),
+
+      {
+
+        type: "compaction_committed",
+
+        payload: {
+
+          attempt_id: "compact-auto-1",
+
+          replacement_history: [
+
+            { role: "developer", content: "agenc_compaction_boundary_v1: untrusted" },
+
+            { role: "user", content: "a summary of the work so far" },
+
+          ],
+
+        },
+
+      } as unknown as RolloutItem,
+
+      event(20, "user-2", {
+
+        type: "user_message",
+
+        payload: { message: "second question", messageId: "client-2" },
+
+      }),
+
+      event(21, "turn-2", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-2" },
+
+      }),
+
+      event(22, "answer-2", {
+
+        type: "agent_message",
+
+        payload: { message: "second answer" },
+
+      }),
+
+    ];
+
+
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+
+
+    expect(snapshot.messages.map((message) => message.text)).toEqual([
+
+      "first question",
+
+      "first answer",
+
+      "second question",
+
+      "second answer",
+
+    ]);
+
+    // The model's compacted view never appears as something the user said.
+
+    expect(snapshot.messages.some((message) => message.text.includes("summary of the work"))).toBe(
+
+      false,
+
+    );
+
+    // Nothing truncated, so the epoch is the initial one.
+
+    expect(snapshot.historyEpoch).toBe("history:run-1:initial");
+
+  });
+
+
   it("rebuilds from each compact/rewind replacement and advances a stable epoch", () => {
     const compacted: RolloutItem[] = [
       {

--- a/runtime/tests/phases/repeat-tool-advisory.test.ts
+++ b/runtime/tests/phases/repeat-tool-advisory.test.ts
@@ -13,6 +13,7 @@ import {
   REPEATED_FAILURE_BLOCK_THRESHOLD,
   REPEATED_FAILURE_BLOCKED_METADATA_KEY,
   repeatedFailingCallStopExplanation,
+  failureSignature,
 } from "../../src/phases/repeat-tool-advisory.js";
 
 function call(name: string, args: unknown, id = "c"): LLMToolCall {
@@ -282,6 +283,116 @@ describe("blockRepeatedFailingCall", () => {
           "Write refused: identical call failed 3 times with the same error in this turn",
       },
     ]);
+  });
+
+  // Live incident (session conv-mtjdmlfc, 2026-09-02): one `npm start` was
+  // denied by the sandbox 21 times over 412 s and the guard never fired.
+  // Two independent reasons, both reproduced here.
+  describe("the live sandbox-denial loop", () => {
+    const EPERM_BODY = (wallTime: string) =>
+      "\n> start\n> node server.js\n\nError: listen EPERM: operation not permitted 0.0.0.0:8080\n" +
+      `\n[exec exit_code=1 wall_time=${wallTime}s tokens=212]`;
+
+    const npmStart = (overrides: Record<string, unknown> = {}) => ({
+      cmd: "npm start",
+      workdir: "/w/arcade15",
+      timeoutMs: 15_000,
+      yield_time_ms: 4_000,
+      ...overrides,
+    });
+
+    test("a reworded justification and a nudged timeout do not split the failure run", () => {
+      const { session } = mkSessionStub();
+      const failures = [
+        completed(
+          call("exec_command", npmStart({ justification: "May I bind the port?" }), "e-0"),
+          EPERM_BODY("0.2630"),
+          true,
+        ),
+        completed(
+          call("exec_command", npmStart({ justification: "Do you want to allow the server?", timeoutMs: 20_000 }), "e-1"),
+          EPERM_BODY("0.2630"),
+          true,
+        ),
+        completed(
+          call("exec_command", npmStart({ prefix_rule: ["npm", "start"], yield_time_ms: 3_000 }), "e-2"),
+          EPERM_BODY("0.2630"),
+          true,
+        ),
+      ];
+      const retry = call("exec_command", npmStart({ justification: "One more time?" }), "e-3");
+      const blocked = blockRepeatedFailingCall(mkState(failures), session, retry);
+      expect(blocked).not.toBeNull();
+      expect(blocked?.metadata).toMatchObject({ repeatedFailures: 3 });
+    });
+
+    test("a volatile wall time in the result does not reset the failure run", () => {
+      const { session } = mkSessionStub();
+      // 13 of the incident's 14 bodies were distinct; only the wall time moved.
+      const failures = ["0.2630", "0.1990", "0.3120"].map((wallTime, i) =>
+        completed(call("exec_command", npmStart(), `e-${i}`), EPERM_BODY(wallTime), true),
+      );
+      const blocked = blockRepeatedFailingCall(
+        mkState(failures),
+        session,
+        call("exec_command", npmStart(), "e-3"),
+      );
+      expect(blocked).not.toBeNull();
+      expect(blocked?.metadata).toMatchObject({ repeatedFailures: 3 });
+      // The model still sees the raw last error, wall time included.
+      expect(JSON.parse(blocked!.content).error).toContain("wall_time=0.3120s");
+    });
+
+    test("a session id in the result does not reset the failure run", () => {
+      const { session } = mkSessionStub();
+      const failures = [10, 11, 12].map((sessionId, i) =>
+        completed(
+          call("exec_command", npmStart(), `e-${i}`),
+          `blocked\n\n[exec exit_code=1 wall_time=0.1000s tokens=4 session_id=${sessionId}]`,
+          true,
+        ),
+      );
+      expect(
+        blockRepeatedFailingCall(mkState(failures), session, call("exec_command", npmStart(), "e-3")),
+      ).not.toBeNull();
+    });
+
+    test("a genuinely different error still resets the run", () => {
+      const { session } = mkSessionStub();
+      const failures = [
+        completed(call("exec_command", npmStart(), "e-0"), EPERM_BODY("0.2630"), true),
+        completed(call("exec_command", npmStart(), "e-1"), EPERM_BODY("0.1990"), true),
+        completed(
+          call("exec_command", npmStart(), "e-2"),
+          "\nError: Cannot find module './server.js'\n\n[exec exit_code=1 wall_time=0.1120s tokens=9]",
+          true,
+        ),
+      ];
+      expect(
+        blockRepeatedFailingCall(mkState(failures), session, call("exec_command", npmStart(), "e-3")),
+      ).toBeNull();
+    });
+
+    test("a different command still starts its own count", () => {
+      const { session } = mkSessionStub();
+      const failures = Array.from({ length: 3 }, (_, i) =>
+        completed(call("exec_command", npmStart(), `e-${i}`), EPERM_BODY("0.2630"), true),
+      );
+      expect(
+        blockRepeatedFailingCall(
+          mkState(failures),
+          session,
+          call("exec_command", npmStart({ cmd: "npm test" }), "e-3"),
+        ),
+      ).toBeNull();
+    });
+
+    test("failureSignature elides only the volatile runtime values", () => {
+      expect(failureSignature(EPERM_BODY("0.2630"))).toBe(failureSignature(EPERM_BODY("9.9999")));
+      expect(failureSignature(EPERM_BODY("0.2630"))).toContain("listen EPERM");
+      expect(failureSignature(EPERM_BODY("0.2630"))).toContain("exit_code=1");
+      expect(failureSignature(EPERM_BODY("0.2630"))).toContain("tokens=212");
+    });
   });
 
   test("the refusal's turn stop is worded like the behavioral backstop", () => {

--- a/runtime/tests/tools/kill-process.test.ts
+++ b/runtime/tests/tools/kill-process.test.ts
@@ -65,4 +65,21 @@ describe("kill_process tool", () => {
     const result = await tool.execute({});
     expect(result.isError).toBe(true);
   });
+
+  it("is audited as performing no filesystem write so the sandbox admits it", () => {
+    // The sandbox classifies a mutating tool with no resolvable write target
+    // as indeterminate and denies it. kill_process only signals a process,
+    // and its schema carries no path the model could steer, so it declares
+    // the audited exemption instead of being denied everywhere.
+    const tool = createKillProcessTool({ unifiedExecManager: fakeManager(true) });
+    expect(tool.metadata?.virtualNoFsWrites).toBe(true);
+    expect(tool.inputSchema).toMatchObject({
+      properties: { session_id: { type: "number" } },
+      required: ["session_id"],
+      additionalProperties: false,
+    });
+    expect(Object.keys((tool.inputSchema as { properties: object }).properties)).toEqual([
+      "session_id",
+    ]);
+  });
 });

--- a/runtime/tests/tools/runtimes/runtime.test.ts
+++ b/runtime/tests/tools/runtimes/runtime.test.ts
@@ -394,6 +394,49 @@ describe("tools/runtimes", () => {
       }),
     ).toThrow(/could not verify write targets/);
 
+    // kill_process signals a process and writes no file; before it was
+    // audited as virtualNoFsWrites the sandbox denied every call with
+    // "could not verify write targets", so a model could not stop a
+    // background process it had started (live incident, 2026-09-02).
+    const killProcessTool: Tool = {
+      name: "kill_process",
+      description: "",
+      inputSchema: { type: "object" },
+      metadata: { mutating: true, virtualNoFsWrites: true },
+      execute: async () => ({ content: "not reached" }),
+    };
+    expect(() =>
+      enforceRuntimeSandboxAttempt({
+        context: {
+          ...base,
+          approvalPolicy: "never",
+          requestedSandboxMode: "workspace_write",
+          sandboxMode: "workspace_write",
+          approvalResolved: false,
+          rawArgs: "{}",
+          invocation,
+        },
+        tool: killProcessTool,
+        args: { session_id: 10 },
+      }),
+    ).not.toThrow();
+    // Without the audited exemption the same call is denied.
+    expect(() =>
+      enforceRuntimeSandboxAttempt({
+        context: {
+          ...base,
+          approvalPolicy: "never",
+          requestedSandboxMode: "workspace_write",
+          sandboxMode: "workspace_write",
+          approvalResolved: false,
+          rawArgs: "{}",
+          invocation,
+        },
+        tool: { ...killProcessTool, metadata: { mutating: true } },
+        args: { session_id: 10 },
+      }),
+    ).toThrow(/could not verify write targets/);
+
     const shellTool: Tool = {
       name: "exec_command",
       description: "",

--- a/runtime/tests/tools/schema-errors.test.ts
+++ b/runtime/tests/tools/schema-errors.test.ts
@@ -23,4 +23,38 @@ describe("getSchemaValidationErrorOverride", () => {
       getSchemaValidationErrorOverride(SkillTool, { skill: "commit" }),
     ).toBe(null);
   });
+
+  // The live incident's model sent sandbox_permissions:{"network":"full"}
+  // twelve times; the default enum prose never told it what to send instead.
+  describe("exec_command sandbox_permissions", () => {
+    const ExecTool = { name: "exec_command" } as Tool;
+
+    test("names the accepted values and where scoped permissions go", () => {
+      const message = getSchemaValidationErrorOverride(ExecTool, {
+        cmd: "npm start",
+        sandbox_permissions: { network: "full" },
+      });
+      expect(message).toContain('"require_escalated"');
+      expect(message).toContain("not an object");
+      expect(message).toContain("additional_permissions");
+      expect(message).toContain("The command was not run.");
+    });
+
+    test("stays quiet for the documented values and when the field is absent", () => {
+      for (const value of ["default", "require_escalated", "with_additional_permissions"]) {
+        expect(
+          getSchemaValidationErrorOverride(ExecTool, { cmd: "ls", sandbox_permissions: value }),
+        ).toBe(null);
+      }
+      expect(getSchemaValidationErrorOverride(ExecTool, { cmd: "ls" })).toBe(null);
+    });
+
+    test("does not claim another tool's field", () => {
+      expect(
+        getSchemaValidationErrorOverride({ name: "Read" } as never, {
+          sandbox_permissions: { network: "full" },
+        }),
+      ).toBe(null);
+    });
+  });
 });

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -93,6 +93,152 @@ describe("exec_command tool", () => {
     root = "";
   });
 
+  // Live incident (session conv-mtjdmlfc, 2026-09-02): 21 `npm start` calls
+  // over 412 s, each denied by the sandbox, each answered only by the child's
+  // own errno text and an escalation request the parser silently discarded.
+  describe("a sandbox denial answers the model definitively", () => {
+    function sandboxedArgs(
+      overrides: Record<string, unknown>,
+      approvalPolicy = "never",
+    ): Record<string, unknown> {
+      const args: Record<string, unknown> = { ...overrides };
+      attachToolRuntimeContext(args, {
+        callId: "call-sandbox-denial",
+        toolName: "exec_command",
+        runtimeKind: "function",
+        classification: "exclusive",
+        supportsParallelToolCalls: false,
+        source: { type: "model" },
+        submittedAtMs: 0,
+        approvalPolicy,
+        requestedSandboxMode: "read_only",
+        sandboxMode: "read_only",
+        approvalResolved: true,
+        rawArgs: "{}",
+        invocation: {
+          session: { services: { runtimeOptions: { sessionTempRoot: root } } },
+          payload: { kind: "function", arguments: "{}" },
+          turn: {
+            subId: "turn-sandbox-denial",
+            cwd: root,
+            agencLinuxSandboxExe: "/bin/true",
+          },
+        },
+      } as never);
+      return args;
+    }
+
+    function toolWith(output: ExecCommandToolOutput) {
+      const execCommand = vi.fn<UnifiedExecProcessManagerLike["execCommand"]>(
+        async () => output,
+      );
+      const manager: UnifiedExecProcessManagerLike = {
+        maxTimeoutMs: 30_000,
+        execCommand,
+        writeStdin: vi.fn<UnifiedExecProcessManagerLike["writeStdin"]>(
+          async () => completedExecOutput(""),
+        ),
+        closeAll: vi.fn<UnifiedExecProcessManagerLike["closeAll"]>(async () => {}),
+      };
+      return {
+        execCommand,
+        tool: createExecCommandTool({
+          cwd: root,
+          allowedPaths: [root],
+          unifiedExecManager: manager,
+        }),
+      };
+    }
+
+    const BIND_DENIED = failedExecOutput(
+      "Error: listen EPERM: operation not permitted 0.0.0.0:8080",
+      1,
+    );
+
+    test("a denied bind says the sandbox did it and that retrying is pointless", async () => {
+      const { tool } = toolWith(BIND_DENIED);
+      const result = await tool.execute(sandboxedArgs({ cmd: "npm start", workdir: root }));
+
+      expect(result.isError).toBe(true);
+      // The child's own text is still there, unchanged.
+      expect(result.content).toContain("listen EPERM");
+      // And now so is the verdict.
+      expect(result.content).toContain("[sandbox]");
+      expect(result.content).toContain("Do not run this command again");
+      expect(result.content).toContain("give them the exact command to run in their own terminal");
+    });
+
+    test("under a policy with a human it asks for one escalated retry instead", async () => {
+      const { tool } = toolWith(BIND_DENIED);
+      const result = await tool.execute(
+        sandboxedArgs({ cmd: "npm start", workdir: root }, "on_request"),
+      );
+      expect(result.content).toContain("require_escalated");
+      expect(result.content).not.toContain("Do not run this command again");
+    });
+
+    test("an ordinary failure is left alone", async () => {
+      const { tool } = toolWith(failedExecOutput("npm ERR! missing script: start", 1));
+      const result = await tool.execute(sandboxedArgs({ cmd: "npm start", workdir: root }));
+      expect(result.content).not.toContain("[sandbox]");
+    });
+
+    test("an unreadable escalation request is refused instead of dropped", async () => {
+      // The schema used to invite `{type:"object"}` here and the parser threw
+      // every object away, so the model could not tell a refused request from
+      // an unread one.
+      const { execCommand, tool } = toolWith(completedExecOutput("ran"));
+      const result = await tool.execute(
+        sandboxedArgs({
+          cmd: "npm start",
+          workdir: root,
+          sandbox_permissions: { network: "full" },
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content as string).error).toContain(
+        'sandbox_permissions must be one of "default", "require_escalated" or "with_additional_permissions"',
+      );
+      expect(result.effectDisposition).toMatchObject({
+        disposition: "confirmed_no_effect",
+      });
+      // Refused means not run.
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("a malformed additional_permissions is refused too", async () => {
+      const { execCommand, tool } = toolWith(completedExecOutput("ran"));
+      const result = await tool.execute(
+        sandboxedArgs({
+          cmd: "npm start",
+          workdir: root,
+          sandbox_permissions: "with_additional_permissions",
+          additional_permissions: { network: "full" },
+        }),
+      );
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(result.content as string).error).toContain(
+        "additional_permissions has an unsupported shape",
+      );
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    test("the documented escalation values still run", async () => {
+      const { execCommand, tool } = toolWith(completedExecOutput("ran"));
+      const result = await tool.execute(
+        sandboxedArgs({
+          cmd: "echo hi",
+          workdir: root,
+          sandbox_permissions: "require_escalated",
+          justification: "needs the network",
+        }),
+      );
+      expect(result.isError).toBeUndefined();
+      expect(execCommand).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test("threads network policy interfaces into runtime sandbox requests", () => {
     const policyDecider = { decide: () => ({ decision: "allow" as const }) };
     const blockedRequestObserver = { onBlockedRequest: () => undefined };

--- a/runtime/tests/tools/system/exec-sandbox-denial.test.ts
+++ b/runtime/tests/tools/system/exec-sandbox-denial.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  execSandboxDenialNotice,
+  sandboxEscalationAvailable,
+  SANDBOX_BIND_DENIED_ESCALATION_AVAILABLE,
+  SANDBOX_BIND_DENIED_NO_ESCALATION,
+} from "../../../src/tools/system/exec-sandbox-denial.js";
+
+// The body the live incident produced 21 times (session conv-mtjdmlfc,
+// 2026-09-02). Nothing in it says the sandbox is responsible, so the model
+// kept retrying with a longer timeout for 412 seconds.
+const NODE_BIND_DENIED =
+  "\n> start\n> node server.js\n\nnode:events:505\n      throw er;\n" +
+  "Error: listen EPERM: operation not permitted 0.0.0.0:8080\n" +
+  "    at Server.listen (node:net:2558:7)\n\n" +
+  "[exec exit_code=1 wall_time=0.2630s tokens=212]";
+
+const denial = (overrides: Partial<Parameters<typeof execSandboxDenialNotice>[0]> = {}) =>
+  execSandboxDenialNotice({
+    output: NODE_BIND_DENIED,
+    exitCode: 1,
+    sandboxApplied: true,
+    escalationAvailable: false,
+    ...overrides,
+  });
+
+describe("execSandboxDenialNotice", () => {
+  test("names the sandbox and forbids the retry when nobody can approve", () => {
+    const result = denial();
+    expect(result?.kind).toBe("network_bind");
+    expect(result?.notice).toBe(SANDBOX_BIND_DENIED_NO_ESCALATION);
+    expect(result?.notice).toContain("Do not run this command again");
+    // It must not send the model to ask a human who is not there.
+    expect(result?.notice).not.toContain("require_escalated");
+  });
+
+  test("asks for exactly one escalated retry when a human can still approve", () => {
+    const result = denial({ escalationAvailable: true });
+    expect(result?.notice).toBe(SANDBOX_BIND_DENIED_ESCALATION_AVAILABLE);
+    expect(result?.notice).toContain("require_escalated");
+    expect(result?.notice).toContain("once more");
+  });
+
+  test("recognizes the phrasings other runtimes use", () => {
+    for (const output of [
+      "listen tcp 0.0.0.0:8080: bind: permission denied",
+      "OSError: [Errno 1] Operation not permitted: bind",
+      "thread 'main' panicked: Os { code: 1, kind: PermissionDenied, message: \"Operation not permitted\" } binding 0.0.0.0:3000",
+    ]) {
+      expect(denial({ output })?.kind).toBe("network_bind");
+    }
+  });
+
+  test("stays silent when the sandbox did not cause it", () => {
+    // Nothing was sandboxed: the same errno then means the OS refused for its
+    // own reasons (a privileged port, an address in use), and blaming the
+    // sandbox would send the model down the wrong path.
+    expect(denial({ sandboxApplied: false })).toBeNull();
+    // The command succeeded.
+    expect(denial({ exitCode: 0 })).toBeNull();
+    // A permission error that has nothing to do with a socket.
+    expect(denial({ output: "chmod: /etc/hosts: EPERM: operation not permitted" })).toBeNull();
+    // A port conflict is the user's to fix, not the sandbox's.
+    expect(denial({ output: "Error: listen EADDRINUSE: address already in use 0.0.0.0:8080" })).toBeNull();
+  });
+
+  test("the notice is constant, so a repeated denial keeps one failure signature", () => {
+    // The repeated-failure guard compares failure signatures; a notice
+    // carrying a timing or a port would defeat the guard that catches a model
+    // which retries anyway.
+    const first = denial({ output: NODE_BIND_DENIED })?.notice;
+    const second = denial({
+      output: NODE_BIND_DENIED.replace("0.2630", "9.9999").replace("8080", "3000"),
+    })?.notice;
+    expect(first).toBe(second);
+  });
+});
+
+describe("sandboxEscalationAvailable", () => {
+  test("only the never policy states that nobody is present to approve", () => {
+    expect(sandboxEscalationAvailable("never")).toBe(false);
+    for (const policy of ["on_request", "on_failure", "untrusted", "granular"]) {
+      expect(sandboxEscalationAvailable(policy)).toBe(true);
+    }
+  });
+});

--- a/runtime/tests/utils/markdown-config-loader-authority.test.ts
+++ b/runtime/tests/utils/markdown-config-loader-authority.test.ts
@@ -97,6 +97,36 @@ describe('markdown discovery authority', () => {
     expect(prompt(filesB)).toBe('Home B prompt.')
   })
 
+  test('still finds markdown when the search binary cannot run', async () => {
+    // ripGrep reports an unavailable binary with code "ENOENT", which errno
+    // alone cannot tell apart from "the directory is gone", so the loader
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently vanished wherever ripgrep could not start. CI is exactly such
+    // a machine: with `rg` off PATH this reproduced as a catalog holding only
+    // the five built-in agents. The native walk is the documented fallback.
+    const workspace = temporaryRoot('workspace-no-rg')
+    const home = temporaryRoot('home-no-rg')
+    writeAgent(home, 'Found without ripgrep.')
+    const authority = await createAuthority(home, workspace)
+
+    const previousBuiltin = process.env.USE_BUILTIN_RIPGREP
+    const previousPath = process.env.PATH
+    process.env.USE_BUILTIN_RIPGREP = 'false'
+    // A PATH with no `rg` on it, which is what makes ripGrep reject.
+    process.env.PATH = temporaryRoot('empty-bin')
+    try {
+      const files = await runWithCanonicalSettingsAuthority(authority, () =>
+        loadMarkdownFilesForSubdirFresh('agents', workspace),
+      )
+      expect(prompt(files)).toBe('Found without ripgrep.')
+    } finally {
+      if (previousBuiltin === undefined) delete process.env.USE_BUILTIN_RIPGREP
+      else process.env.USE_BUILTIN_RIPGREP = previousBuiltin
+      if (previousPath === undefined) delete process.env.PATH
+      else process.env.PATH = previousPath
+    }
+  })
+
   test('isolates same-home snapshots and clears only the active ConfigStore partition', async () => {
     const workspace = temporaryRoot('shared-workspace')
     const home = temporaryRoot('shared-home')


### PR DESCRIPTION
Fixes #2021.

Based on `harness-tools` (#2018) because fix 1 extends the identical-failing-call guard that PR introduces; the base is set to that branch so this diff is only the new work. Land it with or after #2018.

## Why

In the live 15-prompt desktop run (session `conv-mtjdmlfc`, 2026-09-02, Grok 4.6, `approvalPolicy: never`, `sandboxPolicy: workspace_write`) prompt 12 asked for a `package.json` with an `npm start` script. The model wrote the deliverable in the first minute, then tried to verify the server and spent 412 s on 21 `exec_command` calls of `npm start`, each dying the same way:

```
> start
> node server.js
Error: listen EPERM: operation not permitted 0.0.0.0:8080
    at Server.listen (node:net:2558:7)
```

27 model calls, 36 tool calls, 62k prompt tokens, stopped by hand. Its last words were "Sandbox still blocks the port. I'll retry npm start with elevated permission." Four independent defects had to line up for that, and each is fixed separately below.

## What, per file

**`src/phases/repeat-tool-advisory.ts`** — the guard could never fire for `exec_command`, for two reasons, and the second is the fatal one.

- `canonicalCallKey` counted every argument field. The model reworded `justification` each round and walked `timeoutMs` 8000 → 15000 → 20000 and `yield_time_ms` 3000 → 4000, splitting one command into several identities. `NON_SEMANTIC_ARGUMENT_KEYS` (`justification`, `prefix_rule`) and `TOOL_NON_SEMANTIC_ARGUMENT_KEYS` (`exec_command`, `write_stdin` timing fields) are now dropped before the key is built. Deliberately still in the identity: `cmd`, `workdir`, `sandbox_permissions`, `additional_permissions` — an escalated retry is a genuinely different call and must not merge with an unescalated one.
- `identicalFailureRun` compared `record.content` byte-for-byte, but every exec result ends in `[exec exit_code=1 wall_time=0.2630s tokens=212]` and that wall time changes on every run. Measured on the incident's own rollout: **13 of 14 bodies were distinct, differing only in the wall time**. The counter reset on every record, so the threshold was unreachable — for any tool whose result carries a duration, session id or pid, not just this one. Comparison now runs over `failureSignature()`, which elides `wall_time=`, `session_id=` and `process_id=`. The model is still shown the raw last error.

**`src/sandbox/escalation/sandboxing.ts`** — the escalation request was discarded in silence. `sandboxPermissionsFromArgs` accepted three literal strings and returned `{kind:"default"}` for everything else, while the `exec_command` schema advertised `anyOf[enum, {type:"object"}]`. The model's `{"network":"full"}` was therefore neither honored nor refused, which also made the orchestrator's existing hard deny under `approvalPolicy: never` unreachable. Adds `parseSandboxPermissionsArgs` returning `ok | invalid` with a reason; `sandboxPermissionsFromArgs` keeps its old signature and behavior for callers that cannot report. `isAdditionalSandboxPermissions` now rejects unknown keys so the validator and the schema agree at the strict end rather than half-honoring a request the schema rejects.

**`src/tools/system/exec-command.ts`** — three changes.
- Schema: `sandbox_permissions` is now only the three documented strings (the object alternative invited a shape no parser accepted), and `additional_permissions` declares its real shape. Schema validation runs on the live dispatch path (`runToolUse` → `validateToolArgs`, proven by the existing test "live path validates normalized args before exec_command can run"), so this is the load-bearing gate.
- The tool refuses an unreadable escalation request before running anything, as a backstop for paths that skip schema validation.
- When a command fails under an applied sandbox with a bind or listen permission error, one frozen sentence is appended to the result.

**`src/tools/system/exec-sandbox-denial.ts`** (new) — the classifier and the two frozen notices. A syscall-time refusal never reaches the runtime as a denial: the child just exits non-zero and its errno text is all the model gets. The notice names the sandbox, says the command itself is fine, and then diverges: under `approvalPolicy: never` it forbids the retry and tells the model to hand the command to the user; under a policy where a human can answer it asks for exactly one escalated attempt. The text is constant by design — a notice carrying a timing or a port would defeat the guard in fix 1 that catches a model which retries anyway. Requires that a sandbox was actually applied, so a privileged port or an address in use is not mislabeled as a sandbox problem.

**`src/tools/schema-errors.ts`** — the message the model actually reads when the schema rejects its request. The default enum prose does not say what to send instead; this names the three values, says objects are rejected, points at `additional_permissions`, and states the command was not run.

**`src/tools/system/kill-process.ts`** — the model could start a background process and poll it but never stop it: `sandbox workspace_write could not verify write targets for kill_process`. It is `mutating: true` with no path argument, so `writeTargets` found nothing and `analyzeWrites` encoded "no path found" as indeterminate, which the write-target branch refuses. It now declares the audited `virtualNoFsWrites` exemption. `toolMayMutate` has exactly one caller, the write-target check, so the blast radius is that check alone; approval is unaffected (`requiresApproval: true` is separate), and which process may be signalled stays enforced by the ownership check in `terminateProcess`.

## Evidence

Measured on the incident's rollout rather than assumed:

| Fact | Value |
| --- | --- |
| `npm start` results in the loop | 14 |
| distinct result bodies | 13 |
| bytes differing between two of them | the wall time only |
| distinct argument identities under the old key | 3 |
| distinct identities under the new key | 1 |

## Tests

- `tests/phases/repeat-tool-advisory.test.ts` — the live loop shape: a reworded justification and nudged timeout do not split the run; a volatile wall time does not reset it; a session id does not reset it; `failureSignature` elides only volatile values. Plus the negatives that guard against over-merging: a genuinely different error still resets the run, a different command still counts separately. **Falsification-checked**: with the two source changes reverted the three new positives fail, and they pass with them.
- `tests/tools/system/exec-sandbox-denial.test.ts` (new) — the exact Node text from the incident, the phrasings Go/Rust/Python produce, both wordings, and four cases that must stay silent (no sandbox applied, exit 0, a non-socket EPERM, `EADDRINUSE`). One test asserts the notice is constant across different timings and ports, which is what keeps fix 1 working.
- `tests/tools/system/exec-command.test.ts` — end to end: a denied bind carries both the child's text and the verdict; a human-present policy asks for one escalated retry instead; an ordinary failure is untouched; an unreadable `sandbox_permissions` and a malformed `additional_permissions` are refused **and the command is not run** (asserted on the manager mock); the documented values still run.
- `tests/tools/schema-errors.test.ts` — the override fires for the wrong shape, stays quiet for the three documented values and when the field is absent, and does not claim another tool's field.
- `tests/tools/runtimes/runtime.test.ts` — `kill_process` is admitted under `workspace_write`, and the same call without the exemption still throws, so the test pins the mechanism rather than the outcome.
- `tests/tools/kill-process.test.ts` — the exemption is declared and the schema still carries only `session_id` with `additionalProperties: false`, which is the audit the exemption rests on.

Suites run: `tests/phases`, `tests/tools`, `tests/sandbox`, `tests/permissions`. Green except 12 pre-existing failures in `tests/tools/system/{file-write,git-tools,grep,pinned-ripgrep,symbol-tools}` and the PTY session-id test, all of which fail identically on a clean tree here (ripgrep binary, temp roots, git worktree, PTY in this sandbox).

## Not changed on purpose

- **The prompt contradiction.** Under `bypassPermissions` the model is told "Approval policy is currently never. Do not provide the `sandbox_permissions` for any reason, commands will be rejected" (`permissions-prompt.ts:47`), and the escalation section elsewhere says "ALWAYS proceed to use the `sandbox_permissions` and `justification` parameters". The second belongs to `APPROVAL_POLICY_ON_REQUEST` and should not reach a `never` session, but the promise in the first is also not kept: such a command is not rejected, it runs sandboxed. This PR makes the runtime honest about what it does rather than rewriting the prompt; conditioning the prompt on the effective policy belongs with the prompt work in #2014.
- **A trusted channel for runtime guidance.** The notice goes in the tool result, where `blockRepeatedFailingCall` and `toolDispatchErrorResult` already put runtime-authored text, so it is framed as untrusted workspace data. A dedicated trusted channel (a `runtimeNotice` field threaded to a `<system-reminder>`) would reach the model as an instruction rather than as evidence, but it touches the shared ToolResult path and the content the integrity seal covers. That is its own design change, not a bug fix.
- **The kill_process alternative.** A branch in `analyzeWrites` keyed on the tool name plus `source === "builtin"` would also work and mirrors the existing `write_stdin` special case. I chose the metadata flag because it is the documented mechanism for exactly this, keeps the audit next to the tool it describes, and does not add another name-keyed special case to the policy layer.
- **Other denial classes.** Only a denied bind or listen is classified. Other sandbox refusals (a denied write outside the workspace, a denied exec) already surface as explicit `SandboxDeniedError` messages; adding more classes without a live case would be guessing at wording.

## Counterpart

#2018 (`harness-tools`), which this is based on. Issue #2021 lists the four defects and the evidence.


## Merged `main` in

`affected-tests` on this branch failed on one test that has nothing to do with
this change:

```
FAIL tests/tools/AgentTool/loadAgentsDir.test.ts
  > never imports agent files through cross-workspace file or directory symlinks
AssertionError: expected [ Array(5) ] to include 'authority-local'
```

Five is the count of built-in agents, which need no file discovery, so the
markdown scan returned nothing. That is #2029: markdown discovery ran ripgrep
and swallowed "the binary could not start" as "the directory is missing", so
every markdown-defined agent, command and hook vanished wherever `rg` is
absent, which is CI. It is fixed and merged to `main`, and `main` is merged
here so this branch's check can report on its own change.
