### PR TITLE
fix(durability): publish atomic artifacts on macOS through a witnessed path

### DIFF
--- a/docs/design/durable-runs-effects-events.md
+++ b/docs/design/durable-runs-effects-events.md
@@ -546,12 +546,23 @@ returned to the model:
 4. remove the temporary name and fsync the parent directory.
 
 Those child-path operations stay bound to the already-open trusted-root
-descriptor. The supported and acceptance-tested aliases are `/proc/self/fd`
-or `/dev/fd` on Linux and `/dev/fd` on macOS. A platform where AgenC cannot
-resolve such a descriptor-relative path fails commit, cleanup, and recovery
-observation closed with `ARTIFACT_SAFE_OPERATION_UNSUPPORTED`; the current
-Windows implementation therefore does not publish large tool-result artifacts
-until an equivalent descriptor-bound primitive is available.
+descriptor wherever the platform offers a descriptor path: `/proc/self/fd` or
+`/dev/fd` on Linux. macOS offers none (`/dev/fd/N` is not traversable for a
+directory and never resolves to the canonical path), so on darwin the helper
+runs in a witnessed-path mode: children are addressed through the canonical
+lexical path while the directory descriptor stays open, and every directory
+mutation (temp creation, publication link, temp or orphan unlink) must be
+witnessed by that descriptor as a change of the pinned directory's own
+mtime/ctime. A mutation the pinned directory did not witness landed in a
+directory swapped into the path; it is retracted by the exact inode it created
+and reported as `AtomicArtifactUnsafePathError`. Reads (recovery observation,
+orphan listing) have no witness and rely on the identity re-verification around
+them, so a same-user swap installed and removed inside that window is the
+residual darwin cannot detect. A platform with neither primitive fails commit,
+cleanup, and recovery observation closed with
+`ARTIFACT_SAFE_OPERATION_UNSUPPORTED`; the current Windows implementation
+therefore does not publish large tool-result artifacts until an equivalent
+descriptor-bound primitive is available.
 
 After publication, `artifact_committed` records `committed` or
 `already_committed` and references the intent sequence. An identical retry is

--- a/runtime/src/durability/atomic-artifact.ts
+++ b/runtime/src/durability/atomic-artifact.ts
@@ -94,7 +94,11 @@ export interface AtomicArtifactObservationOptions {
 }
 
 type AtomicArtifactOperation =
