### PR TITLE
fix(plugins): trust official publisher on clean profiles

### DIFF
--- a/docs/reference/skills-plugins.md
+++ b/docs/reference/skills-plugins.md
@@ -653,11 +653,12 @@ from each skill directory's `SKILL.md` frontmatter.
 
 Remote plugin resolution (`resolvePluginSource` in
 `runtime/src/plugins/resolution.ts`) verifies an Ed25519 publisher signature
-against a local keyring. Marketplace install through either the CLI or the
+against the operator keyring plus AgenC's built-in official publisher root.
+Marketplace install through either the CLI or the
 `/plugins` menu sets `requireSignature` when the marketplace `sourceType` is
 not `local` (`installRequiresSignature` in `catalog-cli.ts`). The official
 `agenc-plugins` catalog is a URL marketplace, so this gate applies to it.
-There is no `agenc plugin sign` command and no shipped default keyring.
+There is no `agenc plugin sign` command and no generated default keyring file.
 
 #### When verification runs
 
@@ -712,6 +713,13 @@ same-named workspace directory. The shipped CLI cannot opt out.
 Default path: `$AGENC_HOME/plugin-publishers.json`. The resolver accepts an
 in-process `publishersPath` override; there is no operator CLI for it.
 
+AgenC includes the `tetsuo-ai` public key as its official publisher trust root,
+so signed plugins from the shipped marketplace work in a clean profile. The
+default keyring can add third-party publishers or explicitly replace that entry.
+An in-process `publishersPath` override is authoritative and does not use the
+built-in fallback. Missing or malformed keyrings still fail closed for every
+other publisher.
+
 ```json
 {
   "publishers": {
@@ -722,11 +730,13 @@ in-process `publishersPath` override; there is no operator CLI for it.
 }
 ```
 
-A publisher entry may be that base64 string directly. A parsed keyring without
-a usable entry for the named publisher throws
-`plugin publisher is not trusted: <name>`. Missing, unreadable, or malformed
-keyrings surface their filesystem or JSON error. A well-formed public key and
-signature that do not verify throw
+A publisher entry may be that base64 string directly. An explicit entry with
+an empty or unusable value is authoritative and throws
+`plugin publisher is not trusted: <name>`; it never falls back to the shipped
+root. A missing default keyring uses the built-in root only for `tetsuo-ai`.
+Missing keyrings for other publishers, unreadable files, and malformed JSON
+surface their filesystem or JSON error. A well-formed public key and signature
+that do not verify throw
 `plugin signature verification failed for publisher <name>`; malformed key
 material can surface a crypto parsing error.
 
@@ -761,7 +771,7 @@ payload.
 | Symptom | What to check |
 | --- | --- |
 | `plugin signature is required` | A required install lacks `.agenc-plugin/signature.json`. Direct local `plugin install ./dir` does not take this path. |
-| `plugin publisher is not trusted` | The parsed `$AGENC_HOME/plugin-publishers.json` has no usable key for that publisher. Missing, unreadable, or malformed keyrings report their underlying error instead. |
+| `plugin publisher is not trusted` | The selected keyring has an explicit unusable entry, or has no usable key for a non-built-in publisher. A missing default keyring is supported only for the built-in `tetsuo-ai` root; other missing, unreadable, or malformed keyrings report their underlying error. |
 | `signatureVerified: false` after marketplace install | Expected only for a local marketplace or a custom caller that disabled the requirement. A successful non-local marketplace install returning false violates the shipped path's invariant. |
 | `plugin update` without `--source` accepts an unsigned tree | Install metadata records a waiver or has neither `signatureRequired: true` nor the legacy `signatureVerified: true` signal. Reinstall the plugin from its marketplace to establish the current requirement. |
 | `plugin update --source <remote>` rejects an unsigned tree after a local install | The replacement source uses the remote resolver default. Sign the replacement or keep using a local source. |

