### PR TITLE
test(runtime): refresh FND benchmark evidence after daemon hardening

### DIFF
--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.751128,
-            "maxMs": 88.410115,
-            "medianMs": 86.658987,
-            "minMs": 82.74101,
+            "madMs": 1.047131,
+            "maxMs": 99.367188,
+            "medianMs": 89.461279,
+            "minMs": 85.636365,
             "sampleCount": 5,
             "samplesMs": [
-              86.658987,
-              88.016798,
-              88.410115,
-              83.153316,
-              82.74101
+              99.367188,
+              89.461279,
+              88.414148,
+              89.910272,
+              85.636365
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 185421824,
+              "maximumObservedBytes": 184942592,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                125673472,
-                139952128,
-                141905920,
-                141905920,
-                177557504,
-                177557504,
-                178606080,
-                178606080,
-                182276096,
-                182276096,
-                185421824
+                134860800,
+                140378112,
+                176553984,
+                176553984,
+                178651136,
+                178651136,
+                180748288,
+                180748288,
+                182321152,
+                182321152,
+                184942592
               ]
             },
-            "peakRssBytes": 185421824,
+            "peakRssBytes": 184942592,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 2.342276,
-            "maxMs": 176.271988,
-            "medianMs": 166.713819,
-            "minMs": 164.371543,
+            "madMs": 6.08497,
+            "maxMs": 190.248375,
+            "medianMs": 184.163405,
+            "minMs": 166.612285,
             "sampleCount": 5,
             "samplesMs": [
-              171.866401,
-              176.271988,
-              166.584554,
-              166.713819,
-              164.371543
+              190.248375,
+              185.499666,
+              166.612285,
+              184.163405,
+              173.7136
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 198762496,
+              "maximumObservedBytes": 196628480,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                122437632,
-                140271616,
-                178020352,
-                178020352,
-                183787520,
-                183787520,
-                190603264,
-                190603264,
-                194568192,
-                194568192,
-                198762496
+                122662912,
+                139616256,
+                177364992,
+                177364992,
+                182607872,
+                182607872,
+                188375040,
+                188375040,
+                192958464,
+                192958464,
+                196628480
               ]
             },
-            "peakRssBytes": 202252288,
+            "peakRssBytes": 199614464,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 8.615238,
-            "maxMs": 349.578465,
-            "medianMs": 339.024655,
-            "minMs": 326.717102,
+            "madMs": 3.333769,
+            "maxMs": 362.349932,
+            "medianMs": 343.236087,
+            "minMs": 338.661673,
             "sampleCount": 5,
             "samplesMs": [
-              347.639893,
-              339.024655,
-              333.894237,
-              349.578465,
-              326.717102
+              362.349932,
+              346.569856,
+              341.116815,
+              343.236087,
+              338.661673
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 214384640,
+              "maximumObservedBytes": 219652096,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                126349312,
-                179462144,
-                191299584,
-                191299584,
-                203993088,
-                203993088,
-                212381696,
-                212381696,
-                213336064,
-                213336064,
-                214384640
+                122675200,
+                176758784,
+                189865984,
+                189865984,
+                199475200,
+                199475200,
+                207863808,
+                207863808,
+                218120192,
+                218120192,
+                219652096
               ]
             },
-            "peakRssBytes": 216969216,
+            "peakRssBytes": 220741632,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.246524,
-            "maxMs": 3.828161,
-            "medianMs": 2.884528,
-            "minMs": 2.638004,
+            "madMs": 0.396182,
+            "maxMs": 3.878996,
+            "medianMs": 2.958357,
+            "minMs": 2.527863,
             "sampleCount": 5,
             "samplesMs": [
-              3.828161,
-              2.779349,
-              3.264305,
-              2.638004,
-              2.884528
+              3.878996,
+              2.68425,
+              3.354539,
+              2.527863,
+              2.958357
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 92348416,
+              "maximumObservedBytes": 89731072,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                83435520,
-                85532672,
-                87629824,
-                87629824,
-                88678400,
-                88678400,
-                90775552,
-                90775552,
-                91824128,
-                91824128,
-                92348416
+                81342464,
+                82391040,
+                85012480,
+                85012480,
+                86061056,
+                86061056,
+                87633920,
+                87633920,
+                88682496,
+                88682496,
+                89731072
               ]
             },
-            "peakRssBytes": 92348416,
+            "peakRssBytes": 89731072,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.452117,
-            "maxMs": 7.29928,
-            "medianMs": 5.304302,
-            "minMs": 4.852185,
+            "madMs": 0.212313,
+            "maxMs": 7.251573,
+            "medianMs": 5.559851,
+            "minMs": 5.333457,
             "sampleCount": 5,
             "samplesMs": [
-              7.29928,
-              5.304302,
-              5.782207,
-              4.860178,
-              4.852185
+              7.251573,
+              5.559851,
+              5.772164,
+              5.436674,
+              5.333457
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 105832448,
+              "maximumObservedBytes": 104407040,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84336640,
-                89579520,
-                92200960,
-                92200960,
-                96395264,
-                96395264,
-                97968128,
-                97968128,
-                103735296,
-                103735296,
-                105832448
+                82911232,
+                88678400,
+                90251264,
+                90251264,
+                94445568,
+                94445568,
+                96542720,
+                96542720,
+                102309888,
+                102309888,
+                104407040
               ]
             },
