### PR TITLE
ci(platform-tests): run on push to main and cover the darwin-sensitive suites on macOS

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -2,6 +2,8 @@ name: platform-tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
 
 concurrency:
   group: platform-tests-${{ github.event.pull_request.number || github.ref }}
@@ -1147,6 +1149,22 @@ jobs:
           npm_config_build_from_source=true \
             npm rebuild better-sqlite3 esbuild node-pty
 
+      - name: Run the suites that only fail on macOS when darwin is broken
+        # The durability helper, the run-turn tool-result budget that depends on
+        # it, and the MCP client's artifact persistence were unsupported on
+        # darwin for seven weeks while this job ran one unrelated file.
+        shell: bash
+        run: |
+          set -euo pipefail
+          node runtime/scripts/run-hermetic-vitest.mjs \
+            --require-zero-skips \
+            run \
+            tests/durability \
+            tests/session/run-turn.test.ts \
+            tests/services/mcp/client.test.ts \
+            --allowOnly=false \
+            --reporter=dot
+
       - name: Run the exact macOS red-probe runner contract
         shell: bash
         run: |
@@ -1215,6 +1233,7 @@ jobs:
             --require-zero-skips \
             run \
             tests/agents/jobs/csv-output.native.test.ts \
+            tests/durability/atomic-artifact.darwin.test.ts \
             tests/fnd/benchmark-harness-faults.test.ts \
             tests/fnd/bounded-file-io.test.ts \
             tests/fnd/fnd-fixtures.test.ts \
