### PR TITLE
fix(tools): decouple execution backends from providers

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -41,10 +41,10 @@ history; the linked pages below are current product truth.
 | [eval/real-agent-baseline-runbook.md](eval/real-agent-baseline-runbook.md) | Operator runbook for reproducible real-agent pilot batches from pinned inputs, including fail-closed CLI parsing |
 | [eval/seed-baseline-2026-07-17.md](eval/seed-baseline-2026-07-17.md) | Dated snapshot: first contained 10-task real-agent scorecard (2026-07-17, runtime 0.6.1). Not a reproduction contract |
 | [ci-required-gates.md](ci-required-gates.md) | Fast `test:fast` classification, typecheck-only native/policy-inventory surfaces, exact-SHA release gates, and the inactive optional GitHub App/ruleset design |
-| [provider-tool-compat.md](provider-tool-compat.md) | Wire-schema shaping: object-root tools, llama.cpp grammar-safe schemas, Gemini native JSON Schema, Gemini object-applicator roots that omit type, and the LM Studio/openai-compatible 8192 ceiling |
+| [provider-tool-compat.md](provider-tool-compat.md) | Provider-independent tool backends plus wire-schema shaping: object-root tools, llama.cpp grammar-safe schemas, Gemini native JSON Schema, Gemini object-applicator roots that omit type, and the LM Studio/openai-compatible 8192 ceiling |
 | [embedded-neovim-buffer.md](embedded-neovim-buffer.md) | Embedded Neovim workspace, multi-buffer safety, recovery, editor/chat handoff, request-scoped Editor turn bounds, configuration, troubleshooting, and hosted PTY split |
 | [browser.md](browser.md) | Browser tool, Chromium profile, SSRF proxy, `[browser]` config |
-| [imagine.md](imagine.md) | Grok ImagineImage / ImagineVideo tools (direct xAI only) |
+| [imagine.md](imagine.md) | Provider-independent image/video tools backed by Meta Muse Image or direct xAI Imagine |
 | [sdk.md](sdk.md) | Embed via `@tetsuo-ai/agenc-sdk` (socket + subprocess), including `startRun` model/provider, the generated transcript.v2 protocol slice, and marker-checked workflow-result types |
 | [security/slm-transaction-guard.md](security/slm-transaction-guard.md) | Opt-in SLM CourtGuard for Solana-like tool calls |
 | [security/mobile-ledger-transfer.md](security/mobile-ledger-transfer.md) | Typed Android `@ledger` SOL handoff: trust boundary, schemas, idempotency, recovery |

--- a/docs/imagine.md
+++ b/docs/imagine.md
@@ -1,13 +1,21 @@
-# Imagine image and video tools
+# Image and video generation tools
 
-LIVE tools `ImagineImage` and `ImagineVideo` call xAI Grok Imagine REST
-endpoints. They are registered on the tool catalog but only run when all of
-these hold:
+LIVE tools `ImagineImage` and `ImagineVideo` use separately authenticated
+media backends. The provider that performs the reasoning turn does **not** gate
+these tools: Meta, OpenAI, Grok, and any other tool-capable model can invoke
+them when the corresponding media backend is configured.
 
-1. Session provider is `grok`
-2. Inference host is direct xAI (`api.x.ai`), not OpenRouter or another gateway
-3. Credentials: `XAI_API_KEY` / `GROK_API_KEY`, or
-   `/grok-login` subscription OAuth
+| Tool | Backend availability |
+| --- | --- |
+| `ImagineImage` | Meta Muse Image with `MODEL_API_KEY`, or xAI Imagine with `XAI_API_KEY`, `GROK_API_KEY`, or `/grok-login` OAuth |
+| `ImagineVideo` | xAI Imagine with `XAI_API_KEY`, `GROK_API_KEY`, or `/grok-login` OAuth |
+
+Backend authority is credential-isolated. A Meta, OpenAI, or gateway session
+key is never forwarded to xAI, and an xAI key is never forwarded to Meta. A
+direct Grok session may reuse its own xAI bearer; otherwise xAI media calls use
+the independently configured xAI credentials. A Meta reasoning session prefers
+Muse Image when `MODEL_API_KEY` is configured. Other reasoning providers can
+also use Muse Image when it is the available image backend.
 
 Both tools require approval (`requiresApproval: true`) and run exclusive
 (no parallel sibling Imagine calls). Files land under
@@ -20,25 +28,34 @@ OAuth: [grok-oauth.md](grok-oauth.md).
 ## ImagineImage
 
 Source: `runtime/src/tools/system/imagine-image.ts`.
-POST `https://api.x.ai/v1/images/generations`. Tool timeout 150 s; the
-request itself uses a 120 s abort.
+
+- Meta backend: POST
+  `${META_BASE_URL:-https://api.meta.ai/v1}/images/generations` with
+  `muse-image-1.0`.
+- xAI backend: POST `https://api.x.ai/v1/images/generations` with
+  `grok-imagine-image` or `grok-imagine-image-quality`.
+
+The tool timeout is 150 s; the request itself uses a 120 s abort.
 
 | Argument | Required | Notes |
 | --- | --- | --- |
 | `prompt` | yes | Text prompt |
-| `model` | no | `grok-imagine-image` (default) or `grok-imagine-image-quality` |
+| `model` | no | Backend default: `muse-image-1.0` on Meta; `grok-imagine-image` on xAI. xAI also accepts `grok-imagine-image-quality` |
 | `n` | no | 1-10 images, default 1 |
 | `aspect_ratio` | no | `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`, `2:1`, `1:2`, `19.5:9`, `9:19.5`, `20:9`, `9:20`, `auto` |
-| `resolution` | no | `1k` or `2k` |
+| `resolution` | no | xAI only: `1k` or `2k` |
 
-Ask the agent to generate an image in a grok session, or call the tool by
-name. The model only sees the tool when the gate stack above succeeds.
+For Meta, aspect ratios map to `1024x1024`, `1536x1024`, or `1024x1536`.
+The tool accepts either base64 or URL results from both backends, downloads the
+image when necessary, and saves Meta output as WebP (xAI output as JPEG) under
+the workspace so desktop media rendering receives the correct content type.
 
 ## ImagineVideo
 
 Source: `runtime/src/tools/system/imagine-video.ts`.
-POST `/v1/videos/generations`, then poll `GET /v1/videos/{request_id}` until
-done. Tool timeout 300 s. Poll interval 5 s, poll budget 240 s.
+The execution backend is always direct xAI: POST `/v1/videos/generations`, then
+poll `GET /v1/videos/{request_id}` until done. The reasoning model can belong to
+any provider. Tool timeout 300 s. Poll interval 5 s, poll budget 240 s.
 
 | Argument | Required | Notes |
 | --- | --- | --- |
@@ -54,10 +71,11 @@ Saves an MP4 under the workspace.
 
 ## Failures you will actually see
 
-- Session provider is not grok
-- Base URL is not `api.x.ai` (OpenRouter is refused)
-- No bearer token (set a key or run `/grok-login`)
+- No compatible media credential is configured
+- An independently configured xAI base URL is not direct `api.x.ai`
+- The requested model belongs to the other image backend
 - Missing `prompt`
 - Approval denied
 
-There is no separate `agenc imagine` CLI. These are model tools.
+Changing the reasoning provider does not fix a missing media credential. There
+is no separate `agenc imagine` CLI; these are model tools.

