### PR TITLE
supervised process: terminate the darwin gate handoff with a newline instead of end-of-file

### DIFF
--- a/runtime/src/agents/worktree.ts
+++ b/runtime/src/agents/worktree.ts
@@ -43,7 +43,10 @@ import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import { AsyncLock } from "./_deps/async-lock.js";
 import type { SandboxExecutionBrokerLike } from "../sandbox/execution-broker.js";
 import { gitChildEnvironment } from "../sandbox/git-environment.js";
-import { runSupervisedProcess } from "../utils/supervisedProcess.js";
+import {
+  runSupervisedProcess,
+  type SupervisedProcessResult,
+} from "../utils/supervisedProcess.js";
 import type { AdditionalPermissionProfile } from "../sandbox/engine/index.js";
 import {
   hardenGitWorktreeMutationArgs,
@@ -109,8 +112,22 @@ export function runGit(
           ? 1
           : (result.exitCode ?? 1),
     stdout: result.stdout.toString("utf8"),
-    stderr: result.error?.message ?? result.stderr.toString("utf8"),
+    stderr: describeGitProcessFailure(result),
   }));
+}
+
+/**
+ * git's own stderr when it has any; otherwise what the supervised runner did
+ * to the process. A stop reason with no output (timeout, aborted, residual
+ * process) used to surface as an empty string, and the workflow reported
+ * "git status failed: " with nothing after the colon.
+ */
+function describeGitProcessFailure(result: SupervisedProcessResult): string {
+  if (result.error !== undefined) return result.error.message;
+  const stderr = result.stderr.toString("utf8");
+  if (stderr.trim().length > 0 || result.stopReason === undefined) return stderr;
+  const signal = result.signal !== null ? ` (${result.signal})` : "";
+  return `supervised process ${result.stopReason}${signal}`;
 }
 
 export function runGitMutation(

--- a/runtime/src/utils/supervisedProcess.ts
+++ b/runtime/src/utils/supervisedProcess.ts
@@ -354,7 +354,7 @@ timer = setInterval(() => {
 }, 25);
 `;
 
-const POSIX_PROCESS_GATE_SCRIPT = String.raw`
+export const POSIX_PROCESS_GATE_SCRIPT = String.raw`
 'use strict';
 const fs = require('node:fs');
 const path = require('node:path');
@@ -367,11 +367,39 @@ function fail(message, exitCode = 125) {
   }
 }
 
+// The handoff is one JSON document followed by a newline. Read until that
+// terminator (or end-of-file, for an older owner) with blocking reads. On
+// darwin a socketpair's end-of-file raced the child's first read and was
+// lost about one spawn in two hundred; the child then sat in readFileSync
+// forever and the owner timed it out with nothing to show for it.
 let config;
 try {
-  const encoded = fs.readFileSync(3, 'utf8');
+  const chunk = Buffer.alloc(65536);
+  const parts = [];
+  let terminated = false;
+  while (!terminated) {
+    let bytes;
+    try {
+      bytes = fs.readSync(3, chunk, 0, chunk.length, null);
+    } catch (error) {
+      if (error && (error.code === 'EAGAIN' || error.code === 'EWOULDBLOCK')) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+        continue;
+      }
+      throw error;
+    }
+    if (bytes === 0) break;
+    const part = Buffer.from(chunk.subarray(0, bytes));
+    const newline = part.indexOf(0x0a);
+    if (newline === -1) {
+      parts.push(part);
+    } else {
+      parts.push(part.subarray(0, newline));
+      terminated = true;
+    }
+  }
   fs.closeSync(3);
-  config = JSON.parse(encoded);
+  config = JSON.parse(Buffer.concat(parts).toString('utf8'));
 } catch {
   fail('invalid containment handoff');
 }
@@ -529,7 +557,14 @@ export interface TerminateProcessTreeOptions {
   readonly label?: string;
 }
 
-function serializePosixProcessGatePayload(
+/**
+ * One JSON document plus a newline terminator. JSON.stringify never emits a
+ * raw newline, so the terminator is unambiguous, and the gate stops reading
+ * at it instead of waiting for an end-of-file that darwin socketpairs
+ * occasionally fail to deliver (see the gate script). Exported for the test
+ * that drives the gate script directly.
+ */
+export function serializePosixProcessGatePayload(
   program: string,
   args: readonly string[],
   options: ContainedProcessSpawnOptions,
@@ -538,12 +573,12 @@ function serializePosixProcessGatePayload(
   for (const [name, value] of Object.entries(options.env)) {
     if (value !== undefined) environment.push([name, String(value)]);
   }
-  return JSON.stringify({
+  return `${JSON.stringify({
     program,
     argv0: options.argv0 ?? program,
     args,
     environment,
-  });
+  })}\n`;
 }
 
 function trustedPosixBootstrapEnvironment(

--- a/runtime/src/workflow/worktree-lifecycle.ts
+++ b/runtime/src/workflow/worktree-lifecycle.ts
@@ -82,7 +82,9 @@ export class WorkflowGitError extends Error {
   readonly operation: string;
 
   constructor(operation: string, detail: string) {
-    super(`workflow git ${operation} failed: ${detail}`);
+    super(
+      `workflow git ${operation} failed: ${detail.trim().length > 0 ? detail : "(no output)"}`,
+    );
     this.name = "WorkflowGitError";
     this.operation = operation;
   }

--- a/runtime/tests/utils/supervisedProcess.test.ts
+++ b/runtime/tests/utils/supervisedProcess.test.ts
@@ -37,6 +37,8 @@ import {
   spawnContainedProcess,
   terminateProcessTreeAndWait,
   throwIfPreparedSpawnCleanupUnproven,
+  POSIX_PROCESS_GATE_SCRIPT,
+  serializePosixProcessGatePayload,
 } from "../../src/utils/supervisedProcess.js";
 import {
   SandboxExecutionBroker,
@@ -1897,5 +1899,64 @@ describe("terminateProcessTreeAndWait on Windows", () => {
           .map((line) => line.trim()),
       ).toEqual(["/PID 4242 /T", "/PID 4242 /T /F"]);
     });
+  });
+});
+
+describe("posix process gate handoff", () => {
+  it("execs once the newline terminator arrives, without waiting for end-of-file", async () => {
+    if (process.platform === "win32") return;
+    const payload = serializePosixProcessGatePayload("/bin/echo", ["gate-ok"], {
+      cwd: process.cwd(),
+      env: { PATH: "/usr/bin:/bin" },
+    } as never);
+    expect(payload.endsWith("\n")).toBe(true);
+    expect(payload.slice(0, -1)).not.toContain("\n");
+    const child = spawn(process.execPath, ["-e", POSIX_PROCESS_GATE_SCRIPT], {
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
+      env: { PATH: "/usr/bin:/bin" },
+    });
+    const gate = child.stdio[3] as import("node:net").Socket;
+    gate.on("error", () => {});
+    let stdout = "";
+    let stderr = "";
+    child.stdout!.on("data", (chunk) => { stdout += chunk; });
+    child.stderr!.on("data", (chunk) => { stderr += chunk; });
+    child.stdin!.end();
+    // Two writes, split mid-document, and the owner never closes its end.
+    gate.write(payload.slice(0, 20));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    gate.write(payload.slice(20));
+    const code = await new Promise<number | null>((resolve) => {
+      const timer = setTimeout(() => resolve(-1), 5_000);
+      child.once("close", (exitCode) => { clearTimeout(timer); resolve(exitCode); });
+    });
+    gate.destroy();
+    expect(stderr).toBe("");
+    expect(code).toBe(0);
+    expect(stdout).toBe("gate-ok\n");
+  });
+
+  it("still accepts an end-of-file terminated handoff from an older owner", async () => {
+    if (process.platform === "win32") return;
+    const payload = serializePosixProcessGatePayload("/bin/echo", ["legacy"], {
+      cwd: process.cwd(),
+      env: { PATH: "/usr/bin:/bin" },
+    } as never).slice(0, -1);
+    const child = spawn(process.execPath, ["-e", POSIX_PROCESS_GATE_SCRIPT], {
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
+      env: { PATH: "/usr/bin:/bin" },
+    });
+    const gate = child.stdio[3] as import("node:net").Socket;
+    gate.on("error", () => {});
+    let stdout = "";
+    child.stdout!.on("data", (chunk) => { stdout += chunk; });
+    child.stdin!.end();
+    gate.end(payload);
+    const code = await new Promise<number | null>((resolve) => {
+      const timer = setTimeout(() => resolve(-1), 5_000);
+      child.once("close", (exitCode) => { clearTimeout(timer); resolve(exitCode); });
+    });
+    expect(code).toBe(0);
+    expect(stdout).toBe("legacy\n");
   });
 });


### PR DESCRIPTION
## Why

Soak finding F34. On the first goal soak with the worktree fixes in place, a goal's implement attempt committed cleanly (`npm test` exited 0) and the run then ended `failed` with `workflow internal error: workflow git status failed: ` and nothing after the colon. `git status --porcelain` in that worktree runs in 30 ms and lists 7 files by hand.

The cause is below git. On darwin every contained process is a node gate (`spawnContainedProcess`): the owner spawns `node -e <gate script>` with a fourth stdio socketpair, starts the owner watchdog, and once the watchdog reports ready writes the JSON handoff to the socket and ends it. The gate script read that handoff with `fs.readFileSync(3)`, which returns only at end-of-file. That end-of-file is sometimes not delivered:

| experiment (800 spawns each, `/bin/echo hi`, handoff written 60 ms after spawn as in production) | hung children |
| --- | --- |
| `readFileSync(3)` until end-of-file, owner ends the socket | 4 |
| blocking `readSync` loop until end-of-file, owner ends the socket | 1 |
| handoff terminated by a newline, gate reads to the newline, owner ends the socket | 0 |
| handoff terminated by a newline, gate reads to the newline, owner never ends | 0 |

A hung gate is a live node process with fd 3 open and no output; the owner's 30 s timeout then kills it, `runGit` maps that to code 124 with an empty stderr, and the workflow prints `git status failed: `. Through `runSupervisedProcess`, every tool spawn on macOS carries the same one-in-a-few-hundred hang, seen in this soak as `exec_command` calls that took 30 s and failed with nothing to show.

## What changed

- `runtime/src/utils/supervisedProcess.ts`: `serializePosixProcessGatePayload` appends a newline (JSON.stringify never emits a raw one). The gate script reads fd 3 with blocking `readSync` until that newline, or end-of-file for an older owner, and retries on `EAGAIN`. Both are exported for the test that drives the gate directly.
- `runtime/src/agents/worktree.ts`: `runGit` reports what the runner did when git printed nothing (`supervised process timeout (SIGTERM)`), so a stopped process is never an empty string.
- `runtime/src/workflow/worktree-lifecycle.ts`: `WorkflowGitError` prints `(no output)` instead of nothing.

## Evidence

| check | result |
| --- | --- |
| goal `wf-9e3c041b` | implement committed at 19:36:51, terminal `failed` at once with the empty git status message; no verify intent journaled |
| isolation runs above | 4 and 1 hangs of 800 for the end-of-file protocol; 0 of 1600 with the newline terminator |
| hung gate forensics (`ps`, `lsof` at 2.6 s) | still the node gate, state `Ss`, fd 3 open, no signal, so readiness had arrived and the end-of-file had not |
| `vitest run tests/utils/supervisedProcess.test.ts tests/workflow/worktree-lifecycle.test.ts tests/utils/git.test.ts` | 46 passed, 12 skipped; the one failure (`terminates a session-long TERM-resistant process-group leader`) fails identically on unmodified main on this Mac |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/utils/supervisedProcess.test.ts`: the gate execs the program once the newline arrives, written in two pieces split mid-document, with the owner never closing its end; and it still accepts an end-of-file terminated handoff without the newline.

## Not changed

- The watchdog, the readiness handshake and its 2 s guard, the Linux cgroup and subreaper paths (they share the gate script and now send the terminator too).
- Timeouts and the residual-process classification.

## Counterparts

Soak finding F34 (report PR to follow). #2174 (the worktree argument fix that let a goal reach this stage for the first time).
