### PR TITLE
spawn_agent: model, reasoning effort and service tier refusals carry confirmed_no_effect

### DIFF
--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -46,6 +46,7 @@ import {
   stringValue,
   toolMetadata,
   type MultiAgentV2Options,
+  agentValidationError,
 } from "./common.js";
 
 const SPAWN_AGENT_INHERITED_MODEL_GUIDANCE =
@@ -228,11 +229,8 @@ async function validateSpawnModelOverrides(opts: {
       modelsManager.tryListModels() ?? (await modelsManager.listModels());
     if (!listed.some((candidate) => candidate.slug === opts.model)) {
       const available = listed.map((candidate) => candidate.slug).join(", ");
-      return json(
-        {
-          error: `Unknown model \`${opts.model}\` for spawn_agent. Available models: ${available}`,
-        },
-        true,
+      return agentValidationError(
+        `Unknown model \`${opts.model}\` for spawn_agent. Available models: ${available}`,
       );
     }
   }
@@ -246,11 +244,8 @@ async function validateSpawnModelOverrides(opts: {
         : await modelsManager.getModelInfo(model);
     if (!modelInfo.supportedReasoningLevels.includes(opts.reasoningEffort)) {
       const supported = modelInfo.supportedReasoningLevels.join(", ");
-      return json(
-        {
-          error: `Reasoning effort \`${opts.reasoningEffort}\` is not supported for model \`${model}\`. Supported reasoning efforts: ${supported}`,
-        },
-        true,
+      return agentValidationError(
+        `Reasoning effort \`${opts.reasoningEffort}\` is not supported for model \`${model}\`. Supported reasoning efforts: ${supported}`,
       );
     }
   }
@@ -276,12 +271,8 @@ async function resolveSpawnServiceTier(opts: {
     opts.session.sessionConfiguration.collaborationMode.model ??
     opts.session.modelInfo.slug;
   if (!model) {
-    return json(
-      {
-        error:
-          "spawn_agent could not resolve the child model for service tier validation",
-      },
-      true,
+    return agentValidationError(
+      "spawn_agent could not resolve the child model for service tier validation",
     );
   }
   const modelInfo =
@@ -292,11 +283,8 @@ async function resolveSpawnServiceTier(opts: {
     opts.requestedServiceTier !== undefined &&
     !modelSupportsServiceTier(modelInfo, opts.requestedServiceTier)
   ) {
-    return json(
-      {
-        error: `Service tier \`${opts.requestedServiceTier}\` is not supported for model \`${model}\`. Supported service tiers: ${formatSupportedServiceTiers(modelInfo)}`,
-      },
-      true,
+    return agentValidationError(
+      `Service tier \`${opts.requestedServiceTier}\` is not supported for model \`${model}\`. Supported service tiers: ${formatSupportedServiceTiers(modelInfo)}`,
     );
   }
   for (const candidate of [

--- a/runtime/tests/agents/v2/spawn-isolation.test.ts
+++ b/runtime/tests/agents/v2/spawn-isolation.test.ts
@@ -107,6 +107,25 @@ describe("spawn_agent isolation", () => {
     mockDelegate.mockReset();
   });
 
+  it("refuses an unknown model as a confirmed no-effect failure before anything is spawned", async () => {
+    // #2190: a bare isError from a side-effecting tool is filed as an unknown
+    // outcome and gates the session behind /resolve; nothing was spawned here.
+    const session = makeSession();
+    const tool = createSpawnAgentTool(makeOptions(session));
+
+    const result = await tool.execute({
+      message: "review the change",
+      task_name: "review",
+      model: "sonnet",
+      __callId: "spawn-unknown-model",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("Unknown model");
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    expect(mockDelegate).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["review-patch", "review_patch"],
     ["Review Patch", "review_patch"],


### PR DESCRIPTION
## Why

#2190: an error result from a side-effecting tool without an `effectDisposition` is filed as an unknown outcome and gates the session's side-effecting dispatch behind `/resolve`. `spawn_agent` already decorates most of its preflight refusals through `spawnValidationError` and `confirmedNoSpawn`, but four of them still used the bare `json({ error }, true)` helper: an unknown model, a reasoning effort the model does not support, a service tier the model does not support, and a child model that could not be resolved for tier validation. A swarm session whose spawn names a model the provider does not list would have been gated by its own typo.

## What changed

- `runtime/src/agents/v2/spawn.ts`: the four refusals return `agentValidationError(...)` from `./common.js`, which carries `confirmed_no_effect` with `boundary_not_crossed` evidence. Failures at or beyond `delegate()` are unchanged and stay undecided.

## Evidence

The audit in #2190 (`agents/v2/spawn.ts` had three disposition sites next to these four bare results).

## Tests

- `tests/agents/v2/spawn-isolation.test.ts`, "refuses an unknown model as a confirmed no-effect failure before anything is spawned": with a provider that lists no models, a spawn with `model: "sonnet"` returns `isError`, names the unknown model, carries `confirmed_no_effect`, and never reaches `delegate()`. The three spawn suites: 26 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- `spawn_agent` failures after the child or worktree exists.
- `close_agent`'s close failure, which follows an attempted close and stays undecided.

## Counterparts

#2190, #2189, #2191, #2193.