### PR TITLE
fix(runtime): unify prompt command submission transactions

### DIFF
--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -5632,6 +5632,85 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         }
         return null;
       };
+      const submitPromptCommand = async (
+        parsedCommand: NonNullable<ReturnType<typeof parseDollarSkillCommand>>,
+        command: Extract<Command, { type: "prompt" }>,
+        displayText: string,
+      ): Promise<void> => {
+        let admissionLease: {
+          commit(): void;
+          rollback(): boolean;
+        } | null = null;
+        let workbenchLease: { settle(admitted: boolean): void } | null = null;
+        let submitted = false;
+        try {
+          try {
+            setComposerPastedContentsForView(submissionWorkspaceView, {});
+            const loaded = await loadDollarSkillCommandForTurn(
+              parsedCommand,
+              command,
+              getToolUseContext(
+                transcriptMessagesRef.current as any[],
+                [],
+                new AbortController(),
+              ) as PromptInputContext,
+            );
+            const admissionToken = admitPendingInputs([
+              ...(attachmentsMessage !== null ? [attachmentsMessage] : []),
+              loaded.metadata,
+              { content: loaded.blocks },
+            ]);
+            admissionLease = {
+              commit: () => {
+                if (admissionToken !== null) {
+                  props.session.commitIdleInputAdmission?.(admissionToken);
+                }
+              },
+              rollback: () =>
+                admissionToken !== null &&
+                props.session.rollbackIdleInputAdmission?.(admissionToken) ===
+                  true,
+            };
+            startPendingSubmission();
+            const workbenchAdmission = armWorkbenchAttachmentAdmission();
+            workbenchLease = {
+              settle: (admitted) =>
+                settleWorkbenchAttachmentAdmission(workbenchAdmission, admitted),
+            };
+            await submitToSession("", { displayUserMessage: displayText });
+            submitted = true;
+          } finally {
+            try {
+              if (submitted) {
+                admissionLease?.commit();
+              } else if (admissionLease === null || admissionLease.rollback()) {
+                restoreComposerDraftForView(submissionWorkspaceView, {
+                  input: draftRestoreValue,
+                  pastedContents: activePastedContents,
+                });
+              }
+            } finally {
+              workbenchLease?.settle(submitted);
+            }
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          showTransientResult(message, { display: "error" });
+          addNotification({
+            key: "prompt-submit-failed",
+            text: submitted
+              ? `Message sent, but cleanup failed: ${message}`
+              : `Message not sent: ${message}`,
+            color: "error",
+            priority: "immediate",
+            timeoutMs: 10_000,
+            wrap: true,
+          });
+          if (options?.rethrowSubmitError) throw error;
+        } finally {
+          if (!submitted) setPendingSubmission(false);
+        }
+      };
       // Slash-command interception. The daemon-backed TUI does not have
       // any server-side slash-command dispatch — every / input would
       // otherwise be forwarded to the model as plain text and the model
@@ -5659,69 +5738,14 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           slashPromptCommand.userInvocable !== false &&
           isCommandEnabled(slashPromptCommand)
         ) {
-          let inputsAdmitted = false;
-          let admissionToken: string | null = null;
-          let workbenchAdmission: PendingWorkbenchAttachmentAdmission | null =
-            null;
-          try {
-            const loaded = await loadDollarSkillCommandForTurn(
-              {
-                commandName: parsedSlashCommand.name,
-                args: parsedSlashCommand.argsRaw,
-              },
-              slashPromptCommand,
-              getToolUseContext(
-                transcriptMessagesRef.current as any[],
-                [],
-                new AbortController(),
-              ) as PromptInputContext,
-            );
-            const pendingInputs = [
-              ...(attachmentsMessage !== null ? [attachmentsMessage] : []),
-              loaded.metadata,
-              { content: loaded.blocks },
-            ];
-            admissionToken = admitPendingInputs(pendingInputs);
-            inputsAdmitted = true;
-            setComposerPastedContentsForView(submissionWorkspaceView, {});
-            startPendingSubmission();
-            workbenchAdmission = armWorkbenchAttachmentAdmission();
-            await submitToSession("", { displayUserMessage: text_0 });
-            if (admissionToken !== null) {
-              props.session.commitIdleInputAdmission?.(admissionToken);
-            }
-            settleWorkbenchAttachmentAdmission(workbenchAdmission, true);
-          } catch (err_slash_prompt) {
-            settleWorkbenchAttachmentAdmission(workbenchAdmission, false);
-            const message_slash_prompt =
-              err_slash_prompt instanceof Error
-                ? err_slash_prompt.message
-                : String(err_slash_prompt);
-            showTransientResult(message_slash_prompt, { display: "error" });
-            addNotification({
-              key: "prompt-submit-failed",
-              text: `Message not sent: ${message_slash_prompt}`,
-              color: "error",
-              priority: "immediate",
-              timeoutMs: 10_000,
-              // The remediation lives at the tail of these messages
-              // (sandbox setup commands, failing paths); truncating to one
-              // line hides exactly the part the user needs.
-              wrap: true,
-            });
-            setPendingSubmission(false);
-            const rolledBack =
-              admissionToken !== null &&
-              props.session.rollbackIdleInputAdmission?.(admissionToken) ===
-                true;
-            if (!inputsAdmitted || rolledBack) {
-              restoreComposerDraftForView(submissionWorkspaceView, {
-                input: draftRestoreValue,
-                pastedContents: activePastedContents,
-              });
-            }
-            if (options?.rethrowSubmitError) throw err_slash_prompt;
-          }
+          await submitPromptCommand(
+            {
+              commandName: parsedSlashCommand.name,
+              args: parsedSlashCommand.argsRaw,
+            },
+            slashPromptCommand,
+            text_0,
+          );
           return;
         }
         try {
@@ -5857,66 +5881,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           commands as unknown as Command[],
         );
         if (isDollarSkillCommand(command)) {
-          let inputsAdmitted = false;
-          let admissionToken: string | null = null;
-          let workbenchAdmission: PendingWorkbenchAttachmentAdmission | null =
-            null;
-          try {
-            const loaded = await loadDollarSkillCommandForTurn(
-              parsedDollarSkill,
-              command,
-              getToolUseContext(
-                transcriptMessagesRef.current as any[],
-                [],
-                new AbortController(),
-              ) as PromptInputContext,
-            );
-            const pendingInputs = [
-              ...(attachmentsMessage !== null ? [attachmentsMessage] : []),
-              loaded.metadata,
-              { content: loaded.blocks },
-            ];
-            admissionToken = admitPendingInputs(pendingInputs);
-            inputsAdmitted = true;
-            setComposerPastedContentsForView(submissionWorkspaceView, {});
-            startPendingSubmission();
-            workbenchAdmission = armWorkbenchAttachmentAdmission();
-            await submitToSession("", { displayUserMessage: text_0 });
-            if (admissionToken !== null) {
-              props.session.commitIdleInputAdmission?.(admissionToken);
-            }
-            settleWorkbenchAttachmentAdmission(workbenchAdmission, true);
-          } catch (err_1) {
-            settleWorkbenchAttachmentAdmission(workbenchAdmission, false);
-            const message_0 =
-              err_1 instanceof Error ? err_1.message : String(err_1);
-            showTransientResult(message_0, {
-              display: "error",
-            });
-            addNotification({
-              key: "prompt-submit-failed",
-              text: `Message not sent: ${message_0}`,
-              color: "error",
-              priority: "immediate",
-              timeoutMs: 10_000,
-              // The remediation lives at the tail of these messages
-              // (sandbox setup commands, failing paths); truncating to one
-              // line hides exactly the part the user needs.
-              wrap: true,
-            });
-            setPendingSubmission(false);
-            const rolledBack =
-              admissionToken !== null &&
-              props.session.rollbackIdleInputAdmission?.(admissionToken) ===
-                true;
-            if (!inputsAdmitted || rolledBack) {
-              restoreComposerDraftForView(submissionWorkspaceView, {
-                input: draftRestoreValue,
-                pastedContents: activePastedContents,
-              });
-            }
-            if (options?.rethrowSubmitError) throw err_1;
-          }
+          await submitPromptCommand(parsedDollarSkill, command, text_0);
           return;
         }
         if (command?.type === "local") {

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -4598,6 +4598,284 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
     );
   });
 
