### PR TITLE
skills: propose draft skill candidates from the extraction child

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -662,12 +662,23 @@ Install text mode never prints the specifier. See
 ```text
 agenc skills list
 agenc skills list --json
+agenc skills candidates list [--json]
+agenc skills candidates show <name>
+agenc skills candidates accept <name>
+agenc skills candidates reject <name>
 ```
 
 Skill inventory for the current cwd and `AGENC_HOME`. Desktop clients can use
 this instead of opening a session to read `/skills`. It does not install
 content or print skill bodies. Normal runtime initialization can still create
 runtime directories or migrate legacy plugin-data directories.
+
+`candidates` reviews the draft skills the runtime proposed from past sessions
+(`$AGENC_HOME/skill-candidates/<name>/`). Drafts are inactive until `accept`
+moves one into `$AGENC_HOME/skills/<name>/`; `accept` refuses a name any
+installed skill already uses, and `reject` deletes the draft. A malformed
+`candidates` command exits 1 instead of becoming a prompt. Details:
+[skills-plugins.md](skills-plugins.md#skill-candidates).
 
 ```bash
 agenc skills list --json
@@ -678,10 +689,10 @@ Text mode prints `[origin] name — description`. After an inventory is emitted,
 both modes exit 0; inspect `errors[]` (or stderr in text mode) for
 config/registry failures.
 
-Only `list` plus optional `--json` is a skills command. `agenc skills` or
-`agenc skills --help` is **not** help: the parser rejects it and the default
-route treats those tokens as a prompt. Use `agenc help skills`. Top-level
-`agenc help` does not list this command.
+Only `list` plus optional `--json` and the `candidates` commands are skills
+commands. `agenc skills` or `agenc skills --help` is **not** help: the parser
+rejects it and the default route treats those tokens as a prompt. Use
+`agenc help skills`. Top-level `agenc help` does not list this command.
 
 This is not `agenc plugin`. Details, JSON fields, and differences from
 `/skills`:

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -300,6 +300,7 @@ Defaults are "feature on unless the disable var is set" unless noted.
 | `AGENC_DISABLE_LANDLOCK_FALLBACK` | Do not use the Landlock helper when bubblewrap cannot run |
 | `AGENC_LINUX_SANDBOX_EXE` | Override the Linux sandbox helper path |
 | `AGENC_DISABLE_EXTRACT_MEMORIES` | Skip turn-end memory extraction |
+| `AGENC_SKILL_CANDIDATES` | `0` stops the memory-extraction child from proposing draft skills under `$AGENC_HOME/skill-candidates/`. Drafts are never active until `agenc skills candidates accept <name>`; see [skills-plugins.md](skills-plugins.md#skill-candidates) |
 | `AGENC_POLICY_LIMITS_URL` | Override hosted policy-limits URL (default `https://id.agenc.ag/v1/policy-limits`) |
 
 Every CLI runtime ingress captures `AGENC_ALLOW_UNTRUSTED_HOOKS` once as
@@ -382,7 +383,7 @@ The sections above explain the common operator controls. The index below makes t
 
 ### AGENC_S*
 
-`AGENC_SANDBOX_DEVICE_BINDS`, `AGENC_SAVE_HOOK_ADDITIONAL_CONTEXT`, `AGENC_SESSIONEND_HOOKS_TIMEOUT_MS`, `AGENC_SESSION_ACCESS_TOKEN`, `AGENC_SESSION_KIND`, `AGENC_SESSION_LOG`, `AGENC_SESSION_NAME`, `AGENC_SKIP_PROMPT_HISTORY`, `AGENC_SLACK_GROUP_ADDRESSING`, `AGENC_SLOW_OPERATION_THRESHOLD_MS`, `AGENC_SSE_PORT`, `AGENC_STALL_TIMEOUT_MS_FOR_TESTING`, `AGENC_SUBPROCESS_ENV_NO_SCRUB`, `AGENC_SYNTAX_HIGHLIGHT`.
+`AGENC_SANDBOX_DEVICE_BINDS`, `AGENC_SAVE_HOOK_ADDITIONAL_CONTEXT`, `AGENC_SESSIONEND_HOOKS_TIMEOUT_MS`, `AGENC_SESSION_ACCESS_TOKEN`, `AGENC_SESSION_KIND`, `AGENC_SESSION_LOG`, `AGENC_SESSION_NAME`, `AGENC_SKILL_CANDIDATES`, `AGENC_SKIP_PROMPT_HISTORY`, `AGENC_SLACK_GROUP_ADDRESSING`, `AGENC_SLOW_OPERATION_THRESHOLD_MS`, `AGENC_SSE_PORT`, `AGENC_STALL_TIMEOUT_MS_FOR_TESTING`, `AGENC_SUBPROCESS_ENV_NO_SCRUB`, `AGENC_SYNTAX_HIGHLIGHT`.
 
 ### AGENC_T*
 

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -161,6 +161,9 @@ the memory directory, and never blocks a turn: in-flight runs are drained at
 session shutdown. Every gate that stops a run and every failed run emits a
 `warning` event with cause `memory_extraction_skipped` or
 `memory_extraction_failed` (session log only; not shown in the transcript).
+The same run may also propose a draft skill; those outcomes use cause
+`skill_candidate_proposed` or `skill_candidate_skipped` and are described in
+[skills-plugins.md](skills-plugins.md#skill-candidates).
 
 Query-time recall of those files uses the full-corpus index below when a
 resolved `AGENC_HOME` is available. Session-start recall never uses the index.

--- a/docs/reference/skills-plugins.md
+++ b/docs/reference/skills-plugins.md
@@ -179,9 +179,10 @@ that session only.
 
 #### Constraints
 
-- The parser accepts only `agenc skills list` and optional `--json`.
-  `agenc skills`, `agenc skills --help`, `agenc skills install <name>`, and any
-  extra flag return `null` from `parseAgenCSkillsCliArgs` and fall through
+- The parser accepts `agenc skills list` with optional `--json`, and the
+  `agenc skills candidates ...` commands below. `agenc skills`,
+  `agenc skills --help`, `agenc skills install <name>`, and any extra flag
+  after `list` return `null` from `parseAgenCSkillsCliArgs` and fall through
   to the default CLI route, which treats the tokens as a **session prompt**.
   Use `agenc help skills` for syntax.
 - Top-level `agenc help` / `agenc --help` does not list this command.
@@ -195,6 +196,55 @@ that session only.
   `/skills` and remain absent from `agenc skills list`.
 - Duplicate `origin:name` keys keep the first row (local snapshot before
   the bundled-registry fallback).
+
+### Skill candidates
+
+The runtime can draft a skill from a session. The memory-extraction child
+(`services/extractMemories`, see [memory.md](memory.md)) already reviews a
+finished stretch of conversation on every third eligible turn. The same run
+is told to look for one more thing: a procedure that was carried out and then
+checked (at least 3 tool calls leading to a verified outcome, such as a test
+run or a build) that no installed skill covers. It answers with a fenced
+`skill-candidates` block at the end of its final reply, at most 2 entries per
+run. The parent validates each entry (kebab-case name, one-line description
+and when-to-use, a body under 16 KiB, at least one line of evidence, and the
+memory secrets scan over every field) and writes each survivor as a draft:
+
+```text
+$AGENC_HOME/skill-candidates/<name>/SKILL.md      frontmatter + body, ready to move
+$AGENC_HOME/skill-candidates/<name>/candidate.json provenance: session, created, model, evidence
+$AGENC_HOME/skill-candidates/ledger.jsonl         {slug, action, at, sessionId} per event
+```
+
+A draft is inert. `skill-candidates` is a sibling of `$AGENC_HOME/skills`; it
+is not one of the roots in [Load paths](#load-paths-discoverskillroots) and
+the loader only walks downward from a root, so a draft never reaches the
+skill listing, the command catalog, or the model. A name that already
+belongs to an installed skill or an existing draft is skipped and logged. The
+session log carries the outcome as `warning` events with cause
+`skill_candidate_proposed` or `skill_candidate_skipped`.
+
+Review with the CLI:
+
+```text
+agenc skills candidates list [--json]
+agenc skills candidates show <name>
+agenc skills candidates accept <name>
+agenc skills candidates reject <name>
+```
+
+`list` prints one line per draft (name, created, description, evidence
+count); `--json` emits `{ schemaVersion: 1, kind: "agenc.skills.candidates",
+root, candidates, errors }`. `show` prints the SKILL.md. `accept` moves the
+directory to `$AGENC_HOME/skills/<name>/`, drops `candidate.json`, and appends
+`accepted` to the ledger; it refuses when any installed skill (any origin,
+built-ins included) or an existing directory already has that name. `reject`
+deletes the directory and appends `rejected`. Unlike `list`, a malformed
+`candidates` command is an error (exit 1), not a session prompt.
+
+`AGENC_SKILL_CANDIDATES=0` turns proposals off. Proposals also stop whenever
+memory extraction does (`AGENC_DISABLE_EXTRACT_MEMORIES`, `--bare`, auto
+memory disabled), since they ride that child run.
 
 ---
 

--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -17,6 +17,11 @@
  *   - Every gate that stops a run and every failed run emits a `warning`
  *     event (`memory_extraction_skipped` / `memory_extraction_failed`) so the
  *     reason is visible in the session log instead of being swallowed.
+ *   - Skill candidates ride the same child run: the prompt asks the reviewer
+ *     for at most two draft skills, answered as a fenced block in its final
+ *     reply, and `skills/skill-candidates.ts` validates and writes them as
+ *     inactive drafts under `<AGENC_HOME>/skill-candidates`. No second
+ *     scheduler, no extra model call.
  *
  * Scope boundaries:
  *   - remote feature-service lookups, team-memory routing, and shell access.
@@ -27,8 +32,14 @@ import type { LLMMessage } from "../../llm/types.js";
 import {
   cloneLlmMessageSnapshot as cloneMessage,
 } from "../../llm/content-conversion.js";
-import type { Session } from "../../session/session.js";
+import type { Session, SessionServices } from "../../session/session.js";
 import type { TurnContext } from "../../session/turn-context.js";
+import { resolveAgencHome } from "../../config/env.js";
+import {
+  isSkillCandidatesDisabledByEnv,
+  parseSkillCandidateProposals,
+  writeSkillCandidates,
+} from "../../skills/skill-candidates.js";
 import type { CompletedToolResultRecord } from "../../session/turn-state.js";
 import type {
   ChildToolPolicy,
@@ -69,7 +80,10 @@ import {
   type MemoryPathEnv,
   type ResolveAutoMemoryDirectoryOptions,
 } from "./memory-paths.js";
-import { buildExtractAutoOnlyPrompt } from "./prompts.js";
+import {
+  buildExtractAutoOnlyPrompt,
+  buildSkillCandidatesPromptSection,
+} from "./prompts.js";
 
 const READ_TOOL_NAMES = new Set(["FileRead", "Grep", "Glob"]);
 const WRITE_TOOL_NAMES = new Set(["Edit", "MultiEdit", "Write"]);
@@ -92,7 +106,9 @@ type ExtractionWarningCause =
   | "memory_extraction_skipped"
   | "memory_extraction_failed"
   | "memory_extraction_denied_read"
-  | "memory_extraction_state_not_persisted";
+  | "memory_extraction_state_not_persisted"
+  | "skill_candidate_proposed"
+  | "skill_candidate_skipped";
 
 /**
  * Record why an extraction run stopped. Warning causes outside the TUI's
@@ -149,6 +165,11 @@ export interface ExtractMemoriesChildRequest {
 export interface ExtractMemoriesChildResult {
   readonly outcome: RunAgentResult["outcome"] | "rejected";
   readonly error?: unknown;
+  /**
+   * The child's final reply. Memory lands on disk through the tool policy;
+   * this text is read only for the optional `skill-candidates` block.
+   */
+  readonly finalMessage?: string;
 }
 
 export interface ExtractMemoriesDependencies {
@@ -165,6 +186,20 @@ export interface ExtractMemoriesDependencies {
   readonly minEligibleTurns?: number;
   readonly delegateFn?: typeof delegateFn;
   readonly ensureAgentControl?: typeof ensureAgentControlFn;
+  /**
+   * AgenC home that receives skill-candidate drafts. Defaults to the
+   * session's config-store home, then `resolveAgencHome(env)`. An injected
+   * `env` that names no `AGENC_HOME` turns proposals off instead of falling
+   * back to the process user's home.
+   */
+  readonly skillCandidatesHome?: string;
+  /**
+   * Names a proposal must not duplicate. Defaults to the session's skills
+   * manager plus the bundled registry.
+   */
+  readonly listInstalledSkillNames?: (
+    session: Session,
+  ) => Promise<readonly string[]>;
 }
 
 interface QueuedExtraction {
@@ -517,7 +552,139 @@ async function defaultRunChild(
   return {
     outcome: outcome.result.outcome,
     ...(outcome.result.error !== undefined ? { error: outcome.result.error } : {}),
+    ...(outcome.result.finalMessage !== undefined
+      ? { finalMessage: outcome.result.finalMessage }
+      : {}),
   };
+}
+
+interface SkillCandidateContext {
+  readonly agencHome: string;
+  readonly installedSkillNames: readonly string[];
+}
+
+function resolveSkillCandidatesHome(
+  session: Session,
+  deps: ExtractMemoriesDependencies,
+): string | undefined {
+  if (deps.skillCandidatesHome !== undefined) return deps.skillCandidatesHome;
+  const storeHome = (session.services as Partial<SessionServices> | undefined)
+    ?.configStore?.homeContext.path;
+  if (typeof storeHome === "string" && storeHome.length > 0) return storeHome;
+  const env = deps.env;
+  if (env !== undefined && (env.AGENC_HOME ?? "").trim().length === 0) {
+    return undefined;
+  }
+  try {
+    return resolveAgencHome(env ?? process.env);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The names an accepted draft would collide with: what the session's skills
+ * manager serves (every root, plugins included) plus the bundled registry.
+ */
+async function defaultInstalledSkillNames(
+  session: Session,
+): Promise<readonly string[]> {
+  const names = new Set<string>();
+  const manager = (session.services as Partial<SessionServices> | undefined)
+    ?.skillsManager;
+  if (manager !== undefined) {
+    const outcome = await manager.skillsForConfig(
+      (session as Partial<Pick<Session, "config">>).config ?? {},
+      null,
+    );
+    for (const skill of outcome.availableSkills ?? []) names.add(skill.name);
+  }
+  const { getBundledSkills } = await import("../../skills/bundledSkills.js");
+  for (const command of getBundledSkills()) names.add(command.name);
+  return [...names];
+}
+
+/**
+ * Where drafts go and what they must not duplicate, or undefined when
+ * proposals are off: `AGENC_SKILL_CANDIDATES=0`, or no AgenC home is known.
+ */
+async function resolveSkillCandidateContext(
+  session: Session,
+  deps: ExtractMemoriesDependencies,
+): Promise<SkillCandidateContext | undefined> {
+  if (isSkillCandidatesDisabledByEnv(deps.env)) return undefined;
+  const agencHome = resolveSkillCandidatesHome(session, deps);
+  if (agencHome === undefined) return undefined;
+  let installedSkillNames: readonly string[] = [];
+  try {
+    installedSkillNames = await (
+      deps.listInstalledSkillNames ?? defaultInstalledSkillNames
+    )(session);
+  } catch (error) {
+    // The writer still refuses names that exist as drafts, and accept
+    // re-checks the full inventory; a failed lookup only weakens the prompt.
+    emitExtractionWarning(
+      session,
+      "skill_candidate_skipped",
+      `installed skill names unavailable, proposals are deduped at accept time: ${errorText(error)}`,
+    );
+  }
+  return { agencHome, installedSkillNames };
+}
+
+/**
+ * Turn the child's `skill-candidates` block into drafts on disk. Runs only
+ * after a completed extraction, and every outcome is reported through the
+ * same warning channel as the extraction itself.
+ */
+async function proposeSkillCandidates(
+  context: ExtractMemoriesContext,
+  skillCandidates: SkillCandidateContext,
+  finalMessage: string | undefined,
+): Promise<void> {
+  const session = context.session;
+  const parsed = parseSkillCandidateProposals(finalMessage);
+  for (const reason of parsed.dropped) {
+    emitExtractionWarning(session, "skill_candidate_skipped", reason);
+  }
+  if (parsed.candidates.length === 0) return;
+  const sessionId = (session as { readonly conversationId?: unknown })
+    .conversationId;
+  const conversationId = (context.ctx as { readonly conversationId?: unknown })
+    .conversationId;
+  const model = (
+    session as { readonly modelInfo?: { readonly slug?: unknown } }
+  ).modelInfo?.slug;
+  const result = await writeSkillCandidates({
+    agencHome: skillCandidates.agencHome,
+    candidates: parsed.candidates,
+    installedSkillNames: skillCandidates.installedSkillNames,
+    provenance: {
+      ...(typeof sessionId === "string" && sessionId.length > 0
+        ? { sessionId }
+        : {}),
+      ...(typeof conversationId === "string" && conversationId.length > 0
+        ? { conversationId }
+        : {}),
+      ...(typeof model === "string" && model.length > 0 ? { model } : {}),
+    },
+  });
+  for (const skipped of result.skipped) {
+    emitExtractionWarning(
+      session,
+      "skill_candidate_skipped",
+      `${skipped.slug}: ${skipped.reason}`,
+    );
+  }
+  if (result.written.length > 0) {
+    emitExtractionWarning(
+      session,
+      "skill_candidate_proposed",
+      `draft skill${result.written.length === 1 ? "" : "s"} written for review: ${result.written
+        .map((entry) => entry.slug)
+        .join(", ")} (agenc skills candidates list)`,
+    );
+  }
 }
 
 export function initExtractMemories(
@@ -693,13 +860,26 @@ export function initExtractMemories(
         queued.context.signal,
       ),
     );
-    const prompt = buildExtractAutoOnlyPrompt(
-      newMessageCount,
-      existingMemories,
-      deps.omitIndexFile ?? false,
-      memoryDir,
-      readOnlyMemoryRoots[0],
-    );
+    // Skill candidates ride this same child run: one more thing the reviewer
+    // looks for, answered in its final reply, never a second scheduler.
+    const skillCandidates = await resolveSkillCandidateContext(session, deps);
+    const prompt = [
+      buildExtractAutoOnlyPrompt(
+        newMessageCount,
+        existingMemories,
+        deps.omitIndexFile ?? false,
+        memoryDir,
+        readOnlyMemoryRoots[0],
+      ),
+      ...(skillCandidates === undefined
+        ? []
+        : [
+            "",
+            buildSkillCandidatesPromptSection(
+              skillCandidates.installedSkillNames,
+            ),
+          ]),
+    ].join("\n");
     const maxTurns = deps.maxTurns ?? DEFAULT_MAX_TURNS;
     const childResult = await (deps.runChild ??
       ((request) => defaultRunChild(request, maxTurns, deps)))({
@@ -749,6 +929,23 @@ export function initExtractMemories(
     );
     if (savedPaths.length > 0) {
       queued.appendSavedMemories?.(savedPaths);
+    }
+    if (skillCandidates !== undefined) {
+      try {
+        await proposeSkillCandidates(
+          queued.context,
+          skillCandidates,
+          childResult.finalMessage,
+        );
+      } catch (error) {
+        // The extraction itself succeeded and advanced; a draft that could
+        // not be written is a note, not a reason to re-run the child.
+        emitExtractionWarning(
+          session,
+          "skill_candidate_skipped",
+          `draft not written: ${errorText(error)}`,
+        );
+      }
     }
   }
 

--- a/runtime/src/services/extractMemories/prompts.ts
+++ b/runtime/src/services/extractMemories/prompts.ts
@@ -16,6 +16,11 @@ import {
   TYPES_SECTION_INDIVIDUAL,
   WHAT_NOT_TO_SAVE_SECTION,
 } from "../../memdir/memory-types.js";
+import {
+  MAX_SKILL_CANDIDATE_BODY_BYTES,
+  MAX_SKILL_CANDIDATES_PER_RUN,
+  SKILL_CANDIDATE_BLOCK_TAG,
+} from "../../skills/skill-candidates.js";
 
 /**
  * Shared opener for the project-memory extraction prompt.
@@ -103,5 +108,57 @@ export function buildExtractAutoOnlyPrompt(
     ...WHAT_NOT_TO_SAVE_SECTION,
     "",
     ...howToSave,
+  ].join("\n");
+}
+
+/**
+ * Installed names are shown so the child does not propose a skill the user
+ * already has. A shared catalog can hold well over a thousand skills, so the
+ * line is capped; the parent dedupes every proposal by name regardless.
+ */
+const MAX_INSTALLED_SKILL_NAMES_CHARS = 4000;
+
+function installedSkillNamesLine(names: readonly string[]): string {
+  const sorted = [...new Set(names)].sort((a, b) => a.localeCompare(b));
+  if (sorted.length === 0) return "Installed skills: none.";
+  const shown: string[] = [];
+  let length = 0;
+  for (const name of sorted) {
+    if (length + name.length + 2 > MAX_INSTALLED_SKILL_NAMES_CHARS) break;
+    shown.push(name);
+    length += name.length + 2;
+  }
+  const omitted = sorted.length - shown.length;
+  return `Installed skills: ${shown.join(", ")}${omitted > 0 ? ` and ${omitted} more` : ""}.`;
+}
+
+/**
+ * The one extra thing the extraction child looks for when skill candidates
+ * are on: a procedure that was carried out and checked, proposed as a draft
+ * skill in a fenced block at the end of its final reply. The parent parses
+ * and validates that block (skills/skill-candidates.ts); the child never
+ * writes a candidate itself.
+ */
+export function buildSkillCandidatesPromptSection(
+  installedSkillNames: readonly string[],
+): string {
+  return [
+    "## Skill candidates (drafts for the user to review)",
+    "",
+    "Separately from memory, look for one procedure in those messages that is worth keeping as a reusable skill. Propose it only when all of these hold:",
+    "",
+    "- The conversation shows the procedure being carried out and checked: at least 3 tool calls that led to an outcome that was then verified (a test run, a build, a command whose output confirmed the result).",
+    "- It is likely to recur in later sessions. A one-off fix, a single command, or something derivable from the code is not a skill.",
+    `- No installed skill already covers it. ${installedSkillNamesLine(installedSkillNames)}`,
+    "",
+    "If nothing qualifies, propose nothing; most runs propose nothing. Never write a candidate as a memory file, never invent steps that did not happen, and never include tokens, keys, passwords, or other secrets.",
+    "",
+    `To propose, end your final reply with one fenced block whose info string is \`${SKILL_CANDIDATE_BLOCK_TAG}\`. It holds a JSON object with a \`skillCandidates\` array of at most ${MAX_SKILL_CANDIDATES_PER_RUN} entries:`,
+    "",
+    "```" + SKILL_CANDIDATE_BLOCK_TAG,
+    '{"skillCandidates":[{"name":"kebab-case-name","description":"one line: what the skill does","whenToUse":"one line: the situation that calls for it","body":"SKILL.md markdown with the sections Purpose, Steps, Verification, Pitfalls","evidence":["what in the conversation showed the procedure","one item per observation"]}]}',
+    "```",
+    "",
+    `\`name\` is kebab-case and becomes the skill name. \`body\` is the SKILL.md text without frontmatter (the runtime adds it) and stays under ${MAX_SKILL_CANDIDATE_BODY_BYTES / 1024} KiB. Candidates are written as drafts under the skill-candidates directory of the AgenC home and stay inactive until the user accepts them with \`agenc skills candidates accept <name>\`.`,
   ].join("\n");
 }

--- a/runtime/src/skills/skill-candidates.ts
+++ b/runtime/src/skills/skill-candidates.ts
@@ -1,0 +1,624 @@
+/**
+ * Self-authored skill candidates: drafts the runtime proposes, the user accepts.
+ *
+ * The memory-extraction child (services/extractMemories) already reviews a
+ * finished stretch of conversation. This module gives that same run one more
+ * thing to look for: a procedure that was carried out and then checked, worth
+ * keeping as a skill. The child answers with a fenced `skill-candidates` block
+ * at the end of its final reply; the parent parses that block here, validates
+ * every entry, and writes each survivor as a DRAFT under
+ * `<AGENC_HOME>/skill-candidates/<slug>/` (SKILL.md plus candidate.json) with
+ * one line appended to `<AGENC_HOME>/skill-candidates/ledger.jsonl`.
+ *
+ * A draft is inert. The local loader (local-loader.ts) discovers skills only
+ * from fixed roots (`<dir>/.agenc/skills` and `<dir>/.agents/skills` on the
+ * project walk, `<AGENC_HOME>/skills`, `$HOME/.agents/skills`,
+ * `$AGENC_MANAGED_HOME/.agenc/skills`, and plugin skill roots) and walks
+ * downward from each of them. `<AGENC_HOME>/skill-candidates` is a sibling of
+ * `<AGENC_HOME>/skills`, never a root and never below one, so nothing written
+ * here reaches the listing, the command catalog, or the model until
+ * `agenc skills candidates accept <slug>` moves the directory into
+ * `<AGENC_HOME>/skills/<slug>/`.
+ *
+ * Everything the child says is untrusted conversation output: names are
+ * validated against a strict slug grammar before they become a path, bodies
+ * are capped, and the memory secrets scan runs over every text field.
+ */
+
+import {
+  appendFile,
+  cp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { join } from "node:path";
+import { scanForSecrets } from "../memory/index.js";
+import { isEnvDefinedFalsy } from "../utils/envBoolean.js";
+
+/** Sibling of `<AGENC_HOME>/skills`; never a skills root. */
+export const SKILL_CANDIDATES_DIR_NAME = "skill-candidates";
+export const SKILL_CANDIDATES_LEDGER_FILE = "ledger.jsonl";
+export const SKILL_CANDIDATE_RECORD_FILE = "candidate.json";
+export const SKILL_CANDIDATE_SKILL_FILE = "SKILL.md";
+/** Info string of the fenced block the extraction child answers with. */
+export const SKILL_CANDIDATE_BLOCK_TAG = "skill-candidates";
+/** `AGENC_SKILL_CANDIDATES=0` switches proposals off. */
+export const SKILL_CANDIDATES_ENV = "AGENC_SKILL_CANDIDATES";
+export const MAX_SKILL_CANDIDATES_PER_RUN = 2;
+export const MAX_SKILL_CANDIDATE_BODY_BYTES = 16 * 1024;
+export const MAX_SKILL_CANDIDATE_EVIDENCE = 8;
+const MAX_ONE_LINE_LENGTH = 300;
+const MIN_SLUG_LENGTH = 3;
+const MAX_SLUG_LENGTH = 64;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const FENCED_BLOCK_PATTERN = new RegExp(
+  "^[ \\t]*```" +
+    SKILL_CANDIDATE_BLOCK_TAG +
+    "[ \\t]*\\r?\\n([\\s\\S]*?)\\r?\\n[ \\t]*```[ \\t]*$",
+  "gmu",
+);
+
+export interface SkillCandidateProposal {
+  /** Kebab-case skill name; also the directory slug. */
+  readonly name: string;
+  readonly description: string;
+  readonly whenToUse: string;
+  /** SKILL.md markdown body (purpose, steps, verification, pitfalls). */
+  readonly body: string;
+  /** What in the conversation showed the procedure. */
+  readonly evidence: readonly string[];
+}
+
+export interface SkillCandidateProvenance {
+  readonly sessionId?: string;
+  readonly conversationId?: string;
+  readonly createdAt: string;
+  readonly model?: string;
+}
+
+/** Contents of `<slug>/candidate.json`. */
+export interface SkillCandidateRecord {
+  readonly schemaVersion: 1;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly whenToUse: string;
+  readonly evidence: readonly string[];
+  readonly provenance: SkillCandidateProvenance;
+}
+
+export type SkillCandidateLedgerAction = "proposed" | "accepted" | "rejected";
+
+export interface SkillCandidateLedgerEntry {
+  readonly slug: string;
+  readonly action: SkillCandidateLedgerAction;
+  readonly at: string;
+  readonly sessionId?: string;
+}
+
+export interface SkillCandidateParseResult {
+  readonly candidates: readonly SkillCandidateProposal[];
+  /** Why an entry was dropped, one line each, for the session log. */
+  readonly dropped: readonly string[];
+}
+
+export type SkillCandidateValidation =
+  | { readonly ok: true; readonly candidate: SkillCandidateProposal }
+  | { readonly ok: false; readonly reason: string };
+
+export type SkillCandidateErrorCode = "invalid_slug" | "not_found" | "name_taken";
+
+export class SkillCandidateError extends Error {
+  readonly name = "SkillCandidateError";
+
+  constructor(
+    readonly code: SkillCandidateErrorCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function isSkillCandidatesDisabledByEnv(
+  env: Readonly<Record<string, string | undefined>> | undefined,
+): boolean {
+  return isEnvDefinedFalsy((env ?? process.env)[SKILL_CANDIDATES_ENV]);
+}
+
+export function isValidSkillCandidateSlug(value: string): boolean {
+  return (
+    value.length >= MIN_SLUG_LENGTH &&
+    value.length <= MAX_SLUG_LENGTH &&
+    SLUG_PATTERN.test(value)
+  );
+}
+
+export function resolveSkillCandidatesRoot(agencHome: string): string {
+  return join(agencHome, SKILL_CANDIDATES_DIR_NAME);
+}
+
+export function resolveSkillCandidateDirectory(
+  agencHome: string,
+  slug: string,
+): string {
+  assertSlug(slug);
+  return join(resolveSkillCandidatesRoot(agencHome), slug);
+}
+
+function assertSlug(slug: string): void {
+  if (!isValidSkillCandidateSlug(slug)) {
+    throw new SkillCandidateError(
+      "invalid_slug",
+      `skill candidate names are kebab-case (letters, digits, single hyphens, ${MIN_SLUG_LENGTH} to ${MAX_SLUG_LENGTH} characters): ${JSON.stringify(slug)}`,
+    );
+  }
+}
+
+function oneLine(value: unknown, field: string): string | { readonly reason: string } {
+  if (typeof value !== "string") return { reason: `${field} is not a string` };
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return { reason: `${field} is empty` };
+  if (/[\r\n]/u.test(trimmed)) return { reason: `${field} must be one line` };
+  if (trimmed.length > MAX_ONE_LINE_LENGTH) {
+    return { reason: `${field} is longer than ${MAX_ONE_LINE_LENGTH} characters` };
+  }
+  return trimmed;
+}
+
+function isReason(value: unknown): value is { readonly reason: string } {
+  return typeof value === "object" && value !== null && "reason" in value;
+}
+
+/** A body that arrives with its own frontmatter would double the header. */
+function stripLeadingFrontmatter(body: string): string {
+  const match = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/u.exec(body);
+  return match ? body.slice(match[0].length) : body;
+}
+
+/**
+ * Shape and content check for one proposed entry. The secrets scan covers
+ * every text field because the child read the whole conversation, tool output
+ * included, and a token it saw there must not land in a draft on disk.
+ */
+export function validateSkillCandidateProposal(
+  raw: unknown,
+): SkillCandidateValidation {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { ok: false, reason: "entry is not an object" };
+  }
+  const record = raw as Record<string, unknown>;
+  const label =
+    typeof record.name === "string" && record.name.length > 0
+      ? record.name
+      : "<unnamed>";
+  if (typeof record.name !== "string" || !isValidSkillCandidateSlug(record.name)) {
+    return {
+      ok: false,
+      reason: `${label}: name is not a kebab-case slug of ${MIN_SLUG_LENGTH} to ${MAX_SLUG_LENGTH} characters`,
+    };
+  }
+  const description = oneLine(record.description, "description");
+  if (isReason(description)) return { ok: false, reason: `${label}: ${description.reason}` };
+  const whenToUse = oneLine(record.whenToUse, "whenToUse");
+  if (isReason(whenToUse)) return { ok: false, reason: `${label}: ${whenToUse.reason}` };
+  if (typeof record.body !== "string") {
+    return { ok: false, reason: `${label}: body is not a string` };
+  }
+  const body = stripLeadingFrontmatter(record.body).trim();
+  if (body.length === 0) return { ok: false, reason: `${label}: body is empty` };
+  const bodyBytes = Buffer.byteLength(body, "utf8");
+  if (bodyBytes > MAX_SKILL_CANDIDATE_BODY_BYTES) {
+    return {
+      ok: false,
+      reason: `${label}: body is ${bodyBytes} bytes, the cap is ${MAX_SKILL_CANDIDATE_BODY_BYTES}`,
+    };
+  }
+  if (!Array.isArray(record.evidence) || record.evidence.length === 0) {
+    return { ok: false, reason: `${label}: evidence is missing` };
+  }
+  const evidence: string[] = [];
+  for (const item of record.evidence.slice(0, MAX_SKILL_CANDIDATE_EVIDENCE)) {
+    const line = oneLine(item, "evidence item");
+    if (isReason(line)) return { ok: false, reason: `${label}: ${line.reason}` };
+    evidence.push(line);
+  }
+  const secrets = scanForSecrets(
+    [description, whenToUse, body, ...evidence].join("\n"),
+  );
+  if (secrets.length > 0) {
+    return {
+      ok: false,
+      reason: `${label}: content contains potential secrets (${secrets.map((match) => match.label).join(", ")})`,
+    };
+  }
+  return {
+    ok: true,
+    candidate: {
+      name: record.name,
+      description,
+      whenToUse,
+      body,
+      evidence,
+    },
+  };
+}
+
+/**
+ * The proposals in a child's final reply: every fenced `skill-candidates`
+ * block, parsed as `{ "skillCandidates": [...] }` or a bare array. Entries
+ * past the per-run cap and entries that fail validation are dropped with a
+ * reason; a malformed block drops as a whole. No block means no proposal.
+ */
+export function parseSkillCandidateProposals(
+  finalMessage: string | undefined,
+): SkillCandidateParseResult {
+  const candidates: SkillCandidateProposal[] = [];
+  const dropped: string[] = [];
+  if (typeof finalMessage !== "string" || finalMessage.length === 0) {
+    return { candidates, dropped };
+  }
+  const seen = new Set<string>();
+  for (const match of finalMessage.matchAll(FENCED_BLOCK_PATTERN)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(match[1] ?? "");
+    } catch (error) {
+      dropped.push(
+        `skill-candidates block is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    const entries = Array.isArray(parsed)
+      ? parsed
+      : typeof parsed === "object" &&
+          parsed !== null &&
+          Array.isArray((parsed as { skillCandidates?: unknown }).skillCandidates)
+        ? ((parsed as { skillCandidates: unknown[] }).skillCandidates)
+        : null;
+    if (entries === null) {
+      dropped.push(
+        "skill-candidates block is neither an array nor an object with a skillCandidates array",
+      );
+      continue;
+    }
+    for (const entry of entries) {
+      const validation = validateSkillCandidateProposal(entry);
+      if (!validation.ok) {
+        dropped.push(validation.reason);
+        continue;
+      }
+      if (seen.has(validation.candidate.name)) {
+        dropped.push(`${validation.candidate.name}: proposed twice in one run`);
+        continue;
+      }
+      if (candidates.length >= MAX_SKILL_CANDIDATES_PER_RUN) {
+        dropped.push(
+          `${validation.candidate.name}: over the per-run cap of ${MAX_SKILL_CANDIDATES_PER_RUN}`,
+        );
+        continue;
+      }
+      seen.add(validation.candidate.name);
+      candidates.push(validation.candidate);
+    }
+  }
+  return { candidates, dropped };
+}
+
+/** YAML double-quoted scalar; JSON string escaping is valid YAML. */
+function yamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+/** The SKILL.md a candidate becomes: loader frontmatter plus the body as given. */
+export function renderSkillCandidateFile(candidate: SkillCandidateProposal): string {
+  return [
+    "---",
+    `name: ${yamlScalar(candidate.name)}`,
+    `description: ${yamlScalar(candidate.description)}`,
+    `when_to_use: ${yamlScalar(candidate.whenToUse)}`,
+    "---",
+    "",
+    candidate.body.trim(),
+    "",
+  ].join("\n");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function appendLedger(
+  agencHome: string,
+  entry: SkillCandidateLedgerEntry,
+): Promise<void> {
+  const root = resolveSkillCandidatesRoot(agencHome);
+  await mkdir(root, { recursive: true });
+  await appendFile(
+    join(root, SKILL_CANDIDATES_LEDGER_FILE),
+    `${JSON.stringify(entry)}\n`,
+    "utf8",
+  );
+}
+
+/** Every ledger line that parses, oldest first. */
+export async function readSkillCandidateLedger(
+  agencHome: string,
+): Promise<readonly SkillCandidateLedgerEntry[]> {
+  let raw: string;
+  try {
+    raw = await readFile(
+      join(resolveSkillCandidatesRoot(agencHome), SKILL_CANDIDATES_LEDGER_FILE),
+      "utf8",
+    );
+  } catch {
+    return [];
+  }
+  const entries: SkillCandidateLedgerEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) continue;
+    try {
+      const parsed = JSON.parse(line) as Partial<SkillCandidateLedgerEntry>;
+      if (
+        typeof parsed.slug === "string" &&
+        typeof parsed.action === "string" &&
+        typeof parsed.at === "string"
+      ) {
+        entries.push(parsed as SkillCandidateLedgerEntry);
+      }
+    } catch {
+      // A torn line from an interrupted append is skipped, not fatal.
+    }
+  }
+  return entries;
+}
+
+export interface WriteSkillCandidatesOptions {
+  readonly agencHome: string;
+  readonly candidates: readonly SkillCandidateProposal[];
+  /** Names that already resolve to a skill; a proposal with one is skipped. */
+  readonly installedSkillNames: Iterable<string>;
+  readonly provenance: Omit<SkillCandidateProvenance, "createdAt"> & {
+    readonly createdAt?: string;
+  };
+}
+
+export interface WrittenSkillCandidate {
+  readonly slug: string;
+  readonly path: string;
+}
+
+export interface SkippedSkillCandidate {
+  readonly slug: string;
+  readonly reason: string;
+}
+
+export interface WriteSkillCandidatesResult {
+  readonly written: readonly WrittenSkillCandidate[];
+  readonly skipped: readonly SkippedSkillCandidate[];
+}
+
+/**
+ * Write validated proposals as drafts. A name that is already an installed
+ * skill or an existing draft is skipped and reported, never overwritten.
+ */
+export async function writeSkillCandidates(
+  options: WriteSkillCandidatesOptions,
+): Promise<WriteSkillCandidatesResult> {
+  const installed = new Set(options.installedSkillNames);
+  const written: WrittenSkillCandidate[] = [];
+  const skipped: SkippedSkillCandidate[] = [];
+  const createdAt = options.provenance.createdAt ?? new Date().toISOString();
+  for (const candidate of options.candidates) {
+    const slug = candidate.name;
+    if (!isValidSkillCandidateSlug(slug)) {
+      skipped.push({ slug, reason: "name is not a valid slug" });
+      continue;
+    }
+    if (installed.has(slug)) {
+      skipped.push({ slug, reason: "a skill with this name is already installed" });
+      continue;
+    }
+    const directory = resolveSkillCandidateDirectory(options.agencHome, slug);
+    if (await pathExists(directory)) {
+      skipped.push({ slug, reason: "a candidate with this name already exists" });
+      continue;
+    }
+    const record: SkillCandidateRecord = {
+      schemaVersion: 1,
+      slug,
+      name: candidate.name,
+      description: candidate.description,
+      whenToUse: candidate.whenToUse,
+      evidence: candidate.evidence,
+      provenance: {
+        ...(options.provenance.sessionId !== undefined
+          ? { sessionId: options.provenance.sessionId }
+          : {}),
+        ...(options.provenance.conversationId !== undefined
+          ? { conversationId: options.provenance.conversationId }
+          : {}),
+        createdAt,
+        ...(options.provenance.model !== undefined
+          ? { model: options.provenance.model }
+          : {}),
+      },
+    };
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, SKILL_CANDIDATE_SKILL_FILE),
+      renderSkillCandidateFile(candidate),
+      "utf8",
+    );
+    await writeFile(
+      join(directory, SKILL_CANDIDATE_RECORD_FILE),
+      `${JSON.stringify(record, null, 2)}\n`,
+      "utf8",
+    );
+    await appendLedger(options.agencHome, {
+      slug,
+      action: "proposed",
+      at: createdAt,
+      ...(options.provenance.sessionId !== undefined
+        ? { sessionId: options.provenance.sessionId }
+        : {}),
+    });
+    written.push({ slug, path: directory });
+  }
+  return { written, skipped };
+}
+
+export interface SkillCandidateSummary {
+  readonly slug: string;
+  readonly description: string;
+  readonly whenToUse?: string;
+  readonly createdAt?: string;
+  readonly evidenceCount: number;
+  readonly path: string;
+}
+
+export interface SkillCandidateListing {
+  readonly candidates: readonly SkillCandidateSummary[];
+  readonly errors: readonly string[];
+}
+
+/** Every draft directory that holds a SKILL.md, sorted by slug. */
+export async function listSkillCandidates(
+  agencHome: string,
+): Promise<SkillCandidateListing> {
+  const root = resolveSkillCandidatesRoot(agencHome);
+  let entries: Dirent[];
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return { candidates: [], errors: [] };
+  }
+  const candidates: SkillCandidateSummary[] = [];
+  const errors: string[] = [];
+  for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory() || !isValidSkillCandidateSlug(entry.name)) continue;
+    const directory = join(root, entry.name);
+    if (!(await pathExists(join(directory, SKILL_CANDIDATE_SKILL_FILE)))) continue;
+    let record: Partial<SkillCandidateRecord> = {};
+    try {
+      record = JSON.parse(
+        await readFile(join(directory, SKILL_CANDIDATE_RECORD_FILE), "utf8"),
+      ) as Partial<SkillCandidateRecord>;
+    } catch (error) {
+      errors.push(
+        `${entry.name}: ${SKILL_CANDIDATE_RECORD_FILE} unreadable (${error instanceof Error ? error.message : String(error)})`,
+      );
+    }
+    candidates.push({
+      slug: entry.name,
+      description: typeof record.description === "string" ? record.description : "",
+      ...(typeof record.whenToUse === "string" ? { whenToUse: record.whenToUse } : {}),
+      ...(typeof record.provenance?.createdAt === "string"
+        ? { createdAt: record.provenance.createdAt }
+        : {}),
+      evidenceCount: Array.isArray(record.evidence) ? record.evidence.length : 0,
+      path: directory,
+    });
+  }
+  return { candidates, errors };
+}
+
+/** The draft's SKILL.md text. */
+export async function readSkillCandidateFile(
+  agencHome: string,
+  slug: string,
+): Promise<string> {
+  const directory = resolveSkillCandidateDirectory(agencHome, slug);
+  try {
+    return await readFile(join(directory, SKILL_CANDIDATE_SKILL_FILE), "utf8");
+  } catch {
+    throw new SkillCandidateError("not_found", `no skill candidate named ${slug}`);
+  }
+}
+
+export interface AcceptSkillCandidateOptions {
+  readonly agencHome: string;
+  readonly slug: string;
+  /** Names that already resolve to a skill; accepting one of them is refused. */
+  readonly installedSkillNames: Iterable<string>;
+  /** Destination root; defaults to the user skills root `<AGENC_HOME>/skills`. */
+  readonly skillsRoot?: string;
+  readonly sessionId?: string;
+}
+
+/**
+ * Promote a draft: move `<candidates>/<slug>` to `<skills root>/<slug>` so the
+ * loader picks it up on its next scan, drop the provenance file from the
+ * moved directory, and record the acceptance. Refuses when the name already
+ * belongs to any installed skill or an occupied directory.
+ */
+export async function acceptSkillCandidate(
+  options: AcceptSkillCandidateOptions,
+): Promise<{ readonly path: string }> {
+  const source = resolveSkillCandidateDirectory(options.agencHome, options.slug);
+  if (!(await pathExists(join(source, SKILL_CANDIDATE_SKILL_FILE)))) {
+    throw new SkillCandidateError(
+      "not_found",
+      `no skill candidate named ${options.slug}`,
+    );
+  }
+  const skillsRoot = options.skillsRoot ?? join(options.agencHome, "skills");
+  const target = join(skillsRoot, options.slug);
+  if (new Set(options.installedSkillNames).has(options.slug)) {
+    throw new SkillCandidateError(
+      "name_taken",
+      `a skill named ${options.slug} is already installed; rename the candidate or reject it`,
+    );
+  }
+  if (await pathExists(target)) {
+    throw new SkillCandidateError(
+      "name_taken",
+      `${target} already exists; refusing to overwrite it`,
+    );
+  }
+  await mkdir(skillsRoot, { recursive: true });
+  try {
+    await rename(source, target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EXDEV") throw error;
+    await cp(source, target, { recursive: true });
+    await rm(source, { recursive: true, force: true });
+  }
+  await rm(join(target, SKILL_CANDIDATE_RECORD_FILE), { force: true });
+  await appendLedger(options.agencHome, {
+    slug: options.slug,
+    action: "accepted",
+    at: new Date().toISOString(),
+    ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
+  });
+  return { path: target };
+}
+
+/** Delete a draft and record the rejection. */
+export async function rejectSkillCandidate(
+  agencHome: string,
+  slug: string,
+  sessionId?: string,
+): Promise<void> {
+  const directory = resolveSkillCandidateDirectory(agencHome, slug);
+  if (!(await pathExists(directory))) {
+    throw new SkillCandidateError("not_found", `no skill candidate named ${slug}`);
+  }
+  await rm(directory, { recursive: true, force: true });
+  await appendLedger(agencHome, {
+    slug,
+    action: "rejected",
+    at: new Date().toISOString(),
+    ...(sessionId !== undefined ? { sessionId } : {}),
+  });
+}

--- a/runtime/src/skills/skills-cli.ts
+++ b/runtime/src/skills/skills-cli.ts
@@ -18,6 +18,18 @@ import {
   loadLocalSkillsSnapshot,
   type LocalSkillMetadata,
 } from "./local-loader.js";
+import {
+  acceptSkillCandidate,
+  isValidSkillCandidateSlug,
+  listSkillCandidates,
+  readSkillCandidateFile,
+  rejectSkillCandidate,
+  resolveSkillCandidatesRoot,
+  SKILL_CANDIDATES_DIR_NAME,
+  SKILL_CANDIDATES_ENV,
+  SKILL_CANDIDATES_LEDGER_FILE,
+  SkillCandidateError,
+} from "./skill-candidates.js";
 
 export const SKILLS_INVENTORY_SCHEMA_VERSION = 1;
 export const SKILLS_INVENTORY_KIND = "agenc.skills.inventory";
@@ -58,17 +70,34 @@ export interface SkillsCliOptions {
   readonly env: Readonly<Record<string, string | undefined>>;
 }
 
-export type AgenCSkillsCliCommand = {
-  readonly kind: "list";
-  readonly json: boolean;
-};
+export type AgenCSkillsCliCommand =
+  | { readonly kind: "list"; readonly json: boolean }
+  | { readonly kind: "candidates-list"; readonly json: boolean }
+  | { readonly kind: "candidates-show"; readonly slug: string }
+  | { readonly kind: "candidates-accept"; readonly slug: string }
+  | { readonly kind: "candidates-reject"; readonly slug: string }
+  | { readonly kind: "error"; readonly message: string };
 
+export const SKILL_CANDIDATES_LISTING_KIND = "agenc.skills.candidates";
+
+/**
+ * `agenc skills list [--json]` keeps its original contract: anything else
+ * after `list` returns null and falls through to the default route. Once the
+ * user has typed `skills candidates`, a malformed rest is reported as an
+ * error instead of being handed to a session as a prompt, because three of
+ * the four candidate commands move or delete files.
+ */
 export function parseAgenCSkillsCliArgs(
   argv: readonly string[],
 ): AgenCSkillsCliCommand | null {
   const [command, subcommand, ...rest] = argv;
   if (command !== "skills") return null;
-  if (subcommand !== "list") return null;
+  if (subcommand === "list") return parseListArgs(rest);
+  if (subcommand === "candidates") return parseCandidatesArgs(rest);
+  return null;
+}
+
+function parseListArgs(rest: readonly string[]): AgenCSkillsCliCommand | null {
   let json = false;
   for (const argument of rest) {
     if (argument === "--json") json = true;
@@ -77,13 +106,65 @@ export function parseAgenCSkillsCliArgs(
   return { kind: "list", json };
 }
 
+function cliError(message: string): AgenCSkillsCliCommand {
+  return { kind: "error", message };
+}
+
+function parseCandidatesArgs(rest: readonly string[]): AgenCSkillsCliCommand {
+  const [action, ...args] = rest;
+  switch (action) {
+    case "list": {
+      let json = false;
+      for (const argument of args) {
+        if (argument === "--json") json = true;
+        else return cliError(`unexpected argument for skills candidates list: ${argument}`);
+      }
+      return { kind: "candidates-list", json };
+    }
+    case "show":
+    case "accept":
+    case "reject": {
+      const [slug, ...extra] = args;
+      if (slug === undefined) {
+        return cliError(`skills candidates ${action} needs a candidate name`);
+      }
+      if (extra.length > 0) {
+        return cliError(
+          `unexpected argument for skills candidates ${action}: ${extra[0]}`,
+        );
+      }
+      if (!isValidSkillCandidateSlug(slug)) {
+        return cliError(
+          `not a skill candidate name (kebab-case letters, digits, hyphens): ${slug}`,
+        );
+      }
+      return { kind: `candidates-${action}`, slug };
+    }
+    case undefined:
+      return cliError(
+        "skills candidates needs one of: list [--json], show <name>, accept <name>, reject <name>",
+      );
+    default:
+      return cliError(`unknown skills candidates command: ${action}`);
+  }
+}
+
 export function formatAgenCSkillsCliHelpText(): string {
   return [
     "Usage: agenc skills <command>",
     "",
     "Commands:",
-    "  list [--json]   List every skill this runtime serves (built-in,",
-    "                  personal, project, and plugin-shipped), readonly.",
+    "  list [--json]               List every skill this runtime serves (built-in,",
+    "                              personal, project, and plugin-shipped), readonly.",
+    "  candidates list [--json]    List draft skills the runtime proposed from past",
+    "                              sessions. Drafts are inactive until accepted.",
+    "  candidates show <name>      Print a draft's SKILL.md.",
+    "  candidates accept <name>    Move a draft into $AGENC_HOME/skills/<name>/ so",
+    "                              the loader picks it up. Refuses an existing name.",
+    "  candidates reject <name>    Delete a draft.",
+    "",
+    `Drafts live under $AGENC_HOME/${SKILL_CANDIDATES_DIR_NAME}/<name>/ next to a`,
+    `${SKILL_CANDIDATES_LEDGER_FILE} audit trail. ${SKILL_CANDIDATES_ENV}=0 stops new proposals.`,
   ].join("\n");
 }
 
@@ -205,8 +286,26 @@ export async function runAgenCSkillsCli(
   command: AgenCSkillsCliCommand,
   options: SkillsCliOptions,
 ): Promise<number> {
+  switch (command.kind) {
+    case "error":
+      process.stderr.write(`agenc: ${command.message}\n`);
+      return 1;
+    case "list":
+      return runList(command.json, options);
+    case "candidates-list":
+      return runCandidatesList(command.json, options);
+    case "candidates-show":
+      return runCandidatesShow(command.slug, options);
+    case "candidates-accept":
+      return runCandidatesAccept(command.slug, options);
+    case "candidates-reject":
+      return runCandidatesReject(command.slug, options);
+  }
+}
+
+async function runList(json: boolean, options: SkillsCliOptions): Promise<number> {
   const inventory = await buildSkillsInventory(options);
-  if (command.json) {
+  if (json) {
     process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);
     return 0;
   }
@@ -218,4 +317,100 @@ export async function runAgenCSkillsCli(
     process.stderr.write(`agenc: ${error}\n`);
   }
   return 0;
+}
+
+async function runCandidatesList(
+  json: boolean,
+  options: SkillsCliOptions,
+): Promise<number> {
+  const listing = await listSkillCandidates(options.agencHome);
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          schemaVersion: SKILLS_INVENTORY_SCHEMA_VERSION,
+          kind: SKILL_CANDIDATES_LISTING_KIND,
+          root: resolveSkillCandidatesRoot(options.agencHome),
+          candidates: listing.candidates,
+          errors: listing.errors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return 0;
+  }
+  if (listing.candidates.length === 0) {
+    process.stdout.write(
+      `no skill candidates in ${resolveSkillCandidatesRoot(options.agencHome)}\n`,
+    );
+  }
+  for (const candidate of listing.candidates) {
+    const evidence = `${candidate.evidenceCount} evidence`;
+    process.stdout.write(
+      `${candidate.slug}  ${candidate.createdAt ?? "created: unknown"}  ${candidate.description}  (${evidence})\n`,
+    );
+  }
+  for (const error of listing.errors) {
+    process.stderr.write(`agenc: ${error}\n`);
+  }
+  return 0;
+}
+
+function reportCandidateFailure(error: unknown): number {
+  const message =
+    error instanceof SkillCandidateError || error instanceof Error
+      ? error.message
+      : String(error);
+  process.stderr.write(`agenc: ${message}\n`);
+  return 1;
+}
+
+async function runCandidatesShow(
+  slug: string,
+  options: SkillsCliOptions,
+): Promise<number> {
+  try {
+    const content = await readSkillCandidateFile(options.agencHome, slug);
+    process.stdout.write(content.endsWith("\n") ? content : `${content}\n`);
+    return 0;
+  } catch (error) {
+    return reportCandidateFailure(error);
+  }
+}
+
+/**
+ * Accept checks the name against the same inventory `agenc skills list`
+ * prints (every origin, bundled included), not only the destination
+ * directory, so a draft cannot shadow a project, plugin, or built-in skill.
+ */
+async function runCandidatesAccept(
+  slug: string,
+  options: SkillsCliOptions,
+): Promise<number> {
+  try {
+    const inventory = await buildSkillsInventory(options);
+    const accepted = await acceptSkillCandidate({
+      agencHome: options.agencHome,
+      slug,
+      installedSkillNames: inventory.skills.map((skill) => skill.name),
+    });
+    process.stdout.write(`accepted ${slug}: ${accepted.path}\n`);
+    return 0;
+  } catch (error) {
+    return reportCandidateFailure(error);
+  }
+}
+
+async function runCandidatesReject(
+  slug: string,
+  options: SkillsCliOptions,
+): Promise<number> {
+  try {
+    await rejectSkillCandidate(options.agencHome, slug);
+    process.stdout.write(`rejected ${slug}\n`);
+    return 0;
+  } catch (error) {
+    return reportCandidateFailure(error);
+  }
 }

--- a/runtime/tests/services/extractMemories/extractMemories.test.ts
+++ b/runtime/tests/services/extractMemories/extractMemories.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1323,5 +1323,200 @@ describe("extraction cadence across a daemon restart", () => {
         message: expect.stringContaining("disk full"),
       },
     ]);
+  });
+});
+
+describe("skill candidates ride the extraction child", () => {
+  let root: string;
+  let memoryDir: string;
+  let agencHome: string;
+
+  const candidate = {
+    name: "run-hermetic-vitest",
+    description: "Run one runtime test file through the hermetic vitest runner.",
+    whenToUse: "When a runtime change needs its tests run in isolation.",
+    body: "# Purpose\n\nRun tests in isolation.\n\n## Steps\n\n1. node scripts/run-hermetic-vitest.mjs run <file>\n\n## Verification\n\nSummary line passes.\n\n## Pitfalls\n\nNever use the real AGENC_HOME.\n",
+    evidence: ["Three runner invocations, each checked against the summary line."],
+  };
+  const replyWithCandidate = (entry: Record<string, unknown> = candidate) =>
+    `Memory updated.\n\n\`\`\`skill-candidates\n${JSON.stringify({ skillCandidates: [entry] })}\n\`\`\`\n`;
+  const messages: LLMMessage[] = [
+    { role: "user", content: "run the runtime tests for this change" },
+    { role: "assistant", content: "done, all green" },
+  ];
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-extract-skillcand-"));
+    memoryDir = join(root, "memory");
+    agencHome = join(root, "agenc-home");
+    await mkdir(memoryDir, { recursive: true });
+    await mkdir(agencHome, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("asks the child for candidates and writes the one it returns as an inactive draft", async () => {
+    const warnings: Array<{ cause: string; message: string }> = [];
+    const session = sessionWithBus(warnings);
+    const runChild = vi.fn(async (_request: ExtractMemoriesChildRequest) => ({
+      outcome: "completed" as const,
+      finalMessage: replyWithCandidate(),
+    }));
+    initExtractMemories({
+      env: {},
+      minEligibleTurns: 1,
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+      runChild,
+      skillCandidatesHome: agencHome,
+      listInstalledSkillNames: async () => ["verify", "already-there"],
+    });
+
+    await executeExtractMemories(extractionContext({ cwd: root, messages, session }));
+
+    expect(runChild).toHaveBeenCalledOnce();
+    const prompt = runChild.mock.calls[0]![0].prompt;
+    expect(prompt).toContain("## Skill candidates (drafts for the user to review)");
+    expect(prompt).toContain("at least 3 tool calls");
+    expect(prompt).toContain("Installed skills: already-there, verify.");
+    expect(prompt).toContain("```skill-candidates");
+
+    const draftDir = join(agencHome, "skill-candidates", "run-hermetic-vitest");
+    const skill = await readFile(join(draftDir, "SKILL.md"), "utf8");
+    expect(skill).toContain('name: "run-hermetic-vitest"');
+    expect(skill).toContain("## Verification");
+    const record = JSON.parse(await readFile(join(draftDir, "candidate.json"), "utf8")) as {
+      provenance: { sessionId?: string; createdAt: string };
+      evidence: string[];
+    };
+    expect(record.provenance.sessionId).toBe(
+      (session as unknown as { conversationId: string }).conversationId,
+    );
+    expect(record.provenance.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/u);
+    expect(record.evidence).toHaveLength(1);
+    const ledger = (await readFile(join(agencHome, "skill-candidates", "ledger.jsonl"), "utf8"))
+      .trim()
+      .split("\n");
+    expect(ledger).toHaveLength(1);
+    expect(JSON.parse(ledger[0]!)).toMatchObject({
+      slug: "run-hermetic-vitest",
+      action: "proposed",
+    });
+    // A draft is not a skill: nothing lands where the loader looks.
+    await expect(stat(join(agencHome, "skills"))).rejects.toThrow();
+    expect(warnings.at(-1)).toEqual({
+      cause: "skill_candidate_proposed",
+      message:
+        "draft skill written for review: run-hermetic-vitest (agenc skills candidates list)",
+    });
+  });
+
+  it("skips a candidate that duplicates an installed skill or trips validation, and says why", async () => {
+    const warnings: Array<{ cause: string; message: string }> = [];
+    const session = sessionWithBus(warnings);
+    initExtractMemories({
+      env: {},
+      minEligibleTurns: 1,
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+      runChild: vi.fn(async () => ({
+        outcome: "completed" as const,
+        finalMessage:
+          "```skill-candidates\n" +
+          JSON.stringify({
+            skillCandidates: [candidate, { ...candidate, name: "Not A Slug" }],
+          }) +
+          "\n```\n",
+      })),
+      skillCandidatesHome: agencHome,
+      listInstalledSkillNames: async () => ["run-hermetic-vitest"],
+    });
+
+    await executeExtractMemories(extractionContext({ cwd: root, messages, session }));
+
+    await expect(stat(join(agencHome, "skill-candidates", "run-hermetic-vitest"))).rejects.toThrow();
+    const causes = warnings.map((warning) => warning.cause);
+    expect(causes).not.toContain("skill_candidate_proposed");
+    expect(causes.filter((cause) => cause === "skill_candidate_skipped")).toHaveLength(2);
+    expect(warnings.map((warning) => warning.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Not A Slug: name is not a kebab-case slug"),
+        "run-hermetic-vitest: a skill with this name is already installed",
+      ]),
+    );
+  });
+
+  it("neither asks for nor writes candidates when AGENC_SKILL_CANDIDATES=0", async () => {
+    const warnings: Array<{ cause: string; message: string }> = [];
+    const session = sessionWithBus(warnings);
+    const runChild = vi.fn(async () => ({
+      outcome: "completed" as const,
+      finalMessage: replyWithCandidate(),
+    }));
+    initExtractMemories({
+      env: { AGENC_SKILL_CANDIDATES: "0" },
+      minEligibleTurns: 1,
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+      runChild,
+      skillCandidatesHome: agencHome,
+      listInstalledSkillNames: async () => [],
+    });
+
+    await executeExtractMemories(extractionContext({ cwd: root, messages, session }));
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(runChild.mock.calls[0]![0].prompt).not.toContain("Skill candidates");
+    await expect(stat(join(agencHome, "skill-candidates"))).rejects.toThrow();
+    expect(warnings.map((warning) => warning.cause)).not.toContain("skill_candidate_proposed");
+  });
+
+  it("stays off when an injected env names no AgenC home", async () => {
+    const runChild = vi.fn(async () => ({
+      outcome: "completed" as const,
+      finalMessage: replyWithCandidate(),
+    }));
+    initExtractMemories({
+      env: {},
+      minEligibleTurns: 1,
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+      runChild,
+      listInstalledSkillNames: async () => [],
+    });
+
+    await executeExtractMemories(extractionContext({ cwd: root, messages }));
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(runChild.mock.calls[0]![0].prompt).not.toContain("Skill candidates");
+    await expect(stat(join(agencHome, "skill-candidates"))).rejects.toThrow();
+  });
+
+  it("reads the candidate block from the real delegate result", async () => {
+    const delegateFn = vi.fn(async () => ({
+      kind: "sync_completed" as const,
+      result: {
+        threadId: "child-thread",
+        durationMs: 0,
+        outcome: "completed" as const,
+        finalMessage: replyWithCandidate(),
+      },
+      thread: {},
+    }));
+    const ensureAgentControl = vi.fn(() => ({ control: {}, registry: {} }));
+    initExtractMemories({
+      env: {},
+      minEligibleTurns: 1,
+      resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }),
+      delegateFn: delegateFn as never,
+      ensureAgentControl: ensureAgentControl as never,
+      skillCandidatesHome: agencHome,
+      listInstalledSkillNames: async () => [],
+    });
+
+    await executeExtractMemories(extractionContext({ cwd: root, messages }));
+
+    expect(delegateFn).toHaveBeenCalledOnce();
+    await expect(
+      stat(join(agencHome, "skill-candidates", "run-hermetic-vitest", "SKILL.md")),
+    ).resolves.toBeDefined();
   });
 });

--- a/runtime/tests/skills/skill-candidates.test.ts
+++ b/runtime/tests/skills/skill-candidates.test.ts
@@ -1,0 +1,416 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { loadLocalSkillsSnapshot } from "../../src/skills/local-loader.js";
+import {
+  acceptSkillCandidate,
+  isSkillCandidatesDisabledByEnv,
+  listSkillCandidates,
+  MAX_SKILL_CANDIDATE_BODY_BYTES,
+  MAX_SKILL_CANDIDATES_PER_RUN,
+  parseSkillCandidateProposals,
+  readSkillCandidateFile,
+  readSkillCandidateLedger,
+  rejectSkillCandidate,
+  renderSkillCandidateFile,
+  resolveSkillCandidatesRoot,
+  SkillCandidateError,
+  validateSkillCandidateProposal,
+  writeSkillCandidates,
+} from "../../src/skills/skill-candidates.js";
+
+vi.mock("bun:bundle", () => ({ feature: () => false }));
+
+const BODY = [
+  "# Purpose",
+  "",
+  "Run one runtime test file in isolation.",
+  "",
+  "## Steps",
+  "",
+  "1. cd runtime",
+  "2. node scripts/run-hermetic-vitest.mjs run <file>",
+  "",
+  "## Verification",
+  "",
+  "The summary line reports every file as passed.",
+  "",
+  "## Pitfalls",
+  "",
+  "Never point AGENC_HOME at the real home while testing.",
+].join("\n");
+
+function proposal(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    name: "run-hermetic-vitest",
+    description: "Run one runtime test file through the hermetic vitest runner.",
+    whenToUse: "When a runtime change needs its tests run in isolation.",
+    body: BODY,
+    evidence: [
+      "Three hermetic runs in the session, each checked against the summary line.",
+    ],
+    ...overrides,
+  };
+}
+
+function reply(payload: unknown): string {
+  return `Memory updated.\n\n\`\`\`skill-candidates\n${JSON.stringify(payload)}\n\`\`\`\n`;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function tempHome(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "agenc-cand-home-"));
+}
+
+describe("skill candidate proposals", () => {
+  it("parses a valid block into a trimmed candidate", () => {
+    const parsed = parseSkillCandidateProposals(
+      reply({
+        skillCandidates: [
+          proposal({ description: "  Run the hermetic runner.  " }),
+        ],
+      }),
+    );
+    expect(parsed.dropped).toEqual([]);
+    expect(parsed.candidates).toHaveLength(1);
+    expect(parsed.candidates[0]).toMatchObject({
+      name: "run-hermetic-vitest",
+      description: "Run the hermetic runner.",
+      whenToUse: "When a runtime change needs its tests run in isolation.",
+    });
+    expect(parsed.candidates[0]?.evidence).toHaveLength(1);
+  });
+
+  it("accepts a bare array and finds the block after other prose", () => {
+    const parsed = parseSkillCandidateProposals(
+      `Saved two memories.\n\n\`\`\`skill-candidates\n${JSON.stringify([proposal()])}\n\`\`\`\nDone.`,
+    );
+    expect(parsed.candidates.map((candidate) => candidate.name)).toEqual([
+      "run-hermetic-vitest",
+    ]);
+  });
+
+  it("keeps the first two entries and drops the rest with a reason", () => {
+    const parsed = parseSkillCandidateProposals(
+      reply({
+        skillCandidates: [
+          proposal({ name: "first-one" }),
+          proposal({ name: "second-one" }),
+          proposal({ name: "third-one" }),
+        ],
+      }),
+    );
+    expect(parsed.candidates.map((candidate) => candidate.name)).toEqual([
+      "first-one",
+      "second-one",
+    ]);
+    expect(parsed.candidates).toHaveLength(MAX_SKILL_CANDIDATES_PER_RUN);
+    expect(parsed.dropped).toEqual([
+      `third-one: over the per-run cap of ${MAX_SKILL_CANDIDATES_PER_RUN}`,
+    ]);
+  });
+
+  it("drops a name that is not a kebab-case slug", () => {
+    for (const name of ["Run Tests", "run_tests", "-leading", "trailing-", "ab", "../escape", "a".repeat(65)]) {
+      const validation = validateSkillCandidateProposal(proposal({ name }));
+      expect(validation.ok, name).toBe(false);
+      if (!validation.ok) expect(validation.reason).toContain("kebab-case");
+    }
+    const parsed = parseSkillCandidateProposals(
+      reply({ skillCandidates: [proposal({ name: "Bad Name" })] }),
+    );
+    expect(parsed.candidates).toEqual([]);
+    expect(parsed.dropped).toHaveLength(1);
+  });
+
+  it("drops a body over the 16 KiB cap and an empty or multi-line description", () => {
+    const tooLong = validateSkillCandidateProposal(
+      proposal({ body: "x".repeat(MAX_SKILL_CANDIDATE_BODY_BYTES + 1) }),
+    );
+    expect(tooLong.ok).toBe(false);
+    if (!tooLong.ok) expect(tooLong.reason).toContain("the cap is 16384");
+    expect(
+      validateSkillCandidateProposal(
+        proposal({ body: "x".repeat(MAX_SKILL_CANDIDATE_BODY_BYTES) }),
+      ).ok,
+    ).toBe(true);
+    expect(validateSkillCandidateProposal(proposal({ description: "" })).ok).toBe(false);
+    expect(
+      validateSkillCandidateProposal(proposal({ whenToUse: "two\nlines" })).ok,
+    ).toBe(false);
+    expect(validateSkillCandidateProposal(proposal({ evidence: [] })).ok).toBe(false);
+  });
+
+  it("drops a candidate whose text trips the secrets scan", () => {
+    const secret = `sk_live_${"a1b2c3d4".repeat(4)}`;
+    const validation = validateSkillCandidateProposal(
+      proposal({ body: `${BODY}\n\nUse the key ${secret} to log in.\n` }),
+    );
+    expect(validation.ok).toBe(false);
+    if (!validation.ok) expect(validation.reason).toContain("potential secrets");
+    const inEvidence = validateSkillCandidateProposal(
+      proposal({ evidence: [`Logged in with ${secret} `] }),
+    );
+    expect(inEvidence.ok).toBe(false);
+  });
+
+  it("ignores replies without a block and reports a malformed one", () => {
+    expect(parseSkillCandidateProposals(undefined)).toEqual({
+      candidates: [],
+      dropped: [],
+    });
+    expect(parseSkillCandidateProposals("Memory updated, nothing to propose.")).toEqual({
+      candidates: [],
+      dropped: [],
+    });
+    const malformed = parseSkillCandidateProposals(
+      "```skill-candidates\n{not json\n```",
+    );
+    expect(malformed.candidates).toEqual([]);
+    expect(malformed.dropped[0]).toContain("not valid JSON");
+    const wrongShape = parseSkillCandidateProposals(
+      "```skill-candidates\n{\"other\": 1}\n```",
+    );
+    expect(wrongShape.dropped[0]).toContain("skillCandidates array");
+  });
+
+  it("renders loader frontmatter once, even when the body brought its own", () => {
+    const validation = validateSkillCandidateProposal(
+      proposal({
+        body: `---\nname: whatever\ndescription: stale\n---\n${BODY}`,
+        description: 'Run tests: the "hermetic" way',
+      }),
+    );
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+    const rendered = renderSkillCandidateFile(validation.candidate);
+    expect(rendered.startsWith("---\nname: \"run-hermetic-vitest\"\n")).toBe(true);
+    expect(rendered).toContain('description: "Run tests: the \\"hermetic\\" way"');
+    expect(rendered).toContain(
+      'when_to_use: "When a runtime change needs its tests run in isolation."',
+    );
+    expect(rendered.match(/^---$/gmu)).toHaveLength(2);
+    expect(rendered).not.toContain("description: stale");
+    expect(rendered).toContain("## Verification");
+  });
+
+  it("is switched off by AGENC_SKILL_CANDIDATES=0 and equivalent spellings", () => {
+    for (const value of ["0", "false", "off", "no"]) {
+      expect(isSkillCandidatesDisabledByEnv({ AGENC_SKILL_CANDIDATES: value })).toBe(true);
+    }
+    for (const value of [undefined, "", "1", "true"]) {
+      expect(isSkillCandidatesDisabledByEnv({ AGENC_SKILL_CANDIDATES: value })).toBe(false);
+    }
+  });
+});
+
+describe("skill candidate drafts on disk", () => {
+  it("writes drafts under skill-candidates with provenance and a ledger line, never under the skills root", async () => {
+    const home = await tempHome();
+    const parsed = parseSkillCandidateProposals(
+      reply({ skillCandidates: [proposal()] }),
+    );
+    const result = await writeSkillCandidates({
+      agencHome: home,
+      candidates: parsed.candidates,
+      installedSkillNames: ["verify", "batch"],
+      provenance: {
+        sessionId: "conv-1",
+        conversationId: "conv-1",
+        model: "test-model",
+        createdAt: "2026-09-05T00:00:00.000Z",
+      },
+    });
+
+    const directory = join(home, "skill-candidates", "run-hermetic-vitest");
+    expect(result.skipped).toEqual([]);
+    expect(result.written).toEqual([{ slug: "run-hermetic-vitest", path: directory }]);
+    expect(await readFile(join(directory, "SKILL.md"), "utf8")).toContain(
+      'name: "run-hermetic-vitest"',
+    );
+    expect(JSON.parse(await readFile(join(directory, "candidate.json"), "utf8"))).toEqual({
+      schemaVersion: 1,
+      slug: "run-hermetic-vitest",
+      name: "run-hermetic-vitest",
+      description: "Run one runtime test file through the hermetic vitest runner.",
+      whenToUse: "When a runtime change needs its tests run in isolation.",
+      evidence: [
+        "Three hermetic runs in the session, each checked against the summary line.",
+      ],
+      provenance: {
+        sessionId: "conv-1",
+        conversationId: "conv-1",
+        createdAt: "2026-09-05T00:00:00.000Z",
+        model: "test-model",
+      },
+    });
+    expect(await readSkillCandidateLedger(home)).toEqual([
+      {
+        slug: "run-hermetic-vitest",
+        action: "proposed",
+        at: "2026-09-05T00:00:00.000Z",
+        sessionId: "conv-1",
+      },
+    ]);
+    expect(await exists(join(home, "skills"))).toBe(false);
+    expect(resolveSkillCandidatesRoot(home)).toBe(join(home, "skill-candidates"));
+  });
+
+  it("skips names that are installed skills or existing drafts and leaves the ledger alone", async () => {
+    const home = await tempHome();
+    const first = await writeSkillCandidates({
+      agencHome: home,
+      candidates: parseSkillCandidateProposals(
+        reply({ skillCandidates: [proposal(), proposal({ name: "verify" })] }),
+      ).candidates,
+      installedSkillNames: ["verify"],
+      provenance: { sessionId: "conv-1" },
+    });
+    expect(first.written.map((entry) => entry.slug)).toEqual(["run-hermetic-vitest"]);
+    expect(first.skipped).toEqual([
+      { slug: "verify", reason: "a skill with this name is already installed" },
+    ]);
+
+    const before = await readFile(join(home, "skill-candidates", "run-hermetic-vitest", "SKILL.md"), "utf8");
+    const again = await writeSkillCandidates({
+      agencHome: home,
+      candidates: parseSkillCandidateProposals(
+        reply({ skillCandidates: [proposal({ description: "A different draft." })] }),
+      ).candidates,
+      installedSkillNames: [],
+      provenance: { sessionId: "conv-2" },
+    });
+    expect(again.written).toEqual([]);
+    expect(again.skipped).toEqual([
+      { slug: "run-hermetic-vitest", reason: "a candidate with this name already exists" },
+    ]);
+    expect(await readFile(join(home, "skill-candidates", "run-hermetic-vitest", "SKILL.md"), "utf8")).toBe(before);
+    expect(await readSkillCandidateLedger(home)).toHaveLength(1);
+  });
+
+  it("is invisible to the skills loader until accepted", async () => {
+    const home = await tempHome();
+    const fakeUserHome = await tempHome();
+    const workspaceRoot = await tempHome();
+    await mkdir(join(home, "skills", "real-skill"), { recursive: true });
+    await writeFile(
+      join(home, "skills", "real-skill", "SKILL.md"),
+      "---\nname: real-skill\ndescription: an installed skill\n---\n# real-skill\n",
+    );
+    await writeSkillCandidates({
+      agencHome: home,
+      candidates: parseSkillCandidateProposals(
+        reply({ skillCandidates: [proposal()] }),
+      ).candidates,
+      installedSkillNames: ["real-skill"],
+      provenance: {},
+    });
+    const options = {
+      agencHome: home,
+      pluginStorageRoot: join(home, "plugins"),
+      workspaceRoot,
+      env: { HOME: fakeUserHome },
+    };
+
+    const before = await loadLocalSkillsSnapshot(options);
+    expect(before.skills.map((skill) => skill.name)).toContain("real-skill");
+    expect(before.skills.map((skill) => skill.name)).not.toContain("run-hermetic-vitest");
+    // No discovered root is the candidates directory or anything below it.
+    expect(
+      before.skillRoots.filter((root) => root.split(sep).includes("skill-candidates")),
+    ).toEqual([]);
+
+    await acceptSkillCandidate({
+      agencHome: home,
+      slug: "run-hermetic-vitest",
+      installedSkillNames: before.skills.map((skill) => skill.name),
+    });
+    const after = await loadLocalSkillsSnapshot(options);
+    const accepted = after.skills.find((skill) => skill.name === "run-hermetic-vitest");
+    expect(accepted).toBeDefined();
+    expect(accepted?.scope).toBe("user");
+    expect(accepted?.whenToUse).toBe(
+      "When a runtime change needs its tests run in isolation.",
+    );
+    expect(await exists(join(home, "skills", "run-hermetic-vitest", "candidate.json"))).toBe(false);
+    expect(await exists(join(home, "skill-candidates", "run-hermetic-vitest"))).toBe(false);
+  });
+
+  it("lists, shows, accepts and rejects drafts and refuses to accept a taken name", async () => {
+    const home = await tempHome();
+    await writeSkillCandidates({
+      agencHome: home,
+      candidates: parseSkillCandidateProposals(
+        reply({
+          skillCandidates: [proposal(), proposal({ name: "taken-name", evidence: ["a", "b"] })],
+        }),
+      ).candidates,
+      installedSkillNames: [],
+      provenance: { createdAt: "2026-09-05T01:02:03.000Z" },
+    });
+
+    const listing = await listSkillCandidates(home);
+    expect(listing.errors).toEqual([]);
+    expect(listing.candidates.map((candidate) => [candidate.slug, candidate.evidenceCount, candidate.createdAt])).toEqual([
+      ["run-hermetic-vitest", 1, "2026-09-05T01:02:03.000Z"],
+      ["taken-name", 2, "2026-09-05T01:02:03.000Z"],
+    ]);
+    expect(await readSkillCandidateFile(home, "taken-name")).toContain('name: "taken-name"');
+    await expect(readSkillCandidateFile(home, "missing-one")).rejects.toMatchObject({
+      code: "not_found",
+    });
+
+    await expect(
+      acceptSkillCandidate({ agencHome: home, slug: "taken-name", installedSkillNames: ["taken-name"] }),
+    ).rejects.toMatchObject({ code: "name_taken" });
+    await mkdir(join(home, "skills", "taken-name"), { recursive: true });
+    await expect(
+      acceptSkillCandidate({ agencHome: home, slug: "taken-name", installedSkillNames: [] }),
+    ).rejects.toMatchObject({ code: "name_taken" });
+    expect(await exists(join(home, "skill-candidates", "taken-name", "SKILL.md"))).toBe(true);
+
+    await rejectSkillCandidate(home, "taken-name", "conv-9");
+    expect(await exists(join(home, "skill-candidates", "taken-name"))).toBe(false);
+    await expect(rejectSkillCandidate(home, "taken-name")).rejects.toBeInstanceOf(SkillCandidateError);
+    await expect(
+      acceptSkillCandidate({ agencHome: home, slug: "not-a-draft", installedSkillNames: [] }),
+    ).rejects.toMatchObject({ code: "not_found" });
+
+    const accepted = await acceptSkillCandidate({
+      agencHome: home,
+      slug: "run-hermetic-vitest",
+      installedSkillNames: ["verify"],
+    });
+    expect(accepted.path).toBe(join(home, "skills", "run-hermetic-vitest"));
+    expect(await exists(join(accepted.path, "SKILL.md"))).toBe(true);
+    expect((await listSkillCandidates(home)).candidates).toEqual([]);
+    expect((await readSkillCandidateLedger(home)).map((entry) => `${entry.slug}:${entry.action}`)).toEqual([
+      "run-hermetic-vitest:proposed",
+      "taken-name:proposed",
+      "taken-name:rejected",
+      "run-hermetic-vitest:accepted",
+    ]);
+    expect((await readSkillCandidateLedger(home))[2]).toMatchObject({ sessionId: "conv-9" });
+  });
+
+  it("refuses a slug that could leave the candidates directory", async () => {
+    const home = await tempHome();
+    await expect(readSkillCandidateFile(home, "../skills")).rejects.toMatchObject({
+      code: "invalid_slug",
+    });
+    await expect(rejectSkillCandidate(home, "Skills")).rejects.toMatchObject({
+      code: "invalid_slug",
+    });
+  });
+});

--- a/runtime/tests/skills/skills-cli.test.ts
+++ b/runtime/tests/skills/skills-cli.test.ts
@@ -1,8 +1,17 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { buildSkillsInventory, parseAgenCSkillsCliArgs } from "../../src/skills/skills-cli.js";
+import { describe, expect, it, vi } from "vitest";
+import { writeSkillCandidates } from "../../src/skills/skill-candidates.js";
+import {
+  buildSkillsInventory,
+  formatAgenCSkillsCliHelpText,
+  parseAgenCSkillsCliArgs,
+  runAgenCSkillsCli,
+  type SkillsCliOptions,
+} from "../../src/skills/skills-cli.js";
+
+vi.mock("bun:bundle", () => ({ feature: () => false }));
 
 async function writeSkill(root: string, name: string): Promise<void> {
   await mkdir(join(root, name), { recursive: true });
@@ -122,6 +131,180 @@ describe("agenc skills CLI", () => {
     } finally {
       if (previousCap === undefined) delete process.env.AGENC_MAX_SKILL_FILES_PER_ROOT;
       else process.env.AGENC_MAX_SKILL_FILES_PER_ROOT = previousCap;
+    }
+  });
+});
+
+describe("agenc skills candidates CLI", () => {
+  const draft = (name: string, evidence: string[] = ["one verified run"]) => ({
+    name,
+    description: `${name} description`,
+    whenToUse: `when ${name} applies`,
+    body: `# ${name}\n\n## Steps\n\n1. do it\n\n## Verification\n\ncheck it\n`,
+    evidence,
+  });
+
+  async function seedHome(): Promise<{ agencHome: string; options: SkillsCliOptions }> {
+    const agencHome = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cand-"));
+    const fakeUserHome = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cand-user-"));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "agenc-skills-cli-cand-ws-"));
+    await writeSkill(join(agencHome, "skills"), "my-notes");
+    await writeSkillCandidates({
+      agencHome,
+      candidates: [draft("fresh-draft"), draft("my-notes", ["a", "b"]), draft("doomed-draft")],
+      installedSkillNames: [],
+      provenance: { sessionId: "conv-1", createdAt: "2026-09-05T00:00:00.000Z" },
+    });
+    return {
+      agencHome,
+      options: {
+        agencHome,
+        pluginStorageRoot: join(agencHome, "plugins"),
+        workspaceRoot,
+        env: { AGENC_HOME: agencHome, HOME: fakeUserHome },
+      },
+    };
+  }
+
+  function captureOutput(): { stdout: string[]; stderr: string[]; restore: () => void } {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const outSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        stdout.push(String(chunk));
+        return true;
+      }) as typeof process.stdout.write);
+    const errSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        stderr.push(String(chunk));
+        return true;
+      }) as typeof process.stderr.write);
+    return {
+      stdout,
+      stderr,
+      restore: () => {
+        outSpy.mockRestore();
+        errSpy.mockRestore();
+      },
+    };
+  }
+
+  it("parses the candidates commands and reports malformed ones as errors", () => {
+    expect(parseAgenCSkillsCliArgs(["skills", "candidates", "list"])).toEqual({
+      kind: "candidates-list",
+      json: false,
+    });
+    expect(parseAgenCSkillsCliArgs(["skills", "candidates", "list", "--json"])).toEqual({
+      kind: "candidates-list",
+      json: true,
+    });
+    expect(parseAgenCSkillsCliArgs(["skills", "candidates", "show", "my-draft"])).toEqual({
+      kind: "candidates-show",
+      slug: "my-draft",
+    });
+    expect(parseAgenCSkillsCliArgs(["skills", "candidates", "accept", "my-draft"])).toEqual({
+      kind: "candidates-accept",
+      slug: "my-draft",
+    });
+    expect(parseAgenCSkillsCliArgs(["skills", "candidates", "reject", "my-draft"])).toEqual({
+      kind: "candidates-reject",
+      slug: "my-draft",
+    });
+    for (const argv of [
+      ["skills", "candidates"],
+      ["skills", "candidates", "accept"],
+      ["skills", "candidates", "accept", "Bad Name"],
+      ["skills", "candidates", "accept", "../skills"],
+      ["skills", "candidates", "reject", "one", "two"],
+      ["skills", "candidates", "list", "--verbose"],
+      ["skills", "candidates", "frobnicate"],
+    ]) {
+      expect(parseAgenCSkillsCliArgs(argv), argv.join(" ")).toMatchObject({ kind: "error" });
+    }
+    // The original list contract is unchanged.
+    expect(parseAgenCSkillsCliArgs(["skills", "list", "--verbose"])).toBeNull();
+    expect(parseAgenCSkillsCliArgs(["skills", "install", "x"])).toBeNull();
+    expect(formatAgenCSkillsCliHelpText()).toContain("candidates accept <name>");
+  });
+
+  it("lists and shows drafts", async () => {
+    const { agencHome, options } = await seedHome();
+    const output = captureOutput();
+    try {
+      expect(await runAgenCSkillsCli({ kind: "candidates-list", json: false }, options)).toBe(0);
+      const text = output.stdout.join("");
+      expect(text).toContain("fresh-draft  2026-09-05T00:00:00.000Z  fresh-draft description  (1 evidence)");
+      expect(text).toContain("my-notes  2026-09-05T00:00:00.000Z  my-notes description  (2 evidence)");
+
+      output.stdout.length = 0;
+      expect(await runAgenCSkillsCli({ kind: "candidates-list", json: true }, options)).toBe(0);
+      const document = JSON.parse(output.stdout.join("")) as {
+        kind: string;
+        root: string;
+        candidates: Array<{ slug: string; evidenceCount: number }>;
+        errors: string[];
+      };
+      expect(document.kind).toBe("agenc.skills.candidates");
+      expect(document.root).toBe(join(agencHome, "skill-candidates"));
+      expect(document.candidates.map((candidate) => candidate.slug)).toEqual([
+        "doomed-draft",
+        "fresh-draft",
+        "my-notes",
+      ]);
+      expect(document.errors).toEqual([]);
+
+      output.stdout.length = 0;
+      expect(await runAgenCSkillsCli({ kind: "candidates-show", slug: "fresh-draft" }, options)).toBe(0);
+      expect(output.stdout.join("")).toContain('name: "fresh-draft"');
+      expect(output.stdout.join("")).toContain("## Verification");
+
+      expect(await runAgenCSkillsCli({ kind: "candidates-show", slug: "no-such-draft" }, options)).toBe(1);
+      expect(output.stderr.join("")).toContain("agenc: no skill candidate named no-such-draft");
+      expect(await runAgenCSkillsCli({ kind: "error", message: "boom" }, options)).toBe(1);
+      expect(output.stderr.join("")).toContain("agenc: boom");
+    } finally {
+      output.restore();
+    }
+  });
+
+  it("accepts a draft into the user skills root, refuses a taken name, and rejects", async () => {
+    const { agencHome, options } = await seedHome();
+    const output = captureOutput();
+    try {
+      expect(await runAgenCSkillsCli({ kind: "candidates-accept", slug: "my-notes" }, options)).toBe(1);
+      expect(output.stderr.join("")).toContain("a skill named my-notes is already installed");
+      await expect(stat(join(agencHome, "skill-candidates", "my-notes", "SKILL.md"))).resolves.toBeDefined();
+
+      expect(await runAgenCSkillsCli({ kind: "candidates-accept", slug: "fresh-draft" }, options)).toBe(0);
+      expect(output.stdout.join("")).toContain(
+        `accepted fresh-draft: ${join(agencHome, "skills", "fresh-draft")}`,
+      );
+      await expect(stat(join(agencHome, "skills", "fresh-draft", "SKILL.md"))).resolves.toBeDefined();
+      await expect(stat(join(agencHome, "skills", "fresh-draft", "candidate.json"))).rejects.toThrow();
+      await expect(stat(join(agencHome, "skill-candidates", "fresh-draft"))).rejects.toThrow();
+      const inventory = await buildSkillsInventory(options);
+      expect(inventory.skills.some((skill) => skill.origin === "personal" && skill.name === "fresh-draft")).toBe(true);
+
+      expect(await runAgenCSkillsCli({ kind: "candidates-reject", slug: "doomed-draft" }, options)).toBe(0);
+      expect(output.stdout.join("")).toContain("rejected doomed-draft");
+      await expect(stat(join(agencHome, "skill-candidates", "doomed-draft"))).rejects.toThrow();
+      expect(await runAgenCSkillsCli({ kind: "candidates-reject", slug: "doomed-draft" }, options)).toBe(1);
+
+      const ledger = (await readFile(join(agencHome, "skill-candidates", "ledger.jsonl"), "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { slug: string; action: string });
+      expect(ledger.map((entry) => `${entry.slug}:${entry.action}`)).toEqual([
+        "fresh-draft:proposed",
+        "my-notes:proposed",
+        "doomed-draft:proposed",
+        "fresh-draft:accepted",
+        "doomed-draft:rejected",
+      ]);
+    } finally {
+      output.restore();
     }
   });
 });


### PR DESCRIPTION
## Why

Point 4 of the agentic-coding plan: the agent should turn procedures it has actually carried out and verified into reusable skills, but never activate them on its own. A draft the user reviews is the right shape: the model proposes, the user accepts or rejects, and only an accepted draft becomes a skill the loader sees. The proposal rides the memory-extraction child that already reviews the conversation every third eligible turn, so there is no new scheduler and no extra model call.

## What changed

- `runtime/src/skills/skill-candidates.ts` (new): types, the `AGENC_SKILL_CANDIDATES` opt-out, parsing of a fenced `skill-candidates` block in the child's final message (an array or `{ "skillCandidates": [...] }`, at most 2 per run), validation (kebab-case slug of 3 to 64 chars, one-line description and `whenToUse` up to 300 chars, body under 16 KiB with leading frontmatter stripped, 1 to 8 evidence lines, the existing `scanForSecrets` over every field), rendering, writing, list, show, accept, reject and the ledger.
- `runtime/src/services/extractMemories/extractMemories.ts`: the child result now carries `finalMessage`; after a successful extraction the proposals are parsed and written; two new warning causes, `skill_candidate_proposed` and `skill_candidate_skipped`, on the session log channel like the other extraction warnings; injectable `skillCandidatesHome` and `listInstalledSkillNames` (default: the session's skills manager plus the bundled registry). Proposals are off when an injected env names no `AGENC_HOME`, so test doubles cannot write into a real home.
- `runtime/src/services/extractMemories/prompts.ts`: `buildSkillCandidatesPromptSection` tells the reviewer to propose only a procedure that was carried out and checked (at least three tool calls leading to a verified outcome such as a passing test run), likely to recur, and not covered by an installed skill; the installed names are listed (sorted, capped at 4,000 chars); it is told most runs propose nothing and never to write a candidate as a memory file or include secrets.
- `runtime/src/skills/skills-cli.ts`: `agenc skills candidates list [--json] | show <slug> | accept <slug> | reject <slug>`. Accept refuses a slug that names any installed skill (built-ins included) or an occupied directory, moves the directory into the user skills root, drops `candidate.json` and appends `accepted` to the ledger; reject deletes the directory and appends `rejected`. A malformed `candidates` command returns an error (exit 1) rather than falling through, because falling through would start a session with the words as a prompt.
- Docs: `docs/reference/skills-plugins.md` (new "Skill candidates" section), `docs/reference/env.md` (`AGENC_SKILL_CANDIDATES` row and index), `docs/reference/cli.md`, `docs/reference/memory.md`.

## Where drafts live and why the loader never sees them

`<AGENC_HOME>/skill-candidates/<slug>/SKILL.md` (frontmatter `name`, `description`, `when_to_use`, then the body) plus `candidate.json` (sessionId, conversationId, createdAt, model, evidence) and one `ledger.jsonl` line per action. `localSkillRootCandidates` in `local-loader.ts` enumerates only `<dir>/.agenc/skills`, `<dir>/.agents/skills` up the project walk, `<agencHome>/skills`, `$HOME/.agents/skills`, the managed home and plugin roots, and walks downward from each; `skill-candidates` is a sibling of `<agencHome>/skills`, never a root or under one. The test "is invisible to the skills loader until accepted" proves it: the draft is absent from the loader snapshot, no root path contains a `skill-candidates` segment, and after `accept` it loads with `scope: "user"` and its `whenToUse`.

## Tests

- `tests/skills/skill-candidates.test.ts` (new, 14): parse and validate (valid, over the cap, bad slug, secret in body dropped, proposed twice), write and dedupe, ledger, loader invisibility, accept and reject including the name-taken refusals.
- `tests/skills/skills-cli.test.ts` (+3): list, show, accept and reject on a temp home; malformed command is an error.
- `tests/services/extractMemories/extractMemories.test.ts` (+5): a child result carrying a proposal produces the files through the real delegate path; skipped proposals warn; the opt-out env; no home means no writes.
- Hermetic runner over the touched files and every importer (agent-name, background-extraction-fence, lifecycle, phases/commit, autoDream gates, memory-wiring contract, local-loader) plus the two env-doc architecture tests: 12 files, 148 passed. `tsc --noEmit`: clean apart from the local TS2883 lines.

## Not changed

- No TUI notice for a new draft; discovery is `agenc skills candidates list` and the session-log warning.
- The skill listing shown to the model (`prompts/attachments/skill-listing.ts`) is untouched; drafts never appear in it.
- No automatic acceptance of any kind.

## Counterparts

#2147 (relevance block in the listing), #2143 (extraction cadence persistence, the child this rides on), #2022 (skills never invoked in a 15-turn session).
