### PR TITLE
fix(runtime): bound daemon agent startup and shutdown

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -268,6 +268,7 @@ otherwise.
 | `mcp.server.enabled` | `false` |
 | `mcp.server.transport` | `stdio` |
 | `daemon.autostart` | `true` |
+| `daemon.agent_stop_timeout_ms` | `30000` |
 | `gateway.defaultAgent` | `default` |
 | `gateway.hooks.enabled` | `false` |
 | `project_root_markers` | `.git`, `package.json`, `Cargo.toml`, `pyproject.toml` |
@@ -700,6 +701,7 @@ environment ingress.
 | Paths | Type / meaning |
 | --- | --- |
 | `daemon`, `daemon.autostart` | Daemon block and automatic daemon startup. The local daemon transport is fixed by the platform runtime. |
+| `daemon.agent_stop_timeout_ms` | Graceful agent stop and previous-generation cleanup deadline in milliseconds (default `30000`, positive integer up to `2147483647`). A stop that exceeds this deadline aborts execution and allows up to `5000` ms for hard teardown before reporting failure. Restart the daemon after changing this setting. |
 | `browser` | Chromium execution policy. |
 | `browser.executable_path`, `browser.profile_dir` | Browser binary/profile paths. |
 | `browser.headless`, `browser.allow_private_network`, `browser.no_sandbox` | Security/runtime booleans. |

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -34,6 +34,12 @@ import type { RunRuntimeSettingsSnapshot } from "../contracts/run-contracts.js";
 import { cloneFrozenRuntimeSettingsSnapshot } from "../state/runtime-settings-snapshot.js";
 
 import { AsyncLock } from "../utils/async-lock.js";
