### PR TITLE
fix(runtime): bound completed agent event retention

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -573,6 +573,15 @@ All 18 names in `AGENC_DAEMON_NOTIFICATION_METHODS`:
 | Sync | `event.event_gap` (retention eviction or replay required; do not skip) |
 | Realtime (typed; start is advertised `false`) | `thread/realtime/started`, `itemAdded`, `transcript/delta`, `transcript/done`, `outputAudio/delta`, `sdp`, `error`, `closed` |
 
+Completed agents retain detached events for five minutes, with a global limit
+of 128 agents and 8 MiB of UTF-8 data, including agent IDs. An individual
+buffer over 1 MiB requires durable replay. Attaching after cache eviction or
+expiry emits `event.event_gap` with `retiredCount: 0`,
+`retiredCountKnown: false`, and `coordinatesAvailable: false`: the cache cannot
+prove how many events are missing. Use `run.replay` with the run ID and the
+client's last durable sequence (or zero for a full replay). Existing count
+gaps omit `retiredCountKnown` and carry a positive, known `retiredCount`.
+
 `event.mcp_status_changed` is an invalidation, not a state dump. Its strict
 payload is `{ sessionId, revision }`. Fetch `session.mcp.status` for the
 sanitized server/tool projection. A daemon replacement starts a new revision

--- a/packages/agenc-sdk/src/events.ts
+++ b/packages/agenc-sdk/src/events.ts
@@ -88,6 +88,7 @@ export type AgencPromptEvent = AgencPromptEventIdentity &
         readonly afterSequence?: number;
         readonly firstAvailableSequence?: number;
         readonly retiredCount: number;
+        readonly retiredCountKnown?: boolean;
       }
     | {
         readonly type: "session_event";
@@ -247,7 +248,8 @@ export function promptEventFromNotification(
       params.reason !== "retention" ||
       typeof params.sessionId !== "string" ||
       !Number.isSafeInteger(params.retiredCount) ||
-      (params.retiredCount as number) < 1
+      (params.retiredCount as number) < 0 ||
+      (params.retiredCount === 0 && params.retiredCountKnown !== false)
     ) {
       return null;
     }
@@ -262,6 +264,7 @@ export function promptEventFromNotification(
       ...identity,
       sessionId: params.sessionId,
       retiredCount: params.retiredCount as number,
+      ...(params.retiredCountKnown === false ? { retiredCountKnown: false } : {}),
       ...(typeof params.runId === "string" ? { runId: params.runId } : {}),
       ...(afterSequence !== undefined ? { afterSequence } : {}),
       ...(firstAvailableSequence !== undefined

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -1550,6 +1550,8 @@ export interface EventGapParams extends JsonObject {
   readonly reason: "retention";
   readonly source: "background_runner_retention" | "multiplexer_retention";
   readonly retiredCount: number;
+  /** False means replay is required but the loss count is unknown (zero). */
+  readonly retiredCountKnown?: boolean;
   readonly coordinatesAvailable?: boolean;
   readonly afterSequence?: number;
   readonly firstAvailableSequence?: number;

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -10,6 +10,10 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync, readdirSync } from "node:fs";
 import { join as joinPath } from "node:path";
+import {
+  CompletedAgentEventCache,
+  completedEventReplayRequired,
+} from "./background-agent-runner/completed-event-cache.js";
 import { roughTokenCountEstimation } from "../llm/token-estimation.js";
 import {
   bootstrapLocalRuntimeSession,
@@ -395,8 +399,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   readonly #active = new Map<string, ActiveBackgroundAgent>();
   readonly #quiescing = new WeakMap<ActiveBackgroundAgent, Promise<void>>();
   readonly #pendingExplicitRestores = new Set<string>();
-  readonly #pendingEvents = new Map<string, BackgroundAgentDaemonEvent[]>();
-  readonly #pendingActiveToolCallIds = new Map<string, Set<string>>();
+  readonly #pendingEvents = new CompletedAgentEventCache();
   readonly #assistantTextByAgent = new Map<string, string>();
   readonly #pendingToolDecisions = new Map<
     string,
@@ -625,13 +628,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         durableTerminalFinalizerInstalled: false,
         lastActiveAt: startedAt,
         uninstallApprovalBridge,
-        bufferedEvents: boundBufferedAgentEvents(
-          this.#pendingEvents.get(managedThread.threadId) ?? [],
-          managedThread.threadId,
-        ),
-        activeToolCallIds:
-          this.#pendingActiveToolCallIds.get(managedThread.threadId) ??
-          new Set(),
+        bufferedEvents: [],
+        activeToolCallIds: new Set(),
         historyEpoch: historyEpochFromRollout(
           bootstrap.rolloutStore.readAll(),
           managedThread.threadId,
@@ -689,7 +687,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         uninstallPermissionAuthorityCoordinator();
       };
       this.#pendingEvents.delete(managedThread.threadId);
-      this.#pendingActiveToolCallIds.delete(managedThread.threadId);
       params.signal?.throwIfAborted();
       this.#active.set(managedThread.threadId, active);
       active.unsubscribeMcpSurfaceInvalidations =
@@ -703,7 +700,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         (phase) => {
           const progress = phaseEventToProgressEvent(phase);
           if (progress === null) return;
-          void this.#recordPhaseProgressEvent(managedThread.threadId, progress);
+          void this.#recordPhaseProgressEvent(
+            managedThread.threadId,
+            progress,
+            active,
+          );
         },
       );
       active.cleanupComplete = this.#cleanupWhenComplete(
@@ -1175,12 +1176,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
             : {}),
           lastActiveAt: restoredAt,
           uninstallApprovalBridge,
-          bufferedEvents: boundBufferedAgentEvents(
-            this.#pendingEvents.get(params.agentId) ?? [],
-            params.agentId,
-          ),
-          activeToolCallIds:
-            this.#pendingActiveToolCallIds.get(params.agentId) ?? new Set(),
+          bufferedEvents: [],
+          activeToolCallIds: new Set(),
           historyEpoch: historyEpochFromRollout(
             bootstrap.rolloutStore.readAll(),
             params.agentId,
@@ -1273,7 +1270,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           uninstallPermissionAuthorityCoordinator();
         };
         this.#pendingEvents.delete(params.agentId);
-        this.#pendingActiveToolCallIds.delete(params.agentId);
         params.signal?.throwIfAborted();
         this.#active.set(params.agentId, active);
         active.unsubscribeMcpSurfaceInvalidations =
@@ -1299,7 +1295,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           (phase) => {
             const progress = phaseEventToProgressEvent(phase);
             if (progress === null) return;
-            void this.#recordPhaseProgressEvent(params.agentId, progress);
+            void this.#recordPhaseProgressEvent(params.agentId, progress, active);
           },
         );
         active.cleanupComplete = this.#cleanupWhenComplete(
