### PR TITLE
workflow: a goal started without a model reviews with the daemon's configured model

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -3456,6 +3456,7 @@ async function runAgenCDaemonForegroundLocked(
       kernel: executionAdmissionKernel,
       warn: (message) => io.stderr.write(`agenc: ${message}\n`),
       env: host.env,
+      config: () => activeConfig,
       argv: [host.execPath, host.entrypointPath],
       authBackend: reloadableAuthBackend,
       stateDatabasePaths: () =>

--- a/runtime/src/app-server/workflow/daemon-wiring.ts
+++ b/runtime/src/app-server/workflow/daemon-wiring.ts
@@ -310,12 +310,39 @@ export interface DaemonWorkflowWiring {
   close(): void;
 }
 
+/**
+ * The reviewer model for a goal whose caller named none: the provider model
+ * selected in the current scope when one is bound, else the daemon's
+ * configured model. The selection accessor throws outside a startup or
+ * session scope, which is where the daemon's RPC handlers run (soak F62).
+ */
+export function resolveDaemonDefaultReviewerModel(
+  selected: () => string,
+  configured: () => string | undefined,
+): string | undefined {
+  try {
+    const model = selected().trim();
+    if (model.length > 0) return model;
+  } catch {
+    // No provider scope is bound here; the configured model decides below.
+  }
+  const fallback = configured()?.trim();
+  return fallback !== undefined && fallback.length > 0 ? fallback : undefined;
+}
+
 export function createDaemonWorkflowController(options: {
   readonly agencHome: string;
   readonly primaryCwd: string;
   readonly kernel: ExecutionAdmissionKernel;
   readonly warn: (message: string) => void;
   readonly env: NodeJS.ProcessEnv;
+  /**
+   * The daemon's active config. A goal started without a model by a client
+   * that names none (the SDK, a script) needs a reviewer model; the selected
+   * provider model exists only inside a session's startup scope, which the
+   * daemon's RPC handlers never bind, so the configured pair is the fallback.
+   */
+  readonly config?: () => { readonly model?: string } | undefined;
   /** Executable and entrypoint coordinates for child-session bootstraps. */
   readonly argv: readonly string[];
   readonly authBackend?: AuthBackend;
@@ -465,14 +492,11 @@ export function createDaemonWorkflowController(options: {
     commands: seams.commands,
     spawner: seams.spawner,
     reviewer: seams.reviewer,
-    defaultReviewerModel: () => {
-      try {
-        const model = getSelectedProviderModel().trim();
-        return model.length > 0 ? model : undefined;
-      } catch {
-        return undefined;
-      }
-    },
+    defaultReviewerModel: () =>
+      resolveDaemonDefaultReviewerModel(
+        getSelectedProviderModel,
+        () => options.config?.()?.model,
+      ),
     warn: options.warn,
   });
   return {

--- a/runtime/tests/workflow/daemon-wiring.test.ts
+++ b/runtime/tests/workflow/daemon-wiring.test.ts
@@ -14,7 +14,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { createDaemonWorkflowController } from "../../src/app-server/workflow/daemon-wiring.js";
+import {
+  createDaemonWorkflowController,
+  resolveDaemonDefaultReviewerModel,
+} from "../../src/app-server/workflow/daemon-wiring.js";
 import type {
   WorkflowAgentSpawner,
   WorkflowChildOutcome,
@@ -316,7 +319,7 @@ function makeSeams(): WorkflowSessionSeams & {
   };
 }
 
-function makeWiring() {
+function makeWiring(options: { readonly config?: () => { readonly model?: string } } = {}) {
   const admission = new FakeAdmission();
   const kernel = {
     bindClient: ({ scope }: { scope: { runId: string } }) => {
@@ -332,6 +335,7 @@ function makeWiring() {
     warn: () => {},
     env: {},
     argv: ["node", "agenc"],
+    ...(options.config !== undefined ? { config: options.config } : {}),
     stateDatabasePaths: () => [
       resolveStateDatabasePaths({ cwd: projectA.cwd, agencHome: home }),
       resolveStateDatabasePaths({ cwd: projectB.cwd, agencHome: home }),
@@ -376,6 +380,25 @@ describe("createDaemonWorkflowController — reviewer model", () => {
     expect(projectB.repo.getCurrentTerminalResult("wf-default-reviewer")).toMatchObject({
       status: "completed",
     });
+  });
+
+  it("resolves the reviewer model from the scope first and the configured model second", () => {
+    // The daemon's RPC handlers run outside any session startup scope, which is
+    // where an SDK or script client that names no model arrives (soak F62).
+    const unbound = () => {
+      throw new Error("No provider authority is bound");
+    };
+    expect(resolveDaemonDefaultReviewerModel(() => "grok-4.6", () => "grok-4.6-fast")).toBe(
+      "grok-4.6",
+    );
+    expect(resolveDaemonDefaultReviewerModel(unbound, () => "grok-4.6-fast")).toBe(
+      "grok-4.6-fast",
+    );
+    expect(resolveDaemonDefaultReviewerModel(() => "  ", () => " grok-4.6-fast ")).toBe(
+      "grok-4.6-fast",
+    );
+    expect(resolveDaemonDefaultReviewerModel(unbound, () => undefined)).toBeUndefined();
+    expect(resolveDaemonDefaultReviewerModel(unbound, () => "")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Why

Soak finding F62. On a freshly rebuilt daemon, every goal the soak driver started was refused at intake with "no reviewer model: pass `reviewerModel` or `model`, or configure the daemon's default model", three runs in a row, and a chat turn on the daemon changed nothing. #2198 made the reviewer model fall back to the daemon's selected provider model, but that selection exists only inside a session's startup scope; the daemon's RPC handlers never bind one, so the fallback always threw and yielded nothing. The desktop's goal UI works only because it attaches the composer's model and provider; the SDK, the TUI and any script that omits the model cannot start a goal at all.

## What changed

- `src/app-server/workflow/daemon-wiring.ts`: `createDaemonWorkflowController` takes an optional `config` getter returning the daemon's active config. `defaultReviewerModel` keeps trying the selected provider model first and, when no scope is bound or it is empty, falls back to the configured `model`, which the default config always carries.
- `src/app-server/daemon-cli.ts`: passes `config: () => activeConfig`, the reloadable active config the daemon already holds beside the controller.
- `tests/workflow/daemon-wiring.test.ts`: the harness accepts a config getter, and `resolveDaemonDefaultReviewerModel` is tested on its own, since the test environment always binds a provider scope: a bound selection wins, an unbound or blank selection falls back to the configured model, and neither yields nothing so the intake still refuses.

## Evidence

Soak runs `goal-9` and `goal-10` (2026-09-06, daemon at e551a8002): three `goal-start-error` steps each with the intake message above; `goal-11` through the app UI, which sends the model, ran. `docs/eval/app-soak-2026-09-05.md` F58 for the original gap, F62 in the soak log for this one.

## Tests

`vitest run tests/workflow/daemon-wiring.test.ts tests/workflow/verified-change-controller.test.ts`: all passing including the two new cases. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

The intake's refusal when nothing can name a model, the caller's `reviewerModel` and `model` precedence, the desktop.

## Counterparts

#2198 (the fallback this completes), the soak report #2192, #2204, #2210.
