### PR TITLE
runtime: microcompact clears tool results in pressure batches with stable labels

### DIFF
--- a/runtime/src/services/compact/microCompact.ts
+++ b/runtime/src/services/compact/microCompact.ts
@@ -16,6 +16,10 @@ import { isRecord } from "../../utils/record.js";
 
 const MICROCOMPACT_MIN_CHARS = 6_000;
 const MICROCOMPACT_KEEP_RECENT = 5;
+/** Live compactable tool output (characters) a history may hold before the oldest results are cleared. */
+const MICROCOMPACT_PRESSURE_CHARS = 120_000;
+/** Share of the context window (at 4 characters per token) that caps that limit for small models. */
+const MICROCOMPACT_PRESSURE_WINDOW_SHARE = 0.25;
 const TOOL_RESULT_CLEARED_MESSAGE = "[Old tool result content cleared]";
 const MCP_TOOL_PREFIX = "mcp__";
 // Tool names MUST match the names the LIVE tool registry registers, not the
@@ -51,6 +55,79 @@ const PATH_BEARING_READ_TOOLS = new Set(["FileRead", "Read"]);
 
 let microcompactSequence = 0;
 
+function standaloneKey(message: RuntimeMessage, index: number): string {
+  return message.toolCallId ?? `msg:${index}`;
+}
+
+interface CompactableResultPosition {
+  readonly toolUseId: string;
+  /** Length of the result text as the model would see it. */
+  readonly chars: number;
+  /** Inside the time-based clear window: never a victim. */
+  readonly recent: boolean;
+}
+
+function pressureLimitChars(contextWindowTokens: number | undefined): number {
+  if (
+    contextWindowTokens === undefined ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return MICROCOMPACT_PRESSURE_CHARS;
+  }
+  const windowShare = Math.floor(contextWindowTokens * 4 * MICROCOMPACT_PRESSURE_WINDOW_SHARE);
+  return Math.min(MICROCOMPACT_PRESSURE_CHARS, Math.max(MICROCOMPACT_MIN_CHARS * 2, windowShare));
+}
+
+/**
+ * Which compactable results are cleared, replayed over the append-only
+ * history so every projection of one history agrees byte for byte. Results
+ * accumulate until their live text exceeds the pressure limit; the valve then
+ * clears the oldest clearable ones down to half the limit, never the most
+ * recent ones, never the latest read of a path, never a result inside the
+ * time window. Between two firings nothing moves, so the provider's cached
+ * prefix breaks once per batch instead of once per call, which is what a
+ * recent-N window sliding with every tool result did (measured as mid-turn
+ * cache misses of the whole tail).
+ */
+function decideClearedResults(
+  positions: readonly CompactableResultPosition[],
+  readPathByToolUseId: ReadonlyMap<string, string>,
+  limitChars: number,
+): Set<string> {
+  const cleared = new Set<string>();
+  const live: CompactableResultPosition[] = [];
+  const latestReadByPath = new Map<string, string>();
+  const target = Math.floor(limitChars / 2);
+  let liveChars = 0;
+  for (const position of positions) {
+    const path = readPathByToolUseId.get(position.toolUseId);
+    if (path !== undefined) latestReadByPath.set(path, position.toolUseId);
+    if (position.chars < MICROCOMPACT_MIN_CHARS) continue;
+    live.push(position);
+    liveChars += position.chars;
+    if (liveChars <= limitChars) continue;
+    for (
+      let index = 0;
+      index < live.length - MICROCOMPACT_KEEP_RECENT && liveChars > target;
+
+    ) {
+      const victim = live[index]!;
+      const victimPath = readPathByToolUseId.get(victim.toolUseId);
+      const isLatestReadOfPath =
+        victimPath !== undefined && latestReadByPath.get(victimPath) === victim.toolUseId;
+      if (victim.recent || isLatestReadOfPath) {
+        index += 1;
+        continue;
+      }
+      cleared.add(victim.toolUseId);
+      liveChars -= victim.chars;
+      live.splice(index, 1);
+    }
+  }
+  return cleared;
+}
+
 export async function microcompactMessages(
   messages: RuntimeMessage[],
   context?: CompactContext,
@@ -63,41 +140,35 @@ export async function microcompactMessages(
 }> {
   const compactableIds = collectCompactableToolUseIds(messages);
   const readPathByToolUseId = collectReadFilePaths(messages);
-  const compactableResultPositions = collectCompactableToolResultPositions(
-    messages,
-    compactableIds,
-  );
-  const keepIds = new Set(
-    compactableResultPositions
-      .slice(-MICROCOMPACT_KEEP_RECENT)
-      .map((position) => position.toolUseId),
-  );
-  // Path-aware retention: always preserve the most-recently-read result for
-  // each distinct file path the agent has read. Without this, the active
-  // working file is evicted by the flat recent-N window and the agent
-  // re-reads it on the next turn (context-retention thrash).
-  for (
-    const toolUseId of latestReadResultPerPath(
-      compactableResultPositions,
-      readPathByToolUseId,
-    )
-  ) {
-    keepIds.add(toolUseId);
-  }
   const clearAfterMs = getTimeBasedMicrocompactClearAfterMs();
   const now = Date.now();
+  const positions = collectCompactableToolResultPositions(
+    messages,
+    compactableIds,
+    now,
+    clearAfterMs,
+  );
   const apiContextManagement = getAPIContextManagement(
     context?.options?.apiMicrocompact,
   );
+  // Stable labels: a cleared result is named by its position among the
+  // compactable results, which the append-only history never changes, instead
+  // of by a process counter that renumbered it on every re-projection.
+  const positionByToolUseId = new Map<string, number>(
+    positions.map((position, index) => [position.toolUseId, index + 1]),
+  );
+  const clearedIds = decideClearedResults(
+    positions,
+    readPathByToolUseId,
+    pressureLimitChars(context?.options?.contextWindowTokens),
+  );
+
   return {
-    messages: messages.map((message) => {
-      const rewrittenBlocks = isWithinTimeWindow(message, now, clearAfterMs)
-        ? undefined
-        : microcompactContentBlocks(
-          message.message?.content ?? message.content,
-          compactableIds,
-          keepIds,
-        );
+    messages: messages.map((message, index) => {
+      const rewrittenBlocks = microcompactContentBlocks(
+        message.message?.content ?? message.content,
+        clearedIds,
+      );
       if (rewrittenBlocks !== undefined) {
         return {
           ...message,
@@ -109,32 +180,16 @@ export async function microcompactMessages(
           isMeta: true,
         };
       }
+      const key = standaloneKey(message, index);
+      if (!clearedIds.has(key)) return message;
       const text = messageText(message);
-      // gaphunt3 #3: mirror the content-block branch's compactable-tool gate
-      // on the standalone tool-message branch. The live pipeline stores tool
-      // results as standalone role:"tool" messages, so without this gate every
-      // large result was cleared regardless of the COMPACTABLE_TOOLS allowlist,
-      // discarding results from non-compactable tools (Task/agent/custom tools).
-      const isNonCompactableTool =
-        message.toolName !== undefined && !isCompactableTool(message.toolName);
-      const isExcludedById =
-        message.toolCallId !== undefined &&
-        compactableIds.size > 0 &&
-        !compactableIds.has(message.toolCallId) &&
-        !(message.toolName !== undefined && isCompactableTool(message.toolName));
-      if (
-        text.length < MICROCOMPACT_MIN_CHARS ||
-        !isToolLikeMessage(message) ||
-        isNonCompactableTool ||
-        isExcludedById ||
-        (message.toolCallId !== undefined && keepIds.has(message.toolCallId)) ||
-        isWithinTimeWindow(message, now, clearAfterMs)
-      ) {
-        return message;
-      }
       microcompactSequence += 1;
+      const label =
+        (message.toolCallId !== undefined
+          ? positionByToolUseId.get(message.toolCallId)
+          : undefined) ?? index + 1;
       const content =
-        `[microcompact:${microcompactSequence}] Older tool output compressed; original length ${text.length.toLocaleString()} characters.`;
+        `[microcompact:${label}] Older tool output compressed; original length ${text.length.toLocaleString()} characters.`;
       return {
         ...message,
         content,
@@ -238,37 +293,22 @@ function readFilePathFromInput(input: unknown): string | undefined {
     : undefined;
 }
 
-/**
- * For each distinct file path, return the tool_use id of its last (most
- * recent) result position so that the active working file is never evicted.
- */
-function latestReadResultPerPath(
-  resultPositions: ReadonlyArray<{ readonly toolUseId: string }>,
-  readPathByToolUseId: ReadonlyMap<string, string>,
-): Set<string> {
-  const latestByPath = new Map<string, string>();
-  for (const position of resultPositions) {
-    const filePath = readPathByToolUseId.get(position.toolUseId);
-    if (filePath === undefined) continue;
-    latestByPath.set(filePath, position.toolUseId);
-  }
-  return new Set(latestByPath.values());
-}
 
 function collectCompactableToolResultPositions(
   messages: readonly RuntimeMessage[],
   compactableIds: ReadonlySet<string>,
-): Array<{ readonly toolUseId: string }> {
-  const positions: Array<{ readonly toolUseId: string }> = [];
+  now: number,
+  clearAfterMs: number,
+): CompactableResultPosition[] {
+  const positions: CompactableResultPosition[] = [];
   for (const message of messages) {
-    if (
-      (message.role === "tool" || message.originalRole === "tool") &&
-      message.toolCallId !== undefined &&
-      (compactableIds.size === 0 ||
-        compactableIds.has(message.toolCallId) ||
-        (message.toolName !== undefined && isCompactableTool(message.toolName)))
-    ) {
-      positions.push({ toolUseId: message.toolCallId });
+    const recent = isWithinTimeWindow(message, now, clearAfterMs);
+    if (isStandaloneCompactableResult(message, compactableIds)) {
+      positions.push({
+        toolUseId: message.toolCallId!,
+        chars: messageText(message).length,
+        recent,
+      });
       continue;
     }
     for (const block of asContentBlocks(message.message?.content ?? message.content)) {
@@ -276,17 +316,36 @@ function collectCompactableToolResultPositions(
         continue;
       }
       if (compactableIds.size === 0 || compactableIds.has(block.tool_use_id)) {
-        positions.push({ toolUseId: block.tool_use_id });
+        positions.push({
+          toolUseId: block.tool_use_id,
+          chars: stringifyContent(block.content ?? "").length,
+          recent,
+        });
       }
     }
   }
   return positions;
 }
 
+/**
+ * The live pipeline stores tool results as standalone role:"tool" messages.
+ * They count only when the tool is compactable (gaphunt3 #3: results of
+ * Task/agent/custom tools are never cleared), by allowlisted name or by the
+ * id the assistant's tool_use gave them.
+ */
+function isStandaloneCompactableResult(
+  message: RuntimeMessage,
+  compactableIds: ReadonlySet<string>,
+): boolean {
+  if (message.role !== "tool" && message.originalRole !== "tool") return false;
+  if (message.toolCallId === undefined || !isToolLikeMessage(message)) return false;
+  if (message.toolName !== undefined) return isCompactableTool(message.toolName);
+  return compactableIds.size === 0 || compactableIds.has(message.toolCallId);
+}
+
 function microcompactContentBlocks(
   content: unknown,
-  compactableIds: ReadonlySet<string>,
-  keepIds: ReadonlySet<string>,
+  clearedIds: ReadonlySet<string>,
 ): unknown[] | undefined {
   const blocks = asContentBlocks(content);
   if (blocks.length === 0) return undefined;
@@ -295,12 +354,7 @@ function microcompactContentBlocks(
     if (block.type !== "tool_result" || typeof block.tool_use_id !== "string") {
       return block;
     }
-    if (keepIds.has(block.tool_use_id)) return block;
-    if (compactableIds.size > 0 && !compactableIds.has(block.tool_use_id)) {
-      return block;
-    }
-    const text = stringifyContent(block.content ?? "");
-    if (text.length < MICROCOMPACT_MIN_CHARS) return block;
+    if (!clearedIds.has(block.tool_use_id)) return block;
     touched = true;
     return {
       ...block,

--- a/runtime/tests/gaphunt3/compaction.test.ts
+++ b/runtime/tests/gaphunt3/compaction.test.ts
@@ -53,9 +53,9 @@ describe("gaphunt3 #3 — microcompact standalone branch honors COMPACTABLE_TOOL
     // Confirms the gate does not over-protect: an old, large, COMPACTABLE
     // result outside the recent window is still compressed.
     const messages: RuntimeMessage[] = [
-      standaloneToolResult("old-read", "FileRead", "y".repeat(8_000)),
+      standaloneToolResult("old-read", "FileRead", "y".repeat(25_000)),
       ...Array.from({ length: 6 }, (_, index) =>
-        standaloneToolResult(`recent-${index}`, "FileRead", "z".repeat(7_000))),
+        standaloneToolResult(`recent-${index}`, "FileRead", "z".repeat(25_000))),
     ];
 
     const result = await microcompactMessages(messages);

--- a/runtime/tests/runtime-session.compact-contract.test.ts
+++ b/runtime/tests/runtime-session.compact-contract.test.ts
@@ -150,7 +150,7 @@ describe("runtime session compact contract", () => {
 
   test("preflight microcompact compresses older compactable tool results while preserving recent ones", async () => {
     process.env.AGENC_DISABLE_AUTO_COMPACT = "1";
-    const history = Array.from({ length: 7 }, (_, index) => longToolExchange(index))
+    const history = Array.from({ length: 20 }, (_, index) => longToolExchange(index))
       .flat();
     const seen: LLMMessage[][] = [];
     const provider = mkProvider(
@@ -171,7 +171,7 @@ describe("runtime session compact contract", () => {
     const toolMessages = (seen[0] ?? []).filter(
       (message) => message.role === "tool",
     );
-    expect(toolMessages).toHaveLength(7);
+    expect(toolMessages).toHaveLength(20);
     expect(toolMessages[0]?.content).toContain(
       "Older tool output compressed",
     );

--- a/runtime/tests/services/compact/microCompact.memory-bound-naming.test.ts
+++ b/runtime/tests/services/compact/microCompact.memory-bound-naming.test.ts
@@ -127,7 +127,7 @@ describe("micro compact — memory-bound-naming (live tool names)", () => {
           })),
         ),
         ...Array.from({ length: 6 }, (_, index) =>
-          toolResult(`other-${index + 1}`, "y".repeat(6_500))),
+          toolResult(`other-${index + 1}`, "y".repeat(25_000))),
       ];
 
       const result = await microcompactMessages(messages);

--- a/runtime/tests/services/compact/microCompact.test.ts
+++ b/runtime/tests/services/compact/microCompact.test.ts
@@ -20,19 +20,61 @@ describe("micro compact", () => {
         })),
       ),
       ...Array.from({ length: 6 }, (_, index) =>
-        toolResult(`tool-${index + 1}`, "x".repeat(6_500))),
+        toolResult(`tool-${index + 1}`, "x".repeat(25_000))),
     ];
 
     const result = await microcompactMessages(messages);
     const contents = result.messages.slice(1).map((entry) => entry.content);
 
     expect(contents[0]).toBe(
-      "[microcompact:1] Older tool output compressed; original length 6,500 characters.",
+      "[microcompact:1] Older tool output compressed; original length 25,000 characters.",
     );
     expect(contents.slice(1)).toHaveLength(5);
-    expect(contents.slice(1).every((content) => content === "x".repeat(6_500)))
+    expect(contents.slice(1).every((content) => content === "x".repeat(25_000)))
       .toBe(true);
     expect(getMicrocompactSequenceForTests()).toBe(1);
+  });
+
+  test("labels a cleared result by its position so two projections agree byte for byte", async () => {
+    const big = "x".repeat(16_000);
+    const history = [
+      assistantToolUse(
+        Array.from({ length: 8 }, (_, index) => ({ id: `tool-${index + 1}`, name: "Read" })),
+      ),
+      ...Array.from({ length: 8 }, (_, index) => toolResult(`tool-${index + 1}`, big)),
+    ];
+    // Two projections of the same history, no reset in between: a process
+    // counter would have numbered the second one 4, 5, 6.
+    const first = await microcompactMessages(history);
+    const second = await microcompactMessages(history);
+    expect(first.messages[1]?.content).toMatch(/^\[microcompact:1\] Older tool output compressed/);
+    expect(first.messages[3]?.content).toMatch(/^\[microcompact:3\]/);
+    expect(second.messages).toEqual(first.messages);
+  });
+
+  test("clears the oldest results in batches under pressure and holds the projection between firings", async () => {
+    const big = "x".repeat(16_000);
+    const history = (count: number) => [
+      assistantToolUse(
+        Array.from({ length: count }, (_, index) => ({ id: `tool-${index + 1}`, name: "Read" })),
+      ),
+      ...Array.from({ length: count }, (_, index) => toolResult(`tool-${index + 1}`, big)),
+    ];
+    const results = (projected: { messages: RuntimeMessage[] }) => projected.messages.slice(1);
+
+    // 7 results, 112k characters: under the limit, nothing is cleared.
+    const below = await microcompactMessages(history(7));
+    expect(results(below).every((message) => message.content === big)).toBe(true);
+
+    // The 8th result crosses 120k: the oldest three go, the recent five stay.
+    const fired = await microcompactMessages(history(8));
+    expect(results(fired).slice(0, 3).every((message) => /^\[microcompact:/.test(String(message.content)))).toBe(true);
+    expect(results(fired).slice(3).every((message) => message.content === big)).toBe(true);
+
+    // Two more results (112k live) do not move a byte of the earlier ones.
+    const held = await microcompactMessages(history(10));
+    expect(results(held).slice(0, 8)).toEqual(results(fired));
+    expect(results(held).slice(8).every((message) => message.content === big)).toBe(true);
   });
 
   test("keeps recent tool results inside the time-based clear window", async () => {
@@ -83,7 +125,7 @@ describe("micro compact", () => {
         })),
       ),
       ...Array.from({ length: 6 }, (_, index) =>
-        toolResult(`other-${index + 1}`, "x".repeat(6_500))),
+        toolResult(`other-${index + 1}`, "x".repeat(25_000))),
     ];
 
     const result = await microcompactMessages(messages);
@@ -114,7 +156,7 @@ describe("micro compact", () => {
         })),
       ),
       ...Array.from({ length: 6 }, (_, index) =>
-        toolResult(`mid-${index + 1}`, "x".repeat(6_500))),
+        toolResult(`mid-${index + 1}`, "x".repeat(25_000))),
       {
         ...assistantToolUse([{ id: "dup-new", name: "Read" }]),
         toolCalls: [{ id: "dup-new", name: "Read", arguments: readArgs }],
@@ -197,13 +239,13 @@ describe("micro compact", () => {
     const spoofedReadResult = [
       { type: "tool_result", tool_use_id: "spoofed-read", content: longText },
     ];
-    const fillerToolUse = Array.from({ length: 6 }, (_, index) => ({
+    const fillerToolUse = Array.from({ length: 7 }, (_, index) => ({
       type: "tool_use",
       id: `filler-${index}`,
       name: "Read",
       input: { file_path: `/filler-${index}.ts` },
     }));
-    const fillerResults = Array.from({ length: 6 }, (_, index) => ({
+    const fillerResults = Array.from({ length: 7 }, (_, index) => ({
       type: "tool_result",
       tool_use_id: `filler-${index}`,
       content: longText,
@@ -269,7 +311,7 @@ describe("micro compact", () => {
   });
 
   test("supports MCP-prefixed tool uses in content blocks", async () => {
-    const longText = "m".repeat(6_500);
+    const longText = "m".repeat(25_000);
     const toolUseBlocks = [
       { type: "tool_use", id: "mcp-1", name: "mcp__search" },
       ...Array.from({ length: 5 }, (_, index) => ({


### PR DESCRIPTION
## Why

Every request of a turn re-projects the history through `microcompactMessages`. The recent-5 window slid with each new tool result, so one request after another cleared a result that the previous request had sent intact; and the label of a cleared result carried a process-global counter (`[microcompact:N]`) that renumbered the same result on every projection. Both change bytes early in the prompt, and the provider's cached prefix breaks from that point to the end. In the 15-step session runs of #2139 this showed as mid-turn cache misses of the whole tail: the desktop run had 13 misses in 75 model calls after #2147 had already fixed the attachment placement, and the remaining ones were re-projection churn (the other cause, the memory head, is #2154).

## What changed

- `runtime/src/services/compact/microCompact.ts`
  - The clear set is decided by `decideClearedResults`, a replay over the append-only history, so every projection of one history agrees byte for byte. Compactable results accumulate until their live text exceeds `MICROCOMPACT_PRESSURE_CHARS` (120k characters, capped at a quarter of the context window at 4 characters per token for small models); the valve then clears the oldest clearable ones down to half the limit, never the most recent five, never the latest read of a path, never a result inside the time window. Between two firings nothing moves.
  - Labels: a cleared standalone result is named by its position among the compactable results, which the history never changes, instead of the process counter. The counter is kept for `getMicrocompactSequenceForTests`.
  - `collectCompactableToolResultPositions` records the result length and recency; `isStandaloneCompactableResult` carries the gaphunt3 #3 tool-name gate that the decision pass used to apply. `latestReadResultPerPath` is gone, path retention lives in the replay (as of the firing point, so it stays monotonic).
- Tests
  - `tests/services/compact/microCompact.test.ts`: two new cases. One projects the same history twice with no reset and asserts identical output and `[microcompact:1]`, `[microcompact:3]` labels. One asserts nothing is cleared under the limit (7 x 16k), the 8th result clears the oldest three and keeps the recent five, and two more results leave the earlier bytes untouched.
  - Five existing cases there, one in `microCompact.memory-bound-naming.test.ts`, the preflight case in `tests/runtime-session.compact-contract.test.ts` and the gaphunt3 #3 standalone case in `tests/gaphunt3/compaction.test.ts` encoded "clear beyond five at once"; their fixtures now cross the limit (25k results, or 7 and 20 results) with the same victims the assertions name. No assertion changed meaning; one expected label string carries the new length. Every test file that imports `microcompactMessages` (four) was run.

## Evidence

| run | result |
| --- | --- |
| `run-hermetic-vitest` on `tests/services/compact` plus the run-turn, runtime-session, gaphunt3 and tool-use-context compaction suites | 22 files, 282 tests passed |
| `tsc -p tsconfig.json --noEmit` | 0 errors |
| trace inside the contract test (20 results of 7,008 chars, window 131,072) | limit 120,000, valve fires at the 18th result, clears `toolu_0` to `toolu_9`, later requests keep that set |

## Not changed

- The time-based clear window and its default; the tool-result byte budget before microcompaction and `truncateToolResultsToFit` after it, which still bound a single oversized turn.
- The API-side context-management passthrough (`apiMicrocompact`).
- Runtime message conversion stamps every converted message with the epoch, so the time window never protected anything in the live pipeline; left as is, noted for a follow-up.

## Counterparts

#2147 (attachment retention, first cache fix), #2154 (stable instruction head, the other remaining miss), #2139 (the session lane that measures cache hits per call).
