### PR TITLE
feat(eval): measure the coding loop with multi-prompt session tasks

### DIFF
--- a/docs/agent-eval-reports.md
+++ b/docs/agent-eval-reports.md
@@ -103,6 +103,7 @@ comparison against a committed baseline.
 | `runtime/eval/tasks/<task-id>/fixture/` | Tiny self-contained fixture repo copied into a temp workspace |
 | `runtime/eval/tasks/<task-id>/verify.mjs` | Pure deterministic checker (cwd = workspace; exit nonzero on fail; no network) |
 | `runtime/eval/tasks/<task-id>/solution.sh` + `solution/` | Scripted "mock executor" answer (proves checkers can pass) |
+| `runtime/eval/tasks/asteroid-drift-15/` | The first `kind: "session"` task: 15 prompts with per-step verifiers and a reference solution for the mock executor |
 | `runtime/eval/baseline-report.json` | Committed baseline the regression gate compares against |
 | `runtime/eval/reports/` | Gitignored output directory for fresh runs |
 | `runtime/eval/eval-config.example.json` | Example model/config matrix |
@@ -144,6 +145,20 @@ and a `configFingerprint` (sha256 over the benchmark, executor, agent command,
 agent identity, and the normalized task list) so runs are only compared
 like-for-like.
 
+## Session tasks (multi-prompt) and harness metrics
+
+`"kind": "session"` tasks drive one daemon session through `steps[].prompt`
+over the AgenC SDK, so the report measures the whole coding loop instead of one
+patch: per-step wall time and tokens, tool calls and tool errors, re-reads of a
+path with no edit in between, compaction attempts and failures, prompt-token
+growth and cached tokens, and permission requests an unattended run had to
+deny. Real session runs require `AGENC_HOME` set to an isolated home whose
+`config.toml` selects the model under test; the runner never starts a daemon in
+the default home. The mock executor installs the task's scripted solution once
+and runs every verifier, which proves the checkers. See
+[`runtime/eval/README.md`](../runtime/eval/README.md) for the metric table and
+the first session task, `asteroid-drift-15`.
+
 ## Regression gate
 
 ```bash
@@ -161,6 +176,10 @@ Exits nonzero when the candidate regresses beyond thresholds. Defaults:
 | Pass rate | passed / attempted (skipped excluded) | any drop > 0pp fails |
 | Cost | avg tokens per attempted task | > +20% fails |
 | Latency | avg duration per attempted task | > +50% fails |
+| Session tool-error rate | tool errors / tool calls across session tasks | warns; `--max-tool-error-rate-increase-pp` makes it fail |
+| Session re-read ratio | re-reads / file reads across session tasks | warns; `--max-reread-ratio-increase-pp` makes it fail |
+| Compactions per step | compactions / steps across session tasks | warns; `--max-compactions-per-step-increase` makes it fail |
+| Session cache-hit ratio | cached tokens / prompt tokens at the last turn | warns on any drop |
 
 Override with `--max-pass-rate-drop <pp>`, `--max-token-increase-pct <pct>`,
 `--max-latency-increase-pct <pct>`. A config-fingerprint mismatch is a warning

--- a/docs/agent-eval-reports.md
+++ b/docs/agent-eval-reports.md
@@ -152,9 +152,10 @@ over the AgenC SDK, so the report measures the whole coding loop instead of one
 patch: per-step wall time and tokens, tool calls and tool errors, re-reads of a
 path with no edit in between, compaction attempts and failures, prompt-token
 growth and cached tokens, and permission requests an unattended run had to
-deny. Real session runs require `AGENC_HOME` set to an isolated home whose
+deny. Every real run requires `AGENC_HOME` set to an isolated home whose
 `config.toml` selects the model under test; the runner never starts a daemon in
-the default home. The mock executor installs the task's scripted solution once
+the default home, and it trusts each temporary task workspace inside that home
+because print mode has no TTY for the trust prompt. The mock executor installs the task's scripted solution once
 and runs every verifier, which proves the checkers. See
 [`runtime/eval/README.md`](../runtime/eval/README.md) for the metric table and
 the first session task, `asteroid-drift-15`.

--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -53,6 +53,13 @@ npm run eval:agent -- --suite eval/tasks \
   --output eval/reports/grok-4.json
 ```
 
+The real executor needs `AGENC_HOME` pointing at an isolated home, never your
+own. Print mode has no TTY for the project-trust prompt, so the runner trusts
+each temporary task workspace inside that home before the agent runs there.
+`--setup-command <cmd>` (repeatable) runs in every workspace before the agent,
+with the same placeholders as `--agent-command`; task-level `setupCommands`
+run after it.
+
 Model/config matrix (one schema-valid report per entry):
 
 ```bash

--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -60,6 +60,17 @@ each temporary task workspace inside that home before the agent runs there.
 with the same placeholders as `--agent-command`; task-level `setupCommands`
 run after it.
 
+`eval/baseline-real-grok-4.6-xhigh.json` is the first real-agent baseline
+(grok-4.6 at xhigh effort over xAI, isolated home, 2026-09-04). It is a
+separate file from the mock baseline so each executor compares against its
+own kind of run; `npm run eval:coding:check` compares the newest report in
+`eval/reports` against it, warning on the session ratios and failing on the
+pass-rate, token and latency limits.
+In that run 12 of 12 command tasks passed and the session task passed 14 of
+15 steps; step 15 failed only because the changelog verifier counted list
+items while the agent wrote one headed section per step. The verifier now
+accepts both, so the recorded 92.31% fix rate understates the run.
+
 Model/config matrix (one schema-valid report per entry):
 
 ```bash

--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -138,6 +138,7 @@ results and a `metrics` block; the task carries the aggregate:
 | `compactions`, `compactionAttempts`, `compactionFailures`, `compactionRollbacks` | live `history_reset` plus rollout `compaction_*` records | context management pressure and its failure rate |
 | `promptTokensFirst`, `promptTokensLast`, `cachedTokensLast`, `cachedTokensMax` | rollout `token_count` | context growth and prompt-cache behaviour |
 | `permissionRequests` | live events | approvals the unattended run had to deny |
+| `providerFailures` | rollout `execution_admission` `held_unknown` records | model turns the provider dropped after dispatch; a step that did no work because of one is an error, not a pass |
 | `assistantMessages`, `assistantChars`, `reasoningOutputTokens` | live events and rollout | verbosity and reasoning spend |
 
 `check:eval-regression` derives tool-error rate, re-read ratio, compactions per

--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -105,3 +105,46 @@ and a scripted `solution.sh` so the mock executor and the harness tests can
 prove the checker passes after the intended change (and fails without it —
 `tests/eval/agent-eval-suite.test.ts` checks a no-op solution yields
 `failed`). After adding a task, refresh the baseline (above).
+
+## Session tasks and harness metrics
+
+A task with `"kind": "session"` drives one daemon session through several
+prompts (`steps[]`) instead of running one agent command. It measures the loop
+the desktop and TUI users actually experience: context growth, compaction,
+tool errors, unnecessary re-reads and cache behaviour across a whole project,
+not one patch. `asteroid-drift-15` is the first one: the 15-prompt browser game
+from the September harness review, with deterministic verifiers after the
+steps that matter (scaffold, style rules, module layout, features, tests,
+README, final CHANGELOG and high scores) and a scripted reference solution so
+the mock executor proves the checkers.
+
+Real runs go through the AgenC SDK against a daemon in an isolated home. The
+runner refuses to start a daemon in the default home:
+
+```bash
+AGENC_HOME=/absolute/isolated/home npm run eval:coding
+```
+
+The home's `config.toml` selects the model under test (the September baseline
+is `grok-4.6` at `reasoning_effort = "xhigh"` over the xAI sign-in stored for
+that home). Each step records wall time, token usage, stop reason, its verifier
+results and a `metrics` block; the task carries the aggregate:
+
+| metric | source | meaning |
+| --- | --- | --- |
+| `toolCalls`, `toolCallsByName` | live `tool_call` events | how much work each prompt took |
+| `toolErrors`, `warnings` | rollout tool results and `warning` events | failed tool calls the model had to recover from |
+| `fileReads`, `fileReReads` | live events | a re-read is a second read of a path with no Edit or Write in between |
+| `compactions`, `compactionAttempts`, `compactionFailures`, `compactionRollbacks` | live `history_reset` plus rollout `compaction_*` records | context management pressure and its failure rate |
+| `promptTokensFirst`, `promptTokensLast`, `cachedTokensLast`, `cachedTokensMax` | rollout `token_count` | context growth and prompt-cache behaviour |
+| `permissionRequests` | live events | approvals the unattended run had to deny |
+| `assistantMessages`, `assistantChars`, `reasoningOutputTokens` | live events and rollout | verbosity and reasoning spend |
+
+`check:eval-regression` derives tool-error rate, re-read ratio, compactions per
+step and cache-hit ratio from these and reports their movement against the
+baseline as warnings; `--max-tool-error-rate-increase-pp`,
+`--max-reread-ratio-increase-pp` and `--max-compactions-per-step-increase`
+turn any of them into a hard gate.
+
+This lane is diagnostic and non-confirmatory, like the rest of this directory;
+competitive claims come from the TFR suites under `eval/suites/`.

