### PR TITLE
fix(llm): preserve managed request identity across retries

### DIFF
--- a/runtime/src/llm/provider.ts
+++ b/runtime/src/llm/provider.ts
@@ -1380,6 +1380,7 @@ function buildOpenAICompatibleProvider(
     tools: opts.tools ? [...opts.tools] : undefined,
     baseURL,
     useResponsesApi,
+    ...(extra.managedCredential === true ? { managedRequestId: true } : {}),
     ...(extra.store !== undefined ? { store: extra.store } : {}),
     ...(extra.contextWindowTokens !== undefined
       ? { contextWindowTokens: extra.contextWindowTokens }
@@ -1438,6 +1439,7 @@ function buildManagedGatewayProvider(
     model,
     providerName: provider,
     apiKeyEnvLabel: "AgenC subscription",
+    managedRequestId: true,
     tools: opts.tools ? [...opts.tools] : undefined,
     useResponsesApi: false,
     ...(extra.contextWindowTokens !== undefined

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -657,7 +657,7 @@ export class OpenAIProvider implements LLMProvider {
     messages: LLMMessage[],
     options?: LLMChatOptions,
   ): Promise<LLMResponse> {
-    const headers = this.managedRequestHeaders();
+    const headers = this.managedRequestHeaders(options);
     const timeoutMs = resolveTimeoutMs(this.config.timeoutMs, options?.timeoutMs);
     const model = options?.model?.trim() || this.config.model;
     const requestTools = options?.tools
@@ -786,7 +786,7 @@ export class OpenAIProvider implements LLMProvider {
     onChunk: StreamProgressCallback,
     options?: LLMChatOptions,
   ): Promise<LLMResponse> {
-    const headers = this.managedRequestHeaders();
+    const headers = this.managedRequestHeaders(options);
     const timeoutMs = resolveTimeoutMs(this.config.timeoutMs, options?.timeoutMs);
 
     try {
@@ -1051,12 +1051,14 @@ export class OpenAIProvider implements LLMProvider {
     return this.config.chatgptBackend === true;
   }
 
-  private managedRequestHeaders(): Readonly<Record<string, string>> | undefined {
-    // One UUID belongs to this logical provider call. Generate it outside
-    // authentication and stream fallback loops so a retry cannot buy twice.
-    // A fresh call (including the next tool round) always receives a fresh ID.
+  private managedRequestHeaders(
+    options: LLMChatOptions | undefined,
+  ): Readonly<Record<string, string>> | undefined {
+    // Session reconnects carry the immutable sampling snapshot's UUID. For
+    // standalone calls, mint one outside authentication and stream fallback
+    // loops so their transport retries keep the same remote charge identity.
     return this.config.managedRequestId === true
-      ? { "Idempotency-Key": randomUUID() }
+      ? { "Idempotency-Key": options?.managedRequestId ?? randomUUID() }
       : undefined;
   }
 

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -6,6 +6,7 @@
  * @module
  */
 
+import { randomUUID } from "node:crypto";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -656,6 +657,7 @@ export class OpenAIProvider implements LLMProvider {
     messages: LLMMessage[],
     options?: LLMChatOptions,
   ): Promise<LLMResponse> {
+    const headers = this.managedRequestHeaders();
     const timeoutMs = resolveTimeoutMs(this.config.timeoutMs, options?.timeoutMs);
     const model = options?.model?.trim() || this.config.model;
     const requestTools = options?.tools
@@ -686,6 +688,7 @@ export class OpenAIProvider implements LLMProvider {
           });
           const response = await session.requestJson<Record<string, unknown>>({
             api: "responses",
+            headers,
             path: this.resolvePath("/responses"),
             method: "POST",
             body: request,
@@ -731,6 +734,7 @@ export class OpenAIProvider implements LLMProvider {
           chatCompletionsCapabilityHintsForProvider(this.name, model);
         const response = await session.requestJson<Record<string, unknown>>({
           api: "chat_completions",
+          headers,
           path: this.resolvePath("/chat/completions"),
           method: "POST",
           body: request,
@@ -782,18 +786,20 @@ export class OpenAIProvider implements LLMProvider {
     onChunk: StreamProgressCallback,
     options?: LLMChatOptions,
   ): Promise<LLMResponse> {
+    const headers = this.managedRequestHeaders();
     const timeoutMs = resolveTimeoutMs(this.config.timeoutMs, options?.timeoutMs);
 
     try {
       return await this.auth.withAuthorizedOperation(async () => {
         if (this.config.useResponsesApi !== false) {
-          return await this.streamResponses(messages, onChunk, options, timeoutMs);
+          return await this.streamResponses(messages, onChunk, options, timeoutMs, headers);
         }
         return await this.streamChatCompletions(
           messages,
           onChunk,
           options,
           timeoutMs,
+          headers,
         );
       }, { singleWireAttempt: options?.singleWireAttempt });
     } catch (error) {
@@ -1045,11 +1051,21 @@ export class OpenAIProvider implements LLMProvider {
     return this.config.chatgptBackend === true;
   }
 
+  private managedRequestHeaders(): Readonly<Record<string, string>> | undefined {
+    // One UUID belongs to this logical provider call. Generate it outside
+    // authentication and stream fallback loops so a retry cannot buy twice.
+    // A fresh call (including the next tool round) always receives a fresh ID.
+    return this.config.managedRequestId === true
+      ? { "Idempotency-Key": randomUUID() }
+      : undefined;
+  }
+
   private async streamResponses(
     messages: LLMMessage[],
     onChunk: StreamProgressCallback,
     options: LLMChatOptions | undefined,
     timeoutMs: number | undefined,
+    headers: Readonly<Record<string, string>> | undefined,
   ): Promise<LLMResponse> {
     const model = options?.model?.trim() || this.config.model;
     const requestOptions = {
@@ -1078,6 +1094,7 @@ export class OpenAIProvider implements LLMProvider {
       try {
         response = await this.requestStream({
           api: "responses",
+          headers,
           path: this.resolvePath("/responses"),
           body: request,
           timeoutMs,
@@ -1300,6 +1317,7 @@ export class OpenAIProvider implements LLMProvider {
     onChunk: StreamProgressCallback,
     options: LLMChatOptions | undefined,
     timeoutMs: number | undefined,
+    headers: Readonly<Record<string, string>> | undefined,
   ): Promise<LLMResponse> {
     const requestModel = options?.model?.trim() || this.config.model;
     const streamCapabilityHints = chatCompletionsCapabilityHintsForProvider(
@@ -1352,6 +1370,7 @@ export class OpenAIProvider implements LLMProvider {
       try {
         response = await this.requestStream({
           api: "chat_completions",
+          headers,
           path: this.resolvePath("/chat/completions"),
           body: request,
           timeoutMs,
@@ -1752,6 +1771,7 @@ export class OpenAIProvider implements LLMProvider {
     readonly api: "responses" | "chat_completions";
     readonly path: string;
     readonly body: Record<string, unknown>;
+    readonly headers?: Readonly<Record<string, string>>;
     readonly timeoutMs?: number;
     readonly signal?: AbortSignal;
     readonly providerFallback?: OpenAIProviderConfig["providerFallback"];
@@ -1764,7 +1784,7 @@ export class OpenAIProvider implements LLMProvider {
       api: args.api,
       path: args.path,
       method: "POST",
-      headers: { accept: "text/event-stream" },
+      headers: { accept: "text/event-stream", ...args.headers },
       body: args.body,
       timeoutMs: normalizeTimeoutMs(args.timeoutMs),
       signal: args.signal,

--- a/runtime/src/llm/providers/openai/types.ts
+++ b/runtime/src/llm/providers/openai/types.ts
@@ -35,4 +35,6 @@ export interface OpenAIProviderConfig extends LLMProviderConfig {
   readonly apiKeyEnvLabel?: string;
   readonly authStrategy?: OpenAIProviderAuthStrategy;
   readonly basePath?: string;
+  /** Internal managed transport marker; direct provider credentials omit it. */
+  readonly managedRequestId?: boolean;
 }

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -632,6 +632,12 @@ export type LLMToolChoice =
  */
 export interface LLMChatOptions {
   /**
+   * @internal UUID of one immutable sampling request, preserved across
+   * session reconnects. Only AgenC-managed adapters use it, as a transport
+   * idempotency header; it is never part of the model request body.
+   */
+  readonly managedRequestId?: string;
+  /**
    * @internal Admission-grade complete input count. Adapters may use this for
    * final wire fitting, but must never synthesize or increase it themselves.
    */

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -128,6 +128,8 @@ import type {
 import { runAdmittedModelCall } from "../budget/admitted-model-call.js";
 
 export interface StreamModelRequestContract {
+  /** Internal managed transport UUID, stable for every retry of this snapshot. */
+  readonly managedRequestId?: string;
   readonly input: ReadonlyArray<LLMMessage>;
   readonly tools: ReadonlyArray<LLMTool>;
   readonly parallelToolCalls: boolean;
@@ -300,6 +302,9 @@ function buildProviderOptions(
   const traceSink = resolveProviderTraceSink(session);
   return {
     signal,
+    ...(request.managedRequestId !== undefined
+      ? { managedRequestId: request.managedRequestId }
+      : {}),
     tools: cloneProviderTools(request.tools),
     parallelToolCalls: request.parallelToolCalls,
     ...(systemPrompt.length > 0 ? { systemPrompt } : {}),

--- a/runtime/src/session/run-turn-sampling-request.ts
+++ b/runtime/src/session/run-turn-sampling-request.ts
@@ -7,6 +7,7 @@
  * @module
  */
 
+import { randomUUID } from "node:crypto";
 import type { LLMMessage, LLMTool } from "../llm/types.js";
 import { cloneLlmMessageSnapshot } from "../llm/content-conversion.js";
 import {
@@ -243,6 +244,9 @@ function snapshotSamplingRequestContract(
 ): StreamModelRequestContract {
   return {
     ...request,
+    // Reconnects reuse this snapshot; a new sample or tool round snapshots
+    // again and receives its own identity, even when the prompt is identical.
+    managedRequestId: randomUUID(),
     input: request.input.map(cloneLlmMessageSnapshot),
     tools: request.tools.map((tool) => ({
       ...tool,

--- a/runtime/tests/llm/managed-usage-idempotency.test.ts
+++ b/runtime/tests/llm/managed-usage-idempotency.test.ts
@@ -94,14 +94,15 @@ describe("managed paid request identity", () => {
 
   test("preserves direct BYOK headers and does not infer managed authority from a hostname", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => response());
+    const options = { managedRequestId: "40c87426-0d3a-4b8e-9eb7-a06a882d52a3" };
     for (const target of ["https://openrouter.ai/api/v1", baseURL]) {
       const provider = createProvider("openrouter", { apiKey: "synthetic-byok", baseURL: target, model, extra: { fetchImpl } });
-      await provider.chat(messages);
+      await provider.chat(messages, options);
       expect(requestId(fetchImpl.mock.lastCall![1])).toBeNull();
     }
     const explicit = createProvider("openrouter", { apiKey: "synthetic-byok", model,
       extra: { fetchImpl, defaultHeaders: { "Idempotency-Key": "synthetic-custom-direct-header" } } });
-    await explicit.chat(messages);
+    await explicit.chat(messages, options);
     expect(requestId(fetchImpl.mock.lastCall![1])).toBe("synthetic-custom-direct-header");
   });
 });

--- a/runtime/tests/llm/managed-usage-idempotency.test.ts
+++ b/runtime/tests/llm/managed-usage-idempotency.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AuthBackend } from "../../src/auth/backend.js";
+import { createProvider } from "../../src/llm/provider.js";
+import type { LLMMessage } from "../../src/llm/types.js";
+
+const baseURL = "https://id.agenc.ag/v1/auth/openrouter/v1";
+const model = "openai/gpt-5";
+const messages: LLMMessage[] = [{ role: "user", content: "Synthetic request" }];
+const uuid = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u;
+const response = () => Response.json({ id: "synthetic-response", model, choices: [
+  { index: 0, message: { role: "assistant", content: "Synthetic answer" }, finish_reason: "stop" },
+], usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 } });
+const stream = () => new Response([
+  `data: ${JSON.stringify({ id: "synthetic-stream", model, choices: [{ index: 0, delta: { content: "Synthetic answer" } }] })}\n\n`,
+  `data: ${JSON.stringify({ id: "synthetic-stream", model, choices: [{ index: 0, finish_reason: "stop" }], usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 } })}\n\n`,
+  "data: [DONE]\n\n",
+].join(""), { headers: { "content-type": "text/event-stream" } });
+
+function managed(fetchImpl: typeof fetch, extra: Record<string, unknown> = {}) {
+  return createProvider("openrouter", { apiKey: "synthetic-agenc-session", baseURL, model,
+    extra: { managedGateway: true, maxTokens: 100, fetchImpl, ...extra } });
+}
+function requestId(init: RequestInit | undefined) { return new Headers(init?.headers).get("Idempotency-Key"); }
+afterEach(() => { vi.restoreAllMocks(); vi.useRealTimers(); });
+
+describe("managed paid request identity", () => {
+  test("keeps one UUID through lost responses and HTTP retries, then gives a new call its own identity", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(Response.json({ error: "synthetic-unavailable" }, { status: 503 }))
+      .mockImplementation(async () => response());
+    const provider = managed(fetchImpl, { defaultHeaders: { "idempotency-key": "unsafe-session-wide-static-value" } });
+    const first = expect(provider.chat(messages)).resolves.toMatchObject({ content: "Synthetic answer" });
+    await vi.runAllTimersAsync();
+    await first;
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const identities = fetchImpl.mock.calls.map(([, init]) => requestId(init));
+    expect(identities[0]).toMatch(uuid); expect(new Set(identities).size).toBe(1);
+    expect(fetchImpl.mock.calls.map(([, init]) => init?.body)).toEqual(Array(3).fill(fetchImpl.mock.calls[0]![1]!.body));
+    await provider.chat(messages);
+    expect(requestId(fetchImpl.mock.calls[3]![1])).toMatch(uuid);
+    expect(requestId(fetchImpl.mock.calls[3]![1])).not.toBe(identities[0]);
+  });
+
+  test("preserves the UUID when a streaming fallback recreates the HTTP session", async () => {
+    vi.useFakeTimers(); vi.spyOn(Math, "random").mockReturnValue(0);
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ error: { message: "overloaded" } }, { status: 503 }))
+      .mockImplementation(async () => stream());
+    const provider = managed(fetchImpl, { providerFallback: { provider: "openrouter", model,
+      statuses: [503], targets: [{ provider: "openrouter", model: "qwen/synthetic-fallback" }] } });
+    const onChunk = vi.fn();
+    const pending = expect(provider.chatStream(messages, onChunk)).resolves.toMatchObject({ content: "Synthetic answer" });
+    await vi.runAllTimersAsync();
+    await pending;
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(requestId(fetchImpl.mock.calls[0]![1])).toMatch(uuid);
+    expect(requestId(fetchImpl.mock.calls[1]![1])).toBe(requestId(fetchImpl.mock.calls[0]![1]));
+    expect(fetchImpl.mock.calls[1]![1]!.body).toBe(fetchImpl.mock.calls[0]![1]!.body);
+    expect(new Headers(fetchImpl.mock.calls[1]![1]!.headers).get("accept")).toBe("text/event-stream");
+    expect(onChunk).toHaveBeenCalledWith(expect.objectContaining({ content: "Synthetic answer", done: false }));
+  });
+
+  test("assigns distinct IDs to concurrent calls and tool rounds even when inputs and options are reused", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => JSON.parse(String(init?.body)).stream ? stream() : response());
+    const provider = managed(fetchImpl), options = { maxOutputTokens: 100 };
+    await Promise.all([provider.chat(messages, options), provider.chat(messages, options),
+      provider.chatStream(messages, () => {}, options), provider.chatStream(messages, () => {}, options)]);
+    await provider.chat([...messages, { role: "assistant", content: "", toolCalls: [{ id: "synthetic-call", name: "read_file", arguments: "{}" }] },
+      { role: "tool", content: "Synthetic tool result", toolCallId: "synthetic-call" }], options);
+    const identities = fetchImpl.mock.calls.map(([, init]) => requestId(init));
+    for (const identity of identities) expect(identity).toMatch(uuid);
+    expect(new Set(identities).size).toBe(5);
+  });
+
+  test("sets the wire identity after lazy managed credential vending without exposing it as a body field", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => response());
+    const backend: AuthBackend = { login: () => ({ authenticated: true, provider: "remote" }), logout: () => ({ authenticated: false }),
+      whoami: () => ({ authenticated: true, provider: "remote" }), getSubscriptionTier: () => "pro",
+      inferAgencModel: () => ({ provider: "openrouter", model }),
+      vendKey: (provider, sessionId) => ({ kind: "api-key", provider, sessionId, apiKey: "synthetic-vended-session", baseUrl: baseURL }) };
+    const provider = createProvider("openrouter", { model, extra: { authBackend: backend, managedCredential: true,
+      sessionId: "synthetic-session", maxTokens: 100, fetchImpl } });
+    await provider.chat(messages);
+    expect(String(fetchImpl.mock.calls[0]![0])).toBe(`${baseURL}/chat/completions`);
+    const init = fetchImpl.mock.calls[0]![1]!;
+    expect(requestId(init)).toMatch(uuid);
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer synthetic-vended-session");
+    expect(JSON.parse(String(init.body))).toEqual({ model: "openrouter/openai/gpt-5", stream: false,
+      messages: [{ role: "user", content: "Synthetic request" }], max_tokens: 100 });
+    expect(String(init.body)).not.toContain("Idempotency"); expect(String(init.body)).not.toContain("synthetic-vended-session");
+  });
+
+  test("preserves direct BYOK headers and does not infer managed authority from a hostname", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => response());
+    for (const target of ["https://openrouter.ai/api/v1", baseURL]) {
+      const provider = createProvider("openrouter", { apiKey: "synthetic-byok", baseURL: target, model, extra: { fetchImpl } });
+      await provider.chat(messages);
+      expect(requestId(fetchImpl.mock.lastCall![1])).toBeNull();
+    }
+    const explicit = createProvider("openrouter", { apiKey: "synthetic-byok", model,
+      extra: { fetchImpl, defaultHeaders: { "Idempotency-Key": "synthetic-custom-direct-header" } } });
+    await explicit.chat(messages);
+    expect(requestId(fetchImpl.mock.lastCall![1])).toBe("synthetic-custom-direct-header");
+  });
+});

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -91,6 +91,7 @@ import {
   SessionProviderService,
 } from "./provider-service.js";
 import { resolveProviderRuntimeRequest } from "../llm/provider-request.js";
+import { createProvider } from "../llm/provider.js";
 import type {
   Config,
   ManagedFeatures,
@@ -5133,6 +5134,64 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
         },
       }),
     );
+  });
+
+  test("managed wire retries reuse the sampling UUID while tool rounds and new turns receive distinct UUIDs", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const model = "openrouter/openai/gpt-5";
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      const attempt = fetchImpl.mock.calls.length;
+      if (attempt === 1) {
+        throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+      }
+      if (attempt === 2) {
+        return Response.json({ error: { message: "Service Unavailable" } }, { status: 503 });
+      }
+      const toolRound = attempt === 3;
+      return new Response([
+        `data: ${JSON.stringify({ id: "synthetic-stream", model, choices: [{ index: 0, delta: toolRound
+          ? { tool_calls: [{ index: 0, id: "synthetic-read", type: "function", function: { name: "FileRead", arguments: "{}" } }] }
+          : { content: "Synthetic answer" } }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "synthetic-stream", model, choices: [{ index: 0, delta: {}, finish_reason: toolRound ? "tool_calls" : "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 } })}\n\n`,
+        "data: [DONE]\n\n",
+      ].join(""), { headers: { "content-type": "text/event-stream" } });
+    });
+    const provider = createProvider("openrouter", {
+      apiKey: "synthetic-session",
+      baseURL: "https://id.agenc.ag/v1/auth/openrouter/v1",
+      model,
+      extra: { managedGateway: true, maxRetries: 0, maxTokens: 100, fetchImpl },
+    });
+    // Adapter retries are disabled: each failed fetch must re-enter through
+    // runSamplingRequest's outer reconnect loop using its saved snapshot.
+    const chatStream = vi.spyOn(provider, "chatStream");
+    const { registry, dispatch } = mkTrustedEditorReadRegistry();
+    const { session, events } = mkSession({ provider, registry, sessionConfiguration: {
+      provider: { slug: "openrouter" }, collaborationMode: { model },
+    } });
+    const ctx = { ...mkCtx(), modelProviderId: "openrouter", modelInfo: { ...mkCtx().modelInfo, slug: model }, collaborationMode: { model } };
+
+    await drain(session.runTurn("Read once and answer", { ctx }));
+    expect(chatStream).toHaveBeenCalledTimes(4);
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(events).toContainEqual(expect.objectContaining({ msg: {
+      type: "turn_complete", payload: expect.objectContaining({ lastAgentMessage: "Synthetic answer" }),
+    } }));
+    await drain(session.runTurn("Another request", { ctx: { ...ctx, subId: "turn-next" } }));
+
+    expect(chatStream).toHaveBeenCalledTimes(5);
+    const ids = fetchImpl.mock.calls.map(([, init]) => new Headers(init?.headers).get("Idempotency-Key"));
+    for (const id of ids) expect(id).toMatch(/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/u);
+    expect(ids.slice(0, 3)).toEqual(Array(3).fill(ids[0]));
+    expect(new Set([ids[0], ids[3], ids[4]]).size).toBe(3);
+    const bodies = fetchImpl.mock.calls.map(([, init]) => String(init?.body));
+    expect(bodies.slice(0, 3)).toEqual(Array(3).fill(bodies[0]));
+    expect(JSON.parse(bodies[3]!).messages).toContainEqual(expect.objectContaining({ role: "tool", tool_call_id: "synthetic-read" }));
+    for (const body of bodies) {
+      expect(body).not.toContain("managedRequestId");
+      for (const id of ids) expect(body).not.toContain(id!);
+    }
   });
 
   test("reconnects reuse one prompt snapshot across every transport attempt", async () => {


### PR DESCRIPTION
Managed paid requests could be dispatched again after a lost response or session reconnect because each transport entry generated a new identity. Core now assigns one `Idempotency-Key` UUID to the immutable sampling request and preserves it through session reconnects, HTTP/authentication retries and streaming fallback. New samples, concurrent calls and subsequent tool rounds receive distinct UUIDs. Standalone managed calls generate a UUID at adapter entry; direct provider credentials retain their existing behavior.

The change covers both the normal auth-vended `managedCredential` path and the explicit managed gateway path. The backend uses the UUID to prevent another paid dispatch. Repeating an existing attempt returns HTTP 409 with durable status, without replaying completion text; Core does not automatically retry that response. Model selection, capabilities, provider labels and Desktop UI are unchanged. Backend integration is [agenc-backend #167](https://github.com/tetsuo-ai/agenc-backend/pull/167), stacked on funding #166, and remains disabled pending live readiness.

Validation at `e4b0ecb75356fb923f15b9cefd425ebb551e2479`, based on main `fe80edafc38d1b6a8c8792a741f0b76e123df492`, with Node 26.5.0 / npm 11.17.0:

- Required `npm run test:fast -- --base fe80edafc38d1b6a8c8792a741f0b76e123df492` passed: both TypeScript stages, 141 exact changed tests in 2 files, and 10,813 related tests in all 945 selected files. No failures or skips. The source tree was clean before and after.
- The end-to-end regression exercises ECONNRESET then HTTP 503 with adapter retries disabled, forcing three adapter entries under one UUID/body. A tool follow-up and a new turn each get a distinct UUID. Its red/green evidence establishes that the session fix prevents the prior duplicate-identity behavior.
- Independent review covered the session snapshot lifetime, both managed factory paths, static-header precedence, concurrent/tool calls and direct credentials. Synthetic Core text, streaming/tools and tool-round payloads pass backend admission. The two commits rebase cleanly onto current main with an identical managed patch and unchanged range-diff.

The required gate ran as UID 1000 in cached `node:26.5.0-bookworm` with a private `/tmp` and the worktree's native PTY dependency prepared for that container. Source, lockfiles, hermetic runner and test selection were unchanged during validation; no guard was bypassed or test excluded. Image digest: `sha256:219fc9da91e7f29a9f32290ff598cdf8886fd68f421ff515c8f93434da39a271`.

Local evidence and the exact container command: `/var/tmp/agenc-core-pr-e4b0ecb7-ci-t2qwnumw/evidence.json`. Successful fast log SHA-256: `d1d92874fef673af172934f0698c5376f567ab738b013b46556327c14f788d3e`. Rebase and patch-equivalence evidence: `/var/tmp/agenc-core-rebase-fe80edaf-z3mu43sp/evidence.json`. Focused red/green evidence: `/tmp/agenc-core-managed-outer-retry-evidence.json`.

SonarCloud passed on the final head. The owner requested local CI validation and merge after it passed; no successful Actions execution is claimed. A compatible Core release is required before backend credit usage activation. No live provider calls, releases, deployments or account changes were performed.
