### PR TITLE
test(runtime): retry lost SIGTERM in daemon-cli teardowns

### DIFF
--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -560,6 +560,66 @@ async function waitForPid(pidPath: string): Promise<number> {
   throw new Error("timed out waiting for daemon pid");
 }
 
+/**
+ * How long {@link stopRunningDaemons} waits for the runs to settle once its
+ * SIGTERM loop has given up. Bounded so a daemon that never stops fails with a
+ * named error instead of the case dying on the vitest deadline.
+ */
+const DAEMON_STOP_GRACE_MS = 2_000;
+
+/**
+ * Shuts foreground daemons down without depending on when they installed
+ * their signal handlers.
+ *
+ * runAgenCDaemonCli only calls installAgenCShutdownSignalHandlers after its
+ * services are constructed. The test signal process has no default action, so
+ * a single SIGTERM emitted before that point is dropped, the daemon keeps
+ * running, and the awaited run promise never settles -- the test then dies on
+ * the vitest deadline with no indication of what it was waiting for. Repeating
+ * the signal until the runs settle closes that window; the handler's own
+ * `settled` guard makes the extra signals no-ops.
+ *
+ * Every wait here is bounded. Falling through to an unbounded await on runs
+ * that never settle would reintroduce exactly the content-free
+ * "Test timed out" this helper exists to remove, only later, against the
+ * widened case timeout.
+ */
+async function stopRunningDaemons(
+  daemons: readonly {
+    readonly signalProcess: ReturnType<typeof createSignalProcess>;
+    readonly running: Promise<number>;
+  }[],
+): Promise<void> {
+  let running = true;
+  let signalsSent = 0;
+  const startedAt = Date.now();
+  const settled = Promise.allSettled(
+    daemons.map((daemon) => daemon.running),
+  ).finally(() => {
+    running = false;
+  });
+  const deadline = startedAt + DEFAULT_DAEMON_READY_TIMEOUT_MS;
+  while (running && Date.now() < deadline) {
+    for (const daemon of daemons) daemon.signalProcess.emit("SIGTERM");
+    signalsSent += daemons.length;
+    await Promise.race([settled, delay(25)]);
+  }
+  if (running) {
+    const stopped = await Promise.race([
+      settled.then(() => true),
+      delay(DAEMON_STOP_GRACE_MS).then(() => false),
+    ]);
+    if (!stopped) {
+      throw new Error(
+        `daemon did not stop after ${signalsSent} SIGTERM${
+          signalsSent === 1 ? "" : "s"
+        } over ${Date.now() - startedAt} ms`,
+      );
+    }
+  }
+  await settled;
+}
+
 async function availableLoopbackPort(): Promise<number> {
   const server = createServer();
   server.listen(0, "127.0.0.1");
@@ -1014,9 +1074,10 @@ describe("AgenC daemon CLI", () => {
       const secondUrl = await waitForDaemonWebSocketUrl(secondIo);
       expect(firstUrl).not.toBe(secondUrl);
     } finally {
-      firstSignalProcess.emit("SIGTERM");
-      secondSignalProcess.emit("SIGTERM");
-      await Promise.allSettled([firstRunning, secondRunning]);
+      await stopRunningDaemons([
+        { signalProcess: firstSignalProcess, running: firstRunning },
+        { signalProcess: secondSignalProcess, running: secondRunning },
+      ]);
       await rm(firstHome, { recursive: true, force: true });
       await rm(secondHome, { recursive: true, force: true });
     }
@@ -1365,13 +1426,12 @@ describe("AgenC daemon CLI", () => {
       expect(out).toMatch(/memory: rss=[\d.]+ MiB/);
       expect(out).toMatch(/sessions: active=\d+, closed=\d+, total=\d+/);
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -2659,14 +2719,15 @@ describe("AgenC daemon CLI", () => {
       });
       expect(spawnCount).toBe(0);
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running: foreground }]);
       stopped = true;
       await expect(foreground).resolves.toBe(0);
     } finally {
       publishForeground();
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await foreground.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running: foreground }]).catch(
+          () => {},
+        );
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3039,13 +3100,12 @@ token_cap = 123
       );
       expect(io.stderrText()).toContain("AgenC daemon config reloaded");
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
       updateRuntimeConfig.mockRestore();
@@ -3144,13 +3204,12 @@ workspace = ${JSON.stringify(workspaceB)}
       );
       expect(workspaceARead.body).toContain("ADMISSION_IDENTITY_REQUIRED");
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await Promise.all([
         rm(agencHome, { recursive: true, force: true }),
@@ -3256,13 +3315,12 @@ workspace = ${JSON.stringify(process.cwd())}
       expect(host.terminatedPids).toEqual([]);
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4100);
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3436,8 +3494,7 @@ workspace = ${JSON.stringify(process.cwd())}
       ).toEqual(replacement);
     } finally {
       await releaseLifecycleLock?.();
-      signalProcess.emit("SIGTERM");
-      await running.catch(() => {});
+      await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -3532,8 +3589,7 @@ workspace = ${JSON.stringify(process.cwd())}
       ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        signalProcess.emit("SIGTERM");
-        await running;
+        await stopRunningDaemons([{ signalProcess, running }]);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3644,8 +3700,7 @@ workspace = ${JSON.stringify(process.cwd())}
       reloadSocket?.destroy();
       shutdownSocket?.destroy();
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        signalProcess.emit("SIGTERM");
-        await running;
+        await stopRunningDaemons([{ signalProcess, running }]);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3863,7 +3918,7 @@ backend = "local"
       ).identity?.daemon,
     );
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -3913,7 +3968,7 @@ backend = "local"
     expect(line.error?.data?.code).toBe("CONNECTION_AUTHENTICATION_FAILED");
     await expect(waitForSocketClose(socket)).resolves.toBe("closed");
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4053,7 +4108,7 @@ backend = "local"
       expect(resolvedThreadIds).toEqual([]);
       socket.end();
     } finally {
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       await expect(running).resolves.toBe(0);
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4146,7 +4201,7 @@ backend = "local"
 
     socket.close();
     await waitForWebSocketClose(socket);
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4241,13 +4296,12 @@ backend = "local"
         initialSnapshots,
       );
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4340,13 +4394,12 @@ backend = "local"
       });
       expect(permissionAgentIds).toEqual([created.agentId]);
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4394,7 +4447,7 @@ backend = "local"
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
     expect(io.stdoutText()).toContain("AgenC daemon running");
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
@@ -4429,7 +4482,7 @@ port = 0
       "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
     );
     expect(io.stderrText()).not.toContain("AgenC MCP server listening");
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
@@ -4464,7 +4517,7 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(io.stderrText()).toMatch(
       /AgenC MCP server listening on http:\/\/127\.0\.0\.1:\d+\/mcp/,
     );
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
@@ -4566,13 +4619,12 @@ snapshot_max_bytes = 64
         readSnapshotTimes(agencHome, process.cwd(), "session-retention-bytes"),
       ).toEqual(["2026-05-06T00:00:01.000Z"]);
 
-      signalProcess.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess, running }]);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4832,7 +4884,7 @@ snapshot_max_bytes = 64
       expect.objectContaining({ displayUserMessage: "continue" }),
     );
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-restart"),
@@ -4912,7 +4964,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5022,7 +5074,7 @@ snapshot_max_bytes = 64
     expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
       "cancelled",
     );
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5121,7 +5173,7 @@ snapshot_max_bytes = 64
       expect(restoredOptions[0]?.deferSessionStartHooks).toBe(true);
       expect(restoredOptions[0]?.deferAgentStartupSideEffects).toBeUndefined();
 
-      firstSignal.emit("SIGTERM");
+      await stopRunningDaemons([{ signalProcess: firstSignal, running: first }]);
       firstStopped = true;
       await expect(first).resolves.toBe(0);
       const suspended = readCanonicalRunLifecycle(rolloutPath);
@@ -5209,7 +5261,9 @@ snapshot_max_bytes = 64
         }),
       );
 
