### PR TITLE
fix(packaging): provide bounded temporary storage for Docker

### DIFF
--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -105,6 +105,13 @@ as env (or secrets), never bake them into the image. The peer-credential addon
 is prebuilt and root-owned in the image; the daemon never compiles or loads
 native code from `/data`, and the release smoke starts it with `/data:noexec`.
 
+Compose also mounts a 256 MiB `/tmp` tmpfs for daemon startup and session
+scratch files. The mount is owned by UID/GID `10001:10001`, mode `0700`, with
+`nosuid,nodev`; it permits tool execution and is discarded when the container
+stops. The root filesystem remains read-only. Recreate existing containers
+with Compose to apply this mount. See the [Docker install notes](../install.md#docker)
+for the equivalent `docker run` command and packaging smoke checks.
+
 ## Provider credentials
 
 Set BYOK keys in the service environment, never in files inside the image or

--- a/docs/install.md
+++ b/docs/install.md
@@ -305,6 +305,7 @@ git archive --format=tar HEAD | \
   --build-arg AGENC_VERSION="$version" -
 docker run -it --read-only --cap-drop ALL \
   --security-opt no-new-privileges:true \
+  --tmpfs /tmp:rw,nosuid,nodev,size=268435456,mode=700,uid=10001,gid=10001 \
   -v agenc-data:/data -e XAI_API_KEY agenc:local
 ```
 
@@ -319,6 +320,21 @@ addon is prebuilt and root-owned under `/usr/lib/agenc`; startup fails closed if
 that configured addon cannot load, and `/data` can be `noexec` without weakening
 socket authentication. No GHCR image is authorized. Build locally as above.
 VPS deployment shapes: [docs/deploy/vps.md](deploy/vps.md).
+
+The read-only container needs writable temporary storage during daemon startup.
+Compose and the command above mount `/tmp` as a 256 MiB tmpfs owned by
+UID/GID `10001:10001`, mode `0700`, with `nosuid,nodev`. Files disappear when
+the container stops and count against available container memory. Tools may
+execute scratch files there; the peer-credential addon still loads only from
+its root-owned image path. Persistent state stays in `/data`, and the rest of
+the root filesystem remains read-only. Recreate existing Compose containers
+to apply the mount change.
+
+The `npm run check:clean-build` image smoke uses the same temp mount, creates
+and removes temporary session files as the daemon user, rejects writes to the
+read-only home directory, and starts the real daemon. Its separate `/data`
+tmpfs retains `noexec` to check that native addons do not depend on writable
+state.
 
 ## Homebrew
 

--- a/packages/agenc/test/native-module-smoke.test.mjs
+++ b/packages/agenc/test/native-module-smoke.test.mjs
@@ -10,7 +10,7 @@ import { hardenedContainerRuntimeSmokeProgram } from "../../../scripts/check-cle
 
 function executeSmoke(
   program,
-  { sqliteValue = 42, environment = {}, container = false } = {},
+  { sqliteValue = 42, environment = {}, container = false, temporary = {}, scratchEvents = [] } = {},
 ) {
   const exited = Symbol("process exit");
   const state = {
@@ -20,7 +20,9 @@ function executeSmoke(
     timerCleared: false,
     queries: [],
     closed: false,
+    scratchEvents,
   };
+  const scratchFiles = new Map();
   const child = {
     kill() {
       state.killed = true;
@@ -83,6 +85,8 @@ function executeSmoke(
       process,
       require(name) {
         if (name === "node:path") return { join };
+        if (container && name === "node:os")
+          return { tmpdir: () => temporary.root ?? "/tmp" };
         if (name === "node:module")
           return {
             createRequire(path) {
@@ -95,13 +99,54 @@ function executeSmoke(
           };
         if (container && name === "node:fs")
           return {
+            mkdtempSync(prefix) {
+              assert.equal(prefix, "/tmp/agenc-session-smoke-");
+              scratchEvents.push("create");
+              return `${prefix}fixture`;
+            },
+            writeFileSync(path, contents, options) {
+              assert.equal(options.mode, 0o600);
+              if (path === "/home/agenc/agenc-readonly-probe") {
+                assert.equal(options.flag, "wx");
+                if (!temporary.writableRoot)
+                  throw Object.assign(new Error(path), { code: "EROFS" });
+                return;
+              }
+              assert.equal(path, "/tmp/agenc-session-smoke-fixture/probe");
+              scratchEvents.push("write");
+              if (temporary.writeError) throw temporary.writeError;
+              scratchFiles.set(path, contents);
+            },
+            rmSync(path, options) {
+              assert.equal(path, "/tmp/agenc-session-smoke-fixture");
+              assert.equal(options.recursive, true);
+              scratchEvents.push("remove");
+              scratchFiles.clear();
+            },
+            statfsSync(path) {
+              assert.equal(path, "/tmp");
+              return {
+                type: temporary.filesystem ?? 0x01021994,
+                bsize: 4096,
+                blocks: (temporary.bytes ?? 268435456) / 4096,
+              };
+            },
             statSync(path) {
+              if (path === "/tmp") return {
+                uid: temporary.uid ?? 10001,
+                gid: temporary.gid ?? 10001,
+                mode: temporary.mode ?? 0o700,
+              };
               if (path === "/opt/agenc") return { uid: 0, gid: 0, mode: 0o755 };
               if (path === "/usr/lib/agenc/agenc-peer-credentials.node")
                 return { uid: 0, gid: 0, mode: 0o555 };
               throw Object.assign(new Error(path), { code: "ENOENT" });
             },
             readFileSync(path) {
+              if (path === "/tmp/agenc-session-smoke-fixture/probe") {
+                scratchEvents.push("read");
+                return temporary.readback ?? scratchFiles.get(path);
+              }
               if (path === "/usr/lib/agenc/peer-credentials-required")
                 return "required\n";
               assert.equal(path, "/usr/share/agenc/debian-packages.txt");
@@ -253,7 +298,39 @@ test("Docker hardening composes with the same native checks and container paths"
     "/opt/agenc/node_modules/@tetsuo-ai/runtime/package.json",
   );
   assert.equal(probe.state.spawn.options.cwd, "/data");
+  assert.deepEqual(probe.state.scratchEvents, ["create", "write", "read", "remove"]);
   probe.exit({ exitCode: 0 });
   probe.data("pty-ok");
   assert.deepEqual(probe.state.exits, [0]);
 });
+
+for (const [temporary, message] of [
+  [{ root: "/data" }, /platform temp directory/],
+  [{ uid: 0 }, /private to the daemon identity/],
+  [{ gid: 0 }, /private to the daemon identity/],
+  [{ mode: 0o777 }, /private to the daemon identity/],
+  [{ filesystem: 0xef53 }, /256 MiB tmpfs/],
+  [{ bytes: 536870912 }, /256 MiB tmpfs/],
+  [{ writableRoot: true }, /root filesystem is writable/],
+]) {
+  test(`Docker smoke rejects unsafe temporary storage ${JSON.stringify(temporary)}`, () => {
+    assert.throws(
+      () => executeSmoke(hardenedContainerRuntimeSmokeProgram(), { container: true, temporary }),
+      message,
+    );
+  });
+}
+
+for (const temporary of [
+  { writeError: Object.assign(new Error("scratch storage full"), { code: "ENOSPC" }) },
+  { readback: "incorrect contents" },
+]) {
+  test(`Docker smoke cleans scratch files after ${temporary.writeError ? "write failure" : "readback mismatch"}`, () => {
+    const scratchEvents = [];
+    assert.throws(
+      () => executeSmoke(hardenedContainerRuntimeSmokeProgram(), { container: true, temporary, scratchEvents }),
+      /scratch storage full|temporary file readback failed/,
+    );
+    assert.equal(scratchEvents.at(-1), "remove");
+  });
+}

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     image: agenc:local
     restart: unless-stopped
     read_only: true
+    tmpfs:
+      - /tmp:rw,nosuid,nodev,size=268435456,mode=700,uid=10001,gid=10001
     cap_drop:
       - ALL
     security_opt:

--- a/runtime/tests/packaging/distribution.test.ts
+++ b/runtime/tests/packaging/distribution.test.ts
@@ -8,6 +8,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { load as loadYaml } from "js-yaml";
 import { describe, expect, test } from "vitest";
+import { hardenedContainerMountArgs, hardenedContainerRuntimeSmokeProgram } from "../../../scripts/check-clean-build.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..", "..");
@@ -65,6 +66,39 @@ describe("docker packaging", () => {
     expect(ignore).toContain("node_modules");
     expect(ignore).toContain("**/dist");
     expect(ignore).not.toMatch(/^!\.git(?:\/|$)/m);
+  });
+
+  test("compose gives the non-root daemon bounded temporary storage without a writable root", () => {
+    const compose = loadYaml(readFileSync(join(DOCKER_DIR, "docker-compose.yml"), "utf8")) as {
+      services: Record<string, {
+        read_only: boolean;
+        tmpfs: string[];
+        cap_drop: string[];
+        security_opt: string[];
+      }>;
+    };
+    const service = compose.services["agenc-daemon"];
+    expect(service.read_only).toBe(true);
+    expect(service.cap_drop).toEqual(["ALL"]);
+    expect(service.security_opt).toContain("no-new-privileges:true");
+    expect(service.tmpfs).toEqual([
+      "/tmp:rw,nosuid,nodev,size=268435456,mode=700,uid=10001,gid=10001",
+    ]);
+    const mounts = hardenedContainerMountArgs();
+    expect(mounts).toEqual([
+      "--tmpfs", "/data:rw,nosuid,nodev,noexec,mode=700,uid=10001,gid=10001",
+      "--tmpfs", service.tmpfs[0],
+    ]);
+    const smoke = hardenedContainerRuntimeSmokeProgram();
+    expect(() => new Function(smoke)).not.toThrow();
+    expect(smoke).toContain("statfsSync(tempRoot)");
+    expect(smoke).toContain('mkdtempSync(tempRoot + "/agenc-session-smoke-")');
+    expect(smoke).toContain("rmSync(scratch, { recursive: true })");
+    expect(smoke).toContain('error?.code !== "EROFS"');
+    const cleanBuild = readFileSync(join(REPO_ROOT, "scripts/check-clean-build.mjs"), "utf8");
+    expect(cleanBuild.match(/\.\.\.hardenedContainerMountArgs\(\)/g)).toHaveLength(3);
+    const installDocs = readFileSync(join(REPO_ROOT, "docs/install.md"), "utf8");
+    expect(installDocs).toContain(`--tmpfs ${service.tmpfs[0]}`);
   });
 });
 

--- a/scripts/check-clean-build.mjs
+++ b/scripts/check-clean-build.mjs
@@ -755,9 +755,37 @@ function compareOciLayouts(first, second) {
   );
 }
 
+export function hardenedContainerMountArgs() {
+  return [
+    "--tmpfs",
+    "/data:rw,nosuid,nodev,noexec,mode=700,uid=10001,gid=10001",
+    "--tmpfs",
+    "/tmp:rw,nosuid,nodev,size=268435456,mode=700,uid=10001,gid=10001",
+  ];
+}
+
 export function hardenedContainerRuntimeSmokeProgram() {
-  const hardeningChecks = String.raw`const { readFileSync, statSync } = require("node:fs");
+  const hardeningChecks = String.raw`const { mkdtempSync, readFileSync, rmSync, statfsSync, statSync, writeFileSync } = require("node:fs");
        if (process.getuid?.() !== 10001 || process.getgid?.() !== 10001) throw new Error("container is not the dedicated non-root identity");
+       const tempRoot = require("node:os").tmpdir();
+       if (tempRoot !== "/tmp") throw new Error("platform temp directory does not use the Compose mount");
+       const tempStat = statSync(tempRoot);
+       if (tempStat.uid !== 10001 || tempStat.gid !== 10001 || (tempStat.mode & 0o777) !== 0o700) throw new Error("temporary directory must be private to the daemon identity");
+       const tempFilesystem = statfsSync(tempRoot);
+       if (tempFilesystem.type !== 0x01021994 || tempFilesystem.bsize * tempFilesystem.blocks !== 268435456) throw new Error("temporary directory must be a 256 MiB tmpfs");
+       const scratch = mkdtempSync(tempRoot + "/agenc-session-smoke-");
+       try {
+         writeFileSync(scratch + "/probe", "temporary session data", { mode: 0o600 });
+         if (readFileSync(scratch + "/probe", "utf8") !== "temporary session data") throw new Error("temporary file readback failed");
+       } finally {
+         rmSync(scratch, { recursive: true });
+       }
+       try {
+         writeFileSync("/home/agenc/agenc-readonly-probe", "must not be written", { flag: "wx", mode: 0o600 });
+         throw new Error("container root filesystem is writable");
+       } catch (error) {
+         if (error?.code !== "EROFS") throw error;
+       }
        const runtimeRoot = statSync("/opt/agenc");
        if (runtimeRoot.uid !== 0 || runtimeRoot.gid !== 0 || (runtimeRoot.mode & 0o022) !== 0) throw new Error("runtime tree is not root-owned and immutable");
        const peerAddon = statSync("/usr/lib/agenc/agenc-peer-credentials.node");
@@ -1008,8 +1036,7 @@ async function dockerSmoke({ sources, metadata, work, buildkitHostNetwork }) {
       "ALL",
       "--security-opt",
       "no-new-privileges:true",
-      "--tmpfs",
-      "/data:rw,nosuid,nodev,noexec,mode=700,uid=10001,gid=10001",
+      ...hardenedContainerMountArgs(),
       tag,
       "--version",
     ], { env: dockerEnv });
@@ -1023,8 +1050,7 @@ async function dockerSmoke({ sources, metadata, work, buildkitHostNetwork }) {
       "ALL",
       "--security-opt",
       "no-new-privileges:true",
-      "--tmpfs",
-      "/data:rw,nosuid,nodev,noexec,mode=700,uid=10001,gid=10001",
+      ...hardenedContainerMountArgs(),
       "--entrypoint",
       "node",
       "--env",
@@ -1084,8 +1110,7 @@ async function dockerSmoke({ sources, metadata, work, buildkitHostNetwork }) {
       "AGENC_NATIVE_PEER_CREDENTIAL_ADDON=/data/evil.node",
       "--env",
       "AGENC_AUTH_BACKEND=local",
-      "--tmpfs",
-      "/data:rw,nosuid,nodev,noexec,mode=700,uid=10001,gid=10001",
+      ...hardenedContainerMountArgs(),
       tag,
     ], { env: dockerEnv });
     const daemonProbe = `


### PR DESCRIPTION
## Changes

Closes #2066.

- Add a 256 MiB `/tmp` tmpfs to Compose, owned by UID/GID 10001 with mode 0700 and `nosuid,nodev`. Keep the root filesystem read-only, capabilities dropped, no-new-privileges, and no published ports.
- Use the same temporary mount in all three hardened image smoke invocations. Retain the separate `/data:noexec` smoke constraint and immutable native addon checks.
- Extend the image smoke to verify temp ownership, mode, filesystem type and capacity; create/read/remove a session scratch file; and require an EROFS failure when writing the read-only home directory.
- Update the direct Docker install command and deployment notes. The temporary mount permits scratch-file execution for tools and is discarded on container stop.

## Verification

- The new Compose regression failed against the original missing mount. All 177 packaging tests across seven files and both TypeScript checks pass locally in the test container.
- Standalone Compose v2.29.7 accepts the effective configuration with read-only root, the bounded tmpfs, dropped capabilities and no published ports. Script syntax and GitNexus staged-change checks pass; reported impact is low.
- Built the real Linux amd64 image from tracked source `90633cfa7` with checksum-verified Buildx 0.35.0 and digest-pinned BuildKit 0.31.1. The later `009f80146` commit changes only the smoke-test VM fixture and adds nine negative/cleanup tests; runtime, Dockerfile, Compose and smoke implementation are unchanged.
- That image fails with the old mount policy and the expected `/tmp` EROFS error. The corrected hardened runtime smoke passes, including SQLite, PTY, immutable peer credentials, `/data:noexec`, temp ownership/capacity, scratch create/read/delete, and denied home writes.
- The actual shipped Compose service becomes healthy with the built image, its named data volume, read-only root and bounded temp mount. The acceptance override selects only the test image, disables network access and selects local authentication. No credentials are passed. Daemon status succeeds and shutdown exits 0; owned test containers/volumes and the temporary builder are removed.
- The first full local run found an outdated native-smoke VM fixture. The fixture is updated, and all 20 native-smoke unit tests pass. Final head `009f801465c4444513dd82e5b33c3278f1d86598` passes the full local `npm test` run, including 23,660 runtime tests across 2,286 files with no failures or skips.
- SonarCloud's actual gate is OK, with zero new issues and 0.0% duplication. Exact-head approval and security review have completed. Bugbot independently reviewed the final head and found no issues; all final check runs succeeded.
- No release artifacts are published. Automatic GitHub Actions remain disabled; no workflows are enabled or dispatched.
