### PR TITLE
give the fast-check gate headroom over its own measured runtime

### DIFF
--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -24,13 +24,18 @@ jobs:
     name: affected-tests
     runs-on: ubuntu-24.04
     # `vitest related` walks the import graph, so a change to a widely imported
-    # module (a util, a config loader) selects most of the suite, not a handful
-    # of files. At the runner's two workers that is ~20 minutes of tests, and
-    # the old 15-minute cap cancelled the job mid-run: the gate reported
-    # `cancelled` with zero failures, so a correct change could never go green
-    # and the module was effectively unmergeable. Other jobs in this repo
-    # already allow 30-60 minutes.
-    timeout-minutes: 30
+    # module (a util, a config loader, a schema) selects most of the suite, not
+    # a handful of files. At the runner's two workers that is most of an hour
+    # of tests on the larger branches.
+    #
+    # This cap was 15, which cancelled such a job mid-run: the gate reported
+    # `cancelled` with zero failures, so a correct change could never go green.
+    # Raising it to 30 was still too tight, and measurably so: across the
+    # harness branches the runs that finished took 22, 25, 27, 29, 29 and 29
+    # minutes, while three others were cancelled at exactly 30. A gate that
+    # coin-flips on wall time is not a gate. 60 leaves real headroom and
+    # matches the longest job this repo already allows in platform-tests.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Why

`pr-fast` selects tests with `vitest related`, which walks the import graph
from the changed files. On the harness branches, which touch utils, config
loaders and schemas, that selects most of the suite. At the runner's two
workers those runs take most of an hour.

The cap went 15 to 30 in #2030, after a 15-minute job was cancelled mid-run.
30 turns out to sit inside the range these jobs actually take, so the gate has
been deciding on wall time rather than on tests.

Measured across the harness branches, from `gh run list` on `pr-fast`:

| conclusion | duration | branch |
| --- | --- | --- |
| success | 22m | issue-2023-memory-survives-restart |
| success | 25m | harness-daemon |
| success | 27m | harness-daemon |
| success | 29m | harness-compaction-accounting |
| success | 29m | harness-memory |
| success | 29m | harness-tools |
| cancelled | 30m | harness-llm |
| cancelled | 30m | harness-tools |
| cancelled | 30m | harness-tools |

Every finished run is within three minutes of the cap and every cancellation
is exactly at it. That is a coin flip, and its failure mode is the worst kind:
a `cancelled` conclusion with **zero failing tests**, which reads as flakiness
and costs a full diagnosis each time. Two of those three cancellations were
diagnosed as concurrency races before the durations made the real cause plain.

## What changed

`.github/workflows/pr-fast.yml` — `timeout-minutes` on the `affected-tests`
job goes from 30 to 60, and the comment now records the measurements rather
than an estimate. Nothing else changes: same trigger, same concurrency group,
same install, same `npm run test:fast -- --base "$BASE_SHA"`.

## Evidence

Run 33665219666 on `harness-llm`, head `d8abb4710`:

- job `affected-tests`, `cancelled`
- started 18:06:57Z, ended 18:37:19Z — 30m22s
- steps 1-5 all succeeded; step 6 `Run fast checks` is the cancelled one
- no newer run superseded it, so this is the timeout, not the concurrency
  group

## Tests

No test change. This is a CI job limit, not runtime behaviour, and there is no
test surface for a workflow timeout. The check on this PR exercises the edited
workflow.

## Not changed

- `--maxWorkers=2` stays: the hosted runner has two cores, so raising it would
  oversubscribe rather than help.
- `cancel-in-progress: true` stays; it is correct for superseded pushes.
- No change to which tests are selected. Narrowing the related set would mean
  running fewer tests on exactly the changes most likely to break things.
- No other workflow is touched.

## Counterpart PRs

Unblocks #2015 and #2018, whose runs are being cancelled at the cap rather
than failing. #2030 was the first step of the same fix.
