### PR TITLE
refactor(tui): centralize surface close shortcuts

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -6,7 +6,10 @@ import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContex
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useTerminalSize } from "../../hooks/useTerminalSize.js";
 import type { PendingRequest } from "../../permission-requests.js";
-import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
+import { useSetAppState } from "../../state/AppState.js";
+import { useWorkbenchState } from "../state.js";
+import { useBufferStore } from "../buffer/useBufferStore.js";
+import { bufferKeybindingContext } from "../buffer/keybindingContext.js";
 import { WorkbenchTranscriptLayoutProvider } from "../transcriptLayoutContext.js";
 import type { ActiveSurfaceMode, WorkbenchState } from "../types.js";
 import { AgentSurface } from "./AgentSurface.js";
@@ -23,6 +26,7 @@ import { ShellSurface } from "./ShellSurface.js";
 import { TestSurface } from "./TestSurface.js";
 import { TranscriptSurface } from "./TranscriptSurface.js";
 import type { BufferIntegrationIntent } from "../buffer/providers/types.js";
+import { requestWorkbenchSurfaceClose } from "./closeSurface.js";
 
 export type WorkbenchSurfaceRenderProps = {
   readonly focused: boolean;
@@ -181,17 +185,28 @@ export function ActiveWorkSurface({
   readonly editorStaleAuthorityRecovery?: BufferStaleAuthorityRecoveryUi;
 }): React.ReactElement {
   const workbench = useWorkbenchState();
-  const dispatch = useWorkbenchDispatch();
+  const setAppState = useSetAppState();
+  const buffer = useBufferStore();
   const descriptor = descriptorForSurface(workbench.activeSurfaceMode);
   const { columns } = useTerminalSize();
   const isTranscript = descriptor.mode === "transcript";
   const showSurfaceHeader = columns >= 100 && !isTranscript;
+  const requestClose = (): void => {
+    setAppState((state) => requestWorkbenchSurfaceClose(state).state);
+  };
   useRegisterKeybindingContext("Surface", focused);
   useKeybindings(
     {
-      "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
+      "workbench:closeSurface": requestClose,
     },
     { context: "Surface", isActive: focused && descriptor.mode !== "buffer" },
+  );
+  useKeybindings(
+    {
+      "buffer:close": requestClose,
+      "buffer:closeDiscard": requestClose,
+    },
+    { context: bufferKeybindingContext(buffer), isActive: focused && descriptor.mode === "buffer" },
   );
 
   return (

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -1618,14 +1618,6 @@ export function createBufferSurfaceKeyHandlers({
       if (snapshot.provider.capabilities.terminalUi) return false;
       void store.revert().catch(logError);
     },
-    "buffer:close": () => {
-      dispatch({ type: "closeSurface" });
-    },
-    "buffer:closeDiscard": () => {
-      // Deliberately route through the same reviewed leave transaction. A
-      // single shortcut must never bypass the double-confirmed Discard All.
-      dispatch({ type: "closeSurface" });
-    },
     "buffer:externalEditor": () => {
       if (mutationBlocked) return;
       void store.openExternalEditor().catch(logError);

--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -85,7 +85,6 @@ export function DiffSurface({
         }
         if (selectedFile) setDecisions((prev) => ({ ...prev, [selectedFile.path]: "skip" }));
       },
-      "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
     { context: "Surface", isActive: focused },
   );

--- a/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
@@ -238,7 +238,6 @@ export function PreviewSurface({
       "surface:edit": () => {
         if (activePath) dispatch(openBufferCommand(activePath, startLine + 1, true));
       },
-      "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
     { context: "Surface", isActive: focused },
   );

--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -147,7 +147,6 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
         disablePendingSelectedMatchRestore();
         setSelected((value) => groupStep(groups, matches, value, 1));
       },
-      "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
     { context: "Surface", isActive: focused },
   );

--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -56,7 +56,6 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
       "surface:stop": () => {
         if (task) stopWorkbenchTask(task, setAppState);
       },
-      "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
     { context: "Surface", isActive: focused },
   );

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -66,7 +66,6 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
           }));
         }
       },
