### PR TITLE
An error result without an effect disposition no longer gates the turn

### DIFF
--- a/runtime/src/bin/model-facing-tools.ts
+++ b/runtime/src/bin/model-facing-tools.ts
@@ -2780,11 +2780,14 @@ function createSkillInvocationRuntimeTool(opts: ModelFacingToolOptions): Tool {
     },
     checkPermissions: async (input, context) =>
       checkSkillPermissions(input, context),
+    // Recording the invocation is the tool's only effect, so every refusal
+    // below is made before it. A bare error from a side-effecting tool is
+    // filed as an unknown outcome and gates the whole session (#2190).
     execute: async (args) => {
       const skillName = normalizeSkillName(stringValue(args.skill) ?? "");
-      if (!skillName) return json({ error: "skill is required" }, true);
+      if (!skillName) return refusal({ error: "skill is required" });
       if (isMcpToolName(skillName)) {
-        return json({ error: mcpToolUsedAsSkillMessage(skillName) }, true);
+        return refusal({ error: mcpToolUsedAsSkillMessage(skillName) });
       }
       const sessionOrError = getSessionOrError(opts);
       if (!("conversationId" in sessionOrError)) return sessionOrError;
@@ -2799,10 +2802,9 @@ function createSkillInvocationRuntimeTool(opts: ModelFacingToolOptions): Tool {
         const bundled = await findBundledSkillCommand(skillName);
         if (bundled?.getPromptForCommand !== undefined) {
           if (bundled.disableModelInvocation === true) {
-            return json(
-              { error: `skill is not model-invocable: ${bundled.name}` },
-              true,
-            );
+            return refusal({
+              error: `skill is not model-invocable: ${bundled.name}`,
+            });
           }
           const blocks = await bundled.getPromptForCommand(
             stringValue(args.args) ?? "",
@@ -2825,25 +2827,19 @@ function createSkillInvocationRuntimeTool(opts: ModelFacingToolOptions): Tool {
         const bundledNames = (await listBundledSkillNames()).filter(
           (name) => !(outcome.availableSkills ?? []).some((s) => s.name === name),
         );
-        return json(
-          {
-            error: `skill not found: ${skillName}`,
-            available: [
-              ...(outcome.availableSkills?.map((entry) => entry.name) ?? []),
-              ...bundledNames,
-            ].sort((a, b) => a.localeCompare(b)),
-          },
-          true,
-        );
+        return refusal({
+          error: `skill not found: ${skillName}`,
+          available: [
+            ...(outcome.availableSkills?.map((entry) => entry.name) ?? []),
+            ...bundledNames,
+          ].sort((a, b) => a.localeCompare(b)),
+        });
       }
 
       if (rendered.skill.disableModelInvocation === true) {
-        return json(
-          {
-            error: `skill is not model-invocable: ${rendered.skill.name}`,
-          },
-          true,
-        );
+        return refusal({
+          error: `skill is not model-invocable: ${rendered.skill.name}`,
+        });
       }
 
       const modelVisibleContent = isRepositoryControlledSkillSource(
@@ -4248,8 +4244,9 @@ function createPlanAndMessageTools(
       additionalProperties: false,
     },
     execute: async (args) => {
+      // Refused before the emit, so the refusal must not gate the session.
       const message = stringValue(args.message);
-      if (!message) return json({ error: "message is required" }, true);
+      if (!message) return refusal({ error: "message is required" });
       const session = opts.getSession();
       session?.emit({
         id: session.nextInternalSubId(),

--- a/runtime/tests/helpers/admitted-tool-harness.ts
+++ b/runtime/tests/helpers/admitted-tool-harness.ts
@@ -1,0 +1,85 @@
+import { vi } from "vitest";
+
+import type {
+  AdmissionAcquireInput,
+  ExecutionAdmissionClient,
+} from "../../src/budget/admission-client.js";
+import type { AdmissionLease } from "../../src/budget/admission-types.js";
+import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
+import {
+  createEmptyToolPermissionContext,
+  type ToolPermissionContext,
+} from "../../src/permissions/types.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
+import type { Session } from "../../src/session/session.js";
+
+export interface AdmittedToolHarness {
+  readonly session: Session;
+  readonly events: Event[];
+  readonly acquire: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * A session that admits every tool call and collects the events it emits, so a
+ * test can dispatch through `runAdmittedToolCall` and read back what the effect
+ * gate filed. `label` names this test's admission scope: the run is
+ * `run-${label}`, the session `session-${label}`, and callers pass
+ * `turn-${label}` as the turn id.
+ */
+export function bindAdmittedToolHarness(options: {
+  readonly workspaceRoot: string;
+  readonly label: string;
+  readonly toolPermissionContext?: ToolPermissionContext;
+}): AdmittedToolHarness {
+  const { workspaceRoot, label } = options;
+  const events: Event[] = [];
+  const eventLog = new EventLog();
+  eventLog.subscribe((event) => events.push(event));
+  const acquire = vi.fn(async (input: AdmissionAcquireInput): Promise<AdmissionLease> => ({
+    decision: "allow",
+    reservation: {
+      reservationId: input.stepId,
+      step: { runId: `run-${label}`, stepId: input.stepId },
+      reservedCostUsd: input.maxCostUsd ?? 0,
+      reservedTokens: input.maxInputTokens + input.maxOutputTokens,
+      reservedAt: "2026-09-07T00:00:00.000Z",
+    },
+    request: {
+      step: { runId: `run-${label}`, stepId: input.stepId },
+      kind: input.kind,
+      estimate: {
+        maxInputTokens: input.maxInputTokens,
+        maxOutputTokens: input.maxOutputTokens,
+        maxCostUsd: input.maxCostUsd,
+      },
+      workspaceId: workspaceRoot,
+      sessionId: `session-${label}`,
+      parentScopeId: `turn-${label}`,
+      autonomous: false,
+    },
+    signal: new AbortController().signal,
+  }));
+  const admission = {
+    scope: { runId: `run-${label}` },
+    acquire,
+    markDispatched: vi.fn(),
+    reconcile: vi.fn(() => ({ applied: true, outcome: "reconciled" })),
+    holdUnknown: vi.fn(),
+    void: vi.fn(),
+    acknowledgeCompletion: vi.fn(),
+  } as unknown as ExecutionAdmissionClient;
+  const session = {
+    conversationId: `session-${label}`,
+    eventLog,
+    emit: (event: Event) => eventLog.emit(event),
+    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
+    services: {
+      executionAdmission: admission,
+      admissionRequired: true,
+      permissionModeRegistry: new PermissionModeRegistry(
+        options.toolPermissionContext ?? createEmptyToolPermissionContext(),
+      ),
+    },
+  } as unknown as Session;
+  return { session, events, acquire };
+}

--- a/runtime/tests/tools/mutating-refusals.sweep.test.ts
+++ b/runtime/tests/tools/mutating-refusals.sweep.test.ts
@@ -8,12 +8,12 @@ import { buildToolRegistry } from "../../src/tool-registry.js";
 import type { Tool, ToolResult } from "../../src/tools/types.js";
 
 /**
- * #2190, proposal 3. A mutating tool that refuses before it touches anything
- * must say so with a `confirmed_no_effect` disposition; a bare error (or a
- * thrown one) is filed as an unknown outcome and gates the whole session
- * behind /resolve. Empty arguments are the refusal every tool has, so this
- * sweep asserts the contract over every mutating built-in tool at once and a
- * new tool cannot regress it silently.
+ * #2190, proposal 3. A tool that refuses before it touches anything must say
+ * so with a `confirmed_no_effect` disposition; a bare error (or a thrown one)
+ * is filed as an unknown outcome and gates the whole session behind /resolve.
+ * Empty arguments are the refusal every tool has, so this sweep asserts the
+ * contract over every built-in tool the gate can stop, at once, and a new tool
+ * cannot regress it silently.
  */
 
 let root = "";
@@ -36,7 +36,14 @@ afterAll(async () => {
  */
 const EMPTY_CALL_IS_AN_ATTEMPT = new Set(["install_ledger_wallet_cli"]);
 
-function mutatingTools(): readonly Tool[] {
+/**
+ * The gate's own population, not the metadata's. `runAdmittedToolCall` poisons
+ * the live effect for every recovery category but `idempotent`, and a missing
+ * category means side-effecting, so a tool can be read-only in its metadata and
+ * still stop the session when it refuses — `Skill` and `SendUserMessage` are.
+ * Sweeping `metadata.mutating` alone left those outside the guard.
+ */
+function gatedTools(): readonly Tool[] {
   const modelFacing = createModelFacingTools({
     workspaceRoot: root,
     agencHome: home,
@@ -46,7 +53,11 @@ function mutatingTools(): readonly Tool[] {
   const coding = buildToolRegistry({ workspaceRoot: root }).tools;
   const seen = new Set<string>();
   return [...coding, ...modelFacing].filter((tool) => {
-    if (tool.metadata?.mutating !== true || seen.has(tool.name)) return false;
+    if (seen.has(tool.name)) return false;
+    const gated =
+      tool.metadata?.mutating === true ||
+      (tool.recoveryCategory ?? "side-effecting") !== "idempotent";
+    if (!gated) return false;
     seen.add(tool.name);
     return !EMPTY_CALL_IS_AN_ATTEMPT.has(tool.name);
   });
@@ -68,19 +79,25 @@ async function refusal(tool: Tool): Promise<ToolResult | string> {
   }
 }
 
-describe("every mutating tool names its boundary when it refuses empty arguments", () => {
-  test("the sweep sees the mutating tool family", () => {
-    const names = mutatingTools().map((tool) => tool.name);
+describe("every gated tool names its boundary when it refuses empty arguments", () => {
+  test("the sweep sees the gated tool family", () => {
+    const names = gatedTools().map((tool) => tool.name);
     expect(names, names.join(", ")).toEqual(
-      expect.arrayContaining(["exec_command", "TaskCreate", "WorkflowTool"]),
+      expect.arrayContaining([
+        "exec_command",
+        "TaskCreate",
+        "WorkflowTool",
+        "Skill",
+        "SendUserMessage",
+      ]),
     );
     expect(names.length).toBeGreaterThan(20);
   });
 
-  test("no mutating tool refuses empty arguments with a bare or thrown error", async () => {
+  test("no gated tool refuses empty arguments with a bare or thrown error", async () => {
     const failures: string[] = [];
     const accepted: string[] = [];
-    for (const tool of mutatingTools()) {
+    for (const tool of gatedTools()) {
       const result = await refusal(tool);
       if (typeof result === "string") {
         failures.push(`${tool.name}: ${result}`);

--- a/runtime/tests/tools/read-only-recovery-category.test.ts
+++ b/runtime/tests/tools/read-only-recovery-category.test.ts
@@ -8,19 +8,12 @@ import {
   createModelFacingTools,
   __setLiveWebFetchDnsAllLookupForTests,
 } from "../../src/bin/model-facing-tools.js";
-import type {
-  AdmissionAcquireInput,
-  ExecutionAdmissionClient,
-} from "../../src/budget/admission-client.js";
-import type { AdmissionLease } from "../../src/budget/admission-types.js";
 import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
 import type { ToolEvaluatorContext } from "../../src/permissions/evaluator.js";
-import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
 import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
-import { EventLog, type Event } from "../../src/session/event-log.js";
-import type { Session } from "../../src/session/session.js";
 import { buildToolRegistry, type ToolRegistry } from "../../src/tool-registry.js";
 import type { Tool } from "../../src/tools/types.js";
+import { bindAdmittedToolHarness } from "../helpers/admitted-tool-harness.js";
 
 const READ_ONLY_TOOLS = ["web_fetch", "WebSearch", "XSearch", "Sleep"] as const;
 const READ_ONLY_EFFECT_EXCEPTIONS: Readonly<Record<string, string>> = {
@@ -63,54 +56,11 @@ function registeredTool(name: string): Tool {
 }
 
 function admissionHarness(toolPermissionContext = createEmptyToolPermissionContext()) {
-  const events: Event[] = [];
-  const eventLog = new EventLog();
-  eventLog.subscribe((event) => events.push(event));
-  const acquire = vi.fn(async (input: AdmissionAcquireInput): Promise<AdmissionLease> => ({
-    decision: "allow",
-    reservation: {
-      reservationId: input.stepId,
-      step: { runId: "run-web-recovery", stepId: input.stepId },
-      reservedCostUsd: input.maxCostUsd ?? 0,
-      reservedTokens: input.maxInputTokens + input.maxOutputTokens,
-      reservedAt: "2026-09-07T00:00:00.000Z",
-    },
-    request: {
-      step: { runId: "run-web-recovery", stepId: input.stepId },
-      kind: input.kind,
-      estimate: {
-        maxInputTokens: input.maxInputTokens,
-        maxOutputTokens: input.maxOutputTokens,
-        maxCostUsd: input.maxCostUsd,
-      },
-      workspaceId: workspaceRoot,
-      sessionId: "session-web-recovery",
-      parentScopeId: "turn-web-recovery",
-      autonomous: false,
-    },
-    signal: new AbortController().signal,
-  }));
-  const admission = {
-    scope: { runId: "run-web-recovery" },
-    acquire,
-    markDispatched: vi.fn(),
-    reconcile: vi.fn(() => ({ applied: true, outcome: "reconciled" })),
-    holdUnknown: vi.fn(),
-    void: vi.fn(),
-    acknowledgeCompletion: vi.fn(),
-  } as unknown as ExecutionAdmissionClient;
-  const session = {
-    conversationId: "session-web-recovery",
-    eventLog,
-    emit: (event: Event) => eventLog.emit(event),
-    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
-    services: {
-      executionAdmission: admission,
-      admissionRequired: true,
-      permissionModeRegistry: new PermissionModeRegistry(toolPermissionContext),
-    },
-  } as unknown as Session;
-  return { session, events, acquire };
+  return bindAdmittedToolHarness({
+    workspaceRoot,
+    label: "web-recovery",
+    toolPermissionContext,
+  });
 }
 
 describe("production read-only tool recovery", () => {

--- a/runtime/tests/tools/refusal-session-gate.test.ts
+++ b/runtime/tests/tools/refusal-session-gate.test.ts
@@ -5,19 +5,12 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createModelFacingTools } from "../../src/bin/model-facing-tools.js";
-import type {
-  AdmissionAcquireInput,
-  ExecutionAdmissionClient,
-} from "../../src/budget/admission-client.js";
-import type { AdmissionLease } from "../../src/budget/admission-types.js";
 import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
 import { LiveEffectMutationBlockedError } from "../../src/budget/effect-settlement-supervisor.js";
-import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
-import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
-import { EventLog, type Event } from "../../src/session/event-log.js";
 import type { Session } from "../../src/session/session.js";
 import { buildToolRegistry, type ToolRegistry } from "../../src/tool-registry.js";
 import type { Tool } from "../../src/tools/types.js";
+import { bindAdmittedToolHarness } from "../helpers/admitted-tool-harness.js";
 
 /**
  * #2190. `Skill` and `SendUserMessage` read as read-only in their metadata and
@@ -57,59 +50,6 @@ function registeredTool(name: string): Tool {
   return tool;
 }
 
-function admissionHarness(): { readonly session: Session; readonly events: Event[] } {
-  const events: Event[] = [];
-  const eventLog = new EventLog();
-  eventLog.subscribe((event) => events.push(event));
-  const acquire = vi.fn(async (input: AdmissionAcquireInput): Promise<AdmissionLease> => ({
-    decision: "allow",
-    reservation: {
-      reservationId: input.stepId,
-      step: { runId: "run-refusal-gate", stepId: input.stepId },
-      reservedCostUsd: input.maxCostUsd ?? 0,
-      reservedTokens: input.maxInputTokens + input.maxOutputTokens,
-      reservedAt: "2026-09-08T00:00:00.000Z",
-    },
-    request: {
-      step: { runId: "run-refusal-gate", stepId: input.stepId },
-      kind: input.kind,
-      estimate: {
-        maxInputTokens: input.maxInputTokens,
-        maxOutputTokens: input.maxOutputTokens,
-        maxCostUsd: input.maxCostUsd,
-      },
-      workspaceId: workspaceRoot,
-      sessionId: "session-refusal-gate",
-      parentScopeId: "turn-refusal-gate",
-      autonomous: false,
-    },
-    signal: new AbortController().signal,
-  }));
-  const admission = {
-    scope: { runId: "run-refusal-gate" },
-    acquire,
-    markDispatched: vi.fn(),
-    reconcile: vi.fn(() => ({ applied: true, outcome: "reconciled" })),
-    holdUnknown: vi.fn(),
-    void: vi.fn(),
-    acknowledgeCompletion: vi.fn(),
-  } as unknown as ExecutionAdmissionClient;
-  const session = {
-    conversationId: "session-refusal-gate",
-    eventLog,
-    emit: (event: Event) => eventLog.emit(event),
-    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
-    services: {
-      executionAdmission: admission,
-      admissionRequired: true,
-      permissionModeRegistry: new PermissionModeRegistry(
-        createEmptyToolPermissionContext(),
-      ),
-    },
-  } as unknown as Session;
-  return { session, events };
-}
-
 /** Dispatch the way the executor does: cross the boundary, then execute. */
 async function admitted(
   session: Session,
@@ -135,7 +75,10 @@ describe.each([
   { tool: "SendUserMessage", args: {} },
 ])("a refused $tool leaves the session able to mutate", ({ tool, args }) => {
   it("files no unknown effect and does not block the next write", async () => {
-    const { session, events } = admissionHarness();
+    const { session, events } = bindAdmittedToolHarness({
+      workspaceRoot,
+      label: "refusal-gate",
+    });
 
     const refused = await admitted(session, "refused-call", registeredTool(tool), args);
     expect(refused.isError).toBe(true);

--- a/runtime/tests/tools/refusal-session-gate.test.ts
+++ b/runtime/tests/tools/refusal-session-gate.test.ts
@@ -1,0 +1,155 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createModelFacingTools } from "../../src/bin/model-facing-tools.js";
+import type {
+  AdmissionAcquireInput,
+  ExecutionAdmissionClient,
+} from "../../src/budget/admission-client.js";
+import type { AdmissionLease } from "../../src/budget/admission-types.js";
+import { runAdmittedToolCall } from "../../src/budget/admitted-tool-call.js";
+import { LiveEffectMutationBlockedError } from "../../src/budget/effect-settlement-supervisor.js";
+import { PermissionModeRegistry } from "../../src/permissions/permission-mode.js";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { EventLog, type Event } from "../../src/session/event-log.js";
+import type { Session } from "../../src/session/session.js";
+import { buildToolRegistry, type ToolRegistry } from "../../src/tool-registry.js";
+import type { Tool } from "../../src/tools/types.js";
+
+/**
+ * #2190. `Skill` and `SendUserMessage` read as read-only in their metadata and
+ * side-effecting to the effect gate, so the mutating-tool sweep never saw them
+ * and their refusals stayed bare. A bare error result from a non-idempotent
+ * tool is filed as `effect_unknown_outcome`, poisons the live effect, and
+ * every later mutation of the session is refused until an operator runs
+ * /resolve. Both refusals below are made before the tool touches anything: the
+ * model named an MCP tool as a skill, or sent no message at all.
+ */
+
+let workspaceRoot: string;
+let registry: ToolRegistry;
+
+beforeEach(async () => {
+  workspaceRoot = await mkdtemp(join(tmpdir(), "agenc-refusal-gate-"));
+  registry = buildToolRegistry({
+    workspaceRoot,
+    agencHome: workspaceRoot,
+    modelFacingTools: createModelFacingTools({
+      workspaceRoot,
+      agencHome: workspaceRoot,
+      getSession: () => null,
+      env: {},
+    }),
+  });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+function registeredTool(name: string): Tool {
+  const tool = registry.tools.find((candidate) => candidate.name === name);
+  if (tool === undefined) throw new Error(`Missing production tool: ${name}`);
+  return tool;
+}
+
+function admissionHarness(): { readonly session: Session; readonly events: Event[] } {
+  const events: Event[] = [];
+  const eventLog = new EventLog();
+  eventLog.subscribe((event) => events.push(event));
+  const acquire = vi.fn(async (input: AdmissionAcquireInput): Promise<AdmissionLease> => ({
+    decision: "allow",
+    reservation: {
+      reservationId: input.stepId,
+      step: { runId: "run-refusal-gate", stepId: input.stepId },
+      reservedCostUsd: input.maxCostUsd ?? 0,
+      reservedTokens: input.maxInputTokens + input.maxOutputTokens,
+      reservedAt: "2026-09-08T00:00:00.000Z",
+    },
+    request: {
+      step: { runId: "run-refusal-gate", stepId: input.stepId },
+      kind: input.kind,
+      estimate: {
+        maxInputTokens: input.maxInputTokens,
+        maxOutputTokens: input.maxOutputTokens,
+        maxCostUsd: input.maxCostUsd,
+      },
+      workspaceId: workspaceRoot,
+      sessionId: "session-refusal-gate",
+      parentScopeId: "turn-refusal-gate",
+      autonomous: false,
+    },
+    signal: new AbortController().signal,
+  }));
+  const admission = {
+    scope: { runId: "run-refusal-gate" },
+    acquire,
+    markDispatched: vi.fn(),
+    reconcile: vi.fn(() => ({ applied: true, outcome: "reconciled" })),
+    holdUnknown: vi.fn(),
+    void: vi.fn(),
+    acknowledgeCompletion: vi.fn(),
+  } as unknown as ExecutionAdmissionClient;
+  const session = {
+    conversationId: "session-refusal-gate",
+    eventLog,
+    emit: (event: Event) => eventLog.emit(event),
+    rolloutStore: { assertToolAdmissionAllowed: vi.fn() },
+    services: {
+      executionAdmission: admission,
+      admissionRequired: true,
+      permissionModeRegistry: new PermissionModeRegistry(
+        createEmptyToolPermissionContext(),
+      ),
+    },
+  } as unknown as Session;
+  return { session, events };
+}
+
+/** Dispatch the way the executor does: cross the boundary, then execute. */
+async function admitted(
+  session: Session,
+  callId: string,
+  tool: Tool,
+  args: Record<string, unknown>,
+): Promise<{ readonly isError?: boolean; readonly content: string }> {
+  return runAdmittedToolCall({
+    session,
+    turnId: "turn-refusal-gate",
+    callId,
+    tool,
+    args,
+    invoke: async ({ crossEffectBoundary }) => {
+      crossEffectBoundary();
+      return tool.execute(args);
+    },
+  });
+}
+
+describe.each([
+  { tool: "Skill", args: { skill: "mcp.linear.create_issue" } },
+  { tool: "SendUserMessage", args: {} },
+])("a refused $tool leaves the session able to mutate", ({ tool, args }) => {
+  it("files no unknown effect and does not block the next write", async () => {
+    const { session, events } = admissionHarness();
+
+    const refused = await admitted(session, "refused-call", registeredTool(tool), args);
+    expect(refused.isError).toBe(true);
+    expect(events.some((event) => event.msg.type === "effect_unknown_outcome")).toBe(
+      false,
+    );
+
+    const filePath = join(workspaceRoot, "after-refusal.txt");
+    const outcome = await admitted(session, "write-after-refusal", registeredTool("Write"), {
+      file_path: filePath,
+      content: "written after the refusal",
+    }).catch((error: unknown) => error);
+
+    expect(outcome).not.toBeInstanceOf(LiveEffectMutationBlockedError);
+    expect(await readFile(filePath, "utf8")).toBe("written after the refusal");
+  });
+});


### PR DESCRIPTION
## Why

Closes #2190.

First checked what had already landed: the issue's proposals 1 and 3 are merged (#2189 write_stdin, #2191 apply_patch, #2193 filesystem/kill_process/sleep/monitor, #2195 spawn_agent, #2206 Task+worktree, #2207 Imagine/Browser/code-mode, #2209 the sweep). The parent's local clone of main was stale at f93ef2ace, so I fetched the real upstream and based the branch on GitHub main a6a431739 ("fix(runtime): isolate project storage with versioned canonical keys (#2308)").

The class defect is still real, because the #2209 sweep guards the wrong population. runtime/tests/tools/mutating-refusals.sweep.test.ts enumerated tools by `metadata.mutating === true`, while the gate in runtime/src/budget/admitted-tool-call.ts:948 poisons the live effect for every tool whose `recoveryCategory ?? "side-effecting"` is not "idempotent". I enumerated both populations in a scratch test: of 80 built-in tools, 42 are gated, 36 are swept, and 7 are gated but unswept. Calling those 7 with `{}` showed two returning a bare error result: `Skill` -> `{"error":"skill is required"}` and `SendUserMessage` -> `{"error":"message is required"}`, neither with an effectDisposition. Both are `isReadOnly: true` with `recoveryCategory: "side-effecting"` (they are literally listed as read-only-but-side-effecting exceptions in runtime/tests/tools/read-only-recovery-category.test.ts:26-32).

Fix, both mechanical and in the issue's proposal-1 shape: every refusal in those two tools is made before the tool's only effect (re

## Evidence

Measured on the branch base a6a431739 (real upstream main), not asserted.

BEFORE, end to end through the production dispatch path (runtime/tests/tools/refusal-session-gate.test.ts drives `runAdmittedToolCall` exactly as the executor does: crossEffectBoundary(), then tool.execute):
- `Skill` called with `{ skill: "mcp.linear.create_issue" }` (the mistake its own description warns against) returned isError with no disposition; an `effect_unknown_outcome` event was emitted, and the next `Write` rejected with: "LiveEffectMutationBlockedError: live effect settlement is unresolved for refused-call (Skill); side-effecting and interactive dispatch remain blocked. ... ask the user to run `/resolve refused-call ...`". Stack: assertNoLiveUnknownEffect src/budget/effect-settlement-supervisor.ts:103 <- runAdmittedToolCall src/budget/admitted-tool-call.ts:777. Same for `SendUserMessage` with `{}`.
- Reason string is set at runtime/src/budget/admitted-tool-call.ts:953, `tool_error_result_without_authoritative_effect_disposition`, right after poisonLiveEffect at :948.

Population measurement (scratch test, deleted): 80 built-in tools total, 42 gated by `recoveryCategory !== "idempotent"`, 36 swept by `metadata.mutating`, 7 gated-but-unswept: system.mkdir, system.delete, system.move (all already carry the disposition from #2193), system.searchTools (accepts `{}`, no refusal), AskUserQuestion (

## Tests

Two tests, both failing before and passing after.

1. runtime/tests/tools/refusal-session-gate.test.ts (new, 155 lines): drives `runAdmittedToolCall` with the real registry tools and a mock admission client, once per tool (`Skill` with an MCP tool name as the skill, `SendUserMessage` with no message), and asserts the consequence rather than the field: the refusal is an error, no `effect_unknown_outcome` event is emitted, the next `Write` does not come back as `LiveEffectMutationBlockedError`, and the file is actually on disk afterwards.

2. runtime/tests/tools/mutating-refusals.sweep.test.ts (modified): `mutatingTools()` -> `gatedTools()`, now `metadata.mutating === true || (recoveryCategory ?? "side-effecting") !== "idempotent"`, i.e. the gate's own predicate, so a new tool that is read-only in metadata and side-effecting to the gate cannot ship a bare refusal unnoticed. The family assertion now names Skill and SendUserMessage so the predicate cannot be quietly narrowed back.

Failing first, on unfixed source:



## Review

An independent reviewer reproduced the measurements and reverted the change to confirm the tests fail without it.

Merge. The defect is real, reproduced end-to-end through the production dispatch path, and the fix is minimal, truthful, and correctly guarded. Every quantitative claim in the report was independently re-measured and matched exactly, including the one that was off by nothing that matters (one cited line number, 2842 vs the actual 2840). The tests are not inert and the change is a strict superset of the prior guard. Branch core/2190-effect-disposition-gate at a8431e656, based on real upstream main a6a431739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
