### PR TITLE
recovery: quarantine a pending effect review without journal evidence instead of refusing to start

### DIFF
--- a/runtime/src/state/startup-run-journal-recovery.ts
+++ b/runtime/src/state/startup-run-journal-recovery.ts
@@ -45,6 +45,7 @@ import {
   type PreparedPinnedRolloutRun,
 } from "./backfill.js";
 import { RecoveryOperationalError } from "./recovery-contract.js";
+import { StateRecoveryIncidentRepository } from "./recovery-incidents.js";
 import { RecoveryDescriptorBudget } from "./recovery-file.js";
 import {
   StartupRecoveryBudget,
@@ -256,6 +257,48 @@ export function recoverCanonicalRunJournalForRun(
   return recoverStrictRun(driver, threads, run, sources, options.strict);
 }
 
+/** The sha256 recorded for a source that no longer exists; an operator confirms it to abandon the incident. */
+export const MISSING_RECOVERY_SOURCE_SHA256 = "0".repeat(64);
+
+/**
+ * A run whose pending effect review has no retained canonical journal cannot
+ * be reviewed and cannot be executed, but it must not stop the daemon from
+ * starting (#2238). Record one quarantine incident for it (idempotent: an
+ * existing exclusion is returned as is) with a sentinel source so the
+ * operator can list and abandon it.
+ */
+function quarantineReviewWithoutEvidence(
+  driver: StateSqliteDriver,
+  runId: string,
+): RecoveryRunExclusion {
+  const existing = getRecoveryRunExclusion(driver, runId);
+  if (existing !== undefined) return existing;
+  const detectedAtMs = Date.now();
+  new StateRecoveryIncidentRepository(driver).recordQuarantine({
+    runId,
+    sourceKind: "run_journal",
+    sourcePath: join(
+      driver.projectDir,
+      "sessions",
+      runId,
+      "canonical-rollout-unavailable.jsonl",
+    ),
+    // The schema pins the reason codes; "source_changed" is the closest truth:
+    // the bound source no longer exists.
+    reasonCode: "source_changed",
+    safeDetail: {
+      message:
+        "pending effect review without retained canonical journal evidence; " +
+        "the journal was removed (retention or loss) before the review was settled",
+    },
+    sourceSizeBytes: 0,
+    sourceMtimeMs: detectedAtMs,
+    sourceSha256: MISSING_RECOVERY_SOURCE_SHA256,
+    detectedAtMs,
+  });
+  return getRecoveryRunExclusion(driver, runId)!;
+}
+
 /**
  * Project the bounded set of review-locked runs independently of executable
  * run status. Offline human review may append leased audit evidence after the
@@ -307,9 +350,13 @@ export function recoverPendingEffectReviewsOnStartup(
       continue;
     }
     if (projected.filesScanned === 0) {
-      throw new Error(
-        `run ${row.run_id} has a pending effect review without retained canonical journal evidence`,
-      );
+      // The review's evidence is gone (a swept or lost journal). Refusing to
+      // start here left a home with no daemon at all: every start died on
+      // this run (#2238). Quarantine the run instead, so it stays out of
+      // executable recovery and shows in `agenc state recovery quarantine
+      // list`, and let the daemon start.
+      exclusions.push(quarantineReviewWithoutEvidence(driver, row.run_id));
+      continue;
     }
     filesScanned += projected.filesScanned;
     eventsProjected += projected.eventsProjected;

--- a/runtime/tests/state/helpers/effect-review-fixture.ts
+++ b/runtime/tests/state/helpers/effect-review-fixture.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { StateRunDurabilityRepository } from "../../../src/state/run-durability.js";
+import { openStateDatabases, type StateSqliteDriver } from "../../../src/state/sqlite-driver.js";
+
+export interface TempStateDatabases {
+  readonly driver: StateSqliteDriver;
+  readonly home: string;
+  readonly cwd: string;
+  /** Close the driver, restore AGENC_HOME and remove both directories. */
+  readonly dispose: () => void;
+}
+
+/** A project state database in a throwaway home and workspace, with AGENC_HOME pointed at it. */
+export function openTempStateDatabases(prefix: string): TempStateDatabases {
+  const home = mkdtempSync(join(tmpdir(), `${prefix}-home-`));
+  const cwd = mkdtempSync(join(tmpdir(), `${prefix}-cwd-`));
+  mkdirSync(join(cwd, ".git"));
+  const originalAgencHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = home;
+  const driver = openStateDatabases({ cwd });
+  return {
+    driver,
+    home,
+    cwd,
+    dispose: () => {
+      driver.close();
+      if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
+      else delete process.env.AGENC_HOME;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Record, through the run-durability repository so every table constraint is
+ * met the way the runtime meets it, a side-effecting tool call whose outcome
+ * is unknown: a `run_effects` row with `review_status = 'pending'` (#2238).
+ */
+export function seedPendingEffectReview(
+  driver: StateSqliteDriver,
+  runId: string,
+  now: string,
+): void {
+  const runs = new StateRunDurabilityRepository(driver);
+  runs.ensureInitialEpoch({ runId, openedAt: now });
+  runs.beginEffect({
+    runId,
+    stepId: "tool:step-1",
+    epoch: 1,
+    sessionId: runId,
+    callId: "call-1",
+    toolName: "exec_command",
+    recoveryCategory: "side-effecting",
+    intentDigest: "d".repeat(64),
+    eventId: "intent-1",
+    eventSequence: 1,
+    intentAt: now,
+  });
+  runs.markEffectUnknown({
+    runId,
+    stepId: "tool:step-1",
+    eventId: "unknown-1",
+    eventSequence: 2,
+    reason: "tool_error_result_without_authoritative_effect_disposition",
+    observedAt: now,
+  });
+}

--- a/runtime/tests/state/pending-review-recovery.test.ts
+++ b/runtime/tests/state/pending-review-recovery.test.ts
@@ -1,74 +1,36 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { getRecoveryRunExclusion } from "../../src/state/recovery-exclusions.js";
-import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
-import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
 import {
   MISSING_RECOVERY_SOURCE_SHA256,
   recoverPendingEffectReviewsOnStartup,
 } from "../../src/state/startup-run-journal-recovery.js";
+import {
+  openTempStateDatabases,
+  seedPendingEffectReview,
+  type TempStateDatabases,
+} from "./helpers/effect-review-fixture.js";
 
 // #2238: a pending effect review whose canonical journal is gone used to make
 // startup recovery throw, which left the home unable to start any daemon.
 
-let home = "";
-let cwd = "";
-let originalAgencHome = "";
-let driver: StateSqliteDriver;
+let state: TempStateDatabases;
 const NOW = "2026-09-06T21:00:00.000Z";
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), "agenc-review-recovery-home-"));
-  cwd = mkdtempSync(join(tmpdir(), "agenc-review-recovery-cwd-"));
-  mkdirSync(join(cwd, ".git"));
-  originalAgencHome = process.env.AGENC_HOME ?? "";
-  process.env.AGENC_HOME = home;
-  driver = openStateDatabases({ cwd });
+  state = openTempStateDatabases("agenc-review-recovery");
 });
 
 afterEach(() => {
-  driver.close();
-  if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
-  else delete process.env.AGENC_HOME;
-  rmSync(home, { recursive: true, force: true });
-  rmSync(cwd, { recursive: true, force: true });
+  state.dispose();
 });
