### PR TITLE
test(plugins): bind archive fetch docs to runtime policy

### DIFF
--- a/docs/reference/skills-plugins.md
+++ b/docs/reference/skills-plugins.md
@@ -569,6 +569,10 @@ HTTP(S) tarball and remote mcpb installs fetch through
 | Redirects | Manual follow of 301 / 302 / 303 / 307 / 308, at most 5 hops |
 | Redirect URL | Same `origin` as the previous hop; `http:` / `https:` only; userinfo forbidden |
 
+These defaults come from `PLUGIN_ARCHIVE_FETCH_POLICY` in the plugin resolver.
+Resolver options can override `downloadTimeoutMs` and `maxDownloadBytes`.
+Redirect limits, protocols, origin checks, and credential rules are fixed.
+
 A cross-origin `Location` fails with
 `plugin archive redirects must stay on <origin>: <redacted-url>` and is not
 fetched. Extraction quotas (depth 32, 4096 files, 200 MiB) stay in

--- a/runtime/src/plugins/resolution.ts
+++ b/runtime/src/plugins/resolution.ts
@@ -146,13 +146,19 @@ const MAX_PUBLISHER_PUBLIC_KEYS = 16;
 
 const DEFAULT_PROCESS_TIMEOUT_MS = 120_000;
 const DEFAULT_PROCESS_MAX_OUTPUT_BYTES = 1_048_576;
-const DEFAULT_DOWNLOAD_TIMEOUT_MS = 120_000;
-const DEFAULT_MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024;
+export const PLUGIN_ARCHIVE_FETCH_POLICY = Object.freeze({
+  downloadTimeoutMs: 120_000,
+  maxDownloadBytes: 50 * 1024 * 1024,
+  maxRedirectHops: 5,
+  redirectStatuses: Object.freeze([301, 302, 303, 307, 308] as const),
+  allowedRedirectProtocols: Object.freeze(["http:", "https:"] as const),
+  requireSameOrigin: true,
+  allowUrlCredentials: false,
+});
 const DEFAULT_MAX_EXTRACTED_BYTES = 200 * 1024 * 1024;
 const DEFAULT_MAX_EXTRACTED_FILES = 4096;
 const DEFAULT_MAX_EXTRACT_DEPTH = 32;
 const DEFAULT_CACHE_LOCK_TIMEOUT_MS = 60_000;
