### PR TITLE
eval: run session tasks through an external agent's CLI, one step at a time

### DIFF
--- a/runtime/eval/README.md
+++ b/runtime/eval/README.md
@@ -56,6 +56,23 @@ npm run eval:agent -- --suite eval/tasks \
 The real executor needs `AGENC_HOME` pointing at an isolated home, never your
 own. Print mode has no TTY for the project-trust prompt, so the runner trusts
 each temporary task workspace inside that home before the agent runs there.
+`--session-command <cmd>` runs a session task through another agent's CLI, one
+command per step in the same workspace, with `{prompt}`, `{stepId}`,
+`{stepIndex}` and `{continue}` (the value of `--session-continue-arg` from
+the second step on, empty on the first). Step and task verifiers are the same
+as for the SDK path; per-step metrics stay empty because the runner cannot read
+that agent's transcript, and the task carries the
+`external_agent_no_session_metrics` flag. Example for Hermes, which resumes
+its last session with `-c`:
+
+```bash
+npm run eval:agent -- --suite eval/tasks --executor real \
+  --agent-command "hermes chat -Q --yolo --provider xai -m grok-4.6 -q {prompt}" \
+  --session-command "hermes chat -Q --yolo --provider xai -m grok-4.6 {continue} -q {prompt}" \
+  --session-continue-arg -c --agent-name hermes --provider xai --model grok-4.6 \
+  --output eval/reports/hermes.json
+```
+
 `--setup-command <cmd>` (repeatable) runs in every workspace before the agent,
 with the same placeholders as `--agent-command`; task-level `setupCommands`
 run after it.

--- a/runtime/scripts/eval/workspace-trust.mjs
+++ b/runtime/scripts/eval/workspace-trust.mjs
@@ -1,7 +1,60 @@
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
 const TRUSTED_PROJECTS_FILENAME = "trusted-projects.json";
