### PR TITLE
test(hermetic): assert the run-root base without a platform skip

### DIFF
--- a/runtime/tests/hermetic-run-root.test.ts
+++ b/runtime/tests/hermetic-run-root.test.ts
@@ -25,24 +25,17 @@ describe("createHermeticRunRoot", () => {
     },
   );
 
-  it.runIf(process.platform === "darwin")(
-    "bases the root under /private/tmp on macOS, never the /tmp symlink",
+  it.runIf(process.platform !== "win32")(
+    "bases the root on the canonical temp directory of the platform",
     () => {
+      // macOS: /private/tmp, the real directory behind the /tmp symlink.
+      // Linux: /tmp itself. One assertion, no platform-specific skip, so the
+      // suite registers zero skipped tests on every default-suite runner.
+      const expectedBase =
+        process.platform === "darwin" ? "/private/tmp" : "/tmp";
       const root = createHermeticRunRoot("agv-test-");
       try {
-        expect(root.startsWith("/private/tmp/agv-test-")).toBe(true);
-      } finally {
-        rmSync(root, { recursive: true, force: true });
-      }
-    },
-  );
-
-  it.runIf(process.platform === "linux")(
-    "bases the root under /tmp on Linux",
-    () => {
-      const root = createHermeticRunRoot("agv-test-");
-      try {
-        expect(root.startsWith("/tmp/agv-test-")).toBe(true);
+        expect(root.startsWith(`${expectedBase}/agv-test-`)).toBe(true);
       } finally {
         rmSync(root, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Why

The default platform suite runs `run-hermetic-vitest.mjs --require-zero-skips`. `runtime/tests/hermetic-run-root.test.ts` (from #2134) gated its darwin case and its linux case with `it.runIf`, and vitest reports the inactive one as a skipped test. On the first platform-tests dispatch that carried #2134 (run 33890022955, on a branch stacked on main), `default-suite 1/4` passed 5183 tests and still exited 1 with "Hermetic Vitest requires zero skipped tests; observed 1". That would fail the next platform run on `main`.

## What changed

- `runtime/tests/hermetic-run-root.test.ts`: the two platform cases are one assertion that derives the expected base from the platform (`/private/tmp` on darwin, `/tmp` elsewhere), gated only by `process.platform !== "win32"`, which is true on every default-suite runner. The canonical-path and socket-length assertions are unchanged.

## Evidence

macOS, `run-hermetic-vitest.mjs --require-zero-skips run tests/hermetic-run-root.test.ts`: 3 passed, 0 skipped, exit 0. Before this change the same command reported 1 skipped on Linux and would have failed under the zero-skip rule.

## Tests

The file is the test. `run-fast-checks.mjs` picks it up directly as a changed runtime test.

## Not changed

The helper itself (`createHermeticRunRoot`) and #2134's behaviour.

## Counterparts

#2134 (merged, introduced the file); the platform-tests-on-push PR that surfaced this.