### PR TITLE
agents: a user Stop holds child receipts until the next prompt instead of restarting the turn

### DIFF
--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -200,7 +200,9 @@ prompt; consumed or indeterminate outcomes are not duplicated. Per model
 turn, agent projection is capped at 32 records / 128 KiB. Oversized first
 records are visibly truncated for forward progress; only deferred triggers
 schedule autonomous follow-up turns, while passive context waits for the next
-human/root turn.
+human/root turn. A user Stop holds even the deferred triggers: until the user
+speaks again, a child receipt stays in the mailbox instead of starting a parent
+turn, so stopping a turn does not let its verifiers resume it.
 
 `wait_agent` drains all currently delivered updates, not one named worker. It
 is therefore mutating and intentionally has no target filter. Use

--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -1591,6 +1591,11 @@ function requestParentFollowupTurn(params: {
   readonly parent: Session;
 }): void {
   const parent = params.parent;
+  // The user stopped this session's last turn and has not spoken since: hold
+  // the receipt in the mailbox for the next user turn instead of starting a
+  // turn of our own, which would resume the very work the user stopped
+  // (#2236: an interrupted verifier's receipt restarted an 18-minute turn).
+  if (parent.stoppedByUserSinceLastPrompt === true) return;
   // Coalesce bursts of subagent completions into ONE parent turn. Each
   // completion notifies the parent's mailbox and then requests a follow-up
   // turn; without coalescing, N near-simultaneous completions queue N
@@ -1620,6 +1625,11 @@ function requestParentFollowupTurn(params: {
   const schedule = (delayMs = PARENT_FOLLOWUP_COALESCE_MS): void => {
     state.timer = setTimeout(() => {
       state.timer = null;
+      // A stop that landed inside the coalescing window holds the burst too.
+      if (parent.stoppedByUserSinceLastPrompt === true) {
+        followupTurnStateByParent.delete(parent);
+        return;
+      }
       state.submitInFlight = true;
       let transientSubmitFailure = false;
       void parent

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1756,6 +1756,9 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     if (active === undefined || !isRunnableActiveAgent(active)) {
       throw new Error(`AgenC daemon agent not running: ${agentId}`);
     }
+    // The user speaks again: child receipts held since a stop may now start
+    // follow-up turns (#2236).
+    active.bootstrap.session.clearUserStop?.();
     const contentFingerprint = messageContentFingerprint(
       params.originalContent,
     );
@@ -3960,6 +3963,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     const active = this.#active.get(agentId);
     if (active === undefined || !isInterruptibleActiveAgent(active))
       return false;
+    // A client asked for the stop; hold child receipts until the next prompt.
+    active.bootstrap.session.markStoppedByUser?.();
     try {
       await active.bootstrap.session.abortAllTasks("interrupted");
     } catch {
@@ -4015,6 +4020,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ...(turnAfterAttempt !== expectedTurnId ? { stale: true } : {}),
       };
     }
+    active.bootstrap.session.markStoppedByUser?.();
     for (const [childThreadId] of active.control.openThreadSpawnChildren(
       active.thread.threadId,
     )) {

--- a/runtime/src/session/session.ts
+++ b/runtime/src/session/session.ts
@@ -5182,6 +5182,27 @@ export class Session {
     return messages;
   }
 
+  private stoppedByUserSinceLastPromptFlag = false;
+
+  /**
+   * A user Stop holds the session quiet until the user speaks again: while
+   * this is set, a child agent's receipt does not start a parent follow-up
+   * turn (#2236). The daemon sets it on a client-initiated interrupt and
+   * clears it when the next user message is submitted; receipts that arrive
+   * meanwhile wait in the mailbox for that turn.
+   */
+  markStoppedByUser(): void {
+    this.stoppedByUserSinceLastPromptFlag = true;
+  }
+
+  clearUserStop(): void {
+    this.stoppedByUserSinceLastPromptFlag = false;
+  }
+
+  get stoppedByUserSinceLastPrompt(): boolean {
+    return this.stoppedByUserSinceLastPromptFlag;
+  }
+
   hasDeferredAgentMailboxMessages(): boolean {
     return this.hasDeferredAgentMailboxProjection;
   }

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -2279,6 +2279,41 @@ describe("runAgent", () => {
     expect(session.mailbox.hasPending()).toBe(false);
   });
 
+  // #2236: after a user Stop, a child's receipt must not start a parent turn;
+  // it waits in the mailbox for the user's next prompt.
+  it("holds a parent follow-up while the user's stop is latched; the receipt waits for the next user turn", async () => {
+    vi.useFakeTimers();
+    const provider = makeProvider([{ content: "follow-up result" }]);
+    const session = makeStubSession({ services: { provider } });
+    const submit = vi.fn(async () => {
+      session.drainPendingInputMessages();
+    });
+    session.installTurnDriverHooks({ submit });
+    session.markStoppedByUser();
+    const { live } = await spawnLive(session);
+
+    const { result } = await collectRun(
+      runAgent({
+        live,
+        parent: session,
+        initialMessages: [{ role: "user", content: "schedule follow-up" }],
+        taskPrompt: "schedule follow-up",
+      }),
+    );
+    expect(result.outcome).toBe("completed");
+    expect(session.mailbox.hasPending()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(submit).not.toHaveBeenCalled();
+    expect(session.mailbox.hasPending()).toBe(true);
+
+    // The next user prompt clears the latch and its turn drains the receipt.
+    session.clearUserStop();
+    expect(session.stoppedByUserSinceLastPrompt).toBe(false);
+    session.drainPendingInputMessages();
+    expect(session.mailbox.hasPending()).toBe(false);
+  });
+
   it("durably NACKs an accepted assignment that teardown prevents from starting", async () => {
     const provider = makeProvider([{ content: "initial result" }]);
     const session = makeStubSession({ services: { provider } });

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -806,6 +806,8 @@ function makeTopLevelRunner(opts: {
       unsafePeek: () => sessionState,
     },
     abortAllTasks: vi.fn(async () => {}),
+    markStoppedByUser: vi.fn(),
+    clearUserStop: vi.fn(),
     trackDurableOperation: <T>(operation: Promise<T>): Promise<T> => {
       durableOperations.add(operation);
       void operation.then(
@@ -9685,6 +9687,8 @@ describe("AgenC delegate background-agent runner", () => {
 
     expect(interrupted).toBe(true);
     expect(session.abortAllTasks).toHaveBeenCalledWith("interrupted");
+    // #2236: the stop is latched so child receipts do not restart the turn.
+    expect(session.markStoppedByUser).toHaveBeenCalledTimes(1);
     expect(stub.thread.submit).toHaveBeenCalledWith({
       type: "interrupt",
       reason: "user_cancel",


### PR DESCRIPTION
## Why

In the app soak a user Stop was honoured for nine seconds. The stop aborted the turn, but it also interrupted the verifier agent the model had spawned earlier, and that child's receipt (`<subagent_notification> ... status: interrupted`) reached the parent's mailbox and started a follow-up turn through `requestParentFollowupTurn`. The new turn carried only the receipt and nothing about the stop, so the model saw its half-finished work in the history and resumed it: eighteen minutes of edits, commands and another spawned agent that nobody asked for, and a composer blocked until it ended (#2236). The same shape appeared after both stops of the run.

## What changed

- `runtime/src/session/session.ts`: a session-level latch, `markStoppedByUser()`, `clearUserStop()`, `stoppedByUserSinceLastPrompt`. A user Stop holds the session quiet until the user speaks again.
- `runtime/src/app-server/background-agent-runner.ts`: `interruptAgentTurn` and `interruptAgentTurnIfMatches` (the client-initiated cancel paths) set the latch, the second only when a turn was actually cancelled; `submitAgentMessage` (the user's next message) clears it.
- `runtime/src/agents/run-agent.ts`: `requestParentFollowupTurn` returns without scheduling while the latch is set, and a burst whose timer fires after a stop landed inside the coalescing window is dropped the same way. The receipt is already in the parent's mailbox; the next user turn drains it, so the model still learns what its children did, at the moment the user chose.
- `docs/reference/agents.md`: one sentence beside the deferred-trigger rule.
- Tests: `tests/agents/run-agent.test.ts` (with the latch set, a completed child's receipt stays pending, no submit is scheduled, and the next user turn drains it); `tests/app-server/background-agent-runner.contract.test.ts` (the interrupt latches the session; the mock session gains the two methods).

## Evidence

| run | result |
| --- | --- |
| `tests/agents/run-agent.test.ts` (whole file) | 79 passed |
| `background-agent-runner.contract.test.ts -t "submitAgentMessage\|interrupt\|cancel"` | 10 passed, 162 skipped |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

## Tests

The run-agent test mirrors the existing follow-up retry test: a real `Session` with the stop latched, a child that completes and enqueues its receipt, fake timers advanced well past the coalescing window, `submit` never called, the mailbox still pending, then the latch cleared and the receipt drained by the next turn. The runner test asserts `markStoppedByUser` is called exactly once on a user cancel.

## Not changed

- Stop still interrupts the children (`control.interrupt`), as before.
- Follow-ups outside a stop: coalescing, retry on transient submit failure, and the abort-signal check are untouched.
- What the follow-up turn says to the model; a system note about the stop (suggestion 3 in #2236) is not added, since no follow-up starts before the user speaks.

## Counterparts

#2236 (this), #2201 (stopping a swarm leaves the parent active), #2220 (wait_agent ends at once on a stopped turn), #2197.
