### PR TITLE
fix(llm): keep request cancellation active through body reads

### DIFF
--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -633,6 +633,15 @@ Its retry behavior is:
 - Session backoff base is **200 ms**.
 - After budget admission, model calls set `singleWireAttempt: true`: **no HTTP
   retry** on that lease. A retry needs a new reservation.
+
+Request deadlines and caller cancellation stay active through JSON, text,
+and non-2xx body consumption. A body-read failure after a successful HTTP
+status does not trigger a transport retry. An aborted or timed-out error body
+is not retried either.
+Body failures cancel the reader without waiting for a stalled cancellation
+callback. Completed reads release the reader, timers and abort listeners.
+Successful streams keep their separate streaming lifecycle and idle watchdog.
+
 Grok uses an SDK transport with a distinct retry contract: its default budget
 is **2**, `maxRetries` can override it, and the SDK owns retry eligibility and
 backoff. A `singleWireAttempt` still forces that SDK budget to **0**. Those are

--- a/runtime/src/llm/client-session.ts
+++ b/runtime/src/llm/client-session.ts
@@ -961,33 +961,28 @@ export class ProviderHttpClientSession {
       });
     }
     const text = await readResponseBodyText(response, attemptState.signal);
-    let data: T;
-    if (contentType.includes("application/json")) {
-      if (text.length > 0) {
-        try {
-          data = JSON.parse(text) as T;
-        } catch (error) {
-          throw createMalformedProviderJsonError({
-            providerName: this.config.providerName,
-            response,
-            body: text,
-            message: `Invalid JSON response from ${this.config.providerName}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          });
-        }
-      } else {
-        data = undefined as T;
+    const isJson = contentType.includes("application/json");
+    let data = undefined as T;
+    if (isJson && text.length > 0) {
+      try {
+        data = JSON.parse(text) as T;
+      } catch (error) {
+        throw createMalformedProviderJsonError({
+          providerName: this.config.providerName,
+          response,
+          body: text,
+          message: `Invalid JSON response from ${this.config.providerName}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        });
       }
-    } else if (text.trim().length > 0) {
+    } else if (!isJson && text.trim().length > 0) {
       throw createMalformedProviderJsonError({
         providerName: this.config.providerName,
         response,
         body: text,
         message: `Non-JSON response from ${this.config.providerName}; content-type=${contentType || "missing"}`,
       });
-    } else {
-      data = undefined as T;
     }
     if (
       prepared.continuation &&
@@ -1244,35 +1239,8 @@ export class ProviderHttpClientSession {
         return { response, attemptState };
       } catch (error) {
         attemptState.cleanup();
-        if (isFallbackTriggeredError(error)) {
-          throw error;
-        }
-        if (error instanceof ProviderHttpError) {
-          maybeEmitCapabilityDriftWarning(this.config, error);
-          throw error;
-        }
+        await this.waitForTransportRetry(error, options, retryBudget, attempt, responseReceived);
         consecutiveFallbackFailures = 0;
-        const transport = normalizeTransportError(error);
-        if (
-          !responseReceived &&
-          !options.singleWireAttempt &&
-          ((attempt < retryBudget.maxRetries &&
-            shouldRetryTransportError(transport, retryBudget)) ||
-            shouldRetryTlsCertificateError(transport, attempt))
-        ) {
-          const retryDelay = resolveRetryDelayMs(
-            this.config.providerName,
-            retryBudget,
-            attempt + 1,
-            this.config.emitWarning,
-          );
-          await sleep(
-            retryDelay.delayMs,
-            options.signal,
-          );
-          continue;
-        }
-        throw materializeTransportError(this.config.providerName, transport);
       }
     }
 
@@ -1356,39 +1324,41 @@ export class ProviderHttpClientSession {
         return { attempt, response, attemptState };
       } catch (error) {
         attemptState.cleanup();
-        if (isFallbackTriggeredError(error)) {
-          throw error;
-        }
-        if (error instanceof ProviderHttpError) {
-          maybeEmitCapabilityDriftWarning(this.config, error);
-          throw error;
-        }
+        await this.waitForTransportRetry(error, options, retryBudget, attempt, responseReceived);
         consecutiveFallbackFailures = 0;
-        const transport = normalizeTransportError(error);
-        if (
-          !responseReceived &&
-          !options.singleWireAttempt &&
-          ((attempt < retryBudget.maxRetries &&
-            shouldRetryTransportError(transport, retryBudget)) ||
-            shouldRetryTlsCertificateError(transport, attempt))
-        ) {
-          const retryDelay = resolveRetryDelayMs(
-            this.config.providerName,
-            retryBudget,
-            attempt + 1,
-            this.config.emitWarning,
-          );
-          await sleep(
-            retryDelay.delayMs,
-            options.signal,
-          );
-          continue;
-        }
-        throw materializeTransportError(this.config.providerName, transport);
       }
     }
 
     throw new Error(`${this.config.providerName} stream retry budget exhausted`);
