### PR TITLE
daemon: a heartbeat file so an unexplained exit carries the process's last state

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -56,6 +56,11 @@ import {
   writeDaemonRuntimeInfo,
 } from "./daemon-runtime-info.js";
 import {
+  installAgenCDaemonHeartbeat,
+  reportLastDaemonHeartbeat,
+  resolveAgenCDaemonHeartbeatPath,
+} from "./daemon-heartbeat.js";
+import {
   findLinuxAgenCDaemonProcesses,
   inspectLinuxAgenCDaemonProcess,
   isAgenCDaemonInstanceIdentity,
@@ -1913,6 +1918,11 @@ async function stopAgenCDaemon(
         removeDaemonRuntimeInfo(runtimeInfoPath, runtimeInfo.instanceId);
       }
     }
+    reportLastDaemonHeartbeat(
+      io,
+      resolveAgenCDaemonHeartbeatPath(daemonHome),
+      pid,
+    );
     io.stdout.write(`AgenC daemon stopped (pid ${pid})\n`);
     return 0;
   });
@@ -2132,6 +2142,13 @@ async function statusAgenCDaemon(
         );
         return 1;
       }
+      reportLastDaemonHeartbeat(
+        io,
+        resolveAgenCDaemonHeartbeatPath(
+          resolveAgenCDaemonHome(host.env, host.userHome),
+        ),
+        null,
+      );
       io.stdout.write("AgenC daemon stopped\n");
       return 1;
     }
@@ -3179,6 +3196,19 @@ async function runAgenCDaemonForegroundLocked(
           logSink.dispose();
         });
       }
+      // The heartbeat outlives every handler: a daemon killed without warning
+      // leaves its last pid, memory and event-loop lag on disk for `status`.
+      const disposeHeartbeat = installAgenCDaemonHeartbeat({
+        path: resolveAgenCDaemonHeartbeatPath(
+          resolveAgenCDaemonHome(host.env, host.userHome),
+        ),
+        onError: (error) => {
+          logSink?.sink.write(
+            `agenc: daemon heartbeat write failed: ${formatCleanupError(error)}\n`,
+          );
+        },
+      });
+      cleanup.register("daemon-heartbeat", disposeHeartbeat);
     }
     let shuttingDown = false;
     let resolveRpcShutdown!: () => void;

