### PR TITLE
fix(tui): separate Neovim preservation and exit deadlines

### DIFF
--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -651,6 +651,14 @@ Normal TUI teardown waits for a final exact workspace sync and daemon-lease
 release before destroying the Neovim provider. If either step cannot be
 confirmed, teardown fails visibly and leaves the provider available for
 recovery instead of claiming the editor was safely detached.
+
+Abnormal teardown gives Neovim up to 10 seconds to acknowledge exact recovery
+preservation before stopping the process. This fixed acknowledgement deadline
+is separate from `cleanup_timeout_ms`, which still bounds process exit after
+preservation succeeds. If the acknowledgement is missing or its recovery
+manifest is invalid, AgenC reports failure and retains the live process and
+its transport. Cleanup does not automatically retry preservation.
+
 Hosted Linux and Darwin PTY scenarios
 (`130-workbench-buffer-neovim-platform-gate.mjs` and
 `131-workbench-buffer-neovim-platform-kill-cleanup.mjs`) launch a detached,

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -158,6 +158,7 @@ export type NeovimCloseResult =
     };
 
 const DEFAULT_CLEANUP_TIMEOUT_MS = 1000;
+const RECOVERY_PRESERVATION_TIMEOUT_MS = 10_000;
 const DEFAULT_OPERATION_TIMEOUT_MS = 10_000;
 const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
 const INPUT_BUFFER_RETRY_DELAY_MS = 1;