@@ -1401,7 +1397,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       this.#active.delete(agentId);
       this.#pendingEvents.delete(agentId);
       this.#assistantTextByAgent.delete(agentId);
-      this.#pendingActiveToolCallIds.delete(agentId);
     }
     this.#authBackend?.clearVendedKeysForSession(agentId);
 
@@ -1533,7 +1528,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       this.#active.delete(agentId);
       this.#pendingEvents.delete(agentId);
       this.#assistantTextByAgent.delete(agentId);
-      this.#pendingActiveToolCallIds.delete(agentId);
     }
     active.unsubscribeStatus?.();
     if (active.terminal !== undefined) {
@@ -1668,7 +1662,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       this.#active.delete(agentId);
       this.#pendingEvents.delete(agentId);
       this.#assistantTextByAgent.delete(agentId);
-      this.#pendingActiveToolCallIds.delete(agentId);
     }
     active.unsubscribeStatus?.();
     active.unsubscribeDurableTerminalFinalizer?.();
@@ -1774,9 +1767,9 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   ): Promise<void> {
     const active = this.#active.get(agentId);
     if (active === undefined) {
-      const replay = this.#pendingEvents.get(agentId)?.splice(0) ?? [];
-      if (replay.length === 0) return;
-      this.#pendingEvents.delete(agentId);
+      const replay = this.#pendingEvents.take(agentId) ?? [
+        completedEventReplayRequired(agentId),
+      ];
       for (const event of replay) {
         await binding.emit(
           notificationFromDaemonEvent(binding.sessionId, agentId, event),
@@ -4462,18 +4455,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         if (this.#active.get(agentId) !== generation) return;
         const bufferedEvents = active.bufferedEvents.splice(0);
         this.#active.delete(agentId);
-        if (bufferedEvents.length > 0) {
-          const pending = this.#pendingEvents.get(agentId) ?? [];
-          pending.push(...bufferedEvents);
-          this.#pendingEvents.set(
-            agentId,
-            boundBufferedAgentEvents(pending, agentId),
-          );
-        } else {
-          this.#pendingEvents.delete(agentId);
-        }
+        this.#pendingEvents.put(agentId, bufferedEvents);
         this.#assistantTextByAgent.delete(agentId);
-        this.#pendingActiveToolCallIds.delete(agentId);
         active.unsubscribeStatus?.();
         if (active.terminal !== undefined || active.suspension !== undefined) {
           active.unsubscribeDurableTerminalFinalizer?.();
@@ -4535,23 +4518,15 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     agentId: string,
     progress: RunAgentProgressEvent,
   ): Promise<void> {
-    this.#trackActiveToolCall(agentId, progress);
     const active = this.#active.get(agentId);
+    if (active === undefined) return;
+    this.#trackActiveToolCall(agentId, progress);
     const event = this.#eventFromProgress(agentId, progress);
     const events = [
       ...this.#takeInterruptedToolCompletionEvents(agentId, progress),
       ...(event !== null ? [event] : []),
     ];
     if (events.length === 0) return;
-    if (active === undefined) {
-      const pending = this.#pendingEvents.get(agentId) ?? [];
-      pending.push(...events);
-      this.#pendingEvents.set(
-        agentId,
-        boundBufferedAgentEvents(pending, agentId),
-      );
-      return;
-    }
     this.#applyProgressStatus(active, progress);
     for (const nextEvent of events) {
       await this.#emitOrBufferEvent(active, nextEvent);
@@ -4561,9 +4536,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   async #recordPhaseProgressEvent(
     agentId: string,
     progress: RunAgentProgressEvent,
+    generation: ActiveBackgroundAgent,
   ): Promise<void> {
     const active = this.#active.get(agentId);
-    if (active === undefined || !active.canonicalEventBridgeInstalled) {
+    if (active !== generation) return;
+    if (!active.canonicalEventBridgeInstalled) {
       await this.#recordProgressEvent(agentId, progress);
       return;
     }
@@ -4589,7 +4566,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     progress: RunAgentProgressEvent,
   ): Promise<void> {
     const active = this.#active.get(agentId);
-    if (active?.canonicalEventBridgeInstalled !== true) {
+    if (active === undefined || active.bootstrap.session !== session) return;
+    if (!active.canonicalEventBridgeInstalled) {
       await this.#recordProgressEvent(agentId, progress);
       return;
     }
@@ -4598,7 +4576,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       session.emit(event);
       return;
     }
-    await this.#recordPhaseProgressEvent(agentId, progress);
+    await this.#recordPhaseProgressEvent(agentId, progress, active);
   }
 
   #applyProgressStatus(
@@ -4640,21 +4618,12 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       return;
     }
     const active = this.#active.get(agentId);
-    const activeToolCallIds =
-      active?.activeToolCallIds ??
-      this.#pendingActiveToolCallIds.get(agentId) ??
-      new Set<string>();
+    if (active === undefined) return;
+    const activeToolCallIds = active.activeToolCallIds;
     if (progress.kind === "tool_call") {
       activeToolCallIds.add(progress.callId);
     } else {
       activeToolCallIds.delete(progress.callId);
-    }
-    if (active === undefined) {
-      if (activeToolCallIds.size === 0) {
-        this.#pendingActiveToolCallIds.delete(agentId);
-      } else {
-        this.#pendingActiveToolCallIds.set(agentId, activeToolCallIds);
-      }
     }
   }
 
@@ -4669,8 +4638,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       return [];
     }
     const active = this.#active.get(agentId);
-    const activeToolCallIds =
-      active?.activeToolCallIds ?? this.#pendingActiveToolCallIds.get(agentId);
+    const activeToolCallIds = active?.activeToolCallIds;
     if (activeToolCallIds === undefined || activeToolCallIds.size === 0) {
       return [];
     }
@@ -4687,9 +4655,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       },
     }));
     activeToolCallIds.clear();
