### PR TITLE
fix(gateway): preserve service executable arguments

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -84,6 +84,18 @@ paths containing control characters, unpaired Unicode surrogates or Unicode
 noncharacters are rejected before a service file is written or a service
 manager is called.
 
+Executable and entrypoint paths are recorded as literal arguments, including
+spaces, quotes, backslashes, percent signs, dollar signs and XML characters.
+The Linux unit uses `/usr/bin/env --` to execute Node because systemd rejects
+quotes and backslashes in the executable field itself. The unit disables
+environment expansion for that command and escapes percent specifiers.
+`/usr/bin/env` must be available. No shell parses the command.
+
+Both paths must be absolute file paths without control characters or invalid
+Unicode. A missing entrypoint or rejected path leaves an existing definition
+unchanged and does not invoke the service manager. Reinstall older service
+definitions to apply the corrected argument quoting.
+
 ## Channels
 
 ### stdio (dev)

--- a/runtime/src/bin/gateway-cli.ts
+++ b/runtime/src/bin/gateway-cli.ts
@@ -19,7 +19,7 @@ import { loadCanonicalConfig } from "../config/repository.js";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import { gatewayConfigFromCanonical } from "../gateway/config.js";
 import { PairingStore } from "../gateway/pairing.js";
 import { startGateway } from "../gateway/run.js";
