### PR TITLE
prompts: keep every attachment at its place so the prompt cache holds

### DIFF
--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -227,6 +227,7 @@ These have their own pages. Short map:
 | Web search | `AGENC_WEB_SEARCH_ENDPOINT`, `AGENC_WEB_SEARCH_KIND`, `AGENC_WEB_SEARCH_API_KEY` | [config.md](config.md) |
 | xAI incremental continuation | `AGENC_XAI_INCREMENTAL` (boolean-like; projects to `providers.grok.incremental_continuation`, off by default). Streaming Grok turns then send `previous_response_id` plus the items added since the last completed response instead of the full history | [providers.md](providers.md) |
 | Provider trace | `AGENC_PROVIDER_TRACE` (truthy). Writes one JSON line per model request and per response or error, without message bodies (model, `prompt_cache_key`, `previous_response_id`, `reasoning`, `parallel_tool_calls`, `max_output_tokens`, usage, stream event count, elapsed ms), to `<AGENC_HOME>/agent-logs/<conversation>/llm-<seq>.jsonl` | [providers.md](providers.md) |
+| Provider trace bodies | `AGENC_PROVIDER_TRACE_BODIES` (truthy, only with `AGENC_PROVIDER_TRACE`). Also writes each full request as `agent-logs/<conversationId>/llm-<seq>.request.json` (secrets redacted, mode 0600). The whole prompt lands on disk, so use it in an isolated home for cache-prefix diagnosis and delete the files afterwards. `node scripts/eval/prefix-diff.mjs <that directory>` reports where consecutive requests first diverge. |
 | Trajectories | `AGENC_TRAJECTORY_EXPORT_DIR`, `AGENC_TRAJECTORY_EXPORT_PATH` | [trajectory-training-data.md](../trajectory-training-data.md) |
 
 ## TUI and BUFFER

--- a/runtime/scripts/eval/prefix-diff.mjs
+++ b/runtime/scripts/eval/prefix-diff.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Where do two consecutive provider requests first diverge?
+ *
+ * Reads the `llm-<seq>.request.json` bodies written by the provider trace
+ * with `AGENC_PROVIDER_TRACE=1 AGENC_PROVIDER_TRACE_BODIES=1` and, for every
+ * consecutive pair, finds the first byte that differs in the order the
+ * provider sees the prompt: `instructions`, then each `input` item, then the
+ * tool list. A pair whose only change is items appended to `input` keeps its
+ * cached prefix; any other divergence re-bills everything after the offset.
+ *
+ * Usage: node scripts/eval/prefix-diff.mjs <agent-logs/<conversationId>> [--json]
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REQUEST_FILE_RE = /^llm-(\d+)\.request\.json$/u;
+const CHARS_PER_TOKEN = 4;
+
+export function loadTraceRequests(directory) {
+  const out = [];
+  for (const name of readdirSync(directory)) {
+    const match = REQUEST_FILE_RE.exec(name);
+    if (match === null) continue;
+    out.push({
+      seq: Number.parseInt(match[1], 10),
+      body: JSON.parse(readFileSync(join(directory, name), "utf8")),
+    });
+  }
+  return out.sort((a, b) => a.seq - b.seq);
+}
+
+function text(value) {
+  if (value === undefined || value === null) return "";
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function commonPrefixLength(a, b) {
+  const limit = Math.min(a.length, b.length);
+  let index = 0;
+  while (index < limit && a.charCodeAt(index) === b.charCodeAt(index)) index += 1;
+  return index;
+}
+
+function snippet(source, at, span = 90) {
+  const start = Math.max(0, at - 24);
+  return source.slice(start, at + span);
+}
+
+function itemLabel(item) {
+  if (!item || typeof item !== "object") return "?";
+  return String(item.role ?? item.type ?? "?");
+}
+
+function toolName(tool) {
+  return String(tool?.name ?? tool?.function?.name ?? "?");
+}
+
+function toolsDivergence(prevTools, nextTools) {
+  const prevNames = prevTools.map(toolName);
+  const nextNames = nextTools.map(toolName);
+  const prevSet = new Set(prevNames);
+  const nextSet = new Set(nextNames);
+  const added = nextNames.filter((name) => !prevSet.has(name));
+  const removed = prevNames.filter((name) => !nextSet.has(name));
+  const sharedBefore = prevNames.filter((name) => nextSet.has(name));
+  const sharedAfter = nextNames.filter((name) => prevSet.has(name));
+  const reordered = JSON.stringify(sharedBefore) !== JSON.stringify(sharedAfter);
+  const prevByName = new Map(prevTools.map((tool) => [toolName(tool), text(tool)]));
+  const changedSchemas = nextTools
+    .filter((tool) => prevByName.has(toolName(tool)) && prevByName.get(toolName(tool)) !== text(tool))
+    .map(toolName);
+  return { field: "tools", added, removed, reordered, changedSchemas };
+}
+
+function divergenceAt(field, index, role, offsetChars, a, b, at) {
+  return {
+    field,
+    index,
+    role,
+    offsetChars,
+    approxTokens: Math.round(offsetChars / CHARS_PER_TOKEN),
+    before: snippet(a, at),
+    after: snippet(b, at),
+  };
+}
+
+/**
+ * The first difference between two request bodies, or null when `next` only
+ * appends `input` items to `prev` and nothing else moved.
+ */
+export function firstDivergence(prev, next) {
+  let charsBefore = 0;
+  const prevInstructions = text(prev.instructions);
+  const nextInstructions = text(next.instructions);
+  if (prevInstructions !== nextInstructions) {
+    const at = commonPrefixLength(prevInstructions, nextInstructions);
+    return divergenceAt("instructions", -1, "system", charsBefore + at, prevInstructions, nextInstructions, at);
+  }
+  charsBefore += prevInstructions.length;
+  const prevInput = Array.isArray(prev.input) ? prev.input : [];
+  const nextInput = Array.isArray(next.input) ? next.input : [];
+  const shared = Math.min(prevInput.length, nextInput.length);
+  for (let index = 0; index < shared; index += 1) {
+    const a = text(prevInput[index]);
+    const b = text(nextInput[index]);
+    if (a !== b) {
+      const at = commonPrefixLength(a, b);
+      return {
+        ...divergenceAt("input", index, itemLabel(prevInput[index]), charsBefore + at, a, b, at),
+        prevItemChars: a.length,
+        nextItemChars: b.length,
+      };
+    }
+    charsBefore += a.length;
+  }
+  const prevTools = Array.isArray(prev.tools) ? prev.tools : [];
+  const nextTools = Array.isArray(next.tools) ? next.tools : [];
+  if (text(prevTools) !== text(nextTools)) {
+    return {
+      ...toolsDivergence(prevTools, nextTools),
+      offsetChars: charsBefore,
+      approxTokens: Math.round(charsBefore / CHARS_PER_TOKEN),
+    };
+  }
+  if (prevInput.length > nextInput.length) {
+    return {
+      field: "input",
+      index: shared,
+      role: itemLabel(prevInput[shared]),
+      removed: prevInput.length - nextInput.length,
+      offsetChars: charsBefore,
+      approxTokens: Math.round(charsBefore / CHARS_PER_TOKEN),
+    };
+  }
+  return null;
+}
+
+export function describeDivergence(divergence) {
+  if (divergence === null) return "prefix unchanged; input only appended";
+  const indexed = divergence.index !== undefined && divergence.index >= 0;
+  const where = `${divergence.field}${indexed ? `[${divergence.index}]` : ""}`;
+  const position = `offset ${divergence.offsetChars} chars (~${divergence.approxTokens} tokens)`;
+  if (divergence.field === "tools") {
+    const parts = [];
+    if (divergence.added.length > 0) parts.push(`added ${divergence.added.join(",")}`);
+    if (divergence.removed.length > 0) parts.push(`removed ${divergence.removed.join(",")}`);
+    if (divergence.reordered) parts.push("reordered");
+    if (divergence.changedSchemas.length > 0) parts.push(`schema changed ${divergence.changedSchemas.join(",")}`);
+    return `${where} after ${position}: ${parts.join("; ")}`;
+  }
+  if (divergence.removed !== undefined) {
+    return `${where} (${divergence.role}) at ${position}: ${divergence.removed} item(s) removed`;
+  }
+  return `${where} (${divergence.role}) at ${position}\n    before: ${JSON.stringify(divergence.before)}\n    after:  ${JSON.stringify(divergence.after)}`;
+}
+
+export function reportPrefixStability(requests) {
+  const lines = [];
+  let stable = 0;
+  for (let index = 1; index < requests.length; index += 1) {
+    const divergence = firstDivergence(requests[index - 1].body, requests[index].body);
+    if (divergence === null) stable += 1;
+    lines.push(`#${requests[index - 1].seq} -> #${requests[index].seq}: ${describeDivergence(divergence)}`);
+  }
+  lines.push(`${requests.length} requests, ${Math.max(0, requests.length - 1)} pairs, ${stable} with an unchanged prefix`);
+  return lines;
+}
+
+const invokedDirectly = process.argv[1] !== undefined
+  && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  const args = process.argv.slice(2);
+  const directory = args.find((arg) => !arg.startsWith("--"));
+  if (!directory) {
+    console.error("usage: node scripts/eval/prefix-diff.mjs <agent-logs/<conversationId>> [--json]");
+    process.exit(2);
+  }
+  const requests = loadTraceRequests(directory);
+  if (args.includes("--json")) {
+    const pairs = requests.slice(1).map((request, index) => ({
+      from: requests[index].seq,
+      to: request.seq,
+      divergence: firstDivergence(requests[index].body, request.body),
+    }));
+    console.log(JSON.stringify(pairs, null, 2));
+  } else {
+    console.log(reportPrefixStability(requests).join("\n"));
+  }
+}

