### PR TITLE
the fast-check gate can finish a run it starts

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -23,7 +23,14 @@ jobs:
   affected-tests:
     name: affected-tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # `vitest related` walks the import graph, so a change to a widely imported
+    # module (a util, a config loader) selects most of the suite, not a handful
+    # of files. At the runner's two workers that is ~20 minutes of tests, and
+    # the old 15-minute cap cancelled the job mid-run: the gate reported
+    # `cancelled` with zero failures, so a correct change could never go green
+    # and the module was effectively unmergeable. Other jobs in this repo
+    # already allow 30-60 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Why

`pr-fast` selects tests with `vitest related`, which walks the import graph
from the changed files. For a leaf module that picks a handful of test files.
For a widely imported one, a util or a config loader, it picks most of the
suite.

At the runner's two workers that is roughly twenty minutes of tests, and the
job was capped at fifteen. GitHub cancelled it part-way through, so the check
reported `cancelled`, not `failure`, with zero failing tests.

The effect is a false negative that no author can act on. PR #2029 changes
`runtime/src/utils/markdownConfigLoader.ts`, a module imported across the
runtime. Its last run got through 391 test files with 0 failures, including
the new test for the change, and was then cancelled at 15m20s. Every re-run
did the same. While branch protection requires this check, a correct change to
a shared module cannot be merged.

## What changed

`.github/workflows/pr-fast.yml` — `timeout-minutes` on the `affected-tests`
job goes from 15 to 30, with a comment recording why. Nothing else in the job
changes: same trigger, same concurrency group, same install, same
`npm run test:fast -- --base "$BASE_SHA"`.

## Evidence

Run 33630595173 on `fix-markdown-discovery-without-ripgrep`, a fresh run with
no re-run racing it:

- job `affected-tests`, `cancelled`, started 12:33:40Z, ended 12:49:00Z
- step 6 `Run fast checks` is the cancelled step, steps 1-5 all succeeded
- 391 test files completed, 0 failed
- still running the `tests/tui/coverage-swarm/` files when the cap hit

For comparison, recent `pr-fast` runs on branches that touch narrower modules
finish in 3 to 8 minutes and report `success` or `failure` normally. The two
runs that report `cancelled` are both this one branch.

Sizing: 391 files in about 13 minutes of test time is roughly 30 files per
minute, so the full set needs about 20 minutes plus 2 minutes of setup. 30
leaves headroom without hiding a genuine hang.

## Tests

No test change. This is a CI job limit, not runtime behaviour, and there is no
test surface for a workflow timeout. The check on this PR is itself the
evidence: it exercises the edited workflow.

## Not changed

- `--maxWorkers=2` stays. The hosted runner has two cores, so raising it would
  oversubscribe rather than speed anything up.
- `cancel-in-progress: true` stays. It is correct for superseded pushes.
- No change to which tests are selected. Narrowing the related set would mean
  running fewer tests on the changes most likely to break things.
- No change to any other workflow.

## Counterpart PRs

Unblocks #2029, which cannot reach green until this lands. #2024, #2025 and
#2026 fail on test content rather than the cap, so this does not affect them.
