### PR TITLE
fix(runtime): distinguish failed turns from diagnostics

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,2 @@
-# The public wire copy is generated and checked against its canonical declarations.
-sonar.cpd.exclusions=scripts/install/runtime-installer.cjs,packages/agenc-sdk/src/protocol-wire.generated.ts
+# The generated public contracts are checked against their canonical sources.
+sonar.cpd.exclusions=scripts/install/runtime-installer.cjs,packages/agenc-sdk/src/protocol-wire.generated.ts,packages/agenc-sdk/src/turn-terminal.generated.ts

--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -274,8 +274,8 @@ part of the public SDK method set.
 `clientMessageId`. Reusing it with the same content is idempotent; reusing it
 with different content is rejected. A retry response reports
 `duplicateState: "completed" | "incomplete"` and never invents success for a
-crash tail without a durable terminal event. Only `turn_complete` (code 0)
-and `turn_aborted` (code 130) are those terminals. A mid-turn `error` is
+crash tail without a durable terminal event. The terminals are `turn_complete`
+(code 0), `turn_aborted` (code 130), and `turn_failed` (code 1). A mid-turn `error` is
 session telemetry, not a closer; see [Mid-turn error events](#mid-turn-error-events).
 Callers that require strict
 single-turn admission pass `ifBusy: "reject"`. That flag refuses only an
@@ -322,8 +322,8 @@ Older 1.2 clients ignore the additive field.
 | --- | --- |
 | `turnId` | The open `turn_started` |
 | `committedSequence` | Durable sequence of that turn's terminal event (placement anchor) |
-| `outcome` | `completed` (`turn_complete`) or `aborted` (`turn_aborted`) |
-| `durationMs` | Completed turns only: `turn_complete.durationMs`, else `completedAt - startedAt` when both stamps are finite and ≥ 0 |
+| `outcome` | `completed` (`turn_complete`), `aborted` (`turn_aborted`), or `errored` (`turn_failed`) |
+| `durationMs` | Terminal `durationMs`, else `completedAt - startedAt` when both stamps are finite and non-negative |
 | `inputTokens` / `outputTokens` / `totalTokens` | Sum of enclosed `token_count.promptTokens` / `completionTokens` / `totalTokens` |
 | `model` / `provider` | Last nonempty strings on those same `token_count` events |
 
@@ -338,8 +338,8 @@ Constraints:
   the same mismatched-terminal guard the message scan already applies.
 - `error` events are telemetry, not terminals. A stop-hook throw or similar
   mid-turn failure does not close the accumulator; later `token_count` and
-  the real `turn_complete` / `turn_aborted` still belong to that turn.
-- `durationMs` is not emitted for aborted turns.
+  the matching terminal still belong to that turn.
+- Timing is omitted when the terminal has no usable duration or completion stamp.
 - A `token_count` with no finite non-negative token field is ignored,
   including its model/provider. Cache, reasoning, and search counters
   on that event are not copied.
@@ -386,7 +386,7 @@ history.
 | Markers missing after compact or rewind | Expected. Rows exist only for turns that closed after the current `historyEpoch`. |
 | Duration missing on a completed turn | The terminal lacked `durationMs` and a usable `completedAt - startedAt` pair. |
 | Tokens or model missing | No enclosed `token_count` carried a finite non-negative token field. |
-| `outcome: "errored"` or tokens cut off at a mid-turn `error` | The connected daemon closed the accumulator on the first `error`. Current main keeps the turn open until `turn_complete` / `turn_aborted`. See [Mid-turn error events](#mid-turn-error-events). |
+| Tokens cut off at a mid-turn diagnostic `error` | The connected daemon closed the accumulator too early. Current readers wait for an explicit terminal. See [Mid-turn error events](#mid-turn-error-events). |
 
 #### Mid-turn error events
 
@@ -395,7 +395,7 @@ Raw session `error` events are diagnostic telemetry. Stop-hook throws
 cause) emit them while the ladder continues
 (`runtime/src/phases/stop-hooks.ts`). The recursion cap emits
 `stop_hook_loop` and then allows the turn to terminate. In every case
-the submission closer is still `turn_complete` or `turn_aborted`. A real
+the submission closer is an explicit turn terminal. A real
 run failure is reported separately as `RunAgentProgressEvent.run_error` or a
 canonical `run_terminal` failure.
 
@@ -417,19 +417,16 @@ Constraints:
   SDK throws `AgencDuplicateSubmissionIncompleteError`.
 - A later turn's terminal is never attributed to an earlier crash tail.
   The next `user_message` or `message_submission` ends the persisted scan.
-- Current writers never emit `turnResults.outcome: "errored"`. The
-  protocol union in `runtime/src/app-server/protocol/index.ts` (and the
-  generated SDK mirror) still lists it so type-sync stays exact and older
-  daemons that closed on the first `error` remain representable.
+- Failed turns emit `turnResults.outcome: "errored"`. A settled duplicate
+  retry returns `terminal.code === 1` without rerunning the prompt.
 - The live event-log bridge passes every raw session `error` through
   `projectTelemetryErrorAsSessionOnly`. The resulting
   `statusProjection: "session_only"` keeps the diagnostic visible without
   changing agent or run status.
 - Terminal run failures use an explicit path. `run_error` and failed
   `run_terminal` records produce `event.agent_status` with `status: "error"`.
-  The TUI adapter converts that notification to an `error` transcript event
-  with `payload.terminal: true`. Runtime-settings authority failures carry
-  the same marker.
+  The TUI adapter converts a turn-scoped failure notification to `turn_failed`.
+  Runtime-settings authority failures use the same explicit event locally.
 - An unmarked raw session error remains visible in the transcript, but it does
   not clear the TUI's active turn or stop the streaming reducer.
 
@@ -450,9 +447,38 @@ when `turn_complete` was still ahead in the journal.
 | Symptom | What to check |
 | --- | --- |
 | Retry reports `completed` with `terminal.code === 1` after a hook throw | Connected daemon predates the mid-turn error closer. |
-| `AgencDuplicateSubmissionIncompleteError` after an `error` event | Expected until a matching `turn_complete` or `turn_aborted`. |
+| `AgencDuplicateSubmissionIncompleteError` after a diagnostic `error` event | Expected until a matching explicit turn terminal. |
 | A raw session `error` also emits `event.agent_status: error` | The connected daemon predates the diagnostic-error projection or bypassed the live event bridge. Current writers reserve that status notification for a terminal run failure. |
-| The TUI spinner stops on a diagnostic error | Check that the transcript event lacks `payload.terminal: true`. Only explicit terminal errors clear the active turn. |
+| The TUI spinner stops on a diagnostic error | Check for a matching `turn_failed`, `turn_complete`, or `turn_aborted`. A raw `error` must not clear the active turn. |
+
+#### Failed-turn events
+
+`turn_failed` is an additive durable event. Its payload requires a nonempty
+`turnId`, a stable `code` matching `[a-z][a-z0-9_]{0,63}`, and a `message`
+bounded to 2,000 UTF-16 code units. Optional `completedAt` and `durationMs`
+are finite, non-negative milliseconds. The event closes only the matching
+turn and returns exit code 1 through live submission tracking, persisted
+retries, the SDK, and the one-shot CLI.
+
+`runtime/src/contracts/turn-terminal.ts` defines the classifier. The SDK uses
+an exact generated copy checked by `check:sdk-generated-types`. A failed
+turn does not by itself kill a reusable daemon run. The daemon sends its
+canonical `turn_failed` as `event.session_event` and returns to idle.
+Fatal thread cleanup closes an open turn before writing `run_terminal`;
+it does not write a second terminal if the kernel already closed that turn.
+
+Journal reads alone recognize two old terminal representations, `error`
+with cause `background_agent_error` or `review_task_failed`, a nonempty
+matching turn ID, and a string message. No other cause is terminal, and
+live `error` events never use this compatibility rule. The audit found
+these old writers in thread-status projection and the spawned review-task
+catch path. Stop hooks, compaction, editor diagnostics, and stream retries
+remain non-terminal.
+
+No journal rewrite or schema-version change is required. Deploy reader
+support before enabling new writers. If writers are rolled back after a
+journal contains `turn_failed`, retain the additive reader support so the
+failed turn is not reconstructed as an unfinished turn.
 
 `session.resolveToolCall` accepts two strict protocol-1.0 request shapes. The
 earlier `{ sessionId, toolCallId?, reviewer? }` shape can settle only a legacy

--- a/packages/agenc-sdk/src/client.ts
+++ b/packages/agenc-sdk/src/client.ts
@@ -1407,7 +1407,7 @@ export class AgencClient {
           void respondToElicitation(event);
         }
       }
-      const terminal = terminalStatusFromNotification(message);
+      const terminal = terminalStatusFromNotification(message, reservation.turnId);
       if (terminal !== null) void finish(terminal);
     });
 

--- a/packages/agenc-sdk/src/events.ts
+++ b/packages/agenc-sdk/src/events.ts
@@ -15,6 +15,8 @@
  */
 
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
+import { classifyTurnTerminal } from "./turn-terminal.generated.js";
+export type { TurnFailedEvent, TurnTerminal } from "./turn-terminal.generated.js";
 
 export type AgencStopReason = "completed" | "errored" | "stopped";
 
