### PR TITLE
session: the in-memory tool-result bound mirrors the outbound view

### DIFF
--- a/runtime/src/session/durable-turns.ts
+++ b/runtime/src/session/durable-turns.ts
@@ -162,8 +162,10 @@ function contentText(content: unknown): string {
  * Is this a tool-output message? Tool-output BODIES are the only content
  * that diverges between the write side and the read side: reconstruction
  * caps them at `DEFAULT_MAX_TOOL_RESULT_BYTES` on replay, while the live
- * in-memory copy is independently bounded (`boundInMemoryToolResultContent`
- * replaces older large bodies with a fixed marker). So the hash must NOT
+ * in-memory copy is bounded by `boundInMemoryToolResultContent`, which
+ * replaces older large bodies either with the bytes the outbound projection
+ * already carried or, before a compaction boundary, with a fixed marker. So
+ * the hash must NOT
  * depend on the variable tool-output body — only on its threading identity
  * and a bound-stable size class.
  */

--- a/runtime/src/session/run-turn-query-messages.ts
+++ b/runtime/src/session/run-turn-query-messages.ts
@@ -410,7 +410,63 @@ function toolResultContentLength(content: LLMMessage["content"]): number {
 function boundInMemoryToolResultContent(
   messages: LLMMessage[],
   boundUpToIndex: number,
+  outboundMessages: readonly LLMMessage[] | undefined,
 ): number {
+  // Soak F74 / #2244: this bound used to decide on its own which results to
+  // clear, using constants "kept in lockstep" with microcompact by hand. The
+  // two policies drifted, and worse, this one has no pressure gate: a result
+  // still being sent in FULL on the wire was cleared here the moment it fell
+  // out of a flat recent-N window, so the NEXT request sent a marker where the
+  // last one sent the body. That rewrites an already-cached prefix, and the
+  // provider re-reads every token after it (438,986 re-billed input tokens in
+  // one traced six-goal run, up to 51,725 per event).
+  //
+  // The decision now belongs to the OUTBOUND projection alone. This function
+  // may only:
+  //   - adopt, byte for byte, content the request that just went out already
+  //     carried in shrunken form (zero delta by construction), or
+  //   - clear results before the newest authenticated compaction boundary,
+  //     which no future request will ever carry again (free).
+  // Anything the wire still carries in full stays full here.
+  const outboundContentByCallId = new Map<string, LLMMessage["content"]>();
+  for (const message of outboundMessages ?? []) {
+    if (!isToolResultMessage(message)) continue;
+    const callId = message.toolCallId;
+    if (callId === undefined) continue;
+    outboundContentByCallId.set(callId, message.content);
+  }
+  // Messages at or after this index are still reachable by future requests.
+  let boundaryIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message !== undefined && isAuthenticatedCompactionBoundary(message)) {
+      boundaryIndex = index;
+      break;
+    }
+  }
+  let clearedBeforeBoundary = 0;
+  // Everything before the newest boundary is sliced away by
+  // `messagesAfterAgenCBoundary` on every future projection, so no request
+  // will ever carry it again. Clearing there is free, which is why it needs
+  // none of the eligibility rules below: no keep-recent window, no
+  // compactable-tool list, no path retention. The durable rollout still holds
+  // the full bytes for resume.
+  const preBoundaryLimit = Math.min(boundaryIndex, boundUpToIndex);
+  for (let index = 0; index < preBoundaryLimit; index += 1) {
+    const message = messages[index];
+    if (message === undefined || !isToolResultMessage(message)) continue;
+    if (message.content === IN_MEMORY_TOOL_RESULT_CLEARED_MARKER) continue;
+    if (
+      toolResultContentLength(message.content) < IN_MEMORY_TOOL_RESULT_MAX_CHARS
+    ) {
+      continue;
+    }
+    messages[index] = {
+      ...message,
+      content: IN_MEMORY_TOOL_RESULT_CLEARED_MARKER,
+    };
+    clearedBeforeBoundary += 1;
+  }
   // Compactability is keyed off the assistant `toolCalls` that requested each
   // tool, exactly like microcompact's `collectCompactableToolUseIds` — the
   // tool-result message itself does not reliably carry `toolName`. A result is
@@ -491,13 +547,29 @@ function boundInMemoryToolResultContent(
       continue;
     }
     if (message.content === IN_MEMORY_TOOL_RESULT_CLEARED_MARKER) continue;
-    messages[index] = {
-      ...message,
-      content: IN_MEMORY_TOOL_RESULT_CLEARED_MARKER,
-    };
-    cleared += 1;
+    const callId = message.toolCallId;
+    const outboundContent =
+      callId !== undefined ? outboundContentByCallId.get(callId) : undefined;
+    if (outboundContent !== undefined) {
+      // The wire still carries this result in full: clearing it here would
+      // change the next request's bytes and cost the whole cached suffix.
+      if (
+        toolResultContentLength(outboundContent) >=
+        toolResultContentLength(message.content)
+      ) {
+        continue;
+      }
+      // Adopt the outbound bytes verbatim, so the next request's projection
+      // reproduces exactly what the last one sent.
+      messages[index] = { ...message, content: outboundContent };
+      cleared += 1;
+      continue;
+    }
+    // Not carried by the request that just went out, and after the boundary:
+    // a future projection may still carry it, so it stays whole. (Anything
+    // before the boundary was already handled by the free pass above.)
   }
