### PR TITLE
fix(runtime): preserve configured Gemini model visibility

### DIFF
--- a/runtime/src/llm/registry/model-catalog.ts
+++ b/runtime/src/llm/registry/model-catalog.ts
@@ -456,9 +456,9 @@ const OPENAI_PERSONALITY_MESSAGES: ModelMessages = Object.freeze({
   }),
 });
 
-export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
-  Object.freeze([
-    ...GEMINI_THINKING_MODELS.map((entry, index): RegisteredModelCatalogEntry => ({
+const GEMINI_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
+  Object.freeze(
+    GEMINI_THINKING_MODELS.map((entry, index): RegisteredModelCatalogEntry => ({
       provider: "gemini",
       model: entry.model,
       displayName: entry.model,
@@ -471,12 +471,19 @@ export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
       supportsVerbosity: false,
       webSearchToolType: "none",
       supportsReasoningSummaries: false,
-      defaultReasoningSummary: "none",
+      defaultReasoningSummary: "auto",
       supportedReasoningLevels: entry.levels,
       additionalSpeedTiers: NO_ADDITIONAL_SPEED_TIERS,
       priority: index,
-      visibility: entry.curated ? "list" : "none",
+      visibility: "list",
     })),
+  );
+
+export const REGISTERED_MODEL_CATALOG: readonly RegisteredModelCatalogEntry[] =
+  Object.freeze([
+    ...GEMINI_MODEL_CATALOG.filter((entry) =>
+      GEMINI_THINKING_MODELS.some((model) => model.curated && model.model === entry.model)
+    ),
     ...OPENAI_REASONING_MODELS.map((entry, index): RegisteredModelCatalogEntry => ({
       provider: "openai",
       model: entry.model,
@@ -1047,15 +1054,15 @@ export function resolveRegisteredModelCatalogEntry(input: {
   const provider = modelCatalogProviderIdentity(input.provider);
   const model = input.model?.trim() ?? "";
   if (provider.length === 0 || model.length === 0) return undefined;
-  const candidates = REGISTERED_MODEL_CATALOG.filter(
-    (entry) => modelCatalogProviderIdentity(entry.provider) === provider,
-  );
   if (provider === "gemini") {
     return findExactModel(
       resolveGeminiThinkingModel(model)?.model ?? "",
-      candidates,
+      GEMINI_MODEL_CATALOG,
     );
   }
+  const candidates = REGISTERED_MODEL_CATALOG.filter(
+    (entry) => modelCatalogProviderIdentity(entry.provider) === provider,
+  );
   const exact = findExactModel(model, candidates) ??
     findNamespacedSuffix(model, candidates, true);
   if (exact !== undefined) return exact;

--- a/runtime/src/phases/stream-model.ts
+++ b/runtime/src/phases/stream-model.ts
@@ -120,13 +120,8 @@ function resolveSessionReasoningEffort(
       selection.effortSource,
     );
   }
-  let requested: ReasoningEffort | undefined;
-  if (turnEffort === undefined) {
-    requested = getInitialEffortSetting();
-  } else if (turnEffort !== "none") {
-    requested = turnEffort;
-  }
-  if (requested === undefined) return undefined;
+  const requested = turnEffort ?? getInitialEffortSetting();
+  if (requested === undefined || requested === "none") return undefined;
   if (requested === "max" || requested === "xhigh") {
     if (supportedReasoningLevels === undefined) {
       return requested === "max" ? "xhigh" : requested;

--- a/runtime/tests/llm/gemini-reasoning-effort.test.ts
+++ b/runtime/tests/llm/gemini-reasoning-effort.test.ts
@@ -39,6 +39,10 @@ describe("Gemini reasoning metadata", () => {
     const info = await manager.getModelInfo(model);
     expect(info.supportedReasoningLevels).toEqual(levels);
     expect(info.defaultReasoningLevel).toBeUndefined();
+    expect(info.visibility).toBe("list");
+    expect(info.showInPicker).toBe(true);
+    expect(info.defaultReasoningSummary).toBe("auto");
+    expect((await manager.listModels()).some((entry) => entry.slug === model)).toBe(true);
   });
 
   test.each(["gemini-3.1-pro-preview-unverified", "gemini-3.5-flash-unverified"])("does not grant levels to %s", (model) => {


### PR DESCRIPTION
## Changes

Follow-up to #2289 for #1887. Keep the issue open until the final receipt in #2291 is refreshed and merged.

The Gemini metadata table mistakenly used catalog visibility to keep older models out of the curated suggestions. That also hid an explicitly configured older model from the picker and child-model list. The new catalog rows also changed the unrelated default reasoning-summary projection from `auto` to `none`.

- Keep complete Gemini metadata available to exact lookup while limiting the global suggestion catalog to the existing four curated models. Explicitly configured older Gemini models retain `list` visibility, picker availability, and child-model availability.
- Restore Gemini's previous `auto` summary default. Supported effort levels and exact native wire validation are unchanged.
- Simplify the effort resolver's existing fallback/none handling without changing alias behavior. Explicit `none` still avoids reading the configured fallback. This addresses the remaining Sonar complexity note from #2289.

## Validation

- Eight regression assertions fail on the prior main source, covering the accidentally changed visibility and summary defaults across the verified Gemini models.
- All 722 targeted model, command, phase, wire, spawn, and configuration tests across 17 files pass, with zero skips or failures. Runtime/test-support typechecks, build/generated SDK parity, and all six PTY starts pass.
- Full root validation on `01839c474d3e063724f2d30b854714a96ff9a1df` finishes with 23,336 passing runtime tests and one expected stale CSV receipt failure across 2,265 files, with zero skips or unhandled errors. No functional test fails.
- The previous combined main plus receipt passed all 23,337 runtime tests across 2,265 files. This extra check caught a missing assertion rather than a failure in that earlier test run.
- GitNexus rates the shared catalog resolver critical, with 14 direct callers and command/input/bootstrap reach. The change is Gemini-specific. No curated suggestions are added, and no other provider metadata changes.
- Pre-commit change analysis reports low risk for three expected files and no affected indexed flows. Independent Cursor approval, Bugbot, Security, and Sonar checks pass on this head. Sonar reports zero new issues, including resolution of the complexity note.

The catalog correction changes a benchmark-bound source file. After this source merge, #2291 will receive a newly captured exact-main receipt, fresh-clone verification, full local validation, and a fresh independent review. No stale receipt will be merged as final evidence.

Paid Actions CI remains disabled. No workflow was enabled, dispatched, rerun, or retried.