-      "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
     { context: "Surface", isActive: focused },
   );

--- a/runtime/src/tui/workbench/surfaces/closeSurface.ts
+++ b/runtime/src/tui/workbench/surfaces/closeSurface.ts
@@ -1,0 +1,16 @@
+import type { AppState } from "../../state/AppStateStore.js";
+import { applyWorkbenchCommand } from "../state.js";
+
+export type SurfaceCloseResult = {
+  readonly status: "closed" | "needs_confirmation" | "blocked";
+  readonly state: AppState;
+};
+
+export function requestWorkbenchSurfaceClose(appState: AppState): SurfaceCloseResult {
+  const state = applyWorkbenchCommand(appState, { type: "closeSurface" });
+  if (state === appState) return { status: "blocked", state };
+  return {
+    status: state.workbench.pendingBlockedOverlay === null ? "closed" : "needs_confirmation",
+    state,
+  };
+}

--- a/runtime/tests/tui/workbench/active-work-surface.test.tsx
+++ b/runtime/tests/tui/workbench/active-work-surface.test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const activeSurfaceHarness = vi.hoisted(() => ({
+  terminalUi: false,
+  dirty: false,
   keybindingCalls: [] as Array<{
     handlers: Record<string, () => void>;
     options?: Record<string, unknown>;
@@ -10,6 +12,19 @@ const activeSurfaceHarness = vi.hoisted(() => ({
     name: string;
     props: Record<string, unknown>;
   }>,
+}));
+
+vi.mock("../../../src/tui/workbench/buffer/providers/BufferProviderController.js", () => ({
+  getWorkbenchBufferProviderController: () => ({
+    getSnapshot: () => ({ dirty: activeSurfaceHarness.dirty }),
+  }),
+}));
+
+vi.mock("../../../src/tui/workbench/buffer/useBufferStore.js", () => ({
+  useBufferStore: () => ({
+    filePath: "target.ts",
+    provider: { capabilities: { terminalUi: activeSurfaceHarness.terminalUi } },
+  }),
 }));
 
 function surfaceMock(
@@ -90,6 +105,13 @@ import {
 import type { ActiveSurfaceMode } from "../../../src/tui/workbench/types.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
+beforeEach(() => {
+  activeSurfaceHarness.terminalUi = false;
+  activeSurfaceHarness.dirty = false;
+  activeSurfaceHarness.keybindingCalls = [];
+  activeSurfaceHarness.renderCalls = [];
+});
+
 describe("ActiveWorkSurface", () => {
   it.each([
     "transcript",
@@ -144,7 +166,7 @@ describe("ActiveWorkSurface", () => {
     }
   });
 
-  it("closes non-buffer surfaces through the surface close keybinding", async () => {
+  it.each(["transcript", "preview", "diff", "shell", "test", "search", "task-detail"] as const)("closes %s through the parent surface close keybinding", async (mode) => {
     activeSurfaceHarness.keybindingCalls = [];
     const changes: AppState[] = [];
 
@@ -154,7 +176,7 @@ describe("ActiveWorkSurface", () => {
           ...getDefaultAppState(),
           workbench: {
             ...getDefaultAppState().workbench,
-            activeSurfaceMode: "preview",
+            activeSurfaceMode: mode,
             focusedPane: "surface",
           },
         }}
@@ -183,6 +205,68 @@ describe("ActiveWorkSurface", () => {
       activeSurfaceMode: "transcript",
       focusedPane: "composer",
     });
+  });
+
+  it.each([
+    [false, "Buffer", "buffer:close", false],
+    [false, "Buffer", "buffer:closeDiscard", false],
+    [true, "BufferHost", "buffer:close", false],
+    [true, "BufferHost", "buffer:closeDiscard", false],
+    [false, "Buffer", "buffer:close", true],
+    [false, "Buffer", "buffer:closeDiscard", true],
+    [true, "BufferHost", "buffer:close", true],
+    [true, "BufferHost", "buffer:closeDiscard", true],
+  ] as const)("owns buffer close with terminalUi=%s in %s for %s and dirty=%s", async (terminalUi, context, action, dirty) => {
+    activeSurfaceHarness.keybindingCalls = [];
+    activeSurfaceHarness.terminalUi = terminalUi;
+    activeSurfaceHarness.dirty = dirty;
+    const changes: AppState[] = [];
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "buffer",
+            focusedPane: "surface",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <ActiveWorkSurface focused transcript={<Text>transcript</Text>} />
+      </AppStateProvider>,
+      100,
+    );
+    const owners = activeSurfaceHarness.keybindingCalls.filter(
+      (call) => call.options?.isActive && call.handlers[action] !== undefined,
+    );
+    expect(owners).toHaveLength(1);
+    expect(owners[0]?.options?.context).toBe(context);
+    owners[0]?.handlers[action]?.();
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.workbench.activeSurfaceMode).toBe(dirty ? "buffer" : "transcript");
+    if (dirty) {
+      expect(changes[0]?.workbench.pendingBlockedOverlay?.deferredCommand).toEqual({
+        type: "closeSurface",
+      });
+    } else {
+      expect(changes[0]?.workbench.pendingBlockedOverlay).toBeNull();
+    }
+  });
+
+  it.each(["preview", "buffer"] as const)("does not register active close handlers for unfocused %s", async (mode) => {
+    await renderToString(
+      <AppStateProvider initialState={{
+        ...getDefaultAppState(),
+        workbench: { ...getDefaultAppState().workbench, activeSurfaceMode: mode },
+      }}>
+        <ActiveWorkSurface focused={false} transcript={<Text>transcript</Text>} />
+      </AppStateProvider>,
+      100,
+    );
+    expect(activeSurfaceHarness.keybindingCalls.every(
+      (call) => call.options?.isActive === false,
+    )).toBe(true);
   });
 
   it("leaves parent surface close keybindings inactive for buffer mode", async () => {

--- a/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface-handlers.test.tsx
@@ -20,6 +20,7 @@ import {
   type BufferTopologyRecoveryUi,
 } from "../../../src/tui/workbench/surfaces/BufferSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
 
 type BufferSnapshot = BufferProviderSnapshot;
 type BufferStoreHarness = ReturnType<typeof createStoreHarness>;
@@ -140,10 +141,15 @@ describe("BufferSurface handlers", () => {
     expect(bufferHarness.store?.requestHover).toHaveBeenCalledTimes(1);
     expect(bufferHarness.store?.goToDefinition).toHaveBeenCalledTimes(1);
 
-    await bufferHarness.handlers["buffer:close"]?.();
-    expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
-
-    await bufferHarness.handlers["buffer:closeDiscard"]?.();
+    expect(bufferHarness.handlers["buffer:close"]).toBeUndefined();
+    expect(bufferHarness.handlers["buffer:closeDiscard"]).toBeUndefined();
+    const state = getDefaultAppState();
+    const closed = requestWorkbenchSurfaceClose({
+      ...state,
+      workbench: { ...state.workbench, activeSurfaceMode: "buffer" },
+    });
+    expect(closed.status).toBe("closed");
+    expect(closed.state.workbench.activeSurfaceMode).toBe("transcript");
     expect(bufferHarness.store?.close).not.toHaveBeenCalled();
 
     bufferHarness.handlers["buffer:up"]?.();
@@ -255,8 +261,7 @@ describe("BufferSurface handlers", () => {
       expect.objectContaining({ message: "open cleanup failed" }),
     );
 
-    bufferHarness.handlers["buffer:closeDiscard"]?.();
-    expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
+    expect(bufferHarness.handlers["buffer:closeDiscard"]).toBeUndefined();
 
     for (const [action, method, message] of [
       ["buffer:save", "save", "save failed"],

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -298,8 +298,8 @@ describe("BufferSurface", () => {
     expect(handlers["workbench:focusRail"]?.()).toBe(false);
     handlers["workbench:toggleFileRail"]?.();
     await handlers["buffer:revert"]?.();
-    await handlers["buffer:close"]?.();
-    await handlers["buffer:closeDiscard"]?.();
+    expect(handlers["buffer:close"]).toBeUndefined();
+    expect(handlers["buffer:closeDiscard"]).toBeUndefined();
     handlers["buffer:externalEditor"]?.();
     handlers["buffer:undo"]?.();
     handlers["buffer:redo"]?.();
@@ -328,13 +328,11 @@ describe("BufferSurface", () => {
     expect(dispatch).toHaveBeenCalledWith({ type: "focus", pane: "agents" });
     expect(dispatch).toHaveBeenCalledWith({ type: "focus", pane: "composer" });
     expect(store.close).not.toHaveBeenCalled();
-    expect(dispatch).toHaveBeenCalledTimes(6);
+    expect(dispatch).toHaveBeenCalledTimes(4);
     expect(dispatch).toHaveBeenNthCalledWith(4, {
       type: "moveFileToRail",
       path: "target.ts",
     });
-    expect(dispatch).toHaveBeenNthCalledWith(5, { type: "closeSurface" });
-    expect(dispatch).toHaveBeenNthCalledWith(6, { type: "closeSurface" });
     expect(store.move).toHaveBeenCalledWith("up");
     expect(store.move).toHaveBeenCalledWith("down");
     expect(store.move).toHaveBeenCalledWith("left");
@@ -387,11 +385,10 @@ describe("BufferSurface", () => {
       hasInFlightAgent: false,
       dispatch: blockedDispatch,
     });
-    await blockedHandlers["buffer:close"]?.();
-    await blockedHandlers["buffer:closeDiscard"]?.();
+    expect(blockedHandlers["buffer:close"]).toBeUndefined();
+    expect(blockedHandlers["buffer:closeDiscard"]).toBeUndefined();
     expect(blockedCloseStore.close).not.toHaveBeenCalled();
-    expect(blockedDispatch).toHaveBeenCalledTimes(2);
-    expect(blockedDispatch).toHaveBeenCalledWith({ type: "closeSurface" });
+    expect(blockedDispatch).not.toHaveBeenCalled();
 
     const panelDispatch = vi.fn();
     const panelHandlers = createBufferSurfaceKeyHandlers({

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -30,6 +30,7 @@ import { createRoot } from "../../../src/tui/ink.js";
 import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
 import { DiffSurface, DiffSurfaceView } from "../../../src/tui/workbench/surfaces/DiffSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
 
 type TestStdin = PassThrough & {
   isTTY: boolean;
@@ -279,7 +280,8 @@ describe("DiffSurface", () => {
       diffHarness.handlers["surface:attach"]?.();
       diffHarness.handlers["surface:open"]?.();
       diffHarness.handlers["surface:top"]?.();
-      diffHarness.handlers["workbench:closeSurface"]?.();
+      expect(diffHarness.handlers["workbench:closeSurface"]).toBeUndefined();
+      const closed = requestWorkbenchSurfaceClose(changes.at(-1)!);
       await sleep();
 
       expect(changes.some((state) =>
@@ -291,7 +293,8 @@ describe("DiffSurface", () => {
         state.workbench?.activeSurfaceMode === "buffer" &&
         state.workbench.activeFilePath === "src/file-00.ts"
       )).toBe(true);
-      expect(changes.at(-1)?.workbench).toMatchObject({
+      expect(closed.status).toBe("closed");
+      expect(closed.state.workbench).toMatchObject({
         activeSurfaceMode: "transcript",
         focusedPane: "composer",
       });

--- a/runtime/tests/tui/workbench/preview-surface-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/preview-surface-interactions.test.tsx
@@ -81,6 +81,7 @@ import {
   useSetAppState,
 } from "../../../src/tui/state/AppState.js";
 import { PreviewSurface } from "../../../src/tui/workbench/surfaces/PreviewSurface.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
 
 type TestStdin = PassThrough & {
   isTTY: boolean;
@@ -439,9 +440,10 @@ describe("PreviewSurface interactions", () => {
         activeFileLine: 2,
       });
 
-      previewHarness.handlers["workbench:closeSurface"]?.();
-      await sleep();
-      expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("preview");
+      expect(previewHarness.handlers["workbench:closeSurface"]).toBeUndefined();
+      const closed = requestWorkbenchSurfaceClose(changes.at(-1)!);
+      expect(closed.status).toBe("closed");
+      expect(closed.state.workbench.activeSurfaceMode).toBe("preview");
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -68,6 +68,7 @@ import {
   SearchSurfaceView,
 } from "../../../src/tui/workbench/surfaces/SearchSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
 
 type TestStdin = PassThrough & {
   isTTY: boolean;
@@ -308,9 +309,14 @@ describe("SearchSurface", () => {
         "Openglobalsearchortypeaqueryfromthecomposer",
       );
 
-      searchHarness.handlers["workbench:closeSurface"]?.();
-
-      expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("transcript");
+      expect(searchHarness.handlers["workbench:closeSurface"]).toBeUndefined();
+      const state = getDefaultAppState();
+      const closed = requestWorkbenchSurfaceClose({
+        ...state,
+        workbench: { ...state.workbench, activeSurfaceMode: "search" },
+      });
+      expect(closed.status).toBe("closed");
+      expect(closed.state.workbench.activeSurfaceMode).toBe("transcript");
     } finally {
       root.unmount();
       stdin.end();
@@ -530,9 +536,10 @@ describe("SearchSurface", () => {
         focusedPane: "surface",
       });
 
-      await press("workbench:closeSurface");
-
-      expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("search");
+      expect(searchHarness.handlers["workbench:closeSurface"]).toBeUndefined();
+      const closed = requestWorkbenchSurfaceClose(changes.at(-1)!);
+      expect(closed.status).toBe("closed");
+      expect(closed.state.workbench.activeSurfaceMode).toBe("search");
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -61,6 +61,7 @@ import {
 } from "../../../src/tui/state/AppState.js";
 import { ShellSurface } from "../../../src/tui/workbench/surfaces/ShellSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
 
 type TestStdin = PassThrough & {
   isTTY: boolean;
@@ -259,8 +260,10 @@ describe("ShellSurface", () => {
     shellHarness.handlers["surface:stop"]?.();
     expect(changes.at(-1)?.tasks["shell-1"]?.status).toBe("killed");
 
-    shellHarness.handlers["workbench:closeSurface"]?.();
-    expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("shell");
+    expect(shellHarness.handlers["workbench:closeSurface"]).toBeUndefined();
+    const closed = requestWorkbenchSurfaceClose(changes.at(-1)!);
+    expect(closed.status).toBe("closed");
+    expect(closed.state.workbench.activeSurfaceMode).toBe("shell");
   });
 
   it("does not dispatch location actions when no shell output location is parsed", async () => {

--- a/runtime/tests/tui/workbench/surface-close.integration.test.tsx
+++ b/runtime/tests/tui/workbench/surface-close.integration.test.tsx
@@ -1,0 +1,133 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createRoot, Text } from "../../../src/tui/ink.js";
+import { KeybindingSetup } from "../../../src/tui/keybindings/KeybindingProviderSetup.js";
+import { useRegisterKeybindingContext } from "../../../src/tui/keybindings/KeybindingContext.js";
+import { useInputCapture } from "../../../src/tui/keybindings/useKeybinding.js";
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { bufferKeybindingContext } from "../../../src/tui/workbench/buffer/keybindingContext.js";
+import {
+  emptyProviderSnapshot,
+  INLINE_BUFFER_CAPABILITIES,
+  NEOVIM_BUFFER_CAPABILITIES,
+} from "../../../src/tui/workbench/buffer/providers/types.js";
+import { ActiveWorkSurface } from "../../../src/tui/workbench/surfaces/ActiveWorkSurface.js";
+
+const closeInput = vi.hoisted(() => ({
+  dirty: false,
+  terminalUi: false,
+  inputs: [] as string[],
+}));
+
+function snapshot() {
+  return {
+    ...emptyProviderSnapshot({
+      kind: closeInput.terminalUi ? "neovim" : "inline",
+      label: "test editor",
+      fallbackReason: null,
+      capabilities: closeInput.terminalUi ? NEOVIM_BUFFER_CAPABILITIES : INLINE_BUFFER_CAPABILITIES,
+    }),
+    filePath: "target.ts",
+    dirty: closeInput.dirty,
+  };
+}
+
+vi.mock("../../../src/tui/workbench/buffer/providers/BufferProviderController.js", () => ({
+  getWorkbenchBufferProviderController: () => ({ getSnapshot: snapshot }),
+}));
+
+vi.mock("../../../src/tui/workbench/buffer/useBufferStore.js", () => ({
+  useBufferStore: snapshot,
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/BufferSurface.js", () => ({
+  BufferSurface: ({ focused }: { readonly focused: boolean }) => {
+    const context = bufferKeybindingContext(snapshot());
+    useRegisterKeybindingContext(context, focused);
+    useInputCapture((input) => {
+      closeInput.inputs.push(input);
+      return true;
+    }, { context, isActive: focused });
+    return <Text>editor</Text>;
+  },
+}));
+
+vi.mock("../../../src/tui/workbench/surfaces/PreviewSurface.js", () => ({
+  PreviewSurface: () => <Text>preview</Text>,
+  EmptySurface: () => null,
+  SurfaceHeader: () => null,
+}));
+
+beforeEach(() => {
+  closeInput.inputs = [];
+  closeInput.dirty = false;
+  closeInput.terminalUi = false;
+});
+
+describe("parent surface close input routing", () => {
+  it.each([
+    ["preview", false, false, ["q"]],
+    ["buffer", false, false, ["\u0018", "q"]],
+    ["buffer", false, true, ["\u0018", "q"]],
+    ["buffer", false, true, ["\u0018", "x"]],
+    ["buffer", true, false, ["\u001bq"]],
+    ["buffer", true, true, ["\u001bq"]],
+  ] as const)("closes %s with terminalUi=%s and dirty=%s", async (mode, terminalUi, dirty, keys) => {
+    closeInput.terminalUi = terminalUi;
+    closeInput.dirty = dirty;
+    const stdin = Object.assign(new PassThrough(), {
+      isTTY: true,
+      setRawMode: () => {},
+      ref: () => {},
+      unref: () => {},
+    });
+    const stdout = Object.assign(new PassThrough(), { columns: 100, rows: 30, isTTY: true });
+    stdout.resume();
+    const root = await createRoot({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+    const changes: AppState[] = [];
+    const initialState = getDefaultAppState();
+    try {
+      root.render(
+        <AppStateProvider initialState={{
+          ...initialState,
+          workbench: { ...initialState.workbench, activeSurfaceMode: mode, focusedPane: "surface" },
+        }} onChangeAppState={({ newState }) => changes.push(newState)}>
+          <KeybindingSetup>
+            <ActiveWorkSurface focused transcript={<Text>transcript</Text>} />
+          </KeybindingSetup>
+        </AppStateProvider>,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      if (mode === "buffer") {
+        stdin.write("q");
+        await vi.waitFor(() => expect(closeInput.inputs).toEqual(["q"]));
+        expect(changes).toHaveLength(0);
+      }
+      for (const key of keys) {
+        stdin.write(key);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      await vi.waitFor(() => expect(changes).toHaveLength(1));
+      expect(changes[0]?.workbench.activeSurfaceMode).toBe(dirty ? "buffer" : "transcript");
+      if (dirty) {
+        expect(changes[0]?.workbench.pendingBlockedOverlay?.deferredCommand).toEqual({
+          type: "closeSurface",
+        });
+      } else {
+        expect(changes[0]?.workbench.pendingBlockedOverlay).toBeNull();
+      }
+      expect(closeInput.inputs).toEqual(mode === "buffer" ? ["q"] : []);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/workbench/surface-close.test.ts
+++ b/runtime/tests/tui/workbench/surface-close.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDefaultAppState, type AppState } from "../../../src/tui/state/AppStateStore.js";
+import { applyWorkbenchCommand } from "../../../src/tui/workbench/state.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
+import type { ActiveSurfaceMode } from "../../../src/tui/workbench/types.js";
+
+const provider = vi.hoisted(() => ({ dirty: false }));
+
+vi.mock("../../../src/tui/workbench/buffer/providers/BufferProviderController.js", () => ({
+  getWorkbenchBufferProviderController: () => ({
+    getSnapshot: () => provider,
+  }),
+}));
+
+beforeEach(() => {
+  provider.dirty = false;
+});
+
+function surfaceState(mode: ActiveSurfaceMode): AppState {
+  const state = getDefaultAppState();
+  return {
+    ...state,
+    workbench: { ...state.workbench, activeSurfaceMode: mode, focusedPane: "surface" },
+  };
+}
+
+describe("workbench close policy", () => {
+  it.each(["transcript", "preview", "diff", "shell", "test", "search", "task-detail", "buffer"] as const)(
+    "closes clean %s without a keybinding",
+    (mode) => {
+      const state = surfaceState(mode);
+      const closed = requestWorkbenchSurfaceClose(state);
+      expect(closed.status).toBe("closed");
+      expect(closed.state.workbench).toMatchObject({
+        activeSurfaceMode: "transcript",
+        focusedPane: "composer",
+        pendingBlockedOverlay: null,
+      });
+      expect(state.workbench.activeSurfaceMode).toBe(mode);
+    },
+  );
+
+  it("requires confirmation using live dirty state and blocks repeated requests", () => {
+    const state = surfaceState("buffer");
+    provider.dirty = true;
+    const pending = requestWorkbenchSurfaceClose(state);
+    expect(pending.status).toBe("needs_confirmation");
+    expect(pending.state.workbench.activeSurfaceMode).toBe("buffer");
+    expect(pending.state.workbench.pendingBlockedOverlay).toMatchObject({
+      requestId: "buffer-dirty-surface-switch",
+      deferredCommand: { type: "closeSurface" },
+    });
+    expect(requestWorkbenchSurfaceClose(pending.state)).toEqual({
+      status: "blocked",
+      state: pending.state,
+    });
+  });
+
+  it("does not bypass a pending unrelated approval", () => {
+    const state = applyWorkbenchCommand(surfaceState("preview"), {
+      type: "blockForApproval",
+      requestId: "approval-1",
+      attemptedAction: "opening a file",
+      deferredCommand: { type: "openSurface", mode: "diff" },
+    });
+    const closed = requestWorkbenchSurfaceClose(state);
+    expect(closed.status).toBe("blocked");
+    expect(closed.state).toBe(state);
+  });
+
+  it("rechecks dirty state before deferred close can complete", () => {
+    provider.dirty = true;
+    const pending = requestWorkbenchSurfaceClose(surfaceState("buffer"));
+    const resolve = {
+      type: "resolveBlockedOverlay",
+      requestId: "buffer-dirty-surface-switch",
+    } as const;
+    expect(applyWorkbenchCommand(pending.state, resolve)).toBe(pending.state);
+    provider.dirty = false;
+    const closed = applyWorkbenchCommand(pending.state, resolve);
+    expect(closed.workbench.activeSurfaceMode).toBe("transcript");
+    expect(closed.workbench.pendingBlockedOverlay).toBeNull();
+  });
+
+  it("allows cancellation without losing the dirty buffer", () => {
+    provider.dirty = true;
+    const pending = requestWorkbenchSurfaceClose(surfaceState("buffer"));
+    const cancelled = applyWorkbenchCommand(pending.state, { type: "clearBlockedOverlay" });
+    expect(cancelled.workbench.activeSurfaceMode).toBe("buffer");
+    expect(cancelled.workbench.pendingBlockedOverlay).toBeNull();
+    expect(requestWorkbenchSurfaceClose(cancelled).status).toBe("needs_confirmation");
+  });
+
+  it("does not demand confirmation for a non-buffer surface with a dirty background buffer", () => {
+    provider.dirty = true;
+    expect(requestWorkbenchSurfaceClose(surfaceState("search")).status).toBe("closed");
+  });
+});

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -62,6 +62,7 @@ import {
   TestSurfaceView,
 } from "../../../src/tui/workbench/surfaces/TestSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
+import { requestWorkbenchSurfaceClose } from "../../../src/tui/workbench/surfaces/closeSurface.js";
 
 type TestStdin = PassThrough & {
   isTTY: boolean;
@@ -205,8 +206,10 @@ describe("TestSurface", () => {
       label: "first failure",
     });
 
-    keybindingHarness.handlers["workbench:closeSurface"]?.();
-    expect(changes.at(-1)?.workbench.activeSurfaceMode).toBe("test");
+    expect(keybindingHarness.handlers["workbench:closeSurface"]).toBeUndefined();
+    const closed = requestWorkbenchSurfaceClose(changes.at(-1)!);
+    expect(closed.status).toBe("closed");
+    expect(closed.state.workbench.activeSurfaceMode).toBe("test");
   });
 
   it("normalizes test failure paths when opening buffers", async () => {


### PR DESCRIPTION
## Changes

- Register every active-surface close shortcut in ActiveWorkSurface. Remove the five duplicate child handlers and move Buffer close/discard shortcuts to the parent.
- Keep separate Surface and Buffer/BufferHost key contexts. Plain q still reaches the editor; the existing Ctrl+X chords and Alt+Q close shortcuts are unchanged.
- Add a typed close request returning closed, needs_confirmation, or blocked. The request calls the existing applyWorkbenchCommand guard, so live dirty-state checks, pending approvals, save/discard confirmation, and deferred replay retain one implementation.
- Make standalone surface tests call the close policy directly. Vim save/quit behavior and the dirty-buffer overlay are unchanged.

## Validation

- Root typecheck passes, including test-support types.
- All 1,052 workbench tests in 82 files pass with no failures or skips.
- Six additional input integration tests pass using the real keybinding resolver and editor input capture. They cover Surface, Buffer, and BufferHost shortcuts, dirty close/discard, and plain q passthrough.
- Four parent-ownership regressions fail against the original runtime.
- Runtime build and all six real PTY startup checks pass.
- The full root test command passes, including 23,026 runtime tests in 2,257 files with no failures or skips. Test-support typecheck also passes after the input tests were added.
- GitNexus pre-edit impact is LOW, with one or two direct callers per changed component/helper and no indexed execution processes. Index refresh still fails with the previously recorded Invalid UTF-8 tooling error. Staged change detection and direct diff review check the modified scope.
- Hosted test CI stays disabled at the repository owner's request. No hosted test workflow was enabled, dispatched, or rerun. Native Windows and macOS checks are unavailable here.

Closes #1826.
