### PR TITLE
background runner: a cold-restored agent is idle until its next turn

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1076,7 +1076,15 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           bootstrap,
           control,
           thread: managedThread,
-          status: "running",
+          // A restored agent is only running when there is a turn to pick
+          // back up. Otherwise it is idle until its next prompt; reporting
+          // "running" here kept every session restored by a daemon restart
+          // listed as a working agent for the rest of the day (#2167).
+          status:
+            canonicalRuntimeState.pendingStartupActivationResumeEventId !==
+            undefined
+              ? "running"
+              : "idle",
           startedAt,
           ...(params.restoreAttemptId !== undefined
             ? { restoreAttemptId: params.restoreAttemptId }
@@ -1209,6 +1217,18 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         active.unsubscribeElicitationEvents =
           this.#installSessionEventLogBridge(active);
         this.#trackAgentStatus(active);
+        // The thread replays its current status on subscribe, and a hydrated
+        // thread reports pending_init, which maps to "running". A restored
+        // agent with no turn to pick up is idle until its next prompt; left
+        // as "running" it sat in every agent list as a working agent for the
+        // rest of the day (#2167).
+        if (
+          canonicalRuntimeState.pendingStartupActivationResumeEventId ===
+            undefined &&
+          managedThread.status().status === "pending_init"
+        ) {
+          active.status = "idle";
+        }
         active.unsubscribePhaseEvents = bootstrap.session.subscribeToEvents(
           (phase) => {
             const progress = phaseEventToProgressEvent(phase);

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -2363,6 +2363,36 @@ describe("AgenC delegate background-agent runner", () => {
     ).resolves.not.toBeNull();
   });
 
+  it("reports a cold-restored agent idle until a turn starts", async () => {
+    // A hydrated thread reports pending_init, which maps to "running"; with
+    // nothing to resume the restored agent must read idle until its next
+    // prompt, not sit in every agent list as a working agent.
+    const harness = makeTopLevelRunner({
+      conversationId: "session-restored-idle",
+      threadInitialStatus: { status: "pending_init" },
+    });
+    await expect(
+      harness.runner.restoreAgent({
+        agentId: "session-restored-idle",
+        objective: "retained objective",
+        explicitColdResume: true,
+        initialMessages: [{ role: "user" as const, content: "retained" }],
+      }),
+    ).resolves.toBe(true);
+    const restored = await harness.runner.getAgentSnapshot("session-restored-idle");
+    expect(restored?.status).toBe("idle");
+
+    harness.stub.pushStatus({
+      status: "running",
+      turnId: "turn-after-restart",
+      startedAtMs: 3,
+    });
+    await vi.waitFor(async () => {
+      const snapshot = await harness.runner.getAgentSnapshot("session-restored-idle");
+      expect(snapshot?.status).toBe("running");
+    });
+  });
+
   it("retires a failed restore generation so an exact retry can proceed", async () => {
     let harness: ReturnType<typeof makeTopLevelRunner>;
     let hydrationAttempts = 0;

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -6202,7 +6202,7 @@ snapshot_max_bytes = 64
     );
     expect(recovered).toMatchObject({
       agentId: createdAgentId,
-      status: "running",
+      status: "idle",
       metadata: {
         recovery: {
           runnable: true,

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -4998,7 +4998,9 @@ snapshot_max_bytes = 64
     expect(agentList.agents[1]).toMatchObject({
       agentId: "run-restart",
       objective: "recover daemon state",
-      status: "running",
+      // Restored with nothing to resume: idle until its next prompt. The
+      // run's own persisted status stays "running" in the recovery metadata.
+      status: "idle",
       activeSessionIds: ["session-restart"],
       metadata: {
         recovery: {

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -5033,7 +5033,7 @@ snapshot_max_bytes = 64
     });
     expect(agentList.agents[0]).toMatchObject({
       agentId: "run-other",
-      status: "running",
+      status: "idle",
       metadata: {
         recovery: {
           runStatus: "blocked",


### PR DESCRIPTION
## Why

Issue #2167, the part that remained after today's restarts. Every session restored by a daemon restart read `running` in `agent.list` and in the desktop's Agents pane until it happened to run a turn: after the 21:02 restart three goal narrating sessions sat as working agents for hours with nothing in flight, while sessions that had a turn afterwards flipped to `idle` correctly.

The runner builds a restored agent's record with `status: "running"`, subscribes to the thread's status, and the thread manager replays its current status on subscribe. A hydrated thread reports `pending_init`, which `mapThreadStatus` maps to `running`. So a cold-restored agent with no turn to resume was `running` by construction, and nothing changed it until a turn started and completed.

## What changed

- `runtime/src/app-server/background-agent-runner.ts`: the restored record starts `running` only when a startup activation is pending; after the status subscription's replay, a restored agent whose thread is still `pending_init` and has nothing to resume is set to `idle`. The next `turn_started` moves it to `running` as before.

## Evidence

| check | result |
| --- | --- |
| app agent list after the 21:02 restart | `conv-mtolraqm`, `conv-mtoo1i4k`, `conv-mtornctu` `running` with `lastActiveAt` 21:02:50 and no turn since; sessions that ran a turn later read `idle` |
| new test against the stashed source | fails: `expected 'running' to be 'idle'` |
| `vitest run tests/app-server/background-agent-runner.contract.test.ts tests/app-server/agent-lifecycle.contract.test.ts` | passed |
| `tsc --noEmit` | no errors beyond this Mac's known worktree declaration quirk |

## Tests

`tests/app-server/daemon-cli.contract.test.ts` (`foreground daemon runs restart recovery before advertising readiness`): the recovered agent is now listed `idle`; its recovery metadata still records the run's persisted `runStatus: "running"`.

`tests/app-server/background-agent-runner.contract.test.ts`: a cold restore on a `pending_init` thread reports `idle`, and a pushed `running` status moves it to `running`.

## Not changed

- `mapThreadStatus`: a freshly started agent still reads `running` from `pending_init` until its first turn event.
- The manager's recovery path (`agentStatusForRecoveredRun` already said `idle`; the runner snapshot overrode it).
- Interactive sessions that never restart: their status already follows `turn_started` and `turn_complete`.

## Counterparts

#2167; soak finding F22.