+import { withTimeout } from "../utils/sleep.js";
+import {
+  DaemonOperationScope,
+  DAEMON_AGENT_CREATE_TIMEOUT_MS,
+  DAEMON_AGENT_STOP_TIMEOUT_MS,
+} from "./operation-deadline.js";
 import { openStateDatabases } from "../state/sqlite-driver.js";
 import {
   createOperatorEffectReviewResolution,
@@ -464,6 +470,8 @@ function isEvidenceToolCallResolution(
   return Object.prototype.hasOwnProperty.call(params, "disposition");
 }
 
+const AGENT_LIFECYCLE_OPERATION_TIMEOUT_MS = 30_000;
+
 export class AgenCDaemonAgentManager {
   readonly #agencHome: string;
   readonly #now: () => string;
@@ -514,6 +522,7 @@ export class AgenCDaemonAgentManager {
   #shuttingDown = false;
   #shutdownDisposition: "cancel" | "suspend_idle" = "cancel";
   #activeCreates = 0;
+  readonly #activeCreateScopes = new Set<DaemonOperationScope>();
   readonly #createWaiters = new Set<() => void>();
   readonly #pendingResumeCreates = new Map<
     string,
@@ -558,12 +567,13 @@ export class AgenCDaemonAgentManager {
     this.#voidBudgetHoldsForAgents = options.voidBudgetHoldsForAgents;
   }
 
-  createAgent(params: AgentCreateParams): Promise<AgentCreateResult> {
+  createAgent(
+    params: AgentCreateParams,
+    options: { readonly signal?: AbortSignal } = {},
+  ): Promise<AgentCreateResult> {
     const resumeSessionId = normalizeNonEmpty(params.resumeSessionId);
-    if (resumeSessionId === undefined) {
-      return this.#createAgentOnce(params);
-    }
-    const pending = this.#pendingResumeCreates.get(resumeSessionId);
+    const pending = resumeSessionId === undefined
+      ? undefined : this.#pendingResumeCreates.get(resumeSessionId);
     if (pending !== undefined) {
       if (!isDeepStrictEqual(pending.params, params)) {
         return Promise.reject(
@@ -573,23 +583,38 @@ export class AgenCDaemonAgentManager {
           ),
         );
       }
-      return pending.result;
+      if (options.signal === undefined) return pending.result;
+      const waiter = new DaemonOperationScope(
+        "agent.create resume waiter", DAEMON_AGENT_CREATE_TIMEOUT_MS, options.signal,
+      );
+      return waiter.wait(() => pending.result).finally(() => waiter.dispose());
     }
 
-    const result = this.#createAgentOnce(params);
+    const scope = new DaemonOperationScope(
+      "agent.create", DAEMON_AGENT_CREATE_TIMEOUT_MS, options.signal,
+    );
+    this.#activeCreateScopes.add(scope);
+    const work = this.#createAgentOnce(params, scope.signal);
+    const result = scope.wait(() => work).finally(() => scope.dispose());
     const reservation = {
       params: structuredClone(params),
       result,
     };
-    this.#pendingResumeCreates.set(resumeSessionId, reservation);
-    void result.then(
+    if (resumeSessionId !== undefined) {
+      this.#pendingResumeCreates.set(resumeSessionId, reservation);
+    }
+    // Retain the resume reservation until actual rollback finishes, even when
+    // the caller has already received its cancellation or timeout error.
+    void work.then(
       () => {
-        if (this.#pendingResumeCreates.get(resumeSessionId) === reservation) {
+        this.#activeCreateScopes.delete(scope);
+        if (resumeSessionId !== undefined && this.#pendingResumeCreates.get(resumeSessionId) === reservation) {
           this.#pendingResumeCreates.delete(resumeSessionId);
         }
       },
       () => {
-        if (this.#pendingResumeCreates.get(resumeSessionId) === reservation) {
+        this.#activeCreateScopes.delete(scope);
+        if (resumeSessionId !== undefined && this.#pendingResumeCreates.get(resumeSessionId) === reservation) {
           this.#pendingResumeCreates.delete(resumeSessionId);
         }
       },
@@ -599,6 +624,7 @@ export class AgenCDaemonAgentManager {
 
   async #createAgentOnce(
     params: AgentCreateParams,
+    signal: AbortSignal,
   ): Promise<AgentCreateResult> {
     const finishCreate = this.#beginCreate();
     let resumeProof: ResumeSourceProof | undefined;
@@ -612,6 +638,7 @@ export class AgenCDaemonAgentManager {
       );
     }
     try {
+      signal.throwIfAborted();
       const resumeSessionId = normalizeNonEmpty(params.resumeSessionId);
       const resumeRolloutPath = normalizeNonEmpty(params.resumeRolloutPath);
       const resumeSourceProof = params.resumeSourceProof;
@@ -918,9 +945,11 @@ export class AgenCDaemonAgentManager {
       };
       const resumeRestoreAttemptId =
         resumeSessionId === undefined ? undefined : randomUUID();
+      signal.throwIfAborted();
       const started =
         resumeSessionId === undefined
           ? await startNewBackgroundAgent(this.#runner, {
+              signal,
               objective,
               cwd,
               ...(model !== undefined ? { model } : {}),
@@ -954,6 +983,7 @@ export class AgenCDaemonAgentManager {
                 : {}),
             })
           : await this.#resumeTerminalAgent({
+              signal,
               agentId: resumeSessionId,
               resumeRolloutPath: resumeRolloutPath!,
               resumeCwdIdentity: resumeProof!.cwdIdentity,
@@ -1046,7 +1076,28 @@ export class AgenCDaemonAgentManager {
       };
 
       let createdLifecycleSessionId: string | undefined;
+      let runnerCleanup: Promise<void> | undefined;
+      const cleanupRunner = (): Promise<void> => {
+        runnerCleanup ??= (async () => {
+          if (resumeSessionId !== undefined) {
+            if (resumeRestoreAttemptId === undefined || this.#runner?.rollbackRestoredAgent === undefined) {
+              throw new Error("background runner cannot safely roll back the unpublished restored generation");
+            }
+            await this.#runner.rollbackRestoredAgent(agent.agentId, resumeRestoreAttemptId);
+          } else {
+            await this.#runner?.stopAgent?.(agent.agentId, "agent.create rollback after lifecycle failure");
+          }
+        })();
+        return runnerCleanup;
+      };
+      const abortUnpublishedAgent = (): void => {
+        // A projection or persistence callback may ignore cancellation. Revoke
+        // execution now; the normal rollback cleans up its late result.
+        void cleanupRunner().catch(() => undefined);
+      };
+      signal.addEventListener("abort", abortUnpublishedAgent, { once: true });
       try {
+        signal.throwIfAborted();
         if (this.#sessionManager !== undefined) {
           const session = await this.#sessionManager.createSession({
             agentId: agent.agentId,
@@ -1062,11 +1113,14 @@ export class AgenCDaemonAgentManager {
             },
           });
           createdLifecycleSessionId = session.sessionId;
+          signal.throwIfAborted();
           agent.sessionIds.push(session.sessionId);
           agent.logSessionIds.push(session.sessionId);
           await this.#registerSnapshotSessionRoute(session.sessionId, agent);
+          signal.throwIfAborted();
         }
         await this.#recordAgentRunSnapshot(agent, { required: true });
+        signal.throwIfAborted();
         await this.#recordAgentStatusSnapshots(
           agent.sessionIds,
           agent.agentId,
@@ -1077,6 +1131,7 @@ export class AgenCDaemonAgentManager {
         );
         if (this.#sessionManager !== undefined) {
           for (const sessionId of agent.sessionIds) {
+            signal.throwIfAborted();
             await this.#runner.attachAgentSessionEvents?.(agent.agentId, {
               sessionId,
               emit: (event) => this.#broadcastSessionEvent?.(sessionId, event),
@@ -1086,6 +1141,7 @@ export class AgenCDaemonAgentManager {
 
         const { result, pendingTermination } = await this.#state.with(
           (state) => {
+            signal.throwIfAborted();
             state.agents.set(agent.agentId, agent);
             const pending = this.#pendingRunnerTerminations.get(agent.agentId);
             let pendingTermination: RunnerTerminationTarget | null = null;
@@ -1112,37 +1168,17 @@ export class AgenCDaemonAgentManager {
         }
         return result;
       } catch (error) {
+        await this.#state.with((state) => {
+          if (state.agents.get(agent.agentId) !== agent) return;
+          if (retainedAgent !== undefined) state.agents.set(agent.agentId, retainedAgent);
+          else state.agents.delete(agent.agentId);
+        });
         this.#pendingRunnerTerminations.delete(agent.agentId);
         const cleanupErrors: unknown[] = [];
-        if (resumeSessionId !== undefined) {
-          if (
-            resumeRestoreAttemptId === undefined ||
-            this.#runner.rollbackRestoredAgent === undefined
-          ) {
-            cleanupErrors.push(
-              new Error(
-                "background runner cannot safely roll back the unpublished restored generation",
-              ),
-            );
-          } else {
-            try {
-              await this.#runner.rollbackRestoredAgent(
-                agent.agentId,
-                resumeRestoreAttemptId,
-              );
-            } catch (cleanupError) {
-              cleanupErrors.push(cleanupError);
-            }
-          }
-        } else {
-          try {
-            await this.#runner.stopAgent?.(
-              agent.agentId,
-              "agent.create rollback after lifecycle failure",
-            );
-          } catch (cleanupError) {
-            cleanupErrors.push(cleanupError);
-          }
+        try {
+          await cleanupRunner();
+        } catch (cleanupError) {
+          cleanupErrors.push(cleanupError);
         }
         if (
           createdLifecycleSessionId !== undefined &&
@@ -1182,6 +1218,8 @@ export class AgenCDaemonAgentManager {
           );
         }
         throw error;
+      } finally {
+        signal.removeEventListener("abort", abortUnpublishedAgent);
       }
     } catch (error) {
       createFailed = true;
@@ -1226,6 +1264,7 @@ export class AgenCDaemonAgentManager {
   }
 
   async #resumeTerminalAgent(params: {
+    readonly signal: AbortSignal;
     readonly agentId: string;
     readonly resumeRolloutPath: string;
     readonly resumeCwdIdentity: { readonly dev: string; readonly ino: string };
@@ -1264,6 +1303,7 @@ export class AgenCDaemonAgentManager {
       );
     }
     const restored = await this.#runner.restoreAgent({
+      signal: params.signal,
       agentId: params.agentId,
       objective: params.objective,
       cwd: params.cwd,
@@ -1446,15 +1486,23 @@ export class AgenCDaemonAgentManager {
 
   async #waitForActiveCreates(): Promise<void> {
     if (this.#activeCreates === 0) return;
-    await new Promise<void>((resolve) => {
-      this.#createWaiters.add(resolve);
-    });
+    const scope = new DaemonOperationScope(
+      "daemon shutdown active creates", DAEMON_AGENT_STOP_TIMEOUT_MS,
+    );
+    let resolveSettled!: () => void;
+    const settled = new Promise<void>((resolve) => { resolveSettled = resolve; });
+    this.#createWaiters.add(resolveSettled);
+    try {
+      await scope.wait(() => settled);
+    } finally {
+      this.#createWaiters.delete(resolveSettled);
+      scope.dispose();
+    }
   }
 
   async listAgents(params: AgentListParams = {}): Promise<AgentListResult> {
-    return this.#state.with(async (state) => {
-      await this.#refreshAgentsFromRunner(state);
-      await this.#reconcileSessionBackedAgents(state);
+    await this.#refreshAgentsFromRunner(true);
+    return this.#state.with((state) => {
       const cursor = normalizeCursor(params.cursor);
       const limit = normalizeLimit(params.limit);
       const agents = [...state.agents.values()]
@@ -1619,11 +1667,8 @@ export class AgenCDaemonAgentManager {
   }
 
   async getAgent(agentId: string): Promise<AgentSummary | null> {
-    return this.#state.with(async (state) => {
-      const agent = state.agents.get(agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-      }
+    await this.#refreshAgentFromRunner(agentId);
+    return this.#state.with((state) => {
       const refreshed = state.agents.get(agentId);
       if (refreshed !== undefined) {
         return toAgentSummary(refreshed);
@@ -1637,12 +1682,8 @@ export class AgenCDaemonAgentManager {
 
   async getAgentLogs(params: AgentLogsParams): Promise<AgentLogsResult> {
     const agentId = normalizeRequiredAgentId(params.agentId, "agent.logs");
-    const target = await this.#state.with(async (state) => {
-      const agent = state.agents.get(agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-        await this.#reconcileAgentSessions(agent);
-      }
+    await this.#refreshAgentFromRunner(agentId, true);
+    const target = await this.#state.with((state) => {
       const refreshed = state.agents.get(agentId);
       if (refreshed !== undefined) {
         return {
@@ -1731,11 +1772,8 @@ export class AgenCDaemonAgentManager {
     const runner = this.#runner;
     const stopRunner = runner?.stopAgent?.bind(runner);
     let transitionAt: string | undefined;
-    const target = await this.#state.with(async (state) => {
-      const agent = state.agents.get(agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-      }
+    await this.#refreshAgentFromRunner(agentId);
+    const target = await this.#state.with((state) => {
       const refreshed = state.agents.get(agentId);
       if (refreshed === undefined) {
         const persisted = this.#listPersistedAgents(state).find(
@@ -2168,9 +2206,19 @@ export class AgenCDaemonAgentManager {
   ): Promise<number> {
     this.#shuttingDown = true;
     this.#shutdownDisposition = options.disposition ?? "cancel";
-    await this.#waitForActiveCreates();
-    const targets = await this.#state.with(async (state) => {
-      await this.#refreshAgentsFromRunner(state);
+    for (const scope of this.#activeCreateScopes) {
+      scope.abort(new AgenCDaemonAgentLifecycleError(
+        "INVALID_ARGUMENT", "agent.start cancelled because the daemon is shutting down",
+      ));
+    }
+    let createDrainFailure: unknown;
+    try {
+      await this.#waitForActiveCreates();
+    } catch (error) {
+      createDrainFailure = error;
+    }
+    await this.#refreshAgentsFromRunner();
+    const targets = await this.#state.with((state) => {
       return [...state.agents.values()].filter(isActiveAgent).map((agent) => ({
         agentId: agent.agentId,
         sessionIds: [...agent.sessionIds],
@@ -2181,6 +2229,9 @@ export class AgenCDaemonAgentManager {
       readonly agentId: string;
       readonly error: unknown;
     }> = [];
+    if (createDrainFailure !== undefined) {
+      failures.push({ agentId: "pending agent.create", error: createDrainFailure });
+    }
     let stopped = 0;
     for (const target of targets) {
       const stopRunner = this.#runner?.stopAgent?.bind(this.#runner);
@@ -2274,8 +2325,8 @@ export class AgenCDaemonAgentManager {
     options: { readonly reason?: string } = {},
   ): Promise<readonly string[]> {
     const reason = options.reason ?? "stale_runner";
-    const candidates = await this.#state.with(async (state) => {
-      await this.#refreshAgentsFromRunner(state);
+    await this.#refreshAgentsFromRunner();
+    const candidates = await this.#state.with((state) => {
       return [...state.agents.values()].filter((agent) => isStaleAgent(agent));
     });
     if (candidates.length === 0) return [];
@@ -2634,11 +2685,8 @@ export class AgenCDaemonAgentManager {
     if (session === null || !isActiveSession(session)) {
       return { sessionId: params.sessionId, cancelled: false, reason };
     }
-    const canCancel = await this.#state.with(async (state) => {
-      const agent = state.agents.get(session.agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-      }
+    await this.#refreshAgentFromRunner(session.agentId);
+    const canCancel = await this.#state.with((state) => {
       const refreshed = state.agents.get(session.agentId);
       return (
         refreshed !== undefined &&
@@ -3575,11 +3623,8 @@ export class AgenCDaemonAgentManager {
     // Resume only becomes safe once that terminal process has exited (its lock
     // is released and reclaimable as stale). Read-only history is still served
     // via getSessionTranscript's thread-store fallback. Keep the throw.
-    const messageTarget = await this.#state.with(async (state) => {
-      const agent = state.agents.get(session.agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-      }
+    await this.#refreshAgentFromRunner(session.agentId);
+    const messageTarget = await this.#state.with((state) => {
       const refreshed = state.agents.get(session.agentId);
       if (refreshed === undefined || !isActiveAgent(refreshed)) {
         throw new AgenCDaemonAgentLifecycleError(
@@ -3641,9 +3686,10 @@ export class AgenCDaemonAgentManager {
     return submission;
   }
 
-  async #refreshAgentsFromRunner(state: AgentLifecycleState): Promise<void> {
-    for (const agent of [...state.agents.values()]) {
-      await this.#refreshAgentFromRunner(state, agent);
+  async #refreshAgentsFromRunner(reconcileSessions = false): Promise<void> {
+    const agentIds = await this.#state.with((state) => [...state.agents.keys()]);
+    for (const agentId of agentIds) {
+      await this.#refreshAgentFromRunner(agentId, reconcileSessions);
     }
   }
 
@@ -3861,11 +3907,8 @@ export class AgenCDaemonAgentManager {
         `AgenC daemon session not found or closed: ${sessionId}`,
       );
     }
-    await this.#state.with(async (state) => {
-      const agent = state.agents.get(session.agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-      }
+    await this.#refreshAgentFromRunner(session.agentId);
+    await this.#state.with((state) => {
       const refreshed = state.agents.get(session.agentId);
       if (refreshed === undefined || !isActiveAgent(refreshed)) {
         throw new AgenCDaemonAgentLifecycleError(
@@ -3930,12 +3973,8 @@ export class AgenCDaemonAgentManager {
         "permission.list requires agentId or sessionId",
       );
     }
-    await this.#state.with(async (state) => {
-      const agent = state.agents.get(agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-        await this.#reconcileAgentSessions(agent);
-      }
+    await this.#refreshAgentFromRunner(agentId, true);
+    await this.#state.with((state) => {
       const refreshed = state.agents.get(agentId);
       if (refreshed === undefined || !isActiveAgent(refreshed)) {
         throw new AgenCDaemonAgentLifecycleError(
@@ -3954,78 +3993,103 @@ export class AgenCDaemonAgentManager {
   }
 
   async #refreshAgentFromRunner(
-    _state: AgentLifecycleState,
-    agent: MutableAgent,
+    agentId: string,
+    reconcileSessions = false,
   ): Promise<void> {
-    if (!isActiveAgent(agent)) return;
-    const snapshot = await this.#runner?.getAgentSnapshot?.(agent.agentId);
-    if (snapshot === undefined) return;
-    if (snapshot === null) {
-      // The runner returned null — agent isn't in its #active map. This
-      // SHOULD only happen after an explicit stop or daemon-shutdown
-      // cleanup, not on a transient race after a turn completes. The
-      // earlier eviction here was the second symptom of the
-      // GAP-DMN-AGENT-NOT-FOUND class: the runner's getAgentSnapshot
-      // would briefly return null for completed-status agents (now
-      // fixed in background-agent-runner), and the lifecycle would
-      // evict before the snapshot stabilized, dooming the next user
-      // turn's message.stream. Defense in depth: only delete if the
-      // runner has explicitly removed the agent from its registry AND
-      // we have an authoritative terminal-state signal (via
-      // recordAgentStatusSnapshots / stopAgent). Without that signal,
-      // a null snapshot is a no-op refresh — leave state.agents alone.
-      if (agent.recovered === true) return;
-      // Mark the runner as unavailable but keep the agent record so
-      // the next message.stream finds it. The next refresh that
-      // returns a real snapshot (or an explicit stop event) will
-      // reconcile.
-      agent.runtimeAvailable = false;
-      agent.runtimeUnavailableSince ??= this.#now();
-      return;
+    const candidate = await this.#state.with((state) => {
+      const agent = state.agents.get(agentId);
+      return agent === undefined
+        ? undefined
+        : { owner: agent, expected: structuredClone(agent) };
+    });
+    if (candidate === undefined) return;
+    const { owner, expected } = candidate;
+    const snapshot = isActiveAgent(expected)
+      ? await withTimeout(
+          Promise.resolve(this.#runner?.getAgentSnapshot?.(agentId)),
+          AGENT_LIFECYCLE_OPERATION_TIMEOUT_MS,
+          `agent ${agentId} runner snapshot timed out`,
+        )
+      : undefined;
+    const sessionManager = this.#sessionManager;
+    let activeSessionIds: ReadonlySet<string> | undefined;
+    if (reconcileSessions && sessionManager !== undefined) {
+      const sessions = await withTimeout(
+        Promise.all(expected.sessionIds.map(async (sessionId) => {
+          const session = await sessionManager.getSession(sessionId);
+          return session !== null && isActiveSession(session) ? sessionId : null;
+        })),
+        AGENT_LIFECYCLE_OPERATION_TIMEOUT_MS,
+        `agent ${agentId} session reconciliation timed out`,
+      );
+      activeSessionIds = new Set(sessions.filter((id) => id !== null));
     }
-    const previousStatus = agent.status;
-    const sessionIds = [...agent.sessionIds];
-    agent.recovered = false;
-    agent.runtimeAvailable = true;
-    agent.runtimeUnavailableSince = undefined;
-    applyAgentSnapshot(agent, snapshot);
-    if (agent.status !== previousStatus) {
-      await this.#recordAgentStatusSnapshots(
-        sessionIds,
-        agent.agentId,
-        agent.status,
-        agent.lastActiveAt,
-        undefined,
-        snapshotRouteForAgent(agent),
-        snapshot.metadata,
+    const change = await this.#state.with((state) => {
+      const agent = state.agents.get(agentId);
+      // A stop, attachment, or restore can commit while the reads are pending.
+      // Apply only to the generation and state that initiated those reads.
+      if (agent !== owner || !isDeepStrictEqual(agent, expected)) return undefined;
+      const previousStatus = agent.status;
+      if (snapshot === null && agent.recovered !== true) {
+        // Retain the record through transient runner misses. The reaper needs
+        // an unavailable interval before it can make a terminal transition.
+        agent.runtimeAvailable = false;
+        agent.runtimeUnavailableSince ??= this.#now();
+      } else if (snapshot !== undefined && snapshot !== null) {
+        agent.recovered = false;
+        agent.runtimeAvailable = true;
+        agent.runtimeUnavailableSince = undefined;
+        applyAgentSnapshot(agent, snapshot);
+      }
+      const stopAgentId = activeSessionIds === undefined
+        ? undefined
+        : this.#reconcileAgentSessions(agent, activeSessionIds);
+      return {
+        stopAgentId,
+        transition: agent.status === previousStatus ? undefined : {
+          status: agent.status,
+          lastActiveAt: agent.lastActiveAt,
+          route: snapshotRouteForAgent(agent),
+          metadata: snapshot?.metadata,
+        },
+      };
+    });
+    if (change?.stopAgentId !== undefined) {
+      this.#scheduleReconcileRunnerStop(change.stopAgentId);
+    }
+    if (change?.transition !== undefined) {
+      const transition = change.transition;
+      await withTimeout(
+        this.#recordAgentStatusSnapshots(
+          expected.sessionIds,
+          agentId,
+          transition.status,
+          transition.lastActiveAt,
+          undefined,
+          transition.route,
+          transition.metadata,
+        ),
+        AGENT_LIFECYCLE_OPERATION_TIMEOUT_MS,
+        `agent ${agentId} status persistence timed out`,
       );
     }
   }
 
-  async #reconcileSessionBackedAgents(
-    state: AgentLifecycleState,
-  ): Promise<void> {
-    if (this.#sessionManager === undefined) return;
-    for (const agent of state.agents.values()) {
-      await this.#reconcileAgentSessions(agent);
-    }
-  }
-
-  async #reconcileAgentSessions(agent: MutableAgent): Promise<void> {
-    if (this.#sessionManager === undefined || agent.sessionIds.length === 0) {
-      return;
-    }
+  #reconcileAgentSessions(
+    agent: MutableAgent,
+    activeSessions: ReadonlySet<string>,
+  ): string | undefined {
+    if (agent.sessionIds.length === 0) return undefined;
     const activeSessionIds: string[] = [];
     const inactiveSessionIds: string[] = [];
     for (const sessionId of agent.sessionIds) {
-      const session = await this.#sessionManager.getSession(sessionId);
-      if (session !== null && isActiveSession(session)) {
+      if (activeSessions.has(sessionId)) {
         activeSessionIds.push(sessionId);
       } else {
         inactiveSessionIds.push(sessionId);
       }
     }
-    if (inactiveSessionIds.length === 0) return;
+    if (inactiveSessionIds.length === 0) return undefined;
     agent.logSessionIds = uniqueNonEmptyStrings([
       ...agent.logSessionIds,
       ...inactiveSessionIds,
@@ -4036,14 +4100,10 @@ export class AgenCDaemonAgentManager {
       agent.status = "stopped";
       agent.lastActiveAt = this.#now();
       agent.runtimeAvailable = false;
-      // The runner stop must NOT be awaited here: every reconcile caller
-      // holds the #state lock, and stopAgent's termination path re-acquires
-      // it (handleRunnerTerminated), so an in-lock await self-deadlocks the
-      // whole daemon the moment a zombie agent exists. The state mutation
-      // above is the observable outcome; the runtime teardown runs after
-      // the lock is released, matching the public stopAgent path.
-      if (stoppable) this.#scheduleReconcileRunnerStop(agent.agentId);
+      // The caller starts teardown after releasing the lifecycle lock.
+      if (stoppable) return agent.agentId;
     }
+    return undefined;
   }
 
   /** Deduplicates deferred session_terminated runner stops per agent. */
@@ -4079,12 +4139,8 @@ export class AgenCDaemonAgentManager {
   async #resolveAttachmentTarget(
     agentId: string,
   ): Promise<AgentAttachmentTarget> {
-    return this.#state.with(async (state) => {
-      const agent = state.agents.get(agentId);
-      if (agent !== undefined) {
-        await this.#refreshAgentFromRunner(state, agent);
-        await this.#reconcileAgentSessions(agent);
-      }
+    await this.#refreshAgentFromRunner(agentId, true);
+    return this.#state.with((state) => {
       const refreshed = state.agents.get(agentId);
       if (refreshed === undefined || !isActiveAgent(refreshed)) {
         const persisted = this.#listPersistedAgents(state).find(

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -1772,7 +1772,9 @@ export class AgenCDaemonAgentManager {
     const runner = this.#runner;
     const stopRunner = runner?.stopAgent?.bind(runner);
     let transitionAt: string | undefined;
-    await this.#refreshAgentFromRunner(agentId);
+    // Snapshot availability cannot veto teardown. A failed refresh leaves the
+    // last known state available for selecting and stopping this runner.
+    await this.#refreshAgentFromRunner(agentId).catch(() => {});
     const target = await this.#state.with((state) => {
       const refreshed = state.agents.get(agentId);
       if (refreshed === undefined) {
@@ -2217,7 +2219,8 @@ export class AgenCDaemonAgentManager {
     } catch (error) {
       createDrainFailure = error;
     }
-    await this.#refreshAgentsFromRunner();
+    // Shutdown must reach every retained runner even when a status read fails.
+    await this.#refreshAgentsFromRunner().catch(() => {});
     const targets = await this.#state.with((state) => {
       return [...state.agents.values()].filter(isActiveAgent).map((agent) => ({
         agentId: agent.agentId,

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -16,6 +16,7 @@ import {
   type LocalRuntimeBootstrap,
 } from "../bin/bootstrap.js";
 import { ensureAgentControl } from "../bin/delegate-tool.js";
+import { AgentControl } from "../agents/control.js";
 import { clearSession } from "../commands/clear.js";
 import { runTurn } from "../session/run-turn.js";
 import {
@@ -158,6 +159,13 @@ import {
   cloneFrozenRuntimeSettingsSnapshot,
 } from "../state/runtime-settings-snapshot.js";
 import { runWithAgentRuntimeOptions } from "../session/runtime-options.js";
+import { shutdownSessionLifecycle } from "../session/lifecycle.js";
+import { withTimeout } from "../utils/sleep.js";
+import {
+  DaemonOperationScope,
+  DAEMON_AGENT_STOP_TIMEOUT_MS,
+  DAEMON_AGENT_HARD_STOP_TIMEOUT_MS,
+} from "./operation-deadline.js";
 
 import {
   AgenCBackgroundAgentSuspensionShutdownError,
@@ -371,6 +379,7 @@ export {
 } from "./background-agent-runner/tool-recovery.js";
 
 export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentRunner {
+  readonly #agentStopTimeoutMs: number;
   readonly #bootstrap: AgenCBootstrapFunction;
   readonly #requireSandboxReadyAtStartup: boolean;
   readonly #ensureAgentControl: AgenCEnsureAgentControlFunction;
@@ -384,6 +393,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   #realtimeCallClient: AgenCRealtimeCallClient | undefined;
   #realtimeConnectTransport: AgenCBackgroundRealtimeTransportConnector;
   readonly #active = new Map<string, ActiveBackgroundAgent>();
+  readonly #quiescing = new WeakMap<ActiveBackgroundAgent, Promise<void>>();
   readonly #pendingExplicitRestores = new Set<string>();
   readonly #pendingEvents = new Map<string, BackgroundAgentDaemonEvent[]>();
   readonly #pendingActiveToolCallIds = new Map<string, Set<string>>();
@@ -400,6 +410,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     | undefined;
 
   constructor(options: AgenCDelegateBackgroundAgentRunnerOptions = {}) {
+    this.#agentStopTimeoutMs = options.agentStopTimeoutMs ?? DAEMON_AGENT_STOP_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.#agentStopTimeoutMs) || this.#agentStopTimeoutMs <= 0 || this.#agentStopTimeoutMs > 2_147_483_647) {
+      throw new RangeError("agentStopTimeoutMs must be a positive timer interval");
+    }
     this.#bootstrap = options.bootstrap ?? bootstrapLocalRuntimeSession;
     this.#requireSandboxReadyAtStartup = options.bootstrap === undefined;
     this.#ensureAgentControl = options.ensureAgentControl ?? ensureAgentControl;
@@ -448,6 +462,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   async startAgent(
     params: AgenCBackgroundAgentStartParams,
   ): Promise<AgenCBackgroundAgentStartResult> {
+    params.signal?.throwIfAborted();
     // Materialize the client's complete allowlisted snapshot on top of the
     // runner's captured env. Protocol clear markers become absent runtime keys
     // so daemon-start provider/config values cannot leak into this session.
@@ -465,6 +480,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       () =>
         runWithBootstrapSessionScope(() =>
           this.#bootstrap({
+      ...(params.signal !== undefined ? { signal: params.signal } : {}),
       ...(mergedEnv !== undefined ? { env: mergedEnv } : {}),
       ...(this.#authBackend !== undefined
         ? { authBackend: this.#authBackend }
@@ -494,6 +510,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           }),
         ),
     );
+    const unbindCancellation = this.#bindBootstrapCancellation(bootstrap, params.signal);
     const uninstallApprovalBridge = this.#installDaemonApprovalBridge(
       bootstrap.session,
     );
@@ -502,6 +519,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     let authorityOwner: ActiveBackgroundAgent | undefined;
     let uninstallPermissionAuthorityCoordinator = (): void => {};
     try {
+      params.signal?.throwIfAborted();
       uninstallPermissionAuthorityCoordinator =
         installDaemonPermissionAuthorityCoordinator(
           bootstrap,
@@ -672,6 +690,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       };
       this.#pendingEvents.delete(managedThread.threadId);
       this.#pendingActiveToolCallIds.delete(managedThread.threadId);
+      params.signal?.throwIfAborted();
       this.#active.set(managedThread.threadId, active);
       active.unsubscribeMcpSurfaceInvalidations =
         this.#installMcpSurfaceInvalidationBridge(active);
@@ -742,16 +761,18 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               }
             : {}),
         };
+        params.signal?.throwIfAborted();
         active.pendingMessageSubmissionCount += 1;
-        const initialSubmission = active.messageSubmissionQueue.then(() =>
-          runWithCurrentRuntimeSession(active.bootstrap.session, () =>
+        const initialSubmission = active.messageSubmissionQueue.then(() => {
+          params.signal?.throwIfAborted();
+          return runWithCurrentRuntimeSession(active.bootstrap.session, () =>
             managedThread.submit({
               type: "user_input",
               input: preparedFirstInput,
               submitOptions: firstSubmitOptions,
             }),
-          ),
-        );
+          );
+        });
         const trackedInitialSubmission = initialSubmission.finally(() => {
           active.pendingMessageSubmissionCount = Math.max(
             0,
@@ -785,9 +806,39 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     } catch (error) {
       uninstallPermissionAuthorityCoordinator();
       uninstallApprovalBridge();
-      await bootstrap.shutdown().catch(() => {});
+      bootstrap.session.beginShutdown?.();
+      bootstrap.session.abortController?.abort(error);
+      if (authorityOwner !== undefined &&
+          this.#active.get(authorityOwner.thread.threadId) === authorityOwner) {
+        await this.#retireUnpublishedRestoreGeneration(
+          authorityOwner.thread.threadId, authorityOwner,
+        ).catch(() => {});
+      } else {
+        await withTimeout(bootstrap.shutdown(), this.#agentStopTimeoutMs,
+          "failed agent bootstrap cleanup timed out").catch(() => {});
+      }
       throw error;
+    } finally {
+      unbindCancellation();
     }
+  }
+
+  #bindBootstrapCancellation(bootstrap: LocalRuntimeBootstrap, signal?: AbortSignal): () => void {
+    const abort = (): void => {
+      bootstrap.session.beginShutdown?.();
+      bootstrap.session.abortController?.abort(signal?.reason);
+      const control = bootstrap.session.services.agentControl;
+      void withTimeout(shutdownSessionLifecycle({
+        session: bootstrap.session,
+        ...(control instanceof AgentControl ? { agentControl: control } : {}),
+        mcpManager: bootstrap.mcpManager,
+        skipMemoryExtractionDrain: true,
+        shutdownBudgetMs: DAEMON_AGENT_HARD_STOP_TIMEOUT_MS,
+      }), DAEMON_AGENT_HARD_STOP_TIMEOUT_MS, "cancelled bootstrap teardown timed out").catch(() => undefined);
+    };
+    if (signal?.aborted) abort();
+    else signal?.addEventListener("abort", abort, { once: true });
+    return () => signal?.removeEventListener("abort", abort);
   }
 
   async getAgentSnapshot(
@@ -858,6 +909,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   async restoreAgent(
     params: AgenCBackgroundAgentRestoreParams,
   ): Promise<boolean> {
+    params.signal?.throwIfAborted();
     if (
       params.restoreAttemptId !== undefined &&
       params.restoreAttemptId.length === 0
@@ -878,7 +930,16 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       const previous = this.#active.get(params.agentId);
       if (previous !== undefined) {
         if (!explicitRestore) return true;
-        await previous.cleanupComplete;
+        const cleanup = new DaemonOperationScope(
+          `restoreAgent ${params.agentId} previous generation cleanup`,
+          this.#agentStopTimeoutMs,
+          params.signal,
+        );
+        try {
+          await cleanup.wait(() => previous.cleanupComplete);
+        } finally {
+          cleanup.dispose();
+        }
         if (this.#active.get(params.agentId) === previous) {
           throw new Error(
             `terminal generation ${params.agentId} did not relinquish its runtime`,
@@ -895,6 +956,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       let authorityOwner: ActiveBackgroundAgent | undefined;
       let uninstallPermissionAuthorityCoordinator = (): void => {};
       let insertedGeneration: ActiveBackgroundAgent | undefined;
+      let unbindCancellation = (): void => {};
       try {
         // Restores retain the same complete per-client snapshot semantics as
         // first start, including removal of cleared daemon-start state.
@@ -909,6 +971,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           () =>
             runWithBootstrapSessionScope(() =>
               this.#bootstrap({
+          ...(params.signal !== undefined ? { signal: params.signal } : {}),
           ...(mergedEnv !== undefined ? { env: mergedEnv } : {}),
           ...(this.#authBackend !== undefined
             ? { authBackend: this.#authBackend }
@@ -963,6 +1026,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               }),
             ),
         );
+        unbindCancellation = this.#bindBootstrapCancellation(bootstrap, params.signal);
+        params.signal?.throwIfAborted();
         uninstallApprovalBridge = this.#installDaemonApprovalBridge(
           bootstrap.session,
         );
@@ -1209,6 +1274,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         };
         this.#pendingEvents.delete(params.agentId);
         this.#pendingActiveToolCallIds.delete(params.agentId);
+        params.signal?.throwIfAborted();
         this.#active.set(params.agentId, active);
         active.unsubscribeMcpSurfaceInvalidations =
           this.#installMcpSurfaceInvalidationBridge(active);
@@ -1250,6 +1316,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           currentSessionId: params.currentSessionId,
           onReplayToolResult: params.onReplayToolResult,
         });
+        params.signal?.throwIfAborted();
         return true;
       } catch (error) {
         const cleanupErrors: unknown[] = [];
@@ -1269,7 +1336,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         } else {
           uninstallApprovalBridge?.();
           try {
-            await bootstrap?.shutdown();
+            bootstrap?.session.beginShutdown?.();
+            bootstrap?.session.abortController?.abort(error);
+            await withTimeout(Promise.resolve(bootstrap?.shutdown()),
+              this.#agentStopTimeoutMs, "failed restore cleanup timed out");
           } catch (cleanupError) {
             cleanupErrors.push(cleanupError);
           }
@@ -1284,6 +1354,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           throw error;
         }
         return false;
+      } finally {
+        unbindCancellation();
       }
     } finally {
       if (explicitRestore) this.#pendingExplicitRestores.delete(params.agentId);
@@ -1335,17 +1407,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
 
     const errors: unknown[] = [];
     try {
-      await this.#drainDispatchChain(active);
-    } catch (error) {
-      errors.push(error);
-    }
-    try {
-      await active.bootstrap.shutdown();
-    } catch (error) {
-      errors.push(error);
-    }
-    try {
-      await this.#drainDispatchChain(active);
+      await this.#quiesceAgent(agentId, active);
     } catch (error) {
       errors.push(error);
     }
@@ -1425,6 +1487,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   ): Promise<void> {
     const active = this.#active.get(agentId);
     if (active === undefined) return;
+    active.ingressClosed = true;
     active.status = "stopping";
     active.lastActiveAt = this.#now();
     let stopError: unknown;
@@ -1451,9 +1514,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       // Bootstrap lifecycle quiesces the root turn, descendants, execs, hooks,
       // and tracked durable continuations before Session's close-boundary
       // callback appends the terminal as the canonical tail.
-      await this.#drainDispatchChain(active);
-      await active.bootstrap.shutdown();
-      await this.#drainDispatchChain(active);
+      await this.#quiesceAgent(agentId, active);
     } catch (error) {
       stopError ??= error;
     }
@@ -1462,6 +1523,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       stopError ??= new Error(
         `run ${agentId} shutdown completed without a durable terminal result`,
       );
+    }
+    if (stopError !== undefined) {
+      active.status = "error";
+      active.lastActiveAt = this.#now();
     }
     await this.#notifyActiveAgentTerminated(agentId, active);
     if (this.#active.get(agentId) === active) {
@@ -1490,6 +1555,55 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     }
   }
 
+  #quiesceAgent(agentId: string, active: ActiveBackgroundAgent, initialError?: unknown): Promise<void> {
+    const pending = this.#quiescing.get(active);
+    if (pending !== undefined) return pending;
+    const task = this.#performQuiescence(agentId, active, initialError);
+    this.#quiescing.set(active, task);
+    return task;
+  }
+
+  async #performQuiescence(agentId: string, active: ActiveBackgroundAgent, initialError?: unknown): Promise<void> {
+    const graceful = new DaemonOperationScope(
+      `stopAgent ${agentId} quiescence`, this.#agentStopTimeoutMs,
+    );
+    try {
+      if (initialError !== undefined) throw initialError;
+      await graceful.wait(() => this.#drainDispatchChain(active));
+      await graceful.wait(() => active.bootstrap.shutdown());
+      await graceful.wait(() => this.#drainDispatchChain(active));
+    } catch (error) {
+      active.ingressClosed = true;
+      active.status = "error";
+      active.lastActiveAt = this.#now();
+      const session = active.bootstrap.session;
+      session.beginShutdown?.();
+      session.abortController?.abort(error);
+      const hard = new DaemonOperationScope(
+        `stopAgent ${agentId} hard teardown`, DAEMON_AGENT_HARD_STOP_TIMEOUT_MS,
+      );
+      try {
+        // Start resource cancellation even if bootstrap is stuck before its
+        // own session-shutdown step (for example in sidecar cleanup).
+        await hard.wait(() => shutdownSessionLifecycle({
+          session,
+          agentControl: active.control,
+          mcpManager: active.bootstrap.mcpManager,
+          skipMemoryExtractionDrain: true,
+          shutdownBudgetMs: DAEMON_AGENT_HARD_STOP_TIMEOUT_MS,
+        }));
+      } catch {
+        // The original failure remains authoritative. stopAgent still removes
+        // this generation and reports that teardown could not be completed.
+      } finally {
+        hard.dispose();
+      }
+      throw error;
+    } finally {
+      graceful.dispose();
+    }
+  }
+
   async suspendIdleAgentForDaemonShutdown(
     agentId: string,
   ): Promise<AgenCBackgroundAgentDaemonShutdownResult> {
@@ -1501,7 +1615,18 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     active.ingressClosed = true;
     active.status = "stopping";
     active.lastActiveAt = this.#now();
-    await this.#drainDispatchChain(active);
+    const drain = new DaemonOperationScope(
+      `suspendAgent ${agentId} dispatch drain`, this.#agentStopTimeoutMs,
+    );
+    try {
+      await drain.wait(() => this.#drainDispatchChain(active));
+    } catch (error) {
+      await this.#quiesceAgent(agentId, active, error).catch(() => undefined);
+      await this.stopAgent(agentId, "daemon_shutdown_dispatch_timeout");
+      throw error;
+    } finally {
+      drain.dispose();
+    }
 
     if (!this.#canSuspendIdleAgent(agentId, active)) {
       await this.stopAgent(agentId, "daemon_shutdown_not_idle");
@@ -1518,12 +1643,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     };
     const shutdownErrors: unknown[] = [];
     try {
-      await active.bootstrap.shutdown();
-    } catch (error) {
-      shutdownErrors.push(error);
-    }
-    try {
-      await this.#drainDispatchChain(active);
+      await this.#quiesceAgent(agentId, active);
     } catch (error) {
       shutdownErrors.push(error);
     }
@@ -4334,12 +4454,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         // journaled, while daemon delivery is intentionally serialized on an
         // async chain. Drain that already-committed turn tail before shutdown
         // can close the writer or lifecycle teardown can retire its route.
-        await this.#drainDispatchChain(active);
-        await active.bootstrap.shutdown().catch(() => {});
+        await this.#quiesceAgent(agentId, active).catch(() => {});
         // The durable close finalizer appends run_terminal during shutdown.
         // Keep the session route live until that new canonical tail has also
         // crossed the same ordered delivery chain.
-        await this.#drainDispatchChain(active);
         await this.#notifyActiveAgentTerminated(agentId, active);
         if (this.#active.get(agentId) !== generation) return;
         const bufferedEvents = active.bufferedEvents.splice(0);
@@ -4399,7 +4517,14 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       ...(active.terminal !== undefined ? { terminal: active.terminal } : {}),
     };
     try {
-      await this.#onActiveAgentTerminated(agentId, terminalSnapshot);
+      const notification = new DaemonOperationScope(
+        `agent ${agentId} termination notification`, DAEMON_AGENT_HARD_STOP_TIMEOUT_MS,
+      );
+      try {
+        await notification.wait(() => this.#onActiveAgentTerminated?.(agentId, terminalSnapshot));
+      } finally {
+        notification.dispose();
+      }
     } catch {
       // Lifecycle owns projection error reporting; cleanup must still revoke
       // runtime resources and execution authority.

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -85,6 +85,7 @@ import type {
 import type { AgentRuntimeOptions } from "../../session/runtime-options.js";
 
 export interface AgenCBackgroundAgentStartParams {
+  readonly signal?: AbortSignal;
   readonly objective: string;
   readonly cwd?: string;
   readonly model?: string;
@@ -129,6 +130,7 @@ export interface AgenCBackgroundAgentStartResult {
 }
 
 export interface AgenCBackgroundAgentRestoreParams {
+  readonly signal?: AbortSignal;
   readonly agentId: string;
   readonly objective: string;
   readonly cwd?: string;
@@ -801,6 +803,7 @@ function positiveInteger(value: unknown): number {
 }
 
 export interface AgenCDelegateBackgroundAgentRunnerOptions {
+  readonly agentStopTimeoutMs?: number;
   readonly bootstrap?: AgenCBootstrapFunction;
   readonly ensureAgentControl?: AgenCEnsureAgentControlFunction;
   readonly authBackend?: AuthBackend;

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -3332,6 +3332,9 @@ async function runAgenCDaemonForegroundLocked(
     let configuredRunner: AgenCDelegateBackgroundAgentRunner | undefined;
     if (runner === undefined) {
       configuredRunner = new AgenCDelegateBackgroundAgentRunner({
+        ...(activeConfig.daemon?.agent_stop_timeout_ms !== undefined
+          ? { agentStopTimeoutMs: activeConfig.daemon.agent_stop_timeout_ms }
+          : {}),
         env: host.env,
         argv: [host.execPath, host.entrypointPath, "--autonomous"],
         executionAdmissionKernel,

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -9,6 +9,7 @@
 
 import { isAbsolute } from "node:path";
 import { isSafeSessionIdSegment } from "../session/session-store.js";
+import { DaemonOperationTimeoutError } from "./operation-deadline.js";
 
 import {
   AgenCDaemonAgentLifecycleError,
@@ -924,6 +925,7 @@ export class AgenCDaemonJsonRpcDispatcher {
           id,
           await this.#agentManager.createAgent(
             validateAgentCreateParams(params),
+            { signal },
           ),
         );
       case "agent.list":
@@ -2206,6 +2208,7 @@ function methodSupportsRequestCancellation(
   method: AgenCDaemonKnownMethod,
 ): boolean {
   return (
+    method === "agent.create" ||
     method === "fs.fuzzy_search" ||
     method === "commandExec.start" ||
     method === "csvJob.review.list" ||
@@ -5515,6 +5518,11 @@ function mapDispatchError(
   id: RequestId | null,
   error: unknown,
 ): AgenCDaemonResponse {
+  if (error instanceof DaemonOperationTimeoutError) {
+    return errorResponse(id, -32000, error.message, {
+      code: error.code, operation: error.operation, timeoutMs: error.timeoutMs,
+    });
+  }
   if (error instanceof PermissionRuleMutationPrecommitError) {
     return errorResponse(id, -32602, error.message, {
       code: "PERMISSION_RULE_MUTATION_REJECTED",

--- a/runtime/src/app-server/operation-deadline.ts
+++ b/runtime/src/app-server/operation-deadline.ts
@@ -1,0 +1,80 @@
+export const DAEMON_AGENT_STOP_TIMEOUT_MS = 30_000;
+export const DAEMON_AGENT_CREATE_TIMEOUT_MS = 120_000;
+export const DAEMON_AGENT_HARD_STOP_TIMEOUT_MS = 5_000;
+
+export class DaemonOperationTimeoutError extends Error {
+  override readonly name = "DaemonOperationTimeoutError";
+  readonly code = "DAEMON_OPERATION_TIMEOUT";
+
+  constructor(
+    readonly operation: string,
+    readonly timeoutMs: number,
+  ) {
+    super(`${operation} exceeded ${timeoutMs}ms`);
+  }
+}
+
+/** One deadline and cancellation signal for all stages of an operation. */
+export class DaemonOperationScope {
+  readonly #controller = new AbortController();
+  readonly #aborted: Promise<never>;
+  readonly #timer: ReturnType<typeof setTimeout>;
+  readonly #parent: AbortSignal | undefined;
+  readonly #onParentAbort: () => void;
+
+  constructor(operation: string, timeoutMs: number, parent?: AbortSignal) {
+    if (
+      !Number.isSafeInteger(timeoutMs) ||
+      timeoutMs <= 0 ||
+      timeoutMs > 2_147_483_647
+    ) {
+      throw new RangeError(
+        "daemon operation timeout must be a positive timer interval",
+      );
+    }
+    this.#parent = parent;
+    this.#aborted = new Promise<never>((_, reject) => {
+      this.signal.addEventListener("abort", () => reject(this.signal.reason), {
+        once: true,
+      });
+    });
+    // Cancellation may arrive between waits or before the first stage starts.
+    void this.#aborted.catch(() => undefined);
+    this.#timer = setTimeout(() => {
+      this.abort(new DaemonOperationTimeoutError(operation, timeoutMs));
+    }, timeoutMs);
+    this.#timer.unref?.();
+    this.#onParentAbort = () => this.abort(parent?.reason);
+    if (parent?.aborted) this.#onParentAbort();
+    else parent?.addEventListener("abort", this.#onParentAbort, { once: true });
+  }
+
+  get signal(): AbortSignal {
+    return this.#controller.signal;
+  }
+
+  abort(
+    reason: unknown = new DOMException(
+      "daemon operation cancelled",
+      "AbortError",
+    ),
+  ): void {
+    this.#controller.abort(reason);
+  }
+
+  async wait<T>(operation: () => T | PromiseLike<T>): Promise<T> {
+    this.signal.throwIfAborted();
+    return Promise.race([
+      Promise.resolve().then(() => {
+        this.signal.throwIfAborted();
+        return operation();
+      }),
+      this.#aborted,
+    ]);
+  }
+
+  dispose(): void {
+    clearTimeout(this.#timer);
+    this.#parent?.removeEventListener("abort", this.#onParentAbort);
+  }
+}

--- a/runtime/src/app-server/overload.ts
+++ b/runtime/src/app-server/overload.ts
@@ -42,6 +42,7 @@ const DAEMON_PREEMPTIVE_METHODS = new Set<string>([
 ]);
 
 const DAEMON_PRIORITY_METHODS = new Set<string>([
+  "agent.create",
   ...DAEMON_PREEMPTIVE_METHODS,
   "agent.list",
   "run.status",
@@ -81,11 +82,11 @@ export function isDaemonPreemptiveMessage(message: JsonObject): boolean {
 /**
  * Requests that use the connection's priority lane instead of waiting behind
  * a full streaming model turn. Abort/decision messages are included, along
- * with bounded health, status, and session lookup operations. Attach requests
+ * with bounded agent creation, health, status, and session lookup operations. Attach requests
  * remain in the normal FIFO because they commonly depend on a preceding
  * create request from the same connection.
  *
- * Read-only priority requests remain subject to the normal connection
+ * Priority requests remain subject to the normal connection
  * limiter. Only {@link isDaemonControlMessage} operations are overload-exempt.
  */
 export function isDaemonPriorityMessage(message: JsonObject): boolean {

--- a/runtime/src/app-server/transport/stdio.ts
+++ b/runtime/src/app-server/transport/stdio.ts
@@ -146,6 +146,11 @@ export class AgenCStdioTransport {
         .catch((error) => {
           this.#options.onError?.(asError(error), line);
         });
+      if (message.method === "agent.create") {
+        // Create can start during a stream, but a later attach must still
+        // wait for its session to exist.
+        this.#dispatchChain = Promise.all([this.#dispatchChain, pending]).then(() => {});
+      }
       this.#pendingMessages.add(pending);
       pending.finally(() => {
         this.#pendingMessages.delete(pending);

--- a/runtime/src/app-server/transport/websocket.ts
+++ b/runtime/src/app-server/transport/websocket.ts
@@ -466,6 +466,10 @@ export class AgenCWebSocketServer {
         .catch((error) => {
           this.#options.onError?.(asError(error), context.connectionId);
         });
+      if (message.method === "agent.create") {
+        // Preserve create-to-attach ordering without delaying creation behind a stream.
+        active.dispatchChain = Promise.all([active.dispatchChain, pending]).then(() => {});
+      }
       active.pendingMessages.add(pending);
       pending.finally(() => {
         active.pendingMessages.delete(pending);

--- a/runtime/src/auth/backends/remote.ts
+++ b/runtime/src/auth/backends/remote.ts
@@ -62,6 +62,7 @@ const REMOTE_AUTH_TOKEN_ENV = "AGENC_REMOTE_AUTH_TOKEN" as const;
 const REMOTE_AUTH_STATE_FILENAME = "auth.json" as const;
 const REMOTE_AUTH_STATE_VERSION = 1 as const;
 const REMOTE_AUTH_KEY_CACHE_TTL_MS = 5 * 60 * 1000;
+const REMOTE_AUTH_REQUEST_TIMEOUT_MS = 30_000;
 const REMOTE_AUTH_MIN_LOGIN_POLL_INTERVAL_MS = 5_000;
 const REMOTE_AUTH_STATE_VERIFY_MAX_ATTEMPTS = 3;
 const REMOTE_AUTH_STATE_LOCK_OPTIONS = {
@@ -874,10 +875,14 @@ async function remoteAuthFetch(
   environment: EnvSnapshot,
   configureTransport: boolean,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(REMOTE_AUTH_REQUEST_TIMEOUT_MS);
   try {
     return await fetchImpl(input, {
       ...init,
       ...(configureTransport ? getProxyFetchOptions({ environment }) : {}),
+      signal: init.signal == null
+        ? deadline
+        : AbortSignal.any([init.signal, deadline]),
     });
   } catch (error) {
     throw new Error(
@@ -1061,8 +1066,11 @@ async function readRemoteAuthJsonResponse(
 ): Promise<unknown> {
   try {
     return await response.json();
-  } catch {
-    throw new Error(`RemoteAuthBackend ${operation} returned invalid JSON`);
+  } catch (error) {
+    const message = error instanceof SyntaxError
+      ? `RemoteAuthBackend ${operation} returned invalid JSON`
+      : `RemoteAuthBackend ${operation} response read failed: ${formatRemoteAuthNetworkError(error)}`;
+    throw new Error(message, { cause: error });
   }
 }
 

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -65,6 +65,8 @@ import {
   type BootstrapSessionConfiguredPayload,
 } from "../session/bootstrap.js";
 import { SidecarManager, type Sidecar } from "../session/sidecar.js";
+import { withTimeout } from "../utils/sleep.js";
+import { DaemonOperationScope, DAEMON_AGENT_CREATE_TIMEOUT_MS } from "../app-server/operation-deadline.js";
 import { FileHistory, FileHistorySidecar } from "../session/file-history.js";
 import { ErrorLogSidecar } from "../session/error-log.js";
 import { CostSidecar } from "../session/cost.js";
@@ -586,6 +588,7 @@ function createMemoryAutoSaveSidecar(): Sidecar {
 }
 
 export interface BootstrapLocalRuntimeSessionOptions {
+  readonly signal?: AbortSignal;
   readonly apiKey?: string;
   readonly authBackend?: AuthBackend;
   readonly fetchImpl?: typeof fetch;
@@ -680,25 +683,12 @@ export interface PreparedConfiguredExecutionAuthority {
   rollback(): void;
 }
 
-async function waitForPartialMcpDisposal(task: Promise<void>): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(
-      () =>
-        reject(
-          new Error(
-            `partial MCP disposal exceeded ${SESSION_LIFECYCLE_SHUTDOWN_BUDGET_MS}ms`,
-          ),
-        ),
-      SESSION_LIFECYCLE_SHUTDOWN_BUDGET_MS,
-    );
-    timer.unref?.();
-  });
-  try {
-    await Promise.race([task, timeout]);
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-  }
+function waitForPartialMcpDisposal(task: Promise<void>): Promise<void> {
+  return withTimeout(
+    task,
+    SESSION_LIFECYCLE_SHUTDOWN_BUDGET_MS,
+    `partial MCP disposal exceeded ${SESSION_LIFECYCLE_SHUTDOWN_BUDGET_MS}ms`,
+  );
 }
 
 function parsePositiveFileIdentity(value: string, label: string): bigint {
@@ -773,6 +763,7 @@ function snapshotGrokAcpChildEnvironment(
 export async function bootstrapLocalRuntimeSession(
   options: BootstrapLocalRuntimeSessionOptions,
 ): Promise<LocalRuntimeBootstrap> {
+  options.signal?.throwIfAborted();
   const env = { ...(options.env ?? process.env) };
   const providerEnvironment = snapshotProviderEnvironment(env);
   const mcpRequestEnvironment = snapshotMcpRequestEnvironment(env);
@@ -786,6 +777,7 @@ export async function bootstrapLocalRuntimeSession(
         cli.dangerouslyBypassApprovalsAndSandbox === true,
     });
   const commandShellPath = await findSuitableShell(parsedRuntimeOptions, env);
+  options.signal?.throwIfAborted();
   const commandExecutionAuthority = resolveCommandExecutionAuthority(
     parsedRuntimeOptions,
     commandShellPath,
@@ -1716,7 +1708,13 @@ async function bootstrapLocalRuntimeSessionScoped(
     return task;
   };
 
+  const abortStartup = (): void => {
+    sessionForShutdown?.beginShutdown();
+    sessionForShutdown?.abortController.abort(options.signal?.reason);
+  };
+  options.signal?.addEventListener("abort", abortStartup, { once: true });
   try {
+    options.signal?.throwIfAborted();
     // Construct the session through `bootstrapSession` so shell
     // discovery, SessionConfigured emit, startup prewarm, and
     // resume-history recording all flow through the shared entry
@@ -1729,6 +1727,7 @@ async function bootstrapLocalRuntimeSessionScoped(
     // (session.rs:856-908); the `onAfterSessionConfigured` hook does
     // that work instead.
     const session = await bootstrapSession({
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
       conversationId,
       roleWorkspace,
       agentDefinitions,
@@ -2085,9 +2084,16 @@ async function bootstrapLocalRuntimeSessionScoped(
           // daemon session this additionally waits for ordinary Agent
           // authority, because configured stdio servers are processes.
           assertStartupActive();
-          await s.startMcpManager(mcpManager, {
-            signal: startupSignal,
-          });
+          try {
+            await withTimeout(
+              s.startMcpManager(mcpManager, { signal: startupSignal }),
+              60_000,
+              "MCP startup exceeded 60000ms",
+            );
+          } catch (error) {
+            s.services.mcpStartupCancellationToken.cancel();
+            throw error;
+          }
           assertStartupActive();
 
           // Re-arm persisted cron jobs across restarts only once ordinary
@@ -2159,7 +2165,20 @@ async function bootstrapLocalRuntimeSessionScoped(
               );
             }
             assertStartupActive();
-            await activeConversationManager.runStartupPrewarm(s);
+            const prewarm = new DaemonOperationScope(
+              "session startup prewarm", DAEMON_AGENT_CREATE_TIMEOUT_MS, options.signal,
+            );
+            const abortPrewarm = (): void => {
+              s.beginShutdown();
+              s.abortController.abort(prewarm.signal.reason);
+            };
+            prewarm.signal.addEventListener("abort", abortPrewarm, { once: true });
+            try {
+              await prewarm.wait(() => activeConversationManager.runStartupPrewarm(s));
+            } finally {
+              prewarm.signal.removeEventListener("abort", abortPrewarm);
+              prewarm.dispose();
+            }
             assertStartupActive();
           }
         };
@@ -2213,7 +2232,8 @@ async function bootstrapLocalRuntimeSessionScoped(
     };
   } catch (err) {
     try {
-      await shutdown();
+      await withTimeout(shutdown(), SESSION_LIFECYCLE_SHUTDOWN_BUDGET_MS,
+        "failed bootstrap cleanup exceeded its shutdown budget");
     } catch (shutdownError) {
       throw new AggregateError(
         [err, shutdownError],
@@ -2228,6 +2248,8 @@ async function bootstrapLocalRuntimeSessionScoped(
       throw err;
     }
     throw err;
+  } finally {
+    options.signal?.removeEventListener("abort", abortStartup);
   }
   });
 }

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -355,6 +355,7 @@ export type ProtocolConfig =
 
 export interface DaemonConfig {
   readonly autostart?: boolean;
+  readonly agent_stop_timeout_ms?: number;
 }
 
 export type GatewayDmPolicy = "pairing" | "allowlist" | "open" | "disabled";

--- a/runtime/src/config/strict-schema.ts
+++ b/runtime/src/config/strict-schema.ts
@@ -282,8 +282,12 @@ function validateDaemon(value: unknown): void {
   if (value === undefined) return;
   const field = "daemon";
   const record = requirePlainObject(value, field);
-  rejectUnknownFields(record, new Set(["autostart"]), field);
+  rejectUnknownFields(record, new Set(["autostart", "agent_stop_timeout_ms"]), field);
   optionalBoolean(record.autostart, `${field}.autostart`);
+  optionalPositiveInteger(record.agent_stop_timeout_ms, `${field}.agent_stop_timeout_ms`);
+  if (typeof record.agent_stop_timeout_ms === "number" && record.agent_stop_timeout_ms > 2_147_483_647) {
+    throw new InvalidStrictConfigError(`${field}.agent_stop_timeout_ms`, "exceeds the maximum timer interval");
+  }
 }
 
 function validateGateway(value: unknown): void {

--- a/runtime/src/session/lifecycle.ts
+++ b/runtime/src/session/lifecycle.ts
@@ -49,6 +49,8 @@ export interface SessionLifecycleOpts {
   readonly mcpManager?: MCPManager;
   /** Override budget for testing (ms). */
   readonly shutdownBudgetMs?: number;
+  /** Escalated teardown skips the optional memory-extraction grace period. */
+  readonly skipMemoryExtractionDrain?: boolean;
 }
 
 /**
@@ -80,12 +82,14 @@ export async function shutdownSessionLifecycle(
   // Step 0: memory extraction is fire-and-forget at turn end and must not
   // block turn completion, so shutdown is the one place that waits for it.
   // A no-op when nothing is in flight; bounded by its own budget otherwise.
-  await raceBudget(
-    drainPendingExtraction(MEMORY_EXTRACTION_SHUTDOWN_DRAIN_MS),
-    monotonicMs() + MEMORY_EXTRACTION_SHUTDOWN_DRAIN_MS,
-    "memory_extraction_drain",
-    opts.session,
-  );
+  if (opts.skipMemoryExtractionDrain !== true) {
+    await raceBudget(
+      drainPendingExtraction(MEMORY_EXTRACTION_SHUTDOWN_DRAIN_MS),
+      monotonicMs() + MEMORY_EXTRACTION_SHUTDOWN_DRAIN_MS,
+      "memory_extraction_drain",
+      opts.session,
+    );
+  }
 
   const deadlineMs = monotonicMs() + budgetMs;
 

--- a/runtime/tests/app-server/agent-create-deadline.contract.test.ts
+++ b/runtime/tests/app-server/agent-create-deadline.contract.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import type { AgenCBackgroundAgentStartResult } from "../../src/app-server/background-agent-runner.js";
+
+const params = {
+  objective: "deadline test",
+  cwd: process.cwd(),
+  runtimeOptions: resolveAgentRuntimeOptions({}),
+};
+const started: AgenCBackgroundAgentStartResult = {
+  agentId: "late-agent",
+  status: "running",
+  startedAt: "2026-09-07T00:00:00.000Z",
+};
+
+describe("daemon agent creation deadlines", () => {
+  it.each(["cancel", "deadline"] as const)(
+    "settles stalled agent.create through JSON-RPC on %s",
+    async (kind) => {
+      const entered = Promise.withResolvers<AbortSignal | undefined>();
+      const release = Promise.withResolvers<AgenCBackgroundAgentStartResult>();
+      const manager = new AgenCDaemonAgentManager({
+        runner: {
+          startAgent: async (request) => {
+            entered.resolve(request.signal);
+            return release.promise;
+          },
+          stopAgent: async () => {},
+        },
+      });
+      const connection = new AgenCDaemonJsonRpcDispatcher({
+        agentManager: manager,
+      }).createConnection();
+      await connection.dispatch({
+        jsonrpc: "2.0",
+        id: "init",
+        method: "initialize",
+        params: {
+          protocolVersion: "1.0.0",
+          clientName: "create-cancellation-test",
+        },
+      });
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const creating = connection.dispatch({
+        jsonrpc: "2.0",
+        id: "creating",
+        method: "agent.create",
+        params,
+      });
+      const signal = await entered.promise;
+      try {
+        if (kind === "cancel") {
+          expect(
+            await connection.dispatch({
+              jsonrpc: "2.0",
+              id: "cancel",
+              method: "request.cancel",
+              params: { requestId: "creating", reason: "user stop" },
+            }),
+          ).toMatchObject({ result: { cancelled: true } });
+        } else {
+          await vi.advanceTimersByTimeAsync(120_000);
+        }
+        expect(signal?.aborted).toBe(true);
+        expect(await creating).toMatchObject({
+          error: {
+            data:
+              kind === "cancel"
+                ? { code: "REQUEST_CANCELLED", reason: "user stop" }
+                : {
+                    code: "DAEMON_OPERATION_TIMEOUT",
+                    operation: "agent.create",
+                    timeoutMs: 120_000,
+                  },
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+        release.resolve(started);
+        await manager.stopAll();
+      }
+    },
+  );
+  it.each(["cancel", "deadline"] as const)(
+    "rejects a stalled create on %s and retires its late result",
+    async (kind) => {
+      const entered = Promise.withResolvers<AbortSignal | undefined>();
+      const release = Promise.withResolvers<AgenCBackgroundAgentStartResult>();
+      const stopAgent = vi.fn(async () => {});
+      const recordAgentRun = vi.fn();
+      const manager = new AgenCDaemonAgentManager({
+        recordAgentRun,
+        runner: {
+          stopAgent,
+          startAgent: async (request) => {
+            entered.resolve(request.signal);
+            return release.promise;
+          },
+        },
+      });
+      const controller = new AbortController();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const outcome = manager
+        .createAgent(params, { signal: controller.signal })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      try {
+        const signal = await entered.promise;
+        if (kind === "cancel") controller.abort(new Error("caller cancelled"));
+        else await vi.advanceTimersByTimeAsync(120_000);
+        expect(signal?.aborted).toBe(true);
+        expect(await outcome).toMatchObject(
+          kind === "cancel"
+            ? { message: "caller cancelled" }
+            : { name: "DaemonOperationTimeoutError" },
+        );
+        release.resolve(started);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(stopAgent).toHaveBeenCalledWith(
+          "late-agent",
+          expect.stringContaining("rollback"),
+        );
+        expect(recordAgentRun).not.toHaveBeenCalled();
+        expect((await manager.listAgents()).agents).toEqual([]);
+      } finally {
+        release.resolve(started);
+        await outcome;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("bounds shutdown's create drain and still stops an existing agent", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<AgenCBackgroundAgentStartResult>();
+    const stopAgent = vi.fn(async () => {});
+    const manager = new AgenCDaemonAgentManager({
+      runner: {
+        stopAgent,
+        startAgent: async () => {
+          entered.resolve();
+          return release.promise;
+        },
+      },
+    });
+    await manager.restoreAgent({
+      agentId: "existing",
+      objective: "existing",
+      runtimeAvailable: true,
+    });
+    const creating = manager
+      .createAgent(params)
+      .catch((error: unknown) => error);
+    await entered.promise;
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const stopping = manager.stopAll().catch((error: unknown) => error);
+    try {
+      expect(await creating).toMatchObject({
+        code: "INVALID_ARGUMENT",
+        message: "agent.start cancelled because the daemon is shutting down",
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(await stopping).toBeInstanceOf(AggregateError);
+      expect(stopAgent).toHaveBeenCalledWith("existing", "daemon_shutdown");
+      release.resolve(started);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(stopAgent).toHaveBeenCalledWith("late-agent", "daemon_shutdown");
+      expect((await manager.listAgents()).agents).toEqual([]);
+    } finally {
+      release.resolve(started);
+      await Promise.all([creating, stopping]);
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops an unpublished runner while session creation is stuck, then cleans its late session", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const stopped = Promise.withResolvers<void>();
+    const sessions = new AgenCDaemonSessionManager();
+    const createSession = sessions.createSession.bind(sessions);
+    vi.spyOn(sessions, "createSession").mockImplementation(async (request) => {
+      entered.resolve();
+      await release.promise;
+      return createSession(request);
+    });
+    const terminateSession = vi.spyOn(sessions, "terminateSession");
+    const stopAgent = vi.fn(async () => {
+      stopped.resolve();
+    });
+    const recordAgentRun = vi.fn();
+    const manager = new AgenCDaemonAgentManager({
+      sessionManager: sessions,
+      recordAgentRun,
+      runner: { startAgent: async () => started, stopAgent },
+    });
+    const controller = new AbortController();
+    const creating = manager
+      .createAgent(params, { signal: controller.signal })
+      .catch((error: unknown) => error);
+    await entered.promise;
+    try {
+      controller.abort(new Error("caller cancelled"));
+      expect(await creating).toMatchObject({ message: "caller cancelled" });
+      await stopped.promise;
+      expect(stopAgent).toHaveBeenCalledTimes(1);
+      expect(recordAgentRun).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      // stopAll waits for the late projection rollback, without starting it a second time.
+      await manager.stopAll();
+    }
+    expect(terminateSession).toHaveBeenCalledOnce();
+    expect(stopAgent).toHaveBeenCalledOnce();
+    expect((await manager.listAgents()).agents).toEqual([]);
+  });
+});

--- a/runtime/tests/app-server/agent-lifecycle-locks.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle-locks.contract.test.ts
@@ -7,6 +7,67 @@ import type { AgenCBackgroundAgentSnapshot } from "../../src/app-server/backgrou
 const timestamp = "2026-09-07T00:00:00.000Z";
 
 describe("daemon lifecycle lock boundaries", () => {
+  it.each(["stopAgent", "stopAll"] as const)(
+    "%s still tears down a runner whose snapshot hangs",
+    async (method) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const stopAgent = vi.fn(async () => {});
+      const manager = new AgenCDaemonAgentManager({
+        runner: {
+          startAgent: async () => {
+            throw new Error("unexpected start");
+          },
+          stopAgent,
+          getAgentSnapshot: async () => {
+            entered.resolve();
+            await release.promise;
+            return { status: "running", lastActiveAt: timestamp };
+          },
+        },
+      });
+      await manager.restoreAgent({
+        agentId: "stalled-snapshot",
+        objective: "stop me",
+        runtimeAvailable: true,
+      });
+      if (method === "stopAll") {
+        await manager.restoreAgent({
+          agentId: "second-agent",
+          objective: "stop me too",
+          runtimeAvailable: true,
+        });
+      }
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const stopping = (
+        method === "stopAgent"
+          ? manager.stopAgent({ agentId: "stalled-snapshot" })
+          : manager.stopAll()
+      ).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      try {
+        await entered.promise;
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(stopAgent).toHaveBeenCalledWith(
+          "stalled-snapshot",
+          expect.any(String),
+        );
+        if (method === "stopAll") {
+          expect(stopAgent).toHaveBeenCalledWith("second-agent", "daemon_shutdown");
+        }
+        expect(await stopping).toBeUndefined();
+        expect(await manager.getAgent("stalled-snapshot")).toMatchObject({
+          status: "stopped",
+        });
+      } finally {
+        release.resolve();
+        await stopping;
+        vi.useRealTimers();
+      }
+    },
+  );
   it.each(["session lookup", "status persistence"] as const)(
     "keeps unrelated agents readable during a blocked %s",
     async (operation) => {

--- a/runtime/tests/app-server/agent-lifecycle-locks.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle-locks.contract.test.ts
@@ -1,0 +1,111 @@
+import { setImmediate } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import type { AgenCBackgroundAgentSnapshot } from "../../src/app-server/background-agent-runner.js";
+
+const timestamp = "2026-09-07T00:00:00.000Z";
+
+describe("daemon lifecycle lock boundaries", () => {
+  it.each(["session lookup", "status persistence"] as const)(
+    "keeps unrelated agents readable during a blocked %s",
+    async (operation) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const sessions = new AgenCDaemonSessionManager();
+      vi.spyOn(sessions, "getSession").mockImplementation(async () => {
+        if (operation === "session lookup") {
+          entered.resolve();
+          await release.promise;
+        }
+        return null;
+      });
+      const manager = new AgenCDaemonAgentManager({
+        sessionManager: sessions,
+        runner: {
+          startAgent: async () => {
+            throw new Error("unexpected agent start");
+          },
+          getAgentSnapshot: async (id) =>
+            id === "blocked"
+              ? { status: "idle", lastActiveAt: timestamp }
+              : null,
+        },
+        recordAgentStatusTransition: async () => {
+          if (operation === "status persistence") {
+            entered.resolve();
+            await release.promise;
+          }
+        },
+      });
+      await manager.restoreAgent({
+        agentId: "blocked",
+        objective: "blocked agent",
+        sessionIds: ["session"],
+      });
+      await manager.restoreAgent({
+        agentId: "other",
+        objective: "other agent",
+      });
+      const blocked =
+        operation === "session lookup"
+          ? manager.listAgents()
+          : manager.getAgent("blocked");
+      await entered.promise;
+      let completed = false;
+      const other = manager.getAgent("other").then((result) => {
+        completed = true;
+        return result;
+      });
+      try {
+        await setImmediate();
+        expect(completed).toBe(true);
+        expect(await other).toMatchObject({ agentId: "other" });
+      } finally {
+        release.resolve();
+        await Promise.all([blocked, other]);
+      }
+    },
+  );
+
+  it("keeps a late runner snapshot from replacing a terminal transition", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<AgenCBackgroundAgentSnapshot>();
+    const manager = new AgenCDaemonAgentManager({
+      runner: {
+        startAgent: async () => {
+          throw new Error("unexpected agent start");
+        },
+        getAgentSnapshot: async () => {
+          entered.resolve();
+          return release.promise;
+        },
+      },
+    });
+    await manager.restoreAgent({
+      agentId: "agent",
+      objective: "pending snapshot",
+    });
+    const lookup = manager.getAgent("agent");
+    await entered.promise;
+    let terminated = false;
+    const terminal = manager
+      .handleRunnerTerminated("agent", {
+        status: "stopped",
+        lastActiveAt: timestamp,
+      })
+      .then(() => {
+        terminated = true;
+      });
+    try {
+      await setImmediate();
+      expect(terminated).toBe(true);
+    } finally {
+      release.resolve({ status: "running", lastActiveAt: timestamp });
+      await Promise.all([lookup, terminal]);
+    }
+    expect(await manager.getAgent("agent")).toMatchObject({
+      status: "stopped",
+    });
+  });
+});

--- a/runtime/tests/app-server/agent-lifecycle.contract.test.ts
+++ b/runtime/tests/app-server/agent-lifecycle.contract.test.ts
@@ -2534,6 +2534,7 @@ describe("AgenC background agent lifecycle", () => {
     expect(starts).toEqual([
       {
         objective: "build the parser",
+        signal: expect.any(AbortSignal),
         cwd: process.cwd(),
         addDirs: ["../shared workspace", "/tmp/shared"],
         metadata: {
@@ -2897,6 +2898,7 @@ describe("AgenC background agent lifecycle", () => {
     expect(startAgent).not.toHaveBeenCalled();
     expect(restoreAgent).toHaveBeenCalledWith({
       agentId: "conv-retained1",
+      signal: expect.any(AbortSignal),
       resumeRolloutPath: fixture.rolloutPath,
       resumeRolloutLease: expect.objectContaining({
         rolloutPath: fixture.rolloutPath,
@@ -6820,6 +6822,7 @@ describe("AgenC background agent lifecycle", () => {
     expect(starts).toEqual([
       {
         objective: "index queued work",
+        signal: expect.any(AbortSignal),
         cwd: process.cwd(),
         envOverrides: expect.any(Object),
         metadata: {

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -2314,6 +2314,81 @@ describe("AgenC delegate background-agent runner", () => {
     expect(runtimeEnvironment).not.toHaveProperty("AGENC_CREDENTIAL_DOCS_MCP");
   });
 
+  it.each([30_000, 50])("bounds a hung stop at %i ms, aborts execution, and retires the generation", async (timeoutMs) => {
+    const release = Promise.withResolvers<void>();
+    const h = makeTopLevelRunner({
+      conversationId: "session-stop-deadline",
+      additionalRunnerOptions: { agentStopTimeoutMs: timeoutMs },
+      bootstrapShutdown: vi.fn(() => release.promise),
+    });
+    const abortController = new AbortController();
+    const beginShutdown = vi.fn();
+    Object.assign(h.session, {
+      abortController, beginShutdown,
+      abortAllTasks: vi.fn(() => release.promise),
+    });
+    await h.runner.startAgent({
+      objective: "bounded stop", initialContent: [],
+      unattendedAllow: [], unattendedDeny: [],
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let settled = false;
+    const stopping = h.runner.stopAgent("session-stop-deadline").catch((error: unknown) => {
+      settled = true;
+      return error;
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(timeoutMs);
+      expect(abortController.signal.aborted).toBe(true);
+      expect(beginShutdown).toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(settled).toBe(true);
+      expect(await stopping).toMatchObject({
+        name: "DaemonOperationTimeoutError", code: "DAEMON_OPERATION_TIMEOUT",
+      });
+      expect(await h.runner.getAgentSnapshot("session-stop-deadline")).toBeNull();
+    } finally {
+      release.resolve();
+      await stopping;
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds restore waiting for a previous generation without starting another bootstrap", async () => {
+    const release = Promise.withResolvers<void>();
+    const h = makeTopLevelRunner({
+      conversationId: "session-restore-deadline",
+      bootstrapShutdown: vi.fn(() => release.promise),
+    });
+    Object.assign(h.session, {
+      abortController: new AbortController(),
+      abortAllTasks: vi.fn(() => release.promise),
+    });
+    await h.runner.startAgent({
+      objective: "bounded restore", initialContent: [],
+      unattendedAllow: [], unattendedDeny: [],
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    h.stub.pushStatus({ status: "completed", turnId: "old-turn", endedAtMs: 2, lastMessage: "done" });
+    await vi.advanceTimersByTimeAsync(0);
+    let settled = false;
+    const restoring = h.runner.restoreAgent({
+      agentId: "session-restore-deadline", objective: "bounded restore",
+      reopenTerminalRun: true,
+    }).catch((error: unknown) => { settled = true; return error; });
+    try {
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(settled).toBe(true);
+      expect(await restoring).toMatchObject({ name: "DaemonOperationTimeoutError" });
+      expect(h.bootstrap).toHaveBeenCalledOnce();
+    } finally {
+      release.resolve();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await restoring;
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for the exact terminal generation cleanup before explicit restore", async () => {
     let releaseShutdown!: () => void;
     const shutdownBlocked = new Promise<void>((resolve) => {

--- a/runtime/tests/app-server/overload.contract.test.ts
+++ b/runtime/tests/app-server/overload.contract.test.ts
@@ -51,8 +51,9 @@ describe("AgenC daemon overload control messages", () => {
     expect(isDaemonPreemptiveMessage({ method: 1 })).toBe(false);
   });
 
-  it("prioritizes bounded health, status, and session lookup methods", () => {
+  it("prioritizes bounded creation, health, status, and session lookup methods", () => {
     for (const method of [
+      "agent.create",
       "agent.list",
       "run.status",
       "run.result",

--- a/runtime/tests/app-server/stdio-transport.contract.test.ts
+++ b/runtime/tests/app-server/stdio-transport.contract.test.ts
@@ -20,6 +20,7 @@ function nextChunk(stream: PassThrough): Promise<string> {
 }
 
 const RESPONSIVE_CONTROL_METHODS = [
+  "agent.create",
   "run.cancel",
   "session.cancelTurn",
   "agent.list",

--- a/runtime/tests/app-server/websocket-transport.contract.test.ts
+++ b/runtime/tests/app-server/websocket-transport.contract.test.ts
@@ -31,6 +31,7 @@ function nextClose(socket: WebSocket): Promise<void> {
 }
 
 const RESPONSIVE_CONTROL_METHODS = [
+  "agent.create",
   "run.cancel",
   "session.cancelTurn",
   "agent.list",
@@ -155,6 +156,39 @@ describe("AgenC websocket app-server transport", () => {
     client.close();
     await nextClose(client);
     await server.close();
+  });
+
+  it("does not let attach overtake a pipelined create dependency", async () => {
+    const events: string[] = [];
+    const release = Promise.withResolvers<void>();
+    const server = new AgenCWebSocketServer({
+      onMessage: async (message) => {
+        if (message.method === "agent.create") {
+          events.push("create:start");
+          await release.promise;
+          events.push("create:end");
+        } else {
+          events.push(String(message.method));
+        }
+      },
+    });
+    const address = await server.listen();
+    const client = new WebSocket(address.url);
+    await once(client, "open");
+    try {
+      client.send('{"jsonrpc":"2.0","id":1,"method":"agent.create"}');
+      client.send('{"jsonrpc":"2.0","id":2,"method":"agent.attach"}');
+      await delay(20);
+      expect(events).toEqual(["create:start"]);
+      release.resolve();
+      await delay(20);
+      expect(events).toEqual(["create:start", "create:end", "agent.attach"]);
+    } finally {
+      release.resolve();
+      client.close();
+      await nextClose(client);
+      await server.close();
+    }
   });
 
   it("does not let a priority request overtake connection initialization", async () => {

--- a/runtime/tests/auth/backends/remote-timeout.contract.test.ts
+++ b/runtime/tests/auth/backends/remote-timeout.contract.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { RemoteAuthBackend } from "../../../src/auth/backends/remote.js";
+
+describe("remote authentication request deadlines", () => {
+  it.each(["headers", "body"] as const)(
+    "aborts model routing while waiting for response %s",
+    async (stage) => {
+      const controller = new AbortController();
+      const timeout = vi
+        .spyOn(AbortSignal, "timeout")
+        .mockReturnValue(controller.signal);
+      const entered = Promise.withResolvers<AbortSignal | null | undefined>();
+      const headers = Promise.withResolvers<Response>();
+      let body: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const fetchImpl: typeof fetch = async (_input, init) => {
+        const signal = init?.signal;
+        const abort = (): void => {
+          if (stage === "headers") headers.reject(signal?.reason);
+          else body?.error(signal?.reason);
+        };
+        signal?.addEventListener("abort", abort, { once: true });
+        if (stage === "body") {
+          const response = new Response(
+            new ReadableStream<Uint8Array>({
+              start(stream) {
+                body = stream;
+              },
+              pull() {
+                entered.resolve(signal);
+              },
+            }),
+          );
+          return response;
+        }
+        entered.resolve(signal);
+        return headers.promise;
+      };
+      const backend = new RemoteAuthBackend({
+        env: {},
+        token: "test-token",
+        fetchImpl,
+      });
+      const outcome = backend
+        .inferAgencModel({
+          provider: "agenc",
+          requestedModel: "agenc:fast",
+          sessionId: "timeout-test",
+          subscriptionTier: "pro",
+        })
+        .then(
+          () => ({ error: undefined }),
+          (error: unknown) => ({ error }),
+        );
+      try {
+        expect(await entered.promise).toBe(controller.signal);
+        expect(timeout).toHaveBeenCalledWith(30_000);
+        const reason = new DOMException(
+          "request deadline elapsed",
+          "TimeoutError",
+        );
+        controller.abort(reason);
+        expect((await outcome).error).toMatchObject({ cause: reason });
+      } finally {
+        const cleanup = new Error("release stalled test request");
+        if (stage === "headers") headers.reject(cleanup);
+        else body?.error(cleanup);
+        await outcome;
+        timeout.mockRestore();
+      }
+    },
+  );
+});

--- a/runtime/tests/auth/backends/remote.contract.test.ts
+++ b/runtime/tests/auth/backends/remote.contract.test.ts
@@ -155,6 +155,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/subscription-tier",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: {
             "content-type": "application/json",
             authorization: "Bearer bootstrap-token",
@@ -307,6 +308,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/auth/me",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: {
             "content-type": "application/json",
             authorization: "Bearer remote-token",
@@ -637,6 +639,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/llm-usage",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: {
             "content-type": "application/json",
             authorization: "Bearer bootstrap-token",
@@ -705,6 +708,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/login/start",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ sessionId: "cli" }),
         },
@@ -714,6 +718,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/login/poll",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             deviceCode: "device-1",
@@ -726,6 +731,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/login/poll",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             deviceCode: "device-1",
@@ -861,6 +867,7 @@ describe("RemoteAuthBackend", () => {
         "https://api.agenc.tech/test/login/poll",
         {
           method: "POST",
+          signal: expect.any(AbortSignal),
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             deviceCode: "device-1",
@@ -1263,6 +1270,7 @@ describe("RemoteAuthBackend", () => {
       "https://api.agenc.tech/test/vend-key",
       {
         method: "POST",
+        signal: expect.any(AbortSignal),
         headers: {
           "content-type": "application/json",
           authorization: "Bearer remote-token",
@@ -1305,6 +1313,7 @@ describe("RemoteAuthBackend", () => {
       "https://id.agenc.ag/v1/auth/llm-credential",
       {
         method: "POST",
+        signal: expect.any(AbortSignal),
         headers: {
           "content-type": "application/json",
           authorization: "Bearer remote-token",
@@ -1576,6 +1585,7 @@ describe("RemoteAuthBackend", () => {
       "https://api.agenc.tech/test/infer-model",
       {
         method: "POST",
+        signal: expect.any(AbortSignal),
         headers: {
           "content-type": "application/json",
           authorization: "Bearer remote-token",
@@ -1710,6 +1720,7 @@ describe("RemoteAuthBackend", () => {
       "https://api.agenc.tech/test/subscription-tier",
       {
         method: "POST",
+        signal: expect.any(AbortSignal),
         headers: {
           "content-type": "application/json",
           authorization: "Bearer remote-token",

--- a/runtime/tests/bin/bootstrap.session-ingress.test.ts
+++ b/runtime/tests/bin/bootstrap.session-ingress.test.ts
@@ -89,6 +89,84 @@ describe("bootstrapLocalRuntimeSession session-ingress startup wiring", () => {
     }
   });
 
+  it("cancels stalled MCP startup before prewarm and rejects bootstrap", async () => {
+    const providerMod = await import("../llm/provider.js");
+    vi.spyOn(providerMod, "createProvider").mockImplementation(() => ({
+      name: "stub",
+      chat: async () => ({
+        content: "ok", toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      }),
+    }) as never);
+    const entered = Promise.withResolvers<AbortSignal | undefined>();
+    const release = Promise.withResolvers<void>();
+    vi.spyOn(Session.prototype, "startMcpManager").mockImplementation(
+      async (_manager, options) => {
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        entered.resolve(options?.signal);
+        await release.promise;
+      },
+    );
+    const prewarm = vi.spyOn(
+      ConversationThreadManager.prototype, "runStartupPrewarm",
+    ).mockResolvedValue("ready");
+    const outcome = bootstrapLocalRuntimeSession({
+      apiKey: "test-key",
+      conversationId: "mcp_startup_timeout",
+      env: {
+        ...process.env, AGENC_HOME: home, AGENC_WORKSPACE: workspace, HOME: home,
+      },
+    }).then(
+      (boot) => ({ boot, error: undefined }),
+      (error: unknown) => ({ boot: undefined, error }),
+    );
+    try {
+      const signal = await entered.promise;
+      expect(signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(signal?.aborted).toBe(true);
+      expect(prewarm).not.toHaveBeenCalled();
+      vi.useRealTimers();
+      expect((await outcome).error).toMatchObject({
+        message: "MCP startup exceeded 60000ms",
+      });
+    } finally {
+      vi.useRealTimers();
+      release.resolve();
+      const result = await outcome;
+      await result.boot?.shutdown();
+    }
+  });
+
+  it("cancels bootstrap while startup prewarm is stuck", async () => {
+    const providerMod = await import("../llm/provider.js");
+    vi.spyOn(providerMod, "createProvider").mockImplementation(() => ({
+      name: "stub", chat: async () => ({ content: "ok", toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      }),
+    }) as never);
+    const entered = Promise.withResolvers<Session>();
+    const release = Promise.withResolvers<"ready">();
+    vi.spyOn(ConversationThreadManager.prototype, "runStartupPrewarm").mockImplementation(async (session) => {
+      entered.resolve(session);
+      return release.promise;
+    });
+    const controller = new AbortController();
+    const outcome = bootstrapLocalRuntimeSession({
+      apiKey: "test-key", conversationId: "cancel_startup_prewarm", signal: controller.signal,
+      env: { ...process.env, AGENC_HOME: home, AGENC_WORKSPACE: workspace, HOME: home },
+    }).then((boot) => ({ boot, error: undefined }), (error: unknown) => ({ boot: undefined, error }));
+    try {
+      const session = await entered.promise;
+      controller.abort(new Error("cancelled startup prewarm"));
+      expect(session.abortController.signal.aborted).toBe(true);
+      expect((await outcome).error).toMatchObject({ message: "cancelled startup prewarm" });
+    } finally {
+      release.resolve("ready");
+      await (await outcome).boot?.shutdown();
+    }
+  });
+
   it("binds Grok ACP to the scrubbed client child environment", async () => {
     const providerMod = await import("../llm/provider.js");
     let capturedOptions:

--- a/runtime/tests/config/strict-schema-validation.test.ts
+++ b/runtime/tests/config/strict-schema-validation.test.ts
@@ -89,6 +89,9 @@ describe("strict schema-v2 validation coverage", () => {
       /web_search_endpoint_kind/u,
     ],
     ["daemon unknown field", { daemon: { socket: true } }, /daemon\.socket/u],
+    ["daemon zero stop timeout", { daemon: { agent_stop_timeout_ms: 0 } }, /daemon\.agent_stop_timeout_ms/u],
+    ["daemon fractional stop timeout", { daemon: { agent_stop_timeout_ms: 1.5 } }, /daemon\.agent_stop_timeout_ms/u],
+    ["daemon overflowing stop timeout", { daemon: { agent_stop_timeout_ms: 2_147_483_648 } }, /daemon\.agent_stop_timeout_ms/u],
     ["daemon unknown transport", { daemon: { transport: "unix" } }, /daemon\.transport.*unknown field/u],
     [
       "LSP unknown field",

--- a/runtime/tests/tools/system/imagine-image.test.ts
+++ b/runtime/tests/tools/system/imagine-image.test.ts
@@ -607,6 +607,7 @@ describe("ImagineImage tool", () => {
   });
 
   it("rejects unsupported Z.ai image requests and untrusted result hosts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-zai-untrusted-"));
     const provider = createProvider("zai", {
       apiKey: "isolated-zai-key",
       model: "glm-5.3",
@@ -620,8 +621,8 @@ describe("ImagineImage tool", () => {
       }),
     );
     const tool = createImagineImageTool({
-      workspaceRoot: process.cwd(),
-      home: testHome(process.cwd()),
+      workspaceRoot: root,
+      home: testHome(root),
       getSession: () => ({ services: { provider } }) as unknown as Session,
       env: {},
       fetchImpl,
@@ -771,6 +772,7 @@ describe("ImagineImage tool", () => {
   });
 
   it("blocks a signed-image redirect that leaves trusted HTTPS hosts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-qwen-redirect-"));
     const signed =
       "https://dashscope-result-sg.oss-ap-southeast-1.aliyuncs.com/image.png";
     const fetchImpl = vi.fn(async (url: string | URL | Request) =>
@@ -780,7 +782,7 @@ describe("ImagineImage tool", () => {
             status: 302,
             headers: { location: "http://127.0.0.1/internal" },
           }));
-    const tool = createQwenImagineTool("qwen", fetchImpl);
+    const tool = createQwenImagineTool("qwen", fetchImpl, root);
 
     const result = await tool.execute({ prompt: "safe redirect handling" });
 
@@ -790,6 +792,7 @@ describe("ImagineImage tool", () => {
   });
 
   it("rejects oversized signed images before buffering the response", async () => {
+    const root = await mkdtemp(join(tmpdir(), "imagine-qwen-oversized-"));
     const signed =
       "https://dashscope-result-sg.oss-ap-southeast-1.aliyuncs.com/large.png";
     const fetchImpl = vi.fn(async (url: string | URL | Request) =>
@@ -802,7 +805,7 @@ describe("ImagineImage tool", () => {
               "content-length": String(20 * 1024 * 1024 + 1),
             },
           }));
-    const tool = createQwenImagineTool("qwen", fetchImpl);
+    const tool = createQwenImagineTool("qwen", fetchImpl, root);
 
     const result = await tool.execute({ prompt: "bounded download" });
 


### PR DESCRIPTION
A stalled provider, MCP server, runner cleanup, or persistence callback could leave agent creation and daemon shutdown waiting indefinitely.

- Bound agent.create to 120 seconds and propagate request cancellation through bootstrap and prewarm. Stop unpublished runners on cancellation, reject late publication, and clean up late session results.
- Add a configurable graceful stop deadline (daemon.agent_stop_timeout_ms, default 30000), escalate to hard execution teardown, and bound previous-generation cleanup and shutdown's active-create drain.
- Add 30-second remote-auth request/body deadlines and a 60-second MCP startup deadline that cancels startup.
- Move asynchronous session lookup, runner snapshots, and persistence outside the lifecycle state lock, with generation and state checks before applying reads.
- Dispatch agent.create during busy streams while preserving create-to-attach order. Return structured timeout errors through JSON-RPC.

Addresses #1760. The issue stays open through the benchmark refresh described below.

Validation: typecheck, runtime build, and PTY startup smoke passed. The clean-tree hermetic run at bec58393b passed 22,270 tests with zero skips; its sole failure is the FND binding described below. The review follow-up makes snapshot refresh best-effort during stop and shutdown. Its two regression tests fail before the fix, and all 147 targeted lifecycle tests pass afterwards. Three image-tool tests also now use temporary output workspaces so their security assertions run in the read-only test boundary.


The remaining FND failure reports stale production-module bindings. The benchmark capture contract requires a source revision already on the default branch with an identical runtime/src tree, so the new measurements must be captured after this runtime change merges. That follow-up will regenerate both artifacts without changing the provenance checks. Full hosted platform checks and independent review are required for this change; #1760 remains unfinished until the artifact refresh and final validation are complete.
