### PR TITLE
llm: the stored xAI OAuth grant wins in the grok factory itself

### DIFF
--- a/runtime/src/llm/provider.ts
+++ b/runtime/src/llm/provider.ts
@@ -80,7 +80,7 @@ import {
 export { resolveBuiltInProviderSlug } from "./registry/provider-info.js";
 import {
   forceRefreshXaiOauthCredentials,
-  isXaiOauthBearer,
+  readXaiOauthAccessToken,
   xaiOauthRequiresRelogin,
 } from "../utils/xaiOauthCredentials.js";
 import { isTrustedXaiOauthInferenceBaseUrl } from "../services/xai/oauth.js";
@@ -1614,10 +1614,19 @@ export function createProvider(
       // X means subscription access; leftover XAI_API_KEY must not shadow it.
       // Bearer refreshes via the adapter's I-14 401-recovery hook.
       const factoryApiKey = resolveFactoryApiKey(opts);
-      const usesXaiOauth =
-        opts.credentialHome !== undefined &&
-        isXaiOauthBearer(opts.credentialHome, factoryApiKey);
-      const apiKey = factoryApiKey ?? requireFactoryApiKey("grok", opts);
+      // The stored grant wins whenever it exists, here and not only in the
+      // option resolver upstream. Soak F76: a provider re-created from
+      // another instance's recorded factory options carries that instance's
+      // bearer snapshot; once the stored grant has been refreshed the
+      // snapshot no longer matches, and treating it as an API key sends a
+      // dead token with no refresh path (xAI answers 403).
+      const storedOauthBearer =
+        opts.credentialHome !== undefined
+          ? readXaiOauthAccessToken(opts.credentialHome)
+          : undefined;
+      const usesXaiOauth = storedOauthBearer !== undefined;
+      const apiKey =
+        storedOauthBearer ?? factoryApiKey ?? requireFactoryApiKey("grok", opts);
       const model = requireModel("grok", opts.model, defaultModelFor("grok"));
       const cfg: GrokProviderConfig = {
         ...buildCommonConfig(extra),

--- a/runtime/src/utils/xaiOauthCredentials.ts
+++ b/runtime/src/utils/xaiOauthCredentials.ts
@@ -103,18 +103,6 @@ export function readXaiOauthAccessToken(home: HomeContext): string | undefined {
   return blob.accessToken
 }
 
-/** True when `apiKey` is the stored OAuth bearer (vs a real xAI API key). */
-export function isXaiOauthBearer(
-  home: HomeContext,
-  apiKey: string | undefined,
-): boolean {
-  if (!apiKey) return false
-  const blob = readXaiOauthCredentials(home)
-  return blob !== undefined &&
-    blob.quarantinedAt === undefined &&
-    blob.accessToken === apiKey
-}
-
 export function saveXaiOauthCredentials(
   home: HomeContext,
   blob: XaiOauthCredentialBlob,

--- a/runtime/src/utils/xaiOauthCredentials.ts
+++ b/runtime/src/utils/xaiOauthCredentials.ts
@@ -103,6 +103,18 @@ export function readXaiOauthAccessToken(home: HomeContext): string | undefined {
   return blob.accessToken
 }
 
+/** True when `apiKey` is the stored OAuth bearer (vs a real xAI API key). */
+export function isXaiOauthBearer(
+  home: HomeContext,
+  apiKey: string | undefined,
+): boolean {
+  if (!apiKey) return false
+  const blob = readXaiOauthCredentials(home)
+  return blob !== undefined &&
+    blob.quarantinedAt === undefined &&
+    blob.accessToken === apiKey
+}
+
 export function saveXaiOauthCredentials(
   home: HomeContext,
   blob: XaiOauthCredentialBlob,

--- a/runtime/tests/llm/grok-oauth-factory.test.ts
+++ b/runtime/tests/llm/grok-oauth-factory.test.ts
@@ -32,6 +32,8 @@ async function importProviderModule() {
   ])
   return {
     ...providerModule,
+    /** The factory itself, without the option resolver's OAuth substitution. */
+    createProviderRaw: providerModule.createProvider,
     createProvider: (
       provider: 'grok',
       requested: Parameters<typeof providerModule.createProvider>[1],
@@ -235,4 +237,53 @@ test('API-key mode keeps the no-refresh default callback', async () => {
     previousError: Object.assign(new Error('401'), { status: 401 }),
   })
   expect(outcome.kind).toBe('skipped')
+})
+
+test('a stale bearer snapshot passed as apiKey does not demote the raw factory to API-key mode', async () => {
+  // Soak F76: the verified-change reviewer's provider was re-created from
+  // the parent session's recorded factory options, which held the bearer
+  // resolved at run start. The stored grant had been refreshed since, so
+  // the snapshot matched nothing and the raw factory picked API-key mode:
+  // no refresh callbacks, no pre-flight, and xAI answered 403.
+  storedAccessToken = 'oauth-bearer-2'
+  const { createProviderRaw } = await importProviderModule()
+
+  const provider = createProviderRaw('grok', {
+    apiKey: 'oauth-bearer-1',
+    model: 'grok-4.5',
+    credentialHome: CREDENTIAL_HOME,
+  })
+  expect((provider as unknown as { config: { apiKey: string } }).config.apiKey).toBe(
+    'oauth-bearer-2',
+  )
+  // OAuth mode is active: the bearer is refused for a non-xAI host.
+  expect(() =>
+    createProviderRaw('grok', {
+      apiKey: 'oauth-bearer-1',
+      model: 'grok-4.5',
+      credentialHome: CREDENTIAL_HOME,
+      baseURL: 'https://attacker.example/v1',
+    }),
+  ).toThrow(/refusing to send the xAI OAuth bearer/)
+})
+
+test('a provider re-created from recorded factory options after a refresh carries the current grant', async () => {
+  storedAccessToken = 'oauth-bearer-1'
+  const { createProviderRaw, readProviderFactoryOptions } = await importProviderModule()
+  const first = createProviderRaw('grok', {
+    model: 'grok-4.5',
+    credentialHome: CREDENTIAL_HOME,
+  })
+
+  storedAccessToken = 'oauth-bearer-2'
+  const second = createProviderRaw('grok', {
+    ...readProviderFactoryOptions(first),
+    model: 'grok-4.5',
+  })
+  expect((second as unknown as { config: { apiKey: string } }).config.apiKey).toBe(
+    'oauth-bearer-2',
+  )
+  expect(
+    (second as unknown as { oauthCallbacksInstalled: boolean }).oauthCallbacksInstalled,
+  ).toBe(true)
 })


### PR DESCRIPTION
## Why

Desktop soak `goal-14`: the verified-change reviewer's single Grok call got HTTP 403 `The OAuth2 access token could not be validated.` one second after the verify child's calls had succeeded on the same daemon, and a prompt through the same daemon worked again minutes later. The review delegate builds its provider with `createProvider(providerName, { ...readProviderFactoryOptions(parentProvider), model })`. The recorded options hold the bearer the parent resolved when it was created (`markFactoryProvider` records `apiKey`), and `readProviderFactoryOptions` returns them unchanged. The parent here was the run session's provider, created at 06:58:41 and never used for a model call; by 07:22:44 sibling child providers had refreshed the stored grant, so the snapshot no longer matched it, `isXaiOauthBearer` said no, and the factory built the reviewer's provider in API-key mode: no refresh callbacks, so no pre-flight refresh, and a dead bearer on the wire with no recovery.

The product rule already says the stored grant wins over any passed key ("/grok-login OAuth wins over an explicit env-style apiKey"), but only `resolveProviderFactoryOptions` applied it, and twelve call sites re-create providers from recorded options without going through it (review delegate, compaction, memory selector, code prediction, admitted model calls, bootstrap services, model-facing tools).

## What changed

- `runtime/src/llm/provider.ts` (grok branch): when `credentialHome` is given, read the stored grant with `readXaiOauthAccessToken`; if a live one exists the factory is in OAuth mode and uses its current bearer, whatever `apiKey` was passed. Without a grant the previous behaviour stands (passed key, or the "requires apiKey" error).
- `runtime/tests/llm/grok-oauth-factory.test.ts`: the harness also exposes the raw factory; two cases: a stale bearer snapshot passed as `apiKey` yields the stored bearer and OAuth mode (a non-xAI base URL is refused); a provider re-created from the recorded options of one built before a refresh carries the current bearer with the refresh callbacks installed.

## Evidence

| run | result |
| --- | --- |
| `vitest run tests/llm/grok-oauth-factory.test.ts tests/llm/providers/grok/adapter.test.ts tests/llm/provider-credential-authority.test.ts` | 66 passed (64 before, plus the two new cases) |
| `vitest run tests/utils/xaiOauthCredentials.test.ts` (covers `isXaiOauthBearer`, which stays although the factory no longer calls it) | passed |
| `tsc --noEmit`, `tsc --noEmit --project tsconfig.test-support.json` | no errors outside this worktree's `TS2883` lodash baseline |
| goal-14 provider trace `agent-logs/review-2209…/llm-00001.jsonl` | one request, `error` after 250 ms, status 403, body `The OAuth2 access token could not be validated.`; the verify child's trace ends with a successful response at 07:22:43 |

## Tests

The new cases drive the real `createProvider` with the credentials module mocked, as the existing tests in the file do; the second case reproduces the failing sequence exactly: build, refresh the stored grant, re-create from recorded options.

## Not changed

- The option resolver's own OAuth substitution and the API-key mode without a grant (its base-URL exemption test still passes).
- The recorded factory options still carry `apiKey`; with the factory re-resolving the grant the snapshot is harmless for grok.
- `isXaiOauthBearer` stays in the credentials module (its unit test covers it); the factory no longer calls it.
- The controller side of the same incident is #2248 (a reviewer that never answered is a retried known failure).

## Counterparts

Soak finding F76; #2248.
