### PR TITLE
run-turn: wait out a provider outage with a slow backoff instead of ending the turn

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -316,6 +316,15 @@ the stream with a retryable `stream_idle` error at the deadline. Set it to
 turns only: a one-shot review delegate (`/review`, guardian approval review)
 carries its own deadline, so the ten-minute default is not layered on top of
 it. A value you configure yourself is still honoured inside a review delegate.
+
+`provider_outage_wait_ms` and `provider_outage_retry_ms` govern what happens
+after the fast reconnect ladder gives up on a transient provider error
+(connection refused or reset, a 5xx, a request timeout). Instead of ending the
+turn, the runtime waits `provider_outage_retry_ms` (30 s), then twice that,
+doubling up to ten times the base (5 min), and tries again until the waits
+would exceed `provider_outage_wait_ms` (30 min); each wait is announced by a
+`provider_outage_wait` warning event, and cancelling the turn ends it at once.
+A streamed tool call that makes a retry unsafe still ends the turn immediately.
 The guardian approval review behind a permission prompt runs under a
 ten-minute deadline of its own, so a dead provider socket expires that review
 instead of parking the approval. `[budget]`, `[heartbeat]`, `[browser]`, and
@@ -375,6 +384,8 @@ names; `[]` denotes an array entry. Open maps accept keys at the indicated
 | `autonomous_mode` | Boolean autonomous runtime mode. |
 | `coordinator_mode` | Boolean coordinator-only main-session behavior. |
 | `stream_watchdog_timeout_ms` | Non-negative inter-chunk idle timeout; default `600000`, `0` disables. |
+| `provider_outage_wait_ms` | Non-negative total time a turn keeps waiting for a provider outage to end once the reconnect ladder is spent; default `1800000` (30 minutes), `0` ends the turn as soon as the ladder is exhausted. |
+| `provider_outage_retry_ms` | Positive first slow-retry delay during a provider outage, doubling up to ten times this value; default `30000`. |
 
 Project-root discovery happens before project and local configuration can be
 loaded. Its marker authority is therefore limited to the built-in/plugin/user

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -35,6 +35,8 @@ Boolean-like values that go through `applyEnvOverrides` treat
 | `AGENC_AGENT_MAX_DEPTH` | Non-negative subagent nesting cap projected to `agent_max_depth`; `0` disables spawning |
 | `AGENC_COORDINATOR_MODE` | Overrides `coordinator_mode` both ways when the `COORDINATOR_MODE` build flag is on (it is on in `runtime/src/build/feature.ts`). `0` / `false` / `off` force off |
 | `AGENC_STREAM_IDLE_TIMEOUT_MS` | Stream idle deadline in milliseconds. Unset keeps the `600000` config default; `0` means no idle deadline |
+| `AGENC_PROVIDER_OUTAGE_WAIT_MS` | Overrides `provider_outage_wait_ms`: how long a turn keeps waiting for a provider outage to end after the reconnect ladder is spent. Unset keeps the `1800000` default; `0` ends the turn when the ladder is exhausted |
+| `AGENC_PROVIDER_OUTAGE_RETRY_MS` | Overrides `provider_outage_retry_ms`: the first slow-retry delay during a provider outage, doubling up to ten times the value. Unset keeps the `30000` default |
 | `AGENC_MARKETPLACE_CLI` | Path to marketplace-cli (`[protocol].cli_path`) |
 
 ## Provider credentials and endpoints

--- a/runtime/src/config/env.ts
+++ b/runtime/src/config/env.ts
@@ -10,6 +10,8 @@
 //   AGENC_MAX_TURNS                               → max_turns
 //   AGENC_COORDINATOR_MODE                        → coordinator_mode
 //   AGENC_STREAM_IDLE_TIMEOUT_MS                  → stream_watchdog_timeout_ms
