### PR TITLE
fix(runtime): defer SessionStore diagnostics until flush exits

### DIFF
--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -1421,6 +1421,14 @@ export class SessionStore {
   private readonly diagnosticsBuffer: SessionStoreDiagnostic[] = [];
   private onDiagnostic?: (d: SessionStoreDiagnostic) => void;
   /**
+   * Depth of an in-flight `flushBatch`. Diagnostics raised while > 0 are
+   * deferred so a listener wired to `session.emit` (see
+   * `Session.mountRolloutStore`) cannot append a live-sequenced event into
+   * the batch currently being written (#2032).
+   */
+  private flushDepth = 0;
+  private readonly deferredFlushDiagnostics: SessionStoreDiagnostic[] = [];
+  /**
    * I-38 async fsync retries currently in flight. Tracked so `close()`
    * can wait for them to settle (or so tests can await completion).
    * Each entry is the Promise returned by `scheduleFsyncRetry()`.
@@ -1812,12 +1820,26 @@ export class SessionStore {
     for (const d of buffered) listener(d);
   }
 
-  private emitDiagnostic(d: SessionStoreDiagnostic): void {
+  private deliverDiagnostic(d: SessionStoreDiagnostic): void {
     if (this.onDiagnostic) {
       this.onDiagnostic(d);
     } else {
       this.diagnosticsBuffer.push(d);
     }
+  }
+
+  private emitDiagnostic(d: SessionStoreDiagnostic): void {
+    if (this.flushDepth > 0) {
+      this.deferredFlushDiagnostics.push(d);
+      return;
+    }
+    this.deliverDiagnostic(d);
+  }
+
+  private releaseDeferredFlushDiagnostics(): void {
+    if (this.flushDepth !== 0) return;
+    const deferred = this.deferredFlushDiagnostics.splice(0);
+    for (const d of deferred) this.deliverDiagnostic(d);
   }
 
   /** Drain any buffered diagnostics. Used by tests. */
@@ -1969,139 +1991,150 @@ export class SessionStore {
       this.batchOpenedAtMs = null;
       return true;
     }
-    // I-83 suspend detection: if the batch was open for > 10s (e.g.
-    // system suspend/resume gap), emit TWO marker events (warning +
-    // sentinel system_resumed_from) AHEAD of the pending batch.
-    // The markers are informational warnings (non-state-mutating in the
-    // reducer); the queued durable response_item / session_state lines
-    // that straddle the suspend window MUST be preserved and flushed,
-    // not discarded — dropping them permanently loses in-flight history.
-    if (
-      this.batchOpenedAtMs !== null &&
-      monotonicMs() - this.batchOpenedAtMs > I83_SUSPEND_DETECTION_MS
-    ) {
-      const durationMs = Math.round(monotonicMs() - this.batchOpenedAtMs);
-      this.batchOpenedAtMs = null;
-      // Prepend the two I-83 marker events so the log shows (a) the
-      // operator-visible warning and (b) a structural sentinel the
-      // reducer can reason about, while the original pending items
-      // remain queued behind them.
-      const warning: RolloutItem = {
-        type: "event_msg",
-        payload: {
-          id: "system",
-          msg: {
-            type: "warning",
-            payload: {
-              cause: "event_log_batch_delayed",
-              message: `event-log batch delayed ${durationMs}ms (I-83)`,
+    this.flushDepth += 1;
+    try {
+      // I-83 suspend detection: if the batch was open for > 10s (e.g.
+      // system suspend/resume gap), emit TWO marker events (warning +
+      // sentinel system_resumed_from) AHEAD of the pending batch.
+      // The markers are informational warnings (non-state-mutating in the
+      // reducer); the queued durable response_item / session_state lines
+      // that straddle the suspend window MUST be preserved and flushed,
+      // not discarded — dropping them permanently loses in-flight history.
+      if (
+        this.batchOpenedAtMs !== null &&
+        monotonicMs() - this.batchOpenedAtMs > I83_SUSPEND_DETECTION_MS
+      ) {
+        const durationMs = Math.round(monotonicMs() - this.batchOpenedAtMs);
+        this.batchOpenedAtMs = null;
+        // Prepend the two I-83 marker events so the log shows (a) the
+        // operator-visible warning and (b) a structural sentinel the
+        // reducer can reason about, while the original pending items
+        // remain queued behind them.
+        const warning: RolloutItem = {
+          type: "event_msg",
+          payload: {
+            id: "system",
+            msg: {
+              type: "warning",
+              payload: {
+                cause: "event_log_batch_delayed",
+                message: `event-log batch delayed ${durationMs}ms (I-83)`,
+              },
             },
           },
-        },
-      };
-      // Sentinel encoded as a warning with cause=system_resumed_from
-      // so it round-trips through the 24-variant EventMsg union
-      // without adding a new variant.
-      const sentinel: RolloutItem = {
-        type: "event_msg",
-        payload: {
-          id: "system",
-          msg: {
-            type: "warning",
-            payload: {
-              cause: "system_resumed_from",
-              message: `${durationMs}`,
+        };
+        // Sentinel encoded as a warning with cause=system_resumed_from
+        // so it round-trips through the 24-variant EventMsg union
+        // without adding a new variant.
+        const sentinel: RolloutItem = {
+          type: "event_msg",
+          payload: {
+            id: "system",
+            msg: {
+              type: "warning",
+              payload: {
+                cause: "system_resumed_from",
+                message: `${durationMs}`,
+              },
             },
           },
-        },
-      };
-      this.pending = [warning, sentinel, ...this.pending];
-      this.emitDiagnostic({
-        at: Date.now(),
-        level: "warning",
-        cause: "event_log_batch_delayed",
-        message: `system_resumed_from(${durationMs}ms)`,
-      });
-    }
-
-    // Record byte offsets for each event row before write so the
-    // index.json snapshot + fast-seek readers can jump to a specific
-    // seq without parsing the whole file.
-    let offsetAccumulator = this.fileSize;
-    for (const item of this.pending) {
-      if (item.type === "event_msg" && item.payload.seq !== undefined) {
-        this.offsetsBySeq.set(item.payload.seq, offsetAccumulator);
-      }
-      offsetAccumulator += Buffer.byteLength(
-        serializeRolloutItem(item),
-        "utf8",
-      );
-    }
-    this.boundIndexMap(this.offsetsBySeq);
-
-    const lines = this.pending.map(serializeRolloutItem).join("");
-    const toWrite = this.pending;
-    this.pending = [];
-    this.batchOpenedAtMs = null;
-
-    // `requeue` distinguishes the failure shapes (#11):
-    //   - writeSync failed before writing, or a partial append was rolled back
-    //     and fsync'd: the items can be re-queued into the degraded ring buffer
-    //     for a later complete re-append (requeue=true).
-    //   - a partial append could not be durably rolled back: the on-disk tail
-    //     is uncertain and re-append could duplicate it (requeue=false).
-    //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
-    //     bytes are ALREADY appended to the rollout on disk. Re-queueing
-    //     them would re-serialize + re-append the same rows on degraded
-    //     flush, bypassing the append()-level seq/UUID dedup and landing
-    //     duplicates in the JSONL (double on resume). So we enter
-    //     degraded mode WITHOUT re-queueing (requeue=false).
-    const routeToDegraded = (err: unknown, requeue: boolean) => {
-      if (isDegradedErrno(err)) {
-        // I-12 / I-38 path: enter degraded so subsequent appends buffer
-        // instead of touching the sick disk.
-        this.degraded.enterDegraded(
-          `${(err as { code?: string }).code} during append`,
-        );
-        if (requeue) {
-          for (const item of toWrite) this.degraded.append(item);
-        }
+        };
+        this.pending = [warning, sentinel, ...this.pending];
         this.emitDiagnostic({
           at: Date.now(),
-          level: "error",
-          cause: "rollout_degraded",
-          message: requeue
-            ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
-            : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
+          level: "warning",
+          cause: "event_log_batch_delayed",
+          message: `system_resumed_from(${durationMs}ms)`,
         });
-        return true;
       }
-      return false;
-    };
 
-    let committed = true;
-    try {
-      if (durable) {
-        // I-38: async retry on fsync failure routes to degraded via
-        // the callback. The bytes were already writeSync'd by this
-        // point, so we MUST NOT re-queue them (#11) — only enter
-        // degraded mode.
-        committed = this.writeBytesWithFsync(lines, (err) => {
-          routeToDegraded(err, /*requeue*/ false);
-        });
-      } else {
-        this.writeBytesAppendOnly(lines);
+      // Record byte offsets for each event row before write so the
+      // index.json snapshot + fast-seek readers can jump to a specific
+      // seq without parsing the whole file.
+      let offsetAccumulator = this.fileSize;
+      for (const item of this.pending) {
+        if (item.type === "event_msg" && item.payload.seq !== undefined) {
+          this.offsetsBySeq.set(item.payload.seq, offsetAccumulator);
+        }
+        offsetAccumulator += Buffer.byteLength(
+          serializeRolloutItem(item),
+          "utf8",
+        );
       }
-      this.fileSize += Buffer.byteLength(lines, "utf8");
-      this.trajectoryExport.writeItems(toWrite);
-    } catch (err) {
-      const safeToRequeue = !(err instanceof AppendRollbackError);
-      if (!routeToDegraded(err, safeToRequeue)) {
-        throw err;
+      this.boundIndexMap(this.offsetsBySeq);
+
+      const lines = this.pending.map(serializeRolloutItem).join("");
+      const toWrite = this.pending;
+      this.pending = [];
+      this.batchOpenedAtMs = null;
+
+      // `requeue` distinguishes the failure shapes (#11):
+      //   - writeSync failed before writing, or a partial append was rolled back
+      //     and fsync'd: the items can be re-queued into the degraded ring buffer
+      //     for a later complete re-append (requeue=true).
+      //   - a partial append could not be durably rolled back: the on-disk tail
+      //     is uncertain and re-append could duplicate it (requeue=false).
+      //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
+      //     bytes are ALREADY appended to the rollout on disk. Re-queueing
+      //     them would re-serialize + re-append the same rows on degraded
+      //     flush, bypassing the append()-level seq/UUID dedup and landing
+      //     duplicates in the JSONL (double on resume). So we enter
+      //     degraded mode WITHOUT re-queueing (requeue=false).
+      const routeToDegraded = (err: unknown, requeue: boolean) => {
+        if (isDegradedErrno(err)) {
+          // I-12 / I-38 path: enter degraded so subsequent appends buffer
+          // instead of touching the sick disk. Emit once on the transition
+          // so a live-sequenced diagnostic listener cannot re-enter flush
+          // and recurse on the still-failing write (#2032).
+          const entered = !this.degraded.isDegraded;
+          this.degraded.enterDegraded(
+            `${(err as { code?: string }).code} during append`,
+          );
+          if (requeue) {
+            for (const item of toWrite) this.degraded.append(item);
+          }
+          if (entered) {
+            this.emitDiagnostic({
+              at: Date.now(),
+              level: "error",
+              cause: "rollout_degraded",
+              message: requeue
+                ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
+                : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
+            });
+          }
+          return true;
+        }
+        return false;
+      };
+
+      let committed = true;
+      try {
+        if (durable) {
+          // I-38: async retry on fsync failure routes to degraded via
+          // the callback. The bytes were already writeSync'd by this
+          // point, so we MUST NOT re-queue them (#11) — only enter
+          // degraded mode.
+          committed = this.writeBytesWithFsync(lines, (err) => {
+            routeToDegraded(err, /*requeue*/ false);
+          });
+        } else {
+          this.writeBytesAppendOnly(lines);
+        }
+        this.fileSize += Buffer.byteLength(lines, "utf8");
+        this.trajectoryExport.writeItems(toWrite);
+      } catch (err) {
+        const safeToRequeue = !(err instanceof AppendRollbackError);
+        if (!routeToDegraded(err, safeToRequeue)) {
+          throw err;
+        }
+        committed = false;
       }
-      committed = false;
+      return committed;
+    } finally {
+      this.flushDepth -= 1;
+      this.releaseDeferredFlushDiagnostics();
     }
-    return committed;
   }
 
   /**

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -1993,152 +1993,148 @@ export class SessionStore {
     }
     this.flushDepth += 1;
     try {
-      return this.flushBatchUnlocked(durable);
+      // I-83 suspend detection: if the batch was open for > 10s (e.g.
+      // system suspend/resume gap), emit TWO marker events (warning +
+      // sentinel system_resumed_from) AHEAD of the pending batch.
+      // The markers are informational warnings (non-state-mutating in the
+      // reducer); the queued durable response_item / session_state lines
+      // that straddle the suspend window MUST be preserved and flushed,
+      // not discarded — dropping them permanently loses in-flight history.
+      if (
+        this.batchOpenedAtMs !== null &&
+        monotonicMs() - this.batchOpenedAtMs > I83_SUSPEND_DETECTION_MS
+      ) {
+        const durationMs = Math.round(monotonicMs() - this.batchOpenedAtMs);
+        this.batchOpenedAtMs = null;
+        // Prepend the two I-83 marker events so the log shows (a) the
+        // operator-visible warning and (b) a structural sentinel the
+        // reducer can reason about, while the original pending items
+        // remain queued behind them.
+        const warning: RolloutItem = {
+          type: "event_msg",
+          payload: {
+            id: "system",
+            msg: {
+              type: "warning",
+              payload: {
+                cause: "event_log_batch_delayed",
+                message: `event-log batch delayed ${durationMs}ms (I-83)`,
+              },
+            },
+          },
+        };
+        // Sentinel encoded as a warning with cause=system_resumed_from
+        // so it round-trips through the 24-variant EventMsg union
+        // without adding a new variant.
+        const sentinel: RolloutItem = {
+          type: "event_msg",
+          payload: {
+            id: "system",
+            msg: {
+              type: "warning",
+              payload: {
+                cause: "system_resumed_from",
+                message: `${durationMs}`,
+              },
+            },
+          },
+        };
+        this.pending = [warning, sentinel, ...this.pending];
+        this.emitDiagnostic({
+          at: Date.now(),
+          level: "warning",
+          cause: "event_log_batch_delayed",
+          message: `system_resumed_from(${durationMs}ms)`,
+        });
+      }
+
+      // Record byte offsets for each event row before write so the
+      // index.json snapshot + fast-seek readers can jump to a specific
+      // seq without parsing the whole file.
+      let offsetAccumulator = this.fileSize;
+      for (const item of this.pending) {
+        if (item.type === "event_msg" && item.payload.seq !== undefined) {
+          this.offsetsBySeq.set(item.payload.seq, offsetAccumulator);
+        }
+        offsetAccumulator += Buffer.byteLength(
+          serializeRolloutItem(item),
+          "utf8",
+        );
+      }
+      this.boundIndexMap(this.offsetsBySeq);
+
+      const lines = this.pending.map(serializeRolloutItem).join("");
+      const toWrite = this.pending;
+      this.pending = [];
+      this.batchOpenedAtMs = null;
+
+      // `requeue` distinguishes the failure shapes (#11):
+      //   - writeSync failed before writing, or a partial append was rolled back
+      //     and fsync'd: the items can be re-queued into the degraded ring buffer
+      //     for a later complete re-append (requeue=true).
+      //   - a partial append could not be durably rolled back: the on-disk tail
+      //     is uncertain and re-append could duplicate it (requeue=false).
+      //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
+      //     bytes are ALREADY appended to the rollout on disk. Re-queueing
+      //     them would re-serialize + re-append the same rows on degraded
+      //     flush, bypassing the append()-level seq/UUID dedup and landing
+      //     duplicates in the JSONL (double on resume). So we enter
+      //     degraded mode WITHOUT re-queueing (requeue=false).
+      const routeToDegraded = (err: unknown, requeue: boolean) => {
+        if (isDegradedErrno(err)) {
+          // I-12 / I-38 path: enter degraded so subsequent appends buffer
+          // instead of touching the sick disk. Emit once on the transition
+          // so a live-sequenced diagnostic listener cannot re-enter flush
+          // and recurse on the still-failing write (#2032).
+          const entered = !this.degraded.isDegraded;
+          this.degraded.enterDegraded(
+            `${(err as { code?: string }).code} during append`,
+          );
+          if (requeue) {
+            for (const item of toWrite) this.degraded.append(item);
+          }
+          if (entered) {
+            this.emitDiagnostic({
+              at: Date.now(),
+              level: "error",
+              cause: "rollout_degraded",
+              message: requeue
+                ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
+                : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
+            });
+          }
+          return true;
+        }
+        return false;
+      };
+
+      let committed = true;
+      try {
+        if (durable) {
+          // I-38: async retry on fsync failure routes to degraded via
+          // the callback. The bytes were already writeSync'd by this
+          // point, so we MUST NOT re-queue them (#11) — only enter
+          // degraded mode.
+          committed = this.writeBytesWithFsync(lines, (err) => {
+            routeToDegraded(err, /*requeue*/ false);
+          });
+        } else {
+          this.writeBytesAppendOnly(lines);
+        }
+        this.fileSize += Buffer.byteLength(lines, "utf8");
+        this.trajectoryExport.writeItems(toWrite);
+      } catch (err) {
+        const safeToRequeue = !(err instanceof AppendRollbackError);
+        if (!routeToDegraded(err, safeToRequeue)) {
+          throw err;
+        }
+        committed = false;
+      }
+      return committed;
     } finally {
       this.flushDepth -= 1;
       this.releaseDeferredFlushDiagnostics();
     }
-  }
-
-  private flushBatchUnlocked(durable: boolean): boolean {
-    // I-83 suspend detection: if the batch was open for > 10s (e.g.
-    // system suspend/resume gap), emit TWO marker events (warning +
-    // sentinel system_resumed_from) AHEAD of the pending batch.
-    // The markers are informational warnings (non-state-mutating in the
-    // reducer); the queued durable response_item / session_state lines
-    // that straddle the suspend window MUST be preserved and flushed,
-    // not discarded — dropping them permanently loses in-flight history.
-    if (
-      this.batchOpenedAtMs !== null &&
-      monotonicMs() - this.batchOpenedAtMs > I83_SUSPEND_DETECTION_MS
-    ) {
-      const durationMs = Math.round(monotonicMs() - this.batchOpenedAtMs);
-      this.batchOpenedAtMs = null;
-      // Prepend the two I-83 marker events so the log shows (a) the
-      // operator-visible warning and (b) a structural sentinel the
-      // reducer can reason about, while the original pending items
-      // remain queued behind them.
-      const warning: RolloutItem = {
-        type: "event_msg",
-        payload: {
-          id: "system",
-          msg: {
-            type: "warning",
-            payload: {
-              cause: "event_log_batch_delayed",
-              message: `event-log batch delayed ${durationMs}ms (I-83)`,
-            },
-          },
-        },
-      };
-      // Sentinel encoded as a warning with cause=system_resumed_from
-      // so it round-trips through the 24-variant EventMsg union
-      // without adding a new variant.
-      const sentinel: RolloutItem = {
-        type: "event_msg",
-        payload: {
-          id: "system",
-          msg: {
-            type: "warning",
-            payload: {
-              cause: "system_resumed_from",
-              message: `${durationMs}`,
-            },
-          },
-        },
-      };
-      this.pending = [warning, sentinel, ...this.pending];
-      this.emitDiagnostic({
-        at: Date.now(),
-        level: "warning",
-        cause: "event_log_batch_delayed",
-        message: `system_resumed_from(${durationMs}ms)`,
-      });
-    }
-
-    // Record byte offsets for each event row before write so the
-    // index.json snapshot + fast-seek readers can jump to a specific
-    // seq without parsing the whole file.
-    let offsetAccumulator = this.fileSize;
-    for (const item of this.pending) {
-      if (item.type === "event_msg" && item.payload.seq !== undefined) {
-        this.offsetsBySeq.set(item.payload.seq, offsetAccumulator);
-      }
-      offsetAccumulator += Buffer.byteLength(
-        serializeRolloutItem(item),
-        "utf8",
-      );
-    }
-    this.boundIndexMap(this.offsetsBySeq);
-
-    const lines = this.pending.map(serializeRolloutItem).join("");
-    const toWrite = this.pending;
-    this.pending = [];
-    this.batchOpenedAtMs = null;
-
-    // `requeue` distinguishes the failure shapes (#11):
-    //   - writeSync failed before writing, or a partial append was rolled back
-    //     and fsync'd: the items can be re-queued into the degraded ring buffer
-    //     for a later complete re-append (requeue=true).
-    //   - a partial append could not be durably rolled back: the on-disk tail
-    //     is uncertain and re-append could duplicate it (requeue=false).
-    //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
-    //     bytes are ALREADY appended to the rollout on disk. Re-queueing
-    //     them would re-serialize + re-append the same rows on degraded
-    //     flush, bypassing the append()-level seq/UUID dedup and landing
-    //     duplicates in the JSONL (double on resume). So we enter
-    //     degraded mode WITHOUT re-queueing (requeue=false).
-    const routeToDegraded = (err: unknown, requeue: boolean) => {
-      if (isDegradedErrno(err)) {
-        // I-12 / I-38 path: enter degraded so subsequent appends buffer
-        // instead of touching the sick disk. Emit once on the transition
-        // so a live-sequenced diagnostic listener cannot re-enter flush
-        // and recurse on the still-failing write (#2032).
-        const entered = !this.degraded.isDegraded;
-        this.degraded.enterDegraded(
-          `${(err as { code?: string }).code} during append`,
-        );
-        if (requeue) {
-          for (const item of toWrite) this.degraded.append(item);
-        }
-        if (entered) {
-          this.emitDiagnostic({
-            at: Date.now(),
-            level: "error",
-            cause: "rollout_degraded",
-            message: requeue
-              ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
-              : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
-          });
-        }
-        return true;
-      }
-      return false;
-    };
-
-    let committed = true;
-    try {
-      if (durable) {
-        // I-38: async retry on fsync failure routes to degraded via
-        // the callback. The bytes were already writeSync'd by this
-        // point, so we MUST NOT re-queue them (#11) — only enter
-        // degraded mode.
-        committed = this.writeBytesWithFsync(lines, (err) => {
-          routeToDegraded(err, /*requeue*/ false);
-        });
-      } else {
-        this.writeBytesAppendOnly(lines);
-      }
-      this.fileSize += Buffer.byteLength(lines, "utf8");
-      this.trajectoryExport.writeItems(toWrite);
-    } catch (err) {
-      const safeToRequeue = !(err instanceof AppendRollbackError);
-      if (!routeToDegraded(err, safeToRequeue)) {
-        throw err;
-      }
-      committed = false;
-    }
-    return committed;
   }
 
   /**

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -1993,148 +1993,152 @@ export class SessionStore {
     }
     this.flushDepth += 1;
     try {
-      // I-83 suspend detection: if the batch was open for > 10s (e.g.
-      // system suspend/resume gap), emit TWO marker events (warning +
-      // sentinel system_resumed_from) AHEAD of the pending batch.
-      // The markers are informational warnings (non-state-mutating in the
-      // reducer); the queued durable response_item / session_state lines
-      // that straddle the suspend window MUST be preserved and flushed,
-      // not discarded — dropping them permanently loses in-flight history.
-      if (
-        this.batchOpenedAtMs !== null &&
-        monotonicMs() - this.batchOpenedAtMs > I83_SUSPEND_DETECTION_MS
-      ) {
-        const durationMs = Math.round(monotonicMs() - this.batchOpenedAtMs);
-        this.batchOpenedAtMs = null;
-        // Prepend the two I-83 marker events so the log shows (a) the
-        // operator-visible warning and (b) a structural sentinel the
-        // reducer can reason about, while the original pending items
-        // remain queued behind them.
-        const warning: RolloutItem = {
-          type: "event_msg",
-          payload: {
-            id: "system",
-            msg: {
-              type: "warning",
-              payload: {
-                cause: "event_log_batch_delayed",
-                message: `event-log batch delayed ${durationMs}ms (I-83)`,
-              },
-            },
-          },
-        };
-        // Sentinel encoded as a warning with cause=system_resumed_from
-        // so it round-trips through the 24-variant EventMsg union
-        // without adding a new variant.
-        const sentinel: RolloutItem = {
-          type: "event_msg",
-          payload: {
-            id: "system",
-            msg: {
-              type: "warning",
-              payload: {
-                cause: "system_resumed_from",
-                message: `${durationMs}`,
-              },
-            },
-          },
-        };
-        this.pending = [warning, sentinel, ...this.pending];
-        this.emitDiagnostic({
-          at: Date.now(),
-          level: "warning",
-          cause: "event_log_batch_delayed",
-          message: `system_resumed_from(${durationMs}ms)`,
-        });
-      }
-
-      // Record byte offsets for each event row before write so the
-      // index.json snapshot + fast-seek readers can jump to a specific
-      // seq without parsing the whole file.
-      let offsetAccumulator = this.fileSize;
-      for (const item of this.pending) {
-        if (item.type === "event_msg" && item.payload.seq !== undefined) {
-          this.offsetsBySeq.set(item.payload.seq, offsetAccumulator);
-        }
-        offsetAccumulator += Buffer.byteLength(
-          serializeRolloutItem(item),
-          "utf8",
-        );
-      }
-      this.boundIndexMap(this.offsetsBySeq);
-
-      const lines = this.pending.map(serializeRolloutItem).join("");
-      const toWrite = this.pending;
-      this.pending = [];
-      this.batchOpenedAtMs = null;
-
-      // `requeue` distinguishes the failure shapes (#11):
-      //   - writeSync failed before writing, or a partial append was rolled back
-      //     and fsync'd: the items can be re-queued into the degraded ring buffer
-      //     for a later complete re-append (requeue=true).
-      //   - a partial append could not be durably rolled back: the on-disk tail
-      //     is uncertain and re-append could duplicate it (requeue=false).
-      //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
-      //     bytes are ALREADY appended to the rollout on disk. Re-queueing
-      //     them would re-serialize + re-append the same rows on degraded
-      //     flush, bypassing the append()-level seq/UUID dedup and landing
-      //     duplicates in the JSONL (double on resume). So we enter
-      //     degraded mode WITHOUT re-queueing (requeue=false).
-      const routeToDegraded = (err: unknown, requeue: boolean) => {
-        if (isDegradedErrno(err)) {
-          // I-12 / I-38 path: enter degraded so subsequent appends buffer
-          // instead of touching the sick disk. Emit once on the transition
-          // so a live-sequenced diagnostic listener cannot re-enter flush
-          // and recurse on the still-failing write (#2032).
-          const entered = !this.degraded.isDegraded;
-          this.degraded.enterDegraded(
-            `${(err as { code?: string }).code} during append`,
-          );
-          if (requeue) {
-            for (const item of toWrite) this.degraded.append(item);
-          }
-          if (entered) {
-            this.emitDiagnostic({
-              at: Date.now(),
-              level: "error",
-              cause: "rollout_degraded",
-              message: requeue
-                ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
-                : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
-            });
-          }
-          return true;
-        }
-        return false;
-      };
-
-      let committed = true;
-      try {
-        if (durable) {
-          // I-38: async retry on fsync failure routes to degraded via
-          // the callback. The bytes were already writeSync'd by this
-          // point, so we MUST NOT re-queue them (#11) — only enter
-          // degraded mode.
-          committed = this.writeBytesWithFsync(lines, (err) => {
-            routeToDegraded(err, /*requeue*/ false);
-          });
-        } else {
-          this.writeBytesAppendOnly(lines);
-        }
-        this.fileSize += Buffer.byteLength(lines, "utf8");
-        this.trajectoryExport.writeItems(toWrite);
-      } catch (err) {
-        const safeToRequeue = !(err instanceof AppendRollbackError);
-        if (!routeToDegraded(err, safeToRequeue)) {
-          throw err;
-        }
-        committed = false;
-      }
-      return committed;
+      return this.flushBatchUnlocked(durable);
     } finally {
       this.flushDepth -= 1;
       this.releaseDeferredFlushDiagnostics();
     }
