### PR TITLE
llm: classify SDK connection errors as transient so the reconnect ladder retries them

### DIFF
--- a/runtime/src/llm/errors.ts
+++ b/runtime/src/llm/errors.ts
@@ -487,7 +487,16 @@ export function mapLLMError(
     return new LLMServerError(providerName, 503, message);
   }
 
-  return new LLMProviderError(providerName, message, status);
+  const mapped = new LLMProviderError(providerName, message, status);
+  // Keep the transport error underneath: SDK connection failures carry the
+  // socket-level code (ECONNRESET, UND_ERR_SOCKET, ...) on their own cause,
+  // and the recovery ladder's transient classifier walks the cause chain.
+  // Without it a dropped connection became a bare "Connection error." that
+  // nothing retried, and one blip ended the turn.
+  if (err !== null && typeof err === "object") {
+    (mapped as { cause?: unknown }).cause = err;
+  }
+  return mapped;
 }
 
 /**

--- a/runtime/src/recovery/api-errors.ts
+++ b/runtime/src/recovery/api-errors.ts
@@ -339,6 +339,10 @@ const TRANSIENT_PROVIDER_MESSAGE_PARTS = [
   "connection reset",
   "socket connection was closed unexpectedly",
   "socket closed",
+  // The OpenAI-compatible SDK raises APIConnectionError with the fixed text
+  // "Connection error." and no status or code of its own; mapLLMError keeps
+  // that text in the provider error it returns.
+  "connection error",
 ];
 
 function isExplicitNonTransientProviderError(err: unknown): boolean {

--- a/runtime/tests/llm/errors.test.ts
+++ b/runtime/tests/llm/errors.test.ts
@@ -7,6 +7,19 @@ import {
 } from "./errors.js";
 
 describe("LLM error network classification", () => {
+  test("mapLLMError keeps the transport error as the cause of a generic provider error", () => {
+    const socket = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    const sdkError = Object.assign(new Error("Connection error."), {
+      name: "APIConnectionError",
+      cause: socket,
+    });
+    const mapped = mapLLMError("grok", sdkError, 30_000);
+    expect(mapped.message).toBe("grok error: Connection error.");
+    expect((mapped as { cause?: unknown }).cause).toBe(sdkError);
+    // Already-typed errors pass through untouched, as before.
+    expect(mapLLMError("grok", mapped, 30_000)).toBe(mapped);
+  });
+
   test("mapLLMError promotes TLS validation failures into LLMCertificateError", () => {
     const mapped = mapLLMError(
       "openai",

--- a/runtime/tests/recovery/api-errors.test.ts
+++ b/runtime/tests/recovery/api-errors.test.ts
@@ -12,7 +12,7 @@ import {
   isWithheldMaxOutputTokens,
   parsePromptTooLongTokenCounts,
 } from "./api-errors.js";
-import { LLMProviderError } from "../llm/errors.js";
+import { LLMProviderError, mapLLMError } from "../llm/errors.js";
 import type { AssistantMessage, TurnState } from "../session/turn-state.js";
 
 function mkMsg(
@@ -106,6 +106,35 @@ describe("isTransientProviderError", () => {
     expect(isTransientProviderError(err502)).toBe(true);
     expect(isTransientProviderError(new Error("stream_idle"))).toBe(true);
   });
+  test("an SDK connection error is transient, raw and after mapLLMError", () => {
+    // openai's APIConnectionError: fixed message, no status, the socket error as cause.
+    const socket = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    const sdkError = Object.assign(new Error("Connection error."), {
+      name: "APIConnectionError",
+      cause: socket,
+    });
+    expect(isTransientProviderError(sdkError)).toBe(true);
+    const mapped = mapLLMError("grok", sdkError, 30_000);
+    expect(mapped).toBeInstanceOf(LLMProviderError);
+    expect(mapped.message).toBe("grok error: Connection error.");
+    expect(isTransientProviderError(mapped)).toBe(true);
+    // A bland message still classifies through the preserved cause code.
+    const bland = mapLLMError(
+      "grok",
+      Object.assign(new Error("request failed"), { cause: socket }),
+      30_000,
+    );
+    expect(isTransientProviderError(bland)).toBe(true);
+    // A mapped 4xx with a plain message stays non-transient.
+    expect(
+      isTransientProviderError(
+        mapLLMError("grok", Object.assign(new Error("bad request"), { status: 400 }), 30_000),
+      ),
+    ).toBe(false);
+  });
+
   test("401 + generic syntax → not transient", () => {
     const err401 = new Error("unauthorized");
     (err401 as unknown as { status: number }).status = 401;


### PR DESCRIPTION
## Why

Soak finding F32. Both implement attempts of a goal run died the same way: a model call was admitted, nothing came back for 42 s, the turn aborted with `grok error: Connection error.` and the child run went terminal `failed`. $0.81 and $1.29 of work were lost per attempt and the goal ended `step_retries_exhausted`. The daemon log has no line for it.

The turn already owns a same-model reconnect ladder (`runSamplingRequest` wraps the sample in `reconnectWithBackoff`, up to `MAX_RECOVERY_REENTRIES + 1` attempts, each a fresh admission). It never fired because neither gate recognised the error:

- The OpenAI-compatible SDK raises `APIConnectionError` with the fixed text `Connection error.`, no status, no code, and the socket error as its `cause`.
- `mapLLMError` turned that into a bare `LLMProviderError("grok error: Connection error.")`, dropping the cause. `isRetryableStreamError` looks for typed errors or a `code`; `isTransientProviderError` looks for codes, 5xx statuses, message fragments and walks `cause` chains. The mapped error had none of those, so the ladder classified the drop as permanent and the turn ended.

## What changed

- `runtime/src/recovery/api-errors.ts`: `"connection error"` joins `TRANSIENT_PROVIDER_MESSAGE_PARTS`, the SDK's own wording for a dropped connection.
- `runtime/src/llm/errors.ts`: the generic `LLMProviderError` branch of `mapLLMError` keeps the original error as `cause`, so socket-level codes (`ECONNRESET`, `UND_ERR_SOCKET`, ...) stay reachable for the transient classifier even when the message is bland. Typed errors still pass through untouched.

Nothing changes for the ladder itself, its cap, or its "not retrying after streamed tool work" rule.

## Evidence

| check | result |
| --- | --- |
| child rollout `0b9b1495` (goal `wf-1689b097`, implement attempt 2) | model step 17 admitted 16:56:17, `turn_aborted` at 16:56:59 with reason `grok error: Connection error.`, `run_terminal failed`; no `stream_disconnected` notice, so no retry was attempted |
| `runtime/node_modules/openai/core/error.js` (6.46.0) | `APIConnectionError` constructor: `message || 'Connection error.'`, `this.cause = cause` |
| `vitest run tests/recovery/api-errors.test.ts tests/llm/errors.test.ts tests/llm/errors-413-substring.test.ts tests/session/run-turn.test.ts` | 154 passed |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

- `tests/recovery/api-errors.test.ts`: an SDK connection error is transient raw and after `mapLLMError`; a bland message classifies through the preserved cause code; a mapped 4xx with a plain message stays non-transient.
- `tests/llm/errors.test.ts`: `mapLLMError` keeps the transport error as the cause of a generic provider error and still passes already-typed errors through.

## Not changed

- The reconnect ladder, `MAX_RECOVERY_REENTRIES`, backoff, and the streamed-tool replay rule.
- Admission semantics: every retry is still its own reservation; the failed attempt stays `held_unknown`.
- Provider adapters and `singleWireAttempt`.

## Counterparts

Soak finding F32 (report PR to follow). Related: #2142 (a provider error ends the turn, not the session), #2172 (goal runs after a daemon restart).
