### PR TITLE
workflow: the reviewer model is resolved at start, never a placeholder the provider has not heard of

### DIFF
--- a/runtime/src/app-server/workflow/daemon-wiring.ts
+++ b/runtime/src/app-server/workflow/daemon-wiring.ts
@@ -69,6 +69,7 @@ import {
 } from "./session-adapters.js";
 import { runWithBootstrapSessionScope } from "../../session/current-session.js";
 import { createPlatformProtectionVerifier } from "../../eval-contract/platform-protection.js";
+import { getSelectedProviderModel } from "../../utils/model/providers.js";
 
 const WORKFLOW_TASK_ID = "verified-change";
 const WORKFLOW_SYSTEM_ID = "agenc.workflow.m5";
@@ -464,6 +465,14 @@ export function createDaemonWorkflowController(options: {
     commands: seams.commands,
     spawner: seams.spawner,
     reviewer: seams.reviewer,
+    defaultReviewerModel: () => {
+      try {
+        const model = getSelectedProviderModel().trim();
+        return model.length > 0 ? model : undefined;
+      } catch {
+        return undefined;
+      }
+    },
     warn: options.warn,
   });
   return {

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -328,6 +328,14 @@ export interface VerifiedChangeWorkflowControllerDeps {
   readonly commands: WorkflowCommandRunner;
   readonly spawner: WorkflowAgentSpawner;
   readonly reviewer: ReviewerInvoker;
+  /**
+   * The model the daemon would give a new session, used as the reviewer model
+   * when the caller pins neither `reviewerModel` nor `model`. Without it the
+   * spec froze a placeholder that reached the provider as a model id (desktop
+   * soak, 2026-09-06: a 404 on `default-reviewer` ended a goal in
+   * `unknown_outcome` after every other stage had committed).
+   */
+  readonly defaultReviewerModel?: () => string | undefined;
   readonly evidenceLedger: (spec: WorkflowSpec) => Promise<WorkflowEvidenceLedger>;
   readonly warn: (message: string) => void;
   readonly now?: () => Date;
@@ -579,7 +587,12 @@ export class VerifiedChangeWorkflowController {
     const base = await this.#deps.worktrees.captureBaseState(params.repoPath, {
       runId,
     });
-    const spec = freezeWorkflowSpec(runId, params, base);
+    const spec = freezeWorkflowSpec(
+      runId,
+      params,
+      base,
+      this.#deps.defaultReviewerModel?.(),
+    );
     const specDigest = computeSpecDigest(spec);
     const admission = this.#deps.admission({
       runId,
@@ -2436,10 +2449,35 @@ export class VerifiedChangeWorkflowController {
 // Spec freeze + prompts
 // ---------------------------------------------------------------------------
 
+/**
+ * The reviewer model is resolved once, here, and pinned: the caller's
+ * `reviewerModel`, else the caller's `model`, else the model the daemon gives
+ * a new session. A start that can name none is refused instead of freezing a
+ * name the provider has never heard of.
+ */
+function resolveReviewerModel(
+  runId: string,
+  params: WorkflowStartParams,
+  daemonDefaultModel: string | undefined,
+): string {
+  const candidate =
+    params.reviewerModel ?? params.model ?? daemonDefaultModel;
+  const trimmed = candidate?.trim() ?? "";
+  if (trimmed.length === 0) {
+    throw new WorkflowIntakeError(
+      runId,
+      null,
+      "no reviewer model: pass `reviewerModel` or `model`, or configure the daemon's default model",
+    );
+  }
+  return trimmed;
+}
+
 function freezeWorkflowSpec(
   runId: string,
   params: WorkflowStartParams,
   base: BaseState,
+  daemonDefaultModel: string | undefined,
 ): WorkflowSpec {
   return {
     runId,
@@ -2453,8 +2491,7 @@ function freezeWorkflowSpec(
     },
     ...(params.model !== undefined ? { model: params.model } : {}),
     ...(params.provider !== undefined ? { provider: params.provider } : {}),
-    reviewerModel:
-      params.reviewerModel ?? params.model ?? "default-reviewer",
+    reviewerModel: resolveReviewerModel(runId, params, daemonDefaultModel),
     permissionMode: params.permissionMode ?? DEFAULT_PERMISSION_MODE,
     ...(params.unattendedAllow !== undefined
       ? { unattendedAllow: params.unattendedAllow }

--- a/runtime/tests/workflow/daemon-wiring.test.ts
+++ b/runtime/tests/workflow/daemon-wiring.test.ts
@@ -40,6 +40,7 @@ import {
 } from "../../src/state/sqlite-driver.js";
 import type { WorkflowCommandRunner } from "../../src/workflow/verification.js";
 import type { ReviewerInvoker } from "../../src/workflow/independent-review.js";
+import { runWithStartupProviderSelection } from "../../src/utils/model/providers.js";
 import type { WorktreeHandle } from "../../src/agents/worktree.js";
 
 const BASE_COMMIT = "c".repeat(40);
@@ -238,8 +239,12 @@ const commands: WorkflowCommandRunner = {
   }),
 };
 
+const reviewerInvocations: { readonly reviewerModel: string }[] = [];
 const reviewer: ReviewerInvoker = {
-  invoke: async () => APPROVING_REVIEW,
+  invoke: async (input) => {
+    reviewerInvocations.push({ reviewerModel: input.reviewerModel });
+    return APPROVING_REVIEW;
+  },
 };
 
 interface ProjectFixture {
@@ -348,6 +353,30 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
   rmSync(projectA.cwd, { recursive: true, force: true });
   rmSync(projectB.cwd, { recursive: true, force: true });
+});
+
+describe("createDaemonWorkflowController — reviewer model", () => {
+  it("pins the daemon's selected model as the reviewer model when the caller names none", async () => {
+    const { wiring } = makeWiring();
+    const before = reviewerInvocations.length;
+    const started = await runWithStartupProviderSelection(
+      { provider: "grok", model: "grok-4.6", environment: { ...process.env } },
+      () =>
+        wiring.controller.start({
+          goal: "fix a bug with the daemon's default model",
+          repoPath: projectB.cwd,
+          requiredVerification: [{ label: "unit", script: "run-tests" }],
+          runId: "wf-default-reviewer",
+        }),
+    );
+    await wiring.controller.awaitRun(started.runId);
+    expect(reviewerInvocations.slice(before).map((entry) => entry.reviewerModel)).toEqual([
+      "grok-4.6",
+    ]);
+    expect(projectB.repo.getCurrentTerminalResult("wf-default-reviewer")).toMatchObject({
+      status: "completed",
+    });
+  });
 });
 
 describe("createDaemonWorkflowController — per-run durability resolution", () => {

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -493,7 +493,9 @@ interface Harness {
 
 const RUN_ID = "run-wf-1";
 
-function makeHarness(): Harness {
+function makeHarness(
+  options: { readonly defaultReviewerModel?: () => string | undefined } = {},
+): Harness {
   const home = mkdtempSync(join(tmpdir(), "agenc-m5-controller-home-"));
   const cwd = mkdtempSync(join(tmpdir(), "agenc-m5-controller-cwd-"));
   mkdirSync(join(cwd, ".git"));
@@ -526,6 +528,9 @@ function makeHarness(): Harness {
     commands,
     spawner,
     reviewer,
+    ...(options.defaultReviewerModel !== undefined
+      ? { defaultReviewerModel: options.defaultReviewerModel }
+      : {}),
     evidenceLedger: async (spec) => {
       let ledger = ledgers.get(spec.runId);
       if (ledger === undefined) {
@@ -586,6 +591,32 @@ let harness: Harness;
 
 beforeEach(() => {
   harness = makeHarness();
+});
+
+describe("reviewer model resolution at start", () => {
+  // Desktop soak, 2026-09-06: with neither `reviewerModel` nor `model` the
+  // spec froze the placeholder "default-reviewer", the provider answered 404,
+  // and a goal whose other stages had all committed ended unknown_outcome.
+  it("pins the daemon's default model when the caller names none", async () => {
+    const own = makeHarness({ defaultReviewerModel: () => "grok-4.6" });
+    await runToTerminal(own, { model: undefined, reviewerModel: undefined });
+    expect(own.reviewer.invocations[0]?.reviewerModel).toBe("grok-4.6");
+  });
+
+  it("prefers the caller's model over the daemon's default", async () => {
+    const own = makeHarness({ defaultReviewerModel: () => "grok-4.6" });
+    await runToTerminal(own, { model: "grok-4", reviewerModel: undefined });
+    expect(own.reviewer.invocations[0]?.reviewerModel).toBe("grok-4");
+  });
+
+  it("refuses a start that can name no reviewer model", async () => {
+    const own = makeHarness();
+    await expect(
+      own.controller.start(
+        startParams(own, { model: undefined, reviewerModel: undefined }),
+      ),
+    ).rejects.toThrow(/no reviewer model/);
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Why

Desktop soak, goal run `goal-8`, 2026-09-06 (run `wf-65b785c1…`). Intake, worktree, plan (second attempt), implement and verify all committed; the review stage then failed with:

```
grok error: 404 "The model default-reviewer does not exist or your team … does not have access to it."
```

and the workflow recorded `workflow.review failed after dispatch without acknowledgement`, ending the whole goal in `unknown_outcome` after 3109 s and $4.09, with the verified change sitting in its worktree. `freezeWorkflowSpec` set `reviewerModel: params.reviewerModel ?? params.model ?? "default-reviewer"`. The app's goal start passes neither, so every other stage inherited the session's model while the reviewer got a placeholder that the session adapter handed to `buildGuardianReviewSessionConfig` as `activeModel` and so to the provider. The contract pins `reviewerModel` as a resolved string precisely so it is never re-resolved later; the placeholder was neither resolved nor a model.

## What changed

- `runtime/src/app-server/workflow/verified-change-controller.ts`: `resolveReviewerModel(runId, params, daemonDefaultModel)` pins the caller's `reviewerModel`, else the caller's `model`, else the daemon's default; a start that can name none throws `WorkflowIntakeError` ("no reviewer model: pass `reviewerModel` or `model`, or configure the daemon's default model") instead of freezing a name. The controller's dependencies gain an optional `defaultReviewerModel` resolver.
- `runtime/src/app-server/workflow/daemon-wiring.ts`: supplies that resolver from `getSelectedProviderModel()`, the model the daemon gives a new session, guarded to `undefined` when no selection exists.

## Evidence

The run's terminal rows in the project state database: four committed stages and the review terminal above; the frozen spec's `reviewerModel: "default-reviewer"`.

## Tests

- `tests/workflow/verified-change-controller.test.ts`, three new cases: with a default resolver and no caller models the reviewer is invoked with the daemon's model; a caller `model` wins over the default; without either the start is refused with the intake error.
- `tests/workflow/daemon-wiring.test.ts`, one new case: under an installed provider selection naming `grok-4.6`, a start with no models runs the reviewer with `grok-4.6` and completes. Both files green. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The review stage's `unknown_outcome` classification for a spawn that fails after dispatch (D3); with a real model this path is no longer reached for this cause.
- Callers that pass `reviewerModel` or `model` (the CLI, the SDK contract tests).

## Counterparts

Desktop soak F58 (`~/claude-agenc/soak/findings.md`); #2172 (the goal runner's earlier restart fix).