### PR TITLE
refactor(runtime): share confined workflow filesystem I/O

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1460,6 +1460,7 @@ jobs:
             --require-zero-skips `
             run `
             tests/agents/jobs/csv-output.native.test.ts `
+            tests/agents/workflow-filesystem.win32.test.ts `
             tests/app-server/windows-named-pipe.win32.test.ts `
             tests/durability/atomic-artifact.win32.test.ts `
             tests/fnd/benchmark-harness-faults.test.ts `
@@ -1485,6 +1486,7 @@ jobs:
           const results = JSON.parse(readFileSync(resultsPath, "utf8"));
           const expectedFiles = [
             "tests/agents/jobs/csv-output.native.test.ts",
+            "tests/agents/workflow-filesystem.win32.test.ts",
             "tests/app-server/windows-named-pipe.win32.test.ts",
             "tests/durability/atomic-artifact.win32.test.ts",
             "tests/fnd/benchmark-harness-faults.test.ts",
@@ -1497,12 +1499,12 @@ jobs:
             "tests/workspace/bound-helper-transport.win32.test.ts",
           ];
           const exactCounts = {
-            numTotalTestSuites: 18,
-            numPassedTestSuites: 18,
+            numTotalTestSuites: 19,
+            numPassedTestSuites: 19,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 104,
-            numPassedTests: 104,
+            numTotalTests: 110,
+            numPassedTests: 110,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -1525,7 +1527,7 @@ jobs:
               `Windows-native files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
             );
           }
-          console.log("Windows FND/native capability lane passed 104 tests in 11 files with zero skipped");
+          console.log("Windows FND/native capability lane passed 110 tests in 12 files with zero skipped");
           '@ | node --input-type=module - $results
           if ($LASTEXITCODE -ne 0) { throw "Windows native result contract failed" }
           if (-not [string]::IsNullOrWhiteSpace(

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1503,8 +1503,8 @@ jobs:
             numPassedTestSuites: 19,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
-            numTotalTests: 110,
-            numPassedTests: 110,
+            numTotalTests: 111,
+            numPassedTests: 111,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -1527,7 +1527,7 @@ jobs:
               `Windows-native files were ${JSON.stringify(files)}, expected ${JSON.stringify(expectedFiles)}`,
             );
           }
-          console.log("Windows FND/native capability lane passed 110 tests in 12 files with zero skipped");
+          console.log("Windows FND/native capability lane passed 111 tests in 12 files with zero skipped");
           '@ | node --input-type=module - $results
           if ($LASTEXITCODE -ne 0) { throw "Windows native result contract failed" }
           if (-not [string]::IsNullOrWhiteSpace(

--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -57,6 +57,30 @@ data. They are never used directly as filesystem or agent-path components.
 Input aliases must start with a letter and then contain only letters, digits,
 `_`, or `-`.
 
+### Filesystem access
+
+Manifest loading and handoff storage share the descriptor, identity, and
+bounded-read operations in `runtime/src/fs/descriptor-confined-io.ts`.
+Both reject symlink roots and children and recheck file snapshots and root
+identity after reading. Child creation or removal elsewhere in the root does
+not invalidate an unchanged file.
+
+Manifest roots and files may be shared, and manifests may have hard links.
+When traversable descriptor aliases are unavailable, the manifest loader uses
+an explicitly selected path fallback with identity checks before and after I/O.
+
+Committed handoffs require private roots and files and reject hard links.
+POSIX handoff I/O fails closed without a traversable descriptor alias. Windows
+handoffs use the path fallback only with protected, current-user-only NTFS ACL
+checks on roots and files. During Windows installation, a candidate may still
+have the temporary publication hard link; committed reads retain the strict
+single-link rule. Reads, cleanup checks, and existing-candidate comparisons
+retain their byte caps even if a file grows.
+
+Path fallback checks can detect observed replacements but cannot provide an
+atomic namespace-confinement guarantee against an ancestor that another actor
+replaces and restores entirely between checks.
+
 ### Child identity
 
 The agent registry accepts only `[a-z0-9_]+` path segments

--- a/runtime/src/agents/workflow-handoff-store.ts
+++ b/runtime/src/agents/workflow-handoff-store.ts
@@ -8,17 +8,14 @@ import {
   mkdirSync,
   realpathSync,
   statSync,
-  type BigIntStats,
 } from "node:fs";
 import {
   link,
-  lstat,
   open,
-  realpath,
   unlink,
   type FileHandle,
 } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { TextDecoder } from "node:util";
 
 import {
@@ -50,6 +47,20 @@ import {
   type WorkflowHandoffOwner,
 } from "./workflow-handoff-schema.js";
 import { assertWindowsPrivatePathSecurity } from "./workflow-private-path.js";
+import {
+  ConfinedIoError,
+  noFollowFlag,
+  readConfinedFile,
+  safePrivateDirectory,
+  sameIdentity,
+  scanConfinedFile,
+  withConfinedDirectory,
+  withRegularChild,
+  type ConfinedDirectory,
+  type ConfinedFile,
+  type ConfinedIoHooks,
+  type ConfinedIoPolicy,
+} from "../fs/descriptor-confined-io.js";
 
 const ARTIFACT_ID_DIGEST_DOMAIN = "agenc.workflow-handoff.artifact-id.v2\0";
 const ARTIFACT_CONTENT_DIGEST_DOMAIN = "";
@@ -58,7 +69,17 @@ const ARTIFACT_FILE_MODE = 0o600;
 const ARTIFACT_ROOT_MODE = 0o700;
 const SHA256_PREFIX = "sha256:";
 const MAX_REFERENCE_FIELD_UTF8_BYTES = 1_024;
-const SOURCE_COPY_BYTES = 64 * 1_024;
+const HANDOFF_IO_POLICY = Object.freeze({
+  hardLinks: "reject",
+  privateDirectory: true,
+  privateFile: true,
+  unavailableAlias: "windows-private-path",
+  verifyWindowsPrivatePath: (path, role) => assertWindowsPrivatePath(path, role, false),
+} satisfies ConfinedIoPolicy);
+const HANDOFF_INSTALLATION_IO_POLICY = Object.freeze({
+  ...HANDOFF_IO_POLICY,
+  hardLinks: "allow",
+} satisfies ConfinedIoPolicy);
 
 export type WorkflowHandoffStatus =
   | "intent"
@@ -108,7 +129,7 @@ export interface WorkflowHandoffStoreOptions {
   readonly hooks?: WorkflowHandoffStoreHooks;
 }
 
-export interface WorkflowHandoffStoreHooks {
+export interface WorkflowHandoffStoreHooks extends ConfinedIoHooks {
   readonly afterIntentReserved?: (artifactId: string) => void | Promise<void>;
   readonly afterArtifactInstalled?: (artifactId: string) => void | Promise<void>;
   readonly afterCleanupReserved?: (
@@ -1043,81 +1064,26 @@ export class WorkflowHandoffArtifactStore {
     readonly observation: "missing" | "match" | "conflict";
     readonly bytes?: Buffer;
   }> {
-    return this.#withPinnedRoot(async (operationRoot) => {
-      const path = join(operationRoot, artifactFilename(row.artifact_id));
-      let pathBefore: BigIntStats;
+    return this.#withPinnedRoot(async (root) => {
       try {
-        pathBefore = await lstat(path, { bigint: true });
+        return await withRegularChild(
+          root,
+          artifactFilename(row.artifact_id),
+          {
+            maximumBytes: MAX_WORKFLOW_ARTIFACT_BYTES,
+            expectedBytes: row.byte_length,
+          },
+          async (file) => {
+            const bytes = await readConfinedFile(file);
+            return contentDigest(bytes) === row.digest
+              ? { observation: "match" as const, bytes }
+              : { observation: "conflict" as const };
+          },
+          this.#hooks,
+        ) ?? { observation: "missing" as const };
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-          return { observation: "missing" as const };
-        }
+        if (isConfinedChildError(error)) return { observation: "conflict" as const };
         throw error;
-      }
-      if (!pathBefore.isFile() || pathBefore.isSymbolicLink()) {
-        return { observation: "conflict" as const };
-      }
-      if (process.platform === "win32") {
-        try {
-          assertWindowsPrivatePath(path, "file", false);
-        } catch {
-          return { observation: "conflict" as const };
-        }
-      }
-      let handle: FileHandle;
-      try {
-        handle = await open(path, fsConstants.O_RDONLY | noFollowFlag());
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-          return { observation: "missing" as const };
-        }
-        if ((error as NodeJS.ErrnoException).code === "ELOOP") {
-          return { observation: "conflict" as const };
-        }
-        throw error;
-      }
-      try {
-        const before = await handle.stat({ bigint: true });
-        if (
-          !before.isFile() ||
-          !sameSnapshot(pathBefore, before) ||
-          before.nlink !== 1n ||
-          before.size !== BigInt(row.byte_length) ||
-          !privateFileMode(before)
-        ) {
-          return { observation: "conflict" as const };
-        }
-        const bytes = Buffer.allocUnsafe(row.byte_length);
-        let offset = 0;
-        while (offset < bytes.byteLength) {
-          const read = await handle.read(
-            bytes,
-            offset,
-            bytes.byteLength - offset,
-            offset,
-          );
-          if (read.bytesRead === 0) break;
-          offset += read.bytesRead;
-        }
-        const [after, currentPath] = await Promise.all([
-          handle.stat({ bigint: true }),
-          lstat(path, { bigint: true }).catch(() => undefined),
-        ]);
-        if (
-          offset !== bytes.byteLength ||
-          currentPath === undefined ||
-          currentPath.isSymbolicLink() ||
-          !sameSnapshot(before, after) ||
-          !sameSnapshot(before, currentPath)
-        ) {
-          return { observation: "conflict" as const };
-        }
-        if (contentDigest(bytes) !== row.digest) {
-          return { observation: "conflict" as const };
-        }
-        return { observation: "match" as const, bytes };
-      } finally {
-        await handle.close();
       }
     });
   }
@@ -1125,141 +1091,41 @@ export class WorkflowHandoffArtifactStore {
   async #removeExpectedFile(
     row: WorkflowHandoffRow,
   ): Promise<"removed" | "missing" | "conflict"> {
-    return this.#withPinnedRoot(async (operationRoot, rootHandle) => {
-      const path = join(operationRoot, artifactFilename(row.artifact_id));
-      let pathBefore: BigIntStats;
+    return this.#withPinnedRoot(async (root) => {
       try {
-        pathBefore = await lstat(path, { bigint: true });
+        return await withRegularChild(
+          root,
+          artifactFilename(row.artifact_id),
+          {
+            maximumBytes: MAX_WORKFLOW_ARTIFACT_BYTES,
+            expectedBytes: row.byte_length,
+          },
+          async (file) => {
+            const bytes = await readConfinedFile(file);
+            if (contentDigest(bytes) !== row.digest) return "conflict" as const;
+            await file.verify();
+            await unlink(file.path);
+            await root.handle?.sync().catch((error: unknown) => {
+              const code = (error as NodeJS.ErrnoException).code;
+              if (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EPERM") {
+                throw error;
+              }
+            });
+            return "removed" as const;
+          },
+          this.#hooks,
+        ) ?? "missing";
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+        if (isConfinedChildError(error)) return "conflict";
         throw error;
-      }
-      if (!pathBefore.isFile() || pathBefore.isSymbolicLink()) return "conflict";
-      if (process.platform === "win32") {
-        try {
-          assertWindowsPrivatePath(path, "file", false);
-        } catch {
-          return "conflict";
-        }
-      }
-      let handle: FileHandle;
-      try {
-        handle = await open(path, fsConstants.O_RDONLY | noFollowFlag());
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
-        if ((error as NodeJS.ErrnoException).code === "ELOOP") return "conflict";
-        throw error;
-      }
-      try {
-        const before = await handle.stat({ bigint: true });
-        if (
-          !before.isFile() ||
-          !sameSnapshot(pathBefore, before) ||
-          before.nlink !== 1n ||
-          before.size !== BigInt(row.byte_length) ||
-          !privateFileMode(before)
-        ) {
-          return "conflict";
-        }
-        const bytes = await handle.readFile();
-        const currentPath = await lstat(path, { bigint: true }).catch(
-          () => undefined,
-        );
-        if (
-          currentPath === undefined ||
-          currentPath.isSymbolicLink() ||
-          !sameSnapshot(before, currentPath) ||
-          bytes.byteLength !== row.byte_length ||
-          contentDigest(bytes) !== row.digest
-        ) {
-          return "conflict";
-        }
-        await unlink(path);
-        await rootHandle?.sync().catch((error: unknown) => {
-          const code = (error as NodeJS.ErrnoException).code;
-          if (code !== "EINVAL" && code !== "ENOTSUP" && code !== "EPERM") {
-            throw error;
-          }
-        });
-        return "removed";
-      } finally {
-        await handle.close();
       }
     });
   }
 
