### PR TITLE
daemon: a session whose live history is blocked refuses new prompts with the reason

### DIFF
--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -212,7 +212,8 @@ export type AgenCDaemonAgentLifecycleErrorCode =
   | "RUN_CANCEL_UNAVAILABLE"
   | "TURN_IN_PROGRESS"
   | "CLIENT_MESSAGE_ID_CONFLICT"
-  | "PROMPT_BLOCKED";
+  | "PROMPT_BLOCKED"
+  | "SESSION_HISTORY_BLOCKED";
 
 export class AgenCDaemonAgentLifecycleError extends Error {
   readonly code: AgenCDaemonAgentLifecycleErrorCode;

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1802,6 +1802,18 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         `session ${params.sessionId} already has an active or queued turn`,
       );
     }
+    // A history the live tool-pair validator has closed cannot take the user
+    // message this turn would start with. Refusing here gives the client the
+    // reason; opening the turn gave it an empty turn that ended in seconds.
+    const historyBlocked =
+      active.bootstrap.rolloutStore.liveHistoryBlockedReason();
+    if (historyBlocked !== undefined) {
+      throw new AgenCBackgroundAgentMessageError(
+        "SESSION_HISTORY_BLOCKED",
+        `session ${params.sessionId} cannot start a turn: ${historyBlocked}. ` +
+          "Its history no longer accepts new entries; continue in a new session.",
+      );
+    }
 
     let resolveSubmission!: (result: AgenCBackgroundAgentMessageResult) => void;
     let rejectSubmission!: (error: unknown) => void;

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -298,7 +298,10 @@ export interface AgenCBackgroundAgentMessageTerminal extends JsonObject {
 }
 
 export type AgenCBackgroundAgentMessageErrorCode =
-  "TURN_IN_PROGRESS" | "CLIENT_MESSAGE_ID_CONFLICT" | "PROMPT_BLOCKED";
+  | "TURN_IN_PROGRESS"
+  | "CLIENT_MESSAGE_ID_CONFLICT"
+  | "PROMPT_BLOCKED"
+  | "SESSION_HISTORY_BLOCKED";
 
 export class AgenCBackgroundAgentMessageError extends Error {
   readonly code: AgenCBackgroundAgentMessageErrorCode;

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -3453,6 +3453,19 @@ export class RolloutStore {
     this.liveToolPairValidator = validator;
   }
 
+  /**
+   * Why this session's live history can no longer take a response item, once
+   * the live tool-pair validator has closed on a failure; `undefined` while
+   * appends are still accepted. Callers that start turns check this before
+   * opening one, so a client hears the reason instead of watching an empty
+   * turn end.
+   */
+  liveHistoryBlockedReason(): string | undefined {
+    const failure = this.liveToolPairValidator?.terminalFailureOutcome;
+    if (failure === undefined) return undefined;
+    return new ToolPairHistoryBlockedError("live append", failure).message;
+  }
+
   private validateLiveResponseItem(message: ToolPairMessage): void {
     const projection = this.liveToolPairProjection;
     const validator = this.liveToolPairValidator;

--- a/runtime/src/session/tool-pair-validator.ts
+++ b/runtime/src/session/tool-pair-validator.ts
@@ -212,6 +212,11 @@ export class StreamingToolPairValidator {
     });
   }
 
