### PR TITLE
recovery: a completed sample resets the re-entry cap built up in this process

### DIFF
--- a/runtime/src/recovery/fallback-ladder.ts
+++ b/runtime/src/recovery/fallback-ladder.ts
@@ -196,6 +196,26 @@ export function resetRecoveryReentries(state: TurnState): void {
   state.recoveryReentryCount = 0;
 }
 
+/**
+ * Turn states that reserved a re-entry in this process. A resumed turn
+ * restores its pre-crash count and must keep it until something happens
+ * here; a count built up live is different: once a sample completes after
+ * it, the run made progress and the cap starts over.
+ */
+const liveRecoveryReentries = new WeakSet<object>();
+
+/**
+ * The re-entry cap stops a turn that keeps recovering without getting
+ * anywhere. A completed sample is getting somewhere. Without this, five
+ * transient reconnects spread over a long turn ended it as if it had looped
+ * (each retry had succeeded; the count only ever went up).
+ */
+export function resetRecoveryReentriesAfterProgress(state: TurnState): void {
+  if (!liveRecoveryReentries.has(state)) return;
+  liveRecoveryReentries.delete(state);
+  state.recoveryReentryCount = 0;
+}
+
 export type RecoveryReentryReservation =
   | { readonly kind: "reserved"; readonly count: number }
   | { readonly kind: "exhausted"; readonly cap: number };
@@ -218,6 +238,7 @@ function reserveRecoveryReentryLocked(
   }
 
   state.recoveryReentryCount += 1;
+  liveRecoveryReentries.add(state);
   if (triggerName) {
     emitWarning(
       session.eventLog,

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -101,6 +101,7 @@ import { reconnectWithBackoff } from "../recovery/reconnection.js";
 import {
   MAX_RECOVERY_REENTRIES,
   reserveRecoveryReentry,
+  resetRecoveryReentriesAfterProgress,
 } from "../recovery/fallback-ladder.js";
 import * as planModeHelpers from "./plan-mode.js";
 import type { ResponseItem } from "./rollout-item.js";
@@ -2308,6 +2309,11 @@ async function* runTurnKernelInner(
       // sampling request so the terminal turn_complete event carries
       // cumulative token consumption across continuation iterations.
       usage = cumulativeUsage(usage, result.usage);
+      // A sample that came back is forward progress. The recovery re-entry
+      // cap exists to stop a turn that keeps failing without getting
+      // anywhere; it was never brought back down, so five transient
+      // reconnects spread over a long turn ended it as if it had looped.
+      resetRecoveryReentriesAfterProgress(state);
       modelNeedsFollowUp = result.needsFollowUp;
       if (result.terminal) {
         if (result.assistantText.length > 0) {

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -4993,6 +4993,68 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
     vi.restoreAllMocks();
   });
 
+  test("spaced transient drops do not exhaust the recovery cap once samples complete in between", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    // Six drops, each followed by a sample that completes with a tool call,
+    // then a final answer. The cap is MAX_RECOVERY_REENTRIES = 5 consecutive
+    // re-entries; progress in between must bring the count back down.
+    let attempts = 0;
+    const provider: LLMProvider = {
+      ...mkProvider({}),
+      chatStream: async (): Promise<LLMResponse> => {
+        attempts += 1;
+        if (attempts % 2 === 1 && attempts <= 11) {
+          throw Object.assign(new Error("socket hang up"), {
+            code: "ECONNRESET",
+            statusCode: 502,
+          });
+        }
+        if (attempts < 12) {
+          return {
+            content: "",
+            toolCalls: [{ id: `tool_${attempts}`, name: "queue_tool", arguments: "{}" }],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "test-model",
+            finishReason: "tool_calls",
+          };
+        }
+        return {
+          content: "final",
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "test-model",
+          finishReason: "stop",
+        };
+      },
+    };
+    const { session, events } = mkSession({
+      provider,
+      registry: mkStaticToolRegistry(),
+    });
+
+    await drain(session.runTurn("hello", { ctx: mkCtx() }));
+
+    expect(attempts).toBe(12);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        msg: {
+          type: "turn_complete",
+          payload: expect.objectContaining({ lastAgentMessage: "final" }),
+        },
+      }),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.msg.type === "error" &&
+          String((event.msg.payload as { message?: string }).message ?? "").includes(
+            "recovery ladder exceeded",
+          ),
+      ),
+    ).toBe(false);
+  });
+
   test("LP-07 retries a mid-stream network drop and emits a stream_error notice", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.5);
 


### PR DESCRIPTION
## Why

Soak finding F37, observed live on the build with #2175 and #2179. In a long plan-mode turn the reconnect ladder handled three transient drops (`trigger=reconnect, reentryCount=1/5 … 3/5`), each retry connected and the turn went on working; a streaming fallback took the count to 4 and one more drop to 5, and the turn was aborted with `recovery ladder exceeded MAX_RECOVERY_REENTRIES=5` and `reconnect_exhausted`.

`MAX_RECOVERY_REENTRIES` exists to stop a turn that keeps recovering without getting anywhere. The count only ever went up: `resetRecoveryReentries` was defined and never called. So a turn that ran for an hour on an evening network died after its fifth blip, however much it had achieved in between.

## What changed

- `runtime/src/recovery/fallback-ladder.ts`: `reserveRecoveryReentryLocked` records that the turn state reserved a re-entry in this process; new `resetRecoveryReentriesAfterProgress(state)` brings the count back to zero only for such states. A resumed turn that restored a pre-crash count and has not recovered here keeps that count, which is what the durable-resume contract requires (`crash mid-drain → resume CONTINUES` asserts the restored `recoveryReentryCount` survives the resumed iteration).
- `runtime/src/session/run-turn.ts`: after each sampling request that returns, the turn calls `resetRecoveryReentriesAfterProgress`. A completed sample is forward progress; five consecutive failures still end the turn.

## Evidence

| check | result |
| --- | --- |
| plan session `conv-mtovggow`, turn 2 | reconnect re-entries 1, 2, 3, fallback 4, reconnect 5, `recovery_loop` error, `reconnect_exhausted`, `turn_aborted`; the retries in between had all succeeded |
| new test against the unmodified source (stashed) | fails: the turn ends after 11 provider attempts, the cap hit on the sixth drop |
| `vitest run tests/session/run-turn.test.ts tests/recovery` | 233 passed, including the durable-resume counter guard |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/session/run-turn.test.ts`: six transient `ECONNRESET` drops, each followed by a completed sample with a tool call, then a final answer: the turn completes after 12 attempts with no `recovery ladder exceeded` error. The existing resume test keeps asserting that a restored count of 3 survives a resumed iteration with no live recovery.

## Not changed

- `MAX_RECOVERY_REENTRIES`, the trigger order, the reconnect backoff.
- The restored-counter semantics on resume.

## Counterparts

Soak finding F37; #2175 and #2179 (which made the retries succeed in the first place); #2181 (the plan-mode loop that spent those retries).