-            "peakRssBytes": 105832448,
+            "peakRssBytes": 104407040,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.359946,
-            "maxMs": 14.891495,
-            "medianMs": 11.510703,
-            "minMs": 9.918827,
+            "madMs": 0.792615,
+            "maxMs": 15.876814,
+            "medianMs": 11.153264,
+            "minMs": 10.360649,
             "sampleCount": 5,
             "samplesMs": [
-              11.201103,
-              11.870649,
-              11.510703,
-              9.918827,
-              14.891495
+              11.037548,
+              12.791294,
+              11.153264,
+              10.360649,
+              15.876814
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 127041536,
+              "maximumObservedBytes": 125190144,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                86147072,
-                96632832,
-                101875712,
-                101875712,
-                106594304,
-                106594304,
-                112361472,
-                112361472,
-                120225792,
-                120225792,
-                127041536
+                83771392,
+                93208576,
+                98975744,
+                98975744,
+                103170048,
+                103170048,
+                109461504,
+                109461504,
+                117325824,
+                117325824,
+                125190144
               ]
             },
-            "peakRssBytes": 127041536,
+            "peakRssBytes": 125190144,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -604,11 +604,11 @@
         },
         {
           "path": "runtime/src/config/schema.ts",
-          "sha256": "cd45f9ef1c3d0994426448c9deadc8aa46dda03284f0821f135e5e64088b9587"
+          "sha256": "91a470708e57cdfbcef72417ce2d8a63df4d275f11a0cb0fc2754e06053d83b8"
         },
         {
           "path": "runtime/src/config/strict-schema.ts",
-          "sha256": "eb381ee5cb9bf81101cbd47216eb638faba8fe3471612bb12665e88eb204fdd9"
+          "sha256": "2d6385dbd9c80a6f376f087bf3abe121e810db0319aaf73bdb9e27a81f83d0b1"
         },
         {
           "path": "runtime/src/constants/oauth.ts",
@@ -943,11 +943,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "db32040f616d30e5abb760c1d043880aac714122",
+    "gitObjectId": "ba2c22104cc0bb3d9cf242f17bc50bdd1427ca8e",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "39242337bfe5176392223a1161999dafe4daa0b4",
+  "sourceRevision": "c506ece504e0e82a367e63c208654a20c3525143",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,9 +4,9 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `16756c677156c8d11a951ee66741de1377cd835be56fb002f54cf1eef3f9e3a5`
-- Source revision: `39242337bfe5176392223a1161999dafe4daa0b4`
-- Production tree: `runtime/src` at Git object `db32040f616d30e5abb760c1d043880aac714122`
+- JSON SHA-256: `4bae451c602631b0733596659e1bbe226cc27dbaef5aeb3f2f1cce97abc5e6b8`
+- Source revision: `c506ece504e0e82a367e63c208654a20c3525143`
+- Production tree: `runtime/src` at Git object `ba2c22104cc0bb3d9cf242f17bc50bdd1427ca8e`
 - Loaded production closure: `94` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
@@ -18,12 +18,12 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 86.659 | 1.751 | 185421824 | 185421824 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 166.714 | 2.342 | 202252288 | 198762496 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 339.025 | 8.615 | 216969216 | 214384640 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.885 | 0.247 | 92348416 | 92348416 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.304 | 0.452 | 105832448 | 105832448 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 11.511 | 0.360 | 127041536 | 127041536 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 89.461 | 1.047 | 184942592 | 184942592 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 184.163 | 6.085 | 199614464 | 196628480 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 343.236 | 3.334 | 220741632 | 219652096 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.958 | 0.396 | 89731072 | 89731072 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.560 | 0.212 | 104407040 | 104407040 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 11.153 | 0.793 | 125190144 | 125190144 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 39242337bfe5176392223a1161999dafe4daa0b4 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision c506ece504e0e82a367e63c208654a20c3525143 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/tests/commands/provider-command-access.test.ts
+++ b/runtime/tests/commands/provider-command-access.test.ts
@@ -646,6 +646,7 @@ describe("provider command access", () => {
         }),
       ),
     ).inspect(selection);
+    expect(signedOut.configurationError).toBeUndefined();
     expect(signedOut).toMatchObject({
       effect: "blocked",
       route: "unavailable",


### PR DESCRIPTION
The daemon hardening in #2255 changed production modules loaded by the CSV scheduler benchmark, leaving the checked-in baseline stale. Regenerate the JSON and Markdown reports from merged source c506ece504e0e82a367e63c208654a20c3525143 using Node 26.5.0 and npm 11.17.0. All six measured points completed and matched their correctness oracles.

Add an explicit configuration-error assertion to the managed-provider access test. An earlier hosted attempt returned an unexpected configuration rejection once; 30 isolated repetitions and full local and hosted shard replays passed. The cause was not reproduced, and the assertion will report the underlying error if it recurs.

Validation: the complete local suite passed 22,273 tests with zero failures or skips. [Hosted validation](https://github.com/tetsuo-ai/agenc-core/actions/runs/34122036464) passed all 13 jobs on 564d61a8c24e477fb774b27c7dab5a8a7f73582f, including all four default-suite shards, nine native-platform jobs, and the fresh-clone benchmark provenance check. Affected tests, independent review, Bugbot, security review, and Sonar checks passed.

Closes #1760.
