### PR TITLE
test(tui): acknowledge Neovim input independently of frames

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1025,8 +1025,8 @@ jobs:
             "tests/tui/workbench/buffer-neovim-provider.contract.test.ts",
           ];
           const exactCounts = {
-            numTotalTests: 65,
-            numPassedTests: 65,
+            numTotalTests: 68,
+            numPassedTests: 68,
             numFailedTestSuites: 0,
             numPendingTestSuites: 0,
             numFailedTests: 0,
@@ -1054,7 +1054,7 @@ jobs:
             );
           }
           console.log(
-            "Neovim provider/observed-descendant platform lane passed 65 tests in 3 files with zero skipped",
+            "Neovim provider/observed-descendant platform lane passed 68 tests in 3 files with zero skipped",
           );
           NODE
 

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -1047,7 +1047,7 @@ with `--platform linux-x64` (or `linux-arm64` / `darwin-x64` /
 `darwin-arm64`). `--platform win-x64` fails closed. The full local BUFFER
 PTY set remains
 `npm --workspace=@tetsuo-ai/runtime run check:tui-workbench-buffer-neovim`.
-Windows still runs the 18-test lifecycle suite, the 65-test
+Windows still runs the 18-test lifecycle suite, the 68-test
 provider/observed-descendant set (including Job Object tree cleanup), and
 post-job leak assertions.
 The `macos-native` job first runs the 66-test red-probe runner contract.

