### PR TITLE
workflow: journal the child run id so a restarted goal ends instead of running forever; run.cancel closes runs no pipeline drives

### DIFF
--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -209,6 +209,15 @@ import type { CodePredictionService } from "../services/code-prediction/service.
  */
 export interface AgenCDaemonWorkflowStartService {
   startRun(params: RunStartParams): Promise<RunStartResult>;
+  /**
+   * Closes a workflow run's projection when run.cancel finds no live
+   * pipeline for it. Optional: older wirings without it keep the previous
+   * behaviour (agents-rail cancel only).
+   */
+  cancelDetachedRun?(params: {
+    readonly runId: string;
+    readonly reason: string;
+  }): string | Promise<string>;
 }
 
 export interface AgenCDaemonConnectionInitializeState {
@@ -968,13 +977,18 @@ export class AgenCDaemonJsonRpcDispatcher {
           id,
           await this.#runInspection.evidence(validateRunEvidenceParams(params)),
         );
-      case "run.cancel":
-        return successResponse(
-          id,
-          await this.#agentManager.cancelRunTree(
-            validateRunCancelParams(params),
-          ),
-        );
+      case "run.cancel": {
+        const cancelParams = validateRunCancelParams(params);
+        const result = await this.#agentManager.cancelRunTree(cancelParams);
+        // A workflow run with no live pipeline has nothing observing the
+        // cancellation cascade; close its projection so run.status agrees
+        // with the cancel that just succeeded.
+        await this.#workflow?.cancelDetachedRun?.({
+          runId: cancelParams.runId,
+          reason: cancelParams.reason ?? "run.cancel",
+        });
+        return successResponse(id, result);
+      }
       case "run.start":
         if (this.#workflow === undefined) {
           return methodNotImplementedResponse(id, method);

--- a/runtime/src/app-server/workflow/run-start-service.ts
+++ b/runtime/src/app-server/workflow/run-start-service.ts
@@ -15,6 +15,7 @@ import type {
 } from "../protocol/index.js";
 import type { AgenCStateAgentRunRecord } from "../../state/agent-runs.js";
 import {
+  type WorkflowDetachedCancelOutcome,
   VerifiedChangeWorkflowController,
   WorkflowIntakeError,
   type WorkflowStartParams,
@@ -76,6 +77,14 @@ export class DaemonWorkflowStartService {
   constructor(options: DaemonWorkflowStartServiceOptions) {
     this.#options = options;
     this.#now = options.now ?? (() => new Date());
+  }
+
+  /** See VerifiedChangeWorkflowController.cancelDetached. */
+  cancelDetachedRun(params: {
+    readonly runId: string;
+    readonly reason: string;
+  }): WorkflowDetachedCancelOutcome {
+    return this.#options.controller.cancelDetached(params.runId, params.reason);
   }
 
   async startRun(params: RunStartParams): Promise<RunStartResult> {

--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -430,6 +430,9 @@ class SessionWorkflowJournal implements WorkflowRunJournal {
       intentDigest: input.intentDigest,
       attempt: parseWorkflowStepId(input.stepId)?.attempt ?? 1,
       recordedAt: input.intentAt,
+      ...(input.childRunId !== undefined
+        ? { childRunId: input.childRunId }
+        : {}),
     };
     const event = this.#emitDurable(
       { type: "effect_intent", payload },

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -403,6 +403,17 @@ const EVIDENCE_MESSAGE_LIMIT = 20_000;
 // Internal control flow
 // ---------------------------------------------------------------------------
 
+/** Outcome of closing a run that no live pipeline is driving (see cancelDetached). */
+export type WorkflowDetachedCancelOutcome =
+  | "live"
+  | "not_a_workflow"
+  | "already_terminal"
+  | "cancelled"
+  | "not_recorded";
+
+/** Event id prefix for terminals recorded without a session journal. */
+const WORKFLOW_DETACHED_TERMINAL_EVENT_PREFIX = "workflow-detached-terminal:";
+
 interface WorkflowTerminalIntent {
   readonly status: RunTerminalStatus;
   readonly stopReason: WorkflowStopReason | null;
@@ -655,12 +666,88 @@ export class VerifiedChangeWorkflowController {
         if (started) resumed.push(runId);
       } catch (error) {
         if (error instanceof M5WorkflowFailpointError) throw error;
-        this.#deps.warn(
-          `workflow resume failed for ${runId}: ${errorMessage(error)}`,
+        const message = errorMessage(error);
+        this.#deps.warn(`workflow resume failed for ${runId}: ${message}`);
+        // Nothing is driving this run any more and, when the journal itself
+        // failed to open, nothing can journal through its session. Left as
+        // it is, the run reads "running" forever and run.cancel cannot reach
+        // it (a goal that survived a daemon restart used to do exactly
+        // that). Close it durably as failed instead.
+        this.#recordDetachedTerminal(
+          repo,
+          runId,
+          "failed",
+          `workflow resume failed after a daemon restart: ${message}. Any worktree the run created is left in place for review; re-submit the request to continue the work.`,
         );
       }
     }
     return resumed;
+  }
+
+  /**
+   * `run.cancel` reaches a live pipeline through the admission cascade, which
+   * the pipeline observes and terminalizes as cancelled. A run with no live
+   * pipeline in this process (its resume failed, or the process that ran it
+   * is gone) has nothing observing that cascade: the agents-rail row turns
+   * cancelled while the workflow projection stays "running". Close the
+   * projection directly so status and cancel agree.
+   */
+  cancelDetached(runId: string, reason: string): WorkflowDetachedCancelOutcome {
+    if (this.#active.has(runId)) return "live";
+    const repo = this.#deps.durability({ runId });
+    if (repo.getEffect(runId, "workflow.intake") === undefined) {
+      return "not_a_workflow";
+    }
+    if (repo.getCurrentTerminalResult(runId) !== undefined) {
+      return "already_terminal";
+    }
+    return this.#recordDetachedTerminal(
+      repo,
+      runId,
+      "cancelled",
+      `cancelled by run.cancel (${reason}); the run had no live pipeline`,
+    )
+      ? "cancelled"
+      : "not_recorded";
+  }
+
+  /**
+   * Durable-only terminal for a run without a live writer, the same offline
+   * authority run.cancel and child terminals already use. Never throws: a
+   * failure here is logged and the caller reports it, because the run is
+   * already beyond any journal this process can open.
+   */
+  #recordDetachedTerminal(
+    repo: StateRunDurabilityRepository,
+    runId: string,
+    status: "failed" | "cancelled",
+    finalMessage: string,
+  ): boolean {
+    try {
+      if (repo.getCurrentTerminalResult(runId) !== undefined) return true;
+      const epoch = repo.currentEpoch(runId)?.epoch;
+      if (epoch === undefined) return false;
+      repo.recordTerminalResult({
+        epoch,
+        eventId: `${WORKFLOW_DETACHED_TERMINAL_EVENT_PREFIX}${runId}:${epoch}`,
+        result: {
+          runId,
+          status,
+          exitCode: 1,
+          stopReason: null,
+          finalMessage,
+          usage: null,
+          lastSequence: null,
+          finishedAt: this.#nowIso(),
+        },
+      });
+      return true;
+    } catch (error) {
+      this.#deps.warn(
+        `workflow ${runId} could not record its ${status} terminal: ${errorMessage(error)}`,
+      );
+      return false;
+    }
   }
 
   async #resumeRun(

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -463,6 +463,14 @@ export interface EffectIntentEvent {
   readonly intentDigest: string;
   readonly attempt: number;
   readonly recordedAt: string;
+  /**
+   * The subordinate run that executes this step (a workflow's plan or
+   * implement child). Absent when the effect belongs to the journaling
+   * session itself. Projected to `run_effects.child_run_id`; a replay that
+   * drops it rebuilds a different intent identity, which is how a resumed
+   * workflow used to die on its own history.
+   */
+  readonly childRunId?: string;
 }
 
 /**

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -2974,13 +2974,18 @@ export class RolloutStore {
         projection === undefined
           ? this.requireRunEpoch(payload.runId)
           : { epoch: projection.epoch };
+      // The journaled child run id wins: a workflow session journals its
+      // plan/implement steps on behalf of a subordinate run, and a replay
+      // that derived the child from the session id alone rebuilt those
+      // intents without it and conflicted with the live projection.
+      const childRunId =
+        payload.childRunId ??
+        (this.sessionId !== payload.runId ? this.sessionId : undefined);
       this.runDurabilityRepo.beginEffect({
         runId: payload.runId,
         epoch: epoch.epoch,
         stepId: payload.stepId,
-        ...(this.sessionId !== payload.runId
-          ? { childRunId: this.sessionId }
-          : {}),
+        ...(childRunId !== undefined ? { childRunId } : {}),
         sessionId: this.sessionId,
         callId: payload.callId,
         toolName: payload.toolName,

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -978,6 +978,7 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
       formatVersion: literal(2),
       minimumReaderRuntime: isString,
       idempotencyKey: isString,
+      childRunId: isString,
     },
   ),
   effect_result: objectShape(

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -1211,6 +1211,19 @@ export class StateRunDurabilityRepository {
         if (effectIntentContent(existing) === effectIntentContent(params)) {
           return { applied: false, value: existing };
         }
+        // Rollouts written before effect_intent carried childRunId replay a
+        // child-backed step without it while the row projected live has it.
+        // Same event, same sequence, same digest: accept the replay rather
+        // than strand the run on its own history.
+        if (
+          params.projection === "canonical_replay" &&
+          params.childRunId === undefined &&
+          existing.childRunId !== undefined &&
+          effectIntentContent(existing) ===
+            effectIntentContent({ ...params, childRunId: existing.childRunId })
+        ) {
+          return { applied: false, value: existing };
+        }
         throw conflict(
           "RUN_EFFECT_INTENT_CONFLICT",
           `run ${params.runId} step ${params.stepId} already has a different effect intent`,

--- a/runtime/src/state/startup-run-journal-recovery.ts
+++ b/runtime/src/state/startup-run-journal-recovery.ts
@@ -1774,11 +1774,16 @@ function projectEffectIntent(
   const category = requireRecoveryCategory(payload.recoveryCategory);
   const sessionId = row.thread_id;
   const idempotencyKey = optionalString(payload.idempotencyKey);
+  // Same rule as RolloutStore.recordEffectEvent: the journaled child run id
+  // is the step's identity; the session id only stands in when absent.
+  const childRunId =
+    optionalString(payload.childRunId) ??
+    (sessionId !== runId ? sessionId : undefined);
   repository.beginEffect({
     runId,
     epoch,
     stepId: requireString(payload.stepId, "stepId"),
-    ...(sessionId !== runId ? { childRunId: sessionId } : {}),
+    ...(childRunId !== undefined ? { childRunId } : {}),
     sessionId,
     callId: requireString(payload.callId, "callId"),
     toolName: requireString(payload.toolName, "toolName"),

--- a/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
+++ b/runtime/tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts
@@ -5,7 +5,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
-import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
+import {
+  AgenCDaemonJsonRpcDispatcher,
+  type AgenCDaemonWorkflowStartService,
+} from "./daemon-dispatcher.js";
 import {
   AGENC_DAEMON_METHOD_CAPABILITIES_KEY,
   JSON_RPC_VERSION,
@@ -42,6 +45,7 @@ async function dispatchRunCancel(options: {
   readonly live?: boolean;
   readonly stopError?: Error;
   readonly liveTerminal?: AgenCBackgroundAgentTerminalSnapshot;
+  readonly workflow?: AgenCDaemonWorkflowStartService;
 }) {
   const order: string[] = [];
   const cancelDurable = vi.fn(async () => {
@@ -124,7 +128,10 @@ async function dispatchRunCancel(options: {
       sessionIds: [options.report.runId],
     });
   }
-  const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager });
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({
+    agentManager,
+    ...(options.workflow !== undefined ? { workflow: options.workflow } : {}),
+  });
   const connection = dispatcher.createConnection({
     sendNotification: () => {},
   });
@@ -147,6 +154,47 @@ async function dispatchRunCancel(options: {
 }
 
 describe("run.cancel dispatcher contract", () => {
+  it("closes a workflow run's projection after the tree cancel when no pipeline is live", async () => {
+    const order: string[] = [];
+    const cancelDetachedRun = vi.fn(
+      (params: { readonly runId: string; readonly reason: string }) => {
+        order.push(`workflow_projection:${params.runId}:${params.reason}`);
+        return "cancelled";
+      },
+    );
+    const harness = await dispatchRunCancel({
+      report: cancelledReport("wf_a"),
+      workflow: { startRun: vi.fn(), cancelDetachedRun },
+    });
+    harness.cancelDurable.mockImplementation(async () => {
+      order.push("db_cascade");
+      return cancelledReport("wf_a");
+    });
+    const response = await harness.connection.dispatch(
+      request("rc-wf", "run.cancel", { runId: "wf_a", reason: "operator" }),
+    );
+    expect(response).toMatchObject({
+      result: { runId: "wf_a", cancelledRunIds: ["wf_a", "wf_a_child"] },
+    });
+    // The projection closes only after the durable cascade converged.
+    expect(order).toEqual(["db_cascade", "workflow_projection:wf_a:operator"]);
+  });
+
+  it("defaults the reason handed to the workflow projection", async () => {
+    const cancelDetachedRun = vi.fn(() => "already_terminal");
+    const harness = await dispatchRunCancel({
+      report: cancelledReport("wf_b"),
+      workflow: { startRun: vi.fn(), cancelDetachedRun },
+    });
+    await harness.connection.dispatch(
+      request("rc-wf2", "run.cancel", { runId: "wf_b" }),
+    );
+    expect(cancelDetachedRun).toHaveBeenCalledWith({
+      runId: "wf_b",
+      reason: "run.cancel",
+    });
+  });
+
   it("advertises the capability and routes to the tree-scoped cancel", async () => {
     const harness = await dispatchRunCancel({
       report: cancelledReport("run_a"),

--- a/runtime/tests/session/rollout-store.test.ts
+++ b/runtime/tests/session/rollout-store.test.ts
@@ -21,6 +21,7 @@ import type { Session } from "./session.js";
 import type { AgentMetadata } from "../agents/registry.js";
 import { upsertAgentRun } from "../state/agent-runs.js";
 import { createOperatorEffectReviewResolution } from "../state/effect-review.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
 import {
   openStateDatabases,
   resolveStateDatabasePaths,
@@ -1739,6 +1740,72 @@ describe("RolloutStore thread-spawn edges", () => {
         status: "open",
       });
       expect(existsSync(snapshotPath)).toBe(true);
+    } finally {
+      store.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("RolloutStore effect_intent childRunId", () => {
+  it("projects the journaled childRunId and accepts a legacy replay that lacks it", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-store-cwd-"));
+    const sessionId = "workflow-child-run-id";
+    const childRunId = `${sessionId}:plan#1`;
+    const store = openStore({ cwd, sessionId });
+    const payload = {
+      formatVersion: 2 as const,
+      minimumReaderRuntime: "0.14.0",
+      runId: sessionId,
+      stepId: "workflow.plan",
+      callId: "workflow.plan",
+      toolName: "workflow.plan",
+      recoveryCategory: "side-effecting" as const,
+      intentDigest: "digest-plan",
+      attempt: 1,
+      recordedAt: "2026-08-19T00:00:00.000Z",
+      childRunId,
+    };
+    const intent: Event = {
+      eventId: "event:1",
+      id: "event:1",
+      seq: 1,
+      msg: { type: "effect_intent", payload },
+    };
+    try {
+      expect(store.append(intent, { durable: true })).toBe(true);
+      store.recordEffectEvent(intent);
+      const driver = openStateDatabases({ cwd });
+      try {
+        const repo = new StateRunDurabilityRepository(driver);
+        expect(repo.getEffect(sessionId, "workflow.plan")?.childRunId).toBe(
+          childRunId,
+        );
+      } finally {
+        driver.close();
+      }
+      // A rollout written before effect_intent carried childRunId replays the
+      // same event without it; the live projection row must not conflict.
+      const { childRunId: _dropped, ...legacyPayload } = payload;
+      expect(() =>
+        store.recordEffectEvent(
+          { ...intent, msg: { type: "effect_intent", payload: legacyPayload } },
+          { epoch: 1, canonicalReplay: true },
+        ),
+      ).not.toThrow();
+      // Anything else that differs is still the conflict it always was.
+      expect(() =>
+        store.recordEffectEvent(
+          {
+            ...intent,
+            msg: {
+              type: "effect_intent",
+              payload: { ...legacyPayload, intentDigest: "digest-other" },
+            },
+          },
+          { epoch: 1, canonicalReplay: true },
+        ),
+      ).toThrow(/different effect intent/);
     } finally {
       store.close();
       rmSync(cwd, { recursive: true, force: true });

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -493,6 +493,29 @@ describe("strict canonical journal contract", () => {
     },
   );
 
+  it("validates the optional effect_intent childRunId as a string", () => {
+    const intent = (childRunId: unknown) =>
+      validEvent(1, "effect_intent", {
+        formatVersion: 2,
+        minimumReaderRuntime: "0.14.0",
+        runId: "run-1",
+        stepId: "workflow.plan",
+        callId: "workflow.plan",
+        toolName: "workflow.plan",
+        recoveryCategory: "side-effecting",
+        intentDigest: "intent-digest",
+        attempt: 1,
+        recordedAt: "2026-08-19T00:00:00.000Z",
+        childRunId,
+      });
+    expect(() =>
+      validateCanonicalJournalText(intent("run-1:plan#1")),
+    ).not.toThrow(expect.objectContaining({ reasonCode: "schema_invalid" }));
+    expect(() => validateCanonicalJournalText(intent(7))).toThrow(
+      expect.objectContaining({ reasonCode: "schema_invalid" }),
+    );
+  });
+
   it("rejects invalid payloads for known event variants", () => {
     expect(() =>
       validateCanonicalJournalText(validEvent(1, "agent_message", {})),

--- a/runtime/tests/state/run-durability.test.ts
+++ b/runtime/tests/state/run-durability.test.ts
@@ -122,6 +122,38 @@ function beginSideEffect(stepId = "step-write", sequence = 1) {
 }
 
 describe("StateRunDurabilityRepository", () => {
+  it("accepts a canonical replay of a child-backed intent journaled before childRunId existed", () => {
+    runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
+    const live = beginSideEffect("workflow.plan");
+    expect(live.value.childRunId).toBe("child-1");
+    const legacy = {
+      runId: "run-1",
+      epoch: 1,
+      stepId: "workflow.plan",
+      sessionId: "session-1",
+      toolName: "FileWrite",
+      recoveryCategory: "side-effecting" as const,
+      intentDigest: "sha256:intent:workflow.plan",
+      eventId: "event-intent-workflow.plan",
+      eventSequence: 1,
+      intentAt: T0,
+    };
+    // Same event, same sequence, same digest: the replay adopts the row.
+    const replayed = runs.beginEffect({ ...legacy, projection: "canonical_replay" });
+    expect(replayed.applied).toBe(false);
+    expect(replayed.value.childRunId).toBe("child-1");
+    // The tolerance is for replays only; a live writer dropping the child is
+    // a different intent, and so is a replay that differs in anything else.
+    expect(() => runs.beginEffect(legacy)).toThrow(RunDurabilityConflictError);
+    expect(() =>
+      runs.beginEffect({
+        ...legacy,
+        intentDigest: "sha256:intent:other",
+        projection: "canonical_replay",
+      }),
+    ).toThrow(/different effect intent/);
+  });
+
   it("records a single exact suspension and resumes it in the same epoch", () => {
     runs.ensureInitialEpoch({ runId: "run-1", openedAt: T0 });
     const suspended = runs.recordRunSuspended({

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -486,6 +486,8 @@ interface Harness {
   ledgers: Map<string, MemoryLedger>;
   warnings: string[];
   controller: VerifiedChangeWorkflowController;
+  /** Test seams: `failJournalOpenWith` makes the next journal open throw. */
+  hooks: { failJournalOpenWith?: Error };
   cleanup(): void;
 }
 