-      secondSignal.emit("SIGTERM");
+      await stopRunningDaemons([
+        { signalProcess: secondSignal, running: second },
+      ]);
       secondStopped = true;
       await expect(second).resolves.toBe(0);
       expect(
@@ -5217,12 +5271,14 @@ snapshot_max_bytes = 64
       ).toEqual(["run_suspended", "run_resumed", "run_suspended"]);
     } finally {
       if (!firstStopped && first !== undefined) {
-        firstSignal.emit("SIGTERM");
-        await first.catch(() => {});
+        await stopRunningDaemons([
+          { signalProcess: firstSignal, running: first },
+        ]).catch(() => {});
       }
-      if (!secondStopped && second !== undefined) {
-        secondSignal?.emit("SIGTERM");
-        await second.catch(() => {});
+      if (!secondStopped && second !== undefined && secondSignal !== undefined) {
+        await stopRunningDaemons([
+          { signalProcess: secondSignal, running: second },
+        ]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -5361,7 +5417,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-replay"),
@@ -5488,7 +5544,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -5598,7 +5654,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -5751,7 +5807,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -5818,7 +5874,7 @@ snapshot_max_bytes = 64
       1,
     );
 
-    firstSignal.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess: firstSignal, running: first }]);
     await expect(first).resolves.toBe(0);
     // The harness can only stop gracefully; reset the row to simulate a crash
     // after proving agent.create produced the running row and session snapshot.
@@ -5958,7 +6014,9 @@ snapshot_max_bytes = 64
       },
     });
 
-    secondSignal.emit("SIGTERM");
+    await stopRunningDaemons([
+      { signalProcess: secondSignal, running: second },
+    ]);
     await expect(second).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -6028,7 +6086,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
     await expect(running).resolves.toBe(0);
 
     await rm(otherCwd, { recursive: true, force: true });
@@ -6051,7 +6109,7 @@ snapshot_max_bytes = 64
     );
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
-    signalProcess.emit("SIGTERM");
+    await stopRunningDaemons([{ signalProcess, running }]);
 
     await expect(running).resolves.toBe(1);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
@@ -6714,8 +6772,7 @@ describe("daemon startup proxy isolation", () => {
     try {
       await waitForDaemonWebSocketUrl(io);
     } finally {
-      signalProcess.emit("SIGTERM");
-      await Promise.allSettled([running]);
+      await stopRunningDaemons([{ signalProcess, running }]);
       await rm(agencHome, { recursive: true, force: true });
     }
   }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -560,6 +560,99 @@ async function waitForPid(pidPath: string): Promise<number> {
   throw new Error("timed out waiting for daemon pid");
 }
 
+const DAEMON_STOP_GRACE_MS = 2_000;
+
+type ForegroundDaemon = {
+  readonly signalProcess: ReturnType<typeof createSignalProcess>;
+  readonly running: Promise<number>;
+};
+
+/** Retry SIGTERM until runs settle; a single emit can be lost pre-handler. */
+async function stopRunningDaemons(
+  daemons: readonly ForegroundDaemon[],
+): Promise<void> {
+  let running = true;
+  let signalsSent = 0;
+  const startedAt = Date.now();
+  const settled = Promise.allSettled(
+    daemons.map((daemon) => daemon.running),
+  ).finally(() => {
+    running = false;
+  });
+  const deadline = startedAt + DEFAULT_DAEMON_READY_TIMEOUT_MS;
+  while (running && Date.now() < deadline) {
+    for (const daemon of daemons) daemon.signalProcess.emit("SIGTERM");
+    signalsSent += daemons.length;
+    await Promise.race([settled, delay(25)]);
+  }
+  if (running) {
+    const stopped = await Promise.race([
+      settled.then(() => true),
+      delay(DAEMON_STOP_GRACE_MS).then(() => false),
+    ]);
+    if (!stopped) {
+      throw new Error(
+        `daemon did not stop after ${signalsSent} SIGTERM${
+          signalsSent === 1 ? "" : "s"
+        } over ${Date.now() - startedAt} ms`,
+      );
+    }
+  }
+  await settled;
+}
+
+async function stopDaemon(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+): Promise<void> {
+  await stopRunningDaemons([{ signalProcess, running }]);
+}
+
+async function stopDaemonQuiet(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+): Promise<void> {
+  await stopDaemon(signalProcess, running).catch(() => {});
+}
+
+async function stopDaemonExpectZero(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+): Promise<void> {
+  await stopDaemon(signalProcess, running);
+  await expect(running).resolves.toBe(0);
+}
+
+async function cleanupDaemonTest(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+  stopped: boolean,
+  agencHome: string,
+): Promise<void> {
+  if (!stopped) await stopDaemonQuiet(signalProcess, running);
+  await rm(agencHome, { recursive: true, force: true });
+}
+
+async function stopDaemonRemoveHome(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+  agencHome: string,
+): Promise<void> {
+  await stopDaemonExpectZero(signalProcess, running);
+  await rm(agencHome, { recursive: true, force: true });
+}
+
+async function stopDaemonExpectPidCleared(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+  pidPath: string,
+  agencHome: string,
+): Promise<void> {
+  await stopDaemonExpectZero(signalProcess, running);
+  await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+  await rm(agencHome, { recursive: true, force: true });
+}
+
 async function availableLoopbackPort(): Promise<number> {
   const server = createServer();
   server.listen(0, "127.0.0.1");
@@ -1014,9 +1107,10 @@ describe("AgenC daemon CLI", () => {
       const secondUrl = await waitForDaemonWebSocketUrl(secondIo);
       expect(firstUrl).not.toBe(secondUrl);
     } finally {
-      firstSignalProcess.emit("SIGTERM");
-      secondSignalProcess.emit("SIGTERM");
-      await Promise.allSettled([firstRunning, secondRunning]);
+      await stopRunningDaemons([
+        { signalProcess: firstSignalProcess, running: firstRunning },
+        { signalProcess: secondSignalProcess, running: secondRunning },
+      ]);
       await rm(firstHome, { recursive: true, force: true });
       await rm(secondHome, { recursive: true, force: true });
     }
@@ -1365,15 +1459,10 @@ describe("AgenC daemon CLI", () => {
       expect(out).toMatch(/memory: rss=[\d.]+ MiB/);
       expect(out).toMatch(/sessions: active=\d+, closed=\d+, total=\d+/);
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -2659,14 +2748,12 @@ describe("AgenC daemon CLI", () => {
       });
       expect(spawnCount).toBe(0);
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, foreground);
       stopped = true;
-      await expect(foreground).resolves.toBe(0);
     } finally {
       publishForeground();
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await foreground.catch(() => {});
+        await stopDaemonQuiet(signalProcess, foreground);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3039,15 +3126,10 @@ token_cap = 123
       );
       expect(io.stderrText()).toContain("AgenC daemon config reloaded");
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
       updateRuntimeConfig.mockRestore();
     }
     // Starts a real daemon and reloads its config; on a loaded runner that
@@ -3144,13 +3226,11 @@ workspace = ${JSON.stringify(workspaceB)}
       );
       expect(workspaceARead.body).toContain("ADMISSION_IDENTITY_REQUIRED");
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await Promise.all([
         rm(agencHome, { recursive: true, force: true }),
@@ -3256,15 +3336,10 @@ workspace = ${JSON.stringify(process.cwd())}
       expect(host.terminatedPids).toEqual([]);
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4100);
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -3436,8 +3511,7 @@ workspace = ${JSON.stringify(process.cwd())}
       ).toEqual(replacement);
     } finally {
       await releaseLifecycleLock?.();
-      signalProcess.emit("SIGTERM");
-      await running.catch(() => {});
+      await stopDaemonQuiet(signalProcess, running);
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -3532,8 +3606,7 @@ workspace = ${JSON.stringify(process.cwd())}
       ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        signalProcess.emit("SIGTERM");
-        await running;
+        await stopDaemon(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3644,8 +3717,7 @@ workspace = ${JSON.stringify(process.cwd())}
       reloadSocket?.destroy();
       shutdownSocket?.destroy();
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        signalProcess.emit("SIGTERM");
-        await running;
+        await stopDaemon(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3863,10 +3935,7 @@ backend = "local"
       ).identity?.daemon,
     );
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonRemoveHome(signalProcess, running, agencHome);
   });
 
   it("foreground daemon rejects mismatched native peer uid without cookie", async () => {
@@ -3913,10 +3982,7 @@ backend = "local"
     expect(line.error?.data?.code).toBe("CONNECTION_AUTHENTICATION_FAILED");
     await expect(waitForSocketClose(socket)).resolves.toBe("closed");
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonRemoveHome(signalProcess, running, agencHome);
   });
 
   it("required native peer lookup failure shuts the daemon down nonzero", async () => {
@@ -4053,8 +4119,7 @@ backend = "local"
       expect(resolvedThreadIds).toEqual([]);
       socket.end();
     } finally {
-      signalProcess.emit("SIGTERM");
-      await expect(running).resolves.toBe(0);
+      await stopDaemonExpectZero(signalProcess, running);
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -4146,10 +4211,7 @@ backend = "local"
 
     socket.close();
     await waitForWebSocketClose(socket);
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonRemoveHome(signalProcess, running, agencHome);
   });
 
   it("foreground daemon serves read-only state stats to daemon clients", async () => {
@@ -4241,15 +4303,10 @@ backend = "local"
         initialSnapshots,
       );
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -4340,15 +4397,10 @@ backend = "local"
       });
       expect(permissionAgentIds).toEqual([created.agentId]);
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -4394,11 +4446,7 @@ backend = "local"
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
     expect(io.stdoutText()).toContain("AgenC daemon running");
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonExpectPidCleared(signalProcess, running, pidPath, agencHome);
   });
 
   it("does not autostart MCP without an explicit workspace scope", async () => {
@@ -4429,11 +4477,7 @@ port = 0
       "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
     );
     expect(io.stderrText()).not.toContain("AgenC MCP server listening");
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonExpectPidCleared(signalProcess, running, pidPath, agencHome);
   });
 
   it("foreground daemon starts a workspace-scoped mcp.server SSE endpoint", async () => {
@@ -4464,11 +4508,7 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(io.stderrText()).toMatch(
       /AgenC MCP server listening on http:\/\/127\.0\.0\.1:\d+\/mcp/,
     );
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonExpectPidCleared(signalProcess, running, pidPath, agencHome);
   });
 
   it("foreground daemon applies agent.retention config to terminal and snapshot startup pruning", async () => {
@@ -4566,15 +4606,10 @@ snapshot_max_bytes = 64
         readSnapshotTimes(agencHome, process.cwd(), "session-retention-bytes"),
       ).toEqual(["2026-05-06T00:00:01.000Z"]);
 
-      signalProcess.emit("SIGTERM");
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        signalProcess.emit("SIGTERM");
-        await running.catch(() => {});
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -4832,8 +4867,7 @@ snapshot_max_bytes = 64
       expect.objectContaining({ displayUserMessage: "continue" }),
     );
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-restart"),
     ).toBe("poisoned");
