### PR TITLE
sdk: a failed daemon autostart carries the CLI's last stderr lines

### DIFF
--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -70,7 +70,7 @@ await client.close();
 - Local endpoint: `${AGENC_HOME:-~/.agenc}/daemon.sock` on Unix; a stable per-home named pipe on Windows
 - Cookie: `${AGENC_HOME:-~/.agenc}/daemon.cookie` (first message must be `initialize` with `authCookie`; `connect()` handles this)
 - Plugin storage: `createSession()` requires an exact absolute `pluginStorageRoot` of at most 4096 UTF-8 bytes, with no surrounding whitespace. `AgencClient` does not reread `AGENC_PLUGIN_CACHE_DIR`, derive a root from `AGENC_HOME`, or accept `agentId`; use `attachAgent()` for an existing agent.
-- Autostart: runs `agenc daemon start` when the socket is down (disable with `autostart: false`)
+- Autostart: runs `agenc daemon start` when the socket is down (disable with `autostart: false`); when that start fails, the error carries the CLI's exit code and its last stderr lines
 - Hook authority: `createSession()` sends `allowUntrustedHooks: false`. A caller using `spawnAgent()` must send complete runtime options and may set the field to `true` only after vetting the workspace. It permits command effects only and cannot override `simpleMode` hook suppression.
 - Home authority: `AGENC_HOME` must be absolute and is canonicalized before daemon paths are derived. Explicit socket and cookie paths do not bypass home-authority validation.
 

--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -320,12 +320,35 @@ export type AgencSpawnFn = (
   args: readonly string[],
   options: {
     readonly env: NodeJS.ProcessEnv;
-    readonly stdio: "ignore";
+    /** stdin and stdout are discarded; stderr is piped so a failed start can say why. */
+    readonly stdio: "ignore" | readonly ["ignore", "ignore", "pipe"];
   },
 ) => {
   once(event: "exit", listener: (code: number | null) => void): unknown;
   once(event: "error", listener: (error: Error) => void): unknown;
+  /** Present when stderr is piped; absent or null spawners keep the bare exit message. */
+  readonly stderr?: {
+    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+  } | null;
 };
