### PR TITLE
fix(tui): share validated ripgrep match parsing

### DIFF
--- a/runtime/src/tui/components/GlobalSearchDialog.tsx
+++ b/runtime/src/tui/components/GlobalSearchDialog.tsx
@@ -6,7 +6,11 @@ import { useRegisterOverlay } from '../context/overlayContext';
 import { useTerminalSize } from '../hooks/useTerminalSize';
 import { useOptionalSetAppState } from '../state/AppState.js';
 import { openPreviewCommand } from '../workbench/commands.js';
-import { normalizeWorkspacePathForReferences } from '../workbench/pathReferences.js';
+import {
+  normalizeRipgrepMatchPath,
+  parseRipgrepJsonLine,
+  type RipgrepMatch as Match,
+} from '../search/ripgrep-match.js';
 import { applyWorkbenchCommand, isWorkbenchEnabled } from '../workbench/state.js';
 import { stringWidth } from '../ink/stringWidth.js';
 import { Text } from '../ink.js';
@@ -17,18 +21,14 @@ import { highlightMatch } from '../../utils/highlightMatch';
 import { readFileInRange } from '../../utils/readFileInRange';
 import { ripGrepStream } from '../../utils/ripgrep';
 import { logError } from '../../utils/log';
-import { displayPathRelativeToBase } from '../pathDisplay.js';
+
 import { FuzzyPicker } from './design-system/FuzzyPicker';
 import { LoadingState } from './design-system/LoadingState';
 type Props = {
   onDone: () => void;
   onInsert: (text: string) => void;
 };
-type Match = {
-  file: string;
-  line: number;
-  text: string;
-};
+
 const VISIBLE_RESULTS = 12;
 const DEBOUNCE_MS = 100;
 const PREVIEW_CONTEXT_LINES = 4;
