### PR TITLE
fix(gateway): serialize pairing state transactions across processes

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -413,9 +413,20 @@ agenc gateway pairing revoke telegram 123456789
 | `config.toml` `[gateway]` | 0600 | policies, bindings, hooks flag |
 | Native secure storage | OS-managed | bot tokens and gateway bearer tokens |
 | `gateway/pairing.json` | 0600 | paired senders |
+| `gateway/pairing.json.lock.sqlite` | 0600 | cross-process pairing transaction lock |
 | `gateway/sessions.json` | 0600 | channel → daemon session map |
 | `gateway/control.json` | 0600 | Telegram owner/public state |
 | `gateway/conversation-recovery.json` | 0600 | bounded recovery journal |
+
+Pairing mutations hold a cross-process lock from reload through persistence.
+Writes use a unique temporary file, file sync, atomic rename, and directory sync
+where supported. Gateway and CLI processes therefore share one ordered sequence
+of approvals, revocations, and single-use challenges.
+
+Runtime callers must await `PairingStore.approve`, `revoke`, `challenge`, `redeem`,
+`listPending`, and `evaluateDmAccess`. Read-only `isPaired` and `listPaired`
+queries remain synchronous. The pairing JSON format stays at version 1.
+Restart existing gateway processes after upgrading so every writer uses the lock.
 
 Session mappings reattach conversations after gateway restart; the daemon
 session remains the source of truth for history. The recovery journal

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -329,7 +329,7 @@ export async function runAgenCGatewayCli(
       return 0;
     }
     case "pairing-pending": {
-      const pending = store.listPending();
+      const pending = await store.listPending();
       if (command.json) {
         stdout(JSON.stringify(pending, null, 2));
         return 0;
@@ -346,12 +346,12 @@ export async function runAgenCGatewayCli(
       return 0;
     }
     case "pairing-approve": {
-      store.approve(command.channelId, command.peerId);
+      await store.approve(command.channelId, command.peerId);
       stdout(`Approved ${command.peerId} on ${command.channelId}.`);
       return 0;
     }
     case "pairing-revoke": {
-      const removed = store.revoke(command.channelId, command.peerId);
+      const removed = await store.revoke(command.channelId, command.peerId);
       if (removed) {
         stdout(`Revoked ${command.peerId} on ${command.channelId}.`);
         return 0;

--- a/runtime/src/gateway/gateway.ts
+++ b/runtime/src/gateway/gateway.ts
@@ -156,7 +156,7 @@ export class ChannelGateway {
     //    unpaired sender in a group cannot drive the agent either).
     if (!bypassAccess) {
       const policy = this.#config.channels[message.channelId];
-      const access = evaluateDmAccess({
+      const access = await evaluateDmAccess({
         ...(policy !== undefined ? { policy } : {}),
         channelId: message.channelId,
         sender: message.sender,
@@ -172,7 +172,7 @@ export class ChannelGateway {
         // Host-gated pairing (todo-103): never DM the secret code. Operator
         // reads it via gateway logs or `agenc gateway pairing pending`, then
         // either tells the user out-of-band or runs `pairing approve`.
-        if (this.#pairing.redeem(message.channelId, message.sender, message.text)) {
+        if (await this.#pairing.redeem(message.channelId, message.sender, message.text)) {
           await reply(
             "Paired. This conversation now reaches your AgenC agent — send a message to begin.",
           );

--- a/runtime/src/gateway/pairing.ts
+++ b/runtime/src/gateway/pairing.ts
@@ -7,14 +7,15 @@
  * enough. State persists to `<agencHome>/gateway/pairing.json` (0600).
  */
 
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
   readFileSync,
-  writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { writeDurableAtomicFileSync } from "../utils/durable-atomic-file.js";
+import { acquireLocalSqliteLock, assertLocalPrivateFile } from "../utils/sqlite-lock.js";
 
 import {
   DEFAULT_CHANNEL_POLICY,
@@ -125,11 +126,34 @@ export class PairingStore {
   }
 
   #save(): void {
-    mkdirSync(dirname(this.#path), { recursive: true, mode: 0o700 });
     // pairing.json holds paired peers + host-only pending codes (0600).
-    writeFileSync(this.#path, `${JSON.stringify(this.#state, null, 2)}\n`, {
-      mode: 0o600,
+    writeDurableAtomicFileSync(
+      this.#path,
+      `${this.#path}.${process.pid}.${randomUUID()}.tmp`,
+      `${JSON.stringify(this.#state, null, 2)}\n`,
+      0o600,
+    );
+  }
+
+  async #mutate<Value>(change: () => { value: Value; changed: boolean }): Promise<Value> {
+    mkdirSync(dirname(this.#path), { recursive: true, mode: 0o700 });
+    const release = await acquireLocalSqliteLock(`${this.#path}.lock.sqlite`, {
+      timeoutMs: 5_000,
+      label: "pairing store transaction",
     });
+    try {
+      try {
+        await assertLocalPrivateFile(this.#path, { label: "pairing state" });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      this.#reloadFromDisk();
+      const result = change();
+      if (result.changed) this.#save();
+      return result.value;
+    } finally {
+      release();
+    }
   }
 
   /**
@@ -153,7 +177,7 @@ export class PairingStore {
     return this.#state.pending;
   }
 
-  #pruneExpiredPending(): void {
+  #pruneExpiredPending(): boolean {
     const now = this.#now();
     const pending = this.#pendingMap();
     let dirty = false;
@@ -163,7 +187,7 @@ export class PairingStore {
         dirty = true;
       }
     }
-    if (dirty) this.#save();
+    return dirty;
   }
 
   isPaired(channelId: string, peerId: string): boolean {
@@ -176,78 +200,80 @@ export class PairingStore {
     return this.#state.paired[channelId] ?? [];
   }
 
-  revoke(channelId: string, peerId: string): boolean {
-    this.#reloadFromDisk();
-    const peers = this.#state.paired[channelId] ?? [];
-    if (!peers.includes(peerId)) return false;
-    this.#state.paired[channelId] = peers.filter((p) => p !== peerId);
-    this.#save();
-    return true;
+  async revoke(channelId: string, peerId: string): Promise<boolean> {
+    return this.#mutate(() => {
+      const peers = this.#state.paired[channelId] ?? [];
+      if (!peers.includes(peerId)) return { value: false, changed: false };
+      this.#state.paired[channelId] = peers.filter((peer) => peer !== peerId);
+      return { value: true, changed: true };
+    });
   }
 
   /**
    * Host-only view of pending challenges (codes never DM'd — todo-103).
    * Durable so a separate CLI process can list/approve.
    */
-  listPending(): readonly {
+  async listPending(): Promise<readonly {
     readonly channelId: string;
     readonly peerId: string;
     readonly code: string;
     readonly expiresAt: number;
-  }[] {
-    this.#reloadFromDisk();
-    this.#pruneExpiredPending();
-    const out: {
-      channelId: string;
-      peerId: string;
-      code: string;
-      expiresAt: number;
-    }[] = [];
-    for (const [key, pending] of Object.entries(this.#pendingMap())) {
-      const sep = key.indexOf("\u0000");
-      if (sep < 0) continue;
-      out.push({
-        channelId: key.slice(0, sep),
-        peerId: key.slice(sep + 1),
-        code: pending.code,
-        expiresAt: pending.expiresAt,
-      });
-    }
-    return out;
+  }[]> {
+    return this.#mutate(() => {
+      const changed = this.#pruneExpiredPending();
+      const out: {
+        channelId: string;
+        peerId: string;
+        code: string;
+        expiresAt: number;
+      }[] = [];
+      for (const [key, pending] of Object.entries(this.#pendingMap())) {
+        const separator = key.indexOf("\u0000");
+        if (separator < 0) continue;
+        out.push({
+          channelId: key.slice(0, separator),
+          peerId: key.slice(separator + 1),
+          code: pending.code,
+          expiresAt: pending.expiresAt,
+        });
+      }
+      return { value: out, changed };
+    });
   }
 
   /**
    * Host-side approve: pair without the remote party seeing a code (todo-103).
    * Clears any pending challenge for the peer.
    */
-  approve(channelId: string, peerId: string): void {
-    this.#reloadFromDisk();
-    const pending = this.#pendingMap();
-    delete pending[this.#key(channelId, peerId)];
-    const peers = this.#state.paired[channelId] ?? [];
-    if (!peers.includes(peerId)) {
-      this.#state.paired[channelId] = [...peers, peerId];
-    }
-    this.#save();
+  async approve(channelId: string, peerId: string): Promise<void> {
+    return this.#mutate(() => {
+      const pending = this.#pendingMap();
+      delete pending[this.#key(channelId, peerId)];
+      const peers = this.#state.paired[channelId] ?? [];
+      if (!peers.includes(peerId)) {
+        this.#state.paired[channelId] = [...peers, peerId];
+      }
+      return { value: undefined, changed: true };
+    });
   }
 
   /**
    * Begin (or refresh) a pairing challenge for a sender. Reuses the live
    * code when one is pending so repeated messages don't rotate it.
    */
-  challenge(channelId: string, sender: ChannelSender): string {
-    this.#reloadFromDisk();
-    this.#pruneExpiredPending();
-    const key = this.#key(channelId, sender.peerId);
-    const pending = this.#pendingMap();
-    const existing = pending[key];
-    if (existing !== undefined && existing.expiresAt > this.#now()) {
-      return existing.code;
-    }
-    const code = this.#generateCode();
-    pending[key] = { code, expiresAt: this.#now() + this.#ttlMs };
-    this.#save();
-    return code;
+  async challenge(channelId: string, sender: ChannelSender): Promise<string> {
+    return this.#mutate(() => {
+      const changed = this.#pruneExpiredPending();
+      const key = this.#key(channelId, sender.peerId);
+      const pending = this.#pendingMap();
+      const existing = pending[key];
+      if (existing !== undefined && existing.expiresAt > this.#now()) {
+        return { value: existing.code, changed };
+      }
+      const code = this.#generateCode();
+      pending[key] = { code, expiresAt: this.#now() + this.#ttlMs };
+      return { value: code, changed: true };
+    });
   }
 
   /**
@@ -257,26 +283,25 @@ export class PairingStore {
    * Codes are disclosed only on the gateway host (`listPending` / logs), not
    * in the channel DM (todo-103).
    */
-  redeem(channelId: string, sender: ChannelSender, input: string): boolean {
-    this.#reloadFromDisk();
-    this.#pruneExpiredPending();
-    const key = this.#key(channelId, sender.peerId);
-    const pending = this.#pendingMap();
-    const entry = pending[key];
-    if (entry === undefined) return false;
-    if (entry.expiresAt <= this.#now()) {
+  async redeem(channelId: string, sender: ChannelSender, input: string): Promise<boolean> {
+    return this.#mutate(() => {
+      const changed = this.#pruneExpiredPending();
+      const key = this.#key(channelId, sender.peerId);
+      const pending = this.#pendingMap();
+      const entry = pending[key];
+      if (entry === undefined) return { value: false, changed };
+      if (entry.expiresAt <= this.#now()) {
+        delete pending[key];
+        return { value: false, changed: true };
+      }
+      if (input.trim().toUpperCase() !== entry.code) return { value: false, changed };
       delete pending[key];
-      this.#save();
-      return false;
-    }
-    if (input.trim().toUpperCase() !== entry.code) return false;
-    delete pending[key];
-    const peers = this.#state.paired[channelId] ?? [];
-    if (!peers.includes(sender.peerId)) {
-      this.#state.paired[channelId] = [...peers, sender.peerId];
-    }
-    this.#save();
-    return true;
+      const peers = this.#state.paired[channelId] ?? [];
+      if (!peers.includes(sender.peerId)) {
+        this.#state.paired[channelId] = [...peers, sender.peerId];
+      }
+      return { value: true, changed: true };
+    });
   }
 }
 
@@ -284,12 +309,12 @@ export class PairingStore {
  * Decide whether a DM sender may reach an agent right now. Pure policy
  * evaluation; the caller renders challenges/denials back to the channel.
  */
-export function evaluateDmAccess(options: {
+export async function evaluateDmAccess(options: {
   readonly policy?: GatewayChannelPolicy;
   readonly channelId: string;
   readonly sender: ChannelSender;
   readonly store: PairingStore;
-}): DmAccessDecision {
+}): Promise<DmAccessDecision> {
   const policy = options.policy ?? DEFAULT_CHANNEL_POLICY;
   switch (policy.dmPolicy) {
     case "disabled":
@@ -317,7 +342,7 @@ export function evaluateDmAccess(options: {
       }
       return {
         kind: "pairing_challenge",
-        code: options.store.challenge(options.channelId, options.sender),
+        code: await options.store.challenge(options.channelId, options.sender),
       };
     }
   }

--- a/runtime/tests/bin/gateway-cli.test.ts
+++ b/runtime/tests/bin/gateway-cli.test.ts
@@ -120,8 +120,8 @@ describe("gateway CLI against a temp home", () => {
       agencHome: home,
       generateCode: () => "C",
     });
-    store.challenge("tg", { peerId: "alice" });
-    store.redeem("tg", { peerId: "alice" }, "C");
+    await store.challenge("tg", { peerId: "alice" });
+    await store.redeem("tg", { peerId: "alice" }, "C");
 
     const out: string[] = [];
     const code = await runAgenCGatewayCli(
@@ -144,8 +144,8 @@ describe("gateway CLI against a temp home", () => {
       agencHome: home,
       generateCode: () => "C",
     });
-    store.challenge("tg", { peerId: "alice" });
-    store.redeem("tg", { peerId: "alice" }, "C");
+    await store.challenge("tg", { peerId: "alice" });
+    await store.redeem("tg", { peerId: "alice" }, "C");
 
     const listOut: string[] = [];
     await runAgenCGatewayCli(

--- a/runtime/tests/gateway/fixtures/pairing-worker.mjs
+++ b/runtime/tests/gateway/fixtures/pairing-worker.mjs
@@ -1,17 +1,31 @@
 import filesystem from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
-import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
-const { PairingStore } = await import(pathToFileURL(process.argv[2]).href);
-const options = JSON.parse(process.argv[3]);
-const store = new PairingStore({ agencHome: options.home, generateCode: () => options.code });
-const pairingPath = join(options.home, "gateway", "pairing.json");
+const home = filesystem.realpathSync(process.cwd());
+const homeInfo = filesystem.lstatSync(home);
+if (dirname(home) !== filesystem.realpathSync(tmpdir()) || !basename(home).startsWith("agenc-pairing-transaction-") || !homeInfo.isDirectory()) {
+  throw new Error("pairing worker requires its private fixture directory");
+}
+if (process.platform !== "win32" && ((homeInfo.mode & 0o077) !== 0 || homeInfo.uid !== process.getuid())) {
+  throw new Error("pairing worker directory is not private and owned");
+}
+const runtimePath = join(home, "pairing-runtime.mjs");
+const runtimeInfo = filesystem.lstatSync(runtimePath);
+if (!runtimeInfo.isFile() || runtimeInfo.nlink !== 1) throw new Error("pairing worker requires a regular fixture runtime");
+const { PairingStore } = await import(pathToFileURL(runtimePath).href);
+const options = JSON.parse(process.argv[2]);
+const delayMs = options.delayMs ?? 120;
+if (!Number.isFinite(delayMs) || delayMs < 0 || delayMs > 500) throw new Error("invalid pairing worker delay");
+const store = new PairingStore({ agencHome: home, generateCode: () => options.code });
+const pairingPath = join(home, "gateway", "pairing.json");
 const readFile = filesystem.readFileSync;
 const sleeper = new Int32Array(new SharedArrayBuffer(4));
 filesystem.readFileSync = (path, ...args) => {
   const content = readFile(path, ...args);
-  if (String(path) === pairingPath) Atomics.wait(sleeper, 0, 0, options.delayMs ?? 120);
+  if (String(path) === pairingPath) Atomics.wait(sleeper, 0, 0, delayMs);
   return content;
 };
 syncBuiltinESMExports();

--- a/runtime/tests/gateway/fixtures/pairing-worker.mjs
+++ b/runtime/tests/gateway/fixtures/pairing-worker.mjs
@@ -23,9 +23,10 @@ const store = new PairingStore({ agencHome: home, generateCode: () => options.co
 const pairingPath = join(home, "gateway", "pairing.json");
 const readFile = filesystem.readFileSync;
 const sleeper = new Int32Array(new SharedArrayBuffer(4));
-filesystem.readFileSync = (path, ...args) => {
-  const content = readFile(path, ...args);
-  if (String(path) === pairingPath) Atomics.wait(sleeper, 0, 0, delayMs);
+filesystem.readFileSync = (path) => {
+  if (path !== pairingPath) throw new Error("pairing fixture read outside its state file");
+  const content = readFile(pairingPath, "utf8");
+  Atomics.wait(sleeper, 0, 0, delayMs);
   return content;
 };
 syncBuiltinESMExports();
@@ -38,6 +39,7 @@ process.once("message", async () => {
       case "revoke": result = await store.revoke("tg", options.peer); break;
       case "challenge": result = await store.challenge("tg", { peerId: options.peer }); break;
       case "redeem": result = await store.redeem("tg", { peerId: options.peer }, options.code); break;
+      case "unexpected-read": result = filesystem.readFileSync(runtimePath, "utf8"); break;
       default: throw new Error("unknown pairing worker operation");
     }
     process.send({ result: result ?? null });

--- a/runtime/tests/gateway/fixtures/pairing-worker.mjs
+++ b/runtime/tests/gateway/fixtures/pairing-worker.mjs
@@ -1,0 +1,37 @@
+import filesystem from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const { PairingStore } = await import(pathToFileURL(process.argv[2]).href);
+const options = JSON.parse(process.argv[3]);
+const store = new PairingStore({ agencHome: options.home, generateCode: () => options.code });
+const pairingPath = join(options.home, "gateway", "pairing.json");
+const readFile = filesystem.readFileSync;
+const sleeper = new Int32Array(new SharedArrayBuffer(4));
+filesystem.readFileSync = (path, ...args) => {
+  const content = readFile(path, ...args);
+  if (String(path) === pairingPath) Atomics.wait(sleeper, 0, 0, options.delayMs ?? 120);
+  return content;
+};
+syncBuiltinESMExports();
+
+process.once("message", async () => {
+  try {
+    let result;
+    switch (options.operation) {
+      case "approve": result = await store.approve("tg", options.peer); break;
+      case "revoke": result = await store.revoke("tg", options.peer); break;
+      case "challenge": result = await store.challenge("tg", { peerId: options.peer }); break;
+      case "redeem": result = await store.redeem("tg", { peerId: options.peer }, options.code); break;
+      default: throw new Error("unknown pairing worker operation");
+    }
+    process.send({ result: result ?? null });
+  } catch (error) {
+    process.send({ error: error instanceof Error ? error.stack : String(error) });
+    process.exitCode = 1;
+  } finally {
+    process.disconnect();
+  }
+});
+process.send({ ready: true });

--- a/runtime/tests/gateway/pairing-durability.test.ts
+++ b/runtime/tests/gateway/pairing-durability.test.ts
@@ -1,0 +1,67 @@
+import { closeSync, fsyncSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { PairingStore } from "../../src/gateway/pairing.js";
+
+const failure = vi.hoisted(() => ({ enabled: false, destination: "" }));
+vi.mock("../../src/utils/durable-atomic-file.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../src/utils/durable-atomic-file.js")>();
+  return {
+    ...actual,
+    writeDurableAtomicFileSync: (path: string, temporary: string, data: string, mode = 0o600) => {
+      if (!failure.enabled) return actual.writeDurableAtomicFileSync(path, temporary, data, mode);
+      return actual.writeDurableAtomicFileSync(path, temporary, data, mode, {
+        mkdir: directory => { mkdirSync(directory, { recursive: true, mode: 0o700 }); },
+        openTemporary: (temporaryPath, fileMode) => openSync(temporaryPath, "wx", fileMode),
+        write: (handle, content) => writeFileSync(handle as number, content),
+        sync: handle => fsyncSync(handle as number),
+        close: handle => closeSync(handle as number),
+        rename: () => { throw new Error("injected pairing rename failure"); },
+        syncDirectory: () => { throw new Error("failed publication reached directory sync"); },
+        remove: temporaryPath => rmSync(temporaryPath, { force: true }),
+      });
+    },
+  };
+});
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agenc-pairing-durability-"));
+  failure.destination = join(home, "gateway", "pairing.json");
+});
+afterEach(() => {
+  failure.enabled = false;
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("a failure before rename preserves the previous private state and releases the lock", async () => {
+  const store = new PairingStore({ agencHome: home });
+  await store.approve("tg", "retained");
+  const previous = readFileSync(failure.destination, "utf8");
+  failure.enabled = true;
+  await expect(store.approve("tg", "uncommitted")).rejects.toThrow("injected pairing rename failure");
+  expect(readFileSync(failure.destination, "utf8")).toBe(previous);
+  expect(statSync(failure.destination).mode & 0o777).toBe(0o600);
+  expect(readdirSync(join(home, "gateway")).filter(name => name.endsWith(".tmp"))).toEqual([]);
+  expect(store.isPaired("tg", "retained")).toBe(true);
+  expect(store.isPaired("tg", "uncommitted")).toBe(false);
+  failure.enabled = false;
+  await new PairingStore({ agencHome: home }).approve("tg", "later");
+  expect(store.listPaired("tg").toSorted()).toEqual(["later", "retained"]);
+});
+
+test("expiry pruning and an independent approval preserve each other's state", async () => {
+  let now = 1000;
+  const store = new PairingStore({ agencHome: home, now: () => now, codeTtlMs: 10, generateCode: () => "EXPIRED" });
+  await store.challenge("tg", { peerId: "expired" });
+  now = 2000;
+  const [pending] = await Promise.all([
+    store.listPending(),
+    new PairingStore({ agencHome: home }).approve("tg", "approved"),
+  ]);
+  expect(pending).toEqual([]);
+  const state = JSON.parse(readFileSync(failure.destination, "utf8"));
+  expect(state.pending).toEqual({});
+  expect(state.paired.tg).toEqual(["approved"]);
+});

--- a/runtime/tests/gateway/pairing-store-reload.test.ts
+++ b/runtime/tests/gateway/pairing-store-reload.test.ts
@@ -11,10 +11,10 @@ describe("PairingStore disk reload (GW-02)", () => {
     if (home) rmSync(home, { recursive: true, force: true });
   });
 
-  it("CLI approve is visible to a separate live store without restart", () => {
+  it("CLI approve is visible to a separate live store without restart", async () => {
     home = mkdtempSync(join(tmpdir(), "agenc-pair-"));
     const live = new PairingStore({ agencHome: home });
-    const code = live.challenge("telegram", {
+    const code = await live.challenge("telegram", {
       peerId: "42",
       displayName: "u",
     });
@@ -22,13 +22,13 @@ describe("PairingStore disk reload (GW-02)", () => {
 
     // Host CLI uses a second process/store instance.
     const cli = new PairingStore({ agencHome: home });
-    cli.approve("telegram", "42");
+    await cli.approve("telegram", "42");
 
     // Live gateway must see the pair without reconstructing.
     expect(live.isPaired("telegram", "42")).toBe(true);
 
     // Further live challenge must not wipe the CLI pairing on save.
-    live.challenge("discord", {
+    await live.challenge("discord", {
       peerId: "99",
       displayName: "other",
     });

--- a/runtime/tests/gateway/pairing-transactions.test.ts
+++ b/runtime/tests/gateway/pairing-transactions.test.ts
@@ -7,7 +7,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import { PairingStore } from "../../src/gateway/pairing.js";
 
 interface WorkerOperation {
-  operation: "approve" | "revoke" | "challenge" | "redeem";
+  operation: "approve" | "revoke" | "challenge" | "redeem" | "unexpected-read";
   peer: string;
   code?: string;
   delayMs?: number;
@@ -90,6 +90,10 @@ async function runWorkers(operations: readonly WorkerOperation[]): Promise<unkno
 }
 
 describe("PairingStore transactions", () => {
+  test("the instrumented worker refuses reads outside its pairing state file", async () => {
+    await expect(runWorkers([{ operation: "unexpected-read", peer: "unused" }])).rejects.toThrow("pairing fixture read outside its state file");
+  });
+
   test("the worker rejects execution outside its private fixture directory", () => {
     const result = spawnSync(process.execPath, [join(import.meta.dirname, "fixtures/pairing-worker.mjs"), JSON.stringify({ operation: "approve", peer: "outside", home })], {
       cwd: bundleRoot,

--- a/runtime/tests/gateway/pairing-transactions.test.ts
+++ b/runtime/tests/gateway/pairing-transactions.test.ts
@@ -1,5 +1,5 @@
-import { fork, type ChildProcess } from "node:child_process";
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { fork, spawnSync, type ChildProcess } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { build } from "esbuild";
@@ -34,6 +34,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   home = mkdtempSync(join(tmpdir(), "agenc-pairing-transaction-"));
+  copyFileSync(bundlePath, join(home, "pairing-runtime.mjs"));
   await new PairingStore({ agencHome: home }).approve("tg", "seed");
 });
 
@@ -51,7 +52,8 @@ afterAll(() => rmSync(bundleRoot, { recursive: true, force: true }));
 
 async function runWorkers(operations: readonly WorkerOperation[]): Promise<unknown[]> {
   const workers = operations.map(operation => {
-    const child = fork(join(import.meta.dirname, "fixtures/pairing-worker.mjs"), [bundlePath, JSON.stringify({ ...operation, home })], {
+    const child = fork(join(import.meta.dirname, "fixtures/pairing-worker.mjs"), [JSON.stringify(operation)], {
+      cwd: home,
       stdio: ["ignore", "ignore", "pipe", "ipc"],
     });
     children.add(child);
@@ -88,6 +90,17 @@ async function runWorkers(operations: readonly WorkerOperation[]): Promise<unkno
 }
 
 describe("PairingStore transactions", () => {
+  test("the worker rejects execution outside its private fixture directory", () => {
+    const result = spawnSync(process.execPath, [join(import.meta.dirname, "fixtures/pairing-worker.mjs"), JSON.stringify({ operation: "approve", peer: "outside", home })], {
+      cwd: bundleRoot,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("pairing worker requires its private fixture directory");
+    expect(new PairingStore({ agencHome: home }).isPaired("tg", "outside")).toBe(false);
+  });
+
   test("retains approvals from separate store instances", async () => {
     const peers = Array.from({ length: 20 }, (_, index) => `peer-${index}`);
     await Promise.all(peers.map(peer => new PairingStore({ agencHome: home }).approve("tg", peer)));

--- a/runtime/tests/gateway/pairing-transactions.test.ts
+++ b/runtime/tests/gateway/pairing-transactions.test.ts
@@ -1,0 +1,125 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { build } from "esbuild";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { PairingStore } from "../../src/gateway/pairing.js";
+
+interface WorkerOperation {
+  operation: "approve" | "revoke" | "challenge" | "redeem";
+  peer: string;
+  code?: string;
+  delayMs?: number;
+}
+
+const children = new Set<ChildProcess>();
+let bundleRoot: string;
+let bundlePath: string;
+let home: string;
+
+beforeAll(async () => {
+  bundleRoot = mkdtempSync(join(tmpdir(), "agenc-pairing-worker-"));
+  bundlePath = join(bundleRoot, "pairing.mjs");
+  await build({
+    entryPoints: [join(import.meta.dirname, "../../src/gateway/pairing.ts")],
+    outfile: bundlePath,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node26",
+    logLevel: "silent",
+  });
+});
+
+beforeEach(async () => {
+  home = mkdtempSync(join(tmpdir(), "agenc-pairing-transaction-"));
+  await new PairingStore({ agencHome: home }).approve("tg", "seed");
+});
+
+afterEach(async () => {
+  await Promise.all([...children].map(child => new Promise<void>(resolve => {
+    if (child.exitCode !== null || child.signalCode !== null) return resolve();
+    child.once("exit", () => resolve());
+    child.kill("SIGKILL");
+  })));
+  children.clear();
+  rmSync(home, { recursive: true, force: true });
+});
+
+afterAll(() => rmSync(bundleRoot, { recursive: true, force: true }));
+
+async function runWorkers(operations: readonly WorkerOperation[]): Promise<unknown[]> {
+  const workers = operations.map(operation => {
+    const child = fork(join(import.meta.dirname, "fixtures/pairing-worker.mjs"), [bundlePath, JSON.stringify({ ...operation, home })], {
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    });
+    children.add(child);
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => { stderr = (stderr + chunk.toString()).slice(-4000); });
+    let markReady!: () => void;
+    let failReady!: (error: Error) => void;
+    const ready = new Promise<void>((resolve, reject) => { markReady = resolve; failReady = reject; });
+    const result = new Promise<unknown>((resolve, reject) => {
+      let reported = false;
+      let value: unknown;
+      child.on("message", (message: { ready?: boolean; error?: string; result?: unknown }) => {
+        if (message.ready) { markReady(); return; }
+        reported = true;
+        value = message.result;
+        if (message.error) reject(new Error(message.error));
+      });
+      child.once("error", error => { failReady(error); reject(error); });
+      child.once("exit", code => {
+        children.delete(child);
+        if (code === 0 && reported) { resolve(value); return; }
+        const error = new Error(`pairing worker exited ${code}: ${stderr}`);
+        failReady(error);
+        reject(error);
+      });
+    });
+    return { child, ready, result };
+  });
+  const results = Promise.all(workers.map(worker => worker.result));
+  void results.catch(() => {});
+  await Promise.all(workers.map(worker => worker.ready));
+  for (const worker of workers) worker.child.send("start");
+  return results;
+}
+
+describe("PairingStore transactions", () => {
+  test("retains approvals from separate store instances", async () => {
+    const peers = Array.from({ length: 20 }, (_, index) => `peer-${index}`);
+    await Promise.all(peers.map(peer => new PairingStore({ agencHome: home }).approve("tg", peer)));
+    expect(new PairingStore({ agencHome: home }).listPaired("tg").toSorted()).toEqual([...peers, "seed"].toSorted());
+  });
+
+  test("retains every synchronized child-process approval", async () => {
+    const peers = Array.from({ length: 8 }, (_, index) => `peer-${index}`);
+    await runWorkers(peers.map(peer => ({ operation: "approve", peer })));
+    expect(new PairingStore({ agencHome: home }).listPaired("tg").toSorted()).toEqual([...peers, "seed"].toSorted());
+    expect(statSync(join(home, "gateway/pairing.json")).mode & 0o777).toBe(0o600);
+  }, 30_000);
+
+  test("does not resurrect a revoked sender beside an unrelated process approval", async () => {
+    await new PairingStore({ agencHome: home }).approve("tg", "revoked");
+    await runWorkers([
+      { operation: "revoke", peer: "revoked", delayMs: 100 },
+      { operation: "approve", peer: "unrelated", delayMs: 300 },
+    ]);
+    expect(new PairingStore({ agencHome: home }).listPaired("tg").toSorted()).toEqual(["seed", "unrelated"]);
+  }, 30_000);
+
+  test("shares one pending challenge across contending processes", async () => {
+    const codes = await runWorkers(Array.from({ length: 8 }, (_, index) => ({ operation: "challenge", peer: "alice", code: `CODE${index}` })));
+    expect(new Set(codes).size).toBe(1);
+    expect(await new PairingStore({ agencHome: home }).listPending()).toEqual([expect.objectContaining({ peerId: "alice", code: codes[0] })]);
+  }, 30_000);
+
+  test("redeems a pending code only once across processes", async () => {
+    await new PairingStore({ agencHome: home, generateCode: () => "ONCE" }).challenge("tg", { peerId: "alice" });
+    const results = await runWorkers(Array.from({ length: 8 }, () => ({ operation: "redeem", peer: "alice", code: "ONCE" })));
+    expect(results.filter(result => result === true)).toHaveLength(1);
+    expect(new PairingStore({ agencHome: home }).isPaired("tg", "alice")).toBe(true);
+  }, 30_000);
+});

--- a/runtime/tests/gateway/units.test.ts
+++ b/runtime/tests/gateway/units.test.ts
@@ -25,7 +25,7 @@ describe("PairingStore", () => {
   });
   afterEach(() => rmSync(home, { recursive: true, force: true }));
 
-  test("challenge → redeem persists (0600), survives reconstruction", () => {
+  test("challenge → redeem persists (0600), survives reconstruction", async () => {
     let t = 1000;
     const store = new PairingStore({
       agencHome: home,
@@ -33,8 +33,8 @@ describe("PairingStore", () => {
       generateCode: () => "ABC123",
     });
     const sender = { peerId: "alice" };
-    expect(store.challenge("tg", sender)).toBe("ABC123");
-    expect(store.redeem("tg", sender, "abc123")).toBe(true); // case-insensitive
+    expect(await store.challenge("tg", sender)).toBe("ABC123");
+    expect(await store.redeem("tg", sender, "abc123")).toBe(true);
     expect(store.isPaired("tg", "alice")).toBe(true);
 
     const perms = statSync(join(home, "gateway", "pairing.json")).mode & 0o777;
@@ -46,7 +46,7 @@ describe("PairingStore", () => {
     expect(store2.listPaired("tg")).toEqual(["alice"]);
   });
 
-  test("expired code cannot be redeemed", () => {
+  test("expired code cannot be redeemed", async () => {
     let t = 0;
     const store = new PairingStore({
       agencHome: home,
@@ -54,23 +54,23 @@ describe("PairingStore", () => {
       generateCode: () => "ABC123",
       codeTtlMs: 100,
     });
-    store.challenge("tg", { peerId: "alice" });
+    await store.challenge("tg", { peerId: "alice" });
     t = 200;
-    expect(store.redeem("tg", { peerId: "alice" }, "ABC123")).toBe(false);
+    expect(await store.redeem("tg", { peerId: "alice" }, "ABC123")).toBe(false);
     expect(store.isPaired("tg", "alice")).toBe(false);
   });
 
-  test("pending pairing codes are durable for host CLI (todo-103)", () => {
+  test("pending pairing codes are durable for host CLI (todo-103)", async () => {
     const store = new PairingStore({
       agencHome: home,
       generateCode: () => "SECRET7",
     });
-    store.challenge("tg", { peerId: "alice" });
+    await store.challenge("tg", { peerId: "alice" });
     // Host-only durable pending so `agenc gateway pairing pending` works
     // across processes; codes must never be DM'd (gateway message path).
     const raw = readFileSync(join(home, "gateway", "pairing.json"), "utf8");
     expect(raw).toContain("SECRET7");
-    const pending = store.listPending();
+    const pending = await store.listPending();
     expect(pending).toEqual([
       expect.objectContaining({
         channelId: "tg",
@@ -78,23 +78,23 @@ describe("PairingStore", () => {
         code: "SECRET7",
       }),
     ]);
-    store.approve("tg", "alice");
+    await store.approve("tg", "alice");
     expect(store.isPaired("tg", "alice")).toBe(true);
-    expect(store.listPending()).toHaveLength(0);
+    expect(await store.listPending()).toHaveLength(0);
   });
 
-  test("revoke removes a pairing", () => {
+  test("revoke removes a pairing", async () => {
     const store = new PairingStore({ agencHome: home, generateCode: () => "C" });
-    store.challenge("tg", { peerId: "alice" });
-    store.redeem("tg", { peerId: "alice" }, "C");
-    expect(store.revoke("tg", "alice")).toBe(true);
+    await store.challenge("tg", { peerId: "alice" });
+    await store.redeem("tg", { peerId: "alice" }, "C");
+    expect(await store.revoke("tg", "alice")).toBe(true);
     expect(store.isPaired("tg", "alice")).toBe(false);
   });
 
-  test("corrupt pairing file fails closed (nobody paired)", () => {
+  test("corrupt pairing file fails closed (nobody paired)", async () => {
     const store = new PairingStore({ agencHome: home, generateCode: () => "C" });
-    store.challenge("tg", { peerId: "alice" });
-    store.redeem("tg", { peerId: "alice" }, "C");
+    await store.challenge("tg", { peerId: "alice" });
+    await store.redeem("tg", { peerId: "alice" }, "C");
     // Corrupt it.
     rmSync(join(home, "gateway", "pairing.json"));
     require("node:fs").writeFileSync(
@@ -107,14 +107,14 @@ describe("PairingStore", () => {
 });
 
 describe("evaluateDmAccess default", () => {
-  test("no policy → pairing challenge (fail closed)", () => {
+  test("no policy → pairing challenge (fail closed)", async () => {
     const home = mkdtempSync(join(tmpdir(), "agenc-dm-"));
     try {
       const store = new PairingStore({
         agencHome: home,
         generateCode: () => "XYZ",
       });
-      const decision = evaluateDmAccess({
+      const decision = await evaluateDmAccess({
         channelId: "tg",
         sender: { peerId: "alice" },
         store,


### PR DESCRIPTION
## Summary

- Serialize pairing reload, validation, mutation, and persistence with the existing cross-process SQLite lock implementation. Pruning writes use the same transaction.
- Publish pairing JSON through the existing durable atomic-file helper with a unique same-directory temporary file, file sync, atomic rename, directory sync where supported, and mode 0600.
- Make mutations and DM policy evaluation asynchronous; await them in gateway and CLI callers. Keep read-only queries synchronous and JSON v1 unchanged. Document that existing gateways must restart after upgrade so all writers participate in locking.
- Add synchronized child-process approval, revoke, challenge, and redemption regressions, independent-store contention, expiry pruning, and a pre-rename failure probe that verifies retained state, temporary cleanup, and lock release.

## Validation

- Four child-process regressions fail against the old implementation: lost approvals, resurrected revocation, competing challenge codes, and eight successful redemptions of one code. All pass after the fix.
- All 353 gateway, CLI, and durability tests pass locally, including seven focused transaction/durability tests. Runtime and test-support typecheck pass.
- Build, real PTY startup, and the full local suite must pass before merge; final results will be recorded here.
- GitNexus rates the modified store, methods, policy evaluator, gateway handler, and CLI handler low risk. Staged detection reports only the expected files. New helpers and anonymous test callbacks are unindexed; manual call-site review confirms every mutation caller awaits completion.
- No hosted Actions workflows were enabled or dispatched. Native Darwin and Windows execution is not claimed on this Linux host.

Fixes #2058

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-sensitive DM pairing persistence and concurrency; incorrect locking or missed awaits could allow stale pairing state or blocked pairing, though behavior is heavily regression-tested.
> 
> **Overview**
> **Gateway pairing** now runs approve, revoke, challenge, redeem, and pending-list mutations inside a cross-process SQLite lock (`pairing.json.lock.sqlite`), with reload-from-disk before each change and **durable atomic** writes to `pairing.json` (temp file, sync, rename). That stops the live gateway and `agenc gateway pairing` CLI from racing and losing or resurrecting paired peers or double-redeeming codes.
> 
> **API surface:** those `PairingStore` methods and `evaluateDmAccess` are **async**; the gateway inbound path and CLI `pairing pending` / approve / revoke **await** them. Read-only `isPaired` / `listPaired` stay synchronous; pairing JSON stays v1. Docs note the lock file and that **existing gateway processes should restart** after upgrade so every writer participates.
> 
> **Tests** add multi-process transaction regressions, rename-failure durability, and update existing pairing tests for `await`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f396229cedd161c24279296f6048172181416eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->