### PR TITLE
fix(compact): share runtime message converters so /compact keeps tool calls

### DIFF
--- a/runtime/src/commands/session-compact.ts
+++ b/runtime/src/commands/session-compact.ts
@@ -5,13 +5,9 @@ import {
   type SlashCommandResult,
 } from "./types.js";
 import React from "react";
-import type { LLMContentPart, LLMMessage, LLMProvider, LLMTool } from "../llm/types.js";
+import type { LLMMessage, LLMProvider, LLMTool } from "../llm/types.js";
 import { createChildAbortController } from "../utils/abortController.js";
-import {
-  cloneLlmContent as cloneContent,
-  fromRuntimeMessageContent,
-  toRuntimeMessageContent,
-} from "../llm/content-conversion.js";
+import { cloneLlmContent as cloneContent } from "../llm/content-conversion.js";
 import type {
   CompactCleanupDeps,
   CompactionResult,
@@ -26,7 +22,12 @@ import {
 } from "../services/compact/finalize-transaction.js";
 import { formatCompactionOperatorDisplay } from "../services/compact/operator.js";
 import type { CompactedItem } from "../session/rollout-item.js";
-import { validateAgentInvocationMessageSequence } from "../contracts/agent-invocation-envelope.js";
+import {
+  extractMessageText,
+  fromAgenCRuntimeMessages,
+  toAgenCRuntimeMessages,
+  type AgenCRuntimeMessage,
+} from "../session/runtime-message-conversion.js";
 import type { Session } from "../session/session.js";
 import { isAuthenticatedCompactionBoundary } from "../session/compaction-history-marker.js";
 import {
@@ -682,47 +683,6 @@ interface AgenCContextUsageResult {
   readonly text: string;
 }
 
-type AgenCMessageRole =
-  | "system"
-  | "developer"
-  | "user"
-  | "assistant"
-  | "tool";
-
-interface AgenCMessage {
-  readonly role: AgenCMessageRole;
-  readonly content: string | readonly LLMContentPart[];
-  readonly providerReasoningContent?: string;
-  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
-  readonly toolCallId?: string;
-  readonly toolName?: string;
-  readonly phase?: string;
-  readonly runtimeOnly?: LLMMessage["runtimeOnly"];
-}
-
-type AgenCRuntimeWireRole = NonNullable<RuntimeMessage["role"]>;
-
-type AgenCRuntimeMessage = Omit<
-  RuntimeMessage,
-  "role" | "originalRole" | "message"
-> & {
-  readonly role?: AgenCRuntimeWireRole;
-  readonly originalRole?: AgenCMessage["role"];
-  readonly toolCallId?: string;
-  readonly toolName?: string;
-  readonly toolCalls?: readonly {
-    readonly id: string;
-    readonly name: string;
-    readonly arguments?: string;
-  }[];
-  readonly phase?: string;
-  readonly type?: string;
-  readonly message?: {
-    readonly role?: string;
-    readonly content?: unknown;
-  };
-};
-
 type AgenCCompactionResult = {
   readonly boundaryMarker?: AgenCRuntimeMessage;
   readonly summaryMessages?: readonly AgenCRuntimeMessage[];
@@ -1075,40 +1035,6 @@ function buildAgenCCompactedRolloutItem(
     preCompactTokens: result.preCompactTokens,
     postCompactTokens: result.postCompactTokens,
   });
-}
-
-function toAgenCMessage(message: LLMMessage): AgenCMessage {
-  return {
-    role: message.role,
-    content: cloneContent(message.content),
-    ...(message.providerReasoningContent !== undefined
-      ? { providerReasoningContent: message.providerReasoningContent }
-      : {}),
-    ...(message.providerReasoningProvenance !== undefined
-      ? { providerReasoningProvenance: message.providerReasoningProvenance }
-      : {}),
-    ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
-    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-    ...(message.phase !== undefined ? { phase: message.phase } : {}),
-    ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-    message.runtimeOnly?.agentInvocation !== undefined
-      ? {
-          runtimeOnly: {
-            ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-              ? {
-                  toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
-                }
-              : {}),
-            ...(message.runtimeOnly?.agentInvocation !== undefined
-              ? {
-                  agentInvocation: message.runtimeOnly.agentInvocation,
-                  mergeBoundary: "user_context" as const,
-                }
-              : {}),
-          },
-        }
-      : {}),
-  };
 }
 
 function buildCompactedRolloutPayload(params: {
@@ -1520,187 +1446,6 @@ async function addManualCompactSlashMessages(
       ...slashMessages,
     ],
   };
-}
-
-function toAgenCRuntimeMessages(
-  messages: readonly LLMMessage[],
-): AgenCRuntimeMessage[] {
-  return messages.map((message, index) => {
-    const converted = toAgenCMessage(message);
-    const runtimeContent = toRuntimeMessageContent(message.content);
-    if (message.role === "system") {
-      return {
-        ...converted,
-        role: "system",
-        type: "system",
-        content: runtimeContent,
-        uuid: `agenc-system-${index}`,
-        timestamp: new Date(0).toISOString(),
-      };
-    }
-    const role = toAgenCRuntimeWireRole(message.role);
-    return {
-      ...converted,
-      content: runtimeContent,
-      role,
-      ...(message.role !== role ? { originalRole: message.role } : {}),
-      type: role,
-      message: {
-        role,
-        content: runtimeContent,
-      },
-      uuid: `agenc-${role}-${index}`,
-      timestamp: new Date(0).toISOString(),
-      ...(message.toolCalls !== undefined
-        ? {
-            toolCalls: message.toolCalls.map((call) => ({
-              id: call.id,
-              name: call.name,
-              arguments: call.arguments,
-            })),
-          }
-        : {}),
-      ...(message.role === "tool" ? { isMeta: true } : {}),
-    };
-  });
-}
-
-function toAgenCRuntimeWireRole(role: LLMMessage["role"]): AgenCRuntimeWireRole {
-  if (role === "tool") return "user";
-  if (role === "developer") return "system";
-  return role;
-}
-
-function fromAgenCRuntimeMessages(
-  messages: readonly AgenCRuntimeMessage[],
-): LLMMessage[] {
-  const converted = messages
-    .map(fromAgenCRuntimeMessage)
-    .filter((message): message is LLMMessage => message !== null);
-  validateAgentInvocationMessageSequence(converted);
-  return converted;
-}
-
-function fromAgenCRuntimeMessage(
-  message: AgenCRuntimeMessage,
-): LLMMessage | null {
-  if (message.role && message.content !== undefined) {
-    const role = message.originalRole ?? message.role;
-    return {
-      role,
-      content: fromRuntimeMessageContent(message.content),
-      ...(message.providerReasoningContent !== undefined
-        ? { providerReasoningContent: message.providerReasoningContent }
-        : {}),
-      ...(message.providerReasoningProvenance !== undefined
-        ? { providerReasoningProvenance: message.providerReasoningProvenance }
-        : {}),
-      ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
-      ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-      ...(message.phase === "commentary" || message.phase === "final_answer"
-        ? { phase: message.phase }
-        : {}),
-      ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-      message.runtimeOnly?.agentInvocation !== undefined
-        ? {
-            runtimeOnly: {
-              ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-                ? {
-                    toolResultIntegrity:
-                      message.runtimeOnly.toolResultIntegrity,
-                  }
-                : {}),
-              ...(message.runtimeOnly?.agentInvocation !== undefined
-                ? {
-                    agentInvocation: message.runtimeOnly.agentInvocation,
-                    mergeBoundary: "user_context" as const,
-                  }
-                : {}),
-            },
-          }
-        : {}),
-    };
-  }
-  const role = normalizeRole(message.message?.role ?? message.type);
-  if (!role) return null;
-  return {
-    role,
-    content: fromRuntimeMessageContent(readContent(message)),
-    ...(message.providerReasoningContent !== undefined
-      ? { providerReasoningContent: message.providerReasoningContent }
-      : {}),
-    ...(message.providerReasoningProvenance !== undefined
-      ? { providerReasoningProvenance: message.providerReasoningProvenance }
-      : {}),
-    ...(message.toolCalls !== undefined
-      ? {
-          toolCalls: message.toolCalls.map((call) => ({
-            id: call.id,
-            name: call.name,
-            arguments: call.arguments ?? "",
-          })),
-        }
-      : {}),
-    ...(message.toolCallId !== undefined
-      ? { toolCallId: message.toolCallId }
-      : {}),
-    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-    ...(message.phase === "commentary" || message.phase === "final_answer"
-      ? { phase: message.phase }
-      : {}),
-    ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-    message.runtimeOnly?.agentInvocation !== undefined
-      ? {
-          runtimeOnly: {
-            ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-              ? {
-                  toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
-                }
-              : {}),
-            ...(message.runtimeOnly?.agentInvocation !== undefined
-              ? {
-                  agentInvocation: message.runtimeOnly.agentInvocation,
-                  mergeBoundary: "user_context" as const,
-                }
-              : {}),
-          },
-        }
-      : {}),
-  };
-}
-
-function normalizeRole(value: unknown): LLMMessage["role"] | null {
-  if (
-    value === "system" ||
-    value === "developer" ||
-    value === "user" ||
-    value === "assistant" ||
-    value === "tool"
-  ) {
-    return value;
-  }
-  return null;
-}
-
-function readContent(
-  message: AgenCRuntimeMessage,
-): LLMMessage["content"] {
-  const content = message.message?.content ?? message.content ?? "";
-  return cloneContent(content);
-}
-
-function extractMessageText(
-  message: AgenCRuntimeMessage | undefined,
-): string | undefined {
-  if (!message) return undefined;
-  const content = readContent(message);
-  if (typeof content === "string") return content;
-  const text = content
-    .map((part) => (part.type === "text" ? part.text : ""))
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-  return text.length > 0 ? text : undefined;
 }
 
 function cloneLLMMessage(message: LLMMessage): LLMMessage {

--- a/runtime/src/phases/post-sample-recovery.ts
+++ b/runtime/src/phases/post-sample-recovery.ts
@@ -23,6 +23,10 @@
  */
 
 import { createHash } from "node:crypto";
+import {
+  runtimeWireEnvelope,
+  toolCallsForRuntime,
+} from "../session/runtime-message-conversion.js";
 
 import { emitError, emitWarning } from "../session/event-log.js";
 import type { LLMMessage } from "../llm/types.js";
@@ -249,22 +253,8 @@ function toCollapseRuntimeMessages(
         : {}),
       ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
       ...(message.phase !== undefined ? { phase: message.phase } : {}),
-      type: role,
-      message: {
-        role,
-        content: runtimeContent,
-      },
-      uuid: `agenc-${role}-${index}`,
-      timestamp: new Date(0).toISOString(),
-      ...(message.toolCalls !== undefined
-        ? {
-            toolCalls: message.toolCalls.map((call) => ({
-              id: call.id,
-              name: call.name,
-              arguments: call.arguments,
-            })),
-          }
-        : {}),
+      ...runtimeWireEnvelope(role, runtimeContent, index),
+      ...toolCallsForRuntime(message.toolCalls),
       ...(message.role === "tool" ? { isMeta: true } : {}),
       ...(message.runtimeOnly !== undefined
         ? { runtimeOnly: message.runtimeOnly }

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -59,8 +59,6 @@ import type {
 import {
   cloneLlmContent as cloneContent,
   cloneLlmMessageSnapshot,
-  fromRuntimeMessageContent,
-  toRuntimeMessageContent,
 } from "../llm/content-conversion.js";
 import {
   filterToolsForLocalProfile,
@@ -81,14 +79,16 @@ import {
   hasLedgerWalletCliMention,
   LEDGER_WALLET_CLI_ROUTING_GUIDANCE,
 } from "../elicitation/ledger-wallet-cli.js";
-import type {
-  CompactionResult,
-  RuntimeMessage,
-} from "../services/compact/types.js";
+import type { CompactionResult } from "../services/compact/types.js";
 import { isAuthenticatedCompactionBoundary } from "./compaction-history-marker.js";
 import { getAutoCompactThreshold } from "../services/compact/autoCompact.js";
 import { estimateMessagesTokens } from "../services/compact/_deps/runtime.js";
-import { validateAgentInvocationMessageSequence } from "../contracts/agent-invocation-envelope.js";
+import {
+  extractMessageText,
+  fromAgenCRuntimeMessages,
+  toAgenCRuntimeMessages,
+  type AgenCRuntimeMessage,
+} from "./runtime-message-conversion.js";
 import {
   applyToolResultBudget,
   resolveToolResultBudgetChars,
@@ -380,44 +380,6 @@ interface AgenCAutoCompactResult {
   readonly consecutiveFailures?: number;
 }
 
-type AgenCMessageRole = "system" | "developer" | "user" | "assistant" | "tool";
-
-interface AgenCMessage {
-  readonly role: AgenCMessageRole;
-  readonly content: string | readonly LLMContentPart[];
-  readonly providerReasoningContent?: string;
-  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
-  readonly toolCallId?: string;
-  readonly toolName?: string;
-  readonly phase?: string;
-  readonly runtimeOnly?: LLMMessage["runtimeOnly"];
-}
-
-type AgenCRuntimeWireRole = NonNullable<RuntimeMessage["role"]>;
-
-type AgenCRuntimeMessage = Omit<
-  RuntimeMessage,
-  "role" | "originalRole" | "message"
-> & {
-  readonly role?: AgenCRuntimeWireRole;
-  readonly originalRole?: AgenCMessage["role"];
-  readonly toolCallId?: string;
-  readonly toolName?: string;
-  readonly providerReasoningContent?: string;
-  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
-  readonly toolCalls?: readonly {
-    readonly id: string;
-    readonly name: string;
-    readonly arguments?: string;
-  }[];
-  readonly phase?: string;
-  readonly type?: string;
-  readonly message?: {
-    readonly role?: string;
-    readonly content?: unknown;
-  };
-};
-
 type AgenCCompactionResult = {
   readonly boundaryMarker?: AgenCRuntimeMessage;
   readonly summaryMessages?: readonly AgenCRuntimeMessage[];
@@ -556,42 +518,6 @@ function buildAgenCCompactedRolloutItem(
 
 function buildAgenCPostCompactMessages(result: CompactedItem): LLMMessage[] {
   return (result.replacementHistory ?? []).map(responseItemToLlmMessage);
-}
-
-function toAgenCMessage(message: LLMMessage): AgenCMessage {
-  return {
-    role: message.role,
-    content: cloneContent(message.content),
-    ...(message.providerReasoningContent !== undefined
-      ? { providerReasoningContent: message.providerReasoningContent }
-      : {}),
-    ...(message.providerReasoningProvenance !== undefined
-      ? { providerReasoningProvenance: message.providerReasoningProvenance }
-      : {}),
-    ...(message.toolCallId !== undefined
-      ? { toolCallId: message.toolCallId }
-      : {}),
-    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-    ...(message.phase !== undefined ? { phase: message.phase } : {}),
-    ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-    message.runtimeOnly?.agentInvocation !== undefined
-      ? {
-          runtimeOnly: {
-            ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-              ? {
-                  toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
-                }
-              : {}),
-            ...(message.runtimeOnly?.agentInvocation !== undefined
-              ? {
-                  agentInvocation: message.runtimeOnly.agentInvocation,
-                  mergeBoundary: "user_context" as const,
-                }
-              : {}),
-          },
-        }
-      : {}),
-  };
 }
 
 function buildCompactedRolloutPayload(params: {
@@ -879,212 +805,6 @@ function toCompactServiceResult(
       ? { transaction: result.transaction }
       : {}),
   };
-}
-
-function toAgenCRuntimeMessages(
-  messages: readonly LLMMessage[],
-): AgenCRuntimeMessage[] {
-  return messages.map((message, index) => {
-    const converted = toAgenCMessage(message);
-    const runtimeContent = toRuntimeMessageContent(message.content);
-    if (message.role === "system") {
-      return {
-        ...converted,
-        role: "system",
-        type: "system",
-        content: runtimeContent,
-        uuid: `agenc-system-${index}`,
-        timestamp: new Date(0).toISOString(),
-      };
-    }
-    const role = toAgenCRuntimeWireRole(message.role);
-    return {
-      ...converted,
-      content: runtimeContent,
-      role,
-      ...(message.role !== role ? { originalRole: message.role } : {}),
-      type: role,
-      message: {
-        role,
-        content: runtimeContent,
-      },
-      uuid: `agenc-${role}-${index}`,
-      timestamp: new Date(0).toISOString(),
-      ...(message.toolCalls !== undefined
-        ? {
-            toolCalls: message.toolCalls.map((call) => ({
-              id: call.id,
-              name: call.name,
-              arguments: call.arguments,
-            })),
-          }
-        : {}),
-      ...(message.role === "tool" ? { isMeta: true } : {}),
-    };
-  });
-}
-
-function toAgenCRuntimeWireRole(
-  role: LLMMessage["role"],
-): AgenCRuntimeWireRole {
-  if (role === "tool") return "user";
-  if (role === "developer") return "system";
-  return role;
-}
-
-function fromAgenCRuntimeMessages(
-  messages: readonly AgenCRuntimeMessage[],
-): LLMMessage[] {
-  const converted = messages
-    .map(fromAgenCRuntimeMessage)
-    .filter((message): message is LLMMessage => message !== null);
-  validateAgentInvocationMessageSequence(converted);
-  return converted;
-}
-
-function fromAgenCRuntimeMessage(
-  message: AgenCRuntimeMessage,
-): LLMMessage | null {
-  if (message.role && message.content !== undefined) {
-    const role = message.originalRole ?? message.role;
-    return {
-      role,
-      content: fromRuntimeMessageContent(message.content),
-      ...(message.providerReasoningContent !== undefined
-        ? { providerReasoningContent: message.providerReasoningContent }
-        : {}),
-      ...(message.providerReasoningProvenance !== undefined
-        ? { providerReasoningProvenance: message.providerReasoningProvenance }
-        : {}),
-      ...(message.toolCallId !== undefined
-        ? { toolCallId: message.toolCallId }
-        : {}),
-      ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-      // pwd-storm root cause: previously this round-trip dropped the
-      // assistant's `toolCalls` array. `toAgenCRuntimeMessages` writes
-      // it (run-turn.ts:884-892) but the inverse never read it back.
-      // Every iteration of the turn loop calls
-      // `prepareAgenCTurnContext` → `prepareAgenCQueryMessages` →
-      // this projection. The strip cascaded: the assistant arrived at
-      // the wire layer with no tool_calls, so `normalizeMessagesForAPI`
-      // (`runtime/src/llm/messages.ts:113-136`) treated every following
-      // `role:"tool"` message as orphan and dropped it. The model on
-      // the next iteration saw the prior turn as an empty assistant
-      // reply and re-emitted the same tool call, ad nauseam. The
-      // executor + state.messages writes were always correct; this
-      // single missing field broke the entire tool-result threading
-      // contract for daemon-mode + openai-compat providers.
-      ...(message.toolCalls !== undefined
-        ? {
-            toolCalls: message.toolCalls.map((call) => ({
-              id: call.id,
-              name: call.name,
-              arguments: call.arguments ?? "",
-            })),
-          }
-        : {}),
-      ...(message.phase === "commentary" || message.phase === "final_answer"
-        ? { phase: message.phase }
-        : {}),
-      ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-      message.runtimeOnly?.agentInvocation !== undefined
-        ? {
-            runtimeOnly: {
-              ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-                ? {
-                    toolResultIntegrity:
-                      message.runtimeOnly.toolResultIntegrity,
-                  }
-                : {}),
-              ...(message.runtimeOnly?.agentInvocation !== undefined
-                ? {
-                    agentInvocation: message.runtimeOnly.agentInvocation,
-                    mergeBoundary: "user_context" as const,
-                  }
-                : {}),
-            },
-          }
-        : {}),
-    };
-  }
-  const role = normalizeRole(message.message?.role ?? message.type);
-  if (!role) return null;
-  return {
-    role,
-    content: fromRuntimeMessageContent(readContent(message)),
-    ...(message.providerReasoningContent !== undefined
-      ? { providerReasoningContent: message.providerReasoningContent }
-      : {}),
-    ...(message.providerReasoningProvenance !== undefined
-      ? { providerReasoningProvenance: message.providerReasoningProvenance }
-      : {}),
-    ...(message.toolCalls !== undefined
-      ? {
-          toolCalls: message.toolCalls.map((call) => ({
-            id: call.id,
-            name: call.name,
-            arguments: call.arguments ?? "",
-          })),
-        }
-      : {}),
-    ...(message.toolCallId !== undefined
-      ? { toolCallId: message.toolCallId }
-      : {}),
-    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-    ...(message.phase === "commentary" || message.phase === "final_answer"
-      ? { phase: message.phase }
-      : {}),
-    ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-    message.runtimeOnly?.agentInvocation !== undefined
-      ? {
-          runtimeOnly: {
-            ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-              ? {
-                  toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
-                }
-              : {}),
-            ...(message.runtimeOnly?.agentInvocation !== undefined
-              ? {
-                  agentInvocation: message.runtimeOnly.agentInvocation,
-                  mergeBoundary: "user_context" as const,
-                }
-              : {}),
-          },
-        }
-      : {}),
-  };
-}
-
-function normalizeRole(value: unknown): LLMMessage["role"] | null {
-  if (
-    value === "system" ||
-    value === "developer" ||
-    value === "user" ||
-    value === "assistant" ||
-    value === "tool"
-  ) {
-    return value;
-  }
-  return null;
-}
-
-function readContent(message: AgenCRuntimeMessage): LLMMessage["content"] {
-  const content = message.message?.content ?? message.content ?? "";
-  return cloneContent(content);
-}
-
-function extractMessageText(
-  message: AgenCRuntimeMessage | undefined,
-): string | undefined {
-  if (!message) return undefined;
-  const content = readContent(message);
-  if (typeof content === "string") return content;
-  const text = content
-    .map((part) => (part.type === "text" ? part.text : ""))
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-  return text.length > 0 ? text : undefined;
 }
 
 function compactionNotRun(

--- a/runtime/src/session/runtime-message-conversion.ts
+++ b/runtime/src/session/runtime-message-conversion.ts
@@ -1,0 +1,286 @@
+/**
+ * Shared conversion between `LLMMessage` history and the AgenC runtime
+ * message shape consumed by the compaction service.
+ *
+ * Live turns (`run-turn.ts`) and manual `/compact` (`session-compact.ts`)
+ * both project history into runtime messages before compaction and project
+ * the retained messages back afterwards. Each caller used to carry its own
+ * copy of this pair, and the copies drifted: the manual-compaction inverse
+ * stopped copying assistant `toolCalls`, so a kept tool result could lose the
+ * call that produced it (issue #1792). Both directions live here so every
+ * caller preserves the same wire fields: `toolCalls` with their arguments,
+ * `toolCallId`, `toolName`, `phase`, provider reasoning state, the
+ * runtime-only tool-result integrity and agent-invocation metadata, and the
+ * original role of messages whose runtime wire role differs.
+ */
+import type { LLMContentPart, LLMMessage } from "../llm/types.js";
+import {
+  cloneLlmContent,
+  fromRuntimeMessageContent,
+  toRuntimeMessageContent,
+} from "../llm/content-conversion.js";
+import type { RuntimeMessage } from "../services/compact/types.js";
+import { validateAgentInvocationMessageSequence } from "../contracts/agent-invocation-envelope.js";
+
+export type AgenCMessageRole =
+  | "system"
+  | "developer"
+  | "user"
+  | "assistant"
+  | "tool";
+
+export interface AgenCMessage {
+  readonly role: AgenCMessageRole;
+  readonly content: string | readonly LLMContentPart[];
+  readonly providerReasoningContent?: string;
+  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
+  readonly toolCallId?: string;
+  readonly toolName?: string;
+  readonly phase?: string;
+  readonly runtimeOnly?: LLMMessage["runtimeOnly"];
+}
+
+export type AgenCRuntimeWireRole = NonNullable<RuntimeMessage["role"]>;
+
+export type AgenCRuntimeMessage = Omit<
+  RuntimeMessage,
+  "role" | "originalRole" | "message"
+> & {
+  readonly role?: AgenCRuntimeWireRole;
+  readonly originalRole?: AgenCMessage["role"];
+  readonly toolCallId?: string;
+  readonly toolName?: string;
+  readonly providerReasoningContent?: string;
+  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
+  readonly toolCalls?: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly arguments?: string;
+  }[];
+  readonly phase?: string;
+  readonly type?: string;
+  readonly message?: {
+    readonly role?: string;
+    readonly content?: unknown;
+  };
+};
+
+type RuntimeOnlyProjectionSource = {
+  readonly toolResultIntegrity?: NonNullable<
+    LLMMessage["runtimeOnly"]
+  >["toolResultIntegrity"];
+  readonly agentInvocation?: NonNullable<
+    LLMMessage["runtimeOnly"]
+  >["agentInvocation"];
+};
+
+/**
+ * Project `LLMMessage` history into runtime messages. Runtime wire roles are
+ * narrower than LLM roles: `tool` results travel as `user` messages and
+ * `developer` messages as `system`, with the original role recorded so the
+ * inverse can restore it.
+ */
+export function toAgenCRuntimeMessages(
+  messages: readonly LLMMessage[],
+): AgenCRuntimeMessage[] {
+  return messages.map((message, index) => {
+    const converted = toAgenCMessage(message);
+    const runtimeContent = toRuntimeMessageContent(message.content);
+    if (message.role === "system") {
+      return {
+        ...converted,
+        role: "system",
+        type: "system",
+        content: runtimeContent,
+        uuid: `agenc-system-${index}`,
+        timestamp: new Date(0).toISOString(),
+      };
+    }
+    const role = toAgenCRuntimeWireRole(message.role);
+    return {
+      ...converted,
+      content: runtimeContent,
+      role,
+      ...(message.role !== role ? { originalRole: message.role } : {}),
+      type: role,
+      message: {
+        role,
+        content: runtimeContent,
+      },
+      uuid: `agenc-${role}-${index}`,
+      timestamp: new Date(0).toISOString(),
+      ...(message.toolCalls !== undefined
+        ? {
+            toolCalls: message.toolCalls.map((call) => ({
+              id: call.id,
+              name: call.name,
+              arguments: call.arguments,
+            })),
+          }
+        : {}),
+      ...(message.role === "tool" ? { isMeta: true } : {}),
+    };
+  });
+}
+
+/**
+ * Project runtime messages back into `LLMMessage` history and validate that
+ * the restored sequence still carries complete agent-invocation channels.
+ */
+export function fromAgenCRuntimeMessages(
+  messages: readonly AgenCRuntimeMessage[],
+): LLMMessage[] {
+  const converted = messages
+    .map(fromAgenCRuntimeMessage)
+    .filter((message): message is LLMMessage => message !== null);
+  validateAgentInvocationMessageSequence(converted);
+  return converted;
+}
+
+/**
+ * Project one runtime message back into an `LLMMessage`, or `null` when the
+ * message carries no recognizable role. Messages written by
+ * `toAgenCRuntimeMessages` carry a top-level `role` and `content`; older
+ * runtime shapes only carry `type` plus a nested `message`. Both shapes share
+ * one wire-field projection so they cannot drift apart again.
+ */
+export function fromAgenCRuntimeMessage(
+  message: AgenCRuntimeMessage,
+): LLMMessage | null {
+  if (message.role && message.content !== undefined) {
+    return {
+      role: message.originalRole ?? message.role,
+      content: fromRuntimeMessageContent(message.content),
+      ...projectRuntimeWireFields(message),
+    };
+  }
+  const role = normalizeRole(message.message?.role ?? message.type);
+  if (!role) return null;
+  return {
+    role,
+    content: fromRuntimeMessageContent(readRuntimeMessageContent(message)),
+    ...projectRuntimeWireFields(message),
+  };
+}
+
+export function extractMessageText(
+  message: AgenCRuntimeMessage | undefined,
+): string | undefined {
+  if (!message) return undefined;
+  const content = readRuntimeMessageContent(message);
+  if (typeof content === "string") return content;
+  const text = content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function toAgenCMessage(message: LLMMessage): AgenCMessage {
+  return {
+    role: message.role,
+    content: cloneLlmContent(message.content),
+    ...(message.providerReasoningContent !== undefined
+      ? { providerReasoningContent: message.providerReasoningContent }
+      : {}),
+    ...(message.providerReasoningProvenance !== undefined
+      ? { providerReasoningProvenance: message.providerReasoningProvenance }
+      : {}),
+    ...(message.toolCallId !== undefined
+      ? { toolCallId: message.toolCallId }
+      : {}),
+    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
+    ...(message.phase !== undefined ? { phase: message.phase } : {}),
+    ...projectRuntimeOnly(message.runtimeOnly),
+  };
+}
+
+function toAgenCRuntimeWireRole(
+  role: LLMMessage["role"],
+): AgenCRuntimeWireRole {
+  if (role === "tool") return "user";
+  if (role === "developer") return "system";
+  return role;
+}
+
+/**
+ * Every optional wire field an `LLMMessage` can carry besides role and
+ * content. Assistant `toolCalls` are part of this set: dropping them leaves
+ * the following `tool` results without the call they answer, which provider
+ * wire normalization then discards as orphans and the model re-issues the
+ * same call on its next iteration.
+ */
+function projectRuntimeWireFields(
+  message: AgenCRuntimeMessage,
+): Omit<LLMMessage, "role" | "content"> {
+  return {
+    ...(message.providerReasoningContent !== undefined
+      ? { providerReasoningContent: message.providerReasoningContent }
+      : {}),
+    ...(message.providerReasoningProvenance !== undefined
+      ? { providerReasoningProvenance: message.providerReasoningProvenance }
+      : {}),
+    ...(message.toolCalls !== undefined
+      ? {
+          toolCalls: message.toolCalls.map((call) => ({
+            id: call.id,
+            name: call.name,
+            arguments: call.arguments ?? "",
+          })),
+        }
+      : {}),
+    ...(message.toolCallId !== undefined
+      ? { toolCallId: message.toolCallId }
+      : {}),
+    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
+    ...(message.phase === "commentary" || message.phase === "final_answer"
+      ? { phase: message.phase }
+      : {}),
+    ...projectRuntimeOnly(message.runtimeOnly),
+  };
+}
+
+function projectRuntimeOnly(
+  runtimeOnly: RuntimeOnlyProjectionSource | undefined,
+): Pick<LLMMessage, "runtimeOnly"> {
+  if (
+    runtimeOnly?.toolResultIntegrity === undefined &&
+    runtimeOnly?.agentInvocation === undefined
+  ) {
+    return {};
+  }
+  return {
+    runtimeOnly: {
+      ...(runtimeOnly.toolResultIntegrity !== undefined
+        ? { toolResultIntegrity: runtimeOnly.toolResultIntegrity }
+        : {}),
+      ...(runtimeOnly.agentInvocation !== undefined
+        ? {
+            agentInvocation: runtimeOnly.agentInvocation,
+            mergeBoundary: "user_context" as const,
+          }
+        : {}),
+    },
+  };
+}
+
+function normalizeRole(value: unknown): LLMMessage["role"] | null {
+  if (
+    value === "system" ||
+    value === "developer" ||
+    value === "user" ||
+    value === "assistant" ||
+    value === "tool"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function readRuntimeMessageContent(
+  message: AgenCRuntimeMessage,
+): LLMMessage["content"] {
+  const content = message.message?.content ?? message.content ?? "";
+  return cloneLlmContent(content);
+}

--- a/runtime/src/session/runtime-message-conversion.ts
+++ b/runtime/src/session/runtime-message-conversion.ts
@@ -33,11 +33,11 @@ export interface AgenCMessage {
   readonly role: AgenCMessageRole;
   readonly content: string | readonly LLMContentPart[];
   readonly providerReasoningContent?: string;
-  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
+  readonly providerReasoningProvenance?: NonNullable<LLMMessage["providerReasoningProvenance"]>;
   readonly toolCallId?: string;
   readonly toolName?: string;
   readonly phase?: string;
-  readonly runtimeOnly?: LLMMessage["runtimeOnly"];
+  readonly runtimeOnly?: NonNullable<LLMMessage["runtimeOnly"]>;
 }
 
 export type AgenCRuntimeWireRole = NonNullable<RuntimeMessage["role"]>;
@@ -51,7 +51,7 @@ export type AgenCRuntimeMessage = Omit<
   readonly toolCallId?: string;
   readonly toolName?: string;
   readonly providerReasoningContent?: string;
-  readonly providerReasoningProvenance?: LLMMessage["providerReasoningProvenance"];
+  readonly providerReasoningProvenance?: NonNullable<LLMMessage["providerReasoningProvenance"]>;
   readonly toolCalls?: readonly {
     readonly id: string;
     readonly name: string;
@@ -67,11 +67,11 @@ export type AgenCRuntimeMessage = Omit<
 
 type RuntimeOnlyProjectionSource = {
   readonly toolResultIntegrity?: NonNullable<
-    LLMMessage["runtimeOnly"]
-  >["toolResultIntegrity"];
+    NonNullable<LLMMessage["runtimeOnly"]>["toolResultIntegrity"]
+  >;
   readonly agentInvocation?: NonNullable<
-    LLMMessage["runtimeOnly"]
-  >["agentInvocation"];
+    NonNullable<LLMMessage["runtimeOnly"]>["agentInvocation"]
+  >;
 };
 
 /**
@@ -102,22 +102,8 @@ export function toAgenCRuntimeMessages(
       content: runtimeContent,
       role,
       ...(message.role !== role ? { originalRole: message.role } : {}),
-      type: role,
-      message: {
-        role,
-        content: runtimeContent,
-      },
-      uuid: `agenc-${role}-${index}`,
-      timestamp: new Date(0).toISOString(),
-      ...(message.toolCalls !== undefined
-        ? {
-            toolCalls: message.toolCalls.map((call) => ({
-              id: call.id,
-              name: call.name,
-              arguments: call.arguments,
-            })),
-          }
-        : {}),
+      ...runtimeWireEnvelope(role, runtimeContent, index),
+      ...toolCallsForRuntime(message.toolCalls),
       ...(message.role === "tool" ? { isMeta: true } : {}),
     };
   });
@@ -221,6 +207,33 @@ function projectRuntimeWireFields(
     ...(message.providerReasoningProvenance !== undefined
       ? { providerReasoningProvenance: message.providerReasoningProvenance }
       : {}),
+    ...projectToolExchangeFields(message),
+    ...projectRuntimeOnly(message.runtimeOnly),
+  };
+}
+
+/** The tool-exchange fields a persisted runtime message may carry. */
+export interface ToolExchangeSource {
+  readonly toolCalls?: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly arguments?: string;
+  }[];
+  readonly toolCallId?: string;
+  readonly toolName?: string;
+  readonly phase?: string;
+}
+
+/**
+ * Restore the tool exchange of a persisted runtime message the way the LLM
+ * message expects it: the assistant's calls with their arguments, the result's
+ * call id and tool name, and the phase when it is one the runtime emits. Shared
+ * by every runtime-to-LLM restore so the copies cannot drift apart again.
+ */
+export function projectToolExchangeFields(
+  message: ToolExchangeSource,
+): Pick<LLMMessage, "toolCalls" | "toolCallId" | "toolName" | "phase"> {
+  return {
     ...(message.toolCalls !== undefined
       ? {
           toolCalls: message.toolCalls.map((call) => ({
@@ -237,11 +250,43 @@ function projectRuntimeWireFields(
     ...(message.phase === "commentary" || message.phase === "final_answer"
       ? { phase: message.phase }
       : {}),
-    ...projectRuntimeOnly(message.runtimeOnly),
   };
 }
 
-function projectRuntimeOnly(
+/** The wire envelope every non-system runtime message carries. */
+export function runtimeWireEnvelope(
+  role: AgenCRuntimeWireRole,
+  content: unknown,
+  index: number,
+): {
+  readonly type: AgenCRuntimeWireRole;
+  readonly message: { readonly role: AgenCRuntimeWireRole; readonly content: unknown };
+  readonly uuid: string;
+  readonly timestamp: string;
+} {
+  return {
+    type: role,
+    message: { role, content },
+    uuid: `agenc-${role}-${index}`,
+    timestamp: new Date(0).toISOString(),
+  };
+}
+
+/** The assistant's tool calls as the runtime persists them (arguments verbatim). */
+export function toolCallsForRuntime(
+  toolCalls: LLMMessage["toolCalls"],
+): Pick<AgenCRuntimeMessage, "toolCalls"> {
+  if (toolCalls === undefined) return {};
+  return {
+    toolCalls: toolCalls.map((call) => ({
+      id: call.id,
+      name: call.name,
+      arguments: call.arguments,
+    })),
+  };
+}
+
+export function projectRuntimeOnly(
   runtimeOnly: RuntimeOnlyProjectionSource | undefined,
 ): Pick<LLMMessage, "runtimeOnly"> {
   if (

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -60,6 +60,10 @@ import {
   type AgentInvocationChannelMetadata,
 } from "../contracts/agent-invocation-envelope.js";
 import {
+  projectRuntimeOnly,
+  projectToolExchangeFields,
+} from "./runtime-message-conversion.js";
+import {
   buildPostCompactMessages,
   partialCompactConversationAsync,
 } from "../services/compact/compact.js";
@@ -2248,40 +2252,8 @@ function fromCompactRuntimeMessage(message: RuntimeMessage): LLMMessage | null {
   return {
     role,
     content,
-    ...(message.toolCalls !== undefined
-      ? {
-          toolCalls: message.toolCalls.map((call) => ({
-            id: call.id,
-            name: call.name,
-            arguments: call.arguments ?? "",
-          })),
-        }
-      : {}),
-    ...(message.toolCallId !== undefined
-      ? { toolCallId: message.toolCallId }
-      : {}),
-    ...(message.toolName !== undefined ? { toolName: message.toolName } : {}),
-    ...(message.phase === "commentary" || message.phase === "final_answer"
-      ? { phase: message.phase }
-      : {}),
-    ...(message.runtimeOnly?.toolResultIntegrity !== undefined ||
-    message.runtimeOnly?.agentInvocation !== undefined
-      ? {
-          runtimeOnly: {
-            ...(message.runtimeOnly?.toolResultIntegrity !== undefined
-              ? {
-                  toolResultIntegrity: message.runtimeOnly.toolResultIntegrity,
-                }
-              : {}),
-            ...(message.runtimeOnly?.agentInvocation !== undefined
-              ? {
-                  agentInvocation: message.runtimeOnly.agentInvocation,
-                  mergeBoundary: "user_context" as const,
-                }
-              : {}),
-          },
-        }
-      : {}),
+    ...projectToolExchangeFields(message),
+    ...projectRuntimeOnly(message.runtimeOnly),
   };
 }
 

--- a/runtime/tests/commands/session-compact-context.test.ts
+++ b/runtime/tests/commands/session-compact-context.test.ts
@@ -93,6 +93,63 @@ describe("manual compact runtime projection", () => {
       },
     });
   });
+
+  test("keeps a retained assistant tool call and its result with the arguments intact", async () => {
+    // The summarizer hands back `messagesToKeep` in the shape
+    // `toAgenCRuntimeMessages` wrote: top-level role and runtime content, the
+    // tool result remapped to the user wire role with its original role
+    // recorded. This is the branch that used to drop `toolCalls`.
+    const toolCall = {
+      id: "toolu_keep_1792",
+      name: "Bash",
+      arguments: JSON.stringify({ command: "pwd" }),
+    };
+    const replacementHistory =
+      await projectManualCompactionReplacementHistoryForTests({
+        boundaryMarker: { role: "user", content: "boundary" },
+        summaryMessages: [],
+        messagesToKeep: [
+          {
+            role: "assistant",
+            type: "assistant",
+            content: [{ type: "text", text: "Checking the working directory." }],
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Checking the working directory." }],
+            },
+            toolCalls: [toolCall],
+          },
+          {
+            role: "user",
+            originalRole: "tool",
+            type: "user",
+            isMeta: true,
+            content: [{ type: "text", text: "/tmp/project" }],
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "/tmp/project" }],
+            },
+            toolCallId: toolCall.id,
+            toolName: "Bash",
+          },
+        ],
+        attachments: [],
+      });
+
+    expect(replacementHistory.slice(1)).toEqual([
+      {
+        role: "assistant",
+        content: "Checking the working directory.",
+        toolCalls: [toolCall],
+      },
+      {
+        role: "tool",
+        content: "/tmp/project",
+        toolCallId: toolCall.id,
+        toolName: "Bash",
+      },
+    ]);
+  });
 });
 
 describe("/context display: computeContextUsageBreakdown", () => {

--- a/runtime/tests/commands/session-compact.tool-calls.test.ts
+++ b/runtime/tests/commands/session-compact.tool-calls.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { LLMMessage } from "../../src/llm/types.js";
+import type {
+  CompactContext,
+  RuntimeMessage,
+} from "../../src/services/compact/types.js";
+import { mkProvider, mkSession } from "../fixtures.js";
+
+const summarizer = vi.hoisted(() => ({
+  manualCompactCall: vi.fn(),
+}));
+
+// Replace only the provider-backed summarizer. Everything else on the manual
+// /compact path stays real: history projection into runtime messages, the
+// slash-command bookkeeping messages, post-compact message assembly, the
+// projection back into LLM history, and the session history replacement.
+vi.mock("../../src/services/compact/compact.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../src/services/compact/compact.js")
+  >()),
+  manualCompactCall: summarizer.manualCompactCall,
+}));
+
+import { compactCommand } from "../../src/commands/session-compact.js";
+
+const TOOL_CALL_ID = "toolu_compact_1792";
+const TOOL_ARGUMENTS = JSON.stringify({ command: "pwd" });
+const TOOL_RESULT = "/tmp/project\n";
+
+function commandContext(session: unknown, argsRaw = "") {
+  return {
+    session,
+    argsRaw,
+    cwd: "/tmp/project",
+    home: "/tmp",
+    agencHome: "/tmp/.agenc",
+  } as never;
+}
+
+/**
+ * Stand-in for the compaction summarizer: keep the two most recent runtime
+ * messages exactly as they were handed in, the way the real summarizer keeps
+ * its recent tail, and summarize everything before them.
+ */
+function keepRecentTail(
+  _args: string,
+  context: CompactContext & { readonly messages?: RuntimeMessage[] },
+) {
+  const messages = context.messages ?? [];
+  return Promise.resolve({
+    type: "compact" as const,
+    displayText: "Conversation compacted (test summarizer)",
+    compactionResult: {
+      boundaryMarker: { role: "user" as const, content: "compaction boundary" },
+      summaryMessages: [
+        { role: "user" as const, content: "Summary of the earlier turns." },
+      ],
+      messagesToKeep: messages.slice(-2),
+      attachments: [],
+    },
+  });
+}
+
+function expectEveryToolResultToFollowItsCall(messages: readonly LLMMessage[]): void {
+  const toolResults = messages.filter((message) => message.role === "tool");
+  expect(toolResults.length).toBeGreaterThan(0);
+  for (const result of toolResults) {
+    const producer = messages[messages.indexOf(result) - 1];
+    expect(producer?.role).toBe("assistant");
+    expect(producer?.toolCalls?.map((call) => call.id)).toContain(result.toolCallId);
+  }
+}
+
+describe("/compact keeps retained assistant tool calls", () => {
+  afterEach(() => {
+    summarizer.manualCompactCall.mockReset();
+  });
+
+  test("a retained assistant tool call and its result survive manual compaction with the arguments intact", async () => {
+    summarizer.manualCompactCall.mockImplementation(keepRecentTail);
+    const { session, state } = mkSession({
+      provider: mkProvider({ content: "unused by the mocked summarizer" }),
+      modelInfo: { contextWindow: 131_072 },
+      history: [
+        { role: "user", content: "first request" },
+        { role: "assistant", content: "first answer" },
+        { role: "user", content: "Where are we?" },
+        {
+          role: "assistant",
+          content: "Checking the working directory.",
+          toolCalls: [
+            { id: TOOL_CALL_ID, name: "Bash", arguments: TOOL_ARGUMENTS },
+          ],
+        },
+        {
+          role: "tool",
+          toolCallId: TOOL_CALL_ID,
+          toolName: "Bash",
+          content: TOOL_RESULT,
+        },
+      ],
+    });
+
+    const result = await compactCommand.execute(commandContext(session));
+
+    expect(result).toMatchObject({ kind: "compact" });
+    expect(summarizer.manualCompactCall).toHaveBeenCalledTimes(1);
+
+    const history = session.snapshotHistoryMessages();
+    const assistantIndex = history.findIndex(
+      (message) => message.role === "assistant",
+    );
+    expect(assistantIndex).toBeGreaterThan(-1);
+    expect(history[assistantIndex]).toEqual({
+      role: "assistant",
+      content: "Checking the working directory.",
+      toolCalls: [{ id: TOOL_CALL_ID, name: "Bash", arguments: TOOL_ARGUMENTS }],
+    });
+    expect(history[assistantIndex + 1]).toMatchObject({
+      role: "tool",
+      toolCallId: TOOL_CALL_ID,
+      toolName: "Bash",
+      content: TOOL_RESULT,
+    });
+    expectEveryToolResultToFollowItsCall(history);
+    expect(state.history[assistantIndex]?.toolCalls).toEqual([
+      { id: TOOL_CALL_ID, name: "Bash", arguments: TOOL_ARGUMENTS },
+    ]);
+    expect(JSON.stringify(history)).not.toContain("first request");
+  });
+});

--- a/runtime/tests/session/runtime-message-conversion.test.ts
+++ b/runtime/tests/session/runtime-message-conversion.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCsvAgentInvocationEnvelope,
+  materializeAgentInvocationMessages,
+  validateAgentInvocationMessageSequence,
+} from "../../src/contracts/agent-invocation-envelope.js";
+import type { LLMMessage } from "../../src/llm/types.js";
+import {
+  fromAgenCRuntimeMessage,
+  fromAgenCRuntimeMessages,
+  toAgenCRuntimeMessages,
+} from "../../src/session/runtime-message-conversion.js";
+import { createToolResultIntegrity } from "../../src/session/tool-result-integrity.js";
+
+const TOOL_CALL_ID = "toolu_read_1792";
+const TOOL_ARGUMENTS = JSON.stringify({ path: "src/index.ts", offset: 10 });
+const TOOL_RESULT = "export const answer = 42;\n";
+
+/**
+ * An assistant tool call followed by its result, decorated with every optional
+ * wire field the converters must carry: phase, provider reasoning state, the
+ * tool call arguments, the result's call id and tool name, and the
+ * runtime-only tool-result integrity record.
+ */
+function pairedToolExchange(): LLMMessage[] {
+  return [
+    { role: "system", content: "You are a careful assistant." },
+    { role: "user", content: "Read src/index.ts" },
+    {
+      role: "assistant",
+      content: "Reading the file.",
+      phase: "commentary",
+      providerReasoningContent: "opaque provider state",
+      providerReasoningProvenance: { provider: "qwen", model: "qwen3.8-max" },
+      toolCalls: [
+        { id: TOOL_CALL_ID, name: "FileRead", arguments: TOOL_ARGUMENTS },
+      ],
+    },
+    {
+      role: "tool",
+      toolCallId: TOOL_CALL_ID,
+      toolName: "FileRead",
+      content: TOOL_RESULT,
+      runtimeOnly: {
+        toolResultIntegrity: createToolResultIntegrity({
+          runId: "run-1792",
+          toolCallId: TOOL_CALL_ID,
+          content: TOOL_RESULT,
+        }),
+      },
+    },
+    { role: "assistant", content: "The answer is 42.", phase: "final_answer" },
+  ];
+}
+
+function expectEveryToolResultToFollowItsCall(messages: readonly LLMMessage[]): void {
+  const toolResults = messages.filter((message) => message.role === "tool");
+  expect(toolResults.length).toBeGreaterThan(0);
+  for (const result of toolResults) {
+    const index = messages.indexOf(result);
+    const producer = messages[index - 1];
+    expect(producer?.role).toBe("assistant");
+    expect(producer?.toolCalls?.map((call) => call.id)).toContain(result.toolCallId);
+  }
+}
+
+describe("runtime message conversion round trip", () => {
+  it("restores an assistant tool call and its result with every wire field intact", () => {
+    const source = pairedToolExchange();
+
+    const restored = fromAgenCRuntimeMessages(toAgenCRuntimeMessages(source));
+
+    expect(restored).toEqual(source);
+    expect(restored[2]?.toolCalls).toEqual([
+      { id: TOOL_CALL_ID, name: "FileRead", arguments: TOOL_ARGUMENTS },
+    ]);
+    expectEveryToolResultToFollowItsCall(restored);
+    expect(() => validateAgentInvocationMessageSequence(restored)).not.toThrow();
+  });
+
+  it("writes the tool call onto the runtime assistant message and remaps the result to the user wire role", () => {
+    const [, , assistant, toolResult] = toAgenCRuntimeMessages(pairedToolExchange());
+
+    expect(assistant).toMatchObject({
+      role: "assistant",
+      type: "assistant",
+      phase: "commentary",
+      providerReasoningContent: "opaque provider state",
+      toolCalls: [
+        { id: TOOL_CALL_ID, name: "FileRead", arguments: TOOL_ARGUMENTS },
+      ],
+    });
+    expect(toolResult).toMatchObject({
+      role: "user",
+      originalRole: "tool",
+      type: "user",
+      isMeta: true,
+      toolCallId: TOOL_CALL_ID,
+      toolName: "FileRead",
+    });
+    expect(toolResult?.runtimeOnly?.toolResultIntegrity?.toolCallId).toBe(TOOL_CALL_ID);
+  });
+
+  it("keeps tool calls on the legacy type plus nested message runtime shape", () => {
+    const restored = fromAgenCRuntimeMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "kept" }],
+      },
+      toolCalls: [{ id: TOOL_CALL_ID, name: "FileRead" }],
+    });
+
+    expect(restored).toEqual({
+      role: "assistant",
+      content: "kept",
+      toolCalls: [{ id: TOOL_CALL_ID, name: "FileRead", arguments: "" }],
+    });
+  });
+
+  it("restores the developer role and runtime-only metadata of agent invocation channels", () => {
+    const envelope = createCsvAgentInvocationEnvelope({
+      jobId: "job-1792",
+      itemId: "item-1",
+      rowIndex: 0,
+      rowSha256: `sha256:${"e".repeat(64)}`,
+      instruction: "Classify the row.",
+      row: { payload: "value" },
+    });
+    const channels: LLMMessage[] = [...materializeAgentInvocationMessages(envelope)];
+    const source: LLMMessage[] = [
+      { role: "system", content: "You are a careful assistant." },
+      ...channels,
+      ...pairedToolExchange().slice(2),
+    ];
+
+    const runtime = toAgenCRuntimeMessages(source);
+    const restored = fromAgenCRuntimeMessages(runtime);
+
+    expect(channels.some((channel) => channel.role === "developer")).toBe(true);
+    expect(
+      runtime.filter((message) => message.originalRole === "developer"),
+    ).toHaveLength(channels.filter((channel) => channel.role === "developer").length);
+    expect(restored).toEqual(source);
+    expect(() => validateAgentInvocationMessageSequence(restored)).not.toThrow();
+  });
+
+  it("drops runtime messages that carry no recognizable role", () => {
+    expect(fromAgenCRuntimeMessage({ type: "progress", content: "ignored" })).toBeNull();
+    expect(
+      fromAgenCRuntimeMessages([
+        { type: "progress", content: "ignored" },
+        { type: "user", message: { role: "user", content: "kept" } },
+      ]),
+    ).toEqual([{ role: "user", content: "kept" }]);
+  });
+});


