### PR TITLE
fix(gateway): preserve the installed service home

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -72,6 +72,18 @@ agenc onboard channel
 agenc gateway install-service
 ```
 
+`install-service` records the selected canonical `AGENC_HOME` in the systemd
+unit or launchd plist. The service uses that home's config, pairing store,
+daemon socket and native credential namespace even when the service manager
+has a different environment. Reinstall the service after selecting a different
+home, or to update an older definition that did not record one.
+
+Only `AGENC_HOME` is added to the service environment. Provider keys, channel
+tokens and unrelated shell exports are not copied into the definition. Home
+paths containing control characters, unpaired Unicode surrogates or Unicode
+noncharacters are rejected before a service file is written or a service
+manager is called.
+
 ## Channels
 
 ### stdio (dev)

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -14,6 +14,7 @@
  */
 
 import { resolveAgencHome } from "../config/env.js";
+import { canonicalizeHomePath } from "../config/home.js";
 import { loadCanonicalConfig } from "../config/repository.js";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -23,6 +24,7 @@ import { gatewayConfigFromCanonical } from "../gateway/config.js";
 import { PairingStore } from "../gateway/pairing.js";
 import { startGateway } from "../gateway/run.js";
 import type { GatewayConfig } from "../gateway/types.js";
+import { escapeXml } from "../utils/xml.js";
 
 export type AgenCGatewayCliCommand =
   | {
@@ -364,6 +366,21 @@ export async function runAgenCGatewayCli(
   }
 }
 
+function assertServiceHomeText(home: string): void {
+  for (const character of home) {
+    const codePoint = character.codePointAt(0)!;
+    if (
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      (codePoint >= 0xd800 && codePoint <= 0xdfff) ||
+      (codePoint >= 0xfdd0 && codePoint <= 0xfdef) ||
+      (codePoint & 0xfffe) === 0xfffe
+    ) {
+      throw new Error("Cannot install gateway service: AGENC_HOME contains control characters or invalid Unicode");
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Always-on gateway service (onboarding-plan-2026-07 O-4)
 // ---------------------------------------------------------------------------
@@ -387,6 +404,9 @@ export async function installGatewayService(options: {
 }): Promise<number> {
   const platform = options.platform ?? process.platform;
   const home = options.home ?? homedir();
+  assertServiceHomeText(options.agencHome);
+  const agencHome = canonicalizeHomePath(options.agencHome);
+  assertServiceHomeText(agencHome);
   const nodeBin = options.execPath ?? process.execPath;
   const entry = options.entryPath ?? process.argv[1];
   const run =
@@ -408,6 +428,7 @@ export async function installGatewayService(options: {
         "",
         "[Service]",
         "Type=simple",
+        `Environment=${JSON.stringify(`AGENC_HOME=${agencHome}`).replaceAll("%", "%%")}`,
         `ExecStart=${nodeBin} ${entry} gateway run`,
         "Restart=on-failure",
         "RestartSec=5",
@@ -449,6 +470,11 @@ export async function installGatewayService(options: {
         "<dict>",
         "  <key>Label</key>",
         "  <string>dev.agenc.gateway</string>",
+        "  <key>EnvironmentVariables</key>",
+        "  <dict>",
+        "    <key>AGENC_HOME</key>",
+        `    <string>${escapeXml(agencHome)}</string>`,
+        "  </dict>",
         "  <key>ProgramArguments</key>",
         "  <array>",
         `    <string>${nodeBin}</string>`,

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -428,7 +428,7 @@ export async function installGatewayService(options: {
         "",
         "[Service]",
         "Type=simple",
-        `Environment=${JSON.stringify(`AGENC_HOME=${agencHome}`).replaceAll("%", "%%")}`,
+        `Environment=${JSON.stringify("AGENC_HOME=" + agencHome).replaceAll("%", "%%")}`,
         `ExecStart=${nodeBin} ${entry} gateway run`,
         "Restart=on-failure",
         "RestartSec=5",

--- a/runtime/tests/bin/fixtures/gateway-service-home.mjs
+++ b/runtime/tests/bin/fixtures/gateway-service-home.mjs
@@ -1,0 +1,12 @@
+import { agenCDaemonLocalEndpoint } from "../../../src/app-server/transport/unix-socket.ts";
+import { runAgenCGatewayCli } from "../../../src/bin/gateway-cli.ts";
+import { resolveAgencHome } from "../../../src/config/env.ts";
+
+let status;
+const code = await runAgenCGatewayCli({ kind: "status", json: true }, {
+  env: process.env,
+  stdout: text => { status = JSON.parse(text); },
+});
+const home = resolveAgencHome();
+process.stdout.write(JSON.stringify({ home, socket: agenCDaemonLocalEndpoint(home), status }));
+process.exitCode = code;

--- a/runtime/tests/bin/gateway-service-home.test.ts
+++ b/runtime/tests/bin/gateway-service-home.test.ts
@@ -1,0 +1,160 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { load as loadXml } from "cheerio";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveAgenCDaemonSocketPath } from "../../src/app-server/daemon-cli.js";
+import { installGatewayService } from "../../src/bin/gateway-cli.js";
+import { resolveAgencHome } from "../../src/config/env.js";
+import { canonicalizeHomePath } from "../../src/config/home.js";
+import { serializeConfigToml } from "../../src/config/serialize.js";
+import { PairingStore } from "../../src/gateway/pairing.js";
+
+type ServicePlatform = "linux" | "darwin";
+
+describe("gateway service home persistence", () => {
+  let home: string;
+  let commands: string[][];
+  let previousKey: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-service-home-"));
+    commands = [];
+    previousKey = process.env.XAI_API_KEY;
+    process.env.XAI_API_KEY = "service-must-not-copy-this-key";
+  });
+
+  afterEach(() => {
+    if (previousKey === undefined) delete process.env.XAI_API_KEY;
+    else process.env.XAI_API_KEY = previousKey;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function definitionPath(platform: ServicePlatform): string {
+    return platform === "linux"
+      ? join(home, ".config/systemd/user/agenc-gateway.service")
+      : join(home, "Library/LaunchAgents/dev.agenc.gateway.plist");
+  }
+
+  function install(platform: ServicePlatform, agencHome: string): Promise<number> {
+    return installGatewayService({
+      platform, home, agencHome,
+      execPath: "/usr/bin/node",
+      entryPath: "/opt/agenc/bin/agenc.js",
+      stdout: () => undefined,
+      stderr: () => undefined,
+      runCommand: (command, args) => { commands.push([command, ...args]); return true; },
+    });
+  }
+
+  function serviceEnvironment(platform: ServicePlatform): Record<string, string> {
+    const definition = readFileSync(definitionPath(platform), "utf8");
+    expect(definition).not.toContain("service-must-not-copy-this-key");
+    expect(definition).not.toContain("XAI_API_KEY");
+    expect(definition).not.toContain("EnvironmentFile=");
+    if (platform === "linux") {
+      const entries = definition.split("\n").filter(line => line.startsWith("Environment="));
+      expect(entries).toHaveLength(1);
+      const assignment = JSON.parse(entries[0]!.slice("Environment=".length)).replaceAll("%%", "%") as string;
+      expect(assignment.startsWith("AGENC_HOME=")).toBe(true);
+      return { AGENC_HOME: assignment.slice("AGENC_HOME=".length) };
+    }
+    const document = loadXml(definition, { xmlMode: true });
+    const dictionary = document("plist > dict > key").filter((_, key) =>
+      document(key).text() === "EnvironmentVariables",
+    ).next("dict");
+    expect(dictionary.length).toBe(1);
+    const keys = dictionary.children("key");
+    expect(keys.map((_, key) => document(key).text()).get()).toEqual(["AGENC_HOME"]);
+    return { AGENC_HOME: keys.next("string").text() };
+  }
+
+  for (const platform of ["linux", "darwin"] as const) {
+    it.each(["alternate", "space = home", 'quoted "home" and \'single\'', "%h %n %% $HOME ${TOKEN}", "a & <home>", "学習 😀"])(
+      `${platform} preserves the canonical selected home (%s)`, async (suffix) => {
+        const selected = join(home, suffix);
+        expect(await install(platform, selected)).toBe(0);
+        expect(serviceEnvironment(platform)).toEqual({ AGENC_HOME: canonicalizeHomePath(selected) });
+        expect(commands).toHaveLength(platform === "linux" ? 2 : 1);
+      },
+    );
+
+    it(`${platform} preserves a selected default home`, async () => {
+      const selected = resolveAgencHome({ HOME: home });
+      expect(await install(platform, selected)).toBe(0);
+      expect(serviceEnvironment(platform)).toEqual({ AGENC_HOME: selected });
+    });
+
+    it(`${platform} records the physical parent of a home that does not exist yet`, async () => {
+      const parent = join(home, "physical");
+      const alias = join(home, "alias");
+      mkdirSync(parent);
+      symlinkSync(parent, alias, "junction");
+      expect(await install(platform, join(alias, "future-home"))).toBe(0);
+      expect(serviceEnvironment(platform)).toEqual({ AGENC_HOME: join(canonicalizeHomePath(parent), "future-home") });
+    });
+
+    it(`${platform} launches a new process with the selected config, pairing store and socket identity`, async () => {
+      const selected = join(home, "alternate");
+      mkdirSync(selected);
+      writeFileSync(join(selected, "config.toml"), serializeConfigToml({
+        config_version: 2,
+        gateway: { defaultAgent: "selected-home-agent", channels: { tg: { dmPolicy: "pairing", allowlist: [] } } },
+      }));
+      const pairing = new PairingStore({ agencHome: selected });
+      await pairing.approve("tg", "selected-peer");
+      expect(pairing.isPaired("tg", "selected-peer")).toBe(true);
+      expect(await install(platform, selected)).toBe(0);
+      const environment = { HOME: home, ...serviceEnvironment(platform) };
+      const runtimeRoot = join(import.meta.dirname, "../..");
+      const child = spawnSync(process.execPath, [
+        "--import", "tsx", join(import.meta.dirname, "fixtures/gateway-service-home.mjs"),
+      ], {
+        cwd: runtimeRoot,
+        env: { ...environment, PATH: process.env.PATH, TSX_TSCONFIG_PATH: join(runtimeRoot, "tsconfig.json") },
+        encoding: "utf8", timeout: 15_000,
+      });
+      expect(child.status, `${child.error ?? ""}\n${child.stderr}`).toBe(0);
+      const report = JSON.parse(child.stdout);
+      expect(report.home).toBe(canonicalizeHomePath(selected));
+      expect(report.socket).toBe(resolveAgenCDaemonSocketPath({ AGENC_HOME: selected, HOME: home }));
+      expect(report.socket).not.toBe(resolveAgenCDaemonSocketPath({ HOME: home }));
+      expect(report.status.defaultAgent).toBe("selected-home-agent");
+      expect(report.status.channels).toContainEqual(expect.objectContaining({ channelId: "tg", pairedCount: 1 }));
+    });
+
+    it.each(["line\nbreak", "carriage\rreturn", "tab\tpath", "null\0path", "\ud800", "\ufffe"])(
+      `${platform} rejects unrepresentable homes before writing or starting a service (%j)`, async (suffix) => {
+        await expect(install(platform, join(home, suffix))).rejects.toThrow(/AGENC_HOME/);
+        expect(existsSync(definitionPath(platform))).toBe(false);
+        expect(commands).toEqual([]);
+      },
+    );
+
+    it(`${platform} leaves an existing service unchanged when the new home is invalid`, async () => {
+      expect(await install(platform, join(home, "original"))).toBe(0);
+      const original = readFileSync(definitionPath(platform), "utf8");
+      commands = [];
+      await expect(install(platform, join(home, "bad\nhome"))).rejects.toThrow(/AGENC_HOME/);
+      expect(readFileSync(definitionPath(platform), "utf8")).toBe(original);
+      expect(commands).toEqual([]);
+    });
+  }
+
+  it("systemd quotes backslashes and percent specifiers without expanding dollar signs", async () => {
+    const selected = join(home, 'literal\\name %h $HOME "value"');
+    expect(await install("linux", selected)).toBe(0);
+    const definition = readFileSync(definitionPath("linux"), "utf8");
+    expect(definition).toContain('\\\\name %%h $HOME \\"value\\"');
+    expect(serviceEnvironment("linux").AGENC_HOME).toBe(canonicalizeHomePath(selected));
+  });
+
+  it("launchd escapes XML text instead of introducing plist elements", async () => {
+    expect(await install("darwin", join(home, "a & <home>"))).toBe(0);
+    const definition = readFileSync(definitionPath("darwin"), "utf8");
+    expect(definition).toContain("a &amp; &lt;home&gt;");
+    const document = loadXml(definition, { xmlMode: true });
+    expect(document("home").length).toBe(0);
+  });
+});

--- a/runtime/tests/bin/gateway-service-home.test.ts
+++ b/runtime/tests/bin/gateway-service-home.test.ts
@@ -64,7 +64,7 @@ describe("gateway service home persistence", () => {
     const dictionary = document("plist > dict > key").filter((_, key) =>
       document(key).text() === "EnvironmentVariables",
     ).next("dict");
-    expect(dictionary.length).toBe(1);
+    expect(dictionary).toHaveLength(1);
     const keys = dictionary.children("key");
     expect(keys.map((_, key) => document(key).text()).get()).toEqual(["AGENC_HOME"]);
     return { AGENC_HOME: keys.next("string").text() };
@@ -155,6 +155,6 @@ describe("gateway service home persistence", () => {
     const definition = readFileSync(definitionPath("darwin"), "utf8");
     expect(definition).toContain("a &amp; &lt;home&gt;");
     const document = loadXml(definition, { xmlMode: true });
-    expect(document("home").length).toBe(0);
+    expect(document("home")).toHaveLength(0);
   });
 });

--- a/runtime/tests/bin/gateway-service-home.test.ts
+++ b/runtime/tests/bin/gateway-service-home.test.ts
@@ -89,7 +89,7 @@ describe("gateway service home persistence", () => {
     it(`${platform} records the physical parent of a home that does not exist yet`, async () => {
       const parent = join(home, "physical");
       const alias = join(home, "alias");
-      mkdirSync(parent);
+      mkdirSync(parent, { mode: 0o700 });
       symlinkSync(parent, alias, "junction");
       expect(await install(platform, join(alias, "future-home"))).toBe(0);
       expect(serviceEnvironment(platform)).toEqual({ AGENC_HOME: join(canonicalizeHomePath(parent), "future-home") });
@@ -97,11 +97,11 @@ describe("gateway service home persistence", () => {
 
     it(`${platform} launches a new process with the selected config, pairing store and socket identity`, async () => {
       const selected = join(home, "alternate");
-      mkdirSync(selected);
+      mkdirSync(selected, { mode: 0o700 });
       writeFileSync(join(selected, "config.toml"), serializeConfigToml({
         config_version: 2,
         gateway: { defaultAgent: "selected-home-agent", channels: { tg: { dmPolicy: "pairing", allowlist: [] } } },
-      }));
+      }), { mode: 0o600 });
       const pairing = new PairingStore({ agencHome: selected });
       await pairing.approve("tg", "selected-peer");
       expect(pairing.isPaired("tg", "selected-peer")).toBe(true);


### PR DESCRIPTION
## Changes

Closes #2067.

- Record the canonical selected `AGENC_HOME` in systemd `Environment=` and launchd `EnvironmentVariables`. Preserve spaces, quotes, backslashes, literal percent specifiers, dollar signs and XML text.
- Validate both the supplied and canonical home before writing a service file or invoking its manager. Reject controls, unpaired surrogates and Unicode noncharacters rather than installing a definition that can lose its home setting.
- Copy only the home, not provider credentials, channel tokens or unrelated process environment. Document reinstalling older definitions and selecting a different home.
- Keep executable-path serialization unchanged; that separate defect remains tracked by #2068.

## Verification

- Reproduced both original definitions omitting the home with mocked service commands and private temporary files. All 32 initial regression cases failed against the original source.
- Final focused verification passes both TypeScript checks and 443 tests across 35 gateway/CLI/onboarding files. New coverage includes 34 service-home tests, default/non-default homes, physical-parent aliases, metacharacters, rejected values, and preservation of an existing definition after invalid input.
- Fresh Node processes receive the decoded service environment and read the selected config and pairing store, with the same socket identity as the daemon resolver. The fixture uses the daemon's shared endpoint resolver rather than importing the entire daemon CLI and its bundled Markdown assets.
- Real systemd 255 parsing preserves the exact decoded environment value for a home containing percent specifiers, dollar signs, quotes, backslashes, Unicode and XML characters. `xmllint --nonet` parses the launchd XML and recovers the same home. No service is installed or started during these tests; no native macOS launchd execution is claimed.
- Quoting follows the primary [systemd environment contract](https://github.com/systemd/systemd/blob/main/man/systemd.exec.xml) and [systemd syntax contract](https://github.com/systemd/systemd/blob/main/man/systemd.syntax.xml), also checked against the installed manual pages.
- Build, generated SDK verification and all PTY startup checks pass on these source changes. The Linux native lane passes 92 tests across five files. GitNexus upstream and staged checks report low risk.
- The full local suite passed on `f62e004b3`, including 23,694 runtime tests across 2,287 files. Sonar reported three style findings; the follow-up removes a nested template literal and improves two length assertions without changing serialization. A host-only rerun exposed group-writable test fixture permissions under the host umask; fixtures now use explicit 0700 directories and a 0600 config file. No production permission check was weakened.
- All 34 home tests, both native serializer probes, build and startup checks pass after the follow-up. The full suite passed with 23,694 runtime tests on `5fbd8c9be`. An earlier run had one unrelated FND supervisor assertion report `residual_process`; all 79 tests in that unchanged file passed in isolation, followed by the passing full run. No FND test or production behavior was changed.
- Independent Bugbot review on `5fbd8c9be` reports no issues. Security review succeeds and Sonar reports an OK gate, zero new issues and 0.0% duplication. The earlier approval is retained from `f62e004b3`.
- Rebased onto the independently merged main commit `1eabd97ce`; the PR diff is byte-identical before and after rebase. Current head is `23281c951b443c2837d44d6c8ca8acbab7f9b4b4`. Combined-tree build, generated SDK checks, all PTY startup checks and the full local suite pass, including 23,711 runtime tests across 2,289 files with no failures or skips. Exact-head Bugbot review reports no issues; security and approval checks succeed. Sonar reports zero new issues. Automatic GitHub Actions remain disabled; no workflows are enabled, dispatched or rerun.