+  /** The failure that closed this validator, if one has. Every later push returns it. */
+  get terminalFailureOutcome(): ToolPairTerminalFailureOutcome | undefined {
+    return this.terminalFailure;
+  }
+
   push(message: ToolPairMessage): ToolPairTerminalFailureOutcome | undefined {
     if (this.terminalFailure !== undefined) return this.terminalFailure;
     if (

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -578,6 +578,7 @@ function makeTopLevelRunner(opts: {
   const rolloutStore = {
     rolloutPath: `/tmp/${opts.conversationId}.jsonl`,
     readAll: () => [...rolloutItems],
+    liveHistoryBlockedReason: vi.fn((): string | undefined => undefined),
     assertRunSuspendable: vi.fn(() => {}),
     recordRunSuspensionEvent: vi.fn(() => {}),
     recordRunStartupActivationEvent: vi.fn(() => {}),
@@ -8807,6 +8808,34 @@ describe("AgenC delegate background-agent runner", () => {
       terminal: { code: 0 },
     });
     expect(control.sendInput).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a message once the session's live history is blocked", async () => {
+    const { runner, rolloutStore } = makeTopLevelRunner({
+      conversationId: "session-history-blocked",
+    });
+    await runner.startAgent({
+      objective: "history closes after this",
+      unattendedAllow: [],
+      unattendedDeny: [],
+    });
+    const reason =
+      'tool-pair history rejected during live append: tool result repeats "call-22" (44 UTF-8 bytes)';
+    rolloutStore.liveHistoryBlockedReason.mockReturnValue(reason);
+
+    await expect(
+      runner.submitAgentMessage("session-history-blocked", {
+        sessionId: "session_1",
+        content: "another prompt",
+        originalContent: "another prompt",
+        messageId: "blocked-message",
+        streamId: "blocked-message",
+        acceptedAt: "2026-08-17T00:00:00.000Z",
+      }),
+    ).rejects.toMatchObject({
+      code: "SESSION_HISTORY_BLOCKED",
+      message: expect.stringContaining(reason),
+    });
   });
 
   it("[managed-thread] rejects opt-in admission during the initial turn without changing legacy FIFO", async () => {

--- a/runtime/tests/session/a3b-tool-result-cutover.test.ts
+++ b/runtime/tests/session/a3b-tool-result-cutover.test.ts
@@ -498,6 +498,7 @@ describe("A3b shared ID-paired validator cutover", () => {
       store.appendRollout({ type: "response_item", payload: tool });
     }).not.toThrow();
     store.flushDurable();
+    expect(store.liveHistoryBlockedReason()).toBeUndefined();
 
     expect(() =>
       store.appendRollout(
@@ -533,6 +534,11 @@ describe("A3b shared ID-paired validator cutover", () => {
         }),
       }),
     );
+    // Once the live validator has closed, the store says why, in the words the
+    // rejected append used, so a turn can be refused before it opens.
+    expect(store.liveHistoryBlockedReason()).toMatch(
+      /^tool-pair history rejected during live append: /,
+    );
 
     store.close();
 
@@ -555,6 +561,7 @@ describe("A3b shared ID-paired validator cutover", () => {
         content: "next result",
       }),
     };
+    expect(restarted.liveHistoryBlockedReason()).toBeUndefined();
     expect(() => {
       restarted.appendRollout({
         type: "response_item",


### PR DESCRIPTION
## Why

#2163, seen again in the desktop soak on 2026-09-06 (session `conv-mtp5odh9`). After the live tool-pair validator rejected a duplicate tool result (#2184), the session's rollout could not take another response item: `validateLiveResponseItem` returns the validator's terminal failure for every later push. A new prompt on that session still opened a turn, wrote `turn_started` and `turn_context`, threw on the user message, and closed with `turn_aborted` four seconds later. The client got a turn with no answer; the desktop's banner said the daemon gave no reason (agenc-desktop #188 fixes the banner). Nothing in the daemon told a client up front that the session could not take a prompt at all.

## What changed

- `runtime/src/session/tool-pair-validator.ts`: `terminalFailureOutcome` exposes the failure that closed the validator.
- `runtime/src/session/rollout-store.ts`: `liveHistoryBlockedReason()` returns the same message a rejected append throws (`tool-pair history rejected during live append: …`), or `undefined` while appends are accepted. A restarted store starts unblocked, as the existing restart path already validates.
- `runtime/src/app-server/background-agent-runner.ts`: `submitAgentMessage` refuses a message on a session whose history is blocked, after the duplicate and busy checks and before anything is queued, with `AgenCBackgroundAgentMessageError("SESSION_HISTORY_BLOCKED", …)` carrying the reason and the way out (continue in a new session). The lifecycle already converts the runner's message errors to `AgenCDaemonAgentLifecycleError` by code, so `message.send` and `message.stream` return it as an RPC error.
- `runtime/src/app-server/background-agent-runner/shared.ts`, `runtime/src/app-server/agent-lifecycle.ts`: the code joins both unions.

## Evidence

The soak session's rollout, records 1081 to 1088: two prompts, each `user_message`, `turn_started`, `turn_context` and nothing else. With this change both `message.send` calls return the `SESSION_HISTORY_BLOCKED` error with the duplicate-result reason and no turn opens.

## Tests

- `tests/session/a3b-tool-result-cutover.test.ts`, "enforces exact resolved-ID uniqueness on live append and compaction": the store reports no reason before the failure, the rejected append's message after it, and no reason again after a restart.
- `tests/app-server/background-agent-runner.contract.test.ts`, "refuses a message once the session's live history is blocked": a started agent whose store reports a blocked history rejects `submitAgentMessage` with the code and the reason; the harness's store stub gained the method, returning `undefined` by default so every other test is unchanged.
- Both files: 184 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The turn that first hits the failure still ends through the turn kernel's error path with `turn_aborted` and the reason.
- Repairing a blocked rollout (#2162).
- The desktop's rendering of an aborted turn (agenc-desktop #188).

## Counterparts

#2163 (this closes the daemon half), #2184, #2162, agenc-desktop #188.
