### PR TITLE
retention: the sweep keeps a session whose run has an effect still under review

### DIFF
--- a/runtime/src/state/pruning.ts
+++ b/runtime/src/state/pruning.ts
@@ -422,6 +422,10 @@ export function pruneRolloutSessions(
     // of file age. Only the durable released state makes whole-session
     // retention eligible again.
     if (sessionHasUnreleasedCompactionSource(driver, sessionId)) continue;
+    // A run with an effect still under review needs its canonical journal as
+    // evidence; startup recovery refuses to start a daemon whose review has
+    // none (#2238). Keep the session until the review is settled.
+    if (sessionHasPendingEffectReview(driver, sessionId)) continue;
     // Live-writer guard: never prune a session whose rollout lock is held by a
     // live process. The daemon shares this sessions dir with separate foreground
     // processes; the mtime cutoff already spares actively-written sessions, and
@@ -495,6 +499,30 @@ export function pruneRolloutSessions(
     prunedMirrorRows,
     prunedSessionIds,
   };
+}
+
+/**
+ * A `run_effects` row still awaiting review pins the session's journal: the
+ * review needs it as evidence, and startup recovery treats a pending review
+ * without retained journal files as fatal (#2238).
+ */
+export function sessionHasPendingEffectReview(
+  driver: StateSqliteDriver,
+  sessionId: string,
+): boolean {
+  try {
+    const row = driver
+      .prepareState<[string], { readonly one: number }>(
+        `SELECT 1 AS one FROM run_effects
+         WHERE session_id = ? AND review_status = 'pending'
+         LIMIT 1`,
+      )
+      .get(sessionId);
+    return row !== undefined;
+  } catch {
+    // A database without the run_effects table has nothing under review.
+    return false;
+  }
 }
 
 function sessionHasUnreleasedCompactionSource(

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -180,6 +180,47 @@ describe("pruneRolloutSessions", () => {
     expect(existsSync(sourcePath)).toBe(false);
   });
 
+  // #2238: a run with an effect still under review needs its journal as
+  // evidence, and startup recovery refuses to start when the review has none.
+  it("keeps a session whose run has an effect still under review", () => {
+    const reviewed = "thread-pending-review";
+    const reviewedPath = seedSession(reviewed, 60);
+    const plain = "thread-old-plain";
+    const plainPath = seedSession(plain, 60);
+    const runs = new StateRunDurabilityRepository(driver);
+    runs.ensureInitialEpoch({ runId: reviewed, openedAt: NOW });
+    runs.beginEffect({
+      runId: reviewed,
+      stepId: "tool:step-1",
+      epoch: 1,
+      sessionId: reviewed,
+      callId: "call-1",
+      toolName: "exec_command",
+      recoveryCategory: "side-effecting",
+      intentDigest: "d".repeat(64),
+      eventId: "intent-1",
+      eventSequence: 1,
+      intentAt: NOW,
+    });
+    runs.markEffectUnknown({
+      runId: reviewed,
+      stepId: "tool:step-1",
+      eventId: "unknown-1",
+      eventSequence: 2,
+      reason: "tool_error_result_without_authoritative_effect_disposition",
+      observedAt: NOW,
+    });
+
+    const report = pruneRolloutSessions(driver, {
+      sessionsDir: join(driver.projectDir, "sessions"),
+      retention_days: 30,
+      now: () => NOW,
+    });
+    expect(report.prunedSessionIds).toEqual([plain]);
+    expect(existsSync(plainPath)).toBe(false);
+    expect(existsSync(reviewedPath)).toBe(true);
+  });
+
   it("deletes an old session + its mirror rows, keeps recent and active", () => {
     const oldPath = seedSession("thread-old", 60); // older than the window
     const recentPath = seedSession("thread-recent", 5); // inside the window


### PR DESCRIPTION
## Why

Tonight the retention sweep removed a day-old session whose run still had a `run_effects` row with `review_status = 'pending'` (an `unknown_outcome`, side-effecting tool call awaiting review). Startup recovery treats a pending review without retained journal files as fatal, so after the next daemon restart every daemon in that home exited during startup with `daemon state recovery failed: run conv-mtnmi70l has a pending effect review without retained canonical journal evidence`; the app looped on autostart, `agenc daemon start` refused, and `state resolve-tool-call` refused for want of the evidence the sweep had deleted (#2238). Under the new 30-day default (#2235) every long-lived install can reach this.

## What changed

- `runtime/src/state/pruning.ts`: `pruneRolloutSessions` skips a session whose runs hold a pending effect review, beside the existing compaction-pin and live-lock guards. `sessionHasPendingEffectReview(driver, sessionId)` is the query (`run_effects WHERE session_id = ? AND review_status = 'pending' LIMIT 1`); a database without the table counts as having nothing under review.
- `runtime/tests/state/rollout-retention-sweep.test.ts`: two 60-day-old sessions, one with a pending review recorded through `StateRunDurabilityRepository` (`ensureInitialEpoch`, `beginEffect`, `markEffectUnknown`); the sweep prunes the plain one and keeps the reviewed one and its rollout file.

## Evidence

| run | result |
| --- | --- |
| `tests/state/rollout-retention-sweep.test.ts` | 15 passed |
| `tests/state/pruning.test.ts` | 12 passed |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

## Tests

The new case seeds the review through the repository's own API so it satisfies the table's constraints the way the runtime does, and asserts the exact pruned set (`[plain]`), the removed plain rollout, and the retained reviewed rollout.

## Not changed

- Startup recovery still refuses to start on a pending review without evidence; making it quarantine the run instead is the second half of #2238 and a separate change.
- The sweep's other guards, throttle and bounds.
- The 30-day default (#2235); with this guard the default can no longer delete review evidence.

## Counterparts

#2238 (this closes its first suggestion), #2235, #2228, #2190.
