### PR TITLE
write_stdin: a failure before the write is a confirmed no-effect result, and the tool can ask for its session's sandbox

### DIFF
--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -88,6 +88,49 @@ function isMcpShellPlaceholderCommand(command: string): boolean {
   );
 }
 
+/**
+ * The sandbox permission fields a tool takes when it may need a wider sandbox
+ * than the turn's default: exec_command for the command it starts, write_stdin
+ * for a session exec_command started that way. The orchestrator reads them
+ * from any tool's arguments.
+ */
+export const SANDBOX_PERMISSION_INPUT_PROPERTIES = {
+  sandbox_permissions: {
+    // Only the three documented modes. The former `{type:"object"}`
+    // alternative invited a shape no parser accepted, so a model could
+    // send an escalation request that was discarded without a word.
+    type: "string",
+    enum: ["default", "require_escalated", "with_additional_permissions"],
+    description:
+      "Sandbox escalation mode. Scoped permissions go in additional_permissions.",
+  },
+  additional_permissions: {
+    type: "object",
+    properties: {
+      network: {
+        type: "object",
+        properties: { enabled: { type: "boolean" } },
+        additionalProperties: false,
+      },
+      file_system: {
+        type: "object",
+        properties: {
+          read: { type: "array", items: { type: "string" } },
+          write: { type: "array", items: { type: "string" } },
+        },
+        additionalProperties: false,
+      },
+    },
+    additionalProperties: false,
+    description:
+      'Scoped permissions to request alongside sandbox_permissions "with_additional_permissions".',
+  },
+  justification: {
+    type: "string",
+    description: "Why elevated execution is needed, when applicable.",
+  },
+} as const;
+
 export function runtimeSandboxForExec(
   args: Record<string, unknown>,
   fallbackCwd: string,
@@ -408,44 +451,7 @@ export function createExecCommandTool(config?: ExecCommandToolConfig): Tool {
           description:
             "Shell executable to run the command through. Defaults to the user's shell.",
         },
-        sandbox_permissions: {
-          // Only the three documented modes. The former `{type:"object"}`
-          // alternative invited a shape no parser accepted, so a model could
-          // send an escalation request that was discarded without a word.
-          type: "string",
-          enum: [
-            "default",
-            "require_escalated",
-            "with_additional_permissions",
-          ],
-          description:
-            "Sandbox escalation mode. Scoped permissions go in additional_permissions.",
-        },
-        additional_permissions: {
-          type: "object",
-          properties: {
-            network: {
-              type: "object",
-              properties: { enabled: { type: "boolean" } },
-              additionalProperties: false,
-            },
-            file_system: {
-              type: "object",
-              properties: {
-                read: { type: "array", items: { type: "string" } },
-                write: { type: "array", items: { type: "string" } },
-              },
-              additionalProperties: false,
-            },
-          },
-          additionalProperties: false,
-          description:
-            "Scoped permissions to request alongside sandbox_permissions \"with_additional_permissions\".",
-        },
-        justification: {
-          type: "string",
-          description: "Why elevated execution is needed, when applicable.",
-        },
+        ...SANDBOX_PERMISSION_INPUT_PROPERTIES,
         prefix_rule: {
           type: "array",
           items: { type: "string" },

--- a/runtime/src/tools/system/exec-command.ts
+++ b/runtime/src/tools/system/exec-command.ts
@@ -283,7 +283,7 @@ function errorResult(error: unknown): ToolResult {
   };
 }
 
-function confirmedNoEffectDisposition(
+export function confirmedNoEffectDisposition(
   evidenceRef: string,
   evidenceMaterial: string,
 ) {

--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -11,7 +11,11 @@ import {
   unifiedExecCodeModeResult,
 } from "./exec-result-format.js";
 import { buildRecoverableToolFailureMetadata } from "../result-metadata.js";
-import { runtimeSandboxForExec } from "./exec-command.js";
+import {
+  confirmedNoEffectDisposition,
+  runtimeSandboxForExec,
+} from "./exec-command.js";
+import { SandboxExecutionError } from "../../sandbox/execution-broker.js";
 
 export interface WriteStdinToolConfig {
   readonly cwd?: string;
@@ -31,6 +35,27 @@ function asNumber(value: unknown): number | undefined {
     : undefined;
 }
 
+/**
+ * A failure that happened before any byte reached the process: an argument the
+ * tool rejected, a session it could not find or reach, a closed stdin, or a
+ * sandbox boundary it could not build. These carry a confirmed no-effect
+ * disposition; without it the admission layer files the error as an unknown
+ * outcome, poisons the live effect, and blocks every side-effecting tool of the
+ * session until an operator runs `/resolve` (desktop soak, 2026-09-06). Only a
+ * write that failed after it started stays undecided.
+ */
+function preWriteFailure(error: unknown, message: string): Partial<ToolResult> {
+  if (error instanceof UnifiedExecError && error.code === "stdin_write_failed") {
+    return {};
+  }
+  return {
+    effectDisposition: confirmedNoEffectDisposition(
+      "tool:system.write-stdin:pre-write-error",
+      message,
+    ),
+  };
+}
+
 function errorResult(error: unknown): ToolResult {
   const message = error instanceof Error ? error.message : String(error);
   return {
@@ -39,6 +64,20 @@ function errorResult(error: unknown): ToolResult {
       ...(error instanceof UnifiedExecError ? { code: error.code } : {}),
     }),
     isError: true,
+    ...(error instanceof UnifiedExecError || error instanceof SandboxExecutionError
+      ? preWriteFailure(error, message)
+      : {}),
+  };
+}
+
+function argumentErrorResult(message: string): ToolResult {
+  return {
+    content: safeStringify({ error: message }),
+    isError: true,
+    effectDisposition: confirmedNoEffectDisposition(
+      "tool:system.write-stdin:argument-error",
+      message,
+    ),
   };
 }
 export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
@@ -96,6 +135,41 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
           type: "number",
           description: "Maximum output tokens to return.",
         },
+        sandbox_permissions: {
+          type: "string",
+          enum: [
+            "default",
+            "require_escalated",
+            "with_additional_permissions",
+          ],
+          description:
+            "Sandbox escalation mode. A session started by exec_command with sandbox_permissions runs in that sandbox; pass the same value here to reach it.",
+        },
+        additional_permissions: {
+          type: "object",
+          properties: {
+            network: {
+              type: "object",
+              properties: { enabled: { type: "boolean" } },
+              additionalProperties: false,
+            },
+            file_system: {
+              type: "object",
+              properties: {
+                read: { type: "array", items: { type: "string" } },
+                write: { type: "array", items: { type: "string" } },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+          description:
+            "Scoped permissions to request alongside sandbox_permissions \"with_additional_permissions\".",
+        },
+        justification: {
+          type: "string",
+          description: "Why elevated execution is needed, when applicable.",
+        },
       },
       required: ["session_id"],
       additionalProperties: false,
@@ -103,16 +177,11 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
       const args = rawArgs as Record<string, unknown> & ToolExecutionInjectedArgs;
       if (Object.prototype.hasOwnProperty.call(args, "process_id")) {
-        return errorResult("unknown field `process_id`");
+        return argumentErrorResult("unknown field `process_id`");
       }
       const sessionId = asNumber(args.session_id);
       if (sessionId === undefined) {
-        return {
-          content: safeStringify({
-            error: "session_id must be a number",
-          }),
-          isError: true,
-        };
+        return argumentErrorResult("session_id must be a number");
       }
       const chars = asString(args.chars) ?? "";
       if (chars.trim().length > 0) {
@@ -123,15 +192,18 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
           ...shellWorkspaceMutationPermission(args),
         });
         if (workspaceWriteDecision.blocked) {
+          const blockedMessage =
+            workspaceWriteDecision.message ??
+            "Shell workspace write policy blocked the input.";
           return {
-            content: safeStringify({
-              error:
-                workspaceWriteDecision.message ??
-                "Shell workspace write policy blocked the input.",
-            }),
+            content: safeStringify({ error: blockedMessage }),
             isError: true,
             metadata: buildRecoverableToolFailureMetadata(
               "shell_workspace_write_policy",
+            ),
+            effectDisposition: confirmedNoEffectDisposition(
+              "tool:system.write-stdin:workspace-write-policy",
+              blockedMessage,
             ),
           };
         }

--- a/runtime/src/tools/system/write-stdin.ts
+++ b/runtime/src/tools/system/write-stdin.ts
@@ -14,6 +14,7 @@ import { buildRecoverableToolFailureMetadata } from "../result-metadata.js";
 import {
   confirmedNoEffectDisposition,
   runtimeSandboxForExec,
+  SANDBOX_PERMISSION_INPUT_PROPERTIES,
 } from "./exec-command.js";
 import { SandboxExecutionError } from "../../sandbox/execution-broker.js";
 
@@ -135,40 +136,11 @@ export function createWriteStdinTool(config?: WriteStdinToolConfig): Tool {
           type: "number",
           description: "Maximum output tokens to return.",
         },
+        ...SANDBOX_PERMISSION_INPUT_PROPERTIES,
         sandbox_permissions: {
-          type: "string",
-          enum: [
-            "default",
-            "require_escalated",
-            "with_additional_permissions",
-          ],
+          ...SANDBOX_PERMISSION_INPUT_PROPERTIES.sandbox_permissions,
           description:
             "Sandbox escalation mode. A session started by exec_command with sandbox_permissions runs in that sandbox; pass the same value here to reach it.",
-        },
-        additional_permissions: {
-          type: "object",
-          properties: {
-            network: {
-              type: "object",
-              properties: { enabled: { type: "boolean" } },
-              additionalProperties: false,
-            },
-            file_system: {
-              type: "object",
-              properties: {
-                read: { type: "array", items: { type: "string" } },
-                write: { type: "array", items: { type: "string" } },
-              },
-              additionalProperties: false,
-            },
-          },
-          additionalProperties: false,
-          description:
-            "Scoped permissions to request alongside sandbox_permissions \"with_additional_permissions\".",
-        },
-        justification: {
-          type: "string",
-          description: "Why elevated execution is needed, when applicable.",
         },
       },
       required: ["session_id"],

--- a/runtime/src/unified-exec/process-manager.ts
+++ b/runtime/src/unified-exec/process-manager.ts
@@ -678,7 +678,9 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
     ) {
       throw new UnifiedExecError(
         "write_stdin",
-        "write_stdin requires an existing session with a compatible sandbox profile",
+        "write_stdin requires an existing session with a compatible sandbox profile; " +
+          "a session started with sandbox_permissions (an escalated or widened sandbox) " +
+          "is reached by passing the same sandbox_permissions, and justification, to write_stdin",
       );
     }
     if (input.length > 0) {
@@ -710,7 +712,7 @@ export class UnifiedExecProcessManager implements UnifiedExecProcessManagerLike 
         }
         throw error instanceof UnifiedExecError
           ? error
-          : new UnifiedExecError("write_stdin", "failed to write to stdin");
+          : new UnifiedExecError("stdin_write_failed", "failed to write to stdin");
       }
     }
 

