### PR TITLE
bind MCP content reads to a verified root descriptor

### DIFF
--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -475,9 +475,28 @@ admission, redaction, and audit path.
 Prompts and resources are scoped to the same canonical workspace: project
 `.agenc/skills`, `.agenc/memory`, and `AGENC.md`. User-global skills, memory,
 and instructions are never exposed by inbound serve.
-Every candidate is canonicalized, regular-file checked, and rejected if a
-symlink resolves outside the workspace. Resource listing remains metadata-only;
-the server revalidates and reads only the resource selected by `resources/read`.
+Containment is bound to an open directory descriptor, not to a pathname. Each
+skill root, memory directory, and instruction-file parent is opened once per
+request and retained; that handle is proven to sit inside the workspace, and
+every candidate below it is admitted, opened with `O_NOFOLLOW`, read, and
+re-proven against the same handle, with the whole ancestor chain checked for
+symlinks and escapes before and after the bytes are taken. Deciding containment
+by resolving a candidate's pathname a second time is not sound: `lstat` and
+`realpath` are independent resolutions, and a writable workspace can flip an
+ancestor between them so the two checks describe different files. Resource
+listing remains metadata-only; the server revalidates and reads only the
+resource selected by `resources/read`.
+
+An instruction file is served up to the same 5 MiB ceiling the runtime applies
+to the same file in-process, so an AGENC.md that the agent reads is not
+silently missing over MCP. Skills and memory files keep a 1 MiB ceiling.
+
+The descriptor proofs need a platform mechanism for reading back where an open
+descriptor points (`/proc/self/fd` on Linux; a descriptor-identity comparison
+on macOS and FreeBSD). Where the platform offers neither — **Windows** — inbound
+serve fails closed: `prompts/list` and `resources/list` are empty rather than
+falling back to plain pathname resolution. Memory resources were already empty
+there, because the memory scanner reports `unsupported` on win32.
 
 ## Security notes
 

--- a/runtime/src/fs/verified-read.ts
+++ b/runtime/src/fs/verified-read.ts
@@ -1,0 +1,493 @@
+/**
+ * Descriptor-bound filesystem primitives shared by every reader that must
+ * serve bytes from a *proven* location inside a root, not from a pathname it
+ * resolved twice.
+ *
+ * The problem these solve: `lstat(p)` and `realpath(p)` are two independent
+ * resolutions of the same name. An attacker with write access to the workspace
+ * can flip an ancestor directory between them, so the identity check lands on
+ * an out-of-scope inode while the containment check lands on an in-scope
+ * pathname. The two proofs then describe different files, and a reader that
+ * trusts both serves out-of-scope bytes under an in-scope path.
+ *
+ * The fix is to bind containment to an opened root descriptor:
+ *
+ *   1. `bindVerifiedRoot` opens the root directory with `O_NOFOLLOW`, proves
+ *      the opened object is the one the path named, and retains the handle.
+ *   2. `verifyParentChain` walks every parent segment from that handle's
+ *      descriptor path, rejects symlinked or non-directory ancestors, requires
+ *      each ancestor's canonical path to sit inside the root's canonical path,
+ *      and re-proves the root handle against the retained binding.
+ *   3. `openVerifiedCandidate` opens the final component with `O_NOFOLLOW`,
+ *      proves the opened object against the path stat, and proves the
+ *      descriptor still resolves inside the root.
+ *   4. `assertCandidateUnchanged` re-proves the object after the bytes are read.
+ *
+ * Platform story, and it is not uniform:
+ *
+ *   - linux: `/proc/self/fd/N` is a traversable, live view of an open
+ *     descriptor. Every path above is descriptor-relative and
+ *     `finalDescriptorPath` reads back the descriptor's true location, so
+ *     containment is a *proof*: an ancestor swap cannot make an out-of-scope
+ *     inode look contained.
+ *   - darwin / freebsd: `/dev/fd/N` is not traversable (`opendir` returns
+ *     ENOTDIR and children resolve to ENOENT), so the requested path is used
+ *     and `finalDescriptorPath` degrades to an identity comparison against the
+ *     expected path. Containment there is the retained root identity plus an
+ *     `O_NOFOLLOW`, non-symlink, identity-checked walk of every segment before
+ *     and after the read. That narrows an ancestor swap to a flip that must be
+ *     timed against both walks; it is not the closed proof linux gets. Node
+ *     exposes no root-confined open (`openat2`/`RESOLVE_BENEATH`), so this is
+ *     the strongest construction available on those platforms.
+ *   - everything else, Windows included: no descriptor-path mechanism at all.
+ *     These helpers throw `context.unsupportedPlatform(...)` rather than
+ *     silently falling back to plain pathname resolution. Callers decide
+ *     whether that is fatal or a documented loss of function; none of them may
+ *     answer it by reopening a validated pathname.
+ *
+ * @module
+ */
+import { constants, type BigIntStats } from "node:fs";
+import { lstat, open, realpath, type FileHandle } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import process from "node:process";
+
+/** Stat fields that together identify one filesystem object at one moment. */
+export interface FileIdentity {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+}
+
+/** The proven location and identity of a retained root directory handle. */
+export interface VerifiedRootBinding {
+  readonly requestedPath: string;
+  readonly canonicalPath: string;
+  readonly identity: FileIdentity;
+}
+
+/** A root directory descriptor plus the binding it was proven against. */
+export interface VerifiedRoot {
+  readonly binding: VerifiedRootBinding;
+  readonly handle: FileHandle;
+}
+
+/**
+ * Caller-supplied error and cancellation behaviour.
+ *
+ * The memory scanner reports platform failures as its own scan-result kind and
+ * cancels through the memory recall contract; the MCP providers have neither.
+ * Passing both in keeps the primitives identical for every caller instead of
+ * forking the security-critical code per consumer.
+ */
+export interface VerifiedReadContext {
+  /** Throws the caller's own cancellation error when `signal` has fired. */
+  readonly checkAborted: (signal: AbortSignal) => void;
+  /** Builds the error raised on a platform without descriptor-path proofs. */
+  readonly unsupportedPlatform: (message: string) => Error;
+}
+
+/** Raised when the platform cannot prove where an open descriptor points. */
+export class UnsupportedVerifiedReadPlatformError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedVerifiedReadPlatformError";
+  }
+}
+
+/** Raised when a root directory changed identity or location while binding. */
+export class VerifiedRootUnstableError extends Error {
+  constructor(readonly reason: "identity" | "final-path", message: string) {
+    super(message);
+    this.name = "VerifiedRootUnstableError";
+  }
+}
+
+/** Cancellation/error behaviour for callers with no contract of their own. */
+export const DEFAULT_VERIFIED_READ_CONTEXT: VerifiedReadContext = {
+  checkAborted: (signal: AbortSignal): void => {
+    if (!signal.aborted) return;
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error("verified read aborted");
+  },
+  unsupportedPlatform: (message: string): Error =>
+    new UnsupportedVerifiedReadPlatformError(message),
+};
+
+/**
+ * Open flags for a verified regular-file read.
+ *
+ * `O_NOFOLLOW` rejects a final component swapped to a symlink and `O_NONBLOCK`
+ * stops an open of a swapped-in FIFO from hanging. Both are structural: the
+ * identity proofs around the open reject every *distinct* replacement on their
+ * own, so these flags are what remains for a replacement that is the same
+ * inode reached through another name.
+ */
+export function verifiedFileOpenFlags(): number {
+  if (process.platform === "win32") return constants.O_RDONLY;
+  return (
+    constants.O_RDONLY |
+    (constants.O_NOFOLLOW ?? 0) |
+    (constants.O_NONBLOCK ?? 0)
+  );
+}
+
+/** Open flags for a verified directory handle. */
+export function verifiedDirectoryOpenFlags(): number {
+  if (process.platform === "win32") return constants.O_RDONLY;
+  return (
+    constants.O_RDONLY |
+    (constants.O_DIRECTORY ?? 0) |
+    (constants.O_NOFOLLOW ?? 0)
+  );
+}
+
+export function identityFromStats(stats: BigIntStats): FileIdentity {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    size: stats.size,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+  };
+}
+
+export function sameStats(
+  left: BigIntStats | FileIdentity,
+  right: BigIntStats | FileIdentity,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+/** True when `candidate` is a strict descendant of `root`. */
+export function isContained(root: string, candidate: string): boolean {
+  const relation = relative(root, candidate);
+  return (
+    relation.length > 0 &&
+    relation !== ".." &&
+    !relation.startsWith(`..${sep}`) &&
+    !isAbsolute(relation)
+  );
+}
+
+/**
+ * Path used to enumerate and open entries below an already-verified
+ * descriptor. Linux traverses through `/proc/self/fd/N`. On darwin and
+ * freebsd `/dev/fd/N` is not traversable (`opendir` fails with ENOTDIR and
+ * children resolve to ENOENT), so the real requested path is used while the
+ * retained descriptor, `O_NOFOLLOW`, `nlink === 1`, and the before/after
+ * identity checks continue to guard against exchanges.
+ */
+export function descriptorHandlePath(
+  handle: FileHandle,
+  requestedPath: string,
+  context: VerifiedReadContext,
+): string {
+  if (process.platform === "linux") return `/proc/self/fd/${handle.fd}`;
+  if (process.platform === "darwin" || process.platform === "freebsd") {
+    return requestedPath;
+  }
+  throw context.unsupportedPlatform(
+    "descriptor-relative traversal is unavailable on this platform",
+  );
+}
+
+export function descriptorRelativePath(
+  root: VerifiedRoot,
+  relativePath: string,
+  context: VerifiedReadContext,
+): string {
+  const descriptorPath = descriptorHandlePath(
+    root.handle,
+    root.binding.requestedPath,
+    context,
+  );
+  return relativePath.length === 0
+    ? descriptorPath
+    : join(descriptorPath, relativePath);
+}
+
+export function canonicalRelativePath(
+  root: VerifiedRoot,
+  relativePath: string,
+): string {
+  return relativePath.length === 0
+    ? root.binding.canonicalPath
+    : join(root.binding.canonicalPath, relativePath);
+}
+
+export async function closeVerifiedHandle(
+  handle: FileHandle,
+  signal: AbortSignal,
+  context: VerifiedReadContext,
+): Promise<void> {
+  await handle.close().catch(() => undefined);
+  context.checkAborted(signal);
+}
+
+/**
+ * Open a root directory and retain the descriptor every later proof is made
+ * against. Returns `null` when the directory is absent, is a symlink, is not a
+ * directory, or cannot be opened; throws `VerifiedRootUnstableError` when the
+ * object changed identity or location between the checks.
+ */
+export async function bindVerifiedRoot(
+  directory: string,
+  signal: AbortSignal,
+  context: VerifiedReadContext,
+): Promise<VerifiedRoot | null> {
+  context.checkAborted(signal);
+  const requestedPath = resolve(directory);
+  let before: BigIntStats;
+  try {
+    before = await lstat(requestedPath, { bigint: true });
+  } catch {
+    context.checkAborted(signal);
+    return null;
+  }
+  context.checkAborted(signal);
+  if (before.isSymbolicLink() || !before.isDirectory()) return null;
+  let canonicalPath: string;
+  try {
+    canonicalPath = await realpath(requestedPath);
+  } catch {
+    context.checkAborted(signal);
+    return null;
+  }
+  context.checkAborted(signal);
+  let handle: FileHandle;
+  try {
+    handle = await open(requestedPath, verifiedDirectoryOpenFlags());
+  } catch {
+    context.checkAborted(signal);
+    return null;
+  }
+  let retainHandle = false;
+  try {
+    context.checkAborted(signal);
+    const opened = await handle.stat({ bigint: true });
+    context.checkAborted(signal);
+    const after = await lstat(requestedPath, { bigint: true });
+    context.checkAborted(signal);
+    if (
+      !opened.isDirectory() ||
+      !sameStats(before, opened) ||
+      !sameStats(opened, after)
+    ) {
+      throw new VerifiedRootUnstableError(
+        "identity",
+        "verified root changed while binding",
+      );
+    }
+    const finalPath = await finalDescriptorPath(
+      handle,
+      canonicalPath,
+      signal,
+      context,
+    );
+    if (finalPath !== canonicalPath) {
+      throw new VerifiedRootUnstableError(
+        "final-path",
+        "verified root final path changed",
+      );
+    }
+    retainHandle = true;
+    return {
+      binding: {
+        requestedPath,
+        canonicalPath,
+        identity: identityFromStats(opened),
+      },
+      handle,
+    };
+  } finally {
+    if (!retainHandle) await closeVerifiedHandle(handle, signal, context);
+  }
+}
+
+/**
+ * Open one candidate below a bound root and prove it is still reachable only
+ * from inside that root. This is the check that closes the ancestor-swap
+ * escape: containment is decided against the retained root descriptor, never
+ * against a second resolution of the candidate's pathname.
+ */
+export async function openVerifiedCandidate(
+  root: VerifiedRoot,
+  relativePath: string,
+  signal: AbortSignal,
+  context: VerifiedReadContext,
+): Promise<FileHandle | null> {
+  context.checkAborted(signal);
+  const filePath = join(root.binding.requestedPath, relativePath);
+  if (!isContained(root.binding.requestedPath, filePath)) return null;
+  if (!(await verifyParentChain(root, relativePath, signal, context))) {
+    return null;
+  }
+  const descriptorPath = descriptorRelativePath(root, relativePath, context);
+  let pathStats: BigIntStats;
+  try {
+    pathStats = await lstat(descriptorPath, { bigint: true });
+  } catch {
+    context.checkAborted(signal);
+    return null;
+  }
+  context.checkAborted(signal);
+  if (pathStats.isSymbolicLink() || !pathStats.isFile()) return null;
+  let handle: FileHandle;
+  try {
+    handle = await open(descriptorPath, verifiedFileOpenFlags());
+  } catch {
+    context.checkAborted(signal);
+    return null;
+  }
+  try {
+    context.checkAborted(signal);
+    const opened = await handle.stat({ bigint: true });
+    context.checkAborted(signal);
+    if (!opened.isFile() || opened.nlink !== 1n || !sameStats(pathStats, opened)) {
+      await handle.close();
+      context.checkAborted(signal);
+      return null;
+    }
+    const finalPath = await finalDescriptorPath(
+      handle,
+      canonicalRelativePath(root, relativePath),
+      signal,
+      context,
+    );
+    if (
+      finalPath === null ||
+      !isContained(root.binding.canonicalPath, finalPath)
+    ) {
+      await handle.close();
+      context.checkAborted(signal);
+      return null;
+    }
+    const finalStats = await lstat(finalPath, { bigint: true });
+    context.checkAborted(signal);
+    if (!sameStats(opened, finalStats)) {
+      await handle.close();
+      context.checkAborted(signal);
+      return null;
+    }
+    context.checkAborted(signal);
+    return handle;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    context.checkAborted(signal);
+    throw error;
+  }
+}
+
+/**
+ * Walk every parent segment from the bound root's descriptor path: each must
+ * be a real, non-symlink directory whose canonical path is inside the root's
+ * canonical path, and the root handle itself must still match its binding.
+ */
+export async function verifyParentChain(
+  root: VerifiedRoot,
+  relativePath: string,
+  signal: AbortSignal,
+  context: VerifiedReadContext,
+): Promise<boolean> {
+  const segments = relativePath.split(sep);
+  let cursor = descriptorHandlePath(
+    root.handle,
+    root.binding.requestedPath,
+    context,
+  );
+  const parentSegments = segments.slice(0, -1);
+  for (const segment of parentSegments) {
+    context.checkAborted(signal);
+    cursor = join(cursor, segment);
+    const stats = await lstat(cursor, { bigint: true });
+    context.checkAborted(signal);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) return false;
+    const canonical = await realpath(cursor);
+    context.checkAborted(signal);
+    if (!isContained(root.binding.canonicalPath, canonical)) return false;
+  }
+  const openedRoot = await root.handle.stat({ bigint: true });
+  context.checkAborted(signal);
+  const currentRoot = await lstat(root.binding.requestedPath, { bigint: true });
+  context.checkAborted(signal);
+  return (
+    !currentRoot.isSymbolicLink() &&
+    sameStats(openedRoot, root.binding.identity) &&
+    sameStats(currentRoot, root.binding.identity)
+  );
+}
+
+/** Re-prove an opened candidate against its path after its bytes were read. */
+export async function assertCandidateUnchanged(
+  handle: FileHandle,
+  descriptorPath: string,
+  before: FileIdentity,
+  signal: AbortSignal,
+  context: VerifiedReadContext,
+): Promise<void> {
+  context.checkAborted(signal);
+  const openedAfter = identityFromStats(await handle.stat({ bigint: true }));
+  context.checkAborted(signal);
+  const pathAfter = identityFromStats(
+    await lstat(descriptorPath, { bigint: true }),
+  );
+  context.checkAborted(signal);
+  if (!sameStats(before, openedAfter) || !sameStats(before, pathAfter)) {
+    throw new Error("verified candidate changed during descriptor-bound read");
+  }
+}
+
+/**
+ * Resolve the path an open descriptor currently refers to, or `null` when it
+ * can no longer be proven to sit at `expectedPath`.
+ *
+ * Linux exposes the live target through `/proc/self/fd/N`. darwin and freebsd
+ * do not: `realpath("/dev/fd/N")` yields `/dev/fd/<basename>` instead of the
+ * target, so a string comparison against the canonical path can never match
+ * and every recall root used to fail closed. Those platforms instead prove the
+ * descriptor identity (dev/ino/mode/size/mtime/ctime) against `expectedPath`,
+ * which is the property the alias comparison was buying.
+ */
+export async function finalDescriptorPath(
+  handle: FileHandle,
+  expectedPath: string,
+  signal: AbortSignal,
+  context: VerifiedReadContext,
+): Promise<string | null> {
+  if (process.platform === "linux") {
+    const path = await realpath(`/proc/self/fd/${handle.fd}`);
+    context.checkAborted(signal);
+    return path;
+  }
+  if (process.platform === "darwin" || process.platform === "freebsd") {
+    const opened = await handle.stat({ bigint: true });
+    context.checkAborted(signal);
+    let expected: BigIntStats;
+    try {
+      expected = await lstat(expectedPath, { bigint: true });
+    } catch {
+      context.checkAborted(signal);
+      return null;
+    }
+    context.checkAborted(signal);
+    return !expected.isSymbolicLink() && sameStats(opened, expected)
+      ? expectedPath
+      : null;
+  }
+  throw context.unsupportedPlatform(
+    "descriptor final-path verification is unavailable on this platform",
+  );
+}

--- a/runtime/src/fs/verified-read.ts
+++ b/runtime/src/fs/verified-read.ts
@@ -18,9 +18,10 @@
  *      descriptor path, rejects symlinked or non-directory ancestors, requires
  *      each ancestor's canonical path to sit inside the root's canonical path,
  *      and re-proves the root handle against the retained binding.
- *   3. `openVerifiedCandidate` opens the final component with `O_NOFOLLOW`,
- *      proves the opened object against the path stat, and proves the
- *      descriptor still resolves inside the root.
+ *   3. `openVerifiedCandidate` opens the final component with `O_NOFOLLOW`
+ *      and proves the opened object against the path stat. What it then does
+ *      about containment differs by platform, and the docstring on that
+ *      function says which half is load-bearing where.
  *   4. `assertCandidateUnchanged` re-proves the object after the bytes are read.
  *
  * Directories and files are proven on different fields, deliberately. A
@@ -34,6 +35,21 @@
  * 112 of 172,076 attempts. What an ancestor swap must do is make the retained
  * handle and the pathname name different objects, and `dev`/`ino` is exactly
  * the pair that catches that.
+ *
+ * That number is the SKILL listing, and only the skill listing. The MCP
+ * MEMORY listing runs through `runtime/src/memory/scan.ts`, which has
+ * directory proofs of its own and was still comparing the full identity in
+ * all three of them; narrowing this file did nothing for it. Re-measured with
+ * one separate process writing and removing a single sibling file, the three
+ * heads run back to back:
+ *
+ *   surface   before this file was narrowed   after   after scan.ts too
+ *   skills    102/116,343 = 0.09%             100.00%  100.00%
+ *   memory     50/139,285 = 0.04%               0.15%  100.00%
+ *
+ * Controls, both surfaces and all three heads: no churn 100.00%, churn in a
+ * directory outside the listed root 100.00%. Both surfaces are narrowed now;
+ * the memory proofs and their own mutation tests live with that module.
  *
  * Platform story, and it is not uniform:
  *
@@ -208,8 +224,10 @@ export function sameStats(
  * directory proof that included them rejected every ordinary concurrent write
  * in the workspace. Measured under purely benign sibling churn and no
  * attacker at all, the full-identity proof left the MCP skill listing
- * available 0.07% of the time (112 of 172,076 listings); the entire listing
- * collapsed because a neighbouring file was being written.
+ * available 0.09% of the time (102 of 116,343 listings) and, through the
+ * separate proofs in `memory/scan.ts`, the MCP memory listing available 0.15%
+ * of the time (113 of 76,583 listings); the entire listing collapsed because
+ * a neighbouring file was being written.
  *
  * Containment does not need those fields. What an ancestor swap has to do is
  * make the retained handle and the pathname refer to *different* objects, and
@@ -386,10 +404,40 @@ export async function bindVerifiedRoot(
 }
 
 /**
- * Open one candidate below a bound root and prove it is still reachable only
- * from inside that root. This is the check that closes the ancestor-swap
- * escape: containment is decided against the retained root descriptor, never
- * against a second resolution of the candidate's pathname.
+ * Open one candidate below a bound root, prove the opened object is the one
+ * the path named, and prove it is still reachable only from inside that root.
+ *
+ * Be precise about which clause buys what, because the obvious reading of the
+ * last step is wrong on two of the three platforms:
+ *
+ *   - `verifyParentChain`, called here before the open and again by every
+ *     caller after the bytes are read, is what actually rejects an ancestor
+ *     swap. It walks each parent segment from the retained root descriptor,
+ *     refuses a symlinked or non-directory segment, requires each segment's
+ *     canonical path to sit inside the root's, and re-proves the root handle.
+ *   - on linux, `finalDescriptorPath` reads the descriptor's live location
+ *     back out of `/proc/self/fd`, so `isContained` on that result is a real
+ *     containment proof about the opened object.
+ *   - on darwin and freebsd it is not. There `finalDescriptorPath` returns
+ *     the very `expectedPath` it was handed — `join(canonicalPath, rel)` —
+ *     or `null`, so `isContained(canonicalPath, join(canonicalPath, rel))` is
+ *     a tautology for any `rel` the `isContained` pre-check already admitted.
+ *     Only `canonicalPath` is symlink-free by construction; the `rel` part of
+ *     that name traverses the very segments an attacker controls, the same
+ *     ones the open traversed. What the call still buys on those platforms is
+ *     the identity comparison inside it — the open handle against
+ *     `lstat(join(canonicalPath, rel))` — which is a third resolution of the
+ *     name, not a containment proof.
+ *
+ * Measured, in the geometry where a segment INSIDE the bound root is flipped
+ * between a real directory and a symlink to an out-of-scope twin, attacker in
+ * its own process, no seams: deleting the whole final-path block here forges
+ * nothing (0 of 31,621 served, 53,722 attempts), and deleting the callers'
+ * post-read `assertCandidateUnchanged` and ancestor re-walk on top of it
+ * still forges nothing (0 of 44,394 served, 66,736 attempts). Deleting
+ * `verifyParentChain` forges immediately: 56 of 40,342 served, 54,687
+ * attempts. In that geometry the ancestor walk is the guard; everything after
+ * the open is depth behind it.
  */
 export async function openVerifiedCandidate(
   root: VerifiedRoot,

--- a/runtime/src/fs/verified-read.ts
+++ b/runtime/src/fs/verified-read.ts
@@ -30,9 +30,9 @@
  * handle. A DIRECTORY is proven on `sameDirectoryIdentity` — `dev`, `ino`,
  * `mode` — because a directory's `size`, `mtime`, and `ctime` move whenever
  * any child is added, removed, or renamed. Requiring those to stand still was
- * not stricter containment, it was an availability collapse: measured under
- * purely benign sibling churn with no attacker, an MCP skill listing survived
- * 112 of 172,076 attempts. What an ancestor swap must do is make the retained
+ * not stricter containment, it was an availability collapse. The measurement
+ * is in the table below rather than stated twice here. What an ancestor swap
+ * must do is make the retained
  * handle and the pathname name different objects, and `dev`/`ino` is exactly
  * the pair that catches that.
  *

--- a/runtime/src/fs/verified-read.ts
+++ b/runtime/src/fs/verified-read.ts
@@ -23,6 +23,18 @@
  *      descriptor still resolves inside the root.
  *   4. `assertCandidateUnchanged` re-proves the object after the bytes are read.
  *
+ * Directories and files are proven on different fields, deliberately. A
+ * candidate FILE is proven on the full `sameStats` identity, because `size`,
+ * `mtime`, and `ctime` are what detect a content swap under a retained
+ * handle. A DIRECTORY is proven on `sameDirectoryIdentity` — `dev`, `ino`,
+ * `mode` — because a directory's `size`, `mtime`, and `ctime` move whenever
+ * any child is added, removed, or renamed. Requiring those to stand still was
+ * not stricter containment, it was an availability collapse: measured under
+ * purely benign sibling churn with no attacker, an MCP skill listing survived
+ * 112 of 172,076 attempts. What an ancestor swap must do is make the retained
+ * handle and the pathname name different objects, and `dev`/`ino` is exactly
+ * the pair that catches that.
+ *
  * Platform story, and it is not uniform:
  *
  *   - linux: `/proc/self/fd/N` is a traversable, live view of an open
@@ -88,6 +100,23 @@ export interface VerifiedReadContext {
   readonly checkAborted: (signal: AbortSignal) => void;
   /** Builds the error raised on a platform without descriptor-path proofs. */
   readonly unsupportedPlatform: (message: string) => Error;
+  /**
+   * @internal Deterministic race seam, fired by `bindVerifiedRoot` after the
+   * validating `lstat`/`realpath` and before the `open` that retains the
+   * descriptor.
+   *
+   * That gap is the one window a root binding cannot close by construction:
+   * `O_NOFOLLOW` refuses a symlinked *final* component but says nothing about
+   * mid-path ones, so an attacker who repoints an ancestor here makes the
+   * `open` land on a different directory than the one that was validated. The
+   * two proofs that catch it — the before/opened/after identity proof and the
+   * final-path proof — are what the tests reach through this hook; without a
+   * seam they are only reachable by a timing race, which is why they sat
+   * unpinned while a mutant that deletes them served out-of-scope bodies.
+   */
+  readonly beforeRootOpenForTesting?: (
+    requestedPath: string,
+  ) => void | Promise<void>;
 }
 
 /** Raised when the platform cannot prove where an open descriptor points. */
@@ -168,6 +197,38 @@ export function sameStats(
     left.size === right.size &&
     left.mtimeNs === right.mtimeNs &&
     left.ctimeNs === right.ctimeNs
+  );
+}
+
+/**
+ * Identity fields that prove two observations describe the same *directory*.
+ *
+ * Deliberately narrower than `sameStats`: a directory's `mtime`, `ctime`, and
+ * `size` all move whenever any child is added, removed, or renamed, so a
+ * directory proof that included them rejected every ordinary concurrent write
+ * in the workspace. Measured under purely benign sibling churn and no
+ * attacker at all, the full-identity proof left the MCP skill listing
+ * available 0.07% of the time (112 of 172,076 listings); the entire listing
+ * collapsed because a neighbouring file was being written.
+ *
+ * Containment does not need those fields. What an ancestor swap has to do is
+ * make the retained handle and the pathname refer to *different* objects, and
+ * `dev`/`ino` is exactly the pair that detects that; `mode` pins the object
+ * type and permission bits alongside it. A directory's own timestamp
+ * advancing is not a containment violation, and treating it as one traded all
+ * availability for no additional proof.
+ *
+ * Candidate *files* keep the full `sameStats` identity, where `size`, `mtime`,
+ * and `ctime` are what detect an in-place content swap.
+ */
+export function sameDirectoryIdentity(
+  left: BigIntStats | FileIdentity,
+  right: BigIntStats | FileIdentity,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode
   );
 }
 
