### PR TITLE
memory: resolve the skill-candidate home through the home resolver

### DIFF
--- a/runtime/src/services/extractMemories/extractMemories.ts
+++ b/runtime/src/services/extractMemories/extractMemories.ts
@@ -34,7 +34,7 @@ import {
 } from "../../llm/content-conversion.js";
 import type { Session, SessionServices } from "../../session/session.js";
 import type { TurnContext } from "../../session/turn-context.js";
-import { resolveAgencHome } from "../../config/env.js";
+import { resolveHomeContext } from "../../config/home.js";
 import {
   isSkillCandidatesDisabledByEnv,
   parseSkillCandidateProposals,
@@ -198,7 +198,7 @@ export interface ExtractMemoriesDependencies {
   readonly ensureAgentControl?: typeof ensureAgentControlFn;
   /**
    * AgenC home that receives skill-candidate drafts. Defaults to the
-   * session's config-store home, then `resolveAgencHome(env)`. An injected
+   * session's config-store home, then the home resolver. An injected
    * `env` that names no `AGENC_HOME` turns proposals off instead of falling
    * back to the process user's home.
    */
@@ -584,11 +584,13 @@ function resolveSkillCandidatesHome(
     ?.configStore?.homeContext.path;
   if (typeof storeHome === "string" && storeHome.length > 0) return storeHome;
   const env = deps.env;
-  if (env !== undefined && (env.AGENC_HOME ?? "").trim().length === 0) {
-    return undefined;
-  }
   try {
-    return resolveAgencHome(env ?? process.env);
+    const home = resolveHomeContext(env ?? process.env);
+    // An injected environment that names no home turns proposals off instead
+    // of falling back to the default home; the resolver's provenance says
+    // which, so no code here reads the variable itself.
+    if (env !== undefined && home.isDefault) return undefined;
+    return home.path;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Why

`tests/config/home-state-authority.architecture.test.ts` ("keeps direct AGENC_HOME reads at explicit ingress and isolation boundaries") has failed on every main run of the platform-tests lane today, and it fails in any PR whose affected set includes it, which is how #2215 hit it. The violation is one line in the memory-extraction service: the skill-candidate home helper reads `env.AGENC_HOME` itself to tell an injected environment that names no home from one that does.

## What changed

- `src/services/extractMemories/extractMemories.ts`: `resolveSkillCandidatesHome` asks `resolveHomeContext(env)` for the home and uses its `isDefault` provenance for the same decision, so the behaviour is unchanged (an injected environment without a home still turns proposals off; a real environment still falls back to the default home) and no code outside the sanctioned boundaries reads the variable. The comment that named the old helper follows.

## Evidence

Main's platform-tests lane: failures at 09:26, 09:58, 10:31, 11:33, 12:13, 12:38 and 13:07 today, each naming this test with `services/extractMemories/extractMemories.ts` as the one violation; #2215's affected-tests rerun failed on the same test.

## Tests

`vitest run tests/config/home-state-authority.architecture.test.ts tests/services/extractMemories`: 4 files, 62 tests passing. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

The skill-candidate proposal logic, the extraction cadence, the architecture test's allowlist.

## Counterparts

#2164 and #2151 (where the read arrived), #2215 (blocked by it).
