### PR TITLE
the skills a request is about reach the model (#2022)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -23,7 +23,14 @@ jobs:
   affected-tests:
     name: affected-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # `vitest related` walks the import graph, so a change to a widely imported
+    # module (a util, a config loader) selects most of the suite, not a handful
+    # of files. At the runner's two workers that is ~20 minutes of tests, and
+    # the old 15-minute cap cancelled the job mid-run: the gate reported
+    # `cancelled` with zero failures, so a correct change could never go green
+    # and the module was effectively unmergeable. Other jobs in this repo
+    # already allow 30-60 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -5667,7 +5667,7 @@ function historyEpochFromRollout(
 ): string {
   return historyEpochForBoundary(
     runId,
-    latestTranscriptBoundary(items, runId)?.id ?? "initial",
+    latestTranscriptBoundary(items)?.id ?? "initial",
   );
 }
 
@@ -5680,7 +5680,6 @@ interface TranscriptBoundary {
 
 function latestTranscriptBoundary(
   items: readonly RolloutItem[],
-  runId: string,
 ): TranscriptBoundary | undefined {
   let latest: TranscriptBoundary | undefined;
   for (const [index, item] of items.entries()) {
@@ -5700,35 +5699,19 @@ function latestTranscriptBoundary(
       };
       continue;
     }
-    if (
-      item.type === "compacted" &&
-      item.payload.replacementHistory !== undefined
-    ) {
-      latest = {
-        index,
-        id: `compacted:${index}:${hashStable(JSON.stringify(item.payload.replacementHistory))}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (item.type === "compaction_committed") {
-      latest = {
-        index,
-        id: `compaction:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (
-      item.type === "compaction_rollback_committed" &&
-      item.payload.target_session_id === runId
-    ) {
-      latest = {
-        index,
-        id: `compaction-rollback:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-    }
+    // Compaction is deliberately NOT a transcript boundary.
+    //
+    // It changes what the MODEL sees; the person reading the transcript still
+    // sent every earlier message and expects to find them. Treating a commit
+    // as a boundary truncated the reloaded transcript to the compacted view
+    // and rendered the summary itself as a user message: live, a 13-turn
+    // session came back as two turns after an app relaunch, because that
+    // rollout contained two compaction commits and no explicit epoch event.
+    //
+    // A user-facing reset still truncates, and is still the only thing that
+    // does: `history_cleared` and `transcript_epoch` above. A partial compact
+    // or a rewind that means to reset the transcript emits `transcript_epoch`
+    // alongside its `compacted` item, so those keep working unchanged.
   }
   return latest;
 }
@@ -6092,7 +6075,7 @@ export function sessionTranscriptV2FromRollout(
   runId: string,
   activeTurn?: { readonly turnId: string; readonly clientMessageId: string },
 ): SessionTranscriptV2Result {
-  const boundary = latestTranscriptBoundary(items, runId);
+  const boundary = latestTranscriptBoundary(items);
   const boundaryIndex = boundary?.index ?? -1;
   const boundaryId = boundary?.id ?? "initial";
   let asOfSequence = 0;

--- a/runtime/src/prompts/attachments/orchestrator.ts
+++ b/runtime/src/prompts/attachments/orchestrator.ts
@@ -85,6 +85,17 @@ export interface GetAttachmentsOptions {
       readonly text: string;
     } | null;
   };
+  /**
+   * Optional sink for a producer's diagnostics. Producers are pure functions
+   * of their options and hold only an opaque `sessionKey`, so a producer that
+   * has something an operator needs to see — what it decided and on what —
+   * reports it here and the caller routes it to the session's event log.
+   * Absent in tests and in callers that do not care.
+   */
+  readonly emitDiagnostic?: (diagnostic: {
+    readonly cause: string;
+    readonly message: string;
+  }) => void;
   /** Most recent user-channel message text, if any. */
   readonly userInput: string | null;
   /**
@@ -140,6 +151,11 @@ export interface GetAttachmentsOptions {
         readonly loadedFrom?: string;
         readonly scope?: string;
         readonly root?: string;
+      }>;
+      /** Roots holding more skills than the per-root cap loaded. */
+      readonly truncatedSkillRoots?: ReadonlyArray<{
+        readonly root: string;
+        readonly droppedCount: number;
       }>;
     }>;
   };

--- a/runtime/src/prompts/attachments/skill-listing.ts
+++ b/runtime/src/prompts/attachments/skill-listing.ts
@@ -73,6 +73,9 @@ export const skillListingProducer: AttachmentProducer = async (opts) => {
   const listing = formatSkillListingWithinBudget(
     [...skills, ...bundled],
     opts.contextWindowTokens,
+    // What the user just asked for decides which skills get the budget when
+    // the installed catalog does not fit.
+    opts.userInput,
   );
   if (listing.length === 0) return [];
 

--- a/runtime/src/prompts/attachments/skill-listing.ts
+++ b/runtime/src/prompts/attachments/skill-listing.ts
@@ -2,7 +2,7 @@ import type { LLMMessage } from "../../llm/types.js";
 import type { AttachmentProducer } from "./orchestrator.js";
 import { SKILL_LISTING_REMINDER_HEADER } from "./messages.js";
 import {
-  formatSkillListingWithinBudget,
+  buildSkillListingWithinBudget,
   type SkillListingEntry,
 } from "../../skills/local-loader.js";
 
@@ -66,17 +66,41 @@ export const skillListingProducer: AttachmentProducer = async (opts) => {
 
   const outcome = await opts.skillsManager.skillsForConfig(opts.config ?? {}, null);
   const skills = outcome.availableSkills ?? [];
+  // Roots that hold more skills than the per-root cap loaded: those never
+  // reached the listing at all, so a truncated listing is only half the story.
+  const truncatedRoots = (outcome.truncatedSkillRoots ?? []).filter(
+    (root) => root.droppedCount > 0,
+  );
   const known = new Set(skills.map((skill) => skill.name));
   const bundled = (await bundledRegistrySkills()).filter(
     (skill) => !known.has(skill.name),
   );
-  const listing = formatSkillListingWithinBudget(
+  const { listing, stats } = buildSkillListingWithinBudget(
     [...skills, ...bundled],
     opts.contextWindowTokens,
     // What the user just asked for decides which skills get the budget when
     // the installed catalog does not fit.
     opts.userInput,
   );
+  // What the model was shown is otherwise unrecoverable: the listing is an
+  // attachment, so it never reaches the rollout, and the provider trace keeps
+  // no message bodies. A run where the model ignored every skill could not be
+  // told apart from one where it was shown none of the right ones.
+  if (stats.hidden > 0 || truncatedRoots.length > 0) {
+    opts.emitDiagnostic?.({
+      cause: "skill_listing_truncated",
+      message:
+        `listed ${stats.listed} of ${stats.invocable} invocable skills ` +
+        `(${stats.usedChars}/${stats.budgetChars} chars, ` +
+        `${stats.ranked ? "ranked by this request" : "unranked"})` +
+        (truncatedRoots.length > 0
+          ? `; ${truncatedRoots.reduce((sum, root) => sum + root.droppedCount, 0)} more were never loaded: ` +
+            truncatedRoots
+              .map((root) => `${root.root} holds ${root.droppedCount} past the per-root cap`)
+              .join(", ")
+          : ""),
+    });
+  }
   if (listing.length === 0) return [];
 
   return [

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -3154,6 +3154,16 @@ async function prepareSamplingRequestBoundary(
       : {}),
     sessionKey: session,
     admittedMemorySelector: createAdmittedMemorySelector(session),
+    // Producers hold only an opaque session key, so what they decide is
+    // invisible to an operator unless they can report it. Routed to the
+    // session log, not to the chat: these causes are outside the TUI's
+    // user-visible allow-list.
+    emitDiagnostic: ({ cause, message }) => {
+      session.emit({
+        id: session.nextInternalSubId(),
+        msg: { type: "warning", payload: { cause, message } },
+      });
+    },
     turnProvenance: {
       turnId: ctx.subId,
       rootHumanTurn,

--- a/runtime/src/skills/local-loader.ts
+++ b/runtime/src/skills/local-loader.ts
@@ -197,7 +197,37 @@ interface BundledSkillDefinition {
 }
 
 const SKILL_FILE_NAME = "SKILL.md";
-const MAX_SKILL_FILES = 500;
+/**
+ * Per-root ceiling on skills loaded from disk. The walk keeps counting past
+ * it (`droppedCount`) so the snapshot can say what it skipped, but a dropped
+ * skill is invisible to the listing, to ranking and to the Skill tool.
+ *
+ * 500 was set when a catalog meant a handful of hand-written skills. A shared
+ * catalog is now the normal case: the machine this was measured on holds
+ * 1,820 skills in `~/.agents/skills`, so 1,320 of them — including three of
+ * the four that matched the work in a live 15-turn run — were dropped before
+ * any ranking or budget logic could see them, in readdir order. The ceiling
+ * stays, because it is what stops a pathological directory from being walked
+ * forever, but it is now above a real installation rather than inside one.
+ * The cost of the higher bound is a cold scan reading the frontmatter of each
+ * file once (7.7 MB across those 1,820), behind the snapshot's change
+ * detector; the listing budget, not this cap, is what bounds what the model
+ * is shown.
+ *
+ * Overridable with `AGENC_MAX_SKILL_FILES_PER_ROOT` so an operator with an
+ * unusual catalog can tune it, and so tests can exercise truncation without
+ * writing thousands of files.
+ */
+const DEFAULT_MAX_SKILL_FILES = 5_000;
+
+export function maxSkillFilesPerRoot(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = Number(env.AGENC_MAX_SKILL_FILES_PER_ROOT);
+  return Number.isFinite(raw) && raw > 0
+    ? Math.floor(raw)
+    : DEFAULT_MAX_SKILL_FILES;
+}
 const MAX_SCAN_DEPTH = 12;
 const MAX_ACTIVE_PATHS = 256;
 const INVOKED_MAIN_AGENT_ID = "__main__";
@@ -430,6 +460,7 @@ interface SkillFileScan {
 interface MutableSkillFileScan {
   readonly files: string[];
   droppedCount: number;
+  readonly maxFiles: number;
 }
 
 interface ScanFrame {
@@ -466,7 +497,7 @@ async function markVisited(path: string, visited: Set<string>): Promise<boolean>
 function recordSkillFile(scan: MutableSkillFileScan, file: string): void {
   // Past the cap the walk keeps going but only counts, so the snapshot can
   // say how many skills this root holds that were never loaded.
-  if (scan.files.length >= MAX_SKILL_FILES) scan.droppedCount += 1;
+  if (scan.files.length >= scan.maxFiles) scan.droppedCount += 1;
   else scan.files.push(file);
 }
 
@@ -488,7 +519,11 @@ async function scanSkillDir(
 }
 
 async function findSkillFiles(root: string): Promise<SkillFileScan> {
-  const scan: MutableSkillFileScan = { files: [], droppedCount: 0 };
+  const scan: MutableSkillFileScan = {
+    files: [],
+    droppedCount: 0,
+    maxFiles: maxSkillFilesPerRoot(),
+  };
   const queue = await topLevelScanFrames(root);
   const visitedDirs = new Set<string>();
   while (queue.length > 0) {
@@ -987,9 +1022,67 @@ function formatHiddenSkillsLine(count: number): string {
   return `- ...and ${count} more skill${count === 1 ? "" : "s"} not shown; ask the user to run /skills <search> to find one`;
 }
 
+/**
+ * Words too common to say anything about which skill fits a request.
+ */
+const SKILL_MATCH_STOPWORDS: ReadonlySet<string> = new Set([
+  "the", "and", "for", "with", "that", "this", "you", "your", "are", "was",
+  "not", "but", "all", "any", "can", "has", "have", "how", "its", "let",
+  "make", "made", "new", "now", "one", "out", "run", "see", "use", "using",
+  "add", "into", "from", "when", "what", "where", "which", "will", "would",
+  "please", "should", "then", "them", "they", "there", "here", "just", "like",
+  "file", "files", "code", "line", "lines",
+]);
+
+/** Content words of the current request, lowercased and de-duplicated. */
+function requestMatchTokens(request: string | null | undefined): readonly string[] {
+  if (typeof request !== "string" || request.length === 0) return [];
+  const tokens = new Set<string>();
+  for (const raw of request.toLowerCase().split(/[^a-z0-9+#.]+/u)) {
+    const token = raw.replace(/^[.]+|[.]+$/gu, "");
+    if (token.length < 3) continue;
+    if (SKILL_MATCH_STOPWORDS.has(token)) continue;
+    tokens.add(token);
+  }
+  return [...tokens];
+}
+
+/** Cap so one long description cannot outweigh a real name match. */
+const SKILL_DESCRIPTION_MATCH_CAP = 6;
+
+/**
+ * How well a skill answers the current request. A name match counts most: a
+ * skill called `generating-unit-tests` is what "write unit tests" wants, and
+ * its description only corroborates that.
+ */
+function skillRelevance(
+  skill: SkillListingEntry,
+  tokens: readonly string[],
+): number {
+  if (tokens.length === 0) return 0;
+  const nameParts = new Set(skill.name.toLowerCase().split(/[^a-z0-9]+/u));
+  const name = skill.name.toLowerCase();
+  const description = `${skill.description ?? ""} ${skill.whenToUse ?? ""}`.toLowerCase();
+  let score = 0;
+  let fromDescription = 0;
+  for (const token of tokens) {
+    if (nameParts.has(token)) {
+      score += 4;
+    } else if (name.includes(token)) {
+      score += 2;
+    }
+    if (fromDescription < SKILL_DESCRIPTION_MATCH_CAP && description.includes(token)) {
+      score += 1;
+      fromDescription += 1;
+    }
+  }
+  return score;
+}
+
 export function formatSkillListingWithinBudget(
   skills: readonly SkillListingEntry[],
   contextWindowTokens?: number,
+  request?: string | null,
 ): string {
   const commands = skills.filter((skill) => !skill.disableModelInvocation);
   if (commands.length === 0) return "";
@@ -1005,10 +1098,27 @@ export function formatSkillListingWithinBudget(
   // so the skills that do not fit are counted in one closing line instead
   // of being listed by name.
   const bundled = commands.filter((skill) => skill.loadedFrom === "bundled");
+  // Over budget, insertion order inside a scope is alphabetical, so a large
+  // shared catalog fills the whole listing with whatever sorts first. Live
+  // measurement on a machine with 1,823 installed skills: 101 fit, the list
+  // stopped at "apollo-core-workflow-a", and every skill matching the work at
+  // hand — canvas-design, frontend-design, generating-unit-tests,
+  // javascript-typescript — was never shown, which is why 15 turns of exactly
+  // that work produced zero Skill invocations. What the request is about now
+  // decides who gets the space; scope rank breaks ties, as before.
+  const tokens = requestMatchTokens(request);
   const rest = commands
-    .map((skill, index) => ({ skill, index, rank: skillListingRank(skill) }))
+    .map((skill, index) => ({
+      skill,
+      index,
+      rank: skillListingRank(skill),
+      relevance: skillRelevance(skill, tokens),
+    }))
     .filter((entry) => entry.skill.loadedFrom !== "bundled")
-    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .sort(
+      (a, b) =>
+        b.relevance - a.relevance || a.rank - b.rank || a.index - b.index,
+    )
     .map((entry) => entry.skill);
   const lines = bundled.map(formatSkillListingLine);
   let used = lines.reduce((sum, line) => sum + line.length + 1, 0);

--- a/runtime/src/skills/local-loader.ts
+++ b/runtime/src/skills/local-loader.ts
@@ -1079,18 +1079,64 @@ function skillRelevance(
   return score;
 }
 
+/** What a listing pass decided, for the operator-facing diagnostic. */
+export interface SkillListingStats {
+  /** Skills offered to the listing (already excludes non-invocable ones). */
+  readonly invocable: number;
+  /** Skills whose full line fit the budget. */
+  readonly listed: number;
+  /** Skills the budget had no room for. */
+  readonly hidden: number;
+  readonly budgetChars: number;
+  readonly usedChars: number;
+  /** True when the request reordered the listing. */
+  readonly ranked: boolean;
+}
+
 export function formatSkillListingWithinBudget(
   skills: readonly SkillListingEntry[],
   contextWindowTokens?: number,
   request?: string | null,
 ): string {
+  return buildSkillListingWithinBudget(skills, contextWindowTokens, request)
+    .listing;
+}
+
+export function buildSkillListingWithinBudget(
+  skills: readonly SkillListingEntry[],
+  contextWindowTokens?: number,
+  request?: string | null,
+): { readonly listing: string; readonly stats: SkillListingStats } {
   const commands = skills.filter((skill) => !skill.disableModelInvocation);
-  if (commands.length === 0) return "";
+  const tokensForStats = requestMatchTokens(request);
+  const emptyStats = (budgetChars: number): SkillListingStats => ({
+    invocable: commands.length,
+    listed: 0,
+    hidden: commands.length,
+    budgetChars,
+    usedChars: 0,
+    ranked: false,
+  });
+  if (commands.length === 0) {
+    return { listing: "", stats: emptyStats(getListingCharBudget(contextWindowTokens)) };
+  }
   const budget = getListingCharBudget(contextWindowTokens);
   const fullLines = commands.map(formatSkillListingLine);
   const fullTotal =
     fullLines.reduce((sum, line) => sum + line.length, 0) + fullLines.length - 1;
-  if (fullTotal <= budget) return fullLines.join("\n");
+  if (fullTotal <= budget) {
+    return {
+      listing: fullLines.join("\n"),
+      stats: {
+        invocable: commands.length,
+        listed: commands.length,
+        hidden: 0,
+        budgetChars: budget,
+        usedChars: fullTotal,
+        ranked: false,
+      },
+    };
+  }
 
   // Over budget: bundled skills always stay (they describe the runtime's own
   // surfaces), then full lines in rank order until the budget is spent. A
@@ -1106,7 +1152,7 @@ export function formatSkillListingWithinBudget(
   // javascript-typescript — was never shown, which is why 15 turns of exactly
   // that work produced zero Skill invocations. What the request is about now
   // decides who gets the space; scope rank breaks ties, as before.
-  const tokens = requestMatchTokens(request);
+  const tokens = tokensForStats;
   const rest = commands
     .map((skill, index) => ({
       skill,
@@ -1135,7 +1181,18 @@ export function formatSkillListingWithinBudget(
   }
   const hidden = rest.length - shown;
   if (hidden > 0) lines.push(formatHiddenSkillsLine(hidden));
-  return lines.join("\n");
+  const listing = lines.join("\n");
+  return {
+    listing,
+    stats: {
+      invocable: commands.length,
+      listed: bundled.length + shown,
+      hidden,
+      budgetChars: budget,
+      usedChars: listing.length,
+      ranked: tokensForStats.length > 0,
+    },
+  };
 }
 
 function getListingCharBudget(contextWindowTokens?: number): number {

--- a/runtime/src/utils/markdownConfigLoader.ts
+++ b/runtime/src/utils/markdownConfigLoader.ts
@@ -12,7 +12,7 @@ import type { FrontmatterData } from './frontmatterParser.js'
 import { parseFrontmatter } from './frontmatterParser.js'
 import { findCanonicalGitRoot, findGitRoot } from './git.js'
 import { parseToolListFromCLI } from './permissions/toolListParser.js'
-import { ripGrep } from './ripgrep.js'
+import { isRipgrepUnavailable, ripGrep } from './ripgrep.js'
 import {
   isSettingSourceEnabled,
   type SettingSource,
@@ -623,13 +623,25 @@ async function loadMarkdownFiles(dir: string): Promise<
           signal,
         )
   } catch (e: unknown) {
-    // Handle missing/inaccessible dir directly instead of pre-checking
-    // existence (TOCTOU). findMarkdownFilesNative already catches internally;
-    // ripGrep rejects on inaccessible target paths.
-    if (isFsInaccessible(e)) return []
-    throw e
+    // A search tool that cannot start is not an empty directory. `ripGrep`
+    // reports an unavailable binary with `code: "ENOENT"`, which errno alone
+    // cannot tell apart from "the directory is gone", so the check below
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently disappeared wherever ripgrep could not run — a machine with
+    // no `rg` on PATH, a build without the packaged binary, a container that
+    // cannot spawn it. The native walk is documented above as the fallback
+    // for exactly this and needs no external binary, so use it.
+    if (!useNative && isRipgrepUnavailable(e)) {
+      files = await findMarkdownFilesNative(dir, signal)
+    } else if (isFsInaccessible(e)) {
+      // Handle missing/inaccessible dir directly instead of pre-checking
+      // existence (TOCTOU). findMarkdownFilesNative already catches
+      // internally; ripGrep rejects on inaccessible target paths.
+      return []
+    } else {
+      throw e
+    }
   }
-
   const results = await Promise.all(
     files.map(async filePath => {
       let handle: Awaited<ReturnType<typeof open>> | undefined

--- a/runtime/src/utils/ripgrep.ts
+++ b/runtime/src/utils/ripgrep.ts
@@ -182,6 +182,11 @@ export function getRipgrepInstallHint(platform = process.platform): string {
   }
 }
 
+/** True when the failure means the search binary could not run at all. */
+export function isRipgrepUnavailable(error: unknown): boolean {
+  return error instanceof RipgrepUnavailableError
+}
+
 export function wrapRipgrepUnavailableError(
   error: RipgrepErrorLike,
   config = getRipgrepConfig(),

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -101,6 +101,121 @@ describe("session.transcript.v2 durable projection", () => {
     expect(afterAppend.messages).toEqual(first.messages);
   });
 
+  it("keeps the whole conversation when a compaction commits without an epoch", () => {
+
+    // Compaction changes what the model sees, not what the person reading
+
+    // the transcript sent. Live: a 13-turn session came back as two turns
+
+    // after an app relaunch, because its rollout carried two compaction
+
+    // commits and no explicit epoch event, and the summary itself was
+
+    // rendered as one of those turns.
+
+    const items: RolloutItem[] = [
+
+      event(10, "user-1", {
+
+        type: "user_message",
+
+        payload: { message: "first question", messageId: "client-1" },
+
+      }),
+
+      event(11, "turn-1", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-1" },
+
+      }),
+
+      event(12, "answer-1", {
+
+        type: "agent_message",
+
+        payload: { message: "first answer" },
+
+      }),
+
+      {
+
+        type: "compaction_committed",
+
+        payload: {
+
+          attempt_id: "compact-auto-1",
+
+          replacement_history: [
+
+            { role: "developer", content: "agenc_compaction_boundary_v1: untrusted" },
+
+            { role: "user", content: "a summary of the work so far" },
+
+          ],
+
+        },
+
+      } as unknown as RolloutItem,
+
+      event(20, "user-2", {
+
+        type: "user_message",
+
+        payload: { message: "second question", messageId: "client-2" },
+
+      }),
+
+      event(21, "turn-2", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-2" },
+
+      }),
+
+      event(22, "answer-2", {
+
+        type: "agent_message",
+
+        payload: { message: "second answer" },
+
+      }),
+
+    ];
+
+
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+
+
+    expect(snapshot.messages.map((message) => message.text)).toEqual([
+
+      "first question",
+
+      "first answer",
+
+      "second question",
+
+      "second answer",
+
+    ]);
+
+    // The model's compacted view never appears as something the user said.
+
+    expect(snapshot.messages.some((message) => message.text.includes("summary of the work"))).toBe(
+
+      false,
+
+    );
+
+    // Nothing truncated, so the epoch is the initial one.
+
+    expect(snapshot.historyEpoch).toBe("history:run-1:initial");
+
+  });
+
+
   it("rebuilds from each compact/rewind replacement and advances a stable epoch", () => {
     const compacted: RolloutItem[] = [
       {

--- a/runtime/tests/prompts/attachments/skill-listing.test.ts
+++ b/runtime/tests/prompts/attachments/skill-listing.test.ts
@@ -57,6 +57,112 @@ describe("skillListingProducer", () => {
     }
   });
 
+  describe("the per-turn diagnostic", () => {
+    const manySkills = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        name: `filler-${String(i).padStart(4, "0")}`,
+        description: "a skill with a description long enough to consume budget",
+        loadedFrom: "skills" as const,
+        scope: "user" as const,
+      }));
+
+    function collect(partial?: Partial<GetAttachmentsOptions>) {
+      const diagnostics: { cause: string; message: string }[] = [];
+      const opts = makeOpts({
+        emitDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+        ...partial,
+      });
+      return { opts, diagnostics };
+    }
+
+    test("reports what the model was shown when the budget cut the listing", async () => {
+      // The listing is an attachment, so it never reaches the rollout, and the
+      // provider trace keeps no bodies. Without this, a run where the model
+      // ignored every skill is indistinguishable from one where it was shown
+      // none of the right ones.
+      const { opts, diagnostics } = collect({
+        contextWindowTokens: 20_000,
+        skillsManager: {
+          skillsForConfig: async () => ({
+            invokedSkills: [],
+            availableSkills: manySkills(200),
+          }),
+        },
+      });
+
+      await skillListingProducer(opts, getAttachmentTrackingState(opts.sessionKey));
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.cause).toBe("skill_listing_truncated");
+      // The count includes whatever else the harness offers alongside them.
+      expect(diagnostics[0]?.message).toMatch(/listed \d+ of \d+ invocable skills/);
+      const [, listed, invocable] =
+        /listed (\d+) of (\d+) invocable skills/.exec(diagnostics[0]?.message ?? "") ?? [];
+      expect(Number(invocable)).toBeGreaterThanOrEqual(200);
+      expect(Number(listed)).toBeLessThan(Number(invocable));
+      expect(diagnostics[0]?.message).toContain("chars");
+      expect(diagnostics[0]?.message).toContain("unranked");
+    });
+
+    test("says the listing was ranked when the request drove the order", async () => {
+      const { opts, diagnostics } = collect({
+        contextWindowTokens: 20_000,
+        userInput: "write unit tests for the parser",
+        skillsManager: {
+          skillsForConfig: async () => ({
+            invokedSkills: [],
+            availableSkills: manySkills(200),
+          }),
+        },
+      });
+
+      await skillListingProducer(opts, getAttachmentTrackingState(opts.sessionKey));
+
+      expect(diagnostics[0]?.message).toContain("ranked by this request");
+    });
+
+    test("names roots whose skills were never loaded at all", async () => {
+      const { opts, diagnostics } = collect({
+        contextWindowTokens: 20_000,
+        skillsManager: {
+          skillsForConfig: async () => ({
+            invokedSkills: [],
+            availableSkills: manySkills(200),
+            truncatedSkillRoots: [
+              { root: "/home/u/.agents/skills", droppedCount: 1_320 },
+            ],
+          }),
+        },
+      });
+
+      await skillListingProducer(opts, getAttachmentTrackingState(opts.sessionKey));
+
+      expect(diagnostics[0]?.message).toContain("1320 more were never loaded");
+      expect(diagnostics[0]?.message).toContain("/home/u/.agents/skills holds 1320 past the per-root cap");
+    });
+
+    test("stays quiet when every skill fit", async () => {
+      const { opts, diagnostics } = collect();
+      await skillListingProducer(opts, getAttachmentTrackingState(opts.sessionKey));
+      expect(diagnostics).toEqual([]);
+    });
+
+    test("never throws when no sink is provided", async () => {
+      const opts = makeOpts({
+        contextWindowTokens: 20_000,
+        skillsManager: {
+          skillsForConfig: async () => ({
+            invokedSkills: [],
+            availableSkills: manySkills(200),
+          }),
+        },
+      });
+      await expect(
+        skillListingProducer(opts, getAttachmentTrackingState(opts.sessionKey)),
+      ).resolves.toHaveLength(1);
+    });
+  });
+
   test("stays quiet when a message already carries the rendered listing", async () => {
     const rendered =
       `<system-reminder>\n${SKILL_LISTING_REMINDER_HEADER}\n\n- repo-docs: Explain the repository docs\n</system-reminder>`;

--- a/runtime/tests/skills/local-loader.test.ts
+++ b/runtime/tests/skills/local-loader.test.ts
@@ -15,6 +15,7 @@ import {
   discoverSkillRoots,
   formatSkillListingWithinBudget,
   loadLocalSkillsSnapshot,
+  maxSkillFilesPerRoot,
 } from "./local-loader.js";
 import { substituteArguments } from "../tui/slash/argument-substitution.js";
 
@@ -53,6 +54,112 @@ async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+describe("per-root skill scan cap", () => {
+  it("defaults above a real shared catalog and honors an operator override", () => {
+    // Measured: 1,820 skills in ~/.agents/skills. The old 500 dropped 1,320
+    // of them in readdir order, before any ranking could see them.
+    expect(maxSkillFilesPerRoot({})).toBeGreaterThan(1_820);
+    expect(maxSkillFilesPerRoot({ AGENC_MAX_SKILL_FILES_PER_ROOT: "10" })).toBe(10);
+    // Nonsense falls back to the default rather than disabling the guard.
+    for (const raw of ["0", "-5", "abc", ""]) {
+      expect(
+        maxSkillFilesPerRoot({ AGENC_MAX_SKILL_FILES_PER_ROOT: raw }),
+      ).toBe(maxSkillFilesPerRoot({}));
+    }
+  });
+});
+
+describe("skill listing relevance", () => {
+  // Live measurement on the reviewer's machine (1,823 skills installed under
+  // ~/.agents/skills, 500k context window): the 20,000-char budget fit 101 of
+  // them, the list stopped at "apollo-core-workflow-a", and every skill that
+  // matched the work at hand was never shown. Fifteen turns of exactly that
+  // work produced zero Skill invocations.
+  const catalog = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      name: `a-filler-${String(i).padStart(4, "0")}`,
+      description: "filler skill that matches nothing in particular",
+      scope: "user" as const,
+      loadedFrom: "skills" as const,
+    }));
+
+  const matching = {
+    name: "generating-unit-tests",
+    description:
+      "Automatically generate comprehensive unit tests from source code. Use when creating test coverage for functions, classes, or modules.",
+    scope: "user" as const,
+    loadedFrom: "skills" as const,
+  };
+
+  const skills = [...catalog(400), matching];
+  // A window whose 1-percent listing budget fits roughly a dozen lines, far
+  // fewer than the catalog — the same shape as the live machine.
+  const BUDGET_TOKENS = 25_000;
+
+  it("lists the skill the request is about, even when it sorts last", () => {
+    const listing = formatSkillListingWithinBudget(
+      skills,
+      BUDGET_TOKENS,
+      "Write unit tests with node:test for the pure logic only",
+    );
+    expect(listing).toContain("- generating-unit-tests");
+    expect(listing).toContain("more skill");
+  });
+
+  it("without the request the same skill never fits", () => {
+    const listing = formatSkillListingWithinBudget(skills, BUDGET_TOKENS);
+    expect(listing).not.toContain("- generating-unit-tests");
+    expect(listing).toContain("- a-filler-0000");
+  });
+
+  it("an unrelated request does not promote it", () => {
+    const listing = formatSkillListingWithinBudget(
+      skills,
+      BUDGET_TOKENS,
+      "rename the deployment pipeline variables",
+    );
+    expect(listing).not.toContain("- generating-unit-tests");
+  });
+
+  it("a name match outranks a description-only match", () => {
+    const descriptionOnly = {
+      name: "z-unrelated-name",
+      description: "helps you write unit tests and coverage reports",
+      scope: "user" as const,
+      loadedFrom: "skills" as const,
+    };
+    const listing = formatSkillListingWithinBudget(
+      [...catalog(400), descriptionOnly, matching],
+      BUDGET_TOKENS,
+      "write unit tests",
+    );
+    const nameFirst = listing.indexOf("- generating-unit-tests");
+    const descriptionSecond = listing.indexOf("- z-unrelated-name");
+    expect(nameFirst).toBeGreaterThanOrEqual(0);
+    expect(descriptionSecond).toBeGreaterThan(nameFirst);
+  });
+
+  it("leaves a listing that already fits completely alone", () => {
+    const few = [matching, ...catalog(2)];
+    const ranked = formatSkillListingWithinBudget(few, 100_000, "write unit tests");
+    const plain = formatSkillListingWithinBudget(few, 100_000);
+    expect(ranked).toBe(plain);
+    expect(ranked.split("\n")).toHaveLength(3);
+  });
+
+  it("keeps bundled skills regardless of the request", () => {
+    const listing = formatSkillListingWithinBudget(
+      [
+        { name: "browser-automation", description: "drive a browser", loadedFrom: "bundled" as const },
+        ...catalog(400),
+      ],
+      BUDGET_TOKENS,
+      "write unit tests",
+    );
+    expect(listing).toContain("- browser-automation");
+  });
+});
 
 describe("local skills loader", () => {
   it("discovers AgenC, agent, user, and plugin skill roots", async () => {
@@ -895,21 +1002,31 @@ All=$ARGUMENTS
     const agencHome = tmpRoot("skills-home");
     const workspaceRoot = tmpRoot("skills-workspace");
     const userRoot = join(agencHome, "skills");
-    for (let i = 0; i < 600; i++) {
-      const name = `skill-${String(i).padStart(3, "0")}`;
-      writeSkill(
-        userRoot,
-        name,
-        `---\ndescription: ${name} does a specific job\n---\nBody\n`,
-      );
-    }
+    // The cap is configurable; set it low here instead of writing thousands of
+    // files to reach the default, which is now above a real catalog.
+    const previousCap = process.env.AGENC_MAX_SKILL_FILES_PER_ROOT;
+    process.env.AGENC_MAX_SKILL_FILES_PER_ROOT = "500";
+    let snapshot;
+    try {
+      for (let i = 0; i < 600; i++) {
+        const name = `skill-${String(i).padStart(3, "0")}`;
+        writeSkill(
+          userRoot,
+          name,
+          `---\ndescription: ${name} does a specific job\n---\nBody\n`,
+        );
+      }
 
-    const snapshot = await loadLocalSkillsSnapshot({
-      agencHome,
-      pluginStorageRoot: join(agencHome, "plugins"),
-      workspaceRoot,
-      env: {},
-    });
+      snapshot = await loadLocalSkillsSnapshot({
+        agencHome,
+        pluginStorageRoot: join(agencHome, "plugins"),
+        workspaceRoot,
+        env: {},
+      });
+    } finally {
+      if (previousCap === undefined) delete process.env.AGENC_MAX_SKILL_FILES_PER_ROOT;
+      else process.env.AGENC_MAX_SKILL_FILES_PER_ROOT = previousCap;
+    }
 
     expect(snapshot.truncatedRoots).toEqual([
       { root: userRoot, loadedCount: 500, droppedCount: 100 },

--- a/runtime/tests/skills/skills-cli.test.ts
+++ b/runtime/tests/skills/skills-cli.test.ts
@@ -97,22 +97,31 @@ describe("agenc skills CLI", () => {
     const agencHome = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cap-"));
     const workspaceRoot = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cap-ws-"));
     const userRoot = join(agencHome, "skills");
-    for (let i = 0; i < 505; i++) {
-      await writeSkill(userRoot, `cap-${String(i).padStart(3, "0")}`);
+    // The cap is configurable so a real catalog loads whole; set it low here
+    // rather than writing thousands of files to reach the default.
+    const previousCap = process.env.AGENC_MAX_SKILL_FILES_PER_ROOT;
+    process.env.AGENC_MAX_SKILL_FILES_PER_ROOT = "10";
+    try {
+      for (let i = 0; i < 15; i++) {
+        await writeSkill(userRoot, `cap-${String(i).padStart(3, "0")}`);
+      }
+
+      const inventory = await buildSkillsInventory({
+        agencHome,
+        pluginStorageRoot: join(agencHome, "plugins"),
+        workspaceRoot,
+        env: { AGENC_HOME: agencHome },
+      });
+
+      expect(
+        inventory.skills.filter((skill) => skill.name.startsWith("cap-")),
+      ).toHaveLength(10);
+      expect(inventory.errors).toContain(
+        `5 SKILL.md files under ${userRoot} were not loaded: the per-root cap was reached after 10`,
+      );
+    } finally {
+      if (previousCap === undefined) delete process.env.AGENC_MAX_SKILL_FILES_PER_ROOT;
+      else process.env.AGENC_MAX_SKILL_FILES_PER_ROOT = previousCap;
     }
-
-    const inventory = await buildSkillsInventory({
-      agencHome,
-      pluginStorageRoot: join(agencHome, "plugins"),
-      workspaceRoot,
-      env: { AGENC_HOME: agencHome },
-    });
-
-    expect(
-      inventory.skills.filter((skill) => skill.name.startsWith("cap-")),
-    ).toHaveLength(500);
-    expect(inventory.errors).toContain(
-      `5 SKILL.md files under ${userRoot} were not loaded: the per-root cap was reached after 500`,
-    );
   });
 });

--- a/runtime/tests/utils/markdown-config-loader-authority.test.ts
+++ b/runtime/tests/utils/markdown-config-loader-authority.test.ts
@@ -97,6 +97,36 @@ describe('markdown discovery authority', () => {
     expect(prompt(filesB)).toBe('Home B prompt.')
   })
 
+  test('still finds markdown when the search binary cannot run', async () => {
+    // ripGrep reports an unavailable binary with code "ENOENT", which errno
+    // alone cannot tell apart from "the directory is gone", so the loader
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently vanished wherever ripgrep could not start. CI is exactly such
+    // a machine: with `rg` off PATH this reproduced as a catalog holding only
+    // the five built-in agents. The native walk is the documented fallback.
+    const workspace = temporaryRoot('workspace-no-rg')
+    const home = temporaryRoot('home-no-rg')
+    writeAgent(home, 'Found without ripgrep.')
+    const authority = await createAuthority(home, workspace)
+
+    const previousBuiltin = process.env.USE_BUILTIN_RIPGREP
+    const previousPath = process.env.PATH
+    process.env.USE_BUILTIN_RIPGREP = 'false'
+    // A PATH with no `rg` on it, which is what makes ripGrep reject.
+    process.env.PATH = temporaryRoot('empty-bin')
+    try {
+      const files = await runWithCanonicalSettingsAuthority(authority, () =>
+        loadMarkdownFilesForSubdirFresh('agents', workspace),
+      )
+      expect(prompt(files)).toBe('Found without ripgrep.')
+    } finally {
+      if (previousBuiltin === undefined) delete process.env.USE_BUILTIN_RIPGREP
+      else process.env.USE_BUILTIN_RIPGREP = previousBuiltin
+      if (previousPath === undefined) delete process.env.PATH
+      else process.env.PATH = previousPath
+    }
+  })
+
   test('isolates same-home snapshots and clears only the active ConfigStore partition', async () => {
     const workspace = temporaryRoot('shared-workspace')
     const home = temporaryRoot('shared-home')


### PR DESCRIPTION
Fixes #2022. Based on `harness-skills-prompt` (#2014), which made the listing reach the model on every request; this makes the right skills be in it.

## Why

In the live 15-prompt run the model invoked **zero** skills across 15 turns and 149 tool calls, on a machine with 1,820 skills installed, several of them squarely about the work being done (`generating-unit-tests` while writing node:test cases, `javascript-typescript`, `canvas-design`, `frontend-design` while building a canvas game). The `Skill` tool was in the provider payload on every call.

The model never declined to use a skill. It was never shown one that fit.

## What, measured

Two filters removed them, both before the model could choose.

**The scan cap.** `MAX_SKILL_FILES = 500` is a per-root ceiling applied during the directory walk, in readdir order. On this machine that dropped 1,320 of 1,820 skills before any ranking or budget logic ran, including three of the four that matched the run's prompts. The cap now defaults to 5,000, above a real installation, and is overridable with `AGENC_MAX_SKILL_FILES_PER_ROOT`. The guard against a pathological directory stays; it is simply no longer inside a normal catalog. The drop counter is unchanged, so a truncated root still reports itself.

**The listing order.** What survived was ordered by scope rank and, inside a scope, by snapshot index, which is alphabetical. Measured against the real catalog:

| | |
| --- | --- |
| listing budget, 500k window | 20,000 chars (`window × 4 × 1%`) |
| skills that fit | 101 of 1,823 |
| last skill listed | `apollo-core-workflow-a` |
| `canvas-design` | position 185, not listed |
| `frontend-design` | position 650, not listed |
| `generating-unit-tests` | position 707, not listed |
| `javascript-typescript` | position 883, not listed |

The listing was, in effect, "every skill whose name starts with a". The order now puts the skills the current request is about first, with the previous scope rank as the tie-break, so the budget is spent on what the turn needs. A name match outranks a description match, because a skill called `generating-unit-tests` is what "write unit tests" wants and its description only corroborates that.

The request text reaches the listing from the attachment producer, which already had it as `opts.userInput`; nothing new is threaded.

## Behavior preserved

- A listing that fits the budget is byte-identical to before: ranking only applies to the over-budget path.
- A request that matches nothing keeps the old scope order.
- Bundled skills still always appear.
- The "…and N more skills not shown" line is unchanged.

## Tests

`tests/skills/local-loader.test.ts`:
- the skill a request is about is listed even when it sorts last (**falsification-checked**: fails with the ranking removed);
- without the request the same skill never fits, which is the old behavior stated as a test;
- an unrelated request does not promote it;
- a name match outranks a description-only match;
- a listing that already fits is byte-identical with and without a request;
- bundled skills survive regardless;
- the cap defaults above a real catalog and honors the override, and nonsense values fall back to the default rather than disabling the guard.

The two existing cap tests now set the cap through the env instead of writing 505 files, so they still pin truncation without depending on the constant's value.

Suites: `tests/skills` and `tests/prompts/attachments` show the same 12 pre-existing failures with and without this change (macOS memory-recall, fixed separately on #2017; watcher/mtime timing), and 7 more passing tests.

## Not changed on purpose

- **The instruction side.** The `Skill` tool already tells the model "when a skill matches the user's request, call this tool before responding", and the system prompt lists skills in a system reminder. The evidence does not support a prompt change: the matching skills were absent from the listing, so no instruction could have helped.
(The per-turn listing diagnostic the issue also asks for is included; see below.)

## The per-turn diagnostic (`8c86c4a1c`)

The listing is an attachment, so it never reaches the rollout, and the provider trace keeps no message bodies. A run where the model ignored every skill was therefore indistinguishable from one where it was shown none of the right ones — which is why explaining the zero-invocation run needed a measurement taken on the operator's own machine rather than anything in the logs.

Attachment producers are pure functions of their options and hold only an opaque `sessionKey`, so they had no way to report anything. `GetAttachmentsOptions` now carries an optional `emitDiagnostic` sink and `run-turn` binds it to the session event log, where the cause stays outside the TUI's user-visible allow-list and lands in the session log and the rollout, exactly like `memory_extraction_skipped`.

The skills producer emits `skill_listing_truncated` when the listing was cut, carrying: how many of the invocable skills were listed, characters used against the budget, whether the request drove the order, and which roots hold skills that were never loaded because the per-root cap stopped the walk. A listing where everything fit stays silent, and a caller with no sink is unaffected.

Tests in `tests/prompts/attachments/skill-listing.test.ts`: the truncated case reports listed-of-invocable and the budget; a request marks the listing ranked; never-loaded roots are named with their counts; a listing that fits emits nothing; a producer with no sink does not throw. The three suites show the same 15 pre-existing failures at this commit and at its parent, with 5 more passing tests.

## Merged `main` in

`affected-tests` on this branch failed on one test that has nothing to do with
this change:

```
FAIL tests/tools/AgentTool/loadAgentsDir.test.ts
  > never imports agent files through cross-workspace file or directory symlinks
AssertionError: expected [ Array(5) ] to include 'authority-local'
```

Five is the count of built-in agents, which need no file discovery, so the
markdown scan returned nothing. That is #2029: markdown discovery ran ripgrep
and swallowed "the binary could not start" as "the directory is missing", so
every markdown-defined agent, command and hook vanished wherever `rg` is
absent, which is CI. It is fixed and merged to `main`, and `main` is merged
here so this branch's check can report on its own change.