@@ -1236,6 +1255,7 @@ jobs:
           const results = JSON.parse(readFileSync(resultsPath, "utf8"));
           const expectedFiles = [
             "tests/agents/jobs/csv-output.native.test.ts",
+            "tests/durability/atomic-artifact.darwin.test.ts",
             "tests/fnd/benchmark-harness-faults.test.ts",
             "tests/fnd/bounded-file-io.test.ts",
             "tests/fnd/fnd-fixtures.test.ts",
@@ -1245,12 +1265,12 @@ jobs:
             "tests/utils/secureStorage/macOsKeychainHelper.darwin.test.ts",
           ];
           const exactCounts = {
-            numTotalTestSuites: 12,
-            numPassedTestSuites: 12,
+            numTotalTestSuites: 14,
+            numPassedTestSuites: 14,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 97,
-            numPassedTests: 97,
+            numTotalTests: 101,
+            numPassedTests: 101,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -1277,7 +1297,7 @@ jobs:
               `macOS-native files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
             );
           }
-          console.log("macOS FND/native capability lane passed 97 tests in 8 files with zero skipped");
+          console.log("macOS FND/native capability lane passed 101 tests in 9 files with zero skipped");
           NODE
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
 

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -447,6 +447,9 @@ describe("reproducible install and release contract", () => {
       "Run the exact macOS FND/native capability lane",
     );
     expect(macosJob).toContain("tests/agents/jobs/csv-output.native.test.ts");
+    expect(macosJob).toContain(
+      "tests/durability/atomic-artifact.darwin.test.ts",
+    );
     expect(macosJob).toContain("tests/fnd/benchmark-harness-faults.test.ts");
     expect(macosJob).toContain("tests/fnd/bounded-file-io.test.ts");
     expect(macosJob).toContain("tests/fnd/fnd-fixtures.test.ts");
@@ -459,11 +462,17 @@ describe("reproducible install and release contract", () => {
       "tests/utils/secureStorage/macOsKeychainHelper.darwin.test.ts",
     );
     expect(macosJob).toContain("--config vitest.native.config.ts");
-    expect(macosJob).toContain("numTotalTestSuites: 12");
-    expect(macosJob).toContain("numTotalTests: 97");
+    expect(macosJob).toContain("numTotalTestSuites: 14");
+    expect(macosJob).toContain("numTotalTests: 101");
     expect(macosJob).toContain(
-      "macOS FND/native capability lane passed 97 tests in 8 files with zero skipped",
+      "macOS FND/native capability lane passed 101 tests in 9 files with zero skipped",
     );
+    expect(macosJob).toContain(
+      "Run the suites that only fail on macOS when darwin is broken",
+    );
+    expect(macosJob).toContain("tests/durability");
+    expect(macosJob).toContain("tests/session/run-turn.test.ts");
+    expect(macosJob).toContain("tests/services/mcp/client.test.ts");
 
     const windowsJob = workflow.slice(workflow.indexOf("\n  windows-native:"));
     expect(windowsJob).toContain("runs-on: windows-2025-vs2026");
@@ -553,7 +562,7 @@ describe("reproducible install and release contract", () => {
         /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/g,
       ),
     ).toHaveLength(4);
-    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(9);
+    expect(workflow.match(/--require-zero-skips/g)).toHaveLength(10);
     expect(workflow).not.toMatch(/uses:\s+actions\/[\w-]+@v\d/);
     expect(workflow).not.toContain("cache: npm");
     expect(workflow).not.toContain("--passWithNoTests");


### PR DESCRIPTION
## Why

`platform-tests.yml` was `workflow_dispatch` only, so the merged tree on `main` was never tested as a whole. The first dispatch on `main` (run 33887199821, 2026-09-04) showed what that hid: 5,544 of 5,545 tests pass on the Linux shards, and the one failure is the stale FND benchmark baseline that #1832 has tracked since 08-30. Separately, ten PRs merged 09-01 to 09-03 with the `affected-tests` gate red. Nothing runs after a merge to catch either.

`macos-native` ran exactly one file, `tests/fnd/red-probe-runner.contract.test.ts`, plus an exact eight-file native lane. The durability helper being unsupported on darwin since #1544 (#2135, fixed in #2136) was therefore invisible to CI for seven weeks, and with it the run-turn tool-result budget and MCP artifact persistence on the platform the desktop app ships on.

## What changed

- `.github/workflows/platform-tests.yml`
  - `on.push.branches: [main]`. The existing concurrency group (`platform-tests-${{ github.ref }}` with `cancel-in-progress`) collapses a burst of merges to the newest commit.
  - `macos-native`: a new step runs `tests/durability`, `tests/session/run-turn.test.ts` and `tests/services/mcp/client.test.ts` under the default config with `--require-zero-skips`, ahead of the unchanged exact red-probe contract. The exact native lane gains `tests/durability/atomic-artifact.darwin.test.ts` (9 files, 14 suites, 101 tests; the lane's exact counts, expected-file list and success message are updated).
- `runtime/tests/packaging/reproducible-build.test.ts`: the pins that mirror the workflow are updated to match (the new file in the macOS lane, 14 suites, 101 tests, the success message, the new step and its three suites, and the `--require-zero-skips` occurrence count 9 to 10).

## Evidence

Dispatched on this branch while it was stacked on #2136 (run 33894603058):

| job | result |
| --- | --- |
| macos-native | success: exact native lane 101 tests in 9 files, new step 266 tests in 9 files, red-probe 66 tests |
| default-suite 2/4, 4/4 | success (4/4 carries `reproducible-build.test.ts`, so the pins are consistent) |
| default-suite 3/4 | failure: `tests/fnd/benchmark-baselines.contract.test.ts`, the stale FND baseline (#1832), identical to `main` |
| default-suite 1/4 | failure: one skipped test in `hermetic-run-root.test.ts`, already fixed on `main` by #2137 which this branch predated; plus one intermittent failure in `tests/llm/provider-credential-authority.test.ts` that passed in both earlier shard-1 runs |
| every other lane (kernel sandbox, PowerShell, Neovim x6, Windows) | success |

An earlier dispatch on the same branch (run 33892280130) is what surfaced the two meta-tests this PR now satisfies: the discovery allowlist (fixed in #2136) and the lane pins in `reproducible-build.test.ts` (fixed here).

## Cost

Every push to `main` now runs 4 Linux shards (about 25 minutes each, in parallel), the kernel-sandbox, PowerShell and Neovim lanes, `windows-native` and `macos-native` on GitHub-hosted runners, so roughly one hour of wall clock and, at this week's merge rate, several full runs a day, macOS minutes included. `cancel-in-progress` keeps only the newest commit's run alive during a merge burst. If the minutes matter more than per-merge signal, the alternative is a daily `schedule` trigger on `main`; the diff for that is one block.

## Tests

`runtime/tests/packaging/reproducible-build.test.ts` passes locally with the updated pins (15/15) and passed in shard 4 of run 33894603058. The workflow itself is exercised by that run.

## Not changed

- The exact red-probe contract step in `macos-native` and every other lane's exact allowlist.
- No test file gains a platform gate; the default suite's zero-skip rule is untouched.
- The FND baseline (#1832) stays red on `main` until it is regenerated from a clean `main` worktree; this PR makes that visible on every push instead of never.

## Counterparts

#2135 (issue), #2136 (merged: darwin witnessed-path mode and the native-list convention for the darwin file), #2134 and #2137 (merged: hermetic run root on macOS without platform skips), #1832 (the remaining red on `main`).
