### PR TITLE
fix(daemon): generate collision-resistant message IDs

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -292,6 +292,12 @@ Hidden-user submissions persist a non-rendering `message_submission` marker
 with a SHA-256 content fingerprint, so their idempotency identity also survives
 a process crash without duplicating the hidden prompt in that marker.
 
+When `clientMessageId` is omitted, the daemon assigns a collision-resistant
+ID with a random UUID suffix. Concurrent requests remain separate submissions
+even if they have identical content or arrive in the same millisecond. Treat
+the generated ID as opaque. Clients that need retry deduplication must provide
+their own stable `clientMessageId` before the first attempt.
+
 `session.transcript.v2` returns `schemaVersion: 2`, `runId`, `historyEpoch`,
 `asOfSequence`, and stable identity-bearing messages. Canonical messages carry
 `messageId`, `commitEventId`, `turnId`/`clientMessageId` when known, and

--- a/runtime/src/app-server/daemon-dispatcher.ts
+++ b/runtime/src/app-server/daemon-dispatcher.ts
@@ -7,6 +7,7 @@
  * land.
  */
 
+import { randomUUID } from "node:crypto";
 import { isAbsolute } from "node:path";
 import { RemoteError, REMOTE_METHODS, type RemoteMethod } from "../remote/types.js";
 import type { RemoteAccessBoundary } from "../remote/access.js";
