### PR TITLE
refactor(packaging): share native module smoke program

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -653,7 +653,7 @@ jobs:
           const [resultsPath] = process.argv.slice(2);
           if (!resultsPath) throw new Error("missing PowerShell-test results path");
           const results = JSON.parse(readFileSync(resultsPath, "utf8"));
-          const expectedTests = 40;
+          const expectedTests = 51;
           const expectedFiles = [
             "tests/budget/admitted-legacy-powershell.powershell.test.ts",
             "tests/packaging/install-ps1.powershell.test.ts",

--- a/packages/agenc/scripts/build-runtime-tarball.mjs
+++ b/packages/agenc/scripts/build-runtime-tarball.mjs
@@ -55,10 +55,13 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import { create as createTar, extract as extractTar } from "tar";
 import { validateEmbeddedNodeRuntimeArchive } from "../lib/runtime-archive.mjs";
+import { installedNativeModuleSmokeProgram } from "./native-module-smoke.mjs";
 import {
   expectedHostedRunnerBuilder,
   resolveHostedRunnerImageProfile,
 } from "./hosted-runner-contract.mjs";
+
+export { installedNativeModuleSmokeProgram } from "./native-module-smoke.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const launcherDir = resolve(__dirname, "..");
@@ -1365,87 +1368,8 @@ function darwinNativeCompatibility(nodeModules, releaseLimits) {
   return { minimumMacosVersion };
 }
 
-export function installedNativeModuleSmokeProgram(platform = process.platform) {
-  const windowsSmoke = platform === "win32";
-  return String.raw`
-    const { createRequire } = require("node:module");
-    const { join } = require("node:path");
-    const requireFromArtifact = createRequire(join(process.cwd(), "smoke.cjs"));
-    const Database = requireFromArtifact("better-sqlite3");
-    const db = new Database(":memory:");
-    if (db.prepare("select 42 as value").get().value !== 42) process.exit(20);
-    db.close();
-    const pty = requireFromArtifact("node-pty");
-    const childEnvironment = {};
-    if (${JSON.stringify(windowsSmoke)}) {
-      // node-pty passes an exact custom environment block to CreateProcessW,
-      // bypassing libuv's restoration of these Node 26.5 required variables.
-      const requiredNames = [
-        "HOMEDRIVE", "HOMEPATH", "LOGONSERVER", "PATH", "SYSTEMDRIVE",
-        "SYSTEMROOT", "TEMP", "USERDOMAIN", "USERNAME", "USERPROFILE", "WINDIR",
-      ];
-      const parentEnvironment = new Map(
-        Object.entries(process.env).map(([name, value]) => [name.toUpperCase(), value]),
-      );
-      for (const name of requiredNames) {
-        const value = parentEnvironment.get(name);
-        if (typeof value === "string" && value.length > 0) childEnvironment[name] = value;
-      }
-      if (childEnvironment.SYSTEMROOT === undefined) {
-        process.stderr.write("node-pty smoke requires SystemRoot on Windows\n");
-        process.exit(24);
-      }
-    } else {
-      childEnvironment.PATH = process.env.PATH || "";
-    }
-    const child = pty.spawn(process.execPath, ["-e", "process.stdout.write('pty-ok')"], {
-      cols: 80,
-      rows: 24,
-      cwd: process.cwd(),
-      env: childEnvironment,
-    });
-    let output = "";
-    let exitEvent;
-    const fail = () => {
-      process.stderr.write("node-pty smoke failed: " + JSON.stringify({
-        exitCode: exitEvent?.exitCode,
-        signal: exitEvent?.signal,
-        output,
-      }) + "\n");
-      process.exit(22);
-    };
-    const finish = () => {
-      if (exitEvent === undefined || !output.includes("pty-ok")) return;
-      clearTimeout(timeout);
-      if (exitEvent.exitCode !== 0 || (exitEvent.signal ?? 0) !== 0) fail();
-      // This script is a standalone smoke process. On Windows, ConPTY may
-      // retain a native/libuv handle after delivering both exit and output;
-      // finish explicitly once every success invariant has been observed.
-      process.exit(0);
-    };
-    const timeout = setTimeout(() => {
-      if (exitEvent === undefined) {
-        child.kill();
-        process.exit(21);
-      }
-      fail();
-    }, 10000);
-    child.onData((chunk) => {
-      output += chunk;
-      finish();
-    });
-    child.onExit((event) => {
-      exitEvent = event;
-      if (event.exitCode !== 0 || (event.signal ?? 0) !== 0) fail();
-      // Windows ConPTY can report process exit before its final output event.
-      // The existing hard timeout bounds the drain and fails closed.
-      finish();
-    });
-  `;
-}
-
 function smokeInstalledNativeModules(installRoot, env) {
-  const script = installedNativeModuleSmokeProgram();
+  const script = installedNativeModuleSmokeProgram(process.platform);
   run(process.execPath, ["-e", script], { cwd: installRoot, env });
 }
 
@@ -1484,7 +1408,7 @@ function smokeEmbeddedNodeRuntime(installRoot, embeddedNode, env) {
   );
   run(
     embeddedNode.executablePath,
-    ["-e", installedNativeModuleSmokeProgram()],
+    ["-e", installedNativeModuleSmokeProgram(process.platform)],
     { cwd: installRoot, env: embeddedEnvironment },
   );
 }