-    if (active === undefined) {
-      this.#pendingActiveToolCallIds.delete(agentId);
-    }
     return events;
   }
 

--- a/runtime/src/app-server/background-agent-runner/completed-event-cache.ts
+++ b/runtime/src/app-server/background-agent-runner/completed-event-cache.ts
@@ -1,0 +1,134 @@
+import { Buffer } from "node:buffer";
+
+import { EVENT_GAP_EVENT } from "../../contracts/run-contracts.js";
+import {
+  BACKGROUND_RUNNER_GAP_SOURCE,
+  boundBufferedAgentEvents,
+} from "./snapshot-retention.js";
+import type { BackgroundAgentDaemonEvent } from "./shared.js";
+
+export const COMPLETED_EVENT_CACHE_LIMITS = {
+  entries: 128,
+  bytes: 8 * 1_024 * 1_024,
+  entryBytes: 1_024 * 1_024,
+  ttlMs: 5 * 60_000,
+} as const;
+
+interface CompletedEventEntry {
+  readonly data: Buffer;
+  readonly bytes: number;
+  readonly expiresAt: number;
+}
+
+/** Terminal-only replay cache. The runner fences writes by active generation. */
+export class CompletedAgentEventCache {
+  readonly #entries = new Map<string, CompletedEventEntry>();
+  #bytes = 0;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+
+  get retained(): { readonly entries: number; readonly bytes: number } {
+    return { entries: this.#entries.size, bytes: this.#bytes };
+  }
+
+  put(agentId: string, events: BackgroundAgentDaemonEvent[]): void {
+    this.delete(agentId);
+    this.#expire();
+    try {
+      // Own the bytes instead of retaining payload graphs or string slices.
+      const key: string = JSON.parse(
+        Buffer.from(JSON.stringify(agentId), "utf8").toString("utf8"),
+      );
+      const data = Buffer.from(
+        JSON.stringify(boundBufferedAgentEvents(events, agentId)),
+        "utf8",
+      );
+      const bytes = data.byteLength + Buffer.byteLength(key, "utf8");
+      if (bytes > COMPLETED_EVENT_CACHE_LIMITS.entryBytes) return;
+      this.#entries.set(key, {
+        data,
+        bytes,
+        expiresAt: Date.now() + COMPLETED_EVENT_CACHE_LIMITS.ttlMs,
+      });
+      this.#bytes += bytes;
+      // Entries are consumed on read, so the least recently used survivor is
+      // the oldest insertion/replacement. No per-agent tombstones are kept.
+      while (
+        this.#entries.size > COMPLETED_EVENT_CACHE_LIMITS.entries ||
+        this.#bytes > COMPLETED_EVENT_CACHE_LIMITS.bytes
+      ) {
+        const oldest = this.#entries.keys().next().value;
+        if (oldest === undefined) break;
+        this.#remove(oldest);
+      }
+    } catch {
+      // Unserializable or oversized buffers require durable replay on attach.
+    } finally {
+      this.#scheduleExpiry();
+    }
+  }
+
+  take(agentId: string): BackgroundAgentDaemonEvent[] | undefined {
+    this.#expire();
+    const entry = this.#entries.get(agentId);
+    this.delete(agentId);
+    return entry === undefined
+      ? undefined
+      : JSON.parse(entry.data.toString("utf8"));
+  }
+
+  delete(agentId: string): void {
+    this.#remove(agentId);
+    this.#scheduleExpiry();
+  }
+
+  #remove(agentId: string): void {
+    const entry = this.#entries.get(agentId);
+    if (entry === undefined) return;
+    this.#bytes -= entry.bytes;
+    this.#entries.delete(agentId);
+  }
+
+  #expire(): void {
+    const now = Date.now();
+    for (const [agentId, entry] of this.#entries) {
+      if (entry.expiresAt <= now) this.#remove(agentId);
+    }
+  }
+
+  #scheduleExpiry(): void {
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+    let deadline = Infinity;
+    for (const entry of this.#entries.values())
+      deadline = Math.min(deadline, entry.expiresAt);
+    if (deadline === Infinity) return;
+    this.#timer = setTimeout(
+      () => {
+        this.#timer = undefined;
+        this.#expire();
+        this.#scheduleExpiry();
+      },
+      Math.max(1, deadline - Date.now()),
+    );
+    this.#timer.unref();
+  }
+}
+
+/** A cache miss cannot prove either a complete stream or an exact loss count. */
+export function completedEventReplayRequired(
+  agentId: string,
+): BackgroundAgentDaemonEvent {
+  return {
+    id: `runner-gap:${agentId}`,
+    type: EVENT_GAP_EVENT,
+    payload: {
+      kind: EVENT_GAP_EVENT,
+      reason: "retention",
+      source: BACKGROUND_RUNNER_GAP_SOURCE,
+      runId: agentId,
+      retiredCount: 0,
+      retiredCountKnown: false,
+      coordinatesAvailable: false,
+    },
+  };
+}

