### PR TITLE
run-agent: pin worktree children through each tool's own working-directory field

### DIFF
--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -2544,7 +2544,7 @@ function stripModelSuppliedChildArgs(
   return out;
 }
 
-function injectChildToolArgs(
+export function injectChildToolArgs(
   parsedArgs: Record<string, unknown>,
   toolName: string,
   opts: {
@@ -2571,17 +2571,29 @@ function injectChildToolArgs(
   if (opts.worktree?.path) {
     injectedArgs = withSignedAllowedRoots(injectedArgs, [opts.worktree.path]);
   }
-  if (
-    opts.worktree?.path &&
-    (toolName === "system.bash" ||
-      toolName === "exec_command" ||
-      toolName === "apply_patch") &&
-    (typeof injectedArgs.cwd !== "string" || injectedArgs.cwd.length === 0)
-  ) {
-    injectedArgs.cwd = opts.worktree.path;
+  if (opts.worktree?.path) {
+    // Each tool names its working-directory field differently. exec_command
+    // takes `workdir` and rejects `cwd` as a removed alias, so injecting
+    // `cwd` there made every exec_command in a worktree child fail with a
+    // message that blamed the model for a field it never sent.
+    const field = WORKTREE_CWD_FIELD_BY_TOOL[toolName];
+    if (
+      field !== undefined &&
+      (typeof injectedArgs[field] !== "string" ||
+        (injectedArgs[field] as string).length === 0)
+    ) {
+      injectedArgs[field] = opts.worktree.path;
+    }
   }
   return injectedArgs;
 }
+
+/** Tools pinned to the child's worktree, and the argument that carries it. */
+export const WORKTREE_CWD_FIELD_BY_TOOL: Readonly<Record<string, string>> = {
+  "system.bash": "cwd",
+  exec_command: "workdir",
+  apply_patch: "cwd",
+};
 
 async function applyChildToolPolicy(
   tool: Pick<Tool, "name">,

--- a/runtime/tests/agents/run-agent.inject-child-args.test.ts
+++ b/runtime/tests/agents/run-agent.inject-child-args.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  SESSION_ALLOWED_ROOTS_ARG,
+  SESSION_ID_ARG,
+} from "../../src/agents/_deps/filesystem-args.js";
+import {
+  injectChildToolArgs,
+  WORKTREE_CWD_FIELD_BY_TOOL,
+} from "../../src/agents/run-agent.js";
+
+const worktree = { path: "/repo/.agenc-worktrees/m5-abc" } as never;
+const opts = { childConversationId: "child-1", worktree };
+
+describe("injectChildToolArgs pins the worktree through each tool's own field", () => {
+  it("gives exec_command a workdir and never the removed cwd alias", () => {
+    const args = injectChildToolArgs({ cmd: "npm test" }, "exec_command", opts);
+    expect(args.workdir).toBe(worktree.path);
+    expect(Object.hasOwn(args, "cwd")).toBe(false);
+    expect(args[SESSION_ID_ARG]).toBe("child-1");
+    expect(args[SESSION_ALLOWED_ROOTS_ARG]).toContain(worktree.path);
+  });
+
+  it("keeps a working directory the model supplied", () => {
+    const args = injectChildToolArgs(
+      { cmd: "npm test", workdir: "/repo/.agenc-worktrees/m5-abc/pkg" },
+      "exec_command",
+      opts,
+    );
+    expect(args.workdir).toBe("/repo/.agenc-worktrees/m5-abc/pkg");
+    expect(Object.hasOwn(args, "cwd")).toBe(false);
+  });
+
+  it("uses cwd for system.bash and apply_patch, and touches nothing else", () => {
+    expect(injectChildToolArgs({ command: "ls" }, "system.bash", opts).cwd).toBe(
+      worktree.path,
+    );
+    expect(injectChildToolArgs({ patch: "" }, "apply_patch", opts).cwd).toBe(
+      worktree.path,
+    );
+    const other = injectChildToolArgs({ path: "x" }, "FileRead", opts);
+    expect(Object.hasOwn(other, "cwd")).toBe(false);
+    expect(Object.hasOwn(other, "workdir")).toBe(false);
+    expect(WORKTREE_CWD_FIELD_BY_TOOL).toEqual({
+      "system.bash": "cwd",
+      exec_command: "workdir",
+      apply_patch: "cwd",
+    });
+  });
+
+  it("injects no working directory without a worktree", () => {
+    const args = injectChildToolArgs({ cmd: "ls" }, "exec_command", {
+      childConversationId: "child-1",
+    });
+    expect(Object.hasOwn(args, "workdir")).toBe(false);
+    expect(Object.hasOwn(args, "cwd")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Soak finding F28 (#2171 changed the error text; this is the cause). In every goal run the implement child's `exec_command` calls failed with `unknown field \`cwd\``, 11 times in one attempt and 44 in the next, until the repeat guard and the backstop ended the attempt. The model was blamed for a field it never sent. A temporary probe in the rejection message showed the arguments as the tool saw them:

```
value="/Users/…/work/.agenc-worktrees/m5-wf1689b097e6"
keys=cmd,workdir,timeoutMs,__agencSessionId,__agencSessionIdSig,__agencSessionAllowedRoots,__agencSessionAllowedRootsSig,cwd
```

The model sent `cmd`, `workdir`, `timeoutMs`. The runtime added the signed session identity, the allowed roots, and `cwd` with the worktree path. `injectChildToolArgs` in `src/agents/run-agent.ts` pins worktree children to their worktree by setting `cwd` on `system.bash`, `exec_command` and `apply_patch`. `exec_command` takes `workdir` and rejects `cwd` as a removed alias (#2171 made it say so). So every `exec_command` a worktree child made was rejected by the runtime's own injection, with a message telling the model to fix what it had already done right. Goal runs could not run a single command in their worktree.

## What changed

- `runtime/src/agents/run-agent.ts`: `WORKTREE_CWD_FIELD_BY_TOOL` names the working-directory field per tool (`system.bash` and `apply_patch` keep `cwd`, `exec_command` gets `workdir`); the injection fills that field when the model left it empty and never writes `cwd` on `exec_command`. `injectChildToolArgs` is exported for the test.

## Evidence

| check | result |
| --- | --- |
| probe in the live daemon (goal `wf-1689b097`, implement child `6f25cd62`) | arguments carried model `workdir` plus injected `cwd` = worktree path; 14 `unknown field` rejections in the first 56 `exec_command` calls of the next child |
| `vitest run tests/agents/run-agent.inject-child-args.test.ts tests/agents/run-agent.test.ts` | 82 passed |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/agents/run-agent.inject-child-args.test.ts` (new): `exec_command` gets `workdir` and no `cwd`, with the signed session id and the allowed roots still injected; a model-supplied `workdir` is kept; `system.bash` and `apply_patch` get `cwd`; other tools get neither; without a worktree nothing is injected.

## Not changed

- `exec_command`'s field set and its removed-alias rejection (#2171).
- The signed session identity and allowed-roots injection.
- The parent (non-worktree) dispatch path.

## Counterparts

F28 in the app soak report; #2171 (error text). The next goal soak on this build is the live check: implement children should run their commands.
