### PR TITLE
fix(fnd): distinguish metadata deadlines and limit native contention

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1243,6 +1243,7 @@ jobs:
             tests/tools/runtimes/runtime.darwin.test.ts \
             tests/utils/secureStorage/macOsKeychainHelper.darwin.test.ts \
             --config vitest.native.config.ts \
+            --maxWorkers=1 \
             --allowOnly=false \
             --reporter=verbose \
             --reporter=json \

--- a/runtime/benchmarks/fnd/README.md
+++ b/runtime/benchmarks/fnd/README.md
@@ -73,6 +73,14 @@ persistence, cancellation, and 10,000-candidate checks remain in
   `.com` before `.exe`; the checkout directory is never an implicit executable
   source. npm metadata resolves only from fixed layouts beneath the canonical
   current Node installation and ignores ambient `npm_execpath` injection.
+- Metadata failures distinguish the child command deadline, outer worker
+  deadline, and unproven process-tree settlement. Their `metadataCommand`
+  fields retain the stop reason, cleanup result, limits, total elapsed time,
+  and execution/settlement time without copying command paths or arguments.
+  Helper startup happens before the child command timer starts. The production
+  command limit remains 5 seconds, with separate 2-second settlement and
+  worker-overhead allowances. The macOS native slice runs one test file at a
+  time so provenance helpers do not compete with its other native fixtures.
 - Setup and index construction happen before warmup and timed samples. Completed
   cases report five or more measured samples.
 - Elapsed time uses `performance.now()`. Operation counts are exact where the

--- a/runtime/benchmarks/fnd/baseline.v1.json
+++ b/runtime/benchmarks/fnd/baseline.v1.json
@@ -22,17 +22,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 3.434566,
-            "maxMs": 100.738952,
-            "medianMs": 94.547551,
-            "minMs": 88.802827,
+            "madMs": 1.243188,
+            "maxMs": 110.950331,
+            "medianMs": 82.302288,
+            "minMs": 80.252585,
             "sampleCount": 5,
             "samplesMs": [
-              96.767221,
-              94.547551,
-              88.802827,
-              91.112985,
-              100.738952
+              81.065069,
+              110.950331,
+              83.545476,
+              82.302288,
+              80.252585
             ]
           },
           "fixtureDigest": "0ca9b86d1a9d5bac08bdeb5ded3c9183569ada6b552ba01d662b8e1365cff2fe",
@@ -43,23 +43,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 183164928,
+              "maximumObservedBytes": 209743872,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                135270400,
-                139386880,
-                174252032,
-                174252032,
-                176349184,
-                176349184,
-                179494912,
-                179494912,
-                181067776,
-                181067776,
-                183164928
+                123879424,
+                137916416,
+                140537856,
+                140537856,
+                208695296,
+                208695296,
+                209219584,
+                209219584,
+                209219584,
+                209219584,
+                209743872
               ]
             },
-            "peakRssBytes": 183164928,
+            "peakRssBytes": 209743872,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -78,17 +78,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 9.385021,
-            "maxMs": 195.734503,
-            "medianMs": 180.434861,
-            "minMs": 170.075903,
+            "madMs": 3.762514,
+            "maxMs": 176.362801,
+            "medianMs": 166.370297,
+            "minMs": 162.607783,
             "sampleCount": 5,
             "samplesMs": [
-              195.734503,
-              189.819882,
-              180.434861,
-              170.075903,
-              171.980304
+              174.127506,
+              176.362801,
+              162.607783,
+              166.370297,
+              163.002614
             ]
           },
           "fixtureDigest": "ccbf8b3d5336415b2ded77d1c42203949fafd1496957db250011cf0bd2cd00ce",
@@ -99,23 +99,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 198746112,
+              "maximumObservedBytes": 198258688,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                123854848,
-                139194368,
-                176943104,
-                176943104,
-                183758848,
-                183758848,
-                190574592,
-                190574592,
-                196124672,
-                196124672,
-                198746112
+                133001216,
+                172965888,
+                179257344,
+                179257344,
+                186073088,
+                186073088,
+                190791680,
+                190791680,
+                195637248,
+                195637248,
+                198258688
               ]
             },
