### PR TITLE
workflow: a reviewer that never answered is a known, retried failure

### DIFF
--- a/runtime/src/app-server/workflow/session-adapters.ts
+++ b/runtime/src/app-server/workflow/session-adapters.ts
@@ -62,7 +62,10 @@ import { runSupervisedProcess } from "../../utils/supervisedProcess.js";
 import { applyUnattendedPermissionPolicyToContext } from "../../permissions/unattended-policy.js";
 import type { PermissionModeRegistry } from "../../permissions/permission-mode.js";
 import type { StateRunDurabilityRepository } from "../../state/run-durability.js";
-import type { ReviewerInvoker } from "../../workflow/independent-review.js";
+import {
+  ReviewInvocationError,
+  type ReviewerInvoker,
+} from "../../workflow/independent-review.js";
 import type {
   WorkflowCommandResult,
   WorkflowCommandRunner,
@@ -977,11 +980,13 @@ export function createWorkflowSessionSeams(
         },
       );
       if (outcome.rawText === null) {
-        throw (
-          outcome.error ??
-          new WorkflowSessionSeamError(
-            `independent review produced no output (${outcome.verdict})`,
-          )
+        // The one-shot settled without a response. Typed so the controller
+        // treats it as a known, retryable failure (soak F76).
+        throw new ReviewInvocationError(
+          outcome.error !== undefined
+            ? errorMessage(outcome.error)
+            : `verdict ${outcome.verdict}`,
+          outcome.error !== undefined ? { cause: outcome.error } : undefined,
         );
       }
       return outcome.rawText;

--- a/runtime/src/app-server/workflow/verified-change-controller.ts
+++ b/runtime/src/app-server/workflow/verified-change-controller.ts
@@ -79,6 +79,7 @@ import {
 } from "../../workflow/evidence-record.js";
 import {
   extractBlockers,
+  ReviewInvocationError,
   ReviewParseError,
   runIndependentReview,
   type ReviewerInvoker,
@@ -1371,11 +1372,16 @@ export class VerifiedChangeWorkflowController {
                 review.artifact,
               );
             } catch (error) {
-              if (error instanceof ReviewParseError) {
-                // A settled-but-unparseable reviewer is a KNOWN failure —
-                // durable for adoption too, so a crash in the commit window
-                // resumes into the same failed outcome (and its bounded
-                // retry), never into unknown_outcome.
+              if (
+                error instanceof ReviewParseError ||
+                error instanceof ReviewInvocationError
+              ) {
+                // A settled-but-unparseable reviewer, or one whose single
+                // call failed before any output (soak F76: a 403 on the
+                // reviewer's token), is a KNOWN failure — durable for
+                // adoption too, so a crash in the commit window resumes
+                // into the same failed outcome (and its bounded retry),
+                // never into unknown_outcome.
                 this.#recordReviewChildTerminal(ctx, childRunId, {
                   status: "failed",
                   finalMessage: error.message,
@@ -1387,7 +1393,10 @@ export class VerifiedChangeWorkflowController {
                     stage: "workflow.review",
                     attempt,
                     failure: {
-                      reason: "review_unparseable",
+                      reason:
+                        error instanceof ReviewParseError
+                          ? "review_unparseable"
+                          : "review_invocation_failed",
                       message: error.message,
                     },
                   },

--- a/runtime/src/workflow/independent-review.ts
+++ b/runtime/src/workflow/independent-review.ts
@@ -52,6 +52,21 @@ export class ReviewParseError extends Error {
 }
 
 /**
+ * The reviewer settled without producing any output: its one model call
+ * failed (provider error, authentication, timeout) before a response
+ * existed. Soak F76: a 403 on the reviewer's single call was rethrown as a
+ * plain error and the controller, knowing only `ReviewParseError`, recorded
+ * the run as `unknown_outcome`. A read-only reviewer that never answered is
+ * a KNOWN failure: nothing was committed, the attempt can be retried.
+ */
+export class ReviewInvocationError extends Error {
+  constructor(detail: string, options?: { readonly cause?: unknown }) {
+    super(`independent review produced no output: ${detail}`, options);
+    this.name = "ReviewInvocationError";
+  }
+}
+
+/**
  * A finding blocks completion when the reviewer marked it high priority
  * with real confidence. Priority follows the P0/P1 convention (lower is
  * more severe); the threshold and floor are pinned in the spec digest via

--- a/runtime/tests/workflow/verified-change-controller.test.ts
+++ b/runtime/tests/workflow/verified-change-controller.test.ts
@@ -34,7 +34,10 @@ import {
   openStateDatabases,
   type StateSqliteDriver,
 } from "../../src/state/sqlite-driver.js";
-import type { ReviewerInvoker } from "../../src/workflow/independent-review.js";
+import {
+  ReviewInvocationError,
+  type ReviewerInvoker,
+} from "../../src/workflow/independent-review.js";
 import type {
   WorkflowCommandResult,
   WorkflowCommandRunner,
@@ -438,6 +441,8 @@ class FakeReviewer implements ReviewerInvoker {
   readonly responses: string[] = [];
   /** Simulate a daemon death mid-review (before the reviewer settled). */
   onInvoke?: () => void;
+  /** Errors to throw instead of answering, in order (soak F76). */
+  readonly errors: Error[] = [];
 
   async invoke(input: {
     reviewerModel: string;
@@ -448,6 +453,8 @@ class FakeReviewer implements ReviewerInvoker {
       userMessage: input.userMessage,
     });
     this.onInvoke?.();
+    const error = this.errors.shift();
+    if (error !== undefined) throw error;
     return this.responses.shift() ?? APPROVING_REVIEW;
   }
 }
@@ -1277,6 +1284,53 @@ describe("VerifiedChangeWorkflowController — review-child adoption (A1 for the
     );
     // Attempt 1: the reply and its repair turn. Attempt 2: one verdict.
     expect(harness.reviewer.invocations).toHaveLength(3);
+  });
+});
+
+describe("VerifiedChangeWorkflowController — reviewer that never answered", () => {
+  // Soak F76: the reviewer's single model call got a 403 on a stale OAuth
+  // bearer; the error was rethrown untyped and the run died as
+  // unknown_outcome with an operator review pending. A read-only reviewer
+  // that settled without output is a known failure with a bounded retry.
+  it("a failed review invocation is a known failure that retries once", async () => {
+    harness.reviewer.errors.push(
+      new ReviewInvocationError("grok authentication failed (HTTP 403)"),
+    );
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)?.status).toBe(
+      "completed",
+    );
+    const first = harness.repo.getEffect(RUN_ID, "workflow.review");
+    expect(first?.outcome).toBe("failed");
+    expect(
+      harness.repo.getEffect(RUN_ID, "workflow.review#2")?.outcome,
+    ).toBe("committed");
+    // The failed attempt is durable as a FAILED review child terminal that
+    // names the cause, never as a pending unknown outcome.
+    expect(
+      harness.repo.getCurrentTerminalResult(`${RUN_ID}:review#1`),
+    ).toMatchObject({
+      status: "failed",
+      finalMessage: expect.stringContaining(
+        "grok authentication failed (HTTP 403)",
+      ),
+    });
+    expect(harness.reviewer.invocations).toHaveLength(2);
+  });
+
+  it("two failed invocations end the run failed, not unknown_outcome", async () => {
+    harness.reviewer.errors.push(
+      new ReviewInvocationError("grok authentication failed (HTTP 403)"),
+      new ReviewInvocationError("grok authentication failed (HTTP 403)"),
+    );
+    await runToTerminal(harness);
+    expect(harness.repo.getCurrentTerminalResult(RUN_ID)).toMatchObject({
+      status: "failed",
+      stopReason: "step_retries_exhausted",
+    });
+    expect(
+      harness.repo.listEffects(RUN_ID).filter((e) => e.outcome === "unknown_outcome"),
+    ).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Why

Desktop soak `goal-14` (the retest of #2245 on a daemon built from main at 4e92c3f6a): plan, implement and verify passed, then the review stage died within 250 ms. The reviewer's single model call returned HTTP 403 `The OAuth2 access token could not be validated.` (provider trace `agent-logs/review-2209…/llm-00001.jsonl`) while the verify child's calls had succeeded one second earlier on the same daemon and a prompt through the same daemon worked again eight minutes later. The seam threw the provider error as a plain `Error`; the controller's catch around `runIndependentReview` knew only `ReviewParseError`, so `#driveEffect` classified the dispatched spawn as `spawn_failed_after_dispatch_without_acknowledgement` and the run ended `unknown_outcome` with an operator review pending, at $8.25.

A read-only reviewer with no tools attached that settled without a response has committed nothing, so the honest classification is a known failure with the stage's bounded retry, the same path an unparseable review already takes.

## What changed

- `runtime/src/workflow/independent-review.ts`: `ReviewInvocationError` (message `independent review produced no output: <detail>`, keeps the cause).
- `runtime/src/app-server/workflow/session-adapters.ts`: the reviewer seam throws `ReviewInvocationError` when the one-shot review ends with no text, wrapping `outcome.error` when there is one and the verdict otherwise, instead of rethrowing the raw provider error.
- `runtime/src/app-server/workflow/verified-change-controller.ts`: the review stage catches `ReviewInvocationError` alongside `ReviewParseError`, records a failed review child terminal that names the cause and returns a failed attempt with `failure.reason = "review_invocation_failed"` (`review_unparseable` stays for the parse case). `#runStageWithRetries` then reruns the reviewer once; a second failure ends the run `failed / step_retries_exhausted`.
- `runtime/tests/workflow/verified-change-controller.test.ts`: `FakeReviewer` gains an `errors` queue; two cases: one failed invocation retries once and the run completes with the first attempt durable as a failed child terminal naming the 403; two failed invocations end the run `failed`, and no effect of the run is `unknown_outcome`.

## Evidence

| run | result |
| --- | --- |
| `vitest run tests/workflow/verified-change-controller.test.ts tests/workflow/session-adapters.policy.test.ts` | 44 passed (42 before, plus the two new cases) |
| `tsc --noEmit`, `tsc --noEmit --project tsconfig.test-support.json` | no errors outside this worktree's `TS2883` lodash baseline |
| goal-14 rollouts | reviewer run `review-2209…` terminal `failed`, stop reason `grok authentication failed (HTTP 403)`; parent run terminal `unknown_outcome`, `workflow.review failed after dispatch without acknowledgement` |

## Tests

The new cases drive the real controller through the M5 harness with a reviewer that throws `ReviewInvocationError` on its first call (and on both calls in the second case) and assert the effect outcomes, the child terminal and the run terminal.

## Not changed

- Why the bearer was stale: the adapter's only recovery for admitted single-wire-attempt calls is the pre-flight `refreshOAuthBearerIfExpiring`, which refreshes when the stored grant is expiring but does not re-read a bearer that another provider instance already refreshed. That is a separate fix; this PR makes the failure survivable.
- Errors other than a settled reviewer without output keep the unknown-outcome path.

## Counterparts

Soak finding F76; follows #2245 (goal-13 F73). The auth-side issue is filed separately.
