### PR TITLE
state: reclaim free pages of the state database

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -179,6 +179,7 @@ import {
   discoverStateDatabasePaths,
   LOGS_DATABASE_FILENAME,
   openStateDatabasePaths,
+  type StateFreePageReclaim,
   resolveStateDatabasePaths,
   STATE_DATABASE_FILENAME,
   type StateDatabasePaths,
@@ -4139,6 +4140,16 @@ function describeSnapshotRetention(
   return `${configured} (hard cap ${SESSION_SNAPSHOT_HARD_CAP} rows per session)`;
 }
 
+function describeStateReclaim(
+  report: StateFreePageReclaim,
+  stateDbPath: string,
+): string {
+  const pages = report.freePagesBefore - report.freePagesAfter;
+  const mib = ((pages * report.pageSize) / (1024 * 1024)).toFixed(1);
+  const how = report.mode === "full" ? "full vacuum, now incremental" : "incremental";
+  return `daemon state reclaimed ${pages} free page(s) (${mib} MiB, ${how}) in ${stateDbPath}`;
+}
+
 function recoverAgenCDaemonStartupState(
   daemonHome: string,
   cwd: string,
@@ -4176,6 +4187,12 @@ function recoverAgenCDaemonStartupState(
           driver,
           config.agent?.retention,
         );
+        // Before the socket opens is the one moment a full VACUUM cannot stall a
+        // client; a database created without auto-vacuum is converted here once.
+        const reclaimed = driver.reclaimFreePages({ allowFullVacuum: true });
+        if (reclaimed.mode !== "none") {
+          log(describeStateReclaim(reclaimed, pathSet.stateDbPath));
+        }
         const prunedSnapshots =
           prunedRuns.prunedSnapshots +
           prunedPerSession.prunedSnapshots +
@@ -4703,6 +4720,8 @@ class AgenCDaemonSnapshotPolicyRegistry {
           `daemon snapshot retention pruned ${report.prunedSnapshots} row(s) ` +
             `across ${report.prunedSessionIds.length} session(s) in ${paths.projectDir}`,
         ),
+      onReclaimReport: (report) =>
+        this.#log(describeStateReclaim(report, paths.stateDbPath)),
     });
     const entry = { driver, policy };
     this.#policies.set(paths.stateDbPath, entry);

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -9,7 +9,10 @@ import {
   type AgentSnapshotPruningReport,
   type RolloutRetentionPolicy,
 } from "./pruning.js";
