### PR TITLE
state: the rollout retention sweep says which sessions it deleted

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -172,6 +172,7 @@ import {
   pruneSessionStateSnapshots,
   pruneTerminalAgentRuns,
   SESSION_SNAPSHOT_HARD_CAP,
+  type RolloutPruningReport,
   type RolloutRetentionPolicy,
 } from "../state/pruning.js";
 import { StateSqliteHealthStatsReader } from "../state/health-stats.js";
@@ -4419,6 +4420,26 @@ function describeStateReclaim(
   return `daemon state reclaimed ${pages} free page(s) (${mib} MiB, ${how}) in ${stateDbPath}`;
 }
 
+/**
+ * A retention sweep deletes session directories permanently and unattended, so
+ * the ids it removed must survive in the log. Sessions are named, not counted:
+ * "which of my sessions went" is the only question this line has to answer.
+ */
+function describeRolloutRetentionPrune(
+  report: RolloutPruningReport,
+  projectDir: string,
+): string {
+  const NAMED = 20;
+  const ids = report.prunedSessionIds.slice(0, NAMED).join(", ");
+  const rest = report.prunedSessionIds.length - NAMED;
+  const named = ids.length > 0 ? `: ${ids}${rest > 0 ? `, and ${rest} more` : ""}` : "";
+  return (
+    `daemon rollout retention deleted ${report.prunedSessions} session(s) ` +
+    `(${report.prunedRolloutFiles} rollout file(s), ${report.prunedMirrorRows} mirror row(s)) ` +
+    `in ${projectDir}${named}`
+  );
+}
+
 function recoverAgenCDaemonStartupState(
   daemonHome: string,
   cwd: string,
@@ -4997,6 +5018,8 @@ class AgenCDaemonSnapshotPolicyRegistry {
         ),
       onReclaimReport: (report) =>
         this.#log(describeStateReclaim(report, paths.stateDbPath)),
+      onRolloutPruneReport: (report) =>
+        this.#log(describeRolloutRetentionPrune(report, paths.projectDir)),
     });
     const entry = { driver, policy };
     this.#policies.set(paths.stateDbPath, entry);

