### PR TITLE
fix(commands): share explicit bridge command policy

### DIFF
--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -80,6 +80,30 @@ Sources: `runtime/src/commands/*.ts(x)` modules imported by
 
 ---
 
+## Bridge command policy
+
+`runtime/src/commands/bridge-policy.ts` defines the fixed bridge allowlist
+and the shared `isBridgeSafeCommand` predicate. The CLI, dispatcher, and
+command-object exports use that same predicate. Commands outside the list
+require direct CLI confirmation when `runSlashCommand` receives
+`bridge: true`.
+
+The policy accepts exact canonical names. Raw aliases such as `/reset` for
+`/clear` remain blocked over the bridge. A resolved command object is checked
+by its canonical `name`; its aliases and displayed name cannot grant bridge
+access. Local JSX commands are rejected even when their name is allowlisted.
+Local dispatch without `bridge: true` retains normal alias handling.
+
+Prompt commands are not in the fixed allowlist.
+`isBridgeForwardablePromptCommand` identifies prompt objects for a separate
+prompt-forwarding path. That predicate does not authorize local command
+execution or bypass tool permissions. A parsed name alone never grants
+prompt-forwarding access.
+
+Change the allowlist in the policy module and update the expected names in
+`runtime/tests/commands/bridge-policy.test.ts` when approving another command.
+The adapters and command-object set derive their membership from that list.
+
 ## `/login`
 
 `/login` signs into the AgenC account. The PromptInput footer

--- a/runtime/src/bin/_deps/commands.ts
+++ b/runtime/src/bin/_deps/commands.ts
@@ -21,7 +21,6 @@
 
 import {
   dispatchSlashCommand as realDispatch,
-  isBridgeSafeCommand as realIsBridgeSafe,
   type DispatchOutcome as RealDispatchOutcome,
   type ParsedSlashCommand as RealParsedSlashCommand,
 } from "../../commands/dispatcher.js";