### PR DESCRIPTION
Closes #1792

## Why

`runtime/src/commands/session-compact.ts` carried its own copy of the runtime-message converters that `runtime/src/session/run-turn.ts` also declares. The two drifted: run-turn's `fromAgenCRuntimeMessage` copies the assistant `toolCalls` array (with arguments), session-compact's did not. A manual `/compact` could therefore keep a tool result while dropping the assistant call that produced it, which fails message-sequence validation or leaves the model a result with no call. The issue asked for one shared converter used by live turns and manual compaction, plus a round-trip contract.

## What changed

- `runtime/src/session/runtime-message-conversion.ts` (new): the shared pair, `toAgenCRuntimeMessages`, `fromAgenCRuntimeMessages`, `fromAgenCRuntimeMessage`, `extractMessageText`, with the types `AgenCMessage`, `AgenCMessageRole`, `AgenCRuntimeWireRole`, `AgenCRuntimeMessage`. One internal `projectRuntimeWireFields` serves both message shapes (top-level `role` + `content`, and the legacy `type` + nested `message`), so the two branches cannot drift again. Every wire field the run-turn version preserved is preserved: `toolCalls` with arguments, `toolCallId`, `toolName`, `phase`, `providerReasoningContent`, `providerReasoningProvenance`, `runtimeOnly.toolResultIntegrity`, `runtimeOnly.agentInvocation`, `originalRole`.
- `runtime/src/session/run-turn.ts`: the 12 local declarations (4 types, 8 functions) are deleted and imported from the shared module; unused imports dropped. `cloneLLMMessage`, `compactionNotRun`, `AgenCCompactionResult` stay local.
- `runtime/src/commands/session-compact.ts`: the same deletion and import rewiring.