-import type { StateSqliteDriver } from "./sqlite-driver.js";
+import type {
+  StateFreePageReclaim,
+  StateSqliteDriver,
+} from "./sqlite-driver.js";
 import {
   normalizeToolRecoveryCategory,
   recordInFlightToolCallCompletion,
@@ -65,6 +68,8 @@ export interface SnapshotPolicyOptions {
   // Aggregated snapshot-retention report, delivered from the periodic tick
   // (and close) whenever rows were pruned since the previous report.
   readonly onPruneReport?: (report: AgentSnapshotPruningReport) => void;
+  /** Called after a periodic tick returned free pages of the state database to the file system. */
+  readonly onReclaimReport?: (report: StateFreePageReclaim) => void;
   readonly snapshotRetention?: AgentRunRetentionPolicy;
   // Rollout/session disk-retention sweep config. Disabled unless
   // `rolloutRetention.retention_days` is set AND `rolloutSessionsDir` resolves;
@@ -192,6 +197,7 @@ export class AgenCSessionSnapshotPolicy {
   readonly #clearTimeout: (timer: SnapshotPolicyTimer) => void;
   readonly #onError: (error: unknown) => void;
   readonly #onPruneReport: ((report: AgentSnapshotPruningReport) => void) | undefined;
+  readonly #onReclaimReport: ((report: StateFreePageReclaim) => void) | undefined;
   #prunedSinceReport = 0;
   readonly #prunedSessionsSinceReport = new Set<string>();
   #snapshotRetention: AgentRunRetentionPolicy | undefined;
@@ -254,6 +260,7 @@ export class AgenCSessionSnapshotPolicy {
       ((timer) => clearTimeout(timer as ReturnType<typeof setTimeout>));
     this.#onError = options.onError ?? (() => {});
     this.#onPruneReport = options.onPruneReport;
+    this.#onReclaimReport = options.onReclaimReport;
     this.#snapshotRetention = options.snapshotRetention;
     this.#rolloutRetention = options.rolloutRetention;
     this.#rolloutSessionsDir = options.rolloutSessionsDir;
@@ -632,8 +639,19 @@ export class AgenCSessionSnapshotPolicy {
     // Piggy-back the disk-retention sweep on the same throttled tick so
     // rollout/session pruning runs on a bounded timer, not a tight loop.
     this.sweepRolloutRetention();
+    this.#reclaimFreePages();
     this.#reportPruning();
     return records;
+  }
+
+  /** Bounded, incremental only: a full vacuum belongs to daemon start. */
+  #reclaimFreePages(): void {
+    try {
+      const report = this.#driver.reclaimFreePages();
+      if (report.mode !== "none") this.#onReclaimReport?.(report);
+    } catch (error) {
+      this.#onError(error);
+    }
   }
 
   loadLatest(sessionId: string): SnapshotPolicySnapshotRecord | undefined {

--- a/runtime/src/state/sqlite-driver.ts
+++ b/runtime/src/state/sqlite-driver.ts
@@ -52,6 +52,32 @@ export const STATE_PRE_V19_BACKUP_FILENAME = "agenc-state_1.pre-v19.sqlite";
 export const STATE_PRE_V21_BACKUP_FILENAME = "agenc-state_1.pre-v21.sqlite";
 
 export type SqliteDatabase = BetterSqlite3.Database;
+
+/** One free-page reclaim pass over a state database. */
+export interface StateFreePageReclaim {
+  readonly mode: "none" | "incremental" | "full";
+  readonly pageSize: number;
+  readonly pageCountBefore: number;
+  readonly freePagesBefore: number;
+  readonly freePagesAfter: number;
+  readonly reason?: "no-free-pages" | "below-threshold" | "full-vacuum-not-allowed";
+}
+
+export interface ReclaimStateFreePagesOptions {
+  /** Pages one incremental pass returns to the file system (default 2048, 8 MiB at 4 KiB pages). */
+  readonly maxPages?: number;
+  /** Allow one full VACUUM for a database created without auto_vacuum (default false). */
+  readonly allowFullVacuum?: boolean;
+  /** Full vacuum only when at least this share of the file is free (default 0.5). */
+  readonly fullVacuumMinFreeRatio?: number;
+  /** Full vacuum only when at least this many bytes are free (default 64 MiB). */
+  readonly fullVacuumMinFreeBytes?: number;
+}
+
+const AUTO_VACUUM_INCREMENTAL = 2;
+const DEFAULT_RECLAIM_MAX_PAGES = 2048;
+const DEFAULT_FULL_VACUUM_MIN_FREE_RATIO = 0.5;
+const DEFAULT_FULL_VACUUM_MIN_FREE_BYTES = 64 * 1024 * 1024;
 export type SqliteStatement<
   Params extends unknown[] = unknown[],
   Row = unknown,
@@ -72,6 +98,9 @@ export class StateSqliteDriver {
     let logs: SqliteDatabase | undefined;
     try {
       logs = new Database(paths.logsDbPath);
+      // Before the WAL pragma: switching the journal mode writes the file
+      // header, and auto_vacuum can only be chosen while there is none.
+      configureFreshDatabaseVacuum(state);
       configureDatabase(state);
       configureDatabase(logs);
       applyStateMigrations(state, paths);
@@ -115,6 +144,11 @@ export class StateSqliteDriver {
 
   logsTransaction<T>(fn: () => T): T {
     return this.logs.transaction(fn)();
+  }
+
+  /** Return free pages of the state database to the file system; see `reclaimStateFreePages`. */
+  reclaimFreePages(options: ReclaimStateFreePagesOptions = {}): StateFreePageReclaim {
+    return reclaimStateFreePages(this.state, options);
   }
 
   close(): void {
@@ -236,6 +270,68 @@ function configureDatabase(db: SqliteDatabase): void {
   db.pragma("foreign_keys = ON");
   db.pragma("busy_timeout = 5000");
   db.pragma("temp_store = MEMORY");
+}
+
+/**
+ * Deleted rows leave free pages that SQLite never returns to the file system
+ * on its own, so a state database only grew (a soak home reached 1.28 GB with
+ * 89% free pages). A fresh database is created with incremental auto-vacuum,
+ * which `reclaimStateFreePages` drains in bounded steps. The pragma takes
+ * effect only before the first table exists, so it is set ahead of migrations.
+ */
+function configureFreshDatabaseVacuum(db: SqliteDatabase): void {
+  if (hasUserStateTables(db)) return;
+  db.pragma("auto_vacuum = INCREMENTAL");
+}
+
+function pragmaNumber(db: SqliteDatabase, name: string): number {
+  const value: unknown = db.pragma(name, { simple: true });
+  return typeof value === "number" ? value : Number(value);
+}
+
+/**
+ * Reclaim free pages. A database with incremental auto-vacuum releases up to
+ * `maxPages` per call, cheap enough for a periodic tick. A database created
+ * before auto-vacuum existed needs one full VACUUM, which rewrites the file
+ * and switches it to incremental mode for good; that is allowed only when
+ * the caller says so (daemon start, before the socket opens) and only when
+ * enough of the file is free to justify the rewrite.
+ */
+export function reclaimStateFreePages(
+  db: SqliteDatabase,
+  options: ReclaimStateFreePagesOptions = {},
+): StateFreePageReclaim {
+  const pageSize = pragmaNumber(db, "page_size");
+  const pageCountBefore = pragmaNumber(db, "page_count");
+  const freePagesBefore = pragmaNumber(db, "freelist_count");
+  const base = { pageSize, pageCountBefore, freePagesBefore };
+  if (freePagesBefore === 0) {
+    return { ...base, mode: "none", freePagesAfter: 0, reason: "no-free-pages" };
+  }
+  if (pragmaNumber(db, "auto_vacuum") === AUTO_VACUUM_INCREMENTAL) {
+    const pages = Math.min(freePagesBefore, options.maxPages ?? DEFAULT_RECLAIM_MAX_PAGES);
+    db.pragma(`incremental_vacuum(${pages})`);
+    return { ...base, mode: "incremental", freePagesAfter: pragmaNumber(db, "freelist_count") };
+  }
+  if (options.allowFullVacuum !== true) {
+    return { ...base, mode: "none", freePagesAfter: freePagesBefore, reason: "full-vacuum-not-allowed" };
+  }
+  const freeRatio = freePagesBefore / Math.max(1, pageCountBefore);
+  const freeBytes = freePagesBefore * pageSize;
+  if (
+    freeRatio < (options.fullVacuumMinFreeRatio ?? DEFAULT_FULL_VACUUM_MIN_FREE_RATIO) ||
+    freeBytes < (options.fullVacuumMinFreeBytes ?? DEFAULT_FULL_VACUUM_MIN_FREE_BYTES)
+  ) {
+    return { ...base, mode: "none", freePagesAfter: freePagesBefore, reason: "below-threshold" };
+  }
+  // VACUUM rebuilds the file and applies the pending auto_vacuum mode, so every
+  // later pass on this database is incremental.
+  db.pragma("auto_vacuum = INCREMENTAL");
+  db.exec("VACUUM");
+  // In WAL mode the rebuilt image lives in the log until a checkpoint truncates
+  // the database file to its new size; do it now so the space is really back.
+  db.pragma("wal_checkpoint(TRUNCATE)");
+  return { ...base, mode: "full", freePagesAfter: pragmaNumber(db, "freelist_count") };
 }
 
 function configureReadOnlyDatabase(db: SqliteDatabase): void {

--- a/runtime/tests/state/snapshot-policy.test.ts
+++ b/runtime/tests/state/snapshot-policy.test.ts
@@ -1597,3 +1597,32 @@ function clock(values: readonly string[]): () => string {
     return value;
   };
 }
+
+describe("free-page reclaim on the periodic tick", () => {
+  it("reports the pages a periodic flush returned to the file system", () => {
+    const reports: Array<{ mode: string; freePagesBefore: number; freePagesAfter: number }> = [];
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => "2026-05-01T00:00:00.000Z",
+      agencHome: home,
+      onReclaimReport: (report) => reports.push(report),
+    });
+    driver.state.exec("CREATE TABLE scratch (id INTEGER PRIMARY KEY, blob BLOB NOT NULL)");
+    const insert = driver.prepareState<[Buffer]>("INSERT INTO scratch (blob) VALUES (?)");
+    driver.transaction(() => {
+      for (let index = 0; index < 1_000; index += 1) insert.run(Buffer.alloc(4_000, 3));
+    });
+    driver.state.exec("DELETE FROM scratch");
+    const freeBefore = Number(driver.state.pragma("freelist_count", { simple: true }));
+    expect(freeBefore).toBeGreaterThan(500);
+
+    policy.flushPeriodic();
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({ mode: "incremental", freePagesBefore: freeBefore });
+    expect(reports[0]!.freePagesAfter).toBeLessThan(freeBefore);
+    // Nothing to report once the free list is drained.
+    while (Number(driver.state.pragma("freelist_count", { simple: true })) > 0) driver.reclaimFreePages();
+    policy.flushPeriodic();
+    expect(reports).toHaveLength(1);
+  });
+});

--- a/runtime/tests/state/sqlite-driver.test.ts
+++ b/runtime/tests/state/sqlite-driver.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   rmSync,
 } from "node:fs";
+import { statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
@@ -13,6 +14,7 @@ import { StateSchemaMismatchError } from "./errors.js";
 import {
   applyMigrations,
   openStateDatabases,
+  reclaimStateFreePages,
   resolveStateDatabasePaths,
   STATE_PRE_V15_BACKUP_FILENAME,
   STATE_PRE_V12_BACKUP_FILENAME,
@@ -608,3 +610,103 @@ function seedCurrentMainStateWithoutMigration19(): ReturnType<
   }
   return paths;
 }
+
+describe("free-page reclaim", () => {
+  const PAGE = 4096;
+  function fillAndEmpty(db: Database.Database, rows: number): void {
+    db.exec("CREATE TABLE IF NOT EXISTS scratch (id INTEGER PRIMARY KEY, blob BLOB NOT NULL)");
+    const insert = db.prepare("INSERT INTO scratch (blob) VALUES (?)");
+    const payload = Buffer.alloc(PAGE - 64, 1);
+    db.transaction(() => {
+      for (let index = 0; index < rows; index += 1) insert.run(payload);
+    })();
+    db.exec("DELETE FROM scratch");
+  }
+  const freePages = (db: Database.Database): number =>
+    Number(db.pragma("freelist_count", { simple: true }));
+  const autoVacuum = (db: Database.Database): number =>
+    Number(db.pragma("auto_vacuum", { simple: true }));
+
+  it("creates a fresh state database with incremental auto-vacuum", () => {
+    const driver = openStateDatabases({ cwd, agencHome: home });
+    try {
+      expect(autoVacuum(driver.state)).toBe(2);
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("returns free pages of an incremental database in bounded steps", () => {
+    const driver = openStateDatabases({ cwd, agencHome: home });
+    try {
+      fillAndEmpty(driver.state, 3_000);
+      const before = freePages(driver.state);
+      expect(before).toBeGreaterThan(1_000);
+      const report = driver.reclaimFreePages({ maxPages: 100 });
+      expect(report.mode).toBe("incremental");
+      expect(report.freePagesBefore).toBe(before);
+      expect(before - report.freePagesAfter).toBeGreaterThan(0);
+      expect(before - report.freePagesAfter).toBeLessThanOrEqual(100);
+      expect(freePages(driver.state)).toBe(report.freePagesAfter);
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("rewrites a legacy database once when most of it is free, then it is incremental", () => {
+    const paths = resolveStateDatabasePaths({ cwd, agencHome: home });
+    mkdirSync(paths.projectDir, { recursive: true });
+    const legacy = new Database(paths.stateDbPath);
+    fillAndEmpty(legacy, 4_000);
+    expect(autoVacuum(legacy)).toBe(0);
+    expect(freePages(legacy)).toBeGreaterThan(3_000);
+    legacy.close();
+    const sizeBefore = statSync(paths.stateDbPath).size;
+
+    const driver = openStateDatabases({ cwd, agencHome: home });
+    try {
+      // Existing tables: the fresh-database pragma must not have been applied.
+      expect(autoVacuum(driver.state)).toBe(0);
+      const declined = driver.reclaimFreePages();
+      expect(declined).toMatchObject({ mode: "none", reason: "full-vacuum-not-allowed" });
+      const report = driver.reclaimFreePages({
+        allowFullVacuum: true,
+        fullVacuumMinFreeBytes: 1024 * 1024,
+      });
+      expect(report.mode).toBe("full");
+      expect(report.freePagesAfter).toBe(0);
+      expect(autoVacuum(driver.state)).toBe(2);
+      expect(statSync(paths.stateDbPath).size).toBeLessThan(sizeBefore / 2);
+      // From now on the periodic path works without a full vacuum.
+      fillAndEmpty(driver.state, 500);
+      expect(driver.reclaimFreePages({ maxPages: 50 }).mode).toBe("incremental");
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("leaves a legacy database alone below the free-space threshold and reports why", () => {
+    const paths = resolveStateDatabasePaths({ cwd, agencHome: home });
+    mkdirSync(paths.projectDir, { recursive: true });
+    const legacy = new Database(paths.stateDbPath);
+    legacy.exec("CREATE TABLE keep (id INTEGER PRIMARY KEY, blob BLOB NOT NULL)");
+    const insert = legacy.prepare("INSERT INTO keep (blob) VALUES (?)");
+    for (let index = 0; index < 400; index += 1) insert.run(Buffer.alloc(PAGE - 64, 2));
+    fillAndEmpty(legacy, 20);
+    expect(freePages(legacy)).toBeGreaterThan(0);
+    const report = reclaimStateFreePages(legacy, { allowFullVacuum: true });
+    expect(report).toMatchObject({ mode: "none", reason: "below-threshold" });
+    expect(freePages(legacy)).toBe(report.freePagesBefore);
+    legacy.close();
+  });
+
+  it("reports nothing to do when the file has no free pages", () => {
+    const driver = openStateDatabases({ cwd, agencHome: home });
+    try {
+      driver.reclaimFreePages({ maxPages: 100_000 });
+      expect(driver.reclaimFreePages()).toMatchObject({ mode: "none", reason: "no-free-pages" });
+    } finally {
+      driver.close();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Deleted rows leave free pages, and SQLite never returns them to the file system on its own. Snapshot retention, rollout truncation and run pruning all delete, so a project's state database only grows. Measured on the soak home after one day of desktop and eval sessions: `agenc-state_1.sqlite` was 1.28 GB with `freelist_count` 293,154 of 328,372 pages (89% free), about 135 MB of live rows (`dbstat`), and it kept growing about 20 MB per turn while `session_state_snapshots` stayed at its capped row count. For a user who runs the agent for hours or days this is disk bloat that nothing reclaims.

## What changed

- `runtime/src/state/sqlite-driver.ts`
  - `configureFreshDatabaseVacuum`: a state database with no user tables gets `PRAGMA auto_vacuum = INCREMENTAL`. It runs before `configureDatabase`, because switching the journal mode to WAL writes the file header and auto-vacuum can only be chosen while there is none (the first test run caught this: the pragma after WAL was ignored).
  - `reclaimStateFreePages(db, options)` and `StateSqliteDriver.reclaimFreePages`: on an incremental database, `PRAGMA incremental_vacuum(min(free, maxPages))` with `maxPages` default 2048 (8 MiB at 4 KiB pages). On a database created without auto-vacuum, and only when the caller allows it, a full `VACUUM` when at least `fullVacuumMinFreeRatio` (0.5) of the file and `fullVacuumMinFreeBytes` (64 MiB) are free; the rebuild applies the pending `auto_vacuum = INCREMENTAL` so every later pass is incremental, and `wal_checkpoint(TRUNCATE)` gives the space back immediately (in WAL mode the rebuilt image otherwise waits in the log). The report says which mode ran and why nothing ran (`no-free-pages`, `below-threshold`, `full-vacuum-not-allowed`).
- `runtime/src/state/snapshot-policy.ts`: `flushPeriodic` runs a bounded incremental pass after the rollout sweep and calls the new `onReclaimReport` when pages were returned; errors go to `onError` like the sweep's.
- `runtime/src/app-server/daemon-cli.ts`: `recoverAgenCDaemonStartupState` runs `reclaimFreePages({ allowFullVacuum: true })` on each project database right after the startup pruning, before the socket opens, and logs `daemon state reclaimed N free page(s) (X MiB, full vacuum, now incremental | incremental) in <path>`; the snapshot policy gets `onReclaimReport` wired to the same log line.

## Evidence

| check | result |
| --- | --- |
| copy of the real 1.28 GB database: `auto_vacuum = INCREMENTAL; VACUUM; wal_checkpoint(TRUNCATE)` | 1.3 s; 1282 MB to 135 MB; page_count 328,372 to 34,589; freelist 0; `integrity_check` ok; `auto_vacuum` 2 |
| `run-hermetic-vitest tests/state` (35 files) | 461 passed |
| `tsc -p tsconfig.json --noEmit` | 0 errors |
| live: daemon restarted on a build with this change, soak home, before the socket opened | log line `daemon state reclaimed 291686 free page(s) (1139.4 MiB, full vacuum, now incremental) in .../agenc-state_1.sqlite`; file 1282 MB to 141 MB; `daemon status` running 12 s after start; the desktop app connected to that daemon without replacing it |

## Tests

- `tests/state/sqlite-driver.test.ts`, new `free-page reclaim` block: a fresh database reports `auto_vacuum` 2; an incremental database returns at most `maxPages` per pass and the pragma agrees with the report; a legacy database (created raw, 4,000 deleted 4 KiB rows) is declined without `allowFullVacuum`, rewritten to less than half its size with it, ends at `auto_vacuum` 2 and then reclaims incrementally; a legacy database below the threshold is left alone with `below-threshold`; a drained file reports `no-free-pages`.
- `tests/state/snapshot-policy.test.ts`: a periodic flush on a database with free pages calls `onReclaimReport` once with `mode: "incremental"`, and a second flush on a drained file reports nothing.

## Not changed

- Retention configuration and the pruning queries; the logs database (`agenc-logs_1.sqlite`), which is small; `VACUUM INTO` backups; the WAL autocheckpoint setting.
- No full vacuum on the live path: the periodic tick only ever runs the bounded incremental pass.

## Counterparts

Soak findings F13 (this), core #2158 (health counters), the eval and soak harness notes in `docs/eval/`.
