### PR TITLE
agents: a stopped turn ends wait_agent at once instead of at the mailbox deadline

### DIFF
--- a/runtime/src/agents/v2/wait.ts
+++ b/runtime/src/agents/v2/wait.ts
@@ -206,9 +206,17 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
         callId: waitCallId,
       },
     });
+    // The executor injects the turn's abort signal; a stopped swarm used to
+    // hold its parent turn open until this wait's deadline (#2201).
+    const abortSignal = (args as { readonly __abortSignal?: AbortSignal })
+      .__abortSignal;
     let mailboxChanged = false;
     try {
-      mailboxChanged = await sessionOrError.waitForMailboxChange(timeoutMs);
+      mailboxChanged = await sessionOrError.waitForMailboxChange(
+        timeoutMs,
+        undefined,
+        abortSignal,
+      );
     } catch (error) {
       emit(sessionOrError, {
         type: "collab_waiting_end",
@@ -237,6 +245,16 @@ export function createWaitAgentTool(opts: MultiAgentV2Options): Tool {
         ...(updates.length > 0 ? { mailboxUpdates: updates } : {}),
       },
     });
+    if (timedOut && abortSignal?.aborted === true) {
+      // The turn was stopped while waiting: return now so the stop lands now,
+      // not at the deadline, and start no timeout streak over it.
+      waitTimeoutStreaks.delete(sessionOrError);
+      return json({
+        message: "Wait interrupted: the turn was stopped.",
+        interrupted: true,
+        timed_out: false,
+      });
+    }
     if (!timedOut) {
       waitTimeoutStreaks.delete(sessionOrError);
       return json({

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -4828,6 +4828,7 @@ export class Session {
   async waitForMailboxChange(
     timeoutMs: number,
     ownership?: IdleInputOwnership,
+    signal?: AbortSignal,
   ): Promise<boolean> {
     if (this.hasPendingInput(ownership)) {
       return true;
@@ -4835,17 +4836,25 @@ export class Session {
     if (this.mailboxSeqWatch.isClosed) {
       return false;
     }
+    // A stopped turn must not sit out the deadline: the wait ends at once and
+    // reports no change, and the caller sees the aborted signal (#2201).
+    if (signal?.aborted === true) {
+      return false;
+    }
     const startSeq = this.mailboxSeqWatch.value;
     return new Promise<boolean>((resolve) => {
       let settled = false;
       let unsubscribe: (() => void) | null = null;
+      const onAbort = (): void => finish(false);
       const finish = (value: boolean): void => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
         unsubscribe?.();
+        signal?.removeEventListener("abort", onAbort);
         resolve(value);
       };
+      signal?.addEventListener("abort", onAbort, { once: true });
       const timer = setTimeout(() => finish(false), timeoutMs);
       const subscription = this.mailboxSeqWatch.subscribe((seq) => {
         if (seq !== startSeq && this.hasPendingInput(ownership)) {

--- a/runtime/tests/agents/v2/wait.test.ts
+++ b/runtime/tests/agents/v2/wait.test.ts
@@ -7,7 +7,9 @@ function fixture(options?: {
   readonly maxConsecutiveWaitTimeouts?: number;
   readonly conversationId?: string;
 }) {
-  const waitForMailboxChange = vi.fn(async (_timeoutMs: number) => false);
+  const waitForMailboxChange = vi.fn(
+    async (_timeoutMs: number, _ownership?: unknown, _signal?: AbortSignal) => false,
+  );
   const emit = vi.fn();
   const session = {
     conversationId: options?.conversationId ?? "root-session",
@@ -97,6 +99,27 @@ describe("wait_agent consecutive timeouts", () => {
     const fifth = await call(tool);
     expect(fifth.isError).toBe(true);
     expect(fifth.body).toMatchObject({ consecutive_timeouts: 5 });
+  });
+
+  it("returns at once when the turn's abort signal fires, and counts no timeout", async () => {
+    // #2201: a stopped swarm held its parent turn open until the wait's deadline.
+    const { tool, waitForMailboxChange } = fixture();
+    const controller = new AbortController();
+    waitForMailboxChange.mockImplementationOnce(async (_timeoutMs, _ownership, signal) => {
+      controller.abort("interrupted");
+      return signal?.aborted === true ? false : true;
+    });
+    const args: Record<string, unknown> = {};
+    Object.defineProperty(args, "__abortSignal", { value: controller.signal, enumerable: false });
+    const interrupted = await call(tool, args);
+    expect(interrupted.body).toMatchObject({ interrupted: true, timed_out: false });
+    expect(waitForMailboxChange).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      undefined,
+      controller.signal,
+    );
+    const next = await call(tool);
+    expect(next.body).toMatchObject({ timed_out: true, consecutive_timeouts: 1 });
   });
 
   it("a completed wait clears the streak", async () => {

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -4555,15 +4555,15 @@ describe("model-facing tools", () => {
 
       const tooSmall = await wait.execute({ timeout_ms: 5_000 });
       expect(tooSmall.isError).toBeUndefined();
-      expect(waitForMailboxChange).toHaveBeenLastCalledWith(10_000);
+      expect(waitForMailboxChange).toHaveBeenLastCalledWith(10_000, undefined, undefined);
 
       const tooLarge = await wait.execute({ timeout_ms: 3_600_001 });
       expect(tooLarge.isError).toBeUndefined();
-      expect(waitForMailboxChange).toHaveBeenLastCalledWith(3_600_000);
+      expect(waitForMailboxChange).toHaveBeenLastCalledWith(3_600_000, undefined, undefined);
 
       const inRange = await wait.execute({ timeout_ms: 45_000 });
       expect(inRange.isError).toBeUndefined();
-      expect(waitForMailboxChange).toHaveBeenLastCalledWith(45_000);
+      expect(waitForMailboxChange).toHaveBeenLastCalledWith(45_000, undefined, undefined);
     } finally {
       _clearAgentControlCacheForTesting(session);
     }
@@ -4654,7 +4654,7 @@ describe("model-facing tools", () => {
       consecutive_timeouts: 1,
       waited_ms: 10_000,
     });
-    expect(waitForMailboxChange).toHaveBeenCalledWith(10_000);
+    expect(waitForMailboxChange).toHaveBeenCalledWith(10_000, undefined, undefined);
   });
 
   it("wait_agent rejects the removed target filter instead of draining unrelated receipts", async () => {
@@ -4708,12 +4708,12 @@ describe("model-facing tools", () => {
     const tooSmall = await wait.execute({ timeout_ms: 100 });
 
     expect(defaulted.isError).toBeUndefined();
-    expect(waitForMailboxChange).toHaveBeenNthCalledWith(1, 1_250);
+    expect(waitForMailboxChange).toHaveBeenNthCalledWith(1, 1_250, undefined, undefined);
     // Out-of-range values clamp to the configured bounds instead of erroring.
     expect(tooLarge.isError).toBeUndefined();
-    expect(waitForMailboxChange).toHaveBeenNthCalledWith(2, 2_000);
+    expect(waitForMailboxChange).toHaveBeenNthCalledWith(2, 2_000, undefined, undefined);
     expect(tooSmall.isError).toBeUndefined();
-    expect(waitForMailboxChange).toHaveBeenNthCalledWith(3, 500);
+    expect(waitForMailboxChange).toHaveBeenNthCalledWith(3, 500, undefined, undefined);
     expect(wait.inputSchema.properties?.timeout_ms).toMatchObject({
       minimum: 500,
       maximum: 2_000,

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -4495,7 +4495,9 @@ describe("model-facing tools", () => {
         message: "Wait completed.",
         timed_out: false,
       });
-      expect(waitForMailboxChange).toHaveBeenCalledWith(30_000);
+      // The wait now also receives the ownership slot and the turn's abort
+      // signal (#2201); neither is set when the executor injected no signal.
+      expect(waitForMailboxChange).toHaveBeenCalledWith(30_000, undefined, undefined);
       expect(control.listAgents).not.toHaveBeenCalled();
       expect(control.subscribeStatus).not.toHaveBeenCalled();
       expect(

--- a/runtime/tests/session/idle-input.test.ts
+++ b/runtime/tests/session/idle-input.test.ts
@@ -246,6 +246,18 @@ describe("Session idle-input → mailbox merge", () => {
     await expect(waiting).resolves.toBe(true);
   });
 
+  it("waitForMailboxChange ends at once on an aborted signal and reports no change", async () => {
+    // #2201: a stopped swarm's parent turn sat out the wait's deadline.
+    const session = buildSession();
+    const early = new AbortController();
+    early.abort("interrupted");
+    await expect(session.waitForMailboxChange(60_000, undefined, early.signal)).resolves.toBe(false);
+    const late = new AbortController();
+    const waiting = session.waitForMailboxChange(60_000, undefined, late.signal);
+    late.abort("interrupted");
+    await expect(waiting).resolves.toBe(false);
+  });
+
   it("waitForMailboxChange does not lose traffic arriving before its sequence snapshot", async () => {
     const session = buildSession();
     const originalHasPending = session.hasPendingInput.bind(session);


### PR DESCRIPTION
## Why

#2201, first proposal. Stopping a swarm from the app left the parent turn active for over a minute and the next prompt was refused with "already has an active turn". The cancel path itself is immediate (a plain streaming turn ends 0.0 s after `run.cancel`); the latency came from `wait_agent`: the parent sits in `waitForMailboxChange` for the model's chosen deadline, and neither the wait nor the tool looked at the turn's abort signal that the executor injects into every tool call. A stop therefore landed only when the wait timed out on its own.

## What changed

- `src/session/session.ts`: `waitForMailboxChange(timeoutMs, ownership?, signal?)` takes an optional abort signal. An already-aborted signal returns `false` at once; a later abort settles the wait with `false` through the same `finish` path, which also removes the listener.
- `src/agents/v2/wait.ts`: `wait_agent` reads the executor-injected `__abortSignal` (a non-enumerable property, so the strict-argument check never sees it) and passes it to the wait. When the wait returns because the signal fired, the tool returns "Wait interrupted: the turn was stopped." with `interrupted: true` and no timeout counted, so the stop lands now and a later wait starts a fresh streak.
- Tests: `tests/agents/v2/wait.test.ts` (the fixture's mock accepts the signal; a fired signal returns at once, is passed through, counts no timeout); `tests/session/idle-input.test.ts` (an aborted signal ends the wait at once, before and during the wait).

## Evidence

Soak finding F57 (`docs/eval/app-soak-2026-09-05.md`): swarm run `swarm-2`, 27 agents fanned out, the stop took over a minute to land while the ticker kept reading "27 agents working"; `soak/cancel-probe.mjs` ended a plain turn 0.0 s after cancel.

## Tests

`vitest run tests/agents/v2/wait.test.ts tests/session/idle-input.test.ts`: all passing including the two new cases. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

How children are cancelled once the parent stops (they still finish cancelling in the background), the "stopping N agents" status line and the prompt queue during a stop (proposals 2 and 3 of #2201), the wait's timeout-streak rule for ordinary timeouts.

## Counterparts

#2201, #2197 (cancel reaches the turn's tasks), #2190.