-            "peakRssBytes": 202158080,
+            "peakRssBytes": 202723328,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -134,17 +134,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 10.594677,
-            "maxMs": 349.410073,
-            "medianMs": 336.359627,
-            "minMs": 325.76495,
+            "madMs": 9.927675,
+            "maxMs": 350.343234,
+            "medianMs": 334.10144,
+            "minMs": 323.68982,
             "sampleCount": 5,
             "samplesMs": [
-              348.59813,
-              329.772816,
-              336.359627,
-              349.410073,
-              325.76495
+              350.343234,
+              334.10144,
+              324.173765,
+              323.68982,
+              336.89383
             ]
           },
           "fixtureDigest": "0f4385af1bcdc19019e76509840700e8cfd68621daaa29a63ec4c05a4464cfac",
@@ -155,23 +155,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 214728704,
+              "maximumObservedBytes": 222416896,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                122707968,
-                181116928,
-                194224128,
-                194224128,
-                205561856,
-                205561856,
-                212901888,
-                212901888,
-                214204416,
-                214204416,
-                214728704
+                133287936,
+                179220480,
+                190754816,
+                190754816,
+                203104256,
+                203104256,
+                211492864,
+                211492864,
+                220876800,
+                220876800,
+                222416896
               ]
             },
-            "peakRssBytes": 217468928,
+            "peakRssBytes": 222973952,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -204,17 +204,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.549615,
-            "maxMs": 3.938611,
-            "medianMs": 2.727361,
-            "minMs": 2.177746,
+            "madMs": 0.36911,
+            "maxMs": 3.557092,
+            "medianMs": 2.892232,
+            "minMs": 2.407355,
             "sampleCount": 5,
             "samplesMs": [
-              3.311708,
-              2.562451,
-              2.727361,
-              2.177746,
-              3.938611
+              3.557092,
+              2.578786,
+              3.261342,
+              2.407355,
+              2.892232
             ]
           },
           "fixtureDigest": "5fdb1381163adfa352201f2446aeeacb8d3f5652fdb4f2d14e34a3ae73f48fe6",
@@ -225,23 +225,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 89006080,
+              "maximumObservedBytes": 90693632,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                81666048,
-                83238912,
-                84811776,
-                84811776,
-                86384640,
-                86384640,
-                87433216,
-                87433216,
-                88481792,
-                88481792,
-                89006080
+                82829312,
+                83353600,
+                85450752,
+                85450752,
+                86499328,
+                86499328,
+                88072192,
+                88072192,
+                89645056,
+                89645056,
+                90693632
               ]
             },
-            "peakRssBytes": 89006080,
+            "peakRssBytes": 90693632,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -259,17 +259,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 0.347547,
-            "maxMs": 6.147694,
-            "medianMs": 5.444547,
-            "minMs": 4.623249,
+            "madMs": 0.299355,
+            "maxMs": 6.64472,
+            "medianMs": 5.528305,
+            "minMs": 5.22895,
             "sampleCount": 5,
             "samplesMs": [
-              6.147694,
-              5.546502,
-              5.444547,
-              5.097,
-              4.623249
+              6.64472,
+              5.528305,
+              5.95986,
+              5.289923,
+              5.22895
             ]
           },
           "fixtureDigest": "a46028608f2726a48af61c9fb505a7cecce18d6e5f4c570fb9747ed5b9ebf728",
@@ -280,23 +280,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 106123264,
+              "maximumObservedBytes": 105881600,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                84103168,
-                89870336,
-                91967488,
-                91967488,
-                95637504,
-                95637504,
-                98258944,
-                98258944,
-                104026112,
-                104026112,
-                106123264
+                83337216,
+                88580096,
+                91201536,
+                91201536,
+                94871552,
+                94871552,
+                97492992,
+                97492992,
+                103260160,
+                103260160,
+                105881600
               ]
             },
-            "peakRssBytes": 106123264,
+            "peakRssBytes": 105881600,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -314,17 +314,17 @@
           },
           "elapsed": {
             "clock": "performance.now",
-            "madMs": 1.031818,
-            "maxMs": 13.135926,
-            "medianMs": 11.356463,
-            "minMs": 9.50969,
+            "madMs": 0.825964,
+            "maxMs": 14.913967,
+            "medianMs": 10.937599,
+            "minMs": 9.791718,
             "sampleCount": 5,
             "samplesMs": [
-              10.684464,
-              12.388281,
-              11.356463,
-              9.50969,
-              13.135926
+              10.755282,
+              11.763563,
+              10.937599,
+              9.791718,
+              14.913967
             ]
           },
           "fixtureDigest": "83b961c07a66f67bd9408e666deccce73a7030fa14f72050fa1b042f1df6beb6",