+
+/** How much of the CLI's stderr a failed daemon start carries into its error. */
+const DAEMON_START_STDERR_TAIL_BYTES = 2_048;
+
+/**
+ * Keep the last bytes the daemon CLI wrote to stderr, and render them as the
+ * last non-empty lines, so "exited with code 1" says what the CLI said (for
+ * example that an unbound daemon cannot be signalled on this platform).
+ */
+export function describeDaemonStartStderr(chunks: readonly string[]): string {
+  const tail = chunks.join("").slice(-DAEMON_START_STDERR_TAIL_BYTES);
+  const lines = tail
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(-3);
+  return lines.length === 0 ? "" : `: ${lines.join(" | ")}`;
+}
 
 export interface AgencConnectOptions {
   readonly env?: NodeJS.ProcessEnv;
@@ -474,11 +497,31 @@ function startDaemonViaCli(
   }
   const spawner: AgencSpawnFn =
     spawnFn ??
-    ((cmd, args, spawnOptions) => nodeSpawn(cmd, [...args], spawnOptions));
+    ((cmd, args, spawnOptions) =>
+      nodeSpawn(cmd, [...args], {
+        env: spawnOptions.env,
+        // Node wants a mutable stdio array; the option type is readonly.
+        stdio:
+          spawnOptions.stdio === "ignore" ? "ignore" : [...spawnOptions.stdio],
+      }));
   return new Promise((resolve, reject) => {
     const child = spawner(executable, [...prefixArgs, "daemon", "start"], {
       env,
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrChunks: string[] = [];
+    let stderrBytes = 0;
+    child.stderr?.on("data", (chunk) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      stderrChunks.push(text);
+      stderrBytes += text.length;
+      // Bound the buffer: drop whole leading chunks once the tail is covered.
+      while (
+        stderrChunks.length > 1 &&
+        stderrBytes - stderrChunks[0].length >= DAEMON_START_STDERR_TAIL_BYTES
+      ) {
+        stderrBytes -= stderrChunks.shift()!.length;
+      }
     });
     child.once("error", (error: Error) => {
       reject(
@@ -492,7 +535,8 @@ function startDaemonViaCli(
       }
       reject(
         new Error(
-          `AgenC daemon start exited with code ${code ?? "null"} (command: ${executable})`,
+          `AgenC daemon start exited with code ${code ?? "null"} (command: ${executable})` +
+            describeDaemonStartStderr(stderrChunks),
         ),
       );
     });

--- a/runtime/tests/sdk-package/socket-autostart-stderr.test.ts
+++ b/runtime/tests/sdk-package/socket-autostart-stderr.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  type AgencSpawnFn,
+  connect,
+  describeDaemonStartStderr,
+} from "../../../packages/agenc-sdk/src/socket.js";
+
+// A daemon start that fails used to surface only its exit code; the CLI's
+// reason went to a discarded stderr. The soak saw six "exited with code 1"
+// in a row while the CLI was saying an unbound daemon cannot be signalled.
+
+interface SpawnCall {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly stdio: unknown;
+}
+
+function fakeSpawner(
+  stderrText: string | null,
+  code: number,
+): { readonly spawn: AgencSpawnFn; readonly calls: SpawnCall[] } {
+  const calls: SpawnCall[] = [];
+  const spawn: AgencSpawnFn = (command, args, options) => {
+    calls.push({ command, args, stdio: options.stdio });
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: EventEmitter | null;
+    };
+    child.stderr = stderrText === null ? null : new EventEmitter();
+    setImmediate(() => {
+      if (stderrText !== null) child.stderr?.emit("data", Buffer.from(stderrText));
+      child.emit("exit", code);
+    });
+    return child;
+  };
+  return { spawn, calls };
+}
+
+describe("daemon autostart failure carries the CLI's stderr", () => {
+  let home = "";
+  afterEach(() => {
+    if (home !== "") rmSync(home, { recursive: true, force: true });
+  });
+
+  it("appends the last stderr lines to the exit error and pipes only stderr", async () => {
+    home = mkdtempSync(join(tmpdir(), "agenc-sdk-autostart-"));
+    const { spawn, calls } = fakeSpawner(
+      "agenc: daemon status is indeterminate for unbound pid 149\n" +
+        "agenc: an unbound daemon cannot be signalled on this platform\n",
+      1,
+    );
+    await expect(
+      connect({
+        env: { AGENC_HOME: home },
+        autostart: true,
+        agencCommand: "fake-agenc",
+        spawn,
+        readyTimeoutMs: 500,
+      }),
+    ).rejects.toThrow(
+      "AgenC daemon start exited with code 1 (command: fake-agenc): " +
+        "agenc: daemon status is indeterminate for unbound pid 149 | " +
+        "agenc: an unbound daemon cannot be signalled on this platform",
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toEqual(["daemon", "start"]);
+    expect(calls[0]?.stdio).toEqual(["ignore", "ignore", "pipe"]);
+  });
+
+  it("keeps the bare exit message when the spawner pipes no stderr", async () => {
+    home = mkdtempSync(join(tmpdir(), "agenc-sdk-autostart-"));
+    const { spawn } = fakeSpawner(null, 2);
+    await expect(
+      connect({
+        env: { AGENC_HOME: home },
+        autostart: true,
+        agencCommand: "fake-agenc",
+        spawn,
+        readyTimeoutMs: 500,
+      }),
+    ).rejects.toThrow(/exited with code 2 \(command: fake-agenc\)$/u);
+  });
+
+  it("renders at most the last three non-empty lines of the tail", () => {
+    expect(describeDaemonStartStderr([])).toBe("");
+    expect(describeDaemonStartStderr(["\n  \n"])).toBe("");
+    expect(describeDaemonStartStderr(["a\n", "b\n", "c\n", "d\n"])).toBe(": b | c | d");
+    expect(describeDaemonStartStderr(["x".repeat(5000) + "\nlast line\n"])).toMatch(
+      /^: x+ \| last line$/u,
+    );
+  });
+});


### PR DESCRIPTION
## Why

When the SDK's autostart spawns `agenc daemon start` and the CLI fails, the caller sees `AgenC daemon start exited with code 1 (command: ...)` and nothing else: the child is spawned with `stdio: "ignore"`, so the reason the CLI printed is thrown away. In the app soak that turned a nine-minute outage into a mystery: the desktop logged six of those lines in a row while the CLI was saying `an unbound daemon cannot be signalled on this platform` (#2232). The error should carry what the CLI said.

## What changed

- `packages/agenc-sdk/README.md`: the autostart bullet says the error carries the exit code and the last stderr lines.
- `packages/agenc-sdk/src/socket.ts`: the daemon start child is spawned with `stdio: ["ignore", "ignore", "pipe"]`; the last 2 KB of its stderr are kept in a bounded buffer and, on a non-zero exit, the last three non-empty lines are appended to the error after the unchanged prefix, joined by ` | `. `describeDaemonStartStderr` is the exported pure renderer. `AgencSpawnFn`'s option type widens `stdio` to `"ignore" | readonly ["ignore", "ignore", "pipe"]` and the returned child may expose `stderr`; a custom spawner without `stderr` keeps the bare message, so existing spawners still type-check and behave as before. The default spawner copies the readonly tuple into the mutable array Node's `spawn` wants.
- `runtime/tests/sdk-package/socket-autostart-stderr.test.ts` (new): a fake spawner that writes two stderr lines and exits 1 yields the message with both lines and receives the piped stdio; a spawner with no stderr yields the bare message; the renderer keeps at most the last three non-empty lines of the 2 KB tail and renders nothing for empty output.

## Evidence

| run | result |
| --- | --- |
| `tests/sdk-package/socket-autostart-stderr.test.ts` | 3 passed |
| `tests/sdk-package` (whole directory, 15 files) | 124 passed, 1 failed: `protocol-drift.contract.test.ts` "mirrors the runtime local endpoint" expects `/tmp/...` and gets `/private/tmp/...`; it fails identically on the unpatched tree on this macOS host (realpath baseline), green in CI |
| `tsc --noEmit -p packages/agenc-sdk/tsconfig.json` | clean |

## Tests

The first case asserts the exact composed message, the `["daemon", "start"]` arguments and the `["ignore", "ignore", "pipe"]` stdio; the second asserts the message ends at the command with no trailing separator; the third pins the renderer's line cap, whitespace handling and tail cut.

## Not changed

- The readiness polling, the timeout, and the success path.
- `dist` is not tracked; consumers build from source.
- The desktop's hand-vendored copy of this module (`src/vendor/agenc-sdk/socket.ts`) needs the same change to benefit; that is agenc-desktop #194.

## Counterparts

agenc-desktop #194 (the vendored mirror), #2232 (the outage this would have explained at once), #2199.