@@ -1518,7 +1519,7 @@ export class EmbeddedNeovimSession {
           const manifest = await this.#rpc.request(
             "nvim_exec_lua",
             [PRESERVE_DIRTY_BUFFERS_FOR_ABNORMAL_EXIT, []],
-            { timeoutMs: this.#cleanupTimeoutMs },
+            { timeoutMs: RECOVERY_PRESERVATION_TIMEOUT_MS },
           );
           assertAbnormalRecoveryManifest(manifest, this.#recovery?.swap);
           this.#recoveryPreservationProven = true;

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -1125,23 +1125,8 @@ describe("embedded Neovim lifecycle", () => {
     vi.useFakeTimers();
     const context = createRecoveryTransportSession();
     try {
-      let settled = false;
-      const cleanup = context.session.cleanup({ preserveRecovery: true }).then(
-        () => {
-          settled = true;
-          return null;
-        },
-        (error: unknown) => {
-          settled = true;
-          return error;
-        },
-      );
-      expect(decode(context.input.read())).toEqual([
-        0, 1, "nvim_exec_lua", [expect.stringContaining("silent preserve"), []],
-      ]);
-
       await vi.advanceTimersByTimeAsync(1_500);
-      expect(settled).toBe(false);
+      expect(context.settled).toBe(false);
       expect(context.handle.kill).not.toHaveBeenCalled();
       expect(context.child.kill).not.toHaveBeenCalled();
       expect(context.endInput).not.toHaveBeenCalled();
@@ -1152,11 +1137,11 @@ describe("embedded Neovim lifecycle", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(context.session.recoveryPreservationProven).toBe(true);
       expect(context.handle.kill).toHaveBeenCalledWith("SIGKILL");
-      expect(settled).toBe(false);
+      expect(context.settled).toBe(false);
       await vi.advanceTimersByTimeAsync(999);
       expect(context.child.kill).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
-      expect(await cleanup).toBeNull();
+      expect(await context.cleanup).toBeNull();
       expect(context.child.kill).toHaveBeenCalledWith("SIGTERM");
       expect(context.closeRpc).toHaveBeenCalledWith("abnormal session cleanup");
       expect(context.endInput).not.toHaveBeenCalled();
@@ -1171,24 +1156,10 @@ describe("embedded Neovim lifecycle", () => {
     vi.useFakeTimers();
     const context = createRecoveryTransportSession();
     try {
-      let settled = false;
-      const cleanup = context.session.cleanup({ preserveRecovery: true }).then(
-        () => {
-          settled = true;
-          return null;
-        },
-        (error: unknown) => {
-          settled = true;
-          return error;
-        },
-      );
-      expect(decode(context.input.read())).toEqual([
-        0, 1, "nvim_exec_lua", [expect.stringContaining("silent preserve"), []],
-      ]);
       await vi.advanceTimersByTimeAsync(9_999);
-      expect(settled).toBe(false);
+      expect(context.settled).toBe(false);
       await vi.advanceTimersByTimeAsync(1);
-      expect(await cleanup).toMatchObject({
+      expect(await context.cleanup).toMatchObject({
         message: expect.stringContaining("exact recovery preservation was not confirmed"),
         cause: expect.objectContaining({
           name: "NeovimRpcRequestTimeoutError",
@@ -1219,12 +1190,9 @@ describe("embedded Neovim lifecycle", () => {
     vi.useFakeTimers();
     const context = createRecoveryTransportSession();
     try {
-      const cleanup = context.session.cleanup({ preserveRecovery: true })
-        .catch((error: unknown) => error);
-      context.input.read();
       await vi.advanceTimersByTimeAsync(1_500);
       context.output.write(encode([1, 1, null, [{ ...context.manifest[0], size: 0 }]]));
-      expect(await cleanup).toMatchObject({
+      expect(await context.cleanup).toMatchObject({
         message: expect.stringContaining("invalid abnormal-exit recovery manifest"),
       });
       expect(context.session.recoveryPreservationProven).toBe(false);
@@ -2014,8 +1982,25 @@ function createRecoveryTransportSession() {
     swap: join(dir, "recovery.swp"),
     size: 4096,
   }];
+  let settled = false;
+  const cleanup = session.cleanup({ preserveRecovery: true }).then(
+    () => {
+      settled = true;
+      return null;
+    },
+    (error: unknown) => {
+      settled = true;
+      return error;
+    },
+  );
+  expect(decode(input.read())).toEqual([
+    0, 1, "nvim_exec_lua", [expect.stringContaining("silent preserve"), []],
+  ]);
   return {
-    child, input, output, endInput, handle, rpc, closeRpc, session, manifest,
+    child, input, output, endInput, handle, rpc, closeRpc, session, manifest, cleanup,
+    get settled() {
+      return settled;
+    },
     dispose() {
       rpc.close("test cleanup");
       output.end();

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -2,8 +2,9 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 
-import { encode } from "@msgpack/msgpack";
+import { decode, encode } from "@msgpack/msgpack";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -16,6 +17,7 @@ import {
 import {
   NeovimRpcError,
   NeovimRpcRequestTimeoutError,
+  NeovimRpcTransport,
 } from "../../../src/tui/workbench/buffer/neovim/NeovimRpc.js";
 import {
   cleanupTrackedNeovimProcesses,
@@ -965,16 +967,26 @@ describe("embedded Neovim lifecycle", () => {
       onFatalError,
     );
 
-    await expect(session.input("i")).rejects.toBeInstanceOf(
-      NeovimRpcRequestTimeoutError,
-    );
-    await vi.waitFor(() => {
+    vi.useFakeTimers();
+    try {
+      const inputFailure = expect(session.input("i")).rejects.toBeInstanceOf(
+        NeovimRpcRequestTimeoutError,
+      );
+      await vi.advanceTimersByTimeAsync(5);
+      await inputFailure;
+      expect(onFatalError).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(onFatalError).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
       expect(onFatalError).toHaveBeenCalledTimes(2);
-    });
-    expect(child.kill).not.toHaveBeenCalled();
-    expect(handle.kill).not.toHaveBeenCalled();
-    expect(rpc.close).not.toHaveBeenCalled();
-    await expect(session.save(false)).resolves.toBe(false);
+      expect(child.kill).not.toHaveBeenCalled();
+      expect(handle.kill).not.toHaveBeenCalled();
+      expect(rpc.close).not.toHaveBeenCalled();
+      await expect(session.save(false)).resolves.toBe(false);
+    } finally {
+      rpc.close();
+      vi.useRealTimers();
+    }
   });
 
   it("poisons ambiguous Discard All and safe-close timeouts instead of applying them late", async () => {
@@ -1097,7 +1109,7 @@ describe("embedded Neovim lifecycle", () => {
     expect(rpc.request).toHaveBeenCalledWith(
       "nvim_exec_lua",
       [expect.stringContaining("silent preserve"), []],
-      { timeoutMs: 5 },
+      { timeoutMs: 10_000 },
     );
     expect(rpc.request).not.toHaveBeenCalledWith("nvim_command", ["qa!"]);
     expect(child.stdin.end).not.toHaveBeenCalled();
@@ -1107,6 +1119,124 @@ describe("embedded Neovim lifecycle", () => {
     expect(rpc.request.mock.invocationCallOrder[0]).toBeLessThan(
       handle.kill.mock.invocationCallOrder[0]!,
     );
+  });
+
+  it("accepts a delayed preservation acknowledgement without extending the process exit deadline", async () => {
+    vi.useFakeTimers();
+    const context = createRecoveryTransportSession();
+    try {
+      let settled = false;
+      const cleanup = context.session.cleanup({ preserveRecovery: true }).then(
+        () => {
+          settled = true;
+          return null;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+      expect(decode(context.input.read())).toEqual([
+        0, 1, "nvim_exec_lua", [expect.stringContaining("silent preserve"), []],
+      ]);
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(settled).toBe(false);
+      expect(context.handle.kill).not.toHaveBeenCalled();
+      expect(context.child.kill).not.toHaveBeenCalled();
+      expect(context.endInput).not.toHaveBeenCalled();
+      expect(context.closeRpc).not.toHaveBeenCalled();
+      expect(context.session.recoveryPreservationProven).toBe(false);
+
+      context.output.write(encode([1, 1, null, context.manifest]));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(context.session.recoveryPreservationProven).toBe(true);
+      expect(context.handle.kill).toHaveBeenCalledWith("SIGKILL");
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(999);
+      expect(context.child.kill).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(await cleanup).toBeNull();
+      expect(context.child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(context.closeRpc).toHaveBeenCalledWith("abnormal session cleanup");
+      expect(context.endInput).not.toHaveBeenCalled();
+      expect(context.input.read()).toBeNull();
+    } finally {
+      context.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains the child and ignores a late acknowledgement after the preservation deadline", async () => {
+    vi.useFakeTimers();
+    const context = createRecoveryTransportSession();
+    try {
+      let settled = false;
+      const cleanup = context.session.cleanup({ preserveRecovery: true }).then(
+        () => {
+          settled = true;
+          return null;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+      expect(decode(context.input.read())).toEqual([
+        0, 1, "nvim_exec_lua", [expect.stringContaining("silent preserve"), []],
+      ]);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(await cleanup).toMatchObject({
+        message: expect.stringContaining("exact recovery preservation was not confirmed"),
+        cause: expect.objectContaining({
+          name: "NeovimRpcRequestTimeoutError",
+          timeoutMs: 10_000,
+        }),
+      });
+
+      context.output.write(encode([1, 1, null, context.manifest]));
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(context.session.recoveryPreservationProven).toBe(false);
+      expect(context.handle.kill).not.toHaveBeenCalled();
+      expect(context.child.kill).not.toHaveBeenCalled();
+      expect(context.endInput).not.toHaveBeenCalled();
+      expect(context.closeRpc).not.toHaveBeenCalled();
+      expect(context.input.read()).toBeNull();
+
+      const probe = context.rpc.request("nvim_get_mode", [], { timeoutMs: 100 });
+      expect(decode(context.input.read())).toEqual([0, 2, "nvim_get_mode", []]);
+      context.output.write(encode([1, 2, null, { mode: "n" }]));
+      await expect(probe).resolves.toEqual({ mode: "n" });
+    } finally {
+      context.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains the child when a delayed preservation acknowledgement has an invalid manifest", async () => {
+    vi.useFakeTimers();
+    const context = createRecoveryTransportSession();
+    try {
+      const cleanup = context.session.cleanup({ preserveRecovery: true })
+        .catch((error: unknown) => error);
+      context.input.read();
+      await vi.advanceTimersByTimeAsync(1_500);
+      context.output.write(encode([1, 1, null, [{ ...context.manifest[0], size: 0 }]]));
+      expect(await cleanup).toMatchObject({
+        message: expect.stringContaining("invalid abnormal-exit recovery manifest"),
+      });
+      expect(context.session.recoveryPreservationProven).toBe(false);
+      expect(context.handle.kill).not.toHaveBeenCalled();
+      expect(context.child.kill).not.toHaveBeenCalled();
+      expect(context.endInput).not.toHaveBeenCalled();
+      expect(context.closeRpc).not.toHaveBeenCalled();
+      expect(context.input.read()).toBeNull();
+    } finally {
+      context.dispose();
+      vi.useRealTimers();
+    }
   });
 
   it("leaves the live process intact when abnormal recovery preservation is unproven", async () => {
@@ -1857,6 +1987,41 @@ function controlled<T>() {
     resolve = promiseResolve;
   });
   return { promise, resolve };
+}
+
+function createRecoveryTransportSession() {
+  mockMissingProcessGroups();
+  const child = fakeChild({ pid: syntheticNeovimPid(7843) });
+  const input = new PassThrough();
+  const output = new PassThrough();
+  child.stdin = input;
+  child.stdout = output;
+  const endInput = vi.spyOn(input, "end");
+  const handle = { child, pid: child.pid, kill: vi.fn() };
+  const rpc = new NeovimRpcTransport(output, input);
+  const closeRpc = vi.spyOn(rpc, "close");
+  rpc.start();
+  const session = new EmbeddedNeovimSession(
+    handle as any,
+    rpc,
+    { dispose: vi.fn() } as any,
+    1_000,
+  );
+  const manifest = [{
+    handle: 1,
+    changedtick: 7,
+    end_of_line: true,
+    swap: join(dir, "recovery.swp"),
+    size: 4096,
+  }];
+  return {
+    child, input, output, endInput, handle, rpc, closeRpc, session, manifest,
+    dispose() {
+      rpc.close("test cleanup");
+      output.end();
+      input.end();
+    },
+  };
 }
 
 function createDeadlineRpcHarness() {

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.real-neovim.test.ts
@@ -794,9 +794,12 @@ describe("real embedded Neovim lifecycle", () => {
       await startupExecLua(String.raw`
         _G.AgenCTestOriginalStageEditorProposal =
           _G.AgenCStageEditorProposal
+        _G.AgenCTestOriginalGetfsize = vim.fn.getfsize
         _G.AgenCStageEditorProposal = function(...)
           vim.uv.sleep(1000)
-          return _G.AgenCTestOriginalStageEditorProposal(...)
+          local result = _G.AgenCTestOriginalStageEditorProposal(...)
+          vim.fn.getfsize = function() return -1 end
+          return result
         end
         return true
       `);
@@ -833,12 +836,16 @@ describe("real embedded Neovim lifecycle", () => {
       expect(preservationFailure.message).toContain(
         "exact Neovim recovery preservation failed",
       );
+      expect(preservationFailure).toBeInstanceOf(AggregateError);
+      expect((preservationFailure as AggregateError).errors[1].message).toContain(
+        "Neovim did not durably write the recovery swap",
+      );
 
-      // The timed-out mutation eventually leaves Neovim's serial RPC queue.
-      // A cleanup retry can then obtain the preservation acknowledgement. Only
-      // that proven retry may stop the process.
       await withTestTimeout(
-        startupExecLua("return true"),
+        startupExecLua(String.raw`
+          vim.fn.getfsize = _G.AgenCTestOriginalGetfsize
+          return true
+        `),
         5_000,
         "timed out waiting for the poisoned Neovim RPC queue to drain",
       );


### PR DESCRIPTION
## Changes

Closes #1901.

Recovery preservation now has a fixed 10,000 ms acknowledgement deadline. The existing configurable process-exit deadline remains unchanged, as do normal cleanup, startup, and operation timeouts. No new configuration option or automatic retry is added.

Neovim must still return a valid exact recovery manifest before any process termination. Missing or invalid acknowledgement retains the live child, stdin, and RPC transport.

Three new tests use the real MessagePack RPC transport with a controlled clock. They cover an acknowledgement after 1,500 ms, unchanged 1,000 ms process-exit grace, a missing acknowledgement at 10,000 ms, ignored late replies, a still-usable transport, and an invalid delayed manifest. The mutation-timeout test now advances the two deadlines separately instead of waiting for a short wall-clock callback.

The native poisoned-session test previously relied on the same short preservation deadline. It now injects a failed swap-size check after the timed-out mutation, verifies the specific preservation error and retained live process, then restores the size check before the explicit cleanup retry. The recovered copy still must match the exact unsaved bytes. No native test is removed or skipped.

## Validation

- Four selected assertions fail against the original source, including all three new transport regressions. All 143 targeted contract tests now pass across five files with no skips.
- Runtime and test-support typechecks, build, and generated SDK parity pass.
- Full root tests pass on final head `6db8c215a0bdffc3602a17d51db8f115f93012c9`, including all 23,340 runtime tests across 2,265 files with no failures or skips. The earlier source head also passed the complete suite.
- All six PTY startups pass. Pinned Linux Neovim 0.12.1 passes all 18 lifecycle tests, followed by three further complete 18-test repeats. The separate Linux provider/process-tree/platform lane passes all 65 tests across three files, with zero skips.
- The final fixture/helper correction passes 78 contract, packaging, and discovery tests across three files. Runtime and test-support typechecks pass again.
- The first native invocation correctly rejected the system Neovim 0.13.0-dev because this lane requires 0.12.1. The repeat uses the existing pinned 0.12.1 distribution; no version assertion is weakened.

GitNexus reports medium class-level impact across five direct Neovim consumers and no indexed execution processes. The actual source edit changes only the preservation RPC timeout. Pre-commit change detection reports low risk for both commits. The final diff contains the source, documentation, and two lifecycle test files. Automatic index refresh later crashed, but staged change detection still succeeded. The new test helper is not yet indexed; its three test-only callers were checked directly.

Final-head Bugbot, Security, Approval Agent, and Sonar checks all pass. Sonar reports zero new duplication after the shared-helper correction and no open issues. The GitHub APPROVED review remains on the initial head; fresh final-head review checks provide the final evidence. GitHub reports zero Actions runs for both heads.

Paid Actions CI remains disabled. No hosted Windows/macOS run, workflow dispatch, rerun, or retry is authorized or started. Native validation is Linux-only on this host. Independent PR review checks remain enabled.
