### PR TITLE
Fix project root discovery below the user home

### DIFF
--- a/runtime/src/config/repository.ts
+++ b/runtime/src/config/repository.ts
@@ -176,6 +176,18 @@ export class ConfigRepositoryError extends Error {
   }
 }
 
+function findConfigProjectRoot(
+  cwd: string,
+  markers: readonly string[] | undefined,
+  env: EnvSnapshot,
+): { rootDir: string; marker: string } | null {
+  return findProjectRootSync(
+    cwd,
+    markers,
+    env.HOME ? { stopBefore: env.HOME } : undefined,
+  );
+}
+
 const V2_TOP_LEVEL_KEYS = new Set(
   KNOWN_CONFIG_KEYS.filter(
     (key) => key !== "configVersion" && key !== "_unknown",
@@ -1216,7 +1228,8 @@ export async function assertNoRetiredConfigInputsForMutation(
   const cwd = resolve(options.cwd ?? process.cwd());
   const projectRoot = resolve(
     options.projectRoot ??
-      findProjectRootSync(cwd, defaultConfig().project_root_markers)?.rootDir ??
+      findConfigProjectRoot(cwd, defaultConfig().project_root_markers, env)
+        ?.rootDir ??
       cwd,
   );
   await assertNoRetiredConfigInputs({
@@ -1351,7 +1364,7 @@ async function loadLayeredConfigInternal(
   const projectRoot = includeWorkspaceLayers
     ? resolve(
         options.projectRoot ??
-          findProjectRootSync(cwd, rootMarkers)?.rootDir ??
+          findConfigProjectRoot(cwd, rootMarkers, env)?.rootDir ??
           cwd,
       )
     : home.path;

--- a/runtime/src/prompts/project-instructions.ts
+++ b/runtime/src/prompts/project-instructions.ts
@@ -13,7 +13,15 @@
  * @module
  */
 import { lstat } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { homedir } from "node:os";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 
 import {
   type InstructionFileIdentity,
@@ -102,6 +110,14 @@ export interface LoadProjectInstructionsOptions extends ProjectInstructionsConfi
   readonly cwd: string;
 }
 
+export interface ProjectRootSearchOptions {
+  /**
+   * Exclusive ancestor boundary for marker discovery. Markers at this path
+   * and above it cannot become the root of a strict descendant workspace.
+   */
+  readonly stopBefore?: string;
+}
+
 export interface ProjectInstructions {
   /** Absolute path to the file that was loaded. */
   readonly path: string;
@@ -146,6 +162,24 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+function projectRootStopBefore(
+  cwd: string,
+  requestedBoundary: string,
+): string | undefined {
+  const start = resolve(cwd);
+  const boundary = resolve(requestedBoundary);
+  const fromBoundary = relative(boundary, start);
+  if (
+    fromBoundary === "" ||
+    fromBoundary === ".." ||
+    fromBoundary.startsWith(`..${sep}`) ||
+    isAbsolute(fromBoundary)
+  ) {
+    return undefined;
+  }
+  return boundary;
+}
+
 /**
  * Returns the directory where the first configured marker exists when
  * walking from `cwd` upward. Returns `null` if no marker is found before
@@ -154,13 +188,21 @@ async function pathExists(p: string): Promise<boolean> {
 export async function findProjectRoot(
   cwd: string,
   markers: readonly string[] = DEFAULT_PROJECT_ROOT_MARKERS,
+  options: ProjectRootSearchOptions = {},
 ): Promise<{ rootDir: string; marker: string } | null> {
   if (markers.length === 0) {
     return null;
   }
 
+  const stopBefore = projectRootStopBefore(
+    cwd,
+    options.stopBefore ?? homedir(),
+  );
   let currentDir = cwd;
   while (true) {
+    if (stopBefore !== undefined && resolve(currentDir) === stopBefore) {
+      return null;
+    }
     for (const marker of markers) {
       if (await pathExists(join(currentDir, marker))) {
         return { rootDir: currentDir, marker };

--- a/runtime/src/session/session-store.ts
+++ b/runtime/src/session/session-store.ts
@@ -67,6 +67,7 @@ import {
   writeSync,
   unlinkSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { timed } from "../utils/slow-store-op.js";
 import {
   basename,
@@ -75,6 +76,7 @@ import {
   join,
   relative,
   resolve,
+  sep,
 } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import {
@@ -267,10 +269,41 @@ export const DEFAULT_SESSION_ROOT_MARKERS: readonly string[] = [
   ".hg",
 ];
 
+export interface ProjectRootSearchOptions {
+  /**
+   * Exclusive ancestor boundary for marker discovery. When `cwd` is a strict
+   * descendant of this directory, markers in the boundary itself (and above
+   * it) are ignored. This prevents a workspace beneath the platform home from
+   * inheriting an unrelated home-level package manifest or VCS checkout.
+   */
+  readonly stopBefore?: string;
+}
+
+function projectRootStopBefore(
+  cwd: string,
+  requestedBoundary: string,
+): string | undefined {
+  const start = resolve(cwd);
+  const boundary = resolve(requestedBoundary);
+  const fromBoundary = relative(boundary, start);
+  if (
+    fromBoundary === "" ||
+    fromBoundary === ".." ||
+    fromBoundary.startsWith(`..${sep}`) ||
+    isAbsolute(fromBoundary)
+  ) {
+    return undefined;
+  }
+  return boundary;
+}
+
 /**
  * Synchronous ancestor walk to the nearest directory that contains one
  * of the configured project-root markers. Returns `null` when no marker
- * is found before reaching the filesystem root.
+ * is found before reaching the filesystem root. By default, a workspace
+ * strictly beneath the platform home does not inspect the home directory
+ * itself; callers with an injected platform home can pass the same boundary
+ * explicitly.
  *
  * Kept sync (unlike `findProjectRoot` in `prompts/project-instructions.ts`)
  * because `getProjectDir` and the SessionStore constructor are called
@@ -281,10 +314,18 @@ export const DEFAULT_SESSION_ROOT_MARKERS: readonly string[] = [
 export function findProjectRootSync(
   cwd: string,
   markers: readonly string[] = DEFAULT_SESSION_ROOT_MARKERS,
+  options: ProjectRootSearchOptions = {},
 ): { rootDir: string; marker: string } | null {
   if (markers.length === 0) return null;
+  const stopBefore = projectRootStopBefore(
+    cwd,
+    options.stopBefore ?? homedir(),
+  );
   let currentDir = cwd;
   while (true) {
+    if (stopBefore !== undefined && resolve(currentDir) === stopBefore) {
+      return null;
+    }
     for (const marker of markers) {
       if (existsSync(join(currentDir, marker))) {
         return { rootDir: currentDir, marker };

--- a/runtime/tests/config/canonical-repository.test.ts
+++ b/runtime/tests/config/canonical-repository.test.ts
@@ -139,6 +139,61 @@ describe("HomeContext", () => {
 });
 
 describe("strict layered repository", () => {
+  test("does not inherit retired home config through a home-level package marker", async () => {
+    const root = realpathSync(temp("agenc-selected-workspace-boundary"));
+    const platformHome = join(root, "Users", "tester");
+    const isolatedAgencHome = join(root, "desktop-user-data", "core");
+    const workspace = join(platformHome, "Documents", "huntsman-key");
+    mkdirSync(workspace, { recursive: true });
+    write(join(platformHome, "package.json"), "{}\n");
+    write(join(platformHome, ".agenc", "settings.json"), "{}\n");
+
+    const loaded = await loadLayeredConfig({
+      env: { AGENC_HOME: isolatedAgencHome, HOME: platformHome },
+      cwd: workspace,
+      managedConfigPath: join(root, "missing-managed.toml"),
+      managedDropInDir: join(root, "missing-managed.d"),
+    });
+
+    expect(loaded.projectRoot).toBe(workspace);
+    expect(loaded.sources).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: join(platformHome, ".agenc", "settings.json"),
+      }),
+    ]));
+  });
+
+  test("still discovers a package-rooted monorepo below the home boundary", async () => {
+    const root = realpathSync(temp("agenc-selected-monorepo-boundary"));
+    const platformHome = join(root, "Users", "tester");
+    const isolatedAgencHome = join(root, "desktop-user-data", "core");
+    const projectRoot = join(platformHome, "Documents", "workspace-monorepo");
+    const workspace = join(projectRoot, "packages", "huntsman-key");
+    const projectConfig = join(projectRoot, ".agenc", "config.toml");
+    mkdirSync(workspace, { recursive: true });
+    write(join(platformHome, "package.json"), "{}\n");
+    write(join(platformHome, ".agenc", "settings.json"), "{}\n");
+    write(join(projectRoot, "package.json"), "{}\n");
+    write(projectConfig, [
+      "config_version = 2",
+      'model = "grok-4.3"',
+      "",
+    ].join("\n"));
+
+    const loaded = await loadLayeredConfig({
+      env: { AGENC_HOME: isolatedAgencHome, HOME: platformHome },
+      cwd: workspace,
+      projectTrusted: true,
+      managedConfigPath: join(root, "missing-managed.toml"),
+      managedDropInDir: join(root, "missing-managed.d"),
+    });
+
+    expect(loaded.projectRoot).toBe(projectRoot);
+    expect(loaded.sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ scope: "project", path: projectConfig }),
+    ]));
+  });
+
   test("keeps daemon configuration independent from the launch workspace", async () => {
     const root = temp("agenc-daemon-home-authority");
     const home = join(root, "home");

--- a/runtime/tests/prompts/project-instructions.test.ts
+++ b/runtime/tests/prompts/project-instructions.test.ts
@@ -64,6 +64,19 @@ describe("project-instructions (T10-B)", () => {
     expect(r).toBeNull();
   });
 
+  test("findProjectRoot respects an exclusive home boundary", async () => {
+    const platformHome = join(root, "home");
+    const workspace = join(platformHome, "Documents", "huntsman-key");
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(platformHome, "package.json"), "{}\n");
+
+    await expect(findProjectRoot(
+      workspace,
+      ["package.json"],
+      { stopBefore: platformHome },
+    )).resolves.toBeNull();
+  });
+
   test("resolveInstructionFile prefers AGENC.override.md over AGENC.md", async () => {
     const dir = join(root, "d");
     mkdirSync(dir);

--- a/runtime/tests/session/session-store.test.ts
+++ b/runtime/tests/session/session-store.test.ts
@@ -2472,6 +2472,38 @@ describe("session-store", () => {
     }
   });
 
+  test("findProjectRootSync excludes a home-level marker without hiding a nested monorepo", () => {
+    const platformHome = mkdtempSync(join(tmpdir(), "agenc-root-boundary-"));
+    try {
+      writeFileSync(join(platformHome, "package.json"), "{}\n");
+      const standaloneWorkspace = join(
+        platformHome,
+        "Documents",
+        "huntsman-key",
+      );
+      mkdirSync(standaloneWorkspace, { recursive: true });
+
+      expect(findProjectRootSync(
+        standaloneWorkspace,
+        ["package.json"],
+        { stopBefore: platformHome },
+      )).toBeNull();
+
+      const monorepo = join(platformHome, "Documents", "workspace-monorepo");
+      const nestedWorkspace = join(monorepo, "packages", "huntsman-key");
+      mkdirSync(nestedWorkspace, { recursive: true });
+      writeFileSync(join(monorepo, "package.json"), "{}\n");
+
+      expect(findProjectRootSync(
+        nestedWorkspace,
+        ["package.json"],
+        { stopBefore: platformHome },
+      )).toEqual({ rootDir: monorepo, marker: "package.json" });
+    } finally {
+      rmSync(platformHome, { recursive: true, force: true });
+    }
+  });
+
   test("DEFAULT_SESSION_ROOT_MARKERS covers common ecosystem roots", () => {
     // Guards against accidental drift between this list and the
     // project-instructions loader; a full equality check would couple


### PR DESCRIPTION
## Summary
- stop project-root discovery before a descendant workspace reaches the platform home
- keep nested monorepo marker discovery intact
- prevent selected workspaces from inheriting retired home-level .agenc inputs

## Validation
- focused root-boundary regressions pass
- project-instructions suite: 30/30
- source and test-support typechecks pass
- packaged Core validation succeeds from /Users/tetsuoarena/Documents/huntsman-key