### PR TITLE
A turn resumed after a daemon restart waits for the approval bridge

### DIFF
--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1004,17 +1004,28 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               }
             : {}),
           deferSessionStartHooks: true,
-          // A daemon restore is exactly the case where an orphaned in-flight
-          // turn exists, and bootstrap would resume-continue it before this
-          // method can install the approval bridge or register the agent.
-          // Keep that one step for `#driveDeferredDurableResume` below (#2239).
-          deferDurableTurnResume: true,
+          // The two deferrals are mutually exclusive, and which one applies
+          // decides where the orphaned in-flight turn gets resumed (#2239).
+          //
+          // `deferAgentStartupSideEffects` already postpones the WHOLE startup
+          // prewarm — the durable resume with it — to the first ordinary
+          // submit, which cannot happen before this method returns, installs
+          // the approval bridge and registers the agent. That shape needs no
+          // help. Withholding the resume from it as well would strand the
+          // turn: nothing calls `runDeferredDurableTurnResume` once
+          // `restoreAgent` has returned, and the orphan is single-shot
+          // (bootstrap's replay persists its `turn_aborted{process_killed}`),
+          // so it would be lost rather than merely late.
+          //
+          // Otherwise bootstrap runs the prewarm inline and would
+          // resume-continue the turn before either prerequisite exists, so
+          // that one step is kept for `#driveDeferredDurableResume` below.
           ...(params.resumeSuspendedRun === true ||
           params.resumeStartupActivationPending === true
             ? {
                 deferAgentStartupSideEffects: true,
               }
-            : {}),
+            : { deferDurableTurnResume: true }),
           argv: buildBootstrapArgv(
             restoreBootstrapSelection(params),
             this.#argv,
@@ -1308,21 +1319,43 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           params.agentId,
           active,
         );
-        await this.#hydrateRecoveredAgentState({
-          agentId: params.agentId,
-          session: bootstrap.session,
-          registry: bootstrap.registry,
-          thread: managedThread,
-          initialMessages: params.initialMessages ?? [],
-          replayToolCalls: params.replayToolCalls ?? [],
-          currentSessionId: params.currentSessionId,
-          onReplayToolResult: params.onReplayToolResult,
-        });
+        const restoredSession = bootstrap.session;
+        const recoveredInitialMessages = params.initialMessages ?? [];
+        const recoveredReplayedMessages =
+          await this.#hydrateRecoveredAgentState({
+            agentId: params.agentId,
+            session: restoredSession,
+            registry: bootstrap.registry,
+            thread: managedThread,
+            initialMessages: recoveredInitialMessages,
+            replayToolCalls: params.replayToolCalls ?? [],
+            currentSessionId: params.currentSessionId,
+            onReplayToolResult: params.onReplayToolResult,
+          });
         params.signal?.throwIfAborted();
         // Last: this generation now owns `#active`, the approval bridge, and
         // the canonical event bridge, so a resumed turn that needs approval
         // reaches a client instead of the arbiter default deny.
-        this.#driveDeferredDurableResume(active);
+        await this.#driveDeferredDurableResume(
+          params.agentId,
+          active,
+          // The resumed turn republishes `session.state.history` from the
+          // checkpoint prefix it continues (`syncSessionState`), which erases
+          // the recovered conversation hydrated just above. Re-apply it once
+          // the turn is over, which is the order that held while the resume
+          // ran inside bootstrap.
+          () =>
+            hydrateRecoveredSessionHistory(restoredSession, {
+              initialMessages: recoveredInitialMessages,
+              replayedMessages: recoveredReplayedMessages,
+            }),
+        );
+        // Waiting for the recovered turn to start is a new suspension point,
+        // so an abort raised during it must still fail the restore rather
+        // than publish this generation. `#bindBootstrapCancellation` aborts
+        // the session on that signal, which ends the resumed turn and
+        // releases the wait above.
+        params.signal?.throwIfAborted();
         return true;
       } catch (error) {
         const cleanupErrors: unknown[] = [];
@@ -1776,7 +1809,7 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     readonly onReplayToolResult?: (
       result: AgenCBackgroundAgentReplayToolResult,
     ) => void | Promise<void>;
-  }): Promise<void> {
+  }): Promise<readonly LLMMessage[]> {
     const replayedMessages = await replayRecoveredToolCalls({
       thread: params.thread,
       parent: params.session,
@@ -1796,6 +1829,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       initialMessages: params.initialMessages,
       replayedMessages,
     });
+    // Returned so the caller can re-apply the history merge after a durable
+    // resume has republished the same slot; the tool calls themselves are
+    // dispatched exactly once, here (#2239).
+    return replayedMessages;
   }
 
   async attachAgentSessionEvents(
@@ -4237,32 +4274,77 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
    * AFTER `#active.set`, because `#requestDaemonToolDecision` denies outright
    * for an agent that is not registered.
    *
-   * Deliberately NOT awaited by `restoreAgent`: an approval has no default
-   * timeout, so awaiting it would block the whole restore — and the daemon's
-   * own startup — on a human decision that cannot be delivered until restore
-   * returns and a client attaches. The permission request is buffered on the
-   * agent until then. The promise is retained on the generation so the
-   * in-flight resume stays observable; stopping the agent aborts the session,
-   * which ends the resumed turn.
+   * Returns once the recovered turn has STARTED (`turn_resumed`) or the resume
+   * has finished without one — never once it has completed. Waiting for the
+   * start closes the window in which `restoreAgent` had already returned while
+   * the resume was still queued: a client that submitted in that window had
+   * its brand-new turn aborted `replaced` by the late resume. With the
+   * recovered turn already holding the session's turn slot, the newer user
+   * message replaces the resume instead, which is the direction every other
+   * in-flight turn follows. Waiting for COMPLETION is not an option: an
+   * approval has no default timeout, so it would block the restore — and the
+   * daemon's own startup — on a decision that cannot be delivered until
+   * restore returns and a client attaches. The request buffers on the agent
+   * until then.
    *
-   * A user message that arrives while the resumed turn waits for its approval
-   * is never queued behind it: `Session.spawnTask` aborts the running turn as
-   * `replaced`, so the new message wins exactly as it does for any other
-   * in-flight turn.
+   * `reapplyRecoveredHistory` runs after the resumed turn is over, because the
+   * turn republishes `session.state.history` from its checkpoint prefix and
+   * would otherwise leave the daemon-recovered conversation erased.
    */
-  #driveDeferredDurableResume(active: ActiveBackgroundAgent): void {
+  async #driveDeferredDurableResume(
+    agentId: string,
+    active: ActiveBackgroundAgent,
+    reapplyRecoveredHistory: () => Promise<void>,
+  ): Promise<void> {
     const runDeferredDurableTurnResume =
       active.bootstrap.runDeferredDurableTurnResume;
     if (typeof runDeferredDurableTurnResume !== "function") return;
-    active.durableResumeComplete = (async () => {
+    let signalStarted = (): void => {};
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
+    const stopWatchingForStart = subscribeDurableResumeStarted(
+      active.bootstrap.session,
+      () => signalStarted(),
+    );
+    const finished = (async () => {
       try {
-        await runDeferredDurableTurnResume();
+        const attempt = await runDeferredDurableTurnResume();
+        if (attempt.resumed !== true) return;
+        await this.#reapplyRecoveredHistory(
+          agentId,
+          active,
+          reapplyRecoveredHistory,
+        );
       } catch {
         // The resume is best-effort and already records its own failure on
         // the conversation thread record; it must never surface as an
         // unhandled rejection on a live daemon.
+      } finally {
+        stopWatchingForStart();
+        signalStarted();
       }
     })();
+    void finished.catch(() => undefined);
+    await Promise.race([finished, started]);
+  }
+
+  /**
+   * Restore the daemon-recovered conversation the resumed turn republished
+   * over. Skipped when a newer turn owns the history — a user message that
+   * replaced the resume is the fresher authority, and appending recovered
+   * tool results underneath it would rewrite a live turn's context — and when
+   * this generation no longer owns the agent.
+   */
+  async #reapplyRecoveredHistory(
+    agentId: string,
+    active: ActiveBackgroundAgent,
+    reapplyRecoveredHistory: () => Promise<void>,
+  ): Promise<void> {
+    if (this.#active.get(agentId) !== active) return;
+    if (!isRunnableActiveAgent(active)) return;
+    if (active.bootstrap.session.activeTurn.unsafePeek() !== null) return;
+    await reapplyRecoveredHistory();
   }
 
   #installDaemonApprovalBridge(
@@ -5089,6 +5171,25 @@ async function consumeDaemonPendingProviderSwitches(
       `provider switch to ${pending.provider}/${pending.model} could not be applied before turn: ${outcome.reason}`,
     );
   }
+}
+
+/**
+ * Call `onStarted` the first time the session re-opens a durable turn.
+ *
+ * `turn_resumed` is emitted by `run-turn` immediately after `spawnTask` has
+ * installed the recovered turn as the session's active turn and before any
+ * phase work, so it is the earliest point at which the resume can no longer be
+ * beaten to the turn slot by a client message (#2239).
+ */
+function subscribeDurableResumeStarted(
+  session: LocalRuntimeBootstrap["session"],
+  onStarted: () => void,
+): () => void {
+  // Typed on purpose: renaming the event or the subscription must break the
+  // build here rather than turn the start barrier into a silent no-op.
+  return session.eventLog.subscribe((event) => {
+    if (event.msg.type === "turn_resumed") onStarted();
+  });
 }
 
 // Install the daemon turn driver. Prompt ingress normally runs before durable

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -164,10 +164,11 @@ import {
 } from "../state/runtime-settings-snapshot.js";
 import { runWithAgentRuntimeOptions } from "../session/runtime-options.js";
 import { shutdownSessionLifecycle } from "../session/lifecycle.js";
-import { withTimeout } from "../utils/sleep.js";
+import { sleep, withTimeout } from "../utils/sleep.js";
 import {
   DaemonOperationScope,
   DAEMON_AGENT_STOP_TIMEOUT_MS,
+  DAEMON_AGENT_CREATE_TIMEOUT_MS,
   DAEMON_AGENT_HARD_STOP_TIMEOUT_MS,
 } from "./operation-deadline.js";
 
@@ -384,6 +385,7 @@ export {
 
 export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentRunner {
   readonly #agentStopTimeoutMs: number;
+  readonly #durableResumeTimeoutMs: number;
   readonly #bootstrap: AgenCBootstrapFunction;
   readonly #requireSandboxReadyAtStartup: boolean;
   readonly #ensureAgentControl: AgenCEnsureAgentControlFunction;
@@ -416,6 +418,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
     this.#agentStopTimeoutMs = options.agentStopTimeoutMs ?? DAEMON_AGENT_STOP_TIMEOUT_MS;
     if (!Number.isSafeInteger(this.#agentStopTimeoutMs) || this.#agentStopTimeoutMs <= 0 || this.#agentStopTimeoutMs > 2_147_483_647) {
       throw new RangeError("agentStopTimeoutMs must be a positive timer interval");
+    }
+    this.#durableResumeTimeoutMs =
+      options.durableResumeTimeoutMs ?? DAEMON_AGENT_CREATE_TIMEOUT_MS;
+    if (!Number.isSafeInteger(this.#durableResumeTimeoutMs) || this.#durableResumeTimeoutMs <= 0 || this.#durableResumeTimeoutMs > 2_147_483_647) {
+      throw new RangeError("durableResumeTimeoutMs must be a positive timer interval");
     }
     this.#bootstrap = options.bootstrap ?? bootstrapLocalRuntimeSession;
     this.#requireSandboxReadyAtStartup = options.bootstrap === undefined;
@@ -1004,22 +1011,25 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               }
             : {}),
           deferSessionStartHooks: true,
-          // The two deferrals are mutually exclusive, and which one applies
-          // decides where the orphaned in-flight turn gets resumed (#2239).
+          // The two deferrals are mutually exclusive (#2239).
           //
-          // `deferAgentStartupSideEffects` already postpones the WHOLE startup
-          // prewarm — the durable resume with it — to the first ordinary
-          // submit, which cannot happen before this method returns, installs
-          // the approval bridge and registers the agent. That shape needs no
-          // help. Withholding the resume from it as well would strand the
-          // turn: nothing calls `runDeferredDurableTurnResume` once
-          // `restoreAgent` has returned, and the orphan is single-shot
+          // Without `deferAgentStartupSideEffects`, bootstrap runs the startup
+          // prewarm inline and would resume-continue the orphaned turn before
+          // either prerequisite exists, so that ONE step is withheld here for
+          // `#driveDeferredDurableResume` below.
+          //
+          // With it, `bin/bootstrap.ts` gates the whole prewarm block on the
+          // same flag from INSIDE the function it defers, so
+          // `runStartupPrewarm` runs for those restores neither at bootstrap
+          // nor on the first ordinary submit — the orphan is not resumed at
+          // all today, before or after this change. That gap is pre-existing
+          // and out of scope here. Not setting `deferDurableTurnResume` on top
+          // of it is therefore a no-op right now, and deliberately so: if the
+          // prewarm is ever moved onto the deferred submit hook, the flag
+          // would mark the resume pending long after `#driveDeferredDurableResume`
+          // has already run and returned, and the orphan is single-shot
           // (bootstrap's replay persists its `turn_aborted{process_killed}`),
           // so it would be lost rather than merely late.
-          //
-          // Otherwise bootstrap runs the prewarm inline and would
-          // resume-continue the turn before either prerequisite exists, so
-          // that one step is kept for `#driveDeferredDurableResume` below.
           ...(params.resumeSuspendedRun === true ||
           params.resumeStartupActivationPending === true
             ? {
@@ -1337,7 +1347,6 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         // the canonical event bridge, so a resumed turn that needs approval
         // reaches a client instead of the arbiter default deny.
         await this.#driveDeferredDurableResume(
-          params.agentId,
           active,
           // The resumed turn republishes `session.state.history` from the
           // checkpoint prefix it continues (`syncSessionState`), which erases
@@ -1349,12 +1358,14 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               initialMessages: recoveredInitialMessages,
               replayedMessages: recoveredReplayedMessages,
             }),
+          // Callers that own a restore deadline (the on-demand lifecycle path)
+          // release the wait immediately on abort; the daemon-startup path
+          // passes none, which is why that wait is also bounded by a timeout.
+          params.signal,
         );
         // Waiting for the recovered turn to start is a new suspension point,
         // so an abort raised during it must still fail the restore rather
-        // than publish this generation. `#bindBootstrapCancellation` aborts
-        // the session on that signal, which ends the resumed turn and
-        // releases the wait above.
+        // than publish this generation.
         params.signal?.throwIfAborted();
         return true;
       } catch (error) {
@@ -4274,77 +4285,144 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
    * AFTER `#active.set`, because `#requestDaemonToolDecision` denies outright
    * for an agent that is not registered.
    *
-   * Returns once the recovered turn has STARTED (`turn_resumed`) or the resume
-   * has finished without one — never once it has completed. Waiting for the
-   * start closes the window in which `restoreAgent` had already returned while
-   * the resume was still queued: a client that submitted in that window had
-   * its brand-new turn aborted `replaced` by the late resume. With the
-   * recovered turn already holding the session's turn slot, the newer user
-   * message replaces the resume instead, which is the direction every other
-   * in-flight turn follows. Waiting for COMPLETION is not an option: an
-   * approval has no default timeout, so it would block the restore — and the
-   * daemon's own startup — on a decision that cannot be delivered until
-   * restore returns and a client attaches. The request buffers on the agent
-   * until then.
+   * Returns once the recovered turn has STARTED (`turn_resumed`), or the
+   * resume has finished without one, or `durableResumeTimeoutMs` expires —
+   * never once it has completed. Waiting for the start closes the window in
+   * which `restoreAgent` had already returned while the resume was still
+   * queued: a client that submitted in that window had its brand-new turn
+   * aborted `replaced` by the late resume. With the recovered turn already
+   * holding the session's turn slot, the newer user message replaces the
+   * resume instead, which is the direction every other in-flight turn follows.
+   *
+   * Waiting for COMPLETION is not an option: an approval has no default
+   * timeout, so it would block the restore — and the daemon's own startup — on
+   * a decision that cannot be delivered until restore returns and a client
+   * attaches. The request buffers on the agent until then.
+   *
+   * The bound is not optional either. Everything the resume does before
+   * `turn_resumed` can block (checkpoint provider restore, `spawnTask`'s abort
+   * drain, the fsync-durable emit), `daemon-cli` awaits every recovered
+   * restore serially BEFORE `socketServer.listen()`, and the only caller on
+   * that path passes no `signal` — so an unbounded wait here stops the daemon
+   * from ever listening, and with it the client attach this fix exists to
+   * enable. `durableResumeTimeoutMs` defaults to the deadline the inline
+   * resume already ran under (`DaemonOperationScope("session startup prewarm",
+   * DAEMON_AGENT_CREATE_TIMEOUT_MS)` in `bin/bootstrap.ts`), so the restore
+   * cannot block for longer than it did before the reorder.
+   *
+   * On expiry the resume KEEPS RUNNING and the reason is recorded on the
+   * session. Cancelling it would be worse than late: the orphan is single-shot
+   * (bootstrap's replay has already persisted its `turn_aborted{process_killed}`),
+   * so abandoning it destroys the interrupted turn, where the only thing lost
+   * by not waiting is the start barrier — the pre-existing race in which a
+   * client message submitted in the gap is replaced by the late resume.
    *
    * `reapplyRecoveredHistory` runs after the resumed turn is over, because the
    * turn republishes `session.state.history` from its checkpoint prefix and
    * would otherwise leave the daemon-recovered conversation erased.
    */
   async #driveDeferredDurableResume(
-    agentId: string,
     active: ActiveBackgroundAgent,
     reapplyRecoveredHistory: () => Promise<void>,
+    signal: AbortSignal | undefined,
   ): Promise<void> {
     const runDeferredDurableTurnResume =
       active.bootstrap.runDeferredDurableTurnResume;
     if (typeof runDeferredDurableTurnResume !== "function") return;
+    const session = active.bootstrap.session;
     let signalStarted = (): void => {};
     const started = new Promise<void>((resolve) => {
       signalStarted = resolve;
     });
-    const stopWatchingForStart = subscribeDurableResumeStarted(
-      active.bootstrap.session,
-      () => signalStarted(),
-    );
+    let turnWasOpened = false;
+    const stopWatchingForStart = subscribeDurableResumeStarted(session, () => {
+      turnWasOpened = true;
+      signalStarted();
+    });
     const finished = (async () => {
       try {
-        const attempt = await runDeferredDurableTurnResume();
-        if (attempt.resumed !== true) return;
-        await this.#reapplyRecoveredHistory(
-          agentId,
-          active,
-          reapplyRecoveredHistory,
-        );
+        let resumed = false;
+        try {
+          resumed = (await runDeferredDurableTurnResume()).resumed === true;
+        } catch {
+          // The resume is best-effort and already records its own failure on
+          // the conversation thread record.
+        }
+        // History is republished by `syncSessionState` only if a turn actually
+        // re-opened, so `turn_resumed` — not just a clean attempt outcome —
+        // also decides this: a resume that threw after re-opening the turn
+        // overwrote the recovered conversation just the same.
+        if (!resumed && !turnWasOpened) return;
+        await this.#reapplyRecoveredHistory(active, reapplyRecoveredHistory);
       } catch {
-        // The resume is best-effort and already records its own failure on
-        // the conversation thread record; it must never surface as an
-        // unhandled rejection on a live daemon.
+        // Nothing here may surface as an unhandled rejection on a live daemon.
       } finally {
         stopWatchingForStart();
         signalStarted();
       }
     })();
     void finished.catch(() => undefined);
-    await Promise.race([finished, started]);
+    const outcome = await waitForDurableResumeStart(
+      started,
+      this.#durableResumeTimeoutMs,
+      signal,
+    );
+    if (outcome !== "timed-out") return;
+    // Recorded, never silent: the operator and the client that attaches next
+    // both learn that this agent's recovered turn had not started yet, and
+    // that the daemon went on listening rather than waiting for it.
+    emitDurableResumeWarning(
+      session,
+      "durable_resume_start_timeout",
+      `the recovered turn did not start within ${this.#durableResumeTimeoutMs}ms; ` +
+        "daemon startup continued and the resume is still running in the background",
+    );
   }
 
   /**
    * Restore the daemon-recovered conversation the resumed turn republished
-   * over. Skipped when a newer turn owns the history — a user message that
-   * replaced the resume is the fresher authority, and appending recovered
-   * tool results underneath it would rewrite a live turn's context — and when
-   * this generation no longer owns the agent.
+   * over.
+   *
+   * A newer turn owning the session's turn slot is the hard case: a client
+   * message that replaced the resume is the fresher authority, and merging the
+   * recovered tool results underneath a live turn would rewrite its context —
+   * and be overwritten by that turn's next `syncSessionState` anyway. Skipping
+   * outright, however, drops `initialMessages` and the re-dispatched
+   * `replayToolCalls` for good, a loss that did not exist before the resume
+   * moved after `#hydrateRecoveredAgentState`. So the merge WAITS for the slot
+   * instead, bounded by `durableResumeTimeoutMs`; only a slot that never frees
+   * within that bound records the drop and gives up.
+   *
+   * The slot read and the merge are not one atomic step. The merge is
+   * idempotent (`hydrateRecoveredSessionHistory` skips messages already in
+   * history), so a turn that starts inside that window costs at worst the same
+   * overwrite skipping would have caused, never a corrupted history.
    */
   async #reapplyRecoveredHistory(
