### PR TITLE
fix(sdk): generate exact daemon wire types and enforce parity

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
-sonar.cpd.exclusions=scripts/install/runtime-installer.cjs
+# The public wire copy is generated and checked against its canonical declarations.
+sonar.cpd.exclusions=scripts/install/runtime-installer.cjs,packages/agenc-sdk/src/protocol-wire.generated.ts

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -560,6 +560,7 @@ optional `headers`), `github` (`repo`, optional `ref`, `path`, `sparsePaths`),
 | `mcp_servers.<server>.command`, `mcp_servers.<server>.args`, `mcp_servers.<server>.cwd` | Stdio process launch fields. |
 | `mcp_servers.<server>.env`, `mcp_servers.<server>.env.<name>`, `mcp_servers.<server>.env_vars` | Literal environment map and inherited variable-name array. |
 | `mcp_servers.<server>.endpoint`, `mcp_servers.<server>.headers`, `mcp_servers.<server>.headers.<name>` | Remote URL and header map. |
+| `mcp_servers.<server>.oauth` | Public OAuth metadata for HTTP/SSE connections: `clientId`, `scopes`, `authServerMetadataUrl`, `callbackPort`, and `xaa`. Metadata URLs require HTTPS; callback ports range from 1024 to 65535. Credentials stay in native storage, and this block cannot accompany an `Authorization` header. |
 | `mcp_servers.<server>.enabled`, `mcp_servers.<server>.required`, `mcp_servers.<server>.timeout` | Enablement, required-startup policy, and timeout. |
 | `mcp_servers.<server>.default_tools_approval_mode` | Server-wide approval default. |
 | `mcp_servers.<server>.enabled_tools`, `mcp_servers.<server>.disabled_tools` | Tool arrays. |

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -512,6 +512,8 @@ Changes covered by these guards fail the check until the mirrored or
 marker-checked content is updated. Refresh the public wire declarations with
 `npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write`,
 then run the same command without `--write` to verify the committed files.
+Write mode regenerates artifacts; default check mode compiles wire parity.
+Runtime builds use check mode.
 `SessionTranscriptV2Params` is included in the public wire generation.
 
 The generator follows the public declarations and their referenced types,

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -496,7 +496,7 @@ of the public surface:
 
 | Layer | Authority | Guard |
 | --- | --- | --- |
