### PR TITLE
fix(runtime): keep completion log watcher attached

### DIFF
--- a/runtime/src/tui/completion-pipeline-watcher.ts
+++ b/runtime/src/tui/completion-pipeline-watcher.ts
@@ -1,0 +1,114 @@
+import { watch, type FSWatcher, type WatchEventType } from "node:fs";
+import { basename, dirname } from "node:path";
+
+const ACTIVE_POLL_INTERVAL_MS = 250;
+const IDLE_POLL_INTERVAL_MS = 1_000;
+
+type WatchFactory = (
+  directoryPath: string,
+  options: { readonly persistent: false },
+  listener: (
+    eventType: WatchEventType,
+    filename: string | Buffer | null,
+  ) => void,
+) => FSWatcher;
+
+type ScheduleTimeout = (
+  callback: () => void,
+  delay: number,
+) => ReturnType<typeof setTimeout>;
+
+export type CompletionPipelineWatcherOptions = {
+  readonly eventLogPath: string;
+  readonly refresh: () => boolean;
+  readonly watchDirectory?: WatchFactory;
+  readonly scheduleTimeout?: ScheduleTimeout;
+  readonly cancelTimeout?: (timer: ReturnType<typeof setTimeout>) => void;
+  readonly activePollIntervalMs?: number;
+  readonly idlePollIntervalMs?: number;
+};
+
+export function watchCompletionPipelineEventLog(
+  options: CompletionPipelineWatcherOptions,
+): () => void {
+  const watchDirectory = options.watchDirectory ?? watch;
+  const scheduleTimeout = options.scheduleTimeout ?? setTimeout;
+  const cancelTimeout = options.cancelTimeout ?? clearTimeout;
+  const activePollIntervalMs =
+    options.activePollIntervalMs ?? ACTIVE_POLL_INTERVAL_MS;
+  const idlePollIntervalMs =
+    options.idlePollIntervalMs ?? IDLE_POLL_INTERVAL_MS;
+  const directoryPath = dirname(options.eventLogPath);
+  const eventLogName = basename(options.eventLogPath);
+  let disposed = false;
+  let watcher: FSWatcher | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const closeWatcher = (): void => {
+    const current = watcher;
+    watcher = null;
+    current?.close();
+  };
+
+  const attachWatcher = (): void => {
+    if (disposed || watcher !== null) return;
+    try {
+      const nextWatcher = watchDirectory(
+        directoryPath,
+        { persistent: false },
+        (eventType, filename) => {
+          if (disposed || watcher !== nextWatcher) return;
+          if (filename !== null && filename.toString() !== eventLogName) return;
+          const active = options.refresh();
+          if (eventType === "rename") {
+            closeWatcher();
+            attachWatcher();
+          }
+          schedulePoll(active);
+        },
+      );
+      watcher = nextWatcher;
+      nextWatcher.on("error", () => {
+        if (disposed || watcher !== nextWatcher) return;
+        closeWatcher();
+        attachWatcher();
+      });
+    } catch {
+      watcher = null;
+    }
+  };
+
+  const schedulePoll = (active: boolean): void => {
+    if (disposed) return;
+    if (pollTimer !== null) cancelTimeout(pollTimer);
+    pollTimer = scheduleTimeout(
+      () => {
+        pollTimer = null;
+        if (disposed) return;
+        const nextActive = options.refresh();
+        attachWatcher();
+        schedulePoll(nextActive);
+      },
+      active ? activePollIntervalMs : idlePollIntervalMs,
+    );
+    (
+      pollTimer as ReturnType<typeof setTimeout> & {
+        unref?: () => void;
+      }
+    ).unref?.();
+  };
+
+  const active = options.refresh();
+  attachWatcher();
+  schedulePoll(active);
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    closeWatcher();
+    if (pollTimer !== null) {
+      cancelTimeout(pollTimer);
+      pollTimer = null;
+    }
+  };
+}

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1,4 +1,3 @@
-import { watch, type FSWatcher } from "node:fs";
 import { logForDebugging } from "src/utils/debug.js";
 import { createHash, randomUUID } from "node:crypto";
 import { join, resolve } from "node:path";
@@ -290,6 +289,7 @@ import {
   resolveCompletionPipelineEventLogPath,
   type CompletionPipelineState,
 } from "../completion-pipeline.js";
+import { watchCompletionPipelineEventLog } from "../completion-pipeline-watcher.js";
 export { shouldEnableTranscriptScrollKeybindings } from "../workbench/transcriptScroll.js";
 export type McpFieldValue = string | number | boolean | readonly string[];
 const EMPTY_MCP_CLIENTS: readonly MCPServerConnection[] = [];
@@ -2454,43 +2454,21 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     // parsed object per poll would re-render the whole shell even when
     // nothing moved (same compare-before-setState pattern as
     // useSessionMcpSurface above).
