### PR TITLE
refactor(runtime): centralize exhaustive settings equality

### DIFF
--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -31,7 +31,10 @@ import {
   validateAndDedupeAdditionalWorkingDirectoryInputs,
 } from "../contracts/additional-working-directories.js";
 import type { RunRuntimeSettingsSnapshot } from "../contracts/run-contracts.js";
-import { cloneFrozenRuntimeSettingsSnapshot } from "../state/runtime-settings-snapshot.js";
+import {
+  cloneFrozenRuntimeSettingsSnapshot,
+  runtimeSettingsEqual,
+} from "../state/runtime-settings-snapshot.js";
 
 import { AsyncLock } from "../utils/async-lock.js";
 import { withTimeout } from "../utils/sleep.js";
@@ -4371,37 +4374,13 @@ export function assertCanonicalRuntimeSettingsProjection(
     proof.runtimeSettings === undefined ||
     proof.runtimeSettingsEventId === undefined ||
     projected.eventId !== proof.runtimeSettingsEventId ||
-    !runtimeSettingsSnapshotsEqual(projected, proof.runtimeSettings)
+    !runtimeSettingsEqual(projected, proof.runtimeSettings)
   ) {
     throw new AgenCDaemonAgentLifecycleError(
       "INVALID_ARGUMENT",
       `canonical session ${runId} runtime settings projection is ahead of or disagrees with the rollout`,
     );
   }
-}
-
-function runtimeSettingsSnapshotsEqual(
-  left: RunRuntimeSettingsSnapshot,
-  right: RunRuntimeSettingsSnapshot,
-): boolean {
-  return (
-    left.permissionMode === right.permissionMode &&
-    left.prePlanMode === right.prePlanMode &&
-    left.autoModeActive === right.autoModeActive &&
-    left.autoModeAvailable === right.autoModeAvailable &&
-    left.bypassPermissionsModeAvailable ===
-      right.bypassPermissionsModeAvailable &&
-    left.bypassPermissionsWorkspace === right.bypassPermissionsWorkspace &&
-    left.bypassPermissionsConsentWorkspace ===
-      right.bypassPermissionsConsentWorkspace &&
-    left.model === right.model &&
-    left.provider === right.provider &&
-    left.profile === right.profile &&
-    left.reasoningEffort === right.reasoningEffort &&
-    left.modelVerbosity === right.modelVerbosity &&
-    left.serviceTier === right.serviceTier &&
-    left.hooksDisabled === right.hooksDisabled
-  );
 }
 
 const MAX_RESUME_ROLLOUT_FILES_PER_SESSION = 256;

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -37,7 +37,6 @@ import type { ApprovalCtx, ApprovalResolver } from "../tools/orchestrator.js";
 import { routerFromRegistry } from "../tools/router.js";
 import { buildLiveToolDispatchOptions } from "../phases/execute-tools.js";
 import type { ToolDispatchResult, ToolRegistry } from "../tool-registry.js";
