### PR TITLE
build(sdk): generate the workflow handoff contract from its schema

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -144,12 +144,10 @@ not change their public shapes independently:
   generated-type command checks selected version and outcome markers. See
   [Workflow result generated mirror](#workflow-result-generated-mirror).
 - `packages/agenc-sdk/src/workflow-handoff.generated.ts` mirrors the workflow
-  handoff schema under `runtime/src/agents/`. Run
-  `npm exec --workspace=@tetsuo-ai/runtime -- vitest run tests/sdk-package/workflow-handoff.contract.test.ts`
-  for selected public constant and validator coverage. The generated-type
-  command checks runtime handoff markers and does not read this public file.
-  No current check proves full structural parity. [#1941](https://github.com/tetsuo-ai/agenc-core/issues/1941)
-  tracks that work.
+  handoff JSON schema under `runtime/src/agents/`. The same generated-type
+  command renders and compares the complete file, including types, constants,
+  and structural validator data. SDK build and typecheck run this check too.
+  See [Workflow handoff generated mirror](#workflow-handoff-generated-mirror).
 
 Permission requests with no registered handler are **denied** (never granted)
 so an unattended embedder can't hang a turn, mirroring `agenc -p`.
@@ -499,14 +497,14 @@ of the public surface:
 | Public wire declarations and params/result maps | `runtime/src/app-server/protocol/index.ts` and referenced shared declarations | `check:sdk-generated-types` generates `protocol-wire.generated.ts`, checks the complete artifact and compiles exact request, result, envelope and client-argument types for every public method. The drift contract also checks registry names and order. |
 | `session.transcript.v2` result shapes | `runtime/src/app-server/protocol/index.ts` | `check:sdk-generated-types` renders `transcript-v2.generated.ts` and compares the complete committed file after newline normalization |
 | Workflow result contract markers | `runtime/src/agents/workflow-result.ts`, `coreSchemas.ts`, `coreTypes.generated.ts`, and `packages/agenc-sdk/src/workflow-result.generated.ts` | The same check requires selected version and outcome markers. It does not compare the complete file. Refresh and the extra contract-test lock: [Workflow result generated mirror](#workflow-result-generated-mirror) |
-| Workflow handoff contract markers | `runtime/src/entrypoints/sdk/coreSchemas.ts` and `coreTypes.generated.ts` | The same check requires selected runtime handoff markers. It does not read or structurally compare `packages/agenc-sdk/src/workflow-handoff.generated.ts` |
+| Workflow handoff metadata | `runtime/src/agents/workflow-handoff-artifact.v1.schema.json`, checked against `workflow-handoff-schema.ts` | The same check renders the complete public `workflow-handoff.generated.ts`, compares it after newline normalization, and rejects unsupported constraints |
 
 `runtime/tests/sdk-package/workflow-handoff.contract.test.ts` supplies separate
 behavioral coverage. It compares selected public constants with runtime values
-and exercises the public validator against runtime and schema validators. No
-current check compares every field, optional marker, union, declaration order,
-or export in the public workflow-handoff mirror. [#1941](https://github.com/tetsuo-ai/agenc-core/issues/1941)
-tracks a generated structural parity check.
+and exercises the public validator against runtime and schema validators.
+`workflow-handoff-generation.test.ts` checks field, optionality, literal,
+limit, pattern, property-order, and post-validation drift, then executes the
+regenerated SDK validators without repository dependencies.
 
 Changes covered by these guards fail the check until the mirrored or
 marker-checked content is updated. Refresh the public wire declarations with
@@ -586,6 +584,39 @@ Constraints:
 | `must extend JsonObject` | A mirrored interface dropped or changed its heritage |
 | `transcriptV2()` type-checks but a new field is only `JsonObject` | The generated file was not refreshed; `protocol.ts` re-exports those interfaces |
 
+### Workflow handoff generated mirror
+
+`runtime/src/agents/workflow-handoff-artifact.v1.schema.json` defines the
+public handoff fields and constraints. The generator checks that schema
+against the runtime schema and named constants in
+`runtime/src/agents/workflow-handoff-schema.ts`, then renders
+`packages/agenc-sdk/src/workflow-handoff.generated.ts`.
+
+The generated file contains public constants, readonly interfaces, optional
+markers, structural validation data, and the public validator entrypoint.
+Property order follows the JSON schema. The complete file is compared after
+LF/CRLF normalization. No field list is maintained separately in the SDK.
+
+`packages/agenc-sdk/src/workflow-handoff-validation.ts` provides plain-object,
+Unicode, UTF-8 byte-length, and cross-field checks. Structural fields and limits
+come from generated data. Unsupported schema keywords or post-validation
+constraints fail generation rather than disappearing from the validator.
+The repository generator uses TypeScript, but the published SDK keeps zero
+external runtime dependencies.
+
+After changing the authority, run:
+
+```sh
+npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --write
+npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types -- --check
+npm run typecheck --workspace=@tetsuo-ai/agenc-sdk
+```
+
+Check mode is the default and never writes. Write mode uses the existing
+atomic generated-file replacement. Runtime build and SDK build/typecheck run
+the read-only check. Keep handwritten relationship checks and their behavioral
+tests aligned when changing cross-field semantics.
+
 ### Workflow result generated mirror
 
 `runtime/scripts/check-sdk-generated-types.mjs` reads
@@ -602,7 +633,8 @@ substrings:
 It does **not** render or compare the complete file. Changing a field type,
 optionality, property order, cancellation-cause list, or numeric limit does
 not fail this check. Runtime `coreSchemas.ts` and `coreTypes.generated.ts`
-have their own selected marker lists (handoff markers live only there).
+have their own selected marker lists. Those checks remain distinct from the
+exact public handoff generation check.
 
 Authorities:
 
@@ -637,12 +669,9 @@ Constraints:
 - Outcome and cancellation field semantics stay in
   [workflows.md](reference/workflows.md#failures-and-results). This page
   only covers how the public types stay in sync.
-- The public handoff file is a separate, weaker guard: the generated-type
-  command does not read
-  `packages/agenc-sdk/src/workflow-handoff.generated.ts`.
-  [#1941](https://github.com/tetsuo-ai/agenc-core/issues/1941) tracks
-  structural parity for that file. Do not treat a green generated-type
-  check as proof the handoff mirror is current.
+- The public handoff file has an exact generation check, described in
+  [Workflow handoff generated mirror](#workflow-handoff-generated-mirror).
+  That stronger check does not apply to this marker-only workflow result file.
 - Leading comments and interface member lists are outside the marker check.
 
 | Symptom | What to check |

--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -2,7 +2,8 @@
 
 **0.3.0** — typed, zero-dependency embedding SDK for the AgenC daemon protocol.
 
-Node **>=26.5 <27** · ESM only · plain `tsc` build · no runtime dependencies.
+Node **>=26.5 <27**, ESM only, TypeScript build with generated-contract checks,
+and no external runtime dependencies.
 
 ## Surfaces
 
@@ -110,6 +111,13 @@ then check it with
 Workflow-result types in `src/workflow-result.generated.ts` are marker-checked
 by the same command, not an exact file compare
 (see [`docs/sdk.md`](../../docs/sdk.md#workflow-result-generated-mirror)).
+Workflow-handoff types, constants, and structural validator data in
+`src/workflow-handoff.generated.ts` are generated from the versioned runtime
+JSON schema and checked against the runtime schema and named constants.
+The same `--write` command refreshes the complete file. SDK build and typecheck
+run the read-only generated checks. Cross-field and UTF-8 validation stays in
+`src/workflow-handoff-validation.ts`, with no runtime package dependencies
+(see [`docs/sdk.md`](../../docs/sdk.md#workflow-handoff-generated-mirror)).
 
 ## Durable reconnect
 

--- a/packages/agenc-sdk/package.json
+++ b/packages/agenc-sdk/package.json
@@ -25,9 +25,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json && node ../../scripts/canonicalize-package-modes.mjs .",
+    "check:generated": "node ../../runtime/scripts/check-sdk-generated-types.mjs --check",
+    "build": "npm run check:generated && tsc -p tsconfig.json && node ../../scripts/canonicalize-package-modes.mjs .",
     "prepack": "npm run build",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "npm run check:generated && tsc --noEmit -p tsconfig.json"
   },
   "keywords": [
     "agenc",

--- a/packages/agenc-sdk/src/workflow-handoff-validation.ts
+++ b/packages/agenc-sdk/src/workflow-handoff-validation.ts
@@ -1,0 +1,107 @@
+import type { WorkflowHandoffArtifact } from "./workflow-handoff.generated.js";
+
+interface HandoffSchema {
+  readonly const?: string | number | boolean;
+  readonly type?: "object" | "string" | "integer" | "boolean";
+  readonly properties?: Readonly<Record<string, HandoffSchema>>;
+  readonly required?: readonly string[];
+  readonly additionalProperties?: false;
+  readonly pattern?: string;
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minimum?: number;
+  readonly maximum?: number;
+}
+
+interface HandoffPostValidation {
+  readonly ownerFieldMaxUtf8Bytes: number;
+  readonly previewMaxUtf8Bytes: number;
+}
+
+const loneSurrogatePattern = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+
+export class WorkflowHandoffArtifactValidationError extends Error {
+  readonly code = "WORKFLOW_HANDOFF_SCHEMA" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowHandoffArtifactValidationError";
+  }
+}
+
+function invalid(message: string): never {
+  throw new WorkflowHandoffArtifactValidationError(message);
+}
+
+function handoffRecord(value: unknown, label: string): object {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) invalid(`${label} must be an object`);
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) invalid(`${label} must be a plain object`);
+  return value;
+}
+
+function validateHandoffObject(value: unknown, schema: HandoffSchema, label: string): void {
+  const record = handoffRecord(value, label);
+  const properties = schema.properties ?? {};
+  for (const name of Object.keys(record)) {
+    if (!Object.hasOwn(properties, name)) invalid(`${label} fields are invalid`);
+  }
+  for (const [name, field] of Object.entries(properties)) {
+    const descriptor = Object.getOwnPropertyDescriptor(record, name);
+    if (descriptor === undefined) {
+      if (schema.required?.includes(name)) invalid(`${label}.${name} is required`);
+      continue;
+    }
+    if (!("value" in descriptor) || !descriptor.enumerable) invalid(`${label}.${name} must be an enumerable data property`);
+    validateHandoffStructure(descriptor.value, field, `${label}.${name}`);
+  }
+}
+
+function validateHandoffString(value: unknown, schema: HandoffSchema, label: string): void {
+  if (typeof value !== "string" || loneSurrogatePattern.test(value)) invalid(`${label} is invalid`);
+  if (schema.pattern !== undefined && !new RegExp(schema.pattern, "u").test(value)) invalid(`${label} is invalid`);
+  if (schema.minLength !== undefined || schema.maxLength !== undefined) {
+    const length = Array.from(value).length;
+    if (length < (schema.minLength ?? 0) || length > (schema.maxLength ?? Number.MAX_SAFE_INTEGER)) invalid(`${label} length is invalid`);
+  }
+}
+
+function validateHandoffInteger(value: unknown, schema: HandoffSchema, label: string): void {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < (schema.minimum ?? Number.MIN_SAFE_INTEGER) ||
+    (value as number) > (schema.maximum ?? Number.MAX_SAFE_INTEGER)
+  ) invalid(`${label} is invalid`);
+}
+
+export function validateHandoffStructure(value: unknown, schema: HandoffSchema, label: string): void {
+  if (schema.const !== undefined) {
+    if (value !== schema.const) invalid(`${label} is invalid`);
+    return;
+  }
+  switch (schema.type) {
+    case "object": return validateHandoffObject(value, schema, label);
+    case "string": return validateHandoffString(value, schema, label);
+    case "integer": return validateHandoffInteger(value, schema, label);
+    case "boolean":
+      if (typeof value !== "boolean") invalid(`${label} must be a boolean`);
+      return;
+    default: invalid(`${label} has an unsupported schema`);
+  }
+}
+
+export function validateHandoffRelationships(artifact: WorkflowHandoffArtifact, constraints: HandoffPostValidation): void {
+  const encoder = new TextEncoder();
+  for (const value of Object.values(artifact.owner)) {
+    if (encoder.encode(value).byteLength > constraints.ownerFieldMaxUtf8Bytes) invalid("owner field exceeds its UTF-8 limit");
+  }
+  if (artifact.storage_ref !== `workflow-handoff:${artifact.artifact_id}`) invalid("storage_ref is invalid");
+  if (artifact.committed_at_ms < artifact.created_at_ms) invalid("committed_at_ms precedes created_at_ms");
+  const previewBytes = encoder.encode(artifact.preview).byteLength;
+  if (previewBytes > constraints.previewMaxUtf8Bytes) invalid("preview exceeds its UTF-8 limit");
+  if (
+    previewBytes > artifact.byte_length ||
+    (!artifact.preview_truncated && previewBytes !== artifact.byte_length) ||
+    (artifact.preview_truncated && previewBytes >= artifact.byte_length)
+  ) invalid("preview length is inconsistent with byte_length");
+}

--- a/packages/agenc-sdk/src/workflow-handoff.generated.ts
+++ b/packages/agenc-sdk/src/workflow-handoff.generated.ts
@@ -1,18 +1,13 @@
-/**
- * Generated public metadata contract for durable workflow handoffs.
- * Keep synchronized with
- * `runtime/src/agents/workflow-handoff-artifact.v1.schema.json`.
- */
+import { validateHandoffStructure, validateHandoffRelationships } from "./workflow-handoff-validation.js";
+export { WorkflowHandoffArtifactValidationError } from "./workflow-handoff-validation.js";
 
 export const AGENC_WORKFLOW_HANDOFF_ARTIFACT_FORMAT_VERSION = 1 as const;
-export const AGENC_WORKFLOW_HANDOFF_ARTIFACT_KIND =
-  "workflow_handoff" as const;
-export const AGENC_WORKFLOW_HANDOFF_COMPATIBILITY_EPOCH =
-  "workflow_handoff.v1/state-schema.22" as const;
-export const AGENC_MAX_WORKFLOW_HANDOFF_ARTIFACT_BYTES = 16_777_216 as const;
-export const AGENC_MAX_WORKFLOW_STEP_RESULT_TOKENS = 131_072 as const;
-export const AGENC_MAX_WORKFLOW_STEP_PREVIEW_BYTES = 2_048 as const;
-export const AGENC_MAX_WORKFLOW_HANDOFF_OWNER_FIELD_UTF8_BYTES = 1_024 as const;
+export const AGENC_WORKFLOW_HANDOFF_ARTIFACT_KIND = "workflow_handoff" as const;
+export const AGENC_WORKFLOW_HANDOFF_COMPATIBILITY_EPOCH = "workflow_handoff.v1/state-schema.22" as const;
+export const AGENC_MAX_WORKFLOW_HANDOFF_ARTIFACT_BYTES = 16777216 as const;
+export const AGENC_MAX_WORKFLOW_STEP_RESULT_TOKENS = 131072 as const;
+export const AGENC_MAX_WORKFLOW_STEP_PREVIEW_BYTES = 2048 as const;
+export const AGENC_MAX_WORKFLOW_HANDOFF_OWNER_FIELD_UTF8_BYTES = 1024 as const;
 
 export interface WorkflowHandoffOwner {
   readonly run_id: string;
@@ -39,202 +34,123 @@ export interface WorkflowHandoffArtifact {
   readonly preview_truncated: boolean;
 }
 
-const ARTIFACT_KEYS = Object.freeze([
-  "format_version",
-  "kind",
-  "compatibility_epoch",
-  "artifact_id",
-  "owner",
-  "digest",
-  "byte_length",
-  "token_count",
-  "media_type",
-  "encoding",
-  "storage_ref",
-  "created_at_ms",
-  "committed_at_ms",
-  "commit_sequence",
-  "preview",
-  "preview_truncated",
-] as const);
-const OWNER_KEYS = Object.freeze([
-  "run_id",
-  "workflow_id",
-  "producer_step_id",
-] as const);
-const LONE_SURROGATE_PATTERN =
-  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
-
-export class WorkflowHandoffArtifactValidationError extends Error {
-  readonly code = "WORKFLOW_HANDOFF_SCHEMA" as const;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "WorkflowHandoffArtifactValidationError";
-  }
-}
-
-/** Strict dependency-free validator for the generated public SDK contract. */
-export function validateWorkflowHandoffArtifact(
-  value: unknown,
-): WorkflowHandoffArtifact {
-  const artifact = strictRecord(
-    value,
-    ARTIFACT_KEYS,
-    "workflow handoff artifact",
-  );
-  expectLiteral(artifact.format_version, 1, "format_version");
-  expectLiteral(artifact.kind, AGENC_WORKFLOW_HANDOFF_ARTIFACT_KIND, "kind");
-  expectLiteral(
-    artifact.compatibility_epoch,
-    AGENC_WORKFLOW_HANDOFF_COMPATIBILITY_EPOCH,
+const artifactSchema = {
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format_version",
+    "kind",
     "compatibility_epoch",
-  );
-  const artifactId = boundedString(artifact.artifact_id, "artifact_id");
-  if (!/^wh_[0-9a-f]{48}$/u.test(artifactId)) invalid("artifact_id is invalid");
-
-  const owner = strictRecord(artifact.owner, OWNER_KEYS, "owner");
-  for (const key of OWNER_KEYS) {
-    boundedString(
-      owner[key],
-      `owner.${key}`,
-      AGENC_MAX_WORKFLOW_HANDOFF_OWNER_FIELD_UTF8_BYTES,
-    );
-  }
-  const digest = boundedString(artifact.digest, "digest");
-  if (!/^sha256:[0-9a-f]{64}$/u.test(digest)) invalid("digest is invalid");
-  const byteLength = boundedInteger(
-    artifact.byte_length,
+    "artifact_id",
+    "owner",
+    "digest",
     "byte_length",
-    0,
-    AGENC_MAX_WORKFLOW_HANDOFF_ARTIFACT_BYTES,
-  );
-  boundedInteger(
-    artifact.token_count,
     "token_count",
-    0,
-    AGENC_MAX_WORKFLOW_STEP_RESULT_TOKENS,
-  );
-  expectLiteral(artifact.media_type, "text/plain", "media_type");
-  expectLiteral(artifact.encoding, "utf-8", "encoding");
-  expectLiteral(
-    artifact.storage_ref,
-    `workflow-handoff:${artifactId}`,
+    "media_type",
+    "encoding",
     "storage_ref",
-  );
-  const createdAt = boundedInteger(
-    artifact.created_at_ms,
     "created_at_ms",
-    0,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const committedAt = boundedInteger(
-    artifact.committed_at_ms,
     "committed_at_ms",
-    0,
-    Number.MAX_SAFE_INTEGER,
-  );
-  if (committedAt < createdAt) invalid("committed_at_ms precedes created_at_ms");
-  boundedInteger(
-    artifact.commit_sequence,
     "commit_sequence",
-    1,
-    Number.MAX_SAFE_INTEGER,
-  );
-  const preview = boundedString(
-    artifact.preview,
     "preview",
-    AGENC_MAX_WORKFLOW_STEP_PREVIEW_BYTES,
-    true,
-  );
-  if (typeof artifact.preview_truncated !== "boolean") {
-    invalid("preview_truncated must be a boolean");
-  }
-  const previewBytes = utf8Length(preview);
-  if (
-    previewBytes > byteLength ||
-    (!artifact.preview_truncated && previewBytes !== byteLength) ||
-    (artifact.preview_truncated && previewBytes >= byteLength)
-  ) {
-    invalid("preview length is inconsistent with byte_length");
-  }
-  return artifact as unknown as WorkflowHandoffArtifact;
-}
-
-function strictRecord<const Key extends string>(
-  value: unknown,
-  keys: readonly Key[],
-  label: string,
-): Record<Key, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    invalid(`${label} must be an object`);
-  }
-  const prototype = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) {
-    invalid(`${label} must be a plain object`);
-  }
-  const names = Object.keys(value).sort();
-  const expected = [...keys].sort();
-  if (
-    names.length !== expected.length ||
-    names.some((name, index) => name !== expected[index])
-  ) {
-    invalid(`${label} fields are invalid`);
-  }
-  for (const key of keys) {
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (
-      descriptor === undefined ||
-      !("value" in descriptor) ||
-      !descriptor.enumerable
-    ) {
-      invalid(`${label}.${key} must be an enumerable data property`);
+    "preview_truncated"
+  ],
+  "properties": {
+    "format_version": {
+      "const": 1
+    },
+    "kind": {
+      "const": "workflow_handoff"
+    },
+    "compatibility_epoch": {
+      "const": "workflow_handoff.v1/state-schema.22"
+    },
+    "artifact_id": {
+      "type": "string",
+      "pattern": "^wh_[0-9a-f]{48}$"
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id",
+        "workflow_id",
+        "producer_step_id"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workflow_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "producer_step_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "byte_length": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 16777216
+    },
+    "token_count": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 131072
+    },
+    "media_type": {
+      "const": "text/plain"
+    },
+    "encoding": {
+      "const": "utf-8"
+    },
+    "storage_ref": {
+      "type": "string",
+      "pattern": "^workflow-handoff:wh_[0-9a-f]{48}$"
+    },
+    "created_at_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "committed_at_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "commit_sequence": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "preview": {
+      "type": "string"
+    },
+    "preview_truncated": {
+      "type": "boolean"
     }
   }
-  return value as Record<Key, unknown>;
-}
+} as const;
+const postValidation = {
+  "ownerFieldMaxUtf8Bytes": 1024,
+  "previewMaxUtf8Bytes": 2048,
+  "requireWellFormedUnicode": true,
+  "storageRefMustMatchArtifactId": true,
+  "committedAtMustNotPrecedeCreatedAt": true,
+  "previewBytesMustMatchByteLengthAndTruncation": true
+} as const;
 
-function boundedString(
-  value: unknown,
-  label: string,
-  maximumUtf8Bytes = Number.MAX_SAFE_INTEGER,
-  allowEmpty = false,
-): string {
-  if (
-    typeof value !== "string" ||
-    (!allowEmpty && value.length === 0) ||
-    LONE_SURROGATE_PATTERN.test(value) ||
-    utf8Length(value) > maximumUtf8Bytes
-  ) {
-    invalid(`${label} is invalid`);
-  }
-  return value;
-}
-
-function boundedInteger(
-  value: unknown,
-  label: string,
-  minimum: number,
-  maximum: number,
-): number {
-  if (
-    !Number.isSafeInteger(value) ||
-    (value as number) < minimum ||
-    (value as number) > maximum
-  ) {
-    invalid(`${label} is invalid`);
-  }
-  return value as number;
-}
-
-function expectLiteral(value: unknown, expected: unknown, label: string): void {
-  if (value !== expected) invalid(`${label} is invalid`);
-}
-
-function utf8Length(value: string): number {
-  return new TextEncoder().encode(value).byteLength;
-}
-
-function invalid(message: string): never {
-  throw new WorkflowHandoffArtifactValidationError(message);
+export function validateWorkflowHandoffArtifact(value: unknown): WorkflowHandoffArtifact {
+  validateHandoffStructure(value, artifactSchema, "workflow handoff artifact");
+  const artifact = value as WorkflowHandoffArtifact;
+  validateHandoffRelationships(artifact, postValidation);
+  return artifact;
 }

--- a/runtime/scripts/check-sdk-generated-types.mjs
+++ b/runtime/scripts/check-sdk-generated-types.mjs
@@ -7,6 +7,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { renderSdkWireTypes } from "./sdk-wire-types.mjs";
 import { checkSdkWireParity } from "./check-sdk-wire-parity.mjs";
+import { readWorkflowHandoffGenerated } from "./sdk-workflow-handoff.mjs";
 import {
   createSourceFile,
   isInterfaceDeclaration,
@@ -28,6 +29,9 @@ const paths = {
   packageWire: "../packages/agenc-sdk/src/protocol-wire.generated.ts",
   packageWorkflowResult:
     "../packages/agenc-sdk/src/workflow-result.generated.ts",
+  handoffSchema: "src/agents/workflow-handoff-artifact.v1.schema.json",
+  handoffSource: "src/agents/workflow-handoff-schema.ts",
+  packageWorkflowHandoff: "../packages/agenc-sdk/src/workflow-handoff.generated.ts",
 };
 const checkCommand =
   "npm --workspace=@tetsuo-ai/runtime run check:sdk-generated-types";
@@ -51,10 +55,10 @@ function normalizeLineEndings(source) {
 }
 
 export function parseSdkGeneratedTypesMode(args) {
-  if (args.length === 0) return "check";
+  if (args.length === 0 || (args.length === 1 && args[0] === "--check")) return "check";
   if (args.length === 1 && args[0] === "--write") return "write";
   throw new Error(
-    "usage: check-sdk-generated-types.mjs [--write]",
+    "usage: check-sdk-generated-types.mjs [--check | --write]",
   );
 }
 
@@ -178,6 +182,11 @@ export async function synchronizeTurnTerminalGenerated({
   return synchronizeGeneratedFile({ generatedPath, expected, write });
 }
 
+export async function synchronizeWorkflowHandoffGenerated({ schemaPath, runtimeSourcePath, generatedPath, write = false }) {
+  const expected = await readWorkflowHandoffGenerated({ schemaPath, runtimeSourcePath });
+  return synchronizeGeneratedFile({ generatedPath, expected, write });
+}
+
 async function synchronizeGeneratedFile({ generatedPath, expected, write }) {
   let current;
   try {
@@ -222,7 +231,7 @@ function reportSdkGeneratedTypesSuccess(mode) {
   process.stdout.write(`[sdk generated types] ${message}\n`);
 }
 
-function reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTerminal) {
+function reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTerminal, workflowHandoff) {
   const displayPath = path
     .relative(path.dirname(runtimeRoot), transcriptV2Path)
     .split(path.sep)
@@ -237,6 +246,9 @@ function reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTer
   );
   process.stdout.write(
     `[sdk generated types] ${turnTerminal.changed ? "wrote" : "current"} ${paths.packageTurnTerminal}\n`,
+  );
+  process.stdout.write(
+    `[sdk generated types] ${workflowHandoff.changed ? "wrote" : "current"} ${paths.packageWorkflowHandoff}\n`,
   );
 }
 
@@ -254,6 +266,7 @@ async function main() {
     transcriptV2,
     wire,
     turnTerminal,
+    workflowHandoff,
   ] = await Promise.all([
     readRuntimeFile(paths.schemas),
     readRuntimeFile(paths.coreTypes),
@@ -274,9 +287,15 @@ async function main() {
       generatedPath: path.join(runtimeRoot, paths.packageTurnTerminal),
       write: mode === "write",
     }),
+    synchronizeWorkflowHandoffGenerated({
+      schemaPath: path.join(runtimeRoot, paths.handoffSchema),
+      runtimeSourcePath: path.join(runtimeRoot, paths.handoffSource),
+      generatedPath: path.join(runtimeRoot, paths.packageWorkflowHandoff),
+      write: mode === "write",
+    }),
   ]);
   if (mode === "write") {
-    reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTerminal);
+    reportWrittenSdkArtifacts(transcriptV2Path, transcriptV2, wire, turnTerminal, workflowHandoff);
   }
   const failures = [];
   const sources = [
@@ -423,6 +442,11 @@ async function main() {
     failures,
     turnTerminal.matches,
     `${paths.packageTurnTerminal} is stale; run ${checkCommand} -- --write`,
+  );
+  expectCondition(
+    failures,
+    workflowHandoff.matches,
+    `${paths.packageWorkflowHandoff} is stale; run ${checkCommand} -- --write`,
   );
 
   if (mode === "check") {

--- a/runtime/scripts/sdk-workflow-handoff.mjs
+++ b/runtime/scripts/sdk-workflow-handoff.mjs
@@ -1,0 +1,233 @@
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+
+const metadataKeys = new Set(["$schema", "$id", "$comment", "title"]);
+const constantBindings = [
+  ["AGENC_WORKFLOW_HANDOFF_ARTIFACT_FORMAT_VERSION", "WORKFLOW_HANDOFF_ARTIFACT_FORMAT_VERSION", ["properties", "format_version", "const"]],
+  ["AGENC_WORKFLOW_HANDOFF_ARTIFACT_KIND", "WORKFLOW_HANDOFF_ARTIFACT_KIND", ["properties", "kind", "const"]],
+  ["AGENC_WORKFLOW_HANDOFF_COMPATIBILITY_EPOCH", "WORKFLOW_HANDOFF_COMPATIBILITY_EPOCH", ["properties", "compatibility_epoch", "const"]],
+  ["AGENC_MAX_WORKFLOW_HANDOFF_ARTIFACT_BYTES", "MAX_WORKFLOW_ARTIFACT_BYTES", ["properties", "byte_length", "maximum"]],
+  ["AGENC_MAX_WORKFLOW_STEP_RESULT_TOKENS", "MAX_WORKFLOW_STEP_RESULT_TOKENS", ["properties", "token_count", "maximum"]],
+  ["AGENC_MAX_WORKFLOW_STEP_PREVIEW_BYTES", "MAX_WORKFLOW_STEP_PREVIEW_BYTES", ["x-agenc-post-validation", "previewMaxUtf8Bytes"]],
+  ["AGENC_MAX_WORKFLOW_HANDOFF_OWNER_FIELD_UTF8_BYTES", "MAX_WORKFLOW_ARTIFACT_OWNER_FIELD_UTF8_BYTES", ["x-agenc-post-validation", "ownerFieldMaxUtf8Bytes"]],
+];
+
+function runtimeConstants(source) {
+  const parsed = ts.createSourceFile("workflow-handoff-schema.ts", source, ts.ScriptTarget.Latest, true);
+  if (parsed.parseDiagnostics.length > 0) throw new Error("invalid runtime handoff source");
+  const declarations = new Map();
+  for (const statement of parsed.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name)) declarations.set(declaration.name.text, declaration.initializer);
+    }
+  }
+  const resolving = new Set();
+  const resolve = (name) => {
+    const initializer = declarations.get(name);
+    if (initializer === undefined || resolving.has(name)) throw new Error(`unresolved handoff authority ${name}`);
+    resolving.add(name);
+    try {
+      return constantValue(initializer, resolve);
+    } finally {
+      resolving.delete(name);
+    }
+  };
+  return resolve;
+}
+
+function constantValue(node, resolve) {
+  if (ts.isStringLiteral(node)) return node.text;
+  if (ts.isNumericLiteral(node)) return Number(node.text.replaceAll("_", ""));
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (ts.isIdentifier(node)) return resolve(node.text);
+  if (ts.isAsExpression(node) || ts.isParenthesizedExpression(node)) return constantValue(node.expression, resolve);
+  if (ts.isArrayLiteralExpression(node)) return node.elements.map((element) => constantValue(element, resolve));
+  if (ts.isObjectLiteralExpression(node)) return constantObject(node, resolve);
+  if (node.getText() === "Number.MAX_SAFE_INTEGER") return Number.MAX_SAFE_INTEGER;
+  if (ts.isCallExpression(node) && node.expression.getText() === "Object.freeze" && node.arguments.length === 1) {
+    return constantValue(node.arguments[0], resolve);
+  }
+  throw new Error(`unsupported handoff authority expression ${node.getText()}`);
+}
+
+function constantObject(node, resolve) {
+  return Object.fromEntries(node.properties.map((property) => {
+    if (!ts.isPropertyAssignment(property) || (!ts.isIdentifier(property.name) && !ts.isStringLiteral(property.name))) {
+      throw new Error("unsupported handoff authority property");
+    }
+    return [property.name.text, constantValue(property.initializer, resolve)];
+  }));
+}
+
+function orderedValue(value) {
+  if (Array.isArray(value)) return value.map(orderedValue);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, orderedValue(value[key])]));
+  }
+  return value;
+}
+
+function withoutMetadata(schema) {
+  return Object.fromEntries(Object.entries(schema).filter(([key]) => !metadataKeys.has(key)));
+}
+
+function assertKeys(value, allowed, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) throw new Error(`unsupported ${label} constraint ${key}`);
+  }
+}
+
+function safeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${label} must be a nonnegative safe integer`);
+}
+
+function validateStringSchema(schema) {
+  assertKeys(schema, ["type", "pattern", "minLength", "maxLength"], "string");
+  if (schema.pattern !== undefined) {
+    if (typeof schema.pattern !== "string") throw new Error("string pattern must be a string");
+    new RegExp(schema.pattern, "u");
+  }
+  for (const key of ["minLength", "maxLength"]) {
+    if (schema[key] !== undefined) safeInteger(schema[key], key);
+  }
+}
+
+function validateObjectSchema(schema, depth) {
+  assertKeys(schema, ["type", "properties", "required", "additionalProperties"], "object");
+  if (schema.additionalProperties !== false || !Array.isArray(schema.required)) {
+    throw new Error("handoff objects require explicit keys and required fields");
+  }
+  const properties = schema.properties;
+  if (properties === null || typeof properties !== "object" || Array.isArray(properties)) throw new Error("invalid handoff properties");
+  if (new Set(schema.required).size !== schema.required.length) throw new Error("duplicate required handoff field");
+  for (const name of schema.required) {
+    if (typeof name !== "string" || !Object.hasOwn(properties, name)) throw new Error("unknown required handoff field");
+  }
+  for (const [name, field] of Object.entries(properties)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name) || name === "__proto__") throw new Error(`unsupported handoff field ${name}`);
+    validateSchema(field, depth + 1);
+  }
+}
+
+function validateSchema(schema, depth = 0) {
+  if (depth > 8 || schema === null || typeof schema !== "object") throw new Error("invalid handoff schema");
+  if (Object.hasOwn(schema, "const")) {
+    assertKeys(schema, ["const"], "literal");
+    if (!["string", "boolean", "number"].includes(typeof schema.const)) throw new Error("unsupported handoff literal");
+    if (typeof schema.const === "number") safeInteger(schema.const, "literal");
+    return;
+  }
+  switch (schema.type) {
+    case "object": return validateObjectSchema(schema, depth);
+    case "string": return validateStringSchema(schema);
+    case "boolean": return assertKeys(schema, ["type"], "boolean");
+    case "integer":
+      assertKeys(schema, ["type", "minimum", "maximum"], "integer");
+      for (const key of ["minimum", "maximum"]) {
+        if (schema[key] !== undefined) safeInteger(schema[key], key);
+      }
+      return;
+    default: throw new Error(`unsupported handoff type ${schema.type}`);
+  }
+}
+
+function validatePostValidation(post) {
+  const flags = ["requireWellFormedUnicode", "storageRefMustMatchArtifactId", "committedAtMustNotPrecedeCreatedAt", "previewBytesMustMatchByteLengthAndTruncation"];
+  assertKeys(post, ["ownerFieldMaxUtf8Bytes", "previewMaxUtf8Bytes", ...flags], "post-validation");
+  safeInteger(post.ownerFieldMaxUtf8Bytes, "ownerFieldMaxUtf8Bytes");
+  safeInteger(post.previewMaxUtf8Bytes, "previewMaxUtf8Bytes");
+  for (const flag of flags) {
+    if (post[flag] !== true) throw new Error(`unsupported post-validation constraint ${flag}`);
+  }
+}
+
+function validateRelationshipShape(schema) {
+  const dependentTypes = {
+    owner: "object",
+    artifact_id: "string",
+    storage_ref: "string",
+    created_at_ms: "integer",
+    committed_at_ms: "integer",
+    byte_length: "integer",
+    preview: "string",
+    preview_truncated: "boolean",
+  };
+  for (const [name, type] of Object.entries(dependentTypes)) {
+    if (!schema.required.includes(name) || schema.properties[name]?.type !== type) throw new Error(`unsupported relationship field ${name}`);
+  }
+  if (!schema.properties.storage_ref.pattern?.startsWith("^workflow-handoff:")) throw new Error("unsupported storage reference relationship");
+  for (const field of Object.values(schema.properties.owner.properties)) {
+    if (field.type !== "string") throw new Error("unsupported owner field relationship");
+  }
+}
+
+function renderType(schema, name) {
+  if (Object.hasOwn(schema, "const")) return JSON.stringify(schema.const);
+  if (schema.type === "integer") return "number";
+  if (schema.type === "object") {
+    if (name === "owner") return "WorkflowHandoffOwner";
+    return `{ ${renderFields(schema).join(" ")} }`;
+  }
+  if (name === "digest" && schema.type === "string") {
+    const prefix = schema.pattern?.match(/^\^([a-z][a-z0-9_-]*:)/u)?.[1];
+    if (prefix !== undefined) return "`" + prefix + "${string}`";
+  }
+  return schema.type;
+}
+
+function renderFields(schema) {
+  return Object.entries(schema.properties).map(([name, field]) =>
+    `readonly ${name}${schema.required.includes(name) ? "" : "?"}: ${renderType(field, name)};`,
+  );
+}
+
+export function renderWorkflowHandoffGenerated(schema, runtimeSource) {
+  const resolve = runtimeConstants(runtimeSource);
+  const authority = withoutMetadata(schema);
+  if (JSON.stringify(orderedValue(authority)) !== JSON.stringify(orderedValue(withoutMetadata(resolve("WORKFLOW_HANDOFF_ARTIFACT_SCHEMA"))))) {
+    throw new Error("runtime and JSON workflow handoff schemas disagree");
+  }
+  const { "x-agenc-post-validation": post, ...structural } = authority;
+  validateSchema(structural);
+  validatePostValidation(post);
+  if (structural.type !== "object" || structural.properties.owner?.type !== "object") throw new Error("handoff artifact and owner must be objects");
+  validateRelationshipShape(structural);
+  const constants = constantBindings.map(([publicName, runtimeName, selectors]) => {
+    const value = selectors.reduce((current, key) => current?.[key], schema);
+    if (value === undefined || value !== resolve(runtimeName)) throw new Error(`handoff constant ${runtimeName} disagrees with JSON schema`);
+    return `export const ${publicName} = ${JSON.stringify(value)} as const;`;
+  });
+  return [
+    'import { validateHandoffStructure, validateHandoffRelationships } from "./workflow-handoff-validation.js";',
+    'export { WorkflowHandoffArtifactValidationError } from "./workflow-handoff-validation.js";',
+    "",
+    ...constants,
+    "",
+    "export interface WorkflowHandoffOwner {",
+    ...renderFields(structural.properties.owner).map((line) => `  ${line}`),
+    "}",
+    "",
+    "export interface WorkflowHandoffArtifact {",
+    ...renderFields(structural).map((line) => `  ${line}`),
+    "}",
+    "",
+    `const artifactSchema = ${JSON.stringify(structural, null, 2)} as const;`,
+    `const postValidation = ${JSON.stringify(post, null, 2)} as const;`,
+    "",
+    "export function validateWorkflowHandoffArtifact(value: unknown): WorkflowHandoffArtifact {",
+    '  validateHandoffStructure(value, artifactSchema, "workflow handoff artifact");',
+    "  const artifact = value as WorkflowHandoffArtifact;",
+    "  validateHandoffRelationships(artifact, postValidation);",
+    "  return artifact;",
+    "}",
+    "",
+  ].join("\n");
+}
+
+export async function readWorkflowHandoffGenerated({ schemaPath, runtimeSourcePath }) {
+  const [schema, runtimeSource] = await Promise.all([readFile(schemaPath, "utf8"), readFile(runtimeSourcePath, "utf8")]);
+  return renderWorkflowHandoffGenerated(JSON.parse(schema), runtimeSource);
+}

--- a/runtime/scripts/sdk-workflow-handoff.mjs
+++ b/runtime/scripts/sdk-workflow-handoff.mjs
@@ -64,7 +64,11 @@ function constantObject(node, resolve) {
 function orderedValue(value) {
   if (Array.isArray(value)) return value.map(orderedValue);
   if (value !== null && typeof value === "object") {
-    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, orderedValue(value[key])]));
+    const keys = Object.keys(value).sort((left, right) => {
+      if (left === right) return 0;
+      return left < right ? -1 : 1;
+    });
+    return Object.fromEntries(keys.map((key) => [key, orderedValue(value[key])]));
   }
   return value;
 }
@@ -88,7 +92,7 @@ function validateStringSchema(schema) {
   assertKeys(schema, ["type", "pattern", "minLength", "maxLength"], "string");
   if (schema.pattern !== undefined) {
     if (typeof schema.pattern !== "string") throw new Error("string pattern must be a string");
-    new RegExp(schema.pattern, "u");
+    RegExp(schema.pattern, "u");
   }
   for (const key of ["minLength", "maxLength"]) {
     if (schema[key] !== undefined) safeInteger(schema[key], key);
@@ -107,7 +111,7 @@ function validateObjectSchema(schema, depth) {
     if (typeof name !== "string" || !Object.hasOwn(properties, name)) throw new Error("unknown required handoff field");
   }
   for (const [name, field] of Object.entries(properties)) {
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name) || name === "__proto__") throw new Error(`unsupported handoff field ${name}`);
+    if (!/^[A-Za-z_]\w*$/u.test(name) || name === "__proto__") throw new Error(`unsupported handoff field ${name}`);
     validateSchema(field, depth + 1);
   }
 }

--- a/runtime/scripts/sdk-workflow-handoff.mjs
+++ b/runtime/scripts/sdk-workflow-handoff.mjs
@@ -90,13 +90,12 @@ function safeInteger(value, label) {
 
 function validateStringSchema(schema) {
   assertKeys(schema, ["type", "pattern", "minLength", "maxLength"], "string");
-  if (schema.pattern !== undefined) {
-    if (typeof schema.pattern !== "string") throw new Error("string pattern must be a string");
-    RegExp(schema.pattern, "u");
-  }
   for (const key of ["minLength", "maxLength"]) {
     if (schema[key] !== undefined) safeInteger(schema[key], key);
   }
+  if (schema.pattern === undefined) return undefined;
+  if (typeof schema.pattern !== "string") throw new Error("string pattern must be a string");
+  return new RegExp(schema.pattern, "u");
 }
 
 function validateObjectSchema(schema, depth) {

--- a/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
+++ b/runtime/tests/sdk-package/sdk-generated-types-script.test.ts
@@ -150,7 +150,8 @@ describe("SDK generated transcript v2 script", () => {
   it("keeps check mode as the default and requires an explicit write flag", () => {
     expect(parseSdkGeneratedTypesMode([])).toBe("check");
     expect(parseSdkGeneratedTypesMode(["--write"])).toBe("write");
-    expect(() => parseSdkGeneratedTypesMode(["--check"])).toThrow(/usage/);
+    expect(parseSdkGeneratedTypesMode(["--check"])).toBe("check");
+    expect(() => parseSdkGeneratedTypesMode(["--check", "--write"])).toThrow(/usage/);
     expect(() => parseSdkGeneratedTypesMode(["--write", "extra"])).toThrow(
       /usage/,
     );

--- a/runtime/tests/sdk-package/workflow-handoff-generation.test.ts
+++ b/runtime/tests/sdk-package/workflow-handoff-generation.test.ts
@@ -219,6 +219,16 @@ describe("exact public workflow handoff generation", () => {
     expect(() => renderWorkflowHandoffGenerated(schema, source)).toThrow(/unsupported handoff authority expression/);
   });
 
+  it("rejects invalid regex syntax before writing a generated validator", async () => {
+    const { schema, options } = await createFixture();
+    const original = await readFile(options.generatedPath, "utf8");
+    schema.properties.preview.pattern = "[";
+    await writeFile(options.schemaPath, JSON.stringify(schema));
+    await writeFile(options.runtimeSourcePath, fixtureRuntimeSource(schema));
+    await expect(synchronizeWorkflowHandoffGenerated({ ...options, write: true })).rejects.toThrow(SyntaxError);
+    expect(await readFile(options.generatedPath, "utf8")).toBe(original);
+  });
+
   it.each(["optional owner", "owner value type", "storage prefix"])("rejects unsupported handwritten relationship changes to %s", async (kind) => {
     const { schema, options } = await createFixture();
     if (kind === "optional owner") schema.required = schema.required.filter((name) => name !== "owner");

--- a/runtime/tests/sdk-package/workflow-handoff-generation.test.ts
+++ b/runtime/tests/sdk-package/workflow-handoff-generation.test.ts
@@ -1,0 +1,255 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import ts from "typescript";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { synchronizeWorkflowHandoffGenerated } from "../../scripts/check-sdk-generated-types.mjs";
+import { renderWorkflowHandoffGenerated } from "../../scripts/sdk-workflow-handoff.mjs";
+
+interface SchemaNode {
+  type?: string;
+  const?: string | number | boolean;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  pattern?: string;
+  properties?: Record<string, SchemaNode>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+interface HandoffSchema extends SchemaNode {
+  properties: Record<string, SchemaNode>;
+  required: string[];
+  "x-agenc-post-validation": Record<string, number | boolean>;
+}
+
+const roots: string[] = [];
+const repositoryRoot = join(import.meta.dirname, "../../..");
+const execFileAsync = promisify(execFile);
+const schemaFile = join(repositoryRoot, "runtime/src/agents/workflow-handoff-artifact.v1.schema.json");
+const runtimeFile = join(repositoryRoot, "runtime/src/agents/workflow-handoff-schema.ts");
+const publicFile = join(repositoryRoot, "packages/agenc-sdk/src/workflow-handoff.generated.ts");
+const validationFile = join(repositoryRoot, "packages/agenc-sdk/src/workflow-handoff-validation.ts");
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function fixtureRuntimeSource(schema: HandoffSchema): string {
+  const properties = schema.properties;
+  const post = schema["x-agenc-post-validation"];
+  const constants = {
+    WORKFLOW_HANDOFF_ARTIFACT_FORMAT_VERSION: properties.format_version.const,
+    WORKFLOW_HANDOFF_ARTIFACT_KIND: properties.kind.const,
+    WORKFLOW_HANDOFF_COMPATIBILITY_EPOCH: properties.compatibility_epoch.const,
+    MAX_WORKFLOW_ARTIFACT_BYTES: properties.byte_length.maximum,
+    MAX_WORKFLOW_STEP_RESULT_TOKENS: properties.token_count.maximum,
+    MAX_WORKFLOW_STEP_PREVIEW_BYTES: post.previewMaxUtf8Bytes,
+    MAX_WORKFLOW_ARTIFACT_OWNER_FIELD_UTF8_BYTES: post.ownerFieldMaxUtf8Bytes,
+    WORKFLOW_HANDOFF_ARTIFACT_SCHEMA: schema,
+  };
+  return Object.entries(constants).map(([name, value]) => `export const ${name} = ${JSON.stringify(value)};`).join("\n");
+}
+
+function validArtifact() {
+  const artifactId = `wh_${"0".repeat(48)}`;
+  return {
+    format_version: 1,
+    kind: "workflow_handoff",
+    compatibility_epoch: "workflow_handoff.v1/state-schema.22",
+    artifact_id: artifactId,
+    owner: { run_id: "run", workflow_id: "workflow", producer_step_id: "step" },
+    digest: `sha256:${"0".repeat(64)}`,
+    byte_length: 4,
+    token_count: 1,
+    media_type: "text/plain",
+    encoding: "utf-8",
+    storage_ref: `workflow-handoff:${artifactId}`,
+    created_at_ms: 1,
+    committed_at_ms: 2,
+    commit_sequence: 1,
+    preview: "data",
+    preview_truncated: false,
+  };
+}
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), "agenc-handoff-generation-"));
+  roots.push(root);
+  const schema = JSON.parse(await readFile(schemaFile, "utf8")) as HandoffSchema;
+  const options = {
+    schemaPath: join(root, "schema.json"),
+    runtimeSourcePath: join(root, "runtime.ts"),
+    generatedPath: join(root, "workflow-handoff.generated.ts"),
+  };
+  await writeFile(options.schemaPath, JSON.stringify(schema));
+  await writeFile(options.runtimeSourcePath, fixtureRuntimeSource(schema));
+  await synchronizeWorkflowHandoffGenerated({ ...options, write: true });
+  return { root, schema, options };
+}
+
+async function validateGenerated(root: string, candidate: unknown): Promise<{ valid: boolean; name?: string; code?: string }> {
+  for (const [sourcePath, outputName] of [
+    [join(root, "workflow-handoff.generated.ts"), "workflow-handoff.generated.js"],
+    [validationFile, "workflow-handoff-validation.js"],
+  ]) {
+    const { outputText } = ts.transpileModule(await readFile(sourcePath, "utf8"), {
+      compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+    });
+    await writeFile(join(root, outputName), outputText);
+  }
+  await writeFile(join(root, "package.json"), '{"type":"module"}');
+  const { stdout } = await execFileAsync(process.execPath, [
+    "--input-type=module", "-e",
+    `import { validateWorkflowHandoffArtifact } from './workflow-handoff.generated.js';
+try { validateWorkflowHandoffArtifact(JSON.parse(process.argv[1])); console.log(JSON.stringify({valid:true})); }
+catch (error) { console.log(JSON.stringify({valid:false,name:error.name,code:error.code})); }`,
+    JSON.stringify(candidate),
+  ], { cwd: root, encoding: "utf8" });
+  return JSON.parse(stdout);
+}
+
+const mutations: readonly {
+  name: string;
+  mutate(schema: HandoffSchema): void;
+  accepted(): unknown;
+  rejectsOriginal: boolean;
+}[] = [
+  {
+    name: "required field",
+    mutate(schema) { schema.properties.extra = { type: "boolean" }; schema.required.push("extra"); },
+    accepted: () => ({ ...validArtifact(), extra: true }),
+    rejectsOriginal: true,
+  },
+  {
+    name: "optional marker",
+    mutate(schema) { schema.required = schema.required.filter((name) => name !== "token_count"); },
+    accepted: () => { const { token_count: _tokens, ...candidate } = validArtifact(); return candidate; },
+    rejectsOriginal: false,
+  },
+  {
+    name: "removed field",
+    mutate(schema) { delete schema.properties.encoding; schema.required = schema.required.filter((name) => name !== "encoding"); },
+    accepted: () => { const { encoding: _encoding, ...candidate } = validArtifact(); return candidate; },
+    rejectsOriginal: true,
+  },
+  {
+    name: "literal",
+    mutate(schema) { schema.properties.kind.const = "workflow_handoff_next"; },
+    accepted: () => ({ ...validArtifact(), kind: "workflow_handoff_next" }),
+    rejectsOriginal: true,
+  },
+  {
+    name: "numeric limit",
+    mutate(schema) { schema.properties.token_count.maximum = 0; },
+    accepted: () => ({ ...validArtifact(), token_count: 0 }),
+    rejectsOriginal: true,
+  },
+  {
+    name: "pattern",
+    mutate(schema) { schema.properties.artifact_id.pattern = "^wh_[1-9a-f]{48}$"; },
+    accepted: () => ({ ...validArtifact(), artifact_id: `wh_${"1".repeat(48)}`, storage_ref: `workflow-handoff:wh_${"1".repeat(48)}` }),
+    rejectsOriginal: true,
+  },
+  {
+    name: "property order",
+    mutate(schema) { schema.properties = Object.fromEntries(Object.entries(schema.properties).reverse()); },
+    accepted: validArtifact,
+    rejectsOriginal: false,
+  },
+  {
+    name: "string constraint",
+    mutate(schema) { schema.properties.preview.minLength = 5; },
+    accepted: () => ({ ...validArtifact(), preview: "datum", byte_length: 5 }),
+    rejectsOriginal: true,
+  },
+  {
+    name: "post-validation limit",
+    mutate(schema) { schema["x-agenc-post-validation"].ownerFieldMaxUtf8Bytes = 2; },
+    accepted: () => ({ ...validArtifact(), owner: { run_id: "r", workflow_id: "w", producer_step_id: "s" } }),
+    rejectsOriginal: true,
+  },
+];
+
+describe("exact public workflow handoff generation", () => {
+  it("renders the complete committed file from the real runtime authority", async () => {
+    expect(renderWorkflowHandoffGenerated(JSON.parse(await readFile(schemaFile, "utf8")), await readFile(runtimeFile, "utf8"))).toBe(await readFile(publicFile, "utf8"));
+  });
+
+  it.each(mutations)("detects $name drift and regenerates its validator", async ({ mutate, accepted, rejectsOriginal }) => {
+    const { root, schema, options } = await createFixture();
+    const original = await readFile(options.generatedPath, "utf8");
+    mutate(schema);
+    await writeFile(options.schemaPath, JSON.stringify(schema));
+    await writeFile(options.runtimeSourcePath, fixtureRuntimeSource(schema));
+    expect(await synchronizeWorkflowHandoffGenerated(options)).toMatchObject({ matches: false, changed: false });
+    expect(await readFile(options.generatedPath, "utf8")).toBe(original);
+    expect(await synchronizeWorkflowHandoffGenerated({ ...options, write: true })).toMatchObject({ matches: true, changed: true });
+    expect(await synchronizeWorkflowHandoffGenerated(options)).toMatchObject({ matches: true, changed: false });
+    expect(await synchronizeWorkflowHandoffGenerated({ ...options, write: true })).toMatchObject({ matches: true, changed: false });
+    expect(await validateGenerated(root, accepted())).toEqual({ valid: true });
+    if (rejectsOriginal) expect(await validateGenerated(root, validArtifact())).toMatchObject({ valid: false, name: "WorkflowHandoffArtifactValidationError", code: "WORKFLOW_HANDOFF_SCHEMA" });
+  });
+
+  it("accepts CRLF without rewriting during checks and writes canonical LF", async () => {
+    const { options } = await createFixture();
+    const original = await readFile(options.generatedPath, "utf8");
+    await writeFile(options.generatedPath, original.replaceAll("\n", "\r\n"));
+    expect(await synchronizeWorkflowHandoffGenerated(options)).toMatchObject({ matches: true, changed: false });
+    expect(await readFile(options.generatedPath, "utf8")).toContain("\r\n");
+    await synchronizeWorkflowHandoffGenerated({ ...options, write: true });
+    expect(await readFile(options.generatedPath, "utf8")).toBe(original);
+  });
+
+  it("runs the read-only generator from SDK build and validation", async () => {
+    const manifest = JSON.parse(await readFile(join(repositoryRoot, "packages/agenc-sdk/package.json"), "utf8"));
+    expect(manifest.scripts["check:generated"]).toBe("node ../../runtime/scripts/check-sdk-generated-types.mjs --check");
+    expect(manifest.scripts.build).toMatch(/^npm run check:generated && /u);
+    expect(manifest.scripts.typecheck).toMatch(/^npm run check:generated && /u);
+    expect(manifest.dependencies).toBeUndefined();
+  });
+
+  it("does not evaluate unsupported runtime authority expressions", async () => {
+    const schema = JSON.parse(await readFile(schemaFile, "utf8"));
+    const source = fixtureRuntimeSource(schema).replace("MAX_WORKFLOW_STEP_RESULT_TOKENS = 131072;", "MAX_WORKFLOW_STEP_RESULT_TOKENS = (() => { throw new Error('executed'); })();");
+    expect(() => renderWorkflowHandoffGenerated(schema, source)).toThrow(/unsupported handoff authority expression/);
+  });
+
+  it.each(["optional owner", "owner value type", "storage prefix"])("rejects unsupported handwritten relationship changes to %s", async (kind) => {
+    const { schema, options } = await createFixture();
+    if (kind === "optional owner") schema.required = schema.required.filter((name) => name !== "owner");
+    else if (kind === "owner value type") schema.properties.owner.properties!.run_id = { type: "integer" };
+    else schema.properties.storage_ref.pattern = "^other:wh_[0-9a-f]{48}$";
+    await writeFile(options.schemaPath, JSON.stringify(schema));
+    await writeFile(options.runtimeSourcePath, fixtureRuntimeSource(schema));
+    await expect(synchronizeWorkflowHandoffGenerated({ ...options, write: true })).rejects.toThrow(/unsupported.*relationship/);
+  });
+
+  it("rejects schema-only and constant-only authority drift without writing", async () => {
+    const { schema, options } = await createFixture();
+    const original = await readFile(options.generatedPath, "utf8");
+    schema.properties.preview.minLength = 1;
+    await writeFile(options.schemaPath, JSON.stringify(schema));
+    await expect(synchronizeWorkflowHandoffGenerated({ ...options, write: true })).rejects.toThrow(/schemas disagree/);
+    const source = fixtureRuntimeSource(schema).replace("MAX_WORKFLOW_STEP_RESULT_TOKENS = 131072;", "MAX_WORKFLOW_STEP_RESULT_TOKENS = 131073;");
+    await writeFile(options.runtimeSourcePath, source);
+    await expect(synchronizeWorkflowHandoffGenerated({ ...options, write: true })).rejects.toThrow(/constant.*disagrees/);
+    expect(await readFile(options.generatedPath, "utf8")).toBe(original);
+  });
+
+  it.each(["unknown structural constraint", "unknown post-validation constraint", "unsupported post-validation flag"])("rejects %s instead of omitting it", async (kind) => {
+    const { schema, options } = await createFixture();
+    const original = await readFile(options.generatedPath, "utf8");
+    if (kind === "unknown structural constraint") schema.properties.preview.format = "uri";
+    else if (kind === "unknown post-validation constraint") schema["x-agenc-post-validation"].newConstraint = true;
+    else schema["x-agenc-post-validation"].requireWellFormedUnicode = false;
+    await writeFile(options.schemaPath, JSON.stringify(schema));
+    await writeFile(options.runtimeSourcePath, fixtureRuntimeSource(schema));
+    await expect(synchronizeWorkflowHandoffGenerated({ ...options, write: true })).rejects.toThrow(/unsupported/);
+    expect(await readFile(options.generatedPath, "utf8")).toBe(original);
+  });
+});

--- a/runtime/tests/sdk-package/workflow-handoff.contract.test.ts
+++ b/runtime/tests/sdk-package/workflow-handoff.contract.test.ts
@@ -60,6 +60,53 @@ const artifact = Object.freeze({
 } as const satisfies SdkWorkflowHandoffArtifact);
 
 describe("public workflow handoff artifact contract", () => {
+  it("preserves strict public field validation and accepts null-prototype records", () => {
+    const candidates: readonly unknown[] = [
+      null,
+      [],
+      { ...artifact, extra: true },
+      { ...artifact, format_version: 2 },
+      { ...artifact, kind: "other" },
+      { ...artifact, compatibility_epoch: "future" },
+      { ...artifact, artifact_id: "bad" },
+      { ...artifact, digest: "sha256:bad" },
+      { ...artifact, owner: { ...artifact.owner, extra: "value" } },
+      { ...artifact, owner: { ...artifact.owner, run_id: "" } },
+      { ...artifact, byte_length: -1 },
+      { ...artifact, byte_length: MAX_WORKFLOW_ARTIFACT_BYTES + 1 },
+      { ...artifact, token_count: MAX_WORKFLOW_STEP_RESULT_TOKENS + 1 },
+      { ...artifact, token_count: 1.5 },
+      { ...artifact, created_at_ms: Number.NaN },
+      { ...artifact, commit_sequence: 0 },
+      { ...artifact, media_type: "application/json" },
+      { ...artifact, encoding: "utf-16" },
+      { ...artifact, preview_truncated: "false" },
+    ];
+    for (const candidate of candidates) {
+      expect(() => validateWorkflowHandoffArtifact(candidate)).toThrowError(expect.objectContaining({
+        name: "WorkflowHandoffArtifactValidationError", code: "WORKFLOW_HANDOFF_SCHEMA",
+      }));
+    }
+    for (const field of Object.keys(artifact)) {
+      const missing = { ...artifact } as Record<string, unknown>;
+      delete missing[field];
+      expect(() => validateWorkflowHandoffArtifact(missing)).toThrow();
+    }
+    expect(validateWorkflowHandoffArtifact(Object.assign(Object.create(null), artifact))).toEqual(artifact);
+  });
+
+  it("rejects accessor and non-data records without reading accessors", () => {
+    let reads = 0;
+    const accessor = { ...artifact };
+    Object.defineProperty(accessor, "preview", { enumerable: true, get() { reads += 1; return "data"; } });
+    expect(() => validateWorkflowHandoffArtifact(accessor)).toThrow(/data property/);
+    expect(reads).toBe(0);
+    expect(() => validateWorkflowHandoffArtifact(Object.assign(Object.create({}), artifact))).toThrow(/plain object/);
+    const hidden = { ...artifact };
+    Object.defineProperty(hidden, "preview", { enumerable: false, value: "data" });
+    expect(() => validateWorkflowHandoffArtifact(hidden)).toThrow(/data property/);
+  });
+
   it("keeps JSON schema, runtime validation, and SDK constants aligned", () => {
     const jsonSchema = JSON.parse(readFileSync(schemaPath, "utf8")) as {
       readonly properties: {


### PR DESCRIPTION
## Changes

- Generate the complete public handoff file from the versioned JSON schema, after checking agreement with the runtime schema and named constants through a restricted TypeScript AST reader.
- Generate readonly fields, optionality, literals, limits, and structural validator data. Keep dependency-free Unicode, plain-data-property, byte-length, and relationship validation in a small SDK module.
- Reject unsupported schema keywords, runtime expressions, post-validation flags, and relationship changes instead of silently omitting constraints.
- Add explicit --check, preserve default read-only checks and atomic --write, and run generated checks from SDK build/typecheck as well as runtime build.
- Document exact handoff generation separately from marker-only workflow-result checks.

## Validation

- The real checker rejects the old handwritten SDK file as stale.
- Field addition/removal, optionality, literal, limit, pattern, property order, string constraint, and post-limit fixtures prove drift detection, read-only checks, deterministic writes, and regenerated validator behavior in dependency-free Node processes.
- CRLF/LF, authority disagreement, unsupported expressions/constraints, public validation errors, missing fields, accessors, and record prototypes have direct tests.
- Runtime, test-support, and SDK typechecks pass. All 185 SDK-package and handoff store/spool tests pass; the final expanded generation/behavior suite passes 37 tests. Runtime/SDK builds and real-PTY startup checks pass.
- Full root test suite passes on final head e40020b2b56964ee3c0a9de7ff576b583b52e42c, including 23,466 runtime tests across 2,269 files with no failures or skips. All 38 focused tests pass, including invalid-pattern rejection before writing. Final Bugbot, Security, Approval, and Sonar checks pass with zero new Sonar issues or duplication.
- Hosted Actions remains disabled, with no workflows enabled, dispatched, or rerun. Darwin and Windows execution is not claimed.

Fixes #1941.
