### PR TITLE
plugins: uninstall and update accept the name@marketplace id the marketplace install used

### DIFF
--- a/runtime/src/plugins/cli/pluginOperations.ts
+++ b/runtime/src/plugins/cli/pluginOperations.ts
@@ -44,6 +44,7 @@ import {
   type PluginResolutionKind,
   type ResolvedPluginSource,
 } from "../resolution.js";
+import { parsePluginIdentifier } from "../identifier.js";
 
 export type PluginScope = "user" | "project" | "local";
 
@@ -501,34 +502,62 @@ export async function installPluginOp(
   }
 }
 
+/**
+ * `plugin marketplace install name@marketplace` installs the plugin under its
+ * bare name: the marketplace is where it came from, not part of its installed
+ * identity. Uninstall and update therefore accept the same qualified id the
+ * operator installed with. The qualified form is tried first so a plugin whose
+ * own name legitimately contains "@" keeps resolving as before.
+ */
+async function resolveInstalledPluginForRemoval(
+  requestedId: string,
+  scope: PluginScope,
+  options: PluginOperationOptions,
+): Promise<{ readonly pluginId: string; readonly roots: string[] }> {
+  const direct = await resolvePluginRootsForRemoval(requestedId, scope, options);
+  if (direct.length > 0) return { pluginId: requestedId, roots: direct };
+  const parsed = parsePluginIdentifier(requestedId);
+  if (parsed.marketplace === undefined || parsed.name.length === 0) {
+    return { pluginId: requestedId, roots: [] };
+  }
+  const bare = await resolvePluginRootsForRemoval(parsed.name, scope, options);
+  return bare.length > 0
+    ? { pluginId: parsed.name, roots: bare }
+    : { pluginId: requestedId, roots: [] };
+}
+
 export async function uninstallPluginOp(
   input: UninstallPluginInput,
 ): Promise<UninstallPluginResult> {
   const scope = input.scope ?? "user";
-  const targetRoots = await resolvePluginRootsForRemoval(input.pluginId, scope, input);
+  const { pluginId, roots: targetRoots } = await resolveInstalledPluginForRemoval(
+    input.pluginId,
+    scope,
+    input,
+  );
   if (targetRoots.length === 0) {
     throw new Error(`plugin is not installed in ${scope} scope: ${input.pluginId}`);
   }
   for (const root of targetRoots) {
     await rm(root, { recursive: true, force: true });
   }
-  const remainsInstalled = await pluginIdRemainsInstalled(input.pluginId, input);
+  const remainsInstalled = await pluginIdRemainsInstalled(pluginId, input);
   const removedConfig = remainsInstalled
     ? false
-    : await removePluginConfigEntry(input.pluginId, input);
+    : await removePluginConfigEntry(pluginId, input);
   let removedData = false;
   if (!remainsInstalled && input.keepData !== true) {
     const authority = {
       pluginStorageRoot: input.pluginStorageRoot,
     };
-    const dataDir = pluginDataDirPath(input.pluginId, authority);
+    const dataDir = pluginDataDirPath(pluginId, authority);
     if (await pathExists(dataDir)) {
-      await deletePluginDataDir(input.pluginId, authority);
+      await deletePluginDataDir(pluginId, authority);
       removedData = !(await pathExists(dataDir));
     }
   }
   return {
-    pluginId: input.pluginId,
+    pluginId,
     removedRoots: targetRoots,
     removedConfig,
     removedData,
@@ -570,7 +599,11 @@ export async function updatePluginOp(
 ): Promise<UpdatePluginResult> {
   const scope = input.scope ?? "user";
   const workspaceRoot = resolvePluginWorkspaceRoot(input);
-  const roots = await resolvePluginRootsForRemoval(input.pluginId, scope, input);
+  const { pluginId, roots } = await resolveInstalledPluginForRemoval(
+    input.pluginId,
+    scope,
+    input,
+  );
   if (roots.length === 0) {
     throw new Error(`plugin is not installed in ${scope} scope: ${input.pluginId}`);
   }
@@ -595,7 +628,7 @@ export async function updatePluginOp(
   const installed = await installPluginOp({
     ...input,
     source,
-    name: input.pluginId,
+    name: pluginId,
     scope,
     force: true,
     refreshCache: true,

--- a/runtime/tests/plugins/cli/pluginConfigMigrationMarkers.test.ts
+++ b/runtime/tests/plugins/cli/pluginConfigMigrationMarkers.test.ts
@@ -395,3 +395,54 @@ describe("plugin entries in canonical config", () => {
     ]);
   });
 });
+
+describe("marketplace-qualified plugin identifiers on removal", () => {
+  it("uninstall accepts the name@marketplace id the marketplace install was made with", async () => {
+    const { root, agencHome, workspaceRoot } = await tempRuntime();
+    const alphaSource = await writePlugin(root, "alpha");
+    // `plugin marketplace install alpha@bundled` installs under the bare name.
+    const installed = await installPluginOp({
+      ...pluginAuthority(agencHome, workspaceRoot),
+      source: alphaSource,
+      name: "alpha",
+    });
+    expect(installed.destination).toBe(
+      join(agencHome, "plugins", pluginFilesystemKey("alpha")),
+    );
+
+    const result = await uninstallPluginOp({
+      ...pluginAuthority(agencHome, workspaceRoot),
+      pluginId: "alpha@bundled",
+    });
+    expect(result.pluginId).toBe("alpha");
+    expect(result.removedRoots).toEqual([installed.destination]);
+    await expect(access(installed.destination)).rejects.toThrow();
+    const listed = await listInstalledPlugins(pluginAuthority(agencHome, workspaceRoot));
+    expect(listed.plugins.map((plugin) => plugin.id)).not.toContain("alpha");
+  });
+
+  it("update accepts the qualified id and reinstalls under the bare name", async () => {
+    const { root, agencHome, workspaceRoot } = await tempRuntime();
+    const alphaSource = await writePlugin(root, "alpha");
+    const authority = pluginAuthority(agencHome, workspaceRoot);
+    const installed = await installPluginOp({ ...authority, source: alphaSource, name: "alpha" });
+    const updated = await updatePluginOp({
+      ...authority,
+      pluginId: "alpha@bundled",
+      source: alphaSource,
+    });
+    expect(updated.destination).toBe(installed.destination);
+    const listed = await listInstalledPlugins(authority);
+    expect(listed.plugins.map((plugin) => plugin.id)).toEqual(["alpha"]);
+  });
+
+  it("a qualified id whose bare name is not installed is still reported as not installed", async () => {
+    const { agencHome, workspaceRoot } = await tempRuntime();
+    await expect(
+      uninstallPluginOp({
+        ...pluginAuthority(agencHome, workspaceRoot),
+        pluginId: "ghost@bundled",
+      }),
+    ).rejects.toThrow("plugin is not installed in user scope: ghost@bundled");
+  });
+});


### PR DESCRIPTION
## Why

Soak finding F33. Plugin churn through the desktop app (`pluginInstall`, `pluginUninstall`, `reloadDaemon`) with `llm-checker@agenc-plugins`: the first install succeeded (30 s) and the inventory showed the plugin installed, then every uninstall failed with `plugin is not installed in user scope: llm-checker@agenc-plugins` and every reinstall failed with `plugin destination already exists: …/plugins/llm-checker--6030…`. A user who installs a marketplace plugin once cannot remove or update it from the app.

`plugin marketplace install name@marketplace` resolves the catalog entry and calls `installPluginOp` with `name: target.pluginName`, so the plugin lands under its bare name (`plugins/<pluginFilesystemKey("llm-checker")>`, install metadata `name: "llm-checker"`, `plugin list` id `llm-checker`). `uninstallPluginOp` and `updatePluginOp` took the requested id literally: the direct root for `llm-checker@agenc-plugins` hashes differently and the lister's ids never carry a marketplace, so nothing matched. The desktop passes the same qualified id to `plugin uninstall` and `plugin update`.

## What changed

- `runtime/src/plugins/cli/pluginOperations.ts`: `resolveInstalledPluginForRemoval` tries the requested id first and, when it has the `name@marketplace` shape and nothing matched, the bare name. Uninstall removes the roots, config entry and data directory under the resolved id and reports it; update re-installs under the resolved id. A qualified id whose bare name is not installed still fails with the same message as before, and a plugin whose own name contains `@` keeps resolving directly.

## Evidence

| check | result |
| --- | --- |
| isolated home after the churn | `plugins/llm-checker--6030…/.agenc-plugin/agenc-install.json`: `name: "llm-checker"`, `scope: "user"`; `agenc plugin list --json`: id `llm-checker` |
| churn log | round 1 install ok; rounds 1 to 3 uninstall `not installed in user scope: llm-checker@agenc-plugins`; rounds 2 and 3 install `destination already exists` |
| `vitest run tests/plugins/cli` | 29 passed (2 files), including the 3 new cases |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/plugins/cli/pluginConfigMigrationMarkers.test.ts`: uninstall with `alpha@bundled` removes the install made under `alpha` and reports `pluginId: "alpha"`; update with the qualified id reinstalls under the bare name; `ghost@bundled` is still "not installed in user scope".

## Not changed

- Install naming and the marketplace resolution.
- The "destination already exists" error on a repeated install without `--force`; the desktop does not offer install for an installed plugin, the churn driver did.
- The desktop bridge (`plugin uninstall <id> [--scope]`): it keeps passing the catalog id, which now resolves.

## Counterparts

Soak finding F33 (report PR to follow).