-  "commit" | "cleanup" | "cleanup_sync" | "observe";
+  | "commit"
+  | "commit_before_link"
+  | "cleanup"
+  | "cleanup_sync"
+  | "observe";
 type AtomicArtifactOperationForTesting = (operation: {
   readonly operation: AtomicArtifactOperation;
   readonly targetPath: string;
@@ -330,23 +334,14 @@ export async function commitArtifactAtomically(
       trustedRoot: scope.trustedRoot,
     });
 
-    const handle = await open(
+    const { handle, opened } = await openWitnessedTemp(
+      scope,
+      pinned,
       tempPath,
-      fsConstants.O_WRONLY |
-        fsConstants.O_CREAT |
-        fsConstants.O_EXCL |
-        noFollowFlag(),
       options.mode ?? 0o600,
     );
     tempExists = true;
     try {
-      const opened = await handle.stat();
-      if (!opened.isFile() || opened.nlink !== 1) {
-        throw new AtomicArtifactUnsafePathError(
-          scope.targetPath,
-          scope.trustedRoot,
-        );
-      }
       await handle.writeFile(expected);
       await handle.sync();
       const afterWrite = await handle.stat();
@@ -361,12 +356,15 @@ export async function commitArtifactAtomically(
     }
 
     await assertPinnedRootCurrent(scope, pinned);
-    hitM4DurabilityFailpoint("before_artifact_commit");
     let outcome: AtomicArtifactCommitResult = "committed";
     try {
-      // link() is an atomic no-replace publication on the same filesystem.
-      // Unlike rename(), it cannot silently overwrite immutable evidence.
-      await link(tempPath, pinnedTargetPath);
+      await publishWitnessedTemp(
+        scope,
+        pinned,
+        tempPath,
+        pinnedTargetPath,
+        opened,
+      );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const existing = await readExistingRegularFile(pinnedTargetPath);
@@ -433,23 +431,14 @@ export async function commitArtifactSourceAtomically(
       trustedRoot: scope.trustedRoot,
     });
 
-    const handle = await open(
+    const { handle, opened } = await openWitnessedTemp(
+      scope,
+      pinned,
       tempPath,
-      fsConstants.O_WRONLY |
-        fsConstants.O_CREAT |
-        fsConstants.O_EXCL |
-        noFollowFlag(),
       options.mode ?? 0o600,
     );
     tempExists = true;
     try {
-      const opened = await handle.stat();
-      if (!opened.isFile() || opened.nlink !== 1) {
-        throw new AtomicArtifactUnsafePathError(
-          scope.targetPath,
-          scope.trustedRoot,
-        );
-      }
       await copyAtomicArtifactSource(handle, source);
       await handle.sync();
       const afterWrite = await handle.stat();
@@ -468,10 +457,15 @@ export async function commitArtifactSourceAtomically(
     }
 
     await assertPinnedRootCurrent(scope, pinned);
-    hitM4DurabilityFailpoint("before_artifact_commit");
     let outcome: AtomicArtifactCommitResult = "committed";
     try {
-      await link(tempPath, pinnedTargetPath);
+      await publishWitnessedTemp(
+        scope,
+        pinned,
+        tempPath,
+        pinnedTargetPath,
+        opened,
+      );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const existing = await digestExistingRegularFile(pinnedTargetPath);
@@ -532,12 +526,47 @@ function artifactScope(targetPath: string, trustedRoot: string): ArtifactScope {
 }
 
 type AsyncDirectoryHandle = Awaited<ReturnType<typeof open>>;
+
+interface FileIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+/**
+ * How child operations under a pinned trusted root are bound to that root.
+ *
+ * `descriptor`: children are addressed through a descriptor path such as
+ * `/proc/self/fd/N/<child>`, so swapping the lexical root cannot redirect them.
+ *
+ * `witnessed-path` (darwin only): macOS exposes no traversable descriptor path
+ * for a directory and Node has no openat-style primitive, so children are
+ * addressed through the canonical lexical path while the directory descriptor
+ * stays open. Every directory MUTATION is then witnessed through that
+ * descriptor: the pinned directory's own mtime/ctime must change, which proves
+ * the entry landed in the pinned directory and not in one swapped into its
+ * path (APFS stamps each entry mutation with a distinct nanosecond time; a
+ * mutation elsewhere leaves the pinned directory untouched). A mutation the
+ * pinned directory did not witness is retracted by the exact inode it created
+ * and reported as AtomicArtifactUnsafePathError. Reads (observation, cleanup
+ * listing) have no witness and rely on the identity re-verification around
+ * them; a same-user swap installed and removed inside that window is the
+ * residual this mode cannot detect, and the reason `descriptor` stays the
+ * default wherever the platform offers it.
+ */
+type PinnedRootMode = "descriptor" | "witnessed-path";
+
+interface DirectoryWitness {
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+}
+
 interface PinnedTrustedRoot {
   readonly canonicalPath: string;
   readonly dev: number | bigint;
   readonly ino: number | bigint;
   readonly handle: AsyncDirectoryHandle;
   readonly operationPath: string;
+  readonly mode: PinnedRootMode;
 }
 
 interface PinnedTrustedRootSync {
@@ -546,6 +575,182 @@ interface PinnedTrustedRootSync {
   readonly ino: number | bigint;
   readonly fd: number;
   readonly operationPath: string;
+  readonly mode: PinnedRootMode;
+}
+
+function bindPinnedRoot(
+  descriptorPath: string | undefined,
+  canonicalPath: string,
+  scope: ArtifactScope,
+  operation: "commit" | "cleanup" | "observe",
+): { readonly operationPath: string; readonly mode: PinnedRootMode } {
+  if (descriptorPath !== undefined) {
+    return { operationPath: descriptorPath, mode: "descriptor" };
+  }
+  if (process.platform === "darwin") {
+    return { operationPath: canonicalPath, mode: "witnessed-path" };
+  }
+  throw new AtomicArtifactOperationUnsupportedError(
+    operation,
+    scope.trustedRoot,
+  );
+}
+
+/** The pinned directory's own timestamps; undefined in descriptor mode. */
+async function directoryWitness(
+  pinned: PinnedTrustedRoot,
+): Promise<DirectoryWitness | undefined> {
+  if (pinned.mode !== "witnessed-path") return undefined;
+  const stat = await pinned.handle.stat({ bigint: true });
+  return { mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs };
+}
+
+function directoryWitnessSync(
+  pinned: PinnedTrustedRootSync,
+): DirectoryWitness | undefined {
+  if (pinned.mode !== "witnessed-path") return undefined;
+  const stat = fstatSync(pinned.fd, { bigint: true });
+  return { mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs };
+}
+
+/**
+ * True when a directory mutation performed between the two snapshots was
+ * witnessed by the pinned directory. Descriptor mode needs no witness because
+ * the operation itself was descriptor-relative.
+ */
+function witnessedMutation(
+  before: DirectoryWitness | undefined,
+  after: DirectoryWitness | undefined,
+): boolean {
+  if (before === undefined || after === undefined) return true;
+  return after.mtimeNs !== before.mtimeNs || after.ctimeNs !== before.ctimeNs;
+}
+
+/**
+ * Remove an entry that a pathname operation created somewhere the pinned
+ * directory did not witness, but only when it is exactly the inode this
+ * commit created. Anything else at that path belongs to someone else.
+ */
+async function retractMisplacedEntry(
+  path: string,
+  identity: FileIdentity,
+): Promise<void> {
+  try {
+    const stat = await lstat(path);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      !isSameIdentity(stat, identity)
+    ) {
+      return;
+    }
+    await unlink(path);
+  } catch {
+    // Nothing to retract, or it is already gone.
+  }
+}
+
+/**
+ * Create the exclusive temp file and require the pinned directory to witness
+ * it. A temp the pinned directory did not witness landed in a directory
+ * swapped into the lexical path; it is removed through that same path.
+ */
+async function openWitnessedTemp(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRoot,
+  tempPath: string,
+  mode: number,
+): Promise<{
+  readonly handle: AsyncDirectoryHandle;
+  readonly opened: Awaited<ReturnType<AsyncDirectoryHandle["stat"]>>;
+}> {
+  const before = await directoryWitness(pinned);
+  const handle = await open(
+    tempPath,
+    fsConstants.O_WRONLY |
+      fsConstants.O_CREAT |
+      fsConstants.O_EXCL |
+      noFollowFlag(),
+    mode,
+  );
+  try {
+    if (!witnessedMutation(before, await directoryWitness(pinned))) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+    const opened = await handle.stat();
+    if (!opened.isFile() || opened.nlink !== 1) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+    return { handle, opened };
+  } catch (error) {
+    await handle.close();
+    try {
+      await unlink(tempPath);
+    } catch {
+      // Already gone; nothing else at this path is ours.
+    }
+    throw error;
+  }
+}
+
+/**
+ * Publish the verified temp: run the test seam and the crash failpoint that
+ * sit at the commit boundary, then link with the pinned directory as witness.
+ */
+async function publishWitnessedTemp(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRoot,
+  tempPath: string,
+  pinnedTargetPath: string,
+  tempIdentity: FileIdentity,
+): Promise<void> {
+  await atomicArtifactOperationForTesting?.({
+    operation: "commit_before_link",
+    targetPath: scope.targetPath,
+    trustedRoot: scope.trustedRoot,
+  });
+  hitM4DurabilityFailpoint("before_artifact_commit");
+  await linkWitnessed(scope, pinned, tempPath, pinnedTargetPath, tempIdentity);
+}
+
+/**
+ * link() is an atomic no-replace publication on the same filesystem. Unlike
+ * rename(), it cannot silently overwrite immutable evidence. The pinned
+ * directory must witness the new entry; a link it did not witness was
+ * published into a swapped directory and is retracted by the temp's inode.
+ * EEXIST is left to the caller, which decides between replay and conflict.
+ */
+async function linkWitnessed(
+  scope: ArtifactScope,
+  pinned: PinnedTrustedRoot,
+  tempPath: string,
+  pinnedTargetPath: string,
+  tempIdentity: FileIdentity,
+): Promise<void> {
+  const before = await directoryWitness(pinned);
+  try {
+    await link(tempPath, pinnedTargetPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" && pinned.mode === "witnessed-path") {
+      // The temp this commit just wrote is no longer where its path points:
+      // the lexical root was swapped underneath the pathname.
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
+    }
+    throw error;
+  }
+  if (witnessedMutation(before, await directoryWitness(pinned))) return;
+  await retractMisplacedEntry(pinnedTargetPath, tempIdentity);
+  throw new AtomicArtifactUnsafePathError(scope.targetPath, scope.trustedRoot);
 }
 
 function isSameIdentity(
@@ -585,8 +790,9 @@ async function descriptorOperationPath(
     try {
       if ((await realpath(candidate)) === canonicalPath) return candidate;
     } catch {
-      // Optional descriptor aliases are probed below; an unavailable alias is
-      // not permission to fall back to a racy POSIX pathname.
+      // Optional descriptor aliases are probed in turn. An unavailable alias
+      // is not permission to fall back to a bare POSIX pathname; bindPinnedRoot
+      // decides what the platform may do instead (see PinnedRootMode).
     }
   }
   return undefined;
@@ -657,20 +863,20 @@ async function pinTrustedRoot(
         scope.trustedRoot,
       );
     }
-    const descriptorPath = await descriptorOperationPath(handle, canonicalPath);
-    if (descriptorPath === undefined) {
-      throw new AtomicArtifactOperationUnsupportedError(
-        options.operation,
-        scope.trustedRoot,
-      );
-    }
+    const binding = bindPinnedRoot(
+      await descriptorOperationPath(handle, canonicalPath),
+      canonicalPath,
+      scope,
+      options.operation,
+    );
 
     const pinned: PinnedTrustedRoot = {
       canonicalPath,
       dev: lexical.dev,
       ino: lexical.ino,
       handle,
-      operationPath: descriptorPath,
+      operationPath: binding.operationPath,
+      mode: binding.mode,
     };
     await assertPinnedRootCurrent(scope, pinned);
     return pinned;
@@ -725,25 +931,25 @@ function pinTrustedRootSync(
 
   try {
     const opened = fstatSync(fd);
-    const operationPath = descriptorOperationPathSync(fd, canonicalPath);
     if (!opened.isDirectory() || !isSameIdentity(opened, lexical)) {
       throw new AtomicArtifactUnsafePathError(
         scope.targetPath,
         scope.trustedRoot,
       );
     }
-    if (operationPath === undefined) {
-      throw new AtomicArtifactOperationUnsupportedError(
-        options.operation,
-        scope.trustedRoot,
-      );
-    }
+    const binding = bindPinnedRoot(
+      descriptorOperationPathSync(fd, canonicalPath),
+      canonicalPath,
+      scope,
+      options.operation,
+    );
     const pinned: PinnedTrustedRootSync = {
       canonicalPath,
       dev: lexical.dev,
       ino: lexical.ino,
       fd,
-      operationPath,
+      operationPath: binding.operationPath,
+      mode: binding.mode,
     };
     assertPinnedRootCurrentSync(scope, pinned);
     return pinned;
@@ -842,11 +1048,24 @@ async function cleanupPinnedArtifactTemps(
       if (removedCount > 0) await fsyncPinnedRoot(pinned);
       return { removedCount, truncated: true };
     }
+    if (pinned.mode === "witnessed-path") {
+      // A pathname unlink cannot be undone: re-verify the root immediately
+      // before each one and require the pinned directory to witness it.
+      await assertPinnedRootCurrent(scope, pinned);
+    }
+    const beforeUnlink = await directoryWitness(pinned);
     try {
       await unlink(candidate);
       removedCount += 1;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      continue;
+    }
+    if (!witnessedMutation(beforeUnlink, await directoryWitness(pinned))) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
     }
   }
   if (removedCount > 0) await fsyncPinnedRoot(pinned);
@@ -877,11 +1096,22 @@ function cleanupPinnedArtifactTempsSync(
       if (removedCount > 0) fsyncPinnedRootSync(pinned);
       return { removedCount, truncated: true };
     }
+    if (pinned.mode === "witnessed-path") {
+      assertPinnedRootCurrentSync(scope, pinned);
+    }
+    const beforeUnlink = directoryWitnessSync(pinned);
     try {
       unlinkSync(candidate);
       removedCount += 1;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      continue;
+    }
+    if (!witnessedMutation(beforeUnlink, directoryWitnessSync(pinned))) {
+      throw new AtomicArtifactUnsafePathError(
+        scope.targetPath,
+        scope.trustedRoot,
+      );
     }
   }
   if (removedCount > 0) fsyncPinnedRootSync(pinned);

--- a/runtime/tests/durability/atomic-artifact.darwin.test.ts
+++ b/runtime/tests/durability/atomic-artifact.darwin.test.ts
@@ -23,9 +23,16 @@ import {
 // macOS has no traversable descriptor path for a directory, so the helper runs
 // in its witnessed-path mode there: children are addressed through the
 // canonical path, and every directory mutation must be witnessed by the pinned
-// directory descriptor. These tests pin that mode's contract. They are darwin
-// only because the descriptor mode on Linux makes the injected swaps inert.
-describe.runIf(process.platform === "darwin")(
+// directory descriptor. These tests pin that mode's contract. Like the other
+// platform probes in NATIVE_TEST_INCLUDE, the file runs only in its matching
+// native lane (vitest.native.config.ts on a macOS builder); on Linux the
+// descriptor mode makes the injected swaps inert, and a platform skip would
+// trip the default suite's zero-skip rule.
+if (process.platform !== "darwin") {
+  throw new Error("the darwin atomic-artifact integration tests require macOS");
+}
+
+describe(
   "atomic artifact commit on macOS (witnessed-path mode)",
   () => {
     const directories: string[] = [];

--- a/runtime/tests/durability/atomic-artifact.darwin.test.ts
+++ b/runtime/tests/durability/atomic-artifact.darwin.test.ts
@@ -25,9 +25,10 @@ import {
 // canonical path, and every directory mutation must be witnessed by the pinned
 // directory descriptor. These tests pin that mode's contract. Like the other
 // platform probes in NATIVE_TEST_INCLUDE, the file runs only in its matching
-// native lane (vitest.native.config.ts on a macOS builder); on Linux the
-// descriptor mode makes the injected swaps inert, and a platform skip would
-// trip the default suite's zero-skip rule.
+// native lane (vitest.native.config.ts on a macOS builder). On Linux the
+// descriptor mode makes the injected swaps inert, and the default suite
+// requires every collected test to run, so the file is excluded there
+// rather than gated.
 if (process.platform !== "darwin") {
   throw new Error("the darwin atomic-artifact integration tests require macOS");
 }

--- a/runtime/tests/durability/atomic-artifact.darwin.test.ts
+++ b/runtime/tests/durability/atomic-artifact.darwin.test.ts
@@ -1,0 +1,170 @@
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  __setAtomicArtifactOperationForTesting,
+  AtomicArtifactUnsafePathError,
+  cleanupOrphanedArtifactTemps,
+  commitArtifactAtomically,
+} from "../../src/durability/atomic-artifact.js";
+
+// macOS has no traversable descriptor path for a directory, so the helper runs
+// in its witnessed-path mode there: children are addressed through the
+// canonical path, and every directory mutation must be witnessed by the pinned
+// directory descriptor. These tests pin that mode's contract. They are darwin
+// only because the descriptor mode on Linux makes the injected swaps inert.
+describe.runIf(process.platform === "darwin")(
+  "atomic artifact commit on macOS (witnessed-path mode)",
+  () => {
+    const directories: string[] = [];
+
+    afterEach(() => {
+      __setAtomicArtifactOperationForTesting(undefined);
+      for (const directory of directories.splice(0)) {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+
+    function swapFixture(): {
+      trustedRoot: string;
+      movedRoot: string;
+      outsideRoot: string;
+      targetPath: string;
+    } {
+      const container = mkdtempSync(join(tmpdir(), "agenc-artifact-darwin-"));
+      directories.push(container);
+      const trustedRoot = join(container, "tool-results");
+      const movedRoot = join(container, "tool-results-original");
+      const outsideRoot = join(container, "outside");
+      mkdirSync(trustedRoot);
+      mkdirSync(outsideRoot);
+      return {
+        trustedRoot,
+        movedRoot,
+        outsideRoot,
+        targetPath: join(trustedRoot, "result.txt"),
+      };
+    }
+
+    it("publishes complete bytes through the witnessed path and replays idempotently", async () => {
+      const directory = mkdtempSync(join(tmpdir(), "agenc-artifact-darwin-"));
+      directories.push(directory);
+      const path = join(directory, "artifact.txt");
+
+      await expect(
+        commitArtifactAtomically(path, "complete bytes", {
+          trustedRoot: directory,
+        }),
+      ).resolves.toBe("committed");
+      await expect(
+        commitArtifactAtomically(path, "complete bytes", {
+          trustedRoot: directory,
+        }),
+      ).resolves.toBe("already_committed");
+
+      expect(readFileSync(path, "utf8")).toBe("complete bytes");
+      expect(readdirSync(directory)).toEqual(["artifact.txt"]);
+    });
+
+    it("refuses to publish when the root is swapped between the temp write and the link", async () => {
+      const fixture = swapFixture();
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "commit_before_link") return;
+        // The temp already exists inside the real root. Swap the lexical path
+        // to a directory that does not contain it.
+        renameSync(fixture.trustedRoot, fixture.movedRoot);
+        symlinkSync(fixture.outsideRoot, fixture.trustedRoot, "dir");
+      });
+
+      await expect(
+        commitArtifactAtomically(fixture.targetPath, "must stay contained", {
+          trustedRoot: fixture.trustedRoot,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+
+      expect(existsSync(join(fixture.outsideRoot, "result.txt"))).toBe(false);
+      expect(existsSync(join(fixture.movedRoot, "result.txt"))).toBe(false);
+      // The temp written before the swap is an orphan in the real root now,
+      // and the ordinary orphan sweep removes it.
+      const orphans = readdirSync(fixture.movedRoot);
+      expect(orphans.every((name) => name.endsWith(".tmp"))).toBe(true);
+      await expect(
+        cleanupOrphanedArtifactTemps(join(fixture.movedRoot, "result.txt"), {
+          trustedRoot: fixture.movedRoot,
+        }),
+      ).resolves.toEqual({ removedCount: orphans.length, truncated: false });
+      expect(readdirSync(fixture.movedRoot)).toEqual([]);
+    });
+
+    it("retracts a publication the pinned directory did not witness", async () => {
+      const fixture = swapFixture();
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "commit_before_link") return;
+        // Mirror the fresh temp into the outside directory by hard link, so the
+        // link() by pathname SUCCEEDS there after the swap. The pinned root
+        // sees no mutation, and the retraction must remove exactly that inode.
+        for (const name of readdirSync(fixture.trustedRoot)) {
+          linkSync(
+            join(fixture.trustedRoot, name),
+            join(fixture.outsideRoot, name),
+          );
+        }
+        renameSync(fixture.trustedRoot, fixture.movedRoot);
+        symlinkSync(fixture.outsideRoot, fixture.trustedRoot, "dir");
+      });
+
+      await expect(
+        commitArtifactAtomically(fixture.targetPath, "must stay contained", {
+          trustedRoot: fixture.trustedRoot,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+
+      expect(existsSync(join(fixture.outsideRoot, "result.txt"))).toBe(false);
+      expect(existsSync(join(fixture.movedRoot, "result.txt"))).toBe(false);
+      // Only temps remain anywhere; nothing was acknowledged as published.
+      expect(
+        [...readdirSync(fixture.outsideRoot), ...readdirSync(fixture.movedRoot)]
+          .every((name) => name.endsWith(".tmp")),
+      ).toBe(true);
+    });
+
+    it("refuses to sweep orphans through a swapped path", async () => {
+      const fixture = swapFixture();
+      const tempName = "result.txt.101.orphan.tmp";
+      const outsideTemp = join(fixture.outsideRoot, tempName);
+      mkdirSync(fixture.movedRoot);
+      rmSync(fixture.movedRoot, { recursive: true });
+      const { writeFileSync } = await import("node:fs");
+      writeFileSync(join(fixture.trustedRoot, tempName), "owned orphan");
+      writeFileSync(outsideTemp, "must stay");
+      __setAtomicArtifactOperationForTesting(({ operation }) => {
+        if (operation !== "cleanup") return;
+        renameSync(fixture.trustedRoot, fixture.movedRoot);
+        symlinkSync(fixture.outsideRoot, fixture.trustedRoot, "dir");
+      });
+
+      await expect(
+        cleanupOrphanedArtifactTemps(fixture.targetPath, {
+          trustedRoot: fixture.trustedRoot,
+        }),
+      ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
+
+      expect(readFileSync(outsideTemp, "utf8")).toBe("must stay");
+      expect(readFileSync(join(fixture.movedRoot, tempName), "utf8")).toBe(
+        "owned orphan",
+      );
+    });
+  },
+);

--- a/runtime/tests/durability/atomic-artifact.test.ts
+++ b/runtime/tests/durability/atomic-artifact.test.ts
@@ -269,7 +269,13 @@ describe("atomic artifact commit", () => {
         cleanupOrphanedArtifactTemps(targetPath, { trustedRoot }),
       ).rejects.toBeInstanceOf(AtomicArtifactUnsafePathError);
 
-      expect(existsSync(join(movedRoot, tempName))).toBe(false);
+      // Descriptor mode keeps operating inside the pinned root after the
+      // lexical swap, so the owned orphan is gone. Witnessed-path mode (darwin)
+      // can no longer address the pinned root through its path, so it refuses
+      // to delete anything and the owned orphan survives for the next pass.
+      expect(existsSync(join(movedRoot, tempName))).toBe(
+        process.platform === "darwin",
+      );
       expect(readFileSync(join(outsideRoot, tempName), "utf8")).toBe(
         "must stay",
       );

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -55,6 +55,7 @@ const CROSS_REPO_TEST_FILES = [
 const NATIVE_TEST_FILES = [
   "tests/agents/jobs/csv-output.native.test.ts",
   "tests/app-server/windows-named-pipe.win32.test.ts",
+  "tests/durability/atomic-artifact.darwin.test.ts",
   "tests/durability/atomic-artifact.win32.test.ts",
   "tests/fnd/process-repository-helpers.native.test.ts",
   "tests/state/recovery-file.win32.test.ts",

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -118,6 +118,7 @@ export const CROSS_REPO_TEST_INCLUDE = Object.freeze([
 export const NATIVE_TEST_INCLUDE = Object.freeze([
   "tests/agents/jobs/csv-output.native.test.ts",
   "tests/app-server/windows-named-pipe.win32.test.ts",
+  "tests/durability/atomic-artifact.darwin.test.ts",
   "tests/durability/atomic-artifact.win32.test.ts",
   "tests/fnd/process-repository-helpers.native.test.ts",
   "tests/state/recovery-file.win32.test.ts",


### PR DESCRIPTION
Closes #2135.

## Why

`runtime/src/durability/atomic-artifact.ts` pins the trusted root through a descriptor path and requires `realpath('/dev/fd/N') === canonicalPath`. On darwin the fdesc filesystem returns `/dev/fd/<name>` and `/dev/fd/N` is not traversable for a directory (no readdir, no child open, no link/rename through it, and even `stat` does not match the fd's identity). So every `commitArtifactAtomically`, `commitArtifactSourceAtomically`, `cleanupOrphanedArtifactTemps` and `withAtomicArtifactObservationSync` on macOS threw `AtomicArtifactOperationUnsupportedError` since #1544 (2026-07-18).

Every caller swallows that error, so nothing was logged:

| consumer | effect on macOS |
| --- | --- |
| `utils/toolResultStorage.ts` | returns `{ error }`; `persistOversizedToolResult` in `session/run-turn.ts` returns `null`; the aggregate tool-result budget is a no-op and medium results flow verbatim into the context; a single oversized result is truncated instead of offloaded |
| `utils/mcpOutputStorage.ts` | MCP and IDE binary/audio artifacts: "could not be saved to disk" |
| `agents/workflow-handoff-store.ts` | every artifact publication throws |
| `session/rollout-store.ts` | recovery treats every artifact as a review-required conflict |

Production evidence on the reviewing machine: the packaged AgenC.app daemon had 27 rollouts and three `tool-results/` directories, all empty. The desktop pins core 0.17.0 (76811dd5, 2026-08-20), so the shipped Mac app carries this.

Node exposes no `openat`/`renameat`/`linkat`/`F_GETPATH`, so descriptor semantics cannot be restored in pure Node on darwin. This PR adds a second, explicitly weaker binding mode for darwin instead of leaving the platform with nothing.

## What changed

- `runtime/src/durability/atomic-artifact.ts`
  - `PinnedRootMode`: `descriptor` (unchanged, still the default wherever the platform offers a descriptor path) or `witnessed-path` (darwin only, chosen by `bindPinnedRoot` when no descriptor path resolves). Any other platform without a descriptor path still fails closed with `ARTIFACT_SAFE_OPERATION_UNSUPPORTED`; Windows behaviour is unchanged.
  - Witness: `directoryWitness`/`directoryWitnessSync` snapshot the pinned directory's own `mtimeNs`/`ctimeNs` through the open descriptor; `witnessedMutation` requires them to change across a pathname mutation. APFS stamps each entry mutation with a distinct nanosecond time (probe: 50/50 rapid creates distinct), and a mutation in another directory leaves the pinned one untouched. In descriptor mode the witness is a no-op.
  - `openWitnessedTemp`: exclusive `O_CREAT|O_EXCL|O_NOFOLLOW` temp, witnessed; owns the regular-file/`nlink === 1` check that both commit variants used to duplicate; on failure closes, unlinks the misplaced temp through the same path, rethrows.
  - `linkWitnessed` + `retractMisplacedEntry`: the no-replace `link()` publication must be witnessed; a link the pinned directory did not witness went into a swapped directory and is retracted only if the entry is exactly the temp's inode. `ENOENT` on the link in witnessed mode means the temp this commit just wrote is no longer where its path points, which is a swap, and is reported as `AtomicArtifactUnsafePathError`.
  - `publishWitnessedTemp`: the test seam (`commit_before_link`, new) and the `before_artifact_commit` failpoint, then the witnessed link. Both commit variants call it, which removes the duplicated block SonarCloud would otherwise count.
  - Orphan sweeps: in witnessed mode, re-verify the root (`assertPinnedRootCurrent`) immediately before each pathname unlink and require the pinned directory to witness the unlink.
  - Doc comment on `PinnedRootMode` states the residual: reads (observation, cleanup listing) have no witness and rely on the identity re-verification around them, so a same-user swap installed and removed inside that window is not detectable.
- `runtime/tests/durability/atomic-artifact.test.ts`: one expectation in "keeps cleanup inside the pinned root when its lexical path is swapped" is now platform-conditional with a comment. Descriptor mode keeps deleting inside the pinned root after the swap; witnessed-path mode refuses to delete through a swapped path, so the owned orphan survives for the next pass. Everything else in the file is unchanged and now passes on macOS.
- `runtime/vitest.config.ts`: the new darwin file is listed in `NATIVE_TEST_INCLUDE`, so the default suite excludes it (the default platform suite runs with `--require-zero-skips`, and a `describe.runIf(darwin)` registered four skipped tests on Linux: shard 3 of the first dispatch carrying this branch failed on exactly that). It runs through `vitest.native.config.ts` on a macOS builder, like `runtime.darwin.test.ts` and `macOsKeychainHelper.darwin.test.ts`.
- `runtime/tests/durability/atomic-artifact.darwin.test.ts` (new, native lane, macOS builder): guarded with a platform throw like `atomic-artifact.win32.test.ts`; publish and idempotent replay through the witnessed path; a swap injected at `commit_before_link` is refused and the orphan temp is swept by the ordinary cleanup; a publication the pinned directory did not witness (the outside directory carries a hard link of the fresh temp, so `link()` by pathname succeeds there) is retracted; an orphan sweep through a swapped path is refused.
- `docs/design/durable-runs-effects-events.md`: the "Immutable artifact publication" section no longer claims `/dev/fd` on macOS is supported and acceptance-tested; it describes the witnessed-path mode and its residual.

## Evidence

macOS 26 (Darwin 25.6.0), Node 26.8.1, hermetic runner at `origin/main` d79513c29:

| run | before | after |
| --- | --- | --- |
| `tests/durability/atomic-artifact.test.ts` | 11 failed / 4 passed | 15 passed |
| `tests/durability/atomic-artifact.darwin.test.ts` (new, `--config vitest.native.config.ts`) | n/a | 4 passed, 0 skipped |
| `tests/durability` under the default config (darwin file excluded) | | 6 files, 80 passed, 0 skipped |
| `tests/session/run-turn.test.ts` "a burst of medium tool results is bounded by the aggregate budget" | failed at every commit this week (persistence never succeeded) | passed; file 130/130 |
| `tests/services/mcp/client.test.ts` (incl. "persists audio and binary resource content as file references") | 2 failed | 56 passed; both files 186/186 |
| `tsc --noEmit -p runtime/tsconfig.json` | | exit 0 |

Direct probe outside the harness (plain home directory, no `/tmp` symlink involved): `realpathSync('/dev/fd/N')` -> `/dev/fd/11`, `realpathSync.native` -> `/dev/fd/A`, `readdir('/dev/fd/N')` -> ENOTDIR, `open('/dev/fd/N/child')` -> ENOENT, `commitArtifactAtomically` -> `ARTIFACT_SAFE_OPERATION_UNSUPPORTED`.

## Tests

Each protective mechanism has a mutant that exactly one darwin test kills:

| mutant | test that goes red |
| --- | --- |
| `witnessedMutation` always true (witness disabled) | "retracts a publication the pinned directory did not witness" |
| `ENOENT` on link no longer mapped to `AtomicArtifactUnsafePathError` | "refuses to publish when the root is swapped between the temp write and the link" |
| orphan sweep skips the pre-unlink `assertPinnedRootCurrent` | "refuses to sweep orphans through a swapped path" |

Linux: the descriptor path still resolves, `bindPinnedRoot` returns `descriptor`, the witness is a no-op, and the injected swaps in the darwin file would be inert, which is why that file lives in the native lane instead of the default suite. The affected-tests gate on this PR is the Linux run.

## Not changed

- Descriptor mode on Linux: the same calls, in the same order, with `operationPath` still the `/proc/self/fd/N` alias. The only Linux-visible change is that the `nlink === 1` check moved into `openWitnessedTemp`, and the `before_artifact_commit` failpoint now fires from `publishWitnessedTemp` at the same point in the sequence.
- Windows: `bindPinnedRoot` throws `AtomicArtifactOperationUnsupportedError` exactly where the old code did.
- `observePinnedArtifactSync` reads by pathname in witnessed mode with no witness (there is no directory mutation to witness). It keeps the existing `assertPinnedRootCurrentSync` before and after plus the two-observation identity comparison. That residual is stated in the code, the doc, and #2135.
- No native helper. Option B in #2135 (an `openat`/`linkat`/`F_GETPATH` helper under `runtime/native/`) would restore full descriptor semantics on darwin and can replace this mode later without touching callers.
- `macos-native` in `platform-tests.yml` does not yet run the new file; the follow-up PR adds it to the exact native lane (13 suites, 101 tests) and runs `tests/durability`, the run-turn suite and the MCP client suite on the macOS builder.

## Counterparts

- #2135 (issue, closed by this PR).
- #2134 (merged): the hermetic run root on `/private/tmp`, without which these tests cannot be run on a Mac at all.
- Follow-up PR: run `platform-tests.yml` on push to `main` and have `macos-native` cover `tests/durability` and `tests/session`.
