### PR TITLE
Move the session-guidance block into the cached prefix

### DIFF
--- a/runtime/src/prompts/system-prompt.ts
+++ b/runtime/src/prompts/system-prompt.ts
@@ -339,14 +339,18 @@ export function getSimpleToneAndStyleSection(): string {
   return joinSection("# Tone and style", items);
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// Dynamic sections (post-boundary — session-specific)
-// ─────────────────────────────────────────────────────────────────────
-
-/** session_guidance — per-session guidance derived from config/tools.
- *  AgenC-original. Drives the `Use ask-user-question when stuck` and
- *  `Use subagents when matching` reminders that depend on the actual
- *  visible tool catalog and agent surface for this turn. */
+/**
+ * 9. session_guidance — guidance derived from the visible tool catalog.
+ * AgenC-original. Drives the `Use ask-user-question when stuck` and
+ * `Use subagents when matching` reminders.
+ *
+ * agenc-core#2263: this belongs in the static head, next to
+ * {@link getUsingYourToolsSection}, because it is a pure function of the same
+ * `enabledTools` set (`agentsEnabled` is `enabledTools.has("spawn_agent")`).
+ * Sitting in the dynamic tail cost it a re-read on every request — the tail is
+ * the last input item, so the provider's cached prefix always stops in front
+ * of it — for content that never changes while the catalog holds.
+ */
 function getSessionGuidanceSection(
   enabledTools: ReadonlySet<string>,
   agentsEnabled: boolean,
@@ -376,6 +380,10 @@ function getSessionGuidanceSection(
   if (items.length === 0) return null;
   return joinSection("# Session-specific guidance", items);
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Dynamic sections (post-boundary — session-specific)
+// ─────────────────────────────────────────────────────────────────────
 
 /** memory — the directory block of `loadMemoryPrompt()` (per-session
  *  paths). Wired as a compute closure so the caller can pass a pre-loaded
@@ -996,7 +1004,8 @@ export async function assembleSystemPrompt(
   // next to per-tool guidance.
   // Section order:
   //   intro → system → doing_tasks → actions → using_your_tools
-  //   → (agent_tool) → tone_and_style → output_efficiency → (auto memory)
+  //   → (agent_tool) → (session_guidance) → tone_and_style
+  //   → output_efficiency → (auto memory)
   const staticSections: Array<string | null> = [
     getSimpleIntroSection(opts.outputStyle != null),
     getSimpleSystemSection(),
@@ -1006,6 +1015,7 @@ export async function assembleSystemPrompt(
     getActionsSection(),
     getUsingYourToolsSection(enabledTools),
     getAgentToolSection(enabledTools),
+    getSessionGuidanceSection(enabledTools, agentsEnabled),
     getSimpleToneAndStyleSection(),
     getOutputEfficiencySection(),
     getMemoryInstructionsSection(opts.memoryInstructions),
@@ -1017,11 +1027,6 @@ export async function assembleSystemPrompt(
       "client_rendering",
       () => clientRendering,
       "rendering capabilities belong to the captured client, not the daemon process",
-    ),
-    DANGEROUS_uncachedSystemPromptSection(
-      "session_guidance",
-      () => getSessionGuidanceSection(enabledTools, agentsEnabled),
-      "session-scoped guidance changes with tools/agent availability",
     ),
     DANGEROUS_uncachedSystemPromptSection(
       "permissions",

--- a/runtime/tests/prompts/session-guidance-placement.test.ts
+++ b/runtime/tests/prompts/session-guidance-placement.test.ts
@@ -1,0 +1,145 @@
+/**
+ * agenc-core#2263: the `# Session-specific guidance` block must ride the
+ * cached static head, not the volatile tail.
+ *
+ * The tail is the LAST input item of every request, so it always sits after
+ * the history the previous request ended with — the provider's cached prefix
+ * stops before it and its bytes are re-read on every call. Guidance is a pure
+ * function of `enabledTools` (and `agentsEnabled`, itself
+ * `enabledTools.has("spawn_agent")`), the same input that already decides
+ * `# Using your tools` inside the cached head, so nothing about it needs to
+ * be re-read per request.
+ */
+import { describe, expect, test } from "vitest";
+
+import type { TurnContext } from "../session/turn-context.js";
+import type { Session } from "../session/session.js";
+import { assembleSystemPrompt } from "./system-prompt.js";
+import { buildOpenAIResponsesRequest } from "../llm/wire/responses-openai.js";
+import type { LLMMessage } from "../llm/types.js";
+
+function fakeCtx(): TurnContext {
+  const cfg = {
+    model: "grok-4-fast",
+    cwd: "/tmp/agenc-fake-cwd",
+    features: {} as unknown,
+    multiAgentV2: {
+      usageHintEnabled: false,
+      usageHintText: "",
+      hideSpawnAgentMetadata: false,
+    },
+    permissions: {
+      allowLoginShell: false,
+      shellEnvironmentPolicy: { allowedEnvVars: [], blockedEnvVars: [] },
+      windowsSandboxPrivateDesktop: false,
+    },
+    ghostSnapshot: { enabled: false },
+    agentRoles: [],
+  };
+  return {
+    subId: "sub-test-1",
+    config: cfg as unknown,
+    configSnapshot: cfg as unknown,
+    cwd: "/tmp/agenc-fake-cwd",
+    approvalPolicy: { value: "on_request" },
+    sandboxPolicy: { value: "workspace_write" },
+    networkSandboxPolicy: {
+      allowlist: [],
+      denylist: [],
+      allowManagedDomainsOnly: false,
+    },
+  } as unknown as TurnContext;
+}
+
+const fakeSession = {} as unknown as Session;
+
+const TOOLS: ReadonlySet<string> = new Set([
+  "exec_command",
+  "FileRead",
+  "Edit",
+  "Write",
+  "Glob",
+  "Grep",
+  "TodoWrite",
+  "ask_user_question",
+  "spawn_agent",
+]);
+
+const GUIDANCE_HEADING = "# Session-specific guidance";
+
+async function assemble(): Promise<{
+  readonly staticPrefix: string;
+  readonly dynamicSuffix: string;
+  readonly text: string;
+  readonly guidance: string;
+}> {
+  const prompt = await assembleSystemPrompt({
+    session: fakeSession,
+    ctx: fakeCtx(),
+    enabledToolNames: TOOLS,
+    agentsEnabled: true,
+    simpleMode: false,
+    permissionContext: null,
+    projectInstructions: "",
+    mcpServers: [],
+  });
+  const guidance = prompt.sections.find((section) =>
+    section.startsWith(GUIDANCE_HEADING),
+  );
+  expect(guidance, "the guidance section is still emitted").toBeDefined();
+  return { ...prompt, guidance: guidance as string };
+}
+
+describe("session guidance rides the cached prefix", () => {
+  test("the assembler puts guidance in the static head, not the volatile tail", async () => {
+    const { staticPrefix, dynamicSuffix, guidance } = await assemble();
+
+    expect(staticPrefix).toContain(guidance);
+    expect(dynamicSuffix).not.toContain(GUIDANCE_HEADING);
+    // The tail keeps what genuinely changes per turn.
+    expect(dynamicSuffix).toContain("# Environment");
+    // Measured on this fixture: guidance is 1128 chars of a 1924-char tail,
+    // so once it moves the tail is smaller than the block that left it.
+    expect(guidance.length).toBeGreaterThan(dynamicSuffix.length);
+  });
+
+  test("no request re-sends guidance outside the cached prefix", async () => {
+    const turn1 = await assemble();
+    // A turn boundary: same session, same tools, later wall clock.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const turn2 = await assemble();
+    expect(turn2.dynamicSuffix).not.toBe(turn1.dynamicSuffix);
+
+    const history: LLMMessage[] = [{ role: "user", content: "first" }];
+    const request1 = buildOpenAIResponsesRequest({
+      model: "gpt-test",
+      messages: history,
+      tools: [],
+      options: { systemPrompt: turn1.text },
+    });
+    const request2 = buildOpenAIResponsesRequest({
+      model: "gpt-test",
+      messages: [
+        ...history,
+        { role: "assistant", content: "answer" },
+        { role: "user", content: "second" },
+      ],
+      tools: [],
+      options: { systemPrompt: turn2.text },
+    });
+
+    // `instructions` is the cached prefix: guidance belongs there, and it
+    // stays byte-identical while the turn's timestamp moves.
+    expect(request1.instructions).toContain(turn1.guidance);
+    expect(request2.instructions).toBe(request1.instructions);
+
+    for (const request of [request1, request2]) {
+      const input = JSON.stringify(request.input);
+      expect(input).not.toContain(GUIDANCE_HEADING);
+      // The dynamic tail is still the final item, just smaller.
+      expect(
+        JSON.stringify((request.input as unknown[]).at(-1)),
+      ).toContain("# Environment");
+    }
+  });
+});


### PR DESCRIPTION
## Why

Closes #2263.

Searched git log for 2263 and for the symptom (--grep on "guidance", "Session-specific", "prefix") and diffed 1078cd98e..upstream/main over runtime/src/prompts/system-prompt.ts, runtime/src/llm/wire/responses-openai.ts, runtime/src/llm/wire/shared.ts and runtime/scripts/eval/prefix-diff.mjs. Only one commit touched any of them (719f2c527, which added the client_rendering section) and it does not address placement, so nothing had fixed this under a different PR number. Note the local source clone was 100+ commits behind GitHub (f93ef2ace vs a6a431739), so I added the real upstream remote and verified against a6a431739.

Reading the code changed the diagnosis. The block is ALREADY strictly last: runtime/src/llm/wire/responses-openai.ts:324 pushes the dynamic suffix as the final input item, and runtime/src/llm/providers/grok/adapter.ts:2174 does the same for xAI. So the issue's second suggestion was already satisfied, and the four flagged pairs are not an ordering slip. They are the turn boundaries where the suffix's own bytes changed: prefix-diff's suffixMoved() (runtime/scripts/eval/prefix-diff.mjs:80) only forgives a moved tail when it is byte-identical, and the tail carries `Current time (UTC)` at ISO-millisecond precision from buildEnvInfoSection (runtime/src/prompts/system-prompt.ts:476). That also means the real cost is not confined to those four pairs: because the tail is the last item, the provider's cached prefix stops in front of it on EVERY request, so its whole size

## Evidence

Measured with the real assembler and the real wire builder (10 tools, agents on, no MCP/memory/permission sections), two assemblies 5 ms apart standing in for a turn boundary, compared with runtime/scripts/eval/prefix-diff.mjs:

                             main (a6a431739)    fixed
 trailing system input item   2,026 chars         888 chars
                              ~507 tokens         ~222 tokens
 instructions (cached head)  14,140 chars      15,270 chars
 prefix-diff divergence      input[1] (system)  input[1] (system)
                             prefixStable false prefixStable false

At the assembler level the guidance block is 1,128 chars (~282 tokens) and the whole dynamic tail was 1,924 chars (~481 tokens), so the block was 59% of the tail; after the move the tail is 794 chars (~199 tokens). Per provider request that is ~285 tokens no longer re-read; the session in the issue made 50 of them.

Honest limit, measured not assumed: prefixStable stays false. The tail still carries the ISO-millisecond `Current time (UTC)`, so prefix-diff still reports a divergence at the old suffix index at every turn boundary. The fix shrinks what is re-read by 56%; it does not make those pairs report clean. Eliminating the report would need the wall clock out of the tail, which is a different change.

Files: /private/tmp/tt/core-guidance-block-suffix/runtime/src/prompts/system-prompt.ts

## Tests

/private/tmp/tt/core-guidance-block-suffix/runtime/tests/prompts/session-guidance-placement.test.ts — two tests, both driving the real assembleSystemPrompt and the real buildOpenAIResponsesRequest, not a synthetic prompt string.

1. "the assembler puts guidance in the static head, not the volatile tail": the emitted guidance section is inside staticPrefix, absent from dynamicSuffix, the tail still carries "# Environment" (so a fix that collapses the split fails), and guidance.length > dynamicSuffix.length — a measurement pin that fails while the block is in the tail (1,128 > 1,924 is false) and holds once it moves (1,128 > 794).
2. "no request re-sends guidance outside the cached prefix": two assemblies across a turn boundary, asserted to differ, fed through the OpenAI Responses wire; `instructions` must contain the guidance and be byte-identical across both turns, and no input item of either request may contain the heading.

Both are non-vacuous in the deletion direction: the shared a

Failing first, on unfixed source:



## Review

An independent reviewer reproduced the measurements and reverted the change to confirm the tests fail without it.

MERGE. I reproduced the before/after myself, reverted the source and confirmed both tests fail, ran a deletion probe and confirmed they fail that way too, and checked the predicate against the real tool names and the real production assembly path (session.ts:2855 -> assembleBaseInstructionsForModel -> live-instructions.ts:520), not just the test stub. Every measured number in the report matched to the byte, including the honest limit that prefixStable stays false. The diff is two hunks, touches no permission check, moves no cost elsewhere, and introduces zero regressions against a measured baseline (16 pre-existing failures with the fix vs 18 without, i.e. the same 16). Two nits I would rais

🤖 Generated with [Claude Code](https://claude.com/claude-code)