@@ -505,9 +507,17 @@ function makeHarness(): Harness {
   spawner.durableRepo = repo;
   const ledgers = new Map<string, MemoryLedger>();
   const warnings: string[] = [];
+  const hooks: Harness["hooks"] = {};
   const controller = new VerifiedChangeWorkflowController({
     durability: () => repo,
-    journal: { open: async (runId) => new TestJournal(repo, runId) },
+    journal: {
+      open: async (runId) => {
+        if (hooks.failJournalOpenWith !== undefined) {
+          throw hooks.failJournalOpenWith;
+        }
+        return new TestJournal(repo, runId);
+      },
+    },
     admission: ({ runId }) => {
       admission.scope.runId = runId;
       return admission;
@@ -539,6 +549,7 @@ function makeHarness(): Harness {
     ledgers,
     warnings,
     controller,
+    hooks,
     cleanup: () => {
       driver.close();
       rmSync(home, { recursive: true, force: true });
@@ -1281,5 +1292,76 @@ describe("VerifiedChangeWorkflowController — child usage rollup", () => {
       totalTokens: 67,
       costUsd: 0.875,
     });
+  });
+});
+
+describe("VerifiedChangeWorkflowController — runs with no live pipeline", () => {
+  async function interruptBeforeWorktree(): Promise<void> {
+    armFailpoint("before_worktree_provision");
+    const started = await harness.controller.start(startParams(harness));
+    await expect(harness.controller.awaitRun(started.runId)).rejects.toThrow(
+      /failpoint/,
+    );
+    disarmFailpoint();
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toBeUndefined();
+  }
+
+  it("closes a run whose resume fails as failed instead of leaving it running", async () => {
+    await interruptBeforeWorktree();
+    harness.hooks.failJournalOpenWith = new Error(
+      `run ${RUN_ID} step workflow.plan already has a different effect intent`,
+    );
+    await expect(harness.controller.resumeOpenWorkflows()).resolves.toEqual([]);
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID);
+    expect(terminal).toMatchObject({
+      status: "failed",
+      exitCode: 1,
+      stopReason: null,
+    });
+    expect(terminal?.finalMessage).toContain(
+      "workflow resume failed after a daemon restart",
+    );
+    expect(terminal?.finalMessage).toContain("different effect intent");
+    expect(
+      harness.warnings.some((w) =>
+        w.startsWith(`workflow resume failed for ${RUN_ID}:`),
+      ),
+    ).toBe(true);
+    // Terminal runs are skipped by the next sweep.
+    delete harness.hooks.failJournalOpenWith;
+    await expect(harness.controller.resumeOpenWorkflows()).resolves.toEqual([]);
+  });
+
+  it("cancelDetached closes a run with no live pipeline and reports everything else honestly", async () => {
+    await interruptBeforeWorktree();
+    expect(harness.controller.cancelDetached("run-unknown", "run.cancel")).toBe(
+      "not_a_workflow",
+    );
+    expect(harness.controller.cancelDetached(RUN_ID, "operator")).toBe(
+      "cancelled",
+    );
+    const terminal = harness.repo.getCurrentTerminalResult(RUN_ID);
+    expect(terminal).toMatchObject({
+      status: "cancelled",
+      exitCode: 1,
+      stopReason: null,
+    });
+    expect(terminal?.finalMessage).toContain("run.cancel (operator)");
+    expect(terminal?.finalMessage).toContain("no live pipeline");
+    expect(harness.controller.cancelDetached(RUN_ID, "operator")).toBe(
+      "already_terminal",
+    );
+    await expect(harness.controller.resumeOpenWorkflows()).resolves.toEqual([]);
+  });
+
+  it("cancelDetached leaves a live pipeline to the admission cascade", async () => {
+    const started = await harness.controller.start(startParams(harness));
+    expect(harness.controller.cancelDetached(started.runId, "operator")).toBe(
+      "live",
+    );
+    await harness.controller.awaitRun(started.runId);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
   });
 });


### PR DESCRIPTION
## Why

During the desktop app soak a goal run (`wf-454d3ccc`, verified-change workflow on grok-4.6) was in its implement stage when the daemon restarted. It never resumed and never ended: `run.status` and the app's goal panel read `running` for hours at $4.02 and 3.1M tokens, `run.cancel` returned success, the agents-rail row turned `cancelled`, and the workflow projection still said `running`. The stop button did nothing the user could see.

The daemon's own log had the cause in one line: `workflow resume failed for wf-454d3ccc…: run … step workflow.plan already has a different effect intent`.

Three defects stack up here:

1. **The journal loses the child run id.** `SessionWorkflowJournal.appendIntent` projects the step with `childRunId` (the plan or implement child, `wf-…:plan#1`) into `run_effects`, but the `effect_intent` event it writes to the rollout has no such field. On resume the bootstrap re-opens the rollout and `RolloutStore.recordEffectEvent` replays every effect event; it derives the child from the session id, which equals the run id for a workflow session, so the replayed plan intent has no child. `effectIntentContent` compares `childRunId`, `beginEffect` raises `RUN_EFFECT_INTENT_CONFLICT`, and the throw escapes `journal.open` before any pipeline exists. Intake and worktree replay fine because they have no child. Every goal that gets past planning and then meets a daemon restart hits this.
2. **A failed resume leaves the run open.** `resumeOpenWorkflows` catches the error and warns. Nothing terminalizes the run, so it is neither driven nor closable.
3. **`run.cancel` cannot reach a run without a live pipeline.** The tree cancel is observed by a live pipeline through the admission cascade; a run with no pipeline has nothing observing it. The agents-rail row is cancelled, `run_terminal_results` is not, and `run.status` reads the latter.

## What changed

- `runtime/src/session/event-log.ts`: `EffectIntentEvent.childRunId?: string`, documented as the step's subordinate run.
- `runtime/src/state/recovery-journal-schema.ts`: the strict reader accepts `childRunId` as an optional string on `effect_intent` (unknown fields were already additive; this validates the type).
- `runtime/src/app-server/workflow/session-adapters.ts`: `appendIntent` writes `childRunId` into the journaled payload when the controller passes one.
- `runtime/src/session/rollout-store.ts` and `runtime/src/state/startup-run-journal-recovery.ts`: both replays prefer the journaled `childRunId` and fall back to the previous session-id rule.
- `runtime/src/state/run-durability.ts`: `beginEffect` accepts a `canonical_replay` of an intent that lacks only the child id while the projected row has one and everything else is identical. Rollouts written before this change still resume. A live writer dropping the child, or any other difference, conflicts exactly as before.
- `runtime/src/app-server/workflow/verified-change-controller.ts`: a resume that throws now records a `failed` terminal straight into the durability repository (`#recordDetachedTerminal`, the same durable-only authority `run.cancel` and child terminals already use for runs with no live writer) with the cause in the final message. New `cancelDetached(runId, reason)` closes a run with no live pipeline as `cancelled` and reports `live`, `not_a_workflow`, `already_terminal` or `not_recorded` otherwise.
- A resumed run then follows the existing D3 rules: a child whose durable terminal exists is adopted; a child that died with the daemon ends the run `unknown_outcome_effect`. The point of this PR is that the run ends and says why, instead of reading `running` forever.
- `runtime/src/app-server/workflow/run-start-service.ts`: `cancelDetachedRun` pass-through.
- `runtime/src/app-server/daemon-dispatcher.ts`: the optional `cancelDetachedRun` on the workflow service; `run.cancel` calls it after the tree cancel and still returns the tree-cancel result unchanged. No protocol change.

## Evidence

| check | result |
| --- | --- |
| zombie run's rows | `run_effects.child_run_id` is `wf-…:plan#1` / `wf-…:implement#1` on the plan and implement rows; the rollout's `effect_intent` payloads for the same events have no `childRunId`; intake and worktree rows have no child and replayed without conflict |
| `daemon-spawn-stderr.log` | `workflow resume failed for wf-454d3ccc-…: run … step workflow.plan already has a different effect intent` |
| `agent_runs` vs `run_terminal_results` after `run.cancel` | agents-rail row `cancelled` at 10:27:24, no terminal row, `run.status` still `running` |
| `tsc --noEmit` on the branch | no errors beyond this Mac's known worktree declaration quirk (TS2883 lodash paths, present on unmodified main) |
| targeted suites (rollout-store, recovery-journal-contract, run-durability, verified-change-controller, daemon-dispatcher run-cancel, daemon-wiring, run-start, event-log) | 182 passed |
| live: daemon restarted on this build with the zombie's real database and rollout | the boot sweep resumed `wf-454d3ccc` through the previously conflicting replay and ended it at 11:18:06 as `unknown_outcome` / `unknown_outcome_effect`, "implement step workflow.implement has an unresolved unknown outcome"; no resume warning in `daemon-spawn-stderr.log` |
| live: fresh goal through the desktop app on this build, daemon SIGKILLed while `workflow.implement` was running (the F31 condition) | the app autostarted a daemon in 2 s; its boot sweep resumed `wf-74cdbd93` and ended it 23 s after the kill as `unknown_outcome` / `unknown_outcome_effect`; the plan row carries `child_run_id`, the new rollout's `effect_intent` carries `childRunId`, no resume warning; the app shows "Goal run unknown_outcome: unknown_outcome_effect" |
| durability + recovery + workflow suites | the only failures are the 15 SIGKILL failure-matrix cases and the 5 M5 crash-restart / evidence-reconstruction cases, all failing identically on unmodified main with `a pinned platform protection verifier is required for darwin`; same set, same messages |

## Tests

- `tests/session/rollout-store.test.ts`: a journaled `childRunId` reaches `run_effects.child_run_id`; a replay of the same event without the field does not throw; a replay that differs in the digest still throws `different effect intent`.
- `tests/state/run-durability.test.ts`: the tolerance is replay-only and narrow: a live re-append without the child conflicts, a replay differing in anything else conflicts.
- `tests/state/recovery-journal-contract.test.ts`: `childRunId` validates as a string and a number is `schema_invalid`.
- `tests/workflow/verified-change-controller.test.ts`: a resume whose journal open throws closes the run `failed` with the cause in the message and a warning, and the next sweep skips it; `cancelDetached` returns `not_a_workflow`, `cancelled` (terminal `cancelled`, exit 1, message names `run.cancel` and the missing pipeline), `already_terminal`, and `live` for a pipeline still in flight, which then completes normally.
- `tests/app-server/daemon-dispatcher.run-cancel.contract.test.ts`: `run.cancel` calls the workflow hook after the durable cascade with the request's reason, defaults the reason to `run.cancel`, and the response is the unchanged tree-cancel result.

## Not changed

- Protocol schema, `RunCancelResult`, stop-reason list: the resume-failure and detached-cancel terminals use `stopReason: null` with a descriptive `finalMessage`, like the existing intake-interrupted terminal.
- The live-pipeline cancel path (admission cascade) and its test.
- Existing rollouts: legacy intents replay under the tolerance rule; nothing is rewritten.
- The desktop app: it already calls `run.cancel` from the stop button (desktop #177); with this change the goal panel sees the run end.

## Counterparts

Found by the app soak (`docs/eval/app-soak-2026-09-05.md`, finding F31, report PR to follow). Related: #2168 (resume scope), #2170 (darwin platform protection at intake), desktop #177 (stop button cancels a goal run).
