### PR TITLE
apply_patch: a failure before any file is touched is a confirmed no-effect result

### DIFF
--- a/runtime/src/tools/apply-patch/tool.ts
+++ b/runtime/src/tools/apply-patch/tool.ts
@@ -16,12 +16,17 @@ import { checkToolPathPermission } from "../../permissions/path-validation.js";
 import type { PermissionResult } from "../../permissions/types.js";
 import { nonEmptyString as asNonEmptyString } from "../../utils/stringUtils.js";
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
-import { plainTextErrorToolResult as errorResult } from "../results.js";
+import {
+  plainTextErrorToolResult as errorResult,
+  validationErrorToolResult,
+} from "../results.js";
+import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 import { SESSION_ID_ARG } from "../system/filesystem.js";
 import { parsePatch } from "./parser.js";
 import { applyPatchText } from "./runtime.js";
 import { WorkspaceMutationRejectedError } from "../../workspace/mutation-coordinator.js";
 import type { ApplyPatchHunk } from "./types.js";
+import { ApplyPatchInputError, ApplyPatchParseError } from "./types.js";
 
 export const APPLY_PATCH_TOOL_NAME = "apply_patch";
 
@@ -197,7 +202,12 @@ export function createApplyPatchTool(config: ApplyPatchToolConfig): Tool {
     async execute(rawArgs: Record<string, unknown>): Promise<ToolResult> {
       const args = rawArgs as ApplyPatchToolInput;
       const patch = asNonEmptyString(args.input);
-      if (!patch) return errorResult("input must be a non-empty string");
+      if (!patch) {
+        return validationErrorToolResult(
+          "tool:apply_patch:validation",
+          "input must be a non-empty string",
+        );
+      }
 
       const cwd = asNonEmptyString(args.cwd) ?? config.cwd;
       const sessionId = asNonEmptyString(args[SESSION_ID_ARG]);
@@ -224,12 +234,31 @@ export function createApplyPatchTool(config: ApplyPatchToolConfig): Tool {
           metadata: result.metadata,
         };
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Failures that happen before any file is touched carry a confirmed
+        // no-effect disposition. Without it the admission layer files the
+        // error as an unknown outcome and blocks every side-effecting tool of
+        // the session until an operator runs /resolve (#2190). A runtime
+        // failure may have applied part of the patch and stays undecided.
         if (error instanceof WorkspaceMutationRejectedError) {
-          return error.toolResult;
+          // Admission refused the proposal before any byte was written.
+          return {
+            ...error.toolResult,
+            effectDisposition: createToolEffectDispositionEvidence({
+              disposition: "confirmed_no_effect",
+              evidenceKind: "boundary_not_crossed",
+              evidenceRef: "tool:apply_patch:admission-rejected",
+              evidenceMaterial: error.toolResult.content,
+            }),
+          };
         }
-        return errorResult(
-          error instanceof Error ? error.message : String(error),
-        );
+        if (
+          error instanceof ApplyPatchParseError ||
+          error instanceof ApplyPatchInputError
+        ) {
+          return validationErrorToolResult("tool:apply_patch:parse", message);
+        }
+        return errorResult(message);
       }
     },
   };

--- a/runtime/tests/tools/apply-patch/tool.test.ts
+++ b/runtime/tests/tools/apply-patch/tool.test.ts
@@ -88,6 +88,42 @@ describe("apply_patch tool", () => {
     expect(decision.behavior).not.toBe("allow");
   });
 
+  describe("failures before any file is touched are confirmed no-effect", () => {
+    // #2190: a bare isError from a side-effecting tool is filed as an unknown
+    // outcome and gates the session behind /resolve.
+    test("an empty payload", async () => {
+      const tool = createApplyPatchTool({ cwd: "/tmp", allowedPaths: ["/tmp"] });
+      const result = await tool.execute({ input: "" });
+      expect(result.isError).toBe(true);
+      expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    });
+
+    test("a payload the parser rejects", async () => {
+      const tool = createApplyPatchTool({ cwd: "/tmp", allowedPaths: ["/tmp"] });
+      const result = await tool.execute({
+        input: "this is not a valid apply_patch payload",
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("invalid patch");
+      expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    });
+
+    test("a runtime failure while applying stays undecided", async () => {
+      const root = await mkdtemp(join(tmpdir(), "agenc-apply-patch-runtime-"));
+      const tool = createApplyPatchTool({ cwd: root, allowedPaths: [root] });
+      const result = await tool.execute({
+        input: `*** Begin Patch
+*** Update File: ${join(root, "missing.txt")}
+@@
+-old
++new
+*** End Patch`,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.effectDisposition).toBeUndefined();
+    });
+  });
+
   test("declares a deferred mutating filesystem surface", () => {
     const tool = createApplyPatchTool({ cwd: "/tmp", allowedPaths: ["/tmp"] });
 


### PR DESCRIPTION
## Why

#2190: the executor signals a side-effecting tool's effect boundary before `tool.execute` runs, so an error result without an `effectDisposition` is filed as `effect_unknown_outcome`, the live effect is poisoned, and the session's side-effecting and interactive dispatch is blocked until an operator runs `/resolve`. `apply_patch` returned bare errors from three paths that never touch a file: an empty `input`, a payload the strict parser rejects (`ApplyPatchParseError`, `ApplyPatchInputError`), and a proposal the workspace mutation coordinator refuses (`WorkspaceMutationRejectedError`). A model that sends one malformed patch in a coding session would put the session behind a manual `/resolve`.

## What changed

- `runtime/src/tools/apply-patch/tool.ts`: the empty-input refusal goes through `validationErrorToolResult`; in the catch, a parse or input error becomes a `validationErrorToolResult` under `tool:apply_patch:parse`, and a mutation-coordinator rejection keeps its result and gains a `confirmed_no_effect` disposition under `tool:apply_patch:admission-rejected`, the same shape `file-edit.ts` uses for its admission rejections. An `ApplyPatchRuntimeError`, which can follow a partially applied patch, still returns a bare error and stays undecided.

## Evidence

The audit in #2190: `apply_patch` had no disposition site; `Edit`, `Write`, `bash`, `exec_command` and `notebook-edit` already decorate their pre-mutation failures.

## Tests

- `tests/tools/apply-patch/tool.test.ts`, three new cases: an empty payload and an unparseable payload return `isError` with `confirmed_no_effect`; a runtime failure (an update to a file that does not exist) returns `isError` with no disposition. 8 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- `checkPermissions`, which already fails closed on an unparseable patch.
- Runtime failures during apply.
- The other tools listed in #2190.

## Counterparts

#2190, #2189 (the same fix for `write_stdin`).
