### PR TITLE
tool-use context: descend from the turn's task controller so a stop reaches the calls the context makes

### DIFF
--- a/runtime/src/session/agenc-tool-use-context.ts
+++ b/runtime/src/session/agenc-tool-use-context.ts
@@ -166,6 +166,29 @@ export function toAgenCModelContext(ctx: TurnContext): AgenCModelContext {
   };
 }
 
+/**
+ * The controller a turn's tool-use context descends from: the running task of
+ * this turn when the session has one, so a cancel of the turn reaches every
+ * model call the context makes (compaction included), else the session's
+ * controller, so session teardown still stops the work.
+ */
+function abortParentForTurn(
+  session: Session,
+  ctx: TurnContext,
+): AbortController | undefined {
+  const activeTurn = (
+    session as { activeTurn?: { unsafePeek?: () => unknown } }
+  ).activeTurn;
+  const peeked =
+    typeof activeTurn?.unsafePeek === "function"
+      ? (activeTurn.unsafePeek as () => unknown).call(activeTurn)
+      : undefined;
+  const tasks = (peeked as { tasks?: Map<string, { abortController?: AbortController }> } | null)
+    ?.tasks;
+  const task = tasks?.get(ctx.subId);
+  return task?.abortController ?? session.abortController;
+}
+
 export function buildAgenCToolUseContext(
   session: Session,
   ctx: TurnContext,
@@ -217,15 +240,20 @@ export function buildAgenCToolUseContext(
     surface.appendSystemMessage ?? createSessionSystemMessageAppender(session);
   const attachmentState = getAttachmentTrackingState(session);
 
+  const abortParent = abortParentForTurn(session, ctx);
   return {
-    // A child of the session's controller, never the controller itself.
-    // This context is handed to the tool/agent runtime, which aborts it to
-    // cancel the context's own work; aliasing the session's one-shot root
-    // controller here meant one collab interrupt permanently poisoned the
-    // session — every later turn was born aborted.
+    // A child of the turn's task controller when this turn has one, else of
+    // the session's controller; never either controller itself. This context
+    // is handed to the tool/agent runtime, which aborts it to cancel the
+    // context's own work; aliasing the session's one-shot root controller here
+    // meant one collab interrupt permanently poisoned the session — every later
+    // turn was born aborted. Descending from the session alone meant the
+    // user's stop never reached the model calls made through this context: a
+    // compaction summarizer call ran on for minutes after the turn was
+    // cancelled (desktop soak, 2026-09-06).
     abortController:
-      session.abortController !== undefined
-        ? createChildAbortController(session.abortController)
+      abortParent !== undefined
+        ? createChildAbortController(abortParent)
         : new AbortController(),
     agentId: inferAgentId(session, ctx, surface, opts.querySource),
     agentType: surface.agentType,

--- a/runtime/tests/session/agenc-tool-use-context.test.ts
+++ b/runtime/tests/session/agenc-tool-use-context.test.ts
@@ -231,6 +231,66 @@ describe("buildAgenCToolUseContext", () => {
   });
 });
 
+describe("the turn's stop reaches the context", () => {
+  // Desktop soak, 2026-09-06: the context descended from the session's
+  // controller alone, so a cancelled turn's compaction summarizer call ran on
+  // for minutes; stop only landed when the provider gave up.
+  function sessionWithRunningTask(ctx: TurnContext, taskAbort: AbortController, subId = ctx.subId) {
+    return createSession({
+      abortController: new AbortController(),
+      activeTurn: {
+        unsafePeek: () => ({
+          turnId: ctx.subId,
+          tasks: new Map([[subId, { subId, abortController: taskAbort }]]),
+        }),
+      },
+    });
+  }
+
+  test("aborting the turn's task aborts the context", () => {
+    const ctx = createTurnContext();
+    const taskAbort = new AbortController();
+    const context = buildAgenCToolUseContext(
+      sessionWithRunningTask(ctx, taskAbort) as unknown as Session,
+      ctx,
+      { llmTools: [] },
+    );
+
+    expect(context.abortController.signal.aborted).toBe(false);
+    taskAbort.abort("interrupted");
+    expect(context.abortController.signal.aborted).toBe(true);
+  });
+
+  test("aborting the context never stops the turn's task", () => {
+    const ctx = createTurnContext();
+    const taskAbort = new AbortController();
+    const context = buildAgenCToolUseContext(
+      sessionWithRunningTask(ctx, taskAbort) as unknown as Session,
+      ctx,
+      { llmTools: [] },
+    );
+
+    context.abortController.abort("tool runtime done");
+    expect(taskAbort.signal.aborted).toBe(false);
+  });
+
+  test("another turn's task is not this context's parent", () => {
+    const ctx = createTurnContext();
+    const otherTaskAbort = new AbortController();
+    const session = sessionWithRunningTask(ctx, otherTaskAbort, "some-other-turn");
+    const context = buildAgenCToolUseContext(
+      session as unknown as Session,
+      ctx,
+      { llmTools: [] },
+    );
+
+    otherTaskAbort.abort("interrupted");
+    expect(context.abortController.signal.aborted).toBe(false);
+    (session.abortController as AbortController).abort("session_shutdown");
+    expect(context.abortController.signal.aborted).toBe(true);
+  });
+});
+
 describe("daemon sessions route tool permission changes through the registry", () => {
   test("EnterPlanMode's update lands in the registry and is visible to the next read", async () => {
     const registry = new PermissionModeRegistry(createEmptyToolPermissionContext());


### PR DESCRIPTION
## Why

Desktop soak, plan run `plan-3`, 2026-09-06 (session `conv-mtpaj1h5`). The driver pressed stop on the turn at 05:07:34Z; the harness pressed it seven more times from 05:09:50Z; the daemon recorded `turn_aborted interrupted` at 05:10:51Z, immediately after the in-turn compaction's summarizer call failed on its own (`grok error: Connection error.`). A control over the SDK (`session.prompt` then `run.cancel` mid-stream on a fresh session) ended its turn 0.0 s after the cancel, so the cancel path is immediate; the latency belonged to the turn's work that the cancel could not reach.

`buildAgenCToolUseContext` gave the context an `abortController` that was a child of `session.abortController` only. `Session.abortTurnIfActive` aborts the running task's controller (`RunningTask.abortController` on `ActiveTurn.tasks`), which the context never followed. The compaction transaction runs its provider call on `context.abortController?.signal` (`services/compact/transaction.ts`), so a stop during compaction, or during any other model call made through the context, waited for the provider.

## What changed

- `runtime/src/session/agenc-tool-use-context.ts`: `abortParentForTurn` returns the running task's controller for the turn (`session.activeTurn.unsafePeek().tasks.get(ctx.subId)`) when there is one, else the session's controller; the context's controller is a child of that parent through `createChildAbortController`, so aborting the context still never touches either parent (the regression #1751's fix pinned).

## Evidence

The soak session's rollout records 4930 to 4941 (intent at 05:10:09Z, failure and abort at 05:10:51Z) and the driver's stop at 05:07:34Z; `soak/cancel-probe.mjs` for the 0.0 s control.

## Tests

- `tests/session/agenc-tool-use-context.test.ts`, three new cases: aborting the turn's task aborts the context; aborting the context never stops the task; another turn's task is not the parent and a session abort still cascades. The two existing controller tests (the session root is never consumed; a session abort cascades) still pass. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- What `autoCompactIfNeeded` does on an abort (it re-throws without counting a failure, as before) and the transaction's rollback on abort.
- A stalled provider request that does not respond to its abort signal (soak F52); this makes the signal reach it.

## Counterparts

Desktop soak F56 (`~/claude-agenc/soak/findings.md`); #2196 (the compaction retry from the same turn); #1751.