### PR TITLE
docs: soak report, the 40-prompt session, the kill-and-resume check, findings F70 to F72

### DIFF
--- a/docs/eval/app-soak-2026-09-05.md
+++ b/docs/eval/app-soak-2026-09-05.md
@@ -32,6 +32,7 @@ health. Driver and scenarios: `soak/soak.mjs`, `soak/scenarios/*.txt`; one JSONL
 | goal-9, goal-10 | driver goal mode (no model in the request), fresh daemon | 6 | 0 reached: every start refused at intake, "no reviewer model" (F62); fixed in #2217 | 0 | | | |
 | goal-11 | app goal UI, composer in default permission mode | 1 | failed after 10 min and $3: both implement attempts died because the headless children had no approver (F63); fixed in #2219 and desktop #192 | 0.2 h | | | |
 | goal-12 | driver goal mode, bypass, daemon main with #2216 and #2217 | 6 | 5 completed end to end (12, 33, 15, 23 and 14 minutes; plan, implement, verify, review, finalize; $3.80 to $9.68 each); run 6 ended `verification_failed` after 35 minutes and $11.75: its first implement attempt died because every nested `spawn_agent` was refused for an injected argument (F64, fixed in the strict-check PR), the second implemented without delegating, and the adversarial verifier failed the change while the sandbox refused its fixtures under /tmp (F65) | 2.1 h | 350 to 620 MB | | the goal path holds for hours; what it lost was one delegation attempt and one verdict |