@@ -335,23 +335,23 @@
           "memory": {
             "lowerBound": {
               "limitation": "RSS is sampled at setup and operation endpoints; these observations are retained as a lower-bound diagnostic separate from the process high-water RSS.",
-              "maximumObservedBytes": 126689280,
+              "maximumObservedBytes": 127500288,
               "method": "endpoint_rss_lower_bound",
               "observationsBytes": [
-                86319104,
-                95756288,
-                100999168,
-                100999168,
-                106242048,
-                106242048,
-                112533504,
-                112533504,
-                120397824,
-                120397824,
-                126689280
+                83984384,
+                94994432,
+                100237312,
+                100237312,
+                106528768,
+                106528768,
+                112295936,
+                112295936,
+                119635968,
+                119635968,
+                127500288
               ]
             },
-            "peakRssBytes": 126689280,
+            "peakRssBytes": 127500288,
             "peakRssMethod": "process.resourceUsage.maxRSS_kib_to_bytes"
           },
           "operations": {
@@ -510,7 +510,7 @@
     {
       "normalization": "utf8_lf",
       "path": "runtime/benchmarks/fnd/metadata-command-worker.mjs",
-      "sha256": "4322637c5eb97e2ee35e517e2537f5a08099079135cf7851d20e8b7f4b2ca423"
+      "sha256": "cf764dde1ad36f1194852c7dd99a5d4f698beb1de77bf7c290398ae021087be3"
     },
     {
       "normalization": "utf8_lf",
@@ -525,7 +525,7 @@
     {
       "normalization": "utf8_lf",
       "path": "runtime/benchmarks/fnd/provenance.mjs",
-      "sha256": "be1119d985b833335a42b262f8d8cb60239067450a05ef9054587148cbc23a5b"
+      "sha256": "5aa41b3f15908ba367f53329ee6be74e2981cb6b212dde710959c6eb7039d30f"
     },
     {
       "normalization": "utf8_lf",
@@ -967,11 +967,11 @@
     }
   ],
   "productionTreeBinding": {
-    "gitObjectId": "0d43e12fd4202287452f9e09bc330c6d09e36341",
+    "gitObjectId": "ff3829b500404e249a54dd59a6109cfa40f22e90",
     "objectType": "tree",
     "path": "runtime/src"
   },
   "schemaVersion": 1,
-  "sourceRevision": "811d1f1f8fbae7021449ff73b0e738101e4a0f9e",
+  "sourceRevision": "87bbfcf13c2a5cc4bc5431ea2762e6389ec613c5",
   "suiteId": "agenc.fnd.algorithm-baseline.v1"
 }

--- a/runtime/benchmarks/fnd/baseline.v1.md
+++ b/runtime/benchmarks/fnd/baseline.v1.md
@@ -4,9 +4,9 @@ This artifact records bounded current and historical-reference observations.
 Every row is informational: no result is a performance threshold or gate.
 Generated inputs are synthetic and created only for the benchmark process.
 
-- JSON SHA-256: `c536f008a60b4a8d13519e095879258b8c408137c85429d26394068edec0274e`
-- Source revision: `811d1f1f8fbae7021449ff73b0e738101e4a0f9e`
-- Production tree: `runtime/src` at Git object `0d43e12fd4202287452f9e09bc330c6d09e36341`
+- JSON SHA-256: `43e1fe22f22ee7669a6fbfe3d61472c142ee68299fec39b13f23fc1a86eb8702`
+- Source revision: `87bbfcf13c2a5cc4bc5431ea2762e6389ec613c5`
+- Production tree: `runtime/src` at Git object `ff3829b500404e249a54dd59a6109cfa40f22e90`
 - Loaded production closure: `100` module bindings across `2` cases
 - Plan SHA-256: `672538014498283c935efce76c0a5244abd280aadaeb5a03a9d835f041db2ebe`
 - Node/npm: `v26.5.0` / `11.17.0`
@@ -18,12 +18,12 @@ Generated inputs are synthetic and created only for the benchmark process.
 
 | Case | Input | Status | Median ms | MAD ms | Worker peak RSS bytes | RSS lower-bound bytes |
 | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 94.548 | 3.435 | 183164928 | 183164928 |
-| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 180.435 | 9.385 | 202158080 | 198746112 |
-| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 336.360 | 10.595 | 217468928 | 214728704 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.727 | 0.550 | 89006080 | 89006080 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.445 | 0.348 | 106123264 | 106123264 |
-| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 11.356 | 1.032 | 126689280 | 126689280 |
+| `csv_scheduler_progress_scan` | `rowCount=1000` | `completed` | 82.302 | 1.243 | 209743872 | 209743872 |
+| `csv_scheduler_progress_scan` | `rowCount=2000` | `completed` | 166.370 | 3.763 | 202723328 | 198258688 |
+| `csv_scheduler_progress_scan` | `rowCount=4000` | `completed` | 334.101 | 9.928 | 222973952 | 222416896 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=8000` | `completed` | 2.892 | 0.369 | 90693632 | 90693632 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=16000` | `completed` | 5.528 | 0.299 | 105881600 | 105881600 |
+| `patch_delete_parser_historical_comparison` | `hunkCount=32000` | `completed` | 10.938 | 0.826 | 127500288 | 127500288 |
 
 ## Assessment notes
 
@@ -36,7 +36,7 @@ Run on the same pinned runtime and machine state; compare medians, MAD,
 operation counts, and relative scaling rather than one wall-clock sample.
 
 ```sh
-npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 811d1f1f8fbae7021449ff73b0e738101e4a0f9e --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
+npm run benchmark:fnd-baseline --workspace=@tetsuo-ai/runtime -- --source-revision 87bbfcf13c2a5cc4bc5431ea2762e6389ec613c5 --output /tmp/agenc-fnd-baseline.v1.json --markdown-output /tmp/agenc-fnd-baseline.v1.md
 npm run check:fnd-benchmark-baseline --workspace=@tetsuo-ai/runtime
 ```
 

--- a/runtime/benchmarks/fnd/metadata-command-worker.mjs
+++ b/runtime/benchmarks/fnd/metadata-command-worker.mjs
@@ -14,6 +14,7 @@ try {
   }
   const request = JSON.parse(requestBytes.toString("utf8"));
   const keepAlive = setInterval(() => {}, SETTLEMENT_KEEPALIVE_INTERVAL_MS);
+  const startedAt = performance.now();
   let result;
   try {
     result = await runSupervisedProcess(
@@ -42,6 +43,7 @@ try {
       stderrBase64: result.stderr.toString("base64"),
       stdoutBase64: result.stdout.toString("base64"),
       stopReason: result.stopReason,
+      workerElapsedMs: Math.max(0, Math.round(performance.now() - startedAt)),
     }),
   );
 } catch (error) {

--- a/runtime/benchmarks/fnd/provenance.mjs
+++ b/runtime/benchmarks/fnd/provenance.mjs
@@ -27,6 +27,9 @@ const METADATA_COMMAND_WORKER_PATH = join(
 export const METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS = 2_000;
 export const METADATA_COMMAND_WORKER_OVERHEAD_MS = 2_000;
 const METADATA_COMMAND_RESPONSE_OVERHEAD_BYTES = 65_536;
+const METADATA_COMMAND_STOP_REASONS = new Set([
+  "timeout", "aborted", "output_limit", "consumer_limit", "spawn_error", "residual_process",
+]);
 const MAX_WINDOWS_GIT_SEARCH_PATH_BYTES = 131_072;
 const MAX_WINDOWS_GIT_SEARCH_PATH_ENTRIES = 512;
 const MAX_WINDOWS_GIT_SEARCH_PATH_ENTRY_BYTES = 32_768;
@@ -260,12 +263,7 @@ export function runBoundedCommandText(
     }
     return result.stdout.toString("utf8").trim();
   } catch (error) {
-    throw new Error(
-      `${label} failed or exceeded its ${timeoutMs} ms deadline`,
-      {
-        cause: error,
-      },
-    );
+    throw boundedCommandFailure(label, timeoutMs, error);
   }
 }
 
