### PR TITLE
a compaction no longer truncates the transcript a person reads

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -5667,7 +5667,7 @@ function historyEpochFromRollout(
 ): string {
   return historyEpochForBoundary(
     runId,
-    latestTranscriptBoundary(items, runId)?.id ?? "initial",
+    latestTranscriptBoundary(items)?.id ?? "initial",
   );
 }
 
@@ -5680,7 +5680,6 @@ interface TranscriptBoundary {
 
 function latestTranscriptBoundary(
   items: readonly RolloutItem[],
-  runId: string,
 ): TranscriptBoundary | undefined {
   let latest: TranscriptBoundary | undefined;
   for (const [index, item] of items.entries()) {
@@ -5700,35 +5699,19 @@ function latestTranscriptBoundary(
       };
       continue;
     }
-    if (
-      item.type === "compacted" &&
-      item.payload.replacementHistory !== undefined
-    ) {
-      latest = {
-        index,
-        id: `compacted:${index}:${hashStable(JSON.stringify(item.payload.replacementHistory))}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (item.type === "compaction_committed") {
-      latest = {
-        index,
-        id: `compaction:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-      continue;
-    }
-    if (
-      item.type === "compaction_rollback_committed" &&
-      item.payload.target_session_id === runId
-    ) {
-      latest = {
-        index,
-        id: `compaction-rollback:${item.payload.attempt_id}`,
-        kind: "replaced",
-      };
-    }
+    // Compaction is deliberately NOT a transcript boundary.
+    //
+    // It changes what the MODEL sees; the person reading the transcript still
+    // sent every earlier message and expects to find them. Treating a commit
+    // as a boundary truncated the reloaded transcript to the compacted view
+    // and rendered the summary itself as a user message: live, a 13-turn
+    // session came back as two turns after an app relaunch, because that
+    // rollout contained two compaction commits and no explicit epoch event.
+    //
+    // A user-facing reset still truncates, and is still the only thing that
+    // does: `history_cleared` and `transcript_epoch` above. A partial compact
+    // or a rewind that means to reset the transcript emits `transcript_epoch`
+    // alongside its `compacted` item, so those keep working unchanged.
   }
   return latest;
 }
@@ -6092,7 +6075,7 @@ export function sessionTranscriptV2FromRollout(
   runId: string,
   activeTurn?: { readonly turnId: string; readonly clientMessageId: string },
 ): SessionTranscriptV2Result {
-  const boundary = latestTranscriptBoundary(items, runId);
+  const boundary = latestTranscriptBoundary(items);
   const boundaryIndex = boundary?.index ?? -1;
   const boundaryId = boundary?.id ?? "initial";
   let asOfSequence = 0;

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -101,6 +101,121 @@ describe("session.transcript.v2 durable projection", () => {
     expect(afterAppend.messages).toEqual(first.messages);
   });
 
+  it("keeps the whole conversation when a compaction commits without an epoch", () => {
+
+    // Compaction changes what the model sees, not what the person reading
+
+    // the transcript sent. Live: a 13-turn session came back as two turns
+
+    // after an app relaunch, because its rollout carried two compaction
+
+    // commits and no explicit epoch event, and the summary itself was
+
+    // rendered as one of those turns.
+
+    const items: RolloutItem[] = [
+
+      event(10, "user-1", {
+
+        type: "user_message",
+
+        payload: { message: "first question", messageId: "client-1" },
+
+      }),
+
+      event(11, "turn-1", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-1" },
+
+      }),
+
+      event(12, "answer-1", {
+
+        type: "agent_message",
+
+        payload: { message: "first answer" },
+
+      }),
+
+      {
+
+        type: "compaction_committed",
+
+        payload: {
+
+          attempt_id: "compact-auto-1",
+
+          replacement_history: [
+
+            { role: "developer", content: "agenc_compaction_boundary_v1: untrusted" },
+
+            { role: "user", content: "a summary of the work so far" },
+
+          ],
+
+        },
+
+      } as unknown as RolloutItem,
+
+      event(20, "user-2", {
+
+        type: "user_message",
+
+        payload: { message: "second question", messageId: "client-2" },
+
+      }),
+
+      event(21, "turn-2", {
+
+        type: "turn_started",
+
+        payload: { turnId: "turn-2" },
+
+      }),
+
+      event(22, "answer-2", {
+
+        type: "agent_message",
+
+        payload: { message: "second answer" },
+
+      }),
+
+    ];
+
+
+    const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+
+
+    expect(snapshot.messages.map((message) => message.text)).toEqual([
+
+      "first question",
+
+      "first answer",
+
+      "second question",
+
+      "second answer",
+
+    ]);
+
+    // The model's compacted view never appears as something the user said.
+
+    expect(snapshot.messages.some((message) => message.text.includes("summary of the work"))).toBe(
+
+      false,
+
+    );
+
+    // Nothing truncated, so the epoch is the initial one.
+
+    expect(snapshot.historyEpoch).toBe("history:run-1:initial");
+
+  });
+
+
   it("rebuilds from each compact/rewind replacement and advances a stable epoch", () => {
     const compacted: RolloutItem[] = [
       {


### PR DESCRIPTION
Fixes part D of tetsuo-ai/agenc-desktop#156. Core-side, and independent of the desktop changes in that issue, so it targets `main` on its own.

## Why

After an app relaunch, opening a 13-turn session rendered two turns. The truncation is invisible while the app is running, because the live view accumulates events and only the reload path reads the projection, so it looks like history vanished on restart.

## What

`latestTranscriptBoundary` treated three compaction items as transcript epochs: `compacted`, `compaction_committed` and `compaction_rollback_committed`. A boundary makes `sessionTranscriptV2FromRollout` start the transcript after it and render the reconstructed replacement history in place of everything before, so a reader saw the model's compacted view, with the compaction summary itself rendered as a user message.

Compaction changes what the **model** sees. The person reading the transcript still sent every earlier message and expects to find it. Those three branches are gone.

A user-facing reset still truncates, and is now the only thing that does: `history_cleared` and `transcript_epoch`.

## Why the existing fixtures still pass

A partial compact or a rewind that intends to reset the transcript emits `transcript_epoch` alongside its `compacted` item, and the contract test's two fixtures both carry one, so they keep selecting the same boundary and asserting the same output. What changes is only the case with no epoch event.

That case is exactly what auto compaction produces. Measured on the live rollout behind this issue: 2 `compaction_committed`, 3 `context_compacted`, and **zero** `transcript_epoch` or `history_cleared`. After the last commit the rollout holds 19 assistant and 1 user response items, which is the two turns that survived on screen.

## Tests

`tests/app-server/transcript-v2.contract.test.ts` gains "keeps the whole conversation when a compaction commits without an epoch": four real messages spanning a commit, asserting all four render in order, that the summary never appears as something the user said, and that the history epoch stays `initial` because nothing was truncated. **Falsification-checked**: restoring the `compaction_committed` branch makes it fail.

`background-agent-runner.contract.test.ts` and `transcript-v2.contract.test.ts` together: 171 passing with this change, 170 at the parent, with the same 3 pre-existing failures ([managed-thread] editor fencing, bypass authority rebase) either way. The wider `tests/app-server` suite has ~180 environment failures on this machine, present at the parent commit too and drifting between runs, mostly `daemon-cli` and socket-transport tests that spawn real daemons.

## Related, found while verifying this

The thread store's SQLite mirror drifts behind the rollout: `thread_rollout_items` holds items 0 to 3969 for a conversation whose rollout is 14,223 lines, and `threads.last_item_index` reads 0 for all 28 rows.

I first thought that was a second route to a short transcript and filed it as such. It is not, and I checked before writing a fix: `readThread({includeHistory:true})` never consults the mirror — `loadHistory` serves the live recorder or reads the rollout file directly (`thread-store/store.ts:589-618`, `:1023`). A test where a session appends after indexing passes with and without an index refresh, because the read does not look at the mirror. So the compaction boundary fixed here was the only cause of the truncation.

What remains is real but smaller and not user-visible: the mirror drifts, and `threads.last_item_index` is vestigial (it appears only in the initial migration; nothing reads or writes it). Tracked in #2028 with that corrected framing.