### PR TITLE
tools: refusals before the effect carry confirmed_no_effect in kill_process, sleep, monitor and the filesystem tools

### DIFF
--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -79,6 +79,7 @@ import {
   withSignedSessionId,
 } from "../../agents/_deps/filesystem-args.js";
 import type { Tool, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
 import { safeStringify } from "../types.js";
 import {
   completeWorkspaceTopologyMutation,
@@ -899,6 +900,21 @@ function errorResult(message: string): ToolResult {
   return { content: safeStringify({ error: message }), isError: true };
 }
 
+/**
+ * An error result for a refusal that happened before the tool touched the
+ * filesystem: a bad argument, a path outside the allowed roots, a missing
+ * source, an Editor conflict, a refused reservation. It carries a confirmed
+ * no-effect disposition; a bare error from a side-effecting tool is filed as
+ * an unknown outcome and gates the session behind /resolve (#2190). Failures
+ * after mkdir, rm or rename started keep the bare result.
+ */
+function preEffectErrorResult(message: string): ToolResult {
+  return {
+    ...validationErrorToolResult("tool:system.filesystem:pre-effect", message),
+    content: safeStringify({ error: message }),
+  };
+}
+
 /** Format error for fallback catch without leaking resolved internal paths. */
 function safeError(err: unknown, operation: string): string {
   const code = (err as NodeJS.ErrnoException)?.code;
@@ -1196,7 +1212,7 @@ async function validatePath(
   args?: Record<string, unknown>,
 ): Promise<[string | null, ToolResult | null]> {
   if (typeof input !== "string" || input.trim().length === 0) {
-    return [null, errorResult(`${paramName} must be a non-empty string`)];
+    return [null, preEffectErrorResult(`${paramName} must be a non-empty string`)];
   }
   const result = await safePath(
     input,
@@ -1221,7 +1237,7 @@ async function validatePath(
       // canonicalize threw — fall through to the original rejection.
     }
   }
-  return [null, errorResult(`Access denied: ${result.reason}`)];
+  return [null, preEffectErrorResult(`Access denied: ${result.reason}`)];
 }
 
 /**
@@ -1456,7 +1472,7 @@ function createDeleteTool(
         if (pathErr) return pathErr;
 
         if (!allowDelete) {
-          return errorResult(
+          return preEffectErrorResult(
             "Delete operations are disabled. Set allowDelete: true in config.",
           );
         }
@@ -1474,20 +1490,20 @@ function createDeleteTool(
             );
           }
           if (resolved === canonicalAllowed) {
-            return errorResult("Cannot delete sandbox root directory");
+            return preEffectErrorResult("Cannot delete sandbox root directory");
           }
         }
 
         // Check if target is a directory — require explicit recursive opt-in
         const targetStat = await stat(resolved!);
         if (targetStat.isDirectory() && args.recursive !== true) {
-          return errorResult("Cannot delete directory without recursive: true");
+          return preEffectErrorResult("Cannot delete directory without recursive: true");
         }
         const conflict = workspaceMutationPathConflict(resolved!, {
           includeDescendants: targetStat.isDirectory(),
         });
         if (conflict !== null) {
-          return errorResult(
+          return preEffectErrorResult(
             `Cannot delete ${String(args.path)}: ${conflict.path} has ${
               conflict.authority === "editor_dirty"
                 ? "unsaved editor changes"
@@ -1499,7 +1515,7 @@ function createDeleteTool(
           includeDescendants: targetStat.isDirectory(),
         });
         if (loadedConflict !== null) {
-          return errorResult(
+          return preEffectErrorResult(
             `Cannot delete ${String(args.path)}: ${loadedConflict.path} is loaded in Editor. Close that buffer or use the Editor project tree to delete it safely.`,
           );
         }
@@ -1531,11 +1547,12 @@ function createDeleteTool(
         };
       } catch (err) {
         if (err instanceof WorkspaceMutationCoordinatorError) {
-          return errorResult(err.message);
+          // The reservation was refused before rm ran.
+          return preEffectErrorResult(err.message);
         }
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes("ENOENT"))
-          return errorResult(`Path not found: ${args.path}`);
+          return preEffectErrorResult(`Path not found: ${args.path}`);
         return errorResult(safeError(err, "delete"));
       }
     },
@@ -1585,7 +1602,7 @@ function createMoveTool(allowedPaths: readonly string[]): Tool {
           includeDescendants: sourceStat.isDirectory(),
         });
         if (sourceConflict !== null) {
-          return errorResult(
+          return preEffectErrorResult(
             `Cannot move ${String(args.source)}: ${sourceConflict.path} has ${
               sourceConflict.authority === "editor_dirty"
                 ? "unsaved editor changes"
@@ -1597,7 +1614,7 @@ function createMoveTool(allowedPaths: readonly string[]): Tool {
           includeDescendants: sourceStat.isDirectory(),
         });
         if (loadedSourceConflict !== null) {
-          return errorResult(
+          return preEffectErrorResult(
             `Cannot move ${String(args.source)}: ${loadedSourceConflict.path} is loaded in Editor. Close that buffer or use the Editor project tree to move it safely.`,
           );
         }
@@ -1605,7 +1622,7 @@ function createMoveTool(allowedPaths: readonly string[]): Tool {
           includeDescendants: true,
         });
         if (destinationConflict !== null) {
-          return errorResult(
+          return preEffectErrorResult(
             `Cannot move to ${String(args.destination)}: ${destinationConflict.path} has ${
               destinationConflict.authority === "editor_dirty"
                 ? "unsaved editor changes"
@@ -1620,7 +1637,7 @@ function createMoveTool(allowedPaths: readonly string[]): Tool {
           },
         );
         if (loadedDestinationConflict !== null) {
-          return errorResult(
+          return preEffectErrorResult(
             `Cannot move to ${String(args.destination)}: ${loadedDestinationConflict.path} is loaded in Editor. Close that buffer or use the Editor project tree to move it safely.`,
           );
         }
@@ -1658,11 +1675,12 @@ function createMoveTool(allowedPaths: readonly string[]): Tool {
         };
       } catch (err) {
         if (err instanceof WorkspaceMutationCoordinatorError) {
-          return errorResult(err.message);
+          // The reservation was refused before rename ran.
+          return preEffectErrorResult(err.message);
         }
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes("ENOENT"))
-          return errorResult(`Source not found: ${args.source}`);
+          return preEffectErrorResult(`Source not found: ${args.source}`);
         return errorResult(safeError(err, "move"));
       }
     },

--- a/runtime/src/tools/system/kill-process.ts
+++ b/runtime/src/tools/system/kill-process.ts
@@ -7,6 +7,8 @@
  * for the manager's hard timeout.
  */
 import type { Tool, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
+import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 import { safeStringify } from "../types.js";
 import { UnifiedExecProcessManager } from "../../unified-exec/process-manager.js";
 import type { UnifiedExecProcessManagerLike } from "../../unified-exec/types.js";
@@ -84,26 +86,22 @@ export function createKillProcessTool(config?: KillProcessToolConfig): Tool {
       additionalProperties: false,
     },
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      // Refusals before any signal is sent carry a confirmed no-effect
+      // disposition; a bare error from a side-effecting tool gates the
+      // session behind /resolve (#2190).
+      const refuse = (error: string): ToolResult => ({
+        ...validationErrorToolResult("tool:system.kill-process:validation", error),
+        content: safeStringify({ error }),
+      });
       if (Object.prototype.hasOwnProperty.call(args, "process_id")) {
-        return {
-          content: safeStringify({ error: "unknown field `process_id`" }),
-          isError: true,
-        };
+        return refuse("unknown field `process_id`");
       }
       const sessionId = asNumber(args.session_id);
       if (sessionId === undefined) {
-        return {
-          content: safeStringify({ error: "session_id must be a number" }),
-          isError: true,
-        };
+        return refuse("session_id must be a number");
       }
       if (manager.terminateProcess === undefined) {
-        return {
-          content: safeStringify({
-            error: "process termination is not supported by this runtime",
-          }),
-          isError: true,
-        };
+        return refuse("process termination is not supported by this runtime");
       }
       const ownerId = processOwnerIdFromToolArgs(args);
       try {
@@ -133,6 +131,18 @@ export function createKillProcessTool(config?: KillProcessToolConfig): Tool {
               : {}),
           }),
           isError: true,
+          // The manager refuses (unknown owner, denied access) before it
+          // signals the process.
+          ...(error instanceof UnifiedExecError
+            ? {
+                effectDisposition: createToolEffectDispositionEvidence({
+                  disposition: "confirmed_no_effect",
+                  evidenceKind: "boundary_not_crossed",
+                  evidenceRef: "tool:system.kill-process:refused",
+                  evidenceMaterial: message,
+                }),
+              }
+            : {}),
         };
       }
     },