--- a/runtime/src/app-server/background-agent-runner/daemon-events.ts
+++ b/runtime/src/app-server/background-agent-runner/daemon-events.ts
@@ -440,7 +440,8 @@ export function notificationFromDaemonEvent(
     payload.source === BACKGROUND_RUNNER_GAP_SOURCE &&
     typeof payload.runId === "string" &&
     payload.runId.length > 0 &&
-    positiveInteger(payload.retiredCount) > 0
+    (positiveInteger(payload.retiredCount) > 0 ||
+      (payload.retiredCount === 0 && payload.retiredCountKnown === false))
   ) {
     const afterSequence = nonNegativeSequence(payload.afterSequence);
     const firstAvailableSequence = positiveSequence(
@@ -457,6 +458,7 @@ export function notificationFromDaemonEvent(
         reason: "retention",
         source: BACKGROUND_RUNNER_GAP_SOURCE,
         retiredCount: positiveInteger(payload.retiredCount),
+        ...(payload.retiredCountKnown === false ? { retiredCountKnown: false } : {}),
         ...(typeof payload.coordinatesAvailable === "boolean"
           ? { coordinatesAvailable: payload.coordinatesAvailable }
           : {}),

--- a/runtime/src/app-server/protocol/index.ts
+++ b/runtime/src/app-server/protocol/index.ts
@@ -2086,6 +2086,8 @@ export interface EventGapParams extends JsonObject {
   readonly reason: "retention";
   readonly source: "background_runner_retention" | "multiplexer_retention";
   readonly retiredCount: number;
+  /** False means replay is required but the loss count is unknown (zero). */
+  readonly retiredCountKnown?: boolean;
   readonly coordinatesAvailable?: boolean;
   readonly afterSequence?: number;
   readonly firstAvailableSequence?: number;

--- a/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.bounded-ordered.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   AgenCDelegateBackgroundAgentRunner,
@@ -6,9 +6,7 @@ import {
   type AgenCEnsureAgentControlFunction,
 } from "./background-agent-runner.js";
 import type { AgentStatus } from "../agents/status.js";
-import {
-  createEmptyToolPermissionContext,
-} from "../permissions/types.js";
+import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
 import { SandboxExecutionBroker } from "../sandbox/execution-broker.js";
 import {
@@ -74,11 +72,13 @@ function makeTopLevelRunner(opts: { readonly conversationId: string }) {
   const stub = makeStubConversationThreadManager({
     threadId: opts.conversationId,
   });
-  const configuredExecutionAuthority = sessionExecutionAuthorityFromAgenCConfig({
-    config: {},
-    workspaceRoot: process.cwd(),
-    projectTrust: "trusted",
-  });
+  const configuredExecutionAuthority = sessionExecutionAuthorityFromAgenCConfig(
+    {
+      config: {},
+      workspaceRoot: process.cwd(),
+      projectTrust: "trusted",
+    },
+  );
   const sandboxExecutionBroker = new SandboxExecutionBroker({
     cwd: process.cwd(),
     ...sandboxExecutionBrokerAuthorityFromSessionAuthority(
@@ -96,6 +96,7 @@ function makeTopLevelRunner(opts: { readonly conversationId: string }) {
     }),
   };
   let nextEventSequence = 0;
+  const phaseListeners: ((phase: never) => void)[] = [];
   const session = {
     conversationId: opts.conversationId,
     abortController: new AbortController(),
@@ -103,7 +104,10 @@ function makeTopLevelRunner(opts: { readonly conversationId: string }) {
     get sessionConfiguration() {
       return sessionState.sessionConfiguration;
     },
-    subscribeToEvents: () => () => {},
+    subscribeToEvents: (listener: (phase: never) => void) => {
+      phaseListeners.push(listener);
+      return () => {};
+    },
     emitPhaseEvent: () => {},
     prepareEmit: vi.fn((candidate: Record<string, unknown>) => {
       const event = { ...candidate, seq: ++nextEventSequence };
@@ -152,7 +156,7 @@ function makeTopLevelRunner(opts: { readonly conversationId: string }) {
     })) as unknown as AgenCEnsureAgentControlFunction,
     now: () => "2026-05-09T00:00:00.000Z",
   });
-  return { runner, stub, control };
+  return { runner, stub, control, bootstrap, phaseListeners };
 }
 
 function runningStatus(turnId: string, startedAtMs: number): AgentStatus {
@@ -160,6 +164,136 @@ function runningStatus(turnId: string, startedAtMs: number): AgentStatus {
 }
 
 describe("AgenC background-agent runner: bounded + ordered events", () => {
+  afterEach(() => vi.useRealTimers());
+
+  async function complete(
+    stub: ReturnType<typeof makeStubConversationThreadManager>,
+  ) {
+    stub.pushStatus({
+      status: "completed",
+      lastAgentMessage: "done",
+    } as AgentStatus);
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
+
+  async function attach(
+    runner: AgenCDelegateBackgroundAgentRunner,
+    agentId: string,
+  ) {
+    const events: unknown[] = [];
+    await runner.attachAgentSessionEvents(agentId, {
+      sessionId: "late-client",
+      emit: (event) => {
+        events.push(event);
+      },
+    });
+    return events;
+  }
+
+  const startParams = {
+    objective: "retention",
+    unattendedAllow: [],
+    unattendedDeny: [],
+  };
+  const replayRequired = {
+    method: "event.event_gap",
+    params: expect.objectContaining({
+      retiredCount: 0,
+      retiredCountKnown: false,
+      coordinatesAvailable: false,
+      source: "background_runner_retention",
+    }),
+  };
+
+  it("expires completed buffers without a later attachment", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const { runner, stub } = makeTopLevelRunner({
+      conversationId: "expired-agent",
+    });
+    await runner.startAgent(startParams);
+    await complete(stub);
+    expect(await runner.getAgentSnapshot("expired-agent")).toBeNull();
+    await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+    expect(await attach(runner, "expired-agent")).toEqual([
+      expect.objectContaining(replayRequired),
+    ]);
+  });
+
+  it("does not replay a completed generation into a reused agent ID", async () => {
+    const first = makeTopLevelRunner({ conversationId: "reused-agent" });
+    await first.runner.startAgent(startParams);
+    first.stub.pushStatus(runningStatus("old-generation-only", 1));
+    await complete(first.stub);
+    const next = makeTopLevelRunner({ conversationId: "reused-agent" });
+    first.bootstrap.mockImplementation(() => next.bootstrap({} as never));
+    await first.runner.startAgent(startParams);
+    const events = await attach(first.runner, "reused-agent");
+    expect(JSON.stringify(events)).not.toContain("old-generation-only");
+    await complete(next.stub);
+  });
+
+  it("bounds replay across thousands of completed unattached agents", async () => {
+    const first = makeTopLevelRunner({ conversationId: "completed-0" });
+    for (let i = 0; i < 2_000; i++) {
+      const next =
+        i === 0
+          ? first
+          : makeTopLevelRunner({ conversationId: `completed-${i}` });
+      if (i !== 0)
+        first.bootstrap.mockImplementation(() => next.bootstrap({} as never));
+      await first.runner.startAgent(startParams);
+      await complete(next.stub);
+      expect(await first.runner.getAgentSnapshot(`completed-${i}`)).toBeNull();
+    }
+    expect(await attach(first.runner, "completed-0")).toEqual([
+      expect.objectContaining(replayRequired),
+    ]);
+    const newest = await attach(first.runner, "completed-1999");
+    expect(newest.length).toBeGreaterThan(0);
+    expect(newest).not.toContainEqual(expect.objectContaining(replayRequired));
+  }, 60_000);
+
+  it("ignores delayed phase callbacks after cleanup and after ID reuse", async () => {
+    const first = makeTopLevelRunner({ conversationId: "late-phase-agent" });
+    await first.runner.startAgent(startParams);
+    await complete(first.stub);
+    for (const listener of first.phaseListeners) {
+      listener({
+        type: "assistant_text",
+        content: "retired-before-reuse",
+      } as never);
+    }
+    const completedEvents = await attach(first.runner, "late-phase-agent");
+    expect(JSON.stringify(completedEvents)).not.toContain(
+      "retired-before-reuse",
+    );
+    const next = makeTopLevelRunner({ conversationId: "late-phase-agent" });
+    first.bootstrap.mockImplementation(() => next.bootstrap({} as never));
+    await first.runner.startAgent(startParams);
+    for (const listener of first.phaseListeners) {
+      listener({
+        type: "assistant_text",
+        content: "retired-after-reuse",
+      } as never);
+    }
+    for (const listener of next.phaseListeners) {
+      listener({
+        type: "assistant_text",
+        content: "current-generation",
+      } as never);
+    }
+    for (let i = 0; i < 5; i++)
+      await new Promise((resolve) => setImmediate(resolve));
+    const events = JSON.stringify(
+      await attach(first.runner, "late-phase-agent"),
+    );
+    expect(events).not.toContain("retired-after-reuse");
+    expect(events).toContain("current-generation");
+    await complete(next.stub);
+  });
+
   it("announces buffered-event eviction while retaining the newest events", async () => {
     const { runner, stub } = makeTopLevelRunner({
       conversationId: "session-bounded",

--- a/runtime/tests/app-server/completed-event-cache.test.ts
+++ b/runtime/tests/app-server/completed-event-cache.test.ts
@@ -1,0 +1,132 @@
+import { Buffer } from "node:buffer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CompletedAgentEventCache,
+  COMPLETED_EVENT_CACHE_LIMITS as limits,
+} from "../../src/app-server/background-agent-runner/completed-event-cache.js";
+
+describe("completed agent event cache", () => {
+  afterEach(() => vi.useRealTimers());
+
+  const event = (text = "hello") => ({
+    id: "event-1",
+    type: "agent_message_delta",
+    payload: { delta: text },
+  });
+
+  it("owns payload bytes and releases them when consumed", () => {
+    const cache = new CompletedAgentEventCache();
+    const input = [event("🦀")];
+    const expectedBytes =
+      Buffer.byteLength(JSON.stringify(input)) + Buffer.byteLength("agent");
+    cache.put("agent", input);
+    expect(cache.retained).toEqual({ entries: 1, bytes: expectedBytes });
+    input[0]!.payload.delta = "mutated";
+    input.push(event());
+    expect(cache.take("agent")).toEqual([event("🦀")]);
+    expect(cache.retained).toEqual({ entries: 0, bytes: 0 });
+    expect(cache.take("agent")).toBeUndefined();
+  });
+
+  it("caps entries across ten thousand unique completed agents", () => {
+    const cache = new CompletedAgentEventCache();
+    for (let i = 0; i < 10_000; i++) {
+      cache.put(`agent-${i}`, [event()]);
+      expect(cache.retained.entries).toBeLessThanOrEqual(limits.entries);
+      expect(cache.retained.bytes).toBeLessThanOrEqual(limits.bytes);
+    }
+    expect(cache.take("agent-0")).toBeUndefined();
+    expect(cache.take("agent-9999")).toEqual([event()]);
+  });
+
+  it("evicts by total UTF-8 bytes before reaching the entry cap", () => {
+    const cache = new CompletedAgentEventCache();
+    const input = [event("🦀".repeat(120_000))];
+    for (let i = 0; i < 40; i++) cache.put(`agent-${i}`, input);
+    expect(cache.retained.entries).toBeLessThan(40);
+    expect(cache.retained.bytes).toBeLessThanOrEqual(limits.bytes);
+    expect(cache.take("agent-0")).toBeUndefined();
+    expect(cache.take("agent-39")).toEqual(input);
+  });
+
+  it("rejects oversized payloads and keys without retaining metadata", () => {
+    const cache = new CompletedAgentEventCache();
+    cache.put("large", [event("x".repeat(limits.entryBytes))]);
+    cache.put("x".repeat(limits.entryBytes), [event()]);
+    expect(cache.retained).toEqual({ entries: 0, bytes: 0 });
+    expect(cache.take("large")).toBeUndefined();
+  });
+
+  it("replaces an entry atomically even when the new payload cannot serialize", () => {
+    const cache = new CompletedAgentEventCache();
+    cache.put("agent", [event()]);
+    const circular = event();
+    Object.assign(circular.payload, { circular });
+    expect(() => cache.put("agent", [circular])).not.toThrow();
+    expect(cache.retained).toEqual({ entries: 0, bytes: 0 });
+  });
+
+  it("keeps the newest replacement when evicting the least recently used entry", () => {
+    const cache = new CompletedAgentEventCache();
+    for (let i = 0; i < limits.entries; i++) cache.put(`agent-${i}`, [event()]);
+    cache.put("agent-0", [event("replacement")]);
+    cache.put("new-agent", [event()]);
+    expect(cache.take("agent-1")).toBeUndefined();
+    expect(cache.take("agent-0")).toEqual([event("replacement")]);
+  });
+
+  it("expires entries automatically using one timer and removes that timer when empty", async () => {
+    vi.useFakeTimers();
+    const cache = new CompletedAgentEventCache();
+    cache.put("first", [event()]);
+    await vi.advanceTimersByTimeAsync(100);
+    cache.put("second", [event()]);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(limits.ttlMs - 100);
+    // Reading diagnostics does not itself prune: the timer must free the bytes.
+    expect(cache.retained.entries).toBe(1);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(cache.retained).toEqual({ entries: 0, bytes: 0 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("expires before replay even if the event loop has not run the timer", () => {
+    vi.useFakeTimers();
+    const cache = new CompletedAgentEventCache();
+    cache.put("agent", [event()]);
+    vi.setSystemTime(Date.now() + limits.ttlMs);
+    expect(cache.take("agent")).toBeUndefined();
+    expect(cache.retained.bytes).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("distinguishes a retained empty buffer from a cache miss", () => {
+    const cache = new CompletedAgentEventCache();
+    cache.put("empty", []);
+    expect(cache.take("empty")).toEqual([]);
+    expect(cache.take("unknown")).toBeUndefined();
+  });
+
+  it("copies identifiers without conflating malformed Unicode with a replacement character", () => {
+    const cache = new CompletedAgentEventCache();
+    cache.put("agent-\ud800", [event("surrogate")]);
+    cache.put("agent-\ufffd", [event("replacement")]);
+    expect(cache.take("agent-\ud800")).toEqual([event("surrogate")]);
+    expect(cache.take("agent-\ufffd")).toEqual([event("replacement")]);
+  });
+
+  it("retains the existing per-agent event count gap", () => {
+    const cache = new CompletedAgentEventCache();
+    cache.put(
+      "agent",
+      Array.from({ length: 1_100 }, () => event()),
+    );
+    const replay = cache.take("agent")!;
+    expect(replay).toHaveLength(1_001);
+    expect(replay[0]).toMatchObject({
+      type: "event_gap",
+      payload: { retiredCount: 100 },
+    });
+  });
+});

--- a/runtime/tests/sdk-package/events.contract.test.ts
+++ b/runtime/tests/sdk-package/events.contract.test.ts
@@ -3,6 +3,38 @@ import { describe, expect, it } from "vitest";
 import { promptEventFromNotification } from "../../../packages/agenc-sdk/src/events";
 
 describe("agenc-sdk prompt event mapping", () => {
+  it("preserves a replay-required gap when the retired count is no longer known", () => {
+    const notification = {
+      method: "event.event_gap",
+      params: {
+        kind: "event_gap",
+        reason: "retention",
+        sessionId: "session_1",
+        runId: "run_1",
+        retiredCount: 0,
+        retiredCountKnown: false,
+      },
+    };
+    expect(promptEventFromNotification(notification)).toMatchObject({
+      type: "gap",
+      runId: "run_1",
+      retiredCount: 0,
+      retiredCountKnown: false,
+    });
+    expect(
+      promptEventFromNotification({
+        ...notification,
+        params: { ...notification.params, retiredCountKnown: true },
+      }),
+    ).toBeNull();
+    expect(
+      promptEventFromNotification({
+        ...notification,
+        params: { ...notification.params, retiredCount: -1 },
+      }),
+    ).toBeNull();
+  });
+
   it("preserves a typed mobile client action on user-input requests", () => {
     const clientAction = {
       type: "ledger_solana_transfer_v1",


### PR DESCRIPTION
Completed unattached agents previously accumulated in an unbounded map, and a reused agent ID could inherit the previous generation's buffered events. Replace that map with an owned UTF-8 cache limited to 128 agents, 8 MiB total, 1 MiB per buffer, and five minutes of retention, with automatic expiry and oldest-entry eviction.

A cache miss emits a replay-required gap with `retiredCountKnown: false`; the daemon protocol, SDK decoder, and documentation preserve that distinction and direct clients to `run.replay`. New generations start with empty buffers, delayed phase/recovery callbacks require the current generation, and the obsolete pending tool-call map is removed.

Closes #1799.

Validation:
- Five new regressions fail against the original implementation: expiry, global retention, ID reuse, delayed callbacks, and SDK gap decoding.
- 328 focused runner/SDK tests pass, including 2,000 completed agents through the runner and 10,000 cache insertions, byte limits, autonomous TTL cleanup, and existing protocol drift checks.
- Runtime typecheck and SDK typecheck/build pass.
- Full local suite: 22,359 tests pass in 2,229 files, with zero failures or skips.
- Runtime build, all PTY startup checks, the complete agent-surface contract, and the FND baseline check pass.
- Hosted fast checks pass. Bugbot and security review pass; independent approval is recorded on `a1fa44339cd37738bed5614abd1cb4091972c513`.
- All 13 jobs in hosted platform run 34142411854 pass, including the four default-suite shards and all nine native lanes.