@@ -367,7 +367,13 @@ export async function runAgenCGatewayCli(
 }
 
 function assertServiceHomeText(home: string): void {
-  for (const character of home) {
+  if (!isServiceTextRepresentable(home)) {
+    throw new Error("Cannot install gateway service: AGENC_HOME contains control characters or invalid Unicode");
+  }
+}
+
+function isServiceTextRepresentable(text: string): boolean {
+  for (const character of text) {
     const codePoint = character.codePointAt(0)!;
     if (
       codePoint < 0x20 ||
@@ -376,9 +382,20 @@ function assertServiceHomeText(home: string): void {
       (codePoint >= 0xfdd0 && codePoint <= 0xfdef) ||
       (codePoint & 0xfffe) === 0xfffe
     ) {
-      throw new Error("Cannot install gateway service: AGENC_HOME contains control characters or invalid Unicode");
+      return false;
     }
   }
+  return true;
+}
+
+function assertServicePath(path: string | undefined, label: string): asserts path is string {
+  if (typeof path !== "string" || !posix.isAbsolute(path) || path.endsWith("/") || !isServiceTextRepresentable(path)) {
+    throw new Error(`Cannot install gateway service: ${label} must be an absolute file path without control characters or invalid Unicode`);
+  }
+}
+
+function quoteSystemdValue(value: string): string {
+  return JSON.stringify(value).replaceAll("%", "%%");
 }
 
 // ---------------------------------------------------------------------------
@@ -403,12 +420,20 @@ export async function installGatewayService(options: {
   readonly runCommand?: (cmd: string, args: readonly string[]) => boolean;
 }): Promise<number> {
   const platform = options.platform ?? process.platform;
+  if (platform !== "linux" && platform !== "darwin") {
+    options.stderr(
+      `install-service supports linux (systemd --user) and macOS (launchd); on ${platform} run the gateway directly: agenc gateway run`,
+    );
+    return 1;
+  }
   const home = options.home ?? homedir();
   assertServiceHomeText(options.agencHome);
   const agencHome = canonicalizeHomePath(options.agencHome);
   assertServiceHomeText(agencHome);
   const nodeBin = options.execPath ?? process.execPath;
   const entry = options.entryPath ?? process.argv[1];
+  assertServicePath(nodeBin, "Node executable");
+  assertServicePath(entry, "CLI entrypoint");
   const run =
     options.runCommand ??
     ((cmd: string, args: readonly string[]): boolean =>
@@ -428,8 +453,8 @@ export async function installGatewayService(options: {
         "",
         "[Service]",
         "Type=simple",
-        `Environment=${JSON.stringify("AGENC_HOME=" + agencHome).replaceAll("%", "%%")}`,
-        `ExecStart=${nodeBin} ${entry} gateway run`,
+        `Environment=${quoteSystemdValue("AGENC_HOME=" + agencHome)}`,
+        `ExecStart=:/usr/bin/env ${["--", nodeBin, entry, "gateway", "run"].map(quoteSystemdValue).join(" ")}`,
         "Restart=on-failure",
         "RestartSec=5",
         "",
@@ -455,9 +480,7 @@ export async function installGatewayService(options: {
     options.stderr("  systemctl --user daemon-reload");
     options.stderr("  systemctl --user enable --now agenc-gateway");
     return 1;
-  }
-
-  if (platform === "darwin") {
+  } else {
     const agentsDir = join(home, "Library", "LaunchAgents");
     const plistPath = join(agentsDir, "dev.agenc.gateway.plist");
     mkdirSync(agentsDir, { recursive: true });
@@ -477,8 +500,8 @@ export async function installGatewayService(options: {
         "  </dict>",
         "  <key>ProgramArguments</key>",
         "  <array>",
-        `    <string>${nodeBin}</string>`,
-        `    <string>${entry}</string>`,
+        `    <string>${escapeXml(nodeBin)}</string>`,
+        `    <string>${escapeXml(entry)}</string>`,
         "    <string>gateway</string>",
         "    <string>run</string>",
         "  </array>",
@@ -501,9 +524,4 @@ export async function installGatewayService(options: {
     options.stderr(`  launchctl load -w ${plistPath}`);
     return 1;
   }
-
-  options.stderr(
-    `install-service supports linux (systemd --user) and macOS (launchd); on ${platform} run the gateway directly: agenc gateway run`,
-  );
-  return 1;
 }

--- a/runtime/tests/bin/gateway-service-paths.test.ts
+++ b/runtime/tests/bin/gateway-service-paths.test.ts
@@ -1,0 +1,119 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { load as loadXml } from "cheerio";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installGatewayService } from "../../src/bin/gateway-cli.js";
+
+type ServicePlatform = "linux" | "darwin";
+
+describe("gateway service executable paths", () => {
+  let home: string;
+  let commands: string[][];
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agenc-service-paths-"));
+    commands = [];
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function definitionPath(platform: ServicePlatform): string {
+    return platform === "linux"
+      ? join(home, ".config/systemd/user/agenc-gateway.service")
+      : join(home, "Library/LaunchAgents/dev.agenc.gateway.plist");
+  }
+
+  function install(platform: ServicePlatform, execPath: string, entryPath?: string): Promise<number> {
+    return installGatewayService({
+      platform, home, agencHome: join(home, "state"), execPath, entryPath,
+      stdout: () => undefined,
+      stderr: () => undefined,
+      runCommand: (command, args) => { commands.push([command, ...args]); return true; },
+    });
+  }
+
+  function serviceArguments(platform: ServicePlatform): string[] {
+    const definition = readFileSync(definitionPath(platform), "utf8");
+    if (platform === "linux") {
+      const entries = definition.split("\n").filter(line => line.startsWith("ExecStart="));
+      expect(entries).toHaveLength(1);
+      const prefix = "ExecStart=:/usr/bin/env ";
+      expect(entries[0]!.startsWith(prefix)).toBe(true);
+      const encoded = entries[0]!.slice(prefix.length);
+      const values = encoded.match(/"(?:[^"\\]|\\.)*"/g) ?? [];
+      expect(values.join(" ")).toBe(encoded);
+      const decoded = values.map(value => (JSON.parse(value) as string).replaceAll("%%", "%"));
+      expect(decoded.shift()).toBe("--");
+      return decoded;
+    }
+    const document = loadXml(definition, { xmlMode: true });
+    const array = document("plist > dict > key").filter((_, key) =>
+      document(key).text() === "ProgramArguments",
+    ).next("array");
+    expect(array).toHaveLength(1);
+    expect(array.children()).toHaveLength(4);
+    return array.children("string").map((_, value) => document(value).text()).get();
+  }
+
+  for (const platform of ["linux", "darwin"] as const) {
+    it.each(["space path", 'double "quote"', "single 'quote'", "back\\slash", "%h %n %%", "$HOME ${TOKEN} $$", "a & <path>", "学習 😀", "semi ; colon"])(
+      `${platform} preserves executable and entry arguments (%s)`, async suffix => {
+        const executable = `/opt/${suffix}/node`;
+        const entry = `/opt/${suffix}/agenc.js`;
+        expect(await install(platform, executable, entry)).toBe(0);
+        expect(serviceArguments(platform)).toEqual([executable, entry, "gateway", "run"]);
+        expect(commands).toHaveLength(platform === "linux" ? 2 : 1);
+      },
+    );
+
+    for (const field of ["executable", "entrypoint"] as const) {
+      it.each(["", "relative/file", "../file", "/", "/directory/", "/line\nbreak", "/carriage\rreturn", "/tab\tpath", "/null\0path", "/\ud800", "/\ufffe"])(
+        `${platform} rejects unsafe ${field} paths before writing or starting a service (%j)`, async value => {
+          const executable = field === "executable" ? value : "/usr/bin/node";
+          const entry = field === "entrypoint" ? value : "/opt/agenc/agenc.js";
+          await expect(install(platform, executable, entry)).rejects.toThrow(/Cannot install gateway service/);
+          expect(existsSync(definitionPath(platform))).toBe(false);
+          expect(commands).toEqual([]);
+        },
+      );
+    }
+
+    it(`${platform} rejects a missing process entrypoint without replacing an existing service`, async () => {
+      expect(await install(platform, "/usr/bin/node", "/opt/agenc/agenc.js")).toBe(0);
+      const original = readFileSync(definitionPath(platform), "utf8");
+      commands = [];
+      const originalArgv = process.argv;
+      try {
+        process.argv = [process.execPath];
+        await expect(install(platform, "/usr/bin/node")).rejects.toThrow(/entrypoint/);
+      } finally {
+        process.argv = originalArgv;
+      }
+      expect(readFileSync(definitionPath(platform), "utf8")).toBe(original);
+      expect(commands).toEqual([]);
+    });
+
+    it(`${platform} launches the decoded command with exact executable and entry argv`, async () => {
+      const directory = join(home, 'space %h %% $HOME ${TOKEN} & <xml> "quote" \\slash 学習');
+      mkdirSync(directory, { mode: 0o700 });
+      const executable = join(directory, "node");
+      const entry = join(directory, "entry 'single'.cjs");
+      symlinkSync(process.execPath, executable);
+      writeFileSync(entry, 'process.stdout.write(JSON.stringify({argv0:process.argv0,argv:process.argv.slice(1)}));\n', { mode: 0o600 });
+      expect(await install(platform, executable, entry)).toBe(0);
+      const argv = serviceArguments(platform);
+      const command = platform === "linux" ? "/usr/bin/env" : argv.shift()!;
+      const args = platform === "linux" ? ["--", ...argv] : argv;
+      const result = spawnSync(command, args, {
+        env: { HOME: home, AGENC_HOME: join(home, "state") },
+        encoding: "utf8", timeout: 10_000,
+      });
+      expect(result.status, `${result.error ?? ""}\n${result.stderr}`).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ argv0: executable, argv: [entry, "gateway", "run"] });
+    });
+  }
+});

--- a/runtime/tests/onboarding/acts.test.ts
+++ b/runtime/tests/onboarding/acts.test.ts
@@ -505,7 +505,7 @@ describe("gateway install-service (O-4)", () => {
       join(home, ".config", "systemd", "user", "agenc-gateway.service"),
       "utf8",
     );
-    expect(unit).toContain("ExecStart=/usr/bin/node /opt/agenc/bin/agenc.js gateway run");
+    expect(unit).toContain('ExecStart=:/usr/bin/env "--" "/usr/bin/node" "/opt/agenc/bin/agenc.js" "gateway" "run"');
     expect(unit).not.toContain("EnvironmentFile=");
     expect(commands).toEqual([
       ["systemctl", "--user", "daemon-reload"],


### PR DESCRIPTION
## Changes

Closes #2068.

- Quote each systemd argument, escape percent specifiers, and disable dollar expansion with the `:` command prefix. Use `/usr/bin/env --` to execute the selected absolute Node path without a shell. This preserves quotes and backslashes that systemd rejects in its executable field even after correct unit-file quoting.
- XML-escape the launchd executable and entrypoint with the existing helper. Preserve the selected home from #2067.
- Reject missing, relative, directory-only or unrepresentable executable/entrypoint paths before service writes or manager calls. Share Unicode validation and systemd value quoting instead of repeating encoders.
- Document `/usr/bin/env` on Linux and reinstalling older definitions. Unsupported platforms retain their existing diagnostic without entering supported-platform validation.

## Verification

- Reproduced the original Linux unit failing native `systemd-analyze verify` and the original plist failing `xmllint`. The new regression file has 58 failing and eight passing cases against the original source.
- Both TypeScript checks and 509 tests across 36 gateway/CLI/onboarding files pass, including all 66 executable-path cases and 34 home-persistence cases. Tests verify exact decoded argv in fresh child processes, special characters, rejected paths, and preservation of existing definitions when the entrypoint is missing.
- Real generated units pass systemd 255 verification. A uniquely named, runtime-only systemd fixture executes the generated command and records the exact Node `argv0`, entrypoint, `gateway run` arguments and selected home. Test executable and entrypoint paths contain spaces, both quote types, a backslash, percent specifiers, dollar text, XML characters and Unicode. Manager environment keys are removed except explicitly controlled home settings. The unit, link and files are removed afterward; no existing service is changed and no gateway/provider is started.
- `xmllint --nonet` parses the generated plist and decodes the same arguments/home. A fresh Node fixture executes that decoded argv. Native macOS launchd execution is not claimed.
- The argv fixture is CommonJS because Node's ESM entrypoint resolver independently rejects a literal backslash in a filesystem path. This change preserves service arguments; it does not change Node's module-loading rules.
- The [systemd command-line contract](https://github.com/systemd/systemd/blob/main/man/systemd.service.xml) documents the no-expansion prefix. The installed systemd 255 parser also rejects quotes/backslashes after unquoting its executable field; the fixed `env` executable avoids that restriction without a shell.
- GitNexus upstream checks report low risk with one direct production caller for each edited function; the staged check also reports low risk. Build, generated SDK verification and all PTY startup checks pass. The Linux native lane passes 92 tests across five files. The reviewed-head build and full local suite pass, including 23,777 runtime tests across 2,290 files with no failures or skips.
- Exact head `3ce0a9c07b07a239dab9e091d52b5b9b0df82cf5` has an independent approval, Bugbot reports no issues, and security checks succeed. Sonar reports zero new issues. Automatic Actions stay disabled with zero runs for this head; no workflow is enabled, dispatched or rerun.