--- a/runtime/src/unified-exec/types.ts
+++ b/runtime/src/unified-exec/types.ts
@@ -148,6 +148,8 @@ export class UnifiedExecError extends Error {
     | "unknown_process"
     | "stdin_closed"
     | "write_stdin"
+    /** The write itself failed after bytes may have reached the process. */
+    | "stdin_write_failed"
     | "process_limit"
     | "owner_denied";
 

--- a/runtime/tests/tools/system/write-stdin.test.ts
+++ b/runtime/tests/tools/system/write-stdin.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { bindExplicitDangerBoundary } from "../../helpers/explicit-danger-boundary.js";
+import { createWriteStdinTool as createUnboundWriteStdinTool } from "../../../src/tools/system/write-stdin.js";
+import {
+  UnifiedExecError,
+  type ExecCommandToolOutput,
+  type UnifiedExecProcessManagerLike,
+} from "../../../src/unified-exec/types.js";
+
+let root = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "agenc-write-stdin-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function completedOutput(stdout: string): ExecCommandToolOutput {
+  return {
+    output: stdout,
+    stdout,
+    stderr: "",
+    exitCode: 0,
+    exit_code: 0,
+    durationMs: 1,
+    wall_time_seconds: 0.001,
+    timedOut: false,
+    truncated: false,
+    original_token_count: 1,
+  };
+}
+
+/** A write_stdin tool whose manager answers every write with `outcome`. */
+function toolWhoseManager(outcome: () => Promise<ExecCommandToolOutput>) {
+  const manager: UnifiedExecProcessManagerLike = {
+    maxTimeoutMs: 30_000,
+    execCommand: vi.fn(async () => completedOutput("")),
+    writeStdin: vi.fn(outcome),
+    closeAll: vi.fn(async () => {}),
+  };
+  return bindExplicitDangerBoundary(
+    createUnboundWriteStdinTool({ cwd: root, unifiedExecManager: manager }),
+  );
+}
+
+function parsed(result: { content: string }): { error?: string; code?: string } {
+  return JSON.parse(result.content) as { error?: string; code?: string };
+}
+
+describe("write_stdin failures before any byte reaches the process", () => {
+  // Desktop soak, 2026-09-06: a 35 ms precondition failure was filed as an
+  // unknown outcome and blocked every side-effecting tool of the session.
+  test("an unknown session is a confirmed no-effect failure", async () => {
+    const tool = toolWhoseManager(async () => {
+      throw new UnifiedExecError("unknown_process", "Unknown process id 4");
+    });
+    const result = await tool.execute({ session_id: 4, chars: "" });
+    expect(result.isError).toBe(true);
+    expect(parsed(result).code).toBe("unknown_process");
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  });
+
+  test("a sandbox-profile mismatch is a confirmed no-effect failure", async () => {
+    const tool = toolWhoseManager(async () => {
+      throw new UnifiedExecError(
+        "write_stdin",
+        "write_stdin requires an existing session with a compatible sandbox profile; a session started with sandbox_permissions is reached by passing the same sandbox_permissions",
+      );
+    });
+    const result = await tool.execute({ session_id: 4, chars: "" });
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error).toContain("sandbox_permissions");
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  });
+
+  test("a closed stdin is a confirmed no-effect failure", async () => {
+    const tool = toolWhoseManager(async () => {
+      throw new UnifiedExecError("stdin_closed", "stdin is closed for this session");
+    });
+    const result = await tool.execute({ session_id: 4, chars: "y\n" });
+    expect(result.isError).toBe(true);
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  });
+
+  test("a rejected argument is a confirmed no-effect failure", async () => {
+    const tool = toolWhoseManager(async () => completedOutput(""));
+    const missing = await tool.execute({ chars: "" });
+    expect(missing.isError).toBe(true);
+    expect(parsed(missing).error).toBe("session_id must be a number");
+    expect(missing.effectDisposition?.disposition).toBe("confirmed_no_effect");
+
+    const removed = await tool.execute({ process_id: 4, session_id: 4 });
+    expect(removed.isError).toBe(true);
+    expect(removed.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  });
+});
+
+describe("write_stdin failures after the write started", () => {
+  test("a write that failed once bytes may have reached the process stays undecided", async () => {
+    const tool = toolWhoseManager(async () => {
+      throw new UnifiedExecError("stdin_write_failed", "failed to write to stdin");
+    });
+    const result = await tool.execute({ session_id: 4, chars: "y\n" });
+    expect(result.isError).toBe(true);
+    expect(parsed(result).code).toBe("stdin_write_failed");
+    expect(result.effectDisposition).toBeUndefined();
+  });
+});
+
+describe("write_stdin reaches a session started in another sandbox", () => {
+  test("the schema takes the same sandbox permission fields as exec_command", () => {
+    const tool = toolWhoseManager(async () => completedOutput(""));
+    const properties = (tool.inputSchema as { properties: Record<string, unknown> })
+      .properties;
+    expect(properties.sandbox_permissions).toMatchObject({
+      type: "string",
+      enum: ["default", "require_escalated", "with_additional_permissions"],
+    });
+    expect(properties.additional_permissions).toMatchObject({ type: "object" });
+    expect(properties.justification).toMatchObject({ type: "string" });
+  });
+});

