### PR TITLE
workflow: carry the verifier's report into the re-implement and re-verify prompts

### DIFF
--- a/docs/design/verified-change-workflow-m5.md
+++ b/docs/design/verified-change-workflow-m5.md
@@ -103,6 +103,16 @@ A failed verification earns one bounded re-implement attempt
 `maxImplementAttempts` and remaining budget allow; otherwise the run
 terminates `failed/verification_failed`.
 
+Both retry prompts carry the previous verification forward: the
+re-implement prompt lists the verdict, the required-command results and the
+verification agent's report, and asks for every reported failure to be fixed;
+the second verification prompt carries the same report and asks the verifier
+to re-check every listed failure first, then continue its own independent
+pass. The report is read back from the committed `child.finalMessage`
+evidence, so a run resumed between the two attempts carries it too. (Soak
+F73: with only `Agent verdict: FAIL` in hand the implementer changed nothing,
+and the second verifier spent 22 minutes re-deriving the same two defects.)
+
 ## Session policy
 
 The frozen spec's `permissionMode`, unattended allow/deny lists, and the

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -531,6 +531,14 @@ interface RunContext {
     readonly testResult: RunArtifactPointer;
   };
   verifyVerdict?: string;
+  /**
+   * The verification agent's final message from the latest verify attempt,
+   * read back from the committed child evidence so a resumed run carries it
+   * too. Soak F73: without it the re-implement prompt said only
+   * `Agent verdict: FAIL` and the implementer changed nothing, while the
+   * second verifier re-derived the same defects from scratch.
+   */
+  verifyReport?: string;
   review?: VerifiedChangeReviewRecord;
   reviewNonBlocking?: readonly string[];
   export?: ExportedPatchArtifacts;
@@ -1180,7 +1188,17 @@ export class VerifiedChangeWorkflowController {
         attempt,
         spawnKind: "verify_agent",
         childRunId: `${ctx.runId}:verify-agent#${attempt}`,
-        prompt: buildVerifyAgentPrompt(ctx.spec, records),
+        prompt: buildVerifyAgentPrompt(
+          ctx.spec,
+          records,
+          attempt > 1 && ctx.verifyReport !== undefined
+            ? {
+                attempt: attempt - 1,
+                verdict: ctx.verifyVerdict ?? "FAIL",
+                report: ctx.verifyReport,
+              }
+            : undefined,
+        ),
         decorate: (outcome) => {
           const verdict = parseVerificationVerdict(outcome.finalMessage ?? "");
           return {
@@ -1220,6 +1238,7 @@ export class VerifiedChangeWorkflowController {
     const verdict = agent.evidence.verdict ?? "FAIL";
     ctx.verification = { records, allPassed, testResult };
     ctx.verifyVerdict = verdict;
+    ctx.verifyReport = agent.evidence.child?.finalMessage;
     return allPassed && verdict === "PASS";
   }
 
@@ -2564,9 +2583,13 @@ function buildImplementPrompt(ctx: RunContext, attempt: number): string {
           `- ${record.label}: exit ${record.exitCode}` +
           (record.timedOut ? " (timed out)" : ""),
       ),
-      "",
-      "Fix the failures above, then stop.",
     );
+    // Soak F73: the verdict alone told the implementer nothing; the report
+    // names the failures it has to fix.
+    if (ctx.verifyReport !== undefined) {
+      lines.push("", "### Verifier's report", ctx.verifyReport);
+    }
+    lines.push("", "Fix every failure reported above, then stop.");
   }
   return lines.join("\n");
 }