+const LOCK_SUFFIX = ".lock";
+const LOCK_WAIT_MS = 5000;
+const LOCK_STALE_MS = 30000;
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Exclusive lock around the record's read-modify-write. Two runners sharing
+ * one isolated home (a command-task run next to a session run) each rewrote
+ * the file from their own read and dropped the other's entry, which the CLI
+ * then refused as an untrusted project one second into the task. The lock is
+ * a directory-free O_EXCL file; a holder older than LOCK_STALE_MS is treated
+ * as crashed and replaced.
+ */
+function withTrustLock(file, fn) {
+  const lock = `${file}${LOCK_SUFFIX}`;
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      const fd = openSync(lock, "wx");
+      try {
+        return fn();
+      } finally {
+        closeSync(fd);
+        rmSync(lock, { force: true });
+      }
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) rmSync(lock, { force: true });
+      } catch {
+        // The holder released it between our checks; retry immediately.
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`trusted-projects lock held too long: ${lock}`);
+      }
+      sleepSync(50);
+    }
+  }
+}
 
 function readRecord(file) {
   if (!existsSync(file)) return { version: 1, trustedProjects: [] };
@@ -25,16 +78,18 @@ function readRecord(file) {
 export function trustWorkspace({ agencHome, workspace, now = () => new Date() }) {
   const canonical = realpathSync(workspace);
   const file = path.join(agencHome, TRUSTED_PROJECTS_FILENAME);
-  const record = readRecord(file);
-  const others = record.trustedProjects.filter((entry) => entry?.path !== canonical);
-  const next = {
-    ...record,
-    version: 1,
-    trustedProjects: [...others, { path: canonical, trustedAt: now().toISOString() }],
-  };
   mkdirSync(agencHome, { recursive: true });
-  const tmp = `${file}.${process.pid}.tmp`;
-  writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
-  renameSync(tmp, file);
-  return { path: canonical, file };
+  return withTrustLock(file, () => {
+    const record = readRecord(file);
+    const others = record.trustedProjects.filter((entry) => entry?.path !== canonical);
+    const next = {
+      ...record,
+      version: 1,
+      trustedProjects: [...others, { path: canonical, trustedAt: now().toISOString() }],
+    };
+    const tmp = `${file}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmp, file);
+    return { path: canonical, file };
+  });
 }

--- a/runtime/scripts/run-agent-eval.mjs
+++ b/runtime/scripts/run-agent-eval.mjs
@@ -51,6 +51,8 @@ function usage() {
     "  --executor <mode>       'real' (default) or 'mock' (scripted solution.sh)",
     "  --agent-command <cmd>   Default shell command for each task",
     "  --setup-command <cmd>   Shell command run in each task workspace before the agent (repeatable; real executor only; same placeholders as --agent-command)",
+    "  --session-command <cmd> Run session tasks as one shell command per step instead of an AgenC SDK session (external agents). Placeholders: {prompt} {stepId} {stepIndex} {continue} plus those of --agent-command",
+    "  --session-continue-arg <arg>  Text that {continue} expands to from the second step on (empty on the first); e.g. -c for agents that resume their last session",
     "  --benchmark <name>      Override manifest benchmark name",
     "  --run-id <id>           Override generated run id",
     "  --agent-name <name>     Agent name for report metadata (default: agenc)",
@@ -84,6 +86,8 @@ function parseArgs(argv) {
     keepWorkspaces: false,
     agentCommand: undefined,
     setupCommands: [],
+    sessionCommand: undefined,
+    sessionContinueArg: "",
     benchmark: undefined,
     runId: undefined,
     agentName: "agenc",
@@ -137,6 +141,12 @@ function parseArgs(argv) {
         break;
       case "--setup-command":
         parsed.setupCommands.push(readValue());
+        break;
+      case "--session-command":
+        parsed.sessionCommand = readValue();
+        break;
+      case "--session-continue-arg":
+        parsed.sessionContinueArg = readValue();
         break;
       case "--benchmark":
         parsed.benchmark = readValue();
@@ -598,9 +608,17 @@ async function runTaskInWorkspace(task, manifest, args, workspace) {
   }
 
   if (task.kind === "session") {
-    return args.executor === "mock"
-      ? runMockSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted })
-      : runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted });
+    if (args.executor === "mock") {
+      return runMockSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted });
+    }
+    if (args.sessionCommand) {
+      return runExternalSessionTask({
+        task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted,
+        sessionCommand: args.sessionCommand,
+        continueArg: args.sessionContinueArg ?? "",
+      });
+    }
+    return runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted });
   }
 
   const agentCommand = args.executor === "mock"
@@ -934,6 +952,94 @@ function describeSession(session, rolloutPath) {
   return `session ${session.sessionId}${rolloutNote}`;
 }
 
+/**
+ * A step of a session task as a shell command, for agents without an AgenC
+ * SDK: {prompt} is the step prompt, {continue} expands to the continuation
+ * argument from the second step on so the agent resumes the conversation it
+ * started in this workspace, and {stepId}/{stepIndex} name the step.
+ */
+function renderStepCommand(template, task, step, index, cwd, taskDir, continueArg) {
+  const base = renderCommand(template, { ...task, prompt: step.prompt }, cwd, taskDir);
+  return base
+    .replaceAll("{stepId}", shellQuote(step.id))
+    .replaceAll("{stepIndex}", String(index + 1))
+    .replaceAll("{continue}", index === 0 ? "" : continueArg);
+}
+
+/**
+ * Drive a session task through an external agent's CLI, one command per step
+ * in the same workspace, with the same step and task verifiers as the SDK
+ * path. Tool calls, re-reads and compaction stay unknown for an agent whose
+ * transcript the runner cannot read, so the step metrics are empty and the
+ * task notes say so; pass rate, wall time and any usage the command prints
+ * as JSON are comparable.
+ */
+async function runExternalSessionTask({
+  task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted, sessionCommand, continueArg,
+}) {
+  const steps = [];
+  const tokens = { input: 0, output: 0, total: 0 };
+  let sawTokens = false;
+  for (const [index, step] of task.steps.entries()) {
+    const stepStarted = performance.now();
+    const result = await runCommand(
+      renderStepCommand(sessionCommand, task, step, index, cwd, taskDir, continueArg),
+      {
+        cwd,
+        timeoutMs: step.timeoutMs ?? timeoutMs,
+        env: { ...process.env, AGENC_WORKSPACE: cwd },
+      },
+    );
+    commands.push(commandReport(result));
+    rawResults.push(result);
+    if (result.timedOut) riskFlags.add("agent_timeout");
+    const exitCode = result.exitCode ?? 1;
+    if (exitCode !== 0) riskFlags.add("agent_command_failed");
+    const stepTokens = extractTokens(result.stdout);
+    if (stepTokens) {
+      sawTokens = true;
+      addTokens(tokens, stepTokens);
+    }
+    const verifiers = exitCode === 0
+      ? await runStepVerifiers(step, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
+      : [];
+    steps.push({
+      id: step.id,
+      status: exitCode !== 0 ? "error" : verifierStatus(verifiers),
+      durationMs: Math.round(performance.now() - stepStarted),
+      ...(stepTokens ? { tokens: stepTokens } : {}),
+      exitCode,
+      metrics: finalizeMetrics(createStepMetrics()),
+      verifiers,
+    });
+    if (exitCode !== 0) break;
+  }
+  const completed = steps.length === task.steps.length && steps.every((step) => step.status !== "error");
+  const verifiers = completed
+    ? await runStepVerifiers({ verifiers: task.verifiers }, task, cwd, taskDir, timeoutMs, rawResults, riskFlags)
+    : [];
+  riskFlags.add("external_agent_no_session_metrics");
+  const how = continueArg
+    ? `steps ran as shell commands; steps after the first carried ${continueArg}`
+    : "steps ran as shell commands without a continuation argument";
+  return buildTaskReport({
+    task,
+    status: completed ? sessionStatus(steps, verifiers) : "error",
+    durationMs: performance.now() - taskStarted,
+    commands,
+    verifiers,
+    riskFlags,
+    rawResults,
+    tokens: sawTokens ? tokens : undefined,
+    steps,
+    metrics: aggregateMetrics(steps.map((step) => step.metrics)),
+    notes: [`${how}; session metrics are unavailable for an external agent`, taskNotes(rawResults)]
+      .filter(Boolean)
+      .join("\n")
+      .slice(0, 4000),
+  });
+}
+
 async function runSessionTask({ task, taskDir, cwd, timeoutMs, commands, riskFlags, rawResults, taskStarted }) {
   const agencHome = requireIsolatedHome(process.env);
   const sdk = await loadSdk();
@@ -1034,6 +1140,8 @@ function computeConfigFingerprint(manifest, effective) {
     benchmark: effective.benchmark ?? manifest.benchmark,
     executor: effective.executor,
     agentCommand: effective.agentCommand ?? manifest.agentCommand ?? null,
+    sessionCommand: effective.sessionCommand ?? null,
+    sessionContinueArg: effective.sessionContinueArg ?? null,
     agent: {
       name: effective.agentName ?? null,
       provider: effective.provider ?? null,

--- a/runtime/scripts/run-agent-eval.mjs
+++ b/runtime/scripts/run-agent-eval.mjs
@@ -1261,11 +1261,14 @@ async function main() {
         args.outputDir,
         `report-${entry?.id ?? "default"}.json`,
       );
+      await mkdir(path.dirname(reportPath), { recursive: true });
       await writeFile(reportPath, output, "utf8");
       process.stdout.write(`Wrote eval report: ${reportPath}\n`);
       continue;
     }
     if (args.outputPath) {
+      // A fresh checkout has no eval/reports yet; a lost report after a long run is unrecoverable.
+      await mkdir(path.dirname(args.outputPath), { recursive: true });
       await writeFile(args.outputPath, output, "utf8");
       process.stdout.write(`Wrote eval report: ${args.outputPath}\n`);
       continue;

--- a/runtime/tests/eval/agent-eval-suite.test.ts
+++ b/runtime/tests/eval/agent-eval-suite.test.ts
@@ -201,6 +201,14 @@ describe("agent eval suite (mock executor)", () => {
     120_000,
   );
 
+  test("writes the report into a directory that does not exist yet", () => {
+    const dir = mkdtempSync(join(controlledTmpDir, "fresh-reports-"));
+    const output = join(dir, "reports", "nested", "report.json");
+    const result = runRunner(["--suite", suitePath, "--executor", "mock", "--output", output]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(output, "utf8")).toContain('"schemaVersion"');
+  });
+
   test("a session task can run through an external agent command, one step at a time", () => {
     // Both live under the controlled temp root, which afterAll removes.
     const dir = mkdtempSync(join(controlledTmpDir, "external-"));

--- a/runtime/tests/eval/agent-eval-suite.test.ts
+++ b/runtime/tests/eval/agent-eval-suite.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   cpSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -199,6 +200,61 @@ describe("agent eval suite (mock executor)", () => {
     },
     120_000,
   );
+
+  test("a session task can run through an external agent command, one step at a time", () => {
+    // Both live under the controlled temp root, which afterAll removes.
+    const dir = mkdtempSync(join(controlledTmpDir, "external-"));
+    const home = mkdtempSync(join(controlledTmpDir, "external-home-"));
+    const taskDir = join(dir, "notes");
+    mkdirSync(join(taskDir, "fixture"), { recursive: true });
+    writeFileSync(join(taskDir, "fixture", "README.md"), "# notes\n");
+    // The fake agent appends the prompt it received, plus argv, to a log and
+    // prints a usage object the way an --output-format json agent would.
+    const agent = join(dir, "agent.mjs");
+    writeFileSync(agent, [
+      'import { appendFileSync } from "node:fs";',
+      'const args = process.argv.slice(2);',
+      'appendFileSync("agent.log", JSON.stringify(args) + "\\n");',
+      'console.log(JSON.stringify({ usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 } }));',
+    ].join("\n"));
+    writeFileSync(join(dir, "tasks.json"), JSON.stringify({
+      benchmark: "external-agent-check",
+      tasks: [{
+        id: "notes",
+        kind: "session",
+        dir: "notes",
+        fixture: "fixture",
+        steps: [
+          { id: "one", prompt: "first prompt", verifiers: [{ name: "logged", command: "grep -q 'first prompt' agent.log" }] },
+          { id: "two", prompt: "second prompt", verifiers: [{ name: "resumed", command: "grep -q -- '--resume-last' agent.log" }] },
+        ],
+        verifiers: [{ name: "two-calls", command: "test \"$(wc -l < agent.log | tr -d ' ')\" = 2" }],
+      }],
+    }));
+    const output = join(dir, "report.json");
+    const result = spawnSync(process.execPath, [
+      runnerScriptPath,
+      "--tasks", join(dir, "tasks.json"),
+      "--executor", "real",
+      "--agent-command", "true",
+      "--session-command", `${JSON.stringify(process.execPath)} ${JSON.stringify(agent)} {continue} --prompt {prompt} --step {stepId}`,
+      "--session-continue-arg", "--resume-last",
+      "--agent-name", "fake-external",
+      "--output", output,
+    ], { encoding: "utf8", env: { ...process.env, AGENC_HOME: home } });
+    expect(result.status, result.stderr).toBe(0);
+    const report = JSON.parse(readFileSync(output, "utf8"));
+    const task = report.tasks[0];
+    expect(task.status).toBe("passed");
+    expect(task.steps.map((step: { id: string; status: string }) => [step.id, step.status])).toEqual([["one", "passed"], ["two", "passed"]]);
+    expect(task.commands).toHaveLength(2);
+    expect(task.commands[0].command).not.toContain("--resume-last");
+    expect(task.commands[1].command).toContain("--resume-last");
+    expect(task.tokens).toEqual({ input: 20, output: 10, total: 30 });
+    expect(task.riskFlags).toContain("external_agent_no_session_metrics");
+    expect(task.notes).toContain("steps after the first carried --resume-last");
+    expect(report.run.agent.name).toBe("fake-external");
+  });
 
   test("a session task without steps is a manifest error", () => {
     const dir = mkdtempSync(join(tmpdir(), "agenc-eval-session-invalid-"));

--- a/runtime/tests/eval/workspace-trust.test.ts
+++ b/runtime/tests/eval/workspace-trust.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -45,6 +46,25 @@ describe("trustWorkspace", () => {
       { path: realpathSync(workspace), trustedAt: "2026-09-04T10:00:00.000Z" },
     ]);
     expect(record.projectMcpServerChoices).toEqual([{ path: "/somewhere/else", rejectedServers: ["x"] }]);
+  });
+
+  it("keeps every entry when two runners trust different workspaces at once", () => {
+    const { home, workspace } = freshRoot();
+    const second = join(workspace, "..", "ws2");
+    mkdirSync(second);
+    // Two processes, each trusting its own workspace against the same home.
+    const script = `import { trustWorkspace } from ${JSON.stringify(new URL("../../scripts/eval/workspace-trust.mjs", import.meta.url).href)};
+      for (let i = 0; i < 20; i += 1) trustWorkspace({ agencHome: process.argv[1], workspace: process.argv[2] });`;
+    const runners = [workspace, second].map((ws) =>
+      spawn(process.execPath, ["--input-type=module", "-e", script, home, ws], { stdio: "inherit" }));
+    return Promise.all(runners.map((child) => new Promise<void>((resolve, reject) => {
+      child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`runner exited ${code}`))));
+    }))).then(() => {
+      const record = JSON.parse(readFileSync(join(home, "trusted-projects.json"), "utf8"));
+      const paths = record.trustedProjects.map((entry: { path: string }) => entry.path).sort();
+      expect(paths).toEqual([realpathSync(second), realpathSync(workspace)].sort());
+      expect(existsSync(join(home, "trusted-projects.json.lock"))).toBe(false);
+    });
   });
 
   it("replaces an unreadable record instead of failing", () => {


### PR DESCRIPTION
## Why

The goal is a real agent that beats Hermes and OpenCode on the same work, measured. The diagnostic lane (#2139) can already run any CLI on the 12 single-prompt tasks through `--agent-command`, but the 15-step session task only ran through the AgenC SDK, so the multi-turn comparison had no way to run for another agent.

## What changed

- `runtime/scripts/run-agent-eval.mjs`: `--session-command <cmd>` runs a session task as one shell command per step in the same workspace, with the placeholders `{prompt}` (the step prompt), `{stepId}`, `{stepIndex}` and `{continue}`; `--session-continue-arg <arg>` is what `{continue}` expands to from the second step on (empty on the first), so agents that resume their last session (`hermes chat -c`, `opencode run -c`) keep the conversation. Step and task verifiers, timeouts, command records, `AGENC_WORKSPACE` pinning and token extraction from JSON stdout are the same as the other paths. Per-step metrics stay empty because the runner cannot read that agent's transcript; the task carries the `external_agent_no_session_metrics` flag and its notes say how the steps ran. Both options are part of the config fingerprint.
- `runtime/eval/README.md`: the option, its placeholders, and a Hermes example.
- `runtime/scripts/eval/workspace-trust.mjs`: the trust record's read-modify-write now holds an exclusive lock file (stale holders replaced after 30 s). Two runners sharing one isolated home (a command run next to a session run) could each rewrite the file from their own read and drop the other's entry, which the CLI then refused as untrusted. `tests/eval/workspace-trust.test.ts` runs two processes trusting different workspaces twenty times each and checks both entries survive.
- `runtime/tests/eval/agent-eval-suite.test.ts`: a session task driven by a fake agent script that logs its argv and prints a usage object: both steps pass, the first command has no continuation flag and the second does, tokens sum across steps, the flag and the note are present, and the agent name lands in the report.

## Evidence

The test is the evidence for the mechanics. The first real use is the Hermes run of `asteroid-drift-15` on xAI grok-4.6, which is queued behind the 12-task comparison so Hermes never has two sessions open at once (its `-c` resumes the most recent session).

## Tests

`tests/eval` under the hermetic runner: 26 files, 236 passed (the new case included).

## Not changed

- The SDK session path, the mock executor and the verifiers.
- No metrics are invented for external agents; the comparison on session tasks is pass rate, per-step wall time and, when the agent prints usage as JSON, tokens.

## Counterparts

#2139 (the lane), #2147 (the cache fix whose effect these runs measure).