--- a/docs/embedded-neovim-buffer.md
+++ b/docs/embedded-neovim-buffer.md
@@ -743,12 +743,27 @@ node scripts/check-embedded-neovim-buffer.mjs
 ```
 
 Hosted Neovim coverage is split. All five runners still run the 18-test
-lifecycle suite and the 65-test provider/observed-descendant set. Only Linux
+lifecycle suite and the 68-test provider/observed-descendant set. Only Linux
 and Darwin then run the two hosted PTY scenarios and expect `2/2 passed`.
 `--platform win-x64` fails closed (`unsupported TUI E2E platform`). Local
 full BUFFER PTY coverage is `check:tui-workbench-buffer-neovim`, not the
 hosted `--platform` filter. Inventory and the ConPTY constraint:
 [`ci-required-gates.md`](ci-required-gates.md).
+
+The two platform PTY scenarios enable a private input trace through
+`AGENC_TEST_NEOVIM_INPUT_TRACE` before starting the TUI. The trace records the
+owning editor session, BUFFER focus, input sequence, input RPC completion, and
+native mode probes. It does not record input text. Normal runs leave tracing
+off and make no additional mode requests.
+
+Command entry sends CSI-u Escape, waits for that sequence to acknowledge
+normal mode, sends one colon, waits for command-line mode, and then pastes the
+body. Enter follows the paste acknowledgement. The input steps share a
+five-second deadline and never resend an ambiguous input. Retired-session
+acknowledgements cannot authorize a replacement session. Timeout diagnostics
+include the owner, focus, provider state, last sequence, RPC phase, and latest
+frame. A separate presentation test checks delayed `CMDLINE_NORMAL` painting;
+command delivery does not wait for that frame.
 
 The TUI talks to the daemon over `AGENC_DAEMON_INTERNAL_METHODS`
 (`workspace.editor.acquire` / `sync` / `heartbeat` / `release`, topology,

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -260,6 +260,7 @@ These have their own pages. Short map:
 
 | Var | Effect |
 | --- | --- |
+| `AGENC_TEST_NEOVIM_INPUT_TRACE` | Test-only JSONL output path for embedded Neovim input acknowledgements. Records session identity, BUFFER focus, sequence, RPC phase, and mode without input text. Enables bounded read-only mode probes; unset in ordinary runs. See [embedded Neovim testing](../embedded-neovim-buffer.md). |
 | `AGENC_ONBOARDING` | First-run wizard control captured for the owning TUI session. `force` shows the wizard even after completion; `0`, `false`, or `off` suppress it. Unset follows persisted `onboarding.json` state |
 | `AGENC_TUI_WORKBENCH` | `0` uses classic fullscreen instead of workbench |
 | `AGENC_NO_FLICKER` | `0` disables fullscreen; `1` forces it on, including under tmux `-CC`. When unset, tmux `-CC` disables fullscreen; otherwise `tui.flickerFreeMode` is authoritative and defaults to on |

--- a/runtime/platform-tests/neovim-platform-gate.contract.test.ts
+++ b/runtime/platform-tests/neovim-platform-gate.contract.test.ts
@@ -154,10 +154,10 @@ describe("hosted Neovim platform gate contract", () => {
     expect(source).toContain(
       "platform-tests/neovim-process-tree.real.test.ts",
     );
-    expect(source).toContain("numTotalTests: 65");
-    expect(source).toContain("numPassedTests: 65");
+    expect(source).toContain("numTotalTests: 68");
+    expect(source).toContain("numPassedTests: 68");
     expect(source).toContain(
-      "Neovim provider/observed-descendant platform lane passed 65 tests in 3 files with zero skipped",
+      "Neovim provider/observed-descendant platform lane passed 68 tests in 3 files with zero skipped",
     );
     expect(source).toContain(
       "scripts/check-tui-e2e/runner.mjs --platform",
@@ -234,7 +234,7 @@ describe("hosted Neovim platform gate contract", () => {
       "const editProof = await waitForExactFileText(",
     );
     const editEscapeIndex = saveScenario.indexOf(
-      'session.send("\\x1b")',
+      'runEmbeddedNeovimCommand(session, "write"',
       editInputIndex,
     );
     expect(editInputIndex).toBeGreaterThan(-1);
@@ -243,6 +243,7 @@ describe("hosted Neovim platform gate contract", () => {
     expect(saveScenario).not.toContain("\\x1b[201~");
     expect(editProofWaitIndex).toBeGreaterThan(editInputIndex);
     expect(editEscapeIndex).toBeGreaterThan(editProofWaitIndex);
+    expect(saveScenario).not.toContain('session.send("\\x1b")');
     expect(saveScenario).toContain("nvim-platform-exit.intent");
     expect(saveScenario).toContain("| qa!");
     expect(saveScenario).toContain(
@@ -255,7 +256,8 @@ describe("hosted Neovim platform gate contract", () => {
       ),
       "utf8",
     );
-    expect(helperSource).toContain("/CMDLINE_NORMAL/u");
+    expect(helperSource).toContain("readNeovimInputTrace");
+    expect(helperSource).toContain("input.rpcCompleted === true");
     expect(helperSource).toContain("export function sendEmbeddedNeovimInput");
     expect(helperSource).toContain("\\x1b[200~");
     expect(helperSource).toContain("\\x1b[201~");

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -118,31 +118,17 @@ export async function runEmbeddedNeovimCommand(
     while (Date.now() < deadline) {
       session.throwIfAborted?.();
       const records = await readTrace();
-      const state = records.findLast((record) => record.type === "state");
-      const inputs = new Map();
-      for (const record of records) {
-        if (record.type === "input" && record.sessionId === (owner ?? state?.sessionId)) {
-          inputs.set(record.sequence, record);
-        }
-      }
-      const lastSequence = Math.max(0, ...inputs.keys());
-      const input = inputs.get(sequence);
-      latest = { owner, state, expectedSequence: sequence, expectedKind: kind, lastInput: inputs.get(lastSequence), input };
+      latest = summarizeNeovimInputTrace(records, owner, sequence, kind);
       if (session.exited === true) throw fail("failed because the TUI exited");
-      if (owner && (state?.sessionId !== owner || state.focusOwner !== "buffer")) {
-        throw fail("lost its owning session or BUFFER focus");
-      }
+      assertNeovimInputOwner(latest, fail);
       if (!kind) {
-        const pending = [...inputs.values()].some((record) => !["complete", "failed", "retired", "skipped"].includes(record.phase));
-        if (state?.sessionId && state.providerStatus === "ready" && state.focusOwner === "buffer" && !pending) {
-          owner = state.sessionId;
-          sequence = lastSequence;
+        if (neovimInputTraceReady(latest)) {
+          owner = latest.state.sessionId;
+          sequence = latest.lastSequence;
           return;
         }
-      } else if (input) {
-        if (input.kind !== kind || lastSequence !== sequence) throw fail("received an unexpected input sequence");
-        if (["failed", "retired", "skipped"].includes(input.phase)) throw fail(`failed in ${input.phase}`);
-        if (input.phase === "complete" && input.rpcCompleted === true && input.mode === expectedMode) return;
+      } else if (neovimInputTraceComplete(latest, expectedMode, fail)) {
+        return;
       }
       await wait(10);
     }
@@ -160,6 +146,52 @@ export async function runEmbeddedNeovimCommand(
   }
   session.send("\r");
   await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
+}
+
+function summarizeNeovimInputTrace(records, owner, sequence, kind) {
+  const state = records.findLast((record) => record.type === "state");
+  const inputs = new Map();
+  for (const record of records) {
+    if (
+      record.type === "input" &&
+      record.sessionId === (owner ?? state?.sessionId)
+    ) inputs.set(record.sequence, record);
+  }
+  const lastSequence = Math.max(0, ...inputs.keys());
+  const pending = [...inputs.values()].some(
+    (record) => !["complete", "failed", "retired", "skipped"].includes(record.phase),
+  );
+  return {
+    owner, state, lastSequence, pending,
+    expectedSequence: sequence,
+    expectedKind: kind,
+    lastInput: inputs.get(lastSequence),
+    input: inputs.get(sequence),
+  };
+}
+
+function assertNeovimInputOwner({ owner, state }, fail) {
+  if (owner && (state?.sessionId !== owner || state.focusOwner !== "buffer")) {
+    throw fail("lost its owning session or BUFFER focus");
+  }
+}
+
+function neovimInputTraceReady({ state, pending }) {
+  return state?.sessionId && state.providerStatus === "ready" &&
+    state.focusOwner === "buffer" && !pending;
+}
+
+function neovimInputTraceComplete(latest, expectedMode, fail) {
+  const { input, lastSequence, expectedSequence, expectedKind } = latest;
+  if (!input) return false;
+  if (input.kind !== expectedKind || lastSequence !== expectedSequence) {
+    throw fail("received an unexpected input sequence");
+  }
+  if (["failed", "retired", "skipped"].includes(input.phase)) {
+    throw fail(`failed in ${input.phase}`);
+  }
+  return input.phase === "complete" && input.rpcCompleted === true &&
+    input.mode === expectedMode;
 }
 
 export async function listNeovimPids() {

--- a/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
+++ b/runtime/scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs
@@ -88,54 +88,76 @@ export function sendEmbeddedNeovimInput(session, text) {
   session.send(text);
 }
 
+export function enableNeovimInputTrace(session) {
+  session.neovimInputTracePath = join(session.cwd, ".agenc-neovim-input-trace.jsonl");
+  session.envOverrides.AGENC_TEST_NEOVIM_INPUT_TRACE = session.neovimInputTracePath;
+}
+
+export async function readNeovimInputTrace(session) {
+  if (!session.neovimInputTracePath) throw new Error("Neovim input trace was not enabled before TUI startup");
+  const text = await readFile(session.neovimInputTracePath, "utf8").catch((error) => {
+    if (error.code === "ENOENT") return "";
+    throw error;
+  });
+  return text.split("\n").slice(0, -1).filter(Boolean).map((line) => JSON.parse(line));
+}
+
 export async function runEmbeddedNeovimCommand(
   session,
   command,
-  { readySession = false } = {},
+  { readTrace = () => readNeovimInputTrace(session), wait = sleep, timeoutMs = 5_000 } = {},
 ) {
-  // The terminal grid can paint NORMAL before the provider commits the session
-  // that receives input. The provider header binds ready state to that
-  // committed session, but its coarse "normal" label also covers transient
-  // native modes. Normalize the owned session with Escape before entering Ex.
-  // The callers prove command delivery through concrete process/file effects;
-  // do not make that contract depend on a ConPTY-rendered presentation footer.
-  // A caller may bypass the presentation gate only after concrete evidence
-  // proves that this same Neovim process is live and already received input.
-  if (!readySession) {
-    await waitForFrameText(
-      session,
-      /\[embedded Neovim [^,\n]+,\s*normal,\s*ready(?:,|\])/iu,
-      `committed embedded Neovim session before :${command}`,
-      5_000,
-    );
-  }
-  await session.waitForIdle({ idleWindow: 200, timeout: 5_000 });
-  // A lone ESC is intentionally buffered by the TUI parser so a following
-  // byte can complete an Alt/meta sequence. A parent-side delay cannot prove
-  // that a render-stalled child flushed that byte first: ESC and ':' can be
-  // read together, dropping the Escape normalization that transient native
-  // modes require. CSI-u encodes Escape as one complete key, so it remains
-  // distinct from the colon even when both writes reach the same stdin read.
-  session.send(CSI_U_ESCAPE);
-  await sleep(80);
-  session.send(":");
-  // Neovim's provider footer remains in CMDLINE_NORMAL for the lifetime of
-  // command mode. Do not paste the command body until that real editor-state
-  // acknowledgement proves the normalized Escape and colon were consumed.
-  await waitForFrameText(
-    session,
-    /CMDLINE_NORMAL/u,
-    `embedded Neovim command mode before :${command}`,
-    5_000,
+  const deadline = Date.now() + timeoutMs;
+  let owner = null;
+  let sequence = 0;
+  let latest = {};
+  const fail = (reason) => new Error(
+    `Embedded Neovim input acknowledgement ${reason}: ${JSON.stringify(latest)}; latest frame: ${frameText(session).slice(-1200)}`,
   );
-  // Deliver the command body through the terminal's real bracketed-paste
-  // protocol. BufferSurface routes that one paste event to one acknowledged
-  // nvim_paste RPC instead of launching an unobserved nvim_input request for
-  // every character. Escape, colon, the command-mode acknowledgement, and
-  // Enter remain real editor interactions, so this still exercises the
-  // complete PTY input path.
-  session.send(`\x1b[200~${command}\x1b[201~`);
-  await sleep(80);
+  const poll = async (kind = null, expectedMode = null) => {
+    while (Date.now() < deadline) {
+      session.throwIfAborted?.();
+      const records = await readTrace();
+      const state = records.findLast((record) => record.type === "state");
+      const inputs = new Map();
+      for (const record of records) {
+        if (record.type === "input" && record.sessionId === (owner ?? state?.sessionId)) {
+          inputs.set(record.sequence, record);
+        }
+      }
+      const lastSequence = Math.max(0, ...inputs.keys());
+      const input = inputs.get(sequence);
+      latest = { owner, state, expectedSequence: sequence, expectedKind: kind, lastInput: inputs.get(lastSequence), input };
+      if (session.exited === true) throw fail("failed because the TUI exited");
+      if (owner && (state?.sessionId !== owner || state.focusOwner !== "buffer")) {
+        throw fail("lost its owning session or BUFFER focus");
+      }
+      if (!kind) {
+        const pending = [...inputs.values()].some((record) => !["complete", "failed", "retired", "skipped"].includes(record.phase));
+        if (state?.sessionId && state.providerStatus === "ready" && state.focusOwner === "buffer" && !pending) {
+          owner = state.sessionId;
+          sequence = lastSequence;
+          return;
+        }
+      } else if (input) {
+        if (input.kind !== kind || lastSequence !== sequence) throw fail("received an unexpected input sequence");
+        if (["failed", "retired", "skipped"].includes(input.phase)) throw fail(`failed in ${input.phase}`);
+        if (input.phase === "complete" && input.rpcCompleted === true && input.mode === expectedMode) return;
+      }
+      await wait(10);
+    }
+    throw fail("timed out without resending input");
+  };
+  await poll();
+  for (const [bytes, kind, mode] of [
+    [CSI_U_ESCAPE, "escape", "n"],
+    [":", "colon", "c"],
+    [`\x1b[200~${command}\x1b[201~`, "paste", "c"],
+  ]) {
+    sequence += 1;
+    session.send(bytes);
+    await poll(kind, mode);
+  }
   session.send("\r");
   await session.waitForIdle({ idleWindow: 500, timeout: 10_000 });
 }

--- a/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/130-workbench-buffer-neovim-platform-gate.mjs
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import {
   anchorWorkbenchProjectRoot,
+  enableNeovimInputTrace,
   runEmbeddedNeovimCommand,
   sendEmbeddedNeovimInput,
   waitForExactFileText,
@@ -74,7 +75,6 @@ export default async function (session) {
         `Neovim platform edit proof was not exact: ${JSON.stringify(editProof)}`,
       );
     }
-    session.send("\x1b");
     // Exercise Neovim's real write path in the hosted PTY. The host-owned
     // Ctrl+S boundary is covered separately through the terminal parser and
     // rendered BufferSurface integration test; emitting Ctrl+S from node-pty
@@ -117,6 +117,7 @@ export default async function (session) {
 }
 
 async function openEmbeddedNeovim(session) {
+  enableNeovimInputTrace(session);
   await session.start();
   await session.waitForPrompt({ timeout: 20_000 });
   await waitForFrameText(

--- a/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/131-workbench-buffer-neovim-platform-kill-cleanup.mjs
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import {
   anchorWorkbenchProjectRoot,
+  enableNeovimInputTrace,
   runEmbeddedNeovimCommand,
   sendEmbeddedNeovimInput,
   waitForExactFileText,
@@ -156,6 +157,7 @@ function vimLiteral(value) {
 }
 
 async function openEmbeddedNeovim(session) {
+  enableNeovimInputTrace(session);
   await session.start();
   await session.waitForPrompt({ timeout: 20_000 });
   await waitForFrameText(

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimInputTrace.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimInputTrace.ts
@@ -1,0 +1,86 @@
+import { appendFileSync } from "node:fs";
+
+export type NeovimInputTraceState = {
+  readonly sessionId: string | null;
+  readonly focusOwner: "buffer" | "other";
+  readonly providerStatus: string;
+  readonly providerMode: string;
+};
+
+export type NeovimInputTraceToken = {
+  readonly sessionId: string;
+  readonly sequence: number;
+  readonly kind: "escape" | "colon" | "paste" | "enter" | "other";
+  rpcCompleted: boolean;
+};
+
+export type NeovimInputTraceRecord =
+  | (NeovimInputTraceState & { readonly type: "state" })
+  | (NeovimInputTraceToken & {
+      readonly type: "input";
+      readonly phase:
+        | "queued"
+        | "running"
+        | "rpc-complete"
+        | "mode"
+        | "complete"
+        | "failed"
+        | "retired"
+        | "skipped";
+      readonly mode: string | null;
+      readonly pendingRpc: "input" | "mode" | null;
+    });
+
+export class NeovimInputTrace {
+  #sequence = 0;
+  #state = "";
+
+  constructor(readonly write: (record: NeovimInputTraceRecord) => void) {}
+
+  state(state: NeovimInputTraceState): void {
+    const serialized = JSON.stringify(state);
+    if (serialized === this.#state) return;
+    this.#state = serialized;
+    this.write({ type: "state", ...state });
+  }
+
+  begin(
+    sessionId: string,
+    kind: NeovimInputTraceToken["kind"],
+  ): NeovimInputTraceToken {
+    const token = {
+      sessionId,
+      kind,
+      sequence: ++this.#sequence,
+      rpcCompleted: false,
+    };
+    this.progress(token, "queued");
+    return token;
+  }
+
+  progress(
+    token: NeovimInputTraceToken,
+    phase: Extract<NeovimInputTraceRecord, { type: "input" }>["phase"],
+    mode: string | null = null,
+  ): void {
+    if (phase === "rpc-complete") token.rpcCompleted = true;
+    let pendingRpc: "input" | "mode" | null = null;
+    if (phase === "running") pendingRpc = "input";
+    if (phase === "mode" || phase === "rpc-complete") pendingRpc = "mode";
+    this.write({ type: "input", ...token, phase, mode, pendingRpc });
+  }
+}
+
+export function neovimInputTraceForTesting(
+  env: NodeJS.ProcessEnv = process.env,
+): NeovimInputTrace | null {
+  const path = env.AGENC_TEST_NEOVIM_INPUT_TRACE;
+  if (!path) return null;
+  return new NeovimInputTrace((record) => {
+    try {
+      appendFileSync(path, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+    } catch {
+      return;
+    }
+  });
+}

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -702,6 +702,36 @@ export class EmbeddedNeovimSession {
     );
   }
 
+  async inspectInputModeForTesting(
+    expectedMode: string | null,
+    onMode: (mode: string) => void,
+  ): Promise<string> {
+    return this.#runRpcOperation(
+      "Embedded Neovim input mode probe",
+      false,
+      async (signal, timeoutMs) => {
+        while (true) {
+          const value = rpcRecord(
+            await this.#request("nvim_get_mode", [], signal, timeoutMs),
+          );
+          if (
+            typeof value?.mode !== "string" ||
+            typeof value.blocking !== "boolean"
+          ) {
+            throw new Error("Embedded Neovim returned an invalid input mode.");
+          }
+          onMode(value.mode);
+          if (
+            (expectedMode === null || value.mode === expectedMode) &&
+            !value.blocking
+          ) return value.mode;
+          await waitForNeovimInputBuffer(signal);
+        }
+      },
+      5_000,
+    );
+  }
+
   async paste(text: string): Promise<void> {
     if (this.#closed || text.length === 0) return;
     await this.#runRpcOperation(

--- a/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
+++ b/runtime/src/tui/workbench/buffer/neovim/NeovimLifecycle.ts
@@ -718,7 +718,7 @@ export class EmbeddedNeovimSession {
             typeof value?.mode !== "string" ||
             typeof value.blocking !== "boolean"
           ) {
-            throw new Error("Embedded Neovim returned an invalid input mode.");
+            throw new TypeError("Embedded Neovim returned an invalid input mode.");
           }
           onMode(value.mode);
           if (

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -26,6 +26,11 @@ import {
 import type { NeovimDiscoveryResult } from "../../neovim/NeovimDiscovery.js";
 import { translateKeyToNeovimInput } from "../../neovim/NeovimInput.js";
 import {
+  neovimInputTraceForTesting,
+  type NeovimInputTrace,
+  type NeovimInputTraceToken,
+} from "../../neovim/NeovimInputTrace.js";
+import {
   createNeovimRenderSnapshot,
   type NeovimRenderSnapshot,
 } from "../../neovim/NeovimGrid.js";
@@ -90,6 +95,7 @@ export type NeovimBufferProviderOptions = {
   readonly startupTimeoutMs?: number;
   readonly operationTimeoutMs?: number;
   readonly cleanupTimeoutMs?: number;
+  readonly inputTraceForTesting?: NeovimInputTrace;
   /** One-release rollback switch for the legacy per-file process lifecycle. */
   readonly sessionMode?: "workspace" | "file";
   readonly workspaceRoot?: string;
@@ -362,8 +368,12 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     null;
   #recoveryPreservationRequired = false;
   #unconfirmedRecoveryExit: Error | null = null;
+  readonly #inputTrace: NeovimInputTrace | null;
+  #focused = false;
 
   constructor(options: NeovimBufferProviderOptions) {
+    this.#inputTrace =
+      options.inputTraceForTesting ?? neovimInputTraceForTesting();
     this.#discovery = options.discovery;
     this.#startupTimeoutMs = options.startupTimeoutMs;
     this.#operationTimeoutMs = options.operationTimeoutMs;
@@ -2248,7 +2258,11 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     const session = this.#session;
     if (!session) return false;
     if (event.isPaste === true) {
-      void this.#runSessionAction(session, () => session.paste(event.input));
+      void this.#runSessionAction(
+        session,
+        () => session.paste(event.input),
+        "paste",
+      );
       return true;
     }
     const keys = translateKeyToNeovimInput(event.input, event.key);
@@ -2276,6 +2290,8 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   }
 
   focus(focused: boolean): void {
+    this.#focused = focused;
+    this.#traceInputState();
     const session = this.#session;
     if (session)
       void this.#runSessionAction(session, () => session.focus(focused));
@@ -2470,14 +2486,24 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     session: EmbeddedNeovimSession,
     keys: string,
   ): Promise<void> {
-    await this.#runSessionAction(session, () => session.input(keys));
+    let kind: NeovimInputTraceToken["kind"] = "other";
+    if (keys === "<Esc>") kind = "escape";
+    else if (keys === ":") kind = "colon";
+    else if (keys === "<CR>") kind = "enter";
+    await this.#runSessionAction(session, () => session.input(keys), kind);
   }
 
   async #runSessionAction(
     session: EmbeddedNeovimSession,
     action: () => Promise<unknown>,
+    inputKind?: NeovimInputTraceToken["kind"],
   ): Promise<void> {
     const ownership = this.#captureOperationOwnership(session);
+    const sessionId = NEOVIM_EDITOR_SESSION_IDS.get(session);
+    const traceToken = inputKind && sessionId
+      ? this.#inputTrace?.begin(sessionId, inputKind)
+      : undefined;
+    let traceSettled = false;
     const pendingTransitionGeneration = this.#pendingTransitionGeneration;
     const sessionActionGate = this.#sessionActionGate;
     const previousAction = this.#sessionActionTail;
@@ -2498,12 +2524,72 @@ export class NeovimBufferProvider implements BufferEditorProvider {
         if (!sessionActionGate.allowActions) return;
       }
       if (!this.#ownsOperation(ownership)) return;
-      await action();
+      if (traceToken) this.#inputTrace?.progress(traceToken, "running");
+      const result = await action();
+      if (traceToken) {
+        traceSettled = true;
+        if (result === false) {
+          this.#inputTrace?.progress(traceToken, "skipped");
+        } else {
+          this.#inputTrace?.progress(traceToken, "rpc-complete");
+          await this.#traceInputMode(ownership, traceToken);
+        }
+      }
     } catch (error) {
+      if (traceToken) {
+        traceSettled = true;
+        this.#inputTrace?.progress(traceToken, "failed");
+      }
       if (this.#ownsOperation(ownership)) this.#setInputError(error);
     } finally {
+      if (traceToken && !traceSettled) {
+        this.#inputTrace?.progress(traceToken, "skipped");
+      }
       releaseAction();
     }
+  }
+
+  async #traceInputMode(
+    ownership: NeovimOperationOwnership,
+    token: NeovimInputTraceToken,
+  ): Promise<void> {
+    if (!this.#ownsOperation(ownership)) {
+      this.#inputTrace?.progress(token, "retired");
+      return;
+    }
+    let expectedMode: string | null = null;
+    if (token.kind === "escape") expectedMode = "n";
+    else if (token.kind === "colon") expectedMode = "c";
+    let observedMode: string | null = null;
+    try {
+      const mode = expectedMode === null && token.kind !== "paste"
+        ? null
+        : await ownership.session.inspectInputModeForTesting(
+            expectedMode,
+            (mode) => {
+              observedMode = mode;
+              this.#inputTrace?.progress(token, "mode", mode);
+            },
+          );
+      this.#inputTrace?.progress(
+        token,
+        this.#ownsOperation(ownership) ? "complete" : "retired",
+        mode,
+      );
+    } catch {
+      this.#inputTrace?.progress(token, "failed", observedMode);
+    }
+  }
+
+  #traceInputState(): void {
+    this.#inputTrace?.state({
+      sessionId: this.#session
+        ? NEOVIM_EDITOR_SESSION_IDS.get(this.#session) ?? null
+        : null,
+      focusOwner: this.#focused ? "buffer" : "other",
+      providerStatus: this.#snapshot.providerStatus,
+      providerMode: this.#terminal.mode,
+    });
   }
 
   #beginSessionActionGate(generation: number): NeovimSessionActionGate {
@@ -2602,6 +2688,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     if (this.#session !== session) return;
     this.#session = null;
     this.#ownershipGeneration += 1;
+    this.#traceInputState();
   }
 
   #scheduleWorkspaceRefresh(ownership: NeovimProviderOwnership): void {
@@ -3138,6 +3225,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
   }
 
   #emit(): void {
+    this.#traceInputState();
     for (const listener of this.#listeners) listener();
   }
 }

--- a/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
+++ b/runtime/src/tui/workbench/buffer/providers/neovim/NeovimBufferProvider.ts
@@ -2499,10 +2499,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
     inputKind?: NeovimInputTraceToken["kind"],
   ): Promise<void> {
     const ownership = this.#captureOperationOwnership(session);
-    const sessionId = NEOVIM_EDITOR_SESSION_IDS.get(session);
-    const traceToken = inputKind && sessionId
-      ? this.#inputTrace?.begin(sessionId, inputKind)
-      : undefined;
+    const traceToken = this.#beginInputTrace(session, inputKind);
     let traceSettled = false;
     const pendingTransitionGeneration = this.#pendingTransitionGeneration;
     const sessionActionGate = this.#sessionActionGate;
@@ -2528,12 +2525,7 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       const result = await action();
       if (traceToken) {
         traceSettled = true;
-        if (result === false) {
-          this.#inputTrace?.progress(traceToken, "skipped");
-        } else {
-          this.#inputTrace?.progress(traceToken, "rpc-complete");
-          await this.#traceInputMode(ownership, traceToken);
-        }
+        await this.#traceCompletedInput(ownership, traceToken, result);
       }
     } catch (error) {
       if (traceToken) {
@@ -2547,6 +2539,28 @@ export class NeovimBufferProvider implements BufferEditorProvider {
       }
       releaseAction();
     }
+  }
+
+  #beginInputTrace(
+    session: EmbeddedNeovimSession,
+    kind: NeovimInputTraceToken["kind"] | undefined,
+  ): NeovimInputTraceToken | undefined {
+    const sessionId = NEOVIM_EDITOR_SESSION_IDS.get(session);
+    if (!kind || !sessionId) return undefined;
+    return this.#inputTrace?.begin(sessionId, kind);
+  }
+
+  async #traceCompletedInput(
+    ownership: NeovimOperationOwnership,
+    token: NeovimInputTraceToken,
+    result: unknown,
+  ): Promise<void> {
+    if (result === false) {
+      this.#inputTrace?.progress(token, "skipped");
+      return;
+    }
+    this.#inputTrace?.progress(token, "rpc-complete");
+    await this.#traceInputMode(ownership, token);
   }
 
   async #traceInputMode(

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   INITIAL_STATE,
@@ -11,6 +11,13 @@ import {
   runEmbeddedNeovimCommand,
   waitForFrameText,
 } from "../../../scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs";
+import {
+  NeovimInputTrace,
+  type NeovimInputTraceRecord,
+  type NeovimInputTraceToken,
+} from "../../../src/tui/workbench/buffer/neovim/NeovimInputTrace.js";
+
+afterEach(() => vi.restoreAllMocks());
 
 // NOTE: This is a STATIC contract check that the PTY gate scripts exist and
 // declare the expected lifecycle assertions — it does NOT spawn nvim or run a
@@ -51,53 +58,17 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
   });
 
   it("enters command mode with an unambiguous Escape before provider-state acknowledgements", async () => {
-    const events: string[] = [];
-    const sentInputs: string[] = [];
-    const session = {
-      cols: 80,
-      rows: 24,
-      raw: "target.txt [embedded Neovim NVIM v0.11.4, normal, ready]",
-      send(input: string) {
-        events.push(`send:${JSON.stringify(input)}`);
-        sentInputs.push(input);
-        if (input === ":") {
-          this.raw =
-            "target.txt [embedded Neovim NVIM v0.11.4, normal, ready] CMDLINE_NORMAL";
-        }
-      },
-      async type() {
-        throw new Error(
-          "embedded Neovim commands must not fan out into unacknowledged character inputs",
-        );
-      },
-      async waitForIdle(options: { idleWindow: number }) {
-        events.push(`idle:${options.idleWindow}`);
-      },
-    };
-
-    await runEmbeddedNeovimCommand(session, "write");
-    session.raw = "";
-    await runEmbeddedNeovimCommand(session, "q!", {
-      readySession: true,
-    });
-
-    expect(events).toEqual([
-      "idle:200",
-      'send:"\\u001b[27u"',
-      'send:":"',
-      'send:"\\u001b[200~write\\u001b[201~"',
-      'send:"\\r"',
-      "idle:500",
-      "idle:200",
-      'send:"\\u001b[27u"',
-      'send:":"',
-      'send:"\\u001b[200~q!\\u001b[201~"',
-      'send:"\\r"',
-      "idle:500",
+    const fixture = createInputAcknowledgementFixture();
+    await runEmbeddedNeovimCommand(fixture.session, "write", fixture.options);
+    await runEmbeddedNeovimCommand(fixture.session, "q!", fixture.options);
+    expect(fixture.sentInputs).toEqual([
+      "\x1b[27u", ":", "\x1b[200~write\x1b[201~", "\r",
+      "\x1b[27u", ":", "\x1b[200~q!\x1b[201~", "\r",
     ]);
+    expect(fixture.session.raw).toBe("");
     const [parsedCommandModeInputs] = parseMultipleKeypresses(
       INITIAL_STATE,
-      sentInputs.slice(0, 2).join(""),
+      fixture.sentInputs.slice(0, 2).join(""),
     );
     expect(
       parsedCommandModeInputs.map((input) =>
@@ -109,6 +80,54 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
       { kind: "key", name: "escape", sequence: "\x1b[27u" },
       { kind: "key", name: "", sequence: ":" },
     ]);
+  });
+
+  it.each([["escape", 1], ["colon", 2], ["paste", 3]] as const)("does not send the next input before a delayed %s acknowledgement", async (delayedKind, expectedCount) => {
+    const fixture = createInputAcknowledgementFixture();
+    fixture.session.raw = "CMDLINE_NORMAL";
+    const pending = fixture.delay(delayedKind);
+    let waitCalls = 0;
+    fixture.options.wait = async () => {
+      waitCalls += 1;
+      expect(fixture.sentInputs).toHaveLength(expectedCount);
+      pending();
+    };
+    await runEmbeddedNeovimCommand(fixture.session, "write", fixture.options);
+    expect(waitCalls).toBe(1);
+    expect(fixture.sentInputs).toHaveLength(4);
+  });
+
+  it.each(["running", "rpc-complete"])("never resends an ambiguous colon in %s state", async (phase) => {
+    const fixture = createInputAcknowledgementFixture();
+    fixture.delay("colon", phase);
+    fixture.session.raw = "CMDLINE_NORMAL";
+    await expect(runEmbeddedNeovimCommand(fixture.session, "write", fixture.options)).rejects.toThrow(/timed out without resending.*session-one.*buffer.*colon.*CMDLINE_NORMAL/su);
+    expect(fixture.sentInputs).toEqual(["\x1b[27u", ":"]);
+  });
+
+  it("rejects a completed acknowledgement after the owner is replaced", async () => {
+    const fixture = createInputAcknowledgementFixture();
+    const acknowledge = fixture.delay("colon");
+    fixture.options.wait = async () => {
+      fixture.trace.state({ sessionId: "session-two", focusOwner: "buffer", providerStatus: "ready", providerMode: "normal" });
+      acknowledge();
+    };
+    await expect(runEmbeddedNeovimCommand(fixture.session, "write", fixture.options)).rejects.toThrow("lost its owning session");
+    expect(fixture.sentInputs).toEqual(["\x1b[27u", ":"]);
+  });
+
+  it("keeps delayed command-mode painting as a separate presentation assertion", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = { raw: "NORMAL", cols: 80, rows: 24 };
+      const painting = waitForFrameText(session, /CMDLINE_NORMAL/u, "command mode", 500);
+      await vi.advanceTimersByTimeAsync(200);
+      session.raw = "CMDLINE_NORMAL";
+      await vi.advanceTimersByTimeAsync(100);
+      await painting;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("defines the workbench Neovim scenarios and wrapper command", async () => {
@@ -283,7 +302,8 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(helpers).toContain("waitForFrameText");
     expect(helpers).toContain("workspaceSnapshot");
     expect(helpers).toContain("anchorWorkbenchProjectRoot");
-    expect(helpers).toContain("/CMDLINE_NORMAL/u");
+    expect(helpers).toContain("readNeovimInputTrace");
+    expect(helpers).not.toContain("await sleep(80)");
     expect(helpers).toContain("\\x1b[200~");
     expect(helpers).toContain("\\x1b[201~");
     expect(helpers).not.toContain("session.type(`:${command}`");
@@ -303,3 +323,50 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
     expect(visualSmoke).toContain("WORKSPA");
   });
 });
+
+function createInputAcknowledgementFixture() {
+  const records: NeovimInputTraceRecord[] = [];
+  const trace = new NeovimInputTrace((record) => records.push(record));
+  trace.state({ sessionId: "session-one", focusOwner: "buffer", providerStatus: "ready", providerMode: "normal" });
+  const sentInputs: string[] = [];
+  let delayedKind: string | null = null;
+  let delayedPhase: "running" | "rpc-complete" = "running";
+  let acknowledge = () => {};
+  let now = 0;
+  vi.spyOn(Date, "now").mockImplementation(() => now);
+  const session = {
+    cols: 80,
+    rows: 24,
+    raw: "",
+    send(input: string) {
+      sentInputs.push(input);
+      let kind: NeovimInputTraceToken["kind"] = "paste";
+      if (input === "\x1b[27u") kind = "escape";
+      else if (input === ":") kind = "colon";
+      else if (input === "\r") kind = "enter";
+      const token = trace.begin("session-one", kind);
+      trace.progress(token, "running");
+      const complete = () => {
+        trace.progress(token, "rpc-complete");
+        let mode: string | null = "c";
+        if (kind === "escape") mode = "n";
+        else if (kind === "enter") mode = null;
+        trace.progress(token, "complete", mode);
+      };
+      if (kind === delayedKind) {
+        if (delayedPhase === "rpc-complete") trace.progress(token, "rpc-complete");
+        acknowledge = complete;
+      } else complete();
+    },
+    waitForIdle: vi.fn(async () => {}),
+  };
+  return {
+    session, records, trace, sentInputs,
+    options: { readTrace: async () => records, wait: async () => { now += 10; }, timeoutMs: 100 },
+    delay(kind: string, phase: "running" | "rpc-complete" = "running") {
+      delayedKind = kind;
+      delayedPhase = phase;
+      return () => acknowledge();
+    },
+  };
+}

--- a/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-e2e-contract.test.ts
@@ -124,7 +124,7 @@ describe("embedded Neovim BUFFER PTY gate files", () => {
       await vi.advanceTimersByTimeAsync(200);
       session.raw = "CMDLINE_NORMAL";
       await vi.advanceTimersByTimeAsync(100);
-      await painting;
+      await expect(painting).resolves.toBeUndefined();
     } finally {
       vi.useRealTimers();
     }

--- a/runtime/tests/tui/workbench/buffer-neovim-input-trace.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-input-trace.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  NeovimInputTrace,
+  neovimInputTraceForTesting,
+  type NeovimInputTraceRecord,
+} from "../../../src/tui/workbench/buffer/neovim/NeovimInputTrace.js";
+import {
+  enableNeovimInputTrace,
+  readNeovimInputTrace,
+} from "../../../scripts/check-tui-e2e/helpers/workbench-buffer-neovim.mjs";
+
+describe("Neovim test input trace", () => {
+  it("is disabled without an explicit test trace path", () => {
+    expect(neovimInputTraceForTesting({})).toBeNull();
+  });
+
+  it("keeps sequences monotonic across owners and snapshots RPC completion", () => {
+    const records: NeovimInputTraceRecord[] = [];
+    const trace = new NeovimInputTrace((record) => records.push(record));
+    const first = trace.begin("first", "escape");
+    trace.progress(first, "running");
+    trace.progress(first, "rpc-complete");
+    trace.progress(first, "mode", "i");
+    trace.progress(first, "complete", "n");
+    const second = trace.begin("second", "colon");
+    expect(second.sequence).toBe(first.sequence + 1);
+    expect(records[0]).toMatchObject({ rpcCompleted: false, phase: "queued" });
+    expect(records[1]).toMatchObject({ pendingRpc: "input" });
+    expect(records[2]).toMatchObject({ rpcCompleted: true, pendingRpc: "mode" });
+    expect(records[3]).toMatchObject({ mode: "i", pendingRpc: "mode" });
+    expect(records[4]).toMatchObject({ mode: "n", pendingRpc: null });
+  });
+
+  it("writes a private trace without input text and ignores unfinished records", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-neovim-trace-"));
+    try {
+      const session = {
+        cwd,
+        envOverrides: {} as NodeJS.ProcessEnv,
+        neovimInputTracePath: "",
+      };
+      enableNeovimInputTrace(session);
+      expect(await readNeovimInputTrace(session)).toEqual([]);
+      const trace = neovimInputTraceForTesting(session.envOverrides)!;
+      const state = {
+        sessionId: "owned", focusOwner: "buffer",
+        providerStatus: "ready", providerMode: "normal",
+      } as const;
+      trace.state(state);
+      trace.state(state);
+      const token = trace.begin("owned", "paste");
+      trace.progress(token, "rpc-complete");
+      trace.progress(token, "complete", "c");
+      const records = await readNeovimInputTrace(session);
+      expect(records).toHaveLength(4);
+      expect(records.at(-1)).toMatchObject({
+        sequence: 1, mode: "c", rpcCompleted: true,
+      });
+      const text = await readFile(session.neovimInputTracePath, "utf8");
+      expect(text).not.toContain('"text"');
+      expect(text).not.toContain('"keys"');
+      if (process.platform !== "win32") {
+        expect((await stat(session.neovimInputTracePath)).mode & 0o777).toBe(0o600);
+      }
+      await writeFile(session.neovimInputTracePath, `${text}{"type":`);
+      expect(await readNeovimInputTrace(session)).toEqual(records);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not throw into provider input when a test trace cannot be written", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agenc-neovim-trace-failure-"));
+    try {
+      const trace = neovimInputTraceForTesting({ AGENC_TEST_NEOVIM_INPUT_TRACE: cwd })!;
+      expect(() => trace.begin("owned", "escape")).not.toThrow();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-lifecycle.contract.test.ts
@@ -42,6 +42,38 @@ afterEach(async () => {
 });
 
 describe("embedded Neovim lifecycle", () => {
+  it("probes actual mode until buffered input is consumed without sending more input", async () => {
+    const responses = [{ mode: "n", blocking: false }, { mode: "c", blocking: true }, { mode: "c", blocking: false }];
+    const { session, rpc } = createInputModeProbeSession(async () => responses.shift());
+    const modes: string[] = [];
+    await expect(session.inspectInputModeForTesting("c", (mode) => modes.push(mode))).resolves.toBe("c");
+    expect(modes).toEqual(["n", "c", "c"]);
+    expect(rpc.request).toHaveBeenCalledTimes(3);
+    for (const args of rpc.request.mock.calls) expect(args.slice(0, 2)).toEqual(["nvim_get_mode", []]);
+    await session.cleanup();
+  });
+
+  it("bounds an ambiguous mode probe without poisoning or replaying input", async () => {
+    vi.useFakeTimers();
+    try {
+      const { session, rpc } = createInputModeProbeSession(async () => ({ mode: "n", blocking: false }));
+      const outcome = expect(session.inspectInputModeForTesting("c", () => {})).rejects.toThrow(/5000ms/u);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await outcome;
+      expect(rpc.close).not.toHaveBeenCalled();
+      for (const args of rpc.request.mock.calls) expect(args[0]).toBe("nvim_get_mode");
+      await session.cleanup();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([null, { mode: 1, blocking: false }, { mode: "c" }])("rejects malformed mode-probe results: %j", async (value) => {
+    const { session } = createInputModeProbeSession(async () => value);
+    await expect(session.inspectInputModeForTesting(null, () => {})).rejects.toThrow("invalid input mode");
+    await session.cleanup();
+  });
+
   it("covers process cleanup branches without spawning real Neovim", async () => {
     mockMissingProcessGroups();
     const killedChild = fakeChild({
@@ -2112,6 +2144,21 @@ async function waitForPidFile(path: string): Promise<number> {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(`timed out waiting for pid file ${path}`);
+}
+
+function createInputModeProbeSession(response: () => Promise<unknown>) {
+  const child = fakeChild({ exitCode: 0, pid: syntheticNeovimPid(779) });
+  const rpc = {
+    request: vi.fn(async (_method: string, _params: readonly unknown[]) => response()),
+    close: vi.fn(),
+  };
+  const session = new EmbeddedNeovimSession(
+    { child, pid: child.pid, kill: vi.fn() } as any,
+    rpc as any,
+    { dispose: vi.fn() } as any,
+    5,
+  );
+  return { session, rpc };
 }
 
 function mockMissingProcessGroups(): void {

--- a/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
+++ b/runtime/tests/tui/workbench/buffer-neovim-provider.contract.test.ts
@@ -14,6 +14,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createNeovimRenderSnapshot } from "../../../src/tui/workbench/buffer/neovim/NeovimGrid.js";
 import { canonicalNeovimPath } from "../../../src/tui/workbench/buffer/neovim/NeovimPath.js";
+import {
+  NeovimInputTrace,
+  type NeovimInputTraceRecord,
+} from "../../../src/tui/workbench/buffer/neovim/NeovimInputTrace.js";
 import { bufferIntegrationIntentCommand } from "../../../src/tui/workbench/commands.js";
 import { BufferProviderController } from "../../../src/tui/workbench/buffer/providers/BufferProviderController.js";
 import {
@@ -65,6 +69,60 @@ function normalizedTestPath(pathValue: string): string {
 }
 
 describe("embedded Neovim BUFFER provider", () => {
+  it("binds input RPC and mode acknowledgements to an exact queued sequence without rendering", async () => {
+    const { fixture, records, provider } = createTracedProviderFixture();
+    const input = controlled<boolean>();
+    const mode = controlled<string>();
+    vi.mocked(fixture.session.input).mockReturnValueOnce(input.promise);
+    vi.mocked(fixture.session.inspectInputModeForTesting).mockReturnValueOnce(mode.promise);
+    await provider.open({ filePath: "target.txt" });
+    provider.focus(true);
+    provider.handleInput({ input: ":", key: baseKey(), context: { rows: 20, columns: 80 } });
+    await flush();
+    expect(records.at(-1)).toMatchObject({ type: "input", sequence: 1, kind: "colon", phase: "running", rpcCompleted: false });
+    expect(fixture.session.inspectInputModeForTesting).not.toHaveBeenCalled();
+    input.resolve(true);
+    await flush();
+    expect(records.at(-1)).toMatchObject({ sequence: 1, phase: "rpc-complete", rpcCompleted: true });
+    mode.resolve("c");
+    await flush();
+    expect(records.at(-1)).toMatchObject({ sequence: 1, phase: "complete", mode: "c", rpcCompleted: true });
+    const owner = records.find((record) => record.type === "state" && record.sessionId !== null)?.sessionId;
+    expect(owner).toEqual(expect.any(String));
+    expect(records.filter((record) => record.type === "input").every((record) => record.sessionId === owner)).toBe(true);
+    expect(provider.getSnapshot().terminal?.mode).toBe("normal");
+    await provider.cleanup();
+  });
+
+  it("retires a late input-mode acknowledgement when a replacement session takes ownership", async () => {
+    const { fixture, records, provider } = createTracedProviderFixture();
+    const mode = controlled<string>();
+    vi.mocked(fixture.session.inspectInputModeForTesting).mockReturnValueOnce(mode.promise);
+    await provider.open({ filePath: "target.txt" });
+    provider.handleInput({ input: ":", key: baseKey(), context: { rows: 20, columns: 80 } });
+    await flush();
+    const firstOwner = records.at(-1)?.sessionId;
+    await provider.cleanup();
+    await provider.open({ filePath: "replacement.txt" });
+    const replacementOwner = records.findLast((record) => record.type === "state")?.sessionId;
+    expect(replacementOwner).not.toBe(firstOwner);
+    mode.resolve("c");
+    await flush();
+    expect(records.at(-1)).toMatchObject({ sessionId: firstOwner, sequence: 1, phase: "retired" });
+    await provider.cleanup();
+  });
+
+  it("does not probe input mode when test tracing is disabled", async () => {
+    const fixture = createHarness();
+    const provider = new NeovimBufferProvider(fixture.options);
+    await provider.open({ filePath: "target.txt" });
+    provider.handleInput({ input: ":", key: baseKey(), context: { rows: 20, columns: 80 } });
+    await flush();
+    expect(fixture.session.input).toHaveBeenCalledWith(":");
+    expect(fixture.session.inspectInputModeForTesting).not.toHaveBeenCalled();
+    await provider.cleanup();
+  });
+
   it("opens through the injected embedded session and publishes bounded terminal snapshots", async () => {
     const harness = createHarness();
     const provider = new NeovimBufferProvider(harness.options);
@@ -2580,6 +2638,16 @@ describe("embedded Neovim BUFFER provider", () => {
   });
 });
 
+function createTracedProviderFixture() {
+  const fixture = createHarness();
+  const records: NeovimInputTraceRecord[] = [];
+  const provider = new NeovimBufferProvider({
+    ...fixture.options,
+    inputTraceForTesting: new NeovimInputTrace((record) => records.push(record)),
+  });
+  return { fixture, records, provider };
+}
+
 function createHarness(
   overrides: {
     readonly launch?: (filePath: string, line: number) => boolean;
@@ -2646,6 +2714,10 @@ function createHarness(
   const session = {
     pid: 12345,
     recovery: overrides.recovery ?? null,
+    inspectInputModeForTesting: vi.fn(async (expectedMode: string, onMode: (mode: string) => void) => {
+      onMode(expectedMode);
+      return expectedMode;
+    }),
     input: vi.fn(async (keys: string) => {
       if (keys.includes(":edit!")) currentBuffer().dirty = false;
       else if (keys.length > 0) {

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -1366,7 +1366,7 @@ describe("BufferSurface", () => {
             "",
             nativeCommandLine === null ? "" : `:${nativeCommandLine}`,
           ],
-          mode: "insert",
+          mode: nativeCommandLine === null ? "insert" : "cmdline_normal",
           cursor: { grid: 1, row: 1, column: 2 },
         },
         vimMode: "INSERT",
@@ -1451,10 +1451,12 @@ describe("BufferSurface", () => {
       );
 
       nativeCommandLine = "set number relativenumber wrapscan";
+      expect(output()).not.toContain("CMDLINE_NORMAL");
       providerListener?.();
       await sleep();
 
       expect(output()).toContain(":setnumber");
+      expect(output()).toContain("CMDLINE_NORMAL");
       expect(provider.resize).toHaveBeenCalledWith({ rows: 4, columns: 80 });
     } finally {
       root.unmount();


### PR DESCRIPTION
## Changes

Closes #1918.

The two platform PTY scenarios now send command input through session-bound acknowledgements rather than an 80 ms sleep and a rendered footer.

- Add an opt-in private test trace with the editor session identity, BUFFER focus, monotonic input sequence, RPC completion, pending RPC phase, and native mode. Input text is never recorded. Ordinary runs do not write traces or issue mode probes.
- Keep Escape, colon, bracketed paste, and Enter on the real PTY input path. Wait for the exact Escape sequence and normal mode, then the exact colon sequence and command-line mode. Wait for paste completion before Enter. Native mode probes are read-only and bounded; a fast mode response that precedes buffered input processing is polled without resending input.
- Use one five-second command-entry deadline. Fail closed on ambiguous, unexpected, skipped, or retired-session input. There is no retry of colon or the command body, and no fallback to painted footer state.
- Include owner, focus, last input sequence, RPC phase, native/provider modes, and the latest frame in acknowledgement failures. Keep delayed footer painting as separate rendered BufferSurface coverage.
- Remove the platform save scenario's redundant lone Escape. The first real run exposed that buffered Escape as an unexpected extra sequence before the helper's own unambiguous Escape.
- Update the native provider lane's exact count from 65 to 68 for the three added provider cases. Its live Actions workflow remains disabled. The existing Windows PTY exclusion stays unchanged.

## Local validation

- All 249 targeted tests pass across 16 files, including the rendered BufferSurface case. All 120 final focused tests pass across four files. After review fixes, 124 tests pass across those files plus the environment documentation contract.
- All 68 native provider/platform tests pass across three files. All 18 pinned Neovim lifecycle tests pass. Native execution is Linux x64 with Neovim 0.12.1 only; no Darwin or Windows hosted run is claimed.
- Both real platform PTY scenarios pass, then pass three more complete runs. The initial failure correctly identified the redundant Escape; the scenario is corrected rather than retried unchanged.
- Seven selected provider/lifecycle tests fail against the original source. Removing acknowledgement waits makes all five selected sequencing/ambiguous-input tests fail. Temporary mutations are removed and restored source contents are checked exactly.
- Runtime and test-support typechecks, build, generated SDK checks, and all six PTY startup cases pass. Final-head build, both real platform PTY scenarios, and the 68-test native provider/platform set also pass on `4055deea88ebfdc097e1cd6afe3fdb3c89326f3b`.
- Full root tests pass on the final head: 23,380 runtime tests across 2,267 files, with zero failures or skips.
- The optional embedded-Neovim contract script cannot run because its external implementation-contract skill checker is not installed at any configured path. This is a local tooling limitation, not a passing gate.

The first full root run passed 23,379 tests and failed one environment-documentation assertion. The trace variable is now documented in the environment reference, and that contract passes. Sonar's four initial findings are addressed by splitting the polling and trace-completion helpers, using `TypeError` for malformed mode data, and making the delayed-paint promise assertion explicit. Final-head Bugbot, Approval, Security, and Sonar checks all pass. Sonar reports zero open issues and a passing quality gate. The PR is approved; the recorded approval review is on the first head, with fresh review checks on the final head.

GitNexus reports medium lifecycle-class impact with five direct consumers and no indexed flows. Provider-class impact is low with two direct consumers; the command helper has two scenario callers. Existing edited methods were checked before edits. Newly added test symbols are not yet indexed, so their callers were also inspected directly.

Paid Actions CI stays off. No workflows are enabled, dispatched, rerun, or retried. Independent PR review remains enabled, and merge waits for local validation and review.