--- a/docs/provider-tool-compat.md
+++ b/docs/provider-tool-compat.md
@@ -11,6 +11,26 @@ exactly now fail in-process with `LLMProviderError` instead of reaching
 Local window probes and `context_window_exceeded` text:
 [providers.md](reference/providers.md#local-context-windows).
 
+## Reasoning providers and execution backends
+
+The model that selects a client tool and the service that executes that tool
+are separate identities. A tool-capable reasoning provider is not required to
+own a tool's backend. Catalog exposure follows the backend credentials and
+capabilities captured for the request, not the reasoning provider slug.
+
+For example, a Meta Muse Spark or OpenAI model can invoke `XSearch`,
+`ImagineImage`, or `ImagineVideo`. `XSearch` then performs native X search
+through an independently authenticated direct-xAI Grok backend;
+`ImagineVideo` similarly uses xAI Imagine. `ImagineImage` can use Meta Muse
+Image with `MODEL_API_KEY` or xAI Imagine with separate xAI credentials. The
+reasoning session's API key and base URL are never borrowed for a different
+provider's backend.
+
+This does not turn provider-native server tools into generic wire features.
+Native `x_search`, for example, is still sent only on the internal compatible
+Grok request. The original reasoning model sees and invokes the AgenC client
+tool, while AgenC owns the backend-specific request.
+
 ## Object-root tools (Grok / DeepSeek)
 
 Strict OpenAI-compatible providers (x.ai / Grok, DeepSeek) require each tool
@@ -117,7 +137,9 @@ Model API rejects them. Meta accepts only `tool_choice: "auto"`: required and
 named choices are normalized to `auto`, while `none` removes tools from the
 request. Caller-supplied stop sequences are stripped because Meta rejects the
 `stop` field. Meta requests use `max_completion_tokens`; Muse Spark supports
-image input, JSON-schema structured output, and parallel function calls.
+image input, JSON-schema structured output, and parallel function calls. Those
+function calls can target the same backend-qualified AgenC tool catalog as
+calls from other cloud providers.
 
 ## Gemini native JSON Schema
 

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -207,16 +207,22 @@ Meta Model API uses `MODEL_API_KEY` and the OpenAI-compatible
 `/chat/completions` transport. Its LLM catalog includes `muse-spark-1.3`,
 `muse-spark-1.3-contributor`, `muse-spark-1.2`,
 `muse-spark-1.2-contributor`, and `muse-spark-1.1`. The `/models` entries
-`muse-image-1.0` and `muse-voice-transcribe-1.0` are media APIs, so they are
-not offered as session LLMs. Muse Spark is registered with a 1,048,576-token
-context window and a 131,072-token maximum output. Its supported reasoning
-levels are `minimal`, `low`, `medium`, `high`, and `xhigh` (default `medium`);
-`none` and `max` are rejected by the API. The chat models accept image input,
-JSON-schema structured output, and parallel function calls. Meta accepts only
-`tool_choice: "auto"` and rejects `stop`, so AgenC normalizes those controls
-before sending a request. Exact per-token pricing is not published in the
-authoritative provider documentation, so AgenC reports the cost as unknown
-instead of treating its conservative fallback estimate as authoritative.
+`muse-image-1.0` and `muse-voice-transcribe-1.0` are media APIs, so they remain
+excluded from the chat/session model picker. `muse-image-1.0` is instead the
+native Meta backend for the model-facing `ImagineImage` tool. Muse Spark (and
+any other tool-capable reasoning provider) can invoke that tool when
+`MODEL_API_KEY` is configured; tool availability is not restricted by the
+reasoning provider slug.
+
+Muse Spark is registered with a 1,048,576-token context window and a
+131,072-token maximum output. Its supported reasoning levels are `minimal`,
+`low`, `medium`, `high`, and `xhigh` (default `medium`); `none` and `max` are
+rejected by the API. The chat models accept image input, JSON-schema structured
+output, and parallel function calls. Meta accepts only `tool_choice: "auto"`
+and rejects `stop`, so AgenC normalizes those controls before sending a
+request. Exact per-token pricing is not published in the authoritative
+provider documentation, so AgenC reports the cost as unknown instead of
+treating its conservative fallback estimate as authoritative.
 
 ## Local context windows
 

--- a/docs/reference/tools-permissions-sandbox.md
+++ b/docs/reference/tools-permissions-sandbox.md
@@ -152,12 +152,14 @@ Legacy `system.*` utilities (not the primary edit surface):
 | `system.symbolReferences` | Deferred |
 | `LSP` | Language-server diagnostics / definition / references / symbols |
 | `WebSearch` | Web search (provider-native Grok path when available, else configured endpoint / DuckDuckGo) |
-| `XSearch` | **Grok-gated.** Live X/Twitter search via direct xAI when session provider is `grok` and `[providers.grok] x_search = true` |
+| `XSearch` | Live X/Twitter search through an independent direct-xAI backend. Any tool-capable reasoning provider may invoke it when xAI credentials exist and `[providers.grok] x_search = true` |
 | `web_fetch` | Fetch URL → text/markdown |
 
 There is **no** separate LIVE tool named `web_search`; that string is only a
 provider-native server-side tool id used internally by the Grok web-search
-path. Model-facing search is `WebSearch` (plus gated `XSearch` when enabled).
+path. Model-facing search is `WebSearch` (plus backend-gated `XSearch` when
+enabled). The reasoning provider does not have to be Grok; `XSearch` performs
+its server-side native search through a separately authenticated Grok backend.
 
 ### Planning / workflow
 
@@ -191,16 +193,18 @@ path. Model-facing search is `WebSearch` (plus gated `XSearch` when enabled).
 | `EnterWorktree` | **Deferred** by default |
 | `ExitWorktree` | **Deferred** by default |
 
-### Media (Grok-gated)
+### Media (backend-gated, provider-independent)
 
 | Name | Notes |
 | --- | --- |
-| `ImagineImage` | Image generation via direct xAI when session provider is `grok` and credentials are available |
-| `ImagineVideo` | Video generation via direct xAI when session provider is `grok` and credentials are available |
+| `ImagineImage` | Image generation via Meta Muse Image (`MODEL_API_KEY`) or direct xAI Imagine (xAI credentials); callable by any tool-capable reasoning provider |
+| `ImagineVideo` | Video generation via an independently authenticated direct-xAI Imagine backend; callable by any tool-capable reasoning provider |
 
-These are registered on the LIVE surface but only usable on the Grok/direct-xAI
-path. Other providers do not advertise them as working media tools. Operator
-guide: [imagine.md](../imagine.md).
+Registration follows execution-backend capability, not the provider doing the
+reasoning. `ImagineImage` is included when a Meta or xAI image credential is
+available; `ImagineVideo` is included when xAI credentials are available.
+Provider session keys never cross backend trust boundaries. Operator guide:
+[imagine.md](../imagine.md).
 
 ### Browser
 

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -1177,7 +1177,6 @@ async function bootstrapLocalRuntimeSessionScoped(
         config: startup.config,
         environment: providerEnvironment,
       }).settings;
-  const selectedBaseURL = initialTransportRequest.requested.baseURL;
   const mcpManager = createSessionMcpManager([], {
     environment: sessionMcpRequestEnvironment,
     sandboxExecutionBroker,
@@ -1286,14 +1285,10 @@ async function bootstrapLocalRuntimeSessionScoped(
             enabled_tools: [...LIVE_COORDINATOR_ALLOWED_TOOLS],
           }
         : baseToolsConfig,
-      // G1/G3 Hermes-style catalog gates: pass session provider + host so
-      // XSearch / ImagineImage are not advertised to Claude/GPT/OpenRouter.
+      // xAI settings configure an independent tool backend. They do not
+      // restrict which reasoning provider may invoke XSearch/Imagine.
       ...(startup.config.providers?.grok !== undefined
         ? { grokCapabilities: startup.config.providers.grok }
-        : {}),
-      sessionProvider: resolvedProvider,
-      ...(selectedBaseURL !== undefined
-        ? { sessionBaseURL: selectedBaseURL }
         : {}),
     },
   });

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -9,7 +9,6 @@ import type * as undici from "undici";
 import pMap from "p-map";
 import { resolveHomeContext } from "../config/home.js";
 import type { ProviderEnvironment } from "../llm/provider-options.js";
