### PR TITLE
health: count only running tool calls as in flight

### DIFF
--- a/runtime/src/state/health-stats.ts
+++ b/runtime/src/state/health-stats.ts
@@ -6,10 +6,7 @@ import {
   type StateSqliteReader,
 } from "./sqlite-driver.js";
 
-type StateCountTable =
-  | "agent_runs"
-  | "session_state_snapshots"
-  | "in_flight_tool_calls";
+type StateCountTable = "agent_runs" | "session_state_snapshots";
 
 /**
  * Read-only health counter for persisted AgenC state.
@@ -50,7 +47,9 @@ function readStateStatsForPath(paths: StateDatabasePaths): HealthStateStats {
       projectDir: reader.projectDir,
       agentRuns: countRows(reader, "agent_runs"),
       sessionStateSnapshots: countRows(reader, "session_state_snapshots"),
-      inFlightToolCalls: countRows(reader, "in_flight_tool_calls"),
+      // Completed, failed and poisoned calls stay in this table as durable
+      // history; only rows still marked running are work in flight.
+      inFlightToolCalls: countRunningToolCalls(reader),
       logs: countLogs(reader),
     };
   } finally {
@@ -74,6 +73,16 @@ function countRows(reader: StateSqliteReader, table: StateCountTable): number {
     reader
       .prepareState<[], { count: number }>(
         `SELECT COUNT(*) AS count FROM ${table}`,
+      )
+      .get()?.count ?? 0
+  );
+}
+
+function countRunningToolCalls(reader: StateSqliteReader): number {
+  return (
+    reader
+      .prepareState<[], { count: number }>(
+        `SELECT COUNT(*) AS count FROM in_flight_tool_calls WHERE status = 'running'`,
       )
       .get()?.count ?? 0
   );

--- a/runtime/tests/state/health-stats.test.ts
+++ b/runtime/tests/state/health-stats.test.ts
@@ -148,6 +148,25 @@ function seedStateRows(driver: StateSqliteDriver): void {
       "running",
       "2026-05-01T00:01:00.000Z",
     );
+  // Settled calls stay in the table as history and must not count as in flight.
+  for (const [id, status] of [
+    ["tool-done", "completed"],
+    ["tool-failed", "failed"],
+    ["tool-poisoned", "poisoned"],
+  ] as const) {
+    driver
+      .prepareState(
+        `INSERT INTO in_flight_tool_calls (
+          session_id,
+          tool_call_id,
+          tool_name,
+          args_json,
+          status,
+          started_at
+        ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run("session-health", id, "FileRead", "{}", status, "2026-05-01T00:00:30.000Z");
+  }
   driver
     .prepareLogs(
       `INSERT INTO logs (


### PR DESCRIPTION
## Why

Issue #2158. `agenc daemon status` on an idle daemon printed `inFlightToolCalls=2334`. The counter is `COUNT(*)` over `in_flight_tool_calls`, and that table keeps every settled call as durable history (`completed`, `failed`, `poisoned`; the isolated soak home holds 4138, 225 and 10 of those and no `running` row while idle). An "in flight" number that only grows hides a real leak and tells an operator nothing about load.

## What changed

- `runtime/src/state/health-stats.ts`: `inFlightToolCalls` counts rows whose `status = 'running'`, the value `recordInFlightToolCallStart` writes; the other counters are unchanged. The unused table name leaves the `countRows` union.

## Evidence

| check | result |
| --- | --- |
| soak home, idle daemon | statuses in `in_flight_tool_calls`: completed 4138, failed 225, poisoned 10, running 0; `daemon status` reported all of them as in flight |
| `vitest run tests/state/health-stats.test.ts tests/app-server/health.contract.test.ts` | 8 passed |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/state/health-stats.test.ts`: the seeded state now holds one running call and one each of completed, failed and poisoned; the count stays 1 in the single-database and the aggregated case.

## Not changed

- The `HealthStateStats` field names (protocol schema); `sessions: active` in the status line, which counts stored sessions and is the other half of #2158, stays for a separate change.
- Persistence of settled calls.

## Counterparts

#2158.
