### PR TITLE
fix(gateway): reserve media quota before provider calls

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -350,6 +350,32 @@ Use the coding-agent `ImagineImage` / `ImagineVideo` tools in a grok session
 instead ([imagine.md](imagine.md)). Helius on-chain reads still install when
 configured.
 
+#### Quotas for directly constructed media helpers
+
+Embedders that construct `XaiMemeFeature` or `XaiVoiceFeature` directly use a
+durable reservation ledger at `usageFile`. A slot is committed before the
+initial progress reply and provider call. Instances and processes using the
+same ledger share its limit, including image and voice helpers configured
+with the same path. Independent ledgers retain independent limits.
+
+The ledger keeps the existing `{day, count}` format. The UTC day is sampled
+under the runtime's Node.js SQLite lock, and publication uses a synced
+temporary file, atomic rename, and directory sync. Clock rollback does not
+reopen an earlier day's quota. Invalid limits and malformed or inaccessible
+ledgers block provider calls rather than resetting the count.
+
+Empty or unrecognized requests do not reserve quota. Once committed, a slot
+is never refunded, including after provider errors, timeouts, invalid media,
+reply failures, or a process crash. A crash before provider entry can consume
+an unused slot. Keeping that reservation prevents an uncertain paid outcome
+from being counted as free. A provider finishing after midnight cannot
+overwrite the new day's usage.
+
+Stop older gateway processes before adopting this reservation protocol;
+older writers do not take the quota lock. Existing counts are preserved,
+but historical undercounts cannot be reconstructed from this ledger. This
+change does not install media routes in `startGateway`.
+
 ### Read-only Solana (Helius)
 
 ```bash

--- a/runtime/src/gateway/media-quota.ts
+++ b/runtime/src/gateway/media-quota.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, realpath } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { writeDurableAtomicFile } from "../utils/durable-atomic-file.js";
+import { asRecord } from "../utils/record.js";
+import { acquireLocalSqliteLock, assertLocalPrivateFile } from "../utils/sqlite-lock.js";
+
+interface DailyMediaUsage {
+  readonly day: string;
+  readonly count: number;
+}
+
+function isUtcDay(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const midnight = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isFinite(midnight) &&
+    new Date(midnight).toISOString().slice(0, 10) === value;
+}
+
+async function readDailyMediaUsage(path: string): Promise<DailyMediaUsage | undefined> {
+  let serialized: string;
+  try {
+    await assertLocalPrivateFile(path, { timeoutMs: 5_000, label: "media quota ledger" });
+    serialized = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  const state = asRecord(JSON.parse(serialized) as unknown);
+  const day = state?.day;
+  const count = state?.count;
+  if (!isUtcDay(day) || typeof count !== "number" || !Number.isSafeInteger(count) || count < 0) {
+    throw new Error("Invalid media quota ledger; preserve it for recovery");
+  }
+  return { day, count };
+}
+
+export async function reserveDailyMediaQuota(options: {
+  readonly usageFile: string;
+  readonly dailyLimit: number;
+  readonly now: () => number;
+}): Promise<boolean> {
+  if (!Number.isSafeInteger(options.dailyLimit) || options.dailyLimit < 0) {
+    throw new Error("Daily media limit must be a nonnegative safe integer");
+  }
+  const requestedPath = resolve(options.usageFile);
+  await mkdir(dirname(requestedPath), { recursive: true, mode: 0o700 });
+  const directory = await realpath(dirname(requestedPath));
+  const path = join(directory, basename(requestedPath));
+  const release = await acquireLocalSqliteLock(`${path}.lock.sqlite`, {
+    timeoutMs: 5_000,
+    label: "media quota reservation",
+  });
+  try {
+    const today = new Date(options.now()).toISOString().slice(0, 10);
+    const usage = await readDailyMediaUsage(path);
+    const day = usage !== undefined && usage.day > today ? usage.day : today;
+    const count = usage?.day === day ? usage.count : 0;
+    if (count >= options.dailyLimit) return false;
+    await writeDurableAtomicFile(
+      path,
+      `${path}.${randomUUID()}.tmp`,
+      `${JSON.stringify({ day, count: count + 1 }, null, 2)}\n`,
+    );
+    return true;
+  } finally {
+    release();
+  }
+}

--- a/runtime/src/gateway/meme.ts
+++ b/runtime/src/gateway/meme.ts
@@ -6,13 +6,7 @@
  * agent so media credits are not spent by surprise.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
-import { dirname } from "node:path";
+import { reserveDailyMediaQuota } from "./media-quota.js";
 import type { ChannelReplyOptions } from "./types.js";
 
 export type GatewayMemeReplyOptions = ChannelReplyOptions;
@@ -37,11 +31,6 @@ export interface XaiMemeFeatureOptions {
 interface XaiImageGenerationResponse {
   readonly data?: readonly { readonly url?: string }[];
   readonly error?: { readonly message?: string };
-}
-
-interface MemeUsageState {
-  readonly day: string;
-  readonly count: number;
 }
 
 export function parseMemePrompt(text: string): string | null {
@@ -76,28 +65,6 @@ function cleanNaturalMediaPrompt(prompt: string): string {
     .replace(/\s+/g, " ")
     .replace(/^[\s:,-]+/u, "")
     .trim();
-}
-
-function readUsage(path: string, day: string): MemeUsageState {
-  if (!existsSync(path)) return { day, count: 0 };
-  try {
-    const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<MemeUsageState>;
-    if (raw.day === day && typeof raw.count === "number" && raw.count >= 0) {
-      return { day, count: Math.floor(raw.count) };
-    }
-  } catch {
-    // Corrupt usage file resets only the soft daily cap, not any xAI-side cap.
-  }
-  return { day, count: 0 };
-}
-
-function writeUsage(path: string, usage: MemeUsageState): void {
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  writeFileSync(path, `${JSON.stringify(usage, null, 2)}\n`, { mode: 0o600 });
-}
-
-function today(now: number): string {
-  return new Date(now).toISOString().slice(0, 10);
 }
 
 function trimPrompt(prompt: string): string {
@@ -136,9 +103,12 @@ export class XaiMemeFeature implements GatewayMemeFeature {
       return true;
     }
 
-    const day = today(this.#now());
-    const usage = readUsage(this.#usageFile, day);
-    if (usage.count >= this.#dailyLimit) {
+    const reserved = await reserveDailyMediaQuota({
+      usageFile: this.#usageFile,
+      dailyLimit: this.#dailyLimit,
+      now: this.#now,
+    });
+    if (!reserved) {
       await input.reply("Meme cap hit for today. The image wallet is not an infinite buffet.");
       return true;
     }
@@ -146,7 +116,6 @@ export class XaiMemeFeature implements GatewayMemeFeature {
     await input.reply("Building the image. Keep your tabs on.");
     try {
       const imageUrl = await this.#generate(prompt);
-      writeUsage(this.#usageFile, { day, count: usage.count + 1 });
       const caption = `AgenC image: ${prompt}`.slice(0, 1024);
       await input.reply(caption, { photoUrl: imageUrl, caption });
     } catch (error) {

--- a/runtime/src/gateway/voice.ts
+++ b/runtime/src/gateway/voice.ts
@@ -7,9 +7,7 @@
  * surprise.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
-
+import { reserveDailyMediaQuota } from "./media-quota.js";
 import type { ChannelReplyOptions } from "./types.js";
 
 export interface GatewayVoiceFeature {
@@ -36,11 +34,6 @@ export interface ParsedVoicePrompt {
   readonly text: string;
   readonly voiceId: string;
   readonly song: boolean;
-}
-
-interface VoiceUsageState {
-  readonly day: string;
-  readonly count: number;
 }
 
 interface VoiceConfig {
@@ -250,28 +243,6 @@ function normalizeVoiceText(prompt: string): string {
   return prompt.replace(/\s+/g, " ").trim().slice(0, 1_500);
 }
 
-function readUsage(path: string, day: string): VoiceUsageState {
-  if (!existsSync(path)) return { day, count: 0 };
-  try {
-    const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<VoiceUsageState>;
-    if (raw.day === day && typeof raw.count === "number" && raw.count >= 0) {
-      return { day, count: Math.floor(raw.count) };
-    }
-  } catch {
-    // Corrupt usage file resets only the soft daily cap, not any xAI-side cap.
-  }
-  return { day, count: 0 };
-}
-
-function writeUsage(path: string, usage: VoiceUsageState): void {
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  writeFileSync(path, `${JSON.stringify(usage, null, 2)}\n`, { mode: 0o600 });
-}
-
-function today(now: number): string {
-  return new Date(now).toISOString().slice(0, 10);
-}
-
 export class XaiVoiceFeature implements GatewayVoiceFeature {
   readonly #apiKey: string;
   readonly #usageFile: string;
@@ -314,9 +285,12 @@ export class XaiVoiceFeature implements GatewayVoiceFeature {
       return true;
     }
 
-    const day = today(this.#now());
-    const usage = readUsage(this.#usageFile, day);
-    if (usage.count >= this.#dailyLimit) {
+    const reserved = await reserveDailyMediaQuota({
+      usageFile: this.#usageFile,
+      dailyLimit: this.#dailyLimit,
+      now: this.#now,
+    });
+    if (!reserved) {
       await input.reply("Daily voice limit reached. Try again later.");
       return true;
     }
@@ -327,7 +301,6 @@ export class XaiVoiceFeature implements GatewayVoiceFeature {
         text: parsed.song ? wrapSinging(prompt) : prompt,
         voiceId: parsed.voiceId,
       });
-      writeUsage(this.#usageFile, { day, count: usage.count + 1 });
       const title = parsed.song ? "AgenC short song" : "AgenC voice";
       await input.reply(title, {
         audioBytes: audio.bytes,

--- a/runtime/tests/gateway/fixtures/media-quota.mjs
+++ b/runtime/tests/gateway/fixtures/media-quota.mjs
@@ -1,0 +1,38 @@
+import { appendFileSync } from "node:fs";
+import { once } from "node:events";
+import { XaiMemeFeature } from "../../../src/gateway/meme.ts";
+import { XaiVoiceFeature } from "../../../src/gateway/voice.ts";
+
+const [usageFile, effectsFile, kind, limitText, mode, date] = process.argv.slice(2);
+const timer = setTimeout(() => process.exit(70), 10_000);
+try {
+  const ready = once(process.stdin, "data");
+  process.stdin.resume();
+  process.stdout.write("READY\n");
+  await ready;
+  process.stdin.pause();
+  const Feature = kind === "meme" ? XaiMemeFeature : XaiVoiceFeature;
+  const feature = new Feature({
+    apiKey: "fake-provider-only",
+    usageFile,
+    dailyLimit: Number(limitText),
+    now: () => Date.parse(date),
+    fetchImpl: async () => {
+      appendFileSync(effectsFile, JSON.stringify({ kind, pid: process.pid }) + "\n", { mode: 0o600 });
+      if (mode === "after_provider") process.exit(17);
+      return kind === "meme"
+        ? Response.json({ data: [{ url: "https://image.example/fake.png" }] })
+        : new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "audio/mpeg" } });
+    },
+  });
+  await feature.handle({
+    text: `/${kind} test`,
+    reply: async () => {
+      if (mode === "before_provider") process.exit(17);
+      return "reply-id";
+    },
+  });
+  process.stdout.write("DONE\n");
+} finally {
+  clearTimeout(timer);
+}

--- a/runtime/tests/gateway/media-quota.process.test.ts
+++ b/runtime/tests/gateway/media-quota.process.test.ts
@@ -1,0 +1,117 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Worker {
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly ready: Promise<void>;
+  readonly completion: Promise<{ code: number | null; stdout: string; stderr: string }>;
+}
+
+describe("cross-process media quota reservations", () => {
+  let home: string;
+  let usageFile: string;
+  let effectsFile: string;
+  let workers: Worker[];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-media-process-"));
+    usageFile = join(home, "usage.json");
+    effectsFile = join(home, "effects.jsonl");
+    workers = [];
+  });
+
+  afterEach(async () => {
+    for (const worker of workers) {
+      if (worker.child.exitCode === null && worker.child.signalCode === null) {
+        worker.child.kill("SIGKILL");
+      }
+    }
+    await Promise.allSettled(workers.map(worker => worker.completion));
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function launch(kind: "meme" | "voice", limit: number, mode = "normal", date = "2026-09-08T00:00:00Z"): Worker {
+    const runtimeRoot = join(import.meta.dirname, "../..");
+    const child = spawn(process.execPath, [
+      "--unhandled-rejections=strict", "--import", "tsx",
+      join(import.meta.dirname, "fixtures/media-quota.mjs"),
+      usageFile, effectsFile, kind, String(limit), mode, date,
+    ], {
+      cwd: runtimeRoot,
+      env: { ...process.env, TSX_TSCONFIG_PATH: join(runtimeRoot, "tsconfig.json") },
+      stdio: "pipe",
+    });
+    let stdout = "";
+    let stderr = "";
+    const ready = Promise.withResolvers<void>();
+    child.stdout.setEncoding("utf8").on("data", (chunk: string) => {
+      stdout += chunk;
+      if (stdout.includes("READY\n")) ready.resolve();
+    });
+    child.stderr.setEncoding("utf8").on("data", (chunk: string) => { stderr += chunk; });
+    const completion = new Promise<Awaited<Worker["completion"]>>((resolveCompletion, reject) => {
+      child.once("error", error => {
+        ready.reject(error);
+        reject(error);
+      });
+      child.once("close", code => {
+        ready.reject(new Error(`worker exited before readiness: ${code} ${stderr}`));
+        resolveCompletion({ code, stdout, stderr });
+      });
+    });
+    void completion.catch(() => undefined);
+    void ready.promise.catch(() => undefined);
+    const worker = { child, ready: ready.promise, completion };
+    workers.push(worker);
+    return worker;
+  }
+
+  async function start(group: readonly Worker[]): Promise<void> {
+    await Promise.all(group.map(worker => worker.ready));
+    for (const worker of group) worker.child.stdin.end("GO\n");
+  }
+
+  function effects(): unknown[] {
+    return existsSync(effectsFile)
+      ? readFileSync(effectsFile, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line))
+      : [];
+  }
+
+  it.each([1, 3])("limits a synchronized six-process burst to %s provider calls", async (limit) => {
+    const group = Array.from({ length: 6 }, (_, index) => launch(index % 2 === 0 ? "meme" : "voice", limit));
+    await start(group);
+    for (const result of await Promise.all(group.map(worker => worker.completion))) {
+      expect(result.code, result.stderr).toBe(0);
+      expect(result.stdout).toContain("DONE\n");
+    }
+    expect(effects()).toHaveLength(limit);
+    expect(JSON.parse(readFileSync(usageFile, "utf8"))).toEqual({ day: "2026-09-08", count: limit });
+  }, 15_000);
+
+  it("rolls a full previous-day ledger forward under concurrent processes", async () => {
+    writeFileSync(usageFile, JSON.stringify({ day: "2026-09-07", count: 50 }), { mode: 0o600 });
+    const group = [launch("meme", 1), launch("voice", 1)];
+    await start(group);
+    for (const result of await Promise.all(group.map(worker => worker.completion))) {
+      expect(result.code, result.stderr).toBe(0);
+    }
+    expect(effects()).toHaveLength(1);
+    expect(JSON.parse(readFileSync(usageFile, "utf8"))).toEqual({ day: "2026-09-08", count: 1 });
+  }, 15_000);
+
+  it.each(["before_provider", "after_provider"])("does not refund a crash %s", async (mode) => {
+    const crashed = launch("meme", 1, mode);
+    await start([crashed]);
+    const crashedResult = await crashed.completion;
+    expect(crashedResult.code, crashedResult.stderr).toBe(17);
+    expect(JSON.parse(readFileSync(usageFile, "utf8"))).toEqual({ day: "2026-09-08", count: 1 });
+    const retry = launch("voice", 1);
+    await start([retry]);
+    const retryResult = await retry.completion;
+    expect(retryResult.code, retryResult.stderr).toBe(0);
+    expect(effects()).toHaveLength(mode === "before_provider" ? 0 : 1);
+  }, 15_000);
+});

--- a/runtime/tests/gateway/media-quota.test.ts
+++ b/runtime/tests/gateway/media-quota.test.ts
@@ -1,0 +1,237 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { XaiMemeFeature } from "../../src/gateway/meme.js";
+import { XaiVoiceFeature } from "../../src/gateway/voice.js";
+import { acquireLocalSqliteLock } from "../../src/utils/sqlite-lock.js";
+
+type MediaKind = "meme" | "voice";
+
+describe("gateway media quota reservations", () => {
+  let home: string;
+  let usageFile: string;
+  let now: number;
+  let providerCalls: string[];
+  let providerGate: Promise<void> | undefined;
+  let firstProvider: ReturnType<typeof Promise.withResolvers<void>>;
+  let failProvider: boolean;
+  let pending: Promise<unknown>[];
+  let gates: ReturnType<typeof Promise.withResolvers<void>>[];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-media-quota-"));
+    usageFile = join(home, "usage.json");
+    now = Date.parse("2026-09-08T23:59:59Z");
+    providerCalls = [];
+    providerGate = undefined;
+    firstProvider = Promise.withResolvers<void>();
+    failProvider = false;
+    pending = [];
+    gates = [];
+  });
+
+  afterEach(async () => {
+    for (const gate of gates) gate.resolve();
+    await Promise.allSettled(pending);
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function usage(path = usageFile): { day: string; count: number } {
+    return JSON.parse(readFileSync(path, "utf8"));
+  }
+
+  function request(kind: MediaKind, options: {
+    readonly limit?: number;
+    readonly path?: string;
+    readonly text?: string;
+    readonly reply?: () => Promise<string>;
+  } = {}): Promise<boolean> {
+    const fetchImpl: typeof fetch = async (input) => {
+      providerCalls.push(String(input));
+      firstProvider.resolve();
+      await providerGate;
+      if (failProvider) throw new Error("uncertain provider outcome");
+      return String(input).endsWith("/tts")
+        ? new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "audio/mpeg" } })
+        : Response.json({ data: [{ url: "https://image.example/fake.png" }] });
+    };
+    const configuration = {
+      apiKey: "fake-provider-only",
+      usageFile: options.path ?? usageFile,
+      dailyLimit: options.limit ?? 1,
+      now: () => now,
+      fetchImpl,
+    };
+    const feature = kind === "meme"
+      ? new XaiMemeFeature(configuration)
+      : new XaiVoiceFeature(configuration);
+    const result = feature.handle({
+      text: options.text ?? `/${kind} test`,
+      reply: options.reply ?? (async () => "reply-id"),
+    });
+    pending.push(result);
+    void result.catch(() => undefined);
+    return result;
+  }
+
+  it.each<MediaKind>(["meme", "voice"])("admits only one of two concurrent %s instances", async (kind) => {
+    await Promise.all([request(kind), request(kind)]);
+    expect(providerCalls).toHaveLength(1);
+    expect(usage()).toEqual({ day: "2026-09-08", count: 1 });
+  });
+
+  it("shares one ledger across meme and voice instances", async () => {
+    await Promise.all([request("meme"), request("voice")]);
+    expect(providerCalls).toHaveLength(1);
+    expect(usage().count).toBe(1);
+  });
+
+  it("does not exceed the remaining quota during a larger burst", async () => {
+    writeFileSync(usageFile, JSON.stringify({ day: "2026-09-08", count: 3 }), { mode: 0o600 });
+    await Promise.all(Array.from({ length: 20 }, (_, index) =>
+      request(index % 2 === 0 ? "meme" : "voice", { limit: 5 }),
+    ));
+    expect(providerCalls).toHaveLength(2);
+    expect(usage().count).toBe(5);
+  });
+
+  it("keeps independent ledgers independent", async () => {
+    const second = join(home, "voice.json");
+    await Promise.all([request("meme"), request("voice", { path: second })]);
+    expect(providerCalls).toHaveLength(2);
+    expect(usage().count).toBe(1);
+    expect(usage(second).count).toBe(1);
+  });
+
+  it("reserves durably before entering a pending provider call", async () => {
+    const gate = Promise.withResolvers<void>();
+    gates.push(gate);
+    providerGate = gate.promise;
+    const result = request("meme");
+    await firstProvider.promise;
+    expect(existsSync(usageFile)).toBe(true);
+    expect(usage().count).toBe(1);
+    gate.resolve();
+    await result;
+  });
+
+  it.each<MediaKind>(["meme", "voice"])("keeps uncertain %s provider failures charged", async (kind) => {
+    failProvider = true;
+    await request(kind);
+    await request(kind);
+    expect(providerCalls).toHaveLength(1);
+    expect(usage().count).toBe(1);
+  });
+
+  it("keeps a committed slot when the initial reply fails before provider entry", async () => {
+    const failure = new Error("reply failed");
+    await expect(request("voice", { reply: async () => { throw failure; } })).rejects.toBe(failure);
+    expect(providerCalls).toHaveLength(0);
+    expect(usage().count).toBe(1);
+    await request("voice");
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  it("keeps a slot when delivering the generated media fails", async () => {
+    let replies = 0;
+    await request("meme", { reply: async () => {
+      replies += 1;
+      if (replies === 2) throw new Error("media delivery failed");
+      return "reply-id";
+    } });
+    expect(providerCalls).toHaveLength(1);
+    expect(usage().count).toBe(1);
+    await request("meme");
+    expect(providerCalls).toHaveLength(1);
+  });
+
+  it.each<MediaKind>(["meme", "voice"])("does not charge an empty or unrelated %s request", async (kind) => {
+    await request(kind, { text: `/${kind}` });
+    await expect(request(kind, { text: "ordinary question" })).resolves.toBe(false);
+    expect(providerCalls).toHaveLength(0);
+    expect(existsSync(usageFile)).toBe(false);
+  });
+
+  it("rolls the UTC day forward without overspending the new bucket", async () => {
+    await request("meme");
+    now = Date.parse("2026-09-09T00:00:00Z");
+    await Promise.all([request("meme"), request("voice")]);
+    expect(providerCalls).toHaveLength(2);
+    expect(usage()).toEqual({ day: "2026-09-09", count: 1 });
+  });
+
+  it("does not reopen an earlier bucket after clock rollback", async () => {
+    await request("voice");
+    now = Date.parse("2026-09-07T00:00:00Z");
+    await request("meme");
+    expect(providerCalls).toHaveLength(1);
+    expect(usage()).toEqual({ day: "2026-09-08", count: 1 });
+  });
+
+  it("samples the day after waiting for the reservation lock", async () => {
+    const release = await acquireLocalSqliteLock(`${usageFile}.lock.sqlite`);
+    let result: Promise<boolean>;
+    try {
+      result = request("meme");
+      await nextEventLoopTurn();
+      now = Date.parse("2026-09-09T00:00:00Z");
+    } finally {
+      release();
+    }
+    await result;
+    expect(usage()).toEqual({ day: "2026-09-09", count: 1 });
+  });
+
+  it("does not let an older in-flight provider overwrite a new day's usage", async () => {
+    const gate = Promise.withResolvers<void>();
+    gates.push(gate);
+    providerGate = gate.promise;
+    const older = request("meme");
+    await firstProvider.promise;
+    providerGate = undefined;
+    now = Date.parse("2026-09-09T00:00:00Z");
+    await request("voice");
+    expect(usage()).toEqual({ day: "2026-09-09", count: 1 });
+    gate.resolve();
+    await older;
+    expect(usage()).toEqual({ day: "2026-09-09", count: 1 });
+    expect(providerCalls).toHaveLength(2);
+  });
+
+  it.each(["{", "null", '{"day":"2026-09-08","count":-1}', '{"day":"2026-09-08","count":1.5}', '{"day":"2026-02-30","count":0}'])(
+    "fails closed on an invalid usage ledger (%s)", async (contents) => {
+      writeFileSync(usageFile, contents, { mode: 0o600 });
+      await expect(request("meme")).rejects.toThrow();
+      expect(providerCalls).toHaveLength(0);
+      expect(readFileSync(usageFile, "utf8")).toBe(contents);
+    },
+  );
+
+  it.each([NaN, Infinity, -1, 1.5])("rejects an invalid daily limit (%s) before provider entry", async (limit) => {
+    await expect(request("voice", { limit })).rejects.toThrow();
+    expect(providerCalls).toHaveLength(0);
+    expect(existsSync(usageFile)).toBe(false);
+  });
+
+  it("blocks provider calls when the ledger is not a regular file", async () => {
+    mkdirSync(usageFile);
+    await expect(request("meme")).rejects.toThrow();
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  it("uses one lock through two aliases of the ledger parent", async () => {
+    const alias = join(home, "alias");
+    const directory = join(home, "ledger");
+    mkdirSync(directory, { mode: 0o700 });
+    symlinkSync(directory, alias, "junction");
+    const directPath = join(directory, "usage.json");
+    await Promise.all([
+      request("meme", { path: directPath }),
+      request("voice", { path: join(alias, "usage.json") }),
+    ]);
+    expect(providerCalls).toHaveLength(1);
+    expect(usage(directPath).count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Changes

Closes #2065.

- Reserve daily image and voice quota before the progress reply and provider call. Instances and processes sharing a ledger use the existing Node.js SQLite lock and durable atomic writer.
- Preserve the `{day, count}` ledger format, sample UTC day under the lock, and prevent clock rollback from reopening an earlier bucket. Invalid limits or unreadable/malformed ledgers block provider entry.
- Keep every committed reservation, including uncertain provider outcomes, reply failures, and process crashes. A crash before provider entry can consume an unused slot. Document the policy and the need to stop older unlocked writers before upgrading.
- Remove duplicated read/write helpers and post-provider writes. This does not install the currently disabled media routes in `startGateway`.

## Verification

- Reproduced both original races with two instances at limit 1. Each made two fake provider calls and recorded one use. The initial regression suite failed 21 cases against the original implementation.
- Both TypeScript checks and all gateway tests passed locally in the test container, 378 tests across 32 files. New coverage includes 27 unit cases and five real-process cases for simultaneous bursts, midnight rollover, and crashes before/after provider entry. All provider responses are fake; no paid requests were made.
- Build, generated SDK verification, all PTY startup checks, and the Linux native lane passed. The native lane ran 92 tests across five files.
- The optional Bun 1.3.12 probe cannot load `node:sqlite` from the existing lock primitive. The supported Node 26 runtime passes. No fallback or weakened lock was added.
- GitNexus staged-change analysis reported low risk. The patch changes only the two media helpers, their shared quota module, regression tests, and quota documentation.
- Rebased onto current `main` before pushing; `git range-diff` confirms the patch is unchanged. Final head `95120bca82da4bee15c0f71e664c2b24a1c93ec7` passes build, generated SDK verification, all PTY startup checks, and the full local `npm test` run. All 23,659 runtime tests across 2,286 files pass with no failures or skips.
- Cursor Bugbot completed independent review of that exact head with no issues. Security review passed. The approval router had already timed out while waiting for Bugbot, so its review is COMMENTED rather than APPROVED; no approval is claimed. All final check runs succeeded and main has no required-review rule.
- SonarCloud's actual quality gate is OK, with no new issues and 0.0% duplicated lines.
- Automatic GitHub Actions remain disabled. No workflows were enabled, dispatched, or rerun.
