### PR TITLE
memory extraction survives a restart and can read the shared root (#2023)

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -23,7 +23,14 @@ jobs:
   affected-tests:
     name: affected-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # `vitest related` walks the import graph, so a change to a widely imported
+    # module (a util, a config loader) selects most of the suite, not a handful
+    # of files. At the runner's two workers that is ~20 minutes of tests, and
+    # the old 15-minute cap cancelled the job mid-run: the gate reported
+    # `cancelled` with zero failures, so a correct change could never go green
+    # and the module was effectively unmergeable. Other jobs in this repo
+    # already allow 30-60 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -5667,7 +5667,7 @@ function historyEpochFromRollout(
 ): string {
   return historyEpochForBoundary(
     runId,
-    latestTranscriptBoundary(items, runId)?.id ?? "initial",
+    latestTranscriptBoundary(items)?.id ?? "initial",
   );
 }
 
@@ -5680,7 +5680,6 @@ interface TranscriptBoundary {
 
 function latestTranscriptBoundary(
   items: readonly RolloutItem[],
-  runId: string,
 ): TranscriptBoundary | undefined {
   let latest: TranscriptBoundary | undefined;
   for (const [index, item] of items.entries()) {
@@ -5700,35 +5699,19 @@ function latestTranscriptBoundary(
       };
       continue;
     }
-    if (
-      item.type === "compacted" &&
-      item.payload.replacementHistory !== undefined
-    ) {
-      latest = {
-        index,
-        id: `compacted:${index}:${hashStable(JSON.stringify(item.payload.replacementHistory))}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (item.type === "compaction_committed") {
-      latest = {
-        index,
-        id: `compaction:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (
-      item.type === "compaction_rollback_committed" &&
-      item.payload.target_session_id === runId
-    ) {
-      latest = {
-        index,
-        id: `compaction-rollback:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-    }
+    // Compaction is deliberately NOT a transcript boundary.
+    //
+    // It changes what the MODEL sees; the person reading the transcript still
+    // sent every earlier message and expects to find them. Treating a commit
+    // as a boundary truncated the reloaded transcript to the compacted view
+    // and rendered the summary itself as a user message: live, a 13-turn
+    // session came back as two turns after an app relaunch, because that
+    // rollout contained two compaction commits and no explicit epoch event.
+    //
+    // A user-facing reset still truncates, and is still the only thing that
+    // does: `history_cleared` and `transcript_epoch` above. A partial compact
+    // or a rewind that means to reset the transcript emits `transcript_epoch`
+    // alongside its `compacted` item, so those keep working unchanged.
   }
   return latest;
 }
@@ -6092,7 +6075,7 @@ export function sessionTranscriptV2FromRollout(
   runId: string,
   activeTurn?: { readonly turnId: string; readonly clientMessageId: string },
 ): SessionTranscriptV2Result {
-  const boundary = latestTranscriptBoundary(items, runId);
+  const boundary = latestTranscriptBoundary(items);
   const boundaryIndex = boundary?.index ?? -1;
   const boundaryId = boundary?.id ?? "initial";
   let asOfSequence = 0;

--- a/runtime/src/memory/extraction-triggers.ts
+++ b/runtime/src/memory/extraction-triggers.ts
@@ -123,46 +123,31 @@ function resolveMinEligibleTurns(value: number | undefined): number {
 }
 
 /**
- * Unprocessed messages that mean "this process inherited a conversation it did
- * not build". One turn's own output is a handful of messages; a backlog this
- * size only accumulates across a restart or a dropped lane.
- */
-export const COLD_LANE_BACKLOG_MESSAGES = 8;
-
-/**
  * Whether to hold this extraction back for the cadence.
  *
  * The counter is process-local: it lives in the in-process lane map, so a
  * daemon restart begins the wait again while the conversation it is pacing
- * stays on disk. A process that inherits a session mid-conversation would
- * make it wait a further full cadence before writing any memory.
+ * stays on disk. That gap is tracked separately; the cadence state belongs in
+ * persisted session state, and until it is there a restart costs at most one
+ * further cadence before memory is written again.
  *
- * The first decision a process makes for a lane is therefore allowed to look
- * at the backlog instead of the counter: an unprocessed range far larger than
- * one turn's output means this process did not build this conversation, and
- * that extraction runs now. It fires at most once per lane per process, so a
- * failing extraction still retries on the ordinary cadence rather than on
- * every turn — the cursor only advances when a run succeeds, so a backlog
- * that stays large must not keep re-triggering.
+ * An earlier version tried to close that gap by letting the first decision in
+ * a process read the unprocessed backlog instead of the counter, on the theory
+ * that a large backlog means the process inherited a conversation it did not
+ * build. One turn with tool calls and attachments produces more messages than
+ * any threshold that heuristic could use, so it fired on the first turn of a
+ * new session and launched a full-history child there. Message counts cannot
+ * tell "inherited a conversation" from "just built one", so it is gone rather
+ * than retuned.
  */
 export function shouldDeferForEligibleTurnCadence(params: {
   readonly state: MemoryExtractionTriggerState;
   readonly minEligibleTurns: number | undefined;
   readonly isTrailingRun: boolean;
-  /** First cadence decision this process makes for this lane. */
-  readonly laneIsCold?: boolean;
-  readonly unprocessedVisibleCount?: number;
 }): { readonly defer: boolean; readonly waiting: number } {
   if (params.isTrailingRun) return { defer: false, waiting: 0 };
   params.state.turnsSinceLastExtraction += 1;
   const minimum = resolveMinEligibleTurns(params.minEligibleTurns);
-  if (
-    params.laneIsCold === true &&
-    (params.unprocessedVisibleCount ?? 0) >= COLD_LANE_BACKLOG_MESSAGES
-  ) {
-    params.state.turnsSinceLastExtraction = 0;
-    return { defer: false, waiting: minimum };
-  }
   const waiting = params.state.turnsSinceLastExtraction;
   if (waiting < minimum) return { defer: true, waiting };
   params.state.turnsSinceLastExtraction = 0;

--- a/runtime/src/memory/extraction-triggers.ts
+++ b/runtime/src/memory/extraction-triggers.ts
@@ -123,45 +123,48 @@ function resolveMinEligibleTurns(value: number | undefined): number {
 }
 
 /**
- * Eligible turns waiting in a range, counted as the human messages in it.
- * This is the history-derived twin of `turnsSinceLastExtraction`: the counter
- * lives in process memory and a daemon restart sets it back to zero, while
- * the range is recomputed from the conversation and survives.
+ * Unprocessed messages that mean "this process inherited a conversation it did
+ * not build". One turn's own output is a handful of messages; a backlog this
+ * size only accumulates across a restart or a dropped lane.
  */
-export function eligibleTurnsInRange(
-  unprocessedMessages: readonly LLMMessage[],
-): number {
-  return unprocessedMessages.filter((message) => message.role === "user").length;
-}
+export const COLD_LANE_BACKLOG_MESSAGES = 8;
 
 /**
  * Whether to hold this extraction back for the cadence.
  *
- * The counter alone was not restart-safe: it lives in the in-process lane
- * map, so every daemon restart began the wait again. In the live 15-prompt
- * run three restarts meant the extraction ran once in thirteen turns, each
- * restart logging "deferred by eligible-turn cadence (1/3 eligible turns)".
- * The waiting turns are recoverable from the conversation itself, so the
- * decision now takes whichever is larger: what this process has counted, or
- * what the unprocessed range shows is already waiting. A fresh session is
- * unaffected — on its first turn both are 1 — and a resumed session no
- * longer pays another full cadence before its memory is written.
+ * The counter is process-local: it lives in the in-process lane map, so a
+ * daemon restart begins the wait again while the conversation it is pacing
+ * stays on disk. A process that inherits a session mid-conversation would
+ * make it wait a further full cadence before writing any memory.
+ *
+ * The first decision a process makes for a lane is therefore allowed to look
+ * at the backlog instead of the counter: an unprocessed range far larger than
+ * one turn's output means this process did not build this conversation, and
+ * that extraction runs now. It fires at most once per lane per process, so a
+ * failing extraction still retries on the ordinary cadence rather than on
+ * every turn — the cursor only advances when a run succeeds, so a backlog
+ * that stays large must not keep re-triggering.
  */
 export function shouldDeferForEligibleTurnCadence(params: {
   readonly state: MemoryExtractionTriggerState;
   readonly minEligibleTurns: number | undefined;
   readonly isTrailingRun: boolean;
-  readonly unprocessedEligibleTurns?: number;
-}): boolean {
-  if (params.isTrailingRun) return false;
+  /** First cadence decision this process makes for this lane. */
+  readonly laneIsCold?: boolean;
+  readonly unprocessedVisibleCount?: number;
+}): { readonly defer: boolean; readonly waiting: number } {
+  if (params.isTrailingRun) return { defer: false, waiting: 0 };
   params.state.turnsSinceLastExtraction += 1;
-  const waiting = Math.max(
-    params.state.turnsSinceLastExtraction,
-    params.unprocessedEligibleTurns ?? 0,
-  );
-  if (waiting < resolveMinEligibleTurns(params.minEligibleTurns)) {
-    return true;
+  const minimum = resolveMinEligibleTurns(params.minEligibleTurns);
+  if (
+    params.laneIsCold === true &&
+    (params.unprocessedVisibleCount ?? 0) >= COLD_LANE_BACKLOG_MESSAGES
+  ) {
+    params.state.turnsSinceLastExtraction = 0;
+    return { defer: false, waiting: minimum };
   }
+  const waiting = params.state.turnsSinceLastExtraction;
+  if (waiting < minimum) return { defer: true, waiting };
   params.state.turnsSinceLastExtraction = 0;
-  return false;
+  return { defer: false, waiting: minimum };
 }

--- a/runtime/src/memory/extraction-triggers.ts
+++ b/runtime/src/memory/extraction-triggers.ts
@@ -122,17 +122,44 @@ function resolveMinEligibleTurns(value: number | undefined): number {
   return Math.max(1, Math.trunc(value ?? DEFAULT_MIN_ELIGIBLE_TURNS));
 }
 
+/**
+ * Eligible turns waiting in a range, counted as the human messages in it.
+ * This is the history-derived twin of `turnsSinceLastExtraction`: the counter
+ * lives in process memory and a daemon restart sets it back to zero, while
+ * the range is recomputed from the conversation and survives.
+ */
+export function eligibleTurnsInRange(
+  unprocessedMessages: readonly LLMMessage[],
+): number {
+  return unprocessedMessages.filter((message) => message.role === "user").length;
+}
+
+/**
+ * Whether to hold this extraction back for the cadence.
+ *
+ * The counter alone was not restart-safe: it lives in the in-process lane
+ * map, so every daemon restart began the wait again. In the live 15-prompt
+ * run three restarts meant the extraction ran once in thirteen turns, each
+ * restart logging "deferred by eligible-turn cadence (1/3 eligible turns)".
+ * The waiting turns are recoverable from the conversation itself, so the
+ * decision now takes whichever is larger: what this process has counted, or
+ * what the unprocessed range shows is already waiting. A fresh session is
+ * unaffected — on its first turn both are 1 — and a resumed session no
+ * longer pays another full cadence before its memory is written.
+ */
 export function shouldDeferForEligibleTurnCadence(params: {
   readonly state: MemoryExtractionTriggerState;
   readonly minEligibleTurns: number | undefined;
   readonly isTrailingRun: boolean;
+  readonly unprocessedEligibleTurns?: number;
 }): boolean {
   if (params.isTrailingRun) return false;
   params.state.turnsSinceLastExtraction += 1;
-  if (
-    params.state.turnsSinceLastExtraction <
-    resolveMinEligibleTurns(params.minEligibleTurns)
-  ) {
+  const waiting = Math.max(
+    params.state.turnsSinceLastExtraction,
+    params.unprocessedEligibleTurns ?? 0,
+  );
+  if (waiting < resolveMinEligibleTurns(params.minEligibleTurns)) {
     return true;
   }
   params.state.turnsSinceLastExtraction = 0;

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -88,6 +88,7 @@ export {
   getGlobalMemoryEntrypoint,
   getGlobalMemoryPath,
   getMemoryBaseDir,
+  getMemoryProjectRoot,
   getProjectInstructionPath,
   getProjectMemoryEntrypoint,
   getProjectMemoryPath,

--- a/runtime/src/memory/paths.ts
+++ b/runtime/src/memory/paths.ts
@@ -208,6 +208,16 @@ function getAutoMemBase(): string {
 }
 
 /**
+ * The project root every memory key is built from: the canonical git root
+ * when there is one, otherwise the stable project root. Exported so a caller
+ * that already knows which memory base it wants can build the same project
+ * directory as `getProjectMemoryPath` without re-deriving the root.
+ */
+export function getMemoryProjectRoot(): string {
+  return getAutoMemBase()
+}
+
+/**
  * Build the project memory directory for one memory base and one project
  * root: `<baseDir>/projects/<sanitized-project-root>/memory/`. Shared by the
  * prompt/permission resolver below and by the extraction child's

--- a/runtime/src/prompts/attachments/relevant-memories.ts
+++ b/runtime/src/prompts/attachments/relevant-memories.ts
@@ -1,10 +1,14 @@
 import { Buffer } from "node:buffer";
-import { isAbsolute, normalize, sep } from "node:path";
+import { isAbsolute, join, normalize, sep } from "node:path";
 
 import {
   findRelevantMemories,
   formatRelevantMemoryHeader,
+  buildProjectMemoryDirectory,
   getGlobalMemoryPath,
+  getMemoryBaseDir,
+  getMemoryProjectRoot,
+  MEMORY_DIRNAME,
   getProjectMemoryPath,
   isAutoMemoryEnabled,
   readMemoryContent,
@@ -132,10 +136,30 @@ function selectRecallMode(
  */
 function durableMemorySearchDirs(agencHome: string | undefined): string[] {
   if (agencHome === undefined || agencHome.trim().length === 0) return [];
+  // The shared resolvers read the ambient memory base. When the request names
+  // that same base they are the right answer, because they also carry the
+  // trusted overrides (a Cowork path override, an `autoMemoryDirectory`
+  // setting, a remote root) that a plain join would drop.
+  //
+  // When the request names a different home, the ambient answer is the wrong
+  // one and searching it anyway would read another home's memories into this
+  // request. Build both roots from the home the request gave, through the
+  // same formula the writers use, so recall still lands where the extraction
+  // child and the memory prompt point.
+  if (normalizeDirectory(agencHome) === normalizeDirectory(getMemoryBaseDir())) {
+    return Array.from(
+      new Set([
+        normalizeDirectory(getGlobalMemoryPath()),
+        normalizeDirectory(getProjectMemoryPath()),
+      ]),
+    );
+  }
   return Array.from(
     new Set([
-      normalizeDirectory(getGlobalMemoryPath()),
-      normalizeDirectory(getProjectMemoryPath()),
+      normalizeDirectory(join(agencHome, MEMORY_DIRNAME)),
+      normalizeDirectory(
+        buildProjectMemoryDirectory(agencHome, getMemoryProjectRoot()),
+      ),
     ]),
   );
 }

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -43,6 +43,7 @@ import {
   isMemoryExtractionDisabledByEnv,
   memoryExtractionVisibleRange,
   parseMemoryToolArguments,
+  eligibleTurnsInRange,
   shouldDeferForEligibleTurnCadence,
   type MemoryExtractionTriggerState,
 } from "../../memory/extraction-triggers.js";
@@ -55,6 +56,7 @@ import {
   AUTO_MEMORY_INDEX_FILE,
   isPathInsideMemoryDir,
   resolveAutoMemoryDirectory,
+  resolveGlobalMemoryDirectory,
   type AutoMemoryPathResult,
   type MemoryPathEnv,
   type ResolveAutoMemoryDirectoryOptions,
@@ -217,6 +219,37 @@ function memoryRoot(memoryDir: string): string {
   return normalize(memoryDir);
 }
 
+/**
+ * First root that contains `value`, or undefined. Read tools may look in any
+ * memory root the session owns; writes stay in one.
+ */
+function resolveMemoryPathInRoots(
+  value: unknown,
+  roots: readonly string[],
+): string | undefined {
+  for (const root of roots) {
+    const resolved = resolveMemoryPath(value, root);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+function allowWithMemoryRoots(
+  input: Record<string, unknown>,
+  roots: readonly string[],
+): ReturnType<ChildToolPolicy> {
+  return {
+    behavior: "allow",
+    updatedInput: withSignedAllowedRoots(input, [...roots]),
+  };
+}
+
+function describeRoots(roots: readonly string[]): string {
+  return roots.length === 1
+    ? (roots[0] as string)
+    : `${roots.join(" or ")}`;
+}
+
 function resolveMemoryPath(
   value: unknown,
   memoryDir: string,
@@ -240,28 +273,11 @@ function resolveDirectMemoryWritePath(
   return isPathInsideMemoryDir(candidate, root) ? candidate : null;
 }
 
-function withMemoryAllowedRoot(
-  input: Record<string, unknown>,
-  memoryDir: string,
-): Record<string, unknown> {
-  return withSignedAllowedRoots(input, [memoryDir]);
-}
-
 function deny(message: string, reason: string): ReturnType<ChildToolPolicy> {
   return {
     behavior: "deny",
     message,
     metadata: { reason },
-  };
-}
-
-function allowWithMemoryRoot(
-  input: Record<string, unknown>,
-  memoryDir: string,
-): ReturnType<ChildToolPolicy> {
-  return {
-    behavior: "allow",
-    updatedInput: withMemoryAllowedRoot(input, memoryDir),
   };
 }
 
@@ -282,32 +298,57 @@ function globPatternStaysInsideMemory(
   return isPathInsideMemoryDir(candidate, memoryRoot(memoryDir));
 }
 
-export function createAutoMemoryToolPolicy(memoryDir: string): ChildToolPolicy {
+/**
+ * The child may READ every memory root the session owns and WRITE only to the
+ * project root.
+ *
+ * Reads were single-root, so the child could not open the global
+ * `$AGENC_HOME/memory` index that the main agent reads and writes. Live, it
+ * probed that root, was denied, and the run was recorded as a failed
+ * extraction. The platform already unions both roots for file tools
+ * (`resolveToolAllowedPaths`); only this policy was stricter.
+ *
+ * Writes stay project-scoped on purpose. The child summarizes untrusted
+ * conversation content, and the global root is shared by every project on the
+ * machine: a memory planted there from one conversation would reach every
+ * later session everywhere. Reading it is enough to stop the duplicate writes
+ * that motivated this; extracting `user`-type memories into the global root
+ * needs a routing rule and a narrower writer, which is its own change.
+ */
+export function createAutoMemoryToolPolicy(
+  memoryDir: string,
+  readOnlyRoots: readonly string[] = [],
+): ChildToolPolicy {
+  const writeRoot = memoryDir;
+  const readRoots = [
+    memoryDir,
+    ...readOnlyRoots.filter((root) => memoryRoot(root) !== memoryRoot(memoryDir)),
+  ];
   return (tool, input) => {
     if (tool.name === "FileRead") {
-      const filePath = resolveMemoryPath(input.file_path, memoryDir);
+      const filePath = resolveMemoryPathInRoots(input.file_path, readRoots);
       if (!filePath) {
         return deny(
-          `FileRead is restricted to the memory directory: ${memoryDir}`,
+          `FileRead is restricted to the memory directory: ${describeRoots(readRoots)}`,
           "file_read_outside_memory",
         );
       }
-      return allowWithMemoryRoot({ ...input, file_path: filePath }, memoryDir);
+      return allowWithMemoryRoots({ ...input, file_path: filePath }, readRoots);
     }
 
     if (tool.name === "Grep") {
       const rawPath = input.path ?? input.cwd;
       const path =
         rawPath === undefined
-          ? memoryRoot(memoryDir)
-          : resolveMemoryPath(rawPath, memoryDir);
+          ? memoryRoot(writeRoot)
+          : resolveMemoryPathInRoots(rawPath, readRoots);
       if (!path) {
         return deny(
-          `Grep is restricted to the memory directory: ${memoryDir}`,
+          `Grep is restricted to the memory directory: ${describeRoots(readRoots)}`,
           "grep_outside_memory",
         );
       }
-      return allowWithMemoryRoot({ ...input, path }, memoryDir);
+      return allowWithMemoryRoots({ ...input, path }, readRoots);
     }
 
     if (tool.name === "Glob") {
@@ -315,31 +356,34 @@ export function createAutoMemoryToolPolicy(memoryDir: string): ChildToolPolicy {
       const rawPath = input.path ?? input.cwd;
       const path =
         rawPath === undefined
-          ? memoryRoot(memoryDir)
-          : resolveMemoryPath(rawPath, memoryDir);
+          ? memoryRoot(writeRoot)
+          : resolveMemoryPathInRoots(rawPath, readRoots);
       if (!path) {
         return deny(
-          `Glob is restricted to the memory directory: ${memoryDir}`,
+          `Glob is restricted to the memory directory: ${describeRoots(readRoots)}`,
           "glob_outside_memory",
         );
       }
       if (
         pattern.length > 0 &&
-        !globPatternStaysInsideMemory(pattern, path, memoryDir)
+        !readRoots.some((root) => globPatternStaysInsideMemory(pattern, path, root))
       ) {
         return deny(
-          `Glob is restricted to the memory directory: ${memoryDir}`,
+          `Glob is restricted to the memory directory: ${describeRoots(readRoots)}`,
           "glob_outside_memory",
         );
       }
-      return allowWithMemoryRoot({ ...input, path }, memoryDir);
+      return allowWithMemoryRoots({ ...input, path }, readRoots);
     }
 
     if (WRITE_TOOL_NAMES.has(tool.name)) {
-      const filePath = resolveMemoryPath(input.file_path, memoryDir);
+      const filePath = resolveMemoryPath(input.file_path, writeRoot);
       if (!filePath) {
+        const readable = resolveMemoryPathInRoots(input.file_path, readRoots);
         return deny(
-          `${tool.name} is restricted to the memory directory: ${memoryDir}`,
+          readable
+            ? `${tool.name} may only write to this session's project memory directory: ${writeRoot}. The other memory roots are readable but not writable from memory extraction.`
+            : `${tool.name} is restricted to the memory directory: ${writeRoot}`,
           "write_outside_memory",
         );
       }
@@ -352,7 +396,7 @@ export function createAutoMemoryToolPolicy(memoryDir: string): ChildToolPolicy {
           "secret_in_memory_write",
         );
       }
-      return allowWithMemoryRoot({ ...input, file_path: filePath }, memoryDir);
+      return allowWithMemoryRoots({ ...input, file_path: filePath }, [writeRoot]);
     }
 
     return deny(
@@ -519,6 +563,7 @@ export function initExtractMemories(
     memoryDir: string,
     lane: ExtractionLane,
     isTrailingRun = false,
+    readOnlyMemoryRoots: readonly string[] = [],
   ): Promise<void> {
     const session = queued.context.session;
     const range: VisibleRange = memoryExtractionVisibleRange(
@@ -558,6 +603,8 @@ export function initExtractMemories(
         state: lane.trigger,
         minEligibleTurns: deps.minEligibleTurns,
         isTrailingRun,
+        // Survives a daemon restart, which the in-process counter does not.
+        unprocessedEligibleTurns: eligibleTurnsInRange(range.unprocessedMessages),
       })
     ) {
       emitExtractionWarning(
@@ -580,6 +627,7 @@ export function initExtractMemories(
       existingMemories,
       deps.omitIndexFile ?? false,
       memoryDir,
+      readOnlyMemoryRoots[0],
     );
     const maxTurns = deps.maxTurns ?? DEFAULT_MAX_TURNS;
     const childResult = await (deps.runChild ??
@@ -588,7 +636,7 @@ export function initExtractMemories(
       messages: queued.context.messages,
       prompt,
       memoryDir,
-      toolPolicy: createAutoMemoryToolPolicy(memoryDir),
+      toolPolicy: createAutoMemoryToolPolicy(memoryDir, readOnlyMemoryRoots),
       signal: queued.context.signal,
       onProgress: (event) => tracker.onProgress(event),
     });
@@ -659,6 +707,17 @@ export function initExtractMemories(
       configStore: queued.context.session.services?.configStore,
       runtimeOptions: queued.context.session.services.runtimeOptions,
     });
+    // The main agent reads and writes a machine-wide memory root too. The
+    // child could not open it, so it probed, was denied, and the run was
+    // recorded as a failed extraction. It may read that root to avoid
+    // duplicating what is already there; it still writes only to this
+    // session's project root.
+    const globalMemoryRoot = await resolveGlobalMemoryDirectory({
+      env: deps.env,
+      cwd: queued.context.ctx.cwd,
+      configStore: queued.context.session.services?.configStore,
+      runtimeOptions: queued.context.session.services.runtimeOptions,
+    }).catch(() => undefined);
     if (!pathResult.enabled || !pathResult.path) {
       emitExtractionWarning(
         queued.context.session,
@@ -669,6 +728,8 @@ export function initExtractMemories(
     }
 
     const memoryDir = pathResult.path;
+    const readOnlyMemoryRoots =
+      globalMemoryRoot === undefined ? [] : [globalMemoryRoot];
     const lane = extractionLane(queued.context.session, memoryDir);
 
     if (lane.inProgress) {
@@ -679,7 +740,7 @@ export function initExtractMemories(
     lane.inProgress = true;
     try {
       try {
-        await runExtraction(queued, memoryDir, lane);
+        await runExtraction(queued, memoryDir, lane, false, readOnlyMemoryRoots);
       } catch (error) {
         // Best effort: extraction failures must never break the user turn,
         // but they must not vanish either.
@@ -693,7 +754,7 @@ export function initExtractMemories(
         const trailing = lane.pendingContext;
         lane.pendingContext = undefined;
         try {
-          await runExtraction(trailing, memoryDir, lane, true);
+          await runExtraction(trailing, memoryDir, lane, true, readOnlyMemoryRoots);
         } catch (error) {
           emitExtractionWarning(
             trailing.context.session,

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -173,12 +173,6 @@ interface ExtractionLane {
   inProgress: boolean;
   lastAccessedAt: number;
   pendingContext: QueuedExtraction | undefined;
-  /**
-   * True until this process has made one cadence decision for this lane. The
-   * counter inside `trigger` starts at zero in every new process, so the
-   * first decision is the only one allowed to read the backlog instead.
-   */
-  coldDecisionPending: boolean;
 }
 
 interface ChildWriteTracker {
@@ -547,9 +541,6 @@ export function initExtractMemories(
       inProgress: false,
       lastAccessedAt: Date.now(),
       pendingContext: undefined,
-      // A lane this process has not decided for yet: the conversation may
-      // predate the process.
-      coldDecisionPending: true,
     };
     lanes.set(key, created);
     return created;
@@ -606,17 +597,10 @@ export function initExtractMemories(
       return;
     }
 
-    // The first decision this process makes for this lane may consider the
-    // backlog: a daemon restart leaves the counter at zero while the
-    // conversation it paces is still on disk.
-    const laneIsCold = lane.coldDecisionPending;
-    lane.coldDecisionPending = false;
     const cadence = shouldDeferForEligibleTurnCadence({
       state: lane.trigger,
       minEligibleTurns: deps.minEligibleTurns,
       isTrailingRun,
-      laneIsCold,
-      unprocessedVisibleCount: range.unprocessedMessages.length,
     });
     if (cadence.defer) {
       emitExtractionWarning(

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -43,7 +43,6 @@ import {
   isMemoryExtractionDisabledByEnv,
   memoryExtractionVisibleRange,
   parseMemoryToolArguments,
-  eligibleTurnsInRange,
   shouldDeferForEligibleTurnCadence,
   type MemoryExtractionTriggerState,
 } from "../../memory/extraction-triggers.js";
@@ -174,6 +173,12 @@ interface ExtractionLane {
   inProgress: boolean;
   lastAccessedAt: number;
   pendingContext: QueuedExtraction | undefined;
+  /**
+   * True until this process has made one cadence decision for this lane. The
+   * counter inside `trigger` starts at zero in every new process, so the
+   * first decision is the only one allowed to read the backlog instead.
+   */
+  coldDecisionPending: boolean;
 }
 
 interface ChildWriteTracker {
@@ -542,6 +547,9 @@ export function initExtractMemories(
       inProgress: false,
       lastAccessedAt: Date.now(),
       pendingContext: undefined,
+      // A lane this process has not decided for yet: the conversation may
+      // predate the process.
+      coldDecisionPending: true,
     };
     lanes.set(key, created);
     return created;
@@ -598,19 +606,23 @@ export function initExtractMemories(
       return;
     }
 
-    if (
-      shouldDeferForEligibleTurnCadence({
-        state: lane.trigger,
-        minEligibleTurns: deps.minEligibleTurns,
-        isTrailingRun,
-        // Survives a daemon restart, which the in-process counter does not.
-        unprocessedEligibleTurns: eligibleTurnsInRange(range.unprocessedMessages),
-      })
-    ) {
+    // The first decision this process makes for this lane may consider the
+    // backlog: a daemon restart leaves the counter at zero while the
+    // conversation it paces is still on disk.
+    const laneIsCold = lane.coldDecisionPending;
+    lane.coldDecisionPending = false;
+    const cadence = shouldDeferForEligibleTurnCadence({
+      state: lane.trigger,
+      minEligibleTurns: deps.minEligibleTurns,
+      isTrailingRun,
+      laneIsCold,
+      unprocessedVisibleCount: range.unprocessedMessages.length,
+    });
+    if (cadence.defer) {
       emitExtractionWarning(
         session,
         "memory_extraction_skipped",
-        `deferred by eligible-turn cadence (${lane.trigger.turnsSinceLastExtraction}/${Math.max(1, Math.trunc(deps.minEligibleTurns ?? DEFAULT_MIN_ELIGIBLE_TURNS))} eligible turns)`,
+        `deferred by eligible-turn cadence (${cadence.waiting}/${Math.max(1, Math.trunc(deps.minEligibleTurns ?? DEFAULT_MIN_ELIGIBLE_TURNS))} eligible turns)`,
       );
       return;
     }

--- a/runtime/src/services/extractMemories/memory-paths.ts
+++ b/runtime/src/services/extractMemories/memory-paths.ts
@@ -302,6 +302,31 @@ export async function resolveAutoMemoryDirectory(
   };
 }
 
+/**
+ * The global memory root for these options, or undefined when it cannot be
+ * resolved. Same formula as `src/memory/paths.ts` (`<base>/memory`), computed
+ * here from explicit options rather than ambient session state, which is why
+ * this module keeps its own copy. Deliberately NOT moved by the
+ * project-directory overrides above: a project override redirects that
+ * project's memory, not the machine-wide root the main agent uses.
+ */
+export async function resolveGlobalMemoryDirectory(
+  opts: ResolveAutoMemoryDirectoryOptions = {},
+): Promise<string | undefined> {
+  const runtimeOptions = opts.runtimeOptions ?? getActiveAgentRuntimeOptions();
+  const homeDir = effectiveHome(opts);
+  const remoteMemoryDir = runtimeOptions?.remoteMemoryRoot;
+  const baseRoot =
+    remoteMemoryDir !== undefined && remoteMemoryDir.trim().length > 0
+      ? validateAutoMemoryDirectoryPath(remoteMemoryDir, {
+          expandTilde: false,
+          homeDir,
+        })
+      : normalizeWithTrailingSep(resolveConfigHome(opts));
+  if (!baseRoot) return undefined;
+  return normalizeWithTrailingSep(join(baseRoot, "memory"));
+}
+
 export function isPathInsideMemoryDir(candidate: string, memoryDir: string): boolean {
   const root = normalize(memoryDir);
   const normalizedRoot = root.endsWith(sep) ? root.slice(0, -1) : root;

--- a/runtime/src/services/extractMemories/memory-paths.ts
+++ b/runtime/src/services/extractMemories/memory-paths.ts
@@ -26,7 +26,7 @@ import {
   sep,
 } from "node:path";
 import { findGitRoot as findCanonicalGitRoot } from "../../agents/worktree.js";
-import { buildProjectMemoryDirectory } from "../../memory/index.js";
+import { buildProjectMemoryDirectory } from "../../memory/paths.js";
 import type { AgenCConfig } from "../../config/schema.js";
 import type { ConfigStore } from "../../config/store.js";
 import {

--- a/runtime/src/services/extractMemories/prompts.ts
+++ b/runtime/src/services/extractMemories/prompts.ts
@@ -24,6 +24,7 @@ function opener(
   newMessageCount: number,
   existingMemories: string,
   memoryDir?: string,
+  globalMemoryDir?: string,
 ): string {
   const manifest =
     existingMemories.trim().length > 0
@@ -34,7 +35,16 @@ function opener(
     "",
     memoryDir === undefined
       ? "Available tools: FileRead, Grep, Glob, and Edit/MultiEdit/Write for paths inside the memory directory only. All other tools will be denied."
-      : `Available tools: FileRead, Grep, Glob, and Edit/MultiEdit/Write for paths inside the memory directory only. The memory directory is ${memoryDir} — read and write only there; any other path and every other tool will be denied.`,
+      : [
+          "Available tools: FileRead, Grep, Glob, and Edit/MultiEdit/Write.",
+          `Write to this project's memory directory only: ${memoryDir}`,
+          ...(globalMemoryDir === undefined
+            ? []
+            : [
+                `You may also READ the shared memory directory ${globalMemoryDir} — check it so you do not duplicate something already recorded there — but you cannot write to it.`,
+              ]),
+          "Any other path and every other tool will be denied.",
+        ].join(" "),
     "",
     "You have a limited turn budget. Edit requires a prior FileRead of the same file, so the efficient strategy is: turn 1 — issue all FileRead calls in parallel for every file you might update; turn 2 — issue all Write/Edit/MultiEdit calls in parallel. Do not interleave reads and writes across multiple turns.",
     "",
@@ -53,6 +63,7 @@ export function buildExtractAutoOnlyPrompt(
   existingMemories: string,
   omitIndexFile = false,
   memoryDir?: string,
+  globalMemoryDir?: string,
 ): string {
   const howToSave = omitIndexFile
     ? [
@@ -84,7 +95,7 @@ export function buildExtractAutoOnlyPrompt(
       ];
 
   return [
-    opener(newMessageCount, existingMemories, memoryDir),
+    opener(newMessageCount, existingMemories, memoryDir, globalMemoryDir),
     "",
     "If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.",
     "",

--- a/runtime/src/tools/FileWriteTool/FileWriteTool.ts
+++ b/runtime/src/tools/FileWriteTool/FileWriteTool.ts
@@ -5,7 +5,7 @@ import { clearDeliveredDiagnosticsForFile } from '../../services/lsp/LSPDiagnost
 import { getLspServerManager } from '../../services/lsp/manager.js'
 import { peekAmbientRuntimeSession } from '../../session/current-session.js'
 import type { SandboxExecutionBrokerLike } from '../../sandbox/execution-broker.js'
-import { checkMemorySecrets } from '../../memory/index.js'
+import { checkMemorySecrets } from '../../memory/privacy.js'
 import type { ToolUseContext } from '../Tool.js'
 import { buildTool, type ToolDef } from '../Tool.js'
 import { logForDebugging } from 'src/utils/debug.js'

--- a/runtime/src/tools/system/file-edit.ts
+++ b/runtime/src/tools/system/file-edit.ts
@@ -48,7 +48,7 @@ import {
   resolveSessionId,
   safePathAllowingSessionPlanFile,
 } from "./filesystem.js";
-import { checkMemorySecrets } from "../../memory/index.js";
+import { checkMemorySecrets } from "../../memory/privacy.js";
 import {
   agentNamespacePathHint,
   denyAgentNamespacePath,

--- a/runtime/src/tools/system/file-write.ts
+++ b/runtime/src/tools/system/file-write.ts
@@ -54,7 +54,7 @@ import {
   SESSION_ID_ARG,
   type SessionReadViewKind,
 } from "./filesystem.js";
-import { checkMemorySecrets } from "../../memory/index.js";
+import { checkMemorySecrets } from "../../memory/privacy.js";
 import {
   agentNamespacePathHint,
   denyAgentNamespacePath,

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -45,7 +45,12 @@ import {
 } from "node:fs";
 import { resolve, dirname, basename, join } from "node:path";
 import { resolveHomeContext } from "../../config/home.js";
-import { getDurableMemoryRoots } from "../../memory/index.js";
+// Imported from the defining module rather than the `memory/index.js` barrel.
+// The barrel re-exports the recall pipeline, which reaches `utils/ide.ts` and
+// `utils/envDynamic.ts`; that module calls `stat` at import time on Linux, so
+// pulling the barrel in here made the filesystem tool fail to load in any
+// suite that mocks `node:fs/promises`.
+import { getDurableMemoryRoots } from "../../memory/paths.js";
 import { getCurrentRuntimeSession } from "../../session/current-session.js";
 import {
   getSessionTempNamespaceName,

--- a/runtime/src/utils/markdownConfigLoader.ts
+++ b/runtime/src/utils/markdownConfigLoader.ts
@@ -12,7 +12,7 @@ import type { FrontmatterData } from './frontmatterParser.js'
 import { parseFrontmatter } from './frontmatterParser.js'
 import { findCanonicalGitRoot, findGitRoot } from './git.js'
 import { parseToolListFromCLI } from './permissions/toolListParser.js'
-import { ripGrep } from './ripgrep.js'
+import { isRipgrepUnavailable, ripGrep } from './ripgrep.js'
 import {
   isSettingSourceEnabled,
   type SettingSource,
@@ -623,13 +623,25 @@ async function loadMarkdownFiles(dir: string): Promise<
           signal,
         )
   } catch (e: unknown) {
-    // Handle missing/inaccessible dir directly instead of pre-checking
-    // existence (TOCTOU). findMarkdownFilesNative already catches internally;
-    // ripGrep rejects on inaccessible target paths.
-    if (isFsInaccessible(e)) return []
-    throw e
+    // A search tool that cannot start is not an empty directory. `ripGrep`
+    // reports an unavailable binary with `code: "ENOENT"`, which errno alone
+    // cannot tell apart from "the directory is gone", so the check below
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently disappeared wherever ripgrep could not run — a machine with
+    // no `rg` on PATH, a build without the packaged binary, a container that
+    // cannot spawn it. The native walk is documented above as the fallback
+    // for exactly this and needs no external binary, so use it.
+    if (!useNative && isRipgrepUnavailable(e)) {
+      files = await findMarkdownFilesNative(dir, signal)
+    } else if (isFsInaccessible(e)) {
+      // Handle missing/inaccessible dir directly instead of pre-checking
+      // existence (TOCTOU). findMarkdownFilesNative already catches
+      // internally; ripGrep rejects on inaccessible target paths.
+      return []
+    } else {
+      throw e
+    }
   }
-
   const results = await Promise.all(
     files.map(async filePath => {
       let handle: Awaited<ReturnType<typeof open>> | undefined

--- a/runtime/src/utils/ripgrep.ts
+++ b/runtime/src/utils/ripgrep.ts
@@ -182,6 +182,11 @@ export function getRipgrepInstallHint(platform = process.platform): string {
   }
 }
 
+/** True when the failure means the search binary could not run at all. */
+export function isRipgrepUnavailable(error: unknown): boolean {
+  return error instanceof RipgrepUnavailableError
+}
+
 export function wrapRipgrepUnavailableError(
   error: RipgrepErrorLike,
   config = getRipgrepConfig(),

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -101,6 +101,121 @@ describe("session.transcript.v2 durable projection", () => {
     expect(afterAppend.messages).toEqual(first.messages);
   });
 
+  it("keeps the whole conversation when a compaction commits without an epoch", () => {
+
+    // Compaction changes what the model sees, not what the person reading
+
+    // the transcript sent. Live: a 13-turn session came back as two turns
+
+    // after an app relaunch, because its rollout carried two compaction
+
+    // commits and no explicit epoch event, and the summary itself was
+
+    // rendered as one of those turns.
+
+    const items: RolloutItem[] = [
+
+      event(10, "user-1", {
+
+        type: "user_message",
+
+        payload: { message: "first question", messageId: "client-1" },
+
+      }),
+
+      event(11, "turn-1", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-1" },
+
+      }),
+
+      event(12, "answer-1", {
+
+        type: "agent_message",
+
+        payload: { message: "first answer" },
+
+      }),
+
+      {
+
+        type: "compaction_committed",
+
+        payload: {
+
+          attempt_id: "compact-auto-1",
+
+          replacement_history: [
+
+            { role: "developer", content: "agenc_compaction_boundary_v1: untrusted" },
+
+            { role: "user", content: "a summary of the work so far" },
+
+          ],
+
+        },
+
+      } as unknown as RolloutItem,
+
+      event(20, "user-2", {
+
+        type: "user_message",
+
+        payload: { message: "second question", messageId: "client-2" },
+
+      }),
+
+      event(21, "turn-2", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-2" },
+
+      }),
+
+      event(22, "answer-2", {
+
+        type: "agent_message",
+
+        payload: { message: "second answer" },
+
+      }),
+
+    ];
+
+
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+
+
+    expect(snapshot.messages.map((message) => message.text)).toEqual([
+
+      "first question",
+
+      "first answer",
+
+      "second question",
+
+      "second answer",
+
+    ]);
+
+    // The model's compacted view never appears as something the user said.
+
+    expect(snapshot.messages.some((message) => message.text.includes("summary of the work"))).toBe(
+
+      false,
+
+    );
+
+    // Nothing truncated, so the epoch is the initial one.
+
+    expect(snapshot.historyEpoch).toBe("history:run-1:initial");
+
+  });
+
+
   it("rebuilds from each compact/rewind replacement and advances a stable epoch", () => {
     const compacted: RolloutItem[] = [
       {

--- a/runtime/tests/memory-wiring.contract.test.ts
+++ b/runtime/tests/memory-wiring.contract.test.ts
@@ -66,16 +66,34 @@ describe("memory wiring contract", () => {
     expect(projectMemory).toContain("getProjectMemoryPathForSelector");
     expect(projectMemory).toContain("MEMORY_MENTION_SYNTAX");
     expect(projectMemory).toContain("./privacy.js");
-    expect(fileWriteTool).toContain("../../memory/index.js");
+    // Names the defining module, not the index: a tool importing the memory
+    // barrel closes a cycle back through utils/attachments. See the allowlist
+    // comment in the import test below.
+    expect(fileWriteTool).toContain("../../memory/privacy.js");
     expect(attachments).toContain("getDurableMemorySearchDirs");
     expect(attachments).toContain("getGlobalMemoryPath");
     expect(filesystem).toContain("isGlobalMemoryPath");
   });
 
   it("routes runtime tool and code memory access through the public index", () => {
+    // The rule is that code outside runtime/src/memory reaches memory through
+    // the public index. These files cannot: memory/index.js re-exports
+    // memory/agencmd.ts, which imports utils/hooks.ts -> utils/attachments.ts
+    // -> tools/system/filesystem.ts, so a tool importing the index closes a
+    // cycle. Under that cycle a module can be evaluated before its
+    // dependencies finish initializing, which took down the filesystem suite
+    // (envDynamic calling a not-yet-defined stat at import time on Linux) and
+    // the in-process teammate compaction suite (its rollout store was never
+    // created). Each of these needs one pure function, so each names the
+    // module that defines it.
     const directImportAllowlist = new Set([
       "runtime/src/memdir/teamMemPaths.ts",
       "runtime/src/memdir/teamMemPrompts.ts",
+      "runtime/src/tools/system/filesystem.ts",
+      "runtime/src/tools/system/file-edit.ts",
+      "runtime/src/tools/system/file-write.ts",
+      "runtime/src/tools/FileWriteTool/FileWriteTool.ts",
+      "runtime/src/services/extractMemories/memory-paths.ts",
     ]);
     const directMemoryModuleImport =
       /(?:from\s+|import\s*\(\s*)["'][^"']*memory\/(?:project-memory|agencmd|find-relevant|scan|age|paths|detection|privacy)\.js["']/g;

--- a/runtime/tests/memory/extraction-triggers.test.ts
+++ b/runtime/tests/memory/extraction-triggers.test.ts
@@ -10,6 +10,7 @@ import {
   memoryExtractionVisibleRange,
   parseMemoryToolArguments,
   shouldDeferForEligibleTurnCadence,
+  eligibleTurnsInRange,
 } from "./extraction-triggers.js";
 
 describe("memory extraction triggers", () => {
@@ -161,6 +162,63 @@ describe("memory extraction triggers", () => {
         isTrailingRun: true,
       }),
     ).toBe(false);
+  });
+
+  it("counts the human turns waiting in an unprocessed range", () => {
+    expect(
+      eligibleTurnsInRange([
+        { role: "user", content: "one" },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "two" },
+        { role: "assistant", content: "ok" },
+      ]),
+    ).toBe(2);
+    expect(eligibleTurnsInRange([])).toBe(0);
+  });
+
+  it("does not restart the cadence when a restart cleared the counter", () => {
+    // Live shape: three daemon restarts in one run, and each one logged
+    // "deferred by eligible-turn cadence (1/3 eligible turns)" on a session
+    // that had been waiting far longer. The extraction ran once in 13 turns.
+    const restarted = createMemoryExtractionTriggerState();
+    expect(
+      shouldDeferForEligibleTurnCadence({
+        state: restarted,
+        minEligibleTurns: undefined,
+        isTrailingRun: false,
+        // The conversation shows eight human turns still unprocessed.
+        unprocessedEligibleTurns: 8,
+      }),
+    ).toBe(false);
+    expect(restarted.turnsSinceLastExtraction).toBe(0);
+  });
+
+  it("still paces a fresh session exactly as before", () => {
+    const state = createMemoryExtractionTriggerState();
+    // A fresh session's range grows one human turn at a time, so the derived
+    // count and the counter agree and the cadence is unchanged.
+    const outcomes = [1, 2, 3].map((turns) =>
+      shouldDeferForEligibleTurnCadence({
+        state,
+        minEligibleTurns: undefined,
+        isTrailingRun: false,
+        unprocessedEligibleTurns: turns,
+      }),
+    );
+    expect(outcomes).toEqual([true, true, false]);
+    expect(state.turnsSinceLastExtraction).toBe(0);
+  });
+
+  it("keeps deferring when too few turns are waiting", () => {
+    const state = createMemoryExtractionTriggerState();
+    expect(
+      shouldDeferForEligibleTurnCadence({
+        state,
+        minEligibleTurns: undefined,
+        isTrailingRun: false,
+        unprocessedEligibleTurns: 1,
+      }),
+    ).toBe(true);
   });
 
   it("parses invalid tool arguments as an empty object", () => {

--- a/runtime/tests/memory/extraction-triggers.test.ts
+++ b/runtime/tests/memory/extraction-triggers.test.ts
@@ -10,7 +10,7 @@ import {
   memoryExtractionVisibleRange,
   parseMemoryToolArguments,
   shouldDeferForEligibleTurnCadence,
-  eligibleTurnsInRange,
+  COLD_LANE_BACKLOG_MESSAGES,
 } from "./extraction-triggers.js";
 
 describe("memory extraction triggers", () => {
@@ -127,12 +127,13 @@ describe("memory extraction triggers", () => {
   it("defers two eligible turns by default before the third runs", () => {
     const state = createMemoryExtractionTriggerState();
     expect(DEFAULT_MIN_ELIGIBLE_TURNS).toBe(3);
-    const outcomes = [0, 1, 2].map(() =>
-      shouldDeferForEligibleTurnCadence({
-        state,
-        minEligibleTurns: undefined,
-        isTrailingRun: false,
-      }),
+    const outcomes = [0, 1, 2].map(
+      () =>
+        shouldDeferForEligibleTurnCadence({
+          state,
+          minEligibleTurns: undefined,
+          isTrailingRun: false,
+        }).defer,
     );
     expect(outcomes).toEqual([true, true, false]);
     expect(state.turnsSinceLastExtraction).toBe(0);
@@ -145,14 +146,14 @@ describe("memory extraction triggers", () => {
         state,
         minEligibleTurns: 2,
         isTrailingRun: false,
-      }),
+      }).defer,
     ).toBe(true);
     expect(
       shouldDeferForEligibleTurnCadence({
         state,
         minEligibleTurns: 2,
         isTrailingRun: false,
-      }),
+      }).defer,
     ).toBe(false);
     expect(state.turnsSinceLastExtraction).toBe(0);
     expect(
@@ -160,65 +161,75 @@ describe("memory extraction triggers", () => {
         state,
         minEligibleTurns: 99,
         isTrailingRun: true,
-      }),
+      }).defer,
     ).toBe(false);
   });
 
-  it("counts the human turns waiting in an unprocessed range", () => {
-    expect(
-      eligibleTurnsInRange([
-        { role: "user", content: "one" },
-        { role: "assistant", content: "ok" },
-        { role: "user", content: "two" },
-        { role: "assistant", content: "ok" },
-      ]),
-    ).toBe(2);
-    expect(eligibleTurnsInRange([])).toBe(0);
-  });
-
-  it("does not restart the cadence when a restart cleared the counter", () => {
-    // Live shape: three daemon restarts in one run, and each one logged
-    // "deferred by eligible-turn cadence (1/3 eligible turns)" on a session
-    // that had been waiting far longer. The extraction ran once in 13 turns.
-    const restarted = createMemoryExtractionTriggerState();
+  it("lets a process that inherited a conversation extract without waiting again", () => {
+    // The counter is process-local; a daemon restart sets it to zero while
+    // the conversation it paces stays on disk. The first decision this
+    // process makes for the lane may look at the backlog instead.
+    const inherited = createMemoryExtractionTriggerState();
     expect(
       shouldDeferForEligibleTurnCadence({
-        state: restarted,
+        state: inherited,
         minEligibleTurns: undefined,
         isTrailingRun: false,
-        // The conversation shows eight human turns still unprocessed.
-        unprocessedEligibleTurns: 8,
+        laneIsCold: true,
+        unprocessedVisibleCount: COLD_LANE_BACKLOG_MESSAGES,
       }),
-    ).toBe(false);
-    expect(restarted.turnsSinceLastExtraction).toBe(0);
+    ).toEqual({ defer: false, waiting: 3 });
+    expect(inherited.turnsSinceLastExtraction).toBe(0);
   });
 
-  it("still paces a fresh session exactly as before", () => {
+  it("only does that once, so a failing extraction still paces itself", () => {
+    // A failed run leaves the cursor where it was, so the backlog stays large.
+    // If the backlog kept deciding, every turn would relaunch a full-history
+    // child. Only the first decision per lane is allowed to use it.
     const state = createMemoryExtractionTriggerState();
-    // A fresh session's range grows one human turn at a time, so the derived
-    // count and the counter agree and the cadence is unchanged.
-    const outcomes = [1, 2, 3].map((turns) =>
+    shouldDeferForEligibleTurnCadence({
+      state,
+      minEligibleTurns: undefined,
+      isTrailingRun: false,
+      laneIsCold: true,
+      unprocessedVisibleCount: 40,
+    });
+    const afterwards = [1, 2, 3].map(() =>
       shouldDeferForEligibleTurnCadence({
         state,
         minEligibleTurns: undefined,
         isTrailingRun: false,
-        unprocessedEligibleTurns: turns,
+        laneIsCold: false,
+        unprocessedVisibleCount: 40,
       }),
     );
-    expect(outcomes).toEqual([true, true, false]);
-    expect(state.turnsSinceLastExtraction).toBe(0);
+    expect(afterwards.map((result) => result.defer)).toEqual([true, true, false]);
   });
 
-  it("keeps deferring when too few turns are waiting", () => {
+  it("does not fire for a fresh session, whose backlog is one turn", () => {
+    const fresh = createMemoryExtractionTriggerState();
+    expect(
+      shouldDeferForEligibleTurnCadence({
+        state: fresh,
+        minEligibleTurns: undefined,
+        isTrailingRun: false,
+        laneIsCold: true,
+        unprocessedVisibleCount: 2,
+      }),
+    ).toEqual({ defer: true, waiting: 1 });
+  });
+
+  it("reports the waiting count it actually used", () => {
+    // The warning used to print the counter after the call, which is 0 on the
+    // turn a run is allowed; it now prints what the decision was made on.
     const state = createMemoryExtractionTriggerState();
     expect(
       shouldDeferForEligibleTurnCadence({
         state,
         minEligibleTurns: undefined,
         isTrailingRun: false,
-        unprocessedEligibleTurns: 1,
       }),
-    ).toBe(true);
+    ).toEqual({ defer: true, waiting: 1 });
   });
 
   it("parses invalid tool arguments as an empty object", () => {

--- a/runtime/tests/memory/extraction-triggers.test.ts
+++ b/runtime/tests/memory/extraction-triggers.test.ts
@@ -10,7 +10,6 @@ import {
   memoryExtractionVisibleRange,
   parseMemoryToolArguments,
   shouldDeferForEligibleTurnCadence,
-  COLD_LANE_BACKLOG_MESSAGES,
 } from "./extraction-triggers.js";
 
 describe("memory extraction triggers", () => {
@@ -165,58 +164,26 @@ describe("memory extraction triggers", () => {
     ).toBe(false);
   });
 
-  it("lets a process that inherited a conversation extract without waiting again", () => {
-    // The counter is process-local; a daemon restart sets it to zero while
-    // the conversation it paces stays on disk. The first decision this
-    // process makes for the lane may look at the backlog instead.
-    const inherited = createMemoryExtractionTriggerState();
-    expect(
-      shouldDeferForEligibleTurnCadence({
-        state: inherited,
-        minEligibleTurns: undefined,
-        isTrailingRun: false,
-        laneIsCold: true,
-        unprocessedVisibleCount: COLD_LANE_BACKLOG_MESSAGES,
-      }),
-    ).toEqual({ defer: false, waiting: 3 });
-    expect(inherited.turnsSinceLastExtraction).toBe(0);
-  });
-
-  it("only does that once, so a failing extraction still paces itself", () => {
-    // A failed run leaves the cursor where it was, so the backlog stays large.
-    // If the backlog kept deciding, every turn would relaunch a full-history
-    // child. Only the first decision per lane is allowed to use it.
-    const state = createMemoryExtractionTriggerState();
-    shouldDeferForEligibleTurnCadence({
-      state,
-      minEligibleTurns: undefined,
-      isTrailingRun: false,
-      laneIsCold: true,
-      unprocessedVisibleCount: 40,
-    });
-    const afterwards = [1, 2, 3].map(() =>
-      shouldDeferForEligibleTurnCadence({
-        state,
-        minEligibleTurns: undefined,
-        isTrailingRun: false,
-        laneIsCold: false,
-        unprocessedVisibleCount: 40,
-      }),
-    );
-    expect(afterwards.map((result) => result.defer)).toEqual([true, true, false]);
-  });
-
-  it("does not fire for a fresh session, whose backlog is one turn", () => {
+  it("gives a lane no head start for being new to this process", () => {
+    // An earlier version let the first decision in a process read the
+    // unprocessed backlog, so a restart would not wait a further cadence. A
+    // single turn with tool calls and attachments produces more messages than
+    // any threshold that heuristic could use, so it fired on the first turn of
+    // every new session and ran a full-history child there. The cadence is
+    // turn-based only; a fresh lane waits like any other.
     const fresh = createMemoryExtractionTriggerState();
-    expect(
+    const decisions = [1, 2, 3].map(() =>
       shouldDeferForEligibleTurnCadence({
         state: fresh,
         minEligibleTurns: undefined,
         isTrailingRun: false,
-        laneIsCold: true,
-        unprocessedVisibleCount: 2,
       }),
-    ).toEqual({ defer: true, waiting: 1 });
+    );
+    expect(decisions.map((decision) => decision.defer)).toEqual([
+      true,
+      true,
+      false,
+    ]);
   });
 
   it("reports the waiting count it actually used", () => {

--- a/runtime/tests/services/extractMemories/extractMemories.test.ts
+++ b/runtime/tests/services/extractMemories/extractMemories.test.ts
@@ -197,6 +197,72 @@ describe("auto memory child tool policy", () => {
     });
   });
 
+  // Live (session 2763eb6e, 2026-09-02): the child opened the shared root the
+  // main agent uses, was denied, and the run was recorded as a failed
+  // extraction with its messages re-queued.
+  describe("the shared memory root", () => {
+    const policy = () =>
+      createAutoMemoryToolPolicy("/tmp/project-memory/", ["/tmp/global-memory/"]);
+
+    it("is readable, so the child can check what is already recorded", () => {
+      expect(
+        policy()({ name: "FileRead" }, { file_path: "/tmp/global-memory/MEMORY.md" }),
+      ).toMatchObject({
+        behavior: "allow",
+        updatedInput: {
+          file_path: "/tmp/global-memory/MEMORY.md",
+          __agencSessionAllowedRoots: ["/tmp/project-memory/", "/tmp/global-memory/"],
+        },
+      });
+      expect(
+        policy()({ name: "Grep" }, { pattern: "style", path: "/tmp/global-memory/" }),
+      ).toMatchObject({ behavior: "allow" });
+      expect(
+        policy()({ name: "Glob" }, { pattern: "*.md", path: "/tmp/global-memory/" }),
+      ).toMatchObject({ behavior: "allow" });
+    });
+
+    it("is not writable, and says so", () => {
+      // The child summarizes untrusted conversation content, and this root is
+      // shared by every project on the machine.
+      const denial = policy()(
+        { name: "Write" },
+        { file_path: "/tmp/global-memory/user.md", content: "x" },
+      );
+      expect(denial).toMatchObject({
+        behavior: "deny",
+        metadata: { reason: "write_outside_memory" },
+      });
+      expect((denial as { message: string }).message).toContain(
+        "may only write to this session's project memory directory",
+      );
+    });
+
+    it("still writes to the project root and still denies everything else", () => {
+      expect(
+        policy()({ name: "Write" }, { file_path: "notes.md", content: "hello" }),
+      ).toMatchObject({
+        behavior: "allow",
+        updatedInput: {
+          file_path: "/tmp/project-memory/notes.md",
+          __agencSessionAllowedRoots: ["/tmp/project-memory/"],
+        },
+      });
+      expect(
+        policy()({ name: "FileRead" }, { file_path: "/tmp/elsewhere/secrets.md" }),
+      ).toMatchObject({ behavior: "deny" });
+    });
+
+    it("without a shared root the policy is unchanged", () => {
+      expect(
+        createAutoMemoryToolPolicy("/tmp/project-memory/")(
+          { name: "FileRead" },
+          { file_path: "/tmp/global-memory/MEMORY.md" },
+        ),
+      ).toMatchObject({ behavior: "deny" });
+    });
+  });
+
   it("denies reads outside the memory directory", async () => {
     const policy = createAutoMemoryToolPolicy("/tmp/memory/");
     expect(

--- a/runtime/tests/services/extractMemories/prompts.test.ts
+++ b/runtime/tests/services/extractMemories/prompts.test.ts
@@ -28,8 +28,23 @@ describe("memory extraction prompt", () => {
 
   it("names the memory directory the child may use", () => {
     const prompt = buildExtractAutoOnlyPrompt(1, "", false, "/home/u/.agenc/projects/p/memory");
-    expect(prompt).toContain("The memory directory is /home/u/.agenc/projects/p/memory");
-    expect(buildExtractAutoOnlyPrompt(1, "")).not.toContain("The memory directory is");
+    expect(prompt).toContain(
+      "Write to this project's memory directory only: /home/u/.agenc/projects/p/memory",
+    );
+    expect(buildExtractAutoOnlyPrompt(1, "")).not.toContain("memory directory only:");
+  });
+
+  it("names the shared root as readable and the project root as the only writable one", () => {
+    const prompt = buildExtractAutoOnlyPrompt(
+      1, "", false, "/home/u/.agenc/projects/p/memory", "/home/u/.agenc/memory",
+    );
+    expect(prompt).toContain("Write to this project's memory directory only: /home/u/.agenc/projects/p/memory");
+    expect(prompt).toContain("READ the shared memory directory /home/u/.agenc/memory");
+    expect(prompt).toContain("cannot write to it");
+    // Without a shared root the sentence is absent entirely.
+    expect(
+      buildExtractAutoOnlyPrompt(1, "", false, "/home/u/.agenc/projects/p/memory"),
+    ).not.toContain("shared memory directory");
   });
 
   it("omits index instructions when the memory index is disabled", () => {

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -8,7 +8,7 @@
  * `process_killed` abort for every clean turn.
  */
 
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   chmodSync,
   mkdirSync,
@@ -176,7 +176,20 @@ function createTestConfigStore(base?: AgenCConfig): ConfigStore {
   });
 }
 
+// Every session in this file shares the conversation id "conv-test", so they
+// share one memory-extraction lane and its eligible-turn counter. Extraction
+// therefore fires in whichever test happens to be running when the counter
+// reaches the cadence, launching a background child that samples on that
+// test's own provider. These tests are about turn mechanics, not memory, and
+// several of them count model calls or post-sampling launches exactly, so the
+// extraction fork is switched off for the file rather than being absorbed
+// into each expectation.
+beforeEach(() => {
+  vi.stubEnv("AGENC_DISABLE_EXTRACT_MEMORIES", "1");
+});
+
 afterEach(() => {
+  vi.unstubAllEnvs();
   sessionMemoryPostSamplingMockState.calls.length = 0;
   sessionMemoryPostSamplingMockState.error = null;
   clearSessionReadState("conv-test", tmpdir());
@@ -5297,14 +5310,6 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
 
   test("LP-07 clears failed streamed tool state before retrying", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.5);
-    // This test counts sampling attempts to prove the retry path does not
-    // re-send a dropped streamed tool. Memory extraction runs a background
-    // child on this same provider once a lane reaches its eligible-turn
-    // cadence, which lands inside the settle window below and is counted as a
-    // third attempt. That child has nothing to do with retry behaviour, so it
-    // is switched off here rather than being folded into the expected count.
-    vi.stubEnv("AGENC_DISABLE_EXTRACT_MEMORIES", "1");
-
     let attempts = 0;
     let staleInvocations = 0;
     let staleSawAbort = false;

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -5297,6 +5297,13 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
 
   test("LP-07 clears failed streamed tool state before retrying", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.5);
+    // This test counts sampling attempts to prove the retry path does not
+    // re-send a dropped streamed tool. Memory extraction runs a background
+    // child on this same provider once a lane reaches its eligible-turn
+    // cadence, which lands inside the settle window below and is counted as a
+    // third attempt. That child has nothing to do with retry behaviour, so it
+    // is switched off here rather than being folded into the expected count.
+    vi.stubEnv("AGENC_DISABLE_EXTRACT_MEMORIES", "1");
 
     let attempts = 0;
     let staleInvocations = 0;

--- a/runtime/tests/tools/system/signed-allowed-roots.test.ts
+++ b/runtime/tests/tools/system/signed-allowed-roots.test.ts
@@ -66,9 +66,14 @@ describe("HMAC-signed trusted filesystem roots", () => {
   // (a) FORGE: a model-supplied root with NO / a bogus signature must NOT
   // be folded into the resolved allowed paths.
   describe("FORGE — sink ignores unsigned/forged model roots", () => {
+    // The sink also folds in the two durable memory roots, which are
+    // runtime-derived and never model-supplied. Comparing against the result
+    // for the same call with no model roots keeps these assertions exact:
+    // a forged root must change nothing at all, not merely fail to appear.
+    const unforged = (): string[] => resolveToolAllowedPaths(BASE, roundTrip({}));
     it("ignores __agencSessionAllowedRoots with no signature", () => {
       const args = roundTrip({ [SESSION_ALLOWED_ROOTS_ARG]: ["/"] });
-      expect(resolveToolAllowedPaths(BASE, args)).toEqual([...BASE]);
+      expect(resolveToolAllowedPaths(BASE, args)).toEqual(unforged());
     });
 
     it("ignores __agencSessionAllowedRoots with a bogus signature", () => {
@@ -76,7 +81,7 @@ describe("HMAC-signed trusted filesystem roots", () => {
         [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
         [SESSION_ALLOWED_ROOTS_SIG_ARG]: "00".repeat(32),
       });
-      expect(resolveToolAllowedPaths(BASE, args)).toEqual([...BASE]);
+      expect(resolveToolAllowedPaths(BASE, args)).toEqual(unforged());
     });
 
     it("ignores a signature copied from a DIFFERENT root set", () => {
@@ -86,7 +91,7 @@ describe("HMAC-signed trusted filesystem roots", () => {
         [SESSION_ALLOWED_ROOTS_ARG]: ["/"],
         [SESSION_ALLOWED_ROOTS_SIG_ARG]: signAllowedRoots(["/srv/trusted"]),
       });
-      expect(resolveToolAllowedPaths(BASE, args)).toEqual([...BASE]);
+      expect(resolveToolAllowedPaths(BASE, args)).toEqual(unforged());
     });
   });
 

--- a/runtime/tests/utils/markdown-config-loader-authority.test.ts
+++ b/runtime/tests/utils/markdown-config-loader-authority.test.ts
@@ -97,6 +97,36 @@ describe('markdown discovery authority', () => {
     expect(prompt(filesB)).toBe('Home B prompt.')
   })
 
+  test('still finds markdown when the search binary cannot run', async () => {
+    // ripGrep reports an unavailable binary with code "ENOENT", which errno
+    // alone cannot tell apart from "the directory is gone", so the loader
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently vanished wherever ripgrep could not start. CI is exactly such
+    // a machine: with `rg` off PATH this reproduced as a catalog holding only
+    // the five built-in agents. The native walk is the documented fallback.
+    const workspace = temporaryRoot('workspace-no-rg')
+    const home = temporaryRoot('home-no-rg')
+    writeAgent(home, 'Found without ripgrep.')
+    const authority = await createAuthority(home, workspace)
+
+    const previousBuiltin = process.env.USE_BUILTIN_RIPGREP
+    const previousPath = process.env.PATH
+    process.env.USE_BUILTIN_RIPGREP = 'false'
+    // A PATH with no `rg` on it, which is what makes ripGrep reject.
+    process.env.PATH = temporaryRoot('empty-bin')
+    try {
+      const files = await runWithCanonicalSettingsAuthority(authority, () =>
+        loadMarkdownFilesForSubdirFresh('agents', workspace),
+      )
+      expect(prompt(files)).toBe('Found without ripgrep.')
+    } finally {
+      if (previousBuiltin === undefined) delete process.env.USE_BUILTIN_RIPGREP
+      else process.env.USE_BUILTIN_RIPGREP = previousBuiltin
+      if (previousPath === undefined) delete process.env.PATH
+      else process.env.PATH = previousPath
+    }
+  })
+
   test('isolates same-home snapshots and clears only the active ConfigStore partition', async () => {
     const workspace = temporaryRoot('shared-workspace')
     const home = temporaryRoot('shared-home')


### PR DESCRIPTION
Fixes parts A and B of #2023. Part C turned out not to be a bug; the evidence is below and the issue has been corrected. Based on `harness-memory` (#2017).

## Part A — the extraction cadence restarted with every daemon restart

Extraction runs every third eligible turn. The counter lived only in the in-process lane map, so each daemon restart began the wait again. The live run had three restarts and the extraction ran **once in thirteen turns**, each restart logging `deferred by eligible-turn cadence (1/3 eligible turns)` for a session that had been waiting far longer.

The turns waiting are recoverable from the conversation, so the decision now takes whichever is larger: what this process has counted, or what the unprocessed range shows is already waiting (`eligibleTurnsInRange`, the human messages in it). A fresh session is unaffected, because on its first turn the two agree.

No new durable state. I looked at persisting the counter first: `session_state` is written but never restored (`rollout-reconstruction.ts` ignores it), so a durable counter would have meant building a restore path through the canonical journal and extending its strict schema, for a counter. Deriving it from history is smaller and cannot drift.

## Part B — the child could not read the shared memory root

The extraction subagent tried to read `$AGENC_HOME/memory/MEMORY.md`, the root the main agent reads and writes, and got `FileRead is restricted to the memory directory: …/projects/<slug>/memory/`. It then spent turns probing, and the run was recorded as a failed extraction with its messages re-queued. The platform already unions both roots for file tools; only this policy was stricter than the platform it runs on.

Reads now cover every memory root the session owns, and the prompt names them so the child does not have to guess.

**Writes stay in the project root, deliberately.** The child summarizes untrusted conversation content, and the shared root reaches every project on the machine: a memory planted there out of one conversation would follow the user everywhere afterwards. Reading it is enough to stop the duplicate writes that motivated the issue. Extracting `user`-type memories into the shared root needs a routing rule and a narrower writer, and that is its own change. A write aimed at a readable-but-not-writable root now says exactly that instead of giving the generic denial.

## Part C — not a bug

The issue said a resumed session kept its first epoch's compaction limit, compacting at a 75k gate instead of the configured 160k window. That was my error in the run report, and re-measuring the rollout disproves it.

The gate compares `reservedTokens`. Over the run's 1,267 samples:

| | |
| --- | --- |
| maximum `reservedTokens` | 121,538 |
| both compactions fire | immediately after a sample crosses 120,000 |
| samples in 75,990 – 117,704 that did **not** compact | 312 |
| gate for a 160k window | `min(160000-13000, 0.75×160000)` = 120,000 |
| gate for a 100k window | 75,000 |

A 75,000 gate would have fired at 75,990. The 160k override was in force, in both epochs. What I had compared was the compaction transaction's `source_tokens` (97,556 — the size of the history slice being summarized), a number the gate never sees. The run report and the plan now carry the correction, and the issue is updated.

One thing the mis-diagnosis did expose, left for its own change: `getAutoCompactTokenLimit` has an `explicit` branch that would let a restored value beat live configuration if anything ever wrote one, and `turnContextForPreviousModel` merges a restored `autoCompactTokenLimit` into a live `modelInfo`. Neither fires today. Making "current configuration wins" structural means removing a seam about a dozen tests use to force compaction, which is a refactor, not a fix.

## Tests

- `tests/memory/extraction-triggers.test.ts` — the human turns waiting in a range are counted; a cleared counter with eight turns waiting no longer defers (**falsification-checked**: fails without the derived count); a fresh session still paces exactly as before; too few waiting still defers.
- `tests/services/extractMemories/extractMemories.test.ts` — the shared root is readable by FileRead, Grep and Glob; it is not writable and the denial says so; the project root still takes writes and everything outside both roots is still denied; without a shared root the policy is unchanged.
- `tests/services/extractMemories/prompts.test.ts` — the prompt names the writable root and the readable one, and says nothing about a shared root when there is none.

Memory and extraction suites green (47 tests across 4 files). `tests/memory` shows four pre-existing failures here (file-watcher mtime timing) whose names vary between runs and which fail identically on a clean tree.

## Correction after adversarial review (`664ad937d`)

Two problems with the first commit, both found by re-checking rather than by testing.

**The evidence was misattributed.** Re-parsing the rollout structurally instead of by text shows **one** daemon process restart in that run, not three: the other two `session_meta` lines are auto-compact boundaries, and sub-ids stay monotonic across them. The pair I cited as the smoking gun (`2/3` at 11990, then `1/3` at 14223) has a completed extraction child between them at 12883, and a completed run resets the counter by design, so no state was lost there. What that run actually shows is two child failures, both already fixed on this branch (the agent-name rejection and the denied-read misclassification), five turns that emit no extraction event at all (a separate bug, not touched here), and one genuinely unexplained reset at 8451. The defect this PR fixes is still real and still worth fixing — the counter is process-local and a restart clears it while the conversation stays on disk — but it is a design defect, not the reason memory was barely written in that run. The claim in the first commit message overstated it.

**The first shape would have made the failure path worse.** Taking `max(counter, backlog)` on every turn ignores that the cursor only advances when an extraction *succeeds*. A failing extraction leaves the backlog large, so every subsequent turn would have relaunched a full-history child instead of retrying on the ordinary cadence. The catch-up is now bounded to the first cadence decision a process makes for a lane: after that, the counter decides. A fresh session never triggers it, because one turn's output is far below the eight-message backlog threshold.

`shouldDeferForEligibleTurnCadence` now returns `{ defer, waiting }`, so the deferral warning prints the count the decision was actually made on rather than the counter's value after the call, which was zero on the turn a run was allowed.

Tests updated accordingly, and falsification-checked: with the cold-lane branch removed, the two new tests fail.


## Second correction (`2b11a4277`): the cold-lane bypass is gone

The bounded catch-up described above still rested on a threshold, and the
threshold was wrong. It assumed "one turn's output is far below eight
messages". A turn with tool calls and attachments produces more than eight
model-visible messages, so `laneIsCold && backlog >= 8` was true on the **first
turn of every new session**, and the bypass launched a full-history extraction
child there. That is exactly the cost the eligible-turn cadence exists to
prevent, and I asserted the opposite in a test (`unprocessedVisibleCount: 2`
for a "fresh session") instead of measuring a real turn.

Message counts cannot separate "this process inherited a conversation" from
"this process just built one". Rather than retune a threshold that cannot
work, the bypass is removed:

- `shouldDeferForEligibleTurnCadence` no longer takes `laneIsCold` or
  `unprocessedVisibleCount`, and `COLD_LANE_BACKLOG_MESSAGES` is gone.
- `ExtractionLane` no longer carries `coldDecisionPending`.
- The three tests that encoded the bad assumption are replaced by one that
  states the rule: a lane new to this process gets no head start, and defers
  twice before its first run like any other.

A restart therefore costs at most one further cadence before memory is written
again. That is a bounded delay, not lost memory. **Part A of the issue asks
for persistence, and this PR does not deliver it.** Doing it properly means
writing the cadence state into persisted session state, and the obvious slot
has a trap worth recording: `latestPersistedAgentTask` returns the `agentTask`
of the most recent `session_state` rollout item, so any `session_state` item
written for a different slot reads as "the agent task was explicitly cleared".
A correct implementation needs either a read-modify-write of both slots or a
slot-aware walker. That is filed separately rather than rushed in here.

## Why LP-07 needed a change in `run-turn.test.ts`

`LP-07 clears failed streamed tool state before retrying` counts sampling
attempts and expects exactly 2. It failed on this branch with 3.

The third call is real and is not a regression. It is the memory-extraction
child, sampling on the session's own provider. Traced to its stack: the
message list ends with a subagent task prompt, and disabling extraction with
`AGENC_DISABLE_EXTRACT_MEMORIES=1` makes the test pass with the branch
otherwise untouched.

It passed on `main` only because the child never started there: it ran under
an invalid agent name and died before reaching the model, which is one of the
defects this branch fixes. Instrumenting `runExtraction` on `main` shows it
entered four times during this file and produced no model call. So making
extraction work is what surfaced this.

The test's subject is the retry path, not background memory work, so it now
stubs `AGENC_DISABLE_EXTRACT_MEMORIES` with a comment saying why. Two
alternatives were tried and rejected: a minimum-new-messages guard before
launching a child, which contradicts a dozen existing extraction tests that
deliberately exercise two-message ranges; and folding the extra call into the
expected count, which would make an unrelated background actor part of a retry
contract.

## Verification

- `tests/session/run-turn.test.ts`: LP-07 passes. The file is left with the
  same three failures that `main` produces on this machine (`a burst of medium
  tool results`, `resolves on-disk workspace instructions`, `keeps hostile
  nested-repository instructions`), verified by running the file against a
  checkout of `main`'s `runtime/src`. CI reported only LP-07, so those three
  are local.
- `tests/memory/extraction-triggers.test.ts` and
  `tests/services/extractMemories/extractMemories.test.ts`: 38 passed.

## Merged `main` in

With LP-07 fixed, the run came back with one unrelated failure:
`tests/tools/AgentTool/loadAgentsDir.test.ts > never imports agent files
through cross-workspace file or directory symlinks`, `expected [ Array(5) ] to
include 'authority-local'`. That is #2029, now on `main`: markdown discovery
treated "ripgrep could not start" as "the directory is missing", so every
markdown-defined agent disappeared wherever `rg` is absent, which is CI.
`main` is merged here so this branch's check reports on its own change.

## Third commit (`6f552e80b`): the lane is shared, so one test was the wrong scope

Switching extraction off inside LP-07 alone moved the failure rather than
fixing it. The next run failed on `Editor turns do not launch MagicDocs or
session-memory post-sampling`, `expected [ { …(4) } ] to have a length of +0
but got 1`.

The reason is that every session in `run-turn.test.ts` is built with the
conversation id `"conv-test"`, and the extraction lane is keyed by
conversation. All 128 tests share one lane and one eligible-turn counter, so
the child fires in whichever test is running when the counter reaches the
cadence. Excluding one test just shifts which test pays.

The fork is now switched off for the whole file in a `beforeEach`, with the
existing `afterEach` clearing the stub. Giving each session a unique
conversation id would be the deeper fix, but `"conv-test"` is a shared key in
this file and others (`clearSessionReadState`, `registerMagicDoc`), so that is
a wider change than this PR should carry.

Re-verified: the file is left with exactly the three failures `main` produces
on this machine and no others.

## Fourth commit (`738df3803`): recall ignored the home the request named

The next run surfaced `tests/prompts/attachments/integration.test.ts >
relevant memories resolve through the live pipeline with an untrusted frame`,
`expected false to be true`. That one is a defect in this branch, not a test
artifact.

`durableMemorySearchDirs` was changed here to go through
`getGlobalMemoryPath()` and `getProjectMemoryPath()` so recall lands where the
memory prompt and the extraction child point, including trusted overrides.
Both resolvers read the **ambient** memory base. The producer already receives
an `agencHome` in its options, and when the two differ, recall searched the
machine's home and ignored the one the request named. A session with an
explicit home recalled nothing from its own memory, and would have read
another home's memories instead.

Traced by logging the resolved roots: with `agencHome` pointing at the test's
temporary home, the roots came back under the ambient home.

The fix keeps the resolvers authoritative when the request names the ambient
base, because only they carry the Cowork path override, the
`autoMemoryDirectory` setting and the remote root. When the request names a
different home, both roots are built from that home through the same formulas
the writers use. `getMemoryProjectRoot` is exported so the project key is
derived once in `paths.ts` rather than restated by each caller.

Verified by logging that the roots now resolve under the requested home. The
assertion itself cannot be exercised on this machine: the recall path opens
the memory index through `better-sqlite3`, and the copy in `node_modules` is
built for `NODE_MODULE_VERSION 147` (Node 26) while only Node 25 is installed
here, so the producer throws before reaching the selector. CI rebuilds the
module and is the check that closes this.

## Fifth commit (`eaa65ca06`): the filesystem tool pulled in the memory barrel

With recall fixed, CI reported `tests/tools/system/filesystem.test.ts` as a
failed **suite**, not a failed test:

```
TypeError: Cannot read properties of undefined (reading 'then')
 ❯ src/utils/envDynamic.ts:36:47
 ❯ src/utils/ide.ts:40:1
 ❯ src/utils/attachments.ts:31:1
```

`filesystem.ts` needs one function from this branch, `getDurableMemoryRoots`,
and imported it from the `memory/index.js` barrel. That barrel re-exports the
recall pipeline, which reaches `utils/ide.ts` and through it
`utils/envDynamic.ts`. On Linux that module calls `stat()` at import time to
probe for musl. The suite mocks `node:fs/promises` with a bare `vi.fn()` for
`stat`, so the call returns `undefined` and `.then` throws before any test
runs. It passes on macOS, where the probe never executes, which is why it only
showed up in CI.

The import now names the defining module, `memory/paths.js`.

**Falsification-checked** by forcing the Linux branch locally: with the barrel
import the suite fails to load with exactly the CI error and reports "no
tests"; with the narrowed import all 57 tests pass.

## Still open

The same run also failed
`tests/tools/AgentTool/inProcessRunner.compaction.test.ts > compacts its
isolated rollout, continues, and reopens without parent history leakage`
(`expected undefined to be defined`). That file fails on this machine with
`main`'s `runtime/src` checked out as well, so it is not attributable to this
branch from a local run. It is being watched on the next CI run rather than
guessed at.

## Sixth commit (`a0f088184`): the barrel import was a pattern, not one file

`tests/tools/AgentTool/inProcessRunner.compaction.test.ts > compacts its
isolated rollout, continues, and reopens without parent history leakage` was
listed above as "still open". It is closed, and it was this branch's doing.

It could not be run on this machine before: the recall path opens the memory
index through `better-sqlite3`, and the copy in `node_modules` was built for
`NODE_MODULE_VERSION 147` (Node 26) while only Node 25 is installed here.
Fetching the matching prebuild made the suite runnable, after which it
reproduced immediately: 2 failed on this branch, 2 passed with `main`'s
`runtime/src`.

Bisected by directory, then by file: `runtime/src/tools` was the group, and
`file-edit.ts` alone accounted for it. The cause is the same one behind the
`filesystem.test.ts` suite failure in the previous commit. Four files reached
`memory/index.js` for a single symbol:

| file | symbol | now imports from |
| --- | --- | --- |
| `tools/system/file-edit.ts` | `checkMemorySecrets` | `memory/privacy.js` |
| `tools/system/file-write.ts` | `checkMemorySecrets` | `memory/privacy.js` |
| `tools/FileWriteTool/FileWriteTool.ts` | `checkMemorySecrets` | `memory/privacy.js` |
| `services/extractMemories/memory-paths.ts` | `buildProjectMemoryDirectory` | `memory/paths.js` |

The barrel re-exports the whole memory surface, including the recall pipeline
and the full-corpus index, so a file needing one pure function pulled in a
large module graph.

Verified: the compaction suite and the filesystem suite pass together, 59
tests. `file-edit.test.ts` fails identically with this change, with the barrel
import, and with `main`'s `file-edit.ts` on this machine, so those 29 failures
are local and unrelated to the branch.

## Seventh commit (`43af0ab58`): the forge assertions

With the compaction and filesystem suites green, the run surfaced
`tests/tools/system/signed-allowed-roots.test.ts > FORGE — sink ignores
unsigned/forged model roots`:

```
expected [ '/srv/trusted', …(2) ] to deeply equal [ '/srv/trusted' ]
```

`resolveToolAllowedPaths` folds in the two durable memory roots on this
branch, so the model can write the memories the prompt tells it to write.
Those roots are runtime-derived and never model-supplied. The three forge
cases asserted the resolved list equals `BASE` exactly, so the extra entries
failed them.

The property they guard is that a forged or unsigned model root changes
nothing. They now compare against the same call with no model roots at all,
which keeps the comparison **exhaustive** rather than relaxing it to "the
forged root is absent": anything unexpected in the list still fails them.

**Falsification-checked**: with signature verification bypassed so unsigned
model roots are folded in, all three fail again.

## Eighth commit (`c4e27e0a5`): the contract, and why the barrel rule bends here

Narrowing those imports broke `tests/memory-wiring.contract.test.ts`, which
states the rule explicitly: code outside `runtime/src/memory` reaches memory
through the public index. The sixth commit broke that rule without saying so.

The rule cannot hold for these four files, and this branch is what makes that
true. `memory/index.js` re-exports `memory/agencmd.ts`, which imports
`utils/hooks.ts` → `utils/attachments.ts` → `tools/system/filesystem.ts`. A
tool importing the index closes a cycle, and under that cycle a module can be
evaluated before its dependencies finish initializing. That is the mechanism
behind both earlier failures: `envDynamic` calling a not-yet-defined `stat` at
import time on Linux, and the teammate compactor's rollout store never being
created. Before this branch nothing in the file tools imported memory at all,
so the back edge did not exist.

The allowlist now carries those four files with that reasoning attached, and
the `FileWriteTool` wiring assertion names `memory/privacy.js` instead of the
index. Everything else still goes through the barrel.

## Local verification against a main baseline

Because the recall path now runs here, a `main` worktree sharing the same
`node_modules` gives a real baseline. Running `tests/memory`,
`tests/services/extractMemories`, `tests/prompts/attachments`,
`tests/tools/system`, `tests/tools/AgentTool` and the wiring contract on both:

| tree | failures |
| --- | --- |
| `main` | 113 |
| this branch | 62 |

The branch fails fewer tests than `main` does on this machine, and comparing
the failing test names leaves **no test that fails here and passes on
`main`**. The two that looked branch-only on a later run
(`creates a worktree for a safe branch`, `EnterWorktree refuses when called
outside a git repository`) are one order-dependent failure in
`tests/tools/system/git-tools.test.ts`, which fails 1 of 25 on both trees when
that file is run alone.

Most of those 62 are this machine, not the code: 29 in `file-edit.test.ts`
alone fail identically with `main`'s `file-edit.ts` checked out.
