### PR TITLE
workflow: start and resume goal runs outside any session scope

### DIFF
--- a/runtime/src/app-server/workflow/daemon-wiring.ts
+++ b/runtime/src/app-server/workflow/daemon-wiring.ts
@@ -67,6 +67,7 @@ import {
   type WorkflowSessionSeams,
   type WorkflowSessionSeamsOptions,
 } from "./session-adapters.js";
+import { runWithBootstrapSessionScope } from "../../session/current-session.js";
 
 const WORKFLOW_TASK_ID = "verified-change";
 const WORKFLOW_SYSTEM_ID = "agenc.workflow.m5";
@@ -468,7 +469,13 @@ export function createDaemonWorkflowController(options: {
       for (const paths of candidatePaths()) {
         activeResumePaths = paths;
         try {
-          resumed.push(...(await controller.resumeOpenWorkflows()));
+          // Same scope as run.start: resumed runs spawn sessions from daemon
+          // context, where the ambient current session is undefined.
+          resumed.push(
+            ...(await runWithBootstrapSessionScope(() =>
+              controller.resumeOpenWorkflows(),
+            )),
+          );
         } finally {
           activeResumePaths = undefined;
         }

--- a/runtime/src/app-server/workflow/run-start-service.ts
+++ b/runtime/src/app-server/workflow/run-start-service.ts
@@ -19,6 +19,7 @@ import {
   WorkflowIntakeError,
   type WorkflowStartParams,
 } from "./verified-change-controller.js";
+import { runWithBootstrapSessionScope } from "../../session/current-session.js";
 
 export type AgenCDaemonWorkflowStartErrorCode =
   | "INVALID_ARGUMENT"
@@ -126,7 +127,16 @@ export class DaemonWorkflowStartService {
     };
     let started;
     try {
-      started = await this.#options.controller.start(startParams);
+      // A goal run is daemon work, not a turn of any session. Utilities on its
+      // path fall back to the ambient "current session", which refuses when
+      // the daemon tracks more than one session, as a desktop daemon always
+      // does: every run.start then failed with "Ambiguous runtime session".
+      // Inside this scope the fallback yields no session and the utilities
+      // use their environment defaults; the run's own sessions bind their
+      // scopes as they start.
+      started = await runWithBootstrapSessionScope(() =>
+        this.#options.controller.start(startParams),
+      );
     } catch (error) {
       if (error instanceof TypeError) {
         // Pre-intake parameter refusal (e.g. no verification commands):

--- a/runtime/tests/app-server/workflow/run-start-session-scope.test.ts
+++ b/runtime/tests/app-server/workflow/run-start-session-scope.test.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { DaemonWorkflowStartService } from "../../../src/app-server/workflow/run-start-service.js";
+import type { VerifiedChangeWorkflowController } from "../../../src/app-server/workflow/verified-change-controller.js";
+import {
+  getCurrentRuntimeSession,
+  setCurrentRuntimeSession,
+} from "../../../src/session/current-session.js";
+import type { Session } from "../../../src/session/session.js";
+
+/**
+ * A desktop daemon tracks many sessions. The goal runner's path reaches
+ * utilities that fall back to the ambient current session, which throws
+ * "Ambiguous runtime session" once more than one session is tracked; every
+ * run.start from the app failed that way. The start service runs the
+ * controller inside the bootstrap scope, where the fallback yields null.
+ */
+describe("run.start with several sessions tracked in the process", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    setCurrentRuntimeSession(null);
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("starts the run and gives the controller no ambient session instead of an error", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "agenc-run-start-scope-"));
+    dirs.push(repo);
+    execFileSync("git", ["init", "-q"], { cwd: repo });
+    mkdirSync(join(repo, "src"));
+    setCurrentRuntimeSession({ sessionConfiguration: { cwd: repo } } as unknown as Session);
+    setCurrentRuntimeSession({ sessionConfiguration: { cwd: repo } } as unknown as Session);
+    expect(() => getCurrentRuntimeSession()).toThrow(/Ambiguous runtime session/);
+
+    let seenInsideStart: unknown = "unset";
+    const controller = {
+      start: async () => {
+        seenInsideStart = getCurrentRuntimeSession();
+        return {
+          runId: "run-scope-test",
+          specDigest: "a".repeat(64),
+          baseCommit: "b".repeat(40),
+          baseDirty: false,
+        };
+      },
+    } as unknown as VerifiedChangeWorkflowController;
+    const service = new DaemonWorkflowStartService({
+      controller,
+      primaryCwd: repo,
+      warn: () => {},
+    });
+
+    const result = await service.startRun({
+      goal: "make the tests green",
+      cwd: repo,
+      verification: [{ label: "verify", script: "true" }],
+    } as never);
+    expect(result.runId).toBe("run-scope-test");
+    expect(seenInsideStart).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Every goal started from the desktop app failed at once with `AgencRpcError: Ambiguous runtime session: N sessions are bootstrapped in this process and no session is bound to the current async context` (soak, 2026-09-05, six goals, six failures in under a second each). `getCurrentRuntimeSession` in `current-session.ts` throws that when the process tracks more than one session and no scope is bound; several utilities on the goal runner's path use it as a fallback (`runtime-options.ts`, `model/providers.ts`, `envUtils.ts`, `secureStorage/home.ts`, `project-trust.ts`, `tools/system/filesystem.ts`). A daemon serving the desktop tracks every open session, so `run.start` could only have worked in a single-session daemon.

## What changed

- `runtime/src/app-server/workflow/run-start-service.ts`: `startRun` calls the controller inside `runWithBootstrapSessionScope`, the existing scope in which the ambient fallback returns null instead of throwing, so the utilities use their environment defaults. The run's own child sessions bind their scopes as they start, unaffected.
- `runtime/src/app-server/workflow/daemon-wiring.ts`: the resume sweep at daemon start runs `controller.resumeOpenWorkflows()` in the same scope, since resumed runs spawn sessions from daemon context too.

## Evidence

| check | result |
| --- | --- |
| new `tests/app-server/workflow/run-start-session-scope.test.ts`: two sessions tracked, `getCurrentRuntimeSession` throws outside, `startRun` succeeds and the controller observes `null` inside | passes; fails without the change with the soak's exact error |
| `run-hermetic-vitest` on the new test, `daemon-dispatcher.run-start.contract.test.ts`, `session/current-session.test.ts` | passed |
| `tests/workflow/daemon-wiring.test.ts` | 1 of 2 fails identically on unmodified `main` on this Mac ("journals a run into its own repository's project database": `WorkflowIntakeError`); not related, noted for CI |
| `tsc -p tsconfig.json --noEmit` | 0 errors |

## Not changed

- `current-session.ts` and its ambiguity check, which protects turns from reading the wrong session.
- The utilities' fallbacks; only the goal path stops relying on them.

## Counterparts

Soak findings F23; desktop goal cancel #177 depends on goals being startable to be verified at runtime.