### PR TITLE
an index told not to refresh in the background stops doing it from a watcher event

### DIFF
--- a/runtime/src/memory/full-corpus-index.ts
+++ b/runtime/src/memory/full-corpus-index.ts
@@ -1209,7 +1209,22 @@ export class PersistentMemoryIndex {
   }
 
   #scheduleBackgroundRefresh(root: BoundRoot): void {
-    if (this.#closed || this.#backgroundRefreshes.has(root.rootId)) return;
+    // A watcher event is the other way in here, and it used to bypass the
+    // constructor's `backgroundRefresh` choice entirely: an index built with
+    // `backgroundRefresh: false` still started a background refresh loop the
+    // moment a file under one of its roots changed. That loop takes the same
+    // builder lease as a foreground writer, and `query()` correctly refuses a
+    // generation whose lease is held, so a caller that asked for no background
+    // work could still have a read answered with zero candidates. The option
+    // is checked here, at the single place background work is started, rather
+    // than only at the one call site in `refresh()`.
+    if (
+      this.#closed ||
+      !this.#backgroundRefreshEnabled ||
+      this.#backgroundRefreshes.has(root.rootId)
+    ) {
+      return;
+    }
     const controller = new AbortController();
     this.#backgroundRefreshes.set(root.rootId, controller);
     void this.#continueBackgroundRefresh(root, controller).finally(() => {


### PR DESCRIPTION
## Why

`PersistentMemoryIndex` ignored its own `backgroundRefresh: false` option on
the fs-watcher path. The flag (`#backgroundRefreshEnabled`) was consulted in
exactly one place, the tail of `refresh()`, while `#recordWatcherChange`'s
100 ms debounce called `#scheduleBackgroundRefresh` unconditionally. An index
explicitly constructed with background refresh disabled therefore started a
background refresh loop the moment any file under one of its roots changed.

That loop is a writer. It takes the same builder lease as a foreground slice,
and `#pinCurrentGenerations` correctly refuses to pin a generation whose
builder lease is live, so `query()` returns `kind: "unavailable"`,
`candidates: []`, `reason: "memory index update is in progress; retry the
query"`.

This surfaced as a test that reddens branch gates at random:

```
tests/memory/full-corpus-index.test.ts
  > lands an incremental update after overlapping readers outlive the prior drain bound
AssertionError: expected [] to have a length of 1 but got +0
```

It is not a flaky test. It was reporting this bug.

Two points worth stating precisely:

1. **The incremental update is not lost.** At the moment the query reads
   empty, the row is in the generation with the new description and the
   generation id is unchanged. The write path is correct; only the read is
   refused.
2. **The unwanted loop is what makes the window wide enough for CI to hit it.**
   Instrumenting `#continueBackgroundRefresh` over one run counts 8,081
   background slices, 8,067 of them returning "memory index build slice is
   already active". While the test deliberately holds a foreground slice for
   1.1 s, the watcher-scheduled loop spins on `setImmediate`, rewriting
   `memory_index_roots.last_used_at_ms` every pass: roughly 6,700 SQLite
   writes per second against the same database the readers and the final query
   use. On the two-worker `ubuntu-24.04` runner that is what turns a narrow
   window into one CI actually lands on.

## What changed

`runtime/src/memory/full-corpus-index.ts` — the `backgroundRefreshEnabled`
check moves into `#scheduleBackgroundRefresh`, the single place background work
is started, so every entry point honours it: the watcher debounce, the audit's
degraded-health path, and `refresh()`.

One file, +16/-1. **No test file is touched.**

## Evidence

**Mechanism, in isolation.** An index built with `backgroundRefresh: false`,
given nothing but a plain external `writeFile` under its root, fired the
incremental-read hook, i.e. a background refresh started from the watcher event
alone; while it held the lease (`builder_owner` non-null in the DB),
`index.query()` returned `{kind: "unavailable", reason: "memory index update is
in progress; retry the query", candidates: []}`.

**Deterministic reproduction on `main`**, with none of this change present, by
forcing the losing interleaving with three stalls, each of them something a
loaded runner does on its own: an extra watcher event delivered after a
foreground slice takes its change-log snapshot; a watcher-scheduled background
slice taking 400 ms while it owns the lease; the loop's contention retry
landing inside the gap rather than after it.

Unmodified test, 10 runs: **0 passed / 10 failed**, every one with the same
assertion, message and line as CI run 33671842373. A timestamped trace of the
losing run shows the order explicitly: the writer's explicit slice releases the
lease, the writer's background loop claims it, the reader index claims and
applies incrementally, and the test's final query pins and is refused.

**With the fix, same forcing: 10 passed / 0 failed** — no background slice is
started, so no builder lease exists when the final query pins.

Without forcing, the race does not open on an idle M-series machine: 15/15 and
12/12 green before, 12/12 after. Local green proves nothing here, which is why
the forcing is the evidence.

## Falsification

Both halves of the behaviour the test names are still load-bearing with the fix
in place:

- `#waitForIncrementalReaderDrain` made to give up instead of waiting for the
  readers → fails at line 1593, `expected { kind: 'refresh_pending' } to match
  object { kind: 'complete' }`.
- `#upsertIndexedEntry` skipped so the incremental update never lands → fails
  at line 1610 on the description.
- Restored → passes.

## Tests

No new test. This is a product fix under an existing one that was already
asserting the right thing; the falsification above is what establishes it still
has teeth.

## Not changed

- The option defaults to `true` and is set only by tests, so production
  behaviour is unaffected.
- The one test that genuinely relies on watcher-driven background refresh
  ("observes an external update through the debounced watcher and refreshes
  atomically") uses `createFixture()`, which leaves the option at its default,
  and passes.
- No test file, and nothing outside `full-corpus-index.ts`.

## Counterpart PRs

Unblocks #2015, whose gate this was reddening.
