### PR TITLE
tools: pre-effect dispositions for the Task and worktree tools

### DIFF
--- a/runtime/src/tools/system/worktree.ts
+++ b/runtime/src/tools/system/worktree.ts
@@ -54,7 +54,10 @@ import {
 import { nonEmptyString as asNonEmptyString } from "../../utils/stringUtils.js";
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
-import { plainTextErrorToolResult as errorResult } from "../results.js";
+import {
+  plainTextErrorToolResult as errorResult,
+  validationErrorToolResult,
+} from "../results.js";
 import { runSandboxedToolCommand } from "./coding-common.js";
 import { verifiedPlanFileContextFromArgs } from "./filesystem.js";
 import {
@@ -336,6 +339,15 @@ export interface WorktreeToolConfig {
   readonly cwd: string;
 }
 
+/**
+ * A refusal made before any git command ran. A bare error from this mutating
+ * tool is filed as an unknown outcome and gates the session behind /resolve
+ * (#2190); failures after `git worktree add` started keep the bare form.
+ */
+function refuse(tool: "EnterWorktree" | "ExitWorktree", message: string): ToolResult {
+  return validationErrorToolResult(`tool:${tool}:validation`, message);
+}
+
 export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
   return {
     name: "EnterWorktree",
@@ -366,7 +378,8 @@ export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
       const args = rawArgs as ToolExecutionInjectedArgs & { name?: unknown };
       const planContext = verifiedPlanFileContextFromArgs(rawArgs);
       if (planContext === null || planContext.sessionId === undefined) {
-        return errorResult(
+        return refuse(
+          "EnterWorktree",
           "EnterWorktree requires signed session and canonical home context from a session-bound dispatcher.",
         );
       }
@@ -375,7 +388,8 @@ export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
       // matches donor `EnterWorktreeTool.call:79-81`.
       const existing = getCurrentWorktreeSession(sessionId);
       if (existing !== undefined) {
-        return errorResult(
+        return refuse(
+          "EnterWorktree",
           `Already in a worktree session at ${existing.worktreePath}. Use ExitWorktree first.`,
         );
       }
@@ -387,7 +401,7 @@ export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
           validateWorktreeSlug(slugRaw);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          return errorResult(message);
+          return refuse("EnterWorktree", message);
         }
         slug = slugRaw;
       } else {
@@ -405,7 +419,8 @@ export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
       const startCwd = resolve(config.cwd);
       const mainRepoRoot = await findGitRoot(startCwd, rawArgs);
       if (mainRepoRoot === null) {
-        return errorResult(
+        return refuse(
+          "EnterWorktree",
           `Not in a git repository (no rev-parse --show-toplevel from ${startCwd}). EnterWorktree requires a git repo or configured WorktreeCreate hooks (the latter aren't yet wired in AgenC).`,
         );
       }
@@ -421,7 +436,8 @@ export function createEnterWorktreeTool(config: WorktreeToolConfig): Tool {
         worktreePath !== worktreesRoot &&
         !worktreePath.startsWith(`${worktreesRoot}/`)
       ) {
-        return errorResult(
+        return refuse(
+          "EnterWorktree",
           `Refusing to create worktree: resolved path ${worktreePath} escapes ${worktreesRoot}.`,
         );
       }
@@ -629,14 +645,15 @@ export function createExitWorktreeTool(_config: WorktreeToolConfig): Tool {
       };
       const planContext = verifiedPlanFileContextFromArgs(rawArgs);
       if (planContext === null || planContext.sessionId === undefined) {
-        return errorResult(
+        return refuse(
+          "ExitWorktree",
           "ExitWorktree requires signed session and canonical home context from a session-bound dispatcher.",
         );
       }
       const sessionId = planContext.sessionId;
       const action = asNonEmptyString(args.action);
       if (action !== "keep" && action !== "remove") {
-        return errorResult('action must be "keep" or "remove"');
+        return refuse("ExitWorktree", 'action must be "keep" or "remove"');
       }
       const discardChanges = args.discard_changes === true;
 

--- a/runtime/src/tools/tasks/background.ts
+++ b/runtime/src/tools/tasks/background.ts
@@ -26,6 +26,7 @@ import {
   stringValue,
   taskStrictArgs,
   taskTextResult,
+  taskValidationResult,
   toolMetadata,
 } from "./helpers.js";
 
@@ -191,11 +192,9 @@ export function createBackgroundTaskTools(
         if (strict) return strict;
         const taskId = stringValue(args.task_id);
         if (!taskId) {
-          return taskTextResult(
-            "Missing required parameter: task_id",
-            { error: "Missing required parameter: task_id" },
-            true,
-          );
+          return taskValidationResult("Missing required parameter: task_id", {
+            error: "Missing required parameter: task_id",
+          });
         }
         try {
           const stopped = await stopTask(taskId, {

--- a/runtime/src/tools/tasks/helpers.ts
+++ b/runtime/src/tools/tasks/helpers.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Tool, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
 import { SESSION_ID_ARG } from "../system/filesystem.js";
 import { sharedServer } from "../concurrency.js";
 
@@ -57,6 +58,21 @@ export function taskTextResult(
   };
 }
 
+/**
+ * A refusal made before the tool touched anything. Without the disposition a
+ * bare error from a mutating Task* tool is filed as an unknown outcome and
+ * gates the whole session behind /resolve (#2190).
+ */
+export function taskValidationResult(
+  content: string,
+  codeModeResult?: unknown,
+): ToolResult {
+  return {
+    ...validationErrorToolResult("tool:tasks:validation", content),
+    ...(codeModeResult !== undefined ? { codeModeResult } : {}),
+  };
+}
+
 export function taskStrictArgs(
   args: Record<string, unknown>,
   opts: {
@@ -71,20 +87,16 @@ export function taskStrictArgs(
   ]);
   for (const key of Object.keys(args)) {
     if (!allowed.has(key)) {
-      return taskTextResult(
-        `unknown field \`${key}\``,
-        { error: `unknown field \`${key}\`` },
-        true,
-      );
+      return taskValidationResult(`unknown field \`${key}\``, {
+        error: `unknown field \`${key}\``,
+      });
     }
   }
   for (const key of opts.required ?? []) {
     if (typeof args[key] !== "string" || args[key].trim().length === 0) {
-      return taskTextResult(
-        `${key} is required`,
-        { error: `${key} is required` },
-        true,
-      );
+      return taskValidationResult(`${key} is required`, {
+        error: `${key} is required`,
+      });
     }
   }
   return null;

--- a/runtime/src/tools/tasks/task-board.ts
+++ b/runtime/src/tools/tasks/task-board.ts
@@ -33,6 +33,7 @@ import {
   stringValue,
   taskStrictArgs,
   taskTextResult,
+  taskValidationResult,
   toolMetadata,
   type TaskToolOptions,
 } from "./helpers.js";
@@ -79,11 +80,9 @@ function parseTaskMetadata(value: unknown): {
     return { metadata: value };
   }
   return {
-    error: taskTextResult(
-      "metadata must be an object",
-      { error: "metadata must be an object" },
-      true,
-    ),
+    error: taskValidationResult("metadata must be an object", {
+      error: "metadata must be an object",
+    }),
   };
 }
 
@@ -93,11 +92,9 @@ function taskStringArray(
 ): ToolResult | readonly string[] | undefined {
   if (value === undefined) return undefined;
   if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
-    return taskTextResult(
-      `${field} must be an array of task id strings`,
-      { error: `${field} must be an array of task id strings` },
-      true,
-    );
+    return taskValidationResult(`${field} must be an array of task id strings`, {
+      error: `${field} must be an array of task id strings`,
+    });
   }
   return value;
 }
@@ -226,7 +223,7 @@ export function createTaskBoardTools(opts: TaskToolOptions): readonly Tool[] {
         if (strict) return strict;
         const subject = stringValue(args.subject);
         if (!subject) {
-          return taskTextResult("subject is required", { error: "subject is required" }, true);
+          return taskValidationResult("subject is required", { error: "subject is required" });
         }
         // Models routinely send only a subject — that is how the tool
         // reads. The description is display copy layered over it.
@@ -273,15 +270,14 @@ export function createTaskBoardTools(opts: TaskToolOptions): readonly Tool[] {
         if (strict) return strict;
         const taskId = stringValue(args.taskId);
         if (!taskId) {
-          return taskTextResult("taskId is required", { error: "taskId is required" }, true);
+          return taskValidationResult("taskId is required", { error: "taskId is required" });
         }
         const task = await taskLoadOne(storeOpts, taskId);
         if (task === null) {
-          return taskTextResult(
-            "Task not found",
-            { error: "Task not found", taskId },
-            true,
-          );
+          return taskValidationResult("Task not found", {
+            error: "Task not found",
+            taskId,
+          });
         }
         return taskTextResult(formatTask(task), { task: publicTask(task) });
       },
@@ -333,15 +329,14 @@ export function createTaskBoardTools(opts: TaskToolOptions): readonly Tool[] {
         if (strict) return strict;
         const taskId = stringValue(args.taskId);
         if (!taskId) {
-          return taskTextResult("taskId is required", { error: "taskId is required" }, true);
+          return taskValidationResult("taskId is required", { error: "taskId is required" });
         }
         const existing = await taskLoadOne(storeOpts, taskId);
         if (existing === null) {
-          return taskTextResult(
-            "Task not found",
-            { error: "Task not found", taskId },
-            true,
-          );
+          return taskValidationResult("Task not found", {
+            error: "Task not found",
+            taskId,
+          });
         }
         const update: UpdateTaskInput = {};
         const subject = stringValue(args.subject);
@@ -356,10 +351,9 @@ export function createTaskBoardTools(opts: TaskToolOptions): readonly Tool[] {
         }
         const status = normalizeTaskUpdateStatus(args.status);
         if (args.status !== undefined && status === undefined) {
-          return taskTextResult(
+          return taskValidationResult(
             "status must be pending, in_progress, completed, or deleted",
             { error: "invalid status" },
-            true,
           );
         }
         if (status !== undefined) {

--- a/runtime/tests/tools/system/worktree.test.ts
+++ b/runtime/tests/tools/system/worktree.test.ts
@@ -274,3 +274,64 @@ describe("EnterWorktree / ExitWorktree (AgenC port)", () => {
     }
   });
 });
+
+// #2190: a bare error from a mutating tool is filed as an unknown outcome and
+// gates the session behind /resolve. Every refusal made before a git command
+// runs must say the boundary was not crossed.
+describe("worktree refusals before any git command", () => {
+  let repo: Awaited<ReturnType<typeof setupRepo>>;
+  const sessionId = "test-session";
+
+  beforeEach(async () => {
+    __resetWorktreeSessionsForTesting();
+    repo = await setupRepo();
+  });
+
+  afterEach(async () => {
+    __resetWorktreeSessionsForTesting();
+    if (repo) await repo.cleanup();
+  });
+
+  function expectNoEffect(result: unknown, contains: RegExp): void {
+    const r = result as { isError?: boolean; content: unknown; effectDisposition?: { disposition?: string } };
+    expect(r.isError).toBe(true);
+    expect(String(r.content)).toMatch(contains);
+    expect(r.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  }
+
+  test("EnterWorktree: a bad slug, a session already in a worktree, a missing session", async () => {
+    const enter = createEnterWorktreeTool({ cwd: repo.root });
+    expectNoEffect(
+      await enter.execute({ name: "has space", __agencSessionId: sessionId }),
+      /letters, digits/,
+    );
+    await enter.execute({ name: "first.tree", __agencSessionId: sessionId });
+    expectNoEffect(
+      await enter.execute({ name: "second.tree", __agencSessionId: sessionId }),
+      /Already in a worktree session/,
+    );
+    expectNoEffect(await enter.execute({ name: "third.tree" }), /requires signed session/);
+  });
+
+  test("EnterWorktree outside a git repository", async () => {
+    const plain = await mkdtemp(join(tmpdir(), "agenc-worktree-nogit-"));
+    try {
+      const enter = createEnterWorktreeTool({ cwd: plain });
+      expectNoEffect(
+        await enter.execute({ name: "nowhere", __agencSessionId: sessionId }),
+        /Not in a git repository/,
+      );
+    } finally {
+      await rm(plain, { recursive: true, force: true });
+    }
+  });
+
+  test("ExitWorktree: a bad action and a missing session", async () => {
+    const exit = createExitWorktreeTool({ cwd: repo.root });
+    expectNoEffect(
+      await exit.execute({ action: "burn", __agencSessionId: sessionId }),
+      /action must be/,
+    );
+    expectNoEffect(await exit.execute({ action: "keep" }), /requires signed session/);
+  });
+});

--- a/runtime/tests/tools/tasks/task-tools.test.ts
+++ b/runtime/tests/tools/tasks/task-tools.test.ts
@@ -223,3 +223,56 @@ describe("createTaskTools", () => {
     expect(again.content).toBe("task bash-1 is not running (status: killed)");
   });
 });
+
+// #2190: a bare error from a mutating Task* tool is filed as an unknown outcome
+// and gates the session behind /resolve. Refusals made before the store is
+// touched must say the boundary was not crossed.
+describe("Task* refusals before the store is touched", () => {
+  function expectNoEffect(result: ToolResult, content: string | RegExp): void {
+    expect(result.isError).toBe(true);
+    if (typeof content === "string") expect(result.content).toBe(content);
+    else expect(String(result.content)).toMatch(content);
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  }
+
+  it("names the boundary on every argument refusal", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agenc-task-tools-"));
+    try {
+      const map = byName(
+        createTaskTools({ workspaceRoot: process.cwd(), agencHome: home, getSession: () => null }),
+      );
+      const create = map.get("TaskCreate")!;
+      const update = map.get("TaskUpdate")!;
+      expectNoEffect(await create.execute({}), "subject is required");
+      expectNoEffect(await create.execute({ subject: "x", bogus: 1 }), /unknown field/);
+      expectNoEffect(await create.execute({ subject: "x", metadata: [] }), "metadata must be an object");
+      expectNoEffect(await update.execute({ taskId: "no-such-task" }), "Task not found");
+      expectNoEffect(await map.get("TaskStop")!.execute({ task_id: "" }), /task_id/);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an unknown status before writing", async () => {
+    const home = await mkdtemp(join(tmpdir(), "agenc-task-tools-"));
+    try {
+      const map = byName(
+        createTaskTools({ workspaceRoot: process.cwd(), agencHome: home, getSession: () => null }),
+      );
+      const created = await map.get("TaskCreate")!.execute({ subject: "Status check" });
+      const id = codeMode<{ task: { id: string } }>(created).task.id;
+      expectNoEffect(
+        await map.get("TaskUpdate")!.execute({ taskId: id, status: "paused" }),
+        /status must be/,
+      );
+      expectNoEffect(
+        await map.get("TaskUpdate")!.execute({ taskId: id, addBlocks: [1] }),
+        /array of task id strings/,
+      );
+      const after = await map.get("TaskGet")!.execute({ taskId: id });
+      expect(codeMode<{ task: { status: string } }>(after).task.status).toBe("pending");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

#2190: when a mutating tool returns a bare error, the executor cannot tell whether the mutation half-happened and files an unknown outcome, which gates the whole session behind `/resolve`. The soak showed that this costs the session every time it fires, and that a user who left the agent working never sees the `/resolve` instruction. The Task* tools and the worktree tools were among the mutating tools still returning bare errors for refusals made before they touched anything: a missing subject, an unknown field, a bad status, a task id that does not exist, a bad worktree name, a session already in a worktree, a cwd outside any git repository.

## What changed

- `src/tools/tasks/helpers.ts`: `taskValidationResult(content, codeModeResult?)` builds the error result with a `confirmed_no_effect` disposition (`boundary_not_crossed`, `tool:tasks:validation`); `taskStrictArgs` uses it for unknown-field and missing-required refusals.
- `src/tools/tasks/task-board.ts`: the pre-store refusals of TaskCreate and TaskUpdate (subject and taskId required, metadata not an object, block lists not string arrays, unknown status, task not found) go through `taskValidationResult`. TaskGet's identical refusals do too, harmlessly. The failures reported by `taskUpdateOne` after the write was attempted keep the bare form.
- `src/tools/tasks/background.ts`: TaskStop's missing `task_id` refusal. The failure after `stopTask` was attempted keeps the bare form.
- `src/tools/system/worktree.ts`: `refuse(tool, message)` wraps `validationErrorToolResult` with `tool:EnterWorktree:validation` or `tool:ExitWorktree:validation`. EnterWorktree uses it for the missing session context, a session already in a worktree, a bad slug, a cwd outside a git repository and the confinement check; ExitWorktree for the missing context and a bad action. `git worktree add` and checkout failures keep the bare form: git ran.
- Tests: `tests/tools/tasks/task-tools.test.ts` walks every argument refusal of TaskCreate, TaskUpdate and TaskStop and asserts the disposition, and checks that an unknown status leaves the task untouched; `tests/tools/system/worktree.test.ts` covers the seven worktree refusals, including one from a directory that is not a repository.

## Evidence

Soak findings F47 and F49 (`docs/eval/app-soak-2026-09-05.md`): the trap fired on `Edit` and twice on `write_stdin`, each time locking the session until a manual `/resolve`. Those tools were fixed in #2189, #2191 and #2193; this PR continues the sweep over the mutating tools a coding session and a swarm reach next.

## Tests

`vitest run tests/tools/tasks/task-tools.test.ts tests/tools/system/worktree.test.ts`: all passing locally, including the eight new cases. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

Post-attempt failures in the same tools, the planning tools (already decorated), BrowserTool, code-mode, notebook-edit, imagine-image and bash (next in the sweep), the executor.

## Counterparts

#2190 (tracking issue), #2189, #2191, #2193, #2195.
