### PR TITLE
daemon status: report the project state databases on disk

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -67,8 +67,8 @@ agenc daemon restart
 agenc daemon stop
 ```
 
-`agenc daemon status` distinguishes three states. `running (pid N)` with uptime
-and memory: the daemon is bound and answering. `alive but not yet bound (pid N)`
+`agenc daemon status` distinguishes three states. `running (pid N)` with uptime,
+memory and the project state databases on disk (count, total, largest): the daemon is bound and answering. `alive but not yet bound (pid N)`
 with its last heartbeat: the process is beating but has not published its
 identity record, because it is still starting (recovering its agent runs, which
 takes a while under memory pressure) or the record was removed; lifecycle

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -23,7 +23,7 @@ import {
 import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection, isIP } from "node:net";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import { resolveHomeContext } from "../config/home.js";
 import {
   AgenCDaemonAgentManager,
@@ -2243,6 +2243,20 @@ async function statusAgenCDaemon(
       // Leave the pid-only line in place; the daemon is up but health.stats
       // is unavailable (older daemon, missing cookie, socket race, timeout).
     }
+    // The project state databases are read from disk, not over the socket, so
+    // their footprint is reported even when health.stats is unavailable. A
+    // database that keeps growing is how a long-lived home gets slow to start
+    // and heavy to recover (#2228); this line makes that growth visible.
+    try {
+      const databasesLine = formatAgenCDaemonStateDatabasesLine(
+        measureAgenCDaemonStateDatabases(
+          resolveAgenCDaemonHome(host.env, host.userHome),
+        ),
+      );
+      if (databasesLine !== null) io.stdout.write(`${databasesLine}\n`);
+    } catch {
+      // A projects directory that cannot be listed is not a status failure.
+    }
     return 0;
   }
   io.stdout.write("AgenC daemon stopped\n");
@@ -2450,6 +2464,60 @@ export function formatAgenCDaemonHealthStatsLines(
     );
   }
   return lines;
+}
+
+export interface AgenCDaemonStateDatabaseFootprint {
+  /** Projects whose state database (plus WAL) occupies any bytes on disk. */
+  readonly projects: number;
+  readonly totalBytes: number;
+  readonly largestBytes: number;
+  /** Project directory name of the largest database, when there is one. */
+  readonly largestProject: string | null;
+}
+
+function fileSizeOrZero(path: string): number {
+  return statSync(path, { throwIfNoEntry: false })?.size ?? 0;
+}
+
+/**
+ * Sum every project's state database and its WAL under `<home>/projects`.
+ * Read from disk so `status` can report it without the daemon's help.
+ */
+export function measureAgenCDaemonStateDatabases(
+  daemonHome: string,
+  sizeOf: (path: string) => number = fileSizeOrZero,
+): AgenCDaemonStateDatabaseFootprint {
+  let projects = 0;
+  let totalBytes = 0;
+  let largestBytes = 0;
+  let largestProject: string | null = null;
+  for (const paths of discoverStateDatabasePaths(daemonHome)) {
+    const bytes =
+      sizeOf(paths.stateDbPath) + sizeOf(`${paths.stateDbPath}-wal`);
+    if (bytes === 0) continue;
+    projects += 1;
+    totalBytes += bytes;
+    if (bytes > largestBytes) {
+      largestBytes = bytes;
+      largestProject = basename(paths.projectDir);
+    }
+  }
+  return { projects, totalBytes, largestBytes, largestProject };
+}
+
+/** The status line for the footprint, or null when no project has a database. */
+export function formatAgenCDaemonStateDatabasesLine(
+  footprint: AgenCDaemonStateDatabaseFootprint,
+): string | null {
+  if (footprint.projects === 0) return null;
+  const largest =
+    footprint.largestProject === null
+      ? ""
+      : ` (largest ${formatDaemonMebibytes(footprint.largestBytes)}: ${footprint.largestProject})`;
+  return (
+    `  databases: ${footprint.projects} project state DB(s), ` +
+    `${formatDaemonMebibytes(footprint.totalBytes)} on disk${largest}`
+  );
 }
 
 function formatDaemonUptime(uptimeMs: number): string {

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -42,6 +42,7 @@ import {
   resolveAgenCDaemonHeartbeatPath,
 } from "./daemon-heartbeat.js";
 import {
+  acquireAgenCDaemonLifecycleLock,
   AGENC_DAEMON_PID_MAX_BYTES,
   AGENC_DAEMON_READY_TIMEOUT_MS_ENV,
   AGENC_DAEMON_WEBSOCKET_DEFAULT_HOST,
@@ -49,27 +50,27 @@ import {
   AGENC_DAEMON_WEBSOCKET_DEFAULT_PORT,
   AGENC_DAEMON_WEBSOCKET_PORT_ENV,
   AgenCDaemonRpcShutdownCoordinator,
-  acquireAgenCDaemonLifecycleLock,
+  createAgenCDaemonRealtimeHeaderResolver,
   DEFAULT_DAEMON_READY_TIMEOUT_MS,
   defaultAgenCDaemonPidPath,
-  resolveAgenCDaemonReadyTimeoutMs,
   ensureAgenCDaemonCookie,
   formatAgenCDaemonCliHelpText,
-  createAgenCDaemonRealtimeHeaderResolver,
+  formatAgenCDaemonStateDatabasesLine,
   parseAgenCDaemonCliArgs,
   readAgenCDaemonPid,
-  resolveAgenCDaemonRealtimeBaseUrl,
-  resolveAgenCDaemonWebSocketListenOptions,
   resolveAgenCDaemonCookiePath,
   resolveAgenCDaemonPidPath,
+  resolveAgenCDaemonReadyTimeoutMs,
+  resolveAgenCDaemonRealtimeBaseUrl,
   resolveAgenCDaemonSnapshotPath,
   resolveAgenCDaemonSocketPath,
+  resolveAgenCDaemonWebSocketListenOptions,
   runAgenCDaemonAuthorityCleanup,
   runAgenCDaemonCli,
-  validateAgenCDaemonWebSocketOrigin,
-  writeAgenCDaemonPid,
   type AgenCDaemonCliHost,
   type AgenCDaemonCliIo,
+  validateAgenCDaemonWebSocketOrigin,
+  writeAgenCDaemonPid,
 } from "./daemon-cli.js";
 import {
   AgenCDelegateBackgroundAgentRunner,
@@ -1481,6 +1482,73 @@ describe("AgenC daemon CLI", () => {
     } finally {
       await rm(agencHome, { recursive: true, force: true });
     }
+  });
+
+  // #2228: the project state databases on disk are part of status, so a home
+  // whose database keeps growing shows it before every start gets slow.
+  it("status reports the project state databases on disk", async () => {
+    const agencHome = await tempAgencHome();
+    // Pin the Linux branch so the pid is proven by the injected inspector on
+    // every host; off Linux an unbound pid is indeterminate by design.
+    const host = { ...createHost(agencHome), platform: "linux" as const };
+    const io = createIo();
+    host.runningPids.add(4555);
+    await writeAgenCDaemonPid(resolveAgenCDaemonPidPath(host.env, host.userHome), 4555);
+    const projects = join(agencHome, "projects");
+    for (const name of ["alpha", "beta", "empty"]) {
+      await mkdir(join(projects, name), { recursive: true });
+    }
+    const mebibyte = 1024 * 1024;
+    await writeFile(join(projects, "alpha", "agenc-state_1.sqlite"), Buffer.alloc(3 * mebibyte));
+    await writeFile(join(projects, "alpha", "agenc-state_1.sqlite-wal"), Buffer.alloc(mebibyte));
+    await writeFile(join(projects, "beta", "agenc-state_1.sqlite"), Buffer.alloc(mebibyte));
+
+    await expect(
+      runAgenCDaemonCli(
+        { kind: "command", action: "status" },
+        {
+          host,
+          io,
+          // The footprint comes from disk, so it is reported even when
+          // health.stats is unavailable.
+          requestHealthStats: vi.fn(async () => {
+            throw new Error("health.stats unavailable");
+          }),
+          inspectLegacyDaemonProcess: inspectLegacyTestDaemon,
+          waitForDaemonReady: async () => true,
+        },
+      ),
+    ).resolves.toBe(0);
+
+    const out = io.stdoutText();
+    expect(out).toContain("AgenC daemon running (pid 4555)");
+    expect(out).toMatch(
+      /databases: \d+ project state DB\(s\), [\d.]+ MiB on disk \(largest 4\.0 MiB: alpha\)/u,
+    );
+    expect(out).not.toContain("uptime:");
+
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
+  it("omits the databases line when no project has a state database", () => {
+    expect(
+      formatAgenCDaemonStateDatabasesLine({
+        projects: 0,
+        totalBytes: 0,
+        largestBytes: 0,
+        largestProject: null,
+      }),
+    ).toBeNull();
+    expect(
+      formatAgenCDaemonStateDatabasesLine({
+        projects: 196,
+        totalBytes: 1_235_812_352,
+        largestBytes: 693_108_736,
+        largestProject: "Users-tetsuoarena-claude-agenc-work-be0c0dda",
+      }),
+    ).toBe(
+      "  databases: 196 project state DB(s), 1178.6 MiB on disk (largest 661.0 MiB: Users-tetsuoarena-claude-agenc-work-be0c0dda)",
+    );
   });
 
   it("status enriches the running line with health.stats over the socket", async () => {


### PR DESCRIPTION
## Why

The soak home's main project reached a 693 MB state database in two days without anything showing it (#2228). Growth of that kind is what makes a long-lived home slow to start and heavy to recover, and `agenc daemon status` is the place a user looks. It reported uptime, memory and counts, but nothing about the databases on disk.

## What changed

- `runtime/src/app-server/daemon-cli.ts`: `measureAgenCDaemonStateDatabases(daemonHome, sizeOf?)` sums each project's `agenc-state_1.sqlite` plus its WAL under `<home>/projects` (projects without a database are not counted) and tracks the largest; `formatAgenCDaemonStateDatabasesLine(footprint)` renders `  databases: N project state DB(s), X MiB on disk (largest Y MiB: <project dir>)` or null when there is nothing to report. The running branch of `status` prints the line after the health lines. It is read from disk, so it appears even when `health.stats` is unavailable, and a projects directory that cannot be listed leaves status unchanged.
- `runtime/tests/app-server/daemon-cli.contract.test.ts`: a status case with three project directories (4 MiB with WAL, 1 MiB, empty) asserting the line and that it prints without `health.stats`; a formatter case for the null footprint and the soak home's own numbers.
- `docs/reference/daemon.md`: the running state now lists the databases line.

## Evidence

| run | result |
| --- | --- |
| `daemon-cli.contract.test.ts -t "state databases\|databases line"` (short `TMPDIR`) | 2 passed |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

The new status case pins `platform: "linux"` so the injected inspector proves the pid on any host; the existing running-branch test has no platform and fails on macOS on the unpatched tree too (an unbound pid is indeterminate off Linux by design), which is why it is red here and green in CI.

## Tests

The disk case writes real files of known sizes and matches the rendered MiB values and the largest project's name; the formatter case pins the exact line for 196 projects, 1178.6 MiB, largest 661.0 MiB, and the null case.

## Not changed

- `formatAgenCDaemonHealthStatsLines` and its lines.
- The daemon's own health stats; nothing new crosses the socket.
- Retention; this is visibility only (#2228 keeps the retention fixes).

## Counterparts

#2228 (suggested fix 3), #2226 (the previous status change).
