### PR TITLE
daemon: record how the detached process ends in its own log

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -838,6 +838,79 @@ export function installAgenCDaemonLogSink(options: {
   };
 }
 
+type DaemonExitDiagnosticsProcess = Pick<NodeJS.Process, "on" | "off" | "pid" | "kill">;
+
+const DAEMON_EXIT_SIGNALS = ["SIGTERM", "SIGINT", "SIGHUP"] as const;
+
+/**
+ * Record how the detached daemon's process ends, in its own log, before the
+ * process is gone.
+ *
+ * The soak saw a daemon exit mid-turn with no line in `daemon.log`, no crash
+ * report and nothing in the system log; the app autostarted a replacement in
+ * three seconds and the only trace was a turn that ended with "connection
+ * closed" (#2199). Node prints an uncaught exception to stderr and dies on a
+ * signal without a word; neither reaches the log sink. This writes one line
+ * for each: the exit code on `exit`, the signal on SIGTERM/SIGINT/SIGHUP
+ * (then re-raised so the default termination and its exit code stand), and
+ * the error with its stack on an uncaught exception or unhandled rejection
+ * (then exit 1, as node would). Writes never throw: a sink already closed by
+ * cleanup swallows the line rather than failing the exit.
+ */
+export function installAgenCDaemonExitDiagnostics(options: {
+  readonly sink: Pick<SizeCappedFileLogSink, "write">;
+  readonly proc?: DaemonExitDiagnosticsProcess;
+  readonly now?: () => string;
+  readonly exit?: (code: number) => void;
+}): () => void {
+  const proc = options.proc ?? (process as DaemonExitDiagnosticsProcess);
+  const now = options.now ?? (() => new Date().toISOString());
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const line = (text: string): void => {
+    try {
+      options.sink.write(`agenc: daemon ${text} (pid ${proc.pid}) at ${now()}\n`);
+    } catch {
+      /* the sink may already be closed; the exit must not fail on its own log */
+    }
+  };
+  const describe = (thrown: unknown): string =>
+    thrown instanceof Error ? (thrown.stack ?? thrown.message) : String(thrown);
+  const onExit = (code: number): void => line(`process exit code=${code}`);
+  const onUncaught = (error: unknown): void => {
+    line(`uncaught exception: ${describe(error)}`);
+    exit(1);
+  };
+  const onRejection = (reason: unknown): void => {
+    line(`unhandled rejection: ${describe(reason)}`);
+    exit(1);
+  };
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+  const removeSignalHandlers = (): void => {
+    for (const [signal, handler] of signalHandlers) proc.off(signal, handler);
+    signalHandlers.clear();
+  };
+  for (const signal of DAEMON_EXIT_SIGNALS) {
+    const handler = (): void => {
+      line(`received ${signal}`);
+      // Re-raise with our handlers gone so the default termination, and the
+      // exit code that goes with it, stands.
+      removeSignalHandlers();
+      proc.kill(proc.pid, signal);
+    };
+    signalHandlers.set(signal, handler);
+    proc.on(signal, handler);
+  }
+  proc.on("exit", onExit);
+  proc.on("uncaughtException", onUncaught);
+  proc.on("unhandledRejection", onRejection);
+  return () => {
+    removeSignalHandlers();
+    proc.off("exit", onExit);
+    proc.off("uncaughtException", onUncaught);
+    proc.off("unhandledRejection", onRejection);
+  };
+}
+
 function safeStringifyLogArg(arg: unknown): string {
   if (arg instanceof Error) return arg.stack ?? arg.message;
   try {
@@ -3098,7 +3171,11 @@ async function runAgenCDaemonForegroundLocked(
         path: resolveAgenCDaemonLogPath(host.env, host.userHome),
       });
       if (logSink !== null) {
+        const disposeExitDiagnostics = installAgenCDaemonExitDiagnostics({
+          sink: logSink.sink,
+        });
         cleanup.register("daemon-log-sink", () => {
+          disposeExitDiagnostics();
           logSink.dispose();
         });
       }

--- a/runtime/tests/app-server/daemon-cli.heap-and-log.test.ts
+++ b/runtime/tests/app-server/daemon-cli.heap-and-log.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildAgenCDaemonChildNodeArgs,
+  installAgenCDaemonExitDiagnostics,
   installAgenCDaemonLogSink,
   resolveAgenCDaemonLogPath,
 } from "./daemon-cli.js";