@@ -4912,8 +4946,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5022,8 +5055,7 @@ snapshot_max_bytes = 64
     expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
       "cancelled",
     );
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5121,9 +5153,8 @@ snapshot_max_bytes = 64
       expect(restoredOptions[0]?.deferSessionStartHooks).toBe(true);
       expect(restoredOptions[0]?.deferAgentStartupSideEffects).toBeUndefined();
 
-      firstSignal.emit("SIGTERM");
+      await stopDaemonExpectZero(firstSignal, first);
       firstStopped = true;
-      await expect(first).resolves.toBe(0);
       const suspended = readCanonicalRunLifecycle(rolloutPath);
       expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
         "suspended",
@@ -5209,7 +5240,9 @@ snapshot_max_bytes = 64
         }),
       );
 
-      secondSignal.emit("SIGTERM");
+      await stopRunningDaemons([
+        { signalProcess: secondSignal, running: second },
+      ]);
       secondStopped = true;
       await expect(second).resolves.toBe(0);
       expect(
@@ -5217,12 +5250,14 @@ snapshot_max_bytes = 64
       ).toEqual(["run_suspended", "run_resumed", "run_suspended"]);
     } finally {
       if (!firstStopped && first !== undefined) {
-        firstSignal.emit("SIGTERM");
-        await first.catch(() => {});
+        await stopRunningDaemons([
+          { signalProcess: firstSignal, running: first },
+        ]).catch(() => {});
       }
-      if (!secondStopped && second !== undefined) {
-        secondSignal?.emit("SIGTERM");
-        await second.catch(() => {});
+      if (!secondStopped && second !== undefined && secondSignal !== undefined) {
+        await stopRunningDaemons([
+          { signalProcess: secondSignal, running: second },
+        ]).catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -5361,8 +5396,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-replay"),
     ).toBe("completed");
@@ -5488,8 +5522,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5598,10 +5631,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-
-    await rm(agencHome, { recursive: true, force: true });
+    await stopDaemonRemoveHome(signalProcess, running, agencHome);
   });
 
   it("foreground daemon exposes poisoned and cancelled recovery details through attach", async () => {
@@ -5751,8 +5781,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5818,8 +5847,7 @@ snapshot_max_bytes = 64
       1,
     );
 
-    firstSignal.emit("SIGTERM");
-    await expect(first).resolves.toBe(0);
+    await stopDaemonExpectZero(firstSignal, first);
     // The harness can only stop gracefully; reset the row to simulate a crash
     // after proving agent.create produced the running row and session snapshot.
     markAgentRunRunning(agencHome, process.cwd(), createdAgentId, sessionId);
@@ -5958,7 +5986,9 @@ snapshot_max_bytes = 64
       },
     });
 
-    secondSignal.emit("SIGTERM");
+    await stopRunningDaemons([
+      { signalProcess: secondSignal, running: second },
+    ]);
     await expect(second).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -6028,8 +6058,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(otherCwd, { recursive: true, force: true });
     await rm(agencHome, { recursive: true, force: true });
@@ -6051,7 +6080,7 @@ snapshot_max_bytes = 64
     );
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
-    signalProcess.emit("SIGTERM");
+    await stopDaemon(signalProcess, running);
 
     await expect(running).resolves.toBe(1);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
@@ -6714,8 +6743,7 @@ describe("daemon startup proxy isolation", () => {
     try {
       await waitForDaemonWebSocketUrl(io);
     } finally {
-      signalProcess.emit("SIGTERM");
-      await Promise.allSettled([running]);
+      await stopDaemon(signalProcess, running);
       await rm(agencHome, { recursive: true, force: true });
     }
   }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -5166,7 +5166,7 @@ snapshot_max_bytes = 64
       expect(restoredOptions[0]?.deferSessionStartHooks).toBe(true);
       expect(restoredOptions[0]?.deferAgentStartupSideEffects).toBeUndefined();
 
-      await stopRunningDaemons([{ signalProcess: firstSignal, running: first }]);
+      await stopDaemon(firstSignal, first);
       firstStopped = true;
       await expect(first).resolves.toBe(0);
       const suspended = readCanonicalRunLifecycle(rolloutPath);
@@ -5867,7 +5867,7 @@ snapshot_max_bytes = 64
       1,
     );
 
