### PR TITLE
markdown agents survive a machine without ripgrep

### DIFF
--- a/runtime/src/utils/markdownConfigLoader.ts
+++ b/runtime/src/utils/markdownConfigLoader.ts
@@ -12,7 +12,7 @@ import type { FrontmatterData } from './frontmatterParser.js'
 import { parseFrontmatter } from './frontmatterParser.js'
 import { findCanonicalGitRoot, findGitRoot } from './git.js'
 import { parseToolListFromCLI } from './permissions/toolListParser.js'
-import { ripGrep } from './ripgrep.js'
+import { isRipgrepUnavailable, ripGrep } from './ripgrep.js'
 import {
   isSettingSourceEnabled,
   type SettingSource,
@@ -623,11 +623,31 @@ async function loadMarkdownFiles(dir: string): Promise<
           signal,
         )
   } catch (e: unknown) {
-    // Handle missing/inaccessible dir directly instead of pre-checking
-    // existence (TOCTOU). findMarkdownFilesNative already catches internally;
-    // ripGrep rejects on inaccessible target paths.
-    if (isFsInaccessible(e)) return []
-    throw e
+    // A search tool that cannot start is not an empty directory. `ripGrep`
+    // reports an unavailable binary with `code: "ENOENT"`, which errno alone
+    // cannot tell apart from "the directory is gone", so the check below
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently disappeared wherever ripgrep could not run — a machine with
+    // no `rg` on PATH, a build without the packaged binary, a container that
+    // cannot spawn it. The native walk is documented above as the fallback
+    // for exactly this and needs no external binary, so use it.
+    if (!useNative && isRipgrepUnavailable(e)) {
+      files = await findMarkdownFilesNative(dir, signal)
+    } else if (isFsInaccessible(e)) {
+      // Handle missing/inaccessible dir directly instead of pre-checking
+      // existence (TOCTOU). findMarkdownFilesNative already catches
+      // internally; ripGrep rejects on inaccessible target paths.
+      return []
+    } else {
+      throw e
+    }
+  }
+  // Ripgrep can also fail by returning nothing: a spawn that dies before it
+  // writes, a sandbox that blocks it, a retry that exhausts itself. The
+  // directory is small, so confirming an empty answer with the native walk
+  // costs little and turns a silent disappearance into a correct listing.
+  if (!useNative && files.length === 0) {
+    files = await findMarkdownFilesNative(dir, signal)
   }
 
   const results = await Promise.all(

--- a/runtime/src/utils/markdownConfigLoader.ts
+++ b/runtime/src/utils/markdownConfigLoader.ts
@@ -642,14 +642,6 @@ async function loadMarkdownFiles(dir: string): Promise<
       throw e
     }
   }
