### PR TITLE
docs(runtime): remove false Gemini retirement claim

### DIFF
--- a/runtime/src/llm/registry/provider-info.ts
+++ b/runtime/src/llm/registry/provider-info.ts
@@ -492,8 +492,6 @@ export const BUILT_IN_PROVIDER_DEFINITIONS = Object.freeze({
   }),
   gemini: providerDefinition({
     name: "Gemini",
-    // gemini-2.5-pro is retired for new keys (404 pointing at the 3.x
-    // line), so the default must live on the current family.
     defaultModel: "gemini-3.1-pro-preview",
     baseURL: GEMINI_DEVELOPER_NATIVE_BASE_URL,
     credentials: apiKeyCredentials(["GEMINI_API_KEY", "GOOGLE_API_KEY"]),


### PR DESCRIPTION
## Correction

Remove the comment claiming stable `gemini-2.5-pro` is retired for new keys and returns a 404 directing users to Gemini 3.x. Google's current deprecation table lists no shutdown date for that stable model. [Google's deprecation table](https://ai.google.dev/gemini-api/docs/deprecations#gemini-25-pro-models), checked September 8, 2026.

The default remains `gemini-3.1-pro-preview`. This PR changes two comment lines only. Comment-free emitted JavaScript is identical before and after the edit.

## Mainline receipt refresh

Addresses #1885. The issue stays open until the follow-up benchmark receipt and full validation are complete.

The FND receipt binds the exact bytes of `provider-info.ts` in the CSV scheduler's loaded production-module closure. This comment correction intentionally makes that receipt stale. The unchanged capture rules require the measured source revision to be an ancestor of the default branch with an identical complete production tree, so the source correction must merge first.

After this PR merges, capture from that exact mainline SHA using the documented `benchmark:fnd-baseline` command. Regenerate the JSON and Markdown together in a separate reviewed artifact PR, check their bindings and digest, and run the full local `npm test` gate from a clean tree. No provenance rule, ancestry check, or tree binding is relaxed.

## Local verification

- All 257 provider registry, ingress, ambiguity, and Gemini adapter tests pass across five files with zero skips.
- Runtime and test-support typechecks pass. The comment-free JavaScript comparison passes.
- The benchmark contract passes nine tests and reports exactly one expected failure, the stale `csv_scheduler_progress_scan` production-module closure. The receipt and verifier are unchanged in this source PR.
- GitNexus reports LOW impact and no changed executable symbols. Only `provider-info.ts` changes.
- The false retirement claim is absent from runtime source and user documentation after the edit.
- Hosted test CI remains disabled at the user's request. No hosted tests were dispatched.

Cursor approved `8a7e3728e90474fc28ce5f1c644413d09b029e44` at 06:38:43 UTC on September 8, 2026. Bugbot, security review, and Sonar checks pass with no review findings.
