### PR TITLE
workflow: tell the verifier where scratch files may go

### DIFF
--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -2579,6 +2579,11 @@ function buildVerifyAgentPrompt(
     "You are an ADVERSARIAL verification agent for a proposed code change.",
     "Independently verify the change in the current worktree against the goal.",
     "Re-run spot checks; do not trust the implementer's claims.",
+    // Soak F65: the verifier wrote its fixtures to /tmp and by redirection into
+    // tracked paths, and the sandbox refused both; say where scratch may go.
+    "Write any scratch files or fixtures you need under `tmp/` inside the worktree:",
+    "the sandbox refuses writes outside the workspace (including /tmp) and shell",
+    "redirection into other workspace paths.",
     "",
     "## Goal",
     spec.goal,

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -594,6 +594,16 @@ beforeEach(() => {
   harness = makeHarness();
 });
 
+describe("verifier prompt", () => {
+  it("tells the verifier where scratch files may go", async () => {
+    // Soak F65: a verifier wrote fixtures to /tmp and the sandbox refused them.
+    await runToTerminal(harness);
+    const verify = harness.spawner.spawns.find((spawn) => spawn.kind === "verify_agent");
+    expect(verify?.prompt).toContain("under `tmp/` inside the worktree");
+    expect(verify?.prompt).toContain("refuses writes outside the workspace");
+  });
+});
+
 describe("permission mode at start", () => {
   // Desktop soak F63: a goal started from the app in default mode planned, then
   // both implement attempts died because no approver existed for the headless


### PR DESCRIPTION
## Why

Soak finding F65. The adversarial verifier of a goal run wrote its test fixtures to `/tmp/seed.csv` and, when that was refused, by shell redirection into the worktree; the sandbox refused both (`workspace_write blocked write outside workspace`, `shell_workspace_file_write_disallowed`), the verifier worked around it and the run still ended `verification_failed` after 35 minutes. The refusals are right; the prompt never told the verifier where scratch may go, and the shell policy does allow writes under `tmp/`, `build/`, `dist/`, `logs/`, `.cache/` and `coverage/` inside the workspace.

## What changed

- `src/app-server/workflow/verified-change-controller.ts`: `buildVerifyAgentPrompt` tells the verifier to put scratch files and fixtures under `tmp/` inside the worktree and that the sandbox refuses writes outside the workspace, `/tmp` included, and redirection into other workspace paths.
- `tests/workflow/verified-change-controller.test.ts`: the spawned verifier's prompt carries the guidance.

## Evidence

Soak run `goal-12`, run 6 (2026-09-06): verifier child `6369f15f…`, two `shell_workspace_file_write_disallowed` results and one `sandbox workspace_write blocked write outside workspace: /tmp/seed.csv`; the shell policy's allowlist in `src/llm/shell-write-policy.ts`.

## Tests

`vitest run tests/workflow/verified-change-controller.test.ts`: all passing including the new case. `tsc --noEmit -p tsconfig.json` clean apart from the known TS2883 baseline.

## Not changed

The sandbox policy, the implementer's prompt, the verdict rules.

## Counterparts

The soak report (#2222), #2219, #2217.