--- a/packages/agenc/scripts/native-module-smoke.mjs
+++ b/packages/agenc/scripts/native-module-smoke.mjs
@@ -1,0 +1,87 @@
+// Generate the standalone SQLite and PTY check shared by release verifiers.
+
+export function installedNativeModuleSmokeProgram(
+  platform = process.platform,
+  { modulePath, cwd } = {},
+) {
+  const windowsSmoke = platform === "win32";
+  return String.raw`
+    const { createRequire } = require("node:module");
+    const { join } = require("node:path");
+    const requireFromArtifact = createRequire(${
+      modulePath === undefined
+        ? 'join(process.cwd(), "smoke.cjs")'
+        : JSON.stringify(modulePath)
+    });
+    const Database = requireFromArtifact("better-sqlite3");
+    const db = new Database(":memory:");
+    if (db.prepare("select 42 as value").get().value !== 42) process.exit(20);
+    db.close();
+    const pty = requireFromArtifact("node-pty");
+    const childEnvironment = {};
+    if (${JSON.stringify(windowsSmoke)}) {
+      // node-pty passes an exact custom environment block to CreateProcessW,
+      // bypassing libuv's restoration of these Node 26.5 required variables.
+      const requiredNames = [
+        "HOMEDRIVE", "HOMEPATH", "LOGONSERVER", "PATH", "SYSTEMDRIVE",
+        "SYSTEMROOT", "TEMP", "USERDOMAIN", "USERNAME", "USERPROFILE", "WINDIR",
+      ];
+      const parentEnvironment = new Map(
+        Object.entries(process.env).map(([name, value]) => [name.toUpperCase(), value]),
+      );
+      for (const name of requiredNames) {
+        const value = parentEnvironment.get(name);
+        if (typeof value === "string" && value.length > 0) childEnvironment[name] = value;
+      }
+      if (childEnvironment.SYSTEMROOT === undefined) {
+        process.stderr.write("node-pty smoke requires SystemRoot on Windows\n");
+        process.exit(24);
+      }
+    } else {
+      childEnvironment.PATH = process.env.PATH || "";
+    }
+    const child = pty.spawn(process.execPath, ["-e", "process.stdout.write('pty-ok')"], {
+      cols: 80,
+      rows: 24,
+      cwd: ${cwd === undefined ? "process.cwd()" : JSON.stringify(cwd)},
+      env: childEnvironment,
+    });
+    let output = "";
+    let exitEvent;
+    const fail = () => {
+      process.stderr.write("node-pty smoke failed: " + JSON.stringify({
+        exitCode: exitEvent?.exitCode,
+        signal: exitEvent?.signal,
+        output,
+      }) + "\n");
+      process.exit(22);
+    };
+    const finish = () => {
+      if (exitEvent === undefined || !output.includes("pty-ok")) return;
+      clearTimeout(timeout);
+      if (exitEvent.exitCode !== 0 || (exitEvent.signal ?? 0) !== 0) fail();
+      // This script is a standalone smoke process. On Windows, ConPTY may
+      // retain a native/libuv handle after delivering both exit and output;
+      // finish explicitly once every success invariant has been observed.
+      process.exit(0);
+    };
+    const timeout = setTimeout(() => {
+      if (exitEvent === undefined) {
+        child.kill();
+        process.exit(21);
+      }
+      fail();
+    }, 10000);
+    child.onData((chunk) => {
+      output += chunk;
+      finish();
+    });
+    child.onExit((event) => {
+      exitEvent = event;
+      if (event.exitCode !== 0 || (event.signal ?? 0) !== 0) fail();
+      // Windows ConPTY can report process exit before its final output event.
+      // The existing hard timeout bounds the drain and fails closed.
+      finish();
+    });
+  `;
+}

