### PR TITLE
runtime-state: one file watcher per state path shared by every repository

### DIFF
--- a/runtime/src/config/runtime-state-repository.ts
+++ b/runtime/src/config/runtime-state-repository.ts
@@ -608,12 +608,71 @@ function createStateBackup(
   }
 }
 
+type StateFileListener = (current: Stats, previous: Stats) => void;
 type WatchFile = (
   path: string,
   options: { readonly interval: number; readonly persistent: boolean },
-  listener: (current: Stats, previous: Stats) => void,
+  listener: StateFileListener,
 ) => void;
-type UnwatchFile = (path: string) => void;
+type UnwatchFile = (path: string, listener?: StateFileListener) => void;
+
+/**
+ * One OS-level poller per state file, however many repositories watch it.
+ *
+ * Every `ConfigStore` owns a repository, and the daemon builds one per session
+ * bootstrap and per permission-settings load. Each used to call
+ * `fs.watchFile` itself, which adds one more change listener to the single
+ * `StatWatcher` node keeps per path: the listener count grew with every
+ * session for the life of the process (the `MaxListenersExceededWarning: 11
+ * change listeners added to [StatWatcher]` in the daemon log), and a
+ * repository closing called `fs.unwatchFile(path)` without its listener, which
+ * removed every other repository's listener as well. The registry subscribes
+ * the path once, fans the change out to each live repository, and stops the
+ * poller when the last one closes.
+ */
+export function createSharedFileWatch(primitives: {
+  readonly watchFile: WatchFile;
+  readonly unwatchFile: UnwatchFile;
+}): {
+  readonly watchFile: WatchFile;
+  readonly unwatchFile: UnwatchFile;
+  readonly activeWatchCount: () => number;
+} {
+  const watches = new Map<
+    string,
+    { readonly listeners: Set<StateFileListener>; readonly dispatch: StateFileListener }
+  >();
+  return {
+    watchFile(path, options, listener) {
+      let watch = watches.get(path);
+      if (watch === undefined) {
+        const listeners = new Set<StateFileListener>();
+        const dispatch: StateFileListener = (current, previous) => {
+          for (const each of [...listeners]) each(current, previous);
+        };
+        watch = { listeners, dispatch };
+        watches.set(path, watch);
+        primitives.watchFile(path, options, dispatch);
+      }
+      watch.listeners.add(listener);
+    },
+    unwatchFile(path, listener) {
+      const watch = watches.get(path);
+      if (watch === undefined) return;
+      if (listener === undefined) watch.listeners.clear();
+      else watch.listeners.delete(listener);
+      if (watch.listeners.size > 0) return;
+      watches.delete(path);
+      primitives.unwatchFile(path, watch.dispatch);
+    },
+    activeWatchCount: () => watches.size,
+  };
+}
+
+const SHARED_STATE_FILE_WATCH = createSharedFileWatch({
+  watchFile: nodeWatchFile,
+  unwatchFile: nodeUnwatchFile,
+});
 
 export interface RuntimeStateRepositoryOptions {
   /** Tests default to isolated in-memory state; disk tests opt in explicitly. */
@@ -733,6 +792,7 @@ export class RuntimeStateRepository {
   readonly #watchFile: WatchFile;
   readonly #unwatchFile: UnwatchFile;
   readonly #freshnessPollMs: number;
+  #watchListener: StateFileListener | undefined;
   #cache: StateCache = { loaded: false, config: null };
   #memoryState: GlobalRuntimeState = immutableGlobalState({});
   #watcherStarted = false;
@@ -746,8 +806,9 @@ export class RuntimeStateRepository {
     this.homeContext = Object.freeze({ ...homeContext });
     this.#storage = options.storage ??
       (process.env.NODE_ENV === "test" ? "memory" : "disk");
-    this.#watchFile = options.watchFile ?? nodeWatchFile;
-    this.#unwatchFile = options.unwatchFile ?? nodeUnwatchFile;
+    this.#watchFile = options.watchFile ?? SHARED_STATE_FILE_WATCH.watchFile;
+    this.#unwatchFile =
+      options.unwatchFile ?? SHARED_STATE_FILE_WATCH.unwatchFile;
     this.#freshnessPollMs = options.freshnessPollMs ?? STATE_FRESHNESS_POLL_MS;
   }
 
@@ -905,7 +966,8 @@ export class RuntimeStateRepository {
     this.#closed = true;
     this.#refreshGeneration += 1;
     if (this.#watcherStarted) {
-      this.#unwatchFile(this.statePath);
+      this.#unwatchFile(this.statePath, this.#watchListener);
+      this.#watchListener = undefined;
       this.#watcherStarted = false;
     }
   }
@@ -937,10 +999,11 @@ export class RuntimeStateRepository {
   #startFreshnessWatcher(): void {
     if (this.#watcherStarted || this.#closed || this.#storage === "memory") return;
     this.#watcherStarted = true;
+    this.#watchListener = () => this.#refreshAfterWatchEvent();
     this.#watchFile(
       this.statePath,
       { interval: this.#freshnessPollMs, persistent: false },
-      () => this.#refreshAfterWatchEvent(),
+      this.#watchListener,
     );
     registerCleanup(async () => this.close());
   }

--- a/runtime/tests/config/runtime-state-shared-watch.test.ts
+++ b/runtime/tests/config/runtime-state-shared-watch.test.ts
@@ -1,0 +1,120 @@
+import type { Stats } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { resolveHomeContext } from "../../src/config/home.js";
+import {
+  RuntimeStateRepository,
+  createSharedFileWatch,
+} from "../../src/config/runtime-state-repository.js";
+
+type Listener = (current: Stats, previous: Stats) => void;
+
+/** Fake `fs.watchFile` primitives that record every call and keep the listeners. */
+function fakePrimitives() {
+  const listeners = new Map<string, Set<Listener>>();
+  const watchFile = vi.fn((path: string, _options: unknown, listener: Listener) => {
+    const set = listeners.get(path) ?? new Set<Listener>();
+    set.add(listener);
+    listeners.set(path, set);
+  });
+  const unwatchFile = vi.fn((path: string, listener?: Listener) => {
+    const set = listeners.get(path);
+    if (set === undefined) return;
+    if (listener === undefined) set.clear();
+    else set.delete(listener);
+  });
+  const fire = (path: string): void => {
+    for (const listener of listeners.get(path) ?? []) {
+      listener({} as Stats, {} as Stats);
+    }
+  };
+  return { watchFile, unwatchFile, fire, listeners };
+}
+
+const directories: string[] = [];
+const repositories: RuntimeStateRepository[] = [];
+
+afterEach(() => {
+  for (const repository of repositories.splice(0)) repository.close();
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("createSharedFileWatch", () => {
+  test("one poller per path, fanned out to every subscriber", () => {
+    const fake = fakePrimitives();
+    const shared = createSharedFileWatch(fake);
+    const first = vi.fn();
+    const second = vi.fn();
+    const options = { interval: 50, persistent: false };
+
+    shared.watchFile("/state.json", options, first);
+    shared.watchFile("/state.json", options, second);
+    shared.watchFile("/other.json", options, vi.fn());
+
+    expect(fake.watchFile).toHaveBeenCalledTimes(2);
+    expect(shared.activeWatchCount()).toBe(2);
+    fake.fire("/state.json");
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("closing one subscriber keeps the others watching; the last one stops the poller", () => {
+    const fake = fakePrimitives();
+    const shared = createSharedFileWatch(fake);
+    const first = vi.fn();
+    const second = vi.fn();
+    const options = { interval: 50, persistent: false };
+    shared.watchFile("/state.json", options, first);
+    shared.watchFile("/state.json", options, second);
+
+    shared.unwatchFile("/state.json", first);
+    expect(fake.unwatchFile).not.toHaveBeenCalled();
+    fake.fire("/state.json");
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+
+    shared.unwatchFile("/state.json", second);
+    expect(fake.unwatchFile).toHaveBeenCalledTimes(1);
+    expect(shared.activeWatchCount()).toBe(0);
+    // The poller is released with the dispatcher it was installed with, not bare.
+    expect(fake.unwatchFile.mock.calls[0]?.[1]).toBeTypeOf("function");
+  });
+});
+
+describe("repositories on one state file", () => {
+  test("share one poller and do not blind each other on close", () => {
+    const root = mkdtempSync(join(tmpdir(), "agenc-shared-watch-"));
+    directories.push(root);
+    const home = resolveHomeContext({ AGENC_HOME: join(root, "home"), HOME: root });
+    const fake = fakePrimitives();
+    const shared = createSharedFileWatch(fake);
+    const options = {
+      storage: "disk" as const,
+      watchFile: shared.watchFile,
+      unwatchFile: shared.unwatchFile,
+    };
+    const a = new RuntimeStateRepository(home, options);
+    const b = new RuntimeStateRepository(home, options);
+    repositories.push(a, b);
+
+    // A read starts each repository's freshness watcher.
+    a.get();
+    b.get();
+    expect(fake.watchFile).toHaveBeenCalledTimes(1);
+    expect(shared.activeWatchCount()).toBe(1);
+
+    // The session that owned `a` ends. `b` must still see changes.
+    a.close();
+    expect(fake.unwatchFile).not.toHaveBeenCalled();
+    expect(fake.listeners.get(a.statePath)?.size).toBe(1);
+
+    b.close();
+    expect(fake.unwatchFile).toHaveBeenCalledTimes(1);
+    expect(shared.activeWatchCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Desktop soak finding F39: the daemon log carries `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 change listeners added to [StatWatcher]` from every long-lived daemon. The source is `RuntimeStateRepository`. Every `ConfigStore` owns one (`config/store.ts`), and the daemon builds a `ConfigStore` per session bootstrap (`bin/bootstrap.ts`) and per permission-settings load (`permissions/settings.ts`, `withCanonicalStore`, reached from `loadPermissionRulesSnapshot` in the background runner). Each repository's first `get()` calls `fs.watchFile` on the same `runtime-state` file. Node keeps one `StatWatcher` per path and adds a listener per call, so the listener count grew with every session for the life of the process: 320 sessions on the soak home meant 320 closures on one watcher, and the warning at eleven.

A second defect sits in `close()`: it called `fs.unwatchFile(path)` without the repository's own listener, which removes every listener on that path, so one repository closing left every other live repository blind to state changes.

## What changed

- `runtime/src/config/runtime-state-repository.ts`: `createSharedFileWatch(primitives)` keeps one subscription per path, fans each change out to the live listeners, and releases the poller (with the dispatcher it installed) when the last listener unsubscribes. The module holds one instance over node's `watchFile`/`unwatchFile`, and repositories use it by default; the `watchFile`/`unwatchFile` options still inject alternatives, and `UnwatchFile` now takes the optional listener node's own signature has. A repository remembers its listener and passes it on `close()`.

## Evidence

The warning's count and the daemon's session count in the soak (`~/claude-agenc/soak/findings.md`, F39); the two `fs.watchFile` call sites in the runtime, of which `gitFilesystem.ts` is a per-process singleton and this one was per instance.

## Tests

- `tests/config/runtime-state-shared-watch.test.ts` (new): two subscribers on one path install one poller and both receive the change; a third path installs a second; unsubscribing one keeps the other receiving and does not touch the primitive; the last unsubscribe releases the poller with its dispatcher. Two disk repositories on one home read once each and install one poller; closing the first leaves the second's listener in place; closing the second releases it.
- `tests/config/runtime-state-home-isolation.test.ts`, `runtime-state-backup-race.test.ts`, `runtime-state-backup-staging.test.ts`: unchanged and green. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- `ConfigStore` still has no `close()`, so the repository objects built per permission-settings load still live until process exit; with this change they cost no watcher. Giving `ConfigStore` a lifecycle is a separate change.
- The freshness poll interval and the state file format.

## Counterparts

Desktop soak F39; #2159 (state database reclaim, the other per-process growth found in the soak).
