### PR TITLE
test(runtime): make supervised cleanup-backstop poisoning deterministic

### DIFF
--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -58,6 +58,19 @@ export interface SupervisedProcessControl {
   stop(reason?: "consumer_limit"): void;
 }
 
+/**
+ * Deterministic prepared-spawn settlement for authority tests. When set, the
+ * supervisor skips spawning and resolves with this cleanup verdict under the
+ * active broker lease.
+ */
+export interface SupervisedProcessDeterministicSettlement {
+  readonly backstopExpired: boolean;
+  readonly processTreeCleanupProven: boolean;
+  readonly stopReason?: SupervisedProcessStopReason;
+  readonly forced?: boolean;
+  readonly error?: Error;
+}
+
 export interface SupervisedProcessOptions {
   /** Optional caller-supplied deadline. Omitted means unbounded. */
   readonly timeoutMs?: number;
@@ -77,6 +90,12 @@ export interface SupervisedProcessOptions {
   readonly settleBackstopMs?: number;
   /** Select the Linux containment backend explicitly for deterministic tests. */
   readonly linuxContainment?: "auto" | "subreaper";
+  /**
+   * Test-only settlement that replaces real process cleanup. Production
+   * callers must omit this; prepared-spawn authority tests use it to enter
+   * the unproven-cleanup path without racing OS exit timing.
+   */
+  readonly deterministicSettlement?: SupervisedProcessDeterministicSettlement;
   readonly onStdout?: (
     chunk: Buffer,
     control: SupervisedProcessControl,
@@ -1494,6 +1513,59 @@ export function windowsCommandLineUtf16CodeUnits(
   );
 }
 
+/**
+ * True when prepared-spawn cleanup authority failed and the broker must close.
+ * Kept dependency-light so authority tests can fabricate the same verdict the
+ * supervisor produces after a real backstop or boundary protocol failure.
+ */
+export function isPreparedSpawnCleanupUnproven(
+  result: Pick<
+    SupervisedProcessResult,
+    "backstopExpired" | "processTreeCleanupProven"
+  >,
+): boolean {
+  return (
+    result.backstopExpired === true ||
+    result.processTreeCleanupProven === false
+  );
+}
+
+/** Throw when prepared-spawn cleanup could not be proven under the broker lease. */
+export function throwIfPreparedSpawnCleanupUnproven(
+  result: SupervisedProcessResult,
+): void {
+  if (!isPreparedSpawnCleanupUnproven(result)) {
+    return;
+  }
+  const terminal =
+    result.backstopExpired === true
+      ? "backstop"
+      : "unproven_tree";
+  throw new SandboxExecutionLeaseCleanupError(
+    `sandbox lifecycle could not prove supervised process-tree cleanup (${terminal})`,
+    result.error === undefined ? undefined : { cause: result.error },
+  );
+}
+
+function resolveDeterministicSettlement(
+  settlement: SupervisedProcessDeterministicSettlement,
+): SupervisedProcessResult {
+  return {
+    exitCode: null,
+    signal: null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    ...(settlement.stopReason !== undefined
+      ? { stopReason: settlement.stopReason }
+      : {}),
+    forced: settlement.forced === true,
+    backstopExpired: settlement.backstopExpired,
+    processTreeCleanupProven: settlement.processTreeCleanupProven,
+    ...(settlement.error !== undefined ? { error: settlement.error } : {}),
+    processStarted: true,
+  };
+}
+
 /** Run a native helper with bounded output and process-tree cleanup. */
 export function runSupervisedProcess(
   command: SupervisedProcessCommand | SandboxPreparedSpawn,
@@ -1505,19 +1577,14 @@ export function runSupervisedProcess(
         options.signal === undefined
           ? lifecycleSignal
           : AbortSignal.any([options.signal, lifecycleSignal]);
-      const result = await runSupervisedProcessCommand(preparedCommand, {
-        ...options,
-        signal,
-      });
-      if (
-        result.backstopExpired ||
-        result.processTreeCleanupProven === false
-      ) {
-        throw new SandboxExecutionLeaseCleanupError(
-          "sandbox lifecycle could not prove supervised process-tree cleanup",
-          result.error === undefined ? undefined : { cause: result.error },
-        );
-      }
+      const result =
+        options.deterministicSettlement !== undefined
+          ? resolveDeterministicSettlement(options.deterministicSettlement)
+          : await runSupervisedProcessCommand(preparedCommand, {
+              ...options,
+              signal,
+            });
+      throwIfPreparedSpawnCleanupUnproven(result);
       return result;
     });
   }

--- a/runtime/tests/utils/supervisedProcess.test.ts
+++ b/runtime/tests/utils/supervisedProcess.test.ts
@@ -30,11 +30,13 @@ vi.mock("../../src/utils/windows-system-path.js", () => ({
 }));
 
 import {
+  isPreparedSpawnCleanupUnproven,
   isProcessTreeAlive,
   runSupervisedProcess,
   signalProcessTree,
   spawnContainedProcess,
   terminateProcessTreeAndWait,
+  throwIfPreparedSpawnCleanupUnproven,
 } from "../../src/utils/supervisedProcess.js";
 import {
   SandboxExecutionBroker,
@@ -317,8 +319,71 @@ async function withFakeWindowsTaskkill(
 }
 
 describe("runSupervisedProcess", () => {
+  it("treats backstop expiry and unproven trees as prepared-spawn cleanup failure", () => {
+    expect(
+      isPreparedSpawnCleanupUnproven({
+        backstopExpired: true,
+        processTreeCleanupProven: true,
+      }),
+    ).toBe(true);
+    expect(
+      isPreparedSpawnCleanupUnproven({
+        backstopExpired: false,
+        processTreeCleanupProven: false,
+      }),
+    ).toBe(true);
+    expect(
+      isPreparedSpawnCleanupUnproven({
+        backstopExpired: false,
+        processTreeCleanupProven: true,
+      }),
+    ).toBe(false);
+    expect(() =>
+      throwIfPreparedSpawnCleanupUnproven({
+        exitCode: null,
+        signal: null,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        forced: true,
+        backstopExpired: true,
+        processTreeCleanupProven: false,
+      }),
+    ).toThrow(/backstop/u);
+  });
+
+  it("poisons broker authority when prepared-spawn cleanup is unproven", async () => {
+    const broker = new SandboxExecutionBroker({
+      mode: "danger_full_access",
+      cwd: process.cwd(),
+    });
+    const prepared = broker.prepareSpawn(
+      "hook",
+      nodeCommand("process.exit(0)"),
+    );
+
+    await expect(
+      runSupervisedProcess(prepared, {
+        maxOutputBytes: 1_024,
+        deterministicSettlement: {
+          backstopExpired: true,
+          processTreeCleanupProven: false,
+          stopReason: "timeout",
+          forced: true,
+        },
+      }),
+    ).rejects.toBeInstanceOf(SandboxExecutionLeaseCleanupError);
+
+    expect(broker.isClosedAfterLifecycleAuthorityFailure()).toBe(true);
+    expect(() =>
+      broker.prepareSpawn("hook", nodeCommand("process.exit(0)")),
+    ).toThrow(/cleanup was unproven/u);
+    await expect(
+      transitionSandboxExecutionBrokerMode(broker, "read_only"),
+    ).rejects.toThrow(/closed after an authority failure/u);
+  });
+
   it.runIf(process.platform !== "win32")(
-    "poisons broker authority when an ordinary timeout reaches the cleanup backstop",
+    "keeps broker authority after an ordinary forced timeout with proven cleanup",
     async () => {
       const broker = new SandboxExecutionBroker({
         mode: "danger_full_access",
@@ -331,22 +396,23 @@ describe("runSupervisedProcess", () => {
         ),
       );
 
-      await expect(
-        runSupervisedProcess(prepared, {
-          timeoutMs: 250,
-          maxOutputBytes: 1_024,
-          terminateGraceMs: 0,
-          settleBackstopMs: 0,
-        }),
-      ).rejects.toBeInstanceOf(SandboxExecutionLeaseCleanupError);
+      const result = await runSupervisedProcess(prepared, {
+        timeoutMs: 250,
+        maxOutputBytes: 1_024,
+        terminateGraceMs: 0,
+        settleBackstopMs: 1_000,
+      });
 
-      expect(broker.isClosedAfterLifecycleAuthorityFailure()).toBe(true);
-      expect(() =>
-        broker.prepareSpawn("hook", nodeCommand("process.exit(0)")),
-      ).toThrow(/cleanup was unproven/u);
+      expect(result).toMatchObject({
+        stopReason: "timeout",
+        forced: true,
+        backstopExpired: false,
+        processTreeCleanupProven: true,
+      });
+      expect(broker.isClosedAfterLifecycleAuthorityFailure()).toBe(false);
       await expect(
-        transitionSandboxExecutionBrokerMode(broker, "read_only"),
-      ).rejects.toThrow(/closed after an authority failure/u);
+        transitionSandboxExecutionBrokerMode(broker, "danger_full_access"),
+      ).resolves.toBeUndefined();
     },
   );
 


### PR DESCRIPTION
## Why

`runSupervisedProcess` broker-poisoning coverage raced `settleBackstopMs: 0` against real SIGKILL cleanup. Hosted default-suite 1/4 on PR #1949 saw proven cleanup win that race, so the test expected `SandboxExecutionLeaseCleanupError` and failed. Fixes #1955.

## Scope

- Extract `isPreparedSpawnCleanupUnproven` / `throwIfPreparedSpawnCleanupUnproven` for the prepared-spawn authority decision.
- Add `deterministicSettlement` so authority tests enter unproven cleanup under an active broker lease without OS exit timing.
- Replace the flaky zero-delay backstop race with a deterministic poison path; keep a real-process ordinary-timeout case that asserts proven cleanup and open broker authority.
- Retain Linux subreaper fault-library coverage.
- Include the winning terminal (`backstop` / `unproven_tree`) in the cleanup error message.

## Tradeoffs

A test-only settlement seam lives on `SupervisedProcessOptions` so `runSupervisedProcess` still exercises the real prepared-spawn lease and poison path. Raising timeouts or retrying the old race was rejected.

## Blast Radius

Callers that omit `deterministicSettlement` keep prior behavior aside from the richer cleanup error suffix. Broker poisoning on unproven cleanup is unchanged.

## Verification

- Reproduce: issue-hosted interleaving (`stopReason: timeout`, `forced: true`, `backstopExpired: false`, `processTreeCleanupProven: true`) vs required `SandboxExecutionLeaseCleanupError`; local Windows host skips the old posix race (`runIf !== win32`).
- Focused hermetic vitest on `tests/utils/supervisedProcess.test.ts` for the deterministic poison and decision helpers: exit 0 (2 passed).
- Self-check New Code: thin unique helpers; no `*Unlocked` re-indent clones; no N identical finally rewrites.