--- a/packages/agenc/test/native-module-smoke.test.mjs
+++ b/packages/agenc/test/native-module-smoke.test.mjs
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+
+import { installedNativeModuleSmokeProgram } from "../scripts/native-module-smoke.mjs";
+import { installedNativeModuleSmokeProgram as packagingProgram } from "../scripts/build-runtime-tarball.mjs";
+import { hardenedContainerRuntimeSmokeProgram } from "../../../scripts/check-clean-build.mjs";
+
+function executeSmoke(
+  program,
+  { sqliteValue = 42, environment = {}, container = false } = {},
+) {
+  const exited = Symbol("process exit");
+  const state = {
+    exits: [],
+    stderr: "",
+    killed: false,
+    timerCleared: false,
+    queries: [],
+    closed: false,
+  };
+  const child = {
+    kill() {
+      state.killed = true;
+    },
+    onData(callback) {
+      state.onData = callback;
+    },
+    onExit(callback) {
+      state.onExit = callback;
+    },
+  };
+  const modules = {
+    "better-sqlite3": class Database {
+      constructor(path) {
+        assert.equal(path, ":memory:");
+      }
+      prepare(sql) {
+        state.queries.push(sql);
+        return { get: () => ({ value: sqliteValue }) };
+      }
+      close() {
+        state.closed = true;
+      }
+    },
+    "node-pty": {
+      spawn(file, args, options) {
+        state.spawn = { file, args, options };
+        return child;
+      },
+    },
+  };
+  const timer = {};
+  const process = {
+    env: environment,
+    execPath: "/test/node",
+    cwd: () => "/artifact",
+    getuid: () => 10001,
+    getgid: () => 10001,
+    arch: "x64",
+    versions: { modules: "147" },
+    stderr: {
+      write(text) {
+        state.stderr += text;
+      },
+    },
+    exit(code) {
+      state.exits.push(code);
+      throw exited;
+    },
+  };
+  const dispatch = (callback) => {
+    try {
+      callback();
+    } catch (error) {
+      if (error !== exited) throw error;
+    }
+  };
+  dispatch(() =>
+    runInNewContext(program, {
+      process,
+      require(name) {
+        if (name === "node:path") return { join };
+        if (name === "node:module")
+          return {
+            createRequire(path) {
+              state.modulePath = path;
+              return (moduleName) => {
+                assert.ok(Object.hasOwn(modules, moduleName), moduleName);
+                return modules[moduleName];
+              };
+            },
+          };
+        if (container && name === "node:fs")
+          return {
+            statSync(path) {
+              if (path === "/opt/agenc") return { uid: 0, gid: 0, mode: 0o755 };
+              if (path === "/usr/lib/agenc/agenc-peer-credentials.node")
+                return { uid: 0, gid: 0, mode: 0o555 };
+              throw Object.assign(new Error(path), { code: "ENOENT" });
+            },
+            readFileSync(path) {
+              if (path === "/usr/lib/agenc/peer-credentials-required")
+                return "required\n";
+              assert.equal(path, "/usr/share/agenc/debian-packages.txt");
+              return "libc6:amd64=1.0\n";
+            },
+          };
+        if (container && name === "/usr/lib/agenc/agenc-peer-credentials.node")
+          return { getPeerUid() {} };
+        throw new Error(`unexpected require ${name}`);
+      },
+      setTimeout(callback, ms) {
+        state.onTimeout = callback;
+        state.timeoutMs = ms;
+        return timer;
+      },
+      clearTimeout(value) {
+        assert.equal(value, timer);
+        state.timerCleared = true;
+      },
+    }),
+  );
+  return {
+    state,
+    data: (text) => dispatch(() => state.onData(text)),
+    exit: (event) => dispatch(() => state.onExit(event)),
+    timeout: () => dispatch(() => state.onTimeout()),
+  };
+}
+
+test("packaging and Docker use the shared native program", () => {
+  assert.equal(packagingProgram, installedNativeModuleSmokeProgram);
+  assert.ok(
+    hardenedContainerRuntimeSmokeProgram().includes(
+      installedNativeModuleSmokeProgram("linux", {
+        modulePath: "/opt/agenc/node_modules/@tetsuo-ai/runtime/package.json",
+        cwd: "/data",
+      }),
+    ),
+  );
+});
+
+test("importing the shared builder has no CLI output or exit side effects", () => {
+  const moduleUrl = new URL(
+    "../scripts/native-module-smoke.mjs",
+    import.meta.url,
+  ).href;
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `await import(${JSON.stringify(moduleUrl)}); process.stdout.write("imported");`,
+    ],
+    { encoding: "utf8", timeout: 5_000 },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "imported");
+  assert.equal(result.stderr, "");
+});
+
+for (const order of ["output-first", "exit-first"]) {
+  test(`native smoke requires SQLite and complete PTY output with ${order}`, () => {
+    const probe = executeSmoke(installedNativeModuleSmokeProgram("linux"), {
+      environment: { PATH: "/bin", PRIVATE_KEY: "must-not-forward" },
+    });
+    assert.deepEqual(probe.state.queries, ["select 42 as value"]);
+    assert.equal(probe.state.closed, true);
+    assert.equal(probe.state.modulePath, join("/artifact", "smoke.cjs"));
+    assert.deepEqual({ ...probe.state.spawn.options.env }, { PATH: "/bin" });
+    if (order === "exit-first") probe.exit({ exitCode: 0 });
+    probe.data("pty-");
+    assert.deepEqual(probe.state.exits, []);
+    probe.data("ok");
+    if (order === "output-first") {
+      assert.deepEqual(probe.state.exits, []);
+      probe.exit({ exitCode: 0 });
+    }
+    assert.deepEqual(probe.state.exits, [0]);
+    assert.equal(probe.state.timerCleared, true);
+  });
+}
+
+test("SQLite failure prevents PTY startup", () => {
+  const { state } = executeSmoke(installedNativeModuleSmokeProgram("linux"), {
+    sqliteValue: 0,
+  });
+  assert.deepEqual(state.exits, [20]);
+  assert.equal(state.spawn, undefined);
+});
+
+for (const event of [{ exitCode: 9 }, { exitCode: 0, signal: 9 }]) {
+  test(`native smoke rejects failed PTY exit ${JSON.stringify(event)}`, () => {
+    const probe = executeSmoke(installedNativeModuleSmokeProgram("linux"));
+    probe.data("pty-ok");
+    probe.exit(event);
+    assert.deepEqual(probe.state.exits, [22]);
+    assert.match(probe.state.stderr, /node-pty smoke failed/);
+  });
+}
+
+test("timeout kills a PTY that has not exited", () => {
+  const probe = executeSmoke(installedNativeModuleSmokeProgram("linux"));
+  probe.data("pty-ok");
+  assert.deepEqual(probe.state.exits, []);
+  assert.equal(probe.state.timeoutMs, 10_000);
+  probe.timeout();
+  assert.equal(probe.state.killed, true);
+  assert.deepEqual(probe.state.exits, [21]);
+});
+
+test("timeout rejects a successful exit whose output never arrived", () => {
+  const probe = executeSmoke(installedNativeModuleSmokeProgram("linux"));
+  probe.exit({ exitCode: 0 });
+  assert.deepEqual(probe.state.exits, []);
+  probe.timeout();
+  assert.equal(probe.state.killed, false);
+  assert.deepEqual(probe.state.exits, [22]);
+});
+
+test("Windows environment selection is explicit and case insensitive", () => {
+  const probe = executeSmoke(installedNativeModuleSmokeProgram("win32"), {
+    environment: {
+      SystemRoot: "C:\\Windows",
+      Path: "C:\\bin",
+      temp: "C:\\Temp",
+      AGENC_API_KEY: "must-not-forward",
+    },
+  });
+  assert.deepEqual(
+    { ...probe.state.spawn.options.env },
+    { PATH: "C:\\bin", SYSTEMROOT: "C:\\Windows", TEMP: "C:\\Temp" },
+  );
+  const missing = executeSmoke(installedNativeModuleSmokeProgram("win32"));
+  assert.deepEqual(missing.state.exits, [24]);
+  assert.equal(missing.state.spawn, undefined);
+});
+
+test("Docker hardening composes with the same native checks and container paths", () => {
+  const probe = executeSmoke(hardenedContainerRuntimeSmokeProgram(), {
+    container: true,
+    environment: {
+      PATH: "/bin",
+      AGENC_EXPECTED_ABI: "147",
+      AGENC_EXPECTED_PACKAGES: JSON.stringify({ libc6: "1.0" }),
+    },
+  });
+  assert.equal(
+    probe.state.modulePath,
+    "/opt/agenc/node_modules/@tetsuo-ai/runtime/package.json",
+  );
+  assert.equal(probe.state.spawn.options.cwd, "/data");
+  probe.exit({ exitCode: 0 });
+  probe.data("pty-ok");
+  assert.deepEqual(probe.state.exits, [0]);
+});

--- a/runtime/tests/meta/license-and-version.test.ts
+++ b/runtime/tests/meta/license-and-version.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
@@ -190,7 +191,7 @@ describe("runtime SDK surface hygiene", () => {
     }
   });
 