@@ -113,5 +114,80 @@ describe("daemon log sink installation", () => {
   it("resolves the daemon log path under the daemon home", () => {
     const logPath = resolveAgenCDaemonLogPath({ AGENC_HOME: "/tmp/agenc-home" });
     expect(logPath).toBe("/tmp/agenc-home/daemon.log");
+  });
+});
+
+describe("daemon exit diagnostics", () => {
+  function fakeProcess() {
+    const handlers = new Map<string, Set<(...args: unknown[]) => void>>();
+    const proc = {
+      pid: 4242,
+      kill: vi.fn(),
+      on(event: string, handler: (...args: unknown[]) => void) {
+        const set = handlers.get(event) ?? new Set();
+        set.add(handler);
+        handlers.set(event, set);
+        return proc;
+      },
+      off(event: string, handler: (...args: unknown[]) => void) {
+        handlers.get(event)?.delete(handler);
+        return proc;
+      },
+      emit(event: string, ...args: unknown[]) {
+        for (const handler of [...(handlers.get(event) ?? [])]) handler(...args);
+      },
+      listenerCount(event: string) {
+        return handlers.get(event)?.size ?? 0;
+      },
+    };
+    return proc;
+  }
+
+  it("writes the signal, the crash and the exit code into the daemon's log", () => {
+    const writes: string[] = [];
+    const proc = fakeProcess();
+    const exit = vi.fn();
+    const dispose = installAgenCDaemonExitDiagnostics({
+      sink: { write: (chunk) => writes.push(String(chunk)) },
+      proc: proc as never,
+      now: () => "2026-09-06T02:33:20.000Z",
+      exit,
+    });
+
+    proc.emit("SIGTERM", "SIGTERM");
+    expect(writes.at(-1)).toBe(
+      "agenc: daemon received SIGTERM (pid 4242) at 2026-09-06T02:33:20.000Z\n",
+    );
+    // Re-raised with our handler gone, so the default termination stands.
+    expect(proc.kill).toHaveBeenCalledWith(4242, "SIGTERM");
+    expect(proc.listenerCount("SIGTERM")).toBe(0);
+
+    proc.emit("uncaughtException", new Error("boom"));
+    expect(writes.at(-1)).toContain("uncaught exception: Error: boom");
+    expect(exit).toHaveBeenCalledWith(1);
+
+    proc.emit("unhandledRejection", "late promise");
+    expect(writes.at(-1)).toContain("unhandled rejection: late promise");
+
+    proc.emit("exit", 1);
+    expect(writes.at(-1)).toContain("process exit code=1");
+
+    dispose();
+    expect(proc.listenerCount("exit")).toBe(0);
+    expect(proc.listenerCount("uncaughtException")).toBe(0);
+  });
+
+  it("a sink already closed by cleanup does not fail the exit", () => {
+    const proc = fakeProcess();
+    installAgenCDaemonExitDiagnostics({
+      sink: {
+        write: () => {
+          throw new Error("EBADF: bad file descriptor");
+        },
+      },
+      proc: proc as never,
+      exit: vi.fn(),
+    });
+    expect(() => proc.emit("exit", 0)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Why

#2199: on 2026-09-06 at 02:33Z the daemon under the desktop soak exited mid-turn and left nothing behind: no line in `daemon.log`, no macOS crash report, no OOM heap snapshot, nothing in the system log. The app autostarted a replacement in three seconds, whose spawn truncated the only stderr capture (#2188 now keeps the previous one). The detached daemon has no process-level handlers: node prints an uncaught exception to stderr, dies on a signal without a word, and its `exit` event writes nothing, so none of those ever reach the daemon's own log sink.

## What changed

- `runtime/src/app-server/daemon-cli.ts`: `installAgenCDaemonExitDiagnostics({ sink })` writes one line into the daemon's log for each way the process can end: the exit code on `exit`; the signal on `SIGTERM`, `SIGINT` and `SIGHUP`, after which the handlers are removed and the signal re-raised so the default termination and its exit code stand (`daemon stop` works exactly as before); the error with its stack on `uncaughtException` and `unhandledRejection`, followed by `exit(1)` as node would do. Writes never throw, so a sink already closed by cleanup cannot fail the exit. The detached daemon installs it right after its log sink and disposes it in the same cleanup step. The `--foreground` daemon a user runs in a terminal is unchanged (it never installs the sink).

## Evidence

The empty logs of the 02:33Z exit in the soak report (`docs/eval/app-soak-2026-09-05.md`, F46) and #2199.

## Tests

- `tests/app-server/daemon-cli.heap-and-log.test.ts`, two new cases on a fake process: a SIGTERM writes its line and re-raises once with the handler removed; an uncaught exception and an unhandled rejection write their lines and request exit 1; `exit` writes the code; dispose removes every listener. A sink whose write throws does not make the exit throw. The file's one other failure on this Mac, "resolves the daemon log path under the daemon home", fails identically on unmodified main (`/tmp` resolves to `/private/tmp` here). `tsc --noEmit`: clean apart from the worktree's baseline lodash TS2883 lines.

## Not changed

- The graceful shutdown path and the `daemon stop` semantics.
- Why the 02:33Z process exited; this makes the next occurrence leave a reason.

## Counterparts

#2199, #2188.
