### PR TITLE
feat(lsp): fold language-server diagnostics into edit results and start servers without config

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -598,7 +598,7 @@ optional `headers`), `github` (`repo`, optional `ref`, `path`, `sparsePaths`),
 
 | Paths | Type / meaning |
 | --- | --- |
-| `lsp_servers`, `lsp_servers.<server>` | Named language server configs. |
+| `lsp_servers`, `lsp_servers.<server>` | Named language server configs. Without any, built-in profiles start `typescript-language-server`, `basedpyright-langserver`/`pyright-langserver`, `gopls` and `rust-analyzer` when the binary is on PATH (never from the workspace); a configured server that claims an extension replaces the matching profile. `AGENC_DISABLE_BUILTIN_LSP=1` turns the profiles off. |
 | `lsp_servers.<server>.command`, `lsp_servers.<server>.args`, `lsp_servers.<server>.workspaceFolder` | Launch command and workspace. |
 | `lsp_servers.<server>.env`, `lsp_servers.<server>.env.<name>` | String environment map. |
 | `lsp_servers.<server>.extensionToLanguage`, `lsp_servers.<server>.extensionToLanguage.<name>` | Required extension-to-language map. |

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -274,6 +274,8 @@ Defaults are "feature on unless the disable var is set" unless noted.
 | `AGENC_AUTO_COMPACT_WINDOW` | Positive integer context-window override used by compaction thresholds |
 | `AGENC_AUTOCOMPACT_PCT_OVERRIDE` | Percentage `1` to `100`; can only make automatic compaction fire earlier than the safety default |
 | `AGENC_DISABLE_LSP` | Do not start LSP |
