### PR TITLE
tools: a sweep over every mutating tool's refusals, and the eleven it found

### DIFF
--- a/runtime/src/agents/v2/common.ts
+++ b/runtime/src/agents/v2/common.ts
@@ -26,6 +26,7 @@ import type {
 } from "../../tools/types.js";
 import { safeStringify } from "../../tools/types.js";
 import { validationErrorToolResult } from "../../tools/results.js";
+import { strictArgsRefusal } from "../../tools/strict-args.js";
 
 export const MIN_WAIT_TIMEOUT_MS = 10_000;
 export const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
@@ -145,24 +146,15 @@ export function strictArgs(
     readonly required?: ReadonlyArray<string>;
   },
 ): ToolResult | null {
-  const allowed = new Set<string>([
-    ...opts.allowed,
-    "__callId",
-    SESSION_ID_ARG,
-    SESSION_ID_SIG_ARG,
-  ]);
-  for (const key of Object.keys(args)) {
-    if (!allowed.has(key)) {
-      return refusal({ error: `unknown field \`${key}\`` });
-    }
-  }
-  for (const key of opts.required ?? []) {
-    const value = args[key];
-    if (typeof value !== "string") {
-      return refusal({ error: `${key} is required` });
-    }
-  }
-  return null;
+  return strictArgsRefusal(
+    args,
+    {
+      ...opts,
+      injected: ["__callId", SESSION_ID_ARG, SESSION_ID_SIG_ARG],
+      allowBlank: true,
+    },
+    (message) => refusal({ error: message }),
+  );
 }
 
 /**

--- a/runtime/src/agents/v2/common.ts
+++ b/runtime/src/agents/v2/common.ts
@@ -153,16 +153,28 @@ export function strictArgs(
   ]);
   for (const key of Object.keys(args)) {
     if (!allowed.has(key)) {
-      return json({ error: `unknown field \`${key}\`` }, true);
+      return refusal({ error: `unknown field \`${key}\`` });
     }
   }
   for (const key of opts.required ?? []) {
     const value = args[key];
     if (typeof value !== "string") {
-      return json({ error: `${key} is required` }, true);
+      return refusal({ error: `${key} is required` });
     }
   }
   return null;
+}
+
+/**
+ * A refusal made before the tool touched anything. A bare error from a
+ * mutating agent tool is filed as an unknown outcome and gates the whole
+ * session behind /resolve (#2190).
+ */
+function refusal(content: Record<string, unknown>): ToolResult {
+  return validationErrorToolResult(
+    "tool:agents:validation",
+    JSON.stringify(content),
+  );
 }
 
 export function getSessionOrError(
@@ -170,7 +182,7 @@ export function getSessionOrError(
 ): Session | ToolResult {
   const session = opts.getSession();
   if (session === null) {
-    return json({ error: "tool invoked before session was initialized" }, true);
+    return refusal({ error: "tool invoked before session was initialized" });
   }
   return session;
 }

--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -61,6 +61,7 @@ import {
   resolveProviderBaseURLEnvironment,
 } from "../llm/registry/provider-ingress.js";
 import type { Tool, ToolResult } from "../tools/types.js";
+import { validationErrorToolResult } from "../tools/results.js";
 import { safeStringify } from "../tools/types.js";
 import { createFileReadTool } from "../tools/system/file-read.js";
 import { createNotebookEditTool as createSystemNotebookEditTool } from "../tools/system/notebook-edit.js";
@@ -238,6 +239,14 @@ function json(content: unknown, isError?: boolean): ToolResult {
     content: safeStringify(content),
     ...(isError ? { isError: true } : {}),
   };
+}
+
+/** A refusal made before the tool touched anything; see preEffectRefusal. */
+function refusal(content: unknown): ToolResult {
+  return validationErrorToolResult(
+    "tool:model-facing:validation",
+    safeStringify(content),
+  );
 }
 
 function errorMessage(error: unknown): string {
@@ -1585,13 +1594,13 @@ function strictArgs(
   ]);
   for (const key of Object.keys(args)) {
     if (!allowed.has(key)) {
-      return json({ error: `unknown field \`${key}\`` }, true);
+      return refusal({ error: `unknown field \`${key}\`` });
     }
   }
   for (const key of opts.required ?? []) {
     const value = args[key];
     if (typeof value !== "string") {
-      return json({ error: `${key} is required` }, true);
+      return refusal({ error: `${key} is required` });
     }
   }
   return null;
