### PR TITLE
tools: pre-effect dispositions for ImagineImage, Browser and exec

### DIFF
--- a/runtime/src/tools/BrowserTool/tool.ts
+++ b/runtime/src/tools/BrowserTool/tool.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
 import type { FunctionCallOutputContentItem } from "../context.js";
 import type { PermissionResult, PermissionUpdate } from "../../permissions/types.js";
 import type { ToolEvaluatorContext } from "../../permissions/evaluator.js";
@@ -84,6 +85,15 @@ function str(value: unknown): string | undefined {
 
 function errorResult(message: string): ToolResult {
   return { content: message, isError: true };
+}
+
+/**
+ * A refusal made before the browser was touched. A bare error from this
+ * mutating tool is filed as an unknown outcome and gates the session behind
+ * /resolve (#2190); a failed browser action keeps the bare form.
+ */
+function refuse(message: string): ToolResult {
+  return validationErrorToolResult("tool:Browser:validation", message);
 }
 
 function safeAgencHome(explicit?: string): string | undefined {
@@ -235,12 +245,10 @@ export function createBrowserTool(
   ): Promise<ToolResult> {
     const action = str(input.action);
     if (action === undefined || !BROWSER_ACTIONS.includes(action as never)) {
-      return errorResult(
-        `action must be one of: ${BROWSER_ACTIONS.join(", ")}`,
-      );
+      return refuse(`action must be one of: ${BROWSER_ACTIONS.join(", ")}`);
     }
     const requiredError = validateRequired(action, input);
-    if (requiredError !== undefined) return errorResult(requiredError);
+    if (requiredError !== undefined) return refuse(requiredError);
     if (sandboxExecutionBroker === undefined) {
       throw missingSandboxExecutionBoundary("browser");
     }
@@ -358,7 +366,7 @@ export function createBrowserTool(
         return { content: `Closed tab ${tabId}.`, metadata: { action, tabId } };
       }
       default:
-        return errorResult(`unsupported action: ${action}`);
+        return refuse(`unsupported action: ${action}`);
     }
   }
 

--- a/runtime/src/tools/code-mode/tools.ts
+++ b/runtime/src/tools/code-mode/tools.ts
@@ -1,5 +1,6 @@
 import type { FunctionCallOutputContentItem } from "../context.js";
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
 import {
   buildExecToolDescription,
   buildWaitToolDescription,
@@ -166,8 +167,17 @@ async function executeCodeMode(
   stringArgumentFields: Readonly<Record<string, string>> | undefined,
   args: Record<string, unknown>,
 ): Promise<ToolResult> {
-  const source = readStringArg(args, ["code", "source", "input"]);
-  const parsed = parseExecSource(source);
+  // Argument and pragma errors happen before any cell runs; say so, or the
+  // bare error is filed as an unknown outcome and gates the session (#2190).
+  let parsed: ReturnType<typeof parseExecSource>;
+  try {
+    parsed = parseExecSource(readStringArg(args, ["code", "source", "input"]));
+  } catch (error) {
+    return validationErrorToolResult(
+      "tool:exec:validation",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
   const response = await service.execute({
     cellId: service.allocateCellId(),
     toolCallId: callId(args),

--- a/runtime/src/tools/system/imagine-image.ts
+++ b/runtime/src/tools/system/imagine-image.ts
@@ -28,6 +28,7 @@ import {
   resolveProviderBaseURLEnvironment,
 } from "../../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../types.js";
+import { validationErrorToolResult } from "../results.js";
 import { safeStringify } from "../types.js";
 import type { HomeContext } from "../../config/home.js";
 
@@ -39,6 +40,18 @@ export interface ImagineImageToolOptions {
   } | null;
   readonly env?: NodeJS.ProcessEnv;
   readonly fetchImpl?: typeof fetch;
+}
+
+/**
+ * A refusal made before any provider request. A bare error from this
+ * mutating tool is filed as an unknown outcome and gates the session behind
+ * /resolve (#2190); failures after the request keep the bare form.
+ */
+function refusal(payload: unknown): ToolResult {
+  return validationErrorToolResult(
+    "tool:ImagineImage:validation",
+    safeStringify(payload),
+  );
 }
 
 function json(payload: unknown, isError?: boolean): ToolResult {
@@ -768,12 +781,12 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
       admittedSignal?.throwIfAborted();
       const backendResolution = resolveImageBackend(opts);
       if ("error" in backendResolution) {
-        return json({ error: backendResolution.error }, true);
+        return refusal({ error: backendResolution.error });
       }
       const { backend } = backendResolution;
 
       const prompt = stringValue(args.prompt);
-      if (!prompt) return json({ error: "prompt is required" }, true);
+      if (!prompt) return refusal({ error: "prompt is required" });
 
       const model =
         stringValue(args.model) ??
@@ -788,7 +801,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
               : "grok-imagine-image");
       if (backend.kind === "meta") {
         if (model !== "muse-image-1.0") {
-          return json({ error: "Meta image model must be muse-image-1.0" }, true);
+          return refusal({ error: "Meta image model must be muse-image-1.0" });
         }
       } else if (backend.kind === "qwen") {
         const isPayGoModel = /^qwen-image-3\.0(?:-pro)?$/i.test(model);
@@ -860,7 +873,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         resolution !== "1k" &&
         resolution !== "2k"
       ) {
-        return json({ error: "resolution must be 1k or 2k" }, true);
+        return refusal({ error: "resolution must be 1k or 2k" });
       }
       if (backend.kind === "zai" && resolution !== undefined) {
         return json(
@@ -877,10 +890,10 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         quality !== "hd" &&
         quality !== "standard"
       ) {
-        return json({ error: "quality must be hd or standard" }, true);
+        return refusal({ error: "quality must be hd or standard" });
       }
       if (backend.kind !== "zai" && quality !== undefined) {
-        return json({ error: "quality is supported only by Z.AI images" }, true);
+        return refusal({ error: "quality is supported only by Z.AI images" });
       }
 
       const body: Record<string, unknown> =
@@ -916,7 +929,7 @@ export function createImagineImageTool(opts: ImagineImageToolOptions): Tool {
         if (backend.kind === "qwen") {
           const origin = qwenApiOrigin(backend.baseURL);
           if (origin === undefined) {
-            return json({ error: "QwenCloud image endpoint is invalid" }, true);
+            return refusal({ error: "QwenCloud image endpoint is invalid" });
           }
           const size = qwenImageSize(aspect_ratio, resolution);
           if (/^wan2\.7-image(?:-pro)?$/i.test(model)) {

--- a/runtime/tests/tools/BrowserTool/tool.test.ts
+++ b/runtime/tests/tools/BrowserTool/tool.test.ts
@@ -110,19 +110,17 @@ describe("Browser tool permissions", () => {
 });
 
 describe("Browser tool validation (no browser launched)", () => {
-  test("rejects an unknown action", async () => {
-    const result = await createBrowserTool().execute({ action: "fly" });
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("action must be one of");
-    // #2190: refused before the browser was touched, and the result says so.
-    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
-  });
-
-  test("rejects navigate without a url", async () => {
-    const result = await createBrowserTool().execute({ action: "navigate" });
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("requires a url");
-    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+  test("refuses an unknown action and a navigate without a url before touching the browser", async () => {
+    // #2190: each refusal happens before the browser was touched, and says so.
+    for (const [input, message] of [
+      [{ action: "fly" }, "action must be one of"],
+      [{ action: "navigate" }, "requires a url"],
+    ] as const) {
+      const result = await createBrowserTool().execute({ ...input });
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(message);
+      expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    }
   });
 
   test("rejects click without a ref", async () => {

--- a/runtime/tests/tools/BrowserTool/tool.test.ts
+++ b/runtime/tests/tools/BrowserTool/tool.test.ts
@@ -114,12 +114,15 @@ describe("Browser tool validation (no browser launched)", () => {
     const result = await createBrowserTool().execute({ action: "fly" });
     expect(result.isError).toBe(true);
     expect(result.content).toContain("action must be one of");
+    // #2190: refused before the browser was touched, and the result says so.
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
   });
 
   test("rejects navigate without a url", async () => {
     const result = await createBrowserTool().execute({ action: "navigate" });
     expect(result.isError).toBe(true);
     expect(result.content).toContain("requires a url");
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
   });
 
   test("rejects click without a ref", async () => {

--- a/runtime/tests/tools/code-mode/tools.test.ts
+++ b/runtime/tests/tools/code-mode/tools.test.ts
@@ -66,4 +66,18 @@ describe("code-mode tools", () => {
     expect(result.content).toMatch(/\[code_mode status=completed [^\]]+\]$/);
     expect(exec.description).toContain("system_echo");
   });
+
+  test("exec refuses before a cell runs, and says the boundary was not crossed", async () => {
+    // #2190: a bare error from a mutating tool gates the session behind /resolve.
+    const [exec] = createCodeModeTools({
+      service: new QuickJsCodeModeService({ enabled: true }),
+      getEnabledTools: () => [],
+    });
+    for (const args of [{}, { code: 42 }]) {
+      const result = await exec.execute(args);
+      expect(result.isError).toBe(true);
+      expect(String(result.content)).toContain("code must be a string");
+      expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    }
+  });
 });

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -1116,4 +1116,14 @@ describe("ImagineImage tool", () => {
     await expect(running).rejects.toBe(reason);
     expect(requestSignal?.aborted).toBe(true);
   });
+
+  it("refuses a missing prompt before any request, and says so", async () => {
+    // #2190: a bare error from a mutating tool gates the session behind /resolve.
+    const fetchImpl = vi.fn(async () => new Response("unreachable", { status: 500 }));
+    const result = await createQwenImagineTool("qwen", fetchImpl).execute({});
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain("prompt is required");
+    expect(result.effectDisposition?.disposition).toBe("confirmed_no_effect");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Why

#2190, continued: a mutating tool that returns a bare error for a refusal made before it touched anything is filed as an unknown outcome, and the session is gated behind `/resolve` until a human types it. After #2189, #2191, #2193, #2195 and #2206, three mutating tools still did that: ImagineImage (a missing prompt, a bad resolution or quality, an invalid endpoint), the Browser tool (an unknown action, a missing required argument) and code-mode's `exec` (a missing or non-string `code`, a bad pragma), whose argument errors were thrown, so the executor saw them after crossing the boundary.

## What changed

- `src/tools/system/imagine-image.ts`: `refusal(payload)` wraps `validationErrorToolResult` with `tool:ImagineImage:validation`; the seven refusals that precede the provider request use it. Failures after the request, including the download errors, keep the bare form.
- `src/tools/BrowserTool/tool.ts`: `refuse(message)` with `tool:Browser:validation` for the action check, the required-argument check and the unreachable default branch. A failed browser action keeps the bare form.
- `src/tools/code-mode/tools.ts`: `exec` parses its arguments and pragma inside a try; an error there returns `validationErrorToolResult("tool:exec:validation", message)` instead of propagating. The service call is unchanged.
- Tests: the two existing Browser validation cases assert the disposition; `tests/tools/code-mode/tools.test.ts` adds a case for a missing and a non-string `code`; `tests/tools/system/imagine-image.test.ts` adds a case for a missing prompt that also asserts the fetch spy was never called.

## Evidence

Soak findings F47 and F49 (`docs/eval/app-soak-2026-09-05.md`): the trap fired on `Edit` and twice on `write_stdin`, each time locking the session until a manual `/resolve`. With this PR every mutating built-in tool's pre-effect refusals carry a disposition; the remaining bare errors are failures after an attempt, which is what the gate is for.

## Tests

`vitest run tests/tools/BrowserTool/tool.test.ts tests/tools/code-mode/tools.test.ts tests/tools/system/imagine-image.test.ts`: 47 passed. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

Post-attempt failures, the `wait` tool (not mutating), the executor. #2190's proposals 2 (an explicit boundary declaration) and 3 (a sweep test over every mutating tool) stay open.

## Counterparts

#2190 (tracking issue), #2206 (Task and worktree tools), #2189, #2191, #2193, #2195.
