### PR TITLE
memory: extract in bounded batches and drop a batch after two failed runs

### DIFF
--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -100,6 +100,16 @@ export const MEMORY_EXTRACTION_TOOL_ALLOWLIST: readonly string[] = [
 export const MEMORY_EXTRACTION_AGENT_NAME = "memory_extraction";
 
 const DEFAULT_MAX_TURNS = 5;
+/**
+ * Visible messages one extraction run may cover. The child has
+ * DEFAULT_MAX_TURNS tool rounds; a run that failed on N messages was handed N
+ * plus everything new the next time, so a long session's extraction never
+ * completed again (backlog 6, 20, 25, 31 messages across four failed runs in
+ * one soak session). A bounded batch drains over several runs instead.
+ */
+const MAX_EXTRACTION_BATCH_MESSAGES = 12;
+/** Failed runs on the same batch before it is dropped so the lane recovers. */
+const MAX_FAILED_RUNS_PER_BATCH = 2;
 const MAX_EXTRACTION_LANES = 256;
 
 type ExtractionWarningCause =
@@ -216,6 +226,8 @@ interface VisibleRange {
 interface ExtractionLane {
   trigger: MemoryExtractionTriggerState;
   inProgress: boolean;
+  /** Consecutive failed runs on the current batch. */
+  failedRuns: number;
   lastAccessedAt: number;
   pendingContext: QueuedExtraction | undefined;
   /** The persisted cadence was read once, before the lane's first decision. */
@@ -720,6 +732,7 @@ export function initExtractMemories(
     const created: ExtractionLane = {
       trigger: createMemoryExtractionTriggerState(),
       inProgress: false,
+      failedRuns: 0,
       lastAccessedAt: Date.now(),
       pendingContext: undefined,
       restored: false,
@@ -811,7 +824,17 @@ export function initExtractMemories(
       queued.context.messages,
       lane.trigger.processedVisibleCount,
     );
-    const newMessageCount = range.unprocessedMessages.length;
+    // The cursor restarts at zero when the visible history shrank (a reset).
+    const batchStart =
+      range.currentVisibleCount < lane.trigger.processedVisibleCount
+        ? 0
+        : lane.trigger.processedVisibleCount;
+    const batch = range.unprocessedMessages.slice(
+      0,
+      MAX_EXTRACTION_BATCH_MESSAGES,
+    );
+    const batchEnd = batchStart + batch.length;
+    const newMessageCount = batch.length;
     if (newMessageCount === 0) {
       emitExtractionWarning(
         session,
@@ -823,14 +846,15 @@ export function initExtractMemories(
 
     if (
       hasSuccessfulMemoryWrite({
-        messages: range.unprocessedMessages,
+        messages: batch,
         completedToolResults: queued.context.completedToolResults,
         writeToolNames: WRITE_TOOL_NAMES,
         resolveMemoryPath: (value) =>
           resolveDirectMemoryWritePath(value, memoryDir),
       })
     ) {
-      lane.trigger.processedVisibleCount = range.currentVisibleCount;
+      lane.trigger.processedVisibleCount = batchEnd;
+      lane.failedRuns = 0;
       emitExtractionWarning(
         session,
         "memory_extraction_skipped",
@@ -884,7 +908,8 @@ export function initExtractMemories(
     const childResult = await (deps.runChild ??
       ((request) => defaultRunChild(request, maxTurns, deps)))({
       session: queued.context.session,
-      messages: queued.context.messages,
+      // The batch, not the whole history: the child's work stays bounded.
+      messages: batch,
       prompt,
       memoryDir,
       toolPolicy: createAutoMemoryToolPolicy(memoryDir, readOnlyMemoryRoots),
@@ -908,6 +933,19 @@ export function initExtractMemories(
       } else {
         detail = "a memory write failed";
       }
+      lane.failedRuns += 1;
+      if (lane.failedRuns >= MAX_FAILED_RUNS_PER_BATCH) {
+        // The same batch failed twice; move past it so the lane recovers.
+        lane.trigger.processedVisibleCount = batchEnd;
+        lane.failedRuns = 0;
+        emitExtractionWarning(
+          session,
+          "memory_extraction_failed",
+          detail + "; dropped " + newMessageCount + " message(s) after " +
+            MAX_FAILED_RUNS_PER_BATCH + " failed runs on the same batch",
+        );
+        return;
+      }
       emitExtractionWarning(
         session,
         "memory_extraction_failed",
@@ -923,7 +961,8 @@ export function initExtractMemories(
         `child tool policy denied ${tracker.deniedReads} read(s) outside the memory directory; the extraction completed`,
       );
     }
-    lane.trigger.processedVisibleCount = range.currentVisibleCount;
+    lane.trigger.processedVisibleCount = batchEnd;
+    lane.failedRuns = 0;
     const savedPaths = [...tracker.savedPaths].filter(
       (path) => basename(path) !== AUTO_MEMORY_INDEX_FILE,
     );

--- a/runtime/tests/services/extractMemories/extractMemories.test.ts
+++ b/runtime/tests/services/extractMemories/extractMemories.test.ts
@@ -1520,3 +1520,54 @@ describe("skill candidates ride the extraction child", () => {
     ).resolves.toBeDefined();
   });
 });
+
+describe("extraction batches and failed runs", () => {
+  let root = "";
+  let memoryDir = "";
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-extract-batches-"));
+    memoryDir = join(root, "memory");
+    await mkdir(memoryDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+  const conversation = (count: number): LLMMessage[] =>
+    Array.from({ length: count }, (_, index) => ({
+      role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `turn ${index}: something durable about the project`,
+    }));
+
+  it("covers at most twelve messages per run and drains the rest on later runs", async () => {
+    const runChild = vi.fn(async (_request: ExtractMemoriesChildRequest) => ({ outcome: "completed" as const }));
+    initExtractMemories({ env: {}, minEligibleTurns: 1, resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }), runChild });
+    const messages = conversation(30);
+    await executeExtractMemories(extractionContext({ cwd: root, messages }));
+    await executeExtractMemories(extractionContext({ cwd: root, messages }));
+    await executeExtractMemories(extractionContext({ cwd: root, messages }));
+    expect(runChild.mock.calls.map((call) => call[0].messages.length)).toEqual([12, 12, 6]);
+    expect(runChild.mock.calls[0]![0].messages[0]!.content).toContain("turn 0:");
+    expect(runChild.mock.calls[2]![0].messages[0]!.content).toContain("turn 24:");
+    expect(runChild.mock.calls[0]![0].prompt).toContain("~12 model-visible");
+    await executeExtractMemories(extractionContext({ cwd: root, messages }));
+    expect(runChild).toHaveBeenCalledTimes(3);
+  });
+
+  it("drops a batch after two failed runs and continues with the newer messages", async () => {
+    const outcomes: ExtractMemoriesChildResult[] = [
+      { outcome: "errored", error: new Error("subagent exceeded maxTurns (5)") },
+      { outcome: "errored", error: new Error("subagent exceeded maxTurns (5)") },
+      { outcome: "completed" },
+    ];
+    const runChild = vi.fn(async (_request: ExtractMemoriesChildRequest) => outcomes.shift() ?? { outcome: "completed" as const });
+    initExtractMemories({ env: {}, minEligibleTurns: 1, resolveMemoryDirectory: async () => ({ enabled: true, path: memoryDir }), runChild });
+    const first = conversation(4);
+    await executeExtractMemories(extractionContext({ cwd: root, messages: first }));
+    await executeExtractMemories(extractionContext({ cwd: root, messages: first }));
+    expect(runChild.mock.calls.map((call) => call[0].messages.length)).toEqual([4, 4]);
+    const later = [...first, ...conversation(2).map((message, index) => ({ ...message, content: `turn ${index + 4}: newer` }))];
+    await executeExtractMemories(extractionContext({ cwd: root, messages: later }));
+    expect(runChild).toHaveBeenCalledTimes(3);
+    expect(runChild.mock.calls[2]![0].messages.map((message) => message.content)).toEqual(["turn 4: newer", "turn 5: newer"]);
+  });
+});


### PR DESCRIPTION
## Why

In a 15-turn desktop coding session on grok-4.6 the automatic memory extraction failed four times in a row, each time `subagent exceeded maxTurns (5)`, with the queued backlog growing 6, 20, 25, 31 messages. `runExtraction` left `processedVisibleCount` untouched after a failure, so every later eligible turn gave the child the same range plus the new messages, and the child also received the whole session history. A range that already exceeded five tool rounds could only get worse, so extraction never completed again for that session while each retry spent up to five model calls. #2161 has the log lines.

## What changed

- `runtime/src/services/extractMemories/extractMemories.ts`
  - `MAX_EXTRACTION_BATCH_MESSAGES = 12`: a run covers the oldest twelve unprocessed visible messages; the cursor advances by the messages covered (`batchEnd`), so a long backlog drains over several runs. The "main agent already wrote memory" shortcut and the child's `messages` use the same batch, so the child's work is bounded by the batch rather than by the session's age. The prompt's `~N model-visible` count is the batch size.
  - `MAX_FAILED_RUNS_PER_BATCH = 2` and `ExtractionLane.failedRuns`: a batch that fails twice is dropped with `memory_extraction_failed: …; dropped N message(s) after 2 failed runs on the same batch`, and the lane continues with the newer messages. Successful runs and the shortcut reset the counter.
  - When the visible history shrank below the cursor (a reset), the batch starts at zero, matching `memoryExtractionVisibleRange`.

## Evidence

| check | result |
| --- | --- |
| `run-hermetic-vitest tests/services/extractMemories tests/memory-wiring.contract.test.ts` | 4 files, 54 tests passed (52 existing + 2 new) |
| `tsc -p tsconfig.json --noEmit` | 0 errors |

## Tests

`tests/services/extractMemories/extractMemories.test.ts`, new block:
- thirty visible messages drain as three runs of 12, 12 and 6, oldest first, with the prompt naming `~12 model-visible`; a fourth run has nothing to do.
- two failed runs on the same four messages drop the batch; the third run receives only the two newer messages.

## Not changed

- `DEFAULT_MAX_TURNS`, the cadence deferral, the tool policy, the skill-candidate section, the warning causes (the drop reuses `memory_extraction_failed` so the canonical event schema is untouched).

## Counterparts

Closes #2161. Found by the desktop soak (findings F15); #2160 and #2159 came from the same session.