### PR TITLE
fix(runtime): persist cron delivery retries per destination

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -267,6 +267,15 @@ is up (`startCronDelivery`), not from a daemon restart alone. Isolated session
 key `cron|default|<id>`. Permissions denied. Scan cap 5 minutes. Spend rides the same
 budget envelope as other autonomous surfaces.
 
+The gateway persists completed model results and per-destination retry state
+in the task file before delivery. Failed destinations retry with bounded
+backoff without repeating the model turn or a destination already marked
+delivered. One-shots are removed and recurring tasks advance only after all
+destinations acknowledge delivery. Exhausted failures remain visible in the
+outbox for operator action. External delivery is at-least-once across the
+acknowledgment/local-commit crash window unless the receiver deduplicates the
+stable delivery key.
+
 Webhook POST is **address-pinned**: the gateway resolves the host once, dials
 that exact IP, and keeps the original hostname on `Host` / TLS SNI. http(s)
 only; URL credentials, `localhost` / `*.localhost`, loopback, private,

--- a/docs/reference/autonomy.md
+++ b/docs/reference/autonomy.md
@@ -199,8 +199,8 @@ so a fire is never double-run.
 - Sleep until earliest due time, with scan cap **5 minutes**
   (`CRON_DELIVERY_SCAN_CAP_MS`) so tasks added by other processes are noticed.
 - Source file: workspace **`.agenc/scheduled_tasks.json`**.
-- Past-due schedules coalesce to **one** fire; stamps `lastFiredAt` / removes
-  one-shots.
+- Past-due schedules coalesce to one occurrence. The task advances or is
+  removed only after every configured destination acknowledges delivery.
 - Delivery-routed jobs (`announceChannel` / `announceTo` / `webhook` on
   CronCreate) are **always durable** and run only while
   **`agenc gateway run`** is up (`startCronDelivery`). A daemon restart
@@ -210,14 +210,75 @@ so a fire is never double-run.
 
 ### Per fire
 
