### PR TITLE
fix(hooks): unify lifecycle execution and redact skipped labels

### DIFF
--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -119,7 +119,9 @@ runtime options, project trust, and hook effect before anything runs.
 - SDK embedders pass the typed capability explicitly after vetting the
   workspace.
 - AgenC redacts secrets from configured-hook diagnostics where that path is
-  wired (`configured-hooks.ts`).
+  wired (`configured-hooks.ts`). Lifecycle results use the redacted
+  `statusMessage`, or the redacted command when no label is configured.
+  Disabled, bare-mode, and matcher-skipped hooks use the same display label.
 - Outbound skill/session **HTTP hooks** resolve through `ssrfGuardedLookup`
   (`runtime/src/utils/hooks/ssrfGuard.ts`). Private, link-local, CGNAT,
   reserved/docs/benchmark/multicast, and cloud-metadata addresses are

--- a/runtime/src/hooks/configured-hooks.ts
+++ b/runtime/src/hooks/configured-hooks.ts
@@ -910,47 +910,12 @@ export class ConfiguredHooksRuntime {
     };
   }
 
-  /**
-   * Lifecycle-hook wrapper for events whose matcher key is not the
-   * PreCompact/PostCompact `trigger` (SubagentStop matches
-   * agent_type/task_name, SessionEnd matches reason, Notification
-   * matches notification_type). Same run/parse semantics as
-   * `createLifecycleHook`.
-   */
-  private createGenericLifecycleHook<I extends HookInput>(
+  private createGenericLifecycleHook<Input extends HookInput>(
     hook: IndividualHookConfig,
-    matchKey: (input: I) => string,
-  ): (input: I, signal?: AbortSignal) => Promise<HookResult> {
-    return async (input, signal) => {
-      if (
-        this.isExecutionSuppressed() ||
-        !matchesPattern(matchKey(input), hook.matcher)
-      ) {
-        return { succeeded: true, output: "", command: hook.command.command };
-      }
-      const run = await this.runCommandHook(
-        hook,
-        input as unknown as Record<string, unknown>,
-        signal,
-      );
-      const parsed = this.readStructuredOutput(run);
-      const specific = parsed.output;
-      const output =
-        specific?.suppressOutput === true
-          ? ""
-          : run.status === "success"
-            ? run.stdout
-            : run.stderr || run.stdout;
-      return {
-        succeeded:
-          run.status === "success" && specific?.continueProcessing !== false,
-        output,
-        command: hookCommandLabel(hook),
-        ...(specific?.additionalContext !== undefined
-          ? { additionalContexts: [redactSecrets(specific.additionalContext)] }
-          : {}),
-      };
-    };
+    matchKey: (input: Input) => string,
+  ): (input: Input, signal?: AbortSignal) => Promise<HookResult> {
+    return (input, signal) =>
+      this.runLifecycleHook(hook, input, () => matchKey(input), signal);
   }
 
   private createLifecycleHook(
@@ -959,72 +924,47 @@ export class ConfiguredHooksRuntime {
     input: PreCompactHookInput | PostCompactHookInput | SessionStartHookInput,
     signal?: AbortSignal,
   ) => Promise<HookResult> {
-    if (hook.event === "SessionStart") {
-      return this.createSessionStartHook(hook) as (
-        input:
-          PreCompactHookInput | PostCompactHookInput | SessionStartHookInput,
-        signal?: AbortSignal,
-      ) => Promise<HookResult>;
-    }
-    return async (input, signal) => {
-      const matchQuery =
-        input.hook_event_name === "SessionStart" ? input.source : input.trigger;
-      if (
-        this.isExecutionSuppressed() ||
-        !matchesPattern(matchQuery, hook.matcher)
-      ) {
-        return { succeeded: true, output: "", command: hook.command.command };
-      }
-      const run = await this.runCommandHook(
-        hook,
-        input as unknown as Record<string, unknown>,
-        signal,
-      );
-      const parsed = this.readStructuredOutput(run);
-      const specific = parsed.output;
-      const output =
-        specific?.suppressOutput === true
-          ? ""
-          : run.status === "success"
-            ? run.stdout
-            : run.stderr || run.stdout;
-      return {
-        succeeded:
-          run.status === "success" && specific?.continueProcessing !== false,
-        output,
-        command: hookCommandLabel(hook),
-        ...(specific?.additionalContext !== undefined
-          ? { additionalContexts: [redactSecrets(specific.additionalContext)] }
-          : {}),
-      };
-    };
+    return this.createGenericLifecycleHook<
+      PreCompactHookInput | PostCompactHookInput | SessionStartHookInput
+    >(hook, (input) =>
+      input.hook_event_name === "SessionStart" ? input.source : input.trigger,
+    );
   }
 
-  private createSessionStartHook(
+  private async runLifecycleHook(
     hook: IndividualHookConfig,
-  ): (
-    input: SessionStartHookInput,
+    input: HookInput,
+    matchQuery: () => string,
     signal?: AbortSignal,
-  ) => Promise<HookResult> {
-    return async (input, signal) => {
-      if (
-        this.isExecutionSuppressed() ||
-        !matchesPattern(input.source, hook.matcher)
-      ) {
-        return { succeeded: true, output: "", command: hook.command.command };
-      }
-      const run = await this.runCommandHook(
-        hook,
-        sessionStartInput(input, this.opts.cwd),
-        signal,
-      );
-      const parsed =
-        run.status === "success" ? this.readStructuredOutput(run) : undefined;
-      const specific = parsed?.output;
-      const additionalContexts = sessionStartAdditionalContexts(
-        parsed,
-        run.rawStdout,
-      );
+  ): Promise<HookResult> {
+    const command = hookCommandLabel(hook);
+    if (
+      this.isExecutionSuppressed() ||
+      !matchesPattern(matchQuery(), hook.matcher)
+    ) {
+      return { succeeded: true, output: "", command };
+    }
+
+    const isSessionStart = input.hook_event_name === "SessionStart";
+    const run = await this.runCommandHook(
+      hook,
+      isSessionStart ? sessionStartInput(input, this.opts.cwd) : { ...input },
+      signal,
+    );
+    const parsed =
+      isSessionStart && run.status !== "success"
+        ? undefined
+        : this.readStructuredOutput(run);
+    const specific = parsed?.output;
+    const additionalContexts = isSessionStart
+      ? sessionStartAdditionalContexts(parsed, run.rawStdout)
+      : specific?.additionalContext !== undefined
+        ? [redactSecrets(specific.additionalContext)]
+        : [];
+    const contextFields =
+      additionalContexts.length > 0 ? { additionalContexts } : {};
+
+    if (isSessionStart) {
       if (
         run.status === "success" &&
         run.rawStdout.trim().length > 0 &&
@@ -1043,29 +983,38 @@ export class ConfiguredHooksRuntime {
         return {
           succeeded: false,
           output: message,
-          command: hookCommandLabel(hook),
+          command,
           message: {
             type: "hook_stopped_continuation",
             hookEvent: "SessionStart",
-            hookName: hookCommandLabel(hook),
+            hookName: command,
             message,
           },
-          ...(additionalContexts.length > 0 ? { additionalContexts } : {}),
-        };
-      }
-      if (run.status === "success") {
-        return {
-          succeeded: true,
-          output: "",
-          command: hookCommandLabel(hook),
-          ...(additionalContexts.length > 0 ? { additionalContexts } : {}),
+          ...contextFields,
         };
       }
       return {
-        succeeded: false,
-        output: redactSecrets(run.rawStderr.trim() || run.rawStdout.trim()),
-        command: hookCommandLabel(hook),
+        succeeded: run.status === "success",
+        output:
+          run.status === "success"
+            ? ""
+            : redactSecrets(run.rawStderr.trim() || run.rawStdout.trim()),
+        command,
+        ...contextFields,
       };
+    }
+
+    return {
+      succeeded:
+        run.status === "success" && specific?.continueProcessing !== false,
+      output:
+        specific?.suppressOutput === true
+          ? ""
+          : run.status === "success"
+            ? run.stdout
+            : run.stderr || run.stdout,
+      command,
+      ...contextFields,
     };
   }
 

--- a/runtime/tests/hooks/configured-lifecycle.test.ts
+++ b/runtime/tests/hooks/configured-lifecycle.test.ts
@@ -1,0 +1,261 @@
+import { getEventListeners } from "node:events";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConfiguredHooksRuntime, hookDisplayText, type HookInstallTarget } from "../../src/hooks/configured-hooks.js";
+import { createHookExecutionAuthority } from "../../src/hooks/execution-authority.js";
+import { HookEngine } from "../../src/hooks/engine/dispatcher.js";
+import type { HookInput, HookResult } from "../../src/llm/hooks/types.js";
+import { SandboxExecutionBroker } from "../../src/sandbox/execution-broker.js";
+
+const SECRET = "sk-proj-abcdefghijklmnopqrstuvwxyz123456-";
+const commonInput = {
+  session_id: "session-1",
+  transcript_path: "",
+  cwd: process.cwd(),
+  permission_mode: "default",
+};
+const events = [
+  {
+    register: "addPreCompactHook",
+    input: { ...commonInput, hook_event_name: "PreCompact", trigger: "manual", custom_instructions: null },
+    matcher: "manual",
+  },
+  {
+    register: "addPostCompactHook",
+    input: { ...commonInput, hook_event_name: "PostCompact", trigger: "manual", compact_summary: "" },
+    matcher: "manual",
+  },
+  {
+    register: "addSessionStartHook",
+    input: { hook_event_name: "SessionStart", source: "startup" },
+    matcher: "startup",
+  },
+  {
+    register: "addSubagentStopHook",
+    input: { hook_event_name: "SubagentStop", agent_id: "agent-1", task_name: "task", agent_type: "reviewer", outcome: "completed", final_message: "" },
+    matcher: "reviewer",
+  },
+  {
+    register: "addSessionEndHook",
+    input: { hook_event_name: "SessionEnd", reason: "exit" },
+    matcher: "exit",
+  },
+  {
+    register: "addNotificationHook",
+    input: { hook_event_name: "Notification", notification_type: "permission_request", message: "approve" },
+    matcher: "permission_request",
+  },
+] as const satisfies readonly {
+  readonly register: keyof HookInstallTarget;
+  readonly input: HookInput;
+  readonly matcher: string;
+}[];
+
+type LifecycleCallback = (input: HookInput, signal?: AbortSignal) => Promise<HookResult>;
+
+function configuredLifecycle(
+  event: (typeof events)[number],
+  options: {
+    readonly command?: string;
+    readonly matcher?: string;
+    readonly simpleMode?: boolean;
+    readonly trusted?: boolean;
+  } = {},
+) {
+  const runtime = new ConfiguredHooksRuntime({
+    cwd: process.cwd(),
+    env: process.env,
+    agencHome: "/tmp/agenc-lifecycle-tests",
+    shellPath: process.env.SHELL ?? "/bin/sh",
+    admissionRequired: false,
+    executionAuthority: createHookExecutionAuthority({
+      runtimeOptions: { simpleMode: options.simpleMode ?? false, allowUntrustedHooks: false },
+      isWorkspaceTrusted: () => options.trusted ?? true,
+    }),
+    runtimeOptions: { simpleMode: options.simpleMode ?? false },
+    sandboxExecutionBroker: new SandboxExecutionBroker({
+      mode: "danger_full_access",
+      cwd: process.cwd(),
+    }),
+  });
+  let callback: LifecycleCallback | undefined;
+  runtime.attachTarget({
+    preToolUseHooks: [],
+    postToolUseHooks: [],
+    failureToolUseHooks: [],
+    permissionDecisionHooks: [],
+    userPromptSubmitHooks: [],
+    stopHooks: [],
+    stopFailureHooks: [],
+    [event.register]: (hook: LifecycleCallback) => {
+      callback = hook;
+      return () => {};
+    },
+  });
+  runtime.loadForTesting({
+    [event.input.hook_event_name]: [{
+      matcher: options.matcher ?? event.matcher,
+      hooks: [{
+        type: "command",
+        command: options.command ?? `printf '%s' '${SECRET}'`,
+        statusMessage: `lifecycle ${SECRET}`,
+      }],
+    }],
+  });
+  expect(callback).toBeDefined();
+  return {
+    runtime,
+    invoke: (signal?: AbortSignal) => callback!(event.input, signal),
+    label: hookDisplayText(runtime.listHooks()[0]!),
+  };
+}
+
+function jsonCommand(output: unknown): string {
+  return `printf '%s' '${JSON.stringify(output).replace(/'/gu, `'\\''`)}'`;
+}
+
+describe.each(events)("configured lifecycle $input.hook_event_name", (event) => {
+  const sessionStart = event.input.hook_event_name === "SessionStart";
+
+  it.each(["disabled", "bare", "mismatch"] as const)("uses the redacted display label when %s", async (mode) => {
+    const fixture = configuredLifecycle(event, {
+      simpleMode: mode === "bare",
+      ...(mode === "mismatch" ? { matcher: "does-not-match" } : {}),
+    });
+    if (mode === "disabled") fixture.runtime.setDisabled(true);
+    const result = await fixture.invoke();
+    expect(result).toEqual({ succeeded: true, output: "", command: fixture.label });
+    expect(result.command).not.toContain(SECRET);
+    expect(fixture.runtime.latestDiagnostics()).toHaveLength(0);
+  });
+
+  it("converts successful text with redaction", async () => {
+    const fixture = configuredLifecycle(event);
+    const result = await fixture.invoke();
+    expect(result.succeeded).toBe(true);
+    expect(result.command).toBe(fixture.label);
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+    if (sessionStart) {
+      expect(result.output).toBe("");
+      expect(result.additionalContexts).toEqual(["[REDACTED_SECRET]"]);
+    } else {
+      expect(result.output).toBe("[REDACTED_SECRET]");
+      expect(result.additionalContexts).toBeUndefined();
+    }
+    expect(fixture.runtime.latestDiagnostics()[0]?.status).toBe("success");
+  });
+
+  it("suppresses output without losing structured additional context", async () => {
+    const fixture = configuredLifecycle(event, {
+      command: jsonCommand({
+        suppressOutput: true,
+        hookSpecificOutput: { hookEventName: event.input.hook_event_name, additionalContext: SECRET },
+      }),
+    });
+    const result = await fixture.invoke();
+    expect(result).toEqual({
+      succeeded: true,
+      output: "",
+      command: fixture.label,
+      additionalContexts: ["[REDACTED_SECRET]"],
+    });
+  });
+
+  it("preserves stop-processing and context conversion", async () => {
+    const fixture = configuredLifecycle(event, {
+      command: jsonCommand({
+        continue: false,
+        stopReason: "pause",
+        hookSpecificOutput: { hookEventName: event.input.hook_event_name, additionalContext: SECRET },
+      }),
+    });
+    const result = await fixture.invoke();
+    expect(result.succeeded).toBe(false);
+    expect(result.additionalContexts).toEqual(["[REDACTED_SECRET]"]);
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+    if (sessionStart) {
+      expect(result.output).toBe("pause");
+      expect(result.message).toMatchObject({ type: "hook_stopped_continuation", message: "pause" });
+    } else {
+      expect(result.message).toBeUndefined();
+      expect(result.output).toContain('"continue":false');
+    }
+  });
+
+  it.each([1, 2])("reports exit code %i with stderr first", async (exitCode) => {
+    const fixture = configuredLifecycle(event, {
+      command: `printf ignored; printf '%s' '${SECRET}' >&2; exit ${exitCode}`,
+    });
+    const result = await fixture.invoke();
+    expect(result).toEqual({
+      succeeded: false,
+      output: "[REDACTED_SECRET]",
+      command: fixture.label,
+    });
+    expect(fixture.runtime.latestDiagnostics()[0]?.status).toBe(exitCode === 2 ? "blocking" : "non_blocking_error");
+  });
+
+  it("preserves cancellation without executing the command", async () => {
+    const fixture = configuredLifecycle(event);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await fixture.invoke(controller.signal);
+    expect(result).toEqual({ succeeded: false, output: "", command: fixture.label });
+    expect(fixture.runtime.latestDiagnostics()[0]).toMatchObject({
+      status: "skipped",
+      error: "hook aborted",
+    });
+  });
+
+  it("does not execute commands without workspace trust", async () => {
+    const fixture = configuredLifecycle(event, { trusted: false });
+    expect(await fixture.invoke()).toEqual({
+      succeeded: false,
+      output: "",
+      command: fixture.label,
+    });
+    expect(fixture.runtime.latestDiagnostics()).toHaveLength(0);
+  });
+
+  it("cancels a running command without retaining abort listeners", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "agenc-lifecycle-cancel-"));
+    const marker = join(directory, "started");
+    const fixture = configuredLifecycle(event, {
+      command: `printf started > ${JSON.stringify(marker)}; sleep 10`,
+    });
+    const controller = new AbortController();
+    const pending = fixture.invoke(controller.signal);
+    try {
+      await vi.waitFor(() => expect(existsSync(marker)).toBe(true));
+      controller.abort();
+      expect((await pending).succeeded).toBe(false);
+      expect(fixture.runtime.latestDiagnostics()[0]).toMatchObject({
+        status: "skipped",
+        error: "hook aborted",
+      });
+      expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+    } finally {
+      controller.abort();
+      try {
+        await pending;
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("propagates engine failures to the lifecycle dispatcher", async () => {
+    const fixture = configuredLifecycle(event);
+    const error = new Error("hook execution failed");
+    const run = vi.spyOn(HookEngine.prototype, "runCommandHook").mockRejectedValueOnce(error);
+    try {
+      await expect(fixture.invoke()).rejects.toBe(error);
+    } finally {
+      run.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Changes

- Use one lifecycle runner for generic events, compact hooks, and SessionStart. The factories select matcher values; the runner handles suppression, execution, structured output, continuation, display output, and redacted additional context.
- Preserve SessionStart input normalization, plain-stdout context, malformed-output diagnostics, stopped-continuation messages, and failure output. Other events retain their existing output and continuation rules.
- Use the redacted display label for every result, including disabled, bare-mode, and matcher-skipped hooks. Previously those neutral results returned the raw command and could expose embedded secrets.
- Keep cancellation and engine error propagation unchanged. Tool-use and permission hooks are untouched.

## Validation

- All 235 targeted tests in 14 files pass with no failures or skips.
- The new 72-case table covers all six lifecycle events, including suppression, success, exit failures, stop-processing, additional context, pre-aborted and running-command cancellation, untrusted execution, and propagated engine errors.
- Eighteen skipped-label regressions fail against the original runtime.
- Root typecheck, runtime build, and six real PTY startup checks pass.
- The full root test command passes on the clean final commit, including 23,122 runtime tests in 2,259 files with no failures or skips. The earlier pre-commit run hit only the fuzzy benchmark's dirty-production-tree precondition. Final test-support typecheck also passes.
- GitNexus reports HIGH impact for the generic/compact factories and CRITICAL reach for the containing class, including bootstrap flows and five direct class dependents. The user was warned before editing. Changes remain in private lifecycle methods. Index refresh still has the previously recorded Invalid UTF-8 tooling failure; staged change detection and direct diff review check the modified scope.
- Hosted test CI stays disabled at the repository owner's request. No hosted test workflow was enabled, dispatched, or rerun. Native Windows and macOS checks are unavailable here.

Closes #1828.