@@ -318,7 +318,7 @@ function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearch
       }
       parsed.push({
         ...m_1,
-        file: normalizeWorkspacePathForReferences(displayPathRelativeToBase(cwd, m_1.file))
+        file: normalizeRipgrepMatchPath(m_1.file, cwd)
       });
     }
     if (!parsed.length) {
@@ -370,45 +370,7 @@ function matchKey(m: Match): string {
   return `${m.file}:${m.line}`;
 }
 
-function stripJsonLineTerminator(text: string): string {
-  if (text.endsWith('\r\n')) return text.slice(0, -2);
-  if (text.endsWith('\n') || text.endsWith('\r')) return text.slice(0, -1);
-  return text;
-}
 
-function parseRipgrepJsonLine(line: string): Match | null {
-  let message: unknown;
-  try {
-    message = JSON.parse(line);
-  } catch {
-    return null;
-  }
-  if (!message || typeof message !== 'object') return null;
-  const typedMessage = message as {
-    type?: unknown;
-    data?: {
-      path?: {
-        text?: unknown;
-      };
-      line_number?: unknown;
-      lines?: {
-        text?: unknown;
-      };
-    };
-  };
-  if (typedMessage.type !== 'match') return null;
-  const file = typedMessage.data?.path?.text;
-  const lineNum = Number(typedMessage.data?.line_number);
-  const text = typedMessage.data?.lines?.text;
-  if (typeof file !== 'string' || !file || !Number.isSafeInteger(lineNum) || lineNum < 1 || typeof text !== 'string') {
-    return null;
-  }
-  return {
-    file,
-    line: lineNum,
-    text: stripJsonLineTerminator(text)
-  };
-}
 
 /**
  * Parse a ripgrep -n --no-heading output line: "path:line:text".

--- a/runtime/src/tui/search/ripgrep-match.ts
+++ b/runtime/src/tui/search/ripgrep-match.ts
@@ -1,0 +1,53 @@
+import { displayPathRelativeToBase } from "../pathDisplay.js";
+import { normalizeWorkspacePathForReferences } from "../workbench/pathReferences.js";
+
+export interface RipgrepMatch {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+}
+
+export function parseRipgrepJsonLine(line: string): RipgrepMatch | null {
+  let message: unknown;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!message || typeof message !== "object") return null;
+  const event = message as {
+    readonly type?: unknown;
+    readonly data?: {
+      readonly path?: { readonly text?: unknown };
+      readonly line_number?: unknown;
+      readonly lines?: { readonly text?: unknown };
+    };
+  };
+  if (event.type !== "match") return null;
+  const file = event.data?.path?.text;
+  const lineNumber = event.data?.line_number;
+  const text = event.data?.lines?.text;
+  if (
+    typeof file !== "string" ||
+    file.length === 0 ||
+    typeof lineNumber !== "number" ||
+    !Number.isSafeInteger(lineNumber) ||
+    lineNumber < 1 ||
+    typeof text !== "string"
+  ) {
+    return null;
+  }
+  return { file, line: lineNumber, text: stripJsonLineTerminator(text) };
+}
+
+function stripJsonLineTerminator(text: string): string {
+  if (text.endsWith("\r\n")) return text.slice(0, -2);
+  if (text.endsWith("\n") || text.endsWith("\r")) return text.slice(0, -1);
+  return text;
+}
+
+export function normalizeRipgrepMatchPath(rawFile: string, cwd: string): string {
+  const file = normalizeWorkspacePathForReferences(rawFile);
+  const base = normalizeWorkspacePathForReferences(cwd);
+  return displayPathRelativeToBase(base, file);
+}

--- a/runtime/src/tui/workbench/search/model.ts
+++ b/runtime/src/tui/workbench/search/model.ts
@@ -1,64 +1,19 @@
-import { relativePath } from "../../../utils/permissions/filesystem.js";
-import { isRelativePathOutsideBase } from "../../pathDisplay.js";
-import { normalizeWorkspacePathForReferences } from "../pathReferences.js";
+import {
+  normalizeRipgrepMatchPath,
+  parseRipgrepJsonLine,
+} from "../../search/ripgrep-match.js";
 import type { SearchGroup, SearchMatch } from "../types.js";
 
 export function parseWorkbenchRipgrepJsonLine(line: string, cwd: string): SearchMatch | null {
-  let message: unknown;
-  try {
-    message = JSON.parse(line);
-  } catch {
-    return null;
-  }
-  if (!message || typeof message !== "object") return null;
-  const typedMessage = message as {
-    readonly type?: unknown;
-    readonly data?: {
-      readonly path?: {
-        readonly text?: unknown;
-      };
-      readonly line_number?: unknown;
-      readonly lines?: {
-        readonly text?: unknown;
-      };
-    };
-  };
-  if (typedMessage.type !== "match") return null;
-  const rawFile = typedMessage.data?.path?.text;
-  const lineNumber = Number(typedMessage.data?.line_number);
-  const text = typedMessage.data?.lines?.text;
-  if (
-    typeof rawFile !== "string" ||
-    !rawFile ||
-    !Number.isSafeInteger(lineNumber) ||
-    lineNumber < 1 ||
-    typeof text !== "string"
-  ) {
-    return null;
-  }
-  const strippedText = stripJsonLineTerminator(text);
-  const file = normalizeWorkbenchSearchPath(rawFile, cwd);
+  const match = parseRipgrepJsonLine(line);
+  if (match === null) return null;
+  const file = normalizeRipgrepMatchPath(match.file, cwd);
   return {
-    id: `${file}:${lineNumber}:${strippedText}`,
+    id: `${file}:${match.line}:${match.text}`,
     file,
-    line: lineNumber,
-    text: strippedText,
+    line: match.line,
+    text: match.text,
   };
-}
-
-function normalizeWorkbenchSearchPath(rawFile: string, cwd: string): string {
-  const rel = isAbsoluteLike(rawFile) ? relativePath(cwd, rawFile) : rawFile;
-  return normalizeWorkspacePathForReferences(isRelativePathOutsideBase(rel) ? rawFile : rel);
-}
-
-function isAbsoluteLike(value: string): boolean {
-  return value.startsWith("/") || /^[A-Za-z]:[\\/]/u.test(value);
-}
-
-function stripJsonLineTerminator(text: string): string {
-  if (text.endsWith("\r\n")) return text.slice(0, -2);
-  if (text.endsWith("\n") || text.endsWith("\r")) return text.slice(0, -1);
-  return text;
 }
 
 export function groupSearchMatches(matches: readonly SearchMatch[]): SearchGroup[] {

--- a/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
@@ -85,6 +85,7 @@ vi.mock('./design-system/FuzzyPicker', () => ({
 import { createRoot } from '../ink/root.js'
 import { renderToString } from '../../utils/staticRender.js'
 import { GlobalSearchDialog } from './GlobalSearchDialog.js'
+import { parseWorkbenchRipgrepJsonLine } from '../../../src/tui/workbench/search/model.js'
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -244,6 +245,60 @@ async function searchFor(query: string, lines: readonly string[]) {
 describe('GlobalSearchDialog render and interactions', () => {
   beforeEach(() => {
     resetHarness()
+  })
+
+  it.each([
+    { cwd: '/repo', rawFile: 'src/app.ts', file: 'src/app.ts' },
+    { cwd: '/repo', rawFile: '/repo/src/../app.ts', file: 'app.ts' },
+    { cwd: '/repo', rawFile: '/repo/..config', file: '..config' },
+    { cwd: '/repo', rawFile: '/outside/app.ts', file: '/outside/app.ts' },
+    { cwd: '/repo', rawFile: '../outside/app.ts', file: '../outside/app.ts' },
+    { cwd: '/repo', rawFile: '/repo', file: '/repo' },
+    { cwd: 'C:/repo', rawFile: 'C:/repo/src/app.ts', file: 'src/app.ts' },
+    { cwd: 'C:\\repo', rawFile: 'C:\\repo\\src\\app.ts', file: 'src/app.ts' },
+    { cwd: 'C:\\repo', rawFile: 'D:\\shared\\app.ts', file: 'D:/shared/app.ts' },
+    { cwd: 'C:/repo', rawFile: 'C:/outside/app.ts', file: 'C:/outside/app.ts' },
+  ])('matches the workbench path policy for $rawFile from $cwd', async ({ cwd, rawFile, file }) => {
+    const previousCwd = harness.cwd
+    harness.cwd = cwd
+    const rendered = await renderDialog()
+    try {
+      const line = jsonMatchLine(rawFile, 9, 'needle\r')
+      await searchFor('needle', [line])
+      await waitFor(() => pickerProps().items.length === 1, 'Search match did not render')
+      expect(pickerProps().items).toEqual([{ file, line: 9, text: 'needle' }])
+      expect(parseWorkbenchRipgrepJsonLine(line, cwd)).toEqual({
+        id: `${file}:9:needle`,
+        file,
+        line: 9,
+        text: 'needle',
+      })
+    } finally {
+      await rendered.dispose()
+      harness.cwd = previousCwd
+    }
+  })
+
+  it('ignores invalid JSON line numbers without losing valid matches', async () => {
+    const rendered = await renderDialog()
+    try {
+      const invalidLines = [true, '12', [12], { toString: 0, valueOf: 0 }].map((lineNumber, index) =>
+        JSON.stringify({
+          type: 'match',
+          data: {
+            path: { text: `invalid-${index}.ts` },
+            line_number: lineNumber,
+            lines: { text: 'needle' },
+          },
+        }),
+      )
+      await searchFor('needle', [jsonMatchLine('valid.ts', 9, 'needle'), ...invalidLines])
+      await waitFor(() => pickerProps().matchLabel === '1 matches', 'Valid match was not retained')
+      expect(pickerProps().items).toEqual([{ file: 'valid.ts', line: 9, text: 'needle' }])
+      expect(harness.logError).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
   })
 
   it('renders the initial picker state and cancel wiring', async () => {

--- a/runtime/tests/tui/search/ripgrep-match.test.ts
+++ b/runtime/tests/tui/search/ripgrep-match.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRipgrepJsonLine } from "../../../src/tui/search/ripgrep-match.js";
+
+describe("shared ripgrep JSON match parser", () => {
+  it.each([
+    { text: "needle", expected: "needle" },
+    { text: "needle\n", expected: "needle" },
+    { text: "needle\r", expected: "needle" },
+    { text: "needle\r\n", expected: "needle" },
+    { text: "first\nsecond\n", expected: "first\nsecond" },
+    { text: "needle\n\n", expected: "needle\n" },
+    { text: "", expected: "" },
+  ])("strips one line terminator from $text", ({ text, expected }) => {
+    expect(parseRipgrepJsonLine(JSON.stringify({
+      type: "match",
+      data: {
+        path: { text: "/workspace/src/topic:12/app.ts" },
+        line_number: 12,
+        lines: { text },
+      },
+    }))).toEqual({
+      file: "/workspace/src/topic:12/app.ts",
+      line: 12,
+      text: expected,
+    });
+  });
+
+  it.each(["not json", "{", "null", "false", "[]", "{}", '{"type":"end"}'])(
+    "ignores malformed or non-match input %s",
+    (line) => expect(parseRipgrepJsonLine(line)).toBeNull(),
+  );
+
+  it.each([
+    { name: "missing data", data: undefined },
+    { name: "null data", data: null },
+    { name: "missing path", data: { line_number: 1, lines: { text: "needle" } } },
+    { name: "empty path", data: { path: { text: "" }, line_number: 1, lines: { text: "needle" } } },
+    { name: "encoded path", data: { path: { bytes: "YQ==" }, line_number: 1, lines: { text: "needle" } } },
+    { name: "invalid text", data: { path: { text: "app.ts" }, line_number: 1, lines: { text: 3 } } },
+  ])("rejects $name", ({ data }) => {
+    expect(parseRipgrepJsonLine(JSON.stringify({ type: "match", data }))).toBeNull();
+  });
+
+  it.each([
+    { name: "missing", value: undefined },
+    { name: "null", value: null },
+    { name: "zero", value: 0 },
+    { name: "negative", value: -1 },
+    { name: "fractional", value: 1.5 },
+    { name: "unsafe integer", value: Number.MAX_SAFE_INTEGER + 1 },
+    { name: "boolean", value: true },
+    { name: "numeric string", value: "1" },
+    { name: "array", value: [1] },
+    { name: "object", value: { toString: 0, valueOf: 0 } },
+  ])("rejects a $name line number", ({ value }) => {
+    expect(parseRipgrepJsonLine(JSON.stringify({
+      type: "match",
+      data: {
+        path: { text: "app.ts" },
+        line_number: value,
+        lines: { text: "needle" },
+      },
+    }))).toBeNull();
+  });
+});

--- a/runtime/tests/tui/workbench/search-model.test.ts
+++ b/runtime/tests/tui/workbench/search-model.test.ts
@@ -83,6 +83,35 @@ describe("workbench search model", () => {
       "match:b:2:z",
     ]);
   });
+
+  it.each([
+    { name: "boolean", value: true },
+    { name: "numeric string", value: "12" },
+    { name: "array", value: [12] },
+    { name: "object", value: { valueOf: 0, toString: 0 } },
+  ])("rejects a $name line number without coercion", ({ value }) => {
+    const line = JSON.stringify({
+      type: "match",
+      data: {
+        path: { text: "src/app.ts" },
+        line_number: value,
+        lines: { text: "needle" },
+      },
+    });
+    expect(parseWorkbenchRipgrepJsonLine(line, "/repo")).toBeNull();
+  });
+
+  it("normalizes Windows separators before making paths workspace-relative", () => {
+    expect(parseWorkbenchRipgrepJsonLine(
+      jsonMatchLine("C:\\repo\\src\\app.ts", 7, "needle"),
+      "C:\\repo",
+    )).toEqual({
+      id: "src/app.ts:7:needle",
+      file: "src/app.ts",
+      line: 7,
+      text: "needle",
+    });
+  });
 });
 
 function jsonMatchLine(file: string, line: number, text: string): string {


### PR DESCRIPTION
## Changes

- Use one pure, typed ripgrep JSON match parser in global search and workbench search. Remove the duplicate event parsers and line-terminator helpers.
- Require positive, safe-integer JSON numbers for line numbers. Invalid strings, booleans, arrays, and objects are ignored without coercion or exceptions.
- Use one workspace path policy in both views. Normalize separators first, display in-workspace absolute paths relatively, retain outside-workspace absolute paths, and preserve relative parent traversal. A path equal to the workspace root stays nonempty.
- Keep workbench IDs, grouping, and global-search deduplication in their existing callers. The legacy non-JSON parser is unchanged.

## Validation

- Root typecheck passes, including test-support types.
- All 79 targeted tests in seven files pass with no failures or skips.
- All 1,053 workbench and shared-search tests in 82 files pass with no failures or skips.
- Five regressions fail on the original workbench parser, covering invalid line-number coercion and Windows separators.
- Paired global/workbench tests compare the same events across POSIX and Windows paths, absolute and relative outside-workspace paths, dot-prefixed names, and CRLF text. Parser tests cover malformed JSON and invalid event fields.
- Runtime build and all six real PTY startup checks pass.
- GitNexus pre-edit impact is LOW, with one direct caller per parser and no indexed execution processes. The index-refresh failure recorded in #2278 remains a tooling limitation; the actual diff is reviewed directly.
- Hosted test CI remains disabled at the repository owner's request. No hosted test workflow was enabled, dispatched, or rerun. Windows path fixtures run locally on Linux; native Windows and macOS coverage is unavailable here.

Closes #1825.