-import { stableStringify } from "../utils/stableStringify.js";
 import { logForDebugging } from "../utils/debug.js";
 import {
   runWithBootstrapSessionScope,
@@ -161,6 +160,7 @@ import {
 } from "../contracts/run-contracts.js";
 import {
   cloneFrozenRuntimeSettingsSnapshot,
+  runtimeSettingsEqual,
 } from "../state/runtime-settings-snapshot.js";
 import { runWithAgentRuntimeOptions } from "../session/runtime-options.js";
 import { shutdownSessionLifecycle } from "../session/lifecycle.js";
@@ -1051,8 +1051,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         );
         if (
           params.runtimeSettings !== undefined &&
-          stableStringify(params.runtimeSettings) !==
-            stableStringify(canonicalRuntimeState.runtimeSettings)
+          (canonicalRuntimeState.runtimeSettings === undefined ||
+            !runtimeSettingsEqual(
+              params.runtimeSettings,
+              canonicalRuntimeState.runtimeSettings,
+            ))
         ) {
           throw new Error(
             `restoreAgent runtime settings disagree with canonical run ${params.agentId}`,
@@ -1196,8 +1199,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         if (
           canonicalRuntimeState.runtimeSettings !== undefined &&
           restoredRuntimeSettings !== undefined &&
-          stableStringify(restoredRuntimeSettings) !==
-            stableStringify(canonicalRuntimeState.runtimeSettings)
+          !runtimeSettingsEqual(
+            restoredRuntimeSettings,
+            canonicalRuntimeState.runtimeSettings,
+          )
         ) {
           commitDurableRuntimeSettingsChange(
             active,
@@ -1214,10 +1219,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
             runtimeWorkspaceRoot(bootstrap),
             bootstrap.configStore.current(),
           );
-          if (
-            stableStringify(restoreOverrides) !==
-            stableStringify(restoredBaseline)
-          ) {
+          if (!runtimeSettingsEqual(restoreOverrides, restoredBaseline)) {
             const previousSettings = restoredBaseline;
             const reason: RunRuntimeSettingsChangeReason =
               restoreOverrides.permissionMode !==
@@ -3955,7 +3957,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         ...(nextServiceTier !== null ? { serviceTier: nextServiceTier } : {}),
       };
       const settingsChanged =
-        stableStringify(nextSettings) !== stableStringify(previousSettings);
+        !runtimeSettingsEqual(nextSettings, previousSettings);
       let preparedSettingsChange: PreparedRuntimeSettingsChange | undefined;
       let stagedProviderSwitch: PreparedSessionProviderSwitch | undefined;
       if (settingsChanged) {

--- a/runtime/src/app-server/background-agent-runner/runtime-settings.ts
+++ b/runtime/src/app-server/background-agent-runner/runtime-settings.ts
@@ -12,7 +12,6 @@ import type {
 import {
   buildStructuredSessionBootstrapArgv,
 } from "../session-bootstrap-argv.js";
-import { stableStringify } from "../../utils/stableStringify.js";
 import { runWithCurrentRuntimeSession } from "../../session/current-session.js";
 import {
   transitionPermissionMode,
@@ -55,6 +54,7 @@ import {
 } from "../../contracts/run-contracts.js";
 import {
   cloneFrozenRuntimeSettingsSnapshot,
+  runtimeSettingsEqual,
 } from "../../state/runtime-settings-snapshot.js";
 import {
   applySessionExecutionAuthority,
@@ -653,8 +653,7 @@ function installRuntimeSettingsPreCommit(
       });
       if (
         active.runtimeSettings !== undefined &&
-        stableStringify(active.runtimeSettings) ===
-          stableStringify(nextSettings)
+        runtimeSettingsEqual(active.runtimeSettings, nextSettings)
       ) {
         release();
         return undefined;
@@ -1148,8 +1147,10 @@ function prepareDurableRuntimeSettingsChange(
         rollbackOfSettingsEventId ||
       event.msg.payload.reason !== reason ||
       event.msg.payload.changedAt !== changedAt ||
-      stableStringify(runtimeSettingsSnapshotFromCanonicalEvent(event)) !==
-        stableStringify(canonicalSettings)
+      !runtimeSettingsEqual(
+        runtimeSettingsSnapshotFromCanonicalEvent(event),
+        canonicalSettings,
+      )
     ) {
       throw new Error(`runtime settings ${eventId} has conflicting evidence`);
     }

--- a/runtime/src/state/recovery-journal-contract.ts
+++ b/runtime/src/state/recovery-journal-contract.ts
@@ -1,3 +1,4 @@
+import { runtimeSettingsEqual } from "./runtime-settings-snapshot.js";
 import { createHash, type Hash } from "node:crypto";
 import {
   parseRolloutLine,
@@ -1880,30 +1881,6 @@ function validBoundedSettingString(value: unknown, maxBytes: number): boolean {
     typeof value === "string" &&
     value.trim().length > 0 &&
     Buffer.byteLength(value, "utf8") <= maxBytes
-  );
-}
-
-function runtimeSettingsEqual(
-  left: RunRuntimeSettingsSnapshot,
-  right: RunRuntimeSettingsSnapshot,
-): boolean {
-  return (
-    left.permissionMode === right.permissionMode &&
-    left.prePlanMode === right.prePlanMode &&
-    left.autoModeActive === right.autoModeActive &&
-    left.autoModeAvailable === right.autoModeAvailable &&
-    left.bypassPermissionsModeAvailable ===
-      right.bypassPermissionsModeAvailable &&
-    left.bypassPermissionsWorkspace === right.bypassPermissionsWorkspace &&
-    left.bypassPermissionsConsentWorkspace ===
-      right.bypassPermissionsConsentWorkspace &&
-    left.model === right.model &&
-    left.provider === right.provider &&
-    left.profile === right.profile &&
-    left.reasoningEffort === right.reasoningEffort &&
-    left.modelVerbosity === right.modelVerbosity &&
-    left.serviceTier === right.serviceTier &&
-    left.hooksDisabled === right.hooksDisabled
   );
 }
 

--- a/runtime/src/state/run-durability.ts
+++ b/runtime/src/state/run-durability.ts
@@ -1,3 +1,4 @@
+import { runtimeSettingsEqual } from "./runtime-settings-snapshot.js";
 import type {
   EffectBoundary,
   EffectNoEffectProof,
@@ -2371,30 +2372,6 @@ function runtimeSettingsFromRow(
     serviceTier: row.service_tier,
     hooksDisabled: row.hooks_disabled === 1,
   };
-}
-
-function runtimeSettingsEqual(
-  left: RunRuntimeSettingsSnapshot,
-  right: RunRuntimeSettingsSnapshot,
-): boolean {
-  return (
-    left.permissionMode === right.permissionMode &&
-    left.prePlanMode === right.prePlanMode &&
-    left.autoModeActive === right.autoModeActive &&
-    left.autoModeAvailable === right.autoModeAvailable &&
-    left.bypassPermissionsModeAvailable ===
-      right.bypassPermissionsModeAvailable &&
-    left.bypassPermissionsWorkspace === right.bypassPermissionsWorkspace &&
-    left.bypassPermissionsConsentWorkspace ===
-      right.bypassPermissionsConsentWorkspace &&
-    left.model === right.model &&
-    left.provider === right.provider &&
-    left.profile === right.profile &&
-    left.reasoningEffort === right.reasoningEffort &&
-    left.modelVerbosity === right.modelVerbosity &&
-    left.serviceTier === right.serviceTier &&
-    left.hooksDisabled === right.hooksDisabled
-  );
 }
 
 function effectFromRow(row: EffectRow): DurableRunEffect {

--- a/runtime/src/state/runtime-settings-snapshot.ts
+++ b/runtime/src/state/runtime-settings-snapshot.ts
@@ -1,5 +1,41 @@
 import type { RunRuntimeSettingsSnapshot } from "../contracts/run-contracts.js";
 
+function exhaustiveRuntimeSettingsKeys<
+  const Keys extends readonly (keyof RunRuntimeSettingsSnapshot)[],
+>(
+  keys: Keys &
+    (Exclude<keyof RunRuntimeSettingsSnapshot, Keys[number]> extends never
+      ? unknown
+      : never),
+): Keys {
+  return keys;
+}
+
+const RUNTIME_SETTINGS_KEYS = exhaustiveRuntimeSettingsKeys([
+  "permissionMode",
+  "prePlanMode",
+  "autoModeActive",
+  "autoModeAvailable",
+  "bypassPermissionsModeAvailable",
+  "bypassPermissionsWorkspace",
+  "bypassPermissionsConsentWorkspace",
+  "model",
+  "provider",
+  "profile",
+  "reasoningEffort",
+  "modelVerbosity",
+  "serviceTier",
+  "hooksDisabled",
+] as const satisfies readonly (keyof RunRuntimeSettingsSnapshot)[]);
+
+/** Canonical snapshots represent absent optional settings as null. */
+export function runtimeSettingsEqual(
+  left: RunRuntimeSettingsSnapshot,
+  right: RunRuntimeSettingsSnapshot,
+): boolean {
+  return RUNTIME_SETTINGS_KEYS.every((key) => left[key] === right[key]);
+}
+
 function freezeRuntimeSettingsValue<T>(value: T): T {
   if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
     return value;

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -3101,6 +3101,77 @@ describe("AgenC delegate background-agent runner", () => {
     expect(harness.stateRepository.reload).toHaveBeenCalled();
   });
 
+  it("restores matching snapshot fields without comparing durable metadata", async () => {
+    const runId = "session-settings-comparison-metadata";
+    const baseline = canonicalRuntimeSettings();
+    const rolloutItems = [runtimeSettingsRolloutItem(runId, baseline)];
+    const harness = makeTopLevelRunner({
+      conversationId: runId,
+      rolloutItems,
+      canonicalRuntimeSettings: true,
+    });
+    const projection = {
+      ...baseline,
+      eventId: `runtime-settings:${runId}:initial`,
+      epoch: 1,
+    };
+
+    await expect(
+      harness.runner.restoreAgent({
+        agentId: runId,
+        objective: "compare canonical settings fields",
+        explicitColdResume: true,
+        runtimeSettings: projection,
+      }),
+    ).resolves.toBe(true);
+
+    expect(recordedRuntimeSettingsEvents(rolloutItems)).toHaveLength(1);
+    expect((await harness.runner.getAgentSnapshot(runId))?.runtimeSettings)
+      .toEqual(baseline);
+  });
+
+  it.each(["missing", "conflicting", "serialization-hook"])(
+    "rejects a %s canonical settings projection during restore",
+    async (scenario) => {
+      const runId = `session-settings-comparison-${scenario}`;
+      const baseline = canonicalRuntimeSettings();
+      const rolloutItems = scenario === "missing"
+        ? []
+        : [runtimeSettingsRolloutItem(runId, baseline)];
+      const harness = makeTopLevelRunner({
+        conversationId: runId,
+        rolloutItems,
+        canonicalRuntimeSettings: true,
+      });
+      const serialize = vi.fn(() => baseline);
+      const projection = {
+        ...baseline,
+        hooksDisabled: true,
+        ...(scenario === "serialization-hook" ? { toJSON: serialize } : {}),
+      };
+
+      await expect(
+        harness.runner.restoreAgent({
+          agentId: runId,
+          objective: "reject inconsistent settings evidence",
+          explicitColdResume: true,
+          runtimeSettings: projection,
+        }),
+      ).rejects.toThrow("runtime settings disagree with canonical run");
+
+      expect(serialize).not.toHaveBeenCalled();
+      expect(await harness.runner.getAgentSnapshot(runId)).toBeNull();
+      expect(recordedRuntimeSettingsEvents(rolloutItems))
+        .toHaveLength(scenario === "missing" ? 0 : 1);
+    },
+  );
+
+  it("uses field comparison throughout runner restore and configuration", () => {
+    const source = readFileSync(backgroundAgentRunnerSourcePath, "utf8");
+    expect(source.includes("stableStringify")).toBe(false);
+    expect(source).toContain("runtimeSettingsEqual");
+  });
+
   it("durably applies explicit restore overrides after the canonical settings baseline", async () => {
     const baseline = {
       permissionMode: "default" as const,

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -5499,6 +5499,34 @@ describe("AgenC delegate background-agent runner", () => {
     );
   });
 
+  it.each([undefined, null])("normalizes absent optional runtime settings from %s", async (absent) => {
+    const agentId = `normalized-runtime-settings-${String(absent)}`;
+    const { runner, sessionState, rolloutItems } = makeTopLevelRunner({
+      conversationId: agentId,
+      canonicalRuntimeSettings: true,
+    });
+    Object.assign(sessionState.sessionConfiguration.collaborationMode, {
+      reasoningEffort: absent,
+    });
+    Object.assign(sessionState.sessionConfiguration, {
+      modelVerbosity: absent,
+      serviceTier: absent,
+    });
+    await runner.startAgent({ objective: "work", cwd: process.cwd() });
+
+    const canonicalAbsent = {
+      prePlanMode: null,
+      bypassPermissionsWorkspace: null,
+      bypassPermissionsConsentWorkspace: null,
+      profile: null,
+      reasoningEffort: null,
+      modelVerbosity: null,
+      serviceTier: null,
+    };
+    expect((await runner.getAgentSnapshot(agentId))?.runtimeSettings).toMatchObject(canonicalAbsent);
+    expect(recordedRuntimeSettingsEvents(rolloutItems).at(-1)?.msg?.payload).toMatchObject(canonicalAbsent);
+  });
+
   it("keeps canonical runtime settings detached from mutable in-process snapshots", async () => {
     const agentId = "runtime-settings-snapshot-isolation";
     let hooksDisabled = false;

--- a/runtime/tests/state/runtime-settings-snapshot.test.ts
+++ b/runtime/tests/state/runtime-settings-snapshot.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import type { RunRuntimeSettingsSnapshot } from "../../src/contracts/run-contracts.js";
+import { runtimeSettingsEqual } from "../../src/state/runtime-settings-snapshot.js";
+
+const baseline: RunRuntimeSettingsSnapshot = {
+  permissionMode: "default",
+  prePlanMode: null,
+  autoModeActive: false,
+  autoModeAvailable: false,
+  bypassPermissionsModeAvailable: false,
+  bypassPermissionsWorkspace: null,
+  bypassPermissionsConsentWorkspace: null,
+  model: "grok-4.5",
+  provider: "grok",
+  profile: null,
+  reasoningEffort: null,
+  modelVerbosity: null,
+  serviceTier: null,
+  hooksDisabled: false,
+};
+
+const alternatives: RunRuntimeSettingsSnapshot = {
+  permissionMode: "plan",
+  prePlanMode: "default",
+  autoModeActive: true,
+  autoModeAvailable: true,
+  bypassPermissionsModeAvailable: true,
+  bypassPermissionsWorkspace: "/workspace",
+  bypassPermissionsConsentWorkspace: "/workspace",
+  model: "gpt-5",
+  provider: "openai",
+  profile: "review",
+  reasoningEffort: "high",
+  modelVerbosity: "low",
+  serviceTier: "priority",
+  hooksDisabled: true,
+};
+
+const keys = Object.keys(baseline) as (keyof RunRuntimeSettingsSnapshot)[];
+
+describe("runtime settings equality", () => {
+  it.each(keys)("detects a change to %s in either direction", (key) => {
+    const changed = { ...baseline, [key]: alternatives[key] };
+    expect(runtimeSettingsEqual(baseline, changed)).toBe(false);
+    expect(runtimeSettingsEqual(changed, baseline)).toBe(false);
+  });
+
+  it("compares detached snapshots independently of property order and durable metadata", () => {
+    const reversed = Object.fromEntries(
+      Object.entries(baseline).toReversed(),
+    ) as unknown as RunRuntimeSettingsSnapshot;
+    const durable = {
+      ...structuredClone(baseline),
+      eventId: "settings:1",
+      epoch: 1,
+    };
+    expect(runtimeSettingsEqual(baseline, reversed)).toBe(true);
+    expect(runtimeSettingsEqual(baseline, durable)).toBe(true);
+    expect(
+      runtimeSettingsEqual(alternatives, structuredClone(alternatives)),
+    ).toBe(true);
+  });
+
+  it.each(keys.filter((key) => baseline[key] === null))(
+    "requires the canonical null representation for absent %s",
+    (key) => {
+      const absent = {
+        ...baseline,
+        [key]: undefined,
+      } as unknown as RunRuntimeSettingsSnapshot;
+      expect(runtimeSettingsEqual(baseline, { ...baseline })).toBe(true);
+      expect(runtimeSettingsEqual(baseline, absent)).toBe(false);
+      expect(runtimeSettingsEqual(absent, baseline)).toBe(false);
+    },
+  );
+});
+
+const snapshotPath = fileURLToPath(
+  new URL("../../src/state/runtime-settings-snapshot.ts", import.meta.url),
+);
+const contractsPath = fileURLToPath(
+  new URL("../../src/contracts/run-contracts.ts", import.meta.url),
+);
+const snapshotSource = readFileSync(snapshotPath, "utf8");
+const contractsSource = ts.createSourceFile(
+  contractsPath,
+  readFileSync(contractsPath, "utf8"),
+  ts.ScriptTarget.Latest,
+  true,
+);
+// Compile the actual snapshot contract without unrelated run/tool contracts.
+const snapshotContracts = contractsSource.statements
+  .filter((statement) => {
+    if (ts.isInterfaceDeclaration(statement)) {
+      return statement.name.text === "RunRuntimeSettingsSnapshot";
+    }
+    if (ts.isTypeAliasDeclaration(statement)) {
+      return statement.name.text.startsWith("RunRuntime");
+    }
+    return (
+      ts.isVariableStatement(statement) &&
+      statement.declarationList.declarations.some(
+        (declaration) =>
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text.startsWith("RUN_RUNTIME_"),
+      )
+    );
+  })
+  .map((statement) => statement.getFullText(contractsSource))
+  .join("\n");
+
+function compileSnapshot(additionalField = "", source = snapshotSource) {
+  const options: ts.CompilerOptions = {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    types: [],
+    lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
+  };
+  const host = ts.createCompilerHost(options);
+  const readSource = host.getSourceFile;
+  host.getSourceFile = (
+    fileName,
+    languageVersion,
+    onError,
+    shouldCreateNewSourceFile,
+  ) => {
+    if (fileName === snapshotPath || fileName === contractsPath) {
+      const content =
+        fileName === snapshotPath
+          ? source
+          : snapshotContracts + additionalField;
+      return ts.createSourceFile(fileName, content, languageVersion, true);
+    }
+    return readSource(
+      fileName,
+      languageVersion,
+      onError,
+      shouldCreateNewSourceFile,
+    );
+  };
+  return ts
+    .getPreEmitDiagnostics(ts.createProgram([snapshotPath], options, host))
+    .map((diagnostic) => ({
+      file: diagnostic.file?.fileName,
+      code: diagnostic.code,
+      message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    }));
+}
+
+describe("runtime settings comparison coverage", () => {
+  it("type-checks the current production comparator", () => {
+    expect(compileSnapshot()).toEqual([]);
+  });
+
+  it.each(["", "?"])(
+    "rejects an unlisted future field%s until a policy is chosen",
+    (optional) => {
+      const extra = `\nexport interface RunRuntimeSettingsSnapshot { readonly futureSetting${optional}: string; }`;
+      expect(compileSnapshot(extra)).toEqual([
+        expect.objectContaining({ file: snapshotPath, code: 2345 }),
+      ]);
+      const updated = snapshotSource.replace(
+        '"hooksDisabled",',
+        '"hooksDisabled", "futureSetting",',
+      );
+      expect(updated).not.toBe(snapshotSource);
+      expect(compileSnapshot(extra, updated)).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
Runtime settings comparisons were duplicated across durability, journal validation, and agent resume. Six more comparisons in the background runner serialized snapshots to JSON. All now use one field-based equality function from `runtime-settings-snapshot.ts`, including restore validation, restore overrides, and configuration changes.

The explicit 14-key tuple rejects invalid keys and cannot compile if a required or optional snapshot field is omitted. Canonical absent settings remain `null`; comparison stays strict. Existing producers already normalize omitted and explicit-null optional settings before creating snapshots. Durable event identity and provenance checks remain separate from snapshot equality.

Tests cover each field, property order, durable metadata, canonical nulls, and optional-value normalization through the real background runner. Compiler regression cases add a required or optional field to the actual snapshot contract, confirm compilation fails, then add the comparison key and confirm it succeeds. Restore regression tests preserve rejection of missing canonical settings and conflicting fields, accept matching fields with durable metadata, and prevent serialization hooks from hiding conflicts. Three new checks fail against the previous runner implementation.

On a7817b8846e0697e8e2fc320a4a8c67830644a51, typecheck, all 404 targeted tests, the runtime build, every terminal startup check, and the complete agent-surface contract passed. The full local suite passed 22,698 tests with zero skips and only the stale benchmark-binding failure described below. All nine hosted native-platform jobs passed. Three hosted full-suite shards passed; the fourth reported only that same binding failure. Bugbot, security review, approval, and Sonar checks passed with no new findings. The hosted affected-test repeat is still running; the completed full-suite and targeted runs cover the final source.

The remaining failure is the stale FND production-module binding for `run-durability.ts`. Benchmark capture requires the measured revision to be an ancestor of the default branch and its complete `runtime/src` tree to match the checkout. The new measurements therefore require this source change to merge first. A follow-up PR will regenerate both benchmark artifacts from the merged revision without weakening the provenance checks, then rerun the full suite and platform lanes.

Addresses #1818. The issue stays open until the benchmark refresh and final validation are complete.