-1. Resolve channel adapter and/or webhook from `task.deliver`.
-2. `SessionRouter.runTurn` on an unattended daemon session with permission
-   requests **denied**.
-3. Model/tool calls reserve and reconcile through daemon execution admission.
-   On denial: log + optional channel pause notice.
-4. On a successful turn, optionally POST the result JSON to
-   `deliver.webhook`. A webhook failure is **logged and does not retry**
-   the turn; the fire is still stamped.
+1. Claim the task ID and computed occurrence time under a local process lock.
+   A persisted 60-second lease delays recovery after a process crash. The
+   process lock prevents overlapping execution even if a live turn outlasts
+   its lease.
+2. Run `SessionRouter.runTurn` with permission requests denied and channel
+   streaming disabled. Model and tool calls still use daemon admission.
+3. Only a `completed` result with a string `finalMessage` is deliverable.
+   Persist its payload before sending to any destination. Admission refusal,
+   thrown errors, `errored`, and `stopped` results remain retryable. An
+   unsupported result or oversized payload requires operator action.
+4. Track channel and webhook attempts separately. Missing adapters and
+   webhook transport, HTTP, timeout, or redirect failures remain failures.
+   Retry only failed destinations, using the saved result without another
+   model turn. An admission refusal can also send a short pause notice.
+5. Persist each destination acknowledgment. Once all destinations are
+   delivered, remove the one-shot or update the recurring task's `lastFiredAt`
+   in the same atomic file replacement that completes the outbox record.
+
+Retries use persisted exponential backoff with deterministic jitter. The
+base delay is 30 seconds, jitter ranges from 75% to 125%, and the final delay
+is capped at five minutes. Each model or destination phase has at most ten
+attempts. Exhausted failures remain in the task file and do not advance the
+schedule. Completed recurring occurrences coalesce missed slots through the
+completion time.
+
+If the gateway dies before committing a model result, recovery may run that
+model phase again. The daemon interface does not provide an exactly-once
+turn key. Once the result is committed, delivery retries never rerun the model.
+
+The gateway sends a stable destination key in webhook `Idempotency-Key`
+headers and in channel messages. Discord converts that key into a distinct
+nonce for each text chunk and requests nonce deduplication. Discord's
+deduplication window lasts only a few minutes. Other adapters and webhook
+receivers may not support deduplication. Delivery remains at-least-once when
+a process crashes after an external acknowledgment but before recording it
+locally, or when the receiver's deduplication window expires.
+[Discord message API](https://docs.discord.com/developers/resources/message)
+documents that limitation.
+
+### Delivery state and recovery
+
+The versioned `deliveryOutbox` field shares `.agenc/scheduled_tasks.json`
+with the task list. Updates use the repository's local SQLite process lock
+and durable atomic file writer. The file is private (`0600` on POSIX), and
+its directory chain must not permit untrusted writes. Stop writers and fix
+directory permissions if the gateway reports that storage is unavailable.
+
+Payloads are limited to 64 KiB, the file to 16 MiB, and the outbox to 128
+records. Stored errors are fixed classifications, not raw exceptions.
+Completed records can be discarded to make space; unresolved records are
+never discarded automatically. Inspect status without printing saved prompts
+or results:
+
+```sh
+jq '.deliveryOutbox.occurrences[] | {taskId, key, model, channel, webhook, blockedReason, completedAt}' \
+  .agenc/scheduled_tasks.json
+```
+
+Fix a retryable destination and let its next attempt run. For a terminal
+failure, preserve the private file before canceling the task with `CronDelete`
+and creating a replacement. Recreate only the failed destination if another
+destination already received the result. Deleting a task cancels pending
+work; an external request already in flight cannot be recalled.
+Changing a task while its occurrence is pending blocks that occurrence with
+`task_changed`, preserving its existing delivery acknowledgments.
+
+Stop old gateways and cron writers before upgrading or rolling back. Older
+binaries can discard outbox fields when rewriting the task file. Preserve
+pending records during rollback rather than replaying successful destinations.
 
 `isRunning()` is exposed so heartbeat can defer while a cron delivery turn is
 in flight.

--- a/docs/reference/autonomy.md
+++ b/docs/reference/autonomy.md
@@ -228,7 +228,9 @@ so a fire is never double-run.
    delivered, remove the one-shot or update the recurring task's `lastFiredAt`
    in the same atomic file replacement that completes the outbox record.
 
-Retries use persisted exponential backoff with deterministic jitter. The
+Retries use persisted exponential backoff with deterministic jitter, measured
+from when a failure finishes. An interrupted attempt also has a retry deadline
+recorded before execution so a process crash preserves its retry state. The
 base delay is 30 seconds, jitter ranges from 75% to 125%, and the final delay
 is capped at five minutes. Each model or destination phase has at most ten
 attempts. Exhausted failures remain in the task file and do not advance the

--- a/docs/reference/autonomy.md
+++ b/docs/reference/autonomy.md
@@ -223,7 +223,10 @@ so a fire is never double-run.
 4. Track channel and webhook attempts separately. Missing adapters and
    webhook transport, HTTP, timeout, or redirect failures remain failures.
    Retry only failed destinations, using the saved result without another
-   model turn. An admission refusal can also send a short pause notice.
+   model turn. An admission refusal can also attempt one short pause notice
+   per occurrence, with its own stable idempotency key. The notice attempt
+   is recorded before sending and is not retried, including after a crash
+   or notice transport failure. Result delivery retries remain independent.
 5. Persist each destination acknowledgment. Once all destinations are
    delivered, remove the one-shot or update the recurring task's `lastFiredAt`
    in the same atomic file replacement that completes the outbox record.
@@ -266,7 +269,7 @@ never discarded automatically. Inspect status without printing saved prompts
 or results:
 
 ```sh
-jq '.deliveryOutbox.occurrences[] | {taskId, key, model, channel, webhook, blockedReason, completedAt}' \
+jq '.deliveryOutbox.occurrences[] | {taskId, key, model, channel, webhook, admissionNoticeAttemptedAt, blockedReason, completedAt}' \
   .agenc/scheduled_tasks.json
 ```
 

--- a/runtime/src/gateway/cron-delivery.ts
+++ b/runtime/src/gateway/cron-delivery.ts
@@ -455,12 +455,19 @@ export function startCronDelivery(
           deliver.channel !== undefined && deliver.to !== undefined
         ) {
           const adapter = adaptersById.get(deliver.channel);
+          if (
+            adapter === undefined ||
+            !(await outbox.beginAdmissionNotice(claim, now())) || stopped
+          ) return;
           const reason = executionAdmissionErrorMessage(error).includes("budget_exceeded")
             ? "budget_exceeded"
             : "admission_denied";
-          await adapter?.send({
+          await adapter.send({
             conversationId: deliver.to,
             text: "⏸ cron task " + task.id + " paused: " + reason,
+            idempotencyKey: createHash("sha256")
+              .update(claim.key + ":admission-notice")
+              .digest("hex"),
           }).catch(() => log("cron: admission pause notice failed"));
         }
         return;

--- a/runtime/src/gateway/cron-delivery.ts
+++ b/runtime/src/gateway/cron-delivery.ts
@@ -445,7 +445,7 @@ export function startCronDelivery(
       } catch (error) {
         const admission = isExecutionAdmissionDenied(error);
         const errorClass = admission ? "admission_pause" : "turn_error";
-        const status = await outbox.failAttempt(claim, "model", errorClass);
+        const status = await outbox.failAttempt(claim, "model", errorClass, now());
         const action = status === "terminal"
           ? " requires operator action"
           : " retry pending";
@@ -472,13 +472,13 @@ export function startCronDelivery(
             ? "turn_stopped"
             : "unsupported_result";
         await outbox.failAttempt(
-          claim, "model", errorClass, errorClass === "unsupported_result",
+          claim, "model", errorClass, now(), errorClass === "unsupported_result",
         );
         log("cron: task " + JSON.stringify(task.id) + " result not deliverable (" + errorClass + ")");
         return;
       }
       if (typeof result.finalMessage !== "string") {
-        await outbox.failAttempt(claim, "model", "unsupported_result", true);
+        await outbox.failAttempt(claim, "model", "unsupported_result", now(), true);
         return;
       }
       const completedPayload: CronDeliveryPayload = {
@@ -494,7 +494,7 @@ export function startCronDelivery(
         Buffer.byteLength(JSON.stringify(completedPayload), "utf8") >
         MAX_CRON_PAYLOAD_BYTES
       ) {
-        await outbox.failAttempt(claim, "model", "payload_too_large", true);
+        await outbox.failAttempt(claim, "model", "payload_too_large", now(), true);
         log("cron: task " + JSON.stringify(task.id) + " requires operator action (payload_too_large)");
         return;
       }
@@ -518,7 +518,7 @@ export function startCronDelivery(
             : adaptersById.get(deliver.channel);
           if (adapter === undefined || deliver.to === undefined) {
             const status = await outbox.failAttempt(
-              claim, phase, "missing_adapter",
+              claim, phase, "missing_adapter", now(),
             );
             const action = status === "terminal"
               ? "requires operator action"
@@ -537,7 +537,7 @@ export function startCronDelivery(
         }
       } catch {
         const status = await outbox.failAttempt(
-          claim, phase, phase === "channel" ? "channel_error" : "webhook_error",
+          claim, phase, phase === "channel" ? "channel_error" : "webhook_error", now(),
         );
         const action = status === "terminal"
           ? " requires operator action"

--- a/runtime/src/gateway/cron-delivery.ts
+++ b/runtime/src/gateway/cron-delivery.ts
@@ -1,29 +1,18 @@
 /**
- * Gateway cron delivery (TODO task 16).
+ * Durable gateway delivery for scheduled prompts.
  *
- * Runs delivery-tagged cron tasks (`CronTask.deliver` set) in ISOLATED
- * gateway daemon sessions — heartbeat parity — and routes each result to a
- * channel adapter and/or a webhook POST. The in-session cron scheduler skips
- * these tasks (cronScheduler loadRunnableTasks), so the gateway is their
- * exclusive executor and a fire is never double-run.
- *
- * Scheduling: sleep-until-earliest-due with a scan cap. Every wake re-reads
- * `.agenc/scheduled_tasks.json` (cheap, non-model), fires the due tasks
- * (each past-due schedule coalesces to ONE fire), stamps `lastFiredAt` /
- * deletes one-shots, and re-arms. The scan cap bounds how stale the armed
- * timer can get when tasks are added by another process — the model is still
- * only invoked when a task is concretely due.
- *
- * Turns reuse the SessionRouter: one persistent daemon session per task
- * (`cron|<id>`), dead-agent retry, and channel streaming for free. Turns are
- * autonomous: permission requests are DENIED and the daemon-owned execution
- * admission kernel gates every model/tool boundary (refusal delivers a paused
- * notice, never silent).
+ * Delivery-tagged tasks use isolated daemon sessions. Completed model results
+ * and destination retry state are persisted before external delivery. The
+ * task advances or is removed only after every destination acknowledges it.
+ * Process locks prevent overlapping execution, and persisted leases and
+ * backoff allow recovery after a gateway restart. Tool permissions are denied;
+ * model and tool calls still pass through daemon-owned execution admission.
  */
 
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
+import { createHash } from "node:crypto";
 import type { AgenCConfig } from "../config/schema.js";
 import {
   BrowserSsrfError,
@@ -31,14 +20,19 @@ import {
   type HostLookup,
 } from "../browser/ssrf.js";
 import {
-  listAllCronTasks,
-  markCronTasksFired,
-  nextCronRunMs,
-  removeCronTasks,
-  type CronTask,
-} from "../utils/cronTasks.js";
+  MAX_CRON_PAYLOAD_BYTES,
+  type CronDeliveryPayload,
+} from "../utils/cron-delivery-state.js";
+import {
+  CronDeliveryOutboxStore,
+  type CronOccurrenceClaim,
+} from "./cron-outbox.js";
 import { SessionRouter } from "./session-router.js";
-import type { ChannelAdapter, GatewayDaemonClient } from "./types.js";
+import type {
+  ChannelAdapter,
+  GatewayDaemonClient,
+  GatewayPromptResult,
+} from "./types.js";
 import { frameChannelMessage } from "./untrusted.js";
 import {
   executionAdmissionErrorMessage,
@@ -52,7 +46,10 @@ export const CRON_WEBHOOK_MAX_REDIRECTS = 5;
 
 export interface CronDeliveryClock {
   now(): Date;
-  setTimer(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
+  setTimer(
+    fn: () => void | Promise<void>,
+    ms: number,
+  ): ReturnType<typeof setTimeout>;
   clearTimer(handle: ReturnType<typeof setTimeout>): void;
 }
 
@@ -75,7 +72,11 @@ export interface StartCronDeliveryOptions {
   /** Test seam: real timers by default. */
   readonly clock?: CronDeliveryClock;
   /** Test seam: webhook transport (address-pinned HTTP client by default). */
-  readonly postWebhook?: (url: string, body: unknown) => Promise<void>;
+  readonly postWebhook?: (
+    url: string,
+    body: unknown,
+    deliveryKey?: string,
+  ) => Promise<void>;
 }
 
 export interface CronDeliveryHandle {
@@ -95,6 +96,7 @@ export interface CronWebhookRequest {
   readonly address: string;
   readonly method: "GET" | "POST";
   readonly body?: Uint8Array;
+  readonly idempotencyKey?: string;
   readonly signal: AbortSignal;
 }
 
@@ -114,6 +116,7 @@ export interface PostCronWebhookOptions {
   readonly request?: CronWebhookRequester;
   readonly timeoutMs?: number;
   readonly maxRedirects?: number;
+  readonly idempotencyKey?: string;
 }
 
 function stripHostBrackets(host: string): string {
@@ -211,6 +214,9 @@ export async function requestPinnedCronWebhook(
     host: input.url.host,
     connection: "close",
   };
+  if (input.idempotencyKey !== undefined) {
+    headers["idempotency-key"] = input.idempotencyKey;
+  }
   if (input.body !== undefined) {
     headers["content-type"] = "application/json";
     headers["content-length"] = input.body.byteLength;
@@ -281,6 +287,12 @@ export async function postCronWebhook(
   if (!Number.isSafeInteger(maxRedirects) || maxRedirects < 0) {
     throw new Error("cron webhook: max redirects must be a non-negative integer");
   }
+  if (
+    options.idempotencyKey !== undefined &&
+    !/^[a-zA-Z0-9:_-]{1,256}$/.test(options.idempotencyKey)
+  ) {
+    throw new Error("cron webhook: invalid idempotency key");
+  }
 
   const requester = options.request ?? requestPinnedCronWebhook;
   const serializedBody = JSON.stringify(body);
@@ -311,10 +323,20 @@ export async function postCronWebhook(
           method,
           ...(requestBody !== undefined ? { body: requestBody } : {}),
           signal: controller.signal,
+          ...(options.idempotencyKey !== undefined
+            ? { idempotencyKey: options.idempotencyKey }
+            : {}),
         }),
         controller.signal,
       );
-      if (!isRedirectStatus(response.statusCode)) return;
+      if (!isRedirectStatus(response.statusCode)) {
+        if (
+          Number.isInteger(response.statusCode) &&
+          response.statusCode >= 200 &&
+          response.statusCode < 300
+        ) return;
+        throw new Error("cron webhook: unsuccessful HTTP response");
+      }
       if (response.location === undefined) {
         throw new Error("cron webhook: redirect missing Location header");
       }
@@ -346,11 +368,17 @@ export async function postCronWebhook(
   }
 }
 
-async function defaultPostWebhook(url: string, body: unknown): Promise<void> {
-  await postCronWebhook(url, body);
+async function defaultPostWebhook(
+  url: string,
+  body: unknown,
+  deliveryKey?: string,
+): Promise<void> {
+  await postCronWebhook(url, body, {
+    ...(deliveryKey !== undefined ? { idempotencyKey: deliveryKey } : {}),
+  });
 }
 
-/** Adapter used when a task delivers to a webhook only — swallows channel output. */
+/** Suppresses streaming until the completed result is durably recorded. */
 const NULL_ADAPTER: ChannelAdapter = {
   id: "cron-webhook-null",
   supportsEdit: false,
@@ -367,8 +395,10 @@ export function startCronDelivery(
   const log = options.log ?? (() => {});
   const clock = options.clock ?? REAL_CLOCK;
   const postWebhook = options.postWebhook ?? defaultPostWebhook;
-  const adaptersById = new Map(options.adapters.map((a) => [a.id, a]));
-
+  const adaptersById = new Map(
+    options.adapters.map((adapter) => [adapter.id, adapter]),
+  );
+  const outbox = new CronDeliveryOutboxStore(options.workspaceDir);
   const router = new SessionRouter({
     agencHome: options.agencHome,
     client: options.client,
@@ -377,148 +407,206 @@ export function startCronDelivery(
   let stopped = false;
   let running = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let activeTick: Promise<void> | undefined;
+  let retryFloorAt = 0;
+  const now = (): number => clock.now().getTime();
 
-  const deliveredTasks = async (): Promise<CronTask[]> => {
-    const tasks = await listAllCronTasks(options.workspaceDir);
-    return tasks.filter((t) => t.deliver !== undefined);
-  };
-
-  const fireTask = async (task: CronTask): Promise<void> => {
+  const fireTask = async (claim: CronOccurrenceClaim): Promise<void> => {
+    const task = claim.task;
     const deliver = task.deliver;
     if (deliver === undefined) return;
-    const adapter =
-      deliver.channel !== undefined
-        ? adaptersById.get(deliver.channel)
-        : undefined;
-    if (deliver.channel !== undefined && adapter === undefined) {
-      log(
-        `cron: task ${task.id} targets unknown channel '${deliver.channel}' — skipping channel delivery this fire`,
-      );
-    }
-    const routeAdapter = adapter ?? NULL_ADAPTER;
-    const conversationId = adapter !== undefined ? deliver.to ?? "" : "cron";
-
-    // Admission/reservation/reconciliation belongs to the daemon session at
-    // the actual model/tool boundary. The gateway owns only scheduling and
-    // delivery, never a second outer-turn spend ledger.
-    try {
-      // Frame scheduled prompts as untrusted work data (parity with hooks/channels, todo-126).
-      const framedPrompt = frameChannelMessage({
-        channelId: "cron",
-        peerId: `cron:${task.id}`,
-        text: task.prompt,
-      });
-      const result = await router.runTurn({
-        key: SessionRouter.conversationKey({
-          channelId: "cron",
-          agent: "default",
-          conversationId: task.id,
-        }),
-        text: framedPrompt,
-        adapter: routeAdapter,
-        conversationId,
-        // Autonomous, no human watching → deny permission requests (fail safe).
-        onPermissionRequest: async () => ({
-          behavior: "deny",
-          reason: "cron delivery turns do not grant tool permissions",
-        }),
-      });
-
-      if (deliver.webhook !== undefined) {
-        await postWebhook(deliver.webhook, {
-          taskId: task.id,
-          cron: task.cron,
-          prompt: task.prompt,
-          finalMessage: result.finalMessage,
-          stopReason: result.stopReason,
-          firedAt: clock.now().toISOString(),
-        }).catch((error: unknown) =>
-          log(`cron: webhook POST failed for task ${task.id}: ${String(error)}`),
+    let payload = claim.occurrence.payload;
+    if (payload === undefined) {
+      if (
+        stopped ||
+        (await outbox.beginAttempt(claim, "model", now())) === undefined
+      ) return;
+      if (stopped) return;
+      let result: GatewayPromptResult;
+      try {
+        result = await router.runTurn({
+          key: SessionRouter.conversationKey({
+            channelId: "cron",
+            agent: "default",
+            conversationId: task.id,
+          }),
+          text: frameChannelMessage({
+            channelId: "cron",
+            peerId: "cron:" + task.id,
+            text: task.prompt,
+          }),
+          adapter: NULL_ADAPTER,
+          conversationId: "cron",
+          onPermissionRequest: async () => ({
+            behavior: "deny",
+            reason: "cron delivery turns do not grant tool permissions",
+          }),
+        });
+      } catch (error) {
+        const admission = isExecutionAdmissionDenied(error);
+        const errorClass = admission ? "admission_pause" : "turn_error";
+        const status = await outbox.failAttempt(claim, "model", errorClass);
+        const action = status === "terminal"
+          ? " requires operator action"
+          : " retry pending";
+        log("cron: task " + JSON.stringify(task.id) + action + " (" + errorClass + ")");
+        if (
+          admission && !stopped &&
+          deliver.channel !== undefined && deliver.to !== undefined
+        ) {
+          const adapter = adaptersById.get(deliver.channel);
+          const reason = executionAdmissionErrorMessage(error).includes("budget_exceeded")
+            ? "budget_exceeded"
+            : "admission_denied";
+          await adapter?.send({
+            conversationId: deliver.to,
+            text: "⏸ cron task " + task.id + " paused: " + reason,
+          }).catch(() => log("cron: admission pause notice failed"));
+        }
+        return;
+      }
+      if (result.stopReason !== "completed") {
+        const errorClass = result.stopReason === "errored"
+          ? "turn_errored"
+          : result.stopReason === "stopped"
+            ? "turn_stopped"
+            : "unsupported_result";
+        await outbox.failAttempt(
+          claim, "model", errorClass, errorClass === "unsupported_result",
         );
+        log("cron: task " + JSON.stringify(task.id) + " result not deliverable (" + errorClass + ")");
+        return;
       }
-      log(`cron: task ${task.id} delivered (${result.stopReason})`);
-    } catch (error) {
-      if (!isExecutionAdmissionDenied(error)) throw error;
-      const notice =
-        `⏸ cron task ${task.id} paused: ` +
-        executionAdmissionErrorMessage(error);
-      log(`cron: ${notice}`);
-      if (adapter !== undefined && deliver.to !== undefined) {
-        await adapter
-          .send({ conversationId: deliver.to, text: notice })
-          .catch((noticeError: unknown) =>
-            log(`cron: notice failed: ${String(noticeError)}`),
-          );
+      if (typeof result.finalMessage !== "string") {
+        await outbox.failAttempt(claim, "model", "unsupported_result", true);
+        return;
       }
+      const completedPayload: CronDeliveryPayload = {
+        taskId: task.id,
+        occurrenceId: claim.key,
+        cron: task.cron,
+        prompt: task.prompt,
+        finalMessage: result.finalMessage,
+        stopReason: "completed",
+        firedAt: clock.now().toISOString(),
+      };
+      if (
+        Buffer.byteLength(JSON.stringify(completedPayload), "utf8") >
+        MAX_CRON_PAYLOAD_BYTES
+      ) {
+        await outbox.failAttempt(claim, "model", "payload_too_large", true);
+        log("cron: task " + JSON.stringify(task.id) + " requires operator action (payload_too_large)");
+        return;
+      }
+      if (!(await outbox.persistResult(claim, completedPayload))) return;
+      payload = completedPayload;
     }
+
+    for (const phase of ["channel", "webhook"] as const) {
+      if (
+        stopped ||
+        (await outbox.beginAttempt(claim, phase, now())) === undefined
+      ) continue;
+      if (stopped) return;
+      const deliveryKey = createHash("sha256")
+        .update(claim.key + ":" + phase)
+        .digest("hex");
+      try {
+        if (phase === "channel") {
+          const adapter = deliver.channel === undefined
+            ? undefined
+            : adaptersById.get(deliver.channel);
+          if (adapter === undefined || deliver.to === undefined) {
+            const status = await outbox.failAttempt(
+              claim, phase, "missing_adapter",
+            );
+            const action = status === "terminal"
+              ? "requires operator action"
+              : "delivery retry pending";
+            log("cron: unknown channel for task " + JSON.stringify(task.id) + "; " + action);
+            continue;
+          }
+          await adapter.send({
+            conversationId: deliver.to,
+            text: payload.finalMessage,
+            idempotencyKey: deliveryKey,
+          });
+        } else {
+          if (deliver.webhook === undefined) continue;
+          await postWebhook(deliver.webhook, payload, deliveryKey);
+        }
+      } catch {
+        const status = await outbox.failAttempt(
+          claim, phase, phase === "channel" ? "channel_error" : "webhook_error",
+        );
+        const action = status === "terminal"
+          ? " requires operator action"
+          : " delivery retry pending";
+        log("cron: task " + JSON.stringify(task.id) + " " + phase + action);
+        continue;
+      }
+      await outbox.markDelivered(claim, phase);
+    }
+    if (await outbox.complete(claim, now())) {
+      log("cron: task " + JSON.stringify(task.id) + " delivered (completed)");
+    }
+  };
+
+  const arm = async (): Promise<void> => {
+    if (stopped) return;
+    if (timer !== null) clock.clearTimer(timer);
+    let sleep = CRON_DELIVERY_SCAN_CAP_MS;
+    try {
+      let earliest = Infinity;
+      for (const entry of await outbox.schedule()) {
+        earliest = Math.min(earliest, entry.at);
+      }
+      sleep = Math.min(
+        CRON_DELIVERY_SCAN_CAP_MS,
+        Math.max(0, Math.max(retryFloorAt, earliest) - now()),
+      );
+    } catch {
+      log("cron: delivery state unavailable; inspect the task file and directory permissions");
+    }
+    if (stopped) return;
+    timer = clock.setTimer(() => {
+      activeTick = tick();
+      return activeTick;
+    }, sleep);
   };
 
   const tick = async (): Promise<void> => {
     if (stopped || running) return;
     running = true;
     try {
-      const now = clock.now().getTime();
-      const tasks = await deliveredTasks();
-      const firedRecurring: CronTask[] = [];
-      const firedOneShots: string[] = [];
-      for (const task of tasks) {
-        // Anchor from the last fire (or creation) — a past-due schedule
-        // coalesces to ONE fire regardless of how many slots were missed.
-        const due = nextCronRunMs(task.cron, task.lastFiredAt ?? task.createdAt);
-        if (due === null || due > now) continue;
+      for (const entry of await outbox.schedule()) {
+        if (stopped) break;
+        if (entry.at > now()) continue;
         try {
-          await fireTask(task);
-        } catch (error) {
-          log(`cron: task ${task.id} failed: ${String(error)}`);
+          await outbox.withClaim(entry.taskId, now, fireTask);
+        } catch {
+          retryFloorAt = now() + 1_000;
+          log("cron: task " + JSON.stringify(entry.taskId) + " delivery deferred; inspect persisted state");
         }
-        if (task.recurring === true) firedRecurring.push(task);
-        else firedOneShots.push(task.id);
       }
-      if (firedRecurring.length > 0) {
-        await markCronTasksFired(
-          firedRecurring.map((t) => t.id),
-          now,
-          options.workspaceDir,
-        );
-      }
-      if (firedOneShots.length > 0) {
-        await removeCronTasks(firedOneShots, options.workspaceDir);
-      }
+    } catch {
+      log("cron: delivery state unavailable; inspect the task file and directory permissions");
     } finally {
       running = false;
+      await arm();
     }
-    arm();
   };
 
-  const arm = (): void => {
-    if (stopped) return;
-    if (timer !== null) clock.clearTimer(timer);
-    void (async () => {
-      const now = clock.now().getTime();
-      let earliest: number | null = null;
-      for (const task of await deliveredTasks()) {
-        const due = nextCronRunMs(task.cron, task.lastFiredAt ?? task.createdAt);
-        if (due === null) continue;
-        if (earliest === null || due < earliest) earliest = due;
-      }
-      if (stopped) return;
-      const sleep = Math.min(
-        earliest === null ? CRON_DELIVERY_SCAN_CAP_MS : Math.max(0, earliest - now),
-        CRON_DELIVERY_SCAN_CAP_MS,
-      );
-      timer = clock.setTimer(() => void tick(), sleep);
-    })();
-  };
-
-  arm();
+  const initialArm = arm();
   log("cron: gateway delivery armed");
-
   return {
     isRunning: () => running,
     async stop() {
       stopped = true;
       if (timer !== null) clock.clearTimer(timer);
       timer = null;
+      await initialArm;
+      await activeTick;
     },
   };
 }

--- a/runtime/src/gateway/cron-outbox.ts
+++ b/runtime/src/gateway/cron-outbox.ts
@@ -1,0 +1,306 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, realpath } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  getCronFilePath,
+  mutateCronFile,
+  nextCronRunMs,
+  readCronFile,
+  type CronFile,
+  type CronTask,
+} from "../utils/cronTasks.js";
+import { acquireLocalSqliteLock } from "../utils/sqlite-lock.js";
+import {
+  CRON_DELIVERY_LEASE_MS,
+  CRON_DELIVERY_RETRY_BASE_MS,
+  CRON_DELIVERY_RETRY_CAP_MS,
+  MAX_CRON_DELIVERY_ATTEMPTS,
+  MAX_CRON_OUTBOX_ENTRIES,
+  type CronDeliveryAttempt,
+  type CronDeliveryErrorClass,
+  type CronDeliveryOccurrence,
+  type CronDeliveryPayload,
+} from "../utils/cron-delivery-state.js";
+
+export type CronDeliveryPhase = "model" | "channel" | "webhook";
+
+export interface CronOccurrenceClaim {
+  readonly key: string;
+  readonly token: string;
+  readonly task: CronTask;
+  readonly occurrence: CronDeliveryOccurrence;
+}
+
+function taskFingerprint(task: CronTask): string {
+  return createHash("sha256").update(JSON.stringify(task)).digest("hex");
+}
+
+function attemptTime(attempt: CronDeliveryAttempt | undefined): number {
+  if (
+    attempt === undefined ||
+    attempt.status === "delivered" || attempt.status === "terminal"
+  ) {
+    return Infinity;
+  }
+  return attempt.nextAttemptAt ?? 0;
+}
+
+function allDestinationsDelivered(entry: CronDeliveryOccurrence): boolean {
+  return [entry.channel, entry.webhook].every(
+    (attempt) => attempt === undefined || attempt.status === "delivered",
+  );
+}
+
+function occurrenceTime(entry: CronDeliveryOccurrence): number {
+  if (entry.blockedReason !== undefined) return Infinity;
+  const next = entry.model.status !== "delivered"
+    ? attemptTime(entry.model)
+    : allDestinationsDelivered(entry)
+      ? 0
+      : Math.min(attemptTime(entry.channel), attemptTime(entry.webhook));
+  return Math.max(next, entry.lease?.expiresAt ?? 0);
+}
+
+function retryTime(
+  key: string,
+  phase: CronDeliveryPhase,
+  attempts: number,
+  now: number,
+): number {
+  const digest = createHash("sha256")
+    .update(`${key}:${phase}:${attempts}`)
+    .digest();
+  const fraction = digest.readUInt32BE(0) / 0x1_0000_0000;
+  const base = Math.min(
+    CRON_DELIVERY_RETRY_CAP_MS,
+    CRON_DELIVERY_RETRY_BASE_MS * 2 ** (attempts - 1),
+  );
+  return now + Math.floor(
+    Math.min(CRON_DELIVERY_RETRY_CAP_MS, base * (0.75 + fraction / 2)),
+  );
+}
+
+export class CronDeliveryOutboxStore {
+  constructor(readonly workspaceDir: string) {}
+
+  async schedule(): Promise<readonly { taskId: string; at: number }[]> {
+    const state = await readCronFile(this.workspaceDir);
+    return state.tasks.filter((task) => task.deliver !== undefined).flatMap((task) => {
+      const active = state.deliveryOutbox?.occurrences.find(
+        (entry) => entry.taskId === task.id && entry.completedAt === undefined,
+      );
+      const at = active !== undefined
+        ? occurrenceTime(active)
+        : nextCronRunMs(task.cron, task.lastFiredAt ?? task.createdAt);
+      return at === null || !Number.isFinite(at) ? [] : [{ taskId: task.id, at }];
+    });
+  }
+
+  async withClaim(
+    taskId: string,
+    now: () => number,
+    operation: (claim: CronOccurrenceClaim) => Promise<void>,
+  ): Promise<void> {
+    const directory = dirname(getCronFilePath(this.workspaceDir));
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    const canonicalDirectory = await realpath(directory);
+    const stripe = createHash("sha256").update(taskId).digest()[0]! % 16;
+    const release = await acquireLocalSqliteLock(
+      join(canonicalDirectory, `cron-delivery-${stripe}.lock.sqlite`),
+      { timeoutMs: 1_000, label: "cron occurrence execution" },
+    );
+    try {
+      const claim = await this.claim(taskId, now());
+      if (claim === undefined) return;
+      try {
+        await operation(claim);
+      } finally {
+        await mutateCronFile(this.workspaceDir, (state) => {
+          const entry = state.deliveryOutbox?.occurrences.find(
+            (candidate) => candidate.key === claim.key,
+          );
+          if (entry?.lease?.token === claim.token) delete entry.lease;
+        });
+      }
+    } finally {
+      release();
+    }
+  }
+
+  private async claim(
+    taskId: string,
+    now: number,
+  ): Promise<CronOccurrenceClaim | undefined> {
+    return mutateCronFile(this.workspaceDir, (state) => {
+      const task = state.tasks.find((candidate) => candidate.id === taskId);
+      if (task?.deliver === undefined) return undefined;
+      state.deliveryOutbox ??= { version: 1, occurrences: [] };
+      const outbox = state.deliveryOutbox;
+      let entry = outbox.occurrences.find(
+        (candidate) =>
+          candidate.taskId === task.id && candidate.completedAt === undefined,
+      );
+      if (entry === undefined) {
+        const dueAt = nextCronRunMs(task.cron, task.lastFiredAt ?? task.createdAt);
+        if (dueAt === null || dueAt > now) return undefined;
+        if (outbox.occurrences.length >= MAX_CRON_OUTBOX_ENTRIES) {
+          outbox.occurrences = outbox.occurrences.filter(
+            (candidate) => candidate.completedAt === undefined,
+          );
+        }
+        if (outbox.occurrences.length >= MAX_CRON_OUTBOX_ENTRIES) {
+          throw new Error(
+            "Cron delivery outbox is full; resolve pending deliveries first",
+          );
+        }
+        entry = {
+          key: `${task.id}:${dueAt}`,
+          taskId: task.id,
+          dueAt,
+          coalescedAt: now,
+          taskFingerprint: taskFingerprint(task),
+          model: { status: "pending", attempts: 0 },
+          ...(task.deliver.channel !== undefined
+            ? { channel: { status: "pending" as const, attempts: 0 } }
+            : {}),
+          ...(task.deliver.webhook !== undefined
+            ? { webhook: { status: "pending" as const, attempts: 0 } }
+            : {}),
+        };
+        outbox.occurrences.push(entry);
+      }
+      if (entry.taskFingerprint !== taskFingerprint(task)) {
+        entry.blockedReason = "task_changed";
+        for (const attempt of [entry.model, entry.channel, entry.webhook]) {
+          if (attempt !== undefined && attempt.status !== "delivered") {
+            attempt.status = "terminal";
+            attempt.lastError = "task_changed";
+            delete attempt.nextAttemptAt;
+          }
+        }
+        delete entry.lease;
+        return undefined;
+      }
+      if (occurrenceTime(entry) > now) return undefined;
+      const token = randomUUID();
+      entry.lease = { token, expiresAt: now + CRON_DELIVERY_LEASE_MS };
+      return {
+        key: entry.key,
+        token,
+        task: structuredClone(task),
+        occurrence: structuredClone(entry),
+      };
+    });
+  }
+
+  private async update(
+    claim: CronOccurrenceClaim,
+    mutate: (
+      entry: CronDeliveryOccurrence,
+      task: CronTask,
+      state: CronFile,
+    ) => void,
+  ): Promise<CronDeliveryOccurrence | undefined> {
+    return mutateCronFile(this.workspaceDir, (state) => {
+      const entry = state.deliveryOutbox?.occurrences.find(
+        (candidate) => candidate.key === claim.key,
+      );
+      const task = state.tasks.find((candidate) => candidate.id === claim.task.id);
+      if (
+        entry?.lease?.token !== claim.token ||
+        entry.blockedReason !== undefined ||
+        task === undefined ||
+        entry.taskFingerprint !== taskFingerprint(task)
+      ) {
+        return undefined;
+      }
+      mutate(entry, task, state);
+      return structuredClone(entry);
+    });
+  }
+
+  async beginAttempt(
+    claim: CronOccurrenceClaim,
+    phase: CronDeliveryPhase,
+    now: number,
+  ): Promise<CronDeliveryOccurrence | undefined> {
+    let started = false;
+    const entry = await this.update(claim, (current) => {
+      const attempt = current[phase];
+      if (attemptTime(attempt) > now || attempt === undefined) return;
+      if (attempt.attempts >= MAX_CRON_DELIVERY_ATTEMPTS) {
+        attempt.status = "terminal";
+        attempt.lastError ??= "interrupted";
+        delete attempt.nextAttemptAt;
+        return;
+      }
+      attempt.attempts += 1;
+      attempt.status = "retryable";
+      attempt.lastError = "interrupted";
+      attempt.nextAttemptAt = retryTime(claim.key, phase, attempt.attempts, now);
+      started = true;
+    });
+    return started ? entry : undefined;
+  }
+
+  async persistResult(
+    claim: CronOccurrenceClaim,
+    payload: CronDeliveryPayload,
+  ): Promise<boolean> {
+    return (await this.update(claim, (entry) => {
+      entry.payload = payload;
+      entry.model.status = "delivered";
+      delete entry.model.lastError;
+      delete entry.model.nextAttemptAt;
+    })) !== undefined;
+  }
+
+  async failAttempt(
+    claim: CronOccurrenceClaim,
+    phase: CronDeliveryPhase,
+    error: CronDeliveryErrorClass,
+    terminal = false,
+  ): Promise<CronDeliveryAttempt["status"] | undefined> {
+    const updated = await this.update(claim, (entry) => {
+      const attempt = entry[phase];
+      if (attempt === undefined) return;
+      attempt.lastError = error;
+      if (terminal || attempt.attempts >= MAX_CRON_DELIVERY_ATTEMPTS) {
+        attempt.status = "terminal";
+        delete attempt.nextAttemptAt;
+      }
+    });
+    return updated?.[phase]?.status;
+  }
+
+  async markDelivered(
+    claim: CronOccurrenceClaim,
+    phase: "channel" | "webhook",
+  ): Promise<void> {
+    await this.update(claim, (entry) => {
+      const attempt = entry[phase];
+      if (attempt === undefined) return;
+      attempt.status = "delivered";
+      delete attempt.lastError;
+      delete attempt.nextAttemptAt;
+    });
+  }
+
+  async complete(claim: CronOccurrenceClaim, now: number): Promise<boolean> {
+    let completed = false;
+    await this.update(claim, (entry, task, state) => {
+      if (
+        entry.model.status !== "delivered" || !allDestinationsDelivered(entry)
+      ) return;
+      if (task.recurring === true) {
+        task.lastFiredAt = Math.max(now, entry.coalescedAt);
+      } else {
+        state.tasks = state.tasks.filter((candidate) => candidate.id !== task.id);
+      }
+      entry.completedAt = now;
+      delete entry.lease;
+      completed = true;
+    });
+    return completed;
+  }
+}

--- a/runtime/src/gateway/cron-outbox.ts
+++ b/runtime/src/gateway/cron-outbox.ts
@@ -259,6 +259,7 @@ export class CronDeliveryOutboxStore {
     claim: CronOccurrenceClaim,
     phase: CronDeliveryPhase,
     error: CronDeliveryErrorClass,
+    now: number,
     terminal = false,
   ): Promise<CronDeliveryAttempt["status"] | undefined> {
     const updated = await this.update(claim, (entry) => {
@@ -268,6 +269,8 @@ export class CronDeliveryOutboxStore {
       if (terminal || attempt.attempts >= MAX_CRON_DELIVERY_ATTEMPTS) {
         attempt.status = "terminal";
         delete attempt.nextAttemptAt;
+      } else {
+        attempt.nextAttemptAt = retryTime(claim.key, phase, attempt.attempts, now);
       }
     });
     return updated?.[phase]?.status;

--- a/runtime/src/gateway/cron-outbox.ts
+++ b/runtime/src/gateway/cron-outbox.ts
@@ -243,6 +243,19 @@ export class CronDeliveryOutboxStore {
     return started ? entry : undefined;
   }
 
+  async beginAdmissionNotice(
+    claim: CronOccurrenceClaim,
+    now: number,
+  ): Promise<boolean> {
+    let started = false;
+    await this.update(claim, (entry) => {
+      if (entry.admissionNoticeAttemptedAt !== undefined) return;
+      entry.admissionNoticeAttemptedAt = now;
+      started = true;
+    });
+    return started;
+  }
+
   async persistResult(
     claim: CronOccurrenceClaim,
     payload: CronDeliveryPayload,

--- a/runtime/src/gateway/discord-channel.ts
+++ b/runtime/src/gateway/discord-channel.ts
@@ -24,6 +24,7 @@
  * allowlist gate, and message text is untrusted (framed upstream).
  */
 
+import { createHash } from "node:crypto";
 import type {
   ChannelAdapter,
   ChannelAdapterContext,
@@ -88,7 +89,11 @@ export interface DiscordTransport {
   getGatewayUrl(): Promise<string>;
   connect(url: string, handlers: DiscordSocketHandlers): Promise<DiscordSocket>;
   /** POST /channels/{id}/messages */
-  createMessage(channelId: string, text: string): Promise<{ id: string }>;
+  createMessage(
+    channelId: string,
+    text: string,
+    nonce?: string,
+  ): Promise<{ id: string }>;
   /** PATCH /channels/{id}/messages/{messageId} */
   editMessage(channelId: string, messageId: string, text: string): Promise<void>;
 }
@@ -161,10 +166,22 @@ export class FetchDiscordTransport implements DiscordTransport {
     };
   }
 
-  async createMessage(channelId: string, text: string): Promise<{ id: string }> {
+  async createMessage(
+    channelId: string,
+    text: string,
+    nonce?: string,
+  ): Promise<{ id: string }> {
+    if (nonce !== undefined && (nonce.length === 0 || nonce.length > 25)) {
+      throw new DiscordApiError(
+        "discord message nonce must contain 1 to 25 characters",
+      );
+    }
     const result = (await this.#rest(`/channels/${channelId}/messages`, {
       method: "POST",
-      body: JSON.stringify({ content: text }),
+      body: JSON.stringify({
+        content: text,
+        ...(nonce !== undefined ? { nonce, enforce_nonce: true } : {}),
+      }),
     })) as { id?: string };
     if (typeof result.id !== "string") {
       throw new DiscordApiError("discord createMessage returned no id");
@@ -457,11 +474,18 @@ export class DiscordChannelAdapter implements ChannelAdapter {
       }
     }
     let firstId: string | null = null;
-    for (const chunk of chunks) {
-      const sent = await this.#transport.createMessage(
-        message.conversationId,
-        chunk,
-      );
+    for (const [chunkIndex, chunk] of chunks.entries()) {
+      const nonce = message.idempotencyKey === undefined
+        ? undefined
+        : createHash("sha256")
+            .update(message.idempotencyKey + ":" + chunkIndex)
+            .digest("hex")
+            .slice(0, 24);
+      const sent = nonce === undefined
+        ? await this.#transport.createMessage(message.conversationId, chunk)
+        : await this.#transport.createMessage(
+            message.conversationId, chunk, nonce,
+          );
       if (firstId === null) firstId = sent.id;
     }
     const handle = `${this.id}-out-${++this.#outCounter}`;

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -44,6 +44,7 @@ export interface InboundChannelMessage {
 export interface OutboundChannelMessage {
   readonly conversationId: string;
   readonly text: string;
+  readonly idempotencyKey?: string;
   /**
    * Optional public image URL to deliver as native media on channels that
    * support it. Adapters without media support may ignore it and send `text`.

--- a/runtime/src/onboarding/acts/autonomy.ts
+++ b/runtime/src/onboarding/acts/autonomy.ts
@@ -29,8 +29,7 @@ import {
 import { resolveHooksToken } from "../../gateway/run.js";
 import { HOOKS_PATH } from "../../gateway/hooks.js";
 import {
-  readCronTasks,
-  writeCronTasks,
+  appendCronTask,
   nextCronRunMs,
   normalizeDelivery,
 } from "../../utils/cronTasks.js";
@@ -268,16 +267,14 @@ export async function runAutonomyAct(
       const to =
         channel.length > 0 ? await io.ask("Conversation id", "") : "";
       const deliver = normalizeDelivery({ channel, to });
-      const tasks = await readCronTasks(workspace);
-      tasks.push({
+      await appendCronTask({
         id: randomUUID().slice(0, 8),
         cron: schedule,
         prompt,
         createdAt: now(),
         recurring: true,
         ...(deliver !== undefined ? { deliver } : {}),
-      });
-      await writeCronTasks(tasks, workspace);
+      }, workspace);
       io.say(
         `Job saved (${schedule}). Delivery-routed jobs run under \`agenc gateway run\` from ${workspace}.`,
       );

--- a/runtime/src/utils/cron-delivery-state.ts
+++ b/runtime/src/utils/cron-delivery-state.ts
@@ -1,0 +1,127 @@
+import { z } from "zod/v4";
+
+export const MAX_CRON_OUTBOX_ENTRIES = 128;
+export const MAX_CRON_PAYLOAD_BYTES = 64 * 1024;
+export const MAX_CRON_FILE_BYTES = 16 * 1024 * 1024;
+export const MAX_CRON_DELIVERY_ATTEMPTS = 10;
+export const CRON_DELIVERY_LEASE_MS = 60_000;
+export const CRON_DELIVERY_RETRY_BASE_MS = 30_000;
+export const CRON_DELIVERY_RETRY_CAP_MS = 5 * 60_000;
+
+const timestamp = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const identifier = z.string().min(1).max(256);
+const errorClass = z.enum([
+  "turn_error",
+  "admission_pause",
+  "turn_errored",
+  "turn_stopped",
+  "unsupported_result",
+  "payload_too_large",
+  "missing_adapter",
+  "channel_error",
+  "webhook_error",
+  "interrupted",
+  "task_changed",
+]);
+
+const attemptSchema = z.strictObject({
+  status: z.enum(["pending", "delivered", "retryable", "terminal"]),
+  attempts: z.number().int().min(0).max(MAX_CRON_DELIVERY_ATTEMPTS),
+  nextAttemptAt: timestamp.optional(),
+  lastError: errorClass.optional(),
+}).refine((attempt) => {
+  if (attempt.status === "retryable") {
+    return attempt.attempts > 0 &&
+      attempt.nextAttemptAt !== undefined && attempt.lastError !== undefined;
+  }
+  if (attempt.status === "terminal") {
+    return attempt.nextAttemptAt === undefined && attempt.lastError !== undefined;
+  }
+  return attempt.nextAttemptAt === undefined && attempt.lastError === undefined &&
+    (attempt.status === "pending" ? attempt.attempts === 0 : attempt.attempts > 0);
+}, "cron delivery attempt state is inconsistent");
+
+const payloadSchema = z.strictObject({
+  taskId: identifier,
+  occurrenceId: identifier,
+  cron: z.string().max(256),
+  prompt: z.string().max(MAX_CRON_PAYLOAD_BYTES),
+  finalMessage: z.string().max(MAX_CRON_PAYLOAD_BYTES),
+  stopReason: z.literal("completed"),
+  firedAt: z.iso.datetime(),
+}).refine(
+  (payload) =>
+    Buffer.byteLength(JSON.stringify(payload), "utf8") <= MAX_CRON_PAYLOAD_BYTES,
+  "cron delivery payload exceeds its byte limit",
+);
+
+const occurrenceSchema = z.strictObject({
+  key: identifier,
+  taskId: identifier,
+  dueAt: timestamp,
+  coalescedAt: timestamp,
+  taskFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+  blockedReason: z.literal("task_changed").optional(),
+  lease: z.strictObject({
+    token: identifier,
+    expiresAt: timestamp,
+  }).optional(),
+  model: attemptSchema,
+  channel: attemptSchema.optional(),
+  webhook: attemptSchema.optional(),
+  payload: payloadSchema.optional(),
+  completedAt: timestamp.optional(),
+}).refine((entry) => {
+  if (entry.channel === undefined && entry.webhook === undefined) return false;
+  if (entry.coalescedAt < entry.dueAt) return false;
+  if (entry.model.status === "delivered") {
+    if (
+      entry.payload === undefined ||
+      entry.payload.taskId !== entry.taskId ||
+      entry.payload.occurrenceId !== entry.key
+    ) return false;
+  } else if (entry.payload !== undefined) {
+    return false;
+  }
+  if (entry.completedAt !== undefined) {
+    return entry.lease === undefined && entry.model.status === "delivered" &&
+      [entry.channel, entry.webhook].every(
+        (attempt) => attempt === undefined || attempt.status === "delivered",
+      );
+  }
+  return true;
+}, "cron delivery occurrence state is inconsistent");
+
+const outboxSchema = z.strictObject({
+  version: z.literal(1),
+  occurrences: z.array(occurrenceSchema).max(MAX_CRON_OUTBOX_ENTRIES),
+}).refine(
+  (outbox) =>
+    new Set(outbox.occurrences.map((entry) => entry.key)).size ===
+    outbox.occurrences.length,
+  "cron delivery occurrence keys must be unique",
+).refine(
+  (outbox) => {
+    const pending = outbox.occurrences.filter(
+      (entry) => entry.completedAt === undefined,
+    );
+    return new Set(pending.map((entry) => entry.taskId)).size === pending.length;
+  },
+  "a task cannot have multiple pending occurrences",
+);
+
+export type CronDeliveryAttempt = z.infer<typeof attemptSchema>;
+export type CronDeliveryErrorClass = z.infer<typeof errorClass>;
+export type CronDeliveryPayload = z.infer<typeof payloadSchema>;
+export type CronDeliveryOccurrence = z.infer<typeof occurrenceSchema>;
+export type CronDeliveryOutbox = z.infer<typeof outboxSchema>;
+
+export function parseCronDeliveryOutbox(value: unknown): CronDeliveryOutbox {
+  const parsed = outboxSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      "Invalid cron delivery outbox; preserve the task file for recovery",
+    );
+  }
+  return parsed.data;
+}

--- a/runtime/src/utils/cron-delivery-state.ts
+++ b/runtime/src/utils/cron-delivery-state.ts
@@ -62,6 +62,7 @@ const occurrenceSchema = z.strictObject({
   coalescedAt: timestamp,
   taskFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
   blockedReason: z.literal("task_changed").optional(),
+  admissionNoticeAttemptedAt: timestamp.optional(),
   lease: z.strictObject({
     token: identifier,
     expiresAt: timestamp,

--- a/runtime/src/utils/cronTasks.ts
+++ b/runtime/src/utils/cronTasks.ts
@@ -11,8 +11,8 @@
 
 import { randomUUID } from "crypto";
 import { readFileSync } from "fs";
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { join } from "path";
+import { mkdir, readFile, realpath, stat } from "fs/promises";
+import { dirname, join } from "path";
 import {
   addSessionCronTask,
   getProjectRoot,
@@ -22,6 +22,13 @@ import {
 import { computeNextCronRun, parseCronExpression } from "./cron.js";
 import { logForDebugging } from "./debug.js";
 import { isFsInaccessible } from "./errors.js";
+import { acquireLocalSqliteLock, assertLocalPrivateFile } from "./sqlite-lock.js";
+import { writeDurableAtomicFile } from "./durable-atomic-file.js";
+import {
+  MAX_CRON_FILE_BYTES,
+  parseCronDeliveryOutbox,
+  type CronDeliveryOutbox,
+} from "./cron-delivery-state.js";
 
 /**
  * Delivery routing for gateway-executed cron tasks (TODO task 16). A task
@@ -98,7 +105,10 @@ export type CronSessionQueueOwner = {
   readonly conversationId: string;
 };
 
-type CronFile = { tasks: CronTask[] };
+export type CronFile = {
+  tasks: CronTask[];
+  deliveryOutbox?: CronDeliveryOutbox;
+};
 
 const CRON_FILE_REL = join(".agenc", "scheduled_tasks.json");
 
@@ -134,7 +144,10 @@ export async function readCronTasks(dir?: string): Promise<CronTask[]> {
     return [];
   }
 
-  const parsed = parseCronJson(raw);
+  return parseCronTaskRecords(parseCronJson(raw));
+}
+
+function parseCronTaskRecords(parsed: unknown): CronTask[] {
   if (!parsed || typeof parsed !== "object") return [];
   const file = parsed as Partial<CronFile>;
   if (!Array.isArray(file.tasks)) return [];
@@ -203,26 +216,104 @@ export async function writeCronTasks(
   tasks: CronTask[],
   dir?: string,
 ): Promise<void> {
-  const root = dir ?? getProjectRoot();
-  await mkdir(join(root, ".agenc"), { recursive: true });
-  // Strip runtime-only routing fields. Everything on disk is durable by
-  // definition and binds to the scheduler activation that loads it. Persisting
-  // a conversation owner here would route a restarted task to a stale session.
-  const body: CronFile = {
-    tasks: tasks.map(
-      ({
-        durable: _durable,
-        queueOwner: _queueOwner,
-        agentId: _agentId,
-        ...rest
-      }) => rest,
-    ),
+  await mutateCronFile(dir, (state) => {
+    state.tasks = tasks;
+    if (state.deliveryOutbox !== undefined) {
+      const taskIds = new Set(tasks.map((task) => task.id));
+      state.deliveryOutbox.occurrences = state.deliveryOutbox.occurrences.filter(
+        (entry) => entry.completedAt !== undefined || taskIds.has(entry.taskId),
+      );
+    }
+  });
+}
+
+export async function readCronFile(dir?: string): Promise<CronFile> {
+  return readCronFileAtPath(getCronFilePath(dir));
+}
+
+async function readCronFileAtPath(path: string): Promise<CronFile> {
+  let raw: string;
+  try {
+    const metadata = await stat(path);
+    if (!metadata.isFile() || metadata.size > MAX_CRON_FILE_BYTES) {
+      throw new Error("Cron task file exceeds its storage limit or is not a file");
+    }
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { tasks: [] };
+    throw error;
+  }
+  if (Buffer.byteLength(raw, "utf8") > MAX_CRON_FILE_BYTES) {
+    throw new Error("Cron task file exceeds its storage limit");
+  }
+  const parsed = parseCronJson(raw);
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    !Array.isArray((parsed as CronFile).tasks)
+  ) {
+    throw new Error("Invalid cron task file; preserve it for recovery");
+  }
+  const outbox = (parsed as { deliveryOutbox?: unknown }).deliveryOutbox;
+  return {
+    tasks: parseCronTaskRecords(parsed),
+    ...(outbox !== undefined
+      ? { deliveryOutbox: parseCronDeliveryOutbox(outbox) }
+      : {}),
   };
-  await writeFile(
-    getCronFilePath(root),
-    JSON.stringify(body, null, 2) + "\n",
-    "utf-8",
-  );
+}
+
+export async function mutateCronFile<Result>(
+  dir: string | undefined,
+  mutate: (state: CronFile) => Result,
+): Promise<Result> {
+  const directory = dirname(getCronFilePath(dir));
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const canonicalDirectory = await realpath(directory);
+  const path = join(canonicalDirectory, "scheduled_tasks.json");
+  const release = await acquireLocalSqliteLock(`${path}.lock.sqlite`, {
+    timeoutMs: 5_000,
+    label: "cron task transaction",
+  });
+  try {
+    try {
+      await assertLocalPrivateFile(path, {
+        timeoutMs: 5_000,
+        label: "cron task file",
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const state = await readCronFileAtPath(path);
+    const result = mutate(state);
+    const body: CronFile = {
+      tasks: state.tasks.map(
+        ({
+          durable: _durable,
+          queueOwner: _queueOwner,
+          agentId: _agentId,
+          ...task
+        }) => task,
+      ),
+      ...(state.deliveryOutbox !== undefined
+        ? { deliveryOutbox: parseCronDeliveryOutbox(state.deliveryOutbox) }
+        : {}),
+    };
+    const serialized = `${JSON.stringify(body, null, 2)}\n`;
+    if (Buffer.byteLength(serialized, "utf8") > MAX_CRON_FILE_BYTES) {
+      throw new Error("Cron task file exceeds its storage limit");
+    }
+    await writeDurableAtomicFile(path, `${path}.${randomUUID()}.tmp`, serialized);
+    return result;
+  } finally {
+    release();
+  }
+}
+
+export async function appendCronTask(task: CronTask, dir?: string): Promise<void> {
+  await mutateCronFile(dir, (state) => {
+    state.tasks.push(task);
+  });
 }
 
 /**
@@ -275,9 +366,7 @@ export async function addCronTask(
     });
     return id;
   }
-  const tasks = await readCronTasks(dir);
-  tasks.push(task);
-  await writeCronTasks(tasks, dir);
+  await appendCronTask(task, dir);
   return id;
 }
 
@@ -338,10 +427,14 @@ export async function removeCronTasks(
     return;
   }
   const idSet = new Set(ids);
-  const tasks = await readCronTasks(dir);
-  const remaining = tasks.filter((t) => !idSet.has(t.id));
-  if (remaining.length === tasks.length) return;
-  await writeCronTasks(remaining, dir);
+  await mutateCronFile(dir, (state) => {
+    state.tasks = state.tasks.filter((task) => !idSet.has(task.id));
+    if (state.deliveryOutbox !== undefined) {
+      state.deliveryOutbox.occurrences = state.deliveryOutbox.occurrences.filter(
+        (entry) => !idSet.has(entry.taskId),
+      );
+    }
+  });
 }
 
 /**
@@ -362,16 +455,11 @@ export async function markCronTasksFired(
 ): Promise<void> {
   if (ids.length === 0) return;
   const idSet = new Set(ids);
-  const tasks = await readCronTasks(dir);
-  let changed = false;
-  for (const t of tasks) {
-    if (idSet.has(t.id)) {
-      t.lastFiredAt = firedAt;
-      changed = true;
+  await mutateCronFile(dir, (state) => {
+    for (const task of state.tasks) {
+      if (idSet.has(task.id)) task.lastFiredAt = firedAt;
     }
-  }
-  if (!changed) return;
-  await writeCronTasks(tasks, dir);
+  });
 }
 
 /**

--- a/runtime/tests/cronTasks.transactions.test.ts
+++ b/runtime/tests/cronTasks.transactions.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  appendCronTask,
+  getCronFilePath,
+  markCronTasksFired,
+  mutateCronFile,
+  readCronFile,
+  readCronTasks,
+  removeCronTasks,
+  writeCronTasks,
+  type CronTask,
+} from "../src/utils/cronTasks.js";
+import type { CronDeliveryOccurrence } from "../src/utils/cron-delivery-state.js";
+
+let workspace: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "agenc-cron-transaction-"));
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+function task(id: string): CronTask {
+  return {
+    id,
+    cron: "* * * * *",
+    prompt: "scheduled work",
+    createdAt: 1_000,
+    recurring: true,
+  };
+}
+
+function occurrence(taskId: string): CronDeliveryOccurrence {
+  return {
+    key: `${taskId}:60000`,
+    taskId,
+    dueAt: 60_000,
+    coalescedAt: 60_000,
+    taskFingerprint: "a".repeat(64),
+    model: { status: "pending", attempts: 0 },
+    webhook: { status: "pending", attempts: 0 },
+  };
+}
+
+describe("cron file transactions", () => {
+  test("serializes concurrent append and stamp operations without losing tasks", async () => {
+    await appendCronTask(task("first"), workspace);
+    await Promise.all([
+      ...Array.from({ length: 20 }, (_, ordinal) =>
+        appendCronTask(task(`added-${ordinal}`), workspace),
+      ),
+      markCronTasksFired(["first"], 75_000, workspace),
+    ]);
+
+    const tasks = await readCronTasks(workspace);
+    expect(tasks).toHaveLength(21);
+    expect(tasks.find((entry) => entry.id === "first")?.lastFiredAt).toBe(75_000);
+  });
+
+  test("preserves outbox state across ordinary task writes and removes canceled deliveries", async () => {
+    await writeCronTasks([task("delivery"), task("ordinary")], workspace);
+    await mutateCronFile(workspace, (state) => {
+      state.deliveryOutbox = { version: 1, occurrences: [occurrence("delivery")] };
+    });
+    await appendCronTask(task("added"), workspace);
+    await markCronTasksFired(["ordinary"], 90_000, workspace);
+    await removeCronTasks(["added"], workspace);
+
+    expect((await readCronFile(workspace)).deliveryOutbox?.occurrences).toEqual([
+      occurrence("delivery"),
+    ]);
+    await writeCronTasks(await readCronTasks(workspace), workspace);
+    expect((await readCronFile(workspace)).deliveryOutbox?.occurrences).toHaveLength(1);
+    await removeCronTasks(["delivery"], workspace);
+    expect((await readCronFile(workspace)).deliveryOutbox?.occurrences).toEqual([]);
+  });
+
+  test("does not publish partial task or outbox changes when a transaction fails", async () => {
+    await writeCronTasks([task("kept")], workspace);
+    const before = await readFile(getCronFilePath(workspace), "utf8");
+
+    await expect(mutateCronFile(workspace, (state) => {
+      state.tasks = [];
+      state.deliveryOutbox = { version: 1, occurrences: [occurrence("kept")] };
+      throw new Error("before publication");
+    })).rejects.toThrow("before publication");
+    expect(await readFile(getCronFilePath(workspace), "utf8")).toBe(before);
+  });
+
+  test("fails closed on invalid stored outbox state", async () => {
+    await writeCronTasks([task("kept")], workspace);
+    const invalid = JSON.stringify({ tasks: [task("kept")], deliveryOutbox: { version: 99 } });
+    await writeFile(getCronFilePath(workspace), invalid);
+
+    await expect(appendCronTask(task("new"), workspace)).rejects.toThrow("Invalid cron delivery outbox");
+    expect(await readFile(getCronFilePath(workspace), "utf8")).toBe(invalid);
+  });
+
+  test("publishes private task and payload files", async () => {
+    await writeCronTasks([task("private")], workspace);
+    if (process.platform !== "win32") {
+      expect((await stat(getCronFilePath(workspace))).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/runtime/tests/gateway/cron-delivery.test.ts
+++ b/runtime/tests/gateway/cron-delivery.test.ts
@@ -16,7 +16,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   startCronDelivery,
@@ -106,7 +106,7 @@ function manualClock(startMs: number): {
 } {
   let now = startMs;
   let nextId = 1;
-  const timers = new Map<number, { at: number; fn: () => void }>();
+  const timers = new Map<number, { at: number; fn: () => void | Promise<void> }>();
   // The runner's arm()/tick() await real fs I/O (readCronTasks), which
   // resolves on the macrotask queue — hop it, not just microtasks, or the
   // armed timer is invisible to advance().
@@ -129,7 +129,7 @@ function manualClock(startMs: number): {
     },
     async advance(ms: number) {
       const target = now + ms;
-      await flush();
+      await vi.waitFor(() => expect(timers.size).toBeGreaterThan(0));
       for (;;) {
         let dueId: number | null = null;
         let dueAt = Infinity;
@@ -143,7 +143,7 @@ function manualClock(startMs: number): {
         const t = timers.get(dueId)!;
         timers.delete(dueId);
         now = t.at;
-        t.fn();
+        await t.fn();
         await flush();
       }
       now = target;
@@ -160,7 +160,7 @@ describe("startCronDelivery", () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "agenc-cron-del-"));
     ws = join(home, "ws");
-    mkdirSync(join(ws, ".agenc"), { recursive: true });
+    mkdirSync(join(ws, ".agenc"), { recursive: true, mode: 0o700 });
   });
   afterEach(() => rmSync(home, { recursive: true, force: true }));
 
@@ -168,6 +168,7 @@ describe("startCronDelivery", () => {
     writeFileSync(
       join(ws, ".agenc", "scheduled_tasks.json"),
       JSON.stringify({ tasks }, null, 2),
+      { mode: 0o600 },
     );
   }
 
@@ -388,6 +389,81 @@ describe("startCronDelivery", () => {
     await handle.stop();
   });
 
+  test.each([
+    "turn_error",
+    "admission_pause",
+    "webhook_error",
+    "missing_adapter",
+    "errored",
+    "stopped",
+  ])("retains a failed one-shot occurrence for %s", async (failure) => {
+    const startMs = Date.parse("2026-07-09T10:00:30Z");
+    writeTasks([
+      {
+        id: "retry-one-shot",
+        cron: "* * * * *",
+        prompt: "retain this occurrence",
+        createdAt: startMs - 1_000,
+        deliver:
+          failure === "webhook_error"
+            ? { webhook: "https://hooks.example/retry" }
+            : {
+                channel: failure === "missing_adapter" ? "missing" : "mem",
+                to: "ops",
+              },
+      },
+    ]);
+    let attempts = 0;
+    const client: GatewayDaemonClient = {
+      async createSession() {
+        return {
+          sessionId: "retry-session",
+          async prompt(_text, handlers) {
+            attempts += 1;
+            if (failure === "turn_error") throw new Error("turn failed");
+            if (failure === "admission_pause") {
+              throw new Error("execution admission deny: budget_exceeded");
+            }
+            await handlers.onEvent({ type: "text", delta: "partial output" });
+            return {
+              stopReason:
+                failure === "errored" || failure === "stopped"
+                  ? failure
+                  : "completed",
+              finalMessage: "result",
+            };
+          },
+        };
+      },
+      async attachSession() {
+        throw new Error("unexpected attach");
+      },
+      async close() {},
+    };
+    const adapter = new InMemoryChannelAdapter({ id: "mem" });
+    const { clock, advance } = manualClock(startMs);
+    const handle = startCronDelivery({
+      ...baseOptions(client, adapter),
+      clock,
+      postWebhook: async () => {
+        throw new Error("webhook failed");
+      },
+    });
+
+    try {
+      await advance(35_000);
+      expect(attempts).toBe(1);
+      expect(await readCronTasks(ws)).toMatchObject([
+        { id: "retry-one-shot" },
+      ]);
+      if (failure === "errored" || failure === "stopped") {
+        expect(adapter.sent).toHaveLength(0);
+      }
+    } finally {
+      await handle.stop();
+    }
+  });
+
   test("unknown channel: fire is skipped gracefully without crashing", async () => {
     const startMs = Date.parse("2026-07-09T10:00:30Z");
     writeTasks([
@@ -421,7 +497,7 @@ describe("cron task delivery persistence", () => {
   let ws: string;
   beforeEach(() => {
     ws = mkdtempSync(join(tmpdir(), "agenc-cron-tasks-"));
-    mkdirSync(join(ws, ".agenc"), { recursive: true });
+    mkdirSync(join(ws, ".agenc"), { recursive: true, mode: 0o700 });
   });
   afterEach(async () => {
     const { resetStateForTests } = await import("../../src/bootstrap/state.js");

--- a/runtime/tests/gateway/cron-outbox.process.test.ts
+++ b/runtime/tests/gateway/cron-outbox.process.test.ts
@@ -1,0 +1,161 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { readCronFile, writeCronTasks } from "../../src/utils/cronTasks.js";
+import { CRON_DELIVERY_LEASE_MS } from "../../src/utils/cron-delivery-state.js";
+
+const CREATED_AT = Date.parse("2026-07-09T10:00:00Z");
+const DUE_AT = CREATED_AT + 60_000;
+const runnerUrl = new URL("../../src/gateway/cron-delivery.ts", import.meta.url).href;
+const outboxUrl = new URL("../../src/gateway/cron-outbox.ts", import.meta.url).href;
+const workerSource = `
+import { appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { once } from "node:events";
+import { startCronDelivery } from ${JSON.stringify(runnerUrl)};
+import { CronDeliveryOutboxStore } from ${JSON.stringify(outboxUrl)};
+const [workspace, mode, nowText] = process.argv.slice(1);
+const now = Number(nowText);
+const record = async (event) => appendFile(join(workspace, "external-effects.jsonl"), JSON.stringify(event) + "\\n", { mode: 0o600 });
+if (mode === "before_completion") {
+  CronDeliveryOutboxStore.prototype.complete = async () => process.exit(17);
+}
+try {
+  const session = {
+    sessionId: "process-session",
+    async prompt() {
+      await record({ kind: "model" });
+      if (mode === "hold") {
+        const input = once(process.stdin, "data");
+        process.stdin.resume();
+        process.stdout.write("HOLDING\\n");
+        await input;
+        process.stdin.pause();
+      }
+      return { stopReason: "completed", finalMessage: "persisted process result" };
+    },
+  };
+  let fire;
+  let armed;
+  const ready = new Promise((resolve) => { armed = resolve; });
+  const handle = startCronDelivery({
+    agencHome: join(workspace, "home"), workspaceDir: workspace, config: {},
+    client: { createSession: async () => session, attachSession: async () => session, close: async () => {} },
+    adapters: [{
+      id: "test", supportsEdit: false, start: async () => {}, stop: async () => {},
+      async send(message) {
+        if (mode === "after_result") process.exit(17);
+        await record({ kind: "channel", key: message.idempotencyKey });
+        if (mode === "after_channel_ack") process.exit(17);
+        return "message-id";
+      },
+    }],
+    postWebhook: async (_url, _body, key) => record({ kind: "webhook", key }),
+    log: (line) => process.stdout.write(line + "\\n"),
+    clock: {
+      now: () => new Date(now),
+      setTimer: (callback) => { fire = callback; armed(); return 1; },
+      clearTimer: () => {},
+    },
+  });
+  await ready;
+  await fire();
+  await handle.stop();
+  process.exit(0);
+} catch (error) {
+  process.stderr.write(String(error?.stack ?? error));
+  process.exit(2);
+}
+`;
+
+let workspace: string;
+const workers = new Set<{
+  child: ChildProcessWithoutNullStreams;
+  completion: Promise<{ code: number | null; stdout: string; stderr: string }>;
+}>();
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "agenc-cron-process-"));
+  await writeCronTasks([{
+    id: "delivery", cron: "* * * * *", prompt: "scheduled prompt", createdAt: CREATED_AT,
+    deliver: { channel: "test", to: "ops", webhook: "https://hooks.example/result" },
+  }], workspace);
+});
+
+afterEach(async () => {
+  for (const worker of workers) {
+    if (worker.child.exitCode === null && worker.child.signalCode === null) worker.child.kill("SIGKILL");
+  }
+  await Promise.all([...workers].map((worker) => worker.completion));
+  workers.clear();
+  await rm(workspace, { recursive: true, force: true });
+});
+
+function launch(mode: string, now = DUE_AT) {
+  const child = spawn(process.execPath, [
+    "--import", "tsx", "--input-type=module", "--eval", workerSource,
+    workspace, mode, String(now),
+  ], { cwd: join(import.meta.dirname, "../.."), stdio: "pipe" });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8").on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr.setEncoding("utf8").on("data", (chunk: string) => { stderr += chunk; });
+  const completion = new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+  });
+  const worker = { child, completion };
+  workers.add(worker);
+  return {
+    ...worker,
+    async waitForModel() {
+      await vi.waitFor(() => expect(stdout, stderr).toContain("HOLDING"), { timeout: 10_000 });
+    },
+  };
+}
+
+async function effects(): Promise<Array<{ kind: string; key?: string }>> {
+  return (await readFile(join(workspace, "external-effects.jsonl"), "utf8"))
+    .trim().split("\n").map((line) => JSON.parse(line));
+}
+
+describe("cron delivery process recovery", () => {
+  test.each(["after_result", "after_channel_ack", "before_completion"])("recovers after process exit at %s", async (point) => {
+    const crashed = await launch(point).completion;
+    expect(crashed.code, crashed.stderr).toBe(17);
+    const state = await readCronFile(workspace);
+    expect(state.tasks).toHaveLength(1);
+    expect(state.deliveryOutbox?.occurrences[0]?.model.status).toBe("delivered");
+    expect(state.deliveryOutbox?.occurrences[0]?.lease).toBeDefined();
+    const recovered = await launch("finish", DUE_AT + CRON_DELIVERY_LEASE_MS + 1).completion;
+    expect(recovered.code, recovered.stderr).toBe(0);
+    const recorded = await effects();
+    expect(recorded.filter((event) => event.kind === "model")).toHaveLength(1);
+    const channels = recorded.filter((event) => event.kind === "channel");
+    expect(channels).toHaveLength(point === "after_channel_ack" ? 2 : 1);
+    expect(new Set(channels.map((event) => event.key)).size).toBe(1);
+    expect(channels[0]?.key).toMatch(/^[a-f0-9]{64}$/);
+    expect(recorded.filter((event) => event.kind === "webhook")).toHaveLength(1);
+    expect((await readCronFile(workspace)).tasks).toEqual([]);
+  }, 30_000);
+
+  test("prevents concurrent gateway execution even when a live owner's lease has expired", async () => {
+    const owner = launch("hold");
+    await owner.waitForModel();
+    const before = (await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!;
+    const contenderTime = DUE_AT + CRON_DELIVERY_LEASE_MS + 1;
+    expect(before.lease!.expiresAt).toBeLessThan(contenderTime);
+    const contender = await launch("finish", contenderTime).completion;
+    expect(contender.code, contender.stderr).toBe(0);
+    expect(contender.stdout).toContain("delivery deferred");
+    expect((await effects()).filter((event) => event.kind === "model")).toHaveLength(1);
+    expect((await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!.lease).toEqual(before.lease);
+    owner.child.stdin.write("continue\n");
+    const finished = await owner.completion;
+    expect(finished.code, finished.stderr).toBe(0);
+    expect((await readCronFile(workspace)).tasks).toEqual([]);
+    expect((await effects()).filter((event) => event.kind === "model")).toHaveLength(1);
+  }, 30_000);
+});

--- a/runtime/tests/gateway/cron-outbox.test.ts
+++ b/runtime/tests/gateway/cron-outbox.test.ts
@@ -1,0 +1,315 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { startCronDelivery, type CronDeliveryHandle } from "../../src/gateway/cron-delivery.js";
+import { CronDeliveryOutboxStore } from "../../src/gateway/cron-outbox.js";
+import {
+  MAX_CRON_DELIVERY_ATTEMPTS,
+  MAX_CRON_PAYLOAD_BYTES,
+  MAX_CRON_OUTBOX_ENTRIES,
+  type CronDeliveryPayload,
+} from "../../src/utils/cron-delivery-state.js";
+import { getCronFilePath, mutateCronFile, readCronFile, removeCronTasks, writeCronTasks } from "../../src/utils/cronTasks.js";
+import type { ChannelAdapter, GatewayDaemonClient, GatewayPromptResult } from "../../src/gateway/types.js";
+import type { AgenCConfig } from "../../src/config/schema.js";
+
+const CREATED_AT = Date.parse("2026-07-09T10:00:00Z");
+const DUE_AT = CREATED_AT + 60_000;
+let workspace: string;
+const handles: CronDeliveryHandle[] = [];
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "agenc-cron-outbox-"));
+  await writeCronTasks([{
+    id: "delivery",
+    cron: "* * * * *",
+    prompt: "scheduled prompt",
+    createdAt: CREATED_AT,
+    deliver: { channel: "test", to: "ops", webhook: "https://hooks.example/result" },
+  }], workspace);
+});
+
+afterEach(async () => {
+  await Promise.all(handles.splice(0).map((handle) => handle.stop()));
+  await rm(workspace, { recursive: true, force: true });
+});
+
+function result(finalMessage = "completed result"): GatewayPromptResult {
+  return { stopReason: "completed", finalMessage };
+}
+
+function start(options: {
+  now?: number;
+  prompt?: () => Promise<GatewayPromptResult>;
+  send?: ChannelAdapter["send"];
+  postWebhook?: (url: string, body: unknown, key?: string) => Promise<void>;
+  missingAdapter?: boolean;
+}) {
+  let now = options.now ?? CREATED_AT;
+  let callback: (() => void | Promise<void>) | undefined;
+  let scheduledAt = Infinity;
+  const model = vi.fn(options.prompt ?? (async () => result()));
+  const send = vi.fn(options.send ?? (async () => "message-id"));
+  const postWebhook = vi.fn(options.postWebhook ?? (async () => {}));
+  const session = {
+    sessionId: "outbox-session",
+    prompt: model,
+  };
+  const client: GatewayDaemonClient = {
+    createSession: async () => session,
+    attachSession: async () => session,
+    close: async () => {},
+  };
+  const lines: string[] = [];
+  const handle = startCronDelivery({
+    agencHome: join(workspace, "home"),
+    workspaceDir: workspace,
+    config: {} as AgenCConfig,
+    client,
+    adapters: options.missingAdapter ? [] : [{
+      id: "test",
+      supportsEdit: false,
+      start: async () => {},
+      stop: async () => {},
+      send,
+    }],
+    postWebhook,
+    log: (line) => lines.push(line),
+    clock: {
+      now: () => new Date(now),
+      setTimer: (timer, milliseconds) => {
+        callback = timer;
+        scheduledAt = now + milliseconds;
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      },
+      clearTimer: () => { callback = undefined; },
+    },
+  });
+  handles.push(handle);
+  return {
+    handle,
+    model,
+    send,
+    postWebhook,
+    lines,
+    get scheduledAt() { return scheduledAt; },
+    async fire(at = DUE_AT) {
+      await vi.waitFor(() => expect(callback).toBeDefined());
+      now = at;
+      const timer = callback!;
+      callback = undefined;
+      await timer();
+    },
+  };
+}
+
+describe("durable cron delivery", () => {
+  test.each(["channel", "webhook"] as const)("retries only the failed %s destination after restart", async (phase) => {
+    const first = start({
+      ...(phase === "channel" ? { send: async () => { throw new Error("private channel failure"); } } : {}),
+      ...(phase === "webhook" ? { postWebhook: async () => { throw new Error("private webhook failure"); } } : {}),
+    });
+    await first.fire();
+    expect(first.model).toHaveBeenCalledTimes(1);
+    expect(first.send).toHaveBeenCalledTimes(1);
+    expect(first.postWebhook).toHaveBeenCalledTimes(1);
+    const persisted = await readCronFile(workspace);
+    const entry = persisted.deliveryOutbox!.occurrences[0]!;
+    expect(entry.model.status).toBe("delivered");
+    expect(entry[phase]?.status).toBe("retryable");
+    expect(persisted.tasks).toHaveLength(1);
+    expect(await readFile(getCronFilePath(workspace), "utf8")).not.toContain("private ");
+    const retryAt = entry[phase]!.nextAttemptAt!;
+    await first.handle.stop();
+
+    const restarted = start({ now: DUE_AT });
+    await restarted.fire(retryAt - 1);
+    expect(restarted.model).not.toHaveBeenCalled();
+    expect(restarted.send).not.toHaveBeenCalled();
+    expect(restarted.postWebhook).not.toHaveBeenCalled();
+    await restarted.fire(retryAt);
+    expect(restarted.model).not.toHaveBeenCalled();
+    expect(restarted.send).toHaveBeenCalledTimes(phase === "channel" ? 1 : 0);
+    expect(restarted.postWebhook).toHaveBeenCalledTimes(phase === "webhook" ? 1 : 0);
+    if (phase === "webhook") {
+      expect(restarted.postWebhook.mock.calls[0]).toEqual(first.postWebhook.mock.calls[0]);
+    } else {
+      expect(restarted.send.mock.calls[0]).toEqual(first.send.mock.calls[0]);
+    }
+    expect((await readCronFile(workspace)).tasks).toEqual([]);
+  });
+
+  test.each(["errored", "stopped"] as const)("persists retry state for a %s result without delivering text", async (stopReason) => {
+    const runner = start({ prompt: async () => ({ stopReason, finalMessage: "partial" }) });
+    await runner.fire();
+    expect(runner.send).not.toHaveBeenCalled();
+    expect(runner.postWebhook).not.toHaveBeenCalled();
+    const state = await readCronFile(workspace);
+    expect(state.tasks).toHaveLength(1);
+    expect(state.deliveryOutbox?.occurrences[0]?.model).toMatchObject({
+      status: "retryable", attempts: 1, lastError: `turn_${stopReason}`,
+    });
+  });
+
+  test("records only a fixed admission error class and preserves the occurrence", async () => {
+    const runner = start({ prompt: async () => {
+      throw new Error("execution admission deny: budget_exceeded token=secret-value");
+    } });
+    await runner.fire();
+    expect((await readCronFile(workspace)).deliveryOutbox?.occurrences[0]?.model.lastError).toBe("admission_pause");
+    expect(await readFile(getCronFilePath(workspace), "utf8")).not.toContain("secret-value");
+    expect(runner.lines.join("\n")).not.toContain("secret-value");
+    expect(runner.send.mock.calls[0]?.[0].text).toContain("budget_exceeded");
+    expect(runner.send.mock.calls[0]?.[0].text).not.toContain("secret-value");
+    expect(runner.postWebhook).not.toHaveBeenCalled();
+  });
+
+  test("uses the persisted model result when a missing adapter becomes available", async () => {
+    const first = start({ missingAdapter: true });
+    await first.fire();
+    const state = await readCronFile(workspace);
+    const channel = state.deliveryOutbox!.occurrences[0]!.channel!;
+    expect(channel.lastError).toBe("missing_adapter");
+    await first.handle.stop();
+    const restarted = start({ now: DUE_AT });
+    await restarted.fire(channel.nextAttemptAt!);
+    expect(restarted.model).not.toHaveBeenCalled();
+    expect(restarted.send).toHaveBeenCalledTimes(1);
+    expect(restarted.postWebhook).not.toHaveBeenCalled();
+    expect((await readCronFile(workspace)).tasks).toEqual([]);
+  });
+
+  test.each([
+    { acknowledgments: 0, changed: false },
+    { acknowledgments: 1, changed: false },
+    { acknowledgments: 2, changed: false },
+    { acknowledgments: 2, changed: true },
+  ])("recovers persisted acknowledgments=$acknowledgments, task changed=$changed", async ({ acknowledgments, changed }) => {
+    const store = new CronDeliveryOutboxStore(workspace);
+    await store.withClaim("delivery", () => DUE_AT, async (claim) => {
+      await store.beginAttempt(claim, "model", DUE_AT);
+      const payload: CronDeliveryPayload = {
+        taskId: "delivery", occurrenceId: claim.key, cron: "* * * * *",
+        prompt: "scheduled prompt", finalMessage: "saved result",
+        stopReason: "completed", firedAt: new Date(DUE_AT).toISOString(),
+      };
+      await store.persistResult(claim, payload);
+      for (const phase of (["channel", "webhook"] as const).slice(0, acknowledgments)) {
+        await store.beginAttempt(claim, phase, DUE_AT);
+        await store.markDelivered(claim, phase);
+      }
+    });
+    expect((await readCronFile(workspace)).tasks).toHaveLength(1);
+    if (changed) {
+      await mutateCronFile(workspace, (state) => {
+        state.tasks[0]!.prompt = "new task contents";
+      });
+    }
+    const runner = start({ now: DUE_AT });
+    await runner.fire(DUE_AT + 1_000);
+    expect(runner.model).not.toHaveBeenCalled();
+    expect(runner.send).toHaveBeenCalledTimes(acknowledgments >= 1 ? 0 : 1);
+    expect(runner.postWebhook).toHaveBeenCalledTimes(acknowledgments >= 2 ? 0 : 1);
+    const recovered = await readCronFile(workspace);
+    if (changed) {
+      expect(recovered.tasks).toHaveLength(1);
+      expect(recovered.deliveryOutbox?.occurrences[0]?.blockedReason).toBe("task_changed");
+      expect(runner.scheduledAt).toBe(DUE_AT + 1_000 + 5 * 60_000);
+    } else {
+      expect(recovered.tasks).toEqual([]);
+    }
+  });
+
+  test("coalesces missed recurring slots through successful completion", async () => {
+    await mutateCronFile(workspace, (state) => { state.tasks[0]!.recurring = true; });
+    const late = DUE_AT + 3 * 60 * 60_000;
+    const runner = start({ now: late });
+    await runner.fire(late);
+    let state = await readCronFile(workspace);
+    expect(state.tasks[0]?.lastFiredAt).toBe(late);
+    expect(state.deliveryOutbox?.occurrences[0]?.dueAt).toBe(DUE_AT);
+    expect(runner.model).toHaveBeenCalledTimes(1);
+    await runner.fire(late + 1_000);
+    expect(runner.model).toHaveBeenCalledTimes(1);
+    await runner.fire(late + 60_000);
+    state = await readCronFile(workspace);
+    expect(runner.model).toHaveBeenCalledTimes(2);
+    expect(state.tasks[0]?.lastFiredAt).toBe(late + 60_000);
+  });
+
+  test("does not deliver or recreate a task deleted while its model turn runs", async () => {
+    let finish!: (value: GatewayPromptResult) => void;
+    const pending = new Promise<GatewayPromptResult>((resolve) => { finish = resolve; });
+    const runner = start({ prompt: () => pending });
+    const firing = runner.fire();
+    await vi.waitFor(() => expect(runner.model).toHaveBeenCalledTimes(1));
+    await removeCronTasks(["delivery"], workspace);
+    finish(result());
+    await firing;
+    expect(runner.send).not.toHaveBeenCalled();
+    expect(runner.postWebhook).not.toHaveBeenCalled();
+    expect((await readCronFile(workspace)).tasks).toEqual([]);
+  });
+
+  test("keeps oversized results as terminal failures without external delivery", async () => {
+    const runner = start({ prompt: async () => result("x".repeat(MAX_CRON_PAYLOAD_BYTES)) });
+    await runner.fire();
+    const state = await readCronFile(workspace);
+    expect(state.tasks).toHaveLength(1);
+    expect(state.deliveryOutbox?.occurrences[0]?.model).toMatchObject({ status: "terminal", lastError: "payload_too_large" });
+    expect(state.deliveryOutbox?.occurrences[0]?.payload).toBeUndefined();
+    expect(runner.send).not.toHaveBeenCalled();
+    expect(runner.postWebhook).not.toHaveBeenCalled();
+  });
+
+  test("bounds destination attempts and retains exhausted failures for operators", async () => {
+    const runner = start({ postWebhook: async () => { throw new Error("still failing"); } });
+    await runner.fire();
+    for (let attempt = 1; attempt < MAX_CRON_DELIVERY_ATTEMPTS; attempt += 1) {
+      const phase = (await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!.webhook!;
+      await runner.fire(phase.nextAttemptAt!);
+    }
+    const state = await readCronFile(workspace);
+    expect(state.tasks).toHaveLength(1);
+    expect(state.deliveryOutbox?.occurrences[0]?.webhook).toMatchObject({ status: "terminal", attempts: MAX_CRON_DELIVERY_ATTEMPTS });
+    expect(runner.model).toHaveBeenCalledTimes(1);
+    expect(runner.send).toHaveBeenCalledTimes(1);
+    expect(runner.postWebhook).toHaveBeenCalledTimes(MAX_CRON_DELIVERY_ATTEMPTS);
+    expect(runner.lines.at(-1)).toContain("requires operator action");
+    await runner.fire(runner.scheduledAt);
+    expect(runner.postWebhook).toHaveBeenCalledTimes(MAX_CRON_DELIVERY_ATTEMPTS);
+  });
+
+  test.each([false, true])("bounds outbox records without evicting unresolved entries, completed=%s", async (completed) => {
+    await mutateCronFile(workspace, (state) => {
+      state.deliveryOutbox = {
+        version: 1,
+        occurrences: Array.from({ length: MAX_CRON_OUTBOX_ENTRIES }, (_, ordinal) => {
+          const taskId = "retained-" + ordinal;
+          const key = taskId + ":" + DUE_AT;
+          return {
+            taskId, key, dueAt: DUE_AT, coalescedAt: DUE_AT,
+            taskFingerprint: "a".repeat(64),
+            model: { status: completed ? "delivered" as const : "pending" as const, attempts: completed ? 1 : 0 },
+            webhook: { status: completed ? "delivered" as const : "pending" as const, attempts: completed ? 1 : 0 },
+            ...(completed ? {
+              completedAt: DUE_AT,
+              payload: {
+                taskId, occurrenceId: key, cron: "* * * * *", prompt: "old prompt",
+                finalMessage: "old result", stopReason: "completed" as const,
+                firedAt: new Date(DUE_AT).toISOString(),
+              },
+            } : {}),
+          };
+        }),
+      };
+    });
+    const runner = start({});
+    await runner.fire();
+    const state = await readCronFile(workspace);
+    expect(runner.model).toHaveBeenCalledTimes(completed ? 1 : 0);
+    expect(state.deliveryOutbox?.occurrences).toHaveLength(completed ? 1 : MAX_CRON_OUTBOX_ENTRIES);
+    expect(state.tasks).toHaveLength(completed ? 0 : 1);
+  });
+});

--- a/runtime/tests/gateway/cron-outbox.test.ts
+++ b/runtime/tests/gateway/cron-outbox.test.ts
@@ -94,6 +94,7 @@ function start(options: {
     postWebhook,
     lines,
     get scheduledAt() { return scheduledAt; },
+    setNow(at: number) { now = at; },
     async fire(at = DUE_AT) {
       await vi.waitFor(() => expect(callback).toBeDefined());
       now = at;
@@ -105,6 +106,30 @@ function start(options: {
 }
 
 describe("durable cron delivery", () => {
+  test.each(["model", "errored", "channel", "webhook"] as const)("backs off after a slow %s failure finishes", async (failure) => {
+    const finishedAt = DUE_AT + 120_000;
+    const fail = async () => {
+      runner.setNow(finishedAt);
+      throw new Error("delayed failure");
+    };
+    const runner = start({
+      ...(failure === "model" ? { prompt: fail } : {}),
+      ...(failure === "errored" ? { prompt: async () => {
+        runner.setNow(finishedAt);
+        return { stopReason: "errored" as const, finalMessage: "partial" };
+      } } : {}),
+      ...(failure === "channel" ? { send: fail } : {}),
+      ...(failure === "webhook" ? { postWebhook: fail } : {}),
+    });
+    await runner.fire();
+    const phase = failure === "errored" ? "model" : failure;
+    const entry = (await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!;
+    const retryAt = entry[phase]!.nextAttemptAt!;
+    expect(retryAt).toBeGreaterThanOrEqual(finishedAt + 22_500);
+    expect(retryAt).toBeLessThanOrEqual(finishedAt + 37_500);
+    expect(runner.scheduledAt).toBe(retryAt);
+  });
+
   test.each(["channel", "webhook"] as const)("retries only the failed %s destination after restart", async (phase) => {
     const first = start({
       ...(phase === "channel" ? { send: async () => { throw new Error("private channel failure"); } } : {}),

--- a/runtime/tests/gateway/cron-outbox.test.ts
+++ b/runtime/tests/gateway/cron-outbox.test.ts
@@ -190,6 +190,40 @@ describe("durable cron delivery", () => {
     expect(runner.postWebhook).not.toHaveBeenCalled();
   });
 
+  test.each([false, true])("does not repeat an admission notice across retries and restart, notice failed=%s", async (noticeFails) => {
+    const prompt = async () => {
+      throw new Error("execution admission deny: budget_exceeded");
+    };
+    let recordedBeforeSend = false;
+    const notice = vi.fn(async () => {
+      const entry = (await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!;
+      recordedBeforeSend = entry.admissionNoticeAttemptedAt === DUE_AT;
+      if (noticeFails) throw new Error("notice transport failed");
+      return "notice-id";
+    });
+    const first = start({ prompt, send: notice });
+    await first.fire();
+    const firstEntry = (await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!;
+    await first.fire(firstEntry.model.nextAttemptAt!);
+    await first.handle.stop();
+    const retryAt = (await readCronFile(workspace)).deliveryOutbox!.occurrences[0]!.model.nextAttemptAt!;
+    const restarted = start({ now: retryAt, prompt, send: notice });
+    await restarted.fire(retryAt);
+
+    expect(first.model).toHaveBeenCalledTimes(2);
+    expect(restarted.model).toHaveBeenCalledTimes(1);
+    expect(notice).toHaveBeenCalledTimes(1);
+    expect(recordedBeforeSend).toBe(true);
+    expect(first.send.mock.calls[0]?.[0].idempotencyKey).toMatch(/^[a-f0-9]{64}$/);
+    const state = await readCronFile(workspace);
+    expect(state.tasks).toHaveLength(1);
+    expect(state.deliveryOutbox!.occurrences[0]!).toMatchObject({
+      admissionNoticeAttemptedAt: DUE_AT,
+      model: { status: "retryable", attempts: 3 },
+      channel: { status: "pending", attempts: 0 },
+    });
+  });
+
   test("uses the persisted model result when a missing adapter becomes available", async () => {
     const first = start({ missingAdapter: true });
     await first.fire();

--- a/runtime/tests/gateway/cron-webhook-ssrf.test.ts
+++ b/runtime/tests/gateway/cron-webhook-ssrf.test.ts
@@ -75,6 +75,18 @@ describe("assertCronWebhookUrlSafe", () => {
 });
 
 describe("postCronWebhook", () => {
+  it.each([400, 404, 429, 500, 503])(
+    "rejects unsuccessful HTTP status %s",
+    async (statusCode) => {
+      await expect(
+        postCronWebhook("https://public.test/hook", { ok: true }, {
+          lookup: async () => [PUBLIC_ADDRESS_A],
+          request: async () => ({ statusCode }),
+        }),
+      ).rejects.toThrow(/HTTP/);
+    },
+  );
+
   it("passes only the approved address to the transport", async () => {
     const requests: CronWebhookRequest[] = [];
     let lookups = 0;
@@ -140,6 +152,7 @@ describe("postCronWebhook", () => {
     };
 
     await postCronWebhook("https://public.test/hook", { ok: true }, {
+      idempotencyKey: "stable-webhook-delivery",
       lookup: async (hostname) =>
         hostname === "public.test" ? [PUBLIC_ADDRESS_A] : [PUBLIC_ADDRESS_B],
       request,
@@ -148,6 +161,10 @@ describe("postCronWebhook", () => {
     expect(requests.map(({ address }) => address)).toEqual([
       PUBLIC_ADDRESS_A,
       PUBLIC_ADDRESS_B,
+    ]);
+    expect(requests.map((request) => request.idempotencyKey)).toEqual([
+      "stable-webhook-delivery",
+      "stable-webhook-delivery",
     ]);
     expect(requests.map(({ method }) => method)).toEqual(["POST", "POST"]);
     expect(Buffer.from(requests[1]!.body!).toString("utf8")).toBe(
@@ -216,9 +233,11 @@ describe("requestPinnedCronWebhook", () => {
 
   it("dials the approved IP without resolving the URL hostname", async () => {
     let receivedHost: string | undefined;
+    let receivedKey: string | string[] | undefined;
     let receivedBody = "";
     const server = createServer((request, response) => {
       receivedHost = request.headers.host;
+      receivedKey = request.headers["idempotency-key"];
       request.setEncoding("utf8");
       request.on("data", (chunk: string) => {
         receivedBody += chunk;
@@ -244,11 +263,13 @@ describe("requestPinnedCronWebhook", () => {
         address: "127.0.0.1",
         method: "POST",
         body: Buffer.from('{"pinned":true}', "utf8"),
+        idempotencyKey: "stable-webhook-delivery",
         signal: AbortSignal.timeout(1_000),
       }),
     ).resolves.toEqual({ statusCode: 204 });
 
     expect(receivedHost).toBe(`must-not-resolve.invalid:${port}`);
+    expect(receivedKey).toBe("stable-webhook-delivery");
     expect(receivedBody).toBe('{"pinned":true}');
   });
 });

--- a/runtime/tests/gateway/discord.test.ts
+++ b/runtime/tests/gateway/discord.test.ts
@@ -13,6 +13,7 @@ import {
   DISCORD_MESSAGE_LIMIT,
   DISCORD_OP,
   DiscordChannelAdapter,
+  FetchDiscordTransport,
   type DiscordGatewayPayload,
   type DiscordSocketHandlers,
   type DiscordTransport,
@@ -284,6 +285,46 @@ describe("discord run-loop wiring contract", () => {
 });
 
 describe("DiscordChannelAdapter outbound", () => {
+  test("reuses a distinct bounded nonce for each chunk of a retried delivery", async () => {
+    const createMessage = vi.fn<DiscordTransport["createMessage"]>(async () => ({ id: "sent" }));
+    const transport: DiscordTransport = {
+      getGatewayUrl: async () => "wss://unused.example",
+      connect: async () => ({ send: () => {}, close: () => {} }),
+      createMessage,
+      editMessage: async () => {},
+    };
+    const adapter = new DiscordChannelAdapter({ transport, token: "unused" });
+    const message = { conversationId: "ops", text: "x".repeat(4500), idempotencyKey: "stable-delivery" };
+    await adapter.send(message);
+    const firstNonces = createMessage.mock.calls.map((call) => call[2]);
+    expect(firstNonces).toHaveLength(3);
+    expect(new Set(firstNonces).size).toBe(3);
+    for (const nonce of firstNonces) expect(nonce).toMatch(/^[a-f0-9]{24}$/);
+    await adapter.send(message);
+    expect(createMessage.mock.calls.slice(3).map((call) => call[2])).toEqual(firstNonces);
+    await adapter.send({ ...message, idempotencyKey: "next-delivery" });
+    expect(createMessage.mock.calls[6]?.[2]).not.toBe(firstNonces[0]);
+  });
+
+  test("enforces nonce deduplication in the production Discord request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ id: "sent" }), { status: 200 }),
+    );
+    try {
+      const transport = new FetchDiscordTransport({ token: "unused" });
+      await transport.createMessage("ops", "message", "bounded-nonce");
+      expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
+        content: "message", nonce: "bounded-nonce", enforce_nonce: true,
+      });
+      await transport.createMessage("ops", "ordinary");
+      expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).toEqual({ content: "ordinary" });
+      await expect(transport.createMessage("ops", "message", "x".repeat(26))).rejects.toThrow("nonce");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   test("send creates a message and edit routes to the stored target", async () => {
     const h = await makeAdapter();
     const handle = await h.adapter.send({

--- a/runtime/tests/gateway/run.test.ts
+++ b/runtime/tests/gateway/run.test.ts
@@ -6,7 +6,7 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   GATEWAY_DIRECT_PROVIDER_ADMISSION_DIAGNOSTIC,
@@ -583,7 +583,7 @@ describe("startGateway", () => {
   test("cron delivery: a deliver-tagged task fires through the run loop to a channel", async () => {
     writeConfig({ channels: { mem: { dmPolicy: "allowlist", allowlist: ["x"] } } });
     const ws = join(home, "ws");
-    mkdirSync(join(ws, ".agenc"), { recursive: true });
+    mkdirSync(join(ws, ".agenc"), { recursive: true, mode: 0o700 });
     const startMs = Date.parse("2026-07-09T10:00:30Z");
     writeFileSync(
       join(ws, ".agenc", "scheduled_tasks.json"),
@@ -599,6 +599,7 @@ describe("startGateway", () => {
           },
         ],
       }),
+      { mode: 0o600 },
     );
 
     const client = new FakeClient();
@@ -606,11 +607,11 @@ describe("startGateway", () => {
 
     // Manual cron clock: capture armed timers, fire the earliest by hand.
     let now = startMs;
-    const timers = new Map<number, { at: number; fn: () => void }>();
+    const timers = new Map<number, { at: number; fn: () => void | Promise<void> }>();
     let nextTimer = 1;
     const cronClock = {
       now: () => new Date(now),
-      setTimer: (fn: () => void, ms: number) => {
+      setTimer: (fn: () => void | Promise<void>, ms: number) => {
         const id = nextTimer++;
         timers.set(id, { at: now + ms, fn });
         return id as unknown as ReturnType<typeof setTimeout>;
@@ -629,13 +630,12 @@ describe("startGateway", () => {
     });
 
     // Let arm() finish its async file read, then fire the armed timer.
-    await new Promise((r) => setTimeout(r, 20));
+    await vi.waitFor(() => expect(timers.size).toBeGreaterThan(0));
     const armed = [...timers.values()].sort((a, b) => a.at - b.at)[0];
     expect(armed).toBeDefined();
     now = armed.at;
     timers.delete([...timers.keys()][0]);
-    armed.fn();
-    await new Promise((r) => setTimeout(r, 30));
+    await armed.fn();
 
     // The cron turn ran in its own gateway session and delivered in-channel.
     expect(mem.sent.some((m) => m.conversationId === "c9")).toBe(true);

--- a/runtime/tests/onboarding/acts.test.ts
+++ b/runtime/tests/onboarding/acts.test.ts
@@ -265,7 +265,7 @@ describe("channel act (O-3)", () => {
 
 describe("autonomy act (O-5): guardrails before autonomy", () => {
   test("sets the budget cap, then heartbeat/cron/hooks configure", async () => {
-    mkdirSync(ws, { recursive: true });
+    mkdirSync(ws, { recursive: true, mode: 0o700 });
     markOnboardingActComplete(home, "identity", { workspace: ws });
     const { io, output } = createScriptedActIO([
       "2.5", // daily cap


### PR DESCRIPTION
## Changes

- Persist a bounded cron outbox beside the task list, using the existing SQLite process lock and durable atomic file writer. Serialize task creation, deletion, and fired timestamps with delivery updates.
- Claim each occurrence under a process lock and a persisted crash-recovery lease. Save completed model results before sending, then retry channel and webhook destinations independently with persisted attempt counts, fixed error classes, and bounded backoff.
- Keep failed tasks pending. Missing adapters, non-completed turns, and unsuccessful HTTP responses cannot consume an occurrence. Complete the outbox record and remove or advance its task in one file replacement.
- Send stable webhook idempotency keys and Discord per-chunk enforced nonces. Document the external acknowledgment/local commit crash window, pre-result model retry limit, storage bounds, operator recovery, and upgrade precautions.
- Persist a best-effort admission notice attempt before sending. Model retries and restarts cannot repeat the notice, and its stable key is separate from result delivery.

Closes #1865.

## Local verification

- Eleven regressions fail against the original code, covering six failed one-shot outcomes and five unsuccessful HTTP statuses.
- Four further regressions reject retry deadlines measured before a slow attempt finishes. Each now passes with backoff measured from the failure time.
- Focused gateway, scheduler, transaction, onboarding, and cron tool tests pass, 488 tests across 37 files with no skips. Four tests use independent gateway processes to verify crash recovery and live-lock exclusion beyond lease expiry. Two additional regressions reproduce duplicate admission notices before the review fix and prove a successful or failed notice is not repeated across retries and restart.
- Runtime and test-support typechecks pass. Build, generated SDK parity, and all six PTY startup checks pass.
- The full local root `npm test` passes from clean final commit `89a6d1babd8f671acac939297032a0f6989a6a43`, including 23,174 runtime tests across 2,263 files with zero failures or skips. Final typechecks, build, generated SDK parity, and all six PTY startup checks pass.
- Native Windows and macOS checks are unavailable on this Linux host. No paid hosted tests were dispatched. Hosted test CI remains disabled at the user's request.

## Impact and review

GitNexus pre-edit analysis flagged shared cron task operations and the outbound channel message type as HIGH impact. The affected paths include scheduler persistence, onboarding, gateway startup, and channel adapters. Discord interface dispatch is only partly represented in the index. Initial staged detection reported the expected 17 files with stale symbol offsets. After the first commit, the index includes the new outbox symbols. Final staged detection flags eight expected cron execution flows as HIGH impact. The actual diff was also reviewed directly; earlier index refresh attempts failed with invalid UTF-8 or native allocator corruption.

Bugbot identified repeated admission-pause notices. Commit `89a6d1babd8f671acac939297032a0f6989a6a43` records a single notice attempt durably and supplies its own idempotency key. Bugbot re-review passes with no unresolved findings. Cursor approved that exact commit at 06:15:48 UTC on September 8, 2026.

Sonar's gate passes. Its six maintainability notes concern function complexity, nested conditionals, and numeric grouping; it reports no security hotspots.
