### PR TITLE
fix(runtime): claim task IDs and aliases atomically

### DIFF
--- a/runtime/src/tasks/lifecycle.ts
+++ b/runtime/src/tasks/lifecycle.ts
@@ -199,27 +199,16 @@ export class BackgroundTaskLifecycle {
     Set<(snapshot: BackgroundTaskSnapshot) => void>
   >();
 
+  /**
+   * IDs and aliases share one namespace. Names owned by terminal tasks may be
+   * reclaimed; live owners remain reserved. Prepare and validate the complete
+   * registration before removing any terminal owner or publishing new state.
+   */
   register(input: RegisterBackgroundTaskInput): BackgroundTaskSnapshot {
     const id = input.id ?? generateBackgroundTaskId(input.type);
-    if (this.tasks.has(id)) {
-      throw new BackgroundTaskError(`task ${id} already exists`, "already_exists");
-    }
     const aliases = [...new Set(input.aliases ?? [])].filter(
       (alias) => alias.length > 0 && alias !== id,
     );
-    for (const alias of aliases) {
-      const existingId = this.resolveTaskId(alias);
-      const existing = this.tasks.get(existingId);
-      if (!existing) continue;
-      if (!isTerminalTaskStatus(existing.status)) {
-        throw new BackgroundTaskError(
-          `task ${alias} already exists`,
-          "already_exists",
-        );
-      }
-      this.deleteTaskRecord(existing.id);
-    }
-
     const record: MutableTaskRecord = {
       id,
       type: input.type,
@@ -239,6 +228,21 @@ export class BackgroundTaskLifecycle {
       ...(input.onStop !== undefined ? { onStop: input.onStop } : {}),
     };
 
+    // Input getters may run user code. Check ownership after all fields have
+    // been read, with no callbacks between validation and the map updates.
+    const terminalOwners = new Set<string>();
+    for (const name of [id, ...aliases]) {
+      const existing = this.tasks.get(this.resolveTaskId(name));
+      if (!existing) continue;
+      if (!isTerminalTaskStatus(existing.status)) {
+        throw new BackgroundTaskError(
+          `task ${name} already exists`,
+          "already_exists",
+        );
+      }
+      terminalOwners.add(existing.id);
+    }
+    for (const owner of terminalOwners) this.deleteTaskRecord(owner);
     this.tasks.set(id, record);
     this.outputs.set(id, { content: "", totalBytes: 0 });
     for (const alias of aliases) {

--- a/runtime/tests/tasks/lifecycle-identifiers.test.ts
+++ b/runtime/tests/tasks/lifecycle-identifiers.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  BackgroundTaskLifecycle,
+  type RegisterBackgroundTaskInput,
+} from "../../src/tasks/lifecycle.js";
+
+const claims = [
+  { held: "primary", requested: "primary", name: "owner" },
+  { held: "alias", requested: "primary", name: "nickname" },
+  { held: "primary", requested: "alias", name: "owner" },
+  { held: "alias", requested: "alias", name: "nickname" },
+] as const;
+
+function replacementInput(requested: "primary" | "alias", name: string): RegisterBackgroundTaskInput {
+  return {
+    id: requested === "primary" ? name : "replacement",
+    ...(requested === "alias" ? { aliases: [name] } : {}),
+    type: "generic",
+    description: "replacement task",
+  };
+}
+
+describe("background task identifier ownership", () => {
+  describe.each(["pending", "running"] as const)("%s task names", (status) => {
+    it.each(claims)("rejects a new $requested that collides with a live $held", ({ requested, name }) => {
+      const lifecycle = new BackgroundTaskLifecycle();
+      lifecycle.register({
+        id: "owner", aliases: ["nickname"], type: "generic", description: "original task", status,
+      });
+      lifecycle.appendOutput("owner", "retained output");
+      const original = lifecycle.get("owner");
+
+      expect(() => lifecycle.register(replacementInput(requested, name))).toThrow(
+        expect.objectContaining({ code: "already_exists" }),
+      );
+      expect(lifecycle.list()).toEqual([original]);
+      expect(lifecycle.get("nickname")).toEqual(original);
+      expect(lifecycle.readOutput("nickname")).toBe("retained output");
+    });
+  });
+
+  it.each(claims)("reclaims a terminal $held for a new $requested", ({ requested, name }) => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.register({
+      id: "owner", aliases: ["nickname", "old-spare"], type: "generic", description: "original task",
+    });
+    lifecycle.complete("owner", "old output");
+
+    const replacement = lifecycle.register(replacementInput(requested, name));
+
+    expect(lifecycle.list()).toEqual([replacement]);
+    expect(lifecycle.get(name)).toEqual(replacement);
+    expect(lifecycle.get("old-spare")).toBeUndefined();
+    expect(lifecycle.readOutput(name)).toBe("");
+    expect(replacement).toMatchObject({ status: "running", description: "replacement task" });
+  });
+
+  it.each(["failed", "killed"] as const)("also reclaims names from a %s task", (status) => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.register({ id: "owner", type: "generic", description: "original task" });
+    if (status === "failed") lifecycle.fail("owner", "failed");
+    else lifecycle.kill("owner", "stopped");
+
+    const replacement = lifecycle.register(replacementInput("primary", "owner"));
+    expect(lifecycle.list()).toEqual([replacement]);
+    expect(replacement.status).toBe("running");
+  });
+
+  it.each([
+    ["reclaim", "blocked"],
+    ["blocked", "reclaim"],
+  ])("leaves all state unchanged when any proposed alias is occupied (%s, %s)", (first, second) => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.register({
+      id: "done", aliases: ["reclaim", "spare"], type: "generic", description: "completed task",
+      metadata: { retained: true },
+    });
+    lifecycle.appendOutput("done", "consumed");
+    lifecycle.takeOutputDelta("done");
+    lifecycle.complete("done", " tail");
+    lifecycle.register({ id: "live", aliases: ["blocked"], type: "generic", description: "live task" });
+    lifecycle.drainNotifications();
+    const before = lifecycle.list();
+    const observed = vi.fn();
+    lifecycle.subscribe("done", observed);
+
+    expect(() => lifecycle.register({
+      id: "attempt", aliases: [first, second], type: "generic", description: "must fail",
+    })).toThrow(expect.objectContaining({ code: "already_exists" }));
+
+    expect(lifecycle.list()).toEqual(before);
+    expect(lifecycle.get("reclaim")).toEqual(before[0]);
+    expect(lifecycle.get("spare")).toEqual(before[0]);
+    expect(lifecycle.get("blocked")).toEqual(before[1]);
+    expect(lifecycle.get("attempt")).toBeUndefined();
+    expect(lifecycle.readOutput("reclaim")).toBe("consumed tail");
+    expect(lifecycle.takeOutputDelta("reclaim")).toEqual({ content: " tail", newOffset: 13 });
+    expect(lifecycle.drainNotifications()).toEqual([]);
+    lifecycle.markRunning("done");
+    expect(observed).toHaveBeenCalledOnce();
+  });
+
+  it("prepares the new record before reclaiming terminal owners", () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.register({ id: "owner", aliases: ["reclaim"], type: "generic", description: "original" });
+    lifecycle.complete("owner", "retained");
+    const before = lifecycle.list();
+
+    expect(() => lifecycle.register({
+      id: "replacement", aliases: ["reclaim"], type: "generic",
+      get description(): string { throw new Error("invalid description"); },
+    })).toThrow("invalid description");
+
+    expect(lifecycle.list()).toEqual(before);
+    expect(lifecycle.get("reclaim")).toEqual(before[0]);
+    expect(lifecycle.readOutput("reclaim")).toBe("retained");
+  });
+
+  it("checks ownership after input getters have finished", () => {
+    const lifecycle = new BackgroundTaskLifecycle();
+    lifecycle.register({ id: "original", aliases: ["reclaim"], type: "generic", description: "original" });
+    lifecycle.complete("original");
+    const metadata = vi.fn(() => {
+      if (!lifecycle.get("replacement")) {
+        lifecycle.register({ id: "replacement", type: "generic", description: "getter-owned task" });
+      }
+      return {};
+    });
+
+    expect(() => lifecycle.register({
+      id: "replacement", aliases: ["reclaim"], type: "generic", description: "outer task",
+      get metadata() { return metadata(); },
+    })).toThrow(expect.objectContaining({ code: "already_exists" }));
+
+    expect(metadata).toHaveBeenCalled();
+    expect(lifecycle.get("reclaim")?.id).toBe("original");
+    expect(lifecycle.get("replacement")?.description).toBe("getter-owned task");
+  });
+});


### PR DESCRIPTION
A new task ID could take over another live task's alias, and checking aliases could delete a completed task before discovering a later collision. Treat primary IDs and aliases as one namespace, reject all live-name collisions, and reclaim terminal owners only after the whole registration is ready to commit. Terminal IDs and aliases now follow the same reuse rule.

Read input fields before the final ownership check so throwing or reentrant getters cannot invalidate the check or cause partial reclamation. Preserve existing output, offsets, notifications, aliases, and listeners when registration fails.

Validation: eight regressions fail against the original implementation; another reproduces ownership changing during input preparation. All 90 focused task, output, agent-completion, and spawning tests pass with zero skips. Typechecking passes. The complete local fast check passes: typechecking, 18 explicit regression tests, and 1,981 affected tests, with zero failures or skips. Independent review is approved; Bugbot, Security Agent, SonarCloud, and Code Analysis pass. The hosted fast check also passes.

Closes #1798.