+  }
+
+  private async waitForTransportRetry(
+    error: unknown,
+    options: ProviderHttpRequestOptions,
+    retryBudget: NormalizedRetryBudget,
+    attempt: number,
+    responseReceived: boolean,
+  ): Promise<void> {
+    if (isFallbackTriggeredError(error)) throw error;
+    if (error instanceof ProviderHttpError) {
+      maybeEmitCapabilityDriftWarning(this.config, error);
+      throw error;
+    }
+    const transport = normalizeTransportError(error);
+    const retryable =
+      !responseReceived &&
+      !options.singleWireAttempt &&
+      ((attempt < retryBudget.maxRetries &&
+        shouldRetryTransportError(transport, retryBudget)) ||
+        shouldRetryTlsCertificateError(transport, attempt));
+    if (!retryable) throw materializeTransportError(this.config.providerName, transport);
+    const retryDelay = resolveRetryDelayMs(
+      this.config.providerName,
+      retryBudget,
+      attempt + 1,
+      this.config.emitWarning,
+    );
+    await sleep(retryDelay.delayMs, options.signal);
   }
 
   private async fetchResponse(

--- a/runtime/src/llm/client-session.ts
+++ b/runtime/src/llm/client-session.ts
@@ -389,19 +389,44 @@ function throwCaptivePortalError(args: {
   response: Response;
   expected: "json" | "sse";
 }): never {
-  throw new LLMCaptivePortalError(args.providerName, {
+  const error = new LLMCaptivePortalError(args.providerName, {
     contentType: args.response.headers.get("content-type") ?? undefined,
     statusCode: args.response.status,
     url: args.response.url,
     expected: args.expected,
   });
+  void args.response.body?.cancel(error).catch(() => {});
+  throw error;
 }
 
-async function readErrorBody(response: Response): Promise<unknown> {
+async function readResponseBodyText(response: Response, signal?: AbortSignal): Promise<string> {
+  if (!response.body) {
+    if (signal?.aborted) throw abortReasonToError(signal.reason);
+    return "";
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  try {
+    for (;;) {
+      const next = await readWithAbort(reader, signal);
+      if (next.done) return text + decoder.decode();
+      text += decoder.decode(next.value, { stream: true });
+    }
+  } catch (error) {
+    void reader.cancel(error).catch(() => {});
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function readErrorBody(response: Response, signal?: AbortSignal): Promise<unknown> {
   try {
     const contentType = response.headers.get("content-type") ?? "";
-    return readErrorBodyText(contentType, await response.text());
+    return readErrorBodyText(contentType, await readResponseBodyText(response, signal));
   } catch {
+    if (signal?.aborted) throw abortReasonToError(signal.reason);
     return undefined;
   }
 }
@@ -710,8 +735,9 @@ function normalizeHeaders(
 async function createProviderHttpError(
   providerName: string,
   response: Response,
+  signal?: AbortSignal,
 ): Promise<ProviderHttpError> {
-  const errorBody = await readErrorBody(response);
+  const errorBody = await readErrorBody(response, signal);
   const retryAfterDirective = parseProviderRetryAfterDirective(
     response.headers,
   );
@@ -742,10 +768,13 @@ function createMalformedProviderJsonError(args: {
   });
 }
 
-interface PreparedStreamAttempt {
-  readonly attempt: number;
+interface PreparedResponseAttempt {
   readonly response: Response;
   readonly attemptState: ReturnType<typeof createAttemptAbortState>;
+}
+
+interface PreparedStreamAttempt extends PreparedResponseAttempt {
+  readonly attempt: number;
 }
 
 interface PreparedProviderHttpRequest {
@@ -895,9 +924,9 @@ export class ProviderHttpClientSession {
     options: ProviderHttpRequestOptions,
   ): Promise<ProviderHttpJsonResponse<T>> {
     const prepared = this.prepareRequest(options);
-    let response: Response;
+    let attempt: PreparedResponseAttempt;
     try {
-      response = await this.requestWithRetry(prepared.options, "request");
+      attempt = await this.requestWithRetry(prepared.options);
     } catch (error) {
       if (
         prepared.options.singleWireAttempt === true ||
@@ -908,11 +937,21 @@ export class ProviderHttpClientSession {
       }
       warnContinuationExpiry(this.config);
       clearContinuationState(this.config.responsesContinuationState);
-      response = await this.requestWithRetry(
+      attempt = await this.requestWithRetry(
         buildContinuationFallbackOptions(prepared),
-        "request",
       );
     }
+    try {
+      return await this.readJsonResponse<T>(attempt, prepared);
+    } finally {
+      attempt.attemptState.cleanup();
+    }
+  }
+
+  private async readJsonResponse<T>(
+    { response, attemptState }: PreparedResponseAttempt,
+    prepared: PreparedProviderHttpRequest,
+  ): Promise<ProviderHttpJsonResponse<T>> {
     const contentType = response.headers.get("content-type") ?? "";
     if (isHtmlContentType(contentType)) {
       throwCaptivePortalError({
@@ -921,7 +960,7 @@ export class ProviderHttpClientSession {
         expected: "json",
       });
     }
-    const text = await response.text();
+    const text = await readResponseBodyText(response, attemptState.signal);
     let data: T;
     if (contentType.includes("application/json")) {
       if (text.length > 0) {
@@ -973,13 +1012,17 @@ export class ProviderHttpClientSession {
   async requestText(
     options: ProviderHttpRequestOptions,
   ): Promise<ProviderHttpTextResponse> {
-    const response = await this.requestWithRetry(options, "request");
-    return {
-      data: await response.text(),
-      status: response.status,
-      headers: response.headers,
-      url: response.url,
-    };
+    const { response, attemptState } = await this.requestWithRetry(options);
+    try {
+      return {
+        data: await readResponseBodyText(response, attemptState.signal),
+        status: response.status,
+        headers: response.headers,
+        url: response.url,
+      };
+    } finally {
+      attemptState.cleanup();
+    }
   }
 
   async requestStream(
@@ -1131,14 +1174,11 @@ export class ProviderHttpClientSession {
 
   private async requestWithRetry(
     options: ProviderHttpRequestOptions,
-    mode: "request" | "stream",
-  ): Promise<Response> {
+  ): Promise<PreparedResponseAttempt> {
     const retryBudget = normalizeRetryBudget(
-      mode === "stream" ? this.config.streamRetry : this.config.requestRetry,
+      this.config.requestRetry,
       options.retryBudget,
-      mode === "stream"
-        ? DEFAULT_STREAM_RETRY_POLICY
-        : DEFAULT_REQUEST_RETRY_POLICY,
+      DEFAULT_REQUEST_RETRY_POLICY,
     );
     const maxAttempts = options.singleWireAttempt
       ? 1
@@ -1152,18 +1192,21 @@ export class ProviderHttpClientSession {
       attempt += 1
     ) {
       const attemptState = createAttemptAbortState(options.signal, timeoutMs);
+      let responseReceived = false;
       try {
         const response = await this.fetchResponse(
           options,
           attempt,
           attemptState.signal,
         );
-        attemptState.cleanup();
+        responseReceived = true;
         if (!response.ok) {
           const error = await createProviderHttpError(
             this.config.providerName,
             response,
+            attemptState.signal,
           );
+          attemptState.cleanup();
           const fallbackDecision = evaluateConfiguredProviderFallback(
             options.providerFallback ?? this.config.providerFallback,
             error,
@@ -1198,7 +1241,7 @@ export class ProviderHttpClientSession {
           }
           throw error;
         }
-        return response;
+        return { response, attemptState };
       } catch (error) {
         attemptState.cleanup();
         if (isFallbackTriggeredError(error)) {
@@ -1211,10 +1254,10 @@ export class ProviderHttpClientSession {
         consecutiveFallbackFailures = 0;
         const transport = normalizeTransportError(error);
         if (
-          (!options.singleWireAttempt &&
-            attempt < retryBudget.maxRetries &&
+          !responseReceived &&
+          !options.singleWireAttempt &&
+          ((attempt < retryBudget.maxRetries &&
             shouldRetryTransportError(transport, retryBudget)) ||
-          (!options.singleWireAttempt &&
             shouldRetryTlsCertificateError(transport, attempt))
         ) {
           const retryDelay = resolveRetryDelayMs(
@@ -1254,16 +1297,19 @@ export class ProviderHttpClientSession {
       attempt += 1
     ) {
       const attemptState = createAttemptAbortState(options.signal, timeoutMs);
+      let responseReceived = false;
       try {
         const response = await this.fetchResponse(
           options,
           attempt,
           attemptState.signal,
         );
+        responseReceived = true;
         if (!response.ok) {
           const error = await createProviderHttpError(
             this.config.providerName,
             response,
+            attemptState.signal,
           );
           const fallbackDecision = evaluateConfiguredProviderFallback(
             options.providerFallback ?? this.config.providerFallback,
@@ -1320,10 +1366,10 @@ export class ProviderHttpClientSession {
         consecutiveFallbackFailures = 0;
         const transport = normalizeTransportError(error);
         if (
-          (!options.singleWireAttempt &&
-            attempt < retryBudget.maxRetries &&
+          !responseReceived &&
+          !options.singleWireAttempt &&
+          ((attempt < retryBudget.maxRetries &&
             shouldRetryTransportError(transport, retryBudget)) ||
-          (!options.singleWireAttempt &&
             shouldRetryTlsCertificateError(transport, attempt))
         ) {
           const retryDelay = resolveRetryDelayMs(

--- a/runtime/tests/llm/client-session-body-lifetime.test.ts
+++ b/runtime/tests/llm/client-session-body-lifetime.test.ts
@@ -1,0 +1,222 @@
+import { getEventListeners } from "node:events";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  ProviderHttpClientSession,
+  ProviderHttpError,
+} from "../../src/llm/client-session.js";
+import { LLMCaptivePortalError } from "../../src/llm/errors.js";
+import {
+  createControlledPromise,
+  drainMicrotasks,
+  settleWithinMicrotasks,
+} from "../helpers/controlled-async.js";
+
+type RequestMode = "json" | "text" | "stream";
+
+function createBodyFixture(options: {
+  status?: number;
+  contentType?: string;
+  cancel?: () => Promise<void>;
+} = {}) {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const cancel = vi.fn(options.cancel ?? (() => undefined));
+  const body = new ReadableStream<Uint8Array>({
+    start(value) { controller = value; },
+    cancel,
+  });
+  const signals: AbortSignal[] = [];
+  const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+    if (init?.signal) signals.push(init.signal);
+    return new Response(body, {
+      status: options.status ?? 200,
+      headers: { "content-type": options.contentType ?? "application/json" },
+    });
+  });
+  const session = new ProviderHttpClientSession({
+    providerName: "fixture",
+    baseURL: "https://fixture.invalid",
+    wireApi: "chat_completions",
+    timeoutMs: 50,
+    requestRetry: { maxRetries: 2 },
+    streamRetry: { maxRetries: 2 },
+    fetchImpl,
+  });
+  return {
+    body, controller, cancel, signals, fetchImpl, session,
+    dispose: () => controller.error(new Error("fixture cleanup")),
+  };
+}
+
+function startRequest(
+  session: ProviderHttpClientSession,
+  mode: RequestMode,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  if (mode === "text") return session.requestText({ signal });
+  if (mode === "stream") return session.requestStream({ signal });
+  return session.requestJson({ signal });
+}
+
+const stalledCases: Array<{ mode: RequestMode; status: number }> = [
+  { mode: "json", status: 200 },
+  { mode: "text", status: 200 },
+  { mode: "json", status: 503 },
+  { mode: "stream", status: 503 },
+];
+
+describe("provider response body lifetime", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  test.each(stalledCases)("times out stalled $mode/$status bodies without replay", async ({ mode, status }) => {
+    const fixture = createBodyFixture({ status });
+    const caller = new AbortController();
+    const observed = startRequest(fixture.session, mode, caller.signal).catch(error => error);
+    try {
+      await drainMicrotasks(20);
+      expect(fixture.body.locked).toBe(true);
+      vi.advanceTimersByTime(50);
+      expect(await settleWithinMicrotasks(observed)).toMatchObject({
+        status: "fulfilled", value: { message: expect.stringContaining("timed out") },
+      });
+      expect(fixture.signals[0]?.aborted).toBe(true);
+      expect(fixture.cancel).toHaveBeenCalledTimes(1);
+      expect(fixture.body.locked).toBe(false);
+      expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      caller.abort(new DOMException("fixture cleanup", "AbortError"));
+      fixture.dispose();
+      await observed;
+    }
+  });
+
+  test.each(stalledCases)("cancels stalled $mode/$status bodies after headers", async ({ mode, status }) => {
+    const fixture = createBodyFixture({ status });
+    const caller = new AbortController();
+    const reason = new DOMException("caller cancelled", "AbortError");
+    const observed = startRequest(fixture.session, mode, caller.signal).catch(error => error);
+    try {
+      await drainMicrotasks(20);
+      caller.abort(reason);
+      expect(await settleWithinMicrotasks(observed)).toMatchObject({ status: "fulfilled", value: reason });
+      expect(fixture.signals[0]?.aborted).toBe(true);
+      expect(fixture.cancel).toHaveBeenCalledTimes(1);
+      expect(fixture.body.locked).toBe(false);
+      expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      caller.abort(new DOMException("fixture cleanup", "AbortError"));
+      fixture.dispose();
+      await observed;
+    }
+  });
+
+  test.each(["json", "text"] as const)("releases %s body timers and listeners after success", async mode => {
+    const fixture = createBodyFixture();
+    const caller = new AbortController();
+    const pending = startRequest(fixture.session, mode, caller.signal).catch(error => error);
+    const encoded = new TextEncoder().encode('{"value":"café"}');
+    try {
+      await drainMicrotasks(20);
+      vi.advanceTimersByTime(49);
+      fixture.controller.enqueue(encoded.slice(0, 14));
+      fixture.controller.enqueue(encoded.slice(14));
+      fixture.controller.close();
+      await expect(pending).resolves.toMatchObject({
+        data: mode === "json" ? { value: "café" } : '{"value":"café"}',
+      });
+      expect(fixture.cancel).not.toHaveBeenCalled();
+      expect(fixture.body.locked).toBe(false);
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+      vi.advanceTimersByTime(100);
+      expect(fixture.signals[0]?.aborted).toBe(false);
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  test.each(["json", "stream"] as const)("releases %s error-body resources after a complete response", async mode => {
+    const fixture = createBodyFixture({ status: 401 });
+    const caller = new AbortController();
+    const observed = startRequest(fixture.session, mode, caller.signal).catch(error => error);
+    try {
+      await drainMicrotasks(20);
+      fixture.controller.enqueue(new TextEncoder().encode('{"error":{"message":"expired"}}'));
+      fixture.controller.close();
+      expect(await observed).toMatchObject({
+        name: "ProviderHttpError", status: 401, message: "expired",
+      });
+      expect(fixture.cancel).not.toHaveBeenCalled();
+      expect(fixture.body.locked).toBe(false);
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  test.each(["json", "stream"] as const)("cancels an unread %s HTML body on early rejection", async mode => {
+    const fixture = createBodyFixture({ contentType: "text/html" });
+    const caller = new AbortController();
+    try {
+      await expect(startRequest(fixture.session, mode, caller.signal)).rejects.toBeInstanceOf(LLMCaptivePortalError);
+      expect(fixture.cancel).toHaveBeenCalledTimes(1);
+      expect(fixture.body.locked).toBe(false);
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  test("does not wait for a stalled body cancellation callback", async () => {
+    const cancellationGate = createControlledPromise<void>();
+    const fixture = createBodyFixture({ cancel: () => cancellationGate.promise });
+    const caller = new AbortController();
+    const observed = fixture.session.requestJson({ signal: caller.signal }).catch(error => error);
+    try {
+      await drainMicrotasks(20);
+      caller.abort(new DOMException("caller cancelled", "AbortError"));
+      expect(await settleWithinMicrotasks(observed)).toMatchObject({
+        status: "fulfilled", value: { name: "AbortError" },
+      });
+      expect(fixture.cancel).toHaveBeenCalledTimes(1);
+      expect(fixture.body.locked).toBe(false);
+      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      cancellationGate.resolve();
+      fixture.dispose();
+      await observed;
+    }
+  });
+
+  test("does not replay a successful response after its body fails", async () => {
+    const fixture = createBodyFixture();
+    const caller = new AbortController();
+    const failure = new Error("body socket ECONNRESET");
+    const observed = fixture.session.requestJson({ signal: caller.signal }).catch(error => error);
+    await drainMicrotasks(20);
+    fixture.controller.error(failure);
+    expect(await observed).toBe(failure);
+    expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fixture.body.locked).toBe(false);
+    expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("preserves HTTP errors when a non-abort error body fails", async () => {
+    const fixture = createBodyFixture({ status: 401 });
+    const observed = fixture.session.requestJson({}).catch(error => error);
+    await drainMicrotasks(20);
+    fixture.controller.error(new Error("error body socket ECONNRESET"));
+    expect(await observed).toBeInstanceOf(ProviderHttpError);
+    expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fixture.body.locked).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/runtime/tests/llm/client-session-body-lifetime.test.ts
+++ b/runtime/tests/llm/client-session-body-lifetime.test.ts
@@ -57,6 +57,15 @@ function startRequest(
   return session.requestJson({ signal });
 }
 
+function expectCancelledBody(fixture: ReturnType<typeof createBodyFixture>, caller: AbortController): void {
+  expect(fixture.signals[0]?.aborted).toBe(true);
+  expect(fixture.cancel).toHaveBeenCalledTimes(1);
+  expect(fixture.body.locked).toBe(false);
+  expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
+  expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
+  expect(vi.getTimerCount()).toBe(0);
+}
+
 const stalledCases: Array<{ mode: RequestMode; status: number }> = [
   { mode: "json", status: 200 },
   { mode: "text", status: 200 },
@@ -79,12 +88,7 @@ describe("provider response body lifetime", () => {
       expect(await settleWithinMicrotasks(observed)).toMatchObject({
         status: "fulfilled", value: { message: expect.stringContaining("timed out") },
       });
-      expect(fixture.signals[0]?.aborted).toBe(true);
-      expect(fixture.cancel).toHaveBeenCalledTimes(1);
-      expect(fixture.body.locked).toBe(false);
-      expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
-      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
-      expect(vi.getTimerCount()).toBe(0);
+      expectCancelledBody(fixture, caller);
     } finally {
       caller.abort(new DOMException("fixture cleanup", "AbortError"));
       fixture.dispose();
@@ -101,12 +105,7 @@ describe("provider response body lifetime", () => {
       await drainMicrotasks(20);
       caller.abort(reason);
       expect(await settleWithinMicrotasks(observed)).toMatchObject({ status: "fulfilled", value: reason });
-      expect(fixture.signals[0]?.aborted).toBe(true);
-      expect(fixture.cancel).toHaveBeenCalledTimes(1);
-      expect(fixture.body.locked).toBe(false);
-      expect(fixture.fetchImpl).toHaveBeenCalledTimes(1);
-      expect(getEventListeners(caller.signal, "abort")).toHaveLength(0);
-      expect(vi.getTimerCount()).toBe(0);
+      expectCancelledBody(fixture, caller);
     } finally {
       caller.abort(new DOMException("fixture cleanup", "AbortError"));
       fixture.dispose();


### PR DESCRIPTION
## Changes

- Keep request deadlines and caller cancellation active until JSON, text and non-2xx bodies finish reading. Transfer successful streams to their existing streaming lifecycle.
- Cancel failed or unread bodies and release their readers, timers and abort listeners. Do not wait for a stalled cancellation callback.
- Preserve pre-response transport retries, completed HTTP-status retries, provider fallback and Responses continuation handling. Do not replay requests after successful-response body failures or aborted/timed-out error bodies.
- Remove the unused stream mode from the private non-stream retry method. Share the response-attempt state shape with stream attempts.
- Share transport retry handling between request and stream-open attempts and flatten JSON parsing. These changes remove the duplication and complexity reported by Sonar without changing retry or parsing behavior.
- Add 17 deterministic body-lifetime tests and document the behavior.

## Validation

- All 17 new tests fail against the original implementation, including all JSON/text/error-body deadline and cancellation cases.
- Docker-isolated LLM suite and runtime/test-support typechecks pass: 2,098 tests across 107 files, zero skips.
- Bun 1.3.12 passes all 17 new tests. The tests use fake time and controlled streams rather than wall-clock sleeps.
- GitNexus rates the shared HTTP client critical-risk, with six direct callers and two flows; requestJson has ten direct callers. Impacts ran before source edits, and the staged scope was checked before commit.
- Final root `npm test` passes on 20fa743392d1489f49f2319e83cbf4d9400c67a1: 23,566 runtime tests across 2,279 files, zero failures/skips, plus root and launcher checks. Final build/generated SDK and all PTY startup checks pass. The unaffected supported Linux native slice passes 92 tests. Darwin and Windows native execution is not claimed.
- After retry extraction, all 2,098 LLM tests, both typechecks and 17 Bun tests pass again. Final Cursor Bugbot, Security and Approval checks pass; the earlier approval remains recorded. Sonar reports zero new issues and zero duplication.
- No changed production module is in the current FND measured closure. Hosted test workflows remain disabled, and no Actions runs are requested.

Fixes #2061.
