### PR TITLE
fix(app-server): keep the session alive after a provider turn error

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -7714,9 +7714,19 @@ export function phaseEventToProgressEvent(
         };
       }
       if (event.stopReason === "error") {
+        // A turn that errored, most often a provider call the network dropped
+        // after dispatch, is a per-turn outcome too. Mapping it to run_error
+        // flipped the agent to status=error and every later prompt was
+        // refused with "no longer running": one connection error ended a
+        // session whose earlier turns had all settled. The turn ends with the
+        // failure spelled out; the agent stays idle and takes the next prompt.
+        const reason = event.error?.message?.trim() || "turn errored";
+        const sentence = /[.!?]$/u.test(reason) ? reason : `${reason}.`;
         return {
-          kind: "run_error",
-          error: event.error?.message ?? "turn errored",
+          kind: "turn_complete",
+          turnId,
+          toolCallCount: 0,
+          finalMessage: `Turn failed: ${sentence} Send a new prompt to retry.`,
         };
       }
       // Bounded stops — the backstop, a turn cap, the cost cap, a

--- a/runtime/tests/app-server/background-agent-runner.stop-mapping.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.stop-mapping.test.ts
@@ -72,9 +72,24 @@ describe("stop-reason mapping decides turn versus run scope", () => {
     );
   });
 
-  test("a genuine error still ends the run", () => {
-    const mapped = phaseEventToProgressEvent(turnComplete("error"));
-    expect(mapped?.kind).toBe("run_error");
+  test("a turn error ends the turn with the failure spelled out, never the run", () => {
+    const mapped = phaseEventToProgressEvent({
+      type: "turn_complete",
+      content: "",
+      usage,
+      stopReason: "error",
+      error: new Error("grok error: Connection error."),
+      turnId: "turn-1",
+    } as never);
+    expect(mapped?.kind).toBe("turn_complete");
+    expect((mapped as { finalMessage?: string }).finalMessage).toBe(
+      "Turn failed: grok error: Connection error. Send a new prompt to retry.",
+    );
+    const bare = phaseEventToProgressEvent(turnComplete("error"));
+    expect(bare?.kind).toBe("turn_complete");
+    expect((bare as { finalMessage?: string }).finalMessage).toBe(
+      "Turn failed: turn errored. Send a new prompt to retry.",
+    );
   });
 
   test("completed stays a plain turn completion", () => {


### PR DESCRIPTION
Closes #2141

## Why

In the first real eval run of the 15-step session task (grok-4.6, xAI), step 7 hit a transient provider failure (`grok error: Connection error`). The turn ended with `stopReason: "error"`. `phaseEventToProgressEvent` mapped that to `run_error`, the daemon run moved to `status: "error"`, and every later prompt on the session failed with `agent is no longer running`. Steps 8 to 15 never ran. A single failed model call should cost one turn, not the session: the run is still healthy, the rollout is intact, and the next prompt can retry.

## What changed

- `runtime/src/app-server/background-agent-runner.ts`: a `turn_complete` with `stopReason === "error"` is now reported as `turn_complete` with `finalMessage: "Turn failed: <reason>. Send a new prompt to retry."` (the reason keeps its own terminal punctuation when present, otherwise a period is added) and `toolCallCount: 0`, the same shape as the other bounded per-turn stops (`max_turns`, `max_budget_usd`, `no_progress`, `compact_failed`, `editor_request_failed`). The run stays `running`.
- `runtime/tests/app-server/background-agent-runner.stop-mapping.test.ts`: the "genuine error still ends the run" case is replaced by two cases asserting the `turn_complete` shape, with and without an error message.

`run_error` is unchanged for real run-level failures (startup, invalid session, runner crash), which `run-agent.ts` emits directly.

## Evidence

Rollout of the real eval session (isolated `AGENC_HOME`, workspace `agenc-eval-asteroid-drift-15-*`): step 7 recorded `execution_admission` with `provider_call_failed_after_dispatch`, then `turn_complete` with `stopReason: "error"` and `error.message: "grok error: Connection error"`. The daemon log shows the run status flip to `error`; the eval runner then received `agent is no longer running` for steps 8 to 15.

## Tests

- `tests/app-server/background-agent-runner.stop-mapping.test.ts`: 6 passed.
- `tests/agents/run-agent.test.ts`: 78 passed on a clean rerun (one earlier 30 s timeout of the worktree-baseline test happened while an eval run was saturating the machine, and it passes alone in 1.7 s on both this branch and main).

## Not changed

- No SDK-visible failure signal yet: the client only sees the final message text. A typed turn-failure event should build on #2037 (FalconOrtiz) rather than add a parallel channel here.
- No retry inside the daemon. The user or the driving harness decides whether to resend.

## Counterparts

- Found by the session eval lane in #2139; that PR flags an empty turn after a provider failure as `provider_call_failed` so the step is not a false pass.