--- a/runtime/tests/tools/system/write-stdin.test.ts
+++ b/runtime/tests/tools/system/write-stdin.test.ts
@@ -21,26 +21,12 @@ afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
 
-function completedOutput(stdout: string): ExecCommandToolOutput {
-  return {
-    output: stdout,
-    stdout,
-    stderr: "",
-    exitCode: 0,
-    exit_code: 0,
-    durationMs: 1,
-    wall_time_seconds: 0.001,
-    timedOut: false,
-    truncated: false,
-    original_token_count: 1,
-  };
-}
-
 /** A write_stdin tool whose manager answers every write with `outcome`. */
 function toolWhoseManager(outcome: () => Promise<ExecCommandToolOutput>) {
   const manager: UnifiedExecProcessManagerLike = {
     maxTimeoutMs: 30_000,
-    execCommand: vi.fn(async () => completedOutput("")),
+    // Never reached: these tests fail before or inside the write.
+    execCommand: vi.fn(async () => undefined as never),
     writeStdin: vi.fn(outcome),
     closeAll: vi.fn(async () => {}),
   };
@@ -100,7 +86,7 @@ describe("write_stdin failures before any byte reaches the process", () => {
   }
 
   test("a rejected argument is a confirmed no-effect failure", async () => {
-    const tool = toolWhoseManager(async () => completedOutput(""));
+    const tool = toolWhoseManager(async () => undefined as never);
     const missing = await tool.execute({ chars: "" });
     expect(missing.isError).toBe(true);
     expect(parsed(missing).error).toBe("session_id must be a number");
@@ -126,7 +112,7 @@ describe("write_stdin failures after the write started", () => {
 
 describe("write_stdin reaches a session started in another sandbox", () => {
   test("the schema takes the same sandbox permission fields as exec_command", () => {
-    const tool = toolWhoseManager(async () => completedOutput(""));
+    const tool = toolWhoseManager(async () => undefined as never);
     const properties = (tool.inputSchema as { properties: Record<string, unknown> })
       .properties;
     expect(properties.sandbox_permissions).toMatchObject({

--- a/runtime/tests/tools/system/write-stdin.test.ts
+++ b/runtime/tests/tools/system/write-stdin.test.ts
@@ -53,40 +53,51 @@ function parsed(result: { content: string }): { error?: string; code?: string } 
   return JSON.parse(result.content) as { error?: string; code?: string };
 }
 
+/** A write_stdin tool whose manager throws `error` on every write. */
+function toolWhoseManagerThrows(error: Error) {
+  return toolWhoseManager(async () => {
+    throw error;
+  });
+}
+
+const PRE_WRITE_FAILURES: ReadonlyArray<{
+  readonly name: string;
+  readonly error: UnifiedExecError;
+  readonly chars: string;
+}> = [
+  {
+    name: "an unknown session",
+    error: new UnifiedExecError("unknown_process", "Unknown process id 4"),
+    chars: "",
+  },
+  {
+    name: "a sandbox-profile mismatch",
+    error: new UnifiedExecError(
+      "write_stdin",
+      "write_stdin requires an existing session with a compatible sandbox profile; a session started with sandbox_permissions is reached by passing the same sandbox_permissions",
+    ),
+    chars: "",
+  },
+  {
+    name: "a closed stdin",
+    error: new UnifiedExecError("stdin_closed", "stdin is closed for this session"),
+    chars: "y\n",
+  },
+];
+
 describe("write_stdin failures before any byte reaches the process", () => {
   // Desktop soak, 2026-09-06: a 35 ms precondition failure was filed as an
   // unknown outcome and blocked every side-effecting tool of the session.
-  test("an unknown session is a confirmed no-effect failure", async () => {
-    const tool = toolWhoseManager(async () => {
-      throw new UnifiedExecError("unknown_process", "Unknown process id 4");
+  for (const failure of PRE_WRITE_FAILURES) {
+    test(`${failure.name} is a confirmed no-effect failure`, async () => {
+      const tool = toolWhoseManagerThrows(failure.error);
+      const result = await tool.execute({ session_id: 4, chars: failure.chars });
+      expect(result.isError).toBe(true);
+      expect(parsed(result).code).toBe(failure.error.code);
+      expect(parsed(result).error).toBe(failure.error.message);
+      expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
     });
-    const result = await tool.execute({ session_id: 4, chars: "" });
-    expect(result.isError).toBe(true);
-    expect(parsed(result).code).toBe("unknown_process");
-    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
-  });
-
-  test("a sandbox-profile mismatch is a confirmed no-effect failure", async () => {
-    const tool = toolWhoseManager(async () => {
-      throw new UnifiedExecError(
-        "write_stdin",
-        "write_stdin requires an existing session with a compatible sandbox profile; a session started with sandbox_permissions is reached by passing the same sandbox_permissions",
-      );
-    });
-    const result = await tool.execute({ session_id: 4, chars: "" });
-    expect(result.isError).toBe(true);
-    expect(parsed(result).error).toContain("sandbox_permissions");
-    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
-  });
-
-  test("a closed stdin is a confirmed no-effect failure", async () => {
-    const tool = toolWhoseManager(async () => {
-      throw new UnifiedExecError("stdin_closed", "stdin is closed for this session");
-    });
-    const result = await tool.execute({ session_id: 4, chars: "y\n" });
-    expect(result.isError).toBe(true);
-    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
-  });
+  }
 
   test("a rejected argument is a confirmed no-effect failure", async () => {
     const tool = toolWhoseManager(async () => completedOutput(""));
@@ -103,9 +114,9 @@ describe("write_stdin failures before any byte reaches the process", () => {
 
 describe("write_stdin failures after the write started", () => {
   test("a write that failed once bytes may have reached the process stays undecided", async () => {
-    const tool = toolWhoseManager(async () => {
-      throw new UnifiedExecError("stdin_write_failed", "failed to write to stdin");
-    });
+    const tool = toolWhoseManagerThrows(
+      new UnifiedExecError("stdin_write_failed", "failed to write to stdin"),
+    );
     const result = await tool.execute({ session_id: 4, chars: "y\n" });
     expect(result.isError).toBe(true);
     expect(parsed(result).code).toBe("stdin_write_failed");


### PR DESCRIPTION
## Why

Desktop soak on the production bundle, 2026-09-06, session `conv-mtp80uk3`, the first bypass chat run on the daemon with #2184 and #2185. `npm install` now ran, escalated as requested. The model then polled it with `write_stdin` (session 4, empty chars). The call failed in 35 ms:

```
write_stdin requires an existing session with a compatible sandbox profile
```

and from that moment every `exec_command`, `Skill` and other side-effecting call of the session was refused with `live effect settlement is unresolved for call-…-15 (write_stdin) … ask the user to run /resolve …`. The turn wound down through the repeat guard and the session stayed gated behind a manual `/resolve` for the rest of the run.

Two defects behind it:

1. The tool returned the precondition error without an effect disposition. `admitted-tool-call.ts` files a side-effecting tool's error result without a `confirmed_no_effect` or `confirmed_committed` disposition as `effect_unknown_outcome` (`tool_error_result_without_authoritative_effect_disposition`), poisons the live effect, and the settlement supervisor blocks the session. `exec_command` marks its pre-spawn failures `confirmed_no_effect` for exactly this reason; `write_stdin` never did, so a call that could not have touched the process was treated as one whose effect nobody knows.
2. The session was unreachable because `exec_command` had started it with `sandbox_permissions: require_escalated` (granted under bypass by #2185), so the process runs in the escalated profile, while `write_stdin` ran in the turn's default `workspace_write` profile and `runtimeSandboxesCompatible` refused the mismatch. `write_stdin` had no field to ask for the session's sandbox, and the error did not say what to do, so an escalated long-running command could be started but never driven or polled.

## What changed

- `runtime/src/tools/system/write-stdin.ts`: every failure before a byte reaches the process carries `confirmed_no_effect` (evidence kind `boundary_not_crossed`): the tool's own argument rejections, the workspace-write policy block, and every `UnifiedExecError` or `SandboxExecutionError` except the post-write one. The schema gains `sandbox_permissions`, `additional_permissions` and `justification` with the same shapes as `exec_command`; the orchestrator already reads these from any tool's arguments, so the approval flow (prompt, or grant under bypass) and the runtime sandbox selection apply unchanged.
- `runtime/src/unified-exec/process-manager.ts`: a write that fails after it started throws the new code `stdin_write_failed` instead of reusing `write_stdin`, so the tool can tell it apart; the mismatch message says the session was started with `sandbox_permissions` and that passing the same value reaches it.
- `runtime/src/unified-exec/types.ts`: the new error code. `runtime/src/tools/system/exec-command.ts`: `confirmedNoEffectDisposition` is exported for the sibling tool.

## Evidence

Records 884 to 901 and 982 to 1314 of the session's rollout: the 35 ms failure, `effect_unknown_outcome`, then eleven refusals. With this change the failure is filed as `failed` with `effectBoundary: not_crossed`, nothing is poisoned, and the model's next call runs.

## Tests

- `tests/tools/system/write-stdin.test.ts` (new): an unknown session, a sandbox mismatch, a closed stdin and a rejected argument each return `isError` with `confirmed_no_effect`; a `stdin_write_failed` result carries no disposition; the schema exposes the three sandbox fields with `exec_command`'s enum. 6 passed.
- `tests/unified-exec/process-manager.test.ts` and `tests/tools/system/exec-command.test.ts`: the same seven plus one PTY tests fail on this Mac before and after the change (they need a PTY the runner here lacks); the failure sets are identical to unmodified main. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The admission layer's rule that an undecorated error result on a side-effecting tool is an unknown outcome; this makes `write_stdin` decorate its results.
- The sandbox compatibility rule itself: a sandboxed caller still cannot drive a process running in a wider profile without asking for that profile through the approval flow.
- `/resolve`.

## Counterparts

#2185 (bypass grants the escalation that produced the escalated session), #2184. Desktop soak findings F47 and F48 in `~/claude-agenc/soak/findings.md`.