@@ -267,6 +328,8 @@ export async function bindVerifiedRoot(
     return null;
   }
   context.checkAborted(signal);
+  await context.beforeRootOpenForTesting?.(requestedPath);
+  context.checkAborted(signal);
   let handle: FileHandle;
   try {
     handle = await open(requestedPath, verifiedDirectoryOpenFlags());
@@ -281,10 +344,15 @@ export async function bindVerifiedRoot(
     context.checkAborted(signal);
     const after = await lstat(requestedPath, { bigint: true });
     context.checkAborted(signal);
+    // Directory identity, not full `sameStats`: `before`, `opened`, and
+    // `after` are three observations taken across two awaits, so any child
+    // write anywhere in this directory moved its timestamps between them.
+    // What this proves is that the object the `open` landed on is the object
+    // the `lstat` validated, and `dev`/`ino`/`mode` is that proof.
     if (
       !opened.isDirectory() ||
-      !sameStats(before, opened) ||
-      !sameStats(opened, after)
+      !sameDirectoryIdentity(before, opened) ||
+      !sameDirectoryIdentity(opened, after)
     ) {
       throw new VerifiedRootUnstableError(
         "identity",
@@ -423,10 +491,13 @@ export async function verifyParentChain(
   context.checkAborted(signal);
   const currentRoot = await lstat(root.binding.requestedPath, { bigint: true });
   context.checkAborted(signal);
+  // `sameDirectoryIdentity`, not `sameStats`: see its doc comment. The root
+  // is re-proven on every listing and on every read, so requiring its
+  // timestamps to stand still required the whole workspace to stand still.
   return (
     !currentRoot.isSymbolicLink() &&
-    sameStats(openedRoot, root.binding.identity) &&
-    sameStats(currentRoot, root.binding.identity)
+    sameDirectoryIdentity(openedRoot, root.binding.identity) &&
+    sameDirectoryIdentity(currentRoot, root.binding.identity)
   );
 }
 
@@ -483,9 +554,23 @@ export async function finalDescriptorPath(
       return null;
     }
     context.checkAborted(signal);
-    return !expected.isSymbolicLink() && sameStats(opened, expected)
-      ? expectedPath
-      : null;
+    if (expected.isSymbolicLink()) return null;
+    // Directories are compared on `dev`/`ino`/`mode` for the reason given on
+    // `sameDirectoryIdentity`; every caller that hands a directory here
+    // separately proves the handle against its retained binding. Regular
+    // files keep the full identity, which is what detects a content swap.
+    //
+    // This branch has no deterministic test: the two observations it compares
+    // are both taken inside this function, so nothing can write between them
+    // on demand. It is pinned by measurement instead. Narrowing only the two
+    // other directory proofs and leaving this one on `sameStats` puts the
+    // benign-churn skill listing at 68.91% (24,129 of 35,016) instead of
+    // 100.00%; on linux the branch is not reached at all, because there the
+    // descriptor's path is read back from `/proc/self/fd`.
+    const same = opened.isDirectory()
+      ? expected.isDirectory() && sameDirectoryIdentity(opened, expected)
+      : sameStats(opened, expected);
+    return same ? expectedPath : null;
   }
   throw context.unsupportedPlatform(
     "descriptor final-path verification is unavailable on this platform",

--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -13,32 +13,66 @@
  *     the same way it gates in-process model invocation.
  *   - Resources: memory files (via the same scanner the runtime uses)
  *     plus explicitly-passed instruction files (AGENC.md tiers).
- *     Canonical containment rejects symlink escapes, and `readResource`
- *     only serves URIs minted by a fresh listing — it never resolves
- *     client-supplied paths. Only the selected resource body is read,
- *     then its contents pass through the canonical egress secret sanitizer.
+ *     `readResource` only serves URIs minted by a fresh listing — it never
+ *     resolves client-supplied paths. Only the selected resource body is
+ *     read, then its contents pass through the canonical egress secret
+ *     sanitizer.
  *
- * Skill and resource bodies are served by one shared descriptor-bound
- * reader (`readScopedRegularFile`): a candidate is validated, opened once
- * with `O_NOFOLLOW`/`O_NONBLOCK`, proven to be the same single-link
- * regular object that validation saw, read from that handle under a byte
- * ceiling, and re-proved after the read. A pathname is never reopened
- * after validation, so a writable workspace cannot swap the file or an
- * ancestor between checks and bytes. Node exposes no root-confined
- * open (openat2/`RESOLVE_BENEATH`); as in the runtime's other verified
- * readers, containment is enforced on the canonical resolution plus
- * opened-handle identity proofs rather than a silent weaker path.
+ * Containment is bound to a descriptor, not to a pathname. Each skill root,
+ * memory directory, and instruction-file parent is opened once per request
+ * and retained (`bindVerifiedRoot`); the retained handle is proven to sit
+ * inside `scopeRoot`, and every candidate below it is admitted, opened, read,
+ * and re-proven against that handle through the shared verified-read
+ * primitives. In particular `verifyParentChain` rejects a symlinked or
+ * escaped ancestor before and after the bytes are taken.
+ *
+ * That ancestor proof is the point. Deciding containment by resolving the
+ * candidate's pathname a second time is not a proof at all: `lstat` and
+ * `realpath` are independent resolutions, and a writable workspace can flip an
+ * ancestor between them so the identity check lands on an out-of-scope inode
+ * while the containment check lands on an in-scope name. The two proofs then
+ * describe different files and out-of-scope bytes are served under an in-scope
+ * path. Nothing here resolves a candidate pathname twice.
+ *
+ * Platform: the shared primitives need a descriptor-path mechanism
+ * (`/proc/self/fd` on linux; an identity comparison on darwin and freebsd).
+ * Where the platform offers neither — Windows included — these providers fail
+ * closed: the affected root contributes nothing and the reason is reported
+ * through `onRejected`. There is deliberately no weaker fallback, so `agenc
+ * mcp serve` on Windows advertises no skills, memory, or instruction
+ * resources. That is a real loss of function, taken over serving bytes whose
+ * location cannot be proven; memory resources were already empty there,
+ * because `scanMemoryRoots` reports "unsupported" on win32.
  *
  * @module
  */
-import { constants as fsConstants, type BigIntStats } from "node:fs";
-import { lstat, open, readdir, realpath } from "node:fs/promises";
-import { basename, isAbsolute, join, relative } from "node:path";
+import { Buffer } from "node:buffer";
+import type { BigIntStats } from "node:fs";
+import { lstat, readdir, realpath, type FileHandle } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { TextDecoder } from "node:util";
 
+import {
+  DEFAULT_VERIFIED_READ_CONTEXT,
+  UnsupportedVerifiedReadPlatformError,
+  assertCandidateUnchanged,
+  bindVerifiedRoot,
+  canonicalRelativePath,
+  closeVerifiedHandle,
+  descriptorHandlePath,
+  descriptorRelativePath,
+  identityFromStats,
+  openVerifiedCandidate,
+  sameStats,
+  verifyParentChain,
+  type FileIdentity,
+  type VerifiedRoot,
+} from "../../fs/verified-read.js";
 import {
   detectSessionFileType,
   scanMemoryFiles,
 } from "../../memory/index.js";
+import { MAX_SECURE_PROJECT_FILE_BYTES } from "../../prompts/secure-instruction-file.js";
 import { redactSecrets } from "../../secrets/sanitizer.js";
 import {
   parseBooleanFrontmatter,
@@ -53,29 +87,72 @@ import type {
   McpResourceProvider,
 } from "../../mcp-server/types.js";
 
-/** Byte ceiling for one skill / memory / instruction body served over MCP. */
+/** Byte ceiling for one skill or memory body served over MCP. */
 export const MAX_SCOPED_FILE_BYTES = 1_048_576;
+
+/**
+ * Byte ceiling for one instruction file (AGENC.md tier) served over MCP.
+ *
+ * It is deliberately the same number the runtime uses for the very same file
+ * in-process (`readInstructionFileSnapshot` with
+ * `MAX_SECURE_PROJECT_FILE_BYTES`). When these diverged, a 2 MiB AGENC.md was
+ * read in-process and silently dropped from `resources/list`, which reads as
+ * "the MCP server cannot see my instructions" with no way to tell why.
+ * Skills and memory files keep the smaller ceiling: they are many, are listed
+ * on every request, and have no in-process counterpart to match.
+ */
+export const MAX_SCOPED_INSTRUCTION_FILE_BYTES = MAX_SECURE_PROJECT_FILE_BYTES;
+
+/** Why one candidate did not become a prompt or a resource. */
+export type ScopedReadRejectionReason =
+  | "platform_unsupported"
+  | "root_unavailable"
+  | "root_outside_scope"
+  | "not_found"
+  | "not_admissible"
+  | "too_large"
+  | "verification_failed"
+  | "ancestor_changed"
+  | "invalid_utf8";
+
+export interface ScopedReadRejection {
+  readonly reason: ScopedReadRejectionReason;
+  /** The requested (not canonical) path, so it names what the caller asked for. */
+  readonly path: string;
+}
 
 /**
  * @internal Deterministic race seams for the shared verified reader:
  * tests replace the candidate at each filesystem I/O boundary.
  */
 export interface ScopedRegularFileTestHooks {
-  /** Fires after validation, before the verified open. */
+  /** Fires after admission, before the verified open. */
   readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
   /** Fires after the verified open, before the bounded read. */
   readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
 }
 
-export interface SkillPromptProviderOptions {
+/**
+ * Observability for a rejection.
+ *
+ * Nothing under `runtime/src/mcp/server/` writes a log line, and a stdio MCP
+ * server owns stdout as its protocol channel, so this stays a caller-supplied
+ * observer rather than a new logger: rejections are ordinary for unreadable,
+ * oversized, or foreign files, and a per-candidate log on every `prompts/list`
+ * would be noise. Unwired it behaves exactly as before — the entry is dropped
+ * — but the reason is now reachable instead of unobservable.
+ */
+export interface ScopedReadObserverOptions {
+  readonly onRejected?: (rejection: ScopedReadRejection) => void;
+}
+
+export interface SkillPromptProviderOptions
+  extends ScopedRegularFileTestHooks,
+    ScopedReadObserverOptions {
   /** Directories whose children are skills (`<dir>/<name>/SKILL.md` or `<dir>/<name>.md`). */
   readonly skillRoots: readonly string[];
-  /** Canonical containment root; candidates resolving outside it are omitted. */
+  /** Containment root; a skill root resolving outside it contributes nothing. */
   readonly scopeRoot?: string;
-  /** @internal Test seam: candidate swap point after validation. */
-  readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
-  /** @internal Test seam: candidate swap point after the verified open. */
-  readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
 }
 
 interface DiscoveredSkill {
@@ -86,24 +163,26 @@ interface DiscoveredSkill {
   readonly rawContent: string;
 }
 
-interface ScopedFileIdentity {
-  readonly dev: bigint;
-  readonly ino: bigint;
-  readonly mode: bigint;
-  readonly nlink: bigint;
-  readonly size: bigint;
-  readonly mtimeNs: bigint;
-  readonly ctimeNs: bigint;
-}
-
-interface ScopedRegularFileResolution {
-  readonly canonicalPath: string;
-  readonly identity: ScopedFileIdentity;
-}
-
-interface ScopedRegularFileContents {
+interface ScopedFileBody {
   readonly canonicalPath: string;
   readonly rawContent: string;
+}
+
+/**
+ * These providers answer one MCP request at a time and have no cancellation
+ * channel of their own, so the shared primitives get a signal that never
+ * fires and the default error behaviour.
+ */
+const NEVER_ABORTED: AbortSignal = new AbortController().signal;
+const VERIFIED_READ_CONTEXT = DEFAULT_VERIFIED_READ_CONTEXT;
+
+function noteRejection(
+  observer: ScopedReadObserverOptions,
+  reason: ScopedReadRejectionReason,
+  path: string,
+): null {
+  observer.onRejected?.({ reason, path });
+  return null;
 }
 
 async function canonicalScopeRoot(
@@ -122,60 +201,126 @@ function isSameOrChildPath(scopeRoot: string, candidate: string): boolean {
   return offset === "" || (!offset.startsWith("..") && !isAbsolute(offset));
 }
 
-function scopedIdentity(stats: BigIntStats): ScopedFileIdentity {
-  return {
-    dev: stats.dev,
-    ino: stats.ino,
-    mode: stats.mode,
-    nlink: stats.nlink,
-    size: stats.size,
-    mtimeNs: stats.mtimeNs,
-    ctimeNs: stats.ctimeNs,
-  };
-}
-
-function sameScopedIdentity(
-  left: ScopedFileIdentity,
-  right: ScopedFileIdentity,
-): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mode === right.mode &&
-    left.nlink === right.nlink &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
-  );
-}
-
 /** One admission contract for listing and reading: regular, unlinked-again, bounded. */
-function admitsScopedSnapshot(stats: BigIntStats): boolean {
+function admitsScopedSnapshot(
+  stats: BigIntStats,
+  maximumBytes: number,
+): boolean {
   return (
     stats.isFile() &&
     !stats.isSymbolicLink() &&
     stats.nlink === 1n &&
-    stats.size <= BigInt(MAX_SCOPED_FILE_BYTES)
+    stats.size <= BigInt(maximumBytes)
   );
 }
 
-function scopedOpenFlags(): number {
-  if (process.platform === "win32") return fsConstants.O_RDONLY;
-  // O_NOFOLLOW rejects a final component swapped to a symlink; O_NONBLOCK
-  // stops an open of a swapped-in FIFO from hanging. The opened-handle
-  // fstat below rejects every non-regular replacement; both flags are
-  // no-ops for the regular files that pass admission.
-  return (
-    fsConstants.O_RDONLY |
-    (fsConstants.O_NOFOLLOW ?? 0) |
-    (fsConstants.O_NONBLOCK ?? 0)
-  );
+/**
+ * Open a root directory, retain its descriptor, and prove it sits inside the
+ * scope root. Every later containment decision is made against this handle,
+ * so a root that cannot be proven contributes nothing at all.
+ */
+async function bindScopedRoot(
+  directory: string,
+  scopeRoot: string | null,
+  observer: ScopedReadObserverOptions,
+): Promise<VerifiedRoot | null> {
+  let root: VerifiedRoot | null;
+  try {
+    root = await bindVerifiedRoot(
+      directory,
+      NEVER_ABORTED,
+      VERIFIED_READ_CONTEXT,
+    );
+  } catch (error) {
+    return noteRejection(
+      observer,
+      error instanceof UnsupportedVerifiedReadPlatformError
+        ? "platform_unsupported"
+        : "root_unavailable",
+      directory,
+    );
+  }
+  if (root === null) {
+    return noteRejection(observer, "root_unavailable", directory);
+  }
+  if (
+    scopeRoot !== null &&
+    !isSameOrChildPath(scopeRoot, root.binding.canonicalPath)
+  ) {
+    await closeVerifiedHandle(root.handle, NEVER_ABORTED, VERIFIED_READ_CONTEXT);
+    return noteRejection(observer, "root_outside_scope", directory);
+  }
+  return root;
 }
 
+async function releaseScopedRoot(root: VerifiedRoot): Promise<void> {
+  await closeVerifiedHandle(root.handle, NEVER_ABORTED, VERIFIED_READ_CONTEXT);
+}
+
+/**
+ * Stat contract for a candidate that is only going to be *listed*. No handle
+ * is opened and no bytes are taken, so the entry never advertises a
+ * directory, FIFO, device, symlink, multiply-linked, or oversized object.
+ */
+async function admitScopedCandidate(
+  root: VerifiedRoot,
+  relativePath: string,
+  maximumBytes: number,
+  observer: ScopedReadObserverOptions,
+): Promise<FileIdentity | null> {
+  const requestedPath = join(root.binding.requestedPath, relativePath);
+  try {
+    // No test can kill this particular call: on the read path
+    // `openVerifiedCandidate` walks the chain again a moment later, and the
+    // listing path has no race seam to swap a root through. It is kept
+    // because listing is the only verification a listed-but-unread resource
+    // gets, and because dropping a containment check to tidy a mutation
+    // matrix is the wrong trade. The guard itself — ancestor symlinks,
+    // escapes, and the bound-root re-proof — is pinned in
+    // tests/fs/verified-read.test.ts.
+    if (
+      !(await verifyParentChain(
+        root,
+        relativePath,
+        NEVER_ABORTED,
+        VERIFIED_READ_CONTEXT,
+      ))
+    ) {
+      return noteRejection(observer, "verification_failed", requestedPath);
+    }
+    const stats = await lstat(
+      descriptorRelativePath(root, relativePath, VERIFIED_READ_CONTEXT),
+      { bigint: true },
+    );
+    if (!admitsScopedSnapshot(stats, maximumBytes)) {
+      return noteRejection(
+        observer,
+        stats.isFile() && stats.size > BigInt(maximumBytes)
+          ? "too_large"
+          : "not_admissible",
+        requestedPath,
+      );
+    }
+    return identityFromStats(stats);
+  } catch (error) {
+    return noteRejection(
+      observer,
+      error instanceof UnsupportedVerifiedReadPlatformError
+        ? "platform_unsupported"
+        : (error as NodeJS.ErrnoException).code === "ENOENT"
+          ? "not_found"
+          : "verification_failed",
+      requestedPath,
+    );
+  }
+}
+
+/** Read exactly the validated byte count, plus one byte to catch growth. */
 async function readScopedHandle(
-  handle: Awaited<ReturnType<typeof open>>,
+  handle: FileHandle,
+  expectedBytes: number,
 ): Promise<Buffer | null> {
-  const buffer = Buffer.allocUnsafe(MAX_SCOPED_FILE_BYTES + 1);
+  const buffer = Buffer.allocUnsafe(expectedBytes + 1);
   let length = 0;
   while (length < buffer.length) {
     const { bytesRead } = await handle.read(
@@ -187,74 +332,121 @@ async function readScopedHandle(
     if (bytesRead === 0) break;
     length += bytesRead;
   }
-  return length > MAX_SCOPED_FILE_BYTES ? null : buffer.subarray(0, length);
-}
-
-async function resolveScopedRegularFile(
-  filePath: string,
-  scopeRoot: string | null,
-): Promise<ScopedRegularFileResolution | null> {
-  try {
-    const before = await lstat(filePath, { bigint: true });
-    if (!admitsScopedSnapshot(before)) return null;
-    const canonicalPath = await realpath(filePath);
-    if (scopeRoot !== null && !isSameOrChildPath(scopeRoot, canonicalPath)) {
-      return null;
-    }
-    return { canonicalPath, identity: scopedIdentity(before) };
-  } catch {
-    return null;
-  }
+  return length > expectedBytes ? null : buffer.subarray(0, length);
 }
 
 /**
- * Shared verified reader for skill prompts and resource bodies: validate,
- * open once, prove the opened object is the validated one, read it under
- * the byte ceiling, and prove it never changed. Any swap, relink, growth,
+ * Shared verified reader for skill prompts and resource bodies: admit the
+ * candidate, open it below the retained root handle, prove the opened object
+ * is the admitted one, read it under the byte ceiling, and re-prove both the
+ * object and its whole ancestor chain afterwards. Any swap, relink, growth,
  * or escape between those boundaries yields `null`.
  */
 async function readScopedRegularFile(
-  filePath: string,
-  scopeRoot: string | null,
-  hooks: ScopedRegularFileTestHooks = {},
-): Promise<ScopedRegularFileContents | null> {
-  const resolved = await resolveScopedRegularFile(filePath, scopeRoot);
-  if (resolved === null) return null;
-  const { canonicalPath, identity: before } = resolved;
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  root: VerifiedRoot,
+  relativePath: string,
+  maximumBytes: number,
+  hooks: ScopedRegularFileTestHooks,
+  observer: ScopedReadObserverOptions,
+): Promise<ScopedFileBody | null> {
+  const requestedPath = join(root.binding.requestedPath, relativePath);
+  const before = await admitScopedCandidate(
+    root,
+    relativePath,
+    maximumBytes,
+    observer,
+  );
+  if (before === null) return null;
+  let handle: FileHandle | null = null;
   try {
-    await hooks.beforeOpenForTesting?.(filePath);
-    handle = await open(filePath, scopedOpenFlags());
+    await hooks.beforeOpenForTesting?.(requestedPath);
+    handle = await openVerifiedCandidate(
+      root,
+      relativePath,
+      NEVER_ABORTED,
+      VERIFIED_READ_CONTEXT,
+    );
+    if (handle === null) {
+      return noteRejection(observer, "verification_failed", requestedPath);
+    }
     const opened = await handle.stat({ bigint: true });
-    if (
-      !admitsScopedSnapshot(opened) ||
-      !sameScopedIdentity(before, scopedIdentity(opened))
-    ) {
-      return null;
+    if (!admitsScopedSnapshot(opened, maximumBytes)) {
+      return noteRejection(observer, "not_admissible", requestedPath);
     }
-    await hooks.beforeReadForTesting?.(filePath);
-    const bytes = await readScopedHandle(handle);
-    if (bytes === null) return null;
-    const [afterRead, pathAfterRead, canonicalAfterRead] = await Promise.all([
-      handle.stat({ bigint: true }),
-      lstat(filePath, { bigint: true }),
-      realpath(filePath),
-    ]);
-    const openedIdentity = scopedIdentity(opened);
-    if (
-      !sameScopedIdentity(openedIdentity, scopedIdentity(afterRead)) ||
-      !sameScopedIdentity(openedIdentity, scopedIdentity(pathAfterRead)) ||
-      canonicalAfterRead !== canonicalPath ||
-      bytes.byteLength !== Number(opened.size)
-    ) {
-      return null;
+    const openedIdentity = identityFromStats(opened);
+    if (!sameStats(before, openedIdentity)) {
+      return noteRejection(observer, "verification_failed", requestedPath);
     }
-    return { canonicalPath, rawContent: bytes.toString("utf8") };
-  } catch {
-    return null;
+    await hooks.beforeReadForTesting?.(requestedPath);
+    const bytes = await readScopedHandle(handle, Number(opened.size));
+    if (bytes === null || bytes.byteLength !== Number(opened.size)) {
+      return noteRejection(observer, "too_large", requestedPath);
+    }
+    // Re-prove the object AND the ancestor chain that made it in-scope. A
+    // pathname re-resolution here would prove nothing: it is exactly the
+    // second, independent resolution an ancestor swap exploits.
+    await assertCandidateUnchanged(
+      handle,
+      descriptorRelativePath(root, relativePath, VERIFIED_READ_CONTEXT),
+      openedIdentity,
+      NEVER_ABORTED,
+      VERIFIED_READ_CONTEXT,
+    );
+    if (
+      !(await verifyParentChain(
+        root,
+        relativePath,
+        NEVER_ABORTED,
+        VERIFIED_READ_CONTEXT,
+      ))
+    ) {
+      return noteRejection(observer, "ancestor_changed", requestedPath);
+    }
+    let rawContent: string;
+    try {
+      rawContent = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      // Substituting U+FFFD would hand the client a body that is not the
+      // file, and would let invalid bytes reshape frontmatter. Fail instead,
+      // the way the in-process instruction reader does.
+      return noteRejection(observer, "invalid_utf8", requestedPath);
+    }
+    return {
+      canonicalPath: canonicalRelativePath(root, relativePath),
+      rawContent,
+    };
+  } catch (error) {
+    return noteRejection(
+      observer,
+      error instanceof UnsupportedVerifiedReadPlatformError
+        ? "platform_unsupported"
+        : "verification_failed",
+      requestedPath,
+    );
   } finally {
-    if (handle !== undefined) await handle.close().catch(() => undefined);
+    if (handle !== null) await handle.close().catch(() => undefined);
   }
+}
+
+interface SkillCandidate {
+  readonly name: string;
+  readonly relativePath: string;
+}
+
+function skillCandidate(entry: {
+  name: string;
+  isDirectory: () => boolean;
+}): SkillCandidate | null {
+  if (entry.isDirectory()) {
+    return { name: entry.name, relativePath: join(entry.name, "SKILL.md") };
+  }
+  if (entry.name.endsWith(".md")) {
+    return {
+      name: entry.name.slice(0, -".md".length),
+      relativePath: entry.name,
+    };
+  }
+  return null;
 }
 
 async function discoverSkills(
@@ -263,48 +455,57 @@ async function discoverSkills(
   const skills = new Map<string, DiscoveredSkill>();
   const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
   if (options.scopeRoot !== undefined && scopeRoot === null) return skills;
-  for (const root of options.skillRoots) {
-    let entries;
+  for (const skillRoot of options.skillRoots) {
+    const root = await bindScopedRoot(skillRoot, scopeRoot, options);
+    if (root === null) continue;
     try {
-      entries = await readdir(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      const candidate = entry.isDirectory()
-        ? { name: entry.name, filePath: join(root, entry.name, "SKILL.md") }
-        : entry.name.endsWith(".md")
-          ? {
-              name: entry.name.slice(0, -".md".length),
-              filePath: join(root, entry.name),
-            }
-          : null;
-      if (candidate === null || skills.has(candidate.name)) continue;
-      const file = await readScopedRegularFile(candidate.filePath, scopeRoot, {
-        beforeOpenForTesting: options.beforeOpenForTesting,
-        beforeReadForTesting: options.beforeReadForTesting,
-      });
-      if (file === null) continue;
-      const { frontmatter } = parseFrontmatter(
-        file.rawContent,
-        file.canonicalPath,
-      );
-      if (parseBooleanFrontmatter(frontmatter["disable-model-invocation"])) {
+      let entries;
+      try {
+        entries = await readdir(
+          descriptorHandlePath(
+            root.handle,
+            root.binding.requestedPath,
+            VERIFIED_READ_CONTEXT,
+          ),
+          { withFileTypes: true },
+        );
+      } catch {
         continue;
       }
-      skills.set(candidate.name, {
-        name: candidate.name,
-        filePath: file.canonicalPath,
-        description:
-          typeof frontmatter.description === "string"
-            ? frontmatter.description
-            : `Skill: ${candidate.name}`,
-        argumentHint:
-          frontmatter["argument-hint"] != null
-            ? String(frontmatter["argument-hint"])
-            : undefined,
-        rawContent: file.rawContent,
-      });
+      for (const entry of entries) {
+        const candidate = skillCandidate(entry);
+        if (candidate === null || skills.has(candidate.name)) continue;
+        const file = await readScopedRegularFile(
+          root,
+          candidate.relativePath,
+          MAX_SCOPED_FILE_BYTES,
+          options,
+          options,
+        );
+        if (file === null) continue;
+        const { frontmatter } = parseFrontmatter(
+          file.rawContent,
+          file.canonicalPath,
+        );
+        if (parseBooleanFrontmatter(frontmatter["disable-model-invocation"])) {
+          continue;
+        }
+        skills.set(candidate.name, {
+          name: candidate.name,
+          filePath: file.canonicalPath,
+          description:
+            typeof frontmatter.description === "string"
+              ? frontmatter.description
+              : `Skill: ${candidate.name}`,
+          argumentHint:
+            frontmatter["argument-hint"] != null
+              ? String(frontmatter["argument-hint"])
+              : undefined,
+          rawContent: file.rawContent,
+        });
+      }
+    } finally {
+      await releaseScopedRoot(root);
     }
   }
   return skills;
@@ -336,10 +537,7 @@ export function createSkillPromptProvider(
       const skills = await discoverSkills(options);
       const skill = skills.get(name);
       if (skill === undefined) return null;
-      const { content } = parseFrontmatter(
-        skill.rawContent,
-        skill.filePath,
-      );
+      const { content } = parseFrontmatter(skill.rawContent, skill.filePath);
       const argumentText = args?.arguments ?? "";
       const text = content.includes("$ARGUMENTS")
         ? content.replaceAll("$ARGUMENTS", argumentText)
@@ -354,19 +552,17 @@ export function createSkillPromptProvider(
   };
 }
 
-export interface MemoryResourceProviderOptions {
+export interface MemoryResourceProviderOptions
+  extends ScopedRegularFileTestHooks,
+    ScopedReadObserverOptions {
   /** Memory directories scanned with the runtime's memory scanner. */
   readonly memoryDirs: readonly string[];
   /** Explicit instruction files (AGENC.md tiers). Listed only if they exist. */
   readonly instructionFiles?: readonly string[];
-  /** Canonical containment root; candidates resolving outside it are omitted. */
+  /** Containment root; a directory resolving outside it contributes nothing. */
   readonly scopeRoot?: string;
   /** Captured config home used to exclude private session files. */
   readonly configHomeDir?: string;
-  /** @internal Test seam: candidate swap point after validation. */
-  readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
-  /** @internal Test seam: candidate swap point after the verified open. */
-  readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
 }
 
 const MEMORY_URI_SCHEME = "agenc-memory://";
@@ -374,7 +570,10 @@ const INSTRUCTIONS_URI_SCHEME = "agenc-instructions://";
 
 interface ListedResource {
   readonly definition: McpResourceDefinition;
-  readonly filePath: string;
+  /** Directory the body must be read from, and the name below it. */
+  readonly rootDir: string;
+  readonly relativePath: string;
+  readonly maximumBytes: number;
 }
 
 async function listMemoryResources(
@@ -384,63 +583,97 @@ async function listMemoryResources(
   const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
   if (options.scopeRoot !== undefined && scopeRoot === null) return resources;
   for (const [dirIndex, dir] of options.memoryDirs.entries()) {
-    const headers = await scanMemoryFiles(dir);
-    for (const header of headers) {
-      // Session memory/transcripts are excluded outright — same boundary
-      // the permission layer enforces for in-process reads.
-      if (detectSessionFileType(header.filePath, options.configHomeDir) !== null) continue;
-      const resolution = await resolveScopedRegularFile(
-        header.filePath,
-        scopeRoot,
+    const root = await bindScopedRoot(dir, scopeRoot, options);
+    if (root === null) continue;
+    try {
+      const headers = await scanMemoryFiles(dir);
+      for (const header of headers) {
+        // Session memory/transcripts are excluded outright — same boundary
+        // the permission layer enforces for in-process reads.
+        if (
+          detectSessionFileType(header.filePath, options.configHomeDir) !== null
+        ) {
+          continue;
+        }
+        const admitted = await admitScopedCandidate(
+          root,
+          header.relativePath,
+          MAX_SCOPED_FILE_BYTES,
+          options,
+        );
+        if (admitted === null) continue;
+        const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${header.filename}`;
+        resources.set(uri, {
+          definition: {
+            uri,
+            name: header.filename,
+            ...(header.description !== null
+              ? { description: header.description }
+              : {}),
+            mimeType: "text/markdown",
+          },
+          rootDir: dir,
+          relativePath: header.relativePath,
+          maximumBytes: MAX_SCOPED_FILE_BYTES,
+        });
+      }
+      const entrypoint = await admitScopedCandidate(
+        root,
+        "MEMORY.md",
+        MAX_SCOPED_FILE_BYTES,
+        options,
       );
-      if (resolution === null) continue;
-      const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${header.filename}`;
-      resources.set(uri, {
-        definition: {
-          uri,
-          name: header.filename,
-          ...(header.description !== null
-            ? { description: header.description }
-            : {}),
-          mimeType: "text/markdown",
-        },
-        filePath: resolution.canonicalPath,
-      });
-    }
-    const entrypoint = join(dir, "MEMORY.md");
-    const entrypointResolution = await resolveScopedRegularFile(
-      entrypoint,
-      scopeRoot,
-    );
-    if (entrypointResolution !== null) {
-      const uri = `${MEMORY_URI_SCHEME}${dirIndex}/MEMORY.md`;
-      resources.set(uri, {
-        definition: {
-          uri,
-          name: "MEMORY.md",
-          description: "Memory index",
-          mimeType: "text/markdown",
-        },
-        filePath: entrypointResolution.canonicalPath,
-      });
+      if (entrypoint !== null) {
+        const uri = `${MEMORY_URI_SCHEME}${dirIndex}/MEMORY.md`;
+        resources.set(uri, {
+          definition: {
+            uri,
+            name: "MEMORY.md",
+            description: "Memory index",
+            mimeType: "text/markdown",
+          },
+          rootDir: dir,
+          relativePath: "MEMORY.md",
+          maximumBytes: MAX_SCOPED_FILE_BYTES,
+        });
+      }
+    } finally {
+      await releaseScopedRoot(root);
     }
   }
   for (const [fileIndex, filePath] of (
     options.instructionFiles ?? []
   ).entries()) {
-    const resolution = await resolveScopedRegularFile(filePath, scopeRoot);
-    if (resolution === null) continue;
-    if (detectSessionFileType(filePath, options.configHomeDir) !== null) continue;
-    const uri = `${INSTRUCTIONS_URI_SCHEME}${fileIndex}/${basename(filePath)}`;
-    resources.set(uri, {
-      definition: {
-        uri,
-        name: basename(filePath),
-        description: `Project instructions (${filePath})`,
-        mimeType: "text/markdown",
-      },
-      filePath: resolution.canonicalPath,
-    });
+    if (detectSessionFileType(filePath, options.configHomeDir) !== null) {
+      continue;
+    }
+    const requestedPath = resolve(filePath);
+    const parentDir = dirname(requestedPath);
+    const root = await bindScopedRoot(parentDir, scopeRoot, options);
+    if (root === null) continue;
+    try {
+      const admitted = await admitScopedCandidate(
+        root,
+        basename(requestedPath),
+        MAX_SCOPED_INSTRUCTION_FILE_BYTES,
+        options,
+      );
+      if (admitted === null) continue;
+      const uri = `${INSTRUCTIONS_URI_SCHEME}${fileIndex}/${basename(filePath)}`;
+      resources.set(uri, {
+        definition: {
+          uri,
+          name: basename(filePath),
+          description: `Project instructions (${filePath})`,
+          mimeType: "text/markdown",
+        },
+        rootDir: parentDir,
+        relativePath: basename(requestedPath),
+        maximumBytes: MAX_SCOPED_INSTRUCTION_FILE_BYTES,
+      });
+    } finally {
+      await releaseScopedRoot(root);
+    }
   }
   return resources;
 }
@@ -461,10 +694,20 @@ export function createMemoryResourceProvider(
       if (resource === undefined) return null;
       const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
       if (options.scopeRoot !== undefined && scopeRoot === null) return null;
-      const file = await readScopedRegularFile(resource.filePath, scopeRoot, {
-        beforeOpenForTesting: options.beforeOpenForTesting,
-        beforeReadForTesting: options.beforeReadForTesting,
-      });
+      const root = await bindScopedRoot(resource.rootDir, scopeRoot, options);
+      if (root === null) return null;
+      let file: ScopedFileBody | null;
+      try {
+        file = await readScopedRegularFile(
+          root,
+          resource.relativePath,
+          resource.maximumBytes,
+          options,
+          options,
+        );
+      } finally {
+        await releaseScopedRoot(root);
+      }
       if (file === null) return null;
       return {
         contents: [

--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -32,7 +32,19 @@
  * ancestor between them so the identity check lands on an out-of-scope inode
  * while the containment check lands on an in-scope name. The two proofs then
  * describe different files and out-of-scope bytes are served under an in-scope
- * path. Nothing here resolves a candidate pathname twice.
+ * path.
+ *
+ * There is exactly one second resolution left, and it is quarantined. Memory
+ * listings discover candidates with `scanMemoryFiles`, which binds the memory
+ * directory itself, so flipping that directory's parent while the scan runs
+ * lands the scan on an out-of-scope tree. Its output is therefore treated as
+ * an untrusted list of candidate NAMES and nothing else: a name is only ever
+ * used relative to the retained handle, where admission and the read reject it
+ * if it does not resolve to an admissible file inside the bound root, and
+ * every field this module then serves for that candidate — description and
+ * body alike — comes from a read made through that handle. Before that,
+ * `resources/list` copied the scan's description verbatim and could advertise
+ * an in-scope URI carrying an out-of-scope file's frontmatter.
  *
  * Platform: the shared primitives need a descriptor-path mechanism
  * (`/proc/self/fd` on linux; an identity comparison on darwin and freebsd).
@@ -126,10 +138,16 @@ export interface ScopedReadRejection {
  * tests replace the candidate at each filesystem I/O boundary.
  */
 export interface ScopedRegularFileTestHooks {
-  /** Fires after admission, before the verified open. */
+  /** Fires after admission, before the verified open of a BODY read. */
   readonly beforeOpenForTesting?: (path: string) => void | Promise<void>;
-  /** Fires after the verified open, before the bounded read. */
+  /** Fires after the verified open, before the bounded BODY read. */
   readonly beforeReadForTesting?: (path: string) => void | Promise<void>;
+  /**
+   * Fires after the verified open of a listing's bounded frontmatter read,
+   * before its bytes are taken. Kept separate from the body seams so a test
+   * can tell a listing's metadata read from a `resources/read`.
+   */
+  readonly beforeHeaderReadForTesting?: (path: string) => void | Promise<void>;
 }
 
 /**
@@ -201,14 +219,28 @@ function isSameOrChildPath(scopeRoot: string, candidate: string): boolean {
   return offset === "" || (!offset.startsWith("..") && !isAbsolute(offset));
 }
 
-/** One admission contract for listing and reading: regular, unlinked-again, bounded. */
+/**
+ * One admission contract for listing and reading: regular, unlinked-again,
+ * bounded.
+ *
+ * There is no symlink clause here and there never needs to be: every caller
+ * passes stats from `lstat` or from `fstat` on an already-open handle, and
+ * `isFile()` is false for a symlink in both. A `!isSymbolicLink()` clause did
+ * sit here, and it was dead code — no input could reach it with `isFile()`
+ * true — so it is gone rather than left to read like a guard. Final-component
+ * symlinks are refused by `O_NOFOLLOW` and by the explicit `isSymbolicLink()`
+ * check in `openVerifiedCandidate`, which are reachable.
+ *
+ * `nlink === 1n` is checked here, in `openVerifiedCandidate`, and again on the
+ * opened handle in `readScopedRegularFile`. No one of those three is killable
+ * on its own; they are pinned collectively.
+ */
 function admitsScopedSnapshot(
   stats: BigIntStats,
   maximumBytes: number,
 ): boolean {
   return (
     stats.isFile() &&
-    !stats.isSymbolicLink() &&
     stats.nlink === 1n &&
     stats.size <= BigInt(maximumBytes)
   );
@@ -428,6 +460,131 @@ async function readScopedRegularFile(
   }
 }
 
+/**
+ * Byte ceiling for the frontmatter prefix a memory listing reads.
+ *
+ * A description lives in frontmatter, and `resources/list` runs on every
+ * request, so the listing must not pull whole bodies into memory to find one
+ * field. 8 KiB is comfortably past any frontmatter block and two orders of
+ * magnitude below the body ceiling.
+ */
+const MAX_SCOPED_HEADER_BYTES = 8_192;
+
+/** Decode a possibly-truncated UTF-8 prefix, or `null` if it cannot be. */
+function decodeScopedPrefix(bytes: Buffer, truncated: boolean): string | null {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  // A prefix can end mid-sequence; a UTF-8 sequence is at most 4 bytes, so at
+  // most 3 trailing bytes may be dropped. Nothing else is tolerated: the
+  // decode stays fatal, so invalid bytes cannot reshape frontmatter.
+  const minimumEnd = truncated ? Math.max(0, bytes.byteLength - 3) : bytes.byteLength;
+  for (let end = bytes.byteLength; end >= minimumEnd; end -= 1) {
+    try {
+      return decoder.decode(bytes.subarray(0, end));
+    } catch {
+      // Try one byte fewer.
+    }
+  }
+  return null;
+}
+
+/**
+ * Derive a listed memory resource's description from a read bound to the very
+ * root handle its admission was proven against.
+ *
+ * This is the listing half of #1794. The description used to be copied
+ * verbatim out of `scanMemoryFiles`, which resolves the memory directory a
+ * second time and independently; flipping that directory's PARENT while the
+ * scan ran bound the scan to an out-of-scope tree, and `resources/list` then
+ * advertised an in-scope URI whose description exists only in an out-of-scope
+ * file's frontmatter. Measured against the module before this change, with no
+ * test seams, that leaked on 14 of 253,480 listings. Reading the field here
+ * instead means the listing can only describe a file the retained handle
+ * proved is inside the scope root.
+ */
+async function readScopedFrontmatterDescription(
+  root: VerifiedRoot,
+  relativePath: string,
+  admitted: FileIdentity,
+  hooks: ScopedRegularFileTestHooks,
+  observer: ScopedReadObserverOptions,
+): Promise<string | null> {
+  const requestedPath = join(root.binding.requestedPath, relativePath);
+  let handle: FileHandle | null = null;
+  try {
+    handle = await openVerifiedCandidate(
+      root,
+      relativePath,
+      NEVER_ABORTED,
+      VERIFIED_READ_CONTEXT,
+    );
+    if (handle === null) {
+      return noteRejection(observer, "verification_failed", requestedPath);
+    }
+    const opened = await handle.stat({ bigint: true });
+    const openedIdentity = identityFromStats(opened);
+    // The opened object must be the one admission proved, or the description
+    // would describe a file this listing never admitted.
+    if (!sameStats(admitted, openedIdentity)) {
+      return noteRejection(observer, "verification_failed", requestedPath);
+    }
+    await hooks.beforeHeaderReadForTesting?.(requestedPath);
+    const limit = Math.min(MAX_SCOPED_HEADER_BYTES, Number(opened.size));
+    const buffer = Buffer.allocUnsafe(limit);
+    let length = 0;
+    while (length < limit) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        length,
+        limit - length,
+        length,
+      );
+      if (bytesRead === 0) break;
+      length += bytesRead;
+    }
+    await assertCandidateUnchanged(
+      handle,
+      descriptorRelativePath(root, relativePath, VERIFIED_READ_CONTEXT),
+      openedIdentity,
+      NEVER_ABORTED,
+      VERIFIED_READ_CONTEXT,
+    );
+    if (
+      !(await verifyParentChain(
+        root,
+        relativePath,
+        NEVER_ABORTED,
+        VERIFIED_READ_CONTEXT,
+      ))
+    ) {
+      return noteRejection(observer, "ancestor_changed", requestedPath);
+    }
+    const text = decodeScopedPrefix(
+      buffer.subarray(0, length),
+      Number(opened.size) > limit,
+    );
+    if (text === null) {
+      return noteRejection(observer, "invalid_utf8", requestedPath);
+    }
+    const { frontmatter } = parseFrontmatter(
+      text,
+      canonicalRelativePath(root, relativePath),
+    );
+    return typeof frontmatter.description === "string"
+      ? frontmatter.description
+      : null;
+  } catch (error) {
+    return noteRejection(
+      observer,
+      error instanceof UnsupportedVerifiedReadPlatformError
+        ? "platform_unsupported"
+        : "verification_failed",
+      requestedPath,
+    );
+  } finally {
+    if (handle !== null) await handle.close().catch(() => undefined);
+  }
+}
+
 interface SkillCandidate {
   readonly name: string;
   readonly relativePath: string;
@@ -563,6 +720,14 @@ export interface MemoryResourceProviderOptions
   readonly scopeRoot?: string;
   /** Captured config home used to exclude private session files. */
   readonly configHomeDir?: string;
+  /**
+   * @internal Deterministic race seams around the memory scan, which resolves
+   * the memory directory independently of the retained root handle. A test
+   * flips an ancestor between them to prove the listing trusts nothing the
+   * scan reports about a candidate.
+   */
+  readonly beforeMemoryScanForTesting?: (dir: string) => void | Promise<void>;
+  readonly afterMemoryScanForTesting?: (dir: string) => void | Promise<void>;
 }
 
 const MEMORY_URI_SCHEME = "agenc-memory://";
@@ -586,34 +751,47 @@ async function listMemoryResources(
     const root = await bindScopedRoot(dir, scopeRoot, options);
     if (root === null) continue;
     try {
-      const headers = await scanMemoryFiles(dir);
-      for (const header of headers) {
+      await options.beforeMemoryScanForTesting?.(dir);
+      // The scan binds `dir` itself, so an ancestor flip while it runs lands
+      // it on an out-of-scope tree. Take names from it; take nothing else.
+      const scanned = await scanMemoryFiles(dir);
+      await options.afterMemoryScanForTesting?.(dir);
+      for (const header of scanned) {
+        const { relativePath } = header;
+        const requestedPath = join(root.binding.requestedPath, relativePath);
         // Session memory/transcripts are excluded outright — same boundary
-        // the permission layer enforces for in-process reads.
+        // the permission layer enforces for in-process reads. The path tested
+        // is the candidate's path below the bound root, not the one the scan
+        // reported for it.
         if (
-          detectSessionFileType(header.filePath, options.configHomeDir) !== null
+          detectSessionFileType(requestedPath, options.configHomeDir) !== null
         ) {
           continue;
         }
         const admitted = await admitScopedCandidate(
           root,
-          header.relativePath,
+          relativePath,
           MAX_SCOPED_FILE_BYTES,
           options,
         );
         if (admitted === null) continue;
-        const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${header.filename}`;
+        const description = await readScopedFrontmatterDescription(
+          root,
+          relativePath,
+          admitted,
+          options,
+          options,
+        );
+        const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${relativePath}`;
         resources.set(uri, {
           definition: {
             uri,
-            name: header.filename,
-            ...(header.description !== null
-              ? { description: header.description }
-              : {}),
+            name: relativePath,
+            ...(description !== null ? { description } : {}),
             mimeType: "text/markdown",
           },
           rootDir: dir,
-          relativePath: header.relativePath,
+          relativePath,
           maximumBytes: MAX_SCOPED_FILE_BYTES,
         });
       }

--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -35,7 +35,7 @@
  * path.
  *
  * There is exactly one second resolution left, and it is quarantined. Memory
- * listings discover candidates with `scanMemoryFiles`, which binds the memory
+ * listings discover candidates with the memory scanner, which binds the memory
  * directory itself, so flipping that directory's parent while the scan runs
  * lands the scan on an out-of-scope tree. Its output is therefore treated as
  * an untrusted list of candidate NAMES and nothing else: a name is only ever
@@ -45,6 +45,26 @@
  * body alike — comes from a read made through that handle. Before that,
  * `resources/list` copied the scan's description verbatim and could advertise
  * an in-scope URI carrying an out-of-scope file's frontmatter.
+ *
+ * What that costs, measured on this machine with 200 memory files present,
+ * as the median of 40 requests, the three heads run back to back twice:
+ *
+ *   surface           no description read   description read   this module
+ *   `resources/list`   59.36 / 67.30ms      100.09 / 104.97ms  103.01 / 107.12ms
+ *   `resources/read`   60.47 / 74.91ms      100.51 / 106.43ms   63.13 /  63.78ms
+ *
+ * The listing pays about 70% for the fix and keeps paying: every listed
+ * memory file is admitted through the retained handle and then opened again
+ * for a bounded frontmatter prefix, and the second observation is the whole
+ * point — the identity admission recorded is exactly what the description
+ * read is proven against, so folding the two into one open would delete the
+ * guard rather than optimise it. That is accepted deliberately:
+ * `resources/list` is one request, the extra read is capped at 8 KiB per
+ * file, and the alternative is advertising descriptions that came from a
+ * directory nobody proved. `resources/read` used to pay the same 70% for
+ * nothing — it rebuilds the listing only to bound the client's URI and then
+ * discards the descriptions — so it now asks for the map without them and is
+ * back to what it cost before this fix existed.
  *
  * Platform: the shared primitives need a descriptor-path mechanism
  * (`/proc/self/fd` on linux; an identity comparison on darwin and freebsd).
@@ -82,7 +102,7 @@ import {
 } from "../../fs/verified-read.js";
 import {
   detectSessionFileType,
-  scanMemoryFiles,
+  scanMemoryRoots,
 } from "../../memory/index.js";
 import { MAX_SECURE_PROJECT_FILE_BYTES } from "../../prompts/secure-instruction-file.js";
 import { redactSecrets } from "../../secrets/sanitizer.js";
@@ -148,6 +168,18 @@ export interface ScopedRegularFileTestHooks {
    * can tell a listing's metadata read from a `resources/read`.
    */
   readonly beforeHeaderReadForTesting?: (path: string) => void | Promise<void>;
+  /**
+   * Fires after a listing candidate is admitted, before the verified open of
+   * its frontmatter read. This is the window the description path's
+   * `sameStats(admitted, openedIdentity)` closes: a candidate exchanged here
+   * opens and verifies perfectly on its own terms, and only the comparison
+   * against the admitted identity notices that the listing is about to
+   * describe a file it never admitted. `beforeOpenForTesting` is the same
+   * window on the body path.
+   */
+  readonly beforeDescriptionOpenForTesting?: (
+    path: string,
+  ) => void | Promise<void>;
 }
 
 /**
@@ -231,9 +263,15 @@ function isSameOrChildPath(scopeRoot: string, candidate: string): boolean {
  * symlinks are refused by `O_NOFOLLOW` and by the explicit `isSymbolicLink()`
  * check in `openVerifiedCandidate`, which are reachable.
  *
- * `nlink === 1n` is checked here, in `openVerifiedCandidate`, and again on the
- * opened handle in `readScopedRegularFile`. No one of those three is killable
- * on its own; they are pinned collectively.
+ * `nlink === 1n` is TWO source clauses reached from THREE call sites: this
+ * one, used by `admitScopedCandidate` when listing and again on the opened
+ * handle in `readScopedRegularFile`, and a separate clause in
+ * `openVerifiedCandidate`. Deleting either clause alone leaves the suite
+ * green; they are pinned collectively. The memory listing has a fourth,
+ * earlier check that this module does not own: the memory scanner refuses a
+ * multiply linked candidate before a name ever reaches here, which is why the
+ * multiply-linked MEMORY test stays green when both clauses above are
+ * deleted and only the multiply-linked SKILL test fails.
  */
 function admitsScopedSnapshot(
   stats: BigIntStats,
@@ -492,14 +530,25 @@ function decodeScopedPrefix(bytes: Buffer, truncated: boolean): string | null {
  * root handle its admission was proven against.
  *
  * This is the listing half of #1794. The description used to be copied
- * verbatim out of `scanMemoryFiles`, which resolves the memory directory a
+ * verbatim out of the memory scanner, which resolves the memory directory a
  * second time and independently; flipping that directory's PARENT while the
  * scan ran bound the scan to an out-of-scope tree, and `resources/list` then
  * advertised an in-scope URI whose description exists only in an out-of-scope
- * file's frontmatter. Measured against the module before this change, with no
- * test seams, that leaked on 14 of 253,480 listings. Reading the field here
- * instead means the listing can only describe a file the retained handle
- * proved is inside the scope root.
+ * file's frontmatter.
+ *
+ * That leak is comfortably reproducible free-running, and an earlier note
+ * here that called the window too narrow to hit was a tuning artifact of a
+ * symmetric duty cycle. The attacker has to hold the flip ON for the whole
+ * scan and OFF across the provider's own bind and admission, which is
+ * asymmetric: at ON 700us / OFF 250us against the pre-fix module (ffa7aed91),
+ * with the attacker in a separate process and no test seams, 330 of 330
+ * served listings carried the out-of-scope description across 45,019
+ * attempts. Re-run against this module at the same tuning: 399 served of
+ * 88,077, 0 forged; and at ON 700us / OFF 2500us, where the listing succeeds
+ * most of the time, 14,441 served of 43,261, 0 forged.
+ *
+ * Reading the field here means the listing can only describe a file the
+ * retained handle proved is inside the scope root.
  */
 async function readScopedFrontmatterDescription(
   root: VerifiedRoot,
@@ -511,6 +560,7 @@ async function readScopedFrontmatterDescription(
   const requestedPath = join(root.binding.requestedPath, relativePath);
   let handle: FileHandle | null = null;
   try {
+    await hooks.beforeDescriptionOpenForTesting?.(requestedPath);
     handle = await openVerifiedCandidate(
       root,
       relativePath,
@@ -728,6 +778,14 @@ export interface MemoryResourceProviderOptions
    */
   readonly beforeMemoryScanForTesting?: (dir: string) => void | Promise<void>;
   readonly afterMemoryScanForTesting?: (dir: string) => void | Promise<void>;
+  /**
+   * @internal Fires INSIDE the scan, after one directory's entries have been
+   * enumerated and before the scan re-proves that directory against the
+   * identity it bound. Nothing else can write there: the two seams above
+   * both fire outside the scan, so a write at either of them is not a write
+   * during the scan and cannot show whether the scan survives one.
+   */
+  readonly duringMemoryScanForTesting?: (path: string) => void | Promise<void>;
 }
 
 const MEMORY_URI_SCHEME = "agenc-memory://";
@@ -741,8 +799,23 @@ interface ListedResource {
   readonly maximumBytes: number;
 }
 
+/**
+ * Build the URI -> candidate map a memory listing serves.
+ *
+ * `describe` is a COST switch, never a security one. Every candidate is
+ * admitted through the retained root handle either way, so the set of URIs
+ * this returns is identical; what `describe: false` skips is the bounded
+ * frontmatter read that fills in `description`, which only `resources/list`
+ * ever serves. `resources/read` calls this purely to bound the client's URI
+ * to a candidate it just admitted and then throws the definitions away, so
+ * paying for one open plus one header read plus two re-proofs per memory file
+ * bought it nothing: with 200 memory files that was 100.51ms per read against
+ * 60.47ms before descriptions were read at all, and 63.13ms with this switch.
+ * Full table in the module header.
+ */
 async function listMemoryResources(
   options: MemoryResourceProviderOptions,
+  describe: boolean,
 ): Promise<Map<string, ListedResource>> {
   const resources = new Map<string, ListedResource>();
   const scopeRoot = await canonicalScopeRoot(options.scopeRoot);
@@ -754,7 +827,33 @@ async function listMemoryResources(
       await options.beforeMemoryScanForTesting?.(dir);
       // The scan binds `dir` itself, so an ancestor flip while it runs lands
       // it on an out-of-scope tree. Take names from it; take nothing else.
-      const scanned = await scanMemoryFiles(dir);
+      //
+      // `scanMemoryRoots` rather than `scanMemoryFiles` only so a test can
+      // reach a seam inside the enumeration; the two are otherwise the same
+      // call, and an incomplete scan yields no names here exactly as
+      // `scanMemoryFiles` yields an empty array.
+      const scan = await scanMemoryRoots([dir], NEVER_ABORTED, {
+        ...(options.duringMemoryScanForTesting !== undefined
+          ? { afterDirectoryEnumeration: options.duringMemoryScanForTesting }
+          : {}),
+      });
+      // A scan that does not complete yields NO names, so the listing silently
+      // drops every resource under this directory. That is the pre-existing
+      // failure mode and it is unchanged — `scanMemoryFiles` returns an empty
+      // array for exactly the same cases — but it used to be unobservable, and
+      // "my memory files vanished from the MCP server" with no reason
+      // anywhere is the worst way to meet it. The reason is now reported the
+      // same way every other rejection is.
+      const scanned = scan.kind === "complete" ? scan.headers : [];
+      if (scan.kind !== "complete") {
+        noteRejection(
+          options,
+          scan.kind === "unsupported"
+            ? "platform_unsupported"
+            : "root_unavailable",
+          dir,
+        );
+      }
       await options.afterMemoryScanForTesting?.(dir);
       for (const header of scanned) {
         const { relativePath } = header;
@@ -775,13 +874,15 @@ async function listMemoryResources(
           options,
         );
         if (admitted === null) continue;
-        const description = await readScopedFrontmatterDescription(
-          root,
-          relativePath,
-          admitted,
-          options,
-          options,
-        );
+        const description = describe
+          ? await readScopedFrontmatterDescription(
+              root,
+              relativePath,
+              admitted,
+              options,
+              options,
+            )
+          : null;
         const uri = `${MEMORY_URI_SCHEME}${dirIndex}/${relativePath}`;
         resources.set(uri, {
           definition: {
@@ -861,13 +962,16 @@ export function createMemoryResourceProvider(
 ): McpResourceProvider {
   return {
     async listResources(): Promise<readonly McpResourceDefinition[]> {
-      const resources = await listMemoryResources(options);
+      const resources = await listMemoryResources(options, true);
       return [...resources.values()].map((resource) => resource.definition);
     },
     async readResource(uri: string): Promise<McpReadResourceResult | null> {
       // Path bounding: only URIs from a fresh listing are readable. The
-      // client-supplied uri is a map key, never a filesystem path.
-      const resources = await listMemoryResources(options);
+      // client-supplied uri is a map key, never a filesystem path. The
+      // listing is rebuilt with descriptions off: the same admission runs and
+      // the same URIs come back, and the body below is read and re-proven
+      // through its own bound handle regardless.
+      const resources = await listMemoryResources(options, false);
       const resource = resources.get(uri);
       if (resource === undefined) return null;
       const scopeRoot = await canonicalScopeRoot(options.scopeRoot);

--- a/runtime/src/mcp/server/content-providers.ts
+++ b/runtime/src/mcp/server/content-providers.ts
@@ -373,16 +373,23 @@ async function admitScopedCandidate(
     }
     return identityFromStats(stats);
   } catch (error) {
-    return noteRejection(
-      observer,
-      error instanceof UnsupportedVerifiedReadPlatformError
-        ? "platform_unsupported"
-        : (error as NodeJS.ErrnoException).code === "ENOENT"
-          ? "not_found"
-          : "verification_failed",
-      requestedPath,
-    );
+    return noteRejection(observer, admissionFailureReason(error), requestedPath);
   }
+}
+
+/**
+ * Why an admission attempt threw: a platform with no descriptor-path
+ * mechanism, a candidate that is simply gone, or a proof that did not hold.
+ * The three cases are named here rather than nested at the call site, because
+ * `not_found` and `verification_failed` reach the observer as very different
+ * events and reading them out of a chained ternary invites confusing them.
+ */
+function admissionFailureReason(error: unknown): ScopedReadRejectionReason {
+  if (error instanceof UnsupportedVerifiedReadPlatformError) {
+    return "platform_unsupported";
+  }
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") return "not_found";
+  return "verification_failed";
 }
 
 /** Read exactly the validated byte count, plus one byte to catch growth. */

--- a/runtime/src/memory/scan.ts
+++ b/runtime/src/memory/scan.ts
@@ -15,6 +15,7 @@ import {
   identityFromStats as verifiedIdentityFromStats,
   isContained as verifiedIsContained,
   openVerifiedCandidate as openVerifiedCandidateHandle,
+  sameDirectoryIdentity as verifiedSameDirectoryIdentity,
   sameStats as verifiedSameStats,
   verifiedDirectoryOpenFlags,
   VerifiedRootUnstableError,
@@ -256,9 +257,14 @@ export async function readMemoryContent(
 }> {
   throwIfMemoryRecallAborted(signal);
   const root = await bindMemoryRoot(header.root.requestedPath, signal);
+  // The root is a DIRECTORY and this comparison spans two separate binds, so
+  // it is dev/ino/mode: any write into the memory directory between the scan
+  // and the content read moves its timestamps, and rejecting on that turned
+  // every ordinary neighbouring write into "memory root identity changed".
+  // The candidate itself keeps the full identity, two checks below.
   if (
     root === null ||
-    !sameIdentity(root.binding.identity, header.root.identity)
+    !sameDirectoryIdentity(root.binding.identity, header.root.identity)
   ) {
     if (root !== null) await closeHandle(root.handle, signal);
     throw new Error("memory root identity changed before content read");
@@ -428,11 +434,24 @@ async function assertBoundDirectoryUnchanged(
     canonicalRelativePath(root, pending.relativePath),
     signal,
   );
+  // `sameDirectoryIdentity`, not `sameStats`. `pending.identity` was taken
+  // before this directory was enumerated, and enumerating a memory directory
+  // is exactly when the workspace is likely to be writing into it: a single
+  // benign child add, remove, or rename moves this directory's `size`,
+  // `mtime`, and `ctime`, and comparing those made the whole scan fail
+  // closed. `scanMemoryFiles` swallows that failure and returns an empty
+  // list, so the MCP memory listing simply lost every resource. Measured on
+  // this machine with a separate process writing and removing one sibling
+  // file in the memory directory, and no attacker at all: the memory listing
+  // survived 113 of 76,583 attempts, 0.15%. Narrowed to dev/ino/mode, and
+  // measured back to back against that same head, 22,561 of 22,561, 100.00%.
+  // Controls: no churn 100.00%, churn in a directory outside the memory
+  // directory 100.00%.
   if (
     !opened.isDirectory() ||
     current.isSymbolicLink() ||
-    !sameStats(opened, pending.identity) ||
-    !sameStats(opened, current) ||
+    !sameDirectoryIdentity(opened, pending.identity) ||
+    !sameDirectoryIdentity(opened, current) ||
     finalPath === null ||
     !isBoundDirectoryPath(root.binding.canonicalPath, finalPath)
   ) {
@@ -477,11 +496,14 @@ async function openVerifiedDirectory(
     throwIfMemoryRecallAborted(signal);
     const current = await lstat(descriptorPath, { bigint: true });
     throwIfMemoryRecallAborted(signal);
+    // Directory identity only: see `assertBoundDirectoryUnchanged`. What this
+    // proves is that the descriptor landed on the directory whose identity was
+    // recorded when its parent enumerated it, and dev/ino/mode is that proof.
     if (
       !opened.isDirectory() ||
       opened.nlink < 1n ||
-      !sameStats(opened, pending.identity) ||
-      !sameStats(opened, current)
+      !sameDirectoryIdentity(opened, pending.identity) ||
+      !sameDirectoryIdentity(opened, current)
     ) {
       throw new MemoryScanFailure(
         "unavailable",
@@ -540,10 +562,14 @@ async function openBoundRootDirectory(
   throwIfMemoryRecallAborted(signal);
   const current = await lstat(root.binding.requestedPath, { bigint: true });
   throwIfMemoryRecallAborted(signal);
+  // Directory identity only: see `assertBoundDirectoryUnchanged`. `pending`
+  // here carries the root's own binding identity, so a full comparison
+  // required the memory directory's timestamps to stand still between the
+  // bind and the enumeration a moment later.
   if (
     !opened.isDirectory() ||
-    !sameStats(opened, pending.identity) ||
-    !sameStats(opened, current)
+    !sameDirectoryIdentity(opened, pending.identity) ||
+    !sameDirectoryIdentity(opened, current)
   ) {
     throw new MemoryScanFailure(
       "unavailable",
@@ -941,6 +967,7 @@ function checkScanBudget(budget: ScanBudget, signal: AbortSignal): void {
 const isContained = verifiedIsContained;
 const identityFromStats = verifiedIdentityFromStats;
 const sameStats = verifiedSameStats;
+const sameDirectoryIdentity = verifiedSameDirectoryIdentity;
 
 function sameIdentity(left: FileIdentity, right: FileIdentity): boolean {
   return sameStats(left, right);

--- a/runtime/src/memory/scan.ts
+++ b/runtime/src/memory/scan.ts
@@ -1,16 +1,28 @@
 import { Buffer } from "node:buffer";
-import { constants, type BigIntStats } from "node:fs";
-import {
-  lstat,
-  open,
-  opendir,
-  realpath,
-  type FileHandle,
-} from "node:fs/promises";
-import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { lstat, open, opendir, type FileHandle } from "node:fs/promises";
+import { basename, join, sep } from "node:path";
 import process from "node:process";
 import { TextDecoder } from "node:util";
 
+import {
+  assertCandidateUnchanged as assertVerifiedCandidateUnchanged,
+  bindVerifiedRoot,
+  canonicalRelativePath as verifiedCanonicalRelativePath,
+  closeVerifiedHandle,
+  descriptorHandlePath as verifiedDescriptorHandlePath,
+  descriptorRelativePath as verifiedDescriptorRelativePath,
+  finalDescriptorPath as verifiedFinalDescriptorPath,
+  identityFromStats as verifiedIdentityFromStats,
+  isContained as verifiedIsContained,
+  openVerifiedCandidate as openVerifiedCandidateHandle,
+  sameStats as verifiedSameStats,
+  verifiedDirectoryOpenFlags,
+  VerifiedRootUnstableError,
+  type FileIdentity,
+  type VerifiedReadContext,
+  type VerifiedRoot,
+  type VerifiedRootBinding,
+} from "../fs/verified-read.js";
 import { parseFrontmatter } from "../utils/frontmatterParser.js";
 import {
   MAX_C3A_CANDIDATE_FILES,
@@ -34,20 +46,9 @@ const FILE_INSPECTION_CONCURRENCY = 16;
 const FRONTMATTER_MAX_LINES = 30;
 const MAX_CONTENT_READ_BYTES = 4_096;
 
-export interface FileIdentity {
-  readonly dev: bigint;
-  readonly ino: bigint;
-  readonly mode: bigint;
-  readonly size: bigint;
-  readonly mtimeNs: bigint;
-  readonly ctimeNs: bigint;
-}
+export type { FileIdentity };
 
-export interface MemoryRootBinding {
-  readonly requestedPath: string;
-  readonly canonicalPath: string;
-  readonly identity: FileIdentity;
-}
+export type MemoryRootBinding = VerifiedRootBinding;
 
 export interface MemoryHeader {
   readonly filename: string;
@@ -93,7 +94,7 @@ interface ScanBudget {
 }
 
 interface Candidate {
-  readonly root: BoundMemoryRoot;
+  readonly root: VerifiedRoot;
   readonly relativePath: string;
   readonly filePath: string;
   readonly pathBytes: Buffer;
@@ -102,14 +103,9 @@ interface Candidate {
 }
 
 interface CandidatePath {
-  readonly root: BoundMemoryRoot;
+  readonly root: VerifiedRoot;
   readonly relativePath: string;
   readonly pathBytes: Buffer;
-}
-
-interface BoundMemoryRoot {
-  readonly binding: MemoryRootBinding;
-  readonly handle: FileHandle;
 }
 
 interface PendingDirectory {
@@ -132,6 +128,16 @@ class MemoryScanFailure extends Error {
     this.name = "MemoryScanFailure";
   }
 }
+
+/**
+ * Memory recall's flavour of the shared descriptor-bound primitives: recall
+ * cancellation, and platform gaps reported as an "unsupported" scan result.
+ */
+const MEMORY_VERIFIED_READ_CONTEXT: VerifiedReadContext = {
+  checkAborted: throwIfMemoryRecallAborted,
+  unsupportedPlatform: (message) =>
+    new MemoryScanFailure("unsupported", message),
+};
 
 export async function scanMemoryFiles(
   memoryDir: string,
@@ -156,7 +162,7 @@ export async function scanMemoryRoots(
     deadline: now() + MAX_C3A_SCAN_MS,
     now,
   };
-  const roots: BoundMemoryRoot[] = [];
+  const roots: VerifiedRoot[] = [];
 
   try {
     if (memoryDirs.length > MAX_C3A_ROOTS) {
@@ -299,72 +305,28 @@ export async function readMemoryContent(
 async function bindMemoryRoot(
   directory: string,
   signal: AbortSignal,
-): Promise<BoundMemoryRoot | null> {
-  throwIfMemoryRecallAborted(signal);
-  const requestedPath = resolve(directory);
-  let before: BigIntStats;
+): Promise<VerifiedRoot | null> {
   try {
-    before = await lstat(requestedPath, { bigint: true });
-  } catch {
-    throwIfMemoryRecallAborted(signal);
-    return null;
-  }
-  throwIfMemoryRecallAborted(signal);
-  if (before.isSymbolicLink() || !before.isDirectory()) return null;
-  let canonicalPath: string;
-  try {
-    canonicalPath = await realpath(requestedPath);
-  } catch {
-    throwIfMemoryRecallAborted(signal);
-    return null;
-  }
-  throwIfMemoryRecallAborted(signal);
-  let handle: FileHandle;
-  try {
-    handle = await open(
-      requestedPath,
-      constants.O_RDONLY |
-        (constants.O_DIRECTORY ?? 0) |
-        (constants.O_NOFOLLOW ?? 0),
+    return await bindVerifiedRoot(
+      directory,
+      signal,
+      MEMORY_VERIFIED_READ_CONTEXT,
     );
-  } catch {
-    throwIfMemoryRecallAborted(signal);
-    return null;
-  }
-  let retainHandle = false;
-  try {
-    throwIfMemoryRecallAborted(signal);
-    const opened = await handle.stat({ bigint: true });
-    throwIfMemoryRecallAborted(signal);
-    const after = await lstat(requestedPath, { bigint: true });
-    throwIfMemoryRecallAborted(signal);
-    if (
-      !opened.isDirectory() ||
-      !sameStats(before, opened) ||
-      !sameStats(opened, after)
-    ) {
-      throw new MemoryScanFailure("unavailable", "memory root changed while binding");
+  } catch (error) {
+    if (error instanceof VerifiedRootUnstableError) {
+      throw new MemoryScanFailure(
+        "unavailable",
+        error.reason === "identity"
+          ? "memory root changed while binding"
+          : "memory root final path changed",
+      );
     }
-    const finalPath = await finalDescriptorPath(handle, canonicalPath, signal);
-    if (finalPath !== canonicalPath) {
-      throw new MemoryScanFailure("unavailable", "memory root final path changed");
-    }
-    retainHandle = true;
-    return {
-      binding: {
-        requestedPath,
-        canonicalPath,
-        identity: identityFromStats(opened),
-      },
-      handle,
-    };
-  } finally {
-    if (!retainHandle) await closeHandle(handle, signal);
+    throw error;
   }
 }
 
 async function collectCandidatePaths(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   output: CandidatePath[],
   budget: ScanBudget,
   signal: AbortSignal,
@@ -449,7 +411,7 @@ async function collectCandidatePaths(
 }
 
 async function assertBoundDirectoryUnchanged(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   pending: PendingDirectory,
   handle: FileHandle,
   signal: AbortSignal,
@@ -482,7 +444,7 @@ async function assertBoundDirectoryUnchanged(
 }
 
 async function openVerifiedDirectory(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   pending: PendingDirectory,
   signal: AbortSignal,
   hooks: MemoryScanTestHooks,
@@ -501,9 +463,7 @@ async function openVerifiedDirectory(
   try {
     handle = await open(
       descriptorPath,
-      constants.O_RDONLY |
-        (constants.O_DIRECTORY ?? 0) |
-        (constants.O_NOFOLLOW ?? 0),
+      verifiedDirectoryOpenFlags(),
     );
   } catch {
     throwIfMemoryRecallAborted(signal);
@@ -571,7 +531,7 @@ async function openVerifiedDirectory(
 }
 
 async function openBoundRootDirectory(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   pending: PendingDirectory,
   signal: AbortSignal,
   hooks: MemoryScanTestHooks,
@@ -621,7 +581,7 @@ async function openBoundRootDirectory(
 }
 
 async function inspectDirectoryIdentity(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   relativePath: string,
   signal: AbortSignal,
 ): Promise<FileIdentity> {
@@ -648,7 +608,7 @@ async function inspectDirectoryIdentity(
 }
 
 async function inspectCandidate(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   relativePath: string,
   pathBytes: Buffer,
   signal: AbortSignal,
@@ -765,98 +725,15 @@ async function readMemoryHeader(
 }
 
 async function openVerifiedCandidate(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   relativePath: string,
   signal: AbortSignal,
 ): Promise<FileHandle | null> {
-  throwIfMemoryRecallAborted(signal);
-  const filePath = join(root.binding.requestedPath, relativePath);
-  if (!isContained(root.binding.requestedPath, filePath)) return null;
-  if (!(await verifyParentChain(root, relativePath, signal))) return null;
-  const descriptorPath = descriptorRelativePath(root, relativePath);
-  let pathStats: BigIntStats;
-  try {
-    pathStats = await lstat(descriptorPath, { bigint: true });
-  } catch {
-    throwIfMemoryRecallAborted(signal);
-    return null;
-  }
-  throwIfMemoryRecallAborted(signal);
-  if (pathStats.isSymbolicLink() || !pathStats.isFile()) return null;
-  let handle: FileHandle;
-  try {
-    handle = await open(
-      descriptorPath,
-      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (constants.O_NONBLOCK ?? 0),
-    );
-  } catch {
-    throwIfMemoryRecallAborted(signal);
-    return null;
-  }
-  try {
-    throwIfMemoryRecallAborted(signal);
-    const opened = await handle.stat({ bigint: true });
-    throwIfMemoryRecallAborted(signal);
-    if (!opened.isFile() || opened.nlink !== 1n || !sameStats(pathStats, opened)) {
-      await handle.close();
-      throwIfMemoryRecallAborted(signal);
-      return null;
-    }
-    const finalPath = await finalDescriptorPath(
-      handle,
-      canonicalRelativePath(root, relativePath),
-      signal,
-    );
-    if (
-      finalPath === null ||
-      !isContained(root.binding.canonicalPath, finalPath)
-    ) {
-      await handle.close();
-      throwIfMemoryRecallAborted(signal);
-      return null;
-    }
-    const finalStats = await lstat(finalPath, { bigint: true });
-    throwIfMemoryRecallAborted(signal);
-    if (!sameStats(opened, finalStats)) {
-      await handle.close();
-      throwIfMemoryRecallAborted(signal);
-      return null;
-    }
-    throwIfMemoryRecallAborted(signal);
-    return handle;
-  } catch (error) {
-    await handle.close().catch(() => undefined);
-    throwIfMemoryRecallAborted(signal);
-    throw error;
-  }
-}
-
-async function verifyParentChain(
-  root: BoundMemoryRoot,
-  relativePath: string,
-  signal: AbortSignal,
-): Promise<boolean> {
-  const segments = relativePath.split(sep);
-  let cursor = descriptorHandlePath(root.handle, root.binding.requestedPath);
-  const parentSegments = segments.slice(0, -1);
-  for (const segment of parentSegments) {
-    throwIfMemoryRecallAborted(signal);
-    cursor = join(cursor, segment);
-    const stats = await lstat(cursor, { bigint: true });
-    throwIfMemoryRecallAborted(signal);
-    if (stats.isSymbolicLink() || !stats.isDirectory()) return false;
-    const canonical = await realpath(cursor);
-    throwIfMemoryRecallAborted(signal);
-    if (!isContained(root.binding.canonicalPath, canonical)) return false;
-  }
-  const openedRoot = await root.handle.stat({ bigint: true });
-  throwIfMemoryRecallAborted(signal);
-  const currentRoot = await lstat(root.binding.requestedPath, { bigint: true });
-  throwIfMemoryRecallAborted(signal);
-  return (
-    !currentRoot.isSymbolicLink() &&
-    sameStats(openedRoot, root.binding.identity) &&
-    sameStats(currentRoot, root.binding.identity)
+  return await openVerifiedCandidateHandle(
+    root,
+    relativePath,
+    signal,
+    MEMORY_VERIFIED_READ_CONTEXT,
   );
 }
 
@@ -866,57 +743,25 @@ async function assertCandidateUnchanged(
   before: FileIdentity,
   signal: AbortSignal,
 ): Promise<void> {
-  throwIfMemoryRecallAborted(signal);
-  const openedAfter = identityFromStats(await handle.stat({ bigint: true }));
-  throwIfMemoryRecallAborted(signal);
-  const pathAfter = identityFromStats(
-    await lstat(descriptorPath, { bigint: true }),
+  await assertVerifiedCandidateUnchanged(
+    handle,
+    descriptorPath,
+    before,
+    signal,
+    MEMORY_VERIFIED_READ_CONTEXT,
   );
-  throwIfMemoryRecallAborted(signal);
-  if (!sameIdentity(before, openedAfter) || !sameIdentity(before, pathAfter)) {
-    throw new Error("memory candidate changed during descriptor-bound read");
-  }
 }
 
-/**
- * Resolve the path an open descriptor currently refers to, or `null` when it
- * can no longer be proven to sit at `expectedPath`.
- *
- * Linux exposes the live target through `/proc/self/fd/N`. darwin and freebsd
- * do not: `realpath("/dev/fd/N")` yields `/dev/fd/<basename>` instead of the
- * target, so a string comparison against the canonical path can never match
- * and every recall root used to fail closed. Those platforms instead prove the
- * descriptor identity (dev/ino/mode/size/mtime/ctime) against `expectedPath`,
- * which is the property the alias comparison was buying.
- */
 async function finalDescriptorPath(
   handle: FileHandle,
   expectedPath: string,
   signal: AbortSignal,
 ): Promise<string | null> {
-  if (process.platform === "linux") {
-    const path = await realpath(`/proc/self/fd/${handle.fd}`);
-    throwIfMemoryRecallAborted(signal);
-    return path;
-  }
-  if (process.platform === "darwin" || process.platform === "freebsd") {
-    const opened = await handle.stat({ bigint: true });
-    throwIfMemoryRecallAborted(signal);
-    let expected: BigIntStats;
-    try {
-      expected = await lstat(expectedPath, { bigint: true });
-    } catch {
-      throwIfMemoryRecallAborted(signal);
-      return null;
-    }
-    throwIfMemoryRecallAborted(signal);
-    return !expected.isSymbolicLink() && sameStats(opened, expected)
-      ? expectedPath
-      : null;
-  }
-  throw new MemoryScanFailure(
-    "unsupported",
-    "descriptor final-path verification is unavailable on this platform",
+  return await verifiedFinalDescriptorPath(
+    handle,
+    expectedPath,
+    signal,
+    MEMORY_VERIFIED_READ_CONTEXT,
   );
 }
 
@@ -1032,52 +877,37 @@ function compareMemoryHeadersByRecency(
   return Buffer.compare(left.pathBytes, right.pathBytes);
 }
 
-function portablePathBytes(root: BoundMemoryRoot, relativePath: string): Buffer {
+function portablePathBytes(root: VerifiedRoot, relativePath: string): Buffer {
   return Buffer.from(
     `${root.binding.canonicalPath.replaceAll(sep, "/")}/${relativePath.replaceAll(sep, "/")}`,
     "utf8",
   );
 }
 
-/**
- * Path used to enumerate and open entries below an already-verified
- * descriptor. Linux traverses through `/proc/self/fd/N`. On darwin and
- * freebsd `/dev/fd/N` is not traversable (`opendir` fails with ENOTDIR and
- * children resolve to ENOENT), so the real requested path is used while the
- * retained descriptor, `O_NOFOLLOW`, `nlink === 1`, and the before/after
- * identity checks continue to guard against exchanges.
- */
 function descriptorHandlePath(handle: FileHandle, requestedPath: string): string {
-  if (process.platform === "linux") return `/proc/self/fd/${handle.fd}`;
-  if (process.platform === "darwin" || process.platform === "freebsd") {
-    return requestedPath;
-  }
-  throw new MemoryScanFailure(
-    "unsupported",
-    "descriptor-relative traversal is unavailable on this platform",
+  return verifiedDescriptorHandlePath(
+    handle,
+    requestedPath,
+    MEMORY_VERIFIED_READ_CONTEXT,
   );
 }
 
 function descriptorRelativePath(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   relativePath: string,
 ): string {
-  const descriptorPath = descriptorHandlePath(
-    root.handle,
-    root.binding.requestedPath,
+  return verifiedDescriptorRelativePath(
+    root,
+    relativePath,
+    MEMORY_VERIFIED_READ_CONTEXT,
   );
-  return relativePath.length === 0
-    ? descriptorPath
-    : join(descriptorPath, relativePath);
 }
 
 function canonicalRelativePath(
-  root: BoundMemoryRoot,
+  root: VerifiedRoot,
   relativePath: string,
 ): string {
-  return relativePath.length === 0
-    ? root.binding.canonicalPath
-    : join(root.binding.canonicalPath, relativePath);
+  return verifiedCanonicalRelativePath(root, relativePath);
 }
 
 function isBoundDirectoryPath(root: string, candidate: string): boolean {
@@ -1088,8 +918,7 @@ async function closeHandle(
   handle: FileHandle,
   signal: AbortSignal,
 ): Promise<void> {
-  await handle.close().catch(() => undefined);
-  throwIfMemoryRecallAborted(signal);
+  await closeVerifiedHandle(handle, signal, MEMORY_VERIFIED_READ_CONTEXT);
 }
 
 function accountPath(pathBytes: Buffer, budget: ScanBudget): void {
@@ -1109,37 +938,9 @@ function checkScanBudget(budget: ScanBudget, signal: AbortSignal): void {
   }
 }
 
-function isContained(root: string, candidate: string): boolean {
-  const relation = relative(root, candidate);
-  return (
-    relation.length > 0 &&
-    relation !== ".." &&
-    !relation.startsWith(`..${sep}`) &&
-    !isAbsolute(relation)
-  );
-}
-
-function identityFromStats(stats: BigIntStats): FileIdentity {
-  return {
-    dev: stats.dev,
-    ino: stats.ino,
-    mode: stats.mode,
-    size: stats.size,
-    mtimeNs: stats.mtimeNs,
-    ctimeNs: stats.ctimeNs,
-  };
-}
-
-function sameStats(left: BigIntStats | FileIdentity, right: BigIntStats | FileIdentity): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mode === right.mode &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
-  );
-}
+const isContained = verifiedIsContained;
+const identityFromStats = verifiedIdentityFromStats;
+const sameStats = verifiedSameStats;
 
 function sameIdentity(left: FileIdentity, right: FileIdentity): boolean {
   return sameStats(left, right);

--- a/runtime/src/prompts/project-instructions.ts
+++ b/runtime/src/prompts/project-instructions.ts
@@ -24,6 +24,7 @@ import {
 } from "node:path";
 
 import {
+  MAX_SECURE_PROJECT_FILE_BYTES,
   type InstructionFileIdentity,
   readInstructionFileSnapshot,
 } from "./secure-instruction-file.js";
@@ -46,7 +47,6 @@ export {
  */
 const OVERRIDE_PROJECT_INSTRUCTION_FILE = "AGENC.override.md";
 const DOT_AGENC_PROJECT_INSTRUCTION_FILE = join(".agenc", "AGENC.md");
-const MAX_SECURE_PROJECT_FILE_BYTES = 5 * 1024 * 1024;
 
 /**
  * Default project-root markers used when config does not specify any.

--- a/runtime/src/prompts/secure-instruction-file.ts
+++ b/runtime/src/prompts/secure-instruction-file.ts
@@ -13,6 +13,14 @@ import { isAbsolute, relative, resolve, sep } from "node:path";
 
 import { normalizeExternalText } from "./_deps/file-read.js";
 
+/**
+ * Hard ceiling for a single secure instruction file (5 MiB).
+ *
+ * Every surface that serves the same AGENC.md must use this number, or the
+ * same file is readable in-process and silently missing elsewhere.
+ */
+export const MAX_SECURE_PROJECT_FILE_BYTES = 5 * 1024 * 1024;
+
 export type InstructionSourceClass =
   | "managed"
   | "user"

--- a/runtime/tests/fs/verified-read.test.ts
+++ b/runtime/tests/fs/verified-read.test.ts
@@ -229,8 +229,10 @@ describe("ancestor chain", () => {
    * A directory's `mtime`, `ctime`, and `size` move on every child add,
    * remove, or rename. Proving a *directory* on those fields is not
    * containment, and it cost everything: under purely benign sibling churn,
-   * with no attacker at all, the MCP skill listing was available 0.07% of the
-   * time. Containment is `dev`/`ino`/`mode`.
+   * with no attacker at all, the MCP SKILL listing was available 102 of
+   * 116,343 attempts, 0.09%. (The MCP MEMORY listing is a separate surface
+   * with its own proofs in `runtime/src/memory/scan.ts`; it measured 0.15%
+   * and is narrowed there.) Containment is `dev`/`ino`/`mode`.
    */
   test("keeps a bound root usable while its children are being written", async () => {
     const root = makeRoot();

--- a/runtime/tests/fs/verified-read.test.ts
+++ b/runtime/tests/fs/verified-read.test.ts
@@ -14,7 +14,17 @@
  *     platform with no descriptor-path mechanism.
  */
 import { constants } from "node:fs";
-import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -30,6 +40,7 @@ import {
   verifiedDirectoryOpenFlags,
   verifiedFileOpenFlags,
   verifyParentChain,
+  type VerifiedReadContext,
 } from "../../src/fs/verified-read.js";
 
 const NEVER_ABORTED = new AbortController().signal;
@@ -41,14 +52,30 @@ afterEach(() => {
 });
 
 function makeRoot(): string {
-  const dir = mkdtempSync(join(tmpdir(), "agenc-verified-read-"));
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "agenc-verified-read-")));
   dirs.push(dir);
   return dir;
 }
 
+/**
+ * A context carrying the `bindVerifiedRoot` race seam. That seam is the only
+ * way to reach the window between the root's validating `lstat`/`realpath`
+ * and the `open` that retains its descriptor: `O_NOFOLLOW` does not cover
+ * mid-path components, so an ancestor repointed in that window makes the
+ * `open` land somewhere the validation never saw.
+ */
+function seamContext(
+  hook: (requestedPath: string) => void,
+): VerifiedReadContext {
+  return { ...CONTEXT, beforeRootOpenForTesting: hook };
+}
+
 describe("open flags", () => {
+  // These two assert the flag VALUES. They perform no open, so nothing here
+  // observes `O_NOFOLLOW` or `O_DIRECTORY` actually refusing anything; the
+  // reason a behavioural test is impossible is at the top of this file.
   test.runIf(process.platform !== "win32")(
-    "a verified file open refuses to follow a final-component symlink and never blocks",
+    "the verified file open flags request O_NOFOLLOW and O_NONBLOCK",
     () => {
       const flags = verifiedFileOpenFlags();
       expect(flags & constants.O_NOFOLLOW).toBe(constants.O_NOFOLLOW);
@@ -57,7 +84,7 @@ describe("open flags", () => {
   );
 
   test.runIf(process.platform !== "win32")(
-    "a verified directory open demands a directory and refuses to follow a symlink",
+    "the verified directory open flags request O_DIRECTORY and O_NOFOLLOW",
     () => {
       const flags = verifiedDirectoryOpenFlags();
       expect(flags & constants.O_NOFOLLOW).toBe(constants.O_NOFOLLOW);
@@ -156,11 +183,35 @@ describe("ancestor chain", () => {
     }
   });
 
-  test("rejects a candidate that climbs out of the root", async () => {
-    const root = makeRoot();
-    expect(isContained(root, join(root, "..", "escape"))).toBe(false);
-    const bound = (await bindVerifiedRoot(root, NEVER_ABORTED, CONTEXT))!;
+  test("rejects a candidate that climbs out of the root to a file that exists", async () => {
+    const base = makeRoot();
+    const inner = join(base, "inner");
+    mkdirSync(inner);
+    // The escape target has to EXIST. With `../escape` absent this test passed
+    // on ENOENT: the `isContained` pre-check, the ancestor canonical
+    // containment, and the final-path containment could all be deleted at
+    // once and it stayed green while a probe with a real target returned a
+    // handle and read out-of-scope bytes.
+    const escape = join(base, "escape");
+    writeFileSync(escape, "out-of-scope body");
+    expect(existsSync(escape)).toBe(true);
+    expect(isContained(inner, join(inner, "..", "escape"))).toBe(false);
+    const bound = (await bindVerifiedRoot(inner, NEVER_ABORTED, CONTEXT))!;
     try {
+      // The ancestor walk's canonical containment is what this pins
+      // individually: delete that one clause and the walk returns true. The
+      // `isContained` pre-check in `openVerifiedCandidate` is redundant with
+      // it for every reachable escape — a relative path can only leave the
+      // root through a `..` segment, which is always a parent segment the
+      // walk sees — so it is pinned collectively, not on its own.
+      expect(
+        await verifyParentChain(
+          bound,
+          join("..", "escape"),
+          NEVER_ABORTED,
+          CONTEXT,
+        ),
+      ).toBe(false);
       expect(
         await openVerifiedCandidate(
           bound,
@@ -172,6 +223,113 @@ describe("ancestor chain", () => {
     } finally {
       await closeVerifiedHandle(bound.handle, NEVER_ABORTED, CONTEXT);
     }
+  });
+
+  /**
+   * A directory's `mtime`, `ctime`, and `size` move on every child add,
+   * remove, or rename. Proving a *directory* on those fields is not
+   * containment, and it cost everything: under purely benign sibling churn,
+   * with no attacker at all, the MCP skill listing was available 0.07% of the
+   * time. Containment is `dev`/`ino`/`mode`.
+   */
+  test("keeps a bound root usable while its children are being written", async () => {
+    const root = makeRoot();
+    const nested = join(root, "nested");
+    mkdirSync(nested);
+    writeFileSync(join(nested, "SKILL.md"), "body");
+    const bound = (await bindVerifiedRoot(root, NEVER_ABORTED, CONTEXT))!;
+    try {
+      writeFileSync(join(root, "sibling.md"), "neighbour");
+      writeFileSync(join(nested, "other.md"), "neighbour");
+      expect(
+        await verifyParentChain(
+          bound,
+          join("nested", "SKILL.md"),
+          NEVER_ABORTED,
+          CONTEXT,
+        ),
+      ).toBe(true);
+      const handle = await openVerifiedCandidate(
+        bound,
+        join("nested", "SKILL.md"),
+        NEVER_ABORTED,
+        CONTEXT,
+      );
+      expect(handle).not.toBeNull();
+      await handle!.close();
+    } finally {
+      await closeVerifiedHandle(bound.handle, NEVER_ABORTED, CONTEXT);
+    }
+  });
+});
+
+/**
+ * The window between a root's validating `lstat`/`realpath` and the `open`
+ * that retains its descriptor. Both proofs that close it are pinned here, and
+ * each test fails if *its* proof alone is deleted. They were unpinned before:
+ * with both deleted, the instruction-file reader served out-of-scope bodies
+ * under an in-scope URI (147,022 attempts, 7,985 served, 1 forged with a
+ * natural window; 15,165 / 50 / 33 with the open delayed a millisecond).
+ */
+describe("root binding across the open", () => {
+  test("rejects a root whose name leads to another directory by the time it is opened", async () => {
+    const base = makeRoot();
+    const dir = join(base, "root");
+    mkdirSync(dir);
+    const decoy = join(base, "decoy");
+    mkdirSync(decoy);
+    // Same name, same canonical path, different inode: only the
+    // before/opened/after identity proof can tell.
+    const context = seamContext((path) => {
+      if (path !== dir) return;
+      renameSync(dir, join(base, "root.away"));
+      renameSync(decoy, dir);
+    });
+    await expect(
+      bindVerifiedRoot(dir, NEVER_ABORTED, context),
+    ).rejects.toMatchObject({
+      name: "VerifiedRootUnstableError",
+      reason: "identity",
+    });
+  });
+
+  test("rejects a root whose canonical location moves before it is opened", async () => {
+    const base = makeRoot();
+    const real = join(base, "real");
+    mkdirSync(join(real, "dir"), { recursive: true });
+    symlinkSync(real, join(base, "parent"));
+    const requested = join(base, "parent", "dir");
+    // The inode behind the requested name never changes, so the identity
+    // proof passes; what moves is where that name canonically leads, which
+    // only the final-path proof compares.
+    const context = seamContext((path) => {
+      if (path !== requested) return;
+      renameSync(real, join(base, "real2"));
+      unlinkSync(join(base, "parent"));
+      symlinkSync(join(base, "real2"), join(base, "parent"));
+    });
+    await expect(
+      bindVerifiedRoot(requested, NEVER_ABORTED, context),
+    ).rejects.toMatchObject({
+      name: "VerifiedRootUnstableError",
+      reason: "final-path",
+    });
+  });
+
+  test("binds a root whose own contents change across the open", async () => {
+    const base = makeRoot();
+    const dir = join(base, "root");
+    mkdirSync(dir);
+    const context = seamContext((path) => {
+      if (path !== dir) return;
+      // A neighbouring write moves this directory's mtime and ctime between
+      // the validating lstat and the fstat of the opened handle. That is not
+      // an ancestor swap and must not fail the binding.
+      writeFileSync(join(dir, "sibling.md"), "neighbour");
+    });
+    const bound = await bindVerifiedRoot(dir, NEVER_ABORTED, context);
+    expect(bound).not.toBeNull();
+    await closeVerifiedHandle(bound!.handle, NEVER_ABORTED, CONTEXT);
   });
 });
 

--- a/runtime/tests/fs/verified-read.test.ts
+++ b/runtime/tests/fs/verified-read.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the shared descriptor-bound read primitives.
+ *
+ * Two things are pinned here that no end-to-end test can pin:
+ *
+ *   - the open flags, because `O_NOFOLLOW` has no behavioural mutant. Every
+ *     *distinct* replacement is already rejected by the identity proof around
+ *     the open, so the only case the flag alone catches is a symlink pointing
+ *     at the very inode that was admitted — and no second name for an inode
+ *     can be created without moving its ctime (hard link and rename both do),
+ *     which the identity proof then rejects. The flag is still the structural
+ *     guarantee, so it is pinned on its value.
+ *   - the fail-closed platform decision, because the CI matrix cannot run on a
+ *     platform with no descriptor-path mechanism.
+ */
+import { constants } from "node:fs";
+import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  DEFAULT_VERIFIED_READ_CONTEXT,
+  UnsupportedVerifiedReadPlatformError,
+  bindVerifiedRoot,
+  closeVerifiedHandle,
+  descriptorHandlePath,
+  isContained,
+  openVerifiedCandidate,
+  verifiedDirectoryOpenFlags,
+  verifiedFileOpenFlags,
+  verifyParentChain,
+} from "../../src/fs/verified-read.js";
+
+const NEVER_ABORTED = new AbortController().signal;
+const CONTEXT = DEFAULT_VERIFIED_READ_CONTEXT;
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenc-verified-read-"));
+  dirs.push(dir);
+  return dir;
+}
+
+describe("open flags", () => {
+  test.runIf(process.platform !== "win32")(
+    "a verified file open refuses to follow a final-component symlink and never blocks",
+    () => {
+      const flags = verifiedFileOpenFlags();
+      expect(flags & constants.O_NOFOLLOW).toBe(constants.O_NOFOLLOW);
+      expect(flags & constants.O_NONBLOCK).toBe(constants.O_NONBLOCK);
+    },
+  );
+
+  test.runIf(process.platform !== "win32")(
+    "a verified directory open demands a directory and refuses to follow a symlink",
+    () => {
+      const flags = verifiedDirectoryOpenFlags();
+      expect(flags & constants.O_NOFOLLOW).toBe(constants.O_NOFOLLOW);
+      expect(flags & constants.O_DIRECTORY).toBe(constants.O_DIRECTORY);
+    },
+  );
+});
+
+describe("root binding", () => {
+  test("binds a real directory and reports its canonical path", async () => {
+    const root = makeRoot();
+    const bound = await bindVerifiedRoot(root, NEVER_ABORTED, CONTEXT);
+    expect(bound).not.toBeNull();
+    expect(bound!.binding.canonicalPath).toBe(root);
+    await closeVerifiedHandle(bound!.handle, NEVER_ABORTED, CONTEXT);
+  });
+
+  test("refuses a root that is a symlink", async () => {
+    const root = makeRoot();
+    const target = join(root, "real");
+    mkdirSync(target);
+    symlinkSync(target, join(root, "linked"));
+    expect(
+      await bindVerifiedRoot(join(root, "linked"), NEVER_ABORTED, CONTEXT),
+    ).toBeNull();
+  });
+
+  test("refuses a root that is not a directory", async () => {
+    const root = makeRoot();
+    writeFileSync(join(root, "file"), "x");
+    expect(
+      await bindVerifiedRoot(join(root, "file"), NEVER_ABORTED, CONTEXT),
+    ).toBeNull();
+  });
+});
+
+describe("ancestor chain", () => {
+  test("rejects a candidate reached through a symlinked ancestor", async () => {
+    const root = makeRoot();
+    const real = join(root, "real");
+    mkdirSync(real);
+    writeFileSync(join(real, "SKILL.md"), "body");
+    symlinkSync("real", join(root, "linked"));
+    const bound = (await bindVerifiedRoot(root, NEVER_ABORTED, CONTEXT))!;
+    try {
+      expect(
+        await verifyParentChain(
+          bound,
+          join("real", "SKILL.md"),
+          NEVER_ABORTED,
+          CONTEXT,
+        ),
+      ).toBe(true);
+      expect(
+        await verifyParentChain(
+          bound,
+          join("linked", "SKILL.md"),
+          NEVER_ABORTED,
+          CONTEXT,
+        ),
+      ).toBe(false);
+      expect(
+        await openVerifiedCandidate(
+          bound,
+          join("linked", "SKILL.md"),
+          NEVER_ABORTED,
+          CONTEXT,
+        ),
+      ).toBeNull();
+    } finally {
+      await closeVerifiedHandle(bound.handle, NEVER_ABORTED, CONTEXT);
+    }
+  });
+
+  test("rejects every candidate once the bound root is exchanged for another directory", async () => {
+    const root = makeRoot();
+    const real = join(root, "real");
+    mkdirSync(real);
+    writeFileSync(join(real, "SKILL.md"), "body");
+    const bound = (await bindVerifiedRoot(real, NEVER_ABORTED, CONTEXT))!;
+    try {
+      expect(
+        await verifyParentChain(bound, "SKILL.md", NEVER_ABORTED, CONTEXT),
+      ).toBe(true);
+      // The name the root was bound under now leads to a different directory.
+      const decoy = join(root, "decoy");
+      mkdirSync(decoy);
+      writeFileSync(join(decoy, "SKILL.md"), "decoy");
+      renameSync(real, join(root, "real.away"));
+      renameSync(decoy, real);
+      expect(
+        await verifyParentChain(bound, "SKILL.md", NEVER_ABORTED, CONTEXT),
+      ).toBe(false);
+    } finally {
+      await closeVerifiedHandle(bound.handle, NEVER_ABORTED, CONTEXT);
+    }
+  });
+
+  test("rejects a candidate that climbs out of the root", async () => {
+    const root = makeRoot();
+    expect(isContained(root, join(root, "..", "escape"))).toBe(false);
+    const bound = (await bindVerifiedRoot(root, NEVER_ABORTED, CONTEXT))!;
+    try {
+      expect(
+        await openVerifiedCandidate(
+          bound,
+          join("..", "escape"),
+          NEVER_ABORTED,
+          CONTEXT,
+        ),
+      ).toBeNull();
+    } finally {
+      await closeVerifiedHandle(bound.handle, NEVER_ABORTED, CONTEXT);
+    }
+  });
+});
+
+describe("platform fail-closed", () => {
+  test("a platform with no descriptor-path mechanism raises instead of degrading", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", {
+      ...descriptor,
+      value: "sunos",
+    });
+    try {
+      expect(() =>
+        descriptorHandlePath(
+          { fd: 3 } as never,
+          "/workspace",
+          DEFAULT_VERIFIED_READ_CONTEXT,
+        ),
+      ).toThrow(UnsupportedVerifiedReadPlatformError);
+    } finally {
+      Object.defineProperty(process, "platform", descriptor);
+    }
+  });
+});

--- a/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
+++ b/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
@@ -458,18 +458,7 @@ describe("descriptor-bound ancestor containment", () => {
    * leads somewhere else.
    */
   test("fails a nested resource read whose directory is exchanged after the read", async () => {
-    const nested = join(root, "memory", "a", "b");
-    mkdirSync(nested, { recursive: true });
-    writeFileSync(
-      join(nested, "notes.md"),
-      ["---", "name: notes", "description: nested notes", "---", "safe body"].join("\n"),
-    );
-    const decoy = join(root, "decoy");
-    mkdirSync(decoy, { recursive: true });
-    writeFileSync(
-      join(decoy, "notes.md"),
-      ["---", "name: notes", "description: decoy", "---", "decoy body"].join("\n"),
-    );
+    const { nested, decoy } = nestedCandidateWithDecoy("decoy", "decoy body");
     const provider = resourceProvider();
     const listed = await provider.listResources();
     const target = listed.find((r) => r.name.endsWith("notes.md"))!;
@@ -622,20 +611,56 @@ describe("fatal UTF-8 decoding", () => {
  * that trips the scanner's own directory-identity checks. It is the ROOT
  * BINDING that has to be churned.
  */
+/**
+ * Memory dir at `<root>/sub/memory` with a forged twin outside the scope, so
+ * a test can point `sub` at the twin for exactly as long as it needs to.
+ * Shared by the listing-metadata suite and the description-read suite, which
+ * attack the same geometry at different seams.
+ */
+function flippableMemoryDir(): { sub: string; outside: string } {
+  const sub = join(root, "sub");
+  mkdirSync(join(sub, "memory"), { recursive: true });
+  writeFileSync(
+    join(sub, "memory", "note.md"),
+    ["---", "name: note", "description: in-scope note", "---", "in-scope body"].join("\n"),
+  );
+  const outside = makeOutsideDir();
+  mkdirSync(join(outside, "memory"), { recursive: true });
+  writeFileSync(
+    join(outside, "memory", "note.md"),
+    ["---", "name: note", `description: ${FORGED}`, "---", SECRET].join("\n"),
+  );
+  return { sub, outside };
+}
+
+/**
+ * A nested candidate at `<root>/memory/a/b/notes.md` plus a decoy directory
+ * ready to take its place. Exchanging the intermediate directory leaves the
+ * open inode untouched, which is what isolates the path side of
+ * `assertCandidateUnchanged`; the decoy's frontmatter differs per test.
+ */
+function nestedCandidateWithDecoy(
+  decoyDescription: string,
+  decoyBody: string,
+): { nested: string; decoy: string } {
+  const nested = join(root, "memory", "a", "b");
+  mkdirSync(nested, { recursive: true });
+  writeFileSync(
+    join(nested, "notes.md"),
+    ["---", "name: notes", "description: nested notes", "---", "safe body"].join("\n"),
+  );
+  const decoy = join(root, "decoy");
+  mkdirSync(decoy, { recursive: true });
+  writeFileSync(
+    join(decoy, "notes.md"),
+    ["---", "name: notes", `description: ${decoyDescription}`, "---", decoyBody].join("\n"),
+  );
+  return { nested, decoy };
+}
+
 describe("memory listing metadata", () => {
   test("does not describe an in-scope resource with an out-of-scope file's frontmatter", async () => {
-    const sub = join(root, "sub");
-    mkdirSync(join(sub, "memory"), { recursive: true });
-    writeFileSync(
-      join(sub, "memory", "note.md"),
-      ["---", "name: note", "description: in-scope note", "---", "in-scope body"].join("\n"),
-    );
-    const outside = makeOutsideDir();
-    mkdirSync(join(outside, "memory"), { recursive: true });
-    writeFileSync(
-      join(outside, "memory", "note.md"),
-      ["---", "name: note", `description: ${FORGED}`, "---", SECRET].join("\n"),
-    );
+    const { sub, outside } = flippableMemoryDir();
     const provider = resourceProvider({
       memoryDirs: [join(sub, "memory")],
       beforeMemoryScanForTesting: () => {
@@ -669,22 +694,6 @@ describe("memory listing metadata", () => {
  * written back in.
  */
 describe("scope-bound description reads", () => {
-  /** Memory dir at `<root>/sub/memory`, with a forged twin outside the scope. */
-  function flippableMemoryDir(): { sub: string; outside: string } {
-    const sub = join(root, "sub");
-    mkdirSync(join(sub, "memory"), { recursive: true });
-    writeFileSync(
-      join(sub, "memory", "note.md"),
-      ["---", "name: note", "description: in-scope note", "---", "in-scope body"].join("\n"),
-    );
-    const outside = makeOutsideDir();
-    mkdirSync(join(outside, "memory"), { recursive: true });
-    writeFileSync(
-      join(outside, "memory", "note.md"),
-      ["---", "name: note", `description: ${FORGED}`, "---", SECRET].join("\n"),
-    );
-    return { sub, outside };
-  }
 
   /**
    * GUARD: the description read going through the bound root handle at all.
@@ -803,18 +812,7 @@ describe("scope-bound description reads", () => {
    * the one that was opened sees that the name now leads somewhere else.
    */
   test("does not describe a nested candidate whose directory is exchanged", async () => {
-    const nested = join(root, "memory", "a", "b");
-    mkdirSync(nested, { recursive: true });
-    writeFileSync(
-      join(nested, "notes.md"),
-      ["---", "name: notes", "description: nested notes", "---", "safe body"].join("\n"),
-    );
-    const decoy = join(root, "decoy");
-    mkdirSync(decoy, { recursive: true });
-    writeFileSync(
-      join(decoy, "notes.md"),
-      ["---", "name: notes", `description: ${FORGED}`, "---", SECRET].join("\n"),
-    );
+    const { nested, decoy } = nestedCandidateWithDecoy(FORGED, SECRET);
     const file = join(nested, "notes.md");
     let exchanged = false;
     const provider = resourceProvider({

--- a/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
+++ b/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
@@ -1,10 +1,13 @@
 /**
- * Regression tests for issue #1794: MCP content providers must serve
- * skill prompts and resource bodies through one descriptor-bound reader.
- * A writable workspace cannot swap the candidate file or an ancestor
- * between validation and bytes: every swap lands on a hook at a real
- * filesystem I/O boundary, and each scenario must end with the candidate
- * omitted (prompts) or unreadable (resources) — never with swapped bytes.
+ * Regression tests for issue #1794: MCP content providers must serve skill
+ * prompts and resource bodies from a location proven against a retained root
+ * descriptor, never from a pathname resolved a second time.
+ *
+ * Every test here is a *mutation* test: each one is written so that deleting
+ * the single guard named in its title makes it fail. A guard whose deletion
+ * leaves the suite green is not covered, however many tests surround it. The
+ * one guard with no behavioural mutant, `O_NOFOLLOW`, is pinned on the flag
+ * value instead and the reason is written down in `tests/fs/verified-read.test.ts`.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -14,6 +17,7 @@ import {
   renameSync,
   rmSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -24,19 +28,24 @@ import { enterCanonicalSettingsAuthority } from "../../src/utils/settings/canoni
 
 import {
   MAX_SCOPED_FILE_BYTES,
+  MAX_SCOPED_INSTRUCTION_FILE_BYTES,
   createMemoryResourceProvider,
   createSkillPromptProvider,
+  type ScopedReadRejection,
 } from "../../src/mcp/server/content-providers.js";
 
 const SECRET = "PRIVATE SESSION TRANSCRIPT ak_1794_secret";
 const SECRET_TOKEN = "ghp_1794567890abcdefABCDEF1234567890abcdef";
+const FORGED = "FORGED-OUT-OF-SCOPE";
 
 const roots: string[] = [];
 let root: string;
+let rejections: ScopedReadRejection[];
 
 beforeEach(async () => {
   root = mkdtempSync(join(tmpdir(), "agenc-mcp-verified-"));
   roots.push(root);
+  rejections = [];
   vi.stubEnv("AGENC_HOME", root);
   enterCanonicalSettingsAuthority(new ConfigStore({
     home: root,
@@ -52,6 +61,10 @@ afterEach(() => {
   }
 });
 
+function reasons(): string[] {
+  return rejections.map((rejection) => rejection.reason);
+}
+
 function makeSkill(name: string, body: string): string {
   const dir = join(root, "skills", name);
   mkdirSync(dir, { recursive: true });
@@ -63,10 +76,14 @@ function makeSkill(name: string, body: string): string {
   return file;
 }
 
-function makeOutsideSecret(name: string): string {
+function makeOutsideDir(): string {
   const outside = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
   roots.push(outside);
-  const file = join(outside, name);
+  return outside;
+}
+
+function makeOutsideSecret(name: string): string {
+  const file = join(makeOutsideDir(), name);
   writeFileSync(
     file,
     ["---", `description: ${name}`, "---", SECRET, SECRET_TOKEN].join("\n"),
@@ -84,8 +101,22 @@ function makeMemoryFile(name: string, body: string): string {
   return file;
 }
 
+/**
+ * `mkfifo` is asserted here, in the test body, and never inside a reader hook:
+ * a hook throws *into* the reader's own try/catch, where the failure becomes
+ * the same `null` the test asserts on and the test passes without ever having
+ * built a FIFO.
+ */
+function makeFifo(path: string): void {
+  const result = spawnSync("mkfifo", [path]);
+  expect(result.error).toBeUndefined();
+  expect(result.status).toBe(0);
+}
+
 function skillProvider(
-  hooks: {
+  overrides: {
+    skillRoots?: readonly string[];
+    scopeRoot?: string;
     beforeOpenForTesting?: (path: string) => void;
     beforeReadForTesting?: (path: string) => void;
   } = {},
@@ -93,12 +124,16 @@ function skillProvider(
   return createSkillPromptProvider({
     skillRoots: [join(root, "skills")],
     scopeRoot: root,
-    ...hooks,
+    onRejected: (rejection) => rejections.push(rejection),
+    ...overrides,
   });
 }
 
 function resourceProvider(
-  hooks: {
+  overrides: {
+    memoryDirs?: readonly string[];
+    instructionFiles?: readonly string[];
+    scopeRoot?: string;
     beforeOpenForTesting?: (path: string) => void;
     beforeReadForTesting?: (path: string) => void;
   } = {},
@@ -106,7 +141,8 @@ function resourceProvider(
   return createMemoryResourceProvider({
     memoryDirs: [join(root, "memory")],
     scopeRoot: root,
-    ...hooks,
+    onRejected: (rejection) => rejections.push(rejection),
+    ...overrides,
   });
 }
 
@@ -137,13 +173,16 @@ describe("verified skill prompt reads", () => {
     expect(await provider.getPrompt("swapped")).toBeNull();
   });
 
-  test("omits a skill swapped for a symlink to the same inode after validation", async () => {
+  test("omits a skill swapped for a same-inode symlink: the identity proof rejects it", async () => {
     const file = makeSkill("selflink", "safe body");
     const provider = skillProvider({
       beforeOpenForTesting: (path) => {
         if (path !== file) return;
-        // The replacement symlink resolves to the very inode validation
-        // saw; only the O_NOFOLLOW open rejects it.
+        // The replacement symlink resolves to the very inode validation saw.
+        // What rejects it is the identity proof, not `O_NOFOLLOW`: creating
+        // the second name moves the inode's ctime, so the opened object no
+        // longer matches the admitted one. See tests/fs/verified-read.test.ts
+        // for why no behavioural mutant can isolate the flag.
         const alias = `${file}.same-inode`;
         linkSync(file, alias);
         rmSync(file);
@@ -168,11 +207,10 @@ describe("verified skill prompt reads", () => {
 
   test("omits a skill whose ancestor directory is swapped for a symlink after validation", async () => {
     const file = makeSkill("ancestor", "safe body");
-    const outsideDir = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
-    roots.push(outsideDir);
+    const outsideDir = makeOutsideDir();
     writeFileSync(
       join(outsideDir, "SKILL.md"),
-      ["---", "description: forged", "---", SECRET].join("\n"),
+      ["---", `description: ${FORGED}`, "---", SECRET].join("\n"),
     );
     const provider = skillProvider({
       beforeOpenForTesting: (path) => {
@@ -229,22 +267,281 @@ describe("verified skill prompt reads", () => {
     );
     const provider = skillProvider();
     expect(await provider.listPrompts()).toEqual([]);
+    expect(reasons()).toContain("too_large");
   });
 
   test.runIf(process.platform !== "win32")(
     "omits a skill replaced by a FIFO after validation without blocking",
     async () => {
       const file = makeSkill("fifod", "safe body");
+      const fifo = join(root, "skills", "fifod", "swap-in.fifo");
+      makeFifo(fifo);
       const provider = skillProvider({
         beforeOpenForTesting: (path) => {
           if (path !== file) return;
           rmSync(file);
-          expect(spawnSync("mkfifo", [file]).status).toBe(0);
+          renameSync(fifo, file);
         },
       });
       expect(await provider.listPrompts()).toEqual([]);
     },
   );
+});
+
+/**
+ * GUARD: the `scopeRoot` containment check in `bindScopedRoot`.
+ * Deleting it makes both tests below serve out-of-scope bodies.
+ */
+describe("scope-root containment", () => {
+  test("omits a skill root whose canonical path escapes the scope root", async () => {
+    const outside = makeOutsideDir();
+    const escapedSkills = join(outside, "skills");
+    mkdirSync(join(escapedSkills, "escaped"), { recursive: true });
+    writeFileSync(
+      join(escapedSkills, "escaped", "SKILL.md"),
+      ["---", `description: ${FORGED}`, "---", SECRET].join("\n"),
+    );
+    // The requested path is inside the scope root and is a real directory;
+    // only its canonical resolution is outside, because an ancestor is a
+    // symlink. Nothing about the name gives that away.
+    symlinkSync(outside, join(root, "linked"));
+    const provider = skillProvider({
+      skillRoots: [join(root, "linked", "skills")],
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+    expect(await provider.getPrompt("escaped")).toBeNull();
+    expect(reasons()).toContain("root_outside_scope");
+  });
+
+  test("omits an instruction file whose parent escapes the scope root", async () => {
+    const outside = makeOutsideDir();
+    mkdirSync(join(outside, "project"), { recursive: true });
+    writeFileSync(
+      join(outside, "project", "AGENC.md"),
+      `# escaped instructions\n${SECRET}`,
+    );
+    symlinkSync(outside, join(root, "linked"));
+    const provider = resourceProvider({
+      memoryDirs: [],
+      instructionFiles: [join(root, "linked", "project", "AGENC.md")],
+    });
+    expect(await provider.listResources()).toEqual([]);
+    expect(reasons()).toContain("root_outside_scope");
+  });
+
+  test("omits a skill root that is itself a symlink", async () => {
+    const outside = makeOutsideDir();
+    mkdirSync(join(outside, "escaped"), { recursive: true });
+    writeFileSync(
+      join(outside, "escaped", "SKILL.md"),
+      ["---", `description: ${FORGED}`, "---", SECRET].join("\n"),
+    );
+    symlinkSync(outside, join(root, "skills"));
+    const provider = skillProvider();
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+});
+
+/**
+ * GUARD: `verifyParentChain`, before the open and again after the read.
+ *
+ * Both tests replace one ancestor with a symlink that resolves to the very
+ * directory it replaced, so the candidate's inode, size, and timestamps are
+ * untouched: every identity proof still passes and only the ancestor walk can
+ * tell the difference. That is the check the escape in #1794 defeated.
+ */
+describe("descriptor-bound ancestor containment", () => {
+  function selfSymlinkAncestor(name: string): void {
+    const dir = join(root, "skills", name);
+    renameSync(dir, `${dir}.real`);
+    symlinkSync(`${name}.real`, dir);
+  }
+
+  function restoreAncestor(name: string): void {
+    const dir = join(root, "skills", name);
+    unlinkSync(dir);
+    renameSync(`${dir}.real`, dir);
+  }
+
+  test("omits a skill whose ancestor is a symlink at the open boundary", async () => {
+    const file = makeSkill("preopen", "safe body");
+    const provider = skillProvider({
+      beforeOpenForTesting: (path) => {
+        if (path !== file) return;
+        selfSymlinkAncestor("preopen");
+      },
+      beforeReadForTesting: (path) => {
+        // Restore before the post-read walk, so only the pre-open walk can
+        // reject this. Without it the same bytes are served through an
+        // unvetted ancestor.
+        if (path !== file) return;
+        restoreAncestor("preopen");
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+  });
+
+  test("omits a skill whose ancestor becomes a symlink after the bytes are read", async () => {
+    const file = makeSkill("postread", "safe body");
+    const provider = skillProvider({
+      beforeReadForTesting: (path) => {
+        if (path !== file) return;
+        selfSymlinkAncestor("postread");
+      },
+    });
+    expect(await provider.listPrompts()).toEqual([]);
+    expect(reasons()).toContain("ancestor_changed");
+  });
+
+  /**
+   * GUARD: the path side of `assertCandidateUnchanged`.
+   *
+   * Isolating it takes a nested candidate. Exchanging the *directory* that
+   * holds the file leaves the open inode completely untouched — no unlink, no
+   * ctime move — so the handle-side check passes; and because the exchanged
+   * directory is an intermediate ancestor rather than the bound root, the
+   * ancestor walk passes too: it sees a real, contained, non-symlink
+   * directory and the root's own identity has not moved. Only comparing the
+   * path's object against the one that was read notices that the name now
+   * leads somewhere else.
+   */
+  test("fails a nested resource read whose directory is exchanged after the read", async () => {
+    const nested = join(root, "memory", "a", "b");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(
+      join(nested, "notes.md"),
+      ["---", "name: notes", "description: nested notes", "---", "safe body"].join("\n"),
+    );
+    const decoy = join(root, "decoy");
+    mkdirSync(decoy, { recursive: true });
+    writeFileSync(
+      join(decoy, "notes.md"),
+      ["---", "name: notes", "description: decoy", "---", "decoy body"].join("\n"),
+    );
+    const provider = resourceProvider();
+    const listed = await provider.listResources();
+    const target = listed.find((r) => r.name.endsWith("notes.md"))!;
+    expect(target).toBeDefined();
+    const file = join(root, "memory", "a", "b", "notes.md");
+    const swapped = resourceProvider({
+      beforeReadForTesting: (path) => {
+        if (path !== file) return;
+        renameSync(nested, join(root, "b.away"));
+        renameSync(decoy, nested);
+      },
+    });
+    expect(await swapped.readResource(target.uri)).toBeNull();
+  });
+});
+
+/**
+ * GUARD: the `isFile()` clause of `admitsScopedSnapshot`.
+ *
+ * A FIFO is the case that isolates it: it is not a symlink, has one link, and
+ * has size 0, so every other clause admits it. Without `isFile()` the listing
+ * advertises a resource whose read would block or fail.
+ */
+describe("regular-file admission", () => {
+  test.runIf(process.platform !== "win32")(
+    "does not list an instruction path that is a FIFO",
+    async () => {
+      const fifo = join(root, "AGENC.md");
+      makeFifo(fifo);
+      const provider = resourceProvider({
+        memoryDirs: [],
+        instructionFiles: [fifo],
+      });
+      expect(await provider.listResources()).toEqual([]);
+      expect(reasons()).toContain("not_admissible");
+    },
+  );
+
+  test("does not list an instruction path that is a directory", async () => {
+    mkdirSync(join(root, "AGENC.md"), { recursive: true });
+    const provider = resourceProvider({
+      memoryDirs: [],
+      instructionFiles: [join(root, "AGENC.md")],
+    });
+    expect(await provider.listResources()).toEqual([]);
+  });
+});
+
+/**
+ * GUARD: the byte ceilings, and the fact that the instruction ceiling is the
+ * same number the runtime uses for the same file in-process.
+ */
+describe("byte ceilings", () => {
+  test("serves an instruction file larger than the skill ceiling", async () => {
+    const body = `# big instructions\n${"a".repeat(2 * 1024 * 1024)}`;
+    expect(body.length).toBeGreaterThan(MAX_SCOPED_FILE_BYTES);
+    expect(body.length).toBeLessThan(MAX_SCOPED_INSTRUCTION_FILE_BYTES);
+    writeFileSync(join(root, "AGENC.md"), body);
+    const provider = resourceProvider({
+      memoryDirs: [],
+      instructionFiles: [join(root, "AGENC.md")],
+    });
+    const resources = await provider.listResources();
+    expect(resources.map((r) => r.name)).toContain("AGENC.md");
+    const read = await provider.readResource(resources[0]!.uri);
+    expect(read?.contents[0].text).toContain("# big instructions");
+  });
+
+  test("omits an instruction file past the shared in-process ceiling", async () => {
+    writeFileSync(
+      join(root, "AGENC.md"),
+      Buffer.alloc(MAX_SCOPED_INSTRUCTION_FILE_BYTES + 1, 0x61),
+    );
+    const provider = resourceProvider({
+      memoryDirs: [],
+      instructionFiles: [join(root, "AGENC.md")],
+    });
+    expect(await provider.listResources()).toEqual([]);
+    expect(reasons()).toContain("too_large");
+  });
+});
+
+/**
+ * GUARD: the fatal UTF-8 decode. `Buffer#toString("utf8")` substitutes U+FFFD,
+ * which hands the client a body that is not the file and lets invalid bytes
+ * reshape frontmatter.
+ */
+describe("fatal UTF-8 decoding", () => {
+  test("omits a skill whose bytes are not valid UTF-8", async () => {
+    const dir = join(root, "skills", "binary");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      Buffer.concat([
+        Buffer.from("---\ndescription: binary\n---\n", "utf8"),
+        Buffer.from([0xff, 0xfe, 0x80]),
+      ]),
+    );
+    const provider = skillProvider();
+    expect(await provider.listPrompts()).toEqual([]);
+    expect(reasons()).toContain("invalid_utf8");
+  });
+
+  test("fails a resource read whose bytes are not valid UTF-8", async () => {
+    // The invalid bytes sit past the 64 KiB header prefix the memory scanner
+    // decodes, so the file still lists; only the full body read sees them.
+    makeMemoryFile("notes.md", "placeholder");
+    mkdirSync(join(root, "memory"), { recursive: true });
+    writeFileSync(
+      join(root, "memory", "notes.md"),
+      Buffer.concat([
+        Buffer.from(
+          `---\nname: notes\ndescription: notes.md\n---\n${"pad\n".repeat(20_000)}`,
+          "utf8",
+        ),
+        Buffer.from([0xc3, 0x28]),
+      ]),
+    );
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    const target = resources.find((r) => r.name === "notes.md")!;
+    expect(await provider.readResource(target.uri)).toBeNull();
+    expect(reasons()).toContain("invalid_utf8");
+  });
 });
 
 describe("verified memory resource reads", () => {
@@ -277,8 +574,7 @@ describe("verified memory resource reads", () => {
 
   test("does not list multiply linked memory files", async () => {
     const file = makeMemoryFile("leak.md", SECRET);
-    const outsideDir = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
-    roots.push(outsideDir);
+    const outsideDir = makeOutsideDir();
     // The memory file now also answers to a name outside the scope root.
     linkSync(file, join(outsideDir, "alias.md"));
     const provider = resourceProvider();
@@ -339,11 +635,13 @@ describe("verified memory resource reads", () => {
       const resources = await provider.listResources();
       const target = resources.find((r) => r.name === "notes.md")!;
       const file = join(root, "memory", "notes.md");
+      const fifo = join(root, "memory", "swap-in.fifo");
+      makeFifo(fifo);
       const swapped = resourceProvider({
         beforeOpenForTesting: (path) => {
           if (path !== file) return;
           rmSync(file);
-          expect(spawnSync("mkfifo", [file]).status).toBe(0);
+          renameSync(fifo, file);
         },
       });
       expect(await swapped.readResource(target.uri)).toBeNull();

--- a/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
+++ b/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
@@ -1,7 +1,8 @@
 /**
  * Regression tests for issue #1794: MCP content providers must serve skill
- * prompts and resource bodies from a location proven against a retained root
- * descriptor, never from a pathname resolved a second time.
+ * prompts, resource bodies, AND listing metadata from a location proven
+ * against a retained root descriptor, never from a pathname resolved a second
+ * time.
  *
  * Most tests here are *mutation* tests: each is written so that deleting the
  * single guard named in its title makes it fail. A guard whose deletion leaves
@@ -12,20 +13,44 @@
  *
  *   - `O_NOFOLLOW` has no behavioural mutant at all. It is pinned on the flag
  *     value in `tests/fs/verified-read.test.ts`, with the reason.
- *   - `nlink === 1n` is checked in three places (listing admission, the open
- *     in `openVerifiedCandidate`, and the opened handle in
- *     `readScopedRegularFile`). Deleting any one leaves the suite green; only
- *     deleting all three fails it. They are pinned collectively.
- *   - the root symlink pre-check in `bindVerifiedRoot` is only killable
- *     together with `O_DIRECTORY`/`O_NOFOLLOW` on the root open.
+ *   - `nlink === 1n` is two source clauses reached from three call sites
+ *     (listing admission and the opened handle in `readScopedRegularFile`
+ *     share one clause; `openVerifiedCandidate` has the other). Deleting
+ *     either clause leaves the suite green; only deleting both fails it.
+ *   - the root symlink pre-check in `bindVerifiedRoot` is not pinned by
+ *     anything behavioural, and it is not `O_DIRECTORY`/`O_NOFOLLOW` that
+ *     stands in for it: deleting `before.isSymbolicLink()` AND both directory
+ *     open flags leaves every behavioural test in this file, in
+ *     `tests/fs/verified-read.test.ts`, and in `tests/memory/scan.test.ts`
+ *     green — only the flag-VALUE test fails, and that one asserts a number,
+ *     not an open. Its real partner is `!before.isDirectory()` in the same
+ *     expression: `lstat` of a symlink reports `isDirectory()` false, so that
+ *     clause rejects a symlinked root on its own. Delete the whole expression
+ *     and "refuses a root that is a symlink" finally fails.
  *   - the `isContained` pre-check in `openVerifiedCandidate` is redundant with
  *     the ancestor walk's canonical containment for every reachable escape.
+ *   - `fatal: true` in `decodeScopedPrefix` — see the note in "scope-bound
+ *     description reads".
  *
- * Two tests here used to pass for the wrong reason and now do not: the
- * pre-open ancestor walk (see "at the open boundary") stayed green when it was
+ * Two guards live in another module and are recorded here so this file is not
+ * read as covering them: "does not list multiply linked memory files" passes
+ * because `scanMemoryFiles` refuses a multiply linked candidate before a name
+ * reaches these providers at all, not because of anything here; and the
+ * memory listing's availability under concurrent writes is decided by the
+ * directory proofs in `runtime/src/memory/scan.ts`, whose own mutation tests
+ * live in `tests/memory/scan.test.ts`.
+ *
+ * Tests that used to pass for the wrong reason and now do not: the pre-open
+ * ancestor walk (see "at the open boundary") stayed green when it was
  * deleted, because the test's own restore step moved the bound root's
- * timestamps and the POST-read walk rejected instead; and the same-inode
- * symlink test named a proof that never runs.
+ * timestamps and the POST-read walk rejected instead; the same-inode symlink
+ * test named a proof that never runs; and the memory availability test fired
+ * its write after `scanMemoryRoots` had already returned, so it passed with
+ * the scan's directory proofs left at their broken width — verified by
+ * widening them back, at which point the write at
+ * `beforeHeaderReadForTesting` and the identical write at
+ * `beforeMemoryScanForTesting` both still passed and only the write at
+ * `duringMemoryScanForTesting` failed.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -579,8 +604,17 @@ describe("fatal UTF-8 decoding", () => {
  * exactly the length of the scan lands the scan on an out-of-scope tree while
  * the provider's own bind and admission both land in scope. Deleting the
  * scope-bound read and taking `header.description` back makes this test
- * report the out-of-scope frontmatter under an in-scope URI. Measured without
- * seams against the module before this change: 14 forged listings in 253,480.
+ * report the out-of-scope frontmatter under an in-scope URI.
+ *
+ * It is not a narrow window. Free-running against the pre-fix module, with
+ * the attacker in a separate process and no seams, an ASYMMETRIC duty cycle
+ * (ON ~700us, long enough to span the whole scan; OFF ~250us, spanning the
+ * provider's own bind and admission) forged 330 of 330 served listings across
+ * 45,019 attempts. Symmetric cycles find nothing, which is what an earlier
+ * "0 across 1.9M attempts, window too narrow" note was actually measuring.
+ * The same harness against this module: 0 forged of 399 served in 88,077
+ * attempts at that tuning, and 0 of 14,441 served in 43,261 attempts at ON
+ * 700us / OFF 2500us, where the listing succeeds most of the time.
  *
  * Flipping a deeper ancestor, inside the scanned tree, does not reproduce it:
  * that trips the scanner's own directory-identity checks. It is the ROOT
@@ -621,14 +655,285 @@ describe("memory listing metadata", () => {
 });
 
 /**
+ * The description a memory listing serves is now read through the retained
+ * root handle, and the guards on that read are pinned here one at a time.
+ *
+ * The read is small — open the admitted candidate, prove it is the admitted
+ * one, take a bounded frontmatter prefix, re-prove the object and the
+ * ancestor chain — but every one of those clauses could be deleted with the
+ * whole suite green until these tests existed. The first one matters most:
+ * it fails if `readScopedFrontmatterDescription` is replaced by a plain
+ * `readFile` of the candidate's pathname, which is the original #1794 leak
+ * written back in.
+ */
+describe("scope-bound description reads", () => {
+  /** Memory dir at `<root>/sub/memory`, with a forged twin outside the scope. */
+  function flippableMemoryDir(): { sub: string; outside: string } {
+    const sub = join(root, "sub");
+    mkdirSync(join(sub, "memory"), { recursive: true });
+    writeFileSync(
+      join(sub, "memory", "note.md"),
+      ["---", "name: note", "description: in-scope note", "---", "in-scope body"].join("\n"),
+    );
+    const outside = makeOutsideDir();
+    mkdirSync(join(outside, "memory"), { recursive: true });
+    writeFileSync(
+      join(outside, "memory", "note.md"),
+      ["---", "name: note", `description: ${FORGED}`, "---", SECRET].join("\n"),
+    );
+    return { sub, outside };
+  }
+
+  /**
+   * GUARD: the description read going through the bound root handle at all.
+   *
+   * The candidate's parent is repointed at an out-of-scope tree AFTER the
+   * verified open and held there across the read. Reading through the handle
+   * yields in-scope bytes and the post-read proofs then reject, so the
+   * listing carries no description. A `readFile(join(requestedPath, rel))` in
+   * the same place resolves the name a second time, through the flipped
+   * parent, and serves the out-of-scope frontmatter under the in-scope URI —
+   * which is exactly what `resources/list` did before this round.
+   */
+  test("does not describe a resource through a parent flipped across the read", async () => {
+    const { sub, outside } = flippableMemoryDir();
+    let flipped = false;
+    const provider = resourceProvider({
+      memoryDirs: [join(sub, "memory")],
+      beforeHeaderReadForTesting: () => {
+        if (flipped) return;
+        flipped = true;
+        renameSync(sub, `${sub}.real`);
+        symlinkSync(outside, sub);
+      },
+    });
+    const resources = await provider.listResources();
+    expect(flipped).toBe(true);
+    const note = resources.find((r) => r.name === "note.md");
+    expect(note).toBeDefined();
+    expect(note!.uri).toBe("agenc-memory://0/note.md");
+    expect(note!.description).toBeUndefined();
+    expect(JSON.stringify(resources)).not.toContain(FORGED);
+    // Cleanup runs on a real directory, not the symlink.
+    unlinkSync(sub);
+    renameSync(`${sub}.real`, sub);
+  });
+
+  /**
+   * GUARD: `sameStats(admitted, openedIdentity)` in
+   * `readScopedFrontmatterDescription`.
+   *
+   * The candidate is exchanged for another regular file between admission
+   * and the verified open. The replacement opens and verifies perfectly on
+   * its own terms — right type, one link, path and handle agree — so
+   * `openVerifiedCandidate` returns a handle and nothing downstream objects.
+   * Only the comparison against the identity admission recorded notices that
+   * the listing is about to describe a file it never admitted.
+   */
+  test("does not describe a candidate exchanged between admission and the open", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    const file = join(root, "memory", "notes.md");
+    const replacement = join(root, "replacement.md");
+    writeFileSync(
+      replacement,
+      ["---", "name: notes", `description: ${FORGED}`, "---", SECRET].join("\n"),
+    );
+    let swapped = false;
+    const provider = resourceProvider({
+      beforeDescriptionOpenForTesting: (path) => {
+        if (path !== file || swapped) return;
+        swapped = true;
+        renameSync(replacement, file);
+      },
+    });
+    const resources = await provider.listResources();
+    expect(swapped).toBe(true);
+    const note = resources.find((r) => r.name === "notes.md")!;
+    expect(note.description).toBeUndefined();
+    expect(JSON.stringify(resources)).not.toContain(FORGED);
+    expect(reasons()).toContain("verification_failed");
+  });
+
+  /**
+   * GUARD: the handle side of `assertCandidateUnchanged` on the description
+   * path.
+   *
+   * The file is rewritten in place after the open, so the descriptor still
+   * points at the same inode and every path-based check agrees. The bytes
+   * this read returns are the new ones; only re-proving the opened object
+   * against what it was at open time notices.
+   */
+  test("does not describe a candidate rewritten in place after the open", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    const file = join(root, "memory", "notes.md");
+    let mutated = false;
+    const provider = resourceProvider({
+      beforeHeaderReadForTesting: (path) => {
+        if (path !== file || mutated) return;
+        mutated = true;
+        writeFileSync(
+          file,
+          ["---", "name: notes", `description: ${FORGED}`, "---", SECRET, "x".repeat(400)].join("\n"),
+        );
+      },
+    });
+    const resources = await provider.listResources();
+    expect(mutated).toBe(true);
+    const note = resources.find((r) => r.name === "notes.md")!;
+    expect(note.description).toBeUndefined();
+    expect(JSON.stringify(resources)).not.toContain(FORGED);
+    expect(reasons()).toContain("verification_failed");
+  });
+
+  /**
+   * GUARD: the path side of `assertCandidateUnchanged` on the description
+   * path.
+   *
+   * Exchanging the directory that holds a nested candidate leaves the open
+   * inode untouched, so the handle side passes; and the exchanged directory
+   * is a real, contained, non-symlink directory below an unmoved root, so the
+   * ancestor walk passes too. Only comparing the pathname's object against
+   * the one that was opened sees that the name now leads somewhere else.
+   */
+  test("does not describe a nested candidate whose directory is exchanged", async () => {
+    const nested = join(root, "memory", "a", "b");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(
+      join(nested, "notes.md"),
+      ["---", "name: notes", "description: nested notes", "---", "safe body"].join("\n"),
+    );
+    const decoy = join(root, "decoy");
+    mkdirSync(decoy, { recursive: true });
+    writeFileSync(
+      join(decoy, "notes.md"),
+      ["---", "name: notes", `description: ${FORGED}`, "---", SECRET].join("\n"),
+    );
+    const file = join(nested, "notes.md");
+    let exchanged = false;
+    const provider = resourceProvider({
+      beforeHeaderReadForTesting: (path) => {
+        if (path !== file || exchanged) return;
+        exchanged = true;
+        renameSync(nested, join(root, "b.away"));
+        renameSync(decoy, nested);
+      },
+    });
+    const resources = await provider.listResources();
+    expect(exchanged).toBe(true);
+    const note = resources.find((r) => r.name.endsWith("notes.md"))!;
+    expect(note.description).toBeUndefined();
+    expect(JSON.stringify(resources)).not.toContain(FORGED);
+    expect(reasons()).toContain("verification_failed");
+  });
+
+  /**
+   * GUARD: the post-read `verifyParentChain` on the description path.
+   *
+   * The ancestor is replaced by a symlink to ITSELF, so the candidate's
+   * pathname still resolves to the very same inode and both sides of
+   * `assertCandidateUnchanged` agree. Only the ancestor walk, which rejects a
+   * symlinked parent segment outright, can reject here — and the reason it
+   * reports is what makes this test isolating.
+   */
+  test("does not describe a candidate whose ancestor becomes a symlink", async () => {
+    const dir = join(root, "memory", "nested");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "notes.md"),
+      ["---", "name: notes", "description: nested notes", "---", "safe body"].join("\n"),
+    );
+    const file = join(dir, "notes.md");
+    let linked = false;
+    const provider = resourceProvider({
+      beforeHeaderReadForTesting: (path) => {
+        if (path !== file || linked) return;
+        linked = true;
+        renameSync(dir, `${dir}.real`);
+        symlinkSync("nested.real", dir);
+      },
+    });
+    const resources = await provider.listResources();
+    expect(linked).toBe(true);
+    const note = resources.find((r) => r.name.endsWith("notes.md"))!;
+    expect(note.description).toBeUndefined();
+    expect(reasons()).toContain("ancestor_changed");
+  });
+
+  /*
+   * NOT KILLABLE, and the reason is structural rather than a gap.
+   *
+   * `fatal: true` in `decodeScopedPrefix` has no behavioural mutant reachable
+   * from this module. Its only caller is the memory listing, and a memory
+   * listing only ever sees names `scanMemoryRoots` produced; the scan decodes
+   * the first 65,536 bytes of every candidate with a fatal decoder of its own
+   * and drops the file if that fails, which is strictly wider and strictly
+   * earlier than this module's 8,192-byte prefix. So no file that reaches
+   * `decodeScopedPrefix` can carry invalid bytes in the window it reads, and
+   * the lenient mutant serves exactly what the strict one does.
+   *
+   * The clause stays anyway. This module's whole stance is that the scan is an
+   * untrusted source of candidate names and nothing else; leaning on the
+   * scan's decode to justify deleting this one would be trusting precisely
+   * what the module refuses to trust. The corresponding clause on the BODY
+   * path, which has no scan in front of it, is killed by two tests.
+   */
+
+  /**
+   * GUARD: the truncation-tolerance loop (`minimumEnd`) in
+   * `decodeScopedPrefix`.
+   *
+   * The listing reads a bounded 8 KiB prefix, and a prefix boundary lands
+   * wherever the file happens to put it — including inside a multi-byte
+   * sequence. This file is built so byte 8191 is the lead byte of a two-byte
+   * character, so the prefix ends mid-sequence: a fatal decode of the whole
+   * prefix fails, and only backing off up to three bytes recovers the
+   * frontmatter. Without the loop, any memory file over 8 KiB that happens to
+   * split a character at the boundary silently loses its description.
+   */
+  test("describes a memory file whose 8 KiB prefix is cut mid-sequence", async () => {
+    mkdirSync(join(root, "memory"), { recursive: true });
+    const header = Buffer.from(
+      ["---", "name: cut", "description: cut prefix", "---", ""].join("\n"),
+      "utf8",
+    );
+    const padding = Buffer.alloc(8_191 - header.byteLength, 0x61);
+    const split = Buffer.from("é", "utf8");
+    expect(split.byteLength).toBe(2);
+    const tail = Buffer.alloc(64, 0x61);
+    const bytes = Buffer.concat([header, padding, split, tail]);
+    expect(bytes.byteLength).toBeGreaterThan(8_192);
+    expect(bytes[8_191]).toBe(0xc3);
+    writeFileSync(join(root, "memory", "cut.md"), bytes);
+    const provider = resourceProvider();
+    const resources = await provider.listResources();
+    const note = resources.find((r) => r.name === "cut.md")!;
+    expect(note.description).toBe("cut prefix");
+  });
+});
+
+/**
  * GUARD: the directory re-proof being `dev`/`ino`/`mode` rather than the full
  * six-field identity.
  *
  * A directory's mtime and ctime advance whenever any child is added, removed,
  * or renamed. While the re-proof compared them, one neighbouring write during
- * a listing emptied the whole listing: measured under purely benign sibling
- * churn with no attacker, the skill listing was available 112 times in
- * 172,076 attempts. Widening the comparison back fails this test.
+ * a listing emptied the whole listing.
+ *
+ * The two surfaces are separate and measure separately, because they go
+ * through different modules:
+ *
+ *   SKILL listing   `fs/verified-read.ts` proofs. 102 of 116,343 = 0.09%
+ *                   before narrowing, 33,622 of 33,622 = 100.00% after.
+ *   MEMORY listing  `memory/scan.ts` proofs, which the first narrowing did
+ *                   not touch. 113 of 76,583 = 0.15% before, 22,561 of
+ *                   22,561 = 100.00% after.
+ *
+ * All measured with one separate process writing and removing a single
+ * sibling file, no attacker. Controls: no churn 100.00%, churn in a directory
+ * outside the listed root 100.00%.
+ *
+ * Widening either module's directory comparison back fails one of these two
+ * tests.
  */
 describe("availability under benign concurrent writes", () => {
   test("still lists a skill while a sibling file is written into the skill root", async () => {
@@ -645,15 +950,64 @@ describe("availability under benign concurrent writes", () => {
     expect(prompts.map((p) => p.name)).toContain("stable");
   });
 
-  test("still lists a memory resource while a sibling file is written into the memory dir", async () => {
+  /**
+   * The memory listing's availability is decided INSIDE `scanMemoryRoots`,
+   * not in this module: `listMemoryResources` cannot produce a single
+   * resource without the scan, and a failed scan yields no names at all. So
+   * the write has to land inside the scan, and `duringMemoryScanForTesting`
+   * is the only seam that reaches there.
+   *
+   * The earlier version of this test wrote at `beforeHeaderReadForTesting`,
+   * which fires long after `scanMemoryRoots` has returned; the identical
+   * write also passed at `beforeMemoryScanForTesting`, which fires before the
+   * scan binds anything. Neither could fail, so neither pinned anything, and
+   * the memory listing sat at 0.17% availability under exactly the churn this
+   * test claimed to cover.
+   */
+  test("still lists a memory resource while a sibling file is written during the scan", async () => {
     makeMemoryFile("notes.md", "plain body");
+    let wrote = false;
     const provider = resourceProvider({
-      beforeHeaderReadForTesting: () => {
+      duringMemoryScanForTesting: () => {
+        if (wrote) return;
+        wrote = true;
         writeFileSync(join(root, "memory", "sibling.md"), "neighbour");
       },
     });
     const resources = await provider.listResources();
+    expect(wrote).toBe(true);
     expect(resources.map((r) => r.name)).toContain("notes.md");
+  });
+});
+
+/**
+ * The memory listing's one remaining failure mode, written down rather than
+ * hidden: a scan that does not complete produces no candidate NAMES, so the
+ * listing drops every memory resource under that directory. It has always
+ * behaved this way — `scanMemoryFiles` returns an empty array for a failed
+ * scan — and this round did not change it; what changed is that the reason
+ * reaches `onRejected` instead of vanishing.
+ */
+describe("memory scan failure", () => {
+  test("reports a directory whose scan did not complete instead of dropping it silently", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    const dir = join(root, "memory");
+    const outside = makeOutsideDir();
+    let broke = false;
+    const provider = resourceProvider({
+      duringMemoryScanForTesting: () => {
+        if (broke) return;
+        broke = true;
+        renameSync(dir, `${dir}.real`);
+        symlinkSync(outside, dir);
+      },
+    });
+    const resources = await provider.listResources();
+    expect(broke).toBe(true);
+    expect(resources).toEqual([]);
+    expect(reasons()).toContain("root_unavailable");
+    unlinkSync(dir);
+    renameSync(`${dir}.real`, dir);
   });
 });
 

--- a/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
+++ b/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
@@ -3,17 +3,36 @@
  * prompts and resource bodies from a location proven against a retained root
  * descriptor, never from a pathname resolved a second time.
  *
- * Every test here is a *mutation* test: each one is written so that deleting
- * the single guard named in its title makes it fail. A guard whose deletion
- * leaves the suite green is not covered, however many tests surround it. The
- * one guard with no behavioural mutant, `O_NOFOLLOW`, is pinned on the flag
- * value instead and the reason is written down in `tests/fs/verified-read.test.ts`.
+ * Most tests here are *mutation* tests: each is written so that deleting the
+ * single guard named in its title makes it fail. A guard whose deletion leaves
+ * the suite green is not covered, however many tests surround it.
+ *
+ * Some guards are not individually killable, and saying so is part of the
+ * record rather than a gap to paper over:
+ *
+ *   - `O_NOFOLLOW` has no behavioural mutant at all. It is pinned on the flag
+ *     value in `tests/fs/verified-read.test.ts`, with the reason.
+ *   - `nlink === 1n` is checked in three places (listing admission, the open
+ *     in `openVerifiedCandidate`, and the opened handle in
+ *     `readScopedRegularFile`). Deleting any one leaves the suite green; only
+ *     deleting all three fails it. They are pinned collectively.
+ *   - the root symlink pre-check in `bindVerifiedRoot` is only killable
+ *     together with `O_DIRECTORY`/`O_NOFOLLOW` on the root open.
+ *   - the `isContained` pre-check in `openVerifiedCandidate` is redundant with
+ *     the ancestor walk's canonical containment for every reachable escape.
+ *
+ * Two tests here used to pass for the wrong reason and now do not: the
+ * pre-open ancestor walk (see "at the open boundary") stayed green when it was
+ * deleted, because the test's own restore step moved the bound root's
+ * timestamps and the POST-read walk rejected instead; and the same-inode
+ * symlink test named a proof that never runs.
  */
 import { spawnSync } from "node:child_process";
 import {
   linkSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   renameSync,
   rmSync,
   symlinkSync,
@@ -31,6 +50,7 @@ import {
   MAX_SCOPED_INSTRUCTION_FILE_BYTES,
   createMemoryResourceProvider,
   createSkillPromptProvider,
+  type MemoryResourceProviderOptions,
   type ScopedReadRejection,
 } from "../../src/mcp/server/content-providers.js";
 
@@ -43,7 +63,7 @@ let root: string;
 let rejections: ScopedReadRejection[];
 
 beforeEach(async () => {
-  root = mkdtempSync(join(tmpdir(), "agenc-mcp-verified-"));
+  root = realpathSync(mkdtempSync(join(tmpdir(), "agenc-mcp-verified-")));
   roots.push(root);
   rejections = [];
   vi.stubEnv("AGENC_HOME", root);
@@ -77,7 +97,7 @@ function makeSkill(name: string, body: string): string {
 }
 
 function makeOutsideDir(): string {
-  const outside = mkdtempSync(join(tmpdir(), "agenc-mcp-outside-"));
+  const outside = realpathSync(mkdtempSync(join(tmpdir(), "agenc-mcp-outside-")));
   roots.push(outside);
   return outside;
 }
@@ -119,6 +139,7 @@ function skillProvider(
     scopeRoot?: string;
     beforeOpenForTesting?: (path: string) => void;
     beforeReadForTesting?: (path: string) => void;
+    beforeHeaderReadForTesting?: (path: string) => void;
   } = {},
 ) {
   return createSkillPromptProvider({
@@ -130,13 +151,7 @@ function skillProvider(
 }
 
 function resourceProvider(
-  overrides: {
-    memoryDirs?: readonly string[];
-    instructionFiles?: readonly string[];
-    scopeRoot?: string;
-    beforeOpenForTesting?: (path: string) => void;
-    beforeReadForTesting?: (path: string) => void;
-  } = {},
+  overrides: Partial<MemoryResourceProviderOptions> = {},
 ) {
   return createMemoryResourceProvider({
     memoryDirs: [join(root, "memory")],
@@ -173,16 +188,17 @@ describe("verified skill prompt reads", () => {
     expect(await provider.getPrompt("swapped")).toBeNull();
   });
 
-  test("omits a skill swapped for a same-inode symlink: the identity proof rejects it", async () => {
+  test("omits a skill swapped for a same-inode symlink: the pre-open symlink check rejects it", async () => {
     const file = makeSkill("selflink", "safe body");
     const provider = skillProvider({
       beforeOpenForTesting: (path) => {
         if (path !== file) return;
         // The replacement symlink resolves to the very inode validation saw.
-        // What rejects it is the identity proof, not `O_NOFOLLOW`: creating
-        // the second name moves the inode's ctime, so the opened object no
-        // longer matches the admitted one. See tests/fs/verified-read.test.ts
-        // for why no behavioural mutant can isolate the flag.
+        // Instrumenting both branches shows which clause actually fires: the
+        // `lstat(...).isSymbolicLink()` check inside `openVerifiedCandidate`,
+        // before the open. The identity proof would also reject it — creating
+        // the second name moves the inode's ctime — but it never runs, so
+        // this test does not pin it and the title no longer says it does.
         const alias = `${file}.same-inode`;
         linkSync(file, alias);
         rmSync(file);
@@ -371,14 +387,23 @@ describe("descriptor-bound ancestor containment", () => {
         selfSymlinkAncestor("preopen");
       },
       beforeReadForTesting: (path) => {
-        // Restore before the post-read walk, so only the pre-open walk can
-        // reject this. Without it the same bytes are served through an
-        // unvetted ancestor.
+        // Reached only when the pre-open walk is gone. Restoring here puts the
+        // ancestor back before the post-read walk looks, so the post-read walk
+        // cannot stand in for the deleted one and the mutant serves bytes
+        // taken through an unvetted ancestor.
         if (path !== file) return;
         restoreAncestor("preopen");
       },
     });
     expect(await provider.listPrompts()).toEqual([]);
+    // Naming the reason is what makes this isolating. The restore moves the
+    // bound skills root's mtime and ctime; while the directory re-proof still
+    // compared those, the POST-read walk rejected on the restore alone and
+    // this test stayed green with the pre-open walk deleted. The directory
+    // re-proof is now dev/ino/mode, so a moved timestamp is not a rejection
+    // and `ancestor_changed` here would mean the wrong walk did the work.
+    expect(reasons()).toContain("verification_failed");
+    expect(reasons()).not.toContain("ancestor_changed");
   });
 
   test("omits a skill whose ancestor becomes a symlink after the bytes are read", async () => {
@@ -544,6 +569,94 @@ describe("fatal UTF-8 decoding", () => {
   });
 });
 
+/**
+ * GUARD: `readScopedFrontmatterDescription`, i.e. the listing's description
+ * coming from a read bound to the retained root handle instead of from
+ * `scanMemoryFiles`.
+ *
+ * `scanMemoryFiles` binds the memory directory itself, so it is a second,
+ * independent resolution of that name. Flipping the directory's PARENT for
+ * exactly the length of the scan lands the scan on an out-of-scope tree while
+ * the provider's own bind and admission both land in scope. Deleting the
+ * scope-bound read and taking `header.description` back makes this test
+ * report the out-of-scope frontmatter under an in-scope URI. Measured without
+ * seams against the module before this change: 14 forged listings in 253,480.
+ *
+ * Flipping a deeper ancestor, inside the scanned tree, does not reproduce it:
+ * that trips the scanner's own directory-identity checks. It is the ROOT
+ * BINDING that has to be churned.
+ */
+describe("memory listing metadata", () => {
+  test("does not describe an in-scope resource with an out-of-scope file's frontmatter", async () => {
+    const sub = join(root, "sub");
+    mkdirSync(join(sub, "memory"), { recursive: true });
+    writeFileSync(
+      join(sub, "memory", "note.md"),
+      ["---", "name: note", "description: in-scope note", "---", "in-scope body"].join("\n"),
+    );
+    const outside = makeOutsideDir();
+    mkdirSync(join(outside, "memory"), { recursive: true });
+    writeFileSync(
+      join(outside, "memory", "note.md"),
+      ["---", "name: note", `description: ${FORGED}`, "---", SECRET].join("\n"),
+    );
+    const provider = resourceProvider({
+      memoryDirs: [join(sub, "memory")],
+      beforeMemoryScanForTesting: () => {
+        renameSync(sub, `${sub}.real`);
+        symlinkSync(outside, sub);
+      },
+      afterMemoryScanForTesting: () => {
+        unlinkSync(sub);
+        renameSync(`${sub}.real`, sub);
+      },
+    });
+    const resources = await provider.listResources();
+    const note = resources.find((r) => r.name === "note.md");
+    expect(note).toBeDefined();
+    expect(note!.uri).toBe("agenc-memory://0/note.md");
+    expect(note!.description).toBe("in-scope note");
+    expect(JSON.stringify(resources)).not.toContain(FORGED);
+  });
+});
+
+/**
+ * GUARD: the directory re-proof being `dev`/`ino`/`mode` rather than the full
+ * six-field identity.
+ *
+ * A directory's mtime and ctime advance whenever any child is added, removed,
+ * or renamed. While the re-proof compared them, one neighbouring write during
+ * a listing emptied the whole listing: measured under purely benign sibling
+ * churn with no attacker, the skill listing was available 112 times in
+ * 172,076 attempts. Widening the comparison back fails this test.
+ */
+describe("availability under benign concurrent writes", () => {
+  test("still lists a skill while a sibling file is written into the skill root", async () => {
+    makeSkill("stable", "safe body");
+    const provider = skillProvider({
+      beforeReadForTesting: () => {
+        writeFileSync(
+          join(root, "skills", "sibling.md"),
+          ["---", "description: sibling", "---", "neighbour"].join("\n"),
+        );
+      },
+    });
+    const prompts = await provider.listPrompts();
+    expect(prompts.map((p) => p.name)).toContain("stable");
+  });
+
+  test("still lists a memory resource while a sibling file is written into the memory dir", async () => {
+    makeMemoryFile("notes.md", "plain body");
+    const provider = resourceProvider({
+      beforeHeaderReadForTesting: () => {
+        writeFileSync(join(root, "memory", "sibling.md"), "neighbour");
+      },
+    });
+    const resources = await provider.listResources();
+    expect(resources.map((r) => r.name)).toContain("notes.md");
+  });
+});
+
 describe("verified memory resource reads", () => {
   test("reads an in-scope memory file with secrets redacted", async () => {
     makeMemoryFile("notes.md", `plain body ${SECRET_TOKEN}`);
@@ -557,19 +670,26 @@ describe("verified memory resource reads", () => {
     expect(read?.contents[0].text).not.toContain(SECRET_TOKEN);
   });
 
-  test("does not read resource bodies while listing", async () => {
+  test("reads only a bounded frontmatter prefix while listing, never a body", async () => {
     makeMemoryFile("notes.md", "plain body");
-    let reads = 0;
+    let bodyReads = 0;
+    let headerReads = 0;
     const provider = resourceProvider({
       beforeReadForTesting: () => {
-        reads += 1;
+        bodyReads += 1;
+      },
+      beforeHeaderReadForTesting: () => {
+        headerReads += 1;
       },
     });
     const resources = await provider.listResources();
-    expect(reads).toBe(0);
+    // The listing derives its description from the candidate it admitted, so
+    // it does take bytes — a bounded frontmatter prefix, not the body.
+    expect(headerReads).toBe(1);
+    expect(bodyReads).toBe(0);
     const uri = resources.find((r) => r.name === "notes.md")!.uri;
     await provider.readResource(uri);
-    expect(reads).toBe(1);
+    expect(bodyReads).toBe(1);
   });
 
   test("does not list multiply linked memory files", async () => {

--- a/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
+++ b/runtime/tests/mcp-server/content-providers-verified-reads.test.ts
@@ -25,8 +25,10 @@
  *     green — only the flag-VALUE test fails, and that one asserts a number,
  *     not an open. Its real partner is `!before.isDirectory()` in the same
  *     expression: `lstat` of a symlink reports `isDirectory()` false, so that
- *     clause rejects a symlinked root on its own. Delete the whole expression
- *     and "refuses a root that is a symlink" finally fails.
+ *     clause rejects a symlinked root on its own. Deleting the whole
+ *     expression is still not enough on its own: measured, that alone fails
+ *     nothing, and only the expression together with both directory open
+ *     flags makes "refuses a root that is a symlink" fail.
  *   - the `isContained` pre-check in `openVerifiedCandidate` is redundant with
  *     the ancestor walk's canonical containment for every reachable escape.
  *   - `fatal: true` in `decodeScopedPrefix` — see the note in "scope-bound
@@ -755,13 +757,18 @@ describe("scope-bound description reads", () => {
   });
 
   /**
-   * GUARD: the handle side of `assertCandidateUnchanged` on the description
-   * path.
+   * GUARD: the `assertCandidateUnchanged` CALL on the description path.
+   *
+   * It pins the call, not the handle side, and the distinction is measured
+   * rather than assumed: deleting `!sameStats(before, openedAfter)` from
+   * `runtime/src/fs/verified-read.ts` leaves this suite green, while deleting
+   * `!sameStats(before, pathAfter)` kills two tests, neither of them this one.
+   * So the handle side of that expression is unpinned everywhere in the repo,
+   * and this docstring used to claim the opposite.
    *
    * The file is rewritten in place after the open, so the descriptor still
-   * points at the same inode and every path-based check agrees. The bytes
-   * this read returns are the new ones; only re-proving the opened object
-   * against what it was at open time notices.
+   * points at the same inode. The path side rejects it, which is why the call
+   * being present is what this test proves.
    */
   test("does not describe a candidate rewritten in place after the open", async () => {
     makeMemoryFile("notes.md", "plain body");
@@ -961,7 +968,7 @@ describe("availability under benign concurrent writes", () => {
    * which fires long after `scanMemoryRoots` has returned; the identical
    * write also passed at `beforeMemoryScanForTesting`, which fires before the
    * scan binds anything. Neither could fail, so neither pinned anything, and
-   * the memory listing sat at 0.17% availability under exactly the churn this
+   * the memory listing sat at 0.15% availability under exactly the churn this
    * test claimed to cover.
    */
   test("still lists a memory resource while a sibling file is written during the scan", async () => {

--- a/runtime/tests/mcp-server/prompts-resources.test.ts
+++ b/runtime/tests/mcp-server/prompts-resources.test.ts
@@ -5,7 +5,7 @@
  * prompt, and reads a memory file as a resource; excluded/secret
  * content stays out.
  */
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -140,17 +140,6 @@ describe("MCP prompts backed by skills", () => {
 });
 
 describe("MCP resources backed by memory + instruction files", () => {
-  it("imports the canonical secret sanitizer for resource egress", async () => {
-    const source = await readFile(
-      new URL("../../src/mcp/server/content-providers.ts", import.meta.url),
-      "utf8",
-    );
-
-    expect(source).toContain(
-      'import { redactSecrets } from "../../secrets/sanitizer.js";',
-    );
-  });
-
   async function makeResourceServer(
     setup: {
       /** Body written into deploy-notes.md and AGENC.md before serving. */

--- a/runtime/tests/memory/scan.test.ts
+++ b/runtime/tests/memory/scan.test.ts
@@ -218,12 +218,25 @@ describe("scanMemoryFiles", () => {
    * empty array — so the MCP memory listing, which cannot produce a single
    * resource without the scan, lost everything. Measured on this machine with
    * a separate process writing and removing one sibling file in the memory
-   * directory and no attacker at all: the memory listing was available 105
-   * times in 63,141 attempts, 0.17%. Narrowed, 11,886 of 11,887, 99.99%.
+   * directory and no attacker at all: the memory listing was available 113
+   * times in 76,583 attempts, 0.15%. Narrowed, 22,561 of 22,561, 100.00%.
    *
    * Each of the three tests below writes a sibling file at the one seam that
    * falls inside that proof's window, and each fails if its proof is widened
    * back to `sameStats`.
+   *
+   * Pinned in the WIDENING direction only, and that is worth stating plainly
+   * rather than leaving a reader to assume otherwise. Deleting
+   * `!sameDirectoryIdentity(opened, pending.identity) ||
+   * !sameDirectoryIdentity(opened, current)` outright from
+   * `assertBoundDirectoryUnchanged`, `openVerifiedDirectory` or
+   * `openBoundRootDirectory` leaves this suite green, unlike the
+   * `bindVerifiedRoot` proofs, which each have a test that kills them on
+   * deletion. These three are defence in depth: the adversarial run that
+   * cleared this change attacked the narrowed scan directly for 1,963,015
+   * seam-free attempts across nine shapes, including two aimed at the
+   * narrowing itself, and forged nothing. That is evidence the escape is
+   * closed, not evidence these clauses are individually load-bearing.
    */
   it("survives a sibling write between the root bind and the root open", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "agenc-memory-scan-"));

--- a/runtime/tests/memory/scan.test.ts
+++ b/runtime/tests/memory/scan.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../src/memory/recall-contract.js";
 import {
   MAX_MEMORY_FILES,
+  readMemoryContent,
   scanMemoryRoots,
   scanMemoryFiles,
 } from "../../src/memory/scan.js";
@@ -203,6 +204,114 @@ describe("scanMemoryFiles", () => {
 
     expect(exchanged).toBe(true);
     expect(result).toMatchObject({ kind: "unavailable", headers: [] });
+  });
+
+  /**
+   * GUARD: the scan's three DIRECTORY proofs comparing `dev`/`ino`/`mode`
+   * rather than the full six-field identity.
+   *
+   * A directory's `size`, `mtime`, and `ctime` move whenever any child is
+   * added, removed, or renamed, and a memory directory is written to by the
+   * very runtime that scans it. While these three proofs compared those
+   * fields, one benign neighbouring write anywhere in the memory directory
+   * failed the whole scan, and `scanMemoryFiles` turns a failed scan into an
+   * empty array — so the MCP memory listing, which cannot produce a single
+   * resource without the scan, lost everything. Measured on this machine with
+   * a separate process writing and removing one sibling file in the memory
+   * directory and no attacker at all: the memory listing was available 105
+   * times in 63,141 attempts, 0.17%. Narrowed, 11,886 of 11,887, 99.99%.
+   *
+   * Each of the three tests below writes a sibling file at the one seam that
+   * falls inside that proof's window, and each fails if its proof is widened
+   * back to `sameStats`.
+   */
+  it("survives a sibling write between the root bind and the root open", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "agenc-memory-scan-"));
+    await writeFile(join(tempDir, "note.md"), "---\nname: note\n---\nbody");
+    let wrote = false;
+
+    const result = await scanMemoryRoots([tempDir], new AbortController().signal, {
+      // Fires after the scan bound the root and before `openBoundRootDirectory`
+      // compares the opened handle against that binding.
+      beforeDirectoryOpen: async (path) => {
+        if (path !== tempDir || wrote) return;
+        wrote = true;
+        await writeFile(join(tempDir, "sibling.md"), "---\nname: sibling\n---\nb");
+      },
+    });
+
+    expect(wrote).toBe(true);
+    expect(result.kind).toBe("complete");
+    expect(result.headers.map((header) => header.filename)).toContain("note.md");
+  });
+
+  it("survives a sibling write between a subdirectory's identity binding and its open", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "agenc-memory-scan-"));
+    const nested = join(tempDir, "nested");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(nested, "note.md"), "---\nname: note\n---\nbody");
+    let wrote = false;
+
+    const result = await scanMemoryRoots([tempDir], new AbortController().signal, {
+      // Fires after the parent's enumeration recorded this directory's
+      // identity and before `openVerifiedDirectory` compares its open against
+      // that record.
+      beforeDirectoryOpen: async (path) => {
+        if (path !== nested || wrote) return;
+        wrote = true;
+        await writeFile(join(nested, "sibling.md"), "---\nname: sibling\n---\nb");
+      },
+    });
+
+    expect(wrote).toBe(true);
+    expect(result.kind).toBe("complete");
+    expect(
+      result.headers.some((header) => header.relativePath === "nested/note.md"),
+    ).toBe(true);
+  });
+
+  it("survives a sibling write across a directory's enumeration", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "agenc-memory-scan-"));
+    await writeFile(join(tempDir, "note.md"), "---\nname: note\n---\nbody");
+    let wrote = false;
+
+    const result = await scanMemoryRoots([tempDir], new AbortController().signal, {
+      // Fires after the entries are read and before
+      // `assertBoundDirectoryUnchanged` re-proves the directory.
+      afterDirectoryEnumeration: async (path) => {
+        if (path !== tempDir || wrote) return;
+        wrote = true;
+        await writeFile(join(tempDir, "sibling.md"), "---\nname: sibling\n---\nb");
+      },
+    });
+
+    expect(wrote).toBe(true);
+    expect(result.kind).toBe("complete");
+    expect(result.headers.map((header) => header.filename)).toContain("note.md");
+  });
+
+  /**
+   * GUARD: the root re-bind in `readMemoryContent` comparing directory
+   * identity rather than the full six-field identity.
+   *
+   * The header was produced by one bind and the content read makes another,
+   * with arbitrary time in between. Comparing `size`/`mtime`/`ctime` there
+   * meant any write into the memory directory after recall selected a
+   * memory — including the runtime writing the next memory — turned the read
+   * into "memory root identity changed before content read". The candidate
+   * FILE keeps the full identity, and that is what this test leaves intact.
+   */
+  it("reads memory content after a sibling was written into the memory dir", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "agenc-memory-scan-"));
+    await writeFile(join(tempDir, "note.md"), "---\nname: note\n---\nbody text");
+
+    const headers = await scanMemoryFiles(tempDir, new AbortController().signal);
+    const header = headers.find((entry) => entry.filename === "note.md")!;
+    expect(header).toBeDefined();
+    await writeFile(join(tempDir, "sibling.md"), "---\nname: sibling\n---\nb");
+
+    const content = await readMemoryContent(header, new AbortController().signal);
+    expect(content.content).toContain("body text");
   });
 
   it("discards a candidate whose pathname is exchanged after descriptor open", async () => {


### PR DESCRIPTION
Closes #1794, which #2052 did not. That PR merged as `f75f0a2ac` while the
escape was still reachable; the reproduction is in
[this comment](https://github.com/tetsuo-ai/agenc-core/issues/1794#issuecomment-5530644066).

## Why the merged version did not close it

`readScopedRegularFile` bound the served bytes to one inode with a seven-field
identity, but nothing bound that inode to the scope root. Containment was
decided twice, both times by resolving a pathname (`:200` and `:247`), and
neither resolution was tied to the descriptor that produced the bytes nor
atomic with the validating `lstat` that chose the inode. Flipping an ancestor
between the `lstat` and the `realpath` made the two proofs describe different
files, so the reader returned out-of-scope bytes under an in-scope
`canonicalPath`, which callers store as `skill.filePath` / `resource.filePath`.

Measured seam-free, attacker in a separate process:

| target | attempts | forged |
| --- | --- | --- |
| merged reader, skills `listPrompts` | 30,033 | 10 |
| merged reader, `getPrompt` | 42,394 | 12 |
| merged reader, nested-segment flip | 70,692 | 18 |

`getPrompt` is the worst of them: the payload is the whole skill body, i.e.
attacker-controlled text delivered to the client's model.

## What this does

Binds containment to a retained root descriptor instead of to a pathname.

`runtime/src/fs/verified-read.ts` is new, extracted from
`runtime/src/memory/scan.ts`: `bindVerifiedRoot`, `verifyParentChain`,
`openVerifiedCandidate`, `finalDescriptorPath`, `assertCandidateUnchanged`. It
is parameterised by a `VerifiedReadContext` so the scanner keeps its own
`MemoryScanFailure` kinds and messages; `scan.ts` is rewired onto it with no
behaviour change. #1794 asked for a *shared* descriptor-bound reader and that
primitive already existed here, module-private, which is why it was not reused
the first time.

The MCP providers now open and retain a root handle per skill root, memory dir
and instruction-file parent, prove that handle sits inside the scope root, and
admit, open, read and re-prove every candidate against it. The `scopeRoot`
check moved off the per-candidate path, where it was one of the two independent
resolutions the escape exploited, onto the root binding, where it is a proof
about a descriptor.

The memory listing no longer trusts anything the scan reports. Descriptions
come from a new `readScopedFrontmatterDescription`, which opens the admitted
candidate below the bound root, proves the opened object is the admitted one,
reads a bounded 8 KiB frontmatter prefix and re-proves object and ancestor
chain before parsing. Without that, `scanMemoryFiles` was a second,
non-scope-checked resolution of the same directory, and flipping the memory
dir's PARENT put an out-of-scope description under an in-scope
`agenc-memory://` URI.

## Evidence

Independently adversarial, harness capability validated on vulnerable code
before every clean run, because a harness that finds nothing on vulnerable code
proves nothing on fixed code:

- **1,963,015 seam-free attempts, 426,352 served listings, 0 forged**, across
  nine attack shapes, attacker always in a separate process, providers driven
  as `agenc mcp serve` drives them.
- Shapes include the original skills flip, `getPrompt` body forge, memory
  listing metadata, memory body via `readResource`, instruction body, a flip of
  a segment *inside* the bound root (the one class where `finalDescriptorPath`
  gives no independent proof), and a deterministic hardlink escape.
- Attacks on the narrowing itself: inode reuse does not occur on APFS across
  400 tight cycles, and is structurally blocked because every narrowed proof
  compares an open handle's `fstat` against an `lstat` of the path.

## Availability, which the strict version destroyed

A directory's `size`/`mtime`/`ctime` move on every child add, remove or
rename, so proving a *directory* on them was not stricter containment, it was
an outage. Under purely benign sibling churn with no attacker:

| surface | before | after |
| --- | --- | --- |
| skill listing | 102 / 116,343 = 0.09% | 100.00% |
| memory listing | 50 / 139,285 = 0.04% | 100.00% |

Controls, both surfaces: no churn 100%, churn outside the listed root 100%.
Directories are proven on `dev`/`ino`/`mode`; candidate files keep the full
identity, since `size`/`mtime` are what catch a content swap.

## Cost

200 memory files, median of 40 requests:

| surface | merged | this branch |
| --- | --- | --- |
| `resources/list` | 59.4 ms | 103.0 ms |
| `resources/read` | 60.5 ms | 63.1 ms |

`resources/read` used to rebuild the whole listing just to bound the client's
URI, then discard every description; it now passes `describe: false`.
`resources/list` keeps its ~70%, deliberately: the admitted candidate's
identity is exactly what the description read is proven against, so folding the
two opens into one would delete the guard rather than optimise it. Capped at
8 KiB per file, one request.

## Platform

Fails closed where there is no descriptor-path mechanism (win32, and anything
not linux/darwin/freebsd), reported as `platform_unsupported` through the
observer. **`agenc mcp serve` on Windows therefore advertises no skills, memory
or instruction resources.** That is a real product loss, chosen over a silent
weaker path per the issue, and written into `docs/reference/mcp.md`. Memory
resources were already empty there, since `scanMemoryRoots` reports
`unsupported` on win32.

## What is pinned, and what is not

Every guard the merged version relied on was unpinned: deleting the `scopeRoot`
check, `O_NOFOLLOW`, the `isFile()` clause or either after-read re-check left
all 33 tests green. That is why a green suite did not distinguish it from a
version without them.

Guards here are pinned by tests that die when the guard alone is deleted,
verified by mutation. Two exceptions are recorded in the code rather than
papered over:

- `O_NOFOLLOW` has no reachable behavioural mutant: every distinct replacement
  is already rejected by the identity proof, and no second name for an inode
  can be made without moving its `ctime` (measured on darwin: `linkSync` and
  `renameSync` both do).
- The scan's three directory proofs are pinned in the widening direction only.
  Deleting them outright leaves the suite green, so they are defence in depth,
  and the adversarial run above is what clears them.

## Not changed

- No change to which resources are admitted or to any URI the client sees.
- `runtime/src/memory/scan.ts` keeps its own failure kinds and messages; the
  extraction was confirmed behaviour-preserving by diff and by its own suites.
- The 5 MiB instruction ceiling was private to `project-instructions.ts`; it
  moved to `secure-instruction-file.ts` and is exported, so the same `AGENC.md`
  is not readable in-process and silently missing over MCP. Same value.
