### PR TITLE
fork-context: a child forked mid-batch starts before the parent's unanswered tool calls

### DIFF
--- a/runtime/src/agents/fork-context.ts
+++ b/runtime/src/agents/fork-context.ts
@@ -235,6 +235,46 @@ function rolloutBackedParentMessages(input: ForkContextInput): LLMMessage[] {
 // ─────────────────────────────────────────────────────────────────────
 
 /**
+ * Cut a copied parent history at its last paired tool boundary.
+ *
+ * A fork taken while the parent is mid-batch ends with an assistant message
+ * whose tool calls have no results yet (they are still running, or their
+ * results have not reached the rollout). A child that starts from that copy
+ * sends a request the provider rejects (`Invalid tool-turn sequence
+ * (tool_result_missing)`): the memory-extraction subagent lost a run that way
+ * in the desktop soak, 2026-09-06. The unfinished batch belongs to the
+ * parent; the child gets the history up to the message before it.
+ */
+function trimUnansweredToolBatch(
+  messages: ReadonlyArray<LLMMessage>,
+): LLMMessage[] {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message === undefined) break;
+    if (message.role === "tool") continue;
+    if (
+      message.role === "assistant" &&
+      message.toolCalls !== undefined &&
+      message.toolCalls.length > 0
+    ) {
+      const answered = new Set(
+        messages
+          .slice(index + 1)
+          .filter((later) => later.role === "tool")
+          .map((later) => later.toolCallId),
+      );
+      const unanswered = message.toolCalls.some(
+        (call) => !answered.has(call.id),
+      );
+      return unanswered ? messages.slice(0, index) : [...messages];
+    }
+    // A user or plain assistant message closes every batch before it.
+    break;
+  }
+  return [...messages];
+}
+
+/**
  * Produce the initial message array for a child agent.
  *
  * I-36: before reading the parent's messages, we force-flush the
@@ -278,7 +318,9 @@ export async function forkSubagent(
     };
   }
 
-  const parentMessages = rolloutBackedParentMessages(input);
+  const parentMessages = trimUnansweredToolBatch(
+    rolloutBackedParentMessages(input),
+  );
   validateAgentInvocationMessageSequence(parentMessages);
 
   switch (input.mode.kind) {

--- a/runtime/tests/agents/fork-context.test.ts
+++ b/runtime/tests/agents/fork-context.test.ts
@@ -165,6 +165,53 @@ describe("forkSubagent", () => {
     expect(res.messages.length).toBe(history.length + 1);
   });
 
+  it("a fork taken mid-batch stops before the parent's unanswered tool calls", async () => {
+    // The memory-extraction subagent forked a parent with four running tools
+    // and the provider refused its first request (tool_result_missing).
+    const midBatch: ReadonlyArray<LLMMessage> = [
+      ...history,
+      { role: "user", content: "turn 4 user" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "c1", name: "FileRead", arguments: "{}" },
+          { id: "c2", name: "FileRead", arguments: "{}" },
+        ],
+      },
+      { role: "tool", toolCallId: "c1", toolName: "FileRead", content: "one" },
+    ];
+    const res = await forkSubagent({
+      parent: stubSession(),
+      parentMessages: midBatch,
+      mode: { kind: "full_history" },
+      taskPrompt: "t",
+    });
+    // history + the turn 4 user message + directive; the half-answered batch is left to the parent.
+    expect(res.messages.length).toBe(history.length + 1 + 1);
+    expect(res.messages.some((message) => message.role === "tool")).toBe(false);
+    expect(res.messages.at(-2)).toMatchObject({ role: "user", content: "turn 4 user" });
+  });
+
+  it("a fully answered batch is kept in the fork", async () => {
+    const answered: ReadonlyArray<LLMMessage> = [
+      ...history,
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "c1", name: "FileRead", arguments: "{}" }],
+      },
+      { role: "tool", toolCallId: "c1", toolName: "FileRead", content: "one" },
+    ];
+    const res = await forkSubagent({
+      parent: stubSession(),
+      parentMessages: answered,
+      mode: { kind: "full_history" },
+      taskPrompt: "t",
+    });
+    expect(res.messages.length).toBe(answered.length + 1);
+  });
+
   it("mode=last_n_turns slices from the Nth user turn", async () => {
     const res = await forkSubagent({
       parent: stubSession(),


### PR DESCRIPTION
## Why

Desktop soak, 2026-09-06 08:11:56Z, closing chat run. The memory-extraction subagent (`/root/memory_extraction`, session `8cc02d92…`) was spawned with `forkMode: full_history` while the parent turn had four tool calls running. Its copied history ended with the parent's assistant message carrying those calls and no results, so its first sampling request was refused:

```
grok error: Invalid tool-turn sequence (tool_result_missing) at message[10]: missing tool result message(s) for toolCallId(s): call-…-4, call-…-5, call-…-6, call-…-7
```

The extraction run ended `failed` after one request. Nothing told the user; the memories of that turn were not extracted. Any fork taken mid-batch, by the memory extractor or by `spawn_agent` with `fork_turns`, sends the same invalid history.

## What changed

- `runtime/src/agents/fork-context.ts`: `trimUnansweredToolBatch` walks the copied parent history from the end; if the last assistant message with tool calls has any call without a tool result after it, the history is cut before that message, dropping the half-answered batch, which stays with the parent. A fully answered batch, or a history ending in a user or plain assistant message, is unchanged. Applied once, before the invocation-sequence validation and both fork modes.

## Evidence

The subagent's fourteen-record rollout: `turn_started`, the directive, one `execution_admission` dispatch, `held_unknown provider_call_failed_after_dispatch`, `turn_aborted` with the message above, `run_terminal failed`.

## Tests

- `tests/agents/fork-context.test.ts`, two new cases: a parent mid-batch (two calls, one answered) forks to the history plus the last user message plus the directive, with no tool message; a fully answered batch is kept whole. The existing full-history and last-n-turns cases still pass. `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- When memory extraction runs (it may still start mid-turn; it now forks a valid history when it does).
- The invocation-envelope validation and the last-n-turns truncation.

## Counterparts

Desktop soak F59 (`~/claude-agenc/soak/findings.md`).