-  async #withPinnedRoot<T>(
-    operation: (
-      operationRoot: string,
-      rootHandle: FileHandle | undefined,
-    ) => Promise<T>,
-  ): Promise<T> {
-    const lexical = await lstat(this.#trustedRoot, { bigint: true });
-    if (!safePrivateDirectory(lexical)) {
-      throw storeError(
-        "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-        `workflow handoff root is not a private real directory: ${this.#trustedRoot}`,
-      );
-    }
-    const canonical = await realpath(this.#trustedRoot);
-    if (process.platform === "win32") {
-      assertWindowsPrivatePath(canonical, "directory", false);
-      const result = await operation(canonical, undefined);
-      const [afterPath, afterCanonical] = await Promise.all([
-        lstat(this.#trustedRoot, { bigint: true }),
-        realpath(this.#trustedRoot),
-      ]);
-      assertWindowsPrivatePath(afterCanonical, "directory", false);
-      if (
-        afterCanonical !== canonical ||
-        !sameIdentity(lexical, afterPath) ||
-        !safePrivateDirectory(afterPath)
-      ) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff Windows root changed during I/O",
-        );
-      }
-      return result;
-    }
-    const rootHandle = await open(this.#trustedRoot, directoryOpenFlags());
-    try {
-      const opened = await rootHandle.stat({ bigint: true });
-      if (!safePrivateDirectory(opened) || !sameIdentity(lexical, opened)) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff root changed while opening",
-        );
-      }
-      const operationRoot = await descriptorOperationRoot(rootHandle, canonical);
-      if (operationRoot === undefined) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_SAFE_IO_UNSUPPORTED",
-          `descriptor-confined workflow handoff I/O is unsupported on ${process.platform}`,
-        );
-      }
-      const result = await operation(operationRoot, rootHandle);
-      const [afterPath, afterCanonical, afterHandle] = await Promise.all([
-        lstat(this.#trustedRoot, { bigint: true }),
-        realpath(this.#trustedRoot),
-        rootHandle.stat({ bigint: true }),
-      ]);
-      if (
-        afterCanonical !== canonical ||
-        !sameIdentity(lexical, afterPath) ||
-        !sameIdentity(lexical, afterHandle) ||
-        !safePrivateDirectory(afterPath) ||
-        !safePrivateDirectory(afterHandle)
-      ) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff root changed during I/O",
-        );
-      }
-      return result;
-    } finally {
-      await rootHandle.close();
-    }
+  async #withPinnedRoot<Result>(
+    operation: (root: ConfinedDirectory) => Promise<Result>,
+  ): Promise<Result> {
+    return withHandoffRoot(this.#trustedRoot, operation, HANDOFF_IO_POLICY, this.#hooks);
   }
 
   #markConflict(
@@ -1696,63 +1562,29 @@ function isWellFormedUnicode(value: string): boolean {
   return true;
 }
 
-function safePrivateDirectory(stats: BigIntStats): boolean {
-  return (
-    stats.isDirectory() &&
-    !stats.isSymbolicLink() &&
-    (process.platform === "win32" || (stats.mode & 0o077n) === 0n)
-  );
-}
-
-function privateFileMode(stats: BigIntStats): boolean {
-  return process.platform === "win32" || (stats.mode & 0o077n) === 0n;
-}
-
-function sameIdentity(left: BigIntStats, right: BigIntStats): boolean {
-  return left.dev === right.dev && left.ino === right.ino;
-}
-
-function sameSnapshot(left: BigIntStats, right: BigIntStats): boolean {
-  return (
-    sameIdentity(left, right) &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
-  );
-}
-
-function noFollowFlag(): number {
-  return (
-    (fsConstants as typeof fsConstants & { readonly O_NOFOLLOW?: number })
-      .O_NOFOLLOW ?? 0
-  );
-}
-
-function directoryOpenFlags(): number {
-  const directory =
-    (fsConstants as typeof fsConstants & { readonly O_DIRECTORY?: number })
-      .O_DIRECTORY ?? 0;
-  return fsConstants.O_RDONLY | directory | noFollowFlag();
-}
-
-async function descriptorOperationRoot(
-  handle: FileHandle,
-  canonicalRoot: string,
-): Promise<string | undefined> {
-  const candidates =
-    process.platform === "linux"
-      ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
-      : process.platform === "win32"
-        ? []
-        : [`/dev/fd/${handle.fd}`];
-  for (const candidate of candidates) {
-    try {
-      if ((await realpath(candidate)) === canonicalRoot) return candidate;
-    } catch {
-      // An unavailable descriptor alias is not permission for lexical fallback.
+async function withHandoffRoot<Result>(
+  path: string,
+  operation: (root: ConfinedDirectory) => Promise<Result>,
+  policy: ConfinedIoPolicy = HANDOFF_IO_POLICY,
+  hooks: ConfinedIoHooks = {},
+): Promise<Result> {
+  try {
+    return await withConfinedDirectory(path, policy, operation, hooks);
+  } catch (error) {
+    if (error instanceof ConfinedIoError) {
+      if (error.code === "DESCRIPTOR_UNSUPPORTED") {
+        throw storeError("WORKFLOW_HANDOFF_SAFE_IO_UNSUPPORTED", error.message, error);
+      }
+      if (error.code === "ROOT_UNSAFE" || error.code === "ROOT_CHANGED") {
+        throw storeError("WORKFLOW_HANDOFF_UNSAFE_ROOT", error.message, error);
+      }
     }
+    throw error;
   }
-  return undefined;
+}
+
+function isConfinedChildError(error: unknown): error is ConfinedIoError {
+  return error instanceof ConfinedIoError && error.code.startsWith("CHILD_");
 }
 
 async function inspectWorkflowHandoffSource(
@@ -1823,93 +1655,74 @@ async function commitWindowsArtifactAtomically(
   trustedRoot: string,
   bytes: Uint8Array,
 ): Promise<void> {
-  const rootBefore = lstatSync(trustedRoot, { bigint: true });
-  const canonicalRoot = realpathSync(trustedRoot);
-  if (!safePrivateDirectory(rootBefore)) {
-    throw storeError(
-      "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-      "workflow handoff Windows root is not a real directory",
-    );
-  }
-  assertWindowsPrivatePath(canonicalRoot, "directory", false);
-  if (
-    resolve(join(canonicalRoot, basename(targetPath))) !== resolve(targetPath) ||
-    resolve(targetPath) === canonicalRoot
-  ) {
-    throw storeError(
-      "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-      "workflow handoff Windows target is outside its trusted root",
-    );
-  }
-
-  const expected = Buffer.from(bytes);
-  const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
-  let temporaryExists = false;
-  try {
-    const handle = await open(
-      temporaryPath,
-      fsConstants.O_WRONLY |
-        fsConstants.O_CREAT |
-        fsConstants.O_EXCL |
-        noFollowFlag(),
-      ARTIFACT_FILE_MODE,
-    );
-    temporaryExists = true;
-    try {
-      const before = await handle.stat({ bigint: true });
-      if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1n) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff Windows temporary file is unsafe",
-        );
-      }
-      await handle.writeFile(expected);
-      await handle.sync();
-      const after = await handle.stat({ bigint: true });
-      if (!sameIdentity(before, after) || after.size !== BigInt(expected.byteLength)) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff Windows temporary file changed while writing",
-        );
-      }
-    } finally {
-      await handle.close();
-    }
-    assertWindowsPrivatePath(temporaryPath, "file", true);
-
-    try {
-      await link(temporaryPath, targetPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      const existing = await readWindowsArtifactCandidate(targetPath);
-      if (existing === undefined || !existing.equals(expected)) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_CONFLICT",
-          "workflow handoff Windows target already contains different bytes",
-          error,
-        );
-      }
-    }
-    await unlink(temporaryPath);
-    temporaryExists = false;
-    assertWindowsPrivatePath(targetPath, "file", false);
-
-    const rootAfter = lstatSync(trustedRoot, { bigint: true });
-    const canonicalAfter = realpathSync(trustedRoot);
-    assertWindowsPrivatePath(canonicalAfter, "directory", false);
+  return withHandoffRoot(trustedRoot, async (root) => {
+    const canonicalRoot = root.canonicalPath;
     if (
-      canonicalAfter !== canonicalRoot ||
-      !sameIdentity(rootBefore, rootAfter) ||
-      !safePrivateDirectory(rootAfter)
+      resolve(join(canonicalRoot, basename(targetPath))) !== resolve(targetPath) ||
+      resolve(targetPath) === canonicalRoot
     ) {
       throw storeError(
         "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-        "workflow handoff Windows root changed during publication",
+        "workflow handoff Windows target is outside its trusted root",
       );
     }
-  } finally {
-    if (temporaryExists) await unlink(temporaryPath).catch(() => {});
-  }
+
+    const expected = Buffer.from(bytes);
+    const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
+    let temporaryExists = false;
+    try {
+      const handle = await open(
+        temporaryPath,
+        fsConstants.O_WRONLY |
+          fsConstants.O_CREAT |
+          fsConstants.O_EXCL |
+          noFollowFlag(),
+        ARTIFACT_FILE_MODE,
+      );
+      temporaryExists = true;
+      try {
+        const before = await handle.stat({ bigint: true });
+        if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1n) {
+          throw storeError(
+            "WORKFLOW_HANDOFF_UNSAFE_ROOT",
+            "workflow handoff Windows temporary file is unsafe",
+          );
+        }
+        await handle.writeFile(expected);
+        await handle.sync();
+        const after = await handle.stat({ bigint: true });
+        if (!sameIdentity(before, after) || after.size !== BigInt(expected.byteLength)) {
+          throw storeError(
+            "WORKFLOW_HANDOFF_UNSAFE_ROOT",
+            "workflow handoff Windows temporary file changed while writing",
+          );
+        }
+      } finally {
+        await handle.close();
+      }
+      assertWindowsPrivatePath(temporaryPath, "file", true);
+
+      try {
+        await link(temporaryPath, targetPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        const existing = await readWindowsArtifactCandidate(targetPath);
+        if (existing === undefined || !existing.equals(expected)) {
+          throw storeError(
+            "WORKFLOW_HANDOFF_CONFLICT",
+            "workflow handoff Windows target already contains different bytes",
+            error,
+          );
+        }
+      }
+      await unlink(temporaryPath);
+      temporaryExists = false;
+      assertWindowsPrivatePath(targetPath, "file", false);
+
+    } finally {
+      if (temporaryExists) await unlink(temporaryPath).catch(() => {});
+    }
+  });
 }
 
 async function commitWindowsArtifactSourceAtomically(
@@ -1917,99 +1730,80 @@ async function commitWindowsArtifactSourceAtomically(
   trustedRoot: string,
   source: AtomicArtifactByteSource,
 ): Promise<void> {
-  const rootBefore = lstatSync(trustedRoot, { bigint: true });
-  const canonicalRoot = realpathSync(trustedRoot);
-  if (!safePrivateDirectory(rootBefore)) {
-    throw storeError(
-      "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-      "workflow handoff Windows root is not a real directory",
-    );
-  }
-  assertWindowsPrivatePath(canonicalRoot, "directory", false);
-  if (
-    resolve(join(canonicalRoot, basename(targetPath))) !== resolve(targetPath) ||
-    resolve(targetPath) === canonicalRoot
-  ) {
-    throw storeError(
-      "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-      "workflow handoff Windows target is outside its trusted root",
-    );
-  }
-
-  const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
-  let temporaryExists = false;
-  try {
-    const handle = await open(
-      temporaryPath,
-      fsConstants.O_WRONLY |
-        fsConstants.O_CREAT |
-        fsConstants.O_EXCL |
-        noFollowFlag(),
-      ARTIFACT_FILE_MODE,
-    );
-    temporaryExists = true;
-    try {
-      const before = await handle.stat({ bigint: true });
-      if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1n) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff Windows temporary file is unsafe",
-        );
-      }
-      await copyWorkflowHandoffSource(handle, source);
-      await handle.sync();
-      const after = await handle.stat({ bigint: true });
-      if (
-        !sameIdentity(before, after) ||
-        after.size !== BigInt(source.byteLength)
-      ) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-          "workflow handoff Windows temporary file changed while writing",
-        );
-      }
-    } finally {
-      await handle.close();
-    }
-    assertWindowsPrivatePath(temporaryPath, "file", true);
-
-    try {
-      await link(temporaryPath, targetPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      const existing = await digestWindowsArtifactCandidate(targetPath);
-      if (
-        existing === undefined ||
-        existing.byteLength !== source.byteLength ||
-        existing.sha256 !== source.sha256
-      ) {
-        throw storeError(
-          "WORKFLOW_HANDOFF_CONFLICT",
-          "workflow handoff Windows target already contains different bytes",
-          error,
-        );
-      }
-    }
-    await unlink(temporaryPath);
-    temporaryExists = false;
-    assertWindowsPrivatePath(targetPath, "file", false);
-
-    const rootAfter = lstatSync(trustedRoot, { bigint: true });
-    const canonicalAfter = realpathSync(trustedRoot);
-    assertWindowsPrivatePath(canonicalAfter, "directory", false);
+  return withHandoffRoot(trustedRoot, async (root) => {
+    const canonicalRoot = root.canonicalPath;
     if (
-      canonicalAfter !== canonicalRoot ||
-      !sameIdentity(rootBefore, rootAfter) ||
-      !safePrivateDirectory(rootAfter)
+      resolve(join(canonicalRoot, basename(targetPath))) !== resolve(targetPath) ||
+      resolve(targetPath) === canonicalRoot
     ) {
       throw storeError(
         "WORKFLOW_HANDOFF_UNSAFE_ROOT",
-        "workflow handoff Windows root changed during publication",
+        "workflow handoff Windows target is outside its trusted root",
       );
     }
-  } finally {
-    if (temporaryExists) await unlink(temporaryPath).catch(() => {});
-  }
+
+    const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
+    let temporaryExists = false;
+    try {
+      const handle = await open(
+        temporaryPath,
+        fsConstants.O_WRONLY |
+          fsConstants.O_CREAT |
+          fsConstants.O_EXCL |
+          noFollowFlag(),
+        ARTIFACT_FILE_MODE,
+      );
+      temporaryExists = true;
+      try {
+        const before = await handle.stat({ bigint: true });
+        if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1n) {
+          throw storeError(
+            "WORKFLOW_HANDOFF_UNSAFE_ROOT",
+            "workflow handoff Windows temporary file is unsafe",
+          );
+        }
+        await copyWorkflowHandoffSource(handle, source);
+        await handle.sync();
+        const after = await handle.stat({ bigint: true });
+        if (
+          !sameIdentity(before, after) ||
+          after.size !== BigInt(source.byteLength)
+        ) {
+          throw storeError(
+            "WORKFLOW_HANDOFF_UNSAFE_ROOT",
+            "workflow handoff Windows temporary file changed while writing",
+          );
+        }
+      } finally {
+        await handle.close();
+      }
+      assertWindowsPrivatePath(temporaryPath, "file", true);
+
+      try {
+        await link(temporaryPath, targetPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        const existing = await digestWindowsArtifactCandidate(targetPath);
+        if (
+          existing === undefined ||
+          existing.byteLength !== source.byteLength ||
+          existing.sha256 !== source.sha256
+        ) {
+          throw storeError(
+            "WORKFLOW_HANDOFF_CONFLICT",
+            "workflow handoff Windows target already contains different bytes",
+            error,
+          );
+        }
+      }
+      await unlink(temporaryPath);
+      temporaryExists = false;
+      assertWindowsPrivatePath(targetPath, "file", false);
+
+    } finally {
+      if (temporaryExists) await unlink(temporaryPath).catch(() => {});
+    }
+  });
 }
 
 async function copyWorkflowHandoffSource(
@@ -2054,79 +1848,38 @@ async function copyWorkflowHandoffSource(
 
 async function digestWindowsArtifactCandidate(
   path: string,
-): Promise<
-  { readonly byteLength: number; readonly sha256: string } | undefined
-> {
-  let pathBefore: BigIntStats;
-  try {
-    pathBefore = await lstat(path, { bigint: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw error;
-  }
-  if (!pathBefore.isFile() || pathBefore.isSymbolicLink()) return undefined;
-  assertWindowsPrivatePath(path, "file", false);
-  const handle = await open(path, fsConstants.O_RDONLY | noFollowFlag());
-  try {
-    const opened = await handle.stat({ bigint: true });
-    if (!sameSnapshot(pathBefore, opened)) return undefined;
+): Promise<{ readonly byteLength: number; readonly sha256: string } | undefined> {
+  return withWindowsArtifactCandidate(path, async (file) => {
     const hash = createHash("sha256");
-    const buffer = Buffer.allocUnsafe(SOURCE_COPY_BYTES);
-    let byteLength = 0;
-    while (true) {
-      const read = await handle.read(
-        buffer,
-        0,
-        buffer.byteLength,
-        byteLength,
-      );
-      if (read.bytesRead === 0) break;
-      hash.update(buffer.subarray(0, read.bytesRead));
-      byteLength += read.bytesRead;
-    }
-    const [after, pathAfter] = await Promise.all([
-      handle.stat({ bigint: true }),
-      lstat(path, { bigint: true }),
-    ]);
-    if (
-      !sameSnapshot(opened, after) ||
-      !sameSnapshot(after, pathAfter) ||
-      after.size !== BigInt(byteLength)
-    ) {
-      return undefined;
-    }
-    return { byteLength, sha256: hash.digest("hex") };
-  } finally {
-    await handle.close();
-  }
+    await scanConfinedFile(file, (chunk) => {
+      hash.update(chunk);
+    });
+    return { byteLength: Number(file.snapshot.size), sha256: hash.digest("hex") };
+  });
 }
 
-async function readWindowsArtifactCandidate(
+async function readWindowsArtifactCandidate(path: string): Promise<Buffer | undefined> {
+  return withWindowsArtifactCandidate(path, readConfinedFile);
+}
+
+async function withWindowsArtifactCandidate<Result>(
   path: string,
-): Promise<Buffer | undefined> {
-  let pathBefore: BigIntStats;
+  operation: (file: ConfinedFile) => Promise<Result>,
+): Promise<Result | undefined> {
   try {
-    pathBefore = await lstat(path, { bigint: true });
+    return await withHandoffRoot(
+      dirname(path),
+      (root) => withRegularChild(
+        root,
+        basename(path),
+        { maximumBytes: MAX_WORKFLOW_ARTIFACT_BYTES },
+        operation,
+      ),
+      HANDOFF_INSTALLATION_IO_POLICY,
+    );
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    if (isConfinedChildError(error)) return undefined;
     throw error;
-  }
-  if (!pathBefore.isFile() || pathBefore.isSymbolicLink()) return undefined;
-  assertWindowsPrivatePath(path, "file", false);
-  const handle = await open(path, fsConstants.O_RDONLY | noFollowFlag());
-  try {
-    const opened = await handle.stat({ bigint: true });
-    if (!sameSnapshot(pathBefore, opened)) return undefined;
-    const bytes = await handle.readFile();
-    const [after, pathAfter] = await Promise.all([
-      handle.stat({ bigint: true }),
-      lstat(path, { bigint: true }),
-    ]);
-    return sameSnapshot(opened, after) && sameSnapshot(opened, pathAfter)
-      ? bytes
-      : undefined;
-  } finally {
-    await handle.close();
   }
 }
 

--- a/runtime/src/agents/workflow-manifest.ts
+++ b/runtime/src/agents/workflow-manifest.ts
@@ -1,19 +1,20 @@
 /** Descriptor-confined named workflow manifest loader. */
 
 import {
-  constants as fsConstants,
-  type BigIntStats,
-} from "node:fs";
-import { lstat, open, realpath, type FileHandle } from "node:fs/promises";
-import {
   basename,
-  dirname,
   isAbsolute,
   join,
   normalize,
   resolve,
   win32,
 } from "node:path";
+import {
+  ConfinedIoError,
+  readConfinedFile,
+  withConfinedDirectory,
+  withRegularChild,
+  type ConfinedIoPolicy,
+} from "../fs/descriptor-confined-io.js";
 
 import {
   MAX_WORKFLOW_MANIFEST_BYTES,
@@ -218,54 +219,46 @@ export async function loadNamedWorkflowManifest(
   throw new WorkflowManifestNotFoundError(options.name, searchedPaths);
 }
 
+const MANIFEST_IO_POLICY = Object.freeze({
+  hardLinks: "allow",
+  privateDirectory: false,
+  privateFile: false,
+  unavailableAlias: "identity-checked-path",
+} satisfies ConfinedIoPolicy);
+
+const MANIFEST_IO_ERROR_CODES = {
+  ROOT_UNSAFE: "WORKFLOW_ROOT_UNSAFE",
+  ROOT_CHANGED: "WORKFLOW_ROOT_RACE",
+  DESCRIPTOR_UNSUPPORTED: "WORKFLOW_ROOT_OPEN",
+  CHILD_UNSAFE: "WORKFLOW_MANIFEST_UNSAFE",
+  CHILD_CHANGED: "WORKFLOW_MANIFEST_RACE",
+  CHILD_OUTSIDE_ROOT: "WORKFLOW_MANIFEST_ESCAPE",
+  CHILD_TOO_LARGE: "WORKFLOW_MANIFEST_BYTES",
+} as const satisfies Record<ConfinedIoError["code"], string>;
+
 async function readManifestFromRoot(
   root: string,
   manifestBasename: string,
   hooks: WorkflowManifestLoaderHooks | undefined,
 ): Promise<Buffer | undefined> {
-  let lexicalRoot: BigIntStats;
   try {
-    lexicalRoot = await lstat(root, { bigint: true });
-  } catch (error) {
-    if (isMissingPathError(error)) return undefined;
-    throw pathError(
-      "WORKFLOW_ROOT_OPEN",
-      `could not inspect workflow root ${root}`,
-      error,
-    );
-  }
-  if (!lexicalRoot.isDirectory() || lexicalRoot.isSymbolicLink()) {
-    throw pathError(
-      "WORKFLOW_ROOT_UNSAFE",
-      `workflow root must be a real non-symlink directory: ${root}`,
-    );
-  }
-  const canonicalRoot = await realpath(root);
-  let rootHandle: FileHandle | undefined;
-  try {
-    rootHandle = await open(root, directoryOpenFlags());
-    const openedRoot = await rootHandle.stat({ bigint: true });
-    if (!openedRoot.isDirectory() || !sameIdentity(lexicalRoot, openedRoot)) {
-      throw pathError(
-        "WORKFLOW_ROOT_RACE",
-        `workflow root changed while opening: ${root}`,
-      );
-    }
-    const operationRoot =
-      (await descriptorDirectoryPath(rootHandle, canonicalRoot)) ?? root;
-    await hooks?.afterRootOpen?.(root);
-    await assertRootCurrent(root, canonicalRoot, openedRoot, rootHandle);
-    return await readManifestCandidate(
+    return await withConfinedDirectory(
       root,
-      canonicalRoot,
-      operationRoot,
-      openedRoot,
-      rootHandle,
-      manifestBasename,
+      MANIFEST_IO_POLICY,
+      (directory) => withRegularChild(
+        directory,
+        manifestBasename,
+        { maximumBytes: MAX_WORKFLOW_MANIFEST_BYTES },
+        readConfinedFile,
+        hooks,
+      ),
       hooks,
     );
   } catch (error) {
-    if (error instanceof WorkflowManifestPathError) throw error;
+    if (isMissingPathError(error)) return undefined;
+    if (error instanceof ConfinedIoError) {
+      throw pathError(MANIFEST_IO_ERROR_CODES[error.code], error.message, error);
+    }
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "ENAMETOOLONG" || code === "EINVAL") {
       throw pathError(
@@ -279,185 +272,7 @@ async function readManifestFromRoot(
       `could not safely read workflow root ${root}: ${errorMessage(error)}`,
       error,
     );
-  } finally {
-    await rootHandle?.close().catch(() => {});
   }
-}
-
-async function readManifestCandidate(
-  lexicalRoot: string,
-  canonicalRoot: string,
-  operationRoot: string,
-  openedRoot: BigIntStats,
-  rootHandle: FileHandle,
-  manifestBasename: string,
-  hooks: WorkflowManifestLoaderHooks | undefined,
-): Promise<Buffer | undefined> {
-  const operationPath = join(operationRoot, manifestBasename);
-  const lexicalPath = join(lexicalRoot, manifestBasename);
-  let pathBefore: BigIntStats;
-  try {
-    pathBefore = await lstat(operationPath, { bigint: true });
-  } catch (error) {
-    if (isMissingPathError(error)) return undefined;
-    throw error;
-  }
-  if (!pathBefore.isFile() || pathBefore.isSymbolicLink()) {
-    throw pathError(
-      "WORKFLOW_MANIFEST_UNSAFE",
-      `workflow manifest must be a regular non-symlink file: ${lexicalPath}`,
-    );
-  }
-  if (pathBefore.size > BigInt(MAX_WORKFLOW_MANIFEST_BYTES)) {
-    throw pathError(
-      "WORKFLOW_MANIFEST_BYTES",
-      `workflow manifest exceeds ${MAX_WORKFLOW_MANIFEST_BYTES} bytes: ${lexicalPath}`,
-    );
-  }
-
-  const candidateHandle = await open(operationPath, fileOpenFlags());
-  try {
-    const opened = await candidateHandle.stat({ bigint: true });
-    if (!opened.isFile() || !sameSnapshot(pathBefore, opened)) {
-      throw pathError(
-        "WORKFLOW_MANIFEST_RACE",
-        `workflow manifest changed while opening: ${lexicalPath}`,
-      );
-    }
-    const canonicalCandidate = await realpath(operationPath);
-    if (
-      dirname(canonicalCandidate) !== canonicalRoot ||
-      basename(canonicalCandidate) !== manifestBasename
-    ) {
-      throw pathError(
-        "WORKFLOW_MANIFEST_ESCAPE",
-        `workflow manifest resolves outside its trusted root: ${lexicalPath}`,
-      );
-    }
-    await hooks?.afterCandidateOpen?.(lexicalPath);
-    const buffer = Buffer.allocUnsafe(Number(opened.size));
-    let offset = 0;
-    while (offset < buffer.byteLength) {
-      const { bytesRead } = await candidateHandle.read(
-        buffer,
-        offset,
-        buffer.byteLength - offset,
-        offset,
-      );
-      if (bytesRead === 0) break;
-      offset += bytesRead;
-    }
-    const [after, pathAfter] = await Promise.all([
-      candidateHandle.stat({ bigint: true }),
-      lstat(operationPath, { bigint: true }),
-    ]);
-    if (
-      offset !== buffer.byteLength ||
-      !sameSnapshot(opened, after) ||
-      !sameSnapshot(opened, pathAfter) ||
-      pathAfter.isSymbolicLink()
-    ) {
-      throw pathError(
-        "WORKFLOW_MANIFEST_RACE",
-        `workflow manifest changed while reading: ${lexicalPath}`,
-      );
-    }
-    await assertRootCurrent(
-      lexicalRoot,
-      canonicalRoot,
-      openedRoot,
-      rootHandle,
-    );
-    return buffer;
-  } finally {
-    await candidateHandle.close();
-  }
-}
-
-async function assertRootCurrent(
-  lexicalRoot: string,
-  canonicalRoot: string,
-  openedRoot: BigIntStats,
-  rootHandle: FileHandle,
-): Promise<void> {
-  try {
-    const [lexical, canonical, opened] = await Promise.all([
-      lstat(lexicalRoot, { bigint: true }),
-      realpath(lexicalRoot),
-      rootHandle.stat({ bigint: true }),
-    ]);
-    if (
-      !lexical.isDirectory() ||
-      lexical.isSymbolicLink() ||
-      !opened.isDirectory() ||
-      !sameIdentity(lexical, openedRoot) ||
-      !sameIdentity(opened, openedRoot) ||
-      canonical !== canonicalRoot
-    ) {
-      throw pathError(
-        "WORKFLOW_ROOT_RACE",
-        `workflow root changed during manifest load: ${lexicalRoot}`,
-      );
-    }
-  } catch (error) {
-    if (error instanceof WorkflowManifestPathError) throw error;
-    throw pathError(
-      "WORKFLOW_ROOT_RACE",
-      `workflow root changed during manifest load: ${lexicalRoot}`,
-      error,
-    );
-  }
-}
-
-function directoryOpenFlags(): number {
-  const directory =
-    (fsConstants as typeof fsConstants & { readonly O_DIRECTORY?: number })
-      .O_DIRECTORY ?? 0;
-  return fsConstants.O_RDONLY | directory | noFollowFlag();
-}
-
-function fileOpenFlags(): number {
-  return fsConstants.O_RDONLY | noFollowFlag();
-}
-
-function noFollowFlag(): number {
-  return (
-    (fsConstants as typeof fsConstants & { readonly O_NOFOLLOW?: number })
-      .O_NOFOLLOW ?? 0
-  );
-}
-
-async function descriptorDirectoryPath(
-  handle: FileHandle,
-  canonicalRoot: string,
-): Promise<string | undefined> {
-  const candidates =
-    process.platform === "linux"
-      ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
-      : process.platform === "win32"
-        ? []
-        : [`/dev/fd/${handle.fd}`];
-  for (const candidate of candidates) {
-    try {
-      if ((await realpath(candidate)) === canonicalRoot) return candidate;
-    } catch {
-      // Platforms without descriptor aliases use the identity-checked path.
-    }
-  }
-  return undefined;
-}
-
-function sameIdentity(left: BigIntStats, right: BigIntStats): boolean {
-  return left.dev === right.dev && left.ino === right.ino;
-}
-
-function sameSnapshot(left: BigIntStats, right: BigIntStats): boolean {
-  return (
-    sameIdentity(left, right) &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
-  );
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/runtime/src/fs/descriptor-confined-io.ts
+++ b/runtime/src/fs/descriptor-confined-io.ts
@@ -1,0 +1,397 @@
+import { constants as fsConstants, type BigIntStats } from "node:fs";
+import { lstat, open, realpath, type FileHandle } from "node:fs/promises";
+import { basename, dirname, join, resolve, win32 } from "node:path";
+import {
+  sameStats,
+  verifiedDirectoryOpenFlags,
+  verifiedFileOpenFlags,
+} from "./verified-read.js";
+
+const READ_CHUNK_BYTES = 64 * 1_024;
+
+export interface ConfinedIoPolicy {
+  readonly hardLinks: "allow" | "reject";
+  readonly privateDirectory: boolean;
+  readonly privateFile: boolean;
+  readonly unavailableAlias:
+    | "reject"
+    | "identity-checked-path"
+    | "windows-private-path";
+  readonly verifyWindowsPrivatePath?: (
+    path: string,
+    role: "directory" | "file",
+  ) => void;
+}
+
+export interface ConfinedDirectory {
+  readonly path: string;
+  readonly canonicalPath: string;
+  readonly operationPath: string;
+  readonly handle: FileHandle | undefined;
+  readonly policy: ConfinedIoPolicy;
+  verify(): Promise<void>;
+}
+
+export interface ConfinedFile {
+  readonly path: string;
+  readonly handle: FileHandle;
+  readonly snapshot: BigIntStats;
+  readonly root: ConfinedDirectory;
+  verify(): Promise<void>;
+}
+
+export interface ConfinedIoHooks {
+  readonly afterRootOpen?: (root: string) => void | Promise<void>;
+  readonly afterCandidateOpen?: (candidate: string) => void | Promise<void>;
+}
+
+export class ConfinedIoError extends Error {
+  constructor(
+    readonly code:
+      | "ROOT_UNSAFE"
+      | "ROOT_CHANGED"
+      | "DESCRIPTOR_UNSUPPORTED"
+      | "CHILD_UNSAFE"
+      | "CHILD_CHANGED"
+      | "CHILD_OUTSIDE_ROOT"
+      | "CHILD_TOO_LARGE",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "ConfinedIoError";
+  }
+}
+
+export async function withConfinedDirectory<Result>(
+  path: string,
+  policy: ConfinedIoPolicy,
+  operation: (root: ConfinedDirectory) => Promise<Result>,
+  hooks: ConfinedIoHooks = {},
+): Promise<Result> {
+  const lexicalPath = resolve(path);
+  const before = await lstat(lexicalPath, { bigint: true });
+  assertDirectory(before, policy);
+  const canonicalPath = await realpath(lexicalPath);
+  verifyPrivatePath(canonicalPath, "directory", policy);
+  const handle =
+    process.platform === "win32"
+      ? undefined
+      : await open(lexicalPath, verifiedDirectoryOpenFlags());
+  try {
+    if (handle !== undefined) {
+      const opened = await handle.stat({ bigint: true });
+      assertDirectory(opened, policy);
+      if (!sameIdentity(before, opened)) {
+        throw new ConfinedIoError(
+          "ROOT_CHANGED",
+          `root changed while opening: ${lexicalPath}`,
+        );
+      }
+    }
+    const descriptorPath =
+      handle === undefined
+        ? undefined
+        : await descriptorDirectoryPath(handle, canonicalPath, before);
+    if (descriptorPath === undefined && !allowsPathFallback(policy)) {
+      throw new ConfinedIoError(
+        "DESCRIPTOR_UNSUPPORTED",
+        `descriptor-confined I/O is unsupported on ${process.platform}`,
+      );
+    }
+    const root: ConfinedDirectory = {
+      path: lexicalPath,
+      canonicalPath,
+      operationPath: descriptorPath ?? canonicalPath,
+      handle,
+      policy,
+      async verify() {
+        try {
+          const [current, canonical, opened] = await Promise.all([
+            lstat(lexicalPath, { bigint: true }),
+            realpath(lexicalPath),
+            handle?.stat({ bigint: true }),
+          ]);
+          assertDirectory(current, policy);
+          if (opened !== undefined) assertDirectory(opened, policy);
+          verifyPrivatePath(canonical, "directory", policy);
+          if (
+            canonical !== canonicalPath ||
+            !sameIdentity(before, current) ||
+            (opened !== undefined && !sameIdentity(before, opened))
+          ) {
+            throw new Error("root identity or canonical path changed");
+          }
+        } catch (cause) {
+          throw new ConfinedIoError(
+            "ROOT_CHANGED",
+            `root changed during I/O: ${lexicalPath}`,
+            { cause },
+          );
+        }
+      },
+    };
+    await hooks.afterRootOpen?.(lexicalPath);
+    await root.verify();
+    const result = await operation(root);
+    await root.verify();
+    return result;
+  } finally {
+    await handle?.close();
+  }
+}
+
+export async function withRegularChild<Result>(
+  root: ConfinedDirectory,
+  name: string,
+  limits: { readonly maximumBytes: number; readonly expectedBytes?: number },
+  operation: (file: ConfinedFile) => Promise<Result>,
+  hooks: ConfinedIoHooks = {},
+): Promise<Result | undefined> {
+  if (
+    name.length === 0 ||
+    name === "." ||
+    name === ".." ||
+    basename(name) !== name ||
+    win32.basename(name) !== name ||
+    /[\\/\u0000]/u.test(name)
+  ) {
+    throw new TypeError("confined child must be one basename");
+  }
+  if (!Number.isSafeInteger(limits.maximumBytes) || limits.maximumBytes < 0) {
+    throw new TypeError(
+      "confined read byte limit must be a non-negative safe integer",
+    );
+  }
+  if (
+    limits.expectedBytes !== undefined &&
+    (!Number.isSafeInteger(limits.expectedBytes) ||
+      limits.expectedBytes < 0 ||
+      limits.expectedBytes > limits.maximumBytes)
+  ) {
+    throw new TypeError("confined read expected length must fit its byte limit");
+  }
+  await root.verify();
+  const path = join(root.operationPath, name);
+  let before: BigIntStats;
+  try {
+    before = await lstat(path, { bigint: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  assertRegularFile(before, root.policy);
+  assertByteLength(before, limits);
+  verifyPrivatePath(path, "file", root.policy);
+  let handle: FileHandle;
+  try {
+    handle = await open(path, verifiedFileOpenFlags());
+  } catch (cause) {
+    throw new ConfinedIoError(
+      "CHILD_CHANGED",
+      `child changed while opening: ${path}`,
+      { cause },
+    );
+  }
+  try {
+    const snapshot = await handle.stat({ bigint: true });
+    assertRegularFile(snapshot, root.policy);
+    assertByteLength(snapshot, limits);
+    if (!sameSnapshot(before, snapshot)) {
+      throw new ConfinedIoError(
+        "CHILD_CHANGED",
+        `child changed while opening: ${path}`,
+      );
+    }
+    const file: ConfinedFile = {
+      path,
+      handle,
+      snapshot,
+      root,
+      async verify() {
+        try {
+          const [opened, current, canonical] = await Promise.all([
+            handle.stat({ bigint: true }),
+            lstat(path, { bigint: true }),
+            realpath(path),
+          ]);
+          assertRegularFile(opened, root.policy);
+          assertRegularFile(current, root.policy);
+          verifyPrivatePath(path, "file", root.policy);
+          if (!sameSnapshot(snapshot, opened) || !sameSnapshot(snapshot, current)) {
+            throw new Error("child snapshot changed");
+          }
+          if (
+            dirname(canonical) !== root.canonicalPath ||
+            basename(canonical) !== name
+          ) {
+            throw new ConfinedIoError(
+              "CHILD_OUTSIDE_ROOT",
+              `child resolves outside its root: ${path}`,
+            );
+          }
+        } catch (cause) {
+          if (
+            cause instanceof ConfinedIoError &&
+            cause.code === "CHILD_OUTSIDE_ROOT"
+          ) {
+            throw cause;
+          }
+          throw new ConfinedIoError(
+            "CHILD_CHANGED",
+            `child changed during I/O: ${path}`,
+            { cause },
+          );
+        }
+        await root.verify();
+      },
+    };
+    await file.verify();
+    await hooks.afterCandidateOpen?.(join(root.path, name));
+    return await operation(file);
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function readConfinedFile(file: ConfinedFile): Promise<Buffer> {
+  const bytes = Buffer.allocUnsafe(Number(file.snapshot.size));
+  let offset = 0;
+  await scanConfinedFile(file, (chunk) => {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  });
+  return bytes;
+}
+
+export async function scanConfinedFile(
+  file: ConfinedFile,
+  acceptChunk: (chunk: Uint8Array) => void,
+): Promise<void> {
+  await file.verify();
+  const expectedBytes = Number(file.snapshot.size);
+  const buffer = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, expectedBytes + 1));
+  let offset = 0;
+  while (true) {
+    const { bytesRead } = await file.handle.read(
+      buffer,
+      0,
+      Math.min(buffer.byteLength, expectedBytes - offset + 1),
+      offset,
+    );
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+    if (offset > expectedBytes) {
+      throw new ConfinedIoError(
+        "CHILD_CHANGED",
+        `child grew while reading: ${file.path}`,
+      );
+    }
+    acceptChunk(buffer.subarray(0, bytesRead));
+  }
+  if (offset !== expectedBytes) {
+    throw new ConfinedIoError(
+      "CHILD_CHANGED",
+      `child shrank while reading: ${file.path}`,
+    );
+  }
+  await file.verify();
+}
+
+export function sameIdentity(left: BigIntStats, right: BigIntStats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+export const sameSnapshot = sameStats;
+
+export function safePrivateDirectory(stats: BigIntStats): boolean {
+  return stats.isDirectory() && !stats.isSymbolicLink() && privateFileMode(stats);
+}
+
+function privateFileMode(stats: BigIntStats): boolean {
+  return process.platform === "win32" || (stats.mode & 0o077n) === 0n;
+}
+
+export function noFollowFlag(): number {
+  return process.platform === "win32" ? 0 : (fsConstants.O_NOFOLLOW ?? 0);
+}
+
+function assertDirectory(stats: BigIntStats, policy: ConfinedIoPolicy): void {
+  if (
+    !stats.isDirectory() || stats.isSymbolicLink() ||
+    (policy.privateDirectory && !privateFileMode(stats))
+  ) {
+    throw new ConfinedIoError("ROOT_UNSAFE", "root must be a real directory with the required privacy");
+  }
+}
+
+function assertRegularFile(stats: BigIntStats, policy: ConfinedIoPolicy): void {
+  if (
+    !stats.isFile() || stats.isSymbolicLink() ||
+    (policy.hardLinks === "reject" && stats.nlink !== 1n) ||
+    (policy.privateFile && !privateFileMode(stats))
+  ) {
+    throw new ConfinedIoError("CHILD_UNSAFE", "child must be a regular file with the required privacy and link count");
+  }
+}
+
+function assertByteLength(
+  stats: BigIntStats,
+  limits: { readonly maximumBytes: number; readonly expectedBytes?: number },
+): void {
+  if (stats.size < 0n || stats.size > BigInt(limits.maximumBytes)) {
+    throw new ConfinedIoError("CHILD_TOO_LARGE", `child exceeds ${limits.maximumBytes} bytes`);
+  }
+  if (limits.expectedBytes !== undefined && stats.size !== BigInt(limits.expectedBytes)) {
+    throw new ConfinedIoError("CHILD_CHANGED", "child length does not match its expected bytes");
+  }
+}
+
+function verifyPrivatePath(
+  path: string,
+  role: "directory" | "file",
+  policy: ConfinedIoPolicy,
+): void {
+  if (process.platform !== "win32") return;
+  const required = role === "directory" ? policy.privateDirectory : policy.privateFile;
+  if (!required) return;
+  if (policy.verifyWindowsPrivatePath === undefined) {
+    throw new ConfinedIoError("DESCRIPTOR_UNSUPPORTED", "private Windows I/O requires an ACL verifier");
+  }
+  policy.verifyWindowsPrivatePath(path, role);
+}
+
+function allowsPathFallback(policy: ConfinedIoPolicy): boolean {
+  return policy.unavailableAlias === "identity-checked-path" ||
+    (policy.unavailableAlias === "windows-private-path" && process.platform === "win32" &&
+      policy.privateDirectory && policy.verifyWindowsPrivatePath !== undefined);
+}
+
+async function descriptorDirectoryPath(
+  handle: FileHandle,
+  canonicalRoot: string,
+  snapshot: BigIntStats,
+): Promise<string | undefined> {
+  const candidates =
+    process.platform === "linux"
+      ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
+      : [`/dev/fd/${handle.fd}`];
+  for (const candidate of candidates) {
+    try {
+      const [canonical, traversed] = await Promise.all([
+        realpath(candidate),
+        lstat(`${candidate}/.`, { bigint: true }),
+      ]);
+      if (
+        canonical === canonicalRoot &&
+        traversed.isDirectory() &&
+        sameIdentity(snapshot, traversed)
+      ) {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}

--- a/runtime/src/fs/descriptor-confined-io.ts
+++ b/runtime/src/fs/descriptor-confined-io.ts
@@ -154,7 +154,8 @@ export async function withRegularChild<Result>(
     name === ".." ||
     basename(name) !== name ||
     win32.basename(name) !== name ||
-    /[\\/\u0000]/u.test(name)
+    /[\\/]/u.test(name) ||
+    name.includes("\0")
   ) {
     throw new TypeError("confined child must be one basename");
   }
@@ -182,11 +183,13 @@ export async function withRegularChild<Result>(
   }
   assertRegularFile(before, root.policy);
   assertByteLength(before, limits);
-  verifyPrivatePath(path, "file", root.policy);
+  assertPrivateChildPath(path, root.policy);
   let handle: FileHandle;
   try {
     handle = await open(path, verifiedFileOpenFlags());
   } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    if (!isChildReplacementError(cause)) throw cause;
     throw new ConfinedIoError(
       "CHILD_CHANGED",
       `child changed while opening: ${path}`,
@@ -217,9 +220,9 @@ export async function withRegularChild<Result>(
           ]);
           assertRegularFile(opened, root.policy);
           assertRegularFile(current, root.policy);
-          verifyPrivatePath(path, "file", root.policy);
+          assertPrivateChildPath(path, root.policy);
           if (!sameSnapshot(snapshot, opened) || !sameSnapshot(snapshot, current)) {
-            throw new Error("child snapshot changed");
+            throw new ConfinedIoError("CHILD_CHANGED", "child snapshot changed");
           }
           if (
             dirname(canonical) !== root.canonicalPath ||
@@ -231,12 +234,7 @@ export async function withRegularChild<Result>(
             );
           }
         } catch (cause) {
-          if (
-            cause instanceof ConfinedIoError &&
-            cause.code === "CHILD_OUTSIDE_ROOT"
-          ) {
-            throw cause;
-          }
+          if (cause instanceof ConfinedIoError || !isChildReplacementError(cause)) throw cause;
           throw new ConfinedIoError(
             "CHILD_CHANGED",
             `child changed during I/O: ${path}`,
@@ -262,6 +260,24 @@ export async function readConfinedFile(file: ConfinedFile): Promise<Buffer> {
     offset += chunk.byteLength;
   });
   return bytes;
+}
+
+function isChildReplacementError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
+}
+
+function assertPrivateChildPath(path: string, policy: ConfinedIoPolicy): void {
+  try {
+    verifyPrivatePath(path, "file", policy);
+  } catch (cause) {
+    if (cause instanceof ConfinedIoError) throw cause;
+    throw new ConfinedIoError(
+      "CHILD_UNSAFE",
+      `child does not have the required private ACL: ${path}`,
+      { cause },
+    );
+  }
 }
 
 export async function scanConfinedFile(

--- a/runtime/tests/agents/workflow-filesystem.win32.test.ts
+++ b/runtime/tests/agents/workflow-filesystem.win32.test.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { link, mkdir, mkdtemp, readFile, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { loadNamedWorkflowManifest } from "../../src/agents/workflow-manifest.js";
+import { WorkflowHandoffArtifactStore } from "../../src/agents/workflow-handoff-store.js";
+import { assertWindowsPrivatePathSecurity } from "../../src/agents/workflow-private-path.js";
+import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
+
+if (process.platform !== "win32") {
+  throw new Error("workflow filesystem native tests require Windows");
+}
+
+const manifest = '{"format_version":2,"kind":"agent_dag","steps":[{"id":"step","message":"work"}]}';
+const owner = { run_id: "run", workflow_id: "workflow", producer_step_id: "step" };
+let temporaryDirectory: string;
+let driver: StateSqliteDriver | undefined;
+
+beforeEach(async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "agenc-workflow-win32-"));
+});
+
+afterEach(async () => {
+  driver?.close();
+  driver = undefined;
+  await rm(temporaryDirectory, { recursive: true, force: true });
+});
+
+it("loads regular and hard-linked shared manifests on Windows", async () => {
+  const root = join(temporaryDirectory, "manifests");
+  await mkdir(root);
+  await writeFile(join(root, "example.json"), manifest);
+  await link(join(root, "example.json"), join(root, "linked.json"));
+  for (const name of ["example", "linked"]) {
+    const loaded = await loadNamedWorkflowManifest({ name, roots: [root] });
+    expect(loaded.document.manifest.steps[0]?.id).toBe("step");
+  }
+});
+
+it("rejects a Windows manifest root replaced after opening", async () => {
+  const root = join(temporaryDirectory, "manifests");
+  await mkdir(root);
+  await writeFile(join(root, "example.json"), manifest);
+  await expect(loadNamedWorkflowManifest({
+    name: "example", roots: [root],
+    hooks: {
+      async afterRootOpen() {
+        await rename(root, `${root}.old`);
+        await mkdir(root);
+        await writeFile(join(root, "example.json"), manifest);
+      },
+    },
+  })).rejects.toMatchObject({ code: "WORKFLOW_ROOT_RACE" });
+});
+
+it("rejects a Windows manifest child replaced after opening", async () => {
+  const root = join(temporaryDirectory, "manifests");
+  const candidate = join(root, "example.json");
+  await mkdir(root);
+  await writeFile(candidate, manifest);
+  await expect(loadNamedWorkflowManifest({
+    name: "example", roots: [root],
+    hooks: {
+      async afterCandidateOpen() {
+        await rename(candidate, `${candidate}.old`);
+        await writeFile(candidate, manifest);
+      },
+    },
+  })).rejects.toMatchObject({ code: "WORKFLOW_MANIFEST_RACE" });
+});
+
+it("rejects Windows junction roots in both workflow consumers", async () => {
+  const target = join(temporaryDirectory, "target");
+  const alias = join(temporaryDirectory, "alias");
+  await mkdir(target);
+  await writeFile(join(target, "example.json"), manifest);
+  await symlink(target, alias, "junction");
+  await expect(loadNamedWorkflowManifest({ name: "example", roots: [alias] }))
+    .rejects.toMatchObject({ code: "WORKFLOW_ROOT_UNSAFE" });
+  driver = openStateDatabases({ cwd: temporaryDirectory, agencHome: join(temporaryDirectory, "home") });
+  expect(() => new WorkflowHandoffArtifactStore({ driver: driver!, trustedRoot: alias }))
+    .toThrow(expect.objectContaining({ code: "WORKFLOW_HANDOFF_UNSAFE_ROOT" }));
+});
+
+it("reads and cleans private Windows handoffs while rejecting hard links", async () => {
+  driver = openStateDatabases({ cwd: temporaryDirectory, agencHome: join(temporaryDirectory, "home") });
+  const root = join(temporaryDirectory, "handoffs");
+  let now = 1_000_000;
+  const store = new WorkflowHandoffArtifactStore({
+    driver, trustedRoot: root, retentionMs: 100, now: () => now,
+    hooks: {
+      async afterIntentReserved(artifactId) {
+        const candidate = join(root, `${artifactId}.handoff`);
+        await writeFile(candidate, "safe");
+        assertWindowsPrivatePathSecurity(candidate, "file", true);
+      },
+    },
+  });
+  const artifact = await store.publish({ owner, idempotencyKey: "item", bytes: Buffer.from("safe"), tokenCount: 1 });
+  expect(Buffer.from((await store.read(artifact.artifact_id)).bytes))
+    .toEqual(Buffer.from("safe"));
+  const candidate = join(root, `${artifact.artifact_id}.handoff`);
+  const alias = join(temporaryDirectory, "hard-link");
+  await link(candidate, alias);
+  await expect(store.read(artifact.artifact_id)).rejects.toMatchObject({ code: "WORKFLOW_HANDOFF_CORRUPT" });
+  expect(await readFile(alias, "utf8")).toBe("safe");
+  await unlink(alias);
+  now += 200;
+  expect(await store.cleanupExpired()).toMatchObject({ removed: 1, conflicts: 0 });
+  await expect(readFile(candidate)).rejects.toMatchObject({ code: "ENOENT" });
+}, 90_000);
+
+it("verifies a streamed Windows publication against an existing bounded candidate", async () => {
+  driver = openStateDatabases({ cwd: temporaryDirectory, agencHome: join(temporaryDirectory, "home") });
+  const root = join(temporaryDirectory, "handoffs");
+  const bytes = Buffer.alloc(131_072, 97);
+  const store = new WorkflowHandoffArtifactStore({
+    driver, trustedRoot: root,
+    hooks: {
+      async afterIntentReserved(artifactId) {
+        const candidate = join(root, `${artifactId}.handoff`);
+        await writeFile(candidate, bytes);
+        assertWindowsPrivatePathSecurity(candidate, "file", true);
+        await link(candidate, `${candidate}.pending`);
+      },
+      async afterArtifactInstalled(artifactId) {
+        await unlink(join(root, `${artifactId}.handoff.pending`));
+      },
+    },
+  });
+  const artifact = await store.publishSource({
+    owner, idempotencyKey: "stream", tokenCount: 1,
+    source: {
+      byteLength: bytes.byteLength,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      async *chunks() {
+        yield bytes.subarray(0, 65_536);
+        yield bytes.subarray(65_536);
+      },
+    },
+  });
+  expect(Buffer.from((await store.read(artifact.artifact_id)).bytes)).toEqual(bytes);
+}, 90_000);

--- a/runtime/tests/agents/workflow-filesystem.win32.test.ts
+++ b/runtime/tests/agents/workflow-filesystem.win32.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { link, mkdir, mkdtemp, readFile, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -7,6 +8,10 @@ import { loadNamedWorkflowManifest } from "../../src/agents/workflow-manifest.js
 import { WorkflowHandoffArtifactStore } from "../../src/agents/workflow-handoff-store.js";
 import { assertWindowsPrivatePathSecurity } from "../../src/agents/workflow-private-path.js";
 import { openStateDatabases, type StateSqliteDriver } from "../../src/state/sqlite-driver.js";
+import {
+  resolveTrustedWindowsSystemExecutable,
+  resolveTrustedWindowsSystemPaths,
+} from "../../src/utils/windows-system-path.js";
 
 if (process.platform !== "win32") {
   throw new Error("workflow filesystem native tests require Windows");
@@ -141,4 +146,33 @@ it("verifies a streamed Windows publication against an existing bounded candidat
     },
   });
   expect(Buffer.from((await store.read(artifact.artifact_id)).bytes)).toEqual(bytes);
+}, 90_000);
+
+it("continues Windows cleanup after rejecting one inherited file ACL", async () => {
+  driver = openStateDatabases({
+    cwd: temporaryDirectory, agencHome: join(temporaryDirectory, "home"),
+  });
+  let now = 1_000_000;
+  const root = join(temporaryDirectory, "handoffs");
+  const store = new WorkflowHandoffArtifactStore({
+    driver, trustedRoot: root, retentionMs: 100, now: () => now,
+  });
+  const rejected = await store.publish({
+    owner, idempotencyKey: "rejected", bytes: Buffer.from("bad-acl"), tokenCount: 1,
+  });
+  const accepted = await store.publish({
+    owner, idempotencyKey: "accepted", bytes: Buffer.from("private"), tokenCount: 1,
+  });
+  const rejectedPath = join(root, `${rejected.artifact_id}.handoff`);
+  const icacls = resolveTrustedWindowsSystemExecutable(
+    resolveTrustedWindowsSystemPaths(), ["System32", "icacls.exe"],
+  );
+  execFileSync(icacls, [rejectedPath, "/inheritance:e"], { windowsHide: true });
+  await expect(store.read(rejected.artifact_id))
+    .rejects.toMatchObject({ code: "WORKFLOW_HANDOFF_CORRUPT" });
+  now += 101;
+  expect(await store.cleanupExpired()).toMatchObject({ removed: 1, conflicts: 1 });
+  expect(await readFile(rejectedPath, "utf8")).toBe("bad-acl");
+  await expect(readFile(join(root, `${accepted.artifact_id}.handoff`)))
+    .rejects.toMatchObject({ code: "ENOENT" });
 }, 90_000);

--- a/runtime/tests/agents/workflow-handoff-store.test.ts
+++ b/runtime/tests/agents/workflow-handoff-store.test.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import {
+  appendFile,
   chmod,
+  link,
   mkdir,
   mkdtemp,
   readFile,
@@ -409,6 +411,89 @@ describe("workflow handoff publication and integrity", () => {
 
     await expect(publish(artifactStore, "root-race", "must-not-escape")).rejects.toThrow();
     expect((await readdir(artifactRoot)).filter((name) => name.endsWith(".handoff"))).toEqual([]);
+  });
+});
+
+describe("workflow handoff confined filesystem races", () => {
+  it.each(["read", "cleanup"])(
+    "rejects root replacement before %s touches a child",
+    async (operation) => {
+      let armed = false;
+      const artifactStore = store({
+        async afterRootOpen() {
+          if (!armed) return;
+          armed = false;
+          await rename(artifactRoot, `${artifactRoot}.old`);
+          await mkdir(artifactRoot, { mode: 0o700 });
+        },
+      });
+      const artifact = await publish(artifactStore, "root-race", "safe");
+      now += 101;
+      armed = true;
+      await expectStoreCode(
+        () => operation === "read"
+          ? artifactStore.read(artifact.artifact_id)
+          : artifactStore.cleanupExpired(),
+        "WORKFLOW_HANDOFF_UNSAFE_ROOT",
+      );
+      expect(await readFile(join(
+        `${artifactRoot}.old`, `${artifact.artifact_id}.handoff`,
+      ), "utf8")).toBe("safe");
+      expect(await readdir(artifactRoot)).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["read", "replace"],
+    ["read", "grow"],
+    ["cleanup", "replace"],
+    ["cleanup", "grow"],
+  ])("preserves a child changed by %s/%s after opening", async (operation, mutation) => {
+    let armed = false;
+    const artifactStore = store({
+      async afterCandidateOpen(path) {
+        if (!armed) return;
+        armed = false;
+        if (mutation === "replace") {
+          await rename(path, `${path}.old`);
+          await writeFile(path, "evil", { mode: 0o600 });
+        } else {
+          await appendFile(path, "-oversized");
+        }
+      },
+    });
+    const artifact = await publish(artifactStore, "child-race", "safe");
+    now += 101;
+    armed = true;
+    if (operation === "read") {
+      await expectStoreCode(
+        () => artifactStore.read(artifact.artifact_id),
+        "WORKFLOW_HANDOFF_CORRUPT",
+      );
+    } else {
+      expect(await artifactStore.cleanupExpired()).toMatchObject({
+        removed: 0, conflicts: 1,
+      });
+    }
+    expect(await readFile(artifactPath(artifact.artifact_id), "utf8"))
+      .toBe(mutation === "replace" ? "evil" : "safe-oversized");
+  });
+
+  it("rejects hard-linked handoffs during reads and cleanup", async () => {
+    const artifactStore = store();
+    const artifact = await publish(artifactStore, "hard-link", "safe");
+    const alias = join(temporaryDirectory, "hard-link");
+    await link(artifactPath(artifact.artifact_id), alias);
+    await expectStoreCode(
+      () => artifactStore.read(artifact.artifact_id),
+      "WORKFLOW_HANDOFF_CORRUPT",
+    );
+    now += 101;
+    expect(await artifactStore.cleanupExpired()).toMatchObject({
+      removed: 0, conflicts: 1,
+    });
+    expect(await readFile(alias, "utf8")).toBe("safe");
+    expect(await readFile(artifactPath(artifact.artifact_id), "utf8")).toBe("safe");
   });
 });
 

--- a/runtime/tests/fs/descriptor-confined-io.test.ts
+++ b/runtime/tests/fs/descriptor-confined-io.test.ts
@@ -17,6 +17,7 @@ import { openStateDatabases } from "../../src/state/sqlite-driver.js";
 const controls = vi.hoisted(() => ({
   hideAliases: false,
   beforeOpen: undefined as ((path: string) => Promise<void>) | undefined,
+  beforeRealpath: undefined as ((path: string) => Promise<void>) | undefined,
   afterRead: undefined as (() => Promise<void>) | undefined,
   maximumReadBytes: undefined as number | undefined,
   handles: [] as FileHandle[],
@@ -28,6 +29,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return {
     ...actual,
     realpath: vi.fn(async (...args: Parameters<typeof actual.realpath>) => {
+      await controls.beforeRealpath?.(String(args[0]));
       if (controls.hideAliases && /^\/(?:proc\/self\/fd|dev\/fd)\//u.test(String(args[0]))) {
         throw Object.assign(new Error("descriptor aliases unavailable"), { code: "ENOENT" });
       }
@@ -72,6 +74,7 @@ let candidate: string;
 beforeEach(async () => {
   controls.hideAliases = false;
   controls.beforeOpen = undefined;
+  controls.beforeRealpath = undefined;
   controls.afterRead = undefined;
   controls.maximumReadBytes = undefined;
   controls.handles = [];
@@ -85,6 +88,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   controls.beforeOpen = undefined;
+  controls.beforeRealpath = undefined;
   controls.afterRead = undefined;
   for (const handle of controls.handles) {
     if (handle.fd !== -1) await handle.close();
@@ -103,6 +107,27 @@ function readCandidate(
 }
 
 describe("descriptor-confined I/O", () => {
+  it("preserves an operational failure during post-read verification", async () => {
+    const failure = Object.assign(new Error("temporary verification failure"), { code: "EIO" });
+    controls.afterRead = async () => {
+      controls.beforeRealpath = async (path) => {
+        if (path.endsWith("candidate")) throw failure;
+      };
+    };
+    await expect(readCandidate()).rejects.toBe(failure);
+    expect(controls.handles.every((handle) => handle.fd === -1)).toBe(true);
+  });
+
+  it("reports a child removed between inspection and opening as missing", async () => {
+    controls.beforeOpen = async (path) => {
+      if (!path.endsWith("candidate")) return;
+      controls.beforeOpen = undefined;
+      await unlink(candidate);
+    };
+    expect(await readCandidate()).toBeUndefined();
+    expect(controls.requestedBytes).toEqual([]);
+  });
+
   it("reads the exact cap, handles short reads, and closes both descriptors", async () => {
     controls.maximumReadBytes = 1;
     expect(await readCandidate()).toEqual(Buffer.from("safe"));
@@ -268,6 +293,72 @@ describe("descriptor-confined I/O", () => {
 });
 
 describe("workflow consumer filesystem policies", () => {
+  it.each([
+    ["read", "EMFILE"], ["read", "EACCES"], ["read", "EIO"],
+    ["cleanup", "EMFILE"], ["cleanup", "EACCES"], ["cleanup", "EIO"],
+    ["recovery", "EMFILE"], ["recovery", "EACCES"], ["recovery", "EIO"],
+  ])("keeps %s retryable after a child open returns %s", async (operation, code) => {
+    const driver = openStateDatabases({
+      cwd: temporaryDirectory, agencHome: join(temporaryDirectory, "home"),
+    });
+    try {
+      let now = 1_000_000;
+      let artifactId = "";
+      const store = new WorkflowHandoffArtifactStore({
+        driver, trustedRoot: join(temporaryDirectory, "handoffs"),
+        retentionMs: 100, intentRecoveryGraceMs: 0, now: () => now,
+        hooks: {
+          afterArtifactInstalled(installedId) {
+            artifactId = installedId;
+            if (operation === "recovery") throw new Error("reserved for recovery");
+          },
+        },
+      });
+      const publication = store.publish({
+        owner: { run_id: "run", workflow_id: "workflow", producer_step_id: "step" },
+        idempotencyKey: "retryable", bytes: Buffer.from("safe"), tokenCount: 1,
+      });
+      if (operation === "recovery") {
+        await expect(publication).rejects.toThrow("reserved for recovery");
+      } else {
+        await publication;
+      }
+      const failure = Object.assign(new Error("temporary open failure"), { code });
+      controls.beforeOpen = async (path) => {
+        if (path.endsWith(`${artifactId}.handoff`)) throw failure;
+      };
+      now += 101;
+      const attempt = () => operation === "read"
+        ? store.read(artifactId)
+        : operation === "cleanup" ? store.cleanupExpired() : store.recoverIntents();
+      await expect(attempt()).rejects.toBe(failure);
+      expect(store.inspectForOperator(artifactId).status).toBe(
+        operation === "read" ? "committed" : operation === "cleanup" ? "deleting" : "intent",
+      );
+      controls.beforeOpen = undefined;
+      await expect(attempt()).resolves.toBeDefined();
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("maps a rejected Windows child ACL to a child conflict", async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { ...platform, value: "win32" });
+    try {
+      await expect(readCandidate({
+        ...privatePolicy,
+        unavailableAlias: "windows-private-path",
+        verifyWindowsPrivatePath(_path, role) {
+          if (role === "file") throw new Error("child ACL is inherited");
+        },
+      })).rejects.toMatchObject({ code: "CHILD_UNSAFE" });
+      expect(controls.requestedBytes).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", platform);
+    }
+  });
+
   it("rejects an oversized handoff cleanup candidate before opening it", async () => {
     const driver = openStateDatabases({
       cwd: temporaryDirectory,

--- a/runtime/tests/fs/descriptor-confined-io.test.ts
+++ b/runtime/tests/fs/descriptor-confined-io.test.ts
@@ -1,0 +1,333 @@
+import { execFileSync } from "node:child_process";
+import {
+  appendFile, chmod, link, mkdir, mkdtemp, readFile, rename, rm, symlink, unlink, writeFile,
+  type FileHandle,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  readConfinedFile, scanConfinedFile, withConfinedDirectory, withRegularChild,
+  type ConfinedIoHooks, type ConfinedIoPolicy,
+} from "../../src/fs/descriptor-confined-io.js";
+import { loadNamedWorkflowManifest } from "../../src/agents/workflow-manifest.js";
+import { WorkflowHandoffArtifactStore } from "../../src/agents/workflow-handoff-store.js";
+import { openStateDatabases } from "../../src/state/sqlite-driver.js";
+
+const controls = vi.hoisted(() => ({
+  hideAliases: false,
+  beforeOpen: undefined as ((path: string) => Promise<void>) | undefined,
+  afterRead: undefined as (() => Promise<void>) | undefined,
+  maximumReadBytes: undefined as number | undefined,
+  handles: [] as FileHandle[],
+  requestedBytes: [] as number[],
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    realpath: vi.fn(async (...args: Parameters<typeof actual.realpath>) => {
+      if (controls.hideAliases && /^\/(?:proc\/self\/fd|dev\/fd)\//u.test(String(args[0]))) {
+        throw Object.assign(new Error("descriptor aliases unavailable"), { code: "ENOENT" });
+      }
+      return actual.realpath(...args);
+    }),
+    open: vi.fn(async (...args: Parameters<typeof actual.open>) => {
+      await controls.beforeOpen?.(String(args[0]));
+      const handle = await actual.open(...args);
+      controls.handles.push(handle);
+      const read = handle.read.bind(handle);
+      Object.defineProperty(handle, "read", {
+        value: async (buffer: Buffer, offset: number, length: number, position: number) => {
+          controls.requestedBytes.push(length);
+          const result = await read(buffer, offset, Math.min(length, controls.maximumReadBytes ?? length), position);
+          const afterRead = controls.afterRead;
+          controls.afterRead = undefined;
+          await afterRead?.();
+          return result;
+        },
+      });
+      return handle;
+    }),
+  };
+});
+
+const sharedPolicy: ConfinedIoPolicy = Object.freeze({
+  hardLinks: "allow",
+  privateDirectory: false,
+  privateFile: false,
+  unavailableAlias: "identity-checked-path",
+});
+const privatePolicy: ConfinedIoPolicy = Object.freeze({
+  hardLinks: "reject",
+  privateDirectory: true,
+  privateFile: true,
+  unavailableAlias: "reject",
+});
+let temporaryDirectory: string;
+let root: string;
+let candidate: string;
+
+beforeEach(async () => {
+  controls.hideAliases = false;
+  controls.beforeOpen = undefined;
+  controls.afterRead = undefined;
+  controls.maximumReadBytes = undefined;
+  controls.handles = [];
+  controls.requestedBytes = [];
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "agenc-confined-io-"));
+  root = join(temporaryDirectory, "root");
+  candidate = join(root, "candidate");
+  await mkdir(root, { mode: 0o700 });
+  await writeFile(candidate, "safe", { mode: 0o600 });
+});
+
+afterEach(async () => {
+  controls.beforeOpen = undefined;
+  controls.afterRead = undefined;
+  for (const handle of controls.handles) {
+    if (handle.fd !== -1) await handle.close();
+  }
+  await rm(temporaryDirectory, { recursive: true, force: true });
+});
+
+function readCandidate(
+  policy: ConfinedIoPolicy = sharedPolicy,
+  hooks: ConfinedIoHooks = {},
+  maximumBytes = 4,
+): Promise<Buffer | undefined> {
+  return withConfinedDirectory(root, policy, (directory) => withRegularChild(
+    directory, "candidate", { maximumBytes }, readConfinedFile, hooks,
+  ), hooks);
+}
+
+describe("descriptor-confined I/O", () => {
+  it("reads the exact cap, handles short reads, and closes both descriptors", async () => {
+    controls.maximumReadBytes = 1;
+    expect(await readCandidate()).toEqual(Buffer.from("safe"));
+    expect(controls.handles.every((handle) => handle.fd === -1)).toBe(true);
+  });
+
+  it("rejects an oversized child before opening or reading it", async () => {
+    await expect(readCandidate(sharedPolicy, {}, 3)).rejects.toMatchObject({ code: "CHILD_TOO_LARGE" });
+    expect(controls.requestedBytes).toEqual([]);
+    expect(controls.handles).toHaveLength(process.platform === "win32" ? 0 : 1);
+    expect(controls.handles.every((handle) => handle.fd === -1)).toBe(true);
+  });
+
+  it("accepts an empty file at a zero-byte cap and distinguishes a missing child", async () => {
+    await writeFile(candidate, "");
+    expect(await readCandidate(sharedPolicy, {}, 0)).toEqual(Buffer.alloc(0));
+    await unlink(candidate);
+    expect(await readCandidate()).toBeUndefined();
+  });
+
+  it.each(["root", "child"])("rejects a %s symlink without reading outside bytes", async (role) => {
+    const outside = join(temporaryDirectory, "outside");
+    if (role === "root") {
+      await rename(root, outside);
+      await symlink(outside, root, "junction");
+    } else {
+      await writeFile(outside, "secret");
+      await unlink(candidate);
+      await symlink(outside, candidate);
+    }
+    await expect(readCandidate()).rejects.toMatchObject({
+      code: role === "root" ? "ROOT_UNSAFE" : "CHILD_UNSAFE",
+    });
+    expect(controls.requestedBytes).toEqual([]);
+  });
+
+  it.each([false, true])("detects root replacement before child I/O with path fallback=%s", async (fallback) => {
+    controls.hideAliases = fallback;
+    await expect(readCandidate(sharedPolicy, {
+      async afterRootOpen() {
+        await rename(root, `${root}.old`);
+        await mkdir(root);
+        await writeFile(candidate, "evil");
+      },
+    })).rejects.toMatchObject({ code: "ROOT_CHANGED" });
+    expect(controls.requestedBytes).toEqual([]);
+  });
+
+  it("detects root replacement between inspection and descriptor opening", async () => {
+    if (process.platform === "win32") {
+      expect(sharedPolicy.unavailableAlias).toBe("identity-checked-path");
+      return;
+    }
+    controls.beforeOpen = async (path) => {
+      if (path !== root) return;
+      controls.beforeOpen = undefined;
+      await rename(root, `${root}.old`);
+      await mkdir(root);
+    };
+    await expect(readCandidate()).rejects.toMatchObject({ code: "ROOT_CHANGED" });
+    expect(controls.requestedBytes).toEqual([]);
+  });
+
+  it.each(["regular", "symlink", "fifo"])("rejects a %s replacement between child inspection and open", async (replacement) => {
+    if (process.platform === "win32" && replacement === "fifo") {
+      expect(process.platform).toBe("win32");
+      return;
+    }
+    controls.beforeOpen = async (path) => {
+      if (!path.endsWith("candidate")) return;
+      controls.beforeOpen = undefined;
+      await rename(candidate, `${candidate}.old`);
+      if (replacement === "regular") await writeFile(candidate, "evil");
+      if (replacement === "symlink") await symlink(`${candidate}.old`, candidate);
+      if (replacement === "fifo") execFileSync("mkfifo", [candidate]);
+    };
+    await expect(readCandidate()).rejects.toMatchObject({
+      code: replacement === "fifo" ? "CHILD_UNSAFE" : "CHILD_CHANGED",
+    });
+    expect(controls.requestedBytes).toEqual([]);
+    expect(controls.handles.every((handle) => handle.fd === -1)).toBe(true);
+  });
+
+  it("detects a replaced child before consuming the opened bytes", async () => {
+    await expect(readCandidate(sharedPolicy, {
+      async afterCandidateOpen() {
+        await rename(candidate, `${candidate}.old`);
+        await writeFile(candidate, "evil");
+      },
+    })).rejects.toMatchObject({ code: "CHILD_CHANGED" });
+    expect(controls.requestedBytes).toEqual([]);
+  });
+
+  it.each(["grow", "shrink", "replace"])("rejects a %s during reading without an unbounded read", async (mutation) => {
+    controls.maximumReadBytes = 1;
+    controls.afterRead = async () => {
+      if (mutation === "grow") await appendFile(candidate, "-oversized");
+      if (mutation === "shrink") await writeFile(candidate, "s");
+      if (mutation === "replace") {
+        await rename(candidate, `${candidate}.old`);
+        await writeFile(candidate, "evil");
+      }
+    };
+    await expect(readCandidate()).rejects.toMatchObject({ code: "CHILD_CHANGED" });
+    expect(controls.requestedBytes.every((length) => length <= 5)).toBe(true);
+    expect(controls.handles.every((handle) => handle.fd === -1)).toBe(true);
+  });
+
+  it("allows sibling churn while retaining root and child identity", async () => {
+    expect(await readCandidate(sharedPolicy, {
+      async afterCandidateOpen() {
+        await writeFile(join(root, "sibling"), "unrelated");
+      },
+    })).toEqual(Buffer.from("safe"));
+  });
+
+  it("names hard-link policy without changing shared-manifest semantics", async () => {
+    await link(candidate, join(temporaryDirectory, "hard-link"));
+    expect(await readCandidate(sharedPolicy)).toEqual(Buffer.from("safe"));
+    await expect(readCandidate({ ...sharedPolicy, hardLinks: "reject" }))
+      .rejects.toMatchObject({ code: "CHILD_UNSAFE" });
+  });
+
+  it.each(["directory", "file"])("enforces the named private-%s policy", async (role) => {
+    if (process.platform === "win32") {
+      await expect(readCandidate(privatePolicy)).rejects.toMatchObject({ code: "DESCRIPTOR_UNSUPPORTED" });
+      return;
+    }
+    await chmod(role === "directory" ? root : candidate, 0o755);
+    expect(await readCandidate(sharedPolicy)).toEqual(Buffer.from("safe"));
+    await expect(readCandidate(privatePolicy)).rejects.toMatchObject({
+      code: role === "directory" ? "ROOT_UNSAFE" : "CHILD_UNSAFE",
+    });
+  });
+
+  it("names the descriptor-alias fallback and fail-closed policies", async () => {
+    controls.hideAliases = true;
+    expect(await readCandidate(sharedPolicy)).toEqual(Buffer.from("safe"));
+    await expect(readCandidate({ ...sharedPolicy, unavailableAlias: "reject" }))
+      .rejects.toMatchObject({ code: "DESCRIPTOR_UNSUPPORTED" });
+  });
+
+  it("streams bounded chunks without accumulating a whole-file result", async () => {
+    const bytes = Buffer.alloc(131_072, 97);
+    await writeFile(candidate, bytes);
+    const chunks: number[] = [];
+    await withConfinedDirectory(root, sharedPolicy, (directory) => withRegularChild(
+      directory, "candidate", { maximumBytes: bytes.byteLength },
+      (file) => scanConfinedFile(file, (chunk) => { chunks.push(chunk.byteLength); }),
+    ));
+    expect(chunks).toEqual([65_536, 65_536]);
+    expect(controls.requestedBytes.at(-1)).toBe(1);
+  });
+
+  it.each(["../outside", "..\\outside", "C:\\outside", ".", ""])(
+    "rejects a non-child name %j before filesystem reads", async (name) => {
+      await expect(withConfinedDirectory(root, sharedPolicy, (directory) => withRegularChild(
+        directory, name, { maximumBytes: 4 }, readConfinedFile,
+      ))).rejects.toBeInstanceOf(TypeError);
+      expect(controls.requestedBytes).toEqual([]);
+    },
+  );
+});
+
+describe("workflow consumer filesystem policies", () => {
+  it("rejects an oversized handoff cleanup candidate before opening it", async () => {
+    const driver = openStateDatabases({
+      cwd: temporaryDirectory,
+      agencHome: join(temporaryDirectory, "home"),
+    });
+    try {
+      let now = 1_000_000;
+      const store = new WorkflowHandoffArtifactStore({
+        driver,
+        trustedRoot: join(temporaryDirectory, "handoffs"),
+        retentionMs: 100,
+        now: () => now,
+      });
+      const artifact = await store.publish({
+        owner: { run_id: "run", workflow_id: "workflow", producer_step_id: "step" },
+        idempotencyKey: "cleanup", bytes: Buffer.from("safe"), tokenCount: 1,
+      });
+      const path = join(store.trustedRoot, `${artifact.artifact_id}.handoff`);
+      await appendFile(path, "-oversized");
+      let childOpened = false;
+      controls.beforeOpen = async (openedPath) => {
+        if (openedPath.endsWith(`${artifact.artifact_id}.handoff`)) childOpened = true;
+      };
+      controls.requestedBytes = [];
+      now += 101;
+      expect(await store.cleanupExpired()).toMatchObject({ removed: 0, conflicts: 1 });
+      expect(childOpened).toBe(false);
+      expect(controls.requestedBytes).toEqual([]);
+      expect(await readFile(path, "utf8")).toBe("safe-oversized");
+    } finally {
+      driver.close();
+    }
+  });
+
+  it("loads a shared hard-linked manifest when descriptor aliases are unavailable", async () => {
+    const manifest = '{"format_version":2,"kind":"agent_dag","steps":[{"id":"step","message":"work"}]}';
+    await writeFile(candidate, manifest);
+    await link(candidate, join(root, "example.json"));
+    controls.hideAliases = true;
+    const loaded = await loadNamedWorkflowManifest({ name: "example", roots: [root] });
+    expect(loaded.document.manifest.steps[0]?.id).toBe("step");
+  });
+
+  it("keeps handoff reads fail-closed without POSIX descriptor aliases", async () => {
+    if (process.platform === "win32") {
+      expect(process.platform).toBe("win32");
+      return;
+    }
+    const driver = openStateDatabases({ cwd: temporaryDirectory, agencHome: join(temporaryDirectory, "home") });
+    try {
+      const store = new WorkflowHandoffArtifactStore({ driver, trustedRoot: join(temporaryDirectory, "handoffs") });
+      const artifact = await store.publish({
+        owner: { run_id: "run", workflow_id: "workflow", producer_step_id: "step" },
+        idempotencyKey: "item", bytes: Buffer.from("safe"), tokenCount: 1,
+      });
+      controls.hideAliases = true;
+      await expect(store.read(artifact.artifact_id)).rejects.toMatchObject({ code: "WORKFLOW_HANDOFF_SAFE_IO_UNSUPPORTED" });
+      expect(await readFile(join(store.trustedRoot, `${artifact.artifact_id}.handoff`), "utf8")).toBe("safe");
+    } finally {
+      driver.close();
+    }
+  });
+});

--- a/runtime/tests/hermetic-test-discovery.test.ts
+++ b/runtime/tests/hermetic-test-discovery.test.ts
@@ -54,6 +54,7 @@ const CROSS_REPO_TEST_FILES = [
 
 const NATIVE_TEST_FILES = [
   "tests/agents/jobs/csv-output.native.test.ts",
+  "tests/agents/workflow-filesystem.win32.test.ts",
   "tests/app-server/windows-named-pipe.win32.test.ts",
   "tests/durability/atomic-artifact.darwin.test.ts",
   "tests/durability/atomic-artifact.win32.test.ts",

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -526,6 +526,7 @@ describe("reproducible install and release contract", () => {
       "tests/app-server/windows-named-pipe.win32.test.ts",
     );
     expect(windowsJob).toContain("tests/agents/jobs/csv-output.native.test.ts");
+    expect(windowsJob).toContain("tests/agents/workflow-filesystem.win32.test.ts");
     expect(windowsJob).toContain(
       "tests/durability/atomic-artifact.win32.test.ts",
     );
@@ -542,8 +543,8 @@ describe("reproducible install and release contract", () => {
       "tests/workspace/bound-helper-transport.win32.test.ts",
     );
     expect(windowsJob).toContain("--config vitest.native.config.ts");
-    expect(windowsJob).toContain("numTotalTestSuites: 18");
-    expect(windowsJob).toContain("numTotalTests: 104");
+    expect(windowsJob).toContain("numTotalTestSuites: 19");
+    expect(windowsJob).toContain("numTotalTests: 110");
     expect(windowsJob).toContain(
       "npm.cmd ci --ignore-scripts --no-audit --no-fund",
     );
@@ -553,7 +554,7 @@ describe("reproducible install and release contract", () => {
     );
     expect(windowsJob).not.toContain("npm_config_build_from_source");
     expect(windowsJob).toContain(
-      "Windows FND/native capability lane passed 104 tests in 11 files with zero skipped",
+      "Windows FND/native capability lane passed 110 tests in 12 files with zero skipped",
     );
 
     // Six lanes: default-suite plus the five hosted capability lanes.

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -544,7 +544,7 @@ describe("reproducible install and release contract", () => {
     );
     expect(windowsJob).toContain("--config vitest.native.config.ts");
     expect(windowsJob).toContain("numTotalTestSuites: 19");
-    expect(windowsJob).toContain("numTotalTests: 110");
+    expect(windowsJob).toContain("numTotalTests: 111");
     expect(windowsJob).toContain(
       "npm.cmd ci --ignore-scripts --no-audit --no-fund",
     );
@@ -554,7 +554,7 @@ describe("reproducible install and release contract", () => {
     );
     expect(windowsJob).not.toContain("npm_config_build_from_source");
     expect(windowsJob).toContain(
-      "Windows FND/native capability lane passed 110 tests in 12 files with zero skipped",
+      "Windows FND/native capability lane passed 111 tests in 12 files with zero skipped",
     );
 
     // Six lanes: default-suite plus the five hosted capability lanes.

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -117,6 +117,7 @@ export const CROSS_REPO_TEST_INCLUDE = Object.freeze([
 /** Native integration tests executed only by their matching hosted builder. */
 export const NATIVE_TEST_INCLUDE = Object.freeze([
   "tests/agents/jobs/csv-output.native.test.ts",
+  "tests/agents/workflow-filesystem.win32.test.ts",
   "tests/app-server/windows-named-pipe.win32.test.ts",
   "tests/durability/atomic-artifact.darwin.test.ts",
   "tests/durability/atomic-artifact.win32.test.ts",


### PR DESCRIPTION
## Changes

- Share trusted-root opening, descriptor alias discovery, regular-child checks, snapshot verification, and capped reads between workflow manifests and handoff storage.
- Name the intended policies. Manifests permit shared modes, hard links, and identity-checked path fallback. Committed handoffs require private single-link files, fail closed without POSIX aliases, and require protected current-user NTFS ACLs for Windows fallback. Pending Windows installation permits its temporary hard link.
- Cap cleanup and Windows existing-candidate comparisons as well as ordinary reads. Keep workflow errors, parsing, digest checks, quotas, publication, and persisted formats in the workflow modules.
- Add deterministic replacement, symlink, FIFO, growth, short-read, hard-link, unavailable-alias, ACL-conflict, and retryable-error tests. Add seven real Windows tests to the exact-count native lane.
- Document the path fallback's limits against an ancestor replaced and restored entirely between checks.

## Validation

- Typecheck, build, and six PTY startup scenarios pass.
- 184 targeted tests in 13 files pass with zero skips.
- Removing the cleanup candidate's early expected-length check makes the new regression assertion fail because the oversized child is opened. The guard is restored and the full targeted run passes.
- GitNexus reports low-to-medium per-helper impact, with up to seven direct callers. Final comparison covers only the eleven expected files. New helpers are not yet indexed, so their callers were also checked in source.
- Independent review found two error-classification regressions in the first commit. Both are fixed, and ten new regression cases fail before the fix and pass afterward. Child ACL failures remain per-artifact conflicts. Operational open/verification errors propagate and leave cleanup/recovery retryable.
- The first full run passed 22,734 tests and caught one missing native-discovery allowlist entry. That entry is fixed. The first Windows lane passed all 110 tests; the final lane adds one ACL cleanup test and requires 111 tests in 12 files with zero skips.
- Final-commit typecheck, build, PTY startup, and agent-surface contract pass. The full local suite passes, including 22,747 runtime tests in 2,251 files with zero skips.
- All 13 hosted full/native jobs pass in run `34166385483`, including 111 Windows tests in 12 files. Fast run `34166387948` and all six PR checks pass. Independent review approves commit `e047bbcf2d48e15c1c32b335d805828298c95ccb`; both reported findings are resolved.

No storage migration or public protocol change. Rollback is a source revert.

Closes #1819
