### PR TITLE
state: spill the one-time VACUUM to disk instead of the memory temp store

### DIFF
--- a/runtime/src/state/sqlite-driver.ts
+++ b/runtime/src/state/sqlite-driver.ts
@@ -325,12 +325,22 @@ export function reclaimStateFreePages(
     return { ...base, mode: "none", freePagesAfter: freePagesBefore, reason: "below-threshold" };
   }
   // VACUUM rebuilds the file and applies the pending auto_vacuum mode, so every
-  // later pass on this database is incremental.
-  db.pragma("auto_vacuum = INCREMENTAL");
-  db.exec("VACUUM");
-  // In WAL mode the rebuilt image lives in the log until a checkpoint truncates
-  // the database file to its new size; do it now so the space is really back.
-  db.pragma("wal_checkpoint(TRUNCATE)");
+  // later pass on this database is incremental. The rebuild is staged in the
+  // temp store, which this connection keeps in memory (configureDatabase); a
+  // 1.3 GB file held the daemon at about 1 GB of RSS for minutes after start,
+  // so the temp store goes to disk for the duration of the rebuild.
+  const previousTempStore = pragmaNumber(db, "temp_store");
+  db.pragma("temp_store = FILE");
+  try {
+    db.pragma("auto_vacuum = INCREMENTAL");
+    db.exec("VACUUM");
+    // In WAL mode the rebuilt image lives in the log until a checkpoint
+    // truncates the database file to its new size; do it now so the space is
+    // really back.
+    db.pragma("wal_checkpoint(TRUNCATE)");
+  } finally {
+    db.pragma(`temp_store = ${previousTempStore}`);
+  }
   return { ...base, mode: "full", freePagesAfter: pragmaNumber(db, "freelist_count") };
 }
 

--- a/runtime/tests/state/sqlite-driver.test.ts
+++ b/runtime/tests/state/sqlite-driver.test.ts
@@ -676,6 +676,8 @@ describe("free-page reclaim", () => {
       expect(report.mode).toBe("full");
       expect(report.freePagesAfter).toBe(0);
       expect(autoVacuum(driver.state)).toBe(2);
+      // The rebuild spilled to disk and the connection is back on its memory temp store.
+      expect(Number(driver.state.pragma("temp_store", { simple: true }))).toBe(2);
       expect(statSync(paths.stateDbPath).size).toBeLessThan(sizeBefore / 2);
       // From now on the periodic path works without a full vacuum.
       fillAndEmpty(driver.state, 500);


### PR DESCRIPTION
## Why

#2159 runs one full `VACUUM` at daemon start for a state database created without auto-vacuum. `configureDatabase` sets `temp_store = MEMORY`, and VACUUM stages the rebuilt database in the temp store, so the 1.3 GB soak database was rebuilt in RAM: the daemon reported about 1 GB of RSS from start through the sixth soak step (health samples 949, 946, 1022, 1027, 1030, 1002 MB) and 370 MB from the seventh on. Not a leak, but a needless spike on a machine that may be running the app, a browser and a build at the same time.

## What changed

- `runtime/src/state/sqlite-driver.ts`: the full-vacuum branch of `reclaimStateFreePages` switches `temp_store` to `FILE` before `VACUUM` and restores the previous value in a `finally`. The incremental path is unchanged (it frees pages in place and needs no temp copy).

## Evidence

| check | result |
| --- | --- |
| `run-hermetic-vitest tests/state/sqlite-driver.test.ts tests/state/snapshot-policy.test.ts` | 2 files passed |
| `tsc -p tsconfig.json --noEmit` | 0 errors |

## Tests

`tests/state/sqlite-driver.test.ts`, legacy-database case: after the full vacuum the connection's `temp_store` reads 2 (memory) again, proving the switch happened and was undone.

## Not changed

Everything else in #2159: thresholds, the incremental pass, the boot hook and its log line.

## Counterparts

#2159 (merged); soak findings F18.