--- a/runtime/src/tools/system/monitor.ts
+++ b/runtime/src/tools/system/monitor.ts
@@ -14,6 +14,7 @@ import type {
   ToolExecutionInjectedArgs,
   ToolResult,
 } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
 import type { UnifiedExecProcessManagerLike } from "../../unified-exec/types.js";
 import { processOwnerIdFromToolArgs } from "../../unified-exec/process-ownership.js";
 import { nonEmptyString as asNonEmptyString } from "../../utils/stringUtils.js";
@@ -72,17 +73,16 @@ export function createMonitorTool(config: MonitorToolConfig): Tool {
       const command = asNonEmptyString(args.command);
       const description = asNonEmptyString(args.description);
       if (!command) {
-        return {
-          content: "command must be a non-empty string",
-          isError: true,
-        };
+        return validationErrorToolResult(
+          "tool:system.monitor:validation",
+          "command must be a non-empty string",
+        );
       }
       if (!description) {
-        return {
-          content:
-            "description must be a non-empty string (active-voice summary of the command)",
-          isError: true,
-        };
+        return validationErrorToolResult(
+          "tool:system.monitor:validation",
+          "description must be a non-empty string (active-voice summary of the command)",
+        );
       }
 
       const startedAt = Date.now();

--- a/runtime/src/tools/system/sleep.ts
+++ b/runtime/src/tools/system/sleep.ts
@@ -16,6 +16,8 @@
  */
 
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
+import { createToolEffectDispositionEvidence } from "../effect-boundary.js";
 
 const SLEEP_MIN_MS = 0;
 const SLEEP_MAX_MS = 60 * 60 * 1000; // 1 hour ceiling — same as AgenC.
@@ -77,10 +79,10 @@ export function createSleepTool(): Tool {
       const args = rawArgs as SleepToolInput;
       const requested = asNumber(args.durationMs);
       if (requested === undefined) {
-        return {
-          content: "durationMs must be a finite number of milliseconds",
-          isError: true,
-        };
+        return validationErrorToolResult(
+          "tool:system.sleep:validation",
+          "durationMs must be a finite number of milliseconds",
+        );
       }
       const durationMs = Math.max(
         SLEEP_MIN_MS,
@@ -114,6 +116,14 @@ export function createSleepTool(): Tool {
         return {
           content: `Sleep interrupted after ${elapsedMs}ms`,
           isError: true,
+          // Waiting changes nothing outside this process; an interrupted
+          // wait is not an unknown effect (#2190).
+          effectDisposition: createToolEffectDispositionEvidence({
+            disposition: "confirmed_no_effect",
+            evidenceKind: "boundary_not_crossed",
+            evidenceRef: "tool:system.sleep:interrupted",
+            evidenceMaterial: `Sleep interrupted after ${elapsedMs}ms`,
+          }),
           metadata: {
             interrupted: true,
             elapsedMs,

--- a/runtime/tests/tools/system/pre-effect-dispositions.test.ts
+++ b/runtime/tests/tools/system/pre-effect-dispositions.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createFilesystemTools } from "../../../src/tools/system/filesystem.js";
+import { createKillProcessTool } from "../../../src/tools/system/kill-process.js";
+import { createMonitorTool } from "../../../src/tools/system/monitor.js";
+import { createSleepTool } from "../../../src/tools/system/sleep.js";
+import {
+  UnifiedExecError,
+  type UnifiedExecProcessManagerLike,
+} from "../../../src/unified-exec/types.js";
+import type { ToolResult } from "../../../src/tools/types.js";
+
+// #2190: a bare isError from a side-effecting tool is filed as an unknown
+// outcome and gates the session behind /resolve. Every refusal below happens
+// before the tool touches anything and must say so.
+
+let root = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "agenc-pre-effect-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function expectNoEffect(result: ToolResult, contains: string): void {
+  expect(result.isError).toBe(true);
+  expect(String(result.content)).toContain(contains);
+  expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+}
+
+function manager(terminate?: UnifiedExecProcessManagerLike["terminateProcess"]) {
+  const base: UnifiedExecProcessManagerLike = {
+    maxTimeoutMs: 30_000,
+    execCommand: vi.fn(async () => undefined as never),
+    writeStdin: vi.fn(async () => undefined as never),
+    closeAll: vi.fn(async () => {}),
+  };
+  return terminate === undefined ? base : { ...base, terminateProcess: terminate };
+}
+
+describe("kill_process refusals", () => {
+  test("a rejected argument", async () => {
+    const tool = createKillProcessTool({ unifiedExecManager: manager(() => ({ terminated: true })) });
+    expectNoEffect(await tool.execute({}), "session_id must be a number");
+  });
+
+  test("a runtime without process termination", async () => {
+    const tool = createKillProcessTool({ unifiedExecManager: manager() });
+    expectNoEffect(await tool.execute({ session_id: 4 }), "not supported");
+  });
+
+  test("a manager that refuses before signalling", async () => {
+    const tool = createKillProcessTool({
+      unifiedExecManager: manager(() => {
+        throw new UnifiedExecError("owner_denied", "process belongs to another turn");
+      }),
+    });
+    expectNoEffect(await tool.execute({ session_id: 4 }), "another turn");
+  });
+});
+
+describe("sleep refusals", () => {
+  test("a rejected argument", async () => {
+    expectNoEffect(await createSleepTool().execute({}), "durationMs");
+  });
+
+  test("an interrupted wait", async () => {
+    const controller = new AbortController();
+    const pending = createSleepTool().execute({
+      durationMs: 60_000,
+      __abortSignal: controller.signal,
+    });
+    controller.abort();
+    expectNoEffect(await pending, "Sleep interrupted");
+  });
+});
+
+describe("monitor refusals", () => {
+  test("a rejected argument", async () => {
+    const tool = createMonitorTool({ cwd: root, unifiedExecManager: manager() });
+    expectNoEffect(await tool.execute({ description: "list files" }), "command must be");
+  });
+});
+
+describe("filesystem refusals before mkdir, rm or rename", () => {
+  function toolNamed(name: string) {
+    const tool = createFilesystemTools({ allowedPaths: [root], allowDelete: true }).find(
+      (candidate) => candidate.name === name,
+    );
+    if (tool === undefined) throw new Error(`no tool ${name}`);
+    return tool;
+  }
+
+  test("a path outside the allowed roots", async () => {
+    expectNoEffect(
+      await toolNamed("system.mkdir").execute({ path: "/etc/agenc-no" }),
+      "Access denied",
+    );
+    expectNoEffect(
+      await toolNamed("system.delete").execute({ path: "/etc/passwd" }),
+      "Access denied",
+    );
+  });
+
+  test("a missing path", async () => {
+    expectNoEffect(
+      await toolNamed("system.delete").execute({ path: join(root, "missing.txt") }),
+      "Path not found",
+    );
+    expectNoEffect(
+      await toolNamed("system.move").execute({
+        source: join(root, "missing.txt"),
+        destination: join(root, "moved.txt"),
+      }),
+      "not found",
+    );
+  });
+
+  test("a rejected argument", async () => {
+    expectNoEffect(await toolNamed("system.delete").execute({}), "must be a non-empty string");
+  });
+});


### PR DESCRIPTION
## Why

#2190: the executor signals a side-effecting tool's effect boundary before `tool.execute`, so an error result without an `effectDisposition` is filed as `effect_unknown_outcome`, the live effect is poisoned, and the session's side-effecting and interactive dispatch is blocked until an operator runs `/resolve`. The audit on that issue listed the built-in tools that never attach a disposition. This takes the ones a coding session reaches most after `apply_patch` (#2191) and `write_stdin` (#2189): `kill_process`, `sleep`, `monitor`, and `system.mkdir`, `system.delete`, `system.move`.

## What changed

- `runtime/src/tools/system/filesystem.ts`: `preEffectErrorResult` wraps `validationErrorToolResult` in the module's JSON error envelope. `validatePath` returns it for a rejected argument and a path outside the allowed roots (the read-only tools that share it are unaffected; the disposition is only read for side-effecting ones). `delete` uses it for every refusal before `rm`: deletes disabled, a sandbox root, a directory without `recursive`, an Editor conflict, a refused topology reservation, a missing path. `move` uses it for every refusal before `rename`: Editor conflicts on source or destination, a refused reservation, a missing source. The two "did not complete cleanly" results after `rm`/`rename` failed, and the `safeError` fallbacks, stay bare.
- `runtime/src/tools/system/kill-process.ts`: the three argument and runtime refusals carry the disposition; a `UnifiedExecError` from the manager (ownership denied) is refused before any signal is sent and carries it too.
- `runtime/src/tools/system/sleep.ts`: the argument refusal and an interrupted wait carry it; waiting changes nothing outside the process.
- `runtime/src/tools/system/monitor.ts`: the two argument refusals carry it; a monitor that fails while starting stays bare.

## Evidence

The audit in #2190 (zero disposition sites in each of these files); the `write_stdin` incident in #2189 for what one such refusal costs.

## Tests

- `tests/tools/system/pre-effect-dispositions.test.ts` (new), nine cases: kill_process with a rejected argument, without termination support, and with a manager that refuses; sleep with a rejected argument and an aborted wait; monitor with a rejected argument; mkdir and delete outside the allowed roots; delete and move of a missing path; delete with a rejected argument. Each asserts `isError` and `confirmed_no_effect`.
- `tests/tools/system/filesystem.test.ts`, `filesystem-session-read-bound.test.ts`, `monitor.test.ts`, `monitor-description.test.ts`: unchanged and green. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- Results after the operation started.
- The remaining tools on #2190's list (git worktree tools, tool-search, worktree, task board, background agents, Browser, code-mode, imagine), which report errors by throwing and need the thrown-error brand instead.

## Counterparts

#2190, #2189, #2191.
