### PR TITLE
fix(runtime): let the sandbox preflight admit the session plan file

### DIFF
--- a/runtime/src/tools/runtimes/sandboxing.ts
+++ b/runtime/src/tools/runtimes/sandboxing.ts
@@ -24,6 +24,11 @@ import {
   SandboxDeniedError,
   type SandboxPolicy,
 } from "../../permissions/sandbox.js";
+import {
+  getPlansDirectory,
+  isSessionPlanFile,
+  type PlanFileContext,
+} from "../../planning/plan-files.js";
 import type { SandboxMode } from "../orchestrator.js";
 import type { Tool } from "../types.js";
 import type { ToolRuntimeAttemptContext } from "./context.js";
@@ -414,7 +419,8 @@ export function enforceRuntimeSandboxAttempt(
         target,
         cwd,
         sessionTempRoot,
-      )
+      ) &&
+      !(shellAccess === null && isActiveSessionPlanFile(input.context, target))
     ) {
       throw new SandboxDeniedError(
         `sandbox workspace_write blocked write outside workspace: ${target}`,
@@ -425,6 +431,65 @@ export function enforceRuntimeSandboxAttempt(
         },
       );
     }
+  }
+}
+
+/**
+ * The active session's plan file is the one write target outside the
+ * workspace that the runtime itself hands to the model: the plan-mode
+ * attachment advertises `<AGENC_HOME>/plans/<slug>.md`, and the filesystem
+ * tools carve that family out of their workspace allowlist
+ * (coding-common.ts, filesystem.ts). This preflight runs before any tool
+ * code, so without the same allowance every Write or Edit to the plan file
+ * dies here as "outside workspace" on any machine where the plans directory
+ * is not lexically inside the turn cwd, which is every real installation.
+ *
+ * Authority never comes from model args: the session id is read from the
+ * runtime's own session object and the home from that session's bound
+ * ConfigStore, falling back to the same resolver the plan attachment uses.
+ * Only the session's own plan-file family (`<slug>*.md` directly inside the
+ * plans directory) is admitted; `.slugs.json` and other sessions' plans stay
+ * denied, and shell tools get no carve-out because the platform sandbox
+ * cannot honor it. The plans directory is compared canonically as well as
+ * lexically so a symlinked home or temp directory (macOS `/tmp` resolving to
+ * `/private/tmp`) cannot turn the path the runtime advertised into a denial.
+ */
+function isActiveSessionPlanFile(
+  context: ToolRuntimeAttemptContext,
+  target: string,
+): boolean {
+  const session = context.invocation.session as {
+    readonly conversationId?: unknown;
+    readonly services?: {
+      readonly configStore?: {
+        readonly homeContext?: { readonly path?: unknown };
+      };
+    };
+  };
+  const sessionId = session.conversationId;
+  if (typeof sessionId !== "string" || sessionId.length === 0) return false;
+  const boundHome = session.services?.configStore?.homeContext?.path;
+  const planContext: PlanFileContext =
+    typeof boundHome === "string" && boundHome.length > 0
+      ? { sessionId, agencHome: boundHome }
+      : { sessionId };
+  try {
+    const plansDirectory = path.normalize(getPlansDirectory(planContext));
+    const targetDirectory = path.dirname(target);
+    if (
+      path.normalize(targetDirectory) !== plansDirectory &&
+      safeRealpath(targetDirectory) !== safeRealpath(plansDirectory)
+    ) {
+      return false;
+    }
+    return isSessionPlanFile(
+      path.join(plansDirectory, path.basename(target)),
+      planContext,
+    );
+  } catch {
+    // Home resolution can refuse an ambiguous session binding; the plan
+    // carve-out then stays closed and the ordinary denial applies.
+    return false;
   }
 }
 

--- a/runtime/tests/phases/execute-tools.test.ts
+++ b/runtime/tests/phases/execute-tools.test.ts
@@ -2997,6 +2997,17 @@ describe("executeTools — T7 gap #109 pipeline", () => {
       permissionModeRegistry: permissionRegistry,
       withDenialTracking: true,
     });