-  return cleared;
+  return cleared + clearedBeforeBoundary;
 }
 
 // Shared with run-turn.ts and its sibling modules.

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -1859,7 +1859,11 @@ async function* runTurnKernelInner(
     // most-recent-N tool results full and the disk rollout untouched.
     // See session-history-memory fix above.
     if (ctx.editorInteraction === undefined) {
-      boundInMemoryToolResultContent(state.messages, persistedMessageCount);
+      boundInMemoryToolResultContent(
+        state.messages,
+        persistedMessageCount,
+        state.messagesForQuery,
+      );
     }
     const durableHistory = state.messages
       .slice(durableHistoryStartIndex(state.messages))

--- a/runtime/tests/session/helpers/cleared-tool-result-marker.ts
+++ b/runtime/tests/session/helpers/cleared-tool-result-marker.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared by the in-memory tool-result suites.
+ *
+ * Soak F74 / #2244: the in-memory bound no longer invents its own marker. It
+ * adopts, byte for byte, whatever the request that just went out carried for
+ * that tool result, so the next request reproduces the last one's prefix.
+ * Under microcompact pressure that is microcompact's own marker; the bare
+ * marker is written only for results before a compaction boundary, which no
+ * future request carries at all. A test asserting "this result was cleared in
+ * memory" must therefore accept either form.
+ */
+
+/** Written for results before a compaction boundary. */
+export const CLEARED_MARKER = "[Old tool result content cleared]";
+
+/** Written by microcompact in the outbound view, then adopted verbatim. */
+export const MICROCOMPACT_MARKER_RE =
+  /^\[microcompact:\d+\] Older tool output compressed; original length [\d,]+ characters\.$/;
+
+export function isClearedToolResultMarker(text: string): boolean {
+  return text === CLEARED_MARKER || MICROCOMPACT_MARKER_RE.test(text);
+}

--- a/runtime/tests/session/in-memory-tool-result-mirrors-outbound.test.ts
+++ b/runtime/tests/session/in-memory-tool-result-mirrors-outbound.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Regression: the live in-memory history must never diverge from the request
+ * that just went out (soak F74, agenc-core #2244).
+ *
+ * `boundInMemoryToolResultContent` shrinks `state.messages` after each phase
+ * iteration so the session's heap does not grow with turn count. It used to
+ * decide WHICH results to clear on its own, with constants hand-synced to
+ * microcompact and no pressure gate, so a result the wire was still sending in
+ * full got replaced by a marker in memory. The next request then rendered a
+ * marker where the previous one had rendered the body, which rewrites an
+ * already-cached prefix: the provider re-reads every token after that offset.
+ * A traced six-goal desktop soak run re-billed 438,986 input tokens this way,
+ * up to 51,725 in a single event.
+ *
+ * The bound is now a CONSUMER of the outbound projection. It may adopt exactly
+ * the bytes the last request carried, or clear results before a compaction
+ * boundary that no future request carries at all. Nothing else.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { boundInMemoryToolResultContent } from "../../src/session/run-turn-query-messages.js";
+import type { LLMMessage } from "../../src/llm/types.js";
+
+const BIG = "x".repeat(20_000);
+const MICROCOMPACT_MARKER =
+  "[microcompact:1] Older tool output compressed; original length 20,000 characters.";
+const BARE_MARKER = "[Old tool result content cleared]";
+
+// `exec_command` is compactable but not path-bearing, so these fixtures
+// exercise the keep-recent window without the latest-read-per-path retention
+// that would protect every distinct file in a FileRead fixture.
+function shellCall(id: string): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      { id, name: "exec_command", arguments: JSON.stringify({ cmd: "npm test" }) },
+    ],
+  } as LLMMessage;
+}
+
+function shellResult(id: string, content: string): LLMMessage {
+  return {
+    role: "tool",
+    content,
+    toolCallId: id,
+    toolName: "exec_command",
+  } as LLMMessage;
+}
+
+/** Enough results that the oldest fall outside the keep-recent window. */
+function historyOfReads(count: number): LLMMessage[] {
+  const messages: LLMMessage[] = [];
+  for (let i = 1; i <= count; i += 1) {
+    messages.push(shellCall(`call_${i}`));
+    messages.push(shellResult(`call_${i}`, `${BIG}_${i}`));
+  }
+  return messages;
+}
+
+describe("boundInMemoryToolResultContent mirrors the outbound view", () => {
+  test("a result the request still carries in full is left full in memory", () => {
+    const messages = historyOfReads(12);
+    // The wire carried every result whole: nothing may be cleared, however old.
+    const outbound = messages
+      .filter((message) => message.toolCallId !== undefined)
+      .map((message) => ({ ...message }));
+
+    const cleared = boundInMemoryToolResultContent(
+      messages,
+      messages.length,
+      outbound,
+    );
+
+    expect(cleared).toBe(0);
+    const bodies = messages.filter(
+      (message) =>
+        message.toolCallId !== undefined &&
+        typeof message.content === "string" &&
+        message.content.startsWith("x".repeat(100)),
+    );
+    expect(bodies).toHaveLength(12);
+  });
+
+  test("a result the request carried shrunken is adopted byte for byte", () => {
+    const messages = historyOfReads(12);
+    const outbound = messages
+      .filter((message) => message.toolCallId !== undefined)
+      .map((message) =>
+        message.toolCallId === "call_1"
+          ? { ...message, content: MICROCOMPACT_MARKER }
+          : { ...message },
+      );
+
+    const cleared = boundInMemoryToolResultContent(
+      messages,
+      messages.length,
+      outbound,
+    );
+
+    expect(cleared).toBe(1);
+    const first = messages.find((message) => message.toolCallId === "call_1");
+    // The exact outbound bytes, NOT this module's own marker: anything else
+    // would change the next request's prefix.
+    expect(first?.content).toBe(MICROCOMPACT_MARKER);
+    expect(first?.content).not.toBe(BARE_MARKER);
+  });
+
+  test("results before a compaction boundary are cleared, later ones are not", () => {
+    const before = historyOfReads(3);
+    const boundary = {
+      role: "developer",
+      content: "compacted",
+      runtimeOnly: {
+        compactionHistory: {
+          version: 1,
+          kind: "boundary",
+          attempt_id: "attempt-1",
+          summary_sha256: "a".repeat(64),
+        },
+      },
+    } as unknown as LLMMessage;
+    const after = historyOfReads(3).map((message) =>
+      message.toolCallId !== undefined
+        ? { ...message, toolCallId: `${message.toolCallId}_after` }
+        : {
+            ...message,
+            toolCalls: (message.toolCalls ?? []).map((call) => ({
+              ...call,
+              id: `${call.id}_after`,
+            })),
+          },
+    );
+    const messages = [...before, boundary, ...after];
+    // The outbound view starts after the boundary and carried everything whole.
+    const outbound = after
+      .filter((message) => message.toolCallId !== undefined)
+      .map((message) => ({ ...message }));
+
+    const cleared = boundInMemoryToolResultContent(
+      messages,
+      messages.length,
+      outbound,
+    );
+
+    // Exactly the three pre-boundary results: never sent again, so free.
+    expect(cleared).toBe(3);
+    for (const message of messages.slice(0, before.length)) {
+      if (message.toolCallId === undefined) continue;
+      expect(message.content).toBe(BARE_MARKER);
+    }
+    for (const message of messages.slice(before.length + 1)) {
+      if (message.toolCallId === undefined) continue;
+      expect(message.content).not.toBe(BARE_MARKER);
+    }
+  });
+
+  test("a result absent from the outbound view after the boundary is left alone", () => {
+    const messages = historyOfReads(12);
+    // No boundary and an outbound view that simply does not mention call_1:
+    // the safe reading is that a future request may still carry it.
+    const outbound = messages
+      .filter(
+        (message) =>
+          message.toolCallId !== undefined && message.toolCallId !== "call_1",
+      )
+      .map((message) => ({ ...message }));
+
+    const cleared = boundInMemoryToolResultContent(
+      messages,
+      messages.length,
+      outbound,
+    );
+
+    expect(cleared).toBe(0);
+    const first = messages.find((message) => message.toolCallId === "call_1");
+    expect(first?.content).toBe(`${BIG}_1`);
+  });
+
+  test("not-yet-persisted tail messages are never touched", () => {
+    const messages = historyOfReads(12);
+    const outbound = messages
+      .filter((message) => message.toolCallId !== undefined)
+      .map((message) => ({ ...message, content: MICROCOMPACT_MARKER }));
+
+    // boundUpToIndex 0: nothing has been persisted yet.
+    const cleared = boundInMemoryToolResultContent(messages, 0, outbound);
+
+    expect(cleared).toBe(0);
+  });
+
+  test("no outbound view at all clears nothing without a boundary", () => {
+    const messages = historyOfReads(12);
+    const cleared = boundInMemoryToolResultContent(
+      messages,
+      messages.length,
+      undefined,
+    );
+    expect(cleared).toBe(0);
+  });
+});

