### PR TITLE
permissions: plan mode denies tools that change something until ExitPlanMode

### DIFF
--- a/runtime/src/permissions/classifier.ts
+++ b/runtime/src/permissions/classifier.ts
@@ -70,7 +70,7 @@ import {
  *   - Workflow orchestration
  *   - Internal classifier tool (YoloClassifier)
  */
-const SAFE_YOLO_ALLOWLISTED_TOOLS: ReadonlySet<string> = Object.freeze(
+export const SAFE_YOLO_ALLOWLISTED_TOOLS: ReadonlySet<string> = Object.freeze(
   new Set<string>([
     // Read-only file operations
     "FileRead",

--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -47,6 +47,7 @@ import {
   recordSuccess,
   type DenialTrackingState,
 } from "./denial-tracking.js";
+import { SAFE_YOLO_ALLOWLISTED_TOOLS } from "./classifier.js";
 import {
   getAskRuleForTool,
   getDenyRuleForTool,
@@ -274,6 +275,26 @@ export async function checkRuleBasedPermissions(
     });
   }
 
+  // 1a2. Plan mode is read, ask, plan. Any tool that changes something is
+  // denied until ExitPlanMode restores the mode the session came from, and
+  // the message says so. Read-only tools and the plan-mode UI tools pass;
+  // plan-with-auto keeps its classifier path below (the explicit exception).
+  // Before this the mode gated nothing here, and a session in plan mode ran
+  // whatever its underlying policy approved (#2169).
+  if (
+    appState.toolPermissionContext.mode === "plan" &&
+    appState.autoModeActive !== true &&
+    !toolDoesNotRequireApproval(tool) &&
+    !SAFE_YOLO_ALLOWLISTED_TOOLS.has(tool.name)
+  ) {
+    const message = planModeDenyMessage(tool.name);
+    return Object.freeze({
+      behavior: "deny" as const,
+      message,
+      decisionReason: { type: "other" as const, reason: message },
+    });
+  }
+
   // 1b. Whole-tool ask rule. Bash sandbox fallthrough: when sandboxing
   // is enabled and the Bash input would run inside the sandbox, skip
   // the ask short-circuit so tool.checkPermissions can auto-allow.
@@ -406,6 +427,14 @@ function checkModeGate(
   }
 
   return null;
+}
+
+function planModeDenyMessage(toolName: string): string {
+  return (
+    `Plan mode: ${toolName} would change something, so it is not allowed yet. ` +
+    "Explore with read-only tools, ask with AskUserQuestion if you must, then call " +
+    "ExitPlanMode to present the plan; changes start after it is approved."
+  );
 }
 
 function toolDoesNotRequireApproval(tool: ToolLike): boolean {

--- a/runtime/src/session/run-turn-sampling-request.ts
+++ b/runtime/src/session/run-turn-sampling-request.ts
@@ -293,7 +293,7 @@ function enforcePlanModeToolBoundary(
   state.messages.push({
     role: "user",
     content:
-      "Plan mode requires this step to end with a tool call. Do not ask questions or request approval in assistant text. If you need user input, call AskUserQuestion with concrete options. If the plan is ready for approval, call ExitPlanMode. If you need more context, call a read-only tool.",
+      "Plan mode requires this step to end with a tool call. Do not ask questions or request approval in assistant text. If you need user input, call AskUserQuestion with concrete options. If the plan is ready for approval, call ExitPlanMode. If you have concluded that nothing needs to change, that conclusion is the plan: call ExitPlanMode with it. Repeating the same text does not end the step. If you need more context, call a read-only tool.",
   });
   state.transition = { reason: "plan_tool_required" };
 }

--- a/runtime/tests/permissions/evaluator.test.ts
+++ b/runtime/tests/permissions/evaluator.test.ts
@@ -1062,3 +1062,45 @@ describe("hasPermissionsToUseTool — abort signal", () => {
     ).rejects.toThrow(/aborted/);
   });
 });
+
+describe("hasPermissionsToUseTool — plan mode denies tools that change something", () => {
+  it("denies a mutating tool in plan mode and points at ExitPlanMode", async () => {
+    const { context } = buildHarness({ mode: "plan" });
+    const result = await hasPermissionsToUseTool(
+      makeTool({ name: "Write" }),
+      { path: "/tmp/x", content: "y" },
+      context,
+    );
+    expect(result.behavior).toBe("deny");
+    if (result.behavior === "deny") {
+      expect(result.message).toContain("Plan mode: Write would change something");
+      expect(result.message).toContain("ExitPlanMode");
+    }
+    const shell = await hasPermissionsToUseTool(
+      makeTool({ name: "system.bash" }),
+      { command: "rm -rf build" },
+      context,
+    );
+    expect(shell.behavior).toBe("deny");
+  });
+
+  it("lets read-only and plan-mode tools through in plan mode", async () => {
+    const { context } = buildHarness({ mode: "plan" });
+    for (const tool of [
+      makeTool({ name: "system.gitStatus", isReadOnly: true }),
+      makeTool({ name: "system.gitLog", metadata: { mutating: false } }),
+      makeTool({ name: "ExitPlanMode" }),
+      makeTool({ name: "AskUserQuestion" }),
+      makeTool({ name: "TodoWrite" }),
+    ]) {
+      const result = await hasPermissionsToUseTool(tool, {}, context);
+      expect(result.behavior, tool.name).not.toBe("deny");
+    }
+  });
+
+  it("does not deny outside plan mode", async () => {
+    const { context } = buildHarness({ mode: "default" });
+    const result = await hasPermissionsToUseTool(makeTool({ name: "Write" }), {}, context);
+    expect(result.behavior).not.toBe("deny");
+  });
+});


### PR DESCRIPTION
## Why

Issue #2169, second and third bullets; soak findings F36 and F38, observed live on the build with #2178.

With #2178 in, `EnterPlanMode` moves a daemon session into plan mode (journaled, chip lit). In that same session the agent then ran nine `exec_command` calls which the daemon approved itself (`untrusted policy: approve every call`, the bypass policy underneath plan). They were all read-only git and npm commands, but nothing made that so: `permissions/evaluator.ts` had no plan-mode rule, so a session in plan mode ran whatever its underlying policy approved.

In the next turn the model concluded that the requested feature already existed and answered in prose. Plan mode requires each step to end with a tool call, so the boundary removed the answer and asked again; the model repeated the identical sentence dozens of times (39.6k output tokens) instead of calling `ExitPlanMode`. The nudge named `ExitPlanMode` only "if the plan is ready for approval"; a conclusion of "nothing to change" had no sanctioned exit.

## What changed

- `runtime/src/permissions/evaluator.ts`: in plan mode, a tool that changes something is denied before any policy or allow rule runs, with a message that names `ExitPlanMode`. Read-only tools (`isReadOnly`, `mutating: false`, `requiresApproval: false`) and the classifier's safe set (`AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode`, task and agent bookkeeping, and the rest of `SAFE_YOLO_ALLOWLISTED_TOOLS`, now exported) pass. Plan with `autoModeActive` keeps its classifier path, the explicit exception the issue asked for.
- `runtime/src/session/run-turn-sampling-request.ts`: the plan-mode nudge says that a conclusion of "nothing needs to change" is the plan and goes through `ExitPlanMode`, and that repeating the same text does not end the step.

## Evidence

| check | result |
| --- | --- |
| plan session `conv-mtovggow`, turn 1 | `permission_mode_changed` to `plan` at 21:05:37; 79 tool calls; 9 `exec_command` approved by policy under plan; no `ExitPlanMode` |
| same session, turn 2 | assistant text "The tags feature and search query language are already implemented. Tests passed. No further work." repeated to 39.6k output tokens; no `ExitPlanMode`; turn aborted when the recovery cap ran out (F37, separate PR) |
| `vitest run tests/permissions` | 1000 passed; the 2 failures (`permission-audit-log` AGENC_HOME resolution, `request-permissions` special path grants) fail identically on unmodified main in this shell |
| `vitest run tests/session/run-turn.test.ts -t plan` | passed |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/permissions/evaluator.test.ts`: in plan mode `Write` and `system.bash` are denied with the `ExitPlanMode` message; read-only tools and `ExitPlanMode`, `AskUserQuestion`, `TodoWrite` are not denied; outside plan mode nothing changes. The existing todo-130 case (plan does not full-bypass) still holds.

## Not changed

- `EnterPlanMode`, `ExitPlanMode`, the plan parser, the tool boundary's retry budget.
- A shell command that only reads is denied in plan mode like any other `exec_command`; a read-only classifier for shell in plan mode is a separate piece of work.
- The turn that enters plan mode keeps its `permissionMode` snapshot for the plan-mode tool boundary; the denial here reads the live mode, so it applies within that turn.

## Counterparts

#2169, #2178 (mode transition), soak findings F24, F36, F38.
