### PR TITLE
feat: preserve plugin signatures through publisher key rollover

### DIFF
--- a/docs/reference/skills-plugins.md
+++ b/docs/reference/skills-plugins.md
@@ -763,7 +763,7 @@ same-named workspace directory. The shipped CLI cannot opt out.
 Default path: `$AGENC_HOME/plugin-publishers.json`. The resolver accepts an
 in-process `publishersPath` override; there is no operator CLI for it.
 
-AgenC includes the `tetsuo-ai` public key as its official publisher trust root,
+AgenC includes the legacy and approved rollover `tetsuo-ai` public keys,
 so signed plugins from the shipped marketplace work in a clean profile. The
 default keyring can add third-party publishers or explicitly replace that entry.
 An in-process `publishersPath` override is authoritative and does not use the
@@ -780,15 +780,35 @@ other publisher.
 }
 ```
 
-A publisher entry may be that base64 string directly. An explicit entry with
+A publisher entry may be that base64 string directly. Rollover-aware clients
+also accept `{"publicKey":"<legacy key>","publicKeys":["<legacy key>","<new key>"]}`
+or `{"publicKeys":["<legacy key>","<new key>"]}`. The union is deduplicated and
+limited to sixteen distinct keys; a supplied list must contain 1-16 entries.
+Every supplied value must be a canonical base64 DER-SPKI Ed25519 public key.
+All values are checked before verifying a signature: one malformed key rejects
+the entire publisher entry even if another key would verify. The legacy
+`publicKey` field is retained for older clients, which ignore `publicKeys` and
+therefore cannot verify packages signed only by the new key.
+
+An explicit entry with
 an empty or unusable value is authoritative and throws
 `plugin publisher is not trusted: <name>`; it never falls back to the shipped
 root. A missing default keyring uses the built-in root only for `tetsuo-ai`.
 Missing keyrings for other publishers, unreadable files, and malformed JSON
 surface their filesystem or JSON error. A well-formed public key and signature
 that do not verify throw
-`plugin signature verification failed for publisher <name>`; malformed key
-material can surface a crypto parsing error.
+`plugin signature verification failed for publisher <name>`.
+
+The built-in rollover retains historical signatures; it does not override an
+operator's explicit old-only pin. Such users must deliberately verify and add
+the new fingerprint to their keyring. Core never fetches trust keys from the
+catalog, promotes a downloaded key, or rewrites operator trust. Cached plugin
+payloads are reverified against current trust during resolution.
+
+Official decoded DER-SPKI SHA-256 fingerprints:
+
+- Legacy: `8174e96296289bd8eed26b832296309015216afe544a7f15097356b10aa1b932`
+- Rollover: `d3cd019ab546d8512619fabc80cb4b363c66d1a70bfa25a35bbef5aacf3836c3`
 
 #### Signature file
 

--- a/runtime/src/plugins/publisher-trust.ts
+++ b/runtime/src/plugins/publisher-trust.ts
@@ -3,13 +3,24 @@ import { createHash } from "node:crypto";
 /** Publisher identity used by plugins signed and shipped by AgenC. */
 export const OFFICIAL_PLUGIN_PUBLISHER = "tetsuo-ai";
 
-/** Base64 DER-SPKI Ed25519 public key for the official AgenC publisher. */
+/** Legacy official key. Retained for existing API consumers and old releases. */
 export const OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY =
   "MCowBQYDK2VwAyEAj20DQnldg2gADPiX8xb+7Anc7m8FfdhQYmtqqLUW/+E=";
 
 /** Auditable SHA-256 fingerprint of the decoded DER-SPKI key above. */
 export const OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256 =
   "8174e96296289bd8eed26b832296309015216afe544a7f15097356b10aa1b932";
+
+/** Approved rollover key, added without revoking historical signatures. */
+export const OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_PUBLIC_KEY =
+  "MCowBQYDK2VwAyEALKLkrC3bd6y79NUw5HDmnCbs5A4sxqPb5f7TUVLJang=";
+export const OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_KEY_SHA256 =
+  "d3cd019ab546d8512619fabc80cb4b363c66d1a70bfa25a35bbef5aacf3836c3";
+
+const OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEYS: readonly string[] = Object.freeze([
+  OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY,
+  OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_PUBLIC_KEY,
+]);
 
 /**
  * AgenC ships its own publisher root so a clean profile can verify official
@@ -21,6 +32,15 @@ export function builtInPluginPublisherPublicKey(
 ): string | undefined {
   return publisher === OFFICIAL_PLUGIN_PUBLISHER
     ? OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY
+    : undefined;
+}
+
+/** Only a release-reviewed built-in trust set; never populated from a catalog. */
+export function builtInPluginPublisherPublicKeys(
+  publisher: string,
+): readonly string[] | undefined {
+  return publisher === OFFICIAL_PLUGIN_PUBLISHER
+    ? OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEYS
     : undefined;
 }
 

--- a/runtime/src/plugins/resolution.ts
+++ b/runtime/src/plugins/resolution.ts
@@ -18,13 +18,14 @@ import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 
 import {
   createHash,
   createPublicKey,
+  type KeyObject,
   verify as verifySignatureBytes,
 } from "node:crypto";
 import { redactSecrets } from "../secrets/index.js";
 import { isRecord } from "../utils/record.js";
 import { findPluginManifestPath, loadPluginManifest } from "./manifest.js";
 import { pluginCacheDirPath, sanitizePluginId } from "./directories.js";
-import { builtInPluginPublisherPublicKey } from "./publisher-trust.js";
+import { builtInPluginPublisherPublicKeys } from "./publisher-trust.js";
 import {
   buildPluginIdentifier,
   isCanonicalPluginIdentity,
@@ -138,8 +139,10 @@ interface SignatureFile {
 }
 
 interface PublisherKeyring {
-  readonly publishers?: Readonly<Record<string, string | { readonly publicKey?: string }>>;
+  readonly publishers?: Readonly<Record<string, unknown>>;
 }
+
+const MAX_PUBLISHER_PUBLIC_KEYS = 16;
 
 const DEFAULT_PROCESS_TIMEOUT_MS = 120_000;
 const DEFAULT_PROCESS_MAX_OUTPUT_BYTES = 1_048_576;
@@ -761,13 +764,13 @@ export async function verifyResolvedPluginSignature(
   const publishersPath = options.publishersPath ?? defaultPublishersPath(
     options.agencHome,
   );
-  const publicKey = await readPublisherPublicKey(
+  const publicKeys = await readPublisherPublicKeys(
     publishersPath,
     signature.publisher,
     // An explicit path is an authoritative caller-supplied trust store. The
     // built-in AgenC root is only the fallback for the normal profile keyring.
     options.publishersPath === undefined
-      ? builtInPluginPublisherPublicKey(signature.publisher)
+      ? builtInPluginPublisherPublicKeys(signature.publisher)
       : undefined,
   );
   const manifestPath = await findPluginManifestPath(pluginRoot);
@@ -776,11 +779,11 @@ export async function verifyResolvedPluginSignature(
   const actualFiles = await collectPluginPayloadDigests(pluginRoot, manifestPath, signaturePath, options);
   assertSignedPayloadMatches(signature.files, actualFiles);
   const payload = pluginSignaturePayloadBytes(manifestBytes, signature.files);
-  const verified = verifyEd25519Signature({
+  const verified = publicKeys.some((publicKey) => verifyEd25519Signature({
     publicKey,
     payload,
     signature: signature.signature,
-  });
+  }));
   if (!verified) throw new Error(`plugin signature verification failed for publisher ${signature.publisher}`);
   return {
     required: options.requireSignature === true,
@@ -807,19 +810,14 @@ export function pluginSignaturePayloadBytes(
 }
 
 function verifyEd25519Signature(input: {
-  readonly publicKey: string;
+  readonly publicKey: KeyObject;
   readonly payload: Uint8Array;
   readonly signature: string;
 }): boolean {
-  const key = createPublicKey({
-    key: Buffer.from(input.publicKey, "base64"),
-    format: "der",
-    type: "spki",
-  });
   return verifySignatureBytes(
     null,
     Buffer.from(input.payload),
-    key,
+    input.publicKey,
     Buffer.from(input.signature, "base64"),
   );
 }
@@ -1642,36 +1640,81 @@ function redactPluginResolutionError(error: unknown): Error {
   return new Error(redactPluginSource(String(error)));
 }
 
-async function readPublisherPublicKey(
+/** Validate the entire entry before trying any key, including legacy fields. */
+function parsePublisherPublicKeys(entry: unknown, publisher: string): readonly KeyObject[] {
+  const invalid = () => new Error(`plugin publisher is not trusted: ${publisher}`);
+  const candidates: unknown[] = [];
+  if (typeof entry === "string") {
+    candidates.push(entry);
+  } else if (isRecord(entry)) {
+    if (Object.hasOwn(entry, "publicKey")) candidates.push(entry.publicKey);
+    if (Object.hasOwn(entry, "publicKeys")) {
+      if (
+        !Array.isArray(entry.publicKeys) ||
+        entry.publicKeys.length === 0 ||
+        entry.publicKeys.length > MAX_PUBLISHER_PUBLIC_KEYS
+      ) throw invalid();
+      candidates.push(...entry.publicKeys);
+    }
+  } else {
+    throw invalid();
+  }
+  if (candidates.length === 0) throw invalid();
+  const keys = new Map<string, KeyObject>();
+  for (const candidate of candidates) {
+    // Ed25519 DER-SPKI is exactly 44 bytes, encoded as 60 canonical base64
+    // characters. Reject permissive decoder inputs and oversized key material.
+    if (typeof candidate !== "string" || candidate.length !== 60) throw invalid();
+    const der = Buffer.from(candidate, "base64");
+    if (der.toString("base64") !== candidate) throw invalid();
+    let key: KeyObject;
+    try {
+      key = createPublicKey({ key: der, format: "der", type: "spki" });
+      if (
+        key.asymmetricKeyType !== "ed25519" ||
+        !Buffer.from(key.export({ format: "der", type: "spki" })).equals(der)
+      ) throw invalid();
+    } catch {
+      throw invalid();
+    }
+    keys.set(candidate, key);
+  }
+  if (keys.size > MAX_PUBLISHER_PUBLIC_KEYS) throw invalid();
+  return [...keys.values()];
+}
+
+async function readPublisherPublicKeys(
   path: string,
   publisher: string,
-  builtInPublicKey?: string,
-): Promise<string> {
+  builtInPublicKeys?: readonly string[],
+): Promise<readonly KeyObject[]> {
   let parsed: PublisherKeyring;
   try {
     parsed = JSON.parse(await readFile(path, "utf8")) as PublisherKeyring;
   } catch (error) {
     if (
       (error as NodeJS.ErrnoException).code === "ENOENT" &&
-      builtInPublicKey !== undefined
+      builtInPublicKeys !== undefined
     ) {
-      return builtInPublicKey;
+      return parsePublisherPublicKeys({ publicKeys: builtInPublicKeys }, publisher);
     }
     throw error;
+  }
+  if (!isRecord(parsed) || (parsed.publishers !== undefined && !isRecord(parsed.publishers))) {
+    throw new Error("plugin publisher keyring must contain a publishers object");
   }
   const publishers = parsed.publishers;
   const hasExplicitEntry =
     publishers !== undefined &&
     Object.prototype.hasOwnProperty.call(publishers, publisher);
-  const entry = publishers?.[publisher];
-  const publicKey = typeof entry === "string" ? entry : entry?.publicKey;
-  if (publicKey) return publicKey;
   // An entry with an empty or malformed value is still an explicit operator
   // decision. Never mask it with the shipped root.
   if (hasExplicitEntry) {
-    throw new Error(`plugin publisher is not trusted: ${publisher}`);
+    return parsePublisherPublicKeys(publishers![publisher], publisher);
   }
-  if (builtInPublicKey !== undefined) return builtInPublicKey;
+  if (builtInPublicKeys !== undefined) {
+    return parsePublisherPublicKeys({ publicKeys: builtInPublicKeys }, publisher);
+  }
   throw new Error(`plugin publisher is not trusted: ${publisher}`);
 }
 

--- a/runtime/tests/plugins/publisher-rollover.test.ts
+++ b/runtime/tests/plugins/publisher-rollover.test.ts
@@ -1,0 +1,196 @@
+import { createHash, generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  pluginSignaturePayloadBytes,
+  resolvePluginSource,
+  verifyResolvedPluginSignature,
+} from "../../src/plugins/resolution.js";
+import * as publisherTrust from "../../src/plugins/publisher-trust.js";
+
+const publisher = "tetsuo-ai";
+const oldKey = generateKeyPairSync("ed25519");
+const newKey = generateKeyPairSync("ed25519");
+const otherKey = generateKeyPairSync("ed25519");
+const encode = (key: KeyObject) => key.export({ format: "der", type: "spki" }).toString("base64");
+const oldPublic = encode(oldKey.publicKey);
+const newPublic = encode(newKey.publicKey);
+const payload = "# Signed fixture\n";
+let root: string;
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, JSON.stringify(value));
+}
+
+async function writeSignedPlugin(path: string, key: KeyObject, identity = publisher): Promise<void> {
+  await mkdir(join(path, ".agenc-plugin"), { recursive: true });
+  await mkdir(join(path, "commands"), { recursive: true });
+  const manifest = Buffer.from(JSON.stringify({ name: "signed-fixture", version: "1.0.0" }));
+  await writeFile(join(path, ".agenc-plugin", "plugin.json"), manifest);
+  await writeFile(join(path, "commands", "hello.md"), payload);
+  const files = { "commands/hello.md": `sha256:${createHash("sha256").update(payload).digest("hex")}` };
+  await writeJson(join(path, ".agenc-plugin", "signature.json"), {
+    publisher: identity,
+    signature: sign(null, pluginSignaturePayloadBytes(manifest, files), key).toString("base64"),
+    files,
+  });
+}
+
+async function writeEntry(entry: unknown): Promise<void> {
+  await writeJson(join(root, "plugin-publishers.json"), { publishers: { [publisher]: entry } });
+}
+
+function verify(name = "old", publishersPath?: string) {
+  return verifyResolvedPluginSignature(join(root, name), {
+    agencHome: root, requireSignature: true,
+    ...(publishersPath === undefined ? {} : { publishersPath }),
+  });
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "agenc-publisher-rollover-"));
+  await writeSignedPlugin(join(root, "old"), oldKey.privateKey);
+  await writeSignedPlugin(join(root, "new"), newKey.privateKey);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("publisher key rollover", () => {
+  it.each(["string", "object"])("keeps the legacy %s pin old-only", async (shape) => {
+    await writeEntry(shape === "string" ? oldPublic : { publicKey: oldPublic });
+    await expect(verify("old")).resolves.toMatchObject({ verified: true });
+    await expect(verify("new")).rejects.toThrow(/signature verification failed/u);
+  });
+
+  it("accepts real old and new signatures under a deduplicated overlap entry", async () => {
+    await writeEntry({ publicKey: oldPublic, publicKeys: [oldPublic, newPublic, newPublic] });
+    await expect(verify("old")).resolves.toMatchObject({ verified: true });
+    await expect(verify("new")).resolves.toMatchObject({ verified: true });
+    await writeSignedPlugin(join(root, "unknown"), otherKey.privateKey);
+    await expect(verify("unknown")).rejects.toThrow(/signature verification failed/u);
+  });
+
+  it("unions a legacy key with a new-only list and supports list-only entries", async () => {
+    await writeEntry({ publicKey: oldPublic, publicKeys: [newPublic] });
+    await expect(verify("old")).resolves.toMatchObject({ verified: true });
+    await expect(verify("new")).resolves.toMatchObject({ verified: true });
+    await writeEntry({ publicKeys: [oldPublic, newPublic] });
+    await expect(verify("old")).resolves.toMatchObject({ verified: true });
+    await expect(verify("new")).resolves.toMatchObject({ verified: true });
+  });
+
+  it("uses overlapping built-ins only when no explicit operator entry exists", async () => {
+    const builtIns = vi.spyOn(publisherTrust, "builtInPluginPublisherPublicKeys")
+      .mockImplementation((name) => name === publisher ? [oldPublic, newPublic] : undefined);
+    await expect(verify("old")).resolves.toMatchObject({ verified: true });
+    await expect(verify("new")).resolves.toMatchObject({ verified: true });
+    await writeJson(join(root, "plugin-publishers.json"), { publishers: { unrelated: oldPublic } });
+    await expect(verify("new")).resolves.toMatchObject({ verified: true });
+    await writeEntry({ publicKey: oldPublic });
+    await expect(verify("new")).rejects.toThrow(/signature verification failed/u);
+    await expect(verify("old")).resolves.toMatchObject({ verified: true });
+    builtIns.mockClear();
+    await expect(verify("new", join(root, "missing.json"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(builtIns).not.toHaveBeenCalled();
+    await writeJson(join(root, "explicit.json"), { publishers: {} });
+    await expect(verify("new", join(root, "explicit.json"))).rejects.toThrow(/not trusted/u);
+  });
+
+  const malformedEntries: Array<[string, unknown]> = [
+    ["null", null], ["empty string", ""], ["empty object", {}], ["array entry", []],
+    ["empty list", { publicKeys: [] }], ["non-array list", { publicKeys: oldPublic }],
+    ["null list", { publicKey: oldPublic, publicKeys: null }],
+    ["invalid legacy key alongside valid list", { publicKey: "invalid", publicKeys: [oldPublic] }],
+    ["invalid list member after valid key", { publicKeys: [oldPublic, "invalid"] }],
+    ["numeric member", { publicKeys: [oldPublic, 1] }],
+    ["null member", { publicKeys: [oldPublic, null] }],
+    ["oversized list", { publicKeys: Array(17).fill(oldPublic) }],
+    ["noncanonical base64", { publicKey: `${oldPublic.slice(0, -1)} ` }],
+    ["X25519 key", { publicKeys: [oldPublic, encode(generateKeyPairSync("x25519").publicKey)] }],
+  ];
+  it.each(malformedEntries)("rejects %s without falling back or partially trusting", async (_label, entry) => {
+    vi.spyOn(publisherTrust, "builtInPluginPublisherPublicKeys").mockReturnValue([oldPublic, newPublic]);
+    await writeEntry(entry);
+    await expect(verify()).rejects.toThrow(/plugin publisher is not trusted/u);
+  });
+
+  it("limits the union to sixteen distinct keys", async () => {
+    const keys = Array.from({ length: 15 }, () => encode(generateKeyPairSync("ed25519").publicKey));
+    await writeEntry({ publicKey: oldPublic, publicKeys: [oldPublic, ...keys] });
+    await expect(verify()).resolves.toMatchObject({ verified: true });
+    await writeEntry({ publicKey: oldPublic, publicKeys: [newPublic, ...keys] });
+    await expect(verify()).rejects.toThrow(/not trusted/u);
+  });
+
+  it.each([null, [], { publishers: null }, { publishers: [] }])(
+    "rejects malformed keyring structure without built-in fallback: %j",
+    async (keyring) => {
+      vi.spyOn(publisherTrust, "builtInPluginPublisherPublicKeys").mockReturnValue([oldPublic, newPublic]);
+      await writeJson(join(root, "plugin-publishers.json"), keyring);
+      await expect(verify()).rejects.toThrow(/keyring must contain a publishers object/u);
+    },
+  );
+
+  it("does not grant an unrelated publisher the official trust set", async () => {
+    await writeSignedPlugin(join(root, "other-publisher"), oldKey.privateKey, "unrelated");
+    await writeEntry({ publicKeys: [oldPublic, newPublic] });
+    await expect(verify("other-publisher")).rejects.toThrow(/not trusted/u);
+    await writeJson(join(root, "plugin-publishers.json"), {
+      publishers: { unrelated: { publicKeys: [oldPublic] } },
+    });
+    await expect(verify("other-publisher")).resolves.toMatchObject({ verified: true });
+  });
+
+  it("rechecks old cached signatures after rollover and rejects cached payload tampering", async () => {
+    await writeEntry({ publicKey: oldPublic });
+    const runProcess = vi.fn(async (_command: string, args: readonly string[]) => {
+      await writeSignedPlugin(String(args.at(-1)), oldKey.privateKey);
+      return { stdout: "", stderr: "" };
+    });
+    const options = {
+      agencHome: root, workspaceRoot: root,
+      pluginStorageRoot: join(root, "plugins"), sessionTempRoot: join(root, "tmp"),
+      runProcess,
+    };
+    const source = "git@github.com:tetsuo-ai/key-rollover-fixture.git";
+    const original = await resolvePluginSource(source, options);
+    await original.cleanup();
+    await writeEntry({ publicKey: oldPublic, publicKeys: [oldPublic, newPublic] });
+    const cached = await resolvePluginSource(source, options);
+    expect(cached.signature?.verified).toBe(true);
+    expect(cached.pluginRoot).toBe(original.pluginRoot);
+    expect(runProcess).toHaveBeenCalledTimes(1);
+    await cached.cleanup();
+    // Removing a key is also an explicit trust decision. The cache must not
+    // retain the earlier successful verification as permanent authority.
+    await writeEntry({ publicKeys: [newPublic] });
+    await expect(resolvePluginSource(source, options)).rejects.toThrow(/signature verification failed/u);
+    expect(runProcess).toHaveBeenCalledTimes(1);
+    await writeEntry({ publicKeys: [oldPublic, newPublic] });
+    await writeFile(join(cached.pluginRoot, "commands", "hello.md"), "tampered");
+    await expect(resolvePluginSource(source, options)).rejects.toThrow(/digest mismatch/u);
+    expect(runProcess).toHaveBeenCalledTimes(1);
+    await writeSignedPlugin(cached.pluginRoot, oldKey.privateKey);
+    const signaturePath = join(cached.pluginRoot, ".agenc-plugin", "signature.json");
+    const signature = JSON.parse(await readFile(signaturePath, "utf8"));
+    signature.signature = Buffer.alloc(64).toString("base64");
+    await writeJson(signaturePath, signature);
+    await expect(resolvePluginSource(source, options)).rejects.toThrow(/signature verification failed/u);
+    expect(runProcess).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects current payload and manifest tampering with overlapping trust", async () => {
+    await writeEntry({ publicKeys: [oldPublic, newPublic] });
+    await writeFile(join(root, "new", "commands", "hello.md"), "tampered");
+    await expect(verify("new")).rejects.toThrow(/digest mismatch/u);
+    await writeSignedPlugin(join(root, "new"), newKey.privateKey);
+    await writeJson(join(root, "new", ".agenc-plugin", "plugin.json"), { name: "tampered" });
+    await expect(verify("new")).rejects.toThrow(/signature verification failed/u);
+  });
+});

--- a/runtime/tests/plugins/publisher-trust.test.ts
+++ b/runtime/tests/plugins/publisher-trust.test.ts
@@ -5,6 +5,10 @@ import { pluginSignaturePayloadBytes } from "./resolution.js";
 import {
   OFFICIAL_PLUGIN_PUBLISHER_KEY_SHA256,
   OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY,
+  OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_PUBLIC_KEY,
+  OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_KEY_SHA256,
+  builtInPluginPublisherPublicKey,
+  builtInPluginPublisherPublicKeys,
   pluginPublisherKeyFingerprint,
 } from "./publisher-trust.js";
 
@@ -89,6 +93,22 @@ const SIGNATURE =
   "Bm7Nu3ioVXWncjJraWg6m77pjJO4q20A5cgaSUsGumt0Owt6rMKO9J2WA4NPDh+0jFpAYzDndqUlkXDxn5+vBg==";
 
 describe("official plugin publisher trust", () => {
+  it("adds the audited rollover key without changing the legacy API or key", () => {
+    expect(builtInPluginPublisherPublicKey("tetsuo-ai")).toBe(OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY);
+    expect(builtInPluginPublisherPublicKeys("tetsuo-ai")).toEqual([
+      OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY,
+      OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_PUBLIC_KEY,
+    ]);
+    expect(Object.isFrozen(builtInPluginPublisherPublicKeys("tetsuo-ai"))).toBe(true);
+    expect(builtInPluginPublisherPublicKeys("unrelated")).toBeUndefined();
+    expect(pluginPublisherKeyFingerprint(OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_PUBLIC_KEY))
+      .toBe(OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_KEY_SHA256);
+    expect(createPublicKey({
+      key: Buffer.from(OFFICIAL_PLUGIN_PUBLISHER_ROLLOVER_PUBLIC_KEY, "base64"),
+      format: "der", type: "spki",
+    }).asymmetricKeyType).toBe("ed25519");
+  });
+
   it("matches the audited fingerprint and verifies an official signature", () => {
     expect(
       pluginPublisherKeyFingerprint(OFFICIAL_PLUGIN_PUBLISHER_PUBLIC_KEY),


### PR DESCRIPTION
## Summary

Add an explicitly approved Ed25519 publisher-key overlap for `tetsuo-ai`, retaining the legacy root and all historical plugin signatures. No private key is included in this repository or CI.

- Preserve the existing singular key API and legacy string / `{publicKey}` operator keyrings.
- Accept an explicit `{publicKey, publicKeys}` union (maximum 16 configured keys); validate canonical Base64, exact DER-SPKI round-trip and Ed25519 type for every key before trying signatures.
- Keep explicit operator entries authoritative: old-only pins remain old-only; malformed, empty, unreadable and custom trust stores never gain a built-in fallback.
- Re-read trust and reverify cached payloads; key revocation and tamper checks remain effective.
- No dynamic key downloads, signature-format changes, or payload-verification bypass.

## Public fingerprints

- Retained legacy: `8174e96296289bd8eed26b832296309015216afe544a7f15097356b10aa1b932`
- New September key: `d3cd019ab546d8512619fabc80cb4b363c66d1a70bfa25a35bbef5aacf3836c3`

## Verification

- 84 focused tests pass: rollover, official publisher trust and full plugin resolution suite, including cached-key revocation and malformed stores.
- Source typecheck, test-support typecheck and explicit new-test TypeScript check pass.
- Complete runtime build passes: bundles, declarations, entrypoints and SDK validation.
- Actual compiled resolver in an empty temporary profile verifies all four unchanged old-signed plugins and the updated 22-file Stonks payload signed with the new key.
- Independent read-only security review found no remaining actionable issue.
- Old compiled Core with the overlapping hosted keyring still verifies the four unchanged plugins and correctly rejects new-signed Stonks.
- Combined built Core (this change plus #2213) accepts the actual new-signed Stonks through its built CLI and native sandbox: 45 real AAPL bars, valid SVG chart, `releaseAccepted: true`; a fresh manager without the network grant rejects uncached MSFT data and chart requests.
- The combined checkout also passes the exact normal `npm run build` with SHA-verified, repository-pinned npm 11.17.0 launched from temporary storage; no global toolchain was replaced.

## Rollout

This is a prerequisite for https://github.com/tetsuo-ai/agenc-plugins/pull/5. The plugin change retains `agenc-plugins.pub` and the four existing signatures; only Stonks uses the new key. Publishing a hosted keyring does not update clients. Distribute reviewed Core through the normal release path; users with explicit old-only pins must independently verify and deliberately import the overlap. No live daemon, profile, or signed Desktop bundle is replaced by this PR.

The Stonks real-network release check additionally needs https://github.com/tetsuo-ai/agenc-core/pull/2213; the trust change itself does not grant networking.