-const DEFAULT_MAX_ARCHIVE_REDIRECTS = 5;
 const PLUGIN_INSTALL_METADATA_RELATIVE_PATH = ".agenc-plugin/agenc-install.json";
 const KNOWN_GIT_HOSTS = new Set([
   "github.com",
@@ -1374,7 +1380,7 @@ async function fetchBytes(
   source: string,
   options: PluginResolverOptions,
 ): Promise<Uint8Array> {
-  const maxBytes = options.maxDownloadBytes ?? DEFAULT_MAX_DOWNLOAD_BYTES;
+  const maxBytes = options.maxDownloadBytes ?? PLUGIN_ARCHIVE_FETCH_POLICY.maxDownloadBytes;
   try {
     if (options.fetchBytes) {
       const data = await options.fetchBytes(source);
@@ -1395,7 +1401,7 @@ async function fetchBytesWithRedirectPolicy(
   maxBytes: number,
 ): Promise<Uint8Array> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.downloadTimeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), options.downloadTimeoutMs ?? PLUGIN_ARCHIVE_FETCH_POLICY.downloadTimeoutMs);
   timeout.unref();
   try {
     let current = new URL(source);
@@ -1405,8 +1411,8 @@ async function fetchBytesWithRedirectPolicy(
         redirect: "manual",
       });
       if (isRedirectStatus(response.status)) {
-        if (redirects >= DEFAULT_MAX_ARCHIVE_REDIRECTS) {
-          throw new Error(`plugin archive redirect limit exceeded: ${DEFAULT_MAX_ARCHIVE_REDIRECTS}`);
+        if (redirects >= PLUGIN_ARCHIVE_FETCH_POLICY.maxRedirectHops) {
+          throw new Error(`plugin archive redirect limit exceeded: ${PLUGIN_ARCHIVE_FETCH_POLICY.maxRedirectHops}`);
         }
         current = nextPluginArchiveRedirectUrl(current, response);
         continue;
@@ -1451,20 +1457,20 @@ async function fetchBytesWithRedirectPolicy(
 }
 
 function isRedirectStatus(status: number): boolean {
-  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+  return PLUGIN_ARCHIVE_FETCH_POLICY.redirectStatuses.some((allowed) => status === allowed);
 }
 
 function nextPluginArchiveRedirectUrl(current: URL, response: Response): URL {
   const location = response.headers.get("location");
   if (!location) throw new Error("plugin archive redirect is missing a location header");
   const next = new URL(location, current);
-  if (!["http:", "https:"].includes(next.protocol)) {
+  if (!PLUGIN_ARCHIVE_FETCH_POLICY.allowedRedirectProtocols.some((protocol) => next.protocol === protocol)) {
     throw new Error(`plugin archive redirect uses an unsupported protocol: ${next.protocol}`);
   }
-  if (next.username || next.password) {
+  if (!PLUGIN_ARCHIVE_FETCH_POLICY.allowUrlCredentials && (next.username || next.password)) {
     throw new Error("plugin archive redirects with URL credentials are not allowed");
   }
-  if (next.origin !== current.origin) {
+  if (PLUGIN_ARCHIVE_FETCH_POLICY.requireSameOrigin && next.origin !== current.origin) {
     throw new Error(
       `plugin archive redirects must stay on ${current.origin}: ${redactPluginSource(next.toString())}`,
     );

--- a/runtime/src/plugins/resolution.ts
+++ b/runtime/src/plugins/resolution.ts
@@ -150,8 +150,8 @@ export const PLUGIN_ARCHIVE_FETCH_POLICY = Object.freeze({
   downloadTimeoutMs: 120_000,
   maxDownloadBytes: 50 * 1024 * 1024,
   maxRedirectHops: 5,
-  redirectStatuses: Object.freeze([301, 302, 303, 307, 308] as const),
-  allowedRedirectProtocols: Object.freeze(["http:", "https:"] as const),
+  redirectStatuses: Object.freeze([301, 302, 303, 307, 308]),
+  allowedRedirectProtocols: Object.freeze(["http:", "https:"]),
   requireSameOrigin: true,
   allowUrlCredentials: false,
 });
@@ -1457,14 +1457,14 @@ async function fetchBytesWithRedirectPolicy(
 }
 
 function isRedirectStatus(status: number): boolean {
-  return PLUGIN_ARCHIVE_FETCH_POLICY.redirectStatuses.some((allowed) => status === allowed);
+  return PLUGIN_ARCHIVE_FETCH_POLICY.redirectStatuses.includes(status);
 }
 
 function nextPluginArchiveRedirectUrl(current: URL, response: Response): URL {
   const location = response.headers.get("location");
   if (!location) throw new Error("plugin archive redirect is missing a location header");
   const next = new URL(location, current);
-  if (!PLUGIN_ARCHIVE_FETCH_POLICY.allowedRedirectProtocols.some((protocol) => next.protocol === protocol)) {
+  if (!PLUGIN_ARCHIVE_FETCH_POLICY.allowedRedirectProtocols.includes(next.protocol)) {
     throw new Error(`plugin archive redirect uses an unsupported protocol: ${next.protocol}`);
   }
   if (!PLUGIN_ARCHIVE_FETCH_POLICY.allowUrlCredentials && (next.username || next.password)) {

--- a/runtime/tests/plugins/archive-fetch-policy.test.ts
+++ b/runtime/tests/plugins/archive-fetch-policy.test.ts
@@ -1,0 +1,134 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { PLUGIN_ARCHIVE_FETCH_POLICY, resolvePluginSource } from "../../src/plugins/resolution.js";
+
+const roots: string[] = [];
+const archiveUrl = "https://plugins.example.test/archive.tgz";
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function resolverOptions() {
+  const root = await mkdtemp(join(tmpdir(), "agenc-archive-policy-"));
+  roots.push(root);
+  const pluginStorageRoot = join(root, "home", "plugins");
+  const sessionTempRoot = join(root, "session-tmp");
+  await Promise.all([mkdir(pluginStorageRoot, { recursive: true }), mkdir(sessionTempRoot, { recursive: true })]);
+  return { agencHome: join(root, "home"), pluginStorageRoot, sessionTempRoot, workspaceRoot: root, requireSignature: false, cache: false };
+}
+
+describe("canonical plugin archive fetch policy", () => {
+  test("freezes every policy value and nested list", () => {
+    expect(Object.isFrozen(PLUGIN_ARCHIVE_FETCH_POLICY)).toBe(true);
+    expect(Object.isFrozen(PLUGIN_ARCHIVE_FETCH_POLICY.redirectStatuses)).toBe(true);
+    expect(Object.isFrozen(PLUGIN_ARCHIVE_FETCH_POLICY.allowedRedirectProtocols)).toBe(true);
+  });
+
+  test.each(PLUGIN_ARCHIVE_FETCH_POLICY.redirectStatuses)("follows a same-origin %s redirect manually", async (status) => {
+    const options = await resolverOptions();
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status, headers: { location: "/next.tgz" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 418 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolvePluginSource(archiveUrl, options)).rejects.toThrow(/failed to fetch plugin archive: 418/u);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith("https://plugins.example.test/next.tgz", expect.objectContaining({ redirect: "manual" }));
+  });
+
+  test("allows exactly the canonical number of redirect hops", async () => {
+    const options = await resolverOptions();
+    let requests = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      requests += 1;
+      return requests <= PLUGIN_ARCHIVE_FETCH_POLICY.maxRedirectHops
+        ? new Response(null, { status: 301, headers: { location: "/next.tgz" } })
+        : new Response(null, { status: 418 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolvePluginSource(archiveUrl, options)).rejects.toThrow(/failed to fetch plugin archive: 418/u);
+    expect(fetchMock).toHaveBeenCalledTimes(PLUGIN_ARCHIVE_FETCH_POLICY.maxRedirectHops + 1);
+  });
+
+  test("refuses to fetch a hop beyond the canonical redirect limit", async () => {
+    const options = await resolverOptions();
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 301, headers: { location: "/loop.tgz" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolvePluginSource(archiveUrl, options)).rejects.toThrow(`plugin archive redirect limit exceeded: ${PLUGIN_ARCHIVE_FETCH_POLICY.maxRedirectHops}`);
+    expect(fetchMock).toHaveBeenCalledTimes(PLUGIN_ARCHIVE_FETCH_POLICY.maxRedirectHops + 1);
+  });
+
+  test.each([
+    ["cross-origin", "https://other.example.test/private.tgz", /redirects must stay on/u],
+    ["credentials", "https://opaque:secret@plugins.example.test/private.tgz", /URL credentials are not allowed/u],
+    ["unsupported protocol", "ftp://plugins.example.test/private.tgz", /unsupported protocol/u],
+  ] as const)("rejects %s without fetching the destination", async (_label, location, expectedError) => {
+    const options = await resolverOptions();
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 302, headers: { location } }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolvePluginSource(archiveUrl, options)).rejects.toThrow(expectedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([undefined, 7])("enforces the default timeout or %s ms override", async (downloadTimeoutMs) => {
+    const options = await resolverOptions();
+    let notifyFetch!: () => void;
+    const fetched = new Promise<void>((resolve) => { notifyFetch = resolve; });
+    let signal: AbortSignal | null | undefined;
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>((_input, init) => {
+      signal = init?.signal;
+      const response = new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("archive request aborted")), { once: true });
+      });
+      notifyFetch();
+      return response;
+    }));
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const assertion = expect(resolvePluginSource(archiveUrl, { ...options, downloadTimeoutMs })).rejects.toThrow(/archive request aborted/u);
+    await fetched;
+    await vi.advanceTimersByTimeAsync((downloadTimeoutMs ?? PLUGIN_ARCHIVE_FETCH_POLICY.downloadTimeoutMs) - 1);
+    expect(signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(signal?.aborted).toBe(true);
+    await assertion;
+  });
+
+  test.each([undefined, 3])("enforces the default content-length ceiling or %s byte override", async (maxDownloadBytes) => {
+    const options = await resolverOptions();
+    const maximum = maxDownloadBytes ?? PLUGIN_ARCHIVE_FETCH_POLICY.maxDownloadBytes;
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(async () => new Response(null, { headers: { "content-length": String(maximum + 1) } })));
+    await expect(resolvePluginSource(archiveUrl, { ...options, maxDownloadBytes })).rejects.toThrow(/exceeds maximum download size/u);
+  });
+
+  test("cancels streamed overflow before accepting an archive", async () => {
+    const options = await resolverOptions();
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+        controller.enqueue(new Uint8Array([3, 4]));
+      },
+      cancel,
+    });
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(async () => new Response(body)));
+    await expect(resolvePluginSource(archiveUrl, { ...options, maxDownloadBytes: 3 })).rejects.toThrow(/exceeds maximum download size/u);
+    expect(cancel).toHaveBeenCalledWith("plugin archive exceeded maximum download size");
+  });
+
+  test("keeps the size ceiling on custom byte fetchers", async () => {
+    const options = await resolverOptions();
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(resolvePluginSource(archiveUrl, {
+      ...options,
+      maxDownloadBytes: 3,
+      fetchBytes: async () => new Uint8Array([1, 2, 3, 4]),
+    })).rejects.toThrow(/exceeds maximum download size/u);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/plugins/plugin-source-documentation.contract.test.ts
+++ b/runtime/tests/plugins/plugin-source-documentation.contract.test.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
+  PLUGIN_ARCHIVE_FETCH_POLICY,
   classifyPluginSource,
   pluginInstallSourceNeedsRedaction,
   pluginSourceNeedsRedaction,
@@ -21,6 +22,13 @@ const PLUGIN_REFERENCE = resolve(
 );
 
 describe("plugin source documentation contract", () => {
+  test("normalizes equivalent time and byte units in the policy table", async () => {
+    const section = markdownSection(await readFile(PLUGIN_REFERENCE, "utf8"), "Remote archive fetch and recorded sources")
+      .replace(/\| Download timeout \|[^|]+\|/u, `| Download timeout | ${PLUGIN_ARCHIVE_FETCH_POLICY.downloadTimeoutMs} ms |`)
+      .replace(/\| Download size \|[^|]+\|/u, `| Download size | ${PLUGIN_ARCHIVE_FETCH_POLICY.maxDownloadBytes} B |`);
+    expect(parseArchiveFetchPolicyTable(section)).toEqual(PLUGIN_ARCHIVE_FETCH_POLICY);
+  });
+
   test("keeps local and npm examples in their matching shell fences", async () => {
     const markdown = await readFile(PLUGIN_REFERENCE, "utf8");
     const installSources = markdownSection(markdown, "Install sources");
@@ -90,9 +98,7 @@ describe("plugin source documentation contract", () => {
       "has no recorded source; rerun with --source <source>",
     );
     expect(section).toContain("sourceRedacted");
-    expect(section).toContain("50 MiB");
-    expect(section).toMatch(/at most 5 hops/u);
-    expect(section).toContain("120 s");
+    expect(parseArchiveFetchPolicyTable(section)).toEqual(PLUGIN_ARCHIVE_FETCH_POLICY);
 
     expect(bashSources).toEqual([
       "'https://github.com/acme/tool.mcpb?download=1'",
@@ -205,6 +211,48 @@ function markdownSection(markdown: string, title: string): string {
     .slice(headingIndex + 1)
     .find((match) => match[1]!.length <= headingLevel);
   return markdown.slice(sectionStart, nextHeading?.index ?? markdown.length);
+}
+
+function policyQuantity(value: string, units: Readonly<Record<string, number>>): number {
+  const match = /^(\d+(?:\.\d+)?)\s+([A-Za-z]+)(?:\s+\(.*\))?$/u.exec(value);
+  const multiplier = match === null ? undefined : units[match[2]!];
+  if (match === null || multiplier === undefined) throw new Error(`invalid policy quantity ${value}`);
+  const quantity = Number(match[1]) * multiplier;
+  if (!Number.isSafeInteger(quantity)) throw new Error(`invalid policy quantity ${value}`);
+  return quantity;
+}
+
+function policyBoolean(value: string, enabled: string, disabled: string): boolean {
+  if (value === enabled) return true;
+  if (value === disabled) return false;
+  throw new Error(`invalid policy rule ${value}`);
+}
+
+function parseArchiveFetchPolicyTable(section: string) {
+  const cells = section.split(/\r?\n/u)
+    .filter((line) => line.startsWith("|"))
+    .map((line) => line.slice(1, -1).split("|").map((cell) => cell.trim()));
+  expect(cells.slice(0, 2)).toEqual([["Constraint", "Default"], ["---", "---"]]);
+  expect(cells).toHaveLength(6);
+  const rows = new Map(cells.slice(2).map(([label, value]) => [label, value]));
+  expect(rows.size).toBe(4);
+  const redirects = /^Manual follow of (\d+(?:\s*\/\s*\d+)*), at most (\d+) hops$/u.exec(rows.get("Redirects") ?? "");
+  if (redirects === null) throw new Error("invalid redirect policy row");
+  const redirectRules = (rows.get("Redirect URL") ?? "").split(";").map((rule) => rule.trim());
+  expect(redirectRules).toHaveLength(3);
+  const protocolRule = redirectRules[1]!;
+  expect(protocolRule.endsWith(" only")).toBe(true);
+  const protocols = protocolRule.slice(0, -" only".length).replaceAll("`", "").split(/\s*\/\s*/u);
+  expect(protocols.every((protocol) => /^[a-z][a-z0-9+.-]*:$/u.test(protocol))).toBe(true);
+  return {
+    downloadTimeoutMs: policyQuantity(rows.get("Download timeout") ?? "", { ms: 1, s: 1000 }),
+    maxDownloadBytes: policyQuantity(rows.get("Download size") ?? "", { B: 1, KiB: 1024, MiB: 1024 * 1024 }),
+    maxRedirectHops: Number(redirects[2]),
+    redirectStatuses: redirects[1]!.split(/\s*\/\s*/u).map(Number),
+    allowedRedirectProtocols: protocols,
+    requireSameOrigin: policyBoolean(redirectRules[0]!, "Same `origin` as the previous hop", "Cross-origin allowed"),
+    allowUrlCredentials: policyBoolean(redirectRules[2]!, "userinfo allowed", "userinfo forbidden"),
+  };
 }
 
 function parseMarkdownFences(markdown: string): readonly MarkdownFence[] {


### PR DESCRIPTION
## Summary

- Define an immutable archive-fetch policy consumed by the production resolver and documentation tests. Defaults and option overrides stay unchanged.
- Parse the Markdown policy table with time/byte unit normalization instead of testing independent numeric strings.
- Cover manual redirect statuses and hop limits, origin/protocol/credential rejection, timeouts, declared and streamed size limits, custom fetchers, and existing source-redaction examples.

## Validation

- Runtime and test-support typecheck, all 323 plugin tests, runtime build, and real PTY startup checks pass locally.
- Seven production-policy mutations each made the documentation contract fail; the source was restored and its exact checksum verified after every probe.
- GitNexus impact and staged change detection report low risk. New test helpers are not indexed; the diff was also reviewed manually. Index line drift labels some unchanged neighboring helpers.
- The full local suite is running on this commit; results will be recorded before merge.
- Automatic hosted CI remains disabled. No Actions runs were enabled or dispatched.

Fixes #1954

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor centralizes existing fetch limits with no intended behavior change; added tests and doc contracts reduce drift risk on a security-sensitive download path.
> 
> **Overview**
> Introduces a frozen, exported **`PLUGIN_ARCHIVE_FETCH_POLICY`** in the plugin resolver and routes archive download/redirect logic through it instead of scattered constants. **Runtime behavior is unchanged**: `downloadTimeoutMs` and `maxDownloadBytes` remain overridable via resolver options; redirect hop limits, allowed statuses/protocols, same-origin checks, and credential rules stay fixed.
> 
> **Documentation** in `skills-plugins.md` now names `PLUGIN_ARCHIVE_FETCH_POLICY` and clarifies what can vs. cannot be overridden.
> 
> **Tests** add `archive-fetch-policy.test.ts` (redirects, limits, timeouts, streamed size caps, custom `fetchBytes`) and tighten the docs contract test by **parsing the Markdown policy table** (with ms/MiB normalization) and asserting equality with the runtime policy object instead of brittle string checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70beb9026116d7d934f74e3238d99e4b6f9c20de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->