--- a/runtime/src/plugins/publisher-trust.ts
+++ b/runtime/src/plugins/publisher-trust.ts
@@ -1,0 +1,31 @@
+import { createHash } from "node:crypto";
+
+/** Publisher identity used by plugins signed and shipped by AgenC. */
+export const OFFICIAL_PLUGIN_PUBLISHER = "tetsuo-ai";
+
+/** Base64 DER-SPKI Ed25519 public key for the official AgenC publisher. */
+export const OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY =
+  "MCowBQYDK2VwAyEAj20DQnldg2gADPiX8xb+7Anc7m8FfdhQYmtqqLUW/+E=";
+
+/** Auditable SHA-256 fingerprint of the decoded DER-SPKI key above. */
+export const OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256 =
+  "8174e96296289bd8eed26b832296309015216afe544a7f15097356b10aa1b932";
+
+/**
+ * AgenC ships its own publisher root so a clean profile can verify official
+ * plugins without first downloading or hand-writing a trust file. Third-party
+ * publishers remain exclusively controlled by the operator keyring.
+ */
+export function builtInPluginPublisherPublicKey(
+  publisher: string,
+): string | undefined {
+  return publisher === OFFICIAL_PLUGIN_PUBLISHER
+    ? OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY
+    : undefined;
+}
+
+export function pluginPublisherKeyFingerprint(publicKey: string): string {
+  return createHash("sha256")
+    .update(Buffer.from(publicKey, "base64"))
+    .digest("hex");
+}

--- a/runtime/src/plugins/resolution.ts
+++ b/runtime/src/plugins/resolution.ts
@@ -24,6 +24,7 @@ import { redactSecrets } from "../secrets/index.js";
 import { isRecord } from "../utils/record.js";
 import { findPluginManifestPath, loadPluginManifest } from "./manifest.js";
 import { pluginCacheDirPath, sanitizePluginId } from "./directories.js";