+  }
+
+  private flushBatchUnlocked(durable: boolean): boolean {
+    // I-83 suspend detection: if the batch was open for > 10s (e.g.
+    // system suspend/resume gap), emit TWO marker events (warning +
+    // sentinel system_resumed_from) AHEAD of the pending batch.
+    // The markers are informational warnings (non-state-mutating in the
+    // reducer); the queued durable response_item / session_state lines
+    // that straddle the suspend window MUST be preserved and flushed,
+    // not discarded — dropping them permanently loses in-flight history.
+    if (
+      this.batchOpenedAtMs !== null &&
+      monotonicMs() - this.batchOpenedAtMs > I83_SUSPEND_DETECTION_MS
+    ) {
+      const durationMs = Math.round(monotonicMs() - this.batchOpenedAtMs);
+      this.batchOpenedAtMs = null;
+      // Prepend the two I-83 marker events so the log shows (a) the
+      // operator-visible warning and (b) a structural sentinel the
+      // reducer can reason about, while the original pending items
+      // remain queued behind them.
+      const warning: RolloutItem = {
+        type: "event_msg",
+        payload: {
+          id: "system",
+          msg: {
+            type: "warning",
+            payload: {
+              cause: "event_log_batch_delayed",
+              message: `event-log batch delayed ${durationMs}ms (I-83)`,
+            },
+          },
+        },
+      };
+      // Sentinel encoded as a warning with cause=system_resumed_from
+      // so it round-trips through the 24-variant EventMsg union
+      // without adding a new variant.
+      const sentinel: RolloutItem = {
+        type: "event_msg",
+        payload: {
+          id: "system",
+          msg: {
+            type: "warning",
+            payload: {
+              cause: "system_resumed_from",
+              message: `${durationMs}`,
+            },
+          },
+        },
+      };
+      this.pending = [warning, sentinel, ...this.pending];
+      this.emitDiagnostic({
+        at: Date.now(),
+        level: "warning",
+        cause: "event_log_batch_delayed",
+        message: `system_resumed_from(${durationMs}ms)`,
+      });
+    }
+
+    // Record byte offsets for each event row before write so the
+    // index.json snapshot + fast-seek readers can jump to a specific
+    // seq without parsing the whole file.
+    let offsetAccumulator = this.fileSize;
+    for (const item of this.pending) {
+      if (item.type === "event_msg" && item.payload.seq !== undefined) {
+        this.offsetsBySeq.set(item.payload.seq, offsetAccumulator);
+      }
+      offsetAccumulator += Buffer.byteLength(
+        serializeRolloutItem(item),
+        "utf8",
+      );
+    }
+    this.boundIndexMap(this.offsetsBySeq);
+
+    const lines = this.pending.map(serializeRolloutItem).join("");
+    const toWrite = this.pending;
+    this.pending = [];
+    this.batchOpenedAtMs = null;
+
+    // `requeue` distinguishes the failure shapes (#11):
+    //   - writeSync failed before writing, or a partial append was rolled back
+    //     and fsync'd: the items can be re-queued into the degraded ring buffer
+    //     for a later complete re-append (requeue=true).
+    //   - a partial append could not be durably rolled back: the on-disk tail
+    //     is uncertain and re-append could duplicate it (requeue=false).
+    //   - writeSync succeeded but fsync (+ its I-38 retry) failed: the
+    //     bytes are ALREADY appended to the rollout on disk. Re-queueing
+    //     them would re-serialize + re-append the same rows on degraded
+    //     flush, bypassing the append()-level seq/UUID dedup and landing
+    //     duplicates in the JSONL (double on resume). So we enter
+    //     degraded mode WITHOUT re-queueing (requeue=false).
+    const routeToDegraded = (err: unknown, requeue: boolean) => {
+      if (isDegradedErrno(err)) {
+        // I-12 / I-38 path: enter degraded so subsequent appends buffer
+        // instead of touching the sick disk. Emit once on the transition
+        // so a live-sequenced diagnostic listener cannot re-enter flush
+        // and recurse on the still-failing write (#2032).
+        const entered = !this.degraded.isDegraded;
+        this.degraded.enterDegraded(
+          `${(err as { code?: string }).code} during append`,
+        );
+        if (requeue) {
+          for (const item of toWrite) this.degraded.append(item);
+        }
+        if (entered) {
+          this.emitDiagnostic({
+            at: Date.now(),
+            level: "error",
+            cause: "rollout_degraded",
+            message: requeue
+              ? `${(err as { code?: string }).code ?? "unknown"} during append — ${toWrite.length} events queued in degraded ring buffer`
+              : `${(err as { code?: string }).code ?? "unknown"} during fsync — ${toWrite.length} events already on disk, entering degraded mode without re-queue`,
+          });
+        }
+        return true;
+      }
+      return false;
+    };
+
+    let committed = true;
+    try {
+      if (durable) {
+        // I-38: async retry on fsync failure routes to degraded via
+        // the callback. The bytes were already writeSync'd by this
+        // point, so we MUST NOT re-queue them (#11) — only enter
+        // degraded mode.
+        committed = this.writeBytesWithFsync(lines, (err) => {
+          routeToDegraded(err, /*requeue*/ false);
+        });
+      } else {
+        this.writeBytesAppendOnly(lines);
+      }
+      this.fileSize += Buffer.byteLength(lines, "utf8");
+      this.trajectoryExport.writeItems(toWrite);
+    } catch (err) {
+      const safeToRequeue = !(err instanceof AppendRollbackError);
+      if (!routeToDegraded(err, safeToRequeue)) {
+        throw err;
+      }
+      committed = false;
+    }
+    return committed;
   }
 
   /**

--- a/runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts
+++ b/runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts
@@ -9,9 +9,6 @@ import { SessionStore } from "../../src/session/session-store.js";
  * which appends a live-sequenced event. Emitting that channel mid-flush
  * (before pending is drained) joins the diagnostic to the in-flight batch and
  * can corrupt the canonical journal sequence.
- *
- * Invariant: a diagnostic raised during a flush must not land in the batch
- * that flush is writing.
  */
 describe("session-store flush diagnostic reentry (#2032)", () => {
   let home = "";
@@ -44,16 +41,19 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
     return store;
   }
 
-  function wireLiveSequencedDiagnostic(store: SessionStore, nextSeq: {
-    value: number;
-  }): void {
+  function wireLiveSequencedDiagnostic(
+    store: SessionStore,
+    nextSeq: { value: number },
+    onCause?: (cause: string) => void,
+  ): void {
     store.setDiagnosticListener((d) => {
+      onCause?.(d.cause);
       nextSeq.value += 1;
       store.append({
         id: `live-diag-${nextSeq.value}`,
         seq: nextSeq.value,
         msg: {
-          type: d.level,
+          type: "warning",
           payload: {
             cause: d.cause,
             message: `live-${d.cause}`,
@@ -63,27 +63,20 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
     });
   }
 
-  function rolloutLines(store: SessionStore): Array<Record<string, unknown>> {
+  function liveDiagIds(store: SessionStore): string[] {
     return readFileSync(store.rolloutPath, "utf8")
       .trimEnd()
       .split("\n")
       .filter((line) => line.length > 0)
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
-  }
-
-  function sequencedDiagnosticIds(
-    lines: Array<Record<string, unknown>>,
-  ): string[] {
-    return lines
-      .filter((line) => line.type === "event_msg")
-      .map((line) => line.payload as { id?: string; seq?: number })
+      .map((line) => JSON.parse(line) as { type?: string; payload?: { id?: string; seq?: number } })
       .filter(
-        (payload) =>
-          typeof payload.seq === "number" &&
-          typeof payload.id === "string" &&
-          payload.id.startsWith("live-diag-"),
+        (line) =>
+          line.type === "event_msg" &&
+          typeof line.payload?.seq === "number" &&
+          typeof line.payload?.id === "string" &&
+          line.payload.id.startsWith("live-diag-"),
       )
-      .map((payload) => payload.id as string);
+      .map((line) => line.payload!.id as string);
   }
 
   test("I-83 flush diagnostic does not join the in-flight batch", () => {
@@ -107,14 +100,13 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
 
     store.flushBatch(false);
 
-    const afterFlush = rolloutLines(store);
-    expect(sequencedDiagnosticIds(afterFlush)).toEqual([]);
-    expect(JSON.stringify(afterFlush)).toContain("event_log_batch_delayed");
-    expect(JSON.stringify(afterFlush)).toContain("before-suspend");
+    const afterFlush = readFileSync(store.rolloutPath, "utf8");
+    expect(liveDiagIds(store)).toEqual([]);
+    expect(afterFlush).toContain("event_log_batch_delayed");
+    expect(afterFlush).toContain("before-suspend");
 
     store.flushBatch(false);
-    const afterDrain = rolloutLines(store);
-    expect(sequencedDiagnosticIds(afterDrain)).toEqual(["live-diag-2"]);
+    expect(liveDiagIds(store)).toEqual(["live-diag-2"]);
     store.close();
   });
 
@@ -124,22 +116,8 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
     const committedPrefix = readFileSync(store.rolloutPath, "utf8");
     const delivered: string[] = [];
 
-    store.setDiagnosticListener((d) => {
-      delivered.push(d.cause);
-      nextSeq.value += 1;
-      // Non-durable warning mirrors a sequenced live append without nested
-      // durable flush against the still-failing write seam.
-      store.append({
-        id: `live-diag-${nextSeq.value}`,
-        seq: nextSeq.value,
-        msg: {
-          type: "warning",
-          payload: {
-            cause: d.cause,
-            message: `live-${d.cause}`,
-          },
-        },
-      });
+    wireLiveSequencedDiagnostic(store, nextSeq, (cause) => {
+      delivered.push(cause);
     });
     store.setWriteImplForTest(() => {
       throw Object.assign(new Error("injected ENOSPC"), { code: "ENOSPC" });
@@ -160,7 +138,7 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
     ).toBe(false);
 
     expect(readFileSync(store.rolloutPath, "utf8")).toBe(committedPrefix);
-    expect(sequencedDiagnosticIds(rolloutLines(store))).toEqual([]);
+    expect(liveDiagIds(store)).toEqual([]);
     expect(store.isDegraded).toBe(true);
     expect(delivered).toContain("rollout_degraded");
 
@@ -168,8 +146,7 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
       writeSync(fd, buffer, offset, length),
     );
     store.flushBatch(false);
-    const afterDrain = rolloutLines(store);
-    expect(sequencedDiagnosticIds(afterDrain)).toEqual(["live-diag-2"]);
+    expect(liveDiagIds(store)).toEqual(["live-diag-2"]);
     store.close();
   });
 });

--- a/runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts
+++ b/runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, readFileSync, rmSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { SessionStore } from "../../src/session/session-store.js";
+
+/**
+ * Regression for #2032: mountRolloutStore wires diagnostics to session.emit,
+ * which appends a live-sequenced event. Emitting that channel mid-flush
+ * (before pending is drained) joins the diagnostic to the in-flight batch and
+ * can corrupt the canonical journal sequence.
+ *
+ * Invariant: a diagnostic raised during a flush must not land in the batch
+ * that flush is writing.
+ */
+describe("session-store flush diagnostic reentry (#2032)", () => {
+  let home = "";
+  let origHome = "";
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-flush-diag-"));
+    origHome = process.env.AGENC_HOME ?? "";
+    process.env.AGENC_HOME = home;
+  });
+  afterEach(() => {
+    if (origHome) process.env.AGENC_HOME = origHome;
+    else delete process.env.AGENC_HOME;
+    if (home) rmSync(home, { recursive: true, force: true });
+  });
+
+  function openStore(sessionId: string): SessionStore {
+    const store = new SessionStore({
+      cwd: `/home/${sessionId}`,
+      sessionId,
+      agencVersion: "0.2.0",
+    });
+    store.open({
+      sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: `/home/${sessionId}`,
+      originator: "agenc-cli",
+      agencVersion: "0.2.0",
+    });
+    return store;
+  }
+
+  function wireLiveSequencedDiagnostic(store: SessionStore, nextSeq: {
+    value: number;
+  }): void {
+    store.setDiagnosticListener((d) => {
+      nextSeq.value += 1;
+      store.append({
+        id: `live-diag-${nextSeq.value}`,
+        seq: nextSeq.value,
+        msg: {
+          type: d.level,
+          payload: {
+            cause: d.cause,
+            message: `live-${d.cause}`,
+          },
+        },
+      });
+    });
+  }
+
+  function rolloutLines(store: SessionStore): Array<Record<string, unknown>> {
+    return readFileSync(store.rolloutPath, "utf8")
+      .trimEnd()
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+  }
+
+  function sequencedDiagnosticIds(
+    lines: Array<Record<string, unknown>>,
+  ): string[] {
+    return lines
+      .filter((line) => line.type === "event_msg")
+      .map((line) => line.payload as { id?: string; seq?: number })
+      .filter(
+        (payload) =>
+          typeof payload.seq === "number" &&
+          typeof payload.id === "string" &&
+          payload.id.startsWith("live-diag-"),
+      )
+      .map((payload) => payload.id as string);
+  }
+
+  test("I-83 flush diagnostic does not join the in-flight batch", () => {
+    const store = openStore("sess-2032-i83");
+    const nextSeq = { value: 0 };
+
+    store.append({
+      id: "queued-1",
+      seq: 1,
+      msg: {
+        type: "warning",
+        payload: { cause: "queued", message: "before-suspend" },
+      },
+    });
+    nextSeq.value = 1;
+    wireLiveSequencedDiagnostic(store, nextSeq);
+
+    (
+      store as unknown as { batchOpenedAtMs: number | null }
+    ).batchOpenedAtMs = -1_000_000;
+
+    store.flushBatch(false);
+
+    const afterFlush = rolloutLines(store);
+    expect(sequencedDiagnosticIds(afterFlush)).toEqual([]);
+    expect(JSON.stringify(afterFlush)).toContain("event_log_batch_delayed");
+    expect(JSON.stringify(afterFlush)).toContain("before-suspend");
+
+    store.flushBatch(false);
+    const afterDrain = rolloutLines(store);
+    expect(sequencedDiagnosticIds(afterDrain)).toEqual(["live-diag-2"]);
+    store.close();
+  });
+
+  test("rollout_degraded flush diagnostic does not join the failed batch", () => {
+    const store = openStore("sess-2032-degraded");
+    const nextSeq = { value: 1 };
+    const committedPrefix = readFileSync(store.rolloutPath, "utf8");
+    const delivered: string[] = [];
+
+    store.setDiagnosticListener((d) => {
+      delivered.push(d.cause);
+      nextSeq.value += 1;
+      // Non-durable warning mirrors a sequenced live append without nested
+      // durable flush against the still-failing write seam.
+      store.append({
+        id: `live-diag-${nextSeq.value}`,
+        seq: nextSeq.value,
+        msg: {
+          type: "warning",
+          payload: {
+            cause: d.cause,
+            message: `live-${d.cause}`,
+          },
+        },
+      });
+    });
+    store.setWriteImplForTest(() => {
+      throw Object.assign(new Error("injected ENOSPC"), { code: "ENOSPC" });
+    });
+
+    expect(
+      store.append(
+        {
+          id: "durable-1",
+          seq: 1,
+          msg: {
+            type: "turn_complete",
+            payload: { turnId: "t-2032" },
+          },
+        },
+        { durable: true },
+      ),
+    ).toBe(false);
+
+    expect(readFileSync(store.rolloutPath, "utf8")).toBe(committedPrefix);
+    expect(sequencedDiagnosticIds(rolloutLines(store))).toEqual([]);
+    expect(store.isDegraded).toBe(true);
+    expect(delivered).toContain("rollout_degraded");
+
+    store.setWriteImplForTest((fd, buffer, offset, length) =>
+      writeSync(fd, buffer, offset, length),
+    );
+    store.flushBatch(false);
+    const afterDrain = rolloutLines(store);
+    expect(sequencedDiagnosticIds(afterDrain)).toEqual(["live-diag-2"]);
+    store.close();
+  });
+});

--- a/runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts
+++ b/runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { SessionStore } from "../../src/session/session-store.js";
 
 /**
@@ -11,19 +11,18 @@ import { SessionStore } from "../../src/session/session-store.js";
  * can corrupt the canonical journal sequence.
  */
 describe("session-store flush diagnostic reentry (#2032)", () => {
-  let home = "";
-  let origHome = "";
-
-  beforeEach(() => {
-    home = mkdtempSync(join(tmpdir(), "agenc-flush-diag-"));
-    origHome = process.env.AGENC_HOME ?? "";
-    process.env.AGENC_HOME = home;
-  });
-  afterEach(() => {
-    if (origHome) process.env.AGENC_HOME = origHome;
-    else delete process.env.AGENC_HOME;
-    if (home) rmSync(home, { recursive: true, force: true });
-  });
+  function withTempAgencHome(body: () => void): void {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-2032-diag-"));
+    const prior = process.env.AGENC_HOME;
+    process.env.AGENC_HOME = dir;
+    try {
+      body();
+    } finally {
+      if (prior === undefined) delete process.env.AGENC_HOME;
+      else process.env.AGENC_HOME = prior;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
 
   function openStore(sessionId: string): SessionStore {
     const store = new SessionStore({
@@ -41,17 +40,17 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
     return store;
   }
 
-  function wireLiveSequencedDiagnostic(
+  function attachLiveSequencedDiagnostic(
     store: SessionStore,
-    nextSeq: { value: number },
+    seq: { n: number },
     onCause?: (cause: string) => void,
   ): void {
     store.setDiagnosticListener((d) => {
       onCause?.(d.cause);
-      nextSeq.value += 1;
+      seq.n += 1;
       store.append({
-        id: `live-diag-${nextSeq.value}`,
-        seq: nextSeq.value,
+        id: `live-diag-${seq.n}`,
+        seq: seq.n,
         msg: {
           type: "warning",
           payload: {
@@ -63,90 +62,99 @@ describe("session-store flush diagnostic reentry (#2032)", () => {
     });
   }
 
-  function liveDiagIds(store: SessionStore): string[] {
-    return readFileSync(store.rolloutPath, "utf8")
+  function liveDiagIds(rolloutPath: string): string[] {
+    return readFileSync(rolloutPath, "utf8")
       .trimEnd()
       .split("\n")
       .filter((line) => line.length > 0)
-      .map((line) => JSON.parse(line) as { type?: string; payload?: { id?: string; seq?: number } })
-      .filter(
+      .map(
         (line) =>
-          line.type === "event_msg" &&
-          typeof line.payload?.seq === "number" &&
-          typeof line.payload?.id === "string" &&
-          line.payload.id.startsWith("live-diag-"),
+          JSON.parse(line) as {
+            type?: string;
+            payload?: { id?: string; seq?: number };
+          },
       )
-      .map((line) => line.payload!.id as string);
+      .filter(
+        (row) =>
+          row.type === "event_msg" &&
+          typeof row.payload?.seq === "number" &&
+          typeof row.payload?.id === "string" &&
+          row.payload.id.startsWith("live-diag-"),
+      )
+      .map((row) => row.payload!.id as string);
   }
 
-  test("I-83 flush diagnostic does not join the in-flight batch", () => {
-    const store = openStore("sess-2032-i83");
-    const nextSeq = { value: 0 };
-
-    store.append({
-      id: "queued-1",
-      seq: 1,
-      msg: {
-        type: "warning",
-        payload: { cause: "queued", message: "before-suspend" },
-      },
-    });
-    nextSeq.value = 1;
-    wireLiveSequencedDiagnostic(store, nextSeq);
-
-    (
-      store as unknown as { batchOpenedAtMs: number | null }
-    ).batchOpenedAtMs = -1_000_000;
-
+  function expectDeferredThenReleased(store: SessionStore): void {
+    expect(liveDiagIds(store.rolloutPath)).toEqual([]);
     store.flushBatch(false);
-
-    const afterFlush = readFileSync(store.rolloutPath, "utf8");
-    expect(liveDiagIds(store)).toEqual([]);
-    expect(afterFlush).toContain("event_log_batch_delayed");
-    expect(afterFlush).toContain("before-suspend");
-
-    store.flushBatch(false);
-    expect(liveDiagIds(store)).toEqual(["live-diag-2"]);
+    expect(liveDiagIds(store.rolloutPath)).toEqual(["live-diag-2"]);
     store.close();
-  });
+  }
 
-  test("rollout_degraded flush diagnostic does not join the failed batch", () => {
-    const store = openStore("sess-2032-degraded");
-    const nextSeq = { value: 1 };
-    const committedPrefix = readFileSync(store.rolloutPath, "utf8");
-    const delivered: string[] = [];
-
-    wireLiveSequencedDiagnostic(store, nextSeq, (cause) => {
-      delivered.push(cause);
-    });
-    store.setWriteImplForTest(() => {
-      throw Object.assign(new Error("injected ENOSPC"), { code: "ENOSPC" });
-    });
-
-    expect(
-      store.append(
-        {
-          id: "durable-1",
+  test.each([
+    {
+      title: "I-83 flush diagnostic does not join the in-flight batch",
+      sessionId: "sess-2032-i83",
+      run(store: SessionStore, seq: { n: number }) {
+        store.append({
+          id: "queued-1",
           seq: 1,
           msg: {
-            type: "turn_complete",
-            payload: { turnId: "t-2032" },
+            type: "warning",
+            payload: { cause: "queued", message: "before-suspend" },
           },
-        },
-        { durable: true },
-      ),
-    ).toBe(false);
-
-    expect(readFileSync(store.rolloutPath, "utf8")).toBe(committedPrefix);
-    expect(liveDiagIds(store)).toEqual([]);
-    expect(store.isDegraded).toBe(true);
-    expect(delivered).toContain("rollout_degraded");
-
-    store.setWriteImplForTest((fd, buffer, offset, length) =>
-      writeSync(fd, buffer, offset, length),
-    );
-    store.flushBatch(false);
-    expect(liveDiagIds(store)).toEqual(["live-diag-2"]);
-    store.close();
+        });
+        seq.n = 1;
+        attachLiveSequencedDiagnostic(store, seq);
+        (
+          store as unknown as { batchOpenedAtMs: number | null }
+        ).batchOpenedAtMs = -1_000_000;
+        store.flushBatch(false);
+        const afterFlush = readFileSync(store.rolloutPath, "utf8");
+        expect(afterFlush).toContain("event_log_batch_delayed");
+        expect(afterFlush).toContain("before-suspend");
+        expectDeferredThenReleased(store);
+      },
+    },
+    {
+      title: "rollout_degraded flush diagnostic does not join the failed batch",
+      sessionId: "sess-2032-degraded",
+      run(store: SessionStore, seq: { n: number }) {
+        const committedPrefix = readFileSync(store.rolloutPath, "utf8");
+        const delivered: string[] = [];
+        seq.n = 1;
+        attachLiveSequencedDiagnostic(store, seq, (cause) => {
+          delivered.push(cause);
+        });
+        store.setWriteImplForTest(() => {
+          throw Object.assign(new Error("injected ENOSPC"), { code: "ENOSPC" });
+        });
+        expect(
+          store.append(
+            {
+              id: "durable-1",
+              seq: 1,
+              msg: {
+                type: "turn_complete",
+                payload: { turnId: "t-2032" },
+              },
+            },
+            { durable: true },
+          ),
+        ).toBe(false);
+        expect(readFileSync(store.rolloutPath, "utf8")).toBe(committedPrefix);
+        expect(store.isDegraded).toBe(true);
+        expect(delivered).toContain("rollout_degraded");
+        store.setWriteImplForTest((fd, buffer, offset, length) =>
+          writeSync(fd, buffer, offset, length),
+        );
+        expectDeferredThenReleased(store);
+      },
+    },
+  ])("$title", ({ sessionId, run }) => {
+    withTempAgencHome(() => {
+      const store = openStore(sessionId);
+      run(store, { n: 0 });
+    });
   });
 });


### PR DESCRIPTION
## Why

A diagnostic raised inside `SessionStore.flushBatch` can re-enter through `Session.mountRolloutStore`, which wires the channel to `session.emit`. That appends a live-sequenced event into the batch currently being written and corrupts the canonical journal sequence (#2032).

## Scope

- `runtime/src/session/session-store.ts`: defer `emitDiagnostic` while `flushDepth > 0`, then deliver after the flush unwinds. Emit `rollout_degraded` only on the degraded-mode transition.
- `runtime/tests/session/session-store-flush-diagnostic-reentry.test.ts`: regression for the I-83 and `rollout_degraded` paths.

Out of scope: making `SLOW_STORE_OP_THRESHOLD_MS` configurable.

## Tradeoffs

Deferred diagnostics still reach the listener after the flush. They no longer share the in-flight batch. `rollout_degraded` fires once per enter instead of on every failed write while already degraded.

## Blast Radius

Session stores with a diagnostic listener that appends (production `mountRolloutStore`). Resume integrity for I-83 suspend markers and disk-degraded flushes.

## Verification

- `node scripts/run-hermetic-vitest.mjs run tests/session/session-store-flush-diagnostic-reentry.test.ts` exit 0 (2 pass; failed before the fix with the diagnostic id present in the first flush)
- `node scripts/run-hermetic-vitest.mjs run tests/session/session-store-flush-diagnostic-reentry.test.ts tests/session/session-store-i83-suspend-drop.test.ts` exit 0 (3 pass)

Fixes https://github.com/tetsuo-ai/agenc-core/issues/2032