### PR TITLE
fence the detached memory-extraction fork for the whole suite

### DIFF
--- a/runtime/tests/helpers/hermetic-env.mjs
+++ b/runtime/tests/helpers/hermetic-env.mjs
@@ -456,6 +456,55 @@ export const HERMETIC_HARNESS_INPUT_ENV_VARS = Object.freeze([
   'AGENC_TEST_ZERO_SKIP_REPORT',
 ])
 
+/**
+ * The turn-end memory-extraction fork, pinned OFF for the whole suite.
+ *
+ * The fork used to be fenced inside the turn: runTurn awaited
+ * `drainPendingExtraction()` before returning its terminal. Those two awaits
+ * were deliberately removed so extraction stops blocking a user's turn, which
+ * left a detached child agent that
+ *   - samples the SESSION'S OWN provider (src/agents/run-agent.ts ->
+ *     src/phases/stream-model.ts), i.e. the test's own mock, whose call
+ *     counter many tests assert on;
+ *   - runs on a lane keyed by conversation id, on a cadence of every third
+ *     eligible terminating turn (DEFAULT_MIN_ELIGIBLE_TURNS);
+ *   - is started with `void executeExtractMemories(...)` in
+ *     src/phases/commit.ts, so whether its samples land before an assertion
+ *     reads that counter is wall clock, not program order.
+ *
+ * Any test that drives three or more terminating turns and counts model calls
+ * or post-sampling launches is therefore intermittently wrong, and the failure
+ * lands in whichever test happened to be running when the counter reached the
+ * cadence -- not in the test that caused it. Two files had already been
+ * patched one at a time for exactly this (a retry test that counted three
+ * sampling attempts instead of two; a six-turn back-off test that counted 14,
+ * 12 or 16 depending on the scheduler), each time by stubbing this same
+ * variable for one file. Pinning it once here closes the class instead of
+ * waiting for the next file to go red.
+ *
+ * This is the documented production kill switch
+ * (src/memory/extraction-triggers.ts `isMemoryExtractionDisabledByEnv`), used
+ * the same way this file already pins AGENC_AUTH_BACKEND away from a live
+ * login: a default for ambient behavior no test asked for, not a claim that
+ * extraction is broken.
+ *
+ * It does NOT disable the tests that own extraction. The service reads its
+ * env from an injected dependency, so every caller of
+ * `initExtractMemories({ env })` -- all of
+ * tests/services/extractMemories/extractMemories.test.ts and
+ * tests/session/lifecycle.test.ts -- passes its own `env: {}` and never
+ * consults process.env; tests/memory/extraction-triggers.test.ts likewise
+ * calls `isMemoryExtractionDisabledByEnv` with an explicit object. A test that
+ * genuinely wants the process.env path live opts in with
+ * `vi.stubEnv(MEMORY_EXTRACTION_FENCE_ENV_VAR, "0")`, which runs after this
+ * pin (setup-file hooks are registered first) and wins.
+ *
+ * tests/session/background-extraction-fence.test.ts holds both halves: that
+ * the pin keeps the fork out of a turn-counting test, and that removing it
+ * puts the child's samples back on the same mock.
+ */
+export const MEMORY_EXTRACTION_FENCE_ENV_VAR = 'AGENC_DISABLE_EXTRACT_MEMORIES'
+
 /** OS launch inputs that cannot be synthesized portably. */
 export const HERMETIC_LAUNCH_PASSTHROUGH_ENV_VARS = Object.freeze([
   'COMSPEC',
@@ -538,6 +587,7 @@ export function createHermeticLaunchEnv(source, runRoot, options = {}) {
 
   const tempRoot = join(runRoot, 'tmp')
   mkdirSync(tempRoot, { mode: 0o700, recursive: true })
+  env[MEMORY_EXTRACTION_FENCE_ENV_VAR] = '1'
   env.FORCE_COLOR = '0'
   applyHermeticGitEnv(env, runRoot)
   env.LANG = 'C.UTF-8'
@@ -644,6 +694,9 @@ export function getOrCreateHermeticTestHome() {
  *   synthetic host env objects (daemon-cli contract tests) still pin
  *   `[auth] backend = "local"` in their own config.toml — see the
  *   task-27 breadcrumbs in tests/app-server/daemon-cli.contract.test.ts.
+ * - Forces MEMORY_EXTRACTION_FENCE_ENV_VAR=1 so the detached turn-end memory
+ *   extraction child never samples a test's provider mock behind its back.
+ *   See the constant's own comment for the failure class and the opt-in.
  */
 export function sanitizeHermeticEnv(env, agencHome, options = {}) {
   const marker = lockedHermeticRuntimeMarker()
@@ -667,6 +720,7 @@ export function sanitizeHermeticEnv(env, agencHome, options = {}) {
   env.AGENC_HOME = agencHome
   env.AGENC_MANAGED_HOME = join(agencHome, 'managed-home')
   env.AGENC_AUTH_BACKEND = 'local'
+  env[MEMORY_EXTRACTION_FENCE_ENV_VAR] = '1'
   env.HOME = agencHome
   env.USERPROFILE = agencHome
   env.APPDATA = join(agencHome, 'appdata')

--- a/runtime/tests/hermetic-env.test.ts
+++ b/runtime/tests/hermetic-env.test.ts
@@ -20,11 +20,13 @@ import {
   HERMETIC_PROVIDER_CREDENTIAL_ENV_VARS,
   HERMETIC_RUNTIME_AUTH_ENV_VARS,
   HERMETIC_STRIPPED_ENV_VARS,
+  MEMORY_EXTRACTION_FENCE_ENV_VAR,
   sanitizeHermeticEnv,
 } from "./helpers/hermetic-env.mjs";
 import { BUILT_IN_PROVIDER_DEFINITIONS } from "../src/llm/registry/provider-info.js";
 import { SUBPROCESS_SECRET_ENV } from "../src/utils/subprocessEnv.js";
 import { AGENC_PROXY_SOCKET_DIR_PREFIX } from "../src/sandbox/linux-launcher/config.js";
+import { isMemoryExtractionDisabledByEnv } from "../src/memory/extraction-triggers.js";
 
 const HERMETIC_ENV_CONTRACT = JSON.parse(
   readFileSync(
@@ -175,6 +177,18 @@ describe("suite-level hermetic env (vitest.setup.ts)", () => {
 
   it("pins the auth backend env override to local (no id.agenc.ag logins)", () => {
     expect(process.env.AGENC_AUTH_BACKEND).toBe("local");
+  });
+
+  it("pins the turn-end memory-extraction fork off (no background sampling)", () => {
+    // The fork is detached (`void executeExtractMemories(...)` in
+    // src/phases/commit.ts) and its child samples the session's own provider,
+    // which in a test is the test's mock. Without this pin the child fires on
+    // the third eligible turn of whichever test the shared cadence counter
+    // reaches, and its samples land against wall clock. Deleting the pin makes
+    // this assertion fail before it makes some unrelated call-counting test
+    // fail intermittently.
+    expect(process.env[MEMORY_EXTRACTION_FENCE_ENV_VAR]).toBe("1");
+    expect(isMemoryExtractionDisabledByEnv(process.env)).toBe(true);
   });
 
   it("uses the canonical prelauncher environment instead of ambient behavior knobs", () => {

--- a/runtime/tests/session/background-extraction-fence.test.ts
+++ b/runtime/tests/session/background-extraction-fence.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The suite-wide fence over the turn-end memory-extraction fork, and the
+ * proof that it is load-bearing.
+ *
+ * Class of defect: the fork used to be awaited inside runTurn
+ * (`drainPendingExtraction()`), and no longer is. The extraction child is now
+ * detached, and it samples the SESSION'S OWN provider (in a test, the test's
+ * own mock) on a cadence of every third eligible terminating turn. So a test
+ * that counts model calls or post-sampling launches can see extra samples it
+ * never asked for, and whether it does is wall clock. Worse, the lane is keyed
+ * by conversation id, so in a file whose sessions share one id the fork fires
+ * in whichever test is running when the shared counter reaches three, not in
+ * the test that drove the turns.
+ *
+ * That had already been patched twice, one file at a time. The fence is now
+ * central: tests/helpers/hermetic-env.mjs pins
+ * MEMORY_EXTRACTION_FENCE_ENV_VAR for every hermetic run.
+ *
+ * Both halves live here on purpose:
+ *   - "stays out of a turn-counting test" fails if the pin is removed;
+ *   - "opting back in puts the child's samples on the same mock" fails if the
+ *     fork stops being able to reach a test's provider at all, at which point
+ *     the pin has become decorative and should be re-argued rather than kept
+ *     out of habit.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { runTurn } from "./run-turn.js";
+import { drainPendingExtraction } from "../services/extractMemories/extractMemories.js";
+import { MEMORY_EXTRACTION_FENCE_ENV_VAR } from "../helpers/hermetic-env.mjs";
+import { drain, mkCtx, mkProvider, mkSession } from "../fixtures.js";
+import type { LLMMessage } from "../llm/types.js";
+
+/** Stable marker text from the extraction child's own task prompt. */
+const EXTRACTION_PROMPT_MARKER = "## How to save memories";
+
+/** Past the default cadence (every third eligible turn) with room to spare. */
+const TURNS = 4;
+
+async function driveTurns(): Promise<readonly LLMMessage[][]> {
+  const samples: LLMMessage[][] = [];
+  const { session } = mkSession({
+    provider: mkProvider(
+      { content: "ok" },
+      { onChatStream: (messages) => samples.push(messages) },
+    ),
+  });
+  for (let turn = 0; turn < TURNS; turn += 1) {
+    await drain(runTurn(session, mkCtx(), `hello ${turn}`));
+  }
+  // Deterministic, not a sleep: the fork registers its promise synchronously
+  // when commit.ts calls it, so this awaits every extraction the turns
+  // started (including a trailing run coalesced onto the same lane).
+  await drainPendingExtraction(20_000);
+  return samples;
+}
+
+function extractionSamples(
+  samples: readonly LLMMessage[][],
+): readonly LLMMessage[][] {
+  return samples.filter((messages) =>
+    messages.some(
+      (message) =>
+        typeof message.content === "string" &&
+        message.content.includes(EXTRACTION_PROMPT_MARKER),
+    ),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("background memory extraction is fenced for the suite", () => {
+  test("a turn-counting test sees exactly one sample per turn", async () => {
+    const samples = await driveTurns();
+
+    // The symptom first: removing the pin fails here, on the extra samples
+    // themselves, rather than on the missing variable that let them in.
+    expect(extractionSamples(samples)).toEqual([]);
+    expect(samples).toHaveLength(TURNS);
+    expect(process.env[MEMORY_EXTRACTION_FENCE_ENV_VAR]).toBe("1");
+  });
+
+  test("opting back in puts the extraction child's samples on the same mock", async () => {
+    // The opt-in a test that genuinely exercises extraction would use. It runs
+    // after the setup file's own hook, so it wins over the pin.
+    vi.stubEnv(MEMORY_EXTRACTION_FENCE_ENV_VAR, "0");
+
+    const samples = await driveTurns();
+
+    // Falsifies the fence: without it these are the samples a turn-counting
+    // assertion would have absorbed.
+    expect(extractionSamples(samples).length).toBeGreaterThan(0);
+    expect(samples.length).toBeGreaterThan(TURNS);
+  });
+});

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -8,7 +8,7 @@
  * `process_killed` abort for every clean turn.
  */
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   chmodSync,
   mkdirSync,
@@ -176,20 +176,7 @@ function createTestConfigStore(base?: AgenCConfig): ConfigStore {
   });
 }
 
-// Every session in this file shares the conversation id "conv-test", so they
-// share one memory-extraction lane and its eligible-turn counter. Extraction
-// therefore fires in whichever test happens to be running when the counter
-// reaches the cadence, launching a background child that samples on that
-// test's own provider. These tests are about turn mechanics, not memory, and
-// several of them count model calls or post-sampling launches exactly, so the
-// extraction fork is switched off for the file rather than being absorbed
-// into each expectation.
-beforeEach(() => {
-  vi.stubEnv("AGENC_DISABLE_EXTRACT_MEMORIES", "1");
-});
-
 afterEach(() => {
-  vi.unstubAllEnvs();
   sessionMemoryPostSamplingMockState.calls.length = 0;
   sessionMemoryPostSamplingMockState.error = null;
   clearSessionReadState("conv-test", tmpdir());


### PR DESCRIPTION
## Why

#2017 deliberately made memory extraction non-blocking: it removed the two
`await drainPendingExtraction()` calls that fenced the extraction child inside
`runTurn` before it returned its terminal. The child now runs detached, and it
samples the model through `src/agents/run-agent.ts` into
`src/phases/stream-model.ts`, which in a test means **the test's own provider
mock**, whose call counter is what many tests assert on.

That has now produced two CI reds on two different branches, days apart, each
diagnosed from scratch:

- `tests/session/run-turn.test.ts` — the LP-07 retry test counted 3 sampling
  attempts instead of 2. Excluding only that test moved the failure to a
  different test in the same file.
- `tests/session/run-turn.compact-contract.test.ts` — a six-turn back-off test
  counted 14, or 12, or 16, depending on the scheduler.

Both were patched file by file with the same env stub. The next file that
counts model calls would have been the third.

## What changed

The fence goes in the suite's hermetic environment boundary, not in a fixture.
`runtime/tests/helpers/hermetic-env.mjs` pins the documented production kill
switch `AGENC_DISABLE_EXTRACT_MEMORIES=1` (exported as
`MEMORY_EXTRACTION_FENCE_ENV_VAR`) in `sanitizeHermeticEnv()`, beside the
existing `AGENC_AUTH_BACKEND` and `AGENC_HOME` pins, and in
`createHermeticLaunchEnv()` for spawned children.

Three reasons for that altitude rather than `tests/fixtures.ts`:

1. **A fixture fence would not have closed the class.**
   `tests/session/run-turn.test.ts`, one of the two files that actually went
   red, does not import `tests/fixtures.ts` at all: it builds its own
   `Session`, `mkCtx` and config store. Only 40 of the runTurn-driving files go
   through the shared fixture. All four runners (default suite, design lane,
   the bun runner, `run-hermetic-vitest.mjs`) call `sanitizeHermeticEnv`.
2. **It is the right altitude.** The fork's only production call site is
   `void executeExtractMemories(...)` in `src/phases/commit.ts`, reached via
   `ensureExtractMemoriesInitialized()` with no deps, so
   `isMemoryExtractionDisabledByEnv` falls back to `process.env`. One env read,
   one place, ahead of any provider contact.
3. **It is scoped by construction, which is what keeps the extraction tests
   alive.** The service takes its env as an injected dependency, so tests that
   own extraction pass their own `env` and structurally cannot see this pin.

Opt-in is `vi.stubEnv(MEMORY_EXTRACTION_FENCE_ENV_VAR, "0")`; setup hooks run
first, so a test-level stub wins.

The file-level patch in `tests/session/run-turn.test.ts` is reverted, since the
fence supersedes it. The one in `run-turn.compact-contract.test.ts` lives on
another branch and is left alone.

## Alternatives rejected, with the reasons

**Unique `conversationId` per fixture session** was rejected on two independent
grounds, both checked rather than assumed:

- It does not fix the bug. The lane key is `conversationId + normalize(memoryDir)`,
  and the fixture mints a fresh `mkdtemp` `AGENC_HOME` per session, so
  fixture-built sessions **already** have distinct lanes. Measured: two
  consecutive fixture-built tests each started their own cadence at 1/3, 2/3.
  The real reds are within-test — a six-turn test crosses the cadence twice by
  itself.
- `"conv-test"` is load-bearing in 36 places: `session.test.ts` asserts
  `bindSpy` was called with it, `run-turn.compaction-rollback.contract.test.ts`
  uses it as `SESSION_ID`, `run-turn.test.ts` keys `registerMagicDoc` and
  `clearSessionReadState` off it.

## Evidence

**The class is closed, measured not argued.** `executeExtractMemoriesImpl` was
temporarily instrumented to log past the env gate, then every one of the 21
test files that drive `runTurn` was run. The log file was never created: zero
forks got past the gate. Negative control on the same instrumented build: the
opt-in test logged 4 fires, so the probe was live. Instrumentation reverted.

**The extraction tests still assert what they claim**, proven by mutation
rather than by inspection. `isMemoryExtractionDisabledByEnv` was changed to
also consult `process.env` unconditionally — the blunt fence that *would* reach
them. `tests/services/extractMemories` went to 13 failed / 24 passed and
`tests/session/lifecycle.test.ts` to 1 failed. They notice. With the scoped
fence they are green: extractMemories 37/37, extraction-triggers 8/8, lifecycle
11/11.

**Regression**, before and after against an `origin/main` baseline, one
directory at a time: `tests/session` 1 failed/1320 → 1 failed/1322 (+2 is the
new file, same single failure), `tests/bin` identical, `tests/conversation`,
`tests/gateway`, `tests/personality`, `tests/phases`, `tests/services`,
`tests/llm` all unchanged.

## Tests

- `tests/session/background-extraction-fence.test.ts` — new, holds the
  falsification permanently.
- `tests/hermetic-env.test.ts` — an assertion so the pin is revert-sensitive,
  in the file that already guards the rest of the hermetic contract.

## Not changed

- No product code. `git diff --name-only -- runtime/src` is empty.
- The shutdown drain in `src/session/lifecycle.ts` stays; detaching extraction
  from the turn is #2017's decision and is not relitigated here.
- One residual is named rather than hidden: a test could still fire the fork by
  calling `initExtractMemories({env})` itself and then driving `runTurn`. A
  loop over every file containing `initExtractMemories` found no test that also
  calls `runTurn`.
