### PR TITLE
prompts: keep the instruction head stable for the session

### DIFF
--- a/runtime/src/prompts/attachments/instruction-update.ts
+++ b/runtime/src/prompts/attachments/instruction-update.ts
@@ -1,0 +1,26 @@
+import type { AttachmentProducer } from "./orchestrator.js";
+import { takeInstructionHeadUpdate } from "../instruction-head.js";
+
+/**
+ * Tells the model that the workspace instructions or the persistent memory
+ * index changed since the session started. The head of the prompt keeps the
+ * session-start version so the provider's cached prefix survives; the current
+ * version rides here and stays in place through the attachment ledger.
+ */
+export const instructionUpdateProducer: AttachmentProducer = async (
+  opts,
+  trackingState,
+) => {
+  if (opts.subagentDepth > 0) return [];
+  const update = takeInstructionHeadUpdate(trackingState);
+  if (update === undefined) return [];
+  return [
+    {
+      kind: "instruction_update",
+      ...(update.workspaceText !== undefined
+        ? { workspaceText: update.workspaceText }
+        : {}),
+      ...(update.memoryText !== undefined ? { memoryText: update.memoryText } : {}),
+    },
+  ];
+};

--- a/runtime/src/prompts/attachments/messages.ts
+++ b/runtime/src/prompts/attachments/messages.ts
@@ -335,8 +335,29 @@ function renderAttachment(attachment: Attachment): LLMMessage | null {
         wrapSystemReminder(`${SKILL_RELEVANCE_REMINDER_HEADER}\n\n${content}`),
       );
     }
+    case "instruction_update": {
+      const sections: string[] = [];
+      if (attachment.workspaceText !== undefined) {
+        sections.push(
+          `${INSTRUCTION_UPDATE_WORKSPACE_HEADER}\n\n${sanitizeSystemReminderContent(attachment.workspaceText)}`,
+        );
+      }
+      if (attachment.memoryText !== undefined) {
+        sections.push(
+          `${INSTRUCTION_UPDATE_MEMORY_HEADER}\n\n${sanitizeSystemReminderContent(attachment.memoryText)}`,
+        );
+      }
+      if (sections.length === 0) return null;
+      return userContextMessage(wrapSystemReminder(sections.join("\n\n")));
+    }
   }
 }
+
+/** Opening sentences of the `instruction_update` reminder. */
+export const INSTRUCTION_UPDATE_WORKSPACE_HEADER =
+  "The workspace instructions changed since this session started. This version replaces the one at the start of the prompt:";
+export const INSTRUCTION_UPDATE_MEMORY_HEADER =
+  "The persistent memory index changed since this session started. This version replaces the one at the start of the prompt:";
 
 /** Opening sentence of the per-request `skill_relevance` reminder. */
 export const SKILL_RELEVANCE_REMINDER_HEADER =

--- a/runtime/src/prompts/attachments/orchestrator.ts
+++ b/runtime/src/prompts/attachments/orchestrator.ts
@@ -31,6 +31,7 @@ import { autoModeProducer } from "./auto-mode.js";
 import { swarmModeProducer } from "./swarm-mode.js";
 import { criticalReminderProducer } from "./critical-reminder.js";
 import { dateChangeProducer } from "./date-change.js";
+import { instructionUpdateProducer } from "./instruction-update.js";
 import { deferredToolsDeltaProducer } from "./deferred-tools-delta.js";
 import { mcpInstructionsDeltaProducer } from "./mcp-delta.js";
 import { outputStyleProducer } from "./output-style.js";
