### PR TITLE
fix(memory): persist the extraction cadence so a restart continues it

### DIFF
--- a/runtime/src/memory/extraction-triggers.ts
+++ b/runtime/src/memory/extraction-triggers.ts
@@ -125,11 +125,11 @@ function resolveMinEligibleTurns(value: number | undefined): number {
 /**
  * Whether to hold this extraction back for the cadence.
  *
- * The counter is process-local: it lives in the in-process lane map, so a
- * daemon restart begins the wait again while the conversation it is pacing
- * stays on disk. That gap is tracked separately; the cadence state belongs in
- * persisted session state, and until it is there a restart costs at most one
- * further cadence before memory is written again.
+ * The counter lives in the extraction service's lane, which persists it as
+ * the session's memory-extraction slot after every decision and seeds a new
+ * lane from that slot (see services/extractMemories). A daemon restart
+ * therefore continues the wait where the previous process left it instead of
+ * beginning it again while the conversation it paces stays on disk.
  *
  * An earlier version tried to close that gap by letting the first decision in
  * a process read the unprocessed backlog instead of the counter, on the theory

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -7,6 +7,10 @@
  *     is the count of model-visible messages processed. If compaction shrinks
  *     the visible history, the next extraction falls back to the retained
  *     visible messages instead of permanently disabling extraction.
+ *   - The eligible-turn cadence and that cursor are persisted per (session,
+ *     memory root) as the session's memory-extraction slot and seeded back
+ *     into a new lane, so a daemon restart continues the wait instead of
+ *     beginning it again.
  *   - Child tool access is enforced by a `ChildToolPolicy` layered inside
  *     `run-agent.ts`, not by the older `canUseTool` hook, and the child only
  *     ever sees the read/write file tools through `toolAllowlist`.
@@ -47,6 +51,11 @@ import {
   type MemoryExtractionTriggerState,
 } from "../../memory/extraction-triggers.js";
 import {
+  persistMemoryExtractionState,
+  readMemoryExtractionState,
+  type SessionMemoryExtractionState,
+} from "../../session/memory-extraction-state.js";
+import {
   formatMemoryManifest,
   scanForSecrets,
   scanMemoryFiles,
@@ -82,7 +91,8 @@ const MAX_EXTRACTION_LANES = 256;
 type ExtractionWarningCause =
   | "memory_extraction_skipped"
   | "memory_extraction_failed"
-  | "memory_extraction_denied_read";
+  | "memory_extraction_denied_read"
+  | "memory_extraction_state_not_persisted";
 
 /**
  * Record why an extraction run stopped. Warning causes outside the TUI's
@@ -173,6 +183,10 @@ interface ExtractionLane {
   inProgress: boolean;
   lastAccessedAt: number;
   pendingContext: QueuedExtraction | undefined;
+  /** The persisted cadence was read once, before the lane's first decision. */
+  restored: boolean;
+  /** Last cadence written for this lane, so unchanged state is not rewritten. */
+  persisted: SessionMemoryExtractionState | undefined;
 }
 
 interface ChildWriteTracker {
@@ -541,6 +555,8 @@ export function initExtractMemories(
       inProgress: false,
       lastAccessedAt: Date.now(),
       pendingContext: undefined,
+      restored: false,
+      persisted: undefined,
     };
     lanes.set(key, created);
     return created;
@@ -554,6 +570,65 @@ export function initExtractMemories(
     for (const [key] of idleEntries) {
       if (lanes.size <= MAX_EXTRACTION_LANES) return;
       lanes.delete(key);
+    }
+  }
+
+  /**
+   * Seed a new lane from the session's persisted cadence before its first
+   * decision. The value is the process-local mirror that persistLane keeps
+   * and that the resume path fills from the rollout; a session with nothing
+   * persisted, or a test double without session state, starts at zero as
+   * before.
+   */
+  async function restoreLane(
+    lane: ExtractionLane,
+    session: Session,
+    memoryDir: string,
+  ): Promise<void> {
+    if (lane.restored) return;
+    lane.restored = true;
+    const persisted = await readMemoryExtractionState(
+      session,
+      memoryRoot(memoryDir),
+    );
+    if (persisted === undefined) return;
+    lane.trigger.processedVisibleCount = persisted.processedVisibleCount;
+    lane.trigger.turnsSinceLastExtraction = persisted.turnsSinceLastExtraction;
+    lane.persisted = persisted;
+  }
+
+  /**
+   * Write the lane's cadence after a decision changed it. Writes go to the
+   * session state mirror and the rollout; a failure is reported and costs at
+   * most one further cadence after a restart, never the turn.
+   */
+  async function persistLane(
+    lane: ExtractionLane,
+    session: Session,
+    memoryDir: string,
+  ): Promise<void> {
+    const next: SessionMemoryExtractionState = {
+      memoryRoot: memoryRoot(memoryDir),
+      processedVisibleCount: lane.trigger.processedVisibleCount,
+      turnsSinceLastExtraction: lane.trigger.turnsSinceLastExtraction,
+    };
+    const last = lane.persisted;
+    if (
+      last !== undefined &&
+      last.processedVisibleCount === next.processedVisibleCount &&
+      last.turnsSinceLastExtraction === next.turnsSinceLastExtraction
+    ) {
+      return;
+    }
+    try {
+      await persistMemoryExtractionState(session, next);
+      lane.persisted = next;
+    } catch (error) {
+      emitExtractionWarning(
+        session,
+        "memory_extraction_state_not_persisted",
+        `cadence state not written; a restart may wait a further cadence: ${errorText(error)}`,
+      );
     }
   }
 
@@ -736,6 +811,10 @@ export function initExtractMemories(
     lane.inProgress = true;
     try {
       try {
+        // A lane created after a restart, or after the lane map pruned it,
+        // continues from the persisted cadence. This runs under the
+        // in-progress guard so a concurrent request queues behind it.
+        await restoreLane(lane, queued.context.session, memoryDir);
         await runExtraction(queued, memoryDir, lane, false, readOnlyMemoryRoots);
       } catch (error) {
         // Best effort: extraction failures must never break the user turn,
@@ -746,6 +825,7 @@ export function initExtractMemories(
           errorText(error),
         );
       }
+      await persistLane(lane, queued.context.session, memoryDir);
       while (lane.pendingContext) {
         const trailing = lane.pendingContext;
         lane.pendingContext = undefined;
@@ -758,6 +838,7 @@ export function initExtractMemories(
             `trailing run: ${errorText(error)}`,
           );
         }
+        await persistLane(lane, trailing.context.session, memoryDir);
       }
     } finally {
       lane.inProgress = false;

--- a/runtime/src/session/agent-task-lifecycle.ts
+++ b/runtime/src/session/agent-task-lifecycle.ts
@@ -31,7 +31,11 @@
  */
 
 import type { Session } from "./session.js";
-import type { RolloutItem } from "./rollout-item.js";
+import {
+  sessionStateUpdateAddressesSlot,
+  type RolloutItem,
+} from "./rollout-item.js";
+import { restorePersistedMemoryExtractionState } from "./memory-extraction-state.js";
 import type { TokenCountEvent } from "./event-log.js";
 
 export type { RolloutItem, SessionStateUpdate } from "./rollout-item.js";
@@ -201,20 +205,23 @@ export async function maybePrewarmAgentTaskRegistration(
 /**
  * AgenC-specific. Walks rollout items in reverse and returns the
  * `SessionAgentTask | undefined` from the most recent `SessionState`
- * update, wrapped in a `{ value }` envelope so callers can distinguish
- * "no SessionState ever persisted" (returns `undefined`) from
- * "SessionState persisted with the slot explicitly cleared" (returns
- * `{ value: undefined }`). Upstream agenc runtime does not persist an
- * agent-task slot on rollout, so there is no equivalent walker.
+ * update that addresses the agent-task slot, wrapped in a `{ value }`
+ * envelope so callers can distinguish "no SessionState ever persisted"
+ * (returns `undefined`) from "SessionState persisted with the slot
+ * explicitly cleared" (returns `{ value: undefined }`). Items that only
+ * carry another slot (the memory-extraction cadence) are skipped: reading
+ * their missing key as a clear would drop the persisted task on every
+ * resume. Upstream agenc runtime does not persist an agent-task slot on
+ * rollout, so there is no equivalent walker.
  */
 export function latestPersistedAgentTask(
   rolloutItems: ReadonlyArray<RolloutItem>,
 ): { value: SessionAgentTask | undefined } | undefined {
   for (let i = rolloutItems.length - 1; i >= 0; i -= 1) {
     const item = rolloutItems[i];
-    if (item && item.type === "session_state") {
-      return { value: item.payload.agentTask };
-    }
+    if (!item || item.type !== "session_state") continue;
+    if (!sessionStateUpdateAddressesSlot(item.payload, "agentTask")) continue;
+    return { value: item.payload.agentTask };
   }
   return undefined;
 }
@@ -280,7 +287,7 @@ export function lastTokenInfoFromRollout(
  * function at lines 1151-1236; the Resumed arm runs roughly
  * 1172-1209).
  *
- * Three resume-time behaviors are wired here so the AgenC bootstrap
+ * The resume-time behaviors are wired here so the AgenC bootstrap
  * has a single entrypoint for them:
  *
  *   1. **Agent-task restore.** Delegates to `restorePersistedAgentTask`.
@@ -288,6 +295,10 @@ export function lastTokenInfoFromRollout(
  *      not persist the agent task to the rollout. Runs first so the
  *      cached task is consistent with the post-replay session identity
  *      before any model-dependent state mutations.
+ *   1b. **Memory-extraction cadence restore.** Delegates to
+ *      `restorePersistedMemoryExtractionState`. AgenC-specific: seeds the
+ *      extraction service's eligible-turn count and processed-message
+ *      cursor per memory root so a restart does not begin the wait again.
  *   2. **Model-change warning.** agenc runtime emits
  *      `EventMsg::Warning(WarningEvent { ... })` at
  *      `session/mod.rs:1185-1196` when the rollout's last
@@ -318,6 +329,12 @@ export async function recordInitialHistoryOnResume(
   // run first so the cached task lines up with the restored session
   // identity before any model-dependent state mutations.
   await restorePersistedAgentTask(session, rolloutItems);
+
+  // 1b. Memory-extraction cadence restore. AgenC-specific: the extraction
+  // service seeds its per-root lane from session state, so a restart
+  // continues the eligible-turn count and the processed-message cursor
+  // instead of starting both over.
+  await restorePersistedMemoryExtractionState(session, rolloutItems);
 
   // 2. Model-change warning. Matches agenc runtime's sentence at
   // session/mod.rs:1189-1192 with "agenc runtime" → "AgenC".
@@ -353,7 +370,9 @@ export async function recordInitialHistoryOnResume(
 /**
  * AgenC-specific. Persist a `SessionState` rollout item carrying the
  * current agent-task cache value (or an explicit clear when `agentTask`
- * is null). Upstream agenc runtime does not persist this slot.
+ * is null). The item carries this slot only; the memory-extraction slot
+ * has its own writer, and each walker skips the other's items. Upstream
+ * agenc runtime does not persist this slot.
  */
 async function persistAgentTaskUpdate(
   session: Session,

--- a/runtime/src/session/event-log-reducer.ts
+++ b/runtime/src/session/event-log-reducer.ts
@@ -24,7 +24,10 @@ import type {
   ResponseItem,
   RolloutItem,
 } from "./rollout-item.js";
-import { isKnownRolloutType } from "./rollout-item.js";
+import {
+  isKnownRolloutType,
+  sessionStateUpdateAddressesSlot,
+} from "./rollout-item.js";
 import { agentInvocationGroupStartIndex } from "../contracts/agent-invocation-envelope.js";
 import {
   isUserTurnBoundary,
@@ -56,7 +59,7 @@ export interface ReducedSessionState {
   history: ResponseItem[];
   /** Most-recent TurnContextItem emitted (turn baseline). */
   lastTurnContext?: TurnContextItem;
-  /** Cached agent task from the most recent session_state update. */
+  /** Cached agent task from the newest session_state update that addressed that slot. */
   agentTask?: unknown;
   /** Most-recent compaction boundary metadata. */
   lastCompaction?: CompactedItem;
@@ -135,6 +138,12 @@ export function reduce(
       };
 
     case "session_state":
+      // Writers persist one slot per item. An item that carries another
+      // slot (the memory-extraction cadence) says nothing about the agent
+      // task, so it must not read as a clear.
+      if (!sessionStateUpdateAddressesSlot(item.payload, "agentTask")) {
+        return { state, report: {} };
+      }
       return {
         state: { ...state, agentTask: item.payload.agentTask },
         report: {},

--- a/runtime/src/session/memory-extraction-state.ts
+++ b/runtime/src/session/memory-extraction-state.ts
@@ -1,0 +1,160 @@
+/**
+ * Memory-extraction cadence slot of the persisted session state.
+ *
+ * The extraction service (services/extractMemories) paces its child by
+ * eligible turns and remembers how far into the model-visible history it has
+ * read. Both counters used to live only in the service's in-process lane map,
+ * so a daemon restart began the wait again while the conversation it paced
+ * stayed on disk, and a lane the map pruned lost its place the same way.
+ * This module gives the counters a durable home next to the agent-task slot
+ * in agent-task-lifecycle.ts: the service persists them per memory root as a
+ * `session_state` rollout item, the resume path restores the newest item per
+ * root into session state, and the service seeds a new lane from there.
+ *
+ * Writers persist one slot per `session_state` item. The walker here reads
+ * only items that address the memory-extraction slot, and the agent-task
+ * walker skips these items (sessionStateUpdateAddressesSlot), so neither
+ * writer can clear the other's slot.
+ *
+ * @module
+ */
+
+import type { Session } from "./session.js";
+import {
+  sessionStateUpdateAddressesSlot,
+  type RolloutItem,
+  type SessionMemoryExtractionState,
+} from "./rollout-item.js";
+
+export type { SessionMemoryExtractionState } from "./rollout-item.js";
+
+/**
+ * Augment SessionState with the extraction slot, keyed by normalized memory
+ * root. This module owns the slot the way agent-task-lifecycle.ts owns
+ * `agentTask`.
+ */
+interface SessionStateWithMemoryExtraction {
+  memoryExtraction?: Readonly<Record<string, SessionMemoryExtractionState>>;
+}
+
+/** Test doubles for the extraction service may carry no state lock. */
+function stateLock(session: Session): Session["state"] | undefined {
+  const lock = (session as Partial<Pick<Session, "state">>).state;
+  return lock !== undefined && typeof lock.with === "function"
+    ? lock
+    : undefined;
+}
+
+function isCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+/** Shape check for a slot read back from disk; malformed slots are skipped. */
+export function isSessionMemoryExtractionState(
+  value: unknown,
+): value is SessionMemoryExtractionState {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.memoryRoot === "string" &&
+    record.memoryRoot.length > 0 &&
+    isCount(record.processedVisibleCount) &&
+    isCount(record.turnsSinceLastExtraction)
+  );
+}
+
+/**
+ * Newest persisted cadence per memory root. Walks the rollout backwards and
+ * keeps the first item met for each root, the same "latest wins" reading the
+ * agent-task walker applies to its slot.
+ */
+export function latestPersistedMemoryExtractionState(
+  rolloutItems: ReadonlyArray<RolloutItem>,
+): ReadonlyMap<string, SessionMemoryExtractionState> {
+  const latest = new Map<string, SessionMemoryExtractionState>();
+  for (let i = rolloutItems.length - 1; i >= 0; i -= 1) {
+    const item = rolloutItems[i];
+    if (!item || item.type !== "session_state") continue;
+    if (!sessionStateUpdateAddressesSlot(item.payload, "memoryExtraction")) {
+      continue;
+    }
+    const slot = item.payload.memoryExtraction;
+    if (!isSessionMemoryExtractionState(slot) || latest.has(slot.memoryRoot)) {
+      continue;
+    }
+    latest.set(slot.memoryRoot, {
+      memoryRoot: slot.memoryRoot,
+      processedVisibleCount: slot.processedVisibleCount,
+      turnsSinceLastExtraction: slot.turnsSinceLastExtraction,
+    });
+  }
+  return latest;
+}
+
+/**
+ * Resume step: seed session state with the newest persisted cadence per
+ * memory root so the extraction service continues the count. A rollout
+ * without the slot leaves the state untouched and the service starts at zero
+ * as it always did.
+ */
+export async function restorePersistedMemoryExtractionState(
+  session: Session,
+  rolloutItems: ReadonlyArray<RolloutItem>,
+): Promise<void> {
+  const latest = latestPersistedMemoryExtractionState(rolloutItems);
+  if (latest.size === 0) return;
+  const lock = stateLock(session);
+  if (lock === undefined) return;
+  await lock.with((s) => {
+    const state = s as unknown as SessionStateWithMemoryExtraction;
+    state.memoryExtraction = {
+      ...(state.memoryExtraction ?? {}),
+      ...Object.fromEntries(latest),
+    };
+  });
+}
+
+/** The cadence a lane for `memoryRoot` continues from, if one is known. */
+export async function readMemoryExtractionState(
+  session: Session,
+  memoryRoot: string,
+): Promise<SessionMemoryExtractionState | undefined> {
+  const lock = stateLock(session);
+  if (lock === undefined) return undefined;
+  return lock.with(
+    (s) =>
+      (s as unknown as SessionStateWithMemoryExtraction).memoryExtraction?.[
+        memoryRoot
+      ],
+  );
+}
+
+/**
+ * Record a cadence change: the session state mirror first, so a lane
+ * re-created in this process continues from it, then the rollout, so the
+ * next process does. Sessions without a rollout recorder keep the mirror
+ * only.
+ */
+export async function persistMemoryExtractionState(
+  session: Session,
+  state: SessionMemoryExtractionState,
+): Promise<void> {
+  const lock = stateLock(session);
+  if (lock !== undefined) {
+    await lock.with((s) => {
+      const current = s as unknown as SessionStateWithMemoryExtraction;
+      current.memoryExtraction = {
+        ...(current.memoryExtraction ?? {}),
+        [state.memoryRoot]: state,
+      };
+    });
+  }
+  const rollout = (session as Partial<Pick<Session, "services">>).services
+    ?.rollout;
+  if (rollout === undefined) return;
+  const item: RolloutItem = {
+    type: "session_state",
+    payload: { memoryExtraction: state },
+  };
+  await rollout.record(item);
+}

--- a/runtime/src/session/rollout-item.ts
+++ b/runtime/src/session/rollout-item.ts
@@ -40,9 +40,55 @@ import {
 // Per-variant payloads
 // ─────────────────────────────────────────────────────────────────────
 
-/** agenc runtime `SessionStateUpdate` — session-scoped mutable slots. */
+/**
+ * Memory-extraction cadence for one memory root of a session. The extraction
+ * service paces its child by eligible turns and remembers how far into the
+ * model-visible history it has read. Both counters used to live only in the
+ * service's in-process lane map, so a daemon restart began the wait again
+ * while the conversation it paced stayed on disk. The service writes this
+ * slot after every cadence decision and the resume path seeds a new lane from
+ * the newest item per memory root.
+ */
+export interface SessionMemoryExtractionState {
+  /** Normalized memory directory the counters belong to. */
+  readonly memoryRoot: string;
+  /** Model-visible messages already offered to the extraction child. */
+  readonly processedVisibleCount: number;
+  /** Eligible turns since the last run, compared against minEligibleTurns. */
+  readonly turnsSinceLastExtraction: number;
+}
+
+/**
+ * agenc runtime `SessionStateUpdate`: session-scoped mutable slots.
+ *
+ * Every writer persists one slot per item. A walker restoring one slot must
+ * therefore skip the items another writer produced instead of reading its
+ * own missing key as an explicit clear; see sessionStateUpdateAddressesSlot.
+ */
 export interface SessionStateUpdate {
   readonly agentTask?: SessionAgentTask;
+  readonly memoryExtraction?: SessionMemoryExtractionState;
+}
+
+export type SessionStateSlot = keyof SessionStateUpdate;
+
+/**
+ * Whether a persisted `session_state` payload addresses `slot`.
+ *
+ * A key that is present addresses its slot, cleared or not. An explicit clear
+ * is written as `undefined`, which JSON.stringify drops, so after a round trip
+ * a cleared agent task is a payload with no keys at all. That empty payload
+ * is still read as the agent-task clear, because the agent task is the only
+ * slot that has ever been cleared this way. A payload carrying some other
+ * slot was written by that slot's writer and says nothing about this one.
+ */
+export function sessionStateUpdateAddressesSlot(
+  payload: SessionStateUpdate,
+  slot: SessionStateSlot,
+): boolean {
+  if (typeof payload !== "object" || payload === null) return false;
+  if (Object.hasOwn(payload, slot)) return true;
+  return slot === "agentTask" && Object.keys(payload).length === 0;
 }
 
 export type {

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -249,6 +249,12 @@ const isSessionAgentTask = objectShape({
   registeredAt: isString,
 });
 
+const isSessionMemoryExtractionState = objectShape({
+  memoryRoot: isString,
+  processedVisibleCount: isNonNegativeInteger,
+  turnsSinceLastExtraction: isNonNegativeInteger,
+});
+
 const isFileSystemSandboxPolicy = objectShape({
   allowWrite: isStringArray,
   denyWrite: isStringArray,
@@ -1442,7 +1448,13 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
 
 const ROLLOUT_PAYLOAD_VALIDATORS = defineRolloutPayloadValidators({
   session_meta: EVENT_PAYLOAD_VALIDATORS.session_meta,
-  session_state: objectShape({}, { agentTask: isSessionAgentTask }),
+  session_state: objectShape(
+    {},
+    {
+      agentTask: isSessionAgentTask,
+      memoryExtraction: isSessionMemoryExtractionState,
+    },
+  ),
   response_item: isResponseItem,
   compacted: objectShape(
     { message: isString },

--- a/runtime/tests/services/extractMemories/extractMemories.test.ts
+++ b/runtime/tests/services/extractMemories/extractMemories.test.ts
@@ -21,6 +21,9 @@ import {
 import { formatMemoryManifest, scanMemoryFiles } from "../../memory/index.js";
 import { resolveAgentRuntimeOptions } from "../../session/runtime-options.js";
 import { createControlledPromise } from "../../helpers/controlled-async.js";
+import { AsyncLock } from "../../utils/async-lock.js";
+import type { RolloutItem } from "../../session/rollout-item.js";
+import { recordInitialHistoryOnResume } from "../../session/agent-task-lifecycle.js";
 
 vi.mock("bun:bundle", () => ({ feature: () => false }));
 vi.mock("../../tools.js", () => ({}));
@@ -1096,5 +1099,229 @@ describe("memory manifest scan", () => {
     expect(manifest).toContain("Use terse responses");
     expect(manifest).not.toContain("MEMORY.md");
     expect(manifest).not.toContain("secret.md");
+  });
+});
+
+describe("extraction cadence across a daemon restart", () => {
+  let root: string;
+  let memoryDir: string;
+  const cadenceMessages: LLMMessage[] = [
+    { role: "user", content: "remember the cadence" },
+    { role: "assistant", content: "ok" },
+  ];
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-extract-memory-restart-"));
+    memoryDir = join(root, "memory");
+    await mkdir(memoryDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  type Warning = { cause: string; message: string };
+
+  /** A session whose state lock and rollout recorder outlive the process. */
+  function durableSession(opts: {
+    readonly conversationId: string;
+    readonly rollout: RolloutItem[];
+    readonly warnings?: Warning[];
+    readonly record?: (item: RolloutItem) => Promise<void>;
+  }): Session {
+    let subId = 0;
+    return {
+      conversationId: opts.conversationId,
+      services: {
+        runtimeOptions: defaultRuntimeOptions,
+        rollout: {
+          record: async (item: unknown) => {
+            if (opts.record) await opts.record(item as RolloutItem);
+            opts.rollout.push(item as RolloutItem);
+          },
+        },
+      },
+      state: new AsyncLock<Record<string, unknown>>({}),
+      nextInternalSubId: () => String(subId++),
+      emit: (event: { msg: { type: string; payload: unknown } }) => {
+        if (event.msg.type === "warning") {
+          opts.warnings?.push(event.msg.payload as Warning);
+        }
+      },
+    } as unknown as Session;
+  }
+
+  /**
+   * The daemon restarts: the session object is rebuilt and resumed from the
+   * rollout the previous process wrote (the JSONL round trip drops undefined
+   * keys), and the caller starts a fresh extraction service.
+   */
+  async function resumedSession(opts: {
+    readonly conversationId: string;
+    readonly rollout: RolloutItem[];
+    readonly warnings?: Warning[];
+  }): Promise<Session> {
+    const session = durableSession(opts);
+    const replayed = opts.rollout.map(
+      (item) => JSON.parse(JSON.stringify(item)) as RolloutItem,
+    );
+    await recordInitialHistoryOnResume(session, replayed, {
+      currentModel: "test-model",
+    });
+    return session;
+  }
+
+  function startExtractionService(
+    runChild: NonNullable<Parameters<typeof initExtractMemories>[0]["runChild"]>,
+    minEligibleTurns?: number,
+  ): void {
+    initExtractMemories({
+      env: {},
+      ...(minEligibleTurns !== undefined ? { minEligibleTurns } : {}),
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+      runChild,
+    });
+  }
+
+  function persistedCadences(rollout: readonly RolloutItem[]) {
+    return rollout.map((item) =>
+      item.type === "session_state" ? item.payload.memoryExtraction : item.type,
+    );
+  }
+
+  it("a restart between the second and third eligible turns still extracts on the third", async () => {
+    const rollout: RolloutItem[] = [];
+    const runChild = vi.fn(async () => ({ outcome: "completed" as const }));
+    const firstWarnings: Warning[] = [];
+    const first = durableSession({
+      conversationId: "conv-restart",
+      rollout,
+      warnings: firstWarnings,
+    });
+    startExtractionService(runChild);
+    for (let turn = 0; turn < 2; turn += 1) {
+      await executeExtractMemories(
+        extractionContext({ cwd: root, messages: cadenceMessages, session: first }),
+      );
+    }
+    expect(runChild).not.toHaveBeenCalled();
+    expect(firstWarnings.map((warning) => warning.message)).toEqual([
+      expect.stringContaining("deferred by eligible-turn cadence (1/3"),
+      expect.stringContaining("deferred by eligible-turn cadence (2/3"),
+    ]);
+    expect(persistedCadences(rollout)).toEqual([
+      { memoryRoot: memoryDir, processedVisibleCount: 0, turnsSinceLastExtraction: 1 },
+      { memoryRoot: memoryDir, processedVisibleCount: 0, turnsSinceLastExtraction: 2 },
+    ]);
+
+    const secondWarnings: Warning[] = [];
+    const second = await resumedSession({
+      conversationId: "conv-restart",
+      rollout,
+      warnings: secondWarnings,
+    });
+    startExtractionService(runChild);
+    await executeExtractMemories(
+      extractionContext({ cwd: root, messages: cadenceMessages, session: second }),
+    );
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(secondWarnings).toEqual([]);
+    expect(persistedCadences(rollout).at(-1)).toEqual({
+      memoryRoot: memoryDir,
+      processedVisibleCount: 2,
+      turnsSinceLastExtraction: 0,
+    });
+  });
+
+  it("does not offer the child history the previous process already extracted", async () => {
+    const rollout: RolloutItem[] = [];
+    const runChild = vi.fn(async () => ({ outcome: "completed" as const }));
+    const first = durableSession({ conversationId: "conv-cursor", rollout });
+    startExtractionService(runChild, 1);
+    await executeExtractMemories(
+      extractionContext({ cwd: root, messages: cadenceMessages, session: first }),
+    );
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(runChild.mock.calls[0]![0].prompt).toContain("~2 model-visible");
+
+    const second = await resumedSession({ conversationId: "conv-cursor", rollout });
+    startExtractionService(runChild, 1);
+    await executeExtractMemories(
+      extractionContext({
+        cwd: root,
+        messages: [
+          ...cadenceMessages,
+          { role: "user", content: "one more durable fact" },
+        ],
+        session: second,
+      }),
+    );
+
+    expect(runChild).toHaveBeenCalledTimes(2);
+    expect(runChild.mock.calls[1]![0].prompt).toContain("~1 model-visible");
+  });
+
+  it("waits the full cadence for a session with nothing persisted, as before", async () => {
+    const runChild = vi.fn(async () => ({ outcome: "completed" as const }));
+    const warnings: Warning[] = [];
+    const session = await resumedSession({
+      conversationId: "conv-fresh",
+      rollout: [],
+      warnings,
+    });
+    startExtractionService(runChild);
+    await executeExtractMemories(
+      extractionContext({ cwd: root, messages: cadenceMessages, session }),
+    );
+
+    expect(runChild).not.toHaveBeenCalled();
+    expect(warnings.map((warning) => warning.message)).toEqual([
+      expect.stringContaining("deferred by eligible-turn cadence (1/3"),
+    ]);
+  });
+
+  it("writes the cadence only when a decision changed it", async () => {
+    const rollout: RolloutItem[] = [];
+    const runChild = vi.fn(async () => ({ outcome: "completed" as const }));
+    const session = durableSession({ conversationId: "conv-quiet", rollout });
+    startExtractionService(runChild, 1);
+    await executeExtractMemories(
+      extractionContext({ cwd: root, messages: cadenceMessages, session }),
+    );
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(rollout).toHaveLength(1);
+
+    // The same history again: no new model-visible messages, nothing to write.
+    await executeExtractMemories(
+      extractionContext({ cwd: root, messages: cadenceMessages, session }),
+    );
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(rollout).toHaveLength(1);
+  });
+
+  it("reports a cadence write failure without failing the extraction", async () => {
+    const runChild = vi.fn(async () => ({ outcome: "completed" as const }));
+    const warnings: Warning[] = [];
+    const session = durableSession({
+      conversationId: "conv-broken-rollout",
+      rollout: [],
+      warnings,
+      record: async () => {
+        throw new Error("disk full");
+      },
+    });
+    startExtractionService(runChild, 1);
+    await executeExtractMemories(
+      extractionContext({ cwd: root, messages: cadenceMessages, session }),
+    );
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(warnings).toEqual([
+      {
+        cause: "memory_extraction_state_not_persisted",
+        message: expect.stringContaining("disk full"),
+      },
+    ]);
   });
 });

--- a/runtime/tests/session/agent-task-lifecycle.test.ts
+++ b/runtime/tests/session/agent-task-lifecycle.test.ts
@@ -13,6 +13,7 @@ import {
   type RegisteredAgentTask,
   type SessionAgentTask,
 } from "./agent-task-lifecycle.js";
+import { readMemoryExtractionState } from "./memory-extraction-state.js";
 import type { RolloutItem } from "./rollout-item.js";
 import {
   Session,
@@ -442,4 +443,62 @@ describe("agent task lifecycle", () => {
     // No events emitted, no state mutations.
     expect(session.txEvent.tryRecv()).toBeUndefined();
   });
+
+  it("keeps a persisted agent task when a later session_state item carries only the memory-extraction cadence", async () => {
+    const task: SessionAgentTask = {
+      agentRuntimeId: "agent-5",
+      taskId: "task-5",
+      registeredAt: "2026-04-21T00:00:05Z",
+    };
+    const cadence = {
+      memoryRoot: "/memory",
+      processedVisibleCount: 4,
+      turnsSinceLastExtraction: 2,
+    };
+    // The JSONL round trip drops undefined keys, so the cadence item carries
+    // no agentTask key at all; it must not read as an explicit clear.
+    const replayed = (
+      [
+        { type: "session_state", payload: { agentTask: task } },
+        { type: "session_state", payload: { memoryExtraction: cadence } },
+      ] satisfies RolloutItem[]
+    ).map((item) => JSON.parse(JSON.stringify(item)) as RolloutItem);
+
+    expect(latestPersistedAgentTask(replayed)).toEqual({ value: task });
+
+    const session = buildSession({
+      services: {
+        agentIdentityManager: {
+          ensureRegistered: async () => {},
+          registerTask: vi.fn(async () => null),
+          taskMatchesCurrentIdentity: vi.fn(async () => true),
+        } as SessionServices["agentIdentityManager"],
+      },
+    });
+    await recordInitialHistoryOnResume(session, replayed, {
+      currentModel: "test-model",
+    });
+
+    expect(await readStoredAgentTask(session)).toEqual(task);
+    await expect(readMemoryExtractionState(session, "/memory")).resolves.toEqual(
+      cadence,
+    );
+  });
+
+  it("still reads an empty session_state payload as the legacy explicit clear of the agent task", () => {
+    const task: SessionAgentTask = {
+      agentRuntimeId: "agent-6",
+      taskId: "task-6",
+      registeredAt: "2026-04-21T00:00:06Z",
+    };
+    const replayed = (
+      [
+        { type: "session_state", payload: { agentTask: task } },
+        { type: "session_state", payload: { agentTask: undefined } },
+      ] satisfies RolloutItem[]
+    ).map((item) => JSON.parse(JSON.stringify(item)) as RolloutItem);
+
+    expect(latestPersistedAgentTask(replayed)).toEqual({ value: undefined });
+  });
+
 });

--- a/runtime/tests/session/event-log-reducer.test.ts
+++ b/runtime/tests/session/event-log-reducer.test.ts
@@ -292,4 +292,34 @@ describe("event-log-reducer (I-26 + I-27)", () => {
     expect(report.unknownVariantCount).toBe(0);
     expect(report.seqGapCount).toBe(0);
   });
+
+  test("session_state items that carry only the memory-extraction slot leave the cached agent task alone", () => {
+    const agentTask = {
+      agentRuntimeId: "agent-1",
+      taskId: "task-1",
+      registeredAt: "2026-04-21T00:00:00Z",
+    };
+    const { state } = reduceAll([
+      { type: "session_state", payload: { agentTask } },
+      {
+        type: "session_state",
+        payload: {
+          memoryExtraction: {
+            memoryRoot: "/memory",
+            processedVisibleCount: 2,
+            turnsSinceLastExtraction: 1,
+          },
+        },
+      },
+    ]);
+    expect(state.agentTask).toEqual(agentTask);
+
+    // The legacy explicit clear is an empty payload and still clears.
+    const cleared = reduceAll([
+      { type: "session_state", payload: { agentTask } },
+      { type: "session_state", payload: {} },
+    ]);
+    expect(cleared.state.agentTask).toBeUndefined();
+  });
+
 });

--- a/runtime/tests/session/memory-extraction-state.test.ts
+++ b/runtime/tests/session/memory-extraction-state.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { AsyncLock } from "../utils/async-lock.js";
+import type { RolloutItem } from "./rollout-item.js";
+import type { Session } from "./session.js";
+import {
+  isSessionMemoryExtractionState,
+  latestPersistedMemoryExtractionState,
+  persistMemoryExtractionState,
+  readMemoryExtractionState,
+  restorePersistedMemoryExtractionState,
+} from "./memory-extraction-state.js";
+
+function sessionWith(opts: {
+  readonly state?: boolean;
+  readonly record?: (item: unknown) => Promise<void>;
+}): Session {
+  return {
+    conversationId: "conv-cadence",
+    ...(opts.state === false
+      ? {}
+      : { state: new AsyncLock<Record<string, unknown>>({}) }),
+    services: {
+      ...(opts.record !== undefined ? { rollout: { record: opts.record } } : {}),
+    },
+  } as unknown as Session;
+}
+
+function cadenceItem(
+  memoryRoot: string,
+  processedVisibleCount: number,
+  turnsSinceLastExtraction: number,
+): RolloutItem {
+  return {
+    type: "session_state",
+    payload: {
+      memoryExtraction: {
+        memoryRoot,
+        processedVisibleCount,
+        turnsSinceLastExtraction,
+      },
+    },
+  };
+}
+
+describe("memory extraction cadence slot", () => {
+  it("reads the newest persisted cadence per memory root and skips other slots", () => {
+    const items: RolloutItem[] = [
+      cadenceItem("/m/a", 2, 1),
+      {
+        type: "session_state",
+        payload: {
+          agentTask: { agentRuntimeId: "r", taskId: "t", registeredAt: "now" },
+        },
+      },
+      cadenceItem("/m/b", 4, 0),
+      { type: "session_state", payload: {} },
+      cadenceItem("/m/a", 6, 2),
+      // Malformed slot from a corrupt line: skipped, never restored.
+      cadenceItem("/m/a", -1, 0),
+    ];
+
+    expect([...latestPersistedMemoryExtractionState(items).entries()]).toEqual([
+      [
+        "/m/a",
+        { memoryRoot: "/m/a", processedVisibleCount: 6, turnsSinceLastExtraction: 2 },
+      ],
+      [
+        "/m/b",
+        { memoryRoot: "/m/b", processedVisibleCount: 4, turnsSinceLastExtraction: 0 },
+      ],
+    ]);
+  });
+
+  it("accepts only a complete slot with non-negative integer counts", () => {
+    expect(
+      isSessionMemoryExtractionState({
+        memoryRoot: "/m",
+        processedVisibleCount: 1,
+        turnsSinceLastExtraction: 0,
+      }),
+    ).toBe(true);
+    for (const bad of [
+      null,
+      {},
+      { memoryRoot: "", processedVisibleCount: 1, turnsSinceLastExtraction: 0 },
+      { memoryRoot: "/m", processedVisibleCount: 1.5, turnsSinceLastExtraction: 0 },
+      { memoryRoot: "/m", processedVisibleCount: 1, turnsSinceLastExtraction: -1 },
+      { memoryRoot: "/m", processedVisibleCount: "1", turnsSinceLastExtraction: 0 },
+      { memoryRoot: "/m", processedVisibleCount: 1 },
+    ]) {
+      expect(isSessionMemoryExtractionState(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+
+  it("persists to session state and the rollout, and reads back what it wrote", async () => {
+    const record = vi.fn(async () => {});
+    const session = sessionWith({ record });
+    const state = {
+      memoryRoot: "/m/a",
+      processedVisibleCount: 3,
+      turnsSinceLastExtraction: 1,
+    };
+
+    await persistMemoryExtractionState(session, state);
+
+    expect(record).toHaveBeenCalledWith({
+      type: "session_state",
+      payload: { memoryExtraction: state },
+    });
+    await expect(readMemoryExtractionState(session, "/m/a")).resolves.toEqual(
+      state,
+    );
+    await expect(
+      readMemoryExtractionState(session, "/m/b"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("restores the newest persisted cadence into a resumed session", async () => {
+    const session = sessionWith({});
+    await restorePersistedMemoryExtractionState(session, [
+      cadenceItem("/m/a", 2, 1),
+      cadenceItem("/m/a", 5, 2),
+    ]);
+    await expect(readMemoryExtractionState(session, "/m/a")).resolves.toEqual({
+      memoryRoot: "/m/a",
+      processedVisibleCount: 5,
+      turnsSinceLastExtraction: 2,
+    });
+  });
+
+  it("is a no-op for sessions without a state lock or a rollout recorder", async () => {
+    const bare = sessionWith({ state: false });
+    await expect(
+      persistMemoryExtractionState(bare, {
+        memoryRoot: "/m",
+        processedVisibleCount: 1,
+        turnsSinceLastExtraction: 1,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(readMemoryExtractionState(bare, "/m")).resolves.toBeUndefined();
+    await expect(
+      restorePersistedMemoryExtractionState(bare, [cadenceItem("/m", 1, 1)]),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -468,6 +468,16 @@ describe("strict canonical journal contract", () => {
     ["compacted", {}],
     ["turn_context", {}],
     ["session_state", { agentTask: 42 }],
+    [
+      "session_state",
+      {
+        memoryExtraction: {
+          memoryRoot: "/memory",
+          processedVisibleCount: -1,
+          turnsSinceLastExtraction: 0,
+        },
+      },
+    ],
   ] as const)(
     "rejects an invalid %s payload before normalization",
     (type, payload) => {
@@ -682,6 +692,20 @@ describe("strict canonical journal contract", () => {
       isCanonicalEventPayload("turn_started", {
         turnId: "turn-1",
         startedAt: "not-a-number",
+      }),
+    ).toBe(false);
+    expect(
+      isCanonicalRolloutPayload("session_state", {
+        memoryExtraction: {
+          memoryRoot: "/memory",
+          processedVisibleCount: 4,
+          turnsSinceLastExtraction: 2,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isCanonicalRolloutPayload("session_state", {
+        memoryExtraction: { memoryRoot: "/memory", processedVisibleCount: 4 },
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
Closes the remaining part A of #2023 (part B and C landed in #2026).

## Why

Memory extraction runs its child on every third eligible turn and remembers how many model-visible messages it has already offered. Both counters lived only in the service's in-process lane map, so every daemon restart began the wait again while the conversation it paced stayed on disk. In the 15-prompt desktop run the extraction fired once in 13 turns because three unrelated restarts kept resetting the count. A lane pruned from the map (256-lane cap) lost its place the same way. #2026 tried a conversation-derived heuristic and the maintainer's last comment on #2023 asked for the real thing: persist the cadence per session and restore it on resume.

## What changed

- `runtime/src/session/rollout-item.ts`: new `SessionMemoryExtractionState` (`memoryRoot`, `processedVisibleCount`, `turnsSinceLastExtraction`) and a `memoryExtraction` slot on `SessionStateUpdate`; `sessionStateUpdateAddressesSlot` says whether an item carries a given slot (an empty payload still counts as the legacy explicit agent-task clear, because JSON drops `undefined` and that is the only slot ever cleared that way).
- `runtime/src/session/memory-extraction-state.ts` (new): walker for the newest slot per memory root, resume restore into session state, read, and persist (session-state mirror plus a `session_state` rollout record).
- `runtime/src/session/agent-task-lifecycle.ts`: `latestPersistedAgentTask` skips items that do not address the agent-task slot (otherwise a cadence item would read as a clear and drop the persisted task on the next resume, the trap described in #2031); `recordInitialHistoryOnResume` restores the cadence as step 1b, next to the agent-task restore, so both resume paths (`src/bin/bootstrap.ts`, `src/session/bootstrap.ts`) get it.
- `runtime/src/session/event-log-reducer.ts`: the same skip rule, so the reducer's cached `agentTask` is not clobbered by a cadence item.
- `runtime/src/state/recovery-journal-schema.ts`: strict validator for the new optional field (the exact-field-match type check forces type and validator to move together).
- `runtime/src/services/extractMemories/extractMemories.ts`: a new lane seeds itself from the persisted cadence under the in-progress guard before its first decision, persists after each decision that changed the counters, and reports a write failure as `memory_extraction_state_not_persisted` (a warning; never the turn).
- `runtime/src/memory/extraction-triggers.ts`: docstring only.

Why the rollout `session_state` item and not the SQLite `session_state_snapshots` table: the snapshots are daemon crash-recovery state for conversation, tool and MCP state with a different lifecycle; the rollout item is the slot the agent task already uses and both resume entrypoints already replay it.

## Evidence

The behaviour that motivated the issue is reproduced in tests: two extraction service instances over the same resumed session state continue the count, so a restart between the second and third eligible turns still extracts on the third, and the resumed process does not re-offer the history the previous process already extracted.

## Tests

- `tests/services/extractMemories/extractMemories.test.ts`: 5 new (restart between eligible turns 2 and 3 extracts on 3; resumed process does not re-offer extracted history; no persisted state waits 1/3 as before; writes only on change; write failure reported).
- `tests/session/memory-extraction-state.test.ts` (new): 5.
- `tests/session/agent-task-lifecycle.test.ts`: 2 (a cadence item keeps the agent task through a JSON round trip and a full resume; an empty payload still clears).
- `tests/session/event-log-reducer.test.ts`: 1. `tests/state/recovery-journal-contract.test.ts`: accept and reject cases.
- Hermetic runner: the 9 touched or importing files, 114 passed; 8 heavier importers (compact transaction contracts, canonical rollout scanner, checkpoint upgrade, rollout-store compaction, hermetic env, bin bootstrap), 218 passed; bootstrap, commit phase, lifecycle, autoDream gates, project-memory-root, 51 passed.
- `tsc --noEmit`: only the 39 pre-existing TS2883 lines that symlinked `node_modules` produce on this machine, identical on a throwaway `origin/main` worktree.

## Not changed

- The conversation-derived heuristic that #2026 tried is not reintroduced; a session with nothing persisted still waits the full cadence.
- Extraction output, prompts, and the child's tool policy.
- Downgrade caveat: a runtime older than this commit that reads a rollout containing a cadence item treats it as an agent-task clear (the #2031 trap), costing one agent re-registration; the additive journal schema replays it fine.

## Counterparts

#2023 (issue), #2026 (parts B and C), #2031 (the one-slot-per-item trap this PR avoids), #2017 (durable memory).