### PR TITLE
fix: preserve approved networking for plugin MCPs

### DIFF
--- a/runtime/src/mcp-client/transports/stdio.ts
+++ b/runtime/src/mcp-client/transports/stdio.ts
@@ -331,9 +331,15 @@ export class AgenCStdioClientTransport implements Transport {
         broker.sessionTempRoot,
       );
       childTempRoot = pluginAuthority.tempRoot;
-      permissionProfileOverride = pluginMcpPermissionProfile({
-        pluginDataDir: pluginAuthority.dataRoot,
-      });
+      // Preserve only the owning session's approved network policy. A plugin
+      // cannot grant itself access, and each restart re-reads current authority.
+      const approvedNetwork = broker.mode === "workspace_write"
+        ? broker.executionAuthority?.().permissionProfile?.network
+        : undefined;
+      permissionProfileOverride = pluginMcpPermissionProfile(
+        { pluginDataDir: pluginAuthority.dataRoot },
+        approvedNetwork,
+      );
     }
     const env = withChildTempAuthority(
       this.server.env ?? {},

--- a/runtime/src/sandbox/execution-broker.ts
+++ b/runtime/src/sandbox/execution-broker.ts
@@ -158,6 +158,8 @@ export interface SandboxExecutionBrokerLike {
   readonly sessionTempRoot: string;
   /** Zero for a root session; increments for each isolated child authority. */
   readonly forkDepth?: number;
+  /** Captured operator-owned policy; reading it grants no spawn admission. */
+  executionAuthority?(): SandboxExecutionBrokerAuthority;
   /** Permanent authority poison set after a lifecycle rollback cannot recover. */
   isClosedAfterLifecycleAuthorityFailure?(): boolean;
   /** Fork an independent boundary for a child session or worktree. */

--- a/runtime/src/tools/runtimes/sandboxing.ts
+++ b/runtime/src/tools/runtimes/sandboxing.ts
@@ -127,11 +127,14 @@ export function permissionProfileForSandboxMode(
  * bubblewrap, and —
  * because the writable roots carry no existing `.git`/`.agenc` carve-outs —
  * fully expressible by the Landlock fallback, so plugin MCP servers keep
- * working on hosts where bubblewrap is unusable.
+ * working on hosts where bubblewrap is unusable. Network authority must come
+ * from the owning broker, never from plugin metadata; absent authority stays
+ * denied. Tightening filesystem access must not discard an operator's grant.
  */
-export function pluginMcpPermissionProfile(metadata: {
-  readonly pluginDataDir: string;
-}): PermissionProfile {
+export function pluginMcpPermissionProfile(
+  metadata: { readonly pluginDataDir: string },
+  approvedNetwork: NetworkSandboxPolicy = "disabled",
+): PermissionProfile {
   return permissionProfileFromRuntimePermissions(
     restrictedFileSystemPolicy(
       [
@@ -140,7 +143,7 @@ export function pluginMcpPermissionProfile(metadata: {
       ],
       { includePlatformDefaults: true },
     ),
-    defaultNetworkForSandboxMode("workspace_write"),
+    approvedNetwork,
   );
 }
 

--- a/runtime/tests/mcp-client/plugin-network-authority.test.ts
+++ b/runtime/tests/mcp-client/plugin-network-authority.test.ts
@@ -1,0 +1,141 @@
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { sourcePath } from "../helpers/source-path.js";
+import { MCPManager } from "../../src/mcp-client/manager.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+import { transitionSandboxExecutionBrokerAuthority } from "../../src/sandbox/execution-lifecycle.js";
+import {
+  canWritePathWithCwd,
+  type NetworkSandboxPolicy,
+  type PermissionProfile,
+} from "../../src/sandbox/engine/index.js";
+import {
+  permissionProfileForSandboxMode,
+  pluginMcpPermissionProfile,
+} from "../../src/tools/runtimes/sandboxing.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("plugin MCP approved network authority", () => {
+  it("denies network without an operator-owned grant", () => {
+    const profile = pluginMcpPermissionProfile({ pluginDataDir: "/plugin-data" });
+    expect(profile.network).toBe("disabled");
+  });
+
+  it.each(["disabled", "enabled", "restricted"] as const)(
+    "preserves %s network without adding filesystem authority",
+    (network) => {
+      const base = pluginMcpPermissionProfile({ pluginDataDir: "/plugin-data" });
+      const profile = pluginMcpPermissionProfile(
+        { pluginDataDir: "/plugin-data" },
+        network,
+      );
+      const canWrite = (path: string) => canWritePathWithCwd(
+        profile.fileSystem, path, "/workspace", "/session-temp",
+      );
+      expect(profile.network).toBe(network);
+      expect(profile.fileSystem).toEqual(base.fileSystem);
+      expect(canWrite("/plugin-data/cache")).toBe(true);
+      expect(canWrite("/workspace/file")).toBe(false);
+      expect(canWrite("/session-temp/file")).toBe(false);
+    },
+  );
+
+  it("restarts a real plugin child with revoked network and no stale grant", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agenc-plugin-net-authority-"));
+    roots.push(root);
+    const data = join(root, "data");
+    const sessionTemp = join(root, "session-temp");
+    const workspace = join(root, "workspace");
+    await Promise.all([data, sessionTemp, workspace].map((path) => mkdir(path)));
+    const observed: PermissionProfile[] = [];
+    const profile = (network: NetworkSandboxPolicy) =>
+      permissionProfileForSandboxMode("workspace_write", { cwd: workspace, network });
+    const broker = new SandboxExecutionBroker({
+      mode: "workspace_write",
+      cwd: workspace,
+      env: {},
+      sessionTempRoot: sessionTemp,
+      // No explicit permissionProfile: a new session must remain denied.
+      probe: () => ({
+        kind: "ready", mode: "workspace_write", platform: process.platform,
+      }),
+      // This test observes the exact platform policy and real child lifecycle;
+      // OS isolation itself is covered by platform sandbox integration tests.
+      sandboxManager: {
+        selectInitial: () => "macos_seatbelt",
+        transform: (params) => {
+          observed.push(params.permissions);
+          return {
+            command: [params.command.program, ...params.command.args],
+            cwd: params.command.cwd,
+            env: params.command.env,
+            sandbox: params.sandbox,
+            windowsSandboxLevel: params.windowsSandboxLevel,
+            windowsSandboxPrivateDesktop: params.windowsSandboxPrivateDesktop,
+            permissionProfile: params.permissions,
+            fileSystemSandboxPolicy: params.permissions.fileSystem,
+            networkSandboxPolicy: params.permissions.network,
+          };
+        },
+      },
+    });
+    const pidPath = join(data, "child.pid");
+    const manager = new MCPManager([{
+      name: "plugin:fixture:stdio",
+      transport: "stdio",
+      command: process.execPath,
+      args: [sourcePath("mcp-client/test-fixtures/stdio-pid-server.cjs"), pidPath],
+      cwd: workspace,
+      pluginSandbox: {
+        mode: "stdio-child-process",
+        pluginName: "fixture",
+        pluginRoot: workspace,
+        pluginDataDir: data,
+        serverName: "stdio",
+        scopedServerName: "plugin:fixture:stdio",
+      },
+    }], undefined, {});
+    manager.setSandboxExecutionBroker(broker);
+    try {
+      await manager.start({ requireOneReady: true, timeoutMs: 10_000 });
+      const initialPid = Number.parseInt(await readFile(pidPath, "utf8"), 10);
+      expect(observed.at(-1)?.network).toBe("disabled");
+      await transitionSandboxExecutionBrokerAuthority(broker, {
+        ...broker.executionAuthority(), permissionProfile: profile("enabled"),
+      });
+      const approvedPid = Number.parseInt(await readFile(pidPath, "utf8"), 10);
+      expect(approvedPid).not.toBe(initialPid);
+      expect(() => process.kill(initialPid, 0)).toThrow();
+      expect(observed.at(-1)?.network).toBe("enabled");
+      await transitionSandboxExecutionBrokerAuthority(broker, {
+        ...broker.executionAuthority(), permissionProfile: profile("disabled"),
+      });
+      const restartedPid = Number.parseInt(await readFile(pidPath, "utf8"), 10);
+      expect(restartedPid).not.toBe(approvedPid);
+      expect(() => process.kill(approvedPid, 0)).toThrow();
+      expect(observed.map((entry) => entry.network)).toEqual([
+        "disabled", "enabled", "disabled",
+      ]);
+      for (const entry of observed) {
+        expect(canWritePathWithCwd(
+          entry.fileSystem, data, workspace, sessionTemp,
+        )).toBe(true);
+        expect(canWritePathWithCwd(
+          entry.fileSystem, workspace, workspace, sessionTemp,
+        )).toBe(false);
+      }
+      expect(manager.getConnectedServers()).toEqual(["plugin:fixture:stdio"]);
+    } finally {
+      await manager.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Preserve the owning session's explicitly approved network policy when plugin MCP applies its tighter filesystem sandbox. This fixes the Stonks public-data prerequisite identified in tetsuo-ai/agenc-plugins#5.

- Default network access stays disabled. Plugins cannot grant themselves networking through metadata.
- Only a workspace-write broker's immutable, operator-owned execution authority supplies the network policy.
- Plugin filesystem restrictions are unchanged; writes remain confined to the plugin data directory.
- Existing spawn-admission and lifecycle fencing still apply. A grant/revocation transition terminates and restarts the child with the current policy.
- No configuration changes, global network enablement, unrestricted duplicate MCP or sandbox bypass.

## Validation

- 36 targeted network/stdio/manager/plugin sandbox tests pass.
- The new test's TypeScript program, standard source and test-support typechecks pass.
- Complete runtime build passes, including declarations, package entrypoints and generated SDK types.
- Independent scoped code review found no actionable issues.
- Actual built Core + original signed Stonks fixture: native workspace-write sandbox, 14 tools and metrics registry work. An explicit task-local network grant permits live AAPL data and a valid SVG chart. A fresh manager without the grant denies uncached MSFT reads again.

The live probe uses the original signed plugin revision, not the new unsigned payload. It does not certify the Stonks release. An additional existing broad lifecycle test uses a nonexistent `/stable-workspace` cwd and fails host `sandbox-exec` startup with ENOENT; this PR does not claim that broader suite passed or modify that test.

No real user configuration, credentials, daemon, app instance or released Core artifacts were modified.
