### PR TITLE
fix(tui): expose task tail errors and polling options

### DIFF
--- a/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
@@ -12,6 +12,8 @@ import { stopWorkbenchTask, workbenchStopActionForTask } from "../tasks/stopActi
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { useTaskTail } from "./useTaskTail.js";
 
+const TAIL_BYTES = 16_000;
+
 export function AgentSurface({ focused }: { readonly focused: boolean }): React.ReactElement {
   const workbench = useWorkbenchState();
   const tasks = useAppState((state) => state.tasks);
@@ -20,7 +22,12 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
     const taskList = orderAgentTasks(Object.values(tasks).filter((item: any) => item.type !== "local_bash"));
     return resolveAgentSelection(taskList, workbench.selectedAgentTaskId).selectedTask;
   }, [tasks, workbench.selectedAgentTaskId]);
-  const tail = useTaskTail(task?.id, task?.status, 16_000);
+  const { content: tail, error } = useTaskTail({
+    taskId: task?.id,
+    status: task?.status,
+    maxBytes: TAIL_BYTES,
+    pollIntervalMs: 1_000,
+  });
 
   useRegisterKeybindingContext("Surface", focused);
   useKeybindings(
@@ -45,6 +52,7 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
       <SurfaceHeader title="AGENT" detail={`${task.status} - ${task.description}`} focused={focused} />
+      {error !== null ? <Text color="error" wrap="truncate-end">Output read failed: {error}</Text> : null}
       <Text wrap="truncate-end">id {task.id}</Text>
       <Text wrap="truncate-end">type {task.type}</Text>
       <Text wrap="truncate-end">elapsed {formatTaskElapsed(task)}</Text>

--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -23,7 +23,12 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
   const task = useMemo(() => {
     return resolveWorkbenchShellTask(tasks, workbench.selectedShellTaskId);
   }, [tasks, workbench.selectedShellTaskId]);
-  const tail = useTaskTail(task?.id, task?.status, TAIL_BYTES);
+  const { content: tail, error } = useTaskTail({
+    taskId: task?.id,
+    status: task?.status,
+    maxBytes: TAIL_BYTES,
+    pollIntervalMs: 1_000,
+  });
 
   const locations = useMemo(() => parseSourceLocations(tail), [tail]);
 
@@ -62,6 +67,7 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
       <SurfaceHeader title="SHELL" detail={`${task.status} - ${task.description ?? task.id}`} focused={focused} />
+      {error !== null ? <Text color="error" wrap="truncate-end">Output read failed: {error}</Text> : null}
       <Text dimColor wrap="truncate-end">
         follow tail on running tasks{stopAction === "local-shell" ? " - x stop" : ""}
       </Text>

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -21,7 +21,12 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   const task = useMemo(() => {
     return resolveWorkbenchShellTask(tasks, workbench.selectedShellTaskId);
   }, [tasks, workbench.selectedShellTaskId]);
-  const tail = useTaskTail(task?.id, task?.status, TAIL_BYTES);
+  const { content: tail, error } = useTaskTail({
+    taskId: task?.id,
+    status: task?.status,
+    maxBytes: TAIL_BYTES,
+    pollIntervalMs: 1_000,
+  });
   const [selected, setSelected] = useState(0);
   const failures = useMemo(() => parseVitestFailures(tail), [tail]);
   const selectedIndex = clampSurfaceSelection(selected, failures.length);
@@ -68,23 +73,26 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
 
   if (!task) return <EmptySurface title="TEST" message="No test task selected" />;
 
-  return <TestSurfaceView failures={failures} selected={selectedIndex} focused={focused} />;
+  return <TestSurfaceView failures={failures} selected={selectedIndex} focused={focused} outputError={error} />;
 }
 
 export function TestSurfaceView({
   failures,
   selected,
   focused,
+  outputError,
 }: {
   readonly failures: readonly ReturnType<typeof parseVitestFailures>[number][];
   readonly selected: number;
   readonly focused: boolean;
+  readonly outputError?: string | null;
 }): React.ReactElement {
   const selectedIndex = clampSurfaceSelection(selected, failures.length);
   const selectedFailure = failures[selectedIndex] ?? null;
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
       <SurfaceHeader title="TEST" detail={`${failures.length} failure${failures.length === 1 ? "" : "s"} - enter edit - o keep focus - @ attach`} focused={focused} />
+      {outputError != null ? <Text color="error" wrap="truncate-end">Output read failed: {outputError}</Text> : null}
       {failures.length === 0 ? (
         <Text dimColor wrap="truncate-end">No parsed test failures in the selected task output.</Text>
       ) : null}

--- a/runtime/src/tui/workbench/surfaces/useTaskTail.ts
+++ b/runtime/src/tui/workbench/surfaces/useTaskTail.ts
@@ -4,21 +4,31 @@ import { tailFile } from "../../../utils/fsOperations.js";
 import { logError } from "../../../utils/log.js";
 import { getTaskOutputPath } from "../../../utils/task/diskOutput.js";
 
+interface TaskTail {
+  readonly content: string;
+  readonly error: string | null;
+}
+
 /** Keep task output visible while a status change triggers its final read. */
-export function useTaskTail(
-  taskId: string | null | undefined,
-  status: string | undefined,
-  maxBytes: number,
-): string {
+export function useTaskTail({
+  taskId,
+  status,
+  maxBytes,
+  pollIntervalMs,
+}: {
+  readonly taskId: string | null | undefined;
+  readonly status: string | undefined;
+  readonly maxBytes: number;
+  readonly pollIntervalMs: number;
+}): TaskTail {
   const [tail, setTail] = useState<{
     readonly taskId: string | null;
-    readonly content: string;
-  }>({ taskId: null, content: "" });
+  } & TaskTail>({ taskId: null, content: "", error: null });
 
   useEffect(() => {
     const id = taskId || null;
     setTail((current) =>
-      current.taskId === id ? current : { taskId: id, content: "" },
+      current.taskId === id ? current : { taskId: id, content: "", error: null },
     );
     if (!id) return;
 
@@ -30,24 +40,33 @@ export function useTaskTail(
       reading = true;
       try {
         const result = await tailFile(getTaskOutputPath(id), maxBytes);
-        if (active) setTail({ taskId: id, content: result.content });
+        if (active) {
+          setTail({ taskId: id, content: result.content, error: null });
+        }
       } catch (error) {
         // Retain the last successful tail after a transient disk failure.
-        if (active) logError(error);
+        if (active) {
+          setTail((current) => ({
+            taskId: id,
+            content: current.taskId === id ? current.content : "",
+            error: error instanceof Error ? error.message : String(error),
+          }));
+          logError(error);
+        }
       } finally {
         reading = false;
       }
     };
 
     void readTail();
-    const timer = status === "running" ? setInterval(readTail, 1_000) : null;
+    const timer = status === "running" ? setInterval(readTail, pollIntervalMs) : null;
     timer?.unref?.();
     return () => {
       active = false;
       if (timer) clearInterval(timer);
     };
-  }, [taskId, status, maxBytes]);
+  }, [taskId, status, maxBytes, pollIntervalMs]);
 
   // Hide a previous task's output during the render before effect cleanup.