--- a/runtime/src/state/snapshot-policy.ts
+++ b/runtime/src/state/snapshot-policy.ts
@@ -7,6 +7,7 @@ import {
   pruneSessionSnapshotsForSession,
   type AgentRunRetentionPolicy,
   type AgentSnapshotPruningReport,
+  type RolloutPruningReport,
   type RolloutRetentionPolicy,
 } from "./pruning.js";
 import type {
@@ -70,6 +71,14 @@ export interface SnapshotPolicyOptions {
   readonly onPruneReport?: (report: AgentSnapshotPruningReport) => void;
   /** Called after a periodic tick returned free pages of the state database to the file system. */
   readonly onReclaimReport?: (report: StateFreePageReclaim) => void;
+  /**
+   * Called after a retention sweep permanently deleted session directories.
+   * The sweep is irreversible and runs unattended on the periodic timer, so a
+   * deployment that never set `rollout_days` is opted in by upgrading: what it
+   * removed has to be recoverable from the log, not only from the disk that no
+   * longer holds it.
+   */
+  readonly onRolloutPruneReport?: (report: RolloutPruningReport) => void;
   readonly snapshotRetention?: AgentRunRetentionPolicy;
   // Rollout/session disk-retention sweep config. Disabled unless
   // `rolloutRetention.retention_days` is set AND `rolloutSessionsDir` resolves;
@@ -198,6 +207,9 @@ export class AgenCSessionSnapshotPolicy {
   readonly #onError: (error: unknown) => void;
   readonly #onPruneReport: ((report: AgentSnapshotPruningReport) => void) | undefined;
   readonly #onReclaimReport: ((report: StateFreePageReclaim) => void) | undefined;
+  readonly #onRolloutPruneReport:
+    | ((report: RolloutPruningReport) => void)
+    | undefined;
   #prunedSinceReport = 0;
   readonly #prunedSessionsSinceReport = new Set<string>();
   #snapshotRetention: AgentRunRetentionPolicy | undefined;
@@ -261,6 +273,7 @@ export class AgenCSessionSnapshotPolicy {
     this.#onError = options.onError ?? (() => {});
     this.#onPruneReport = options.onPruneReport;
     this.#onReclaimReport = options.onReclaimReport;
+    this.#onRolloutPruneReport = options.onRolloutPruneReport;
     this.#snapshotRetention = options.snapshotRetention;
     this.#rolloutRetention = options.rolloutRetention;
     this.#rolloutSessionsDir = options.rolloutSessionsDir;
@@ -373,7 +386,7 @@ export class AgenCSessionSnapshotPolicy {
       return;
     }
     try {
-      pruneRolloutSessions(this.#driver, {
+      const report = pruneRolloutSessions(this.#driver, {
         sessionsDir: this.#rolloutSessionsDir,
         retention_days: retentionDays,
         ...(this.#activeSessionId !== undefined
@@ -382,6 +395,8 @@ export class AgenCSessionSnapshotPolicy {
         now: this.#now,
         onError: this.#onError,
       });
+      // Silence is only honest when nothing was destroyed.
+      if (report.prunedSessions > 0) this.#onRolloutPruneReport?.(report);
     } catch (error) {
       this.#onError(error);
     }

--- a/runtime/tests/state/rollout-retention-sweep.test.ts
+++ b/runtime/tests/state/rollout-retention-sweep.test.ts
@@ -655,6 +655,45 @@ describe("AgenCSessionSnapshotPolicy rollout sweep timer", () => {
     expect(mirrorRowCountForSource(activePath)).toBe(2);
   });
 
+  it("reports the sessions it deleted, and stays silent when it deleted nothing", () => {
+    // The sweep is irreversible and unattended, and every install that never
+    // set `rollout_days` is opted in by upgrading (#2235). What it removed has
+    // to be recoverable from the log, not only from the disk it just cleared.
+    const oldPath = seedSession("thread-old", 60);
+    seedSession("thread-active", 90);
+    const sessionsDir = join(driver.projectDir, "sessions");
+    const reports: { prunedSessions: number; prunedSessionIds: readonly string[] }[] = [];
+
+    let tick: (() => void) | undefined;
+    const policy = new AgenCSessionSnapshotPolicy(driver, {
+      now: () => NOW,
+      rolloutRetention: { retention_days: 30 },
+      rolloutSessionsDir: sessionsDir,
+      activeSessionId: "thread-active",
+      onRolloutPruneReport: (report) => reports.push(report),
+      setInterval: (callback) => {
+        tick = callback;
+        return { unref: vi.fn() };
+      },
+      clearInterval: vi.fn(),
+    });
+
+    policy.startPeriodic();
+    tick?.();
+
+    expect(existsSync(oldPath)).toBe(false);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]?.prunedSessions).toBe(1);
+    // Named, not just counted: "which of my sessions went" is the question.
+    expect(reports[0]?.prunedSessionIds).toContain("thread-old");
+    expect(reports[0]?.prunedSessionIds).not.toContain("thread-active");
+
+    // A second sweep removes nothing, so it must not announce anything.
+    tick?.();
+    policy.stopPeriodic();
+    expect(reports).toHaveLength(1);
+  });
+
   it("never sweeps when no rollout retention window is configured", () => {
     const oldPath = seedSession("thread-old", 365);
     const sessionsDir = join(driver.projectDir, "sessions");


### PR DESCRIPTION
## Why

`AgenCSessionSnapshotPolicy.sweepRolloutRetention` calls `pruneRolloutSessions` and throws the result away. That function returns a `RolloutPruningReport` with `prunedSessions`, `prunedRolloutFiles`, `prunedMirrorRows` and `prunedSessionIds`, and nothing captured it, so a sweep that permanently removed a user's session directories left no record of which ones. The free-page reclaim immediately below it already reports through `onReclaimReport`, so the asymmetry was an omission rather than a decision.

This became sharper when #2235 set `agent.retention.rollout_days` to 30 by default. Any install that never set the key is opted in by upgrading, and the sweep is irreversible, unattended and runs on the periodic timer. A user who upgrades and later asks "where did my sessions go" currently has nothing to read.

Found while auditing release readiness for the four fixes merged today.

## What changed

- `runtime/src/state/snapshot-policy.ts`: new optional `onRolloutPruneReport`, stored like its `onReclaimReport` sibling. `sweepRolloutRetention` keeps the report and emits it only when `prunedSessions > 0`, so a sweep that removed nothing stays quiet.
- `runtime/src/app-server/daemon-cli.ts`: wires it next to `onReclaimReport` and adds `describeRolloutRetentionPrune`, which logs the counts and names the session ids, capping the list at 20 with an "and N more" tail.
- `runtime/tests/state/rollout-retention-sweep.test.ts`: a case asserting the report fires once with the deleted id named and the active session absent, and that a second sweep which deletes nothing reports nothing.

Example line:

```
daemon rollout retention deleted 3 session(s) (7 rollout file(s), 12 mirror row(s)) in <projectDir>: conv-a, conv-b, conv-c
```

## Evidence

| run | result |
| --- | --- |
| `vitest run tests/state/rollout-retention-sweep.test.ts` | 16 passed (15 before, plus the new case) |
| `tsc --noEmit` | no errors outside this worktree's `TS2883` lodash baseline |

## Tests

The new case drives the real policy through its periodic tick with a 30-day window, a 60-day-old session and a 90-day-old active one, and asserts the emitted report names the deleted session and not the spared one. The second tick asserts silence, which is what keeps this line meaningful rather than periodic noise.

## Not changed

- The retention default, the sweep's policy, its 50-directory-per-pass bound and its conservatism rules.
- Whether 30 days is the right default. That is a product decision, and it is worth revisiting separately: shipping it means existing installs start deleting on upgrade, and this PR only makes that visible rather than quiet.

## Counterparts

Follows #2235 which set the default.