-import { normalizeProviderIdentity } from "../provider-identity.js";
 import {
   ROOT_AGENT_PATH,
   type AgentPath,
@@ -48,12 +47,19 @@ import { runAdmittedModelCall } from "../budget/admitted-model-call.js";
 import { AdmissionDeniedError } from "../budget/admission-client.js";
 import type { GrokCapabilityConfig } from "../config/schema.js";
 import {
-  hasXaiCredentials,
   isDirectXaiInferenceHost,
   isXaiLiveXSearchEnabled,
+  resolveXaiBearerToken,
   resolveXaiLiveWebSearchOptions,
   resolveXaiLiveXSearchOptions,
 } from "../llm/xai-capability-config.js";
+import {
+  BUILT_IN_PROVIDER_BASE_URLS,
+  BUILT_IN_PROVIDER_DEFAULT_MODELS,
+} from "../llm/registry/provider-info.js";
+import {
+  resolveProviderBaseURLEnvironment,
+} from "../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../tools/types.js";
 import { safeStringify } from "../tools/types.js";
 import { createFileReadTool } from "../tools/system/file-read.js";
@@ -112,8 +118,14 @@ import { isPreapprovedHost } from "./web-fetch-preapproved.js";
 import { createRequestUserInputTool } from "../elicitation/request-user-input.js";
 import { createRequestLedgerTransferTool } from "../elicitation/request-ledger-transfer.js";
 import { createLedgerWalletCliTools } from "../elicitation/ledger-wallet-cli.js";
-import { createImagineImageTool } from "../tools/system/imagine-image.js";
-import { createImagineVideoTool } from "../tools/system/imagine-video.js";
+import {
+  createImagineImageTool,
+  hasImagineImageBackend,
+} from "../tools/system/imagine-image.js";
+import {
+  createImagineVideoTool,
+  hasImagineVideoBackend,
+} from "../tools/system/imagine-video.js";
 import { getRuleByContentsForTool } from "../permissions/rules.js";
 import type {
   PermissionResult,
@@ -182,15 +194,14 @@ export interface ModelFacingToolOptions {
     readonly web_search_endpoint_kind?: string;
     readonly [k: string]: unknown;
   };
-  /** `[providers.grok]` capability profile for Grok-native LIVE tools. */
+  /** `[providers.grok]` capability profile for the independent xAI tool backend. */
   readonly grokCapabilities?: GrokCapabilityConfig;
   /**
-   * Session provider slug at registry build time (e.g. `grok`, `openai`).
-   * Used for Hermes-style *catalog* gating: xAI-only LIVE tools must not be
-   * advertised to non-Grok models (execute-time refuse is defense-in-depth).
+   * Session provider slug retained for embedding compatibility. Tool
+   * availability must not be gated by the provider that performs reasoning.
    */
   readonly sessionProvider?: string;
-  /** Session inference base URL — OpenRouter/custom hosts are not "direct xAI". */
+  /** Session inference base URL retained for embedding compatibility. */
   readonly sessionBaseURL?: string;
 }
 
@@ -201,23 +212,6 @@ function requireModelFacingRequestEnvironment(
     throw new Error("model-facing tools require a captured request environment");
   }
   return opts.env;
-}
-
-/**
- * Hermes-style availability: only advertise xAI-native LIVE tools when the
- * session is actually Grok on a first-party xAI host. Mirrors Hermes
- * `is_available()` + `is_xai_responses` scoping (do not register for Claude/GPT).
- */
-export function isGrokDirectXaiSession(opts: {
-  readonly sessionProvider?: string;
-  readonly sessionBaseURL?: string;
-}): boolean {
-  const provider = normalizeProviderIdentity(
-    opts.sessionProvider,
-    "model-facing tool provider",
-  );
-  if (provider !== "grok") return false;
-  return isDirectXaiInferenceHost(opts.sessionBaseURL);
 }
 
 interface WebSearchFilters {
@@ -929,6 +923,74 @@ function currentSessionProvider(
     ?.provider;
 }
 
+interface XaiToolBackend {
+  readonly apiKey: string;
+  readonly baseURL: string;
+  readonly model: string;
+  readonly credentialHome: ReturnType<typeof resolveSecureStorageHome>;
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Resolve the xAI service used by xAI-backed client tools independently from
+ * the model that is running the main turn. A Meta/OpenAI/Anthropic session may
+ * call XSearch or Imagine without its own credential ever crossing into xAI.
+ */
+function resolveXaiToolBackend(
+  opts: ModelFacingToolOptions,
+): XaiToolBackend | undefined {
+  const environment = requireModelFacingRequestEnvironment(opts);
+  const credentialHome = resolveSecureStorageHome(
+    environment,
+    opts.agencHome,
+  );
+  const currentProvider = currentSessionProvider(opts);
+  const currentIsGrok = readProviderIdentity(currentProvider) === "grok";
+  const currentFactory = currentIsGrok && currentProvider
+    ? readProviderFactoryOptions(currentProvider)
+    : undefined;
+  const currentIsDirect =
+    currentFactory !== undefined &&
+    isDirectXaiInferenceHost(currentFactory.baseURL);
+  const sessionApiKey =
+    currentIsDirect && typeof currentFactory?.apiKey === "string"
+      ? currentFactory.apiKey
+      : undefined;
+  const apiKey = resolveXaiBearerToken(
+    credentialHome,
+    environment,
+    sessionApiKey,
+  );
+  if (apiKey === undefined) return undefined;
+
+  const configuredBaseURL = resolveProviderBaseURLEnvironment(
+    "grok",
+    environment,
+  )?.value;
+  const baseURL = currentIsDirect
+    ? (currentFactory?.baseURL ?? BUILT_IN_PROVIDER_BASE_URLS.grok)
+    : (configuredBaseURL ?? BUILT_IN_PROVIDER_BASE_URLS.grok);
+  if (!isDirectXaiInferenceHost(baseURL)) return undefined;
+
+  const currentModel = currentIsDirect ? currentFactory?.model : undefined;
+  const model = supportsProviderNativeXSearch({
+    provider: "grok",
+    model: currentModel,
+    xSearch: true,
+  })
+    ? currentModel!
+    : BUILT_IN_PROVIDER_DEFAULT_MODELS.grok;
+  return {
+    apiKey,
+    baseURL,
+    model,
+    credentialHome,
+    ...(currentFactory?.timeoutMs !== undefined
+      ? { timeoutMs: currentFactory.timeoutMs }
+      : {}),
+  };
+}
+
 async function runAdmittedModelFacingCall(
   opts: ModelFacingToolOptions,
   provider: LLMProvider,
@@ -1138,7 +1200,7 @@ function xSearchOptionsFromArgs(
   };
 }
 
-function isXSearchEnabledForSession(opts: ModelFacingToolOptions): boolean {
+function isXSearchBackendEnabled(opts: ModelFacingToolOptions): boolean {
   if (
     isXaiLiveXSearchEnabled(opts.grokCapabilities)
   ) {
@@ -1154,18 +1216,14 @@ function buildGrokNativeXSearchProvider(
   opts: ModelFacingToolOptions,
   xSearchOptions: LLMXSearchConfig | undefined,
 ): LLMProvider | undefined {
-  const currentProvider = currentSessionProvider(opts);
-  if (readProviderIdentity(currentProvider) !== "grok" || !currentProvider) {
+  const backend = resolveXaiToolBackend(opts);
+  if (backend === undefined || !isXSearchBackendEnabled(opts)) {
     return undefined;
   }
-  if (!isXSearchEnabledForSession(opts)) {
-    return undefined;
-  }
-  const factoryOptions = readProviderFactoryOptions(currentProvider);
   if (
     !supportsProviderNativeXSearch({
       provider: "grok",
-      model: factoryOptions.model,
+      model: backend.model,
       xSearch: true,
     })
   ) {
@@ -1187,7 +1245,6 @@ function buildGrokNativeXSearchProvider(
     };
   })();
   const extra: ProviderFactoryOptions["extra"] = {
-    ...(factoryOptions.extra ?? {}),
     // One-shot only: native x_search, no dual continuous web search spam.
     webSearch: false,
     xSearch: true,
@@ -1198,10 +1255,14 @@ function buildGrokNativeXSearchProvider(
   const providerFactory = opts.providerFactory ?? createProvider;
   try {
     return providerFactory("grok", {
-      ...factoryOptions,
+      credentialHome: backend.credentialHome,
+      apiKey: backend.apiKey,
+      baseURL: backend.baseURL,
+      model: backend.model,
       tools: [],
-      // Preserve only an operator-supplied timeout. Native x_search agentic
-      // loops are otherwise unbounded like every other model call.
+      ...(backend.timeoutMs !== undefined
+        ? { timeoutMs: backend.timeoutMs }
+        : {}),
       extra,
     });
   } catch {
@@ -1244,17 +1305,16 @@ async function runGrokNativeXSearch(
   args: Record<string, unknown>,
   query: string,
 ): Promise<ToolResult> {
-  const currentProvider = currentSessionProvider(opts);
-  if (readProviderIdentity(currentProvider) !== "grok") {
+  if (resolveXaiToolBackend(opts) === undefined) {
     return json(
       {
         error:
-          "XSearch is only available when the session provider is grok (direct xAI).",
+          "XSearch needs an independent xAI backend: run /grok-login or configure XAI_API_KEY / GROK_API_KEY.",
       },
       true,
     );
   }
-  if (!isXSearchEnabledForSession(opts)) {
+  if (!isXSearchBackendEnabled(opts)) {
     return json(
       {
         error:
@@ -1269,7 +1329,7 @@ async function runGrokNativeXSearch(
     return json(
       {
         error:
-          "XSearch native path unavailable for this Grok model (server tools require Grok 4 family on api.x.ai).",
+          "XSearch backend is unavailable (native x_search requires a compatible Grok 4 model on api.x.ai).",
       },
       true,
     );
@@ -3791,7 +3851,7 @@ function createWebTools(opts: ModelFacingToolOptions): readonly Tool[] {
     {
       name: "XSearch",
       description:
-        "Search X (Twitter) via xAI native x_search when the session uses Grok on api.x.ai and [providers.grok] x_search is enabled. Read-only research with x.com citations.",
+        "Search X (Twitter) through an independently configured xAI backend. Any reasoning provider may call this read-only tool; it returns findings with x.com citations.",
       metadata: toolMetadata("web", {
         keywords: ["x", "twitter", "search", "social", "posts"],
       }),
@@ -3826,11 +3886,11 @@ function createWebTools(opts: ModelFacingToolOptions): readonly Tool[] {
     },
   ];
 
-  // Catalog gate (Hermes is_available): only register XSearch when session is
-  // Grok+direct-xAI AND [providers.grok].x_search is enabled. Non-Grok models must
-  // never see this tool in the schema list.
+  // Tool availability follows its backend, never the provider running the
+  // main turn. The internal one-shot still uses a Grok provider because
+  // native x_search is an xAI wire capability.
   const includeXSearch =
-    isGrokDirectXaiSession(opts) &&
+    resolveXaiToolBackend(opts) !== undefined &&
     isXaiLiveXSearchEnabled(opts.grokCapabilities);
   if (!includeXSearch) {
     return tools.filter((t) => t.name !== "XSearch");
@@ -4935,38 +4995,35 @@ export function createModelFacingTools(
     ...opts,
     env: Object.freeze({ ...(opts.env ?? process.env) }),
   });
-  // Hermes-style catalog gates: xAI-only LIVE tools are omitted unless the
-  // session is Grok on a direct xAI host (and credentials/config allow).
-  // Credentials = BYOK **or** /grok-login OAuth (subscription Grok Build).
-  // Execute-time refuses remain as defense-in-depth.
-  const grokDirect = isGrokDirectXaiSession(scopedOpts);
+  // Media tools follow independently configured execution backends, not the
+  // provider running the reasoning turn. Credentials = provider BYOK or, for
+  // xAI, /grok-login OAuth (subscription Grok Build).
   const credentialHome = resolveSecureStorageHome(
     scopedOpts.env!,
     scopedOpts.agencHome,
   );
-  // Image + video Imagine surface (same credential probe as Hermes).
-  const includeImagineMedia =
-    grokDirect && hasXaiCredentials(credentialHome, scopedOpts.env);
+  const imagineOptions = {
+    workspaceRoot: scopedOpts.workspaceRoot,
+    home: credentialHome,
+    getSession: scopedOpts.getSession,
+    env: scopedOpts.env!,
+  } as const;
+  const includeImagineImage = hasImagineImageBackend(imagineOptions);
+  const includeImagineVideo = hasImagineVideoBackend(imagineOptions);
 
   return [
     ...createMultiAgentV2RuntimeTools(scopedOpts),
     ...createMcpResourceTools(scopedOpts),
     createSkillInvocationRuntimeTool(scopedOpts),
     ...createWebTools(scopedOpts),
-    ...(includeImagineMedia
+    ...(includeImagineImage
       ? [
-          createImagineImageTool({
-            workspaceRoot: scopedOpts.workspaceRoot,
-            home: credentialHome,
-            getSession: scopedOpts.getSession,
-            env: scopedOpts.env!,
-          }),
-          createImagineVideoTool({
-            workspaceRoot: scopedOpts.workspaceRoot,
-            home: credentialHome,
-            getSession: scopedOpts.getSession,
-            env: scopedOpts.env!,
-          }),
+          createImagineImageTool(imagineOptions),
+        ]
+      : []),
+    ...(includeImagineVideo
+      ? [
+          createImagineVideoTool(imagineOptions),
         ]
       : []),
     createNotebookReadTool(scopedOpts),

--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -595,9 +595,9 @@ export interface BuildToolRegistryOptions {
    * LIVE tools (XSearch) so Pattern A one-shots can gate on config.
    */
   readonly grokCapabilities?: import("./config/schema.js").GrokCapabilityConfig;
-  /** Session provider slug for catalog-gating xAI-only LIVE tools. */
+  /** @deprecated Tool availability is independent of the reasoning provider. */
   readonly sessionProvider?: string;
-  /** Session inference base URL for direct-xAI host checks. */
+  /** @deprecated Tool backends resolve their own endpoint authority. */
   readonly sessionBaseURL?: string;
   /**
    * Runtime integration seam: extra tools to register beyond the default

--- a/runtime/src/tools/system/imagine-image.ts
+++ b/runtime/src/tools/system/imagine-image.ts
@@ -1,10 +1,10 @@
 /**
- * G3: LIVE Imagine image generation tool (xAI REST /v1/images/generations).
+ * LIVE image generation tool with provider-independent media backends.
  *
- * Gate stack (fail-closed):
- * 1. Session provider === "grok"
- * 2. Direct xAI host (not OpenRouter)
- * 3. /grok-login OAuth (wins) or BYOK aliases
+ * Backend routing (fail-closed and credential-isolated):
+ * 1. Meta reasoning sessions prefer Meta Muse Image + MODEL_API_KEY.
+ * 2. Any reasoning provider may use independent xAI credentials.
+ * 3. Direct Grok sessions retain their session bearer/base URL compatibility.
  *
  * @module
  */
@@ -14,7 +14,6 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
 import {
-  createProvider,
   readProviderFactoryOptions,
   readProviderIdentity,
 } from "../../llm/provider.js";
@@ -22,6 +21,10 @@ import {
   isDirectXaiInferenceHost,
   resolveXaiBearerToken,
 } from "../../llm/xai-capability-config.js";
+import {
+  resolveProviderApiKeyEnvironment,
+  resolveProviderBaseURLEnvironment,
+} from "../../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import type { HomeContext } from "../../config/home.js";
@@ -73,11 +76,145 @@ const ALLOWED_ASPECT = new Set([
   "auto",
 ]);
 
+const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
+const DEFAULT_META_BASE_URL = "https://api.meta.ai/v1";
+
+type ImageBackend =
+  | {
+      readonly kind: "meta";
+      readonly baseURL: string;
+      readonly bearer: string;
+    }
+  | {
+      readonly kind: "xai";
+      readonly baseURL: string;
+      readonly bearer: string;
+    };
+
+type BackendResolution =
+  | { readonly backend: ImageBackend }
+  | { readonly error: string };
+
+function withoutTrailingSlash(value: string): string {
+  return value.replace(/\/$/, "");
+}
+
+/**
+ * Media credentials are intentionally independent from the reasoning
+ * provider. A Meta/OpenAI/etc session key must never become an xAI bearer.
+ * Direct Grok sessions retain their existing session-bearer compatibility.
+ */
+function resolveImageBackend(opts: ImagineImageToolOptions): BackendResolution {
+  const env = opts.env ?? process.env;
+  const provider = opts.getSession()?.services?.provider;
+  const providerIdentity = readProviderIdentity(provider as never);
+  const metaCredential = resolveProviderApiKeyEnvironment("meta", env);
+  const metaBackend = (): ImageBackend | undefined => {
+    if (metaCredential === undefined) return undefined;
+    const metaBaseURL =
+      resolveProviderBaseURLEnvironment("meta", env)?.value ??
+      DEFAULT_META_BASE_URL;
+    return {
+      kind: "meta",
+      baseURL: withoutTrailingSlash(metaBaseURL),
+      bearer: metaCredential.value,
+    };
+  };
+
+  // A Meta reasoning session prefers Meta's native image API, but only the
+  // canonical MODEL_API_KEY ingress may authorize it. Never borrow a factory
+  // key or an xAI alias for this request.
+  if (providerIdentity === "meta") {
+    const backend = metaBackend();
+    if (backend !== undefined) return { backend };
+  }
+
+  if (providerIdentity === "grok" && provider !== undefined) {
+    const factory = readProviderFactoryOptions(provider as never);
+    if (isDirectXaiInferenceHost(factory.baseURL)) {
+      const sessionKey =
+        typeof factory.apiKey === "string" ? factory.apiKey : undefined;
+      const bearer = resolveXaiBearerToken(opts.home, env, sessionKey);
+      if (bearer !== undefined) {
+        return {
+          backend: {
+            kind: "xai",
+            baseURL: withoutTrailingSlash(
+              factory.baseURL ?? DEFAULT_XAI_BASE_URL,
+            ),
+            bearer,
+          },
+        };
+      }
+    }
+  }
+
+  // A non-direct Grok session follows this path too: use only independent
+  // xAI authority, never the gateway's session key or base URL.
+  const xaiBearer = resolveXaiBearerToken(opts.home, env);
+  if (xaiBearer !== undefined) {
+    const xaiBaseURL =
+      resolveProviderBaseURLEnvironment("grok", env)?.value ??
+      DEFAULT_XAI_BASE_URL;
+    if (!isDirectXaiInferenceHost(xaiBaseURL)) {
+      const fallbackMetaBackend = metaBackend();
+      if (fallbackMetaBackend !== undefined) {
+        return { backend: fallbackMetaBackend };
+      }
+      return {
+        error:
+          "ImagineImage's independent xAI backend must use a direct xAI host (api.x.ai).",
+      };
+    }
+    return {
+      backend: {
+        kind: "xai",
+        baseURL: withoutTrailingSlash(xaiBaseURL),
+        bearer: xaiBearer,
+      },
+    };
+  }
+
+  // MODEL_API_KEY is a complete, isolated Meta media backend even when a
+  // different model provider performs the reasoning turn.
+  const fallbackMetaBackend = metaBackend();
+  if (fallbackMetaBackend !== undefined) {
+    return { backend: fallbackMetaBackend };
+  }
+
+  return {
+    error:
+      "ImagineImage needs a media backend credential: MODEL_API_KEY for Meta Muse Image, or /grok-login, XAI_API_KEY, or GROK_API_KEY for xAI Imagine.",
+  };
+}
+
+/** Whether this request has at least one usable, isolated image backend. */
+export function hasImagineImageBackend(
+  opts: ImagineImageToolOptions,
+): boolean {
+  return "backend" in resolveImageBackend(opts);
+}
+
+function metaImageSize(aspectRatio: string | undefined): string {
+  if (
+    aspectRatio === undefined ||
+    aspectRatio === "auto" ||
+    aspectRatio === "1:1"
+  ) {
+    return "1024x1024";
+  }
+  const [width, height] = aspectRatio.split(":").map(Number);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width === height) {
+    return "1024x1024";
+  }
+  return width > height ? "1536x1024" : "1024x1536";
+}
+
 export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
   return {
     name: "ImagineImage",
     description:
-      "Generate an image with xAI Grok Imagine (POST /v1/images/generations). Only available when the session provider is grok on api.x.ai with either XAI_API_KEY/aliases or /grok-login subscription OAuth. Saves the image under the workspace and returns the path.",
+      "Generate an image with the configured media backend and save it under the workspace. Meta reasoning sessions prefer Muse Image when MODEL_API_KEY is configured; any reasoning provider may use an independent xAI Imagine backend configured with /grok-login, XAI_API_KEY, or GROK_API_KEY.",
     isReadOnly: false,
     requiresApproval: true,
     concurrencyClass: { kind: "exclusive" },
@@ -98,7 +235,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         model: {
           type: "string",
           description:
-            "grok-imagine-image (default) or grok-imagine-image-quality",
+            "Backend-specific model: muse-image-1.0 for Meta, or grok-imagine-image / grok-imagine-image-quality for xAI. Omit to use the selected backend default.",
         },
         n: { type: "number", description: "1–10 images (default 1)" },
         aspect_ratio: { type: "string" },
@@ -110,61 +247,30 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
     execute: async (args) => {
       const admittedSignal = abortSignalFromArgs(args);
       admittedSignal?.throwIfAborted();
-      const session = opts.getSession();
-      const provider = session?.services?.provider;
-      if (readProviderIdentity(provider as never) !== "grok") {
-        return json(
-          {
-            error:
-              "ImagineImage is only available when the session provider is grok.",
-          },
-          true,
-        );
+      const backendResolution = resolveImageBackend(opts);
+      if ("error" in backendResolution) {
+        return json({ error: backendResolution.error }, true);
       }
-
-      const factory = readProviderFactoryOptions(provider as never);
-      if (!isDirectXaiInferenceHost(factory.baseURL)) {
-        return json(
-          {
-            error:
-              "ImagineImage requires a direct xAI host (api.x.ai). OpenRouter and custom gateways are not supported for Imagine REST.",
-          },
-          true,
-        );
-      }
-
-      // Hermes-style: BYOK env wins, else /grok-login OAuth, else session bearer.
-      // Subscription Grok Build users authenticate via OAuth — do not require
-      // a metered XAI_API_KEY for Imagine.
-      const sessionKey =
-        typeof factory.apiKey === "string" ? factory.apiKey : undefined;
-      const bearer = resolveXaiBearerToken(
-        opts.home,
-        opts.env ?? process.env,
-        sessionKey,
-      );
-      if (!bearer) {
-        return json(
-          {
-            error:
-              "ImagineImage needs xAI credentials: set XAI_API_KEY (or GROK_API_KEY), or run /grok-login for subscription access.",
-          },
-          true,
-        );
-      }
+      const { backend } = backendResolution;
 
       const prompt = stringValue(args.prompt);
       if (!prompt) return json({ error: "prompt is required" }, true);
 
-      const model = stringValue(args.model) ?? "grok-imagine-image";
-      if (
+      const model =
+        stringValue(args.model) ??
+        (backend.kind === "meta" ? "muse-image-1.0" : "grok-imagine-image");
+      if (backend.kind === "meta") {
+        if (model !== "muse-image-1.0") {
+          return json({ error: "Meta image model must be muse-image-1.0" }, true);
+        }
+      } else if (
         model !== "grok-imagine-image" &&
         model !== "grok-imagine-image-quality"
       ) {
         return json(
           {
             error:
-              "model must be grok-imagine-image or grok-imagine-image-quality",
+              "xAI image model must be grok-imagine-image or grok-imagine-image-quality",
           },
           true,
         );
@@ -188,29 +294,25 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         return json({ error: "resolution must be 1k or 2k" }, true);
       }
 
-      const body: Record<string, unknown> = {
-        model,
-        prompt,
-        n,
-        response_format: "b64_json",
-      };
-      if (aspect_ratio !== undefined) body.aspect_ratio = aspect_ratio;
-      if (resolution !== undefined) body.resolution = resolution;
+      const body: Record<string, unknown> =
+        backend.kind === "meta"
+          ? { model, prompt, size: metaImageSize(aspect_ratio), n }
+          : { model, prompt, n, response_format: "b64_json" };
+      if (backend.kind === "xai") {
+        if (aspect_ratio !== undefined) body.aspect_ratio = aspect_ratio;
+        if (resolution !== undefined) body.resolution = resolution;
+      }
 
-      const baseURL = (factory.baseURL ?? "https://api.x.ai/v1").replace(
-        /\/$/,
-        "",
-      );
       const fetchImpl = opts.fetchImpl ?? fetch;
       const timeoutSignal = AbortSignal.timeout(120_000);
       const requestSignal = admittedSignal
         ? AbortSignal.any([admittedSignal, timeoutSignal])
         : timeoutSignal;
       try {
-        const res = await fetchImpl(`${baseURL}/images/generations`, {
+        const res = await fetchImpl(`${backend.baseURL}/images/generations`, {
           method: "POST",
           headers: {
-            authorization: `Bearer ${bearer}`,
+            authorization: `Bearer ${backend.bearer}`,
             "content-type": "application/json",
           },
           body: JSON.stringify(body),
@@ -223,7 +325,9 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         if (!res.ok) {
           return json(
             {
-              error: payload.error?.message ?? `Imagine HTTP ${res.status}`,
+              error:
+                payload.error?.message ??
+                `${backend.kind === "meta" ? "Muse Image" : "Imagine"} HTTP ${res.status}`,
             },
             true,
           );
@@ -237,7 +341,10 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         await mkdir(outDir, { recursive: true });
         const paths: string[] = [];
         for (const image of images) {
-          const filename = `imagine-${randomUUID()}.jpg`;
+          // Muse Image returns WebP. Keep the extension honest so Electron's
+          // agenc-media protocol derives a renderable content type.
+          const extension = backend.kind === "meta" ? "webp" : "jpg";
+          const filename = `imagine-${randomUUID()}.${extension}`;
           const path = join(outDir, filename);
           if (image.b64_json) {
             await writeFile(path, Buffer.from(image.b64_json, "base64"), {
@@ -249,6 +356,14 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
             const imgRes = await fetchImpl(image.url, {
               signal: requestSignal,
             });
+            if (!imgRes.ok) {
+              return json(
+                {
+                  error: `Image download HTTP ${imgRes.status}`,
+                },
+                true,
+              );
+            }
             const buf = Buffer.from(await imgRes.arrayBuffer());
             await writeFile(path, buf, { signal: requestSignal });
             paths.push(path);
@@ -261,6 +376,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
           );
         }
         return json({
+          backend: backend.kind,
           model,
           paths,
           path: paths[0],
@@ -279,6 +395,3 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
     },
   };
 }
-
-// Silence unused import if tree-shaken in some builds — createProvider used only for types.
-void createProvider;

--- a/runtime/src/tools/system/imagine-video.ts
+++ b/runtime/src/tools/system/imagine-video.ts
@@ -1,5 +1,5 @@
 /**
- * LIVE Imagine **video** generation (xAI REST).
+ * LIVE Imagine **video** generation through an independent xAI backend.
  *
  * Text-to-video and image-to-video via:
  *   POST /v1/videos/generations  → request_id
@@ -8,10 +8,9 @@
  * Auth (same as Hermes video_gen/xai): `/grok-login` OAuth **wins** over
  * BYOK; subscription SuperGrok / Grok Build users can generate video.
  *
- * Gate stack (fail-closed):
- * 1. Session provider === "grok"
- * 2. Direct xAI host (not OpenRouter)
- * 3. OAuth or BYOK credentials
+ * Any reasoning provider may invoke this tool with independent xAI OAuth or
+ * BYOK credentials. A direct Grok session additionally retains compatibility
+ * with its own session bearer and base URL.
  *
  * @module
  */
@@ -29,6 +28,7 @@ import {
   isDirectXaiInferenceHost,
   resolveXaiBearerToken,
 } from "../../llm/xai-capability-config.js";
+import { resolveProviderBaseURLEnvironment } from "../../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import type { HomeContext } from "../../config/home.js";
@@ -73,6 +73,82 @@ const VALID_RESOLUTIONS = new Set(["480p", "720p"]);
 const TEXT_TO_VIDEO_MODEL = "grok-imagine-video";
 const IMAGE_TO_VIDEO_MODEL = "grok-imagine-video-1.5-preview";
 const MAX_REFERENCE_IMAGES = 7;
+const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
+
+type XaiBackendResolution =
+  | {
+      readonly backend: {
+        readonly baseURL: string;
+        readonly bearer: string;
+      };
+    }
+  | { readonly error: string };
+
+/**
+ * Resolve xAI as a media backend, independently from the reasoning provider.
+ * Only a direct Grok session is allowed to contribute its factory bearer or
+ * URL; Meta/OpenAI/etc credentials must never cross the xAI trust boundary.
+ */
+function resolveXaiVideoBackend(
+  opts: ImagineVideoToolOptions,
+): XaiBackendResolution {
+  const env = opts.env ?? process.env;
+  const provider = opts.getSession()?.services?.provider;
+  const providerIdentity = readProviderIdentity(provider as never);
+
+  if (providerIdentity === "grok" && provider !== undefined) {
+    const factory = readProviderFactoryOptions(provider as never);
+    if (isDirectXaiInferenceHost(factory.baseURL)) {
+      const sessionKey =
+        typeof factory.apiKey === "string" ? factory.apiKey : undefined;
+      const bearer = resolveXaiBearerToken(opts.home, env, sessionKey);
+      if (bearer !== undefined) {
+        return {
+          backend: {
+            baseURL: (factory.baseURL ?? DEFAULT_XAI_BASE_URL).replace(
+              /\/$/,
+              "",
+            ),
+            bearer,
+          },
+        };
+      }
+    }
+  }
+
+  // Never pass a non-Grok session key/base URL. A non-direct Grok session
+  // also lands here and must supply independent xAI authority.
+  const bearer = resolveXaiBearerToken(opts.home, env);
+  if (bearer !== undefined) {
+    const baseURL =
+      resolveProviderBaseURLEnvironment("grok", env)?.value ??
+      DEFAULT_XAI_BASE_URL;
+    if (!isDirectXaiInferenceHost(baseURL)) {
+      return {
+        error:
+          "ImagineVideo's independent xAI backend must use a direct xAI host (api.x.ai).",
+      };
+    }
+    return {
+      backend: {
+        baseURL: baseURL.replace(/\/$/, ""),
+        bearer,
+      },
+    };
+  }
+
+  return {
+    error:
+      "ImagineVideo needs an independent xAI media credential via /grok-login, XAI_API_KEY, or GROK_API_KEY.",
+  };
+}
+
+/** Whether this request has a usable, credential-isolated xAI video backend. */
+export function hasImagineVideoBackend(
+  opts: ImagineVideoToolOptions,
+): boolean {
+  return "backend" in resolveXaiVideoBackend(opts);
+}
 
 async function imageRefToUrl(
   value: string,
@@ -132,9 +208,9 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
   return {
     name: "ImagineVideo",
     description:
-      "Generate a video with xAI Grok Imagine (text-to-video or image-to-video). " +
-      "Uses POST /v1/videos/generations + poll. Available when session provider is grok " +
-      "on api.x.ai with /grok-login OAuth (preferred) or XAI_API_KEY. Saves the MP4 under the workspace.",
+      "Generate a video with an independently configured xAI Grok Imagine media backend (text-to-video or image-to-video). " +
+      "Any reasoning provider may invoke it when /grok-login, XAI_API_KEY, or GROK_API_KEY is available. " +
+      "Direct Grok sessions may also use their session bearer. Saves the MP4 under the workspace.",
     isReadOnly: false,
     requiresApproval: true,
     concurrencyClass: { kind: "exclusive" },
@@ -182,45 +258,11 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
     execute: async (args) => {
       const admittedSignal = abortSignalFromArgs(args);
       admittedSignal?.throwIfAborted();
-      const session = opts.getSession();
-      const provider = session?.services?.provider;
-      if (readProviderIdentity(provider as never) !== "grok") {
-        return json(
-          {
-            error:
-              "ImagineVideo is only available when the session provider is grok.",
-          },
-          true,
-        );
+      const backendResolution = resolveXaiVideoBackend(opts);
+      if ("error" in backendResolution) {
+        return json({ error: backendResolution.error }, true);
       }
-
-      const factory = readProviderFactoryOptions(provider as never);
-      if (!isDirectXaiInferenceHost(factory.baseURL)) {
-        return json(
-          {
-            error:
-              "ImagineVideo requires a direct xAI host (api.x.ai). OpenRouter is not supported for Imagine video REST.",
-          },
-          true,
-        );
-      }
-
-      const sessionKey =
-        typeof factory.apiKey === "string" ? factory.apiKey : undefined;
-      const bearer = resolveXaiBearerToken(
-        opts.home,
-        opts.env ?? process.env,
-        sessionKey,
-      );
-      if (!bearer) {
-        return json(
-          {
-            error:
-              "ImagineVideo needs xAI credentials: /grok-login (subscription) or XAI_API_KEY / GROK_API_KEY.",
-          },
-          true,
-        );
-      }
+      const { backend } = backendResolution;
 
       const prompt = stringValue(args.prompt);
       if (!prompt) return json({ error: "prompt is required" }, true);
@@ -291,18 +333,14 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
         body.reference_images = reference_images;
       }
 
-      const baseURL = (factory.baseURL ?? "https://api.x.ai/v1").replace(
-        /\/$/,
-        "",
-      );
       const fetchImpl = opts.fetchImpl ?? fetch;
       const headers = {
-        authorization: `Bearer ${bearer}`,
+        authorization: `Bearer ${backend.bearer}`,
         "content-type": "application/json",
       };
 
       try {
-        const submitRes = await fetchImpl(`${baseURL}/videos/generations`, {
+        const submitRes = await fetchImpl(`${backend.baseURL}/videos/generations`, {
           method: "POST",
           headers: {
             ...headers,
@@ -342,7 +380,7 @@ export function createImagineVideoTool(opts: ImagineVideoToolOptions): Tool {
         let doneBody: Record<string, unknown> | undefined;
 
         while (elapsed < pollTimeout) {
-          const pollRes = await fetchImpl(`${baseURL}/videos/${requestId}`, {
+          const pollRes = await fetchImpl(`${backend.baseURL}/videos/${requestId}`, {
             method: "GET",
             headers,
             ...(admittedSignal !== undefined

--- a/runtime/tests/bin/xsearch-tool.test.ts
+++ b/runtime/tests/bin/xsearch-tool.test.ts
@@ -51,51 +51,54 @@ describe("supportsProviderNativeXSearch", () => {
   });
 });
 
-describe("LIVE XSearch tool catalog gate (Hermes-style)", () => {
-  it("is NOT registered for non-Grok sessions (openai)", () => {
+describe("LIVE XSearch independent tool backend", () => {
+  it("is not registered without an xAI backend credential", () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),
       getSession: () => null,
-      sessionProvider: "openai",
+      sessionProvider: "meta",
+      env: {},
       grokCapabilities: { x_search: true },
     });
     expect(tools.some((t) => t.name === "XSearch")).toBe(false);
   });
 
-  it("is NOT registered for OpenRouter host even if provider slug is grok", () => {
+  it("is registered for Meta when an independent xAI backend is configured", () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),
       getSession: () => null,
-      sessionProvider: "grok",
-      sessionBaseURL: "https://openrouter.ai/api/v1",
-      grokCapabilities: { x_search: true },
-    });
-    expect(tools.some((t) => t.name === "XSearch")).toBe(false);
-  });
-
-  it("is NOT registered when x_search is disabled (default)", () => {
-    const tools = createModelFacingTools({
-      workspaceRoot: process.cwd(),
-      getSession: () => null,
-      sessionProvider: "grok",
-      sessionBaseURL: "https://api.x.ai/v1",
-      grokCapabilities: { x_search: false },
-    });
-    expect(tools.some((t) => t.name === "XSearch")).toBe(false);
-  });
-
-  it("is registered only for grok + direct xAI + x_search on", () => {
-    const tools = createModelFacingTools({
-      workspaceRoot: process.cwd(),
-      getSession: () => null,
-      sessionProvider: "grok",
-      sessionBaseURL: "https://api.x.ai/v1",
+      sessionProvider: "meta",
+      sessionBaseURL: "https://api.meta.ai/v1",
+      env: { XAI_API_KEY: "xai-tool-key", MODEL_API_KEY: "meta-turn-key" },
       grokCapabilities: { x_search: true },
     });
     expect(tools.some((t) => t.name === "XSearch")).toBe(true);
   });
 
-  it("one-shots native x_search when enabled (mocked provider factory)", async () => {
+  it("does not reuse the reasoning provider host for the xAI backend", () => {
+    const tools = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => null,
+      sessionProvider: "openrouter",
+      sessionBaseURL: "https://openrouter.ai/api/v1",
+      env: { XAI_API_KEY: "xai-tool-key" },
+      grokCapabilities: { x_search: true },
+    });
+    expect(tools.some((t) => t.name === "XSearch")).toBe(true);
+  });
+
+  it("is not registered when the xAI backend capability is disabled", () => {
+    const tools = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => null,
+      sessionProvider: "meta",
+      env: { XAI_API_KEY: "xai-tool-key" },
+      grokCapabilities: { x_search: false },
+    });
+    expect(tools.some((t) => t.name === "XSearch")).toBe(false);
+  });
+
+  it("lets Meta invoke x_search through a credential-isolated Grok backend", async () => {
     const chat = vi.fn(async () => ({
       content: "People are talking about xAI.[[1]](https://x.com/xai/status/1)",
       toolCalls: [],
@@ -112,11 +115,11 @@ describe("LIVE XSearch tool catalog gate (Hermes-style)", () => {
     }));
 
     const { createProvider } = await import("../../src/llm/provider.js");
-    const sessionProvider = createProvider("grok", {
-      apiKey: "test-key",
-      model: "grok-4.5",
+    const sessionProvider = createProvider("meta", {
+      apiKey: "meta-turn-key",
+      model: "muse-spark-1.3",
+      baseURL: "https://api.meta.ai/v1",
       tools: [],
-      extra: { xSearch: true },
     });
 
     const factory = vi.fn((...args: Parameters<typeof createProvider>) => {
@@ -132,8 +135,12 @@ describe("LIVE XSearch tool catalog gate (Hermes-style)", () => {
           nextInternalSubId: () => "xsearch-1",
           services: { admissionRequired: false, provider: sessionProvider },
         }) as unknown as Session,
-      sessionProvider: "grok",
-      sessionBaseURL: "https://api.x.ai/v1",
+      sessionProvider: "meta",
+      sessionBaseURL: "https://api.meta.ai/v1",
+      env: {
+        XAI_API_KEY: "xai-tool-key",
+        MODEL_API_KEY: "meta-turn-key",
+      },
       grokCapabilities: { x_search: true },
       providerFactory: factory as typeof createProvider,
     });
@@ -146,7 +153,15 @@ describe("LIVE XSearch tool catalog gate (Hermes-style)", () => {
     expect(result.content).toMatch(/grok_x_search/);
     expect(result.content).toMatch(/x\.com\/xai\/status\/1/);
     expect(factory).toHaveBeenCalled();
-    const factoryExtra = factory.mock.calls[0]?.[1]?.extra as
+    const factoryCall = factory.mock.calls[0];
+    expect(factoryCall?.[0]).toBe("grok");
+    expect(factoryCall?.[1]).toMatchObject({
+      apiKey: "xai-tool-key",
+      baseURL: "https://api.x.ai/v1",
+      model: "grok-4.6",
+    });
+    expect(factoryCall?.[1]?.apiKey).not.toBe("meta-turn-key");
+    const factoryExtra = factoryCall?.[1]?.extra as
       | { xSearch?: boolean; webSearch?: boolean }
       | undefined;
     expect(factoryExtra?.xSearch).toBe(true);

--- a/runtime/tests/live/grok-full-surface-e2e.live.test.ts
+++ b/runtime/tests/live/grok-full-surface-e2e.live.test.ts
@@ -107,6 +107,31 @@ function sessionWith(provider: unknown): Session {
   return { services: { provider } } as unknown as Session;
 }
 
+describe("provider-independent xAI tool catalog", () => {
+  it("exposes xAI backend tools independently of reasoning provider", async () => {
+    const openaiTools = createModelFacingTools({
+      workspaceRoot: OUT,
+      getSession: () => null,
+      sessionProvider: "openai",
+      env: { XAI_API_KEY: "independent-xai-backend" },
+      grokCapabilities: {
+        x_search: true,
+        web_search: true,
+      },
+    });
+    const openaiNames = openaiTools.map((t) => t.name);
+    expect(openaiNames).toContain("ImagineImage");
+    expect(openaiNames).toContain("ImagineVideo");
+    expect(openaiNames).toContain("XSearch");
+    // WebSearch remains generic.
+    expect(openaiNames).toContain("WebSearch");
+
+    await log(
+      `catalog openai=${openaiNames.filter((n) => n.startsWith("Imagine") || n === "XSearch").join(",")}`,
+    );
+  });
+});
+
 describe("LIVE full Grok surface e2e", () => {
   let bearer = "";
 
@@ -150,46 +175,6 @@ describe("LIVE full Grok surface e2e", () => {
     );
     expect(rest).toBe(bearer);
     await log("OAuth-wins-over-BYOK OK");
-  });
-
-  it("catalog: non-Grok has no Imagine/XSearch; Grok has full media + XSearch", async () => {
-    const openaiTools = createModelFacingTools({
-      workspaceRoot: OUT,
-      getSession: () => null,
-      sessionProvider: "openai",
-      env: { XAI_API_KEY: "should-not-matter" },
-      grokCapabilities: {
-        x_search: true,
-        web_search: true,
-      },
-    });
-    const openaiNames = openaiTools.map((t) => t.name);
-    expect(openaiNames).not.toContain("ImagineImage");
-    expect(openaiNames).not.toContain("ImagineVideo");
-    expect(openaiNames).not.toContain("XSearch");
-    // WebSearch remains generic
-    expect(openaiNames).toContain("WebSearch");
-
-    const grokTools = createModelFacingTools({
-      workspaceRoot: OUT,
-      getSession: () => null,
-      sessionProvider: "grok",
-      sessionBaseURL: "https://api.x.ai/v1",
-      // no env BYOK — OAuth credentials present via storage
-      env: {},
-      grokCapabilities: {
-        x_search: true,
-        web_search: true,
-      },
-    });
-    const grokNames = grokTools.map((t) => t.name);
-    expect(grokNames).toContain("ImagineImage");
-    expect(grokNames).toContain("ImagineVideo");
-    expect(grokNames).toContain("XSearch");
-    expect(grokNames).toContain("WebSearch");
-    await log(
-      `catalog openai=${openaiNames.filter((n) => n.startsWith("Imagine") || n === "XSearch").join(",") || "none"} grok media+XSearch present`,
-    );
   });
 
   it(

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -1,6 +1,4 @@
-/**
- * G3: ImagineImage LIVE tool gates + REST path (mocked fetch).
- */
+/** Provider-independent ImagineImage catalog and REST paths (mocked fetch). */
 import { describe, expect, it, vi } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -23,14 +21,25 @@ function testHome(workspaceRoot: string) {
 }
 
 describe("ImagineImage tool", () => {
-  it("is not catalog-registered for non-Grok (Claude/OpenAI) sessions", () => {
+  it("is catalog-registered for non-Grok sessions with an independent xAI credential", () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),
       getSession: () => null,
       sessionProvider: "openai",
       env: { XAI_API_KEY: "key" },
     });
-    expect(tools.some((t) => t.name === "ImagineImage")).toBe(false);
+    expect(tools.some((t) => t.name === "ImagineImage")).toBe(true);
+  });
+
+  it("is catalog-registered for Meta sessions with a native image credential", () => {
+    const tools = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => null,
+      sessionProvider: "meta",
+      sessionBaseURL: "https://api.meta.ai/v1",
+      env: { MODEL_API_KEY: "meta-key" },
+    });
+    expect(tools.some((t) => t.name === "ImagineImage")).toBe(true);
   });
 
   it("is catalog-registered for grok + direct xAI with BYOK or any credential probe", () => {
@@ -44,19 +53,217 @@ describe("ImagineImage tool", () => {
     expect(tools.some((t) => t.name === "ImagineImage")).toBe(true);
   });
 
-  it("refuses non-grok sessions at execute time (defense-in-depth)", async () => {
+  it("uses a direct Grok factory bearer when no environment key exists", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-factory-catalog-"));
+    const provider = createProvider("grok", {
+      apiKey: "factory-only-xai-key",
+      model: "grok-4.6",
+      baseURL: "https://api.x.ai/v1",
+    });
+    const tools = createModelFacingTools({
+      workspaceRoot: root,
+      agencHome: join(root, ".agenc-test-home"),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {},
+    });
+
+    expect(tools.some((t) => t.name === "ImagineImage")).toBe(true);
+  });
+
+  it("does not advertise an unusable non-direct xAI media backend", () => {
+    const tools = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => null,
+      env: {
+        XAI_API_KEY: "xai-key",
+        XAI_BASE_URL: "https://openrouter.ai/api/v1",
+      },
+    });
+
+    expect(tools.some((t) => t.name === "ImagineImage")).toBe(false);
+  });
+
+  it("uses independent xAI credentials for a Meta reasoning session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-meta-xai-"));
+    const provider = createProvider("meta", {
+      apiKey: "meta-session-key-must-not-leak",
+      model: "muse-spark-1.3",
+      baseURL: "https://api.meta.ai/v1",
+    });
+    const b64 = Buffer.from([0xff, 0xd8, 0xff, 0xd9]).toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: b64 }] }),
+    })) as unknown as typeof fetch;
+    const tool = createImagineImageTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: { XAI_API_KEY: "xai-media-key" },
+      fetchImpl,
+    });
+    const result = await tool.execute({ prompt: "a cat" });
+    expect(result.isError).toBeUndefined();
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] ?? [];
+    expect(String(url)).toBe("https://api.x.ai/v1/images/generations");
+    const authorization = (init as { headers: { authorization: string } })
+      .headers.authorization;
+    expect(authorization).toBe("Bearer xai-media-key");
+    expect(authorization).not.toContain("meta-session-key-must-not-leak");
+  });
+
+  it("prefers Meta Muse Image and saves its response for a Meta session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-meta-native-"));
+    const provider = createProvider("meta", {
+      apiKey: "meta-session-key-must-not-be-used",
+      model: "muse-spark-1.3",
+      baseURL: "https://session-meta.invalid/v1",
+    });
+    const b64 = Buffer.from("RIFF0000WEBP", "ascii").toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: b64 }] }),
+    })) as unknown as typeof fetch;
+    const tool = createImagineImageTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {
+        MODEL_API_KEY: "canonical-meta-image-key",
+        XAI_API_KEY: "unused-xai-key",
+      },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({
+      prompt: "portrait on a quiet street",
+      aspect_ratio: "9:16",
+      n: 1,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content) as {
+      backend: string;
+      model: string;
+      path: string;
+    };
+    expect(parsed.backend).toBe("meta");
+    expect(parsed.model).toBe("muse-image-1.0");
+    expect(parsed.path).toMatch(/\.webp$/u);
+    expect((await readFile(parsed.path)).length).toBeGreaterThan(0);
+
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] ?? [];
+    expect(String(url)).toBe("https://api.meta.ai/v1/images/generations");
+    expect(
+      (init as { headers: { authorization: string } }).headers.authorization,
+    ).toBe("Bearer canonical-meta-image-key");
+    const body = JSON.parse((init as { body: string }).body) as Record<
+      string,
+      unknown
+    >;
+    expect(body).toEqual({
+      model: "muse-image-1.0",
+      prompt: "portrait on a quiet street",
+      size: "1024x1536",
+      n: 1,
+    });
+  });
+
+  it("falls back to Meta when the configured xAI media host is unusable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-invalid-xai-meta-"));
+    const provider = createProvider("openai", {
+      apiKey: "openai-session-key-must-not-leak",
+      model: "gpt-5",
+    });
+    const b64 = Buffer.from("RIFF0000WEBP", "ascii").toString("base64");
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ b64_json: b64 }] }),
+    })) as unknown as typeof fetch;
+    const tool = createImagineImageTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {
+        XAI_API_KEY: "xai-key-for-invalid-host",
+        XAI_BASE_URL: "https://openrouter.ai/api/v1",
+        MODEL_API_KEY: "meta-media-key",
+      },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "safe backend fallback" });
+
+    expect(result.isError).toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = (
+      fetchImpl as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0] ?? [];
+    expect(url).toBe("https://api.meta.ai/v1/images/generations");
+    expect(
+      (init as { headers: { authorization: string } }).headers.authorization,
+    ).toBe("Bearer meta-media-key");
+  });
+
+  it("does not save an error response returned by an image URL", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-download-error-"));
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      if (String(url) === "https://cdn.example/generated.webp") {
+        return {
+          ok: false,
+          status: 502,
+          arrayBuffer: async () => new ArrayBuffer(0),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ url: "https://cdn.example/generated.webp" }],
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const tool = createImagineImageTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () => null,
+      env: { MODEL_API_KEY: "meta-media-key" },
+      fetchImpl,
+    });
+
+    const result = await tool.execute({ prompt: "download failure" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/Image download HTTP 502/u);
+  });
+
+  it("fails closed instead of using a non-Grok reasoning session key for xAI", async () => {
+    const provider = createProvider("openai", {
+      apiKey: "openai-session-key-must-not-leak",
+      model: "gpt-5",
+      baseURL: "https://api.openai.com/v1",
+    });
+    const fetchImpl = vi.fn();
     const tool = createImagineImageTool({
       workspaceRoot: process.cwd(),
       home: testHome(process.cwd()),
-      getSession: () =>
-        ({
-          services: { provider: { name: "openai" } },
-        }) as unknown as Session,
-      env: { XAI_API_KEY: "key" },
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {},
+      fetchImpl: fetchImpl as unknown as typeof fetch,
     });
-    const result = await tool.execute({ prompt: "a cat" });
+
+    const result = await tool.execute({ prompt: "must not run" });
+
     expect(result.isError).toBe(true);
-    expect(result.content).toMatch(/session provider is grok/i);
+    expect(result.content).toMatch(/media backend credential/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("accepts session OAuth bearer when BYOK env is unset (subscription path)", async () => {

--- a/runtime/tests/tools/system/imagine-video.test.ts
+++ b/runtime/tests/tools/system/imagine-video.test.ts
@@ -23,14 +23,14 @@ function testHome(workspaceRoot: string) {
 }
 
 describe("ImagineVideo catalog gate", () => {
-  it("is not registered for non-Grok sessions", () => {
+  it("is registered for non-Grok sessions with independent xAI credentials", () => {
     const tools = createModelFacingTools({
       workspaceRoot: process.cwd(),
       getSession: () => null,
       sessionProvider: "openai",
       env: { XAI_API_KEY: "key" },
     });
-    expect(tools.some((t) => t.name === "ImagineVideo")).toBe(false);
+    expect(tools.some((t) => t.name === "ImagineVideo")).toBe(true);
   });
 
   it("is registered for grok + direct xAI + credentials", () => {
@@ -41,6 +41,36 @@ describe("ImagineVideo catalog gate", () => {
       sessionBaseURL: "https://api.x.ai/v1",
       env: { XAI_API_KEY: "key" },
     });
+    expect(tools.some((t) => t.name === "ImagineVideo")).toBe(true);
+  });
+
+  it("is not registered when the configured xAI media host is not direct", () => {
+    const tools = createModelFacingTools({
+      workspaceRoot: process.cwd(),
+      getSession: () => null,
+      env: {
+        XAI_API_KEY: "xai-key",
+        XAI_BASE_URL: "https://openrouter.ai/api/v1",
+      },
+    });
+
+    expect(tools.some((t) => t.name === "ImagineVideo")).toBe(false);
+  });
+
+  it("is registered with a direct Grok factory bearer and no env key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-video-factory-catalog-"));
+    const provider = createProvider("grok", {
+      apiKey: "factory-only-xai-key",
+      model: "grok-4.6",
+      baseURL: "https://api.x.ai/v1",
+    });
+    const tools = createModelFacingTools({
+      workspaceRoot: root,
+      agencHome: join(root, ".agenc-test-home"),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {},
+    });
+
     expect(tools.some((t) => t.name === "ImagineVideo")).toBe(true);
   });
 });
@@ -190,18 +220,88 @@ describe("ImagineVideo execute", () => {
     await expect(running).rejects.toBe(reason);
   });
 
-  it("refuses non-grok sessions", async () => {
+  it("uses xAI media credentials, never the Meta reasoning credential", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-meta-vid-"));
+    const provider = createProvider("meta", {
+      apiKey: "meta-session-key-must-not-leak",
+      model: "muse-spark-1.3",
+      baseURL: "https://api.meta.ai/v1",
+    });
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const value = String(url);
+      if (value.endsWith("/videos/generations")) {
+        expect(
+          (init?.headers as { authorization: string }).authorization,
+        ).toBe("Bearer xai-media-key");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ request_id: "req-meta-xai" }),
+        };
+      }
+      if (value.endsWith("/videos/req-meta-xai")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: "done",
+            video: { url: "https://cdn.example/meta-xai.mp4" },
+          }),
+        };
+      }
+      if (value === "https://cdn.example/meta-xai.mp4") {
+        return {
+          ok: true,
+          status: 200,
+          arrayBuffer: async () =>
+            Uint8Array.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])
+              .buffer,
+        };
+      }
+      throw new Error(`unexpected fetch ${value}`);
+    }) as unknown as typeof fetch;
+    const tool = createImagineVideoTool({
+      workspaceRoot: root,
+      home: testHome(root),
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: {
+        MODEL_API_KEY: "canonical-meta-key-must-not-leak",
+        XAI_API_KEY: "xai-media-key",
+      },
+      fetchImpl,
+      pollIntervalMs: 1,
+      pollTimeoutMs: 5_000,
+    });
+
+    const result = await tool.execute({ prompt: "a short clip" });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content) as { path: string };
+    expect((await readFile(parsed.path)).length).toBeGreaterThan(0);
+    expect(
+      (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0],
+    ).toBe("https://api.x.ai/v1/videos/generations");
+  });
+
+  it("fails closed when a Meta session has no independent xAI credential", async () => {
+    const provider = createProvider("meta", {
+      apiKey: "meta-session-key-must-not-leak",
+      model: "muse-spark-1.3",
+      baseURL: "https://api.meta.ai/v1",
+    });
+    const fetchImpl = vi.fn();
     const tool = createImagineVideoTool({
       workspaceRoot: process.cwd(),
       home: testHome(process.cwd()),
-      getSession: () =>
-        ({
-          services: { provider: { name: "anthropic" } },
-        }) as unknown as Session,
-      env: { XAI_API_KEY: "k" },
+      getSession: () => ({ services: { provider } }) as unknown as Session,
+      env: { MODEL_API_KEY: "canonical-meta-key-must-not-leak" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
     });
-    const result = await tool.execute({ prompt: "x" });
+
+    const result = await tool.execute({ prompt: "must not run" });
+
     expect(result.isError).toBe(true);
-    expect(result.content).toMatch(/session provider is grok/i);
+    expect(result.content).toMatch(/independent xAI media credential/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- expose XSearch and Imagine tools based on their execution backend, not the reasoning provider
- isolate xAI credentials/base URLs from Meta and other session credentials
- add native Meta Muse Image (`muse-image-1.0`) generation with WebP output
- let any tool-capable provider invoke xAI-backed XSearch/video when an independent xAI backend is configured

## Safety
- Meta/session API keys are never forwarded to xAI
- xAI keys are never forwarded to Meta
- non-direct xAI hosts fail closed; image generation can fall back to a valid Meta backend

## Validation
- `npm --force run typecheck`
- `node scripts/run-hermetic-vitest.mjs run tests/bin/xsearch-tool.test.ts tests/tools/system/imagine-image.test.ts tests/tools/system/imagine-video.test.ts --reporter=dot` (27 passed)
- `npm --force run build`
