### PR TITLE
test(memory): synchronize extraction shutdown on child-start barrier

### DIFF
--- a/runtime/tests/services/extractMemories/extractMemories.test.ts
+++ b/runtime/tests/services/extractMemories/extractMemories.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./memory-paths.js";
 import { formatMemoryManifest, scanMemoryFiles } from "../../memory/index.js";
 import { resolveAgentRuntimeOptions } from "../../session/runtime-options.js";
+import { createControlledPromise } from "../../helpers/controlled-async.js";
 
 vi.mock("bun:bundle", () => ({ feature: () => false }));
 vi.mock("../../tools.js", () => ({}));
@@ -939,13 +940,17 @@ describe("extract memories service", () => {
   });
 
   it("drains active extraction work before the caller finishes shutdown", async () => {
-    let resolveChild!: () => void;
-    const runChild = vi.fn(
-      async () =>
-        new Promise<{ readonly outcome: "completed" }>((resolve) => {
-          resolveChild = () => resolve({ outcome: "completed" });
-        }),
+    const childStarted = createControlledPromise<void>(
+      "extractMemories child started",
     );
+    const releaseChild = createControlledPromise<void>(
+      "extractMemories child release",
+    );
+    const runChild = vi.fn(async () => {
+      childStarted.resolve(undefined);
+      await releaseChild.promise;
+      return { outcome: "completed" as const };
+    });
     initExtractMemories({
       env: {},
       minEligibleTurns: 1,
@@ -960,19 +965,40 @@ describe("extract memories service", () => {
     const extraction = executeExtractMemories(
       extractionContext({ cwd: root, messages }),
     );
-    await eventually(() => expect(runChild).toHaveBeenCalledOnce());
 
-    let drained = false;
-    const drain = drainPendingExtraction(1000).then(() => {
-      drained = true;
-    });
-    await Promise.resolve();
-    expect(drained).toBe(false);
+    try {
+      await Promise.race([
+        childStarted.promise,
+        new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => {
+            reject(
+              new Error(
+                "timed out waiting for memory extraction child to start",
+              ),
+            );
+          }, 10_000);
+          timer.unref?.();
+        }),
+      ]);
+      expect(runChild).toHaveBeenCalledOnce();
 
-    resolveChild();
-    await extraction;
-    await drain;
-    expect(drained).toBe(true);
+      let drained = false;
+      const drain = drainPendingExtraction(1000).then(() => {
+        drained = true;
+      });
+      await Promise.resolve();
+      expect(drained).toBe(false);
+      releaseChild.assertPending();
+
+      releaseChild.resolve(undefined);
+      await extraction;
+      await drain;
+      expect(drained).toBe(true);
+    } finally {
+      if (releaseChild.state().status === "pending") {
+        releaseChild.resolve(undefined);
+      }
+    }
   });
 
   it("scopes extraction cursors by session and memory directory", async () => {


### PR DESCRIPTION
## Why

Hosted shard load can finish the local `eventually` helper's 20 `setTimeout(0)` turns before path resolution and the memory scan reach `runChild`. The drain shutdown test then fails with zero `runChild` calls even though production registered the extraction and would drain it. See #1939 and the flake on PR #1876 at `9e199345`.

## Scope

- `runtime/tests/services/extractMemories/extractMemories.test.ts`: replace the scheduler-spin wait in `drains active extraction work before the caller finishes shutdown` with `createControlledPromise` barriers (`childStarted` / `releaseChild`).
- Await child entry before `drainPendingExtraction`, assert the drain stays pending while the child is held, release in `finally` so a failed assertion cannot leak work.
- Reuse `tests/helpers/controlled-async.ts`. No production changes. No drain timeout change. No new sleeps or higher poll counts.

## Tradeoffs

Left the coalesce test on `eventually` for the smallest diff. Same race class exists there if hosted load worsens; barrierize it in a follow-up if it flakes.

## Blast Radius

Test-only. Consumers of memory extraction see no behavior change. Maintainers get a deterministic shutdown contract in the suite instead of a load-sensitive spin.

## Verification

- Forced repro: delayed `resolveMemoryDirectory` past 20 macrotasks → old `eventually` path failed with `expected runChild once, got 0`.
- Same delay with barriers → pass.
- Focused hermetic vitest `-t "drains active extraction work"` exit 0.
- Focused hermetic vitest `-t "extract memories service"` exit 0 (14 pass).
- Sonar self-check: unique New Code in one test; reused existing deferred helper; no `*Unlocked` re-indent clones; single `finally` site.

Closes #1939
