### PR TITLE
test(runtime): assert live and replayed duplicate submissions share the turn terminal

### DIFF
--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -9392,8 +9392,11 @@ describe("AgenC delegate background-agent runner", () => {
       const terminal = outcome === "errored"
         ? { code: 1, message: "provider failed" }
         : { code: 0, message: "full answer" };
-      await expect(runner.submitAgentMessage(conversationId, request)).resolves.toMatchObject({ terminal, turnId: "turn-1" });
-      await expect(runner.submitAgentMessage(conversationId, request)).resolves.toMatchObject({ disposition: "duplicate", duplicateState: "completed", terminal });
+      const live = await runner.submitAgentMessage(conversationId, request);
+      expect(live).toMatchObject({ terminal, turnId: "turn-1" });
+      const duplicate = await runner.submitAgentMessage(conversationId, request);
+      expect(duplicate).toMatchObject({ disposition: "duplicate", duplicateState: "completed", terminal });
+      expect(duplicate.terminal).toEqual(live.terminal);
       expect(control.sendInput).toHaveBeenCalledOnce();
       await expect(runner.getAgentSnapshot(conversationId)).resolves.toMatchObject({ status: "idle" });
       await expect(runner.getAgentSessionTranscriptV2(conversationId, { sessionId: "session_1" })).resolves.toMatchObject({
@@ -9408,7 +9411,9 @@ describe("AgenC delegate background-agent runner", () => {
       }
       const restored = makeTopLevelRunner({ conversationId, rolloutItems: [...rolloutItems] });
       await restored.runner.startAgent({ objective: "restored", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
-      await expect(restored.runner.submitAgentMessage(conversationId, request)).resolves.toMatchObject({ disposition: "duplicate", duplicateState: "completed", terminal });
+      const replayed = await restored.runner.submitAgentMessage(conversationId, request);
+      expect(replayed).toMatchObject({ disposition: "duplicate", duplicateState: "completed", terminal });
+      expect(replayed.terminal).toEqual(live.terminal);
       expect(restored.control.sendInput).not.toHaveBeenCalled();
       await expect(runner.submitAgentMessage(conversationId, { ...request, content: "next", originalContent: "next", messageId: "next-message", streamId: "next-message" })).resolves.toMatchObject({ disposition: "started" });
     },


### PR DESCRIPTION
## Why

Durable `error` events carried two meanings: mid-turn diagnostics (`stop_hook_threw`, compaction, editor-policy) and genuine terminal turn failure (`ThreadAgentStatus.errored`). After #1937 stopped closing turns on every `error`, real failures with no later `turn_complete`/`turn_aborted` could no longer settle safely. Fixes #1938.

## Scope

- Add durable `turn_failed` to `EventMsg` / validators / `KNOWN_EVENT_TYPES` / durable set
- Central classifier `turnLifecycleTerminalFromEvent` (new writers use `turn_failed`; readers keep a bounded legacy rule for `background_agent_error` and `payload.terminal === true` only)
- Emit `turn_failed` from `eventFromThreadStatus` and TUI `transcriptEventFromAgentStatus`
- Consumers: `messageTerminalFrom*`, `sessionTranscriptV2FromRollout`, `agentStatusFromEvent`, daemon/TUI terminal tracking, truncation/reconstruction helpers

## Tradeoffs

Legacy journals still classify two old `error` shapes as failures so replay stays correct. New journals never write those shapes as terminals.

## Blast Radius

Runtime event contract, background-agent/daemon projection, transcript.v2, agent status, TUI turn activity. Diagnostic `error` remains non-terminal.

## Verification

`npx vitest run` on:
- `tests/session/turn-lifecycle-terminal.test.ts`
- `tests/agents/status.test.ts`
- `tests/app-server/transcript-v2.contract.test.ts`
- `tests/session/event-log.test.ts`
- `tests/state/recovery-journal-contract.test.ts`
- `tests/tui/session-transcript.error-ends-turn.test.ts`

Result: 104 passed (6 files).

Made with [Cursor](https://cursor.com)