@@ -199,6 +200,7 @@ const PRODUCERS: readonly AttachmentProducer[] = [
   //
   // Phase 4 — System reminders:
   dateChangeProducer,
+  instructionUpdateProducer,
   criticalReminderProducer,
   outputStyleProducer,
   //

--- a/runtime/src/prompts/attachments/types.ts
+++ b/runtime/src/prompts/attachments/types.ts
@@ -330,6 +330,17 @@ export interface SkillRelevanceAttachment {
 }
 
 /**
+ * The workspace instructions or the persistent memory index changed since the
+ * session started; the head of the prompt keeps the first version so the
+ * cached prefix holds, and this carries the current one.
+ */
+export interface InstructionUpdateAttachment {
+  readonly kind: "instruction_update";
+  readonly workspaceText?: string;
+  readonly memoryText?: string;
+}
+
+/**
  * Passive diagnostics published by configured LSP servers.
  * Source: upstream attachment donor `attachments.ts:2912-2954`.
  */
@@ -374,6 +385,7 @@ export type Attachment =
   | McpResourceAttachment
   | SkillListingAttachment
   | SkillRelevanceAttachment
+  | InstructionUpdateAttachment
   | LspDiagnosticsAttachment;
 
 /** All possible `Attachment.kind` values. */

--- a/runtime/src/prompts/instruction-head.ts
+++ b/runtime/src/prompts/instruction-head.ts
@@ -36,9 +36,16 @@ export interface InstructionHeadUpdate {
 export function stabilizeInstructionHead(
   tracking: AttachmentTrackingState,
   fresh: InstructionHeadTexts,
+  scope: string,
 ): InstructionHeadTexts {
-  if (tracking.instructionHead === undefined) {
+  // A turn in another workspace is another set of instructions, not a change
+  // to this one: start a fresh head for it instead of announcing a diff.
+  if (
+    tracking.instructionHead === undefined ||
+    tracking.instructionHeadScope !== scope
+  ) {
     tracking.instructionHead = fresh;
+    tracking.instructionHeadScope = scope;
     tracking.instructionAnnounced = fresh;
     tracking.pendingInstructionUpdate = undefined;
     return fresh;
@@ -76,6 +83,7 @@ export function takeInstructionHeadUpdate(
 /** Forget the snapshot; the next turn re-reads and starts a new head. */
 export function resetInstructionHead(tracking: AttachmentTrackingState): void {
   tracking.instructionHead = undefined;
+  tracking.instructionHeadScope = undefined;
   tracking.instructionAnnounced = undefined;
   tracking.pendingInstructionUpdate = undefined;
 }

--- a/runtime/src/prompts/instruction-head.ts
+++ b/runtime/src/prompts/instruction-head.ts
@@ -1,0 +1,81 @@
+/**
+ * Keep the instruction head of the prompt byte-stable for a session.
+ *
+ * The workspace instructions (AGENC.md tiers) and the persistent memory
+ * indexes (MEMORY.md) open the system prompt, ahead of the trusted base
+ * prompt so they can never shadow it. They were re-read every turn, and the
+ * memory extraction child rewrites MEMORY.md every few turns, so the first
+ * bytes of the prompt changed and the provider's cache missed from byte zero
+ * at the next turn (measured: cached 0 of 46k tokens right after an
+ * extraction run). The head now keeps the version the session started with;
+ * a change is delivered once as a system-reminder near the end of the
+ * prompt (`instruction_update`), which the attachment ledger then keeps in
+ * place. Compaction rewrites the history anyway, so the head is re-snapshotted
+ * there (see `resetRelevantMemoryBudget`).
+ *
+ * @module
+ */
+
+import type { AttachmentTrackingState } from "../session/attachment-state.js";
+
+export interface InstructionHeadTexts {
+  readonly workspaceText: string;
+  readonly memoryText: string;
+}
+
+export interface InstructionHeadUpdate {
+  readonly workspaceText?: string;
+  readonly memoryText?: string;
+}
+
+/**
+ * Returns the texts to put at the head of the prompt for this turn: the
+ * session's first version. When `fresh` differs from what the model was last
+ * told, the difference is queued for the update producer.
+ */
+export function stabilizeInstructionHead(
+  tracking: AttachmentTrackingState,
+  fresh: InstructionHeadTexts,
+): InstructionHeadTexts {
+  if (tracking.instructionHead === undefined) {
+    tracking.instructionHead = fresh;
+    tracking.instructionAnnounced = fresh;
+    tracking.pendingInstructionUpdate = undefined;
+    return fresh;
+  }
+  const announced = tracking.instructionAnnounced ?? tracking.instructionHead;
+  const pending: { workspaceText?: string; memoryText?: string } = {};
+  if (fresh.workspaceText !== announced.workspaceText) {
+    pending.workspaceText = fresh.workspaceText;
+  }
+  if (fresh.memoryText !== announced.memoryText) {
+    pending.memoryText = fresh.memoryText;
+  }
+  tracking.pendingInstructionUpdate =
+    pending.workspaceText === undefined && pending.memoryText === undefined
+      ? undefined
+      : pending;
+  return tracking.instructionHead;
+}
+
+/** Take the queued update, marking its content as told to the model. */
+export function takeInstructionHeadUpdate(
+  tracking: AttachmentTrackingState,
+): InstructionHeadUpdate | undefined {
+  const pending = tracking.pendingInstructionUpdate;
+  if (pending === undefined) return undefined;
+  tracking.pendingInstructionUpdate = undefined;
+  const announced = tracking.instructionAnnounced ?? tracking.instructionHead;
+  tracking.instructionAnnounced = {
+    workspaceText: pending.workspaceText ?? announced?.workspaceText ?? "",
+    memoryText: pending.memoryText ?? announced?.memoryText ?? "",
+  };
+  return pending;
+}
+
+/** Forget the snapshot; the next turn re-reads and starts a new head. */
+export function resetInstructionHead(tracking: AttachmentTrackingState): void {
+  tracking.instructionHead = undefined;
+  tracking.instructionAnnounced = undefined;
+  tracking.pendingInstructionUpdate = undefined;
+}

--- a/runtime/src/prompts/live-instructions.ts
+++ b/runtime/src/prompts/live-instructions.ts
@@ -509,10 +509,11 @@ export async function resolveLiveInstructionEnvelope(input: {
   // The head keeps the session-start version of both blocks so the cached
   // prefix holds; a change reaches the model through the instruction_update
   // attachment instead (prompts/instruction-head.ts).
-  const head = stabilizeInstructionHead(getAttachmentTrackingState(input.session), {
-    workspaceText,
-    memoryText: freshMemoryText,
-  });
+  const head = stabilizeInstructionHead(
+    getAttachmentTrackingState(input.session),
+    { workspaceText, memoryText: freshMemoryText },
+    resolve(input.ctx.cwd),
+  );
 
   // The trusted role/base prompt is last and therefore cannot be textually
   // shadowed by lower-authority repository guidance or by persisted memory.

--- a/runtime/src/prompts/live-instructions.ts
+++ b/runtime/src/prompts/live-instructions.ts
@@ -3,6 +3,8 @@ import { lstat, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import type { Session } from "../session/session.js";
+import { getAttachmentTrackingState } from "../session/attachment-state.js";
+import { stabilizeInstructionHead } from "./instruction-head.js";
 import type { TurnContext } from "../session/turn-context.js";
 import {
   getGlobalMemoryEntrypoint,
@@ -497,22 +499,30 @@ export async function resolveLiveInstructionEnvelope(input: {
         ]
       : []),
   ];
-  const memoryText = await loadMemoryEntrypointsText();
+  const freshMemoryText = await loadMemoryEntrypointsText();
   input.session.setProjectMemoryWarnings(warnings);
   const sources = [
     ...sourcesFromTiers({ tiers }),
     ...additionalSources,
   ];
 
+  // The head keeps the session-start version of both blocks so the cached
+  // prefix holds; a change reaches the model through the instruction_update
+  // attachment instead (prompts/instruction-head.ts).
+  const head = stabilizeInstructionHead(getAttachmentTrackingState(input.session), {
+    workspaceText,
+    memoryText: freshMemoryText,
+  });
+
   // The trusted role/base prompt is last and therefore cannot be textually
   // shadowed by lower-authority repository guidance or by persisted memory.
-  const text = [workspaceText, memoryText, input.baseInstructions]
+  const text = [head.workspaceText, head.memoryText, input.baseInstructions]
     .filter((part) => part.trim().length > 0)
     .join("\n\n");
   return {
     text,
-    workspaceText,
-    memoryText,
+    workspaceText: head.workspaceText,
+    memoryText: head.memoryText,
     sources,
     warnings,
     policy,

--- a/runtime/src/session/attachment-state.ts
+++ b/runtime/src/session/attachment-state.ts
@@ -182,6 +182,15 @@ export interface AttachmentTrackingState {
    * them.
    */
   listedSkillNames: Set<string>;
+  /**
+   * Workspace-instruction and memory-index texts at the head of the prompt,
+   * frozen for the session so the cached prefix holds (prompts/instruction-head.ts).
+   */
+  instructionHead?: { readonly workspaceText: string; readonly memoryText: string };
+  /** The latest version of those texts the model has been told about. */
+  instructionAnnounced?: { readonly workspaceText: string; readonly memoryText: string };
+  /** A change waiting to be delivered by the instruction_update producer. */
+  pendingInstructionUpdate?: { readonly workspaceText?: string; readonly memoryText?: string };
 }
 
 const sessionAttachmentState = new WeakMap<object, AttachmentTrackingState>();
@@ -228,6 +237,11 @@ export function resetRelevantMemoryBudget(sessionKey: object): void {
   if (state === undefined) return;
   state.surfacedRelevantMemoryBytes = 0;
   state.surfacedRelevantMemoryPaths.clear();
+  // The compacted history is new bytes anyway: start the instruction head
+  // from the current files instead of carrying a stale snapshot forward.
+  state.instructionHead = undefined;
+  state.instructionAnnounced = undefined;
+  state.pendingInstructionUpdate = undefined;
 }
 
 /** Clears all tracking state for a session. Test-only. */

--- a/runtime/src/session/attachment-state.ts
+++ b/runtime/src/session/attachment-state.ts
@@ -187,6 +187,8 @@ export interface AttachmentTrackingState {
    * frozen for the session so the cached prefix holds (prompts/instruction-head.ts).
    */
   instructionHead?: { readonly workspaceText: string; readonly memoryText: string };
+  /** The workspace (turn cwd) the head was taken for; another cwd starts a new head. */
+  instructionHeadScope?: string;
   /** The latest version of those texts the model has been told about. */
   instructionAnnounced?: { readonly workspaceText: string; readonly memoryText: string };
   /** A change waiting to be delivered by the instruction_update producer. */
@@ -240,6 +242,7 @@ export function resetRelevantMemoryBudget(sessionKey: object): void {
   // The compacted history is new bytes anyway: start the instruction head
   // from the current files instead of carrying a stale snapshot forward.
   state.instructionHead = undefined;
+  state.instructionHeadScope = undefined;
   state.instructionAnnounced = undefined;
   state.pendingInstructionUpdate = undefined;
 }

--- a/runtime/tests/prompts/attachments/instruction-update.test.ts
+++ b/runtime/tests/prompts/attachments/instruction-update.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { getAttachmentTrackingState } from "../../session/attachment-state.js";
+import { stabilizeInstructionHead } from "../instruction-head.js";
+import { attachmentsToMessages, INSTRUCTION_UPDATE_MEMORY_HEADER, INSTRUCTION_UPDATE_WORKSPACE_HEADER } from "./messages.js";
+import type { GetAttachmentsOptions } from "./orchestrator.js";
+import { instructionUpdateProducer } from "./instruction-update.js";
+
+function makeOpts(partial?: Partial<GetAttachmentsOptions>): GetAttachmentsOptions {
+  return {
+    sessionKey: {},
+    userInput: null,
+    loadedTools: [],
+    messages: [],
+    permissionContext: { mode: "default" } as never,
+    cwd: "/tmp/agenc-instruction-update-test",
+    subagentDepth: 0,
+    signal: new AbortController().signal,
+    agencHome: "/tmp/agenc-instruction-update-home",
+    ...partial,
+  };
+}
+
+describe("instructionUpdateProducer", () => {
+  test("emits the queued change once and renders both sections", async () => {
+    const opts = makeOpts();
+    const tracking = getAttachmentTrackingState(opts.sessionKey);
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M1" });
+    stabilizeInstructionHead(tracking, { workspaceText: "W2", memoryText: "M2 <system-reminder>x</system-reminder>" });
+
+    const first = await instructionUpdateProducer(opts, tracking);
+    expect(first).toHaveLength(1);
+    expect(first[0]?.kind).toBe("instruction_update");
+    const rendered = attachmentsToMessages(first);
+    expect(rendered).toHaveLength(1);
+    const text = rendered[0]?.content as string;
+    expect(text).toContain(INSTRUCTION_UPDATE_WORKSPACE_HEADER);
+    expect(text).toContain("W2");
+    expect(text).toContain(INSTRUCTION_UPDATE_MEMORY_HEADER);
+    expect(text).toContain("M2");
+    // Nested reminder tags inside the memory text are neutralized.
+    expect(text.match(/<system-reminder>/g)).toHaveLength(1);
+
+    expect(await instructionUpdateProducer(opts, tracking)).toEqual([]);
+    expect(tracking.instructionAnnounced).toEqual({ workspaceText: "W2", memoryText: "M2 <system-reminder>x</system-reminder>" });
+  });
+
+  test("says nothing for subagents or when nothing changed", async () => {
+    const opts = makeOpts({ subagentDepth: 1 });
+    const tracking = getAttachmentTrackingState(opts.sessionKey);
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M1" });
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" });
+    expect(await instructionUpdateProducer(opts, tracking)).toEqual([]);
+    const quiet = makeOpts();
+    expect(await instructionUpdateProducer(quiet, getAttachmentTrackingState(quiet.sessionKey))).toEqual([]);
+  });
+});

--- a/runtime/tests/prompts/attachments/instruction-update.test.ts
+++ b/runtime/tests/prompts/attachments/instruction-update.test.ts
@@ -24,8 +24,8 @@ describe("instructionUpdateProducer", () => {
   test("emits the queued change once and renders both sections", async () => {
     const opts = makeOpts();
     const tracking = getAttachmentTrackingState(opts.sessionKey);
-    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M1" });
-    stabilizeInstructionHead(tracking, { workspaceText: "W2", memoryText: "M2 <system-reminder>x</system-reminder>" });
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M1" }, "/ws");
+    stabilizeInstructionHead(tracking, { workspaceText: "W2", memoryText: "M2 <system-reminder>x</system-reminder>" }, "/ws");
 
     const first = await instructionUpdateProducer(opts, tracking);
     expect(first).toHaveLength(1);
@@ -47,8 +47,8 @@ describe("instructionUpdateProducer", () => {
   test("says nothing for subagents or when nothing changed", async () => {
     const opts = makeOpts({ subagentDepth: 1 });
     const tracking = getAttachmentTrackingState(opts.sessionKey);
-    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M1" });
-    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" });
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M1" }, "/ws");
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" }, "/ws");
     expect(await instructionUpdateProducer(opts, tracking)).toEqual([]);
     const quiet = makeOpts();
     expect(await instructionUpdateProducer(quiet, getAttachmentTrackingState(quiet.sessionKey))).toEqual([]);

--- a/runtime/tests/prompts/attachments/orchestrator.test.ts
+++ b/runtime/tests/prompts/attachments/orchestrator.test.ts
@@ -44,6 +44,7 @@ describe("attachments orchestrator", () => {
       "agentListingDeltaProducer",
       "mcpInstructionsDeltaProducer",
       "dateChangeProducer",
+      "instructionUpdateProducer",
       "criticalReminderProducer",
       "outputStyleProducer",
       "relevantMemoriesProducer",

--- a/runtime/tests/prompts/instruction-head.test.ts
+++ b/runtime/tests/prompts/instruction-head.test.ts
@@ -14,45 +14,54 @@ const v1 = { workspaceText: "W1", memoryText: "M1" };
 describe("instruction head snapshot", () => {
   it("keeps the first version at the head and queues later changes once", () => {
     const tracking = getAttachmentTrackingState({});
-    expect(stabilizeInstructionHead(tracking, v1)).toEqual(v1);
+    expect(stabilizeInstructionHead(tracking, v1, "/ws")).toEqual(v1);
     expect(tracking.pendingInstructionUpdate).toBeUndefined();
 
     // Same content again: nothing to say.
-    expect(stabilizeInstructionHead(tracking, { ...v1 })).toEqual(v1);
+    expect(stabilizeInstructionHead(tracking, { ...v1 }, "/ws")).toEqual(v1);
     expect(tracking.pendingInstructionUpdate).toBeUndefined();
 
     // Memory changed: the head stays, the change is queued.
-    expect(stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" })).toEqual(v1);
+    expect(stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" }, "/ws")).toEqual(v1);
     expect(tracking.pendingInstructionUpdate).toEqual({ memoryText: "M2" });
 
     // The producer takes it once; the same files next turn say nothing new.
     expect(takeInstructionHeadUpdate(tracking)).toEqual({ memoryText: "M2" });
     expect(takeInstructionHeadUpdate(tracking)).toBeUndefined();
-    expect(stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" })).toEqual(v1);
+    expect(stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" }, "/ws")).toEqual(v1);
     expect(tracking.pendingInstructionUpdate).toBeUndefined();
 
     // A further change is measured against what was announced, not the head.
-    stabilizeInstructionHead(tracking, { workspaceText: "W2", memoryText: "M2" });
+    stabilizeInstructionHead(tracking, { workspaceText: "W2", memoryText: "M2" }, "/ws");
     expect(tracking.pendingInstructionUpdate).toEqual({ workspaceText: "W2" });
   });
 
   it("drops a queued change that reverted before it was delivered", () => {
     const tracking = getAttachmentTrackingState({});
-    stabilizeInstructionHead(tracking, v1);
-    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" });
+    stabilizeInstructionHead(tracking, v1, "/ws");
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" }, "/ws");
     expect(tracking.pendingInstructionUpdate).toEqual({ memoryText: "M2" });
-    stabilizeInstructionHead(tracking, v1);
+    stabilizeInstructionHead(tracking, v1, "/ws");
     expect(tracking.pendingInstructionUpdate).toBeUndefined();
+  });
+
+  it("starts a new head for a turn in another workspace instead of announcing a diff", () => {
+    const tracking = getAttachmentTrackingState({});
+    stabilizeInstructionHead(tracking, v1, "/ws-a");
+    const other = { workspaceText: "WB", memoryText: "MB" };
+    expect(stabilizeInstructionHead(tracking, other, "/ws-b")).toEqual(other);
+    expect(tracking.pendingInstructionUpdate).toBeUndefined();
+    expect(tracking.instructionHeadScope).toBe("/ws-b");
   });
 
   it("starts a new head after compaction reset", () => {
     const key = {};
     const tracking = getAttachmentTrackingState(key);
-    stabilizeInstructionHead(tracking, v1);
+    stabilizeInstructionHead(tracking, v1, "/ws");
     resetRelevantMemoryBudget(key);
     expect(tracking.instructionHead).toBeUndefined();
     const v2 = { workspaceText: "W2", memoryText: "M2" };
-    expect(stabilizeInstructionHead(tracking, v2)).toEqual(v2);
+    expect(stabilizeInstructionHead(tracking, v2, "/ws")).toEqual(v2);
     expect(tracking.pendingInstructionUpdate).toBeUndefined();
     resetInstructionHead(tracking);
     expect(tracking.instructionAnnounced).toBeUndefined();

--- a/runtime/tests/prompts/instruction-head.test.ts
+++ b/runtime/tests/prompts/instruction-head.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  resetRelevantMemoryBudget,
+  getAttachmentTrackingState,
+} from "../../src/session/attachment-state.js";
+import {
+  resetInstructionHead,
+  stabilizeInstructionHead,
+  takeInstructionHeadUpdate,
+} from "../../src/prompts/instruction-head.js";
+
+const v1 = { workspaceText: "W1", memoryText: "M1" };
+
+describe("instruction head snapshot", () => {
+  it("keeps the first version at the head and queues later changes once", () => {
+    const tracking = getAttachmentTrackingState({});
+    expect(stabilizeInstructionHead(tracking, v1)).toEqual(v1);
+    expect(tracking.pendingInstructionUpdate).toBeUndefined();
+
+    // Same content again: nothing to say.
+    expect(stabilizeInstructionHead(tracking, { ...v1 })).toEqual(v1);
+    expect(tracking.pendingInstructionUpdate).toBeUndefined();
+
+    // Memory changed: the head stays, the change is queued.
+    expect(stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" })).toEqual(v1);
+    expect(tracking.pendingInstructionUpdate).toEqual({ memoryText: "M2" });
+
+    // The producer takes it once; the same files next turn say nothing new.
+    expect(takeInstructionHeadUpdate(tracking)).toEqual({ memoryText: "M2" });
+    expect(takeInstructionHeadUpdate(tracking)).toBeUndefined();
+    expect(stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" })).toEqual(v1);
+    expect(tracking.pendingInstructionUpdate).toBeUndefined();
+
+    // A further change is measured against what was announced, not the head.
+    stabilizeInstructionHead(tracking, { workspaceText: "W2", memoryText: "M2" });
+    expect(tracking.pendingInstructionUpdate).toEqual({ workspaceText: "W2" });
+  });
+
+  it("drops a queued change that reverted before it was delivered", () => {
+    const tracking = getAttachmentTrackingState({});
+    stabilizeInstructionHead(tracking, v1);
+    stabilizeInstructionHead(tracking, { workspaceText: "W1", memoryText: "M2" });
+    expect(tracking.pendingInstructionUpdate).toEqual({ memoryText: "M2" });
+    stabilizeInstructionHead(tracking, v1);
+    expect(tracking.pendingInstructionUpdate).toBeUndefined();
+  });
+
+  it("starts a new head after compaction reset", () => {
+    const key = {};
+    const tracking = getAttachmentTrackingState(key);
+    stabilizeInstructionHead(tracking, v1);
+    resetRelevantMemoryBudget(key);
+    expect(tracking.instructionHead).toBeUndefined();
+    const v2 = { workspaceText: "W2", memoryText: "M2" };
+    expect(stabilizeInstructionHead(tracking, v2)).toEqual(v2);
+    expect(tracking.pendingInstructionUpdate).toBeUndefined();
+    resetInstructionHead(tracking);
+    expect(tracking.instructionAnnounced).toBeUndefined();
+  });
+});

--- a/runtime/tests/prompts/live-instructions-memory.test.ts
+++ b/runtime/tests/prompts/live-instructions-memory.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../memory/paths.js";
 import { clearTieredInstructionsCacheForTesting } from "./agenc-md.js";
 import { resolveLiveInstructionEnvelope } from "./live-instructions.js";
+import { getAttachmentTrackingState, resetRelevantMemoryBudget } from "../session/attachment-state.js";
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
 import {
@@ -76,11 +77,7 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
 
-function resolveEnvelope() {
-  const session = {
-    services: { configStore: store },
-    setProjectMemoryWarnings: vi.fn(),
-  } as unknown as Session;
+function resolveEnvelope(session: Session = makeSession()) {
   return runWithCanonicalSettingsAuthority(store, () =>
     resolveLiveInstructionEnvelope({
       session,
@@ -88,6 +85,13 @@ function resolveEnvelope() {
       baseInstructions: "BASE INSTRUCTIONS",
     }),
   );
+}
+
+function makeSession(): Session {
+  return {
+    services: { configStore: store },
+    setProjectMemoryWarnings: vi.fn(),
+  } as unknown as Session;
 }
 
 async function writeEntrypoints(global: string | null, projectIndex: string | null) {
@@ -168,6 +172,28 @@ describe("live instructions memory indexes", () => {
 
     expect(envelope.memoryText).toContain(`token=${REDACTED_SECRET}`);
     expect(envelope.memoryText).not.toContain(token);
+  });
+
+  it("keeps the session-start head when the memory index changes and queues the new version", async () => {
+    installAuthority();
+    await writeEntrypoints(null, "- [Release cadence](release.md): ships on Thursdays\n");
+    const session = makeSession();
+    const first = await resolveEnvelope(session);
+    expect(first.text).toContain("ships on Thursdays");
+
+    // The extraction child appended a line between turns.
+    await writeEntrypoints(null, "- [Release cadence](release.md): ships on Thursdays\n- [Style](style.md): two-space indent\n");
+    const second = await resolveEnvelope(session);
+    expect(second.text).toBe(first.text);
+    const tracking = getAttachmentTrackingState(session);
+    expect(tracking.pendingInstructionUpdate?.memoryText).toContain("two-space indent");
+    expect(tracking.pendingInstructionUpdate?.workspaceText).toBeUndefined();
+
+    // After compaction the head restarts from the current files.
+    resetRelevantMemoryBudget(session);
+    const third = await resolveEnvelope(session);
+    expect(third.text).toContain("two-space indent");
+    expect(getAttachmentTrackingState(session).pendingInstructionUpdate).toBeUndefined();
   });
 
   it("adds nothing when no index exists", async () => {

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -8,6 +8,7 @@
  * `process_killed` abort for every clean turn.
  */
 
+import { INSTRUCTION_UPDATE_WORKSPACE_HEADER } from "../../src/prompts/attachments/messages.js";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   chmodSync,
@@ -4083,7 +4084,7 @@ describe("runTurn — live sampling request contract", () => {
     expect(seenOptions?.skipCacheWrite).toBe(true);
   });
 
-  test("resolves on-disk workspace instructions for every turn and sends each source exactly once", async () => {
+  test("keeps the workspace instruction head stable across turns and delivers a change as an update reminder", async () => {
     const repo = mkdtempSync(join(tmpdir(), "agenc-live-instructions-"));
     const sentinel = "PROJECT_SENTINEL_7a8e";
     const updated = "PROJECT_SENTINEL_UPDATED_4f2c";
@@ -4131,13 +4132,30 @@ describe("runTurn — live sampling request contract", () => {
       expect(
         requests[0]!.systemPrompt.match(/BASE_SENTINEL_8c1d/g),
       ).toHaveLength(1);
-      expect(requests[1]!.systemPrompt).not.toContain(sentinel);
+      // The head keeps the session-start version so the provider's cached
+      // prefix holds; the changed file reaches the model as an update
+      // reminder in the same request (prompts/instruction-head.ts).
       expect(
-        requests[1]!.systemPrompt.match(new RegExp(updated, "g")),
+        requests[1]!.systemPrompt.match(new RegExp(sentinel, "g")),
       ).toHaveLength(1);
+      expect(requests[1]!.systemPrompt).not.toContain(updated);
       expect(
         requests[1]!.systemPrompt.match(/BASE_SENTINEL_8c1d/g),
       ).toHaveLength(1);
+      const updateReminders = requests[1]!.messages.filter(
+        (message) =>
+          typeof message.content === "string" &&
+          message.content.includes(INSTRUCTION_UPDATE_WORKSPACE_HEADER) &&
+          message.content.includes(updated),
+      );
+      expect(updateReminders).toHaveLength(1);
+      expect(
+        requests[0]!.messages.some(
+          (message) =>
+            typeof message.content === "string" &&
+            message.content.includes(INSTRUCTION_UPDATE_WORKSPACE_HEADER),
+        ),
+      ).toBe(false);
       const turnContexts = events.flatMap((event) =>
         event.msg.type === "turn_context" ? [event.msg.payload] : [],
       );


### PR DESCRIPTION
## Why

After #2147 the remaining prompt-cache misses in the 15-step session had one main cause left: the workspace instructions (AGENC.md tiers) and the persistent memory indexes (MEMORY.md) open the system prompt, ahead of the trusted base prompt so they can never shadow it, and they were re-read every turn. The memory extraction child rewrites MEMORY.md every third eligible turn, so at the next turn the first bytes of the prompt had changed and the provider's cache missed from byte zero: turn 6 of the retention-build session opened at 0 cached of 46k tokens right after an extraction run, and turn 1 of the earlier baseline showed the same after the first memory write.

## What changed

- `runtime/src/prompts/instruction-head.ts` (new): `stabilizeInstructionHead` returns the session's first version of both blocks for the head and queues a change against the version the model was last told about; `takeInstructionHeadUpdate` hands the queued change to the producer once and marks it announced; `resetInstructionHead` forgets the snapshot.
- `runtime/src/prompts/live-instructions.ts`: `resolveLiveInstructionEnvelope` runs the fresh texts through the snapshot and assembles `text` from the head version; ordering is unchanged (workspace, memory, then the trusted base prompt last).
- The head is scoped to the turn's workspace (`resolve(ctx.cwd)`): a turn in another workspace starts a new head for that workspace instead of announcing a diff, so a session that moves between projects still gets each project's own instructions at the head (the `pins instruction resolution to each turn workspace` contract).
- `runtime/src/session/attachment-state.ts`: `instructionHead`, `instructionAnnounced`, `pendingInstructionUpdate` on the per-session tracking state; `resetRelevantMemoryBudget` (called when compaction replaces the history) also resets the head, so after compaction, whose bytes are new anyway, the head restarts from the current files.
- `runtime/src/prompts/attachments/instruction-update.ts` (new producer, registered after `dateChangeProducer`): emits the queued change as an `instruction_update` attachment; nothing for subagents.
- `runtime/src/prompts/attachments/types.ts`, `messages.ts`: the attachment kind and its rendering, one section per changed block with a sentence saying it replaces the version at the start of the prompt; content goes through the system-reminder sanitizer.

The attachment lands near the end of the prompt and the ledger from #2147 keeps it in place, so a memory write now costs one small appended reminder instead of re-billing the whole prompt.

## Tests

- `tests/prompts/instruction-head.test.ts` (new, 4): a turn in another workspace starts a new head without a queued diff; first version kept at the head; a change queued once and measured against what was announced; a reverted change dropped; compaction reset restarts the head.
- `tests/prompts/attachments/instruction-update.test.ts` (new, 2): the producer emits once, renders both sections with nested reminder tags neutralized, marks the content announced; nothing for subagents or when nothing changed.
- `tests/prompts/live-instructions-memory.test.ts` (+1): two resolutions on one session with a MEMORY.md line added in between produce identical text, queue the new line, and after `resetRelevantMemoryBudget` the text carries it.
- `tests/prompts/attachments/orchestrator.test.ts`: the explicit producer list gains the new producer.
- `tests/session/run-turn.test.ts`: the "resolves on-disk workspace instructions for every turn" case now states the new contract, a stable head plus one update reminder carrying the changed file; the cross-workspace case is unchanged and passes.
- Hermetic runner: `tests/prompts/attachments` (all), `tests/prompts/instruction-head.test.ts`, `tests/prompts/live-instructions-memory.test.ts`, `tests/session/attachment-state.test.ts`, `tests/managed-prompt-hermetic.test.ts`: 242 passed, 1 pre-existing macOS failure (`caps additional-directory instructions without cross-root source attribution` creates a Windows-style spelling alias with `symlink`, which a case-insensitive filesystem rejects with EEXIST; identical on the unchanged checkout). `tsc --noEmit`: clean apart from the local TS2883 lines.

## Not changed

- The authority order of the head (workspace, memory, base prompt last) and the untrusted framing of both blocks.
- Editor interactions: the producer does not run for them (ordinary producer set), so an editor request never consumes a queued update meant for the conversation.
- The trailing dynamic suffix and the retention ledger.

## Counterparts

#2147 (attachment retention), #2143 (extraction cadence), #2139 (the eval that measures the cache per call).