-    agentId: string,
     active: ActiveBackgroundAgent,
     reapplyRecoveredHistory: () => Promise<void>,
   ): Promise<void> {
-    if (this.#active.get(agentId) !== active) return;
-    if (!isRunnableActiveAgent(active)) return;
-    if (active.bootstrap.session.activeTurn.unsafePeek() !== null) return;
-    await reapplyRecoveredHistory();
+    const session = active.bootstrap.session;
+    const deadline = Date.now() + this.#durableResumeTimeoutMs;
+    for (;;) {
+      // Every path that retires a generation — `stopAgent`,
+      // `#retireUnpublishedRestoreGeneration`, terminal cleanup — closes
+      // ingress or records a pending terminal BEFORE dropping the `#active`
+      // entry, so this one predicate covers "this agent is going away".
+      if (!isRunnableActiveAgent(active)) return;
+      if (session.activeTurn.unsafePeek() === null) {
+        await reapplyRecoveredHistory();
+        return;
+      }
+      if (Date.now() >= deadline) break;
+      await sleep(RECOVERED_HISTORY_SLOT_POLL_MS, undefined, { unref: true });
+    }
+    emitDurableResumeWarning(
+      session,
+      "recovered_history_reapply_abandoned",
+      `a newer turn held the history for ${this.#durableResumeTimeoutMs}ms after the ` +
+        "recovered turn ended; the daemon-recovered conversation was not merged back",
+    );
   }
 
   #installDaemonApprovalBridge(
@@ -5170,6 +5248,68 @@ async function consumeDaemonPendingProviderSwitches(
     throw new Error(
       `provider switch to ${pending.provider}/${pending.model} could not be applied before turn: ${outcome.reason}`,
     );
+  }
+}
+
+/** Re-check cadence for the history slot a newer turn may be holding. */
+const RECOVERED_HISTORY_SLOT_POLL_MS = 25;
+
+/**
+ * Wait for the recovered turn to start, bounded by `timeoutMs` and by
+ * `signal`.
+ *
+ * The bound is what keeps a stalled resume from holding daemon startup:
+ * `daemon-cli` awaits every recovered restore serially before
+ * `socketServer.listen()`, and passes no `signal` on that path, so a timeout
+ * is the only release that path has (#2239).
+ */
+function waitForDurableResumeStart(
+  started: Promise<void>,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+): Promise<"started" | "timed-out" | "aborted"> {
+  return new Promise<"started" | "timed-out" | "aborted">((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
+    let settled = false;
+    const finish = (outcome: "started" | "timed-out" | "aborted"): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      if (onAbort !== undefined) signal?.removeEventListener("abort", onAbort);
+      resolve(outcome);
+    };
+    void started.then(() => finish("started"));
+    if (signal?.aborted === true) {
+      finish("aborted");
+      return;
+    }
+    timer = setTimeout(() => finish("timed-out"), timeoutMs);
+    timer.unref?.();
+    onAbort = (): void => finish("aborted");
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Record why the runner stopped waiting on a recovered turn.
+ *
+ * The session event log is the channel a client sees on attach and the
+ * rollout keeps, so an expiry is diagnosable after the fact instead of
+ * looking like a resume that silently never happened.
+ */
+function emitDurableResumeWarning(
+  session: LocalRuntimeBootstrap["session"],
+  cause: string,
+  message: string,
+): void {
+  try {
+    session.emit({
+      id: session.nextInternalSubId(),
+      msg: { type: "warning", payload: { cause, message } },
+    });
+  } catch {
+    // A session torn down under us must not turn a diagnostic into a failure.
   }
 }
 

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1004,6 +1004,11 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
               }
             : {}),
           deferSessionStartHooks: true,
+          // A daemon restore is exactly the case where an orphaned in-flight
+          // turn exists, and bootstrap would resume-continue it before this
+          // method can install the approval bridge or register the agent.
+          // Keep that one step for `#driveDeferredDurableResume` below (#2239).
+          deferDurableTurnResume: true,
           ...(params.resumeSuspendedRun === true ||
           params.resumeStartupActivationPending === true
             ? {
@@ -1314,6 +1319,10 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           onReplayToolResult: params.onReplayToolResult,
         });
         params.signal?.throwIfAborted();
+        // Last: this generation now owns `#active`, the approval bridge, and
+        // the canonical event bridge, so a resumed turn that needs approval
+        // reaches a client instead of the arbiter default deny.
+        this.#driveDeferredDurableResume(active);
         return true;
       } catch (error) {
         const cleanupErrors: unknown[] = [];
@@ -4217,6 +4226,43 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
       active.lastActiveAt = this.#now();
     }
     return resolved;
+  }
+
+  /**
+   * Drive the durable-turn resume bootstrap withheld from its startup prewarm.
+   *
+   * Ordering is the whole point (#2239): the resumed turn is a real model turn
+   * that can call tools needing approval, and it must run AFTER
+   * `#installDaemonApprovalBridge` published `services.approvalResolver` and
+   * AFTER `#active.set`, because `#requestDaemonToolDecision` denies outright
+   * for an agent that is not registered.
+   *
+   * Deliberately NOT awaited by `restoreAgent`: an approval has no default
+   * timeout, so awaiting it would block the whole restore — and the daemon's
+   * own startup — on a human decision that cannot be delivered until restore
+   * returns and a client attaches. The permission request is buffered on the
+   * agent until then. The promise is retained on the generation so the
+   * in-flight resume stays observable; stopping the agent aborts the session,
+   * which ends the resumed turn.
+   *
+   * A user message that arrives while the resumed turn waits for its approval
+   * is never queued behind it: `Session.spawnTask` aborts the running turn as
+   * `replaced`, so the new message wins exactly as it does for any other
+   * in-flight turn.
+   */
+  #driveDeferredDurableResume(active: ActiveBackgroundAgent): void {
+    const runDeferredDurableTurnResume =
+      active.bootstrap.runDeferredDurableTurnResume;
+    if (typeof runDeferredDurableTurnResume !== "function") return;
+    active.durableResumeComplete = (async () => {
+      try {
+        await runDeferredDurableTurnResume();
+      } catch {
+        // The resume is best-effort and already records its own failure on
+        // the conversation thread record; it must never surface as an
+        // unhandled rejection on a live daemon.
+      }
+    })();
   }
 
   #installDaemonApprovalBridge(

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -1343,6 +1343,16 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
             onReplayToolResult: params.onReplayToolResult,
           });
         params.signal?.throwIfAborted();
+        // Whether there is anything to merge back is decided HERE, before any
+        // waiting: `daemon-cli` supplies recovered messages only when the
+        // snapshot carried them, so the ordinary recovered run — no snapshot
+        // conversation, no in-flight tool calls — has nothing to re-apply.
+        // Leaving that test inside the thunk would make such a run wait out
+        // the whole slot poll and then record a lost conversation that never
+        // existed.
+        const hasRecoveredConversation =
+          recoveredInitialMessages.length > 0 ||
+          recoveredReplayedMessages.length > 0;
         // Last: this generation now owns `#active`, the approval bridge, and
         // the canonical event bridge, so a resumed turn that needs approval
         // reaches a client instead of the arbiter default deny.
@@ -1353,11 +1363,13 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
           // the recovered conversation hydrated just above. Re-apply it once
           // the turn is over, which is the order that held while the resume
           // ran inside bootstrap.
-          () =>
-            hydrateRecoveredSessionHistory(restoredSession, {
-              initialMessages: recoveredInitialMessages,
-              replayedMessages: recoveredReplayedMessages,
-            }),
+          hasRecoveredConversation
+            ? () =>
+                hydrateRecoveredSessionHistory(restoredSession, {
+                  initialMessages: recoveredInitialMessages,
+                  replayedMessages: recoveredReplayedMessages,
+                })
+            : undefined,
           // Callers that own a restore deadline (the on-demand lifecycle path)
           // release the wait immediately on abort; the daemon-startup path
           // passes none, which is why that wait is also bounded by a timeout.
@@ -4319,11 +4331,13 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
    *
    * `reapplyRecoveredHistory` runs after the resumed turn is over, because the
    * turn republishes `session.state.history` from its checkpoint prefix and
-   * would otherwise leave the daemon-recovered conversation erased.
+   * would otherwise leave the daemon-recovered conversation erased. It is
+   * `undefined` when the recovered run carried no conversation to merge, and
+   * then nothing waits and nothing is reported.
    */
   async #driveDeferredDurableResume(
     active: ActiveBackgroundAgent,
