### PR TITLE
the shell deletion guard asks the home authority, not the environment

### DIFF
--- a/runtime/src/tools/system/shell-mutation-permission.ts
+++ b/runtime/src/tools/system/shell-mutation-permission.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { resolveHomeContext } from "../../config/home.js";
 
 import {
   readToolRuntimeContext,
@@ -92,9 +93,20 @@ export function shellDeletionProtectedRoots(
   } catch {
     // A store without a resolvable home contributes nothing.
   }
-  const envHome = process.env.AGENC_HOME;
-  if (typeof envHome === "string" && envHome.trim().length > 0) {
-    roots.add(resolve(envHome.trim()));
+  // Without a session there is still a home to protect, and it is not always
+  // the one AGENC_HOME names: when the variable is unset the home is the
+  // platform default, which a raw env read leaves unguarded entirely. Resolve
+  // it through the canonical authority so this guard protects the same
+  // directory the rest of the runtime treats as home, rather than keeping a
+  // second interpretation of the variable here.
+  try {
+    const ambient = resolveHomeContext().path;
+    if (typeof ambient === "string" && ambient.trim().length > 0) {
+      roots.add(resolve(ambient.trim()));
+    }
+  } catch {
+    // A refused or unresolvable ambient home contributes nothing; the session
+    // root above still stands.
   }
   return [...roots];
 }

--- a/runtime/tests/tools/system/shell-mutation-permission.test.ts
+++ b/runtime/tests/tools/system/shell-mutation-permission.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { shellDeletionProtectedRoots } from "src/tools/system/shell-mutation-permission.js";
+
+describe("shell deletion protected roots", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("protects the configured home when there is no session to ask", () => {
+    // The guard runs for bare tool use too, where no session and therefore no
+    // ConfigStore exists. It must still name the home directory a shell
+    // command may not remove.
+    vi.stubEnv("AGENC_HOME", "/srv/agenc-home");
+
+    expect(shellDeletionProtectedRoots(undefined)).toContain(
+      resolve("/srv/agenc-home"),
+    );
+  });
+
+  test("protects the platform default home when the variable is unset", () => {
+    // Reading AGENC_HOME directly left this case unguarded: with the variable
+    // unset the home is <platform home>/.agenc, and a raw env read contributes
+    // nothing at all. Resolving through the canonical home authority is what
+    // closes that gap.
+    vi.stubEnv("AGENC_HOME", "");
+
+    expect(shellDeletionProtectedRoots(undefined)).toContain(
+      resolve(join(homedir(), ".agenc")),
+    );
+  });
+});


### PR DESCRIPTION
## Why

`shellDeletionProtectedRoots` decides which directories a shell command may
never remove. It read `process.env.AGENC_HOME` directly, which breaks the home
authority boundary that
`tests/config/home-state-authority.architecture.test.ts` enforces:

```
FAIL tests/config/home-state-authority.architecture.test.ts
  > keeps direct AGENC_HOME reads at explicit ingress and isolation boundaries
AssertionError: expected [ Array(1) ] to deeply equal []
+   "tools/system/shell-mutation-permission.ts"
```

Five files are allowed to read that variable; everything else goes through
`config/home.ts`, because home resolution has one implementation and a second
interpretation of the variable drifts from it.

The direct read also left a real gap, which is the part worth caring about.
When `AGENC_HOME` is unset the home is the platform default,
`<platform home>/.agenc`, and a raw env read contributes **nothing at all**. So
in the configuration most users are in, this guard protected no home directory.

The violation is already on `main` and surfaced on #2015's gate, where the
architecture test happened to be in the affected set.

## What changed

`runtime/src/tools/system/shell-mutation-permission.ts` — the ambient root now
comes from `resolveHomeContext()`, the canonical resolver, instead of the raw
variable. The session's own `ConfigStore` home is still preferred and still
added first. The resolver call is wrapped: a refused or unresolvable ambient
home must contribute nothing rather than throw inside a permission check, which
matches how the session lookup above it already behaves.

`runtime/tests/tools/system/shell-mutation-permission.test.ts` — new. The
module had no test file at all.

## Evidence

- The architecture suite passes: `tests/config/home-state-authority.architecture.test.ts`,
  `tests/llm/shell-write-policy.test.ts` and `tests/tools/system/bash.test.ts`
  together are 164 passed.
- The new test is **falsification-checked** against the previous
  implementation: with `main`'s version of the guard restored, it is 1 failed /
  1 passed. The failing one is the platform-default case, which is exactly the
  gap. The explicit-`AGENC_HOME` case passes either way, as it should, since
  the raw read did handle that one.
- Before adding the test I confirmed nothing else covered this path: removing
  the ambient root entirely left `tests/llm/shell-write-policy.test.ts` at 21
  passed, so the behaviour was previously unguarded by any test.

## Tests

Two, both on `shellDeletionProtectedRoots` with no session context, which is
the bare-tool-use path the ambient root exists for:

- protects the configured home when there is no session to ask
- protects the platform default home when the variable is unset

## Not changed

- The session `ConfigStore` home stays the preferred source and is unchanged.
- No change to what the guard does with the roots once collected, or to any
  caller.
- The five files on the architecture allowlist are untouched; this one is
  removed from the violation set rather than added to the allowlist, because it
  is not an ingress or isolation boundary.
