### PR TITLE
daemon: work from the home directory, never the caller's

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -7,6 +7,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { enterDaemonWorkingDirectory } from "./daemon-working-directory.js";
 import { randomUUID } from "node:crypto";
 import { createDaemonWorkflowController } from "./workflow/daemon-wiring.js";
 import { DaemonWorkflowStartService } from "./workflow/run-start-service.js";
@@ -368,6 +369,12 @@ export interface AgenCDaemonCliHost {
 export interface RunAgenCDaemonCliOptions {
   readonly io?: AgenCDaemonCliIo;
   readonly host?: AgenCDaemonCliHost;
+  /**
+   * Make a foreground daemon work from its home instead of the caller's
+   * directory (#2149). Set by the real CLI entry; library callers and tests
+   * that run the daemon inside their own process leave it unset.
+   */
+  readonly enterDaemonHome?: boolean;
   readonly signalProcess?: AgenCSignalProcess;
   readonly beforeDaemonReady?: () => void | Promise<void>;
   /** @internal Reload/shutdown interposition contract-test seam. */
@@ -924,6 +931,7 @@ async function runAgenCDaemonAction(
     }
     case "run":
       return runAgenCDaemonForeground(host, io, {
+        enterDaemonHome: options.enterDaemonHome,
         signalProcess: options.signalProcess,
         beforeDaemonReady: options.beforeDaemonReady,
         beforeDaemonReloadAdoption: options.beforeDaemonReloadAdoption,
@@ -2588,6 +2596,7 @@ async function runAgenCDaemonForeground(
   host: AgenCDaemonCliHost,
   io: AgenCDaemonCliIo,
   options: {
+    readonly enterDaemonHome?: boolean;
     readonly signalProcess?: AgenCSignalProcess;
     readonly beforeDaemonReady?: () => void | Promise<void>;
     readonly beforeDaemonReloadAdoption?: () => void | Promise<void>;
@@ -2604,6 +2613,14 @@ async function runAgenCDaemonForeground(
   } = {},
 ): Promise<number> {
   const startupStartedAt = Date.now();
+  // Leave the caller's directory before anything else: it may not outlive
+  // this process, and a dead cwd breaks every later child spawn (#2149).
+  if (options.enterDaemonHome === true) {
+    enterDaemonWorkingDirectory(
+      resolveAgenCDaemonHome(host.env, host.userHome),
+      io,
+    );
+  }
   writeAgenCDaemonStartupDebug(
     host,
     io,
@@ -5737,7 +5754,10 @@ async function writeAgenCDaemonSnapshot(
 
 export { ensureAgenCDaemonCookie } from "./transport/auth.js";
 
-export function createNodeDaemonCliHost(): AgenCDaemonCliHost {
+export function createNodeDaemonCliHost(
+  deps: { readonly spawnProcess?: typeof spawn } = {},
+): AgenCDaemonCliHost {
+  const spawnProcess = deps.spawnProcess ?? spawn;
   const entrypointPath = process.argv[1] ?? "";
   const userHome = homedir();
   const spawnedStartupGuards = new Map<
@@ -5757,14 +5777,20 @@ export function createNodeDaemonCliHost(): AgenCDaemonCliHost {
     platform: process.platform,
     ...(startupGuardReceiver === undefined ? {} : { startupGuardReceiver }),
     spawnDetachedDaemon: (env) => {
+      const daemonHome = resolveAgenCDaemonHome(env, userHome);
+      // The child works from its home, never from this caller's directory,
+      // which may be a scratch or eval workspace that is deleted while the
+      // daemon keeps running (#2149).
+      try {
+        mkdirSync(daemonHome, { recursive: true, mode: 0o700 });
+      } catch {
+        /* the pid path below fails with a clearer error if the home is unusable */
+      }
       if (!hasOperatorHeapSnapshotOption(env)) {
-        mkdirSync(
-          join(resolveAgenCDaemonHome(env, userHome), "oom-snapshots"),
-          {
-            recursive: true,
-            mode: 0o700,
-          },
-        );
+        mkdirSync(join(daemonHome, "oom-snapshots"), {
+          recursive: true,
+          mode: 0o700,
+        });
       }
       // Capture the child's raw stderr until its log sink takes over: a
       // crash before the sink installs (loader failure, fatal V8 error,
@@ -5788,11 +5814,12 @@ export function createNodeDaemonCliHost(): AgenCDaemonCliHost {
       };
       let child: ChildProcess;
       try {
-        child = spawn(
+        child = spawnProcess(
           process.execPath,
           buildAgenCDaemonChildNodeArgs(entrypointPath, childEnv, userHome),
           {
             detached: true,
+            cwd: daemonHome,
             env: childEnv,
             // stdout stays detached from this short-lived parent; the
             // foreground daemon installs its own size-capped rotating log sink

--- a/runtime/src/app-server/daemon-working-directory.ts
+++ b/runtime/src/app-server/daemon-working-directory.ts
@@ -1,0 +1,38 @@
+/**
+ * The daemon outlives the shell or CLI that spawned it, so it must not keep
+ * that caller's working directory. An eval workspace, a scratch directory or
+ * a project that is later renamed all disappear while the daemon keeps
+ * running, and from then on every child it spawns (the Keychain helper, git,
+ * a tool) fails with ENOENT because the kernel cannot resolve the dead cwd
+ * (#2149). The daemon home exists for exactly as long as the daemon does, so
+ * the daemon works from there.
+ *
+ * @module
+ */
+
+export interface DaemonWorkingDirectoryIo {
+  readonly stderr: { write(text: string): unknown };
+}
+
+/**
+ * Enter `daemonHome`; returns false (and says why on stderr) when the
+ * directory cannot be entered, in which case the daemon keeps the caller's
+ * directory rather than refusing to start.
+ */
+export function enterDaemonWorkingDirectory(
+  daemonHome: string,
+  io: DaemonWorkingDirectoryIo,
+  chdir: (path: string) => void = (path) => process.chdir(path),
+): boolean {
+  try {
+    chdir(daemonHome);
+    return true;
+  } catch (error) {
+    io.stderr.write(
+      `agenc: daemon keeps the caller's working directory; could not enter ${daemonHome}: ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+    return false;
+  }
+}

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -5536,7 +5536,9 @@ export async function main(): Promise<number> {
         // Advisory only.
       }
     }
-    return runAgenCDaemonCli(daemonCommand);
+    // The real daemon process must not keep the caller's working directory;
+    // library callers (and tests running the daemon in-process) leave it.
+    return runAgenCDaemonCli(daemonCommand, { enterDaemonHome: true });
   }
   const remoteCommand = parseAgenCRemoteCliArgs(argv);
   if (remoteCommand !== null) {

--- a/runtime/src/utils/secureStorage/macOsKeychainStorage.ts
+++ b/runtime/src/utils/secureStorage/macOsKeychainStorage.ts
@@ -1,5 +1,5 @@
 import { execa, execaSync } from "execa";
-import { isAbsolute } from "node:path";
+import { dirname, isAbsolute } from "node:path";
 import { jsonStringify } from "../slowOperations.js";
 import {
   CREDENTIALS_SERVICE_SUFFIX,
@@ -40,7 +40,8 @@ function decodeKeychainReadResult(
   if (result.exitCode !== 0) {
     throw new Error(
       result.stderr?.trim() ||
-        `macOS Keychain lookup failed with exit code ${result.exitCode}`,
+        `macOS Keychain lookup failed with exit code ${result.exitCode}` +
+          (result.failure ? ` (${result.failure})` : ""),
     );
   }
   if (!result.stdout) {
@@ -230,6 +231,7 @@ async function doReadAsync(
   let result;
   try {
     result = await execa(executable, ["read", storageServiceName, username], {
+      cwd: dirname(executable),
       reject: false,
       stdin: "ignore",
       stdout: "pipe",

--- a/runtime/src/utils/secureStorage/subprocess.ts
+++ b/runtime/src/utils/secureStorage/subprocess.ts
@@ -1,4 +1,5 @@
 import { execaSync } from 'execa'
+import { dirname } from 'node:path'
 
 export interface SecureStorageCommandOptions {
   readonly input?: string
@@ -14,6 +15,8 @@ export interface SecureStorageCommandResult {
   readonly exitCode?: number
   readonly stdout?: string
   readonly stderr?: string
+  /** Why there is no exit code: the signal that ended the child, or the spawn error. */
+  readonly failure?: string
 }
 
 /** Injectable, shell-free subprocess boundary shared by native secure storage adapters. */
@@ -23,15 +26,43 @@ export type SecureStorageCommandRunner = (
   options?: SecureStorageCommandOptions,
 ) => SecureStorageCommandResult
 
+/**
+ * A child that ends without an exit code was signalled, hit an output cap, or
+ * never spawned. Name which, so the caller's error says more than "undefined".
+ */
+export function describeMissingExitCode(result: {
+  readonly signal?: string
+  readonly isMaxBuffer?: boolean
+  readonly timedOut?: boolean
+  readonly code?: string
+  readonly shortMessage?: string
+  readonly originalMessage?: string
+}): string {
+  const parts: string[] = []
+  if (result.signal) parts.push(`signal ${result.signal}`)
+  if (result.isMaxBuffer) parts.push('output exceeded the buffer limit')
+  if (result.timedOut) parts.push('timed out')
+  if (result.code) parts.push(`spawn error ${result.code}`)
+  const message = result.originalMessage ?? result.shortMessage
+  if (message) parts.push(message.slice(0, 200))
+  return parts.length > 0 ? parts.join('; ') : 'no exit code and no error reported'
+}
+
 export const runSecureStorageCommand: SecureStorageCommandRunner = (
   command,
   args,
   options,
 ) => {
-  const result = execaSync(command, args, options)
+  // The helper's own directory outlives any caller cwd; a daemon whose
+  // inherited working directory was deleted otherwise fails every spawn with
+  // ENOENT (#2149).
+  const result = execaSync(command, args, { cwd: dirname(command), ...options })
   return {
     exitCode: result.exitCode ?? undefined,
     stdout: typeof result.stdout === 'string' ? result.stdout : undefined,
     stderr: typeof result.stderr === 'string' ? result.stderr : undefined,
+    ...(result.exitCode === undefined
+      ? { failure: describeMissingExitCode(result) }
+      : {}),
   }
 }

--- a/runtime/tests/app-server/daemon-working-directory.test.ts
+++ b/runtime/tests/app-server/daemon-working-directory.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { enterDaemonWorkingDirectory } from "../../src/app-server/daemon-working-directory.js";
+import { createNodeDaemonCliHost } from "../../src/app-server/daemon-cli.js";
+
+describe("daemon working directory", () => {
+  it("enters the home and reports a directory it cannot enter without throwing", () => {
+    const entered: string[] = [];
+    const io = { stderr: { write: (text: string) => entered.push(text) } };
+    expect(enterDaemonWorkingDirectory("/some/home", io, (path) => entered.push(`chdir ${path}`))).toBe(true);
+    expect(entered).toEqual(["chdir /some/home"]);
+    const failures: string[] = [];
+    const failing = enterDaemonWorkingDirectory(
+      "/nope",
+      { stderr: { write: (text: string) => failures.push(text) } },
+      () => {
+        throw new Error("ENOENT: no such file or directory");
+      },
+    );
+    expect(failing).toBe(false);
+    expect(failures.join("")).toContain("could not enter /nope");
+    expect(failures.join("")).toContain("ENOENT");
+  });
+
+  it("really changes the process directory (checked in a child process)", () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-daemon-home-"));
+    try {
+      const script = `import { enterDaemonWorkingDirectory } from ${JSON.stringify(new URL("../../src/app-server/daemon-working-directory.ts", import.meta.url).href)};
+        const ok = enterDaemonWorkingDirectory(process.argv[1], { stderr: process.stderr });
+        console.log(JSON.stringify({ ok, cwd: process.cwd() }));`;
+      const result = spawnSync(process.execPath, ["--input-type=module", "-e", script, home], { encoding: "utf8" });
+      expect(result.status, result.stderr).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.ok).toBe(true);
+      expect(realpathSync(parsed.cwd)).toBe(realpathSync(home));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("spawns the detached daemon with its home as the working directory", () => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-daemon-spawn-home-"));
+    try {
+      const calls: Array<{ file: string; options: { cwd?: string; detached?: boolean } }> = [];
+      const fakeChild = {
+        pid: 4242,
+        connected: false,
+        unref() {},
+        once() { return fakeChild; },
+        on() { return fakeChild; },
+        off() { return fakeChild; },
+        removeListener() { return fakeChild; },
+        send() { return true; },
+        kill() { return true; },
+      };
+      const spawnProcess = ((file: string, _args: readonly string[], options: { cwd?: string; detached?: boolean }) => {
+        calls.push({ file, options });
+        return fakeChild;
+      }) as unknown as typeof import("node:child_process").spawn;
+      const host = createNodeDaemonCliHost({ spawnProcess });
+      const pid = host.spawnDetachedDaemon({ ...process.env, AGENC_HOME: home });
+      expect(pid).toBe(4242);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.options.detached).toBe(true);
+      expect(realpathSync(calls[0]?.options.cwd ?? "")).toBe(realpathSync(home));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/runtime/tests/utils/secureStorage/subprocess.test.ts
+++ b/runtime/tests/utils/secureStorage/subprocess.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { describeMissingExitCode, runSecureStorageCommand } from "../../../src/utils/secureStorage/subprocess.js";
+
+describe("secure storage subprocess runner", () => {
+  it("names why a child produced no exit code", () => {
+    expect(describeMissingExitCode({ signal: "SIGKILL" })).toBe("signal SIGKILL");
+    expect(describeMissingExitCode({ code: "ENOENT", originalMessage: "spawnSync helper ENOENT" })).toBe(
+      "spawn error ENOENT; spawnSync helper ENOENT",
+    );
+    expect(describeMissingExitCode({ isMaxBuffer: true, timedOut: true })).toBe(
+      "output exceeded the buffer limit; timed out",
+    );
+    expect(describeMissingExitCode({})).toBe("no exit code and no error reported");
+  });
+
+  it("reports the spawn failure instead of a bare undefined exit code", () => {
+    const result = runSecureStorageCommand("/nonexistent/agenc-helper", ["read"], { reject: false });
+    expect(result.exitCode).toBeUndefined();
+    expect(result.failure).toContain("ENOENT");
+  });
+
+  it("still runs the helper when the process's own working directory is gone", () => {
+    const doomed = mkdtempSync(join(tmpdir(), "agenc-dead-cwd-"));
+    const script = `import { rmSync } from "node:fs";
+      import { runSecureStorageCommand } from ${JSON.stringify(new URL("../../../src/utils/secureStorage/subprocess.ts", import.meta.url).href)};
+      process.chdir(process.argv[1]);
+      rmSync(process.argv[1], { recursive: true, force: true });
+      const result = runSecureStorageCommand("/bin/echo", ["still here"], { reject: false, stdio: ["ignore", "pipe", "pipe"] });
+      console.log(JSON.stringify({ exitCode: result.exitCode, stdout: result.stdout, failure: result.failure }));`;
+    const child = spawnSync(process.execPath, ["--input-type=module", "-e", script, doomed], { encoding: "utf8" });
+    rmSync(doomed, { recursive: true, force: true });
+    expect(child.status, child.stderr).toBe(0);
+    const parsed = JSON.parse(child.stdout.trim());
+    expect(parsed).toMatchObject({ exitCode: 0, stdout: "still here" });
+  });
+});


### PR DESCRIPTION
Closes #2149

## Why

The daemon inherits the working directory of whatever spawned it, usually an `agenc -p` or TUI start in some project folder. That process outlives the folder: an eval workspace deleted when the task ends, a scratch directory, a project renamed. From then on the kernel cannot resolve the daemon's cwd and every child it spawns fails with `ENOENT`. The first casualty is the Keychain helper, and the CLI reported it as `macOS Keychain lookup failed with exit code undefined`, which sent today's investigation through build takeovers, keychain ACLs and process limits before the real cause. In the eval run it looked like this: the first task's `agenc -p` spawned the daemon inside that task's temporary workspace, the runner deleted the workspace at the end of the task, the second task still passed on the credential read cache, and every task after that failed in one second.

## What changed

- `runtime/src/app-server/daemon-working-directory.ts` (new): `enterDaemonWorkingDirectory(daemonHome, io)`; returns false and says why on stderr when the directory cannot be entered, so a daemon still starts rather than refusing.
- `runtime/src/app-server/daemon-cli.ts`: the detached spawn in `createNodeDaemonCliHost` runs the child with `cwd` set to its home (created if missing); `createNodeDaemonCliHost` takes an optional `spawnProcess` so the spawn options are testable; `RunAgenCDaemonCliOptions.enterDaemonHome` makes a foreground daemon enter its home before taking the lifecycle lock. Library callers and the contract tests that run the daemon inside their own process leave it unset, because a `chdir` in the test process broke unrelated tests that read packaging files relative to the checkout.
- `runtime/src/bin/agenc-main.ts`: the real CLI entry passes `enterDaemonHome: true`, so both the detached child (which arrives through this entry with `daemon start --foreground`) and a user's own foreground start work from the home.
- `runtime/src/utils/secureStorage/subprocess.ts`: `runSecureStorageCommand` spawns the helper with `cwd` set to the helper's own directory, which outlives any caller; a result without an exit code now carries `failure` naming the signal, the buffer cap, the timeout or the spawn error (`describeMissingExitCode`).
- `runtime/src/utils/secureStorage/macOsKeychainStorage.ts`: the async read passes the same `cwd`; the error message appends the failure, so the eval today would have said `(spawn error ENOENT; spawnSync .../agenc-keychain-helper ENOENT)` on the first try.

## Evidence

With the instrumented error the reproduction is one command sequence: trust a throwaway directory, run `agenc -p` from it so the daemon starts there (`lsof -a -d cwd -p PID` shows it), delete the directory, probe again. The first probe passes, the one about a minute later fails with the ENOENT message above. Starting the daemon from a directory that persists and rerunning the same 12 eval tasks: 12 of 12 passed in 312 s, against 2 of 12 and then 0 of 12 on the two runs whose daemon had been spawned inside a task workspace.

## Tests

- `tests/app-server/daemon-working-directory.test.ts` (new, 3): the helper enters and reports; a child node process really changes its directory to the home; the detached spawn passes the home as `cwd` (fake spawn injected through `createNodeDaemonCliHost`).
- `tests/utils/secureStorage/subprocess.test.ts` (new, 3): `describeMissingExitCode` names signal, spawn error, buffer cap and timeout; a missing helper yields `failure` containing `ENOENT`; a child process that deletes its own working directory can still run the helper through `runSecureStorageCommand`.
- `tests/utils/secureStorage` (all), `tests/bin/agenc-main-daemon-audit.test.ts`: green.
- `tests/app-server/daemon-cli.contract.test.ts` and `daemon-autostart.contract.test.ts`: 27 failures on this branch, 28 on the unchanged checkout, same names (these suites start real daemons and are red on this macOS box independent of the change); no failure is new. CI runs them on Linux.
- `tsc --noEmit`: clean apart from the TS2883 lines that symlinked `node_modules` produce locally.

## Not changed

- No retry or auto-restart when the working directory is gone; the daemon simply never depends on it.
- The systemd and launchd templates under `packaging/` still do not set a working directory; with this change the process moves itself.

## Counterparts

#2149 (issue), #2147 (the eval that surfaced it), #2148 (runner side: the trust-file lock and report directory).