@@ -469,47 +467,76 @@ function runBoundedCommandResult(
   const maximumResponseBytes =
     Math.ceil((maxOutputBytes * 4) / 3) +
     METADATA_COMMAND_RESPONSE_OVERHEAD_BYTES;
-  const responseText = execFileSync(
-    process.execPath,
-    [METADATA_COMMAND_WORKER_PATH],
-    {
-      cwd,
-      encoding: "utf8",
-      env: helperEnvironment,
-      input: request,
-      killSignal: "SIGKILL",
-      maxBuffer: maximumResponseBytes,
-      timeout:
-        timeoutMs +
-        METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS +
-        METADATA_COMMAND_WORKER_OVERHEAD_MS,
-      windowsHide: true,
-    },
-  );
-  let response;
+  const startedAt = performance.now();
+  let responseText;
   try {
-    response = JSON.parse(responseText);
+    responseText = execFileSync(
+      process.execPath,
+      [METADATA_COMMAND_WORKER_PATH],
+      {
+        cwd,
+        encoding: "utf8",
+        env: helperEnvironment,
+        input: request,
+        stdio: "pipe",
+        killSignal: "SIGKILL",
+        maxBuffer: maximumResponseBytes,
+        timeout:
+          timeoutMs +
+          METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS +
+          METADATA_COMMAND_WORKER_OVERHEAD_MS,
+        windowsHide: true,
+      },
+    );
   } catch (error) {
-    throw new Error("bounded metadata command returned malformed JSON", {
-      cause: error,
-    });
-  }
-  validateMetadataCommandResponse(response);
-  if (response.backstopExpired) {
-    throw new Error("bounded metadata command containment was not proven");
-  }
-  if (typeof response.error === "string" && response.error.length > 0) {
-    throw new Error(`bounded metadata command failed: ${response.error}`);
-  }
-  if (response.stopReason !== undefined) {
-    throw new Error(
-      `bounded metadata command stopped for ${String(response.stopReason)}`,
+    throw metadataCommandFailure(
+      error?.code === "ETIMEDOUT" ? "worker_timeout" : "worker_failed",
+      timeoutMs,
+      startedAt,
     );
   }
-  const stdout = decodeCanonicalBase64(response.stdoutBase64, "stdout");
-  const stderr = decodeCanonicalBase64(response.stderrBase64, "stderr");
-  if (stdout.length + stderr.length > maxOutputBytes) {
-    throw new Error("bounded metadata command exceeded its output ceiling");
+  return readMetadataCommandResult(responseText, {
+    maxOutputBytes,
+    startedAt,
+    timeoutMs,
+  });
+}
+
+function readMetadataCommandResult(
+  responseText,
+  { maxOutputBytes, startedAt, timeoutMs },
+) {
+  let response;
+  let stdout;
+  let stderr;
+  try {
+    response = JSON.parse(responseText);
+    validateMetadataCommandResponse(response);
+    stdout = decodeCanonicalBase64(response.stdoutBase64, "stdout");
+    stderr = decodeCanonicalBase64(response.stderrBase64, "stderr");
+    if (stdout.length + stderr.length > maxOutputBytes) {
+      throw new Error("bounded metadata command exceeded its output ceiling");
+    }
+  } catch {
+    throw metadataCommandFailure("protocol_error", timeoutMs, startedAt);
+  }
+  if (response.backstopExpired) {
+    throw metadataCommandFailure(
+      "settlement_failed", timeoutMs, startedAt, response,
+    );
+  }
+  if (response.stopReason !== undefined) {
+    throw metadataCommandFailure(
+      response.stopReason === "timeout" ? "command_timeout" : "command_stopped",
+      timeoutMs,
+      startedAt,
+      response,
+    );
+  }
+  if (typeof response.error === "string" && response.error.length > 0) {
+    throw metadataCommandFailure(
+      "command_failed", timeoutMs, startedAt, response,
+    );
   }
   return {
     exitCode: response.exitCode,
@@ -517,6 +544,48 @@ function runBoundedCommandResult(
     stderr,
     stdout,
   };
+}
+
+function metadataCommandFailure(phase, timeoutMs, startedAt, response = null) {
+  const elapsedMs = Math.max(0, Math.round(performance.now() - startedAt));
+  const workerElapsedMs = response?.workerElapsedMs ?? null;
+  const metadataCommand = Object.freeze({
+    phase,
+    commandTimeoutMs: timeoutMs,
+    workerTimeoutMs:
+      timeoutMs +
+      METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS +
+      METADATA_COMMAND_WORKER_OVERHEAD_MS,
+    elapsedMs,
+    workerElapsedMs,
+    overheadElapsedMs: workerElapsedMs === null
+      ? null
+      : Math.max(0, elapsedMs - workerElapsedMs),
+    backstopExpired: response?.backstopExpired ?? null,
+    stopReason: response?.stopReason ?? null,
+    exitCode: response?.exitCode ?? null,
+    signal: response?.signal ?? null,
+  });
+  return Object.assign(
+    new Error(`bounded metadata command ${phase} after ${elapsedMs} ms`),
+    { metadataCommand },
+  );
+}
+
+function boundedCommandFailure(label, timeoutMs, cause) {
+  const metadataCommand = cause?.metadataCommand;
+  const detail = metadataCommand === undefined
+    ? ""
+    : ` (${metadataCommand.phase}, ${metadataCommand.elapsedMs} ms elapsed, ` +
+      `${metadataCommand.workerTimeoutMs} ms worker limit, ` +
+      `${metadataCommand.workerElapsedMs ?? "unreported"} ms execution/settlement)`;
+  return Object.assign(
+    new Error(
+      `${label} failed or exceeded its ${timeoutMs} ms deadline${detail}`,
+      { cause },
+    ),
+    metadataCommand === undefined ? {} : { metadataCommand },
+  );
 }
 
 function validateMetadataCommandResponse(response) {
@@ -535,19 +604,23 @@ function validateMetadataCommandResponse(response) {
     "stderrBase64",
     "stdoutBase64",
     "stopReason",
+    "workerElapsedMs",
   ]);
   if (Object.keys(response).some((name) => !allowedNames.has(name))) {
     throw new Error("bounded metadata command result keys differ");
   }
   if (
     typeof response.backstopExpired !== "boolean" ||
-    (!Number.isInteger(response.exitCode) && response.exitCode !== null) ||
-    (response.signal !== null && typeof response.signal !== "string") ||
+    (!Number.isSafeInteger(response.exitCode) && response.exitCode !== null) ||
+    (response.signal !== null &&
+      (typeof response.signal !== "string" || !/^SIG[A-Z0-9]{1,28}$/u.test(response.signal))) ||
     typeof response.stdoutBase64 !== "string" ||
     typeof response.stderrBase64 !== "string" ||
+    !Number.isSafeInteger(response.workerElapsedMs) ||
+    response.workerElapsedMs < 0 ||
     (response.error !== undefined && typeof response.error !== "string") ||
     (response.stopReason !== undefined &&
-      typeof response.stopReason !== "string")
+      !METADATA_COMMAND_STOP_REASONS.has(response.stopReason))
   ) {
     throw new Error("bounded metadata command returned an invalid result");
   }
@@ -859,10 +932,7 @@ function gitBuffer(repositoryRoot, args, label) {
     }
     return result.stdout;
   } catch (error) {
-    throw new Error(
-      `${label} failed or exceeded its ${BOUNDED_COMMAND_TIMEOUT_MS} ms deadline`,
-      { cause: error },
-    );
+    throw boundedCommandFailure(label, BOUNDED_COMMAND_TIMEOUT_MS, error);
   }
 }
 