-  test("generated SDK type workflow uses the checked-in validator", () => {
+  test("generated SDK type workflow uses the checked-in validator", async () => {
     const runtimePkg = JSON.parse(readRepoFile("runtime/package.json")) as {
       scripts?: Record<string, string>;
     };
@@ -215,10 +216,11 @@ describe("runtime SDK surface hygiene", () => {
       expect(source).toContain(checkCommand);
     }
 
-    execFileSync(
+    // The validator compiles the full wire contract, as sdk-wire-parity.test.ts does.
+    await promisify(execFile)(
       process.execPath,
       ["runtime/scripts/check-sdk-generated-types.mjs"],
-      { cwd: repoRoot, stdio: "pipe" },
+      { cwd: repoRoot, timeout: 55_000, killSignal: "SIGKILL" },
     );
-  });
+  }, 60_000);
 });

--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -3770,26 +3770,26 @@ function registerInstallPs1Tests(): void {
       expect(existsSync(windowsPaths(home).installDir)).toBe(false);
     });
 
-    test("PowerShell bounded HTTPS trust rejects malformed manifests and truncated/overrun artifacts without residue", () => {
-      const artifact = makeSyntheticArtifact(work);
-      const fixture = startHttpsFixture(work, trustBoundaryRoutes(artifact, "win"));
-      const fetchRewrite = writeGithubArtifactFetchRewrite(work);
-      try {
-        const cases = [
-          ["oversized-manifest.json", "download exceeds 1048576 byte limit"],
-          ["manifest-length.json", "Content-Length exceeds 1048576 byte limit"],
-          ["invalid-utf8.json", "runtime manifest is not valid UTF-8"],
-          ["short-manifest.json", "download byte count mismatch"],
-          ["overrun-manifest.json", "download exceeds declared"],
-          ["length-manifest.json", "Content-Length mismatch"],
-          ["duplicate-manifest.json", "duplicate runtime manifest artifact"],
-          ["missing-tag-manifest.json", "runtime manifest release identity is invalid"],
-          ["missing-provenance-manifest.json", "runtime manifest build provenance is invalid"],
-          ["detached-artifact-manifest.json", "manifest artifact URL is not canonical"],
-          ["cross-scheme-manifest.json", "remote manifests may only reference HTTPS artifacts"],
-          ["artifact-ceiling-manifest.json", "manifest artifact identity is invalid"],
-        ] as const;
-        for (const [name, expected] of cases) {
+    test.each([
+      ["oversized-manifest.json", "download exceeds 1048576 byte limit"],
+      ["manifest-length.json", "Content-Length exceeds 1048576 byte limit"],
+      ["invalid-utf8.json", "runtime manifest is not valid UTF-8"],
+      ["short-manifest.json", "download byte count mismatch"],
+      ["overrun-manifest.json", "download exceeds declared"],
+      ["length-manifest.json", "Content-Length mismatch"],
+      ["duplicate-manifest.json", "duplicate runtime manifest artifact"],
+      ["missing-tag-manifest.json", "runtime manifest release identity is invalid"],
+      ["missing-provenance-manifest.json", "runtime manifest build provenance is invalid"],
+      ["detached-artifact-manifest.json", "manifest artifact URL is not canonical"],
+      ["cross-scheme-manifest.json", "remote manifests may only reference HTTPS artifacts"],
+      ["artifact-ceiling-manifest.json", "manifest artifact identity is invalid"],
+    ] as const)(
+      "PowerShell bounded HTTPS trust rejects %s without residue",
+      (name, expected) => {
+        const artifact = makeSyntheticArtifact(work);
+        const fixture = startHttpsFixture(work, trustBoundaryRoutes(artifact, "win"));
+        const fetchRewrite = writeGithubArtifactFetchRewrite(work);
+        try {
           const home = join(work, `powershell-${name}`);
           mkdirSync(home, { recursive: true, mode: 0o700 });
           const result = runPowerShell(
@@ -3810,11 +3810,12 @@ function registerInstallPs1Tests(): void {
           expect(result.status, `${name}: ${output}`).not.toBe(0);
           expect(output, name).toContain(expected);
           expectFailedInstallCleanup(home);
+        } finally {
+          fixture.stop();
         }
-      } finally {
-        fixture.stop();
-      }
-    }, 30_000);
+      },
+      30_000,
+    );
 
     test("PowerShell preserves a custom CMD shim containing only the historical marker", () => {
       const home = join(work, "home");

--- a/runtime/tests/packaging/installer-tests.ts
+++ b/runtime/tests/packaging/installer-tests.ts
@@ -1089,6 +1089,87 @@ function runInstallerAsync(opts: {
   });
 }
 
+// Keep activation contenders at an explicit barrier until SQLite reports contention.
+// Instrument only the extracted test copy; the shipped installer is unchanged.
+function writeSynchronizedActivationHelper(work: string): string {
+  const embedded = readFileSync(INSTALL_SH, "utf8").match(
+    /<<'AGENC_RUNTIME_INSTALLER'\n([\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
+  )?.[1];
+  expect(embedded).toBeTruthy();
+  const holdCall = 'activationTestDelay("AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS");';
+  expect(embedded!.split(holdCall)).toHaveLength(2);
+  const helper = join(work, "synchronized-runtime-installer.cjs");
+  writeFileSync(helper, `
+const { DatabaseSync: TestDatabaseSync } = require("node:sqlite");
+const testDatabaseExec = TestDatabaseSync.prototype.exec;
+TestDatabaseSync.prototype.exec = function(sql) {
+  try { return testDatabaseExec.call(this, sql); }
+  catch (error) {
+    if (sql === "BEGIN IMMEDIATE" && (error.errcode & 0xff) === 5) {
+      process.send("contended");
+    }
+    throw error;
+  }
+};
+process.channel.unref();
+async function testActivationBarrier() {
+  if (process.env.AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS === undefined) return;
+  await new Promise((resume) => {
+    process.channel.ref();
+    process.once("message", () => { process.channel.unref(); resume(); });
+    process.send("locked");
+  });
+}
+${embedded!.replace(holdCall, "await testActivationBarrier();")}`);
+  return helper;
+}
+
+function spawnSynchronizedActivation(
+  helper: string,
+  desired: string,
+  wrapper: string,
+  home: string,
+  version: string,
+  env: NodeJS.ProcessEnv,
+) {
+  const child = spawn(
+    process.execPath,
+    [helper, "activate", desired, wrapper, home, version, "false"],
+    { env: { ...process.env, ...env }, stdio: ["ignore", "pipe", "pipe", "ipc"] },
+  );
+  const phases = new Set<unknown>();
+  child.on("message", (phase) => phases.add(phase));
+  const result = new Promise<RunResult>((resolveRun) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => { stderr += error.message; });
+    child.on("close", (code) => resolveRun({ status: code ?? -1, stdout, stderr }));
+  });
+  const waitForPhase = async (phase: string) => {
+    if (phases.has(phase)) return;
+    let listener: (message: unknown) => void;
+    let timer: ReturnType<typeof setTimeout>;
+    try {
+      await Promise.race([
+        new Promise<void>((resolvePhase, rejectPhase) => {
+          listener = (message) => { if (message === phase) resolvePhase(); };
+          child.on("message", listener);
+          timer = setTimeout(() => rejectPhase(new Error(`activation did not report ${phase}`)), 10_000);
+        }),
+        result.then(({ status, stderr }) => {
+          throw new Error(`activation exited ${status} before ${phase}: ${stderr}`);
+        }),
+      ]);
+    } finally {
+      child.off("message", listener!);
+      clearTimeout(timer!);
+    }
+  };
+  return { child, result, waitForPhase };
+}
+
 export type InstallerTestLane = "shell" | "powershell";
 
 let registeredInstallerTestLane: InstallerTestLane | undefined;
@@ -2608,12 +2689,7 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
   });
 
   test("the embedded activation lock makes a waiting older version re-read the winner", async () => {
-    const embedded = readFileSync(INSTALL_SH, "utf8").match(
-      /<<'AGENC_RUNTIME_INSTALLER'\n([\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
-    )?.[1];
-    expect(embedded).toBeTruthy();
-    const helper = join(work, "runtime-installer.cjs");
-    writeFileSync(helper, embedded!);
+    const helper = writeSynchronizedActivationHelper(work);
     const agencHome = join(work, "activation-home");
     mkdirSync(agencHome, { recursive: true, mode: 0o700 });
     const wrapper = join(work, "activation-bin", "agenc");
@@ -2633,36 +2709,23 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
     writeFileSync(highDesired, wrapperText("10.0.0"));
     writeFileSync(lowDesired, wrapperText("9.0.0"));
 
-    const runActivation = (
-      desired: string,
-      version: string,
-      env: NodeJS.ProcessEnv,
-    ): Promise<RunResult> => new Promise((resolveRun) => {
-      const child = spawn(
-        process.execPath,
-        [helper, "activate", desired, wrapper, agencHome, version, "false"],
-        { env: { ...process.env, ...env }, stdio: ["ignore", "pipe", "pipe"] },
-      );
-      let stdout = "";
-      let stderr = "";
-      child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
-      child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
-      child.on("close", (code) => resolveRun({ status: code ?? -1, stdout, stderr }));
+    const high = spawnSynchronizedActivation(helper, highDesired, wrapper, agencHome, "10.0.0", {
+      AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS: "1",
     });
-
-    const high = runActivation(highDesired, "10.0.0", {
-      AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS: "300",
-    });
-    const activationLock = join(agencHome, "runtime", ".activation-lock.sqlite");
-    const deadline = Date.now() + 2_000;
-    while (!existsSync(activationLock) && Date.now() < deadline) {
-      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    let low: ReturnType<typeof spawnSynchronizedActivation> | undefined;
+    let highResult: RunResult;
+    let lowResult: RunResult;
+    try {
+      await high.waitForPhase("locked");
+      low = spawnSynchronizedActivation(helper, lowDesired, wrapper, agencHome, "9.0.0", {});
+      await low.waitForPhase("contended");
+      high.child.send("resume");
+      [highResult, lowResult] = await Promise.all([high.result, low.result]);
+    } finally {
+      high.child.kill();
+      low?.child.kill();
+      await Promise.all([high.result, low?.result]);
     }
-    expect(existsSync(activationLock)).toBe(true);
-    const low = runActivation(lowDesired, "9.0.0", {
-      AGENC_INSTALL_TEST_AFTER_ACTIVATION_READ_MS: "500",
-    });
-    const [highResult, lowResult] = await Promise.all([high, low]);
 
     expect(highResult.status, highResult.stderr).toBe(0);
     expect(lowResult.status, lowResult.stderr).toBe(0);
@@ -2672,12 +2735,7 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
   });
 
   test("cross-home activations share the OS-account registry despite mutable HOME variables", async () => {
-    const embedded = readFileSync(INSTALL_SH, "utf8").match(
-      /<<'AGENC_RUNTIME_INSTALLER'\n([\s\S]*?)\nAGENC_RUNTIME_INSTALLER/,
-    )?.[1];
-    expect(embedded).toBeTruthy();
-    const helper = join(work, "cross-home-runtime-installer.cjs");
-    writeFileSync(helper, embedded!);
+    const helper = writeSynchronizedActivationHelper(work);
     const firstHome = join(work, "first-agenc-home");
     const secondHome = join(work, "second-agenc-home");
     mkdirSync(firstHome, { recursive: true, mode: 0o700 });
@@ -2702,44 +2760,28 @@ describe.skipIf(process.platform === "win32")("install.sh", () => {
     };
     const firstDesired = desired(firstHome, "10.0.0", "first-desired-wrapper");
     const secondDesired = desired(secondHome, "11.0.0", "second-desired-wrapper");
-    const spawnActivation = (
-      desiredPath: string,
-      home: string,
-      version: string,
-      env: NodeJS.ProcessEnv,
-    ): { child: ReturnType<typeof spawn>; result: Promise<RunResult> } => {
-      const child = spawn(
-        process.execPath,
-        [helper, "activate", desiredPath, wrapper, home, version, "false"],
-        { env: { ...process.env, ...env }, stdio: ["ignore", "pipe", "pipe"] },
-      );
-      const result = new Promise<RunResult>((resolveRun) => {
-        let stdout = "";
-        let stderr = "";
-        child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
-        child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
-        child.on("close", (code) => resolveRun({ status: code ?? -1, stdout, stderr }));
-      });
-      return { child, result };
-    };
-
-    const first = spawnActivation(firstDesired, firstHome, "10.0.0", {
+    const first = spawnSynchronizedActivation(helper, firstDesired, wrapper, firstHome, "10.0.0", {
       HOME: join(work, "mutable-home-a"),
       LOCALAPPDATA: join(work, "mutable-local-app-data-a"),
-      AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS: "400",
+      AGENC_INSTALL_TEST_HOLD_ACTIVATION_LOCK_MS: "1",
     });
-    const firstHomeLock = join(firstHome, "runtime", ".activation-lock.sqlite");
-    const deadline = Date.now() + 2_000;
-    while (!existsSync(firstHomeLock) && Date.now() < deadline) {
-      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    let second: ReturnType<typeof spawnSynchronizedActivation> | undefined;
+    let firstResult: RunResult;
+    let secondResult: RunResult;
+    try {
+      await first.waitForPhase("locked");
+      second = spawnSynchronizedActivation(helper, secondDesired, wrapper, secondHome, "11.0.0", {
+        HOME: join(work, "mutable-home-b"),
+        LOCALAPPDATA: join(work, "mutable-local-app-data-b"),
+      });
+      await second.waitForPhase("contended");
+      first.child.send("resume");
+      [firstResult, secondResult] = await Promise.all([first.result, second.result]);
+    } finally {
+      first.child.kill();
+      second?.child.kill();
+      await Promise.all([first.result, second?.result]);
     }
-    expect(existsSync(firstHomeLock)).toBe(true);
-    await new Promise((resolveWait) => setTimeout(resolveWait, 75));
-    const second = spawnActivation(secondDesired, secondHome, "11.0.0", {
-      HOME: join(work, "mutable-home-b"),
-      LOCALAPPDATA: join(work, "mutable-local-app-data-b"),
-    });
-    const [firstResult, secondResult] = await Promise.all([first.result, second.result]);
 
     expect(firstResult.status, firstResult.stderr).toBe(0);
     expect(secondResult.status).not.toBe(0);

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -365,7 +365,7 @@ describe("reproducible install and release contract", () => {
     expect(powershellJob).toContain('["powershellTestRuntime"]["linux-x64"]');
     expect(powershellJob).toContain("--require-zero-skips");
     expect(powershellJob).toContain("--config vitest.powershell.config.ts");
-    expect(powershellJob).toContain("const expectedTests = 40");
+    expect(powershellJob).toContain("const expectedTests = 51");
     expect(powershellJob).toContain("numTotalTestSuites: 5");
     expect(powershellJob).toContain("numPassedTestSuites: 5");
     for (const testFile of [

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -11,6 +11,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
+import { hardenedContainerRuntimeSmokeProgram } from "../../../scripts/check-clean-build.mjs";
+
 const REPO_ROOT = resolve(process.cwd(), "..");
 const BROAD_HOSTED_GATE_COMMANDS = [
   "npm test",
@@ -2235,11 +2237,7 @@ describe("reproducible install and release contract", () => {
     );
     expect(cleanBuild).toContain("checkedJavaScriptProgram(");
     expect(cleanBuild).toContain('"hardened container runtime smoke"');
-    const hardenedSmoke = cleanBuild.match(
-      /checkedJavaScriptProgram\(\s*String\.raw`([\s\S]*?)`,\s*"hardened container runtime smoke"/,
-    );
-    expect(hardenedSmoke).not.toBeNull();
-    const hardenedSmokeSource = hardenedSmoke?.[1] ?? "";
+    const hardenedSmokeSource = hardenedContainerRuntimeSmokeProgram();
     expect(() => new Function(hardenedSmokeSource)).not.toThrow();
     expect(hardenedSmokeSource).toContain('.split("\\n")');
     expect(hardenedSmokeSource).not.toContain('.split("\\\\n")');

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -1047,22 +1047,22 @@ describe("BufferSurface", () => {
     try {
       await runWithCwdOverride(dir, async () => {
         root.render(<App retryAttempt={0} />);
-        await sleep();
-
         const store = getWorkbenchBufferStore();
-        expect(store.getSnapshot()).toMatchObject({
-          status: "error",
-          filePath: null,
+        await vi.waitFor(() => {
+          expect(store.getSnapshot()).toMatchObject({
+            status: "error",
+            filePath: null,
+          });
         });
 
         await writeFile(join(dir, "missing.ts"), "created\n", "utf8");
         root.render(<App retryAttempt={1} />);
-        await sleep();
-
-        expect(store.getSnapshot()).toMatchObject({
-          status: "ready",
-          filePath: "missing.ts",
-          dirty: false,
+        await vi.waitFor(() => {
+          expect(store.getSnapshot()).toMatchObject({
+            status: "ready",
+            filePath: "missing.ts",
+            dirty: false,
+          });
         });
         expect(store.getText()).toBe("created\n");
       });

--- a/scripts/check-clean-build.mjs
+++ b/scripts/check-clean-build.mjs
@@ -27,6 +27,7 @@ import { pipeline } from "node:stream/promises";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { list as listTar } from "tar";
+import { installedNativeModuleSmokeProgram } from "../packages/agenc/scripts/native-module-smoke.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const IS_WINDOWS = process.platform === "win32";
@@ -270,74 +271,7 @@ function smokeExtractedRuntime({ artifact, root, env }) {
   const extracted = join(root, "runtime-smoke");
   mkdirSync(extracted, { recursive: true });
   run("tar", ["-xzf", artifact, "-C", extracted], { env });
-  const script = String.raw`
-    const { createRequire } = require("node:module");
-    const { join } = require("node:path");
-    const requireFromArtifact = createRequire(join(process.cwd(), "smoke.cjs"));
-    const Database = requireFromArtifact("better-sqlite3");
-    const db = new Database(":memory:");
-    if (db.prepare("select 42 as value").get().value !== 42) process.exit(20);
-    db.close();
-    const pty = requireFromArtifact("node-pty");
-    const childEnvironment = {};
-    if (process.platform === "win32") {
-      const requiredNames = [
-        "HOMEDRIVE", "HOMEPATH", "LOGONSERVER", "PATH", "SYSTEMDRIVE",
-        "SYSTEMROOT", "TEMP", "USERDOMAIN", "USERNAME", "USERPROFILE", "WINDIR",
-      ];
-      const parentEnvironment = new Map(
-        Object.entries(process.env).map(([name, value]) => [name.toUpperCase(), value]),
-      );
-      for (const name of requiredNames) {
-        const value = parentEnvironment.get(name);
-        if (typeof value === "string" && value.length > 0) childEnvironment[name] = value;
-      }
-      if (childEnvironment.SYSTEMROOT === undefined) {
-        process.stderr.write("node-pty smoke requires SystemRoot on Windows\n");
-        process.exit(24);
-      }
-    } else {
-      childEnvironment.PATH = process.env.PATH || "";
-    }
-    const child = pty.spawn(process.execPath, ["-e", "process.stdout.write('pty-ok')"], {
-      cols: 80,
-      rows: 24,
-      cwd: process.cwd(),
-      env: childEnvironment,
-    });
-    let output = "";
-    let exitEvent;
-    const fail = () => {
-      process.stderr.write("node-pty smoke failed: " + JSON.stringify({
-        exitCode: exitEvent?.exitCode,
-        signal: exitEvent?.signal,
-        output,
-      }) + "\n");
-      process.exit(22);
-    };
-    const finish = () => {
-      if (exitEvent === undefined || !output.includes("pty-ok")) return;
-      clearTimeout(timeout);
-      if (exitEvent.exitCode !== 0 || (exitEvent.signal ?? 0) !== 0) fail();
-      process.exit(0);
-    };
-    const timeout = setTimeout(() => {
-      if (exitEvent === undefined) {
-        child.kill();
-        process.exit(21);
-      }
-      fail();
-    }, 10000);
-    child.onData((chunk) => {
-      output += chunk;
-      finish();
-    });
-    child.onExit((event) => {
-      exitEvent = event;
-      if (event.exitCode !== 0 || (event.signal ?? 0) !== 0) fail();
-      finish();
-    });
-  `;
+  const script = installedNativeModuleSmokeProgram(process.platform);
   run(process.execPath, ["-e", script], { cwd: extracted, env });
 }
 
@@ -821,6 +755,39 @@ function compareOciLayouts(first, second) {
   );
 }
 
+export function hardenedContainerRuntimeSmokeProgram() {
+  const hardeningChecks = String.raw`const { readFileSync, statSync } = require("node:fs");
+       if (process.getuid?.() !== 10001 || process.getgid?.() !== 10001) throw new Error("container is not the dedicated non-root identity");
+       const runtimeRoot = statSync("/opt/agenc");
+       if (runtimeRoot.uid !== 0 || runtimeRoot.gid !== 0 || (runtimeRoot.mode & 0o022) !== 0) throw new Error("runtime tree is not root-owned and immutable");
+       const peerAddon = statSync("/usr/lib/agenc/agenc-peer-credentials.node");
+       if (peerAddon.uid !== 0 || peerAddon.gid !== 0 || (peerAddon.mode & 0o777) !== 0o555) throw new Error("peer credential addon is not root-owned and immutable");
+       if (readFileSync("/usr/lib/agenc/peer-credentials-required", "utf8") !== "required\n") throw new Error("peer credential system requirement marker is missing");
+       if (typeof require("/usr/lib/agenc/agenc-peer-credentials.node")?.getPeerUid !== "function") throw new Error("peer credential native smoke failed");
+       for (const compiler of ["/usr/bin/cc", "/usr/bin/c++", "/usr/bin/gcc", "/usr/bin/g++", "/usr/bin/clang", "/usr/bin/make", "/usr/local/bin/cc"]) {
+         try { statSync(compiler); throw new Error("runtime compiler unexpectedly present: " + compiler); } catch (error) { if (error?.code !== "ENOENT") throw error; }
+       }
+       const inventory = new Set(readFileSync("/usr/share/agenc/debian-packages.txt", "utf8").trim().split("\n"));
+       for (const forbidden of ["gcc", "g++", "make", "libc6-dev", "linux-libc-dev"]) {
+         if ([...inventory].some((entry) => entry.startsWith(forbidden + "=") || entry.startsWith(forbidden + ":"))) throw new Error("runtime build package unexpectedly present: " + forbidden);
+       }
+       if (process.versions.modules !== process.env.AGENC_EXPECTED_ABI) throw new Error("container Node ABI mismatch");
+       for (const [name, version] of Object.entries(JSON.parse(process.env.AGENC_EXPECTED_PACKAGES))) {
+         const debArch = process.arch === "x64" ? "amd64" : process.arch;
+         if (![name + "=" + version, name + ":" + debArch + "=" + version].some((entry) => inventory.has(entry))) {
+           throw new Error("missing pinned Debian package: " + name + "=" + version);
+         }
+       }`;
+  const nativeSmoke = installedNativeModuleSmokeProgram("linux", {
+    modulePath: "/opt/agenc/node_modules/@tetsuo-ai/runtime/package.json",
+    cwd: "/data",
+  });
+  return checkedJavaScriptProgram(
+    `${hardeningChecks}\n{\n${nativeSmoke}\n}`,
+    "hardened container runtime smoke",
+  );
+}
+
 async function dockerSmoke({ sources, metadata, work, buildkitHostNetwork }) {
   if (!Array.isArray(sources) || sources.length !== 2) {
     throw new Error("Docker reproducibility requires exactly two pristine source trees");
@@ -1066,73 +1033,7 @@ async function dockerSmoke({ sources, metadata, work, buildkitHostNetwork }) {
       `AGENC_EXPECTED_PACKAGES=${JSON.stringify(toolchain.docker.runtimePackages)}`,
       tag,
       "-e",
-      checkedJavaScriptProgram(
-       String.raw`const { readFileSync, statSync } = require("node:fs");
-       const { createRequire } = require("node:module");
-       if (process.getuid?.() !== 10001 || process.getgid?.() !== 10001) throw new Error("container is not the dedicated non-root identity");
-       const runtimeRoot = statSync("/opt/agenc");
-       if (runtimeRoot.uid !== 0 || runtimeRoot.gid !== 0 || (runtimeRoot.mode & 0o022) !== 0) throw new Error("runtime tree is not root-owned and immutable");
-       const peerAddon = statSync("/usr/lib/agenc/agenc-peer-credentials.node");
-       if (peerAddon.uid !== 0 || peerAddon.gid !== 0 || (peerAddon.mode & 0o777) !== 0o555) throw new Error("peer credential addon is not root-owned and immutable");
-       if (readFileSync("/usr/lib/agenc/peer-credentials-required", "utf8") !== "required\n") throw new Error("peer credential system requirement marker is missing");
-       if (typeof require("/usr/lib/agenc/agenc-peer-credentials.node")?.getPeerUid !== "function") throw new Error("peer credential native smoke failed");
-       for (const compiler of ["/usr/bin/cc", "/usr/bin/c++", "/usr/bin/gcc", "/usr/bin/g++", "/usr/bin/clang", "/usr/bin/make", "/usr/local/bin/cc"]) {
-         try { statSync(compiler); throw new Error("runtime compiler unexpectedly present: " + compiler); } catch (error) { if (error?.code !== "ENOENT") throw error; }
-       }
-       const inventory = new Set(readFileSync("/usr/share/agenc/debian-packages.txt", "utf8").trim().split("\n"));
-       for (const forbidden of ["gcc", "g++", "make", "libc6-dev", "linux-libc-dev"]) {
-         if ([...inventory].some((entry) => entry.startsWith(forbidden + "=") || entry.startsWith(forbidden + ":"))) throw new Error("runtime build package unexpectedly present: " + forbidden);
-       }
-       if (process.versions.modules !== process.env.AGENC_EXPECTED_ABI) throw new Error("container Node ABI mismatch");
-       for (const [name, version] of Object.entries(JSON.parse(process.env.AGENC_EXPECTED_PACKAGES))) {
-         const debArch = process.arch === "x64" ? "amd64" : process.arch;
-         if (![name + "=" + version, name + ":" + debArch + "=" + version].some((entry) => inventory.has(entry))) {
-           throw new Error("missing pinned Debian package: " + name + "=" + version);
-         }
-       }
-       const runtimeRequire = createRequire("/opt/agenc/node_modules/@tetsuo-ai/runtime/package.json");
-       const Database = runtimeRequire("better-sqlite3");
-       const db = new Database(":memory:");
-       if (db.prepare("select 42 as value").get().value !== 42) throw new Error("SQLite native smoke failed");
-       db.close();
-       const pty = runtimeRequire("node-pty");
-       const child = pty.spawn(process.execPath, ["-e", "process.stdout.write('pty-ok')"], {
-         cols: 80, rows: 24, cwd: "/data", env: { PATH: process.env.PATH || "" },
-       });
-       let output = "";
-       let exitEvent;
-       const fail = () => {
-         process.stderr.write("node-pty smoke failed: " + JSON.stringify({
-           exitCode: exitEvent?.exitCode,
-           signal: exitEvent?.signal,
-           output,
-         }) + "\n");
-         process.exit(22);
-       };
-       const finish = () => {
-         if (exitEvent === undefined || !output.includes("pty-ok")) return;
-         clearTimeout(timeout);
-         if (exitEvent.exitCode !== 0 || (exitEvent.signal ?? 0) !== 0) fail();
-         process.exit(0);
-       };
-       const timeout = setTimeout(() => {
-         if (exitEvent === undefined) {
-           child.kill();
-           process.exit(21);
-         }
-         fail();
-       }, 10000);
-       child.onData((chunk) => {
-         output += chunk;
-         finish();
-       });
-       child.onExit((event) => {
-         exitEvent = event;
-         if (event.exitCode !== 0 || (event.signal ?? 0) !== 0) fail();
-         finish();
-       });`,
-       "hardened container runtime smoke",
-      ),
+      hardenedContainerRuntimeSmokeProgram(),
     ], { env: dockerEnv });
 
     run("docker", [


### PR DESCRIPTION
Packaging, extracted-runtime verification, and the Docker check each carried a separate SQLite/PTY smoke program. They now generate that program from one side-effect-free utility. Callers choose the platform explicitly, and Docker supplies its module-resolution path and working directory while retaining its existing identity, permissions, ABI, package-inventory, and compiler-absence checks. The packaging export remains available.

The generated packaging program is byte-identical to the previous implementation for Linux, macOS, and Windows. New tests cover SQLite failure, both PTY output/exit orders, missing output, process failure, timeout cleanup, Windows environment filtering, import behavior, and Docker composition. The shared-builder regression fails when the original packaging implementation is restored.

Platform validation exposed a PowerShell test that ran 12 installer trust-boundary scenarios under one 30-second deadline. Those scenarios now run as separate tests with the same assertions and per-test limit. The capability lane requires all 51 tests with zero skips.

Hosted validation also exposed two synchronization assumptions: installer contenders used sleeps to guess lock ownership, and the buffer retry test checked state after 100 ms. The installer tests now hold the first process until the second reports real SQLite contention, and the buffer test waits for the expected state. Removing shared wrapper locking makes the revised activation test fail. The SDK validator test now uses the existing 60-second compiler budget and terminates its subprocess after 55 seconds.

Validation: 32 targeted launcher tests, real SQLite/PTY execution, typecheck, build, all terminal startup checks, and the full local suite (22,667 runtime tests across 2,249 files, zero failures or skips) pass. The test-only follow-ups pass 80 installer/packaging tests, 17 SDK metadata tests, 36 buffer tests, all 51 PowerShell tests, and typecheck. [All 13 hosted platform jobs](https://github.com/tetsuo-ai/agenc-core/actions/runs/34156046962) and [hosted affected tests](https://github.com/tetsuo-ai/agenc-core/actions/runs/34156047270) pass on final commit d2faf8e53. Bugbot found no issues; the security, approval, and Sonar checks also pass.

Closes #1816.
