### PR TITLE
workflow: a goal asked to run in default mode runs its headless children under the workflow default

### DIFF
--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -396,6 +396,22 @@ export class WorkflowIntakeError extends Error {
 
 const DEFAULT_MAX_IMPLEMENT_ATTEMPTS = 2;
 const DEFAULT_PERMISSION_MODE: WorkflowSpec["permissionMode"] = "acceptEdits";
+
+/**
+ * The permission mode a workflow's children run under. A run's children are
+ * headless sessions in the run's worktree: in `default` mode nothing can
+ * approve them, so every edit, write and command is refused and the implement
+ * step dies on the repeat-failure backstop (desktop soak F63, ten minutes and
+ * three dollars for nothing). `default` and an unset mode both become the
+ * workflow's own default; the other modes pass through.
+ */
+export function resolveWorkflowPermissionMode(
+  requested: WorkflowSpec["permissionMode"] | undefined,
+): WorkflowSpec["permissionMode"] {
+  return requested === undefined || requested === "default"
+    ? DEFAULT_PERMISSION_MODE
+    : requested;
+}
 /** Bounded per-stage retry budget for stage-level (non-verdict) failures. */
 const MAX_STAGE_ATTEMPTS = 2;
 const ZERO_ESTIMATE = {
@@ -566,11 +582,16 @@ export class VerifiedChangeWorkflowController {
       );
     }
     const runId = params.runId ?? this.#newRunId();
+    if (params.permissionMode === "default") {
+      this.#deps.warn(
+        `workflow ${runId} was started in default permission mode, which has no approver for its headless children; running it with ${DEFAULT_PERMISSION_MODE}`,
+      );
+    }
     const repo = this.#deps.durability({ runId, repoPath: params.repoPath });
     const journal = await this.#deps.journal.open(runId, {
       repoPath: params.repoPath,
       policy: {
-        permissionMode: params.permissionMode ?? DEFAULT_PERMISSION_MODE,
+        permissionMode: resolveWorkflowPermissionMode(params.permissionMode),
         ...(params.unattendedAllow !== undefined
           ? { unattendedAllow: params.unattendedAllow }
           : {}),
@@ -2492,7 +2513,7 @@ function freezeWorkflowSpec(
     ...(params.model !== undefined ? { model: params.model } : {}),
     ...(params.provider !== undefined ? { provider: params.provider } : {}),
     reviewerModel: resolveReviewerModel(runId, params, daemonDefaultModel),
-    permissionMode: params.permissionMode ?? DEFAULT_PERMISSION_MODE,
+    permissionMode: resolveWorkflowPermissionMode(params.permissionMode),
     ...(params.unattendedAllow !== undefined
       ? { unattendedAllow: params.unattendedAllow }
       : {}),

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  resolveWorkflowPermissionMode,
   VerifiedChangeWorkflowController,
   WorkflowIntakeError,
   type WorkflowAgentSpawner,
@@ -591,6 +592,24 @@ let harness: Harness;
 
 beforeEach(() => {
   harness = makeHarness();
+});
+
+describe("permission mode at start", () => {
+  // Desktop soak F63: a goal started from the app in default mode planned, then
+  // both implement attempts died because no approver existed for the headless
+  // children and every Edit, Write and command was refused.
+  it("runs a default-mode or unset request under the workflow's own default", () => {
+    expect(resolveWorkflowPermissionMode("default")).toBe("acceptEdits");
+    expect(resolveWorkflowPermissionMode(undefined)).toBe("acceptEdits");
+    expect(resolveWorkflowPermissionMode("plan")).toBe("plan");
+    expect(resolveWorkflowPermissionMode("bypassPermissions")).toBe("bypassPermissions");
+  });
+
+  it("warns once when a run asked for default mode, and still completes", async () => {
+    await runToTerminal(harness, { permissionMode: "default" });
+    expect(harness.warnings.filter((w) => /default permission mode/.test(w))).toHaveLength(1);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({ status: "completed" });
+  });
 });
 
 describe("reviewer model resolution at start", () => {


### PR DESCRIPTION
## Why

Soak finding F63. A goal started from the desktop while the composer was in default permission mode planned, then failed both implement attempts: the workflow's children run headless in the run's worktree under the mode the caller passed, and in default mode nothing can approve them, so every Edit, Write and shell call was refused with "no approval resolver is available to allow it" until the repeat-failure backstop ended each attempt. Ten minutes, three dollars, `step_retries_exhausted`. When no mode is passed the workflow already runs its children under accept-edits and they write fine; a caller that names `default` should get the same, since `default` cannot work for a headless child.

## What changed

- `src/app-server/workflow/verified-change-controller.ts`: `resolveWorkflowPermissionMode(requested)` maps `default` and an unset mode to the workflow's own default (`acceptEdits`) and passes `plan`, `acceptEdits` and `bypassPermissions` through; both intake sites (the journal policy and the frozen spec) use it. `start` warns once through the controller's `warn` seam when a caller asked for `default`, naming the run and the mode it runs under instead.
- `tests/workflow/verified-change-controller.test.ts`: the mapping for each mode; a default-mode start completes and leaves exactly one warning.

## Evidence

Soak run `goal-11` (2026-09-06): implement children in the worktree project refused 18 and 12 Edit calls, six Writes each and one exec_command, both turns ended by the repeat-failure backstop, run failed with verify and review never reached. agenc-desktop #192 stops the app from sending `default` for goals; this protects every other client.

## Tests

`vitest run tests/workflow/verified-change-controller.test.ts tests/workflow/daemon-wiring.test.ts`: 35 passed. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

What accept-edits permits (shell commands still need approval; verification is the workflow's own step), the unattended allow and deny lists, the desktop.

## Counterparts

agenc-desktop #192, #2217, soak report addendum to follow.
