### PR TITLE
test(fnd): isolate red-probe forgery and report authenticated phases

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1166,6 +1166,7 @@ jobs:
             --reporter=dot
 
       - name: Run the exact macOS red-probe runner contract
+        id: macos-red-probe-runner
         shell: bash
         run: |
           set -euo pipefail
@@ -1175,9 +1176,10 @@ jobs:
             run \
             tests/fnd/red-probe-runner.contract.test.ts \
             --allowOnly=false \
+            --maxWorkers=1 \
             --reporter=verbose \
             --reporter=json \
-            --outputFile.json "$results"
+            --outputFile.json "$results" 2>&1 | tee "$RUNNER_TEMP/macos-red-probe-runner.log"
           node --input-type=module - "$results" <<'NODE'
           import { readFileSync } from "node:fs";
           import { relative, resolve } from "node:path";
@@ -1186,8 +1188,8 @@ jobs:
           if (!resultsPath) throw new Error("missing macOS red-probe results path");
           const results = JSON.parse(readFileSync(resultsPath, "utf8"));
           const exactCounts = {
-            numTotalTests: 66,
-            numPassedTests: 66,
+            numTotalTests: 79,
+            numPassedTests: 79,
             numFailedTests: 0,
             numPendingTests: 0,
             numTodoTests: 0,
@@ -1215,14 +1217,25 @@ jobs:
           if (
             testResult.status !== "passed" ||
             !Array.isArray(testResult.assertionResults) ||
-            testResult.assertionResults.length !== 66 ||
+            testResult.assertionResults.length !== 79 ||
             testResult.assertionResults.some(({ status }) => status !== "passed")
           ) {
-            throw new Error("macOS red-probe assertions were not exactly 66 passes");
+            throw new Error("macOS red-probe assertions were not exactly 79 passes");
           }
-          console.log("macOS red-probe runner passed 66 tests in 1 file with zero skipped");
+          console.log("macOS red-probe runner passed 79 tests in 1 file with zero skipped");
           NODE
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Preserve failed macOS red-probe diagnostics
+        if: failure() && steps.macos-red-probe-runner.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: macos-red-probe-diagnostics
+          path: |
+            ${{ runner.temp }}/macos-red-probe-runner.json
+            ${{ runner.temp }}/macos-red-probe-runner.log
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Run the exact macOS FND/native capability lane
         shell: bash

--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -385,6 +385,23 @@ source. Contract tests remove each member in turn and require the policy-closure
 check to fail, so containment or handoff code cannot silently fall outside the
 approved digest.
 
+Red-probe failures include the last authenticated startup phase and separate
+spawn, heartbeat, terminal-record, and physical-settlement observations. The
+bootstrap signs an ordered stderr transcript for handoff acceptance, bootstrap
+initialization, dependency import, readiness, and the terminal record. The
+parent verifies each record's identity, sequence, and domain-separated HMAC
+before advancing the reported phase. Partial, forged, replayed, or unrelated
+records cannot advance that phase. Heartbeat observations remain separate from
+authenticated phase evidence.
+
+The assertion reporter stays in the bootstrap closure. One real child checks
+both direct and Function-constructor global lookups, records both observations
+for the parent, and must exit without expected-red evidence. Controlled-clock
+tests simulate stalls at the supervisor boundary. A separate real pre-ready
+stall verifies that the supervisor kills a resistant descendant and settles
+the process tree. Probe deadlines, heartbeat silence bounds, termination grace,
+and settlement backstops are unchanged.
+
 ## Inactive optional worker and publisher trust boundaries
 
 The trusted repository mirror is installed root-owned beneath
@@ -1050,7 +1067,10 @@ PTY set remains
 Windows still runs the 18-test lifecycle suite, the 68-test
 provider/observed-descendant set (including Job Object tree cleanup), and
 post-job leak assertions.
-The `macos-native` job first runs the 66-test red-probe runner contract.
+The `macos-native` job first runs the 79-test red-probe runner contract in a
+separate invocation capped at one worker. A failed invocation preserves its
+console log and JSON report, including phase diagnostics, for one day. This
+workflow remains disabled until an operator explicitly enables it.
 Never add deadline-only descendant-marker coverage back to that contract. Its
 hard deadline begins before probe readiness, so it races cold bootstrap on
 hosted runners. The native process test covers descendant timeout containment

--- a/runtime/scripts/run-fnd-red-probes.mjs
+++ b/runtime/scripts/run-fnd-red-probes.mjs
@@ -1443,8 +1443,8 @@ function createProbeHandoff(sourceBytes, authenticationSecret) {
 }
 
 function expectedPhaseLine(entry, sequence, authenticationSecret) {
+  if (sequence < 1 || sequence > RED_PROBE_PHASES.length) return undefined;
   const phase = RED_PROBE_PHASES[sequence - 1];
-  if (phase === undefined) return undefined;
   const evidence = {
     protocolVersion: RED_PROBE_PROTOCOL_VERSION,
     id: entry.id,

--- a/runtime/scripts/run-fnd-red-probes.mjs
+++ b/runtime/scripts/run-fnd-red-probes.mjs
@@ -52,6 +52,15 @@ export const RED_PROBE_PROTOCOL_VERSION = 1;
 export const RED_PROBE_EXPECTED_EXIT_CODE = 86;
 export const RED_PROBE_PROTOCOL_PREFIX = "AGENC_RED_PROBE_V1 ";
 export const RED_PROBE_HEARTBEAT_PREFIX = "AGENC_RED_PROBE_HEARTBEAT_V1 ";
+export const RED_PROBE_PHASE_PREFIX = "AGENC_RED_PROBE_PHASE_V1 ";
+export const RED_PROBE_PHASES = Object.freeze([
+  "handoff-accepted",
+  "bootstrap-initialized",
+  "dependency-import-begun",
+  "ready",
+  "terminal-record",
+]);
+const PHASE_AUTHENTICATION_DOMAIN = "AGENC_RED_PROBE_PHASE_V1\0";
 
 const MANIFEST_SCHEMA_VERSION = 1;
 const AUDIT_SHA = "d2b228e87ea63bd6a5d93e6f599f36bce88d672b";
@@ -197,7 +206,7 @@ const RED_PROBE_HELPER_FUNCTION = "expectDeepStrictEqualRedProbe";
 const RED_PROBE_HELPER_TYPE = "RedProbeAssertion";
 const RED_PROBE_RUNNER_FUNCTION = "runRedProbe";
 const RED_PROBE_BOOTSTRAP_SHA256 =
-  "11666129eb16783a5514477f4706073bb4ed5d245bd379c87645feee2a62492d";
+  "52e0a1b24b995a892cfdb23c592ae65054ecb273c66dfb9d91418da461d817ee";
 const RED_PROBE_HELPER_SHA256 =
   "289471c65f3852d56e5c40ed95883697f8145b2e471b3eb0aab06660d1c1232a";
 const RED_PROBE_MARKDOWN_LOADER_SHA256 =
@@ -1433,6 +1442,91 @@ function createProbeHandoff(sourceBytes, authenticationSecret) {
   return handoff;
 }
 
+function expectedPhaseLine(entry, sequence, authenticationSecret) {
+  const phase = RED_PROBE_PHASES[sequence - 1];
+  if (phase === undefined) return undefined;
+  const evidence = {
+    protocolVersion: RED_PROBE_PROTOCOL_VERSION,
+    id: entry.id,
+    task: entry.task,
+    fingerprint: entry.fingerprint,
+    sequence,
+    phase,
+  };
+  const authenticationTag = createHmac("sha256", authenticationSecret)
+    .update(PHASE_AUTHENTICATION_DOMAIN, "utf8")
+    .update(JSON.stringify(evidence), "utf8")
+    .digest("hex");
+  return `${RED_PROBE_PHASE_PREFIX}${JSON.stringify({ ...evidence, authenticationTag })}\n`;
+}
+
+export function createRedProbePhaseMonitor(entry, authenticationSecret) {
+  const phases = [];
+  let bufferedOutput = Buffer.alloc(0);
+  let protocolInvalid = false;
+  let recordsObserved = 0;
+  let receivedBytes = 0;
+  return Object.freeze({
+    observe(chunk) {
+      if (protocolInvalid) return;
+      receivedBytes += chunk.byteLength;
+      if (receivedBytes > MAXIMUM_CHILD_OUTPUT_BYTES) {
+        protocolInvalid = true;
+        bufferedOutput = Buffer.alloc(0);
+        return;
+      }
+      bufferedOutput = Buffer.concat([bufferedOutput, chunk]);
+      let newline = bufferedOutput.indexOf(0x0a);
+      while (newline >= 0) {
+        const line = bufferedOutput.subarray(0, newline + 1);
+        bufferedOutput = bufferedOutput.subarray(newline + 1);
+        recordsObserved += 1;
+        const expected = expectedPhaseLine(entry, recordsObserved, authenticationSecret);
+        if (
+          expected === undefined ||
+          line.byteLength !== Buffer.byteLength(expected) ||
+          !timingSafeEqual(line, Buffer.from(expected))
+        ) {
+          protocolInvalid = true;
+          return;
+        }
+        phases.push(RED_PROBE_PHASES[recordsObserved - 1]);
+        newline = bufferedOutput.indexOf(0x0a);
+      }
+    },
+    snapshot() {
+      return Object.freeze({
+        lastAuthenticatedPhase: phases.at(-1) ?? "none",
+        phases: Object.freeze([...phases]),
+        protocolInvalid,
+        recordsObserved,
+        partialRecordBytes: bufferedOutput.byteLength,
+      });
+    },
+  });
+}
+
+function redProbePhaseFailure(error, execution) {
+  const { result, heartbeat, phases } = execution;
+  const diagnostics = Object.freeze({
+    lastAuthenticatedPhase: phases.lastAuthenticatedPhase,
+    authenticatedPhases: phases.phases,
+    phaseProtocolInvalid: phases.protocolInvalid,
+    processStarted: result.processStarted ?? null,
+    readyHeartbeatObserved: heartbeat.observedHeartbeats >= MINIMUM_READY_HEARTBEATS,
+    terminalRecordObserved: heartbeat.finalRecordObserved,
+    processTreeSettled: result.processTreeCleanupProven === true,
+    settlementBackstopExpired: result.backstopExpired,
+  });
+  const message = error instanceof Error ? error.message : String(error);
+  return Object.assign(
+    new Error(`${message}; phase diagnostics: ${JSON.stringify(diagnostics)}`, {
+      cause: error,
+    }),
+    { redProbeDiagnostics: diagnostics },
+  );
+}
+
 function spawnProbe(
   handoffBytes,
   path,
@@ -1443,7 +1537,9 @@ function spawnProbe(
   authenticationSecret,
   heartbeatSilenceMs,
   markdownPolicy,
+  superviseProbe = runSupervisedProcess,
 ) {
+  const phaseMonitor = createRedProbePhaseMonitor(entry, authenticationSecret);
   const heartbeat = createHeartbeatMonitor(
     entry,
     authenticationSecret,
@@ -1454,7 +1550,7 @@ function spawnProbe(
   assertPortableWindowsLaunch(process.execPath, args, env);
   let supervised;
   try {
-    supervised = runSupervisedProcess(
+    supervised = superviseProbe(
       {
         program: process.execPath,
         args,
@@ -1469,6 +1565,7 @@ function spawnProbe(
         terminateGraceMs: TERMINATE_GRACE_MS,
         settleBackstopMs: SETTLE_BACKSTOP_MS,
         onStdout: heartbeat.observe,
+        onStderr: phaseMonitor.observe,
       },
     );
   } catch (error) {
@@ -1491,7 +1588,11 @@ function spawnProbe(
     (result) => {
       const heartbeatEvidence = heartbeat.snapshot();
       heartbeat.close();
-      return Object.freeze({ heartbeat: heartbeatEvidence, result });
+      return Object.freeze({
+        heartbeat: heartbeatEvidence,
+        result,
+        phases: phaseMonitor.snapshot(),
+      });
     },
     (error) => {
       heartbeat.close();
@@ -1515,6 +1616,7 @@ function assertExpectedRedResult(
   heartbeat,
   authenticationSecret,
   markdownPolicy,
+  phases,
 ) {
   if (heartbeat.expired && result.stopReason === "aborted") {
     throw new Error(
@@ -1553,7 +1655,9 @@ function assertExpectedRedResult(
       authenticationSecret,
       markdownPolicy,
     ) ||
-    result.stderr.byteLength !== 0
+    phases.protocolInvalid ||
+    phases.partialRecordBytes !== 0 ||
+    phases.lastAuthenticatedPhase !== "terminal-record"
   ) {
     throw new Error(
       `${entry.id} emitted unrelated or noncanonical output: ${formatChildEvidence(result)}`,
@@ -1655,15 +1759,21 @@ export async function auditRedProbes(options = {}) {
         authenticationSecret,
         heartbeatSilenceMs,
         markdownPolicy,
+        options.testing?.superviseProbe,
       );
       assertNoNetworkAttempts(attemptLedger);
-      assertExpectedRedResult(
-        entry,
-        execution.result,
-        execution.heartbeat,
-        authenticationSecret,
-        markdownPolicy,
-      );
+      try {
+        assertExpectedRedResult(
+          entry,
+          execution.result,
+          execution.heartbeat,
+          authenticationSecret,
+          markdownPolicy,
+          execution.phases,
+        );
+      } catch (error) {
+        throw redProbePhaseFailure(error, execution);
+      }
     }
     return Object.freeze({
       files: manifest.probeCount,

--- a/runtime/tests/fnd/red-probe-runner.contract.test.ts
+++ b/runtime/tests/fnd/red-probe-runner.contract.test.ts
@@ -1441,6 +1441,12 @@ describe("FND red-probe supervisor", () => {
       recordsObserved: 5,
       partialRecordBytes: 0,
     });
+    monitor.observe(Buffer.from(protocolPhaseLine(1)));
+    expect(monitor.snapshot()).toMatchObject({
+      lastAuthenticatedPhase: "terminal-record",
+      protocolInvalid: true,
+      recordsObserved: 6,
+    });
   });
 
   it.each([

--- a/runtime/tests/fnd/red-probe-runner.contract.test.ts
+++ b/runtime/tests/fnd/red-probe-runner.contract.test.ts
@@ -18,7 +18,12 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, matchesGlob, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  SupervisedProcessCommand,
+  SupervisedProcessOptions,
+  SupervisedProcessResult,
+} from "../../src/utils/supervisedProcess.js";
 
 import {
   createRedProbeAssertion,
@@ -31,11 +36,14 @@ import {
   assertPortableWindowsLaunch,
   auditRedProbes,
   createRedProbeProtocolState,
+  createRedProbePhaseMonitor,
   loadRedProbeManifest,
   measurePortableWindowsLaunch,
   observeRedProbeProtocolLine,
   RED_PROBE_EXPECTED_EXIT_CODE as RUNNER_EXPECTED_EXIT_CODE,
   RED_PROBE_HEARTBEAT_PREFIX as RUNNER_HEARTBEAT_PREFIX,
+  RED_PROBE_PHASE_PREFIX,
+  RED_PROBE_PHASES,
   RED_PROBE_PROTOCOL_PREFIX as RUNNER_PROTOCOL_PREFIX,
   RED_PROBE_PROTOCOL_VERSION as RUNNER_PROTOCOL_VERSION,
   RED_PROBE_TASK_IDS as RUNNER_TASK_IDS,
@@ -223,6 +231,26 @@ function protocolHeartbeatLine(sequence: number): string {
     fingerprint: testFingerprint,
     sequence,
   })}\n`;
+}
+
+function protocolPhaseLine(
+  sequence: number,
+  authenticationSecret: Buffer = protocolAuthenticationSecret,
+  domain = "AGENC_RED_PROBE_PHASE_V1\0",
+): string {
+  const evidence = {
+    protocolVersion: RUNNER_PROTOCOL_VERSION,
+    id: testId,
+    task: testTask,
+    fingerprint: testFingerprint,
+    sequence,
+    phase: RED_PROBE_PHASES[sequence - 1],
+  };
+  const authenticationTag = createHmac("sha256", authenticationSecret)
+    .update(domain, "utf8")
+    .update(JSON.stringify(evidence), "utf8")
+    .digest("hex");
+  return `${RED_PROBE_PHASE_PREFIX}${JSON.stringify({ ...evidence, authenticationTag })}\n`;
 }
 
 function protocolFinalLine(
@@ -477,11 +505,19 @@ describe("FND red-probe supervisor", () => {
       ].join("\n"),
     );
 
-    await expect(
-      auditRedProbes({ runtimeRoot: fixtureRoot }),
-    ).rejects.toThrow(
-      `timed out after ${preReadyHardDeadlineMilliseconds}ms`,
-    );
+    const outcome = await auditRedProbes({ runtimeRoot: fixtureRoot })
+      .then(() => null, (error: unknown) => error);
+    expect(outcome).toMatchObject({
+      message: expect.stringContaining(`timed out after ${preReadyHardDeadlineMilliseconds}ms`),
+      redProbeDiagnostics: {
+        lastAuthenticatedPhase: "dependency-import-begun",
+        processStarted: true,
+        readyHeartbeatObserved: false,
+        terminalRecordObserved: false,
+        processTreeSettled: true,
+        settlementBackstopExpired: false,
+      },
+    });
     const descendantPid = Number.parseInt(readFileSync(marker, "utf8"), 10);
     expect(Number.isSafeInteger(descendantPid)).toBe(true);
     expect(() => process.kill(descendantPid, 0)).toThrow();
@@ -1346,44 +1382,162 @@ describe("FND red-probe supervisor", () => {
     expect(readFileSync(marker, "utf8")).toBe("absent");
   });
 
+  it("checks both imported-dependency reporter lookups in one supervised child", async () => {
+    const fixtureRoot = createFixture({
+      source: probeSource({
+        actual: "1",
+        expected: "1",
+        imports: ['import "../../helpers/reporter-forger.js";'],
+      }),
+    });
+    const marker = join(fixtureRoot, "reporter-lookups.json");
+    writeFixtureHelperModule(
+      fixtureRoot,
+      "reporter-forger.ts",
+      [
+        'import { writeFileSync } from "node:fs";',
+        `const key = Symbol.for(${JSON.stringify(reporterHandoffSymbolKey)});`,
+        'const roots = [globalThis, Function("return globalThis")()];',
+        "const reporters = roots.map((root) => root[key]);",
+        `writeFileSync(${JSON.stringify(marker)}, JSON.stringify({ direct: typeof reporters[0] === "function", indirect: typeof reporters[1] === "function" }), "utf8");`,
+        'const reporter = reporters.find((candidate) => typeof candidate === "function");',
+        `if (typeof reporter === "function") reporter(${JSON.stringify({
+          fingerprint: testFingerprint,
+          id: testId,
+          task: testTask,
+        })});`,
+        "",
+      ].join("\n"),
+    );
+    const outcome = await auditRedProbes({ runtimeRoot: fixtureRoot })
+      .then(() => null, (error: unknown) => error);
+    expect(JSON.parse(readFileSync(marker, "utf8"))).toEqual({ direct: false, indirect: false });
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toContain("did not exit expected-red: exit=0 signal=null");
+    expect(outcome).toMatchObject({
+      redProbeDiagnostics: {
+        lastAuthenticatedPhase: "ready",
+        processStarted: true,
+        readyHeartbeatObserved: true,
+        terminalRecordObserved: false,
+        processTreeSettled: true,
+      },
+    });
+  });
+
+  it("authenticates all startup phases in order across split pipe records", () => {
+    const monitor = createRedProbePhaseMonitor(protocolEntry, protocolAuthenticationSecret);
+    for (let sequence = 1; sequence <= RED_PROBE_PHASES.length; sequence += 1) {
+      const bytes = Buffer.from(protocolPhaseLine(sequence));
+      monitor.observe(bytes.subarray(0, 7));
+      expect(monitor.snapshot().recordsObserved).toBe(sequence - 1);
+      expect(monitor.snapshot().lastAuthenticatedPhase).toBe(RED_PROBE_PHASES[sequence - 2] ?? "none");
+      monitor.observe(bytes.subarray(7));
+    }
+    expect(monitor.snapshot()).toEqual({
+      lastAuthenticatedPhase: "terminal-record",
+      phases: RED_PROBE_PHASES,
+      protocolInvalid: false,
+      recordsObserved: 5,
+      partialRecordBytes: 0,
+    });
+  });
+
   it.each([
-    {
-      name: "direct global lookup",
-      expression: "globalThis",
-    },
-    {
-      name: "Function-constructor lookup",
-      expression: 'Function("return globalThis")()',
-    },
-  ])(
-    "does not let an imported dependency forge through $name",
-    async ({ expression }) => {
-      const fixtureRoot = createFixture({
-        source: probeSource({
-          actual: "1",
-          expected: "1",
-          imports: ['import "../../helpers/reporter-forger.js";'],
-        }),
+    { name: "wrong secret", records: () => protocolPhaseLine(1, Buffer.alloc(32, 9)) },
+    { name: "wrong authentication domain", records: () => protocolPhaseLine(1, protocolAuthenticationSecret, finalAuthenticationDomain) },
+    { name: "wrong probe identity", records: () => protocolPhaseLine(1).replace(testId, "different-fixture") },
+    { name: "out-of-order phase", records: () => protocolPhaseLine(2) },
+    { name: "replayed phase", records: () => protocolPhaseLine(1) + protocolPhaseLine(1) },
+    { name: "forged phase name", records: () => protocolPhaseLine(1).replace("handoff-accepted", "ready") },
+    { name: "unrelated stderr", records: () => "unrelated\n" },
+    { name: "oversized partial record", records: () => "x".repeat(16_385) },
+  ])("rejects $name without promoting an unauthenticated phase", ({ name, records }) => {
+    const monitor = createRedProbePhaseMonitor(protocolEntry, protocolAuthenticationSecret);
+    monitor.observe(Buffer.from(records()));
+    expect(monitor.snapshot()).toMatchObject({
+      protocolInvalid: true,
+      lastAuthenticatedPhase: name === "replayed phase" ? "handoff-accepted" : "none",
+    });
+  });
+
+  it.each([0, 1, 2, 3, 4])("classifies deterministic starvation after %i authenticated phases and awaits settlement", async (phaseCount) => {
+    vi.useFakeTimers();
+    try {
+      const fixtureRoot = createFixture();
+      let signalSpawned: () => void = () => {};
+      const spawned = new Promise<void>((resolve) => {
+        signalSpawned = resolve;
       });
-      writeFixtureHelperModule(
-        fixtureRoot,
-        "reporter-forger.ts",
-        [
-          `const root = ${expression};`,
-          `const reporter = root[Symbol.for(${JSON.stringify(reporterHandoffSymbolKey)})];`,
-          `if (typeof reporter === "function") reporter(${JSON.stringify({
-            fingerprint: testFingerprint,
-            id: testId,
-            task: testTask,
-          })});`,
-          "",
-        ].join("\n"),
-      );
-      await expect(
-        auditRedProbes({ runtimeRoot: fixtureRoot }),
-      ).rejects.toThrow("did not exit expected-red");
-    },
-  );
+      const settled = vi.fn();
+      const superviseProbe = vi.fn((_command: SupervisedProcessCommand, options: SupervisedProcessOptions) => new Promise<SupervisedProcessResult>((resolve) => {
+        if (!Buffer.isBuffer(options.stdin)) throw new TypeError("missing fixture handoff bytes");
+        const secretOffset = Buffer.byteLength("AGENC_RED_PROBE_HANDOFF_V1\0");
+        const secret = options.stdin.subarray(secretOffset, secretOffset + 32);
+        const stderr = Buffer.from(
+          Array.from({ length: phaseCount }, (_, index) =>
+            protocolPhaseLine(index + 1, secret),
+          ).join(""),
+        );
+        const stdout = phaseCount === 4
+          ? Buffer.from(protocolHeartbeatLine(1) + protocolHeartbeatLine(2))
+          : Buffer.alloc(0);
+        const control = { stop: vi.fn() };
+        options.onStderr?.(stderr, control);
+        options.onStdout?.(stdout, control);
+        const finish = (stopReason: "timeout" | "aborted") => {
+          clearTimeout(timer);
+          options.signal?.removeEventListener("abort", abort);
+          settled();
+          resolve({
+            stdout,
+            stderr,
+            exitCode: null,
+            signal: "SIGTERM",
+            stopReason,
+            forced: true,
+            backstopExpired: false,
+            processStarted: true,
+            processTreeCleanupProven: true,
+          });
+        };
+        const abort = () => finish("aborted");
+        const timer = setTimeout(() => finish("timeout"), options.timeoutMs);
+        options.signal?.addEventListener("abort", abort, { once: true });
+        signalSpawned();
+      }));
+      const outcome = auditRedProbes({ runtimeRoot: fixtureRoot, testing: { superviseProbe } })
+        .then(() => null, (error: unknown) => error);
+      await Promise.race([
+        spawned,
+        outcome.then((error) => {
+          throw error ?? new Error("probe settled before supervision");
+        }),
+      ]);
+      expect(settled).not.toHaveBeenCalled();
+      const elapsed = phaseCount === 4 ? 5_000 : defaultFixtureTimeoutMs;
+      await vi.advanceTimersByTimeAsync(elapsed);
+      expect(await outcome).toMatchObject({
+        message: expect.stringContaining(phaseCount === 4
+          ? "missed a trusted heartbeat for 5000ms"
+          : `timed out after ${defaultFixtureTimeoutMs}ms`),
+        redProbeDiagnostics: {
+          lastAuthenticatedPhase: RED_PROBE_PHASES[phaseCount - 1] ?? "none",
+          processStarted: true,
+          readyHeartbeatObserved: phaseCount === 4,
+          processTreeSettled: true,
+          settlementBackstopExpired: false,
+        },
+      });
+      expect(settled).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(defaultFixtureTimeoutMs);
+      expect(settled).toHaveBeenCalledOnce();
+      expect(superviseProbe).toHaveBeenCalledOnce();
+      expect(superviseProbe.mock.calls[0]?.[1].timeoutMs).toBe(defaultFixtureTimeoutMs);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("pins the deep-equality predicate before dependencies can replace builtin exports", async () => {
     const fixtureRoot = createFixture({

--- a/runtime/tests/helpers/red-probe-bootstrap.mjs
+++ b/runtime/tests/helpers/red-probe-bootstrap.mjs
@@ -1,5 +1,5 @@
 import { createHash, createHmac } from "node:crypto";
-import { readSync } from "node:fs";
+import { readSync, writeSync } from "node:fs";
 import { registerHooks } from "node:module";
 import { brotliDecompressSync } from "node:zlib";
 
@@ -14,6 +14,8 @@ const HEARTBEAT_INTERVAL_MS = 1_000;
 const AUTHENTICATION_SECRET_BYTES = 32;
 const HANDOFF_MAGIC = Buffer.from("AGENC_RED_PROBE_HANDOFF_V1\0", "ascii");
 const FINAL_AUTHENTICATION_DOMAIN = "AGENC_RED_PROBE_FINAL_V1\0";
+const PHASE_AUTHENTICATION_DOMAIN = "AGENC_RED_PROBE_PHASE_V1\0";
+const PHASE_PROTOCOL_PREFIX = "AGENC_RED_PROBE_PHASE_V1 ";
 const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
 const MAXIMUM_HELPER_BYTES = 65_536;
 const MAXIMUM_COMPRESSED_HELPER_BYTES = MAXIMUM_HELPER_BYTES + 1_024;
@@ -58,6 +60,7 @@ const exitProcess = process.exit.bind(process);
 const scheduleInterval = setInterval;
 const stringifyJson = JSON.stringify;
 const writeStandardOutput = process.stdout.write.bind(process.stdout);
+const writePhaseBytes = writeSync;
 
 function hasExactKeys(value, expectedKeys) {
   if (value === null || typeof value !== "object" || isArray(value)) {
@@ -338,6 +341,23 @@ const configuration = loadConfiguration();
 // only in this closure.
 const { authenticationSecret, probeSource } =
   consumeBootstrapHandoff(configuration);
+let phaseSequence = 0;
+function writePhase(phase) {
+  const evidence = createObject(null);
+  evidence.protocolVersion = PROTOCOL_VERSION;
+  evidence.id = configuration.id;
+  evidence.task = configuration.task;
+  evidence.fingerprint = configuration.fingerprint;
+  evidence.sequence = ++phaseSequence;
+  evidence.phase = phase;
+  const authenticationTag = createHmacSha256("sha256", authenticationSecret)
+    .update(PHASE_AUTHENTICATION_DOMAIN, "utf8")
+    .update(stringifyJson(evidence), "utf8")
+    .digest("hex");
+  evidence.authenticationTag = authenticationTag;
+  writePhaseBytes(2, `${PHASE_PROTOCOL_PREFIX}${stringifyJson(evidence)}\n`);
+}
+writePhase("handoff-accepted");
 await import(configuration.networkTripwireUrl);
 await import(configuration.tsxLoaderUrl);
 let expectedFailureReported = false;
@@ -526,6 +546,7 @@ if (typeof helperModule[HELPER_FACTORY] !== "function") {
   throw new Error("red-probe helper does not export its canonical factory");
 }
 const probeAssertion = helperModule[HELPER_FACTORY](reportExpectedFailure);
+writePhase("bootstrap-initialized");
 
 let heartbeatSequence = 0;
 function writeHeartbeat() {
@@ -548,6 +569,7 @@ function writeHeartbeat() {
 // can synchronously occupy the event loop, while the independent hard deadline
 // still bounds this phase from process spawn.
 writeHeartbeat();
+writePhase("dependency-import-begun");
 const probeModule = await import(configuration.probeSourceUrl);
 if (
   keys(probeModule).length !== 1 ||
@@ -560,6 +582,7 @@ if (
 // Sequence 2 authenticates the ready boundary. The supervisor arms its shorter
 // silence deadline on this record and on every later periodic heartbeat.
 writeHeartbeat();
+writePhase("ready");
 const heartbeatTimer = scheduleInterval(
   writeHeartbeat,
   configuration.heartbeatIntervalMs,
@@ -597,6 +620,7 @@ function emitAuthenticatedExpectedRedResult() {
   writeStandardOutput(
     `${PROTOCOL_PREFIX}${stringifyJson(authenticatedEvidence)}\n`,
   );
+  writePhase("terminal-record");
   process.exitCode = EXPECTED_EXIT_CODE;
 }
 

--- a/runtime/tests/packaging/reproducible-build.test.ts
+++ b/runtime/tests/packaging/reproducible-build.test.ts
@@ -439,11 +439,19 @@ describe("reproducible install and release contract", () => {
     expect(macosJob).toContain("runs-on: macos-15");
     expect(macosJob).toContain("Run the exact macOS red-probe runner contract");
     expect(macosJob).toContain("tests/fnd/red-probe-runner.contract.test.ts");
-    expect(macosJob).toContain("numTotalTests: 66");
-    expect(macosJob).toContain("numPassedTests: 66");
-    expect(macosJob).toContain("testResult.assertionResults.length !== 66");
+    expect(macosJob).toContain("numTotalTests: 79");
+    expect(macosJob).toContain("numPassedTests: 79");
+    expect(macosJob).toContain("testResult.assertionResults.length !== 79");
+    expect(macosJob).toMatch(
+      /red-probe-runner\.contract\.test\.ts\s*\\\s*--allowOnly=false\s*\\\s*--maxWorkers=1/u,
+    );
+    expect(macosJob).toContain('2>&1 | tee "$RUNNER_TEMP/macos-red-probe-runner.log"');
+    expect(macosJob).toContain("failure() && steps.macos-red-probe-runner.outcome == 'failure'");
+    expect(macosJob).toContain("${{ runner.temp }}/macos-red-probe-runner.json");
+    expect(macosJob).toContain("${{ runner.temp }}/macos-red-probe-runner.log");
+    expect(macosJob).toContain("retention-days: 1");
     expect(macosJob).toContain(
-      "macOS red-probe runner passed 66 tests in 1 file with zero skipped",
+      "macOS red-probe runner passed 79 tests in 1 file with zero skipped",
     );
     expect(macosJob).toContain(
       "Run the exact macOS FND/native capability lane",


### PR DESCRIPTION
## Changes

Closes #1923.

- Check direct and Function-constructor reporter lookups in one real child. The parent verifies both observations and the ordinary non-red exit.
- Report ordered, HMAC-authenticated bootstrap phases separately from spawn, heartbeat, terminal-record, and physical-settlement observations. Reject forged, replayed, partial, or unrelated phase records.
- Simulate five stalled startup states with a controlled clock and retain real cold-start and resistant-descendant cleanup coverage. Production deadlines, heartbeat rules, authentication, and containment bounds remain unchanged.
- Cap the existing separate macOS runner invocation at one worker, enforce all 79 cases, and retain failed logs and JSON diagnostics for one day. Hosted CI stays disabled; no hosted runs were dispatched or retried.

The current reporter is closure-scoped. There is no global reporter handoff to delete in the current bootstrap.

## Verification

- Runtime and test-support typechecks pass.
- 97 targeted tests pass in three files, with zero skipped, including all 79 runner contracts.
- The combined real-child case passes five repetitions on one Linux CPU with two competing CPU burners. Neither Darwin nor Windows execution is claimed.
- A temporary reporter-leak mutation fails because both observations find the reporter. Bypassing phase authentication fails both wrong-secret and wrong-domain cases. Both mutations were removed and exact source restoration verified.
- GitNexus reports low change risk across the six expected files, with no indexed affected execution flows. New helpers are unindexed and were inspected directly.
- The full local suite passes 23,393 tests in 2,267 runtime files on final head `94405c6e0b58fa9fbee51cd74814a93371f976c4`, with zero failures or skips. Root checks, launcher tests, and the real red-probe audit also pass.
- Cursor independently approved the initial head. Final-head Approval, Bugbot, Security Review, and Sonar checks all pass. Sonar reports zero open new issues and 0.0% duplicated new lines. The final head makes the phase sequence bound explicit and tests rejection of a sixth record. The 97 targeted cases and both typechecks pass again.
