### PR TITLE
exec_command: name the replacement when a removed alias is rejected

### DIFF
--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -321,6 +321,11 @@ function processObservationDisposition(
   });
 }
 
+const REMOVED_ALIAS_HINTS = {
+  command: "the command line goes in `cmd`",
+  cwd: "the working directory goes in `workdir`",
+} as const;
+
 export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
   const manager =
     config?.unifiedExecManager ??
@@ -454,7 +459,12 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
       const args = rawArgs as Record<string, unknown> & ToolExecutionInjectedArgs;
       for (const removedAlias of ["command", "cwd"] as const) {
         if (Object.prototype.hasOwnProperty.call(args, removedAlias)) {
-          const message = `unknown field \`${removedAlias}\``;
+          // Name the field that replaced the alias: a bare "unknown field"
+          // gave the model nothing to correct, and a goal run's implement
+          // child repeated the same `cwd` call 44 times until the backstop
+          // ended the turn.
+          const message =
+            `unknown field \`${removedAlias}\`; ${REMOVED_ALIAS_HINTS[removedAlias]}`;
           return {
             content: safeStringify({ error: message }),
             isError: true,

--- a/runtime/tests/tools/system/exec-command.test.ts
+++ b/runtime/tests/tools/system/exec-command.test.ts
@@ -155,6 +155,18 @@ describe("exec_command tool", () => {
       1,
     );
 
+    test("a removed alias names the field that replaced it, so the model can correct the call", async () => {
+      const { tool } = toolWith(completedExecOutput(""));
+      const byCwd = await tool.execute(sandboxedArgs({ cmd: "npm test", cwd: root }));
+      expect(byCwd.isError).toBe(true);
+      expect(String(byCwd.content)).toContain("unknown field `cwd`");
+      expect(String(byCwd.content)).toContain("`workdir`");
+      const byCommand = await tool.execute(sandboxedArgs({ command: "npm test" }));
+      expect(byCommand.isError).toBe(true);
+      expect(String(byCommand.content)).toContain("unknown field `command`");
+      expect(String(byCommand.content)).toContain("`cmd`");
+    });
+
     test("a denied bind says the sandbox did it and that retrying is pointless", async () => {
       const { tool } = toolWith(BIND_DENIED);
       const result = await tool.execute(sandboxedArgs({ cmd: "npm start", workdir: root }));


### PR DESCRIPTION
## Why

The first goal run that got past intake on macOS (#2168, #2170) failed both implement attempts the same way: the implement child called `exec_command` with a `cwd` argument, the tool answered `{"error":"unknown field \`cwd\`"}` (44 times in the second attempt, 11 in the first), the repeat guard refused the identical call after three failures, and the no-progress backstop ended the turn. The alias is rejected on purpose (`workdir` replaced it), but the message gave the model nothing to correct toward, so it retried until stopped.

## What changed

- `runtime/src/tools/system/exec-command.ts`: the removed-alias rejection keeps its `unknown field \`…\`` prefix and appends the replacement: `the working directory goes in \`workdir\`` for `cwd`, `the command line goes in \`cmd\`` for `command`.

## Evidence

| check | result |
| --- | --- |
| goal soak run `wf-97c0af73…`: implement children `df1b4ffe…` (11 errors) and `ed3b74d1…` (44 errors), all `unknown field \`cwd\``, then `repeated_failing_call_blocked` and `no_progress_detected` | the motivating failure |
| `run-hermetic-vitest tests/tools/system/exec-command.test.ts` | 21 of 22 pass, including the new case; "returns a session id for live PTY commands and write_stdin can resume it" fails identically on unmodified `main` on this Mac (PTY environment), not related |

## Tests

`tests/tools/system/exec-command.test.ts`: a call with `cwd` is rejected with a message that names `workdir`; a call with `command` is rejected with a message that names `cmd`.

## Not changed

The aliases stay rejected; the schema and the `workdir` handling are untouched.

## Counterparts

Soak findings F28; #2168 and #2170 (the fixes that let the goal reach this point).