--- a/runtime/src/app-server/daemon-heartbeat.ts
+++ b/runtime/src/app-server/daemon-heartbeat.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { writeDurableAtomicFileSync } from "../utils/durable-atomic-file.js";
+
+/**
+ * The daemon's heartbeat file: rewritten every few seconds with the process's
+ * pid, memory and event-loop lag, fsynced, removed on a clean shutdown. A
+ * daemon that dies in a way no handler can see (SIGKILL, an abort with crash
+ * reporting off) leaves its last heartbeat behind, and `agenc daemon status`
+ * reports it beside "stopped" so an unexplained exit at least carries the
+ * process's last known state (#2199).
+ */
+export const AGENC_DAEMON_HEARTBEAT_FILENAME = "daemon-heartbeat.json";
+export const AGENC_DAEMON_HEARTBEAT_INTERVAL_MS = 5_000;
+
+export interface DaemonHeartbeat {
+  readonly pid: number;
+  readonly beat: number;
+  readonly at: string;
+  readonly uptimeS: number;
+  readonly rssMb: number;
+  readonly heapUsedMb: number;
+  readonly eventLoopLagMs: number;
+}
+
+export interface DaemonHeartbeatProcess {
+  readonly pid: number;
+  memoryUsage(): { readonly rss: number; readonly heapUsed: number };
+  uptime(): number;
+}
+
+export function resolveAgenCDaemonHeartbeatPath(daemonHome: string): string {
+  return join(daemonHome, AGENC_DAEMON_HEARTBEAT_FILENAME);
+}
+
+/**
+ * Start the heartbeat. The event-loop lag is how late each tick fired against
+ * its schedule: a loop blocked by synchronous work shows up here before the
+ * process can miss anything else. Returns the disposer, which stops the timer
+ * and removes the file so a clean stop leaves nothing to misreport.
+ */
+export function installAgenCDaemonHeartbeat(options: {
+  readonly path: string;
+  readonly intervalMs?: number;
+  readonly proc?: DaemonHeartbeatProcess;
+  readonly now?: () => number;
+  readonly onError?: (error: unknown) => void;
+}): () => void {
+  const proc = options.proc ?? (process as DaemonHeartbeatProcess);
+  const intervalMs = options.intervalMs ?? AGENC_DAEMON_HEARTBEAT_INTERVAL_MS;
+  const now = options.now ?? Date.now;
+  let beat = 0;
+  let expectedAt = now() + intervalMs;
+  const write = (lagMs: number): void => {
+    beat += 1;
+    const memory = proc.memoryUsage();
+    const heartbeat: DaemonHeartbeat = {
+      pid: proc.pid,
+      beat,
+      at: new Date(now()).toISOString(),
+      uptimeS: Math.round(proc.uptime()),
+      rssMb: Math.round(memory.rss / 1_048_576),
+      heapUsedMb: Math.round(memory.heapUsed / 1_048_576),
+      eventLoopLagMs: Math.round(lagMs),
+    };
+    try {
+      writeDurableAtomicFileSync(
+        options.path,
+        `${options.path}.${proc.pid}.${randomUUID()}.tmp`,
+        `${JSON.stringify(heartbeat, null, 2)}\n`,
+      );
+    } catch (error) {
+      options.onError?.(error);
+    }
+  };
+  write(0);
+  const timer = setInterval(() => {
+    const tickAt = now();
+    const lagMs = Math.max(0, tickAt - expectedAt);
+    expectedAt = tickAt + intervalMs;
+    write(lagMs);
+  }, intervalMs);
+  (timer as { unref?: () => void }).unref?.();
+  return () => {
+    clearInterval(timer);
+    try {
+      if (readAgenCDaemonHeartbeat(options.path)?.pid === proc.pid) {
+        rmSync(options.path, { force: true });
+      }
+    } catch {
+      /* best-effort */
+    }
+  };
+}
+
+export function readAgenCDaemonHeartbeat(path: string): DaemonHeartbeat | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof raw !== "object" || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+  const numbers = ["pid", "beat", "uptimeS", "rssMb", "heapUsedMb", "eventLoopLagMs"] as const;
+  if (!numbers.every((key) => typeof record[key] === "number" && Number.isFinite(record[key]))) {
+    return null;
+  }
+  if (typeof record.at !== "string" || Number.isNaN(Date.parse(record.at))) return null;
+  return record as unknown as DaemonHeartbeat;
+}
+
+/** One line for the status command: what the daemon last said about itself. */
+export function describeDaemonHeartbeat(heartbeat: DaemonHeartbeat, nowMs: number): string {
+  const ageS = Math.max(0, Math.round((nowMs - Date.parse(heartbeat.at)) / 1000));
+  const uptime =
+    heartbeat.uptimeS >= 3600
+      ? `${Math.floor(heartbeat.uptimeS / 3600)} h ${Math.round((heartbeat.uptimeS % 3600) / 60)} min`
+      : `${Math.round(heartbeat.uptimeS / 60)} min`;
+  return (
+    `the last daemon (pid ${heartbeat.pid}) sent its last heartbeat at ${heartbeat.at}, ${ageS} s ago: ` +
+    `rss ${heartbeat.rssMb} MB, heap ${heartbeat.heapUsedMb} MB, event-loop lag ${heartbeat.eventLoopLagMs} ms, up ${uptime}`
+  );
+}
+
+/**
+ * Report the heartbeat a vanished daemon left behind. `pid` is the recorded
+ * pid when there is one; a heartbeat from a different process is not reported
+ * against it.
+ */
+export function reportLastDaemonHeartbeat(
+  io: { readonly stderr: { write(text: string): unknown } },
+  path: string,
+  pid: number | null,
+  nowMs: number = Date.now(),
+): boolean {
+  const heartbeat = readAgenCDaemonHeartbeat(path);
+  if (heartbeat === null || (pid !== null && heartbeat.pid !== pid)) return false;
+  io.stderr.write(`agenc: ${describeDaemonHeartbeat(heartbeat, nowMs)}\n`);
+  return true;
+}

