### PR TITLE
wait_agent: fail after consecutive timeouts with the agents' status instead of polling forever

### DIFF
--- a/runtime/src/agents/v2/common.ts
+++ b/runtime/src/agents/v2/common.ts
@@ -30,6 +30,12 @@ import { validationErrorToolResult } from "../../tools/results.js";
 export const MIN_WAIT_TIMEOUT_MS = 10_000;
 export const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
 export const MAX_WAIT_TIMEOUT_MS = 3_600_000;
+/**
+ * Default number of consecutive timed-out `wait_agent` calls before the tool
+ * stops answering "timed out" and fails with a decision request. Four waits
+ * at the default timeout is two minutes of polling with nothing to show.
+ */
+export const DEFAULT_MAX_CONSECUTIVE_WAIT_TIMEOUTS = 4;
 
 /**
  * Shared evidence ref for agent-tool argument/identity refusals produced

--- a/runtime/src/agents/v2/wait.ts
+++ b/runtime/src/agents/v2/wait.ts
@@ -1,7 +1,9 @@
 import type { Tool, ToolResult } from "../../tools/types.js";
+import type { Session } from "../../session/session.js";
 import {
   callIdFromArgs,
   currentAgentContext,
+  DEFAULT_MAX_CONSECUTIVE_WAIT_TIMEOUTS,
   DEFAULT_WAIT_TIMEOUT_MS,
   emit,
   getSessionOrError,
@@ -12,9 +14,50 @@ import {
   MIN_WAIT_TIMEOUT_MS,
   numberValue,
   strictArgs,
+  toListedAgentJson,
   toolMetadata,
   type MultiAgentV2Options,
 } from "./common.js";
+
+/**
+ * Consecutive timed-out waits with no mailbox update in between, per
+ * session. A wait that completes clears it. Kept off the session object so
+ * the tool needs nothing new from the runtime; the WeakMap dies with the
+ * session.
+ */
+interface WaitTimeoutStreak {
+  consecutive: number;
+  waitedMs: number;
+}
+const waitTimeoutStreaks = new WeakMap<object, WaitTimeoutStreak>();
+
+function maxConsecutiveWaitTimeouts(session: {
+  readonly config?: {
+    readonly multiAgentV2?: { readonly maxConsecutiveWaitTimeouts?: number };
+  };
+}): number {
+  const configured = configuredTimeoutOption(
+    session.config?.multiAgentV2?.maxConsecutiveWaitTimeouts,
+    DEFAULT_MAX_CONSECUTIVE_WAIT_TIMEOUTS,
+  );
+  return Math.max(1, configured);
+}
+
+function liveAgentsForDecision(
+  session: Session,
+  opts: MultiAgentV2Options,
+): ReturnType<typeof toListedAgentJson>[] {
+  try {
+    const { control } = opts.ensureAgentControl(session);
+    control.registerSessionRoot(session.conversationId);
+    return control
+      .listAgents()
+      .filter((agent) => agent.agentName !== "/root")
+      .map(toListedAgentJson);
+  } catch {
+    return [];
+  }
+}
 
 function waitTimeoutMs(
   args: Record<string, unknown>,
@@ -194,11 +237,49 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
         ...(updates.length > 0 ? { mailboxUpdates: updates } : {}),
       },
     });
