### PR TITLE
daemon: keep the previous spawn's stderr capture instead of truncating it

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -18,6 +18,7 @@ import {
   openSync,
   readFileSync,
   statSync,
+  renameSync,
 } from "node:fs";
 import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection, isIP } from "node:net";
@@ -656,6 +657,47 @@ export function resolveAgenCDaemonCookiePath(
  * undiagnosable without rebuilding the runtime.
  */
 export const AGENC_DAEMON_SPAWN_STDERR_FILENAME = "daemon-spawn-stderr.log";
+
+/**
+ * The previous spawn's stderr capture. Each spawn moves the current file here
+ * before it opens a fresh one, so a daemon that died silently and was
+ * replaced by an autostart three seconds later still leaves its last words
+ * on disk instead of having them truncated by the spawn that replaced it.
+ */
+export const AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME =
+  "daemon-spawn-stderr.prev.log";
+
+export function resolveAgenCDaemonSpawnStderrPreviousPath(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome = homedir(),
+): string {
+  return join(
+    resolveAgenCDaemonHome(env, userHome),
+    AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME,
+  );
+}
+
+/**
+ * Open the stderr capture for a daemon spawn: keep the previous capture as
+ * the `.prev.log` sibling, then open the current path truncated. Best-effort:
+ * a failure to keep or to open returns `"ignore"` and the spawn proceeds
+ * without the capture, as before.
+ */
+export function openDaemonSpawnStderrCapture(
+  path: string,
+  previousPath: string,
+): number | "ignore" {
+  try {
+    renameSync(path, previousPath);
+  } catch {
+    /* no previous capture, or it cannot be kept; the current one still opens */
+  }
+  try {
+    return openSync(path, "w", 0o600);
+  } catch {
+    return "ignore";
+  }
+}
 
 export function resolveAgenCDaemonSpawnStderrPath(
   env: NodeJS.ProcessEnv = process.env,
@@ -5813,19 +5855,14 @@ export function createNodeDaemonCliHost(
       }
       // Capture the child's raw stderr until its log sink takes over: a
       // crash before the sink installs (loader failure, fatal V8 error,
-      // top-level throw) is otherwise unobservable. A plain file fd keeps
-      // this short-lived parent decoupled (no pipe); truncated per spawn so
-      // it only ever holds the latest attempt's early stderr.
-      let stderrFd: number | "ignore" = "ignore";
-      try {
-        stderrFd = openSync(
-          resolveAgenCDaemonSpawnStderrPath(env, userHome),
-          "w",
-          0o600,
-        );
-      } catch {
-        /* capture is best-effort; spawn proceeds without it */
-      }
+      // top-level throw) is otherwise unobservable, and the fd stays the
+      // daemon's stderr for its whole life, so a late fatal lands here too.
+      // A plain file fd keeps this short-lived parent decoupled (no pipe).
+      // The previous attempt's capture is kept as the `.prev.log` sibling.
+      const stderrFd = openDaemonSpawnStderrCapture(
+        resolveAgenCDaemonSpawnStderrPath(env, userHome),
+        resolveAgenCDaemonSpawnStderrPreviousPath(env, userHome),
+      );
       const startupGuardToken = randomUUID();
       const childEnv = {
         ...env,

--- a/runtime/tests/app-server/daemon-spawn-stderr.test.ts
+++ b/runtime/tests/app-server/daemon-spawn-stderr.test.ts
@@ -1,0 +1,75 @@
+import { closeSync, mkdtempSync, readFileSync, rmSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AGENC_DAEMON_SPAWN_STDERR_FILENAME,
+  AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME,
+  openDaemonSpawnStderrCapture,
+  resolveAgenCDaemonSpawnStderrPath,
+  resolveAgenCDaemonSpawnStderrPreviousPath,
+} from "../../src/app-server/daemon-cli.js";
+
+const homes: string[] = [];
+
+afterEach(() => {
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+function tempHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "agenc-spawn-stderr-"));
+  homes.push(home);
+  return home;
+}
+
+function capture(path: string, previous: string, text: string): void {
+  const fd = openDaemonSpawnStderrCapture(path, previous);
+  expect(fd).not.toBe("ignore");
+  writeSync(fd as number, text);
+  closeSync(fd as number);
+}
+
+describe("daemon spawn stderr capture", () => {
+  it("keeps the previous spawn's stderr as the .prev.log sibling", () => {
+    const home = tempHome();
+    const env = { AGENC_HOME: home };
+    const path = resolveAgenCDaemonSpawnStderrPath(env, home);
+    const previous = resolveAgenCDaemonSpawnStderrPreviousPath(env, home);
+    expect(path.endsWith(AGENC_DAEMON_SPAWN_STDERR_FILENAME)).toBe(true);
+    expect(previous.endsWith(AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME)).toBe(true);
+
+    capture(path, previous, "first daemon: FATAL ERROR: out of memory\n");
+    capture(path, previous, "second daemon starting\n");
+
+    expect(readFileSync(previous, "utf8")).toBe(
+      "first daemon: FATAL ERROR: out of memory\n",
+    );
+    expect(readFileSync(path, "utf8")).toBe("second daemon starting\n");
+
+    // A third spawn keeps only the immediately preceding attempt.
+    capture(path, previous, "third\n");
+    expect(readFileSync(previous, "utf8")).toBe("second daemon starting\n");
+    expect(readFileSync(path, "utf8")).toBe("third\n");
+  });
+
+  it("opens a fresh capture when no previous file exists", () => {
+    const home = tempHome();
+    const path = join(home, AGENC_DAEMON_SPAWN_STDERR_FILENAME);
+    const previous = join(home, AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME);
+    capture(path, previous, "only\n");
+    expect(readFileSync(path, "utf8")).toBe("only\n");
+    expect(() => readFileSync(previous, "utf8")).toThrow();
+  });
+
+  it("proceeds without a capture when the home cannot take one", () => {
+    const missing = join(tempHome(), "no", "such", "dir");
+    expect(
+      openDaemonSpawnStderrCapture(
+        join(missing, AGENC_DAEMON_SPAWN_STDERR_FILENAME),
+        join(missing, AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME),
+      ),
+    ).toBe("ignore");
+  });
+});


### PR DESCRIPTION
## Why

Desktop soak, 2026-09-06 02:33Z. The daemon under test (54 minutes up, 388 MB RSS, one live turn whose last command was an `ls`) exited with no line in `daemon.log`, no macOS crash report, no OOM heap snapshot in `oom-snapshots`, and nothing in the system log. The production app autostarted a replacement three seconds later. The one place a fatal exit prints is the daemon's stderr, which is the plain file the spawner opens for it (`daemon-spawn-stderr.log`) and which stays its stderr for life. The replacement spawn opened that file with `"w"`, so whatever the old process printed as it died was gone before anyone could read it. The cause of that exit is still unknown; the evidence path had to be fixed first.

## What changed

- `runtime/src/app-server/daemon-cli.ts`: `openDaemonSpawnStderrCapture(path, previousPath)` renames the current capture to `daemon-spawn-stderr.prev.log` (best effort, a missing file is fine) and then opens the current path truncated as before; `"ignore"` when the home cannot take a capture, so the spawn proceeds exactly as it did. `spawnDetachedDaemon` uses it. `AGENC_DAEMON_SPAWN_STDERR_PREVIOUS_FILENAME` and `resolveAgenCDaemonSpawnStderrPreviousPath` name the sibling. The comment on the capture now says the fd is the daemon's stderr for its whole life, not only until the log sink installs.

## Evidence

Had this been in place, `daemon-spawn-stderr.prev.log` in the isolated home would now hold the old daemon's final stderr.

## Tests

- `tests/app-server/daemon-spawn-stderr.test.ts` (new): a second spawn keeps the first capture as `.prev.log` and a third keeps only the second; a first spawn with no previous file opens cleanly and creates no sibling; a home that cannot take a capture yields `"ignore"`. 3 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.
- The existing autostart and CLI contract tests that read `daemon-spawn-stderr.log` for the readiness diagnosis are unchanged.

## Not changed

- The readiness-failure diagnosis, which still reads the current capture's tail.
- No rotation beyond one previous file.

## Counterparts

Desktop soak finding F46 in `~/claude-agenc/soak/findings.md`; #2187 (the recovery duplicate the same restart produced).