-    await stopRunningDaemons([{ signalProcess: firstSignal, running: first }]);
+    await stopDaemon(firstSignal, first);
     await expect(first).resolves.toBe(0);
     // The harness can only stop gracefully; reset the row to simulate a crash
     // after proving agent.create produced the running row and session snapshot.

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -523,6 +523,13 @@ function createReadyPublishedDaemonOptions(
 function createSignalProcess() {
   type TestDaemonSignal = AgenCShutdownSignal;
   const listeners = new Map<TestDaemonSignal, Set<() => void>>();
+  /** Signals emitted before any listener (startup race); flushed on once(). */
+  const pending = new Set<TestDaemonSignal>();
+  const deliver = (signal: TestDaemonSignal): void => {
+    for (const listener of [...(listeners.get(signal) ?? [])]) {
+      listener();
+    }
+  };
   const addListener = (signal: TestDaemonSignal, listener: () => void) => {
     let set = listeners.get(signal);
     if (set === undefined) {
@@ -530,6 +537,9 @@ function createSignalProcess() {
       listeners.set(signal, set);
     }
     set.add(listener);
+    if (pending.delete(signal)) {
+      deliver(signal);
+    }
   };
   return {
     once: (signal: AgenCShutdownSignal, listener: () => void) => {
@@ -539,9 +549,12 @@ function createSignalProcess() {
       listeners.get(signal)?.delete(listener);
     },
     emit(signal: TestDaemonSignal): void {
-      for (const listener of [...(listeners.get(signal) ?? [])]) {
-        listener();
+      const set = listeners.get(signal);
+      if (set !== undefined && set.size > 0) {
+        deliver(signal);
+        return;
       }
+      pending.add(signal);
     },
   };
 }
@@ -558,99 +571,6 @@ async function waitForPid(pidPath: string): Promise<number> {
     await delay(10);
   }
   throw new Error("timed out waiting for daemon pid");
-}
-
-const DAEMON_STOP_GRACE_MS = 2_000;
-
-type ForegroundDaemon = {
-  readonly signalProcess: ReturnType<typeof createSignalProcess>;
-  readonly running: Promise<number>;
-};
-
-/** Retry SIGTERM until runs settle; a single emit can be lost pre-handler. */
-async function stopRunningDaemons(
-  daemons: readonly ForegroundDaemon[],
-): Promise<void> {
-  let running = true;
-  let signalsSent = 0;
-  const startedAt = Date.now();
-  const settled = Promise.allSettled(
-    daemons.map((daemon) => daemon.running),
-  ).finally(() => {
-    running = false;
-  });
-  const deadline = startedAt + DEFAULT_DAEMON_READY_TIMEOUT_MS;
-  while (running && Date.now() < deadline) {
-    for (const daemon of daemons) daemon.signalProcess.emit("SIGTERM");
-    signalsSent += daemons.length;
-    await Promise.race([settled, delay(25)]);
-  }
-  if (running) {
-    const stopped = await Promise.race([
-      settled.then(() => true),
-      delay(DAEMON_STOP_GRACE_MS).then(() => false),
-    ]);
-    if (!stopped) {
-      throw new Error(
-        `daemon did not stop after ${signalsSent} SIGTERM${
-          signalsSent === 1 ? "" : "s"
-        } over ${Date.now() - startedAt} ms`,
-      );
-    }
-  }
-  await settled;
-}
-
-async function stopDaemon(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-): Promise<void> {
-  await stopRunningDaemons([{ signalProcess, running }]);
-}
-
-async function stopDaemonQuiet(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-): Promise<void> {
-  await stopDaemon(signalProcess, running).catch(() => {});
-}
-
-async function stopDaemonExpectZero(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-): Promise<void> {
-  await stopDaemon(signalProcess, running);
-  await expect(running).resolves.toBe(0);
-}
-
-async function cleanupDaemonTest(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-  stopped: boolean,
-  agencHome: string,
-): Promise<void> {
-  if (!stopped) await stopDaemonQuiet(signalProcess, running);
-  await rm(agencHome, { recursive: true, force: true });
-}
-
-async function stopDaemonRemoveHome(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-  agencHome: string,
-): Promise<void> {
-  await stopDaemonExpectZero(signalProcess, running);
-  await rm(agencHome, { recursive: true, force: true });
-}
-
-async function stopDaemonExpectPidCleared(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-  pidPath: string,
-  agencHome: string,
-): Promise<void> {
-  await stopDaemonExpectZero(signalProcess, running);
-  await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
-  await rm(agencHome, { recursive: true, force: true });
 }
 
 async function availableLoopbackPort(): Promise<number> {
@@ -878,6 +798,29 @@ async function resolveRealtimeHeadersForTest(
 ): Promise<Readonly<Record<string, string>>> {
   return typeof provider === "function" ? provider(sessionConfig) : provider;
 }
+
+describe("daemon-cli test signal process (#2033)", () => {
+  it("delivers SIGTERM emitted before shutdown handlers install", () => {
+    const signalProcess = createSignalProcess();
+    let deliveries = 0;
+    signalProcess.emit("SIGTERM");
+    signalProcess.once("SIGTERM", () => {
+      deliveries += 1;
+    });
+    expect(deliveries).toBe(1);
+  });
+
+  it("does not drop live emits after handlers install", () => {
+    const signalProcess = createSignalProcess();
+    let deliveries = 0;
+    signalProcess.once("SIGTERM", () => {
+      deliveries += 1;
+    });
+    signalProcess.emit("SIGTERM");
+    signalProcess.emit("SIGTERM");
+    expect(deliveries).toBe(2);
+  });
+});
 
 describe("AgenC daemon readiness timeout resolution", () => {
   it("raises the default cold-start budget to at least 30s", () => {
@@ -1107,10 +1050,9 @@ describe("AgenC daemon CLI", () => {
       const secondUrl = await waitForDaemonWebSocketUrl(secondIo);
       expect(firstUrl).not.toBe(secondUrl);
     } finally {
-      await stopRunningDaemons([
-        { signalProcess: firstSignalProcess, running: firstRunning },
-        { signalProcess: secondSignalProcess, running: secondRunning },
-      ]);
+      firstSignalProcess.emit("SIGTERM");
+      secondSignalProcess.emit("SIGTERM");
+      await Promise.allSettled([firstRunning, secondRunning]);
       await rm(firstHome, { recursive: true, force: true });
       await rm(secondHome, { recursive: true, force: true });
     }
@@ -1459,10 +1401,15 @@ describe("AgenC daemon CLI", () => {
       expect(out).toMatch(/memory: rss=[\d.]+ MiB/);
       expect(out).toMatch(/sessions: active=\d+, closed=\d+, total=\d+/);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -2748,12 +2695,14 @@ describe("AgenC daemon CLI", () => {
       });
       expect(spawnCount).toBe(0);
 
-      await stopDaemonExpectZero(signalProcess, foreground);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(foreground).resolves.toBe(0);
     } finally {
       publishForeground();
       if (!stopped) {
-        await stopDaemonQuiet(signalProcess, foreground);
+        signalProcess.emit("SIGTERM");
+        await foreground.catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3126,10 +3075,15 @@ token_cap = 123
       );
       expect(io.stderrText()).toContain("AgenC daemon config reloaded");
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
       updateRuntimeConfig.mockRestore();
     }
     // Starts a real daemon and reloads its config; on a loaded runner that
@@ -3226,11 +3180,13 @@ workspace = ${JSON.stringify(workspaceB)}
       );
       expect(workspaceARead.body).toContain("ADMISSION_IDENTITY_REQUIRED");
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
       }
       await Promise.all([
         rm(agencHome, { recursive: true, force: true }),
@@ -3336,10 +3292,15 @@ workspace = ${JSON.stringify(process.cwd())}
       expect(host.terminatedPids).toEqual([]);
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4100);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -3511,7 +3472,8 @@ workspace = ${JSON.stringify(process.cwd())}
       ).toEqual(replacement);
     } finally {
       await releaseLifecycleLock?.();
-      await stopDaemonQuiet(signalProcess, running);
+      signalProcess.emit("SIGTERM");
+      await running.catch(() => {});
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -3606,7 +3568,8 @@ workspace = ${JSON.stringify(process.cwd())}
       ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        await stopDaemon(signalProcess, running);
+        signalProcess.emit("SIGTERM");
+        await running;
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3717,7 +3680,8 @@ workspace = ${JSON.stringify(process.cwd())}
       reloadSocket?.destroy();
       shutdownSocket?.destroy();
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        await stopDaemon(signalProcess, running);
+        signalProcess.emit("SIGTERM");
+        await running;
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3935,7 +3899,10 @@ backend = "local"
       ).identity?.daemon,
     );
 
-    await stopDaemonRemoveHome(signalProcess, running, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("foreground daemon rejects mismatched native peer uid without cookie", async () => {
@@ -3982,7 +3949,10 @@ backend = "local"
     expect(line.error?.data?.code).toBe("CONNECTION_AUTHENTICATION_FAILED");
     await expect(waitForSocketClose(socket)).resolves.toBe("closed");
 
-    await stopDaemonRemoveHome(signalProcess, running, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("required native peer lookup failure shuts the daemon down nonzero", async () => {
@@ -4119,7 +4089,8 @@ backend = "local"
       expect(resolvedThreadIds).toEqual([]);
       socket.end();
     } finally {
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
+      await expect(running).resolves.toBe(0);
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -4211,7 +4182,10 @@ backend = "local"
 
     socket.close();
     await waitForWebSocketClose(socket);
-    await stopDaemonRemoveHome(signalProcess, running, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("foreground daemon serves read-only state stats to daemon clients", async () => {
@@ -4303,10 +4277,15 @@ backend = "local"
         initialSnapshots,
       );
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -4397,10 +4376,15 @@ backend = "local"
       });
       expect(permissionAgentIds).toEqual([created.agentId]);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -4446,7 +4430,11 @@ backend = "local"
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
     expect(io.stdoutText()).toContain("AgenC daemon running");
-    await stopDaemonExpectPidCleared(signalProcess, running, pidPath, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("does not autostart MCP without an explicit workspace scope", async () => {
@@ -4477,7 +4465,11 @@ port = 0
       "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
     );
     expect(io.stderrText()).not.toContain("AgenC MCP server listening");
-    await stopDaemonExpectPidCleared(signalProcess, running, pidPath, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("foreground daemon starts a workspace-scoped mcp.server SSE endpoint", async () => {
@@ -4508,7 +4500,11 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(io.stderrText()).toMatch(
       /AgenC MCP server listening on http:\/\/127\.0\.0\.1:\d+\/mcp/,
     );
-    await stopDaemonExpectPidCleared(signalProcess, running, pidPath, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("foreground daemon applies agent.retention config to terminal and snapshot startup pruning", async () => {
@@ -4606,10 +4602,15 @@ snapshot_max_bytes = 64
         readSnapshotTimes(agencHome, process.cwd(), "session-retention-bytes"),
       ).toEqual(["2026-05-06T00:00:01.000Z"]);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -4867,7 +4868,8 @@ snapshot_max_bytes = 64
       expect.objectContaining({ displayUserMessage: "continue" }),
     );
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-restart"),
     ).toBe("poisoned");
@@ -4946,7 +4948,8 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5055,7 +5058,8 @@ snapshot_max_bytes = 64
     expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
       "cancelled",
     );
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5153,8 +5157,9 @@ snapshot_max_bytes = 64
       expect(restoredOptions[0]?.deferSessionStartHooks).toBe(true);
       expect(restoredOptions[0]?.deferAgentStartupSideEffects).toBeUndefined();
 
-      await stopDaemonExpectZero(firstSignal, first);
+      firstSignal.emit("SIGTERM");
       firstStopped = true;
+      await expect(first).resolves.toBe(0);
       const suspended = readCanonicalRunLifecycle(rolloutPath);
       expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
         "suspended",
@@ -5240,9 +5245,7 @@ snapshot_max_bytes = 64
         }),
       );
 
-      await stopRunningDaemons([
-        { signalProcess: secondSignal, running: second },
-      ]);
+      secondSignal.emit("SIGTERM");
       secondStopped = true;
       await expect(second).resolves.toBe(0);
       expect(
@@ -5250,14 +5253,12 @@ snapshot_max_bytes = 64
       ).toEqual(["run_suspended", "run_resumed", "run_suspended"]);
     } finally {
       if (!firstStopped && first !== undefined) {
-        await stopRunningDaemons([
-          { signalProcess: firstSignal, running: first },
-        ]).catch(() => {});
+        firstSignal.emit("SIGTERM");
+        await first.catch(() => {});
       }
-      if (!secondStopped && second !== undefined && secondSignal !== undefined) {
-        await stopRunningDaemons([
-          { signalProcess: secondSignal, running: second },
-        ]).catch(() => {});
+      if (!secondStopped && second !== undefined) {
+        secondSignal?.emit("SIGTERM");
+        await second.catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -5396,7 +5397,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-replay"),
     ).toBe("completed");
@@ -5522,7 +5524,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5631,7 +5634,10 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonRemoveHome(signalProcess, running, agencHome);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
+
+    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("foreground daemon exposes poisoned and cancelled recovery details through attach", async () => {
@@ -5781,7 +5787,8 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5847,7 +5854,8 @@ snapshot_max_bytes = 64
       1,
     );
 
-    await stopDaemonExpectZero(firstSignal, first);
+    firstSignal.emit("SIGTERM");
+    await expect(first).resolves.toBe(0);
     // The harness can only stop gracefully; reset the row to simulate a crash
     // after proving agent.create produced the running row and session snapshot.
     markAgentRunRunning(agencHome, process.cwd(), createdAgentId, sessionId);
@@ -5986,9 +5994,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopRunningDaemons([
-      { signalProcess: secondSignal, running: second },
-    ]);
+    secondSignal.emit("SIGTERM");
     await expect(second).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -6058,7 +6064,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(otherCwd, { recursive: true, force: true });
     await rm(agencHome, { recursive: true, force: true });
@@ -6080,7 +6087,7 @@ snapshot_max_bytes = 64
     );
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
-    await stopDaemon(signalProcess, running);
+    signalProcess.emit("SIGTERM");
 
     await expect(running).resolves.toBe(1);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
@@ -6743,7 +6750,8 @@ describe("daemon startup proxy isolation", () => {
     try {
       await waitForDaemonWebSocketUrl(io);
     } finally {
-      await stopDaemon(signalProcess, running);
+      signalProcess.emit("SIGTERM");
+      await Promise.allSettled([running]);
       await rm(agencHome, { recursive: true, force: true });
     }
   }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -560,35 +560,16 @@ async function waitForPid(pidPath: string): Promise<number> {
   throw new Error("timed out waiting for daemon pid");
 }
 
-/**
- * How long {@link stopRunningDaemons} waits for the runs to settle once its
- * SIGTERM loop has given up. Bounded so a daemon that never stops fails with a
- * named error instead of the case dying on the vitest deadline.
- */
 const DAEMON_STOP_GRACE_MS = 2_000;
 
-/**
- * Shuts foreground daemons down without depending on when they installed
- * their signal handlers.
- *
- * runAgenCDaemonCli only calls installAgenCShutdownSignalHandlers after its
- * services are constructed. The test signal process has no default action, so
- * a single SIGTERM emitted before that point is dropped, the daemon keeps
- * running, and the awaited run promise never settles -- the test then dies on
- * the vitest deadline with no indication of what it was waiting for. Repeating
- * the signal until the runs settle closes that window; the handler's own
- * `settled` guard makes the extra signals no-ops.
- *
- * Every wait here is bounded. Falling through to an unbounded await on runs
- * that never settle would reintroduce exactly the content-free
- * "Test timed out" this helper exists to remove, only later, against the
- * widened case timeout.
- */
+type ForegroundDaemon = {
+  readonly signalProcess: ReturnType<typeof createSignalProcess>;
+  readonly running: Promise<number>;
+};
+
+/** Retry SIGTERM until runs settle; a single emit can be lost pre-handler. */
 async function stopRunningDaemons(
-  daemons: readonly {
-    readonly signalProcess: ReturnType<typeof createSignalProcess>;
-    readonly running: Promise<number>;
-  }[],
+  daemons: readonly ForegroundDaemon[],
 ): Promise<void> {
   let running = true;
   let signalsSent = 0;
@@ -618,6 +599,20 @@ async function stopRunningDaemons(
     }
   }
   await settled;
+}
+
+async function stopDaemon(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+): Promise<void> {
+  await stopDaemon(signalProcess, running);
+}
+
+async function stopDaemonQuiet(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+): Promise<void> {
+  await stopDaemon(signalProcess, running).catch(() => {});
 }
 
 async function availableLoopbackPort(): Promise<number> {
@@ -1426,12 +1421,12 @@ describe("AgenC daemon CLI", () => {
       expect(out).toMatch(/memory: rss=[\d.]+ MiB/);
       expect(out).toMatch(/sessions: active=\d+, closed=\d+, total=\d+/);
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -2719,15 +2714,13 @@ describe("AgenC daemon CLI", () => {
       });
       expect(spawnCount).toBe(0);
 
-      await stopRunningDaemons([{ signalProcess, running: foreground }]);
+      await stopDaemon(signalProcess, foreground);
       stopped = true;
       await expect(foreground).resolves.toBe(0);
     } finally {
       publishForeground();
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running: foreground }]).catch(
-          () => {},
-        );
+        await stopDaemonQuiet(signalProcess, foreground);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3100,12 +3093,12 @@ token_cap = 123
       );
       expect(io.stderrText()).toContain("AgenC daemon config reloaded");
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
       updateRuntimeConfig.mockRestore();
@@ -3204,12 +3197,12 @@ workspace = ${JSON.stringify(workspaceB)}
       );
       expect(workspaceARead.body).toContain("ADMISSION_IDENTITY_REQUIRED");
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await Promise.all([
         rm(agencHome, { recursive: true, force: true }),
@@ -3315,12 +3308,12 @@ workspace = ${JSON.stringify(process.cwd())}
       expect(host.terminatedPids).toEqual([]);
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4100);
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3494,7 +3487,7 @@ workspace = ${JSON.stringify(process.cwd())}
       ).toEqual(replacement);
     } finally {
       await releaseLifecycleLock?.();
-      await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+      await stopDaemonQuiet(signalProcess, running);
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -3589,7 +3582,7 @@ workspace = ${JSON.stringify(process.cwd())}
       ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        await stopRunningDaemons([{ signalProcess, running }]);
+        await stopDaemon(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3700,7 +3693,7 @@ workspace = ${JSON.stringify(process.cwd())}
       reloadSocket?.destroy();
       shutdownSocket?.destroy();
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        await stopRunningDaemons([{ signalProcess, running }]);
+        await stopDaemon(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3918,7 +3911,7 @@ backend = "local"
       ).identity?.daemon,
     );
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -3968,7 +3961,7 @@ backend = "local"
     expect(line.error?.data?.code).toBe("CONNECTION_AUTHENTICATION_FAILED");
     await expect(waitForSocketClose(socket)).resolves.toBe("closed");
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4108,7 +4101,7 @@ backend = "local"
       expect(resolvedThreadIds).toEqual([]);
       socket.end();
     } finally {
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       await expect(running).resolves.toBe(0);
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4201,7 +4194,7 @@ backend = "local"
 
     socket.close();
     await waitForWebSocketClose(socket);
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4296,12 +4289,12 @@ backend = "local"
         initialSnapshots,
       );
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4394,12 +4387,12 @@ backend = "local"
       });
       expect(permissionAgentIds).toEqual([created.agentId]);
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4447,7 +4440,7 @@ backend = "local"
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
     expect(io.stdoutText()).toContain("AgenC daemon running");
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
@@ -4482,7 +4475,7 @@ port = 0
       "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
     );
     expect(io.stderrText()).not.toContain("AgenC MCP server listening");
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
@@ -4517,7 +4510,7 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(io.stderrText()).toMatch(
       /AgenC MCP server listening on http:\/\/127\.0\.0\.1:\d+\/mcp/,
     );
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
@@ -4619,12 +4612,12 @@ snapshot_max_bytes = 64
         readSnapshotTimes(agencHome, process.cwd(), "session-retention-bytes"),
       ).toEqual(["2026-05-06T00:00:01.000Z"]);
 
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       stopped = true;
       await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopRunningDaemons([{ signalProcess, running }]).catch(() => {});
+        await stopDaemonQuiet(signalProcess, running);
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -4884,7 +4877,7 @@ snapshot_max_bytes = 64
       expect.objectContaining({ displayUserMessage: "continue" }),
     );
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-restart"),
@@ -4964,7 +4957,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5074,7 +5067,7 @@ snapshot_max_bytes = 64
     expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
       "cancelled",
     );
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5417,7 +5410,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-replay"),
@@ -5544,7 +5537,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -5654,7 +5647,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -5807,7 +5800,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
@@ -6086,7 +6079,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
     await expect(running).resolves.toBe(0);
 
     await rm(otherCwd, { recursive: true, force: true });
@@ -6109,7 +6102,7 @@ snapshot_max_bytes = 64
     );
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
-    await stopRunningDaemons([{ signalProcess, running }]);
+    await stopDaemon(signalProcess, running);
 
     await expect(running).resolves.toBe(1);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
@@ -6772,7 +6765,7 @@ describe("daemon startup proxy isolation", () => {
     try {
       await waitForDaemonWebSocketUrl(io);
     } finally {
-      await stopRunningDaemons([{ signalProcess, running }]);
+      await stopDaemon(signalProcess, running);
       await rm(agencHome, { recursive: true, force: true });
     }
   }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -3915,8 +3915,7 @@ backend = "local"
       ).identity?.daemon,
     );
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -3965,8 +3964,7 @@ backend = "local"
     expect(line.error?.data?.code).toBe("CONNECTION_AUTHENTICATION_FAILED");
     await expect(waitForSocketClose(socket)).resolves.toBe("closed");
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -4105,8 +4103,7 @@ backend = "local"
       expect(resolvedThreadIds).toEqual([]);
       socket.end();
     } finally {
-      await stopDaemon(signalProcess, running);
-      await expect(running).resolves.toBe(0);
+      await stopDaemonExpectZero(signalProcess, running);
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -4198,8 +4195,7 @@ backend = "local"
 
     socket.close();
     await waitForWebSocketClose(socket);
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -4436,8 +4432,7 @@ backend = "local"
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
     expect(io.stdoutText()).toContain("AgenC daemon running");
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4471,8 +4466,7 @@ port = 0
       "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
     );
     expect(io.stderrText()).not.toContain("AgenC MCP server listening");
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4506,8 +4500,7 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(io.stderrText()).toMatch(
       /AgenC MCP server listening on http:\/\/127\.0\.0\.1:\d+\/mcp/,
     );
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4869,8 +4862,7 @@ snapshot_max_bytes = 64
       expect.objectContaining({ displayUserMessage: "continue" }),
     );
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-restart"),
     ).toBe("poisoned");
