### PR TITLE
tool-use context: daemon sessions route tool permission changes through the permission registry

### DIFF
--- a/runtime/src/session/agenc-tool-use-context.ts
+++ b/runtime/src/session/agenc-tool-use-context.ts
@@ -197,7 +197,21 @@ export function buildAgenCToolUseContext(
         typeof value === "string" && value.length > 0,
     )
     .join("\n\n");
-  const setAppState = surface.setAppState;
+  const getAppState = createAppStateReader(session, surface, agentDefinitions);
+  const emitWarning: AgenCToolUseContext["emitWarning"] =
+    surface.emitWarning ??
+    ((warning) => {
+      session.emit({
+        id: session.nextInternalSubId(),
+        msg: {
+          type: "warning",
+          payload: warning,
+        },
+      });
+    });
+  const setAppState =
+    surface.setAppState ??
+    createRegistryBackedAppStateSetter(session, getAppState, emitWarning);
   const setAppStateForTasks = surface.setAppStateForTasks ?? setAppState;
   const appendSystemMessage =
     surface.appendSystemMessage ?? createSessionSystemMessageAppender(session);
@@ -236,7 +250,7 @@ export function buildAgenCToolUseContext(
       cwd,
       verbose: opts.verbose ?? surface.verbose ?? false,
     },
-    getAppState: createAppStateReader(session, surface, agentDefinitions),
+    getAppState,
     setAppState,
     setAppStateForTasks,
     appendSystemMessage,
