### PR TITLE
fix(runtime): align Gemini reasoning-effort capabilities

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -258,7 +258,7 @@ otherwise.
 | `model_provider` | `grok` |
 | `approval_policy` | `on-request` |
 | `sandbox_mode` | `workspace-write` |
-| `reasoning_effort` | `medium` |
+| `reasoning_effort` | `medium`; omitted for Gemini unless explicitly configured |
 | `approvals_reviewer` | `user` |
 | `agent_max_depth` | `1` |
 | `auth.backend` | `remote` |

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -26,6 +26,41 @@ Bare interactive startup with a fresh install uses the **config** default
 explicit model, the registry also uses **`grok-4.6`**. Managed OpenRouter is a
 separate provider route and its paid default remains **`x-ai/grok-4.5`**.
 
+## Gemini reasoning effort
+
+The native Gemini adapter sends an explicit effort as
+`generationConfig.thinkingConfig.thinkingLevel`. The model catalog, `/effort`,
+child-agent and role overrides, and provider/model switch checks use the same
+supported-level metadata.
+
+| Model | Explicit levels | Provider default when omitted |
+| --- | --- | --- |
+| `gemini-3.1-pro-preview` | `low`, `medium`, `high` | `high` |
+| `gemini-3.7-flash` | `low`, `medium`, `high` | `medium` |
+| `gemini-3.5-flash` | `minimal`, `low`, `medium`, `high` | `medium` |
+| `gemini-3-flash-preview` | `minimal`, `low`, `medium`, `high` | `high` |
+| `gemini-3-pro-preview` | `low`, `high` | `high` |
+
+An unconfigured Gemini session leaves thinking controls out of the request.
+An explicit `reasoning_effort = "none"` also omits the control, even when
+another configured effort would otherwise apply. Neither case disables the
+model's thinking. `/effort default` removes the saved override. A compatible
+effort already stamped on a session remains in effect after a provider switch.
+
+Unsupported explicit levels fail before a request is sent. AgenC does not
+translate `minimal`, `xhigh`, or `max` into a different Gemini level. Unknown
+model variants do not inherit levels from a name prefix. Gemini 2.5 Pro,
+Flash, and Flash-Lite use `thinkingBudget` on the native `generateContent`
+API, so AgenC does not accept named effort levels for those models or invent
+a token-budget conversion.
+
+Sources checked on 2026-09-08: Google's
+[native ThinkingConfig reference](https://ai.google.dev/api/generate-content#ThinkingConfig),
+[thinking guide](https://ai.google.dev/gemini-api/docs/thinking), and
+[Gemini 3 guide](https://ai.google.dev/gemini-api/docs/gemini-3).
+The Interactions API's level abstraction for Gemini 2.5 does not apply to
+AgenC's native `generateContent` requests.
+
 ## Single provider authority
 
 Startup provider selection is explicit and layered. Before managed policy is

--- a/runtime/src/config/repository.ts
+++ b/runtime/src/config/repository.ts
@@ -1500,6 +1500,15 @@ async function loadLayeredConfigInternal(
     sources.push(merged.source);
   }
 
+  if (
+    config.model_provider === "gemini" &&
+    provenance.reasoning_effort?.scope === "default"
+  ) {
+    const { reasoning_effort: _defaultEffort, ...providerDefaults } = config;
+    config = providerDefaults;
+    delete provenance.reasoning_effort;
+  }
+
   config = mergeConfigs(config, {
     configVersion: CANONICAL_CONFIG_VERSION,
   });

--- a/runtime/src/llm/model-registry.ts
+++ b/runtime/src/llm/model-registry.ts
@@ -74,6 +74,7 @@ function inferDefaultReasoningLevel(
   entry: ModelRegistryEntry,
   supportedReasoningLevels: readonly ReasoningEffort[],
 ): ReasoningEffort | undefined {
+  if (entry.provider === "gemini") return undefined;
   const catalog = resolveRegisteredModelCatalogEntry({
     provider: entry.provider,
     model: entry.model,

--- a/runtime/src/llm/providers/gemini/index.ts
+++ b/runtime/src/llm/providers/gemini/index.ts
@@ -12,6 +12,7 @@ import {
 } from "../../client-session.js";
 import { parseSSEFrames } from "../../_deps/sse.js";
 import { LLMProviderError } from "../../errors.js";
+import { resolveGeminiReasoningEffort } from "../../registry/gemini-thinking-models.js";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -2491,6 +2492,7 @@ function geminiToolConfig(
 }
 
 function geminiGenerationConfig(
+  model: string,
   options: LLMChatOptions | undefined,
   defaultMaxTokens: number | undefined,
   schemaCapabilities: GeminiResponseJsonSchemaCapabilities,
@@ -2512,22 +2514,8 @@ function geminiGenerationConfig(
   ) {
     config.stopSequences = [...options.stopSequences];
   }
-  // Thinking depth here is `thinking_level`, not a token budget: the
-  // documented rungs are minimal/low/medium/high depending on the model.
-  // Mapping the app's ladder onto them is what makes an effort choice
-  // reach this provider at all — without it the setting was inert.
-  const effort = options?.reasoningEffort;
-  if (effort !== undefined) {
-    // gemini-3.1-pro-preview, the curated model here, documents low/medium/high
-    // only: minimal folds down, and xhigh/max fold up to its ceiling.
-    const level =
-      effort === "minimal" || effort === "low"
-        ? "low"
-        : effort === "medium"
-          ? "medium"
-          : "high";
-    // Nested under thinkingConfig, camelCase: the flat snake_case field
-    // is not part of this API's generation config and 400s the request.
+  const level = resolveGeminiReasoningEffort(model, options?.reasoningEffort);
+  if (level !== undefined) {
     config.thinkingConfig = { thinkingLevel: level };
   }
   const structuredSchema = options?.structuredOutput?.schema;
@@ -2583,6 +2571,7 @@ function buildGeminiRequest(args: {
       ? { systemInstruction: contents.systemInstruction }
       : {}),
     generationConfig: geminiGenerationConfig(
+      args.model,
       args.options,
       args.config.maxTokens,
       schemaCapabilities,

--- a/runtime/src/llm/registry/gemini-thinking-models.ts
+++ b/runtime/src/llm/registry/gemini-thinking-models.ts
@@ -1,0 +1,50 @@
+import { LLMProviderError } from "../errors.js";
+
+export type GeminiThinkingLevel = "minimal" | "low" | "medium" | "high";
+
+interface GeminiThinkingModel {
+  readonly model: string;
+  readonly control: "thinkingLevel" | "thinkingBudget";
+  readonly levels: readonly GeminiThinkingLevel[];
+  readonly defaultLevel?: GeminiThinkingLevel;
+  readonly curated: boolean;
+}
+
+const PRO_LEVELS = Object.freeze(["low", "medium", "high"] as const);
+const FLASH_LEVELS = Object.freeze(["minimal", ...PRO_LEVELS] as const);
+const ORIGINAL_PRO_LEVELS = Object.freeze(["low", "high"] as const);
+const BUDGET_LEVELS = Object.freeze([] as const);
+
+export const GEMINI_THINKING_MODELS: readonly GeminiThinkingModel[] = Object.freeze(([
+  { model: "gemini-3.1-pro-preview", control: "thinkingLevel", levels: PRO_LEVELS, defaultLevel: "high", curated: true },
+  { model: "gemini-3.7-flash", control: "thinkingLevel", levels: PRO_LEVELS, defaultLevel: "medium", curated: true },
+  { model: "gemini-3.5-flash", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "medium", curated: true },
+  { model: "gemini-2.5-flash", control: "thinkingBudget", levels: BUDGET_LEVELS, curated: true },
+  { model: "gemini-3-flash-preview", control: "thinkingLevel", levels: FLASH_LEVELS, defaultLevel: "high", curated: false },
+  { model: "gemini-3-pro-preview", control: "thinkingLevel", levels: ORIGINAL_PRO_LEVELS, defaultLevel: "high", curated: false },
+  { model: "gemini-2.5-pro", control: "thinkingBudget", levels: BUDGET_LEVELS, curated: false },
+  { model: "gemini-2.5-flash-lite", control: "thinkingBudget", levels: BUDGET_LEVELS, curated: false },
+] satisfies GeminiThinkingModel[]).map((entry) => Object.freeze(entry)));
+
+export function resolveGeminiThinkingModel(model: string): GeminiThinkingModel | undefined {
+  const normalized = model.trim().toLowerCase()
+    .replace(/^gemini:/u, "")
+    .replace(/^publishers\/google\/models\//u, "")
+    .replace(/^models\//u, "")
+    .replace(/^google\//u, "");
+  return GEMINI_THINKING_MODELS.find((entry) => entry.model === normalized);
+}
+
+export function resolveGeminiReasoningEffort(
+  model: string,
+  effort: string | undefined,
+): GeminiThinkingLevel | undefined {
+  if (effort === undefined || effort === "none") return undefined;
+  const metadata = resolveGeminiThinkingModel(model);
+  const supported = metadata?.levels.find((level) => level === effort);
+  if (metadata?.control === "thinkingLevel" && supported !== undefined) return supported;
+  const detail = metadata?.control === "thinkingBudget"
+    ? "This model uses thinkingBudget, not reasoning-effort levels."
+    : `Supported reasoning efforts: ${metadata?.levels.join(", ") || "none verified"}.`;
+  throw new LLMProviderError("gemini", `Reasoning effort '${effort}' is not supported for model '${model}'. ${detail}`, 400);
+}

--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -16,6 +16,10 @@ import {
 import type { ReasoningEffort, ReasoningSummary } from "../../session/turn-context.js";
 import { normalizeProviderIdentity } from "../../provider-identity.js";
 import { OPENAI_REASONING_MODELS } from "./openai-reasoning-models.js";
+import {
+  GEMINI_THINKING_MODELS,
+  resolveGeminiThinkingModel,
+} from "./gemini-thinking-models.js";
 
 export type ModelInputModality = "text" | "image" | "audio";
 export type ModelWebSearchToolType = "none" | "text" | "text_and_image";
@@ -454,6 +458,25 @@ const OPENAI_PERSONALITY_MESSAGES: ModelMessages = Object.freeze({
 
 export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
   Object.freeze([
+    ...GEMINI_THINKING_MODELS.map((entry, index): RegisteredModelCatalogEntry => ({
+      provider: "gemini",
+      model: entry.model,
+      displayName: entry.model,
+      inputModalities: TEXT_IMAGE_MODALITIES,
+      supportsToolUse: true,
+      supportsParallelToolCalls: false,
+      supportsStructuredOutput: false,
+      supportsStructuredOutputWithTools: false,
+      supportsSearchTool: false,
+      supportsVerbosity: false,
+      webSearchToolType: "none",
+      supportsReasoningSummaries: false,
+      defaultReasoningSummary: "none",
+      supportedReasoningLevels: entry.levels,
+      additionalSpeedTiers: NO_ADDITIONAL_SPEED_TIERS,
+      priority: index,
+      visibility: entry.curated ? "list" : "none",
+    })),
     ...OPENAI_REASONING_MODELS.map((entry, index): RegisteredModelCatalogEntry => ({
       provider: "openai",
       model: entry.model,
@@ -1027,6 +1050,12 @@ export function resolveRegisteredModelCatalogEntry(input: {
   const candidates = REGISTERED_MODEL_CATALOG.filter(
     (entry) => modelCatalogProviderIdentity(entry.provider) === provider,
   );
+  if (provider === "gemini") {
+    return findExactModel(
+      resolveGeminiThinkingModel(model)?.model ?? "",
+      candidates,
+    );
+  }
   const exact = findExactModel(model, candidates) ??
     findNamespacedSuffix(model, candidates, true);
   if (exact !== undefined) return exact;

--- a/runtime/src/llm/shape-request.ts
+++ b/runtime/src/llm/shape-request.ts
@@ -1,11 +1,13 @@
 import { isDeepStrictEqual } from "node:util";
 import type { ProviderModelCapabilities } from "./capabilities.js";
+import { resolveRegisteredModelCatalogEntry } from "./registry/model-catalog.js";
 
 export interface SessionHistoryRequirements {
   readonly hasImageHistory: boolean;
   readonly hasAudioHistory: boolean;
   readonly hasThinkingHistory: boolean;
   readonly reasoningEffortRequested: boolean;
+  readonly reasoningEffort?: string;
 }
 
 export interface HistoryCompatibilityCheck {
@@ -112,6 +114,7 @@ export function analyzeSessionHistoryRequirements(
   const reasoningEffort = state.sessionConfiguration?.collaborationMode?.reasoningEffort;
   return {
     ...requirements,
+    ...(typeof reasoningEffort === "string" ? { reasoningEffort } : {}),
     reasoningEffortRequested:
       typeof reasoningEffort === "string" &&
       reasoningEffort.length > 0 &&
@@ -134,7 +137,15 @@ export function validateHistoryCompatibility(
   if (requirements.hasThinkingHistory && !caps.acceptsThinkingHistory) {
     missing.push("thinking history");
   }
-  if (requirements.reasoningEffortRequested && !caps.acceptsReasoningEffort) {
+  const levels = resolveRegisteredModelCatalogEntry(caps)
+    ?.supportedReasoningLevels;
+  const unsupportedEffort = requirements.reasoningEffort !== undefined &&
+    levels !== undefined &&
+    !levels.some((level) => level === requirements.reasoningEffort);
+  if (
+    requirements.reasoningEffortRequested &&
+    (!caps.acceptsReasoningEffort || unsupportedEffort)
+  ) {
     missing.push("reasoning effort");
   }
 

--- a/runtime/src/llm/shape-request.ts
+++ b/runtime/src/llm/shape-request.ts
@@ -137,11 +137,11 @@ export function validateHistoryCompatibility(
   if (requirements.hasThinkingHistory && !caps.acceptsThinkingHistory) {
     missing.push("thinking history");
   }
-  const levels = resolveRegisteredModelCatalogEntry(caps)
+  const levels: readonly string[] | undefined = resolveRegisteredModelCatalogEntry(caps)
     ?.supportedReasoningLevels;
   const unsupportedEffort = requirements.reasoningEffort !== undefined &&
     levels !== undefined &&
-    !levels.some((level) => level === requirements.reasoningEffort);
+    !levels.includes(requirements.reasoningEffort);
   if (
     requirements.reasoningEffortRequested &&
     (!caps.acceptsReasoningEffort || unsupportedEffort)

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -77,6 +77,18 @@ import { resolveGeminiReasoningEffort } from "../llm/registry/gemini-thinking-mo
 
 type WireReasoningEffort = NonNullable<LLMChatOptions["reasoningEffort"]>;
 
+function resolveGeminiSessionReasoningEffort(
+  turnEffort: ReasoningEffort | undefined,
+  model: string,
+  effortSource: string | undefined,
+): WireReasoningEffort | undefined {
+  if (turnEffort !== undefined) return resolveGeminiReasoningEffort(model, turnEffort);
+  const configuredEffort = effortSource === "default"
+    ? undefined
+    : getInitialEffortSetting();
+  return resolveGeminiReasoningEffort(model, configuredEffort);
+}
+
 /**
  * Sessions created without an explicit reasoning effort — every
  * daemon-spawned interactive session today — must still honor the
@@ -101,20 +113,20 @@ function resolveSessionReasoningEffort(
     readonly effortSource?: string;
   },
 ): WireReasoningEffort | undefined {
+  if (selection?.provider === "gemini") {
+    return resolveGeminiSessionReasoningEffort(
+      turnEffort,
+      selection.model,
+      selection.effortSource,
+    );
+  }
   let requested: ReasoningEffort | undefined;
   if (turnEffort === undefined) {
-    if (
-      selection?.provider === "gemini" &&
-      selection.effortSource === "default"
-    ) return undefined;
     requested = getInitialEffortSetting();
   } else if (turnEffort !== "none") {
     requested = turnEffort;
   }
   if (requested === undefined) return undefined;
-  if (selection?.provider === "gemini") {
-    return resolveGeminiReasoningEffort(selection.model, requested);
-  }
   if (requested === "max" || requested === "xhigh") {
     if (supportedReasoningLevels === undefined) {
       return requested === "max" ? "xhigh" : requested;
@@ -339,8 +351,8 @@ function buildProviderOptions(
       ctx.reasoningEffort,
       ctx.modelInfo.supportedReasoningLevels,
       {
-        provider: ctx.provider.name,
-        model: ctx.modelInfo.slug,
+        provider: session.services.provider.name,
+        model: session.config?.model ?? ctx.modelInfo.slug,
         effortSource: session.services.configStore
           ?.provenance?.("reasoning_effort")?.scope,
       },

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -73,6 +73,7 @@ import {
   getInitialEffortSetting,
 } from "../utils/effort.js";
 import type { ReasoningEffort } from "../session/turn-context.js";
+import { resolveGeminiReasoningEffort } from "../llm/registry/gemini-thinking-models.js";
 
 type WireReasoningEffort = NonNullable<LLMChatOptions["reasoningEffort"]>;
 
@@ -94,14 +95,26 @@ type WireReasoningEffort = NonNullable<LLMChatOptions["reasoningEffort"]>;
 function resolveSessionReasoningEffort(
   turnEffort: ReasoningEffort | undefined,
   supportedReasoningLevels?: ReadonlyArray<ReasoningEffort>,
+  selection?: {
+    readonly provider: string;
+    readonly model: string;
+    readonly effortSource?: string;
+  },
 ): WireReasoningEffort | undefined {
   let requested: ReasoningEffort | undefined;
   if (turnEffort === undefined) {
+    if (
+      selection?.provider === "gemini" &&
+      selection.effortSource === "default"
+    ) return undefined;
     requested = getInitialEffortSetting();
   } else if (turnEffort !== "none") {
     requested = turnEffort;
   }
   if (requested === undefined) return undefined;
+  if (selection?.provider === "gemini") {
+    return resolveGeminiReasoningEffort(selection.model, requested);
+  }
   if (requested === "max" || requested === "xhigh") {
     if (supportedReasoningLevels === undefined) {
       return requested === "max" ? "xhigh" : requested;
@@ -325,6 +338,12 @@ function buildProviderOptions(
     reasoningEffort: resolveSessionReasoningEffort(
       ctx.reasoningEffort,
       ctx.modelInfo.supportedReasoningLevels,
+      {
+        provider: ctx.provider.name,
+        model: ctx.modelInfo.slug,
+        effortSource: session.services.configStore
+          ?.provenance?.("reasoning_effort")?.scope,
+      },
     ),
     reasoningSummary: ctx.reasoningSummary,
     modelVerbosity: ctx.modelVerbosity,

--- a/runtime/src/utils/effort.ts
+++ b/runtime/src/utils/effort.ts
@@ -14,6 +14,7 @@ import {
 import { get3PModelCapabilityOverride } from './model/modelSupportOverrides.js'
 import { resolveRegisteredModelCatalogEntry } from '../llm/registry/model-catalog.js'
 import { isVerifiedOpenAiReasoningModel } from '../llm/registry/openai-reasoning-models.js'
+import { resolveGeminiThinkingModel } from '../llm/registry/gemini-thinking-models.js'
 import type { EffortLevel } from 'src/entrypoints/sdk/runtimeTypes.js'
 import { resolveSecureStorageHome } from './secureStorage/home.js'
 
@@ -62,6 +63,9 @@ function inferCatalogProvider(
   }
   const normalizedModel = model.trim().toLowerCase()
   if (normalizedModel.startsWith('grok-')) return 'grok'
+  if (
+    normalizedModel.startsWith('gemini-') || resolveGeminiThinkingModel(model)
+  ) return 'gemini'
   if (normalizedModel.startsWith('muse-spark-')) return 'meta'
   if (isVerifiedOpenAiReasoningModel(normalizedModel)) return 'openai'
   return undefined
@@ -578,6 +582,9 @@ function getDefaultEffortForModelForOptionalContext(
   }
 
   const registeredProvider = inferCatalogProvider(model, context)
+  if (registeredProvider === 'gemini') {
+    return resolveGeminiThinkingModel(model)?.defaultLevel
+  }
   const registeredEntry =
     registeredProvider === 'meta' ||
       registeredProvider === 'zai' ||

--- a/runtime/tests/agents/v2/spawn-isolation.test.ts
+++ b/runtime/tests/agents/v2/spawn-isolation.test.ts
@@ -11,6 +11,8 @@ import type { Session } from "../../session/session.js";
 import { createAgentRoleWorkspace } from "../role.js";
 import { AgentRoleCatalog } from "../role-catalog.js";
 import { signSessionId } from "../_deps/filesystem-args.js";
+import { StaticModelsManager } from "../../../src/llm/models-manager.js";
+import { defaultConfig } from "../../../src/config/schema.js";
 
 const ROLE_WORKSPACE = createAgentRoleWorkspace("/repo");
 const ROLE_CATALOG = new AgentRoleCatalog(ROLE_WORKSPACE);
@@ -105,6 +107,45 @@ function makeOptions(
 describe("spawn_agent isolation", () => {
   beforeEach(() => {
     mockDelegate.mockReset();
+  });
+
+  it.each(["override", "role"] as const)("validates Gemini %s effort against real model metadata", async (source) => {
+    const modelsManager = new StaticModelsManager({
+      config: { ...defaultConfig(), model_provider: "gemini", model: "gemini-3.1-pro-preview" },
+    });
+    const base = makeSession();
+    const session = {
+      ...base,
+      modelInfo: await modelsManager.getModelInfo("gemini-3.1-pro-preview"),
+      sessionConfiguration: { ...base.sessionConfiguration, collaborationMode: { model: "gemini-3.1-pro-preview" } },
+      services: { ...base.services, modelsManager },
+    } as Session;
+    for (const effort of ["low", "medium", "high", "none", "minimal", "xhigh", "max"] as const) {
+      mockDelegate.mockReset();
+      mockDelegate.mockResolvedValue({ kind: "async_launched", thread: fakeThread(false) } as never);
+      const options = makeOptions(session);
+      const roleOptions = source === "role" ? {
+        ...options,
+        ensureAgentControl: () => {
+          const original = options.ensureAgentControl(session);
+          return { ...original, control: { ...original.control, roleCatalog: { require: () => ({ name: "gemini-review", config: { reasoningEffort: effort } }) } } };
+        },
+      } as unknown as MultiAgentV2Options : options;
+      const result = await createSpawnAgentTool(roleOptions).execute({
+        message: "review fixture",
+        task_name: "gemini_review",
+        ...(source === "role" ? { agent_type: "gemini-review" } : { reasoning_effort: effort }),
+        __callId: `gemini-${source}-${effort}`,
+      });
+      if (["low", "medium", "high", "none"].includes(effort)) {
+        expect(result.isError).not.toBe(true);
+        expect(mockDelegate).toHaveBeenCalledWith(expect.objectContaining({ reasoningEffort: effort }));
+      } else {
+        expect(result.isError).toBe(true);
+        expect(String(result.content)).toMatch(/is not supported for model|invalid reasoning_effort/u);
+        expect(mockDelegate).not.toHaveBeenCalled();
+      }
+    }
   });
 
   it("refuses an unknown model as a confirmed no-effect failure before anything is spawned", async () => {

--- a/runtime/tests/commands/effort.test.ts
+++ b/runtime/tests/commands/effort.test.ts
@@ -65,6 +65,52 @@ function commandContext(
   };
 }
 
+describe("/effort Gemini catalog levels", () => {
+  beforeEach(() => settings.update.mockReset());
+
+  test("displays the exact Pro levels and provider default", async () => {
+    const { context } = commandContext("gemini-3.1-pro-preview", "", { provider: "gemini" });
+    const result = await effortCommand.execute(context);
+    expect(result).toMatchObject({ kind: "text" });
+    if (result.kind === "text") {
+      expect(result.text).toContain("high effort (model default)");
+      expect(result.text).toContain("low/medium/high");
+    }
+  });
+
+  test.each(["low", "medium", "high"])("sets Pro %s without translation", async (level) => {
+    const { context, getAppState } = commandContext("gemini-3.1-pro-preview", level, { provider: "gemini" });
+    expect(await effortCommand.execute(context)).toMatchObject({ kind: "text" });
+    expect(settings.update).toHaveBeenCalledWith("userSettings", { reasoning_effort: level });
+    expect(getAppState()).toMatchObject({ effortValue: level });
+  });
+
+  test.each(["minimal", "xhigh", "max"])("rejects unsupported Pro %s", async (level) => {
+    const { context } = commandContext("gemini-3.1-pro-preview", level, { provider: "gemini" });
+    const result = await effortCommand.execute(context);
+    expect(result).toMatchObject({ kind: "error" });
+    if (result.kind === "error") expect(result.message).toContain("Available: low, medium, high");
+    expect(settings.update).not.toHaveBeenCalled();
+  });
+
+  test("allows minimal on Flash and resets to its documented default", async () => {
+    const { context } = commandContext("gemini-3.5-flash", "minimal", { provider: "gemini" });
+    expect(await effortCommand.execute(context)).toMatchObject({ kind: "text" });
+    expect(settings.update).toHaveBeenLastCalledWith("userSettings", { reasoning_effort: "minimal" });
+    const reset = commandContext("gemini-3.5-flash", "default", { provider: "gemini" });
+    const result = await effortCommand.execute(reset.context);
+    expect(result).toMatchObject({ kind: "text" });
+    if (result.kind === "text") expect(result.text).toContain("default (medium)");
+    expect(settings.update).toHaveBeenLastCalledWith("userSettings", { reasoning_effort: undefined });
+  });
+
+  test.each(["gemini-2.5-flash", "gemini-3.1-pro-preview-unverified"])("does not offer level controls for %s", async (model) => {
+    const { context } = commandContext(model, "low", { provider: "gemini" });
+    expect(await effortCommand.execute(context)).toMatchObject({ kind: "error" });
+    expect(settings.update).not.toHaveBeenCalled();
+  });
+});
+
 describe("/effort Grok catalog levels", () => {
   beforeEach(() => {
     settings.update.mockReset();

--- a/runtime/tests/commands/model.test.ts
+++ b/runtime/tests/commands/model.test.ts
@@ -229,6 +229,22 @@ describe("checkModelHistoryCompat", () => {
   });
 });
 
+describe("Gemini effort switch compatibility", () => {
+  it.each([
+    ["grok", "grok-4.6", "high", "gemini", "gemini-3.1-pro-preview", true],
+    ["grok", "grok-4.6", "xhigh", "gemini", "gemini-3.1-pro-preview", false],
+    ["gemini", "gemini-3.5-flash", "minimal", "gemini", "gemini-3.1-pro-preview", false],
+    ["gemini", "gemini-3.1-pro-preview", "medium", "gemini", "gemini-3-pro-preview", false],
+    ["gemini", "gemini-3.1-pro-preview", "low", "grok", "grok-4.6", true],
+    ["gemini", "gemini-3.5-flash", "minimal", "grok", "grok-4.6", false],
+    ["gemini", "gemini-3.1-pro-preview", "none", "gemini", "gemini-2.5-flash", true],
+    ["gemini", "gemini-3.1-pro-preview", "high", "gemini", "gemini-2.5-flash", false],
+  ] as const)("checks %s/%s %s against %s/%s", (provider, model, reasoningEffort, targetProvider, targetModel, compatible) => {
+    const session = stubSession({ provider, model, reasoningEffort });
+    expect(checkModelHistoryCompat(session, targetModel, targetProvider).compatible).toBe(compatible);
+  });
+});
+
 describe("modelCommand", () => {
   it("is userInvocable and immediate", () => {
     expect(modelCommand.userInvocable).toBe(true);

--- a/runtime/tests/llm/gemini-reasoning-effort.test.ts
+++ b/runtime/tests/llm/gemini-reasoning-effort.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GeminiProvider } from "../../src/llm/providers/gemini/index.js";
+import { createGeminiEndpointPlan } from "../../src/llm/providers/gemini/endpoint-plan.js";
+import { resolveRegisteredModelCatalogEntry } from "../../src/llm/registry/model-catalog.js";
+import { resolveProviderModelCapabilities } from "../../src/llm/capabilities.js";
+import { StaticModelsManager } from "../../src/llm/models-manager.js";
+import { defaultConfig } from "../../src/config/schema.js";
+import { loadCanonicalConfig, loadCanonicalDaemonConfig } from "../../src/config/repository.js";
+import { sessionConfigurationFromAgenCConfig } from "../../src/session/configuration.js";
+import { createTokenAccountingRequest } from "../../src/llm/token-accounting.js";
+import type { LLMChatOptions } from "../../src/llm/types.js";
+
+const MODEL_LEVELS = [
+  ["gemini-3.1-pro-preview", ["low", "medium", "high"]],
+  ["gemini-3.7-flash", ["low", "medium", "high"]],
+  ["gemini-3.5-flash", ["minimal", "low", "medium", "high"]],
+  ["gemini-3-flash-preview", ["minimal", "low", "medium", "high"]],
+  ["gemini-3-pro-preview", ["low", "high"]],
+  ["gemini-2.5-pro", []],
+  ["gemini-2.5-flash", []],
+  ["gemini-2.5-flash-lite", []],
+] as const;
+const DIRECTORIES: string[] = [];
+
+afterEach(() => {
+  for (const directory of DIRECTORIES.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Gemini reasoning metadata", () => {
+  test.each(MODEL_LEVELS)("shares exact %s levels without imposing a session default", async (model, levels) => {
+    expect(resolveRegisteredModelCatalogEntry({ provider: "gemini", model })?.supportedReasoningLevels).toEqual(levels);
+    expect(resolveProviderModelCapabilities({ provider: "gemini", model }).acceptsReasoningEffort).toBe(levels.length > 0);
+    const manager = new StaticModelsManager({
+      config: { ...defaultConfig(), model_provider: "gemini", model },
+    });
+    const info = await manager.getModelInfo(model);
+    expect(info.supportedReasoningLevels).toEqual(levels);
+    expect(info.defaultReasoningLevel).toBeUndefined();
+  });
+
+  test.each(["gemini-3.1-pro-preview-unverified", "gemini-3.5-flash-unverified"])("does not grant levels to %s", (model) => {
+    expect(resolveRegisteredModelCatalogEntry({ provider: "gemini", model })).toBeUndefined();
+    expect(resolveProviderModelCapabilities({ provider: "gemini", model }).acceptsReasoningEffort).toBe(false);
+  });
+});
+
+describe.each(["chat", "stream", "count"] as const)("Gemini %s reasoning wire contract", (operation) => {
+  async function request(model: string, effort: LLMChatOptions["reasoningEffort"]) {
+    const payload = { candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }] };
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => operation === "stream"
+      ? new Response(`data: ${JSON.stringify(payload)}\n\n`, { headers: { "content-type": "text/event-stream" } })
+      : Response.json(operation === "count" ? { totalTokens: 1 } : payload));
+    const provider = new GeminiProvider({
+      model: "gemini-2.5-flash",
+      endpointPlan: createGeminiEndpointPlan(),
+      credentialPlan: { kind: "api-key", credential: "fixture", source: "factory" },
+      fetchImpl,
+    });
+    const messages = [{ role: "user" as const, content: "fixture" }];
+    const options = { model, reasoningEffort: effort };
+    const result = operation === "chat" ? provider.chat(messages, options)
+      : operation === "stream" ? provider.chatStream(messages, () => {}, options)
+        : provider.tokenCountCapability.countTokens(createTokenAccountingRequest({ provider: "gemini", model, messages, options, reservedOutputTokens: 0 }), new AbortController().signal);
+    return { result, fetchImpl };
+  }
+
+  for (const [model, levels] of MODEL_LEVELS) {
+    for (const effort of levels) test(`${model} sends exact ${effort}`, async () => {
+      const { result, fetchImpl } = await request(model, effort);
+      await result;
+      const body = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body));
+      const generationConfig = operation === "count" ? body.generateContentRequest.generationConfig : body.generationConfig;
+      expect(generationConfig.thinkingConfig).toEqual({ thinkingLevel: effort });
+    });
+
+    test.each([undefined, "none"] as const)(`${model} omits thinking for %s`, async (effort) => {
+      const { result, fetchImpl } = await request(model, effort);
+      await result;
+      const body = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body));
+      const generationConfig = operation === "count" ? body.generateContentRequest.generationConfig : body.generationConfig;
+      expect(generationConfig).not.toHaveProperty("thinkingConfig");
+    });
+  }
+
+  test.each([
+    ["gemini-3.1-pro-preview", "minimal"],
+    ["gemini-3.1-pro-preview", "xhigh"],
+    ["gemini-3.1-pro-preview", "max"],
+    ["gemini-3-pro-preview", "medium"],
+    ["gemini-2.5-flash", "high"],
+    ["gemini-3.1-pro-preview-unverified", "low"],
+  ] as const)("rejects %s %s before transport", async (model, effort) => {
+    const { result, fetchImpl } = await request(model, effort);
+    await expect(result).rejects.toThrow(/reasoning effort/iu);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("Gemini canonical effort configuration", () => {
+  test.each([loadCanonicalConfig, loadCanonicalDaemonConfig])("preserves provider defaults and explicit settings through %s", async (load) => {
+    const directory = mkdtempSync(join(tmpdir(), "agenc-gemini-effort-"));
+    DIRECTORIES.push(directory);
+    const options = { home: directory, env: {}, managedConfigPath: join(directory, "managed.toml") };
+    for (const effort of [undefined, "none", "low", "medium", "high"] as const) {
+      writeFileSync(join(directory, "config.toml"), `config_version = 2\nmodel_provider = "gemini"\nmodel = "gemini-3.1-pro-preview"\n${effort === undefined ? "" : `reasoning_effort = "${effort}"\n`}`, { mode: 0o600 });
+      const loaded = await load(options);
+      expect(loaded.config.reasoning_effort).toBe(effort);
+      expect(loaded.provenance.reasoning_effort?.scope).toBe(effort === undefined ? undefined : "user");
+      const configuration = sessionConfigurationFromAgenCConfig({ config: loaded.config, workspaceRoot: directory, model: "gemini-3.1-pro-preview" });
+      expect(configuration.collaborationMode.reasoningEffort).toBe(effort);
+    }
+    writeFileSync(join(directory, "config.toml"), 'config_version = 2\nmodel_provider = "grok"\n', { mode: 0o600 });
+    expect((await load(options)).config.reasoning_effort).toBe("medium");
+  });
+});

--- a/runtime/tests/llm/shape-request.test.ts
+++ b/runtime/tests/llm/shape-request.test.ts
@@ -51,6 +51,7 @@ describe("analyzeSessionHistoryRequirements", () => {
       hasAudioHistory: true,
       hasThinkingHistory: true,
       reasoningEffortRequested: true,
+      reasoningEffort: "high",
     });
   });
 });

--- a/runtime/tests/phases/stream-model-reasoning-effort.test.ts
+++ b/runtime/tests/phases/stream-model-reasoning-effort.test.ts
@@ -94,6 +94,37 @@ describe("resolveSessionReasoningEffort", () => {
   });
 });
 
+describe("Gemini session reasoning effort", () => {
+  const selection = { provider: "gemini", model: "gemini-3.1-pro-preview" };
+
+  beforeEach(() => { settingsEffort.current = undefined; });
+
+  test.each(["low", "medium", "high"] as const)("preserves configured and stamped %s", (effort) => {
+    settingsEffort.current = effort;
+    expect(resolveSessionReasoningEffort(undefined, GROK_4_5_LEVELS, selection)).toBe(effort);
+    expect(resolveSessionReasoningEffort(effort, GROK_4_5_LEVELS, selection)).toBe(effort);
+    expect(resolveSessionReasoningEffort("none", GROK_4_5_LEVELS, selection)).toBeUndefined();
+  });
+
+  test("leaves an unconfigured Gemini effort absent", () => {
+    expect(resolveSessionReasoningEffort(undefined, GROK_4_5_LEVELS, selection)).toBeUndefined();
+  });
+
+  test("does not apply the daemon's built-in Grok default after a Gemini switch", () => {
+    settingsEffort.current = "medium";
+    const defaultSelection = { ...selection, effortSource: "default" };
+    expect(resolveSessionReasoningEffort(undefined, GROK_4_5_LEVELS, defaultSelection)).toBeUndefined();
+    expect(resolveSessionReasoningEffort("medium", GROK_4_5_LEVELS, defaultSelection)).toBe("medium");
+    expect(resolveSessionReasoningEffort(undefined, GROK_4_5_LEVELS, { ...selection, effortSource: "user" })).toBe("medium");
+  });
+
+  test.each(["max", "xhigh"] as const)("never folds unsupported %s to high", (effort) => {
+    expect(() => resolveSessionReasoningEffort(effort, GROK_4_5_LEVELS, selection)).toThrow(/reasoning effort/iu);
+    settingsEffort.current = effort;
+    expect(() => resolveSessionReasoningEffort(undefined, GROK_4_5_LEVELS, selection)).toThrow(/reasoning effort/iu);
+  });
+});
+
 describe("sessionConfigurationFromAgenCConfig reasoning effort seeding", () => {
   test.each(["max", "xhigh"] as const)("retains configured Spark 1.3 %s", (effort) => {
     const configured = sessionConfigurationFromAgenCConfig({

--- a/runtime/tests/phases/stream-model.test.ts
+++ b/runtime/tests/phases/stream-model.test.ts
@@ -278,6 +278,37 @@ function mkRegistry(tools: Tool[]): ToolRegistry {
 }
 
 describe("streamModel — live assistant text sanitization", () => {
+  test.each([
+    ["gemini-3.1-pro-preview", "high", true],
+    ["gemini-3.1-pro-preview", "xhigh", false],
+    ["gemini-3.5-flash", "minimal", true],
+  ] as const)("uses the live Gemini selection for %s %s", async (model, effort, accepted) => {
+    const baseContext = mkCtx();
+    const context = {
+      ...baseContext,
+      provider: { name: "grok" },
+      modelInfo: { ...baseContext.modelInfo, slug: "gemini-3.1-pro-preview" },
+      reasoningEffort: effort,
+    } as TurnContext;
+    const dispatch = vi.fn(async () => ({
+      content: "ok",
+      toolCalls: [],
+      model,
+      finishReason: "stop" as const,
+    }));
+    const provider = { ...mkProvider(dispatch), name: "gemini" };
+    const { session: baseSession } = mkSession(provider);
+    const session = { ...baseSession, config: { model } } as Session;
+    const result = streamModel(mkState(context), context, session, mkRequest([{ role: "user", content: "fixture" }]));
+    if (accepted) {
+      await result;
+      expect(dispatch).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ reasoningEffort: effort }));
+    } else {
+      await expect(result).rejects.toThrow(/reasoning effort/iu);
+      expect(dispatch).not.toHaveBeenCalled();
+    }
+  });
+
   test("writes provider text deltas to the assistant output sink", async () => {
     const ctx = mkCtx("chat");
     const state = mkState(ctx);


### PR DESCRIPTION
## Changes

Related to #1887. Keep the issue open until the exact-main FND receipt is refreshed in a separate artifact PR.

- Add one exact Gemini thinking-model table for catalog levels, command display defaults, and native request validation. Preserve the existing curated model list and unrelated capability flags.
- Admit `low`, `medium`, and `high` on Gemini 3.1 Pro. Preserve the different Flash and original 3 Pro level sets. Keep native Gemini 2.5 budget controls separate, and deny unverified variants.
- Make model/provider switch checks retain the requested level and reject unsupported stamped effort. Child-agent and role checks consume the same catalog through the real models manager.
- Preserve explicit `none` and omitted effort. Do not inject the built-in Grok `medium` default into fresh Gemini configuration or an unstamped Gemini turn. Leave explicit configured or stamped `medium` intact.
- Reject unsupported levels before chat, streaming, or native token-count transport. Do not fold unsupported values into `high`.

Google sources checked on 2026-09-08: [native ThinkingConfig](https://ai.google.dev/api/generate-content#ThinkingConfig), [thinking](https://ai.google.dev/gemini-api/docs/thinking), and [Gemini 3](https://ai.google.dev/gemini-api/docs/gemini-3). The Interactions API's level abstraction for Gemini 2.5 is not used by this adapter.

## Local validation

- 70 revert-sensitive failures reproduced against the original source across metadata, commands, switches, configuration, phase resolution, and wire tests. The fixed implementation passes 686 targeted tests across 16 files, with zero skips or failures.
- Runtime and test-support typechecks pass.
- Build, package entrypoints, and generated SDK parity pass.
- All six real PTY startup cases pass.
- The first full run found 151 downstream request failures and the expected stale receipt guard. The request builder incorrectly read provider identity from the turn context. It now uses the live session provider and selected model, matching dispatch. Three integration regressions cover a stale turn-context provider/model, exact Gemini effort, and rejection before dispatch.
- After that correction, 193 phase/turn tests and 348 command/phase/Gemini/spawn tests pass, with overlap between those runs. Typechecks, build, generated SDK parity, and all six PTYs pass again.
- Full root validation on `190eaecb558cf79e7807d2766f225771a4d94808` finishes with 23,330 passing runtime tests and one failure across 2,264 files, with no skips or unhandled errors. The sole failure is the expected stale CSV benchmark dependency closure. All functional tests pass. The receipt PR will remove that final failure after the source merge.

GitNexus reports critical pre-change reach for the shared catalog resolver (13 direct callers across command, model, and bootstrap paths) and config loader (two direct loaders). Gemini request construction is high risk. The initial staged change report is medium risk across 16 expected files; the correction is low risk across three files. Some indexed line offsets identify adjacent unchanged symbols; manual diff review confirms the source scope listed above.

Bugbot and Security pass on the corrected head with no functional findings. Cursor's approval check also passes on that head. Sonar's quality gate passes with zero security hotspots and one maintainability note: the shared legacy effort resolver has cognitive complexity 16 against a threshold of 15, reduced from 19 by this correction. The separate membership-check note is fixed.

## Receipt and CI policy

The source change invalidates the committed CSV benchmark dependency closure. The verifier requires a clean exact-main source revision, so a truthful receipt cannot be captured on this topic branch before its squash merge. The next PR will contain only the new JSON/Markdown receipt, captured on the source merge, with all normal receipt checks and the full root suite.

Paid Actions CI remains disabled. No workflow was enabled, dispatched, rerun, or retried. Independent review checks remain enabled; merge waits for review and local results. No benchmark guard or test is weakened.