@@ -2574,6 +2597,11 @@ function buildImplementPrompt(ctx: RunContext, attempt: number): string {
 function buildVerifyAgentPrompt(
   spec: WorkflowSpec,
   records: readonly VerifiedChangeCommandRecord[],
+  previous?: {
+    readonly attempt: number;
+    readonly verdict: string;
+    readonly report: string;
+  },
 ): string {
   return [
     "You are an ADVERSARIAL verification agent for a proposed code change.",
@@ -2594,6 +2622,19 @@ function buildVerifyAgentPrompt(
         `- ${record.label}: exit ${record.exitCode}` +
         (record.timedOut ? " (timed out)" : ""),
     ),
+    // Soak F73: a second verifier that starts blind re-derives the previous
+    // findings from scratch; hand it the report and have it re-check those
+    // first, then keep verifying independently.
+    ...(previous !== undefined
+      ? [
+          "",
+          `## Previous verification attempt ${previous.attempt} (verdict ${previous.verdict})`,
+          "The change was re-implemented after this report. Re-check every",
+          "failure it lists first, then continue your own independent verification.",
+          "",
+          previous.report,
+        ]
+      : []),
     "",
     "End your final message with exactly one line:",
     "VERDICT: PASS | FAIL | PARTIAL",

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -604,6 +604,50 @@ describe("verifier prompt", () => {
   });
 });
 
+describe("retry prompts", () => {
+  it("carry the verifier's report into the re-implement and re-verify prompts", async () => {
+    // Soak F73: the implementer saw only `Agent verdict: FAIL` and changed
+    // nothing, and the second verifier re-derived the same defects from
+    // scratch. Attempt 1 fails on the agent's verdict alone.
+    const report =
+      "### Check: undo after a merge with duplicate ids\n" +
+      "undo restored one of two rows\n" +
+      "VERDICT: FAIL";
+    harness.spawner.queue("verify_agent", {
+      status: "completed",
+      finalMessage: report,
+      usage: DEFAULT_USAGE,
+    });
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    const implementSpawns = harness.spawner.spawns.filter(
+      (spawn) => spawn.kind === "implement",
+    );
+    const verifySpawns = harness.spawner.spawns.filter(
+      (spawn) => spawn.kind === "verify_agent",
+    );
+    expect(implementSpawns).toHaveLength(2);
+    expect(verifySpawns).toHaveLength(2);
+    // A first attempt carries nothing: there is no report yet.
+    expect(implementSpawns[0].prompt).not.toContain("Verifier's report");
+    expect(verifySpawns[0].prompt).not.toContain("Previous verification attempt");
+    // The retry names the failures to fix.
+    expect(implementSpawns[1].prompt).toContain("Agent verdict: FAIL");
+    expect(implementSpawns[1].prompt).toContain("undo restored one of two rows");
+    expect(implementSpawns[1].prompt).toContain(
+      "Fix every failure reported above, then stop.",
+    );
+    // The second verifier re-checks the reported failures first.
+    expect(verifySpawns[1].prompt).toContain(
+      "## Previous verification attempt 1 (verdict FAIL)",
+    );
+    expect(verifySpawns[1].prompt).toContain("undo restored one of two rows");
+    expect(verifySpawns[1].prompt).toContain("Re-check every");
+  });
+});
+
 describe("permission mode at start", () => {
   // Desktop soak F63: a goal started from the app in default mode planned, then
   // both implement attempts died because no approver existed for the headless
@@ -774,6 +818,9 @@ describe("VerifiedChangeWorkflowController — stop reasons", () => {
     );
     expect(implementSpawns).toHaveLength(2);
     expect(implementSpawns[1].prompt).toContain("Previous verification failure");
+    // The verifier's own report travels too, whatever its verdict was.
+    expect(implementSpawns[1].prompt).toContain("### Verifier's report");
+    expect(implementSpawns[1].prompt).toContain("checked everything");
   });
 
   it("review_rejected on blocking findings, with the review durably committed", async () => {


### PR DESCRIPTION
## Why

Desktop soak `goal-13`, goal 6 (#2243): the adversarial verifier found two real bugs and returned `VERDICT: FAIL`; the retry told the implementer only

```
## Previous verification failure (attempt 1)
Agent verdict: FAIL
- verify: exit 0
```

so implement 2 changed nothing ("No source changes needed"), and the second verifier, which received nothing from the first, was re-deriving the same defects from scratch (133 tool calls, 21.8 min, 2.74M tokens) when the run was cut. With `DEFAULT_MAX_IMPLEMENT_ATTEMPTS = 2` the run would have ended `verification_failed` after finding the same two bugs twice and fixing neither, at $17.61 against $4.80 to $11.70 for the goals that passed. The verifier's message was already durable in the parent's `effect_result` evidence (`child.finalMessage`, clipped at `EVIDENCE_MESSAGE_LIMIT`); it was never read back into the next prompts.

## What changed

- `runtime/src/app-server/workflow/verified-change-controller.ts`
  - `RunContext.verifyReport`: the verification agent's final message from the latest verify attempt, set in `#stageVerify` from `agent.evidence.child?.finalMessage`, so both a fresh spawn and an adopted committed effect (a run resumed between the two attempts) carry it.
  - `buildImplementPrompt`: on a retry the failure section now ends with `### Verifier's report` followed by the report, and the closing line asks for every reported failure to be fixed.
  - `buildVerifyAgentPrompt`: takes an optional `previous` (attempt, verdict, report). When present it adds `## Previous verification attempt N (verdict V)` with the report and the instruction to re-check every listed failure first, then continue independent verification. The call site passes it only for attempt 2 and later.
- `runtime/tests/workflow/verified-change-controller.test.ts`
  - new `retry prompts` case: verify 1 returns FAIL with a report line; the re-implement prompt and the second verify prompt both carry the line and the new instructions; the first attempts of each stage carry nothing; the run completes.
  - the existing `verification_failed` case also asserts the report travels when the verdict was PASS and a required command failed.
- `docs/design/verified-change-workflow-m5.md`: the retry paragraph describes the handoff and where the report comes from.

## Evidence

| run | result |
| --- | --- |
| `vitest run tests/workflow/verified-change-controller.test.ts` | 33 passed (32 before, plus the new case) |
| `tsc --noEmit` | no errors in changed files; the five `TS2883` lodash portable-type errors in `src/utils/*` are this worktree's baseline (types resolved through the main clone's `node_modules`) |
| `tsc --noEmit --project tsconfig.test-support.json` | 0 errors |
| goal-13 goal 6 child rollouts | verify 1: 86 tool calls, `VERDICT: FAIL`, two bugs named; implement 2 prompt: verdict and exit codes only; verify 2 prompt: 1205 chars, no prior report |

## Tests

The new case queues a verify-agent outcome with a distinctive report line and asserts its presence in exactly the two retry prompts and its absence from the first attempts, plus the two new instruction lines. The existing exhausted-budget case pins that the report is forwarded regardless of verdict.

## Not changed

- The retry budget (`DEFAULT_MAX_IMPLEMENT_ATTEMPTS = 2`) and the verdict parsing.
- The evidence shape: the report is read from the existing `child.finalMessage`, nothing new is journaled.
- No bound on a verification agent's tool calls or wall time; that is a separate question (the soak's verify stages ran 6 to 24 minutes and grew with the project).

## Counterparts

Closes #2243. Related observation #2244 (mid-turn prompt-cache resets in these child agents).