+    // The session's bound ConfigStore home is the plan-path authority the
+    // sandbox preflight consults; the harness binds a canonical authority per
+    // test, so the env override above does not reach runtime home resolution.
+    Object.assign(session.services, {
+      configStore: {
+        homeContext: resolveHomeContext(
+          { AGENC_HOME: agencHome, HOME: agencHome },
+          { platformHome: agencHome },
+        ),
+      },
+    });
     const state = mkState({
       toolCalls: [
         {
@@ -3010,7 +3021,12 @@ describe("executeTools — T7 gap #109 pipeline", () => {
       ],
     });
 
-    await executeTools(state, mkCtx(), session);
+    // The turn cwd must be the real workspace so the plan file sits outside
+    // it on every platform. With the fixture default of "/tmp" the hermetic
+    // temp tree on Linux lives inside the workspace and the sandbox admits
+    // the write by accident, hiding a missing plan-file allowance; macOS
+    // exposes it because its temp tree resolves under /private/tmp.
+    await executeTools(state, mkCtx({ cwd: workspaceRoot }), session);
 
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0]!.content).toContain("File created successfully");

--- a/runtime/tests/tools/runtimes/runtime.test.ts
+++ b/runtime/tests/tools/runtimes/runtime.test.ts
@@ -5,10 +5,12 @@ import {
   mkdtempSync,
   readFileSync,
   realpathSync,
+  rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join, normalize, resolve } from "node:path";
+import { basename, dirname, join, normalize, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, test, vi } from "vitest";
 import {
@@ -28,6 +30,12 @@ import {
 } from "../system/file-edit.js";
 import { createFileWriteTool } from "../system/file-write.js";
 import { createPlanningTools } from "../system/planning.js";
+import {
+  clearAllPlanSlugs,
+  getPlanFilePath,
+  setPlanSlug,
+} from "../../planning/plan-files.js";
+import { resolveHomeContext } from "../../config/home.js";
 import { recordSessionRead } from "../system/filesystem.js";
 import { createWriteStdinTool } from "../system/write-stdin.js";
 import {
@@ -1020,6 +1028,122 @@ describe("tools/runtimes", () => {
         args: { input: "*** Begin Patch\nnot a hunk\n*** End Patch\n" },
       }),
     ).toThrow(/could not verify write targets/);
+  });
+
+  test("workspace-write preflight admits only the active session plan file outside the workspace", () => {
+    const agencHome = mkdtempSync(join(tmpdir(), "agenc-runtime-plan-home-"));
+    const aliasRoot = mkdtempSync(join(tmpdir(), "agenc-runtime-plan-alias-"));
+    // A symlinked spelling of the home stands in for macOS, where the
+    // advertised `/tmp/...` plan path resolves under `/private/tmp`.
+    const aliasHome = join(aliasRoot, "home");
+    symlinkSync(agencHome, aliasHome, process.platform === "win32" ? "junction" : "dir");
+    try {
+      const sessionId = "runtime-plan-session";
+      setPlanSlug({ agencHome, sessionId }, "ivory-bridge-aaed0227");
+      const planPath = getPlanFilePath({ agencHome, sessionId });
+      const agentPlanPath = getPlanFilePath({ agencHome, sessionId, agentId: "agent-1" });
+      const plansDirectory = dirname(planPath);
+      expect(planPath.startsWith(resolve("/repo"))).toBe(false);
+      // The session's bound ConfigStore home is the plan-path authority.
+      const boundServices = {
+        ...TEST_RUNTIME_SERVICES,
+        configStore: {
+          homeContext: resolveHomeContext(
+            { AGENC_HOME: agencHome, HOME: agencHome },
+            { platformHome: agencHome },
+          ),
+        },
+      };
+
+      const mutatingTool: Tool = {
+        name: "Write",
+        description: "",
+        inputSchema: { type: "object" },
+        metadata: { mutating: true },
+        execute: async () => ({ content: "not reached" }),
+      };
+      const base = callContext("call-plan-preflight", EXCLUSIVE, false);
+      const attempt = (
+        args: Record<string, unknown>,
+        overrides: {
+          readonly conversationId?: string;
+          readonly sandboxMode?: "workspace_write" | "read_only";
+          readonly services?: typeof TEST_RUNTIME_SERVICES;
+        } = {},
+      ) => () =>
+        enforceRuntimeSandboxAttempt({
+          context: {
+            ...base,
+            approvalPolicy: "never",
+            requestedSandboxMode: overrides.sandboxMode ?? "workspace_write",
+            sandboxMode: overrides.sandboxMode ?? "workspace_write",
+            approvalResolved: false,
+            rawArgs: "{}",
+            invocation: {
+              session: {
+                ...("conversationId" in overrides
+                  ? { conversationId: overrides.conversationId }
+                  : { conversationId: sessionId }),
+                services: overrides.services ?? boundServices,
+              } as never,
+              turn: { cwd: "/repo" } as never,
+              tracker: tracker() as never,
+              callId: "call-plan-preflight",
+              toolName: { name: "Write" },
+              payload: { kind: "function", arguments: "{}" },
+              source: "direct",
+            } as const,
+          },
+          tool: mutatingTool,
+          args,
+        });
+
+      // The session's own plan-file family is admitted, including the
+      // per-agent spelling and a canonical alias of the plans directory.
+      expect(attempt({ file_path: planPath })).not.toThrow();
+      expect(attempt({ file_path: agentPlanPath })).not.toThrow();
+      expect(
+        attempt({ file_path: join(aliasHome, "plans", basename(planPath)) }),
+      ).not.toThrow();
+
+      // Without a bound home the preflight falls back to the runtime's own
+      // home resolver, the same one the plan attachment uses.
+      const fallbackSessionId = "runtime-plan-fallback-session";
+      const fallbackPlanPath = getPlanFilePath({ sessionId: fallbackSessionId });
+      expect(
+        attempt(
+          { file_path: fallbackPlanPath },
+          { conversationId: fallbackSessionId, services: TEST_RUNTIME_SERVICES },
+        ),
+      ).not.toThrow();
+
+      // Everything else in the plans directory stays outside the workspace.
+      expect(attempt({ file_path: join(plansDirectory, "other-plan.md") })).toThrow(
+        /workspace_write blocked/,
+      );
+      expect(attempt({ file_path: join(plansDirectory, ".slugs.json") })).toThrow(
+        /workspace_write blocked/,
+      );
+      expect(
+        attempt({ file_path: join(plansDirectory, "nested", basename(planPath)) }),
+      ).toThrow(/workspace_write blocked/);
+
+      // A different session gets no carve-out for this plan, no session
+      // identity gets none at all, and read_only stays read-only.
+      expect(
+        attempt({ file_path: planPath }, { conversationId: "some-other-session" }),
+      ).toThrow(/workspace_write blocked/);
+      expect(attempt({ file_path: planPath }, { conversationId: undefined })).toThrow(
+        /workspace_write blocked/,
+      );
+      expect(attempt({ file_path: planPath }, { sandboxMode: "read_only" })).toThrow(
+        /read_only blocked/,
+      );
+    } finally {
+      clearAllPlanSlugs();
+      rmSync(aliasRoot, { recursive: true, force: true });
+      rmSync(agencHome, { recursive: true, force: true });
+    }
   });
 
   test("virtualNoFsWrites tools bypass the indeterminate-target denial without weakening real writers", () => {


### PR DESCRIPTION
## Why

`tests/phases/execute-tools.test.ts` ("main dispatch injects session context so Write can create the active plan file") fails on every macOS checkout while passing on Linux CI. The cause is not the test: the per-attempt sandbox preflight `enforceRuntimeSandboxAttempt` (`runtime/src/tools/runtimes/sandboxing.ts`) checks each write target lexically against the `workspace_write` roots (turn cwd and the session temp root) before any tool code runs, and it knows nothing about the plan-file allowance that the filesystem tools apply later (`coding-common.ts`, `safePathAllowingSessionPlanFile`). Linux passed by accident: the test's cwd is the literal `/tmp` and the hermetic runner keeps its temp tree under `/tmp` there, so the plan file was lexically inside the "workspace". On macOS the run root is `/private/tmp`, the accident stops, and the missing allowance shows.

The consequence is not test-only. The default sandbox mode is `workspace-write` and `~/.agenc/plans/<slug>.md` lies outside every real workspace, so a model Write or Edit to the active plan file through main dispatch is denied at the preflight on every platform.

## What changed

- `runtime/src/tools/runtimes/sandboxing.ts`: `isActiveSessionPlanFile` admits a `workspace_write` target only when it is the session's own `<slug>*.md` family directly inside the plans directory. The session id comes from the runtime's session object and the home from the session's bound config store (fallback: the resolver the plan attachment uses). The plans directory is compared lexically and canonically (realpath), so `/tmp` versus `/private/tmp` cannot cause a denial. `.slugs.json`, other sessions' plans, nested paths, shell tools and `read_only` stay denied.
- `runtime/tests/phases/execute-tools.test.ts`: the turn cwd is now the real workspace root, so the test fails on any platform without the allowance, and the temp home is bound to the fixture session through `configStore.homeContext`, following the file's existing pattern.
- `runtime/tests/tools/runtimes/runtime.test.ts`: a focused preflight test (admitted family, per-agent plan, symlink alias, resolver fallback, and each denied case).

## Evidence

Three reproductions before the fix: `canWritePathWithCwd` with the workspace_write profile returns false for cwd `/tmp` and a target under `/private/tmp/...`, true for cwd `/private/tmp`, and false for the realistic shape (`~/.agenc/plans/x.md` against a project cwd); the failing test passes with cwd `/private/tmp` and fails identically with the realistic workspace cwd; a stack trace at the throw site confirms the preflight as the denial point. A second harness fact surfaced on the way: `vitest.setup.ts` binds a canonical home authority per test, so a mid-test `process.env.AGENC_HOME` change never reaches runtime home resolution.

## Tests

- `tests/phases/execute-tools.test.ts`: 67 passed (was 66 passed, 1 failed on macOS).
- `tests/tools/runtimes/runtime.test.ts`: 19 passed, 3 pre-existing skips.
- `tests/tools/runtimes/runtime.darwin.test.ts` (native config): 2 passed.
- `tests/budget/admitted-tool-call.test.ts`, `tests/config/session-home-authority.architecture.test.ts`, `tests/permissions/donor-stack-import-boundary.test.ts`: 41 passed.
- `tsc --noEmit`: exit 0.

## Not changed

- The filesystem tools' own plan-file allowance; the preflight now agrees with it instead of pre-empting it.
- Shell tools still cannot write the plan file; `read_only` still denies it.

## Counterparts

#2138 (platform lanes that would have caught this on a macOS runner), #2136 (the other darwin path defect found this week).