+import { builtInPluginPublisherPublicKey } from "./publisher-trust.js";
 import {
   buildPluginIdentifier,
   isCanonicalPluginIdentity,
@@ -760,7 +761,15 @@ export async function verifyResolvedPluginSignature(
   const publishersPath = options.publishersPath ?? defaultPublishersPath(
     options.agencHome,
   );
-  const publicKey = await readPublisherPublicKey(publishersPath, signature.publisher);
+  const publicKey = await readPublisherPublicKey(
+    publishersPath,
+    signature.publisher,
+    // An explicit path is an authoritative caller-supplied trust store. The
+    // built-in AgenC root is only the fallback for the normal profile keyring.
+    options.publishersPath === undefined
+      ? builtInPluginPublisherPublicKey(signature.publisher)
+      : undefined,
+  );
   const manifestPath = await findPluginManifestPath(pluginRoot);
   if (!manifestPath) throw new Error("cannot verify plugin signature without plugin.json");
   const manifestBytes = await readFile(manifestPath);
@@ -1633,12 +1642,37 @@ function redactPluginResolutionError(error: unknown): Error {
   return new Error(redactPluginSource(String(error)));
 }
 
-async function readPublisherPublicKey(path: string, publisher: string): Promise<string> {
-  const parsed = JSON.parse(await readFile(path, "utf8")) as PublisherKeyring;
-  const entry = parsed.publishers?.[publisher];
+async function readPublisherPublicKey(
+  path: string,
+  publisher: string,
+  builtInPublicKey?: string,
+): Promise<string> {
+  let parsed: PublisherKeyring;
+  try {
+    parsed = JSON.parse(await readFile(path, "utf8")) as PublisherKeyring;
+  } catch (error) {
+    if (
+      (error as NodeJS.ErrnoException).code === "ENOENT" &&
+      builtInPublicKey !== undefined
+    ) {
+      return builtInPublicKey;
+    }
+    throw error;
+  }
+  const publishers = parsed.publishers;
+  const hasExplicitEntry =
+    publishers !== undefined &&
+    Object.prototype.hasOwnProperty.call(publishers, publisher);
+  const entry = publishers?.[publisher];
   const publicKey = typeof entry === "string" ? entry : entry?.publicKey;
-  if (!publicKey) throw new Error(`plugin publisher is not trusted: ${publisher}`);
-  return publicKey;
+  if (publicKey) return publicKey;
+  // An entry with an empty or malformed value is still an explicit operator
+  // decision. Never mask it with the shipped root.
+  if (hasExplicitEntry) {
+    throw new Error(`plugin publisher is not trusted: ${publisher}`);
+  }
+  if (builtInPublicKey !== undefined) return builtInPublicKey;
+  throw new Error(`plugin publisher is not trusted: ${publisher}`);
 }
 
 function defaultPublishersPath(agencHome: string): string {

--- a/runtime/tests/plugins/publisher-trust.test.ts
+++ b/runtime/tests/plugins/publisher-trust.test.ts
@@ -1,0 +1,111 @@
+import { createPublicKey, verify } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { pluginSignaturePayloadBytes } from "./resolution.js";
+import {
+  OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256,
+  OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY,
+  pluginPublisherKeyFingerprint,
+} from "./publisher-trust.js";
+
+// Known-good llm-checker signature from tetsuo-ai/agenc-plugins at
+// d8f43d61b7448dbb59907d7d9bacb6c660642672. Keeping the manifest bytes and
+// digest set here makes key rotation an explicit, reviewable test update.
+const SIGNED_MANIFEST = Buffer.from(`{
+  "name": "llm-checker",
+  "version": "0.2.1",
+  "description": "Work out which local LLM this machine can run, from measured hardware and a real memory budget.",
+  "author": {
+    "name": "tetsuo-ai"
+  },
+  "homepage": "https://agenc.tech",
+  "repository": "https://github.com/tetsuo-ai/agenc-plugins",
+  "license": "MIT",
+  "keywords": [
+    "llm",
+    "local-models",
+    "hardware",
+    "vram",
+    "ollama",
+    "llama.cpp",
+    "model-selection"
+  ],
+  "commands": {
+    "pick-model": {
+      "source": "./commands/pick-model.md",
+      "description": "Recommend an exact local model artifact that fits this machine's memory budget",
+      "argumentHint": "[category or model name]",
+      "allowedTools": [
+        "Bash",
+        "Read"
+      ]
+    },
+    "runtime-check": {
+      "source": "./commands/runtime-check.md",
+      "description": "Show this machine's hardware budget and installed Ollama models",
+      "argumentHint": "",
+      "allowedTools": [
+        "Bash"
+      ]
+    }
+  },
+  "skills": [
+    "./skills/local-model-fit"
+  ],
+  "interface": {
+    "displayName": "LLM Checker",
+    "shortDescription": "Find which local models this machine can actually run.",
+    "longDescription": "Reads the real usable-memory budget with the llm-checker CLI, then ranks exact registry artifacts by hardware fit and reports their estimated memory requirement, quantization, runtime and provenance. The score is deterministic fit and suitability, not a public benchmark result. It never downloads a model, starts a server, or changes runtime configuration.",
+    "developerName": "tetsuo-ai",
+    "category": "developer-tools",
+    "capabilities": [
+      "hardware-detection",
+      "memory-fit-analysis",
+      "artifact-aware-recommendations",
+      "installed-model-ranking"
+    ],
+    "websiteUrl": "https://agenc.tech",
+    "brandColor": "#f0a93c",
+    "logo": "./assets/logo.png",
+    "defaultPrompt": [
+      "Which local model can my machine run?",
+      "What should I run for coding on this GPU?",
+      "Will a 14B model fit in my memory budget?",
+      "What are my hardware limits for local models?"
+    ],
+    "screenshots": []
+  }
+}
+`, "utf8");
+
+const SIGNED_FILES = {
+  "assets/logo.png": "sha256:044ff5423f891191d2dbe625fe57d76edbc6bde4d326c1f8874a102ab1285585",
+  "commands/pick-model.md": "sha256:fd9adbdfd10ea3f02cd4e2621113357d54c3be02eb09afc55e82b6e289080db6",
+  "commands/runtime-check.md": "sha256:1f1e1e3c7baf28ba09e7e72807f524cd090503ff85a4add437c7f197be54822f",
+  "skills/local-model-fit/SKILL.md": "sha256:7fe5963e32c9c6c2f9d7ef912deb39b998dd2a36190c99982af7ee976e2a561d",
+};
+
+const SIGNATURE =
+  "Bm7Nu3ioVXWncjJraWg6m77pjJO4q20A5cgaSUsGumt0Owt6rMKO9J2WA4NPDh+0jFpAYzDndqUlkXDxn5+vBg==";
+
+describe("official plugin publisher trust", () => {
+  it("matches the audited fingerprint and verifies an official signature", () => {
+    expect(
+      pluginPublisherKeyFingerprint(OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY),
+    ).toBe(OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256);
+
+    const publicKey = createPublicKey({
+      key: Buffer.from(OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY, "base64"),
+      format: "der",
+      type: "spki",
+    });
+    expect(
+      verify(
+        null,
+        pluginSignaturePayloadBytes(SIGNED_MANIFEST, SIGNED_FILES),
+        publicKey,
+        Buffer.from(SIGNATURE, "base64"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/runtime/tests/plugins/resolution.test.ts
+++ b/runtime/tests/plugins/resolution.test.ts
@@ -30,6 +30,12 @@ import {
   loadPlugins as loadPluginsWithAuthority,
   type LoadedPlugin,
 } from "./loader.js";
+import {
+  OFFICIAL_PLUGIN_PUBLISHER,
+  OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256,
+  OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY,
+  pluginPublisherKeyFingerprint,
+} from "./publisher-trust.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -1783,6 +1789,104 @@ describe("plugin source resolution", () => {
           requireSignature: true,
         }),
       ).rejects.toThrow(/digest mismatch/u);
+    });
+  });
+
+  test("uses the built-in official publisher root only for the default keyring", async () => {
+    await withTempDir(async (root) => {
+      expect(
+        pluginPublisherKeyFingerprint(OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY),
+      ).toBe(OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256);
+
+      const pluginRoot = join(root, "official-signed");
+      const manifestPath = await writePlugin(pluginRoot, "official-signed");
+      const files = await pluginPayloadFiles(pluginRoot);
+      await writeJson(join(pluginRoot, ".agenc-plugin", "signature.json"), {
+        publisher: OFFICIAL_PLUGIN_PUBLISHER,
+        signature: Buffer.alloc(64).toString("base64"),
+        files,
+      });
+
+      // The missing default keyring reaches cryptographic verification using
+      // the shipped root; an invalid signature still fails closed.
+      await expect(
+        verifyResolvedPluginSignature(pluginRoot, {
+          agencHome: root,
+          requireSignature: true,
+        }),
+      ).rejects.toThrow(/signature verification failed for publisher tetsuo-ai/u);
+
+      // An explicitly selected missing keyring stays authoritative and keeps
+      // the underlying filesystem error instead of silently using the root.
+      await expect(
+        verifyResolvedPluginSignature(pluginRoot, {
+          agencHome: root,
+          publishersPath: join(root, "explicit-missing.json"),
+          requireSignature: true,
+        }),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+
+      await writeJson(join(root, "plugin-publishers.json"), {
+        publishers: { [OFFICIAL_PLUGIN_PUBLISHER]: {} },
+      });
+      await expect(
+        verifyResolvedPluginSignature(pluginRoot, {
+          agencHome: root,
+          requireSignature: true,
+        }),
+      ).rejects.toThrow(/plugin publisher is not trusted: tetsuo-ai/u);
+
+      await writeFile(join(root, "plugin-publishers.json"), "{not-json");
+      await expect(
+        verifyResolvedPluginSignature(pluginRoot, {
+          agencHome: root,
+          requireSignature: true,
+        }),
+      ).rejects.toBeInstanceOf(SyntaxError);
+
+      // A present default keyring entry is also authoritative.
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const signature = sign(
+        null,
+        pluginSignaturePayloadBytes(await readFile(manifestPath), files),
+        privateKey,
+      ).toString("base64");
+      await writeJson(join(pluginRoot, ".agenc-plugin", "signature.json"), {
+        publisher: OFFICIAL_PLUGIN_PUBLISHER,
+        signature,
+        files,
+      });
+      await writeJson(join(root, "plugin-publishers.json"), {
+        publishers: {
+          [OFFICIAL_PLUGIN_PUBLISHER]: {
+            publicKey: publicKey
+              .export({ format: "der", type: "spki" })
+              .toString("base64"),
+          },
+        },
+      });
+      await expect(
+        verifyResolvedPluginSignature(pluginRoot, {
+          agencHome: root,
+          requireSignature: true,
+        }),
+      ).resolves.toMatchObject({
+        verified: true,
+        publisher: OFFICIAL_PLUGIN_PUBLISHER,
+      });
+
+      await writeJson(join(pluginRoot, ".agenc-plugin", "signature.json"), {
+        publisher: "unknown-publisher",
+        signature,
+        files,
+      });
+      await rm(join(root, "plugin-publishers.json"));
+      await expect(
+        verifyResolvedPluginSignature(pluginRoot, {
+          agencHome: root,
+          requireSignature: true,
+        }),
+      ).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 


### PR DESCRIPTION
## Summary
- ship the audited tetsuo-ai public key as the official plugin publisher trust root
- let clean profiles verify signed official plugins without weakening third-party trust checks
- keep explicit keyring entries and explicit keyring paths authoritative
- document trust semantics and add a known-good official signature vector

## Verification
- 56 focused signature tests passed
- runtime typecheck passed
- clean-home catalog, install, signature verification, and update passed against llm-checker@agenc-plugins