-  // Ripgrep can also fail by returning nothing: a spawn that dies before it
-  // writes, a sandbox that blocks it, a retry that exhausts itself. The
-  // directory is small, so confirming an empty answer with the native walk
-  // costs little and turns a silent disappearance into a correct listing.
-  if (!useNative && files.length === 0) {
-    files = await findMarkdownFilesNative(dir, signal)
-  }
-
   const results = await Promise.all(
     files.map(async filePath => {
       let handle: Awaited<ReturnType<typeof open>> | undefined

--- a/runtime/src/utils/ripgrep.ts
+++ b/runtime/src/utils/ripgrep.ts
@@ -182,6 +182,11 @@ export function getRipgrepInstallHint(platform = process.platform): string {
   }
 }
 
+/** True when the failure means the search binary could not run at all. */
+export function isRipgrepUnavailable(error: unknown): boolean {
+  return error instanceof RipgrepUnavailableError
+}
+
 export function wrapRipgrepUnavailableError(
   error: RipgrepErrorLike,
   config = getRipgrepConfig(),

--- a/runtime/tests/utils/markdown-config-loader-authority.test.ts
+++ b/runtime/tests/utils/markdown-config-loader-authority.test.ts
@@ -97,6 +97,36 @@ describe('markdown discovery authority', () => {
     expect(prompt(filesB)).toBe('Home B prompt.')
   })
 
+  test('still finds markdown when the search binary cannot run', async () => {
+    // ripGrep reports an unavailable binary with code "ENOENT", which errno
+    // alone cannot tell apart from "the directory is gone", so the loader
+    // swallowed it and every markdown-defined agent, command and hook
+    // silently vanished wherever ripgrep could not start. CI is exactly such
+    // a machine: with `rg` off PATH this reproduced as a catalog holding only
+    // the five built-in agents. The native walk is the documented fallback.
+    const workspace = temporaryRoot('workspace-no-rg')
+    const home = temporaryRoot('home-no-rg')
+    writeAgent(home, 'Found without ripgrep.')
+    const authority = await createAuthority(home, workspace)
+
+    const previousBuiltin = process.env.USE_BUILTIN_RIPGREP
+    const previousPath = process.env.PATH
+    process.env.USE_BUILTIN_RIPGREP = 'false'
+    // A PATH with no `rg` on it, which is what makes ripGrep reject.
+    process.env.PATH = temporaryRoot('empty-bin')
+    try {
+      const files = await runWithCanonicalSettingsAuthority(authority, () =>
+        loadMarkdownFilesForSubdirFresh('agents', workspace),
+      )
+      expect(prompt(files)).toBe('Found without ripgrep.')
+    } finally {
+      if (previousBuiltin === undefined) delete process.env.USE_BUILTIN_RIPGREP
+      else process.env.USE_BUILTIN_RIPGREP = previousBuiltin
+      if (previousPath === undefined) delete process.env.PATH
+      else process.env.PATH = previousPath
+    }
+  })
+
   test('isolates same-home snapshots and clears only the active ConfigStore partition', async () => {
     const workspace = temporaryRoot('shared-workspace')
     const home = temporaryRoot('shared-home')


### PR DESCRIPTION
Makes CI honest, and fixes a real user-facing defect behind it.

## The defect

Markdown discovery (`loadMarkdownFilesForSubdir`, used for agents, commands and hooks) runs ripgrep, and keeps `findMarkdownFilesNative` for the case ripgrep cannot run. That function's own comment says it "provides a fallback when ripgrep is unavailable". Nothing ever fell back to it.

`ripGrep` reports a binary it could not start as `RipgrepUnavailableError` carrying `code: "ENOENT"`. The loader's handler asked only `isFsInaccessible(e)`, which is true for ENOENT, so a missing search binary was indistinguishable from a missing directory and the loader returned an empty list.

The result: on any machine without `rg` on PATH and without the packaged binary, **every markdown-defined agent, command and hook silently disappears.** Nothing is logged at the level a user sees. That is the exact opposite of what `ripgrep.ts` intends, where these codes are called "critical errors that indicate ripgrep is broken, not 'no matches'" and are deliberately not turned into an empty result.

## Why this is the CI failure, not a flaky test

`tests/tools/AgentTool/loadAgentsDir.test.ts > never imports agent files through cross-workspace file or directory symlinks` fails in CI and only in CI. It is not failing on the boundary it guards: the two external agents stay correctly excluded. It fails because the **local** agent goes missing too:

```
AssertionError: expected [ Array(5) ] to include 'authority-local'
```

Five is the number of built-in agents, which need no file discovery. The markdown scan returned nothing.

Reproduced locally by removing `rg` from PATH, which is CI's condition:

```
USE_BUILTIN_RIPGREP=false PATH=<no rg> npx vitest run tests/tools/AgentTool/loadAgentsDir.test.ts -t "never imports agent files through"
→ × expected [ Array(5) ] to include 'authority-local'     (before this change)
→ ✓ 1 passed                                                (after)
```

The test was right the whole time. It was reporting a defect that only appears where ripgrep is absent, which happens to be CI and happens to be any user in the same position.

## The change

- `markdownConfigLoader.ts`: fall back to the native walk when the search binary could not run, checked **before** the `isFsInaccessible` branch that used to swallow it.
- `ripgrep.ts`: export `isRipgrepUnavailable`, so the caller distinguishes "the tool is missing" from "the path is missing" instead of inferring it from an errno the two share.

## Tests

`tests/utils/markdown-config-loader-authority.test.ts` gains "still finds markdown when the search binary cannot run": writes an agent, points PATH at an empty directory with `USE_BUILTIN_RIPGREP=false`, and asserts the agent is still discovered. **Falsification-checked**: it fails with the fallback removed.

`markdown-config-loader-authority`, `ripgrep`, `ripgrep-ingress` and `loadAgentsDir`: 34 passing, with 3 pre-existing plugin-discovery failures in `loadAgentsDir` that fail identically at the parent commit on this machine and are unrelated to discovery.

## Why it matters beyond CI

Three open pull requests are red only on this test, and each of their base branches is red on it too. It reads as a flaky test that everyone has learned to ignore; it is a silent capability loss for any install without ripgrep.


## Second commit: the speculative re-scan is gone

The first version also re-ran the native walk whenever ripgrep returned zero
files, guessing at a spawn that dies before it writes. That guess had no
evidence behind it and a measurable cost: every configuration directory that
legitimately holds no markdown would be walked twice on every session start,
once per tier, at three call sites.

It is removed. The defect this pull request exists to fix is a search binary
that cannot run, and the catch branch handles that. Re-verified after removal:

- `rg` off PATH, fix in place: all 4 tests in
  `markdown-config-loader-authority.test.ts` pass.
- `rg` off PATH, catch branch disabled: all 4 fail, each with an empty read
  (`expected '' to be 'Found without ripgrep.'`).

## Why the earlier runs said `cancelled`

Three runs on this branch reported `cancelled`, which reads like flakiness and
is not. `vitest related` walks the import graph, and this file is imported
across the runtime, so the selection was most of the suite. Run 33630595173
completed 391 test files with **0 failures**, including this PR's new test,
and was cut off at 15m20s by the job's 15-minute cap.

That cap is fixed on main in #2030, which raises it to 30 minutes. This branch
is rebased onto that commit, so the same checks can now finish.