-  return tail.taskId === taskId ? tail.content : "";
+  return tail.taskId === taskId ? tail : { content: "", error: null };
 }

--- a/runtime/src/tui/workbench/surfaces/useTaskTail.ts
+++ b/runtime/src/tui/workbench/surfaces/useTaskTail.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { isENOENT } from "../../../utils/errors.js";
 import { tailFile } from "../../../utils/fsOperations.js";
 import { logError } from "../../../utils/log.js";
 import { getTaskOutputPath } from "../../../utils/task/diskOutput.js";
@@ -23,12 +24,15 @@ export function useTaskTail({
 }): TaskTail {
   const [tail, setTail] = useState<{
     readonly taskId: string | null;
-  } & TaskTail>({ taskId: null, content: "", error: null });
+    readonly hasRead: boolean;
+  } & TaskTail>({ taskId: null, content: "", error: null, hasRead: false });
 
   useEffect(() => {
     const id = taskId || null;
     setTail((current) =>
-      current.taskId === id ? current : { taskId: id, content: "", error: null },
+      current.taskId === id
+        ? current
+        : { taskId: id, content: "", error: null, hasRead: false },
     );
     if (!id) return;
 
@@ -41,16 +45,22 @@ export function useTaskTail({
       try {
         const result = await tailFile(getTaskOutputPath(id), maxBytes);
         if (active) {
-          setTail({ taskId: id, content: result.content, error: null });
+          setTail({ taskId: id, content: result.content, error: null, hasRead: true });
         }
       } catch (error) {
         // Retain the last successful tail after a transient disk failure.
         if (active) {
-          setTail((current) => ({
-            taskId: id,
-            content: current.taskId === id ? current.content : "",
-            error: error instanceof Error ? error.message : String(error),
-          }));
+          setTail((current) => {
+            const hasRead = current.taskId === id && current.hasRead;
+            return {
+              taskId: id,
+              content: current.taskId === id ? current.content : "",
+              hasRead,
+              error: isENOENT(error) && !hasRead
+                ? null
+                : error instanceof Error ? error.message : String(error),
+            };
+          });
           logError(error);
         }
       } finally {

--- a/runtime/tests/tui/workbench/agent-surface.test.tsx
+++ b/runtime/tests/tui/workbench/agent-surface.test.tsx
@@ -388,6 +388,7 @@ describe("AgentSurface", () => {
             error.message === "tail failed for agent-1",
         ),
       ).toBe(true);
+      expect(compact(screenText(stdout))).toContain("Outputreadfailed:tailfailedforagent-1");
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -439,6 +439,7 @@ describe("ShellSurface", () => {
 
       expect(compact(screenText(stdout))).toContain("src/current-task.ts:7");
       expect(compact(screenText(stdout))).not.toContain("(nooutput)");
+      expect(compact(screenText(stdout))).toContain("Outputreadfailed:tailfailedforshell-1");
       expect(
         shellHarness.logError.mock.calls.some(
           ([error]) =>

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -576,6 +576,7 @@ describe("TestSurface", () => {
 
       expect(compact(screenText(stdout))).toContain("firstfailure");
       expect(compact(screenText(stdout))).not.toContain("Noparsedtestfailures");
+      expect(compact(screenText(stdout))).toContain("Outputreadfailed:tailfailedforshell-1");
       expect(
         keybindingHarness.logError.mock.calls.some(
           ([error]) =>

--- a/runtime/tests/tui/workbench/use-task-tail.test.tsx
+++ b/runtime/tests/tui/workbench/use-task-tail.test.tsx
@@ -247,6 +247,65 @@ describe("useTaskTail", () => {
     expect(view.frames.at(-1)).toBe("");
   });
 
+  it.each(["running", "completed"])(
+    "treats a missing initial output file as empty for a %s task",
+    async (status) => {
+      const missing = Object.assign(new Error("output is not created"), { code: "ENOENT" });
+      mocks.tailFile.mockRejectedValue(missing);
+      view = await renderTail({ id: "starting", status });
+      await vi.waitFor(() => expect(mocks.logError).toHaveBeenCalledWith(missing));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(view.frames.at(-1)).toBe("");
+      expect(view.errors.at(-1)).toBeNull();
+      if (status === "running") {
+        mocks.tailFile.mockResolvedValue({ content: "first output" });
+        vi.advanceTimersByTime(1_000);
+        await vi.waitFor(() => expect(view!.frames.at(-1)).toBe("first output"));
+        expect(view.errors.at(-1)).toBeNull();
+      } else {
+        vi.advanceTimersByTime(5_000);
+        expect(mocks.tailFile).toHaveBeenCalledTimes(1);
+      }
+    },
+  );
+
+  it.each(["", "retained output"])(
+    "reports a disappeared file after successfully reading %j",
+    async (content) => {
+      const missing = Object.assign(new Error("output disappeared"), { code: "ENOENT" });
+      mocks.tailFile
+        .mockResolvedValueOnce({ content })
+        .mockRejectedValueOnce(missing);
+      view = await renderTail({ id: "task", status: "running" });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mocks.tailFile).toHaveBeenCalledOnce();
+      vi.advanceTimersByTime(1_000);
+      await vi.waitFor(() => expect(view!.errors.at(-1)).toBe(missing.message));
+      expect(view.frames.at(-1)).toBe(content);
+      mocks.tailFile.mockRejectedValueOnce(missing);
+      view.update({ id: "task", status: "completed" });
+      await vi.waitFor(() => expect(mocks.tailFile).toHaveBeenCalledTimes(3));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(view.errors.at(-1)).toBe(missing.message);
+      mocks.tailFile.mockRejectedValueOnce(missing);
+      view.update({ id: "new", status: "completed" });
+      await vi.waitFor(() => expect(mocks.tailFile).toHaveBeenCalledTimes(4));
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(view.errors.at(-1)).toBeNull();
+    },
+  );
+
+  it.each(["EACCES", "EPERM", "EIO"])(
+    "reports an initial %s read error",
+    async (code) => {
+      const error = Object.assign(new Error("output cannot be read"), { code });
+      mocks.tailFile.mockRejectedValue(error);
+      view = await renderTail({ id: "task", status: "running" });
+      await vi.waitFor(() => expect(view!.errors.at(-1)).toBe(error.message));
+      expect(view.frames.at(-1)).toBe("");
+    },
+  );
+
   it("restarts the read and interval when caller limits change", async () => {
     const stale = pendingRead();
     mocks.tailFile

--- a/runtime/tests/tui/workbench/use-task-tail.test.tsx
+++ b/runtime/tests/tui/workbench/use-task-tail.test.tsx
@@ -15,7 +15,12 @@ vi.mock("../../../src/utils/task/diskOutput.js", () => ({
 import { createRoot } from "../../../src/tui/ink.js";
 import { useTaskTail } from "../../../src/tui/workbench/surfaces/useTaskTail.js";
 
-type Selection = { id?: string; status?: string; maxBytes?: number };
+type Selection = {
+  id?: string;
+  status?: string;
+  maxBytes?: number;
+  pollIntervalMs?: number;
+};
 
 function pendingRead() {
   return Promise.withResolvers<{ content: string }>();
@@ -38,8 +43,11 @@ async function renderTail(initial: Selection) {
     stdout: stdout as unknown as NodeJS.WriteStream,
   });
   const frames: string[] = [];
-  function Probe({ id, status, maxBytes = 48_000 }: Selection) {
-    frames.push(useTaskTail(id, status, maxBytes));
+  const errors: Array<string | null> = [];
+  function Probe({ id, status, maxBytes = 48_000, pollIntervalMs = 1_000 }: Selection) {
+    const tail = useTaskTail({ taskId: id, status, maxBytes, pollIntervalMs });
+    frames.push(tail.content);
+    errors.push(tail.error);
     return null;
   }
   const update = (selection: Selection) =>
@@ -47,6 +55,7 @@ async function renderTail(initial: Selection) {
   update(initial);
   return {
     frames,
+    errors,
     update,
     close() {
       root.unmount();
@@ -145,12 +154,14 @@ describe("useTaskTail", () => {
     expect(mocks.tailFile).toHaveBeenCalledTimes(2);
     slow.reject(error);
     await vi.waitFor(() => expect(mocks.logError).toHaveBeenCalledWith(error));
+    await vi.waitFor(() => expect(view!.errors.at(-1)).toBe(error.message));
     expect(view.frames.at(-1)).toBe("last output");
     vi.advanceTimersByTime(1_000);
     await vi.waitFor(() =>
       expect(view!.frames.at(-1)).toBe("recovered output"),
     );
     expect(mocks.tailFile).toHaveBeenCalledTimes(3);
+    expect(view.errors.at(-1)).toBeNull();
   });
 
   it("ignores failures after unmount and cancels polling", async () => {
@@ -183,4 +194,79 @@ describe("useTaskTail", () => {
       expect(mocks.tailFile).toHaveBeenCalledTimes(1);
     },
   );
+
+  it.each(["completed", "failed", "killed"])(
+    "stops custom polling after the final %s read fails",
+    async (status) => {
+      mocks.tailFile.mockResolvedValue({ content: "last good output" });
+      view = await renderTail({ id: "task", status: "running", pollIntervalMs: 250 });
+      await vi.waitFor(() => expect(view!.frames.at(-1)).toBe("last good output"), { interval: 0 });
+      const framesBeforePoll = view.frames.length;
+      vi.advanceTimersByTime(249);
+      expect(mocks.tailFile).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(1);
+      expect(mocks.tailFile).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => expect(view!.frames.length).toBeGreaterThan(framesBeforePoll), { interval: 0 });
+      mocks.tailFile.mockRejectedValueOnce(new Error("final read failed"));
+      view.update({ id: "task", status, pollIntervalMs: 250 });
+      await vi.waitFor(() => expect(view!.errors.at(-1)).toBe("final read failed"), { interval: 0 });
+      expect(view.frames.at(-1)).toBe("last good output");
+      vi.advanceTimersByTime(5_000);
+      expect(mocks.tailFile).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it("clears errors on task changes and ignores stale failures", async () => {
+    const stale = pendingRead();
+    const current = pendingRead();
+    mocks.tailFile
+      .mockRejectedValueOnce("initial read failed")
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(current.promise);
+    view = await renderTail({ id: "old", status: "running" });
+    await vi.waitFor(() => expect(view!.errors.at(-1)).toBe("initial read failed"));
+    expect(view.frames.at(-1)).toBe("");
+    vi.advanceTimersByTime(1_000);
+    const switchFrame = view.frames.length;
+    view.update({ id: "new", status: "completed" });
+    await vi.waitFor(() => expect(mocks.tailFile).toHaveBeenCalledTimes(3));
+    expect(view.errors[switchFrame]).toBeNull();
+    current.resolve({ content: "new output" });
+    await vi.waitFor(() => expect(view!.frames.at(-1)).toBe("new output"));
+    stale.reject(new Error("stale failure"));
+    await stale.promise.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(view.errors.at(-1)).toBeNull();
+    expect(view.frames.at(-1)).toBe("new output");
+    expect(mocks.logError).toHaveBeenCalledTimes(1);
+    mocks.tailFile.mockRejectedValueOnce(new Error("current failure"));
+    view.update({ id: "new", status: "failed" });
+    await vi.waitFor(() => expect(view!.errors.at(-1)).toBe("current failure"));
+    view.update({});
+    await vi.waitFor(() => expect(view!.errors.at(-1)).toBeNull());
+    expect(view.frames.at(-1)).toBe("");
+  });
+
+  it("restarts the read and interval when caller limits change", async () => {
+    const stale = pendingRead();
+    mocks.tailFile
+      .mockResolvedValueOnce({ content: "old limit output" })
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValue({ content: "new limit output" });
+    view = await renderTail({ id: "task", status: "running", maxBytes: 16_000, pollIntervalMs: 500 });
+    await vi.waitFor(() => expect(view!.frames.at(-1)).toBe("old limit output"), { interval: 0 });
+    vi.advanceTimersByTime(500);
+    expect(mocks.tailFile).toHaveBeenCalledTimes(2);
+    view.update({ id: "task", status: "running", maxBytes: 24_000, pollIntervalMs: 250 });
+    await vi.waitFor(() => expect(view!.frames.at(-1)).toBe("new limit output"), { interval: 0 });
+    expect(mocks.tailFile).toHaveBeenLastCalledWith("/tmp/task.log", 24_000);
+    stale.resolve({ content: "stale limit output" });
+    await stale.promise;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(view.frames.at(-1)).toBe("new limit output");
+    vi.advanceTimersByTime(249);
+    expect(mocks.tailFile).toHaveBeenCalledTimes(3);
+    vi.advanceTimersByTime(1);
+    expect(mocks.tailFile).toHaveBeenCalledTimes(4);
+  });
 });


### PR DESCRIPTION
## Changes

- Complete the shared task-tail hook introduced in #2269. Task ID, status, byte limit, and polling interval are named caller inputs.
- Return read errors alongside retained output. Shell, agent, and test surfaces display the error without removing the last successful output or parsed failures.
- Clear errors after a successful read or task switch. Keep the existing final read, stale-result rejection, unmount cleanup, and non-overlapping polling behavior.
- Treat `ENOENT` before the first successful read as output not created yet. After a successful read, including an empty file, a missing file remains observable. Permission and I/O failures are always reported.
- Keep parsing and rendering in each surface. All three callers retain their existing byte limits and one-second intervals.

## Validation

- Root typecheck passes, including test-support types.
- All 1,018 workbench tests in 81 files pass with no failures or skips. Tests cover custom intervals, byte-limit changes, terminal transitions, final-read failures, recovery, task switches, stale promises, and unmount.
- Review regressions cover delayed file creation, empty successful reads, later file deletion, and initial permission/I/O failures. Both missing-initial-file cases fail on the first PR commit.
- All three surface error-display regressions fail against the unchanged runtime on `main` and pass with this change.
- Runtime build, package entrypoint and SDK mirror checks, and all six real PTY startup runs pass.
- GitNexus impact is LOW, with three direct hook callers and no indexed execution processes. The index refresh failure recorded in #2278 remains a tooling limitation; the diff is reviewed directly.
- Hosted test CI remains disabled at the repository owner's request. No hosted test workflow was enabled, dispatched, or rerun. Native Windows and macOS validation is unavailable on this Linux host.

Closes #1824.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workbench TUI output polling only; no auth, data, or core runtime behavior changes beyond clearer error display.
> 
> **Overview**
> **`useTaskTail`** now takes a named options object (`taskId`, `status`, `maxBytes`, **`pollIntervalMs`**) and returns **`{ content, error }`** instead of a bare string. Read failures surface an error message while **keeping the last successful tail**; errors clear on recovery or task switch. **`ENOENT`** before any successful read is treated as “output not created yet” (no UI error); after a read, a missing file is reported, and permission/I/O errors always are.
> 
> **Agent, Shell, and Test** workbench surfaces consume the new shape and show **“Output read failed: …”** without dropping parsed failures or prior output. Tests cover polling intervals, terminal status transitions, stale reads, and the ENOENT edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b816be92b1fd44d027049f39cc61c5729ee1bb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->