### PR TITLE
refactor(mcp): share frozen inert manager factory

### DIFF
--- a/runtime/src/agents/run-agent.ts
+++ b/runtime/src/agents/run-agent.ts
@@ -19,6 +19,7 @@
 
 import { normalize } from "node:path";
 import { LRUCache } from "lru-cache";
+import { createInertMcpManager } from "../mcp-client/inert-manager.js";
 import { createChildAbortController } from "../utils/abortController.js";
 import type {
   LLMChatOptions,
@@ -2877,18 +2878,6 @@ function terminalResultForLiveAgent(live: LiveAgent): ChildRunTerminalResult {
   }
 }
 
-function createInertChildMcpManager(): Session["services"]["mcpManager"] {
-  return {
-    effectiveServers: async () => new Map(),
-    toolPluginProvenance: async () => null,
-    getTools: () => [],
-    getToolsByServer: () => [],
-    getConfiguredServers: () => [],
-    getConnectedServers: () => [],
-    isConnected: () => false,
-  };
-}
-
 function prepareChildSessionAuthority(
   params: RunAgentParams,
 ): ChildSessionAuthority {
@@ -3011,7 +3000,7 @@ function buildChildSession(
       // A child has no independently owned MCP transport in this path. Never
       // retain the parent's manager or its live tool closures under a forked
       // sandbox authority; refresh is deliberately inert and local.
-      mcpManager: createInertChildMcpManager(),
+      mcpManager: createInertMcpManager(),
       lspManager: undefined,
       ...(sandboxExecutionBroker !== undefined
         ? { sandboxExecutionBroker }

--- a/runtime/src/mcp-client/inert-manager.ts
+++ b/runtime/src/mcp-client/inert-manager.ts
@@ -1,0 +1,13 @@
+import type { McpManager } from "../session/session.js";
+
+export function createInertMcpManager(): McpManager {
+  return Object.freeze({
+    effectiveServers: async () => new Map(),
+    toolPluginProvenance: async () => null,
+    getTools: () => [],
+    getToolsByServer: () => [],
+    getConfiguredServers: () => [],
+    getConnectedServers: () => [],
+    isConnected: () => false,
+  });
+}

--- a/runtime/src/session/agenc-delegate.ts
+++ b/runtime/src/session/agenc-delegate.ts
@@ -16,6 +16,7 @@
 
 import { createHash } from "node:crypto";
 
+import { createInertMcpManager } from "../mcp-client/inert-manager.js";
 import type { LLMChatOptions, LLMMessage, LLMProvider } from "../llm/types.js";
 import { STREAM_IDLE_ABORT_REASON } from "../llm/stream-watchdog.js";
 import {
@@ -497,18 +498,6 @@ function createDisabledToolRegistry(): ToolRegistry {
   } as unknown as ToolRegistry;
 }
 
-function createInertDelegateMcpManager(): SessionServices["mcpManager"] {
-  return {
-    effectiveServers: async () => new Map(),
-    toolPluginProvenance: async () => null,
-    getTools: () => [],
-    getToolsByServer: () => [],
-    getConfiguredServers: () => [],
-    getConnectedServers: () => [],
-    isConnected: () => false,
-  };
-}
-
 interface DelegateProviderLease {
   readonly provider: LLMProvider;
   readonly ownedProvider?: LLMProvider;
@@ -679,7 +668,7 @@ function buildChildServices(
     registry: createDisabledToolRegistry(),
     // Review delegates do not own an MCP transport. Keep their service
     // surface inert so refresh/resource operations cannot mutate the parent.
-    mcpManager: createInertDelegateMcpManager(),
+    mcpManager: createInertMcpManager(),
     permissionModeRegistry: new PermissionModeRegistry(
       createEmptyToolPermissionContext(),
     ),

--- a/runtime/tests/agents/run-agent.test.ts
+++ b/runtime/tests/agents/run-agent.test.ts
@@ -987,6 +987,7 @@ describe("runAgent", () => {
       expect(result).toMatchObject({ outcome: "completed" });
       expect(refreshFromAuthority).not.toHaveBeenCalled();
       expect(childServices?.mcpManager).not.toBe(parentMcpManager);
+      expect(Object.isFrozen(childServices?.mcpManager)).toBe(true);
       expect(childServices?.mcpManager.getConnectedServers?.()).toEqual([]);
       expect(childServices?.registry.tools.map((tool) => tool.name)).toEqual([
         "system.echo",

--- a/runtime/tests/mcp-client/inert-manager.test.ts
+++ b/runtime/tests/mcp-client/inert-manager.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { createInertMcpManager } from "../../src/mcp-client/inert-manager.js";
+
+describe("createInertMcpManager", () => {
+  it("returns empty server and tool state without provenance or connections", async () => {
+    const manager = createInertMcpManager();
+
+    expect(await manager.effectiveServers({}, {})).toEqual(new Map());
+    expect(await manager.toolPluginProvenance({})).toBeNull();
+    expect(manager.getTools?.()).toEqual([]);
+    expect(manager.getToolsByServer?.("parent")).toEqual([]);
+    expect(manager.getConfiguredServers?.()).toEqual([]);
+    expect(manager.getConnectedServers?.()).toEqual([]);
+    expect(manager.isConnected?.("parent")).toBe(false);
+    expect(manager.isConnected?.("")).toBe(false);
+  });
+
+  it("creates a frozen manager for each caller", () => {
+    const manager = createInertMcpManager();
+    const otherManager = createInertMcpManager();
+
+    expect(manager).not.toBe(otherManager);
+    expect(Object.isFrozen(manager)).toBe(true);
+    expect(Object.isFrozen(otherManager)).toBe(true);
+    expect(Reflect.set(manager, "isConnected", () => true)).toBe(false);
+    expect(Reflect.set(manager, "callTool", () => undefined)).toBe(false);
+    expect(manager.isConnected?.("parent")).toBe(false);
+    expect(otherManager.isConnected?.("parent")).toBe(false);
+  });
+
+  it("does not expose transport, refresh, resource, or disposal authority", () => {
+    expect(Object.keys(createInertMcpManager()).sort()).toEqual([
+      "effectiveServers",
+      "getConfiguredServers",
+      "getConnectedServers",
+      "getTools",
+      "getToolsByServer",
+      "isConnected",
+      "toolPluginProvenance",
+    ]);
+  });
+
+  it("returns independent maps on every call", async () => {
+    const manager = createInertMcpManager();
+    const otherManager = createInertMcpManager();
+    const servers = await manager.effectiveServers({}, {});
+    const nextServers = await manager.effectiveServers({}, {});
+    const otherServers = await otherManager.effectiveServers({}, {});
+
+    expect(servers).not.toBe(nextServers);
+    expect(servers).not.toBe(otherServers);
+    servers.set("parent", { enabled: true, required: false });
+    expect(nextServers.size).toBe(0);
+    expect(otherServers.size).toBe(0);
+    expect(await manager.effectiveServers({}, {})).toEqual(new Map());
+  });
+
+  it.each([
+    "getTools",
+    "getToolsByServer",
+    "getConfiguredServers",
+    "getConnectedServers",
+  ] as const)("returns independent arrays from %s", (method) => {
+    const manager = createInertMcpManager();
+    const otherManager = createInertMcpManager();
+    const values = manager[method]?.("parent");
+    const nextValues = manager[method]?.("parent");
+    const otherValues = otherManager[method]?.("parent");
+
+    expect(values).toEqual([]);
+    expect(values).not.toBe(nextValues);
+    expect(values).not.toBe(otherValues);
+    Object.defineProperty(values, "0", { value: "parent" });
+    expect(nextValues).toEqual([]);
+    expect(otherValues).toEqual([]);
+    expect(manager[method]?.("parent")).toEqual([]);
+  });
+});

--- a/runtime/tests/session/agenc-delegate.test.ts
+++ b/runtime/tests/session/agenc-delegate.test.ts
@@ -1071,6 +1071,7 @@ describe("runAgenCReviewOneShot happy-path review", () => {
     );
 
     expect(thread.childSession.services.mcpManager).not.toBe(parentMcpManager);
+    expect(Object.isFrozen(thread.childSession.services.mcpManager)).toBe(true);
     expect(thread.childSession.services.mcpManager.getTools?.()).toEqual([]);
     expect(thread.childSession.services.registry.tools).toEqual([]);
     expect(


### PR DESCRIPTION
## Changes

- Replace the duplicate child-agent and review-delegate inert MCP managers with one factory typed as the full `McpManager` interface.
- Return a frozen manager for each caller and fresh maps and arrays for every query. No parent transport, refresh, resource, or disposal authority is exposed.
- Add contract tests for empty state, provenance, connectivity, immutability, and result isolation. Both existing child-session integration tests now check that their manager is frozen.

Closes #1829.

## Local verification

- Both integration regressions fail against the original implementations.
- Targeted agent, delegate, and MCP tests pass, 407 tests across 23 files.
- Runtime and test-support typechecks pass.
- Build and all six PTY startup checks pass.
- The full local root `npm test` passes from the clean final commit, including 23,130 runtime tests across 2,260 files with zero failures or skips.
- GitNexus pre-edit impact is LOW, with one direct caller per factory and child-agent/delegate startup flows affected. Staged change detection reports the two expected caller functions across six files. Index refresh has failed with an invalid UTF-8 diagnostic and an allocator crash, so the source diff was also reviewed directly.
- Hosted test CI remains disabled by explicit user instruction. No hosted tests were dispatched.

## Review

Cursor approved final commit `c23085bf4ff4bf13fbd68eea0baadbb697db6381`. Bugbot, the security reviewer, and Sonar checks pass with no findings.
