### PR TITLE
config: prune sessions untouched for 30 days by default; 0 keeps every session

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -307,6 +307,7 @@ otherwise.
 | `agent.retention.snapshot_days` | `3` |
 | `agent.retention.snapshot_max_count` | `10000` |
 | `agent.retention.snapshot_max_bytes` | `67108864` |
+| `agent.retention.rollout_days` | `30` (0 keeps every session) |
 
 `max_turns` is unset by default; an unset turn cap does not impose a
 synthetic stop. `stream_watchdog_timeout_ms` defaults to `600000` (ten
@@ -402,7 +403,7 @@ from a late CLI layer is rejected.
 | --- | --- |
 | `autoUpdates`, `autoUpdatesChannel` | Update enablement and `latest`/`stable` channel. Absent enablement preserves the updater default. |
 | `respectGitignore`, `includeGitInstructions` | Git-aware discovery and instruction behavior. |
-| `transcriptPersistenceEnabled` | Persist session transcripts (default `true`). Retention is configured only by `agent.retention.rollout_days`. |
+| `transcriptPersistenceEnabled` | Persist session transcripts (default `true`). Retention: `agent.retention.rollout_days`, default 30 days; sessions untouched for longer are deleted with their rollout files; 0 keeps every session. |
 | `outputStyle` | Named assistant response style. |
 | `defaultShell` | `bash` or `powershell`. |
 | `language` | Preferred response language. |

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -4632,14 +4632,20 @@ function uniqueStateDatabasePaths(
 
 /**
  * Project the rollout/session disk-retention window out of the agent retention
- * config. Returns undefined (sweep stays DISABLED) unless `rollout_days` is set
- * — the conservative default, since the sweep deletes user data.
+ * config. Returns undefined (sweep stays DISABLED) when `rollout_days` is unset
+ * or 0. The config default is 30 days (#2228); the sweep deletes user data, so
+ * 0 is the documented way to keep every session.
  */
-function rolloutRetentionPolicy(
+export function rolloutRetentionPolicy(
   retention: AgentRunRetentionConfig | undefined,
 ): RolloutRetentionPolicy | undefined {
   const days = retention?.rollout_days;
-  if (days === undefined) return undefined;
+  // 0 (or anything that is not a positive number) keeps every session: a
+  // zero-day window handed to the sweep would delete everything but the
+  // active session at the first tick.
+  if (days === undefined || !Number.isFinite(days) || days <= 0) {
+    return undefined;
+  }
   return { retention_days: days };
 }
 

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -203,12 +203,10 @@ export interface AgentRunRetentionConfig {
   readonly snapshot_days?: number;
   readonly snapshot_max_count?: number;
   readonly snapshot_max_bytes?: number;
-  // Rollout/session disk retention window (days). Lights up the reserved
-  // `agent.retention.rollout_days` retention intent: when set, the daemon's
-  // throttled sweep deletes session dirs + their rollout JSONL + the
-  // thread_rollout_items mirror rows once their newest rollout is older than
-  // this many days. Unset → DISABLED (no pruning; the conservative default,
-  // since this deletes user data).
+  // Rollout/session disk retention window (days). The daemon's throttled
+  // sweep deletes session dirs + their rollout JSONL + the thread_rollout_items
+  // mirror rows once their newest rollout is older than this many days.
+  // Default 30 (#2228); 0 disables the sweep and keeps every session forever.
   readonly rollout_days?: number;
 }
 
@@ -1187,6 +1185,10 @@ export function defaultConfig(): AgenCConfig {
         snapshot_days: 3,
         snapshot_max_count: 10_000,
         snapshot_max_bytes: 67_108_864,
+        // Sessions untouched for a month are pruned with their rollout files
+        // and mirror rows; without a window a project's state database grows
+        // without bound (693 MB in two days of soak, #2228). 0 keeps forever.
+        rollout_days: 30,
       }) as AgentRunRetentionConfig,
     }) as AgentConfig,
   } satisfies AgenCConfig);