-| Method registry and handwritten params/result maps | `packages/agenc-sdk/src/protocol.ts` | `runtime/tests/sdk-package/protocol-drift.contract.test.ts` compares `AGENC_SDK_DAEMON_METHODS` / `AGENC_SDK_DAEMON_NOTIFICATION_METHODS` to the runtime arrays (names **and** order) and requires a params/result map entry for every method |
+| Public wire declarations and params/result maps | `runtime/src/app-server/protocol/index.ts` and referenced shared declarations | `check:sdk-generated-types` generates `protocol-wire.generated.ts`, checks the complete artifact and compiles exact request, result, envelope and client-argument types for every public method. The drift contract also checks registry names and order. |
 | `session.transcript.v2` result shapes | `runtime/src/app-server/protocol/index.ts` | `check:sdk-generated-types` renders `transcript-v2.generated.ts` and compares the complete committed file after newline normalization |
 | Workflow result contract markers | `runtime/src/agents/workflow-result.ts`, `coreSchemas.ts`, `coreTypes.generated.ts`, and `packages/agenc-sdk/src/workflow-result.generated.ts` | The same check requires selected version and outcome markers. It does not compare the complete file. Refresh and the extra contract-test lock: [Workflow result generated mirror](#workflow-result-generated-mirror) |
 | Workflow handoff contract markers | `runtime/src/entrypoints/sdk/coreSchemas.ts` and `coreTypes.generated.ts` | The same check requires selected runtime handoff markers. It does not read or structurally compare `packages/agenc-sdk/src/workflow-handoff.generated.ts` |
@@ -509,8 +509,26 @@ or export in the public workflow-handoff mirror. [#1941](https://github.com/tets
 tracks a generated structural parity check.
 
 Changes covered by these guards fail the check until the mirrored or
-marker-checked content is updated. `SessionTranscriptV2Params` stays
-handwritten (`{ sessionId }`); only the four result interfaces are generated.
+marker-checked content is updated. Refresh the public wire declarations with
+`npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write`,
+then run the same command without `--write` to verify the committed files.
+`SessionTranscriptV2Params` is included in the public wire generation.
+
+The generator follows the public declarations and their referenced types,
+including shared run settings, without copying runtime imports or internal
+RPC method mappings. It rejects unsupported imports, name collisions and
+executable constant initializers. Optional and nested field changes count as
+drift even when TypeScript would allow assignment in both directions.
+
+Helper adapters have separate types. `createSession()`, `spawnAgent()` and the
+CSV review helpers allow omitted `cwd` and fill it before dispatch. Their
+named fields come from the generated wire declarations. Generic `request()`
+and `AgencDaemonRequest` require every payload and field required by the daemon;
+use a helper when a default is needed. `replayRun()` preserves the existing
+source-specific M3/M4 result union, including admission events from older
+daemons without a category field. The generic `run.replay` result remains the
+canonical flat wire shape; the replay attachment validates pages and events
+before consuming them. No method is exempt from wire parity.
 
 ### Transcript v2 generated mirror
 

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -12,7 +12,7 @@ Node **>=26.5 <27** · ESM only · plain `tsc` build · no runtime dependencies.
 | `promptViaSubprocess()`                                                      | Same event-iterable interface over `agenc -p --output-format stream-json` with no daemon socket access from your process.                                                                                              |
 | `client.runStatus` / `runResult` / `replayRun` / `runEvidence` / `cancelRun` | Read durable run/admission state, replay or hash canonical journal evidence, or cancel a run tree.                                                                                                                     |
 | `client.reattachRun({ runId, afterSequence })`                               | Catch up from a durable cursor, suppress and report duplicate delivery, stop on any explicit replay gap, and fetch the durable terminal result after reconnect.                                                        |
-| `client.request(method, params)`                                             | Raw typed JSON-RPC for all **53** public daemon methods (mirrored in `./protocol`).                                                                                                                                    |
+| `client.request(method, params)`                                             | Raw typed JSON-RPC for all **89** public daemon methods, generated from the daemon protocol. Required wire payloads must be supplied.                                                                                   |
 | `client.listCsvJobReviews` / `showCsvJobReview` / `resolveCsvJobReview`      | Typed CSV unknown-outcome review helpers (`csvJob.review.*`).                                                                                                                                                          |
 
 Errors: `AgencRpcError`, `AgencMalformedResponseError`,
@@ -44,6 +44,12 @@ that root. Strict admission and scoped prompt cancellation fail closed when
 those guarantees are unavailable.
 Protocol 1.9 adds a Core-only admitted shell method; it is not exposed by the
 SDK request union.
+
+`createSession()`, `spawnAgent()`, and the CSV review helpers supply an omitted
+`cwd`. Direct `request()` calls require the daemon's complete payload, including
+`cwd` for those methods. The SDK generation check compiles exact request and
+result parity for every public method. See [protocol generation](../../docs/sdk.md#protocol-mirror--drift-guard)
+for regeneration and compatibility adapters.
 
 ```js
 import { connect, promptViaSubprocess } from "@tetsuo-ai/agenc-sdk";

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -18,8 +18,8 @@ import {
   type AgencDaemonErrorObject,
   type AgencDaemonMethod,
   type AgencDaemonRequest,
+  type AgencRequestParams,
   type AgencDaemonResponse,
-  type AgencParamsByMethod,
   type AgencResultByMethod,
   type AgentAttachResult,
   type AgentCreateParams,
@@ -891,7 +891,7 @@ export class AgencClient {
 
   async request<Method extends AgencDaemonMethod>(
     method: Method,
-    params?: AgencParamsByMethod[Method],
+    ...[params]: AgencRequestParams<NoInfer<Method>>
   ): Promise<AgencResultByMethod[Method]> {
     if (this.#closed) throw new Error("AgenC SDK client is closed");
     if (
@@ -907,10 +907,13 @@ export class AgencClient {
       );
     }
     const id = this.#createRequestId();
-    const request: AgencDaemonRequest<Method> =
+    // The public signature checks the method's payload and optionality. TS
+    // cannot carry that correlation through construction of this envelope.
+    const request = (
       params === undefined
         ? { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method }
-        : { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method, params };
+        : { jsonrpc: AGENC_SDK_JSON_RPC_VERSION, id, method, params }
+    ) as AgencDaemonRequest<Method>;
     const response = await this.#transport.request(request);
     return parseResponse(response, method, id);
   }
@@ -1093,7 +1096,13 @@ export class AgencClient {
 
   /** Replay a bounded page of the canonical run journal. */
   replayRun(params: RunReplayParams): Promise<RunReplayResult> {
-    return this.request("run.replay", params);
+    // Compatibility adapter: the generic wire result has a flat event array.
+    // This helper retains the source-specific M3/M4 event union, including
+    // admission events from older daemons without a category field. The
+    // replay attachment validates the page and events before consuming them.
+    return this.request("run.replay", params).then(
+      (result) => result as RunReplayResult,
+    );
   }
 
   /**

--- a/packages/agenc-sdk/src/csv-jobs.ts
+++ b/packages/agenc-sdk/src/csv-jobs.ts
@@ -5,6 +5,9 @@
  * connected `csvJob.review.*` operator surface.
  */
 
+import type * as Wire from "./protocol-wire.generated.js";
+import type { AgencDefaultCwdParams } from "./protocol.js";
+
 export const AGENC_SDK_CSV_JOB_CONTRACT_VERSION = 1 as const;
 export const AGENC_SDK_CSV_OUTPUT_CONTRACT_VERSION = 1 as const;
 
@@ -143,31 +146,14 @@ export interface CsvOperatorEffectReviewResolution {
   readonly domainAction: CsvReviewDomainAction;
 }
 
-export interface CsvJobReviewListParams {
-  /** Absolute workspace root. The SDK fills the process cwd when omitted. */
-  readonly cwd?: string;
-  readonly jobId: string;
-  readonly cursor?: CsvJobItemCursor;
-  readonly limit?: number;
-}
+/** Helper input; the client fills cwd when omitted. */
+export type CsvJobReviewListParams = AgencDefaultCwdParams<Wire.CsvJobReviewListParams>;
 
-export interface CsvJobReviewShowParams {
-  readonly cwd?: string;
-  readonly jobId: string;
-  readonly itemId: string;
-}
+/** Helper input; the client fills cwd when omitted. */
+export type CsvJobReviewShowParams = AgencDefaultCwdParams<Wire.CsvJobReviewShowParams>;
 
-export interface CsvJobReviewResolveParams {
-  readonly cwd?: string;
-  readonly jobId: string;
-  readonly itemId: string;
-  readonly disposition: CsvReviewDisposition;
-  readonly evidenceRef: string;
-  readonly evidenceSha256: string;
-  readonly reviewer: string;
-  readonly reason: string;
-  readonly result?: Readonly<Record<string, unknown>>;
-}
+/** Helper input; the client fills cwd when omitted. */
+export type CsvJobReviewResolveParams = AgencDefaultCwdParams<Wire.CsvJobReviewResolveParams>;
 
 export interface CsvJobReviewEvidenceProjection {
   readonly bytes: number;

--- a/packages/agenc-sdk/src/protocol-wire.generated.ts
+++ b/packages/agenc-sdk/src/protocol-wire.generated.ts
@@ -1,0 +1,2185 @@
+// @generated from the daemon protocol and its referenced declarations. Do not edit.
+
+// Regenerate: npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write
+
+// Public wire types only; this module has no runtime-internal imports.
+
+/** JSON-RPC version required on daemon requests, responses, and notifications. */
+export const JSON_RPC_VERSION = "2.0" as const;
+
+/**
+ * Current daemon protocol version.
+ * 1.2 adds identity-bearing transcript.v2 and turn-scoped cancellation.
+ * 1.3 adds the passive MCP status projection and its live-only invalidation.
+ * 1.4 makes the owning agent runtime authority part of agent.attach.
+ * 1.5 adds the effective hook-suppression projection.
+ * 1.6 makes the live canonical run-settings snapshot part of agent.attach.
+ * 1.7 adds inactive permission capabilities to that required snapshot and an
+ * authenticated internal session permission-rule mutation authority.
+ * 1.8 requires the exact plugin storage root in owning agent runtime authority
+ * and binds successful model and config mutation responses to the exact
+ * canonical runtime-settings event that clients must apply.
+ * 1.9 adds admitted shell execution on the daemon-owned live session for
+ * internal clients.
+ * 1.10 adds daemon-owned local routines and opt-in routine invalidations.
+ * Clients that need any of these additive surfaces must not negotiate an older
+ * daemon.
+ */
+export const AGENC_DAEMON_PROTOCOL_VERSION = "1.10.0" as const;
+
+export const AGENC_DAEMON_METHODS = [
+    "remote.capabilities",
+    "remote.status",
+    "remote.start",
+    "remote.stop",
+    "remote.pair.begin",
+    "remote.pair.refresh",
+    "remote.pair.cancel",
+    "remote.devices",
+    "remote.pending",
+    "remote.approve",
+    "remote.revoke",
+    "telegram.capabilities",
+    "telegram.status",
+    "telegram.configure",
+    "telegram.start",
+    "telegram.stop",
+    "telegram.revoke",
+    "telegram.agents.list",
+    "telegram.agents.create",
+    "telegram.agents.update",
+    "telegram.agents.start",
+    "telegram.agents.stop",
+    "telegram.agents.remove",
+    "telegram.agents.pair.begin",
+    "telegram.agents.pair.confirm",
+    "telegram.agents.pair.cancel",
+    "initialize",
+    "request.cancel",
+    "agent.create",
+    "agent.list",
+    "agent.attach",
+    "agent.stop",
+    "agent.logs",
+    "run.status",
+    "run.result",
+    "run.replay",
+    "run.evidence",
+    "run.cancel",
+    "run.start",
+    "routine.capabilities",
+    "routine.list",
+    "routine.get",
+    "routine.create",
+    "routine.update",
+    "routine.delete",
+    "routine.run",
+    "routine.runs",
+    "routine.cancel",
+    "csvJob.review.list",
+    "csvJob.review.show",
+    "csvJob.review.resolve",
+    "session.create",
+    "session.list",
+    "session.attach",
+    "session.detach",
+    "session.terminate",
+    "session.clear",
+    "session.snapshot",
+    "session.transcript",
+    "session.transcript.v2",
+    "session.cancelTurn",
+    "session.resolveToolCall",
+    "session.mcp.status",
+    "session.mcp.addServer",
+    "message.send",
+    "message.stream",
+    "thread/realtime/start",
+    "thread/realtime/appendAudio",
+    "thread/realtime/appendText",
+    "thread/realtime/stop",
+    "thread/realtime/listVoices",
+    "tool.approve",
+    "tool.deny",
+    "tool.cancel",
+    "elicitation.respond",
+    "permission.list",
+    "fs.fuzzy_search",
+    "commandExec.start",
+    "commandExec.write",
+    "commandExec.resize",
+    "commandExec.terminate",
+    "health.ping",
+    "health.ready",
+    "health.stats",
+    "daemon.reload",
+    "daemon.shutdown",
+    "auth.login",
+    "auth.whoami",
+    "auth.logout",
+] as const;
+
+export const AGENC_DAEMON_NOTIFICATION_METHODS = [
+    "routine.updated",
+    "commandExec.outputDelta",
+    "event.message_chunk",
+    "event.tool_request",
+    "event.permission_request",
+    "event.user_input_request",
+    "event.mcp_elicitation_request",
+    "event.mcp_status_changed",
+    "event.agent_status",
+    "event.session_event",
+    "event.event_gap",
+    "thread/realtime/started",
+    "thread/realtime/itemAdded",
+    "thread/realtime/transcript/delta",
+    "thread/realtime/transcript/done",
+    "thread/realtime/outputAudio/delta",
+    "thread/realtime/sdp",
+    "thread/realtime/error",
+    "thread/realtime/closed",
+] as const;
+
+export type AgenCDaemonMethod = (typeof AGENC_DAEMON_METHODS)[number];
+
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonArray = readonly JsonValue[];
+
+export type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+
+export interface JsonObject {
+    readonly [key: string]: JsonValue | undefined;
+}
+
+export type RequestId = string | number;
+
+export interface AgenCDaemonRequestWithParams<Method extends AgenCDaemonMethod, Params extends JsonObject> {
+    readonly jsonrpc: typeof JSON_RPC_VERSION;
+    readonly id: RequestId;
+    readonly method: Method;
+    readonly params: Params;
+}
+
+export type EmptyParams = Record<string, never>;
+
+export interface AgenCDaemonRequestWithoutParams<Method extends AgenCDaemonMethod> {
+    readonly jsonrpc: typeof JSON_RPC_VERSION;
+    readonly id: RequestId;
+    readonly method: Method;
+    readonly params?: EmptyParams;
+}
+
+export interface RoutineIdParams extends JsonObject {
+    readonly id: string;
+}
+
+/** Versioned local-daemon contract. No caller-supplied credentials or runtime authority. */
+export type RoutineSchedule = {
+    readonly kind: "manual";
+} | {
+    readonly kind: "cron";
+    readonly expression: string;
+};
+
+export interface RoutineCreateParams extends JsonObject {
+    readonly name: string;
+    readonly description?: string;
+    readonly instructions: string;
+    readonly cwd: string;
+    readonly schedule: RoutineSchedule;
+    readonly provider?: string;
+    readonly model?: string;
+    readonly permissionMode?: "default" | "plan";
+    readonly enabled?: boolean;
+    readonly notifyOnCompletion?: boolean;
+}
+
+export interface RoutineUpdateParams extends RoutineIdParams {
+    readonly patch: Partial<RoutineCreateParams>;
+    readonly expectedUpdatedAt?: string;
+}
+
+export interface RoutineDeleteParams extends RoutineIdParams {
+    readonly expectedUpdatedAt?: string;
+}
+
+export interface RoutineRunsParams extends RoutineIdParams {
+    readonly limit?: number;
+}
+
+export interface RoutineCancelParams extends RoutineIdParams {
+    readonly runId?: string;
+}
+
+export interface DaemonProtocolInfo extends JsonObject {
+    readonly version: string;
+}
+
+export interface InitializeParams extends JsonObject {
+    /**
+     * Compatibility flat version field. Accepted when `protocol` is omitted, and must
+     * match `protocol.version` when both are sent.
+     */
+    readonly protocolVersion?: string;
+    /**
+     * Canonical protocol metadata for the initialize handshake.
+     */
+    readonly protocol?: DaemonProtocolInfo;
+    readonly clientName?: string;
+    readonly authCookie?: string;
+    readonly capabilities?: JsonObject;
+}
+
+export interface RequestCancelParams extends JsonObject {
+    readonly requestId: RequestId;
+    readonly reason?: string;
+}
+
+export interface AgentResumeSourceProof extends JsonObject {
+    readonly dev: string;
+    readonly ino: string;
+    readonly size: string;
+    readonly sha256: string;
+    readonly cwdDev: string;
+    readonly cwdIno: string;
+}
+
+export type MessageContentBlock = (JsonObject & {
+    readonly type: "text";
+    readonly text: string;
+}) | (JsonObject & {
+    readonly type: "image_url";
+    readonly image_url: JsonObject & {
+        readonly url: string;
+    };
+});
+
+export type MessageContent = string | readonly MessageContentBlock[];
+
+export interface EditorInteractionPositionParams extends JsonObject {
+    readonly line: number;
+    readonly column: number;
+}
+
+export interface EditorInteractionRangeParams extends JsonObject {
+    readonly start: EditorInteractionPositionParams;
+    readonly end: EditorInteractionPositionParams;
+}
+
+/**
+ * JSON-wire mirror of SessionEditorInteraction. Keep this protocol-owned shape
+ * structurally aligned without importing runtime session internals.
+ */
+export interface EditorInteractionParams extends JsonObject {
+    readonly interactionId: string;
+    readonly kind: "ask" | "explain" | "fix" | "edit" | "refactor";
+    readonly policy: "read_only" | "proposal_only";
+    readonly editorInstanceId: string;
+    readonly bufferHandle: number;
+    readonly changedtick: number;
+    readonly contentSha256: string;
+    readonly path?: string;
+    readonly range: EditorInteractionRangeParams;
+    readonly selectionMode?: "character" | "line" | "block";
+}
+
+export interface AgentRuntimeOptionsParams extends JsonObject {
+    readonly simpleMode: boolean;
+    /** Omission by an older client is normalized to false. */
+    readonly dangerouslyBypassApprovalsAndSandbox?: boolean;
+    readonly stdinDataMode: boolean;
+    readonly remoteMode: boolean;
+    readonly remoteMemoryRoot?: string;
+    readonly coworkMemoryPathOverride?: string;
+    readonly coworkMemoryExtraGuidelines?: string;
+    readonly posixShellPath?: string;
+    readonly commandWrapperArgv?: readonly string[];
+    readonly sessionTempRoot?: string;
+    readonly pluginStorageRoot: string;
+    readonly allowUntrustedHooks: boolean;
+}
+
+export interface AgentCreateParams extends JsonObject {
+    readonly objective?: string;
+    /**
+     * Explicitly continue this canonical rollout instead of creating a fresh
+     * run. The daemon reopens a terminal epoch only after durable recovery and
+     * unknown-outcome review gates pass.
+     */
+    readonly resumeSessionId?: string;
+    /** Exact absolute canonical rollout selected by the trusted CLI resolver. */
+    readonly resumeRolloutPath?: string;
+    /** Frozen resolver proof; the daemon independently revalidates every field. */
+    readonly resumeSourceProof?: AgentResumeSourceProof;
+    /**
+     * Absolute workspace directory. Required (DAE-02): the daemon will not
+     * invent a project root from its own process.cwd().
+     */
+    readonly cwd: string;
+    readonly model?: string;
+    readonly provider?: string;
+    readonly profile?: string;
+    /** Absolute explicit config layer selected by the invoking client. */
+    readonly configPath?: string;
+    /** Additional working directories selected by repeated CLI flags. */
+    readonly addDirs?: readonly string[];
+    readonly instructions?: string;
+    readonly initialContent?: MessageContent;
+    /**
+     * Provision a live daemon session without submitting an initial model turn.
+     *
+     * Startup hooks and ordinary Agent side effects remain deferred until the
+     * first non-Editor message arrives. This is used by the cold Editor
+     * prediction path, which needs the selected provider/model but must not
+     * manufacture a user turn or start tool-bearing background services.
+     */
+    readonly deferInitialTurn?: boolean;
+    /**
+     * Transcript-facing text for the atomic first turn. `undefined` renders
+     * `initialContent`, while `null` suppresses the initial user-message row.
+     *
+     * This is an explicit agent.create field rather than opaque metadata because
+     * the daemon must validate it before the first model turn is admitted.
+     */
+    readonly initialDisplayUserMessage?: string | null;
+    /**
+     * Trusted policy and immutable buffer identity for an Editor-originated
+     * atomic first turn. The daemon validates this before starting the agent and
+     * carries it into the first runTurn exactly as message.stream does later.
+     */
+    readonly initialEditorInteraction?: EditorInteractionParams;
+    readonly unattendedAllow?: readonly string[];
+    readonly unattendedDeny?: readonly string[];
+    readonly metadata?: JsonObject;
+    /**
+     * Session-wide permission mode override for the spawned agent. When
+     * set, the daemon-side bootstrap honors this in place of the project-
+     * trust default. Used by `agenc --dangerously-bypass-approvals-and-sandbox`, which sends
+     * `permissionMode: "bypassPermissions"` so the spawned agent's session
+     * approvalPolicy resolves to `"never"` regardless of project trust.
+     * Without this, --dangerously-bypass-approvals-and-sandbox only affected the local CLI bootstrap and was
+     * dropped on the wire to the daemon.
+     */
+    readonly permissionMode?: "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "auto";
+    /** Immutable operator policy resolved by the creating client. */
+    readonly runtimeOptions: AgentRuntimeOptionsParams;
+    /**
+     * Per-invocation environment overrides for the spawned agent. Used by
+     * the TUI to propagate `OPENAI_BASE_URL` (and similar provider-config
+     * env vars) from the CLI's process env into the daemon-owned agent —
+     * without this, the daemon's runner uses the frozen env snapshot
+     * captured at daemon-start time, so subsequent CLI invocations with
+     * different env vars silently use the original values.
+     *
+     * Only string values are forwarded. Keys collected from a curated
+     * allow-list (provider URLs, API keys, proxy settings) to avoid
+     * leaking unrelated env into agent processes. Empty strings are explicit
+     * clear markers so an unset client value cannot inherit stale daemon-start
+     * provider/config state.
+     */
+    readonly envOverrides?: {
+        readonly [key: string]: string;
+    };
+}
+
+export interface AgentListParams extends JsonObject {
+    readonly cursor?: string;
+    readonly limit?: number;
+}
+
+export interface AgentAttachParams extends JsonObject {
+    readonly agentId: string;
+    readonly clientId?: string;
+}
+
+export interface AgentStopParams extends JsonObject {
+    readonly agentId: string;
+    readonly reason?: string;
+}
+
+export interface AgentLogsParams extends JsonObject {
+    readonly agentId: string;
+}
+
+export interface RunStatusParams extends JsonObject {
+    readonly runId: string;
+}
+
+export interface RunResultParams extends JsonObject {
+    readonly runId: string;
+}
+
+export interface RunReplayParams extends JsonObject {
+    readonly runId: string;
+    /** Replay journal events strictly after this database-global sequence. */
+    readonly afterSequence?: number;
+    /** Defaults to 100; the daemon rejects values above 200. */
+    readonly limit?: number;
+}
+
+export interface RunEvidenceParams extends JsonObject {
+    readonly runId: string;
+    /** Evidence journal events strictly after this database-global sequence. */
+    readonly afterSequence?: number;
+    /** Defaults to 100; the daemon rejects values above 200. */
+    readonly limit?: number;
+}
+
+export interface RunCancelParams extends JsonObject {
+    /** Root run id (= root agent id, the agent_runs primary key). */
+    readonly runId: string;
+    readonly reason?: string;
+}
+
+/** One required verification command for a verified-change workflow run. */
+export interface RunStartVerificationCommand extends JsonObject {
+    readonly label: string;
+    readonly script: string;
+}
+
+export interface RunStartParams extends JsonObject {
+    /** The engineering goal / issue text driving the change. */
+    readonly goal: string;
+    /** Absolute directory inside the target git repository (daemon cwd default). */
+    readonly cwd?: string;
+    readonly model?: string;
+    readonly provider?: string;
+    /** Reviewer configuration pinned into the frozen spec at intake. */
+    readonly reviewerModel?: string;
+    readonly maxCostUsd?: number;
+    readonly maxTokens?: number;
+    readonly deadlineAt?: string;
+    readonly permissionMode?: "default" | "plan" | "acceptEdits" | "bypassPermissions";
+    readonly unattendedAllow?: readonly string[];
+    readonly unattendedDeny?: readonly string[];
+    /** Required verification commands; the workflow demands at least one. */
+    readonly requiredVerification?: readonly RunStartVerificationCommand[];
+    readonly maxImplementAttempts?: number;
+}
+
+export interface CsvJobReviewListParams extends JsonObject {
+    /** Absolute workspace root selecting the durable project database. */
+    readonly cwd: string;
+    readonly jobId: string;
+    /** Opaque cursor returned by the preceding page. */
+    readonly cursor?: string;
+    /** Bounded page size; the durable CSV contract permits 1..100. */
+    readonly limit?: number;
+}
+
+export interface CsvJobReviewShowParams extends JsonObject {
+    readonly cwd: string;
+    readonly jobId: string;
+    readonly itemId: string;
+}
+
+export type CsvJobReviewDisposition = "confirmed_committed" | "confirmed_no_effect" | "remains_unknown";
+
+export interface CsvJobReviewResolveParams extends JsonObject {
+    readonly cwd: string;
+    readonly jobId: string;
+    readonly itemId: string;
+    readonly disposition: CsvJobReviewDisposition;
+    readonly evidenceRef: string;
+    /** Lowercase SHA-256 digest of the operator's external evidence. */
+    readonly evidenceSha256: string;
+    readonly reviewer: string;
+    readonly reason: string;
+    /** Optional recovered result; valid only for confirmed_committed. */
+    readonly result?: JsonObject;
+}
+
+export interface SessionCreateParams extends JsonObject {
+    readonly agentId?: string;
+    /**
+     * Absolute workspace directory. Required (DAE-02) for new sessions.
+     */
+    readonly cwd: string;
+    readonly initialPrompt?: string;
+    readonly metadata?: JsonObject;
+}
+
+export interface SessionListParams extends JsonObject {
+    readonly agentId?: string;
+    readonly cursor?: string;
+    readonly limit?: number;
+}
+
+export interface SessionAttachParams extends JsonObject {
+    readonly sessionId: string;
+    readonly clientId?: string;
+}
+
+export interface SessionDetachParams extends JsonObject {
+    readonly sessionId: string;
+    readonly attachmentId?: string;
+    readonly clientId?: string;
+}
+
+export interface SessionTerminateParams extends JsonObject {
+    readonly sessionId: string;
+    readonly reason?: string;
+}
+
+export interface SessionClearParams extends JsonObject {
+    readonly sessionId: string;
+}
+
+export interface SessionSnapshotParams extends JsonObject {
+    readonly sessionId: string;
+}
+
+export interface SessionTranscriptParams extends JsonObject {
+    readonly sessionId: string;
+}
+
+export interface SessionTranscriptV2Params extends JsonObject {
+    readonly sessionId: string;
+}
+
+export interface SessionCancelTurnParams extends JsonObject {
+    readonly sessionId: string;
+    readonly reason?: string;
+    /** Cancel only when this exact turn is still active. */
+    readonly expectedTurnId?: string;
+}
+
+/**
+ * Protocol-1.0 compatibility request shipped with agenc-sdk 0.3.0.
+ *
+ * This shape may resolve only legacy poisoned rows that have no canonical
+ * durable effect. Durable effect records always require explicit evidence.
+ */
+export interface SessionResolveToolCallLegacyParams extends JsonObject {
+    readonly sessionId: string;
+    /** When omitted, review every eligible legacy effect in the session. */
+    readonly toolCallId?: string;
+    readonly reviewer?: string;
+    readonly disposition?: never;
+    readonly evidenceRef?: never;
+    readonly evidenceSha256?: never;
+}
+
+/** Evidence-bearing resolution required for every durable effect record. */
+export interface SessionResolveToolCallEvidenceParams extends JsonObject {
+    readonly sessionId: string;
+    readonly toolCallId: string;
+    readonly disposition: "confirmed_committed" | "confirmed_no_effect" | "remains_unknown";
+    readonly evidenceRef: string;
+    readonly evidenceSha256: string;
+    readonly reviewer?: string;
+}
+
+export type SessionResolveToolCallParams = SessionResolveToolCallLegacyParams | SessionResolveToolCallEvidenceParams;
+
+export interface SessionMcpStatusParams extends JsonObject {
+    readonly sessionId: string;
+}
+
+export interface SessionMcpServerConfig extends JsonObject {
+    readonly name: string;
+    readonly transport?: "stdio" | "sse" | "http" | "websocket";
+    readonly command?: string;
+    readonly args?: readonly string[];
+    readonly endpoint?: string;
+    readonly enabled?: boolean;
+    readonly required?: boolean;
+}
+
+export interface SessionMcpAddServerParams extends JsonObject {
+    readonly sessionId: string;
+    readonly config: SessionMcpServerConfig;
+}
+
+export interface MessageSendParams extends JsonObject {
+    readonly sessionId: string;
+    readonly content: MessageContent;
+    readonly clientMessageId?: string;
+    /** Opt in to fail-fast admission instead of the legacy session queue. */
+    readonly ifBusy?: "reject";
+    readonly metadata?: JsonObject;
+}
+
+export interface MessageStreamParams extends MessageSendParams {
+    readonly streamId?: string;
+}
+
+export interface ThreadRealtimeWebsocketTransport extends JsonObject {
+    readonly type: "websocket";
+}
+
+export interface ThreadRealtimeWebrtcTransport extends JsonObject {
+    readonly type: "webrtc";
+    readonly sdp: string;
+}
+
+export type ThreadRealtimeStartTransport = ThreadRealtimeWebsocketTransport | ThreadRealtimeWebrtcTransport;
+
+export type ThreadRealtimeOutputModality = "audio" | "text";
+
+export type ThreadRealtimeVoice = "alloy" | "arbor" | "ash" | "ballad" | "breeze" | "cedar" | "coral" | "cove" | "echo" | "ember" | "juniper" | "maple" | "marin" | "sage" | "shimmer" | "sol" | "spruce" | "vale" | "verse";
+
+export interface ThreadRealtimeStartParams extends JsonObject {
+    readonly threadId: string;
+    readonly transport?: ThreadRealtimeStartTransport | null;
+    readonly realtimeSessionId?: string | null;
+    readonly prompt?: string | null;
+    readonly outputModality: ThreadRealtimeOutputModality;
+    readonly voice?: ThreadRealtimeVoice | null;
+}
+
+export interface ThreadRealtimeAudioChunk extends JsonObject {
+    readonly data: string;
+    readonly sampleRate: number;
+    readonly numChannels: number;
+    readonly samplesPerChannel?: number | null;
+    readonly itemId?: string | null;
+}
+
+export interface ThreadRealtimeAppendAudioParams extends JsonObject {
+    readonly threadId: string;
+    readonly audio: ThreadRealtimeAudioChunk;
+}
+
+export interface ThreadRealtimeAppendTextParams extends JsonObject {
+    readonly threadId: string;
+    readonly text: string;
+}
+
+export interface ThreadRealtimeStopParams extends JsonObject {
+    readonly threadId: string;
+}
+
+export interface ExitPlanApprovalPayload extends JsonObject {
+    readonly action: "approve" | "revise";
+    readonly mode?: "acceptEdits" | "default";
+    readonly applyAllowedPrompts?: boolean;
+    readonly clearContext?: boolean;
+    readonly feedback?: string;
+}
+
+export interface ToolApproveParams extends JsonObject {
+    readonly sessionId: string;
+    readonly requestId: string;
+    readonly scope?: "once" | "session" | "agent";
+    /** Opt in to bypassing future tool prompts for this daemon session only. */
+    readonly allowAllToolsForSession?: boolean;
+    readonly exitPlan?: ExitPlanApprovalPayload;
+}
+
+export interface ToolDenyParams extends JsonObject {
+    readonly sessionId: string;
+    readonly requestId: string;
+    readonly reason?: string;
+}
+
+export interface ToolCancelParams extends JsonObject {
+    readonly sessionId: string;
+    readonly requestId: string;
+    readonly reason?: string;
+}
+
+export interface ElicitationRespondParams extends JsonObject {
+    readonly sessionId: string;
+    readonly requestId: RequestId;
+    readonly kind: "request_user_input" | "mcp";
+    readonly serverName?: string;
+    readonly response: JsonObject;
+}
+
+export interface PermissionListParams extends JsonObject {
+    readonly agentId?: string;
+    readonly sessionId?: string;
+}
+
+export interface FuzzyFileSearchParams extends JsonObject {
+    readonly query: string;
+    readonly roots: readonly string[];
+    readonly cancellationToken?: string | null;
+    /** Maximum number of results to return. The daemon accepts 1 through 1,000. */
+    readonly limit?: number;
+    /** Rebuild the persistent index before evaluating the query. */
+    readonly refresh?: boolean;
+}
+
+export type CommandExecEnv = Readonly<Record<string, string | null>>;
+
+export interface CommandExecTerminalSize extends JsonObject {
+    readonly rows: number;
+    readonly cols: number;
+}
+
+interface CommandExecStartBase extends JsonObject {
+    readonly command: readonly string[];
+    readonly processId?: string | null;
+    readonly tty?: boolean;
+    readonly streamStdin?: boolean;
+    readonly streamStdoutStderr?: boolean;
+    readonly outputBytesCap?: number | null;
+    readonly disableOutputCap?: boolean;
+    readonly disableTimeout?: boolean;
+    readonly timeoutMs?: number | null;
+    readonly cwd?: string | null;
+    readonly env?: CommandExecEnv | null;
+    readonly size?: CommandExecTerminalSize | null;
+}
+
+export type CommandExecStartParams = CommandExecStartBase & ({
+    readonly permissionProfile: string;
+    readonly sandboxPolicy?: null;
+} | {
+    readonly sandboxPolicy: JsonObject;
+    readonly permissionProfile?: null;
+});
+
+export interface CommandExecWriteParams extends JsonObject {
+    readonly processId: string;
+    readonly deltaBase64?: string | null;
+    readonly closeStdin?: boolean;
+}
+
+export interface CommandExecResizeParams extends JsonObject {
+    readonly processId: string;
+    readonly size: CommandExecTerminalSize;
+}
+
+export interface CommandExecTerminateParams extends JsonObject {
+    readonly processId: string;
+}
+
+export interface DaemonShutdownParams extends JsonObject {
+    readonly instanceId: string;
+}
+
+export type AgenCDaemonRequest = AgenCDaemonRequestWithParams<"telegram.capabilities" | "telegram.status" | "telegram.configure" | "telegram.start" | "telegram.stop" | "telegram.revoke", JsonObject> | AgenCDaemonRequestWithParams<"telegram.agents.list" | "telegram.agents.create" | "telegram.agents.update" | "telegram.agents.start" | "telegram.agents.stop" | "telegram.agents.remove" | "telegram.agents.pair.begin" | "telegram.agents.pair.confirm" | "telegram.agents.pair.cancel", JsonObject> | AgenCDaemonRequestWithParams<"remote.capabilities" | "remote.status" | "remote.start" | "remote.stop" | "remote.pair.begin" | "remote.pair.refresh" | "remote.pair.cancel" | "remote.devices" | "remote.pending" | "remote.approve" | "remote.revoke", JsonObject> | AgenCDaemonRequestWithoutParams<"routine.capabilities"> | AgenCDaemonRequestWithoutParams<"routine.list"> | AgenCDaemonRequestWithParams<"routine.get", RoutineIdParams> | AgenCDaemonRequestWithParams<"routine.create", RoutineCreateParams> | AgenCDaemonRequestWithParams<"routine.update", RoutineUpdateParams> | AgenCDaemonRequestWithParams<"routine.delete", RoutineDeleteParams> | AgenCDaemonRequestWithParams<"routine.run", RoutineIdParams> | AgenCDaemonRequestWithParams<"routine.runs", RoutineRunsParams> | AgenCDaemonRequestWithParams<"routine.cancel", RoutineCancelParams> | AgenCDaemonRequestWithParams<"initialize", InitializeParams> | AgenCDaemonRequestWithParams<"request.cancel", RequestCancelParams> | AgenCDaemonRequestWithParams<"agent.create", AgentCreateParams> | AgenCDaemonRequestWithParams<"agent.list", AgentListParams> | AgenCDaemonRequestWithParams<"agent.attach", AgentAttachParams> | AgenCDaemonRequestWithParams<"agent.stop", AgentStopParams> | AgenCDaemonRequestWithParams<"agent.logs", AgentLogsParams> | AgenCDaemonRequestWithParams<"run.status", RunStatusParams> | AgenCDaemonRequestWithParams<"run.result", RunResultParams> | AgenCDaemonRequestWithParams<"run.replay", RunReplayParams> | AgenCDaemonRequestWithParams<"run.evidence", RunEvidenceParams> | AgenCDaemonRequestWithParams<"run.cancel", RunCancelParams> | AgenCDaemonRequestWithParams<"run.start", RunStartParams> | AgenCDaemonRequestWithParams<"csvJob.review.list", CsvJobReviewListParams> | AgenCDaemonRequestWithParams<"csvJob.review.show", CsvJobReviewShowParams> | AgenCDaemonRequestWithParams<"csvJob.review.resolve", CsvJobReviewResolveParams> | AgenCDaemonRequestWithParams<"session.create", SessionCreateParams> | AgenCDaemonRequestWithParams<"session.list", SessionListParams> | AgenCDaemonRequestWithParams<"session.attach", SessionAttachParams> | AgenCDaemonRequestWithParams<"session.detach", SessionDetachParams> | AgenCDaemonRequestWithParams<"session.terminate", SessionTerminateParams> | AgenCDaemonRequestWithParams<"session.clear", SessionClearParams> | AgenCDaemonRequestWithParams<"session.snapshot", SessionSnapshotParams> | AgenCDaemonRequestWithParams<"session.transcript", SessionTranscriptParams> | AgenCDaemonRequestWithParams<"session.transcript.v2", SessionTranscriptV2Params> | AgenCDaemonRequestWithParams<"session.cancelTurn", SessionCancelTurnParams> | AgenCDaemonRequestWithParams<"session.resolveToolCall", SessionResolveToolCallParams> | AgenCDaemonRequestWithParams<"session.mcp.status", SessionMcpStatusParams> | AgenCDaemonRequestWithParams<"session.mcp.addServer", SessionMcpAddServerParams> | AgenCDaemonRequestWithParams<"message.send", MessageSendParams> | AgenCDaemonRequestWithParams<"message.stream", MessageStreamParams> | AgenCDaemonRequestWithParams<"thread/realtime/start", ThreadRealtimeStartParams> | AgenCDaemonRequestWithParams<"thread/realtime/appendAudio", ThreadRealtimeAppendAudioParams> | AgenCDaemonRequestWithParams<"thread/realtime/appendText", ThreadRealtimeAppendTextParams> | AgenCDaemonRequestWithParams<"thread/realtime/stop", ThreadRealtimeStopParams> | AgenCDaemonRequestWithoutParams<"thread/realtime/listVoices"> | AgenCDaemonRequestWithParams<"tool.approve", ToolApproveParams> | AgenCDaemonRequestWithParams<"tool.deny", ToolDenyParams> | AgenCDaemonRequestWithParams<"tool.cancel", ToolCancelParams> | AgenCDaemonRequestWithParams<"elicitation.respond", ElicitationRespondParams> | AgenCDaemonRequestWithParams<"permission.list", PermissionListParams> | AgenCDaemonRequestWithParams<"fs.fuzzy_search", FuzzyFileSearchParams> | AgenCDaemonRequestWithParams<"commandExec.start", CommandExecStartParams> | AgenCDaemonRequestWithParams<"commandExec.write", CommandExecWriteParams> | AgenCDaemonRequestWithParams<"commandExec.resize", CommandExecResizeParams> | AgenCDaemonRequestWithParams<"commandExec.terminate", CommandExecTerminateParams> | AgenCDaemonRequestWithoutParams<"health.ping"> | AgenCDaemonRequestWithoutParams<"health.ready"> | AgenCDaemonRequestWithoutParams<"health.stats"> | AgenCDaemonRequestWithoutParams<"daemon.reload"> | AgenCDaemonRequestWithParams<"daemon.shutdown", DaemonShutdownParams> | AgenCDaemonRequestWithoutParams<"auth.login"> | AgenCDaemonRequestWithoutParams<"auth.whoami"> | AgenCDaemonRequestWithoutParams<"auth.logout">;
+
+export const AGENC_DAEMON_METHOD_CAPABILITIES_KEY = "daemon.methods" as const;
+
+export const AGENC_DAEMON_INTERNAL_METHODS = [
+    "workspace.editor.acquire",
+    "workspace.editor.sync",
+    "workspace.editor.staleAuthority.refresh",
+    "workspace.editor.heartbeat",
+    "workspace.editor.release",
+    "workspace.editor.topology.reserve",
+    "workspace.editor.topology.complete",
+    "workspace.editor.topology.release",
+    "workspace.editor.topology.recovered.list",
+    "workspace.editor.topology.recovered.resolve",
+    "workspace.editor.proposal.get",
+    "workspace.editor.proposal.status",
+    "workspace.editor.proposal.apply",
+    "workspace.editor.proposal.discard",
+    "workspace.editor.changes.list",
+    "workspace.editor.predict",
+    "workspace.editor.cancelPrediction",
+    "workspace.editor.predictionFeedback",
+    "session.partialCompactFromMessage",
+    "session.rollbackCompaction",
+    "session.extendCompactionRollbackRetention",
+    "session.rewindConversationToMessage",
+    "session.previewFileRewind",
+    "session.rewindFilesToMessage",
+    "session.shell.execute",
+    "session.setModel",
+    "session.setPermissionMode",
+    "session.permissions.mutateRule",
+    "session.hooks.status",
+    "session.hooks.setDisabled",
+    "session.applyConfig",
+    "session.mcp.reconnectServer",
+    "session.mcp.enableServer",
+    "session.mcp.disableServer",
+] as const;
+
+export type AgenCDaemonInternalMethod = (typeof AGENC_DAEMON_INTERNAL_METHODS)[number];
+
+export type AgenCDaemonKnownMethod = AgenCDaemonMethod | AgenCDaemonInternalMethod;
+
+export type AgenCDaemonMethodCapabilities = JsonObject & {
+    readonly [Method in AgenCDaemonKnownMethod]: boolean;
+};
+
+export type AgenCDaemonServerCapabilities = JsonObject & {
+    readonly [AGENC_DAEMON_METHOD_CAPABILITIES_KEY]: AgenCDaemonMethodCapabilities;
+};
+
+export interface DaemonInstanceIdentity extends JsonObject {
+    readonly pid: number;
+    readonly instanceId: string;
+    readonly processStart: string;
+    readonly runtimeVersion: string;
+    readonly commit: string;
+    readonly buildTime: string;
+}
+
+export interface InitializeResult extends JsonObject {
+    readonly type: "initialized";
+    /**
+     * Compatibility mirror of `protocol.version` for older daemon clients.
+     */
+    readonly protocolVersion: string;
+    /**
+     * Negotiated server protocol metadata for the connection.
+     */
+    readonly protocol: DaemonProtocolInfo;
+    readonly capabilities: AgenCDaemonServerCapabilities;
+    /** Present on the real daemon and bound to this authenticated connection. */
+    readonly daemonIdentity?: DaemonInstanceIdentity;
+}
+
+export interface RequestCancelResult extends JsonObject {
+    readonly requestId: RequestId;
+    readonly cancelled: boolean;
+    readonly reason?: string;
+}
+
+export type AgentStatus = "idle" | "running" | "stopping" | "stopped" | "error";
+
+export interface AgentSummary extends JsonObject {
+    readonly agentId: string;
+    readonly agentPath?: string;
+    readonly objective?: string;
+    readonly status: AgentStatus;
+    readonly createdAt: string;
+    readonly startedAt?: string;
+    readonly lastActiveAt?: string;
+    readonly cwd?: string;
+    readonly activeSessionIds?: readonly string[];
+    readonly metadata?: JsonObject;
+}
+
+export interface AgentCreateResult extends AgentSummary {
+    readonly sessionId?: string;
+}
+
+export interface AgentListResult extends JsonObject {
+    readonly agents: readonly AgentSummary[];
+    readonly nextCursor?: string;
+}
+
+/**
+ * Canonical permission modes that may govern a root daemon session. `bubble`
+ * is deliberately excluded: it is child-only authority and must never be
+ * revived onto a recovered root run.
+ */
+export const RUN_RUNTIME_PERMISSION_MODES = [
+    "default",
+    "plan",
+    "acceptEdits",
+    "bypassPermissions",
+    "dontAsk",
+    "auto",
+    "unattended",
+] as const;
+
+export type RunRuntimePermissionMode = (typeof RUN_RUNTIME_PERMISSION_MODES)[number];
+
+export const RUN_RUNTIME_REASONING_EFFORTS = [
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "none",
+] as const;
+
+export type RunRuntimeReasoningEffort = (typeof RUN_RUNTIME_REASONING_EFFORTS)[number];
+
+export const RUN_RUNTIME_MODEL_VERBOSITIES = ["low", "medium", "high"] as const;
+
+export type RunRuntimeModelVerbosity = (typeof RUN_RUNTIME_MODEL_VERBOSITIES)[number];
+
+export const RUN_RUNTIME_SERVICE_TIERS = ["priority", "flex"] as const;
+
+export type RunRuntimeServiceTier = (typeof RUN_RUNTIME_SERVICE_TIERS)[number];
+
+/**
+ * Complete desired session overlay. It intentionally omits permission rules:
+ * those are recomputed from current trusted policy on recovery. A bypass
+ * authorization and availability are daemon-owned. Any retained bypass
+ * consent is bound to the exact canonical workspace spelling.
+ */
+export interface RunRuntimeSettingsSnapshot {
+    readonly permissionMode: RunRuntimePermissionMode;
+    readonly prePlanMode: RunRuntimePermissionMode | null;
+    readonly autoModeActive: boolean;
+    readonly autoModeAvailable: boolean;
+    readonly bypassPermissionsModeAvailable: boolean;
+    readonly bypassPermissionsWorkspace: string | null;
+    readonly bypassPermissionsConsentWorkspace: string | null;
+    readonly model: string;
+    readonly provider: string;
+    readonly profile: string | null;
+    readonly reasoningEffort: RunRuntimeReasoningEffort | null;
+    readonly modelVerbosity: RunRuntimeModelVerbosity | null;
+    readonly serviceTier: RunRuntimeServiceTier | null;
+    readonly hooksDisabled: boolean;
+}
+
+export type SessionStatus = "idle" | "running" | "waiting" | "closed" | "error";
+
+export interface SessionSummary extends JsonObject {
+    readonly sessionId: string;
+    readonly agentId: string;
+    readonly status: SessionStatus;
+    readonly createdAt: string;
+    readonly cwd?: string;
+    /** Immutable role-discovery authority; execution cwd may be a worktree. */
+    readonly roleWorkspace?: {
+        readonly id: string;
+        readonly cwd: string;
+    };
+    readonly metadata?: JsonObject;
+    readonly activeAttachmentIds?: readonly string[];
+    readonly closedAt?: string;
+}
+
+export interface AgentAttachSessionSummary extends SessionSummary {
+    readonly cwd: string;
+}
+
+export interface AgentAttachResult extends JsonObject {
+    readonly agentId: string;
+    readonly attachmentId: string;
+    readonly sessionIds: readonly string[];
+    /** Immutable operator authority owned by the attached daemon session. */
+    readonly runtimeOptions: AgentRuntimeOptionsParams;
+    /** Live daemon-owned session settings; static session metadata is not authority. */
+    readonly runtimeSettings: RunRuntimeSettingsSnapshot & JsonObject;
+    /** Canonical settings event hydrated by this response. */
+    readonly runtimeSettingsEventId: string;
+    readonly runtimeSessionId?: string;
+    readonly sessions: readonly AgentAttachSessionSummary[];
+}
+
+export interface AgentStopResult extends JsonObject {
+    readonly agentId: string;
+    readonly stopped: boolean;
+}
+
+export interface AgentLogSession extends JsonObject {
+    readonly sessionId: string;
+    readonly itemCount: number;
+    readonly transcript: string;
+    readonly rolloutPath?: string;
+    readonly source?: string;
+}
+
+export interface AgentToolOutputLog extends JsonObject {
+    readonly sessionId: string;
+    readonly toolCallId: string;
+    readonly toolName: string;
+    readonly status: string;
+    readonly output: string;
+    readonly outputBytes: number;
+    readonly outputLogPath?: string;
+    readonly outputLogBytes?: number;
+}
+
+export interface AgentLogsResult extends JsonObject {
+    readonly agentId: string;
+    readonly transcript: string;
+    readonly sessions: readonly AgentLogSession[];
+    readonly toolOutputs?: readonly AgentToolOutputLog[];
+}
+
+export interface RunDurableRecord extends JsonObject {
+    readonly objective: string;
+    readonly status: string;
+    readonly startedAt: string;
+    readonly lastActiveAt: string;
+    readonly currentSessionId?: string;
+    readonly createdByClient?: string;
+    readonly lastSnapshotAt?: string;
+    readonly metadata?: JsonObject;
+}
+
+export type RunAdmissionAggregateStatus = "none" | "queued" | "running" | "approval_required" | "reconciled" | "voided" | "held_unknown" | "provider_overrun" | "denied" | "cancelled" | "terminal_mixed";
+
+export interface RunAdmissionSourceAvailability extends JsonObject {
+    readonly jobs: boolean;
+    readonly reservations: boolean;
+    readonly allocations: boolean;
+    readonly journal: boolean;
+}
+
+export interface RunAdmissionSummary extends JsonObject {
+    readonly present: boolean;
+    readonly currentStatus: RunAdmissionAggregateStatus;
+    readonly active: boolean;
+    readonly stepCount: number;
+    readonly stepStatusCounts: Readonly<Record<string, number>>;
+    readonly reservationCount: number;
+    readonly reservationStatusCounts: Readonly<Record<string, number>>;
+    readonly openReservationCount: number;
+    readonly reservedTokens: number;
+    readonly reservedCostUsd: number;
+    readonly actualTokens: number;
+    readonly actualCostUsd: number;
+    readonly unpricedActualReservationCount: number;
+    readonly allocationCount: number;
+    readonly usedTokens: number;
+    readonly heldTokens: number;
+    readonly usedCostUsd: number;
+    readonly heldCostUsd: number;
+    readonly providerOverrunBlockedAllocationCount: number;
+    readonly fallbackCount: number;
+    readonly sources: RunAdmissionSourceAvailability;
+    readonly updatedAt?: string;
+}
+
+export interface RunStateSource extends JsonObject {
+    readonly kind: "existing_state_database";
+    readonly projectDir: string;
+    readonly readonly: true;
+}
+
+export type RunWorkflowStepStatus = "pending" | "running" | "committed" | "failed" | "cancelled" | "unknown_outcome" | "blocked";
+
+/** JSON-serializable mirror of a workflow step's content-addressed artifact. */
+export interface RunWorkflowArtifactPointer extends JsonObject {
+    readonly step: {
+        readonly runId: string;
+        readonly stepId: string;
+        readonly parentRunId?: string;
+    };
+    readonly role: string;
+    readonly digest: string;
+    readonly bytes: number;
+    readonly storagePath: string;
+    readonly recordedAt: string;
+}
+
+export interface RunWorkflowStatusStep extends JsonObject {
+    readonly stepId: string;
+    readonly stage: string;
+    readonly status: RunWorkflowStepStatus;
+    readonly attempts: number;
+    readonly verdict?: string;
+    readonly artifacts?: readonly RunWorkflowArtifactPointer[];
+}
+
+/**
+ * M5 verified-change workflow projection, present on `run.status` only for
+ * runs that recorded workflow steps (additive; derived read-only from
+ * durable `run_effects` rows).
+ */
+export interface RunWorkflowStatus extends JsonObject {
+    readonly steps: readonly RunWorkflowStatusStep[];
+    /** Present when the run terminated with a frozen workflow stop reason. */
+    readonly stopReason?: string;
+}
+
+export interface RunStatusResult extends JsonObject {
+    readonly runId: string;
+    readonly status: string;
+    /** Terminal is true only for the current lifecycle epoch. */
+    readonly terminal: boolean;
+    readonly statusSource: "run_terminal_result" | "run_lifecycle_epoch" | "agent_run" | "admission_state";
+    readonly durableRun?: RunDurableRecord;
+    readonly admission: RunAdmissionSummary;
+    readonly source: RunStateSource;
+    /** M5 workflow projection; present only for verified-change workflow runs. */
+    readonly workflow?: RunWorkflowStatus;
+}
+
+export type RunTerminalOutcome = "completed" | "failed" | "cancelled" | "stopped" | "unknown_outcome";
+
+export interface RunUsageTotals extends JsonObject {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly totalTokens: number;
+    readonly costUsd: number;
+    /** False when historical coverage or model pricing is incomplete. */
+    readonly costKnown?: boolean;
+}
+
+/** Terminal output committed by M4 and readable after disconnect/restart. */
+export interface RunTerminalPersistedOutput extends JsonObject {
+    readonly available: true;
+    readonly exitCode: number | null;
+    readonly stopReason: string | null;
+    readonly finalMessage: string | null;
+    readonly usage: RunUsageTotals | null;
+    readonly lastSequence: number | null;
+}
+
+export interface RunTerminalOutputAvailability extends JsonObject {
+    readonly available: false;
+    readonly reason: "terminal_output_not_persisted_in_existing_state";
+}
+
+export interface RunResultResult extends JsonObject {
+    readonly runId: string;
+    readonly status: string;
+    readonly terminal: true;
+    readonly terminalAt: string;
+    readonly outcome: RunTerminalOutcome;
+    readonly epoch?: number;
+    readonly durableRun?: RunDurableRecord;
+    readonly output: RunTerminalPersistedOutput | RunTerminalOutputAvailability;
+    readonly source: RunStateSource;
+}
+
+export type RunJournalCategory = "run" | "step" | "admission" | "budget" | "permission" | "approval" | "effect" | "model" | "artifact" | "cancellation" | "recovery" | "terminal" | "session";
+
+/** One canonical rollout event, preserving its existing id and sequence. */
+export interface RunJournalEvent extends JsonObject {
+    readonly sequence: number;
+    readonly eventId: string;
+    readonly timestamp?: string;
+    readonly runId: string;
+    readonly childRunId?: string;
+    readonly sessionId?: string;
+    readonly stepId?: string;
+    readonly category: RunJournalCategory;
+    readonly kind: string;
+    readonly event: string;
+    readonly payload?: JsonValue;
+    readonly reason?: string;
+    readonly reservationId?: string;
+    readonly model?: string;
+    readonly provider?: string;
+    readonly reservedTokens?: number;
+    readonly reservedCostUsd?: number;
+    readonly actualTokens?: number;
+    readonly actualCostUsd?: number;
+    readonly details?: JsonObject;
+}
+
+export interface RunReplaySourceUnavailableGap extends JsonObject {
+    readonly kind: "source_unavailable";
+    readonly reason: "execution_admission_journal_not_present" | "run_journal_not_present";
+}
+
+export interface RunReplayRetentionGap extends JsonObject {
+    readonly kind: "event_gap";
+    readonly runId: string;
+    readonly afterSequence: number;
+    readonly firstAvailableSequence: number;
+    readonly reason: "retention" | "corruption_truncated" | "compaction";
+}
+
+/** The caller cursor names events beyond the canonical journal tail. */
+export interface RunReplayCursorAheadGap extends JsonObject {
+    readonly kind: "cursor_ahead";
+    readonly runId: string;
+    readonly afterSequence: number;
+    readonly lastAvailableSequence: number;
+    readonly reason: "cursor_ahead";
+}
+
+export type RunReplayGap = RunReplaySourceUnavailableGap | RunReplayRetentionGap | RunReplayCursorAheadGap;
+
+export interface RunJournalReplaySource extends JsonObject {
+    readonly kind: "run_journal";
+    readonly available: boolean;
+    readonly sequenceScope: "run";
+    readonly canonical: "rollout_jsonl";
+    readonly projection: "thread_rollout_items";
+    readonly projectDir: string;
+}
+
+export interface RunAdmissionReplaySource extends JsonObject {
+    readonly kind: "execution_admission_journal";
+    readonly available: boolean;
+    readonly sequenceScope: "project_state_database";
+    readonly projectDir: string;
+}
+
+export type RunReplaySource = RunJournalReplaySource | RunAdmissionReplaySource;
+
+export interface RunReplayResult extends JsonObject {
+    readonly runId: string;
+    readonly afterSequence: number;
+    readonly limit: number;
+    readonly events: readonly RunJournalEvent[];
+    readonly hasMore: boolean;
+    /** Pass this value as afterSequence for the next page. */
+    readonly nextAfterSequence: number;
+    readonly firstAvailableSequence?: number;
+    readonly lastAvailableSequence?: number;
+    /** Null means the append-only source was available; unavailable is explicit. */
+    readonly gap: RunReplayGap | null;
+    readonly source: RunReplaySource;
+}
+
+export type RunEvidenceCompleteness = "complete" | "partial" | "admission_source_unavailable" | "journal_gap";
+
+export interface RunEvidenceSource extends JsonObject {
+    readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
+    readonly projectDir: string;
+    readonly admissionJournal: boolean;
+    readonly workflowEvidenceIncluded: boolean;
+    readonly completeness: RunEvidenceCompleteness;
+}
+
+export interface RunEvidenceCursor extends JsonObject {
+    readonly afterSequence: number;
+    readonly nextAfterSequence: number;
+    readonly limit: number;
+}
+
+export interface RunEvidenceEventHash extends JsonObject {
+    readonly sequence: number;
+    readonly eventId: string;
+    readonly sha256: string;
+}
+
+export interface RunEvidenceHashes extends JsonObject {
+    readonly algorithm: "sha256";
+    readonly runStateSha256: string;
+    readonly admissionSummarySha256: string;
+    readonly gapSha256: string;
+    readonly eventHashes: readonly RunEvidenceEventHash[];
+    readonly bundleSha256: string;
+}
+
+/**
+ * M5 evidence-bundle summary for `run.evidence`, present only when the run
+ * has a per-run evidence ledger directory (`<agencHome>/run-evidence/<runId>`).
+ */
+export interface RunEvidenceBundle extends JsonObject {
+    /** Digest of the self-validated verified-change record, when persisted. */
+    readonly recordDigest?: string;
+    readonly sealed: boolean;
+    readonly ledgerPath: string;
+    readonly artifacts: readonly RunWorkflowArtifactPointer[];
+}
+
+export interface RunEvidenceResult extends JsonObject {
+    readonly runId: string;
+    readonly source: RunEvidenceSource;
+    readonly cursor: RunEvidenceCursor;
+    readonly hasMore: boolean;
+    readonly gap: RunReplayGap | null;
+    readonly events: readonly RunJournalEvent[];
+    readonly hashes: RunEvidenceHashes;
+    /** M5 evidence-ledger summary; present only when the run has a ledger dir. */
+    readonly bundle?: RunEvidenceBundle;
+}
+
+export interface RunCancelResult extends JsonObject {
+    readonly runId: string;
+    /** True when the run was already terminal; nothing was written. */
+    readonly alreadyTerminal: boolean;
+    /** Runs moved to `cancelled` by this call (root included). */
+    readonly cancelledRunIds: readonly string[];
+    /** Open spawn edges closed by this call (child thread ids). */
+    readonly closedEdgeChildIds: readonly string[];
+    /** Live agents interrupted as the second, in-memory step. */
+    readonly interruptedLiveAgentIds: readonly string[];
+    /** Open budget holds voided across the cancelled subtree. */
+    readonly voidedHolds: number;
+}
+
+/** Dirty-state summary of the user's checkout captured at workflow intake. */
+export interface RunStartBaseDirty extends JsonObject {
+    readonly dirty: boolean;
+    readonly fileCount: number;
+}
+
+export interface RunStartResult extends JsonObject {
+    readonly runId: string;
+    /** Canonical digest of the frozen WorkflowSpec (the spec's durable identity). */
+    readonly specDigest: string;
+    /** Exact base commit recorded before any work began. */
+    readonly baseCommit: string;
+    readonly baseDirty: RunStartBaseDirty;
+}
+
+export interface RoutineCapabilities extends JsonObject {
+    readonly version: 1;
+    readonly available: true;
+    readonly scheduleKinds: readonly [
+        "manual",
+        "cron"
+    ];
+    readonly permissionModes: readonly [
+        "default",
+        "plan"
+    ];
+    readonly timezone: string;
+    readonly executionMode: "local";
+    readonly maxRoutines: number;
+    readonly maxRunsPerRoutine: number;
+}
+
+export type RoutineRunStatus = "starting" | "running" | "waiting_permission" | "completed" | "failed" | "cancelled" | "interrupted";
+
+export interface RoutineRun extends JsonObject {
+    readonly id: string;
+    readonly routineId: string;
+    readonly status: RoutineRunStatus;
+    readonly trigger: "manual" | "schedule";
+    readonly startedAt: string;
+    readonly finishedAt: string | null;
+    readonly agentId: string | null;
+    readonly sessionId: string | null;
+    readonly coreRunId: string | null;
+    readonly error: string | null;
+}
+
+export interface Routine extends RoutineCreateParams {
+    readonly id: string;
+    readonly description: string;
+    readonly permissionMode: "default" | "plan";
+    readonly enabled: boolean;
+    readonly notifyOnCompletion: boolean;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+    readonly nextRunAt: string | null;
+    readonly lastRun: RoutineRun | null;
+}
+
+export interface RoutineListResult extends JsonObject {
+    readonly routines: readonly Routine[];
+}
+
+export interface RoutineResult extends JsonObject {
+    readonly routine: Routine;
+}
+
+export interface RoutineDeleteResult extends JsonObject {
+    readonly deleted: true;
+}
+
+export interface RoutineRunResult extends JsonObject {
+    readonly run: RoutineRun;
+}
+
+export interface RoutineRunsResult extends JsonObject {
+    readonly runs: readonly RoutineRun[];
+}
+
+export interface CsvJobReviewJobSummary extends JsonObject {
+    readonly contractVersion: 1;
+    readonly jobId: string;
+    readonly status: "pending" | "running" | "completed" | "failed" | "cancelled" | "needs_review" | "finished_with_unknown_outcomes";
+    readonly totalItems: number;
+    readonly pendingItems: number;
+    readonly runningItems: number;
+    readonly completedItems: number;
+    readonly failedItems: number;
+    readonly cancelledItems: number;
+    readonly unknownOutcomeItems: number;
+    readonly reviewPendingItems: number;
+    readonly resultBytes: number;
+    readonly availableResults: number;
+    readonly unavailableAfterReviewResults: number;
+    readonly notProducedResults: number;
+}
+
+export type CsvJobReviewStatus = "pending" | "resolved" | "abandoned";
+
+export type CsvJobReviewDomainAction = "mark_completed" | "retry_new_attempt" | "abandon_item";
+
+export interface CsvJobReviewEvidenceProjection extends JsonObject {
+    readonly bytes: number;
+    readonly sha256: string;
+    readonly truncated: boolean;
+    readonly value?: JsonObject;
+}
+
+export interface CsvJobReviewEffectReference extends JsonObject {
+    readonly runId: string;
+    readonly stepId: string;
+    readonly epoch: number;
+}
+
+export interface CsvJobReviewDetail extends JsonObject {
+    readonly contractVersion: 1;
+    readonly jobId: string;
+    readonly itemId: string;
+    readonly rowIndex: number;
+    readonly sourceId?: string;
+    readonly sourceIdTruncated?: boolean;
+    readonly status: "pending" | "running" | "completed" | "failed" | "cancelled" | "unknown_outcome";
+    readonly attemptCount: number;
+    readonly resultAvailability: "not_produced" | "available" | "unavailable_after_review";
+    readonly resultSizeBytes: number;
+    readonly resultDigest?: string;
+    readonly reviewStatus: CsvJobReviewStatus;
+    readonly reviewReason?: string;
+    readonly reviewReasonTruncated?: boolean;
+    readonly disposition?: CsvJobReviewDisposition;
+    readonly domainAction?: CsvJobReviewDomainAction;
+    readonly evidence?: CsvJobReviewEvidenceProjection;
+    readonly effect?: CsvJobReviewEffectReference;
+    readonly createdAt: number;
+    readonly updatedAt: number;
+    readonly completedAt?: number;
+}
+
+export interface CsvJobReviewItemSummary extends JsonObject {
+    readonly itemId: string;
+    readonly rowIndex: number;
+    readonly sourceId?: string;
+    readonly sourceIdTruncated?: boolean;
+    readonly sourceIdDigest?: string;
+    readonly status: CsvJobReviewDetail["status"];
+    readonly attemptCount: number;
+    readonly resultAvailability: CsvJobReviewDetail["resultAvailability"];
+    readonly resultSizeBytes: number;
+    readonly resultDigest?: string;
+    readonly resultPreviewJson?: string;
+    readonly resultPreviewTruncated?: boolean;
+    readonly lastError?: string;
+    readonly lastErrorTruncated?: boolean;
+    readonly reviewStatus?: CsvJobReviewStatus;
+    readonly reviewReason?: string;
+    readonly reviewReasonTruncated?: boolean;
+}
+
+export interface CsvJobReviewListResult extends JsonObject {
+    readonly contractVersion: 1;
+    readonly job: CsvJobReviewJobSummary;
+    readonly reviews: readonly CsvJobReviewItemSummary[];
+    readonly nextCursor?: string;
+}
+
+export interface CsvJobReviewShowResult extends JsonObject {
+    readonly contractVersion: 1;
+    readonly review: CsvJobReviewDetail;
+}
+
+export interface CsvJobReviewResolveResult extends JsonObject {
+    readonly contractVersion: 1;
+    readonly outcome: "resolved" | "already_resolved";
+    readonly review: CsvJobReviewDetail;
+    readonly job?: CsvJobReviewJobSummary;
+}
+
+export interface SessionCreateResult extends SessionSummary {
+}
+
+export interface SessionListResult extends JsonObject {
+    readonly sessions: readonly SessionSummary[];
+    readonly nextCursor?: string;
+}
+
+export interface SessionAttachResult extends JsonObject {
+    readonly sessionId: string;
+    readonly attachmentId: string;
+    readonly attachedAt: string;
+    readonly clientId?: string;
+    readonly activeAttachmentIds: readonly string[];
+}
+
+export interface SessionDetachResult extends JsonObject {
+    readonly sessionId: string;
+    readonly detached: boolean;
+    readonly attachmentId?: string;
+    readonly remainingAttachmentIds: readonly string[];
+}
+
+export interface SessionTerminateResult extends JsonObject {
+    readonly sessionId: string;
+    readonly terminated: boolean;
+    readonly status: "closed";
+    readonly closedAt: string;
+    readonly reason?: string;
+}
+
+export interface SessionClearResult extends JsonObject {
+    readonly sessionId: string;
+    readonly cleared: true;
+    readonly clearedAt: string;
+}
+
+/** Counters from the daemon-owned in-process session. */
+export interface SessionSnapshotResult extends JsonObject {
+    readonly sessionId: string;
+    /** Number of completed turns recorded in the session's history. */
+    readonly turnCount: number;
+    readonly tokenUsage: {
+        readonly inputTokens: number;
+        readonly outputTokens: number;
+        readonly totalTokens: number;
+        readonly costUsd: number;
+        /** False when historical coverage or model pricing is incomplete. */
+        readonly costKnown?: boolean;
+    };
+    /** Cumulative cache metrics across API calls this session. */
+    readonly cacheStats: {
+        readonly requestCount: number;
+        readonly cacheReadInputTokens: number;
+        readonly cacheCreationInputTokens: number;
+        readonly cacheTotalInputTokens: number;
+        readonly hitRate: number | null;
+    };
+    /**
+     * What actually occupies the context window, by source. A client can
+     * only estimate the conversation; the tool schemas, MCP catalog and
+     * memory files are the daemon's own and were invisible from outside,
+     * which is why a UI showing them had to make numbers up.
+     */
+    readonly contextBreakdown?: {
+        /** Active provider/model whose context window this estimate describes. */
+        readonly provider?: string;
+        readonly model?: string;
+        /** Counts use the runtime's rough estimator rather than provider tokens. */
+        readonly estimated?: boolean;
+        /** The model's real window, so shares are against the truth. */
+        readonly windowTokens: number;
+        readonly messageTokens: number;
+        readonly systemPromptTokens: number;
+        /** Always-loaded built-in tool schemas. */
+        readonly systemToolTokens: number;
+        readonly systemToolCount: number;
+        /** Tool schemas served by MCP servers. */
+        readonly mcpToolTokens: number;
+        readonly mcpToolCount: number;
+        /** Schemas the model can search for but that are not resident. */
+        readonly deferredToolTokens: number;
+        readonly deferredToolCount: number;
+        readonly memoryFileTokens: number;
+        readonly memoryFileCount: number;
+    };
+}
+
+export interface SessionTranscriptMessage extends JsonObject {
+    readonly role: string; // "user" | "assistant"
+    readonly text: string;
+}
+
+export interface SessionTranscriptResult extends JsonObject {
+    readonly sessionId: string;
+    readonly messages: readonly SessionTranscriptMessage[];
+}
+
+export interface SessionTranscriptV2Message extends JsonObject {
+    readonly messageId: string;
+    readonly commitEventId: string;
+    readonly role: "user" | "assistant";
+    readonly text: string;
+    readonly turnId?: string;
+    readonly clientMessageId?: string;
+    /** Zero only for migrated response_item rows that predate event sequencing. */
+    readonly committedSequence: number;
+}
+
+export interface SessionTranscriptV2ActiveTurn extends JsonObject {
+    readonly turnId: string;
+    readonly clientMessageId?: string;
+}
+
+/**
+ * Closed-turn outcome rebuilt from the durable rollout. Timing comes from
+ * the turn's own terminal event and usage from the token_count events it
+ * enclosed, so a reopened or restored session keeps the per-turn rows a
+ * live client would have shown.
+ */
+export interface SessionTranscriptV2TurnResult extends JsonObject {
+    readonly turnId: string;
+    /** Durable sequence of the turn's terminal event; anchors placement. */
+    readonly committedSequence: number;
+    readonly outcome: "completed" | "aborted" | "errored";
+    readonly durationMs?: number;
+    readonly inputTokens?: number;
+    readonly outputTokens?: number;
+    readonly totalTokens?: number;
+    readonly model?: string;
+    readonly provider?: string;
+}
+
+export interface SessionTranscriptV2Result extends JsonObject {
+    readonly schemaVersion: 2;
+    readonly sessionId: string;
+    readonly runId: string;
+    readonly historyEpoch: string;
+    readonly asOfSequence: number;
+    readonly messages: readonly SessionTranscriptV2Message[];
+    readonly activeTurn?: SessionTranscriptV2ActiveTurn;
+    readonly turnResults?: readonly SessionTranscriptV2TurnResult[];
+}
+
+export interface SessionCancelTurnResult extends JsonObject {
+    readonly sessionId: string;
+    /**
+     * `true` when an active turn was found and interrupted; `false` when
+     * no turn was running (idle session). Either response is normal —
+     * idle is not an error.
+     */
+    readonly cancelled: boolean;
+    readonly reason?: string;
+    readonly activeTurnId?: string;
+    readonly stale?: boolean;
+}
+
+export interface SessionResolveToolCallResult extends JsonObject {
+    readonly sessionId: string;
+    readonly resolved: readonly {
+        readonly toolCallId: string;
+        readonly toolName: string;
+        readonly eventId?: string;
+    }[];
+    readonly remaining: number;
+}
+
+export interface SessionMcpStatusServer extends JsonObject {
+    readonly name: string;
+    readonly transport: "stdio" | "sse" | "http" | "websocket";
+    readonly enabled: boolean;
+    readonly required: boolean;
+    readonly state: "connected" | "pending" | "failed" | "disabled" | "needs-auth" | "disconnected";
+    /** Sanitized executable basename or URL origin; never connection authority. */
+    readonly displayTarget?: string;
+    readonly toolCount: number;
+}
+
+export interface SessionMcpStatusTool extends JsonObject {
+    readonly serverName: string;
+    readonly name: string;
+}
+
+/** Passive, serializable projection of the daemon-owned MCP runtime. */
+export interface SessionMcpStatusResult extends JsonObject {
+    readonly sessionId: string;
+    readonly revision: number;
+    readonly servers: readonly SessionMcpStatusServer[];
+    readonly tools: readonly SessionMcpStatusTool[];
+}
+
+export interface SessionMcpAddServerResult extends JsonObject {
+    readonly sessionId: string;
+    readonly serverName: string;
+    readonly success: boolean;
+    readonly toolCount: number;
+    readonly error?: string;
+}
+
+export interface MessageSendTerminalResult extends JsonObject {
+    readonly code: 0 | 1 | 130;
+    readonly message?: string;
+}
+
+export interface MessageSendResult extends JsonObject {
+    readonly messageId: string;
+    readonly acceptedAt: string;
+    readonly disposition?: "started" | "duplicate";
+    /** Present for duplicate submissions so callers never guess crash outcomes. */
+    readonly duplicateState?: "completed" | "incomplete";
+    readonly turnId?: string;
+    readonly terminal?: MessageSendTerminalResult;
+}
+
+export interface MessageStreamResult extends MessageSendResult {
+    readonly streamId: string;
+}
+
+export interface ThreadRealtimeStartResponse extends JsonObject {
+}
+
+export interface ThreadRealtimeAppendAudioResponse extends JsonObject {
+}
+
+export interface ThreadRealtimeAppendTextResponse extends JsonObject {
+}
+
+export interface ThreadRealtimeStopResponse extends JsonObject {
+}
+
+export interface ThreadRealtimeVoicesList extends JsonObject {
+    readonly v1: readonly ThreadRealtimeVoice[];
+    readonly v2: readonly ThreadRealtimeVoice[];
+    readonly defaultV1: ThreadRealtimeVoice;
+    readonly defaultV2: ThreadRealtimeVoice;
+}
+
+export interface ThreadRealtimeListVoicesResponse extends JsonObject {
+    readonly voices: ThreadRealtimeVoicesList;
+}
+
+export interface ToolDecisionResult extends JsonObject {
+    readonly requestId: string;
+    readonly decision: "approved" | "denied" | "cancelled";
+}
+
+export interface ElicitationRespondResult extends JsonObject {
+    readonly requestId: RequestId;
+    readonly resolved: boolean;
+}
+
+export interface PermissionGrant extends JsonObject {
+    readonly permissionId: string;
+    readonly subject: string;
+    readonly action: string;
+    readonly scope?: string;
+    readonly grantedAt?: string;
+    readonly expiresAt?: string;
+}
+
+export interface PermissionListResult extends JsonObject {
+    readonly permissions: readonly PermissionGrant[];
+}
+
+export interface FuzzyFileSearchResult extends JsonObject {
+    readonly root: string;
+    readonly path: string;
+    readonly match_type: "file" | "directory";
+    readonly file_name: string;
+    readonly score: number;
+    readonly indices?: readonly number[];
+}
+
+export interface FuzzyFileIndexRootFreshness extends JsonObject {
+    readonly root: string;
+    readonly canonicalRoot: string;
+    readonly generationId: number | null;
+    readonly builtAt: string | null;
+    readonly ageMs: number | null;
+    readonly watcherStatus: "active" | "unsupported" | "failed" | "not_started";
+    readonly directoryCoverage: "complete" | "nonempty_only";
+    readonly lastAuditAt: string | null;
+    readonly building: boolean;
+    readonly stale: boolean;
+    readonly degraded: boolean;
+    readonly truncated: boolean;
+    readonly reason: string | null;
+}
+
+export interface FuzzyFileIndexFreshness extends JsonObject {
+    readonly schemaVersion: number;
+    readonly stale: boolean;
+    readonly degraded: boolean;
+    readonly truncated: boolean;
+    readonly roots: readonly FuzzyFileIndexRootFreshness[];
+}
+
+export interface FuzzyFileMatcherMetadata extends JsonObject {
+    readonly quality: "optimal" | "degraded";
+    readonly resourceLimited: boolean;
+    readonly evaluatedCandidates: number;
+    readonly totalCandidates: number;
+}
+
+export interface FuzzyFileSearchResponse extends JsonObject {
+    readonly files: readonly FuzzyFileSearchResult[];
+    /** Present for searches served by the persistent index. */
+    readonly freshness?: FuzzyFileIndexFreshness;
+    /** Present for searches served by the persistent index. */
+    readonly matcher?: FuzzyFileMatcherMetadata;
+}
+
+export interface CommandExecResponse extends JsonObject {
+    readonly exitCode: number;
+    readonly stdout: string;
+    readonly stderr: string;
+}
+
+export interface CommandExecWriteResponse extends JsonObject {
+}
+
+export interface CommandExecResizeResponse extends JsonObject {
+}
+
+export interface CommandExecTerminateResponse extends JsonObject {
+}
+
+export interface HealthPingResult extends JsonObject {
+    readonly ok: true;
+    readonly now: string;
+}
+
+export interface HealthReadyResult extends JsonObject {
+    readonly ready: boolean;
+    readonly uptimeMs: number;
+    readonly now: string;
+}
+
+export interface HealthSessionStats extends JsonObject {
+    readonly active: number;
+    readonly closed: number;
+    readonly total: number;
+}
+
+export interface HealthMemoryStats extends JsonObject {
+    readonly rss: number;
+    readonly heapTotal: number;
+    readonly heapUsed: number;
+    readonly external: number;
+    readonly arrayBuffers: number;
+}
+
+export interface HealthStateStats extends JsonObject {
+    readonly available: boolean;
+    readonly readonly: true;
+    readonly projectDir: string;
+    readonly agentRuns: number;
+    readonly sessionStateSnapshots: number;
+    readonly inFlightToolCalls: number;
+    readonly logs: number;
+}
+
+export interface HealthStatsResult extends JsonObject {
+    readonly uptimeMs: number;
+    readonly now: string;
+    readonly sessions: HealthSessionStats;
+    readonly memory: HealthMemoryStats;
+    readonly state?: HealthStateStats;
+}
+
+export interface DaemonReloadMcpServerResult extends JsonObject {
+    readonly status: "disabled" | "unsupported" | "listening";
+    readonly url?: string;
+}
+
+export interface DaemonReloadResult extends JsonObject {
+    readonly reloaded: true;
+    readonly configReloadedAt: string;
+    readonly mcpServer: DaemonReloadMcpServerResult;
+}
+
+export interface DaemonShutdownResult extends JsonObject {
+    readonly shuttingDown: true;
+    readonly instanceId: string;
+}
+
+export interface AuthDaemonSocketIdentity extends JsonObject {
+    readonly transport: "daemon";
+    readonly verifiedBy: "cookie" | "peerUid" | "privateSocketOwner";
+    readonly cookie?: "verified";
+    readonly peerUid?: number | null;
+    readonly privateSocketOwnerUid?: number | null;
+}
+
+export interface AuthIdentity extends JsonObject {
+    readonly accountId?: string;
+    readonly email?: string;
+    readonly handle?: string;
+    readonly displayName?: string;
+    readonly plan?: string;
+    readonly daemon?: AuthDaemonSocketIdentity;
+}
+
+export interface AuthLoginResult extends JsonObject {
+    readonly authenticated: true;
+    readonly provider?: string;
+    readonly identity?: AuthIdentity;
+}
+
+export interface AuthWhoamiResult extends JsonObject {
+    readonly authenticated: boolean;
+    readonly provider?: string;
+    readonly identity?: AuthIdentity;
+    readonly subscriptionTier?: "free" | "pro" | "team" | "enterprise";
+}
+
+export interface AuthLogoutResult extends JsonObject {
+    readonly authenticated: false;
+}
+
+export interface AgenCDaemonResultByMethod {
+    readonly initialize: InitializeResult;
+    readonly "request.cancel": RequestCancelResult;
+    readonly "agent.create": AgentCreateResult;
+    readonly "agent.list": AgentListResult;
+    readonly "agent.attach": AgentAttachResult;
+    readonly "agent.stop": AgentStopResult;
+    readonly "agent.logs": AgentLogsResult;
+    readonly "run.status": RunStatusResult;
+    readonly "run.result": RunResultResult;
+    readonly "run.replay": RunReplayResult;
+    readonly "run.evidence": RunEvidenceResult;
+    readonly "run.cancel": RunCancelResult;
+    readonly "run.start": RunStartResult;
+    readonly "routine.capabilities": RoutineCapabilities;
+    readonly "remote.capabilities": JsonObject;
+    readonly "remote.status": JsonObject;
+    readonly "remote.start": JsonObject;
+    readonly "remote.stop": JsonObject;
+    readonly "remote.pair.begin": JsonObject;
+    readonly "remote.pair.refresh": JsonObject;
+    readonly "remote.pair.cancel": JsonObject;
+    readonly "remote.devices": JsonObject;
+    readonly "remote.pending": JsonObject;
+    readonly "remote.approve": JsonObject;
+    readonly "remote.revoke": JsonObject;
+    readonly "telegram.capabilities": JsonObject;
+    readonly "telegram.status": JsonObject;
+    readonly "telegram.configure": JsonObject;
+    readonly "telegram.start": JsonObject;
+    readonly "telegram.stop": JsonObject;
+    readonly "telegram.revoke": JsonObject;
+    readonly "telegram.agents.list": JsonObject;
+    readonly "telegram.agents.create": JsonObject;
+    readonly "telegram.agents.update": JsonObject;
+    readonly "telegram.agents.start": JsonObject;
+    readonly "telegram.agents.stop": JsonObject;
+    readonly "telegram.agents.remove": JsonObject;
+    readonly "telegram.agents.pair.begin": JsonObject;
+    readonly "telegram.agents.pair.confirm": JsonObject;
+    readonly "telegram.agents.pair.cancel": JsonObject;
+    readonly "routine.list": RoutineListResult;
+    readonly "routine.get": RoutineResult;
+    readonly "routine.create": RoutineResult;
+    readonly "routine.update": RoutineResult;
+    readonly "routine.delete": RoutineDeleteResult;
+    readonly "routine.run": RoutineRunResult;
+    readonly "routine.runs": RoutineRunsResult;
+    readonly "routine.cancel": RoutineRunResult;
+    readonly "csvJob.review.list": CsvJobReviewListResult;
+    readonly "csvJob.review.show": CsvJobReviewShowResult;
+    readonly "csvJob.review.resolve": CsvJobReviewResolveResult;
+    readonly "session.create": SessionCreateResult;
+    readonly "session.list": SessionListResult;
+    readonly "session.attach": SessionAttachResult;
+    readonly "session.detach": SessionDetachResult;
+    readonly "session.terminate": SessionTerminateResult;
+    readonly "session.clear": SessionClearResult;
+    readonly "session.snapshot": SessionSnapshotResult;
+    readonly "session.transcript": SessionTranscriptResult;
+    readonly "session.transcript.v2": SessionTranscriptV2Result;
+    readonly "session.cancelTurn": SessionCancelTurnResult;
+    readonly "session.resolveToolCall": SessionResolveToolCallResult;
+    readonly "session.mcp.status": SessionMcpStatusResult;
+    readonly "session.mcp.addServer": SessionMcpAddServerResult;
+    readonly "message.send": MessageSendResult;
+    readonly "message.stream": MessageStreamResult;
+    readonly "thread/realtime/start": ThreadRealtimeStartResponse;
+    readonly "thread/realtime/appendAudio": ThreadRealtimeAppendAudioResponse;
+    readonly "thread/realtime/appendText": ThreadRealtimeAppendTextResponse;
+    readonly "thread/realtime/stop": ThreadRealtimeStopResponse;
+    readonly "thread/realtime/listVoices": ThreadRealtimeListVoicesResponse;
+    readonly "tool.approve": ToolDecisionResult;
+    readonly "tool.deny": ToolDecisionResult;
+    readonly "tool.cancel": ToolDecisionResult;
+    readonly "elicitation.respond": ElicitationRespondResult;
+    readonly "permission.list": PermissionListResult;
+    readonly "fs.fuzzy_search": FuzzyFileSearchResponse;
+    readonly "commandExec.start": CommandExecResponse;
+    readonly "commandExec.write": CommandExecWriteResponse;
+    readonly "commandExec.resize": CommandExecResizeResponse;
+    readonly "commandExec.terminate": CommandExecTerminateResponse;
+    readonly "health.ping": HealthPingResult;
+    readonly "health.ready": HealthReadyResult;
+    readonly "health.stats": HealthStatsResult;
+    readonly "daemon.reload": DaemonReloadResult;
+    readonly "daemon.shutdown": DaemonShutdownResult;
+    readonly "auth.login": AuthLoginResult;
+    readonly "auth.whoami": AuthWhoamiResult;
+    readonly "auth.logout": AuthLogoutResult;
+}
+
+/** Invalidation only: clients refresh list/detail; no instructions or results are broadcast. */
+export interface RoutineUpdatedEvent extends JsonObject {
+    readonly id: string;
+    readonly reason: "created" | "updated" | "deleted" | "run";
+}
+
+export type CommandExecOutputStream = "stdout" | "stderr";
+
+export interface CommandExecOutputDeltaParams extends JsonObject {
+    readonly processId: string;
+    readonly stream: CommandExecOutputStream;
+    readonly deltaBase64: string;
+    readonly capReached: boolean;
+}
+
+export interface AgenCEventBaseParams extends JsonObject {
+    readonly sessionId: string;
+    readonly eventId: string;
+    readonly agentId?: string;
+    readonly runId?: string;
+    readonly historyEpoch?: string;
+    readonly sequence?: number;
+    readonly acceptedAt?: string;
+    readonly turnId?: string;
+    readonly clientMessageId?: string;
+    readonly messageId?: string;
+    readonly metadata?: JsonObject;
+}
+
+export interface EventMessageChunkParams extends AgenCEventBaseParams {
+    readonly streamId?: string;
+    readonly delta: string;
+}
+
+export interface EventToolRequestParams extends AgenCEventBaseParams {
+    readonly requestId: string;
+    readonly toolName: string;
+    readonly turnId?: string;
+    readonly input?: JsonValue;
+    readonly recoveryCategory?: "idempotent" | "side-effecting" | "interactive";
+}
+
+export interface EventPermissionRequestParams extends AgenCEventBaseParams {
+    readonly requestId: string;
+    readonly toolName?: string;
+    readonly turnId?: string;
+    readonly permissions: readonly string[];
+    readonly input?: JsonValue;
+    readonly reason?: string;
+}
+
+export interface EventUserInputRequestParams extends AgenCEventBaseParams {
+    readonly requestId: string;
+    readonly callId: string;
+    readonly turnId: string;
+    readonly questions: readonly JsonObject[];
+    readonly clientAction?: JsonObject;
+}
+
+export interface EventMcpElicitationRequestParams extends AgenCEventBaseParams {
+    readonly requestId: RequestId;
+    readonly serverName: string;
+    readonly turnId: string;
+    readonly request: JsonObject;
+}
+
+/** Non-journal control-plane invalidation for the passive MCP projection. */
+export interface EventMcpStatusChangedParams extends JsonObject {
+    readonly sessionId: string;
+    readonly revision: number;
+}
+
+export type AgentRunStatus = "pending" | "running" | "working" | "paused" | "blocked" | "suspended" | "completed" | "errored" | "stopped";
+
+export interface EventAgentStatusParams extends AgenCEventBaseParams {
+    readonly agentId: string;
+    readonly status: AgentStatus;
+    readonly runStatus?: AgentRunStatus;
+    readonly turnId?: string;
+    readonly message?: string;
+}
+
+export interface EventSessionEventParams extends AgenCEventBaseParams {
+    readonly event: JsonObject;
+}
+
+/** Observable, non-journal sentinel emitted by bounded live-delivery buffers. */
+export interface EventGapParams extends JsonObject {
+    readonly type: "event_gap";
+    readonly kind: "event_gap";
+    readonly sessionId: string;
+    readonly runId: string;
+    readonly eventId?: string;
+    readonly agentId?: string;
+    readonly sequence?: number;
+    readonly reason: "retention";
+    readonly source: "background_runner_retention" | "multiplexer_retention";
+    readonly retiredCount: number;
+    /** False means replay is required but the loss count is unknown (zero). */
+    readonly retiredCountKnown?: boolean;
+    readonly coordinatesAvailable?: boolean;
+    readonly afterSequence?: number;
+    readonly firstAvailableSequence?: number;
+}
+
+export interface ThreadRealtimeBaseParams extends JsonObject {
+    readonly threadId: string;
+}
+
+export type ThreadRealtimeVersion = "v1" | "v2";
+
+export interface ThreadRealtimeStartedParams extends ThreadRealtimeBaseParams {
+    readonly realtimeSessionId?: string | null;
+    readonly version: ThreadRealtimeVersion;
+}
+
+export interface ThreadRealtimeItemAddedParams extends ThreadRealtimeBaseParams {
+    readonly item: JsonValue;
+}
+
+export interface ThreadRealtimeTranscriptDeltaParams extends ThreadRealtimeBaseParams {
+    readonly role: string;
+    readonly delta: string;
+}
+
+export interface ThreadRealtimeTranscriptDoneParams extends ThreadRealtimeBaseParams {
+    readonly role: string;
+    readonly text: string;
+}
+
+export interface ThreadRealtimeOutputAudioDeltaParams extends ThreadRealtimeBaseParams {
+    readonly audio: ThreadRealtimeAudioChunk;
+}
+
+export interface ThreadRealtimeSdpParams extends ThreadRealtimeBaseParams {
+    readonly sdp: string;
+}
+
+export interface ThreadRealtimeErrorParams extends ThreadRealtimeBaseParams {
+    readonly message: string;
+}
+
+export interface ThreadRealtimeClosedParams extends ThreadRealtimeBaseParams {
+    readonly reason?: string | null;
+}
+
+export interface AgenCDaemonNotificationParamsByMethod {
+    readonly "routine.updated": RoutineUpdatedEvent;
+    readonly "commandExec.outputDelta": CommandExecOutputDeltaParams;
+    readonly "event.message_chunk": EventMessageChunkParams;
+    readonly "event.tool_request": EventToolRequestParams;
+    readonly "event.permission_request": EventPermissionRequestParams;
+    readonly "event.user_input_request": EventUserInputRequestParams;
+    readonly "event.mcp_elicitation_request": EventMcpElicitationRequestParams;
+    readonly "event.mcp_status_changed": EventMcpStatusChangedParams;
+    readonly "event.agent_status": EventAgentStatusParams;
+    readonly "event.session_event": EventSessionEventParams;
+    readonly "event.event_gap": EventGapParams;
+    readonly "thread/realtime/started": ThreadRealtimeStartedParams;
+    readonly "thread/realtime/itemAdded": ThreadRealtimeItemAddedParams;
+    readonly "thread/realtime/transcript/delta": ThreadRealtimeTranscriptDeltaParams;
+    readonly "thread/realtime/transcript/done": ThreadRealtimeTranscriptDoneParams;
+    readonly "thread/realtime/outputAudio/delta": ThreadRealtimeOutputAudioDeltaParams;
+    readonly "thread/realtime/sdp": ThreadRealtimeSdpParams;
+    readonly "thread/realtime/error": ThreadRealtimeErrorParams;
+    readonly "thread/realtime/closed": ThreadRealtimeClosedParams;
+}
+
+export type AgenCDaemonErrorCode = -32700 | -32600 | -32601 | -32602 | -32603 | -32000;
+
+export interface AgenCDaemonErrorObject extends JsonObject {
+    readonly code: AgenCDaemonErrorCode;
+    readonly message: string;
+    readonly data?: JsonValue;
+}
+
+export interface AgenCDaemonErrorResponse extends JsonObject {
+    readonly jsonrpc: typeof JSON_RPC_VERSION;
+    readonly id: RequestId | null;
+    readonly error: AgenCDaemonErrorObject;
+}
+
+/** Source-compatible M3 admission event contract. */
+export interface RunAdmissionJournalEvent extends JsonObject {
+    readonly sequence: number;
+    readonly eventId: string;
+    readonly timestamp: string;
+    readonly runId: string;
+    readonly stepId: string;
+    readonly kind: string;
+    readonly event: string;
+    readonly reason?: string;
+    readonly reservationId?: string;
+    readonly model?: string;
+    readonly provider?: string;
+    readonly reservedTokens?: number;
+    readonly reservedCostUsd?: number;
+    readonly actualTokens?: number;
+    readonly actualCostUsd?: number;
+    readonly details?: JsonObject;
+}
+
+type PublicRequestForMethod<Method, Request = AgenCDaemonRequest> =
+  Request extends { readonly method: infer Names }
+    ? Method extends Names
+      ? { [Key in keyof Request]: Key extends "method" ? Method : Request[Key] }
+      : never
+    : never;
+
+export type AgenCDaemonRequestByMethod = {
+  readonly [Method in AgenCDaemonMethod]: PublicRequestForMethod<Method>;
+};
+
+export type AgenCDaemonParamsByMethod = {
+  readonly [Method in AgenCDaemonMethod]: NonNullable<
+    AgenCDaemonRequestByMethod[Method]["params"]
+  >;
+};

--- a/packages/agenc-sdk/src/protocol.ts
+++ b/packages/agenc-sdk/src/protocol.ts
@@ -2,27 +2,14 @@
  * Standalone subset of the AgenC daemon JSON-RPC protocol
  * (`runtime/src/app-server/protocol/index.ts`).
  *
- * This package deliberately does NOT import runtime internals; the shapes
- * here mirror the daemon's public control surface. Generated zero-dependency
- * slices are re-exported from this module and checked by
- * `runtime/scripts/check-sdk-generated-types.mjs`. Handwritten method-list
- * drift is guarded by `runtime/tests/sdk-package/protocol-drift.contract.test.ts`,
- * which compares {@link AGENC_SDK_DAEMON_METHODS} and
- * {@link AGENC_SDK_DAEMON_NOTIFICATION_METHODS} against the runtime's
- * `AGENC_DAEMON_METHODS` / `AGENC_DAEMON_NOTIFICATION_METHODS` arrays,
- * so any protocol change fails tests until this mirror is updated.
+ * Wire declarations are generated into a standalone module and re-exported
+ * under the SDK's established names. check:sdk-generated-types verifies the
+ * artifact and compiles exact request/result/envelope parity for every public
+ * method. Helpers may default cwd or adapt older replay results; those helper
+ * types do not change the generic request mappings.
  */
 
-import type {
-  CsvJobReviewListParams,
-  CsvJobReviewListResult,
-  CsvJobReviewResolveParams,
-  CsvJobReviewResolveResult,
-  CsvJobReviewShowParams,
-  CsvJobReviewShowResult,
-} from "./csv-jobs.js";
-import type { SessionTranscriptV2Result } from "./transcript-v2.generated.js";
-import type { RoutineCapabilities, RoutineListResult, RoutineResult, RoutineDeleteResult, RoutineRunResult, RoutineRunsResult, RoutineIdParams, RoutineCreateParams, RoutineUpdateParams, RoutineDeleteParams, RoutineRunsParams, RoutineCancelParams } from "./routines.js";
+import type * as Wire from "./protocol-wire.generated.js";
 export type * from "./routines.js";
 
 export type {
@@ -37,13 +24,26 @@ export const AGENC_SDK_JSON_RPC_VERSION = "2.0" as const;
 /** Protocol the SDK advertises on `initialize`. Handshake rules are in docs/sdk.md. */
 export const AGENC_SDK_DAEMON_PROTOCOL_VERSION = "1.10.0" as const;
 
-export type JsonPrimitive = string | number | boolean | null;
-export type JsonValue = JsonPrimitive | readonly JsonValue[] | JsonObject;
-export interface JsonObject {
-  readonly [key: string]: JsonValue | undefined;
-}
+/** Preserve named wire fields while allowing helpers to supply cwd. */
+export type AgencDefaultCwdParams<Params extends { readonly cwd: string }> =
+  Omit<
+    {
+      [
+        Key in keyof Params as string extends Key
+          ? never
+          : number extends Key
+            ? never
+            : Key
+      ]: Params[Key];
+    },
+    "cwd"
+  > & { readonly cwd?: string } & JsonObject;
 
-export type RequestId = string | number;
+export type JsonPrimitive = Wire.JsonPrimitive;
+export type JsonValue = Wire.JsonValue;
+export type JsonObject = Wire.JsonObject;
+
+export type RequestId = Wire.RequestId;
 
 /**
  * Every public daemon request method, in the runtime's declaration order.
@@ -175,36 +175,16 @@ export type AgencDaemonNotificationMethod =
 
 // ── Shared params/result shapes ──────────────────────────────────────
 
-export interface DaemonProtocolInfo extends JsonObject {
-  readonly version: string;
-}
+export type DaemonProtocolInfo = Wire.DaemonProtocolInfo;
 
 /** Authenticated identity of the exact daemon process serving the connection. */
-export interface DaemonInstanceIdentity extends JsonObject {
-  readonly pid: number;
-  readonly instanceId: string;
-  readonly processStart: string;
-  readonly runtimeVersion: string;
-  readonly commit: string;
-  readonly buildTime: string;
-}
+export type DaemonInstanceIdentity = Wire.DaemonInstanceIdentity;
 
-export interface InitializeParams extends JsonObject {
-  readonly protocolVersion?: string;
-  readonly protocol?: DaemonProtocolInfo;
-  readonly clientName?: string;
-  readonly authCookie?: string;
-  readonly capabilities?: JsonObject;
-}
+export type InitializeParams = Wire.InitializeParams;
 
-export interface RequestCancelParams extends JsonObject {
-  readonly requestId: RequestId;
-  readonly reason?: string;
-}
+export type RequestCancelParams = Wire.RequestCancelParams;
 
-export interface DaemonShutdownParams extends JsonObject {
-  readonly instanceId: string;
-}
+export type DaemonShutdownParams = Wire.DaemonShutdownParams;
 
 export type PermissionMode =
   "default" | "plan" | "acceptEdits" | "bypassPermissions";
@@ -212,824 +192,213 @@ export type PermissionMode =
 /** Maximum raw `AgentCreateParams.addDirs` entries accepted by the daemon. */
 export const AGENC_MAX_AGENT_CREATE_ADD_DIRS = 32;
 
-export type MessageContentBlock =
-  | (JsonObject & { readonly type: "text"; readonly text: string })
-  | (JsonObject & {
-      readonly type: "image_url";
-      readonly image_url: JsonObject & { readonly url: string };
-    });
+export type MessageContentBlock = Wire.MessageContentBlock;
 
-export type MessageContent = string | readonly MessageContentBlock[];
+export type MessageContent = Wire.MessageContent;
 
-export interface AgentRuntimeOptionsParams extends JsonObject {
-  readonly simpleMode: boolean;
-  /** Omission by an older peer is normalized to false. */
-  readonly dangerouslyBypassApprovalsAndSandbox?: boolean;
-  readonly stdinDataMode: boolean;
-  readonly remoteMode: boolean;
-  readonly remoteMemoryRoot?: string;
-  readonly coworkMemoryPathOverride?: string;
-  readonly coworkMemoryExtraGuidelines?: string;
-  readonly posixShellPath?: string;
-  readonly commandWrapperArgv?: readonly string[];
-  readonly sessionTempRoot?: string;
-  readonly pluginStorageRoot: string;
-  /**
-   * Explicit capability for command hook effects in an untrusted workspace.
-   * The SDK safe default is false. This field never permits HTTP, prompt, or
-   * agent hook effects and cannot override simpleMode hook suppression.
-   */
-  readonly allowUntrustedHooks: boolean;
-}
+export type AgentRuntimeOptionsParams = Wire.AgentRuntimeOptionsParams;
 
-export interface AgentCreateParams extends JsonObject {
-  readonly objective?: string;
-  /**
-   * Absolute workspace directory. Required by the daemon (DAE-02).
-   * SDK `spawnAgent` / `createSession` will fill `process.cwd()` when omitted
-   * at the client boundary — never leave this unset on the wire.
-   */
-  readonly cwd?: string;
-  readonly model?: string;
-  readonly provider?: string;
-  readonly profile?: string;
-  /** Absolute explicit config layer selected by the invoking client. */
-  readonly configPath?: string;
-  /**
-   * Additional working directories selected for this runtime session.
-   * Raw entries are limited by {@link AGENC_MAX_AGENT_CREATE_ADD_DIRS}; exact
-   * duplicates are accepted and collapse in first-seen order.
-   */
-  readonly addDirs?: readonly string[];
-  readonly instructions?: string;
-  readonly initialContent?: MessageContent;
-  readonly unattendedAllow?: readonly string[];
-  readonly unattendedDeny?: readonly string[];
-  readonly metadata?: JsonObject;
-  readonly permissionMode?: PermissionMode;
-  /** Immutable operator policy resolved by the embedding client. */
-  readonly runtimeOptions: AgentRuntimeOptionsParams;
-  readonly envOverrides?: { readonly [key: string]: string };
-}
+/** Helper input; generic request() uses the required-cwd wire shape. */
+export type AgentCreateParams = AgencDefaultCwdParams<Wire.AgentCreateParams>;
 
-export interface AgentListParams extends JsonObject {
-  readonly cursor?: string;
-  readonly limit?: number;
-}
+export type AgentListParams = Wire.AgentListParams;
 
-export interface AgentAttachParams extends JsonObject {
-  readonly agentId: string;
-  readonly clientId?: string;
-}
+export type AgentAttachParams = Wire.AgentAttachParams;
 
-export interface AgentStopParams extends JsonObject {
-  readonly agentId: string;
-  readonly reason?: string;
-}
+export type AgentStopParams = Wire.AgentStopParams;
 
-export interface AgentLogsParams extends JsonObject {
-  readonly agentId: string;
-}
+export type AgentLogsParams = Wire.AgentLogsParams;
 
-export interface RunStatusParams extends JsonObject {
-  readonly runId: string;
-}
+export type RunStatusParams = Wire.RunStatusParams;
 
-export interface RunResultParams extends JsonObject {
-  readonly runId: string;
-}
+export type RunResultParams = Wire.RunResultParams;
 
-export interface RunReplayParams extends JsonObject {
-  readonly runId: string;
-  readonly afterSequence?: number;
-  readonly limit?: number;
-}
+export type RunReplayParams = Wire.RunReplayParams;
 
-export interface RunEvidenceParams extends JsonObject {
-  readonly runId: string;
-  readonly afterSequence?: number;
-  readonly limit?: number;
-}
+export type RunEvidenceParams = Wire.RunEvidenceParams;
 
-export interface RunCancelParams extends JsonObject {
-  readonly runId: string;
-  readonly reason?: string;
-}
+export type RunCancelParams = Wire.RunCancelParams;
 
 /** One required verification command for a verified-change workflow run. */
-export interface RunStartVerificationCommand extends JsonObject {
-  readonly label: string;
-  readonly script: string;
-}
+export type RunStartVerificationCommand = Wire.RunStartVerificationCommand;
 
-export interface RunStartParams extends JsonObject {
-  /** The engineering goal / issue text driving the change. */
-  readonly goal: string;
-  /** Absolute directory inside the target git repository (daemon cwd default). */
-  readonly cwd?: string;
-  readonly model?: string;
-  readonly provider?: string;
-  /** Reviewer configuration pinned into the frozen spec at intake. */
-  readonly reviewerModel?: string;
-  readonly maxCostUsd?: number;
-  readonly maxTokens?: number;
-  readonly deadlineAt?: string;
-  readonly permissionMode?: PermissionMode;
-  readonly unattendedAllow?: readonly string[];
-  readonly unattendedDeny?: readonly string[];
-  /** Required verification commands; the workflow demands at least one. */
-  readonly requiredVerification?: readonly RunStartVerificationCommand[];
-  readonly maxImplementAttempts?: number;
-}
+export type RunStartParams = Wire.RunStartParams;
 
-export interface SessionCreateParams extends JsonObject {
-  readonly agentId?: string;
-  readonly cwd?: string;
-  readonly initialPrompt?: string;
-  readonly metadata?: JsonObject;
-}
+/** Helper input; generic request() uses the required-cwd wire shape. */
+export type SessionCreateParams =
+  AgencDefaultCwdParams<Wire.SessionCreateParams>;
 
-export interface SessionListParams extends JsonObject {
-  readonly agentId?: string;
-  readonly cursor?: string;
-  readonly limit?: number;
-}
+export type SessionListParams = Wire.SessionListParams;
 
-export interface SessionAttachParams extends JsonObject {
-  readonly sessionId: string;
-  readonly clientId?: string;
-}
+export type SessionAttachParams = Wire.SessionAttachParams;
 
-export interface SessionDetachParams extends JsonObject {
-  readonly sessionId: string;
-  readonly attachmentId?: string;
-  readonly clientId?: string;
-}
+export type SessionDetachParams = Wire.SessionDetachParams;
 
-export interface SessionTerminateParams extends JsonObject {
-  readonly sessionId: string;
-  readonly reason?: string;
-}
+export type SessionTerminateParams = Wire.SessionTerminateParams;
 
-export interface SessionClearParams extends JsonObject {
-  readonly sessionId: string;
-}
+export type SessionClearParams = Wire.SessionClearParams;
 
-export interface SessionSnapshotParams extends JsonObject {
-  readonly sessionId: string;
-}
+export type SessionSnapshotParams = Wire.SessionSnapshotParams;
 
-export interface SessionTranscriptParams extends JsonObject {
-  readonly sessionId: string;
-}
+export type SessionTranscriptParams = Wire.SessionTranscriptParams;
 
-export interface SessionTranscriptV2Params extends JsonObject {
-  readonly sessionId: string;
-}
+export type SessionTranscriptV2Params = Wire.SessionTranscriptV2Params;
 
-export interface SessionCancelTurnParams extends JsonObject {
-  readonly sessionId: string;
-  readonly reason?: string;
-  readonly expectedTurnId?: string;
-}
+export type SessionCancelTurnParams = Wire.SessionCancelTurnParams;
 
 /** Protocol-1.0 request shape shipped with agenc-sdk 0.3.0. */
-export interface SessionResolveToolCallLegacyParams extends JsonObject {
-  readonly sessionId: string;
-  /** When omitted, every eligible legacy effect in the session is reviewed. */
-  readonly toolCallId?: string;
-  readonly reviewer?: string;
-  readonly disposition?: never;
-  readonly evidenceRef?: never;
-  readonly evidenceSha256?: never;
-}
+export type SessionResolveToolCallLegacyParams =
+  Wire.SessionResolveToolCallLegacyParams;
 
 /** Evidence-bearing request required for canonical durable effect records. */
-export interface SessionResolveToolCallEvidenceParams extends JsonObject {
-  readonly sessionId: string;
-  readonly toolCallId: string;
-  readonly disposition:
-    "confirmed_committed" | "confirmed_no_effect" | "remains_unknown";
-  readonly evidenceRef: string;
-  readonly evidenceSha256: string;
-  readonly reviewer?: string;
-}
+export type SessionResolveToolCallEvidenceParams =
+  Wire.SessionResolveToolCallEvidenceParams;
 
-export type SessionResolveToolCallParams =
-  SessionResolveToolCallLegacyParams | SessionResolveToolCallEvidenceParams;
+export type SessionResolveToolCallParams = Wire.SessionResolveToolCallParams;
 
-export interface SessionMcpStatusParams extends JsonObject {
-  readonly sessionId: string;
-}
+export type SessionMcpStatusParams = Wire.SessionMcpStatusParams;
 
-export interface SessionMcpServerConfig extends JsonObject {
-  readonly name: string;
-  readonly transport?: "stdio" | "sse" | "http" | "websocket";
-  readonly command?: string;
-  readonly args?: readonly string[];
-  readonly endpoint?: string;
-  readonly enabled?: boolean;
-  readonly required?: boolean;
-}
+export type SessionMcpServerConfig = Wire.SessionMcpServerConfig;
 
-export interface SessionMcpAddServerParams extends JsonObject {
-  readonly sessionId: string;
-  readonly config: SessionMcpServerConfig;
-}
+export type SessionMcpAddServerParams = Wire.SessionMcpAddServerParams;
 
-export interface MessageSendParams extends JsonObject {
-  readonly sessionId: string;
-  readonly content: MessageContent;
-  readonly clientMessageId?: string;
-  readonly ifBusy?: "reject";
-  readonly metadata?: JsonObject;
-}
+export type MessageSendParams = Wire.MessageSendParams;
 
-export interface MessageStreamParams extends MessageSendParams {
-  readonly streamId?: string;
-}
+export type MessageStreamParams = Wire.MessageStreamParams;
 
-export interface ThreadRealtimeStartParams extends JsonObject {
-  readonly threadId: string;
-  readonly transport?: JsonObject | null;
-  readonly realtimeSessionId?: string | null;
-  readonly prompt?: string | null;
-  readonly outputModality: "audio" | "text";
-  readonly voice?: string | null;
-}
+export type ThreadRealtimeStartParams = Wire.ThreadRealtimeStartParams;
 
-export interface ThreadRealtimeAudioChunk extends JsonObject {
-  readonly data: string;
-  readonly sampleRate: number;
-  readonly numChannels: number;
-  readonly samplesPerChannel?: number | null;
-  readonly itemId?: string | null;
-}
+export type ThreadRealtimeAudioChunk = Wire.ThreadRealtimeAudioChunk;
 
-export interface ThreadRealtimeAppendAudioParams extends JsonObject {
-  readonly threadId: string;
-  readonly audio: ThreadRealtimeAudioChunk;
-}
+export type ThreadRealtimeAppendAudioParams =
+  Wire.ThreadRealtimeAppendAudioParams;
 
-export interface ThreadRealtimeAppendTextParams extends JsonObject {
-  readonly threadId: string;
-  readonly text: string;
-}
+export type ThreadRealtimeAppendTextParams =
+  Wire.ThreadRealtimeAppendTextParams;
 
-export interface ThreadRealtimeStopParams extends JsonObject {
-  readonly threadId: string;
-}
+export type ThreadRealtimeStopParams = Wire.ThreadRealtimeStopParams;
 
-export interface ExitPlanApprovalPayload extends JsonObject {
-  readonly action: "approve" | "revise";
-  readonly mode?: "acceptEdits" | "default";
-  readonly applyAllowedPrompts?: boolean;
-  readonly clearContext?: boolean;
-  readonly feedback?: string;
-}
+export type ExitPlanApprovalPayload = Wire.ExitPlanApprovalPayload;
 
-export interface ToolApproveParams extends JsonObject {
-  readonly sessionId: string;
-  readonly requestId: string;
-  readonly scope?: "once" | "session" | "agent";
-  /**
-   * Promote this approval to bypass-permissions mode for the owning daemon
-   * session. This is intentionally opt-in: plain `scope: "session"` keeps its
-   * existing, narrower cache semantics for semantically-equivalent calls.
-   */
-  readonly allowAllToolsForSession?: boolean;
-  readonly exitPlan?: ExitPlanApprovalPayload;
-}
+export type ToolApproveParams = Wire.ToolApproveParams;
 
-export interface ToolDenyParams extends JsonObject {
-  readonly sessionId: string;
-  readonly requestId: string;
-  readonly reason?: string;
-}
+export type ToolDenyParams = Wire.ToolDenyParams;
 
-export interface ToolCancelParams extends JsonObject {
-  readonly sessionId: string;
-  readonly requestId: string;
-  readonly reason?: string;
-}
+export type ToolCancelParams = Wire.ToolCancelParams;
 
-export interface ElicitationRespondParams extends JsonObject {
-  readonly sessionId: string;
-  readonly requestId: RequestId;
-  readonly kind: "request_user_input" | "mcp";
-  readonly serverName?: string;
-  readonly response: JsonObject;
-}
+export type ElicitationRespondParams = Wire.ElicitationRespondParams;
 
-export interface PermissionListParams extends JsonObject {
-  readonly agentId?: string;
-  readonly sessionId?: string;
-}
+export type PermissionListParams = Wire.PermissionListParams;
 
-export interface FuzzyFileSearchParams extends JsonObject {
-  readonly query: string;
-  readonly roots: readonly string[];
-  readonly cancellationToken?: string | null;
-  /** Maximum number of results to return. The daemon accepts 1 through 1,000. */
-  readonly limit?: number;
-  /** Rebuild the persistent index before evaluating the query. */
-  readonly refresh?: boolean;
-}
+export type FuzzyFileSearchParams = Wire.FuzzyFileSearchParams;
 
-export interface CommandExecTerminalSize extends JsonObject {
-  readonly rows: number;
-  readonly cols: number;
-}
+export type CommandExecTerminalSize = Wire.CommandExecTerminalSize;
 
-interface CommandExecStartBase extends JsonObject {
-  readonly command: readonly string[];
-  readonly processId?: string | null;
-  readonly tty?: boolean;
-  readonly streamStdin?: boolean;
-  readonly streamStdoutStderr?: boolean;
-  readonly outputBytesCap?: number | null;
-  readonly disableOutputCap?: boolean;
-  readonly disableTimeout?: boolean;
-  readonly timeoutMs?: number | null;
-  readonly cwd?: string | null;
-  readonly env?: Readonly<Record<string, string | null>> | null;
-  readonly size?: CommandExecTerminalSize | null;
-}
+export type CommandExecStartParams = Wire.CommandExecStartParams;
 
-export type CommandExecStartParams = CommandExecStartBase &
-  (
-    | {
-        readonly permissionProfile: string;
-        readonly sandboxPolicy?: null;
-      }
-    | {
-        readonly sandboxPolicy: JsonObject;
-        readonly permissionProfile?: null;
-      }
-  );
+export type CommandExecWriteParams = Wire.CommandExecWriteParams;
 
-export interface CommandExecWriteParams extends JsonObject {
-  readonly processId: string;
-  readonly deltaBase64?: string | null;
-  readonly closeStdin?: boolean;
-}
+export type CommandExecResizeParams = Wire.CommandExecResizeParams;
 
-export interface CommandExecResizeParams extends JsonObject {
-  readonly processId: string;
-  readonly size: CommandExecTerminalSize;
-}
+export type CommandExecTerminateParams = Wire.CommandExecTerminateParams;
 
-export interface CommandExecTerminateParams extends JsonObject {
-  readonly processId: string;
-}
+export type EmptyParams = Wire.EmptyParams;
 
-export type EmptyParams = Record<string, never>;
+export type CsvJobReviewListWireParams = Wire.CsvJobReviewListParams;
 
-export type CsvJobReviewListWireParams = CsvJobReviewListParams & {
-  readonly cwd: string;
-};
-export type CsvJobReviewShowWireParams = CsvJobReviewShowParams & {
-  readonly cwd: string;
-};
-export type CsvJobReviewResolveWireParams = CsvJobReviewResolveParams & {
-  readonly cwd: string;
-};
+export type CsvJobReviewShowWireParams = Wire.CsvJobReviewShowParams;
 
-export interface AgencParamsByMethod {
-  readonly "remote.capabilities": JsonObject;
-  readonly "remote.status": JsonObject;
-  readonly "remote.start": JsonObject;
-  readonly "remote.stop": JsonObject;
-  readonly "remote.pair.begin": JsonObject;
-  readonly "remote.pair.refresh": JsonObject;
-  readonly "remote.pair.cancel": JsonObject;
-  readonly "remote.devices": JsonObject;
-  readonly "remote.pending": JsonObject;
-  readonly "remote.approve": JsonObject;
-  readonly "remote.revoke": JsonObject;
-  readonly "telegram.capabilities": JsonObject;
-  readonly "telegram.status": JsonObject;
-  readonly "telegram.configure": JsonObject;
-  readonly "telegram.start": JsonObject;
-  readonly "telegram.stop": JsonObject;
-  readonly "telegram.revoke": JsonObject;
-  readonly "telegram.agents.list": JsonObject;
-  readonly "telegram.agents.create": JsonObject;
-  readonly "telegram.agents.update": JsonObject;
-  readonly "telegram.agents.start": JsonObject;
-  readonly "telegram.agents.stop": JsonObject;
-  readonly "telegram.agents.remove": JsonObject;
-  readonly "telegram.agents.pair.begin": JsonObject;
-  readonly "telegram.agents.pair.confirm": JsonObject;
-  readonly "telegram.agents.pair.cancel": JsonObject;
-  readonly initialize: InitializeParams;
-  readonly "request.cancel": RequestCancelParams;
-  readonly "agent.create": AgentCreateParams;
-  readonly "agent.list": AgentListParams;
-  readonly "agent.attach": AgentAttachParams;
-  readonly "agent.stop": AgentStopParams;
-  readonly "agent.logs": AgentLogsParams;
-  readonly "run.status": RunStatusParams;
-  readonly "run.result": RunResultParams;
-  readonly "run.replay": RunReplayParams;
-  readonly "run.evidence": RunEvidenceParams;
-  readonly "run.cancel": RunCancelParams;
-  readonly "run.start": RunStartParams;
-  readonly "routine.capabilities": EmptyParams;
-  readonly "routine.list": EmptyParams;
-  readonly "routine.get": RoutineIdParams;
-  readonly "routine.create": RoutineCreateParams;
-  readonly "routine.update": RoutineUpdateParams;
-  readonly "routine.delete": RoutineDeleteParams;
-  readonly "routine.run": RoutineIdParams;
-  readonly "routine.runs": RoutineRunsParams;
-  readonly "routine.cancel": RoutineCancelParams;
-  readonly "csvJob.review.list": CsvJobReviewListWireParams;
-  readonly "csvJob.review.show": CsvJobReviewShowWireParams;
-  readonly "csvJob.review.resolve": CsvJobReviewResolveWireParams;
-  readonly "session.create": SessionCreateParams;
-  readonly "session.list": SessionListParams;
-  readonly "session.attach": SessionAttachParams;
-  readonly "session.detach": SessionDetachParams;
-  readonly "session.terminate": SessionTerminateParams;
-  readonly "session.clear": SessionClearParams;
-  readonly "session.snapshot": SessionSnapshotParams;
-  readonly "session.transcript": SessionTranscriptParams;
-  readonly "session.transcript.v2": SessionTranscriptV2Params;
-  readonly "session.cancelTurn": SessionCancelTurnParams;
-  readonly "session.resolveToolCall": SessionResolveToolCallParams;
-  readonly "session.mcp.status": SessionMcpStatusParams;
-  readonly "session.mcp.addServer": SessionMcpAddServerParams;
-  readonly "message.send": MessageSendParams;
-  readonly "message.stream": MessageStreamParams;
-  readonly "thread/realtime/start": ThreadRealtimeStartParams;
-  readonly "thread/realtime/appendAudio": ThreadRealtimeAppendAudioParams;
-  readonly "thread/realtime/appendText": ThreadRealtimeAppendTextParams;
-  readonly "thread/realtime/stop": ThreadRealtimeStopParams;
-  readonly "thread/realtime/listVoices": EmptyParams;
-  readonly "tool.approve": ToolApproveParams;
-  readonly "tool.deny": ToolDenyParams;
-  readonly "tool.cancel": ToolCancelParams;
-  readonly "elicitation.respond": ElicitationRespondParams;
-  readonly "permission.list": PermissionListParams;
-  readonly "fs.fuzzy_search": FuzzyFileSearchParams;
-  readonly "commandExec.start": CommandExecStartParams;
-  readonly "commandExec.write": CommandExecWriteParams;
-  readonly "commandExec.resize": CommandExecResizeParams;
-  readonly "commandExec.terminate": CommandExecTerminateParams;
-  readonly "health.ping": EmptyParams;
-  readonly "health.ready": EmptyParams;
-  readonly "health.stats": EmptyParams;
-  readonly "daemon.reload": EmptyParams;
-  readonly "daemon.shutdown": DaemonShutdownParams;
-  readonly "auth.login": EmptyParams;
-  readonly "auth.whoami": EmptyParams;
-  readonly "auth.logout": EmptyParams;
-}
+export type CsvJobReviewResolveWireParams = Wire.CsvJobReviewResolveParams;
+
+export type AgencParamsByMethod = Wire.AgenCDaemonParamsByMethod;
 
 // ── Result shapes ────────────────────────────────────────────────────
 
-export type AgentStatus = "idle" | "running" | "stopping" | "stopped" | "error";
-export type AgentRunStatus =
-  | "pending"
-  | "running"
-  | "working"
-  | "paused"
-  | "blocked"
-  | "suspended"
-  | "completed"
-  | "errored"
-  | "stopped";
-export type SessionStatus = "idle" | "running" | "waiting" | "closed" | "error";
+export type AgentStatus = Wire.AgentStatus;
+export type AgentRunStatus = Wire.AgentRunStatus;
+export type SessionStatus = Wire.SessionStatus;
 
-export interface AgentSummary extends JsonObject {
-  readonly agentId: string;
-  readonly agentPath?: string;
-  readonly objective?: string;
-  readonly status: AgentStatus;
-  readonly createdAt: string;
-  readonly startedAt?: string;
-  readonly lastActiveAt?: string;
-  readonly cwd?: string;
-  readonly activeSessionIds?: readonly string[];
-  readonly metadata?: JsonObject;
-}
+export type AgentSummary = Wire.AgentSummary;
 
-export interface SessionSummary extends JsonObject {
-  readonly sessionId: string;
-  readonly agentId: string;
-  readonly status: SessionStatus;
-  readonly createdAt: string;
-  readonly cwd?: string;
-  readonly metadata?: JsonObject;
-  readonly activeAttachmentIds?: readonly string[];
-  readonly closedAt?: string;
-}
+export type SessionSummary = Wire.SessionSummary;
 
-export interface InitializeResult extends JsonObject {
-  readonly type: "initialized";
-  readonly protocolVersion: string;
-  readonly protocol: DaemonProtocolInfo;
-  readonly capabilities: JsonObject;
-  readonly daemonIdentity?: DaemonInstanceIdentity;
-}
+export type InitializeResult = Wire.InitializeResult;
 
-export interface RequestCancelResult extends JsonObject {
-  readonly requestId: RequestId;
-  readonly cancelled: boolean;
-  readonly reason?: string;
-}
+export type RequestCancelResult = Wire.RequestCancelResult;
 
-export interface AgentCreateResult extends AgentSummary {
-  readonly sessionId?: string;
-}
+export type AgentCreateResult = Wire.AgentCreateResult;
 
-export interface AgentListResult extends JsonObject {
-  readonly agents: readonly AgentSummary[];
-  readonly nextCursor?: string;
-}
+export type AgentListResult = Wire.AgentListResult;
 
 /** Standalone wire mirror of the runtime's canonical run-settings snapshot. */
-export interface RunRuntimeSettingsSnapshot extends JsonObject {
-  readonly permissionMode:
-    | "default"
-    | "plan"
-    | "acceptEdits"
-    | "bypassPermissions"
-    | "dontAsk"
-    | "auto"
-    | "unattended";
-  readonly prePlanMode:
-    | "default"
-    | "plan"
-    | "acceptEdits"
-    | "bypassPermissions"
-    | "dontAsk"
-    | "auto"
-    | "unattended"
-    | null;
-  readonly autoModeActive: boolean;
-  readonly autoModeAvailable: boolean;
-  readonly bypassPermissionsModeAvailable: boolean;
-  readonly bypassPermissionsWorkspace: string | null;
-  readonly bypassPermissionsConsentWorkspace: string | null;
-  readonly model: string;
-  readonly provider: string;
-  readonly profile: string | null;
-  readonly reasoningEffort: "low" | "medium" | "high" | "xhigh" | "none" | null;
-  readonly modelVerbosity: "low" | "medium" | "high" | null;
-  readonly serviceTier: "priority" | "flex" | null;
-  readonly hooksDisabled: boolean;
-}
+export type RunRuntimeSettingsSnapshot = Wire.RunRuntimeSettingsSnapshot;
 
-export interface AgentAttachResult extends JsonObject {
-  readonly agentId: string;
-  readonly attachmentId: string;
-  readonly sessionIds: readonly string[];
-  /** Immutable operator authority owned by the attached daemon session. */
-  readonly runtimeOptions: AgentRuntimeOptionsParams;
-  /** Live daemon-owned settings; static session metadata is not authority. */
-  readonly runtimeSettings: RunRuntimeSettingsSnapshot;
-  /** Canonical settings event hydrated by this response. */
-  readonly runtimeSettingsEventId: string;
-  readonly runtimeSessionId?: string;
-  readonly sessions: readonly AgentAttachSessionSummary[];
-}
+export type AgentAttachResult = Wire.AgentAttachResult;
 
-export interface AgentAttachSessionSummary extends SessionSummary {
-  readonly cwd: string;
-}
+export type AgentAttachSessionSummary = Wire.AgentAttachSessionSummary;
 
-export interface AgentStopResult extends JsonObject {
-  readonly agentId: string;
-  readonly stopped: boolean;
-}
+export type AgentStopResult = Wire.AgentStopResult;
 
-export interface AgentLogSession extends JsonObject {
-  readonly sessionId: string;
-  readonly itemCount: number;
-  readonly transcript: string;
-  readonly rolloutPath?: string;
-  readonly source?: string;
-}
+export type AgentLogSession = Wire.AgentLogSession;
 
-export interface AgentLogsResult extends JsonObject {
-  readonly agentId: string;
-  readonly transcript: string;
-  readonly sessions: readonly AgentLogSession[];
-  readonly toolOutputs?: readonly JsonObject[];
-}
+export type AgentLogsResult = Wire.AgentLogsResult;
 
-export interface RunCancelResult extends JsonObject {
-  readonly runId: string;
-  readonly alreadyTerminal: boolean;
-  readonly cancelledRunIds: readonly string[];
-  readonly closedEdgeChildIds: readonly string[];
-  readonly interruptedLiveAgentIds: readonly string[];
-  readonly voidedHolds: number;
-}
+export type RunCancelResult = Wire.RunCancelResult;
 
 /** Dirty-state summary of the user's checkout captured at workflow intake. */
-export interface RunStartBaseDirty extends JsonObject {
-  readonly dirty: boolean;
-  readonly fileCount: number;
-}
+export type RunStartBaseDirty = Wire.RunStartBaseDirty;
 
-export interface RunStartResult extends JsonObject {
-  readonly runId: string;
-  /** Canonical digest of the frozen WorkflowSpec (the spec's durable identity). */
-  readonly specDigest: string;
-  /** Exact base commit recorded before any work began. */
-  readonly baseCommit: string;
-  readonly baseDirty: RunStartBaseDirty;
-}
+export type RunStartResult = Wire.RunStartResult;
 
 /** JSON-serializable mirror of a workflow step's content-addressed artifact. */
-export interface RunWorkflowArtifactPointer extends JsonObject {
-  readonly step: {
-    readonly runId: string;
-    readonly stepId: string;
-    readonly parentRunId?: string;
-  };
-  readonly role: string;
-  readonly digest: string;
-  readonly bytes: number;
-  readonly storagePath: string;
-  readonly recordedAt: string;
-}
+export type RunWorkflowArtifactPointer = Wire.RunWorkflowArtifactPointer;
 
-export type RunWorkflowStepStatus =
-  | "pending"
-  | "running"
-  | "committed"
-  | "failed"
-  | "cancelled"
-  | "unknown_outcome"
-  | "blocked";
+export type RunWorkflowStepStatus = Wire.RunWorkflowStepStatus;
 
-export interface RunWorkflowStatusStep extends JsonObject {
-  readonly stepId: string;
-  readonly stage: string;
-  readonly status: RunWorkflowStepStatus;
-  readonly attempts: number;
-  readonly verdict?: string;
-  readonly artifacts?: readonly RunWorkflowArtifactPointer[];
-}
+export type RunWorkflowStatusStep = Wire.RunWorkflowStatusStep;
 
 /**
  * M5 verified-change workflow projection, present on `run.status` only for
  * runs that recorded workflow steps.
  */
-export interface RunWorkflowStatus extends JsonObject {
-  readonly steps: readonly RunWorkflowStatusStep[];
-  readonly stopReason?: string;
-}
+export type RunWorkflowStatus = Wire.RunWorkflowStatus;
 
 /**
  * M5 evidence-bundle summary for `run.evidence`, present only when the run
  * has a per-run evidence ledger directory.
  */
-export interface RunEvidenceBundle extends JsonObject {
-  readonly recordDigest?: string;
-  readonly sealed: boolean;
-  readonly ledgerPath: string;
-  readonly artifacts: readonly RunWorkflowArtifactPointer[];
-}
+export type RunEvidenceBundle = Wire.RunEvidenceBundle;
 
-export interface RunDurableRecord extends JsonObject {
-  readonly objective: string;
-  readonly status: string;
-  readonly startedAt: string;
-  readonly lastActiveAt: string;
-  readonly currentSessionId?: string;
-  readonly createdByClient?: string;
-  readonly lastSnapshotAt?: string;
-  readonly metadata?: JsonObject;
-}
+export type RunDurableRecord = Wire.RunDurableRecord;
 
-export interface RunStateSource extends JsonObject {
-  readonly kind: "existing_state_database";
-  readonly projectDir: string;
-  readonly readonly: true;
-}
+export type RunStateSource = Wire.RunStateSource;
 
-export interface RunAdmissionSourceAvailability extends JsonObject {
-  readonly jobs: boolean;
-  readonly reservations: boolean;
-  readonly allocations: boolean;
-  readonly journal: boolean;
-}
+export type RunAdmissionSourceAvailability =
+  Wire.RunAdmissionSourceAvailability;
 
-export type RunAdmissionAggregateStatus =
-  | "none"
-  | "queued"
-  | "running"
-  | "approval_required"
-  | "reconciled"
-  | "voided"
-  | "held_unknown"
-  | "provider_overrun"
-  | "denied"
-  | "cancelled"
-  | "terminal_mixed";
+export type RunAdmissionAggregateStatus = Wire.RunAdmissionAggregateStatus;
 
-export interface RunAdmissionSummary extends JsonObject {
-  readonly present: boolean;
-  readonly currentStatus: RunAdmissionAggregateStatus;
-  readonly active: boolean;
-  readonly stepCount: number;
-  readonly stepStatusCounts: Readonly<Record<string, number>>;
-  readonly reservationCount: number;
-  readonly reservationStatusCounts: Readonly<Record<string, number>>;
-  readonly openReservationCount: number;
-  readonly reservedTokens: number;
-  readonly reservedCostUsd: number;
-  readonly actualTokens: number;
-  readonly actualCostUsd: number;
-  readonly unpricedActualReservationCount: number;
-  readonly allocationCount: number;
-  readonly usedTokens: number;
-  readonly heldTokens: number;
-  readonly usedCostUsd: number;
-  readonly heldCostUsd: number;
-  readonly providerOverrunBlockedAllocationCount: number;
-  readonly fallbackCount: number;
-  readonly sources: RunAdmissionSourceAvailability;
-  readonly updatedAt?: string;
-}
+export type RunAdmissionSummary = Wire.RunAdmissionSummary;
 
-export interface RunStatusResult extends JsonObject {
-  readonly runId: string;
-  readonly status: string;
-  readonly terminal: boolean;
-  readonly statusSource:
-    | "run_terminal_result"
-    | "run_lifecycle_epoch"
-    | "agent_run"
-    | "admission_state";
-  readonly durableRun?: RunDurableRecord;
-  readonly admission: RunAdmissionSummary;
-  readonly source: RunStateSource;
-  /** M5 workflow projection; present only for verified-change workflow runs. */
-  readonly workflow?: RunWorkflowStatus;
-}
+export type RunStatusResult = Wire.RunStatusResult;
 
-export type RunTerminalOutcome =
-  "completed" | "failed" | "cancelled" | "stopped" | "unknown_outcome";
+export type RunTerminalOutcome = Wire.RunTerminalOutcome;
 
-export interface RunTerminalOutputAvailability extends JsonObject {
-  readonly available: false;
-  readonly reason: "terminal_output_not_persisted_in_existing_state";
-}
+export type RunTerminalOutputAvailability = Wire.RunTerminalOutputAvailability;
 
-export interface RunUsageTotals extends JsonObject {
-  readonly inputTokens: number;
-  readonly outputTokens: number;
-  readonly totalTokens: number;
-  readonly costUsd: number;
-}
+export type RunUsageTotals = Wire.RunUsageTotals;
 
 /** Terminal output committed by M4 and readable after disconnect/restart. */
-export interface RunTerminalPersistedOutput extends JsonObject {
-  readonly available: true;
-  readonly exitCode: number | null;
-  readonly stopReason: string | null;
-  readonly finalMessage: string | null;
-  readonly usage: RunUsageTotals | null;
-  readonly lastSequence: number | null;
-}
+export type RunTerminalPersistedOutput = Wire.RunTerminalPersistedOutput;
 
 /** Compatibility alias for code that names the unavailable branch directly. */
 export type RunTerminalOutputUnavailable = RunTerminalOutputAvailability;
 export type RunTerminalOutput =
   RunTerminalPersistedOutput | RunTerminalOutputAvailability;
 
-export interface RunResultResult extends JsonObject {
-  readonly runId: string;
-  readonly status: string;
-  readonly terminal: true;
-  readonly terminalAt: string;
-  readonly outcome: RunTerminalOutcome;
-  readonly epoch?: number;
-  readonly durableRun?: RunDurableRecord;
-  readonly output: RunTerminalOutput;
-  readonly source: RunStateSource;
-}
+export type RunResultResult = Wire.RunResultResult;
 
-export type RunJournalCategory =
-  | "run"
-  | "step"
-  | "admission"
-  | "budget"
-  | "permission"
-  | "approval"
-  | "effect"
-  | "model"
-  | "artifact"
-  | "cancellation"
-  | "recovery"
-  | "terminal"
-  | "session";
+export type RunJournalCategory = Wire.RunJournalCategory;
 
 /**
  * One event from the canonical append-only run journal.
@@ -1038,48 +407,10 @@ export type RunJournalCategory =
  * add a canonical category/name/payload envelope without forcing consumers to
  * understand every future event payload before they can advance a cursor.
  */
-export interface RunJournalEvent extends JsonObject {
-  readonly sequence: number;
-  readonly eventId: string;
-  readonly timestamp?: string;
-  readonly runId: string;
-  readonly childRunId?: string;
-  readonly sessionId?: string;
-  readonly stepId?: string;
-  readonly category: RunJournalCategory;
-  readonly kind: string;
-  readonly event: string;
-  readonly payload?: JsonValue;
-  readonly reason?: string;
-  readonly reservationId?: string;
-  readonly model?: string;
-  readonly provider?: string;
-  readonly reservedTokens?: number;
-  readonly reservedCostUsd?: number;
-  readonly actualTokens?: number;
-  readonly actualCostUsd?: number;
-  readonly details?: JsonObject;
-}
+export type RunJournalEvent = Wire.RunJournalEvent;
 
 /** Source-compatible M3 admission event contract. */
-export interface RunAdmissionJournalEvent extends JsonObject {
-  readonly sequence: number;
-  readonly eventId: string;
-  readonly timestamp: string;
-  readonly runId: string;
-  readonly stepId: string;
-  readonly kind: string;
-  readonly event: string;
-  readonly reason?: string;
-  readonly reservationId?: string;
-  readonly model?: string;
-  readonly provider?: string;
-  readonly reservedTokens?: number;
-  readonly reservedCostUsd?: number;
-  readonly actualTokens?: number;
-  readonly actualCostUsd?: number;
-  readonly details?: JsonObject;
-}
+export type RunAdmissionJournalEvent = Wire.RunAdmissionJournalEvent;
 
 /**
  * Event returned by the pre-M4 admission-journal compatibility reader.
@@ -1097,52 +428,21 @@ export interface RunAdmissionReplayEvent extends RunAdmissionJournalEvent {
 /** One event from either the canonical M4 or compatibility M3 replay source. */
 export type RunReplayEvent = RunJournalEvent | RunAdmissionReplayEvent;
 
-export interface RunReplaySourceUnavailableGap extends JsonObject {
-  readonly kind: "source_unavailable";
-  readonly reason:
-    "execution_admission_journal_not_present" | "run_journal_not_present";
-}
+export type RunReplaySourceUnavailableGap = Wire.RunReplaySourceUnavailableGap;
 
 /** A cursor range was retired or could not be recovered contiguously. */
-export interface RunReplayRetentionGap extends JsonObject {
-  readonly kind: "event_gap";
-  readonly runId: string;
-  readonly afterSequence: number;
-  readonly firstAvailableSequence: number;
-  readonly reason: "retention" | "corruption_truncated" | "compaction";
-}
+export type RunReplayRetentionGap = Wire.RunReplayRetentionGap;
 
 /** The supplied cursor is beyond the canonical journal tail. */
-export interface RunReplayCursorAheadGap extends JsonObject {
-  readonly kind: "cursor_ahead";
-  readonly runId: string;
-  readonly afterSequence: number;
-  readonly lastAvailableSequence: number;
-  readonly reason: "cursor_ahead";
-}
+export type RunReplayCursorAheadGap = Wire.RunReplayCursorAheadGap;
 
-export type RunReplayGap =
-  | RunReplayRetentionGap
-  | RunReplayCursorAheadGap
-  | RunReplaySourceUnavailableGap;
+export type RunReplayGap = Wire.RunReplayGap;
 
-export interface RunJournalReplaySource extends JsonObject {
-  readonly kind: "run_journal";
-  readonly available: boolean;
-  readonly sequenceScope: "run";
-  readonly canonical: "rollout_jsonl";
-  readonly projection: "thread_rollout_items";
-  readonly projectDir: string;
-}
+export type RunJournalReplaySource = Wire.RunJournalReplaySource;
 
-export interface RunAdmissionReplaySource extends JsonObject {
-  readonly kind: "execution_admission_journal";
-  readonly available: boolean;
-  readonly sequenceScope: "project_state_database";
-  readonly projectDir: string;
-}
+export type RunAdmissionReplaySource = Wire.RunAdmissionReplaySource;
 
-export type RunReplaySource = RunJournalReplaySource | RunAdmissionReplaySource;
+export type RunReplaySource = Wire.RunReplaySource;
 
 export interface RunReplayPage extends JsonObject {
   readonly runId: string;
@@ -1183,85 +483,29 @@ export function isRunJournalReplayResult(
   return result.source.kind === "run_journal";
 }
 
-export type RunEvidenceCompleteness =
-  "complete" | "partial" | "admission_source_unavailable" | "journal_gap";
+export type RunEvidenceCompleteness = Wire.RunEvidenceCompleteness;
 
-export interface RunEvidenceSource extends JsonObject {
-  readonly kind: "canonical_run_journal" | "existing_m3_admission_state";
-  readonly projectDir: string;
-  readonly admissionJournal: boolean;
-  readonly workflowEvidenceIncluded: boolean;
-  readonly completeness: RunEvidenceCompleteness;
-}
+export type RunEvidenceSource = Wire.RunEvidenceSource;
 
-export interface RunEvidenceCursor extends JsonObject {
-  readonly afterSequence: number;
-  readonly nextAfterSequence: number;
-  readonly limit: number;
-}
+export type RunEvidenceCursor = Wire.RunEvidenceCursor;
 
-export interface RunEvidenceEventHash extends JsonObject {
-  readonly sequence: number;
-  readonly eventId: string;
-  readonly sha256: string;
-}
+export type RunEvidenceEventHash = Wire.RunEvidenceEventHash;
 
-export interface RunEvidenceHashes extends JsonObject {
-  readonly algorithm: "sha256";
-  readonly runStateSha256: string;
-  readonly admissionSummarySha256: string;
-  readonly gapSha256: string;
-  readonly eventHashes: readonly RunEvidenceEventHash[];
-  readonly bundleSha256: string;
-}
+export type RunEvidenceHashes = Wire.RunEvidenceHashes;
 
-export interface RunEvidenceResult extends JsonObject {
-  readonly runId: string;
-  readonly source: RunEvidenceSource;
-  readonly cursor: RunEvidenceCursor;
-  readonly hasMore: boolean;
-  readonly gap: RunReplayGap | null;
-  readonly events: readonly RunReplayEvent[];
-  readonly hashes: RunEvidenceHashes;
-  /** M5 evidence-ledger summary; present only when the run has a ledger dir. */
-  readonly bundle?: RunEvidenceBundle;
-}
+export type RunEvidenceResult = Wire.RunEvidenceResult;
 
-export interface SessionCreateResult extends SessionSummary {}
+export type SessionCreateResult = Wire.SessionCreateResult;
 
-export interface SessionListResult extends JsonObject {
-  readonly sessions: readonly SessionSummary[];
-  readonly nextCursor?: string;
-}
+export type SessionListResult = Wire.SessionListResult;
 
-export interface SessionAttachResult extends JsonObject {
-  readonly sessionId: string;
-  readonly attachmentId: string;
-  readonly attachedAt: string;
-  readonly clientId?: string;
-  readonly activeAttachmentIds: readonly string[];
-}
+export type SessionAttachResult = Wire.SessionAttachResult;
 
-export interface SessionDetachResult extends JsonObject {
-  readonly sessionId: string;
-  readonly detached: boolean;
-  readonly attachmentId?: string;
-  readonly remainingAttachmentIds: readonly string[];
-}
+export type SessionDetachResult = Wire.SessionDetachResult;
 
-export interface SessionTerminateResult extends JsonObject {
-  readonly sessionId: string;
-  readonly terminated: boolean;
-  readonly status: "closed";
-  readonly closedAt: string;
-  readonly reason?: string;
-}
+export type SessionTerminateResult = Wire.SessionTerminateResult;
 
-export interface SessionClearResult extends JsonObject {
-  readonly sessionId: string;
-  readonly cleared: true;
-  readonly clearedAt: string;
-}
+export type SessionClearResult = Wire.SessionClearResult;
 
 export interface TokenUsage extends JsonObject {
   readonly inputTokens: number;
@@ -1270,310 +514,67 @@ export interface TokenUsage extends JsonObject {
   readonly costUsd: number;
 }
 
-export interface SessionSnapshotResult extends JsonObject {
-  readonly sessionId: string;
-  readonly turnCount: number;
-  readonly tokenUsage: TokenUsage;
-}
+export type SessionSnapshotResult = Wire.SessionSnapshotResult;
 
-export interface SessionTranscriptMessage extends JsonObject {
-  readonly role: string;
-  readonly text: string;
-}
+export type SessionTranscriptMessage = Wire.SessionTranscriptMessage;
 
-export interface SessionTranscriptResult extends JsonObject {
-  readonly sessionId: string;
-  readonly messages: readonly SessionTranscriptMessage[];
-}
+export type SessionTranscriptResult = Wire.SessionTranscriptResult;
 
-export interface SessionCancelTurnResult extends JsonObject {
-  readonly sessionId: string;
-  readonly cancelled: boolean;
-  readonly reason?: string;
-  readonly activeTurnId?: string;
-  readonly stale?: boolean;
-}
+export type SessionCancelTurnResult = Wire.SessionCancelTurnResult;
 
-export interface SessionResolveToolCallResult extends JsonObject {
-  readonly sessionId: string;
-  readonly resolved: readonly {
-    readonly toolCallId: string;
-    readonly toolName: string;
-    readonly eventId?: string;
-  }[];
-  readonly remaining: number;
-}
+export type SessionResolveToolCallResult = Wire.SessionResolveToolCallResult;
 
-export interface SessionMcpStatusServer extends JsonObject {
-  readonly name: string;
-  readonly transport: "stdio" | "sse" | "http" | "websocket";
-  readonly enabled: boolean;
-  readonly required: boolean;
-  readonly state:
-    | "connected"
-    | "pending"
-    | "failed"
-    | "disabled"
-    | "needs-auth"
-    | "disconnected";
-  readonly displayTarget?: string;
-  readonly toolCount: number;
-}
+export type SessionMcpStatusServer = Wire.SessionMcpStatusServer;
 
-export interface SessionMcpStatusTool extends JsonObject {
-  readonly serverName: string;
-  readonly name: string;
-}
+export type SessionMcpStatusTool = Wire.SessionMcpStatusTool;
 
-export interface SessionMcpStatusResult extends JsonObject {
-  readonly sessionId: string;
-  readonly revision: number;
-  readonly servers: readonly SessionMcpStatusServer[];
-  readonly tools: readonly SessionMcpStatusTool[];
-}
+export type SessionMcpStatusResult = Wire.SessionMcpStatusResult;
 
-export interface SessionMcpAddServerResult extends JsonObject {
-  readonly sessionId: string;
-  readonly serverName: string;
-  readonly success: boolean;
-  readonly toolCount: number;
-  readonly error?: string;
-}
+export type SessionMcpAddServerResult = Wire.SessionMcpAddServerResult;
 
-export interface MessageSendResult extends JsonObject {
-  readonly messageId: string;
-  readonly acceptedAt: string;
-  readonly disposition?: "started" | "duplicate";
-  /** Present for duplicate submissions so callers never guess crash outcomes. */
-  readonly duplicateState?: "completed" | "incomplete";
-  readonly turnId?: string;
-  readonly terminal?: MessageSendTerminalResult;
-}
+export type MessageSendResult = Wire.MessageSendResult;
 
-export interface MessageSendTerminalResult extends JsonObject {
-  readonly code: 0 | 1 | 130;
-  readonly message?: string;
-}
+export type MessageSendTerminalResult = Wire.MessageSendTerminalResult;
 
-export interface MessageStreamResult extends MessageSendResult {
-  readonly streamId: string;
-}
+export type MessageStreamResult = Wire.MessageStreamResult;
 
-export interface ToolDecisionResult extends JsonObject {
-  readonly requestId: string;
-  readonly decision: "approved" | "denied" | "cancelled";
-}
+export type ToolDecisionResult = Wire.ToolDecisionResult;
 
-export interface ElicitationRespondResult extends JsonObject {
-  readonly requestId: RequestId;
-  readonly resolved: boolean;
-}
+export type ElicitationRespondResult = Wire.ElicitationRespondResult;
 
-export interface PermissionGrant extends JsonObject {
-  readonly permissionId: string;
-  readonly subject: string;
-  readonly action: string;
-  readonly scope?: string;
-  readonly grantedAt?: string;
-  readonly expiresAt?: string;
-}
+export type PermissionGrant = Wire.PermissionGrant;
 
-export interface PermissionListResult extends JsonObject {
-  readonly permissions: readonly PermissionGrant[];
-}
+export type PermissionListResult = Wire.PermissionListResult;
 
-export interface FuzzyFileSearchResult extends JsonObject {
-  readonly root: string;
-  readonly path: string;
-  readonly match_type: "file" | "directory";
-  readonly file_name: string;
-  readonly score: number;
-  readonly indices?: readonly number[];
-}
+export type FuzzyFileSearchResult = Wire.FuzzyFileSearchResult;
 
-export interface FuzzyFileIndexRootFreshness extends JsonObject {
-  readonly root: string;
-  readonly canonicalRoot: string;
-  readonly generationId: number | null;
-  readonly builtAt: string | null;
-  readonly ageMs: number | null;
-  readonly watcherStatus: "active" | "unsupported" | "failed" | "not_started";
-  readonly directoryCoverage: "complete" | "nonempty_only";
-  readonly lastAuditAt: string | null;
-  readonly building: boolean;
-  readonly stale: boolean;
-  readonly degraded: boolean;
-  readonly truncated: boolean;
-  readonly reason: string | null;
-}
+export type FuzzyFileIndexRootFreshness = Wire.FuzzyFileIndexRootFreshness;
 
-export interface FuzzyFileIndexFreshness extends JsonObject {
-  readonly schemaVersion: number;
-  readonly stale: boolean;
-  readonly degraded: boolean;
-  readonly truncated: boolean;
-  readonly roots: readonly FuzzyFileIndexRootFreshness[];
-}
+export type FuzzyFileIndexFreshness = Wire.FuzzyFileIndexFreshness;
 
-export interface FuzzyFileMatcherMetadata extends JsonObject {
-  readonly quality: "optimal" | "degraded";
-  readonly resourceLimited: boolean;
-  readonly evaluatedCandidates: number;
-  readonly totalCandidates: number;
-}
+export type FuzzyFileMatcherMetadata = Wire.FuzzyFileMatcherMetadata;
 
-export interface FuzzyFileSearchResponse extends JsonObject {
-  readonly files: readonly FuzzyFileSearchResult[];
-  /** Present for searches served by the persistent index. */
-  readonly freshness?: FuzzyFileIndexFreshness;
-  /** Present for searches served by the persistent index. */
-  readonly matcher?: FuzzyFileMatcherMetadata;
-}
+export type FuzzyFileSearchResponse = Wire.FuzzyFileSearchResponse;
 
-export interface CommandExecResponse extends JsonObject {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
+export type CommandExecResponse = Wire.CommandExecResponse;
 
-export interface HealthPingResult extends JsonObject {
-  readonly ok: true;
-  readonly now: string;
-}
+export type HealthPingResult = Wire.HealthPingResult;
 
-export interface HealthReadyResult extends JsonObject {
-  readonly ready: boolean;
-  readonly uptimeMs: number;
-  readonly now: string;
-}
+export type HealthReadyResult = Wire.HealthReadyResult;
 
-export interface HealthStatsResult extends JsonObject {
-  readonly uptimeMs: number;
-  readonly now: string;
-  readonly sessions: JsonObject;
-  readonly memory: JsonObject;
-  readonly state?: JsonObject;
-}
+export type HealthStatsResult = Wire.HealthStatsResult;
 
-export interface DaemonReloadResult extends JsonObject {
-  readonly reloaded: true;
-  readonly configReloadedAt: string;
-  readonly mcpServer: JsonObject;
-}
+export type DaemonReloadResult = Wire.DaemonReloadResult;
 
-export interface DaemonShutdownResult extends JsonObject {
-  readonly shuttingDown: true;
-  readonly instanceId: string;
-}
+export type DaemonShutdownResult = Wire.DaemonShutdownResult;
 
-export interface AuthWhoamiResult extends JsonObject {
-  readonly authenticated: boolean;
-  readonly provider?: string;
-  readonly identity?: JsonObject;
-  readonly subscriptionTier?: "free" | "pro" | "team" | "enterprise";
-}
+export type AuthWhoamiResult = Wire.AuthWhoamiResult;
 
-export interface AuthLoginResult extends JsonObject {
-  readonly authenticated: true;
-  readonly provider?: string;
-  readonly identity?: JsonObject;
-}
+export type AuthLoginResult = Wire.AuthLoginResult;
 
-export interface AuthLogoutResult extends JsonObject {
-  readonly authenticated: false;
-}
+export type AuthLogoutResult = Wire.AuthLogoutResult;
 
-export interface AgencResultByMethod {
-  readonly "remote.capabilities": JsonObject;
-  readonly "remote.status": JsonObject;
-  readonly "remote.start": JsonObject;
-  readonly "remote.stop": JsonObject;
-  readonly "remote.pair.begin": JsonObject;
-  readonly "remote.pair.refresh": JsonObject;
-  readonly "remote.pair.cancel": JsonObject;
-  readonly "remote.devices": JsonObject;
-  readonly "remote.pending": JsonObject;
-  readonly "remote.approve": JsonObject;
-  readonly "remote.revoke": JsonObject;
-  readonly "telegram.capabilities": JsonObject;
-  readonly "telegram.status": JsonObject;
-  readonly "telegram.configure": JsonObject;
-  readonly "telegram.start": JsonObject;
-  readonly "telegram.stop": JsonObject;
-  readonly "telegram.revoke": JsonObject;
-  readonly "telegram.agents.list": JsonObject;
-  readonly "telegram.agents.create": JsonObject;
-  readonly "telegram.agents.update": JsonObject;
-  readonly "telegram.agents.start": JsonObject;
-  readonly "telegram.agents.stop": JsonObject;
-  readonly "telegram.agents.remove": JsonObject;
-  readonly "telegram.agents.pair.begin": JsonObject;
-  readonly "telegram.agents.pair.confirm": JsonObject;
-  readonly "telegram.agents.pair.cancel": JsonObject;
-  readonly initialize: InitializeResult;
-  readonly "request.cancel": RequestCancelResult;
-  readonly "agent.create": AgentCreateResult;
-  readonly "agent.list": AgentListResult;
-  readonly "agent.attach": AgentAttachResult;
-  readonly "agent.stop": AgentStopResult;
-  readonly "agent.logs": AgentLogsResult;
-  readonly "run.status": RunStatusResult;
-  readonly "run.result": RunResultResult;
-  readonly "run.replay": RunReplayResult;
-  readonly "run.evidence": RunEvidenceResult;
-  readonly "run.cancel": RunCancelResult;
-  readonly "run.start": RunStartResult;
-  readonly "routine.capabilities": RoutineCapabilities;
-  readonly "routine.list": RoutineListResult;
-  readonly "routine.get": RoutineResult;
-  readonly "routine.create": RoutineResult;
-  readonly "routine.update": RoutineResult;
-  readonly "routine.delete": RoutineDeleteResult;
-  readonly "routine.run": RoutineRunResult;
-  readonly "routine.runs": RoutineRunsResult;
-  readonly "routine.cancel": RoutineRunResult;
-  readonly "csvJob.review.list": CsvJobReviewListResult;
-  readonly "csvJob.review.show": CsvJobReviewShowResult;
-  readonly "csvJob.review.resolve": CsvJobReviewResolveResult;
-  readonly "session.create": SessionCreateResult;
-  readonly "session.list": SessionListResult;
-  readonly "session.attach": SessionAttachResult;
-  readonly "session.detach": SessionDetachResult;
-  readonly "session.terminate": SessionTerminateResult;
-  readonly "session.clear": SessionClearResult;
-  readonly "session.snapshot": SessionSnapshotResult;
-  readonly "session.transcript": SessionTranscriptResult;
-  readonly "session.transcript.v2": SessionTranscriptV2Result;
-  readonly "session.cancelTurn": SessionCancelTurnResult;
-  readonly "session.resolveToolCall": SessionResolveToolCallResult;
-  readonly "session.mcp.status": SessionMcpStatusResult;
-  readonly "session.mcp.addServer": SessionMcpAddServerResult;
-  readonly "message.send": MessageSendResult;
-  readonly "message.stream": MessageStreamResult;
-  readonly "thread/realtime/start": JsonObject;
-  readonly "thread/realtime/appendAudio": JsonObject;
-  readonly "thread/realtime/appendText": JsonObject;
-  readonly "thread/realtime/stop": JsonObject;
-  readonly "thread/realtime/listVoices": JsonObject;
-  readonly "tool.approve": ToolDecisionResult;
-  readonly "tool.deny": ToolDecisionResult;
-  readonly "tool.cancel": ToolDecisionResult;
-  readonly "elicitation.respond": ElicitationRespondResult;
-  readonly "permission.list": PermissionListResult;
-  readonly "fs.fuzzy_search": FuzzyFileSearchResponse;
-  readonly "commandExec.start": CommandExecResponse;
-  readonly "commandExec.write": JsonObject;
-  readonly "commandExec.resize": JsonObject;
-  readonly "commandExec.terminate": JsonObject;
-  readonly "health.ping": HealthPingResult;
-  readonly "health.ready": HealthReadyResult;
-  readonly "health.stats": HealthStatsResult;
-  readonly "daemon.reload": DaemonReloadResult;
-  readonly "daemon.shutdown": DaemonShutdownResult;
-  readonly "auth.login": AuthLoginResult;
-  readonly "auth.whoami": AuthWhoamiResult;
-  readonly "auth.logout": AuthLogoutResult;
-}
+export type AgencResultByMethod = Wire.AgenCDaemonResultByMethod;
 
 // ── Notification params ──────────────────────────────────────────────
 
@@ -1591,90 +592,41 @@ export interface AgencEventBaseParams extends JsonObject {
   readonly metadata?: JsonObject;
 }
 
-export interface EventMessageChunkParams extends AgencEventBaseParams {
-  readonly streamId?: string;
-  readonly delta: string;
-}
+export type EventMessageChunkParams = Wire.EventMessageChunkParams;
 
-export interface EventToolRequestParams extends AgencEventBaseParams {
-  readonly requestId: string;
-  readonly toolName: string;
-  readonly turnId?: string;
-  readonly input?: JsonValue;
-  readonly recoveryCategory?: "idempotent" | "side-effecting" | "interactive";
-}
+export type EventToolRequestParams = Wire.EventToolRequestParams;
 
-export interface EventPermissionRequestParams extends AgencEventBaseParams {
-  readonly requestId: string;
-  readonly toolName?: string;
-  readonly turnId?: string;
-  readonly permissions: readonly string[];
-  readonly input?: JsonValue;
-  readonly reason?: string;
-}
+export type EventPermissionRequestParams = Wire.EventPermissionRequestParams;
 
-export interface EventUserInputRequestParams extends AgencEventBaseParams {
-  readonly requestId: string;
-  readonly callId: string;
-  readonly turnId: string;
-  readonly questions: readonly JsonObject[];
-  readonly clientAction?: JsonObject;
-}
+export type EventUserInputRequestParams = Wire.EventUserInputRequestParams;
 
-export interface EventMcpElicitationRequestParams extends AgencEventBaseParams {
-  readonly requestId: RequestId;
-  readonly serverName: string;
-  readonly turnId: string;
-  readonly request: JsonObject;
-}
+export type EventMcpElicitationRequestParams =
+  Wire.EventMcpElicitationRequestParams;
 
 /** Non-journal control-plane invalidation for the passive MCP projection. */
-export interface EventMcpStatusChangedParams extends JsonObject {
-  readonly sessionId: string;
-  readonly revision: number;
-}
+export type EventMcpStatusChangedParams = Wire.EventMcpStatusChangedParams;
 
-export interface EventAgentStatusParams extends AgencEventBaseParams {
-  readonly agentId: string;
-  readonly status: AgentStatus;
-  readonly runStatus?: AgentRunStatus;
-  readonly turnId?: string;
-  readonly message?: string;
-}
+export type EventAgentStatusParams = Wire.EventAgentStatusParams;
 
-export interface EventSessionEventParams extends AgencEventBaseParams {
-  readonly event: JsonObject;
-}
+export type EventSessionEventParams = Wire.EventSessionEventParams;
 
 /** Observable, non-journal sentinel emitted by bounded live-delivery buffers. */
-export interface EventGapParams extends JsonObject {
-  readonly type: "event_gap";
-  readonly kind: "event_gap";
-  readonly sessionId: string;
-  readonly runId: string;
-  readonly eventId?: string;
-  readonly agentId?: string;
-  readonly sequence?: number;
-  readonly reason: "retention";
-  readonly source: "background_runner_retention" | "multiplexer_retention";
-  readonly retiredCount: number;
-  /** False means replay is required but the loss count is unknown (zero). */
-  readonly retiredCountKnown?: boolean;
-  readonly coordinatesAvailable?: boolean;
-  readonly afterSequence?: number;
-  readonly firstAvailableSequence?: number;
-}
+export type EventGapParams = Wire.EventGapParams;
 
 // ── Envelopes ────────────────────────────────────────────────────────
 
-export interface AgencDaemonRequest<
+export type AgencDaemonRequest<
   Method extends AgencDaemonMethod = AgencDaemonMethod,
-> {
-  readonly jsonrpc: typeof AGENC_SDK_JSON_RPC_VERSION;
-  readonly id: RequestId;
-  readonly method: Method;
-  readonly params?: AgencParamsByMethod[Method];
-}
+> = Wire.AgenCDaemonRequestByMethod[Method];
+
+/** Only methods whose wire envelope permits omission may omit the payload. */
+export type AgencRequestParams<Method extends AgencDaemonMethod> =
+  Extract<
+    AgencDaemonRequest<Method>,
+    { readonly params: unknown }
+  > extends never
+    ? [params?: AgencParamsByMethod[Method]]
+    : [params: AgencParamsByMethod[Method]];
 
 export type AgencDaemonErrorCode =
   -32700 | -32600 | -32601 | -32602 | -32603 | -32000;

--- a/packages/agenc-sdk/src/routines.ts
+++ b/packages/agenc-sdk/src/routines.ts
@@ -1,70 +1,20 @@
-import type { JsonObject } from "./protocol.js";
-
-/** Versioned local-daemon contract. No caller-supplied credentials or runtime authority. */
-export type RoutineSchedule =
-  | { readonly kind: "manual" }
-  | { readonly kind: "cron"; readonly expression: string };
-export type RoutineRunStatus = "starting" | "running" | "waiting_permission" | "completed" | "failed" | "cancelled" | "interrupted";
-export interface RoutineRun extends JsonObject {
-  readonly id: string;
-  readonly routineId: string;
-  readonly status: RoutineRunStatus;
-  readonly trigger: "manual" | "schedule";
-  readonly startedAt: string;
-  readonly finishedAt: string | null;
-  readonly agentId: string | null;
-  readonly sessionId: string | null;
-  readonly coreRunId: string | null;
-  readonly error: string | null;
-}
-export interface RoutineCreateParams extends JsonObject {
-  readonly name: string;
-  readonly description?: string;
-  readonly instructions: string;
-  readonly cwd: string;
-  readonly schedule: RoutineSchedule;
-  readonly provider?: string;
-  readonly model?: string;
-  readonly permissionMode?: "default" | "plan";
-  readonly enabled?: boolean;
-  readonly notifyOnCompletion?: boolean;
-}
-export interface Routine extends RoutineCreateParams {
-  readonly id: string;
-  readonly description: string;
-  readonly permissionMode: "default" | "plan";
-  readonly enabled: boolean;
-  readonly notifyOnCompletion: boolean;
-  readonly createdAt: string;
-  readonly updatedAt: string;
-  readonly nextRunAt: string | null;
-  readonly lastRun: RoutineRun | null;
-}
-export interface RoutineIdParams extends JsonObject { readonly id: string }
-export interface RoutineUpdateParams extends RoutineIdParams {
-  readonly patch: Partial<RoutineCreateParams>;
-  readonly expectedUpdatedAt?: string;
-}
-export interface RoutineDeleteParams extends RoutineIdParams { readonly expectedUpdatedAt?: string }
-export interface RoutineRunsParams extends RoutineIdParams { readonly limit?: number }
-export interface RoutineCancelParams extends RoutineIdParams { readonly runId?: string }
-export interface RoutineCapabilities extends JsonObject {
-  readonly version: 1;
-  readonly available: true;
-  readonly scheduleKinds: readonly ["manual", "cron"];
-  readonly permissionModes: readonly ["default", "plan"];
-  readonly timezone: string;
-  readonly executionMode: "local";
-  readonly maxRoutines: number;
-  readonly maxRunsPerRoutine: number;
-}
-export interface RoutineResult extends JsonObject { readonly routine: Routine }
-export interface RoutineRunResult extends JsonObject { readonly run: RoutineRun }
-export interface RoutineListResult extends JsonObject { readonly routines: readonly Routine[] }
-export interface RoutineRunsResult extends JsonObject { readonly runs: readonly RoutineRun[] }
-export interface RoutineDeleteResult extends JsonObject { readonly deleted: true }
-/** Invalidation only: clients refresh list/detail; no instructions or results are broadcast. */
-export interface RoutineUpdatedEvent extends JsonObject {
-  readonly id: string;
-  readonly reason: "created" | "updated" | "deleted" | "run";
-}
+/** Standalone aliases of the daemon-owned routine wire contract. */
+export type {
+  RoutineSchedule,
+  RoutineRunStatus,
+  RoutineRun,
+  RoutineCreateParams,
+  Routine,
+  RoutineIdParams,
+  RoutineUpdateParams,
+  RoutineDeleteParams,
+  RoutineRunsParams,
+  RoutineCancelParams,
+  RoutineCapabilities,
+  RoutineResult,
+  RoutineRunResult,
+  RoutineListResult,
+  RoutineRunsResult,
+  RoutineDeleteResult,
+  RoutineUpdatedEvent,
+} from "./protocol-wire.generated.js";

--- a/packages/agenc/test/installer-sqlite-lock-sync.test.mjs
+++ b/packages/agenc/test/installer-sqlite-lock-sync.test.mjs
@@ -94,10 +94,11 @@ test("canonical installer uses explicit ASCII ordering for exact keys", () => {
   );
 });
 
-test("Sonar excludes only canonical installer duplication", () => {
+test("Sonar excludes only canonical installer and generated wire copies", () => {
   assert.equal(
     readFileSync(join(repoRoot, ".sonarcloud.properties"), "utf8"),
-    "sonar.cpd.exclusions=scripts/install/runtime-installer.cjs\n",
+    "# The public wire copy is generated and checked against its canonical declarations.\n" +
+      "sonar.cpd.exclusions=scripts/install/runtime-installer.cjs,packages/agenc-sdk/src/protocol-wire.generated.ts\n",
   );
 });
 

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.047131,
-            "maxMs": 99.367188,
-            "medianMs": 89.461279,
-            "minMs": 85.636365,
+            "madMs": 1.995908,
+            "maxMs": 96.089812,
+            "medianMs": 84.562651,
+            "minMs": 82.566743,
             "sampleCount": 5,
             "samplesMs": [
-              99.367188,
-              89.461279,
-              88.414148,
-              89.910272,
-              85.636365
+              96.089812,
+              89.927361,
+              84.562651,
+              84.059517,
+              82.566743
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 184942592,
+              "maximumObservedBytes": 185741312,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                134860800,
-                140378112,
-                176553984,
-                176553984,
-                178651136,
-                178651136,
-                180748288,
-                180748288,
-                182321152,
-                182321152,
-                184942592
+                136654848,
+                141000704,
+                176828416,
+                176828416,
+                178401280,
+                178401280,
+                182071296,
+                182071296,
+                182595584,
+                182595584,
+                185741312
               ]
             },
-            "peakRssBytes": 184942592,
+            "peakRssBytes": 185741312,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 6.08497,
-            "maxMs": 190.248375,
-            "medianMs": 184.163405,
-            "minMs": 166.612285,
+            "madMs": 6.305057,
+            "maxMs": 180.436025,
+            "medianMs": 172.553624,
+            "minMs": 166.248567,
             "sampleCount": 5,
             "samplesMs": [
-              190.248375,
-              185.499666,
-              166.612285,
-              184.163405,
-              173.7136
+              180.436025,
+              179.804396,
+              172.553624,
+              169.773335,
+              166.248567
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 196628480,
+              "maximumObservedBytes": 198356992,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                122662912,
-                139616256,
-                177364992,
-                177364992,
-                182607872,
-                182607872,
-                188375040,
-                188375040,
-                192958464,
-                192958464,
-                196628480
+                122191872,
+                140365824,
+                178114560,
+                178114560,
+                184406016,
+                184406016,
+                190697472,
+                190697472,
+                194686976,
+                194686976,
+                198356992
               ]
             },
-            "peakRssBytes": 199614464,
+            "peakRssBytes": 201408512,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.333769,
-            "maxMs": 362.349932,
-            "medianMs": 343.236087,
-            "minMs": 338.661673,
+            "madMs": 3.296273,
+            "maxMs": 350.108167,
+            "medianMs": 334.73423,
+            "minMs": 331.437957,
             "sampleCount": 5,
             "samplesMs": [
-              362.349932,
-              346.569856,
-              341.116815,
-              343.236087,
-              338.661673
+              350.108167,
+              334.472982,
+              334.73423,
+              344.02702,
+              331.437957
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 219652096,
+              "maximumObservedBytes": 214020096,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                122675200,
-                176758784,
-                189865984,
-                189865984,
-                199475200,
-                199475200,
-                207863808,
-                207863808,
-                218120192,
-                218120192,
-                219652096
+                124325888,
+                180326400,
+                193433600,
+                193433600,
+                204840960,
+                204840960,
+                212705280,
+                212705280,
+                212971520,
+                212971520,
+                214020096
               ]
             },
-            "peakRssBytes": 220741632,
+            "peakRssBytes": 216899584,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.396182,
-            "maxMs": 3.878996,
-            "medianMs": 2.958357,
-            "minMs": 2.527863,
+            "madMs": 0.379275,
+            "maxMs": 3.708307,
+            "medianMs": 3.074875,
+            "minMs": 2.520144,
             "sampleCount": 5,
             "samplesMs": [
-              3.878996,
-              2.68425,
-              3.354539,
-              2.527863,
-              2.958357
+              3.708307,
+              2.6956,
+              3.314329,
+              2.520144,
+              3.074875
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 89731072,
+              "maximumObservedBytes": 91021312,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                81342464,
-                82391040,
-                85012480,
-                85012480,
-                86061056,
-                86061056,
-                87633920,
-                87633920,
-                88682496,
-                88682496,
-                89731072
+                82632704,
+                83156992,
+                86302720,
+                86302720,
+                87351296,
+                87351296,
+                88399872,
+                88399872,
+                89972736,
+                89972736,
+                91021312
               ]
             },
-            "peakRssBytes": 89731072,
+            "peakRssBytes": 91021312,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.212313,
-            "maxMs": 7.251573,
-            "medianMs": 5.559851,
-            "minMs": 5.333457,
+            "madMs": 0.509032,
+            "maxMs": 6.746627,
+            "medianMs": 5.52276,
+            "minMs": 5.013728,
             "sampleCount": 5,
             "samplesMs": [
-              7.251573,
-              5.559851,
-              5.772164,
-              5.436674,
-              5.333457
+              6.746627,
+              5.52276,
+              6.384638,
+              5.127981,
+              5.013728
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 104407040,
+              "maximumObservedBytes": 103096320,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                82911232,
-                88678400,
-                90251264,
-                90251264,
-                94445568,
-                94445568,
-                96542720,
-                96542720,
-                102309888,
-                102309888,
-                104407040
+                81600512,
+                87367680,
+                88940544,
+                88940544,
+                93134848,
+                93134848,
+                95756288,
+                95756288,
+                101523456,
+                101523456,
+                103096320
               ]
             },
-            "peakRssBytes": 104407040,
+            "peakRssBytes": 103096320,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.792615,
-            "maxMs": 15.876814,
-            "medianMs": 11.153264,
-            "minMs": 10.360649,
+            "madMs": 1.192909,
+            "maxMs": 15.51341,
+            "medianMs": 12.121263,
+            "minMs": 9.733118,
             "sampleCount": 5,
             "samplesMs": [
-              11.037548,
-              12.791294,
-              11.153264,
-              10.360649,
-              15.876814
+              11.589465,
+              13.314172,
+              12.121263,
+              9.733118,
+              15.51341
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 125190144,
+              "maximumObservedBytes": 125722624,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                83771392,
-                93208576,
-                98975744,
-                98975744,
-                103170048,
-                103170048,
-                109461504,
-                109461504,
-                117325824,
-                117325824,
-                125190144
+                85876736,
+                96362496,
+                101081088,
+                101081088,
+                106323968,
+                106323968,
+                112091136,
+                112091136,
+                119431168,
+                119431168,
+                125722624
               ]
             },
-            "peakRssBytes": 125190144,
+            "peakRssBytes": 125722624,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -588,7 +588,7 @@
         },
         {
           "path": "runtime/src/config/env.ts",
-          "sha256": "3f89fd7951bd19c5618a6d9ae98b23142e87a2161d6f4b1d1937f9417049991e"
+          "sha256": "4d169fff7ad68e85243f3ddf4d0591f5f151470a8bdab0e7a1000e1e6c35270b"
         },
         {
           "path": "runtime/src/config/home.ts",
@@ -599,12 +599,16 @@
           "sha256": "484e1487b3ab879482a38bb1327485b487b02e0ba85cf15e6daca96b2577cf45"
         },
         {
+          "path": "runtime/src/config/mcp-oauth.ts",
+          "sha256": "02aa27382e73afddd2a36f86f417c3c59014cd2f9bd8470e7bae8d49381a2c66"
+        },
+        {
           "path": "runtime/src/config/provider-model-authority.ts",
           "sha256": "a12b4f3c83db60b2023336e6970ed134c1aa50b7a0cd00fc078f6d3674885a65"
         },
         {
           "path": "runtime/src/config/schema.ts",
-          "sha256": "91a470708e57cdfbcef72417ce2d8a63df4d275f11a0cb0fc2754e06053d83b8"
+          "sha256": "f3d47a5fc0cbd64d136adfb52f5d5af5239a3290a63b17a84f904a9aa3d86996"
         },
         {
           "path": "runtime/src/config/strict-schema.ts",
@@ -652,7 +656,11 @@
         },
         {
           "path": "runtime/src/llm/registry/model-catalog.ts",
-          "sha256": "2ac9b71c5f5276b6d250782b806bdfeaa7d5795b1b92d01f01a7abdf740afee9"
+          "sha256": "a6e593f3ca637754ce3189c85aee044131fd7d32367454f4ead239c6dab282fd"
+        },
+        {
+          "path": "runtime/src/llm/registry/openai-reasoning-models.ts",
+          "sha256": "33f8818602dc8eaa37b28540c079dfd77a0cef3988819a057dade3f0600c8b80"
         },
         {
           "path": "runtime/src/llm/registry/openrouter-free-models.ts",
@@ -660,7 +668,7 @@
         },
         {
           "path": "runtime/src/llm/registry/provider-info.ts",
-          "sha256": "c4c9a14a44b192e7aa480f9a6037edca488dc3df53148351ef6ee7c41e8bcfe6"
+          "sha256": "a81b21f771349a49ba7e9a3e8d09c83093d3c8cd0f68cd145658e0759437a402"
         },
         {
           "path": "runtime/src/llm/registry/provider-ingress.ts",
@@ -740,7 +748,7 @@
         },
         {
           "path": "runtime/src/session/environment.ts",
-          "sha256": "345d611d9852c61aa28a1a4591929b9581314d115188dd6f71f9dcdd678559d9"
+          "sha256": "896dd3d3f5d65df3202e59cedb1e23a2194f64d2b73d38c7d40becbbc4ab71d6"
         },
         {
           "path": "runtime/src/session/event-log.ts",
@@ -868,7 +876,7 @@
         },
         {
           "path": "runtime/src/utils/secretEnv.ts",
-          "sha256": "6239a2650885763e621ca0a3f3b18df73379fe8452a012a06f0f0a96a3dcc60c"
+          "sha256": "94c894ef46ca973705fde1855109c86cc96656ef0b8046cfa297bd732f003d94"
         },
         {
           "path": "runtime/src/utils/semver.ts",
@@ -943,11 +951,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "ba2c22104cc0bb3d9cf242f17bc50bdd1427ca8e",
+    "gitObjectId": "d5dd1db4f900b9d52e3baa50940cfa0bf0923a60",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "c506ece504e0e82a367e63c208654a20c3525143",
+  "sourceRevision": "fbbcf685bc4e9501c0ad5154d2e68104d3655b05",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,10 +4,10 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `4bae451c602631b0733596659e1bbe226cc27dbaef5aeb3f2f1cce97abc5e6b8`
-- Source revision: `c506ece504e0e82a367e63c208654a20c3525143`
-- Production tree: `runtime/src` at Git object `ba2c22104cc0bb3d9cf242f17bc50bdd1427ca8e`
-- Loaded production closure: `94` module bindings across `2` cases
+- JSON SHA-256: `248bda8a02725fcbb9011ef572b67bb47e3b2af6522c08b8eff45a9d69aa26e3`
+- Source revision: `fbbcf685bc4e9501c0ad5154d2e68104d3655b05`
+- Production tree: `runtime/src` at Git object `d5dd1db4f900b9d52e3baa50940cfa0bf0923a60`
+- Loaded production closure: `96` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
 - OS/CPU: `linux 7.0.0-30-generic x64` / `AMD Ryzen Threadripper PRO 9975WX 32-Cores` (64 logical)
@@ -18,12 +18,12 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 89.461 | 1.047 | 184942592 | 184942592 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 184.163 | 6.085 | 199614464 | 196628480 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 343.236 | 3.334 | 220741632 | 219652096 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.958 | 0.396 | 89731072 | 89731072 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.560 | 0.212 | 104407040 | 104407040 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 11.153 | 0.793 | 125190144 | 125190144 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 84.563 | 1.996 | 185741312 | 185741312 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 172.554 | 6.305 | 201408512 | 198356992 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 334.734 | 3.296 | 216899584 | 214020096 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 3.075 | 0.379 | 91021312 | 91021312 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.523 | 0.509 | 103096320 | 103096320 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 12.121 | 1.193 | 125722624 | 125722624 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision c506ece504e0e82a367e63c208654a20c3525143 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision fbbcf685bc4e9501c0ad5154d2e68104d3655b05 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -191,6 +191,26 @@ async function synchronizeGeneratedFile({ generatedPath, expected, write }) {
   return { changed: true, matches: true, expected };
 }
 
+function appendWireParityFailures(failures, parity) {
+  for (const [surface, methods] of Object.entries(parity.mismatches)) {
+    expectCondition(
+      failures,
+      methods.length === 0,
+      `${surface}: ${methods.join(", ")}`,
+    );
+  }
+  for (const diagnostic of parity.diagnostics) {
+    failures.push(`${diagnostic.file ?? "compiler"}: ${diagnostic.message}`);
+  }
+}
+
+function reportSdkGeneratedTypesSuccess(mode) {
+  const message = mode === "write"
+    ? `regenerated SDK artifacts; run ${checkCommand} to verify wire parity`
+    : "verified committed SDK types";
+  process.stdout.write(`[sdk generated types] ${message}\n`);
+}
+
 async function main() {
   const mode = parseSdkGeneratedTypesMode(process.argv.slice(2));
   const transcriptV2Path = path.join(
@@ -376,16 +396,8 @@ async function main() {
     `${paths.packageWire} is stale; run ${checkCommand} -- --write`,
   );
 
-  const parity = checkSdkWireParity();
-  for (const [surface, methods] of Object.entries(parity.mismatches)) {
-    expectCondition(
-      failures,
-      methods.length === 0,
-      `${surface}: ${methods.join(", ")}`,
-    );
-  }
-  for (const diagnostic of parity.diagnostics) {
-    failures.push(`${diagnostic.file ?? "compiler"}: ${diagnostic.message}`);
+  if (mode === "check") {
+    appendWireParityFailures(failures, checkSdkWireParity());
   }
 
   if (failures.length > 0) {
@@ -396,7 +408,7 @@ async function main() {
     return;
   }
 
-  process.stdout.write("[sdk generated types] verified committed SDK types\n");
+  reportSdkGeneratedTypesSuccess(mode);
 }
 
 if (

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -5,6 +5,8 @@ import { lstat, open, readFile, rename, unlink } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { renderSdkWireTypes } from "./sdk-wire-types.mjs";
+import { checkSdkWireParity } from "./check-sdk-wire-parity.mjs";
 import {
   createSourceFile,
   isInterfaceDeclaration,
@@ -21,6 +23,7 @@ const paths = {
   generated: "src/entrypoints/sdk/coreTypes.generated.ts",
   runtimeProtocol: "src/app-server/protocol/index.ts",
   packageTranscriptV2: "../packages/agenc-sdk/src/transcript-v2.generated.ts",
+  packageWire: "../packages/agenc-sdk/src/protocol-wire.generated.ts",
   packageWorkflowResult:
     "../packages/agenc-sdk/src/workflow-result.generated.ts",
 };
@@ -152,6 +155,19 @@ export async function synchronizeTranscriptV2Generated({
 }) {
   const runtimeProtocol = await readFile(runtimeProtocolPath, "utf8");
   const expected = renderTranscriptV2Generated(runtimeProtocol);
+  return synchronizeGeneratedFile({ generatedPath, expected, write });
+}
+
+export async function synchronizeSdkWireGenerated({
+  runtimeProtocolPath,
+  generatedPath,
+  write = false,
+}) {
+  const expected = await renderSdkWireTypes(runtimeProtocolPath);
+  return synchronizeGeneratedFile({ generatedPath, expected, write });
+}
+
+async function synchronizeGeneratedFile({ generatedPath, expected, write }) {
   let current;
   try {
     current = await readFile(generatedPath, "utf8");
@@ -187,6 +203,7 @@ async function main() {
     generated,
     packageWorkflowResult,
     transcriptV2,
+    wire,
   ] = await Promise.all([
     readRuntimeFile(paths.schemas),
     readRuntimeFile(paths.coreTypes),
@@ -195,6 +212,11 @@ async function main() {
     synchronizeTranscriptV2Generated({
       runtimeProtocolPath: path.join(runtimeRoot, paths.runtimeProtocol),
       generatedPath: transcriptV2Path,
+      write: mode === "write",
+    }),
+    synchronizeSdkWireGenerated({
+      runtimeProtocolPath: path.join(runtimeRoot, paths.runtimeProtocol),
+      generatedPath: path.join(runtimeRoot, paths.packageWire),
       write: mode === "write",
     }),
   ]);
@@ -207,6 +229,9 @@ async function main() {
       transcriptV2.changed
         ? `[sdk generated types] wrote ${displayPath}\n`
         : `[sdk generated types] ${displayPath} is already current\n`,
+    );
+    process.stdout.write(
+      `[sdk generated types] ${wire.changed ? "wrote" : "current"} ${paths.packageWire}\n`,
     );
   }
   const failures = [];
@@ -345,6 +370,23 @@ async function main() {
     transcriptV2.matches,
     `${paths.packageTranscriptV2} is not the exact generated transcript.v2 mirror; regenerate it from ${paths.runtimeProtocol}`,
   );
+  expectCondition(
+    failures,
+    wire.matches,
+    `${paths.packageWire} is stale; run ${checkCommand} -- --write`,
+  );
+
+  const parity = checkSdkWireParity();
+  for (const [surface, methods] of Object.entries(parity.mismatches)) {
+    expectCondition(
+      failures,
+      methods.length === 0,
+      `${surface}: ${methods.join(", ")}`,
+    );
+  }
+  for (const diagnostic of parity.diagnostics) {
+    failures.push(`${diagnostic.file ?? "compiler"}: ${diagnostic.message}`);
+  }
 
   if (failures.length > 0) {
     process.stderr.write(

--- a/runtime/scripts/check-sdk-wire-parity.mjs
+++ b/runtime/scripts/check-sdk-wire-parity.mjs
@@ -1,0 +1,220 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+/** Compile every public mapping, envelope and generic client call signature. */
+export function checkSdkWireParity({
+  root = repositoryRoot,
+  sourceOverrides = new Map(),
+  consumerSource = "",
+} = {}) {
+  const runtimeRoot = path.join(root, "runtime");
+  const configFile = path.join(runtimeRoot, "tsconfig.json");
+  const config = ts.readConfigFile(configFile, ts.sys.readFile);
+  if (config.error !== undefined)
+    throw new Error(
+      ts.flattenDiagnosticMessageText(config.error.messageText, "\n"),
+    );
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    runtimeRoot,
+  );
+  if (parsed.errors.length > 0)
+    throw new Error(
+      ts.flattenDiagnosticMessageText(parsed.errors[0].messageText, "\n"),
+    );
+  const virtualPath = path.join(runtimeRoot, "sdk-wire-parity.check.ts");
+  const protocolPath = path.join(
+    runtimeRoot,
+    "src/app-server/protocol/index.ts",
+  );
+  const protocol = ts.createSourceFile(
+    protocolPath,
+    sourceOverrides.get(protocolPath) ?? ts.sys.readFile(protocolPath),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const registry = protocol.statements
+    .filter(ts.isVariableStatement)
+    .flatMap((statement) => statement.declarationList.declarations)
+    .find(
+      (declaration) =>
+        declaration.name.getText(protocol) === "AGENC_DAEMON_METHODS",
+    );
+  const array = registry?.initializer;
+  if (
+    array === undefined ||
+    !ts.isAsExpression(array) ||
+    !ts.isArrayLiteralExpression(array.expression) ||
+    !array.expression.elements.every(ts.isStringLiteral)
+  ) {
+    throw new Error(
+      "SDK wire parity requires the canonical public method registry",
+    );
+  }
+  const methods = array.expression.elements.map((element) => element.text);
+  const exact = (name, left, right) =>
+    `type ${name} = {\n${methods
+      .map((method) => {
+        const literal = JSON.stringify(method);
+        return `${literal}: Equal<${left(literal)}, ${right(literal)}>;`;
+      })
+      .join("\n")}\n};`;
+  const source = `
+import type { AgenCDaemonRequest, AgenCDaemonResultByMethod, AgenCDaemonMethod } from "./src/app-server/protocol/index.js";
+import type { AgencParamsByMethod, AgencResultByMethod, AgencDaemonRequest } from "../packages/agenc-sdk/src/protocol.js";
+import type { AgencClient } from "../packages/agenc-sdk/src/client.js";
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? ((<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2) ? true : false)
+    : false;
+type WireRequest<M extends AgenCDaemonMethod, Request = AgenCDaemonRequest> =
+  Request extends { readonly method: infer Names }
+    ? M extends Names
+      ? { [Key in keyof Request]: Key extends "method" ? M : Request[Key] }
+      : never
+    : never;
+type WireParams<M extends AgenCDaemonMethod> = NonNullable<WireRequest<M>["params"]>;
+${exact(
+  "RequestExact",
+  (method) => `WireParams<${method}>`,
+  (method) => `AgencParamsByMethod[${method}]`,
+)}
+${exact(
+  "ResultExact",
+  (method) => `AgenCDaemonResultByMethod[${method}]`,
+  (method) => `AgencResultByMethod[${method}]`,
+)}
+${exact(
+  "EnvelopeExact",
+  (method) => `WireRequest<${method}>`,
+  (method) => `AgencDaemonRequest<${method}>`,
+)}
+declare const client: AgencClient;
+type WireArguments<M extends AgenCDaemonMethod> = WireRequest<M> extends { readonly params: unknown }
+  ? [method: M, params: WireParams<M>]
+  : [method: M, params?: WireParams<M>];
+${exact(
+  "ClientArgumentsExact",
+  (method) => `WireArguments<${method}>`,
+  (method) => `Parameters<typeof client.request<${method}>>`,
+)}
+type RequireTrue<T extends true> = T;
+type RequestKeysMatch = RequireTrue<Equal<keyof AgencParamsByMethod, AgenCDaemonMethod>>;
+type ResultKeysMatch = RequireTrue<Equal<keyof AgencResultByMethod, AgenCDaemonMethod>>;
+type RequireAll<T extends { [M in AgenCDaemonMethod]: true }> = T;
+type RequestsCovered = RequireAll<{ [M in AgenCDaemonMethod]: [WireRequest<M>] extends [never] ? false : true }>;
+type RequestsMatch = RequireAll<RequestExact>;
+type ResultsMatch = RequireAll<ResultExact>;
+type EnvelopesMatch = RequireAll<EnvelopeExact>;
+type ClientArgumentsMatch = RequireAll<ClientArgumentsExact>;
+${consumerSource}
+`;
+  const options = {
+    ...parsed.options,
+    noEmit: true,
+    rootDir: undefined,
+    noUnusedLocals: false,
+    noUnusedParameters: false,
+    typeRoots: [
+      path.join(root, "node_modules/@types"),
+      path.join(runtimeRoot, "node_modules/@types"),
+    ],
+  };
+  const host = ts.createCompilerHost(options);
+  const originalReadFile = host.readFile.bind(host);
+  host.readFile = (filePath) => {
+    if (path.resolve(filePath) === virtualPath) return source;
+    return (
+      sourceOverrides.get(path.resolve(filePath)) ?? originalReadFile(filePath)
+    );
+  };
+  const originalFileExists = host.fileExists.bind(host);
+  host.fileExists = (filePath) =>
+    path.resolve(filePath) === virtualPath || originalFileExists(filePath);
+  const program = ts.createProgram(
+    [
+      virtualPath,
+      ...parsed.fileNames.filter((fileName) => fileName.endsWith(".d.ts")),
+    ],
+    options,
+    host,
+  );
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(virtualPath);
+  if (sourceFile === undefined)
+    throw new Error("SDK wire parity compiler did not load its assertions");
+  const mismatches = {};
+  for (const name of [
+    "RequestExact",
+    "ResultExact",
+    "EnvelopeExact",
+    "ClientArgumentsExact",
+  ]) {
+    const declaration = sourceFile.statements.find(
+      (node) => ts.isTypeAliasDeclaration(node) && node.name.text === name,
+    );
+    const properties = checker.getTypeAtLocation(declaration).getProperties();
+    if (properties.length === 0)
+      throw new Error(`SDK wire parity found no methods for ${name}`);
+    mismatches[name] = properties
+      .filter(
+        (property) =>
+          checker.typeToString(
+            checker.getTypeOfSymbolAtLocation(property, declaration),
+          ) !== "true",
+      )
+      .map((property) => property.name);
+  }
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)
+    .map((diagnostic) => ({
+      file:
+        diagnostic.file === undefined
+          ? null
+          : path
+              .relative(root, diagnostic.file.fileName)
+              .split(path.sep)
+              .join("/"),
+      message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    }));
+  return {
+    matches:
+      diagnostics.length === 0 &&
+      Object.values(mismatches).every((list) => list.length === 0),
+    mismatches,
+    diagnostics,
+  };
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const result = checkSdkWireParity();
+  if (!result.matches) {
+    for (const [surface, methods] of Object.entries(result.mismatches)) {
+      if (methods.length > 0)
+        process.stderr.write(
+          `[sdk wire parity] ${surface}: ${methods.join(", ")}\n`,
+        );
+    }
+    for (const diagnostic of result.diagnostics.slice(0, 10)) {
+      process.stderr.write(
+        `[sdk wire parity] ${diagnostic.file ?? "compiler"}: ${diagnostic.message}\n`,
+      );
+    }
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(
+      "[sdk wire parity] all public request, result, envelope and client argument types match\n",
+    );
+  }
+}

--- a/runtime/scripts/sdk-wire-types.mjs
+++ b/runtime/scripts/sdk-wire-types.mjs
@@ -36,30 +36,7 @@ export async function renderSdkWireTypes(
       ts.ScriptTarget.Latest,
       true,
     );
-    const local = new Map();
-    const imports = new Map();
-    for (const node of source.statements) {
-      if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
-        local.set(node.name.text, node);
-      } else if (ts.isVariableStatement(node)) {
-        for (const declaration of node.declarationList.declarations) {
-          if (ts.isIdentifier(declaration.name))
-            local.set(declaration.name.text, node);
-        }
-      } else if (
-        ts.isImportDeclaration(node) &&
-        node.importClause?.namedBindings !== undefined &&
-        ts.isNamedImports(node.importClause.namedBindings)
-      ) {
-        for (const binding of node.importClause.namedBindings.elements) {
-          imports.set(binding.name.text, {
-            specifier: node.moduleSpecifier.text,
-            name: binding.propertyName?.text ?? binding.name.text,
-          });
-        }
-      }
-    }
-    const module = { source, local, imports };
+    const module = indexModuleBindings(source);
     modules.set(filePath, module);
     return module;
   }
@@ -94,19 +71,7 @@ export async function renderSdkWireTypes(
     }
     names.set(name, key);
     included.set(key, node);
-    if (ts.isVariableStatement(node)) {
-      if (!(node.declarationList.flags & ts.NodeFlags.Const)) {
-        throw new Error(`Wire value ${name} must be const`);
-      }
-      for (const declaration of node.declarationList.declarations) {
-        if (
-          declaration.initializer === undefined ||
-          !isStaticWireValue(declaration.initializer)
-        ) {
-          throw new Error(`Wire value ${name} contains executable code`);
-        }
-      }
-    }
+    validateWireConstant(node, name);
     const dependencies = new Set();
     function visit(child) {
       if (
@@ -131,37 +96,81 @@ export async function renderSdkWireTypes(
     emitted.add(node);
     return [printer.printNode(ts.EmitHint.Unspecified, node, source)];
   });
-  return [
-    "// @generated from the daemon protocol and its referenced declarations. Do not edit.",
-    "// Regenerate: npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write",
-    "// Public wire types only; this module has no runtime-internal imports.",
-    "",
-    ...body,
-    "",
+  return (
     [
-      "type PublicRequestForMethod<Method, Request = AgenCDaemonRequest> =",
-      "  Request extends { readonly method: infer Names }",
-      "    ? Method extends Names",
-      '      ? { [Key in keyof Request]: Key extends "method" ? Method : Request[Key] }',
-      "      : never",
-      "    : never;",
+      "// @generated from the daemon protocol and its referenced declarations. Do not edit.",
+      "// Regenerate: npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write",
+      "// Public wire types only; this module has no runtime-internal imports.",
       "",
-      "export type AgenCDaemonRequestByMethod = {",
-      "  readonly [Method in AgenCDaemonMethod]: PublicRequestForMethod<Method>;",
-      "};",
-    ].join("\n"),
-    [
-      "export type AgenCDaemonParamsByMethod = {",
-      "  readonly [Method in AgenCDaemonMethod]: NonNullable<",
-      '    AgenCDaemonRequestByMethod[Method]["params"]',
-      "  >;",
-      "};",
-    ].join("\n"),
-    "",
-  ]
-    .join("\n\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/\n+$/, "\n");
+      ...body,
+      "",
+      [
+        "type PublicRequestForMethod<Method, Request = AgenCDaemonRequest> =",
+        "  Request extends { readonly method: infer Names }",
+        "    ? Method extends Names",
+        '      ? { [Key in keyof Request]: Key extends "method" ? Method : Request[Key] }',
+        "      : never",
+        "    : never;",
+        "",
+        "export type AgenCDaemonRequestByMethod = {",
+        "  readonly [Method in AgenCDaemonMethod]: PublicRequestForMethod<Method>;",
+        "};",
+      ].join("\n"),
+      [
+        "export type AgenCDaemonParamsByMethod = {",
+        "  readonly [Method in AgenCDaemonMethod]: NonNullable<",
+        '    AgenCDaemonRequestByMethod[Method]["params"]',
+        "  >;",
+        "};",
+      ].join("\n"),
+      "",
+    ]
+      .join("\n\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trimEnd() + "\n"
+  );
+}
+
+function indexModuleBindings(source) {
+  const local = new Map();
+  const imports = new Map();
+  for (const node of source.statements) {
+    if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
+      local.set(node.name.text, node);
+    } else if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name))
+          local.set(declaration.name.text, node);
+      }
+    } else if (
+      ts.isImportDeclaration(node) &&
+      node.importClause?.namedBindings !== undefined &&
+      ts.isNamedImports(node.importClause.namedBindings)
+    ) {
+      for (const binding of node.importClause.namedBindings.elements) {
+        imports.set(binding.name.text, {
+          specifier: node.moduleSpecifier.text,
+          name: binding.propertyName?.text ?? binding.name.text,
+        });
+      }
+    }
+  }
+  return { source, local, imports };
+}
+
+function validateWireConstant(node, name) {
+  if (!ts.isVariableStatement(node)) return;
+  if ((node.declarationList.flags & ts.NodeFlags.Const) === 0) {
+    throw new Error(`Wire value ${name} must be const`);
+  }
+  for (const declaration of node.declarationList.declarations) {
+    if (
+      declaration.initializer === undefined ||
+      !isStaticWireValue(declaration.initializer)
+    ) {
+      throw new Error(`Wire value ${name} contains executable code`);
+    }
+  }
 }
 
 function isStaticWireValue(node) {

--- a/runtime/scripts/sdk-wire-types.mjs
+++ b/runtime/scripts/sdk-wire-types.mjs
@@ -1,0 +1,201 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+
+const PUBLIC_WIRE_ROOTS = [
+  "JSON_RPC_VERSION",
+  "AGENC_DAEMON_PROTOCOL_VERSION",
+  "AGENC_DAEMON_METHODS",
+  "AGENC_DAEMON_NOTIFICATION_METHODS",
+  "AgenCDaemonRequest",
+  "AgenCDaemonResultByMethod",
+  "AgenCDaemonNotificationParamsByMethod",
+  "AgenCDaemonErrorResponse",
+  // The SDK retains an explicit compatibility adapter for old admission logs.
+  "RunAdmissionJournalEvent",
+];
+
+/** Copy the public declaration closure without bundling runtime imports. */
+export async function renderSdkWireTypes(
+  protocolPath,
+  { sourceOverrides = new Map() } = {},
+) {
+  const modules = new Map();
+  const included = new Map();
+  const names = new Map();
+  const declarations = [];
+
+  async function loadModule(filePath) {
+    const cached = modules.get(filePath);
+    if (cached !== undefined) return cached;
+    const source = ts.createSourceFile(
+      filePath,
+      (
+        sourceOverrides.get(filePath) ?? (await readFile(filePath, "utf8"))
+      ).replace(/\r\n?/g, "\n"),
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const local = new Map();
+    const imports = new Map();
+    for (const node of source.statements) {
+      if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
+        local.set(node.name.text, node);
+      } else if (ts.isVariableStatement(node)) {
+        for (const declaration of node.declarationList.declarations) {
+          if (ts.isIdentifier(declaration.name))
+            local.set(declaration.name.text, node);
+        }
+      } else if (
+        ts.isImportDeclaration(node) &&
+        node.importClause?.namedBindings !== undefined &&
+        ts.isNamedImports(node.importClause.namedBindings)
+      ) {
+        for (const binding of node.importClause.namedBindings.elements) {
+          imports.set(binding.name.text, {
+            specifier: node.moduleSpecifier.text,
+            name: binding.propertyName?.text ?? binding.name.text,
+          });
+        }
+      }
+    }
+    const module = { source, local, imports };
+    modules.set(filePath, module);
+    return module;
+  }
+
+  async function include(filePath, name) {
+    const module = await loadModule(filePath);
+    const imported = module.imports.get(name);
+    if (imported !== undefined) {
+      if (!imported.specifier.startsWith(".") || imported.name !== name) {
+        throw new Error(
+          `Unsupported wire type import ${name} from ${imported.specifier}`,
+        );
+      }
+      return include(
+        path.resolve(
+          path.dirname(filePath),
+          imported.specifier.replace(/\.js$/, ".ts"),
+        ),
+        imported.name,
+      );
+    }
+    const node = module.local.get(name);
+    if (node === undefined)
+      throw new Error(
+        `Missing canonical wire declaration ${name} in ${filePath}`,
+      );
+    const key = `${filePath}:${name}`;
+    if (included.has(key)) return;
+    const owner = names.get(name);
+    if (owner !== undefined && owner !== key) {
+      throw new Error(`Conflicting canonical wire declarations named ${name}`);
+    }
+    names.set(name, key);
+    included.set(key, node);
+    if (ts.isVariableStatement(node)) {
+      if (!(node.declarationList.flags & ts.NodeFlags.Const)) {
+        throw new Error(`Wire value ${name} must be const`);
+      }
+      for (const declaration of node.declarationList.declarations) {
+        if (
+          declaration.initializer === undefined ||
+          !isStaticWireValue(declaration.initializer)
+        ) {
+          throw new Error(`Wire value ${name} contains executable code`);
+        }
+      }
+    }
+    const dependencies = new Set();
+    function visit(child) {
+      if (
+        ts.isIdentifier(child) &&
+        child.text !== name &&
+        (module.local.has(child.text) || module.imports.has(child.text))
+      )
+        dependencies.add(child.text);
+      ts.forEachChild(child, visit);
+    }
+    ts.forEachChild(node, visit);
+    for (const dependency of dependencies) await include(filePath, dependency);
+    declarations.push({ node, source: module.source });
+  }
+
+  for (const name of PUBLIC_WIRE_ROOTS)
+    await include(path.resolve(protocolPath), name);
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const emitted = new Set();
+  const body = declarations.flatMap(({ node, source }) => {
+    if (emitted.has(node)) return [];
+    emitted.add(node);
+    return [printer.printNode(ts.EmitHint.Unspecified, node, source)];
+  });
+  return [
+    "// @generated from the daemon protocol and its referenced declarations. Do not edit.",
+    "// Regenerate: npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write",
+    "// Public wire types only; this module has no runtime-internal imports.",
+    "",
+    ...body,
+    "",
+    [
+      "type PublicRequestForMethod<Method, Request = AgenCDaemonRequest> =",
+      "  Request extends { readonly method: infer Names }",
+      "    ? Method extends Names",
+      '      ? { [Key in keyof Request]: Key extends "method" ? Method : Request[Key] }',
+      "      : never",
+      "    : never;",
+      "",
+      "export type AgenCDaemonRequestByMethod = {",
+      "  readonly [Method in AgenCDaemonMethod]: PublicRequestForMethod<Method>;",
+      "};",
+    ].join("\n"),
+    [
+      "export type AgenCDaemonParamsByMethod = {",
+      "  readonly [Method in AgenCDaemonMethod]: NonNullable<",
+      '    AgenCDaemonRequestByMethod[Method]["params"]',
+      "  >;",
+      "};",
+    ].join("\n"),
+    "",
+  ]
+    .join("\n\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/\n+$/, "\n");
+}
+
+function isStaticWireValue(node) {
+  if (ts.isLiteralExpression(node) || ts.isIdentifier(node)) return true;
+  if (
+    [
+      ts.SyntaxKind.TrueKeyword,
+      ts.SyntaxKind.FalseKeyword,
+      ts.SyntaxKind.NullKeyword,
+    ].includes(node.kind)
+  )
+    return true;
+  if (
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isParenthesizedExpression(node)
+  )
+    return isStaticWireValue(node.expression);
+  if (ts.isPrefixUnaryExpression(node))
+    return (
+      [ts.SyntaxKind.PlusToken, ts.SyntaxKind.MinusToken].includes(
+        node.operator,
+      ) && isStaticWireValue(node.operand)
+    );
+  if (ts.isArrayLiteralExpression(node))
+    return node.elements.every(isStaticWireValue);
+  if (ts.isSpreadElement(node)) return isStaticWireValue(node.expression);
+  if (ts.isObjectLiteralExpression(node)) {
+    return node.properties.every(
+      (property) =>
+        ts.isPropertyAssignment(property) &&
+        !ts.isComputedPropertyName(property.name) &&
+        isStaticWireValue(property.initializer),
+    );
+  }
+  return false;
+}

--- a/runtime/scripts/sdk-wire-types.mjs
+++ b/runtime/scripts/sdk-wire-types.mjs
@@ -160,7 +160,8 @@ function indexModuleBindings(source) {
 
 function validateWireConstant(node, name) {
   if (!ts.isVariableStatement(node)) return;
-  if ((node.declarationList.flags & ts.NodeFlags.Const) === 0) {
+  const constFlag = node.declarationList.flags & ts.NodeFlags.Const;
+  if (constFlag === 0) {
     throw new Error(`Wire value ${name} must be const`);
   }
   for (const declaration of node.declarationList.declarations) {

--- a/runtime/tests/sdk-package/protocol-drift.contract.test.ts
+++ b/runtime/tests/sdk-package/protocol-drift.contract.test.ts
@@ -1,11 +1,8 @@
 /**
  * Drift guard for the in-repo embedding SDK (`packages/agenc-sdk`).
  *
- * The package hand-mirrors the daemon protocol so it can stand alone with
- * zero runtime-internal imports. This test pins that mirror to the runtime's
- * canonical method registry the same way the sibling-repo SDK is pinned by
- * `tests/app-server/sdk-client.contract.test.ts`: any protocol change fails
- * here until `packages/agenc-sdk/src/protocol.ts` is updated.
+ * The package generates standalone wire declarations. The compiler checks
+ * every method's params, results, envelope and generic client arguments.
  */
 
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync } from "node:fs";
@@ -33,6 +30,7 @@ import {
   resolveDaemonSocketPath,
 } from "../../../packages/agenc-sdk/src/socket";
 import { resolveAgenCHome as resolveLauncherHome } from "../../../packages/agenc/lib/home-authority.mjs";
+import { checkSdkWireParity } from "../../scripts/check-sdk-wire-parity.mjs";
 
 // @ts-expect-error A partial evidence request must not match the legacy branch.
 const invalidPartialToolResolution: AgencParamsByMethod["session.resolveToolCall"] = {
@@ -76,19 +74,13 @@ describe("agenc-sdk protocol mirror", () => {
     expect(resolveOneLegacy.toolCallId).toBe("call_legacy");
   });
 
-  it("declares params and result mappings for every daemon method", () => {
-    const source = readFileSync(packageProtocolPath, "utf8");
-    expectOrderedKeys(
-      "AgencParamsByMethod",
-      AGENC_DAEMON_METHODS,
-      extractInterfaceMethodKeys(source, "AgencParamsByMethod"),
-    );
-    expectOrderedKeys(
-      "AgencResultByMethod",
-      AGENC_DAEMON_METHODS,
-      extractInterfaceMethodKeys(source, "AgencResultByMethod"),
-    );
-  });
+  it("exactly matches every wire request, result and client signature", () => {
+    expect(checkSdkWireParity()).toEqual({
+      matches: true,
+      mismatches: { RequestExact: [], ResultExact: [], EnvelopeExact: [], ClientArgumentsExact: [] },
+      diagnostics: [],
+    });
+  }, 30_000);
 
   it("does not import runtime internals", () => {
     const source = readFileSync(packageProtocolPath, "utf8");
@@ -166,28 +158,3 @@ describe("agenc-sdk protocol mirror", () => {
     );
   });
 });
-
-function extractInterfaceMethodKeys(
-  source: string,
-  interfaceName: string,
-): string[] {
-  const match = new RegExp(
-    `export\\s+interface\\s+${interfaceName}\\s*\\{([\\s\\S]*?)\\n\\}`,
-  ).exec(source);
-  if (!match) throw new Error(`missing interface: ${interfaceName}`);
-  const keys: string[] = [];
-  const keyRe = /readonly\s+(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\s*:/g;
-  let keyMatch;
-  while ((keyMatch = keyRe.exec(match[1]!)) !== null) {
-    keys.push((keyMatch[1] ?? keyMatch[2] ?? keyMatch[3])!);
-  }
-  return keys;
-}
-
-function expectOrderedKeys(
-  label: string,
-  expected: readonly string[],
-  actual: readonly string[],
-): void {
-  expect(actual, label).toEqual([...expected]);
-}

--- a/runtime/tests/sdk-package/sdk-wire-parity.test.ts
+++ b/runtime/tests/sdk-package/sdk-wire-parity.test.ts
@@ -1,0 +1,128 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { checkSdkWireParity } from "../../scripts/check-sdk-wire-parity.mjs";
+import { renderSdkWireTypes } from "../../scripts/sdk-wire-types.mjs";
+
+const root = resolve(import.meta.dirname, "../../..");
+const protocolPath = resolve(root, "runtime/src/app-server/protocol/index.ts");
+const generatedPath = resolve(
+  root,
+  "packages/agenc-sdk/src/protocol-wire.generated.ts",
+);
+
+describe("SDK wire parity compiler", () => {
+  it("rejects optional, required and nested producer drift until regeneration", async () => {
+    const original = await readFile(protocolPath, "utf8");
+    const mutated = original
+      .replace(
+        "export interface RunEvidenceParams extends JsonObject {",
+        "export interface RunEvidenceParams extends JsonObject {\n readonly wireOptionalProbe?: string;",
+      )
+      .replace(
+        "export interface AgentLogsResult extends JsonObject {",
+        "export interface AgentLogsResult extends JsonObject {\n readonly wireRequiredProbe: string;",
+      )
+      .replace(
+        "export interface AgentRuntimeOptionsParams extends JsonObject {",
+        "export interface AgentRuntimeOptionsParams extends JsonObject {\n readonly wireNestedProbe?: { readonly enabled: boolean };",
+      );
+    expect(mutated).not.toBe(original);
+    const sourceOverrides = new Map([[protocolPath, mutated]]);
+    const stale = checkSdkWireParity({ sourceOverrides });
+    expect(stale.matches).toBe(false);
+    expect(stale.mismatches.RequestExact).toEqual(
+      expect.arrayContaining(["run.evidence", "agent.create"]),
+    );
+    expect(stale.mismatches.ResultExact).toEqual(
+      expect.arrayContaining(["agent.logs", "agent.attach"]),
+    );
+    const regenerated = await renderSdkWireTypes(protocolPath, {
+      sourceOverrides,
+    });
+    sourceOverrides.set(generatedPath, regenerated);
+    const refreshed = checkSdkWireParity({ sourceOverrides });
+    expect(refreshed.mismatches).toEqual({
+      RequestExact: [],
+      ResultExact: [],
+      EnvelopeExact: [],
+      ClientArgumentsExact: [],
+    });
+    expect(refreshed.diagnostics).toEqual([]);
+    expect(refreshed.matches).toBe(true);
+  }, 60_000);
+
+  it("type-checks helper defaults and rejects missing or invalid wire payloads", () => {
+    const result = checkSdkWireParity({
+      consumerSource: `
+import type { AgentCreateParams, AgentRuntimeOptionsParams } from "../packages/agenc-sdk/src/protocol.js";
+declare const runtimeOptions: AgentRuntimeOptionsParams;
+const spawn: AgentCreateParams = { runtimeOptions };
+client.spawnAgent(spawn);
+client.createSession({ pluginStorageRoot: "/plugins" });
+client.listCsvJobReviews({ jobId: "job" });
+client.showCsvJobReview({ jobId: "job", itemId: "item" });
+client.request("agent.create", { ...spawn, cwd: "/workspace" });
+client.request("session.create", { cwd: "/workspace" });
+client.request("csvJob.review.list", { jobId: "job", cwd: "/workspace" });
+client.request("health.ping");
+client.request("health.ping", {});
+// The daemon groups several method names into one request-union member.
+client.request("remote.status", {});
+client.request("telegram.status", {});
+client.request("routine.list");
+const grouped: AgencDaemonRequest<"remote.status"> = { jsonrpc: "2.0", id: 2, method: "remote.status", params: {} };
+const result = client.request("run.status", { runId: "run" });
+type InferenceMatches = RequireTrue<Equal<typeof result, Promise<AgencResultByMethod["run.status"]>>>;
+// @ts-expect-error Required payload cannot be omitted.
+client.request("run.status");
+// @ts-expect-error Required payload cannot be undefined.
+client.request("run.status", undefined);
+// @ts-expect-error Required cwd belongs on the wire.
+client.request("agent.create", spawn);
+// @ts-expect-error Session helper defaults cannot weaken the wire shape.
+client.request("session.create", {});
+// @ts-expect-error CSV helper defaults cannot weaken the wire shape.
+client.request("csvJob.review.list", { jobId: "job" });
+// @ts-expect-error A known wire field cannot widen the method inference.
+client.request("run.status", { runId: 42 });
+// @ts-expect-error A helper still requires the named job id despite JsonObject's index signature.
+client.listCsvJobReviews({});
+// @ts-expect-error Helper fields retain their concrete types.
+client.showCsvJobReview({ jobId: 42, itemId: "item" });
+// @ts-expect-error The low-level request envelope requires params too.
+const invalid: AgencDaemonRequest<"run.status"> = { jsonrpc: "2.0", id: 1, method: "run.status" };
+const valid: AgencDaemonRequest<"health.ping"> = { jsonrpc: "2.0", id: 1, method: "health.ping" };
+`,
+    });
+    expect(result.diagnostics).toEqual([]);
+    expect(result.matches).toBe(true);
+  }, 30_000);
+
+  it("generates a deterministic standalone closure without internal RPC methods", async () => {
+    const rendered = await renderSdkWireTypes(protocolPath);
+    expect(rendered).toBe(await readFile(generatedPath, "utf8"));
+    expect(rendered).toBe(await renderSdkWireTypes(protocolPath));
+    expect(rendered).not.toMatch(/^import /m);
+    expect(rendered).not.toContain("AgenCDaemonInternalResultByMethod");
+    expect(rendered).toContain("RunRuntimeSettingsSnapshot");
+    expect(rendered).toContain('"minimal"');
+  });
+
+  it.each(['(() => "2.0")()', '{ [(() => "key")()]: "2.0" }', "++counter"])(
+    "rejects executable wire constants: %s",
+    async (initializer) => {
+      const original = await readFile(protocolPath, "utf8");
+      const mutated = original.replace(
+        /export const JSON_RPC_VERSION = [^;]+;/,
+        `export const JSON_RPC_VERSION = ${initializer};`,
+      );
+      expect(mutated).not.toBe(original);
+      await expect(
+        renderSdkWireTypes(protocolPath, {
+          sourceOverrides: new Map([[protocolPath, mutated]]),
+        }),
+      ).rejects.toThrow(/contains executable code/);
+    },
+  );
+});

--- a/runtime/tests/sdk-package/sdk-wire-parity.test.ts
+++ b/runtime/tests/sdk-package/sdk-wire-parity.test.ts
@@ -111,6 +111,23 @@ const valid: AgencDaemonRequest<"health.ping"> = { jsonrpc: "2.0", id: 1, method
     expect(rendered).toContain('"minimal"');
   });
 
+  it.each(["let", "var"])(
+    "rejects mutable wire declarations: %s",
+    async (keyword) => {
+      const original = await readFile(protocolPath, "utf8");
+      const mutated = original.replace(
+        "export const JSON_RPC_VERSION",
+        `export ${keyword} JSON_RPC_VERSION`,
+      );
+      expect(mutated).not.toBe(original);
+      await expect(
+        renderSdkWireTypes(protocolPath, {
+          sourceOverrides: new Map([[protocolPath, mutated]]),
+        }),
+      ).rejects.toThrow(/must be const/);
+    },
+  );
+
   it.each(['(() => "2.0")()', '{ [(() => "key")()]: "2.0" }', "++counter"])(
     "rejects executable wire constants: %s",
     async (initializer) => {

--- a/runtime/tests/sdk-package/sdk-wire-parity.test.ts
+++ b/runtime/tests/sdk-package/sdk-wire-parity.test.ts
@@ -101,7 +101,9 @@ const valid: AgencDaemonRequest<"health.ping"> = { jsonrpc: "2.0", id: 1, method
 
   it("generates a deterministic standalone closure without internal RPC methods", async () => {
     const rendered = await renderSdkWireTypes(protocolPath);
-    expect(rendered).toBe(await readFile(generatedPath, "utf8"));
+    expect(rendered).toBe(
+      (await readFile(generatedPath, "utf8")).replace(/\r\n?/g, "\n"),
+    );
     expect(rendered).toBe(await renderSdkWireTypes(protocolPath));
     expect(rendered).not.toMatch(/^import /m);
     expect(rendered).not.toContain("AgenCDaemonInternalResultByMethod");


### PR DESCRIPTION
The SDK drift guard checked method names but missed six request-shape and seventeen result-shape differences. It also allowed omitted payloads for 79 methods that require them. Generate the standalone public wire declaration closure from the daemon protocol and compile exact params, results, request envelopes and client arguments for every one of the 89 public methods.

Replace duplicate SDK wire declarations with generated aliases. Keep cwd defaults in helper input adapters and retain the existing M3/M4 replay helper adapter; generic request mappings have no method exceptions. Regeneration and stale-artifact checks run through `check:sdk-generated-types`: `--write` only regenerates, while default check mode and builds compile parity. This avoids timing out the generation-entrypoint contract under CI load. The SDK retains zero runtime dependencies and exposes no internal RPC methods.

Full-suite validation also exposed two failures from the newly merged main: the MCP OAuth config reference was missing, and the CSV benchmark closure was stale. Document the canonical config field and capture fresh observations from main `fbbcf685`, whose complete runtime source tree matches this branch. No benchmark thresholds or provenance checks were weakened.

Validation: the full default suite passed 22,660 tests in 2,250 files with zero failures or skips; the launcher suite passed too. Afterward, naming the existing numeric Const mask and adding `let`/`var` rejection regressions passed 37 targeted checks and preserved the generated artifact byte-for-byte. Replacing that mask with logical `&&` demonstrably accepts an invalid `let` declaration. SDK/runtime type checks, SDK build and standalone packed import/compile, runtime build/all PTY startup checks, the complete agent-surface contract, and fresh-clone benchmark validation passed. All 13 hosted matrix jobs passed: the four full-suite shards and all nine native lanes ([run 34149235774](https://github.com/tetsuo-ai/agenc-core/actions/runs/34149235774)). That run used the same production SDK declarations; later changes only pin the scan allowlist in its test and name the unchanged Const-mask expression, covered by the final targeted checks. The final PR fast check passed ([run 34150093883](https://github.com/tetsuo-ai/agenc-core/actions/runs/34150093883)). Cursor Bugbot and Security Agent reviewed final head `e961f2b` successfully, and Approval Agent completed successfully. SonarCloud reports A ratings for reliability, security and maintainability, with 0% scored duplication on new code.

The compiler gate rejects the original six request, seventeen result and 79 required-payload mismatches on current main. Producer mutations prove optional, required and nested field changes fail until regeneration. The duplication exclusion names only the generated wire copy alongside the existing canonical installer copy; a strict allowlist test prevents broader exclusions.

Fixes #1804.