@@ -1652,7 +1661,7 @@ function currentAgentContext(
 function getSessionOrError(opts: ModelFacingToolOptions): Session | ToolResult {
   const session = opts.getSession();
   if (session === null) {
-    return json({ error: "tool invoked before session was initialized" }, true);
+    return refusal({ error: "tool invoked before session was initialized" });
   }
   return session;
 }
@@ -4667,10 +4676,7 @@ function createCronAndWorkflowTools(
       execute: async (args) => {
         const conversationId = opts.getSession()?.conversationId;
         if (typeof conversationId !== "string" || conversationId.length === 0) {
-          return json(
-            { error: "CronCreate requires an active owning conversation" },
-            true,
-          );
+          return refusal({ error: "CronCreate requires an active owning conversation" });
         }
         const schedule = stringValue(args.cron) ?? stringValue(args.schedule);
         const prompt = stringValue(args.prompt);
@@ -4751,10 +4757,7 @@ function createCronAndWorkflowTools(
       execute: async (args) => {
         const conversationId = opts.getSession()?.conversationId;
         if (typeof conversationId !== "string" || conversationId.length === 0) {
-          return json(
-            { error: "CronDelete requires an active owning conversation" },
-            true,
-          );
+          return refusal({ error: "CronDelete requires an active owning conversation" });
         }
         const id = stringValue(args.id);
         if (!id) return json({ error: "id is required" }, true);
@@ -4789,10 +4792,7 @@ function createCronAndWorkflowTools(
       execute: async () => {
         const conversationId = opts.getSession()?.conversationId;
         if (typeof conversationId !== "string" || conversationId.length === 0) {
-          return json(
-            { error: "CronList requires an active owning conversation" },
-            true,
-          );
+          return refusal({ error: "CronList requires an active owning conversation" });
         }
         const { listAllCronTasks } = await import("../utils/cronTasks.js");
         const tasks = await listAllCronTasks(
@@ -4838,18 +4838,16 @@ function createCronAndWorkflowTools(
             ],
           });
         } catch (error) {
-          return json(
-            {
-              error: error instanceof Error ? error.message : String(error),
-              ...(typeof error === "object" &&
-              error !== null &&
-              "code" in error &&
-              typeof error.code === "string"
-                ? { code: error.code }
-                : {}),
-            },
-            true,
-          );
+          // Validation and manifest loading precede the workflow itself.
+          return refusal({
+            error: error instanceof Error ? error.message : String(error),
+            ...(typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            typeof error.code === "string"
+              ? { code: error.code }
+              : {}),
+          });
         }
         const { document } = loaded;
         const name = invocation.name;

--- a/runtime/src/elicitation/request-ledger-transfer.ts
+++ b/runtime/src/elicitation/request-ledger-transfer.ts
@@ -10,6 +10,7 @@
 
 import { randomBytes, randomUUID } from "node:crypto";
 import type { Tool, ToolExecutionInjectedArgs, ToolResult } from "../tools/types.js";
+import { preEffectRefusal } from "../tools/results.js";
 import { safeStringify } from "../tools/types.js";
 import type { SessionConfiguration } from "../session/turn-context.js";
 import {
@@ -70,6 +71,9 @@ export interface CreateRequestLedgerTransferToolOptions {
   readonly now?: () => number;
   readonly actionTtlMs?: number;
 }
+
+const refuse = (message: string): ToolResult =>
+  preEffectRefusal("request_ledger_transfer", message);
 
 function errorResult(message: string): ToolResult {
   return { content: safeStringify({ error: message }), isError: true };
@@ -312,16 +316,16 @@ export function createRequestLedgerTransferTool(
     timeoutBehavior: "tool",
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
       const session = opts.getSession();
-      if (session === null) return errorResult("request_ledger_transfer requires an active session");
+      if (session === null) return refuse("request_ledger_transfer requires an active session");
       if (isSubagentSource(session.sessionConfiguration.sessionSource)) {
-        return errorResult("request_ledger_transfer can only be used by the root agent");
+        return refuse("request_ledger_transfer can only be used by the root agent");
       }
       const rootHumanTurn = session.currentRootHumanTurn();
       if (
         rootHumanTurn === null ||
         !hasExactLedgerMention(rootHumanTurn.text)
       ) {
-        return errorResult(
+        return refuse(
           "request_ledger_transfer requires an exact @ledger token in the active root human turn",
         );
       }
@@ -330,10 +334,10 @@ export function createRequestLedgerTransferTool(
       try {
         input = parseInput(args);
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error));
+        return refuse(error instanceof Error ? error.message : String(error));
       }
       if (!(await session.claimLedgerTransferAuthorization(rootHumanTurn.turnId))) {
-        return errorResult(
+        return refuse(
           "request_ledger_transfer authorization was already consumed for this human turn",
         );
       }
@@ -344,7 +348,7 @@ export function createRequestLedgerTransferTool(
       const responseNonce = opts.createResponseNonce?.() ??
         randomBytes(32).toString("base64url");
       if (!RESPONSE_NONCE.test(responseNonce)) {
-        return errorResult("failed to generate a valid mobile Ledger response challenge");
+        return refuse("failed to generate a valid mobile Ledger response challenge");
       }
       const clientAction: LedgerSolanaTransferClientAction = {
         type: "ledger_solana_transfer_v1",

--- a/runtime/src/elicitation/request-user-input.ts
+++ b/runtime/src/elicitation/request-user-input.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Tool, ToolResult } from "../tools/types.js";
+import { preEffectRefusal } from "../tools/results.js";
 import { safeStringify, type ToolExecutionInjectedArgs } from "../tools/types.js";
 import type {
   ManagedFeatures,
@@ -66,6 +67,9 @@ function json(content: unknown, isError?: boolean): ToolResult {
     ...(isError ? { isError: true } : {}),
   };
 }
+
+const refuse = (message: string): ToolResult =>
+  preEffectRefusal("request_user_input", message);
 
 function err(message: string): ToolResult {
   return json({ error: message }, true);
@@ -300,16 +304,16 @@ export function createRequestUserInputTool(
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
       const liveSession = opts.getSession();
       if (liveSession === null) {
-        return err("request_user_input requires an active session");
+        return refuse("request_user_input requires an active session");
       }
       if (isSubagentSession(liveSession.sessionConfiguration.sessionSource)) {
-        return err("request_user_input can only be used by the root thread");
+        return refuse("request_user_input can only be used by the root thread");
       }
       const modes = requestUserInputAvailableModes(liveSession.features);
       const mode = liveSession.permissionModeRegistry.current().mode;
       const unavailable = requestUserInputUnavailableMessage(mode, modes);
       if (unavailable !== null) {
-        return err(unavailable);
+        return refuse(unavailable);
       }
 
       let normalized: RequestUserInputArgs;

--- a/runtime/src/tools/results.ts
+++ b/runtime/src/tools/results.ts
@@ -14,6 +14,15 @@ export function plainTextErrorToolResult(message: string): ToolResult {
  * (#1751 — a misfired ExitPlanMode blocked every later side-effecting call).
  * Only use this for paths that provably touched nothing.
  */
+/**
+ * A refusal a mutating tool makes before it touches anything, named after the
+ * tool. Without the disposition the executor files the error as an unknown
+ * outcome and gates the whole session behind /resolve (#2190).
+ */
+export function preEffectRefusal(toolName: string, message: string): ToolResult {
+  return validationErrorToolResult(`tool:${toolName}:validation`, message);
+}
+
 export function validationErrorToolResult(
   evidenceRef: string,
   message: string,

--- a/runtime/src/tools/strict-args.ts
+++ b/runtime/src/tools/strict-args.ts
@@ -1,0 +1,34 @@
+import type { ToolResult } from "./types.js";
+
+export interface StrictArgsOptions {
+  readonly allowed: ReadonlySet<string>;
+  readonly required?: ReadonlyArray<string>;
+  /** Runtime-injected keys tolerated beside the schema's own. */
+  readonly injected: ReadonlyArray<string>;
+  /** Whether a required string may be blank; the Task tools say no. */
+  readonly allowBlank?: boolean;
+}
+
+/**
+ * The shared body of the strict argument checks the Task and multi-agent
+ * tools run before touching anything. Each caller supplies its own refusal
+ * shape; the refusal must carry a no-effect disposition (#2190).
+ */
+export function strictArgsRefusal(
+  args: Record<string, unknown>,
+  opts: StrictArgsOptions,
+  refuse: (message: string) => ToolResult,
+): ToolResult | null {
+  const allowed = new Set<string>([...opts.allowed, ...opts.injected]);
+  for (const key of Object.keys(args)) {
+    if (!allowed.has(key)) return refuse(`unknown field \`${key}\``);
+  }
+  for (const key of opts.required ?? []) {
+    const value = args[key];
+    const blank = typeof value === "string" && value.trim().length === 0;
+    if (typeof value !== "string" || (blank && opts.allowBlank !== true)) {
+      return refuse(`${key} is required`);
+    }
+  }
+  return null;
+}

--- a/runtime/src/tools/system/git-tools.ts
+++ b/runtime/src/tools/system/git-tools.ts
@@ -1,7 +1,7 @@
 import { stat } from "node:fs/promises";
 import { dirname, relative, resolve as resolvePath } from "node:path";
 
-import type { Tool } from "../types.js";
+import type { Tool, ToolResult } from "../types.js";
 import { preEffectRefusal } from "../results.js";
 import { collectWorkspaceLanguages } from "./code-intel.js";
 import {
@@ -49,6 +49,33 @@ function runGitToolCommand(
     ...(additionalPermissions !== undefined ? { additionalPermissions } : {}),
     trustedExecutable: true,
   });
+}
+
+/**
+ * The shared start of the worktree create and remove tools. Every refusal
+ * here precedes any git command, so each carries a no-effect verdict (#2190).
+ */
+async function worktreeTarget(
+  config: CodingToolConfig,
+  args: Record<string, unknown>,
+): Promise<{ readonly repoRoot: string; readonly resolved: string } | ToolResult> {
+  const worktreePath = toOptionalString(args.worktreePath);
+  if (!worktreePath) {
+    return preEffectRefusal("system.gitWorktree", "worktreePath must be a non-empty string");
+  }
+  const repoRoot = await resolveRepoRoot({ config, args, pathArgKeys: ["path"] });
+  if (typeof repoRoot !== "string") return preEffectRefusal("system.gitWorktree", repoRoot.error);
+  const safeWorktreePath = await safePath(
+    worktreePath,
+    resolveToolAllowedPaths(config.allowedPaths, args),
+  );
+  if (!safeWorktreePath.safe) {
+    return preEffectRefusal(
+      "system.gitWorktree",
+      safeWorktreePath.reason ?? "worktreePath is outside allowed directories",
+    );
+  }
+  return { repoRoot, resolved: safeWorktreePath.resolved };
 }
 
 export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[] {
@@ -408,18 +435,9 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
       additionalProperties: false,
     },
     async execute(args) {
-      const worktreePath = toOptionalString(args.worktreePath);
-      // Refusals before git runs carry a no-effect verdict (#2190).
-      if (!worktreePath) {
-        return preEffectRefusal("system.gitWorktree", "worktreePath must be a non-empty string");
-      }
-      const repoRoot = await resolveRepoRoot({ config, args, pathArgKeys: ["path"] });
-      if (typeof repoRoot !== "string") return preEffectRefusal("system.gitWorktree", repoRoot.error);
-      const allowedPaths = resolveToolAllowedPaths(config.allowedPaths, args);
-      const safeWorktreePath = await safePath(worktreePath, allowedPaths);
-      if (!safeWorktreePath.safe) {
-        return errorResult(safeWorktreePath.reason ?? "worktreePath is outside allowed directories");
-      }
+      const target = await worktreeTarget(config, args);
+      if (!("repoRoot" in target)) return target;
+      const { repoRoot, resolved } = target;
       const command = ["-C", repoRoot, "worktree", "add", "--no-checkout"];
       if (args.detached === true) command.push("--detach");
       const branch = toOptionalString(args.branch);
@@ -437,7 +455,7 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
       if (branch) {
         command.push("-b", branch);
       }
-      command.push(safeWorktreePath.resolved);
+      command.push(resolved);
       if (ref) {
         command.push(ref);
       }
@@ -447,7 +465,7 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
         repoRoot,
         undefined,
         worktreeMutationPermissions(repoRoot, [
-          dirname(safeWorktreePath.resolved),
+          dirname(resolved),
         ]),
       );
       if (result.exitCode !== 0) {
@@ -457,19 +475,19 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
       }
       const checkout = await runGitToolCommand(
         args,
-        ["-C", safeWorktreePath.resolved, "checkout", "HEAD"],
+        ["-C", resolved, "checkout", "HEAD"],
         repoRoot,
         undefined,
-        worktreeCheckoutPermissions(repoRoot, safeWorktreePath.resolved),
+        worktreeCheckoutPermissions(repoRoot, resolved),
       );
       if (checkout.exitCode !== 0) {
         await runGitToolCommand(
           args,
-          ["-C", repoRoot, "worktree", "remove", "--force", safeWorktreePath.resolved],
+          ["-C", repoRoot, "worktree", "remove", "--force", resolved],
           repoRoot,
           undefined,
           worktreeMutationPermissions(repoRoot, [
-            dirname(safeWorktreePath.resolved),
+            dirname(resolved),
           ]),
         );
         return errorResult(
@@ -478,7 +496,7 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
       }
       return okResult({
         repoRoot,
-        worktreePath: safeWorktreePath.resolved,
+        worktreePath: resolved,
         branch: branch ?? null,
         ref: ref ?? null,
         detached: args.detached === true,
@@ -508,27 +526,18 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
       additionalProperties: false,
     },
     async execute(args) {
-      const worktreePath = toOptionalString(args.worktreePath);
-      // Refusals before git runs carry a no-effect verdict (#2190).
-      if (!worktreePath) {
-        return preEffectRefusal("system.gitWorktree", "worktreePath must be a non-empty string");
-      }
-      const repoRoot = await resolveRepoRoot({ config, args, pathArgKeys: ["path"] });
-      if (typeof repoRoot !== "string") return preEffectRefusal("system.gitWorktree", repoRoot.error);
-      const allowedPaths = resolveToolAllowedPaths(config.allowedPaths, args);
-      const safeWorktreePath = await safePath(worktreePath, allowedPaths);
-      if (!safeWorktreePath.safe) {
-        return errorResult(safeWorktreePath.reason ?? "worktreePath is outside allowed directories");
-      }
+      const target = await worktreeTarget(config, args);
+      if (!("repoRoot" in target)) return target;
+      const { repoRoot, resolved } = target;
       const status = await runGitToolCommand(
         args,
-        ["-C", safeWorktreePath.resolved, "status", "--porcelain", "--untracked-files=normal"],
-        safeWorktreePath.resolved,
+        ["-C", resolved, "status", "--porcelain", "--untracked-files=normal"],
+        resolved,
       );
       const dirty = status.exitCode === 0 && status.stdout.trim().length > 0;
       if (dirty && args.force !== true) {
         return errorResult(
-          `Worktree ${safeWorktreePath.resolved} has uncommitted changes; re-run with force=true to remove it.`,
+          `Worktree ${resolved} has uncommitted changes; re-run with force=true to remove it.`,
         );
       }
       const result = await runGitToolCommand(
@@ -539,11 +548,11 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
           "worktree",
           "remove",
           ...(args.force === true ? ["--force"] : []),
-          safeWorktreePath.resolved,
+          resolved,
         ],
         repoRoot,
         undefined,
-        worktreeMutationPermissions(repoRoot, [safeWorktreePath.resolved]),
+        worktreeMutationPermissions(repoRoot, [resolved]),
       );
       if (result.exitCode !== 0) {
         return errorResult(
@@ -552,7 +561,7 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
       }
       return okResult({
         repoRoot,
-        worktreePath: safeWorktreePath.resolved,
+        worktreePath: resolved,
         dirty,
         removed: true,
       });

--- a/runtime/src/tools/system/git-tools.ts
+++ b/runtime/src/tools/system/git-tools.ts
@@ -2,6 +2,7 @@ import { stat } from "node:fs/promises";
 import { dirname, relative, resolve as resolvePath } from "node:path";
 
 import type { Tool } from "../types.js";
+import { preEffectRefusal } from "../results.js";
 import { collectWorkspaceLanguages } from "./code-intel.js";
 import {
   codingToolMetadata,
@@ -408,9 +409,12 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
     },
     async execute(args) {
       const worktreePath = toOptionalString(args.worktreePath);
-      if (!worktreePath) return errorResult("worktreePath must be a non-empty string");
+      // Refusals before git runs carry a no-effect verdict (#2190).
+      if (!worktreePath) {
+        return preEffectRefusal("system.gitWorktree", "worktreePath must be a non-empty string");
+      }
       const repoRoot = await resolveRepoRoot({ config, args, pathArgKeys: ["path"] });
-      if (typeof repoRoot !== "string") return errorResult(repoRoot.error);
+      if (typeof repoRoot !== "string") return preEffectRefusal("system.gitWorktree", repoRoot.error);
       const allowedPaths = resolveToolAllowedPaths(config.allowedPaths, args);
       const safeWorktreePath = await safePath(worktreePath, allowedPaths);
       if (!safeWorktreePath.safe) {
@@ -505,9 +509,12 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
     },
     async execute(args) {
       const worktreePath = toOptionalString(args.worktreePath);
-      if (!worktreePath) return errorResult("worktreePath must be a non-empty string");
+      // Refusals before git runs carry a no-effect verdict (#2190).
+      if (!worktreePath) {
+        return preEffectRefusal("system.gitWorktree", "worktreePath must be a non-empty string");
+      }
       const repoRoot = await resolveRepoRoot({ config, args, pathArgKeys: ["path"] });
-      if (typeof repoRoot !== "string") return errorResult(repoRoot.error);
+      if (typeof repoRoot !== "string") return preEffectRefusal("system.gitWorktree", repoRoot.error);
       const allowedPaths = resolveToolAllowedPaths(config.allowedPaths, args);
       const safeWorktreePath = await safePath(worktreePath, allowedPaths);
       if (!safeWorktreePath.safe) {
@@ -571,7 +578,9 @@ export function createGitAndRepoTools(config: CodingToolConfig): readonly Tool[]
     },
     async execute(args) {
       const worktreePath = toOptionalString(args.worktreePath);
-      if (!worktreePath) return errorResult("worktreePath must be a non-empty string");
+      if (!worktreePath) {
+        return preEffectRefusal("system.gitWorktree", "worktreePath must be a non-empty string");
+      }
       const allowedPaths = resolveToolAllowedPaths(config.allowedPaths, args);
       const safeWorktreePath = await safePath(worktreePath, allowedPaths);
       if (!safeWorktreePath.safe) {

--- a/runtime/src/tools/tasks/helpers.ts
+++ b/runtime/src/tools/tasks/helpers.ts
@@ -13,6 +13,7 @@
 
 import type { Tool, ToolResult } from "../types.js";
 import { validationErrorToolResult } from "../results.js";
+import { strictArgsRefusal } from "../strict-args.js";
 import { SESSION_ID_ARG } from "../system/filesystem.js";
 import { sharedServer } from "../concurrency.js";
 
@@ -80,26 +81,11 @@ export function taskStrictArgs(
     readonly required?: ReadonlyArray<string>;
   },
 ): ToolResult | null {
-  const allowed = new Set<string>([
-    ...opts.allowed,
-    "__callId",
-    SESSION_ID_ARG,
-  ]);
-  for (const key of Object.keys(args)) {
-    if (!allowed.has(key)) {
-      return taskValidationResult(`unknown field \`${key}\``, {
-        error: `unknown field \`${key}\``,
-      });
-    }
-  }
-  for (const key of opts.required ?? []) {
-    if (typeof args[key] !== "string" || args[key].trim().length === 0) {
-      return taskValidationResult(`${key} is required`, {
-        error: `${key} is required`,
-      });
-    }
-  }
-  return null;
+  return strictArgsRefusal(
+    args,
+    { ...opts, injected: ["__callId", SESSION_ID_ARG] },
+    (message) => taskValidationResult(message, { error: message }),
+  );
 }
 
 export function stringValue(value: unknown): string | undefined {

--- a/runtime/tests/tools/mutating-refusals.sweep.test.ts
+++ b/runtime/tests/tools/mutating-refusals.sweep.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { createModelFacingTools } from "../../src/bin/model-facing-tools.js";
+import { buildToolRegistry } from "../../src/tool-registry.js";
+import type { Tool, ToolResult } from "../../src/tools/types.js";
+
+/**
+ * #2190, proposal 3. A mutating tool that refuses before it touches anything
+ * must say so with a `confirmed_no_effect` disposition; a bare error (or a
+ * thrown one) is filed as an unknown outcome and gates the whole session
+ * behind /resolve. Empty arguments are the refusal every tool has, so this
+ * sweep asserts the contract over every mutating built-in tool at once and a
+ * new tool cannot regress it silently.
+ */
+
+let root = "";
+let home = "";
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "agenc-refusal-sweep-ws-"));
+  home = await mkdtemp(join(tmpdir(), "agenc-refusal-sweep-home-"));
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+  await rm(home, { recursive: true, force: true });
+});
+
+/**
+ * Tools for which `{}` is a complete, valid call: they attempt their work at
+ * once, so a failure is a real post-attempt failure and not this sweep's
+ * subject. Add a tool here only when its schema has no required argument.
+ */
+const EMPTY_CALL_IS_AN_ATTEMPT = new Set(["install_ledger_wallet_cli"]);
+
+function mutatingTools(): readonly Tool[] {
+  const modelFacing = createModelFacingTools({
+    workspaceRoot: root,
+    agencHome: home,
+    getSession: () => null,
+    env: {},
+  });
+  const coding = buildToolRegistry({ workspaceRoot: root }).tools;
+  const seen = new Set<string>();
+  return [...coding, ...modelFacing].filter((tool) => {
+    if (tool.metadata?.mutating !== true || seen.has(tool.name)) return false;
+    seen.add(tool.name);
+    return !EMPTY_CALL_IS_AN_ATTEMPT.has(tool.name);
+  });
+}
+
+async function refusal(tool: Tool): Promise<ToolResult | string> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      tool.execute({}).catch((error: unknown) =>
+        `threw: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+      new Promise<string>((resolve) => {
+        timer = setTimeout(() => resolve("did not settle within 10 s"), 10_000);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+describe("every mutating tool names its boundary when it refuses empty arguments", () => {
+  test("the sweep sees the mutating tool family", () => {
+    const names = mutatingTools().map((tool) => tool.name);
+    expect(names, names.join(", ")).toEqual(
+      expect.arrayContaining(["exec_command", "TaskCreate", "WorkflowTool"]),
+    );
+    expect(names.length).toBeGreaterThan(20);
+  });
+
+  test("no mutating tool refuses empty arguments with a bare or thrown error", async () => {
+    const failures: string[] = [];
+    const accepted: string[] = [];
+    for (const tool of mutatingTools()) {
+      const result = await refusal(tool);
+      if (typeof result === "string") {
+        failures.push(`${tool.name}: ${result}`);
+        continue;
+      }
+      if (result.isError !== true) {
+        accepted.push(tool.name);
+        continue;
+      }
+      if (result.effectDisposition?.disposition !== "confirmed_no_effect") {
+        failures.push(
+          `${tool.name}: bare error "${String(result.content).slice(0, 80)}"`,
+        );
+      }
+    }
+    // A tool that accepts {} refused nothing; it is not this sweep's subject.
+    expect(failures, `accepted {}: ${accepted.join(", ") || "none"}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

#2190, proposal 3. Each PR in the sweep decorated the tools it knew about; nothing proved the list was complete, and a new mutating tool could return a bare refusal without anyone noticing until a session locked behind `/resolve`. A test that walks every mutating built-in tool with empty arguments and asserts a `confirmed_no_effect` disposition on the refusal is that proof. Written against main plus #2206 and #2207 it found eight more tools: `wait_agent`, `spawn_agents_on_csv`, `report_agent_job_result`, `resolve_csv_job_review`, `request_user_input`, `request_ledger_transfer`, `CronCreate`, `CronDelete`, `WorkflowTool`, `system.gitWorktreeCreate` and `system.gitWorktreeRemove`, all refusing a missing argument or a missing session with a bare error.

## What changed

- `src/tools/results.ts`: `preEffectRefusal(toolName, message)`, the shared form of the per-file helpers the earlier PRs grew.
- `src/bin/model-facing-tools.ts`: `refusal(content)` beside `json`; the strict-argument helper, `getSessionOrError`, the three Cron "requires an active owning conversation" refusals and WorkflowTool's validation-and-manifest catch use it. This covers the CSV job tools and the cron tools through the shared helpers.
- `src/tools/strict-args.ts` (new): `strictArgsRefusal(args, options, refuse)`, the one body behind the Task tools' and the multi-agent tools' strict argument checks, which had become token-identical once both returned refusals. `tasks/helpers.ts` keeps its non-blank rule and `agents/v2/common.ts` its injected signature key through the options.
- `src/agents/v2/common.ts`: the strict-argument helper and `getSessionOrError` used by the multi-agent tools return refusals; this is what `wait_agent` reached.
- `src/elicitation/request-user-input.ts`, `src/elicitation/request-ledger-transfer.ts`: refusals made before anything is sent (no session, not the root agent, no `@ledger` token, bad input, authorization already consumed, challenge generation) carry the disposition; failures after the request keep the bare form.
- `src/tools/system/git-tools.ts`: `worktreeTarget(config, args)` is the shared start of the worktree create and remove tools; its refusals (`worktreePath`, repository root, path confinement) all precede any git command and carry the disposition.
- `tests/tools/mutating-refusals.sweep.test.ts` (new): builds both tool families, the coding registry (`buildToolRegistry({ workspaceRoot })`) and the model-facing set, keeps the tools whose metadata says mutating, calls each with `{}` under a 10 s guard and fails on a bare error, a thrown error or a hang, naming the tool. `install_ledger_wallet_cli` is listed as the one tool for which `{}` is a complete call, so its failure is a real attempt and out of scope; the list is the place to declare any future such tool.

## Evidence

Run before the fixes in this PR, the sweep reported the eleven tools above (and, before #2206 and #2207, the Task, worktree and ImagineImage tools too). With the fixes it passes.

## Tests

`vitest run tests/tools/mutating-refusals.sweep.test.ts tests/agents/v2 tests/tools/system/git-tools tests/elicitation tests/tools/tasks tests/tools/system/worktree.test.ts`: 17 files, 160 tests, all passing. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

Post-attempt failures anywhere, the `wait` and `list` tools (not mutating), the executor. Proposal 2 of #2190 (a tool declares that it signals its own boundary) stays open.

## Counterparts

#2190 (tracking issue), #2206, #2207, #2189, #2191, #2193, #2195.