@@ -165,7 +167,7 @@ export function messageChunkFromNotification(
 /**
  * Detect the terminal status of a turn from a daemon notification. Mirrors
  * the CLI's `daemonOneShotFinalStatus`: `event.agent_status` with a terminal
- * run status, or a nested transcript `turn_complete`/`error` event.
+ * run status, or a nested explicit turn-terminal event.
  */
 export function terminalStatusFromNotification(
   message: JsonObject,
@@ -198,31 +200,18 @@ export function terminalStatusFromNotification(
     }
   }
   const transcriptEvent = nestedTranscriptEvent(message);
-  if (transcriptEvent === null) return null;
-  const payload = isJsonObject(transcriptEvent.payload)
-    ? transcriptEvent.payload
-    : null;
-  if (transcriptEvent.type === "turn_complete") {
-    const finalMessage =
-      payload !== null && typeof payload.lastAgentMessage === "string"
-        ? payload.lastAgentMessage
-        : undefined;
-    return {
-      code: 0,
-      ...(finalMessage !== undefined ? { message: finalMessage } : {}),
-    };
-  }
-  if (transcriptEvent.type === "error") {
-    const errorMessage =
-      payload !== null && typeof payload.message === "string"
-        ? payload.message
-        : undefined;
-    return {
-      code: 1,
-      ...(errorMessage !== undefined ? { message: errorMessage } : {}),
-    };
-  }
-  return null;
+  if (transcriptEvent === null || typeof transcriptEvent.type !== "string") return null;
+  const terminal = classifyTurnTerminal({
+    type: transcriptEvent.type,
+    payload: transcriptEvent.payload,
+    turnId: transcriptEvent.turnId,
+  }, {
+    expectedTurnId: typeof params?.turnId === "string" ? params.turnId : undefined,
+  });
+  return terminal === undefined ? null : {
+    code: terminal.code,
+    ...(terminal.message !== undefined ? { message: terminal.message } : {}),
+  };
 }
 
 export function stopReasonFromExitCode(code: number): AgencStopReason {

--- a/packages/agenc-sdk/src/events.ts
+++ b/packages/agenc-sdk/src/events.ts
@@ -171,8 +171,11 @@ export function messageChunkFromNotification(
  */
 export function terminalStatusFromNotification(
   message: JsonObject,
+  expectedTurnId?: string,
 ): AgencTerminalStatus | null {
   const params = eventParams(message);
+  const notificationTurnId = typeof params?.turnId === "string" ? params.turnId : undefined;
+  if (expectedTurnId !== undefined && notificationTurnId !== undefined && notificationTurnId !== expectedTurnId) return null;
   if (message.method === "event.agent_status" && params !== null) {
     const runStatus =
       typeof params.runStatus === "string" ? params.runStatus : undefined;
@@ -204,9 +207,9 @@ export function terminalStatusFromNotification(
   const terminal = classifyTurnTerminal({
     type: transcriptEvent.type,
     payload: transcriptEvent.payload,
-    turnId: transcriptEvent.turnId,
+    turnId: transcriptEvent.turnId ?? notificationTurnId,
   }, {
-    expectedTurnId: typeof params?.turnId === "string" ? params.turnId : undefined,
+    expectedTurnId: expectedTurnId ?? notificationTurnId,
   });
   return terminal === undefined ? null : {
     code: terminal.code,

--- a/packages/agenc-sdk/src/turn-terminal.generated.ts
+++ b/packages/agenc-sdk/src/turn-terminal.generated.ts
@@ -1,0 +1,181 @@
+export const MAX_TURN_FAILURE_MESSAGE_LENGTH = 2_000;
+const TURN_TERMINAL_EVENT_TYPES = new Set(["turn_complete", "turn_aborted", "turn_failed"]);
+
+export interface TurnFailedEvent {
+  readonly turnId: string;
+  readonly code: string;
+  readonly message: string;
+  readonly completedAt?: number;
+  readonly durationMs?: number;
+}
+
+export interface TurnEventInput {
+  readonly type: string;
+  readonly payload?: unknown;
+  readonly turnId?: unknown;
+}
+
+export interface TurnTerminalOptions {
+  readonly expectedTurnId?: string;
+  readonly legacyJournal?: boolean;
+}
+
+interface TurnTerminalDetails {
+  readonly turnId?: string;
+  readonly message?: string;
+  readonly completedAt?: number;
+  readonly durationMs?: number;
+}
+
+export type TurnTerminal = TurnTerminalDetails & (
+  | { readonly outcome: "completed"; readonly code: 0 }
+  | { readonly outcome: "aborted"; readonly code: 130 }
+  | { readonly outcome: "errored"; readonly code: 1; readonly failureCode: string }
+);
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function nonNegativeFinite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+export function validFailureCode(value: unknown): value is string {
+  return typeof value === "string" && /^[a-z][a-z0-9_]{0,63}$/u.test(value);
+}
+
+export function createTurnFailedEvent(payload: TurnFailedEvent): {
+  readonly type: "turn_failed";
+  readonly payload: TurnFailedEvent;
+} {
+  if (nonEmptyString(payload.turnId) === undefined) {
+    throw new TypeError("turn_failed requires a nonempty turnId");
+  }
+  if (!validFailureCode(payload.code)) {
+    throw new TypeError("turn_failed requires a stable failure code");
+  }
+  const completedAt = nonNegativeFinite(payload.completedAt);
+  const durationMs = nonNegativeFinite(payload.durationMs);
+  return {
+    type: "turn_failed",
+    payload: {
+      turnId: payload.turnId,
+      code: payload.code,
+      message: payload.message.slice(0, MAX_TURN_FAILURE_MESSAGE_LENGTH),
+      ...(completedAt !== undefined ? { completedAt } : {}),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    },
+  };
+}
+
+function readTurnScope(
+  event: TurnEventInput,
+  options: TurnTerminalOptions,
+): {
+  readonly payload: Record<string, unknown>;
+  readonly details: TurnTerminalDetails;
+} | undefined {
+  if (
+    event.payload === null ||
+    typeof event.payload !== "object" ||
+    Array.isArray(event.payload)
+  ) {
+    return undefined;
+  }
+  const payload = event.payload as Record<string, unknown>;
+  const payloadTurnId = nonEmptyString(payload.turnId);
+  const envelopeTurnId = nonEmptyString(event.turnId);
+  if (
+    payloadTurnId !== undefined &&
+    envelopeTurnId !== undefined &&
+    payloadTurnId !== envelopeTurnId
+  ) {
+    return undefined;
+  }
+  const turnId = payloadTurnId ?? envelopeTurnId;
+  if (
+    options.expectedTurnId !== undefined &&
+    turnId !== undefined &&
+    turnId !== options.expectedTurnId
+  ) {
+    return undefined;
+  }
+  const completedAt = nonNegativeFinite(payload.completedAt);
+  const durationMs = nonNegativeFinite(payload.durationMs);
+  const details = {
+    ...(turnId !== undefined ? { turnId } : {}),
+    ...(completedAt !== undefined ? { completedAt } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+  };
+  return { payload, details };
+}
+
+function failedTurnTerminal(
+  type: string,
+  payload: Record<string, unknown>,
+  details: TurnTerminalDetails,
+  legacyJournal: boolean | undefined,
+): TurnTerminal | undefined {
+  const legacyFailure = legacyJournal === true &&
+    type === "error" &&
+    (payload.cause === "background_agent_error" ||
+      payload.cause === "review_task_failed");
+  const failureCode = legacyFailure ? payload.cause : payload.code;
+  if (
+    (type !== "turn_failed" && !legacyFailure) ||
+    details.turnId === undefined ||
+    !validFailureCode(failureCode) ||
+    typeof payload.message !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    ...details,
+    outcome: "errored",
+    code: 1,
+    failureCode,
+    message: payload.message.slice(0, MAX_TURN_FAILURE_MESSAGE_LENGTH),
+  };
+}
+
+export function classifyTurnTerminal(
+  event: TurnEventInput,
+  options: TurnTerminalOptions = {},
+): TurnTerminal | undefined {
+  if (
+    !TURN_TERMINAL_EVENT_TYPES.has(event.type) &&
+    !(options.legacyJournal === true && event.type === "error")
+  ) {
+    return undefined;
+  }
+  const scoped = readTurnScope(event, options);
+  if (scoped === undefined) return undefined;
+  const { payload, details } = scoped;
+  if (event.type === "turn_complete") {
+    if (options.expectedTurnId !== undefined && details.turnId === undefined) {
+      return undefined;
+    }
+    return {
+      ...details,
+      outcome: "completed",
+      code: 0,
+      ...(typeof payload.lastAgentMessage === "string"
+        ? { message: payload.lastAgentMessage }
+        : {}),
+    };
+  }
+  if (event.type === "turn_aborted") {
+    return {
+      ...details,
+      outcome: "aborted",
+      code: 130,
+      ...(typeof payload.reason === "string" ? { message: payload.reason } : {}),
+    };
+  }
+  return failedTurnTerminal(event.type, payload, details, options.legacyJournal);
+}

--- a/packages/agenc/test/installer-sqlite-lock-sync.test.mjs
+++ b/packages/agenc/test/installer-sqlite-lock-sync.test.mjs
@@ -94,11 +94,15 @@ test("canonical installer uses explicit ASCII ordering for exact keys", () => {
   );
 });
 
-test("Sonar excludes only canonical installer and generated wire copies", () => {
+test("Sonar excludes only canonical installer and generated contract copies", () => {
   assert.equal(
     readFileSync(join(repoRoot, ".sonarcloud.properties"), "utf8"),
-    "# The public wire copy is generated and checked against its canonical declarations.\n" +
-      "sonar.cpd.exclusions=scripts/install/runtime-installer.cjs,packages/agenc-sdk/src/protocol-wire.generated.ts\n",
+    "# The generated public contracts are checked against their canonical sources.\n" +
+      "sonar.cpd.exclusions=scripts/install/runtime-installer.cjs,packages/agenc-sdk/src/protocol-wire.generated.ts,packages/agenc-sdk/src/turn-terminal.generated.ts\n",
+  );
+  assert.equal(
+    readFileSync(join(repoRoot, "packages/agenc-sdk/src/turn-terminal.generated.ts"), "utf8"),
+    readFileSync(join(repoRoot, "runtime/src/contracts/turn-terminal.ts"), "utf8"),
   );
 });
 

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -22,6 +22,8 @@ const paths = {
   coreTypes: "src/entrypoints/sdk/coreTypes.ts",
   generated: "src/entrypoints/sdk/coreTypes.generated.ts",
   runtimeProtocol: "src/app-server/protocol/index.ts",
+  turnTerminal: "src/contracts/turn-terminal.ts",
+  packageTurnTerminal: "../packages/agenc-sdk/src/turn-terminal.generated.ts",
   packageTranscriptV2: "../packages/agenc-sdk/src/transcript-v2.generated.ts",
   packageWire: "../packages/agenc-sdk/src/protocol-wire.generated.ts",
   packageWorkflowResult:
@@ -167,6 +169,15 @@ export async function synchronizeSdkWireGenerated({
   return synchronizeGeneratedFile({ generatedPath, expected, write });
 }
 
+export async function synchronizeTurnTerminalGenerated({
+  canonicalPath,
+  generatedPath,
+  write = false,
+}) {
+  const expected = normalizeLineEndings(await readFile(canonicalPath, "utf8"));
+  return synchronizeGeneratedFile({ generatedPath, expected, write });
+}
+
 async function synchronizeGeneratedFile({ generatedPath, expected, write }) {
   let current;
   try {
@@ -224,6 +235,7 @@ async function main() {
     packageWorkflowResult,
     transcriptV2,
     wire,
+    turnTerminal,
   ] = await Promise.all([
     readRuntimeFile(paths.schemas),
     readRuntimeFile(paths.coreTypes),
@@ -239,6 +251,11 @@ async function main() {
       generatedPath: path.join(runtimeRoot, paths.packageWire),
       write: mode === "write",
     }),
+    synchronizeTurnTerminalGenerated({
+      canonicalPath: path.join(runtimeRoot, paths.turnTerminal),
+      generatedPath: path.join(runtimeRoot, paths.packageTurnTerminal),
+      write: mode === "write",
+    }),
   ]);
   if (mode === "write") {
     const displayPath = path
@@ -252,6 +269,9 @@ async function main() {
     );
     process.stdout.write(
       `[sdk generated types] ${wire.changed ? "wrote" : "current"} ${paths.packageWire}\n`,
+    );
+    process.stdout.write(
+      `[sdk generated types] ${turnTerminal.changed ? "wrote" : "current"} ${paths.packageTurnTerminal}\n`,
     );
   }
   const failures = [];
@@ -394,6 +414,11 @@ async function main() {
     failures,
     wire.matches,
     `${paths.packageWire} is stale; run ${checkCommand} -- --write`,
+  );
+  expectCondition(
+    failures,
+    turnTerminal.matches,
+    `${paths.packageTurnTerminal} is stale; run ${checkCommand} -- --write`,
   );
 
   if (mode === "check") {

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -222,6 +222,24 @@ function reportSdkGeneratedTypesSuccess(mode) {
   process.stdout.write(`[sdk generated types] ${message}\n`);
 }
 
+function reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTerminal) {
+  const displayPath = path
+    .relative(path.dirname(runtimeRoot), transcriptV2Path)
+    .split(path.sep)
+    .join("/");
+  process.stdout.write(
+    transcriptV2.changed
+      ? `[sdk generated types] wrote ${displayPath}\n`
+      : `[sdk generated types] ${displayPath} is already current\n`,
+  );
+  process.stdout.write(
+    `[sdk generated types] ${wire.changed ? "wrote" : "current"} ${paths.packageWire}\n`,
+  );
+  process.stdout.write(
+    `[sdk generated types] ${turnTerminal.changed ? "wrote" : "current"} ${paths.packageTurnTerminal}\n`,
+  );
+}
+
 async function main() {
   const mode = parseSdkGeneratedTypesMode(process.argv.slice(2));
   const transcriptV2Path = path.join(
@@ -258,21 +276,7 @@ async function main() {
     }),
   ]);
   if (mode === "write") {
-    const displayPath = path
-      .relative(path.dirname(runtimeRoot), transcriptV2Path)
-      .split(path.sep)
-      .join("/");
-    process.stdout.write(
-      transcriptV2.changed
-        ? `[sdk generated types] wrote ${displayPath}\n`
-        : `[sdk generated types] ${displayPath} is already current\n`,
-    );
-    process.stdout.write(
-      `[sdk generated types] ${wire.changed ? "wrote" : "current"} ${paths.packageWire}\n`,
-    );
-    process.stdout.write(
-      `[sdk generated types] ${turnTerminal.changed ? "wrote" : "current"} ${paths.packageTurnTerminal}\n`,
-    );
+    reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTerminal);
   }
   const failures = [];
   const sources = [

--- a/runtime/src/agents/status.ts
+++ b/runtime/src/agents/status.ts
@@ -25,6 +25,7 @@
 
 import { BehaviorSubject } from "./_deps/behavior-subject.js";
 import { monotonicMs } from "./_deps/monotonic.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 
 export type AgentStatus =
   | { readonly status: "pending_init" }
@@ -101,7 +102,7 @@ export function isFinal(status: AgentStatus): boolean {
  *   - TurnAborted(Interrupted   -> Interrupted
  *                |BudgetLimited)
  *   - TurnAborted(other)        -> Errored(reason)
- *   - Error                     -> Errored(message)
+ *   - TurnFailed                -> Errored(message)
  *   - ShutdownComplete          -> Shutdown
  *   - else                      -> None
  *
@@ -113,76 +114,43 @@ export function agentStatusFromEvent(event: {
   readonly type: string;
   readonly payload?: unknown;
 }): AgentStatus | undefined {
-  switch (event.type) {
-    case "turn_started": {
-      const payload =
-        (event.payload as {
-          turnId?: string;
-          startedAt?: number;
-        }) ?? {};
-      return {
-        status: "running",
-        turnId: payload.turnId ?? "",
-        startedAtMs: payload.startedAt ?? Date.now(),
-      };
-    }
-    case "turn_complete": {
-      const payload =
-        (event.payload as {
-          turnId?: string;
-          lastAgentMessage?: string;
-          completedAt?: number;
-        }) ?? {};
-      return {
-        status: "completed",
-        turnId: payload.turnId ?? "",
-        endedAtMs: payload.completedAt ?? Date.now(),
-        ...(payload.lastAgentMessage !== undefined
-          ? { lastMessage: payload.lastAgentMessage }
-          : {}),
-      };
-    }
-    case "turn_aborted": {
-      const payload =
-        (event.payload as {
-          turnId?: string;
-          reason?: string;
-        }) ?? {};
-      const reason = (payload.reason ?? "").toLowerCase();
-      const isInterruptClass =
-        reason.includes("interrupt") || reason.includes("budget");
-      const endedAtMs = Date.now();
-      if (isInterruptClass) {
-        return {
-          status: "interrupted",
-          turnId: payload.turnId ?? "",
-          endedAtMs,
-          reason: payload.reason ?? "interrupted",
-        };
-      }
-      return {
-        status: "errored",
-        turnId: payload.turnId ?? "",
-        endedAtMs,
-        error: payload.reason ?? "errored",
-      };
-    }
-    case "error": {
-      const payload =
-        (event.payload as {
-          turnId?: string;
-          message?: string;
-        }) ?? {};
-      return {
-        status: "errored",
-        turnId: payload.turnId ?? "",
-        endedAtMs: Date.now(),
-        error: payload.message ?? "error",
-      };
-    }
-    default:
-      return undefined;
+  if (event.type === "turn_started") {
+    const payload = (event.payload as { turnId?: string; startedAt?: number }) ?? {};
+    return {
+      status: "running",
+      turnId: payload.turnId ?? "",
+      startedAtMs: payload.startedAt ?? Date.now(),
+    };
   }
+  const terminal = classifyTurnTerminal(event);
+  if (terminal === undefined) return undefined;
+  const turnId = terminal.turnId ?? "";
+  const endedAtMs = terminal.completedAt ?? Date.now();
+  if (terminal.outcome === "completed") {
+    return {
+      status: "completed",
+      turnId,
+      endedAtMs,
+      ...(terminal.message !== undefined ? { lastMessage: terminal.message } : {}),
+    };
+  }
+  if (terminal.outcome === "aborted") {
+    const reason = (terminal.message ?? "").toLowerCase();
+    if (reason.includes("interrupt") || reason.includes("budget")) {
+      return {
+        status: "interrupted",
+        turnId,
+        endedAtMs,
+        reason: terminal.message ?? "interrupted",
+      };
+    }
+  }
+  return {
+    status: "errored",
+    turnId,
+    endedAtMs,
+    error: terminal.message ?? "errored",
+  };
 }
 
 export function toAgentStatusJson(status: AgentStatus): AgentStatusJson {

--- a/runtime/src/agents/thread-rollout-truncation.ts
+++ b/runtime/src/agents/thread-rollout-truncation.ts
@@ -1,4 +1,5 @@
 import type { ResponseItem, RolloutItem } from "../session/rollout-item.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 import {
   agentInvocationGroupStartIndex,
   isAgentInvocationTurnBoundary,
@@ -137,8 +138,10 @@ function snapshotTurnState(
       return;
     }
     if (
-      (msg.type === "turn_complete" || msg.type === "turn_aborted") &&
-      (activeTurnId === undefined || msg.payload.turnId === activeTurnId)
+      classifyTurnTerminal(msg, {
+        expectedTurnId: activeTurnId,
+        legacyJournal: true,
+      }) !== undefined
     ) {
       activeTurnClosed = true;
     }
@@ -158,8 +161,7 @@ function snapshotTurnState(
   }
   const hasTerminalBoundary = items.slice(lastUserPosition + 1).some((item) => {
     if (item.type !== "event_msg") return false;
-    const type = item.payload.msg.type;
-    return type === "turn_complete" || type === "turn_aborted";
+    return classifyTurnTerminal(item.payload.msg, { legacyJournal: true }) !== undefined;
   });
   return { endsMidTurn: !hasTerminalBoundary };
 }

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -5467,6 +5467,7 @@ function formatEventMessageForLog(
       delta.flushAssistantDelta();
       return formatTranscriptLine("warning", msg.payload.message);
     case "error":
+    case "turn_failed":
     case "stream_error":
       delta.flushAssistantDelta();
       return formatTranscriptLine("error", msg.payload.message);

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -23,6 +23,7 @@ import { ensureAgentControl } from "../bin/delegate-tool.js";
 import { AgentControl } from "../agents/control.js";
 import { clearSession } from "../commands/clear.js";
 import { runTurn } from "../session/run-turn.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 import {
   prepareUserPromptForTurn,
   userPromptDisplayText,
@@ -4349,6 +4350,14 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
   ): void {
     if (event.statusProjection === "session_only") return;
     const payload = event.payload;
+    const terminal = classifyTurnTerminal(event, {
+      expectedTurnId: active.messageSubmission?.turnId,
+    });
+    if (terminal !== undefined) {
+      active.status = "idle";
+      active.activeToolCallIds.clear();
+      return;
+    }
     switch (event.type) {
       case "agent_message_delta":
         if (typeof payload?.delta === "string") {
@@ -4372,17 +4381,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         return;
       case "turn_started":
         active.status = "running";
-        return;
-      case "turn_complete":
-        active.status = "idle";
-        return;
-      case "turn_aborted":
-        active.status = "idle";
-        active.activeToolCallIds.clear();
-        return;
-      case "error":
-        active.status = "error";
-        active.activeToolCallIds.clear();
         return;
       case "run_reopened": {
         const epoch = positiveSequence(payload?.epoch);

--- a/runtime/src/app-server/background-agent-runner/daemon-events.ts
+++ b/runtime/src/app-server/background-agent-runner/daemon-events.ts
@@ -6,6 +6,7 @@
 import type { LLMContentPart } from "../../llm/types.js";
 import type { AgentStatus as ThreadAgentStatus } from "../../agents/status.js";
 import type { Event } from "../../session/event-log.js";
+import { classifyTurnTerminal, createTurnFailedEvent } from "../../contracts/turn-terminal.js";
 import type {
   AgenCDaemonSessionNotification,
   AgentRunStatus,
@@ -120,10 +121,10 @@ function correlateDaemonEvent(
   }
 
   const turnId =
-    submission?.turnId ??
+    event.turnId ??
     (typeof event.payload?.turnId === "string"
       ? event.payload.turnId
-      : undefined);
+      : submission?.turnId);
   let messageId = event.messageId;
   if (
     submission !== undefined &&
@@ -147,7 +148,7 @@ function correlateDaemonEvent(
   ) {
     messageId = `assistant:${event.eventId ?? event.id}`;
   }
-  if (submission !== undefined) {
+  if (submission !== undefined && submission.terminal === undefined) {
     const terminal = messageTerminalFromDaemonEvent(event, submission.turnId);
     if (terminal !== undefined) submission.terminal = terminal;
   }
@@ -168,38 +169,11 @@ function messageTerminalFromDaemonEvent(
   event: BackgroundAgentDaemonEvent,
   expectedTurnId: string | undefined,
 ): AgenCBackgroundAgentMessageTerminal | undefined {
-  const eventTurnId =
-    event.turnId ??
-    (typeof event.payload?.turnId === "string"
-      ? event.payload.turnId
-      : undefined);
-  if (
-    expectedTurnId !== undefined &&
-    eventTurnId !== undefined &&
-    eventTurnId !== expectedTurnId
-  ) {
-    return undefined;
-  }
-  if (event.type === "turn_complete") {
-    return {
-      code: 0,
-      ...(typeof event.payload?.lastAgentMessage === "string"
-        ? { message: event.payload.lastAgentMessage }
-        : {}),
-    };
-  }
-  if (event.type === "turn_aborted") {
-    return {
-      code: 130,
-      ...(typeof event.payload?.reason === "string"
-        ? { message: event.payload.reason }
-        : {}),
-    };
-  }
-  // `error` is session telemetry, not a turn closer. Stop-hook throws and
-  // similar sites emit it while the turn continues and later writes
-  // turn_complete / turn_aborted.
-  return undefined;
+  const terminal = classifyTurnTerminal(event, { expectedTurnId });
+  return terminal === undefined ? undefined : {
+    code: terminal.code,
+    ...(terminal.message !== undefined ? { message: terminal.message } : {}),
+  };
 }
 
 /**
@@ -469,11 +443,10 @@ export function notificationFromDaemonEvent(
       },
     };
   }
+  const terminal = classifyTurnTerminal(event);
   if (
     (event.type === "turn_started" ||
-      event.type === "turn_complete" ||
-      event.type === "turn_aborted" ||
-      event.type === "error") &&
+      (terminal !== undefined && terminal.outcome !== "errored")) &&
     event.statusProjection !== "session_only" &&
     isJsonObject(payload)
   ) {
@@ -483,8 +456,8 @@ export function notificationFromDaemonEvent(
       params: {
         ...base,
         agentId: base.agentId ?? sessionId,
-        status: agentStatusFromEventType(event.type),
-        runStatus: agentRunStatusFromEventType(event.type),
+        status: event.type === "turn_started" ? "running" : "idle",
+        runStatus: event.type === "turn_started" ? "running" : "completed",
         ...(typeof payload.turnId === "string"
           ? { turnId: payload.turnId }
           : {}),
@@ -559,20 +532,6 @@ function eventBaseParams(
   };
 }
 
-function agentStatusFromEventType(type: string): DaemonAgentStatus {
-  switch (type) {
-    case "turn_started":
-      return "running";
-    case "error":
-      return "error";
-    case "turn_aborted":
-      return "idle";
-    case "turn_complete":
-    default:
-      return "idle";
-  }
-}
-
 function daemonStatusFromRunTerminal(status: unknown): DaemonAgentStatus {
   switch (status) {
     case "completed":
@@ -596,20 +555,6 @@ function agentRunStatusFromRunTerminal(status: unknown): AgentRunStatus {
     case "cancelled":
     default:
       return "stopped";
-  }
-}
-
-function agentRunStatusFromEventType(type: string): AgentRunStatus {
-  switch (type) {
-    case "turn_started":
-      return "running";
-    case "error":
-      return "errored";
-    case "turn_aborted":
-      return "completed";
-    case "turn_complete":
-    default:
-      return "completed";
   }
 }
 
@@ -692,6 +637,7 @@ const CANONICAL_CORE_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
   "turn_started",
   "turn_complete",
   "turn_aborted",
+  "turn_failed",
   "warning",
   "error",
   "stream_error",
@@ -1102,16 +1048,19 @@ function eventFromThreadStatus(
           completedAt: status.endedAtMs,
         },
       };
-    case "errored":
+    case "errored": {
+      const failed = createTurnFailedEvent({
+        turnId: status.turnId,
+        code: "background_agent_error",
+        message: status.error,
+        completedAt: status.endedAtMs,
+      });
       return {
         id: status.turnId,
-        type: "error",
-        payload: {
-          cause: "background_agent_error",
-          message: status.error,
-          turnId: status.turnId,
-        },
+        type: failed.type,
+        payload: { ...failed.payload },
       };
+    }
     case "interrupted":
       return {
         id: `interrupted-${status.turnId}`,

--- a/runtime/src/app-server/background-agent-runner/journal-reconstruction.ts
+++ b/runtime/src/app-server/background-agent-runner/journal-reconstruction.ts
@@ -6,6 +6,7 @@
 
 import type { LocalRuntimeBootstrap } from "../../bin/bootstrap.js";
 import type { Event } from "../../session/event-log.js";
+import { classifyTurnTerminal, type TurnTerminal } from "../../contracts/turn-terminal.js";
 import type { RolloutItem } from "../../session/rollout-item.js";
 import {
   reconstructFromRollout,
@@ -142,35 +143,11 @@ function messageTerminalFromEvent(
   event: Event["msg"],
   expectedTurnId: string | undefined,
 ): AgenCBackgroundAgentMessageTerminal | undefined {
-  if (event.type === "turn_complete") {
-    if (
-      expectedTurnId !== undefined &&
-      event.payload.turnId !== expectedTurnId
-    ) {
-      return undefined;
-    }
-    return {
-      code: 0,
-      ...(event.payload.lastAgentMessage !== undefined
-        ? { message: event.payload.lastAgentMessage }
-        : {}),
-    };
-  }
-  if (event.type === "turn_aborted") {
-    if (
-      expectedTurnId !== undefined &&
-      event.payload.turnId !== undefined &&
-      event.payload.turnId !== expectedTurnId
-    ) {
-      return undefined;
-    }
-    return { code: 130, message: event.payload.reason };
-  }
-  // Same contract as the live bridge: only turn_complete / turn_aborted
-  // close a submission. A mid-turn `error` must not make an idempotent
-  // retry report completed-with-failure while turn_complete is still
-  // ahead in the journal.
-  return undefined;
+  const terminal = classifyTurnTerminal(event, { expectedTurnId, legacyJournal: true });
+  return terminal === undefined ? undefined : {
+    code: terminal.code,
+    ...(terminal.message !== undefined ? { message: terminal.message } : {}),
+  };
 }
 
 interface MutableTranscriptV2Message extends JsonObject {
@@ -202,31 +179,17 @@ interface OpenTurnAccumulator {
 function closedTurnResult(
   turnId: string,
   sequence: number,
-  msg: {
-    readonly type: string;
-    readonly payload: {
-      readonly turnId?: string;
-      readonly durationMs?: number;
-      readonly completedAt?: number;
-    };
-  },
+  terminal: TurnTerminal,
   open: OpenTurnAccumulator,
 ): SessionTranscriptV2TurnResult {
-  const outcome = msg.type === "turn_aborted" ? "aborted" : "completed";
-  let durationMs: number | undefined;
-  if (msg.type === "turn_complete") {
-    durationMs = nonNegativeFinite(msg.payload.durationMs);
-    if (durationMs === undefined) {
-      const completedAt = nonNegativeFinite(msg.payload.completedAt);
-      if (completedAt !== undefined && open.startedAt !== undefined) {
-        durationMs = nonNegativeFinite(completedAt - open.startedAt);
-      }
-    }
+  let durationMs = terminal.durationMs;
+  if (durationMs === undefined && terminal.completedAt !== undefined && open.startedAt !== undefined) {
+    durationMs = nonNegativeFinite(terminal.completedAt - open.startedAt);
   }
   return {
     turnId,
     committedSequence: sequence,
-    outcome,
+    outcome: terminal.outcome,
     ...(durationMs !== undefined ? { durationMs } : {}),
     ...(open.sawUsage
       ? {
@@ -427,26 +390,17 @@ export function sessionTranscriptV2FromRollout(
       });
       continue;
     }
-    if (
-      event.msg.type === "turn_complete" ||
-      event.msg.type === "turn_aborted"
-    ) {
-      const terminalTurnId =
-        "turnId" in event.msg.payload &&
-        typeof event.msg.payload.turnId === "string"
-          ? event.msg.payload.turnId
-          : undefined;
-      if (
-        (currentTurnId === undefined && pendingUserIndex !== undefined) ||
-        (currentTurnId !== undefined &&
-          terminalTurnId !== undefined &&
-          terminalTurnId !== currentTurnId)
-      ) {
+    const terminal = classifyTurnTerminal(event.msg, {
+      expectedTurnId: currentTurnId,
+      legacyJournal: true,
+    });
+    if (terminal !== undefined) {
+      if (currentTurnId === undefined && pendingUserIndex !== undefined) {
         continue;
       }
       if (currentTurnId !== undefined && openTurn !== undefined) {
         turnResults.push(
-          closedTurnResult(currentTurnId, sequence, event.msg, openTurn),
+          closedTurnResult(currentTurnId, sequence, terminal, openTurn),
         );
       }
       currentTurnId = undefined;

--- a/runtime/src/app-server/background-agent-runner/turn-lifecycle.ts
+++ b/runtime/src/app-server/background-agent-runner/turn-lifecycle.ts
@@ -20,6 +20,7 @@ import type {
 } from "../protocol/index.js";
 import { MAX_SESSION_SHELL_RESULT_TEXT_UTF8_BYTES } from "../protocol/index.js";
 import type { RunTerminalResult } from "../../contracts/run-contracts.js";
+import { classifyTurnTerminal, createTurnFailedEvent } from "../../contracts/turn-terminal.js";
 
 import {
   AgenCBackgroundAgentMessageError,
@@ -443,12 +444,45 @@ function commitDurableRunCancellationRequest(
   }
 }
 
+function closeFailedRunTurn(
+  active: ActiveBackgroundAgent,
+  result: RunTerminalResult,
+): void {
+  if (result.status !== "failed") return;
+  let openTurnId: string | undefined;
+  for (const item of active.bootstrap.rolloutStore.readAll()) {
+    if (item.type !== "event_msg") continue;
+    const event = item.payload.msg;
+    if (event.type === "turn_started") {
+      openTurnId = event.payload.turnId;
+    } else if (classifyTurnTerminal(event, {
+      expectedTurnId: openTurnId,
+      legacyJournal: true,
+    }) !== undefined) {
+      openTurnId = undefined;
+    }
+  }
+  if (openTurnId === undefined) return;
+  const eventId = `turn-failed:${openTurnId}`;
+  active.bootstrap.session.emit({
+    id: eventId,
+    eventId,
+    msg: createTurnFailedEvent({
+      turnId: openTurnId,
+      code: "background_agent_error",
+      message: result.finalMessage ?? result.stopReason ?? "background agent failed",
+      completedAt: Date.parse(result.finishedAt),
+    }),
+  });
+}
+
 function commitDurableRunTerminal(
   active: ActiveBackgroundAgent,
   runId: string,
   result: RunTerminalResult,
 ): AgenCBackgroundAgentTerminalSnapshot {
   if (active.terminal !== undefined) return active.terminal;
+  closeFailedRunTurn(active, result);
   const epoch = active.runEpoch;
   const session = active.bootstrap.session;
   const lastSequenceBeforeTerminal =

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -36,6 +36,7 @@ import { isAbsolute, resolve } from "node:path";
 import { cwd as processCwd } from "node:process";
 import { isDeepStrictEqual } from "node:util";
 import { VERSION } from "../index.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 import { applyBestEffortPreMainProcessHardening } from "../sandbox/hardening/index.js";
 import {
   classifyCLI,
@@ -1692,25 +1693,18 @@ function daemonOneShotFinalStatus(
     }
   }
   const transcriptEvent = daemonNestedTranscriptEvent(event);
-  if (transcriptEvent === null) return null;
-  const payload = isJsonRecord(transcriptEvent.payload)
-    ? transcriptEvent.payload
-    : null;
-  if (transcriptEvent.type === "turn_complete") {
-    const message =
-      payload !== null && typeof payload.lastAgentMessage === "string"
-        ? payload.lastAgentMessage
-        : undefined;
-    return { code: 0, ...(message !== undefined ? { message } : {}) };
-  }
-  if (transcriptEvent.type === "error") {
-    const message =
-      payload !== null && typeof payload.message === "string"
-        ? payload.message
-        : undefined;
-    return { code: 1, ...(message !== undefined ? { message } : {}) };
-  }
-  return null;
+  if (transcriptEvent === null || typeof transcriptEvent.type !== "string") return null;
+  const terminal = classifyTurnTerminal({
+    type: transcriptEvent.type,
+    payload: transcriptEvent.payload,
+    turnId: transcriptEvent.turnId,
+  }, {
+    expectedTurnId: typeof params?.turnId === "string" ? params.turnId : undefined,
+  });
+  return terminal === undefined ? null : {
+    code: terminal.code,
+    ...(terminal.message !== undefined ? { message: terminal.message } : {}),
+  };
 }
 
 async function runDaemonOneShotPrompt(params: {

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -1945,7 +1945,7 @@ async function runDaemonOneShotPrompt(params: {
             lastPrintedChar = chunk.at(-1) ?? lastPrintedChar;
           }
 
-          activeTurnId = daemonOneShotStartedTurnId(event) ?? activeTurnId;
+          activeTurnId ??= daemonOneShotStartedTurnId(event);
           const finalStatus = daemonOneShotFinalStatus(event, activeTurnId);
           if (finalStatus === null) return;
           if (finalizing) return;

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -1670,11 +1670,27 @@ const ONE_SHOT_TOOL_DENIED_MARKER =
   "tool call and gave up. Re-run with --permission-mode or " +
   "--dangerously-bypass-approvals-and-sandbox to allow tools.";
 
+function daemonOneShotStartedTurnId(event: unknown): string | undefined {
+  if (!isJsonRecord(event)) return undefined;
+  const params = daemonEventParams(event);
+  if (
+    event.method === "event.agent_status" &&
+    (params?.status === "running" || params?.runStatus === "running") &&
+    typeof params.turnId === "string"
+  ) return params.turnId;
+  const transcriptEvent = daemonNestedTranscriptEvent(event);
+  if (transcriptEvent?.type !== "turn_started" || !isJsonRecord(transcriptEvent.payload)) return undefined;
+  return typeof transcriptEvent.payload.turnId === "string" ? transcriptEvent.payload.turnId : undefined;
+}
+
 function daemonOneShotFinalStatus(
   event: unknown,
+  expectedTurnId?: string,
 ): DaemonOneShotFinalStatus | null {
   if (!isJsonRecord(event)) return null;
   const params = daemonEventParams(event);
+  const notificationTurnId = typeof params?.turnId === "string" ? params.turnId : undefined;
+  if (expectedTurnId !== undefined && notificationTurnId !== undefined && notificationTurnId !== expectedTurnId) return null;
   if (event.method === "event.agent_status" && params !== null) {
     const runStatus =
       typeof params.runStatus === "string" ? params.runStatus : undefined;
@@ -1697,9 +1713,9 @@ function daemonOneShotFinalStatus(
   const terminal = classifyTurnTerminal({
     type: transcriptEvent.type,
     payload: transcriptEvent.payload,
-    turnId: transcriptEvent.turnId,
+    turnId: transcriptEvent.turnId ?? notificationTurnId,
   }, {
-    expectedTurnId: typeof params?.turnId === "string" ? params.turnId : undefined,
+    expectedTurnId: expectedTurnId ?? notificationTurnId,
   });
   return terminal === undefined ? null : {
     code: terminal.code,
@@ -1740,6 +1756,7 @@ async function runDaemonOneShotPrompt(params: {
   let cancelled = false;
   let printedAssistantOutput = false;
   let assistantOutput = "";
+  let activeTurnId: string | undefined;
   let lastPrintedChar = "";
   const outputFormat = params.outputFormat ?? "text";
   const collectedEvents: unknown[] = [];
@@ -1928,7 +1945,8 @@ async function runDaemonOneShotPrompt(params: {
             lastPrintedChar = chunk.at(-1) ?? lastPrintedChar;
           }
 
-          const finalStatus = daemonOneShotFinalStatus(event);
+          activeTurnId = daemonOneShotStartedTurnId(event) ?? activeTurnId;
+          const finalStatus = daemonOneShotFinalStatus(event, activeTurnId);
           if (finalStatus === null) return;
           if (finalizing) return;
           finalizing = true;

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -382,6 +382,7 @@ const TRANSCRIPT_BOOT_EVENT_TYPES = new Set<string>([
   "turn_started",
   "turn_complete",
   "turn_aborted",
+  "turn_failed",
   "user_message",
   "token_count",
   "agent_message",

--- a/runtime/src/contracts/turn-terminal.ts
+++ b/runtime/src/contracts/turn-terminal.ts
@@ -1,0 +1,181 @@
+export const MAX_TURN_FAILURE_MESSAGE_LENGTH = 2_000;
+const TURN_TERMINAL_EVENT_TYPES = new Set(["turn_complete", "turn_aborted", "turn_failed"]);
+
+export interface TurnFailedEvent {
+  readonly turnId: string;
+  readonly code: string;
+  readonly message: string;
+  readonly completedAt?: number;
+  readonly durationMs?: number;
+}
+
+export interface TurnEventInput {
+  readonly type: string;
+  readonly payload?: unknown;
+  readonly turnId?: unknown;
+}
+
+export interface TurnTerminalOptions {
+  readonly expectedTurnId?: string;
+  readonly legacyJournal?: boolean;
+}
+
+interface TurnTerminalDetails {
+  readonly turnId?: string;
+  readonly message?: string;
+  readonly completedAt?: number;
+  readonly durationMs?: number;
+}
+
+export type TurnTerminal = TurnTerminalDetails & (
+  | { readonly outcome: "completed"; readonly code: 0 }
+  | { readonly outcome: "aborted"; readonly code: 130 }
+  | { readonly outcome: "errored"; readonly code: 1; readonly failureCode: string }
+);
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function nonNegativeFinite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+export function validFailureCode(value: unknown): value is string {
+  return typeof value === "string" && /^[a-z][a-z0-9_]{0,63}$/u.test(value);
+}
+
+export function createTurnFailedEvent(payload: TurnFailedEvent): {
+  readonly type: "turn_failed";
+  readonly payload: TurnFailedEvent;
+} {
+  if (nonEmptyString(payload.turnId) === undefined) {
+    throw new TypeError("turn_failed requires a nonempty turnId");
+  }
+  if (!validFailureCode(payload.code)) {
+    throw new TypeError("turn_failed requires a stable failure code");
+  }
+  const completedAt = nonNegativeFinite(payload.completedAt);
+  const durationMs = nonNegativeFinite(payload.durationMs);
+  return {
+    type: "turn_failed",
+    payload: {
+      turnId: payload.turnId,
+      code: payload.code,
+      message: payload.message.slice(0, MAX_TURN_FAILURE_MESSAGE_LENGTH),
+      ...(completedAt !== undefined ? { completedAt } : {}),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    },
+  };
+}
+
+function readTurnScope(
+  event: TurnEventInput,
+  options: TurnTerminalOptions,
+): {
+  readonly payload: Record<string, unknown>;
+  readonly details: TurnTerminalDetails;
+} | undefined {
+  if (
+    event.payload === null ||
+    typeof event.payload !== "object" ||
+    Array.isArray(event.payload)
+  ) {
+    return undefined;
+  }
+  const payload = event.payload as Record<string, unknown>;
+  const payloadTurnId = nonEmptyString(payload.turnId);
+  const envelopeTurnId = nonEmptyString(event.turnId);
+  if (
+    payloadTurnId !== undefined &&
+    envelopeTurnId !== undefined &&
+    payloadTurnId !== envelopeTurnId
+  ) {
+    return undefined;
+  }
+  const turnId = payloadTurnId ?? envelopeTurnId;
+  if (
+    options.expectedTurnId !== undefined &&
+    turnId !== undefined &&
+    turnId !== options.expectedTurnId
+  ) {
+    return undefined;
+  }
+  const completedAt = nonNegativeFinite(payload.completedAt);
+  const durationMs = nonNegativeFinite(payload.durationMs);
+  const details = {
+    ...(turnId !== undefined ? { turnId } : {}),
+    ...(completedAt !== undefined ? { completedAt } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+  };
+  return { payload, details };
+}
+
+function failedTurnTerminal(
+  type: string,
+  payload: Record<string, unknown>,
+  details: TurnTerminalDetails,
+  legacyJournal: boolean | undefined,
+): TurnTerminal | undefined {
+  const legacyFailure = legacyJournal === true &&
+    type === "error" &&
+    (payload.cause === "background_agent_error" ||
+      payload.cause === "review_task_failed");
+  const failureCode = legacyFailure ? payload.cause : payload.code;
+  if (
+    (type !== "turn_failed" && !legacyFailure) ||
+    details.turnId === undefined ||
+    !validFailureCode(failureCode) ||
+    typeof payload.message !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    ...details,
+    outcome: "errored",
+    code: 1,
+    failureCode,
+    message: payload.message.slice(0, MAX_TURN_FAILURE_MESSAGE_LENGTH),
+  };
+}
+
+export function classifyTurnTerminal(
+  event: TurnEventInput,
+  options: TurnTerminalOptions = {},
+): TurnTerminal | undefined {
+  if (
+    !TURN_TERMINAL_EVENT_TYPES.has(event.type) &&
+    !(options.legacyJournal === true && event.type === "error")
+  ) {
+    return undefined;
+  }
+  const scoped = readTurnScope(event, options);
+  if (scoped === undefined) return undefined;
+  const { payload, details } = scoped;
+  if (event.type === "turn_complete") {
+    if (options.expectedTurnId !== undefined && details.turnId === undefined) {
+      return undefined;
+    }
+    return {
+      ...details,
+      outcome: "completed",
+      code: 0,
+      ...(typeof payload.lastAgentMessage === "string"
+        ? { message: payload.lastAgentMessage }
+        : {}),
+    };
+  }
+  if (event.type === "turn_aborted") {
+    return {
+      ...details,
+      outcome: "aborted",
+      code: 130,
+      ...(typeof payload.reason === "string" ? { message: payload.reason } : {}),
+    };
+  }
+  return failedTurnTerminal(event.type, payload, details, options.legacyJournal);
+}

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -3,7 +3,7 @@
  * AgenC flows through.
  *
  * Hand-port of agenc runtime `protocol/src/protocol.rs` EventMsg (78 variants)
- * reduced to AgenC's 82-variant runtime surface.
+ * reduced to AgenC's 83-variant runtime surface.
  *
  * Invariants wired here:
  *   I-8  (every error site emits a typed event) — `emitError()` helper
@@ -35,6 +35,8 @@ import type {
   RunUsageTotals,
 } from "../contracts/run-contracts.js";
 import type { ToolRecoveryCategory } from "../tools/types.js";
+import type { TurnFailedEvent } from "../contracts/turn-terminal.js";
+export type { TurnFailedEvent } from "../contracts/turn-terminal.js";
 import type {
   CollaborationMode,
   FileSystemSandboxPolicy,
@@ -101,7 +103,7 @@ export interface Event {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Event payloads — 82 variants
+// Event payloads — 83 variants
 // ─────────────────────────────────────────────────────────────────────
 
 export interface SessionMetaLine {
@@ -965,7 +967,7 @@ export interface TurnContextItem {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// EventMsg discriminated union (82 variants)
+// EventMsg discriminated union (83 variants)
 // ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -1163,6 +1165,7 @@ export type EventMsg =
     }
   | { readonly type: "turn_complete"; readonly payload: TurnCompleteEvent }
   | { readonly type: "turn_aborted"; readonly payload: TurnAbortedEvent }
+  | { readonly type: "turn_failed"; readonly payload: TurnFailedEvent }
   | {
       readonly type: "turn_checkpoint";
       readonly payload: TurnCheckpointEvent;
@@ -1421,6 +1424,7 @@ export const KNOWN_EVENT_TYPES = Object.freeze(
     "subagent_turn_outcome",
     "turn_complete",
     "turn_aborted",
+    "turn_failed",
     "turn_checkpoint",
     "turn_resumed",
     "thread_rolled_back",
@@ -1489,6 +1493,7 @@ const DURABLE_EVENT_TYPES = Object.freeze(
     "message_submission",
     "turn_complete",
     "turn_aborted",
+    "turn_failed",
     "error",
     "context_compacted",
     "subagent_turn_outcome",

--- a/runtime/src/session/review.ts
+++ b/runtime/src/session/review.ts
@@ -81,6 +81,7 @@ import type {
   ExitReviewModePayload,
 } from "./agenc-delegate.js";
 import type { ReviewDelegateCompletionReason } from "./event-log.js";
+import { createTurnFailedEvent } from "../contracts/turn-terminal.js";
 import type { ResponseItem } from "./rollout-item.js";
 import type { LLMMessage } from "../llm/types.js";
 
@@ -1048,6 +1049,18 @@ async function runSpawnedReviewTask(
   manager: ReviewManager | undefined,
 ): Promise<AgenCReviewOneShotOutcome | null> {
   const startedAt = Date.now();
+  let failureAttempted = false;
+  const emitFailure = (message: string, completedAt: number): void => {
+    if (failureAttempted) return;
+    failureAttempted = true;
+    session.sendEvent(subId, createTurnFailedEvent({
+      turnId: subId,
+      code: "review_task_failed",
+      message,
+      completedAt,
+      durationMs: completedAt - startedAt,
+    }));
+  };
   const modelUsed = req.reviewerModel ?? req.parentContext.modelInfo.slug;
   const explicitReuseKey = explicitReviewReuseKey(req);
   const priorFindingCount = priorFindingCountFromHistory(req.initialHistory);
@@ -1085,9 +1098,13 @@ async function runSpawnedReviewTask(
         ...(outcome.error !== null ? { error: outcome.error.message } : {}),
       },
     });
+    if (outcome.verdict === "fail" && outcome.error !== null) {
+      emitFailure(outcome.error.message, completedAt);
+    }
     return outcome;
   } catch (err) {
     const completedAt = Date.now();
+    emitFailure(err instanceof Error ? err.message : String(err), completedAt);
     session.sendEvent(subId, {
       type: "review_delegate_completed",
       payload: {
@@ -1118,17 +1135,6 @@ async function runSpawnedReviewTask(
     session.sendEvent(subId, {
       type: "exit_review_mode",
       payload: exitPayload,
-    });
-    session.sendEvent(subId, {
-      type: "error",
-      payload: {
-        cause: "review_task_failed",
-        message: err instanceof Error ? err.message : String(err),
-        turnId: subId,
-        ...(err instanceof Error && err.stack !== undefined
-          ? { stack: err.stack }
-          : {}),
-      },
     });
     return null;
   } finally {

--- a/runtime/src/session/rollout-reconstruction.ts
+++ b/runtime/src/session/rollout-reconstruction.ts
@@ -41,6 +41,7 @@ import type {
   TurnContextItem,
 } from "./rollout-item.js";
 import { isAgentInvocationTurnBoundary } from "../contracts/agent-invocation-envelope.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 import {
   reduce,
   type ReducedSessionState,
@@ -719,32 +720,21 @@ export function reconstructFromRollout(
       case "event_msg": {
         const inner = item.payload.msg;
         const innerType = (inner as { type?: string }).type;
+        const terminal = classifyTurnTerminal(inner, { legacyJournal: true });
+        if (terminal !== undefined) {
+          if (!active) active = emptySegment();
+          if (active.turnId === undefined && terminal.turnId !== undefined) {
+            active.turnId = terminal.turnId;
+          }
+          if (terminal.turnId !== undefined) seenTerminated.add(terminal.turnId);
+          break;
+        }
         switch (innerType) {
           case "thread_rolled_back": {
             const payload = (
               inner as unknown as { payload: { numTurns: number } }
             ).payload;
             pending.pendingRollbackTurns += payload?.numTurns ?? 0;
-            break;
-          }
-          case "turn_complete": {
-            if (!active) active = emptySegment();
-            const payload = (
-              inner as unknown as { payload: { turnId: string } }
-            ).payload;
-            if (active.turnId === undefined) active.turnId = payload.turnId;
-            seenTerminated.add(payload.turnId);
-            break;
-          }
-          case "turn_aborted": {
-            if (!active) active = emptySegment();
-            const payload = (
-              inner as unknown as { payload: { turnId?: string } }
-            ).payload;
-            if (active.turnId === undefined && payload.turnId) {
-              active.turnId = payload.turnId;
-            }
-            if (payload.turnId) seenTerminated.add(payload.turnId);
             break;
           }
           case "user_message": {
@@ -822,11 +812,11 @@ export function reconstructFromRollout(
       }
       continue;
     }
-    if (inner.type === "turn_complete" || inner.type === "turn_aborted") {
-      const payload = inner.payload as { turnId?: string };
-      if (typeof payload?.turnId === "string") {
-        seenTerminated.add(payload.turnId);
-      }
+    const terminal = typeof inner.type === "string"
+      ? classifyTurnTerminal({ ...inner, type: inner.type }, { legacyJournal: true })
+      : undefined;
+    if (terminal?.turnId !== undefined) {
+      seenTerminated.add(terminal.turnId);
       continue;
     }
     if (inner.type !== "turn_checkpoint") continue;

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -59,6 +59,7 @@ import {
   LEDGER_WALLET_CLI_ROUTING_GUIDANCE,
 } from "../elicitation/ledger-wallet-cli.js";
 import { startCodeModeTurnWorker } from "../tools/code-mode/turn-host.js";
+import { createTurnFailedEvent } from "../contracts/turn-terminal.js";
 import { commit } from "../phases/commit.js";
 import {
   continuationNudge,
@@ -1406,11 +1407,13 @@ export async function* runTurnKernel(
   // T6 gap #119: canonical turn-lifecycle emits. Each `runTurn`
   // invocation must flank its work with a `turn_started` +
   // `turn_context` pair and either a matching `turn_complete` (happy
-  // path) or `turn_aborted` (cancel/error path) so durable rollouts
+  // path), `turn_aborted` (cancel), or `turn_failed` so durable rollouts
   // see closed turn boundaries. Without these, I-48 orphan-TurnStarted
   // recovery in rollout-reconstruction would treat every clean turn
   // as a `process_killed` abort.
   const turnStartedAt = Date.now();
+  let turnStarted = false;
+  let terminalAttempted = false;
   const emitTurnStarted = (turnContextItem: TurnContextItem): void => {
     session.emit({
       id: session.nextInternalSubId(),
@@ -1430,6 +1433,7 @@ export async function* runTurnKernel(
         },
       },
     });
+    turnStarted = true;
     session.emit({
       id: session.nextInternalSubId(),
       msg: {
@@ -1439,6 +1443,8 @@ export async function* runTurnKernel(
     });
   };
   const emitTurnComplete = (content: string): void => {
+    if (terminalAttempted) return;
+    terminalAttempted = true;
     session.emit({
       id: session.nextInternalSubId(),
       msg: {
@@ -1453,7 +1459,24 @@ export async function* runTurnKernel(
     });
   };
   const emitTurnAborted = (reason: string): void => {
+    if (terminalAttempted) return;
+    terminalAttempted = true;
     session.emitTurnAbortedOnce(ctx.subId, reason);
+  };
+  const emitTurnFailed = (message: string): void => {
+    if (terminalAttempted) return;
+    terminalAttempted = true;
+    const completedAt = Date.now();
+    session.emit({
+      id: session.nextInternalSubId(),
+      msg: createTurnFailedEvent({
+        turnId: ctx.subId,
+        code: "turn_execution_failed",
+        message,
+        completedAt,
+        durationMs: completedAt - turnStartedAt,
+      }),
+    });
   };
   const referenceContextItem = toTurnContextItem(ctx);
 
@@ -1555,6 +1578,7 @@ export async function* runTurnKernel(
         emitTurnStarted,
         emitTurnComplete,
         emitTurnAborted,
+        emitTurnFailed,
         referenceContextItem,
         sessionOwner,
         ...(ledgerRootTurnGuidance !== undefined
@@ -1563,6 +1587,11 @@ export async function* runTurnKernel(
         signalCleanups,
       },
     );
+  } catch (error) {
+    if (turnStarted) {
+      emitTurnFailed(error instanceof Error ? error.message : String(error));
+    }
+    throw error;
   } finally {
     for (const cleanup of signalCleanups) cleanup();
     codeModeTurnWorker.dispose();
@@ -1585,6 +1614,7 @@ interface RunTurnKernelCommons {
   readonly emitTurnStarted: (turnContextItem: TurnContextItem) => void;
   readonly emitTurnComplete: (content: string) => void;
   readonly emitTurnAborted: (reason: string) => void;
+  readonly emitTurnFailed: (message: string) => void;
   readonly referenceContextItem: TurnContextItem;
   readonly sessionOwner: Session & {
     consumePendingProviderSwitch?: () => Promise<void>;
@@ -1609,6 +1639,7 @@ async function* runTurnKernelInner(
     emitTurnStarted,
     emitTurnComplete,
     emitTurnAborted,
+    emitTurnFailed,
     referenceContextItem,
     sessionOwner,
     turnStartedAt,
@@ -2483,19 +2514,8 @@ async function* runTurnKernelInner(
         yield editorRequestFailedTurnComplete(content, usage, underlying);
         return terminal;
       }
-      /*
-       * T6 gap #119: an error-terminated turn still closes the turn
-       * boundary for rollout reducers — but it must close it as what it
-       * is. Writing the success-shaped `turn_complete` made the durable
-       * record indistinguishable from a turn that finished, so a run
-       * killed by, say, `execution admission deny: context_window_exceeded`
-       * was replayed to clients as a completed turn whose final answer was
-       * the model's previous intent sentence. `turn_aborted` is the same
-       * boundary for every reducer that consumes one and carries the
-       * reason with it.
-       */
       await syncSessionState();
-      emitTurnAborted(
+      emitTurnFailed(
         underlying instanceof Error && underlying.message.trim().length > 0
           ? underlying.message
           : "turn failed",

--- a/runtime/src/session/trajectory-curate.ts
+++ b/runtime/src/session/trajectory-curate.ts
@@ -12,11 +12,11 @@
  *
  * Curation is pure local file processing:
  *   - **Filter** — keep only trajectories that finished at least one
- *     turn (`turn_complete`), hit no terminal `error` event, were never
+ *     turn (`turn_complete`), hit no `error` or `turn_failed` event, were never
  *     aborted/interrupted (`turn_aborted` covers Esc/cancel), and carry
  *     no user tool-use rejection markers. Transient `stream_error`
  *     events do NOT exclude a trajectory: when the provider hiccup is
- *     fatal the runtime follows up with `error`/`turn_aborted`, which
+ *     fatal the runtime follows up with `turn_failed`/`turn_aborted`, which
  *     do.
  *   - **Redact** — every emitted row is passed through the same
  *     `redactSecretsInValue` the export sink already applies at write
@@ -246,6 +246,7 @@ export function classifyTrajectory(
         hasTurnComplete = true;
         break;
       case "error":
+      case "turn_failed":
         hasErrorEvent = true;
         break;
       case "turn_aborted":

--- a/runtime/src/state/recovery-journal-schema.ts
+++ b/runtime/src/state/recovery-journal-schema.ts
@@ -1,4 +1,8 @@
 import type { EventMsg } from "../session/event-log.js";
+import {
+  MAX_TURN_FAILURE_MESSAGE_LENGTH,
+  validFailureCode,
+} from "../contracts/turn-terminal.js";
 import type {
   RunResumeReason,
   RunRuntimeModelVerbosity,
@@ -105,6 +109,12 @@ const LEGACY_EVENT_TYPES = Object.freeze({
 
 const isString: Validator<string> = (value): value is string =>
   typeof value === "string";
+const isTurnFailureId: Validator<string> = (value): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+const isTurnFailureMessage: Validator<string> = (value): value is string =>
+  typeof value === "string" && value.length <= MAX_TURN_FAILURE_MESSAGE_LENGTH;
+const isTurnFailureTime: Validator<number> = (value): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
 const isRunSuspensionReason: Validator<RunSuspensionReason> = (
   value,
 ): value is RunSuspensionReason => value === "daemon_shutdown_idle";
@@ -941,6 +951,10 @@ const EVENT_PAYLOAD_VALIDATORS = defineEventPayloadValidators({
     },
   ),
   turn_aborted: objectShape({ reason: isString }, { turnId: isString }),
+  turn_failed: objectShape(
+    { turnId: isTurnFailureId, code: validFailureCode, message: isTurnFailureMessage },
+    { completedAt: isTurnFailureTime, durationMs: isTurnFailureTime },
+  ),
   turn_checkpoint: isTurnCheckpoint,
   turn_resumed: objectShape(
     {

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -8,7 +8,7 @@
 import { randomUUID } from "node:crypto";
 import { isAbsolute } from "node:path";
 import { AgenCDaemonResponseError } from "../app-server/agent-cli.js";
-import { isTerminalDaemonErrorPayload } from "./daemon-terminal-error.js";
+import { classifyTurnTerminal, createTurnFailedEvent } from "../contracts/turn-terminal.js";
 import type {
   AgentAttachParams,
   AgenCDaemonMethod,
@@ -223,12 +223,6 @@ const ACTIVE_DAEMON_TRANSCRIPT_EVENTS = new Set([
   "request_permissions",
   "request_user_input",
   "mcp_elicitation_request",
-]);
-
-const TERMINAL_DAEMON_TRANSCRIPT_EVENTS = new Set([
-  "turn_complete",
-  "turn_aborted",
-  "error",
 ]);
 
 export type AgenCDaemonConnectionStatus =
@@ -796,6 +790,7 @@ export function createDaemonTuiSession<
   const receivedEvents: unknown[] = [];
   const REPLAY_BACKLOG_LIMIT = 500;
   let activeTurnSnapshot: { readonly turnId: string } | null = null;
+  let lastObservedTurnId: string | undefined;
   let daemonTurnStartGeneration = 0;
   let inFlightShellExecutionCount = 0;
   const inFlightShellCommandIds = new Set<string>();
@@ -830,26 +825,24 @@ export function createDaemonTuiSession<
         ? payload.turnId
         : (activeTurnSnapshot?.turnId ?? "daemon-turn");
     activeTurnSnapshot = { turnId };
+    if (turnId !== "daemon-turn") lastObservedTurnId = turnId;
   };
   const noteDaemonActivity = (event: unknown): void => {
     if (typeof event !== "object" || event === null) {
       return;
     }
     const eventType = (event as { readonly type?: unknown }).type;
-    // Raw session errors are diagnostic events. A terminal agent-status error
-    // carries an explicit marker added by transcriptEventFromAgentStatus.
-    if (
-      typeof eventType === "string" &&
-      TERMINAL_DAEMON_TRANSCRIPT_EVENTS.has(eventType)
-    ) {
-      if (
-        eventType === "error" &&
-        !isTerminalDaemonErrorPayload(
-          (event as { readonly payload?: unknown }).payload,
-        )
-      ) {
-        return;
-      }
+    const terminal = typeof eventType === "string"
+      ? classifyTurnTerminal({
+          type: eventType,
+          payload: (event as { readonly payload?: unknown }).payload,
+        }, {
+          expectedTurnId: activeTurnSnapshot?.turnId === "daemon-turn"
+            ? lastObservedTurnId
+            : activeTurnSnapshot?.turnId,
+        })
+      : undefined;
+    if (terminal !== undefined) {
       activeTurnSnapshot = null;
       terminalDaemonTurnObserved = true;
       return;
@@ -902,6 +895,9 @@ export function createDaemonTuiSession<
       return;
     }
     if (terminalDaemonTurnObserved) return;
+    if (typeof turnId === "string" && turnId.length > 0) {
+      lastObservedTurnId = turnId;
+    }
     activeTurnSnapshot = {
       turnId:
         typeof turnId === "string" && turnId.length > 0
@@ -948,13 +944,12 @@ export function createDaemonTuiSession<
       runtimeSettingsAuthorityError = error;
       broadcastDaemonEvent({
         id: `daemon-runtime-settings-authority-failed-${Date.now()}`,
-        type: "error",
-        payload: {
-          cause: "runtime_settings_authority_gap",
+        ...createTurnFailedEvent({
+          turnId: activeTurnSnapshot?.turnId ?? "daemon-turn",
+          code: "runtime_settings_authority_gap",
           message: error.message,
-          terminal: true,
-          terminalSource: "runtime_settings_authority",
-        },
+          completedAt: Date.now(),
+        }),
       });
       const abortTerminal = (
         baseSession as AgenCTuiBridgeSession & {
@@ -984,13 +979,12 @@ export function createDaemonTuiSession<
     try {
       broadcastDaemonEvent({
         id: `daemon-runtime-settings-authority-failed-${Date.now()}`,
-        type: "error",
-        payload: {
-          cause: failureCause,
+        ...createTurnFailedEvent({
+          turnId: activeTurnSnapshot?.turnId ?? "daemon-turn",
+          code: failureCause,
           message: error.message,
-          terminal: true,
-          terminalSource: "runtime_settings_authority",
-        },
+          completedAt: Date.now(),
+        }),
       });
     } catch {
       // The authority fence and terminal abort below must survive UI listeners.
@@ -1036,6 +1030,9 @@ export function createDaemonTuiSession<
       mcpProjection,
       broadcastDaemonEvent,
       runtimeSettingsReconciler,
+      () => activeTurnSnapshot?.turnId === "daemon-turn"
+        ? lastObservedTurnId
+        : activeTurnSnapshot?.turnId ?? lastObservedTurnId,
     );
     const currentConnectionState = client.getConnectionState?.();
     if (
@@ -2515,6 +2512,7 @@ function subscribeToDaemonEvents(
   mcpProjection: DaemonMcpProjection,
   cb: (event: unknown) => void,
   runtimeSettingsReconciler?: RuntimeSettingsReconciler,
+  activeTurnId?: () => string | undefined,
 ): () => void {
   let replayingInitialEvents = true;
   const deliver = (event: JsonObject): void => {
@@ -2546,7 +2544,7 @@ function subscribeToDaemonEvents(
         mcpProjection.invalidate(event.params.revision);
         return;
       }
-      const transcriptEvent = toTranscriptEvent(event);
+      const transcriptEvent = toTranscriptEvent(event, activeTurnId?.());
       if (runtimeSettingsReconciler === undefined) {
         deliver(transcriptEvent);
       } else if (replayingInitialEvents) {
@@ -2835,7 +2833,7 @@ function baseInitialTranscriptEvents(
   ];
 }
 
-function toTranscriptEvent(event: JsonObject): JsonObject {
+function toTranscriptEvent(event: JsonObject, activeTurnId?: string): JsonObject {
   const msg = event.msg;
   if (isJsonObject(msg)) {
     return msg;
@@ -2946,7 +2944,7 @@ function toTranscriptEvent(event: JsonObject): JsonObject {
     };
   }
   if (method === "event.agent_status") {
-    return transcriptEventFromAgentStatus(params);
+    return transcriptEventFromAgentStatus(params, activeTurnId);
   }
   if (method === "event.session_event" && isJsonObject(params.event)) {
     return {
@@ -3073,26 +3071,22 @@ function nextRealtimeEventId(
   return `realtime:${method}:${String(threadId ?? "thread")}:${nextRealtimeTranscriptEventSequence}`;
 }
 
-function transcriptEventFromAgentStatus(params: JsonObject): JsonObject {
+function transcriptEventFromAgentStatus(params: JsonObject, activeTurnId?: string): JsonObject {
   const status = params.status;
   const turnId = stringParam(
     params.turnId,
-    stringParam(params.eventId, "status"),
+    activeTurnId ?? stringParam(params.eventId, "status"),
   );
   if (status === "error") {
+    const failed = createTurnFailedEvent({
+      turnId,
+      code: "background_agent_error",
+      message: typeof params.message === "string" ? params.message : "agent error",
+    });
     return {
       id: daemonTranscriptEventId(params, turnId),
-      type: "error",
-      payload: {
-        turnId,
-        message:
-          typeof params.message === "string" ? params.message : "agent error",
-        terminal: true,
-        terminalSource: "agent_status",
-        ...(typeof params.runStatus === "string"
-          ? { runStatus: params.runStatus }
-          : {}),
-      },
+      type: failed.type,
+      payload: { ...failed.payload },
     };
   }
   return {

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -2833,6 +2833,85 @@ function baseInitialTranscriptEvents(
   ];
 }
 
+function transcriptEventFromPermissionRequest(params: JsonObject): JsonObject | null {
+  if (typeof params.requestId !== "string") return null;
+  return {
+    id: daemonTranscriptEventId(
+      params,
+      `permission-request:${params.requestId}`,
+    ),
+    type: "request_permissions",
+    payload: {
+      callId: params.requestId,
+      ...(typeof params.toolName === "string"
+        ? { toolName: params.toolName }
+        : {}),
+      ...(typeof params.turnId === "string" ? { turnId: params.turnId } : {}),
+      permissions: Array.isArray(params.permissions)
+        ? params.permissions.filter(
+            (item): item is string => typeof item === "string",
+          )
+        : [],
+      ...(params.input !== undefined ? { input: params.input } : {}),
+      ...(typeof params.reason === "string" ? { reason: params.reason } : {}),
+      ...(typeof params.planContent === "string"
+        ? { planContent: params.planContent }
+        : {}),
+      ...(typeof params.planFilePath === "string"
+        ? { planFilePath: params.planFilePath }
+        : {}),
+    },
+  };
+}
+
+function transcriptEventFromUserInputRequest(params: JsonObject): JsonObject | null {
+  if (
+    typeof params.requestId !== "string" ||
+    typeof params.callId !== "string" ||
+    typeof params.turnId !== "string" ||
+    !Array.isArray(params.questions)
+  ) return null;
+  return {
+    id: daemonTranscriptEventId(
+      params,
+      `user-input-request:${params.requestId}`,
+    ),
+    type: "request_user_input",
+    payload: {
+      requestId: params.requestId,
+      callId: params.callId,
+      turnId: params.turnId,
+      questions: jsonObjectArray(params.questions),
+      ...(isJsonObject(params.clientAction)
+        ? { clientAction: params.clientAction }
+        : {}),
+    },
+  };
+}
+
+function transcriptEventFromMcpElicitationRequest(params: JsonObject): JsonObject | null {
+  if (
+    (typeof params.requestId !== "string" &&
+      typeof params.requestId !== "number") ||
+    typeof params.serverName !== "string" ||
+    typeof params.turnId !== "string" ||
+    !isJsonObject(params.request)
+  ) return null;
+  return {
+    id: daemonTranscriptEventId(
+      params,
+      `mcp-elicitation:${String(params.requestId)}`,
+    ),
+    type: "mcp_elicitation_request",
+    payload: {
+      requestId: params.requestId,
+      serverName: params.serverName,
+      turnId: params.turnId,
+      request: params.request,
+    },
+  };
+}
+
 function toTranscriptEvent(event: JsonObject, activeTurnId?: string): JsonObject {
   const msg = event.msg;
   if (isJsonObject(msg)) {
@@ -2865,83 +2944,14 @@ function toTranscriptEvent(event: JsonObject, activeTurnId?: string): JsonObject
       },
     };
   }
-  if (
-    method === "event.permission_request" &&
-    typeof params.requestId === "string"
-  ) {
-    return {
-      id: daemonTranscriptEventId(
-        params,
-        `permission-request:${params.requestId}`,
-      ),
-      type: "request_permissions",
-      payload: {
-        callId: params.requestId,
-        ...(typeof params.toolName === "string"
-          ? { toolName: params.toolName }
-          : {}),
-        ...(typeof params.turnId === "string" ? { turnId: params.turnId } : {}),
-        permissions: Array.isArray(params.permissions)
-          ? params.permissions.filter(
-              (item): item is string => typeof item === "string",
-            )
-          : [],
-        ...(params.input !== undefined ? { input: params.input } : {}),
-        ...(typeof params.reason === "string" ? { reason: params.reason } : {}),
-        ...(typeof params.planContent === "string"
-          ? { planContent: params.planContent }
-          : {}),
-        ...(typeof params.planFilePath === "string"
-          ? { planFilePath: params.planFilePath }
-          : {}),
-      },
-    };
+  if (method === "event.permission_request") {
+    return transcriptEventFromPermissionRequest(params) ?? event;
   }
-  if (
-    method === "event.user_input_request" &&
-    typeof params.requestId === "string" &&
-    typeof params.callId === "string" &&
-    typeof params.turnId === "string" &&
-    Array.isArray(params.questions)
-  ) {
-    return {
-      id: daemonTranscriptEventId(
-        params,
-        `user-input-request:${params.requestId}`,
-      ),
-      type: "request_user_input",
-      payload: {
-        requestId: params.requestId,
-        callId: params.callId,
-        turnId: params.turnId,
-        questions: jsonObjectArray(params.questions),
-        ...(isJsonObject(params.clientAction)
-          ? { clientAction: params.clientAction }
-          : {}),
-      },
-    };
+  if (method === "event.user_input_request") {
+    return transcriptEventFromUserInputRequest(params) ?? event;
   }
-  if (
-    method === "event.mcp_elicitation_request" &&
-    (typeof params.requestId === "string" ||
-      typeof params.requestId === "number") &&
-    typeof params.serverName === "string" &&
-    typeof params.turnId === "string" &&
-    isJsonObject(params.request)
-  ) {
-    return {
-      id: daemonTranscriptEventId(
-        params,
-        `mcp-elicitation:${String(params.requestId)}`,
-      ),
-      type: "mcp_elicitation_request",
-      payload: {
-        requestId: params.requestId,
-        serverName: params.serverName,
-        turnId: params.turnId,
-        request: params.request,
-      },
-    };
+  if (method === "event.mcp_elicitation_request") {
+    return transcriptEventFromMcpElicitationRequest(params) ?? event;
   }
   if (method === "event.agent_status") {
     return transcriptEventFromAgentStatus(params, activeTurnId);

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -2912,6 +2912,20 @@ function transcriptEventFromMcpElicitationRequest(params: JsonObject): JsonObjec
   };
 }
 
+function transcriptEventFromSessionEvent(params: JsonObject): JsonObject | null {
+  if (!isJsonObject(params.event)) return null;
+  return {
+    ...params.event,
+    ...(typeof params.eventId === "string" && params.eventId.length > 0
+      ? { eventId: params.eventId }
+      : {}),
+    id: daemonTranscriptEventId(
+      params,
+      typeof params.event.id === "string" ? params.event.id : "session-event",
+    ),
+  };
+}
+
 function toTranscriptEvent(event: JsonObject, activeTurnId?: string): JsonObject {
   const msg = event.msg;
   if (isJsonObject(msg)) {
@@ -2956,17 +2970,8 @@ function toTranscriptEvent(event: JsonObject, activeTurnId?: string): JsonObject
   if (method === "event.agent_status") {
     return transcriptEventFromAgentStatus(params, activeTurnId);
   }
-  if (method === "event.session_event" && isJsonObject(params.event)) {
-    return {
-      ...params.event,
-      ...(typeof params.eventId === "string" && params.eventId.length > 0
-        ? { eventId: params.eventId }
-        : {}),
-      id: daemonTranscriptEventId(
-        params,
-        typeof params.event.id === "string" ? params.event.id : "session-event",
-      ),
-    };
+  if (method === "event.session_event") {
+    return transcriptEventFromSessionEvent(params) ?? event;
   }
   return event;
 }

--- a/runtime/src/tui/daemon-terminal-error.ts
+++ b/runtime/src/tui/daemon-terminal-error.ts
@@ -1,7 +1,0 @@
-export function isTerminalDaemonErrorPayload(payload: unknown): boolean {
-  return (
-    payload !== null &&
-    typeof payload === "object" &&
-    (payload as { readonly terminal?: unknown }).terminal === true
-  );
-}

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -21,7 +21,7 @@ import {
   isPermissionDeniedToolResult,
   PERMISSION_DENIED_TOOL_RESULT_MESSAGE,
 } from "./tool-result-denial.js";
-import { isTerminalDaemonErrorPayload } from "./daemon-terminal-error.js";
+import { classifyTurnTerminal } from "../contracts/turn-terminal.js";
 import { escapeXml } from "../utils/xml.js";
 
 /**
@@ -2008,6 +2008,9 @@ export function adaptTranscriptEvents(
         lastThinkingText = "";
         break;
       case "turn_complete": {
+        if (classifyTurnTerminal(event, {
+          expectedTurnId: currentTurnId ?? undefined,
+        }) === undefined) break;
         const completionTimestamp =
           timestampFromUnixMillis(payload.completedAt) ?? currentTurnTimestamp ?? "";
         // `turn_complete` is the authoritative end of every provider stream.
@@ -2059,16 +2062,14 @@ export function adaptTranscriptEvents(
         suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
         isStreaming = false;
-        if (
-          typeof payload.turnId !== "string" ||
-          currentTurnId === null ||
-          payload.turnId === currentTurnId
-        ) {
-          currentTurnId = null;
-        }
+        currentTurnId = null;
         break;
       }
       case "turn_aborted":
+      case "turn_failed":
+        if (classifyTurnTerminal(event, {
+          expectedTurnId: currentTurnId ?? undefined,
+        }) === undefined) break;
         // Phase 5 #56: previously this case cleared `streamingText`
         // unconditionally, so any text the model had already
         // produced before the user pressed ESC was silently dropped
@@ -2096,13 +2097,7 @@ export function adaptTranscriptEvents(
         isStreaming = false;
         currentTurnTimestamp = undefined;
         currentTurnAssistantMessageIndexes = [];
-        if (
-          typeof payload.turnId !== "string" ||
-          currentTurnId === null ||
-          payload.turnId === currentTurnId
-        ) {
-          currentTurnId = null;
-        }
+        currentTurnId = null;
         // Clear streaming tool state on cancellation.
         // stream cancellation — any partially-streamed tool inputs are
         // abandoned because their completion events will never arrive
@@ -2111,7 +2106,9 @@ export function adaptTranscriptEvents(
         suppressedStreamingToolCallIds.clear();
         suppressedStreamingToolInputIndexes.clear();
         pendingToolInputDeltas.clear();
-        out.push(makeSystemMessage(`Turn aborted: ${stringResult(payload.reason)}`, "warning", nextUuid()));
+        out.push(event.type === "turn_failed"
+          ? makeSystemMessage(stringResult(payload.message), "error", nextUuid())
+          : makeSystemMessage(`Turn aborted: ${stringResult(payload.reason)}`, "warning", nextUuid()));
         break;
       case "execution_admission":
         // A denied model turn is the ONLY admission outcome a person must see:
@@ -2657,23 +2654,6 @@ export function adaptTranscriptEvents(
       case "error":
       case "stream_error":
         out.push(makeSystemMessage(stringResult(payload.message), "error", nextUuid()));
-        // Raw session errors are diagnostic events. Agent-status run failures
-        // carry an explicit terminal marker from the daemon adapter.
-        if (
-          event.type === "error" &&
-          !isTerminalDaemonErrorPayload(payload)
-        ) {
-          break;
-        }
-        persistAssistantText(streamingText, nextUuid);
-        streamingText = "";
-        streamingThinking = null;
-        streamingToolUses.length = 0;
-        suppressedStreamingToolCallIds.clear();
-        suppressedStreamingToolInputIndexes.clear();
-        pendingToolInputDeltas.clear();
-        isStreaming = false;
-        currentTurnId = null;
         break;
       case "slash_result": {
         // Format SlashCommandResult based on its kind instead of

--- a/runtime/tests/agents/status.test.ts
+++ b/runtime/tests/agents/status.test.ts
@@ -179,16 +179,23 @@ describe("agentStatusFromEvent (reference parity)", () => {
     expect(status?.status).toBe("errored");
   });
 
-  it("error event maps to errored with payload message", () => {
+  it("failed turns map to errored with their failure message", () => {
     const status = agentStatusFromEvent({
-      type: "error",
-      payload: { turnId: "t1", message: "boom" },
+      type: "turn_failed",
+      payload: { turnId: "t1", code: "provider_error", message: "boom" },
     });
     expect(status).toMatchObject({
       status: "errored",
       turnId: "t1",
       error: "boom",
     });
+  });
+
+  it("does not transition agent status on diagnostic errors", () => {
+    expect(agentStatusFromEvent({
+      type: "error",
+      payload: { turnId: "t1", cause: "stop_hook_threw", message: "boom" },
+    })).toBeUndefined();
   });
 
   it("unrelated event types return undefined (no transition)", () => {

--- a/runtime/tests/agents/thread-rollout-truncation.test.ts
+++ b/runtime/tests/agents/thread-rollout-truncation.test.ts
@@ -55,6 +55,16 @@ const rollback = (numTurns: number): RolloutItem => ({
 });
 
 describe("thread rollout truncation", () => {
+  it("preserves a failed-turn snapshot without adding a false interruption", () => {
+    const failure: RolloutItem = {
+      type: "event_msg",
+      payload: { id: "failure", msg: { type: "turn_failed", payload: { turnId: "failed-turn", code: "provider_error", message: "failed" } } },
+    };
+    const items = [response("user", "question"), turnStarted("failed-turn"), failure];
+    expect(forkSnapshotRollout(items, { kind: "interrupted" })).toEqual(items);
+    expect(forkSnapshotRollout(items, { kind: "truncate_before_nth_user_message", n: 1 })).toEqual(items);
+  });
+
   it("counts real user messages and trigger-turn assistant messages as fork turns", () => {
     const items: RolloutItem[] = [
       response("system", "system"),

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -9276,6 +9276,77 @@ describe("AgenC delegate background-agent runner", () => {
     expect(control.sendInput).not.toHaveBeenCalled();
   });
 
+  it.each(["completed", "errored"] as const)(
+    "[managed-thread] agrees on live and replayed %s turns after diagnostics",
+    async (outcome) => {
+      const conversationId = `session-explicit-${outcome}`;
+      const { runner, session, control, rolloutItems } = makeTopLevelRunner({ conversationId });
+      const notifications: unknown[] = [];
+      await runner.startAgent({ objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+      await runner.attachAgentSessionEvents(conversationId, {
+        sessionId: "session_1",
+        emit: (notification) => { notifications.push(notification); },
+      });
+      control.sendInput.mockImplementationOnce(async () => {
+        session.emit({ id: "start", msg: { type: "turn_started", payload: { turnId: "turn-1" } } });
+        session.emit({ id: "diagnostic", msg: { type: "error", payload: { turnId: "turn-1", cause: "stop_hook_threw", message: "hook failed" } } });
+        session.emit({ id: "stale", msg: { type: "turn_failed", payload: { turnId: "old-turn", code: "provider_error", message: "stale failure" } } });
+        session.emit({ id: "answer", msg: { type: "agent_message", payload: { message: "full answer" } } });
+        session.emit({ id: "tokens", msg: { type: "token_count", payload: { promptTokens: 4, completionTokens: 3, totalTokens: 7 } } });
+        session.emit({ id: "terminal", msg: outcome === "errored"
+          ? { type: "turn_failed", payload: { turnId: "turn-1", code: "provider_error", message: "provider failed" } }
+          : { type: "turn_complete", payload: { turnId: "turn-1", lastAgentMessage: "full answer" } },
+        });
+      });
+      const request = {
+        sessionId: "session_1", content: "retry me", originalContent: "retry me",
+        messageId: "explicit-message", streamId: "explicit-message",
+        acceptedAt: "2026-08-17T00:00:00.000Z",
+      };
+      const terminal = outcome === "errored"
+        ? { code: 1, message: "provider failed" }
+        : { code: 0, message: "full answer" };
+      await expect(runner.submitAgentMessage(conversationId, request)).resolves.toMatchObject({ terminal, turnId: "turn-1" });
+      await expect(runner.submitAgentMessage(conversationId, request)).resolves.toMatchObject({ disposition: "duplicate", duplicateState: "completed", terminal });
+      expect(control.sendInput).toHaveBeenCalledOnce();
+      await expect(runner.getAgentSnapshot(conversationId)).resolves.toMatchObject({ status: "idle" });
+      await expect(runner.getAgentSessionTranscriptV2(conversationId, { sessionId: "session_1" })).resolves.toMatchObject({
+        turnResults: [{ turnId: "turn-1", outcome, inputTokens: 4, outputTokens: 3, totalTokens: 7 }],
+        messages: [expect.objectContaining({ text: "retry me" }), expect.objectContaining({ text: "full answer" })],
+      });
+      if (outcome === "errored") {
+        expect(notifications).toContainEqual(expect.objectContaining({
+          method: "event.session_event",
+          params: expect.objectContaining({ event: expect.objectContaining({ type: "turn_failed", payload: expect.objectContaining({ turnId: "turn-1" }) }) }),
+        }));
+      }
+      const restored = makeTopLevelRunner({ conversationId, rolloutItems: [...rolloutItems] });
+      await restored.runner.startAgent({ objective: "restored", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+      await expect(restored.runner.submitAgentMessage(conversationId, request)).resolves.toMatchObject({ disposition: "duplicate", duplicateState: "completed", terminal });
+      expect(restored.control.sendInput).not.toHaveBeenCalled();
+      await expect(runner.submitAgentMessage(conversationId, { ...request, content: "next", originalContent: "next", messageId: "next-message", streamId: "next-message" })).resolves.toMatchObject({ disposition: "started" });
+    },
+  );
+
+  it.each([false, true])("[managed-thread] journals one failed terminal before run failure (already closed: %s)", async (alreadyClosed) => {
+    const conversationId = `session-terminal-once-${alreadyClosed}`;
+    const { runner, session, stub, rolloutItems, shutdown } = makeTopLevelRunner({ conversationId });
+    await runner.startAgent({ objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+    session.emit({ id: "started", msg: { type: "turn_started", payload: { turnId: "failed-turn" } } });
+    if (alreadyClosed) {
+      session.emit({ id: "failed", msg: { type: "turn_failed", payload: { turnId: "failed-turn", code: "turn_execution_failed", message: "failed" } } });
+    }
+    stub.pushStatus({ status: "errored", turnId: "failed-turn", error: "failed", endedAtMs: 1_500 });
+    await vi.waitFor(() => expect(shutdown).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(rolloutItems).toContainEqual(expect.objectContaining({ payload: expect.objectContaining({ msg: expect.objectContaining({ type: "run_terminal" }) }) })));
+    const events = rolloutItems.flatMap((item) => {
+      const candidate = item as { type: string; payload: { msg: { type: string } } };
+      return candidate.type === "event_msg" ? [candidate.payload.msg] : [];
+    });
+    expect(events.filter((event) => event.type === "turn_failed")).toHaveLength(1);
+    expect(events.findIndex((event) => event.type === "turn_failed")).toBeLessThan(events.findIndex((event) => event.type === "run_terminal"));
+  });
+
   it("[managed-thread] never attributes a later completed turn to a crashed submission", async () => {
     const event = (id: string, seq: number, msg: Record<string, unknown>) => ({
       type: "event_msg",

--- a/runtime/tests/app-server/transcript-v2.contract.test.ts
+++ b/runtime/tests/app-server/transcript-v2.contract.test.ts
@@ -10,6 +10,29 @@ function event(seq: number, eventId: string, msg: EventMsg): RolloutItem {
 }
 
 describe("session.transcript.v2 durable projection", () => {
+  it.each(["turn_failed", "background_agent_error", "review_task_failed"])(
+    "closes %s failures without a later completion and ignores stale identities",
+    (failureType) => {
+      const failure: EventMsg = failureType === "turn_failed"
+        ? { type: "turn_failed", payload: { turnId: "turn-1", code: "provider_error", message: "failed", completedAt: 1_500 } }
+        : { type: "error", payload: { turnId: "turn-1", cause: failureType, message: "failed" } };
+      const items = [
+        event(1, "user", { type: "user_message", payload: { message: "question", messageId: "client-1" } }),
+        event(2, "start", { type: "turn_started", payload: { turnId: "turn-1", startedAt: 1_000 } }),
+        event(3, "stale", { type: "turn_failed", payload: { turnId: "turn-old", code: "provider_error", message: "stale" } }),
+        event(4, "answer", { type: "agent_message", payload: { message: "partial answer" } }),
+        event(5, "usage", { type: "token_count", payload: { promptTokens: 5, completionTokens: 2, totalTokens: 7 } }),
+        event(6, "failure", failure),
+      ];
+      const snapshot = sessionTranscriptV2FromRollout(items, "session-1", "run-1");
+      expect(snapshot.turnResults).toEqual([expect.objectContaining({
+        turnId: "turn-1", outcome: "errored", committedSequence: 6,
+        inputTokens: 5, outputTokens: 2, totalTokens: 7,
+      })]);
+      expect(snapshot.messages.at(-1)).toMatchObject({ text: "partial answer", turnId: "turn-1" });
+    },
+  );
+
   it("keeps a migrated response_item prefix when canonical events are appended", () => {
     const prefix: RolloutItem[] = [
       {

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1852,6 +1852,48 @@ describe("main() smoke", () => {
     }
   });
 
+  it.each(["turn_complete", "turn_failed"])("oneShotCLI ignores diagnostics and settles on %s", async (terminalType) => {
+    const tmpHome = await mkdtemp(join(tmpdir(), "agenc-terminal-home-"));
+    const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-terminal-cwd-"));
+    const previousEnv = { ...process.env };
+    Object.assign(process.env, {
+      AGENC_HOME: tmpHome, AGENC_WORKSPACE: tmpCwd, AGENC_PROVIDER: "openai",
+      OPENAI_API_KEY: "stub-openai-key-for-test", AGENC_CLI_ENTRY_DISABLE: "1",
+    });
+    const notification = (id: string, type: string, payload: Record<string, unknown>) => ({
+      method: "event.session_event",
+      params: { sessionId: "session_terminal", turnId: "turn-1", eventId: id, event: { id, type, payload } },
+    });
+    installDaemonCliDepsForTest({
+      agentId: "agent_terminal", sessionId: "session_terminal", cwd: tmpCwd,
+      oneShotEvents: [
+        notification("diagnostic", "error", { turnId: "turn-1", cause: "stop_hook_threw", message: "diagnostic" }),
+        notification("stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" }),
+        notification("terminal", terminalType, terminalType === "turn_failed"
+          ? { turnId: "turn-1", code: "provider_error", message: "provider failed" }
+          : { turnId: "turn-1", lastAgentMessage: "full answer" }),
+      ],
+    });
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      trustWorkspaceForTest(tmpHome, tmpCwd);
+      expect(await oneShotCLI("work")).toBe(terminalType === "turn_failed" ? 1 : 0);
+      const output = [...stdoutSpy.mock.calls, ...stderrSpy.mock.calls].map(([chunk]) => String(chunk)).join("");
+      expect(output).toContain(terminalType === "turn_failed" ? "provider failed" : "full answer");
+      expect(output).not.toContain("stale failure");
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      for (const key of Object.keys(process.env)) {
+        if (!(key in previousEnv)) delete process.env[key];
+      }
+      Object.assign(process.env, previousEnv);
+      await rm(tmpHome, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
+    }
+  });
+
   it("oneShotCLI DENIES an unanswerable permission request and terminates instead of hanging", async () => {
     // Regression for the non-interactive one-shot deadlock: the daemon forces
     // --autonomous, so any tool the model invokes that is not on the (empty by

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1860,15 +1860,17 @@ describe("main() smoke", () => {
       AGENC_HOME: tmpHome, AGENC_WORKSPACE: tmpCwd, AGENC_PROVIDER: "openai",
       OPENAI_API_KEY: "stub-openai-key-for-test", AGENC_CLI_ENTRY_DISABLE: "1",
     });
-    const notification = (id: string, type: string, payload: Record<string, unknown>) => ({
+    const notification = (id: string, type: string, payload: Record<string, unknown>, turnId = "turn-1") => ({
       method: "event.session_event",
-      params: { sessionId: "session_terminal", turnId: "turn-1", eventId: id, event: { id, type, payload } },
+      params: { sessionId: "session_terminal", turnId, eventId: id, event: { id, type, payload } },
     });
     installDaemonCliDepsForTest({
       agentId: "agent_terminal", sessionId: "session_terminal", cwd: tmpCwd,
       oneShotEvents: [
+        notification("started", "turn_started", { turnId: "turn-1" }),
         notification("diagnostic", "error", { turnId: "turn-1", cause: "stop_hook_threw", message: "diagnostic" }),
         notification("stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" }),
+        notification("consistent-stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" }, "old-turn"),
         notification("terminal", terminalType, terminalType === "turn_failed"
           ? { turnId: "turn-1", code: "provider_error", message: "provider failed" }
           : { turnId: "turn-1", lastAgentMessage: "full answer" }),

--- a/runtime/tests/bin/agenc.test.ts
+++ b/runtime/tests/bin/agenc.test.ts
@@ -1852,7 +1852,12 @@ describe("main() smoke", () => {
     }
   });
 
-  it.each(["turn_complete", "turn_failed"])("oneShotCLI ignores diagnostics and settles on %s", async (terminalType) => {
+  it.each([
+    ["turn_complete", "turn_started"],
+    ["turn_failed", "turn_started"],
+    ["turn_complete", "agent_status"],
+    ["turn_failed", "agent_status"],
+  ])("oneShotCLI ignores diagnostics and settles on %s after stale %s", async (terminalType, staleStartType) => {
     const tmpHome = await mkdtemp(join(tmpdir(), "agenc-terminal-home-"));
     const tmpCwd = await mkdtemp(join(tmpdir(), "agenc-terminal-cwd-"));
     const previousEnv = { ...process.env };
@@ -1868,6 +1873,9 @@ describe("main() smoke", () => {
       agentId: "agent_terminal", sessionId: "session_terminal", cwd: tmpCwd,
       oneShotEvents: [
         notification("started", "turn_started", { turnId: "turn-1" }),
+        staleStartType === "turn_started"
+          ? notification("stale-start", "turn_started", { turnId: "old-turn" }, "old-turn")
+          : { method: "event.agent_status", params: { sessionId: "session_terminal", turnId: "old-turn", status: "running" } },
         notification("diagnostic", "error", { turnId: "turn-1", cause: "stop_hook_threw", message: "diagnostic" }),
         notification("stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" }),
         notification("consistent-stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" }, "old-turn"),

--- a/runtime/tests/bin/bootstrap.test.ts
+++ b/runtime/tests/bin/bootstrap.test.ts
@@ -840,6 +840,18 @@ describe("bootstrapLocalRuntimeSession", () => {
           { turnId: "turn-1", lastAgentMessage: "done" },
           firstEventSequence + 5,
         ),
+        rolloutEvent(
+          "failed-turn-start",
+          "turn_started",
+          { turnId: "turn-2" },
+          firstEventSequence + 6,
+        ),
+        rolloutEvent(
+          "failed-turn-end",
+          "turn_failed",
+          { turnId: "turn-2", code: "provider_error", message: "provider failed" },
+          firstEventSequence + 7,
+        ),
       ]) {
         first.rolloutStore.appendRollout(event);
       }
@@ -880,11 +892,14 @@ describe("bootstrapLocalRuntimeSession", () => {
           "assistant_thinking_block_stop",
           "agent_thinking",
           "turn_complete",
+          "turn_failed",
         ]),
       );
       const transcript = adaptTranscriptEvents(
         initialTranscriptEvents as Parameters<typeof adaptTranscriptEvents>[0],
       );
+      expect(transcript.isStreaming).toBe(false);
+      expect(JSON.stringify(transcript.messages)).toContain("provider failed");
       expect(
         transcript.messages.some(
           (message) =>

--- a/runtime/tests/contracts/turn-terminal.test.ts
+++ b/runtime/tests/contracts/turn-terminal.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { isDurableEvent, isKnownEventType } from "../../src/session/event-log.js";
+import { isCanonicalEventPayload } from "../../src/state/recovery-journal-schema.js";
+import {
+  classifyTurnTerminal,
+  createTurnFailedEvent,
+  MAX_TURN_FAILURE_MESSAGE_LENGTH,
+} from "../../src/contracts/turn-terminal.js";
+
+describe("turn terminal classification", () => {
+  it("recognizes failed turns as durable journal events", () => {
+    const msg = createTurnFailedEvent({
+      turnId: "turn-1", code: "provider_error", message: "provider disconnected",
+    });
+    expect(isKnownEventType(msg.type)).toBe(true);
+    expect(isDurableEvent({ id: "failure-event", msg })).toBe(true);
+    expect(isCanonicalEventPayload(msg.type, msg.payload)).toBe(true);
+  });
+
+  it.each([
+    { turnId: "" },
+    { code: "invalid code" },
+    { message: "x".repeat(MAX_TURN_FAILURE_MESSAGE_LENGTH + 1) },
+    { completedAt: -1 },
+    { durationMs: Number.NaN },
+  ])("rejects invalid durable failure fields %j", (fields) => {
+    expect(isCanonicalEventPayload("turn_failed", {
+      turnId: "turn-1", code: "provider_error", message: "failed", ...fields,
+    })).toBe(false);
+  });
+
+  it.each(["stop_hook_threw", "compact_failed", "editor_policy", "background_agent_error"])(
+    "keeps live %s errors non-terminal",
+    (cause) => {
+      expect(classifyTurnTerminal({
+        type: "error",
+        payload: { turnId: "turn-1", cause, message: "diagnostic" },
+      })).toBeUndefined();
+    },
+  );
+
+  it("keeps diagnostics open until the later successful completion", () => {
+    const events = [
+      { type: "error", payload: { cause: "stop_hook_threw", message: "hook failed" } },
+      { type: "agent_message", payload: { message: "full answer" } },
+      { type: "token_count", payload: { totalTokens: 42 } },
+      { type: "turn_complete", payload: { turnId: "turn-1", lastAgentMessage: "full answer" } },
+    ];
+    expect(events.flatMap((event) => {
+      const terminal = classifyTurnTerminal(event, { expectedTurnId: "turn-1" });
+      return terminal === undefined ? [] : [terminal];
+    })).toEqual([{ outcome: "completed", code: 0, turnId: "turn-1", message: "full answer" }]);
+  });
+
+  it("classifies an explicit failure without requiring another terminal event", () => {
+    const event = createTurnFailedEvent({
+      turnId: "turn-1", code: "provider_error", message: "provider disconnected",
+      completedAt: 120, durationMs: 20,
+    });
+    expect(classifyTurnTerminal(event, { expectedTurnId: "turn-1" })).toEqual({
+      outcome: "errored", code: 1, failureCode: "provider_error", turnId: "turn-1",
+      message: "provider disconnected", completedAt: 120, durationMs: 20,
+    });
+  });
+
+  it.each(["turn_complete", "turn_aborted", "turn_failed"])(
+    "rejects mismatched %s turn identities",
+    (type) => {
+      const event = { type, payload: { turnId: "turn-2", code: "provider_error", message: "failed" } };
+      expect(classifyTurnTerminal(event, { expectedTurnId: "turn-1" })).toBeUndefined();
+      expect(classifyTurnTerminal({ ...event, turnId: "turn-1" })).toBeUndefined();
+    },
+  );
+
+  it("preserves legacy unscoped aborts but requires scoped completion identities", () => {
+    expect(classifyTurnTerminal({ type: "turn_aborted", payload: { reason: "cancelled" } }, {
+      expectedTurnId: "turn-1",
+    })).toEqual({ outcome: "aborted", code: 130, message: "cancelled" });
+    expect(classifyTurnTerminal({ type: "turn_complete", payload: {} }, {
+      expectedTurnId: "turn-1",
+    })).toBeUndefined();
+  });
+
+  it.each(["background_agent_error", "review_task_failed"])("reads legacy %s only when journal compatibility is enabled", (cause) => {
+    const event = { type: "error", payload: {
+      turnId: "turn-1", cause, message: "legacy failure",
+    } };
+    expect(classifyTurnTerminal(event, { legacyJournal: true })).toMatchObject({
+      outcome: "errored", code: 1, failureCode: cause, turnId: "turn-1",
+    });
+    expect(classifyTurnTerminal(event, { legacyJournal: true, expectedTurnId: "turn-2" })).toBeUndefined();
+    expect(classifyTurnTerminal({ ...event, payload: { ...event.payload, turnId: undefined } }, {
+      legacyJournal: true,
+    })).toBeUndefined();
+    expect(classifyTurnTerminal({ ...event, payload: { ...event.payload, cause: "stop_hook_threw" } }, {
+      legacyJournal: true,
+    })).toBeUndefined();
+  });
+
+  it.each([
+    undefined, null, [], {},
+    { turnId: "turn-1", code: "bad code", message: "failed" },
+    { turnId: "turn-1", code: "provider_error", message: 1 },
+    { turnId: "", code: "provider_error", message: "failed" },
+  ])("rejects malformed failure payload %j", (payload) => {
+    expect(classifyTurnTerminal({ type: "turn_failed", payload })).toBeUndefined();
+  });
+
+  it("bounds new journal and projected failure messages and drops invalid timing", () => {
+    const payload = {
+      turnId: "turn-1", code: "provider_error", message: "x".repeat(10_000),
+      completedAt: Number.NaN, durationMs: -1,
+    };
+    const event = createTurnFailedEvent(payload);
+    expect(event.payload.message).toHaveLength(MAX_TURN_FAILURE_MESSAGE_LENGTH);
+    expect(event.payload).not.toHaveProperty("completedAt");
+    expect(event.payload).not.toHaveProperty("durationMs");
+    expect(classifyTurnTerminal({ type: "turn_failed", payload })?.message)
+      .toHaveLength(MAX_TURN_FAILURE_MESSAGE_LENGTH);
+    expect(() => createTurnFailedEvent({ ...payload, turnId: "" })).toThrow(TypeError);
+    expect(() => createTurnFailedEvent({ ...payload, code: "bad code" })).toThrow(TypeError);
+  });
+});

--- a/runtime/tests/sdk-package/events.contract.test.ts
+++ b/runtime/tests/sdk-package/events.contract.test.ts
@@ -1,8 +1,46 @@
 import { describe, expect, it } from "vitest";
 
-import { promptEventFromNotification } from "../../../packages/agenc-sdk/src/events";
+import {
+  promptEventFromNotification,
+  terminalStatusFromNotification,
+} from "../../../packages/agenc-sdk/src/events";
 
 describe("agenc-sdk prompt event mapping", () => {
+  it("rejects conflicting outer and failed-turn identities", () => {
+    expect(terminalStatusFromNotification({
+      method: "event.session_event",
+      params: {
+        turnId: "current-turn",
+        event: { type: "turn_failed", payload: { turnId: "stale-turn", code: "provider_error", message: "stale" } },
+      },
+    })).toBeNull();
+  });
+
+  it("keeps diagnostics non-terminal and recognizes explicit failed turns", () => {
+    const notification = {
+      method: "event.session_event",
+      params: { event: {
+        type: "error",
+        payload: { turnId: "turn-1", cause: "stop_hook_threw", message: "diagnostic" },
+      } },
+    };
+    expect(terminalStatusFromNotification(notification)).toBeNull();
+    expect(terminalStatusFromNotification({
+      ...notification,
+      params: { event: {
+        type: "turn_failed",
+        payload: { turnId: "turn-1", code: "provider_error", message: "failed" },
+      } },
+    })).toEqual({ code: 1, message: "failed" });
+    expect(terminalStatusFromNotification({
+      ...notification,
+      params: { event: {
+        type: "turn_complete",
+        payload: { turnId: "turn-1", lastAgentMessage: "full answer" },
+      } },
+    })).toEqual({ code: 0, message: "full answer" });
+  });
+
   it("preserves a replay-required gap when the retired count is no longer known", () => {
     const notification = {
       method: "event.event_gap",

--- a/runtime/tests/sdk-package/events.contract.test.ts
+++ b/runtime/tests/sdk-package/events.contract.test.ts
@@ -6,6 +6,18 @@ import {
 } from "../../../packages/agenc-sdk/src/events";
 
 describe("agenc-sdk prompt event mapping", () => {
+  it("correlates consistent stale failures against the caller's active turn", () => {
+    const notification = {
+      method: "event.session_event",
+      params: {
+        turnId: "stale-turn",
+        event: { type: "turn_failed", payload: { turnId: "stale-turn", code: "provider_error", message: "stale" } },
+      },
+    };
+    expect(terminalStatusFromNotification(notification, "current-turn")).toBeNull();
+    expect(terminalStatusFromNotification(notification, "stale-turn")).toEqual({ code: 1, message: "stale" });
+  });
+
   it("rejects conflicting outer and failed-turn identities", () => {
     expect(terminalStatusFromNotification({
       method: "event.session_event",

--- a/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
+++ b/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
@@ -736,11 +736,12 @@ describe("agenc-sdk prompt race safety", () => {
     const send = await waitForSend(transport, 0);
     transport.emit(userMessage("failure-message"));
     transport.emit(turnStarted("turn-failure"));
-    const emit = (id: string, type: string, payload: JsonObject) => transport.emit({
+    const emit = (id: string, type: string, payload: JsonObject, turnId = "turn-failure") => transport.emit({
       jsonrpc: "2.0", method: "event.session_event",
-      params: { sessionId: "session_1", turnId: "turn-failure", eventId: id, event: { id, type, payload } },
+      params: { sessionId: "session_1", turnId, eventId: id, event: { id, type, payload } },
     });
     emit("stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" });
+    emit("consistent-stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" }, "old-turn");
     emit("diagnostic", "error", { turnId: "turn-failure", cause: "stop_hook_threw", message: "diagnostic" });
     transport.emit(text("turn-failure", "partial answer"));
     emit("failed", "turn_failed", { turnId: "turn-failure", code: "provider_error", message: "provider failed" });

--- a/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
+++ b/runtime/tests/sdk-package/prompt-race-safety.contract.test.ts
@@ -729,6 +729,33 @@ describe("agenc-sdk prompt race safety", () => {
     ).toEqual([expect.objectContaining({ text: "haha" })]);
   });
 
+  it("keeps diagnostics and stale failures open, then returns the explicit failure", async () => {
+    const transport = new PromptTransport();
+    const client = await initializedClient(transport);
+    const run = client.runPrompt("session_1", "work", { clientMessageId: "failure-message", includeUsage: false });
+    const send = await waitForSend(transport, 0);
+    transport.emit(userMessage("failure-message"));
+    transport.emit(turnStarted("turn-failure"));
+    const emit = (id: string, type: string, payload: JsonObject) => transport.emit({
+      jsonrpc: "2.0", method: "event.session_event",
+      params: { sessionId: "session_1", turnId: "turn-failure", eventId: id, event: { id, type, payload } },
+    });
+    emit("stale", "turn_failed", { turnId: "old-turn", code: "provider_error", message: "stale failure" });
+    emit("diagnostic", "error", { turnId: "turn-failure", cause: "stop_hook_threw", message: "diagnostic" });
+    transport.emit(text("turn-failure", "partial answer"));
+    emit("failed", "turn_failed", { turnId: "turn-failure", code: "provider_error", message: "provider failed" });
+    resolveSend(send, "turn-failure");
+    await expect(run.result()).resolves.toMatchObject({ stopReason: "errored", exitCode: 1, finalMessage: "provider failed" });
+    const events: AgencPromptEvent[] = [];
+    for await (const event of run) events.push(event);
+    expect(events).toContainEqual(expect.objectContaining({ type: "text", delta: "partial answer" }));
+    const next = client.runPrompt("session_1", "next", { clientMessageId: "next-message", includeUsage: false });
+    const nextSend = await waitForSend(transport, 1);
+    resolveSend(nextSend, "next-turn");
+    await expect(next.result()).resolves.toMatchObject({ exitCode: 0 });
+    await client.close();
+  });
+
   it("never sends or cancels when an AbortSignal is already aborted", async () => {
     const transport = new PromptTransport();
     const client = await initializedClient(transport);

--- a/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
+++ b/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   parseSdkGeneratedTypesMode,
   synchronizeTranscriptV2Generated,
+  synchronizeTurnTerminalGenerated,
 } from "../../scripts/check-sdk-generated-types.mjs";
 
 const temporaryRoots: string[] = [];
@@ -121,6 +122,31 @@ async function createCanonicalFixture() {
 }
 
 describe("SDK generated transcript v2 script", () => {
+  it("checks the terminal classifier implementation as well as its types", async () => {
+    const source = "export const terminalCode = 1;\n";
+    const fixture = await createFixture(source);
+    const options = {
+      canonicalPath: fixture.protocolPath,
+      generatedPath: fixture.generatedPath,
+    };
+    expect(await synchronizeTurnTerminalGenerated(options)).toMatchObject({
+      changed: false, matches: false,
+    });
+    expect(await readFile(fixture.generatedPath, "utf8")).toBe("stale generated output\n");
+    expect(await synchronizeTurnTerminalGenerated({ ...options, write: true })).toMatchObject({
+      changed: true, matches: true,
+    });
+    expect(await readFile(fixture.generatedPath, "utf8")).toBe(source);
+    expect(await synchronizeTurnTerminalGenerated({ ...options, write: true })).toMatchObject({
+      changed: false, matches: true,
+    });
+    await writeFile(fixture.generatedPath, source.replace("= 1", "= 0"));
+    expect(await synchronizeTurnTerminalGenerated(options)).toMatchObject({
+      changed: false, matches: false,
+    });
+    expect(await readFile(fixture.generatedPath, "utf8")).toBe(source.replace("= 1", "= 0"));
+  });
+
   it("keeps check mode as the default and requires an explicit write flag", () => {
     expect(parseSdkGeneratedTypesMode([])).toBe("check");
     expect(parseSdkGeneratedTypesMode(["--write"])).toBe("write");

--- a/runtime/tests/session/event-log.test.ts
+++ b/runtime/tests/session/event-log.test.ts
@@ -372,7 +372,7 @@ describe("I-8 emitError helper", () => {
 
 describe("I-26 forward-compat + schema version", () => {
   test("KNOWN_EVENT_TYPES contains all known variants", () => {
-    expect(KNOWN_EVENT_TYPES.size).toBe(82);
+    expect(KNOWN_EVENT_TYPES.size).toBe(83);
     expect(isKnownEventType("entered_review_mode")).toBe(true);
     expect(isKnownEventType("run_suspended")).toBe(true);
     expect(isKnownEventType("run_resumed")).toBe(true);

--- a/runtime/tests/session/review.test.ts
+++ b/runtime/tests/session/review.test.ts
@@ -25,7 +25,8 @@
  * across the session-kernel test suites.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as reviewDelegate from "./agenc-delegate.js";
 
 import { AsyncQueue } from "../utils/async-queue.js";
 import { createTestConfigStore } from "../fixtures.js";
@@ -326,6 +327,28 @@ describe("isTaskKindSteerable — Item 6 gate classification", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("spawnReviewTask registry lifecycle", () => {
+  it.each(["throw", "outcome"])("writes one explicit failed review terminal (%s)", async (failurePath) => {
+    const session = mkSession();
+    const store = mountTestRollout(session);
+    const delegate = vi.spyOn(reviewDelegate, "runAgenCReviewOneShot");
+    const failure = new Error("review failed");
+    if (failurePath === "throw") delegate.mockRejectedValue(failure);
+    else delegate.mockResolvedValue({ verdict: "fail", output: emptyReviewOutput(), rawText: null, modelUsed: "test-model", error: failure });
+    try {
+      const review = await spawnReviewTask(session, { subId: "failed-review", request: mkReviewRequest() });
+      expect(await review.outcome === null).toBe(failurePath === "throw");
+      await review.done;
+      const terminals = store.readAll().flatMap((item) => item.type === "event_msg" && item.payload.msg.type === "turn_failed" ? [item.payload.msg] : []);
+      expect(terminals).toEqual([{
+        type: "turn_failed",
+        payload: { turnId: "failed-review", code: "review_task_failed", message: "review failed", completedAt: expect.any(Number), durationMs: expect.any(Number) },
+      }]);
+      expect(session.activeTurn.unsafePeek()).toBeNull();
+    } finally {
+      delegate.mockRestore();
+    }
+  });
+
   it("registers a task with kind === 'review' in the session's activeTurn", async () => {
     const session = mkSession();
     const spawned = await spawnReviewTask(session, {

--- a/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
+++ b/runtime/tests/session/rollout-reconstruction.durable-resume.test.ts
@@ -349,6 +349,17 @@ describe("reconstruction durable resume descriptors", () => {
     expect(synthTypes).toContain("warning");
   });
 
+  test("failed turns are not recovered as process-killed orphans", () => {
+    const items: RolloutItem[] = [
+      { type: "event_msg", payload: { id: "start", seq: 1, msg: { type: "turn_started", payload: { turnId: "failed-turn" } } } },
+      { type: "event_msg", payload: { id: "failure", seq: 2, msg: { type: "turn_failed", payload: { turnId: "failed-turn", code: "provider_error", message: "failed" } } } },
+    ];
+    const result = reconstruct(items);
+    expect(result.orphanedTurnIds).toEqual([]);
+    expect(result.resumableTurns).toEqual([]);
+    expect(result.synthesizedEvents).toEqual([]);
+  });
+
   test("dangling tool_use in the checkpoint prefix is surfaced", () => {
     const buildId = pinBuild("build-A");
     const prefix: ResponseItem[] = [

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -5534,15 +5534,20 @@ describe("runTurn — D1 isRetryableStreamError type-based discrimination", () =
         },
       }),
     );
-    // The turn still closes its boundary, but as what it is: an errored
-    // turn emits `turn_aborted` with the reason instead of the
-    // success-shaped `turn_complete`, which used to make a failed turn
-    // replay to clients as a completed one with an empty answer.
-    expect(events).toContainEqual(
+    expect(events.filter((event) => event.msg.type === "turn_failed")).toEqual([
       expect.objectContaining({
-        msg: expect.objectContaining({ type: "turn_aborted" }),
+        msg: {
+          type: "turn_failed",
+          payload: expect.objectContaining({
+            turnId: mkCtx().subId,
+            code: "turn_execution_failed",
+            message: expect.any(String),
+            completedAt: expect.any(Number),
+          }),
+        },
       }),
-    );
+    ]);
+    expect(events.some((event) => event.msg.type === "turn_aborted")).toBe(false);
     expect(events).not.toContainEqual(
       expect.objectContaining({
         msg: expect.objectContaining({ type: "turn_complete" }),

--- a/runtime/tests/session/trajectory-curate.test.ts
+++ b/runtime/tests/session/trajectory-curate.test.ts
@@ -143,6 +143,15 @@ describe("parseTrajectoryExportContents", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("classifyTrajectory filtering", () => {
+  test("rejects explicit failed turns even when an earlier turn completed", () => {
+    const result = classifyTrajectory([
+      turnComplete("completed-turn"),
+      eventItem({ type: "turn_failed", payload: { turnId: "failed-turn", code: "provider_error", message: "failed" } }),
+    ]);
+    expect(result.hasErrorEvent).toBe(true);
+    expect(isSftEligible(result)).toBe(false);
+  });
+
   test("a clean completed session is SFT eligible", () => {
     const c = classifyTrajectory(cleanSessionItems());
     expect(c.hasTurnComplete).toBe(true);

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -841,7 +841,7 @@ describe("strict canonical journal contract", () => {
   });
 
   it("keeps an exhaustive fail-closed schema for every known event discriminant", () => {
-    expect(KNOWN_EVENT_TYPES.size).toBe(82);
+    expect(KNOWN_EVENT_TYPES.size).toBe(83);
     expect(CANONICAL_EVENT_SCHEMA_TYPES).toEqual([...KNOWN_EVENT_TYPES].sort());
     expect(CANONICAL_EVENT_SCHEMA_TYPES).toEqual(
       expect.arrayContaining(["run_suspended", "run_resumed"]),

--- a/runtime/tests/tui/daemon-session.ihunt-error-clears-active-turn.test.ts
+++ b/runtime/tests/tui/daemon-session.ihunt-error-clears-active-turn.test.ts
@@ -159,7 +159,33 @@ function createClient(): AgenCDaemonTuiClient & {
 }
 
 describe("daemon session activeTurn error handling (ihunt)", () => {
-  it("clears activeTurn when the daemon agent/turn reports an error status", async () => {
+  it("closes only the matching explicit failed turn and permits the next turn", () => {
+    const client = createClient();
+    const session = createDaemonTuiSession({ baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1" });
+    const unsubscribe = session.subscribeToEvents(() => undefined);
+    const emit = (id: string, type: string, payload: JsonObject) => client.emit("session_1", {
+      method: "event.session_event", params: { eventId: id, event: { id, type, payload } },
+    });
+    emit("start", "turn_started", { turnId: "turn-1" });
+    emit("diagnostic", "error", { turnId: "turn-1", cause: "stop_hook_threw", message: "diagnostic" });
+    expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "turn-1" });
+    emit("stale", "turn_failed", { turnId: "turn-old", code: "provider_error", message: "stale" });
+    expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "turn-1" });
+    emit("failure", "turn_failed", { turnId: "turn-1", code: "provider_error", message: "failed" });
+    expect(session.activeTurn?.unsafePeek()).toBeNull();
+    emit("next", "turn_started", { turnId: "turn-2" });
+    expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "turn-2" });
+    client.emit("session_1", { method: "event.agent_status", params: { eventId: "idle-step", turnId: "turn-2", status: "idle" } });
+    const observed: unknown[] = [];
+    const unsubscribeObserved = session.subscribeToEvents((event) => observed.push(event));
+    client.emit("session_1", { method: "event.agent_status", params: { eventId: "run-failure", status: "error", message: "run failed" } });
+    expect(observed).toContainEqual(expect.objectContaining({ type: "turn_failed", payload: expect.objectContaining({ turnId: "turn-2" }) }));
+    expect(session.activeTurn?.unsafePeek()).toBeNull();
+    unsubscribeObserved();
+    unsubscribe();
+  });
+
+  it.each([false, true])("clears activeTurn on an agent failure (turn-scoped: %s)", async (turnScoped) => {
     const client = createClient();
     const session = createDaemonTuiSession({
       baseSession: createBaseSession(),
@@ -185,16 +211,11 @@ describe("daemon session activeTurn error handling (ihunt)", () => {
     });
     expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "turn_1" });
 
-    // A mid-turn failure arrives as event.agent_status { status: "error" },
-    // which the bridge rewrites into a transcript event with type "error"
-    // (NOT background_agent_status). Before the fix, noteDaemonActivity ignored
-    // this event and left activeTurnSnapshot set forever, permanently blocking
-    // /rewind and /compact-from-message.
     client.emit("session_1", {
       method: "event.agent_status",
       params: {
         eventId: "status_2",
-        turnId: "turn_1",
+        ...(turnScoped ? { turnId: "turn_1" } : {}),
         status: "error",
         message: "provider API error",
       },

--- a/runtime/tests/tui/session-transcript.error-ends-turn.test.ts
+++ b/runtime/tests/tui/session-transcript.error-ends-turn.test.ts
@@ -2,16 +2,13 @@ import { describe, expect, test } from "vitest";
 
 import { adaptTranscriptEvents } from "./session-transcript.js";
 
-// Audit finding #13: agent_status:error is translated into a terminal-marked
-// transcript error. The reducer must clear streaming for that event while
-// leaving unmarked session diagnostics inside the active turn.
-describe("error events end the streaming turn", () => {
+describe("explicit failures end the streaming turn", () => {
   const turnStart = {
     type: "turn_started",
     payload: { turnId: "turn-1" },
   } as never;
 
-  test("`error` clears isStreaming and preserves partial text", () => {
+  test("`turn_failed` clears isStreaming and preserves partial text", () => {
     const transcript = adaptTranscriptEvents([
       turnStart,
       {
@@ -19,12 +16,12 @@ describe("error events end the streaming turn", () => {
         payload: { content: "partial answ" },
       } as never,
       {
-        type: "error",
+        type: "turn_failed",
         payload: {
+          turnId: "turn-1",
+          code: "background_agent_error",
           message:
             "openai-compatible error: fetch failed [openai_category=connection_refused]",
-          terminal: true,
-          terminalSource: "agent_status",
         },
       } as never,
     ]);
@@ -35,7 +32,7 @@ describe("error events end the streaming turn", () => {
     expect(rendered).toContain("partial answ");
   });
 
-  test("`stream_error` clears isStreaming", () => {
+  test("`stream_error` keeps a retrying stream active", () => {
     const transcript = adaptTranscriptEvents([
       turnStart,
       {
@@ -44,7 +41,7 @@ describe("error events end the streaming turn", () => {
       } as never,
     ]);
 
-    expect(transcript.isStreaming).toBe(false);
+    expect(transcript.isStreaming).toBe(true);
   });
 
   test("`error` with stream_disconnected cause keeps the turn streaming", () => {

--- a/runtime/tests/tui/session-transcript.streaming-identity.test.ts
+++ b/runtime/tests/tui/session-transcript.streaming-identity.test.ts
@@ -102,17 +102,12 @@ describe("session transcript streaming identity (M-TUI-1)", () => {
   });
 
   test("one event fanning out to several messages gets collision-free per-event block indices", () => {
-    // A terminal `error` event mid-stream projects TWO messages from the same
-    // source event: the error row itself and the preserved partial assistant
-    // text. Only the daemon's terminal marker ends the turn; a bare session
-    // error is diagnostic and leaves the stream open (#1978), so it projects
-    // one row and keeps the partial text in the accumulator.
     const events = [
       { id: "turn", msg: { type: "turn_started", payload: { turnId: "t1" } } } as never,
       deltaEvent("delta-0", "partial "),
       {
         id: "err",
-        msg: { type: "error", payload: { message: "boom", terminal: true } },
+        msg: { type: "turn_failed", payload: { turnId: "t1", code: "provider_error", message: "boom" } },
       } as never,
     ];
 


### PR DESCRIPTION
## Changes

- Add durable `turn_failed` with a bounded message, stable failure code, turn identity, and optional completion timing.
- Keep diagnostic `error` and retrying `stream_error` events non-terminal. Share terminal classification across runtime, daemon, replay, TUI, CLI, and an exactly checked SDK copy.
- Write explicit kernel, review-task, and background-thread failures. Close an open turn before fatal run finalization without duplicating a terminal already written by the kernel.
- Keep reusable daemon sessions promptable after failed turns. Preserve stale event identities so an older failure cannot settle the current request.
- Update bootstrap replay, fork snapshots, trajectory filtering, log rendering, and the documented two-shape legacy journal rule.

## Local validation

- Runtime, test-support, and SDK typechecks pass; SDK generation check and runtime/SDK builds pass.
- 855 targeted tests across 32 files pass. The final review-outcome addition passes all 59 review tests. Additional bootstrap/reconstruction checks pass 86 tests.
- Agent-surface contract passes. Three temporary mutations reproduce failures for the old kernel terminal, diagnostic-as-terminal classification, and omitted failed-run closure. All mutated sources were restored byte-for-byte.
- The full local suite passes 23,439 runtime tests. Its sole failure is the FND receipt's stale production-module closure, expected after the event contract changes. The receipt requires a source revision already on the default branch, so a follow-up artifact PR will capture the merged source and rerun the full suite before closing #1938. No provenance or test rule is weakened.
- Rebuilt TUI startup checks pass at all required viewports. Review regression probes fail against the old self-correlated SDK/CLI behavior. The corrected SDK mapper accepts the caller's active turn ID, and the CLI tracks the started turn before accepting a terminal. Focused SDK/CLI/generator checks pass 154 tests.
- GitNexus reports high risk across durable turn writes and replay. No hosted Actions workflows were enabled, dispatched, or rerun. Darwin and Windows execution is not claimed.

Related PR #2037 belongs to another contributor and remains untouched.

Part of #1938. Keep the issue open until the benchmark follow-up and final validation pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes durable turn boundaries, idempotent message retry semantics, and shared SDK/runtime classification across daemon, TUI, CLI, and journal replay—incorrect terminal handling would mis-report completion or deadlock sessions.
> 
> **Overview**
> Introduces **`turn_failed`** as a durable, explicit turn closer (exit code 1) alongside `turn_complete` and `turn_aborted`, and centralizes recognition in **`classifyTurnTerminal`** (`runtime/src/contracts/turn-terminal.ts`) with an exactly synced SDK copy.
> 
> **Mid-turn `error` and `stream_error` stay diagnostic**—they no longer settle submissions, drive agent status to errored, or stop the TUI/CLI stream. Real failures are written as `turn_failed` from the turn kernel, review tasks, background-agent status projection, and fatal run cleanup (one terminal per turn, with legacy journal reads for old `error` causes `background_agent_error` / `review_task_failed`).
> 
> **Clients correlate terminals to the active turn** via `expectedTurnId` in the SDK, one-shot CLI, daemon runner, transcript v2 (`turnResults.outcome: "errored"`), and TUI adapters—so stale or mismatched failure events cannot complete the wrong prompt. Docs and tooling (Sonar CPD, `check:sdk-generated-types`) are updated for the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa400bb8ee81494d7cf260de5a96b9c5f9f4ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->