--- a/runtime/tests/session/in-memory-tool-result-mirrors-outbound.test.ts
+++ b/runtime/tests/session/in-memory-tool-result-mirrors-outbound.test.ts
@@ -20,12 +20,12 @@
 import { describe, expect, test } from "vitest";
 
 import { boundInMemoryToolResultContent } from "../../src/session/run-turn-query-messages.js";
+import { CLEARED_MARKER as BARE_MARKER } from "./helpers/cleared-tool-result-marker.js";
 import type { LLMMessage } from "../../src/llm/types.js";
 
 const BIG = "x".repeat(20_000);
 const MICROCOMPACT_MARKER =
   "[microcompact:1] Older tool output compressed; original length 20,000 characters.";
-const BARE_MARKER = "[Old tool result content cleared]";
 
 // `exec_command` is compactable but not path-bearing, so these fixtures
 // exercise the keep-recent window without the latest-read-per-path retention
@@ -49,6 +49,24 @@ function shellResult(id: string, content: string): LLMMessage {
   } as LLMMessage;
 }
 
+/** The tool results of a history, as the outbound projection would carry them. */
+function outboundOf(
+  messages: readonly LLMMessage[],
+  rewrite: (message: LLMMessage) => LLMMessage = (message) => ({ ...message }),
+): LLMMessage[] {
+  return messages
+    .filter((message) => message.toolCallId !== undefined)
+    .map(rewrite);
+}
+
+/** Bound the whole history as `syncSessionState` does once everything is persisted. */
+function boundAll(
+  messages: LLMMessage[],
+  outbound: readonly LLMMessage[] | undefined,
+): number {
+  return boundInMemoryToolResultContent(messages, messages.length, outbound);
+}
+
 /** Enough results that the oldest fall outside the keep-recent window. */
 function historyOfReads(count: number): LLMMessage[] {
   const messages: LLMMessage[] = [];
@@ -63,15 +81,7 @@ describe("boundInMemoryToolResultContent mirrors the outbound view", () => {
   test("a result the request still carries in full is left full in memory", () => {
     const messages = historyOfReads(12);
     // The wire carried every result whole: nothing may be cleared, however old.
-    const outbound = messages
-      .filter((message) => message.toolCallId !== undefined)
-      .map((message) => ({ ...message }));
-
-    const cleared = boundInMemoryToolResultContent(
-      messages,
-      messages.length,
-      outbound,
-    );
+    const cleared = boundAll(messages, outboundOf(messages));
 
     expect(cleared).toBe(0);
     const bodies = messages.filter(
@@ -85,18 +95,13 @@ describe("boundInMemoryToolResultContent mirrors the outbound view", () => {
 
   test("a result the request carried shrunken is adopted byte for byte", () => {
     const messages = historyOfReads(12);
-    const outbound = messages
-      .filter((message) => message.toolCallId !== undefined)
-      .map((message) =>
+    const cleared = boundAll(
+      messages,
+      outboundOf(messages, (message) =>
         message.toolCallId === "call_1"
           ? { ...message, content: MICROCOMPACT_MARKER }
           : { ...message },
-      );
-
-    const cleared = boundInMemoryToolResultContent(
-      messages,
-      messages.length,
-      outbound,
+      ),
     );
 
     expect(cleared).toBe(1);
@@ -134,15 +139,7 @@ describe("boundInMemoryToolResultContent mirrors the outbound view", () => {
     );
     const messages = [...before, boundary, ...after];
     // The outbound view starts after the boundary and carried everything whole.
-    const outbound = after
-      .filter((message) => message.toolCallId !== undefined)
-      .map((message) => ({ ...message }));
-
-    const cleared = boundInMemoryToolResultContent(
-      messages,
-      messages.length,
-      outbound,
-    );
+    const cleared = boundAll(messages, outboundOf(after));
 
     // Exactly the three pre-boundary results: never sent again, so free.
     expect(cleared).toBe(3);
@@ -160,17 +157,11 @@ describe("boundInMemoryToolResultContent mirrors the outbound view", () => {
     const messages = historyOfReads(12);
     // No boundary and an outbound view that simply does not mention call_1:
     // the safe reading is that a future request may still carry it.
-    const outbound = messages
-      .filter(
-        (message) =>
-          message.toolCallId !== undefined && message.toolCallId !== "call_1",
-      )
-      .map((message) => ({ ...message }));
-
-    const cleared = boundInMemoryToolResultContent(
+    const cleared = boundAll(
       messages,
-      messages.length,
-      outbound,
+      outboundOf(messages).filter(
+        (message) => message.toolCallId !== "call_1",
+      ),
     );
 
     expect(cleared).toBe(0);
@@ -180,23 +171,22 @@ describe("boundInMemoryToolResultContent mirrors the outbound view", () => {
 
   test("not-yet-persisted tail messages are never touched", () => {
     const messages = historyOfReads(12);
-    const outbound = messages
-      .filter((message) => message.toolCallId !== undefined)
-      .map((message) => ({ ...message, content: MICROCOMPACT_MARKER }));
-
     // boundUpToIndex 0: nothing has been persisted yet.
-    const cleared = boundInMemoryToolResultContent(messages, 0, outbound);
+    const cleared = boundInMemoryToolResultContent(
+      messages,
+      0,
+      outboundOf(messages, (message) => ({
+        ...message,
+        content: MICROCOMPACT_MARKER,
+      })),
+    );
 
     expect(cleared).toBe(0);
   });
 
   test("no outbound view at all clears nothing without a boundary", () => {
     const messages = historyOfReads(12);
-    const cleared = boundInMemoryToolResultContent(
-      messages,
-      messages.length,
-      undefined,
-    );
+    const cleared = boundAll(messages, undefined);
     expect(cleared).toBe(0);
   });
 });

--- a/runtime/tests/session/run-turn.memory-bound-naming.test.ts
+++ b/runtime/tests/session/run-turn.memory-bound-naming.test.ts
@@ -70,17 +70,10 @@ import { createTestConfigStore } from "../fixtures.js";
 
 const LARGE_TOOL_OUTPUT_BYTES = 80_000; // > clear threshold (6_000).
 const KEEP_RECENT = 5; // mirrors the in-memory keep-recent window.
-const CLEARED_MARKER = "[Old tool result content cleared]";
-// Soak F74 / #2244: the in-memory bound no longer invents its own marker. It
-// adopts, byte for byte, whatever the request that just went out carried for
-// that tool result, so the next request reproduces the last one's prefix. Under
-// microcompact pressure that is microcompact's own marker; the bare marker
-// above is written only for results before a compaction boundary, which no
-// future request carries at all.
-const MICROCOMPACT_MARKER_RE =
-  /^\[microcompact:\d+\] Older tool output compressed; original length [\d,]+ characters\.$/;
-const isClearedToolResultMarker = (text: string): boolean =>
-  text === CLEARED_MARKER || MICROCOMPACT_MARKER_RE.test(text);
+import {
+  CLEARED_MARKER,
+  isClearedToolResultMarker,
+} from "./helpers/cleared-tool-result-marker.js";
 const UNTRUSTED_TOOL_RESULT_BOUNDARY =
   "===== AGENC UNTRUSTED TOOL RESULT DATA =====";
 // The shell tool registers as "exec_command" in the live registry. Mirrored

--- a/runtime/tests/session/run-turn.memory-bound-naming.test.ts
+++ b/runtime/tests/session/run-turn.memory-bound-naming.test.ts
@@ -71,6 +71,16 @@ import { createTestConfigStore } from "../fixtures.js";
 const LARGE_TOOL_OUTPUT_BYTES = 80_000; // > clear threshold (6_000).
 const KEEP_RECENT = 5; // mirrors the in-memory keep-recent window.
 const CLEARED_MARKER = "[Old tool result content cleared]";
+// Soak F74 / #2244: the in-memory bound no longer invents its own marker. It
+// adopts, byte for byte, whatever the request that just went out carried for
+// that tool result, so the next request reproduces the last one's prefix. Under
+// microcompact pressure that is microcompact's own marker; the bare marker
+// above is written only for results before a compaction boundary, which no
+// future request carries at all.
+const MICROCOMPACT_MARKER_RE =
+  /^\[microcompact:\d+\] Older tool output compressed; original length [\d,]+ characters\.$/;
+const isClearedToolResultMarker = (text: string): boolean =>
+  text === CLEARED_MARKER || MICROCOMPACT_MARKER_RE.test(text);
 const UNTRUSTED_TOOL_RESULT_BOUNDARY =
   "===== AGENC UNTRUSTED TOOL RESULT DATA =====";
 // The shell tool registers as "exec_command" in the live registry. Mirrored
@@ -421,7 +431,7 @@ describe("runTurn — memory-bound-naming in-memory bound (FileRead)", () => {
       const clearedMarkers = history.filter(
         (m) =>
           (m.role === "tool" || m.toolCallId !== undefined) &&
-          messageText(m) === CLEARED_MARKER,
+          isClearedToolResultMarker(messageText(m)),
       );
       expect(clearedMarkers.length).toBeGreaterThan(0);
     },
@@ -475,7 +485,7 @@ describe("runTurn — memory-bound-naming in-memory bound (FileRead)", () => {
       // by later OTHER-path reads, IS cleared — proving clearing actually fired
       // and the active-path retention is path-aware, not just the window.
       const oldOther = byCallId.get("tool_call_turn_2");
-      expect(oldOther).toBe(CLEARED_MARKER);
+      expect(isClearedToolResultMarker(String(oldOther))).toBe(true);
 
       // The most-recent OTHER read (turn TOTAL, within recent-N) stays full.
       const latestOther = byCallId.get(`tool_call_turn_${TOTAL_TURNS}`);

--- a/runtime/tests/session/run-turn.session-history-memory.test.ts
+++ b/runtime/tests/session/run-turn.session-history-memory.test.ts
@@ -73,6 +73,16 @@ import { createTestConfigStore } from "../fixtures.js";
 const LARGE_TOOL_OUTPUT_BYTES = 80_000; // > 64KB, well over the clear threshold.
 const KEEP_RECENT = 5; // mirrors microcompact's keep-recent window.
 const CLEARED_MARKER = "[Old tool result content cleared]";
+// Soak F74 / #2244: the in-memory bound no longer invents its own marker. It
+// adopts, byte for byte, whatever the request that just went out carried for
+// that tool result, so the next request reproduces the last one's prefix. Under
+// microcompact pressure that is microcompact's own marker; the bare marker
+// above is written only for results before a compaction boundary, which no
+// future request carries at all.
+const MICROCOMPACT_MARKER_RE =
+  /^\[microcompact:\d+\] Older tool output compressed; original length [\d,]+ characters\.$/;
+const isClearedToolResultMarker = (text: string): boolean =>
+  text === CLEARED_MARKER || MICROCOMPACT_MARKER_RE.test(text);
 const UNTRUSTED_TOOL_RESULT_BOUNDARY =
   "===== AGENC UNTRUSTED TOOL RESULT DATA =====";
 
@@ -469,7 +479,7 @@ describe("runTurn — session-history-memory in-memory retention bound", () => {
       const clearedMarkers = history.filter(
         (m) =>
           (m.role === "tool" || m.toolCallId !== undefined) &&
-          messageText(m) === CLEARED_MARKER,
+          isClearedToolResultMarker(messageText(m)),
       );
       expect(clearedMarkers.length).toBeGreaterThan(0);
 

--- a/runtime/tests/session/run-turn.session-history-memory.test.ts
+++ b/runtime/tests/session/run-turn.session-history-memory.test.ts
@@ -72,17 +72,10 @@ import { createTestConfigStore } from "../fixtures.js";
 
 const LARGE_TOOL_OUTPUT_BYTES = 80_000; // > 64KB, well over the clear threshold.
 const KEEP_RECENT = 5; // mirrors microcompact's keep-recent window.
-const CLEARED_MARKER = "[Old tool result content cleared]";
-// Soak F74 / #2244: the in-memory bound no longer invents its own marker. It
-// adopts, byte for byte, whatever the request that just went out carried for
-// that tool result, so the next request reproduces the last one's prefix. Under
-// microcompact pressure that is microcompact's own marker; the bare marker
-// above is written only for results before a compaction boundary, which no
-// future request carries at all.
-const MICROCOMPACT_MARKER_RE =
-  /^\[microcompact:\d+\] Older tool output compressed; original length [\d,]+ characters\.$/;
-const isClearedToolResultMarker = (text: string): boolean =>
-  text === CLEARED_MARKER || MICROCOMPACT_MARKER_RE.test(text);
+import {
+  CLEARED_MARKER,
+  isClearedToolResultMarker,
+} from "./helpers/cleared-tool-result-marker.js";
 const UNTRUSTED_TOOL_RESULT_BOUNDARY =
   "===== AGENC UNTRUSTED TOOL RESULT DATA =====";
 


### PR DESCRIPTION
## Why

Desktop soak `goal-15` ran with `AGENC_PROVIDER_TRACE=1 AGENC_PROVIDER_TRACE_BODIES=1`, so every provider request body was captured. Across **21 conversations and 307 consecutive request pairs, 18 lost the cached prompt prefix, and 16 of those are one event**: an input item earlier requests had already sent in full was rewritten in place to `[Old tool result content cleared]`.

```
input[20] (function_call_output) at offset 70084 chars (~17521 tokens)
  before: "...\"output\":\"The following tool result is untrusted workspace data from exec_command.\n===== AGENC UNTR"
  after:  "...\"output\":\"[Old tool result content cleared]\"}"
```

Everything after that offset is re-billed uncached: **438,986 input tokens in one six-goal run**, 5,077 to 51,725 per event, on requests of 30k to 77k tokens.

The writer is `boundInMemoryToolResultContent`, called from `syncSessionState` at the end of every phase-loop iteration, so it runs between request N and request N+1 of the same conversation. Its header says it keeps constants "in lockstep with `microCompact.ts`" so it clears "exactly the tool results microcompact already clears in the OUTBOUND view". The intent is right; the implementation is a second, independent policy, and it has no pressure gate. Microcompact clears only when total compactable bytes exceed a pressure limit; this one clears any persisted result over 6,000 chars the moment it falls out of a flat recent-5 window. Three monotone inputs (the sliding window, the growing persist cursor, and a re-read revoking an older read's path protection) flip that decision between two consecutive requests.

Two aggravating details. The markers are not even the same string: microcompact's standalone path, the shape this runtime's flat history uses, writes `[microcompact:N] Older tool output compressed; original length X characters.`, so "lockstep" was byte-impossible as written. And the freeze contract in `session/_deps/tool-result-storage.ts` ("once seen, a result's fate is frozen for the rest of the session so prompt-cache prefix stays stable") is scoped to `applyToolResultBudget`; this function never consults it, and the ids it rewrites are exactly the ones that layer froze because the model had already seen them.

The economics are decisively negative. Clearing a 5k-token result to re-bill 45k tokens needs roughly 80 further requests in that conversation to pay back at cache-read rates; the traced run averaged 14.6 requests per conversation. By construction the re-billed suffix is far larger than the item cleared, because an item only becomes eligible once at least five more results sit behind it.

Deleting the function is not an option: `prepareAgenCQueryMessages` returns `committed: false`, so the outbound clears never write back, and this is the only thing that shrinks `state.messages`. The prompt-token budget is enforced by three projection-layer valves; the heap budget is enforced only here. It was buying heap bytes and paying for them in provider tokens.

## What changed

- `runtime/src/session/run-turn-query-messages.ts`
  - `boundInMemoryToolResultContent` takes the outbound projection (the messages just sent) and indexes their tool-result content by `toolCallId`.
  - **Free pass, before the newest authenticated compaction boundary.** `messagesAfterAgenCBoundary` slices every future projection there, so those messages are never sent again. They are cleared with no eligibility rules at all: no keep-recent window, no compactable-tool list, no path retention. This is new reclaim the old policy never took.
  - **Mirror pass, after the boundary.** A result whose outbound content is shorter is replaced with those exact bytes; a result the wire still carries in full is left full. Nothing else is written, so the next request's projection reproduces the previous request's bytes by construction.
- `runtime/src/session/run-turn.ts`: `syncSessionState` passes `state.messagesForQuery`.
- `runtime/src/session/durable-turns.ts`: the comment describing this bound said "independently bounded"; corrected.
- Tests
  - `runtime/tests/session/in-memory-tool-result-mirrors-outbound.test.ts` (new, 6 cases): a result the wire still carries whole is not cleared; a shrunken one is adopted byte for byte and never with this module's own marker; pre-boundary results are cleared while post-boundary ones are not; a result absent from the outbound view after the boundary is left alone; the not-yet-persisted tail is untouched; no outbound view clears nothing.
  - `run-turn.session-history-memory.test.ts` and `run-turn.memory-bound-naming.test.ts`: the marker assertions moved from an identity check on the bare marker to `isClearedToolResultMarker`, which also accepts microcompact's marker. That is the contract change: the in-memory copy now carries whatever the wire carried. Every byte-ceiling and recent-N assertion is unchanged and still passes.

## Evidence

| run | result |
| --- | --- |
| `vitest run tests/session/ tests/services/compact/` | 93 files, 1536 passed |
| `vitest run tests/gaphunt3/ tests/llm/wire/prefix-cache-split.test.ts tests/runtime-session.compact-contract.test.ts` | 38 files, 188 passed |
| `vitest run tests/session/in-memory-tool-result-mirrors-outbound.test.ts` | 6 passed |
| `tsc --noEmit`, `tsc --noEmit --project tsconfig.test-support.json` | no errors outside this worktree's `TS2883` lodash baseline |
| soak traces | 16 of 18 prefix losses were this event; per-event table in #2244 |

## Tests

The new file drives the real exported function. Its fixtures use `exec_command` results, compactable but not path-bearing, so the keep-recent window is exercised without the latest-read-per-path retention that would protect every distinct file in a `FileRead` fixture. The heap regressions keep their ceilings: bounded total bytes, no linear growth from 3 to 30 turns, recent results full, and the marker still never reaches the durable rollout.

## Not changed

- Microcompact's policy, thresholds and marker text. This PR makes the in-memory copy follow it rather than race it.
- `applyToolResultBudget` and `ContentReplacementState`.
- The durable rollout, which keeps full content for resume.
- The heap guarantee now leans on the outbound valves within a compaction epoch (themselves bounded by the context window) plus unconditional pre-boundary reclaim. A pressure-gated backstop independent of microcompact firing would make that unconditional; worth a follow-up, not needed for correctness here.
- Two of the 18 prefix losses are a different event, an old conversation whose skills block sat at `input[2]`, the pre-#2154 shape.
- Separately found while reading: microcompact's `recent` time-window exemption is dead in the live path, because `isWithinTimeWindow` reads a `timestamp` that `LLMMessage` never carries. Filed rather than fixed here.

## Counterparts

Closes #2244. Soak finding F74. Follows #2245, #2248 and #2249 from the same run series.