+//   AGENC_PROVIDER_OUTAGE_WAIT_MS                 → provider_outage_wait_ms
+//   AGENC_PROVIDER_OUTAGE_RETRY_MS                → provider_outage_retry_ms
 //   AGENC_XAI_INCREMENTAL                         → providers.grok.incremental_continuation
 //   AGENC_WORKSPACE is consumed only by pre-repository bootstrap cwd
 //   resolution. It is captured here but is not projected into AgenCConfig.
@@ -57,6 +59,8 @@ export interface EnvSnapshot {
   readonly AGENC_MAX_TURNS?: string;
   readonly AGENC_COORDINATOR_MODE?: string;
   readonly AGENC_STREAM_IDLE_TIMEOUT_MS?: string;
+  readonly AGENC_PROVIDER_OUTAGE_WAIT_MS?: string;
+  readonly AGENC_PROVIDER_OUTAGE_RETRY_MS?: string;
   readonly AGENC_XAI_INCREMENTAL?: string;
   readonly AGENC_DISABLE_STREAM_WATCHDOG?: string;
   readonly AGENC_ENABLE_STREAM_WATCHDOG?: string;
@@ -444,6 +448,26 @@ export function applyEnvOverrides(
     } else if (e.AGENC_STREAM_IDLE_TIMEOUT_MS.trim().length > 0) {
       onWarn?.(
         `[agenc:config] invalid AGENC_STREAM_IDLE_TIMEOUT_MS="${e.AGENC_STREAM_IDLE_TIMEOUT_MS}"; expected a non-negative integer`,
+      );
+    }
+  }
+  if (e.AGENC_PROVIDER_OUTAGE_WAIT_MS !== undefined) {
+    const waitMs = readNonNegativeInteger(e.AGENC_PROVIDER_OUTAGE_WAIT_MS);
+    if (waitMs !== undefined) {
+      override.provider_outage_wait_ms = waitMs;
+    } else if (e.AGENC_PROVIDER_OUTAGE_WAIT_MS.trim().length > 0) {
+      onWarn?.(
+        `[agenc:config] invalid AGENC_PROVIDER_OUTAGE_WAIT_MS="${e.AGENC_PROVIDER_OUTAGE_WAIT_MS}"; expected a non-negative integer`,
+      );
+    }
+  }
+  if (e.AGENC_PROVIDER_OUTAGE_RETRY_MS !== undefined) {
+    const retryMs = readNonNegativeInteger(e.AGENC_PROVIDER_OUTAGE_RETRY_MS);
+    if (retryMs !== undefined && retryMs > 0) {
+      override.provider_outage_retry_ms = retryMs;
+    } else if (e.AGENC_PROVIDER_OUTAGE_RETRY_MS.trim().length > 0) {
+      onWarn?.(
+        `[agenc:config] invalid AGENC_PROVIDER_OUTAGE_RETRY_MS="${e.AGENC_PROVIDER_OUTAGE_RETRY_MS}"; expected a positive integer`,
       );
     }
   }

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -900,6 +900,8 @@ export interface AgenCConfig {
   readonly agent?: AgentConfig;
   readonly durableTurns?: DurableTurnsConfig;
   readonly stream_watchdog_timeout_ms?: number;
+  readonly provider_outage_wait_ms?: number;
+  readonly provider_outage_retry_ms?: number;
   readonly max_output_tokens?: number;
   readonly capped_default_max_output_tokens?: boolean;
   readonly max_turns?: number;
@@ -1038,6 +1040,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = Object.freeze([
   "pluginTrustMessage",
   "agent",
   "stream_watchdog_timeout_ms",
+  "provider_outage_wait_ms",
+  "provider_outage_retry_ms",
   "max_output_tokens",
   "capped_default_max_output_tokens",
   "max_turns",
@@ -1061,6 +1065,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = Object.freeze([
  * set `stream_watchdog_timeout_ms = 0` to disable it.
  */
 export const DEFAULT_STREAM_WATCHDOG_TIMEOUT_MS = 600_000;
+/** Total time a turn keeps waiting for a provider outage to end (30 min). */
+export const DEFAULT_PROVIDER_OUTAGE_WAIT_MS = 1_800_000;
+/** First slow-retry delay after the reconnect ladder is spent (30 s). */
+export const DEFAULT_PROVIDER_OUTAGE_RETRY_MS = 30_000;
 
 export function defaultConfig(): AgenCConfig {
   return Object.freeze({
@@ -1115,6 +1123,12 @@ export function defaultConfig(): AgenCConfig {
     // provider stream otherwise hangs the turn until the user cancels;
     // `0` disables the deadline for operators who need unbounded silence.
     stream_watchdog_timeout_ms: DEFAULT_STREAM_WATCHDOG_TIMEOUT_MS,
+    // A provider that is down for minutes is not the turn's fault (#2212).
+    // Once the fast reconnect ladder is spent, the turn waits with a slow
+    // backoff (30 s doubling to 5 min) and tries again for up to this long;
+    // `0` ends the turn as soon as the ladder is exhausted.
+    provider_outage_wait_ms: DEFAULT_PROVIDER_OUTAGE_WAIT_MS,
+    provider_outage_retry_ms: DEFAULT_PROVIDER_OUTAGE_RETRY_MS,
     // No default turn cap. Interactive / long-running agents stop on the
     // model’s own stop signal (or explicit cancel / budget). Operators who
     // want a runaway-loop backstop can set `max_turns` (or its documented env

--- a/runtime/src/config/strict-schema.ts
+++ b/runtime/src/config/strict-schema.ts
@@ -635,6 +635,8 @@ const ROOT_FIELD_VALIDATORS = {
   agent: delegatedObjectValidator("agent"),
   durableTurns: validateDurableTurns,
   stream_watchdog_timeout_ms: fieldValidator("stream_watchdog_timeout_ms", optionalNonNegativeInteger),
+  provider_outage_wait_ms: fieldValidator("provider_outage_wait_ms", optionalNonNegativeInteger),
+  provider_outage_retry_ms: fieldValidator("provider_outage_retry_ms", optionalPositiveInteger),
   max_output_tokens: fieldValidator("max_output_tokens", optionalPositiveInteger),
   capped_default_max_output_tokens: fieldValidator("capped_default_max_output_tokens", optionalBoolean),
   max_turns: fieldValidator("max_turns", optionalPositiveInteger),

--- a/runtime/src/recovery/reconnection.ts
+++ b/runtime/src/recovery/reconnection.ts
@@ -489,7 +489,7 @@ function isReconnectAborted(signal: AbortSignal | undefined): boolean {
   return signal?.aborted === true;
 }
 
-function abortableSleep(
+export function abortableSleep(
   delayMs: number,
   signal: AbortSignal | undefined,
 ): Promise<void> {

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -97,7 +97,11 @@ import {
   isWithheld413Message,
   isWithheldMaxOutputTokens,
 } from "../recovery/api-errors.js";
-import { reconnectWithBackoff } from "../recovery/reconnection.js";
+import { abortableSleep, reconnectWithBackoff } from "../recovery/reconnection.js";
+import {
+  DEFAULT_PROVIDER_OUTAGE_RETRY_MS,
+  DEFAULT_PROVIDER_OUTAGE_WAIT_MS,
+} from "../config/schema.js";
 import {
   MAX_RECOVERY_REENTRIES,
   reserveRecoveryReentry,
@@ -121,7 +125,7 @@ import type {
   SessionTaskRunContext,
   RunningTask,
 } from "./tasks.js";
-import { emitError } from "./event-log.js";
+import { emitError, emitWarning } from "./event-log.js";
 import { SLEEP_TOOL_NAME } from "../tools/SleepTool/prompt.js";
 import {
   advanceModelSampleOrdinal,
@@ -1005,86 +1009,167 @@ async function runSamplingRequest(
   );
   if (prepared.kind === "terminal") return prepared.result;
 
-  const outcome = await reconnectWithBackoff<SamplingRequestResult>({
-    session,
-    signal,
-    // One initial provider call plus the five recovery-ladder reservations.
-    // The reservation hook remains authoritative when another recovery path
-    // has already consumed part of the shared A1 ladder.
-    maxAttempts: MAX_RECOVERY_REENTRIES + 1,
-    attempt: () =>
-      tryRunSamplingRequest(
-        state,
-        ctx,
-        session,
-        prepared.request,
-        signal,
-        events,
-        assistantOutputSink,
-      ),
-    isTransient: (err) => {
-      if (isPartialProviderResponseError(err)) return false;
-      if (isRetryableStreamError(err)) return true;
-      // Fall-through: the raw-error classifier covers bare
-      // ECONNRESET / 5xx / socket-hang-up failures that never got
-      // wrapped in StreamModelError.
-      if (err instanceof StreamModelError) {
-        return isTransientProviderError(err.cause);
-      }
-      return isTransientProviderError(err);
-    },
-    onTransientRetry: async (attempt, err) => {
-      const blockedReason = interruptedStreamRetryBlockReason(state, session);
-      if (blockedReason !== null) {
-        suppressInterruptedStreamToolHistory(state);
-        cancelQueuedInterruptedTools(state);
+  const outage = providerOutagePolicy(session);
+  let waitedMs = 0;
+  let outageRetries = 0;
+  for (;;) {
+    let retryBlocked = false;
+    const outcome = await reconnectWithBackoff<SamplingRequestResult>({
+      session,
+      signal,
+      // One initial provider call plus the five recovery-ladder reservations.
+      // The reservation hook remains authoritative when another recovery path
+      // has already consumed part of the shared A1 ladder.
+      maxAttempts: MAX_RECOVERY_REENTRIES + 1,
+      attempt: () =>
+        tryRunSamplingRequest(
+          state,
+          ctx,
+          session,
+          prepared.request,
+          signal,
+          events,
+          assistantOutputSink,
+        ),
+      isTransient: isTransientSamplingError,
+      onTransientRetry: async (attempt, err) => {
+        const blockedReason = interruptedStreamRetryBlockReason(state, session);
+        if (blockedReason !== null) {
+          retryBlocked = true;
+          suppressInterruptedStreamToolHistory(state);
+          cancelQueuedInterruptedTools(state);
+          emitError(session, session.nextInternalSubId(), {
+            cause: "stream_disconnected",
+            message: `Stream interrupted after streamed tool work; ${blockedReason}.`,
+            provider: session.services.provider.name,
+            status: streamRetryErrorStatus(err),
+            streamError: true,
+          });
+          return false;
+        }
+        const reservation = await reserveRecoveryReentry(session, state, {
+          triggerName: "reconnect",
+        });
+        if (reservation.kind !== "reserved") {
+          // The fast ladder is spent. Whether the turn now waits for the
+          // provider or ends is decided below, once the outcome is known.
+          return false;
+        }
+        cleanupInterruptedStreamAttempt(state, session, err);
         emitError(session, session.nextInternalSubId(), {
           cause: "stream_disconnected",
-          message: `Stream interrupted after streamed tool work; ${blockedReason}.`,
+          message: streamRetryNoticeMessage(
+            err,
+            attempt,
+            MAX_RECOVERY_REENTRIES + 1,
+          ),
           provider: session.services.provider.name,
           status: streamRetryErrorStatus(err),
           streamError: true,
         });
-        return false;
-      }
-      const reservation = await reserveRecoveryReentry(session, state, {
-        triggerName: "reconnect",
-      });
-      if (reservation.kind !== "reserved") {
+        return true;
+      },
+    });
+
+    if (outcome.kind === "ok") return outcome.value;
+    if (outcome.kind === "aborted") {
+      throw samplingAbortError(signal, outcome.reason);
+    }
+    // The fast ladder is exhausted. A provider that is down for minutes is
+    // not the turn's fault (#2212): wait with a slow backoff and try again,
+    // within the operator's patience, unless retrying is unsafe.
+    const lastError = outcome.lastError;
+    const delayMs = providerOutageDelayMs(outage.retryMs, outageRetries);
+    const canWait =
+      !retryBlocked &&
+      outage.waitMs > 0 &&
+      waitedMs + delayMs <= outage.waitMs &&
+      isTransientSamplingError(lastError);
+    if (!canWait) {
+      if (!retryBlocked) {
         suppressInterruptedStreamToolHistory(state);
         cancelQueuedInterruptedTools(state);
-        return false;
       }
-      cleanupInterruptedStreamAttempt(state, session, err);
-      emitError(session, session.nextInternalSubId(), {
-        cause: "stream_disconnected",
-        message: streamRetryNoticeMessage(
-          err,
-          attempt,
-          MAX_RECOVERY_REENTRIES + 1,
-        ),
-        provider: session.services.provider.name,
-        status: streamRetryErrorStatus(err),
-        streamError: true,
-      });
-      return true;
-    },
-  });
-
-  if (outcome.kind === "ok") return outcome.value;
-  if (outcome.kind === "aborted") {
-    const abortReason =
-      (signal as AbortSignal & { reason?: unknown }).reason ?? outcome.reason;
-    throw new StreamModelError(
-      abortReason instanceof Error
-        ? abortReason
-        : new Error(String(abortReason)),
+      if (lastError instanceof Error) throw lastError;
+      throw new Error(`stream_retries_exhausted: ${String(lastError)}`);
+    }
+    outageRetries += 1;
+    waitedMs += delayMs;
+    cleanupInterruptedStreamAttempt(state, session, lastError);
+    emitWarning(
+      session.eventLog,
+      session.nextInternalSubId(),
+      "provider_outage_wait",
+      `${session.services.provider.name} unavailable after ${outcome.attempts} attempt(s) ` +
+        `(${errorSummary(lastError)}); retry ${outageRetries} in ${Math.round(delayMs / 1000)} s, ` +
+        `${Math.max(0, Math.round((outage.waitMs - waitedMs) / 60_000))} min of waiting left`,
     );
+    await abortableSleep(delayMs, signal);
+    if (signal.aborted) throw samplingAbortError(signal, "aborted");
   }
-  // exhausted
-  const lastError = outcome.lastError;
-  if (lastError instanceof Error) throw lastError;
-  throw new Error(`stream_retries_exhausted: ${String(lastError)}`);
+}
+
+function isTransientSamplingError(err: unknown): boolean {
+  if (isPartialProviderResponseError(err)) return false;
+  if (isRetryableStreamError(err)) return true;
+  // Fall-through: the raw-error classifier covers bare
+  // ECONNRESET / 5xx / socket-hang-up failures that never got
+  // wrapped in StreamModelError.
+  if (err instanceof StreamModelError) {
+    return isTransientProviderError(err.cause);
+  }
+  return isTransientProviderError(err);
+}
+
+function samplingAbortError(signal: AbortSignal, fallback: unknown): StreamModelError {
+  const abortReason =
+    (signal as AbortSignal & { reason?: unknown }).reason ?? fallback;
+  return new StreamModelError(
+    abortReason instanceof Error ? abortReason : new Error(String(abortReason)),
+  );
+}
+
+function errorSummary(err: unknown): string {
+  const text = err instanceof Error ? err.message : String(err);
+  return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+}
+
+/**
+ * How long a turn keeps waiting for a provider outage to end, and the first
+ * slow-retry delay, from the live config (`provider_outage_wait_ms`,
+ * `provider_outage_retry_ms`) with the documented defaults.
+ */
+function providerOutagePolicy(session: Session): {
+  readonly waitMs: number;
+  readonly retryMs: number;
+} {
+  let current: { provider_outage_wait_ms?: unknown; provider_outage_retry_ms?: unknown } | undefined;
+  try {
+    current = (
+      session.services as {
+        configStore?: { current?: () => typeof current };
+      }
+    ).configStore?.current?.();
+  } catch {
+    current = undefined;
+  }
+  const wait = current?.provider_outage_wait_ms;
+  const retry = current?.provider_outage_retry_ms;
+  return {
+    waitMs:
+      typeof wait === "number" && Number.isFinite(wait) && wait >= 0
+        ? wait
+        : DEFAULT_PROVIDER_OUTAGE_WAIT_MS,
+    retryMs:
+      typeof retry === "number" && Number.isFinite(retry) && retry > 0
+        ? retry
+        : DEFAULT_PROVIDER_OUTAGE_RETRY_MS,
+  };
+}
+
+/** Slow backoff: the base delay doubling per retry, capped at ten times it. */
+export function providerOutageDelayMs(retryMs: number, outageRetries: number): number {
+  return Math.min(retryMs * 2 ** outageRetries, retryMs * 10);
 }
 
 /**

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -5769,6 +5769,8 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
       const { session, events, getState } = mkSession({
         provider,
         registry,
+        // Terminal exhaustion is this test's subject; no provider-outage wait.
+        configStoreBase: { provider_outage_wait_ms: 0 },
         permissionModeRegistry: new PermissionModeRegistry(
           createEmptyToolPermissionContext({
             mode: "bypassPermissions",
@@ -8236,5 +8238,104 @@ describe("runTurn — GOAL #4b Stage 1 durable resume continuation", () => {
       ),
     ).toBe(false);
     expect(events.some((e) => e.msg.type === "turn_complete")).toBe(true);
+  });
+});
+
+describe("provider outage wait (#2212)", () => {
+  function connectionError(): Error {
+    return Object.assign(new Error("Connection error."), { code: "ECONNRESET" });
+  }
+
+  /** Spend the fast ladder at once so each slow retry is one provider call. */
+  async function spentLadder(): Promise<() => void> {
+    const recovery = await import("../recovery/fallback-ladder.js");
+    const reserveRecoveryReentry = recovery.reserveRecoveryReentry;
+    const spy = vi
+      .spyOn(recovery, "reserveRecoveryReentry")
+      .mockImplementation(async (session, state, opts) => {
+        state.recoveryReentryCount = recovery.MAX_RECOVERY_REENTRIES;
+        return reserveRecoveryReentry(session, state, opts);
+      });
+    return () => spy.mockRestore();
+  }
+
+  function failingThenSucceeding(failures: number): { provider: LLMProvider; attempts: () => number } {
+    let attempts = 0;
+    const provider: LLMProvider = {
+      ...mkProvider({}),
+      chatStream: async (
+        _messages: LLMMessage[],
+        onChunk: StreamProgressCallback,
+      ): Promise<LLMResponse> => {
+        attempts += 1;
+        if (attempts <= failures) throw connectionError();
+        onChunk({ content: "resumed", done: false });
+        return {
+          content: "resumed",
+          toolCalls: [],
+          usage: { promptTokens: 3, completionTokens: 2, totalTokens: 5 },
+          model: "test-model",
+          finishReason: "stop",
+        };
+      },
+    };
+    return { provider, attempts: () => attempts };
+  }
+
+  test("waits out a provider outage with a slow backoff and finishes the turn", async () => {
+    const restore = await spentLadder();
+    try {
+      const { provider, attempts } = failingThenSucceeding(2);
+      const { session, events } = mkSession({
+        provider,
+        registry: mkRegistry(),
+        configStoreBase: {
+          provider_outage_wait_ms: 60_000,
+          provider_outage_retry_ms: 1,
+        },
+      });
+      await drain(session.runTurn("hello", { ctx: mkCtx() }));
+      expect(attempts()).toBe(3);
+      const waits = events.filter(
+        (event) =>
+          event.msg.type === "warning" &&
+          (event.msg.payload as { cause?: string }).cause === "provider_outage_wait",
+      );
+      expect(waits).toHaveLength(2);
+      expect(String((waits[0]!.msg.payload as { message: string }).message)).toContain("retry 1 in 0 s");
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          msg: expect.objectContaining({ type: "agent_message", payload: expect.objectContaining({ message: "resumed" }) }),
+        }),
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("ends the turn when the first slow retry would exceed the operator's patience", async () => {
+    const restore = await spentLadder();
+    try {
+      const { provider, attempts } = failingThenSucceeding(5);
+      const { session, events } = mkSession({
+        provider,
+        registry: mkRegistry(),
+        configStoreBase: {
+          provider_outage_wait_ms: 1,
+          provider_outage_retry_ms: 1_000,
+        },
+      });
+      await drain(session.runTurn("hello", { ctx: mkCtx() }));
+      expect(attempts()).toBe(1);
+      expect(
+        events.some(
+          (event) =>
+            event.msg.type === "warning" &&
+            (event.msg.payload as { cause?: string }).cause === "provider_outage_wait",
+        ),
+      ).toBe(false);
+    } finally {
+      restore();
+    }
   });
 });


### PR DESCRIPTION
## Why

Fixes #2212. When xAI was unreachable for a few minutes during the desktop soak, the reconnect ladder retried six times over about fifteen seconds, gave up, and the turn died with "grok error: Connection error."; a single 120 s request timeout killed another turn the same way. The provider was healthy again minutes later and nothing resumed the work; the user, away from the screen, came back to a dead turn and a Retry button. A provider outage of a few minutes should cost minutes, not the turn.

## What changed

- `src/session/run-turn.ts`: `runSamplingRequest` runs the existing fast ladder inside an outer loop. When the ladder is exhausted on a transient error and retrying is not unsafe, it emits a `warning` event (`provider_outage_wait`, naming the provider, the attempts so far, the error, the delay and the patience left), cleans up the interrupted attempt the way a fast retry does, sleeps with an abortable timer, and runs the ladder again. Delays start at `provider_outage_retry_ms` (30 s) and double up to ten times that (5 min); the loop gives up when the next delay would exceed `provider_outage_wait_ms` (30 min), when the error is not transient, or when a streamed tool made retrying unsafe (that branch is unchanged and still ends the turn). The suppression of interrupted tool history that used to happen inside the retry callback when the ladder ran out now happens at the give-up point, so a turn that waits and resumes keeps its history intact. Cancelling the turn still ends it at once. Helpers: `isTransientSamplingError`, `samplingAbortError`, `providerOutagePolicy` (reads the live config store), `providerOutageDelayMs`.
- `src/config/schema.ts`, `src/config/strict-schema.ts`, `src/config/env.ts`: `provider_outage_wait_ms` (non-negative, default 1 800 000, `0` disables the wait) and `provider_outage_retry_ms` (positive, default 30 000), with `AGENC_PROVIDER_OUTAGE_WAIT_MS` and `AGENC_PROVIDER_OUTAGE_RETRY_MS` overrides following the stream watchdog's pattern.
- `src/recovery/reconnection.ts`: `abortableSleep` exported for the slow loop.
- `tests/session/run-turn.test.ts`: two new tests spend the fast ladder at once with the same spy LP-07 uses; one shows two slow retries at a 1 ms base and the turn finishing with the resumed reply and two `provider_outage_wait` warnings, the other shows the turn ending immediately when the first delay would exceed the patience. LP-07, whose subject is the terminal exhaustion path, sets the wait to zero.

## Evidence

Soak run `final-chat-2`, prompt 16 (`docs/eval/app-soak-2026-09-05.md`): `reconnect_exhausted attempt=6 exhaustion=retry_callback_rejected`, then `recovery ladder exceeded MAX_RECOVERY_REENTRIES=5`, then `turn_aborted: grok error: Connection error.`; the same run's prompt 15: `grok request timed out after 120000ms`. Both would now wait.

## Tests

`vitest run tests/session/run-turn.test.ts`, `tests/config`, `tests/recovery`: run-turn 135 passed; recovery all passed; config 871 passed with the eight home-authority failures this Mac shows on main too (they read the real home) and both documentation-contract tests passing with the new entries. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

The fast ladder's attempts and delays, the recovery re-entry cap, what counts as transient, the unsafe-retry branch, and the desktop, which shows the turn as still running during a wait (a follow-up can render the warning's next-retry time in the ticker).

## Counterparts

#2212, #2200 (quiet stream), #2201.
