### PR TITLE
daemon: a cancelled startup bounds its cleanup; macOS autostart waits for a beating unbound daemon to exit

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -30,7 +30,10 @@ Further restarts wait 250 ms, then 1 s, then 4 s. After the cap it throws
 opens the TUI and shows the `daemon-autostart-failed` status notice. Background
 agents and reconnectable sessions stay unavailable until `agenc daemon start`
 succeeds. Inspect with `agenc daemon status`; stop a wedged process with
-`agenc daemon stop`.
+`agenc daemon stop`. Off Linux an unbound daemon is never signalled; if its
+heartbeat is fresh (still starting, or leaving after a cancelled startup),
+autostart waits up to 30 s for it to exit before refusing. A daemon whose
+startup was cancelled bounds each cleanup task to 5 s so it cannot linger.
 
 Ready-wait timeout for clients that start the daemon
 (`AGENC_DAEMON_READY_TIMEOUT_MS`):

--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -34,6 +34,11 @@ import {
   resolveRuntimePackageRootFromUrl,
 } from "./daemon-runtime-info.js";
 import {
+  isDaemonHeartbeatFresh,
+  readAgenCDaemonHeartbeat,
+  resolveAgenCDaemonHeartbeatPath,
+} from "./daemon-heartbeat.js";
+import {
   findLinuxAgenCDaemonProcesses,
   inspectLinuxAgenCDaemonProcess,
   readAgenCDaemonProcessStart,
@@ -69,6 +74,12 @@ const AGENC_DAEMON_BUILD_SKEW_STOP_TIMEOUT_MS = 5_000;
 const AGENC_DAEMON_ORPHAN_STOP_TIMEOUT_MS = 1_000;
 const AGENC_DAEMON_FORCE_STOP_GRACE_MS = 2_000;
 const AGENC_DAEMON_STOP_POLL_MS = 50;
+/**
+ * Off Linux an unbound daemon is never signalled; a beating one is given this
+ * long to exit on its own (a cancelled startup leaving, #2232) before the
+ * refusal stands.
+ */
+const AGENC_DAEMON_UNBOUND_EXIT_WAIT_MS = 30_000;
 /**
  * Restart-cycle bound for the two self-restart paths (legacy identity-less
  * daemon, build-identity skew). When the condition that forced a restart is a
@@ -155,6 +166,8 @@ export interface AgenCDaemonAutostartOptions {
     targetHome: string,
   ) => Promise<readonly number[]> | readonly number[];
   readonly terminateOrphanDaemonPid?: (pid: number) => Promise<void> | void;
+  /** How long to wait for a beating unbound daemon to exit off Linux; test seam. */
+  readonly unboundDaemonExitWaitMs?: number;
   readonly inspectLegacyDaemonProcess?: (
     pid: number,
   ) =>
@@ -816,6 +829,16 @@ async function terminatePidlessAgenCDaemonPid(
   options: AgenCDaemonAutostartOptions,
 ): Promise<void> {
   if (hostPlatform(host) !== "linux") {
+    if (
+      await waitForBeatingUnboundDaemonToExit(
+        identity,
+        daemonHome,
+        host,
+        options,
+      )
+    ) {
+      return;
+    }
     throw instanceProofFailed(
       identity.pid,
       "an unbound daemon cannot be signalled on this platform",
@@ -856,6 +879,42 @@ async function terminatePidlessAgenCDaemonPid(
     options,
     AGENC_DAEMON_ORPHAN_STOP_TIMEOUT_MS,
   );
+}
+
+/**
+ * A daemon that is unbound yet beating is alive on purpose: still starting,
+ * or leaving after a cancelled startup. Off Linux it cannot be signalled, so
+ * instead of refusing at once, wait a bounded time for it to exit; that turns
+ * the minutes of "cannot be signalled" retries of #2232 into seconds. A stale
+ * heartbeat (hung), one that keeps beating past the budget, or a pid that is
+ * still running at the end keeps the original refusal. A daemon that binds
+ * meanwhile is left for the next connect to adopt.
+ */
+async function waitForBeatingUnboundDaemonToExit(
+  identity: AgenCDaemonProcessIdentity,
+  daemonHome: string,
+  host: AgenCDaemonAutostartHost,
+  options: AgenCDaemonAutostartOptions,
+): Promise<boolean> {
+  const heartbeatPath = resolveAgenCDaemonHeartbeatPath(daemonHome);
+  const beating = (): boolean => {
+    const heartbeat = readAgenCDaemonHeartbeat(heartbeatPath);
+    return (
+      heartbeat !== null &&
+      heartbeat.pid === identity.pid &&
+      isDaemonHeartbeatFresh(heartbeat, Date.now())
+    );
+  };
+  if (!beating()) return false;
+  const deadline =
+    Date.now() +
+    (options.unboundDaemonExitWaitMs ?? AGENC_DAEMON_UNBOUND_EXIT_WAIT_MS);
+  while (Date.now() < deadline) {
+    if (!host.isPidRunning(identity.pid)) return true;
+    if (!beating()) return false;
+    await host.sleep(AGENC_DAEMON_STOP_POLL_MS);
+  }
+  return !host.isPidRunning(identity.pid);
 }
 
 async function terminateAgenCDaemonPid(

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -331,6 +331,11 @@ const DEFAULT_DAEMON_WEBSOCKET_URL = new URL(
 // ceiling. Startup cancellation checkpoints bracket that query and every
 // other slow phase, so the parent allowance includes bounded cleanup margin.
 const AGENC_DAEMON_STARTUP_CANCELLATION_TIMEOUT_MS = 60_000;
+// A daemon whose startup was cancelled has served nobody, so its cleanup only
+// has to be safe, not complete: each task gets this long before the run moves
+// on. Without the bound one hung task kept a cancelled daemon alive for eight
+// minutes while every autostart refused to replace it (#2232).
+const AGENC_DAEMON_STARTUP_CANCEL_CLEANUP_TASK_TIMEOUT_MS = 5_000;
 export const AGENC_DAEMON_WEBSOCKET_DEFAULT_HOST =
   DEFAULT_DAEMON_WEBSOCKET_URL.hostname;
 export const AGENC_DAEMON_WEBSOCKET_DEFAULT_PORT = Number(
@@ -392,6 +397,8 @@ export interface RunAgenCDaemonCliOptions {
   readonly beforeDaemonReloadAdoption?: () => void | Promise<void>;
   /** @internal Deterministic lifecycle-cleanup interposition test seam. */
   readonly beforeDaemonAuthorityCleanup?: () => void | Promise<void>;
+  /** Test seam: per-task bound for the cleanup of a cancelled startup. */
+  readonly startupCancelCleanupTaskTimeoutMs?: number;
   readonly runner?: AgenCBackgroundAgentRunner;
   readonly nativePeerCredentialBinding?: AgenCNativePeerCredentialBinding;
   readonly nativePeerCredentialAddonPath?: string;
@@ -1061,6 +1068,7 @@ async function runAgenCDaemonAction(
         beforeDaemonReady: options.beforeDaemonReady,
         beforeDaemonReloadAdoption: options.beforeDaemonReloadAdoption,
         beforeDaemonAuthorityCleanup: options.beforeDaemonAuthorityCleanup,
+        startupCancelCleanupTaskTimeoutMs: options.startupCancelCleanupTaskTimeoutMs,
         runner: options.runner,
         nativePeerCredentialBinding: options.nativePeerCredentialBinding,
         nativePeerCredentialAddonPath: options.nativePeerCredentialAddonPath,
@@ -2829,6 +2837,7 @@ async function runAgenCDaemonForeground(
     readonly beforeDaemonReady?: () => void | Promise<void>;
     readonly beforeDaemonReloadAdoption?: () => void | Promise<void>;
     readonly beforeDaemonAuthorityCleanup?: () => void | Promise<void>;
+    readonly startupCancelCleanupTaskTimeoutMs?: number;
     readonly runner?: AgenCBackgroundAgentRunner;
     readonly nativePeerCredentialBinding?: AgenCNativePeerCredentialBinding;
     readonly nativePeerCredentialAddonPath?: string;
@@ -2903,6 +2912,7 @@ async function runAgenCDaemonForegroundLocked(
     readonly beforeDaemonReady?: () => void | Promise<void>;
     readonly beforeDaemonReloadAdoption?: () => void | Promise<void>;
     readonly beforeDaemonAuthorityCleanup?: () => void | Promise<void>;
+    readonly startupCancelCleanupTaskTimeoutMs?: number;
     readonly runner?: AgenCBackgroundAgentRunner;
     readonly nativePeerCredentialBinding?: AgenCNativePeerCredentialBinding;
     readonly nativePeerCredentialAddonPath?: string;
@@ -3306,6 +3316,7 @@ async function runAgenCDaemonForegroundLocked(
       cleanup.register("daemon-heartbeat", disposeHeartbeat);
     }
     let shuttingDown = false;
+    let startupCancelled = false;
     let resolveRpcShutdown!: () => void;
     const rpcShutdownCompleted = new Promise<void>((resolve) => {
       resolveRpcShutdown = resolve;
@@ -4053,7 +4064,8 @@ async function runAgenCDaemonForegroundLocked(
         exitCode = 1;
       } else {
         cleanupContext = { reason: "daemon_shutdown" };
-        exitCode = termination.kind === "startup_cancel" ? 1 : 0;
+        startupCancelled = termination.kind === "startup_cancel";
+        exitCode = startupCancelled ? 1 : 0;
       }
     } finally {
       shuttingDown = true;
@@ -4061,7 +4073,16 @@ async function runAgenCDaemonForegroundLocked(
       // Any reload admitted before the ingress fence must either finish or
       // reject its prepared resources before MCP/socket cleanup begins.
       await reloadChain.catch(() => null);
-      const results = await cleanup.run(cleanupContext);
+      const results = await cleanup.run(
+        cleanupContext,
+        startupCancelled
+          ? {
+              taskTimeoutMs:
+                options.startupCancelCleanupTaskTimeoutMs ??
+                AGENC_DAEMON_STARTUP_CANCEL_CLEANUP_TASK_TIMEOUT_MS,
+            }
+          : {},
+      );
       cleanupHandled = true;
       const failed = results.filter((result) => !result.ok);
       if (failed.length > 0) {

--- a/runtime/src/lifecycle/cleanup-registry.ts
+++ b/runtime/src/lifecycle/cleanup-registry.ts
@@ -28,6 +28,49 @@ export interface AgenCCleanupResult {
   readonly error?: unknown;
 }
 
+export interface AgenCCleanupRunOptions {
+  /**
+   * When set, a task that has not settled within this many milliseconds is
+   * recorded as failed with a timeout error and the run moves on to the next
+   * task, instead of waiting on it forever. A cancelled daemon startup uses
+   * this so a hung cleanup cannot keep the process alive for minutes (#2232).
+   */
+  readonly taskTimeoutMs?: number;
+}
+
+export class AgenCCleanupTimeoutError extends Error {
+  constructor(name: string, timeoutMs: number) {
+    super(`cleanup task "${name}" did not finish within ${timeoutMs} ms`);
+    this.name = "AgenCCleanupTimeoutError";
+  }
+}
+
+async function runCleanupTaskWithin(
+  task: AgenCCleanupTask,
+  context: AgenCCleanupContext,
+  name: string,
+  timeoutMs: number | undefined,
+): Promise<void> {
+  if (timeoutMs === undefined) {
+    await task(context);
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => task(context)),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new AgenCCleanupTimeoutError(name, timeoutMs)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export type AgenCCleanupTask = (
   context: AgenCCleanupContext,
 ) => void | Promise<void>;
@@ -53,22 +96,24 @@ export class AgenCCleanupRegistry {
 
   async run(
     context: AgenCCleanupContext,
+    options: AgenCCleanupRunOptions = {},
   ): Promise<readonly AgenCCleanupResult[]> {
     if (this.#completed !== null) return this.#completed;
     if (this.#running !== null) return this.#running;
-    this.#running = this.#runOnce(context);
+    this.#running = this.#runOnce(context, options);
     this.#completed = await this.#running;
     return this.#completed;
   }
 
   async #runOnce(
     context: AgenCCleanupContext,
+    options: AgenCCleanupRunOptions,
   ): Promise<readonly AgenCCleanupResult[]> {
     const results: AgenCCleanupResult[] = [];
     const tasks = [...this.#tasks.entries()].reverse();
     for (const [name, task] of tasks) {
       try {
-        await task(context);
+        await runCleanupTaskWithin(task, context, name, options.taskTimeoutMs);
         results.push({ name, ok: true });
       } catch (error) {
         results.push({ name, ok: false, error });

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -15,6 +15,7 @@ import {
   resolveAgenCDaemonAutostartConfig,
   shouldAutostartAgenCDaemon,
 } from "./daemon-autostart.js";
+import { resolveAgenCDaemonHeartbeatPath } from "./daemon-heartbeat.js";
 import {
   acquireAgenCDaemonLifecycleLock,
   DEFAULT_DAEMON_READY_TIMEOUT_MS,
@@ -1139,6 +1140,103 @@ autostart = true
       expect(host.spawnedPids).toEqual([]);
     } finally {
       await rm(agencHome, { recursive: true, force: true });
+    }
+  });
+
+  // #2232: an unbound daemon off Linux is never signalled, but one that is
+  // beating (still starting, or leaving after a cancelled startup) is given a
+  // bounded chance to exit before the refusal stands.
+  async function beatingOrphanScenario(params: {
+    readonly heartbeatAgeMs: number;
+    readonly exitsAfterPolls: number | null;
+    readonly waitMs: number;
+  }): Promise<{
+    readonly outcome: PromiseSettledResult<unknown>;
+    readonly signals: NodeJS.Signals[];
+    readonly spawned: number[];
+    readonly cleanup: () => Promise<void>;
+  }> {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const orphanPid = 5320;
+    host.platform = "darwin";
+    host.runningPids.add(orphanPid);
+    const signals: NodeJS.Signals[] = [];
+    host.terminatePid = (_pid, signal = "SIGTERM") => {
+      signals.push(signal);
+    };
+    let polls = 0;
+    const isPidRunning = host.isPidRunning.bind(host);
+    host.isPidRunning = (pid) => {
+      if (pid === orphanPid && params.exitsAfterPolls !== null) {
+        polls += 1;
+        if (polls > params.exitsAfterPolls) host.runningPids.delete(orphanPid);
+      }
+      return isPidRunning(pid);
+    };
+    await writeFile(
+      resolveAgenCDaemonHeartbeatPath(agencHome),
+      JSON.stringify({
+        pid: orphanPid,
+        beat: 7,
+        at: new Date(Date.now() - params.heartbeatAgeMs).toISOString(),
+        uptimeS: 35,
+        rssMb: 400,
+        heapUsedMb: 120,
+        eventLoopLagMs: 1,
+      }),
+    );
+    const [outcome] = await Promise.allSettled([
+      ensureAgenCDaemonAutostart({
+        host,
+        findOrphanDaemonPids: () => [orphanPid],
+        unboundDaemonExitWaitMs: params.waitMs,
+        isReady: () => true,
+      }),
+    ]);
+    return {
+      outcome,
+      signals,
+      spawned: host.spawnedPids,
+      cleanup: () => rm(agencHome, { recursive: true, force: true }),
+    };
+  }
+
+  it("waits for a beating unbound non-Linux daemon to exit, then spawns", async () => {
+    const run = await beatingOrphanScenario({ heartbeatAgeMs: 1_000, exitsAfterPolls: 3, waitMs: 5_000 });
+    try {
+      expect(run.outcome.status).toBe("fulfilled");
+      expect(run.signals).toEqual([]);
+      expect(run.spawned).toHaveLength(1);
+    } finally {
+      await run.cleanup();
+    }
+  });
+
+  it("keeps refusing a beating unbound daemon that never exits within the budget", async () => {
+    const run = await beatingOrphanScenario({ heartbeatAgeMs: 1_000, exitsAfterPolls: null, waitMs: 150 });
+    try {
+      expect(run.outcome.status).toBe("rejected");
+      expect(String((run.outcome as PromiseRejectedResult).reason)).toMatch(
+        /unbound daemon cannot be signalled/u,
+      );
+      expect(run.signals).toEqual([]);
+      expect(run.spawned).toEqual([]);
+    } finally {
+      await run.cleanup();
+    }
+  });
+
+  it("does not wait on a stale heartbeat", async () => {
+    const run = await beatingOrphanScenario({ heartbeatAgeMs: 120_000, exitsAfterPolls: 3, waitMs: 5_000 });
+    try {
+      expect(run.outcome.status).toBe("rejected");
+      expect(String((run.outcome as PromiseRejectedResult).reason)).toMatch(
+        /unbound daemon cannot be signalled/u,
+      );
+      expect(run.spawned).toEqual([]);
+    } finally {
+      await run.cleanup();
     }
   });
 

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -2899,6 +2899,59 @@ describe("AgenC daemon CLI", () => {
     }
   });
 
+  // #2232: a startup cancelled during recovery must not linger on a hung
+  // cleanup task; each task is bounded and the daemon exits.
+  it("bounds a hung cleanup task after a cancelled startup instead of lingering", async () => {
+    const agencHome = await tempAgencHome();
+    const baseHost = createHost(agencHome);
+    const io = createIo();
+    const acknowledgeAfterCleanup = vi.fn(async () => {});
+    let requested = false;
+    let resolveRequested!: () => void;
+    const requestedPromise = new Promise<void>((resolve) => {
+      resolveRequested = () => {
+        requested = true;
+        resolve();
+      };
+    });
+    const host: AgenCDaemonCliHost = {
+      ...baseHost,
+      startupGuardReceiver: {
+        requested: requestedPromise,
+        wasRequested: () => requested,
+        acknowledgeAfterCleanup,
+        close: () => {},
+      },
+    };
+    const started = Date.now();
+    await expect(
+      runAgenCDaemonCli(
+        { kind: "command", action: "run" },
+        {
+          host,
+          io,
+          // The parent cancels while recovery is still running, as in the
+          // incident; recovery itself never finishes.
+          beforeDaemonReady: () => {
+            resolveRequested();
+            return new Promise<void>(() => {});
+          },
+          beforeDaemonAuthorityCleanup: () => new Promise<void>(() => {}),
+          startupCancelCleanupTaskTimeoutMs: 100,
+        },
+      ),
+    ).resolves.toBe(1);
+    expect(Date.now() - started).toBeLessThan(20_000);
+    expect(io.stderrText()).toContain(
+      'cleanup[daemon-authority] failed: cleanup task "daemon-authority" did not finish within 100 ms',
+    );
+    // The real receiver closes its channel after the first send, so the parent
+    // sees the cleanup verdict: not ok. The foreground wrapper's later call is
+    // a no-op there; this fake records it, hence the first-call assertion.
+    expect(acknowledgeAfterCleanup.mock.calls[0]).toEqual([false]);
+    await rm(agencHome, { recursive: true, force: true });
+  });
+
   it("consumes rejected lifecycle lock diagnostic observers", async () => {
     const agencHome = await tempAgencHome();
     const host = createHost(agencHome);

--- a/runtime/tests/lifecycle/cleanup-registry.contract.test.ts
+++ b/runtime/tests/lifecycle/cleanup-registry.contract.test.ts
@@ -78,6 +78,42 @@ describe("AgenC lifecycle cleanup registry", () => {
     ]);
   });
 
+  // #2232: a cancelled daemon startup bounds each cleanup task so one hung
+  // task cannot keep the process alive.
+  it("records a task that outlives the per-task timeout and keeps going", async () => {
+    const registry = new AgenCCleanupRegistry();
+    const calls: string[] = [];
+    registry.register("first", () => {
+      calls.push("first");
+    });
+    registry.register("hangs", () => new Promise<void>(() => {}));
+    registry.register("last", () => {
+      calls.push("last");
+    });
+    const started = Date.now();
+    const results = await registry.run(
+      { reason: "daemon_shutdown" },
+      { taskTimeoutMs: 20 },
+    );
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(calls).toEqual(["last", "first"]);
+    expect(results.map((r) => [r.name, r.ok])).toEqual([
+      ["last", true],
+      ["hangs", false],
+      ["first", true],
+    ]);
+    expect(String(results[1]?.error)).toContain(
+      'cleanup task "hangs" did not finish within 20 ms',
+    );
+  });
+
+  it("does not bound tasks when no timeout is given", async () => {
+    const registry = new AgenCCleanupRegistry();
+    registry.register("slow", () => new Promise<void>((resolve) => setTimeout(resolve, 30)));
+    const results = await registry.run({ reason: "daemon_shutdown" });
+    expect(results).toEqual([{ name: "slow", ok: true }]);
+  });
+
   it("unregisters cleanup tasks before shutdown starts", async () => {
     const registry = new AgenCCleanupRegistry();
     const cleanup = vi.fn();


### PR DESCRIPTION
## Why

The third daemon kill of the app soak cost nine minutes without a daemon instead of three seconds (#2232). The replacement's recovery outran the 45 s ready-wait, the app cancelled it through the startup guard, and the cancelled daemon then lingered for eight minutes: its cleanup had no bound, and while it held the pid file every autostart on macOS refused with `an unbound daemon cannot be signalled on this platform`, six times in a row. Two changes close that loop: a cancelled startup bounds its cleanup, and macOS autostart waits for a daemon that is visibly leaving or starting instead of refusing at once.

## What changed

- `runtime/src/lifecycle/cleanup-registry.ts`: `run(context, { taskTimeoutMs })`. When the bound is given, a task that has not settled in time is recorded as failed with `AgenCCleanupTimeoutError` (`cleanup task "<name>" did not finish within N ms`) and the run moves on to the next task. Without the option, behaviour is unchanged.
- `runtime/src/app-server/daemon-cli.ts`: the termination race records whether the daemon is leaving because of a startup cancellation; in that case the cleanup runs with a 5 s per-task bound (`AGENC_DAEMON_STARTUP_CANCEL_CLEANUP_TASK_TIMEOUT_MS`). A cancelled daemon has served nobody, so its cleanup only has to be safe. Timed-out tasks print through the existing `cleanup[name] failed` line, so the next occurrence names the task that hung. `startupCancelCleanupTaskTimeoutMs` is a test seam threaded like the other hooks.
- `runtime/src/app-server/daemon-autostart.ts`: off Linux, `terminatePidlessAgenCDaemonPid` still never signals. Before refusing, `waitForBeatingUnboundDaemonToExit` checks the heartbeat file (#2216): a fresh beat for that pid means the daemon is alive on purpose, so autostart polls up to 30 s (`AGENC_DAEMON_UNBOUND_EXIT_WAIT_MS`, `unboundDaemonExitWaitMs` as test seam) for it to exit and then proceeds to spawn. A stale heartbeat (hung), a beat from another pid, or a pid still running at the deadline keeps the original refusal. A daemon that binds meanwhile is left for the next connect to adopt.
- Tests: `tests/lifecycle/cleanup-registry.contract.test.ts` (a hung task is recorded and the run continues; no bound without the option); `tests/app-server/daemon-cli.contract.test.ts` (a startup cancelled during recovery with a hung authority cleanup returns 1 within the bound, prints the timeout line, and acknowledges the parent with `false`); `tests/app-server/daemon-autostart.contract.test.ts` (a beating unbound Darwin pid that exits is waited for and then a daemon is spawned with no signal sent; one that never exits keeps the refusal; a stale heartbeat is not waited on).
- `docs/reference/daemon.md`: the two behaviours in the autostart paragraph.

## Evidence

| run | result |
| --- | --- |
| `cleanup-registry.contract.test.ts` | 8 passed |
| `daemon-cli.contract.test.ts -t "cancel\|lingering"` | 6 passed |
| `daemon-autostart.contract.test.ts -t "beating unbound\|stale heartbeat\|unbound non-Linux orphan\|portable recovery"` | 6 passed |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

Two Linux-branch autostart tests (`preserves metadata when the stopped PID is rebound...`, `uses a rebound Linux SIGTERM...`) fail on this macOS host on the unpatched tree as well (`daemon survived forced termination`); they are untouched by this change and green in CI.

## Tests

The registry test proves the bound in isolation with a task that never settles. The CLI test drives the incident's shape: cancellation arrives during a recovery that never finishes and one cleanup task hangs; without the bound the run never returns. The real guard receiver closes its channel after the first acknowledgement, so the assertion pins the first call (`false`). The autostart tests keep the existing rule (the Darwin orphan test is unchanged and still passes) and add the wait on top.

## Not changed

- Linux behaviour of the autostart ladder.
- The 45 s ready-wait default and the identity-commit order (#2232's remaining suggestions: progress-extended ready-wait, early pid release).
- What made recovery slow in the first place (#2228).

## Counterparts

#2232 (this closes its first two suggestions), #2216 (the heartbeat this reads), #2226, #2228, #2199.