-    const refresh = () =>
+    const refresh = (): boolean => {
+      const next = readCompletionPipelineState();
       setCompletionPipelineState((previous) => {
-        const next = readCompletionPipelineState();
         return completionPipelineStateSignature(previous) ===
           completionPipelineStateSignature(next)
           ? previous
           : next;
       });
-    refresh();
-    // fs.watch is the cheap change source; the 1s poll is the fallback when
-    // the log file can't be watched (e.g. it doesn't exist yet — watching a
-    // missing path throws). While the pipeline owns the prompt, gates flip
-    // quickly, so keep the poll running on top of the watcher to stay
-    // responsive even if watch events get dropped.
-    let watcher: FSWatcher | null = null;
-    try {
-      watcher = watch(
-        resolveCompletionPipelineEventLogPath(),
-        { persistent: false },
-        () => refresh(),
-      );
-      // A watch error (e.g. the file is deleted mid-run) must not surface as
-      // an uncaught 'error' event; the poll/state gates above keep the UI
-      // consistent without it.
-      watcher.on("error", () => {});
-    } catch {
-      watcher = null;
+      return completionPipelineOwnsPrompt(next);
     }
-    const interval =
-      watcher !== null && !completionPipelineActive
-        ? null
-        : setInterval(refresh, 1000);
-    return () => {
-      watcher?.close();
-      if (interval !== null) clearInterval(interval);
-    };
-  }, [completionPipelineActive]);
+    return watchCompletionPipelineEventLog({
+      eventLogPath: resolveCompletionPipelineEventLogPath(),
+      refresh,
+    });
+  }, []);
   const completionPipelineRows = formatCompletionPipelineRows(
     completionPipelineState,
   );