Field-by-field comparison of the two old copies: everything but `fromAgenCRuntimeMessage` was byte-for-byte equivalent (formatting aside); the type declarations were structurally identical (run-turn redeclared the two reasoning fields that session-compact inherited from `RuntimeMessage`). Neither copy carried `runtimeOnly.compactionHistory`; that is unchanged and out of scope, the transactional path reads committed history directly.

## Evidence

Both new manual-compaction tests fail on the unfixed code with exactly `toolCalls` missing from the restored assistant message, and pass with the shared module.

## Tests

- `tests/session/runtime-message-conversion.test.ts` (new, 5): round trip LLM -> runtime -> LLM for an assistant tool call followed by its result, deep-equal on the preserved fields, and `validateAgentInvocationMessageSequence` accepts the restored sequence.
- `tests/commands/session-compact.tool-calls.test.ts` (new): `/compact` through `compactCommand.execute` with a real `Session`; only the provider summarizer is mocked to keep the last two runtime messages. Asserts the assistant call keeps its `arguments`, the tool result follows it, and every retained tool result has a producing call.
- `tests/commands/session-compact-context.test.ts`: one seam test through `projectManualCompactionReplacementHistoryForTests` using the exact top-level shape the converter writes.
- Hermetic runner over the 20 files that import run-turn, session-compact or the new module (including `runtime-session.compact-contract`, `run-turn.compact-contract`, `run-turn.test.ts`): 20 files, 282 passed.
- `tsc --noEmit`: exit 0 with declaration emit off; with it on, only the 39 pre-existing TS2883 lines that symlinked `node_modules` produce on this machine, none in changed files.

## Not changed

- Compaction behaviour, prompts, and the transactional compaction path.
- No new wire fields; `runtimeOnly.compactionHistory` is still not copied by either direction, as before.

## Counterparts

#1792 (issue); #2012 and #2013 (compaction harness work this sits beside).