### PR TITLE
Reuse the validated rollout prefix across bookkeeping scans

### DIFF
--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -73,6 +73,7 @@ class DiskCompactionPayloadRegistry {
   readonly #select: BetterSqlite3.Statement<[string, string]>;
   readonly #count: BetterSqlite3.Statement<[string, string]>;
   #closed = false;
+  #retainedPayloadBytes = 0;
 
   constructor(temporaryRoot: string) {
     const directory = mkdtempSync(join(temporaryRoot, "agenc-c2-payloads-"));
@@ -149,8 +150,17 @@ class DiskCompactionPayloadRegistry {
     );
   }
 
-  reconstruct(manifest: CompactionPayloadManifestV1): unknown {
+  /**
+   * Rebuild a spooled payload. `retained` says whether the caller keeps the
+   * result: a scan that only proves a payload hands it straight back to the
+   * collector, while a hydrated lifecycle row holds it for as long as the
+   * scan state does.
+   */
+  reconstruct(manifest: CompactionPayloadManifestV1, retained = true): unknown {
     this.#assertOpen();
+    if (retained) {
+      this.#retainedPayloadBytes += manifest.canonical_utf8_bytes;
+    }
     const chunks = this.#select
       .all(manifest.attempt_id, manifest.payload_kind)
       .map((row) => {
@@ -167,6 +177,11 @@ class DiskCompactionPayloadRegistry {
         return parsed;
       });
     return reconstructCompactionPayloadV1(manifest, chunks);
+  }
+
+  /** Reconstructed payload bytes the caller is still holding. */
+  get retainedPayloadBytes(): number {
+    return this.#retainedPayloadBytes;
   }
 
   hasComplete(manifest: CompactionPayloadManifestV1): boolean {
@@ -330,18 +345,20 @@ interface ValidatedPrefix {
 const MAX_VALIDATED_PREFIXES = 2;
 
 /**
- * How much active history a scanner keeps between scans of one rollout.
+ * How much a scanner keeps in memory between scans of one rollout.
  *
- * A prefix that reduces active history holds a second copy of the whole
- * conversation, next to the one the runtime already has, and that copy grows
- * with the session. Everything else a prefix holds is the compaction
- * lifecycle, which its own retention budget already bounds. So a prefix that
- * grew past this ceiling answers its scan and is then released: the sessions
- * large enough to reach it are exactly the ones that can least afford the
- * second copy, and the bookkeeping calls that reduce no history - six of the
- * eight per compaction step - keep their prefix either way.
+ * Two of the things a prefix holds grow with the session rather than with the
+ * compaction budget. Reduced active history is a second copy of the whole
+ * conversation next to the one the runtime already has. The other is what a
+ * hydrated compaction lifecycle row reconstructs back into itself:
+ * `MAX_COMPACTION_LIFECYCLE_RECORDS` bounds how many rows a prefix retains,
+ * not how large one is, and a rollback row holds the entire pre-compaction
+ * conversation. A prefix past this ceiling answers its scan and is then
+ * released: the sessions large enough to reach it are the ones that can least
+ * afford a second copy, and the bookkeeping that stays small - six of the
+ * eight calls per compaction step - keeps its prefix either way.
  */
-const MAX_RETAINED_ACTIVE_HISTORY_BYTES = 4 * 1_024 * 1_024;
+const MAX_RETAINED_PREFIX_BYTES = 4 * 1_024 * 1_024;
 
 /** Validated prefixes, most recently used first. */
 interface PrefixOwner {
@@ -358,9 +375,10 @@ interface PrefixOwner {
  * digest must equal the incrementally maintained one, so a prefix that changed
  * underneath a reused validator fails the scan instead of answering from it.
  *
- * What it keeps is bounded: a prefix that reduced more than
- * `MAX_RETAINED_ACTIVE_HISTORY_BYTES` of active history, and a prefix keyed to
- * one attempt, are released once they have answered.
+ * What it keeps is bounded: a prefix holding more than
+ * `MAX_RETAINED_PREFIX_BYTES` of reduced history and hydrated compaction
+ * payload, and a prefix keyed to one attempt, are released once they have
+ * answered.
  *
  * Every prefix owns two disk registries, so a scanner must be closed.
  */
@@ -564,14 +582,15 @@ function scanCanonicalRolloutUntimed(
         historyAtAttempts: new Map(state.historyAtAttempts),
       };
       // Whether this prefix is worth keeping is only knowable now: how much
-      // history it reduced is a fact about the bytes it read. Deciding here
-      // also keeps a prefix that is about to be released from taking a slot
-      // away from one a later scan can still use. A prefix keyed to one
-      // attempt's history is never worth keeping - no later scan asks its
-      // question.
+      // history it reduced, and how much payload its lifecycle rows hold, are
+      // facts about the bytes it read. Deciding here also keeps a prefix that
+      // is about to be released from taking a slot away from one a later scan
+      // can still use. A prefix keyed to one attempt's history is never worth
+      // keeping - no later scan asks its question.
       if (
         (options.captureHistoryAtAttemptIds ?? []).length > 0 ||
-        state.activeSourceBytes > MAX_RETAINED_ACTIVE_HISTORY_BYTES
+        state.activeSourceBytes + prefix.payloadRegistry.retainedPayloadBytes >
+          MAX_RETAINED_PREFIX_BYTES
       ) {
         discardPrefix(owner, prefix);
       } else if (carried === undefined) {
@@ -1145,8 +1164,11 @@ function validatePersistedSourceHistory(
   persisted: CompactionPersistedIntentV1,
   payloadRegistry: DiskCompactionPayloadRegistry,
 ): void {
+  // Proving the chain is all this does with the payload; the reader below
+  // rejects it or drops it, so the prefix keeps nothing from here.
   const sourceHistory = payloadRegistry.reconstruct(
     persisted.source_history_manifest,
+    false,
   );
   // The inline rollback reader strictly validates projection messages and the
   // source-history digest before the value can participate in reconstruction.

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -329,6 +329,20 @@ interface ValidatedPrefix {
  */
 const MAX_VALIDATED_PREFIXES = 2;
 
+/**
+ * How much active history a scanner keeps between scans of one rollout.
+ *
+ * A prefix that reduces active history holds a second copy of the whole
+ * conversation, next to the one the runtime already has, and that copy grows
+ * with the session. Everything else a prefix holds is the compaction
+ * lifecycle, which its own retention budget already bounds. So a prefix that
+ * grew past this ceiling answers its scan and is then released: the sessions
+ * large enough to reach it are exactly the ones that can least afford the
+ * second copy, and the bookkeeping calls that reduce no history - six of the
+ * eight per compaction step - keep their prefix either way.
+ */
+const MAX_RETAINED_ACTIVE_HISTORY_BYTES = 4 * 1_024 * 1_024;
+
 /** Validated prefixes, most recently used first. */
 interface PrefixOwner {
   readonly prefixes: ValidatedPrefix[];
@@ -343,6 +357,10 @@ interface PrefixOwner {
  * scan of the same inode. The second pass still reads the whole file and its
  * digest must equal the incrementally maintained one, so a prefix that changed
  * underneath a reused validator fails the scan instead of answering from it.
+ *
+ * What it keeps is bounded: a prefix that reduced more than
+ * `MAX_RETAINED_ACTIVE_HISTORY_BYTES` of active history, and a prefix keyed to
+ * one attempt, are released once they have answered.
  *
  * Every prefix owns two disk registries, so a scanner must be closed.
  */
@@ -411,24 +429,24 @@ function scanCanonicalRolloutUntimed(
     }
     checkOperationalBudget();
     const fingerprint = prefixFingerprint(options);
+    const carried = reusablePrefix(owner, rolloutPath, fingerprint, snapshot);
     const prefix =
-      reusablePrefix(owner, rolloutPath, fingerprint, snapshot) ??
-      retainPrefix(
-        owner,
-        beginPrefix(rolloutPath, options, fingerprint, snapshot),
-      );
+      carried ?? beginPrefix(rolloutPath, options, fingerprint, snapshot);
     prefix.budget.check = checkOperationalBudget;
     const state = prefix.state;
     try {
       streamCanonicalTail(fd, snapshot.size, prefix, checkOperationalBudget);
       const first = prefix.validator.snapshot();
 
-      if (
-        state.latestCommittedAttempt !== undefined &&
+      // A file that ends mid-bookkeeping is a conclusion about where this
+      // scan stopped reading, not about the bytes: the session_meta that
+      // completes the window is appended straight after the boundary. Keeping
+      // it out of the carried-over state is what makes a reused prefix answer
+      // exactly as a full replay of the same bytes would.
+      const awaitingPostCommitMeta =
         state.postCommitBookkeeping === "await_meta"
-      ) {
-        state.latestCommittedAttempt.laterWork = true;
-      }
+          ? state.latestCommittedAttempt
+          : undefined;
       assertAttemptsReconstructed(state.attempts);
 
       checkOperationalBudget();
@@ -510,7 +528,7 @@ function scanCanonicalRolloutUntimed(
       assertMatchingProof(first, second);
       assertPinnedSnapshot(fd, snapshot);
       checkOperationalBudget();
-      return {
+      const scan: CanonicalRolloutScan = {
         proof: withoutRecords(first),
         attempts: new Map(
           [...state.attempts].map(([attemptId, attempt]) => [
@@ -519,7 +537,8 @@ function scanCanonicalRolloutUntimed(
               intent: attempt.intent!,
               records: Object.freeze(attempt.records.slice()),
               admissionValid: validAdmission(attempt),
-              hasLaterCanonicalWork: attempt.laterWork,
+              hasLaterCanonicalWork:
+                attempt.laterWork || attempt === awaitingPostCommitMeta,
               sourceHistoryRetained: attempt.sourceHistoryValidated === true,
               ...(attempt.sourceHistoryManifest !== undefined
                 ? { sourceHistoryManifest: attempt.sourceHistoryManifest }
@@ -544,6 +563,21 @@ function scanCanonicalRolloutUntimed(
           : {}),
         historyAtAttempts: new Map(state.historyAtAttempts),
       };
+      // Whether this prefix is worth keeping is only knowable now: how much
+      // history it reduced is a fact about the bytes it read. Deciding here
+      // also keeps a prefix that is about to be released from taking a slot
+      // away from one a later scan can still use. A prefix keyed to one
+      // attempt's history is never worth keeping - no later scan asks its
+      // question.
+      if (
+        (options.captureHistoryAtAttemptIds ?? []).length > 0 ||
+        state.activeSourceBytes > MAX_RETAINED_ACTIVE_HISTORY_BYTES
+      ) {
+        discardPrefix(owner, prefix);
+      } else if (carried === undefined) {
+        retainPrefix(owner, prefix);
+      }
+      return scan;
     } catch (error) {
       // Whatever failed may have left this prefix out of step with the
       // file: a partial push, or a second pass that rejected the digest it

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -354,9 +354,26 @@ const MAX_VALIDATED_PREFIXES = 2;
  * `MAX_COMPACTION_LIFECYCLE_RECORDS` bounds how many rows a prefix retains,
  * not how large one is, and a rollback row holds the entire pre-compaction
  * conversation. A prefix past this ceiling answers its scan and is then
- * released: the sessions large enough to reach it are the ones that can least
- * afford a second copy, and the bookkeeping that stays small - six of the
- * eight calls per compaction step - keeps its prefix either way.
+ * released, and the next scan replays the whole file exactly as it did before
+ * this scanner existed: past the ceiling there is no regression and no gain,
+ * so the reuse this file buys is only ever claimed below it.
+ *
+ * Where the ceiling actually bites, measured on real rollouts rather than
+ * argued: the one call per compaction step that reduces active history loses
+ * its prefix as soon as the session's own active history passes the ceiling,
+ * which is the shape #2229 opens with. The other seven reduce none, so they
+ * are charged only for what their lifecycle rows hydrate, and that is charged
+ * in persisted canonical bytes: about 266 B for every message a committed
+ * compaction pins, so a rollout carrying sixteen 1,000-message compactions
+ * releases even that prefix, while one rollback is charged the whole
+ * pre-compaction conversation and releases it at once.
+ *
+ * The charge is not what the prefix holds. A persisted ref hydrates back into
+ * a much larger object than its canonical bytes, so the count runs under the
+ * heap: eight such compactions counted 2.1 MB here and held 4.2 MB of settled
+ * heap. That keeps the bound a small constant - a few times this ceiling,
+ * times `MAX_VALIDATED_PREFIXES` - rather than the session-scaled retention
+ * the ceiling exists to prevent, but the constant is not this number.
  */
 const MAX_RETAINED_PREFIX_BYTES = 4 * 1_024 * 1_024;
 
@@ -1045,6 +1062,10 @@ function observeCanonicalRecord(
   const lifecycleAttemptId = item.payload.attempt_id;
   if (item.type === "compaction_intent") {
     state.attempts.set(lifecycleAttemptId, {
+      // Persisted intents arrive hydrated, and their bytes were counted
+      // against the retention ceiling on the way through the payload
+      // registry. An inline intent is retained here uncounted: no writer
+      // emits that shape today, and one that did would need counting here.
       intent: item.payload,
       records: [record],
       calls: new Map(),

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -640,9 +640,15 @@ function prefixFingerprint(options: CanonicalRolloutScanOptions): string {
     terminalPolicy: options.terminalPolicy ?? null,
     compactionSourceDigestDomain: options.compactionSourceDigestDomain,
     captureActiveHistory: options.captureActiveHistory === true,
+    /*
+     * Code-unit order, not `localeCompare`: this string keys a cache whose
+     * entries must match across machines, and locale-aware collation is not
+     * stable between them. A bare `.sort()` would do the same thing, but only
+     * by accident of these being strings.
+     */
     captureHistoryAtAttemptIds: [
       ...new Set(options.captureHistoryAtAttemptIds ?? []),
-    ].sort(),
+    ].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)),
   });
 }
 

--- a/runtime/src/session/canonical-rollout-scanner.ts
+++ b/runtime/src/session/canonical-rollout-scanner.ts
@@ -286,25 +286,111 @@ export interface CanonicalRolloutScanOptions extends Pick<
 }
 
 /**
+ * Pass-one state that survives between scans of the same rollout inode. It is
+ * exactly what replaying the validated prefix would rebuild, so a scanner that
+ * kept it only has to push the bytes appended since.
+ */
+interface MutableRolloutScanState {
+  readonly capturedAttemptIds: ReadonlySet<string>;
+  readonly trackHistory: boolean;
+  readonly attempts: Map<string, MutableAttemptScan>;
+  readonly payloadLineAttempts: Map<number, string>;
+  readonly historyAtAttempts: Map<string, readonly ResponseItem[]>;
+  readonly activeLineBytes: Map<number, number>;
+  reducedState: ReducedSessionState;
+  activePositions: CanonicalActiveHistoryPosition[];
+  activeSourceBytes: number;
+  retainedLifecycleRecords: number;
+  activeAdmissionAttempt: MutableAttemptScan | undefined;
+  latestCommittedAttempt: MutableAttemptScan | undefined;
+  postCommitBookkeeping: PostCommitBookkeeping;
+}
+
+interface ValidatedPrefix {
+  readonly rolloutPath: string;
+  /** Every scan option the first pass depends on, for reuse eligibility. */
+  readonly fingerprint: string;
+  readonly dev: bigint;
+  readonly ino: bigint;
+  /** Redirected to the running scan's deadline before every push. */
+  readonly budget: { check: () => void };
+  readonly validator: StrictCanonicalJournalValidator;
+  readonly identityRegistry: DiskCanonicalIdentityRegistry;
+  readonly payloadRegistry: DiskCompactionPayloadRegistry;
+  readonly state: MutableRolloutScanState;
+  validatedBytes: bigint;
+}
+
+/**
+ * How many validated prefixes one scanner keeps. Compaction bookkeeping asks
+ * two shapes of question about the same rollout, one that reduces the active
+ * history for a compaction source and one that does not, and evicting either
+ * to answer the other would replay the whole file for both.
+ */
+const MAX_VALIDATED_PREFIXES = 2;
+
+/** Validated prefixes, most recently used first. */
+interface PrefixOwner {
+  readonly prefixes: ValidatedPrefix[];
+}
+
+/**
+ * A rollout scanner that keeps the prefix it already validated.
+ *
+ * Compaction bookkeeping scans the same rollout several times per step, and
+ * every scan used to replay the whole file from zero, so the cost grew with
+ * the session. This scanner replays only the bytes appended since its last
+ * scan of the same inode. The second pass still reads the whole file and its
+ * digest must equal the incrementally maintained one, so a prefix that changed
+ * underneath a reused validator fails the scan instead of answering from it.
+ *
+ * Every prefix owns two disk registries, so a scanner must be closed.
+ */
+export class CanonicalRolloutScanner {
+  readonly #owner: PrefixOwner = { prefixes: [] };
+
+  scan(
+    rolloutPath: string,
+    options: CanonicalRolloutScanOptions,
+  ): CanonicalRolloutScan {
+    return timed("canonical_rollout_scan", () =>
+      scanCanonicalRolloutUntimed(rolloutPath, options, this.#owner),
+    );
+  }
+
+  /** Release the prefix registries. A closed scanner scans from zero again. */
+  close(): void {
+    while (this.#owner.prefixes.length > 0) {
+      discardPrefix(this.#owner, this.#owner.prefixes[0]!);
+    }
+  }
+}
+
+/**
  * Scan a live rollout without retaining ordinary canonical rows. The first
  * pass validates identities with a disk-backed registry and retains only the
  * bounded compaction lifecycle. A digest-anchored second pass selects the
  * exact source rows named by those lifecycles and existing retention pins.
+ *
+ * This replays the whole file. A caller that scans one rollout repeatedly
+ * should hold a `CanonicalRolloutScanner` instead.
  */
 export function scanCanonicalRollout(
   rolloutPath: string,
   options: CanonicalRolloutScanOptions,
 ): CanonicalRolloutScan {
-  // Every open, compaction attempt and resume re-parses the whole file here
-  // (17,610 lines / 8.6 MB for the measured session), synchronously.
-  return timed("canonical_rollout_scan", () =>
-    scanCanonicalRolloutUntimed(rolloutPath, options),
-  );
+  const scanner = new CanonicalRolloutScanner();
+  try {
+    return scanner.scan(rolloutPath, options);
+  } finally {
+    scanner.close();
+  }
 }
 
 function scanCanonicalRolloutUntimed(
   rolloutPath: string,
   options: CanonicalRolloutScanOptions,
+  owner: PrefixOwner,
 ): CanonicalRolloutScan {
   const nowMilliseconds = options.nowMilliseconds ?? Date.now;
   const startedAt = nowMilliseconds();
@@ -324,453 +410,630 @@ function scanCanonicalRolloutUntimed(
       throw new Error("canonical rollout source is not a regular file");
     }
     checkOperationalBudget();
-    const attempts = new Map<string, MutableAttemptScan>();
-    const capturedAttemptIds = new Set(
-      options.captureHistoryAtAttemptIds ?? [],
-    );
-    const capturedPayloadAttemptIds = new Set(
-      options.capturePayloadRecordsAtAttemptIds ?? [],
-    );
-    const payloadLineAttempts = new Map<number, string>();
-    const trackHistory =
-      options.captureActiveHistory === true || capturedAttemptIds.size > 0;
-    let reducedState = emptyReducedState();
-    let activePositions: CanonicalActiveHistoryPosition[] = [];
-    const activeLineBytes = new Map<number, number>();
-    let activeSourceBytes = 0;
-    const historyAtAttempts = new Map<string, readonly ResponseItem[]>();
-    let retainedLifecycleRecords = 0;
-    let activeAdmissionAttempt: MutableAttemptScan | undefined;
-    let latestCommittedAttempt: MutableAttemptScan | undefined;
-    let postCommitBookkeeping: PostCommitBookkeeping;
-    checkOperationalBudget();
-    let identityRegistry: DiskCanonicalIdentityRegistry | undefined;
-    let payloadRegistry: DiskCompactionPayloadRegistry | undefined;
-    let first: StrictCanonicalJournal;
+    const fingerprint = prefixFingerprint(options);
+    const prefix =
+      reusablePrefix(owner, rolloutPath, fingerprint, snapshot) ??
+      retainPrefix(
+        owner,
+        beginPrefix(rolloutPath, options, fingerprint, snapshot),
+      );
+    prefix.budget.check = checkOperationalBudget;
+    const state = prefix.state;
     try {
-      identityRegistry = new DiskCanonicalIdentityRegistry(
-        options.sessionTempRoot,
+      streamCanonicalTail(fd, snapshot.size, prefix, checkOperationalBudget);
+      const first = prefix.validator.snapshot();
+
+      if (
+        state.latestCommittedAttempt !== undefined &&
+        state.postCommitBookkeeping === "await_meta"
+      ) {
+        state.latestCommittedAttempt.laterWork = true;
+      }
+      assertAttemptsReconstructed(state.attempts);
+
+      checkOperationalBudget();
+      const sourceLines = collectSourceLines(
+        options,
+        state.attempts,
+        state.activePositions,
       );
-      payloadRegistry = new DiskCompactionPayloadRegistry(
-        options.sessionTempRoot,
+      const sourceRecords = new Map<number, CanonicalRolloutSourceRecord>();
+      const payloadRecordsAtAttempts = new Map<
+        string,
+        CanonicalRolloutPayloadRecord[]
+      >();
+      const capturedPayloadAttemptIds = new Set(
+        options.capturePayloadRecordsAtAttemptIds ?? [],
       );
-      const activeIdentityRegistry = identityRegistry;
-      const activePayloadRegistry = payloadRegistry;
-      first = scanPass(fd, snapshot.size, {
+      for (const attemptId of capturedPayloadAttemptIds) {
+        payloadRecordsAtAttempts.set(attemptId, []);
+      }
+      const second = scanPass(fd, snapshot.size, {
         ...strictOptions(options, checkOperationalBudget),
+        trustedSourceSha256: first.sourceSha256,
         retainRecords: false,
-        identityRegistry: activeIdentityRegistry,
-        onRecord: (physicalRecord) => {
-          let record = physicalRecord;
-          let item = record.item;
-          const persistedIntent = persistedIntentPayload(item);
-          const attemptId =
-            item.type.startsWith("compaction_") && "attempt_id" in item.payload
-              ? item.payload.attempt_id
-              : undefined;
-
-          if (latestCommittedAttempt !== undefined) {
-            const next = nextPostCommitBookkeeping(
-              item,
-              latestCommittedAttempt,
-              postCommitBookkeeping,
-              options.expectedRunId,
-            );
-            if (next === "later_work") {
-              latestCommittedAttempt.laterWork = true;
-              latestCommittedAttempt = undefined;
-              postCommitBookkeeping = undefined;
-            } else {
-              postCommitBookkeeping = next;
-            }
-          }
-          if (
-            trackHistory &&
-            item.type === "compaction_intent" &&
-            attemptId !== undefined &&
-            capturedAttemptIds.has(attemptId)
-          ) {
-            checkOperationalBudget();
-            historyAtAttempts.set(
-              attemptId,
-              Object.freeze(reducedState.history.slice()),
-            );
-          }
-
-          if (item.type === "compaction_payload_chunk") {
-            if (activeAdmissionAttempt !== undefined) {
-              observeAdmission(record, activeAdmissionAttempt);
-            }
-            activePayloadRegistry.add(item.payload);
-            if (
-              item.payload.payload_kind === "source_history" &&
-              capturedPayloadAttemptIds.has(item.payload.attempt_id)
-            ) {
-              payloadLineAttempts.set(
-                record.lineNumber,
-                item.payload.attempt_id,
-              );
-            }
-            retainedLifecycleRecords += 1;
-            if (retainedLifecycleRecords > MAX_COMPACTION_LIFECYCLE_RECORDS) {
-              throw new RecoveryOperationalError(
-                "recovery_history_storage_limit",
-                "canonical compaction lifecycle exceeds its bounded retention budget",
-              );
-            }
-            const pending = attempts.get(item.payload.attempt_id);
-            const pendingIntent = pending?.persistedIntent;
-            if (
-              pending !== undefined &&
-              pendingIntent !== undefined &&
-              activePayloadRegistry.hasComplete(
-                pendingIntent.source.active_history_refs_manifest,
-              ) &&
-              pending.intent === undefined
-            ) {
-              const hydrated = hydratePersistedIntentRecord(
-                pending.intentRecord!,
-                pendingIntent,
-                activePayloadRegistry,
-              );
-              pending.intent = hydrated.intent;
-              pending.records.push(hydrated.record);
-              pending.sourceHistoryManifest =
-                pendingIntent.source_history_manifest;
-              activeAdmissionAttempt = pending;
-            }
-            if (
-              pending !== undefined &&
-              pendingIntent !== undefined &&
-              item.payload.payload_kind === "source_history" &&
-              activePayloadRegistry.hasComplete(
-                pendingIntent.source_history_manifest,
-              )
-            ) {
-              validatePersistedSourceHistory(
-                pendingIntent,
-                activePayloadRegistry,
-              );
-              pending.sourceHistoryValidated = true;
-            }
-            return;
-          }
-
-          if (persistedIntent !== undefined) {
-            attempts.set(persistedIntent.attempt_id, {
-              persistedIntent,
-              intentRecord: record,
-              sourceHistoryManifest: persistedIntent.source_history_manifest,
-              records: [],
-              calls: new Map(),
-              eventIds: new Set(),
-              reservationIds: new Set(),
-              latestCall: 0,
-              latestAdmissionSequence: 0,
-              contaminated: false,
-              terminal: false,
-              laterWork: false,
-            });
-            retainedLifecycleRecords += 1;
-            if (retainedLifecycleRecords > MAX_COMPACTION_LIFECYCLE_RECORDS) {
-              throw new RecoveryOperationalError(
-                "recovery_history_storage_limit",
-                "canonical compaction lifecycle exceeds its bounded retention budget",
-              );
-            }
-            return;
-          }
-
-          const incompleteAttempt = [...attempts.values()].find(
-            (attempt) =>
-              attempt.persistedIntent !== undefined &&
-              attempt.intent === undefined &&
-              !attempt.terminal,
+        identityPolicy: "trusted_replay",
+        onRecord: (record) => {
+          const payloadLineAttemptId = state.payloadLineAttempts.get(
+            record.lineNumber,
           );
-          if (incompleteAttempt !== undefined) {
-            throw new Error(
-              "canonical compaction intent is missing its required source payload bundle",
-            );
-          }
-
-          const persistedCommit = persistedCommitPayload(item);
-          if (persistedCommit !== undefined) {
-            const attempt = attempts.get(persistedCommit.attempt_id);
-            if (attempt?.intent === undefined) {
-              throw new Error(
-                "persisted compaction commit has no hydrated intent",
-              );
-            }
-            record = hydratePersistedCommitRecord(
-              record,
-              persistedCommit,
-              attempt.intent,
-              activePayloadRegistry,
-            );
-            item = record.item;
-            if (
-              item.type !== "compaction_committed" ||
-              item.payload.summary_dag.planned_provider_calls !==
-                attempt.intent.planned_provider_calls
-            ) {
-              throw new Error(
-                "canonical compaction commit provider-call plan conflicts with its intent",
-              );
-            }
-          }
-          const persistedRollback = persistedRollbackPayload(item);
-          if (persistedRollback !== undefined) {
-            if (
-              activePayloadRegistry.hasComplete(
-                persistedRollback.source_history_manifest,
-              )
-            ) {
-              record = hydratePersistedRollbackRecord(
-                record,
-                persistedRollback,
-                activePayloadRegistry,
-              );
-              item = record.item;
-            }
-          }
-          if (activeAdmissionAttempt !== undefined) {
-            observeAdmission(record, activeAdmissionAttempt);
-          }
-          if (trackHistory) {
-            checkOperationalBudget();
-            const next = reduceStreamingHistory(reducedState, item);
-            if (item.type === "response_item") {
-              activePositions.push({
-                lineNumber: record.lineNumber,
-                recordMessageIndex: 0,
-              });
-              if (!activeLineBytes.has(record.lineNumber)) {
-                activeLineBytes.set(
-                  record.lineNumber,
-                  record.encodedByteLength + 1,
-                );
-                activeSourceBytes += record.encodedByteLength + 1;
-              }
-            } else if (
-              (item.type === "compacted" &&
-                item.payload.replacementHistory !== undefined) ||
-              item.type === "compaction_committed" ||
-              (item.type === "compaction_rollback_committed" &&
-                Array.isArray(item.payload.source_history) &&
-                item.payload.target_session_id === options.expectedRunId)
-            ) {
-              checkOperationalBudget();
-              activePositions = next.history.map((_, recordMessageIndex) => ({
-                lineNumber: record.lineNumber,
-                recordMessageIndex,
-              }));
-              activeLineBytes.clear();
-              activeLineBytes.set(
-                record.lineNumber,
-                record.encodedByteLength + 1,
-              );
-              activeSourceBytes = record.encodedByteLength + 1;
-            } else if (next.history.length < activePositions.length) {
-              activePositions = activePositions.slice(0, next.history.length);
-              const retainedLines = new Set(
-                activePositions.map((position) => position.lineNumber),
-              );
-              for (const lineNumber of activeLineBytes.keys()) {
-                if (!retainedLines.has(lineNumber))
-                  activeLineBytes.delete(lineNumber);
-              }
-              activeSourceBytes = [...activeLineBytes.values()].reduce(
-                (total, bytes) => total + bytes,
-                0,
-              );
-            }
-            reducedState = next;
-            if (
-              reducedState.history.length > MAX_COMPACTION_SOURCE_MESSAGES ||
-              activeSourceBytes > MAX_COMPACTION_SOURCE_BYTES
-            ) {
-              throw new RecoveryOperationalError(
-                "recovery_history_storage_limit",
-                "canonical active history exceeds its bounded compaction scan budget",
-              );
-            }
-          }
+          const payloadAttemptId =
+            payloadLineAttemptId !== undefined &&
+            capturedPayloadAttemptIds.has(payloadLineAttemptId)
+              ? payloadLineAttemptId
+              : undefined;
           if (
-            !item.type.startsWith("compaction_") ||
-            !("attempt_id" in item.payload)
+            !sourceLines.has(record.lineNumber) &&
+            payloadAttemptId === undefined
           )
             return;
-          retainedLifecycleRecords += 1;
-          if (retainedLifecycleRecords > MAX_COMPACTION_LIFECYCLE_RECORDS) {
-            throw new RecoveryOperationalError(
-              "recovery_history_storage_limit",
-              "canonical compaction lifecycle exceeds its bounded retention budget",
-            );
-          }
-          const lifecycleAttemptId = item.payload.attempt_id;
-          if (item.type === "compaction_intent") {
-            attempts.set(lifecycleAttemptId, {
-              intent: item.payload,
-              records: [record],
-              calls: new Map(),
-              eventIds: new Set(),
-              reservationIds: new Set(),
-              latestCall: 0,
-              latestAdmissionSequence: 0,
-              contaminated: false,
-              terminal: false,
-              laterWork: false,
+          checkOperationalBudget();
+          const physical = readPhysicalRecord(fd, record);
+          const item = record.item;
+          const physicalSha256 = createHash("sha256")
+            .update(options.compactionSourceDigestDomain, "utf8")
+            .update(physical)
+            .digest("hex");
+          if (sourceLines.has(record.lineNumber)) {
+            sourceRecords.set(record.lineNumber, {
+              lineNumber: record.lineNumber,
+              encodedByteLength: physical.byteLength,
+              itemType: item.type,
+              compactionSourceSha256: physicalSha256,
+              ...(item.type === "compaction_committed"
+                ? { committedAttemptId: item.payload.attempt_id }
+                : {}),
             });
-            activeAdmissionAttempt = attempts.get(lifecycleAttemptId);
-            return;
           }
-          const attempt = attempts.get(lifecycleAttemptId);
-          if (attempt === undefined) return;
-          if (
-            attempt.commitSha256 !== undefined &&
-            "commit_sha256" in item.payload &&
-            item.payload.commit_sha256 !== attempt.commitSha256
-          ) {
-            throw new Error(
-              "canonical compaction post-commit event is not bound to its hydrated commit",
-            );
-          }
-          attempt.records.push(record);
-          if (
-            item.type === "compaction_committed" ||
-            item.type === "compaction_failed"
-          ) {
-            attempt.terminal = true;
-            if (item.type === "compaction_committed") {
-              attempt.commitSha256 = digestWithDomain(
-                COMPACTION_ACCOUNTING_DIGEST_DOMAIN,
-                item.payload,
+          if (payloadAttemptId !== undefined) {
+            if (
+              item.type !== "compaction_payload_chunk" ||
+              item.payload.attempt_id !== payloadAttemptId ||
+              item.payload.payload_kind !== "source_history"
+            ) {
+              throw new Error(
+                "captured compaction source-history row changed during canonical scan",
               );
-              latestCommittedAttempt = attempt;
-              postCommitBookkeeping = "await_context";
             }
-            if (activeAdmissionAttempt === attempt) {
-              activeAdmissionAttempt = undefined;
-            }
+            const records =
+              payloadRecordsAtAttempts.get(payloadAttemptId) ?? [];
+            records.push({
+              lineNumber: record.lineNumber,
+              encodedByteLength: physical.byteLength,
+              payloadKind: item.payload.payload_kind,
+              compactionSourceSha256: physicalSha256,
+            });
+            payloadRecordsAtAttempts.set(payloadAttemptId, records);
           }
         },
       });
-    } finally {
-      try {
-        identityRegistry?.close();
-      } finally {
-        payloadRegistry?.close();
-      }
-    }
-
-    if (
-      latestCommittedAttempt !== undefined &&
-      postCommitBookkeeping === "await_meta"
-    ) {
-      latestCommittedAttempt.laterWork = true;
-    }
-    assertAttemptsReconstructed(attempts);
-
-    checkOperationalBudget();
-    const sourceLines = collectSourceLines(options, attempts, activePositions);
-    const sourceRecords = new Map<number, CanonicalRolloutSourceRecord>();
-    const payloadRecordsAtAttempts = new Map<
-      string,
-      CanonicalRolloutPayloadRecord[]
-    >();
-    for (const attemptId of capturedPayloadAttemptIds) {
-      payloadRecordsAtAttempts.set(attemptId, []);
-    }
-    const second = scanPass(fd, snapshot.size, {
-      ...strictOptions(options, checkOperationalBudget),
-      trustedSourceSha256: first.sourceSha256,
-      retainRecords: false,
-      identityPolicy: "trusted_replay",
-      onRecord: (record) => {
-        const payloadAttemptId = payloadLineAttempts.get(record.lineNumber);
-        if (
-          !sourceLines.has(record.lineNumber) &&
-          payloadAttemptId === undefined
-        )
-          return;
-        checkOperationalBudget();
-        const physical = readPhysicalRecord(fd, record);
-        const item = record.item;
-        const physicalSha256 = createHash("sha256")
-          .update(options.compactionSourceDigestDomain, "utf8")
-          .update(physical)
-          .digest("hex");
-        if (sourceLines.has(record.lineNumber)) {
-          sourceRecords.set(record.lineNumber, {
-            lineNumber: record.lineNumber,
-            encodedByteLength: physical.byteLength,
-            itemType: item.type,
-            compactionSourceSha256: physicalSha256,
-            ...(item.type === "compaction_committed"
-              ? { committedAttemptId: item.payload.attempt_id }
-              : {}),
-          });
-        }
-        if (payloadAttemptId !== undefined) {
-          if (
-            item.type !== "compaction_payload_chunk" ||
-            item.payload.attempt_id !== payloadAttemptId ||
-            item.payload.payload_kind !== "source_history"
-          ) {
-            throw new Error(
-              "captured compaction source-history row changed during canonical scan",
-            );
-          }
-          const records = payloadRecordsAtAttempts.get(payloadAttemptId) ?? [];
-          records.push({
-            lineNumber: record.lineNumber,
-            encodedByteLength: physical.byteLength,
-            payloadKind: item.payload.payload_kind,
-            compactionSourceSha256: physicalSha256,
-          });
-          payloadRecordsAtAttempts.set(payloadAttemptId, records);
-        }
-      },
-    });
-    assertMatchingProof(first, second);
-    assertPinnedSnapshot(fd, snapshot);
-    checkOperationalBudget();
-    return {
-      proof: withoutRecords(first),
-      attempts: new Map(
-        [...attempts].map(([attemptId, attempt]) => [
-          attemptId,
-          {
-            intent: attempt.intent!,
-            records: Object.freeze(attempt.records.slice()),
-            admissionValid: validAdmission(attempt),
-            hasLaterCanonicalWork: attempt.laterWork,
-            sourceHistoryRetained: attempt.sourceHistoryValidated === true,
-            ...(attempt.sourceHistoryManifest !== undefined
-              ? { sourceHistoryManifest: attempt.sourceHistoryManifest }
-              : {}),
-          },
-        ]),
-      ),
-      sourceRecords,
-      payloadRecordsAtAttempts: new Map(
-        [...payloadRecordsAtAttempts].map(([attemptId, records]) => [
-          attemptId,
-          Object.freeze(records.slice()),
-        ]),
-      ),
-      ...(options.captureActiveHistory === true
-        ? {
-            activeHistory: {
-              messages: Object.freeze(reducedState.history.slice()),
-              positions: Object.freeze(activePositions.slice()),
+      assertMatchingProof(first, second);
+      assertPinnedSnapshot(fd, snapshot);
+      checkOperationalBudget();
+      return {
+        proof: withoutRecords(first),
+        attempts: new Map(
+          [...state.attempts].map(([attemptId, attempt]) => [
+            attemptId,
+            {
+              intent: attempt.intent!,
+              records: Object.freeze(attempt.records.slice()),
+              admissionValid: validAdmission(attempt),
+              hasLaterCanonicalWork: attempt.laterWork,
+              sourceHistoryRetained: attempt.sourceHistoryValidated === true,
+              ...(attempt.sourceHistoryManifest !== undefined
+                ? { sourceHistoryManifest: attempt.sourceHistoryManifest }
+                : {}),
             },
-          }
-        : {}),
-      historyAtAttempts,
-    };
+          ]),
+        ),
+        sourceRecords,
+        payloadRecordsAtAttempts: new Map(
+          [...payloadRecordsAtAttempts].map(([attemptId, records]) => [
+            attemptId,
+            Object.freeze(records.slice()),
+          ]),
+        ),
+        ...(options.captureActiveHistory === true
+          ? {
+              activeHistory: {
+                messages: Object.freeze(state.reducedState.history.slice()),
+                positions: Object.freeze(state.activePositions.slice()),
+              },
+            }
+          : {}),
+        historyAtAttempts: new Map(state.historyAtAttempts),
+      };
+    } catch (error) {
+      // Whatever failed may have left this prefix out of step with the
+      // file: a partial push, or a second pass that rejected the digest it
+      // carried. The next scan rebuilds it from zero.
+      discardPrefix(owner, prefix);
+      throw error;
+    }
   } finally {
     closeSync(fd);
+  }
+}
+
+/**
+ * The scan options the first pass consumes. `additionalSourceLines` and
+ * `capturePayloadRecordsAtAttemptIds` are not among them: both only select
+ * rows in the second pass, which is why one validated prefix serves
+ * bookkeeping calls that ask about different rows.
+ */
+function prefixFingerprint(options: CanonicalRolloutScanOptions): string {
+  return JSON.stringify({
+    sessionTempRoot: options.sessionTempRoot,
+    expectedRunId: options.expectedRunId ?? null,
+    expectedEpoch: options.expectedEpoch ?? null,
+    terminalPolicy: options.terminalPolicy ?? null,
+    compactionSourceDigestDomain: options.compactionSourceDigestDomain,
+    captureActiveHistory: options.captureActiveHistory === true,
+    captureHistoryAtAttemptIds: [
+      ...new Set(options.captureHistoryAtAttemptIds ?? []),
+    ].sort(),
+  });
+}
+
+/**
+ * A prefix stands in for the file only while it is the same inode, still asks
+ * the same questions of the first pass, and the file has only grown.
+ */
+function reusablePrefix(
+  owner: PrefixOwner,
+  rolloutPath: string,
+  fingerprint: string,
+  snapshot: BigIntStats,
+): ValidatedPrefix | undefined {
+  const index = owner.prefixes.findIndex(
+    (candidate) =>
+      candidate.rolloutPath === rolloutPath &&
+      candidate.fingerprint === fingerprint,
+  );
+  if (index === -1) return undefined;
+  const prefix = owner.prefixes[index]!;
+  if (
+    prefix.dev !== snapshot.dev ||
+    prefix.ino !== snapshot.ino ||
+    prefix.validatedBytes > snapshot.size
+  ) {
+    // A replaced or truncated file has no prefix here any more.
+    discardPrefix(owner, prefix);
+    return undefined;
+  }
+  owner.prefixes.splice(index, 1);
+  owner.prefixes.unshift(prefix);
+  return prefix;
+}
+
+function retainPrefix(
+  owner: PrefixOwner,
+  prefix: ValidatedPrefix,
+): ValidatedPrefix {
+  owner.prefixes.unshift(prefix);
+  while (owner.prefixes.length > MAX_VALIDATED_PREFIXES) {
+    discardPrefix(owner, owner.prefixes[owner.prefixes.length - 1]!);
+  }
+  return prefix;
+}
+
+function beginPrefix(
+  rolloutPath: string,
+  options: CanonicalRolloutScanOptions,
+  fingerprint: string,
+  snapshot: BigIntStats,
+): ValidatedPrefix {
+  const capturedAttemptIds = new Set(options.captureHistoryAtAttemptIds ?? []);
+  const state: MutableRolloutScanState = {
+    capturedAttemptIds,
+    trackHistory:
+      options.captureActiveHistory === true || capturedAttemptIds.size > 0,
+    attempts: new Map(),
+    payloadLineAttempts: new Map(),
+    historyAtAttempts: new Map(),
+    activeLineBytes: new Map(),
+    reducedState: emptyReducedState(),
+    activePositions: [],
+    activeSourceBytes: 0,
+    retainedLifecycleRecords: 0,
+    activeAdmissionAttempt: undefined,
+    latestCommittedAttempt: undefined,
+    postCommitBookkeeping: undefined,
+  };
+  const budget = { check: (): void => {} };
+  const checkBudget = (): void => {
+    budget.check();
+  };
+  const identityRegistry = new DiskCanonicalIdentityRegistry(
+    options.sessionTempRoot,
+  );
+  let payloadRegistry: DiskCompactionPayloadRegistry;
+  try {
+    payloadRegistry = new DiskCompactionPayloadRegistry(
+      options.sessionTempRoot,
+    );
+  } catch (error) {
+    identityRegistry.close();
+    throw error;
+  }
+  let validator: StrictCanonicalJournalValidator;
+  try {
+    validator = new StrictCanonicalJournalValidator({
+      ...strictOptions(options, checkBudget),
+      retainRecords: false,
+      identityRegistry,
+      onRecord: (record) =>
+        observeCanonicalRecord(
+          record,
+          options.expectedRunId,
+          state,
+          payloadRegistry,
+          checkBudget,
+        ),
+    });
+  } catch (error) {
+    try {
+      identityRegistry.close();
+    } finally {
+      payloadRegistry.close();
+    }
+    throw error;
+  }
+  return {
+    rolloutPath,
+    fingerprint,
+    dev: snapshot.dev,
+    ino: snapshot.ino,
+    budget,
+    validator,
+    identityRegistry,
+    payloadRegistry,
+    state,
+    validatedBytes: 0n,
+  };
+}
+
+function discardPrefix(owner: PrefixOwner, prefix: ValidatedPrefix): void {
+  const index = owner.prefixes.indexOf(prefix);
+  if (index !== -1) owner.prefixes.splice(index, 1);
+  try {
+    prefix.identityRegistry.close();
+  } finally {
+    prefix.payloadRegistry.close();
+  }
+}
+
+/** Validate everything appended since this prefix was last brought current. */
+function streamCanonicalTail(
+  fd: number,
+  size: bigint,
+  prefix: ValidatedPrefix,
+  checkBudget: () => void,
+): void {
+  checkBudget();
+  const chunk = Buffer.allocUnsafe(RECOVERY_SCAN_CHUNK_BYTES);
+  let offset = Number(prefix.validatedBytes);
+  while (BigInt(offset) < size) {
+    checkBudget();
+    const remaining = size - BigInt(offset);
+    const requested = Number(
+      remaining < BigInt(chunk.byteLength)
+        ? remaining
+        : BigInt(chunk.byteLength),
+    );
+    const bytesRead = readSync(fd, chunk, 0, requested, offset);
+    if (bytesRead <= 0) {
+      throw new Error("canonical rollout ended before its pinned size");
+    }
+    prefix.validator.push(chunk.subarray(0, bytesRead));
+    offset += bytesRead;
+    prefix.validatedBytes = BigInt(offset);
+  }
+}
+
+function observeCanonicalRecord(
+  physicalRecord: StrictCanonicalJournalRecord,
+  expectedRunId: string | undefined,
+  state: MutableRolloutScanState,
+  payloadRegistry: DiskCompactionPayloadRegistry,
+  checkBudget: () => void,
+): void {
+  let record = physicalRecord;
+  let item = record.item;
+  const persistedIntent = persistedIntentPayload(item);
+  const attemptId =
+    item.type.startsWith("compaction_") && "attempt_id" in item.payload
+      ? item.payload.attempt_id
+      : undefined;
+
+  if (state.latestCommittedAttempt !== undefined) {
+    const next = nextPostCommitBookkeeping(
+      item,
+      state.latestCommittedAttempt,
+      state.postCommitBookkeeping,
+      expectedRunId,
+    );
+    if (next === "later_work") {
+      state.latestCommittedAttempt.laterWork = true;
+      state.latestCommittedAttempt = undefined;
+      state.postCommitBookkeeping = undefined;
+    } else {
+      state.postCommitBookkeeping = next;
+    }
+  }
+  if (
+    state.trackHistory &&
+    item.type === "compaction_intent" &&
+    attemptId !== undefined &&
+    state.capturedAttemptIds.has(attemptId)
+  ) {
+    checkBudget();
+    state.historyAtAttempts.set(
+      attemptId,
+      Object.freeze(state.reducedState.history.slice()),
+    );
+  }
+
+  if (item.type === "compaction_payload_chunk") {
+    if (state.activeAdmissionAttempt !== undefined) {
+      observeAdmission(record, state.activeAdmissionAttempt);
+    }
+    payloadRegistry.add(item.payload);
+    if (item.payload.payload_kind === "source_history") {
+      // Every source-history line, not just the ones this scan was asked
+      // about: which attempt a scan captures must not decide what the
+      // reusable first pass builds. The bounded lifecycle budget below
+      // already counts these rows, so the map stays bounded with it.
+      state.payloadLineAttempts.set(
+        record.lineNumber,
+        item.payload.attempt_id,
+      );
+    }
+    state.retainedLifecycleRecords += 1;
+    if (state.retainedLifecycleRecords > MAX_COMPACTION_LIFECYCLE_RECORDS) {
+      throw new RecoveryOperationalError(
+        "recovery_history_storage_limit",
+        "canonical compaction lifecycle exceeds its bounded retention budget",
+      );
+    }
+    const pending = state.attempts.get(item.payload.attempt_id);
+    const pendingIntent = pending?.persistedIntent;
+    if (
+      pending !== undefined &&
+      pendingIntent !== undefined &&
+      payloadRegistry.hasComplete(
+        pendingIntent.source.active_history_refs_manifest,
+      ) &&
+      pending.intent === undefined
+    ) {
+      const hydrated = hydratePersistedIntentRecord(
+        pending.intentRecord!,
+        pendingIntent,
+        payloadRegistry,
+      );
+      pending.intent = hydrated.intent;
+      pending.records.push(hydrated.record);
+      pending.sourceHistoryManifest =
+        pendingIntent.source_history_manifest;
+      state.activeAdmissionAttempt = pending;
+    }
+    if (
+      pending !== undefined &&
+      pendingIntent !== undefined &&
+      item.payload.payload_kind === "source_history" &&
+      payloadRegistry.hasComplete(
+        pendingIntent.source_history_manifest,
+      )
+    ) {
+      validatePersistedSourceHistory(
+        pendingIntent,
+        payloadRegistry,
+      );
+      pending.sourceHistoryValidated = true;
+    }
+    return;
+  }
+
+  if (persistedIntent !== undefined) {
+    state.attempts.set(persistedIntent.attempt_id, {
+      persistedIntent,
+      intentRecord: record,
+      sourceHistoryManifest: persistedIntent.source_history_manifest,
+      records: [],
+      calls: new Map(),
+      eventIds: new Set(),
+      reservationIds: new Set(),
+      latestCall: 0,
+      latestAdmissionSequence: 0,
+      contaminated: false,
+      terminal: false,
+      laterWork: false,
+    });
+    state.retainedLifecycleRecords += 1;
+    if (state.retainedLifecycleRecords > MAX_COMPACTION_LIFECYCLE_RECORDS) {
+      throw new RecoveryOperationalError(
+        "recovery_history_storage_limit",
+        "canonical compaction lifecycle exceeds its bounded retention budget",
+      );
+    }
+    return;
+  }
+
+  const incompleteAttempt = [...state.attempts.values()].find(
+    (attempt) =>
+      attempt.persistedIntent !== undefined &&
+      attempt.intent === undefined &&
+      !attempt.terminal,
+  );
+  if (incompleteAttempt !== undefined) {
+    throw new Error(
+      "canonical compaction intent is missing its required source payload bundle",
+    );
+  }
+
+  const persistedCommit = persistedCommitPayload(item);
+  if (persistedCommit !== undefined) {
+    const attempt = state.attempts.get(persistedCommit.attempt_id);
+    if (attempt?.intent === undefined) {
+      throw new Error(
+        "persisted compaction commit has no hydrated intent",
+      );
+    }
+    record = hydratePersistedCommitRecord(
+      record,
+      persistedCommit,
+      attempt.intent,
+      payloadRegistry,
+    );
+    item = record.item;
+    if (
+      item.type !== "compaction_committed" ||
+      item.payload.summary_dag.planned_provider_calls !==
+        attempt.intent.planned_provider_calls
+    ) {
+      throw new Error(
+        "canonical compaction commit provider-call plan conflicts with its intent",
+      );
+    }
+  }
+  const persistedRollback = persistedRollbackPayload(item);
+  if (persistedRollback !== undefined) {
+    if (
+      payloadRegistry.hasComplete(
+        persistedRollback.source_history_manifest,
+      )
+    ) {
+      record = hydratePersistedRollbackRecord(
+        record,
+        persistedRollback,
+        payloadRegistry,
+      );
+      item = record.item;
+    }
+  }
+  if (state.activeAdmissionAttempt !== undefined) {
+    observeAdmission(record, state.activeAdmissionAttempt);
+  }
+  if (state.trackHistory) {
+    checkBudget();
+    const next = reduceStreamingHistory(state.reducedState, item);
+    if (item.type === "response_item") {
+      state.activePositions.push({
+        lineNumber: record.lineNumber,
+        recordMessageIndex: 0,
+      });
+      if (!state.activeLineBytes.has(record.lineNumber)) {
+        state.activeLineBytes.set(
+          record.lineNumber,
+          record.encodedByteLength + 1,
+        );
+        state.activeSourceBytes += record.encodedByteLength + 1;
+      }
+    } else if (
+      (item.type === "compacted" &&
+        item.payload.replacementHistory !== undefined) ||
+      item.type === "compaction_committed" ||
+      (item.type === "compaction_rollback_committed" &&
+        Array.isArray(item.payload.source_history) &&
+        item.payload.target_session_id === expectedRunId)
+    ) {
+      checkBudget();
+      state.activePositions = next.history.map((_, recordMessageIndex) => ({
+        lineNumber: record.lineNumber,
+        recordMessageIndex,
+      }));
+      state.activeLineBytes.clear();
+      state.activeLineBytes.set(
+        record.lineNumber,
+        record.encodedByteLength + 1,
+      );
+      state.activeSourceBytes = record.encodedByteLength + 1;
+    } else if (next.history.length < state.activePositions.length) {
+      state.activePositions = state.activePositions.slice(
+        0,
+        next.history.length,
+      );
+      const retainedLines = new Set(
+        state.activePositions.map((position) => position.lineNumber),
+      );
+      for (const lineNumber of state.activeLineBytes.keys()) {
+        if (!retainedLines.has(lineNumber))
+          state.activeLineBytes.delete(lineNumber);
+      }
+      state.activeSourceBytes = [...state.activeLineBytes.values()].reduce(
+        (total, bytes) => total + bytes,
+        0,
+      );
+    }
+    state.reducedState = next;
+    if (
+      state.reducedState.history.length > MAX_COMPACTION_SOURCE_MESSAGES ||
+      state.activeSourceBytes > MAX_COMPACTION_SOURCE_BYTES
+    ) {
+      throw new RecoveryOperationalError(
+        "recovery_history_storage_limit",
+        "canonical active history exceeds its bounded compaction scan budget",
+      );
+    }
+  }
+  if (
+    !item.type.startsWith("compaction_") ||
+    !("attempt_id" in item.payload)
+  )
+    return;
+  state.retainedLifecycleRecords += 1;
+  if (state.retainedLifecycleRecords > MAX_COMPACTION_LIFECYCLE_RECORDS) {
+    throw new RecoveryOperationalError(
+      "recovery_history_storage_limit",
+      "canonical compaction lifecycle exceeds its bounded retention budget",
+    );
+  }
+  const lifecycleAttemptId = item.payload.attempt_id;
+  if (item.type === "compaction_intent") {
+    state.attempts.set(lifecycleAttemptId, {
+      intent: item.payload,
+      records: [record],
+      calls: new Map(),
+      eventIds: new Set(),
+      reservationIds: new Set(),
+      latestCall: 0,
+      latestAdmissionSequence: 0,
+      contaminated: false,
+      terminal: false,
+      laterWork: false,
+    });
+    state.activeAdmissionAttempt = state.attempts.get(lifecycleAttemptId);
+    return;
+  }
+  const attempt = state.attempts.get(lifecycleAttemptId);
+  if (attempt === undefined) return;
+  if (
+    attempt.commitSha256 !== undefined &&
+    "commit_sha256" in item.payload &&
+    item.payload.commit_sha256 !== attempt.commitSha256
+  ) {
+    throw new Error(
+      "canonical compaction post-commit event is not bound to its hydrated commit",
+    );
+  }
+  attempt.records.push(record);
+  if (
+    item.type === "compaction_committed" ||
+    item.type === "compaction_failed"
+  ) {
+    attempt.terminal = true;
+    if (item.type === "compaction_committed") {
+      attempt.commitSha256 = digestWithDomain(
+        COMPACTION_ACCOUNTING_DIGEST_DOMAIN,
+        item.payload,
+      );
+      state.latestCommittedAttempt = attempt;
+      state.postCommitBookkeeping = "await_context";
+    }
+    if (state.activeAdmissionAttempt === attempt) {
+      state.activeAdmissionAttempt = undefined;
+    }
   }
 }
 

--- a/runtime/src/session/rollout-store.ts
+++ b/runtime/src/session/rollout-store.ts
@@ -162,7 +162,7 @@ import {
   reconstructCompactionPayloadV1,
 } from "../services/compact/payload-manifest.js";
 import {
-  scanCanonicalRollout,
+  CanonicalRolloutScanner,
   type CanonicalCompactionAttemptScan,
   type CanonicalRolloutScan,
 } from "./canonical-rollout-scanner.js";
@@ -767,6 +767,12 @@ export class RolloutStore {
   private readonly afterCompactionSourcePruneRewriteForTestingOnly?: () => void;
   private readonly afterCompactionRollbackAppendForTestingOnly?: () => void;
   private readonly nowMilliseconds: () => number;
+  /**
+   * One scanner for this store's rollout: compaction bookkeeping scans it
+   * several times per step, and the scanner replays only what was appended
+   * since its last scan instead of the whole session.
+   */
+  private readonly canonicalScanner = new CanonicalRolloutScanner();
   private readonly durablyCommittedCompactionsAwaitingReconstruction =
     new Set<string>();
   private readonly compactionSourcePayloadBundles = new Map<
@@ -959,6 +965,7 @@ export class RolloutStore {
       if (this.startScheduler) this.scheduler.start();
     } catch (error) {
       this.scheduler.stop();
+      this.canonicalScanner.close();
       this.store.close();
       this.stateDriver.close();
       throw error;
@@ -1021,7 +1028,7 @@ export class RolloutStore {
   ): CompactionPreparedSourceV1 {
     this.store.upgradeCanonicalSchemaHeader(ROLLOUT_SCHEMA_VERSION);
     this.store.syncCanonicalTail();
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: this.sessionId,
       expectedEpoch: this.runEpoch,
@@ -1241,7 +1248,7 @@ export class RolloutStore {
     const candidates = this.compactionRetentionRepo.listActiveForSourceBinding(
       source.source_binding,
     );
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: source.session_id,
       expectedEpoch: this.runEpoch,
@@ -1536,7 +1543,7 @@ export class RolloutStore {
 
   private assertCompactionCommitFresh(intent: CompactionIntentV1): void {
     this.store.syncCanonicalTail();
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: intent.source.session_id,
       expectedEpoch: this.runEpoch,
@@ -1725,7 +1732,7 @@ export class RolloutStore {
       );
     }
     this.store.syncCanonicalTail();
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: pin.sessionId,
       expectedEpoch: this.runEpoch,
@@ -2123,7 +2130,7 @@ export class RolloutStore {
       );
     }
     this.store.syncCanonicalTail();
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: pin.sessionId,
       expectedEpoch: this.runEpoch,
@@ -2317,7 +2324,7 @@ export class RolloutStore {
       );
     }
     this.store.syncCanonicalTail();
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: pin.sessionId,
       expectedEpoch: this.runEpoch,
@@ -2453,7 +2460,7 @@ export class RolloutStore {
   private compactionSourcePrefixMatches(pin: CompactionPinRecord): boolean {
     try {
       this.store.syncCanonicalTail();
-      const scan = scanCanonicalRollout(this.rolloutPath, {
+      const scan = this.canonicalScanner.scan(this.rolloutPath, {
         sessionTempRoot: this.sessionTempRoot,
         expectedRunId: pin.sessionId,
         expectedEpoch: this.runEpoch,
@@ -2476,7 +2483,7 @@ export class RolloutStore {
     const existingPins = this.compactionRetentionRepo.listSession(
       this.sessionId,
     );
-    const scan = scanCanonicalRollout(this.rolloutPath, {
+    const scan = this.canonicalScanner.scan(this.rolloutPath, {
       sessionTempRoot: this.sessionTempRoot,
       expectedRunId: this.sessionId,
       ...(this.reopenTerminalRun ? {} : { expectedEpoch: this.runEpoch }),
@@ -3717,6 +3724,7 @@ export class RolloutStore {
 
   close(): void {
     this.scheduler.stop();
+    this.canonicalScanner.close();
     this.stateDriver.close();
     this.store.close();
   }

--- a/runtime/src/state/recovery-journal-contract.ts
+++ b/runtime/src/state/recovery-journal-contract.ts
@@ -305,6 +305,22 @@ export class StrictCanonicalJournalValidator {
     if (this.#finished)
       throw new Error("canonical journal validator is closed");
     this.#finished = true;
+    return this.#seal(this.#sourceHash.digest("hex"));
+  }
+
+  /**
+   * The same proof `finish` returns, computed over everything pushed so far
+   * while the validator stays open. A reader that already validated a prefix
+   * of an append-only journal can prove the prefix, then push only the bytes
+   * appended since instead of replaying the file from zero.
+   */
+  snapshot(): StrictCanonicalJournal {
+    if (this.#finished)
+      throw new Error("canonical journal validator is closed");
+    return this.#seal(this.#sourceHash.copy().digest("hex"));
+  }
+
+  #seal(sourceSha256: string): StrictCanonicalJournal {
     if (this.#pendingByteLength > 0) {
       this.#fail(
         "unterminated_record",
@@ -315,7 +331,6 @@ export class StrictCanonicalJournalValidator {
         },
       );
     }
-    const sourceSha256 = this.#sourceHash.digest("hex");
     if (
       this.#options.trustedSourceSha256 !== undefined &&
       sourceSha256 !== this.#options.trustedSourceSha256

--- a/runtime/src/state/recovery-journal-contract.ts
+++ b/runtime/src/state/recovery-journal-contract.ts
@@ -313,6 +313,11 @@ export class StrictCanonicalJournalValidator {
    * while the validator stays open. A reader that already validated a prefix
    * of an append-only journal can prove the prefix, then push only the bytes
    * appended since instead of replaying the file from zero.
+   *
+   * Unlike `finish`, a rejected snapshot leaves the validator open and
+   * callable again: a record cut in half by the prefix boundary, or a
+   * compaction chunk chain the appended bytes go on to complete, is a
+   * legitimate state for a reader that has not reached the end of the file.
    */
   snapshot(): StrictCanonicalJournal {
     if (this.#finished)

--- a/runtime/tests/helpers/canonical-rollout-scan.ts
+++ b/runtime/tests/helpers/canonical-rollout-scan.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach } from "vitest";
+
+import type { CompactionTransactionMetadataV1 } from "../../src/services/compact/transaction-types.js";
+import { compactConversationTransactionally } from "../../src/services/compact/transaction.js";
+import type { RolloutStore } from "../../src/session/rollout-store.js";
+import { bindCompactionTransactionHarness } from "./compaction-transaction-harness.js";
+
+/** A per-test `AGENC_HOME` and the workspace a rollout store opens under it. */
+export interface TemporaryAgencHome {
+  /** The `AGENC_HOME` this test is running under. */
+  readonly home: string;
+
+  /** A workspace directory outside that home. */
+  readonly workspace: string;
+}
+
+/**
+ * Bind a per-test `AGENC_HOME` and workspace for a rollout scan test file.
+ *
+ * Scanner tests read and write session state under `AGENC_HOME`, so each test
+ * needs its own home and the ambient one has to come back afterwards even when
+ * the test throws. `mkdtemp` keeps the directories unique across parallel
+ * Vitest workers.
+ */
+export function bindTemporaryAgencHome(prefix: string): TemporaryAgencHome {
+  let home = "";
+  let workspace = "";
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), `${prefix}-home-`));
+    workspace = mkdtempSync(join(tmpdir(), `${prefix}-work-`));
+    previousHome = process.env.AGENC_HOME;
+    process.env.AGENC_HOME = home;
+  });
+
+  afterEach(() => {
+    if (previousHome === undefined) delete process.env.AGENC_HOME;
+    else process.env.AGENC_HOME = previousHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  return {
+    get home(): string {
+      return home;
+    },
+    get workspace(): string {
+      return workspace;
+    },
+  };
+}
+
+/** What one whole-history compaction of a rollout store is asked for. */
+export interface WholeHistoryCompactionRequest {
+  /** The attempt id the prepared source is pinned to. */
+  readonly attemptId: string;
+
+  /** Instructions the summariser is given, so failures name their test. */
+  readonly customInstructions: string;
+
+  /** Large enough that the whole prepared history fits in one step. */
+  readonly contextWindowTokens?: number;
+}
+
+/**
+ * Commit one compaction of a store's whole prepared history through the real
+ * transaction, and answer with what it committed.
+ *
+ * Scan tests need a rollout that actually carries a committed compaction, not
+ * a hand-written approximation of one, so this drives the same code path a
+ * session does and fails loudly when nothing committed.
+ */
+export async function commitWholeHistoryCompaction(
+  store: RolloutStore,
+  request: WholeHistoryCompactionRequest,
+): Promise<CompactionTransactionMetadataV1> {
+  const prepared = store.prepareSource(request.attemptId, []);
+  const harness = bindCompactionTransactionHarness(store, {
+    contextWindowTokens: request.contextWindowTokens ?? 64_000,
+    maxOutputTokens: 512,
+  });
+  try {
+    const result = await compactConversationTransactionally(harness.context, {
+      customInstructions: request.customInstructions,
+      automatic: false,
+      messagesToKeep: [],
+      completeSourceMessages: prepared.messages,
+      messagesToSummarize: prepared.messages,
+      summaryPlacement: "before_keep",
+      createBoundaryMarker: () => ({
+        role: "user",
+        originalRole: "developer",
+        content: "compaction boundary",
+      }),
+      createSummaryMessage: (content) => ({ role: "user", content }),
+    });
+    const transaction = result.transaction;
+    if (transaction === undefined) {
+      throw new Error("compaction did not commit a transaction");
+    }
+    return transaction;
+  } finally {
+    harness.close();
+    store.flushDurable();
+  }
+}

--- a/runtime/tests/session/canonical-rollout-scanner.retention.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.retention.test.ts
@@ -1,41 +1,25 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { RolloutStore } from "../../src/session/rollout-store.js";
+import { bindTemporaryAgencHome } from "../helpers/canonical-rollout-scan.js";
 
 // #2229: the scanner keeps the prefix it validated so bookkeeping stops
 // replaying the whole rollout. That moves cost into resident memory, so what
 // a scanner holds between scans has to stay small next to the session it
 // scans rather than growing with it.
 
-let temporaryHome = "";
-let previousHome: string | undefined;
-let temporaryWorkspace = "";
-
-beforeEach(() => {
-  temporaryHome = mkdtempSync(join(tmpdir(), "agenc-c2-retain-home-"));
-  temporaryWorkspace = mkdtempSync(join(tmpdir(), "agenc-c2-retain-work-"));
-  previousHome = process.env.AGENC_HOME;
-  process.env.AGENC_HOME = temporaryHome;
-});
-
-afterEach(() => {
-  if (previousHome === undefined) delete process.env.AGENC_HOME;
-  else process.env.AGENC_HOME = previousHome;
-  rmSync(temporaryHome, { recursive: true, force: true });
-  rmSync(temporaryWorkspace, { recursive: true, force: true });
-});
+const temporary = bindTemporaryAgencHome("agenc-c2-retain");
 
 describe("canonical rollout scanner retention", () => {
   it("does not hold a session-sized copy of the history between scans", () => {
     const rolloutPath = writeLargeRollout("retention-heap");
     const rolloutBytes = statSync(rolloutPath).size;
     expect(rolloutBytes).toBeGreaterThan(4 * 1_024 * 1_024);
-    const sessionTempRoot = join(temporaryHome, "retention-scan-temp");
+    const sessionTempRoot = join(temporary.home, "retention-scan-temp");
     mkdirSync(sessionTempRoot, { recursive: true });
 
     const evidence = measureRetainedHeap(rolloutPath, sessionTempRoot);
@@ -50,16 +34,16 @@ describe("canonical rollout scanner retention", () => {
 
 function writeLargeRollout(sessionId: string): string {
   const store = new RolloutStore({
-    cwd: temporaryWorkspace,
+    cwd: temporary.workspace,
     sessionId,
     agencVersion: "0.13.0",
-    sessionTempRoot: join(temporaryHome, "rollout-temp"),
+    sessionTempRoot: join(temporary.home, "rollout-temp"),
     autoStartScheduler: false,
   });
   store.open({
     sessionId,
     timestamp: new Date().toISOString(),
-    cwd: temporaryWorkspace,
+    cwd: temporary.workspace,
     originator: "canonical-scanner-retention-test",
     agencVersion: "0.13.0",
   });

--- a/runtime/tests/session/canonical-rollout-scanner.retention.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.retention.test.ts
@@ -1,0 +1,180 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { RolloutStore } from "../../src/session/rollout-store.js";
+
+// #2229: the scanner keeps the prefix it validated so bookkeeping stops
+// replaying the whole rollout. That moves cost into resident memory, so what
+// a scanner holds between scans has to stay small next to the session it
+// scans rather than growing with it.
+
+let temporaryHome = "";
+let previousHome: string | undefined;
+let temporaryWorkspace = "";
+
+beforeEach(() => {
+  temporaryHome = mkdtempSync(join(tmpdir(), "agenc-c2-retain-home-"));
+  temporaryWorkspace = mkdtempSync(join(tmpdir(), "agenc-c2-retain-work-"));
+  previousHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = temporaryHome;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.AGENC_HOME;
+  else process.env.AGENC_HOME = previousHome;
+  rmSync(temporaryHome, { recursive: true, force: true });
+  rmSync(temporaryWorkspace, { recursive: true, force: true });
+});
+
+describe("canonical rollout scanner retention", () => {
+  it("does not hold a session-sized copy of the history between scans", () => {
+    const rolloutPath = writeLargeRollout("retention-heap");
+    const rolloutBytes = statSync(rolloutPath).size;
+    expect(rolloutBytes).toBeGreaterThan(4 * 1_024 * 1_024);
+    const sessionTempRoot = join(temporaryHome, "retention-scan-temp");
+    mkdirSync(sessionTempRoot, { recursive: true });
+
+    const evidence = measureRetainedHeap(rolloutPath, sessionTempRoot);
+
+    expect(evidence.gcType).toBe("function");
+    // Keeping the reduced history in the prefix costs about 1.2x the rollout;
+    // releasing it leaves the registries and the lifecycle, which the
+    // compaction budget already bounds.
+    expect(evidence.retainedBytes).toBeLessThan(rolloutBytes / 4);
+  }, 180_000);
+});
+
+function writeLargeRollout(sessionId: string): string {
+  const store = new RolloutStore({
+    cwd: temporaryWorkspace,
+    sessionId,
+    agencVersion: "0.13.0",
+    sessionTempRoot: join(temporaryHome, "rollout-temp"),
+    autoStartScheduler: false,
+  });
+  store.open({
+    sessionId,
+    timestamp: new Date().toISOString(),
+    cwd: temporaryWorkspace,
+    originator: "canonical-scanner-retention-test",
+    agencVersion: "0.13.0",
+  });
+  try {
+    for (let index = 0; index < 1_200; index += 1) {
+      store.appendRollout({
+        type: "response_item",
+        payload: {
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `retained-${index}-${"x".repeat(4_096)}`,
+        },
+      });
+    }
+    store.flushDurable();
+    return store.rolloutPath;
+  } finally {
+    store.close();
+  }
+}
+
+interface RetentionEvidence {
+  readonly gcType: string;
+  readonly retainedBytes: number;
+}
+
+/** Heap held by a scanner after it answered a scan and the answer was dropped. */
+function measureRetainedHeap(
+  rolloutPath: string,
+  sessionTempRoot: string,
+): RetentionEvidence {
+  const scannerUrl = new URL(
+    "../../src/session/canonical-rollout-scanner.ts",
+    import.meta.url,
+  ).href;
+  const childScript = `
+    const { CanonicalRolloutScanner } = await import(${JSON.stringify(scannerUrl)});
+    const { COMPACTION_SOURCE_DIGEST_DOMAIN } = await import(${JSON.stringify(
+      new URL(
+        "../../src/services/compact/transaction-types.ts",
+        import.meta.url,
+      ).href,
+    )});
+    const options = {
+      sessionTempRoot: ${JSON.stringify(sessionTempRoot)},
+      expectedRunId: "retention-heap",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 120000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+      captureActiveHistory: true,
+    };
+    const rolloutPath = ${JSON.stringify(rolloutPath)};
+    const settle = async () => {
+      for (let i = 0; i < 10; i += 1) {
+        globalThis.gc();
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      return process.memoryUsage().heapUsed;
+    };
+    // Pay for the lazily loaded modules and their caches before the baseline,
+    // so the difference is what this scanner kept and nothing else.
+    const warmUp = new CanonicalRolloutScanner();
+    warmUp.scan(rolloutPath, options);
+    warmUp.close();
+    const baseline = await settle();
+
+    const scanner = new CanonicalRolloutScanner();
+    let scan = scanner.scan(rolloutPath, options);
+    if (scan.activeHistory.messages.length !== 1200) {
+      throw new Error("unexpected active history length");
+    }
+    scan = undefined;
+    const held = await settle();
+    scanner.close();
+
+    process.stdout.write(JSON.stringify({
+      gcType: typeof globalThis.gc,
+      retainedBytes: held - baseline,
+    }));
+  `;
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--expose-gc",
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      childScript,
+    ],
+    {
+      cwd: fileURLToPath(new URL("../../", import.meta.url)),
+      encoding: "utf8",
+      // Preserve the hermetic runner's reviewed NODE_OPTIONS preload so its
+      // network tripwire also governs this focused child.
+      env: process.env,
+      timeout: 150_000,
+    },
+  );
+  const diagnostics = [
+    `status=${String(child.status)}`,
+    `signal=${String(child.signal)}`,
+    `error=${child.error?.stack ?? "none"}`,
+    `stdout=${JSON.stringify(child.stdout)}`,
+    `stderr=${JSON.stringify(child.stderr)}`,
+  ].join("\n");
+  expect(child.error, diagnostics).toBeUndefined();
+  expect(child.signal, diagnostics).toBeNull();
+  expect(child.status, diagnostics).toBe(0);
+  try {
+    return JSON.parse(child.stdout) as RetentionEvidence;
+  } catch (error) {
+    throw new Error(
+      `retention child did not return valid evidence: ${
+        error instanceof Error ? error.message : String(error)
+      }\n${diagnostics}`,
+    );
+  }
+}

--- a/runtime/tests/session/canonical-rollout-scanner.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.test.ts
@@ -408,7 +408,9 @@ describe("canonical rollout compaction scanner", () => {
       expect(readdirSync(sessionTempRoot)).toEqual([]);
 
       // The bookkeeping that reduces no history is the repeat-heavy part of a
-      // compaction step, and the ceiling does not cost it its prefix.
+      // compaction step, so an active history this size is not what costs it
+      // its prefix. It is charged for hydrated lifecycle payload instead,
+      // which this rollout has none of; the two tests below charge it.
       const bookkeeping = { ...options, captureActiveHistory: false } as const;
       scanner.scan(rolloutPath, bookkeeping);
       expect(readdirSync(sessionTempRoot)).toHaveLength(2);

--- a/runtime/tests/session/canonical-rollout-scanner.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.test.ts
@@ -420,6 +420,78 @@ describe("canonical rollout compaction scanner", () => {
     }
   }, 120_000);
 
+  it("keeps no prefix once the payload its lifecycle holds passes the ceiling", async () => {
+    const store = createStore("prefix-lifecycle-ceiling");
+    const rolloutPath = store.rolloutPath;
+    const sessionTempRoot = join(temporaryHome, "lifecycle-ceiling-temp");
+    mkdirSync(sessionTempRoot, { recursive: true });
+    const scanner = new CanonicalRolloutScanner();
+    // The bookkeeping shape: it reduces no active history, so the active
+    // history ceiling can never be what releases this prefix.
+    const options = bookkeepingOptions(
+      sessionTempRoot,
+      "prefix-lifecycle-ceiling",
+    );
+    try {
+      appendLargeHistory(store, 1_000);
+
+      // Nothing hydrated yet, so this prefix is small and worth keeping: its
+      // two disk registries are the visible sign that the scanner holds one.
+      scanner.scan(rolloutPath, options);
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+
+      const transaction = await commitWholeHistory(store, "ceiling-source");
+      // A rollback reconstructs the whole pre-compaction conversation back
+      // into the row the scan retains, which is how a bounded number of
+      // lifecycle rows becomes a session-sized thing to hold.
+      store.markProjectionComplete(transaction.attempt_id);
+      store.rollbackCompaction({
+        attemptId: transaction.attempt_id,
+        nowMs: transaction.committed.committed_at_ms + 2,
+      });
+      store.flushDurable();
+
+      const scan = scanner.scan(rolloutPath, options);
+      expect(retainedPayloadBytes(scan)).toBeGreaterThan(4 * 1_024 * 1_024);
+      expect(readdirSync(sessionTempRoot)).toEqual([]);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  }, 180_000);
+
+  it("keeps the prefix of a scan that only proved a large payload", async () => {
+    const store = createStore("prefix-proved-payload");
+    const rolloutPath = store.rolloutPath;
+    const sessionTempRoot = join(temporaryHome, "proved-payload-temp");
+    mkdirSync(sessionTempRoot, { recursive: true });
+    const scanner = new CanonicalRolloutScanner();
+    const options = bookkeepingOptions(
+      sessionTempRoot,
+      "prefix-proved-payload",
+    );
+    try {
+      appendLargeHistory(store, 1_000);
+      await commitWholeHistory(store, "proved-source");
+
+      // Proving the committed attempt's source history reconstructs it and
+      // then drops every byte: counting that would put this prefix over the
+      // ceiling, while what it actually still holds is far under it.
+      const scan = scanner.scan(rolloutPath, options);
+      expect(scan.attempts.size).toBe(1);
+      const proved =
+        [...scan.attempts.values()][0]!.sourceHistoryManifest
+          ?.canonical_utf8_bytes ?? 0;
+      const held = retainedPayloadBytes(scan);
+      expect(held).toBeLessThan(4 * 1_024 * 1_024);
+      expect(proved + held).toBeGreaterThan(4 * 1_024 * 1_024);
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  }, 180_000);
+
   it("keeps no prefix that is keyed to one attempt's history", () => {
     const store = createStore("prefix-per-attempt");
     const rolloutPath = store.rolloutPath;
@@ -533,6 +605,74 @@ function comparable(scan: CanonicalRolloutScan): unknown {
     activeHistory: scan.activeHistory,
     historyAtAttempts: [...scan.historyAtAttempts],
   };
+}
+
+/** The bookkeeping shape of scan: it reduces no active history. */
+function bookkeepingOptions(sessionTempRoot: string, sessionId: string) {
+  return {
+    sessionTempRoot,
+    expectedRunId: sessionId,
+    expectedEpoch: 1,
+    maximumScanMilliseconds: 120_000,
+    compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    captureActiveHistory: false,
+  } as const;
+}
+
+/** Enough conversation that one compaction of it passes the ceiling. */
+function appendLargeHistory(store: RolloutStore, rows: number): void {
+  for (let index = 0; index < rows; index += 1) {
+    store.appendRollout({
+      type: "response_item",
+      payload: {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `lifecycle-${index}-${"x".repeat(4_096)}`,
+      },
+    });
+  }
+  store.flushDurable();
+}
+
+async function commitWholeHistory(store: RolloutStore, attemptId: string) {
+  const prepared = store.prepareSource(attemptId, []);
+  const harness = bindCompactionTransactionHarness(store, {
+    contextWindowTokens: 2_000_000,
+    maxOutputTokens: 512,
+  });
+  try {
+    const result = await compactConversationTransactionally(harness.context, {
+      customInstructions: "retention ceiling",
+      automatic: false,
+      messagesToKeep: [],
+      completeSourceMessages: prepared.messages,
+      messagesToSummarize: prepared.messages,
+      summaryPlacement: "before_keep",
+      createBoundaryMarker: () => ({
+        role: "user",
+        originalRole: "developer",
+        content: "compaction boundary",
+      }),
+      createSummaryMessage: (content) => ({ role: "user", content }),
+    });
+    const transaction = result.transaction;
+    if (transaction === undefined) {
+      throw new Error("compaction did not commit a transaction");
+    }
+    return transaction;
+  } finally {
+    harness.close();
+    store.flushDurable();
+  }
+}
+
+/** What the scan's lifecycle rows reconstructed and are still holding. */
+function retainedPayloadBytes(scan: CanonicalRolloutScan): number {
+  return [...scan.attempts.values()]
+    .flatMap((attempt) => attempt.records)
+    .reduce(
+      (total, record) => total + JSON.stringify(record.item.payload).length,
+      0,
+    );
 }
 
 /** Fixed-width markers so a record can be rewritten without resizing it. */

--- a/runtime/tests/session/canonical-rollout-scanner.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.test.ts
@@ -22,6 +22,7 @@ import {
   type CanonicalRolloutScan,
 } from "../../src/session/canonical-rollout-scanner.js";
 import { RolloutStore } from "../../src/session/rollout-store.js";
+import { commitWholeHistoryCompaction } from "../helpers/canonical-rollout-scan.js";
 import { bindCompactionTransactionHarness } from "../helpers/compaction-transaction-harness.js";
 
 let temporaryHome = "";
@@ -243,34 +244,11 @@ describe("canonical rollout compaction scanner", () => {
       // lifecycle below reaches it as an appended tail.
       scanner.scan(rolloutPath, options);
 
-      const prepared = store.prepareSource("agreement-attempt", []);
-      const harness = bindCompactionTransactionHarness(store, {
-        contextWindowTokens: 64_000,
-        maxOutputTokens: 512,
+      const committed = await commitWholeHistoryCompaction(store, {
+        attemptId: "agreement-attempt",
+        customInstructions: "prefix reuse agreement",
       });
-      try {
-        const result = await compactConversationTransactionally(
-          harness.context,
-          {
-            customInstructions: "prefix reuse agreement",
-            automatic: false,
-            messagesToKeep: [],
-            completeSourceMessages: prepared.messages,
-            messagesToSummarize: prepared.messages,
-            summaryPlacement: "before_keep",
-            createBoundaryMarker: () => ({
-              role: "user",
-              originalRole: "developer",
-              content: "compaction boundary",
-            }),
-            createSummaryMessage: (content) => ({ role: "user", content }),
-          },
-        );
-        expect(result.transaction).toBeDefined();
-      } finally {
-        harness.close();
-      }
-      store.flushDurable();
+      expect(committed).toBeDefined();
 
       const warm = scanner.scan(rolloutPath, options);
       const cold = scanCanonicalRollout(rolloutPath, options);
@@ -527,16 +505,8 @@ describe("canonical rollout compaction scanner", () => {
   });
 
   it("re-validates a rollout replaced at the same path", () => {
-    const store = createStore("prefix-inode-replaced");
-    const rolloutPath = store.rolloutPath;
-    const scanner = new CanonicalRolloutScanner();
-    const options = {
-      sessionTempRoot: join(temporaryHome, "scan-temp"),
-      expectedRunId: "prefix-inode-replaced",
-      expectedEpoch: 1,
-      maximumScanMilliseconds: 30_000,
-      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
-    } as const;
+    const { store, scanner, options, rolloutPath } =
+      bindPrefixScanner("prefix-inode-replaced");
     try {
       appendMarkedRows(store, 40);
       const before = scanner.scan(rolloutPath, options);
@@ -556,16 +526,8 @@ describe("canonical rollout compaction scanner", () => {
   });
 
   it("re-validates a rollout truncated under it", () => {
-    const store = createStore("prefix-truncated");
-    const rolloutPath = store.rolloutPath;
-    const scanner = new CanonicalRolloutScanner();
-    const options = {
-      sessionTempRoot: join(temporaryHome, "scan-temp"),
-      expectedRunId: "prefix-truncated",
-      expectedEpoch: 1,
-      maximumScanMilliseconds: 30_000,
-      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
-    } as const;
+    const { store, scanner, options, rolloutPath } =
+      bindPrefixScanner("prefix-truncated");
     try {
       appendMarkedRows(store, 40);
       const before = scanner.scan(rolloutPath, options);
@@ -636,35 +598,11 @@ function appendLargeHistory(store: RolloutStore, rows: number): void {
 }
 
 async function commitWholeHistory(store: RolloutStore, attemptId: string) {
-  const prepared = store.prepareSource(attemptId, []);
-  const harness = bindCompactionTransactionHarness(store, {
+  return commitWholeHistoryCompaction(store, {
+    attemptId,
+    customInstructions: "retention ceiling",
     contextWindowTokens: 2_000_000,
-    maxOutputTokens: 512,
   });
-  try {
-    const result = await compactConversationTransactionally(harness.context, {
-      customInstructions: "retention ceiling",
-      automatic: false,
-      messagesToKeep: [],
-      completeSourceMessages: prepared.messages,
-      messagesToSummarize: prepared.messages,
-      summaryPlacement: "before_keep",
-      createBoundaryMarker: () => ({
-        role: "user",
-        originalRole: "developer",
-        content: "compaction boundary",
-      }),
-      createSummaryMessage: (content) => ({ role: "user", content }),
-    });
-    const transaction = result.transaction;
-    if (transaction === undefined) {
-      throw new Error("compaction did not commit a transaction");
-    }
-    return transaction;
-  } finally {
-    harness.close();
-    store.flushDurable();
-  }
 }
 
 /** What the scan's lifecycle rows reconstructed and are still holding. */
@@ -675,6 +613,28 @@ function retainedPayloadBytes(scan: CanonicalRolloutScan): number {
       (total, record) => total + JSON.stringify(record.item.payload).length,
       0,
     );
+}
+
+/**
+ * A store, a scanner, and the scan options that name that store's rollout.
+ *
+ * Each caller still opens its own `try`/`finally` around what it does with
+ * them, so what is shared here is only how the three come to exist.
+ */
+function bindPrefixScanner(sessionId: string) {
+  const store = createStore(sessionId);
+  return {
+    store,
+    rolloutPath: store.rolloutPath,
+    scanner: new CanonicalRolloutScanner(),
+    options: {
+      sessionTempRoot: join(temporaryHome, "scan-temp"),
+      expectedRunId: sessionId,
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 30_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    } as const,
+  };
 }
 
 /** Fixed-width markers so a record can be rewritten without resizing it. */

--- a/runtime/tests/session/canonical-rollout-scanner.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.test.ts
@@ -1,4 +1,14 @@
-import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -271,6 +281,233 @@ describe("canonical rollout compaction scanner", () => {
       store.close();
     }
   }, 120_000);
+
+  it("does not carry an end-of-file bookkeeping conclusion into a later scan", async () => {
+    const store = createStore("post-commit-window");
+    const rolloutPath = store.rolloutPath;
+    const scanner = new CanonicalRolloutScanner();
+    const options = {
+      sessionTempRoot: join(temporaryHome, "scan-temp"),
+      expectedRunId: "post-commit-window",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 30_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    } as const;
+    try {
+      for (let index = 0; index < 200; index += 1) {
+        store.appendRollout({
+          type: "response_item",
+          payload: {
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: `post-commit-${index}-${"detail ".repeat(64)}`,
+          },
+        });
+      }
+      store.flushDurable();
+      const prepared = store.prepareSource("window-source", []);
+      const harness = bindCompactionTransactionHarness(store, {
+        contextWindowTokens: 64_000,
+        maxOutputTokens: 512,
+      });
+      try {
+        const result = await compactConversationTransactionally(
+          harness.context,
+          {
+            customInstructions: "post-commit window",
+            automatic: true,
+            messagesToKeep: [],
+            completeSourceMessages: prepared.messages,
+            messagesToSummarize: prepared.messages,
+            summaryPlacement: "before_keep",
+            createBoundaryMarker: () => ({
+              role: "user",
+              originalRole: "developer",
+              content: "compaction boundary",
+            }),
+            createSummaryMessage: (content) => ({ role: "user", content }),
+          },
+        );
+        expect(result.transaction).toBeDefined();
+        // commit.ts stamps the causal boundary straight after an automatic
+        // commit and only then re-appends the session header, so a scan that
+        // lands in between sees a file ending mid-bookkeeping.
+        harness.session.emit({
+          eventId: "post-commit-boundary",
+          id: "post-commit-boundary",
+          msg: {
+            type: "context_compacted",
+            payload: { summary: "auto-compact boundary (turnId=window-turn)" },
+          },
+        });
+      } finally {
+        harness.close();
+      }
+      store.flushDurable();
+
+      const atBoundary = scanner.scan(rolloutPath, options);
+      const attemptId = [...atBoundary.attempts.keys()].at(-1)!;
+      expect(atBoundary.attempts.get(attemptId)?.hasLaterCanonicalWork).toBe(
+        true,
+      );
+
+      store.store.reAppendSessionMetadata();
+      store.flushDurable();
+
+      // The conclusion belonged to where the earlier scan stopped reading, so
+      // the scan that reads past it must answer as a full replay does.
+      const warm = scanner.scan(rolloutPath, options);
+      const cold = scanCanonicalRollout(rolloutPath, options);
+      expect(warm.attempts.get(attemptId)?.hasLaterCanonicalWork).toBe(false);
+      expect(comparable(warm)).toEqual(comparable(cold));
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  }, 120_000);
+
+  it("keeps no prefix once its active history outgrows the retention ceiling", () => {
+    const store = createStore("prefix-history-ceiling");
+    const rolloutPath = store.rolloutPath;
+    const sessionTempRoot = join(temporaryHome, "ceiling-temp");
+    mkdirSync(sessionTempRoot, { recursive: true });
+    const scanner = new CanonicalRolloutScanner();
+    const options = {
+      sessionTempRoot,
+      expectedRunId: "prefix-history-ceiling",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 60_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+      captureActiveHistory: true,
+    } as const;
+    try {
+      // Under the ceiling the prefix is worth its memory, and its two disk
+      // registries are the visible sign that a scanner is holding one.
+      for (let index = 0; index < 64; index += 1) {
+        store.appendRollout({
+          type: "response_item",
+          payload: { role: "user", content: `small-${"x".repeat(4_096)}` },
+        });
+      }
+      store.flushDurable();
+      const small = scanner.scan(rolloutPath, options);
+      expect(small.activeHistory?.messages).toHaveLength(64);
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+
+      // Past it the prefix would hold a second copy of the whole session, so
+      // it answers this scan and is released rather than kept.
+      for (let index = 0; index < 1_100; index += 1) {
+        store.appendRollout({
+          type: "response_item",
+          payload: { role: "assistant", content: `large-${"y".repeat(4_096)}` },
+        });
+      }
+      store.flushDurable();
+      const large = scanner.scan(rolloutPath, options);
+      expect(large.activeHistory?.messages).toHaveLength(1_164);
+      expect(statSync(rolloutPath).size).toBeGreaterThan(4 * 1_024 * 1_024);
+      expect(readdirSync(sessionTempRoot)).toEqual([]);
+
+      // The bookkeeping that reduces no history is the repeat-heavy part of a
+      // compaction step, and the ceiling does not cost it its prefix.
+      const bookkeeping = { ...options, captureActiveHistory: false } as const;
+      scanner.scan(rolloutPath, bookkeeping);
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+      scanner.scan(rolloutPath, bookkeeping);
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  }, 120_000);
+
+  it("keeps no prefix that is keyed to one attempt's history", () => {
+    const store = createStore("prefix-per-attempt");
+    const rolloutPath = store.rolloutPath;
+    const sessionTempRoot = join(temporaryHome, "per-attempt-temp");
+    mkdirSync(sessionTempRoot, { recursive: true });
+    const scanner = new CanonicalRolloutScanner();
+    const options = {
+      sessionTempRoot,
+      expectedRunId: "prefix-per-attempt",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 30_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    } as const;
+    try {
+      appendMarkedRows(store, 40);
+      scanner.scan(rolloutPath, options);
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+
+      // Rollback bookkeeping names the attempt it is reconstructing, so no
+      // later scan can ask this prefix its question: holding it would only
+      // evict one that a later scan can still use.
+      scanner.scan(rolloutPath, {
+        ...options,
+        captureHistoryAtAttemptIds: ["rollback-attempt"],
+      });
+      expect(readdirSync(sessionTempRoot)).toHaveLength(2);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  });
+
+  it("re-validates a rollout replaced at the same path", () => {
+    const store = createStore("prefix-inode-replaced");
+    const rolloutPath = store.rolloutPath;
+    const scanner = new CanonicalRolloutScanner();
+    const options = {
+      sessionTempRoot: join(temporaryHome, "scan-temp"),
+      expectedRunId: "prefix-inode-replaced",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 30_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    } as const;
+    try {
+      appendMarkedRows(store, 40);
+      const before = scanner.scan(rolloutPath, options);
+
+      // What an atomic rewrite leaves behind: the same path, the same length,
+      // other bytes, another inode. The prefix names an inode that no longer
+      // holds them, so it cannot stand in for the file.
+      replaceAtNewInode(rolloutPath, "row-0007-", "row-9999-");
+      const after = scanner.scan(rolloutPath, options);
+
+      expect(after.proof.sourceSha256).not.toBe(before.proof.sourceSha256);
+      expect(after.proof.recordCount).toBe(before.proof.recordCount);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  });
+
+  it("re-validates a rollout truncated under it", () => {
+    const store = createStore("prefix-truncated");
+    const rolloutPath = store.rolloutPath;
+    const scanner = new CanonicalRolloutScanner();
+    const options = {
+      sessionTempRoot: join(temporaryHome, "scan-temp"),
+      expectedRunId: "prefix-truncated",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 30_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    } as const;
+    try {
+      appendMarkedRows(store, 40);
+      const before = scanner.scan(rolloutPath, options);
+
+      // Same inode, fewer bytes: the prefix reaches past the end of the file
+      // it was built from, so there is nothing left for it to stand in for.
+      truncateAtRecordBoundary(rolloutPath, 20);
+      const after = scanner.scan(rolloutPath, options);
+
+      expect(after.proof.recordCount).toBe(20);
+      expect(before.proof.recordCount).toBe(41);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  });
 });
 
 
@@ -296,6 +533,53 @@ function comparable(scan: CanonicalRolloutScan): unknown {
     activeHistory: scan.activeHistory,
     historyAtAttempts: [...scan.historyAtAttempts],
   };
+}
+
+/** Fixed-width markers so a record can be rewritten without resizing it. */
+function appendMarkedRows(store: RolloutStore, rows: number): void {
+  for (let index = 0; index < rows; index += 1) {
+    store.appendRollout({
+      type: "response_item",
+      payload: {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `row-${String(index).padStart(4, "0")}-${"x".repeat(256)}`,
+      },
+    });
+  }
+  store.flushDurable();
+}
+
+/** Rewrite one record and publish the result as a new file at the same path. */
+function replaceAtNewInode(path: string, find: string, replace: string): void {
+  if (find.length !== replace.length) {
+    throw new Error("replacement must preserve the rollout length");
+  }
+  const bytes = readFileSync(path);
+  const offset = bytes.indexOf(find);
+  if (offset === -1) throw new Error(`rollout has no ${find} record`);
+  bytes.write(replace, offset, "utf8");
+  const staged = `${path}.staged`;
+  writeFileSync(staged, bytes);
+  const before = statSync(path);
+  renameSync(staged, path);
+  const after = statSync(path);
+  if (before.ino === after.ino) throw new Error("rollout kept its inode");
+  if (before.size !== after.size) throw new Error("rollout changed size");
+}
+
+/** Drop every record after the first `keepRecords` lines, in place. */
+function truncateAtRecordBoundary(path: string, keepRecords: number): void {
+  const bytes = readFileSync(path);
+  let offset = 0;
+  for (let record = 0; record < keepRecords; record += 1) {
+    const next = bytes.indexOf(0x0a, offset);
+    if (next === -1) throw new Error("rollout has fewer records than that");
+    offset = next + 1;
+  }
+  const before = statSync(path);
+  truncateSync(path, offset);
+  const after = statSync(path);
+  if (before.ino !== after.ino) throw new Error("truncation replaced the file");
 }
 
 function createStore(sessionId: string): RolloutStore {

--- a/runtime/tests/session/canonical-rollout-scanner.test.ts
+++ b/runtime/tests/session/canonical-rollout-scanner.test.ts
@@ -5,8 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Database from "better-sqlite3";
 
 import { COMPACTION_SOURCE_DIGEST_DOMAIN } from "../../src/services/compact/transaction-types.js";
-import { scanCanonicalRollout } from "../../src/session/canonical-rollout-scanner.js";
+import { compactConversationTransactionally } from "../../src/services/compact/transaction.js";
+import {
+  CanonicalRolloutScanner,
+  scanCanonicalRollout,
+  type CanonicalRolloutScan,
+} from "../../src/session/canonical-rollout-scanner.js";
 import { RolloutStore } from "../../src/session/rollout-store.js";
+import { bindCompactionTransactionHarness } from "../helpers/compaction-transaction-harness.js";
 
 let temporaryHome = "";
 let previousHome: string | undefined;
@@ -199,7 +205,98 @@ describe("canonical rollout compaction scanner", () => {
     }
     expect(readdirSync(sessionTempRoot)).toEqual([]);
   });
+
+  it("agrees with a full replay after a compaction landed on the tail", async () => {
+    const store = createStore("prefix-reuse-agrees");
+    const rolloutPath = store.rolloutPath;
+    const scanner = new CanonicalRolloutScanner();
+    const options = {
+      sessionTempRoot: join(temporaryHome, "scan-temp"),
+      expectedRunId: "prefix-reuse-agrees",
+      expectedEpoch: 1,
+      maximumScanMilliseconds: 30_000,
+      compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+      captureActiveHistory: true,
+    } as const;
+    try {
+      for (let index = 0; index < 200; index += 1) {
+        store.appendRollout({
+          type: "response_item",
+          payload: {
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: `before-compaction-${index}-${"detail ".repeat(64)}`,
+          },
+        });
+      }
+      store.flushDurable();
+      // Warm the scanner on the pre-compaction prefix, so the whole compaction
+      // lifecycle below reaches it as an appended tail.
+      scanner.scan(rolloutPath, options);
+
+      const prepared = store.prepareSource("agreement-attempt", []);
+      const harness = bindCompactionTransactionHarness(store, {
+        contextWindowTokens: 64_000,
+        maxOutputTokens: 512,
+      });
+      try {
+        const result = await compactConversationTransactionally(
+          harness.context,
+          {
+            customInstructions: "prefix reuse agreement",
+            automatic: false,
+            messagesToKeep: [],
+            completeSourceMessages: prepared.messages,
+            messagesToSummarize: prepared.messages,
+            summaryPlacement: "before_keep",
+            createBoundaryMarker: () => ({
+              role: "user",
+              originalRole: "developer",
+              content: "compaction boundary",
+            }),
+            createSummaryMessage: (content) => ({ role: "user", content }),
+          },
+        );
+        expect(result.transaction).toBeDefined();
+      } finally {
+        harness.close();
+      }
+      store.flushDurable();
+
+      const warm = scanner.scan(rolloutPath, options);
+      const cold = scanCanonicalRollout(rolloutPath, options);
+      expect(comparable(warm)).toEqual(comparable(cold));
+      expect(warm.attempts.size).toBe(1);
+    } finally {
+      scanner.close();
+      store.close();
+    }
+  }, 120_000);
 });
+
+
+/** Every part of a scan, in a shape deep equality can compare. */
+function comparable(scan: CanonicalRolloutScan): unknown {
+  return {
+    proof: scan.proof,
+    attempts: [...scan.attempts].map(([attemptId, attempt]) => [
+      attemptId,
+      {
+        intent: attempt.intent,
+        records: attempt.records,
+        admissionValid: attempt.admissionValid,
+        hasLaterCanonicalWork: attempt.hasLaterCanonicalWork,
+        sourceHistoryRetained: attempt.sourceHistoryRetained,
+        sourceHistoryManifest: attempt.sourceHistoryManifest,
+      },
+    ]),
+    sourceRecords: [...scan.sourceRecords].sort(
+      ([left], [right]) => left - right,
+    ),
+    payloadRecordsAtAttempts: [...scan.payloadRecordsAtAttempts],
+    activeHistory: scan.activeHistory,
+    historyAtAttempts: [...scan.historyAtAttempts],
+  };
+}
 
 function createStore(sessionId: string): RolloutStore {
   const store = new RolloutStore({

--- a/runtime/tests/session/rollout-store.canonical-scan-reuse.test.ts
+++ b/runtime/tests/session/rollout-store.canonical-scan-reuse.test.ts
@@ -1,0 +1,173 @@
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const meter = vi.hoisted(() => ({ bytes: 0, recording: false }));
+
+// The scan's cost is the bytes it reads back off the rollout, so the contract
+// is measured there rather than in wall-clock milliseconds.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    default: actual,
+    readSync: (...args: Parameters<typeof actual.readSync>) => {
+      const bytesRead = actual.readSync(...args);
+      if (meter.recording) meter.bytes += bytesRead;
+      return bytesRead;
+    },
+  };
+});
+
+import type { CompactionPreparedSourceV1 } from "../../src/services/compact/transaction-types.js";
+import { RolloutStore } from "../../src/session/rollout-store.js";
+
+let temporaryHome = "";
+let previousHome: string | undefined;
+let temporaryWorkspace = "";
+
+beforeEach(() => {
+  temporaryHome = mkdtempSync(join(tmpdir(), "agenc-scan-reuse-home-"));
+  temporaryWorkspace = mkdtempSync(join(tmpdir(), "agenc-scan-reuse-work-"));
+  previousHome = process.env.AGENC_HOME;
+  process.env.AGENC_HOME = temporaryHome;
+  meter.bytes = 0;
+  meter.recording = false;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.AGENC_HOME;
+  else process.env.AGENC_HOME = previousHome;
+  rmSync(temporaryHome, { recursive: true, force: true });
+  rmSync(temporaryWorkspace, { recursive: true, force: true });
+});
+
+describe("canonical rollout scan reuse", () => {
+  it("does not read the prefix it already validated a second time", () => {
+    const store = createStore("scan-reuse-prefix", 1_500);
+    try {
+      const size = statSync(store.rolloutPath).size;
+      const cold = measure(() => store.prepareSource("cold-attempt", []));
+      const warm = measure(() => store.prepareSource("warm-attempt", []));
+
+      // Nothing was appended between the two, so the warm scan owes the file
+      // one whole pass less: the prefix it already validated.
+      expect(cold.bytes - warm.bytes).toBeGreaterThan(size * 0.9);
+      expect(warm.value.messages).toEqual(cold.value.messages);
+      expect(warm.value.source.history_digest).toBe(
+        cold.value.source.history_digest,
+      );
+      expect(pinnedRows(warm.value)).toEqual(pinnedRows(cold.value));
+    } finally {
+      store.close();
+    }
+  });
+
+  it("validates only what was appended since the last scan", () => {
+    const store = createStore("scan-reuse-tail", 1_500);
+    try {
+      const cold = measure(() => store.prepareSource("cold-attempt", []));
+      store.appendRollout(
+        { type: "response_item", payload: { role: "user", content: "tail" } },
+        { durable: true },
+      );
+      const size = statSync(store.rolloutPath).size;
+      const grown = measure(() => store.prepareSource("grown-attempt", []));
+
+      expect(cold.bytes - grown.bytes).toBeGreaterThan(size * 0.9);
+      expect(grown.value.messages).toHaveLength(cold.value.messages.length + 1);
+      expect(grown.value.messages.at(-1)?.content).toBe("tail");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rejects a rollout whose validated prefix changed underneath it", () => {
+    const store = createStore("scan-reuse-corruption", 200);
+    try {
+      const cold = store.prepareSource("cold-attempt", []);
+      expect(cold.messages.length).toBeGreaterThan(0);
+      overwriteInPlace(store.rolloutPath, "row-0007-", "row-9999-");
+
+      // The second pass rereads the whole file every time, so its digest still
+      // has to match the prefix the scanner carried over.
+      expect(() => store.prepareSource("poisoned-attempt", [])).toThrow(
+        /does not match its durable binding/i,
+      );
+    } finally {
+      store.close();
+    }
+  });
+});
+
+function createStore(sessionId: string, rows: number): RolloutStore {
+  const store = new RolloutStore({
+    cwd: temporaryWorkspace,
+    sessionId,
+    agencVersion: "0.13.0",
+    sessionTempRoot: join(temporaryHome, "rollout-temp"),
+    autoStartScheduler: false,
+  });
+  store.open({
+    sessionId,
+    timestamp: new Date().toISOString(),
+    cwd: temporaryWorkspace,
+    originator: "canonical-scan-reuse-test",
+    agencVersion: "0.13.0",
+  });
+  for (let index = 0; index < rows; index += 1) {
+    store.appendRollout({
+      type: "response_item",
+      payload: {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `row-${String(index).padStart(4, "0")}-${"x".repeat(1_024)}`,
+      },
+    });
+  }
+  store.flushDurable();
+  return store;
+}
+
+/** The pinned source rows, minus the per-attempt ref ids. */
+function pinnedRows(
+  prepared: CompactionPreparedSourceV1,
+): readonly (readonly [number, string])[] {
+  return prepared.source.active_history_refs.map(
+    (ref) => [ref.first_sequence, ref.sha256] as const,
+  );
+}
+
+function measure<T>(operation: () => T): { value: T; bytes: number } {
+  meter.bytes = 0;
+  meter.recording = true;
+  try {
+    return { value: operation(), bytes: meter.bytes };
+  } finally {
+    meter.recording = false;
+  }
+}
+
+/** Replace one already-validated record's bytes without changing the length. */
+function overwriteInPlace(path: string, find: string, replace: string): void {
+  if (find.length !== replace.length) {
+    throw new Error("in-place overwrite must preserve the record length");
+  }
+  const bytes = readFileSync(path);
+  const offset = bytes.indexOf(find);
+  if (offset === -1) throw new Error(`rollout has no ${find} record`);
+  const fd = openSync(path, "r+");
+  try {
+    writeSync(fd, Buffer.from(replace, "utf8"), 0, replace.length, offset);
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/runtime/tests/session/rollout-store.canonical-scan-reuse.test.ts
+++ b/runtime/tests/session/rollout-store.canonical-scan-reuse.test.ts
@@ -28,8 +28,14 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
-import type { CompactionPreparedSourceV1 } from "../../src/services/compact/transaction-types.js";
+import {
+  COMPACTION_SOURCE_DIGEST_DOMAIN,
+  type CompactionPreparedSourceV1,
+} from "../../src/services/compact/transaction-types.js";
+import { compactConversationTransactionally } from "../../src/services/compact/transaction.js";
+import { scanCanonicalRollout } from "../../src/session/canonical-rollout-scanner.js";
 import { RolloutStore } from "../../src/session/rollout-store.js";
+import { bindCompactionTransactionHarness } from "../helpers/compaction-transaction-harness.js";
 
 let temporaryHome = "";
 let previousHome: string | undefined;
@@ -91,6 +97,73 @@ describe("canonical rollout scan reuse", () => {
     }
   });
 
+  it("reads a compacted session a whole replay cheaper", async () => {
+    const store = createStore("scan-reuse-compacted", 600);
+    try {
+      await commitWholeHistory(store, "compacted-attempt");
+      // One scan to take in the compaction's own tail: the claim below is
+      // about what the scans after that owe the file.
+      store.prepareSource("settle-attempt", []);
+      const size = statSync(store.rolloutPath).size;
+      // What this scan costs without a validated prefix, on these exact
+      // bytes: the two passes every scan owed before #2229.
+      const replay = measure(() =>
+        scanCanonicalRollout(
+          store.rolloutPath,
+          fullReplayOptions("scan-reuse-compacted"),
+        ),
+      );
+      const warm = measure(() => store.prepareSource("warm-attempt", []));
+
+      // The rollout really carries a committed compaction, and the prepared
+      // source is the history that compaction left active.
+      expect(replay.value.attempts.size).toBe(1);
+      expect(warm.value.messages.length).toBe(
+        replay.value.activeHistory?.messages.length,
+      );
+      expect(warm.value.messages.length).toBeLessThan(600);
+      expect(replay.bytes - warm.bytes).toBeGreaterThan(size * 0.9);
+    } finally {
+      store.close();
+    }
+  }, 180_000);
+
+  it("replays a compacted session past the retention ceiling", async () => {
+    const store = createStore("scan-reuse-ceiling", 200);
+    try {
+      await commitWholeHistory(store, "ceiling-attempt");
+      // Active history back over MAX_RETAINED_PREFIX_BYTES: past the ceiling
+      // a prefix answers its scan and is released, so the next scan replays.
+      appendRows(store, 1_200, 4_096);
+      const size = statSync(store.rolloutPath).size;
+      const replay = measure(() =>
+        scanCanonicalRollout(
+          store.rolloutPath,
+          fullReplayOptions("scan-reuse-ceiling"),
+        ),
+      );
+      const first = measure(() => store.prepareSource("first-attempt", []));
+      const second = measure(() => store.prepareSource("second-attempt", []));
+
+      // The same shape saves a whole replay below the ceiling, one test up.
+      // What is different here is only how much history the scan reduces.
+      const active = replay.value.activeHistory?.messages.length;
+      expect(replay.value.attempts.size).toBe(1);
+      expect(active).toBeGreaterThan(1_200);
+      expect(replay.bytes - second.bytes).toBeLessThan(size * 0.1);
+      // No regression either: what the released prefix costs is a replay, and
+      // a replay answers exactly what the full scan of the same bytes does.
+      expect(second.value.messages.length).toBe(active);
+      expect(second.value.messages).toEqual(first.value.messages);
+      expect(second.value.source.history_digest).toBe(
+        first.value.source.history_digest,
+      );
+      expect(pinnedRows(second.value)).toEqual(pinnedRows(first.value));
+    } finally {
+      store.close();
+    }
+  }, 180_000);
+
   it("rejects a rollout whose validated prefix changed underneath it", () => {
     const store = createStore("scan-reuse-corruption", 200);
     try {
@@ -108,6 +181,65 @@ describe("canonical rollout scan reuse", () => {
     }
   });
 });
+
+/** The scan `prepareSource` asks for, without a scanner to reuse a prefix. */
+function fullReplayOptions(sessionId: string) {
+  return {
+    sessionTempRoot: join(temporaryHome, "rollout-temp"),
+    expectedRunId: sessionId,
+    expectedEpoch: 1,
+    maximumScanMilliseconds: 120_000,
+    compactionSourceDigestDomain: COMPACTION_SOURCE_DIGEST_DOMAIN,
+    captureActiveHistory: true,
+  } as const;
+}
+
+/** Commit one whole-history compaction through the real transaction. */
+async function commitWholeHistory(
+  store: RolloutStore,
+  attemptId: string,
+): Promise<void> {
+  const prepared = store.prepareSource(attemptId, []);
+  const harness = bindCompactionTransactionHarness(store, {
+    contextWindowTokens: 2_000_000,
+    maxOutputTokens: 512,
+  });
+  try {
+    const result = await compactConversationTransactionally(harness.context, {
+      customInstructions: "canonical scan reuse",
+      automatic: false,
+      messagesToKeep: [],
+      completeSourceMessages: prepared.messages,
+      messagesToSummarize: prepared.messages,
+      summaryPlacement: "before_keep",
+      createBoundaryMarker: () => ({
+        role: "user",
+        originalRole: "developer",
+        content: "compaction boundary",
+      }),
+      createSummaryMessage: (content) => ({ role: "user", content }),
+    });
+    if (result.transaction === undefined) {
+      throw new Error("compaction did not commit a transaction");
+    }
+  } finally {
+    harness.close();
+    store.flushDurable();
+  }
+}
+
+function appendRows(store: RolloutStore, rows: number, fill: number): void {
+  for (let index = 0; index < rows; index += 1) {
+    store.appendRollout({
+      type: "response_item",
+      payload: {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `grown-${String(index).padStart(4, "0")}-${"x".repeat(fill)}`,
+      },
+    });
+  }
+  store.flushDurable();
+}
 
 function createStore(sessionId: string, rows: number): RolloutStore {
   const store = new RolloutStore({

--- a/runtime/tests/session/rollout-store.canonical-scan-reuse.test.ts
+++ b/runtime/tests/session/rollout-store.canonical-scan-reuse.test.ts
@@ -32,10 +32,9 @@ import {
   COMPACTION_SOURCE_DIGEST_DOMAIN,
   type CompactionPreparedSourceV1,
 } from "../../src/services/compact/transaction-types.js";
-import { compactConversationTransactionally } from "../../src/services/compact/transaction.js";
 import { scanCanonicalRollout } from "../../src/session/canonical-rollout-scanner.js";
 import { RolloutStore } from "../../src/session/rollout-store.js";
-import { bindCompactionTransactionHarness } from "../helpers/compaction-transaction-harness.js";
+import { commitWholeHistoryCompaction } from "../helpers/canonical-rollout-scan.js";
 
 let temporaryHome = "";
 let previousHome: string | undefined;
@@ -199,33 +198,11 @@ async function commitWholeHistory(
   store: RolloutStore,
   attemptId: string,
 ): Promise<void> {
-  const prepared = store.prepareSource(attemptId, []);
-  const harness = bindCompactionTransactionHarness(store, {
+  await commitWholeHistoryCompaction(store, {
+    attemptId,
+    customInstructions: "canonical scan reuse",
     contextWindowTokens: 2_000_000,
-    maxOutputTokens: 512,
   });
-  try {
-    const result = await compactConversationTransactionally(harness.context, {
-      customInstructions: "canonical scan reuse",
-      automatic: false,
-      messagesToKeep: [],
-      completeSourceMessages: prepared.messages,
-      messagesToSummarize: prepared.messages,
-      summaryPlacement: "before_keep",
-      createBoundaryMarker: () => ({
-        role: "user",
-        originalRole: "developer",
-        content: "compaction boundary",
-      }),
-      createSummaryMessage: (content) => ({ role: "user", content }),
-    });
-    if (result.transaction === undefined) {
-      throw new Error("compaction did not commit a transaction");
-    }
-  } finally {
-    harness.close();
-    store.flushDurable();
-  }
 }
 
 function appendRows(store: RolloutStore, rows: number, fill: number): void {

--- a/runtime/tests/session/rollout-store.test.ts
+++ b/runtime/tests/session/rollout-store.test.ts
@@ -31,7 +31,11 @@ import { RolloutStore } from "./rollout-store.js";
 import { getProjectDir, getSessionDir } from "./session-store.js";
 
 const TEST_RUN_TIMESTAMP = "2026-08-03T00:00:00.000Z";
-/** The two disk registries a validated rollout prefix owns while it is held. */
+/**
+ * The two disk registries a validated rollout prefix owns while it is held. A
+ * store holds one prefix per shape of bookkeeping question, up to the
+ * scanner's own limit of two.
+ */
 const scanRegistryEntries = [
   expect.stringMatching(/^agenc-c2-payloads-/u),
   expect.stringMatching(/^agenc-recovery-identities-/u),
@@ -288,6 +292,46 @@ describe("RolloutStore temporary authority", () => {
     }
     expect(readdirSync(rootA)).toEqual([]);
     expect(readdirSync(rootB)).toEqual([]);
+  });
+
+  it("holds at most the two rollout prefixes its bookkeeping asks about", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "agenc-rollout-prefix-cwd-"));
+    const root = join(agencHome, "session-temp-prefixes");
+    let store: RolloutStore | undefined;
+    try {
+      // Opening reconciles compactions, which is one shape of question.
+      store = openStore({
+        cwd,
+        sessionId: "prefix-lifetime",
+        sessionTempRoot: root,
+      });
+      expect(readdirSync(root).sort()).toEqual(scanRegistryEntries);
+
+      for (let index = 0; index < 32; index += 1) {
+        store.appendRollout({
+          type: "response_item",
+          payload: { role: "user", content: `prefix-lifetime-${index}` },
+        });
+      }
+      store.flushDurable();
+
+      // Preparing a compaction source is the other shape: it reduces active
+      // history, so it cannot answer from the prefix that does not.
+      store.prepareSource("prefix-lifetime-attempt", []);
+      expect(readdirSync(root).sort()).toEqual([
+        expect.stringMatching(/^agenc-c2-payloads-/u),
+        expect.stringMatching(/^agenc-c2-payloads-/u),
+        expect.stringMatching(/^agenc-recovery-identities-/u),
+        expect.stringMatching(/^agenc-recovery-identities-/u),
+      ]);
+
+      store.prepareSource("prefix-lifetime-attempt-2", []);
+      expect(readdirSync(root)).toHaveLength(4);
+    } finally {
+      store?.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+    expect(readdirSync(root)).toEqual([]);
   });
 });
 

--- a/runtime/tests/session/rollout-store.test.ts
+++ b/runtime/tests/session/rollout-store.test.ts
@@ -31,6 +31,11 @@ import { RolloutStore } from "./rollout-store.js";
 import { getProjectDir, getSessionDir } from "./session-store.js";
 
 const TEST_RUN_TIMESTAMP = "2026-08-03T00:00:00.000Z";
+/** The two disk registries a validated rollout prefix owns while it is held. */
+const scanRegistryEntries = [
+  expect.stringMatching(/^agenc-c2-payloads-/u),
+  expect.stringMatching(/^agenc-recovery-identities-/u),
+];
 
 let agencHome = "";
 let originalAgencHome = "";
@@ -270,8 +275,10 @@ describe("RolloutStore temporary authority", () => {
       });
       expect(storeA.sessionTempRoot).toBe(rootA);
       expect(storeB.sessionTempRoot).toBe(rootB);
-      expect(readdirSync(rootA)).toEqual([]);
-      expect(readdirSync(rootB)).toEqual([]);
+      // An open store keeps the registries of the rollout prefix it validated,
+      // and keeps them under the root it captured rather than an ambient one.
+      expect(readdirSync(rootA).sort()).toEqual(scanRegistryEntries);
+      expect(readdirSync(rootB).sort()).toEqual(scanRegistryEntries);
     } finally {
       storeA?.close();
       storeB?.close();
@@ -279,6 +286,8 @@ describe("RolloutStore temporary authority", () => {
       rmSync(cwdA, { recursive: true, force: true });
       rmSync(cwdB, { recursive: true, force: true });
     }
+    expect(readdirSync(rootA)).toEqual([]);
+    expect(readdirSync(rootB)).toEqual([]);
   });
 });
 

--- a/runtime/tests/state/recovery-journal-contract.test.ts
+++ b/runtime/tests/state/recovery-journal-contract.test.ts
@@ -124,6 +124,49 @@ describe("strict canonical journal contract", () => {
     expect(result.records[1]?.rollingSha256).toBe(result.sourceSha256);
   });
 
+  it("snapshots the proof of everything pushed so far without closing", () => {
+    const lines = [1, 2, 3].map((sequence) =>
+      validEvent(sequence, "turn_started"),
+    );
+    const validator = new StrictCanonicalJournalValidator();
+    validator.push(Buffer.from(lines[0]! + lines[1]!, "utf8"));
+
+    // A reader that has validated a prefix of an append-only journal proves
+    // that prefix, then pushes only what was appended since.
+    expect(validator.snapshot()).toEqual(
+      validateCanonicalJournalText(lines[0]! + lines[1]!),
+    );
+    validator.push(Buffer.from(lines[2]!, "utf8"));
+    expect(validator.snapshot()).toEqual(
+      validateCanonicalJournalText(lines.join("")),
+    );
+    expect(validator.finish().physicalLineCount).toBe(3);
+  });
+
+  it("keeps the validator usable after a rejected snapshot, unlike finish", () => {
+    const complete = validEvent(1, "turn_started");
+    const split = complete.length - 4;
+    const validator = new StrictCanonicalJournalValidator();
+    validator.push(Buffer.from(complete.slice(0, split), "utf8"));
+
+    // A record cut in half by the prefix boundary is a legitimate state for a
+    // reader that has not reached the end of the file.
+    expect(() => validator.snapshot()).toThrow(
+      expect.objectContaining({ reasonCode: "unterminated_record" }),
+    );
+    validator.push(Buffer.from(complete.slice(split), "utf8"));
+    expect(validator.snapshot().physicalLineCount).toBe(1);
+
+    const closing = new StrictCanonicalJournalValidator();
+    closing.push(Buffer.from(complete.slice(0, split), "utf8"));
+    expect(() => closing.finish()).toThrow(
+      expect.objectContaining({ reasonCode: "unterminated_record" }),
+    );
+    expect(() => closing.push(Buffer.from(complete.slice(split), "utf8")))
+      .toThrow(/validator is closed/u);
+    expect(() => closing.snapshot()).toThrow(/validator is closed/u);
+  });
+
   it("uses an existing digest as an anchor and never treats a fresh digest as proof", () => {
     const raw = validEvent(1, "turn_complete");
     const unanchored = validateCanonicalJournalText(raw);


### PR DESCRIPTION
## Why

Closes #2229. Measured in production today: opening a session whose rollout is 24 MB took **54.9 s** for 394 entries, against 0.85 s for a 1-entry session. In that window `canonical_rollout_scan` was 187 slow operations totalling **71.4 s** — median 202 ms, p90 967 ms, max 1,895 ms — while every other slow label combined was 5.3 s.

## What

The obvious fix does not work, and the first thing this branch established is why: across a compaction step and a reopen, **zero** scans repeat the same (file identity + options) pair, so memoising scan results would never hit. What repeats is the work.

Each scan is two passes. Pass one validates every record through the strict canonical journal and reduces the compaction lifecycle; pass two is digest-anchored and picks the rows the lifecycles and pins name. Only pass two depends on what the caller asked for. So pass one is now carried between scans: a `CanonicalRolloutScanner` owns a validated prefix keyed by the rollout's `(dev, ino)` plus the options pass one consumes, and a later scan of the same inode pushes only the bytes appended since. `RolloutStore` holds one scanner across all eight bookkeeping call sites.

**Safety is kept, not traded.** Pass two still reads the whole file on every call and its digest must equal the incrementally maintained one, so a prefix that changed underneath a reused validator fails the scan instead of answering from it, and any failure drops the prefix so the next scan replays from zero.

## Evidence

Byte-metered with a `readSync` counter, same scenario on `main` and on the branch:

| | main | branch |
|---|---|---|
| compaction step, 5.6 MB rollout | 37.0 MB read | 24.2 MB |
| session reopen | 42.0 MB | 30.9 MB |
| retention maintenance | 14.6 MB | 9.0 MB |
| two consecutive `prepareSource` calls, unchanged 1.67 MB rollout | 5,024,828 B twice | second reads 3,349,790 B |

On a compacted session the warm scan costs exactly one whole pass less than a full replay (1,497,851 B saved on a 1,497,851 B file).

## Where it stops helping, stated rather than implied

A retained prefix is charged in persisted canonical bytes, about 266 B per pinned message, so it is released past the ceiling and the next scan replays the file exactly as `main` does — no regression, no gain. Both sides are now pinned by tests: the win below the ceiling, and the exact-parity fallback above it (16,329,408 B on both paths, still answering with the same messages, digest and pinned rows).

One residual is documented in the ceiling's own comment: the counter runs under what a prefix actually holds — at eight committed compactions it counts 2.1 MB while a gc-settled `--expose-gc` child measures 4,238,632 B retained, because hydrating a persisted ref costs more than its canonical bytes. The bound stays a small constant rather than session-scaled, which is the property the ceiling exists for, but the constant is not the number in the constant. Making the ceiling mean heap rather than canonical bytes is a separate change.

## Review

Four rounds. Reviewers reproduced the byte measurements independently (to within 5 bytes on the retained total, exactly on the 4,141,391 B proof), falsified every guard by reverting it and reading the failure, and corrected one of their own earlier findings with measurements. 60 files / 725 tests pass; typecheck clean apart from the pre-existing TS2883 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)