+| `AGENC_DISABLE_BUILTIN_LSP` | Do not add the built-in language server profiles (TypeScript, Python, Go, Rust binaries found on PATH); only `lsp_servers` from config start |
+| `AGENC_LSP_EDIT_FEEDBACK_MS` | How long Edit, MultiEdit and Write wait for the language server's diagnostics on the edited file before returning (default `1500`, max `30000`; `0` disables the same-turn feedback, diagnostics then arrive as the next turn's attachment) |
 | `AGENC_DISABLE_CRON` | Disable CronCreate/List/Delete and the in-session scheduler. Delivery-routed jobs still need `agenc gateway run`; their webhook destinations are public-only and address-pinned ([autonomy.md](autonomy.md#webhook-destinations-pinned-fail-closed)) |
 | `AGENC_DISABLE_BACKGROUND_TASKS` | Block background tasks |
 | `AGENC_CODE_MODE` | `1`/`true`/`on` plus resolvable `quickjs-emscripten` registers LIVE `exec`/`wait` |

--- a/runtime/src/bin/bootstrap-services.ts
+++ b/runtime/src/bin/bootstrap-services.ts
@@ -477,6 +477,7 @@ export function loadBootstrapHooks(opts: {
 
 function readConfiguredLspServers(
   cfg: ReturnType<ConfigStore["current"]>,
+  workspaceRoot?: string,
 ): ReturnType<typeof parseLspServersConfig> {
   const parsed = parseLspServersConfig(cfg.lsp_servers);
   if (!parsed.success) return parsed;
@@ -486,7 +487,7 @@ function readConfiguredLspServers(
   return {
     success: true,
     servers: {
-      ...builtinLspServerConfigs({ configured: parsed.servers }),
+      ...builtinLspServerConfigs({ configured: parsed.servers, workspaceRoot }),
       ...parsed.servers,
     },
   };
@@ -501,7 +502,7 @@ export async function loadBootstrapLspServers(
   cfg: ReturnType<ConfigStore["current"]>,
   opts: BootstrapLspServerOptions = {},
 ): Promise<void> {
-  const parsed = readConfiguredLspServers(cfg);
+  const parsed = readConfiguredLspServers(cfg, opts.workspaceRoot);
   const managerOptions = {
     ...(opts.workspaceRoot !== undefined
       ? { workspaceRoot: opts.workspaceRoot }

--- a/runtime/src/bin/bootstrap-services.ts
+++ b/runtime/src/bin/bootstrap-services.ts
@@ -88,6 +88,7 @@ import { createHookExecutionAuthority } from "../hooks/execution-authority.js";
 import { createAutoFixPostToolHook } from "../services/autoFix/autoFixHook.js";
 import { isProjectTrustedSync } from "../permissions/trust/project-trust.js";
 import { parseLspServersConfig } from "../services/lsp/config.js";
+import { builtinLspServerConfigs } from "../services/lsp/builtinServers.js";
 import {
   getInitializationStatus as getLspInitializationStatus,
   initializeLspServerManager,
@@ -477,7 +478,18 @@ export function loadBootstrapHooks(opts: {
 function readConfiguredLspServers(
   cfg: ReturnType<ConfigStore["current"]>,
 ): ReturnType<typeof parseLspServersConfig> {
-  return parseLspServersConfig(cfg.lsp_servers);
+  const parsed = parseLspServersConfig(cfg.lsp_servers);
+  if (!parsed.success) return parsed;
+  // Built-in profiles fill in a language server for TypeScript, Python, Go and
+  // Rust when the binary is on PATH; a configured server that claims any of
+  // the same extensions wins. See builtinServers.ts for why only PATH counts.
+  return {
+    success: true,
+    servers: {
+      ...builtinLspServerConfigs({ configured: parsed.servers }),
+      ...parsed.servers,
+    },
+  };
 }
 
 interface BootstrapLspServerOptions {

--- a/runtime/src/services/lsp/LSPDiagnosticRegistry.ts
+++ b/runtime/src/services/lsp/LSPDiagnosticRegistry.ts
@@ -27,15 +27,22 @@ const MAX_TOTAL_DIAGNOSTICS = 30;
 const MAX_DELIVERED_FILES = 500;
 export const MAX_DELIVERED_DIAGNOSTICS_PER_FILE = 100;
 
+interface FileDiagnosticWaiter {
+  readonly file: string;
+  readonly resolve: (file: DiagnosticFile | undefined) => void;
+}
+
 interface LSPDiagnosticState {
   readonly pendingDiagnostics: Map<string, PendingLSPDiagnostic>;
   readonly deliveredDiagnostics: LRUCache<string, Set<string>>;
+  readonly fileWaiters: Set<FileDiagnosticWaiter>;
 }
 
 function createDiagnosticState(): LSPDiagnosticState {
   return {
     pendingDiagnostics: new Map(),
     deliveredDiagnostics: new LRUCache({ max: MAX_DELIVERED_FILES }),
+    fileWaiters: new Set(),
   };
 }
 
@@ -200,6 +207,7 @@ export function registerPendingLSPDiagnostic(input: {
 }, scope?: LSPDiagnosticScope): void {
   const state = stateForScope(scope, true)!;
   for (const file of input.files) {
+    settleFileWaiters(state, file);
     reconcileDeliveredDiagnosticsForFile(state, file);
     const key = pendingKey(input.serverName, file.uri);
     if (file.diagnostics.length === 0) {
@@ -212,6 +220,71 @@ export function registerPendingLSPDiagnostic(input: {
       timestamp: Date.now(),
       attachmentSent: false,
     });
+  }
+}
+
+function settleFileWaiters(state: LSPDiagnosticState, file: DiagnosticFile): void {
+  for (const waiter of Array.from(state.fileWaiters)) {
+    if (!fileMatches(waiter.file, file.uri)) continue;
+    state.fileWaiters.delete(waiter);
+    waiter.resolve({
+      uri: file.uri,
+      diagnostics: file.diagnostics.map((diagnostic) => ({ ...diagnostic })),
+    });
+  }
+}
+
+/**
+ * Resolve with the next diagnostics publication for one file, including an
+ * empty publication (the server reports the file clean), or with undefined
+ * when nothing arrives within `timeoutMs`. The file mutation tools use it to
+ * fold the language server's verdict into the edit result in the same turn.
+ */
+export function waitForFileDiagnostics(
+  file: string,
+  timeoutMs: number,
+  scope?: LSPDiagnosticScope,
+): Promise<DiagnosticFile | undefined> {
+  const state = stateForScope(scope, true)!;
+  return new Promise((resolvePromise) => {
+    let timer: NodeJS.Timeout | undefined;
+    const waiter: FileDiagnosticWaiter = {
+      file,
+      resolve: (result) => {
+        if (timer !== undefined) clearTimeout(timer);
+        resolvePromise(result);
+      },
+    };
+    state.fileWaiters.add(waiter);
+    // The timer is deliberately not unref'd: the mutation tool is awaiting this
+    // bounded wait, and the loop must stay alive until the server answers or
+    // the window closes.
+    timer = setTimeout(() => {
+      state.fileWaiters.delete(waiter);
+      resolvePromise(undefined);
+    }, Math.max(0, timeoutMs));
+  });
+}
+
+/**
+ * Take one file's pending diagnostics out of the next-turn attachment and
+ * remember them as delivered, because the caller already showed them.
+ */
+export function consumePendingDiagnosticsForFile(
+  file: string,
+  scope?: LSPDiagnosticScope,
+): void {
+  const state = stateForScope(scope, false);
+  if (state === undefined) return;
+  for (const [key, pending] of state.pendingDiagnostics.entries()) {
+    const matching = pending.files.filter((candidate) => fileMatches(candidate.uri, file));
+    if (matching.length === 0) continue;
+    for (const candidate of matching) {
+      for (const diagnostic of candidate.diagnostics) {
+        rememberDeliveredDiagnostic(state, candidate.uri, diagnosticKey(diagnostic));
+      }
+    }
+    state.pendingDiagnostics.delete(key);
   }
 }
 
@@ -292,6 +365,8 @@ export function clearAllLSPDiagnostics(scope?: LSPDiagnosticScope): void {
 
 export function resetAllLSPDiagnosticState(): void {
   for (const state of activeDiagnosticStates) {
+    for (const waiter of state.fileWaiters) waiter.resolve(undefined);
+    state.fileWaiters.clear();
     state.pendingDiagnostics.clear();
     state.deliveredDiagnostics.clear();
   }

--- a/runtime/src/services/lsp/builtinServers.ts
+++ b/runtime/src/services/lsp/builtinServers.ts
@@ -1,0 +1,147 @@
+/**
+ * Built-in language server profiles.
+ *
+ * Nothing in `lsp_servers` means no diagnostics at all, and almost nobody
+ * writes that config. These profiles give TypeScript, JavaScript, Python, Go
+ * and Rust projects a language server with zero configuration when the
+ * server binary is installed on the user's PATH. Only PATH is searched: a
+ * server found inside the workspace (node_modules/.bin, a virtualenv) is code
+ * the repository under edit chose, and the agent must not execute it on the
+ * user's behalf just because it opened the folder. A user-configured server
+ * that claims any of the same extensions replaces the profile. Set
+ * AGENC_DISABLE_BUILTIN_LSP=1 to turn every profile off; AGENC_DISABLE_LSP
+ * still turns the whole service off.
+ */
+import { accessSync, constants as fsConstants, statSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
+import type { ScopedLspServerConfig } from "./types.js";
+
+interface BuiltinProfile {
+  readonly name: string;
+  readonly displayName: string;
+  readonly commands: readonly string[];
+  readonly args: readonly string[];
+  readonly extensionToLanguage: Readonly<Record<string, string>>;
+}
+
+const TYPESCRIPT_EXTENSIONS = Object.freeze({
+  ".ts": "typescript",
+  ".mts": "typescript",
+  ".cts": "typescript",
+  ".tsx": "typescriptreact",
+  ".js": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".jsx": "javascriptreact",
+});
+
+export const BUILTIN_LSP_PROFILES: readonly BuiltinProfile[] = Object.freeze([
+  {
+    name: "builtin-typescript",
+    displayName: "TypeScript (typescript-language-server)",
+    commands: ["typescript-language-server"],
+    args: ["--stdio"],
+    extensionToLanguage: TYPESCRIPT_EXTENSIONS,
+  },
+  {
+    name: "builtin-python",
+    displayName: "Python (pyright)",
+    commands: ["basedpyright-langserver", "pyright-langserver"],
+    args: ["--stdio"],
+    extensionToLanguage: Object.freeze({ ".py": "python", ".pyi": "python" }),
+  },
+  {
+    name: "builtin-go",
+    displayName: "Go (gopls)",
+    commands: ["gopls"],
+    args: [],
+    extensionToLanguage: Object.freeze({ ".go": "go" }),
+  },
+  {
+    name: "builtin-rust",
+    displayName: "Rust (rust-analyzer)",
+    commands: ["rust-analyzer"],
+    args: [],
+    extensionToLanguage: Object.freeze({ ".rs": "rust" }),
+  },
+]);
+
+function isEnvTruthy(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/iu.test(value?.trim() ?? "");
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    if (!statSync(path).isFile()) return false;
+    accessSync(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a bare command name against PATH only. Relative or absolute names
+ * are refused: the profiles never point into the workspace.
+ */
+export function resolveCommandOnPath(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  if (command.length === 0 || isAbsolute(command) || command.includes("/") || command.includes("\\")) {
+    return undefined;
+  }
+  const searchPath = env.PATH ?? env.Path ?? "";
+  if (searchPath.length === 0) return undefined;
+  const suffixes = platform === "win32"
+    ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
+    : [""];
+  for (const directory of searchPath.split(delimiter)) {
+    if (directory.length === 0) continue;
+    for (const suffix of suffixes) {
+      const candidate = join(directory, `${command}${suffix}`);
+      if (isExecutableFile(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+export interface BuiltinLspServerOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  /** Servers the user configured; a profile yields to any overlap in extensions. */
+  readonly configured?: Readonly<Record<string, ScopedLspServerConfig>>;
+  readonly resolveCommand?: (command: string) => string | undefined;
+}
+
+/**
+ * The built-in servers that apply on this machine: each profile whose binary
+ * is on PATH and whose extensions no configured server already claims.
+ */
+export function builtinLspServerConfigs(
+  options: BuiltinLspServerOptions = {},
+): Record<string, ScopedLspServerConfig> {
+  const env = options.env ?? process.env;
+  if (isEnvTruthy(env.AGENC_DISABLE_BUILTIN_LSP)) return {};
+  const resolveCommand = options.resolveCommand ?? ((command: string) => resolveCommandOnPath(command, env));
+  const claimed = new Set<string>();
+  for (const server of Object.values(options.configured ?? {})) {
+    for (const extension of Object.keys(server.extensionToLanguage)) {
+      claimed.add(extension.toLowerCase());
+    }
+  }
+  const out: Record<string, ScopedLspServerConfig> = {};
+  for (const profile of BUILTIN_LSP_PROFILES) {
+    const extensions = Object.keys(profile.extensionToLanguage);
+    if (extensions.some((extension) => claimed.has(extension))) continue;
+    const command = profile.commands.map(resolveCommand).find((path) => path !== undefined);
+    if (command === undefined) continue;
+    out[profile.name] = {
+      command,
+      args: [...profile.args],
+      extensionToLanguage: { ...profile.extensionToLanguage },
+      displayName: profile.displayName,
+    };
+  }
+  return out;
+}

--- a/runtime/src/services/lsp/builtinServers.ts
+++ b/runtime/src/services/lsp/builtinServers.ts
@@ -12,8 +12,8 @@
  * AGENC_DISABLE_BUILTIN_LSP=1 to turn every profile off; AGENC_DISABLE_LSP
  * still turns the whole service off.
  */
-import { accessSync, constants as fsConstants, statSync } from "node:fs";
-import { delimiter, isAbsolute, join } from "node:path";
+import { accessSync, constants as fsConstants, realpathSync, statSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
 import type { ScopedLspServerConfig } from "./types.js";
 
 interface BuiltinProfile {
@@ -112,6 +112,57 @@ export interface BuiltinLspServerOptions {
   /** Servers the user configured; a profile yields to any overlap in extensions. */
   readonly configured?: Readonly<Record<string, ScopedLspServerConfig>>;
   readonly resolveCommand?: (command: string) => string | undefined;
+  /** The workspace the servers will analyse; decides the TypeScript fallback. */
+  readonly workspaceRoot?: string;
+}
+
+const WORKSPACE_TSSERVER = join("node_modules", "typescript", "lib", "tsserver.js");
+
+/**
+ * typescript-language-server 5+ ships no TypeScript of its own: it uses the
+ * workspace's `node_modules/typescript` or an explicit `tsserver.path`, and
+ * exits during initialize otherwise. When the workspace has no TypeScript,
+ * point the server at the TypeScript installed next to it, which the user
+ * installed together with the server. Nothing from the workspace is executed
+ * that the server would not have executed on its own. Only TypeScript 5.x
+ * qualifies: the Go-based TypeScript 7 has no `lib/tsserver.js`, so the
+ * fallback stays undefined and the server reports the missing installation.
+ */
+export function typescriptServerFallback(
+  serverCommand: string,
+  workspaceRoot: string | undefined,
+): { readonly tsserver: { readonly path: string } } | undefined {
+  if (workspaceRoot !== undefined && isRegularFile(join(workspaceRoot, WORKSPACE_TSSERVER))) {
+    return undefined;
+  }
+  let real: string;
+  try {
+    real = realpathSync(serverCommand);
+  } catch {
+    return undefined;
+  }
+  // <prefix>/node_modules/typescript-language-server/lib/cli.mjs (npm) or
+  // <prefix>/lib/node_modules/... (global): walk up to the first node_modules.
+  let dir = dirname(real);
+  for (let depth = 0; depth < 6; depth += 1) {
+    if (dir.endsWith(`${delimiter === ";" ? "\\" : "/"}node_modules`) || dir.endsWith("node_modules")) {
+      const candidate = join(dir, "typescript", "lib", "tsserver.js");
+      if (isRegularFile(candidate)) return { tsserver: { path: candidate } };
+      return undefined;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+function isRegularFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -136,11 +187,15 @@ export function builtinLspServerConfigs(
     if (extensions.some((extension) => claimed.has(extension))) continue;
     const command = profile.commands.map(resolveCommand).find((path) => path !== undefined);
     if (command === undefined) continue;
+    const initializationOptions = profile.name === "builtin-typescript"
+      ? typescriptServerFallback(command, options.workspaceRoot)
+      : undefined;
     out[profile.name] = {
       command,
       args: [...profile.args],
       extensionToLanguage: { ...profile.extensionToLanguage },
       displayName: profile.displayName,
+      ...(initializationOptions !== undefined ? { initializationOptions } : {}),
     };
   }
   return out;

--- a/runtime/src/services/lsp/fileNotifications.ts
+++ b/runtime/src/services/lsp/fileNotifications.ts
@@ -2,10 +2,15 @@
  * Best-effort file mutation notifications for the LSP service.
  */
 
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { clearDeliveredDiagnosticsForFile } from "./LSPDiagnosticRegistry.js";
+import {
+  clearDeliveredDiagnosticsForFile,
+  consumePendingDiagnosticsForFile,
+  waitForFileDiagnostics,
+} from "./LSPDiagnosticRegistry.js";
+import type { DiagnosticEntry, DiagnosticFile } from "./types.js";
 import { getLspServerManager } from "./manager.js";
 import { peekAmbientRuntimeSession } from "../../session/current-session.js";
 import type { SandboxExecutionBrokerLike } from "../../sandbox/execution-broker.js";
@@ -30,4 +35,120 @@ export function notifyLspFileChanged(
       // because an optional language server is unavailable.
     }
   })();
+}
+
+const DEFAULT_EDIT_FEEDBACK_MS = 1500;
+const MAX_EDIT_FEEDBACK_ENTRIES = 8;
+
+/** How long a file mutation waits for the language server's verdict; 0 disables. */
+export function editFeedbackTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.AGENC_LSP_EDIT_FEEDBACK_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_EDIT_FEEDBACK_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_EDIT_FEEDBACK_MS;
+  return Math.min(Math.floor(parsed), 30_000);
+}
+
+function severityRank(severity: DiagnosticEntry["severity"]): number {
+  switch (severity) {
+    case "Error":
+      return 0;
+    case "Warning":
+      return 1;
+    case "Info":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+/**
+ * Render one file's diagnostics as the suffix a mutation tool appends to its
+ * result: errors first, positions 1-based, bounded, one line each.
+ */
+export function formatEditFeedback(
+  displayPath: string,
+  file: DiagnosticFile,
+): string {
+  if (file.diagnostics.length === 0) {
+    return "\n\nLanguage server: no diagnostics for this file after the edit.";
+  }
+  const sorted = [...file.diagnostics].sort(
+    (left, right) => severityRank(left.severity) - severityRank(right.severity),
+  );
+  const errors = sorted.filter((diagnostic) => diagnostic.severity === "Error").length;
+  const warnings = sorted.filter((diagnostic) => diagnostic.severity === "Warning").length;
+  const counts = [
+    errors > 0 ? `${errors} error${errors === 1 ? "" : "s"}` : undefined,
+    warnings > 0 ? `${warnings} warning${warnings === 1 ? "" : "s"}` : undefined,
+    sorted.length - errors - warnings > 0 ? `${sorted.length - errors - warnings} other` : undefined,
+  ].filter(Boolean).join(", ");
+  const lines = sorted.slice(0, MAX_EDIT_FEEDBACK_ENTRIES).map((diagnostic) => {
+    const position = diagnostic.range
+      ? `:${diagnostic.range.start.line + 1}:${diagnostic.range.start.character + 1}`
+      : "";
+    const code = diagnostic.code ? ` ${diagnostic.source ?? ""}${diagnostic.source ? " " : ""}${diagnostic.code}` : diagnostic.source ? ` ${diagnostic.source}` : "";
+    return `  ${displayPath}${position} ${(diagnostic.severity ?? "info").toLowerCase()}${code}: ${diagnostic.message.split("\n")[0]}`;
+  });
+  const more = sorted.length > MAX_EDIT_FEEDBACK_ENTRIES
+    ? `\n  ... ${sorted.length - MAX_EDIT_FEEDBACK_ENTRIES} more`
+    : "";
+  return `\n\nLanguage server diagnostics after this edit (${counts}):\n${lines.join("\n")}${more}`;
+}
+
+/**
+ * Notify the language server of a mutation and wait, bounded, for its verdict
+ * on that file. Returns the suffix to append to the tool result, or "" when
+ * no server covers the file, nothing arrives in time, or feedback is off.
+ * Diagnostics shown here are marked delivered so the next-turn attachment
+ * does not repeat them. Never throws: the mutation already succeeded.
+ */
+export async function collectEditFeedback(
+  filePath: string,
+  content: string,
+  options: {
+    readonly displayPath?: string;
+    readonly timeoutMs?: number;
+    readonly scope?: SandboxExecutionBrokerLike;
+  } = {},
+): Promise<string> {
+  const scope = options.scope ?? peekAmbientRuntimeSession()?.services.sandboxExecutionBroker;
+  const timeoutMs = options.timeoutMs ?? editFeedbackTimeoutMs();
+  const absolutePath = resolve(filePath);
+  const manager = getLspServerManager(scope);
+  const covered = manager !== undefined && timeoutMs > 0 && managerCoversFile(manager, absolutePath);
+  if (!covered) {
+    notifyLspFileChanged(filePath, content, scope);
+    return "";
+  }
+  try {
+    const verdict = waitForFileDiagnostics(absolutePath, timeoutMs, scope);
+    notifyLspFileChanged(filePath, content, scope);
+    const file = await verdict;
+    if (file === undefined) return "";
+    consumePendingDiagnosticsForFile(absolutePath, scope);
+    return formatEditFeedback(options.displayPath ?? displayPathFor(absolutePath), file);
+  } catch {
+    return "";
+  }
+}
+
+/** The path the model sees: relative to the working directory when inside it. */
+function displayPathFor(absolutePath: string): string {
+  const cwd = process.cwd();
+  const rel = relative(cwd, absolutePath);
+  return rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel) ? rel : absolutePath;
+}
+
+function managerCoversFile(
+  manager: NonNullable<ReturnType<typeof getLspServerManager>>,
+  absolutePath: string,
+): boolean {
+  const candidate = manager as { getServerForFile?: (path: string) => unknown };
+  if (typeof candidate.getServerForFile !== "function") return true;
+  try {
+    return candidate.getServerForFile(absolutePath) !== undefined;
+  } catch {
+    return false;
+  }
 }

--- a/runtime/src/tools/system/file-edit.ts
+++ b/runtime/src/tools/system/file-edit.ts
@@ -55,7 +55,7 @@ import {
   isAgentNamespacePath,
 } from "./agent-path-hints.js";
 import { checkToolPathPermission } from "../../permissions/path-validation.js";
-import { notifyLspFileChanged } from "../../services/lsp/fileNotifications.js";
+import { collectEditFeedback } from "../../services/lsp/fileNotifications.js";
 import { nonEmptyString as asNonEmptyString } from "../../utils/stringUtils.js";
 import {
   prepareWorkspaceMutation,
@@ -989,9 +989,9 @@ export function createFileEditTool(config: FileEditToolConfig): Tool {
           absoluteFilePath,
           new_string,
         );
-        notifyLspFileChanged(absoluteFilePath, new_string);
+        const lspFeedback = await collectEditFeedback(absoluteFilePath, new_string);
         return {
-          content: `Created file ${file_path}.`,
+          content: `Created file ${file_path}.${lspFeedback}`,
           metadata: buildFileMutationMetadata({
             filePath: file_path,
             operation: "create",
@@ -1103,9 +1103,9 @@ export function createFileEditTool(config: FileEditToolConfig): Tool {
           return errorResult(formatWriteFileError(err));
         }
         await snapshotPostWrite(sessionId, absoluteFilePath, new_string);
-        notifyLspFileChanged(absoluteFilePath, new_string);
+        const lspFeedback = await collectEditFeedback(absoluteFilePath, new_string);
         return {
-          content: successText(file_path, false),
+          content: `${successText(file_path, false)}${lspFeedback}`,
           metadata: buildFileMutationMetadata({
             filePath: file_path,
             operation: "edit",
@@ -1151,10 +1151,10 @@ export function createFileEditTool(config: FileEditToolConfig): Tool {
 
       await snapshotPostWrite(sessionId, absoluteFilePath, updated);
 
-      notifyLspFileChanged(absoluteFilePath, updated);
+      const lspFeedback = await collectEditFeedback(absoluteFilePath, updated);
 
       return {
-        content: successText(file_path, replace_all),
+        content: `${successText(file_path, replace_all)}${lspFeedback}`,
         metadata: buildFileMutationMetadata({
           filePath: file_path,
           operation: "edit",
@@ -1365,9 +1365,9 @@ export function createFileMultiEditTool(config: FileEditToolConfig): Tool {
           absoluteFilePath,
           firstEdit.new_string,
         );
-        notifyLspFileChanged(absoluteFilePath, firstEdit.new_string);
+        const lspFeedback = await collectEditFeedback(absoluteFilePath, firstEdit.new_string);
         return {
-          content: `Created file ${file_path}.`,
+          content: `Created file ${file_path}.${lspFeedback}`,
           metadata: buildFileMutationMetadata({
             filePath: file_path,
             operation: "create",
@@ -1474,9 +1474,9 @@ export function createFileMultiEditTool(config: FileEditToolConfig): Tool {
           absoluteFilePath,
           firstEdit.new_string,
         );
-        notifyLspFileChanged(absoluteFilePath, firstEdit.new_string);
+        const lspFeedback = await collectEditFeedback(absoluteFilePath, firstEdit.new_string);
         return {
-          content: multiEditSuccessText(file_path, 1, 1),
+          content: `${multiEditSuccessText(file_path, 1, 1)}${lspFeedback}`,
           metadata: buildFileMutationMetadata({
             filePath: file_path,
             operation: "edit",
@@ -1552,10 +1552,10 @@ export function createFileMultiEditTool(config: FileEditToolConfig): Tool {
       }
 
       await snapshotPostWrite(sessionId, absoluteFilePath, updated);
-      notifyLspFileChanged(absoluteFilePath, updated);
+      const lspFeedback = await collectEditFeedback(absoluteFilePath, updated);
 
       return {
-        content: multiEditSuccessText(file_path, edits.length, replacements),
+        content: `${multiEditSuccessText(file_path, edits.length, replacements)}${lspFeedback}`,
         metadata: buildFileMutationMetadata({
           filePath: file_path,
           operation: "edit",

--- a/runtime/src/tools/system/file-write.ts
+++ b/runtime/src/tools/system/file-write.ts
@@ -62,7 +62,7 @@ import {
 } from "./agent-path-hints.js";
 import { checkToolPathPermission } from "../../permissions/path-validation.js";
 import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
-import { notifyLspFileChanged } from "../../services/lsp/fileNotifications.js";
+import { collectEditFeedback } from "../../services/lsp/fileNotifications.js";
 import {
   prepareWorkspaceMutation,
   WorkspaceMutationCoordinatorError,
@@ -590,7 +590,7 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
         );
       }
 
-      notifyLspFileChanged(absolutePath, content);
+      const lspFeedback = await collectEditFeedback(absolutePath, content);
 
       // Record the post-write content as the session's view of the
       // file so subsequent overwrites/edits in the same session do
@@ -631,9 +631,11 @@ export function createFileWriteTool(config: FileWriteToolConfig = {}): Tool {
       void existingStat;
       return {
         ...successResult(
-          existed
-            ? `The file ${filePath} has been updated successfully.`
-            : `File created successfully at: ${filePath}`,
+          `${
+            existed
+              ? `The file ${filePath} has been updated successfully.`
+              : `File created successfully at: ${filePath}`
+          }${lspFeedback}`,
         ),
         metadata: buildFileMutationMetadata({
           filePath,

--- a/runtime/tests/bin/bootstrap-services.test.ts
+++ b/runtime/tests/bin/bootstrap-services.test.ts
@@ -1423,41 +1423,50 @@ describe("loadBootstrapLspServers", () => {
   }
 
   test("starts and stops the LSP manager from typed config", async () => {
-    _resetLspManagerForTesting();
-    try {
-      await loadBootstrapLspServers(
-        {
-          ...defaultConfig(),
-          lsp_servers: {
-            ts: {
-              command: "typescript-language-server",
-              extensionToLanguage: { ".ts": "typescript" },
+      // This test is about the typed lsp_servers config alone. Built-in profiles
+      // would start whatever language server the host happens to have on PATH.
+      const previousBuiltin = process.env.AGENC_DISABLE_BUILTIN_LSP;
+      process.env.AGENC_DISABLE_BUILTIN_LSP = "1";
+      try {
+      _resetLspManagerForTesting();
+      try {
+        await loadBootstrapLspServers(
+          {
+            ...defaultConfig(),
+            lsp_servers: {
+              ts: {
+                command: "typescript-language-server",
+                extensionToLanguage: { ".ts": "typescript" },
+              },
             },
           },
-        },
-        { workspaceRoot: "/workspace/project" },
-      );
-      expect(getInitializationStatus().status).toBe("pending");
-      await waitForInitialization();
-      expect(getInitializationStatus().status).toBe("success");
-      expect(getLspServerManager()?.getAllServers().has("ts")).toBe(true);
+          { workspaceRoot: "/workspace/project" },
+        );
+        expect(getInitializationStatus().status).toBe("pending");
+        await waitForInitialization();
+        expect(getInitializationStatus().status).toBe("success");
+        expect(getLspServerManager()?.getAllServers().has("ts")).toBe(true);
 
-      await loadBootstrapLspServers(
-        { ...defaultConfig(), lsp_servers: undefined },
-        { workspaceRoot: "/workspace/project" },
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(getInitializationStatus().status).toBe("not-started");
+        await loadBootstrapLspServers(
+          { ...defaultConfig(), lsp_servers: undefined },
+          { workspaceRoot: "/workspace/project" },
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(getInitializationStatus().status).toBe("not-started");
 
-      await loadBootstrapLspServers(
-        { ...defaultConfig(), lsp_servers: undefined },
-        { workspaceRoot: "/workspace/project" },
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(getInitializationStatus().status).toBe("not-started");
+        await loadBootstrapLspServers(
+          { ...defaultConfig(), lsp_servers: undefined },
+          { workspaceRoot: "/workspace/project" },
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(getInitializationStatus().status).toBe("not-started");
+      } finally {
+        await shutdownLspServerManager();
+        _resetLspManagerForTesting();
+      }
     } finally {
-      await shutdownLspServerManager();
-      _resetLspManagerForTesting();
+      if (previousBuiltin === undefined) delete process.env.AGENC_DISABLE_BUILTIN_LSP;
+      else process.env.AGENC_DISABLE_BUILTIN_LSP = previousBuiltin;
     }
   });
 

--- a/runtime/tests/bin/bootstrap-services.test.ts
+++ b/runtime/tests/bin/bootstrap-services.test.ts
@@ -8,7 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const policyLimitsMocks = vi.hoisted(() => ({
   configurePolicyLimitsService: vi.fn(),
@@ -1389,6 +1389,19 @@ describe("buildBootstrapSessionServices policy limits wiring", () => {
 });
 
 describe("loadBootstrapLspServers", () => {
+  // These tests are about the typed lsp_servers config alone. Built-in
+  // profiles would otherwise start whatever language server the host happens
+  // to have on PATH and make an empty typed config mean "one server".
+  let previousBuiltinLsp: string | undefined;
+  beforeEach(() => {
+    previousBuiltinLsp = process.env.AGENC_DISABLE_BUILTIN_LSP;
+    process.env.AGENC_DISABLE_BUILTIN_LSP = "1";
+  });
+  afterEach(() => {
+    if (previousBuiltinLsp === undefined) delete process.env.AGENC_DISABLE_BUILTIN_LSP;
+    else process.env.AGENC_DISABLE_BUILTIN_LSP = previousBuiltinLsp;
+  });
+
   function rejectingStopServer(): LSPServerInstance {
     const config = normalizeLspServerConfig("ts", {
       command: "typescript-language-server",
@@ -1423,50 +1436,41 @@ describe("loadBootstrapLspServers", () => {
   }
 
   test("starts and stops the LSP manager from typed config", async () => {
-      // This test is about the typed lsp_servers config alone. Built-in profiles
-      // would start whatever language server the host happens to have on PATH.
-      const previousBuiltin = process.env.AGENC_DISABLE_BUILTIN_LSP;
-      process.env.AGENC_DISABLE_BUILTIN_LSP = "1";
-      try {
-      _resetLspManagerForTesting();
-      try {
-        await loadBootstrapLspServers(
-          {
-            ...defaultConfig(),
-            lsp_servers: {
-              ts: {
-                command: "typescript-language-server",
-                extensionToLanguage: { ".ts": "typescript" },
-              },
+    _resetLspManagerForTesting();
+    try {
+      await loadBootstrapLspServers(
+        {
+          ...defaultConfig(),
+          lsp_servers: {
+            ts: {
+              command: "typescript-language-server",
+              extensionToLanguage: { ".ts": "typescript" },
             },
           },
-          { workspaceRoot: "/workspace/project" },
-        );
-        expect(getInitializationStatus().status).toBe("pending");
-        await waitForInitialization();
-        expect(getInitializationStatus().status).toBe("success");
-        expect(getLspServerManager()?.getAllServers().has("ts")).toBe(true);
+        },
+        { workspaceRoot: "/workspace/project" },
+      );
+      expect(getInitializationStatus().status).toBe("pending");
+      await waitForInitialization();
+      expect(getInitializationStatus().status).toBe("success");
+      expect(getLspServerManager()?.getAllServers().has("ts")).toBe(true);
 
-        await loadBootstrapLspServers(
-          { ...defaultConfig(), lsp_servers: undefined },
-          { workspaceRoot: "/workspace/project" },
-        );
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(getInitializationStatus().status).toBe("not-started");
+      await loadBootstrapLspServers(
+        { ...defaultConfig(), lsp_servers: undefined },
+        { workspaceRoot: "/workspace/project" },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getInitializationStatus().status).toBe("not-started");
 
-        await loadBootstrapLspServers(
-          { ...defaultConfig(), lsp_servers: undefined },
-          { workspaceRoot: "/workspace/project" },
-        );
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        expect(getInitializationStatus().status).toBe("not-started");
-      } finally {
-        await shutdownLspServerManager();
-        _resetLspManagerForTesting();
-      }
+      await loadBootstrapLspServers(
+        { ...defaultConfig(), lsp_servers: undefined },
+        { workspaceRoot: "/workspace/project" },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getInitializationStatus().status).toBe("not-started");
     } finally {
-      if (previousBuiltin === undefined) delete process.env.AGENC_DISABLE_BUILTIN_LSP;
-      else process.env.AGENC_DISABLE_BUILTIN_LSP = previousBuiltin;
+      await shutdownLspServerManager();
+      _resetLspManagerForTesting();
     }
   });
 

--- a/runtime/tests/services/lsp/builtinServers.test.ts
+++ b/runtime/tests/services/lsp/builtinServers.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -7,6 +7,7 @@ import {
   BUILTIN_LSP_PROFILES,
   builtinLspServerConfigs,
   resolveCommandOnPath,
+  typescriptServerFallback,
 } from "./builtinServers.js";
 
 describe("built-in language server profiles", () => {
@@ -90,5 +91,49 @@ describe("built-in language server profiles", () => {
         expect(extension.startsWith(".")).toBe(true);
       }
     }
+  });
+
+  test("the TypeScript profile points at the TypeScript installed next to the server only when the workspace has none", () => {
+    const prefix = mkdtempSync(join(tmpdir(), "agenc-lsp-prefix-"));
+    dirs.push(prefix);
+    const serverDir = join(prefix, "node_modules", "typescript-language-server", "lib");
+    mkdirSync(serverDir, { recursive: true });
+    writeFileSync(join(serverDir, "cli.mjs"), "#!/usr/bin/env node\n");
+    const tsserver = join(prefix, "node_modules", "typescript", "lib", "tsserver.js");
+    mkdirSync(join(prefix, "node_modules", "typescript", "lib"), { recursive: true });
+    writeFileSync(tsserver, "// tsserver\n");
+    const bin = join(prefix, "node_modules", ".bin");
+    mkdirSync(bin, { recursive: true });
+    const link = join(bin, "typescript-language-server");
+    symlinkSync(join(serverDir, "cli.mjs"), link);
+
+    const bareWorkspace = mkdtempSync(join(tmpdir(), "agenc-lsp-ws-"));
+    dirs.push(bareWorkspace);
+    expect(typescriptServerFallback(link, bareWorkspace)).toEqual({ tsserver: { path: tsserver } });
+    expect(typescriptServerFallback(link, undefined)).toEqual({ tsserver: { path: tsserver } });
+
+    const typedWorkspace = mkdtempSync(join(tmpdir(), "agenc-lsp-ws-"));
+    dirs.push(typedWorkspace);
+    mkdirSync(join(typedWorkspace, "node_modules", "typescript", "lib"), { recursive: true });
+    writeFileSync(join(typedWorkspace, "node_modules", "typescript", "lib", "tsserver.js"), "// project tsserver\n");
+    expect(typescriptServerFallback(link, typedWorkspace)).toBeUndefined();
+
+    const servers = builtinLspServerConfigs({
+      env: {},
+      workspaceRoot: bareWorkspace,
+      resolveCommand: (command) => (command === "typescript-language-server" ? link : undefined),
+    });
+    expect(servers["builtin-typescript"]?.initializationOptions).toEqual({ tsserver: { path: tsserver } });
+    expect(typescriptServerFallback("/nonexistent/typescript-language-server", bareWorkspace)).toBeUndefined();
+
+    // TypeScript 7 (the Go port) ships lib/tsc.js but no tsserver.js: nothing to point at.
+    const sevenPrefix = mkdtempSync(join(tmpdir(), "agenc-lsp-prefix7-"));
+    dirs.push(sevenPrefix);
+    const sevenServer = join(sevenPrefix, "node_modules", "typescript-language-server", "lib");
+    mkdirSync(sevenServer, { recursive: true });
+    writeFileSync(join(sevenServer, "cli.mjs"), "#!/usr/bin/env node\n");
+    mkdirSync(join(sevenPrefix, "node_modules", "typescript", "lib"), { recursive: true });
+    writeFileSync(join(sevenPrefix, "node_modules", "typescript", "lib", "tsc.js"), "// tsc only\n");
+    expect(typescriptServerFallback(join(sevenServer, "cli.mjs"), bareWorkspace)).toBeUndefined();
   });
 });

--- a/runtime/tests/services/lsp/builtinServers.test.ts
+++ b/runtime/tests/services/lsp/builtinServers.test.ts
@@ -1,0 +1,94 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  BUILTIN_LSP_PROFILES,
+  builtinLspServerConfigs,
+  resolveCommandOnPath,
+} from "./builtinServers.js";
+
+describe("built-in language server profiles", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function fakeBin(names: string[]): string {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-lsp-bin-"));
+    dirs.push(dir);
+    for (const name of names) {
+      const path = join(dir, name);
+      writeFileSync(path, "#!/bin/sh\nexit 0\n");
+      chmodSync(path, 0o755);
+    }
+    return dir;
+  }
+
+  test("resolves a bare command against PATH and nothing else", () => {
+    const bin = fakeBin(["typescript-language-server"]);
+    const workspaceBin = fakeBin(["gopls"]);
+    mkdirSync(join(workspaceBin, "node_modules", ".bin"), { recursive: true });
+    const env = { PATH: bin };
+    expect(resolveCommandOnPath("typescript-language-server", env, "linux")).toBe(
+      join(bin, "typescript-language-server"),
+    );
+    expect(resolveCommandOnPath("gopls", env, "linux")).toBeUndefined();
+    expect(resolveCommandOnPath(join(workspaceBin, "gopls"), env, "linux")).toBeUndefined();
+    expect(resolveCommandOnPath("./gopls", env, "linux")).toBeUndefined();
+    expect(resolveCommandOnPath("gopls", { PATH: "" }, "linux")).toBeUndefined();
+  });
+
+  test("ignores a directory entry and a non-executable file with the command's name", () => {
+    const bin = fakeBin([]);
+    mkdirSync(join(bin, "gopls"));
+    writeFileSync(join(bin, "rust-analyzer"), "not executable");
+    chmodSync(join(bin, "rust-analyzer"), 0o644);
+    expect(resolveCommandOnPath("gopls", { PATH: bin }, "linux")).toBeUndefined();
+    expect(resolveCommandOnPath("rust-analyzer", { PATH: bin }, "linux")).toBeUndefined();
+  });
+
+  test("activates only the profiles whose binary exists, with the first known command winning", () => {
+    const found = new Set(["pyright-langserver", "gopls"]);
+    const servers = builtinLspServerConfigs({
+      env: {},
+      resolveCommand: (command) => (found.has(command) ? `/opt/bin/${command}` : undefined),
+    });
+    expect(Object.keys(servers).sort()).toEqual(["builtin-go", "builtin-python"]);
+    expect(servers["builtin-python"]).toMatchObject({
+      command: "/opt/bin/pyright-langserver",
+      args: ["--stdio"],
+      extensionToLanguage: { ".py": "python", ".pyi": "python" },
+    });
+    expect(servers["builtin-go"]?.args).toEqual([]);
+  });
+
+  test("a configured server that claims an extension replaces the matching profile", () => {
+    const servers = builtinLspServerConfigs({
+      env: {},
+      resolveCommand: (command) => `/opt/bin/${command}`,
+      configured: {
+        mine: { command: "/opt/bin/my-ts", extensionToLanguage: { ".TS": "typescript" } },
+      },
+    });
+    expect(servers["builtin-typescript"]).toBeUndefined();
+    expect(Object.keys(servers).sort()).toEqual(["builtin-go", "builtin-python", "builtin-rust"]);
+  });
+
+  test("AGENC_DISABLE_BUILTIN_LSP turns every profile off", () => {
+    expect(
+      builtinLspServerConfigs({ env: { AGENC_DISABLE_BUILTIN_LSP: "1" }, resolveCommand: (c) => `/opt/bin/${c}` }),
+    ).toEqual({});
+  });
+
+  test("every profile names at least one command and one extension", () => {
+    for (const profile of BUILTIN_LSP_PROFILES) {
+      expect(profile.commands.length).toBeGreaterThan(0);
+      expect(Object.keys(profile.extensionToLanguage).length).toBeGreaterThan(0);
+      for (const extension of Object.keys(profile.extensionToLanguage)) {
+        expect(extension.startsWith(".")).toBe(true);
+      }
+    }
+  });
+});

--- a/runtime/tests/services/lsp/editFeedback.test.ts
+++ b/runtime/tests/services/lsp/editFeedback.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  consumePendingDiagnosticsForFile,
+  checkForLSPDiagnostics,
+  registerPendingLSPDiagnostic,
+  resetAllLSPDiagnosticState,
+  waitForFileDiagnostics,
+} from "./LSPDiagnosticRegistry.js";
+import {
+  editFeedbackTimeoutMs,
+  formatEditFeedback,
+} from "./fileNotifications.js";
+
+describe("same-turn edit feedback", () => {
+  afterEach(() => {
+    resetAllLSPDiagnosticState();
+  });
+
+  test("a waiter resolves with the next publication for its file, by path or file URI", async () => {
+    const pending = waitForFileDiagnostics("/work/src/a.ts", 2000);
+    registerPendingLSPDiagnostic({
+      serverName: "ts",
+      files: [{ uri: "file:///work/src/other.ts", diagnostics: [{ message: "not mine", severity: "Error" }] }],
+    });
+    registerPendingLSPDiagnostic({
+      serverName: "ts",
+      files: [{ uri: "file:///work/src/a.ts", diagnostics: [{ message: "Cannot find name 'foo'.", severity: "Error", code: "2304", source: "ts" }] }],
+    });
+    const file = await pending;
+    expect(file?.diagnostics.map((diagnostic) => diagnostic.message)).toEqual(["Cannot find name 'foo'."]);
+  });
+
+  test("a clean publication resolves the waiter with zero diagnostics instead of timing out", async () => {
+    const pending = waitForFileDiagnostics("/work/src/a.ts", 2000);
+    registerPendingLSPDiagnostic({ serverName: "ts", files: [{ uri: "/work/src/a.ts", diagnostics: [] }] });
+    expect((await pending)?.diagnostics).toEqual([]);
+  });
+
+  test("a waiter times out with undefined and leaves no trace", async () => {
+    const started = Date.now();
+    expect(await waitForFileDiagnostics("/work/src/never.ts", 20)).toBeUndefined();
+    expect(Date.now() - started).toBeLessThan(1500);
+    registerPendingLSPDiagnostic({ serverName: "ts", files: [{ uri: "/work/src/never.ts", diagnostics: [{ message: "late", severity: "Error" }] }] });
+    // Nothing waits any more, so the late publication only feeds the attachment path.
+    expect(checkForLSPDiagnostics().flatMap((set) => set.files.flatMap((file) => file.diagnostics.map((d) => d.message)))).toEqual(["late"]);
+  });
+
+  test("consuming a file's diagnostics keeps them out of the next-turn attachment", () => {
+    registerPendingLSPDiagnostic({
+      serverName: "ts",
+      files: [
+        { uri: "file:///work/src/a.ts", diagnostics: [{ message: "shown in the edit result", severity: "Error" }] },
+        { uri: "file:///work/src/b.ts", diagnostics: [{ message: "still pending", severity: "Warning" }] },
+      ],
+    });
+    consumePendingDiagnosticsForFile("/work/src/a.ts");
+    const attached = checkForLSPDiagnostics().flatMap((set) => set.files.flatMap((file) => file.diagnostics.map((d) => d.message)));
+    expect(attached).toEqual(["still pending"]);
+    // Re-publishing the same diagnostic later is a duplicate the registry already delivered.
+    registerPendingLSPDiagnostic({
+      serverName: "ts",
+      files: [{ uri: "file:///work/src/a.ts", diagnostics: [{ message: "shown in the edit result", severity: "Error" }] }],
+    });
+    expect(checkForLSPDiagnostics()).toEqual([]);
+  });
+
+  test("formats errors first, one line each, bounded, with a clean verdict spelled out", () => {
+    const clean = formatEditFeedback("src/a.ts", { uri: "/w/src/a.ts", diagnostics: [] });
+    expect(clean).toBe("\n\nLanguage server: no diagnostics for this file after the edit.");
+    const text = formatEditFeedback("src/a.ts", {
+      uri: "/w/src/a.ts",
+      diagnostics: [
+        { message: "unused variable", severity: "Warning", range: { start: { line: 4, character: 2 }, end: { line: 4, character: 5 } }, source: "ts", code: "6133" },
+        { message: "Cannot find name 'foo'.\nDid you mean 'for'?", severity: "Error", range: { start: { line: 11, character: 4 }, end: { line: 11, character: 7 } }, source: "ts", code: "2304" },
+        ...Array.from({ length: 9 }, (_, index) => ({ message: `hint ${index}`, severity: "Hint" as const })),
+      ],
+    });
+    const lines = text.split("\n");
+    expect(lines[2]).toBe("Language server diagnostics after this edit (1 error, 1 warning, 9 other):");
+    expect(lines[3]).toBe("  src/a.ts:12:5 error ts 2304: Cannot find name 'foo'.");
+    expect(lines[4]).toBe("  src/a.ts:5:3 warning ts 6133: unused variable");
+    expect(lines.at(-1)).toBe("  ... 3 more");
+    expect(lines.length).toBe(3 + 8 + 1);
+  });
+
+  test("the feedback window comes from the environment with sane bounds", () => {
+    expect(editFeedbackTimeoutMs({})).toBe(1500);
+    expect(editFeedbackTimeoutMs({ AGENC_LSP_EDIT_FEEDBACK_MS: "0" })).toBe(0);
+    expect(editFeedbackTimeoutMs({ AGENC_LSP_EDIT_FEEDBACK_MS: "250" })).toBe(250);
+    expect(editFeedbackTimeoutMs({ AGENC_LSP_EDIT_FEEDBACK_MS: "999999" })).toBe(30000);
+    expect(editFeedbackTimeoutMs({ AGENC_LSP_EDIT_FEEDBACK_MS: "nope" })).toBe(1500);
+    expect(editFeedbackTimeoutMs({ AGENC_LSP_EDIT_FEEDBACK_MS: "-5" })).toBe(1500);
+  });
+});

--- a/runtime/tests/tools/system/durable-memory-roots.test.ts
+++ b/runtime/tests/tools/system/durable-memory-roots.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../services/lsp/fileNotifications.js", () => ({
   notifyLspFileChanged: vi.fn(),
+  collectEditFeedback: vi.fn(async () => ""),
 }));
 
 import { getProjectRoot, setProjectRoot } from "../../bootstrap/state.js";

--- a/runtime/tests/tools/system/file-edit-lsp-feedback.test.ts
+++ b/runtime/tests/tools/system/file-edit-lsp-feedback.test.ts
@@ -1,0 +1,197 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { createFileEditTool } from "../../tools/system/file-edit.js";
+import { createFileWriteTool } from "../../tools/system/file-write.js";
+import {
+  _resetLspManagerForTesting,
+  initializeLspServerManager,
+  shutdownLspServerManager,
+  waitForInitialization,
+} from "../../services/lsp/manager.js";
+import { normalizeLspServerConfig } from "../../services/lsp/config.js";
+import { resetAllLSPDiagnosticState } from "../../services/lsp/LSPDiagnosticRegistry.js";
+import type { LSPServerInstance } from "../../services/lsp/LSPServerInstance.js";
+import {
+  clearSessionReadState,
+  recordSessionRead,
+  SESSION_ID_ARG,
+} from "./filesystem.js";
+
+const SESSION_ID = "edit-lsp-feedback-test-session";
+
+/**
+ * A language server that answers every didSave with a scripted publication for
+ * that file, the way tsserver answers with its diagnostics.
+ */
+function fakeServer(publish: (uri: string) => { message: string; severity: number; line: number }[] | undefined) {
+  let state: LSPServerInstance["state"] = "stopped";
+  let handler: ((params: unknown) => void) | undefined;
+  const server = {
+    name: "fake-ts",
+    config: normalizeLspServerConfig("fake-ts", {
+      command: "fake-language-server",
+      extensionToLanguage: { ".ts": "typescript" },
+    }),
+    get state() {
+      return state;
+    },
+    start: async () => {
+      state = "running";
+    },
+    stop: async () => {
+      state = "stopped";
+    },
+    restart: async () => {},
+    isHealthy: () => true,
+    sendRequest: async () => ({}),
+    sendNotification: async (method: string, params: { textDocument?: { uri?: string } }) => {
+      if (method !== "textDocument/didSave") return;
+      const uri = params.textDocument?.uri ?? "";
+      const diagnostics = publish(uri);
+      if (diagnostics === undefined) return;
+      setTimeout(() => {
+        handler?.({
+          uri,
+          diagnostics: diagnostics.map((entry) => ({
+            message: entry.message,
+            severity: entry.severity,
+            range: { start: { line: entry.line, character: 2 }, end: { line: entry.line, character: 5 } },
+            source: "ts",
+            code: 2304,
+          })),
+        });
+      }, 20);
+    },
+    onNotification: (method: string, callback: (params: unknown) => void) => {
+      if (method === "textDocument/publishDiagnostics") handler = callback;
+    },
+    onRequest: () => {},
+  } as unknown as LSPServerInstance;
+  return server;
+}
+
+describe("same-turn language server feedback in the mutation tools", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-edit-lsp-"));
+    _resetLspManagerForTesting();
+    resetAllLSPDiagnosticState();
+  });
+
+  afterEach(async () => {
+    await shutdownLspServerManager();
+    _resetLspManagerForTesting();
+    resetAllLSPDiagnosticState();
+    clearSessionReadState(SESSION_ID, tmpdir());
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function seedRead(file: string, content: string): Promise<void> {
+    await writeFile(file, content);
+    const stats = await stat(file);
+    recordSessionRead(SESSION_ID, file, { content, timestamp: stats.mtimeMs, viewKind: "full" });
+  }
+
+  async function startFakeServer(publish: Parameters<typeof fakeServer>[0]): Promise<void> {
+    const server = fakeServer(publish);
+    initializeLspServerManager({
+      workspaceRoot: root,
+      configSource: () => ({ "fake-ts": server.config }),
+      instanceFactory: () => server,
+    });
+    await waitForInitialization();
+  }
+
+  test("an Edit result carries the server's diagnostics for the edited file", async () => {
+    await startFakeServer((uri) =>
+      uri.endsWith("/a.ts") ? [{ message: "Cannot find name 'c'.", severity: 1, line: 1 }] : [],
+    );
+    const file = join(root, "a.ts");
+    await seedRead(file, "export const a = 1\nexport const b = a + 1\n");
+    const tool = createFileEditTool({ allowedPaths: [root] });
+    const result = await tool.execute({
+      file_path: file,
+      old_string: "a + 1",
+      new_string: "a + c",
+      [SESSION_ID_ARG]: SESSION_ID,
+    });
+    expect(result.isError).toBeUndefined();
+    const content = String(result.content);
+    expect(content).toContain("Language server diagnostics after this edit (1 error):");
+    expect(content).toContain(":2:3 error ts 2304: Cannot find name 'c'.");
+    await expect(readFile(file, "utf8")).resolves.toContain("a + c");
+  });
+
+  test("a clean publication is spelled out, and the file's diagnostics do not repeat as an attachment", async () => {
+    await startFakeServer(() => []);
+    const file = join(root, "clean.ts");
+    await seedRead(file, "export const x = 1\n");
+    const tool = createFileEditTool({ allowedPaths: [root] });
+    const result = await tool.execute({
+      file_path: file,
+      old_string: "1",
+      new_string: "2",
+      [SESSION_ID_ARG]: SESSION_ID,
+    });
+    expect(String(result.content)).toContain("Language server: no diagnostics for this file after the edit.");
+  });
+
+  test("a Write result carries diagnostics too", async () => {
+    await startFakeServer((uri) =>
+      uri === pathToFileURL(join(root, "w.ts")).href ? [{ message: "boom", severity: 2, line: 0 }] : [],
+    );
+    const tool = createFileWriteTool({ allowedPaths: [root] });
+    const result = await tool.execute({
+      file_path: join(root, "w.ts"),
+      content: "export const w = 1\n",
+      [SESSION_ID_ARG]: SESSION_ID,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(String(result.content)).toContain("Language server diagnostics after this edit (1 warning):");
+    expect(String(result.content)).toContain("w.ts:1:3 warning ts 2304: boom");
+  });
+
+  test("a file no server covers returns the plain result without waiting", async () => {
+    await startFakeServer(() => []);
+    const file = join(root, "notes.md");
+    await seedRead(file, "# notes\n");
+    const tool = createFileEditTool({ allowedPaths: [root] });
+    const started = Date.now();
+    const result = await tool.execute({
+      file_path: file,
+      old_string: "notes",
+      new_string: "Notes",
+      [SESSION_ID_ARG]: SESSION_ID,
+    });
+    expect(Date.now() - started).toBeLessThan(1000);
+    expect(String(result.content)).not.toContain("Language server");
+  });
+
+  test("a silent server costs at most the feedback window", async () => {
+    process.env.AGENC_LSP_EDIT_FEEDBACK_MS = "150";
+    try {
+      await startFakeServer(() => undefined);
+      const file = join(root, "slow.ts");
+      await seedRead(file, "export const s = 1\n");
+      const tool = createFileEditTool({ allowedPaths: [root] });
+      const started = Date.now();
+      const result = await tool.execute({
+        file_path: file,
+        old_string: "1",
+        new_string: "2",
+        [SESSION_ID_ARG]: SESSION_ID,
+      });
+      const elapsed = Date.now() - started;
+      expect(elapsed).toBeGreaterThanOrEqual(140);
+      expect(elapsed).toBeLessThan(2000);
+      expect(String(result.content)).not.toContain("Language server");
+    } finally {
+      delete process.env.AGENC_LSP_EDIT_FEEDBACK_MS;
+    }
+  });
+});

--- a/runtime/tests/tools/system/file-edit.test.ts
+++ b/runtime/tests/tools/system/file-edit.test.ts
@@ -32,6 +32,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("../../services/lsp/fileNotifications.js", () => ({
   notifyLspFileChanged: vi.fn(),
+  collectEditFeedback: vi.fn(async () => ""),
 }));
 
 import {
@@ -50,7 +51,10 @@ import {
   SESSION_ID_SIG_ARG,
   signSessionId,
 } from "./filesystem.js";
-import { notifyLspFileChanged } from "../../services/lsp/fileNotifications.js";
+import {
+  collectEditFeedback,
+  notifyLspFileChanged,
+} from "../../services/lsp/fileNotifications.js";
 import { ConfigStore } from "../../config/store.js";
 import {
   clearAllPlanSlugs,
@@ -102,6 +106,7 @@ describe("Edit tool", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "agenc-file-edit-"));
     vi.mocked(notifyLspFileChanged).mockClear();
+    vi.mocked(collectEditFeedback).mockClear();
   });
 
   afterEach(async () => {
@@ -1204,7 +1209,7 @@ describe("Edit tool", () => {
     });
     await expect(readFile(file, "utf8")).resolves.toBe("done\n");
     expect(getSessionReadSnapshot(SESSION_ID, file)?.content).toBe("done\n");
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(file, "done\n");
+    expect(collectEditFeedback).toHaveBeenCalledWith(file, "done\n");
   });
 
   test("MultiEdit empty replacement follows the same newline semantics", async () => {
@@ -1257,11 +1262,11 @@ describe("Edit tool", () => {
       [SESSION_ID_ARG]: SESSION_ID,
     });
 
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(
+    expect(collectEditFeedback).toHaveBeenCalledWith(
       created,
       "export const created = true;\n",
     );
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(
+    expect(collectEditFeedback).toHaveBeenCalledWith(
       empty,
       "export const empty = true;\n",
     );
@@ -1290,11 +1295,11 @@ describe("Edit tool", () => {
       [SESSION_ID_ARG]: SESSION_ID,
     });
 
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(
+    expect(collectEditFeedback).toHaveBeenCalledWith(
       created,
       "export const created = true;\n",
     );
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(
+    expect(collectEditFeedback).toHaveBeenCalledWith(
       empty,
       "export const empty = true;\n",
     );

--- a/runtime/tests/tools/system/file-write-session-guard.ihunt.test.ts
+++ b/runtime/tests/tools/system/file-write-session-guard.ihunt.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("../../services/lsp/fileNotifications.js", () => ({
   notifyLspFileChanged: vi.fn(),
+  collectEditFeedback: vi.fn(async () => ""),
 }));
 
 import { createFileWriteTool } from "./file-write.js";

--- a/runtime/tests/tools/system/file-write.test.ts
+++ b/runtime/tests/tools/system/file-write.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("../../services/lsp/fileNotifications.js", () => ({
   notifyLspFileChanged: vi.fn(),
+  collectEditFeedback: vi.fn(async () => ""),
 }));
 
 import type { ToolResult } from "../types.js";
@@ -33,7 +34,10 @@ import {
   getPlanFilePath,
   setPlanSlug,
 } from "../../planning/plan-files.js";
-import { notifyLspFileChanged } from "../../services/lsp/fileNotifications.js";
+import {
+  collectEditFeedback,
+  notifyLspFileChanged,
+} from "../../services/lsp/fileNotifications.js";
 
 describe("Write tool", () => {
   let root = "";
@@ -42,6 +46,7 @@ describe("Write tool", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "agenc-file-write-"));
     vi.mocked(notifyLspFileChanged).mockClear();
+    vi.mocked(collectEditFeedback).mockClear();
   });
 
   afterEach(async () => {
@@ -75,7 +80,7 @@ describe("Write tool", () => {
       },
     });
     await expect(readFile(target, "utf8")).resolves.toBe("hello\nworld\n");
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(target, "hello\nworld\n");
+    expect(collectEditFeedback).toHaveBeenCalledWith(target, "hello\nworld\n");
     // Post-write snapshot anchors the changed-files attachment producer.
     const snap = getSessionReadSnapshot(sessionId, target);
     expect(snap?.rawContent).toBe("hello\nworld\n");
@@ -149,7 +154,7 @@ describe("Write tool", () => {
       },
     });
     await expect(readFile(target, "utf8")).resolves.toBe("alpha\ngamma\n");
-    expect(notifyLspFileChanged).toHaveBeenCalledWith(target, "alpha\ngamma\n");
+    expect(collectEditFeedback).toHaveBeenCalledWith(target, "alpha\ngamma\n");
   });
 
   test("overwrite staleness check compares rawContent when read content is rendered", async () => {


### PR DESCRIPTION
## Why

Core already has passive language-server feedback: a configured server publishes diagnostics, `LSPDiagnosticRegistry` stores them, and the next model turn receives them as an attachment (`prompts/attachments/lsp-diagnostics.ts`). In practice it never runs, for two reasons this PR removes:

1. No server exists unless the user hand-writes `lsp_servers` in config. Nothing is detected, nothing starts, so the model edits blind.
2. When a server does exist, its verdict arrives one turn late, after the model has moved on. OpenCode's loop is tighter because the edit result itself says whether the file still compiles.

## What changed

- `runtime/src/services/lsp/builtinServers.ts` (new): profiles for `typescript-language-server`, `basedpyright-langserver`/`pyright-langserver`, `gopls` and `rust-analyzer`, activated when the binary is on the user's PATH. **Only PATH is searched.** A server inside the workspace (`node_modules/.bin`, a virtualenv) is code the repository under edit chose, and the agent must not execute it because it opened the folder. A configured server that claims any of the same extensions replaces the profile. `AGENC_DISABLE_BUILTIN_LSP=1` turns the profiles off; `AGENC_DISABLE_LSP` still turns the service off.
- `runtime/src/bin/bootstrap-services.ts`: merges the profiles under the user's `lsp_servers`.
- `runtime/src/services/lsp/LSPDiagnosticRegistry.ts`: `waitForFileDiagnostics(file, timeoutMs, scope)` resolves with the next publication for one file, including an empty one (the server says the file is clean), or `undefined` at the window's end; `consumePendingDiagnosticsForFile` takes a file's diagnostics out of the next-turn attachment and marks them delivered. Waiters are settled on reset.
- `runtime/src/services/lsp/fileNotifications.ts`: `collectEditFeedback(path, content)` notifies the server and waits, bounded by `AGENC_LSP_EDIT_FEEDBACK_MS` (default 1500, max 30000, `0` disables), then renders a compact suffix: errors first, one line each, at most eight, positions 1-based, or "no diagnostics for this file after the edit". A file no server covers returns at once. Nothing here can fail a mutation that already succeeded.
- `runtime/src/tools/system/file-edit.ts` (six success sites: create, Edit, MultiEdit variants) and `file-write.ts`: append the suffix to the result text.
- Tests: `tests/services/lsp/builtinServers.test.ts`, `tests/services/lsp/editFeedback.test.ts`, `tests/tools/system/file-edit-lsp-feedback.test.ts` (new, unmocked: a fake server publishes on `didSave`); `file-edit.test.ts` and `file-write.test.ts` now assert the collector instead of the bare notification.
- Docs: `docs/reference/env.md` (two knobs), `docs/reference/config.md` (`lsp_servers` row).

## Evidence

| check | result |
| --- | --- |
| `tests/services/lsp` + `file-edit.test.ts` + `file-write.test.ts` + the new tool-level test, hermetic runner | 12 files, 144 tests, 0 failed |
| `tsc --noEmit -p runtime/tsconfig.json` | 0 errors (`--preserveSymlinks` in the worktree; the 8 TS2883 messages without it are the symlinked `node_modules`, in files this PR does not touch) |
| real `typescript-language-server` 6.0.0 + TypeScript 5.9.3 from a temp prefix on PATH, driven through the collector from source under the explicit danger broker | broken edit: **432 ms** -> `Language server diagnostics after this edit (1 error, 1 other): src/math.ts:2:14 error typescript 2304: Cannot find name 'c'.` plus the unused-parameter hint; fixed edit: **369 ms** -> `Language server: no diagnostics for this file after the edit.`; server state `running` |

## TypeScript note

`typescript-language-server` 5+ ships no TypeScript: it uses the workspace's `node_modules/typescript` or an explicit `tsserver.path`, and exits during `initialize` otherwise (that is exactly how the first probe failed). The profile now resolves the TypeScript 5 `lib/tsserver.js` installed next to the PATH binary and passes it as `tsserver.path`, only when the workspace has no TypeScript of its own. `typescript@latest` is the Go-based 7.x with no `tsserver.js`; there the fallback stays absent by design and the server reports the missing installation. Unit tests cover both layouts.

## Sandbox note

Spawning a language server is the `lsp` sandbox surface. Outside a session it is refused with `sandbox_surface_uncovered`, which is the correct behaviour and also the reason a bare probe returns nothing. The profiles only matter inside sessions whose broker covers `lsp`; that coverage is reported in this PR's follow-up comment.

## Tests

Each mechanism has a test that fails without it: PATH-only resolution rejects workspace and relative paths; a configured server displaces the matching profile; the waiter resolves by path or file URI, on a clean publication, and times out clean; consumed diagnostics do not reappear as an attachment nor on re-publication; the formatter's ordering, cap and clean verdict; Edit and Write results carry the suffix; an uncovered file does not wait; a silent server costs at most the window.

## Not changed

- The next-turn attachment path stays as the fallback for diagnostics that arrive after the window or for other files.
- No server is ever taken from the workspace.
- `LSP` model-facing tool, `notifyLspFileChanged` (still exported, still used internally).

## Counterparts

#2139 (the eval that will measure whether this shortens the edit loop), #2022 and the harness review notes on the tool loop.