--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -337,7 +337,8 @@ export function pruneSessionSnapshotsPerSession(
 // point at the removed rollout files so the index can't outlive its source.
 //
 // CONSERVATISM (this deletes user data):
-//   - Disabled by default — `retention_days === undefined` is a no-op.
+//   - `retention_days === undefined` is a no-op; the daemon maps a configured
+//     0 to undefined. The config default is 30 days (#2228).
 //   - Only sessions whose newest rollout mtime is strictly older than the
 //     cutoff are eligible.
 //   - The active session is never pruned.

--- a/runtime/tests/app-server/rollout-retention-policy.test.ts
+++ b/runtime/tests/app-server/rollout-retention-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { rolloutRetentionPolicy } from "../../src/app-server/daemon-cli.js";
+
+// #2228: rollout retention defaults to 30 days; 0 keeps every session, and a
+// zero-day window must never reach the sweep, which would otherwise delete
+// everything but the active session at its first tick.
+describe("rollout retention policy from config", () => {
+  it("maps a positive window to the sweep policy", () => {
+    expect(rolloutRetentionPolicy({ rollout_days: 30 })).toEqual({ retention_days: 30 });
+    expect(rolloutRetentionPolicy({ rollout_days: 1 })).toEqual({ retention_days: 1 });
+  });
+
+  it("disables the sweep for 0, negative, non-finite and unset windows", () => {
+    expect(rolloutRetentionPolicy({ rollout_days: 0 })).toBeUndefined();
+    expect(rolloutRetentionPolicy({ rollout_days: -3 })).toBeUndefined();
+    expect(rolloutRetentionPolicy({ rollout_days: Number.NaN })).toBeUndefined();
+    expect(rolloutRetentionPolicy({})).toBeUndefined();
+    expect(rolloutRetentionPolicy(undefined)).toBeUndefined();
+  });
+});

--- a/runtime/tests/config/config.test.ts
+++ b/runtime/tests/config/config.test.ts
@@ -102,6 +102,7 @@ describe("schema: defaultConfig", () => {
       snapshot_days: 3,
       snapshot_max_count: 10_000,
       snapshot_max_bytes: 67_108_864,
+      rollout_days: 30,
     });
     expect(Object.isFrozen(cfg)).toBe(true);
   });


### PR DESCRIPTION
## Why

Nothing ever deleted a session unless the user set `agent.retention.rollout_days`. The app soak's project reached a 693 MB state database in two days (267,700 `thread_rollout_items` rows plus 208 MB of indexes), every daemon start walked all of it, and the transient cost about 700 MB of memory at the moment the host was most likely to kill the daemon (#2228, #2199). The decision to prune by default was taken by the maintainer: sessions untouched for 30 days go, matching the existing 30-day default for completed agent runs, with 0 as the documented way to keep every session.

## What changed

- `runtime/src/config/schema.ts`: `agent.retention.rollout_days` defaults to `30`. The field's comment states the default and that 0 disables the sweep.
- `runtime/src/app-server/daemon-cli.ts`: `rolloutRetentionPolicy` (now exported for its test) returns no policy for an unset, zero, negative or non-finite window, so a zero-day window never reaches the sweep; the sweep's own `rolloutCutoffMs` already treats `days <= 0` as disabled, and the two now agree at both layers.
- `runtime/src/state/pruning.ts`: the conservatism note no longer says "disabled by default".
- `runtime/tests/config/config.test.ts`: the defaults assertion includes `rollout_days: 30`.
- `runtime/tests/app-server/rollout-retention-policy.test.ts` (new): positive windows map through; 0, negative, NaN and unset disable.
- `docs/reference/config.md`: the defaults table gains the row; the transcript-persistence row states the default and the 0 escape.

## Behaviour change

A home that has never set `rollout_days` starts pruning sessions whose newest rollout is older than 30 days: the session directory, its rollout files and its mirror rows. The sweep keeps its existing guards (the active session is never pruned, deletions are bounded per tick, directories are removed atomically). Users who want everything kept set `rollout_days = 0`.

## Evidence

| run | result |
| --- | --- |
| `config.test.ts`, `rollout-retention-policy.test.ts`, `state/pruning.test.ts`, `state/snapshot-policy.test.ts`, `config-reference-coverage.test.ts` | 218 passed, 1 failed |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

The one failure, `resolveAgencHome falls back to $HOME/.agenc`, expects `/home/user/.agenc` and gets `/System/Volumes/Data/home/user/.agenc`: the macOS `/home` firmlink. It fails identically on the unpatched tree here and is green in CI.

## Tests

The defaults test pins the new value beside the other retention defaults; the policy test pins that only positive windows produce a policy and that 0 is off.

## Not changed

- The sweep's mechanics, throttle and per-tick bound.
- Snapshot retention and agent-run retention.
- The startup passes over the database (#2228 keeps that item) and the compaction scan (#2229).

## Counterparts

#2228 (suggested fix 1), #2231 (the status line that makes database growth visible), #2199.
