### PR TITLE
fix(runtime): bind MCP content provider reads to verified handles

### DIFF
--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -18,9 +18,21 @@
  *     client-supplied paths. Only the selected resource body is read,
  *     then its contents pass through the canonical egress secret sanitizer.
  *
+ * Skill and resource bodies are served by one shared descriptor-bound
+ * reader (`readScopedRegularFile`): a candidate is validated, opened once
+ * with `O_NOFOLLOW`/`O_NONBLOCK`, proven to be the same single-link
+ * regular object that validation saw, read from that handle under a byte
+ * ceiling, and re-proved after the read. A pathname is never reopened
+ * after validation, so a writable workspace cannot swap the file or an
+ * ancestor between checks and bytes. Node exposes no root-confined
+ * open (openat2/`RESOLVE_BENEATH`); as in the runtime's other verified
+ * readers, containment is enforced on the canonical resolution plus
+ * opened-handle identity proofs rather than a silent weaker path.
+ *
  * @module
  */
-import { lstat, readdir, readFile, realpath } from "node:fs/promises";
+import { constants as fsConstants, type BigIntStats } from "node:fs";
+import { lstat, open, readdir, realpath } from "node:fs/promises";
 import { basename, isAbsolute, join, relative } from "node:path";
 
 import {
@@ -41,11 +53,29 @@ import type {
   McpResourceProvider,
 } from "../../mcp-server/types.js";
 
+/** Byte ceiling for one skill / memory / instruction body served over MCP. */
+export const MAX_SCOPED_FILE_BYTES = 1_048_576;
+
+/**
+ * @internal Deterministic race seams for the shared verified reader:
+ * tests replace the candidate at each filesystem I/O boundary.
+ */
+export interface ScopedRegularFileTestHooks {
+  /** Fires after validation, before the verified open. */
+  readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
+  /** Fires after the verified open, before the bounded read. */
+  readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
+}
+
 export interface SkillPromptProviderOptions {
   /** Directories whose children are skills (`<dir>/<name>/SKILL.md` or `<dir>/<name>.md`). */
   readonly skillRoots: readonly string[];
   /** Canonical containment root; candidates resolving outside it are omitted. */
   readonly scopeRoot?: string;
+  /** @internal Test seam: candidate swap point after validation. */
+  readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
+  /** @internal Test seam: candidate swap point after the verified open. */
+  readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
 }
 
 interface DiscoveredSkill {
@@ -53,6 +83,26 @@ interface DiscoveredSkill {
   readonly filePath: string;
   readonly description: string;
   readonly argumentHint: string | undefined;
+  readonly rawContent: string;
+}
+
+interface ScopedFileIdentity {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly nlink: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+}
+
+interface ScopedRegularFileResolution {
+  readonly canonicalPath: string;
+  readonly identity: ScopedFileIdentity;
+}
+
+interface ScopedRegularFileContents {
+  readonly canonicalPath: string;
   readonly rawContent: string;
 }
 
@@ -72,39 +122,138 @@ function isSameOrChildPath(scopeRoot: string, candidate: string): boolean {
   return offset === "" || (!offset.startsWith("..") && !isAbsolute(offset));
 }
 
-async function readScopedRegularFile(
-  filePath: string,
-  scopeRoot: string | null,
-  readContent: (canonicalPath: string) => Promise<string> = async (
-    canonicalPath,
-  ) => await readFile(canonicalPath, "utf8"),
-): Promise<{
-  readonly canonicalPath: string;
-  readonly rawContent: string;
-} | null> {
-  const canonicalPath = await resolveScopedRegularFile(filePath, scopeRoot);
-  if (canonicalPath === null) return null;
-  try {
-    return { canonicalPath, rawContent: await readContent(canonicalPath) };
-  } catch {
-    return null;
+function scopedIdentity(stats: BigIntStats): ScopedFileIdentity {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    nlink: stats.nlink,
+    size: stats.size,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+  };
+}
+
+function sameScopedIdentity(
+  left: ScopedFileIdentity,
+  right: ScopedFileIdentity,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.nlink === right.nlink &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+/** One admission contract for listing and reading: regular, unlinked-again, bounded. */
+function admitsScopedSnapshot(stats: BigIntStats): boolean {
+  return (
+    stats.isFile() &&
+    !stats.isSymbolicLink() &&
+    stats.nlink === 1n &&
+    stats.size <= BigInt(MAX_SCOPED_FILE_BYTES)
+  );
+}
+
+function scopedOpenFlags(): number {
+  if (process.platform === "win32") return fsConstants.O_RDONLY;
+  // O_NOFOLLOW rejects a final component swapped to a symlink; O_NONBLOCK
+  // stops an open of a swapped-in FIFO from hanging. The opened-handle
+  // fstat below rejects every non-regular replacement; both flags are
+  // no-ops for the regular files that pass admission.
+  return (
+    fsConstants.O_RDONLY |
+    (fsConstants.O_NOFOLLOW ?? 0) |
+    (fsConstants.O_NONBLOCK ?? 0)
+  );
+}
+
+async function readScopedHandle(
+  handle: Awaited<ReturnType<typeof open>>,
+): Promise<Buffer | null> {
+  const buffer = Buffer.allocUnsafe(MAX_SCOPED_FILE_BYTES + 1);
+  let length = 0;
+  while (length < buffer.length) {
+    const { bytesRead } = await handle.read(
+      buffer,
+      length,
+      buffer.length - length,
+      null,
+    );
+    if (bytesRead === 0) break;
+    length += bytesRead;
   }
+  return length > MAX_SCOPED_FILE_BYTES ? null : buffer.subarray(0, length);
 }
 
 async function resolveScopedRegularFile(
   filePath: string,
   scopeRoot: string | null,
-): Promise<string | null> {
+): Promise<ScopedRegularFileResolution | null> {
   try {
-    const fileStat = await lstat(filePath);
-    if (fileStat.isSymbolicLink() || !fileStat.isFile()) return null;
+    const before = await lstat(filePath, { bigint: true });
+    if (!admitsScopedSnapshot(before)) return null;
     const canonicalPath = await realpath(filePath);
     if (scopeRoot !== null && !isSameOrChildPath(scopeRoot, canonicalPath)) {
       return null;
     }
-    return canonicalPath;
+    return { canonicalPath, identity: scopedIdentity(before) };
   } catch {
     return null;
+  }
+}
+
+/**
+ * Shared verified reader for skill prompts and resource bodies: validate,
+ * open once, prove the opened object is the validated one, read it under
+ * the byte ceiling, and prove it never changed. Any swap, relink, growth,
+ * or escape between those boundaries yields `null`.
+ */
+async function readScopedRegularFile(
+  filePath: string,
+  scopeRoot: string | null,
+  hooks: ScopedRegularFileTestHooks = {},
+): Promise<ScopedRegularFileContents | null> {
+  const resolved = await resolveScopedRegularFile(filePath, scopeRoot);
+  if (resolved === null) return null;
+  const { canonicalPath, identity: before } = resolved;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    await hooks.beforeOpenForTesting?.(filePath);
+    handle = await open(filePath, scopedOpenFlags());
+    const opened = await handle.stat({ bigint: true });
+    if (
+      !admitsScopedSnapshot(opened) ||
+      !sameScopedIdentity(before, scopedIdentity(opened))
+    ) {
+      return null;
+    }
+    await hooks.beforeReadForTesting?.(filePath);
+    const bytes = await readScopedHandle(handle);
+    if (bytes === null) return null;
+    const [afterRead, pathAfterRead, canonicalAfterRead] = await Promise.all([
+      handle.stat({ bigint: true }),
+      lstat(filePath, { bigint: true }),
+      realpath(filePath),
+    ]);
+    const openedIdentity = scopedIdentity(opened);
+    if (
+      !sameScopedIdentity(openedIdentity, scopedIdentity(afterRead)) ||
+      !sameScopedIdentity(openedIdentity, scopedIdentity(pathAfterRead)) ||
+      canonicalAfterRead !== canonicalPath ||
+      bytes.byteLength !== Number(opened.size)
+    ) {
+      return null;
+    }
+    return { canonicalPath, rawContent: bytes.toString("utf8") };
+  } catch {
+    return null;
+  } finally {
+    if (handle !== undefined) await handle.close().catch(() => undefined);
   }
 }
 
@@ -131,7 +280,10 @@ async function discoverSkills(
             }
           : null;
       if (candidate === null || skills.has(candidate.name)) continue;
-      const file = await readScopedRegularFile(candidate.filePath, scopeRoot);
+      const file = await readScopedRegularFile(candidate.filePath, scopeRoot, {
+        beforeOpenForTesting: options.beforeOpenForTesting,
+        beforeReadForTesting: options.beforeReadForTesting,
+      });
       if (file === null) continue;
       const { frontmatter } = parseFrontmatter(
         file.rawContent,
@@ -211,8 +363,10 @@ export interface MemoryResourceProviderOptions {
   readonly scopeRoot?: string;
   /** Captured config home used to exclude private session files. */
   readonly configHomeDir?: string;
-  /** Resource body reader. Exposed for deterministic embedding and tests. */
-  readonly readResourceContent?: (canonicalPath: string) => Promise<string>;
+  /** @internal Test seam: candidate swap point after validation. */
+  readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
+  /** @internal Test seam: candidate swap point after the verified open. */
+  readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
 }
 
 const MEMORY_URI_SCHEME = "agenc-memory://";
@@ -235,11 +389,11 @@ async function listMemoryResources(
       // Session memory/transcripts are excluded outright — same boundary
       // the permission layer enforces for in-process reads.
       if (detectSessionFileType(header.filePath, options.configHomeDir) !== null) continue;
-      const canonicalPath = await resolveScopedRegularFile(
+      const resolution = await resolveScopedRegularFile(
         header.filePath,
         scopeRoot,
       );
-      if (canonicalPath === null) continue;
+      if (resolution === null) continue;
       const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${header.filename}`;
       resources.set(uri, {
         definition: {
@@ -250,15 +404,15 @@ async function listMemoryResources(
             : {}),
           mimeType: "text/markdown",
         },
-        filePath: canonicalPath,
+        filePath: resolution.canonicalPath,
       });
     }
     const entrypoint = join(dir, "MEMORY.md");
-    const canonicalEntrypoint = await resolveScopedRegularFile(
+    const entrypointResolution = await resolveScopedRegularFile(
       entrypoint,
       scopeRoot,
     );
-    if (canonicalEntrypoint !== null) {
+    if (entrypointResolution !== null) {
       const uri = `${MEMORY_URI_SCHEME}${dirIndex}/MEMORY.md`;
       resources.set(uri, {
         definition: {
@@ -267,15 +421,15 @@ async function listMemoryResources(
           description: "Memory index",
           mimeType: "text/markdown",
         },
-        filePath: canonicalEntrypoint,
+        filePath: entrypointResolution.canonicalPath,
       });
     }
   }
   for (const [fileIndex, filePath] of (
     options.instructionFiles ?? []
   ).entries()) {
-    const canonicalPath = await resolveScopedRegularFile(filePath, scopeRoot);
-    if (canonicalPath === null) continue;
+    const resolution = await resolveScopedRegularFile(filePath, scopeRoot);
+    if (resolution === null) continue;
     if (detectSessionFileType(filePath, options.configHomeDir) !== null) continue;
     const uri = `${INSTRUCTIONS_URI_SCHEME}${fileIndex}/${basename(filePath)}`;
     resources.set(uri, {
@@ -285,7 +439,7 @@ async function listMemoryResources(
         description: `Project instructions (${filePath})`,
         mimeType: "text/markdown",
       },
-      filePath: canonicalPath,
+      filePath: resolution.canonicalPath,
     });
   }
   return resources;
@@ -307,11 +461,10 @@ export function createMemoryResourceProvider(
       if (resource === undefined) return null;
       const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
       if (options.scopeRoot !== undefined && scopeRoot === null) return null;
-      const file = await readScopedRegularFile(
-        resource.filePath,
-        scopeRoot,
-        options.readResourceContent,
-      );
+      const file = await readScopedRegularFile(resource.filePath, scopeRoot, {
+        beforeOpenForTesting: options.beforeOpenForTesting,
+        beforeReadForTesting: options.beforeReadForTesting,
+      });
       if (file === null) return null;
       return {
         contents: [

--- a/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
+++ b/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Regression tests for issue #1794: MCP content providers must serve
+ * skill prompts and resource bodies through one descriptor-bound reader.
+ * A writable workspace cannot swap the candidate file or an ancestor
+ * between validation and bytes: every swap lands on a hook at a real
+ * filesystem I/O boundary, and each scenario must end with the candidate
+ * omitted (prompts) or unreadable (resources) — never with swapped bytes.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ConfigStore } from "../../src/config/store.js";
+import { enterCanonicalSettingsAuthority } from "../../src/utils/settings/canonicalAuthority.js";
+
+import {
+  MAX_SCOPED_FILE_BYTES,
+  createMemoryResourceProvider,
+  createSkillPromptProvider,
+} from "../../src/mcp/server/content-providers.js";
+
+const SECRET = "PRIVATE SESSION TRANSCRIPT ak_1794_secret";
+const SECRET_TOKEN = "ghp_1794567890abcdefABCDEF1234567890abcdef";
+
+const roots: string[] = [];
+let root: string;
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "agenc-mcp-verified-"));
+  roots.push(root);
+  vi.stubEnv("AGENC_HOME", root);
+  enterCanonicalSettingsAuthority(new ConfigStore({
+    home: root,
+    env: { ...process.env, AGENC_HOME: root },
+    cwd: root,
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of roots.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeSkill(name: string, body: string): string {
+  const dir = join(root, "skills", name);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, "SKILL.md");
+  writeFileSync(
+    file,
+    ["---", `description: ${name} skill`, "---", body].join("\n"),
+  );
+  return file;
+}
+
+function makeOutsideSecret(name: string): string {
+  const outside = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
+  roots.push(outside);
+  const file = join(outside, name);
+  writeFileSync(
+    file,
+    ["---", `description: ${name}`, "---", SECRET, SECRET_TOKEN].join("\n"),
+  );
+  return file;
+}
+
+function makeMemoryFile(name: string, body: string): string {
+  mkdirSync(join(root, "memory"), { recursive: true });
+  const file = join(root, "memory", name);
+  writeFileSync(
+    file,
+    ["---", `name: ${name.replace(/\.md$/, "")}`, `description: ${name}`, "---", body].join("\n"),
+  );
+  return file;
+}
+
+function skillProvider(
+  hooks: {
+    beforeOpenForTesting?: (path: string) => void;
+    beforeReadForTesting?: (path: string) => void;
+  } = {},
+) {
+  return createSkillPromptProvider({
+    skillRoots: [join(root, "skills")],
+    scopeRoot: root,
+    ...hooks,
+  });
+}
+
+function resourceProvider(
+  hooks: {
+    beforeOpenForTesting?: (path: string) => void;
+    beforeReadForTesting?: (path: string) => void;
+  } = {},
+) {
+  return createMemoryResourceProvider({
+    memoryDirs: [join(root, "memory")],
+    scopeRoot: root,
+    ...hooks,
+  });
+}
+
+describe("verified skill prompt reads", () => {
+  test("serves a plain in-scope skill", async () => {
+    makeSkill("plain", "safe body");
+    const provider = skillProvider();
+    const prompts = await provider.listPrompts();
+    expect(prompts.map((p) => p.name)).toContain("plain");
+    const prompt = await provider.getPrompt("plain");
+    expect(prompt?.messages[0]).toMatchObject({
+      role: "user",
+      content: { type: "text", text: expect.stringContaining("safe body") },
+    });
+  });
+
+  test("omits a skill swapped for a symlink after validation", async () => {
+    const file = makeSkill("swapped", "safe body");
+    const secret = makeOutsideSecret("secret.md");
+    const provider = skillProvider({
+      beforeOpenForTesting: (path) => {
+        if (path !== file) return;
+        rmSync(file);
+        symlinkSync(secret, file);
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+    expect(await provider.getPrompt("swapped")).toBeNull();
+  });
+
+  test("omits a skill swapped for a symlink to the same inode after validation", async () => {
+    const file = makeSkill("selflink", "safe body");
+    const provider = skillProvider({
+      beforeOpenForTesting: (path) => {
+        if (path !== file) return;
+        // The replacement symlink resolves to the very inode validation
+        // saw; only the O_NOFOLLOW open rejects it.
+        const alias = `${file}.same-inode`;
+        linkSync(file, alias);
+        rmSync(file);
+        symlinkSync(alias, file);
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+
+  test("omits a skill replaced by another regular file after validation", async () => {
+    const file = makeSkill("replaced", "safe body");
+    const attacker = join(root, "attacker.md");
+    writeFileSync(attacker, "attacker body", "utf8");
+    const provider = skillProvider({
+      beforeOpenForTesting: (path) => {
+        if (path !== file) return;
+        renameSync(attacker, file);
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+
+  test("omits a skill whose ancestor directory is swapped for a symlink after validation", async () => {
+    const file = makeSkill("ancestor", "safe body");
+    const outsideDir = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
+    roots.push(outsideDir);
+    writeFileSync(
+      join(outsideDir, "SKILL.md"),
+      ["---", "description: forged", "---", SECRET].join("\n"),
+    );
+    const provider = skillProvider({
+      beforeOpenForTesting: (path) => {
+        if (path !== file) return;
+        const dir = join(root, "skills", "ancestor");
+        renameSync(dir, `${dir}.moved`);
+        symlinkSync(outsideDir, dir);
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+    expect(await provider.getPrompt("ancestor")).toBeNull();
+  });
+
+  test("omits a skill whose open file is replaced before the read", async () => {
+    const file = makeSkill("midread", "safe body");
+    const attacker = join(root, "midread-attacker.md");
+    writeFileSync(attacker, "attacker body", "utf8");
+    const provider = skillProvider({
+      beforeReadForTesting: (path) => {
+        if (path !== file) return;
+        renameSync(attacker, file);
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+
+  test("omits a skill mutated in place after the open", async () => {
+    const file = makeSkill("mutated", "safe body");
+    const provider = skillProvider({
+      beforeReadForTesting: (path) => {
+        if (path !== file) return;
+        writeFileSync(file, "mutated body!", "utf8");
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+
+  test("omits multiply linked skill files", async () => {
+    const secret = makeOutsideSecret("session.md");
+    const dir = join(root, "skills", "leak");
+    mkdirSync(dir, { recursive: true });
+    linkSync(secret, join(dir, "SKILL.md"));
+    const provider = skillProvider();
+    expect(await provider.listPrompts()).toEqual([]);
+    expect(await provider.getPrompt("leak")).toBeNull();
+  });
+
+  test("omits oversized skill files", async () => {
+    const dir = join(root, "skills", "huge");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      Buffer.alloc(MAX_SCOPED_FILE_BYTES + 1, 0x61),
+    );
+    const provider = skillProvider();
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+
+  test.runIf(process.platform !== "win32")(
+    "omits a skill replaced by a FIFO after validation without blocking",
+    async () => {
+      const file = makeSkill("fifod", "safe body");
+      const provider = skillProvider({
+        beforeOpenForTesting: (path) => {
+          if (path !== file) return;
+          rmSync(file);
+          expect(spawnSync("mkfifo", [file]).status).toBe(0);
+        },
+      });
+      expect(await provider.listPrompts()).toEqual([]);
+    },
+  );
+});
+
+describe("verified memory resource reads", () => {
+  test("reads an in-scope memory file with secrets redacted", async () => {
+    makeMemoryFile("notes.md", `plain body ${SECRET_TOKEN}`);
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    expect(resources.map((r) => r.name)).toContain("notes.md");
+    const uri = resources.find((r) => r.name === "notes.md")!.uri;
+    const read = await provider.readResource(uri);
+    expect(read?.contents[0]).toMatchObject({ mimeType: "text/markdown" });
+    expect(read?.contents[0].text).toContain("plain body");
+    expect(read?.contents[0].text).not.toContain(SECRET_TOKEN);
+  });
+
+  test("does not read resource bodies while listing", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    let reads = 0;
+    const provider = resourceProvider({
+      beforeReadForTesting: () => {
+        reads += 1;
+      },
+    });
+    const resources = await provider.listResources();
+    expect(reads).toBe(0);
+    const uri = resources.find((r) => r.name === "notes.md")!.uri;
+    await provider.readResource(uri);
+    expect(reads).toBe(1);
+  });
+
+  test("does not list multiply linked memory files", async () => {
+    const file = makeMemoryFile("leak.md", SECRET);
+    const outsideDir = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
+    roots.push(outsideDir);
+    // The memory file now also answers to a name outside the scope root.
+    linkSync(file, join(outsideDir, "alias.md"));
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    expect(resources.map((r) => r.name)).not.toContain("leak.md");
+  });
+
+  test("does not list oversized memory files", async () => {
+    mkdirSync(join(root, "memory"), { recursive: true });
+    writeFileSync(
+      join(root, "memory", "huge.md"),
+      Buffer.alloc(MAX_SCOPED_FILE_BYTES + 1, 0x61),
+    );
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    expect(resources.map((r) => r.name)).not.toContain("huge.md");
+  });
+
+  test("fails a resource read when the file is swapped for a symlink after validation", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    const target = resources.find((r) => r.name === "notes.md")!;
+    const file = join(root, "memory", "notes.md");
+    const secret = makeOutsideSecret("secret.md");
+    const swapped = resourceProvider({
+      beforeOpenForTesting: (path) => {
+        if (path !== file) return;
+        rmSync(file);
+        symlinkSync(secret, file);
+      },
+    });
+    expect(await swapped.readResource(target.uri)).toBeNull();
+  });
+
+  test("fails a resource read when the open file is replaced before the read", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    const target = resources.find((r) => r.name === "notes.md")!;
+    const file = join(root, "memory", "notes.md");
+    const attacker = join(root, "attacker.md");
+    writeFileSync(attacker, "attacker body", "utf8");
+    const swapped = resourceProvider({
+      beforeReadForTesting: (path) => {
+        if (path !== file) return;
+        renameSync(attacker, file);
+      },
+    });
+    expect(await swapped.readResource(target.uri)).toBeNull();
+  });
+
+  test.runIf(process.platform !== "win32")(
+    "fails a resource read when the file is replaced by a FIFO after validation without blocking",
+    async () => {
+      makeMemoryFile("notes.md", "plain body");
+      const provider = resourceProvider();
+      const resources = await provider.listResources();
+      const target = resources.find((r) => r.name === "notes.md")!;
+      const file = join(root, "memory", "notes.md");
+      const swapped = resourceProvider({
+        beforeOpenForTesting: (path) => {
+          if (path !== file) return;
+          rmSync(file);
+          expect(spawnSync("mkfifo", [file]).status).toBe(0);
+        },
+      });
+      expect(await swapped.readResource(target.uri)).toBeNull();
+    },
+  );
+});

--- a/runtime/tests/mcp-server/prompts-resources.test.ts
+++ b/runtime/tests/mcp-server/prompts-resources.test.ts
@@ -152,39 +152,47 @@ describe("MCP resources backed by memory + instruction files", () => {
   });
 
   async function makeResourceServer(
-    readResourceContent?: (canonicalPath: string) => Promise<string>,
+    setup: {
+      /** Body written into deploy-notes.md and AGENC.md before serving. */
+      body?: string;
+      /** Fires only when a resource body is actually read from its handle. */
+      beforeReadForTesting?: (path: string) => void;
+    } = {},
   ): Promise<{
     server: McpServerFramework;
     memoryDir: string;
   }> {
-    const memoryDir = join(root, "memory");
-    await mkdir(memoryDir, { recursive: true });
-    await writeFile(
-      join(memoryDir, "MEMORY.md"),
-      "- [Deploy notes](deploy-notes.md)",
-    );
-    await writeFile(
-      join(memoryDir, "deploy-notes.md"),
+    const body =
+      setup.body ??
       [
         "---",
         "name: deploy-notes",
         "description: How deploys work",
         "---",
         "Use the staging pipeline. Token: ghp_0123456789abcdefABCDEF0123456789abcdef",
-      ].join("\n"),
+      ].join("\n");
+    const memoryDir = join(root, "memory");
+    await mkdir(memoryDir, { recursive: true });
+    await writeFile(
+      join(memoryDir, "MEMORY.md"),
+      "- [Deploy notes](deploy-notes.md)",
     );
+    await writeFile(join(memoryDir, "deploy-notes.md"), body);
     // Session memory lives under the config home's session-memory dir; it
     // must never be listed even if a memory dir points at it.
     const sessionDir = join(root, "session-memory");
     await mkdir(sessionDir, { recursive: true });
     await writeFile(join(sessionDir, "leak.md"), "session transcript notes");
-    await writeFile(join(root, "AGENC.md"), "# Project instructions\nhello");
+    await writeFile(
+      join(root, "AGENC.md"),
+      setup.body ?? "# Project instructions\nhello",
+    );
     const server = new McpServerFramework({
       resourceProvider: createMemoryResourceProvider({
         configHomeDir: root,
         memoryDirs: [memoryDir, sessionDir],
         instructionFiles: [join(root, "AGENC.md")],
-        readResourceContent,
+        beforeReadForTesting: setup.beforeReadForTesting,
       }),
     });
     return { server, memoryDir };
@@ -211,20 +219,24 @@ describe("MCP resources backed by memory + instruction files", () => {
   });
 
   it("does not read resource bodies while listing", async () => {
-    const readResourceContent = vi.fn(async () => "selected body");
-    const { server } = await makeResourceServer(readResourceContent);
+    let bodyReads = 0;
+    const { server } = await makeResourceServer({
+      beforeReadForTesting: () => {
+        bodyReads += 1;
+      },
+    });
     await initialized(server);
 
     const list = await request(server, "resources/list");
     expect(list.result.resources.length).toBeGreaterThan(0);
-    expect(readResourceContent).not.toHaveBeenCalled();
+    expect(bodyReads).toBe(0);
 
     const note = list.result.resources.find(
       (resource: any) => resource.name === "deploy-notes.md",
     );
     const read = await request(server, "resources/read", { uri: note.uri });
-    expect(read.result.contents[0].text).toBe("selected body");
-    expect(readResourceContent).toHaveBeenCalledOnce();
+    expect(read.result.contents[0].text).toContain("staging pipeline");
+    expect(bodyReads).toBe(1);
   });
 
   it("reads a memory file with secrets redacted", async () => {
@@ -243,7 +255,7 @@ describe("MCP resources backed by memory + instruction files", () => {
   it.each(canonicalRedactionFixtures)(
     "applies canonical egress redaction to memory and instructions: $name",
     async ({ input, expected, secretFragments, preservedFragments }) => {
-      const { server } = await makeResourceServer(async () => input);
+      const { server } = await makeResourceServer({ body: input });
       await initialized(server);
       const list = await request(server, "resources/list");
 


### PR DESCRIPTION
## Summary

- `readScopedRegularFile` validated a pathname with `lstat`/`realpath` and then reopened the canonical pathname with `readFile`, so a writable workspace could swap the file or an ancestor between validation and bytes; it also served multiply linked files (#1794).
- Skill prompts and resource bodies now share one descriptor-bound reader: validate, open once with `O_NOFOLLOW`/`O_NONBLOCK`, prove the opened object is the same single-link regular file validation saw, read it under a byte ceiling (`MAX_SCOPED_FILE_BYTES`, 1 MiB), and re-prove it after the read. File, ancestor, symlink, hard-link, FIFO, device, and oversized candidates are all rejected.
- Listing applies the same admission contract, so hard-linked or oversized candidates are never advertised as resources in the first place.
- The `readResourceContent` pathname seam is removed — there is no longer any route around the verified reader; deterministic race coverage swaps candidates at each I/O boundary via `beforeOpenForTesting`/`beforeReadForTesting` hooks, mirroring `secure-instruction-file.ts`.
- Node exposes no root-confined open (`openat2`/`RESOLVE_BENEATH`); containment remains canonical-resolution checks plus opened-handle identity proofs, documented in the module header like the runtime's other verified readers.

## Validation

- Reproduced on unchanged `main` end-to-end: `agenc mcp serve --transport stdio` in a workspace whose `.agenc/skills/leak/SKILL.md` was a hard link (nlink=2) to a private transcript outside the workspace — `prompts/list` served the skill and `prompts/get` returned the private body.
- Post-fix on the same live server: the hard-linked skill is rejected (`unknown prompt: leak`), a plain skill still serves, the hard-linked memory file is not listed, and `deploy-notes.md` serves with its token redacted.
- New `runtime/tests/mcp-server/content-providers-verified-reads.test.ts` (17 tests) swaps the candidate at each filesystem I/O boundary via the hooks: symlink, same-inode symlink, regular-file replacement, ancestor-directory swap, mid-read replacement, in-place mutation, hard link, oversized, FIFO. 14/17 fail with the source change reverted (the 3 passing cases are happy-path controls).
- Reworked `runtime/tests/mcp-server/prompts-resources.test.ts` to write redaction-corpus fixtures to real files instead of injecting through the removed seam: 33/33 across both provider test files.
- `npm run typecheck` passed.
- `npm run test:fast -- --base origin/main` passed: 41 files, 1032 tests.

Closes #1794