### PR TITLE
the recovered-row wake test drives the kernel clock instead of the wall clock

### DIFF
--- a/runtime/tests/budget/execution-admission-kernel.test.ts
+++ b/runtime/tests/budget/execution-admission-kernel.test.ts
@@ -256,7 +256,15 @@ describe("ExecutionAdmissionKernel recovery", () => {
 
   it("wakes a recovered row when its durable availability time arrives", async () => {
     await leaveDetachedQueue("delayed-run");
-    const availableAt = new Date(Date.now() + 100).toISOString();
+    // The kernel gates dispatch on its own clock, so this test drives that
+    // clock instead of racing the real one. Pinning the availability a fixed
+    // wall-clock distance ahead made the assertion below depend on how long
+    // the restart underneath it took: on a loaded machine the reopen, the
+    // hydration scan and the bind can outlast that distance, the row becomes
+    // available before the acquire is even measured, and the kernel is right
+    // to admit it.
+    let clock = new Date();
+    const availableAt = new Date(clock.getTime() + 100).toISOString();
     const driver = openStateDatabases({ cwd, agencHome: home });
     driver
       .prepareState<[string, string]>(
@@ -271,6 +279,7 @@ describe("ExecutionAdmissionKernel recovery", () => {
       limits: LIMITS,
       ownerId: "delayed-restart",
       ownerPid: process.pid,
+      now: () => clock,
     });
     kernels.add(value);
     expect(value.initializeExistingState()).toMatchObject({
@@ -282,6 +291,10 @@ describe("ExecutionAdmissionKernel recovery", () => {
     expect(value.activeCount).toBe(0);
     expect(value.queuedCount).toBe(1);
 
+    // Availability arrives. The wake timer the kernel armed re-reads this
+    // clock, so the row is dispatched from the durable queue, not from the
+    // test having waited long enough.
+    clock = new Date(Date.parse(availableAt) + 1);
     const lease = await pending;
     expect(lease.request.step.runId).toBe("delayed-run");
     client.reconcile(lease.reservation.reservationId, {


### PR DESCRIPTION
## Why

`ExecutionAdmissionKernel recovery > wakes a recovered row when its durable
availability time arrives` fails intermittently in CI with:

```
AssertionError: expected 1 to be +0
  tests/budget/execution-admission-kernel.test.ts:282  expect(value.activeCount).toBe(0)
```

The test pins the recovered row's `available_at` to `Date.now() + 100` and
then, against the real clock, closes a state driver, constructs a second
kernel, runs `initializeExistingState()` over the project tree, binds a client
and issues an acquire before asserting that nothing is active yet. Every one of
those steps is real I/O. When they together exceed 100 ms the availability has
already arrived, `#drainQueue` correctly admits the row (it gates on
`Date.parse(entry.record.availableAt) > this.#now().getTime()`), and the
assertion fails. The assertion is right; its premise had expired.

Recent CI timings show it sitting on that edge, and it has now surfaced on two
unrelated branches, which is what makes it worth fixing centrally rather than
per branch:

- `harness-compaction-gates`, run 33653574870
- `harness-llm`, run 33669737329

## What changed

`runtime/tests/budget/execution-admission-kernel.test.ts` — the availability
window is measured on a clock the test owns instead of the wall clock. The
kernel already accepts an injected `now`, and the neighbouring "ages an old
low-priority row" case in the same file uses exactly that idiom. The
availability sits 100 ms ahead of a pinned `clock`, the queued assertions run
against that pinned value however slow the restart underneath them was, and
the test then advances `clock` past `availableAt`. The wake timer `scheduleAt`
armed re-reads the same injected clock, so it dispatches from the durable queue
on the next re-check.

No assertion changed. `expect(value.activeCount).toBe(0)` and
`expect(value.queuedCount).toBe(1)` are byte-identical to their previous form,
and the test still proves what it was written to prove: a row that is not yet
available stays queued, and the kernel wakes it when its durable availability
arrives.

No product code is touched.

## Evidence

The failure is not caused by any branch. On `origin/main`, injecting a 150 ms
stall right after `const availableAt = new Date(Date.now() + 100)` reproduces
the CI failure exactly: same test, same message, same assertion line.

With the injected clock the test survives a 500 ms stall, five times the window
that broke it, and reverting the change under that same stall brings
`expected 1 to be +0` straight back.

Mutation-tested, so the test still discriminates: neutering the availability
gate in `#drainQueue` makes it fail with the identical `expected 1 to be +0`,
and neutering the wake re-arm makes it fail with `Test timed out in 30000ms`.
It still kills both behaviours it is named for.

On this machine the file has six pre-existing environmental failures
(`admission_step_workspace_conflict`, from the macOS `/var` to `/private/var`
symlink) that are identical on `main` and with this change, so they are not
attributable to it.

## Tests

No new test. This is a determinism fix to an existing one, and the mutation
checks above are what establish it still has teeth.

## Not changed

- No product code, and nothing under `runtime/src`.
- The other timing-sensitive cases in this file are untouched; only the one
  that was failing is converted.

## Counterpart PRs

Unblocks #2015 and #2013, which both hit this on their own gates.
