### PR TITLE
recovery: treat undici's terminated message as a transient provider error

### DIFF
--- a/runtime/src/recovery/api-errors.ts
+++ b/runtime/src/recovery/api-errors.ts
@@ -343,6 +343,10 @@ const TRANSIENT_PROVIDER_MESSAGE_PARTS = [
   // "Connection error." and no status or code of its own; mapLLMError keeps
   // that text in the provider error it returns.
   "connection error",
+  // undici ends a response body whose connection dropped mid-stream with a
+  // bare TypeError("terminated"); a goal's plan child died on exactly that
+  // right after its "Connection error." retry had succeeded.
+  "terminated",
 ];
 
 function isExplicitNonTransientProviderError(err: unknown): boolean {

--- a/runtime/tests/recovery/api-errors.test.ts
+++ b/runtime/tests/recovery/api-errors.test.ts
@@ -135,6 +135,14 @@ describe("isTransientProviderError", () => {
     ).toBe(false);
   });
 
+  test("a body that ends mid-stream (undici \"terminated\") is transient", () => {
+    const terminated = new TypeError("terminated");
+    expect(isTransientProviderError(terminated)).toBe(true);
+    const mapped = mapLLMError("grok", terminated, 30_000);
+    expect(mapped.message).toBe("grok error: terminated");
+    expect(isTransientProviderError(mapped)).toBe(true);
+  });
+
   test("401 + generic syntax → not transient", () => {
     const err401 = new Error("unauthorized");
     (err401 as unknown as { status: number }).status = 401;


### PR DESCRIPTION
## Why

Soak finding F35, first goal soak on the build with #2175. A goal's plan child hit `grok error: Connection error.`; the reconnect ladder retried it (`stream_error: provider error, retrying in up to 1 s (2/6)`), the retry connected, and the child then died on `grok error: terminated`. That is undici's `TypeError("terminated")` for a response body whose connection dropped mid-stream. It carries no status, no code, and in this build no cause, and the word was not in the transient message list, so the ladder classified it as permanent and the plan attempt was lost ($0.23).

## What changed

- `runtime/src/recovery/api-errors.ts`: `"terminated"` joins `TRANSIENT_PROVIDER_MESSAGE_PARTS`.

## Evidence

| check | result |
| --- | --- |
| plan child rollout `88bcf729` (goal `wf-9fa8e649`) | `stream_error … retrying in up to 1 s (2/6): grok error: Connection error.` then `turn_aborted` reason `grok error: terminated`, `run_terminal failed` |
| `node_modules/undici/lib/web/fetch/index.js` | the fetch controller emits `terminated` when the body is cut; the reader surfaces it as `TypeError: terminated` |
| `vitest run tests/recovery/api-errors.test.ts tests/session/run-turn.test.ts` | 146 passed |

## Tests

`tests/recovery/api-errors.test.ts`: a raw `TypeError("terminated")` and its `mapLLMError` result both classify as transient.

## Not changed

The ladder, its cap, and the other message parts.

## Counterparts

#2175 (connection errors), soak finding F35.