+| endur-1 | production bundle, chat, one session, daemon main at 585038466 (with #2226, #2231, #2233) | 40 | 37 passed; 3 cut by the driver's 900 s step budget while the model was working (prompts 29, 37 and 40: 330, 487 and 520 rollout records in their windows, longest silences 133, 179 and 150 s); no failure, no reconnect; 3 h 54 min of turns on one daemon that was 4 h 31 min old at the end, 133 to 655 MB; per step 34 to 902 s, median 222 s; Stop on prompts 29 and 37 was undone by a sub-agent receipt nine seconds later (F70, #2236, fixed by #2237) |
 
 ## 2026-09-06: the production bundle, a bypass session, and a daemon that died
 
@@ -89,6 +90,39 @@ host, not the daemon; the product items it leaves are the lost turn and the reco
 
 A 40-prompt single-session coding run started afterwards on the same daemon as the primary-path endurance check and is
 recorded in the runs table when it ends.
+
+## 2026-09-06, night: the 40-prompt session
+
+The primary path, one chat session running the 40-prompt ledgerlite scenario end to end through the app, held for
+3 h 54 min without a failure: 37 prompts completed, 3 were cut by the harness's own 900 s step budget while the model was
+still working (the rollout shows steady activity in each window, with the longest silence a single 179 s model call), and
+the daemon that started the run was still the daemon at the end, 4 h 31 min old, between 133 and 655 MB. No reconnect,
+no turn error, no permission stall.
+
+The run found one defect of the kind that matters most. Both times the driver pressed Stop the turn aborted at once, and
+nine seconds later the daemon started a new turn that nobody asked for: the seed was a receipt from a verifier agent the
+model had spawned and closed earlier, delivered through the parent's mailbox, and `requestParentFollowupTurn` turned it into
+a turn with no notion that the user had just stopped. The model saw its half-finished work in the history and resumed it,
+for eighteen minutes the second time, with edits, commands and another spawned agent, while the composer stayed blocked
+(F70, #2236). The fix, merged the same night as #2237, latches a user stop on the session until the next user message and
+holds child receipts in the mailbox for that turn.
+
+The session's growth also showed on the daemon: the rollout reached 26 MB and each compaction bookkeeping scan of it, a
+whole-file read, grew from 64 ms at the start to 1.2 s at the end (#2229); the project's state database stood at 693 MB
+before the run (#2228, now bounded by the 30-day default of #2235).
+
+After the run, the daemon under test was killed with SIGKILL while a turn had a command in flight, to see the recovery
+end to end with the fixes of the day in place. Two things followed. The kill itself was recovered as designed once a
+daemon was back: hydrating the session in the app replayed the rollout, synthesized the missing abort, restarted the turn
+and resumed it from its checkpoint with the halted `write_stdin` named, and the app showed both lines (desktop #195); but
+the resumed turn ran without an approval resolver, so `write_stdin` and `exec_command` were refused and the model wrapped
+up instead of finishing (F72, #2239). Before that, though, no daemon could come back at all: an hour earlier the
+retention sweep, enabled on this home with a one-day window, had removed a day-old session whose run still held a pending
+effect review, and startup recovery treats a pending review without journal evidence as fatal, so every replacement
+daemon died during recovery and the app looped on autostart with a clear message (thanks to #2233). No CLI path could
+clear it; the home was repaired by hand in the state database (F71, #2238). Two fixes followed the same night: the sweep
+keeps such sessions (#2240) and recovery quarantines the run and starts instead of refusing (#2241). With the 30-day
+default of #2235 this would otherwise have reached every long-lived install.
 
 ## What broke or is missing
 
@@ -159,6 +193,9 @@ recorded in the runs table when it ends.
 | F64 | agents, injected arguments | `goal-12` run 6, first implement attempt: the child called `spawn_agent` and every call was refused with `unknown field \`__agencSessionAllowedRoots\``, seven times, until the repeat-failure backstop ended the turn ("No task was completed"). The executor injects that key beside `__callId` and the session id, but the multi-agent tools' strict-argument check tolerates only the latter two, so any nested spawn from a workflow child fails deterministically. The second attempt implemented without spawning. Costs one implement attempt per goal that tries to delegate. | FIXED #2221 (`isRuntimeInjectedArgKey`: `__callId` or any `__agenc`-prefixed key tolerated by the shared strict check) |
 | F65 | goal verifier, sandbox | The adversarial verifier of `goal-12` run 6 tried to write its fixtures to `/tmp/seed.csv` and via shell redirection; the sandbox refused both (`workspace_write blocked write outside workspace`, `shell_workspace_file_write_disallowed`), and the run ended `verification_failed` after 2103 s and $11.75. The refusals are correct; the verifier's prompt should point it at a writable scratch path inside the worktree. | FIXED #2223 (the verifier is told to write scratch under `tmp/` inside the worktree) |
 | F66 | daemon recovery | After the kill in F46, the replacement the app autostarts serves its websocket while it recovers its agent runs, but commits `daemon-runtime.json` and the final pid only after recovery, so for that whole window (long and about 1.3 GB under saturated swap) `agenc daemon status` could only say `indeterminate for unbound pid 149`. The heartbeat already proved the pid alive. | FIXED (#2226 reads the heartbeat and reports the daemon as alive but not yet bound, with its vitals); bounding the recovery spike stays open in #2225 |
+| F70 | stop, sub-agents | `endur-1` prompts 29 and 37: Stop aborted the turn, but nine seconds later a new turn started, seeded only by the receipt of a verifier agent the model had spawned and closed earlier (`<subagent_notification>`, status interrupted); the model resumed the stopped work for 18 minutes, and a second receipt started a third turn; the next prompt waited 1051 s. `requestParentFollowupTurn` had no notion of a user stop, and the Stop itself interrupts the children, which produces the receipt. | FIXED (#2237: a user stop latches the session until the next prompt; receipts wait in the mailbox) |
+| F71 | retention sweep, startup recovery | The sweep (`rollout_days = 1` on this home) removed a day-old session whose run kept a `run_effects` row with `review_status = pending`; after the next daemon death every replacement died in startup recovery (`pending effect review without retained canonical journal evidence`), `agenc daemon start` refused, quarantine and deferred lists were empty, and `state resolve-tool-call` refused for want of the deleted evidence. The home could not start a daemon by any product path. | FIXED (#2240: the sweep keeps sessions with pending reviews; #2241: recovery quarantines the run and starts). Soak home repaired by hand |
+| F72 | durable resume, permissions | Hydrating the killed session produced `orphaned_turn_recovered`, `turn_started`, `turn_resumed {fromCheckpointSeq: 4, halted: [write_stdin]}` and the halt warning; the resume works. The resumed turn had no approval resolver: `write_stdin` and `exec_command` were refused (`no_approval_resolver`) and the model wrapped up. | OPEN, #2239 |
 
 ## Fixes
 
@@ -208,6 +245,13 @@ Every pull request below was merged by 2026-09-06 02:00Z. The daemon under test 
 - #2220: a stopped turn ends `wait_agent` at once instead of at the mailbox deadline (#2201, F57). #2221: every runtime-injected key is tolerated by the strict argument checks, so a nested spawn from a workflow child no longer fails (F64). #2223: the verifier is told to write scratch files under `tmp/` in the worktree (F65). agenc-desktop #193: after two minutes of uninterrupted reasoning the ticker says no text has arrived yet (#2200, F52).
 - #2211: plan mode lets read-only shell commands through the gate (#2205, F51).
 - #2226: `agenc daemon status` reads the heartbeat of a live pid that has no identity record yet and reports it as alive but not yet bound, with its vitals, instead of indeterminate; a stale heartbeat says how old it is (#2225, F66).
+- #2231: `agenc daemon status` reports the project state databases on disk (count, total, largest) so growth is visible (#2228).
+- #2233 and agenc-desktop #194: a failed daemon autostart carries the CLI's last stderr lines instead of only its exit code (#2232).
+- #2234: a cancelled daemon startup bounds its cleanup, and macOS autostart waits up to 30 s for a beating unbound daemon to exit before refusing (#2232).
+- #2235: sessions untouched for 30 days are pruned by default; `rollout_days = 0` keeps every session (#2228).
+- agenc-desktop #195: a turn resumed after a daemon restart and the tools it did not re-run are shown (#2230).
+- #2237: a user Stop holds child receipts until the next prompt instead of restarting the turn (F70, #2236).
+- #2240 and #2241: the retention sweep keeps a session whose run has an effect under review, and startup recovery quarantines a review without journal evidence instead of refusing to start (F71, #2238).
 
 ## Day 3 in one paragraph
 


### PR DESCRIPTION
## Why

The soak report is the record of the phase. Tonight added the longest single-session run so far, a live kill-and-resume check, and three findings with fixes, and none of it was in the report.

## What changed

- `docs/eval/app-soak-2026-09-05.md`: the `endur-1` row in the runs table (40 prompts, 37 passed, 3 cut by the driver's budget while working, one daemon for 3 h 54 min); a night section for the run, the kill-and-resume check and the bricked home; findings F70 (Stop undone by a child receipt, fixed by #2237), F71 (the sweep deleted review evidence and recovery refused to start, fixed by #2240 and #2241) and F72 (the resumed turn has no approval resolver, #2239); the fixes list brought up to date with #2231, #2233, #2234, #2235, #2237, #2240, #2241 and desktop #194, #195.

## Evidence

Soak findings table `F70` to `F72`, issues #2236, #2238, #2239, PRs #2237, #2240, #2241, desktop #194, #195; the `endur-1` driver log and sampler.

## Tests

Docs only.

## Not changed

The rest of the report; the goal and swarm reruns get their rows when they end.

## Counterparts

The earlier report addenda #2204, #2210, #2222, #2224, #2227.