-
-function seedPendingReview(runId: string): void {
-  const runs = new StateRunDurabilityRepository(driver);
-  runs.ensureInitialEpoch({ runId, openedAt: NOW });
-  runs.beginEffect({
-    runId,
-    stepId: "tool:step-1",
-    epoch: 1,
-    sessionId: runId,
-    callId: "call-1",
-    toolName: "exec_command",
-    recoveryCategory: "side-effecting",
-    intentDigest: "d".repeat(64),
-    eventId: "intent-1",
-    eventSequence: 1,
-    intentAt: NOW,
-  });
-  runs.markEffectUnknown({
-    runId,
-    stepId: "tool:step-1",
-    eventId: "unknown-1",
-    eventSequence: 2,
-    reason: "tool_error_result_without_authoritative_effect_disposition",
-    observedAt: NOW,
-  });
-}
 
 describe("startup recovery of a pending effect review without evidence", () => {
   it("quarantines the run and lets startup continue instead of throwing", () => {
     const runId = "conv-review-no-journal";
-    seedPendingReview(runId);
+    seedPendingEffectReview(state.driver, runId, NOW);
 
-    const result = recoverPendingEffectReviewsOnStartup(driver);
+    const result = recoverPendingEffectReviewsOnStartup(state.driver);
 
     expect(result.exclusions).toHaveLength(1);
     expect(result.exclusions[0]).toMatchObject({
@@ -78,15 +40,15 @@ describe("startup recovery of a pending effect review without evidence", () => {
       sourceKind: "run_journal",
     });
     expect(result.exclusions[0]?.safeDetail).toContain("without retained canonical journal evidence");
-    expect(getRecoveryRunExclusion(driver, runId)).toMatchObject({ runId, kind: "quarantine" });
+    expect(getRecoveryRunExclusion(state.driver, runId)).toMatchObject({ runId, kind: "quarantine" });
   });
 
   it("records the incident once across restarts", () => {
     const runId = "conv-review-no-journal-twice";
-    seedPendingReview(runId);
+    seedPendingEffectReview(state.driver, runId, NOW);
 
-    const first = recoverPendingEffectReviewsOnStartup(driver);
-    const second = recoverPendingEffectReviewsOnStartup(driver);
+    const first = recoverPendingEffectReviewsOnStartup(state.driver);
+    const second = recoverPendingEffectReviewsOnStartup(state.driver);
 
     expect(first.exclusions).toHaveLength(1);
     expect(second.exclusions).toHaveLength(1);

--- a/runtime/tests/state/pending-review-recovery.test.ts
+++ b/runtime/tests/state/pending-review-recovery.test.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getRecoveryRunExclusion } from "../../src/state/recovery-exclusions.js";
+import { StateRunDurabilityRepository } from "../../src/state/run-durability.js";
+import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
+import {
+  MISSING_RECOVERY_SOURCE_SHA256,
+  recoverPendingEffectReviewsOnStartup,
+} from "../../src/state/startup-run-journal-recovery.js";
+
+// #2238: a pending effect review whose canonical journal is gone used to make
+// startup recovery throw, which left the home unable to start any daemon.
+
+let home = "";
+let cwd = "";
+let originalAgencHome = "";
+let driver: StateSqliteDriver;
+const NOW = "2026-09-06T21:00:00.000Z";
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-review-recovery-home-"));
+  cwd = mkdtempSync(join(tmpdir(), "agenc-review-recovery-cwd-"));
+  mkdirSync(join(cwd, ".git"));
+  originalAgencHome = process.env.AGENC_HOME ?? "";
+  process.env.AGENC_HOME = home;
+  driver = openStateDatabases({ cwd });
+});
+
+afterEach(() => {
+  driver.close();
+  if (originalAgencHome) process.env.AGENC_HOME = originalAgencHome;
+  else delete process.env.AGENC_HOME;
+  rmSync(home, { recursive: true, force: true });
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+function seedPendingReview(runId: string): void {
+  const runs = new StateRunDurabilityRepository(driver);
+  runs.ensureInitialEpoch({ runId, openedAt: NOW });
+  runs.beginEffect({
+    runId,
+    stepId: "tool:step-1",
+    epoch: 1,
+    sessionId: runId,
+    callId: "call-1",
+    toolName: "exec_command",
+    recoveryCategory: "side-effecting",
+    intentDigest: "d".repeat(64),
+    eventId: "intent-1",
+    eventSequence: 1,
+    intentAt: NOW,
+  });
+  runs.markEffectUnknown({
+    runId,
+    stepId: "tool:step-1",
+    eventId: "unknown-1",
+    eventSequence: 2,
+    reason: "tool_error_result_without_authoritative_effect_disposition",
+    observedAt: NOW,
+  });
+}
+
+describe("startup recovery of a pending effect review without evidence", () => {
+  it("quarantines the run and lets startup continue instead of throwing", () => {
+    const runId = "conv-review-no-journal";
+    seedPendingReview(runId);
+
+    const result = recoverPendingEffectReviewsOnStartup(driver);
+
+    expect(result.exclusions).toHaveLength(1);
+    expect(result.exclusions[0]).toMatchObject({
+      runId,
+      kind: "quarantine",
+      reasonCode: "source_changed",
+      sourceKind: "run_journal",
+    });
+    expect(result.exclusions[0]?.safeDetail).toContain("without retained canonical journal evidence");
+    expect(getRecoveryRunExclusion(driver, runId)).toMatchObject({ runId, kind: "quarantine" });
+  });
+
+  it("records the incident once across restarts", () => {
+    const runId = "conv-review-no-journal-twice";
+    seedPendingReview(runId);
+
+    const first = recoverPendingEffectReviewsOnStartup(driver);
+    const second = recoverPendingEffectReviewsOnStartup(driver);
+
+    expect(first.exclusions).toHaveLength(1);
+    expect(second.exclusions).toHaveLength(1);
+    expect(second.exclusions[0]?.evidenceId).toBe(first.exclusions[0]?.evidenceId);
+  });
+
+  it("names the sentinel sha an operator confirms to abandon the incident", () => {
+    expect(MISSING_RECOVERY_SOURCE_SHA256).toMatch(/^0{64}$/u);
+  });
+});

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -19,6 +19,7 @@ import { SessionLock, SessionLockedError } from "../session/session-store.js";
 import { backfillProjectRollouts } from "./backfill.js";
 import { pruneRolloutSessions } from "./pruning.js";
 import { StateRunDurabilityRepository } from "./run-durability.js";
+import { seedPendingEffectReview } from "./helpers/effect-review-fixture.js";
 import { AgenCSessionSnapshotPolicy } from "./snapshot-policy.js";
 import { recoverCanonicalRunJournalForRun } from "./startup-run-journal-recovery.js";
 import { openStateDatabases, type StateSqliteDriver } from "./sqlite-driver.js";

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -187,29 +187,7 @@ describe("pruneRolloutSessions", () => {
     const reviewedPath = seedSession(reviewed, 60);
     const plain = "thread-old-plain";
     const plainPath = seedSession(plain, 60);
-    const runs = new StateRunDurabilityRepository(driver);
-    runs.ensureInitialEpoch({ runId: reviewed, openedAt: NOW });
-    runs.beginEffect({
-      runId: reviewed,
-      stepId: "tool:step-1",
-      epoch: 1,
-      sessionId: reviewed,
-      callId: "call-1",
-      toolName: "exec_command",
-      recoveryCategory: "side-effecting",
-      intentDigest: "d".repeat(64),
-      eventId: "intent-1",
-      eventSequence: 1,
-      intentAt: NOW,
-    });
-    runs.markEffectUnknown({
-      runId: reviewed,
-      stepId: "tool:step-1",
-      eventId: "unknown-1",
-      eventSequence: 2,
-      reason: "tool_error_result_without_authoritative_effect_disposition",
-      observedAt: NOW,
-    });
+    seedPendingEffectReview(driver, reviewed, NOW);
 
     const report = pruneRolloutSessions(driver, {
       sessionsDir: join(driver.projectDir, "sessions"),


### PR DESCRIPTION
## Why

When a run has an effect still under review and no canonical journal is left to project (the sweep removed the session, or the file was lost), `recoverPendingEffectReviewsOnStartup` threw, the throw propagated out of startup recovery, and the daemon exited before its control socket opened. Every start in that home died the same way: the app looped on autostart, `agenc daemon start` refused, and no CLI command could clear it (#2238). Refusing to start protects nothing here, the effect already happened or did not, and it only removes the user's ability to use the product. PR #2240 stops the sweep from creating the state; this makes a home that already has it start again.

## What changed

- `runtime/src/state/startup-run-journal-recovery.ts`: instead of throwing, `quarantineReviewWithoutEvidence` records one quarantine incident for the run (idempotent: an existing exclusion for the run is returned as is) through `StateRecoveryIncidentRepository.recordQuarantine`, with `sourceKind: run_journal`, the session's placeholder journal path, reason code `source_changed` (the schema pins the code list in a check constraint; this is the closest truth, the bound source no longer exists) and a detail that says the journal was removed before the review was settled. The run is pushed to the report's `exclusions`, so the daemon prints its existing `recovery excluded N run(s) pending operator recovery action` line, keeps the run out of executable recovery, lists it under `agenc state recovery quarantine list`, and starts. `MISSING_RECOVERY_SOURCE_SHA256` (64 zeros) is the sentinel recorded as the source digest; an operator confirms it to `quarantine abandon` the incident.
- `runtime/tests/state/helpers/effect-review-fixture.ts` (new): opens the temp state databases and seeds a pending effect review through the run-durability repository; `tests/state/rollout-retention-sweep.test.ts` now seeds its #2240 case through it, so the two tests share one copy of that setup.
- `runtime/tests/state/pending-review-recovery.test.ts` (new): a pending review seeded through the run-durability repository with no session directory; recovery returns one quarantine exclusion for the run instead of throwing; a second pass returns the same incident; the sentinel is pinned.

## Evidence

| run | result |
| --- | --- |
| `tests/state/pending-review-recovery.test.ts` and `tests/state/rollout-retention-sweep.test.ts` | 18 passed |
| `tests/state/recovery-incidents.test.ts`, `recovery-restart.test.ts`, `recovery-journal-contract.test.ts`, `execution-admission-canonical-recovery.test.ts` | 90 passed |
| `tsc -p tsconfig.json --noEmit` | no errors other than the pre-existing TS2883 set |

## Tests

The first case asserts the exclusion's run, kind, reason code, source kind and detail and that `getRecoveryRunExclusion` now returns it; the second asserts idempotence by evidence id; the third pins the sentinel digest.

## Not changed

- A pending review whose journal is still present is projected as before.
- The reason-code list and the quarantine schema (a dedicated `source_missing` code needs a migration; noted in #2238).
- The sweep (#2240) and the review CLI.

## Counterparts

#2238 (second suggestion), #2240 (first suggestion), #2235, #2199.
