### PR TITLE
orchestrator: bypass mode grants a sandbox permission request instead of denying it

### DIFF
--- a/runtime/src/tools/orchestrator.ts
+++ b/runtime/src/tools/orchestrator.ts
@@ -546,6 +546,7 @@ function approvalRejectionMessage(
 
 type SandboxPermissionApprovalAction =
   | { readonly kind: "none" }
+  | { readonly kind: "granted"; readonly reason: string }
   | { readonly kind: "prompt"; readonly reason: string }
   | { readonly kind: "deny"; readonly reason: string };
 
@@ -553,11 +554,24 @@ function sandboxPermissionApprovalAction(opts: {
   readonly request: SandboxPermissionsRequest;
   readonly approvalPolicy: ApprovalPolicy;
   readonly granular?: GranularApprovalConfig;
+  /**
+   * The session runs in the `bypassPermissions` mode. Bypass suppresses the
+   * approval a sandbox request would otherwise prompt for, so the request is
+   * granted the way an approval would grant it. The `never` approval policy
+   * outside bypass still denies: there nobody chose to skip the question.
+   */
+  readonly bypassPermissions?: boolean;
 }): SandboxPermissionApprovalAction {
   switch (opts.request.kind) {
     case "default":
       return { kind: "none" };
     case "require_escalated":
+      if (opts.bypassPermissions === true) {
+        return {
+          kind: "granted",
+          reason: "sandbox escalation granted by the bypass permission mode",
+        };
+      }
       if (opts.approvalPolicy === "never") {
         return {
           kind: "deny",
@@ -581,6 +595,13 @@ function sandboxPermissionApprovalAction(opts: {
     case "with_additional_permissions":
       if (!hasAdditionalSandboxPermissions(opts.request.additionalPermissions)) {
         return { kind: "none" };
+      }
+      if (opts.bypassPermissions === true) {
+        return {
+          kind: "granted",
+          reason:
+            "additional sandbox permissions granted by the bypass permission mode",
+        };
       }
       if (opts.approvalPolicy === "never") {
         return {
@@ -713,6 +734,7 @@ export async function orchestrateToolCall<T>(
     request: normalizedSandboxPermissions,
     approvalPolicy: effectiveApprovalPolicy,
     granular: opts.granular,
+    bypassPermissions: isBypassPermissionsMode,
   });
   const execPolicyAction = evaluateLocalShellExecPolicyAction({
     policy: opts.execPolicy,
@@ -830,7 +852,8 @@ export async function orchestrateToolCall<T>(
     alreadyApproved = true;
   }
   const additionalPermissions =
-    alreadyApproved && sandboxPermissionApproval.kind === "prompt"
+    (alreadyApproved && sandboxPermissionApproval.kind === "prompt") ||
+    sandboxPermissionApproval.kind === "granted"
       ? requestedAdditionalPermissions
       : undefined;
 

--- a/runtime/tests/tools/orchestrator.test.ts
+++ b/runtime/tests/tools/orchestrator.test.ts
@@ -926,7 +926,11 @@ describe("orchestrateToolCall lifecycle (orchestrator behavior)", () => {
     expect(dispatched).not.toHaveBeenCalled();
   });
 
-  test("sandbox_permissions=require_escalated: bypassPermissions grants the escalation without a prompt", async () => {
+  /**
+   * A call under the bypassPermissions mode: approval policy never, a
+   * workspace-write sandbox, and a resolver that must never be asked.
+   */
+  async function bypassModeCall(approvalArgs: Record<string, unknown>) {
     const resolver: ApprovalResolver = {
       request: vi.fn(async () => ({ kind: "approved" })),
     };
@@ -945,51 +949,32 @@ describe("orchestrateToolCall lifecycle (orchestrator behavior)", () => {
       },
       approvalPolicy: "never",
       sandboxMode: "workspace_write",
-      approvalArgs: { sandbox_permissions: "require_escalated" },
+      approvalArgs,
       dispatch: dispatched,
       approvalResolver: resolver,
     });
-
     expect(result).toBe("ok");
     expect(resolver.request).not.toHaveBeenCalled();
     expect(dispatched).toHaveBeenCalledOnce();
+    return dispatched.mock.calls[0] as unknown as [string, Record<string, unknown>];
+  }
+
+  test("sandbox_permissions=require_escalated: bypassPermissions grants the escalation without a prompt", async () => {
+    const [sandbox] = await bypassModeCall({
+      sandbox_permissions: "require_escalated",
+    });
     // The grant runs the call the way an approval would: outside the sandbox.
-    expect(dispatched.mock.calls[0]?.[0]).toBe("danger_full_access");
+    expect(sandbox).toBe("danger_full_access");
   });
 
   test("sandbox_permissions=with_additional_permissions: bypassPermissions grants the permissions without a prompt", async () => {
-    const resolver: ApprovalResolver = {
-      request: vi.fn(async () => ({ kind: "approved" })),
-    };
-    const dispatched = vi.fn(async () => "ok");
-    const result = await orchestrateToolCall<string>({
-      tool: mkTool(),
-      approvalCtx: {
-        ...mkCtx(),
-        invocation: {
-          session: approvalSession({
-            permissionModeRegistry: {
-              current: () => ({ mode: "bypassPermissions" }),
-            },
-          }),
-        } as never,
-      },
-      approvalPolicy: "never",
-      sandboxMode: "workspace_write",
-      approvalArgs: {
-        sandbox_permissions: "with_additional_permissions",
-        additional_permissions: { network: { enabled: true } },
-      },
-      dispatch: dispatched,
-      approvalResolver: resolver,
+    const [sandbox, context] = await bypassModeCall({
+      sandbox_permissions: "with_additional_permissions",
+      additional_permissions: { network: { enabled: true } },
     });
-
-    expect(result).toBe("ok");
-    expect(resolver.request).not.toHaveBeenCalled();
-    expect(dispatched).toHaveBeenCalledOnce();
     // Still sandboxed, with the requested permissions passed through.
-    expect(dispatched.mock.calls[0]?.[0]).toBe("workspace_write");
-    expect(dispatched.mock.calls[0]?.[1]).toMatchObject({
+    expect(sandbox).toBe("workspace_write");
+    expect(context).toMatchObject({
       additionalPermissions: { network: { enabled: true } },
     });
   });

--- a/runtime/tests/tools/orchestrator.test.ts
+++ b/runtime/tests/tools/orchestrator.test.ts
@@ -926,6 +926,74 @@ describe("orchestrateToolCall lifecycle (orchestrator behavior)", () => {
     expect(dispatched).not.toHaveBeenCalled();
   });
 
+  test("sandbox_permissions=require_escalated: bypassPermissions grants the escalation without a prompt", async () => {
+    const resolver: ApprovalResolver = {
+      request: vi.fn(async () => ({ kind: "approved" })),
+    };
+    const dispatched = vi.fn(async () => "ok");
+    const result = await orchestrateToolCall<string>({
+      tool: mkTool(),
+      approvalCtx: {
+        ...mkCtx(),
+        invocation: {
+          session: approvalSession({
+            permissionModeRegistry: {
+              current: () => ({ mode: "bypassPermissions" }),
+            },
+          }),
+        } as never,
+      },
+      approvalPolicy: "never",
+      sandboxMode: "workspace_write",
+      approvalArgs: { sandbox_permissions: "require_escalated" },
+      dispatch: dispatched,
+      approvalResolver: resolver,
+    });
+
+    expect(result).toBe("ok");
+    expect(resolver.request).not.toHaveBeenCalled();
+    expect(dispatched).toHaveBeenCalledOnce();
+    // The grant runs the call the way an approval would: outside the sandbox.
+    expect(dispatched.mock.calls[0]?.[0]).toBe("danger_full_access");
+  });
+
+  test("sandbox_permissions=with_additional_permissions: bypassPermissions grants the permissions without a prompt", async () => {
+    const resolver: ApprovalResolver = {
+      request: vi.fn(async () => ({ kind: "approved" })),
+    };
+    const dispatched = vi.fn(async () => "ok");
+    const result = await orchestrateToolCall<string>({
+      tool: mkTool(),
+      approvalCtx: {
+        ...mkCtx(),
+        invocation: {
+          session: approvalSession({
+            permissionModeRegistry: {
+              current: () => ({ mode: "bypassPermissions" }),
+            },
+          }),
+        } as never,
+      },
+      approvalPolicy: "never",
+      sandboxMode: "workspace_write",
+      approvalArgs: {
+        sandbox_permissions: "with_additional_permissions",
+        additional_permissions: { network: { enabled: true } },
+      },
+      dispatch: dispatched,
+      approvalResolver: resolver,
+    });
+
+    expect(result).toBe("ok");
+    expect(resolver.request).not.toHaveBeenCalled();
+    expect(dispatched).toHaveBeenCalledOnce();
+    // Still sandboxed, with the requested permissions passed through.
+    expect(dispatched.mock.calls[0]?.[0]).toBe("workspace_write");
+    expect(dispatched.mock.calls[0]?.[1]).toMatchObject({
+      additionalPermissions: { network: { enabled: true } },
+    });
+  });
+
   test("sandbox_permissions=with_additional_permissions stays sandboxed after approval", async () => {
     const dispatches: string[] = [];
     const resolver = vi.fn(async (ctx: ApprovalCtx) => {


### PR DESCRIPTION
## Why

Desktop soak on the production bundle, 2026-09-06, session `conv-mtp5odh9` in `bypassPermissions` mode. The model ran `npm install` in the workspace-write sandbox, the install needed the network, and the model asked again with `sandbox_permissions: require_escalated`. The orchestrator answered:

```
sandbox escalation requires approval, but approval policy is never
```

three times in a row, the model retried the identical call, and the repeat guard's refusal collided with the streamed dispatch (#2184). Behind it sits the policy gap: `executionAuthorityForPermissionContext` gives a bypass session `approvalPolicy: never` and leaves the sandbox at `workspace_write`, and `sandboxPermissionApprovalAction` treats `never` as "deny every escalation". Bypass had suppressed the approval prompt without granting what the prompt would have granted, so a bypass session could never install a package, fetch a dependency, or write outside the workspace on request. The same session would have prompted the user in the default mode and run the command after a click.

## What changed

- `runtime/src/tools/orchestrator.ts`: `sandboxPermissionApprovalAction` takes `bypassPermissions` (the orchestrator already derives it from the session's permission-mode registry for the classifier). Under bypass, `require_escalated` and `with_additional_permissions` return a new `granted` action instead of the `never` denial: no prompt, no `ApprovalRejectedError`. The first-attempt sandbox override already maps an escalation request to `danger_full_access`, so a granted escalation runs outside the sandbox exactly as an approved one does; a granted additional-permissions request stays sandboxed and passes its permissions to the dispatch, which previously happened only after an accepted prompt. The `never` policy outside bypass, the granular denials and the prompt path are untouched.

## Evidence

The soak session's records 995 to 1003 and 1065 to 1076 are the denials; with this change the first `require_escalated` call runs unsandboxed and the turn continues.

## Tests

- "sandbox_permissions=require_escalated: bypassPermissions grants the escalation without a prompt": approval policy `never`, sandbox `workspace_write`, registry mode `bypassPermissions`; the resolver is never asked, the dispatch runs once with `danger_full_access`.
- "sandbox_permissions=with_additional_permissions: bypassPermissions grants the permissions without a prompt": same mode; the dispatch runs once, still `workspace_write`, with `additionalPermissions: { network: { enabled: true } }`.
- The existing "approvalPolicy=never denies before sandbox bypass" test (no bypass mode) still passes. `tests/tools/orchestrator.test.ts`: 79 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The default sandbox of a bypass session stays `workspace_write`; bypass still does not widen the sandbox for calls that do not ask.
- `dangerouslyBypassApprovalsAndSandbox`, which already runs everything at `danger_full_access`.
- The `never` approval policy in review-forced and unattended contexts.

## Counterparts

#2184 (one result per refused call). Desktop soak finding F44 in `~/claude-agenc/soak/findings.md`.
