### PR TITLE
tools: strict argument checks tolerate every runtime-injected key

### DIFF
--- a/runtime/src/tools/strict-args.ts
+++ b/runtime/src/tools/strict-args.ts
@@ -14,6 +14,18 @@ export interface StrictArgsOptions {
  * tools run before touching anything. Each caller supplies its own refusal
  * shape; the refusal must carry a no-effect disposition (#2190).
  */
+/**
+ * Every key the runtime injects beside the model's arguments carries the
+ * `__agenc` prefix (`__agencSessionId`, `__agencSessionAllowedRoots`, the
+ * signature, the home), plus `__callId`. The executor strips them before
+ * schema validation; a tool's own strict check must tolerate them too, or a
+ * nested `spawn_agent` from a workflow child is refused for a key the model
+ * never wrote (soak F64).
+ */
+export function isRuntimeInjectedArgKey(key: string): boolean {
+  return key === "__callId" || key.startsWith("__agenc");
+}
+
 export function strictArgsRefusal(
   args: Record<string, unknown>,
   opts: StrictArgsOptions,
@@ -21,7 +33,8 @@ export function strictArgsRefusal(
 ): ToolResult | null {
   const allowed = new Set<string>([...opts.allowed, ...opts.injected]);
   for (const key of Object.keys(args)) {
-    if (!allowed.has(key)) return refuse(`unknown field \`${key}\``);
+    if (allowed.has(key) || isRuntimeInjectedArgKey(key)) continue;
+    return refuse(`unknown field \`${key}\``);
   }
   for (const key of opts.required ?? []) {
     const value = args[key];

--- a/runtime/tests/tools/strict-args.test.ts
+++ b/runtime/tests/tools/strict-args.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRuntimeInjectedArgKey,
+  strictArgsRefusal,
+} from "../../src/tools/strict-args.js";
+import type { ToolResult } from "../../src/tools/types.js";
+
+const refuse = (message: string): ToolResult => ({ content: message, isError: true });
+const opts = { allowed: new Set(["name"]), required: ["name"], injected: ["__callId"] };
+
+describe("strict tool arguments", () => {
+  it("tolerates every runtime-injected key, not only the ones a caller lists", () => {
+    // Soak F64: a workflow child's spawn_agent was refused seven times for
+    // `__agencSessionAllowedRoots`, a key the executor injects.
+    expect(
+      strictArgsRefusal(
+        {
+          name: "scanner",
+          __callId: "call-1",
+          __agencSessionId: "s-1",
+          __agencSessionAllowedRoots: ["/repo"],
+          __agencSessionIdSig: "sig",
+          __agencHome: "/home",
+        },
+        opts,
+        refuse,
+      ),
+    ).toBeNull();
+  });
+
+  it("still refuses a field the model invented", () => {
+    expect(strictArgsRefusal({ name: "scanner", bogus: 1 }, opts, refuse)?.content).toBe(
+      "unknown field `bogus`",
+    );
+    expect(strictArgsRefusal({ name: "scanner", __other: 1 }, opts, refuse)?.content).toBe(
+      "unknown field `__other`",
+    );
+  });
+
+  it("enforces required strings, blank or not, as asked", () => {
+    expect(strictArgsRefusal({}, opts, refuse)?.content).toBe("name is required");
+    expect(strictArgsRefusal({ name: "  " }, opts, refuse)?.content).toBe("name is required");
+    expect(strictArgsRefusal({ name: "  " }, { ...opts, allowBlank: true }, refuse)).toBeNull();
+  });
+
+  it("names the injected keys by their prefix", () => {
+    expect(isRuntimeInjectedArgKey("__agencSessionAllowedRoots")).toBe(true);
+    expect(isRuntimeInjectedArgKey("__callId")).toBe(true);
+    expect(isRuntimeInjectedArgKey("__abortSignal")).toBe(false);
+    expect(isRuntimeInjectedArgKey("name")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Soak finding F64. In the goal soak, an implement child called `spawn_agent` and every call was refused with "unknown field `__agencSessionAllowedRoots`", seven times, until the repeat-failure backstop ended the turn with no task completed; the goal needed a second implement attempt. The key is one the executor injects beside the model's arguments (with `__agencSessionId`, the signature and the home), and the executor strips the `__agenc` family before schema validation, but the multi-agent tools' strict check tolerated only `__callId` and the session id, so any nested spawn from a workflow child failed deterministically.

## What changed

- `src/tools/strict-args.ts`: `isRuntimeInjectedArgKey(key)` names the runtime's own convention, `__callId` or any `__agenc`-prefixed key, and `strictArgsRefusal` tolerates those beside the caller's allowlist. Both the Task tools and the multi-agent tools go through it (#2209), so both are covered; a model-invented field, `__other` included, is still refused.
- `tests/tools/strict-args.test.ts` (new): the injected family passes, invented fields are refused, required strings behave as before, and the predicate's edges.

## Evidence

Soak run `goal-12`, run 6 (2026-09-06): implement child `519ad960…`, seven `{"error":"unknown field \`__agencSessionAllowedRoots\`"}` results, then "Turn stopped by the no-progress backstop: the exact spawn_agent call failed 3 times". `src/tools/execution.ts` and `src/tools/router.ts` document the `__agenc*` keys as runtime-injected.

## Tests

`vitest run tests/tools/strict-args.test.ts tests/agents/v2 tests/tools/tasks`: Tests  58 passed (58). `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

Which arguments each tool accepts from the model, the `__abortSignal` property (non-enumerable, never seen by the check), the executor's own stripping.

## Counterparts

#2209 (the shared check), #2219, soak report addendum to follow.
