### PR TITLE
auto-compaction: one retry when the summarizer call fails on a transient provider error

### DIFF
--- a/runtime/src/services/compact/autoCompact.ts
+++ b/runtime/src/services/compact/autoCompact.ts
@@ -7,6 +7,7 @@
 
 import type { CompactContext, CompactionResult, RuntimeMessage } from "./types.js";
 import { compactConversation } from "./compact.js";
+import { isTransientProviderError } from "../../recovery/api-errors.js";
 import { CompactionReconstructionRequiredError } from "./transaction-types.js";
 import {
   estimateMessagesTokens,
@@ -65,6 +66,36 @@ export const MANUAL_COMPACT_BUFFER_TOKENS = 3_000;
 
 const MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3;
 
+/**
+ * One immediate retry of the summarizer call when it fails on a transient
+ * provider error (a dropped connection, a body cut mid-stream). A turn that
+ * has run past the context limit has exactly one way forward, and a single
+ * network blip used to end it: the attempt was recorded as a failure and the
+ * turn went on sampling a prompt the provider would not serve (desktop soak,
+ * 2026-09-06). Only one retry: the transaction refuses further automatic
+ * attempts after two durable failures for the same history.
+ */
+const MAX_TRANSIENT_COMPACTION_RETRIES = 1;
+const TRANSIENT_COMPACTION_RETRY_DELAY_MS = 1_000;
+
+function transientRetryDelay(context: CompactContext): Promise<void> {
+  const signal = context.abortController?.signal;
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(done, TRANSIENT_COMPACTION_RETRY_DELAY_MS);
+    timer.unref?.();
+    function done(): void {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}
+
 export async function autoCompactIfNeeded(
   messages: RuntimeMessage[],
   context: CompactContext,
@@ -105,36 +136,48 @@ export async function autoCompactIfNeeded(
   if (options.force !== true && tokenCount < autoCompactThreshold(context)) {
     return { wasCompacted: false, consecutiveFailures: 0 };
   }
-  try {
-    // Every destructive compaction uses the canonical transaction. Session
-    // memory remains recall input; it is never an unauthenticated replacement
-    // history or a bypass around pin/intent/provider validation/commit.
-    const compactionResult = await compactConversation(messages, context);
-    return {
-      wasCompacted: true,
-      compactionResult,
-      consecutiveFailures: 0,
-    };
-  } catch (error) {
-    // gaphunt3 #41: a user/provider abort mid-compaction is a cancellation,
-    // not a compaction failure. Re-throw it so the cancel propagates instead
-    // of being swallowed, and do NOT increment consecutiveFailures (which
-    // would otherwise trip the 3-strike circuit breaker and disable
-    // auto-compaction for the rest of the turn on benign cancels).
-    if (
-      error instanceof CompactionReconstructionRequiredError ||
-      isAbortError(context, error)
-    ) {
-      throw error;
+  let transientRetries = 0;
+  for (;;) {
+    try {
+      // Every destructive compaction uses the canonical transaction. Session
+      // memory remains recall input; it is never an unauthenticated replacement
+      // history or a bypass around pin/intent/provider validation/commit.
+      const compactionResult = await compactConversation(messages, context);
+      return {
+        wasCompacted: true,
+        compactionResult,
+        consecutiveFailures: 0,
+      };
+    } catch (error) {
+      // gaphunt3 #41: a user/provider abort mid-compaction is a cancellation,
+      // not a compaction failure. Re-throw it so the cancel propagates instead
+      // of being swallowed, and do NOT increment consecutiveFailures (which
+      // would otherwise trip the 3-strike circuit breaker and disable
+      // auto-compaction for the rest of the turn on benign cancels).
+      if (
+        error instanceof CompactionReconstructionRequiredError ||
+        isAbortError(context, error)
+      ) {
+        throw error;
+      }
+      if (
+        transientRetries < MAX_TRANSIENT_COMPACTION_RETRIES &&
+        isTransientProviderError(error) &&
+        context.abortController?.signal.aborted !== true
+      ) {
+        transientRetries += 1;
+        await transientRetryDelay(context);
+        continue;
+      }
+      return {
+        wasCompacted: false,
+        consecutiveFailures: (tracking?.consecutiveFailures ?? 0) + 1,
+        skippedReason:
+          error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : String(error),
+      };
     }
-    return {
-      wasCompacted: false,
-      consecutiveFailures: (tracking?.consecutiveFailures ?? 0) + 1,
-      skippedReason:
-        error instanceof Error && error.message.trim().length > 0
-          ? error.message
-          : String(error),
-    };
   }
 }
 

--- a/runtime/tests/services/compact/autoCompact.test.ts
+++ b/runtime/tests/services/compact/autoCompact.test.ts
@@ -7,7 +7,11 @@ import {
   isAutoCompactEnabled,
 } from "./autoCompact.js";
 import type { RuntimeMessage } from "./types.js";
-import { createCompactionTransactionHarness } from "../../helpers/compaction-transaction-harness.js";
+import type { LLMMessage } from "../../../src/llm/types.js";
+import {
+  createCompactionTransactionHarness,
+  createProvider,
+} from "../../helpers/compaction-transaction-harness.js";
 import { runWithStartupProviderSelection } from "../../utils/model/providers.js";
 
 describe("auto compact", () => {
@@ -221,6 +225,63 @@ describe("auto compact", () => {
       /reconstruction is required/i,
     );
     harness.close();
+  });
+
+  describe("a transient summarizer failure", () => {
+    // Desktop soak, 2026-09-06: a session over the context limit lost its one
+    // way forward when the compaction call died on "Connection error." and
+    // the attempt was filed as a failure instead of retried.
+    function compactionWithChat(chat: (messages: LLMMessage[]) => Promise<unknown>) {
+      const messages = [message("x".repeat(10_000)), message("recent request")];
+      const harness = createCompactionTransactionHarness(messages, {
+        compactionMode: "automatic",
+        chat: chat as never,
+      });
+      process.env.AGENC_AUTOCOMPACT_PCT_OVERRIDE = "1";
+      installNoopCompactionHooks(harness.session);
+      return {
+        harness,
+        run: () => runWithCapturedEnvironment(() => autoCompactIfNeeded(messages, harness.context)),
+      };
+    }
+
+    test("is retried once and the compaction goes through", async () => {
+      const fallback = createProvider(undefined, false);
+      const chat = vi.fn(async (messages: LLMMessage[]) => {
+        if (chat.mock.calls.length === 1) throw new Error("grok error: Connection error.");
+        return fallback.chat(messages);
+      });
+      const { harness, run } = compactionWithChat(chat);
+      const result = await run();
+      expect(result.wasCompacted).toBe(true);
+      expect(result.consecutiveFailures).toBe(0);
+      expect(chat).toHaveBeenCalledTimes(2);
+      harness.close();
+    });
+
+    test("that repeats is reported after the one retry", async () => {
+      const chat = vi.fn(async () => {
+        throw new Error("grok error: Connection error.");
+      });
+      const { harness, run } = compactionWithChat(chat);
+      const result = await run();
+      expect(result.wasCompacted).toBe(false);
+      expect(result.consecutiveFailures).toBe(1);
+      expect(result.skippedReason).toContain("Connection error");
+      expect(chat).toHaveBeenCalledTimes(2);
+      harness.close();
+    });
+
+    test("does not cover a failure that is not transient", async () => {
+      const chat = vi.fn(async () => {
+        throw new Error("prompt is too long for this model");
+      });
+      const { harness, run } = compactionWithChat(chat);
+      const result = await run();
+      expect(result.wasCompacted).toBe(false);
+      expect(chat).toHaveBeenCalledTimes(1);
+      harness.close();
+    });
   });
 
   test("respects AgenC disable switches", async () => {


### PR DESCRIPTION
## Why

Desktop soak, plan run `plan-3`, 2026-09-06 (session `conv-mtpaj1h5`). After some 300 read-only tool calls the session's prompt reached 359,290 tokens against a 356,250 limit. The runtime started an in-turn compaction (`compaction_intent` at 05:10:09Z); its summarizer call failed 42 seconds later with `grok error: Connection error.`; `autoCompactIfNeeded` recorded the attempt as a failure (`auto_compact_failed: context_limit/in_turn: grok error: Connection error.`, then `mid_turn_compact_skipped: lastSamplePromptTokens=359290 limit=356250`) and the turn went back to sampling a prompt the provider neither served nor rejected. The compaction is the only way forward for a turn in that state, and a single network blip ended it.

The turn's own sampling requests already survive that class of error through the reconnect ladder (#2175, #2179, #2182); the compaction call did not.

## What changed

- `runtime/src/services/compact/autoCompact.ts`: when `compactConversation` throws an error that `isTransientProviderError` recognises, the attempt is retried once after one second (the delay ends early on the compaction context's abort signal). A second failure, a non-transient error, an abort and `CompactionReconstructionRequiredError` take the paths they took before: the failure is counted and its reason reported, or the error is re-thrown. One retry only, because the transaction refuses further automatic attempts after two durable failures for the same history and configuration.

## Evidence

The session's rollout, records 4930 to 4941: one intent, one failure, two warnings, no second attempt.

## Tests

- `tests/services/compact/autoCompact.test.ts`, three new cases on the transaction harness with a chat stub: a connection error on the first summarizer call followed by the default answer compacts (two calls, zero consecutive failures); a connection error on both calls is reported with its reason after exactly two calls; a non-transient error is not retried (one call). 12 passed. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The consecutive-failure circuit breaker and the transaction's durable-failure suppression.
- What the turn does when compaction still fails (it keeps sampling); that a stalled provider request holds a turn for as long as it does is F52 and F56 in the soak findings, a separate matter.

## Counterparts

Desktop soak F55 (`~/claude-agenc/soak/findings.md`); #2175, #2179, #2182 (the same class handled for sampling).