@@ -4949,8 +4941,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5059,8 +5050,7 @@ snapshot_max_bytes = 64
     expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
       "cancelled",
     );
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5158,9 +5148,8 @@ snapshot_max_bytes = 64
       expect(restoredOptions[0]?.deferSessionStartHooks).toBe(true);
       expect(restoredOptions[0]?.deferAgentStartupSideEffects).toBeUndefined();
 
-      await stopDaemon(firstSignal, first);
+      await stopDaemonExpectZero(firstSignal, first);
       firstStopped = true;
-      await expect(first).resolves.toBe(0);
       const suspended = readCanonicalRunLifecycle(rolloutPath);
       expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
         "suspended",
@@ -5402,8 +5391,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-replay"),
     ).toBe("completed");
@@ -5529,8 +5517,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5639,8 +5626,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5792,8 +5778,7 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5859,8 +5844,7 @@ snapshot_max_bytes = 64
       1,
     );
 
-    await stopDaemon(firstSignal, first);
-    await expect(first).resolves.toBe(0);
+    await stopDaemonExpectZero(firstSignal, first);
     // The harness can only stop gracefully; reset the row to simulate a crash
     // after proving agent.create produced the running row and session snapshot.
     markAgentRunRunning(agencHome, process.cwd(), createdAgentId, sessionId);