--- a/runtime/tests/tui/completion-pipeline-watcher.test.ts
+++ b/runtime/tests/tui/completion-pipeline-watcher.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { watchCompletionPipelineEventLog } from "../../src/tui/completion-pipeline-watcher.js";
+
+type WatchRecord = {
+  readonly close: ReturnType<typeof vi.fn>;
+  readonly emit: (
+    eventType: "change" | "rename",
+    filename: string | Buffer | null,
+  ) => void;
+  readonly emitError: () => void;
+};
+
+type TimerRecord = {
+  readonly callback: () => void;
+  readonly delay: number;
+  readonly token: ReturnType<typeof setTimeout>;
+  readonly unref: ReturnType<typeof vi.fn>;
+  cancelled: boolean;
+};
+
+function createWatcherHarness(
+  options: { readonly initialWatchFailures?: number } = {},
+) {
+  const watchers: WatchRecord[] = [];
+  const timers: TimerRecord[] = [];
+  let watchFailuresRemaining = options.initialWatchFailures ?? 0;
+  let nextTimerId = 1;
+
+  const watchDirectory = vi.fn(
+    (
+      _directoryPath: string,
+      _watchOptions: { readonly persistent: false },
+      listener: (
+        eventType: "change" | "rename",
+        filename: string | Buffer | null,
+      ) => void,
+    ) => {
+      if (watchFailuresRemaining > 0) {
+        watchFailuresRemaining -= 1;
+        throw new Error("watch unavailable");
+      }
+      let errorListener: (() => void) | undefined;
+      const close = vi.fn();
+      const watcher = {
+        close,
+        on: vi.fn((eventName: string, callback: () => void) => {
+          if (eventName === "error") errorListener = callback;
+          return watcher;
+        }),
+      };
+      watchers.push({
+        close,
+        emit: listener,
+        emitError: () => errorListener?.(),
+      });
+      return watcher;
+    },
+  );
+
+  const scheduleTimeout = vi.fn((callback: () => void, delay: number) => {
+    const unref = vi.fn();
+    const token = { id: nextTimerId, unref } as unknown as ReturnType<
+      typeof setTimeout
+    >;
+    nextTimerId += 1;
+    timers.push({ callback, delay, token, unref, cancelled: false });
+    return token;
+  });
+  const cancelTimeout = vi.fn((token: ReturnType<typeof setTimeout>) => {
+    const timer = timers.find((candidate) => candidate.token === token);
+    if (timer) timer.cancelled = true;
+  });
+  const pendingTimers = () => timers.filter((timer) => !timer.cancelled);
+
+  return {
+    watchers,
+    watchDirectory,
+    scheduleTimeout,
+    cancelTimeout,
+    pendingTimers,
+  };
+}
+
+describe("completion pipeline event-log watcher", () => {
+  test("filters directory events and reattaches after target renames and errors", () => {
+    const harness = createWatcherHarness();
+    const refresh = vi.fn(() => false);
+    const dispose = watchCompletionPipelineEventLog({
+      eventLogPath: "/tmp/agenc-completion/events.jsonl",
+      refresh,
+      watchDirectory: harness.watchDirectory as never,
+      scheduleTimeout: harness.scheduleTimeout as never,
+      cancelTimeout: harness.cancelTimeout,
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(harness.watchDirectory).toHaveBeenCalledWith(
+      "/tmp/agenc-completion",
+      { persistent: false },
+      expect.any(Function),
+    );
+    expect(harness.pendingTimers().map(({ delay }) => delay)).toEqual([1_000]);
+    expect(harness.pendingTimers()[0]?.unref).toHaveBeenCalledTimes(1);
+
+    harness.watchers[0]?.emit("change", "other.jsonl");
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    harness.watchers[0]?.emit("rename", Buffer.from("events.jsonl"));
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(harness.watchers[0]?.close).toHaveBeenCalledTimes(1);
+    expect(harness.watchers).toHaveLength(2);
+    expect(harness.pendingTimers()).toHaveLength(1);
+
+    harness.watchers[1]?.emitError();
+    expect(harness.watchers[1]?.close).toHaveBeenCalledTimes(1);
+    expect(harness.watchers).toHaveLength(3);
+    expect(harness.pendingTimers()).toHaveLength(1);
+
+    dispose();
+    expect(harness.watchers[2]?.close).toHaveBeenCalledTimes(1);
+    expect(harness.pendingTimers()).toHaveLength(0);
+  });
+
+  test("polls after missed events and retries a watcher missing at startup", () => {
+    const harness = createWatcherHarness({ initialWatchFailures: 1 });
+    const refresh = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+    const dispose = watchCompletionPipelineEventLog({
+      eventLogPath: "/missing-at-start/events.jsonl",
+      refresh,
+      watchDirectory: harness.watchDirectory as never,
+      scheduleTimeout: harness.scheduleTimeout as never,
+      cancelTimeout: harness.cancelTimeout,
+    });
+
+    expect(harness.watchers).toHaveLength(0);
+    expect(harness.watchDirectory).toHaveBeenCalledTimes(1);
+    expect(harness.pendingTimers().map(({ delay }) => delay)).toEqual([1_000]);
+
+    const idlePoll = harness.pendingTimers()[0];
+    expect(idlePoll).toBeDefined();
+    idlePoll!.cancelled = true;
+    idlePoll!.callback();
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(harness.watchDirectory).toHaveBeenCalledTimes(2);
+    expect(harness.watchers).toHaveLength(1);
+    expect(harness.pendingTimers().map(({ delay }) => delay)).toEqual([250]);
+    expect(harness.pendingTimers()[0]?.unref).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  test("leaves no watcher or timer behind when the component remounts", () => {
+    const harness = createWatcherHarness();
+    const firstRefresh = vi.fn(() => false);
+    const firstDispose = watchCompletionPipelineEventLog({
+      eventLogPath: "/tmp/remount/events.jsonl",
+      refresh: firstRefresh,
+      watchDirectory: harness.watchDirectory as never,
+      scheduleTimeout: harness.scheduleTimeout as never,
+      cancelTimeout: harness.cancelTimeout,
+    });
+
+    firstDispose();
+    firstDispose();
+    harness.watchers[0]?.emit("change", "events.jsonl");
+    expect(firstRefresh).toHaveBeenCalledTimes(1);
+    expect(harness.pendingTimers()).toHaveLength(0);
+
+    const secondRefresh = vi.fn(() => false);
+    const secondDispose = watchCompletionPipelineEventLog({
+      eventLogPath: "/tmp/remount/events.jsonl",
+      refresh: secondRefresh,
+      watchDirectory: harness.watchDirectory as never,
+      scheduleTimeout: harness.scheduleTimeout as never,
+      cancelTimeout: harness.cancelTimeout,
+    });
+
+    expect(harness.watchers).toHaveLength(2);
+    expect(harness.watchers[0]?.close).toHaveBeenCalledTimes(1);
+    expect(harness.pendingTimers()).toHaveLength(1);
+
+    secondDispose();
+    expect(harness.watchers[1]?.close).toHaveBeenCalledTimes(1);
+    expect(harness.pendingTimers()).toHaveLength(0);
+  });
+});

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -1,6 +1,13 @@
 import { PassThrough } from "node:stream";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import React, { type SetStateAction } from "react";
@@ -1259,6 +1266,96 @@ async function runConcurrentExitIntentScenario({
 }
 
 describeWithVitestMocks("AgenCTuiApp render smoke", () => {
+  test("detects a completion log recreated after the watched file is deleted", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    const tempRoot = mkdtempSync(join(tmpdir(), "agenc-completion-log-watch-"));
+    const eventLogPath = join(tempRoot, "events.jsonl");
+    const previousEventLogPath =
+      process.env.AGENC_TUI_COMPLETION_PIPELINE_LOG;
+    const event = (
+      pipelineId: string,
+      status: "completed" | "started",
+      gateId = "prep",
+      gateIndex = 0,
+    ) =>
+      `${JSON.stringify({
+        pipelineId,
+        sequence: 1,
+        gateId,
+        gateIndex,
+        status,
+        timestamp: "2026-01-01T00:00:00.000Z",
+      })}\n`;
+
+    writeFileSync(eventLogPath, event("inactive", "completed"));
+    process.env.AGENC_TUI_COMPLETION_PIPELINE_LOG = eventLogPath;
+    resetShellSurfaceProbe();
+    const renderedText = (node: React.ReactNode): string => {
+      if (typeof node === "string" || typeof node === "number") {
+        return String(node);
+      }
+      if (Array.isArray(node)) return node.map(renderedText).join("");
+      if (!React.isValidElement(node)) return "";
+      return renderedText(
+        (node.props as { readonly children?: React.ReactNode }).children,
+      );
+    };
+    const completionSurface = () =>
+      renderedText(
+        providerProbe.fullscreenLayoutProps.at(-1)?.scrollable,
+      ).replace(/\s+/gu, "");
+
+    try {
+      await withRenderedApp(
+        <AgenCTuiApp session={createSession()} isInteractive={false} />,
+        async () => {
+          await vi.waitFor(() => {
+            expect(completionSurface()).toContain("Completionpipelinecomplete");
+          });
+
+          unlinkSync(eventLogPath);
+          await vi.waitFor(() => {
+            expect(completionSurface()).not.toContain(
+              "Completionpipelinecomplete",
+            );
+          });
+
+          writeFileSync(eventLogPath, event("replacement", "started"));
+          await vi.waitFor(
+            () => {
+              expect(completionSurface()).toContain(
+                "Completion1/9:Preparegoalrunning",
+              );
+            },
+            { timeout: 3_000 },
+          );
+
+          const atomicReplacementPath = join(tempRoot, "replacement.jsonl");
+          writeFileSync(
+            atomicReplacementPath,
+            event("atomic-replacement", "started", "typecheck", 5),
+          );
+          renameSync(atomicReplacementPath, eventLogPath);
+          await vi.waitFor(
+            () => {
+              expect(completionSurface()).toContain(
+                "Completion6/9:Typecheckrunning",
+              );
+            },
+            { timeout: 3_000 },
+          );
+        },
+      );
+    } finally {
+      if (previousEventLogPath === undefined) {
+        delete process.env.AGENC_TUI_COMPLETION_PIPELINE_LOG;
+      } else {
+        process.env.AGENC_TUI_COMPLETION_PIPELINE_LOG = previousEventLogPath;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test("keeps command discovery on session plugin authority across config reload", async () => {
     const { AgenCTuiApp } = await import("./App.js");
     const pluginStorageRoot = join(


### PR DESCRIPTION
## Summary

- Watch the completion event log's parent directory and filter events by the target filename.
- Reattach after target renames or watcher errors, with one unreferenced timeout polling at 1 second while idle and 250 milliseconds while active.
- Cover missing startup watches, dropped events, deletion and recreation, atomic replacement, error recovery, and remount cleanup.

## Validation

- Focused completion pipeline and App tests: 6 files, 143 tests passed.
- `npm run typecheck`: passed.
- `npm run build`: passed, including package entrypoint and generated SDK type checks.
- `npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup`: passed at 148x40, 120x30, and 80x24 in normal and bypass modes.
- GitNexus change detection against current `origin/main`: LOW, 2 changed symbols, 4 files, 0 affected processes.
- `git diff --check` and staged diff checks: passed.

## Known baseline failure

- `npm run check:agent-surface-contract` reached the final `03-subagent-completion` TUI scenario, then failed because the private daemon socket remained after cleanup. Running that scenario alone produced the same failure. A clean detached `origin/main` checkout at `6c63f0cda7709b64a5158c318cacda3227f21a1d` reproduced the same socket-cleanup failure.

Closes #1802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only completion pipeline refresh logic with injectable timers/watch for tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes completion pipeline UI updates when the event log is deleted, recreated, or atomically replaced by **replacing inline `fs.watch` on the log file** with a dedicated `watchCompletionPipelineEventLog` helper.
> 
> The watcher now observes the **parent directory** and ignores unrelated files, **reattaches** after `rename` or watcher errors, and uses a **single unref’d timeout poll** (250ms while the pipeline owns the prompt, 1s when idle) instead of tying polling to whether a file watcher existed. `App` wires this in via a `refresh` callback that still compare-before-setState and returns whether the pipeline is active; the effect **no longer remounts** when `completionPipelineActive` flips.
> 
> Unit tests cover filtering, reattach, startup watch failure, and dispose; an App render test exercises delete/recreate and atomic rename of the log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5fbf20d10794ed0920d41f9fb14c20b48d14b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->