### PR TITLE
workflow: pin a macOS platform protection verifier so goal runs can start

### DIFF
--- a/runtime/src/app-server/workflow/daemon-wiring.ts
+++ b/runtime/src/app-server/workflow/daemon-wiring.ts
@@ -68,6 +68,7 @@ import {
   type WorkflowSessionSeamsOptions,
 } from "./session-adapters.js";
 import { runWithBootstrapSessionScope } from "../../session/current-session.js";
+import { createPlatformProtectionVerifier } from "../../eval-contract/platform-protection.js";
 
 const WORKFLOW_TASK_ID = "verified-change";
 const WORKFLOW_SYSTEM_ID = "agenc.workflow.m5";
@@ -127,7 +128,13 @@ export function createDaemonWorkflowEvidenceLedgerFactory(options: {
   return async (spec: WorkflowSpec): Promise<WorkflowEvidenceLedger> => {
     const root = path.join(evidenceRoot, sanitizeIdentifierPart(spec.runId));
     await mkdir(root, { recursive: true, mode: 0o700 });
-    const access = { root };
+    // macOS and Windows need an ACL check the ledger cannot do itself; without
+    // one the ledger refuses and every goal run fails at intake on a Mac.
+    const platformProtection = createPlatformProtectionVerifier();
+    const access = {
+      root,
+      ...(platformProtection !== undefined ? { platformProtection } : {}),
+    };
     const context = {
       runId: spec.runId,
       contractDigest: computeSpecDigest(spec),

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -366,6 +366,15 @@ export interface WorkflowStartResult {
 }
 
 /** Intake failed before the pipeline began; the terminal result is durable. */
+/** The journaled failure message of a non-committed effect, as a suffix, or "". */
+function describeEffectFailure(result: unknown): string {
+  if (typeof result !== "object" || result === null) return "";
+  const failure = (result as { readonly failure?: unknown }).failure;
+  if (typeof failure !== "object" || failure === null) return "";
+  const message = (failure as { readonly message?: unknown }).message;
+  return typeof message === "string" && message.length > 0 ? `: ${message}` : "";
+}
+
 export class WorkflowIntakeError extends Error {
   constructor(
     readonly runId: string,
@@ -824,10 +833,13 @@ export class VerifiedChangeWorkflowController {
       },
     });
     if (result.outcome !== "committed") {
+      // The journal keeps the failure; the client used to see only
+      // "workflow intake failed" while the cause sat in run_effects.
+      const failure = describeEffectFailure(result);
       throw new WorkflowHaltError({
         status: result.outcome === "cancelled" ? "cancelled" : "failed",
         stopReason: null,
-        finalMessage: `workflow intake ${result.outcome}`,
+        finalMessage: `workflow intake ${result.outcome}${failure}`,
       });
     }
     if (ctx.ledger === undefined) {

--- a/runtime/src/eval-contract/platform-protection.ts
+++ b/runtime/src/eval-contract/platform-protection.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { lstat } from "node:fs/promises";
+import { promisify } from "node:util";
+import { sha256Digest } from "./canonical-json.js";
+import type {
+  EvidenceArtifactKind,
+  PlatformProtectionVerifier,
+} from "./evidence-ledger.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Identifies this verifier in ledger metadata. The ledger records the digest
+ * of the verifier that ran, so a reader knows which check protected the
+ * evidence; bump the suffix when the check changes.
+ */
+export const DARWIN_PLATFORM_PROTECTION_VERIFIER_ID =
+  "agenc.platform-protection.darwin/v1";
+
+/**
+ * The evidence ledger keeps its own owner and mode checks, but mode bits do
+ * not tell the whole story on macOS: an access control list can grant another
+ * user read access to a 0700 directory or a 0600 file. This verifier reads
+ * the ACL through `ls -led`, the only stable interface macOS offers for it,
+ * and accepts an artifact only when it is a real file or directory, owned by
+ * this user, closed to group and others, and carries no ACL entries at all.
+ * Without a verifier the ledger refuses to run on macOS, which made every
+ * goal run fail at intake on a Mac.
+ */
+export function createDarwinPlatformProtectionVerifier(
+  options: { readonly listCommand?: string } = {},
+): PlatformProtectionVerifier {
+  const listCommand = options.listCommand ?? "/bin/ls";
+  return {
+    verifierDigest: sha256Digest(DARWIN_PLATFORM_PROTECTION_VERIFIER_ID),
+    async verify(path: string, kind: EvidenceArtifactKind): Promise<boolean> {
+      const stat = await lstat(path).catch(() => null);
+      if (stat === null || stat.isSymbolicLink()) return false;
+      if (kind === "directory" ? !stat.isDirectory() : !stat.isFile()) {
+        return false;
+      }
+      if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+        return false;
+      }
+      if ((stat.mode & 0o077) !== 0) return false;
+      return !(await hasAclEntries(listCommand, path));
+    },
+  };
+}
+
+/** `ls -led` prints the entry line, then one indented ` N: ...` line per ACL entry. */
+async function hasAclEntries(listCommand: string, path: string): Promise<boolean> {
+  const { stdout } = await execFileAsync(listCommand, ["-led", "--", path], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024,
+  });
+  return stdout
+    .split("\n")
+    .slice(1)
+    .some((line) => /^\s+\d+:\s/.test(line));
+}
+
+/** The verifier for the running platform, or undefined where the ledger needs none. */
+export function createPlatformProtectionVerifier(): PlatformProtectionVerifier | undefined {
+  if (process.platform === "darwin") return createDarwinPlatformProtectionVerifier();
+  return undefined;
+}

--- a/runtime/tests/eval-contract/platform-protection.test.ts
+++ b/runtime/tests/eval-contract/platform-protection.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createDarwinPlatformProtectionVerifier,
+  createPlatformProtectionVerifier,
+  DARWIN_PLATFORM_PROTECTION_VERIFIER_ID,
+} from "../../src/eval-contract/platform-protection.js";
+import { sha256Digest } from "../../src/eval-contract/canonical-json.js";
+
+const onDarwin = process.platform === "darwin";
+
+describe.skipIf(!onDarwin)("darwin platform protection verifier", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  });
+  const scratch = (): string => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-platform-protection-"));
+    roots.push(root);
+    return root;
+  };
+
+  it("pins a stable digest and is the platform verifier on macOS", () => {
+    const verifier = createDarwinPlatformProtectionVerifier();
+    expect(verifier.verifierDigest).toBe(sha256Digest(DARWIN_PLATFORM_PROTECTION_VERIFIER_ID));
+    expect(createPlatformProtectionVerifier()?.verifierDigest).toBe(verifier.verifierDigest);
+  });
+
+  it("accepts a private directory and file owned by this user", async () => {
+    const root = scratch();
+    const dir = join(root, "evidence");
+    mkdirSync(dir, { mode: 0o700 });
+    const file = join(dir, "ledger.jsonl");
+    writeFileSync(file, "x", { mode: 0o600 });
+    const verifier = createDarwinPlatformProtectionVerifier();
+    expect(await verifier.verify(dir, "directory")).toBe(true);
+    expect(await verifier.verify(file, "ledger")).toBe(true);
+  });
+
+  it("rejects group or world access, symlinks, missing paths and the wrong kind", async () => {
+    const root = scratch();
+    const dir = join(root, "evidence");
+    mkdirSync(dir, { mode: 0o750 });
+    const file = join(root, "note.txt");
+    writeFileSync(file, "x", { mode: 0o600 });
+    symlinkSync(file, join(root, "link"));
+    const verifier = createDarwinPlatformProtectionVerifier();
+    expect(await verifier.verify(dir, "directory")).toBe(false);
+    chmodSync(dir, 0o700);
+    expect(await verifier.verify(dir, "directory")).toBe(true);
+    expect(await verifier.verify(join(root, "link"), "ledger")).toBe(false);
+    expect(await verifier.verify(join(root, "missing"), "ledger")).toBe(false);
+    expect(await verifier.verify(file, "directory")).toBe(false);
+  });
+
+  it("rejects an artifact that carries an ACL entry even with mode 0700", async () => {
+    const root = scratch();
+    const dir = join(root, "evidence");
+    mkdirSync(dir, { mode: 0o700 });
+    execFileSync("/bin/chmod", ["+a", "everyone allow read", dir]);
+    const verifier = createDarwinPlatformProtectionVerifier();
+    expect(await verifier.verify(dir, "directory")).toBe(false);
+    execFileSync("/bin/chmod", ["-a", "everyone allow read", dir]);
+    expect(await verifier.verify(dir, "directory")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

After #2168 the desktop's goal starts got past the session check and failed at intake, every time, in under a second: the client saw `workflow wf-… intake failed: workflow intake failed`, and `run_effects` for the run held the reason: `{"failure":{"message":"a pinned platform protection verifier is required for darwin","reason":"step_execution_failed"}}`. `evidence-ledger.ts` requires an external ACL verifier on macOS and Windows (mode bits do not cover access control lists there), and `createDaemonWorkflowEvidenceLedgerFactory` passed `{ root }` with no verifier. Nothing in the tree constructed one, so goals could never run on a Mac. The `daemon-wiring` test that was red on this Mac fails for the same reason.

## What changed

- `runtime/src/eval-contract/platform-protection.ts` (new): `createDarwinPlatformProtectionVerifier()` accepts an artifact only when it is a real file or directory (not a symlink, of the expected kind), owned by the current user, with no group or other bits, and with no ACL entries, read through `/bin/ls -led` (the stable interface macOS offers for ACLs). `verifierDigest` is the digest of `agenc.platform-protection.darwin/v1`, so ledger metadata names the check that ran. `createPlatformProtectionVerifier()` returns it on darwin and undefined elsewhere; Windows still has no verifier and still refuses, noted below.
- `runtime/src/app-server/workflow/daemon-wiring.ts`: the ledger factory pins the platform verifier when there is one.
- `runtime/src/app-server/workflow/verified-change-controller.ts`: the intake halt appends the journaled failure message (`describeEffectFailure`), so a client sees `workflow intake failed: a pinned platform protection verifier is required for darwin` instead of the bare phrase.

## Evidence

| check | result |
| --- | --- |
| soak `goal-1` after #2168: six starts, six `intake failed`, journaled reason as above | the motivating failure |
| new `tests/eval-contract/platform-protection.test.ts` (macOS only): stable digest; private dir and file accepted; group bits, symlink, missing path and wrong kind rejected; a real ACL added with `chmod +a "everyone allow read"` rejected and accepted again after removal | 4 passed |
| `tests/workflow/daemon-wiring.test.ts` | both cases pass; the second was red on this Mac before the change |
| `daemon-dispatcher.run-start.contract.test.ts`, `run-start-session-scope.test.ts` | pass |
| `tsc -p tsconfig.json --noEmit` | 0 errors |

## Tests

Described above; the ACL case exercises the real macOS ACL path rather than a mock.

## Not changed

- The ledger's own owner and mode checks and the requirement itself: the verifier satisfies it rather than bypassing it.
- Windows: no verifier yet (an `icacls`-based one would follow the same shape), so goal runs still refuse there with a message that now says why.

## Counterparts

#2168 (the session-scope fix this sits behind); soak findings F26; desktop #177 needs goals to start to be verified at runtime.