@@ -6071,8 +6055,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemon(signalProcess, running);
-    await expect(running).resolves.toBe(0);
+    await stopDaemonExpectZero(signalProcess, running);
 
     await rm(otherCwd, { recursive: true, force: true });
     await rm(agencHome, { recursive: true, force: true });

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -560,79 +560,6 @@ async function waitForPid(pidPath: string): Promise<number> {
   throw new Error("timed out waiting for daemon pid");
 }
 
-const DAEMON_STOP_GRACE_MS = 2_000;
-
-type ForegroundDaemon = {
-  readonly signalProcess: ReturnType<typeof createSignalProcess>;
-  readonly running: Promise<number>;
-};
-
-/** Retry SIGTERM until runs settle; a single emit can be lost pre-handler. */
-async function stopRunningDaemons(
-  daemons: readonly ForegroundDaemon[],
-): Promise<void> {
-  let running = true;
-  let signalsSent = 0;
-  const startedAt = Date.now();
-  const settled = Promise.allSettled(
-    daemons.map((daemon) => daemon.running),
-  ).finally(() => {
-    running = false;
-  });
-  const deadline = startedAt + DEFAULT_DAEMON_READY_TIMEOUT_MS;
-  while (running && Date.now() < deadline) {
-    for (const daemon of daemons) daemon.signalProcess.emit("SIGTERM");
-    signalsSent += daemons.length;
-    await Promise.race([settled, delay(25)]);
-  }
-  if (running) {
-    const stopped = await Promise.race([
-      settled.then(() => true),
-      delay(DAEMON_STOP_GRACE_MS).then(() => false),
-    ]);
-    if (!stopped) {
-      throw new Error(
-        `daemon did not stop after ${signalsSent} SIGTERM${
-          signalsSent === 1 ? "" : "s"
-        } over ${Date.now() - startedAt} ms`,
-      );
-    }
-  }
-  await settled;
-}
-
-async function stopDaemon(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-): Promise<void> {
-  await stopRunningDaemons([{ signalProcess, running }]);
-}
-
-async function stopDaemonQuiet(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-): Promise<void> {
-  await stopDaemon(signalProcess, running).catch(() => {});
-}
-
-async function stopDaemonExpectZero(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-): Promise<void> {
-  await stopDaemon(signalProcess, running);
-  await expect(running).resolves.toBe(0);
-}
-
-async function cleanupDaemonTest(
-  signalProcess: ReturnType<typeof createSignalProcess>,
-  running: Promise<number>,
-  stopped: boolean,
-  agencHome: string,
-): Promise<void> {
-  if (!stopped) await stopDaemonQuiet(signalProcess, running);
-  await rm(agencHome, { recursive: true, force: true });
-}
-
 async function availableLoopbackPort(): Promise<number> {
   const server = createServer();
   server.listen(0, "127.0.0.1");
@@ -1087,10 +1014,9 @@ describe("AgenC daemon CLI", () => {
       const secondUrl = await waitForDaemonWebSocketUrl(secondIo);
       expect(firstUrl).not.toBe(secondUrl);
     } finally {
-      await stopRunningDaemons([
-        { signalProcess: firstSignalProcess, running: firstRunning },
-        { signalProcess: secondSignalProcess, running: secondRunning },
-      ]);
+      firstSignalProcess.emit("SIGTERM");
+      secondSignalProcess.emit("SIGTERM");
+      await Promise.allSettled([firstRunning, secondRunning]);
       await rm(firstHome, { recursive: true, force: true });
       await rm(secondHome, { recursive: true, force: true });
     }
@@ -1439,10 +1365,15 @@ describe("AgenC daemon CLI", () => {
       expect(out).toMatch(/memory: rss=[\d.]+ MiB/);
       expect(out).toMatch(/sessions: active=\d+, closed=\d+, total=\d+/);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -2728,12 +2659,14 @@ describe("AgenC daemon CLI", () => {
       });
       expect(spawnCount).toBe(0);
 
-      await stopDaemonExpectZero(signalProcess, foreground);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(foreground).resolves.toBe(0);
     } finally {
       publishForeground();
       if (!stopped) {
-        await stopDaemonQuiet(signalProcess, foreground);
+        signalProcess.emit("SIGTERM");
+        await foreground.catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3106,10 +3039,15 @@ token_cap = 123
       );
       expect(io.stderrText()).toContain("AgenC daemon config reloaded");
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
       updateRuntimeConfig.mockRestore();
     }
     // Starts a real daemon and reloads its config; on a loaded runner that
@@ -3206,11 +3144,13 @@ workspace = ${JSON.stringify(workspaceB)}
       );
       expect(workspaceARead.body).toContain("ADMISSION_IDENTITY_REQUIRED");
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
       }
       await Promise.all([
         rm(agencHome, { recursive: true, force: true }),
@@ -3316,10 +3256,15 @@ workspace = ${JSON.stringify(process.cwd())}
       expect(host.terminatedPids).toEqual([]);
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4100);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -3491,7 +3436,8 @@ workspace = ${JSON.stringify(process.cwd())}
       ).toEqual(replacement);
     } finally {
       await releaseLifecycleLock?.();
-      await stopDaemonQuiet(signalProcess, running);
+      signalProcess.emit("SIGTERM");
+      await running.catch(() => {});
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -3586,7 +3532,8 @@ workspace = ${JSON.stringify(process.cwd())}
       ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        await stopDaemon(signalProcess, running);
+        signalProcess.emit("SIGTERM");
+        await running;
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3697,7 +3644,8 @@ workspace = ${JSON.stringify(process.cwd())}
       reloadSocket?.destroy();
       shutdownSocket?.destroy();
       if ((await readAgenCDaemonPid(pidPath)) !== null) {
-        await stopDaemon(signalProcess, running);
+        signalProcess.emit("SIGTERM");
+        await running;
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -3915,7 +3863,8 @@ backend = "local"
       ).identity?.daemon,
     );
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -3964,7 +3913,8 @@ backend = "local"
     expect(line.error?.data?.code).toBe("CONNECTION_AUTHENTICATION_FAILED");
     await expect(waitForSocketClose(socket)).resolves.toBe("closed");
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -4103,7 +4053,8 @@ backend = "local"
       expect(resolvedThreadIds).toEqual([]);
       socket.end();
     } finally {
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
+      await expect(running).resolves.toBe(0);
       await rm(agencHome, { recursive: true, force: true });
     }
   });