@@ -109,9 +108,7 @@ export function parseSlashCommand(input: string): ParsedSlashLine | null {
 // Bridge-safe allowlist — delegated to the canonical dispatcher.
 // ---------------------------------------------------------------------------
 
-export function isBridgeSafeCommand(name: string): boolean {
-  return realIsBridgeSafe(name);
-}
+export { isBridgeSafeCommand } from "../../commands/dispatcher.js";
 
 // ---------------------------------------------------------------------------
 // Dispatch

--- a/runtime/src/commands.ts
+++ b/runtime/src/commands.ts
@@ -2,6 +2,11 @@ import type * as React from "react";
 import { resolve } from "node:path";
 
 import { buildDefaultRegistry } from "./commands/registry.js";
+import { BRIDGE_SAFE_COMMAND_NAMES } from "./commands/bridge-policy.js";
+export {
+  isBridgeSafeCommand,
+  isBridgeForwardablePromptCommand,
+} from "./commands/bridge-policy.js";
 import type {
   CommandRegistry as SlashCommandRegistry,
   SlashCommand,
@@ -604,16 +609,6 @@ const REMOTE_SAFE_COMMAND_NAMES = new Set([
   "provider",
 ]);
 
-const BRIDGE_SAFE_COMMAND_NAMES = new Set([
-  "clear",
-  "diff",
-  "help",
-  "hello",
-  "model",
-  "provider",
-  "status",
-]);
-
 function commandsForNames(names: ReadonlySet<string>): Set<Command> {
   return new Set(
     [...names]
@@ -669,7 +664,7 @@ export const REMOTE_SAFE_COMMANDS: Set<Command> = new LazyCommandSet(
 );
 
 export const BRIDGE_SAFE_COMMANDS: Set<Command> = new LazyCommandSet(
-  BRIDGE_SAFE_COMMAND_NAMES,
+  new Set(BRIDGE_SAFE_COMMAND_NAMES),
 );
 
 function commandMatchesNameSet(
@@ -687,12 +682,6 @@ export function filterCommandsForRemoteMode(commands: Command[]): Command[] {
   return commands.filter(command =>
     commandMatchesNameSet(command, REMOTE_SAFE_COMMAND_NAMES),
   );
-}
-
-export function isBridgeSafeCommand(cmd: Command): boolean {
-  if (cmd.type === "local-jsx") return false;
-  if (cmd.type === "prompt") return true;
-  return commandMatchesNameSet(cmd, BRIDGE_SAFE_COMMAND_NAMES);
 }
 
 export async function getSkillToolCommands(

--- a/runtime/src/commands/bridge-policy.ts
+++ b/runtime/src/commands/bridge-policy.ts
@@ -1,0 +1,25 @@
+export const BRIDGE_SAFE_COMMAND_NAMES: readonly string[] = Object.freeze([
+  "clear",
+  "diff",
+  "help",
+  "hello",
+  "model",
+  "provider",
+  "status",
+]);
+
+type BridgeCommand = {
+  readonly name: string;
+  readonly type: "local" | "local-jsx" | "prompt";
+};
+
+export function isBridgeSafeCommand(command: string | BridgeCommand): boolean {
+  if (typeof command === "string") {
+    return BRIDGE_SAFE_COMMAND_NAMES.includes(command);
+  }
+  return command.type === "local" && BRIDGE_SAFE_COMMAND_NAMES.includes(command.name);
+}
+
+export function isBridgeForwardablePromptCommand(command: BridgeCommand): boolean {
+  return command.type === "prompt";
+}

--- a/runtime/src/commands/dispatcher.ts
+++ b/runtime/src/commands/dispatcher.ts
@@ -26,6 +26,8 @@
 import { stat } from "node:fs/promises";
 import * as path from "node:path";
 
+export { isBridgeSafeCommand } from "./bridge-policy.js";
+
 import type {
   CommandRegistry,
   SlashCommand,
@@ -286,39 +288,4 @@ async function buildMistypedPathHint(
   } catch {
     return null;
   }
-}
-
-/**
- * Bridge-safe allowlist for remote-origin / daemon-bridged CLI
- * invocations. A "bridge-safe" command is one the daemon can run on
- * behalf of a CLI client without requiring human confirmation: it does
- * not mutate shell state, rewrite config, fork the turn, or exit the
- * process.
- *
- * Commands NOT on this list MUST prompt the user before the bridge
- * forwards them (e.g. `/exit`, `/compact`, `/permissions`, `/config`).
- */
-const BRIDGE_SAFE: ReadonlySet<string> = new Set([
-  "status",
-  "help",
-  "hello",
-  "model",
-  "provider",
-  "clear",
-  "diff",
-]);
-
-/**
- * Bridge-unsafe commands (listed explicitly to make the contract
- * readable; not consulted at runtime — anything outside BRIDGE_SAFE is
- * treated as unsafe).
- */
-// Kept alongside BRIDGE_SAFE to document the contract. Do not export as
-// a negation — checks MUST go through `isBridgeSafeCommand`.
-// (status / help / hello / model / provider / clear / diff) are safe;
-// everything else in the minimal surface requires user confirmation at
-// the bridge.
-
-export function isBridgeSafeCommand(name: string): boolean {
-  return BRIDGE_SAFE.has(name);
 }

--- a/runtime/tests/commands/bridge-policy.test.ts
+++ b/runtime/tests/commands/bridge-policy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BRIDGE_SAFE_COMMAND_NAMES,
+  isBridgeForwardablePromptCommand,
+  isBridgeSafeCommand,
+} from "../../src/commands/bridge-policy.js";
+import {
+  BRIDGE_SAFE_COMMANDS,
+  getCommandsSync,
+  isBridgeSafeCommand as commandObjectPolicy,
+  isBridgeForwardablePromptCommand as commandPromptPolicy,
+} from "../../src/commands.js";
+import { isBridgeSafeCommand as dispatcherPolicy } from "../../src/commands/dispatcher.js";
+import { isBridgeSafeCommand as cliPolicy } from "../../src/bin/slash.js";
+
+describe("bridge command policy contract", () => {
+  it("keeps one frozen list of approved canonical names", () => {
+    expect(BRIDGE_SAFE_COMMAND_NAMES).toEqual([
+      "clear", "diff", "help", "hello", "model", "provider", "status",
+    ]);
+    expect(Object.isFrozen(BRIDGE_SAFE_COMMAND_NAMES)).toBe(true);
+    expect([...BRIDGE_SAFE_COMMANDS].map((command) => command.name).sort()).toEqual(
+      [...BRIDGE_SAFE_COMMAND_NAMES].sort(),
+    );
+  });
+
+  it("exports the same policy through command objects, dispatcher, and CLI", () => {
+    expect(commandObjectPolicy).toBe(isBridgeSafeCommand);
+    expect(dispatcherPolicy).toBe(isBridgeSafeCommand);
+    expect(cliPolicy).toBe(isBridgeSafeCommand);
+    expect(commandPromptPolicy).toBe(isBridgeForwardablePromptCommand);
+  });
+
+  it("keeps every registered command name and command object consistent", () => {
+    for (const command of getCommandsSync()) {
+      const expected = BRIDGE_SAFE_COMMAND_NAMES.includes(command.name);
+      expect(command.type).toBe("local");
+      expect(isBridgeSafeCommand(command)).toBe(expected);
+      expect(cliPolicy(command.name)).toBe(expected);
+      expect(BRIDGE_SAFE_COMMANDS.has(command)).toBe(expected);
+      expect(isBridgeForwardablePromptCommand(command)).toBe(false);
+    }
+  });
+
+  it.each(["reset", "new", "quit", "unknown", "Help", "/help", " help", "help ", ""])(
+    "does not normalize or trust the raw name %j",
+    (name) => {
+      expect(isBridgeSafeCommand(name)).toBe(false);
+      expect(isBridgeSafeCommand({ name, type: "local" })).toBe(false);
+    },
+  );
+
+  it("does not execute display-name callbacks or trust aliases", () => {
+    const command = {
+      type: "local" as const,
+      name: "unsafe",
+      aliases: ["help"],
+      userFacingName: () => { throw new Error("must not run"); },
+    };
+    expect(isBridgeSafeCommand(command)).toBe(false);
+    expect(isBridgeSafeCommand({ ...command, name: "help" })).toBe(true);
+  });
+
+  it.each([...BRIDGE_SAFE_COMMAND_NAMES, "project-skill"])(
+    "keeps prompt forwarding and local JSX separate for %s",
+    (name) => {
+      const prompt = { name, type: "prompt" as const };
+      const localJsx = { name, type: "local-jsx" as const };
+      expect(isBridgeSafeCommand(prompt)).toBe(false);
+      expect(isBridgeSafeCommand(localJsx)).toBe(false);
+      expect(isBridgeForwardablePromptCommand(prompt)).toBe(true);
+      expect(isBridgeForwardablePromptCommand(localJsx)).toBe(false);
+    },
+  );
+});

--- a/runtime/tests/commands/command-surface.test.ts
+++ b/runtime/tests/commands/command-surface.test.ts
@@ -223,6 +223,19 @@ describe("AgenC command surface compatibility", () => {
     expect(isBridgeSafeCommand(byName.get("compact")!)).toBe(false);
   });
 
+  it.each([
+    { aliases: ["help"] },
+    { userFacingName: () => "help" },
+  ])("does not grant bridge safety from display or alias metadata %j", (metadata) => {
+    const unsafe = getCommandsSync().find((command) => command.name === "compact")!;
+    expect(isBridgeSafeCommand({ ...unsafe, ...metadata })).toBe(false);
+  });
+
+  it("keeps prompt forwarding separate from the bridge-safe command allowlist", () => {
+    expect(isBridgeSafeCommand(promptCommand({ name: "project-skill" }))).toBe(false);
+    expect(isBridgeSafeCommand(promptCommand({ name: "help" }))).toBe(false);
+  });
+
   it("keeps custom command providers model-facing without adding TUI slash commands", async () => {
     const unregister = registerCommandProvider(() => [
       promptCommand({ name: "project-skill" }),

--- a/runtime/tests/commands/dispatcher.test.ts
+++ b/runtime/tests/commands/dispatcher.test.ts
@@ -11,6 +11,7 @@ import {
   parseSlashCommand,
 } from "./dispatcher.js";
 import { CommandRegistry } from "./registry.js";
+import { BRIDGE_SAFE_COMMAND_NAMES } from "../../src/commands/bridge-policy.js";
 import type {
   SlashCommand,
   SlashCommandContext,
@@ -240,15 +241,7 @@ describe("maskSensitiveArgs", () => {
 
 describe("isBridgeSafeCommand", () => {
   it("allows known-safe commands", () => {
-    for (const name of [
-      "status",
-      "help",
-      "hello",
-      "model",
-      "provider",
-      "clear",
-      "diff",
-    ]) {
+    for (const name of BRIDGE_SAFE_COMMAND_NAMES) {
       expect(isBridgeSafeCommand(name)).toBe(true);
     }
   });


### PR DESCRIPTION
## Changes

- Put the fixed bridge command names and safety predicate in one dependency-free policy module. The command-object API, dispatcher, and CLI re-export the same function. The compatibility command set derives from the same frozen names.
- Keep the existing CLI allowlist and raw-alias behavior. Command objects must have a canonical allowlisted name and local type; display names and aliases no longer grant access.
- Separate prompt forwarding into isBridgeForwardablePromptCommand. Prompt and local JSX objects are not fixed-allowlist commands, even if their names match. The prompt classifier does not authorize execution or bypass permissions.
- Document alias and prompt behavior. One contract test records the approved names and checks every registered command against all adapters.

## Validation

- All 101 targeted tests in four files pass with no failures or skips.
- Three regressions fail against the original command-object predicate, covering alias/display-name escalation and implicit prompt allowance.
- Root typecheck, runtime build, and all six real PTY startup checks pass.
- The full root test command passes, including 23,050 runtime tests in 2,258 files with no failures or skips.
- GitNexus pre-edit impact is HIGH for the bridge dispatcher and CLI adapter, with one direct caller each and no indexed execution processes. The user was warned before editing. The command-object predicate has no indexed runtime callers. Index refresh still has the previously recorded Invalid UTF-8 tooling failure; staged change detection and direct review check the modified scope.
- Hosted test CI stays disabled at the repository owner's request. No hosted test workflow was enabled, dispatched, or rerun. Native Windows and macOS checks are unavailable here.

Closes #1827.
