### PR TITLE
permissions: plan mode lets read-only shell commands through the gate

### DIFF
--- a/runtime/src/permissions/evaluator.ts
+++ b/runtime/src/permissions/evaluator.ts
@@ -48,6 +48,8 @@ import {
   type DenialTrackingState,
 } from "./denial-tracking.js";
 import { SAFE_YOLO_ALLOWLISTED_TOOLS } from "./classifier.js";
+import { commandHasAnyCd } from "../tools/BashTool/bashPermissions.js";
+import { checkReadOnlyConstraints } from "../tools/BashTool/readOnlyValidation.js";
 import {
   getAskRuleForTool,
   getDenyRuleForTool,
@@ -277,7 +279,8 @@ export async function checkRuleBasedPermissions(
 
   // 1a2. Plan mode is read, ask, plan. Any tool that changes something is
   // denied until ExitPlanMode restores the mode the session came from, and
-  // the message says so. Read-only tools and the plan-mode UI tools pass;
+  // the message says so. Read-only tools and the plan-mode UI tools pass, and
+  // so does a shell command the read-only classifier accepts (#2205);
   // plan-with-auto keeps its classifier path below (the explicit exception).
   // Before this the mode gated nothing here, and a session in plan mode ran
   // whatever its underlying policy approved (#2169).
@@ -285,7 +288,8 @@ export async function checkRuleBasedPermissions(
     appState.toolPermissionContext.mode === "plan" &&
     appState.autoModeActive !== true &&
     !toolDoesNotRequireApproval(tool) &&
-    !SAFE_YOLO_ALLOWLISTED_TOOLS.has(tool.name)
+    !SAFE_YOLO_ALLOWLISTED_TOOLS.has(tool.name) &&
+    !planModeReadOnlyShellCommand(tool, input)
   ) {
     const message = planModeDenyMessage(tool.name);
     return Object.freeze({
@@ -427,6 +431,37 @@ function checkModeGate(
   }
 
   return null;
+}
+
+const SHELL_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "exec_command",
+  "system.bash",
+  "Bash",
+]);
+
+/**
+ * Planning is mostly reading, and the shell is how a model reads a
+ * repository's history and layout. A shell command the read-only classifier
+ * accepts (`ls`, `git log`, `grep`, `wc`) passes the plan gate and continues
+ * into the normal checks; anything it cannot parse, cannot classify or that
+ * writes stays denied with the plan-mode message (#2205).
+ */
+function planModeReadOnlyShellCommand(tool: ToolLike, input: unknown): boolean {
+  if (!SHELL_TOOL_NAMES.has(tool.name)) return false;
+  if (typeof input !== "object" || input === null) return false;
+  const fields = input as { readonly cmd?: unknown; readonly command?: unknown };
+  const command =
+    typeof fields.cmd === "string"
+      ? fields.cmd
+      : typeof fields.command === "string"
+        ? fields.command
+        : undefined;
+  if (command === undefined || command.trim().length === 0) return false;
+  const verdict = checkReadOnlyConstraints(
+    { command } as Parameters<typeof checkReadOnlyConstraints>[0],
+    commandHasAnyCd(command),
+  );
+  return verdict.behavior === "allow";
 }
 
 function planModeDenyMessage(toolName: string): string {

--- a/runtime/tests/permissions/evaluator.test.ts
+++ b/runtime/tests/permissions/evaluator.test.ts
@@ -1084,6 +1084,33 @@ describe("hasPermissionsToUseTool — plan mode denies tools that change somethi
     expect(shell.behavior).toBe("deny");
   });
 
+  it("lets a shell command the read-only classifier accepts through the plan gate (#2205)", async () => {
+    const { context } = buildHarness({ mode: "plan" });
+    for (const command of ["ls -la", "git log --oneline -5", "grep -rn TODO src", "wc -l README.md"]) {
+      const result = await hasPermissionsToUseTool(
+        makeTool({ name: "system.bash" }),
+        { command },
+        context,
+      );
+      expect(result.behavior, command).not.toBe("deny");
+    }
+    const exec = await hasPermissionsToUseTool(
+      makeTool({ name: "exec_command" }),
+      { cmd: "git status --short" },
+      context,
+    );
+    expect(exec.behavior).not.toBe("deny");
+    for (const command of ["echo x > notes.txt", "rm -rf build", "ls | tee listing.txt", "npm install"]) {
+      const result = await hasPermissionsToUseTool(
+        makeTool({ name: "system.bash" }),
+        { command },
+        context,
+      );
+      expect(result.behavior, command).toBe("deny");
+      if (result.behavior === "deny") expect(result.message).toContain("Plan mode");
+    }
+  });
+
   it("lets read-only and plan-mode tools through in plan mode", async () => {
     const { context } = buildHarness({ mode: "plan" });
     for (const tool of [


### PR DESCRIPTION
## Why

Fixes #2205. Plan mode denied every `exec_command` and `system.bash` call with "Plan mode: exec_command would change something", including `ls -la`, `git log` and `wc`, because the gate judged the tool, never the command. Planning is mostly reading, and the shell is how a model reads a repository's history and layout; the desktop soak saw the model give up on `ls -la` in plan mode and work around it (finding F51).

## What changed

- `src/permissions/evaluator.ts`: the plan-mode branch of `checkRuleBasedPermissions` gains one more escape, `planModeReadOnlyShellCommand(tool, input)`. For the shell tools (`exec_command`, `system.bash`, `Bash`) it reads the command string (`cmd` or `command`) and asks the existing read-only classifier, `checkReadOnlyConstraints` with `commandHasAnyCd`, the same pair the accept-edits mode validation uses. A command the classifier accepts passes the plan gate and continues into the normal rule and policy checks, so it is not auto-allowed, only no longer refused for being a shell command. Anything the classifier cannot parse or classify, or that writes or redirects, keeps the plan-mode denial and its message.
- `tests/permissions/evaluator.test.ts`: in plan mode, `ls -la`, `git log --oneline -5`, `grep -rn TODO src`, `wc -l README.md` and an `exec_command` `git status --short` are not denied, while `echo x > notes.txt`, `rm -rf build`, `ls | tee listing.txt` and `npm install` stay denied with the plan-mode message.

## Evidence

Desktop soak run `plan-3` (`docs/eval/app-soak-2026-09-05.md`, F51): plan mode was enforced end to end and the only refusal was `ls -la`, which changes nothing.

## Tests

`vitest run tests/permissions/evaluator.test.ts`: 49 passed. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

Which tools are read-only by identity, the plan-with-auto path, the classifier itself, the permission checks a read-only command meets after the gate.

## Counterparts

#2205, #2169 (the gate this refines), #2178, #2181.
