### PR TITLE
fix(tui): invalidate failed dynamic command snapshots

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -4669,55 +4669,83 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     () => listTuiCommandList(commandRegistry),
     [commandRegistry],
   );
-  // The slash palette (and findCommand execution) previously saw ONLY built-in
-  // Commands include skills from `.agenc/skills` and bundled sources.
-  // skills, and plugin commands were loaded for the model but never surfaced
-  // in the composer. Load the full command set for this workspace and merge
-  // it in, keeping registry built-ins authoritative on name collisions.
+  // Palette display and submission share one command list. A changed source
+  // invalidates the previous snapshot during render, before effects run.
   const dynamicCommandsCwd =
     props.session.cwd ??
     props.session.sessionConfiguration?.cwd ??
     process.cwd();
   const dynamicCommandPluginStorageRoot =
     props.session.services.runtimeOptions?.pluginStorageRoot;
-  const [dynamicTuiCommands, setDynamicTuiCommands] = useState<
-    readonly Command[]
-  >([]);
+  const dynamicCommandSource = useMemo(
+    () => ({
+      cwd: dynamicCommandsCwd,
+      pluginStorageRoot: dynamicCommandPluginStorageRoot,
+      skillsManager: props.session.services.skillsManager,
+      config,
+    }),
+    [
+      dynamicCommandsCwd,
+      dynamicCommandPluginStorageRoot,
+      props.session.services.skillsManager,
+      config,
+    ],
+  );
+  const [dynamicCommandSnapshot, setDynamicCommandSnapshot] = useState<{
+    readonly source: typeof dynamicCommandSource | null;
+    readonly status: "loading" | "ready" | "failed";
+    readonly commands: readonly Command[];
+    readonly error?: string;
+  }>({ source: null, status: "loading", commands: [] });
   useEffect(() => {
-    if (dynamicCommandPluginStorageRoot === undefined) {
-      setDynamicTuiCommands([]);
+    const source = dynamicCommandSource;
+    let cancelled = false;
+    setDynamicCommandSnapshot({ source, status: "loading", commands: [] });
+    if (source.pluginStorageRoot === undefined) {
+      const error = "This session cannot load skills and plugins";
+      setDynamicCommandSnapshot({
+        source,
+        status: "failed",
+        commands: [],
+        error,
+      });
       logForDebugging(
         "dynamic TUI command load skipped: session is missing captured plugin storage authority",
         { level: "warn" },
       );
       return;
     }
-    let cancelled = false;
     void getCommands(
-      dynamicCommandsCwd,
+      source.cwd,
       {
-        pluginStorageRoot: dynamicCommandPluginStorageRoot,
-        ...(props.session.services.skillsManager !== undefined
-          ? { skillsManager: props.session.services.skillsManager }
+        pluginStorageRoot: source.pluginStorageRoot,
+        ...(source.skillsManager !== undefined
+          ? { skillsManager: source.skillsManager }
           : {}),
       },
-      config,
+      source.config,
     )
       .then((all) => {
         if (cancelled) return;
-        setDynamicTuiCommands(
-          all.filter(
+        setDynamicCommandSnapshot({
+          source,
+          status: "ready",
+          commands: all.filter(
             (cmd) =>
               cmd.userInvocable !== false &&
               cmd.isHidden !== true &&
               isCommandEnabled(cmd),
           ),
-        );
+        });
       })
       .catch((error) => {
-        // Palette degrades to built-ins only on load failure — never silently:
-        // a rejected load leaves every dynamic command (skills, rails,
-        // plugins) reporting "Unknown command" on submit.
+        if (cancelled) return;
+        setDynamicCommandSnapshot({
+          source,
+          status: "failed",
+          commands: [],
+          error: error instanceof Error ? error.message : String(error),
+        });
         logForDebugging(
           `dynamic TUI command load failed; palette degraded to built-ins: ${
             error instanceof Error
@@ -4730,21 +4758,27 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     return () => {
       cancelled = true;
     };
-  }, [
-    dynamicCommandPluginStorageRoot,
-    dynamicCommandsCwd,
-    config,
-    props.session.services.skillsManager,
-  ]);
+  }, [dynamicCommandSource]);
+  const dynamicCommandLoadError =
+    dynamicCommandSnapshot.source === dynamicCommandSource &&
+    dynamicCommandSnapshot.status === "failed"
+      ? dynamicCommandSnapshot.error
+      : undefined;
   const commands = useMemo(() => {
     const seen = new Set(
       builtinTuiCommands.map((cmd) => cmd.name.toLowerCase()),
     );
-    const extras = dynamicTuiCommands.filter(
-      (cmd) => !seen.has(cmd.name.toLowerCase()),
-    );
-    return [...builtinTuiCommands, ...extras];
-  }, [builtinTuiCommands, dynamicTuiCommands]);
+    const dynamic =
+      dynamicCommandSnapshot.source === dynamicCommandSource &&
+      dynamicCommandSnapshot.status === "ready"
+        ? dynamicCommandSnapshot.commands
+        : [];
+    return [
+      ...builtinTuiCommands,
+      ...dynamic.filter((cmd) => !seen.has(cmd.name.toLowerCase())),
+    ];
+  }, [builtinTuiCommands, dynamicCommandSource, dynamicCommandSnapshot]);
+
   const agents = useAppState((state) => state.agentDefinitions.activeAgents);
   const appTasks = useAppState((s) => s.tasks);
   const hasActiveLocalAgents = getActiveLocalAgentTasks(appTasks).length > 0;
@@ -7229,6 +7263,12 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
   ) : null;
   const bottomContent = (
     <Box flexDirection="column" flexGrow={1}>
+      {dynamicCommandLoadError !== undefined ? (
+        <Text color="warning" wrap="wrap">
+          Dynamic commands unavailable: {dynamicCommandLoadError}. Built-in
+          commands remain available.
+        </Text>
+      ) : null}
       {backpressureWarning !== null ? (
         <Text color="warning" wrap="truncate">
           {backpressureWarning}

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -51,6 +51,7 @@ let mockWorktreeSession: unknown = null;
 let mockGlobalConfig: Record<string, unknown> = {};
 const mockTuiCommandList = vi.hoisted(() => [] as Array<Record<string, any>>);
 const commandDiscoveryProbe = vi.hoisted(() => vi.fn());
+const commandDebugProbe = vi.hoisted(() => vi.fn());
 const roleDefinitionProbe = vi.hoisted(() =>
   vi.fn((_cwd: string) => [
     {
@@ -143,7 +144,7 @@ vi.mock("bun:bundle", () => ({
 }));
 
 vi.mock("src/utils/debug.js", () => ({
-  logForDebugging: () => {},
+  logForDebugging: commandDebugProbe,
 }));
 
 vi.mock("src/utils/envUtils.js", () => ({
@@ -478,8 +479,7 @@ vi.mock("../../commands.js", () => ({
       (command) => command.name === name || command.aliases?.includes(name),
     ) ?? null,
   getCommands: async (...args: unknown[]) => {
-    commandDiscoveryProbe(...args);
-    return mockTuiCommandList;
+    return commandDiscoveryProbe(...args) ?? mockTuiCommandList;
   },
   isCommandEnabled: () => true,
   listTuiCommandList: () => mockTuiCommandList,
@@ -865,7 +865,8 @@ function resetShellSurfaceProbe(): void {
   ledgerStatusProbe.refresh.mockClear();
   dismissLedgerVerification();
   mockTuiCommandList.length = 0;
-  commandDiscoveryProbe.mockClear();
+  commandDiscoveryProbe.mockReset();
+  commandDebugProbe.mockClear();
   mockTotalCost = 0;
   mockHasConsoleBillingAccess = false;
   mockWorktreeSession = null;
@@ -1025,9 +1026,9 @@ function createSession(
       ? { agentDefinitions: opts.agentDefinitions }
       : {}),
     services: {
-      ...(opts.runtimeOptions !== undefined
-        ? { runtimeOptions: opts.runtimeOptions }
-        : {}),
+      runtimeOptions: opts.runtimeOptions ?? {
+        pluginStorageRoot: join(tmpdir(), "agenc-app-render-plugins"),
+      } as never,
       configStore: opts.configStore ?? testConfigStore,
       providerEnvironment: TEST_REMOTE_AUTH_SESSION_CONTEXT.environment,
       permissionModeRegistry: {
@@ -1387,6 +1388,185 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         for (const call of commandDiscoveryProbe.mock.calls) {
           expect(call[1]).toMatchObject({ pluginStorageRoot });
         }
+      },
+    );
+  });
+
+  test.each(["failure", "pending", "removed"] as const)(
+    "invalidates dynamic command display and execution after a %s reload",
+    async (outcome) => {
+      const { AgenCTuiApp } = await import("./App.js");
+      resetShellSurfaceProbe();
+      mockTuiCommandList.push({ name: "help", type: "local", load: vi.fn() });
+      const getPromptForCommand = vi.fn(async () => [
+        { type: "text", text: "obsolete expansion" },
+      ]);
+      const dynamic = {
+        name: "reloadable",
+        type: "prompt",
+        loadedFrom: "skills",
+        progressMessage: "Loading",
+        contentLength: 1,
+        getPromptForCommand,
+      };
+      const configStore = createAppConfigStore();
+      const session = createSession({
+        configStore,
+        runtimeOptions: { pluginStorageRoot: "/tmp/command-reload" } as never,
+      });
+      commandDiscoveryProbe.mockResolvedValue([dynamic]);
+      const commands = () =>
+        providerProbe.promptProps.at(-1)?.commands as Array<{ name: string }>;
+      await withRenderedApp(
+        <AgenCTuiApp session={session} isInteractive={false} />,
+        async ({ output }) => {
+          await vi.waitFor(() =>
+            expect(commands().map((command) => command.name)).toContain(
+              "reloadable",
+            ),
+          );
+          await providerProbe.promptSubmits.at(-1)!("$reloadable", {
+            clearBuffer: vi.fn(),
+            resetHistory: vi.fn(),
+            setCursorOffset: vi.fn(),
+          });
+          expect(getPromptForCommand).toHaveBeenCalledTimes(1);
+          const pending = Promise.withResolvers<unknown[]>();
+          if (outcome === "failure")
+            commandDiscoveryProbe.mockRejectedValue(
+              new Error("command source removed"),
+            );
+          else if (outcome === "pending")
+            commandDiscoveryProbe.mockReturnValue(pending.promise);
+          else commandDiscoveryProbe.mockResolvedValue([]);
+          const calls = commandDiscoveryProbe.mock.calls.length;
+          await configStore.reload();
+          await vi.waitFor(() =>
+            expect(commandDiscoveryProbe.mock.calls.length).toBeGreaterThan(
+              calls,
+            ),
+          );
+          if (outcome === "failure") {
+            await vi.waitFor(() =>
+              expect(
+                commandDebugProbe.mock.calls.some(([message]) =>
+                  String(message).includes("command source removed"),
+                ),
+              ).toBe(true),
+            );
+          }
+          await vi.waitFor(() =>
+            expect(commands().map((command) => command.name)).toEqual(["help"]),
+          );
+          await providerProbe.promptSubmits.at(-1)!("$reloadable", {
+            clearBuffer: vi.fn(),
+            resetHistory: vi.fn(),
+            setCursorOffset: vi.fn(),
+          });
+          expect(getPromptForCommand).toHaveBeenCalledTimes(1);
+          if (outcome === "failure")
+            expect(stripAnsi(output()).replace(/\s+/gu, "")).toContain(
+              "Dynamiccommandsunavailable",
+            );
+          pending.resolve([]);
+        },
+      );
+    },
+  );
+
+  test.each(["success", "failure"] as const)(
+    "ignores an older command generation's late %s",
+    async (outcome) => {
+      const { AgenCTuiApp } = await import("./App.js");
+      resetShellSurfaceProbe();
+      const configStore = createAppConfigStore();
+      const session = createSession({
+        configStore,
+        runtimeOptions: { pluginStorageRoot: "/tmp/command-race" } as never,
+      });
+      const old = Promise.withResolvers<unknown[]>();
+      commandDiscoveryProbe.mockReturnValue(old.promise);
+      await withRenderedApp(
+        <AgenCTuiApp session={session} isInteractive={false} />,
+        async () => {
+          await vi.waitFor(() =>
+            expect(commandDiscoveryProbe).toHaveBeenCalled(),
+          );
+          commandDiscoveryProbe.mockResolvedValue([
+            { name: "current-command", type: "prompt" },
+          ]);
+          await configStore.reload();
+          const names = () =>
+            (
+              providerProbe.promptProps.at(-1)?.commands as Array<{
+                name: string;
+              }>
+            ).map((command) => command.name);
+          await vi.waitFor(() => expect(names()).toEqual(["current-command"]));
+          commandDebugProbe.mockClear();
+          if (outcome === "success")
+            old.resolve([{ name: "obsolete-command", type: "prompt" }]);
+          else old.reject(new Error("obsolete command failure"));
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          expect(names()).toEqual(["current-command"]);
+          expect(
+            commandDebugProbe.mock.calls.some(([message]) =>
+              String(message).includes("obsolete command failure"),
+            ),
+          ).toBe(false);
+        },
+      );
+    },
+  );
+
+  test("removes commands when their authority disappears and clears the notice after recovery", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    resetShellSurfaceProbe();
+    fullscreenProbe.fullscreen = true;
+    const session = createSession();
+    const runtimeOptions = session.services.runtimeOptions;
+    commandDiscoveryProbe.mockResolvedValue([
+      { name: "before-removal", type: "prompt" },
+    ]);
+    const names = () =>
+      (
+        providerProbe.promptProps.at(-1)?.commands as Array<{ name: string }>
+      ).map((command) => command.name);
+    const textIn = (node: React.ReactNode): string => {
+      if (typeof node === "string" || typeof node === "number")
+        return String(node);
+      if (Array.isArray(node)) return node.map(textIn).join("");
+      if (!React.isValidElement(node)) return "";
+      return textIn((node.props as { children?: React.ReactNode }).children);
+    };
+    const notice = () =>
+      textIn(
+        providerProbe.workbenchLayoutProps.at(-1)?.composer ??
+          providerProbe.fullscreenLayoutProps.at(-1)?.bottom,
+      );
+    await withRenderedApp(
+      <AgenCTuiApp session={session} isInteractive={false} />,
+      async ({ render }) => {
+        await vi.waitFor(() => expect(names()).toEqual(["before-removal"]));
+        const calls = commandDiscoveryProbe.mock.calls.length;
+        Object.assign(session.services, { runtimeOptions: undefined });
+        await render(
+          <AgenCTuiApp session={{ ...session }} isInteractive={false} />,
+        );
+        await vi.waitFor(() => expect(names()).toEqual([]));
+        expect(commandDiscoveryProbe.mock.calls.length).toBe(calls);
+        await vi.waitFor(() =>
+          expect(notice()).toContain("Dynamic commands unavailable"),
+        );
+        commandDiscoveryProbe.mockResolvedValue([
+          { name: "after-recovery", type: "prompt" },
+        ]);
+        Object.assign(session.services, { runtimeOptions });
+        await render(
+          <AgenCTuiApp session={{ ...session }} isInteractive={false} />,
+        );
+        await vi.waitFor(() => expect(names()).toEqual(["after-recovery"]));
+        expect(notice()).not.toContain("Dynamic commands unavailable");
       },
     );
   });


### PR DESCRIPTION
A failed or pending dynamic command reload kept the previous commands visible and executable. Tie each command list to its source snapshot and expose built-ins until that snapshot succeeds. A failed load keeps a visible notice; late results and errors from obsolete loads are ignored. Palette rendering and submission use the same merged command list.

The regression tests exercise success followed by failure, pending and empty reloads, stale completions, source removal and recovery, and actual command execution before and after invalidation. The render fixture now provides the plugin storage authority that production sessions carry.

Closes #1803.

Validation: four regressions fail against the original implementation. All 163 targeted render, registry, command-surface and skill-execution tests pass with zero skips. Runtime typechecking, build and all PTY startup checks pass. The complete local fast check passes: typechecking, 129 explicit tests and 244 affected tests, with zero failures or skips. Independent approval is recorded on `48d4931b15f99d8849c66eb8a9763b0f1a619cd2`; Bugbot passes. The complete agent-surface contract, hosted fast check, Security Agent, SonarCloud and Code Analysis all pass.
