### PR TITLE
fix(llm): coordinate OAuth refresh by credential generation

### DIFF
--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -192,6 +192,12 @@ stores credential values.
   retired native `agenc` credential field are explicit one-way migration
   inputs only. Reads, refreshes, and clears stay bound to the client's captured
   `HomeContext`, and refresh compare-and-swap preserves a newer login.
+  Within an OpenAI provider instance, concurrent 401 failures share one
+  refresh for the credentials used by those requests. Delayed failures from
+  older credentials cannot invalidate a refreshed session. Cancelling a chat
+  or stream stops that caller's wait without cancelling the shared refresh.
+  Genuine refresh exhaustion stays in effect until the provider is recreated
+  after login. Single-wire requests never refresh or mark refresh exhausted.
   List reachable models with `agenc openai-models --json`
   (`{ok, models, authMode}`; tokens never in the output). See
   [cli.md](cli.md#openai-models).

--- a/runtime/src/llm/providers/openai/adapter.ts
+++ b/runtime/src/llm/providers/openai/adapter.ts
@@ -755,7 +755,7 @@ export class OpenAIProvider implements LLMProvider {
           maxTokenField: this.resolveChatCompletionsMaxTokenField(),
           providerCapabilityHints,
         });
-      }, { singleWireAttempt: options?.singleWireAttempt });
+      }, { singleWireAttempt: options?.singleWireAttempt, signal: options?.signal });
     } catch (error) {
       if (isFallbackTriggeredError(error)) {
         throw error;
@@ -801,7 +801,7 @@ export class OpenAIProvider implements LLMProvider {
           timeoutMs,
           headers,
         );
-      }, { singleWireAttempt: options?.singleWireAttempt });
+      }, { singleWireAttempt: options?.singleWireAttempt, signal: options?.signal });
     } catch (error) {
       if (isFallbackTriggeredError(error)) {
         throw error;

--- a/runtime/src/llm/providers/openai/auth.ts
+++ b/runtime/src/llm/providers/openai/auth.ts
@@ -6,12 +6,15 @@
  * @module
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   assertNonEmptyApiKey,
   buildBearerAuthHeaders,
 } from "../../auth/bearer.js";
 import {
-  retryWithOAuthRefresh,
+  MAX_CONSECUTIVE_AUTH_FAILURES,
+  type OAuthRefreshCallbacks,
+  type OAuthRefreshOutcome,
   type OAuthRefreshState,
 } from "../../oauth/refresh-loop.js";
 import type { ProviderAuthHeaderContext } from "../../client-session.js";
@@ -19,10 +22,20 @@ import { LLMProviderError } from "../../errors.js";
 import { providerApiKeyEnvironmentLabel } from "../../registry/provider-info.js";
 import type { OpenAIProviderConfig } from "./types.js";
 
+interface AuthorizedOperationOptions {
+  readonly singleWireAttempt?: boolean;
+  readonly signal?: AbortSignal;
+}
+
 export class OpenAIAuthSession {
   private readonly config: OpenAIProviderConfig;
   private oauthState: OAuthRefreshState | null;
   private oauthExhaustedMessage: string | null = null;
+  private readonly operationState = new AsyncLocalStorage<OAuthRefreshState>();
+  private refreshFlight: {
+    readonly state: OAuthRefreshState;
+    readonly promise: Promise<void>;
+  } | null = null;
   private readonly providerName: string;
   private readonly apiKeyEnvLabel: string;
 
@@ -45,51 +58,106 @@ export class OpenAIAuthSession {
 
   async withAuthorizedOperation<T>(
     operation: () => Promise<T>,
-    options: { readonly singleWireAttempt?: boolean } = {},
+    options: AuthorizedOperationOptions = {},
   ): Promise<T> {
-    if (this.oauthState && this.config.oauth) {
+    const oauth = this.config.oauth;
+    if (!this.oauthState || !oauth) return await operation();
+    let authFailures = 0;
+    for (;;) {
+      options.signal?.throwIfAborted();
+      const state: OAuthRefreshState = this.oauthState;
       if (this.oauthExhaustedMessage) {
-        throw new LLMProviderError(
-          this.providerName,
-          this.oauthExhaustedMessage,
-          401,
-        );
+        throw this.exhaustedError(state);
       }
-
       try {
-        if (options.singleWireAttempt === true) {
-          return await operation();
-        }
-        const result = await retryWithOAuthRefresh(
-          this.oauthState,
-          async () => await operation(),
-          this.config.oauth,
-        );
-        this.oauthState = result.state;
-        this.oauthExhaustedMessage = null;
-        return result.value;
+        const value = await this.operationState.run(state, operation);
+        if (this.oauthState === state) state.consecutiveAuthFailures = 0;
+        return value;
       } catch (error) {
-        if (isUnauthorizedStatus(error)) {
-          this.oauthExhaustedMessage =
-            `OAuth refresh exhausted - re-authenticate via ${this.providerName} login.`;
-          throw new LLMProviderError(
-            this.providerName,
-            this.oauthExhaustedMessage,
-            401,
-          );
-        }
-        throw error;
+        authFailures += 1;
+        await this.recoverAuthFailure(state, error, options, authFailures);
       }
     }
+  }
 
-    return await operation();
+  private async recoverAuthFailure(
+    state: OAuthRefreshState,
+    error: unknown,
+    options: AuthorizedOperationOptions,
+    authFailures: number,
+  ): Promise<void> {
+    const oauth = this.config.oauth;
+    if (!isUnauthorizedStatus(error) || options.singleWireAttempt === true || !oauth) {
+      throw error;
+    }
+    options.signal?.throwIfAborted();
+    if (authFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+      throw this.oauthState === state ? this.exhaustedError(state) : error;
+    }
+    if (this.oauthState !== state) return;
+    await waitForOAuthRefresh(this.refreshOAuthState(state, error, oauth), options.signal);
+  }
+
+  private exhaustedError(state: OAuthRefreshState): LLMProviderError {
+    const message = `OAuth refresh exhausted - re-authenticate via ${this.providerName} login.`;
+    if (this.oauthState === state) this.oauthExhaustedMessage = message;
+    return new LLMProviderError(this.providerName, message, 401);
+  }
+
+  private async refreshOAuthState(
+    state: OAuthRefreshState,
+    previousError: Error & { readonly status?: number },
+    callbacks: OAuthRefreshCallbacks,
+  ): Promise<void> {
+    if (this.refreshFlight?.state === state) return await this.refreshFlight.promise;
+    if (this.oauthState !== state) return;
+    if (this.oauthExhaustedMessage) throw this.exhaustedError(state);
+    state.consecutiveAuthFailures += 1;
+    if (state.consecutiveAuthFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+      throw this.exhaustedError(state);
+    }
+    const promise = this.performOAuthRefresh(state, previousError, callbacks);
+    this.refreshFlight = { state, promise };
+    try {
+      await promise;
+    } finally {
+      if (this.refreshFlight?.promise === promise) this.refreshFlight = null;
+    }
+  }
+
+  private async performOAuthRefresh(
+    state: OAuthRefreshState,
+    previousError: Error & { readonly status?: number },
+    callbacks: OAuthRefreshCallbacks,
+  ): Promise<void> {
+    let outcome: OAuthRefreshOutcome;
+    try {
+      outcome = await callbacks.refreshAccessToken({
+        attempt: state.consecutiveAuthFailures,
+        refreshToken: state.refreshToken,
+        previousError,
+      });
+    } catch (error) {
+      if (this.oauthState !== state) return;
+      if (isUnauthorizedStatus(error)) throw this.exhaustedError(state);
+      throw error;
+    }
+    if (this.oauthState !== state) return;
+    if (outcome.kind !== "refreshed") throw this.exhaustedError(state);
+    this.oauthState = {
+      accessToken: outcome.accessToken,
+      refreshToken: outcome.refreshToken ?? state.refreshToken,
+      consecutiveAuthFailures: state.consecutiveAuthFailures,
+    };
+    this.oauthExhaustedMessage = null;
   }
 
   resolveHeaders(
     _context?: ProviderAuthHeaderContext,
   ): Readonly<Record<string, string>> {
-    if (this.oauthState) {
-      return this.headersForBearerToken(this.oauthState.accessToken);
+    const state = this.operationState.getStore() ?? this.oauthState;
+    if (state) {
+      return this.headersForBearerToken(state.accessToken);
     }
 
     switch (this.config.authStrategy ?? "bearer") {
@@ -127,7 +195,30 @@ export class OpenAIAuthSession {
 function isUnauthorizedStatus(
   error: unknown,
 ): error is Error & { readonly status?: number; readonly statusCode?: number } {
+  if (!(error instanceof Error)) return false;
   const status = (error as { readonly status?: unknown }).status;
   const statusCode = (error as { readonly statusCode?: unknown }).statusCode;
   return status === 401 || statusCode === 401;
+}
+
+function waitForOAuthRefresh(operation: Promise<void>, signal?: AbortSignal): Promise<void> {
+  if (!signal) return operation;
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason ?? new DOMException("Operation aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      () => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+    if (signal.aborted) onAbort();
+  });
 }

--- a/runtime/tests/llm/providers/openai/auth-concurrency.test.ts
+++ b/runtime/tests/llm/providers/openai/auth-concurrency.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, test, vi } from 'vitest'
+import { getEventListeners } from 'node:events'
+import { OpenAIAuthSession } from '../../../../src/llm/providers/openai/auth.js'
+import { OpenAIProvider } from '../../../../src/llm/providers/openai/adapter.js'
+import { LLMTimeoutError } from '../../../../src/llm/errors.js'
+import type { OAuthRefreshCallbacks } from '../../../../src/llm/oauth/refresh-loop.js'
+import {
+  createControlledPromise,
+  drainMicrotasks,
+  settleWithinMicrotasks,
+} from '../../../helpers/controlled-async.js'
+
+function unauthorized(): Error & { status: number } {
+  return Object.assign(new Error('fixture unauthorized'), { status: 401 })
+}
+
+function createAuth(refreshAccessToken: OAuthRefreshCallbacks['refreshAccessToken']): OpenAIAuthSession {
+  return new OpenAIAuthSession({
+    authMode: 'oauth',
+    oauth: { accessToken: 'old-token', refreshToken: 'refresh-token', refreshAccessToken },
+  })
+}
+
+describe('OAuth credential generations', () => {
+  test.each(['chat', 'stream'] as const)('forwards %s cancellation without aborting another refresh waiter', async mode => {
+    const refreshGate = createControlledPromise<void>()
+    const refreshStarted = createControlledPromise<void>()
+    const secondRequestStarted = createControlledPromise<void>()
+    const refresh = vi.fn(async () => {
+      refreshStarted.resolve()
+      await refreshGate.promise
+      return { kind: 'refreshed' as const, accessToken: 'new-token' }
+    })
+    const tokens: Array<string | null> = []
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const token = new Headers(init?.headers).get('authorization')
+      tokens.push(token)
+      if (token === 'Bearer old-token') {
+        if (tokens.length === 2) secondRequestStarted.resolve()
+        return Response.json({ error: { message: 'unauthorized' } }, { status: 401 })
+      }
+      const response = {
+        id: 'response-fixture',
+        status: 'completed',
+        model: 'gpt-5',
+        output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      }
+      return mode === 'chat'
+        ? Response.json(response)
+        : new Response(`event: response.completed\ndata: ${JSON.stringify({ type: 'response.completed', response })}\n\n`, {
+          headers: { 'content-type': 'text/event-stream' },
+        })
+    })
+    const provider = new OpenAIProvider({
+      model: 'gpt-5',
+      authMode: 'oauth',
+      oauth: { accessToken: 'old-token', refreshToken: 'refresh-token', refreshAccessToken: refresh },
+      fetchImpl,
+    })
+    const cancelledController = new AbortController()
+    const survivingController = new AbortController()
+    const run = (signal: AbortSignal) => mode === 'chat'
+      ? provider.chat([{ role: 'user', content: 'hello' }], { signal })
+      : provider.chatStream([{ role: 'user', content: 'hello' }], () => {}, { signal })
+    const cancelled = run(cancelledController.signal).catch(error => error)
+    await refreshStarted.promise
+    const surviving = run(survivingController.signal)
+    await secondRequestStarted.promise
+    cancelledController.abort(new DOMException('cancelled waiter', 'AbortError'))
+    expect(await settleWithinMicrotasks(cancelled)).toMatchObject({
+      status: 'fulfilled', value: expect.any(LLMTimeoutError),
+    })
+    expect(getEventListeners(cancelledController.signal, 'abort')).toHaveLength(0)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    refreshGate.resolve()
+    await expect(surviving).resolves.toMatchObject({ content: 'ok' })
+    expect(tokens).toEqual(['Bearer old-token', 'Bearer old-token', 'Bearer new-token'])
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(getEventListeners(survivingController.signal, 'abort')).toHaveLength(0)
+  })
+
+  test('coalesces simultaneous unauthorized operations into one refresh', async () => {
+    const refreshGate = createControlledPromise<void>()
+    const refreshStarted = createControlledPromise<void>()
+    const refresh = vi.fn(async () => {
+      if (refresh.mock.calls.length === 1) refreshStarted.resolve()
+      await refreshGate.promise
+      return { kind: 'refreshed' as const, accessToken: 'new-token' }
+    })
+    const auth = createAuth(refresh)
+    const operations = Array.from({ length: 8 }, () => auth.withAuthorizedOperation(async () => {
+      const headers = auth.resolveHeaders()
+      if (headers.authorization === 'Bearer old-token') throw unauthorized()
+      return headers.authorization
+    }))
+    await refreshStarted.promise
+    refreshGate.resolve()
+    expect(await Promise.all(operations)).toEqual(Array(8).fill('Bearer new-token'))
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not let a delayed old-generation failure exhaust new credentials', async () => {
+    const oldRequestGate = createControlledPromise<void>()
+    const oldRequestStarted = createControlledPromise<void>()
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValueOnce({ kind: 'refreshed', accessToken: 'new-token' })
+      .mockResolvedValueOnce({ kind: 'exhausted', reason: 'old refresh reused' })
+    const auth = createAuth(refresh)
+    const delayed = auth.withAuthorizedOperation(async () => {
+      const token = auth.resolveHeaders().authorization
+      if (token === 'Bearer old-token') {
+        oldRequestStarted.resolve()
+        await oldRequestGate.promise
+        throw unauthorized()
+      }
+      return token
+    })
+    const observedDelayed = delayed.then(value => ({ value }), error => ({ error }))
+    await oldRequestStarted.promise
+    expect(await auth.withAuthorizedOperation(async () => {
+      const token = auth.resolveHeaders().authorization
+      if (token === 'Bearer old-token') throw unauthorized()
+      return token
+    })).toBe('Bearer new-token')
+    oldRequestGate.resolve()
+    expect(await observedDelayed).toEqual({ value: 'Bearer new-token' })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await expect(auth.withAuthorizedOperation(async () => 'later')).resolves.toBe('later')
+  })
+
+  test('binds headers to each operation attempt across asynchronous setup', async () => {
+    const paused = createControlledPromise<void>()
+    const release = createControlledPromise<void>()
+    const auth = createAuth(async () => ({ kind: 'refreshed', accessToken: 'new-token' }))
+    const delayed = auth.withAuthorizedOperation(async () => {
+      paused.resolve()
+      await release.promise
+      return auth.resolveHeaders().authorization
+    })
+    await paused.promise
+    await auth.withAuthorizedOperation(async () => {
+      if (auth.resolveHeaders().authorization === 'Bearer old-token') throw unauthorized()
+      return 'refreshed'
+    })
+    release.resolve()
+    expect(await delayed).toBe('Bearer old-token')
+    expect(auth.resolveHeaders().authorization).toBe('Bearer new-token')
+  })
+
+  test('single-wire failure does not claim that refresh was exhausted', async () => {
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValue({ kind: 'refreshed', accessToken: 'new-token' })
+    const auth = createAuth(refresh)
+    await expect(auth.withAuthorizedOperation(async () => { throw unauthorized() }, {
+      singleWireAttempt: true,
+    })).rejects.toMatchObject({ status: 401 })
+    expect(refresh).not.toHaveBeenCalled()
+    await expect(auth.withAuthorizedOperation(async () => {
+      if (auth.resolveHeaders().authorization === 'Bearer old-token') throw unauthorized()
+      return 'ok'
+    })).resolves.toBe('ok')
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('cancels one refresh waiter promptly without cancelling another', async () => {
+    const refreshGate = createControlledPromise<void>()
+    const refreshStarted = createControlledPromise<void>()
+    const refresh = vi.fn(async () => {
+      refreshStarted.resolve()
+      await refreshGate.promise
+      return { kind: 'refreshed' as const, accessToken: 'new-token' }
+    })
+    const auth = createAuth(refresh)
+    const cancelledController = new AbortController()
+    const survivingController = new AbortController()
+    const operation = vi.fn(async () => {
+      if (auth.resolveHeaders().authorization === 'Bearer old-token') throw unauthorized()
+      return 'ok'
+    })
+    const cancelled = auth.withAuthorizedOperation(operation, { signal: cancelledController.signal })
+    const cancelledResult = cancelled.catch(error => error)
+    await refreshStarted.promise
+    const surviving = auth.withAuthorizedOperation(operation, { signal: survivingController.signal })
+    await drainMicrotasks(4)
+    const reason = new DOMException('cancelled waiter', 'AbortError')
+    cancelledController.abort(reason)
+    const settled = await settleWithinMicrotasks(cancelledResult)
+    expect(settled).toMatchObject({ status: 'fulfilled', value: reason })
+    expect(getEventListeners(cancelledController.signal, 'abort')).toHaveLength(0)
+    expect(operation).toHaveBeenCalledTimes(2)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    refreshGate.resolve()
+    await expect(surviving).resolves.toBe('ok')
+    expect(operation).toHaveBeenCalledTimes(3)
+    expect(getEventListeners(survivingController.signal, 'abort')).toHaveLength(0)
+  })
+
+  test('observes refresh rejection after every waiter cancels', async () => {
+    const refreshGate = createControlledPromise<void>()
+    const refreshStarted = createControlledPromise<void>()
+    const auth = createAuth(async () => {
+      refreshStarted.resolve()
+      await refreshGate.promise
+      throw unauthorized()
+    })
+    const controller = new AbortController()
+    const pending = auth.withAuthorizedOperation(async () => { throw unauthorized() }, {
+      signal: controller.signal,
+    })
+    const observed = pending.catch(error => error)
+    await refreshStarted.promise
+    controller.abort(new DOMException('cancelled waiter', 'AbortError'))
+    expect(await observed).toMatchObject({ name: 'AbortError' })
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+    refreshGate.resolve()
+    await drainMicrotasks(12)
+    const later = vi.fn(async () => 'should not run')
+    await expect(auth.withAuthorizedOperation(later)).rejects.toMatchObject({ statusCode: 401 })
+    expect(later).not.toHaveBeenCalled()
+  })
+
+  test('does not start work for an already cancelled caller', async () => {
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+    const auth = createAuth(refresh)
+    const controller = new AbortController()
+    const reason = new DOMException('cancelled before start', 'AbortError')
+    controller.abort(reason)
+    const operation = vi.fn(async () => 'should not run')
+    await expect(auth.withAuthorizedOperation(operation, { signal: controller.signal })).rejects.toBe(reason)
+    expect(operation).not.toHaveBeenCalled()
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  test('shares genuine exhaustion and keeps it sticky for subsequent calls', async () => {
+    const gate = createControlledPromise<void>()
+    const started = createControlledPromise<void>()
+    const refresh = vi.fn(async () => {
+      started.resolve()
+      await gate.promise
+      return { kind: 'exhausted' as const, reason: 'revoked' }
+    })
+    const auth = createAuth(refresh)
+    const operation = vi.fn(async () => { throw unauthorized() })
+    const results = Promise.allSettled(Array.from({ length: 4 }, () => auth.withAuthorizedOperation(operation)))
+    await started.promise
+    gate.resolve()
+    for (const result of await results) {
+      expect(result).toMatchObject({ status: 'rejected', reason: { statusCode: 401 } })
+    }
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await expect(auth.withAuthorizedOperation(operation)).rejects.toThrow('OAuth refresh exhausted')
+    expect(operation).toHaveBeenCalledTimes(4)
+  })
+
+  test('does not let an older successful operation clear newer exhaustion', async () => {
+    const oldSuccess = createControlledPromise<void>()
+    const oldStarted = createControlledPromise<void>()
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValueOnce({ kind: 'refreshed', accessToken: 'new-token' })
+      .mockResolvedValueOnce({ kind: 'exhausted', reason: 'revoked' })
+    const auth = createAuth(refresh)
+    const old = auth.withAuthorizedOperation(async () => {
+      oldStarted.resolve()
+      await oldSuccess.promise
+      return 'old request succeeded'
+    })
+    await oldStarted.promise
+    await expect(auth.withAuthorizedOperation(async () => { throw unauthorized() })).rejects.toThrow('OAuth refresh exhausted')
+    oldSuccess.resolve()
+    await expect(old).resolves.toBe('old request succeeded')
+    const later = vi.fn(async () => 'should not run')
+    await expect(auth.withAuthorizedOperation(later)).rejects.toThrow('OAuth refresh exhausted')
+    expect(later).not.toHaveBeenCalled()
+  })
+
+  test('does not revive an exhausted generation when an outstanding request fails', async () => {
+    const delayedFailure = createControlledPromise<void>()
+    const started = createControlledPromise<void>()
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValueOnce({ kind: 'exhausted', reason: 'revoked' })
+      .mockResolvedValueOnce({ kind: 'refreshed', accessToken: 'must not revive' })
+    const auth = createAuth(refresh)
+    const delayed = auth.withAuthorizedOperation(async () => {
+      if (auth.resolveHeaders().authorization === 'Bearer old-token') {
+        started.resolve()
+        await delayedFailure.promise
+        throw unauthorized()
+      }
+      return 'revived'
+    })
+    const observed = delayed.catch(error => error)
+    await started.promise
+    await expect(auth.withAuthorizedOperation(async () => { throw unauthorized() })).rejects.toThrow('OAuth refresh exhausted')
+    delayedFailure.resolve()
+    expect(await observed).toMatchObject({ statusCode: 401 })
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('preserves current credentials after a delayed single-wire auth failure', async () => {
+    const gate = createControlledPromise<void>()
+    const started = createControlledPromise<void>()
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValue({ kind: 'refreshed', accessToken: 'new-token' })
+    const auth = createAuth(refresh)
+    const failure = unauthorized()
+    const delayed = auth.withAuthorizedOperation(async () => {
+      started.resolve()
+      await gate.promise
+      throw failure
+    }, { singleWireAttempt: true }).catch(error => error)
+    await started.promise
+    await auth.withAuthorizedOperation(async () => {
+      if (auth.resolveHeaders().authorization === 'Bearer old-token') throw unauthorized()
+    })
+    gate.resolve()
+    expect(await delayed).toBe(failure)
+    await expect(auth.withAuthorizedOperation(async () => auth.resolveHeaders().authorization))
+      .resolves.toBe('Bearer new-token')
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('bounds repeated rejection of refreshed credentials', async () => {
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValue({ kind: 'refreshed', accessToken: 'still-rejected' })
+    const auth = createAuth(refresh)
+    const operation = vi.fn(async () => { throw unauthorized() })
+    await expect(auth.withAuthorizedOperation(operation)).rejects.toThrow('OAuth refresh exhausted')
+    expect(operation).toHaveBeenCalledTimes(10)
+    expect(refresh).toHaveBeenCalledTimes(9)
+    await expect(auth.withAuthorizedOperation(operation)).rejects.toThrow('OAuth refresh exhausted')
+    expect(operation).toHaveBeenCalledTimes(10)
+  })
+
+  test('tracks a new generation even if refresh returns the same token', async () => {
+    const oldGate = createControlledPromise<void>()
+    const oldStarted = createControlledPromise<void>()
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockResolvedValue({ kind: 'refreshed', accessToken: 'old-token' })
+    const auth = createAuth(refresh)
+    let oldAttempts = 0
+    const delayed = auth.withAuthorizedOperation(async () => {
+      if (++oldAttempts === 1) {
+        oldStarted.resolve()
+        await oldGate.promise
+        throw unauthorized()
+      }
+      return 'reused new generation'
+    })
+    await oldStarted.promise
+    let fastAttempts = 0
+    await auth.withAuthorizedOperation(async () => {
+      if (++fastAttempts === 1) throw unauthorized()
+      return 'refreshed'
+    })
+    oldGate.resolve()
+    await expect(delayed).resolves.toBe('reused new generation')
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test.each([new Error('offline'), null, undefined, 'plain failure'])('preserves non-auth failures without refresh: %s', async error => {
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+    const auth = createAuth(refresh)
+    await expect(auth.withAuthorizedOperation(async () => { throw error })).rejects.toBe(error)
+    expect(refresh).not.toHaveBeenCalled()
+    await expect(auth.withAuthorizedOperation(async () => 'ok')).resolves.toBe('ok')
+  })
+
+  test('allows a later retry after a transient refresh failure', async () => {
+    const networkError = new Error('refresh offline')
+    const refresh = vi.fn<OAuthRefreshCallbacks['refreshAccessToken']>()
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce({ kind: 'refreshed', accessToken: 'new-token' })
+    const auth = createAuth(refresh)
+    const operation = async (): Promise<string> => {
+      if (auth.resolveHeaders().authorization === 'Bearer old-token') throw unauthorized()
+      return 'ok'
+    }
+    await expect(auth.withAuthorizedOperation(operation)).rejects.toBe(networkError)
+    await expect(auth.withAuthorizedOperation(operation)).resolves.toBe('ok')
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Changes

- Coalesce concurrent OpenAI OAuth failures into one refresh per credential generation. Bind request headers to that generation across asynchronous setup.
- Reuse new credentials after delayed old-request failures. Keep genuine exhaustion sticky, including when an outstanding request fails after exhaustion.
- Forward chat and stream cancellation to each refresh waiter without cancelling shared work. Observe late rejection and remove abort listeners.
- Preserve single-wire no-refresh behavior, non-auth errors and bounded retries. Add deterministic race and adapter cancellation tests and document the behavior.

## Validation

- Original implementation fails all four initial regression tests. A further interleaving test caught and now prevents revival after genuine exhaustion.
- Docker-isolated targeted tests and runtime/test-support typechecks pass: 74 tests across four files, zero skips.
- Bun 1.3.12 passes all 20 new race tests.
- The supported Linux native slice passes 92 tests across five files.
- Final build, generated SDK contract and all PTY startup checks pass.
- Full root `npm test` passes on 84be9d3d54032079ec2016648589dc82f1a649db: 23,549 runtime tests across 2,278 files, zero failures or skips, plus the root and launcher checks.
- GitNexus identifies this as a critical authentication boundary with five direct adapter callers. The staged diff contains only the expected auth, adapter, tests and documentation changes. No changed production module is in the FND measured closure.
- Hosted test workflows remain disabled. No Actions runs are requested. Native Darwin and Windows execution is not claimed.

Fixes #2060.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sit on the OpenAI OAuth authentication boundary with complex concurrency; incorrect refresh coalescing or exhaustion handling could break sign-in sessions or allow stale credentials to win.
> 
> **Overview**
> **OpenAI OAuth refresh is reworked** so concurrent 401s on the same credential generation share one in-flight refresh, while each request keeps the bearer token it started with via `AsyncLocalStorage`.
> 
> `OpenAIAuthSession` replaces the generic `retryWithOAuthRefresh` loop with generation-aware recovery: stale operations cannot mark a newer session exhausted, genuine exhaustion stays sticky until re-login, and `singleWireAttempt` still skips refresh entirely. Chat/stream now pass `AbortSignal` into `withAuthorizedOperation`, so cancelling one caller aborts only that waiter’s wait on refresh (listeners cleaned up) without stopping the shared refresh. The OpenAI adapter wires `options.signal` through for chat and stream.
> 
> Provider docs describe the concurrency, cancellation, and exhaustion rules. A large `auth-concurrency.test` suite covers coalescing, races, cancellation, and adapter-level chat/stream behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84be9d3d54032079ec2016648589dc82f1a649db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->