--- a/runtime/tests/fnd/benchmark-harness-faults.test.ts
+++ b/runtime/tests/fnd/benchmark-harness-faults.test.ts
@@ -1523,7 +1523,8 @@ describe("FND benchmark harness fault contracts", () => {
     ].join("\n");
     const startedAt = Date.now();
     try {
-      expect(() =>
+      let failure: unknown;
+      try {
         runBoundedCommandText(
           process.execPath,
           ["-e", source, descendantPath],
@@ -1533,8 +1534,20 @@ describe("FND benchmark harness fault contracts", () => {
             maxOutputBytes: 4_096,
             timeoutMs,
           },
-        ),
-      ).toThrow(new RegExp(`${timeoutMs} ms deadline`, "u"));
+        );
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toMatchObject({
+        message: expect.stringContaining(`${timeoutMs} ms deadline`),
+        metadataCommand: {
+          phase: "command_timeout",
+          stopReason: "timeout",
+          backstopExpired: false,
+          commandTimeoutMs: timeoutMs,
+          workerElapsedMs: expect.any(Number),
+        },
+      });
       expect(Date.now() - startedAt).toBeLessThan(
         timeoutMs +
           METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS +

--- a/runtime/tests/fnd/metadata-command-diagnostics.test.ts
+++ b/runtime/tests/fnd/metadata-command-diagnostics.test.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const dependencies = vi.hoisted(() => ({ execFileSync: vi.fn() }));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: dependencies.execFileSync,
+}));
+
+import {
+  BOUNDED_COMMAND_TIMEOUT_MS,
+  METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS,
+  METADATA_COMMAND_WORKER_OVERHEAD_MS,
+  runBoundedCommandText,
+} from "../../benchmarks/fnd/provenance.mjs";
+
+const RUNTIME_ROOT = join(import.meta.dirname, "../..");
+const PRIVATE_MARKER = "/private/operator-workspace/hidden-command";
+
+beforeEach(() => {
+  dependencies.execFileSync.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function commandFailure() {
+  try {
+    runBoundedCommandText(process.execPath, ["--version"], {
+      cwd: RUNTIME_ROOT,
+      label: "resolve benchmark source revision",
+    });
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the metadata command to fail");
+}
+
+function workerResponse(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    backstopExpired: false,
+    exitCode: 0,
+    signal: null,
+    stderrBase64: "",
+    stdoutBase64: Buffer.from("ready\n").toString("base64"),
+    workerElapsedMs: 0,
+    ...overrides,
+  });
+}
+
+describe("bounded metadata command diagnostics", () => {
+  test.each([
+    {
+      phase: "command_timeout",
+      response: { stopReason: "timeout", exitCode: null, signal: "SIGKILL" },
+    },
+    {
+      phase: "settlement_failed",
+      response: { backstopExpired: true, stopReason: "timeout", exitCode: null },
+    },
+    {
+      phase: "command_failed",
+      response: { error: PRIVATE_MARKER, exitCode: null },
+    },
+    {
+      phase: "command_stopped",
+      response: { stopReason: "output_limit", exitCode: null },
+    },
+  ])("retains $phase without exposing command paths", ({ phase, response }) => {
+    dependencies.execFileSync.mockReturnValue(workerResponse(response));
+    const failure = commandFailure();
+    expect(failure).toMatchObject({
+      message: expect.stringContaining("resolve benchmark source revision"),
+      metadataCommand: {
+        phase,
+        commandTimeoutMs: 5_000,
+        workerTimeoutMs: 9_000,
+        elapsedMs: expect.any(Number),
+        workerElapsedMs: 0,
+        backstopExpired: response.backstopExpired ?? false,
+        stopReason: response.stopReason ?? null,
+      },
+    });
+    expect(String(failure)).toContain(phase);
+    expect(String(failure)).not.toContain(PRIVATE_MARKER);
+  });
+
+  test.each([
+    { code: "ETIMEDOUT", phase: "worker_timeout" },
+    { code: "EACCES", phase: "worker_failed" },
+  ])("distinguishes $phase from the child deadline", ({ code, phase }) => {
+    dependencies.execFileSync.mockImplementation(() => {
+      throw Object.assign(new Error(PRIVATE_MARKER), { code });
+    });
+    const failure = commandFailure();
+    expect(failure).toMatchObject({
+      metadataCommand: {
+        phase,
+        commandTimeoutMs: 5_000,
+        workerTimeoutMs: 9_000,
+        elapsedMs: expect.any(Number),
+        workerElapsedMs: null,
+        backstopExpired: null,
+        stopReason: null,
+      },
+    });
+    expect(String(failure)).toContain(phase);
+    expect(String(failure)).not.toContain(PRIVATE_MARKER);
+    expect((failure as Error).cause?.toString()).not.toContain(PRIVATE_MARKER);
+  });
+
+  test.each([
+    { workerElapsedMs: -1 },
+    { workerElapsedMs: Infinity },
+    { workerElapsedMs: "slow" },
+    { stopReason: PRIVATE_MARKER },
+    { signal: PRIVATE_MARKER },
+  ])("rejects invalid worker metadata %j", (response) => {
+    dependencies.execFileSync.mockReturnValue(workerResponse(response));
+    expect(commandFailure()).toMatchObject({
+      metadataCommand: { phase: "protocol_error" },
+    });
+  });
+
+  test("keeps the child deadline separate from delayed helper startup", async () => {
+    const actual = await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+    const startupDelayMs = 1_100;
+    const timeoutMs = 1_000;
+    const delayModule = `data:text/javascript,${encodeURIComponent(
+      `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ${startupDelayMs});`,
+    )}`;
+    let observedResponse: unknown;
+    dependencies.execFileSync.mockImplementation((command, args, options) => {
+      expect(JSON.parse(options.input).timeoutMs).toBe(timeoutMs);
+      expect(options.stdio).toBe("pipe");
+      expect(options.timeout).toBe(
+        timeoutMs + METADATA_COMMAND_SETTLEMENT_TIMEOUT_MS + METADATA_COMMAND_WORKER_OVERHEAD_MS,
+      );
+      const output = actual.execFileSync(command, ["--import", delayModule, ...args], options);
+      observedResponse = JSON.parse(String(output));
+      return output;
+    });
+
+    expect(runBoundedCommandText(process.execPath, ["-e", 'process.stdout.write("ready")'], {
+      cwd: RUNTIME_ROOT,
+      timeoutMs,
+    })).toBe("ready");
+    expect(observedResponse).toMatchObject({
+      backstopExpired: false,
+      exitCode: 0,
+      workerElapsedMs: expect.any(Number),
+    });
+    expect(BOUNDED_COMMAND_TIMEOUT_MS).toBe(5_000);
+  });
+
+  test("serializes the macOS native slice without enabling its workflow", () => {
+    const workflow = readFileSync(join(RUNTIME_ROOT, "../.github/workflows/platform-tests.yml"), "utf8");
+    const nativeStep = workflow.split("- name: Run the exact macOS FND/native capability lane")[1]?.split("\n      - name:")[0];
+    expect(nativeStep).toContain("--maxWorkers=1");
+  });
+});


### PR DESCRIPTION
## Changes

Closes #1914.

- Run the macOS FND/native slice with one file worker so provenance helpers no longer compete with its other native fixtures. This changes scheduling only; the workflow remains disabled on GitHub.
- Preserve structured metadata-command failures through both text and binary Git wrappers. Diagnostics distinguish child timeout, outer worker timeout, unproven settlement, worker failure, and malformed protocol data. They retain limits, elapsed times, stop reason, exit state, and cleanup status without including command paths or arguments in those fields.
- Record execution/settlement time inside the helper, after startup. Keep the existing 5-second command limit and separate 2-second settlement and worker-overhead allowances unchanged. No retries or longer limits are added.
- Add 13 tests covering phase classification, malformed timing/status fields, safe diagnostics, native-worker scheduling, and a real helper delayed by 1,100 ms before executing a command with a 1,000 ms deadline. The existing signal-resistant metadata process-tree test now checks structured timeout and cleanup evidence as well as physical descendant exit.

The delayed-start test protects an existing distinction: the child timer already starts inside the helper after startup. The scheduling cap addresses contention; phase-specific errors make any remaining outer-worker starvation distinguishable from an actual child timeout. An outer worker that exceeds its combined bound still fails closed.

## Benchmark record

Capture ran once on clean helper commit `97676dad9a1a0365975471eaaffe47605fc37df0`, using reviewed main `87bbfcf13c2a5cc4bc5431ea2762e6389ec613c5` as the production source. This follows the documented default-branch-parent workflow for helper and artifact changes in one PR. The complete `runtime/src` tree matches that main revision; no runtime source changes are included.

- JSON SHA-256 is `43e1fe22f22ee7669a6fbfe3d61472c142ee68299fec39b13f23fc1a86eb8702`.
- Production tree is `ff3829b500404e249a54dd59a6109cfa40f22e90`.
- Benchmark plan and production module closures are unchanged. Only the provenance helper and metadata worker evidence hashes change. No threshold or verifier is weakened.

## Local validation

- All 11 initial diagnostic assertions fail against the original source. Two further malformed-status cases bring the final diagnostic suite to 13 passing tests.
- All 75 targeted tests pass across diagnostic, fault-contract, and packaging files. Final diagnostics pass again after explicit piped helper stdio is added.
- Runtime and test-support typechecks pass. The baseline verifier passes with the refreshed record; its earlier evidence-binding failure correctly detected the two changed helper hashes.
- Full root tests pass on final head `cb2c768376e36d831895236eea9de211fd576d67`, including all 23,353 runtime tests across 2,266 files with zero failures or skips. Fresh-clone verification passes. The serialized portable FND native slice passes 89 tests across four files with zero skips.

Cursor approves the exact final head. Bugbot, Security, Approval Agent, and Sonar checks all pass; Sonar reports zero open issues. GitHub reports zero Actions runs for this head.

GitNexus reports low risk across three direct helper callers and no indexed execution flows. Pre-commit checks report the expected six helper/workflow/test/documentation files and then the two generated files. New helper symbols are not yet indexed and were checked directly. Automatic index refresh crashed earlier; no repair or reindex was forced during this work.

Paid Actions CI remains disabled. No workflow is enabled, dispatched, rerun, or retried. Native execution here is Linux-only; the macOS runner scheduling change is covered by a source contract, not an unauthorized hosted run. Independent PR review checks remain enabled.
