### PR TITLE
fix(tui): fail closed on BUFFER input while the provider opens

### DIFF
--- a/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
+++ b/runtime/src/tui/workbench/buffer/providers/BufferProviderController.ts
@@ -51,6 +51,16 @@ import { emptyProviderSnapshot, INLINE_BUFFER_CAPABILITIES } from "./types.js";
 
 type SelectionFactory = () => Promise<BufferProviderSelection>;
 
+/**
+ * Who owns ordinary keyboard input for a focused BUFFER surface.
+ * `transition` means consume without mutating or replaying: the provider is
+ * absent, still opening, or mid-replacement.
+ */
+export type BufferOrdinaryInputOwnership =
+  | "provider"
+  | "transition"
+  | "none";
+
 export type BufferProviderRuntimeContext = {
   readonly workspaceRoot?: string;
   readonly agencHome?: string;
@@ -83,6 +93,7 @@ export class BufferProviderController {
   #lastOpen: BufferProviderOpenOptions | null = null;
   #lastSize: BufferProviderResize | null = null;
   #openGeneration = 0;
+  #openInFlight = false;
   #cleanupPromise: Promise<void> | null = null;
   #replacementPromise: Promise<boolean> | null = null;
   #restartPromise: Promise<boolean> | null = null;
@@ -146,6 +157,17 @@ export class BufferProviderController {
 
   getSnapshot = (): BufferProviderSnapshot => this.#snapshot;
 
+  getOrdinaryInputOwnership(): BufferOrdinaryInputOwnership {
+    if (this.#replacementPromise !== null || this.#openInFlight) {
+      return "transition";
+    }
+    if (this.#provider !== null) return "provider";
+    if (this.#lastOpen !== null || this.#cleanupPromise !== null) {
+      return "transition";
+    }
+    return "none";
+  }
+
   getVisibleLines(): readonly BufferVisibleLine[] {
     return this.#provider?.getVisibleLines() ?? [];
   }
@@ -166,6 +188,20 @@ export class BufferProviderController {
     const generation = this.#openGeneration + 1;
     this.#openGeneration = generation;
     this.#lastOpen = { filePath, line };
+    this.#openInFlight = true;
+    try {
+      await this.#openGenerationBody(filePath, line, generation, selectionFactory);
+    } finally {
+      if (generation === this.#openGeneration) this.#openInFlight = false;
+    }
+  }
+
+  async #openGenerationBody(
+    filePath: string,
+    line: number,
+    generation: number,
+    selectionFactory: SelectionFactory,
+  ): Promise<void> {
     const cleanupPromise = this.#cleanupPromise;
     if (cleanupPromise) {
       try {
@@ -711,6 +747,7 @@ export class BufferProviderController {
   async close(options: BufferProviderCloseOptions = {}): Promise<boolean> {
     const generation = this.#openGeneration + 1;
     this.#openGeneration = generation;
+    this.#openInFlight = false;
     const replacementPromise = this.#replacementPromise;
     if (replacementPromise) {
       try {
@@ -785,6 +822,9 @@ export class BufferProviderController {
     onInlineCommand?: (command: BufferVimCommand) => void,
     isPaste = false,
   ): boolean {
+    if (this.getOrdinaryInputOwnership() === "transition") {
+      return true;
+    }
     return (
       this.#provider?.handleInput({
         input,
@@ -812,6 +852,7 @@ export class BufferProviderController {
   async cleanup(options: BufferProviderCleanupOptions = {}): Promise<void> {
     const generation = this.#openGeneration + 1;
     this.#openGeneration = generation;
+    this.#openInFlight = false;
     const replacementPromise = this.#replacementPromise;
     if (replacementPromise) {
       // A replacement owns teardown until it settles. This cleanup generation

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -861,15 +861,23 @@ export function BufferSurface({
         ) {
           return false;
         }
-        return store.handleInput(
-          input,
-          key,
-          inputContentSize.current,
-          executeVimCommand,
-          event.keypress.isPasted,
-        );
+        const ownership = store.getOrdinaryInputOwnership();
+        if (ownership === "transition") return true;
+        if (ownership === "provider") {
+          return store.handleInput(
+            input,
+            key,
+            inputContentSize.current,
+            executeVimCommand,
+            event.keypress.isPasted,
+          );
+        }
+        // Host selected a BUFFER path before the controller entered open.
+        // Fail closed so a later useInput handler cannot steal the keystroke.
+        return activePath !== null;
       },
       [
+        activePath,
         copyCrashDetails,
         crashed,
         executeVimCommand,

--- a/runtime/tests/tui/workbench/buffer-provider-boundary.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-provider-boundary.contract.test.ts
@@ -683,6 +683,7 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     }));
 
     expect(controller.getVisibleLines()).toEqual([]);
+    expect(controller.getOrdinaryInputOwnership()).toBe("none");
     await expect(controller.save()).resolves.toBe(false);
     await expect(controller.revert()).resolves.toBeUndefined();
     await expect(controller.close()).resolves.toBe(true);
@@ -696,6 +697,82 @@ describe("embedded Neovim BUFFER provider boundary", () => {
     expect(controller.click(1, 1)).toBe(false);
     controller.focus(true);
     await expect(controller.reopen()).resolves.toBeUndefined();
+  });
+
+  it("consumes ordinary input while provider open is in flight", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const provider = createFakeProvider("inline");
+    const controller = new BufferProviderController(async () => {
+      await gate;
+      return {
+        kind: "inline",
+        provider,
+        discovery: null,
+        reason: "deferred",
+      };
+    });
+
+    const opening = controller.open("deferred.ts", 1);
+    expect(controller.getOrdinaryInputOwnership()).toBe("transition");
+    expect(controller.handleInput("q", baseKey(), { rows: 1, columns: 1 })).toBe(
+      true,
+    );
+    expect(provider.handleInput).not.toHaveBeenCalled();
+
+    release();
+    await opening;
+    expect(controller.getOrdinaryInputOwnership()).toBe("provider");
+    expect(controller.handleInput("x", baseKey(), { rows: 1, columns: 1 })).toBe(
+      true,
+    );
+    expect(provider.handleInput).toHaveBeenCalledTimes(1);
+  });
+
+  it("consumes ordinary input during provider replacement", async () => {
+    const first = createFakeProvider("inline");
+    const controller = new BufferProviderController(async () => ({
+      kind: "inline",
+      provider: first,
+      discovery: null,
+      reason: "first",
+    }));
+    await controller.open("a.ts", 1);
+    first.handleInput.mockClear();
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const second = createFakeProvider("neovim");
+    controller.setSelectionFactoryForTesting(async () => {
+      await gate;
+      return {
+        kind: "neovim",
+        provider: second,
+        discovery: usableDiscovery,
+      };
+    });
+
+    const replacing = controller.open("b.ts", 1);
+    expect(controller.getOrdinaryInputOwnership()).toBe("transition");
+    expect(controller.handleInput("x", baseKey(), { rows: 1, columns: 1 })).toBe(
+      true,
+    );
+    expect(first.handleInput).not.toHaveBeenCalled();
+    expect(second.handleInput).not.toHaveBeenCalled();
+
+    release();
+    await replacing;
+    expect(controller.getOrdinaryInputOwnership()).toBe("provider");
+    expect(controller.getSnapshot().provider.kind).toBe("neovim");
+    expect(controller.handleInput("y", baseKey(), { rows: 1, columns: 1 })).toBe(
+      true,
+    );
+    expect(second.handleInput).toHaveBeenCalledTimes(1);
+    expect(first.handleInput).not.toHaveBeenCalled();
   });
 
   it("keeps the last open request when the active provider refuses close", async () => {

--- a/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
@@ -686,6 +686,7 @@ function createStoreHarness() {
     click: vi.fn(() => false),
     focus: vi.fn(),
     getShowTabsMode: vi.fn<() => "auto" | "always" | "never">(() => "auto"),
+    getOrdinaryInputOwnership: vi.fn(() => "provider" as const),
     getSnapshot: vi.fn(() => bufferHarness.snapshot),
     getVisibleLines: vi.fn(() => bufferHarness.visibleLines),
     goToDefinition: vi.fn(async () => false),

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -30,6 +30,7 @@ import {
   getWorkbenchBufferProviderController,
   resetWorkbenchBufferProviderControllerForTesting,
 } from "../../../src/tui/workbench/buffer/providers/BufferProviderController.js";
+import { InlineBufferProvider } from "../../../src/tui/workbench/buffer/providers/inline/InlineBufferProvider.js";
 import { createNeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
 import {
   emptyProviderSnapshot,
@@ -1072,8 +1073,30 @@ describe("BufferSurface", () => {
     }
   });
 
-  it("captures focused vim insert text before later input handlers", async () => {
+  it("consumes focused BUFFER input while the provider is still opening", async () => {
     await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
+
+    let releaseOpen!: () => void;
+    const openGate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const provider = new InlineBufferProvider({
+      reason: "deferred open test",
+      store: getWorkbenchBufferStore(),
+    });
+    const handleInput = vi.spyOn(provider, "handleInput");
+    getWorkbenchBufferProviderController().setSelectionFactoryForTesting(
+      async () => {
+        await openGate;
+        return {
+          kind: "inline" as const,
+          provider,
+          discovery: null,
+          reason: "deferred open test",
+        };
+      },
+    );
+
     const { stdin, stdout } = createStreams();
     const root = await createRoot({
       patchConsole: false,
@@ -1102,22 +1125,49 @@ describe("BufferSurface", () => {
             </KeybindingSetup>
           </AppStateProvider>,
         );
-        await sleep();
+        await flush();
       });
 
-      stdin.write("q");
-      await sleep();
+      expect(
+        getWorkbenchBufferProviderController().getOrdinaryInputOwnership(),
+      ).toBe("transition");
 
-      expect(getWorkbenchBufferStore().getText()).toBe("const value = 1;\n");
-      stdin.write("i");
-      await sleep();
       stdin.write("q");
-      await sleep();
+      stdin.write("i");
+      stdin.write("q");
+      stdin.write("\x1b[200~paste\x1b[201~");
+      stdin.write("j");
+      await flush();
+
+      expect(leaked).toEqual([]);
+      expect(handleInput).not.toHaveBeenCalled();
+      expect(getWorkbenchBufferStore().getText()).toBe("");
+
+      releaseOpen();
+      await vi.waitFor(() =>
+        expect(
+          getWorkbenchBufferProviderController().getOrdinaryInputOwnership(),
+        ).toBe("provider"),
+      );
+      await vi.waitFor(() =>
+        expect(getWorkbenchBufferStore().getText()).toBe("const value = 1;\n"),
+      );
+
+      expect(leaked).toEqual([]);
+      expect(handleInput).not.toHaveBeenCalled();
+      expect(getWorkbenchBufferStore().getSnapshot().vimMode).toBe("NORMAL");
+
+      stdin.write("i");
+      await flush();
+      stdin.write("q");
+      await flush();
 
       expect(getWorkbenchBufferStore().getText()).toBe("qconst value = 1;\n");
       expect(getWorkbenchBufferStore().getSnapshot().vimMode).toBe("INSERT");
       expect(leaked).toEqual([]);
+      expect(handleInput).toHaveBeenCalled();
     } finally {
+      releaseOpen();
       root.unmount();
       stdin.end();
       stdout.end();


### PR DESCRIPTION
## Why

Focused BUFFER could return false from its top-level input capture while the editor provider was still opening or being replaced. Later useInput handlers then received keys typed for the focused editor, which is the hosted race behind #1932.

## Scope

- Add `BufferOrdinaryInputOwnership` and `getOrdinaryInputOwnership()` on `BufferProviderController`.
- Fail closed in `handleInput` and `BufferSurface` capture while ownership is `transition`, including the host-path gap before `open` starts.
- Replace the 100 ms sleep contract with a deferred selection-factory proof; cover open and replacement at the controller boundary.

## Tradeoffs

Keys typed during open are discarded rather than queued. Replay would target an unknown editor mode and file.

## Blast Radius

TUI BUFFER keyboard ownership only. Ready-provider Vim, paste, and outside-wheel fallthrough stay on the prior paths.

## Verification

- `node scripts/run-hermetic-vitest.mjs run tests/tui/workbench/buffer-surface.test.tsx -t "consumes focused BUFFER input"` (exit 0)
- `node scripts/run-hermetic-vitest.mjs run tests/tui/workbench/buffer-provider-boundary.contract.test.ts -t "consumes ordinary input|conservative fallback"` (exit 0)
- `node scripts/run-hermetic-vitest.mjs run tests/tui/workbench/buffer-surface-handlers.test.tsx` (exit 0)

Fixes #1932
