### PR TITLE
execute-tools: a call the repeat guard refuses gets exactly one result

### DIFF
--- a/runtime/src/phases/execute-tools.ts
+++ b/runtime/src/phases/execute-tools.ts
@@ -61,6 +61,7 @@ import {
   appendRepeatToolAdvisory,
   blockRepeatedFailingCall,
   repeatedFailingCallStopExplanation,
+  isRepeatedFailingCall,
 } from "./repeat-tool-advisory.js";
 import type { Session } from "../session/session.js";
 import type { GuardianApprovalReviewer } from "../permissions/guardian/reviewer.js";
@@ -602,6 +603,11 @@ export function queueStreamingToolCall(
     .getToolStates()
     .some((state) => state.id === call.id);
   if (alreadyQueued) return false;
+  // A call the repeat guard is about to refuse must not run. Leaving it to
+  // the post-stream pass records the refusal as the call's single result;
+  // dispatching it here raced that refusal with the real result under one
+  // call id, and the rollout's tool-pair validator rejected the second.
+  if (state !== undefined && isRepeatedFailingCall(state, call)) return false;
   if (
     call.name === EDITOR_PROPOSAL_TOOL_NAME &&
     ctx?.editorInteraction === undefined
@@ -965,7 +971,14 @@ export async function executeTools(
 
     // Hard stop for a byte-identical call that already failed the same way
     // three times this turn: refuse it instead of burning another round trip.
-    const blocked = blockRepeatedFailingCall(state, session, call);
+    // A call the streaming path already dispatched has a result on the way;
+    // refusing it here would record a second result for the same call id.
+    const alreadyDispatched = executor
+      .getToolStates()
+      .some((toolState) => toolState.id === call.id);
+    const blocked = alreadyDispatched
+      ? null
+      : blockRepeatedFailingCall(state, session, call);
     if (blocked !== null) {
       session.emit({
         id: session.nextInternalSubId(),

--- a/runtime/src/phases/repeat-tool-advisory.ts
+++ b/runtime/src/phases/repeat-tool-advisory.ts
@@ -252,6 +252,21 @@ export function repeatedFailingCallStopExplanation(
 }
 
 /**
+ * Whether `blockRepeatedFailingCall` would refuse this call, decided without
+ * emitting anything. The streaming dispatch path asks this before it queues a
+ * call, so a call that is about to be refused never runs, and the refusal is
+ * recorded once by the post-stream pass as the call's only result.
+ */
+export function isRepeatedFailingCall(
+  state: TurnState,
+  call: LLMToolCall,
+): boolean {
+  return (
+    identicalFailureRun(state, call).count >= REPEATED_FAILURE_BLOCK_THRESHOLD
+  );
+}
+
+/**
  * Refuse a call that has already failed identically
  * `REPEATED_FAILURE_BLOCK_THRESHOLD` times in this turn. Returns the
  * synthetic error result to record in place of a dispatch, or null when the

--- a/runtime/tests/phases/execute-tools.test.ts
+++ b/runtime/tests/phases/execute-tools.test.ts
@@ -1223,18 +1223,23 @@ describe("executeTools — T7 gap #109 pipeline", () => {
     });
   });
 
-  test("the streaming path does not dispatch a call the repeat guard is about to refuse", async () => {
+  /**
+   * A turn whose model keeps issuing one identical `Write` that keeps failing
+   * the same way. `failures(n)` seeds n earlier identical failures; the tool
+   * records how often it really ran.
+   */
+  function repeatedFailureFixture() {
     const denial =
-      '{"error":"sandbox escalation requires approval, but approval policy is never"}';
+      '{"error":"file_path is outside allowed directories: /root/memory/style.md"}';
+    const args = JSON.stringify({ file_path: "/root/memory/style.md", content: "x" });
+    const call: LLMToolCall = { id: "write-4", name: "Write", arguments: args };
     let executed = 0;
-    const args = JSON.stringify({ cmd: "npm install" });
-    const call: LLMToolCall = { id: "exec-4", name: "exec_command", arguments: args };
-    const { state, session, warnings, emitted, run } = singleToolRun(
+    const fixture = singleToolRun(
       {
-        name: "exec_command",
-        description: "runs a command",
+        name: "Write",
+        description: "writes a file",
         inputSchema: { type: "object" },
-        metadata: { family: "shell", source: "builtin", mutating: true },
+        metadata: { family: "filesystem", source: "builtin", mutating: true },
         execute: async () => {
           executed += 1;
           return { content: denial, isError: true };
@@ -1242,104 +1247,80 @@ describe("executeTools — T7 gap #109 pipeline", () => {
       },
       call,
     );
-    state.completedToolResults = [1, 2, 3].map((n) => ({
-      callId: `exec-${n}`,
-      toolName: "exec_command",
-      arguments: args,
-      content: denial,
-      isError: true,
-    }));
-    const executor = ensureStreamingToolExecutor(state, mkCtx(), session);
-
-    // The fourth identical call streams in: it must not start.
-    expect(
-      queueStreamingToolCall(
-        executor,
-        { type: "tool_use", id: call.id, name: call.name, input: {} },
-        call,
-        session,
-        mkCtx(),
-        state,
-      ),
-    ).toBe(false);
-    expect(executor.getToolStates()).toHaveLength(0);
-
-    await run();
-
-    expect(executed).toBe(0);
-    expect(
-      warnings.filter((cause) => cause === "repeated_failing_call_blocked"),
-    ).toHaveLength(1);
-    // One result for the call id: the refusal, recorded by the post-stream pass.
-    expect(
-      emitted.filter(
-        (event) =>
-          event.msg.type === "tool_call_completed" &&
-          event.msg.payload?.callId === call.id,
-      ),
-    ).toHaveLength(1);
-    expect(state.messages).toHaveLength(1);
-    expect(state.messages[0]?.content).toContain("will not run again");
-  });
-
-  test("a call the streaming path already dispatched is not refused again by the post-stream pass", async () => {
-    const denial =
-      '{"error":"sandbox escalation requires approval, but approval policy is never"}';
-    let executed = 0;
-    const args = JSON.stringify({ cmd: "npm install" });
-    const call: LLMToolCall = { id: "exec-4", name: "exec_command", arguments: args };
-    const { state, session, warnings, emitted, run } = singleToolRun(
-      {
-        name: "exec_command",
-        description: "runs a command",
-        inputSchema: { type: "object" },
-        metadata: { family: "shell", source: "builtin", mutating: true },
-        execute: async () => {
-          executed += 1;
-          return { content: denial, isError: true };
-        },
-      },
-      call,
-    );
+    const ctx = mkCtx({ sandboxPolicy: { value: "danger_full_access" } });
     const failures = (count: number) =>
       Array.from({ length: count }, (_, i) => ({
-        callId: `exec-${i + 1}`,
-        toolName: "exec_command",
+        callId: `write-${i + 1}`,
+        toolName: "Write",
         arguments: args,
         content: denial,
         isError: true,
       }));
-    // Two identical failures so far: the guard lets the call stream in.
-    state.completedToolResults = failures(2);
-    const executor = ensureStreamingToolExecutor(state, mkCtx(), session);
-    expect(
-      queueStreamingToolCall(
-        executor,
-        { type: "tool_use", id: call.id, name: call.name, input: {} },
-        call,
-        session,
-        mkCtx(),
-        state,
-      ),
-    ).toBe(true);
-    // A third identical failure lands before the post-stream pass reaches the call.
-    state.completedToolResults = failures(3);
-
-    await run();
-
-    // The dispatched call's own result is the only result for its id.
-    expect(executed).toBe(1);
-    expect(warnings).not.toContain("repeated_failing_call_blocked");
-    expect(
-      emitted.filter(
+    const completionsFor = (callId: string) =>
+      fixture.emitted.filter(
         (event) =>
           event.msg.type === "tool_call_completed" &&
-          event.msg.payload?.callId === call.id,
-      ),
+          event.msg.payload?.callId === callId,
+      );
+    const streamIn = () =>
+      queueStreamingToolCall(
+        ensureStreamingToolExecutor(fixture.state, ctx, fixture.session),
+        { type: "tool_use", id: call.id, name: call.name, input: {} },
+        call,
+        fixture.session,
+        ctx,
+        fixture.state,
+      );
+    return {
+      ...fixture,
+      call,
+      ctx,
+      failures,
+      completionsFor,
+      streamIn,
+      executed: () => executed,
+      run: () => executeTools(fixture.state, ctx, fixture.session),
+    };
+  }
+
+  test("the streaming path does not dispatch a call the repeat guard is about to refuse", async () => {
+    const f = repeatedFailureFixture();
+    f.state.completedToolResults = f.failures(3);
+
+    // The fourth identical call streams in: it must not start.
+    expect(f.streamIn()).toBe(false);
+    expect(f.state.streamingToolExecutor?.getToolStates()).toHaveLength(0);
+
+    await f.run();
+
+    expect(f.executed()).toBe(0);
+    expect(
+      f.warnings.filter((cause) => cause === "repeated_failing_call_blocked"),
     ).toHaveLength(1);
-    expect(state.messages).toHaveLength(1);
-    expect(state.messages[0]?.content).toContain("approval policy is never");
-    expect(state.messages[0]?.content).not.toContain("will not run again");
+    // One result for the call id: the refusal, recorded by the post-stream pass.
+    expect(f.completionsFor(f.call.id)).toHaveLength(1);
+    expect(f.state.messages).toHaveLength(1);
+    expect(f.state.messages[0]?.content).toContain("will not run again");
+  });
+
+  test("a call the streaming path already dispatched is not refused again by the post-stream pass", async () => {
+    const f = repeatedFailureFixture();
+    // Two identical failures so far: the guard lets the call stream in and start.
+    f.state.completedToolResults = f.failures(2);
+    expect(f.streamIn()).toBe(true);
+    f.state.streamingToolExecutor?.dispatchPending();
+    // A third identical failure lands before the post-stream pass reaches the call.
+    f.state.completedToolResults = f.failures(3);
+
+    await f.run();
+
+    // The dispatched call's own result is the only result for its id.
+    expect(f.executed()).toBe(1);
+    expect(f.warnings).not.toContain("repeated_failing_call_blocked");
+    expect(f.completionsFor(f.call.id)).toHaveLength(1);
+    expect(f.state.messages).toHaveLength(1);
+    expect(f.state.messages[0]?.content).toContain("outside allowed directories");
+    expect(f.state.messages[0]?.content).not.toContain("will not run again");
   });
 
   test("identical calls that keep succeeding are never refused", async () => {

--- a/runtime/tests/phases/execute-tools.test.ts
+++ b/runtime/tests/phases/execute-tools.test.ts
@@ -1223,6 +1223,125 @@ describe("executeTools — T7 gap #109 pipeline", () => {
     });
   });
 
+  test("the streaming path does not dispatch a call the repeat guard is about to refuse", async () => {
+    const denial =
+      '{"error":"sandbox escalation requires approval, but approval policy is never"}';
+    let executed = 0;
+    const args = JSON.stringify({ cmd: "npm install" });
+    const call: LLMToolCall = { id: "exec-4", name: "exec_command", arguments: args };
+    const { state, session, warnings, emitted, run } = singleToolRun(
+      {
+        name: "exec_command",
+        description: "runs a command",
+        inputSchema: { type: "object" },
+        metadata: { family: "shell", source: "builtin", mutating: true },
+        execute: async () => {
+          executed += 1;
+          return { content: denial, isError: true };
+        },
+      },
+      call,
+    );
+    state.completedToolResults = [1, 2, 3].map((n) => ({
+      callId: `exec-${n}`,
+      toolName: "exec_command",
+      arguments: args,
+      content: denial,
+      isError: true,
+    }));
+    const executor = ensureStreamingToolExecutor(state, mkCtx(), session);
+
+    // The fourth identical call streams in: it must not start.
+    expect(
+      queueStreamingToolCall(
+        executor,
+        { type: "tool_use", id: call.id, name: call.name, input: {} },
+        call,
+        session,
+        mkCtx(),
+        state,
+      ),
+    ).toBe(false);
+    expect(executor.getToolStates()).toHaveLength(0);
+
+    await run();
+
+    expect(executed).toBe(0);
+    expect(
+      warnings.filter((cause) => cause === "repeated_failing_call_blocked"),
+    ).toHaveLength(1);
+    // One result for the call id: the refusal, recorded by the post-stream pass.
+    expect(
+      emitted.filter(
+        (event) =>
+          event.msg.type === "tool_call_completed" &&
+          event.msg.payload?.callId === call.id,
+      ),
+    ).toHaveLength(1);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.content).toContain("will not run again");
+  });
+
+  test("a call the streaming path already dispatched is not refused again by the post-stream pass", async () => {
+    const denial =
+      '{"error":"sandbox escalation requires approval, but approval policy is never"}';
+    let executed = 0;
+    const args = JSON.stringify({ cmd: "npm install" });
+    const call: LLMToolCall = { id: "exec-4", name: "exec_command", arguments: args };
+    const { state, session, warnings, emitted, run } = singleToolRun(
+      {
+        name: "exec_command",
+        description: "runs a command",
+        inputSchema: { type: "object" },
+        metadata: { family: "shell", source: "builtin", mutating: true },
+        execute: async () => {
+          executed += 1;
+          return { content: denial, isError: true };
+        },
+      },
+      call,
+    );
+    const failures = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        callId: `exec-${i + 1}`,
+        toolName: "exec_command",
+        arguments: args,
+        content: denial,
+        isError: true,
+      }));
+    // Two identical failures so far: the guard lets the call stream in.
+    state.completedToolResults = failures(2);
+    const executor = ensureStreamingToolExecutor(state, mkCtx(), session);
+    expect(
+      queueStreamingToolCall(
+        executor,
+        { type: "tool_use", id: call.id, name: call.name, input: {} },
+        call,
+        session,
+        mkCtx(),
+        state,
+      ),
+    ).toBe(true);
+    // A third identical failure lands before the post-stream pass reaches the call.
+    state.completedToolResults = failures(3);
+
+    await run();
+
+    // The dispatched call's own result is the only result for its id.
+    expect(executed).toBe(1);
+    expect(warnings).not.toContain("repeated_failing_call_blocked");
+    expect(
+      emitted.filter(
+        (event) =>
+          event.msg.type === "tool_call_completed" &&
+          event.msg.payload?.callId === call.id,
+      ),
+    ).toHaveLength(1);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.content).toContain("approval policy is never");
+    expect(state.messages[0]?.content).not.toContain("will not run again");
+  });
+
   test("identical calls that keep succeeding are never refused", async () => {
     let executed = 0;
     const args = JSON.stringify({ file_path: "src/app.ts" });


### PR DESCRIPTION
## Why

Desktop soak on the production bundle, 2026-09-06 (`~/claude-agenc/soak`, run `mem-prod-1`, session `conv-mtp5odh9`). The model issued the same `exec_command` (`npm install` with `sandbox_permissions: require_escalated`) a fourth time after three identical denials. The rollout shows what followed for one call id:

| record | event |
| --- | --- |
| 1065 | `tool_call_started` from the streaming dispatch path, while the call was still streaming in |
| 1073 | `warning repeated_failing_call_blocked` from the post-stream pass |
| 1074, 1075 | `tool_call_started` and `tool_call_completed` again, with the guard's refusal |
| 1076 | `tool_call_completed` again, with the real result of the streamed dispatch |

Two results for one call id. The rollout's live tool-pair validator rejected the second as `tool_result_duplicate` (`tool-pair history rejected during live append: tool result repeats "call-…-22"`), the turn ended in error, and every later turn of the session ended empty within four seconds because nothing could be appended to its history any more (that follow-on is #2163).

The guard was added to save a round trip on a call that keeps failing identically; with streaming dispatch on, the call had already started by the time the guard looked at it, so the guard never prevented a dispatch and only ever produced the duplicate.

## What changed

- `runtime/src/phases/repeat-tool-advisory.ts`: `isRepeatedFailingCall(state, call)`, the guard's decision as a pure predicate with no warning and no synthetic result.
- `runtime/src/phases/execute-tools.ts`: `queueStreamingToolCall` returns `false` for a call the predicate flags, so the streaming path never dispatches it and the post-stream pass records the refusal as the call's only result. The post-stream guard is skipped for a call the executor already has (`getToolStates()` carries its id), so a failure count that crosses the threshold between the two passes cannot record a second result.
- `runtime/tests/phases/execute-tools.test.ts`: two tests, below.

## Evidence

Same session, same rollout: the 1065 dispatch is what this change removes; with it, record 1074 and 1075 are the call's only start and completion and 1076 never exists.

## Tests

- "the streaming path does not dispatch a call the repeat guard is about to refuse": three identical failures on the turn, the fourth call streams in; `queueStreamingToolCall` returns `false`, the executor holds no state for it, the tool never runs, one `repeated_failing_call_blocked` warning, exactly one `tool_call_completed` for the id, one refusal message in `state.messages`.
- "a call the streaming path already dispatched is not refused again by the post-stream pass": two failures at stream time so the call is dispatched, a third lands before the post-stream pass; the tool runs once, no refusal warning, exactly one `tool_call_completed` for the id, and the message is the tool's own result.
- `tests/phases/execute-tools.test.ts` and `tests/phases/repeat-tool-advisory.test.ts`: 94 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The guard's threshold, wording, warning and no-progress stop.
- The tool-pair validator: rejecting a duplicate result is correct; this stops the runtime from producing one.
- Why bypass mode denied the escalation the call asked for (`sandbox escalation requires approval, but approval policy is never`) is a separate fix.

## Counterparts

#2163 (turns after a blocked history report no reason). Desktop soak findings F43 in `~/claude-agenc/soak/findings.md`.