--- a/runtime/eval/baseline-real-grok-4.6-xhigh.json
+++ b/runtime/eval/baseline-real-grok-4.6-xhigh.json
@@ -1,0 +1,1115 @@
+{
+  "schemaVersion": 1,
+  "run": {
+    "id": "baseline-grok-4.6-xhigh-2026-09-04-r2",
+    "benchmark": "agenc-local-coding-v1",
+    "startedAt": "2026-09-04T19:38:03.297Z",
+    "finishedAt": "2026-09-04T20:30:23.408Z",
+    "agent": {
+      "name": "agenc",
+      "version": "0.17.0",
+      "provider": "xai",
+      "model": "grok-4.6"
+    },
+    "environment": {
+      "repo": "<runtime>",
+      "commit": "6ec9c4db7",
+      "branch": "work/eval-coding-loop",
+      "runner": "local",
+      "sandbox": "local",
+      "localOnly": true,
+      "executor": "real",
+      "configFingerprint": "8a1546b2c0ab5d02"
+    }
+  },
+  "tasks": [
+    {
+      "id": "fix-off-by-one",
+      "source": "agenc-local",
+      "title": "Fix off-by-one loop bound in sum()",
+      "status": "passed",
+      "durationMs": 28140,
+      "tokens": {
+        "input": 91474,
+        "output": 639,
+        "total": 92113
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'sum() in sum.js returns NaN because the loop reads one element past the end of the array. Fix the loop bounds so sum([1,2,3]) returns 6 and sum([]) returns 0.'",
+          "exitCode": 0,
+          "durationMs": 28104
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "fix-null-guard",
+      "source": "agenc-local",
+      "title": "Guard greet() against missing users",
+      "status": "passed",
+      "durationMs": 38639,
+      "tokens": {
+        "input": 93054,
+        "output": 789,
+        "total": 93843
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'greet() in greet.js throws when called with null, undefined, or a user without a name. It should fall back to the name \"guest\" in those cases and keep returning \"hello, <name>\" for users with a non-empty string name.'",
+          "exitCode": 0,
+          "durationMs": 38607
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "add-clamp",
+      "source": "agenc-local",
+      "title": "Add a clamp() helper to math.js",
+      "status": "passed",
+      "durationMs": 39760,
+      "tokens": {
+        "input": 91250,
+        "output": 596,
+        "total": 91846
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'Add an exported clamp(value, min, max) function to math.js that returns min when value < min, max when value > max, and value otherwise. Do not break the existing add() export.'",
+          "exitCode": 0,
+          "durationMs": 39728
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "add-cli-upper-flag",
+      "source": "agenc-local",
+      "title": "Add an --upper flag to cli.mjs",
+      "status": "passed",
+      "durationMs": 23220,
+      "tokens": {
+        "input": 74757,
+        "output": 517,
+        "total": 75274
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'cli.mjs prints \"hello, <name>\" using the first CLI argument (default \"world\"). Add support for an --upper flag that uppercases the entire output line. The flag may appear before or after the name and must not be treated as the name itself.'",
+          "exitCode": 0,
+          "durationMs": 23079
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "refactor-no-var",
+      "source": "agenc-local",
+      "title": "Replace var declarations in counter.js",
+      "status": "passed",
+      "durationMs": 48633,
+      "tokens": {
+        "input": 72453,
+        "output": 430,
+        "total": 72883
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'counter.js uses var declarations. Replace every var with const or let (whichever is correct) without changing the module'\\''s behavior: increment() advances the counter and reset() sets it back to 0.'",
+          "exitCode": 0,
+          "durationMs": 48591
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "refactor-extract-helper",
+      "source": "agenc-local",
+      "title": "Extract duplicated name formatting into a helper",
+      "status": "passed",
+      "durationMs": 28077,
+      "tokens": {
+        "input": 73040,
+        "output": 308,
+        "total": 73348
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'customerLabel() and employeeLabel() in report.js duplicate the same name-formatting expression. Extract it into an exported formatFullName(person) helper and make both label functions delegate to it. Output behavior must stay identical (trimmed first and last name, joined by a space, uppercased).'",
+          "exitCode": 0,
+          "durationMs": 28043
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "write-slugify-tests",
+      "source": "agenc-local",
+      "title": "Write assert-based tests for slugify()",
+      "status": "passed",
+      "durationMs": 36983,
+      "tokens": {
+        "input": 92363,
+        "output": 466,
+        "total": 92829
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'Create slugify.test.mjs in the repo root. It must import { slugify } from ./slugify.js and use node:assert to verify at least: slugify(\"Hello World\") === \"hello-world\", slugify(\"  spaced  \") === \"spaced\", and slugify(\"a--b\") === \"a-b\". The script must exit nonzero when an assertion fails and exit 0 otherwise.'",
+          "exitCode": 0,
+          "durationMs": 36886
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "tests-pass-and-catch-mutations",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "find-config-port",
+      "source": "agenc-local",
+      "title": "Locate the configured HTTP port",
+      "status": "passed",
+      "durationMs": 34644,
+      "tokens": {
+        "input": 73310,
+        "output": 254,
+        "total": 73564
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'This repo configures its HTTP port in an ini settings file; other numbers in the tree are red herrings. Find the port the app actually uses and write just that number (no other text) to a new ANSWER.txt file in the repo root.'",
+          "exitCode": 0,
+          "durationMs": 34609
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "answer",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "fix-config-json",
+      "source": "agenc-local",
+      "title": "Repair invalid config.json",
+      "status": "passed",
+      "durationMs": 29461,
+      "tokens": {
+        "input": 91807,
+        "output": 519,
+        "total": 92326
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'config.json fails JSON.parse because of a trailing comma. Fix the file so it parses, preserving every existing key and value exactly.'",
+          "exitCode": 0,
+          "durationMs": 29425
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "parses",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "rename-typo-symbol",
+      "source": "agenc-local",
+      "title": "Rename the misspelled procesData symbol",
+      "status": "passed",
+      "durationMs": 41164,
+      "tokens": {
+        "input": 110311,
+        "output": 951,
+        "total": 111262
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'The function procesData in lib/data.js is misspelled. Rename it to processData everywhere it appears (definition, import, and call site in index.js) without changing behavior.'",
+          "exitCode": 0,
+          "durationMs": 41128
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "docs-usage-section",
+      "source": "agenc-local",
+      "title": "Replace the README TODO with a Usage section",
+      "status": "passed",
+      "durationMs": 25026,
+      "tokens": {
+        "input": 54560,
+        "output": 325,
+        "total": 54885
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'README.md contains a TODO placeholder. Replace it with a \"## Usage\" section that shows how to run the widget with the exact command node index.js. Remove the TODO text entirely.'",
+          "exitCode": 0,
+          "durationMs": 24986
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "readme",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "fix-fizzbuzz-order",
+      "source": "agenc-local",
+      "title": "Fix fizzbuzz branch ordering",
+      "status": "passed",
+      "durationMs": 23828,
+      "tokens": {
+        "input": 74101,
+        "output": 574,
+        "total": 74675
+      },
+      "commands": [
+        {
+          "command": "agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox 'fizzbuzz() in fizzbuzz.js returns \"Fizz\" for multiples of 15 because the divisibility checks run in the wrong order. Fix it so multiples of 15 return \"FizzBuzz\" while multiples of only 3 or only 5 still return \"Fizz\" and \"Buzz\", and other numbers return their decimal string.'",
+          "exitCode": 0,
+          "durationMs": 23788
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "behavior",
+          "status": "passed",
+          "command": "node {taskDir}/verify.mjs"
+        }
+      ]
+    },
+    {
+      "id": "asteroid-drift-15",
+      "source": "agenc-local",
+      "title": "Asteroid Drift: a 15-prompt browser game built in one session",
+      "kind": "session",
+      "status": "failed",
+      "durationMs": 2742619,
+      "tokens": {
+        "input": 34544089,
+        "output": 675940,
+        "total": 35220029
+      },
+      "verifiers": [
+        {
+          "name": "final",
+          "status": "failed",
+          "command": "node {taskDir}/verify-final.mjs",
+          "details": "CHANGELOG.md should summarize the steps; found 0 entries, expected at least 10"
+        }
+      ],
+      "steps": [
+        {
+          "id": "01-scaffold",
+          "status": "passed",
+          "durationMs": 202340,
+          "tokens": {
+            "input": 189492,
+            "output": 8388,
+            "total": 197880
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 15,
+            "toolCallsByName": {
+              "Edit": 4,
+              "FileRead": 3,
+              "Grep": 2,
+              "Write": 2,
+              "exec_command": 4
+            },
+            "toolErrors": 0,
+            "fileReads": 3,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 9,
+            "providerFailures": 0,
+            "assistantMessages": 8,
+            "assistantChars": 1037,
+            "reasoningOutputTokens": 2536,
+            "promptTokensFirst": 18440,
+            "promptTokensLast": 28038,
+            "cachedTokensLast": 16896,
+            "cachedTokensMax": 20352
+          },
+          "verifiers": [
+            {
+              "name": "scaffold",
+              "status": "passed",
+              "command": "node {taskDir}/verify-scaffold.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "02-asteroids",
+          "status": "passed",
+          "durationMs": 64295,
+          "tokens": {
+            "input": 307232,
+            "output": 11051,
+            "total": 318283
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 4,
+            "toolCallsByName": {
+              "FileRead": 1,
+              "Grep": 1,
+              "MultiEdit": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 1,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 5,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 448,
+            "reasoningOutputTokens": 1127,
+            "promptTokensFirst": 28657,
+            "promptTokensLast": 30371,
+            "cachedTokensLast": 16896,
+            "cachedTokensMax": 16896
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "03-score",
+          "status": "passed",
+          "durationMs": 53177,
+          "tokens": {
+            "input": 428449,
+            "output": 13628,
+            "total": 442077
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 6,
+            "toolCallsByName": {
+              "FileRead": 3,
+              "Grep": 1,
+              "MultiEdit": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 3,
+            "fileReReads": 2,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 4,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 387,
+            "reasoningOutputTokens": 893,
+            "promptTokensFirst": 30325,
+            "promptTokensLast": 31004,
+            "cachedTokensLast": 20352,
+            "cachedTokensMax": 20352
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "04-start-pause",
+          "status": "passed",
+          "durationMs": 133288,
+          "tokens": {
+            "input": 612256,
+            "output": 20190,
+            "total": 632446
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 6,
+            "toolCallsByName": {
+              "Edit": 1,
+              "FileRead": 3,
+              "MultiEdit": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 3,
+            "fileReReads": 1,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 5,
+            "providerFailures": 0,
+            "assistantMessages": 5,
+            "assistantChars": 484,
+            "reasoningOutputTokens": 3522,
+            "promptTokensFirst": 31397,
+            "promptTokensLast": 40344,
+            "cachedTokensLast": 36480,
+            "cachedTokensMax": 36480
+          },
+          "verifiers": [
+            {
+              "name": "gameplay",
+              "status": "passed",
+              "command": "node {taskDir}/verify-gameplay.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "05-modules",
+          "status": "passed",
+          "durationMs": 127163,
+          "tokens": {
+            "input": 788186,
+            "output": 26478,
+            "total": 814664
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 10,
+            "toolCallsByName": {
+              "Edit": 2,
+              "FileRead": 2,
+              "Skill": 1,
+              "Write": 4,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 2,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 4,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 552,
+            "reasoningOutputTokens": 2021,
+            "promptTokensFirst": 40382,
+            "promptTokensLast": 46868,
+            "cachedTokensLast": 41600,
+            "cachedTokensMax": 41600
+          },
+          "verifiers": [
+            {
+              "name": "modules",
+              "status": "passed",
+              "command": "node {taskDir}/verify-modules.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "06-effects",
+          "status": "passed",
+          "durationMs": 128747,
+          "tokens": {
+            "input": 987056,
+            "output": 30845,
+            "total": 1017901
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 5,
+            "toolCallsByName": {
+              "FileRead": 2,
+              "Grep": 1,
+              "MultiEdit": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 2,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 4,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 450,
+            "reasoningOutputTokens": 2548,
+            "promptTokensFirst": 47050,
+            "promptTokensLast": 52253,
+            "cachedTokensLast": 512,
+            "cachedTokensMax": 31744
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "07-audio",
+          "status": "passed",
+          "durationMs": 121628,
+          "tokens": {
+            "input": 1213836,
+            "output": 35683,
+            "total": 1249519
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 7,
+            "toolCallsByName": {
+              "FileRead": 3,
+              "MultiEdit": 2,
+              "Write": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 3,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 5,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 470,
+            "reasoningOutputTokens": 1422,
+            "promptTokensFirst": 52642,
+            "promptTokensLast": 59381,
+            "cachedTokensLast": 49664,
+            "cachedTokensMax": 49664
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "08-powerups",
+          "status": "passed",
+          "durationMs": 259195,
+          "tokens": {
+            "input": 1765271,
+            "output": 44953,
+            "total": 1810224
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 23,
+            "toolCallsByName": {
+              "Edit": 7,
+              "FileRead": 12,
+              "MultiEdit": 1,
+              "Skill": 1,
+              "Write": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 12,
+            "fileReReads": 3,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 8,
+            "providerFailures": 0,
+            "assistantMessages": 8,
+            "assistantChars": 784,
+            "reasoningOutputTokens": 4031,
+            "promptTokensFirst": 59223,
+            "promptTokensLast": 76962,
+            "cachedTokensLast": 67712,
+            "cachedTokensMax": 67712
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "09-levels",
+          "status": "passed",
+          "durationMs": 95220,
+          "tokens": {
+            "input": 2081440,
+            "output": 47773,
+            "total": 2129213
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 12,
+            "toolCallsByName": {
+              "Edit": 8,
+              "FileRead": 1,
+              "Grep": 2,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 1,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 3,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 452,
+            "reasoningOutputTokens": 1120,
+            "promptTokensFirst": 77543,
+            "promptTokensLast": 80368,
+            "cachedTokensLast": 76672,
+            "cachedTokensMax": 76672
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "10-touch",
+          "status": "passed",
+          "durationMs": 183997,
+          "tokens": {
+            "input": 2745539,
+            "output": 52539,
+            "total": 2798078
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 19,
+            "toolCallsByName": {
+              "Edit": 9,
+              "FileRead": 9,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 9,
+            "fileReReads": 2,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 8,
+            "providerFailures": 0,
+            "assistantMessages": 8,
+            "assistantChars": 834,
+            "reasoningOutputTokens": 1991,
+            "promptTokensFirst": 80529,
+            "promptTokensLast": 85321,
+            "cachedTokensLast": 83328,
+            "cachedTokensMax": 83328
+          },
+          "verifiers": [
+            {
+              "name": "features",
+              "status": "passed",
+              "command": "node {taskDir}/verify-features.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "11-tests",
+          "status": "passed",
+          "durationMs": 200767,
+          "tokens": {
+            "input": 3283803,
+            "output": 58403,
+            "total": 3342206
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 21,
+            "toolCallsByName": {
+              "Edit": 7,
+              "FileRead": 4,
+              "Glob": 1,
+              "Grep": 2,
+              "Skill": 1,
+              "Write": 2,
+              "exec_command": 4
+            },
+            "toolErrors": 0,
+            "fileReads": 4,
+            "fileReReads": 1,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 7,
+            "providerFailures": 0,
+            "assistantMessages": 6,
+            "assistantChars": 1493,
+            "reasoningOutputTokens": 2663,
+            "promptTokensFirst": 85602,
+            "promptTokensLast": 93455,
+            "cachedTokensLast": 512,
+            "cachedTokensMax": 88704
+          },
+          "verifiers": [
+            {
+              "name": "tests",
+              "status": "passed",
+              "command": "node {taskDir}/verify-tests.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "12-readme",
+          "status": "passed",
+          "durationMs": 237557,
+          "tokens": {
+            "input": 3959270,
+            "output": 62749,
+            "total": 4022019
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 13,
+            "toolCallsByName": {
+              "FileRead": 5,
+              "Glob": 1,
+              "Write": 3,
+              "exec_command": 3,
+              "kill_process": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 5,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 7,
+            "providerFailures": 0,
+            "assistantMessages": 7,
+            "assistantChars": 611,
+            "reasoningOutputTokens": 2353,
+            "promptTokensFirst": 94081,
+            "promptTokensLast": 98115,
+            "cachedTokensLast": 0,
+            "cachedTokensMax": 94848
+          },
+          "verifiers": [
+            {
+              "name": "readme",
+              "status": "passed",
+              "command": "node {taskDir}/verify-readme.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "13-review",
+          "status": "passed",
+          "durationMs": 477162,
+          "tokens": {
+            "input": 4498491,
+            "output": 81334,
+            "total": 4579825
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 22,
+            "toolCallsByName": {
+              "Edit": 6,
+              "FileRead": 14,
+              "Skill": 1,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 14,
+            "fileReReads": 1,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 6,
+            "providerFailures": 0,
+            "assistantMessages": 5,
+            "assistantChars": 1058,
+            "reasoningOutputTokens": 16253,
+            "promptTokensFirst": 98216,
+            "promptTokensLast": 110226,
+            "cachedTokensLast": 0,
+            "cachedTokensMax": 105088
+          },
+          "verifiers": [
+            {
+              "name": "tests",
+              "status": "passed",
+              "command": "node {taskDir}/verify-tests.mjs"
+            },
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "14-highscores",
+          "status": "passed",
+          "durationMs": 317877,
+          "tokens": {
+            "input": 5583275,
+            "output": 89743,
+            "total": 5673018
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 33,
+            "toolCallsByName": {
+              "Edit": 16,
+              "FileRead": 16,
+              "exec_command": 1
+            },
+            "toolErrors": 0,
+            "fileReads": 16,
+            "fileReReads": 7,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 8,
+            "providerFailures": 0,
+            "assistantMessages": 9,
+            "assistantChars": 952,
+            "reasoningOutputTokens": 2855,
+            "promptTokensFirst": 110855,
+            "promptTokensLast": 128457,
+            "cachedTokensLast": 125056,
+            "cachedTokensMax": 125056
+          },
+          "verifiers": [
+            {
+              "name": "style",
+              "status": "passed",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ]
+        },
+        {
+          "id": "15-final",
+          "status": "failed",
+          "durationMs": 139847,
+          "tokens": {
+            "input": 6100493,
+            "output": 92183,
+            "total": 6192676
+          },
+          "stopReason": "completed",
+          "exitCode": 0,
+          "metrics": {
+            "toolCalls": 5,
+            "toolCallsByName": {
+              "Glob": 1,
+              "Skill": 1,
+              "Write": 1,
+              "exec_command": 2
+            },
+            "toolErrors": 0,
+            "fileReads": 0,
+            "fileReReads": 0,
+            "compactions": 0,
+            "compactionAttempts": 0,
+            "compactionFailures": 0,
+            "compactionRollbacks": 0,
+            "permissionRequests": 0,
+            "warnings": 4,
+            "providerFailures": 0,
+            "assistantMessages": 4,
+            "assistantChars": 380,
+            "reasoningOutputTokens": 1269,
+            "promptTokensFirst": 128287,
+            "promptTokensLast": 130255,
+            "cachedTokensLast": 512,
+            "cachedTokensMax": 127488
+          },
+          "verifiers": [
+            {
+              "name": "final",
+              "status": "failed",
+              "command": "node {taskDir}/verify-final.mjs",
+              "details": "CHANGELOG.md should summarize the steps; found 0 entries, expected at least 10"
+            }
+          ]
+        }
+      ],
+      "metrics": {
+        "toolCalls": 201,
+        "toolCallsByName": {
+          "Edit": 60,
+          "FileRead": 78,
+          "Glob": 3,
+          "Grep": 9,
+          "MultiEdit": 7,
+          "Skill": 5,
+          "Write": 14,
+          "exec_command": 24,
+          "kill_process": 1
+        },
+        "toolErrors": 0,
+        "fileReads": 78,
+        "fileReReads": 17,
+        "compactions": 0,
+        "compactionAttempts": 0,
+        "compactionFailures": 0,
+        "compactionRollbacks": 0,
+        "permissionRequests": 0,
+        "warnings": 87,
+        "providerFailures": 0,
+        "assistantMessages": 84,
+        "assistantChars": 10392,
+        "reasoningOutputTokens": 46604,
+        "steps": 15,
+        "promptTokensFirst": 18440,
+        "promptTokensLast": 130255,
+        "cachedTokensLast": 512,
+        "cachedTokensMax": 127488
+      },
+      "riskFlags": [
+        "verifier_failed"
+      ],
+      "notes": "session session_aeabf903-93c1-4ba7-8743-3b95d32878c2 rollout rollout-2026-09-04T19-44-41-007Z-conv-mtnd4uct.jsonl\nnode '<runtime>/eval/tasks/asteroid-drift-15'/verify-final.mjs stderr: CHANGELOG.md should summarize the steps; found 0 entries, expected at least 10\nnode '<runtime>/eval/tasks/asteroid-drift-15'/verify-final.mjs stderr: CHANGELOG.md should summarize the steps; found 0 entries, expected at least 10"
+    }
+  ]
+}

--- a/runtime/eval/tasks/asteroid-drift-15/checks.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/checks.mjs
@@ -1,0 +1,99 @@
+// Shared deterministic checks for the Asteroid Drift session task. No network,
+// no timing: every check reads the workspace (cwd) and exits nonzero on failure.
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, extname, relative } from "node:path";
+
+const SKIP_DIRS = new Set(["node_modules", ".git", ".agenc", "coverage"]);
+
+export function jsFiles(root = process.cwd()) {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(join(dir, entry.name));
+      } else if (extname(entry.name) === ".js" || extname(entry.name) === ".mjs") {
+        out.push(join(dir, entry.name));
+      }
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+export function read(path) {
+  return readFileSync(path, "utf8");
+}
+
+export function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+export function ok(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+export function requireFiles(paths) {
+  const missing = paths.filter((p) => !existsSync(p) || !statSync(p).isFile());
+  if (missing.length > 0) fail(`missing files: ${missing.join(", ")}`);
+}
+
+/** Any of the patterns must match somewhere in the workspace's JS or HTML. */
+export function requireAny(patterns, label) {
+  const sources = [...jsFiles(), ...htmlFiles()].map((p) => read(p)).join("\n");
+  if (!patterns.some((pattern) => pattern.test(sources))) {
+    fail(`${label}: none of ${patterns.map(String).join(" | ")} found`);
+  }
+}
+
+export function htmlFiles(root = process.cwd()) {
+  return readdirSync(root)
+    .filter((name) => name.endsWith(".html"))
+    .map((name) => join(root, name));
+}
+
+/**
+ * The style rules the user states in prompt 1 and that every later prompt must
+ * preserve: two-space indentation and no semicolon-terminated statements, in
+ * every JavaScript file of the project (tests included).
+ */
+export function checkStyle() {
+  const problems = [];
+  for (const file of jsFiles()) {
+    const rel = relative(process.cwd(), file);
+    const lines = read(file).split("\n");
+    let inBlockComment = false;
+    lines.forEach((line, index) => {
+      const trimmed = line.trim();
+      if (inBlockComment) {
+        if (trimmed.includes("*/")) inBlockComment = false;
+        return;
+      }
+      if (trimmed.startsWith("/*")) {
+        if (!trimmed.includes("*/")) inBlockComment = true;
+        return;
+      }
+      if (trimmed.startsWith("//") || trimmed.length === 0) return;
+      if (/^\t/.test(line)) problems.push(`${rel}:${index + 1} tab indentation`);
+      const indent = line.match(/^ */)[0].length;
+      if (indent % 2 !== 0) problems.push(`${rel}:${index + 1} indentation of ${indent} is not a multiple of 2`);
+      if (/;\s*(\/\/.*)?$/.test(line) && !/^\s*for\s*\(/.test(line)) {
+        problems.push(`${rel}:${index + 1} semicolon-terminated line`);
+      }
+    });
+  }
+  return problems;
+}
+
+export function runNodeTests() {
+  // Force the TAP reporter: Node prints the spec reporter even when piped, and
+  // the verifiers parse the "# pass N" summary line.
+  const result = spawnSync(process.execPath, ["--test", "--test-reporter=tap"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: 120_000,
+    env: { ...process.env, NODE_OPTIONS: "" },
+  });
+  return result;
+}

--- a/runtime/eval/tasks/asteroid-drift-15/checks.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/checks.mjs
@@ -18,7 +18,7 @@ export function jsFiles(root = process.cwd()) {
     }
   };
   walk(root);
-  return out.sort();
+  return out.sort((a, b) => a.localeCompare(b));
 }
 
 export function read(path) {
@@ -75,7 +75,7 @@ export function checkStyle() {
         return;
       }
       if (trimmed.startsWith("//") || trimmed.length === 0) return;
-      if (/^\t/.test(line)) problems.push(`${rel}:${index + 1} tab indentation`);
+      if (line.startsWith("\t")) problems.push(`${rel}:${index + 1} tab indentation`);
       const indent = line.match(/^ */)[0].length;
       if (indent % 2 !== 0) problems.push(`${rel}:${index + 1} indentation of ${indent} is not a multiple of 2`);
       if (/;\s*(\/\/.*)?$/.test(line) && !/^\s*for\s*\(/.test(line)) {

--- a/runtime/eval/tasks/asteroid-drift-15/fixture/README.md
+++ b/runtime/eval/tasks/asteroid-drift-15/fixture/README.md
@@ -1,0 +1,3 @@
+# Asteroid Drift
+
+Starting point for the 15-prompt session. The agent creates everything else.

--- a/runtime/eval/tasks/asteroid-drift-15/solution.sh
+++ b/runtime/eval/tasks/asteroid-drift-15/solution.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Scripted answer for the mock executor: install the finished project so every
+# step verifier and the final verifier can be proven against a known-good tree.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp -R "$here/solution/." .
+printf '%s\n' '{"tokenUsage":{"input":15,"output":15}}'

--- a/runtime/eval/tasks/asteroid-drift-15/solution/CHANGELOG.md
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+1. Scaffold: index.html, canvas, requestAnimationFrame loop with delta time, arrow-key ship.
+2. Asteroids fall from random x with rising speed; a hit ends the game with Game Over.
+3. Score counts seconds survived; best score persists in localStorage.
+4. Start screen and pause on P.
+5. Refactor into player.js, asteroids.js, hud.js and main.js.
+6. Particle explosion and screen shake on death.
+7. WebAudio oscillator beeps with a mute toggle on M, remembered in localStorage.
+8. Shield and slow-time power-ups spawn every ten seconds.
+9. Levels every 20 points with faster spawns and a banner.
+10. Touch and pointer controls plus a responsive canvas.
+11. node:test coverage for collision, scoring and leveling.
+12. README with controls and a dependency-free npm start server.
+13. Self-review: keyup lost on blur now clears input; shield consumes the asteroid.
+14. Top-five high score table with initials in localStorage.
+15. Final check: tests pass, style rules hold, this changelog written.

--- a/runtime/eval/tasks/asteroid-drift-15/solution/README.md
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/README.md
@@ -1,0 +1,20 @@
+# Asteroid Drift
+
+A canvas arcade game: dodge falling asteroids for as long as you can.
+
+## Controls
+
+- Arrow keys or A and D move the ship. On touch screens, drag the ship.
+- P pauses and resumes. M toggles sound and the choice is remembered.
+- Space or a tap starts a game and restarts after Game Over.
+- After Game Over, type three initials and press Enter for the high score table.
+
+## How to run
+
+    npm start
+
+Then open http://localhost:8080. No dependencies and no build step.
+
+## Tests
+
+    npm test

--- a/runtime/eval/tasks/asteroid-drift-15/solution/asteroids.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/asteroids.js
@@ -1,6 +1,8 @@
+import { random } from './random.js'
+
 export function spawnAsteroid(width, speedScale) {
-  const radius = 10 + Math.random() * 18
-  return { x: radius + Math.random() * (width - radius * 2), y: -radius, radius, vy: (90 + Math.random() * 120) * speedScale }
+  const radius = 10 + random() * 18
+  return { x: radius + random() * (width - radius * 2), y: -radius, radius, vy: (90 + random() * 120) * speedScale }
 }
 
 export function stepAsteroids(asteroids, dt, height, timeScale) {

--- a/runtime/eval/tasks/asteroid-drift-15/solution/asteroids.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/asteroids.js
@@ -1,0 +1,11 @@
+export function spawnAsteroid(width, speedScale) {
+  const radius = 10 + Math.random() * 18
+  return { x: radius + Math.random() * (width - radius * 2), y: -radius, radius, vy: (90 + Math.random() * 120) * speedScale }
+}
+
+export function stepAsteroids(asteroids, dt, height, timeScale) {
+  for (const asteroid of asteroids) {
+    asteroid.y += asteroid.vy * dt * timeScale
+  }
+  return asteroids.filter((asteroid) => asteroid.y - asteroid.radius < height)
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/audio.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/audio.js
@@ -1,0 +1,23 @@
+const KEY_MUTED = 'asteroid-drift-muted'
+let context = null
+
+export function loadMuted() {
+  return localStorage.getItem(KEY_MUTED) === '1'
+}
+
+export function saveMuted(muted) {
+  localStorage.setItem(KEY_MUTED, muted ? '1' : '0')
+}
+
+export function beep(frequency, durationMs, muted) {
+  if (muted) return
+  context ??= new AudioContext()
+  const oscillator = context.createOscillator()
+  const gain = context.createGain()
+  oscillator.frequency.value = frequency
+  gain.gain.value = 0.05
+  oscillator.connect(gain)
+  gain.connect(context.destination)
+  oscillator.start()
+  oscillator.stop(context.currentTime + durationMs / 1000)
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/effects.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/effects.js
@@ -1,7 +1,9 @@
+import { random } from './random.js'
+
 export function explode(particles, x, y) {
   for (let index = 0; index < 40; index += 1) {
-    const angle = Math.random() * Math.PI * 2
-    const speed = 60 + Math.random() * 180
+    const angle = random() * Math.PI * 2
+    const speed = 60 + random() * 180
     particles.push({ x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, life: 0.8 })
   }
 }
@@ -17,5 +19,5 @@ export function stepParticles(particles, dt) {
 
 export function shakeOffset(shake) {
   if (shake <= 0) return { x: 0, y: 0 }
-  return { x: (Math.random() - 0.5) * shake * 12, y: (Math.random() - 0.5) * shake * 12 }
+  return { x: (random() - 0.5) * shake * 12, y: (random() - 0.5) * shake * 12 }
 }

--- a/runtime/eval/tasks/asteroid-drift-15/solution/effects.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/effects.js
@@ -1,0 +1,21 @@
+export function explode(particles, x, y) {
+  for (let index = 0; index < 40; index += 1) {
+    const angle = Math.random() * Math.PI * 2
+    const speed = 60 + Math.random() * 180
+    particles.push({ x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, life: 0.8 })
+  }
+}
+
+export function stepParticles(particles, dt) {
+  for (const particle of particles) {
+    particle.x += particle.vx * dt
+    particle.y += particle.vy * dt
+    particle.life -= dt
+  }
+  return particles.filter((particle) => particle.life > 0)
+}
+
+export function shakeOffset(shake) {
+  if (shake <= 0) return { x: 0, y: 0 }
+  return { x: (Math.random() - 0.5) * shake * 12, y: (Math.random() - 0.5) * shake * 12 }
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/hud.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/hud.js
@@ -1,0 +1,45 @@
+const KEY_BEST = 'asteroid-drift-best'
+const KEY_SCORES = 'asteroid-drift-scores'
+
+export function loadBest() {
+  return Number(localStorage.getItem(KEY_BEST) || 0)
+}
+
+export function saveBest(score) {
+  localStorage.setItem(KEY_BEST, String(score))
+}
+
+export function loadScores() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY_SCORES) || '[]')
+  } catch {
+    return []
+  }
+}
+
+export function saveScores(table) {
+  localStorage.setItem(KEY_SCORES, JSON.stringify(table))
+}
+
+export function drawHud(ctx, state, width) {
+  ctx.fillStyle = '#fff'
+  ctx.font = '16px monospace'
+  ctx.fillText(`score ${state.score}  best ${state.best}  level ${state.level}`, 12, 24)
+  if (state.muted) ctx.fillText('muted (M)', width - 110, 24)
+  if (state.banner) ctx.fillText(state.banner, width / 2 - 40, 60)
+}
+
+export function drawCenter(ctx, lines, width, height) {
+  ctx.fillStyle = '#fff'
+  ctx.font = '24px monospace'
+  lines.forEach((line, index) => {
+    ctx.fillText(line, width / 2 - line.length * 6.5, height / 2 + index * 32)
+  })
+}
+
+export function drawScores(ctx, table, width, height) {
+  ctx.font = '18px monospace'
+  table.forEach((entry, index) => {
+    ctx.fillText(`${index + 1}. ${entry.initials}  ${entry.score}`, width / 2 - 70, height / 2 + 80 + index * 24)
+  })
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/index.html
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Asteroid Drift</title>
+    <style>
+      html, body { margin: 0; background: #000; height: 100%; overflow: hidden; touch-action: none; }
+      canvas { display: block; width: 100vw; height: 100vh; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/runtime/eval/tasks/asteroid-drift-15/solution/logic.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/logic.js
@@ -1,0 +1,24 @@
+// Pure game logic: no DOM, no timers, so node:test can cover it.
+export function circlesCollide(a, b) {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  const distance = Math.hypot(dx, dy)
+  return distance < a.radius + b.radius
+}
+
+export function scoreForElapsed(elapsedMs) {
+  return Math.floor(elapsedMs / 1000)
+}
+
+export function levelForScore(score) {
+  return Math.floor(score / 20) + 1
+}
+
+export function spawnIntervalForLevel(level) {
+  return Math.max(250, 1000 - (level - 1) * 120)
+}
+
+export function insertHighScore(table, entry, limit = 5) {
+  const next = [...table, entry].sort((left, right) => right.score - left.score)
+  return next.slice(0, limit)
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/main.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/main.js
@@ -1,0 +1,203 @@
+import { createPlayer, movePlayer, playerHit } from './player.js'
+import { spawnAsteroid, stepAsteroids } from './asteroids.js'
+import { drawHud, drawCenter, drawScores, loadBest, saveBest, loadScores, saveScores } from './hud.js'
+import { explode, stepParticles, shakeOffset } from './effects.js'
+import { beep, loadMuted, saveMuted } from './audio.js'
+import { spawnPowerup, stepPowerups, applyPowerup } from './powerups.js'
+import { circlesCollide, scoreForElapsed, levelForScore, spawnIntervalForLevel, insertHighScore } from './logic.js'
+
+const canvas = document.getElementById('game')
+const ctx = canvas.getContext('2d')
+const input = { left: false, right: false }
+let state = null
+let last = performance.now()
+
+function resize() {
+  canvas.width = window.innerWidth
+  canvas.height = window.innerHeight
+}
+
+function reset() {
+  state = {
+    mode: 'start',
+    player: createPlayer(canvas.width, canvas.height),
+    asteroids: [],
+    particles: [],
+    powerups: [],
+    elapsedMs: 0,
+    score: 0,
+    best: loadBest(),
+    level: 1,
+    banner: '',
+    bannerUntil: 0,
+    shake: 0,
+    slowUntil: 0,
+    muted: loadMuted(),
+    sinceSpawn: 0,
+    sincePowerup: 0,
+    initials: '',
+    scores: loadScores(),
+  }
+}
+
+function gameOver() {
+  explode(state.particles, state.player.x, state.player.y)
+  state.shake = 1
+  beep(110, 400, state.muted)
+  if (state.score > state.best) {
+    state.best = state.score
+    saveBest(state.best)
+  }
+  state.mode = 'enter-initials'
+}
+
+function update(dt) {
+  if (state.mode !== 'playing') return
+  const timeScale = state.elapsedMs < state.slowUntil ? 0.4 : 1
+  state.elapsedMs += dt * 1000
+  state.score = scoreForElapsed(state.elapsedMs)
+  const level = levelForScore(state.score)
+  if (level !== state.level) {
+    state.level = level
+    state.banner = `Level ${level}`
+    state.bannerUntil = state.elapsedMs + 1500
+    beep(660, 120, state.muted)
+  }
+  if (state.elapsedMs > state.bannerUntil) state.banner = ''
+  movePlayer(state.player, input, dt, canvas.width)
+  state.sinceSpawn += dt * 1000
+  const speedScale = 1 + state.elapsedMs / 60000
+  if (state.sinceSpawn > spawnIntervalForLevel(state.level)) {
+    state.sinceSpawn = 0
+    state.asteroids.push(spawnAsteroid(canvas.width, speedScale))
+  }
+  state.sincePowerup += dt * 1000
+  if (state.sincePowerup > 10000) {
+    state.sincePowerup = 0
+    state.powerups.push(spawnPowerup(canvas.width))
+  }
+  state.asteroids = stepAsteroids(state.asteroids, dt, canvas.height, timeScale)
+  state.powerups = stepPowerups(state.powerups, dt, canvas.height)
+  state.particles = stepParticles(state.particles, dt)
+  state.shake = Math.max(0, state.shake - dt * 2)
+  for (const powerup of state.powerups) {
+    if (circlesCollide(state.player, powerup)) {
+      applyPowerup(state, powerup)
+      powerup.y = canvas.height + 100
+      beep(880, 100, state.muted)
+    }
+  }
+  for (const asteroid of state.asteroids) {
+    if (playerHit(state.player, asteroid)) {
+      if (state.player.shield) {
+        state.player.shield = false
+        asteroid.y = canvas.height + 100
+        state.shake = 0.4
+        continue
+      }
+      gameOver()
+      return
+    }
+  }
+}
+
+function draw() {
+  const offset = shakeOffset(state.shake)
+  ctx.save()
+  ctx.translate(offset.x, offset.y)
+  ctx.fillStyle = '#000'
+  ctx.fillRect(-20, -20, canvas.width + 40, canvas.height + 40)
+  ctx.fillStyle = state.player.shield ? '#6cf' : '#fff'
+  ctx.beginPath()
+  ctx.arc(state.player.x, state.player.y, state.player.radius, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.fillStyle = '#999'
+  for (const asteroid of state.asteroids) {
+    ctx.beginPath()
+    ctx.arc(asteroid.x, asteroid.y, asteroid.radius, 0, Math.PI * 2)
+    ctx.fill()
+  }
+  for (const powerup of state.powerups) {
+    ctx.fillStyle = powerup.kind === 'shield' ? '#6cf' : '#fc6'
+    ctx.fillRect(powerup.x - 8, powerup.y - 8, 16, 16)
+  }
+  ctx.fillStyle = '#f80'
+  for (const particle of state.particles) {
+    ctx.fillRect(particle.x, particle.y, 3, 3)
+  }
+  drawHud(ctx, state, canvas.width)
+  if (state.mode === 'start') drawCenter(ctx, ['Asteroid Drift', 'press space or tap to start'], canvas.width, canvas.height)
+  if (state.mode === 'paused') drawCenter(ctx, ['Paused', 'press P to resume'], canvas.width, canvas.height)
+  if (state.mode === 'enter-initials') drawCenter(ctx, ['Game Over', `enter initials: ${state.initials}_`], canvas.width, canvas.height)
+  if (state.mode === 'gameover') {
+    drawCenter(ctx, ['Game Over', 'top scores', 'press space to restart'], canvas.width, canvas.height)
+    drawScores(ctx, state.scores, canvas.width, canvas.height)
+  }
+  ctx.restore()
+}
+
+function frame(now) {
+  const dt = Math.min(0.05, (now - last) / 1000)
+  last = now
+  update(dt)
+  draw()
+  requestAnimationFrame(frame)
+}
+
+function commitInitials() {
+  state.scores = insertHighScore(state.scores, { initials: state.initials || 'AAA', score: state.score })
+  saveScores(state.scores)
+  state.mode = 'gameover'
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.code === 'ArrowLeft' || event.code === 'KeyA') input.left = true
+  if (event.code === 'ArrowRight' || event.code === 'KeyD') input.right = true
+  if (event.code === 'KeyM') {
+    state.muted = !state.muted
+    saveMuted(state.muted)
+  }
+  if (event.code === 'KeyP' && state.mode === 'playing') state.mode = 'paused'
+  else if (event.code === 'KeyP' && state.mode === 'paused') state.mode = 'playing'
+  if (event.code === 'Space' && (state.mode === 'start' || state.mode === 'gameover')) {
+    reset()
+    state.mode = 'playing'
+  }
+  if (state.mode === 'enter-initials') {
+    if (/^Key[A-Z]$/.test(event.code) && state.initials.length < 3) state.initials += event.code.slice(3)
+    if (event.code === 'Backspace') state.initials = state.initials.slice(0, -1)
+    if (event.code === 'Enter') commitInitials()
+  }
+})
+
+window.addEventListener('keyup', (event) => {
+  if (event.code === 'ArrowLeft' || event.code === 'KeyA') input.left = false
+  if (event.code === 'ArrowRight' || event.code === 'KeyD') input.right = false
+})
+
+window.addEventListener('blur', () => {
+  input.left = false
+  input.right = false
+})
+
+canvas.addEventListener('pointerdown', (event) => {
+  if (state.mode === 'start' || state.mode === 'gameover') {
+    reset()
+    state.mode = 'playing'
+    return
+  }
+  if (state.mode === 'enter-initials') {
+    commitInitials()
+    return
+  }
+  state.player.x = event.clientX
+})
+
+canvas.addEventListener('pointermove', (event) => {
+  if (state.mode === 'playing' && event.buttons > 0) state.player.x = event.clientX
+})
+
+window.addEventListener('resize', resize)
+resize()
+reset()
+requestAnimationFrame(frame)

--- a/runtime/eval/tasks/asteroid-drift-15/solution/main.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/main.js
@@ -150,24 +150,35 @@ function commitInitials() {
   state.mode = 'gameover'
 }
 
+function toggleMute() {
+  state.muted = !state.muted
+  saveMuted(state.muted)
+}
+
+function togglePause() {
+  if (state.mode === 'playing') state.mode = 'paused'
+  else if (state.mode === 'paused') state.mode = 'playing'
+}
+
+function startFromMenu() {
+  if (state.mode !== 'start' && state.mode !== 'gameover') return
+  reset()
+  state.mode = 'playing'
+}
+
+function handleInitialsKey(event) {
+  if (/^Key[A-Z]$/.test(event.code) && state.initials.length < 3) state.initials += event.code.slice(3)
+  if (event.code === 'Backspace') state.initials = state.initials.slice(0, -1)
+  if (event.code === 'Enter') commitInitials()
+}
+
 window.addEventListener('keydown', (event) => {
   if (event.code === 'ArrowLeft' || event.code === 'KeyA') input.left = true
   if (event.code === 'ArrowRight' || event.code === 'KeyD') input.right = true
-  if (event.code === 'KeyM') {
-    state.muted = !state.muted
-    saveMuted(state.muted)
-  }
-  if (event.code === 'KeyP' && state.mode === 'playing') state.mode = 'paused'
-  else if (event.code === 'KeyP' && state.mode === 'paused') state.mode = 'playing'
-  if (event.code === 'Space' && (state.mode === 'start' || state.mode === 'gameover')) {
-    reset()
-    state.mode = 'playing'
-  }
-  if (state.mode === 'enter-initials') {
-    if (/^Key[A-Z]$/.test(event.code) && state.initials.length < 3) state.initials += event.code.slice(3)
-    if (event.code === 'Backspace') state.initials = state.initials.slice(0, -1)
-    if (event.code === 'Enter') commitInitials()
-  }
+  if (event.code === 'KeyM') toggleMute()
+  if (event.code === 'KeyP') togglePause()
+  if (event.code === 'Space') startFromMenu()
+  if (state.mode === 'enter-initials') handleInitialsKey(event)
 })
 
 window.addEventListener('keyup', (event) => {

--- a/runtime/eval/tasks/asteroid-drift-15/solution/package.json
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "asteroid-drift",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  }
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/player.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/player.js
@@ -1,0 +1,15 @@
+import { circlesCollide } from './logic.js'
+
+export function createPlayer(width, height) {
+  return { x: width / 2, y: height - 60, radius: 14, speed: 320, shield: false }
+}
+
+export function movePlayer(player, input, dt, width) {
+  if (input.left) player.x -= player.speed * dt
+  if (input.right) player.x += player.speed * dt
+  player.x = Math.min(width - player.radius, Math.max(player.radius, player.x))
+}
+
+export function playerHit(player, asteroid) {
+  return circlesCollide(player, asteroid)
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/powerups.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/powerups.js
@@ -1,6 +1,8 @@
+import { random } from './random.js'
+
 export function spawnPowerup(width) {
-  const kind = Math.random() < 0.5 ? 'shield' : 'slow'
-  return { kind, x: 20 + Math.random() * (width - 40), y: -12, radius: 12, vy: 80 }
+  const kind = random() < 0.5 ? 'shield' : 'slow'
+  return { kind, x: 20 + random() * (width - 40), y: -12, radius: 12, vy: 80 }
 }
 
 export function stepPowerups(powerups, dt, height) {

--- a/runtime/eval/tasks/asteroid-drift-15/solution/powerups.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/powerups.js
@@ -1,0 +1,16 @@
+export function spawnPowerup(width) {
+  const kind = Math.random() < 0.5 ? 'shield' : 'slow'
+  return { kind, x: 20 + Math.random() * (width - 40), y: -12, radius: 12, vy: 80 }
+}
+
+export function stepPowerups(powerups, dt, height) {
+  for (const powerup of powerups) {
+    powerup.y += powerup.vy * dt
+  }
+  return powerups.filter((powerup) => powerup.y - powerup.radius < height)
+}
+
+export function applyPowerup(state, powerup) {
+  if (powerup.kind === 'shield') state.player.shield = true
+  if (powerup.kind === 'slow') state.slowUntil = state.elapsedMs + 3000
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/random.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/random.js
@@ -1,0 +1,8 @@
+// One source of randomness for the whole game. crypto.getRandomValues is
+// available in every browser and in node:test without imports, so the same
+// module serves the game and the tests.
+export function random() {
+  const buffer = new Uint32Array(1)
+  crypto.getRandomValues(buffer)
+  return buffer[0] / 4294967296
+}

--- a/runtime/eval/tasks/asteroid-drift-15/solution/server.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/server.js
@@ -1,14 +1,28 @@
 import { createServer } from 'node:http'
 import { readFile } from 'node:fs/promises'
-import { extname, join, normalize } from 'node:path'
+import { extname, normalize, resolve, sep } from 'node:path'
 
 const types = { '.html': 'text/html', '.js': 'text/javascript', '.md': 'text/plain', '.json': 'application/json' }
-const root = process.cwd()
+const root = resolve(process.cwd())
+
+// Only files inside the project directory are served: the canonical path of
+// the request must stay under the root, so `..` segments and absolute paths
+// cannot reach outside it.
+function resolveInsideRoot(url) {
+  const requested = decodeURIComponent(url === '/' ? '/index.html' : url.split('?')[0])
+  const candidate = resolve(root, '.' + normalize('/' + requested))
+  return candidate === root || candidate.startsWith(root + sep) ? candidate : null
+}
 
 createServer(async (request, response) => {
-  const path = normalize(decodeURIComponent(request.url === '/' ? '/index.html' : request.url))
+  const path = resolveInsideRoot(request.url ?? '/')
+  if (path === null) {
+    response.writeHead(403)
+    response.end('forbidden')
+    return
+  }
   try {
-    const body = await readFile(join(root, path))
+    const body = await readFile(path)
     response.writeHead(200, { 'content-type': types[extname(path)] || 'application/octet-stream' })
     response.end(body)
   } catch {

--- a/runtime/eval/tasks/asteroid-drift-15/solution/server.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/server.js
@@ -1,0 +1,20 @@
+import { createServer } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { extname, join, normalize } from 'node:path'
+
+const types = { '.html': 'text/html', '.js': 'text/javascript', '.md': 'text/plain', '.json': 'application/json' }
+const root = process.cwd()
+
+createServer(async (request, response) => {
+  const path = normalize(decodeURIComponent(request.url === '/' ? '/index.html' : request.url))
+  try {
+    const body = await readFile(join(root, path))
+    response.writeHead(200, { 'content-type': types[extname(path)] || 'application/octet-stream' })
+    response.end(body)
+  } catch {
+    response.writeHead(404)
+    response.end('not found')
+  }
+}).listen(8080, () => {
+  console.log('Asteroid Drift on http://localhost:8080')
+})

--- a/runtime/eval/tasks/asteroid-drift-15/solution/test/logic.test.js
+++ b/runtime/eval/tasks/asteroid-drift-15/solution/test/logic.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { circlesCollide, scoreForElapsed, levelForScore, spawnIntervalForLevel, insertHighScore } from '../logic.js'
+
+test('circles collide when centers are closer than the radii sum', () => {
+  assert.equal(circlesCollide({ x: 0, y: 0, radius: 10 }, { x: 15, y: 0, radius: 10 }), true)
+  assert.equal(circlesCollide({ x: 0, y: 0, radius: 10 }, { x: 25, y: 0, radius: 10 }), false)
+})
+
+test('score is whole seconds survived', () => {
+  assert.equal(scoreForElapsed(0), 0)
+  assert.equal(scoreForElapsed(12999), 12)
+})
+
+test('level rises every 20 points and spawns faster', () => {
+  assert.equal(levelForScore(0), 1)
+  assert.equal(levelForScore(20), 2)
+  assert.equal(levelForScore(59), 3)
+  assert.ok(spawnIntervalForLevel(3) < spawnIntervalForLevel(1))
+  assert.equal(spawnIntervalForLevel(50), 250)
+})
+
+test('high score table keeps the top five by score', () => {
+  const table = [{ initials: 'AAA', score: 10 }, { initials: 'BBB', score: 30 }]
+  const next = insertHighScore(table, { initials: 'CCC', score: 20 })
+  assert.deepEqual(next.map((entry) => entry.initials), ['BBB', 'CCC', 'AAA'])
+  const full = insertHighScore(Array.from({ length: 5 }, (_, index) => ({ initials: 'X', score: 100 - index })), { initials: 'Y', score: 1 })
+  assert.equal(full.length, 5)
+})

--- a/runtime/eval/tasks/asteroid-drift-15/verify-features.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-features.mjs
@@ -1,0 +1,10 @@
+import { requireAny, ok } from "./checks.mjs";
+requireAny([/particle/i], "a particle explosion");
+requireAny([/shake/i], "screen shake");
+requireAny([/AudioContext|createOscillator/], "WebAudio oscillator beeps");
+requireAny([/mute/i], "a mute toggle");
+requireAny([/shield/i], "a shield power-up");
+requireAny([/slow/i], "a slow-time power-up");
+requireAny([/level/i], "levels");
+requireAny([/touch|pointer/i], "touch or pointer controls");
+ok("feature markers present: particles, shake, audio, mute, shield, slow-time, levels, touch");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-final.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-final.mjs
@@ -2,10 +2,11 @@ import { readFileSync, existsSync } from "node:fs";
 import { checkStyle, requireAny, runNodeTests, fail, ok } from "./checks.mjs";
 if (!existsSync("CHANGELOG.md")) fail("CHANGELOG.md missing");
 const changelog = readFileSync("CHANGELOG.md", "utf8");
+// One entry per step, as a list item or as a headed section below the title.
 const entries = changelog
   .split("\n")
   .map((line) => line.trimStart())
-  .filter((line) => /^([-*]|\d+\.)[ \t]+\S/.test(line)).length;
+  .filter((line) => /^([-*]|\d+\.)[ \t]+\S/.test(line) || /^#{2,6}[ \t]+\S/.test(line)).length;
 if (entries < 10) fail(`CHANGELOG.md should summarize the steps; found ${entries} entries, expected at least 10`);
 requireAny([/initial/i], "a high-score table with initials");
 const problems = checkStyle();

--- a/runtime/eval/tasks/asteroid-drift-15/verify-final.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-final.mjs
@@ -1,0 +1,12 @@
+import { readFileSync, existsSync } from "node:fs";
+import { checkStyle, requireAny, runNodeTests, fail, ok } from "./checks.mjs";
+if (!existsSync("CHANGELOG.md")) fail("CHANGELOG.md missing");
+const changelog = readFileSync("CHANGELOG.md", "utf8");
+const entries = (changelog.match(/^\s*(?:[-*]|\d+\.)\s+\S/gm) ?? []).length;
+if (entries < 10) fail(`CHANGELOG.md should summarize the steps; found ${entries} entries, expected at least 10`);
+requireAny([/initial/i], "a high-score table with initials");
+const problems = checkStyle();
+if (problems.length > 0) fail(`style rules from prompt 1 violated at the end:\n  ${problems.slice(0, 15).join("\n  ")}`);
+const result = runNodeTests();
+if (result.status !== 0) fail(`node --test failed at the end (exit ${result.status})`);
+ok(`final state verified: CHANGELOG with ${entries} entries, high scores, style rules, tests passing`);

--- a/runtime/eval/tasks/asteroid-drift-15/verify-final.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-final.mjs
@@ -2,7 +2,10 @@ import { readFileSync, existsSync } from "node:fs";
 import { checkStyle, requireAny, runNodeTests, fail, ok } from "./checks.mjs";
 if (!existsSync("CHANGELOG.md")) fail("CHANGELOG.md missing");
 const changelog = readFileSync("CHANGELOG.md", "utf8");
-const entries = (changelog.match(/^\s*(?:[-*]|\d+\.)\s+\S/gm) ?? []).length;
+const entries = changelog
+  .split("\n")
+  .map((line) => line.trimStart())
+  .filter((line) => /^([-*]|\d+\.)[ \t]+\S/.test(line)).length;
 if (entries < 10) fail(`CHANGELOG.md should summarize the steps; found ${entries} entries, expected at least 10`);
 requireAny([/initial/i], "a high-score table with initials");
 const problems = checkStyle();

--- a/runtime/eval/tasks/asteroid-drift-15/verify-gameplay.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-gameplay.mjs
@@ -1,0 +1,5 @@
+import { requireAny, ok } from "./checks.mjs";
+requireAny([/game\s*over/i], "a Game Over state");
+requireAny([/localStorage/], "localStorage for the best score");
+requireAny([/paus/i], "a pause state");
+ok("gameplay markers present: game over, localStorage, pause");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-modules.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-modules.mjs
@@ -1,0 +1,9 @@
+import { requireFiles, read, fail, ok } from "./checks.mjs";
+requireFiles(["index.html", "main.js", "player.js", "asteroids.js", "hud.js"]);
+const html = read("index.html");
+if (!/type\s*=\s*["']module["']/.test(html)) fail("index.html must load the entry as an ES module");
+if (!/main\.js/.test(html)) fail("index.html must reference main.js");
+for (const file of ["player.js", "asteroids.js", "hud.js"]) {
+  if (!/^\s*export\s/m.test(read(file))) fail(`${file} exports nothing`);
+}
+ok("module layout present: main.js, player.js, asteroids.js, hud.js as ES modules");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-modules.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-modules.mjs
@@ -3,7 +3,8 @@ requireFiles(["index.html", "main.js", "player.js", "asteroids.js", "hud.js"]);
 const html = read("index.html");
 if (!/type\s*=\s*["']module["']/.test(html)) fail("index.html must load the entry as an ES module");
 if (!/main\.js/.test(html)) fail("index.html must reference main.js");
+const exportsSomething = (source) => source.split("\n").some((line) => /^export\s/.test(line.trimStart()));
 for (const file of ["player.js", "asteroids.js", "hud.js"]) {
-  if (!/^\s*export\s/m.test(read(file))) fail(`${file} exports nothing`);
+  if (!exportsSomething(read(file))) fail(`${file} exports nothing`);
 }
 ok("module layout present: main.js, player.js, asteroids.js, hud.js as ES modules");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-readme.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-readme.mjs
@@ -7,6 +7,6 @@ if (!/control|arrow|key/i.test(readme)) fail("README.md must describe the contro
 if (!existsSync("package.json")) fail("package.json missing");
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
 if (!pkg.scripts || typeof pkg.scripts.start !== "string") fail("package.json needs a start script");
-const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+const deps = { ...pkg.dependencies, ...pkg.devDependencies };
 if (Object.keys(deps).length > 0) fail(`no dependencies allowed, found: ${Object.keys(deps).join(", ")}`);
 ok("README and dependency-free npm start present");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-readme.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-readme.mjs
@@ -1,0 +1,12 @@
+import { readFileSync, existsSync } from "node:fs";
+import { fail, ok } from "./checks.mjs";
+if (!existsSync("README.md")) fail("README.md missing");
+const readme = readFileSync("README.md", "utf8");
+if (!/npm start/i.test(readme)) fail("README.md must say how to run: npm start");
+if (!/control|arrow|key/i.test(readme)) fail("README.md must describe the controls");
+if (!existsSync("package.json")) fail("package.json missing");
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+if (!pkg.scripts || typeof pkg.scripts.start !== "string") fail("package.json needs a start script");
+const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+if (Object.keys(deps).length > 0) fail(`no dependencies allowed, found: ${Object.keys(deps).join(", ")}`);
+ok("README and dependency-free npm start present");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-scaffold.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-scaffold.mjs
@@ -1,0 +1,6 @@
+import { requireFiles, requireAny, ok } from "./checks.mjs";
+requireFiles(["index.html"]);
+requireAny([/<canvas/i], "index.html or the scripts must create a canvas");
+requireAny([/requestAnimationFrame/], "a requestAnimationFrame loop");
+requireAny([/ArrowLeft|ArrowRight|KeyA|KeyD|keydown/], "arrow-key input handling");
+ok("scaffold present: index.html, canvas, rAF loop, keyboard input");

--- a/runtime/eval/tasks/asteroid-drift-15/verify-style.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-style.mjs
@@ -2,5 +2,7 @@ import { checkStyle, jsFiles, fail, ok } from "./checks.mjs";
 const files = jsFiles();
 if (files.length === 0) fail("no JavaScript files in the workspace");
 const problems = checkStyle();
-if (problems.length > 0) fail(`style rules from prompt 1 violated:\n  ${problems.slice(0, 25).join("\n  ")}${problems.length > 25 ? `\n  ... ${problems.length - 25} more` : ""}`);
+const shown = problems.slice(0, 25).join("\n  ");
+const more = problems.length > 25 ? `\n  ... ${problems.length - 25} more` : "";
+if (problems.length > 0) fail(`style rules from prompt 1 violated:\n  ${shown}${more}`);
 ok(`style rules hold across ${files.length} JavaScript files`);

--- a/runtime/eval/tasks/asteroid-drift-15/verify-style.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-style.mjs
@@ -1,0 +1,6 @@
+import { checkStyle, jsFiles, fail, ok } from "./checks.mjs";
+const files = jsFiles();
+if (files.length === 0) fail("no JavaScript files in the workspace");
+const problems = checkStyle();
+if (problems.length > 0) fail(`style rules from prompt 1 violated:\n  ${problems.slice(0, 25).join("\n  ")}${problems.length > 25 ? `\n  ... ${problems.length - 25} more` : ""}`);
+ok(`style rules hold across ${files.length} JavaScript files`);

--- a/runtime/eval/tasks/asteroid-drift-15/verify-tests.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-tests.mjs
@@ -1,0 +1,8 @@
+import { runNodeTests, jsFiles, fail, ok } from "./checks.mjs";
+const testFiles = jsFiles().filter((f) => /(^|\/)(test|tests)\/|\.test\.(m?js)$/.test(f));
+if (testFiles.length === 0) fail("no test files found (test/ or *.test.js)");
+const result = runNodeTests();
+if (result.status !== 0) fail(`node --test failed (exit ${result.status}):\n${(result.stderr || result.stdout || "").slice(-2000)}`);
+const passMatch = /^# pass (\d+)/m.exec(result.stdout || "");
+if (!passMatch || Number(passMatch[1]) < 3) fail(`expected at least 3 passing tests, got: ${passMatch ? passMatch[1] : "no summary"}`);
+ok(`node --test passed ${passMatch[1]} tests across ${testFiles.length} files`);

--- a/runtime/eval/tasks/asteroid-drift-15/verify-tests.mjs
+++ b/runtime/eval/tasks/asteroid-drift-15/verify-tests.mjs
@@ -1,5 +1,5 @@
 import { runNodeTests, jsFiles, fail, ok } from "./checks.mjs";
-const testFiles = jsFiles().filter((f) => /(^|\/)(test|tests)\/|\.test\.(m?js)$/.test(f));
+const testFiles = jsFiles().filter((f) => /(?:(?:^|\/)tests?\/)|(?:\.test\.m?js$)/.test(f));
 if (testFiles.length === 0) fail("no test files found (test/ or *.test.js)");
 const result = runNodeTests();
 if (result.status !== 0) fail(`node --test failed (exit ${result.status}):\n${(result.stderr || result.stdout || "").slice(-2000)}`);

--- a/runtime/eval/tasks/manifest.json
+++ b/runtime/eval/tasks/manifest.json
@@ -10,7 +10,10 @@
       "fixture": "fixture",
       "prompt": "sum() in sum.js returns NaN because the loop reads one element past the end of the array. Fix the loop bounds so sum([1,2,3]) returns 6 and sum([]) returns 0.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -21,7 +24,10 @@
       "fixture": "fixture",
       "prompt": "greet() in greet.js throws when called with null, undefined, or a user without a name. It should fall back to the name \"guest\" in those cases and keep returning \"hello, <name>\" for users with a non-empty string name.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -32,7 +38,10 @@
       "fixture": "fixture",
       "prompt": "Add an exported clamp(value, min, max) function to math.js that returns min when value < min, max when value > max, and value otherwise. Do not break the existing add() export.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -43,7 +52,10 @@
       "fixture": "fixture",
       "prompt": "cli.mjs prints \"hello, <name>\" using the first CLI argument (default \"world\"). Add support for an --upper flag that uppercases the entire output line. The flag may appear before or after the name and must not be treated as the name itself.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -54,7 +66,10 @@
       "fixture": "fixture",
       "prompt": "counter.js uses var declarations. Replace every var with const or let (whichever is correct) without changing the module's behavior: increment() advances the counter and reset() sets it back to 0.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -65,7 +80,10 @@
       "fixture": "fixture",
       "prompt": "customerLabel() and employeeLabel() in report.js duplicate the same name-formatting expression. Extract it into an exported formatFullName(person) helper and make both label functions delegate to it. Output behavior must stay identical (trimmed first and last name, joined by a space, uppercased).",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -76,7 +94,10 @@
       "fixture": "fixture",
       "prompt": "Create slugify.test.mjs in the repo root. It must import { slugify } from ./slugify.js and use node:assert to verify at least: slugify(\"Hello World\") === \"hello-world\", slugify(\"  spaced  \") === \"spaced\", and slugify(\"a--b\") === \"a-b\". The script must exit nonzero when an assertion fails and exit 0 otherwise.",
       "verifiers": [
-        { "name": "tests-pass-and-catch-mutations", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "tests-pass-and-catch-mutations",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -87,7 +108,10 @@
       "fixture": "fixture",
       "prompt": "This repo configures its HTTP port in an ini settings file; other numbers in the tree are red herrings. Find the port the app actually uses and write just that number (no other text) to a new ANSWER.txt file in the repo root.",
       "verifiers": [
-        { "name": "answer", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "answer",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -98,7 +122,10 @@
       "fixture": "fixture",
       "prompt": "config.json fails JSON.parse because of a trailing comma. Fix the file so it parses, preserving every existing key and value exactly.",
       "verifiers": [
-        { "name": "parses", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "parses",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -109,7 +136,10 @@
       "fixture": "fixture",
       "prompt": "The function procesData in lib/data.js is misspelled. Rename it to processData everywhere it appears (definition, import, and call site in index.js) without changing behavior.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -120,7 +150,10 @@
       "fixture": "fixture",
       "prompt": "README.md contains a TODO placeholder. Replace it with a \"## Usage\" section that shows how to run the widget with the exact command node index.js. Remove the TODO text entirely.",
       "verifiers": [
-        { "name": "readme", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "readme",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
     },
     {
@@ -131,8 +164,221 @@
       "fixture": "fixture",
       "prompt": "fizzbuzz() in fizzbuzz.js returns \"Fizz\" for multiples of 15 because the divisibility checks run in the wrong order. Fix it so multiples of 15 return \"FizzBuzz\" while multiples of only 3 or only 5 still return \"Fizz\" and \"Buzz\", and other numbers return their decimal string.",
       "verifiers": [
-        { "name": "behavior", "command": "node {taskDir}/verify.mjs" }
+        {
+          "name": "behavior",
+          "command": "node {taskDir}/verify.mjs"
+        }
       ]
+    },
+    {
+      "id": "asteroid-drift-15",
+      "kind": "session",
+      "source": "agenc-local",
+      "title": "Asteroid Drift: a 15-prompt browser game built in one session",
+      "dir": "asteroid-drift-15",
+      "fixture": "fixture",
+      "steps": [
+        {
+          "id": "01-scaffold",
+          "prompt": "Create a browser game called Asteroid Drift in this folder: index.html plus game.js, a canvas that fills the window, a requestAnimationFrame loop with delta time, and a player ship at the bottom that moves left and right with the arrow keys. Remember these rules for this project: 2-space indentation, no semicolons, plain ES modules, no frameworks, no build step.",
+          "verifiers": [
+            {
+              "name": "scaffold",
+              "command": "node {taskDir}/verify-scaffold.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "02-asteroids",
+          "prompt": "Add asteroids that fall from the top at random x positions, with their speed rising over time. When one hits the ship the game ends with a Game Over screen.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "03-score",
+          "prompt": "Score is the number of seconds survived. Show it while playing and keep the best score in localStorage across reloads.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "04-start-pause",
+          "prompt": "Add a start screen before the game begins and a pause toggle on the P key.",
+          "verifiers": [
+            {
+              "name": "gameplay",
+              "command": "node {taskDir}/verify-gameplay.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "05-modules",
+          "prompt": "Refactor the code into ES modules: player.js, asteroids.js, hud.js and main.js as the entry point, keeping the behavior identical. Keep the style rules from the first message.",
+          "verifiers": [
+            {
+              "name": "modules",
+              "command": "node {taskDir}/verify-modules.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "06-effects",
+          "prompt": "Add a particle explosion and a short screen shake when the ship is destroyed.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "07-audio",
+          "prompt": "Add WebAudio beeps using an oscillator for events like death and level changes, plus a mute toggle on the M key whose state is remembered in localStorage.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "08-powerups",
+          "prompt": "Add two power-ups that spawn roughly every 10 seconds: a shield that absorbs one hit and a slow-time effect lasting 3 seconds.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "09-levels",
+          "prompt": "Add levels: every 20 points the level rises, asteroids spawn faster, and a banner announces the new level briefly.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "10-touch",
+          "prompt": "Add touch controls: dragging on the canvas moves the ship. Make the canvas responsive to window size changes.",
+          "verifiers": [
+            {
+              "name": "features",
+              "command": "node {taskDir}/verify-features.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "11-tests",
+          "prompt": "Write unit tests with node:test for the pure logic: collision, scoring and leveling. Run them and show me the output.",
+          "verifiers": [
+            {
+              "name": "tests",
+              "command": "node {taskDir}/verify-tests.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "12-readme",
+          "prompt": "Write a README.md that explains the controls and how to run the game, and add an npm start script that serves the folder locally with no dependencies.",
+          "verifiers": [
+            {
+              "name": "readme",
+              "command": "node {taskDir}/verify-readme.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "13-review",
+          "prompt": "Review your own code for real bugs and fix at least two. Show me what changed and why. Do not invent bugs.",
+          "verifiers": [
+            {
+              "name": "tests",
+              "command": "node {taskDir}/verify-tests.mjs"
+            },
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "14-highscores",
+          "prompt": "Add a high-score table: the top 5 scores with three-letter initials, entered after Game Over and kept in localStorage.",
+          "verifiers": [
+            {
+              "name": "style",
+              "command": "node {taskDir}/verify-style.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        },
+        {
+          "id": "15-final",
+          "prompt": "Final check: run the tests, confirm the style rules from the first message hold across every file, write a CHANGELOG.md that summarizes the 15 steps, and then stop.",
+          "verifiers": [
+            {
+              "name": "final",
+              "command": "node {taskDir}/verify-final.mjs"
+            }
+          ],
+          "timeoutMs": 900000
+        }
+      ],
+      "verifiers": [
+        {
+          "name": "final",
+          "command": "node {taskDir}/verify-final.mjs"
+        }
+      ],
+      "timeoutMs": 900000
     }
   ]
 }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -66,6 +66,8 @@
     "check:eval-contract": "tsx src/eval-contract/cli.ts",
     "check:eval-suites": "tsx src/eval-suites/cli.ts",
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
+    "eval:coding:mock": "node scripts/run-agent-eval.mjs --suite eval/tasks --executor mock --provider local --model scripted-mock --output eval/reports/mock-latest.json",
+    "eval:coding": "node scripts/run-agent-eval.mjs --suite eval/tasks --executor real --agent-command \"agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox {prompt}\" --output-dir eval/reports",
     "benchmark:fnd-baseline": "node benchmarks/fnd/run-baselines.mjs",
     "benchmark:fuzzy-search": "node benchmarks/fuzzy-search/run.mjs",
     "benchmark:set-cancellation": "tsx benchmarks/set-based-cancellation.ts",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -68,6 +68,7 @@
     "check:eval-regression": "node scripts/check-eval-regression.mjs",
     "eval:coding:mock": "node scripts/run-agent-eval.mjs --suite eval/tasks --executor mock --provider local --model scripted-mock --output eval/reports/mock-latest.json",
     "eval:coding": "node scripts/run-agent-eval.mjs --suite eval/tasks --executor real --agent-command \"agenc -p --output-format json --dangerously-bypass-approvals-and-sandbox {prompt}\" --output-dir eval/reports",
+    "eval:coding:check": "node scripts/check-eval-regression.mjs --baseline eval/baseline-real-grok-4.6-xhigh.json --reports-dir eval/reports",
     "benchmark:fnd-baseline": "node benchmarks/fnd/run-baselines.mjs",
     "benchmark:fuzzy-search": "node benchmarks/fuzzy-search/run.mjs",
     "benchmark:set-cancellation": "tsx benchmarks/set-based-cancellation.ts",

--- a/runtime/scripts/check-agent-eval-report.mjs
+++ b/runtime/scripts/check-agent-eval-report.mjs
@@ -121,58 +121,84 @@ function tokenTotal(tokens) {
     (Number.isFinite(tokens.output) ? tokens.output : 0);
 }
 
-function summarizeReport(report) {
-  const taskCounts = emptyStatusCounts();
-  const verifierCounts = emptyStatusCounts();
-  const riskFlags = new Map();
-  let durationMs = 0;
-  let tokenCount = 0;
-  let commandCount = 0;
-  let failedCommandCount = 0;
+function emptySummaryAccumulator() {
   const sessions = { tasks: 0, steps: 0, stepDurationMs: 0 };
   for (const key of SESSION_SUM_KEYS) sessions[key] = 0;
+  return {
+    taskCounts: emptyStatusCounts(),
+    verifierCounts: emptyStatusCounts(),
+    riskFlags: new Map(),
+    durationMs: 0,
+    tokenCount: 0,
+    commandCount: 0,
+    failedCommandCount: 0,
+    sessions,
+  };
+}
 
-  for (const task of report.tasks) {
-    taskCounts[task.status] += 1;
-    durationMs += task.durationMs;
-    tokenCount += tokenTotal(task.tokens);
-
-    for (const command of task.commands ?? []) {
-      commandCount += 1;
-      if (
-        Number.isInteger(command.exitCode) &&
-        command.exitCode !== 0
-      ) {
-        failedCommandCount += 1;
-      }
-    }
-
-    for (const verifier of task.verifiers) {
-      verifierCounts[verifier.status] += 1;
-    }
-    for (const step of task.steps ?? []) {
-      for (const verifier of step.verifiers ?? []) {
-        verifierCounts[verifier.status] += 1;
-      }
-    }
-    if (task.metrics) {
-      sessions.tasks += 1;
-      sessions.steps += task.metrics.steps ?? task.steps?.length ?? 0;
-      sessions.stepDurationMs += (task.steps ?? []).reduce((sum, step) => sum + step.durationMs, 0);
-      for (const key of SESSION_SUM_KEYS) {
-        sessions[key] += task.metrics[key] ?? 0;
-      }
-    }
-
-    for (const flag of task.riskFlags ?? []) {
-      riskFlags.set(flag, (riskFlags.get(flag) ?? 0) + 1);
+function countCommands(acc, task) {
+  for (const command of task.commands ?? []) {
+    acc.commandCount += 1;
+    if (Number.isInteger(command.exitCode) && command.exitCode !== 0) {
+      acc.failedCommandCount += 1;
     }
   }
+}
 
+function countVerifiers(acc, task) {
+  for (const verifier of task.verifiers) {
+    acc.verifierCounts[verifier.status] += 1;
+  }
+  for (const step of task.steps ?? []) {
+    for (const verifier of step.verifiers ?? []) {
+      acc.verifierCounts[verifier.status] += 1;
+    }
+  }
+}
+
+function countSession(acc, task) {
+  if (!task.metrics) return;
+  const { sessions } = acc;
+  sessions.tasks += 1;
+  sessions.steps += task.metrics.steps ?? task.steps?.length ?? 0;
+  sessions.stepDurationMs += (task.steps ?? []).reduce((sum, step) => sum + step.durationMs, 0);
+  for (const key of SESSION_SUM_KEYS) {
+    sessions[key] += task.metrics[key] ?? 0;
+  }
+}
+
+function accumulateTask(acc, task) {
+  acc.taskCounts[task.status] += 1;
+  acc.durationMs += task.durationMs;
+  acc.tokenCount += tokenTotal(task.tokens);
+  countCommands(acc, task);
+  countVerifiers(acc, task);
+  countSession(acc, task);
+  for (const flag of task.riskFlags ?? []) {
+    acc.riskFlags.set(flag, (acc.riskFlags.get(flag) ?? 0) + 1);
+  }
+}
+
+function sessionSummary(sessions) {
+  if (sessions.tasks === 0) return {};
+  return {
+    sessions: {
+      ...sessions,
+      avgStepDurationMs: sessions.steps > 0
+        ? Math.round(sessions.stepDurationMs / sessions.steps)
+        : 0,
+      toolErrorRate: percent(sessions.toolErrors, sessions.toolCalls),
+      rereadRate: percent(sessions.fileReReads, sessions.fileReads),
+    },
+  };
+}
+
+function summarizeReport(report) {
+  const acc = emptySummaryAccumulator();
+  for (const task of report.tasks) accumulateTask(acc, task);
+  const { taskCounts, verifierCounts } = acc;
   const attemptedTasks = taskCounts.passed + taskCounts.failed + taskCounts.error;
-  const attemptedVerifiers = verifierCounts.passed +
-    verifierCounts.failed +
-    verifierCounts.error;
+  const attemptedVerifiers = verifierCounts.passed + verifierCounts.failed + verifierCounts.error;
 
   return {
     schemaVersion: report.schemaVersion,
@@ -184,37 +210,23 @@ function summarizeReport(report) {
       fixRate: percent(taskCounts.passed, attemptedTasks),
     },
     verifiers: {
-      total: verifierCounts.passed +
-        verifierCounts.failed +
-        verifierCounts.error +
-        verifierCounts.skipped,
+      total: attemptedVerifiers + verifierCounts.skipped,
       ...verifierCounts,
       attempted: attemptedVerifiers,
       passRate: percent(verifierCounts.passed, attemptedVerifiers),
     },
-    durationMs,
+    durationMs: acc.durationMs,
     tokens: {
-      total: tokenCount,
+      total: acc.tokenCount,
     },
     commands: {
-      total: commandCount,
-      failed: failedCommandCount,
+      total: acc.commandCount,
+      failed: acc.failedCommandCount,
     },
     riskFlags: Object.fromEntries(
-      [...riskFlags.entries()].sort((a, b) => a[0].localeCompare(b[0])),
+      [...acc.riskFlags.entries()].sort((a, b) => a[0].localeCompare(b[0])),
     ),
-    ...(sessions.tasks > 0
-      ? {
-          sessions: {
-            ...sessions,
-            avgStepDurationMs: sessions.steps > 0
-              ? Math.round(sessions.stepDurationMs / sessions.steps)
-              : 0,
-            toolErrorRate: percent(sessions.toolErrors, sessions.toolCalls),
-            rereadRate: percent(sessions.fileReReads, sessions.fileReads),
-          },
-        }
-      : {}),
+    ...sessionSummary(acc.sessions),
   };
 }
 

--- a/runtime/scripts/check-agent-eval-report.mjs
+++ b/runtime/scripts/check-agent-eval-report.mjs
@@ -229,6 +229,7 @@ const SESSION_SUM_KEYS = [
   "compactionRollbacks",
   "permissionRequests",
   "warnings",
+  "providerFailures",
 ];
 
 function formatPercent(value) {
@@ -269,7 +270,7 @@ function formatMarkdownSummary(summary) {
       ? [
           `Sessions: ${summary.sessions.tasks} task(s), ${summary.sessions.steps} steps, avg step ${formatDuration(summary.sessions.avgStepDurationMs)}`,
           `Session tools: ${summary.sessions.toolCalls} calls, ${summary.sessions.toolErrors} errors (${formatPercent(summary.sessions.toolErrorRate)}), ${summary.sessions.fileReReads}/${summary.sessions.fileReads} re-reads (${formatPercent(summary.sessions.rereadRate)})`,
-          `Session context: ${summary.sessions.compactions} compactions (${summary.sessions.compactionAttempts} attempts, ${summary.sessions.compactionFailures} failed, ${summary.sessions.compactionRollbacks} rolled back), ${summary.sessions.permissionRequests} permission requests, ${summary.sessions.warnings} warnings`,
+          `Session context: ${summary.sessions.compactions} compactions (${summary.sessions.compactionAttempts} attempts, ${summary.sessions.compactionFailures} failed, ${summary.sessions.compactionRollbacks} rolled back), ${summary.sessions.permissionRequests} permission requests, ${summary.sessions.warnings} warnings, ${summary.sessions.providerFailures} provider failures`,
         ]
       : []),
   ].join("\n");

--- a/runtime/scripts/check-agent-eval-report.mjs
+++ b/runtime/scripts/check-agent-eval-report.mjs
@@ -129,6 +129,8 @@ function summarizeReport(report) {
   let tokenCount = 0;
   let commandCount = 0;
   let failedCommandCount = 0;
+  const sessions = { tasks: 0, steps: 0, stepDurationMs: 0 };
+  for (const key of SESSION_SUM_KEYS) sessions[key] = 0;
 
   for (const task of report.tasks) {
     taskCounts[task.status] += 1;
@@ -147,6 +149,19 @@ function summarizeReport(report) {
 
     for (const verifier of task.verifiers) {
       verifierCounts[verifier.status] += 1;
+    }
+    for (const step of task.steps ?? []) {
+      for (const verifier of step.verifiers ?? []) {
+        verifierCounts[verifier.status] += 1;
+      }
+    }
+    if (task.metrics) {
+      sessions.tasks += 1;
+      sessions.steps += task.metrics.steps ?? task.steps?.length ?? 0;
+      sessions.stepDurationMs += (task.steps ?? []).reduce((sum, step) => sum + step.durationMs, 0);
+      for (const key of SESSION_SUM_KEYS) {
+        sessions[key] += task.metrics[key] ?? 0;
+      }
     }
 
     for (const flag of task.riskFlags ?? []) {
@@ -188,8 +203,33 @@ function summarizeReport(report) {
     riskFlags: Object.fromEntries(
       [...riskFlags.entries()].sort((a, b) => a[0].localeCompare(b[0])),
     ),
+    ...(sessions.tasks > 0
+      ? {
+          sessions: {
+            ...sessions,
+            avgStepDurationMs: sessions.steps > 0
+              ? Math.round(sessions.stepDurationMs / sessions.steps)
+              : 0,
+            toolErrorRate: percent(sessions.toolErrors, sessions.toolCalls),
+            rereadRate: percent(sessions.fileReReads, sessions.fileReads),
+          },
+        }
+      : {}),
   };
 }
+
+const SESSION_SUM_KEYS = [
+  "toolCalls",
+  "toolErrors",
+  "fileReads",
+  "fileReReads",
+  "compactions",
+  "compactionAttempts",
+  "compactionFailures",
+  "compactionRollbacks",
+  "permissionRequests",
+  "warnings",
+];
 
 function formatPercent(value) {
   return `${value.toFixed(2)}%`;
@@ -225,6 +265,13 @@ function formatMarkdownSummary(summary) {
     `Duration: ${formatDuration(summary.durationMs)}`,
     `Commands: ${summary.commands.total} total, ${summary.commands.failed} failed`,
     riskLine,
+    ...(summary.sessions
+      ? [
+          `Sessions: ${summary.sessions.tasks} task(s), ${summary.sessions.steps} steps, avg step ${formatDuration(summary.sessions.avgStepDurationMs)}`,
+          `Session tools: ${summary.sessions.toolCalls} calls, ${summary.sessions.toolErrors} errors (${formatPercent(summary.sessions.toolErrorRate)}), ${summary.sessions.fileReReads}/${summary.sessions.fileReads} re-reads (${formatPercent(summary.sessions.rereadRate)})`,
+          `Session context: ${summary.sessions.compactions} compactions (${summary.sessions.compactionAttempts} attempts, ${summary.sessions.compactionFailures} failed, ${summary.sessions.compactionRollbacks} rolled back), ${summary.sessions.permissionRequests} permission requests, ${summary.sessions.warnings} warnings`,
+        ]
+      : []),
   ].join("\n");
 }
 

--- a/runtime/scripts/check-eval-regression.mjs
+++ b/runtime/scripts/check-eval-regression.mjs
@@ -19,6 +19,8 @@ const schemaPath = path.join(
 const defaultBaselinePath = path.join(runtimeRoot, "eval", "baseline-report.json");
 const defaultReportsDir = path.join(runtimeRoot, "eval", "reports");
 
+import { aggregateMetrics, deriveRatios } from "./eval/session-metrics.mjs";
+
 export const DEFAULT_THRESHOLDS = {
   // Percentage points of pass-rate drop tolerated before failing.
   maxPassRateDropPct: 0,
@@ -26,6 +28,11 @@ export const DEFAULT_THRESHOLDS = {
   maxTokenIncreasePct: 20,
   // Percent increase in average duration per attempted task tolerated.
   maxLatencyIncreasePct: 50,
+  // Session-metric movements (tool-error rate, re-read ratio, compactions per
+  // step) are reported as warnings unless a limit is given on the command line.
+  maxToolErrorRateIncreasePp: undefined,
+  maxRereadRatioIncreasePp: undefined,
+  maxCompactionsPerStepIncrease: undefined,
   // Treat a config-fingerprint mismatch as a regression instead of a warning.
   requireSameConfig: false,
 };
@@ -47,6 +54,9 @@ function usage() {
     `  --max-pass-rate-drop <pp>      Tolerated pass-rate drop in percentage points (default: ${DEFAULT_THRESHOLDS.maxPassRateDropPct})`,
     `  --max-token-increase-pct <pct> Tolerated avg-token increase percent (default: ${DEFAULT_THRESHOLDS.maxTokenIncreasePct})`,
     `  --max-latency-increase-pct <pct> Tolerated avg-latency increase percent (default: ${DEFAULT_THRESHOLDS.maxLatencyIncreasePct})`,
+    "  --max-tool-error-rate-increase-pp <pp>   Fail when the session tool-error rate rises more (default: warn only)",
+    "  --max-reread-ratio-increase-pp <pp>      Fail when the session re-read ratio rises more (default: warn only)",
+    "  --max-compactions-per-step-increase <n>  Fail when compactions per step rise more (default: warn only)",
     "  --require-same-config          Fail (not warn) on config fingerprint mismatch",
     "  --json                         Emit the comparison as JSON",
   ].join("\n");
@@ -96,6 +106,15 @@ function parseArgs(argv) {
         break;
       case "--max-latency-increase-pct":
         parsed.thresholds.maxLatencyIncreasePct = readNumber();
+        break;
+      case "--max-tool-error-rate-increase-pp":
+        parsed.thresholds.maxToolErrorRateIncreasePp = readNumber();
+        break;
+      case "--max-reread-ratio-increase-pp":
+        parsed.thresholds.maxRereadRatioIncreasePp = readNumber();
+        break;
+      case "--max-compactions-per-step-increase":
+        parsed.thresholds.maxCompactionsPerStepIncrease = readNumber();
         break;
       case "--require-same-config":
         parsed.thresholds.requireSameConfig = true;
@@ -185,8 +204,19 @@ export function reportMetrics(report) {
   }
 
   const attempted = passed + failed + error;
+  const sessionTasks = report.tasks.filter(
+    (task) => task.status !== "skipped" && task.metrics && typeof task.metrics === "object",
+  );
+  const session = sessionTasks.length > 0
+    ? aggregateMetrics(sessionTasks.map((task) => ({ ...task.metrics, steps: undefined })))
+    : undefined;
+  if (session) {
+    session.steps = sessionTasks.reduce((sum, task) => sum + (task.metrics.steps ?? task.steps?.length ?? 0), 0);
+  }
   return {
     totalTasks: report.tasks.length,
+    sessionTasks: sessionTasks.length,
+    ...(session ? { session, sessionRatios: deriveRatios(session) } : {}),
     attempted,
     passed,
     failed,
@@ -251,6 +281,8 @@ export function compareReports(baseline, candidate, thresholds = {}) {
     }
   }
 
+  compareSessionRatios(base, next, limits, regressions, warnings);
+
   if (base.totalTasks !== next.totalTasks) {
     warnings.push(
       `task count changed (${base.totalTasks} -> ${next.totalTasks})`,
@@ -283,6 +315,47 @@ export function compareReports(baseline, candidate, thresholds = {}) {
   };
 }
 
+const SESSION_RATIO_CHECKS = [
+  { key: "toolErrorRate", label: "session tool-error rate", scale: 100, unit: "pp", limit: "maxToolErrorRateIncreasePp" },
+  { key: "rereadRatio", label: "session re-read ratio", scale: 100, unit: "pp", limit: "maxRereadRatioIncreasePp" },
+  { key: "compactionsPerStep", label: "compactions per step", scale: 1, unit: "", limit: "maxCompactionsPerStepIncrease" },
+];
+
+function compareSessionRatios(base, next, limits, regressions, warnings) {
+  if (!base.sessionRatios && !next.sessionRatios) return;
+  if (!base.sessionRatios || !next.sessionRatios) {
+    warnings.push(
+      base.sessionRatios
+        ? "candidate has no session tasks; harness metrics not comparable"
+        : "baseline has no session tasks; harness metrics not enforced",
+    );
+    return;
+  }
+  for (const check of SESSION_RATIO_CHECKS) {
+    const before = base.sessionRatios[check.key];
+    const after = next.sessionRatios[check.key];
+    if (before === undefined || after === undefined) continue;
+    const delta = (after - before) * check.scale;
+    if (delta <= EPSILON) continue;
+    const shown = `${check.label} rose ${delta.toFixed(2)}${check.unit} ` +
+      `(${(before * check.scale).toFixed(2)}${check.unit} -> ${(after * check.scale).toFixed(2)}${check.unit})`;
+    const limit = limits[check.limit];
+    if (limit !== undefined && delta > limit + EPSILON) {
+      regressions.push(`${shown}, tolerated: ${limit}${check.unit}`);
+    } else {
+      warnings.push(shown);
+    }
+  }
+  const cacheBefore = base.sessionRatios.cacheHitRatio;
+  const cacheAfter = next.sessionRatios.cacheHitRatio;
+  if (cacheBefore !== undefined && cacheAfter !== undefined && cacheBefore - cacheAfter > EPSILON) {
+    warnings.push(
+      `session cache-hit ratio fell ${((cacheBefore - cacheAfter) * 100).toFixed(2)}pp ` +
+        `(${(cacheBefore * 100).toFixed(2)}% -> ${(cacheAfter * 100).toFixed(2)}%)`,
+    );
+  }
+}
+
 function compileValidator(schema) {
   const ajv = new Ajv({ allErrors: true, strict: false });
   return ajv.compile(schema);
@@ -292,6 +365,14 @@ function formatAjvErrors(errors) {
   return (errors ?? [])
     .map((error) => `- ${error.instancePath || "/"}: ${error.message}`)
     .join("\n");
+}
+
+function formatRatioPct(value) {
+  return value === undefined ? "n/a" : `${(value * 100).toFixed(2)}%`;
+}
+
+function formatRatio(value) {
+  return value === undefined ? "n/a" : value.toFixed(2);
 }
 
 function formatSummary(comparison, reportPath, baselinePath) {
@@ -304,6 +385,14 @@ function formatSummary(comparison, reportPath, baselinePath) {
     `Pass rate: ${baseline.passRatePct.toFixed(2)}% -> ${candidate.passRatePct.toFixed(2)}%`,
     `Avg tokens/task: ${baseline.avgTokens.toFixed(1)} -> ${candidate.avgTokens.toFixed(1)}`,
     `Avg latency/task: ${baseline.avgDurationMs.toFixed(0)}ms -> ${candidate.avgDurationMs.toFixed(0)}ms`,
+    ...(baseline.sessionRatios || candidate.sessionRatios
+      ? [
+          `Session tool-error rate: ${formatRatioPct(baseline.sessionRatios?.toolErrorRate)} -> ${formatRatioPct(candidate.sessionRatios?.toolErrorRate)}`,
+          `Session re-read ratio: ${formatRatioPct(baseline.sessionRatios?.rereadRatio)} -> ${formatRatioPct(candidate.sessionRatios?.rereadRatio)}`,
+          `Compactions per step: ${formatRatio(baseline.sessionRatios?.compactionsPerStep)} -> ${formatRatio(candidate.sessionRatios?.compactionsPerStep)}`,
+          `Session cache-hit ratio: ${formatRatioPct(baseline.sessionRatios?.cacheHitRatio)} -> ${formatRatioPct(candidate.sessionRatios?.cacheHitRatio)}`,
+        ]
+      : []),
     `Tasks: ${baseline.totalTasks} -> ${candidate.totalTasks} (attempted ${baseline.attempted} -> ${candidate.attempted})`,
   ];
   if (comparison.warnings.length > 0) {

--- a/runtime/scripts/check-eval-regression.mjs
+++ b/runtime/scripts/check-eval-regression.mjs
@@ -321,6 +321,33 @@ const SESSION_RATIO_CHECKS = [
   { key: "compactionsPerStep", label: "compactions per step", scale: 1, unit: "", limit: "maxCompactionsPerStepIncrease" },
 ];
 
+function compareSessionRatioCheck(check, base, next, limits, regressions, warnings) {
+  const before = base[check.key];
+  const after = next[check.key];
+  if (before === undefined || after === undefined) return;
+  const delta = (after - before) * check.scale;
+  if (delta <= EPSILON) return;
+  const shown = `${check.label} rose ${delta.toFixed(2)}${check.unit} ` +
+    `(${(before * check.scale).toFixed(2)}${check.unit} -> ${(after * check.scale).toFixed(2)}${check.unit})`;
+  const limit = limits[check.limit];
+  if (limit !== undefined && delta > limit + EPSILON) {
+    regressions.push(`${shown}, tolerated: ${limit}${check.unit}`);
+  } else {
+    warnings.push(shown);
+  }
+}
+
+function compareCacheHitRatio(base, next, warnings) {
+  const cacheBefore = base.cacheHitRatio;
+  const cacheAfter = next.cacheHitRatio;
+  if (cacheBefore === undefined || cacheAfter === undefined) return;
+  if (cacheBefore - cacheAfter <= EPSILON) return;
+  warnings.push(
+    `session cache-hit ratio fell ${((cacheBefore - cacheAfter) * 100).toFixed(2)}pp ` +
+      `(${(cacheBefore * 100).toFixed(2)}% -> ${(cacheAfter * 100).toFixed(2)}%)`,
+  );
+}
+
 function compareSessionRatios(base, next, limits, regressions, warnings) {
   if (!base.sessionRatios && !next.sessionRatios) return;
   if (!base.sessionRatios || !next.sessionRatios) {
@@ -332,28 +359,9 @@ function compareSessionRatios(base, next, limits, regressions, warnings) {
     return;
   }
   for (const check of SESSION_RATIO_CHECKS) {
-    const before = base.sessionRatios[check.key];
-    const after = next.sessionRatios[check.key];
-    if (before === undefined || after === undefined) continue;
-    const delta = (after - before) * check.scale;
-    if (delta <= EPSILON) continue;
-    const shown = `${check.label} rose ${delta.toFixed(2)}${check.unit} ` +
-      `(${(before * check.scale).toFixed(2)}${check.unit} -> ${(after * check.scale).toFixed(2)}${check.unit})`;
-    const limit = limits[check.limit];
-    if (limit !== undefined && delta > limit + EPSILON) {
-      regressions.push(`${shown}, tolerated: ${limit}${check.unit}`);
-    } else {
-      warnings.push(shown);
-    }
+    compareSessionRatioCheck(check, base.sessionRatios, next.sessionRatios, limits, regressions, warnings);
   }
-  const cacheBefore = base.sessionRatios.cacheHitRatio;
-  const cacheAfter = next.sessionRatios.cacheHitRatio;
-  if (cacheBefore !== undefined && cacheAfter !== undefined && cacheBefore - cacheAfter > EPSILON) {
-    warnings.push(
-      `session cache-hit ratio fell ${((cacheBefore - cacheAfter) * 100).toFixed(2)}pp ` +
-        `(${(cacheBefore * 100).toFixed(2)}% -> ${(cacheAfter * 100).toFixed(2)}%)`,
-    );
-  }
+  compareCacheHitRatio(base.sessionRatios, next.sessionRatios, warnings);
 }
 
 function compileValidator(schema) {

--- a/runtime/scripts/eval/session-metrics.mjs
+++ b/runtime/scripts/eval/session-metrics.mjs
@@ -1,0 +1,357 @@
+// Harness metrics for one multi-turn eval session. Two sources feed the same
+// accumulator: the SDK prompt events the runner receives live, and the
+// session's rollout JSONL, which carries the token counts, tool errors and
+// compaction records the live stream does not. Pure functions, no I/O except
+// the two explicit readers at the bottom, so the shapes are unit-testable.
+import { readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const READ_TOOLS = new Set(["FileRead", "Read", "file_read", "read_file"]);
+const WRITE_TOOLS = new Set([
+  "FileEdit",
+  "Edit",
+  "MultiEdit",
+  "FileWrite",
+  "Write",
+  "file_edit",
+  "file_write",
+]);
+
+export function createStepMetrics() {
+  return {
+    toolCalls: 0,
+    toolCallsByName: new Map(),
+    toolErrors: 0,
+    fileReads: 0,
+    fileReReads: 0,
+    compactions: 0,
+    compactionAttempts: 0,
+    compactionFailures: 0,
+    compactionRollbacks: 0,
+    permissionRequests: 0,
+    warnings: 0,
+    assistantMessages: 0,
+    assistantChars: 0,
+    promptTokensFirst: undefined,
+    promptTokensLast: undefined,
+    cachedTokensLast: undefined,
+    cachedTokensMax: undefined,
+    reasoningOutputTokens: 0,
+    // Paths read since the last mutation of that path. A second read without
+    // an intervening Edit or Write is a re-read the model did not need.
+    readSinceWrite: new Set(),
+  };
+}
+
+function inputPath(input) {
+  if (!input || typeof input !== "object") return undefined;
+  for (const key of ["file_path", "filePath", "path", "notebook_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+/** Feed one SDK prompt event. Unknown event types are ignored. */
+export function observePromptEvent(metrics, event) {
+  if (!event || typeof event !== "object") return;
+  switch (event.type) {
+    case "tool_call": {
+      metrics.toolCalls += 1;
+      const name = typeof event.toolName === "string" ? event.toolName : "?";
+      metrics.toolCallsByName.set(name, (metrics.toolCallsByName.get(name) ?? 0) + 1);
+      const path = inputPath(event.input);
+      if (READ_TOOLS.has(name)) {
+        metrics.fileReads += 1;
+        if (path !== undefined) {
+          if (metrics.readSinceWrite.has(path)) metrics.fileReReads += 1;
+          metrics.readSinceWrite.add(path);
+        }
+      } else if (WRITE_TOOLS.has(name) && path !== undefined) {
+        metrics.readSinceWrite.delete(path);
+      }
+      return;
+    }
+    case "history_reset":
+      if (event.reason === "partial_compact") metrics.compactions += 1;
+      if (event.reason === "compaction_rollback") metrics.compactionRollbacks += 1;
+      return;
+    case "permission_request":
+      metrics.permissionRequests += 1;
+      return;
+    case "text":
+      if (typeof event.delta === "string") metrics.assistantChars += event.delta.length;
+      return;
+    case "message_committed":
+      metrics.assistantMessages += 1;
+      return;
+    default:
+      return;
+  }
+}
+
+function numberField(record, keys) {
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+/** Feed one parsed rollout JSONL record. */
+export function observeRolloutRecord(metrics, record) {
+  if (!record || typeof record !== "object") return;
+  const type = record.type;
+  const payload = record.payload && typeof record.payload === "object" ? record.payload : {};
+  if (type === "event_msg") {
+    const msg = payload.msg && typeof payload.msg === "object" ? payload.msg : {};
+    const inner = msg.payload && typeof msg.payload === "object" ? msg.payload : {};
+    switch (msg.type) {
+      case "token_count": {
+        const prompt = numberField(inner, ["promptTokens", "prompt_tokens", "inputTokens"]);
+        const cached = numberField(inner, [
+          "cachedInputTokens",
+          "cached_input_tokens",
+          "cacheReadInputTokens",
+        ]);
+        const reasoning = numberField(inner, ["reasoningOutputTokens", "reasoning_output_tokens"]);
+        if (prompt !== undefined) {
+          if (metrics.promptTokensFirst === undefined) metrics.promptTokensFirst = prompt;
+          metrics.promptTokensLast = prompt;
+        }
+        if (cached !== undefined) {
+          metrics.cachedTokensLast = cached;
+          metrics.cachedTokensMax = Math.max(metrics.cachedTokensMax ?? 0, cached);
+        }
+        if (reasoning !== undefined) metrics.reasoningOutputTokens += reasoning;
+        return;
+      }
+      case "warning":
+        metrics.warnings += 1;
+        return;
+      default:
+        return;
+    }
+  }
+  if (type === "response_item" && (payload.role === "tool" || payload.type === "tool")) {
+    const content = payload.content ?? payload.output ?? "";
+    const text = typeof content === "string" ? content : JSON.stringify(content);
+    const flagged = payload.is_error === true || payload.isError === true;
+    if (flagged || /^(tool )?error\b/iu.test(text.trimStart().slice(0, 40))) {
+      metrics.toolErrors += 1;
+    }
+    return;
+  }
+  if (type === "compaction_intent") metrics.compactionAttempts += 1;
+  if (type === "compaction_failed") metrics.compactionFailures += 1;
+}
+
+/** The schema-shaped, JSON-serialisable view of one step or one task. */
+export function finalizeMetrics(metrics) {
+  const byName = Object.fromEntries(
+    [...metrics.toolCallsByName.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+  const out = {
+    toolCalls: metrics.toolCalls,
+    toolCallsByName: byName,
+    toolErrors: metrics.toolErrors,
+    fileReads: metrics.fileReads,
+    fileReReads: metrics.fileReReads,
+    compactions: metrics.compactions,
+    compactionAttempts: metrics.compactionAttempts,
+    compactionFailures: metrics.compactionFailures,
+    compactionRollbacks: metrics.compactionRollbacks,
+    permissionRequests: metrics.permissionRequests,
+    warnings: metrics.warnings,
+    assistantMessages: metrics.assistantMessages,
+    assistantChars: metrics.assistantChars,
+    reasoningOutputTokens: metrics.reasoningOutputTokens,
+  };
+  for (const key of ["promptTokensFirst", "promptTokensLast", "cachedTokensLast", "cachedTokensMax"]) {
+    if (metrics[key] !== undefined) out[key] = metrics[key];
+  }
+  return out;
+}
+
+/** Sum step views into a task view. Token watermarks take first/last/max. */
+export function aggregateMetrics(steps) {
+  const sum = (key) => steps.reduce((total, step) => total + (step[key] ?? 0), 0);
+  const byName = {};
+  for (const step of steps) {
+    for (const [name, count] of Object.entries(step.toolCallsByName ?? {})) {
+      byName[name] = (byName[name] ?? 0) + count;
+    }
+  }
+  const out = {
+    toolCalls: sum("toolCalls"),
+    toolCallsByName: Object.fromEntries(Object.entries(byName).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))),
+    toolErrors: sum("toolErrors"),
+    fileReads: sum("fileReads"),
+    fileReReads: sum("fileReReads"),
+    compactions: sum("compactions"),
+    compactionAttempts: sum("compactionAttempts"),
+    compactionFailures: sum("compactionFailures"),
+    compactionRollbacks: sum("compactionRollbacks"),
+    permissionRequests: sum("permissionRequests"),
+    warnings: sum("warnings"),
+    assistantMessages: sum("assistantMessages"),
+    assistantChars: sum("assistantChars"),
+    reasoningOutputTokens: sum("reasoningOutputTokens"),
+    steps: steps.length,
+  };
+  const first = steps.find((step) => step.promptTokensFirst !== undefined);
+  const last = [...steps].reverse().find((step) => step.promptTokensLast !== undefined);
+  const cachedLast = [...steps].reverse().find((step) => step.cachedTokensLast !== undefined);
+  if (first) out.promptTokensFirst = first.promptTokensFirst;
+  if (last) out.promptTokensLast = last.promptTokensLast;
+  if (cachedLast) out.cachedTokensLast = cachedLast.cachedTokensLast;
+  const cachedMax = steps.map((step) => step.cachedTokensMax).filter((value) => value !== undefined);
+  if (cachedMax.length > 0) out.cachedTokensMax = Math.max(...cachedMax);
+  return out;
+}
+
+/** Ratios the regression gate compares. Undefined when the denominator is 0. */
+export function deriveRatios(metrics) {
+  if (!metrics) return {};
+  const ratio = (numerator, denominator) =>
+    denominator > 0 ? Number((numerator / denominator).toFixed(4)) : undefined;
+  return {
+    toolErrorRate: ratio(metrics.toolErrors ?? 0, metrics.toolCalls ?? 0),
+    rereadRatio: ratio(metrics.fileReReads ?? 0, metrics.fileReads ?? 0),
+    compactionsPerStep: ratio(metrics.compactions ?? 0, metrics.steps ?? 0),
+    cacheHitRatio:
+      metrics.promptTokensLast !== undefined && metrics.cachedTokensLast !== undefined
+        ? ratio(metrics.cachedTokensLast, metrics.promptTokensLast)
+        : undefined,
+  };
+}
+
+/**
+ * Find the rollout file of one session under an AgenC home. Sessions live at
+ * projects/<slug>/sessions/<id>/rollout-*.jsonl and move to archived_sessions
+ * when terminated; both are searched.
+ */
+export function findSessionRollout(agencHome, sessionId) {
+  const projects = join(agencHome, "projects");
+  let slugs;
+  try {
+    slugs = readdirSync(projects);
+  } catch {
+    return undefined;
+  }
+  for (const slug of slugs) {
+    for (const bucket of ["sessions", "archived_sessions"]) {
+      const dir = join(projects, slug, bucket, sessionId);
+      let entries;
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue;
+      }
+      const rollout = entries.filter((name) => /^rollout-.*\.jsonl$/u.test(name)).sort().at(-1);
+      if (rollout) return join(dir, rollout);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Find the rollout of the session that runs in `cwd`. The daemon names rollout
+ * directories by conversation id, which the SDK does not expose (it reports the
+ * daemon session id), but every rollout starts with a session_meta record that
+ * carries the workspace cwd, and each eval task runs in its own temp workspace.
+ * Only rollouts modified at or after `sinceMs` are considered.
+ */
+export function findSessionRolloutForWorkspace(agencHome, cwd, sinceMs = 0) {
+  const projects = join(agencHome, "projects");
+  const wanted = canonical(cwd);
+  let slugs;
+  try {
+    slugs = readdirSync(projects);
+  } catch {
+    return undefined;
+  }
+  const candidates = [];
+  for (const slug of slugs) {
+    for (const bucket of ["sessions", "archived_sessions"]) {
+      const bucketDir = join(projects, slug, bucket);
+      let sessions;
+      try {
+        sessions = readdirSync(bucketDir);
+      } catch {
+        continue;
+      }
+      for (const sessionId of sessions) {
+        const dir = join(bucketDir, sessionId);
+        let entries;
+        try {
+          entries = readdirSync(dir);
+        } catch {
+          continue;
+        }
+        for (const name of entries) {
+          if (!/^rollout-.*\.jsonl$/u.test(name)) continue;
+          const path = join(dir, name);
+          let stat;
+          try {
+            stat = statSync(path);
+          } catch {
+            continue;
+          }
+          if (stat.mtimeMs < sinceMs) continue;
+          candidates.push({ path, mtimeMs: stat.mtimeMs });
+        }
+      }
+    }
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const candidate of candidates) {
+    const meta = firstRecord(candidate.path);
+    const recorded = meta?.payload?.cwd;
+    if (typeof recorded === "string" && canonical(recorded) === wanted) return candidate.path;
+  }
+  return undefined;
+}
+
+function canonical(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function firstRecord(path) {
+  try {
+    const text = readFileSync(path, "utf8");
+    const end = text.indexOf("\n");
+    return JSON.parse(end === -1 ? text : text.slice(0, end));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the records appended since `offset` bytes; returns the new offset. */
+export function readRolloutDelta(path, offset) {
+  let size;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return { records: [], offset };
+  }
+  if (size <= offset) return { records: [], offset };
+  const text = readFileSync(path, "utf8");
+  const chunk = text.slice(offset);
+  const lastNewline = chunk.lastIndexOf("\n");
+  const complete = lastNewline === -1 ? "" : chunk.slice(0, lastNewline + 1);
+  const records = [];
+  for (const line of complete.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // A torn or non-JSON line is not a metric; skip it.
+    }
+  }
+  return { records, offset: offset + Buffer.byteLength(complete, "utf8") };
+}

--- a/runtime/scripts/eval/session-metrics.mjs
+++ b/runtime/scripts/eval/session-metrics.mjs
@@ -54,41 +54,45 @@ function inputPath(input) {
 }
 
 /** Feed one SDK prompt event. Unknown event types are ignored. */
+function observeToolCall(metrics, event) {
+  metrics.toolCalls += 1;
+  const name = typeof event.toolName === "string" ? event.toolName : "?";
+  metrics.toolCallsByName.set(name, (metrics.toolCallsByName.get(name) ?? 0) + 1);
+  const path = inputPath(event.input);
+  if (READ_TOOLS.has(name)) {
+    metrics.fileReads += 1;
+    if (path === undefined) return;
+    if (metrics.readSinceWrite.has(path)) metrics.fileReReads += 1;
+    metrics.readSinceWrite.add(path);
+  } else if (WRITE_TOOLS.has(name) && path !== undefined) {
+    metrics.readSinceWrite.delete(path);
+  }
+}
+
+const PROMPT_EVENT_OBSERVERS = {
+  tool_call: observeToolCall,
+  history_reset(metrics, event) {
+    if (event.reason === "partial_compact") metrics.compactions += 1;
+    if (event.reason === "compaction_rollback") metrics.compactionRollbacks += 1;
+  },
+  permission_request(metrics) {
+    metrics.permissionRequests += 1;
+  },
+  text(metrics, event) {
+    if (typeof event.delta === "string") metrics.assistantChars += event.delta.length;
+  },
+  message_committed(metrics) {
+    metrics.assistantMessages += 1;
+  },
+};
+
+function observerFor(table, type) {
+  return typeof type === "string" && Object.hasOwn(table, type) ? table[type] : undefined;
+}
+
 export function observePromptEvent(metrics, event) {
   if (!event || typeof event !== "object") return;
-  switch (event.type) {
-    case "tool_call": {
-      metrics.toolCalls += 1;
-      const name = typeof event.toolName === "string" ? event.toolName : "?";
-      metrics.toolCallsByName.set(name, (metrics.toolCallsByName.get(name) ?? 0) + 1);
-      const path = inputPath(event.input);
-      if (READ_TOOLS.has(name)) {
-        metrics.fileReads += 1;
-        if (path !== undefined) {
-          if (metrics.readSinceWrite.has(path)) metrics.fileReReads += 1;
-          metrics.readSinceWrite.add(path);
-        }
-      } else if (WRITE_TOOLS.has(name) && path !== undefined) {
-        metrics.readSinceWrite.delete(path);
-      }
-      return;
-    }
-    case "history_reset":
-      if (event.reason === "partial_compact") metrics.compactions += 1;
-      if (event.reason === "compaction_rollback") metrics.compactionRollbacks += 1;
-      return;
-    case "permission_request":
-      metrics.permissionRequests += 1;
-      return;
-    case "text":
-      if (typeof event.delta === "string") metrics.assistantChars += event.delta.length;
-      return;
-    case "message_committed":
-      metrics.assistantMessages += 1;
-      return;
-    default:
-      return;
-  }
+  observerFor(PROMPT_EVENT_OBSERVERS, event.type)?.(metrics, event);
 }
 
 function numberField(record, keys) {
@@ -100,64 +104,82 @@ function numberField(record, keys) {
 }
 
 /** Feed one parsed rollout JSONL record. */
-export function observeRolloutRecord(metrics, record) {
-  if (!record || typeof record !== "object") return;
-  const type = record.type;
-  const payload = record.payload && typeof record.payload === "object" ? record.payload : {};
-  if (type === "event_msg") {
-    const msg = payload.msg && typeof payload.msg === "object" ? payload.msg : {};
-    const inner = msg.payload && typeof msg.payload === "object" ? msg.payload : {};
-    switch (msg.type) {
-      case "token_count": {
-        const prompt = numberField(inner, ["promptTokens", "prompt_tokens", "inputTokens"]);
-        const cached = numberField(inner, [
-          "cachedInputTokens",
-          "cached_input_tokens",
-          "cacheReadInputTokens",
-        ]);
-        const reasoning = numberField(inner, ["reasoningOutputTokens", "reasoning_output_tokens"]);
-        if (prompt !== undefined) {
-          if (metrics.promptTokensFirst === undefined) metrics.promptTokensFirst = prompt;
-          metrics.promptTokensLast = prompt;
-        }
-        if (cached !== undefined) {
-          metrics.cachedTokensLast = cached;
-          metrics.cachedTokensMax = Math.max(metrics.cachedTokensMax ?? 0, cached);
-        }
-        if (reasoning !== undefined) metrics.reasoningOutputTokens += reasoning;
-        return;
-      }
-      case "warning":
-        metrics.warnings += 1;
-        return;
-      case "execution_admission":
-        // A model turn that was dispatched and then lost to the provider ends
-        // in held_unknown; the turn still "completes", with nothing in it.
-        if (inner.event === "held_unknown" && inner.kind === "model_turn") {
-          metrics.providerFailures += 1;
-        }
-        return;
-      default:
-        return;
-    }
+function objectOr(value) {
+  return value && typeof value === "object" ? value : {};
+}
+
+function observeTokenCount(metrics, inner) {
+  const prompt = numberField(inner, ["promptTokens", "prompt_tokens", "inputTokens"]);
+  const cached = numberField(inner, [
+    "cachedInputTokens",
+    "cached_input_tokens",
+    "cacheReadInputTokens",
+  ]);
+  const reasoning = numberField(inner, ["reasoningOutputTokens", "reasoning_output_tokens"]);
+  if (prompt !== undefined) {
+    if (metrics.promptTokensFirst === undefined) metrics.promptTokensFirst = prompt;
+    metrics.promptTokensLast = prompt;
   }
-  if (type === "response_item" && (payload.role === "tool" || payload.type === "tool")) {
-    const content = payload.content ?? payload.output ?? "";
-    const text = typeof content === "string" ? content : JSON.stringify(content);
-    const flagged = payload.is_error === true || payload.isError === true;
-    if (flagged || /^(tool )?error\b/iu.test(text.trimStart().slice(0, 40))) {
+  if (cached !== undefined) {
+    metrics.cachedTokensLast = cached;
+    metrics.cachedTokensMax = Math.max(metrics.cachedTokensMax ?? 0, cached);
+  }
+  if (reasoning !== undefined) metrics.reasoningOutputTokens += reasoning;
+}
+
+const EVENT_MSG_OBSERVERS = {
+  token_count: observeTokenCount,
+  warning(metrics) {
+    metrics.warnings += 1;
+  },
+  execution_admission(metrics, inner) {
+    // A model turn that was dispatched and then lost to the provider ends
+    // in held_unknown; the turn still "completes", with nothing in it.
+    if (inner.event === "held_unknown" && inner.kind === "model_turn") {
+      metrics.providerFailures += 1;
+    }
+  },
+};
+
+function isToolError(payload) {
+  if (payload.is_error === true || payload.isError === true) return true;
+  const content = payload.content ?? payload.output ?? "";
+  const text = typeof content === "string" ? content : JSON.stringify(content);
+  return /^(tool )?error\b/iu.test(text.trimStart().slice(0, 40));
+}
+
+const ROLLOUT_RECORD_OBSERVERS = {
+  event_msg(metrics, payload) {
+    const msg = objectOr(payload.msg);
+    observerFor(EVENT_MSG_OBSERVERS, msg.type)?.(metrics, objectOr(msg.payload));
+  },
+  response_item(metrics, payload) {
+    if ((payload.role === "tool" || payload.type === "tool") && isToolError(payload)) {
       metrics.toolErrors += 1;
     }
-    return;
-  }
-  if (type === "compaction_intent") metrics.compactionAttempts += 1;
-  if (type === "compaction_failed") metrics.compactionFailures += 1;
+  },
+  compaction_intent(metrics) {
+    metrics.compactionAttempts += 1;
+  },
+  compaction_failed(metrics) {
+    metrics.compactionFailures += 1;
+  },
+};
+
+export function observeRolloutRecord(metrics, record) {
+  if (!record || typeof record !== "object") return;
+  observerFor(ROLLOUT_RECORD_OBSERVERS, record.type)?.(metrics, objectOr(record.payload));
 }
 
 /** The schema-shaped, JSON-serialisable view of one step or one task. */
+function compareKeys(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
 export function finalizeMetrics(metrics) {
   const byName = Object.fromEntries(
-    [...metrics.toolCallsByName.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+    [...metrics.toolCallsByName.entries()].sort(([a], [b]) => compareKeys(a, b)),
   );
   const out = {
     toolCalls: metrics.toolCalls,
@@ -193,7 +215,7 @@ export function aggregateMetrics(steps) {
   }
   const out = {
     toolCalls: sum("toolCalls"),
-    toolCallsByName: Object.fromEntries(Object.entries(byName).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))),
+    toolCallsByName: Object.fromEntries(Object.entries(byName).sort(([a], [b]) => compareKeys(a, b))),
     toolErrors: sum("toolErrors"),
     fileReads: sum("fileReads"),
     fileReReads: sum("fileReReads"),
@@ -272,52 +294,48 @@ export function findSessionRollout(agencHome, sessionId) {
  * carries the workspace cwd, and each eval task runs in its own temp workspace.
  * Only rollouts modified at or after `sinceMs` are considered.
  */
-export function findSessionRolloutForWorkspace(agencHome, cwd, sinceMs = 0) {
-  const projects = join(agencHome, "projects");
-  const wanted = canonical(cwd);
-  let slugs;
+function listDir(dir) {
   try {
-    slugs = readdirSync(projects);
+    return readdirSync(dir);
   } catch {
-    return undefined;
+    return [];
   }
+}
+
+function rolloutFilesIn(dir, sinceMs) {
+  const out = [];
+  for (const name of listDir(dir)) {
+    if (!name.startsWith("rollout-") || !name.endsWith(".jsonl")) continue;
+    const path = join(dir, name);
+    let stat;
+    try {
+      stat = statSync(path);
+    } catch {
+      continue;
+    }
+    if (stat.mtimeMs >= sinceMs) out.push({ path, mtimeMs: stat.mtimeMs });
+  }
+  return out;
+}
+
+function rolloutCandidates(agencHome, sinceMs) {
+  const projects = join(agencHome, "projects");
   const candidates = [];
-  for (const slug of slugs) {
+  for (const slug of listDir(projects)) {
     for (const bucket of ["sessions", "archived_sessions"]) {
       const bucketDir = join(projects, slug, bucket);
-      let sessions;
-      try {
-        sessions = readdirSync(bucketDir);
-      } catch {
-        continue;
-      }
-      for (const sessionId of sessions) {
-        const dir = join(bucketDir, sessionId);
-        let entries;
-        try {
-          entries = readdirSync(dir);
-        } catch {
-          continue;
-        }
-        for (const name of entries) {
-          if (!/^rollout-.*\.jsonl$/u.test(name)) continue;
-          const path = join(dir, name);
-          let stat;
-          try {
-            stat = statSync(path);
-          } catch {
-            continue;
-          }
-          if (stat.mtimeMs < sinceMs) continue;
-          candidates.push({ path, mtimeMs: stat.mtimeMs });
-        }
+      for (const sessionId of listDir(bucketDir)) {
+        candidates.push(...rolloutFilesIn(join(bucketDir, sessionId), sinceMs));
       }
     }
   }
-  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  for (const candidate of candidates) {
-    const meta = firstRecord(candidate.path);
-    const recorded = meta?.payload?.cwd;
+  return candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
+
+export function findSessionRolloutForWorkspace(agencHome, cwd, sinceMs = 0) {
+  const wanted = canonical(cwd);
+  for (const candidate of rolloutCandidates(agencHome, sinceMs)) {
+    const recorded = firstRecord(candidate.path)?.payload?.cwd;
     if (typeof recorded === "string" && canonical(recorded) === wanted) return candidate.path;
   }
   return undefined;

--- a/runtime/scripts/eval/session-metrics.mjs
+++ b/runtime/scripts/eval/session-metrics.mjs
@@ -30,6 +30,7 @@ export function createStepMetrics() {
     compactionRollbacks: 0,
     permissionRequests: 0,
     warnings: 0,
+    providerFailures: 0,
     assistantMessages: 0,
     assistantChars: 0,
     promptTokensFirst: undefined,
@@ -129,6 +130,13 @@ export function observeRolloutRecord(metrics, record) {
       case "warning":
         metrics.warnings += 1;
         return;
+      case "execution_admission":
+        // A model turn that was dispatched and then lost to the provider ends
+        // in held_unknown; the turn still "completes", with nothing in it.
+        if (inner.event === "held_unknown" && inner.kind === "model_turn") {
+          metrics.providerFailures += 1;
+        }
+        return;
       default:
         return;
     }
@@ -163,6 +171,7 @@ export function finalizeMetrics(metrics) {
     compactionRollbacks: metrics.compactionRollbacks,
     permissionRequests: metrics.permissionRequests,
     warnings: metrics.warnings,
+    providerFailures: metrics.providerFailures,
     assistantMessages: metrics.assistantMessages,
     assistantChars: metrics.assistantChars,
     reasoningOutputTokens: metrics.reasoningOutputTokens,
@@ -194,6 +203,7 @@ export function aggregateMetrics(steps) {
     compactionRollbacks: sum("compactionRollbacks"),
     permissionRequests: sum("permissionRequests"),
     warnings: sum("warnings"),
+    providerFailures: sum("providerFailures"),
     assistantMessages: sum("assistantMessages"),
     assistantChars: sum("assistantChars"),
     reasoningOutputTokens: sum("reasoningOutputTokens"),

--- a/runtime/scripts/eval/workspace-trust.mjs
+++ b/runtime/scripts/eval/workspace-trust.mjs
@@ -1,0 +1,40 @@
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const TRUSTED_PROJECTS_FILENAME = "trusted-projects.json";
+
+function readRecord(file) {
+  if (!existsSync(file)) return { version: 1, trustedProjects: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (parsed && typeof parsed === "object" && parsed.version === 1 && Array.isArray(parsed.trustedProjects)) {
+      return parsed;
+    }
+  } catch {
+    // An unreadable record is replaced; the home is isolated to this eval run.
+  }
+  return { version: 1, trustedProjects: [] };
+}
+
+/**
+ * Trust an eval workspace inside the isolated AGENC_HOME so print mode, which
+ * has no TTY and therefore no trust prompt, accepts it. Writes the same
+ * version-1 record as runtime/src/permissions/trust/project-trust.ts and keeps
+ * every other entry. Never call this with the user's real home.
+ */
+export function trustWorkspace({ agencHome, workspace, now = () => new Date() }) {
+  const canonical = realpathSync(workspace);
+  const file = path.join(agencHome, TRUSTED_PROJECTS_FILENAME);
+  const record = readRecord(file);
+  const others = record.trustedProjects.filter((entry) => entry?.path !== canonical);
+  const next = {
+    ...record,
+    version: 1,
+    trustedProjects: [...others, { path: canonical, trustedAt: now().toISOString() }],
+  };
+  mkdirSync(agencHome, { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  renameSync(tmp, file);
+  return { path: canonical, file };
+}

--- a/runtime/scripts/run-agent-eval.mjs
+++ b/runtime/scripts/run-agent-eval.mjs
@@ -854,20 +854,31 @@ async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFla
         tokens.output += stepTokens.output ?? 0;
         tokens.total += stepTokens.total ?? (stepTokens.input ?? 0) + (stepTokens.output ?? 0);
       }
-      const exitCode = stepError ? 1 : stepResult?.exitCode ?? 1;
+      // A turn the provider dropped after dispatch "completes" with an empty
+      // message and exit 0. That is not a pass: the prompt did no work.
+      const providerDropped = !stepError
+        && metrics.providerFailures > 0
+        && metrics.toolCalls === 0
+        && (stepResult?.finalMessage ?? "").trim().length === 0;
+      if (providerDropped) riskFlags.add("provider_call_failed");
+      const exitCode = stepError ? 1 : providerDropped ? 1 : stepResult?.exitCode ?? 1;
       if (exitCode !== 0) riskFlags.add("agent_command_failed");
       const verifiers = exitCode === 0
         ? await runStepVerifiers(step, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
         : [];
       const notes = stepError
         ? `step ${step.id}: ${stepError.message}`.slice(0, 1000)
-        : undefined;
+        : providerDropped
+          ? `step ${step.id}: the provider call failed after dispatch and the turn completed empty`
+          : undefined;
       steps.push({
         id: step.id,
         status: exitCode !== 0 ? "error" : verifierStatus(verifiers),
         durationMs: Math.round(performance.now() - stepStarted),
         ...(stepTokens ? { tokens: stepTokens } : {}),
-        ...(stepResult?.stopReason ? { stopReason: String(stepResult.stopReason) } : {}),
+        ...(providerDropped
+          ? { stopReason: "provider_failed" }
+          : stepResult?.stopReason ? { stopReason: String(stepResult.stopReason) } : {}),
         exitCode,
         metrics: finalizeMetrics(metrics),
         verifiers,

--- a/runtime/scripts/run-agent-eval.mjs
+++ b/runtime/scripts/run-agent-eval.mjs
@@ -1,6 +1,16 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import {
+  aggregateMetrics,
+  createStepMetrics,
+  finalizeMetrics,
+  findSessionRollout,
+  findSessionRolloutForWorkspace,
+  observePromptEvent,
+  observeRolloutRecord,
+  readRolloutDelta,
+} from "./eval/session-metrics.mjs";
 import { createHash, randomUUID } from "node:crypto";
 import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -46,6 +56,11 @@ function usage() {
     "  --repo <path>           Repository/workspace path (default: cwd)",
     "  --timeout-ms <ms>       Per-command timeout (default: 600000)",
     "  --keep-workspaces       Do not delete per-task fixture workspaces",
+    "",
+    "Session tasks (manifest task.kind = 'session') drive one daemon session",
+    "through task.steps[].prompt over the AgenC SDK. They require AGENC_HOME to",
+    "point at an isolated home whose config selects the model under test; the",
+    "runner refuses to start a daemon in the default home.",
     "",
     "Task commands may use placeholders: {prompt}, {promptJson}, {taskId}, {cwd},",
     "and {taskDir} (for suite tasks with a dir).",
@@ -252,8 +267,17 @@ function normalizeTask(raw, index) {
   if (verifiers !== undefined && !Array.isArray(verifiers)) {
     throw new Error(`task ${id} verifiers must be an array`);
   }
+  const kind = asString(task.kind) ?? "command";
+  if (kind !== "command" && kind !== "session") {
+    throw new Error(`task ${id} kind must be 'command' or 'session'`);
+  }
+  const steps = kind === "session"
+    ? normalizeSteps(task.steps, id)
+    : [];
   return {
     id,
+    kind,
+    steps,
     source: asString(task.source),
     title: asString(task.title),
     prompt: typeof task.prompt === "string" ? task.prompt : "",
@@ -275,6 +299,35 @@ function normalizeTask(raw, index) {
         ? Math.max(1, Math.floor(task.timeoutMs))
         : undefined,
   };
+}
+
+function normalizeSteps(raw, taskId) {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(`session task ${taskId} needs a non-empty steps array`);
+  }
+  const seen = new Set();
+  return raw.map((entry, index) => {
+    const step = asObject(entry, `task ${taskId} steps[${index}]`);
+    const id = asString(step.id) ?? `step-${index + 1}`;
+    if (seen.has(id)) throw new Error(`task ${taskId} repeats step id ${id}`);
+    seen.add(id);
+    const prompt = asString(step.prompt);
+    if (!prompt) throw new Error(`task ${taskId} step ${id} is missing prompt`);
+    const verifiers = step.verifiers;
+    if (verifiers !== undefined && !Array.isArray(verifiers)) {
+      throw new Error(`task ${taskId} step ${id} verifiers must be an array`);
+    }
+    return {
+      id,
+      prompt,
+      verifiers: (verifiers ?? []).map((verifier, verifierIndex) =>
+        normalizeVerifier(verifier, `${taskId}/${id}`, verifierIndex)),
+      timeoutMs:
+        typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)
+          ? Math.max(1, Math.floor(step.timeoutMs))
+          : undefined,
+    };
+  });
 }
 
 function normalizeVerifier(raw, taskId, index) {
@@ -527,6 +580,12 @@ async function runTaskInWorkspace(task, manifest, args, workspace) {
     }
   }
 
+  if (task.kind === "session") {
+    return args.executor === "mock"
+      ? runMockSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted })
+      : runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted });
+  }
+
   const agentCommand = args.executor === "mock"
     ? task.mockCommand ?? (taskDir ? "bash {taskDir}/solution.sh" : undefined)
     : task.agentCommand ?? manifest.agentCommand ?? args.agentCommand;
@@ -594,17 +653,270 @@ async function runTaskInWorkspace(task, manifest, args, workspace) {
   });
 }
 
+async function runStepVerifiers(step, task, cwd, taskDir, timeoutMs, rawResults, riskFlags) {
+  const verifiers = [];
+  for (const verifier of step.verifiers) {
+    const result = await runCommand(renderCommand(verifier.command, task, cwd, taskDir), {
+      cwd,
+      timeoutMs,
+    });
+    rawResults.push(result);
+    verifiers.push(verifierReport(verifier, result));
+    if (result.timedOut) riskFlags.add("verifier_timeout");
+    if (result.exitCode !== 0) riskFlags.add("verifier_failed");
+  }
+  return verifiers;
+}
+
+function verifierStatus(verifiers) {
+  if (verifiers.some((verifier) => verifier.status === "error")) return "error";
+  if (verifiers.some((verifier) => verifier.status === "failed")) return "failed";
+  return "passed";
+}
+
+function sessionStatus(steps, verifiers) {
+  const all = [...steps.map((step) => step.status), verifierStatus(verifiers)];
+  if (all.includes("error")) return "error";
+  if (all.includes("failed")) return "failed";
+  return "passed";
+}
+
+/**
+ * Mock executor for a session task: the scripted solution writes the finished
+ * project once, then every step's verifiers and the task verifiers run in
+ * order. This proves the checkers accept a known-good tree and gives the
+ * regression tests a deterministic session report.
+ */
+async function runMockSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted }) {
+  const solution = task.mockCommand ?? (taskDir ? "bash {taskDir}/solution.sh" : undefined);
+  if (!solution) {
+    riskFlags.add("mock_command_missing");
+    return buildTaskReport({
+      task, status: "error", durationMs: performance.now() - taskStarted, commands, verifiers: [], riskFlags, rawResults,
+      notes: "No mock command or task dir with solution.sh configured for session task.",
+    });
+  }
+  const solutionResult = await runCommand(renderCommand(solution, task, cwd, taskDir), { cwd, timeoutMs });
+  commands.push(commandReport(solutionResult));
+  rawResults.push(solutionResult);
+  if (solutionResult.exitCode !== 0) {
+    riskFlags.add("agent_command_failed");
+    return buildTaskReport({
+      task, status: "error", durationMs: performance.now() - taskStarted, commands, verifiers: [], riskFlags, rawResults,
+    });
+  }
+  const steps = [];
+  for (const step of task.steps) {
+    const stepStarted = performance.now();
+    const verifiers = await runStepVerifiers(step, task, cwd, taskDir, step.timeoutMs ?? timeoutMs, rawResults, riskFlags);
+    steps.push({
+      id: step.id,
+      status: verifierStatus(verifiers),
+      durationMs: Math.round(performance.now() - stepStarted),
+      tokens: { input: 1, output: 1 },
+      exitCode: 0,
+      metrics: finalizeMetrics(createStepMetrics()),
+      verifiers,
+    });
+  }
+  const verifiers = await runStepVerifiers({ verifiers: task.verifiers }, task, cwd, taskDir, timeoutMs, rawResults, riskFlags);
+  return buildTaskReport({
+    task,
+    status: sessionStatus(steps, verifiers),
+    durationMs: performance.now() - taskStarted,
+    commands,
+    verifiers,
+    riskFlags,
+    rawResults,
+    tokens: { input: steps.length, output: steps.length },
+    steps,
+    metrics: aggregateMetrics(steps.map((step) => step.metrics)),
+  });
+}
+
+async function loadSdk() {
+  const candidates = [
+    new URL("../../packages/agenc-sdk/dist/index.js", import.meta.url).href,
+    "@tetsuo-ai/agenc-sdk",
+  ];
+  let lastError;
+  for (const candidate of candidates) {
+    try {
+      return await import(candidate);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw new Error(
+    `session tasks need the built AgenC SDK (npm run build --workspace=@tetsuo-ai/agenc-sdk): ${lastError?.message ?? "not found"}`,
+  );
+}
+
+/**
+ * The daemon names rollout directories by conversation id, which the SDK does
+ * not expose. `agent.logs` reports each session's rolloutPath directly; when
+ * that call is unavailable the runner falls back to matching the workspace.
+ */
+async function rolloutPathFromAgentLogs(client, session) {
+  if (!session.agentId || typeof client.agentLogs !== "function") return undefined;
+  try {
+    const logs = await client.agentLogs(session.agentId);
+    const entry = (logs?.sessions ?? []).find(
+      (candidate) => candidate.sessionId === session.sessionId && typeof candidate.rolloutPath === "string",
+    ) ?? (logs?.sessions ?? []).find((candidate) => typeof candidate.rolloutPath === "string");
+    return entry?.rolloutPath;
+  } catch {
+    return undefined;
+  }
+}
+
+function requireIsolatedHome(env) {
+  const home = env.AGENC_HOME;
+  if (typeof home !== "string" || !path.isAbsolute(home)) {
+    throw new Error(
+      "session tasks require AGENC_HOME set to an absolute, isolated home; the eval runner will not start a daemon in the default home",
+    );
+  }
+  return home;
+}
+
+/**
+ * Real executor for a session task: one daemon session in the isolated
+ * AGENC_HOME, each step a prompt over the SDK. Live prompt events feed the
+ * tool-call, re-read, compaction and permission counters; the session rollout
+ * feeds token counts, tool errors and compaction attempts after each step.
+ */
+async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted }) {
+  const agencHome = requireIsolatedHome(process.env);
+  const sdk = await loadSdk();
+  const client = await sdk.connect({
+    env: process.env,
+    clientName: "agenc-eval",
+    onPermissionRequest: () => ({ behavior: "deny", reason: "eval runner denies interactive approvals" }),
+  });
+  const steps = [];
+  const tokens = { input: 0, output: 0, total: 0 };
+  let session;
+  let rolloutPath;
+  let rolloutOffset = 0;
+  // Rollouts written before this instant belong to earlier sessions in the home.
+  const sessionStartedMs = Date.now() - 5000;
+  try {
+    session = await client.createSession({
+      cwd,
+      pluginStorageRoot: path.join(agencHome, "plugins"),
+      dangerouslyBypassApprovalsAndSandbox: true,
+      metadata: { evalTaskId: task.id, evalRunner: "run-agent-eval" },
+    });
+    for (const step of task.steps) {
+      const stepStarted = performance.now();
+      const metrics = createStepMetrics();
+      const controller = new AbortController();
+      const stepTimeout = step.timeoutMs ?? timeoutMs;
+      const timer = setTimeout(() => controller.abort(new Error(`step ${step.id} exceeded ${stepTimeout} ms`)), stepTimeout);
+      let stepResult;
+      let stepError;
+      try {
+        const run = session.prompt(step.prompt, {
+          includeUsage: true,
+          clientMessageId: `eval-${task.id}-${step.id}`,
+          signal: controller.signal,
+          onPermissionRequest: () => ({ behavior: "deny", reason: "eval runner denies interactive approvals" }),
+        });
+        for await (const event of run) observePromptEvent(metrics, event);
+        stepResult = await run.result();
+      } catch (error) {
+        stepError = error;
+        if (controller.signal.aborted) riskFlags.add("agent_timeout");
+      } finally {
+        clearTimeout(timer);
+      }
+      rolloutPath ??= (await rolloutPathFromAgentLogs(client, session))
+        ?? findSessionRolloutForWorkspace(agencHome, cwd, sessionStartedMs)
+        ?? findSessionRollout(agencHome, session.sessionId);
+      if (rolloutPath) {
+        const delta = readRolloutDelta(rolloutPath, rolloutOffset);
+        rolloutOffset = delta.offset;
+        for (const record of delta.records) observeRolloutRecord(metrics, record);
+      } else {
+        riskFlags.add("rollout_not_found");
+      }
+      const usage = stepResult?.usage && typeof stepResult.usage === "object" ? stepResult.usage : undefined;
+      const stepTokens = usage
+        ? {
+            ...(Number.isFinite(usage.inputTokens) ? { input: usage.inputTokens } : {}),
+            ...(Number.isFinite(usage.outputTokens) ? { output: usage.outputTokens } : {}),
+            ...(Number.isFinite(usage.totalTokens) ? { total: usage.totalTokens } : {}),
+          }
+        : undefined;
+      if (stepTokens) {
+        tokens.input += stepTokens.input ?? 0;
+        tokens.output += stepTokens.output ?? 0;
+        tokens.total += stepTokens.total ?? (stepTokens.input ?? 0) + (stepTokens.output ?? 0);
+      }
+      const exitCode = stepError ? 1 : stepResult?.exitCode ?? 1;
+      if (exitCode !== 0) riskFlags.add("agent_command_failed");
+      const verifiers = exitCode === 0
+        ? await runStepVerifiers(step, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
+        : [];
+      const notes = stepError
+        ? `step ${step.id}: ${stepError.message}`.slice(0, 1000)
+        : undefined;
+      steps.push({
+        id: step.id,
+        status: exitCode !== 0 ? "error" : verifierStatus(verifiers),
+        durationMs: Math.round(performance.now() - stepStarted),
+        ...(stepTokens ? { tokens: stepTokens } : {}),
+        ...(stepResult?.stopReason ? { stopReason: String(stepResult.stopReason) } : {}),
+        exitCode,
+        metrics: finalizeMetrics(metrics),
+        verifiers,
+        ...(notes ? { notes } : {}),
+      });
+      if (exitCode !== 0) break;
+    }
+  } finally {
+    if (session) {
+      await session.terminate("eval session complete").catch(() => {});
+    }
+    await client.close().catch(() => {});
+  }
+  const sessionNote = session
+    ? `session ${session.sessionId}${rolloutPath ? ` rollout ${path.basename(rolloutPath)}` : " (rollout not found)"}`
+    : "session was not created";
+  const completed = steps.length === task.steps.length && steps.every((step) => step.status !== "error");
+  const verifiers = completed
+    ? await runStepVerifiers({ verifiers: task.verifiers }, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
+    : [];
+  return buildTaskReport({
+    task,
+    status: completed ? sessionStatus(steps, verifiers) : "error",
+    durationMs: performance.now() - taskStarted,
+    commands,
+    verifiers,
+    riskFlags,
+    rawResults,
+    tokens: tokens.total > 0 || tokens.input > 0 ? tokens : undefined,
+    steps,
+    metrics: aggregateMetrics(steps.map((step) => step.metrics)),
+    notes: [sessionNote, taskNotes(rawResults)].filter(Boolean).join("\n").slice(0, 4000),
+  });
+}
+
 function buildTaskReport(args) {
   const notes = args.notes ?? taskNotes(args.rawResults);
   return {
     id: args.task.id,
     ...(args.task.source ? { source: args.task.source } : {}),
     ...(args.task.title ? { title: args.task.title } : {}),
+    ...(args.task.kind === "session" ? { kind: "session" } : {}),
     status: args.status,
     durationMs: Math.round(args.durationMs),
     ...(args.tokens ? { tokens: args.tokens } : {}),
     ...(args.commands.length > 0 ? { commands: args.commands } : {}),
     verifiers: args.verifiers,
+    ...(args.steps ? { steps: args.steps } : {}),
+    ...(args.metrics ? { metrics: args.metrics } : {}),
     ...(args.riskFlags.size > 0 ? { riskFlags: [...args.riskFlags].sort() } : {}),
     ...(notes ? { notes } : {}),
   };
@@ -644,6 +956,12 @@ function computeConfigFingerprint(manifest, effective) {
     },
     tasks: manifest.tasks.map((task) => ({
       id: task.id,
+      kind: task.kind,
+      steps: task.steps.map((step) => ({
+        id: step.id,
+        prompt: step.prompt,
+        verifiers: step.verifiers,
+      })),
       prompt: task.prompt,
       setupCommands: task.setupCommands,
       agentCommand: task.agentCommand ?? null,

--- a/runtime/scripts/run-agent-eval.mjs
+++ b/runtime/scripts/run-agent-eval.mjs
@@ -11,6 +11,7 @@ import {
   observeRolloutRecord,
   readRolloutDelta,
 } from "./eval/session-metrics.mjs";
+import { trustWorkspace } from "./eval/workspace-trust.mjs";
 import { createHash, randomUUID } from "node:crypto";
 import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -31,7 +32,9 @@ const schemaPath = path.join(
   "agent-eval-report.schema.json",
 );
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
-const OUTPUT_CAPTURE_LIMIT = 64 * 1024;
+// The agent command in --output-format json prints one result object that
+// carries every event of the run; 64 KiB truncated it and lost the token usage.
+const OUTPUT_CAPTURE_LIMIT = 8 * 1024 * 1024;
 
 function usage() {
   return [
@@ -47,6 +50,7 @@ function usage() {
     "  --config <path>         Model/config matrix JSON ({\"matrix\": [...]})",
     "  --executor <mode>       'real' (default) or 'mock' (scripted solution.sh)",
     "  --agent-command <cmd>   Default shell command for each task",
+    "  --setup-command <cmd>   Shell command run in each task workspace before the agent (repeatable; real executor only; same placeholders as --agent-command)",
     "  --benchmark <name>      Override manifest benchmark name",
     "  --run-id <id>           Override generated run id",
     "  --agent-name <name>     Agent name for report metadata (default: agenc)",
@@ -79,6 +83,7 @@ function parseArgs(argv) {
     executor: "real",
     keepWorkspaces: false,
     agentCommand: undefined,
+    setupCommands: [],
     benchmark: undefined,
     runId: undefined,
     agentName: "agenc",
@@ -129,6 +134,9 @@ function parseArgs(argv) {
         break;
       case "--agent-command":
         parsed.agentCommand = readValue();
+        break;
+      case "--setup-command":
+        parsed.setupCommands.push(readValue());
         break;
       case "--benchmark":
         parsed.benchmark = readValue();
@@ -377,6 +385,7 @@ function runCommand(command, options) {
       shell: true,
       env: process.env,
       stdio: ["ignore", "pipe", "pipe"],
+      ...(options.env ? { env: options.env } : {}),
     });
     let stdout = "";
     let stderr = "";
@@ -560,7 +569,15 @@ async function runTaskInWorkspace(task, manifest, args, workspace) {
   const riskFlags = new Set(task.riskFlags);
   const rawResults = [];
 
-  for (const setupCommand of task.setupCommands) {
+  if (args.executor !== "mock") {
+    // Print mode has no TTY, so the trust prompt cannot run; trust the
+    // workspace inside the isolated home before anything executes there.
+    trustWorkspace({ agencHome: requireIsolatedHome(process.env), workspace: cwd });
+  }
+  const setupCommands = args.executor === "mock"
+    ? task.setupCommands
+    : [...(args.setupCommands ?? []), ...task.setupCommands];
+  for (const setupCommand of setupCommands) {
     const rendered = renderCommand(setupCommand, task, cwd, taskDir);
     const result = await runCommand(rendered, { cwd, timeoutMs });
     commands.push(commandReport(result));
@@ -610,6 +627,11 @@ async function runTaskInWorkspace(task, manifest, args, workspace) {
   agentResult = await runCommand(renderCommand(agentCommand, task, cwd, taskDir), {
     cwd,
     timeoutMs,
+    // The AgenC CLI lets AGENC_WORKSPACE take precedence over the invocation
+    // directory. The first real run inherited an operator's workspace from the
+    // shell and judged every task against that directory instead of its
+    // fixture. Pin the workspace to the task's own directory.
+    env: { ...process.env, AGENC_WORKSPACE: cwd },
   });
   commands.push(commandReport(agentResult));
   rawResults.push(agentResult);
@@ -675,9 +697,9 @@ function verifierStatus(verifiers) {
 }
 
 function sessionStatus(steps, verifiers) {
-  const all = [...steps.map((step) => step.status), verifierStatus(verifiers)];
-  if (all.includes("error")) return "error";
-  if (all.includes("failed")) return "failed";
+  const all = new Set([...steps.map((step) => step.status), verifierStatus(verifiers)]);
+  if (all.has("error")) return "error";
+  if (all.has("failed")) return "failed";
   return "passed";
 }
 
@@ -786,19 +808,144 @@ function requireIsolatedHome(env) {
  * tool-call, re-read, compaction and permission counters; the session rollout
  * feeds token counts, tool errors and compaction attempts after each step.
  */
+const DENY_APPROVALS = () => ({ behavior: "deny", reason: "eval runner denies interactive approvals" });
+
+function usageTokens(usage) {
+  if (!usage || typeof usage !== "object") return undefined;
+  const out = {};
+  if (Number.isFinite(usage.inputTokens)) out.input = usage.inputTokens;
+  if (Number.isFinite(usage.outputTokens)) out.output = usage.outputTokens;
+  if (Number.isFinite(usage.totalTokens)) out.total = usage.totalTokens;
+  return out;
+}
+
+function addTokens(tokens, stepTokens) {
+  if (!stepTokens) return;
+  tokens.input += stepTokens.input ?? 0;
+  tokens.output += stepTokens.output ?? 0;
+  tokens.total += stepTokens.total ?? (stepTokens.input ?? 0) + (stepTokens.output ?? 0);
+}
+
+function stopReasonOf(stepResult) {
+  return stepResult?.stopReason ? String(stepResult.stopReason) : undefined;
+}
+
+function stepOutcome({ step, stepResult, stepError, metrics, riskFlags }) {
+  if (stepError) {
+    riskFlags.add("agent_command_failed");
+    return {
+      exitCode: 1,
+      stopReason: stopReasonOf(stepResult),
+      notes: `step ${step.id}: ${stepError.message}`.slice(0, 1000),
+    };
+  }
+  // A turn the provider dropped after dispatch "completes" with an empty
+  // message and exit 0. That is not a pass: the prompt did no work.
+  const providerDropped = metrics.providerFailures > 0
+    && metrics.toolCalls === 0
+    && (stepResult?.finalMessage ?? "").trim().length === 0;
+  if (providerDropped) {
+    riskFlags.add("provider_call_failed");
+    riskFlags.add("agent_command_failed");
+    return {
+      exitCode: 1,
+      stopReason: "provider_failed",
+      notes: `step ${step.id}: the provider call failed after dispatch and the turn completed empty`,
+    };
+  }
+  const exitCode = stepResult?.exitCode ?? 1;
+  if (exitCode !== 0) riskFlags.add("agent_command_failed");
+  return { exitCode, stopReason: stopReasonOf(stepResult), notes: undefined };
+}
+
+async function promptStep({ session, task, step, metrics, timeoutMs, riskFlags }) {
+  const controller = new AbortController();
+  const stepTimeout = step.timeoutMs ?? timeoutMs;
+  const timer = setTimeout(
+    () => controller.abort(new Error(`step ${step.id} exceeded ${stepTimeout} ms`)),
+    stepTimeout,
+  );
+  try {
+    const run = session.prompt(step.prompt, {
+      includeUsage: true,
+      clientMessageId: `eval-${task.id}-${step.id}`,
+      signal: controller.signal,
+      onPermissionRequest: DENY_APPROVALS,
+    });
+    for await (const event of run) observePromptEvent(metrics, event);
+    return { stepResult: await run.result() };
+  } catch (error) {
+    if (controller.signal.aborted) riskFlags.add("agent_timeout");
+    return { stepError: error };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createRolloutTracker({ client, session, agencHome, cwd, sinceMs, riskFlags }) {
+  let rolloutPath;
+  let offset = 0;
+  return {
+    get path() {
+      return rolloutPath;
+    },
+    async observe(metrics) {
+      rolloutPath ??= (await rolloutPathFromAgentLogs(client, session))
+        ?? findSessionRolloutForWorkspace(agencHome, cwd, sinceMs)
+        ?? findSessionRollout(agencHome, session.sessionId);
+      if (!rolloutPath) {
+        riskFlags.add("rollout_not_found");
+        return;
+      }
+      const delta = readRolloutDelta(rolloutPath, offset);
+      offset = delta.offset;
+      for (const record of delta.records) observeRolloutRecord(metrics, record);
+    },
+  };
+}
+
+async function runSessionStep({ session, rollout, task, step, cwd, taskDir, timeoutMs, rawResults, riskFlags, tokens }) {
+  const stepStarted = performance.now();
+  const metrics = createStepMetrics();
+  const { stepResult, stepError } = await promptStep({ session, task, step, metrics, timeoutMs, riskFlags });
+  await rollout.observe(metrics);
+  const stepTokens = usageTokens(stepResult?.usage);
+  addTokens(tokens, stepTokens);
+  const { exitCode, stopReason, notes } = stepOutcome({ step, stepResult, stepError, metrics, riskFlags });
+  const verifiers = exitCode === 0
+    ? await runStepVerifiers(step, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
+    : [];
+  return {
+    id: step.id,
+    status: exitCode !== 0 ? "error" : verifierStatus(verifiers),
+    durationMs: Math.round(performance.now() - stepStarted),
+    ...(stepTokens ? { tokens: stepTokens } : {}),
+    ...(stopReason ? { stopReason } : {}),
+    exitCode,
+    metrics: finalizeMetrics(metrics),
+    verifiers,
+    ...(notes ? { notes } : {}),
+  };
+}
+
+function describeSession(session, rolloutPath) {
+  if (!session) return "session was not created";
+  const rolloutNote = rolloutPath ? ` rollout ${path.basename(rolloutPath)}` : " (rollout not found)";
+  return `session ${session.sessionId}${rolloutNote}`;
+}
+
 async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted }) {
   const agencHome = requireIsolatedHome(process.env);
   const sdk = await loadSdk();
   const client = await sdk.connect({
     env: process.env,
     clientName: "agenc-eval",
-    onPermissionRequest: () => ({ behavior: "deny", reason: "eval runner denies interactive approvals" }),
+    onPermissionRequest: DENY_APPROVALS,
   });
   const steps = [];
   const tokens = { input: 0, output: 0, total: 0 };
   let session;
-  let rolloutPath;
-  let rolloutOffset = 0;
+  let rollout;
   // Rollouts written before this instant belong to earlier sessions in the home.
   const sessionStartedMs = Date.now() - 5000;
   try {
@@ -808,83 +955,13 @@ async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFla
       dangerouslyBypassApprovalsAndSandbox: true,
       metadata: { evalTaskId: task.id, evalRunner: "run-agent-eval" },
     });
+    rollout = createRolloutTracker({ client, session, agencHome, cwd, sinceMs: sessionStartedMs, riskFlags });
     for (const step of task.steps) {
-      const stepStarted = performance.now();
-      const metrics = createStepMetrics();
-      const controller = new AbortController();
-      const stepTimeout = step.timeoutMs ?? timeoutMs;
-      const timer = setTimeout(() => controller.abort(new Error(`step ${step.id} exceeded ${stepTimeout} ms`)), stepTimeout);
-      let stepResult;
-      let stepError;
-      try {
-        const run = session.prompt(step.prompt, {
-          includeUsage: true,
-          clientMessageId: `eval-${task.id}-${step.id}`,
-          signal: controller.signal,
-          onPermissionRequest: () => ({ behavior: "deny", reason: "eval runner denies interactive approvals" }),
-        });
-        for await (const event of run) observePromptEvent(metrics, event);
-        stepResult = await run.result();
-      } catch (error) {
-        stepError = error;
-        if (controller.signal.aborted) riskFlags.add("agent_timeout");
-      } finally {
-        clearTimeout(timer);
-      }
-      rolloutPath ??= (await rolloutPathFromAgentLogs(client, session))
-        ?? findSessionRolloutForWorkspace(agencHome, cwd, sessionStartedMs)
-        ?? findSessionRollout(agencHome, session.sessionId);
-      if (rolloutPath) {
-        const delta = readRolloutDelta(rolloutPath, rolloutOffset);
-        rolloutOffset = delta.offset;
-        for (const record of delta.records) observeRolloutRecord(metrics, record);
-      } else {
-        riskFlags.add("rollout_not_found");
-      }
-      const usage = stepResult?.usage && typeof stepResult.usage === "object" ? stepResult.usage : undefined;
-      const stepTokens = usage
-        ? {
-            ...(Number.isFinite(usage.inputTokens) ? { input: usage.inputTokens } : {}),
-            ...(Number.isFinite(usage.outputTokens) ? { output: usage.outputTokens } : {}),
-            ...(Number.isFinite(usage.totalTokens) ? { total: usage.totalTokens } : {}),
-          }
-        : undefined;
-      if (stepTokens) {
-        tokens.input += stepTokens.input ?? 0;
-        tokens.output += stepTokens.output ?? 0;
-        tokens.total += stepTokens.total ?? (stepTokens.input ?? 0) + (stepTokens.output ?? 0);
-      }
-      // A turn the provider dropped after dispatch "completes" with an empty
-      // message and exit 0. That is not a pass: the prompt did no work.
-      const providerDropped = !stepError
-        && metrics.providerFailures > 0
-        && metrics.toolCalls === 0
-        && (stepResult?.finalMessage ?? "").trim().length === 0;
-      if (providerDropped) riskFlags.add("provider_call_failed");
-      const exitCode = stepError ? 1 : providerDropped ? 1 : stepResult?.exitCode ?? 1;
-      if (exitCode !== 0) riskFlags.add("agent_command_failed");
-      const verifiers = exitCode === 0
-        ? await runStepVerifiers(step, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
-        : [];
-      const notes = stepError
-        ? `step ${step.id}: ${stepError.message}`.slice(0, 1000)
-        : providerDropped
-          ? `step ${step.id}: the provider call failed after dispatch and the turn completed empty`
-          : undefined;
-      steps.push({
-        id: step.id,
-        status: exitCode !== 0 ? "error" : verifierStatus(verifiers),
-        durationMs: Math.round(performance.now() - stepStarted),
-        ...(stepTokens ? { tokens: stepTokens } : {}),
-        ...(providerDropped
-          ? { stopReason: "provider_failed" }
-          : stepResult?.stopReason ? { stopReason: String(stepResult.stopReason) } : {}),
-        exitCode,
-        metrics: finalizeMetrics(metrics),
-        verifiers,
-        ...(notes ? { notes } : {}),
+      const record = await runSessionStep({
+        session, rollout, task, step, cwd, taskDir, timeoutMs, rawResults, riskFlags, tokens,
       });
-      if (exitCode !== 0) break;
+      steps.push(record);
+      if (record.exitCode !== 0) break;
     }
   } finally {
     if (session) {
@@ -892,9 +969,6 @@ async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFla
     }
     await client.close().catch(() => {});
   }
-  const sessionNote = session
-    ? `session ${session.sessionId}${rolloutPath ? ` rollout ${path.basename(rolloutPath)}` : " (rollout not found)"}`
-    : "session was not created";
   const completed = steps.length === task.steps.length && steps.every((step) => step.status !== "error");
   const verifiers = completed
     ? await runStepVerifiers({ verifiers: task.verifiers }, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
@@ -910,7 +984,7 @@ async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFla
     tokens: tokens.total > 0 || tokens.input > 0 ? tokens : undefined,
     steps,
     metrics: aggregateMetrics(steps.map((step) => step.metrics)),
-    notes: [sessionNote, taskNotes(rawResults)].filter(Boolean).join("\n").slice(0, 4000),
+    notes: [describeSession(session, rollout?.path), taskNotes(rawResults)].filter(Boolean).join("\n").slice(0, 4000),
   });
 }
 

--- a/runtime/src/eval/agent-eval-report.schema.json
+++ b/runtime/src/eval/agent-eval-report.schema.json
@@ -4,7 +4,11 @@
   "title": "AgenC Agent Evaluation Report",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "run", "tasks"],
+  "required": [
+    "schemaVersion",
+    "run",
+    "tasks"
+  ],
   "properties": {
     "schemaVersion": {
       "type": "integer",
@@ -13,7 +17,13 @@
     "run": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "benchmark", "startedAt", "finishedAt", "agent"],
+      "required": [
+        "id",
+        "benchmark",
+        "startedAt",
+        "finishedAt",
+        "agent"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -34,7 +44,9 @@
         "agent": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["name"],
+          "required": [
+            "name"
+          ],
           "properties": {
             "name": {
               "type": "string",
@@ -104,7 +116,12 @@
   "definitions": {
     "status": {
       "type": "string",
-      "enum": ["passed", "failed", "error", "skipped"]
+      "enum": [
+        "passed",
+        "failed",
+        "error",
+        "skipped"
+      ]
     },
     "tokenUsage": {
       "type": "object",
@@ -127,7 +144,9 @@
     "command": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["command"],
+      "required": [
+        "command"
+      ],
       "properties": {
         "command": {
           "type": "string",
@@ -145,7 +164,10 @@
     "verifier": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "status"],
+      "required": [
+        "name",
+        "status"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -184,7 +206,12 @@
     "task": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "status", "durationMs", "verifiers"],
+      "required": [
+        "id",
+        "status",
+        "durationMs",
+        "verifiers"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -230,6 +257,151 @@
             "minLength": 1
           },
           "uniqueItems": true
+        },
+        "notes": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "command",
+            "session"
+          ],
+          "description": "command: one agent command per task (default). session: one daemon session driven through several prompts."
+        },
+        "metrics": {
+          "$ref": "#/definitions/sessionMetrics"
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          }
+        }
+      }
+    },
+    "sessionMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Harness metrics of one prompt turn or one whole session, from the live prompt events and the session rollout.",
+      "properties": {
+        "toolCalls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "toolCallsByName": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "toolErrors": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fileReads": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fileReReads": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compactions": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compactionAttempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compactionFailures": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compactionRollbacks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "permissionRequests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warnings": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "assistantMessages": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "assistantChars": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reasoningOutputTokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "promptTokensFirst": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "promptTokensLast": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cachedTokensLast": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cachedTokensMax": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "steps": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "durationMs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/status"
+        },
+        "durationMs": {
+          "type": "number",
+          "minimum": 0
+        },
+        "tokens": {
+          "$ref": "#/definitions/tokenUsage"
+        },
+        "stopReason": {
+          "type": "string"
+        },
+        "exitCode": {
+          "type": "integer"
+        },
+        "metrics": {
+          "$ref": "#/definitions/sessionMetrics"
+        },
+        "verifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/verifier"
+          }
         },
         "notes": {
           "type": "string"

--- a/runtime/src/eval/agent-eval-report.schema.json
+++ b/runtime/src/eval/agent-eval-report.schema.json
@@ -363,6 +363,10 @@
         "steps": {
           "type": "integer",
           "minimum": 0
+        },
+        "providerFailures": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/runtime/tests/eval/agent-eval-report.test.ts
+++ b/runtime/tests/eval/agent-eval-report.test.ts
@@ -119,6 +119,40 @@ function validReport() {
   };
 }
 
+function sessionTask() {
+  return {
+    id: "session-15",
+    kind: "session",
+    status: "passed",
+    durationMs: 900000,
+    tokens: { input: 400000, output: 60000, total: 460000 },
+    verifiers: [{ name: "final", status: "passed", command: "node verify-final.mjs" }],
+    steps: [
+      {
+        id: "01-scaffold",
+        status: "passed",
+        durationMs: 60000,
+        tokens: { input: 20000, output: 3000 },
+        stopReason: "stop",
+        exitCode: 0,
+        metrics: {
+          toolCalls: 12,
+          toolCallsByName: { FileRead: 4, FileWrite: 2, Bash: 6 },
+          toolErrors: 0,
+          fileReads: 4,
+          fileReReads: 1,
+          compactions: 0,
+          promptTokensFirst: 15000,
+          promptTokensLast: 19000,
+          cachedTokensLast: 14000,
+        },
+        verifiers: [{ name: "scaffold", status: "passed" }],
+      },
+    ],
+    metrics: { steps: 1, toolCalls: 12, toolErrors: 0, fileReads: 4, fileReReads: 1, compactions: 0 },
+  };
+}
+
 describe("agent eval report schema", () => {
   test("validates the documented report shape", () => {
     const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
@@ -126,6 +160,27 @@ describe("agent eval report schema", () => {
     const validate = ajv.compile(schema);
 
     expect(validate(validReport()), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  test("validates a session task with steps and harness metrics", () => {
+    const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+    const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+    const report = validReport();
+    report.tasks.push(sessionTask() as never);
+    expect(validate(report), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  test("rejects unknown metric fields and unknown task kinds", () => {
+    const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
+    const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+    const unknownMetric = validReport();
+    const task = sessionTask();
+    (task.metrics as Record<string, unknown>).vibes = 1;
+    unknownMetric.tasks.push(task as never);
+    expect(validate(unknownMetric)).toBe(false);
+    const unknownKind = validReport();
+    unknownKind.tasks.push({ ...sessionTask(), kind: "swarm" } as never);
+    expect(validate(unknownKind)).toBe(false);
   });
 });
 

--- a/runtime/tests/eval/agent-eval-suite.test.ts
+++ b/runtime/tests/eval/agent-eval-suite.test.ts
@@ -14,7 +14,9 @@ import { runtimeRootPath } from "../helpers/source-path.ts";
 
 const runnerScriptPath = resolve(runtimeRootPath, "scripts", "run-agent-eval.mjs");
 const suitePath = resolve(runtimeRootPath, "eval", "tasks");
-const SUITE_TASK_COUNT = 12;
+const SUITE_TASK_COUNT = 13;
+const SESSION_TASK_ID = "asteroid-drift-15";
+const SESSION_STEP_COUNT = 15;
 const controlledTmpDir = mkdtempSync(join(tmpdir(), "agenc-eval-test-tmp-"));
 
 // Prove copied fixtures do not inherit an unrelated module type from the host.
@@ -25,11 +27,22 @@ writeFileSync(
 
 afterAll(() => rmSync(controlledTmpDir, { force: true, recursive: true }));
 
+interface StepResult {
+  id: string;
+  status: string;
+  durationMs: number;
+  metrics?: Record<string, unknown>;
+  verifiers: { name: string; status: string }[];
+}
+
 interface TaskResult {
   id: string;
+  kind?: string;
   status: string;
   tokens?: { input?: number; output?: number; total?: number };
   verifiers: { name: string; status: string }[];
+  steps?: StepResult[];
+  metrics?: { steps?: number; toolCalls?: number };
   riskFlags?: string[];
 }
 
@@ -133,9 +146,73 @@ describe("agent eval suite (mock executor)", () => {
       expect(report.run.environment?.commit).toBeTruthy();
       expect(report.run.environment?.executor).toBe("mock");
       expect(report.run.environment?.configFingerprint).toMatch(/^[0-9a-f]{16}$/u);
+
+      const session = report.tasks.find((task) => task.id === SESSION_TASK_ID);
+      expect(session, "the session task is part of the suite").toBeDefined();
+      expect(session?.kind).toBe("session");
+      expect(session?.steps).toHaveLength(SESSION_STEP_COUNT);
+      for (const step of session?.steps ?? []) {
+        expect(step.status, `step ${step.id} should pass`).toBe("passed");
+        expect(step.verifiers.length, `step ${step.id} has verifiers`).toBeGreaterThan(0);
+        expect(step.metrics, `step ${step.id} carries metrics`).toBeDefined();
+      }
+      expect(session?.metrics?.steps).toBe(SESSION_STEP_COUNT);
+      // Every step's verifiers plus the task verifier ran against the same tree.
+      expect(session?.verifiers.map((verifier) => verifier.status)).toEqual(["passed"]);
+    },
+    180_000,
+  );
+
+  test(
+    "a session solution that skips the final step fails at the final verifier only",
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), "agenc-eval-session-sabotage-"));
+      cpSync(join(suitePath, SESSION_TASK_ID), join(dir, SESSION_TASK_ID), {
+        recursive: true,
+      });
+      // Prompt 15 asks for CHANGELOG.md; a solution without it must go red
+      // there and nowhere else.
+      rmSync(join(dir, SESSION_TASK_ID, "solution", "CHANGELOG.md"));
+      const manifest = JSON.parse(
+        readFileSync(join(suitePath, "manifest.json"), "utf8"),
+      ) as { tasks: { id: string }[] };
+      writeFileSync(
+        join(dir, "manifest.json"),
+        JSON.stringify(
+          {
+            benchmark: "session-sabotage",
+            tasks: manifest.tasks.filter((task) => task.id === SESSION_TASK_ID),
+          },
+          null,
+          2,
+        ),
+      );
+      const result = runRunner(["--suite", dir, "--executor", "mock"]);
+      expect(result.status, result.stderr).toBe(0);
+      const report = JSON.parse(result.stdout) as EvalReport;
+      const [task] = report.tasks;
+      expect(task.status).toBe("failed");
+      const failedSteps = (task.steps ?? []).filter((step) => step.status !== "passed");
+      expect(failedSteps.map((step) => step.id)).toEqual(["15-final"]);
+      expect(task.verifiers[0]?.status).toBe("failed");
+      expect(task.riskFlags).toContain("verifier_failed");
     },
     120_000,
   );
+
+  test("a session task without steps is a manifest error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-eval-session-invalid-"));
+    writeFileSync(
+      join(dir, "manifest.json"),
+      JSON.stringify({
+        benchmark: "invalid",
+        tasks: [{ id: "no-steps", kind: "session", dir: "x" }],
+      }),
+    );
+    const result = runRunner(["--suite", dir, "--executor", "mock"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("needs a non-empty steps array");
+  });
 
   test(
     "a no-op solution makes the task checker fail (checkers are revert-sensitive)",

--- a/runtime/tests/eval/check-eval-regression.test.ts
+++ b/runtime/tests/eval/check-eval-regression.test.ts
@@ -16,6 +16,7 @@ interface TaskRow {
   status: "passed" | "failed" | "error" | "skipped";
   durationMs: number;
   tokens?: { input: number; output: number };
+  metrics?: Record<string, number>;
 }
 
 function buildReport(options: {
@@ -44,6 +45,7 @@ function buildReport(options: {
       status: task.status,
       durationMs: task.durationMs,
       ...(task.tokens ? { tokens: task.tokens } : {}),
+      ...(task.metrics ? { kind: "session", metrics: task.metrics } : {}),
       verifiers: [],
     })),
   };
@@ -151,6 +153,61 @@ describe("check-eval-regression", () => {
       "150",
     ]);
     expect(relaxed.status).toBe(0);
+  });
+
+  function sessionTasks(metrics: Record<string, number>): TaskRow[] {
+    return [
+      ...passingTasks(3),
+      // Same duration and token cost as the plain tasks, so only the harness
+      // ratios differ between baseline and candidate.
+      { id: "session-1", status: "passed", durationMs: 1000, tokens: { input: 400, output: 100 }, metrics },
+    ];
+  }
+
+  test("session ratio movements warn by default and fail only with an explicit limit", () => {
+    const dir = tempDir();
+    const baseline = writeReport(
+      dir,
+      "baseline.json",
+      buildReport({ tasks: sessionTasks({ steps: 10, toolCalls: 100, toolErrors: 2, fileReads: 40, fileReReads: 4, compactions: 1, promptTokensLast: 1000, cachedTokensLast: 800 }) }),
+    );
+    const candidate = writeReport(
+      dir,
+      "candidate.json",
+      buildReport({ tasks: sessionTasks({ steps: 10, toolCalls: 100, toolErrors: 12, fileReads: 40, fileReReads: 12, compactions: 4, promptTokensLast: 1000, cachedTokensLast: 200 }) }),
+    );
+    const lenient = runCheck([candidate, "--baseline", baseline]);
+    expect(lenient.status).toBe(0);
+    expect(lenient.stdout).toContain("session tool-error rate rose 10.00pp");
+    expect(lenient.stdout).toContain("session re-read ratio rose 20.00pp");
+    expect(lenient.stdout).toContain("compactions per step rose 0.30");
+    expect(lenient.stdout).toContain("session cache-hit ratio fell 60.00pp");
+    const strict = runCheck([
+      candidate,
+      "--baseline",
+      baseline,
+      "--max-tool-error-rate-increase-pp",
+      "5",
+      "--max-compactions-per-step-increase",
+      "0.1",
+    ]);
+    expect(strict.status).toBe(1);
+    expect(strict.stdout).toContain("session tool-error rate rose 10.00pp");
+    expect(strict.stdout).toContain("tolerated: 5pp");
+    expect(strict.stdout).toContain("tolerated: 0.1");
+  });
+
+  test("a baseline without session tasks does not enforce harness metrics", () => {
+    const dir = tempDir();
+    const baseline = writeReport(dir, "baseline.json", buildReport({ tasks: passingTasks(4) }));
+    const candidate = writeReport(
+      dir,
+      "candidate.json",
+      buildReport({ tasks: sessionTasks({ steps: 10, toolCalls: 100, toolErrors: 50 }) }),
+    );
+    const result = runCheck([candidate, "--baseline", baseline, "--max-tool-error-rate-increase-pp", "1"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("baseline has no session tasks");
   });
 
   test("config fingerprint mismatch warns by default, fails with --require-same-config", () => {

--- a/runtime/tests/eval/session-metrics.test.ts
+++ b/runtime/tests/eval/session-metrics.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  aggregateMetrics,
+  createStepMetrics,
+  deriveRatios,
+  finalizeMetrics,
+  findSessionRollout,
+  findSessionRolloutForWorkspace,
+  observePromptEvent,
+  observeRolloutRecord,
+  readRolloutDelta,
+} from "../../scripts/eval/session-metrics.mjs";
+
+describe("session metrics", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("counts tool calls by name and flags a re-read only when nothing was written in between", () => {
+    const metrics = createStepMetrics();
+    const read = (filePath: string) =>
+      observePromptEvent(metrics, { type: "tool_call", requestId: "r", toolName: "FileRead", input: { filePath } });
+    read("a.js");
+    read("b.js");
+    read("a.js"); // re-read
+    observePromptEvent(metrics, { type: "tool_call", requestId: "r", toolName: "FileEdit", input: { filePath: "a.js" } });
+    read("a.js"); // fresh after the edit
+    read("b.js"); // re-read
+    const view = finalizeMetrics(metrics);
+    expect(view.toolCalls).toBe(6);
+    expect(view.fileReads).toBe(5);
+    expect(view.fileReReads).toBe(2);
+    expect(view.toolCallsByName).toEqual({ FileEdit: 1, FileRead: 5 });
+  });
+
+  test("counts compactions, rollbacks, permission requests and assistant output from live events", () => {
+    const metrics = createStepMetrics();
+    observePromptEvent(metrics, { type: "history_reset", reason: "partial_compact" });
+    observePromptEvent(metrics, { type: "history_reset", reason: "compaction_rollback" });
+    observePromptEvent(metrics, { type: "history_reset", reason: "cleared" });
+    observePromptEvent(metrics, { type: "permission_request", requestId: "p", permissions: [] });
+    observePromptEvent(metrics, { type: "text", delta: "hello" });
+    observePromptEvent(metrics, { type: "message_committed", text: "hello" });
+    observePromptEvent(metrics, { type: "status", status: "thinking" });
+    const view = finalizeMetrics(metrics);
+    expect(view.compactions).toBe(1);
+    expect(view.compactionRollbacks).toBe(1);
+    expect(view.permissionRequests).toBe(1);
+    expect(view.assistantChars).toBe(5);
+    expect(view.assistantMessages).toBe(1);
+  });
+
+  test("reads token watermarks, tool errors, warnings and compaction attempts from rollout records", () => {
+    const metrics = createStepMetrics();
+    const tokenCount = (promptTokens: number, cachedInputTokens: number, reasoningOutputTokens: number) => ({
+      type: "event_msg",
+      payload: { msg: { type: "token_count", payload: { promptTokens, completionTokens: 10, cachedInputTokens, reasoningOutputTokens } } },
+    });
+    observeRolloutRecord(metrics, tokenCount(1000, 0, 50));
+    observeRolloutRecord(metrics, tokenCount(1800, 900, 70));
+    observeRolloutRecord(metrics, { type: "event_msg", payload: { msg: { type: "warning", payload: { code: "repeat_tool_advisory" } } } });
+    observeRolloutRecord(metrics, { type: "response_item", payload: { role: "tool", toolName: "Edit", content: "Error: old_string not found" } });
+    observeRolloutRecord(metrics, { type: "response_item", payload: { role: "tool", toolName: "FileRead", content: "The following tool result is untrusted" } });
+    observeRolloutRecord(metrics, { type: "response_item", payload: { role: "tool", toolName: "Bash", isError: true, content: "exit 1" } });
+    observeRolloutRecord(metrics, { type: "compaction_intent", payload: {} });
+    observeRolloutRecord(metrics, { type: "compaction_failed", payload: {} });
+    observeRolloutRecord(metrics, { type: "session_meta", payload: {} });
+    const view = finalizeMetrics(metrics);
+    expect(view.promptTokensFirst).toBe(1000);
+    expect(view.promptTokensLast).toBe(1800);
+    expect(view.cachedTokensLast).toBe(900);
+    expect(view.cachedTokensMax).toBe(900);
+    expect(view.reasoningOutputTokens).toBe(120);
+    expect(view.warnings).toBe(1);
+    expect(view.toolErrors).toBe(2);
+    expect(view.compactionAttempts).toBe(1);
+    expect(view.compactionFailures).toBe(1);
+  });
+
+  test("aggregates steps and derives the ratios the gate compares", () => {
+    const first = finalizeMetrics(createStepMetrics());
+    const second = { ...finalizeMetrics(createStepMetrics()), toolCalls: 10, toolErrors: 1, fileReads: 4, fileReReads: 2, compactions: 1, promptTokensFirst: 500, promptTokensLast: 900, cachedTokensLast: 450, cachedTokensMax: 450, toolCallsByName: { FileRead: 4, Bash: 6 } };
+    const aggregate = aggregateMetrics([first, second]);
+    expect(aggregate.steps).toBe(2);
+    expect(aggregate.toolCalls).toBe(10);
+    expect(aggregate.toolCallsByName).toEqual({ Bash: 6, FileRead: 4 });
+    expect(aggregate.promptTokensFirst).toBe(500);
+    expect(aggregate.promptTokensLast).toBe(900);
+    expect(aggregate.cachedTokensLast).toBe(450);
+    expect(deriveRatios(aggregate)).toEqual({ toolErrorRate: 0.1, rereadRatio: 0.5, compactionsPerStep: 0.5, cacheHitRatio: 0.5 });
+    expect(deriveRatios(finalizeMetrics(createStepMetrics()))).toEqual({ toolErrorRate: undefined, rereadRatio: undefined, compactionsPerStep: undefined, cacheHitRatio: undefined });
+  });
+
+  test("finds the rollout of a workspace by the cwd in its first record, newest first", () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-eval-home-"));
+    dirs.push(home);
+    const workspace = mkdtempSync(join(tmpdir(), "agenc-eval-ws-"));
+    dirs.push(workspace);
+    const write = (bucket: string, id: string, cwd: string, stamp: string) => {
+      const dir = join(home, "projects", "slug", bucket, id);
+      mkdirSync(dir, { recursive: true });
+      const file = join(dir, `rollout-${stamp}-${id}.jsonl`);
+      writeFileSync(file, `${JSON.stringify({ type: "session_meta", payload: { sessionId: id, cwd } })}\n`);
+      return file;
+    };
+    write("archived_sessions", "conv-old", workspace, "2026-09-01T00-00-00-000Z");
+    const other = write("sessions", "conv-other", join(workspace, "elsewhere"), "2026-09-04T00-00-00-000Z");
+    const current = write("sessions", "conv-new", workspace, "2026-09-04T00-00-01-000Z");
+    expect(findSessionRolloutForWorkspace(home, workspace, 0)).toBe(current);
+    expect(findSessionRolloutForWorkspace(home, join(workspace, "elsewhere"), 0)).toBe(other);
+    expect(findSessionRolloutForWorkspace(home, join(workspace, "nowhere"), 0)).toBeUndefined();
+    // A time floor in the future excludes everything.
+    expect(findSessionRolloutForWorkspace(home, workspace, Date.now() + 60_000)).toBeUndefined();
+  });
+
+  test("finds a session rollout under a home and reads only complete new lines", () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-eval-home-"));
+    dirs.push(home);
+    const sessionDir = join(home, "projects", "slug-1", "sessions", "conv-1");
+    mkdirSync(sessionDir, { recursive: true });
+    const rollout = join(sessionDir, "rollout-2026-09-04T00-00-00-000Z-conv-1.jsonl");
+    writeFileSync(rollout, `${JSON.stringify({ type: "session_meta", payload: {} })}\n`);
+    expect(findSessionRollout(home, "conv-1")).toBe(rollout);
+    expect(findSessionRollout(home, "conv-missing")).toBeUndefined();
+    const first = readRolloutDelta(rollout, 0);
+    expect(first.records).toHaveLength(1);
+    appendFileSync(rollout, `${JSON.stringify({ type: "compaction_intent", payload: {} })}\n{"type":"torn"`);
+    const second = readRolloutDelta(rollout, first.offset);
+    expect(second.records.map((record: { type: string }) => record.type)).toEqual(["compaction_intent"]);
+    appendFileSync(rollout, `,"payload":{}}\n`);
+    const third = readRolloutDelta(rollout, second.offset);
+    expect(third.records.map((record: { type: string }) => record.type)).toEqual(["torn"]);
+    expect(readRolloutDelta(rollout, third.offset).records).toEqual([]);
+  });
+});

--- a/runtime/tests/eval/session-metrics.test.ts
+++ b/runtime/tests/eval/session-metrics.test.ts
@@ -67,6 +67,8 @@ describe("session metrics", () => {
     observeRolloutRecord(metrics, { type: "response_item", payload: { role: "tool", toolName: "Edit", content: "Error: old_string not found" } });
     observeRolloutRecord(metrics, { type: "response_item", payload: { role: "tool", toolName: "FileRead", content: "The following tool result is untrusted" } });
     observeRolloutRecord(metrics, { type: "response_item", payload: { role: "tool", toolName: "Bash", isError: true, content: "exit 1" } });
+    observeRolloutRecord(metrics, { type: "event_msg", payload: { msg: { type: "execution_admission", payload: { kind: "model_turn", event: "held_unknown", reason: "provider_call_failed_after_dispatch" } } } });
+    observeRolloutRecord(metrics, { type: "event_msg", payload: { msg: { type: "execution_admission", payload: { kind: "model_turn", event: "allowed" } } } });
     observeRolloutRecord(metrics, { type: "compaction_intent", payload: {} });
     observeRolloutRecord(metrics, { type: "compaction_failed", payload: {} });
     observeRolloutRecord(metrics, { type: "session_meta", payload: {} });
@@ -80,6 +82,7 @@ describe("session metrics", () => {
     expect(view.toolErrors).toBe(2);
     expect(view.compactionAttempts).toBe(1);
     expect(view.compactionFailures).toBe(1);
+    expect(view.providerFailures).toBe(1);
   });
 
   test("aggregates steps and derives the ratios the gate compares", () => {

--- a/runtime/tests/eval/workspace-trust.test.ts
+++ b/runtime/tests/eval/workspace-trust.test.ts
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { trustWorkspace } from "../../scripts/eval/workspace-trust.mjs";
+
+const NOW = () => new Date("2026-09-04T10:00:00Z");
+
+function freshRoot(): { home: string; workspace: string } {
+  const root = mkdtempSync(join(tmpdir(), "eval-trust-"));
+  const workspace = join(root, "ws");
+  mkdirSync(workspace);
+  return { home: join(root, "home"), workspace };
+}
+
+describe("trustWorkspace", () => {
+  it("writes a version-1 record with the canonical workspace into a fresh home", () => {
+    const { home, workspace } = freshRoot();
+    const result = trustWorkspace({ agencHome: home, workspace, now: NOW });
+    const record = JSON.parse(readFileSync(join(home, "trusted-projects.json"), "utf8"));
+    expect(record).toEqual({
+      version: 1,
+      trustedProjects: [{ path: realpathSync(workspace), trustedAt: "2026-09-04T10:00:00.000Z" }],
+    });
+    expect(result.path).toBe(realpathSync(workspace));
+    if (process.platform !== "win32") expect(statSync(result.file).mode & 0o077).toBe(0);
+  });
+
+  it("keeps other entries and extra fields, and replaces its own entry", () => {
+    const { home, workspace } = freshRoot();
+    mkdirSync(home, { recursive: true });
+    const file = join(home, "trusted-projects.json");
+    writeFileSync(file, JSON.stringify({
+      version: 1,
+      trustedProjects: [
+        { path: "/somewhere/else", trustedAt: "2026-01-01T00:00:00.000Z" },
+        { path: realpathSync(workspace), trustedAt: "2026-01-02T00:00:00.000Z" },
+      ],
+      projectMcpServerChoices: [{ path: "/somewhere/else", rejectedServers: ["x"] }],
+    }));
+    trustWorkspace({ agencHome: home, workspace, now: NOW });
+    const record = JSON.parse(readFileSync(file, "utf8"));
+    expect(record.trustedProjects).toEqual([
+      { path: "/somewhere/else", trustedAt: "2026-01-01T00:00:00.000Z" },
+      { path: realpathSync(workspace), trustedAt: "2026-09-04T10:00:00.000Z" },
+    ]);
+    expect(record.projectMcpServerChoices).toEqual([{ path: "/somewhere/else", rejectedServers: ["x"] }]);
+  });
+
+  it("replaces an unreadable record instead of failing", () => {
+    const { home, workspace } = freshRoot();
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "trusted-projects.json"), "not json");
+    trustWorkspace({ agencHome: home, workspace, now: NOW });
+    const record = JSON.parse(readFileSync(join(home, "trusted-projects.json"), "utf8"));
+    expect(record.version).toBe(1);
+    expect(record.trustedProjects).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Why

The diagnostic eval lane (`runtime/eval`, `scripts/run-agent-eval.mjs`) ran one agent command per tiny task and reported pass rate, tokens and duration. Its committed baseline is from the mock executor on 07-08; no real agent has ever been measured by it. Nothing measured the loop a desktop or TUI user actually lives in: context growth across a whole project, compaction pressure and failures, tool errors, re-reads the model did not need, prompt-cache behaviour, or seconds per turn. The 09-02 harness review extracted all of that by hand from rollouts and found the P0s that became #2011 to #2018. This makes those numbers a report the gate can compare.

This stays in the diagnostic, non-confirmatory lane by the repository's own taxonomy (`docs/INDEX.md` marks it legacy, distinct from the TFR suites under `eval/suites/`). `check:eval-contract --legacy` still classifies the new reports as `legacy_non_confirmatory`.

## What changed

- `runtime/scripts/run-agent-eval.mjs`: `task.kind = "session"` with `steps[]` (`id`, `prompt`, `verifiers`, `timeoutMs`). Real executor: one daemon session in `AGENC_HOME` over the SDK (`connect`, `createSession` with `dangerouslyBypassApprovalsAndSandbox`, `prompt` per step, `terminate`), per-step timeout with cancellation, verifiers per step and for the task; refuses to run without an absolute `AGENC_HOME`. Mock executor: installs the scripted solution once and runs every verifier. Rollout lookup: `agent.logs` `rolloutPath`, then the workspace recorded in the rollout's first record, then the session id (the SDK reports `session_…` while rollout directories are `conv-…`). Fingerprint covers kind and steps. Session id and rollout name land in `notes`. Real runs now pin `AGENC_WORKSPACE` to the task workspace (the CLI lets it override the invocation cwd), trust that workspace inside the isolated home before anything runs there (print mode has no TTY for the trust prompt), keep up to 8 MiB of agent stdout (the 64 KiB cap truncated the JSON result, so tokens were never read), and flag a turn the provider dropped after dispatch as `provider_failed` instead of a pass. `--setup-command <cmd>` (repeatable) runs in every workspace before the agent, ahead of task-level `setupCommands`.
- `runtime/scripts/eval/workspace-trust.mjs` (new): writes the version-1 `trusted-projects.json` record for one workspace into the isolated home, keeping every other entry, mode 0600. The runner refuses to run a real task without an absolute `AGENC_HOME`, so this never touches a real home.
- `runtime/scripts/eval/session-metrics.mjs` (new, pure, unit-tested): live-event and rollout-record accumulators, aggregation, ratio derivation, rollout discovery and incremental reading.
- `runtime/src/eval/agent-eval-report.schema.json`: additive `kind`, `steps`, `metrics` on the closed task object; new closed `sessionMetrics` and `step` definitions.
- `runtime/scripts/check-agent-eval-report.mjs`: step verifiers count; a session summary (steps, avg step time, tool calls and errors, re-reads, compactions, permission requests, warnings).
- `runtime/scripts/check-eval-regression.mjs`: session ratios (tool-error rate, re-read ratio, compactions per step, cache-hit ratio) compared against the baseline as warnings; `--max-tool-error-rate-increase-pp`, `--max-reread-ratio-increase-pp`, `--max-compactions-per-step-increase` make them hard limits; summary lines.
- `runtime/eval/tasks/asteroid-drift-15/`: the 15 prompts from the review as one session task, verifiers (`scaffold`, `style`, `gameplay`, `modules`, `features`, `tests`, `readme`, `final`) on a shared `checks.mjs`, a reference solution and `solution.sh`. `manifest.json` gains the task.
- `runtime/package.json`: `eval:coding:mock`, `eval:coding`.
- Tests: `tests/eval/session-metrics.test.ts` and `tests/eval/workspace-trust.test.ts` (new); `agent-eval-suite.test.ts` (13 tasks, session assertions, a session sabotage that fails only at step 15, a manifest error); `agent-eval-report.test.ts` (session shape validates, unknown metric and kind rejected); `check-eval-regression.test.ts` (ratio warnings and limits, baseline without sessions).
- Docs: `docs/agent-eval-reports.md`, `runtime/eval/README.md`.

## Evidence

| run | result |
| --- | --- |
| `eval:coding:mock` (13 tasks) | 13 passed; session task 15/15 steps, metrics attached; report validates |
| `check:eval-contract --legacy` on that report | `legacy_non_confirmatory`, as before |
| four eval test files, hermetic runner | 33 passed |
| `tsc -p tsconfig.test-support.json` | exit 0 |
| two-step real session, grok-4.6 xhigh, isolated home | passed, no risk flags; tool calls by name; prompt tokens 18320 -> 18289; cached tokens 17280 on the second turn; reasoning tokens counted; rollout found |
| one real command task after the harness fixes (`fix-off-by-one`) | passed in 33 s, tokens 91544 in / 673 out; before the fixes the same task failed in 1 s with `project is not trusted` and, before that, worked in the wrong directory |
| two-step real session after the Sonar restructure | both steps passed (118 s and 93 s, 10 and 6 tool calls, 0 tool errors, cached tokens 22400 and 24448), rollout found, no risk flags |
| all `tests/eval` files, hermetic runner | 26 files, 235 passed |

## First real run (grok-4.6 xhigh, isolated home, 31 minutes)

Not committed as a baseline: it is a diagnosis, and it found four things on its first pass (the first is a harness environment trap, the other three are runtime findings). A second full run with the fixed harness is in progress; its report becomes the first real baseline file in this PR when it completes.

| finding | evidence in the report and rollouts |
| --- | --- |
| The twelve headless command tasks were judged against the wrong directory: the CLI lets `AGENC_WORKSPACE` take precedence over the invocation cwd, and the operator shell that launched the run exported one, so every `agenc -p` run worked in `~/claude-agenc/work` while the verifiers checked the fixture workspace | probe of `fix-off-by-one` with the event stream: FileRead returned a `sum.js` that already read `i < values.length`, exec_command paths under `/Users/tetsuoarena/claude-agenc/work/`, final message "no change needed" (true for the file it saw); the fixture still had `<=`. Fixed in this PR: the runner pins `AGENC_WORKSPACE` to each task's workspace, trusts it in the isolated home, and keeps the whole JSON result. The twelve `[GrokProvider] Tool allowlist resolved to empty set` lines in the daemon log are the compaction summarizer's deliberate tool-free calls (`transaction.ts` sends `allowedToolNames: []`) and not a suppression of the agent's tools |
| One provider error ends the whole session (fixed by #2142, merged) | step 7 of the session: `execution_admission held_unknown reason=provider_call_failed_after_dispatch`, daemon log `agent conv-… run error: grok error: Connection error.`; the turn "completed" with an empty message, step 8 was refused with "agent is no longer running (status: error)" |
| Prompt cache collapses as the context grows | cached tokens per step: 18432, 19968, 16896, 29568, then **512** and **0** at steps 5 and 6 while prompt tokens went 18k to 50k; the per-request re-ranked skills listing sits in the prefix |
| The skills listing is saturated | `skill_listing_truncated: listed 80 of 1801 invocable skills (19912/20000 chars, ranked by this request)` on every turn |

Steps 1 to 6 of the session did real work with green verifiers (4 to 15 tool calls each, 95 to 188 s per step, no compactions, no tool errors). The second finding was fixed in #2142 (a failed turn is reported as `turn_complete` with the reason and the run stays alive); this PR makes the eval report a provider-dropped turn as an error instead of a pass, which is how step 7 had slipped through. The third and fourth are the next targets for the latency work and are now measurable per step.

## Tests

The session sabotage test removes `CHANGELOG.md` from a copied solution and asserts exactly step `15-final` and the task verifier go red. The regression tests assert the ratio movements print as warnings, that the explicit limits turn them into failures with the tolerated value shown, and that a baseline without session tasks enforces nothing. The schema tests assert a closed `metrics` object rejects an unknown key and `kind` rejects unknown values. The trust tests cover a fresh home, merging with existing entries and extra fields, and an unreadable record. The metrics tests cover re-read detection across an intervening edit, rollout watermarks, tool-error detection from rollout tool items, aggregation and ratio derivation, torn-line reading, and both rollout finders.

## Not changed

- The 12 existing command tasks, their solutions and verifiers.
- The committed `baseline-report.json` (mock). A real-agent baseline is a separate file so mock and real runs each compare against their own executor.
- The TFR suites, the evaluation contract, and the executor under `src/eval-executor`.
- No CI lane: real session runs need the xAI sign-in of an isolated home, which GitHub-hosted runners do not have.

## Counterparts

The harness review PRs #2011 to #2018 (what this measures going forward); #2022, #2023, #1792 (open issues whose fixes this lane can now score).