-    return json({
-      message: timedOut ? "Wait timed out." : "Wait completed.",
-      timed_out: timedOut,
-      ...(updates.length > 0 ? { updates } : {}),
-    });
+    if (!timedOut) {
+      waitTimeoutStreaks.delete(sessionOrError);
+      return json({
+        message: "Wait completed.",
+        timed_out: false,
+        ...(updates.length > 0 ? { updates } : {}),
+      });
+    }
+    const streak = waitTimeoutStreaks.get(sessionOrError) ?? {
+      consecutive: 0,
+      waitedMs: 0,
+    };
+    streak.consecutive += 1;
+    streak.waitedMs += timeoutMs;
+    waitTimeoutStreaks.set(sessionOrError, streak);
+    const limit = maxConsecutiveWaitTimeouts(sessionOrError);
+    if (streak.consecutive < limit) {
+      return json({
+        message: "Wait timed out.",
+        timed_out: true,
+        consecutive_timeouts: streak.consecutive,
+        waited_ms: streak.waitedMs,
+      });
+    }
+    // Polling on is the one thing that cannot help: nothing arrived in
+    // `limit` waits. Fail the call so the model decides, and hand it the
+    // agents' status so it does not need another list_agents to do so.
+    const waitedSeconds = Math.round(streak.waitedMs / 1000);
+    return json(
+      {
+        error:
+          `wait_agent has timed out ${streak.consecutive} times in a row ` +
+          `(${waitedSeconds} s) with no mailbox update. Do not call it again ` +
+          `the same way. Decide: wait once more with a deadline you can afford ` +
+          `(timeout_ms up to ${maxTimeoutMs}), close the agent with close_agent, ` +
+          `or continue the task without its result and say so.`,
+        timed_out: true,
+        consecutive_timeouts: streak.consecutive,
+        waited_ms: streak.waitedMs,
+        agents: liveAgentsForDecision(sessionOrError, opts),
+      },
+      true,
+    );
   };
 
   return {
@@ -207,7 +288,9 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
       "Wait for a mailbox update from any live agent, including queued messages " +
       "and final-status notifications. When updates arrive, returns the drained " +
       "mailbox content so you can report completed agent findings immediately. " +
-      "If no mailbox update arrives before the deadline, returns a timeout summary.",
+      "If no mailbox update arrives before the deadline, returns a timeout summary. " +
+      "After several consecutive timeouts with no update the call fails and asks " +
+      "you to decide (wait with a longer deadline, close the agent, or continue without it).",
     metadata: toolMetadata("agent", {
       mutating: true,
       virtualNoFsWrites: true,

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -6169,6 +6169,7 @@ function deriveMinimalSessionConfig(
       minWaitTimeoutMs: 10_000,
       defaultWaitTimeoutMs: 30_000,
       maxWaitTimeoutMs: 3_600_000,
+      maxConsecutiveWaitTimeouts: 4,
       usageHintEnabled: false,
       usageHintText: "",
       hideSpawnAgentMetadata: false,

--- a/runtime/src/session/turn-context.ts
+++ b/runtime/src/session/turn-context.ts
@@ -480,6 +480,12 @@ export interface Config {
     readonly minWaitTimeoutMs?: number;
     readonly defaultWaitTimeoutMs?: number;
     readonly maxWaitTimeoutMs?: number;
+    /**
+     * Consecutive timed-out `wait_agent` calls (no mailbox update in between)
+     * after which the wait fails and asks the model to decide instead of
+     * polling on. Minimum 1.
+     */
+    readonly maxConsecutiveWaitTimeouts?: number;
     readonly usageHintEnabled: boolean;
     readonly usageHintText: string;
     readonly rootAgentUsageHintText?: string;

--- a/runtime/tests/agents/v2/wait.test.ts
+++ b/runtime/tests/agents/v2/wait.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Session } from "../../session/session.js";
+import { createWaitAgentTool } from "./wait.js";
+import type { MultiAgentV2Options } from "./common.js";
+
+function fixture(options?: {
+  readonly maxConsecutiveWaitTimeouts?: number;
+  readonly conversationId?: string;
+}) {
+  const waitForMailboxChange = vi.fn(async (_timeoutMs: number) => false);
+  const emit = vi.fn();
+  const session = {
+    conversationId: options?.conversationId ?? "root-session",
+    emit,
+    nextInternalSubId: () => "sub-1",
+    waitForMailboxChange,
+    drainPendingInputMessages: () => [
+      { role: "user", content: "child says: done" },
+    ],
+    config: {
+      multiAgentV2: {
+        minWaitTimeoutMs: 10_000,
+        defaultWaitTimeoutMs: 30_000,
+        maxWaitTimeoutMs: 3_600_000,
+        ...(options?.maxConsecutiveWaitTimeouts !== undefined
+          ? { maxConsecutiveWaitTimeouts: options.maxConsecutiveWaitTimeouts }
+          : {}),
+      },
+    },
+  } as unknown as Session;
+  const registerSessionRoot = vi.fn();
+  const listAgents = vi.fn(() => [
+    {
+      agentName: "/root",
+      agentStatus: { status: "pending_init" as const },
+      lastTaskMessage: "Main thread",
+    },
+    {
+      agentName: "/root/verify_security_md",
+      agentStatus: {
+        status: "running" as const,
+        turnId: "turn-1",
+        startedAtMs: 1,
+      },
+      lastTaskMessage: "verify SECURITY.md",
+    },
+  ]);
+  const opts = {
+    getSession: () => session,
+    workspace: {},
+    ensureAgentControl: () => ({
+      control: { registerSessionRoot, listAgents, getLive: () => undefined },
+      registry: {},
+    }),
+  } as unknown as MultiAgentV2Options;
+  const tool = createWaitAgentTool(opts);
+  return { tool, session, waitForMailboxChange, listAgents, registerSessionRoot };
+}
+
+async function call(tool: ReturnType<typeof createWaitAgentTool>, args = {}) {
+  const result = await tool.execute(args, {} as never);
+  return { ...result, body: JSON.parse(result.content) as Record<string, unknown> };
+}
+
+describe("wait_agent consecutive timeouts", () => {
+  it("counts timed-out waits and fails at the fourth with the agents' status", async () => {
+    const { tool, listAgents } = fixture();
+    for (let n = 1; n <= 3; n += 1) {
+      const result = await call(tool);
+      expect(result.isError).toBeUndefined();
+      expect(result.body).toEqual({
+        message: "Wait timed out.",
+        timed_out: true,
+        consecutive_timeouts: n,
+        waited_ms: 30_000 * n,
+      });
+    }
+    expect(listAgents).not.toHaveBeenCalled();
+    const fourth = await call(tool);
+    expect(fourth.isError).toBe(true);
+    expect(fourth.body).toMatchObject({
+      timed_out: true,
+      consecutive_timeouts: 4,
+      waited_ms: 120_000,
+      agents: [
+        {
+          agent_name: "/root/verify_security_md",
+          last_task_message: "verify SECURITY.md",
+        },
+      ],
+    });
+    const error = fourth.body.error as string;
+    expect(error).toContain("timed out 4 times in a row (120 s)");
+    expect(error).toContain("close_agent");
+    expect(error).toContain("timeout_ms up to 3600000");
+    // A fifth identical call keeps failing, so the tool-loop repeat guard can end the poll.
+    const fifth = await call(tool);
+    expect(fifth.isError).toBe(true);
+    expect(fifth.body).toMatchObject({ consecutive_timeouts: 5 });
+  });
+
+  it("a completed wait clears the streak", async () => {
+    const { tool, waitForMailboxChange } = fixture();
+    await call(tool);
+    await call(tool);
+    await call(tool);
+    waitForMailboxChange.mockResolvedValueOnce(true);
+    const completed = await call(tool);
+    expect(completed.isError).toBeUndefined();
+    expect(completed.body).toEqual({
+      message: "Wait completed.",
+      timed_out: false,
+      updates: [{ role: "user", content: "child says: done" }],
+    });
+    for (let n = 1; n <= 3; n += 1) {
+      const result = await call(tool);
+      expect(result.isError).toBeUndefined();
+      expect(result.body).toMatchObject({ consecutive_timeouts: n });
+    }
+  });
+
+  it("the threshold follows the session config and never drops below one", async () => {
+    const two = fixture({ maxConsecutiveWaitTimeouts: 2 });
+    expect((await call(two.tool)).isError).toBeUndefined();
+    expect((await call(two.tool)).isError).toBe(true);
+    const zero = fixture({ maxConsecutiveWaitTimeouts: 0 });
+    const first = await call(zero.tool);
+    expect(first.isError).toBe(true);
+    expect(first.body).toMatchObject({ consecutive_timeouts: 1 });
+  });
+
+  it("counts the wait the model asked for, not the default", async () => {
+    const { tool } = fixture();
+    const result = await call(tool, { timeout_ms: 60_000 });
+    expect(result.body).toMatchObject({ waited_ms: 60_000 });
+  });
+
+  it("keeps streaks per session", async () => {
+    const a = fixture({ conversationId: "a" });
+    const b = fixture({ conversationId: "b" });
+    for (let n = 0; n < 3; n += 1) await call(a.tool);
+    expect((await call(b.tool)).body).toMatchObject({ consecutive_timeouts: 1 });
+    expect((await call(a.tool)).isError).toBe(true);
+  });
+});

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -4649,6 +4649,8 @@ describe("model-facing tools", () => {
     expect(JSON.parse(result.content)).toEqual({
       message: "Wait timed out.",
       timed_out: true,
+      consecutive_timeouts: 1,
+      waited_ms: 10_000,
     });
     expect(waitForMailboxChange).toHaveBeenCalledWith(10_000);
   });


### PR DESCRIPTION
## Why

Issue #2166. In a 40-prompt desktop soak on grok-4.6 the agent delegated a check to a subagent and then alternated `wait_agent` and `list_agents` for 25 minutes: 180 waits at the default 30 s timeout, each answered `{"message":"Wait timed out.","timed_out":true}`, 162 `list_agents` calls whose output changed slightly every time, so the behavioural backstop never saw an identical run or a stable cycle. The child was working the whole time. Nothing in the runtime ends that poll, and each wait costs a model call.

## What changed

- `runtime/src/agents/v2/wait.ts`: the tool keeps, per session, the streak of consecutive timed-out waits with no mailbox update in between (a `WeakMap` keyed by the session; a completed wait clears it). Every timed-out result now carries `consecutive_timeouts` and `waited_ms`. When the streak reaches the threshold the call fails (`isError: true`) with an error that says how many times and how long it has waited, tells the model not to repeat the call as is, names the three ways out (a longer `timeout_ms` up to the configured maximum, `close_agent`, or continuing without the result), and lists the live agents with their status so no `list_agents` call is needed to decide. Further identical waits keep failing, so the tool loop's repeat guard ends the poll within a few calls. The tool description mentions the escalation.
- `runtime/src/agents/v2/common.ts`: `DEFAULT_MAX_CONSECUTIVE_WAIT_TIMEOUTS = 4` (two minutes at the default timeout).
- `runtime/src/session/turn-context.ts`, `runtime/src/session/session.ts`: `multiAgentV2.maxConsecutiveWaitTimeouts` next to the existing wait timeout options, default 4, floor 1.

## Evidence

| check | result |
| --- | --- |
| soak transcript (F20) | 180 `wait_agent` timeouts and 162 `list_agents` calls over 38 turns and 25 minutes; the child's rollout shows 45 tool calls in that window |
| with this change, the same pattern | the fourth timeout fails the call; the repeat guard refuses the identical failing call after three more; the poll ends in about 3.5 minutes instead of 25 |
| `vitest run tests/agents/v2` | 43 passed (6 files), including the 5 new cases |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/agents/v2/wait.test.ts` (new): three timeouts report the streak without error and the fourth fails with the agents' status, the error text and a fifth failing call; a completed wait clears the streak; the threshold follows the session config and never drops below one; the requested `timeout_ms` is what accumulates; streaks are per session.

## Not changed

- The backstop's result hashing (`normalizeVolatile` stays off): making `list_agents` output hash-stable is a separate detector change with its own false-positive risk. The tool-level escalation ends the loop on its own.
- Wait timeout defaults, minimum and maximum.
- `list_agents`, `close_agent`, the mailbox drain.

## Counterparts

#2166 (this), app soak finding F20; F21 (subagents spawned without the Swarm stance) is separate.