--- a/runtime/tests/app-server/daemon-heartbeat.test.ts
+++ b/runtime/tests/app-server/daemon-heartbeat.test.ts
@@ -1,0 +1,130 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  describeDaemonHeartbeat,
+  installAgenCDaemonHeartbeat,
+  readAgenCDaemonHeartbeat,
+  reportLastDaemonHeartbeat,
+  resolveAgenCDaemonHeartbeatPath,
+} from "../../src/app-server/daemon-heartbeat.js";
+
+// #2199: a daemon that dies in a way no handler can see leaves its last
+// heartbeat behind, and `status` reports it beside "stopped".
+
+let home = "";
+let path = "";
+const proc = {
+  pid: 4242,
+  memoryUsage: () => ({ rss: 600 * 1_048_576, heapUsed: 250 * 1_048_576 }),
+  uptime: () => 1_620,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-06T12:39:00.000Z"));
+  home = mkdtempSync(join(tmpdir(), "agenc-heartbeat-"));
+  path = resolveAgenCDaemonHeartbeatPath(home);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("daemon heartbeat", () => {
+  it("writes a beat at once and on every interval, with pid, memory and lag", () => {
+    const dispose = installAgenCDaemonHeartbeat({ path, intervalMs: 1_000, proc });
+    try {
+      expect(readAgenCDaemonHeartbeat(path)).toMatchObject({
+        pid: 4242,
+        beat: 1,
+        rssMb: 600,
+        heapUsedMb: 250,
+        uptimeS: 1_620,
+        eventLoopLagMs: 0,
+      });
+      vi.advanceTimersByTime(2_000);
+      const third = readAgenCDaemonHeartbeat(path);
+      expect(third?.beat).toBe(3);
+      expect(third?.at).toBe("2026-09-06T12:39:02.000Z");
+    } finally {
+      dispose();
+    }
+  });
+
+  it("measures a late tick as event-loop lag", () => {
+    let drift = 0;
+    const dispose = installAgenCDaemonHeartbeat({
+      path,
+      intervalMs: 1_000,
+      proc,
+      now: () => Date.now() + drift,
+    });
+    try {
+      drift = 700; // the loop was busy; this tick observes the clock 700 ms late
+      vi.advanceTimersByTime(1_000);
+      expect(readAgenCDaemonHeartbeat(path)?.eventLoopLagMs).toBe(700);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("removes its own file on a clean stop and leaves another process's alone", () => {
+    const dispose = installAgenCDaemonHeartbeat({ path, intervalMs: 1_000, proc });
+    dispose();
+    expect(existsSync(path)).toBe(false);
+    writeFileSync(path, JSON.stringify({ ...readOrSample(), pid: 99 }));
+    const disposeAgain = installAgenCDaemonHeartbeat({ path, intervalMs: 1_000, proc });
+    // The install overwrote the file with pid 4242; a later foreign write survives the disposer.
+    writeFileSync(path, JSON.stringify({ ...readOrSample(), pid: 99 }));
+    disposeAgain();
+    expect(readAgenCDaemonHeartbeat(path)?.pid).toBe(99);
+  });
+
+  it("rejects a malformed file", () => {
+    writeFileSync(path, "{not json");
+    expect(readAgenCDaemonHeartbeat(path)).toBeNull();
+    writeFileSync(path, JSON.stringify({ pid: "4242", beat: 1, at: "x" }));
+    expect(readAgenCDaemonHeartbeat(path)).toBeNull();
+  });
+
+  it("reports the vanished daemon's last heartbeat for its pid only", () => {
+    installAgenCDaemonHeartbeat({ path, intervalMs: 1_000, proc })();
+    writeFileSync(path, `${JSON.stringify(readOrSample())}\n`);
+    vi.setSystemTime(new Date("2026-09-06T12:39:45.000Z"));
+    const lines: string[] = [];
+    const io = { stderr: { write: (text: string) => lines.push(text) } };
+    expect(reportLastDaemonHeartbeat(io, path, 4242)).toBe(true);
+    expect(lines[0]).toContain("pid 4242");
+    expect(lines[0]).toContain("45 s ago");
+    expect(lines[0]).toContain("rss 600 MB");
+    expect(lines[0]).toContain("event-loop lag 0 ms");
+    expect(lines[0]).toContain("up 27 min");
+    expect(reportLastDaemonHeartbeat(io, path, 1)).toBe(false);
+    expect(reportLastDaemonHeartbeat(io, path, null)).toBe(true);
+    expect(lines).toHaveLength(2);
+  });
+
+  it("describes long uptimes in hours", () => {
+    const text = describeDaemonHeartbeat(
+      { ...readOrSample(), uptimeS: 2 * 3600 + 5 * 60 },
+      Date.parse("2026-09-06T12:39:00.000Z"),
+    );
+    expect(text).toContain("up 2 h 5 min");
+  });
+});
+
+function readOrSample() {
+  return {
+    pid: 4242,
+    beat: 7,
+    at: "2026-09-06T12:39:00.000Z",
+    uptimeS: 1_620,
+    rssMb: 600,
+    heapUsedMb: 250,
+    eventLoopLagMs: 0,
+  };
+}


### PR DESCRIPTION
## Why

#2199, second occurrence today: the daemon under the swarm soak vanished mid-turn, and with the exit diagnostics from #2203 in place none of them fired: no exit code, no signal, no crash, no rejection, nothing in the system log, no crash report. A termination that no handler can see (SIGKILL, an abort with reporting off) is the only thing consistent with the evidence, and after two such exits in one day the daemon still leaves nothing behind that says what state it was in. This gives it a heartbeat.

## What changed

- `src/app-server/daemon-heartbeat.ts` (new): `installAgenCDaemonHeartbeat` rewrites `daemon-heartbeat.json` in the daemon home every 5 s (fsynced, atomic) with the pid, beat count, timestamp, uptime, RSS, heap in use and the event-loop lag, measured as how late the tick fired against its schedule, so a blocked loop shows up before anything else can. The disposer stops the timer and removes the file if it is still this process's, so a clean stop leaves nothing to misreport; a killed daemon's last beat stays. `readAgenCDaemonHeartbeat` validates the file, `describeDaemonHeartbeat` renders one line, `reportLastDaemonHeartbeat` prints it for a vanished pid (or any pid when none is recorded).
- `src/app-server/daemon-cli.ts`: the detached daemon installs the heartbeat beside the log sink and exit diagnostics and disposes it through the same cleanup registry; `agenc daemon status` prints the last heartbeat on stderr before "stopped" when the recorded pid is gone, and when no pid is recorded but a heartbeat file exists.
- `tests/app-server/daemon-heartbeat.test.ts` (new): the first beat and the interval beats with pid, memory and lag; a late tick measured as lag; the disposer removing its own file and sparing another process's; malformed files rejected; the status report for the matching pid only, with age, memory, lag and uptime; uptimes over an hour.

## Evidence

Issue #2199's two exits: 02:33Z (pid 11285, one live turn, 54 min up) and 12:39Z (pid 3880, eight agents in flight, 27 min up). With this, the next one comes with the daemon's own last five seconds.

## Tests

`vitest run tests/app-server/daemon-heartbeat.test.ts tests/app-server/daemon-cli.heap-and-log.test.ts`: 14 passed, plus the one failure this Mac shows on main too ("resolves the daemon log path under the daemon home", `/tmp` against `/private/tmp`). `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

The exit diagnostics, the log sink, the desktop (a follow-up can show the last heartbeat on the disconnect banner), what the daemon does with the information.

## Counterparts

#2199, #2203, #2188.
