### PR TITLE
fix(gateway): observe streaming delivery failures immediately

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -443,3 +443,11 @@ inbound callback), `stop`, and `send` (return the channel-native message id;
 `StdioChannelAdapter`, `TelegramChannelAdapter`, `DiscordChannelAdapter`,
 `SlackChannelAdapter`, `WebChatChannelAdapter`. Register in `startGateway`
 (`runtime/src/gateway/run.ts`).
+
+The session router observes a rejected `send` immediately, including a failed
+streaming edit. It stops queued sends and ignores later text chunks for that
+turn. The first delivery error is returned after the active prompt settles,
+and the conversation lock is then released. `GatewaySession` has no prompt
+cancellation operation, so a delivery failure does not cancel model execution
+or allow another turn to overlap it. Adapter failures never trigger the
+missing-daemon-agent retry, even when their error fields resemble that error.

--- a/runtime/src/gateway/session-router.ts
+++ b/runtime/src/gateway/session-router.ts
@@ -26,6 +26,7 @@ import type {
   GatewayDaemonClient,
   GatewayPermissionDecision,
   GatewayPermissionRequest,
+  GatewayPromptHandlers,
   GatewayPromptResult,
   GatewaySession,
 } from "./types.js";
@@ -50,6 +51,77 @@ export interface SessionRouterOptions {
 interface RoutedSession {
   readonly session: GatewaySession;
   readonly created: boolean;
+}
+
+type StreamedTurnOutcome =
+  | { readonly kind: "completed"; readonly result: GatewayPromptResult }
+  | { readonly kind: "prompt_failed" | "delivery_failed"; readonly error: unknown };
+
+async function streamPromptToAdapter(options: {
+  readonly session: GatewaySession;
+  readonly promptText: string;
+  readonly adapter: ChannelAdapter;
+  readonly conversationId: string;
+  readonly flushIntervalMs: number;
+  readonly onPermissionRequest: GatewayPromptHandlers["onPermissionRequest"];
+}): Promise<StreamedTurnOutcome> {
+  let buffer = "";
+  let sentMessageId: string | null = null;
+  let lastFlush = 0;
+  let flushing = Promise.resolve();
+  const delivery: { failure?: { readonly error: unknown } } = {};
+
+  const flush = (force: boolean): Promise<void> => {
+    if (delivery.failure !== undefined || buffer.length === 0) return flushing;
+    if (!options.adapter.supportsEdit && !force) return flushing;
+    const now = Date.now();
+    if (!force && now - lastFlush < options.flushIntervalMs) return flushing;
+    lastFlush = now;
+    const text = buffer;
+    flushing = flushing.then(async () => {
+      if (delivery.failure !== undefined) return;
+      if (options.adapter.supportsEdit && sentMessageId !== null) {
+        await options.adapter.send({
+          conversationId: options.conversationId,
+          text,
+          editMessageId: sentMessageId,
+        });
+      } else {
+        sentMessageId = await options.adapter.send({
+          conversationId: options.conversationId,
+          text,
+        });
+      }
+    }).catch((error: unknown) => {
+      delivery.failure ??= { error };
+    });
+    return flushing;
+  };
+
+  const outcome = await Promise.resolve().then(() =>
+    options.session.prompt(options.promptText, {
+      onEvent: (event) => {
+        if (event.type === "text" && delivery.failure === undefined) {
+          buffer += event.delta;
+          void flush(false);
+        }
+      },
+      onPermissionRequest: options.onPermissionRequest,
+    }),
+  ).then(
+    (result): StreamedTurnOutcome => ({ kind: "completed", result }),
+    (error: unknown): StreamedTurnOutcome => ({ kind: "prompt_failed", error }),
+  );
+  if (outcome.kind === "completed") {
+    if (outcome.result.finalMessage.length > 0) {
+      buffer = outcome.result.finalMessage;
+    }
+    await flush(true);
+  }
+  await flushing;
+  return delivery.failure === undefined
+    ? outcome
+    : { kind: "delivery_failed", error: delivery.failure.error };
 }
 
 export class SessionRouter {
@@ -195,79 +267,41 @@ export class SessionRouter {
     this.#turnLocks.set(options.key, lock);
     await previous;
     try {
-      const attempt = async (
+      const attempt = (
         session: GatewaySession,
         promptText: string,
-      ): Promise<GatewayPromptResult> => {
-        let buffer = "";
-        let sentMessageId: string | null = null;
-        let lastFlush = 0;
-        let flushing = Promise.resolve();
-
-        const flush = (force: boolean): Promise<void> => {
-          if (buffer.length === 0) return flushing;
-          if (!options.adapter.supportsEdit && !force) return flushing;
-          const now = Date.now();
-          if (!force && now - lastFlush < this.#flushIntervalMs) {
-            return flushing;
-          }
-          lastFlush = now;
-          const text = buffer;
-          flushing = flushing.then(async () => {
-            if (options.adapter.supportsEdit && sentMessageId !== null) {
-              await options.adapter.send({
-                conversationId: options.conversationId,
-                text,
-                editMessageId: sentMessageId,
-              });
-            } else {
-              sentMessageId = await options.adapter.send({
-                conversationId: options.conversationId,
-                text,
-              });
-            }
-          });
-          return flushing;
-        };
-
-        const result = await session.prompt(promptText, {
-          onEvent: (event) => {
-            if (event.type === "text") {
-              buffer += event.delta;
-              void flush(false);
-            }
-          },
+      ): Promise<StreamedTurnOutcome> =>
+        streamPromptToAdapter({
+          session,
+          promptText,
+          adapter: options.adapter,
+          conversationId: options.conversationId,
+          flushIntervalMs: this.#flushIntervalMs,
           onPermissionRequest: options.onPermissionRequest,
         });
 
-        // Final state always lands, even for non-edit adapters.
-        if (result.finalMessage.length > 0) {
-          buffer = result.finalMessage;
-        }
-        await flush(true);
-        return result;
-      };
-
       const routed = await this.#sessionFor(options.key);
-      let result: GatewayPromptResult;
-      try {
-        result = await attempt(
-          routed.session,
-          this.#textForSession(options.key, options.text, routed.created),
-        );
-      } catch (error) {
+      let outcome = await attempt(
+        routed.session,
+        this.#textForSession(options.key, options.text, routed.created),
+      );
+      if (
+        outcome.kind === "prompt_failed" &&
+        isDaemonAgentGoneError(outcome.error)
+      ) {
         // The daemon lost this session's backing agent (daemon restart,
         // agent stopped). Provision fresh and retry ONCE; a second failure
         // propagates. The bounded recovery journal supplies recent context
         // to the fresh session without replaying server evidence or secrets.
-        if (!isDaemonAgentGoneError(error)) throw error;
         this.#evictSession(options.key);
         const fresh = await this.#sessionFor(options.key);
-        result = await attempt(
+        outcome = await attempt(
           fresh.session,
           this.#textForSession(options.key, options.text, fresh.created),
         );
       }
+      if (outcome.kind !== "completed") throw outcome.error;
+      const result = outcome.result;
       if (options.memoryText !== undefined) {
         try {
           this.#recovery.record(

--- a/runtime/tests/gateway/fixtures/session-router-delivery.mjs
+++ b/runtime/tests/gateway/fixtures/session-router-delivery.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { SessionRouter } from "../../../src/gateway/session-router.ts";
+
+const [home, mode] = process.argv.slice(2);
+const prompt = Promise.withResolvers();
+const ready = Promise.withResolvers();
+const failure = new Error("strict-mode delivery failure");
+const failAt = mode === "edit" ? 2 : 1;
+let sends = 0;
+let promptSettled = false;
+const session = {
+  sessionId: "strict-session",
+  async prompt(_text, handlers) {
+    ready.resolve(handlers);
+    await prompt.promise;
+    promptSettled = true;
+    return { stopReason: "completed", finalMessage: "done" };
+  },
+};
+const router = new SessionRouter({
+  agencHome: home,
+  client: {
+    createSession: async () => session,
+    attachSession: async () => session,
+    close: async () => {},
+  },
+  flushIntervalMs: 0,
+});
+const outcome = router.runTurn({
+  key: "strict", text: "test", conversationId: "strict",
+  adapter: {
+    id: "strict", supportsEdit: true,
+    start: async () => {}, stop: async () => {},
+    send() {
+      sends += 1;
+      if (sends !== failAt) return Promise.resolve("message-id");
+      if (mode === "sync") throw failure;
+      return Promise.reject(failure);
+    },
+  },
+  onPermissionRequest: async () => ({ behavior: "deny" }),
+}).then(value => ({ value }), error => ({ error }));
+try {
+  const handlers = await ready.promise;
+  handlers.onEvent({ type: "text", delta: "first" });
+  await nextEventLoopTurn();
+  if (mode === "edit") {
+    handlers.onEvent({ type: "text", delta: "second" });
+  }
+  handlers.onEvent({ type: "text", delta: "queued" });
+  await nextEventLoopTurn();
+  handlers.onEvent({ type: "text", delta: "late" });
+  await nextEventLoopTurn();
+  assert.equal(promptSettled, false);
+  assert.equal(sends, failAt);
+  prompt.resolve();
+  assert.equal((await outcome).error, failure);
+  process.stdout.write(JSON.stringify({ mode, sends, retainedOriginalError: true }) + "\n");
+} finally {
+  prompt.resolve();
+  await outcome;
+}

--- a/runtime/tests/gateway/session-router-delivery.process.test.ts
+++ b/runtime/tests/gateway/session-router-delivery.process.test.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("SessionRouter strict rejection handling", () => {
+  it.each(["first", "edit", "sync"])("survives %s adapter failure with a pending prompt", (mode) => {
+    const home = mkdtempSync(join(tmpdir(), "agenc-router-strict-"));
+    const runtimeRoot = join(import.meta.dirname, "../..");
+    try {
+      const result = spawnSync(process.execPath, [
+        "--unhandled-rejections=strict", "--import", "tsx",
+        join(import.meta.dirname, "fixtures/session-router-delivery.mjs"), home, mode,
+      ], {
+        cwd: runtimeRoot,
+        env: { ...process.env, TSX_TSCONFIG_PATH: join(runtimeRoot, "tsconfig.json") },
+        encoding: "utf8", timeout: 5_000, maxBuffer: 64 * 1024,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        mode, sends: mode === "edit" ? 2 : 1, retainedOriginalError: true,
+      });
+      expect(result.stderr).not.toContain("PromiseRejectionHandledWarning");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/runtime/tests/gateway/session-router-delivery.test.ts
+++ b/runtime/tests/gateway/session-router-delivery.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SessionRouter } from "../../src/gateway/session-router.js";
+import type {
+  ChannelAdapter,
+  GatewayDaemonClient,
+  GatewayPromptHandlers,
+  GatewayPromptResult,
+  GatewaySession,
+} from "../../src/gateway/types.js";
+
+const completed: GatewayPromptResult = {
+  stopReason: "completed",
+  finalMessage: "final answer",
+};
+
+describe("SessionRouter delivery failures", () => {
+  let home: string;
+  let finishPrompt: ReturnType<typeof Promise.withResolvers<GatewayPromptResult>>;
+  let handlersReady: ReturnType<typeof Promise.withResolvers<GatewayPromptHandlers>>;
+  let promptCalls: number;
+  let sessionCreates: number;
+  let outcomes: Promise<unknown>[];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-router-delivery-"));
+    finishPrompt = Promise.withResolvers<GatewayPromptResult>();
+    handlersReady = Promise.withResolvers<GatewayPromptHandlers>();
+    promptCalls = 0;
+    sessionCreates = 0;
+    outcomes = [];
+  });
+
+  afterEach(async () => {
+    finishPrompt.resolve(completed);
+    await Promise.all(outcomes);
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function setup(send: ChannelAdapter["send"], supportsEdit = true) {
+    const session: GatewaySession = {
+      sessionId: "delivery-session",
+      prompt: async (_text, handlers) => {
+        promptCalls += 1;
+        if (promptCalls > 1) return completed;
+        handlersReady.resolve(handlers);
+        return finishPrompt.promise;
+      },
+    };
+    const client: GatewayDaemonClient = {
+      createSession: async () => { sessionCreates += 1; return session; },
+      attachSession: async () => session,
+      close: async () => {},
+    };
+    const adapter: ChannelAdapter = {
+      id: "test", supportsEdit, send,
+      start: async () => {}, stop: async () => {},
+    };
+    const router = new SessionRouter({ agencHome: home, client, flushIntervalMs: 0 });
+    return () => {
+      const outcome = router.runTurn({
+        key: "conversation", text: "request", conversationId: "conversation", adapter,
+        onPermissionRequest: async () => ({ behavior: "deny" }),
+      }).then(
+        (value) => ({ kind: "completed" as const, value }),
+        (error: unknown) => ({ kind: "failed" as const, error }),
+      );
+      outcomes.push(outcome);
+      return outcome;
+    };
+  }
+
+  it.each([1, 2])("observes send %s failure while prompt is pending and stops queued/later chunks", async (failAt) => {
+    const failure = new Error("delivery failed");
+    let sends = 0;
+    let lateDeltaReads = 0;
+    const run = setup(async () => {
+      sends += 1;
+      if (sends === failAt) throw failure;
+      return "message-id";
+    });
+    const first = run();
+    const handlers = await handlersReady.promise;
+    handlers.onEvent({ type: "text", delta: "first" });
+    await nextEventLoopTurn();
+    if (failAt === 2) {
+      handlers.onEvent({ type: "text", delta: "second" });
+    }
+    handlers.onEvent({ type: "text", delta: "queued" });
+    await nextEventLoopTurn();
+    handlers.onEvent({ type: "text", get delta() { lateDeltaReads += 1; return "late"; } });
+    const next = run();
+    await nextEventLoopTurn();
+    expect(promptCalls).toBe(1);
+    expect(sends).toBe(failAt);
+    expect(lateDeltaReads).toBe(0);
+    finishPrompt.resolve(completed);
+    await expect(first).resolves.toEqual({ kind: "failed", error: failure });
+    await expect(next).resolves.toEqual({ kind: "completed", value: completed });
+    expect(promptCalls).toBe(2);
+    expect(sends).toBe(failAt + 1);
+  });
+
+  it.each([undefined, null, "delivery rejected", { reason: "delivery rejected" }])(
+    "retains the first delivery rejection when the prompt also fails (%j)",
+    async (failure) => {
+      const run = setup(async () => { throw failure; });
+      const outcome = run();
+      const handlers = await handlersReady.promise;
+      handlers.onEvent({ type: "text", delta: "first" });
+      await nextEventLoopTurn();
+      finishPrompt.reject(new Error("later prompt failure"));
+      const result = await outcome;
+      expect(result.kind).toBe("failed");
+      expect("error" in result && result.error).toBe(failure);
+    },
+  );
+
+  it("does not replay the prompt when an adapter failure resembles a missing daemon agent", async () => {
+    const failure = Object.assign(new Error("adapter agent missing"), {
+      data: { code: "AGENT_NOT_FOUND" },
+    });
+    const run = setup(async () => { throw failure; });
+    const outcome = run();
+    const handlers = await handlersReady.promise;
+    handlers.onEvent({ type: "text", delta: "first" });
+    await nextEventLoopTurn();
+    finishPrompt.resolve(completed);
+    await expect(outcome).resolves.toEqual({ kind: "failed", error: failure });
+    expect(sessionCreates).toBe(1);
+    expect(promptCalls).toBe(1);
+  });
+
+  it("reports final-only adapter failure and releases the conversation lock", async () => {
+    const failure = new Error("final delivery failed");
+    let sends = 0;
+    const run = setup(async () => {
+      sends += 1;
+      if (sends === 1) throw failure;
+      return "message-id";
+    }, false);
+    const first = run();
+    const handlers = await handlersReady.promise;
+    handlers.onEvent({ type: "text", delta: "buffered" });
+    await nextEventLoopTurn();
+    expect(sends).toBe(0);
+    finishPrompt.resolve(completed);
+    await expect(first).resolves.toEqual({ kind: "failed", error: failure });
+    await expect(run()).resolves.toEqual({ kind: "completed", value: completed });
+    expect(sends).toBe(2);
+  });
+
+  it("preserves a prompt failure without inventing a final send", async () => {
+    const failure = new Error("prompt failed");
+    let sends = 0;
+    const run = setup(async () => { sends += 1; return "message-id"; }, false);
+    const outcome = run();
+    const handlers = await handlersReady.promise;
+    handlers.onEvent({ type: "text", delta: "partial" });
+    finishPrompt.reject(failure);
+    await expect(outcome).resolves.toEqual({ kind: "failed", error: failure });
+    expect(sends).toBe(0);
+  });
+});


### PR DESCRIPTION
## Change

Fixes #2064.

The router observes each adapter send/edit rejection as soon as the send chain is created. It retains the first delivery failure, including null or undefined rejection values, stops queued sends, and ignores later text chunks. The owning turn returns the original error after the active prompt settles and then releases its conversation lock.

Streaming delivery now returns an internal outcome that distinguishes prompt failure from delivery failure. Only a genuine missing-daemon-agent prompt failure can trigger session recreation and one retry. An adapter error with similar fields cannot replay the prompt. Successful throttling, final-only adapters, and forced final delivery remain covered.

No cancellation API was added. GatewaySession cannot cancel an active prompt, so the router keeps the conversation lock until that prompt settles rather than overlapping another model turn. Adapter documentation states this behavior.

## Local verification

- Original source failed 10 of the 12 new regressions and produced unhandled rejection errors. All three real Node child processes failed under --unhandled-rejections=strict before the fix.
- Both typechecks and all 346 gateway tests across 30 files pass in the Docker boundary, including the strict-mode first-send, edit, and synchronous-send failures.
- Bun 1.3.12 passes the nine delivery behavior tests.
- Final commit 57c69889d387d052b037ecaf3aba703ad9ae43ae passed build, generated SDK type checks, and all PTY startup checks.
- Full root npm test passed, including 23,612 runtime tests across 2,283 files with zero failures or skips. Git range-diff confirms the patch is unchanged after rebasing onto current main.
- The affected production module is outside the measured FND closure. No benchmark recapture is required.
- GitNexus reports low upstream impact on gateway turns and cron delivery. Staged detection is limited to the router, its tests, and adapter documentation; unchanged neighboring symbols in its report reflect index line drift.

Cursor approved the exact final commit. Bugbot, Approval, and Security checks all succeeded without review findings. The actual Sonar gate is OK with zero new issues and 0.0% duplicated lines.

Automatic GitHub Actions stay disabled. No workflow was dispatched, retried, or enabled; this branch has zero Actions runs.
