### PR TITLE
fix(runtime): settle task mapper failures and preserve shutdown cleanup

### DIFF
--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -4088,41 +4088,44 @@ async function runAgenCDaemonForegroundLocked(
       }
     } finally {
       shuttingDown = true;
-      shutdownSignal.dispose();
-      // Any reload admitted before the ingress fence must either finish or
-      // reject its prepared resources before MCP/socket cleanup begins.
-      await reloadChain.catch(() => null);
-      const results = await cleanup.run(
-        cleanupContext,
-        startupCancelled
-          ? {
-              taskTimeoutMs:
-                options.startupCancelCleanupTaskTimeoutMs ??
-                AGENC_DAEMON_STARTUP_CANCEL_CLEANUP_TASK_TIMEOUT_MS,
-            }
-          : {},
-      );
-      cleanupHandled = true;
-      const failed = results.filter((result) => !result.ok);
-      if (failed.length > 0) {
-        for (const failure of failed) {
-          io.stderr.write(
-            `agenc: cleanup[${failure.name}] failed: ${formatCleanupError(failure.error)}\n`,
-          );
-        }
-        if (exitCode === 0) exitCode = 1;
-      }
-      if (host.startupGuardReceiver?.wasRequested() === true) {
-        try {
-          await host.startupGuardReceiver.acknowledgeAfterCleanup(
-            failed.length === 0,
-          );
-        } catch (error) {
-          io.stderr.write(
-            `agenc: startup cancellation acknowledgement failed: ${formatCleanupError(error)}\n`,
-          );
+      try {
+        // Any reload admitted before the ingress fence must either finish or
+        // reject its prepared resources before MCP/socket cleanup begins.
+        await reloadChain.catch(() => null);
+        const results = await cleanup.run(
+          cleanupContext,
+          startupCancelled
+            ? {
+                taskTimeoutMs:
+                  options.startupCancelCleanupTaskTimeoutMs ??
+                  AGENC_DAEMON_STARTUP_CANCEL_CLEANUP_TASK_TIMEOUT_MS,
+              }
+            : {},
+        );
+        cleanupHandled = true;
+        const failed = results.filter((result) => !result.ok);
+        if (failed.length > 0) {
+          for (const failure of failed) {
+            io.stderr.write(
+              `agenc: cleanup[${failure.name}] failed: ${formatCleanupError(failure.error)}\n`,
+            );
+          }
           if (exitCode === 0) exitCode = 1;
         }
+        if (host.startupGuardReceiver?.wasRequested() === true) {
+          try {
+            await host.startupGuardReceiver.acknowledgeAfterCleanup(
+              failed.length === 0,
+            );
+          } catch (error) {
+            io.stderr.write(
+              `agenc: startup cancellation acknowledgement failed: ${formatCleanupError(error)}\n`,
+            );
+            if (exitCode === 0) exitCode = 1;
+          }
+        }
+      } finally {
+        shutdownSignal.dispose();
       }
     }
     return exitCode;

--- a/runtime/src/lifecycle/signal-handlers.ts
+++ b/runtime/src/lifecycle/signal-handlers.ts
@@ -26,7 +26,7 @@ export interface AgenCShutdownSignalHandle {
 }
 
 export interface AgenCSignalProcess {
-  once(signal: AgenCShutdownSignal, listener: () => void): unknown;
+  on(signal: AgenCShutdownSignal, listener: () => void): unknown;
   removeListener(signal: AgenCShutdownSignal, listener: () => void): unknown;
 }
 
@@ -52,7 +52,6 @@ export function installAgenCShutdownSignalHandlers(
     const listener = (): void => {
       if (settled) return;
       settled = true;
-      dispose();
       const event: AgenCShutdownSignalEvent = {
         reason: "signal",
         signal,
@@ -65,7 +64,10 @@ export function installAgenCShutdownSignalHandlers(
         .finally(() => resolveCompleted(event));
     };
     listeners.set(signal, listener);
-    proc.once(signal, listener);
+    // Keep ownership until the caller finishes cleanup. Removing our listener
+    // during delivery lets signal-exit treat this signal as unhandled and
+    // re-raise it before asynchronous cleanup can finish.
+    proc.on(signal, listener);
   }
 
   return { completed, dispose };

--- a/runtime/src/lifecycle/signal-handlers.ts
+++ b/runtime/src/lifecycle/signal-handlers.ts
@@ -57,11 +57,15 @@ export function installAgenCShutdownSignalHandlers(
         signal,
         exitCode: exitCodeForSignal(signal),
       };
-      Promise.resolve(onSignal(event))
-        .catch(() => {
+      void (async () => {
+        try {
+          await onSignal(event);
+        } catch {
           /* Cleanup errors are reported by the cleanup registry caller. */
-        })
-        .finally(() => resolveCompleted(event));
+        } finally {
+          resolveCompleted(event);
+        }
+      })();
     };
     listeners.set(signal, listener);
     // Keep ownership until the caller finishes cleanup. Removing our listener

--- a/runtime/src/tasks/lifecycle.ts
+++ b/runtime/src/tasks/lifecycle.ts
@@ -10,6 +10,7 @@
  * @module
  */
 
+import { logError } from "../utils/log.js";
 import {
   generateTaskId,
   isTerminalTaskStatus,
@@ -91,32 +92,25 @@ export interface RegisterBackgroundTaskInput {
   readonly onStop?: (reason: string) => Promise<void> | void;
 }
 
+interface TaskPromiseMapping {
+  readonly output?: string;
+  readonly error?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+interface TaskPromiseFulfillment extends TaskPromiseMapping {
+  readonly status?: Extract<BackgroundTaskStatus, "completed" | "failed">;
+}
+
 export interface BindTaskPromiseOptions<T> {
   readonly onFulfilled?: (value: T) =>
-    | {
-        readonly status?: Extract<BackgroundTaskStatus, "completed" | "failed">;
-        readonly output?: string;
-        readonly error?: string;
-        readonly metadata?: Readonly<Record<string, unknown>>;
-      }
+    | TaskPromiseFulfillment
     | void
-    | Promise<
-        | {
-            readonly status?: Extract<
-              BackgroundTaskStatus,
-              "completed" | "failed"
-            >;
-            readonly output?: string;
-            readonly error?: string;
-            readonly metadata?: Readonly<Record<string, unknown>>;
-          }
-        | void
-      >;
-  readonly onRejected?: (error: unknown) => {
-    readonly output?: string;
-    readonly error?: string;
-    readonly metadata?: Readonly<Record<string, unknown>>;
-  } | void;
+    | Promise<TaskPromiseFulfillment | void>;
+  readonly onRejected?: (error: unknown) =>
+    | TaskPromiseMapping
+    | void
+    | Promise<TaskPromiseMapping | void>;
   readonly onSnapshot?: (snapshot: BackgroundTaskSnapshot) => void;
 }
 
@@ -168,6 +162,19 @@ function generateBackgroundTaskId(type: BackgroundTaskType): string {
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function boundedTaskPromiseError(error: unknown): string {
+  try {
+    const message = toErrorMessage(error);
+    const limit = 4096;
+    const suffix = message.length > limit ? "...[truncated]" : "";
+    // Copy the bounded prefix so it cannot retain a large backing string.
+    return Buffer.from(message.slice(0, limit - suffix.length), "utf8")
+      .toString("utf8") + suffix;
+  } catch {
+    return "Task failed with an unprintable error";
+  }
 }
 
 function defaultOutputUri(taskId: string): string {
@@ -412,43 +419,54 @@ export class BackgroundTaskLifecycle {
     promise: Promise<T>,
     options: BindTaskPromiseOptions<T> = {},
   ): void {
-    void promise
-      .then(
-        async (value) => {
-          // onFulfilled may be async (e.g. the agent-thread mapper
-          // dispatches SubagentStop hooks and appends their feedback
-          // to the completion output the parent reads).
-          const mapped = await options.onFulfilled?.(value);
-          const status = mapped?.status ?? "completed";
-          if (status === "failed") {
-            const snapshot = this.fail(
-              taskId,
-              mapped?.error ?? "task failed",
-              mapped?.output,
-              mapped?.metadata,
-            );
-            options.onSnapshot?.(snapshot);
-            return;
-          }
-          const snapshot = this.complete(taskId, mapped?.output, mapped?.metadata);
-          options.onSnapshot?.(snapshot);
-        },
-        (error) => {
-          const mapped = options.onRejected?.(error);
-          const snapshot = this.fail(
-            taskId,
-            mapped?.error ?? error,
+    const record = this.tasks.get(this.resolveTaskId(taskId));
+    // Keep identity without retaining an evicted record's metadata and handles
+    // for the remaining lifetime of its backing promise.
+    const binding = record === undefined
+      ? undefined
+      : { id: record.id, record: new WeakRef(record) };
+    const settle = async (): Promise<void> => {
+      let mapped: TaskPromiseFulfillment | void;
+      let status: "completed" | "failed";
+      let failure: unknown;
+      try {
+        const result = await promise.then(
+          (value) => ({ kind: "fulfilled" as const, value }),
+          (error: unknown) => ({ kind: "rejected" as const, error }),
+        );
+        if (result.kind === "fulfilled") {
+          mapped = await options.onFulfilled?.(result.value);
+          status = mapped?.status ?? "completed";
+          failure = mapped?.error ?? "task failed";
+        } else {
+          mapped = await options.onRejected?.(result.error);
+          status = "failed";
+          failure = mapped?.error ?? result.error;
+        }
+      } catch (error) {
+        mapped = undefined;
+        status = "failed";
+        failure = error;
+      }
+
+      if (binding === undefined) {
+        throw new BackgroundTaskError(`task ${taskId} not found`, "not_found");
+      }
+      const current = this.tasks.get(binding.id);
+      // Eviction is harmless, including replacement under the same ID or alias.
+      // Any exception from a live transition or its observers is unexpected.
+      if (current === undefined || current !== binding.record.deref()) return;
+      const snapshot = status === "failed"
+        ? this.fail(
+            binding.id,
+            boundedTaskPromiseError(failure),
             mapped?.output,
             mapped?.metadata,
-          );
-          options.onSnapshot?.(snapshot);
-        },
-      )
-      // A task can be evicted before its join promise settles; in that case the
-      // lifecycle transition throws BackgroundTaskError("not_found"). Swallow it
-      // so a late settle against an evicted task cannot escape as an unhandled
-      // rejection.
-      .catch(() => {});
+          )
+        : this.complete(binding.id, mapped?.output, mapped?.metadata);
+      await options.onSnapshot?.(snapshot);
+    };
+    void settle().catch(logError);
   }
 
   drainNotifications(): BackgroundTaskNotification[] {

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -143,7 +143,7 @@ function createSignalProcess(): AgenCSignalProcess & {
     listeners.set(signal, signalListeners);
   };
   return {
-    once: addListener,
+    on: addListener,
     removeListener: (signal, listener) => {
       listeners.get(signal)?.delete(listener);
     },

--- a/runtime/tests/app-server/daemon-cli.contract.test.ts
+++ b/runtime/tests/app-server/daemon-cli.contract.test.ts
@@ -533,7 +533,7 @@ function createReadyPublishedDaemonOptions(
 function createSignalProcess() {
   type TestDaemonSignal = AgenCShutdownSignal;
   const listeners = new Map<TestDaemonSignal, Set<() => void>>();
-  /** Signals emitted before any listener (startup race); flushed on once(). */
+  /** Signals emitted before any listener (startup race); flushed on registration. */
   const pending = new Set<TestDaemonSignal>();
   const deliver = (signal: TestDaemonSignal): void => {
     for (const listener of [...(listeners.get(signal) ?? [])]) {
@@ -552,6 +552,7 @@ function createSignalProcess() {
     }
   };
   return {
+    on: addListener,
     once: (signal: AgenCShutdownSignal, listener: () => void) => {
       addListener(signal, listener);
     },

--- a/runtime/tests/lifecycle/cleanup-registry.contract.test.ts
+++ b/runtime/tests/lifecycle/cleanup-registry.contract.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { AgenCCleanupRegistry } from "./cleanup-registry.js";
 import {
@@ -10,7 +11,7 @@ import { summarizeAgenCShutdown } from "./shutdown-message.js";
 function createSignalProcess() {
   const listeners = new Map<AgenCShutdownSignal, Set<() => void>>();
   return {
-    once: vi.fn((signal: AgenCShutdownSignal, listener: () => void) => {
+    on: vi.fn((signal: AgenCShutdownSignal, listener: () => void) => {
       let set = listeners.get(signal);
       if (set === undefined) {
         set = new Set();
@@ -127,6 +128,26 @@ describe("AgenC lifecycle cleanup registry", () => {
 });
 
 describe("AgenC lifecycle signal handlers", () => {
+  it("retains signal ownership until cleanup explicitly disposes the handle", async () => {
+    const proc = new EventEmitter();
+    const seen = vi.fn();
+    const handle = installAgenCShutdownSignalHandlers(seen, proc);
+    try {
+      proc.emit("SIGTERM");
+      await handle.completed;
+      for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+        expect(proc.listenerCount(signal)).toBe(1);
+        proc.emit(signal);
+      }
+      expect(seen).toHaveBeenCalledOnce();
+    } finally {
+      handle.dispose();
+    }
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+      expect(proc.listenerCount(signal)).toBe(0);
+    }
+  });
+
   it("maps daemon shutdown signals to cleanup events and exit codes", async () => {
     const proc = createSignalProcess();
     const seen: unknown[] = [];
@@ -144,6 +165,7 @@ describe("AgenC lifecycle signal handlers", () => {
     expect(seen).toMatchObject([
       { reason: "signal", signal: "SIGTERM", exitCode: 0 },
     ]);
+    handle.dispose();
     expect(proc.listenerCount("SIGINT")).toBe(0);
     expect(proc.listenerCount("SIGTERM")).toBe(0);
     expect(proc.listenerCount("SIGHUP")).toBe(0);
@@ -163,6 +185,7 @@ describe("AgenC lifecycle signal handlers", () => {
     expect(seen).toMatchObject([
       { reason: "signal", signal: "SIGINT", exitCode: 130 },
     ]);
+    handle.dispose();
   });
 
   it("summarizes shutdown signals without UI dependencies", () => {

--- a/runtime/tests/lifecycle/cleanup-registry.contract.test.ts
+++ b/runtime/tests/lifecycle/cleanup-registry.contract.test.ts
@@ -128,6 +128,24 @@ describe("AgenC lifecycle cleanup registry", () => {
 });
 
 describe("AgenC lifecycle signal handlers", () => {
+  it.each(["throw", "reject"] as const)(
+    "completes the shutdown signal when its callback %ss",
+    async (mode) => {
+      const proc = new EventEmitter();
+      const handle = installAgenCShutdownSignalHandlers(() => {
+        const error = new Error("signal callback failed");
+        if (mode === "throw") throw error;
+        return Promise.reject(error);
+      }, proc);
+      try {
+        expect(() => proc.emit("SIGTERM")).not.toThrow();
+        await expect(handle.completed).resolves.toMatchObject({ signal: "SIGTERM" });
+      } finally {
+        handle.dispose();
+      }
+    },
+  );
+
   it("retains signal ownership until cleanup explicitly disposes the handle", async () => {
     const proc = new EventEmitter();
     const seen = vi.fn();

--- a/runtime/tests/tasks/lifecycle-promise-settlement.test.ts
+++ b/runtime/tests/tasks/lifecycle-promise-settlement.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BackgroundTaskError,
+  BackgroundTaskLifecycle,
+} from "../../src/tasks/lifecycle.js";
+import { logError } from "../../src/utils/log.js";
+
+vi.mock("../../src/utils/log.js", () => ({ logError: vi.fn() }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+function registerTask(): BackgroundTaskLifecycle {
+  const lifecycle = new BackgroundTaskLifecycle();
+  lifecycle.register({ id: "task", type: "generic", description: "map result" });
+  return lifecycle;
+}
+
+describe("background task promise settlement", () => {
+  it.each(["throw", "reject"] as const)(
+    "marks a task failed when its fulfillment mapper %ss",
+    async (mode) => {
+      const lifecycle = registerTask();
+      const onSnapshot = vi.fn();
+      lifecycle.bindPromise("task", Promise.resolve("result"), {
+        onFulfilled: () => {
+          const error = new Error("fulfillment mapping failed");
+          if (mode === "throw") throw error;
+          return Promise.reject(error);
+        },
+        onSnapshot,
+      });
+
+      await vi.waitFor(() => expect(onSnapshot).toHaveBeenCalledOnce());
+      expect(lifecycle.get("task")).toMatchObject({
+        status: "failed",
+        error: "fulfillment mapping failed",
+      });
+      expect(lifecycle.drainNotifications().map(({ kind }) => kind)).toEqual([
+        "started", "failed",
+      ]);
+    },
+  );
+
+  it.each(["throw", "reject"] as const)(
+    "marks a task failed when its rejection mapper %ss",
+    async (mode) => {
+      const lifecycle = registerTask();
+      const onSnapshot = vi.fn();
+      lifecycle.bindPromise("task", Promise.reject(new Error("backing failure")), {
+        onRejected: () => {
+          const error = new Error("rejection mapping failed");
+          if (mode === "throw") throw error;
+          return Promise.reject(error);
+        },
+        onSnapshot,
+      });
+
+      await vi.waitFor(() => expect(onSnapshot).toHaveBeenCalledOnce());
+      expect(lifecycle.get("task")).toMatchObject({
+        status: "failed",
+        error: "rejection mapping failed",
+      });
+    },
+  );
+
+  it("awaits rejection mapping before publishing its output and metadata", async () => {
+    const lifecycle = registerTask();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const onSnapshot = vi.fn();
+    const onRejected = vi.fn(async () => {
+      await gate;
+      return { error: "mapped failure", output: "partial output", metadata: { attempt: 2 } };
+    });
+    lifecycle.bindPromise("task", Promise.reject("backing failure"), {
+      onRejected,
+      onSnapshot,
+    });
+
+    try {
+      await vi.waitFor(() => expect(onRejected).toHaveBeenCalledOnce());
+      expect(lifecycle.get("task")?.status).toBe("running");
+      expect(onSnapshot).not.toHaveBeenCalled();
+    } finally {
+      release();
+    }
+    await vi.waitFor(() => expect(onSnapshot).toHaveBeenCalledOnce());
+    expect(lifecycle.get("task")).toMatchObject({
+      status: "failed", error: "mapped failure", metadata: { attempt: 2 },
+    });
+    expect(lifecycle.readOutput("task")).toBe("partial output");
+  });
+
+  it.each(["fulfill", "reject"] as const)(
+    "ignores late %s settlement after eviction without an unhandled rejection",
+    async (mode) => {
+      const lifecycle = registerTask();
+      let settle!: () => void;
+      const promise = new Promise<void>((resolve, reject) => {
+        settle = mode === "fulfill" ? resolve : () => reject(new Error("late"));
+      });
+      const onSnapshot = vi.fn();
+      lifecycle.bindPromise("task", promise, { onSnapshot });
+      lifecycle.complete("task");
+      lifecycle.drainNotifications();
+      expect(lifecycle.evictNotifiedTerminalTasks()).toEqual(["task"]);
+
+      settle();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(lifecycle.get("task")).toBeUndefined();
+      expect(onSnapshot).not.toHaveBeenCalled();
+      expect(logError).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    new Error("transition failed"),
+    new BackgroundTaskError("unexpected missing record", "not_found"),
+  ])("reports an unexpected transition error: $message", async (error) => {
+    const lifecycle = registerTask();
+    vi.spyOn(lifecycle, "complete").mockImplementation(() => { throw error; });
+    lifecycle.bindPromise("task", Promise.resolve());
+
+    await vi.waitFor(() => expect(logError).toHaveBeenCalledWith(error));
+  });
+
+  it("reports binding a task that was never registered", async () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.bindPromise("missing", Promise.resolve());
+
+    await vi.waitFor(() => expect(logError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "not_found" }),
+    ));
+  });
+
+  it.each(["task", "alias"])(
+    "does not let an evicted promise bound through %s finish a replacement task",
+    async (binding) => {
+      const lifecycle = new BackgroundTaskLifecycle();
+      lifecycle.register({ id: "task", aliases: ["alias"], type: "generic", description: "old" });
+      let resolve!: () => void;
+      const promise = new Promise<void>((settle) => { resolve = settle; });
+      const onSnapshot = vi.fn();
+      lifecycle.bindPromise(binding, promise, { onSnapshot });
+      lifecycle.complete("task");
+      lifecycle.drainNotifications();
+      lifecycle.evictNotifiedTerminalTasks();
+      lifecycle.register({ id: "task", aliases: ["alias"], type: "generic", description: "new" });
+
+      resolve();
+      await new Promise<void>((settle) => setImmediate(settle));
+      expect(lifecycle.get("task")).toMatchObject({ status: "running", description: "new" });
+      expect(onSnapshot).not.toHaveBeenCalled();
+      expect(logError).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports a snapshot callback rejection after terminal publication", async () => {
+    const lifecycle = registerTask();
+    const error = new BackgroundTaskError("callback failed", "not_found");
+    lifecycle.bindPromise("task", Promise.resolve(), {
+      onSnapshot: async () => { throw error; },
+    });
+
+    await vi.waitFor(() => expect(logError).toHaveBeenCalledWith(error));
+    expect(lifecycle.get("task")?.status).toBe("completed");
+  });
+
+  it("treats a mapper's not_found error as a task failure", async () => {
+    const lifecycle = registerTask();
+    lifecycle.bindPromise("task", Promise.resolve(), {
+      onFulfilled: () => { throw new BackgroundTaskError("mapper input missing", "not_found"); },
+    });
+
+    await vi.waitFor(() => expect(lifecycle.get("task")).toMatchObject({
+      status: "failed", error: "mapper input missing",
+    }));
+  });
+
+  it.each([
+    new Error("mapper: " + "x".repeat(100_000)),
+    { toString() { throw new Error("cannot stringify"); } },
+  ])("bounds mapper error text and tolerates unprintable failures", async (error) => {
+    const lifecycle = registerTask();
+    lifecycle.bindPromise("task", Promise.resolve(), {
+      onFulfilled: () => { throw error; },
+    });
+
+    await vi.waitFor(() => expect(lifecycle.get("task")?.status).toBe("failed"));
+    const message = lifecycle.get("task")?.error;
+    expect(message).toBeTruthy();
+    expect(message!.length).toBeLessThanOrEqual(8192);
+  });
+});


### PR DESCRIPTION
A rejected task-result mapper left its task running indefinitely. Settle fulfillment and rejection mapping through one async routine, convert mapper exceptions into bounded failure text, and report unexpected transition or snapshot-callback errors through the normal logger. Bind settlement to the original task record so late promises cannot finish a replacement that reused its ID or alias. Evicted records remain collectible.

The agent-surface TUI check also reproduced a daemon shutdown bug: removing signal listeners during SIGTERM delivery made proper-lockfile's signal-exit handler re-raise the signal before cleanup removed the socket. Retain signal ownership until daemon cleanup finishes and ignore repeated signals during that interval. Update the injected process interface and test fixtures to use persistent listeners. A synchronous signal-callback exception now settles the completion handle, matching asynchronous rejection handling.

Validation: 11 mapper regressions failed against the original implementation, with two unhandled rejections. Three more regressions exposed missing-task handling and replacement-task settlement. Signal-ownership and synchronous-callback regressions fail against the original handler. All 72 focused task/agent tests and 210 signal/daemon/task tests pass with zero skips. Typechecking, runtime build, PTY startup, benchmark provenance, and the previously failing real TUI completion scenario pass. The complete agent-surface contract also passes. The full suite passes all 22,325 tests across 2,227 files with zero failures or skips on the final commit. All 13 hosted platform jobs, including all four full-suite shards and nine native lanes, and the hosted fast check pass on the final commit. Independent review is approved and all PR checks are green.

Closes #1797.
