### PR TITLE
fix(runtime): resolve installed packaged ripgrep fallback

### DIFF
--- a/docs/ci-required-gates.md
+++ b/docs/ci-required-gates.md
@@ -38,7 +38,10 @@ npm run test:fast
 
 `test:fast` is [`scripts/run-fast-checks.mjs`](../scripts/run-fast-checks.mjs).
 It prints a JSON classification plan, then runs only the commands that plan
-selects. Run the exact test file while developing a bug fix. Use a subsystem
+selects. Plans that run runtime Vitest first check that the shared resolver can
+start system ripgrep or the installed `@vscode/ripgrep` platform binary. A missing
+or unusable binary fails this preflight before typecheck and test discovery.
+Run the exact test file while developing a bug fix. Use a subsystem
 smoke only when the changed behavior needs it. Examples include the PTY startup
 check for startup or terminal work and a native platform job for
 platform-specific code.

--- a/runtime/scripts/check-ripgrep.mjs
+++ b/runtime/scripts/check-ripgrep.mjs
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tsImport } from "tsx/esm/api";
+import { register } from "tsx/cjs/api";
+
+async function loadRipgrepResolver() {
+  const unregister = register();
+  try {
+    return await tsImport("../src/utils/ripgrep.ts", {
+      parentURL: import.meta.url,
+      tsconfig: fileURLToPath(new URL("../tsconfig.json", import.meta.url)),
+    });
+  } finally {
+    unregister();
+  }
+}
+
+export async function checkRipgrep({
+  loadResolver = loadRipgrepResolver,
+  report = (message) => process.stdout.write(`${message}\n`),
+} = {}) {
+  const resolver = await loadResolver();
+  const status = resolver.getRipgrepStatus();
+  if (!await resolver.probeRipgrepAvailable()) {
+    throw new Error(
+      `Ripgrep preflight failed (${status.mode}: ${status.path}). Reinstall dependencies including optional platform packages, or install rg on PATH.`,
+    );
+  }
+  report(`Ripgrep preflight passed (${status.mode}: ${status.path}).`);
+  return status;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await checkRipgrep();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/runtime/scripts/check-ripgrep.test.mjs
+++ b/runtime/scripts/check-ripgrep.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { rgPath } from "@vscode/ripgrep";
+import { checkRipgrep } from "./check-ripgrep.mjs";
+
+test("preflight reports the resolver's executable only after a successful probe", async () => {
+  const messages = [];
+  const status = { mode: "builtin", path: "/installed/rg", working: null };
+  assert.equal(await checkRipgrep({
+    loadResolver: async () => ({ getRipgrepStatus: () => status, probeRipgrepAvailable: async () => true }),
+    report: (message) => messages.push(message),
+  }), status);
+  assert.deepEqual(messages, ["Ripgrep preflight passed (builtin: /installed/rg)."]);
+});
+
+test("preflight fails directly when the resolver's probe fails", async () => {
+  await assert.rejects(checkRipgrep({
+    loadResolver: async () => ({
+      getRipgrepStatus: () => ({ mode: "builtin", path: "@vscode/ripgrep", working: false }),
+      probeRipgrepAvailable: async () => false,
+    }),
+    report: () => assert.fail("unavailable ripgrep must not pass"),
+  }), /Ripgrep preflight failed.*optional platform packages/u);
+});
+
+test("the real preflight finds the packaged binary without system rg", () => {
+  const root = mkdtempSync(join(tmpdir(), "agenc-rg-preflight-"));
+  try {
+    const result = spawnSync(process.execPath, [fileURLToPath(new URL("./check-ripgrep.mjs", import.meta.url))], {
+      encoding: "utf8",
+      timeout: 20_000,
+      env: { ...process.env, PATH: root, USE_BUILTIN_RIPGREP: "0" },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.includes(`Ripgrep preflight passed (builtin: ${rgPath}).`), result.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/runtime/src/utils/ripgrep.ts
+++ b/runtime/src/utils/ripgrep.ts
@@ -1,9 +1,9 @@
 import type { ChildProcess, ExecFileException } from 'child_process'
 import { execFile, spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { accessSync, constants, statSync } from 'fs'
 import memoize from 'lodash-es/memoize.js'
-import * as path from 'path'
-import { fileURLToPath } from 'url'
+import { isAbsolute } from 'node:path'
+import { resolvePinnedRipgrepPath } from '../tools/system/pinned-ripgrep.js'
 import { isInBundledMode } from './bundledMode.js'
 import { logForDebugging } from 'src/utils/debug.js'
 import { isEnvDefinedFalsy } from './envUtils.js'
@@ -11,13 +11,6 @@ import { execFileNoThrow } from './execFileNoThrow.js'
 import { findExecutable } from './findExecutable.js'
 import { logError } from './log.js'
 import { getPlatform } from './platform.js'
-
-const __filename = fileURLToPath(import.meta.url)
-// we use node:path.join instead of node:url.resolve because the former doesn't encode spaces
-const __dirname = path.join(
-  __filename,
-  process.env.NODE_ENV === 'test' ? '../../../' : '../',
-)
 
 type RipgrepConfig = {
   mode: 'system' | 'builtin' | 'embedded'
@@ -35,7 +28,7 @@ function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
 type ResolveRipgrepConfigArgs = {
   userWantsSystemRipgrep: boolean
   bundledMode: boolean
-  builtinCommand: string
+  builtinCommand?: string
   builtinExists: boolean
   systemExecutablePath: string
   processExecPath?: string
@@ -50,8 +43,7 @@ export function resolveRipgrepConfig({
   processExecPath = process.execPath,
 }: ResolveRipgrepConfigArgs): RipgrepConfig {
   if (userWantsSystemRipgrep && systemExecutablePath !== 'rg') {
-    // SECURITY: Use command name 'rg' instead of systemExecutablePath to prevent PATH hijacking
-    return { mode: 'system', command: 'rg', args: [] }
+    return { mode: 'system', command: systemExecutablePath, args: [] }
   }
 
   if (bundledMode) {
@@ -63,20 +55,34 @@ export function resolveRipgrepConfig({
     }
   }
 
-  if (builtinExists) {
+  if (builtinExists && builtinCommand !== undefined) {
     return { mode: 'builtin', command: builtinCommand, args: [] }
   }
 
   if (systemExecutablePath !== 'rg') {
-    return { mode: 'system', command: 'rg', args: [] }
+    return { mode: 'system', command: systemExecutablePath, args: [] }
   }
 
-  return { mode: 'builtin', command: builtinCommand, args: [] }
+  throw wrapRipgrepUnavailableError(
+    { code: 'ENOENT', message: 'Neither system nor packaged ripgrep is an executable file.' },
+    { mode: 'builtin', command: builtinCommand ?? '@vscode/ripgrep', args: [] },
+  )
 }
 
 export type RipgrepIngressOptions = {
   readonly environment: NodeJS.ProcessEnv
   readonly systemExecutablePath: string
+}
+
+function isRipgrepExecutable(candidate: string | undefined): candidate is string {
+  if (candidate === undefined || !isAbsolute(candidate)) return false
+  try {
+    if (!statSync(candidate).isFile()) return false
+    accessSync(candidate, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function buildRipgrepConfig(
@@ -87,19 +93,15 @@ function buildRipgrepConfig(
     environment.USE_BUILTIN_RIPGREP,
   )
   const bundledMode = isInBundledMode()
-  const rgRoot = path.resolve(__dirname, 'vendor', 'ripgrep')
-  const builtinCommand =
-    process.platform === 'win32'
-      ? path.resolve(rgRoot, `${process.arch}-win32`, 'rg.exe')
-      : path.resolve(rgRoot, `${process.arch}-${process.platform}`, 'rg')
-  const builtinExists = existsSync(builtinCommand)
+  const builtinCommand = bundledMode ? undefined : resolvePinnedRipgrepPath()
+  const builtinExists = isRipgrepExecutable(builtinCommand)
 
   return resolveRipgrepConfig({
     userWantsSystemRipgrep,
     bundledMode,
     builtinCommand,
     builtinExists,
-    systemExecutablePath,
+    systemExecutablePath: isRipgrepExecutable(systemExecutablePath) ? systemExecutablePath : 'rg',
   })
 }
 
@@ -541,11 +543,16 @@ export function getRipgrepStatus(options?: RipgrepIngressOptions): {
   path: string
   working: boolean | null // null if not yet tested
 } {
-  const config = getRipgrepConfigForIngress(options)
-  return {
-    mode: config.mode,
-    path: config.command,
-    working: options === undefined ? ripgrepStatus?.working ?? null : null,
+  try {
+    const config = getRipgrepConfigForIngress(options)
+    return {
+      mode: config.mode,
+      path: config.command,
+      working: options === undefined ? ripgrepStatus?.working ?? null : null,
+    }
+  } catch (error) {
+    if (!(error instanceof RipgrepUnavailableError)) throw error
+    return { mode: error.config.mode, path: error.config.command, working: false }
   }
 }
 
@@ -558,8 +565,8 @@ export function getRipgrepStatus(options?: RipgrepIngressOptions): {
 export async function probeRipgrepAvailable(
   options?: RipgrepIngressOptions,
 ): Promise<boolean> {
-  const config = getRipgrepConfigForIngress(options)
   try {
+    const config = getRipgrepConfigForIngress(options)
     if (config.argv0) {
       // Embedded ripgrep is only reachable under a Bun-compiled binary, which
       // always ships rg; treat it as available without spawning here.

--- a/runtime/src/utils/sandbox/sandbox-runtime.ts
+++ b/runtime/src/utils/sandbox/sandbox-runtime.ts
@@ -38,6 +38,7 @@ import { logForDebugging } from 'src/utils/debug.js'
 import { expandPath } from '../path.js'
 import { getPlatform } from '../platform.js'
 import { settingsChangeDetector } from '../settings/changeDetector.js'
+import { getCanonicalSettingsAuthority } from '../settings/canonicalAuthority.js'
 import { SETTING_SOURCES, type SettingSource } from '../settings/constants.js'
 import {
   getExecutionAuthoritySettings,
@@ -58,7 +59,7 @@ import { WEB_FETCH_TOOL_NAME } from 'src/tools/WebFetchTool/prompt.js'
 import { errorMessage } from '../errors.js'
 import { getAgenCTempDir } from '../permissions/filesystem.js'
 import type { PermissionRuleValue } from '../permissions/PermissionRule.js'
-import { ripgrepCommand } from '../ripgrep.js'
+import { RipgrepUnavailableError, ripgrepCommand } from '../ripgrep.js'
 
 function sandboxNetwork(
   settings: AgenCConfig | null,
@@ -70,6 +71,19 @@ function sandboxFilesystem(
   settings: AgenCConfig | null,
 ): SandboxFilesystemConfig | undefined {
   return settings?.sandbox?.filesystem
+}
+
+function sandboxRipgrep(settings: AgenCConfig): NonNullable<SandboxRuntimeConfig['ripgrep']> {
+  const configured = settings.sandbox?.ripgrep
+  if (configured?.command !== undefined) {
+    return { command: configured.command, args: configured.args ? [...configured.args] : [] }
+  }
+  const { rgPath, rgArgs, argv0 } = ripgrepCommand()
+  return {
+    command: rgPath,
+    args: configured?.args ? [...configured.args] : rgArgs,
+    argv0,
+  }
 }
 
 // Local copies to avoid circular dependency
@@ -374,14 +388,11 @@ export function convertToSandboxRuntimeConfig(
   }
   // Ripgrep config for sandbox. User settings take priority; otherwise pass our rg.
   // In embedded mode (argv0='rg' dispatch), sandbox-runtime spawns with argv0 set.
-  const { rgPath, rgArgs, argv0 } = ripgrepCommand()
-  const configuredRipgrep = settings.sandbox?.ripgrep
-  const ripgrepConfig = {
-    command: configuredRipgrep?.command ?? rgPath,
-    args: configuredRipgrep?.args
-      ? [...configuredRipgrep.args]
-      : rgArgs,
-    argv0,
+  let ripgrepConfig: SandboxRuntimeConfig['ripgrep']
+  try {
+    ripgrepConfig = sandboxRipgrep(settings)
+  } catch (error) {
+    if (!(error instanceof RipgrepUnavailableError)) throw error
   }
 
   return {
@@ -486,12 +497,14 @@ async function detectWorktreeMainRepoPath(cwd: string): Promise<string | null> {
  * Returns { errors, warnings } - errors mean sandbox cannot run
  */
 const checkDependencies = memoize((): SandboxDependencyCheck => {
-  const { rgPath, rgArgs } = ripgrepCommand()
-  return BaseSandboxManager.checkDependencies({
-    command: rgPath,
-    args: rgArgs,
-  })
-})
+  try {
+    const settings = getCanonicalSettingsAuthority()?.current() ?? { configVersion: 2 }
+    return BaseSandboxManager.checkDependencies(sandboxRipgrep(settings))
+  } catch (error) {
+    if (!(error instanceof RipgrepUnavailableError)) throw error
+    return { errors: [error.message], warnings: [] }
+  }
+}, () => JSON.stringify(getCanonicalSettingsAuthority()?.current().sandbox?.ripgrep))
 
 /**
  * Read the single resolved canonical sandbox mode. Repository layers are

--- a/runtime/tests/tools/AgentTool/loadAgentsDir.test.ts
+++ b/runtime/tests/tools/AgentTool/loadAgentsDir.test.ts
@@ -253,14 +253,17 @@ describe('AgentTool loadAgentsDir adapter', () => {
     vi.stubEnv('AGENC_HOME', agencHome)
     __setPluginAgentsLoaderForTesting(async () => [])
 
-    const catalog = await loadFreshAgentDefinitions(
-      workspace,
-      testPluginStorageRoot,
-    )
-
-    expect(
-      catalog.allAgents.map(definition => definition.agentType),
-    ).not.toContain('hardlinked-external')
+    for (const nativeSearch of ['1', '']) {
+      vi.stubEnv('AGENC_USE_NATIVE_FILE_SEARCH', nativeSearch)
+      clearAgentDefinitionsCache()
+      const catalog = await loadFreshAgentDefinitions(
+        workspace,
+        testPluginStorageRoot,
+      )
+      expect(
+        catalog.allAgents.map(definition => definition.agentType),
+      ).not.toContain('hardlinked-external')
+    }
   })
 
   test('applies source precedence when active agents collide by type', () => {

--- a/runtime/tests/utils/markdown-config-loader-authority.test.ts
+++ b/runtime/tests/utils/markdown-config-loader-authority.test.ts
@@ -2,9 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import { ConfigStore } from '../../src/config/store.js'
+import * as ripgrep from '../../src/utils/ripgrep.js'
 import {
   loadMarkdownFilesForSubdir,
   loadMarkdownFilesForSubdirFresh,
@@ -98,32 +99,26 @@ describe('markdown discovery authority', () => {
   })
 
   test('still finds markdown when the search binary cannot run', async () => {
-    // ripGrep reports an unavailable binary with code "ENOENT", which errno
-    // alone cannot tell apart from "the directory is gone", so the loader
-    // swallowed it and every markdown-defined agent, command and hook
-    // silently vanished wherever ripgrep could not start. CI is exactly such
-    // a machine: with `rg` off PATH this reproduced as a catalog holding only
-    // the five built-in agents. The native walk is the documented fallback.
     const workspace = temporaryRoot('workspace-no-rg')
     const home = temporaryRoot('home-no-rg')
     writeAgent(home, 'Found without ripgrep.')
     const authority = await createAuthority(home, workspace)
 
-    const previousBuiltin = process.env.USE_BUILTIN_RIPGREP
-    const previousPath = process.env.PATH
-    process.env.USE_BUILTIN_RIPGREP = 'false'
-    // A PATH with no `rg` on it, which is what makes ripGrep reject.
-    process.env.PATH = temporaryRoot('empty-bin')
+    const previousNative = process.env.AGENC_USE_NATIVE_FILE_SEARCH
+    process.env.AGENC_USE_NATIVE_FILE_SEARCH = ''
+    const unavailable = vi.spyOn(ripgrep, 'ripGrep').mockRejectedValue(
+      new ripgrep.RipgrepUnavailableError('fixture binary unavailable', { mode: 'builtin', command: 'missing' }, 'ENOENT'),
+    )
     try {
       const files = await runWithCanonicalSettingsAuthority(authority, () =>
         loadMarkdownFilesForSubdirFresh('agents', workspace),
       )
       expect(prompt(files)).toBe('Found without ripgrep.')
+      expect(unavailable).toHaveBeenCalled()
     } finally {
-      if (previousBuiltin === undefined) delete process.env.USE_BUILTIN_RIPGREP
-      else process.env.USE_BUILTIN_RIPGREP = previousBuiltin
-      if (previousPath === undefined) delete process.env.PATH
-      else process.env.PATH = previousPath
+      unavailable.mockRestore()
+      if (previousNative === undefined) delete process.env.AGENC_USE_NATIVE_FILE_SEARCH
+      else process.env.AGENC_USE_NATIVE_FILE_SEARCH = previousNative
     }
   })
 

--- a/runtime/tests/utils/ripgrep-packaged.test.ts
+++ b/runtime/tests/utils/ripgrep-packaged.test.ts
@@ -1,0 +1,102 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { rgPath } from '@vscode/ripgrep'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const roots: string[] = []
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'agenc-packaged-ripgrep-'))
+  roots.push(root)
+  return root
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.doUnmock('../../src/tools/system/pinned-ripgrep.js')
+  vi.resetModules()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+test('uses the installed platform binary with no ripgrep on PATH', async () => {
+  const { getRipgrepStatus, probeRipgrepAvailable } = await import('../../src/utils/ripgrep.js')
+  const ingress = {
+    environment: { PATH: temporaryRoot(), USE_BUILTIN_RIPGREP: '0' },
+    systemExecutablePath: 'rg',
+  }
+  expect(getRipgrepStatus(ingress)).toMatchObject({ mode: 'builtin', path: rgPath })
+  await expect(probeRipgrepAvailable(ingress)).resolves.toBe(true)
+})
+
+test('discovers Markdown through the packaged executable with an empty PATH', async () => {
+  vi.stubEnv('PATH', temporaryRoot())
+  vi.stubEnv('USE_BUILTIN_RIPGREP', '0')
+  const { ripGrep, ripgrepCommand } = await import('../../src/utils/ripgrep.js')
+  const workspace = temporaryRoot()
+  mkdirSync(join(workspace, 'agents'))
+  const agent = join(workspace, 'agents', 'local.md')
+  writeFileSync(agent, 'Local agent')
+  writeFileSync(join(workspace, 'agents', 'ignored.txt'), 'Not Markdown')
+  expect(ripgrepCommand().rgPath).toBe(rgPath)
+  await expect(ripGrep(['--files', '--glob', '*.md'], workspace, new AbortController().signal))
+    .resolves.toEqual([agent])
+})
+
+test('uses a validated absolute system path when explicitly selected', async () => {
+  const { getRipgrepStatus, probeRipgrepAvailable } = await import('../../src/utils/ripgrep.js')
+  const ingress = {
+    environment: { PATH: temporaryRoot(), USE_BUILTIN_RIPGREP: '0' },
+    systemExecutablePath: rgPath,
+  }
+  expect(getRipgrepStatus(ingress)).toMatchObject({ mode: 'system', path: rgPath })
+  await expect(probeRipgrepAvailable(ingress)).resolves.toBe(true)
+})
+
+test('rejects missing and directory system candidates before selecting the package', async () => {
+  const root = temporaryRoot()
+  const { getRipgrepStatus } = await import('../../src/utils/ripgrep.js')
+  for (const systemExecutablePath of [root, join(root, 'missing')]) {
+    expect(getRipgrepStatus({
+      environment: { USE_BUILTIN_RIPGREP: '0' },
+      systemExecutablePath,
+    })).toMatchObject({ mode: 'builtin', path: rgPath })
+  }
+})
+
+test.skipIf(process.platform === 'win32')('rejects a non-executable system candidate', async () => {
+  const candidate = join(temporaryRoot(), 'rg')
+  writeFileSync(candidate, 'not executable')
+  chmodSync(candidate, 0o644)
+  const { getRipgrepStatus } = await import('../../src/utils/ripgrep.js')
+  expect(getRipgrepStatus({
+    environment: { USE_BUILTIN_RIPGREP: '0' },
+    systemExecutablePath: candidate,
+  })).toMatchObject({ mode: 'builtin', path: rgPath })
+})
+
+test('falls back to the system when the optional platform package is absent', async () => {
+  vi.doMock('../../src/tools/system/pinned-ripgrep.js', () => ({ resolvePinnedRipgrepPath: () => undefined }))
+  const { getRipgrepStatus, probeRipgrepAvailable } = await import('../../src/utils/ripgrep.js')
+  const ingress = { environment: { PATH: temporaryRoot() }, systemExecutablePath: rgPath }
+  expect(getRipgrepStatus(ingress)).toMatchObject({ mode: 'system', path: rgPath })
+  await expect(probeRipgrepAvailable(ingress)).resolves.toBe(true)
+})
+
+test('keeps unavailable status and probes safe when both candidates are missing', async () => {
+  vi.doMock('../../src/tools/system/pinned-ripgrep.js', () => ({ resolvePinnedRipgrepPath: () => undefined }))
+  vi.stubEnv('PATH', temporaryRoot())
+  const { getRipgrepStatus, probeRipgrepAvailable, ripgrepCommand, RipgrepUnavailableError } = await import('../../src/utils/ripgrep.js')
+  expect(getRipgrepStatus()).toMatchObject({ mode: 'builtin', working: false })
+  await expect(probeRipgrepAvailable()).resolves.toBe(false)
+  expect(ripgrepCommand).toThrow(RipgrepUnavailableError)
+})
+
+test('rejects an unusable packaged candidate before falling back to system rg', async () => {
+  const candidate = temporaryRoot()
+  vi.doMock('../../src/tools/system/pinned-ripgrep.js', () => ({ resolvePinnedRipgrepPath: () => candidate }))
+  const { getRipgrepStatus, probeRipgrepAvailable } = await import('../../src/utils/ripgrep.js')
+  const ingress = { environment: { PATH: temporaryRoot() }, systemExecutablePath: rgPath }
+  expect(getRipgrepStatus(ingress)).toMatchObject({ mode: 'system', path: rgPath })
+  await expect(probeRipgrepAvailable(ingress)).resolves.toBe(true)
+})

--- a/runtime/tests/utils/ripgrep.test.ts
+++ b/runtime/tests/utils/ripgrep.test.ts
@@ -21,7 +21,7 @@ test('ripgrepCommand falls back to system rg when builtin binary is missing', ()
 
   expect(config).toMatchObject({
     mode: 'system',
-    command: 'rg',
+    command: '/usr/bin/rg',
     args: [],
   })
 })
@@ -41,6 +41,26 @@ test('ripgrepCommand keeps builtin mode when bundled binary exists', () => {
     command: MOCK_BUILTIN_PATH,
     args: [],
   })
+})
+
+test('ripgrepCommand keeps the embedded executable branch explicit', () => {
+  const config = resolveRipgrepConfig({
+    userWantsSystemRipgrep: false,
+    bundledMode: true,
+    builtinExists: false,
+    systemExecutablePath: 'rg',
+    processExecPath: '/installed/agenc',
+  })
+  expect(config).toEqual({ mode: 'embedded', command: '/installed/agenc', args: ['--no-config'], argv0: 'rg' })
+})
+
+test('ripgrepCommand reports unavailable only after neither candidate is usable', () => {
+  expect(() => resolveRipgrepConfig({
+    userWantsSystemRipgrep: true,
+    bundledMode: false,
+    builtinExists: false,
+    systemExecutablePath: 'rg',
+  })).toThrow('Neither system nor packaged ripgrep is an executable file.')
 })
 
 test('wrapRipgrepUnavailableError explains missing packaged fallback', () => {

--- a/runtime/tests/utils/sandbox-ripgrep.test.ts
+++ b/runtime/tests/utils/sandbox-ripgrep.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import type { AgenCConfig } from '../../src/config/schema.js'
+
+afterEach(() => {
+  vi.doUnmock('../../src/utils/settings/settings.js')
+  vi.doUnmock('../../src/utils/settings/canonicalAuthority.js')
+  vi.doUnmock('../../src/utils/ripgrep.js')
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+async function sandboxFixture(settings: AgenCConfig = { configVersion: 2 }) {
+  let hasAuthority = true
+  vi.doMock('../../src/utils/settings/canonicalAuthority.js', async importOriginal => ({
+    ...await importOriginal<typeof import('../../src/utils/settings/canonicalAuthority.js')>(),
+    getCanonicalSettingsAuthority: () => hasAuthority ? { current: () => settings } : null,
+  }))
+  vi.doMock('../../src/utils/settings/settings.js', async importOriginal => ({
+    ...await importOriginal<typeof import('../../src/utils/settings/settings.js')>(),
+    getExecutionAuthoritySettings: () => settings,
+    getSettingsForSource: () => null,
+    getSettingsFilePathForSource: () => undefined,
+  }))
+  const unavailable = vi.fn()
+  vi.doMock('../../src/utils/ripgrep.js', async importOriginal => {
+    const actual = await importOriginal<typeof import('../../src/utils/ripgrep.js')>()
+    unavailable.mockImplementation(() => {
+      throw new actual.RipgrepUnavailableError('fixture has no ripgrep', { mode: 'builtin', command: '@vscode/ripgrep' }, 'ENOENT')
+    })
+    return { ...actual, ripgrepCommand: unavailable }
+  })
+  const { SandboxManager: base } = await import('@anthropic-ai/sandbox-runtime')
+  const dependencies = vi.spyOn(base, 'checkDependencies').mockReturnValue({ errors: [], warnings: [] })
+  const runtime = await import('../../src/utils/sandbox/sandbox-runtime.js')
+  return {
+    ...runtime,
+    unavailable,
+    dependencies,
+    setSettings: (value: AgenCConfig) => { settings = value },
+    clearAuthority: () => { hasAuthority = false },
+  }
+}
+
+test('honors an explicit sandbox executable before resolving default ripgrep', async () => {
+  const settings: AgenCConfig = { configVersion: 2, sandbox: { ripgrep: { command: '/custom/rg', args: ['--no-config'] } } }
+  const fixture = await sandboxFixture(settings)
+  expect(fixture.convertToSandboxRuntimeConfig(settings).ripgrep).toEqual({ command: '/custom/rg', args: ['--no-config'] })
+  expect(fixture.SandboxManager.checkDependencies()).toEqual({ errors: [], warnings: [] })
+  expect(fixture.dependencies).toHaveBeenCalledWith({ command: '/custom/rg', args: ['--no-config'] })
+  expect(fixture.unavailable).not.toHaveBeenCalled()
+})
+
+test('reports missing ripgrep through dependency errors without throwing during configuration', async () => {
+  const fixture = await sandboxFixture()
+  expect(fixture.convertToSandboxRuntimeConfig({ configVersion: 2 }).ripgrep).toBeUndefined()
+  expect(fixture.SandboxManager.checkDependencies()).toEqual({ errors: ['fixture has no ripgrep'], warnings: [] })
+  expect(fixture.dependencies).not.toHaveBeenCalled()
+})
+
+test('rechecks a changed sandbox override instead of caching an earlier missing binary', async () => {
+  const fixture = await sandboxFixture()
+  expect(fixture.SandboxManager.checkDependencies().errors).toEqual(['fixture has no ripgrep'])
+  fixture.setSettings({ configVersion: 2, sandbox: { ripgrep: { command: '/custom/rg' } } })
+  expect(fixture.SandboxManager.checkDependencies()).toEqual({ errors: [], warnings: [] })
+  expect(fixture.dependencies).toHaveBeenCalledWith({ command: '/custom/rg', args: [] })
+})
+
+test('reports dependency availability before a settings authority has been installed', async () => {
+  const fixture = await sandboxFixture()
+  fixture.clearAuthority()
+  expect(fixture.SandboxManager.checkDependencies()).toEqual({ errors: ['fixture has no ripgrep'], warnings: [] })
+})

--- a/scripts/run-fast-checks.mjs
+++ b/scripts/run-fast-checks.mjs
@@ -279,6 +279,9 @@ export function commandsForPlan(plan, {
     ...plan.mappedRuntimeTests,
     ...deletedRuntime.targets,
   ])].sort();
+  if (runtimeTestTargets.length > 0 || existingRuntimeInputs.length > 0) {
+    commands.unshift({ executable: process.execPath, args: ["runtime/scripts/check-ripgrep.mjs"] });
+  }
   if (runtimeTestTargets.length > 0) {
     commands.push({
       executable: process.execPath,

--- a/scripts/run-fast-checks.test.mjs
+++ b/scripts/run-fast-checks.test.mjs
@@ -72,6 +72,15 @@ test("runtime source and tests select separate Vitest modes", () => {
   assert.equal(related.args.includes("src/session/Session.ts"), true);
 });
 
+test("runtime Vitest plans check ripgrep before typecheck and test discovery", () => {
+  for (const file of ["runtime/src/utils/ripgrep.ts", "runtime/tests/utils/ripgrep.test.ts"]) {
+    const commands = commandsForPlan(classifyChangedFiles([file]), { fileExists: () => true });
+    assert.deepEqual(commands[0], { executable: process.execPath, args: ["runtime/scripts/check-ripgrep.mjs"] });
+    assert.deepEqual(commands[1].args, ["run", "typecheck"]);
+  }
+  assert.deepEqual(commandsForPlan(classifyChangedFiles(["docs/README.md"])), []);
+});
+
 test("deleted runtime source selects its subsystem tests", () => {
   const plan = deletedRuntimeFallbackPlan(
     ["runtime/src/session/removed.ts", "runtime/src/session/also-removed.ts"],


### PR DESCRIPTION
## Summary

- Resolve the installed platform binary through the existing pinned-package resolver instead of constructing a missing vendor path. Keep package-resolution failure safe at import time and preserve embedded executable selection.
- Validate candidate absolute paths, regular files, and execute permission. Use the validated absolute system path, and report RipgrepUnavailableError only when neither candidate is usable. Keep doctor status and probing safe when no binary exists.
- Add a local ripgrep preflight before runtime Vitest plans in test:fast. The preflight uses the production resolver and runs its version probe. Hosted CI triggers and workflow settings are unchanged and remain disabled.
- Cover actual packaged Markdown discovery with an empty PATH, system/package fallback, invalid files, missing candidates, embedded mode, and captured environments. Keep native fallback explicit in its regression test, and check hardlink authority with both discovery modes.

## Validation

- Seven no-PATH and candidate-selection regressions failed against the old resolver before implementation.
- Runtime and test-support typecheck, 89 focused runtime tests, and 30 preflight/fast-plan tests pass locally.
- Runtime build, real PTY startup, and the full local suite must pass before merge; final results will be recorded here.
- GitNexus flagged the shared configuration builder CRITICAL and its selector HIGH; the blast radius includes Markdown discovery, sandbox setup, shell integration, and doctor. This was reported before editing. Staged detection reports only the expected files; new helpers and anonymous test callbacks were manually reviewed because they are not indexed.
- No Actions runs were enabled, dispatched, retried, or rerun. Darwin and Windows native execution was not performed on this Linux host.

Fixes #1990

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared ripgrep resolution used by Markdown discovery, sandbox dependencies, and fast CI gates; behavior shifts when system `rg` is missing or misconfigured, though fallbacks and explicit errors are improved.
> 
> **Overview**
> Fixes **ripgrep selection** so the runtime uses the installed `@vscode/ripgrep` platform binary (via `resolvePinnedRipgrepPath`) instead of a non-existent vendor tree, with **executable checks** (absolute path, regular file, `X_OK`) before choosing system vs packaged. When neither candidate works, resolution surfaces **`RipgrepUnavailableError`**; `getRipgrepStatus` and `probeRipgrepAvailable` stay non-throwing for doctor and preflight.
> 
> **`test:fast`** now runs **`runtime/scripts/check-ripgrep.mjs`** ahead of runtime Vitest/typecheck when the plan includes runtime work, failing fast with a clear reinstall/`rg` message. Docs describe that preflight.
> 
> **Sandbox** wiring respects explicit `sandbox.ripgrep.command`, omits ripgrep from runtime config when default resolution fails, reports missing `rg` through dependency errors, and **re-checks** when the sandbox ripgrep override changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf6a409ee1f35ff2fadda1632d66656766b09487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->