@@ -4195,7 +4146,8 @@ backend = "local"
 
     socket.close();
     await waitForWebSocketClose(socket);
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -4289,10 +4241,15 @@ backend = "local"
         initialSnapshots,
       );
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -4383,10 +4340,15 @@ backend = "local"
       });
       expect(permissionAgentIds).toEqual([created.agentId]);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -4432,7 +4394,8 @@ backend = "local"
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
     expect(io.stdoutText()).toContain("AgenC daemon running");
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4466,7 +4429,8 @@ port = 0
       "daemon MCP autostart requires an explicit absolute mcp.server.workspace",
     );
     expect(io.stderrText()).not.toContain("AgenC MCP server listening");
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4500,7 +4464,8 @@ workspace = ${JSON.stringify(process.cwd())}
     expect(io.stderrText()).toMatch(
       /AgenC MCP server listening on http:\/\/127\.0\.0\.1:\d+\/mcp/,
     );
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
 
     await rm(agencHome, { recursive: true, force: true });
@@ -4601,10 +4566,15 @@ snapshot_max_bytes = 64
         readSnapshotTimes(agencHome, process.cwd(), "session-retention-bytes"),
       ).toEqual(["2026-05-06T00:00:01.000Z"]);
 
-      await stopDaemonExpectZero(signalProcess, running);
+      signalProcess.emit("SIGTERM");
       stopped = true;
+      await expect(running).resolves.toBe(0);
     } finally {
-      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
+      if (!stopped) {
+        signalProcess.emit("SIGTERM");
+        await running.catch(() => {});
+      }
+      await rm(agencHome, { recursive: true, force: true });
     }
   });
 
@@ -4862,7 +4832,8 @@ snapshot_max_bytes = 64
       expect.objectContaining({ displayUserMessage: "continue" }),
     );
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-restart"),
     ).toBe("poisoned");
@@ -4941,7 +4912,8 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5050,7 +5022,8 @@ snapshot_max_bytes = 64
     expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
       "cancelled",
     );
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
 
@@ -5148,8 +5121,9 @@ snapshot_max_bytes = 64
       expect(restoredOptions[0]?.deferSessionStartHooks).toBe(true);
       expect(restoredOptions[0]?.deferAgentStartupSideEffects).toBeUndefined();
 
-      await stopDaemonExpectZero(firstSignal, first);
+      firstSignal.emit("SIGTERM");
       firstStopped = true;
+      await expect(first).resolves.toBe(0);
       const suspended = readCanonicalRunLifecycle(rolloutPath);
       expect(readAgentRunStatus(agencHome, process.cwd(), runId)).toBe(
         "suspended",
@@ -5235,9 +5209,7 @@ snapshot_max_bytes = 64
         }),
       );
 
