### PR TITLE
run-turn: a durable resume does not persist a second result for a call the replay already closed

### DIFF
--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -774,6 +774,7 @@ export class RolloutStore {
     CompactionSourcePayloadBundlesV1
   >();
   private liveToolPairProjection: ToolPairProjection | undefined;
+  private liveToolPairProjectionId: string | undefined;
   private liveToolPairValidator: StreamingToolPairValidator | undefined;
   private openedAt: string | undefined;
   private openedEpoch: number | undefined;
@@ -3450,6 +3451,7 @@ export class RolloutStore {
       throw new Error("live tool-pair projection did not initialize");
     }
     this.liveToolPairProjection = context.projection;
+    this.liveToolPairProjectionId = context.projectionId;
     this.liveToolPairValidator = validator;
   }
 
@@ -3464,6 +3466,20 @@ export class RolloutStore {
     const failure = this.liveToolPairValidator?.terminalFailureOutcome;
     if (failure === undefined) return undefined;
     return new ToolPairHistoryBlockedError("live append", failure).message;
+  }
+
+  /**
+   * Whether the live history already holds a result for this tool call. A
+   * durable resume asks before it persists a synthetic result for a dangling
+   * call: the bootstrap replay may already have closed the call, and a second
+   * result for one call id is a duplicate the live validator rejects, which
+   * blocks the session's history for good.
+   */
+  liveToolCallResolved(callId: string): boolean {
+    const projection = this.liveToolPairProjection;
+    const projectionId = this.liveToolPairProjectionId;
+    if (projection === undefined || projectionId === undefined) return false;
+    return projection.find(projectionId, callId)?.resultIndex !== undefined;
   }
 
   private validateLiveResponseItem(message: ToolPairMessage): void {

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -1674,11 +1674,20 @@ async function* runTurnKernelInner(
       const content = pairing.halt
         ? sideEffectHaltMessage(pairing.toolName)
         : `result not persisted before crash; the read-only tool ${pairing.toolName} was not retried automatically — safe to re-invoke if its result is needed.`;
+      // The bootstrap replay may already have closed this call with its own
+      // persisted result (a restart between the model's calls and their
+      // results). The model's thread still needs the pairing; the rollout
+      // must not receive a second result for the id.
+      const alreadyPersisted =
+        session.rolloutStore?.liveToolCallResolved(pairing.callId) === true;
       state.messages.push({
         role: "tool",
         content,
         toolCallId: pairing.callId,
         toolName: pairing.toolName,
+        ...(alreadyPersisted
+          ? { runtimeOnly: { excludeFromDurableHistory: true } }
+          : {}),
       });
     }
     restoreFromCheckpoint(state, opts.resume.restoreSlice);

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -7921,6 +7921,7 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       assertCompactionProjectionReady: () => {},
       append: vi.fn(),
       appendRollout: vi.fn(),
+      liveToolCallResolved: () => false,
       rolloutPath: "/tmp/does-not-matter.jsonl",
     } as unknown as Session["rolloutStore"];
 
@@ -7979,6 +7980,79 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
     // The turn re-opened durably.
     expect(events.some((e) => e.msg.type === "turn_resumed")).toBe(true);
     expect(events.some((e) => e.msg.type === "turn_complete")).toBe(true);