@@ -252,17 +266,7 @@ export function buildAgenCToolUseContext(
     setResponseLength: surface.setResponseLength ?? (() => {}),
     onCompactProgress: surface.onCompactProgress ?? (() => {}),
     addNotification: surface.addNotification ?? (() => {}),
-    emitWarning:
-      surface.emitWarning ??
-      ((warning) => {
-        session.emit({
-          id: session.nextInternalSubId(),
-          msg: {
-            type: "warning",
-            payload: warning,
-          },
-        });
-      }),
+    emitWarning,
     ...(surface.queryTracking !== undefined
       ? { queryTracking: surface.queryTracking }
       : {}),
@@ -357,6 +361,65 @@ function createFallbackAppState(
     pendingWorkerRequest: null,
     pendingSandboxRequest: null,
     elicitation: { queue: [] },
+  };
+}
+
+/**
+ * Daemon-hosted sessions have no UI app-state store, so `setAppState` was
+ * undefined there: EnterPlanMode and ExitPlanMode "changed" a mode nothing
+ * read, and plan mode was a prompt paragraph plus advice while the agent
+ * edited files under a Plan chip (#2169). The only slice of app state those
+ * tools write is the permission context, and the session already owns it:
+ * its permission registry is the durable, journaled, client-notified path
+ * `session.setPermissionMode` takes. Route tool writes there.
+ *
+ * The updater runs against the snapshot the tool observed; if the registry
+ * moved underneath it the write is dropped, which is what ExitPlanMode's own
+ * compare-and-set expects (it re-reads and retries).
+ */
+function createRegistryBackedAppStateSetter(
+  session: Session,
+  getAppState: () => AppStateShape,
+  emitWarning: AgenCToolUseContext["emitWarning"],
+): (updater: unknown) => void {
+  return (updater) => {
+    const registry =
+      session.permissionModeRegistry ?? session.services?.permissionModeRegistry;
+    if (registry === undefined || typeof registry.transact !== "function") return;
+    const previous = getAppState();
+    const next =
+      typeof updater === "function"
+        ? (updater as (prev: AppStateShape) => unknown)(previous)
+        : updater;
+    if (!isRecord(next)) return;
+    const nextContext = readToolPermissionContext(next.toolPermissionContext);
+    if (nextContext === null || nextContext === previous.toolPermissionContext) {
+      return;
+    }
+    void registry
+      .transact((live) => {
+        if (live !== previous.toolPermissionContext) {
+          return { next: null, result: () => undefined };
+        }
+        return {
+          next: nextContext,
+          metadata: {
+            runtimeSettings: {
+              reason: "permission_mode_changed",
+              rollbackOfSettingsEventId: null,
+            },
+          },
+          result: () => undefined,
+        };
+      })
+      .catch((error: unknown) => {
+        emitWarning({
+          cause: "permission_context_publish_failed",
+          message: `a tool changed the permission context but the change was not published: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
+      });
   };
 }
 

--- a/runtime/tests/session/agenc-tool-use-context.test.ts
+++ b/runtime/tests/session/agenc-tool-use-context.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test, vi } from "vitest";
 
 import { createAgentRoleWorkspace } from "../agents/role.js";
 import { buildAgenCToolUseContext } from "../session/agenc-tool-use-context.js";
+import { PermissionModeRegistry } from "../permissions/permission-mode.js";
+import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import type { Session } from "../session/session.js";
 import type { TurnContext } from "../session/turn-context.js";
 
@@ -226,5 +228,76 @@ describe("buildAgenCToolUseContext", () => {
 
     sessionAbort.abort("session_shutdown");
     expect(context.abortController.signal.aborted).toBe(true);
+  });
+});
+
+describe("daemon sessions route tool permission changes through the registry", () => {
+  test("EnterPlanMode's update lands in the registry and is visible to the next read", async () => {
+    const registry = new PermissionModeRegistry(createEmptyToolPermissionContext());
+    const changes: string[] = [];
+    registry.subscribeToModeChange((next, previous) => {
+      changes.push(`${previous}->${next}`);
+    });
+    const session = createSession({
+      permissionModeRegistry: registry,
+      services: {
+        registry: { toLLMTools: () => [] },
+        provider: undefined,
+        permissionModeRegistry: registry,
+        skillsManager: {
+          skillsForConfig: vi.fn(async () => ({ invokedSkills: [] })),
+        },
+      },
+    });
+    const context = buildAgenCToolUseContext(
+      session as unknown as Session,
+      createTurnContext(),
+      { llmTools: [] },
+    );
+    const before = context.getAppState().toolPermissionContext as {
+      readonly mode: string;
+    };
+    expect(before.mode).toBe("default");
+    expect(context.setAppState).toBeDefined();
+
+    context.setAppState!((prev: { toolPermissionContext: Record<string, unknown> }) => ({
+      ...prev,
+      toolPermissionContext: {
+        ...prev.toolPermissionContext,
+        mode: "plan",
+        prePlanMode: "default",
+      },
+    }));
+    await vi.waitFor(() => expect(registry.current().mode).toBe("plan"));
+    expect(
+      (context.getAppState().toolPermissionContext as { mode: string }).mode,
+    ).toBe("plan");
+    expect(changes).toEqual(["default->plan"]);
+
+    // ExitPlanMode compares against the snapshot it read; a stale snapshot
+    // must not move the live context.
+    context.setAppState!((prev: { toolPermissionContext: unknown }) =>
+      prev.toolPermissionContext === before
+        ? { ...prev, toolPermissionContext: { mode: "acceptEdits" } }
+        : prev,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(registry.current().mode).toBe("plan");
+    expect(changes).toEqual(["default->plan"]);
+
+    // Returning the same snapshot publishes nothing.
+    context.setAppState!((prev: unknown) => prev);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(changes).toEqual(["default->plan"]);
+  });
+
+  test("an explicit app-state store still wins", () => {
+    const setAppState = vi.fn();
+    const context = buildAgenCToolUseContext(
+      createSession({ setAppState }) as unknown as Session,
+      createTurnContext(),
+      { llmTools: [] },
+    );
+    expect(context.setAppState).toBe(setAppState);
   });
 });


### PR DESCRIPTION
## Why

Issue #2169, soak finding F24. With the desktop's Plan stance armed, the agent called `EnterPlanMode` (result: "Entered plan mode…") and then, in the same turn, made 101 reads, 41 edits, 7 writes and 2 shell commands. `ExitPlanMode` was never called, no "Implement this plan?" approval appeared, and the app never lit its plan chip.

The desktop's Plan stance deliberately does not touch the session's permission mode (`composerModes.tsx` explains why: flipping bypass to plan from the client left the user's bypass gone after the plan). It asks the agent to call `EnterPlanMode` and expects the runtime to take it from there. The runtime's plan machinery exists and keys on the session's permission mode (`isPlanMode(ctx)` is `ctx.permissionMode === "plan"`: the plan parser, the tool-call requirement, the ExitPlanMode approval). The link between them was missing: `EnterPlanModeTool.call` and `ExitPlanModeTool` write `toolPermissionContext.mode` through `context.setAppState`, and in a daemon-hosted session `buildAgenCToolUseContext` left `setAppState` undefined because there is no UI app-state store. The tools "changed" a mode nothing read.

## What changed

- `runtime/src/session/agenc-tool-use-context.ts`: when the session surface has no `setAppState`, the context gets `createRegistryBackedAppStateSetter`. It runs the tool's updater against the snapshot `getAppState()` returned, and if the permission context changed, publishes it through `session.permissionModeRegistry.transact` with `runtimeSettings.reason = "permission_mode_changed"`, the same durable, journaled, client-notified path `session.setPermissionMode` takes. A stale snapshot (the registry moved underneath the tool) drops the write, which is what ExitPlanMode's compare-and-set expects; an unchanged context publishes nothing; a publish failure surfaces as a `warning` event. `getAppState` and `emitWarning` are built once and shared. An explicit store, as the TUI provides, still wins.

Downstream, with no further change: the next tool call reads `getAppState().toolPermissionContext.mode === "plan"` from the registry, the turn's `permissionMode` follows the registry on the next turn, the runtime-settings change is journaled, and the desktop derives `planModeActive` from `permissionMode === "plan"` in its snapshot and events (`transcript-snapshot.ts`, `turn-notification.ts`), so the locked chip lights.

## Evidence

| check | result |
| --- | --- |
| soak transcript `conv-mto0fc1p` (F24) | `EnterPlanMode` once, then 151 mutating and reading tool calls in the same turn, no approval |
| `vitest run tests/session/agenc-tool-use-context.test.ts` | 9 passed (2 new) |
| plan-mode, bootstrap, permission and plan-tool suites (47 files) | 1081 passed; the 2 failures (`permission-audit-log` AGENC_HOME resolution, `request-permissions` special path grants) fail identically on unmodified main in this shell |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/session/agenc-tool-use-context.test.ts`: with a real `PermissionModeRegistry` and no app-state store, an EnterPlanMode-shaped update lands in the registry (`default->plan` published once) and the next `getAppState` read sees it; a compare-and-set against a stale snapshot leaves the live context alone; returning the same snapshot publishes nothing; an explicit `setAppState` is used as is.

## Not changed

- The desktop Plan stance and its paragraph; the permission evaluator; the plan parser and ExitPlanMode approval flow.
- The TUI path (it supplies its own store).
- A live check through the app (plan scenario with the daemon on this build) follows once the current goal soak finishes; the soak driver no longer forces bypass in plan mode, which had masked the runtime's plan mode in the earlier run.

## Counterparts

#2169 (this), soak finding F24; desktop #185 (plan word arming).