@@ -739,7 +740,7 @@ export class AgenCDaemonJsonRpcDispatcher {
     this.#clientMultiplexer = options.clientMultiplexer;
     this.#sessionManager = options.sessionManager;
     this.#createMessageId =
-      options.createMessageId ?? (() => `message_${Date.now().toString(36)}`);
+      options.createMessageId ?? (() => `message_${randomUUID()}`);
     this.#fuzzyFileSearch =
       options.fuzzyFileSearch ?? new AgenCFuzzyFileSearchService();
     this.#ownsFuzzyFileSearch = options.fuzzyFileSearch === undefined;

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -26,6 +26,9 @@ import {
   managedTokenUsage,
 } from "./background-agent-runner.js";
 import { collectDaemonClientEnvOverrides } from "./agent-cli.js";
+import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
+import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
+import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
 import type { AgentStatus } from "../agents/status.js";
 import type { AuthBackend } from "../auth/backend.js";
 import type {
@@ -8954,6 +8957,84 @@ describe("AgenC delegate background-agent runner", () => {
     releaseFirst();
     await acceptedThenCrashed;
   });
+
+  it.each(["same prompt", "different prompt"])(
+    "[managed-thread] keeps concurrent dispatcher fallback submissions distinct (%s)", async secondContent => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+      const agentId = "session-dispatcher-fallback";
+      const sessionId = "session-dispatcher-client";
+      const { runner, control } = makeTopLevelRunner({ conversationId: agentId });
+      const sessions = new AgenCDaemonSessionManager();
+      const manager = new AgenCDaemonAgentManager({ runner, sessionManager: sessions });
+      const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: manager, sessionManager: sessions });
+      const connection = dispatcher.createConnection();
+      const emitted: JsonObject[] = [];
+      const pending: Promise<unknown>[] = [];
+      let releaseSend: (() => void) | undefined;
+      const submit = vi.spyOn(runner, "submitAgentMessage");
+      const dispatchMessage = (id: string, method: string, content: string, clientMessageId?: string) =>
+        connection.dispatch({
+          jsonrpc: "2.0", id, method,
+          params: { sessionId, content, ...(clientMessageId === undefined ? {} : { clientMessageId }) },
+        });
+      try {
+        const started = await runner.startAgent({
+          objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [],
+        });
+        await sessions.restoreSession({ sessionId, agentId, status: "waiting", createdAt: started.startedAt });
+        await manager.restoreAgent({
+          agentId, objective: "passive", startedAt: started.startedAt, lastActiveAt: started.startedAt,
+          sessionIds: [sessionId], runtimeAvailable: true,
+        });
+        await runner.attachAgentSessionEvents(agentId, { sessionId, emit: notification => emitted.push(notification) });
+        expect(await connection.dispatch({
+          jsonrpc: "2.0", id: "initialize", method: "initialize", params: { protocol: { version: "1.2.0" } },
+        })).toHaveProperty("result");
+        expect(control.sendInput).not.toHaveBeenCalled();
+        control.sendInput.mockImplementationOnce(() => new Promise<void>(resolve => { releaseSend = resolve; }));
+        const first = dispatchMessage("first", "message.send", "same prompt");
+        pending.push(first);
+        await vi.waitFor(() => expect(control.sendInput).toHaveBeenCalledOnce());
+        const second = dispatchMessage("second", "message.stream", secondContent);
+        pending.push(second);
+        await vi.waitFor(() => expect(submit).toHaveBeenCalledTimes(2));
+        const identities = submit.mock.calls.map(([, params]) => params.messageId);
+        expect(new Set(identities).size).toBe(2);
+        releaseSend!();
+        const responses = await Promise.all([first, second]);
+        for (const [index, response] of responses.entries()) {
+          expect(response).toMatchObject({ result: { messageId: identities[index], disposition: "started" } });
+        }
+        expect(responses[1]).toMatchObject({ result: { streamId: identities[1] } });
+        expect(control.sendInput).toHaveBeenCalledTimes(2);
+        const userIdentities = emitted.flatMap(notification => {
+          const params = notification.params as JsonObject | undefined;
+          const event = params?.event as JsonObject | undefined;
+          return event?.type === "user_message" ? [params?.clientMessageId] : [];
+        });
+        expect(userIdentities).toEqual(identities);
+        const transcript = await runner.getAgentSessionTranscriptV2(agentId, { sessionId });
+        expect(transcript.messages.filter(message => message.role === "user").map(message => message.clientMessageId)).toEqual(identities);
+        expect(await dispatchMessage("explicit", "message.send", "explicit prompt", "caller-message")).toMatchObject({
+          result: { messageId: "caller-message", disposition: "started" },
+        });
+        expect(await dispatchMessage("retry", "message.stream", "explicit prompt", "caller-message")).toMatchObject({
+          result: { messageId: "caller-message", disposition: "duplicate" },
+        });
+        expect(await dispatchMessage("conflict", "message.send", "changed prompt", "caller-message")).toMatchObject({
+          error: { data: { code: "CLIENT_MESSAGE_ID_CONFLICT" } },
+        });
+        expect(control.sendInput).toHaveBeenCalledTimes(3);
+      } finally {
+        releaseSend?.();
+        await Promise.allSettled(pending);
+        await connection.close();
+        await dispatcher.close();
+        await runner.stopAgent(agentId, "test_cleanup");
+        clock.mockRestore();
+      }
+    },
+  );
 
   it("[managed-thread] joins a concurrent idempotent retry and rejects conflicting content", async () => {
     const { runner, control } = makeTopLevelRunner({

--- a/runtime/tests/app-server/daemon-message-id.contract.test.ts
+++ b/runtime/tests/app-server/daemon-message-id.contract.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonJsonRpcDispatcher } from "../../src/app-server/daemon-dispatcher.js";
+import type { JsonObject } from "../../src/app-server/protocol/index.js";
+
+const contexts: Awaited<ReturnType<typeof messageConnection>>[] = [];
+
+async function messageConnection(createMessageId?: () => string) {
+  const manager = new AgenCDaemonAgentManager();
+  const submit = vi.spyOn(manager, "streamAgentMessage").mockImplementation(async params => ({
+    disposition: "started", acceptedAt: params.acceptedAt,
+  }));
+  const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: manager, createMessageId });
+  const connection = dispatcher.createConnection({ overloadLimits: { requestBurst: 5_000 } });
+  expect(await connection.dispatch({
+    jsonrpc: "2.0", id: "initialize", method: "initialize", params: { protocol: { version: "1.2.0" } },
+  })).toHaveProperty("result");
+  const context = { manager, submit, dispatcher, connection };
+  contexts.push(context);
+  return context;
+}
+
+afterEach(async () => {
+  for (const context of contexts.splice(0)) {
+    await context.connection.close();
+    await context.dispatcher.close();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("daemon fallback message identities", () => {
+  it("generates 4,000 distinct IDs across dispatcher instances with a frozen clock", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+    const connections = [await messageConnection(), await messageConnection()];
+    const identities: string[] = [];
+    for (let index = 0; index < 4_000; index += 1) {
+      const context = connections[index % connections.length]!;
+      const method = index % 4 < 2 ? "message.send" : "message.stream";
+      const response = await context.connection.dispatch({
+        jsonrpc: "2.0", id: `request-${index}`, method,
+        params: { sessionId: "session-identities", content: "same content" },
+      });
+      expect(response).not.toHaveProperty("error");
+      const result = response.result as JsonObject;
+      expect(result.messageId).toEqual(expect.stringMatching(/^message_/));
+      identities.push(result.messageId as string);
+      expect(context.submit.mock.lastCall?.[0]).toMatchObject({
+        messageId: result.messageId, streamId: result.messageId,
+      });
+      if (method === "message.stream") expect(result.streamId).toBe(result.messageId);
+    }
+    expect(new Set(identities).size).toBe(4_000);
+  });
+
+  it("keeps injected, caller-supplied and explicit stream identities unchanged", async () => {
+    const generator = vi.fn(() => "injected-message");
+    const { connection, submit } = await messageConnection(generator);
+    const supplied = await connection.dispatch({
+      jsonrpc: "2.0", id: "supplied", method: "message.send",
+      params: { sessionId: "session-explicit", content: "first", clientMessageId: "caller-message" },
+    });
+    expect(supplied).toMatchObject({ result: { messageId: "caller-message" } });
+    expect(generator).not.toHaveBeenCalled();
+    const generated = await connection.dispatch({
+      jsonrpc: "2.0", id: "generated", method: "message.stream",
+      params: { sessionId: "session-explicit", content: "second", streamId: "caller-stream" },
+    });
+    expect(generated).toMatchObject({ result: { messageId: "injected-message", streamId: "caller-stream" } });
+    expect(generator).toHaveBeenCalledOnce();
+    expect(submit.mock.lastCall?.[0]).toMatchObject({ messageId: "injected-message", streamId: "caller-stream" });
+  });
+
+  it("cancels one fallback request without changing the other generated stream identity", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+    const { manager, connection, submit } = await messageConnection();
+    const releases: (() => void)[] = [];
+    submit.mockImplementation(params => new Promise(resolve => {
+      releases.push(() => resolve({ disposition: "started", acceptedAt: params.acceptedAt }));
+    }));
+    const cancel = vi.spyOn(manager, "cancelSessionTurn").mockResolvedValue({
+      sessionId: "session-cancelled", cancelled: true,
+    });
+    const pending = [
+      connection.dispatch({
+        jsonrpc: "2.0", id: "cancelled", method: "message.send",
+        params: { sessionId: "session-cancelled", content: "cancel me" },
+      }),
+      connection.dispatch({
+        jsonrpc: "2.0", id: "survivor", method: "message.stream",
+        params: { sessionId: "session-survivor", content: "keep running" },
+      }),
+    ];
+    try {
+      await vi.waitFor(() => expect(submit).toHaveBeenCalledTimes(2));
+      const identities = submit.mock.calls.map(([params]) => params.messageId);
+      expect(new Set(identities).size).toBe(2);
+      expect(await connection.dispatch({
+        jsonrpc: "2.0", id: "cancel", method: "request.cancel", params: { requestId: "cancelled" },
+      })).toMatchObject({ result: { cancelled: true } });
+      expect(cancel).toHaveBeenCalledExactlyOnceWith({ sessionId: "session-cancelled", reason: "request.cancel" });
+      for (const release of releases) release();
+      const [cancelled, survivor] = await Promise.all(pending);
+      expect(cancelled).toHaveProperty("error");
+      expect(survivor).toMatchObject({ result: { messageId: identities[1], streamId: identities[1] } });
+    } finally {
+      for (const release of releases) release();
+      await Promise.allSettled(pending);
+    }
+  });
+});


### PR DESCRIPTION
## Changes

Closes #2069.

- Replace the timestamp-only fallback message ID with `message_${randomUUID()}`. Keep the injected generator, explicit `clientMessageId`, explicit `streamId`, cancellation routing and idempotency behavior unchanged.
- Document generated IDs as opaque and require a caller-stable ID for retry deduplication.
- Reuse the existing background-runner fixture to test concurrent `message.send` and `message.stream` through the real dispatcher, agent manager and runner. Cover both equal and different content, emitted user events, transcript identities, and explicit-ID retry/conflict behavior.

## Verification

- A read-only evaluation of the original factory produced one unique ID from 4,000 calls with a frozen clock. Four new assertions fail against the original source, including both real dispatcher/runner concurrency cases, the 4,000-ID case and cancellation identity separation.
- Both TypeScript checks and all 225 tests across the new identity file, dispatcher contracts and background-runner contracts pass. The new tests also preserve injected IDs and caller-selected stream IDs. The high-volume unit fixture raises only its own request burst allowance; no production overload limit changes.
- GitNexus constructor impact reports no direct edges; class impact reports four direct references and 19 total affected symbols at low tool-reported risk. The daemon-startup context and symbol count justify treating this as a high-risk change for verification. No measured FND source file changes.
- All 1,231 tests across 88 daemon files pass through the Docker test boundary, including both TypeScript checks. Reviewed-head build, generated SDK verification and all PTY startup checks pass. The Linux native lane passes 92 tests across five files. The full local suite passes, including 23,782 runtime tests across 2,291 files with no failures or skips.
- Exact head `015ce13bf4da1a0b59309759364095ce821a62bf` is independently approved. Bugbot reports no issues, security checks succeed, and Sonar reports an OK gate with zero new issues and 0.0% duplication. Automatic GitHub Actions remain disabled with zero runs for this head; no workflow is enabled, dispatched or rerun.