+  });
+
+  test("a dangling call the bootstrap replay already closed is paired for the model but not persisted a second time", async () => {
+    const sideEffectTool: Tool = {
+      name: "settle",
+      description: "on-chain settlement (side-effecting)",
+      inputSchema: { type: "object", additionalProperties: false },
+      requiresApproval: true,
+      recoveryCategory: "side-effecting",
+      execute: vi.fn(async () => ({ content: "SIDE EFFECT FIRED", isError: false })),
+    } as unknown as Tool;
+    const registry: ToolRegistry = {
+      tools: [sideEffectTool],
+      toLLMTools: () => [],
+      dispatch: vi.fn(async () => ({ content: "SIDE EFFECT FIRED", isError: false })),
+    } as unknown as ToolRegistry;
+    const { session, events } = mkSession({
+      provider: mkProvider({
+        content: "acknowledged, not retrying",
+        toolCalls: [],
+      }),
+      registry,
+    });
+    const appendRollout = vi.fn();
+    session.rolloutStore = {
+      assertCompactionProjectionReady: () => {},
+      append: vi.fn(),
+      appendRollout,
+      // The replay closer already wrote a result for settle-1.
+      liveToolCallResolved: vi.fn((callId: string) => callId === "settle-1"),
+      rolloutPath: "/tmp/does-not-matter.jsonl",
+    } as unknown as Session["rolloutStore"];
+    const history: LLMMessage[] = [
+      { role: "user", content: "settle the task" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "settle-1", name: "settle", arguments: "{}" }],
+      },
+    ];
+
+    await drain(
+      session.runTurn("", {
+        subId: "turn-resumed-closed",
+        history,
+        displayUserMessage: null,
+        resume: {
+          turnId: "turn-resumed-closed",
+          fromIteration: 1,
+          fromCheckpointSeq: 1,
+          persistedMessageCount: history.length,
+          restoreSlice: {
+            turnCount: 2,
+            recoveryReentryCount: 0,
+            maxOutputTokensRecoveryCount: 0,
+            continuationNudgeCount: 0,
+            stopHookBlockingCount: 0,
+          },
+          haltedSideEffectingTools: ["settle"],
+          danglingPairings: [
+            { callId: "settle-1", toolName: "settle", halt: true },
+          ],
+        },
+      }),
+    );
+
+    expect(events.some((e) => e.msg.type === "turn_complete")).toBe(true);
+    // No second result for settle-1 reaches the rollout.
+    const persistedResults = appendRollout.mock.calls.filter(
+      ([item]: [{ type: string; payload?: { toolCallId?: string } }]) =>
+        item.type === "response_item" && item.payload?.toolCallId === "settle-1",
+    );
+    expect(persistedResults).toHaveLength(0);
   });
 
   test("crash mid-drain → resume CONTINUES (restored counters hold pre-crash values, not reset)", async () => {
@@ -8153,6 +8227,7 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       assertCompactionProjectionReady: () => {},
       append: vi.fn(),
       appendRollout: vi.fn(),
+      liveToolCallResolved: () => false,
       rolloutPath: "/tmp/does-not-matter.jsonl",
     } as unknown as Session["rolloutStore"];
 

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -7886,7 +7886,16 @@ describe("runTurn — runAutoCompact dispatcher", () => {
 });
 
 describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
-  test("THE HEADLINE SAFETY TEST: a side-effecting dangling tool_use is NOT re-dispatched on resume (no double side effect)", async () => {
+  /**
+   * A resumed turn whose checkpoint prefix ends in one dangling side-effecting
+   * `settle` call. The provider answers without new tool calls, so the resume
+   * completes once the dangling call is paired. `resolvedCallIds` is what the
+   * rollout store reports as already holding a result.
+   */
+  async function resumeWithDanglingSettle(opts: {
+    readonly turnId: string;
+    readonly resolvedCallIds?: ReadonlyArray<string>;
+  }) {
     const executeSpy = vi.fn(async () => ({
       content: "SIDE EFFECT FIRED",
       isError: false,
@@ -7908,8 +7917,6 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       toLLMTools: () => [],
       dispatch: dispatchSpy,
     } as unknown as ToolRegistry;
-    // Provider returns a terminal answer so the resumed turn completes
-    // without issuing any new tool calls.
     const { session, events } = mkSession({
       provider: mkProvider({
         content: "acknowledged, not retrying",
@@ -7917,16 +7924,15 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       }),
       registry,
     });
+    const appendRollout = vi.fn();
+    const resolved = new Set(opts.resolvedCallIds ?? []);
     session.rolloutStore = {
       assertCompactionProjectionReady: () => {},
       append: vi.fn(),
-      appendRollout: vi.fn(),
-      liveToolCallResolved: () => false,
+      appendRollout,
+      liveToolCallResolved: (callId: string) => resolved.has(callId),
       rolloutPath: "/tmp/does-not-matter.jsonl",
     } as unknown as Session["rolloutStore"];
-
-    // Resume prefix: an assistant message with a DANGLING side-effecting
-    // tool_use (no recorded result).
     const history: LLMMessage[] = [
       { role: "user", content: "settle the task" },
       {
@@ -7935,14 +7941,13 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
         toolCalls: [{ id: "settle-1", name: "settle", arguments: "{}" }],
       },
     ];
-
     await drain(
       session.runTurn("", {
-        subId: "turn-resumed-1",
+        subId: opts.turnId,
         history,
         displayUserMessage: null,
         resume: {
-          turnId: "turn-resumed-1",
+          turnId: opts.turnId,
           fromIteration: 1,
           fromCheckpointSeq: 1,
           persistedMessageCount: history.length,
@@ -7960,6 +7965,17 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
         },
       }),
     );
+    const persistedSettleResults = appendRollout.mock.calls.filter(
+      ([item]: [{ type: string; payload?: { toolCallId?: string } }]) =>
+        item.type === "response_item" && item.payload?.toolCallId === "settle-1",
+    );
+    return { executeSpy, dispatchSpy, events, persistedSettleResults };
+  }
+
+  test("THE HEADLINE SAFETY TEST: a side-effecting dangling tool_use is NOT re-dispatched on resume (no double side effect)", async () => {
+    const { executeSpy, dispatchSpy, events } = await resumeWithDanglingSettle({
+      turnId: "turn-resumed-1",
+    });
 
     // The on-chain-safety property: the side-effecting tool is NEVER
     // re-dispatched on resume.
@@ -7983,76 +7999,22 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
   });
 
   test("a dangling call the bootstrap replay already closed is paired for the model but not persisted a second time", async () => {
-    const sideEffectTool: Tool = {
-      name: "settle",
-      description: "on-chain settlement (side-effecting)",
-      inputSchema: { type: "object", additionalProperties: false },
-      requiresApproval: true,
-      recoveryCategory: "side-effecting",
-      execute: vi.fn(async () => ({ content: "SIDE EFFECT FIRED", isError: false })),
-    } as unknown as Tool;
-    const registry: ToolRegistry = {
-      tools: [sideEffectTool],
-      toLLMTools: () => [],
-      dispatch: vi.fn(async () => ({ content: "SIDE EFFECT FIRED", isError: false })),
-    } as unknown as ToolRegistry;
-    const { session, events } = mkSession({
-      provider: mkProvider({
-        content: "acknowledged, not retrying",
-        toolCalls: [],
-      }),
-      registry,
+    const { events, persistedSettleResults } = await resumeWithDanglingSettle({
+      turnId: "turn-resumed-closed",
+      resolvedCallIds: ["settle-1"],
     });
-    const appendRollout = vi.fn();
-    session.rolloutStore = {
-      assertCompactionProjectionReady: () => {},
-      append: vi.fn(),
-      appendRollout,
-      // The replay closer already wrote a result for settle-1.
-      liveToolCallResolved: vi.fn((callId: string) => callId === "settle-1"),
-      rolloutPath: "/tmp/does-not-matter.jsonl",
-    } as unknown as Session["rolloutStore"];
-    const history: LLMMessage[] = [
-      { role: "user", content: "settle the task" },
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [{ id: "settle-1", name: "settle", arguments: "{}" }],
-      },
-    ];
-
-    await drain(
-      session.runTurn("", {
-        subId: "turn-resumed-closed",
-        history,
-        displayUserMessage: null,
-        resume: {
-          turnId: "turn-resumed-closed",
-          fromIteration: 1,
-          fromCheckpointSeq: 1,
-          persistedMessageCount: history.length,
-          restoreSlice: {
-            turnCount: 2,
-            recoveryReentryCount: 0,
-            maxOutputTokensRecoveryCount: 0,
-            continuationNudgeCount: 0,
-            stopHookBlockingCount: 0,
-          },
-          haltedSideEffectingTools: ["settle"],
-          danglingPairings: [
-            { callId: "settle-1", toolName: "settle", halt: true },
-          ],
-        },
-      }),
-    );
 
     expect(events.some((e) => e.msg.type === "turn_complete")).toBe(true);
-    // No second result for settle-1 reaches the rollout.
-    const persistedResults = appendRollout.mock.calls.filter(
-      ([item]: [{ type: string; payload?: { toolCallId?: string } }]) =>
-        item.type === "response_item" && item.payload?.toolCallId === "settle-1",
-    );
-    expect(persistedResults).toHaveLength(0);
+    // The rollout already holds the replay's result: no second one reaches it.
+    expect(persistedSettleResults).toHaveLength(0);
+  });
+
+  test("a dangling call nobody has resolved yet gets its synthetic result persisted", async () => {
+    const { persistedSettleResults } = await resumeWithDanglingSettle({
+      turnId: "turn-resumed-open",
+    });
+
+    expect(persistedSettleResults).toHaveLength(1);
   });
 
   test("crash mid-drain → resume CONTINUES (restored counters hold pre-crash values, not reset)", async () => {


### PR DESCRIPTION
## Why

Desktop soak on the production bundle, 2026-09-06, session `conv-mtp6vxgq`. The daemon under test died while a turn had four tool calls open (one `TodoWrite` had completed, its result not yet appended; an `exec_command` and two `FileRead`s were in flight). The app autostarted a replacement three seconds later, and its recovery resolved those calls twice:

| record | writer | what it wrote |
| --- | --- | --- |
| 1768 to 1771 | bootstrap replay, `closeTrailingDanglingToolCalls` | one persisted `interrupted` result per open call, `dangling_tool_calls_closed` |
| 1779 to 1781 | durable resume, `turn_resumed` with `haltedSideEffectingTools` | a halt result per side-effecting call, persisted on the next sync |

The second result for `call-…-47` hit the live tool-pair validator as `tool_result_duplicate` (`tool-pair history rejected during live append: tool result repeats "call-…-47"`), the resumed turn failed, and every later prompt on the session ended empty (records 1784 to 1791: `user_message`, `turn_started`, `turn_context`, nothing else). Each writer is correct alone; together they break the session they are both trying to save.

## What changed

- `runtime/src/session/rollout-store.ts`: `liveToolCallResolved(callId)` asks the live tool-pair projection whether the history already holds a result for the call. The store keeps the live projection id it already builds for the validator.
- `runtime/src/session/run-turn.ts`: when a durable resume pairs a dangling call with a synthetic result, it asks the store first; a call the replay already closed keeps its pairing in the model's thread (the first resumed sampling request still needs every `tool_use` answered) but the message is marked `excludeFromDurableHistory`, which the persist loop already honours, so no second result reaches the rollout.

## Evidence

The session above: with this change record 1779's resume would have paired `call-…-47` and `call-…-48` for the model only, the rollout would hold the replay's results alone, and the turn would have continued.

## Tests

- `tests/session/run-turn.test.ts`, "a dangling call the bootstrap replay already closed is paired for the model but not persisted a second time": the store stub reports `settle-1` resolved; the resumed turn completes and no `response_item` for `settle-1` is appended. The two existing resume tests' store stubs gained `liveToolCallResolved: () => false` and are otherwise unchanged; the headline "not re-dispatched on resume" property still holds.
- `tests/session/run-turn.test.ts` and `tests/session/a3b-tool-result-cutover.test.ts`: all passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The replay closer and the resume's classification of dangling tools (replay-safe vs halt).
- The validator: rejecting a duplicate result is right; this stops the runtime from producing one.
- Why the daemon died (separate; the spawn stderr capture that would have shown it is fixed in its own PR).

## Counterparts

#2184 (the other duplicate-result producer, fixed), #2186 (a blocked history refuses prompts with the reason), #2163. Desktop soak finding F45 in `~/claude-agenc/soak/findings.md`.
