### PR TITLE
fix(runtime): bound diagnostic queues and attach the daemon sink

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -210,6 +210,8 @@ import {
   type SizeCappedFileLogSink,
 } from "../utils/logger.js";
 import { isRecord } from "../utils/record.js";
+import { logForDebugging } from "../utils/debug.js";
+import { installAgenCDaemonErrorLogSink } from "./daemon-error-log.js";
 import { startHeapWatchdog } from "../services/heapWatchdog/heapWatchdog.js";
 import { workspaceMutationCoordinators } from "../workspace/mutation-coordinator.js";
 
@@ -3286,6 +3288,12 @@ async function runAgenCDaemonForegroundLocked(
       executionAdmissionKernel.close();
     });
     if (host.startupGuardReceiver?.wasRequested() === true) return 1;
+    let writeErrorLog = (line: string): void => {
+      io.stderr.write(line);
+    };
+    let writeErrorDebugLog = (line: string): void => {
+      logForDebugging(line);
+    };
     // Only the spawned, detached daemon (AGENC_DAEMON_RUN=1) redirects console
     // output into the size-capped rotating sink; a `--foreground` invocation run
     // directly by a user keeps writing to the inherited terminal.
@@ -3294,6 +3302,8 @@ async function runAgenCDaemonForegroundLocked(
         path: resolveAgenCDaemonLogPath(host.env, host.userHome),
       });
       if (logSink !== null) {
+        writeErrorLog = (line) => logSink.sink.write(line);
+        writeErrorDebugLog = writeErrorLog;
         const disposeExitDiagnostics = installAgenCDaemonExitDiagnostics({
           sink: logSink.sink,
         });
@@ -3316,6 +3326,11 @@ async function runAgenCDaemonForegroundLocked(
       });
       cleanup.register("daemon-heartbeat", disposeHeartbeat);
     }
+    cleanup.register("daemon-error-log-sink", installAgenCDaemonErrorLogSink({
+      path: resolveAgenCDaemonLogPath(host.env, host.userHome),
+      write: writeErrorLog,
+      writeDebug: writeErrorDebugLog,
+    }));
     let shuttingDown = false;
     let startupCancelled = false;
     let resolveRpcShutdown!: () => void;

--- a/runtime/src/app-server/daemon-error-log.ts
+++ b/runtime/src/app-server/daemon-error-log.ts
@@ -1,0 +1,24 @@
+import { redactSecrets } from '../secrets/sanitizer.js'
+import { attachErrorLogSink } from '../utils/log.js'
+
+/** Connect startup diagnostics to the daemon's bounded log or inherited stderr. */
+export function installAgenCDaemonErrorLogSink(options: {
+  readonly path: string
+  readonly write: (line: string) => void
+  readonly writeDebug?: (line: string) => void
+}): () => void {
+  const line = (level: 'error' | 'debug', message: string, server?: string) =>
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      ...(server === undefined ? {} : { server: redactSecrets(server) }),
+      message: redactSecrets(message),
+    }) + '\n'
+  return attachErrorLogSink({
+    logError: error => options.write(line('error', error.stack || error.message)),
+    logMCPError: (server, error) => options.write(line('error', String(error), server)),
+    logMCPDebug: (server, message) => (options.writeDebug ?? options.write)(line('debug', message, server)),
+    getErrorsPath: () => options.path,
+    getMCPLogsPath: () => options.path,
+  })
+}