+  describe.each(["/", "$"])("%s prompt submission transaction", (prefix) => {
+    test.each([
+      "success",
+      "load rejection",
+      "admission rejection",
+      "submit rejection",
+      "cancellation",
+      "late failure",
+      "rollback failure",
+      "commit failure",
+      "acknowledgement failure",
+    ])("settles %s", async (outcome) => {
+      const { AgenCTuiApp } = await import("./App.js");
+      resetShellSurfaceProbe();
+      const input = `${prefix}reviewer audit this`;
+      const events: string[] = [];
+      const subscribers = new Set<(event: unknown) => void>();
+      const failure = new Error(outcome);
+      if (outcome === "cancellation") failure.name = "AbortError";
+      const emitCompletion = () => {
+        for (const subscriber of subscribers) {
+          subscriber({
+            type: "turn_started",
+            payload: { turnId: "prompt-turn" },
+          });
+          subscriber({
+            type: "turn_complete",
+            payload: { turnId: "prompt-turn", lastAgentMessage: "Done" },
+          });
+        }
+      };
+      const getPromptForCommand = vi.fn(async () => {
+        events.push("load");
+        if (outcome === "load rejection") throw failure;
+        return [{ type: "text", text: "expanded reviewer prompt" }];
+      });
+      mockTuiCommandList.push({
+        name: "reviewer",
+        type: "prompt",
+        loadedFrom: "skills",
+        progressMessage: "Loading reviewer",
+        contentLength: 1,
+        getPromptForCommand,
+      });
+      const session = {
+        ...createSession(),
+        enqueueIdleInputBatchOwned: vi.fn(() => {
+          events.push("admit");
+          if (outcome === "admission rejection") throw failure;
+          return {
+            token: "prompt-admission",
+            firstSequence: 1,
+            lastSequence: 3,
+            count: 3,
+          };
+        }),
+        commitIdleInputAdmission: vi.fn(() => {
+          events.push("commit");
+          if (outcome === "commit failure") throw failure;
+          return true;
+        }),
+        rollbackIdleInputAdmission: vi.fn(() => {
+          events.push("rollback");
+          if (outcome === "rollback failure") throw failure;
+          return outcome !== "late failure";
+        }),
+        submit: vi.fn(async () => {
+          events.push("submit");
+          if (outcome === "late failure") emitCompletion();
+          if (
+            outcome === "submit rejection" ||
+            outcome === "cancellation" ||
+            outcome === "late failure" ||
+            outcome === "rollback failure"
+          ) {
+            throw failure;
+          }
+        }),
+        subscribeToEvents: (subscriber: (event: unknown) => void) => {
+          subscribers.add(subscriber);
+          return () => {
+            subscribers.delete(subscriber);
+          };
+        },
+      } satisfies AgenCBridgeSession;
+      const acknowledgeWorkbenchAttachments = vi.fn(() => {
+        events.push("acknowledge");
+        if (outcome === "acknowledgement failure") throw failure;
+      });
+      const helpers = {
+        clearBuffer: vi.fn(),
+        resetHistory: vi.fn(),
+        setCursorOffset: vi.fn(),
+      };
+      const pastedContents = {
+        0: {
+          id: 0,
+          type: "image",
+          content: "base64-image",
+          mediaType: "image/png",
+          filename: "prompt.png",
+        },
+      };
+      await withRenderedApp(
+        <AgenCTuiApp session={session} isInteractive={false} />,
+        async () => {
+          const promptProps = providerProbe.promptProps.at(-1)!;
+          (promptProps.onInputChange as (value: string) => void)(input);
+          (promptProps.setPastedContents as (value: unknown) => void)(
+            pastedContents,
+          );
+          await vi.waitFor(() => {
+            expect(providerProbe.promptProps.at(-1)?.input).toBe(input);
+          });
+          const onSubmit = providerProbe.promptProps.at(-1)?.onSubmit as (
+            input: string,
+            helpers: typeof helpers,
+            speculation: undefined,
+            options: { readonly onWorkbenchAttachmentsAdmitted: () => void },
+          ) => Promise<void>;
+          await expect(
+            onSubmit(input, helpers, undefined, {
+              onWorkbenchAttachmentsAdmitted: acknowledgeWorkbenchAttachments,
+            }),
+          ).resolves.toBeUndefined();
+
+          const accepted = [
+            "success",
+            "commit failure",
+            "acknowledgement failure",
+          ].includes(outcome);
+          const admitted =
+            outcome !== "load rejection" && outcome !== "admission rejection";
+          const restored =
+            !accepted &&
+            outcome !== "late failure" &&
+            outcome !== "rollback failure";
+          expect(getPromptForCommand).toHaveBeenCalledOnce();
+          expect(session.submit).toHaveBeenCalledTimes(admitted ? 1 : 0);
+          if (admitted) {
+            expect(session.enqueueIdleInputBatchOwned).toHaveBeenCalledWith(
+              [
+                expect.objectContaining({ content: expect.any(Array) }),
+                expect.stringContaining("<command-name>$reviewer</command-name>"),
+                { content: [{ type: "text", text: "expanded reviewer prompt" }] },
+              ],
+              { workspaceView: "agent" },
+            );
+            expect(session.submit).toHaveBeenCalledWith("", {
+              displayUserMessage: input,
+            });
+          }
+          expect(session.commitIdleInputAdmission).toHaveBeenCalledTimes(
+            accepted ? 1 : 0,
+          );
+          expect(session.rollbackIdleInputAdmission).toHaveBeenCalledTimes(
+            admitted && !accepted ? 1 : 0,
+          );
+          expect(acknowledgeWorkbenchAttachments).toHaveBeenCalledTimes(
+            accepted || outcome === "late failure" ? 1 : 0,
+          );
+          if (accepted) {
+            expect(events.indexOf("commit")).toBeGreaterThan(
+              events.indexOf("submit"),
+            );
+            expect(events.indexOf("acknowledge")).toBeGreaterThan(
+              events.indexOf("commit"),
+            );
+          }
+          if (outcome !== "success") {
+            await vi.waitFor(() => {
+              expect(
+                JSON.stringify(providerProbe.currentAppState?.notifications),
+              ).toContain(outcome);
+              expect(providerProbe.promptProps.at(-1)).toMatchObject({
+                input: restored ? input : "",
+                pastedContents: restored ? pastedContents : {},
+                ...(!accepted ? { isLoading: false } : {}),
+              });
+            });
+          }
+          emitCompletion();
+          await vi.waitFor(() => {
+            expect(providerProbe.promptProps.at(-1)).toMatchObject({
+              input: restored ? input : "",
+              pastedContents: restored ? pastedContents : {},
+              isLoading: false,
+            });
+          });
+          expect(acknowledgeWorkbenchAttachments).toHaveBeenCalledTimes(
+            accepted || outcome === "late failure" ? 1 : 0,
+          );
+        },
+      );
+    });
+
+    test.each(["success", "failure"])(
+      "preserves a newer draft across delayed load %s",
+      async (outcome) => {
+        const { AgenCTuiApp } = await import("./App.js");
+        resetShellSurfaceProbe();
+        const loaded = Promise.withResolvers<unknown[]>();
+        const getPromptForCommand = vi.fn(() => loaded.promise);
+        mockTuiCommandList.push({
+          name: "reviewer",
+          type: "prompt",
+          loadedFrom: "skills",
+          progressMessage: "Loading reviewer",
+          contentLength: 1,
+          getPromptForCommand,
+        });
+        const session = {
+          ...createSession(),
+          enqueueIdleInput: vi.fn(() => 1),
+          submit: vi.fn(async () => {}),
+        } satisfies AgenCBridgeSession;
+        const helpers = {
+          clearBuffer: vi.fn(),
+          resetHistory: vi.fn(),
+          setCursorOffset: vi.fn(),
+        };
+        const originalAttachment = {
+          0: { id: 0, type: "text", content: "original attachment" },
+        };
+        const nextAttachment = {
+          1: { id: 1, type: "text", content: "new attachment" },
+        };
+        await withRenderedApp(
+          <AgenCTuiApp session={session} isInteractive={false} />,
+          async () => {
+            (providerProbe.promptProps.at(-1)?.setPastedContents as (
+              value: unknown,
+            ) => void)(originalAttachment);
+            await vi.waitFor(() => {
+              expect(providerProbe.promptProps.at(-1)?.pastedContents).toEqual(
+                originalAttachment,
+              );
+            });
+            const pending = providerProbe.promptSubmits.at(-1)!(
+              `${prefix}reviewer audit this`,
+              helpers,
+            );
+            await vi.waitFor(() => {
+              expect(getPromptForCommand).toHaveBeenCalledOnce();
+              expect(providerProbe.promptProps.at(-1)).toMatchObject({
+                input: "",
+                pastedContents: {},
+              });
+            });
+            (providerProbe.promptProps.at(-1)?.onInputChange as (
+              value: string,
+            ) => void)("new draft");
+            (providerProbe.promptProps.at(-1)?.setPastedContents as (
+              value: unknown,
+            ) => void)(nextAttachment);
+            await vi.waitFor(() => {
+              expect(providerProbe.promptProps.at(-1)?.input).toBe("new draft");
+            });
+            if (outcome === "success") {
+              loaded.resolve([{ type: "text", text: "expanded prompt" }]);
+            } else {
+              loaded.reject(new Error("prompt load rejected"));
+            }
+            await pending;
+            await new Promise((resolve) => setTimeout(resolve, 25));
+            expect(providerProbe.promptProps.at(-1)).toMatchObject({
+              input: "new draft",
+              pastedContents: nextAttachment,
+            });
+            expect(session.submit).toHaveBeenCalledTimes(
+              outcome === "success" ? 1 : 0,
+            );
+          },
+        );
+      },
+    );
+  });
+
   test("passes current transcript messages to dollar skill commands", async () => {
     const { AgenCTuiApp } = await import("./App.js");
     resetShellSurfaceProbe();


### PR DESCRIPTION
## Changes

- Route slash prompts and dollar skills through one `submitPromptCommand` transaction. Syntax parsing and command eligibility remain outside the transaction.
- Settle idle-input and workbench attachment leases in `finally`. Commit only after session submission succeeds, and do not roll back accepted input if commit or acknowledgement cleanup throws.
- Clear captured pasted contents before loading so load and admission failures can restore the complete draft. Preserve a newer draft written while a command loads.
- Report cleanup failures separately from rejected submissions. Clear pending state even if rollback or notification handling throws.

## Validation

- `npm run typecheck` passes, including test-support types.
- All 22 paired slash/dollar transaction cases pass. The same tests fail in 12 cases when only the runtime change is reverted to `main`.
- Full local `npm test` passes, including all 22,933 runtime tests in 2,254 files with zero failures or skips.
- `npm run validate:runtime` and `npm run check:agent-surface-contract` pass, including runtime build, real PTY startup at three viewport sizes, and the slash-agents TUI scenario.
- GitNexus reports HIGH upstream risk for the submission callback, with two direct callers in the TUI and workbench. No indexed execution processes are listed. Changes are limited to `App.tsx` and its render tests.
- GitNexus impact and staged change detection completed. Its later index refresh failed with `LOWER: Invalid UTF-8`; both changed files validate as UTF-8. The actual diff was reviewed directly.
- Hosted test CI remains disabled at the repository owner's request. No hosted workflow was enabled, dispatched, or rerun. Windows and macOS native checks are not available on this Linux host.

Closes #1823.
