### PR TITLE
fix(tui): bound Neovim recovery preserve separately from cleanup exit

### DIFF
--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -49,6 +49,8 @@ export type StartEmbeddedNeovimOptions = {
   readonly startupTimeoutMs?: number;
   readonly operationTimeoutMs?: number;
   readonly cleanupTimeoutMs?: number;
+  /** Bounded ack wait for abnormal `:preserve` (separate from exit/kill). */
+  readonly recoveryPreservationTimeoutMs?: number;
   /** Force the deterministic broker boundary in Linux containment tests. */
   readonly linuxContainment?: "auto" | "subreaper";
   readonly onSnapshot: (snapshot: NeovimRenderSnapshot) => void;
@@ -158,6 +160,8 @@ export type NeovimCloseResult =
     };
 
 const DEFAULT_CLEANUP_TIMEOUT_MS = 1000;
+/** Real `:preserve` on slow hosted/user FS needs more headroom than force-exit. */
+const DEFAULT_RECOVERY_PRESERVATION_TIMEOUT_MS = 5_000;
 const DEFAULT_OPERATION_TIMEOUT_MS = 10_000;
 const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
 const INPUT_BUFFER_RETRY_DELAY_MS = 1;
@@ -621,6 +625,7 @@ export class EmbeddedNeovimSession {
   readonly #rpc: NeovimRpcTransport;
   readonly #ui: NeovimUi;
   readonly #cleanupTimeoutMs: number;
+  readonly #recoveryPreservationTimeoutMs: number;
   readonly #operationTimeoutMs: number;
   readonly #recovery: EmbeddedNeovimRecoveryInfo | null;
   readonly #onFatalError: ((error: Error) => void) | undefined;
@@ -641,11 +646,13 @@ export class EmbeddedNeovimSession {
     operationTimeoutMs = DEFAULT_OPERATION_TIMEOUT_MS,
     recovery: EmbeddedNeovimRecoveryInfo | null = null,
     onFatalError?: (error: Error) => void,
+    recoveryPreservationTimeoutMs = DEFAULT_RECOVERY_PRESERVATION_TIMEOUT_MS,
   ) {
     this.#handle = handle;
     this.#rpc = rpc;
     this.#ui = ui;
     this.#cleanupTimeoutMs = cleanupTimeoutMs;
+    this.#recoveryPreservationTimeoutMs = recoveryPreservationTimeoutMs;
     this.#operationTimeoutMs = operationTimeoutMs;
     this.#recovery = recovery;
     this.#onFatalError = onFatalError;
@@ -1518,7 +1525,7 @@ export class EmbeddedNeovimSession {
           const manifest = await this.#rpc.request(
             "nvim_exec_lua",
             [PRESERVE_DIRTY_BUFFERS_FOR_ABNORMAL_EXIT, []],
-            { timeoutMs: this.#cleanupTimeoutMs },
+            { timeoutMs: this.#recoveryPreservationTimeoutMs },
           );
           assertAbnormalRecoveryManifest(manifest, this.#recovery?.swap);
           this.#recoveryPreservationProven = true;
@@ -1889,6 +1896,8 @@ export async function startEmbeddedNeovim(
         options.operationTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
         preparation?.recovery ?? null,
         options.onFatalError,
+        options.recoveryPreservationTimeoutMs ??
+          DEFAULT_RECOVERY_PRESERVATION_TIMEOUT_MS,
       );
     } finally {
       startupAbort.signal.removeEventListener("abort", abortStartup);

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -620,6 +620,11 @@ export class NeovimStartupCleanupError extends AggregateError {
   }
 }
 
+export type EmbeddedNeovimSessionHooks = {
+  readonly onFatalError?: (error: Error) => void;
+  readonly recoveryPreservationTimeoutMs?: number;
+};
+
 export class EmbeddedNeovimSession {
   readonly #handle: NeovimProcessHandle;
   readonly #rpc: NeovimRpcTransport;
@@ -645,17 +650,18 @@ export class EmbeddedNeovimSession {
     cleanupTimeoutMs: number,
     operationTimeoutMs = DEFAULT_OPERATION_TIMEOUT_MS,
     recovery: EmbeddedNeovimRecoveryInfo | null = null,
-    onFatalError?: (error: Error) => void,
-    recoveryPreservationTimeoutMs = DEFAULT_RECOVERY_PRESERVATION_TIMEOUT_MS,
+    hooks: EmbeddedNeovimSessionHooks = {},
   ) {
     this.#handle = handle;
     this.#rpc = rpc;
     this.#ui = ui;
     this.#cleanupTimeoutMs = cleanupTimeoutMs;
-    this.#recoveryPreservationTimeoutMs = recoveryPreservationTimeoutMs;
+    this.#recoveryPreservationTimeoutMs =
+      hooks.recoveryPreservationTimeoutMs ??
+      DEFAULT_RECOVERY_PRESERVATION_TIMEOUT_MS;
     this.#operationTimeoutMs = operationTimeoutMs;
     this.#recovery = recovery;
-    this.#onFatalError = onFatalError;
+    this.#onFatalError = hooks.onFatalError;
   }
 
   get pid(): number {
@@ -1895,9 +1901,11 @@ export async function startEmbeddedNeovim(
         options.cleanupTimeoutMs ?? DEFAULT_CLEANUP_TIMEOUT_MS,
         options.operationTimeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
         preparation?.recovery ?? null,
-        options.onFatalError,
-        options.recoveryPreservationTimeoutMs ??
-          DEFAULT_RECOVERY_PRESERVATION_TIMEOUT_MS,
+        {
+          onFatalError: options.onFatalError,
+          recoveryPreservationTimeoutMs:
+            options.recoveryPreservationTimeoutMs,
+        },
       );
     } finally {
       startupAbort.signal.removeEventListener("abort", abortStartup);

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -1066,7 +1066,7 @@ describe("embedded Neovim lifecycle", () => {
     const handle = {
       child,
       pid: syntheticNeovimPid(7841),
-      kill: vi.fn(),
+      kill: fakeSupervisedKill(child),
     };
     const rpc = {
       request: vi.fn(async (method: string) =>
@@ -1097,7 +1097,7 @@ describe("embedded Neovim lifecycle", () => {
     expect(rpc.request).toHaveBeenCalledWith(
       "nvim_exec_lua",
       [expect.stringContaining("silent preserve"), []],
-      { timeoutMs: 5 },
+      { timeoutMs: 5_000 },
     );
     expect(rpc.request).not.toHaveBeenCalledWith("nvim_command", ["qa!"]);
     expect(child.stdin.end).not.toHaveBeenCalled();
@@ -1109,13 +1109,96 @@ describe("embedded Neovim lifecycle", () => {
     );
   });
 
+  it("accepts a late recovery preservation ack after the cleanup exit bound", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: syntheticNeovimPid(7843) });
+    const handle = {
+      child,
+      pid: syntheticNeovimPid(7843),
+      kill: fakeSupervisedKill(child),
+    };
+    const rpc = createDeadlineRpcHarness();
+    const session = new EmbeddedNeovimSession(
+      handle as any,
+      rpc as any,
+      { dispose: vi.fn() } as any,
+      1_000,
+      10_000,
+      null,
+      undefined,
+      2_500,
+    );
+
+    const cleaning = session.cleanup({ preserveRecovery: true });
+    await vi.waitFor(() => {
+      expect(rpc.pendingCount()).toBe(1);
+    });
+    const preserveCall = rpc.request.mock.calls.find(
+      (call) =>
+        call[0] === "nvim_exec_lua" &&
+        typeof call[1]?.[0] === "string" &&
+        call[1][0].includes("silent preserve"),
+    );
+    expect(preserveCall?.[2]).toEqual({ timeoutMs: 2_500 });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 1_200));
+    expect(rpc.pendingCount()).toBe(1);
+    expect(
+      rpc.reply(1, [
+        {
+          handle: 1,
+          changedtick: 9,
+          end_of_line: true,
+          swap: "/private/swap/late.swp",
+          size: 4096,
+        },
+      ]),
+    ).toBe(true);
+
+    await cleaning;
+    expect(session.recoveryPreservationProven).toBe(true);
+    expect(handle.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(rpc.close).toHaveBeenCalledWith("abnormal session cleanup");
+  });
+
+  it("rejects abnormal cleanup and retains the child when preservation never acks", async () => {
+    mockMissingProcessGroups();
+    const child = fakeChild({ pid: syntheticNeovimPid(7844) });
+    const handle = {
+      child,
+      pid: syntheticNeovimPid(7844),
+      kill: vi.fn(),
+    };
+    const rpc = createDeadlineRpcHarness();
+    const session = new EmbeddedNeovimSession(
+      handle as any,
+      rpc as any,
+      { dispose: vi.fn() } as any,
+      1_000,
+      10_000,
+      null,
+      undefined,
+      40,
+    );
+
+    await expect(session.cleanup({ preserveRecovery: true })).rejects.toThrow(
+      /exact recovery preservation was not confirmed:[\s\S]*nvim_exec_lua#1 timed out after 40ms/u,
+    );
+    expect(session.recoveryPreservationProven).toBe(false);
+    expect(handle.kill).not.toHaveBeenCalled();
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(child.stdin.end).not.toHaveBeenCalled();
+    expect(rpc.close).not.toHaveBeenCalled();
+    expect(rpc.reply(1, [{ handle: 1 }])).toBe(false);
+  });
+
   it("leaves the live process intact when abnormal recovery preservation is unproven", async () => {
     mockMissingProcessGroups();
     const child = fakeChild({ pid: syntheticNeovimPid(7842) });
     const handle = {
       child,
       pid: syntheticNeovimPid(7842),
-      kill: vi.fn(),
+      kill: fakeSupervisedKill(child),
     };
     const rpc = {
       request: vi
@@ -1839,6 +1922,22 @@ function fakeChild(options: {
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   return child;
+}
+
+/** Supervised kill for contract fakes: drop synthetic pid so Windows skips taskkill. */
+function fakeSupervisedKill(child: {
+  pid?: number;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  emit: (event: string) => boolean;
+}) {
+  return vi.fn(() => {
+    child.pid = undefined;
+    child.exitCode = 1;
+    child.signalCode = "SIGKILL";
+    child.emit("exit");
+    return true;
+  });
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -963,6 +963,7 @@ describe("embedded Neovim lifecycle", () => {
       5,
       null,
       onFatalError,
+      10,
     );
 
     await expect(session.input("i")).rejects.toBeInstanceOf(

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -750,13 +750,13 @@ describe("embedded Neovim lifecycle", () => {
       5,
     );
 
-    await expect(session.input("Ã©K")).resolves.toBe(true);
+    await expect(session.input("\u00e9K")).resolves.toBe(true);
 
     expect(
       rpc.request.mock.calls
         .filter((call) => call[0] === "nvim_input")
         .map((call) => call[1]),
-    ).toEqual([["Ã©K"], ["Ã©K"], ["K"]]);
+    ).toEqual([["\u00e9K"], ["\u00e9K"], ["K"]]);
     expect(acceptedByteCounts).toEqual([]);
     await session.cleanup();
   });

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+﻿import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter } from "node:events";
@@ -750,13 +750,13 @@ describe("embedded Neovim lifecycle", () => {
       5,
     );
 
-    await expect(session.input("éK")).resolves.toBe(true);
+    await expect(session.input("Ã©K")).resolves.toBe(true);
 
     expect(
       rpc.request.mock.calls
         .filter((call) => call[0] === "nvim_input")
         .map((call) => call[1]),
-    ).toEqual([["éK"], ["éK"], ["K"]]);
+    ).toEqual([["Ã©K"], ["Ã©K"], ["K"]]);
     expect(acceptedByteCounts).toEqual([]);
     await session.cleanup();
   });
@@ -790,7 +790,7 @@ describe("embedded Neovim lifecycle", () => {
       5,
       10_000,
       null,
-      onFatalError,
+      { onFatalError },
     );
 
     await expect(session.input("ab")).rejects.toMatchObject({
@@ -861,7 +861,7 @@ describe("embedded Neovim lifecycle", () => {
       5,
       10,
       null,
-      onFatalError,
+      { onFatalError },
     );
 
     await expect(session.click(4, 9)).rejects.toBeInstanceOf(
@@ -910,7 +910,7 @@ describe("embedded Neovim lifecycle", () => {
       5,
       50,
       null,
-      onFatalError,
+      { onFatalError },
     );
 
     const navigation = session.openFile("/workspace/next file.ts", 8, 3);
@@ -962,8 +962,7 @@ describe("embedded Neovim lifecycle", () => {
       2,
       5,
       null,
-      onFatalError,
-      10,
+      { onFatalError, recoveryPreservationTimeoutMs: 10 },
     );
 
     await expect(session.input("i")).rejects.toBeInstanceOf(
@@ -991,7 +990,7 @@ describe("embedded Neovim lifecycle", () => {
         5,
         10,
         null,
-        onFatalError,
+        { onFatalError },
       );
       return { handle, onFatalError, rpc, session };
     };
@@ -1126,8 +1125,7 @@ describe("embedded Neovim lifecycle", () => {
       1_000,
       10_000,
       null,
-      undefined,
-      2_500,
+      { recoveryPreservationTimeoutMs: 2_500 },
     );
 
     const cleaning = session.cleanup({ preserveRecovery: true });
@@ -1178,8 +1176,7 @@ describe("embedded Neovim lifecycle", () => {
       1_000,
       10_000,
       null,
-      undefined,
-      40,
+      { recoveryPreservationTimeoutMs: 40 },
     );
 
     await expect(session.cleanup({ preserveRecovery: true })).rejects.toThrow(

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
@@ -770,6 +770,9 @@ describe("real embedded Neovim lifecycle", () => {
       agencHome,
       beforeOpenFile,
       cleanupTimeoutMs: 250,
+      // Preservation is decoupled from cleanup exit; keep this short so the
+      // intentional 1000ms StageEditorProposal sleep still fails preserve.
+      recoveryPreservationTimeoutMs: 100,
       size: { rows: 4, columns: 32 },
       onSnapshot: () => {},
       onError: () => {},


### PR DESCRIPTION
## Why

Abnormal Neovim recovery preservation reused the short force-exit cleanup deadline (`cleanupTimeoutMs`, default 1s). On slow Windows hosted runners a live `:preserve` ack can arrive after that bound, so teardown fails closed, retains the process, and flakes the required `neovim-win-x64` lane (issue #1901).

## Scope

- `EmbeddedNeovimSession` keeps `#cleanupTimeoutMs` for exit/kill waits.
- Abnormal `nvim_exec_lua` `:preserve` uses `#recoveryPreservationTimeoutMs` (default 5s).
- Optional `recoveryPreservationTimeoutMs` on `StartEmbeddedNeovimOptions`.
- Contract tests: late ack after 1s succeeds under a longer preserve bound; no-ack still rejects and retains the child.

## Tradeoffs

No blind cleanup retry after an ambiguous RPC timeout. Fail-closed preserve semantics stay unchanged.

## Blast Radius

Touches embedded Neovim abnormal cleanup only. Normal `qa!` cleanup and kill deadlines are unchanged. Callers that pass a short `cleanupTimeoutMs` no longer shrink the preserve ack window.

## Verification

- Duplicate-check: no open/merged PR for #1901.
- Hermetic vitest focused on preservation contract cases (late ack, no-ack, preserve success, retry retain): exit 0, 4 passed.