--- a/runtime/src/utils/log.ts
+++ b/runtime/src/utils/log.ts
@@ -86,67 +86,160 @@ export type ErrorLogSink = {
 
 // Queued events for events logged before sink is attached
 type QueuedErrorEvent =
-  | { type: 'error'; error: Error }
-  | { type: 'mcpError'; serverName: string; error: unknown }
+  | { type: 'error'; message: string; stack: string; name: string }
+  | { type: 'mcpError'; serverName: string; error: string }
   | { type: 'mcpDebug'; serverName: string; message: string }
 
+export const ERROR_LOG_QUEUE_LIMITS = Object.freeze({
+  errors: 100,
+  debug: 100,
+  textBytes: 8192,
+  labelBytes: 256,
+})
+
 const errorQueue: QueuedErrorEvent[] = []
+let droppedErrors = 0
+let droppedDebug = 0
 
 // Sink - initialized during app startup
-let errorLogSink: ErrorLogSink | null = null
+let errorLogSink: { sink: ErrorLogSink } | null = null
 
-/**
- * Attach the error log sink that will receive all error events.
- * Queued events are drained immediately to ensure no errors are lost.
- *
- * Idempotent: if a sink is already attached, this is a no-op. This allows
- * calling from both the preAction hook (for subcommands) and setup() (for
- * the default command) without coordination.
- */
-export function attachErrorLogSink(newSink: ErrorLogSink): void {
+function boundedLogText(
+  text: string,
+  maxBytes: number = ERROR_LOG_QUEUE_LIMITS.textBytes,
+): string {
+  // Copy a bounded prefix so a short substring cannot retain a large backing string.
+  const bytes = Buffer.from(text.slice(0, maxBytes), 'utf8')
+  if (text.length <= maxBytes && bytes.length <= maxBytes) {
+    return bytes.toString('utf8')
+  }
+  const marker = '...[truncated]'
+  let end = Math.min(bytes.length, maxBytes - marker.length)
+  while (end > 0 && (bytes[end]! & 0xc0) === 0x80) end--
+  return bytes.subarray(0, end).toString('utf8') + marker
+}
+
+function formattedLogError(error: unknown): string {
+  try {
+    return boundedLogText(
+      error instanceof Error ? error.stack || error.message : String(error),
+    )
+  } catch {
+    return '[unprintable error]'
+  }
+}
+
+function recordDroppedEvent(event: QueuedErrorEvent): void {
+  if (event.type === 'mcpDebug') {
+    droppedDebug = Math.min(Number.MAX_SAFE_INTEGER, droppedDebug + 1)
+  } else {
+    droppedErrors = Math.min(Number.MAX_SAFE_INTEGER, droppedErrors + 1)
+  }
+}
+
+function deliverErrorLogEvent(sink: ErrorLogSink, event: QueuedErrorEvent): void {
+  try {
+    switch (event.type) {
+      case 'error': {
+        const error = new Error(event.message)
+        error.name = event.name
+        error.stack = event.stack
+        sink.logError(error)
+        break
+      }
+      case 'mcpError':
+        sink.logMCPError(event.serverName, event.error)
+        break
+      case 'mcpDebug':
+        sink.logMCPDebug(event.serverName, event.message)
+        break
+    }
+  } catch {
+    // A failed sink must neither recurse through logging nor stop the drain.
+    recordDroppedEvent(event)
+  }
+}
+
+function emitErrorLogEvent(event: QueuedErrorEvent): void {
   if (errorLogSink !== null) {
+    deliverErrorLogEvent(errorLogSink.sink, event)
     return
   }
-  errorLogSink = newSink
+  const debug = event.type === 'mcpDebug'
+  const sameKind = (queued: QueuedErrorEvent) =>
+    (queued.type === 'mcpDebug') === debug
+  const limit = debug
+    ? ERROR_LOG_QUEUE_LIMITS.debug
+    : ERROR_LOG_QUEUE_LIMITS.errors
+  if (errorQueue.filter(sameKind).length >= limit) {
+    const [evicted] = errorQueue.splice(errorQueue.findIndex(sameKind), 1)
+    if (evicted) recordDroppedEvent(evicted)
+  }
+  errorQueue.push(event)
+}
 
-  // Drain the queue immediately - errors should not be delayed
-  if (errorQueue.length > 0) {
-    const queuedEvents = [...errorQueue]
-    errorQueue.length = 0
-
-    for (const event of queuedEvents) {
-      switch (event.type) {
-        case 'error':
-          errorLogSink.logError(event.error)
-          break
-        case 'mcpError':
-          errorLogSink.logMCPError(event.serverName, event.error)
-          break
-        case 'mcpDebug':
-          errorLogSink.logMCPDebug(event.serverName, event.message)
-          break
-      }
-    }
+export function getErrorLogQueueStats(): {
+  errors: number
+  debug: number
+  /** UTF-8 payload bytes; event count separately bounds object overhead. */
+  retainedBytes: number
+  droppedErrors: number
+  droppedDebug: number
+} {
+  const debug = errorQueue.filter(event => event.type === 'mcpDebug').length
+  return {
+    errors: errorQueue.length - debug,
+    debug,
+    retainedBytes: errorQueue.reduce(
+      (total, event) => total + Object.values(event).reduce(
+        (bytes, value) => bytes + Buffer.byteLength(value, 'utf8'), 0,
+      ), 0,
+    ),
+    droppedErrors,
+    droppedDebug,
   }
 }
 
 /**
- * Logs an error to multiple destinations for debugging and monitoring.
+ * Attach the error log sink that will receive all error events.
+ * Retained startup events are drained immediately. The returned disposer
+ * detaches only this attachment and clears its retained state.
  *
- * This function logs errors to:
- * - Debug logs (visible via `agenc --debug` or `tail -f ~/.agenc/debug/latest`)
- * - In-memory error log (accessible via `getInMemoryErrors()`, useful for including
- *   in bug reports or displaying recent errors to users)
- * - Persistent error log file (only for internal 'ant' users, stored in ~/.agenc/errors/)
+ * An existing attachment keeps ownership; duplicate attachments receive
+ * a no-op disposer.
+ */
+export function attachErrorLogSink(newSink: ErrorLogSink): () => void {
+  if (errorLogSink !== null) {
+    return () => {}
+  }
+  const attachment = { sink: newSink }
+  errorLogSink = attachment
+  const queuedEvents = errorQueue.splice(0)
+  for (const event of queuedEvents) {
+    if (errorLogSink !== attachment) break
+    deliverErrorLogEvent(newSink, event)
+  }
+  return () => {
+    if (errorLogSink !== attachment) return
+    errorLogSink = null
+    errorQueue.length = 0
+    inMemoryErrorLog = []
+    droppedErrors = 0
+    droppedDebug = 0
+  }
+}
+
+/**
+ * Records bounded error text in recent history and the active process sink.
+ * Before sink attachment, events enter the bounded startup queue.
+ * The daemon routes diagnostics to its rotating log or inherited stderr.
  *
  * Usage:
  * ```ts
  * logError(new Error('Failed to connect'))
  * ```
  *
- * To view errors:
- * - Debug: Run `agenc --debug` or `tail -f ~/.agenc/debug/latest`
- * - In-memory: Call `getInMemoryErrors()` to get recent errors for the current session
+ * Call `getInMemoryErrors()` to retrieve recent errors for this sink lifetime.
  */
 const isHardFailMode = memoize((): boolean => {
   return tokenizeCliOptionRegion(process.argv.slice(2)).optionArgs.includes(
@@ -155,7 +248,6 @@ const isHardFailMode = memoize((): boolean => {
 })
 
 export function logError(error: unknown): void {
-  const err = toError(error)
   if (feature('HARD_FAIL') && isHardFailMode()) {
     // biome-ignore lint/suspicious/noConsole:: intentional crash output
     console.error('[HARD FAIL] logError called')
@@ -176,7 +268,8 @@ export function logError(error: unknown): void {
       return
     }
 
-    const errorStr = err.stack || err.message
+    const err = toError(error)
+    const errorStr = formattedLogError(err)
 
     const errorInfo = {
       error: errorStr,
@@ -186,13 +279,12 @@ export function logError(error: unknown): void {
     // Always add to in-memory log (no dependencies needed)
     addToInMemoryErrorLog(errorInfo)
 
-    // If sink not attached, queue the event
-    if (errorLogSink === null) {
-      errorQueue.push({ type: 'error', error: err })
-      return
-    }
-
-    errorLogSink.logError(err)
+    emitErrorLogEvent({
+      type: 'error',
+      message: boundedLogText(err.message),
+      stack: errorStr,
+      name: boundedLogText(err.name, ERROR_LOG_QUEUE_LIMITS.labelBytes),
+    })
   } catch {
     // pass
   }
@@ -315,13 +407,11 @@ function parseISOString(s: string): Date {
 
 export function logMCPError(serverName: string, error: unknown): void {
   try {
-    // If sink not attached, queue the event
-    if (errorLogSink === null) {
-      errorQueue.push({ type: 'mcpError', serverName, error })
-      return
-    }
-
-    errorLogSink.logMCPError(serverName, error)
+    emitErrorLogEvent({
+      type: 'mcpError',
+      serverName: boundedLogText(serverName, ERROR_LOG_QUEUE_LIMITS.labelBytes),
+      error: formattedLogError(error),
+    })
   } catch {
     // Silently fail
   }
@@ -329,13 +419,11 @@ export function logMCPError(serverName: string, error: unknown): void {
 
 export function logMCPDebug(serverName: string, message: string): void {
   try {
-    // If sink not attached, queue the event
-    if (errorLogSink === null) {
-      errorQueue.push({ type: 'mcpDebug', serverName, message })
-      return
-    }
-
-    errorLogSink.logMCPDebug(serverName, message)
+    emitErrorLogEvent({
+      type: 'mcpDebug',
+      serverName: boundedLogText(serverName, ERROR_LOG_QUEUE_LIMITS.labelBytes),
+      message: boundedLogText(message),
+    })
   } catch {
     // Silently fail
   }
@@ -349,4 +437,6 @@ export function _resetErrorLogForTesting(): void {
   errorLogSink = null
   errorQueue.length = 0
   inMemoryErrorLog = []
+  droppedErrors = 0
+  droppedDebug = 0
 }

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -4880,14 +4880,20 @@ backend = "local"
       { kind: "command", action: "run" },
       { host, io, signalProcess },
     );
-    await expect(waitForPid(pidPath)).resolves.toBe(4100);
-
-    expect(io.stdoutText()).toContain("AgenC daemon running");
-    signalProcess.emit("SIGTERM");
-    await expect(running).resolves.toBe(0);
-    await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
-
-    await rm(agencHome, { recursive: true, force: true });
+    try {
+      await expect(waitForPid(pidPath)).resolves.toBe(4100);
+      // PID publication precedes the asynchronous lifecycle-lock release.
+      await vi.waitFor(
+        () => expect(io.stdoutText()).toContain("AgenC daemon running"),
+        { timeout: DAEMON_MILESTONE_BUDGET_MS },
+      );
+      signalProcess.emit("SIGTERM");
+      await expect(running).resolves.toBe(0);
+      await expect(readAgenCDaemonPid(pidPath)).resolves.toBeNull();
+    } finally {
+      await stopRunningDaemons([{ signalProcess, running }]);
+      await rm(agencHome, { recursive: true, force: true });
+    }
   });
 
   it("does not autostart MCP without an explicit workspace scope", async () => {

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -82,6 +82,11 @@ import {
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
 import { ConfigStore } from "../config/store.js";
+import {
+  _resetErrorLogForTesting,
+  getErrorLogQueueStats,
+  logMCPError,
+} from "../../src/utils/log.js";
 import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import {
   sandboxExecutionBrokerAuthorityFromSessionAuthority,
@@ -3400,6 +3405,41 @@ describe("AgenC daemon CLI", () => {
       }
     },
   );
+
+  it("drains diagnostic startup events and detaches the sink when the foreground daemon stops", async () => {
+    const agencHome = await tempAgencHome();
+    const host = createHost(agencHome);
+    const io = createIo();
+    const signalProcess = createSignalProcess();
+    const pidPath = resolveAgenCDaemonPidPath(host.env, host.userHome);
+    host.runningPids.add(host.pid);
+    _resetErrorLogForTesting();
+    logMCPError("server", "queued startup diagnostic");
+    const running = runAgenCDaemonCli(
+      { kind: "command", action: "run" },
+      { host, io, signalProcess },
+    );
+    try {
+      await waitForPid(pidPath);
+      logMCPError("server", "live diagnostic");
+      expect(io.stderrText()).toContain("queued startup diagnostic");
+      expect(io.stderrText()).toContain("live diagnostic");
+      expect(getErrorLogQueueStats()).toMatchObject({ errors: 0, retainedBytes: 0 });
+    } finally {
+      await stopRunningDaemons([{ signalProcess, running }]);
+      await rm(agencHome, { recursive: true, force: true });
+    }
+    try {
+      expect(getErrorLogQueueStats()).toEqual({
+        errors: 0, debug: 0, retainedBytes: 0, droppedErrors: 0, droppedDebug: 0,
+      });
+      logMCPError("server", "after shutdown");
+      expect(io.stderrText()).not.toContain("after shutdown");
+      expect(getErrorLogQueueStats().errors).toBe(1);
+    } finally {
+      _resetErrorLogForTesting();
+    }
+  });
 
   it("reload command re-reads config and starts configured mcp.server without shutdown", async () => {
     const agencHome = await tempAgencHome();

--- a/runtime/tests/app-server/daemon-error-log.test.ts
+++ b/runtime/tests/app-server/daemon-error-log.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { installAgenCDaemonErrorLogSink } from '../../src/app-server/daemon-error-log.js'
+import { installAgenCDaemonLogSink } from '../../src/app-server/daemon-cli.js'
+import {
+  _resetErrorLogForTesting,
+  getErrorLogQueueStats,
+  logMCPDebug,
+  logMCPError,
+} from '../../src/utils/log.js'
+
+beforeEach(() => { _resetErrorLogForTesting() })
+afterEach(() => { _resetErrorLogForTesting() })
+
+it('drains startup events to the rotating daemon log and detaches before it closes', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'agenc-daemon-error-log-'))
+  const path = join(root, 'daemon.log')
+  const fakeConsole = { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }
+  const installed = installAgenCDaemonLogSink({ path, console: fakeConsole })
+  if (!installed) throw new Error('file sink not installed')
+  let detach = () => {}
+  try {
+    logMCPError('server', 'startup error')
+    detach = installAgenCDaemonErrorLogSink({ path, write: line => installed.sink.write(line) })
+    logMCPDebug('server', 'live debug message')
+    expect(getErrorLogQueueStats()).toMatchObject({ errors: 0, debug: 0, retainedBytes: 0 })
+    detach()
+    logMCPDebug('server', 'after shutdown')
+    const contents = await readFile(path, 'utf8')
+    expect(contents).toContain('startup error')
+    expect(contents).toContain('live debug message')
+    expect(contents).not.toContain('after shutdown')
+  } finally {
+    detach()
+    installed.dispose()
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+it('redacts persisted diagnostic text and escapes server-provided line breaks', () => {
+  const writes: string[] = []
+  const detach = installAgenCDaemonErrorLogSink({ path: '/log', write: line => { writes.push(line) } })
+  try {
+    logMCPError('server\nforged line', 'Authorization: Bearer abcdefghijklmnop=')
+    logMCPDebug('server', 'api_key=opaque-value-12345')
+    expect(writes).toHaveLength(2)
+    expect(writes.join('')).not.toContain('abcdefghijklmnop=')
+    expect(writes.join('')).not.toContain('opaque-value-12345')
+    expect(writes.join('')).toContain('[REDACTED_SECRET]')
+    expect(writes[0]!.trim().split('\n')).toHaveLength(1)
+    expect(JSON.parse(writes[0]!)).toMatchObject({ server: 'server\nforged line', level: 'error' })
+  } finally { detach() }
+})
+
+it('keeps foreground debug diagnostics on the configured debug destination', () => {
+  const write = vi.fn()
+  const writeDebug = vi.fn()
+  const detach = installAgenCDaemonErrorLogSink({ path: '/log', write, writeDebug })
+  try {
+    logMCPError('server', 'visible failure')
+    logMCPDebug('server', 'debug details')
+    expect(write).toHaveBeenCalledOnce()
+    expect(write.mock.calls[0]?.[0]).toContain('visible failure')
+    expect(writeDebug).toHaveBeenCalledOnce()
+    expect(writeDebug.mock.calls[0]?.[0]).toContain('debug details')
+  } finally { detach() }
+})

--- a/runtime/tests/llm/provider-credential-authority.test.ts
+++ b/runtime/tests/llm/provider-credential-authority.test.ts
@@ -380,8 +380,8 @@ describe("provider credential authority", () => {
     expect(
       openAiCredentials.saveOpenAiOauthCredentials(home, {
         apiKey: "stored-openai-platform-key",
-      }).success,
-    ).toBe(true);
+      }),
+    ).toMatchObject({ success: true });
 
     const resolved = providerOptions.resolveProviderCredentialAuthority(
       "openai",

--- a/runtime/tests/sandbox/execution-broker.test.ts
+++ b/runtime/tests/sandbox/execution-broker.test.ts
@@ -379,6 +379,7 @@ describe("SandboxExecutionBroker", () => {
       const broker = new SandboxExecutionBroker({
         mode: "workspace_write",
         cwd: root,
+        sessionTempRoot: root,
         platform: "linux",
         sandboxManager: fakeManager,
         probe: fallbackStatus,

--- a/runtime/tests/utils/error-log-queue.test.ts
+++ b/runtime/tests/utils/error-log-queue.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as logging from '../../src/utils/log.js'
+
+vi.mock('../../src/utils/model/providers.js', () => ({
+  getSelectedProviderName: () => 'grok',
+}))
+vi.mock('../../src/utils/privacyLevel.js', () => ({
+  isEssentialTrafficOnly: () => false,
+}))
+
+beforeEach(() => {
+  logging._resetErrorLogForTesting()
+  vi.stubEnv('DISABLE_ERROR_REPORTING', '')
+})
+afterEach(() => {
+  logging._resetErrorLogForTesting()
+  vi.unstubAllEnvs()
+})
+
+function makeSink() {
+  return {
+    logError: vi.fn(),
+    logMCPError: vi.fn(),
+    logMCPDebug: vi.fn(),
+    getErrorsPath: () => '/errors',
+    getMCPLogsPath: () => '/mcp',
+  }
+}
+
+describe('startup error log queue', () => {
+  it.each(['error', 'mcpError', 'mcpDebug'] as const)('evicts the oldest %s events at the startup cap', (type) => {
+    for (let i = 0; i < 107; i++) {
+      if (type === 'error') logging.logError(new Error(`event-${i}`))
+      else if (type === 'mcpError') logging.logMCPError('server', `event-${i}`)
+      else logging.logMCPDebug('server', `event-${i}`)
+    }
+    const sink = makeSink()
+    logging.attachErrorLogSink(sink)
+    const calls = type === 'error' ? sink.logError.mock.calls
+      : type === 'mcpError' ? sink.logMCPError.mock.calls
+      : sink.logMCPDebug.mock.calls
+    expect(calls).toHaveLength(100)
+    expect(type === 'error' ? calls[0]?.[0].message : calls[0]?.[1]).toBe('event-7')
+    expect(type === 'error' ? calls[99]?.[0].message : calls[99]?.[1]).toBe('event-106')
+  })
+
+  it('keeps error capacity available when debug events overflow', () => {
+    logging.logError(new Error('retained error'))
+    for (let i = 0; i < 250; i++) logging.logMCPDebug('server', String(i))
+    const sink = makeSink()
+    logging.attachErrorLogSink(sink)
+    expect(sink.logError.mock.calls[0]?.[0].message).toBe('retained error')
+    expect(sink.logMCPDebug).toHaveBeenCalledTimes(100)
+  })
+
+  it('snapshots errors before callers mutate their object graphs', () => {
+    const original = Object.assign(new Error('original message'), { payload: new Uint8Array(1024 * 1024) })
+    logging.logError(original)
+    logging.logMCPError('server', original)
+    original.message = 'mutated message'
+    original.stack = 'mutated stack'
+    const sink = makeSink()
+    logging.attachErrorLogSink(sink)
+    const replayed = sink.logError.mock.calls[0]?.[0]
+    expect(replayed).not.toBe(original)
+    expect(replayed.message).toBe('original message')
+    expect(replayed).not.toHaveProperty('payload')
+    expect(sink.logMCPError.mock.calls[0]?.[1]).toContain('original message')
+    expect(sink.logMCPError.mock.calls[0]?.[1]).not.toBe(original)
+  })
+
+  it('bounds UTF-8 payloads and the visible error history', () => {
+    const large = '🙂'.repeat(100_000)
+    logging.logError(new Error(large))
+    logging.logMCPError(large, large)
+    logging.logMCPDebug(large, large)
+    const sink = makeSink()
+    logging.attachErrorLogSink(sink)
+    expect(Buffer.byteLength(sink.logError.mock.calls[0]?.[0].message)).toBeLessThanOrEqual(8192)
+    expect(Buffer.byteLength(sink.logError.mock.calls[0]?.[0].stack)).toBeLessThanOrEqual(8192)
+    for (const calls of [sink.logMCPError.mock.calls, sink.logMCPDebug.mock.calls]) {
+      expect(Buffer.byteLength(calls[0]?.[0])).toBeLessThanOrEqual(256)
+      expect(Buffer.byteLength(calls[0]?.[1])).toBeLessThanOrEqual(8192)
+    }
+    expect(Buffer.byteLength(logging.getInMemoryErrors()[0]!.error)).toBeLessThanOrEqual(8192)
+  })
+
+  it('reports bounded retained bytes and separate overflow counts without logging', () => {
+    for (let i = 0; i < 107; i++) logging.logMCPError('server', 'x'.repeat(20_000))
+    for (let i = 0; i < 109; i++) logging.logMCPDebug('server', 'x'.repeat(20_000))
+    const stats = logging.getErrorLogQueueStats()
+    expect(stats).toMatchObject({ errors: 100, debug: 100, droppedErrors: 7, droppedDebug: 9 })
+    expect(stats.retainedBytes).toBeLessThanOrEqual(200 * (8192 + 256 + 8))
+    const sink = makeSink()
+    logging.attachErrorLogSink(sink)
+    expect(sink.logMCPError).toHaveBeenCalledTimes(100)
+    expect(sink.logMCPDebug).toHaveBeenCalledTimes(100)
+    expect(logging.getErrorLogQueueStats()).toMatchObject({ errors: 0, debug: 0, retainedBytes: 0, droppedErrors: 7, droppedDebug: 9 })
+  })
+
+  it('shares the error quota and preserves FIFO order across event types', () => {
+    const delivered: string[] = []
+    for (let i = 0; i < 102; i++) {
+      if (i % 2) logging.logMCPError('server', String(i))
+      else logging.logError(new Error(String(i)))
+      if (i === 10) logging.logMCPDebug('server', 'debug')
+    }
+    logging.attachErrorLogSink({
+      ...makeSink(),
+      logError: error => { delivered.push(error.message) },
+      logMCPError: (_, error) => { delivered.push(String(error)) },
+      logMCPDebug: (_, message) => { delivered.push(message) },
+    })
+    const expected = Array.from({ length: 100 }, (_, i) => String(i + 2))
+    expected.splice(9, 0, 'debug')
+    expect(delivered).toEqual(expected)
+  })
+
+  it('continues draining when a sink fails and records dropped events', () => {
+    logging.logMCPDebug('server', 'first')
+    logging.logMCPDebug('server', 'second')
+    const sink = makeSink()
+    sink.logMCPDebug.mockImplementationOnce(() => { throw new Error('disk unavailable') })
+    expect(() => logging.attachErrorLogSink(sink)).not.toThrow()
+    expect(sink.logMCPDebug).toHaveBeenCalledTimes(2)
+    expect(logging.getErrorLogQueueStats()).toMatchObject({ debug: 0, droppedDebug: 1 })
+  })
+
+  it('detaches and clears state without allowing stale disposers to detach a new sink', () => {
+    const sink = makeSink()
+    const detach = logging.attachErrorLogSink(sink)
+    const duplicateDetach = logging.attachErrorLogSink(makeSink())
+    duplicateDetach()
+    logging.logError(new Error('first lifetime'))
+    expect(sink.logError).toHaveBeenCalledOnce()
+    detach()
+    expect(logging.getInMemoryErrors()).toEqual([])
+    logging.logMCPDebug('server', 'new startup')
+    const nextDetach = logging.attachErrorLogSink(sink)
+    detach()
+    logging.logMCPDebug('server', 'new lifetime')
+    expect(sink.logMCPDebug.mock.calls.map(call => call[1])).toEqual(['new startup', 'new lifetime'])
+    nextDetach()
+    expect(logging.getErrorLogQueueStats()).toEqual({ errors: 0, debug: 0, retainedBytes: 0, droppedErrors: 0, droppedDebug: 0 })
+  })
+})


### PR DESCRIPTION
Daemon error and MCP diagnostics accumulated indefinitely because production never attached the error-log sink. Bound startup storage to 100 error events and 100 debug events, evict the oldest event within its category, cap text fields at 8 KiB and labels at 256 bytes, and retain formatted text instead of caller-owned objects. Expose retained-byte and drop counters; a failing sink cannot interrupt draining.

Install the sink before daemon services start. Detached daemons use the existing rotating file log; foreground errors use inherited stderr and debug messages use the debug destination. Redact secrets and encode each diagnostic as one JSON line. Owned detachment clears retained state during shutdown.

Validation: six queue regressions and the daemon sink lifecycle regression fail against the original implementation. The full suite passes all 22,306 tests with zero failures or skips after incorporating #2259. Typechecking, runtime build, PTY startup, benchmark provenance, and all 13 hosted jobs passed; the hosted run preceded that main-branch update. The final local fast checks pass: typechecking, 195 changed-file tests, and 13,343 affected tests, with zero failures or skips.

CI also exposed a startup-test race: PID publication precedes asynchronous lifecycle-lock release and the readiness message. Wait for the message and always stop the daemon in cleanup; forcing that gap reproduces the old failure and passes with the corrected test. A credential-save test failed once on CI; thirty isolated repetitions (690 tests), the full shard locally, and its hosted replay pass. Its cause remains unconfirmed, and the assertion now includes the storage warning. A fast-check sandbox test also inherited a shared temporary root containing a `.git` fixture. Bind its session temporary root explicitly; injecting a contaminated ambient root reproduces the old assertion failure and passes after the fix, and all 28 broker tests pass. The complete local fast-check replay passes. The corresponding hosted fast check also passes.

Closes #1796.