--- a/runtime/scripts/eval/prefix-diff.mjs
+++ b/runtime/scripts/eval/prefix-diff.mjs
@@ -73,6 +73,19 @@ function toolsDivergence(prevTools, nextTools) {
   return { field: "tools", added, removed, reordered, changedSchemas };
 }
 
+/**
+ * The trailing system item (the dynamic suffix) is the same in both requests
+ * and only moved to the end because `next` appended history before it. Every
+ * byte before it is unchanged, so the cached prefix survives.
+ */
+function suffixMoved(prevInput, nextInput, index) {
+  if (index !== prevInput.length - 1) return false;
+  const tail = prevInput[index];
+  if (itemLabel(tail) !== "system") return false;
+  if (nextInput.length <= prevInput.length) return false;
+  return text(nextInput[nextInput.length - 1]) === text(tail);
+}
+
 function divergenceAt(field, index, role, offsetChars, a, b, at) {
   return {
     field,
@@ -105,6 +118,17 @@ export function firstDivergence(prev, next) {
     const a = text(prevInput[index]);
     const b = text(nextInput[index]);
     if (a !== b) {
+      if (suffixMoved(prevInput, nextInput, index)) {
+        return {
+          field: "input",
+          index,
+          role: itemLabel(prevInput[index]),
+          suffixMoved: true,
+          appended: nextInput.length - prevInput.length,
+          offsetChars: charsBefore,
+          approxTokens: Math.round(charsBefore / CHARS_PER_TOKEN),
+        };
+      }
       const at = commonPrefixLength(a, b);
       return {
         ...divergenceAt("input", index, itemLabel(prevInput[index]), charsBefore + at, a, b, at),
@@ -136,8 +160,15 @@ export function firstDivergence(prev, next) {
   return null;
 }
 
+export function isPrefixStable(divergence) {
+  return divergence === null || divergence.suffixMoved === true;
+}
+
 export function describeDivergence(divergence) {
   if (divergence === null) return "prefix unchanged; input only appended";
+  if (divergence.suffixMoved === true) {
+    return `prefix unchanged up to the trailing system suffix at offset ${divergence.offsetChars} chars (~${divergence.approxTokens} tokens); ${divergence.appended} item(s) appended before it`;
+  }
   const indexed = divergence.index !== undefined && divergence.index >= 0;
   const where = `${divergence.field}${indexed ? `[${divergence.index}]` : ""}`;
   const position = `offset ${divergence.offsetChars} chars (~${divergence.approxTokens} tokens)`;
@@ -160,7 +191,7 @@ export function reportPrefixStability(requests) {
   let stable = 0;
   for (let index = 1; index < requests.length; index += 1) {
     const divergence = firstDivergence(requests[index - 1].body, requests[index].body);
-    if (divergence === null) stable += 1;
+    if (isPrefixStable(divergence)) stable += 1;
     lines.push(`#${requests[index - 1].seq} -> #${requests[index].seq}: ${describeDivergence(divergence)}`);
   }
   lines.push(`${requests.length} requests, ${Math.max(0, requests.length - 1)} pairs, ${stable} with an unchanged prefix`);

--- a/runtime/src/llm/provider-trace-sink.ts
+++ b/runtime/src/llm/provider-trace-sink.ts
@@ -13,13 +13,18 @@
  * `max_output_tokens`, counts for input items and tools), the provider
  * usage, the stream event count and the elapsed milliseconds.
  *
+ * With `AGENC_PROVIDER_TRACE_BODIES=1` as well, each request also lands in
+ * full as `llm-<seq>.request.json` (secrets redacted): the whole prompt, so
+ * two consecutive requests can be diffed byte for byte when the digests say
+ * the cached prefix changed. `scripts/eval/prefix-diff.mjs` reads them.
+ *
  * Diagnostics only: a write failure disables the sink for the session and
  * never reaches the turn.
  *
  * @module
  */
 
-import { appendFileSync, mkdirSync, readdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 
@@ -33,6 +38,18 @@ export function providerTraceEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   return isEnvTruthy(env[PROVIDER_TRACE_ENV]);
+}
+
+export const PROVIDER_TRACE_BODIES_ENV = "AGENC_PROVIDER_TRACE_BODIES";
+
+/**
+ * Full request bodies are a second opt-in on top of the trace: they hold the
+ * whole prompt, so they are never written by the trace flag alone.
+ */
+export function providerTraceBodiesEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return providerTraceEnabled(env) && isEnvTruthy(env[PROVIDER_TRACE_BODIES_ENV]);
 }
 
 export interface ProviderTraceSink {
@@ -214,6 +231,8 @@ export function highestExistingTraceSeq(directory: string): number {
 export function createProviderTraceSink(params: {
   readonly agencHome: string;
   readonly conversationId: string;
+  /** Also write each full request as `llm-<seq>.request.json`. */
+  readonly bodies?: boolean;
   readonly now?: () => number;
   readonly wallClock?: () => string;
 }): ProviderTraceSink {
@@ -251,6 +270,23 @@ export function createProviderTraceSink(params: {
     }
   };
 
+  const writeBody = (path: string, payload: Record<string, unknown>): void => {
+    if (disabled) return;
+    try {
+      if (!directoryReady) {
+        mkdirSync(directory, { recursive: true, mode: 0o700 });
+        directoryReady = true;
+      }
+      writeFileSync(
+        path,
+        `${JSON.stringify(redactSecretsInValue(payload))}\n`,
+        { mode: 0o600 },
+      );
+    } catch {
+      disabled = true;
+    }
+  };
+
   const base = (event: LLMProviderTraceEvent, request: InFlightRequest) => ({
     seq: request.seq,
     ts: wallClock(),
@@ -265,10 +301,11 @@ export function createProviderTraceSink(params: {
     if (disabled) return;
     if (event.kind === "request") {
       seq += 1;
+      const stem = `llm-${String(seq).padStart(5, "0")}`;
       inFlight = {
         seq,
         startedAtMs: now(),
-        path: join(directory, `llm-${String(seq).padStart(5, "0")}.jsonl`),
+        path: join(directory, `${stem}.jsonl`),
         streamEvents: 0,
         firstStreamEventMs: undefined,
       };
@@ -278,6 +315,9 @@ export function createProviderTraceSink(params: {
         params: summarizeProviderRequestParams(event.payload),
         ...(event.context !== undefined ? { context: event.context } : {}),
       });
+      if (params.bodies === true) {
+        writeBody(join(directory, `${stem}.request.json`), event.payload);
+      }
       return;
     }
     if (inFlight === undefined) return;

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -64,6 +64,7 @@ import {
 import { isPlanMode } from "../session/plan-mode.js";
 import {
   createProviderTraceSink,
+  providerTraceBodiesEnabled,
   providerTraceEnabled,
   type ProviderTraceSink,
 } from "../llm/provider-trace-sink.js";
@@ -278,6 +279,7 @@ function resolveProviderTraceSink(session: Session): ProviderTraceSink | undefin
       sink = createProviderTraceSink({
         agencHome: getAgencHomeDir(configuredHome),
         conversationId: String(session.conversationId),
+        bodies: providerTraceBodiesEnabled(),
       });
     } catch {
       sink = null;

--- a/runtime/src/prompts/attachments/messages.ts
+++ b/runtime/src/prompts/attachments/messages.ts
@@ -329,8 +329,18 @@ function renderAttachment(attachment: Attachment): LLMMessage | null {
         wrapSystemReminder(`${SKILL_LISTING_REMINDER_HEADER}\n\n${content}`),
       );
     }
+    case "skill_relevance": {
+      const content = sanitizeSystemReminderContent(attachment.content);
+      return userContextMessage(
+        wrapSystemReminder(`${SKILL_RELEVANCE_REMINDER_HEADER}\n\n${content}`),
+      );
+    }
   }
 }
+
+/** Opening sentence of the per-request `skill_relevance` reminder. */
+export const SKILL_RELEVANCE_REMINDER_HEADER =
+  "Skills relevant to this request that the listing above did not include. Invoke the Skill tool with the name when one fits:";
 
 /**
  * Opening sentence of the rendered `skill_listing` reminder. The producer

--- a/runtime/src/prompts/attachments/skill-listing.ts
+++ b/runtime/src/prompts/attachments/skill-listing.ts
@@ -3,8 +3,12 @@ import type { AttachmentProducer } from "./orchestrator.js";
 import { SKILL_LISTING_REMINDER_HEADER } from "./messages.js";
 import {
   buildSkillListingWithinBudget,
+  rankSkillsForRequest,
   type SkillListingEntry,
 } from "../../skills/local-loader.js";
+
+/** Relevance lines per request, small enough to keep in the prompt. */
+const RELEVANCE_LIMIT = 12;
 
 function messageCarriesText(message: LLMMessage, needle: string): boolean {
   if (typeof message.content === "string") {
@@ -45,24 +49,19 @@ async function bundledRegistrySkills(): Promise<readonly SkillListingEntry[]> {
 }
 
 /**
- * Attachment messages are not persisted into canonical history: every
- * sampling request re-projects `messagesForQuery` from `state.messages`,
- * so a listing emitted on the previous request is gone by the next one.
- * The gate is therefore an absence check against the request's own
- * messages, not a cross-turn hash: the listing is emitted on every request
- * unless this request already carries it. Inserted right after the leading
- * system prefix, it lands at a byte-stable position inside the cached prefix.
+ * The listing is emitted once per session and then retained in the projection
+ * (session/attachment-retention.ts), so the absence check against the
+ * request's messages holds across turns and the listing's bytes stay in the
+ * cached prefix. Later requests that name skills the listing had no room for
+ * get a small relevance block instead, and every name shown is remembered so
+ * neither block repeats itself.
  */
-export const skillListingProducer: AttachmentProducer = async (opts) => {
+export const skillListingProducer: AttachmentProducer = async (opts, tracking) => {
   if (opts.subagentDepth > 0) return [];
   if (!opts.skillsManager) return [];
-  if (
-    opts.messages.some((message) =>
-      messageCarriesText(message, SKILL_LISTING_REMINDER_HEADER),
-    )
-  ) {
-    return [];
-  }
+  const listingPresent = opts.messages.some((message) =>
+    messageCarriesText(message, SKILL_LISTING_REMINDER_HEADER),
+  );
 
   const outcome = await opts.skillsManager.skillsForConfig(opts.config ?? {}, null);
   const skills = outcome.availableSkills ?? [];
@@ -75,13 +74,26 @@ export const skillListingProducer: AttachmentProducer = async (opts) => {
   const bundled = (await bundledRegistrySkills()).filter(
     (skill) => !known.has(skill.name),
   );
-  const { listing, stats } = buildSkillListingWithinBudget(
-    [...skills, ...bundled],
+  const catalog = [...skills, ...bundled];
+  if (listingPresent) {
+    const relevant = rankSkillsForRequest(
+      catalog,
+      opts.userInput,
+      tracking.listedSkillNames,
+      RELEVANCE_LIMIT,
+    );
+    if (relevant.lines.length === 0) return [];
+    for (const name of relevant.names) tracking.listedSkillNames.add(name);
+    return [{ kind: "skill_relevance", content: relevant.lines.join("\n") }];
+  }
+  const { listing, stats, listedNames } = buildSkillListingWithinBudget(
+    catalog,
     opts.contextWindowTokens,
     // What the user just asked for decides which skills get the budget when
     // the installed catalog does not fit.
     opts.userInput,
   );
+  for (const name of listedNames) tracking.listedSkillNames.add(name);
   // What the model was shown is otherwise unrecoverable: the listing is an
   // attachment, so it never reaches the rollout, and the provider trace keeps
   // no message bodies. A run where the model ignored every skill could not be

--- a/runtime/src/prompts/attachments/types.ts
+++ b/runtime/src/prompts/attachments/types.ts
@@ -321,6 +321,15 @@ export interface SkillListingAttachment {
 }
 
 /**
+ * Skills the current request is about that the session listing did not have
+ * room for. Small and per turn, so keeping it in the prompt costs little.
+ */
+export interface SkillRelevanceAttachment {
+  readonly kind: "skill_relevance";
+  readonly content: string;
+}
+
+/**
  * Passive diagnostics published by configured LSP servers.
  * Source: upstream attachment donor `attachments.ts:2912-2954`.
  */
@@ -364,6 +373,7 @@ export type Attachment =
   | PdfMentionContextAttachment
   | McpResourceAttachment
   | SkillListingAttachment
+  | SkillRelevanceAttachment
   | LspDiagnosticsAttachment;
 
 /** All possible `Attachment.kind` values. */

--- a/runtime/src/session/attachment-retention.ts
+++ b/runtime/src/session/attachment-retention.ts
@@ -1,0 +1,191 @@
+/**
+ * Retained attachments: every system-reminder the model has seen stays at
+ * the place it was first shown.
+ *
+ * Attachments are never persisted into canonical history: each sampling
+ * request re-projects `messagesForQuery` from `state.messages` and runs the
+ * producers again. That moved the prompt bytes twice per turn: one-shot
+ * attachments (tool and agent listing deltas, the auto-mode note) vanished
+ * after the request that carried them, and at the next turn every reminder of
+ * the previous turn was gone, so the provider's prompt cache missed from the
+ * first user message onwards. Measured on a two-step session before this
+ * module: 0 of 10 consecutive requests kept an unchanged prefix.
+ *
+ * The ledger remembers each attachment block with the canonical message it
+ * was anchored to (before the user message that opened the turn, or after the
+ * history item it followed) and re-inserts it on every later projection. Within
+ * a turn the projection is append-only: the first request anchors its
+ * reminders before the prompt, later requests append theirs after the newest
+ * history item. A block whose anchor left the history (compaction) is dropped
+ * with it, which also lets one-shot producers speak again after compaction.
+ *
+ * @module
+ */
+
+import { createHash } from "node:crypto";
+
+import type { LLMMessage } from "../llm/types.js";
+
+export type RetainedPlacement = "before" | "after";
+
+export interface RetainedAttachmentBlock {
+  /** Fingerprint of the history message the block is attached to. */
+  readonly anchorKey: string;
+  /** Where the anchor sat when the block was recorded; breaks ties only. */
+  readonly anchorIndexHint: number;
+  readonly placement: RetainedPlacement;
+  readonly messages: readonly LLMMessage[];
+}
+
+export interface AttachmentRetentionLedger {
+  blocks: RetainedAttachmentBlock[];
+}
+
+export function createAttachmentRetentionLedger(): AttachmentRetentionLedger {
+  return { blocks: [] };
+}
+
+/** Attachment messages render as user-channel context, never as history. */
+export function isAttachmentMessage(message: LLMMessage): boolean {
+  return (
+    message.role === "user" &&
+    message.runtimeOnly?.mergeBoundary === "user_context"
+  );
+}
+
+function contentText(message: LLMMessage): string {
+  return typeof message.content === "string"
+    ? message.content
+    : JSON.stringify(message.content) ?? "";
+}
+
+/**
+ * A history message's identity across projections. Tool results are keyed by
+ * their call id because later projections may shorten their bodies; other
+ * roles are keyed by content and tool-call ids, which projections never edit.
+ */
+export function attachmentAnchorKey(message: LLMMessage): string {
+  if (message.role === "tool" && message.toolCallId) {
+    return `tool:${message.toolCallId}`;
+  }
+  const ids = message.toolCalls?.map((call) => call.id).join(",") ?? "";
+  const digest = createHash("sha256")
+    .update(contentText(message))
+    .digest("hex")
+    .slice(0, 16);
+  return `${message.role}:${digest}:${ids}`;
+}
+
+function resolveAnchor(
+  positions: ReadonlyMap<string, readonly number[]>,
+  block: RetainedAttachmentBlock,
+): number {
+  const candidates = positions.get(block.anchorKey);
+  if (candidates === undefined || candidates.length === 0) return -1;
+  let best = candidates[0] as number;
+  for (const index of candidates) {
+    if (
+      Math.abs(index - block.anchorIndexHint) <
+      Math.abs(best - block.anchorIndexHint)
+    ) {
+      best = index;
+    }
+  }
+  return best;
+}
+
+/**
+ * Re-insert every retained block around its anchor in `base`, the freshly
+ * projected history without attachments. Blocks whose anchor is gone are
+ * removed from the ledger; the count is returned for diagnostics.
+ */
+export function projectRetainedAttachments(
+  base: ReadonlyArray<LLMMessage>,
+  ledger: AttachmentRetentionLedger,
+): { readonly messages: LLMMessage[]; readonly dropped: number } {
+  if (ledger.blocks.length === 0) return { messages: [...base], dropped: 0 };
+  const positions = new Map<string, number[]>();
+  base.forEach((message, index) => {
+    if (isAttachmentMessage(message)) return;
+    const key = attachmentAnchorKey(message);
+    const list = positions.get(key);
+    if (list === undefined) positions.set(key, [index]);
+    else list.push(index);
+  });
+  const before = new Map<number, LLMMessage[]>();
+  const after = new Map<number, LLMMessage[]>();
+  const kept: RetainedAttachmentBlock[] = [];
+  let dropped = 0;
+  for (const block of ledger.blocks) {
+    const index = resolveAnchor(positions, block);
+    if (index < 0) {
+      dropped += 1;
+      continue;
+    }
+    kept.push(block);
+    const slots = block.placement === "before" ? before : after;
+    const slot = slots.get(index);
+    if (slot === undefined) slots.set(index, [...block.messages]);
+    else slot.push(...block.messages);
+  }
+  ledger.blocks = kept;
+  const messages: LLMMessage[] = [];
+  base.forEach((message, index) => {
+    const pre = before.get(index);
+    if (pre !== undefined) messages.push(...pre);
+    messages.push(message);
+    const post = after.get(index);
+    if (post !== undefined) messages.push(...post);
+  });
+  return { messages, dropped };
+}
+
+/**
+ * Remember `attachmentMessages` as attached to `messages[anchorIndex]`, which
+ * must be a history message (never an attachment).
+ */
+export function recordRetainedAttachments(
+  ledger: AttachmentRetentionLedger,
+  messages: ReadonlyArray<LLMMessage>,
+  anchorIndex: number,
+  placement: RetainedPlacement,
+  attachmentMessages: ReadonlyArray<LLMMessage>,
+): void {
+  const anchor = messages[anchorIndex];
+  if (anchor === undefined || isAttachmentMessage(anchor)) return;
+  if (attachmentMessages.length === 0) return;
+  ledger.blocks.push({
+    anchorKey: attachmentAnchorKey(anchor),
+    anchorIndexHint: anchorIndex,
+    placement,
+    messages: [...attachmentMessages],
+  });
+}
+
+/** Index of the user message that opened the current turn, or -1. */
+export function currentUserMessageIndex(
+  messages: ReadonlyArray<LLMMessage>,
+): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (
+      message?.role === "user" &&
+      message.runtimeOnly?.mergeBoundary === undefined &&
+      message.runtimeOnly?.agentInvocation === undefined
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/** Index of the newest history message (attachments skipped), or -1. */
+export function lastHistoryMessageIndex(
+  messages: ReadonlyArray<LLMMessage>,
+): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message !== undefined && !isAttachmentMessage(message)) return index;
+  }
+  return -1;
+}

--- a/runtime/src/session/attachment-state.ts
+++ b/runtime/src/session/attachment-state.ts
@@ -28,6 +28,10 @@
  */
 
 import type { SwarmRoutingDecision } from "../agents/swarm-routing.js";
+import {
+  createAttachmentRetentionLedger,
+  type AttachmentRetentionLedger,
+} from "./attachment-retention.js";
 
 /**
  * Tracking fields owned by the per-turn attachments orchestrator.
@@ -166,6 +170,18 @@ export interface AttachmentTrackingState {
     readonly note: string;
     readonly rolloutIds: readonly string[];
   }>;
+  /**
+   * Every attachment block the model has seen, anchored to the history
+   * message it was shown with, so later projections keep the prompt bytes
+   * in place (see session/attachment-retention.ts).
+   */
+  retainedAttachments: AttachmentRetentionLedger;
+  /**
+   * Skill names already in front of the model through the session listing or
+   * a per-request relevance block; the skill listing producer never repeats
+   * them.
+   */
+  listedSkillNames: Set<string>;
 }
 
 const sessionAttachmentState = new WeakMap<object, AttachmentTrackingState>();
@@ -194,6 +210,8 @@ export function getAttachmentTrackingState(
       surfacedRelevantMemoryBytes: 0,
       memoryMode: "enabled",
       memoryCitations: [],
+      retainedAttachments: createAttachmentRetentionLedger(),
+      listedSkillNames: new Set(),
     };
     sessionAttachmentState.set(sessionKey, state);
   }

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -123,6 +123,14 @@ import {
   type LiveInstructionPolicy,
 } from "../prompts/live-instructions.js";
 import { attachmentsToMessages } from "../prompts/attachments/messages.js";
+import {
+  currentUserMessageIndex,
+  isAttachmentMessage,
+  lastHistoryMessageIndex,
+  projectRetainedAttachments,
+  recordRetainedAttachments,
+  type AttachmentRetentionLedger,
+} from "./attachment-retention.js";
 import { extractMentionAllowedRoots } from "../prompts/file-mentions.js";
 import { CompactionReconstructionRequiredError } from "../services/compact/transaction-types.js";
 import {
@@ -2707,6 +2715,42 @@ export function buildPrompt(
  * is represented as leading `role: "system"` messages before provider wiring,
  * so user-channel context belongs immediately after that leading prefix.
  */
+/**
+ * Place this request's attachments and remember them in the session ledger.
+ * The turn's first request puts them before the prompt, as before; later
+ * requests append them after the newest history item, so everything the
+ * provider already received keeps its bytes and only new items follow.
+ */
+function placeRetainedAttachments(
+  state: TurnState,
+  ledger: AttachmentRetentionLedger,
+  attachmentMessages: ReadonlyArray<LLMMessage>,
+): LLMMessage[] {
+  const messages = state.messagesForQuery;
+  if (state.attachmentsAnchoredForTurn !== true) {
+    const anchorIndex = currentUserMessageIndex(messages);
+    if (anchorIndex < 0) {
+      return insertContextMessagesAfterLeadingSystem(messages, attachmentMessages);
+    }
+    recordRetainedAttachments(ledger, messages, anchorIndex, "before", attachmentMessages);
+    return [
+      ...messages.slice(0, anchorIndex),
+      ...attachmentMessages,
+      ...messages.slice(anchorIndex),
+    ];
+  }
+  const anchorIndex = lastHistoryMessageIndex(messages);
+  if (anchorIndex < 0) {
+    return insertContextMessagesAfterLeadingSystem(messages, attachmentMessages);
+  }
+  recordRetainedAttachments(ledger, messages, anchorIndex, "after", attachmentMessages);
+  return [
+    ...messages.slice(0, anchorIndex + 1),
+    ...attachmentMessages,
+    ...messages.slice(anchorIndex + 1),
+  ];
+}
+
 export function insertContextMessagesAfterLeadingSystem(
   messages: ReadonlyArray<LLMMessage>,
   contextMessages: ReadonlyArray<LLMMessage>,
@@ -2781,6 +2825,8 @@ function extractLastUserText(
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const message = messages[i];
     if (message?.role !== "user") continue;
+    // Retained attachments are user-channel context, not what the user asked.
+    if (isAttachmentMessage(message)) continue;
     if (typeof message.content === "string") {
       return message.content.length > 0 ? message.content : null;
     }
@@ -3067,6 +3113,19 @@ async function prepareSamplingRequestBoundary(
   const agencHome = attachmentConfigStore.homeContext.path;
   const currentConfig = attachmentConfigStore.current();
   const fileMentionAllowedRoots = extractMentionAllowedRoots(currentConfig);
+  // Retained attachments first: producers see what the model already has in
+  // front of it, and the bytes sent on earlier requests keep their place.
+  // Editor interactions project one immutable revision and stay out of it.
+  const retention =
+    ctx.editorInteraction === undefined
+      ? getAttachmentTrackingState(session).retainedAttachments
+      : undefined;
+  if (retention !== undefined) {
+    state.messagesForQuery = projectRetainedAttachments(
+      state.messagesForQuery,
+      retention,
+    ).messages;
+  }
   const userInput = extractLastUserText(state.messagesForQuery);
   const rootHumanTurn = session.currentRootHumanTurn();
   if (ctx.editorInteraction === undefined) {
@@ -3121,12 +3180,16 @@ async function prepareSamplingRequestBoundary(
     );
     const attachmentMessages = attachmentsToMessages(attachments);
     if (attachmentMessages.length > 0) {
-      state.messagesForQuery = insertContextMessagesBeforeCurrentUser(
-        state.messagesForQuery,
-        attachmentMessages,
-      );
+      state.messagesForQuery =
+        retention === undefined
+          ? insertContextMessagesBeforeCurrentUser(
+              state.messagesForQuery,
+              attachmentMessages,
+            )
+          : placeRetainedAttachments(state, retention, attachmentMessages);
     }
   }
+  if (retention !== undefined) state.attachmentsAnchoredForTurn = true;
 
   const request = buildSamplingRequestContract(state, session, ctx);
   const swarmToolChoice = claimRequiredSwarmToolChoice({

--- a/runtime/src/session/turn-state.ts
+++ b/runtime/src/session/turn-state.ts
@@ -281,6 +281,13 @@ export interface TurnState {
   messagesForQuery: LLMMessage[];
 
   /**
+   * Set once the turn's first sampling request has placed its attachments
+   * before the prompt; later requests of the same turn append theirs after
+   * the newest history item so the bytes already sent stay in place.
+   */
+  attachmentsAnchoredForTurn?: boolean;
+
+  /**
    * Fully resolved system/developer/workspace instruction envelope for this
    * turn. Kept outside conversation history so providers receive it exactly
    * once through their native system-prompt field on every retry/iteration.

--- a/runtime/src/skills/local-loader.ts
+++ b/runtime/src/skills/local-loader.ts
@@ -1106,7 +1106,12 @@ export function buildSkillListingWithinBudget(
   skills: readonly SkillListingEntry[],
   contextWindowTokens?: number,
   request?: string | null,
-): { readonly listing: string; readonly stats: SkillListingStats } {
+): {
+  readonly listing: string;
+  readonly stats: SkillListingStats;
+  /** Names of the skills whose lines made it into the listing. */
+  readonly listedNames: readonly string[];
+} {
   const commands = skills.filter((skill) => !skill.disableModelInvocation);
   const tokensForStats = requestMatchTokens(request);
   const emptyStats = (budgetChars: number): SkillListingStats => ({
@@ -1118,7 +1123,11 @@ export function buildSkillListingWithinBudget(
     ranked: false,
   });
   if (commands.length === 0) {
-    return { listing: "", stats: emptyStats(getListingCharBudget(contextWindowTokens)) };
+    return {
+      listing: "",
+      stats: emptyStats(getListingCharBudget(contextWindowTokens)),
+      listedNames: [],
+    };
   }
   const budget = getListingCharBudget(contextWindowTokens);
   const fullLines = commands.map(formatSkillListingLine);
@@ -1135,6 +1144,7 @@ export function buildSkillListingWithinBudget(
         usedChars: fullTotal,
         ranked: false,
       },
+      listedNames: commands.map((skill) => skill.name),
     };
   }
 
@@ -1167,6 +1177,7 @@ export function buildSkillListingWithinBudget(
     )
     .map((entry) => entry.skill);
   const lines = bundled.map(formatSkillListingLine);
+  const listedNames = bundled.map((skill) => skill.name);
   let used = lines.reduce((sum, line) => sum + line.length + 1, 0);
   const reserve = formatHiddenSkillsLine(rest.length).length + 1;
   let shown = 0;
@@ -1176,6 +1187,7 @@ export function buildSkillListingWithinBudget(
     // than one line, so the listing never degrades to a bare count.
     if (shown > 0 && used + line.length + reserve > budget) break;
     lines.push(line);
+    listedNames.push(skill.name);
     used += line.length + 1;
     shown += 1;
   }
@@ -1192,6 +1204,40 @@ export function buildSkillListingWithinBudget(
       usedChars: listing.length,
       ranked: tokensForStats.length > 0,
     },
+    listedNames,
+  };
+}
+
+/**
+ * The skills a request is about that are not yet in front of the model:
+ * relevance-ranked lines for up to `limit` invocable skills outside
+ * `exclude`, or nothing when the request carries no matchable words.
+ */
+export function rankSkillsForRequest(
+  skills: readonly SkillListingEntry[],
+  request: string | null | undefined,
+  exclude: ReadonlySet<string>,
+  limit: number,
+): { readonly lines: readonly string[]; readonly names: readonly string[] } {
+  const tokens = requestMatchTokens(request);
+  if (tokens.length === 0 || limit <= 0) return { lines: [], names: [] };
+  const ranked = skills
+    .filter((skill) => !skill.disableModelInvocation && !exclude.has(skill.name))
+    .map((skill, index) => ({
+      skill,
+      index,
+      rank: skillListingRank(skill),
+      relevance: skillRelevance(skill, tokens),
+    }))
+    .filter((entry) => entry.relevance > 0)
+    .sort(
+      (a, b) =>
+        b.relevance - a.relevance || a.rank - b.rank || a.index - b.index,
+    )
+    .slice(0, limit);
+  return {
+    lines: ranked.map((entry) => formatSkillListingLine(entry.skill)),
+    names: ranked.map((entry) => entry.skill.name),
   };
 }
 

--- a/runtime/tests/eval/prefix-diff.test.ts
+++ b/runtime/tests/eval/prefix-diff.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { describeDivergence, firstDivergence, reportPrefixStability } from "../../scripts/eval/prefix-diff.mjs";
+
+const base = {
+  instructions: "You are the agent.",
+  input: [
+    { role: "system", content: "static head" },
+    { role: "user", content: "first prompt" },
+  ],
+  tools: [{ name: "FileRead", parameters: { a: 1 } }, { name: "Write", parameters: { b: 2 } }],
+};
+
+describe("firstDivergence", () => {
+  it("treats appended input items as an unchanged prefix", () => {
+    const next = { ...base, input: [...base.input, { role: "assistant", content: "ok" }, { role: "tool", content: "done" }] };
+    expect(firstDivergence(base, next)).toBeNull();
+    expect(describeDivergence(null)).toContain("unchanged");
+  });
+
+  it("locates a change inside the instructions with its offset", () => {
+    const next = { ...base, instructions: "You are the agent. Time: 12:01" };
+    const divergence = firstDivergence(base, next);
+    expect(divergence).toMatchObject({ field: "instructions", index: -1, offsetChars: 18, approxTokens: 5 });
+    expect(divergence?.after).toContain("Time: 12:01");
+  });
+
+  it("locates a rewritten input item and counts the bytes before it", () => {
+    const next = { ...base, input: [base.input[0], { role: "user", content: "first prompt, edited" }] };
+    const divergence = firstDivergence(base, next);
+    expect(divergence?.field).toBe("input");
+    expect(divergence?.index).toBe(1);
+    expect(divergence?.role).toBe("user");
+    // instructions plus the whole first item precede the differing byte.
+    expect(divergence?.offsetChars).toBeGreaterThan(base.instructions.length + JSON.stringify(base.input[0]).length);
+    expect(describeDivergence(divergence)).toContain("input[1] (user)");
+  });
+
+  it("reports tool list churn by name and schema", () => {
+    const next = { ...base, tools: [{ name: "Write", parameters: { b: 2 } }, { name: "FileRead", parameters: { a: 1, c: 3 } }, { name: "Grep", parameters: {} }] };
+    const divergence = firstDivergence(base, next);
+    expect(divergence).toMatchObject({ field: "tools", added: ["Grep"], removed: [], reordered: true, changedSchemas: ["FileRead"] });
+    expect(describeDivergence(divergence)).toContain("added Grep");
+  });
+
+  it("reports removed input items as a divergence at the removal point", () => {
+    const next = { ...base, input: [base.input[0]] };
+    expect(firstDivergence(base, next)).toMatchObject({ field: "input", index: 1, removed: 1 });
+  });
+
+  it("summarizes a run of requests", () => {
+    const requests = [
+      { seq: 1, body: base },
+      { seq: 2, body: { ...base, input: [...base.input, { role: "assistant", content: "ok" }] } },
+      { seq: 3, body: { ...base, instructions: "You are the agent!", input: [...base.input, { role: "assistant", content: "ok" }] } },
+    ];
+    const lines = reportPrefixStability(requests);
+    expect(lines[0]).toContain("#1 -> #2: prefix unchanged");
+    expect(lines[1]).toContain("#2 -> #3: instructions (system) at offset 17 chars");
+    expect(lines.at(-1)).toBe("3 requests, 2 pairs, 1 with an unchanged prefix");
+  });
+});

--- a/runtime/tests/eval/prefix-diff.test.ts
+++ b/runtime/tests/eval/prefix-diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { describeDivergence, firstDivergence, reportPrefixStability } from "../../scripts/eval/prefix-diff.mjs";
+import { describeDivergence, firstDivergence, isPrefixStable, reportPrefixStability } from "../../scripts/eval/prefix-diff.mjs";
 
 const base = {
   instructions: "You are the agent.",
@@ -40,6 +40,17 @@ describe("firstDivergence", () => {
     const divergence = firstDivergence(base, next);
     expect(divergence).toMatchObject({ field: "tools", added: ["Grep"], removed: [], reordered: true, changedSchemas: ["FileRead"] });
     expect(describeDivergence(divergence)).toContain("added Grep");
+  });
+
+  it("treats the trailing system suffix moving to the end as an unchanged prefix", () => {
+    const suffix = { role: "system", content: "# Session-specific guidance" };
+    const prev = { ...base, input: [...base.input, suffix] };
+    const next = { ...base, input: [...base.input, { role: "assistant", content: "ok" }, { role: "tool", content: "r" }, suffix] };
+    const divergence = firstDivergence(prev, next);
+    expect(divergence).toMatchObject({ field: "input", index: 2, suffixMoved: true, appended: 2 });
+    expect(isPrefixStable(divergence)).toBe(true);
+    expect(describeDivergence(divergence)).toContain("trailing system suffix");
+    expect(reportPrefixStability([{ seq: 1, body: prev }, { seq: 2, body: next }]).at(-1)).toBe("2 requests, 1 pairs, 1 with an unchanged prefix");
   });
 
   it("reports removed input items as a divergence at the removal point", () => {

--- a/runtime/tests/llm/provider-trace-sink.test.ts
+++ b/runtime/tests/llm/provider-trace-sink.test.ts
@@ -161,6 +161,37 @@ describe("provider trace sink", () => {
     });
   });
 
+  test("writes the full request body only when bodies are requested", () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-trace-bodies-"));
+    homes.push(home);
+    const payload = {
+      model: "grok-4",
+      prompt_cache_key: "conv-bodies",
+      instructions: "static head",
+      input: [{ role: "user", content: "hello with token sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG" }],
+      tools: [{ name: "FileRead" }],
+    };
+    const request: LLMProviderTraceEvent = {
+      kind: "request",
+      transport: "chat_stream",
+      provider: "grok",
+      model: "grok-4",
+      payload,
+    };
+    const silent = createProviderTraceSink({ agencHome: home, conversationId: "conv-silent" });
+    silent.onProviderTraceEvent(request);
+    expect(readdirSync(silent.directory)).toEqual(["llm-00001.jsonl"]);
+
+    const loud = createProviderTraceSink({ agencHome: home, conversationId: "conv-bodies", bodies: true });
+    loud.onProviderTraceEvent(request);
+    expect(readdirSync(loud.directory).sort()).toEqual(["llm-00001.jsonl", "llm-00001.request.json"]);
+    const body = JSON.parse(readFileSync(join(loud.directory, "llm-00001.request.json"), "utf8"));
+    expect(body.instructions).toBe("static head");
+    expect(body.input).toHaveLength(1);
+    expect(body.tools).toEqual([{ name: "FileRead" }]);
+    expect(JSON.stringify(body)).not.toContain("sk-ant-api03-abcdefghijklmnopqrstuvwxyz");
+  });
+
   test("numbers files per request and records errors with elapsed time", () => {
     const home = tempHome();
     let clock = 0;

--- a/runtime/tests/prompts/attachments/skill-listing.test.ts
+++ b/runtime/tests/prompts/attachments/skill-listing.test.ts
@@ -187,6 +187,51 @@ describe("skillListingProducer", () => {
     ).toEqual([]);
   });
 
+  test("the session listing records the names it showed", async () => {
+    const opts = makeOpts();
+    const tracking = getAttachmentTrackingState(opts.sessionKey);
+    const result = await skillListingProducer(opts, tracking);
+    expect(result.map((attachment) => attachment.kind)).toEqual(["skill_listing"]);
+    // Bundled runtime skills join the listing too; the loaded one must be recorded.
+    expect(tracking.listedSkillNames.has("repo-docs")).toBe(true);
+  });
+
+  test("once the listing is present, a request that names an unlisted skill gets a relevance block, once", async () => {
+    const rendered =
+      `<system-reminder>\n${SKILL_LISTING_REMINDER_HEADER}\n\n- repo-docs: Explain the repository docs\n</system-reminder>`;
+    const opts = makeOpts({
+      userInput: "write unit tests for the parser",
+      messages: [
+        { role: "user", content: rendered, runtimeOnly: { mergeBoundary: "user_context" } },
+        { role: "user", content: "write unit tests for the parser" },
+      ],
+      skillsManager: {
+        skillsForConfig: async () => ({
+          invokedSkills: [],
+          availableSkills: [
+            { name: "repo-docs", description: "Explain the repository docs", loadedFrom: "skills" },
+            { name: "generating-unit-tests", description: "Write unit tests for a module", loadedFrom: "skills" },
+            { name: "deploy-helm", description: "Deploy charts to a cluster", loadedFrom: "skills" },
+          ],
+        }),
+      },
+    });
+    const tracking = getAttachmentTrackingState(opts.sessionKey);
+    tracking.listedSkillNames.add("repo-docs");
+
+    const first = await skillListingProducer(opts, tracking);
+    expect(first).toHaveLength(1);
+    expect(first[0]?.kind).toBe("skill_relevance");
+    const content = (first[0] as { content: string }).content;
+    expect(content).toContain("generating-unit-tests");
+    expect(content).not.toContain("repo-docs");
+    expect(content).not.toContain("deploy-helm");
+    expect(tracking.listedSkillNames.has("generating-unit-tests")).toBe(true);
+
+    // The same request again: every relevant name is already in front of the model.
+    expect(await skillListingProducer(opts, tracking)).toEqual([]);
+  });
+
   test("emits nothing for subagents and skips skills that are not model-invocable", async () => {
     const subagent = makeOpts({ subagentDepth: 1 });
     expect(

--- a/runtime/tests/session/attachment-retention.test.ts
+++ b/runtime/tests/session/attachment-retention.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage } from "../../src/llm/types.js";
+import {
+  attachmentAnchorKey,
+  createAttachmentRetentionLedger,
+  currentUserMessageIndex,
+  lastHistoryMessageIndex,
+  projectRetainedAttachments,
+  recordRetainedAttachments,
+} from "../../src/session/attachment-retention.js";
+
+const reminder = (text: string): LLMMessage => ({
+  role: "user",
+  content: `<system-reminder>\n${text}\n</system-reminder>`,
+  runtimeOnly: { mergeBoundary: "user_context" },
+});
+const user = (text: string): LLMMessage => ({ role: "user", content: text });
+const assistantCall = (id: string): LLMMessage => ({
+  role: "assistant",
+  content: "",
+  toolCalls: [{ id, name: "FileRead", arguments: "{}" }],
+});
+const toolResult = (id: string, body: string): LLMMessage => ({
+  role: "tool",
+  toolCallId: id,
+  toolName: "FileRead",
+  content: body,
+});
+
+describe("attachment retention", () => {
+  it("keeps the first request's block before the prompt on later projections", () => {
+    const ledger = createAttachmentRetentionLedger();
+    const first = [{ role: "system", content: "sys" } as LLMMessage, user("build it")];
+    recordRetainedAttachments(ledger, first, 1, "before", [reminder("skills")]);
+
+    const second = [...first, assistantCall("c1"), toolResult("c1", "ok")];
+    const projected = projectRetainedAttachments(second, ledger);
+    expect(projected.dropped).toBe(0);
+    expect(projected.messages.map((m) => m.content)).toEqual([
+      "sys",
+      "<system-reminder>\nskills\n</system-reminder>",
+      "build it",
+      "",
+      "ok",
+    ]);
+  });
+
+  it("appends later blocks after the history item they followed and keeps the order across turns", () => {
+    const ledger = createAttachmentRetentionLedger();
+    const base1 = [user("turn one")];
+    recordRetainedAttachments(ledger, base1, 0, "before", [reminder("A1")]);
+    const base2 = [...base1, assistantCall("c1"), toolResult("c1", "r1")];
+    recordRetainedAttachments(ledger, base2, 2, "after", [reminder("A2")]);
+    const base3 = [...base2, { role: "assistant", content: "done" } as LLMMessage, user("turn two")];
+    recordRetainedAttachments(ledger, base3, 4, "before", [reminder("A3")]);
+
+    const projected = projectRetainedAttachments(base3, ledger).messages;
+    expect(projected.map((m) => (typeof m.content === "string" ? m.content : ""))).toEqual([
+      "<system-reminder>\nA1\n</system-reminder>",
+      "turn one",
+      "",
+      "r1",
+      "<system-reminder>\nA2\n</system-reminder>",
+      "done",
+      "<system-reminder>\nA3\n</system-reminder>",
+      "turn two",
+    ]);
+    // The bytes of the earlier requests are a prefix of the later projection.
+    const earlier = projectRetainedAttachments(base2, createLedgerWith(ledger, 2)).messages;
+    expect(projected.slice(0, earlier.length)).toEqual(earlier);
+  });
+
+  it("survives a shortened tool result because tool anchors key on the call id", () => {
+    const ledger = createAttachmentRetentionLedger();
+    const base = [user("go"), assistantCall("c9"), toolResult("c9", "x".repeat(5000))];
+    recordRetainedAttachments(ledger, base, 2, "after", [reminder("diag")]);
+    const shortened = [user("go"), assistantCall("c9"), toolResult("c9", "[truncated]")];
+    const projected = projectRetainedAttachments(shortened, ledger);
+    expect(projected.dropped).toBe(0);
+    expect(projected.messages[3]?.content).toContain("diag");
+  });
+
+  it("drops a block whose anchor left the history", () => {
+    const ledger = createAttachmentRetentionLedger();
+    recordRetainedAttachments(ledger, [user("old prompt")], 0, "before", [reminder("gone")]);
+    const compacted = [{ role: "user", content: "summary of the past" } as LLMMessage, user("new prompt")];
+    const projected = projectRetainedAttachments(compacted, ledger);
+    expect(projected.dropped).toBe(1);
+    expect(ledger.blocks).toHaveLength(0);
+    expect(projected.messages).toHaveLength(2);
+  });
+
+  it("disambiguates identical prompts by the recorded position", () => {
+    const ledger = createAttachmentRetentionLedger();
+    const base = [user("again"), { role: "assistant", content: "ok" } as LLMMessage, user("again")];
+    recordRetainedAttachments(ledger, base, 2, "before", [reminder("second")]);
+    const projected = projectRetainedAttachments(base, ledger).messages;
+    expect(projected.map((m) => (typeof m.content === "string" ? m.content : ""))).toEqual([
+      "again",
+      "ok",
+      "<system-reminder>\nsecond\n</system-reminder>",
+      "again",
+    ]);
+  });
+
+  it("never records an attachment as an anchor and skips them when locating history", () => {
+    const ledger = createAttachmentRetentionLedger();
+    const messages = [user("p"), reminder("r")];
+    recordRetainedAttachments(ledger, messages, 1, "after", [reminder("x")]);
+    expect(ledger.blocks).toHaveLength(0);
+    expect(lastHistoryMessageIndex(messages)).toBe(0);
+    expect(currentUserMessageIndex([reminder("a"), user("p"), reminder("b")])).toBe(1);
+    expect(attachmentAnchorKey(toolResult("c1", "a"))).toBe("tool:c1");
+    expect(attachmentAnchorKey(user("a"))).not.toBe(attachmentAnchorKey(user("b")));
+  });
+});
+
+function createLedgerWith(source: ReturnType<typeof createAttachmentRetentionLedger>, count: number) {
+  const ledger = createAttachmentRetentionLedger();
+  ledger.blocks = source.blocks.slice(0, count);
+  return ledger;
+}


### PR DESCRIPTION
## Why

The first real coding-loop eval (grok-4.6 over xAI, PR #2139) showed the provider's prompt cache missing at the first model call of every turn and on scattered calls inside turns. A per-request trace of the request bodies (added here) found the cause: attachments (the system-reminders for skills, deltas, auto mode, diagnostics, memories) are never persisted into canonical history, and every sampling request re-projects the history and runs the producers again. One-shot attachments vanished after the request that carried them, and at the next turn every reminder of the previous turn was gone, so the bytes the provider saw changed from the first user message onwards. Measured on a two-step session: 0 of 10 consecutive requests kept an unchanged prefix, and the `previous_response_id` continuation never engaged because the input was never an extension of the previous one.

## What changed

- `runtime/src/session/attachment-retention.ts` (new): a per-session ledger that anchors each attachment block to the history message it was shown with (before the user message that opened the turn, or after the history item it followed) and re-inserts it on every projection. Tool results are keyed by call id so later shortening of their bodies keeps the anchor; other roles by content and tool-call ids, which projections never edit. A block whose anchor left the history (compaction) is dropped, which also lets one-shot producers speak again after compaction.
- `runtime/src/session/run-turn.ts`: retained blocks are projected before the producers run, so producers see what the model already has; the turn's first request places its attachments before the prompt as before, later requests append theirs after the newest history item, so the projection is append-only within a turn. `extractLastUserText` skips retained reminders. Editor interactions (one immutable revision) stay out of the ledger.
- `runtime/src/session/turn-state.ts`: `attachmentsAnchoredForTurn`, set after the first request of a turn.
- `runtime/src/session/attachment-state.ts`: `retainedAttachments` ledger and `listedSkillNames` on the per-session tracking state.
- `runtime/src/prompts/attachments/skill-listing.ts`, `types.ts`, `messages.ts`, `runtime/src/skills/local-loader.ts`: the skills listing is emitted once per session and retained (its absence check finally holds across requests). Later requests that name skills the listing had no room for get a small `skill_relevance` block (up to 12 lines, relevance-ranked, never repeating a name shown before); `buildSkillListingWithinBudget` reports `listedNames`, and `rankSkillsForRequest` produces the block.
- `runtime/src/llm/provider-trace-sink.ts`, `runtime/src/phases/stream-model.ts`, `docs/reference/env.md`: `AGENC_PROVIDER_TRACE_BODIES=1` (only with `AGENC_PROVIDER_TRACE`) also writes each full request as `llm-<seq>.request.json` (redacted, mode 0600) so consecutive prompts can be diffed byte for byte.
- `runtime/scripts/eval/prefix-diff.mjs` (new): reports where consecutive traced requests first diverge (instructions, input item, tool list); the trailing dynamic system suffix moving to the end after appended items counts as an unchanged prefix, because every byte before it is the same.

## Evidence

Same two-step session task, same model, isolated home, request bodies traced:

| | before | after |
| --- | --- | --- |
| consecutive request pairs with an unchanged prefix | 0 of 10 | 7 of 7 |
| first call of turn 2, cached input tokens | 0 of 25046 | 20736 of 24432 (85%) |
| cache hit ratio on calls after the session's first | 55% to 92% with drops to 512 or 0 | 78% to 88%, no drops |
| the two steps | passed, 118 s + 93 s, 432k input tokens | passed, 60 s + 62 s, 285k input tokens |

The first divergence in the old trace was `input[2]` at ~4.8k tokens (the agent-listing delta vanished after the first call) and, at the turn boundary, `input[1]` at ~4.5k tokens (the auto-mode reminder before the first prompt was gone). Wall time is model-bound and varies run to run; the prefix and cache columns are the mechanism.

## Tests

- `tests/session/attachment-retention.test.ts` (new, 6): the first request's block stays before the prompt on later projections; later blocks append after the item they followed and earlier request bytes are a prefix of later projections; a shortened tool result keeps its anchor; a block whose anchor left the history is dropped; identical prompts are told apart by position; attachments are never anchors.
- `tests/prompts/attachments/skill-listing.test.ts`: the session listing records what it showed; a present listing plus a request naming an unlisted skill yields one relevance block, and the same request again yields nothing.
- `tests/eval/prefix-diff.test.ts` (new): divergence in instructions, in an input item, in the tool list, removed items, appended items, the suffix-moved case, and the run summary. `tests/llm/provider-trace-sink.test.ts`: bodies written only when requested, redacted.
- Hermetic runner: `tests/prompts/attachments` (all), `tests/session/run-turn.test.ts` (130), `tests/skills/local-loader.test.ts`, the compaction contracts (`run-turn.compact-contract`, `runtime-session.compact-contract`, `gaphunt3/session-run-turn`), `tests/session/attachment-state.test.ts`, `tests/agents/run-agent.test.ts`: all green (counts in the checks).
- `tsc --noEmit`: clean apart from the pre-existing TS2883 lines that symlinked `node_modules` produce locally.
- One known load-sensitive case, `run-agent.test.ts` "rolls clean worktree baselines without mutating the first immutable receipt", timed out at 30 s while the traced smoke and a build ran on the same machine; alone it passes in 1.3 s on this branch and on main.

## Not changed

- Canonical history and the rollout format: attachments are still not persisted; the ledger lives in the session's tracking state and is rebuilt empty after a daemon restart (one prefix miss).
- The `previous_response_id` continuation in the Grok adapter still compares the whole input, including the trailing suffix, so it still never engages; that is the next PR, now measurable with the same trace.
- The 180-skill catalog budget and ranking rules; only when the listing is shown and what follows it changed.

## Counterparts

#2139 (the eval lane that found this), #2014 and #2025 (the listing on every request and relevance ranking, which this keeps), #2142.
