### PR TITLE
refactor(runtime): share runtime tool projection

### DIFF
--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -27,7 +27,6 @@ import type {
   LLMProvider,
   LLMProviderStartupPrewarmHandle,
   LLMProviderStartupPrewarmParams,
-  LLMTool,
   LLMUsage,
 } from "../llm/types.js";
 import { validateAgentInvocationMessageSequence } from "../contracts/agent-invocation-envelope.js";
@@ -43,6 +42,10 @@ import {
 } from "../llm/provider.js";
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
 import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
+import {
+  toRuntimeTools,
+  type RuntimeTool as AgentRuntimeTool,
+} from "../llm/runtime-tool-projection.js";
 import type {
   ToolRegistry,
   ToolDispatchResult,
@@ -656,14 +659,6 @@ interface AgentRunContext {
   readonly cwd?: string;
 }
 
-type AgentRuntimeTool = LLMTool & {
-  readonly name: string;
-  readonly description: string;
-  readonly inputJSONSchema: Record<string, unknown>;
-  readonly isMcp: boolean;
-  readonly maxResultSizeChars: number;
-};
-
 interface AgentModelContext {
   readonly model: string;
   readonly contextWindowTokens: number;
@@ -733,7 +728,10 @@ function buildAgentRunContext(
     sessionId: session.conversationId,
     options: {
       mainLoopModel: model.model,
-      tools: toAgentRuntimeTools(session.services.registry.toLLMTools()),
+      tools: toRuntimeTools(
+        session.services.registry.toLLMTools(),
+        DEFAULT_MAX_RESULT_SIZE_CHARS,
+      ),
       mcpClients: Array.isArray(surface.mcpClients) ? surface.mcpClients : [],
       contextWindowTokens: model.contextWindowTokens,
       ...(model.maxOutputTokens !== undefined
@@ -805,20 +803,6 @@ function toAgentModelContext(ctx: TurnContext): AgentModelContext {
       ? { maxOutputTokens: ctx.modelInfo.maxOutputTokens }
       : {}),
   };
-}
-
-function toAgentRuntimeTools(tools: readonly LLMTool[]): AgentRuntimeTool[] {
-  return tools.map((tool) => {
-    const name = tool.function.name;
-    return {
-      ...tool,
-      name,
-      description: tool.function.description,
-      inputJSONSchema: tool.function.parameters,
-      isMcp: name.startsWith("mcp__"),
-      maxResultSizeChars: DEFAULT_MAX_RESULT_SIZE_CHARS,
-    };
-  });
 }
 
 function firstNonEmpty(

--- a/runtime/src/commands/session-compact.ts
+++ b/runtime/src/commands/session-compact.ts
@@ -44,6 +44,10 @@ import {
 import { asRecord } from "../utils/record.js";
 import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
 import {
+  toRuntimeTools,
+  type RuntimeTool as AgenCRuntimeTool,
+} from "../llm/runtime-tool-projection.js";
+import {
   getAutoCompactThresholdForEnvironment,
   getEffectiveContextWindowSizeForEnvironment,
   isAutoCompactEnabledForEnvironment,
@@ -460,14 +464,6 @@ interface AgenCToolUseContext {
   readonly deps?: { readonly cleanup?: CompactCleanupDeps };
 }
 
-type AgenCRuntimeTool = LLMTool & {
-  readonly name: string;
-  readonly description: string;
-  readonly inputJSONSchema: Record<string, unknown>;
-  readonly isMcp: boolean;
-  readonly maxResultSizeChars: number;
-};
-
 function buildAgenCToolUseContext(
   session: Session,
   ctx: TurnContext,
@@ -509,7 +505,10 @@ function buildAgenCToolUseContext(
     sessionId: session.conversationId,
     options: {
       mainLoopModel: model.model,
-      tools: toAgenCRuntimeTools(session.services.registry.toLLMTools()),
+      tools: toRuntimeTools(
+        session.services.registry.toLLMTools(),
+        DEFAULT_MAX_RESULT_SIZE_CHARS,
+      ),
       mcpClients: Array.isArray(surface.mcpClients) ? surface.mcpClients : [],
       contextWindowTokens: model.contextWindowTokens,
       ...(model.maxOutputTokens !== undefined
@@ -571,20 +570,6 @@ function buildAgenCToolUseContext(
     provider: session.services.provider,
     cwd,
   };
-}
-
-function toAgenCRuntimeTools(tools: readonly LLMTool[]): AgenCRuntimeTool[] {
-  return tools.map((tool) => {
-    const name = tool.function.name;
-    return {
-      ...tool,
-      name,
-      description: tool.function.description,
-      inputJSONSchema: tool.function.parameters,
-      isMcp: name.startsWith("mcp__"),
-      maxResultSizeChars: DEFAULT_MAX_RESULT_SIZE_CHARS,
-    };
-  });
 }
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {

--- a/runtime/src/llm/runtime-tool-projection.ts
+++ b/runtime/src/llm/runtime-tool-projection.ts
@@ -1,0 +1,26 @@
+import type { LLMTool } from "./types.js";
+
+export type RuntimeTool = LLMTool & {
+  readonly name: string;
+  readonly description: string;
+  readonly inputJSONSchema: Record<string, unknown>;
+  readonly isMcp: boolean;
+  readonly maxResultSizeChars: number;
+};
+
+export function toRuntimeTools(
+  tools: readonly LLMTool[],
+  maxResultSizeChars: number,
+): RuntimeTool[] {
+  return tools.map((tool) => {
+    const name = tool.function.name;
+    return {
+      ...tool,
+      name,
+      description: tool.function.description,
+      inputJSONSchema: tool.function.parameters,
+      isMcp: name.startsWith("mcp__"),
+      maxResultSizeChars,
+    };
+  });
+}

--- a/runtime/src/session/agenc-tool-use-context.ts
+++ b/runtime/src/session/agenc-tool-use-context.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
+import { toRuntimeTools, type RuntimeTool } from "../llm/runtime-tool-projection.js";
 import { createChildAbortController } from "../utils/abortController.js";
 import { assertAgentRoleWorkspaceMatches } from "../agents/role-workspace.js";
 import type { LLMProvider, LLMTool } from "../llm/types.js";
@@ -94,13 +95,7 @@ export interface AgenCToolUseContext {
   readonly renderedSystemPrompt: SystemPrompt;
 }
 
-export type AgenCRuntimeTool = LLMTool & {
-  readonly name: string;
-  readonly description: string;
-  readonly inputJSONSchema: Record<string, unknown>;
-  readonly isMcp: boolean;
-  readonly maxResultSizeChars: number;
-};
+export type AgenCRuntimeTool = RuntimeTool;
 
 type AppStateShape = ReturnType<AgenCToolUseContext["getAppState"]>;
 
@@ -260,7 +255,7 @@ export function buildAgenCToolUseContext(
     sessionId: session.conversationId,
     options: {
       mainLoopModel: model.model,
-      tools: toAgenCRuntimeTools(llmTools),
+      tools: toRuntimeTools(llmTools, DEFAULT_MAX_RESULT_SIZE_CHARS),
       mcpClients: Array.isArray(surface.mcpClients) ? surface.mcpClients : [],
       contextWindowTokens: model.contextWindowTokens,
       ...(model.maxOutputTokens !== undefined
@@ -312,20 +307,6 @@ export function buildAgenCToolUseContext(
       systemPrompt.length === 0 ? [] : [systemPrompt],
     ),
   };
-}
-
-function toAgenCRuntimeTools(tools: readonly LLMTool[]): AgenCRuntimeTool[] {
-  return tools.map((tool) => {
-    const name = tool.function.name;
-    return {
-      ...tool,
-      name,
-      description: tool.function.description,
-      inputJSONSchema: tool.function.parameters,
-      isMcp: name.startsWith("mcp__"),
-      maxResultSizeChars: DEFAULT_MAX_RESULT_SIZE_CHARS,
-    };
-  });
 }
 
 function normalizeAgentDefinitions(

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -71,6 +71,8 @@ import {
 } from "../sandbox/execution-broker.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
+import { buildAgenCToolUseContext } from "../session/agenc-tool-use-context.js";
+import { DEFAULT_MAX_RESULT_SIZE_CHARS } from "../constants/toolLimits.js";
 import {
   disposeSandboxExecutionBroker,
   isSandboxExecutionBrokerDisposed,
@@ -97,6 +99,7 @@ import type {
   ManagedFeatures,
   ModelInfo,
   SessionConfiguration,
+  TurnContext,
 } from "../session/turn-context.js";
 import type { ToolRegistry } from "../tool-registry.js";
 import type {
@@ -1715,12 +1718,13 @@ describe("runAgent", () => {
     });
   });
 
-  it("captures AgentSummary cache-safe params from the real child run state", async () => {
+  it("captures matching session and child tool metadata from the same registry", async () => {
+    const toolName = "system.echo";
     const provider = makeProvider([{ content: "summary seed" }]);
     const registry = {
       tools: [
         {
-          name: "system.echo",
+          name: toolName,
           description: "echo",
           inputSchema: { type: "object" },
           execute: async () => ({ content: JSON.stringify({ ok: true }) }),
@@ -1730,7 +1734,7 @@ describe("runAgent", () => {
         {
           type: "function",
           function: {
-            name: "system.echo",
+            name: toolName,
             description: "echo",
             parameters: { type: "object" },
           },
@@ -1789,6 +1793,23 @@ describe("runAgent", () => {
     expect(params.toolUseContext.options.contextWindowTokens).toBe(
       providerOptions.contextWindowTokens,
     );
+    const mainContext = buildAgenCToolUseContext(session, {
+      cwd: "/tmp",
+      modelInfo: {
+        slug: "fake-model",
+        contextWindow: 200_000,
+        effectiveContextWindowPercent: 100,
+      },
+    } as TurnContext);
+    expect(params.toolUseContext.options.tools).toEqual(mainContext.options.tools);
+    expect(params.toolUseContext.options.tools).toEqual([{
+      ...registry.toLLMTools()[0],
+      name: toolName,
+      description: "echo",
+      inputJSONSchema: { type: "object" },
+      isMcp: toolName.startsWith("mcp__"),
+      maxResultSizeChars: DEFAULT_MAX_RESULT_SIZE_CHARS,
+    }]);
     expect(typeof params.toolUseContext.getAppState).toBe("function");
     expect(params.toolUseContext.readFileState.max).toBeGreaterThan(0);
     expect(params.toolUseContext.readFileState.maxSize).toBeGreaterThan(0);

--- a/runtime/tests/llm/runtime-tool-projection.test.ts
+++ b/runtime/tests/llm/runtime-tool-projection.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { toRuntimeTools } from "../../src/llm/runtime-tool-projection.js";
+import type { LLMTool } from "../../src/llm/types.js";
+
+describe("runtime tool projection", () => {
+  it("preserves the original tool and schema while projecting canonical fields", () => {
+    const schema = Object.freeze({ type: "object", properties: { text: { type: "string" } } });
+    const metadata = Object.freeze({ server: "fixture", annotations: { readOnly: true } });
+    const tool = Object.freeze({
+      type: "function" as const,
+      function: Object.freeze({ name: "mcp__fixture__echo", description: "Echo text", parameters: schema }),
+      metadata,
+      name: "stale-name",
+      description: "stale-description",
+      inputJSONSchema: {},
+      isMcp: false,
+      maxResultSizeChars: 999,
+    });
+    const projected = toRuntimeTools(Object.freeze([tool]), 123);
+
+    expect(projected).toEqual([{
+      ...tool,
+      name: "mcp__fixture__echo",
+      description: "Echo text",
+      inputJSONSchema: schema,
+      isMcp: true,
+      maxResultSizeChars: 123,
+    }]);
+    expect(projected[0]).not.toBe(tool);
+    expect(projected[0]?.function).toBe(tool.function);
+    expect(projected[0]?.inputJSONSchema).toBe(schema);
+    expect(projected[0]).toHaveProperty("metadata", metadata);
+    expect(tool.name).toBe("stale-name");
+  });
+
+  it.each([
+    ["mcp__server__tool", true],
+    ["mcp__", true],
+    ["MCP__server__tool", false],
+    ["prefix_mcp__server__tool", false],
+    ["mcp_tool", false],
+    ["Bash", false],
+  ])("classifies MCP name %s as %s", (name, isMcp) => {
+    const tools: LLMTool[] = [{
+      type: "function",
+      function: { name, description: "", parameters: {} },
+    }];
+    expect(toRuntimeTools(tools, 1)[0]?.isMcp).toBe(isMcp);
+  });
+
+  it("uses the explicit caller limit and retains registry order", () => {
+    const tools: LLMTool[] = ["second", "first"].map((name) => ({
+      type: "function", function: { name, description: name, parameters: {} },
+    }));
+    for (const limit of [0, 1, 500_000]) {
+      const projected = toRuntimeTools(tools, limit);
+      expect(projected.map((tool) => tool.name)).toEqual(["second", "first"]);
+      expect(projected.map((tool) => tool.maxResultSizeChars)).toEqual([limit, limit]);
+    }
+    expect(toRuntimeTools([], 1)).toEqual([]);
+  });
+
+  it.each([
+    "agents/run-agent.ts",
+    "session/agenc-tool-use-context.ts",
+    "commands/session-compact.ts",
+  ])("keeps %s wired to the shared projection with an explicit limit", (path) => {
+    const source = readFileSync(new URL(`../../src/${path}`, import.meta.url), "utf8");
+    expect(source).toContain('from "../llm/runtime-tool-projection.js"');
+    expect(source).toMatch(/tools:\s*toRuntimeTools\([\s\S]*?DEFAULT_MAX_RESULT_SIZE_CHARS,?\s*\)/u);
+    expect(source).not.toMatch(/function to(?:Agent|AgenC)RuntimeTools\(/u);
+    expect(source).not.toContain('isMcp: name.startsWith("mcp__")');
+  });
+});

--- a/runtime/tests/session/agenc-tool-use-context.test.ts
+++ b/runtime/tests/session/agenc-tool-use-context.test.ts
@@ -46,6 +46,32 @@ function createSession(overrides: Record<string, unknown> = {}) {
 }
 
 describe("buildAgenCToolUseContext", () => {
+  test("preserves builtin and MCP metadata from the selected registry input", () => {
+    const tools = ["system.echo", "mcp__fixture__echo"].map((name) => ({
+      type: "function" as const,
+      function: {
+        name,
+        description: `Describe ${name}`,
+        parameters: { type: "object", properties: { text: { type: "string" } } },
+      },
+      annotations: { readOnly: true },
+    }));
+    const context = buildAgenCToolUseContext(
+      createSession() as unknown as Session,
+      createTurnContext(),
+      { llmTools: tools },
+    );
+    expect(context.options.tools.map((tool) => tool.name))
+      .toEqual(tools.map((tool) => tool.function.name));
+    expect(context.options.tools.map((tool) => tool.isMcp)).toEqual([false, true]);
+    for (const [index, projected] of context.options.tools.entries()) {
+      expect(projected.function).toBe(tools[index]!.function);
+      expect(projected.description).toBe(tools[index]!.function.description);
+      expect(projected.inputJSONSchema).toBe(tools[index]!.function.parameters);
+      expect(projected).toHaveProperty("annotations", tools[index]!.annotations);
+    }
+  });
+
   test("carries the exact admitted prompt snapshot into tool execution", () => {
     const session = createSession();
     const context = buildAgenCToolUseContext(


### PR DESCRIPTION
## Changes

- Use one leaf projection for session tool-use contexts, child-agent summaries, and manual compaction/context display. The third copy in manual compaction had the same fields and policy as the two reported copies.
- Preserve the original tool fields and function/schema references. Project canonical names, descriptions, schemas, MCP classification, and an explicit caller-supplied result limit.
- Share the runtime tool type while keeping the existing exported session type name. All three callers retain the existing result limit. Registry filtering and MCP authorization do not change.
- Compare real child and session context metadata for the same registry input. Test MCP metadata, field preservation, ordering, explicit limits, and wiring of all three callers to the shared projection.

## Validation

- 123 targeted tests in five files pass with zero skips.
- Final typecheck, build, six PTY startup scenarios, and the agent-surface contract pass. The full local suite passes, including 22,759 runtime tests in 2,252 files with zero skips.
- Independent review approves source `8c619347877c638fae55bd10df690a7ba1907000` with no findings. All six PR checks pass. All 13 jobs in hosted platform run `34167668250` pass, and affected-tests run `34167670124` passes.
- GitNexus reports low impact for each projection and context builder, with at most four direct callers. Staged detection covers the seven expected files.

No data migration or public wire change. Rollback is a source revert.

Closes #1821
