### PR TITLE
daemon status: report a live unbound daemon from its heartbeat instead of indeterminate

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -67,6 +67,17 @@ agenc daemon restart
 agenc daemon stop
 ```
 
+`agenc daemon status` distinguishes three states. `running (pid N)` with uptime
+and memory: the daemon is bound and answering. `alive but not yet bound (pid N)`
+with its last heartbeat: the process is beating but has not published its
+identity record, because it is still starting (recovering its agent runs, which
+takes a while under memory pressure) or the record was removed; lifecycle
+commands wait for the record, and the exit code stays 1 until it appears.
+`stopped`, with the previous daemon's last heartbeat when one was left behind:
+a daemon that vanished without any handler running (an OS SIGKILL, for
+instance) leaves that heartbeat, so the last known pid, memory and event-loop
+lag survive the exit.
+
 Packaging units under `packaging/` (systemd, launchd, Windows service) run
 `agenc daemon start --foreground`.
 

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -56,7 +56,11 @@ import {
   writeDaemonRuntimeInfo,
 } from "./daemon-runtime-info.js";
 import {
+  describeUnboundDaemonHeartbeat,
+  heartbeatAgeSeconds,
   installAgenCDaemonHeartbeat,
+  isDaemonHeartbeatFresh,
+  readAgenCDaemonHeartbeat,
   reportLastDaemonHeartbeat,
   resolveAgenCDaemonHeartbeatPath,
 } from "./daemon-heartbeat.js";
@@ -2134,25 +2138,48 @@ async function statusAgenCDaemon(
         : pidSnapshot !== null && host.isPidRunning(pidSnapshot)
           ? pidSnapshot
           : null;
+    const heartbeatPath = resolveAgenCDaemonHeartbeatPath(
+      resolveAgenCDaemonHome(host.env, host.userHome),
+    );
     if (legacyPid === null) {
       const socketPath = resolveAgenCDaemonSocketPath(host.env, host.userHome);
       if (await canConnectToUnixSocket(socketPath)) {
+        // A daemon that is serving but has not committed its identity yet
+        // (still recovering its agent runs) is beating; say so instead of
+        // leaving the operator with "indeterminate" (#2225).
+        const heartbeat = readAgenCDaemonHeartbeat(heartbeatPath);
+        const nowMs = Date.now();
+        if (
+          heartbeat !== null &&
+          host.isPidRunning(heartbeat.pid) &&
+          isDaemonHeartbeatFresh(heartbeat, nowMs)
+        ) {
+          io.stdout.write(describeUnboundDaemonHeartbeat(heartbeat, nowMs));
+          return 1;
+        }
         io.stderr.write(
           "agenc: daemon control socket is active but no process identity is recorded; status is indeterminate\n",
         );
         return 1;
       }
-      reportLastDaemonHeartbeat(
-        io,
-        resolveAgenCDaemonHeartbeatPath(
-          resolveAgenCDaemonHome(host.env, host.userHome),
-        ),
-        null,
-      );
+      reportLastDaemonHeartbeat(io, heartbeatPath, null);
       io.stdout.write("AgenC daemon stopped\n");
       return 1;
     }
     if ((host.platform ?? process.platform) !== "linux") {
+      const heartbeat = readAgenCDaemonHeartbeat(heartbeatPath);
+      if (heartbeat !== null && heartbeat.pid === legacyPid) {
+        const nowMs = Date.now();
+        if (isDaemonHeartbeatFresh(heartbeat, nowMs)) {
+          io.stdout.write(describeUnboundDaemonHeartbeat(heartbeat, nowMs));
+          return 1;
+        }
+        io.stderr.write(
+          `agenc: daemon status is indeterminate for unbound pid ${legacyPid}; ` +
+            `its last heartbeat is ${heartbeatAgeSeconds(heartbeat, nowMs)} s old (at ${heartbeat.at}), so the process may be hung\n`,
+        );
+        return 1;
+      }
       io.stderr.write(
         `agenc: daemon status is indeterminate for unbound pid ${legacyPid}; no portable instance identity is available\n`,
       );

--- a/runtime/src/app-server/daemon-heartbeat.ts
+++ b/runtime/src/app-server/daemon-heartbeat.ts
@@ -14,6 +14,11 @@ import { writeDurableAtomicFileSync } from "../utils/durable-atomic-file.js";
  */
 export const AGENC_DAEMON_HEARTBEAT_FILENAME = "daemon-heartbeat.json";
 export const AGENC_DAEMON_HEARTBEAT_INTERVAL_MS = 5_000;
+/**
+ * A heartbeat older than this is stale: the process may still exist, but it
+ * has missed several ticks, so `status` must not vouch for it.
+ */
+export const AGENC_DAEMON_HEARTBEAT_FRESH_MS = 3 * AGENC_DAEMON_HEARTBEAT_INTERVAL_MS;
 
 export interface DaemonHeartbeat {
   readonly pid: number;
@@ -112,16 +117,50 @@ export function readAgenCDaemonHeartbeat(path: string): DaemonHeartbeat | null {
   return record as unknown as DaemonHeartbeat;
 }
 
+export function heartbeatAgeSeconds(heartbeat: DaemonHeartbeat, nowMs: number): number {
+  return Math.max(0, Math.round((nowMs - Date.parse(heartbeat.at)) / 1000));
+}
+
+export function isDaemonHeartbeatFresh(heartbeat: DaemonHeartbeat, nowMs: number): boolean {
+  const ageMs = nowMs - Date.parse(heartbeat.at);
+  return ageMs >= 0 ? ageMs <= AGENC_DAEMON_HEARTBEAT_FRESH_MS : true;
+}
+
+function describeUptime(uptimeS: number): string {
+  return uptimeS >= 3600
+    ? `${Math.floor(uptimeS / 3600)} h ${Math.round((uptimeS % 3600) / 60)} min`
+    : `${Math.round(uptimeS / 60)} min`;
+}
+
+/** "rss 600 MB, heap 250 MB, event-loop lag 0 ms, up 27 min" */
+export function describeDaemonHeartbeatVitals(heartbeat: DaemonHeartbeat): string {
+  return (
+    `rss ${heartbeat.rssMb} MB, heap ${heartbeat.heapUsedMb} MB, ` +
+    `event-loop lag ${heartbeat.eventLoopLagMs} ms, up ${describeUptime(heartbeat.uptimeS)}`
+  );
+}
+
 /** One line for the status command: what the daemon last said about itself. */
 export function describeDaemonHeartbeat(heartbeat: DaemonHeartbeat, nowMs: number): string {
-  const ageS = Math.max(0, Math.round((nowMs - Date.parse(heartbeat.at)) / 1000));
-  const uptime =
-    heartbeat.uptimeS >= 3600
-      ? `${Math.floor(heartbeat.uptimeS / 3600)} h ${Math.round((heartbeat.uptimeS % 3600) / 60)} min`
-      : `${Math.round(heartbeat.uptimeS / 60)} min`;
   return (
-    `the last daemon (pid ${heartbeat.pid}) sent its last heartbeat at ${heartbeat.at}, ${ageS} s ago: ` +
-    `rss ${heartbeat.rssMb} MB, heap ${heartbeat.heapUsedMb} MB, event-loop lag ${heartbeat.eventLoopLagMs} ms, up ${uptime}`
+    `the last daemon (pid ${heartbeat.pid}) sent its last heartbeat at ${heartbeat.at}, ` +
+    `${heartbeatAgeSeconds(heartbeat, nowMs)} s ago: ${describeDaemonHeartbeatVitals(heartbeat)}`
+  );
+}
+
+/**
+ * The status lines for a daemon that is alive and beating but has not
+ * published its identity record: it is still starting (recovering its agent
+ * runs, which takes a while under memory pressure) or the record was removed.
+ * Lifecycle commands wait for the record; clients may already be connected.
+ * Without this, `status` could only call such a pid indeterminate (#2225).
+ */
+export function describeUnboundDaemonHeartbeat(heartbeat: DaemonHeartbeat, nowMs: number): string {
+  return (
+    `AgenC daemon alive but not yet bound (pid ${heartbeat.pid})\n` +
+    "  identity: not published yet (still starting, or the runtime record was removed); " +
+    "lifecycle commands wait for it\n" +
+    `  heartbeat: ${heartbeatAgeSeconds(heartbeat, nowMs)} s ago, ${describeDaemonHeartbeatVitals(heartbeat)}\n`
   );
 }
 

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -3022,85 +3022,83 @@ describe("AgenC daemon CLI", () => {
   // #2225: while the replacement daemon recovers its agent runs it is serving
   // but has not committed its identity; the heartbeat proves it is alive, so
   // status says so instead of "indeterminate".
-  function writeHeartbeat(agencHome: string, pid: number, ageMs: number): void {
-    writeFileSync(
-      resolveAgenCDaemonHeartbeatPath(agencHome),
-      JSON.stringify({
-        pid,
-        beat: 45,
-        at: new Date(Date.now() - ageMs).toISOString(),
-        uptimeS: 225,
-        rssMb: 950,
-        heapUsedMb: 700,
-        eventLoopLagMs: 12,
-      }),
-    );
-  }
-
-  it("reports an unbound live pid as alive but not yet bound when its heartbeat is fresh", async () => {
+  async function statusOfUnboundPid(
+    heartbeat: { readonly pid: number; readonly ageMs: number } | null,
+  ): Promise<{
+    readonly code: number;
+    readonly out: string;
+    readonly err: string;
+    readonly terminatedPids: readonly number[];
+    readonly healthProbes: number;
+  }> {
     const agencHome = await tempAgencHome();
     const host = { ...createHost(agencHome), platform: "darwin" as const };
     const io = createIo();
     host.runningPids.add(4602);
     await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4602);
-    writeHeartbeat(agencHome, 4602, 2_000);
+    if (heartbeat !== null) {
+      writeFileSync(
+        resolveAgenCDaemonHeartbeatPath(agencHome),
+        JSON.stringify({
+          pid: heartbeat.pid,
+          beat: 45,
+          at: new Date(Date.now() - heartbeat.ageMs).toISOString(),
+          uptimeS: 225,
+          rssMb: 950,
+          heapUsedMb: 700,
+          eventLoopLagMs: 12,
+        }),
+      );
+    }
     const requestHealthStats = vi.fn(async () => {
       throw new Error("must not probe an unbound pid");
     });
-
-    await expect(
-      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io, requestHealthStats }),
-    ).resolves.toBe(1);
-
-    const out = io.stdoutText();
-    expect(out).toContain("AgenC daemon alive but not yet bound (pid 4602)");
-    expect(out).toContain("identity: not published yet");
-    expect(out).toMatch(/heartbeat: \d+ s ago, rss 950 MB, heap 700 MB, event-loop lag 12 ms, up 4 min/u);
-    expect(out).not.toContain("daemon running");
-    expect(io.stderrText()).not.toContain("indeterminate");
-    expect(requestHealthStats).not.toHaveBeenCalled();
-    expect(host.terminatedPids).toEqual([]);
-
+    const code = await runAgenCDaemonCli(
+      { kind: "command", action: "status" },
+      { host, io, requestHealthStats },
+    );
     await rm(agencHome, { recursive: true, force: true });
+    return {
+      code,
+      out: io.stdoutText(),
+      err: io.stderrText(),
+      terminatedPids: host.terminatedPids,
+      healthProbes: requestHealthStats.mock.calls.length,
+    };
+  }
+
+  it("reports an unbound live pid as alive but not yet bound when its heartbeat is fresh", async () => {
+    const result = await statusOfUnboundPid({ pid: 4602, ageMs: 2_000 });
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("AgenC daemon alive but not yet bound (pid 4602)");
+    expect(result.out).toContain("identity: not published yet");
+    expect(result.out).toMatch(
+      /heartbeat: \d+ s ago, rss 950 MB, heap 700 MB, event-loop lag 12 ms, up 4 min/u,
+    );
+    expect(result.out).not.toContain("daemon running");
+    expect(result.err).not.toContain("indeterminate");
+    expect(result.healthProbes).toBe(0);
+    expect(result.terminatedPids).toEqual([]);
   });
 
   it("keeps an unbound pid indeterminate when its heartbeat is stale, and says how old it is", async () => {
-    const agencHome = await tempAgencHome();
-    const host = { ...createHost(agencHome), platform: "darwin" as const };
-    const io = createIo();
-    host.runningPids.add(4602);
-    await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4602);
-    writeHeartbeat(agencHome, 4602, AGENC_DAEMON_HEARTBEAT_FRESH_MS + 45_000);
-
-    await expect(
-      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io }),
-    ).resolves.toBe(1);
-
-    expect(io.stdoutText()).not.toContain("alive but not yet bound");
-    expect(io.stderrText()).toContain("indeterminate for unbound pid 4602");
-    expect(io.stderrText()).toMatch(/its last heartbeat is \d+ s old .* so the process may be hung/u);
-
-    await rm(agencHome, { recursive: true, force: true });
+    const result = await statusOfUnboundPid({
+      pid: 4602,
+      ageMs: AGENC_DAEMON_HEARTBEAT_FRESH_MS + 45_000,
+    });
+    expect(result.code).toBe(1);
+    expect(result.out).not.toContain("alive but not yet bound");
+    expect(result.err).toContain("indeterminate for unbound pid 4602");
+    expect(result.err).toMatch(/its last heartbeat is \d+ s old .* so the process may be hung/u);
   });
 
   it("does not vouch for an unbound pid on another process's heartbeat", async () => {
-    const agencHome = await tempAgencHome();
-    const host = { ...createHost(agencHome), platform: "darwin" as const };
-    const io = createIo();
-    host.runningPids.add(4602);
-    await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4602);
-    writeHeartbeat(agencHome, 4601, 2_000);
-
-    await expect(
-      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io }),
-    ).resolves.toBe(1);
-
-    expect(io.stdoutText()).not.toContain("alive but not yet bound");
-    expect(io.stderrText()).toContain(
+    const result = await statusOfUnboundPid({ pid: 4601, ageMs: 2_000 });
+    expect(result.code).toBe(1);
+    expect(result.out).not.toContain("alive but not yet bound");
+    expect(result.err).toContain(
       "indeterminate for unbound pid 4602; no portable instance identity is available",
     );
-
-    await rm(agencHome, { recursive: true, force: true });
   });
 
   it("reload targets the authenticated sidecar instead of a live reused pid", async () => {

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -38,6 +38,10 @@ import { AGENC_DAEMON_PROTOCOL_VERSION } from "./protocol/index.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import { ensureAgenCDaemonAutostart } from "./daemon-autostart.js";
 import {
+  AGENC_DAEMON_HEARTBEAT_FRESH_MS,
+  resolveAgenCDaemonHeartbeatPath,
+} from "./daemon-heartbeat.js";
+import {
   AGENC_DAEMON_PID_MAX_BYTES,
   AGENC_DAEMON_READY_TIMEOUT_MS_ENV,
   AGENC_DAEMON_WEBSOCKET_DEFAULT_HOST,
@@ -3011,6 +3015,90 @@ describe("AgenC daemon CLI", () => {
     expect(io.stderrText()).toContain("indeterminate for unbound pid 4602");
     expect(requestHealthStats).not.toHaveBeenCalled();
     expect(host.runningPids.has(4602)).toBe(true);
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  // #2225: while the replacement daemon recovers its agent runs it is serving
+  // but has not committed its identity; the heartbeat proves it is alive, so
+  // status says so instead of "indeterminate".
+  function writeHeartbeat(agencHome: string, pid: number, ageMs: number): void {
+    writeFileSync(
+      resolveAgenCDaemonHeartbeatPath(agencHome),
+      JSON.stringify({
+        pid,
+        beat: 45,
+        at: new Date(Date.now() - ageMs).toISOString(),
+        uptimeS: 225,
+        rssMb: 950,
+        heapUsedMb: 700,
+        eventLoopLagMs: 12,
+      }),
+    );
+  }
+
+  it("reports an unbound live pid as alive but not yet bound when its heartbeat is fresh", async () => {
+    const agencHome = await tempAgencHome();
+    const host = { ...createHost(agencHome), platform: "darwin" as const };
+    const io = createIo();
+    host.runningPids.add(4602);
+    await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4602);
+    writeHeartbeat(agencHome, 4602, 2_000);
+    const requestHealthStats = vi.fn(async () => {
+      throw new Error("must not probe an unbound pid");
+    });
+
+    await expect(
+      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io, requestHealthStats }),
+    ).resolves.toBe(1);
+
+    const out = io.stdoutText();
+    expect(out).toContain("AgenC daemon alive but not yet bound (pid 4602)");
+    expect(out).toContain("identity: not published yet");
+    expect(out).toMatch(/heartbeat: \d+ s ago, rss 950 MB, heap 700 MB, event-loop lag 12 ms, up 4 min/u);
+    expect(out).not.toContain("daemon running");
+    expect(io.stderrText()).not.toContain("indeterminate");
+    expect(requestHealthStats).not.toHaveBeenCalled();
+    expect(host.terminatedPids).toEqual([]);
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("keeps an unbound pid indeterminate when its heartbeat is stale, and says how old it is", async () => {
+    const agencHome = await tempAgencHome();
+    const host = { ...createHost(agencHome), platform: "darwin" as const };
+    const io = createIo();
+    host.runningPids.add(4602);
+    await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4602);
+    writeHeartbeat(agencHome, 4602, AGENC_DAEMON_HEARTBEAT_FRESH_MS + 45_000);
+
+    await expect(
+      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io }),
+    ).resolves.toBe(1);
+
+    expect(io.stdoutText()).not.toContain("alive but not yet bound");
+    expect(io.stderrText()).toContain("indeterminate for unbound pid 4602");
+    expect(io.stderrText()).toMatch(/its last heartbeat is \d+ s old .* so the process may be hung/u);
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("does not vouch for an unbound pid on another process's heartbeat", async () => {
+    const agencHome = await tempAgencHome();
+    const host = { ...createHost(agencHome), platform: "darwin" as const };
+    const io = createIo();
+    host.runningPids.add(4602);
+    await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4602);
+    writeHeartbeat(agencHome, 4601, 2_000);
+
+    await expect(
+      runAgenCDaemonCli({ kind: "command", action: "status" }, { host, io }),
+    ).resolves.toBe(1);
+
+    expect(io.stdoutText()).not.toContain("alive but not yet bound");
+    expect(io.stderrText()).toContain(
+      "indeterminate for unbound pid 4602; no portable instance identity is available",
+    );
 
     await rm(agencHome, { recursive: true, force: true });
   });

--- a/runtime/tests/app-server/daemon-heartbeat.test.ts
+++ b/runtime/tests/app-server/daemon-heartbeat.test.ts
@@ -4,8 +4,11 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  AGENC_DAEMON_HEARTBEAT_FRESH_MS,
   describeDaemonHeartbeat,
+  describeUnboundDaemonHeartbeat,
   installAgenCDaemonHeartbeat,
+  isDaemonHeartbeatFresh,
   readAgenCDaemonHeartbeat,
   reportLastDaemonHeartbeat,
   resolveAgenCDaemonHeartbeatPath,
@@ -35,6 +38,37 @@ afterEach(() => {
 });
 
 describe("daemon heartbeat", () => {
+  // #2225: a daemon that is beating but has not published its identity is
+  // reported as alive and not yet bound, not as indeterminate.
+  it("treats a heartbeat within three intervals as fresh and older ones as stale", () => {
+    const at = "2026-09-06T12:39:00.000Z";
+    const heartbeat = { pid: 149, beat: 45, at, uptimeS: 225, rssMb: 950, heapUsedMb: 700, eventLoopLagMs: 12 };
+    const sent = Date.parse(at);
+    expect(isDaemonHeartbeatFresh(heartbeat, sent)).toBe(true);
+    expect(isDaemonHeartbeatFresh(heartbeat, sent + AGENC_DAEMON_HEARTBEAT_FRESH_MS)).toBe(true);
+    expect(isDaemonHeartbeatFresh(heartbeat, sent + AGENC_DAEMON_HEARTBEAT_FRESH_MS + 1)).toBe(false);
+    // A clock that runs behind the writer must not turn a live daemon stale.
+    expect(isDaemonHeartbeatFresh(heartbeat, sent - 60_000)).toBe(true);
+  });
+
+  it("describes an unbound daemon with its pid, the pending identity and its vitals", () => {
+    const heartbeat = {
+      pid: 149,
+      beat: 45,
+      at: "2026-09-06T12:38:57.000Z",
+      uptimeS: 225,
+      rssMb: 950,
+      heapUsedMb: 700,
+      eventLoopLagMs: 12,
+    };
+    const text = describeUnboundDaemonHeartbeat(heartbeat, Date.parse("2026-09-06T12:39:00.000Z"));
+    expect(text.split("\n").filter(Boolean)).toEqual([
+      "AgenC daemon alive but not yet bound (pid 149)",
+      "  identity: not published yet (still starting, or the runtime record was removed); lifecycle commands wait for it",
+      "  heartbeat: 3 s ago, rss 950 MB, heap 700 MB, event-loop lag 12 ms, up 4 min",
+    ]);
+  });
+
   it("writes a beat at once and on every interval, with pid, memory and lag", () => {
     const dispose = installAgenCDaemonHeartbeat({ path, intervalMs: 1_000, proc });
     try {

--- a/runtime/tests/app-server/daemon-heartbeat.test.ts
+++ b/runtime/tests/app-server/daemon-heartbeat.test.ts
@@ -38,12 +38,22 @@ afterEach(() => {
 });
 
 describe("daemon heartbeat", () => {
+  // #2225: the replacement daemon's heartbeat while it recovers, before its identity is published.
+  const unbound = {
+    pid: 149,
+    beat: 45,
+    at: "2026-09-06T12:38:57.000Z",
+    uptimeS: 225,
+    rssMb: 950,
+    heapUsedMb: 700,
+    eventLoopLagMs: 12,
+  };
+
   // #2225: a daemon that is beating but has not published its identity is
   // reported as alive and not yet bound, not as indeterminate.
   it("treats a heartbeat within three intervals as fresh and older ones as stale", () => {
-    const at = "2026-09-06T12:39:00.000Z";
-    const heartbeat = { pid: 149, beat: 45, at, uptimeS: 225, rssMb: 950, heapUsedMb: 700, eventLoopLagMs: 12 };
-    const sent = Date.parse(at);
+    const sent = Date.parse(unbound.at);
+    const heartbeat = unbound;
     expect(isDaemonHeartbeatFresh(heartbeat, sent)).toBe(true);
     expect(isDaemonHeartbeatFresh(heartbeat, sent + AGENC_DAEMON_HEARTBEAT_FRESH_MS)).toBe(true);
     expect(isDaemonHeartbeatFresh(heartbeat, sent + AGENC_DAEMON_HEARTBEAT_FRESH_MS + 1)).toBe(false);
@@ -52,16 +62,7 @@ describe("daemon heartbeat", () => {
   });
 
   it("describes an unbound daemon with its pid, the pending identity and its vitals", () => {
-    const heartbeat = {
-      pid: 149,
-      beat: 45,
-      at: "2026-09-06T12:38:57.000Z",
-      uptimeS: 225,
-      rssMb: 950,
-      heapUsedMb: 700,
-      eventLoopLagMs: 12,
-    };
-    const text = describeUnboundDaemonHeartbeat(heartbeat, Date.parse("2026-09-06T12:39:00.000Z"));
+    const text = describeUnboundDaemonHeartbeat(unbound, Date.parse("2026-09-06T12:39:00.000Z"));
     expect(text.split("\n").filter(Boolean)).toEqual([
       "AgenC daemon alive but not yet bound (pid 149)",
       "  identity: not published yet (still starting, or the runtime record was removed); lifecycle commands wait for it",


### PR DESCRIPTION
## Why

After the daemon was killed by the OS during the app soak (#2199), the desktop app autostarted a replacement within seconds. That replacement served its websocket and answered the app while it recovered its agent runs, but it commits `daemon-runtime.json` and the final pid only after recovery, at the readiness point. For that whole window, which runs long and heavy under memory pressure, `agenc daemon status` could only say `indeterminate for unbound pid 149`. The heartbeat file from #2216 already proved the pid was alive and beating; `status` did not look at it (#2225).

## What changed

- `runtime/src/app-server/daemon-heartbeat.ts`: `AGENC_DAEMON_HEARTBEAT_FRESH_MS` (three intervals), `heartbeatAgeSeconds`, `isDaemonHeartbeatFresh` (a clock behind the writer never reads as stale), `describeDaemonHeartbeatVitals` (shared by the existing `describeDaemonHeartbeat`, whose output is unchanged) and `describeUnboundDaemonHeartbeat`, the three status lines for a live, unbound daemon.
- `runtime/src/app-server/daemon-cli.ts`, `statusAgenCDaemon`: the heartbeat path is resolved once for the unbound branches. When the pid file names a live pid with no identity record (non-Linux), a fresh heartbeat for that pid prints `AgenC daemon alive but not yet bound (pid N)` with the pending-identity note and the vitals; a stale heartbeat for that pid keeps `indeterminate` and adds how old the last beat is; a heartbeat from another pid changes nothing. When no pid is known but the control socket answers, a fresh heartbeat from a running pid prints the same alive lines. The exit code stays 1 in every unbound case: the daemon is not bound, and scripts that key on `running` keep working.
- `runtime/tests/app-server/daemon-cli.contract.test.ts`: three cases beside the existing unbound-pid test (fresh heartbeat, stale heartbeat, another process's heartbeat).
- `runtime/tests/app-server/daemon-heartbeat.test.ts`: freshness boundaries and the unbound description.
- `docs/reference/daemon.md`: the three states `status` reports and what each means.

## Evidence

| run | result |
| --- | --- |
| `tests/app-server/daemon-heartbeat.test.ts` | 8 passed |
| `tests/app-server/daemon-cli.contract.test.ts -t "unbound\|no process identity\|unrelated live pid\|another process"` (short `TMPDIR`) | 7 passed, 120 skipped |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

The unix-socket status tests need a short `TMPDIR` on macOS (a socket path under a long temp root fails with `listen EINVAL`); they pass with one.

## Tests

The fresh case asserts the alive line, the identity note, the vitals with the fixture's numbers, no `running`, no `indeterminate`, no health probe and no signal. The stale case asserts `indeterminate` plus the age sentence and no alive line. The foreign-heartbeat case asserts the original `indeterminate ... no portable instance identity` message. The unit tests pin the freshness boundary at exactly three intervals, the behind-clock rule, and the exact three lines of the unbound description.

## Not changed

- The readiness commit order in `daemon start`: the identity record is still written after recovery, so lifecycle contenders keep treating the record-less window as pending.
- The Linux branch, which inspects the process and proves the identity.
- Exit codes.

## Counterparts

#2225 (this), #2199 (the kill this window follows), #2216 (the heartbeat file this reads).