-    reapplyRecoveredHistory: () => Promise<void>,
+    reapplyRecoveredHistory: (() => Promise<void>) | undefined,
     signal: AbortSignal | undefined,
   ): Promise<void> {
     const runDeferredDurableTurnResume =
@@ -4353,6 +4367,9 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
         // also decides this: a resume that threw after re-opening the turn
         // overwrote the recovered conversation just the same.
         if (!resumed && !turnWasOpened) return;
+        // No recovered conversation, nothing to wait for: a run with nothing
+        // to merge must not poll the turn slot and must not report a loss.
+        if (reapplyRecoveredHistory === undefined) return;
         await this.#reapplyRecoveredHistory(active, reapplyRecoveredHistory);
       } catch {
         // Nothing here may surface as an unhandled rejection on a live daemon.
@@ -4381,7 +4398,8 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
 
   /**
    * Restore the daemon-recovered conversation the resumed turn republished
-   * over.
+   * over. Only called when there IS one — the caller decides that before any
+   * waiting starts.
    *
    * A newer turn owning the session's turn slot is the hard case: a client
    * message that replaced the resume is the fresher authority, and merging the
@@ -4392,6 +4410,24 @@ export class AgenCDelegateBackgroundAgentRunner implements AgenCBackgroundAgentR
    * moved after `#hydrateRecoveredAgentState`. So the merge WAITS for the slot
    * instead, bounded by `durableResumeTimeoutMs`; only a slot that never frees
    * within that bound records the drop and gives up.
+   *
+   * Two limitations are accepted here rather than claimed away, and both are
+   * pinned by tests:
+   *
+   * 1. What the merge restores depends on what the replacing turn left behind.
+   *    Onto an EMPTY history it restores the whole recovered conversation;
+   *    onto a history that turn has already published, it appends only the
+   *    re-dispatched tool results, at the tail, and does NOT reintroduce
+   *    `initialMessages` ahead of a conversation that has moved on. Base never
+   *    faced that ordering because it merged before any client turn could
+   *    exist. Reordering a newer turn's own conversation to make room for the
+   *    recovered prefix would be the larger harm.
+   * 2. The bound is `durableResumeTimeoutMs`, a daemon-startup deadline;
+   *    nothing derives it from how long a client turn may run, so a replacing
+   *    turn that outlives it gives the merge up and records
+   *    `recovered_history_reapply_abandoned`. The alternative is a background
+   *    poll with no end on a session that may never free the slot. Losing the
+   *    merge is therefore possible, but never silent.
    *
    * The slot read and the merge are not one atomic step. The merge is
    * idempotent (`hydrateRecoveredSessionHistory` skips messages already in

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -716,6 +716,14 @@ interface ActiveBackgroundAgent {
   messageSubmissionQueue: Promise<void>;
   /** Resolves only after this exact generation has relinquished #active. */
   cleanupComplete: Promise<void>;
+  /**
+   * Settles when the deferred durable-turn resume this generation started has
+   * finished. Retained so the in-flight resume is observable to the runner
+   * and its tests; never rejects. Stopping the agent aborts the session,
+   * which ends the resumed turn, so quiescence deliberately does not wait on
+   * it — that would block stop on a pending approval (#2239).
+   */
+  durableResumeComplete?: Promise<void>;
   pendingMessageSubmissionCount: number;
   readonly messageSubmissionsById: Map<string, ActiveMessageSubmission>;
   pendingShellExecutionCount: number;

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -810,6 +810,18 @@ function positiveInteger(value: unknown): number {
 
 export interface AgenCDelegateBackgroundAgentRunnerOptions {
   readonly agentStopTimeoutMs?: number;
+  /**
+   * Bound on the two waits a daemon restore adds around the durable-turn
+   * resume it drives (#2239): waiting for the recovered turn to START before
+   * `restoreAgent` returns, and waiting for a newer turn to release the
+   * history slot before the recovered conversation is merged back.
+   *
+   * Defaults to `DAEMON_AGENT_CREATE_TIMEOUT_MS`, the same deadline the
+   * bootstrap prewarm scope gave the resume when it ran inline, so the restore
+   * can never block longer than it did before the reorder. Injectable so tests
+   * do not have to burn the production deadline.
+   */
+  readonly durableResumeTimeoutMs?: number;
   readonly bootstrap?: AgenCBootstrapFunction;
   readonly ensureAgentControl?: AgenCEnsureAgentControlFunction;
   readonly authBackend?: AuthBackend;

--- a/runtime/src/app-server/background-agent-runner/shared.ts
+++ b/runtime/src/app-server/background-agent-runner/shared.ts
@@ -716,14 +716,6 @@ interface ActiveBackgroundAgent {
   messageSubmissionQueue: Promise<void>;
   /** Resolves only after this exact generation has relinquished #active. */
   cleanupComplete: Promise<void>;
-  /**
-   * Settles when the deferred durable-turn resume this generation started has
-   * finished. Retained so the in-flight resume is observable to the runner
-   * and its tests; never rejects. Stopping the agent aborts the session,
-   * which ends the resumed turn, so quiescence deliberately does not wait on
-   * it — that would block stop on a pending approval (#2239).
-   */
-  durableResumeComplete?: Promise<void>;
   pendingMessageSubmissionCount: number;
   readonly messageSubmissionsById: Map<string, ActiveMessageSubmission>;
   pendingShellExecutionCount: number;

--- a/runtime/src/bin/bootstrap.ts
+++ b/runtime/src/bin/bootstrap.ts
@@ -82,6 +82,7 @@ import { AgentControl } from "../agents/control.js";
 import { AgentRoleCatalog } from "../agents/role-catalog.js";
 import { ThreadManager } from "../agents/thread-manager.js";
 import { ConversationThreadManager } from "../conversation/thread-manager.js";
+import type { DurableResumeAttempt } from "../conversation/thread-manager.js";
 import { AgentRegistry } from "../agents/registry.js";
 import { createAgentRoleWorkspace } from "../agents/role.js";
 import { loadFreshAgentDefinitions } from "../tools/AgentTool/loadAgentsDir.js";
@@ -639,6 +640,19 @@ export interface BootstrapLocalRuntimeSessionOptions {
    * prewarm until the first non-Editor submit.
    */
   readonly deferAgentStartupSideEffects?: boolean;
+  /**
+   * Do not resume-continue an orphaned in-flight turn from inside bootstrap;
+   * hand that one step to the caller through
+   * `LocalRuntimeBootstrap.runDeferredDurableTurnResume`.
+   *
+   * The startup prewarm otherwise runs unchanged (fresh default turn,
+   * provider warm-up, agent-task registration). Daemon-owned sessions set
+   * this because the resumed turn is driven to completion inside bootstrap,
+   * i.e. before the daemon can install `services.approvalResolver` and
+   * register the agent — so every tool needing approval in that turn is
+   * refused with no prompt reaching the user (#2239).
+   */
+  readonly deferDurableTurnResume?: boolean;
   /** Stable calendar-budget identity; daemon agents default to their run id. */
   readonly executionAdmissionBudgetIdentity?: string;
 }
@@ -675,6 +689,20 @@ export interface LocalRuntimeBootstrap {
   readonly memoryMdPath: string;
   readonly shutdown: () => Promise<void>;
   readonly autonomousModeEnabled: boolean;
+  /**
+   * Drive the durable-turn resume that `deferDurableTurnResume` withheld from
+   * the startup prewarm. Call it once the caller can answer approvals for
+   * this session — for the daemon, after the approval bridge is installed and
+   * the agent is registered (#2239).
+   *
+   * Resolves to the neutral no-op outcome when nothing was deferred. Never
+   * throws: a resume failure is recorded on the conversation thread record,
+   * exactly as it is when the prewarm drives the resume inline.
+   *
+   * Optional so the many test doubles that stand in for a bootstrap keep
+   * compiling; `bootstrapLocalRuntimeSession` always provides it.
+   */
+  readonly runDeferredDurableTurnResume?: () => Promise<DurableResumeAttempt>;
 }
 
 export interface PreparedConfiguredExecutionAuthority {
@@ -1564,6 +1592,8 @@ async function bootstrapLocalRuntimeSessionScoped(
   let agentControlForShutdown: AgentControl | null = null;
   let rolloutStoreForReturn: RolloutStore | null = null;
   let ctxForReturn: TurnContext | null = null;
+  let conversationThreadManagerForReturn: ConversationThreadManager | null =
+    null;
   const mcpService = createSessionMcpService(mcpManager, {
     authority: configStore,
     environment: sessionMcpRequestEnvironment,
@@ -1782,7 +1812,11 @@ async function bootstrapLocalRuntimeSessionScoped(
         });
         const conversationThreadManager = new ConversationThreadManager({
           threadManager,
+          ...(options.deferDurableTurnResume === true
+            ? { deferDurableTurnResume: true }
+            : {}),
         });
+        conversationThreadManagerForReturn = conversationThreadManager;
         // `bootstrapSession` runs the canonical startup prewarm after
         // SessionConfigured; registration only claims the root thread here.
         await conversationThreadManager.registerConversationRootSession(s, {
@@ -2230,6 +2264,11 @@ async function bootstrapLocalRuntimeSessionScoped(
       memoryMdPath,
       shutdown,
       autonomousModeEnabled,
+      runDeferredDurableTurnResume: async (): Promise<DurableResumeAttempt> => {
+        const manager = conversationThreadManagerForReturn;
+        if (manager === null) return { resumed: false };
+        return manager.runDeferredDurableTurnResume(session);
+      },
     };
   } catch (err) {
     try {

--- a/runtime/src/conversation/thread-manager.ts
+++ b/runtime/src/conversation/thread-manager.ts
@@ -68,6 +68,14 @@ export type ConversationPrewarmState =
 export interface ConversationStartupPrewarmParams {
   readonly session: Session;
   readonly threadId: ThreadId;
+  /**
+   * When true the prewarm must NOT attempt the durable-turn resume; the
+   * embedder drives it later through
+   * {@link ConversationThreadManager.runDeferredDurableTurnResume}. Every
+   * other prewarm step (fresh default turn, provider warm-up, agent-task
+   * registration) still runs inline. See #2239.
+   */
+  readonly deferDurableTurnResume?: boolean;
 }
 
 export type ConversationStartupPrewarm = (
@@ -78,6 +86,14 @@ export interface ConversationThreadManagerOptions {
   readonly threadManager?: ThreadManager;
   readonly prewarm?: ConversationStartupPrewarm;
   readonly now?: () => number;
+  /**
+   * Hand the durable-turn resume to the embedder instead of driving it from
+   * the startup prewarm. Daemon-owned sessions set this so the resumed turn
+   * runs only after the daemon has installed its approval bridge and
+   * registered the agent; without it the resumed turn has no approval
+   * resolver and every tool that needs approval is refused (#2239).
+   */
+  readonly deferDurableTurnResume?: boolean;
 }
 
 export interface ConversationReplayOptions {
@@ -131,6 +147,14 @@ export class ConversationThreadManager extends ThreadManager {
   readonly threadManager: ThreadManager;
   private readonly prewarm: ConversationStartupPrewarm;
   private readonly now: () => number;
+  private readonly deferDurableTurnResume: boolean;
+  /**
+   * Sessions whose startup prewarm skipped the durable resume because the
+   * embedder owns it. Membership is consumed by the first
+   * `runDeferredDurableTurnResume` so the orphaned turn is driven at most
+   * once per session.
+   */
+  private readonly pendingDurableTurnResumes = new WeakSet<Session>();
   private readonly sessionTurnLocks = new WeakMap<Session, AsyncLock<void>>();
   private forkSequence = 0;
   private readonly records = new Map<
@@ -147,6 +171,7 @@ export class ConversationThreadManager extends ThreadManager {
     });
     this.prewarm = opts.prewarm ?? defaultStartupPrewarm;
     this.now = opts.now ?? (() => Date.now());
+    this.deferDurableTurnResume = opts.deferDurableTurnResume === true;
     this.threadManager.subscribeThreadCreated((threadId) => {
       this.refreshRecordFromThreadId(threadId);
     });
@@ -498,8 +523,20 @@ export class ConversationThreadManager extends ThreadManager {
     const record = this.upsertRecord(thread);
     record.prewarm = "running";
     delete record.prewarmError;
+    // Claim the deferral BEFORE the prewarm runs: `defaultStartupPrewarm`
+    // reads the same flag and skips the resume, so the pending marker and the
+    // skip must be decided from one value.
+    if (this.deferDurableTurnResume) {
+      this.pendingDurableTurnResumes.add(session);
+    }
     try {
-      await this.prewarm({ session, threadId: thread.threadId });
+      await this.prewarm({
+        session,
+        threadId: thread.threadId,
+        ...(this.deferDurableTurnResume
+          ? { deferDurableTurnResume: true }
+          : {}),
+      });
       record.prewarm = "ready";
     } catch (error) {
       record.prewarm = "failed";
@@ -507,6 +544,47 @@ export class ConversationThreadManager extends ThreadManager {
         error instanceof Error ? error.message : String(error);
     }
     return record.prewarm;
+  }
+
+  /**
+   * Drive the durable-turn resume that `runStartupPrewarm` skipped because
+   * this manager was constructed with `deferDurableTurnResume`.
+   *
+   * The daemon calls this after `#installDaemonApprovalBridge` has published
+   * `services.approvalResolver` and the agent is registered, so a resumed
+   * turn that needs approval reaches a client instead of the arbiter's
+   * default deny (#2239). It never throws: like the startup prewarm, a
+   * failure is recorded on the thread record.
+   *
+   * Runs at most once per session. Returns the neutral no-op outcome when
+   * nothing was deferred (fresh start, non-deferring embedder, second call).
+   */
+  async runDeferredDurableTurnResume(
+    session: Session,
+  ): Promise<DurableResumeAttempt> {
+    if (!this.pendingDurableTurnResumes.delete(session)) {
+      return { resumed: false };
+    }
+    const thread = this.threadManager.hasThread(session.conversationId)
+      ? this.threadManager.getThread(session.conversationId)
+      : this.registerRootSession(session);
+    const record = this.upsertRecord(thread);
+    try {
+      const attempt = await attemptDurableTurnResume(session);
+      if (attempt.freshTurnAllowed === false) {
+        // Same disposition the inline prewarm gives this case: the failure is
+        // reported on the record, the session keeps the fresh turn the
+        // prewarm already created.
+        record.prewarmError =
+          "durable resume halted after an incomplete checkpoint provider restore: " +
+          (attempt.failureDetail ?? "provider state could not be restored");
+      }
+      return attempt;
+    } catch (error) {
+      record.prewarmError =
+        error instanceof Error ? error.message : String(error);
+      return { resumed: false };
+    }
   }
 
   snapshot(threadId: ThreadId): ConversationThreadSnapshot {
@@ -1152,9 +1230,27 @@ export async function resumeTurnFromCheckpoint(
   }
 }
 
+/**
+ * Resume-continue the orphaned in-flight turn surfaced by this session's
+ * reconstruction, if any. Returns the neutral no-op outcome when the session
+ * has no stashed reconstruction.
+ *
+ * Split out of `defaultStartupPrewarm` so the daemon can run this ONE step
+ * after its approval bridge is installed while the rest of the prewarm still
+ * happens inline inside bootstrap (#2239).
+ */
+async function attemptDurableTurnResume(
+  session: Session,
+): Promise<DurableResumeAttempt> {
+  const reconstruction = lastReconstructionBySession.get(session);
+  if (reconstruction === undefined) return { resumed: false };
+  return resumeTurnFromCheckpoint(session, reconstruction);
+}
+
 async function defaultStartupPrewarm({
   session,
   threadId,
+  deferDurableTurnResume,
 }: ConversationStartupPrewarmParams): Promise<void> {
   // GOAL #4b Stage 1 — if reconstruction surfaced an orphaned in-flight turn
   // with a valid durable checkpoint (and the build/prefix/lease gates pass),
@@ -1162,11 +1258,19 @@ async function defaultStartupPrewarm({
   // Absence and clean rejection retain the existing fresh-turn behavior.
   // An incomplete provider rollback stops startup before a fresh context can
   // use state whose authority is no longer provable.
-  const reconstruction = lastReconstructionBySession.get(session);
+  //
+  // `deferDurableTurnResume` hands exactly this step to the embedder. The
+  // session still gets its fresh default turn and provider prewarm here, so a
+  // deferring embedder that never drives the resume is no worse off than a
+  // session with no resumable turn.
+  const reconstruction =
+    deferDurableTurnResume === true
+      ? undefined
+      : lastReconstructionBySession.get(session);
   if (reconstruction !== undefined) {
     let attempt: DurableResumeAttempt | undefined;
     try {
-      attempt = await resumeTurnFromCheckpoint(session, reconstruction);
+      attempt = await attemptDurableTurnResume(session);
     } catch {
       // Resume is strictly best-effort; never let it block boot. Fall
       // through to the legacy fresh-turn prewarm.

--- a/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
+++ b/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgenCDelegateBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
+import type { AgenCDelegateBackgroundAgentRunnerOptions } from "../../src/app-server/background-agent-runner/shared.js";
 import {
   bootstrapLocalRuntimeSession,
   type LocalRuntimeBootstrap,
@@ -184,6 +185,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
 
   function makeRunner(
     onBootstrapped?: (bootstrap: LocalRuntimeBootstrap) => void,
+    extra: Partial<AgenCDelegateBackgroundAgentRunnerOptions> = {},
   ): AgenCDelegateBackgroundAgentRunner {
     return new AgenCDelegateBackgroundAgentRunner({
       bootstrap: async (options) => {
@@ -197,6 +199,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
         AGENC_WORKSPACE: workspace,
         HOME: home,
       },
+      ...extra,
     });
   }
 
@@ -236,6 +239,38 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
       return emit.call(this, event, appendOpts);
     });
     return types;
+  }
+
+  /**
+   * Record every `warning` cause the session emits, from before bootstrap runs.
+   * The runner records why it stopped waiting on a stalled resume through this
+   * channel, so it is durable in the rollout and reaches a client on attach.
+   */
+  function recordEmittedWarnings(): Array<{
+    readonly cause: string;
+    readonly message: string;
+  }> {
+    const warnings: Array<{ readonly cause: string; readonly message: string }> =
+      [];
+    const emit = Session.prototype.emit;
+    vi.spyOn(Session.prototype, "emit").mockImplementation(function (
+      this: Session,
+      event: Parameters<Session["emit"]>[0],
+      appendOpts?: Parameters<Session["emit"]>[1],
+    ) {
+      if (event.msg.type === "warning") {
+        const payload = event.msg.payload as {
+          readonly cause?: unknown;
+          readonly message?: unknown;
+        };
+        warnings.push({
+          cause: String(payload.cause ?? ""),
+          message: String(payload.message ?? ""),
+        });
+      }
+      return emit.call(this, event, appendOpts);
+    });
+    return warnings;
   }
 
   async function waitUntil(
@@ -593,6 +628,197 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
 
     await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);
+
+
+  it("returns from a restore whose recovered turn stalls before it can start", async () => {
+    // The wait for `turn_resumed` replaced an inline resume that ran inside
+    // bootstrap's `DaemonOperationScope("session startup prewarm",
+    // DAEMON_AGENT_CREATE_TIMEOUT_MS)`, and everything the resume does before
+    // that event can block: `restoreCheckpointProviderRoute` ->
+    // `session.prepareProviderSwitch` (credential/provider I/O), `spawnTask`'s
+    // abort drain, the fsync-durable emit itself. `daemon-cli` awaits every
+    // recovered restore SERIALLY before `socketServer.listen()`, so an
+    // unbounded wait stops the daemon from ever listening — which also
+    // permanently prevents the client attach this whole fix exists to enable.
+    // The wait must expire and hand control back.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const warnings = recordEmittedWarnings();
+    const stalled = Promise.withResolvers<void>();
+    let resumeEnteredTurn = false;
+    let resumeFinished = false;
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const isResume = options?.resume !== undefined;
+      return (async function* () {
+        if (isResume) {
+          resumeEnteredTurn = true;
+          // Stall exactly where the review measured it: inside the resume,
+          // before any `turn_resumed` reaches the event log.
+          await stalled.promise;
+          resumeFinished = true;
+        }
+        return { reason: "completed" as const };
+      })() as never;
+    });
+
+    const runner = makeRunner(undefined, { durableResumeTimeoutMs: 500 });
+    const restore = runner.restoreAgent(restoreParams());
+    const outcome = await Promise.race([
+      restore.then(
+        () => "restoreAgent returned while the recovered turn was still stalled",
+      ),
+      new Promise<string>((resolve) =>
+        setTimeout(
+          () =>
+            resolve(
+              "restoreAgent never returned: the recovered turn stalled before turn_resumed",
+            ),
+          8_000,
+        ),
+      ),
+    ]);
+    expect(outcome).toBe(
+      "restoreAgent returned while the recovered turn was still stalled",
+    );
+    await expect(restore).resolves.toBe(true);
+
+    // Expiry is recorded, never silent: the operator and the attaching client
+    // both learn that the recovered turn had not started yet.
+    expect(resumeEnteredTurn).toBe(true);
+    expect(
+      warnings.filter(
+        (warning) => warning.cause === "durable_resume_start_timeout",
+      ),
+    ).toHaveLength(1);
+
+    // ...and the orphan is NOT abandoned. It is single-shot (see the
+    // "replay persists its abort" test), so cancelling it at the deadline
+    // would destroy the interrupted turn instead of merely delaying it.
+    expect(resumeFinished).toBe(false);
+    stalled.resolve();
+    await waitUntil(
+      () => resumeFinished,
+      "the resume to keep running in the background after the wait expired",
+    );
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("re-applies the recovered conversation once a newer turn releases the slot", async () => {
+    // Moving the resume after `#hydrateRecoveredAgentState` created a window
+    // that did not exist on base: `syncSessionState` republishes
+    // `session.state.history` from the checkpoint prefix at EVERY sampling
+    // boundary, so once the resumed turn has sampled, the recovered
+    // conversation is gone until the re-apply lands. If a client message
+    // replaces the resume in between, the re-apply used to be skipped
+    // outright and `initialMessages` plus the re-dispatched `replayToolCalls`
+    // were lost for good. It must wait for the slot instead of dropping them.
+    //
+    // The busy slot is simulated by faking exactly the read the runner makes
+    // (`session.activeTurn.unsafePeek()`), which is the whole window: driving
+    // a real replacing turn to sit in that slot at the microsecond the resume
+    // settles is the interleaving the round-3 review could not construct.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const resumeSettled = Promise.withResolvers<void>();
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      this: Session,
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const session = this;
+      const isResume = options?.resume !== undefined;
+      return (async function* () {
+        if (isResume) {
+          // What the real resumed turn does to history: `syncSessionState`
+          // assigns it from the checkpoint prefix, which this fixture's
+          // checkpoint (`persistedMessageCount: 0`) makes empty.
+          await (
+            session as unknown as {
+              readonly state: {
+                with: (fn: (state: { history?: unknown }) => void) => Promise<void>;
+              };
+            }
+          ).state.with((state) => {
+            state.history = [];
+          });
+          // `turn_resumed` is what releases the runner's start barrier.
+          session.emit({
+            id: session.nextInternalSubId(),
+            msg: {
+              type: "turn_resumed",
+              payload: {
+                turnId: TURN_ID,
+                fromCheckpointSeq: 1,
+                fromIteration: 1,
+              },
+            },
+          } as never);
+          resumeSettled.resolve();
+        }
+        return { reason: "completed" as const };
+      })() as never;
+    });
+
+    let booted: LocalRuntimeBootstrap | undefined;
+    const runner = makeRunner(
+      (bootstrap) => {
+        booted = bootstrap;
+        // Hold the slot from before the resume settles, so the re-apply finds
+        // a newer turn owning the history exactly as a replacing client turn
+        // would.
+        vi.spyOn(bootstrap.session.activeTurn, "unsafePeek").mockReturnValue({
+          turnId: "client-turn-that-replaced-the-resume",
+        } as never);
+      },
+      { durableResumeTimeoutMs: 30_000 },
+    );
+
+    await expect(
+      runner.restoreAgent(restoreParams(recoveredRunState())),
+    ).resolves.toBe(true);
+    const bootstrap = booted!;
+    await resumeSettled.promise;
+
+    // While the newer turn owns the slot the recovered conversation stays
+    // erased — appending it under a live turn would rewrite that turn's
+    // context, and its next `syncSessionState` would overwrite it anyway.
+    await waitUntil(
+      async () => (await sessionHistory(bootstrap)).length > 0,
+      "history to be republished under the live turn",
+      750,
+    ).catch(() => undefined);
+    expect(await sessionHistory(bootstrap)).toEqual([]);
+
+    // The slot frees; the recovered conversation must come back rather than
+    // be dropped for good.
+    vi.mocked(bootstrap.session.activeTurn.unsafePeek).mockReturnValue(null);
+    await waitUntil(
+      async () =>
+        (await sessionHistory(bootstrap)).some(
+          (message) =>
+            message.role === "user" &&
+            message.content === RECOVERED_USER_MESSAGE,
+        ),
+      "the recovered conversation to survive the turn that replaced the resume",
+      10_000,
+    );
+    const history = await sessionHistory(bootstrap);
+    expect(
+      history.some(
+        (message) =>
+          message.role === "tool" && message.toolCallId === REPLAY_CALL_ID,
+      ),
+    ).toBe(true);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
 
   it("never withholds the resume from a restore that defers startup side effects", async () => {
     // A suspended / startup-activation-pending restore passes

--- a/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
+++ b/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
@@ -1,12 +1,22 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgenCDelegateBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
-import { bootstrapLocalRuntimeSession } from "../../src/bin/bootstrap.js";
+import {
+  bootstrapLocalRuntimeSession,
+  type LocalRuntimeBootstrap,
+} from "../../src/bin/bootstrap.js";
 import type { ReviewDecision } from "../../src/permissions/review-decision.js";
+import { resolveUnattendedPermissionDecision } from "../../src/permissions/unattended-policy.js";
 import { computeCheckpointPrefixHashV3 } from "../../src/session/durable-checkpoint-reader.js";
 import {
   currentBuildId,
@@ -58,7 +68,9 @@ function orphanRolloutItems(turnId: string): RolloutItem[] {
     {
       type: "event_msg",
       payload: {
+        eventId: `${turnId}-started`,
         id: `${turnId}-started`,
+        seq: 1,
         msg: {
           type: "turn_started",
           payload: { turnId, buildId: currentBuildId() },
@@ -68,7 +80,9 @@ function orphanRolloutItems(turnId: string): RolloutItem[] {
     {
       type: "event_msg",
       payload: {
+        eventId: `${turnId}-checkpoint`,
         id: `${turnId}-checkpoint`,
+        seq: 2,
         msg: {
           type: "turn_checkpoint",
           payload: {
@@ -168,9 +182,15 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     );
   }
 
-  function makeRunner(): AgenCDelegateBackgroundAgentRunner {
+  function makeRunner(
+    onBootstrapped?: (bootstrap: LocalRuntimeBootstrap) => void,
+  ): AgenCDelegateBackgroundAgentRunner {
     return new AgenCDelegateBackgroundAgentRunner({
-      bootstrap: (options) => bootstrapLocalRuntimeSession(options),
+      bootstrap: async (options) => {
+        const bootstrap = await bootstrapLocalRuntimeSession(options);
+        onBootstrapped?.(bootstrap);
+        return bootstrap;
+      },
       env: {
         ...process.env,
         AGENC_HOME: home,
@@ -180,7 +200,58 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     });
   }
 
-  function restoreParams(): never {
+  /** The daemon-recovered conversation the runner hydrates onto the session. */
+  const RECOVERED_USER_MESSAGE = "PRIOR USER MESSAGE";
+  const REPLAY_CALL_ID = "replay-1";
+
+  function sessionHistory(
+    bootstrap: LocalRuntimeBootstrap,
+  ): Promise<ReadonlyArray<Record<string, unknown>>> {
+    return (
+      bootstrap.session as unknown as {
+        readonly state: {
+          with: <T>(
+            fn: (state: { history?: ReadonlyArray<Record<string, unknown>> }) => T,
+          ) => Promise<T>;
+        };
+      }
+    ).state.with((state) => state.history ?? []);
+  }
+
+  /**
+   * Record every event type the session emits, from before bootstrap runs.
+   * Subscribing to `session.eventLog` after `restoreAgent` returns would miss
+   * a resume that already happened inside bootstrap, which is exactly the
+   * ordering these tests compare against.
+   */
+  function recordEmittedEventTypes(): string[] {
+    const types: string[] = [];
+    const emit = Session.prototype.emit;
+    vi.spyOn(Session.prototype, "emit").mockImplementation(function (
+      this: Session,
+      event: Parameters<Session["emit"]>[0],
+      appendOpts?: Parameters<Session["emit"]>[1],
+    ) {
+      types.push(event.msg.type);
+      return emit.call(this, event, appendOpts);
+    });
+    return types;
+  }
+
+  async function waitUntil(
+    predicate: () => boolean | Promise<boolean>,
+    label: string,
+    timeoutMs = 20_000,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (await predicate()) return;
+      if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  function restoreParams(extra: Record<string, unknown> = {}): never {
     return {
       agentId: CONVERSATION_ID,
       objective: "resume after daemon death",
@@ -190,7 +261,75 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
       // The daemon snapshot is complete per client; keys absent from it are
       // cleared, so provider credentials must ride the override.
       envOverrides: { XAI_API_KEY: "test-key" },
+      ...extra,
     } as never;
+  }
+
+  /**
+   * Mark the seeded run as having a startup activation still pending, the
+   * shape `restoreAgent` requires before it accepts
+   * `resumeStartupActivationPending` (`currentCanonicalRuntimeStateFromRollout`
+   * reads a `run_resumed` on the current epoch that no `run_startup_activated`
+   * has closed).
+   */
+  function seedPendingStartupActivation(): void {
+    const suspensionEventId = `run-suspended:${CONVERSATION_ID}:1`;
+    const resumeEventId = `run-resumed:${CONVERSATION_ID}:1`;
+    const lines = [
+      {
+        type: "event_msg",
+        payload: {
+          eventId: suspensionEventId,
+          id: suspensionEventId,
+          seq: 3,
+          msg: {
+            type: "run_suspended",
+            payload: {
+              runId: CONVERSATION_ID,
+              epoch: 1,
+              reason: "daemon_shutdown_idle",
+              suspendedAt: new Date().toISOString(),
+            },
+          },
+        },
+        eventVersion: 1,
+      },
+      {
+        type: "event_msg",
+        payload: {
+          eventId: resumeEventId,
+          id: resumeEventId,
+          seq: 4,
+          msg: {
+            type: "run_resumed",
+            payload: {
+              runId: CONVERSATION_ID,
+              epoch: 1,
+              suspensionEventId,
+              reason: "daemon_startup_restore",
+              resumedAt: new Date().toISOString(),
+            },
+          },
+        },
+        eventVersion: 1,
+      },
+    ];
+    appendFileSync(
+      rolloutPath,
+      lines.map((line) => `${JSON.stringify(line)}\n`).join(""),
+      "utf8",
+    );
+  }
+
+  /** The recovered-run state `daemon-cli` hands `restoreAgent` on a cold start. */
+  function recoveredRunState(): Record<string, unknown> {
+    return {
+      currentSessionId: "recovered-session",
+      initialMessages: [{ role: "user", content: RECOVERED_USER_MESSAGE }],
+      replayToolCalls: [
+        { callId: REPLAY_CALL_ID, toolName: "Glob", args: { pattern: "**/*" } },
+      ],
+    };
   }
 
   it("drives the recovered turn only once a client can answer its approvals", async () => {
@@ -357,5 +496,246 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     );
     expect(abortedTurnIds).toContain(TURN_ID);
     expect(reconstructFromRollout(persisted).resumableTurns).toEqual([]);
+  }, 60_000);
+
+  it("keeps the daemon-recovered conversation the restore hydrated", async () => {
+    // A cold daemon start hands `restoreAgent` the recovered run's own state:
+    // `initialMessages` (the conversation from the last snapshot, including a
+    // message the user had already queued) plus `replayToolCalls`, which are
+    // re-dispatched and appended (daemon-cli.ts
+    // `recoveredInitialMessages`/`recoveredReplayToolCalls`).
+    // `#hydrateRecoveredAgentState` writes them onto `session.state.history`.
+    //
+    // The recovered turn writes that same slot: `syncSessionState` assigns
+    // `sessionState.history` from the checkpoint prefix it was resumed with.
+    // Driving the resume after hydration therefore ERASES the recovered
+    // conversation. Whatever order the resume runs in, the end state must
+    // still carry it.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const eventTypes = recordEmittedEventTypes();
+    let booted: LocalRuntimeBootstrap | undefined;
+    const runner = makeRunner((bootstrap) => {
+      booted = bootstrap;
+    });
+
+    await expect(
+      runner.restoreAgent(restoreParams(recoveredRunState())),
+    ).resolves.toBe(true);
+    const bootstrap = booted!;
+
+    // At return the hydrated conversation is present on both the fixed and the
+    // unfixed source; the regression only shows once the resumed turn settles.
+    expect(
+      (await sessionHistory(bootstrap)).map((message) => message.role),
+    ).toEqual(["user", "assistant", "tool"]);
+
+    // Sample only after the recovered turn has actually started AND finished,
+    // otherwise the assertion races an unstarted resume and passes for the
+    // wrong reason.
+    await waitUntil(
+      () => eventTypes.includes("turn_resumed"),
+      "the recovered turn to start",
+    );
+    await waitUntil(
+      () => bootstrap.session.activeTurn.unsafePeek() === null,
+      "the recovered turn to settle",
+    );
+    // The restoration of the recovered conversation is chained onto the
+    // resume, so give that chain a bounded window and then assert, rather
+    // than turning the property under test into a timeout message.
+    await waitUntil(
+      async () =>
+        (await sessionHistory(bootstrap)).some(
+          (message) =>
+            message.role === "user" &&
+            message.content === RECOVERED_USER_MESSAGE,
+        ),
+      "the recovered conversation to survive the resumed turn",
+      5_000,
+    ).catch(() => undefined);
+
+    const history = await sessionHistory(bootstrap);
+    expect(
+      history.some(
+        (message) =>
+          message.role === "user" && message.content === RECOVERED_USER_MESSAGE,
+      ),
+    ).toBe(true);
+    expect(
+      history.some(
+        (message) =>
+          message.role === "tool" && message.toolCallId === REPLAY_CALL_ID,
+      ),
+    ).toBe(true);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("does not return before the recovered turn has started", async () => {
+    // `restoreAgent` returning while the resume is still queued leaves a
+    // window: a client that submits in it has its brand-new turn aborted
+    // `replaced` by the late resume (`Session.spawnTask` ->
+    // `abortAllTasksLocked("replaced")`). The recovered turn must already own
+    // the session's turn slot by the time restore reports success, so the
+    // newer user message replaces the resume and never the other way round.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const eventTypes = recordEmittedEventTypes();
+    const runner = makeRunner();
+
+    await expect(runner.restoreAgent(restoreParams())).resolves.toBe(true);
+    // `turn_resumed` is emitted right after `spawnTask` installed the
+    // recovered turn as the session's active turn.
+    expect(eventTypes).toContain("turn_resumed");
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("never withholds the resume from a restore that defers startup side effects", async () => {
+    // A suspended / startup-activation-pending restore passes
+    // `deferAgentStartupSideEffects: true`, which hands the WHOLE startup
+    // prewarm — the durable resume with it — to whoever activates it later,
+    // by which time the approval bridge and the `#active` entry exist. The two
+    // deferrals must therefore be mutually exclusive: setting both would mark
+    // the resume pending inside a prewarm nobody can pair with a
+    // `runDeferredDurableTurnResume` call, and the orphan is single-shot, so
+    // the turn would be lost rather than late.
+    //
+    // Out of scope, unchanged, pre-existing: `bin/bootstrap.ts` gates the
+    // prewarm block itself on the same flag, so today nothing runs it for
+    // those restores at all. This test pins that whoever does run it resumes
+    // the orphan, with the daemon approval bridge already installed.
+    await stubProvider();
+    stubProviderAndMcp();
+    seedPendingStartupActivation();
+    expect(
+      reconstructFromRollout(readRollout(rolloutPath)).resumableTurns.map(
+        (turn) => turn.turnId,
+      ),
+    ).toEqual([TURN_ID]);
+
+    const observations: ResumeObservation[] = [];
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      this: Session,
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const services = this.services as {
+        approvalResolver?: unknown;
+        guardianApprovalReviewer?: unknown;
+      };
+      observations.push({
+        resume: options?.resume !== undefined,
+        hasApprovalResolver: services.approvalResolver !== undefined,
+        hasGuardianApprovalReviewer:
+          services.guardianApprovalReviewer !== undefined,
+      });
+      return (async function* () {
+        return { reason: "completed" as const };
+      })() as never;
+    });
+
+    let booted: LocalRuntimeBootstrap | undefined;
+    const bootstrapOptions: Array<Record<string, unknown>> = [];
+    const runner = new AgenCDelegateBackgroundAgentRunner({
+      bootstrap: async (options) => {
+        bootstrapOptions.push(options as unknown as Record<string, unknown>);
+        booted = await bootstrapLocalRuntimeSession(options);
+        return booted;
+      },
+      env: {
+        ...process.env,
+        AGENC_HOME: home,
+        AGENC_WORKSPACE: workspace,
+        HOME: home,
+      },
+    });
+
+    await expect(
+      runner.restoreAgent(
+        restoreParams({ resumeStartupActivationPending: true }),
+      ),
+    ).resolves.toBe(true);
+
+    expect(bootstrapOptions).toHaveLength(1);
+    expect(bootstrapOptions[0]!.deferAgentStartupSideEffects).toBe(true);
+    expect(bootstrapOptions[0]!.deferDurableTurnResume).toBeUndefined();
+    // Nothing ran the prewarm yet, so no turn of any kind was driven.
+    expect(observations).toEqual([]);
+
+    // Whoever activates the deferred startup work drives the resume inline,
+    // and by then the bridge this issue is about is installed.
+    const manager = (
+      booted!.session.services as {
+        readonly conversationThreadManager?: {
+          runStartupPrewarm: (session: unknown) => Promise<unknown>;
+        };
+      }
+    ).conversationThreadManager;
+    await manager!.runStartupPrewarm(booted!.session);
+
+    expect(observations).toEqual([
+      {
+        resume: true,
+        hasApprovalResolver: true,
+        hasGuardianApprovalReviewer: true,
+      },
+    ]);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("runs the recovered turn under the agent's unattended policy", async () => {
+    // Documented consequence of resuming after `installUnattendedPermissionPolicy`
+    // instead of inside bootstrap: the recovered turn is now subject to the
+    // agent's configured unattended allow/deny lists, where before it always
+    // reached the arbiter's `default_deny`. That is the configured behavior of
+    // an unattended agent — an allowlisted tool runs without a prompt and a
+    // denylisted one is refused without one — and it is asserted here rather
+    // than left to be discovered.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const decisions: Array<Record<string, unknown>> = [];
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      this: Session,
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      if (options?.resume !== undefined) {
+        const context = this.permissionModeRegistry!.current();
+        decisions.push({
+          mode: context.mode,
+          glob: resolveUnattendedPermissionDecision(context, "Glob").behavior,
+          exec: resolveUnattendedPermissionDecision(context, "exec_command")
+            .behavior,
+          edit: resolveUnattendedPermissionDecision(context, "Edit").behavior,
+        });
+      }
+      return (async function* () {
+        return { reason: "completed" as const };
+      })() as never;
+    });
+
+    const runner = makeRunner();
+    await expect(
+      runner.restoreAgent(
+        restoreParams({
+          metadata: {
+            unattendedAllow: ["Glob"],
+            unattendedDeny: ["exec_command"],
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    expect(decisions).toEqual([
+      { mode: "unattended", glob: "allow", exec: "deny", edit: "pause" },
+    ]);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);
 });

--- a/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
+++ b/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
@@ -61,6 +61,11 @@ interface ResumeObservation {
   readonly hasGuardianApprovalReviewer: boolean;
 }
 
+/** The slice of `session.state` these tests read and republish. */
+interface MutableSessionState {
+  history?: ReadonlyArray<Record<string, unknown>>;
+}
+
 /**
  * One started-but-never-terminated turn carrying a durable checkpoint whose
  * prefix is empty — the shape a SIGKILLed daemon leaves behind.
@@ -124,8 +129,11 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
   let workspace = "";
   let rolloutPath = "";
   let previousBuildId: string | undefined;
+  /** Every option object the runner handed the real bootstrap, in order. */
+  let bootstrapOptions: Array<Record<string, unknown>> = [];
 
   beforeEach(() => {
+    bootstrapOptions = [];
     home = mkdtempSync(join(tmpdir(), "agenc-2239-home-"));
     workspace = mkdtempSync(join(tmpdir(), "agenc-2239-ws-"));
     mkdirSync(join(workspace, ".git"), { recursive: true });
@@ -190,6 +198,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
   ): AgenCDelegateBackgroundAgentRunner {
     return new AgenCDelegateBackgroundAgentRunner({
       bootstrap: async (options) => {
+        bootstrapOptions.push(options as unknown as Record<string, unknown>);
         const bootstrap = await bootstrapLocalRuntimeSession(options);
         onBootstrapped?.(bootstrap);
         return bootstrap;
@@ -208,44 +217,83 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
   const RECOVERED_USER_MESSAGE = "PRIOR USER MESSAGE";
   const REPLAY_CALL_ID = "replay-1";
 
-  function sessionHistory(
-    bootstrap: LocalRuntimeBootstrap,
-  ): Promise<ReadonlyArray<Record<string, unknown>>> {
+  /**
+   * The session's mutable state cell. These tests both read the conversation
+   * the restore hydrated and write the republication a resumed turn performs,
+   * so they reach past the public type exactly where the runner does.
+   */
+  function sessionState(session: Session): {
+    readonly with: <T>(fn: (state: MutableSessionState) => T) => Promise<T>;
+  } {
     return (
-      bootstrap.session as unknown as {
+      session as unknown as {
         readonly state: {
-          with: <T>(
-            fn: (state: { history?: ReadonlyArray<Record<string, unknown>> }) => T,
+          readonly with: <T>(
+            fn: (state: MutableSessionState) => T,
           ) => Promise<T>;
         };
       }
-    ).state.with((state) => state.history ?? []);
+    ).state;
+  }
+
+  function sessionHistory(
+    bootstrap: LocalRuntimeBootstrap,
+  ): Promise<ReadonlyArray<Record<string, unknown>>> {
+    return sessionState(bootstrap.session).with((state) => state.history ?? []);
+  }
+
+  /** The queued user message `#hydrateRecoveredAgentState` wrote. */
+  function hasRecoveredUserMessage(
+    history: ReadonlyArray<Record<string, unknown>>,
+  ): boolean {
+    return history.some(
+      (message) =>
+        message.role === "user" && message.content === RECOVERED_USER_MESSAGE,
+    );
+  }
+
+  /** The result of the tool call the restore re-dispatched. */
+  function hasReplayedToolResult(
+    history: ReadonlyArray<Record<string, unknown>>,
+  ): boolean {
+    return history.some(
+      (message) =>
+        message.role === "tool" && message.toolCallId === REPLAY_CALL_ID,
+    );
   }
 
   /**
-   * Record every event type the session emits, from before bootstrap runs.
-   * Subscribing to `session.eventLog` after `restoreAgent` returns would miss
-   * a resume that already happened inside bootstrap, which is exactly the
+   * Observe every event the session emits, from before bootstrap runs.
+   * Subscribing to `session.eventLog` after `restoreAgent` returns would miss a
+   * resume that already happened inside bootstrap, which is exactly the
    * ordering these tests compare against.
    */
-  function recordEmittedEventTypes(): string[] {
-    const types: string[] = [];
+  function spyOnEmittedEvents(
+    observe: (event: Parameters<Session["emit"]>[0]) => void,
+  ): void {
     const emit = Session.prototype.emit;
     vi.spyOn(Session.prototype, "emit").mockImplementation(function (
       this: Session,
       event: Parameters<Session["emit"]>[0],
       appendOpts?: Parameters<Session["emit"]>[1],
     ) {
-      types.push(event.msg.type);
+      observe(event);
       return emit.call(this, event, appendOpts);
+    });
+  }
+
+  function recordEmittedEventTypes(): string[] {
+    const types: string[] = [];
+    spyOnEmittedEvents((event) => {
+      types.push(event.msg.type);
     });
     return types;
   }
 
   /**
-   * Record every `warning` cause the session emits, from before bootstrap runs.
-   * The runner records why it stopped waiting on a stalled resume through this
-   * channel, so it is durable in the rollout and reaches a client on attach.
+   * Record every `warning` cause the session emits. The runner records why it
+   * stopped waiting on a stalled resume through this channel, so it is durable
+   * in the rollout and reaches a client on attach.
    */
   function recordEmittedWarnings(): Array<{
     readonly cause: string;
@@ -253,23 +301,16 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
   }> {
     const warnings: Array<{ readonly cause: string; readonly message: string }> =
       [];
-    const emit = Session.prototype.emit;
-    vi.spyOn(Session.prototype, "emit").mockImplementation(function (
-      this: Session,
-      event: Parameters<Session["emit"]>[0],
-      appendOpts?: Parameters<Session["emit"]>[1],
-    ) {
-      if (event.msg.type === "warning") {
-        const payload = event.msg.payload as {
-          readonly cause?: unknown;
-          readonly message?: unknown;
-        };
-        warnings.push({
-          cause: String(payload.cause ?? ""),
-          message: String(payload.message ?? ""),
-        });
-      }
-      return emit.call(this, event, appendOpts);
+    spyOnEmittedEvents((event) => {
+      if (event.msg.type !== "warning") return;
+      const payload = event.msg.payload as {
+        readonly cause?: unknown;
+        readonly message?: unknown;
+      };
+      warnings.push({
+        cause: String(payload.cause ?? ""),
+        message: String(payload.message ?? ""),
+      });
     });
     return warnings;
   }
@@ -368,47 +409,264 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     };
   }
 
-  it("drives the recovered turn only once a client can answer its approvals", async () => {
-    await stubProvider();
-    stubProviderAndMcp();
+  /**
+   * A turn that yields nothing and reports itself completed: what every stub
+   * below returns once it has done the one thing its test is about.
+   */
+  function completedTurn(): never {
+    return (async function* () {
+      return { reason: "completed" as const };
+    })() as never;
+  }
 
-    const runner = makeRunner();
-    const observations: ResumeObservation[] = [];
-    let approvalProbe: Promise<ReviewDecision> | undefined;
-    const resumeDriven = Promise.withResolvers<void>();
-
+  /** Run `onTurn` for every turn the runner drives, then complete that turn. */
+  function stubTurn(
+    onTurn: (session: Session, isResume: boolean) => void,
+  ): void {
     vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
       this: Session,
       _input: unknown,
       options?: { readonly resume?: unknown },
     ) {
-      const services = this.services as {
-        approvalResolver?: {
-          request: (ctx: unknown) => Promise<ReviewDecision>;
-        };
+      onTurn(this, options?.resume !== undefined);
+      return completedTurn();
+    });
+  }
+
+  /**
+   * Record which approval services the session carried on every turn the runner
+   * drove. `onResume` runs from inside the recovered turn, where a real tool
+   * would ask for its approval.
+   */
+  function recordResumeObservations(
+    onResume?: (session: Session) => void,
+  ): ResumeObservation[] {
+    const observations: ResumeObservation[] = [];
+    stubTurn((session, isResume) => {
+      const services = session.services as {
+        approvalResolver?: unknown;
         guardianApprovalReviewer?: unknown;
       };
-      const isResume = options?.resume !== undefined;
       observations.push({
         resume: isResume,
         hasApprovalResolver: services.approvalResolver !== undefined,
         hasGuardianApprovalReviewer:
           services.guardianApprovalReviewer !== undefined,
       });
-      if (isResume) {
-        // Ask for approval exactly the way `execute-tools` does, from inside
-        // the resumed turn. This is the property the issue is about: the
-        // request must become a pending decision the daemon can deliver to a
-        // client, not an instant refusal.
-        approvalProbe = services.approvalResolver?.request({
-          callId: APPROVAL_REQUEST_ID,
-          invocation: { session: { conversationId: CONVERSATION_ID } },
-        });
-        resumeDriven.resolve();
-      }
+      if (isResume) onResume?.(session);
+    });
+    return observations;
+  }
+
+  /**
+   * Replace the resumed turn with the two effects the runner reacts to: the
+   * `syncSessionState` republication that erases the daemon-recovered
+   * conversation (this fixture's checkpoint has `persistedMessageCount: 0`, so
+   * the prefix is empty), and the `turn_resumed` event that releases the start
+   * barrier. `settled` resolves once both have happened.
+   */
+  function stubResumedTurn(
+    opts: { readonly throwAfterStart?: boolean } = {},
+  ): { readonly settled: Promise<void> } {
+    const settled = Promise.withResolvers<void>();
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      this: Session,
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const session = this;
+      const isResume = options?.resume !== undefined;
       return (async function* () {
+        if (isResume) {
+          await sessionState(session).with((state) => {
+            state.history = [];
+          });
+          session.emit({
+            id: session.nextInternalSubId(),
+            msg: {
+              type: "turn_resumed",
+              payload: {
+                turnId: TURN_ID,
+                fromCheckpointSeq: 1,
+                fromIteration: 1,
+              },
+            },
+          } as never);
+          settled.resolve();
+          if (opts.throwAfterStart === true) {
+            throw new Error("resume failed after re-opening the turn");
+          }
+        }
         return { reason: "completed" as const };
       })() as never;
+    });
+    return { settled: settled.promise };
+  }
+
+  /**
+   * Stall the resume before any `turn_resumed` reaches the event log, which is
+   * where the review measured the daemon-startup block. `finished` stays false
+   * until `release` lets the stalled turn run on to completion.
+   */
+  function stubStalledResume(): {
+    readonly entered: () => boolean;
+    readonly finished: () => boolean;
+    readonly release: () => void;
+  } {
+    const stalled = Promise.withResolvers<void>();
+    let entered = false;
+    let finished = false;
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const isResume = options?.resume !== undefined;
+      return (async function* () {
+        if (isResume) {
+          entered = true;
+          await stalled.promise;
+          finished = true;
+        }
+        return { reason: "completed" as const };
+      })() as never;
+    });
+    return {
+      entered: () => entered,
+      finished: () => finished,
+      release: () => stalled.resolve(),
+    };
+  }
+
+  /**
+   * Observe the timers the runner installs. Both waits under test are timers:
+   * the start wait is one `setTimeout(durableResumeTimeoutMs)` and the slot
+   * poll is a run of `setTimeout(RECOVERED_HISTORY_SLOT_POLL_MS)` sleeps, so a
+   * poll that never starts and a bound that changed are both directly visible
+   * here instead of being asserted in prose.
+   */
+  function spyOnTimers(
+    onSet: (ms: number, timer: object) => void,
+    onClear?: (timer: object) => void,
+  ): void {
+    const realSetTimeout = globalThis.setTimeout as unknown as (
+      ...args: readonly unknown[]
+    ) => object;
+    const realClearTimeout = globalThis.clearTimeout as unknown as (
+      timer: unknown,
+    ) => void;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      ...args: readonly unknown[]
+    ) => {
+      const timer = realSetTimeout(...args);
+      const ms = args[1];
+      if (typeof ms === "number") onSet(ms, timer);
+      return timer;
+    }) as never);
+    if (onClear === undefined) return;
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(((
+      timer: unknown,
+    ) => {
+      if (typeof timer === "object" && timer !== null) onClear(timer);
+      realClearTimeout(timer);
+    }) as never);
+  }
+
+  /**
+   * Settle on whichever outcome happens first. A hang has to arrive as the
+   * outcome under test, so a failure names what did not happen instead of
+   * expiring as a bare vitest timeout.
+   */
+  function raceOutcome(
+    candidate: Promise<string>,
+    timedOut: string,
+    timeoutMs: number,
+  ): Promise<string> {
+    return Promise.race([
+      candidate,
+      new Promise<string>((resolve) =>
+        setTimeout(() => resolve(timedOut), timeoutMs),
+      ),
+    ]);
+  }
+
+  /** The delay `#reapplyRecoveredHistory` sleeps between slot re-checks. */
+  const SLOT_POLL_MS = 25;
+
+  /** Hold the session's turn slot the way a replacing client turn would. */
+  function holdTurnSlot(bootstrap: LocalRuntimeBootstrap): void {
+    vi.spyOn(bootstrap.session.activeTurn, "unsafePeek").mockReturnValue({
+      turnId: "client-turn-that-replaced-the-resume",
+    } as never);
+  }
+
+  function releaseTurnSlot(bootstrap: LocalRuntimeBootstrap): void {
+    vi.mocked(bootstrap.session.activeTurn.unsafePeek).mockReturnValue(null);
+  }
+
+  function setSessionHistory(
+    bootstrap: LocalRuntimeBootstrap,
+    history: ReadonlyArray<Record<string, unknown>>,
+  ): Promise<void> {
+    return sessionState(bootstrap.session).with((state) => {
+      state.history = history.map((message) => ({ ...message }));
+    });
+  }
+
+  /**
+   * Restore a run whose snapshot carried a conversation and settle its resumed
+   * turn. `holdSlot` puts a newer client turn in the session's turn slot from
+   * before the resume settles, which is the window the re-apply has to survive;
+   * `resumeThrows` fails the turn after it re-opened. The restore itself must
+   * succeed for any of that to be under test, so it is asserted here.
+   */
+  async function restoreRecoveredRun(opts: {
+    readonly durableResumeTimeoutMs: number;
+    readonly holdSlot?: boolean;
+    readonly resumeThrows?: boolean;
+  }): Promise<{
+    readonly runner: AgenCDelegateBackgroundAgentRunner;
+    readonly bootstrap: LocalRuntimeBootstrap;
+  }> {
+    const resumed = stubResumedTurn({ throwAfterStart: opts.resumeThrows });
+    let booted: LocalRuntimeBootstrap | undefined;
+    const runner = makeRunner(
+      (bootstrap) => {
+        booted = bootstrap;
+        if (opts.holdSlot === true) holdTurnSlot(bootstrap);
+      },
+      { durableResumeTimeoutMs: opts.durableResumeTimeoutMs },
+    );
+
+    await expect(
+      runner.restoreAgent(restoreParams(recoveredRunState())),
+    ).resolves.toBe(true);
+    await resumed.settled;
+    return { runner, bootstrap: booted! };
+  }
+
+  it("drives the recovered turn only once a client can answer its approvals", async () => {
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const runner = makeRunner();
+    let approvalProbe: Promise<ReviewDecision> | undefined;
+    const resumeDriven = Promise.withResolvers<void>();
+    const observations = recordResumeObservations((session) => {
+      // Ask for approval exactly the way `execute-tools` does, from inside the
+      // resumed turn. This is the property the issue is about: the request must
+      // become a pending decision the daemon can deliver to a client, not an
+      // instant refusal.
+      approvalProbe = (
+        session.services as {
+          approvalResolver?: {
+            request: (ctx: unknown) => Promise<ReviewDecision>;
+          };
+        }
+      ).approvalResolver?.request({
+        callId: APPROVAL_REQUEST_ID,
+        invocation: { session: { conversationId: CONVERSATION_ID } },
+      });
+      resumeDriven.resolve();
     });
 
     await expect(runner.restoreAgent(restoreParams())).resolves.toBe(true);
@@ -465,14 +723,8 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     stubProviderAndMcp();
 
     const resumesDrivenDuringBootstrap: boolean[] = [];
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      if (options?.resume !== undefined) resumesDrivenDuringBootstrap.push(true);
-      return (async function* () {
-        return { reason: "completed" as const };
-      })() as never;
+    stubTurn((_session, isResume) => {
+      if (isResume) resumesDrivenDuringBootstrap.push(true);
     });
 
     const boot = await bootstrapLocalRuntimeSession({
@@ -508,12 +760,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     // descriptor ever again, so a deferral that never fires drops it.
     await stubProvider();
     stubProviderAndMcp();
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(
-      () =>
-        (async function* () {
-          return { reason: "completed" as const };
-        })() as never,
-    );
+    stubTurn(() => undefined);
 
     const before = reconstructFromRollout(readRollout(rolloutPath));
     expect(before.resumableTurns.map((turn) => turn.turnId)).toEqual([TURN_ID]);
@@ -646,42 +893,17 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     stubProviderAndMcp();
 
     const warnings = recordEmittedWarnings();
-    const stalled = Promise.withResolvers<void>();
-    let resumeEnteredTurn = false;
-    let resumeFinished = false;
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      const isResume = options?.resume !== undefined;
-      return (async function* () {
-        if (isResume) {
-          resumeEnteredTurn = true;
-          // Stall exactly where the review measured it: inside the resume,
-          // before any `turn_resumed` reaches the event log.
-          await stalled.promise;
-          resumeFinished = true;
-        }
-        return { reason: "completed" as const };
-      })() as never;
-    });
+    const stalled = stubStalledResume();
 
     const runner = makeRunner(undefined, { durableResumeTimeoutMs: 500 });
     const restore = runner.restoreAgent(restoreParams());
-    const outcome = await Promise.race([
+    const outcome = await raceOutcome(
       restore.then(
         () => "restoreAgent returned while the recovered turn was still stalled",
       ),
-      new Promise<string>((resolve) =>
-        setTimeout(
-          () =>
-            resolve(
-              "restoreAgent never returned: the recovered turn stalled before turn_resumed",
-            ),
-          8_000,
-        ),
-      ),
-    ]);
+      "restoreAgent never returned: the recovered turn stalled before turn_resumed",
+      8_000,
+    );
     expect(outcome).toBe(
       "restoreAgent returned while the recovered turn was still stalled",
     );
@@ -689,7 +911,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
 
     // Expiry is recorded, never silent: the operator and the attaching client
     // both learn that the recovered turn had not started yet.
-    expect(resumeEnteredTurn).toBe(true);
+    expect(stalled.entered()).toBe(true);
     expect(
       warnings.filter(
         (warning) => warning.cause === "durable_resume_start_timeout",
@@ -699,10 +921,10 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     // ...and the orphan is NOT abandoned. It is single-shot (see the
     // "replay persists its abort" test), so cancelling it at the deadline
     // would destroy the interrupted turn instead of merely delaying it.
-    expect(resumeFinished).toBe(false);
-    stalled.resolve();
+    expect(stalled.finished()).toBe(false);
+    stalled.release();
     await waitUntil(
-      () => resumeFinished,
+      () => stalled.finished(),
       "the resume to keep running in the background after the wait expired",
     );
 
@@ -726,65 +948,10 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     await stubProvider();
     stubProviderAndMcp();
 
-    const resumeSettled = Promise.withResolvers<void>();
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      this: Session,
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      const session = this;
-      const isResume = options?.resume !== undefined;
-      return (async function* () {
-        if (isResume) {
-          // What the real resumed turn does to history: `syncSessionState`
-          // assigns it from the checkpoint prefix, which this fixture's
-          // checkpoint (`persistedMessageCount: 0`) makes empty.
-          await (
-            session as unknown as {
-              readonly state: {
-                with: (fn: (state: { history?: unknown }) => void) => Promise<void>;
-              };
-            }
-          ).state.with((state) => {
-            state.history = [];
-          });
-          // `turn_resumed` is what releases the runner's start barrier.
-          session.emit({
-            id: session.nextInternalSubId(),
-            msg: {
-              type: "turn_resumed",
-              payload: {
-                turnId: TURN_ID,
-                fromCheckpointSeq: 1,
-                fromIteration: 1,
-              },
-            },
-          } as never);
-          resumeSettled.resolve();
-        }
-        return { reason: "completed" as const };
-      })() as never;
+    const { runner, bootstrap } = await restoreRecoveredRun({
+      durableResumeTimeoutMs: 30_000,
+      holdSlot: true,
     });
-
-    let booted: LocalRuntimeBootstrap | undefined;
-    const runner = makeRunner(
-      (bootstrap) => {
-        booted = bootstrap;
-        // Hold the slot from before the resume settles, so the re-apply finds
-        // a newer turn owning the history exactly as a replacing client turn
-        // would.
-        vi.spyOn(bootstrap.session.activeTurn, "unsafePeek").mockReturnValue({
-          turnId: "client-turn-that-replaced-the-resume",
-        } as never);
-      },
-      { durableResumeTimeoutMs: 30_000 },
-    );
-
-    await expect(
-      runner.restoreAgent(restoreParams(recoveredRunState())),
-    ).resolves.toBe(true);
-    const bootstrap = booted!;
-    await resumeSettled.promise;
 
     // While the newer turn owns the slot the recovered conversation stays
     // erased — appending it under a live turn would rewrite that turn's
@@ -798,24 +965,13 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
 
     // The slot frees; the recovered conversation must come back rather than
     // be dropped for good.
-    vi.mocked(bootstrap.session.activeTurn.unsafePeek).mockReturnValue(null);
+    releaseTurnSlot(bootstrap);
     await waitUntil(
-      async () =>
-        (await sessionHistory(bootstrap)).some(
-          (message) =>
-            message.role === "user" &&
-            message.content === RECOVERED_USER_MESSAGE,
-        ),
+      async () => hasRecoveredUserMessage(await sessionHistory(bootstrap)),
       "the recovered conversation to survive the turn that replaced the resume",
       10_000,
     );
-    const history = await sessionHistory(bootstrap);
-    expect(
-      history.some(
-        (message) =>
-          message.role === "tool" && message.toolCallId === REPLAY_CALL_ID,
-      ),
-    ).toBe(true);
+    expect(hasReplayedToolResult(await sessionHistory(bootstrap))).toBe(true);
 
     await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);
@@ -844,41 +1000,11 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
       ),
     ).toEqual([TURN_ID]);
 
-    const observations: ResumeObservation[] = [];
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      this: Session,
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      const services = this.services as {
-        approvalResolver?: unknown;
-        guardianApprovalReviewer?: unknown;
-      };
-      observations.push({
-        resume: options?.resume !== undefined,
-        hasApprovalResolver: services.approvalResolver !== undefined,
-        hasGuardianApprovalReviewer:
-          services.guardianApprovalReviewer !== undefined,
-      });
-      return (async function* () {
-        return { reason: "completed" as const };
-      })() as never;
-    });
+    const observations = recordResumeObservations();
 
     let booted: LocalRuntimeBootstrap | undefined;
-    const bootstrapOptions: Array<Record<string, unknown>> = [];
-    const runner = new AgenCDelegateBackgroundAgentRunner({
-      bootstrap: async (options) => {
-        bootstrapOptions.push(options as unknown as Record<string, unknown>);
-        booted = await bootstrapLocalRuntimeSession(options);
-        return booted;
-      },
-      env: {
-        ...process.env,
-        AGENC_HOME: home,
-        AGENC_WORKSPACE: workspace,
-        HOME: home,
-      },
+    const runner = makeRunner((bootstrap) => {
+      booted = bootstrap;
     });
 
     await expect(
@@ -927,24 +1053,16 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     stubProviderAndMcp();
 
     const decisions: Array<Record<string, unknown>> = [];
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      this: Session,
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      if (options?.resume !== undefined) {
-        const context = this.permissionModeRegistry!.current();
-        decisions.push({
-          mode: context.mode,
-          glob: resolveUnattendedPermissionDecision(context, "Glob").behavior,
-          exec: resolveUnattendedPermissionDecision(context, "exec_command")
-            .behavior,
-          edit: resolveUnattendedPermissionDecision(context, "Edit").behavior,
-        });
-      }
-      return (async function* () {
-        return { reason: "completed" as const };
-      })() as never;
+    stubTurn((session, isResume) => {
+      if (!isResume) return;
+      const context = session.permissionModeRegistry!.current();
+      decisions.push({
+        mode: context.mode,
+        glob: resolveUnattendedPermissionDecision(context, "Glob").behavior,
+        exec: resolveUnattendedPermissionDecision(context, "exec_command")
+          .behavior,
+        edit: resolveUnattendedPermissionDecision(context, "Edit").behavior,
+      });
     });
 
     const runner = makeRunner();
@@ -965,143 +1083,6 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
 
     await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);
-
-  /**
-   * Replace the resumed turn with the two effects the runner reacts to: the
-   * `syncSessionState` republication that erases the daemon-recovered
-   * conversation (this fixture's checkpoint has `persistedMessageCount: 0`, so
-   * the prefix is empty), and the `turn_resumed` event that releases the start
-   * barrier. `settled` resolves once both have happened.
-   */
-  function stubResumedTurn(
-    opts: { readonly throwAfterStart?: boolean } = {},
-  ): { readonly settled: Promise<void> } {
-    const settled = Promise.withResolvers<void>();
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      this: Session,
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      const session = this;
-      const isResume = options?.resume !== undefined;
-      return (async function* () {
-        if (isResume) {
-          await (
-            session as unknown as {
-              readonly state: {
-                with: (fn: (state: { history?: unknown }) => void) => Promise<void>;
-              };
-            }
-          ).state.with((state) => {
-            state.history = [];
-          });
-          session.emit({
-            id: session.nextInternalSubId(),
-            msg: {
-              type: "turn_resumed",
-              payload: {
-                turnId: TURN_ID,
-                fromCheckpointSeq: 1,
-                fromIteration: 1,
-              },
-            },
-          } as never);
-          settled.resolve();
-          if (opts.throwAfterStart === true) {
-            throw new Error("resume failed after re-opening the turn");
-          }
-        }
-        return { reason: "completed" as const };
-      })() as never;
-    });
-    return { settled: settled.promise };
-  }
-
-  /** Stall the resume before any `turn_resumed` reaches the event log. */
-  function stubStalledResume(): {
-    readonly entered: () => boolean;
-    readonly release: () => void;
-  } {
-    const stalled = Promise.withResolvers<void>();
-    let entered = false;
-    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
-      _input: unknown,
-      options?: { readonly resume?: unknown },
-    ) {
-      const isResume = options?.resume !== undefined;
-      return (async function* () {
-        if (isResume) {
-          entered = true;
-          await stalled.promise;
-        }
-        return { reason: "completed" as const };
-      })() as never;
-    });
-    return { entered: () => entered, release: () => stalled.resolve() };
-  }
-
-  /**
-   * Observe the timers the runner installs. Both waits under test are timers:
-   * the start wait is one `setTimeout(durableResumeTimeoutMs)` and the slot
-   * poll is a run of `setTimeout(RECOVERED_HISTORY_SLOT_POLL_MS)` sleeps, so a
-   * poll that never starts and a bound that changed are both directly visible
-   * here instead of being asserted in prose.
-   */
-  function spyOnTimers(
-    onSet: (ms: number, timer: object) => void,
-    onClear?: (timer: object) => void,
-  ): void {
-    const realSetTimeout = globalThis.setTimeout as unknown as (
-      ...args: readonly unknown[]
-    ) => object;
-    const realClearTimeout = globalThis.clearTimeout as unknown as (
-      timer: unknown,
-    ) => void;
-    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      ...args: readonly unknown[]
-    ) => {
-      const timer = realSetTimeout(...args);
-      const ms = args[1];
-      if (typeof ms === "number") onSet(ms, timer);
-      return timer;
-    }) as never);
-    if (onClear === undefined) return;
-    vi.spyOn(globalThis, "clearTimeout").mockImplementation(((
-      timer: unknown,
-    ) => {
-      if (typeof timer === "object" && timer !== null) onClear(timer);
-      realClearTimeout(timer);
-    }) as never);
-  }
-
-  /** The delay `#reapplyRecoveredHistory` sleeps between slot re-checks. */
-  const SLOT_POLL_MS = 25;
-
-  /** Hold the session's turn slot the way a replacing client turn would. */
-  function holdTurnSlot(bootstrap: LocalRuntimeBootstrap): void {
-    vi.spyOn(bootstrap.session.activeTurn, "unsafePeek").mockReturnValue({
-      turnId: "client-turn-that-replaced-the-resume",
-    } as never);
-  }
-
-  function releaseTurnSlot(bootstrap: LocalRuntimeBootstrap): void {
-    vi.mocked(bootstrap.session.activeTurn.unsafePeek).mockReturnValue(null);
-  }
-
-  function setSessionHistory(
-    bootstrap: LocalRuntimeBootstrap,
-    history: ReadonlyArray<Record<string, unknown>>,
-  ): Promise<void> {
-    return (
-      bootstrap.session as unknown as {
-        readonly state: {
-          with: (fn: (state: { history?: unknown }) => void) => Promise<void>;
-        };
-      }
-    ).state.with((state) => {
-      state.history = history.map((message) => ({ ...message }));
-    });
-  }
 
   it("neither polls nor warns when the recovered run has nothing to merge", async () => {
     // The emptiness test lives inside the merge thunk
@@ -1197,20 +1178,10 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     stubProviderAndMcp();
 
     const warnings = recordEmittedWarnings();
-    const resumed = stubResumedTurn();
-    let booted: LocalRuntimeBootstrap | undefined;
-    const runner = makeRunner(
-      (bootstrap) => {
-        booted = bootstrap;
-        holdTurnSlot(bootstrap);
-      },
-      { durableResumeTimeoutMs: 400 },
-    );
-
-    await expect(
-      runner.restoreAgent(restoreParams(recoveredRunState())),
-    ).resolves.toBe(true);
-    await resumed.settled;
+    const { runner, bootstrap } = await restoreRecoveredRun({
+      durableResumeTimeoutMs: 400,
+      holdSlot: true,
+    });
 
     await waitUntil(
       () =>
@@ -1227,7 +1198,7 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     expect(abandoned[0]!.message).toContain("400ms");
     // The warning is not decorative: the recovered conversation really is gone
     // from the session it was hydrated onto.
-    expect(await sessionHistory(booted!)).toEqual([]);
+    expect(await sessionHistory(bootstrap)).toEqual([]);
 
     await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);
@@ -1241,36 +1212,17 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     await stubProvider();
     stubProviderAndMcp();
 
-    const resumed = stubResumedTurn({ throwAfterStart: true });
-    let booted: LocalRuntimeBootstrap | undefined;
-    const runner = makeRunner(
-      (bootstrap) => {
-        booted = bootstrap;
-      },
-      { durableResumeTimeoutMs: 30_000 },
-    );
-
-    await expect(
-      runner.restoreAgent(restoreParams(recoveredRunState())),
-    ).resolves.toBe(true);
-    await resumed.settled;
+    const { runner, bootstrap } = await restoreRecoveredRun({
+      durableResumeTimeoutMs: 30_000,
+      resumeThrows: true,
+    });
 
     await waitUntil(
-      async () =>
-        (await sessionHistory(booted!)).some(
-          (message) =>
-            message.role === "user" &&
-            message.content === RECOVERED_USER_MESSAGE,
-        ),
+      async () => hasRecoveredUserMessage(await sessionHistory(bootstrap)),
       "the recovered conversation to survive a resume that threw after starting",
       10_000,
     );
-    expect(
-      (await sessionHistory(booted!)).some(
-        (message) =>
-          message.role === "tool" && message.toolCallId === REPLAY_CALL_ID,
-      ),
-    ).toBe(true);
+    expect(hasReplayedToolResult(await sessionHistory(bootstrap))).toBe(true);
 
     await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);
@@ -1304,15 +1256,11 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     );
     const abortedAt = Date.now();
     controller.abort(new Error("the caller cancelled the restore"));
-    const outcome = await Promise.race([
+    const outcome = await raceOutcome(
       settled,
-      new Promise<string>((resolve) =>
-        setTimeout(
-          () => resolve("the restore was still waiting out its own timeout"),
-          10_000,
-        ),
-      ),
-    ]);
+      "the restore was still waiting out its own timeout",
+      10_000,
+    );
     expect(outcome).toBe("the restore rejected");
     expect(Date.now() - abortedAt).toBeLessThan(10_000);
 
@@ -1331,21 +1279,10 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     await stubProvider();
     stubProviderAndMcp();
 
-    const resumed = stubResumedTurn();
-    let booted: LocalRuntimeBootstrap | undefined;
-    const runner = makeRunner(
-      (bootstrap) => {
-        booted = bootstrap;
-        holdTurnSlot(bootstrap);
-      },
-      { durableResumeTimeoutMs: 30_000 },
-    );
-
-    await expect(
-      runner.restoreAgent(restoreParams(recoveredRunState())),
-    ).resolves.toBe(true);
-    const bootstrap = booted!;
-    await resumed.settled;
+    const { runner, bootstrap } = await restoreRecoveredRun({
+      durableResumeTimeoutMs: 30_000,
+      holdSlot: true,
+    });
 
     // What the replacing turn does that the busy-slot test never modelled: it
     // publishes its own history before it releases the slot.

--- a/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
+++ b/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AgenCDelegateBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
 import type { AgenCDelegateBackgroundAgentRunnerOptions } from "../../src/app-server/background-agent-runner/shared.js";
+import { DAEMON_AGENT_CREATE_TIMEOUT_MS } from "../../src/app-server/operation-deadline.js";
 import {
   bootstrapLocalRuntimeSession,
   type LocalRuntimeBootstrap,
@@ -961,6 +962,418 @@ describe("durable resume reaches the daemon approval bridge (#2239)", () => {
     expect(decisions).toEqual([
       { mode: "unattended", glob: "allow", exec: "deny", edit: "pause" },
     ]);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  /**
+   * Replace the resumed turn with the two effects the runner reacts to: the
+   * `syncSessionState` republication that erases the daemon-recovered
+   * conversation (this fixture's checkpoint has `persistedMessageCount: 0`, so
+   * the prefix is empty), and the `turn_resumed` event that releases the start
+   * barrier. `settled` resolves once both have happened.
+   */
+  function stubResumedTurn(
+    opts: { readonly throwAfterStart?: boolean } = {},
+  ): { readonly settled: Promise<void> } {
+    const settled = Promise.withResolvers<void>();
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      this: Session,
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const session = this;
+      const isResume = options?.resume !== undefined;
+      return (async function* () {
+        if (isResume) {
+          await (
+            session as unknown as {
+              readonly state: {
+                with: (fn: (state: { history?: unknown }) => void) => Promise<void>;
+              };
+            }
+          ).state.with((state) => {
+            state.history = [];
+          });
+          session.emit({
+            id: session.nextInternalSubId(),
+            msg: {
+              type: "turn_resumed",
+              payload: {
+                turnId: TURN_ID,
+                fromCheckpointSeq: 1,
+                fromIteration: 1,
+              },
+            },
+          } as never);
+          settled.resolve();
+          if (opts.throwAfterStart === true) {
+            throw new Error("resume failed after re-opening the turn");
+          }
+        }
+        return { reason: "completed" as const };
+      })() as never;
+    });
+    return { settled: settled.promise };
+  }
+
+  /** Stall the resume before any `turn_resumed` reaches the event log. */
+  function stubStalledResume(): {
+    readonly entered: () => boolean;
+    readonly release: () => void;
+  } {
+    const stalled = Promise.withResolvers<void>();
+    let entered = false;
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const isResume = options?.resume !== undefined;
+      return (async function* () {
+        if (isResume) {
+          entered = true;
+          await stalled.promise;
+        }
+        return { reason: "completed" as const };
+      })() as never;
+    });
+    return { entered: () => entered, release: () => stalled.resolve() };
+  }
+
+  /**
+   * Observe the timers the runner installs. Both waits under test are timers:
+   * the start wait is one `setTimeout(durableResumeTimeoutMs)` and the slot
+   * poll is a run of `setTimeout(RECOVERED_HISTORY_SLOT_POLL_MS)` sleeps, so a
+   * poll that never starts and a bound that changed are both directly visible
+   * here instead of being asserted in prose.
+   */
+  function spyOnTimers(
+    onSet: (ms: number, timer: object) => void,
+    onClear?: (timer: object) => void,
+  ): void {
+    const realSetTimeout = globalThis.setTimeout as unknown as (
+      ...args: readonly unknown[]
+    ) => object;
+    const realClearTimeout = globalThis.clearTimeout as unknown as (
+      timer: unknown,
+    ) => void;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      ...args: readonly unknown[]
+    ) => {
+      const timer = realSetTimeout(...args);
+      const ms = args[1];
+      if (typeof ms === "number") onSet(ms, timer);
+      return timer;
+    }) as never);
+    if (onClear === undefined) return;
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(((
+      timer: unknown,
+    ) => {
+      if (typeof timer === "object" && timer !== null) onClear(timer);
+      realClearTimeout(timer);
+    }) as never);
+  }
+
+  /** The delay `#reapplyRecoveredHistory` sleeps between slot re-checks. */
+  const SLOT_POLL_MS = 25;
+
+  /** Hold the session's turn slot the way a replacing client turn would. */
+  function holdTurnSlot(bootstrap: LocalRuntimeBootstrap): void {
+    vi.spyOn(bootstrap.session.activeTurn, "unsafePeek").mockReturnValue({
+      turnId: "client-turn-that-replaced-the-resume",
+    } as never);
+  }
+
+  function releaseTurnSlot(bootstrap: LocalRuntimeBootstrap): void {
+    vi.mocked(bootstrap.session.activeTurn.unsafePeek).mockReturnValue(null);
+  }
+
+  function setSessionHistory(
+    bootstrap: LocalRuntimeBootstrap,
+    history: ReadonlyArray<Record<string, unknown>>,
+  ): Promise<void> {
+    return (
+      bootstrap.session as unknown as {
+        readonly state: {
+          with: (fn: (state: { history?: unknown }) => void) => Promise<void>;
+        };
+      }
+    ).state.with((state) => {
+      state.history = history.map((message) => ({ ...message }));
+    });
+  }
+
+  it("neither polls nor warns when the recovered run has nothing to merge", async () => {
+    // The emptiness test lives inside the merge thunk
+    // (`hydrateRecoveredSessionHistory` returns immediately for an empty
+    // recovered conversation), and `daemon-cli` only supplies recovered
+    // messages when the snapshot HAS them. So the ordinary recovered run — no
+    // snapshot conversation, no in-flight tool calls — must not spend the
+    // whole `durableResumeTimeoutMs` polling a slot it has nothing to write,
+    // and must not then tell the operator that a conversation nobody had was
+    // lost. The decision has to be made BEFORE the wait.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const warnings = recordEmittedWarnings();
+    let pollSleeps = 0;
+    spyOnTimers((ms) => {
+      if (ms === SLOT_POLL_MS) pollSleeps += 1;
+    });
+    const resumed = stubResumedTurn();
+
+    const runner = makeRunner(
+      (bootstrap) => {
+        // A newer client turn owns the slot for the rest of the test: if the
+        // wait ran at all, it would run to its deadline.
+        holdTurnSlot(bootstrap);
+      },
+      { durableResumeTimeoutMs: 300 },
+    );
+
+    // No `initialMessages`, no `replayToolCalls`: nothing to merge back.
+    await expect(runner.restoreAgent(restoreParams())).resolves.toBe(true);
+    await resumed.settled;
+
+    const sleepsBeforeWindow = pollSleeps;
+    // Five times the bound: a poll that started would have run out and
+    // recorded its warning well inside this window.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+    expect(
+      warnings.filter(
+        (warning) => warning.cause === "recovered_history_reapply_abandoned",
+      ),
+    ).toEqual([]);
+    expect(pollSleeps - sleepsBeforeWindow).toBe(0);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("bounds the production start wait by the startup-prewarm deadline it replaced", async () => {
+    // The commit's safety property is that the deferred resume never blocks
+    // the restore for longer than the inline resume it replaced, which ran
+    // inside `DaemonOperationScope("session startup prewarm",
+    // DAEMON_AGENT_CREATE_TIMEOUT_MS)`. Tests that inject their own bound
+    // cannot see that, so this one takes the PRODUCTION default and reads the
+    // timer the runner actually installs: while the resume is stalled before
+    // `turn_resumed`, the start wait is the only long timer still pending
+    // (the prewarm scope disposes its own when bootstrap returns).
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const pendingLongTimers = new Map<object, number>();
+    spyOnTimers(
+      (ms, timer) => {
+        if (ms >= 100_000) pendingLongTimers.set(timer, ms);
+      },
+      (timer) => {
+        pendingLongTimers.delete(timer);
+      },
+    );
+    const stalled = stubStalledResume();
+
+    const runner = makeRunner();
+    const restore = runner.restoreAgent(restoreParams());
+    await waitUntil(
+      () => stalled.entered() && pendingLongTimers.size > 0,
+      "the start wait to be installed with the production default",
+    );
+    expect([...pendingLongTimers.values()]).toEqual([
+      DAEMON_AGENT_CREATE_TIMEOUT_MS,
+    ]);
+
+    stalled.release();
+    await expect(restore).resolves.toBe(true);
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("records the abandoned merge when a newer turn never releases the slot", async () => {
+    // The other end of the wait: recovered content DOES exist, and the turn
+    // that replaced the resume outlives the bound. The merge is given up, and
+    // that loss is recorded rather than silent — the operator and the next
+    // client to attach both see which agent lost its recovered conversation.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const warnings = recordEmittedWarnings();
+    const resumed = stubResumedTurn();
+    let booted: LocalRuntimeBootstrap | undefined;
+    const runner = makeRunner(
+      (bootstrap) => {
+        booted = bootstrap;
+        holdTurnSlot(bootstrap);
+      },
+      { durableResumeTimeoutMs: 400 },
+    );
+
+    await expect(
+      runner.restoreAgent(restoreParams(recoveredRunState())),
+    ).resolves.toBe(true);
+    await resumed.settled;
+
+    await waitUntil(
+      () =>
+        warnings.some(
+          (warning) => warning.cause === "recovered_history_reapply_abandoned",
+        ),
+      "the abandoned merge to be recorded",
+      10_000,
+    );
+    const abandoned = warnings.filter(
+      (warning) => warning.cause === "recovered_history_reapply_abandoned",
+    );
+    expect(abandoned).toHaveLength(1);
+    expect(abandoned[0]!.message).toContain("400ms");
+    // The warning is not decorative: the recovered conversation really is gone
+    // from the session it was hydrated onto.
+    expect(await sessionHistory(booted!)).toEqual([]);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("re-applies the recovered conversation when the resume throws after re-opening the turn", async () => {
+    // `runDeferredDurableTurnResume` swallows the failure and reports
+    // `resumed: false`, but the turn had already re-opened and already
+    // republished `session.state.history` from its checkpoint prefix. Keying
+    // the re-apply off the attempt outcome alone would leave the recovered
+    // conversation erased for exactly the runs that failed.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const resumed = stubResumedTurn({ throwAfterStart: true });
+    let booted: LocalRuntimeBootstrap | undefined;
+    const runner = makeRunner(
+      (bootstrap) => {
+        booted = bootstrap;
+      },
+      { durableResumeTimeoutMs: 30_000 },
+    );
+
+    await expect(
+      runner.restoreAgent(restoreParams(recoveredRunState())),
+    ).resolves.toBe(true);
+    await resumed.settled;
+
+    await waitUntil(
+      async () =>
+        (await sessionHistory(booted!)).some(
+          (message) =>
+            message.role === "user" &&
+            message.content === RECOVERED_USER_MESSAGE,
+        ),
+      "the recovered conversation to survive a resume that threw after starting",
+      10_000,
+    );
+    expect(
+      (await sessionHistory(booted!)).some(
+        (message) =>
+          message.role === "tool" && message.toolCallId === REPLAY_CALL_ID,
+      ),
+    ).toBe(true);
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("releases the start wait as soon as the caller's restore is aborted", async () => {
+    // The daemon-startup path passes no signal, which is why the timeout
+    // exists — but the on-demand lifecycle path (agent-lifecycle.ts, an
+    // `agent.create` resume waiter) owns its own deadline and DOES pass one.
+    // Its cancellation must release this wait immediately instead of waiting
+    // out a bound that belongs to daemon startup.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const stalled = stubStalledResume();
+    const controller = new AbortController();
+    const runner = makeRunner(undefined, {
+      durableResumeTimeoutMs: 30_000,
+      agentStopTimeoutMs: 2_000,
+    });
+    const restore = runner.restoreAgent(
+      restoreParams({ signal: controller.signal }),
+    );
+    const settled = restore.then(
+      () => "the restore resolved",
+      () => "the restore rejected",
+    );
+
+    await waitUntil(
+      () => stalled.entered(),
+      "the recovered turn to reach its stall",
+    );
+    const abortedAt = Date.now();
+    controller.abort(new Error("the caller cancelled the restore"));
+    const outcome = await Promise.race([
+      settled,
+      new Promise<string>((resolve) =>
+        setTimeout(
+          () => resolve("the restore was still waiting out its own timeout"),
+          10_000,
+        ),
+      ),
+    ]);
+    expect(outcome).toBe("the restore rejected");
+    expect(Date.now() - abortedAt).toBeLessThan(10_000);
+
+    stalled.release();
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("appends only the replayed tool results when the replacing turn already published its own conversation", async () => {
+    // The realistic shape of a replaced resume, asserted rather than
+    // described: by the time the slot frees, the client turn that replaced the
+    // resume has published its OWN conversation. The merge then appends the
+    // re-dispatched tool results at the tail and does NOT reintroduce the
+    // recovered `initialMessages` ahead of a conversation that has moved on.
+    // That is a real ordering change from base (which merged before any client
+    // turn could exist) and it is the accepted trade the doc comment states.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const resumed = stubResumedTurn();
+    let booted: LocalRuntimeBootstrap | undefined;
+    const runner = makeRunner(
+      (bootstrap) => {
+        booted = bootstrap;
+        holdTurnSlot(bootstrap);
+      },
+      { durableResumeTimeoutMs: 30_000 },
+    );
+
+    await expect(
+      runner.restoreAgent(restoreParams(recoveredRunState())),
+    ).resolves.toBe(true);
+    const bootstrap = booted!;
+    await resumed.settled;
+
+    // What the replacing turn does that the busy-slot test never modelled: it
+    // publishes its own history before it releases the slot.
+    await setSessionHistory(bootstrap, [
+      { role: "user", content: "NEWER CLIENT MESSAGE" },
+      { role: "assistant", content: "the newer turn's answer" },
+    ]);
+    releaseTurnSlot(bootstrap);
+
+    await waitUntil(
+      async () => (await sessionHistory(bootstrap)).length > 2,
+      "the recovered tool results to be merged onto the newer conversation",
+      10_000,
+    );
+    const history = await sessionHistory(bootstrap);
+    expect(history.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "tool",
+    ]);
+    expect(history[0]!.content).toBe("NEWER CLIENT MESSAGE");
+    expect(history.at(-1)!.toolCallId).toBe(REPLAY_CALL_ID);
+    // Accepted limitation, pinned so it cannot drift into a claim: the
+    // recovered user message is NOT restored ahead of the newer conversation.
+    expect(
+      history.some((message) => message.content === RECOVERED_USER_MESSAGE),
+    ).toBe(false);
 
     await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
   }, 60_000);

--- a/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
+++ b/runtime/tests/app-server/durable-resume-approval-bridge.test.ts
@@ -1,0 +1,361 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgenCDelegateBackgroundAgentRunner } from "../../src/app-server/background-agent-runner.js";
+import { bootstrapLocalRuntimeSession } from "../../src/bin/bootstrap.js";
+import type { ReviewDecision } from "../../src/permissions/review-decision.js";
+import { computeCheckpointPrefixHashV3 } from "../../src/session/durable-checkpoint-reader.js";
+import {
+  currentBuildId,
+  resetBuildIdForTestingOnly,
+} from "../../src/session/durable-turns.js";
+import {
+  parseRolloutLine,
+  type RolloutItem,
+} from "../../src/session/rollout-item.js";
+import { reconstructFromRollout } from "../../src/session/rollout-reconstruction.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+import { Session } from "../../src/session/session.js";
+import { VERSION } from "../../src/version.js";
+
+/**
+ * #2239 — a turn resumed after a daemon death ran with no approval resolver.
+ *
+ * The durable resume is driven from the startup prewarm INSIDE
+ * `bootstrapLocalRuntimeSession`, so it completed before `restoreAgent` could
+ * install `services.approvalResolver` (`#installDaemonApprovalBridge`) or
+ * register the agent in `#active`. Every tool in the recovered turn that
+ * needed approval hit the guardian arbiter's `default_deny`, the user was
+ * never prompted, and the recovered turn was spent.
+ *
+ * These tests run the REAL bootstrap through the REAL runner: the session
+ * under test is built by `buildBootstrapSessionServices`, so it carries every
+ * service a production session carries (`guardianApprovalReviewer` included —
+ * that service is set unconditionally and answers approvals only for
+ * `approvalsReviewer: "auto_review"` turns, so its presence is NOT evidence
+ * that anyone can answer a prompt).
+ */
+
+const CONVERSATION_ID = "session-durable-resume-approval";
+const TURN_ID = "orphan-turn-2239";
+const APPROVAL_REQUEST_ID = "resume-approval-probe";
+
+interface ResumeObservation {
+  readonly resume: boolean;
+  readonly hasApprovalResolver: boolean;
+  readonly hasGuardianApprovalReviewer: boolean;
+}
+
+/**
+ * One started-but-never-terminated turn carrying a durable checkpoint whose
+ * prefix is empty — the shape a SIGKILLed daemon leaves behind.
+ */
+function orphanRolloutItems(turnId: string): RolloutItem[] {
+  return [
+    {
+      type: "event_msg",
+      payload: {
+        id: `${turnId}-started`,
+        msg: {
+          type: "turn_started",
+          payload: { turnId, buildId: currentBuildId() },
+        },
+      },
+    },
+    {
+      type: "event_msg",
+      payload: {
+        id: `${turnId}-checkpoint`,
+        msg: {
+          type: "turn_checkpoint",
+          payload: {
+            turnId,
+            iterationIndex: 1,
+            boundary: "iteration",
+            checkpointSeq: 1,
+            persistedMessageCount: 0,
+            prefixHash: computeCheckpointPrefixHashV3([], 0),
+            checkpointVersion: 4,
+            toolResultIntegrityVersion: 1,
+            prefixHashVersion: 3,
+            resumableState: {
+              turnCount: 1,
+              recoveryReentryCount: 0,
+              maxOutputTokensRecoveryCount: 0,
+              continuationNudgeCount: 0,
+              stopHookBlockingCount: 0,
+            },
+          },
+        },
+      },
+    },
+  ] as unknown as RolloutItem[];
+}
+
+function readRollout(rolloutPath: string): RolloutItem[] {
+  return readFileSync(rolloutPath, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => parseRolloutLine(line))
+    .filter((item): item is RolloutItem => item !== null);
+}
+
+describe("durable resume reaches the daemon approval bridge (#2239)", () => {
+  let home = "";
+  let workspace = "";
+  let rolloutPath = "";
+  let previousBuildId: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-2239-home-"));
+    workspace = mkdtempSync(join(tmpdir(), "agenc-2239-ws-"));
+    mkdirSync(join(workspace, ".git"), { recursive: true });
+    previousBuildId = process.env.AGENC_BUILD_ID;
+    process.env.AGENC_BUILD_ID = "resume-approval-build";
+    resetBuildIdForTestingOnly();
+
+    const seed = new RolloutStore({
+      cwd: workspace,
+      sessionId: CONVERSATION_ID,
+      agencVersion: VERSION,
+      agencHome: home,
+      sessionTempRoot: tmpdir(),
+      autoStartScheduler: false,
+    });
+    seed.open({
+      sessionId: CONVERSATION_ID,
+      timestamp: new Date().toISOString(),
+      cwd: workspace,
+      originator: "agenc-cli",
+      source: "interactive-root",
+      agencVersion: VERSION,
+      model: "base-model",
+      modelProvider: "grok",
+    });
+    for (const item of orphanRolloutItems(TURN_ID)) seed.appendRollout(item);
+    rolloutPath = seed.rolloutPath;
+    seed.close();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousBuildId === undefined) delete process.env.AGENC_BUILD_ID;
+    else process.env.AGENC_BUILD_ID = previousBuildId;
+    resetBuildIdForTestingOnly();
+    rmSync(home, { recursive: true, force: true });
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  function stubProviderAndMcp(): void {
+    vi.spyOn(Session.prototype, "startMcpManager").mockResolvedValue(undefined);
+  }
+
+  async function stubProvider(): Promise<void> {
+    const providerMod = await import("../../src/llm/provider.js");
+    vi.spyOn(providerMod, "createProvider").mockImplementation(
+      () =>
+        ({
+          name: "stub",
+          chat: async () => ({
+            content: "ok",
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          }),
+        }) as never,
+    );
+  }
+
+  function makeRunner(): AgenCDelegateBackgroundAgentRunner {
+    return new AgenCDelegateBackgroundAgentRunner({
+      bootstrap: (options) => bootstrapLocalRuntimeSession(options),
+      env: {
+        ...process.env,
+        AGENC_HOME: home,
+        AGENC_WORKSPACE: workspace,
+        HOME: home,
+      },
+    });
+  }
+
+  function restoreParams(): never {
+    return {
+      agentId: CONVERSATION_ID,
+      objective: "resume after daemon death",
+      cwd: workspace,
+      resumeRolloutPath: rolloutPath,
+      explicitColdResume: true,
+      // The daemon snapshot is complete per client; keys absent from it are
+      // cleared, so provider credentials must ride the override.
+      envOverrides: { XAI_API_KEY: "test-key" },
+    } as never;
+  }
+
+  it("drives the recovered turn only once a client can answer its approvals", async () => {
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const runner = makeRunner();
+    const observations: ResumeObservation[] = [];
+    let approvalProbe: Promise<ReviewDecision> | undefined;
+    const resumeDriven = Promise.withResolvers<void>();
+
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      this: Session,
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      const services = this.services as {
+        approvalResolver?: {
+          request: (ctx: unknown) => Promise<ReviewDecision>;
+        };
+        guardianApprovalReviewer?: unknown;
+      };
+      const isResume = options?.resume !== undefined;
+      observations.push({
+        resume: isResume,
+        hasApprovalResolver: services.approvalResolver !== undefined,
+        hasGuardianApprovalReviewer:
+          services.guardianApprovalReviewer !== undefined,
+      });
+      if (isResume) {
+        // Ask for approval exactly the way `execute-tools` does, from inside
+        // the resumed turn. This is the property the issue is about: the
+        // request must become a pending decision the daemon can deliver to a
+        // client, not an instant refusal.
+        approvalProbe = services.approvalResolver?.request({
+          callId: APPROVAL_REQUEST_ID,
+          invocation: { session: { conversationId: CONVERSATION_ID } },
+        });
+        resumeDriven.resolve();
+      }
+      return (async function* () {
+        return { reason: "completed" as const };
+      })() as never;
+    });
+
+    await expect(runner.restoreAgent(restoreParams())).resolves.toBe(true);
+    await Promise.race([
+      resumeDriven.promise,
+      new Promise((_resolve, reject) =>
+        setTimeout(
+          () => reject(new Error("the recovered turn was never driven")),
+          10_000,
+        ),
+      ),
+    ]);
+
+    expect(observations).toEqual([
+      {
+        resume: true,
+        hasApprovalResolver: true,
+        // Production shape marker: every canonical session carries this
+        // service, so it can never stand in for "someone can answer".
+        hasGuardianApprovalReviewer: true,
+      },
+    ]);
+
+    // The approval is pending on the daemon, not denied: a client answer
+    // reaches it. `#requestDaemonToolDecision` returns DENIED outright when
+    // the agent is absent from `#active`, so this also proves the agent was
+    // registered before the resumed turn ran.
+    expect(approvalProbe).toBeDefined();
+    let settled = false;
+    void approvalProbe?.then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+
+    await expect(
+      runner.resolveToolDecision(CONVERSATION_ID, {
+        requestId: APPROVAL_REQUEST_ID,
+        decision: { kind: "approved" },
+      }),
+    ).resolves.toBe(true);
+    await expect(approvalProbe).resolves.toEqual({ kind: "approved" });
+
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+  }, 60_000);
+
+  it("keeps resuming inline for callers that do not defer (local CLI/TUI)", async () => {
+    // The local TUI installs `session.services.approvalResolver` from a React
+    // effect, i.e. after bootstrap returns, so it has no resolver at prewarm
+    // time either. The fix must not make its resumes defer or fail: without
+    // `deferDurableTurnResume` the resume still runs inside bootstrap, byte
+    // for byte as before.
+    await stubProvider();
+    stubProviderAndMcp();
+
+    const resumesDrivenDuringBootstrap: boolean[] = [];
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(function (
+      _input: unknown,
+      options?: { readonly resume?: unknown },
+    ) {
+      if (options?.resume !== undefined) resumesDrivenDuringBootstrap.push(true);
+      return (async function* () {
+        return { reason: "completed" as const };
+      })() as never;
+    });
+
+    const boot = await bootstrapLocalRuntimeSession({
+      apiKey: "test-key",
+      conversationId: CONVERSATION_ID,
+      resumeConversation: true,
+      resumeRolloutPath: rolloutPath,
+      cwd: workspace,
+      env: {
+        ...process.env,
+        AGENC_HOME: home,
+        AGENC_WORKSPACE: workspace,
+        HOME: home,
+        XAI_API_KEY: "test-key",
+      },
+    });
+    try {
+      expect(resumesDrivenDuringBootstrap).toEqual([true]);
+      // Nothing was deferred, so the driver is an explicit no-op.
+      await expect(boot.runDeferredDurableTurnResume?.()).resolves.toEqual({
+        resumed: false,
+      });
+    } finally {
+      await boot.shutdown();
+    }
+  }, 60_000);
+
+  it("proves the recovered turn is single-shot: replay persists its abort", async () => {
+    // Why the fix drives the resume in THIS process instead of deferring it
+    // to some later user message: bootstrap replays the rollout with
+    // `emitSynthesized: true`, which persists `turn_aborted{process_killed}`
+    // for the orphan. Once that abort is on disk the turn yields no resume
+    // descriptor ever again, so a deferral that never fires drops it.
+    await stubProvider();
+    stubProviderAndMcp();
+    vi.spyOn(Session.prototype, "runTurn").mockImplementation(
+      () =>
+        (async function* () {
+          return { reason: "completed" as const };
+        })() as never,
+    );
+
+    const before = reconstructFromRollout(readRollout(rolloutPath));
+    expect(before.resumableTurns.map((turn) => turn.turnId)).toEqual([TURN_ID]);
+
+    const runner = makeRunner();
+    await expect(runner.restoreAgent(restoreParams())).resolves.toBe(true);
+    await runner.stopAgent(CONVERSATION_ID).catch(() => undefined);
+
+    const persisted = readRollout(rolloutPath);
+    const abortedTurnIds = persisted.flatMap((item) =>
+      item.type === "event_msg" &&
+      item.payload.msg.type === "turn_aborted" &&
+      item.payload.msg.payload.reason === "process_killed"
+        ? [item.payload.msg.payload.turnId]
+        : [],
+    );
+    expect(abortedTurnIds).toContain(TURN_ID);
+    expect(reconstructFromRollout(persisted).resumableTurns).toEqual([]);
+  }, 60_000);
+});


### PR DESCRIPTION
## Why

Closes #2239. The durable resume ran inside bootstrap, and the only writer of `services.approvalResolver` is the daemon's approval bridge, installed after bootstrap returns and after the agent is registered in `#active`. So a turn resumed after the daemon died ran with no broker: every tool needing approval came back `Not permitted: … no approval resolver is available to allow it`, no dialog could reach the user because the agent was not yet in the active map, and the recovered turn was drained to completion inside bootstrap and spent. "Your work survives a restart" only actually worked in `bypassPermissions`.

## What

`restoreAgent` now withholds only the durable resume (`deferDurableTurnResume`, opt-in), and drives it after `#installDaemonApprovalBridge` and `#active.set`, so the resumed turn has both a broker and a registered agent. Startup waits for `turn_resumed` — not for the turn to finish — bounded by `DAEMON_AGENT_CREATE_TIMEOUT_MS`, the same deadline the inline resume already ran under. On expiry the restore returns, the daemon reaches `socketServer.listen()`, and the resume keeps running with `warning{cause:"durable_resume_start_timeout"}` recorded durably.

The local CLI/TUI is untouched: the flag is opt-in and set only by `restoreAgent`, so those sessions still resume inline.

Recovered history is re-applied after the resumed turn ends, because the turn's `syncSessionState` republishes `session.state.history`. The decision that there is anything to merge is made **before** the wait, so an ordinary recovered run — no snapshot conversation, no in-flight tool calls — neither polls the turn slot nor records a loss.

## Why the resume is not deferred past this process

The recovered turn is single-shot. Bootstrap replays with `emitSynthesized: true`, which persists `turn_aborted{process_killed}` for the orphan, so it is gone from `resumableTurns` on the next start. A test pins this and passes on unfixed `main`, so it documents existing behaviour: any design that waits for a client, or retries on a later start, silently destroys the interrupted turn. That is why this reorders within one startup instead of deferring.

## Evidence

Measured on both trees, not read:

- **Bound**: with a resume stalled before `turn_resumed`, `restoreAgent` resolves at ~121.1 s on this branch where `main` rejects at ~121.1 s with `DaemonOperationTimeoutError`. Same wall time, better outcome — the agent is published instead of the restore failing.
- **Socket**: a real in-process daemon over a seeded state DB reaches `listen()` at ~121.4 s with a stalled recovered turn.
- **History**: after a restore carrying `initialMessages` and `replayToolCalls`, `state.history` reaches `[user, assistant, tool]` and stays there.
- **No false loss**: the ordinary recovered shape goes from 13 slot polls and one `recovered_history_reapply_abandoned` warning to zero of each.

## Accepted limitations, stated in the code

A client turn that replaces the resume and publishes its own conversation keeps the replayed tool results, appended at the tail, but does not get the recovered `initialMessages` reintroduced ahead of a conversation that has moved on. And the bound is a daemon-startup deadline, so a replacing turn that outlives it loses the merge — possible, never silent.

## Tests

15 cases in `runtime/tests/app-server/durable-resume-approval-bridge.test.ts`, on production-shaped sessions: real `bootstrapLocalRuntimeSession`, real `RolloutStore`, real runner. Every behaviour is falsified — reverting each change fails its own test and nothing else, including the production default timeout, the abandon path, the `turnWasOpened` condition and the threaded `signal`.

This took five review rounds. Four earlier attempts were rejected for real defects: a gate that was inert in production, a reorder that wiped recovered history, an unbounded wait that stopped the daemon from ever listening, and a warning that announced a lost conversation nobody had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)