-      await stopRunningDaemons([
-        { signalProcess: secondSignal, running: second },
-      ]);
+      secondSignal.emit("SIGTERM");
       secondStopped = true;
       await expect(second).resolves.toBe(0);
       expect(
@@ -5245,14 +5217,12 @@ snapshot_max_bytes = 64
       ).toEqual(["run_suspended", "run_resumed", "run_suspended"]);
     } finally {
       if (!firstStopped && first !== undefined) {
-        await stopRunningDaemons([
-          { signalProcess: firstSignal, running: first },
-        ]).catch(() => {});
+        firstSignal.emit("SIGTERM");
+        await first.catch(() => {});
       }
-      if (!secondStopped && second !== undefined && secondSignal !== undefined) {
-        await stopRunningDaemons([
-          { signalProcess: secondSignal, running: second },
-        ]).catch(() => {});
+      if (!secondStopped && second !== undefined) {
+        secondSignal?.emit("SIGTERM");
+        await second.catch(() => {});
       }
       await rm(agencHome, { recursive: true, force: true });
     }
@@ -5391,7 +5361,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
     expect(
       readRecoveredToolStatus(agencHome, process.cwd(), "tool-replay"),
     ).toBe("completed");
@@ -5517,7 +5488,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5626,7 +5598,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5778,7 +5751,8 @@ snapshot_max_bytes = 64
       ],
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -5844,7 +5818,8 @@ snapshot_max_bytes = 64
       1,
     );
 
-    await stopDaemonExpectZero(firstSignal, first);
+    firstSignal.emit("SIGTERM");
+    await expect(first).resolves.toBe(0);
     // The harness can only stop gracefully; reset the row to simulate a crash
     // after proving agent.create produced the running row and session snapshot.
     markAgentRunRunning(agencHome, process.cwd(), createdAgentId, sessionId);
@@ -5983,9 +5958,7 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopRunningDaemons([
-      { signalProcess: secondSignal, running: second },
-    ]);
+    secondSignal.emit("SIGTERM");
     await expect(second).resolves.toBe(0);
     await rm(agencHome, { recursive: true, force: true });
   });
@@ -6055,7 +6028,8 @@ snapshot_max_bytes = 64
       },
     });
 
-    await stopDaemonExpectZero(signalProcess, running);
+    signalProcess.emit("SIGTERM");
+    await expect(running).resolves.toBe(0);
 
     await rm(otherCwd, { recursive: true, force: true });
     await rm(agencHome, { recursive: true, force: true });
@@ -6077,7 +6051,7 @@ snapshot_max_bytes = 64
     );
     await expect(waitForPid(pidPath)).resolves.toBe(4100);
 
-    await stopDaemon(signalProcess, running);
+    signalProcess.emit("SIGTERM");
 
     await expect(running).resolves.toBe(1);
     await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
@@ -6740,7 +6714,8 @@ describe("daemon startup proxy isolation", () => {
     try {
       await waitForDaemonWebSocketUrl(io);
     } finally {
-      await stopDaemon(signalProcess, running);
+      signalProcess.emit("SIGTERM");
+      await Promise.allSettled([running]);
       await rm(agencHome, { recursive: true, force: true });
     }
   }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -605,7 +605,7 @@ async function stopDaemon(
   signalProcess: ReturnType<typeof createSignalProcess>,
   running: Promise<number>,
 ): Promise<void> {
-  await stopDaemon(signalProcess, running);
+  await stopRunningDaemons([{ signalProcess, running }]);
 }
 
 async function stopDaemonQuiet(
@@ -613,6 +613,24 @@ async function stopDaemonQuiet(
   running: Promise<number>,
 ): Promise<void> {
   await stopDaemon(signalProcess, running).catch(() => {});
+}
+
+async function stopDaemonExpectZero(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+): Promise<void> {
+  await stopDaemon(signalProcess, running);
+  await expect(running).resolves.toBe(0);
+}
+
+async function cleanupDaemonTest(
+  signalProcess: ReturnType<typeof createSignalProcess>,
+  running: Promise<number>,
+  stopped: boolean,
+  agencHome: string,
+): Promise<void> {
+  if (!stopped) await stopDaemonQuiet(signalProcess, running);
+  await rm(agencHome, { recursive: true, force: true });
 }
 
 async function availableLoopbackPort(): Promise<number> {
@@ -1421,14 +1439,10 @@ describe("AgenC daemon CLI", () => {
       expect(out).toMatch(/memory: rss=[\d.]+ MiB/);
       expect(out).toMatch(/sessions: active=\d+, closed=\d+, total=\d+/);
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -2714,9 +2728,8 @@ describe("AgenC daemon CLI", () => {
       });
       expect(spawnCount).toBe(0);
 
-      await stopDaemon(signalProcess, foreground);
+      await stopDaemonExpectZero(signalProcess, foreground);
       stopped = true;
-      await expect(foreground).resolves.toBe(0);
     } finally {
       publishForeground();
       if (!stopped) {
@@ -3093,14 +3106,10 @@ token_cap = 123
       );
       expect(io.stderrText()).toContain("AgenC daemon config reloaded");
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
       updateRuntimeConfig.mockRestore();
     }
     // Starts a real daemon and reloads its config; on a loaded runner that
@@ -3197,9 +3206,8 @@ workspace = ${JSON.stringify(workspaceB)}
       );
       expect(workspaceARead.body).toContain("ADMISSION_IDENTITY_REQUIRED");
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
       if (!stopped) {
         await stopDaemonQuiet(signalProcess, running);
@@ -3308,14 +3316,10 @@ workspace = ${JSON.stringify(process.cwd())}
       expect(host.terminatedPids).toEqual([]);
       await expect(readAgenCDaemonPid(pidPath)).resolves.toBe(4100);
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -4289,14 +4293,10 @@ backend = "local"
         initialSnapshots,
       );
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -4387,14 +4387,10 @@ backend = "local"
       });
       expect(permissionAgentIds).toEqual([created.agentId]);
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 
@@ -4612,14 +4608,10 @@ snapshot_max_bytes = 64
         readSnapshotTimes(agencHome, process.cwd(), "session-retention-bytes"),
       ).toEqual(["2026-05-06T00:00:01.000Z"]);
 
-      await stopDaemon(signalProcess, running);
+      await stopDaemonExpectZero(signalProcess, running);
       stopped = true;
-      await expect(running).resolves.toBe(0);
     } finally {
-      if (!stopped) {
-        await stopDaemonQuiet(signalProcess, running);
-      }
-      await rm(agencHome, { recursive: true, force: true });
+      await cleanupDaemonTest(signalProcess, running, stopped, agencHome);
     }
   });
 


### PR DESCRIPTION
## Why

Foreground-daemon cases in `daemon-cli.contract.test.ts` emit one `SIGTERM` then `await running`. `runAgenCDaemonCli` installs shutdown handlers only after services are constructed. The test signal process has no default action, so a signal in that window is dropped, the run never settles, and vitest reports a content-free 30s timeout. #2018 fixed one call site on `harness-tools`; the other teardowns share the same hang.

## Scope

- Add `stopRunningDaemons` (and `DAEMON_STOP_GRACE_MS`) in `runtime/tests/app-server/daemon-cli.contract.test.ts`.
- Route every foreground-daemon teardown through it (retry SIGTERM until the run settles, or fail with a named error).
- Leave the intentional mid-test SIGTERM in the lifecycle-lock authority case alone.

Out of scope: the `waitForPid` milestone-budget rewrite from #2018.

## Tradeoffs

Retry lives in the test harness, not production. Production signal delivery still has a default action. The harness double does not, so the retry belongs next to that double.

## Blast Radius

Contract tests only. Reviewers and CI see named stop failures instead of silent vitest timeouts when a teardown races handler install. Main stays flaky on slow runners until this lands.

## Verification

- Synthesized the lost-SIGTERM race against the helper: a single emit before the listener hung; `stopRunningDaemons` settled after 5 SIGTERMs (exit 0).
- Full `daemon-cli.contract.test.ts` on this Windows host is not a valid surface (path/ACL/Unix-socket failures dominate). CI Linux `pr-fast` is the package gate for this file.