### PR TITLE
test(hermetic): base the run root on /private/tmp on macOS

### DIFF
--- a/runtime/tests/helpers/hermetic-env.mjs
+++ b/runtime/tests/helpers/hermetic-env.mjs
@@ -558,7 +558,7 @@ export function createHermeticRunRoot(prefix, explicitBase) {
     }
     base = join(systemRoot, 'Temp')
   } else {
-    base = '/tmp'
+    base = process.platform === 'darwin' ? '/private/tmp' : '/tmp'
   }
   mkdirSync(base, { mode: 0o700, recursive: true })
   return mkdtempSync(join(base, prefix))

--- a/runtime/tests/hermetic-run-root.test.ts
+++ b/runtime/tests/hermetic-run-root.test.ts
@@ -1,0 +1,64 @@
+import { realpathSync, rmSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { createHermeticRunRoot } from "./helpers/hermetic-env.mjs";
+
+// The hermetic run root is the base of every sandboxed home, workspace and
+// socket path a test sees. Two properties keep the suite honest on every
+// platform:
+//   1. it is already canonical, so a test that compares a path it was handed
+//      against `realpath()` of the same path sees one string, not two;
+//   2. it stays short, because Unix-domain socket paths are capped at 104
+//      bytes on macOS and 108 on Linux.
+// On macOS `/tmp` is a symlink to `/private/tmp`; using the symlink as the
+// base broke both (1) and every "no symlink ancestor" assertion in the suite.
+describe("createHermeticRunRoot", () => {
+  it.runIf(process.platform !== "win32")(
+    "returns a canonical path: realpath of the root is the root itself",
+    () => {
+      const root = createHermeticRunRoot("agv-test-");
+      try {
+        expect(realpathSync(root)).toBe(root);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "bases the root under /private/tmp on macOS, never the /tmp symlink",
+    () => {
+      const root = createHermeticRunRoot("agv-test-");
+      try {
+        expect(root.startsWith("/private/tmp/agv-test-")).toBe(true);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "bases the root under /tmp on Linux",
+    () => {
+      const root = createHermeticRunRoot("agv-test-");
+      try {
+        expect(root.startsWith("/tmp/agv-test-")).toBe(true);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps the root short enough for a Unix-domain socket path",
+    () => {
+      const root = createHermeticRunRoot("agv-test-");
+      try {
+        // 104 bytes minus room for "<home>/.agenc/daemon.sock"-shaped suffixes.
+        expect(Buffer.byteLength(root)).toBeLessThan(60);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Why

`createHermeticRunRoot` in `runtime/tests/helpers/hermetic-env.mjs` hardcodes `/tmp` as the run-root base on every non-Windows platform, and deliberately ignores `TEMP`/`TMP`/`TMPDIR` so socket paths stay under the 104-byte `sun_path` cap. On macOS `/tmp` is a symlink to `/private/tmp`, so every sandboxed home, workspace and socket path the suite hands to a test sits under a symlink ancestor. Two classes of tests then fail on every Mac with no code defect behind them:

- every "no symlink ancestor" assertion (`ConfigRepositoryError: managed configuration path contains a symbolic-link ancestor: /tmp` from `src/config/repository.ts:369`), which hits the plugin and agent catalog loaders;
- every comparison of a handed path against its `realpath()` (`Expected "/tmp/agv-…" / Received "/private/tmp/agv-…"`).

The hermetic suite therefore could not run clean on a Mac, which is where this project is developed. Exporting `TMPDIR=/private/tmp/...` does nothing because the helper ignores it.

## What changed

- `runtime/tests/helpers/hermetic-env.mjs`: one line. On darwin the base is `/private/tmp`; Linux stays `/tmp`; Windows is unchanged. `/private/tmp` is the canonical path of the very same directory, eight bytes longer, still far inside the socket-path budget.
- `runtime/tests/hermetic-run-root.test.ts` (new): pins the property that matters, `realpathSync(root) === root`, plus the per-platform base and a length budget for socket paths.

## Evidence

Measured on macOS 26 (Darwin 25.6.0), Node 26.8.1, at `origin/main` 77985834a:

| run | result |
| --- | --- |
| `relevant-memories.test.ts` + `loadAgentsDir.test.ts`, unpatched helper | 3 failed / 39 passed (all three are the symlink-ancestor / realpath class) |
| same two files, patched helper | 42 passed / 42 |
| new `hermetic-run-root.test.ts`, patched helper | 3 passed, 1 skipped (the Linux case) |
| new test, unpatched helper (falsification) | 2 failed / 1 passed / 1 skipped |

## Tests

Added `runtime/tests/hermetic-run-root.test.ts`. It fails on macOS without the fix and passes with it; on Linux it asserts the base stays `/tmp` and the canonical-path property holds.

## Not changed

- No test other than the new one was edited. The two files above pass because their environment is now canonical, not because their assertions moved.
- The remaining macOS-only failures in the suite are NOT addressed here and are distinct: case-only symlink pairs on case-insensitive APFS (`tests/managed-prompt-hermetic.test.ts`), the `/home` firmlink resolving to `/System/Volumes/Data/home` (`tests/app-server/daemon-cli.contract.test.ts`, `tests/config/config.test.ts`), a missing `nvim`, and the darwin atomic-artifact break (separate issue, filed next).
- `TMPDIR` is still ignored on purpose; the socket-length rationale in the helper's doc comment still holds.

## Counterparts

None. `run-fast-checks.mjs` maps a change to the hermetic runner onto `tests/hermetic-test-discovery.test.ts`; this PR changes the helper the runner imports, so the affected-tests gate runs the related closure.
