### PR TITLE
fix(tui): preserve bounded daemon replay handoff

### DIFF
--- a/docs/reference/tui-workbench.md
+++ b/docs/reference/tui-workbench.md
@@ -15,6 +15,26 @@ in-tree README:
 - All real work still flows through the **daemon**; the TUI is a client view
   onto daemon-owned sessions.
 
+## Daemon transcript replay
+
+The TUI retains the first 1,000 daemon events for local subscribers that mount
+after the shared daemon connection opens. This matches the transport's initial
+replay capacity. Each subscriber also has a pending queue capped at 1,000 events
+to preserve replay-to-live order, including events emitted from a callback.
+The transcript reducer deduplicates replay/live overlap by canonical event
+identity rather than message text.
+
+Existing live subscribers continue receiving events after the retained history
+fills. A later subscription fails before delivering any incomplete history or
+live events. A subscriber whose pending queue overflows is removed and reports
+the same `DAEMON_EVENT_REPLAY_GAP` error. Other live subscribers remain active.
+
+The transcript error remains visible with instructions to reopen the
+conversation and reload its durable history. Exit the TUI and reopen that
+conversation to create a fresh adapter. Retrying a subscription on the old
+adapter cannot repair its replay gap. Failed transcript subscriptions release
+their event-log listener and pending coalescing timer.
+
 ## Layouts
 
 | Layout                                          | When                                                   |

--- a/runtime/src/app-server/agent-cli.ts
+++ b/runtime/src/app-server/agent-cli.ts
@@ -174,7 +174,7 @@ const MAX_BUFFERED_SESSION_EVENT_SESSIONS = 50;
 // events) until the TUI calls subscribeToSessionEvents. The prior cap of 20
 // dropped the oldest events under a fast first turn — which is almost always
 // the user's first prompt — so the YOU bubble never rendered on cold open.
-const MAX_BUFFERED_SESSION_EVENTS_PER_SESSION = 1000;
+export const MAX_BUFFERED_SESSION_EVENTS_PER_SESSION = 1000;
 const overflowedBufferedSessionEventMaps = new WeakSet<
   Map<string, JsonObject[]>
 >();

--- a/runtime/src/bin/agenc-main.ts
+++ b/runtime/src/bin/agenc-main.ts
@@ -4331,10 +4331,16 @@ async function createDeferredDaemonPromptTuiSession(params: {
       emitLocalTuiEvent(subscribers, event);
     },
     subscribeToEvents: (cb) => {
+      const alreadySubscribed = subscribers.has(cb);
       subscribers.add(cb);
-      if (liveSession !== null) {
-        const unsubscribe = liveSession.subscribeToEvents?.(cb);
-        if (unsubscribe !== undefined) liveUnsubscribers.set(cb, unsubscribe);
+      try {
+        if (liveSession !== null) {
+          const unsubscribe = liveSession.subscribeToEvents?.(cb);
+          if (unsubscribe !== undefined) liveUnsubscribers.set(cb, unsubscribe);
+        }
+      } catch (error) {
+        if (!alreadySubscribed) subscribers.delete(cb);
+        throw error;
       }
       return () => {
         subscribers.delete(cb);
@@ -4488,12 +4494,18 @@ function wrapDaemonTuiSessionWithPromptPreparation<
       await originalSubmit(prepared, opts);
     },
     subscribeToEvents: ((cb: (event: unknown) => void) => {
+      const alreadySubscribed = localSubscribers.has(cb);
       localSubscribers.add(cb);
-      const unsubscribeOriginal = originalSubscribe?.(cb);
-      return () => {
-        localSubscribers.delete(cb);
-        unsubscribeOriginal?.();
-      };
+      try {
+        const unsubscribeOriginal = originalSubscribe?.(cb);
+        return () => {
+          localSubscribers.delete(cb);
+          unsubscribeOriginal?.();
+        };
+      } catch (error) {
+        if (!alreadySubscribed) localSubscribers.delete(cb);
+        throw error;
+      }
     }) as Session["subscribeToEvents"],
     emit: ((event: unknown) => {
       originalEmit?.(event);

--- a/runtime/src/tui/daemon-event-replay.ts
+++ b/runtime/src/tui/daemon-event-replay.ts
@@ -1,0 +1,83 @@
+interface ReplaySubscriber {
+  readonly callback: (event: unknown) => void;
+  readonly pending: unknown[];
+  draining: boolean;
+  failure: DaemonEventReplayGapError | null;
+}
+
+export class DaemonEventReplayGapError extends Error {
+  readonly code = "DAEMON_EVENT_REPLAY_GAP";
+
+  constructor(readonly capacity: number) {
+    super(`Daemon event replay exceeded its ${capacity}-event capacity. Reopen this conversation to reload durable history before subscribing again.`);
+    this.name = "DaemonEventReplayGapError";
+  }
+}
+
+export class DaemonEventReplay {
+  readonly #history: unknown[] = [];
+  readonly #subscribers = new Set<ReplaySubscriber>();
+  #historyHasGap = false;
+
+  constructor(readonly capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new RangeError("Daemon event replay capacity must be a positive safe integer");
+    }
+  }
+
+  get size(): number {
+    return this.#subscribers.size;
+  }
+
+  publish(event: unknown): void {
+    if (this.#history.length < this.capacity) this.#history.push(event);
+    else this.#historyHasGap = true;
+    const subscribers = [...this.#subscribers];
+    for (const subscriber of subscribers) {
+      if (subscriber.pending.length >= this.capacity) {
+        subscriber.failure ??= new DaemonEventReplayGapError(this.capacity);
+      } else if (subscriber.failure === null) {
+        subscriber.pending.push(event);
+      }
+    }
+    let failure: { readonly error: unknown } | undefined;
+    for (const subscriber of subscribers) {
+      try {
+        this.#drain(subscriber);
+      } catch (error) {
+        failure ??= { error };
+      }
+    }
+    if (failure !== undefined) throw failure.error;
+  }
+
+  subscribe(callback: (event: unknown) => void): () => void {
+    if (this.#historyHasGap) throw new DaemonEventReplayGapError(this.capacity);
+    const subscriber: ReplaySubscriber = {
+      callback, pending: [...this.#history], draining: false, failure: null,
+    };
+    this.#subscribers.add(subscriber);
+    this.#drain(subscriber);
+    return () => {
+      this.#subscribers.delete(subscriber);
+      subscriber.pending.length = 0;
+    };
+  }
+
+  #drain(subscriber: ReplaySubscriber): void {
+    if (subscriber.draining || !this.#subscribers.has(subscriber)) return;
+    subscriber.draining = true;
+    try {
+      while (subscriber.pending.length > 0 || subscriber.failure !== null) {
+        if (subscriber.failure !== null) throw subscriber.failure;
+        subscriber.callback(subscriber.pending.shift());
+      }
+    } catch (error) {
+      this.#subscribers.delete(subscriber);
+      subscriber.pending.length = 0;
+      throw error;
+    } finally {
+      subscriber.draining = false;
+    }
+  }
+}

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -7,7 +7,8 @@
 
 import { randomUUID } from "node:crypto";
 import { isAbsolute } from "node:path";
-import { AgenCDaemonResponseError } from "../app-server/agent-cli.js";
+import { AgenCDaemonResponseError, MAX_BUFFERED_SESSION_EVENTS_PER_SESSION } from "../app-server/agent-cli.js";
+import { DaemonEventReplay } from "./daemon-event-replay.js";
 import { classifyTurnTerminal, createTurnFailedEvent } from "../contracts/turn-terminal.js";
 import type {
   AgentAttachParams,
@@ -778,17 +779,7 @@ export function createDaemonTuiSession<
     readonly ownership?: IdleInputOwnership;
   };
   const queuedInputs: DaemonQueuedInput[] = [];
-  const eventSubscribers = new Set<(event: unknown) => void>();
-  // Backlog of received daemon events, replayed to subscribers that register
-  // LATE. The daemon replays the session's early events exactly once when the
-  // RPC subscription opens — a local subscriber that registers after that
-  // single replay (the transcript hook mounts after other subscriptions)
-  // would otherwise lose early events FOREVER: the user's first prompt
-  // (user_message) never reached the transcript hook and the message was
-  // invisible until ctrl+o. Replay from the same received stream — ids match,
-  // so the reducer's eventKey dedupe collapses any overlap with live events.
-  const receivedEvents: unknown[] = [];
-  const REPLAY_BACKLOG_LIMIT = 500;
+  const eventReplay = new DaemonEventReplay(MAX_BUFFERED_SESSION_EVENTS_PER_SESSION);
   let activeTurnSnapshot: { readonly turnId: string } | null = null;
   let lastObservedTurnId: string | undefined;
   let daemonTurnStartGeneration = 0;
@@ -907,12 +898,7 @@ export function createDaemonTuiSession<
   };
   const broadcastDaemonEvent = (event: unknown): void => {
     noteDaemonActivity(event);
-    if (receivedEvents.length < REPLAY_BACKLOG_LIMIT) {
-      receivedEvents.push(event);
-    }
-    for (const subscriber of [...eventSubscribers]) {
-      subscriber(event);
-    }
+    eventReplay.publish(event);
   };
   const realtime = createRealtimeTuiControls({
     threadId: realtimeThreadId,
@@ -1050,7 +1036,7 @@ export function createDaemonTuiSession<
   };
   const maybeStopDaemonEvents = (): void => {
     if (
-      eventSubscribers.size > 0 ||
+      eventReplay.size > 0 ||
       mcpProjection.hasSubscribers() ||
       runtimeSettingsReconciler !== undefined ||
       unsubscribeDaemonEvents === null
@@ -1723,16 +1709,16 @@ export function createDaemonTuiSession<
         sessionId,
       } satisfies WorkspaceEditorPredictionFeedbackParams),
     subscribeToEvents: (cb) => {
-      // Late registrants get the backlog first (see receivedEvents above) —
-      // without this, a subscriber mounting after the daemon's one-shot RPC
-      // replay permanently misses every event that preceded it.
-      for (const event of receivedEvents) {
-        cb(event);
+      const unsubscribe = eventReplay.subscribe(cb);
+      try {
+        ensureDaemonEventsSubscribed();
+      } catch (error) {
+        unsubscribe();
+        maybeStopDaemonEvents();
+        throw error;
       }
-      eventSubscribers.add(cb);
-      ensureDaemonEventsSubscribed();
       return () => {
-        eventSubscribers.delete(cb);
+        unsubscribe();
         maybeStopDaemonEvents();
       };
     },

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -3322,16 +3322,27 @@ export function useSessionTranscript(
     const unsubscribeLog = session.eventLog?.subscribe((event) => {
       enqueue(event, !isCoalescableStreamingEvent(event));
     });
-    const unsubscribePhase = session.subscribeToEvents?.((event) => {
-      if (
-        event &&
-        typeof event === "object" &&
-        ("type" in event || "msg" in event)
-      ) {
-        const typed = event as SessionTranscriptEvent;
-        enqueue(typed, !isCoalescableStreamingEvent(typed));
+    let unsubscribePhase: (() => void) | undefined;
+    try {
+      unsubscribePhase = session.subscribeToEvents?.((event) => {
+        if (
+          event &&
+          typeof event === "object" &&
+          ("type" in event || "msg" in event)
+        ) {
+          const typed = event as SessionTranscriptEvent;
+          enqueue(typed, !isCoalescableStreamingEvent(typed));
+        }
+      });
+    } catch (error) {
+      try {
+        unsubscribeLog?.();
+      } finally {
+        if (timer !== null) clearTimeout(timer);
+        buffer.length = 0;
       }
-    });
+      throw error;
+    }
     return () => {
       unsubscribeLog?.();
       unsubscribePhase?.();

--- a/runtime/tests/bin/agenc.deferred-input.test.ts
+++ b/runtime/tests/bin/agenc.deferred-input.test.ts
@@ -8,6 +8,7 @@ import {
 import { ConfigStore } from "../config/store.js";
 import { PermissionModeRegistry } from "../permissions/permission-mode.js";
 import { createEmptyToolPermissionContext } from "../permissions/types.js";
+import { DaemonEventReplayGapError } from "../../src/tui/daemon-event-replay.js";
 import type {
   SessionEditorInteraction,
   SessionSubmitOptions,
@@ -476,6 +477,54 @@ function daemonHarness(
 }
 
 describe("deferred daemon input ownership", () => {
+  it.each(["emit", "slash"] as const)("rolls back failed subscriptions before local %s delivery", async delivery => {
+    const harness = daemonHarness();
+    const session = await createDeferredInputSession({
+      baseSession: harness.baseSession,
+      deps: harness.deps,
+    });
+    const healthy = vi.fn();
+    const unsubscribe = session.subscribeToEvents(healthy);
+    try {
+      await session.predictEditorCode({
+        requestId: "replay-subscription-cleanup",
+        editorInstanceId: "replay-editor",
+        bufferHandle: 1,
+        generation: 1,
+        changedtick: 1,
+        path: "src/replay.ts",
+        fileBytes: 4,
+        cursor: { line: 1, byteColumn: 2 },
+        prefix: "re",
+        suffix: "ad",
+      });
+      const emitDaemon = harness.client.subscribeToSessionEvents.mock.lastCall?.[1];
+      if (emitDaemon === undefined) throw new Error("Daemon event subscription is missing");
+      for (let index = 1; index <= 1_001; index += 1) {
+        emitDaemon({
+          type: "daemon.event",
+          msg: { id: `overflow-${index}`, type: "user_message", payload: { message: `prompt ${index}` } },
+        } as never);
+      }
+      const failed = vi.fn();
+      expect(() => session.subscribeToEvents(failed)).toThrow(DaemonEventReplayGapError);
+      expect(() => session.subscribeToEvents(healthy)).toThrow(DaemonEventReplayGapError);
+      expect(failed).not.toHaveBeenCalled();
+      healthy.mockClear();
+      if (delivery === "emit") {
+        (session as DeferredInputSession & { emit(event: unknown): void }).emit({
+          type: "agent_message_delta", payload: { delta: "local" },
+        });
+      } else {
+        await session.submit("/help");
+      }
+      expect(failed).not.toHaveBeenCalled();
+      expect(healthy).toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it.each([
     {
       decision: { kind: "approved" },

--- a/runtime/tests/tui/daemon-event-replay.test.ts
+++ b/runtime/tests/tui/daemon-event-replay.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { DaemonEventReplay, DaemonEventReplayGapError } from "../../src/tui/daemon-event-replay.js";
+import {
+  appendSessionTranscriptEventForTesting,
+  createSessionTranscriptStateForTesting,
+  type SessionTranscriptEvent,
+} from "../../src/tui/session-transcript.js";
+
+describe("bounded daemon event replay", () => {
+  it.each([0, -1, 1.5, Infinity, NaN, Number.MAX_SAFE_INTEGER + 1])("rejects invalid capacity %s", capacity => {
+    expect(() => new DaemonEventReplay(capacity)).toThrow(RangeError);
+  });
+
+  it("keeps existing live delivery after retained history overflows", () => {
+    const replay = new DaemonEventReplay(3);
+    for (const event of [1, 2, 3]) replay.publish(event);
+    const received: unknown[] = [];
+    const unsubscribe = replay.subscribe(event => received.push(event));
+    for (let event = 4; event <= 2_000; event += 1) replay.publish(event);
+    expect(received).toEqual(Array.from({ length: 2_000 }, (_, index) => index + 1));
+    const late = vi.fn();
+    expect(() => replay.subscribe(late)).toThrow(DaemonEventReplayGapError);
+    expect(late).not.toHaveBeenCalled();
+    expect(replay.size).toBe(1);
+    unsubscribe();
+    unsubscribe();
+    expect(replay.size).toBe(0);
+  });
+
+  it("gives an explicit gap before invoking a late callback", () => {
+    const replay = new DaemonEventReplay(1);
+    replay.publish("first");
+    replay.publish("missed");
+    expect(() => replay.subscribe(vi.fn())).toThrow(expect.objectContaining({
+      code: "DAEMON_EVENT_REPLAY_GAP", capacity: 1,
+      message: expect.stringMatching(/reopen.*conversation/i),
+    }));
+    expect(replay.size).toBe(0);
+  });
+
+  it("delivers reentrant live events after a complete retained snapshot", () => {
+    const replay = new DaemonEventReplay(3);
+    for (const event of [1, 2, 3]) replay.publish(event);
+    const received: unknown[] = [];
+    const unsubscribe = replay.subscribe(event => {
+      received.push(event);
+      if (event === 1) replay.publish(4);
+    });
+    replay.publish(5);
+    expect(received).toEqual([1, 2, 3, 4, 5]);
+    unsubscribe();
+  });
+
+  it("enqueues each event for all subscribers before a callback can publish another", () => {
+    const replay = new DaemonEventReplay(3);
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    const stopFirst = replay.subscribe(event => {
+      first.push(event);
+      if (event === 1) replay.publish(2);
+    });
+    const stopSecond = replay.subscribe(event => second.push(event));
+    replay.publish(1);
+    expect(first).toEqual([1, 2]);
+    expect(second).toEqual([1, 2]);
+    stopFirst();
+    stopSecond();
+  });
+
+  it("bounds a reentrant pending queue and leaves a healthy subscriber live", () => {
+    const replay = new DaemonEventReplay(3);
+    replay.publish(1);
+    replay.publish(2);
+    const healthy: unknown[] = [];
+    const stopHealthy = replay.subscribe(event => healthy.push(event));
+    const failing = vi.fn((event: unknown) => {
+      if (event === 1) for (const nested of [3, 4, 5, 6]) replay.publish(nested);
+    });
+    expect(() => replay.subscribe(failing)).toThrow(DaemonEventReplayGapError);
+    expect(failing).toHaveBeenCalledExactlyOnceWith(1);
+    expect(replay.size).toBe(1);
+    replay.publish(7);
+    expect(healthy).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(failing).toHaveBeenCalledOnce();
+    stopHealthy();
+  });
+
+  it("removes a callback that fails during replay", () => {
+    const replay = new DaemonEventReplay(3);
+    replay.publish(1);
+    const failure = new Error("subscriber failed");
+    const callback = vi.fn(() => { throw failure; });
+    expect(() => replay.subscribe(callback)).toThrow(failure);
+    expect(replay.size).toBe(0);
+    replay.publish(2);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it("delivers to healthy subscribers before rethrowing a live callback failure", () => {
+    const replay = new DaemonEventReplay(3);
+    const failure = new Error("live callback failed");
+    replay.subscribe(() => { throw failure; });
+    const received: unknown[] = [];
+    const stopHealthy = replay.subscribe(event => received.push(event));
+    expect(() => replay.publish(1)).toThrow(failure);
+    expect(replay.size).toBe(1);
+    replay.publish(2);
+    expect(received).toEqual([1, 2]);
+    stopHealthy();
+  });
+
+  it("does not deliver an already queued event after unsubscribe", () => {
+    const replay = new DaemonEventReplay(3);
+    let stopSecond = () => {};
+    const stopFirst = replay.subscribe(() => stopSecond());
+    const second = vi.fn();
+    stopSecond = replay.subscribe(second);
+    replay.publish(1);
+    expect(second).not.toHaveBeenCalled();
+    stopFirst();
+  });
+
+  it("preserves canonical reducer deduplication across replay and live overlap", () => {
+    const replay = new DaemonEventReplay(3);
+    const events = [1, 2, 3].map(sequence => ({
+      id: `canonical-${sequence}`, seq: sequence, type: "user_message",
+      payload: { message: `prompt ${sequence}` },
+    }));
+    replay.publish(events[0]);
+    replay.publish(events[1]);
+    let state = createSessionTranscriptStateForTesting([]);
+    const unsubscribe = replay.subscribe(event => {
+      state = appendSessionTranscriptEventForTesting(state, event as SessionTranscriptEvent);
+    });
+    replay.publish({ ...events[1] });
+    replay.publish(events[2]);
+    expect(state.events).toEqual(events);
+    unsubscribe();
+  });
+});

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -900,6 +900,55 @@ describe("AgenC TUI daemon session adapter", () => {
     unsubscribeLate();
   });
 
+  it.each([501, 1_000])("replays all %i attach events to a late transcript subscriber", async count => {
+    const client = createClient();
+    const session = await attachDaemonTuiSession({
+      baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1",
+    });
+    const early: unknown[] = [];
+    const stopEarly = session.subscribeToEvents(event => early.push(event));
+    const late: unknown[] = [];
+    let stopLate: (() => void) | undefined;
+    try {
+      for (let index = 1; index <= count; index += 1) {
+        client.emit("session_1", {
+          type: "daemon.event", msg: { id: `replay-${index}`, seq: index, type: "user_message", payload: { message: `prompt ${index}` } },
+        });
+      }
+      stopLate = session.subscribeToEvents(event => late.push(event));
+      expect(late).toHaveLength(count);
+      expect(late).toEqual(early);
+      client.emit("session_1", { type: "daemon.event", msg: { id: "live", type: "turn_delta" } });
+      expect(late).toEqual(early);
+      expect(late).toHaveLength(count + 1);
+    } finally {
+      stopLate?.();
+      stopEarly();
+    }
+  });
+
+  it("rejects incomplete late replay without interrupting an existing live subscriber", async () => {
+    const client = createClient();
+    const session = await attachDaemonTuiSession({
+      baseSession: createBaseSession(), client, sessionId: "session_1", clientId: "tui_1",
+    });
+    const early: unknown[] = [];
+    const stopEarly = session.subscribeToEvents(event => early.push(event));
+    try {
+      for (let index = 1; index <= 1_001; index += 1) {
+        client.emit("session_1", { type: "daemon.event", msg: { id: `event-${index}`, type: "turn_delta" } });
+      }
+      const late = vi.fn();
+      expect(() => session.subscribeToEvents(late)).toThrow(/reopen.*conversation/i);
+      expect(late).not.toHaveBeenCalled();
+      client.emit("session_1", { type: "daemon.event", msg: { id: "still-live", type: "turn_delta" } });
+      expect(early).toHaveLength(1_002);
+      expect(late).not.toHaveBeenCalled();
+    } finally {
+      stopEarly();
+    }
+  });
+
   it("attaches the TUI client before returning a daemon-backed session", async () => {
     const client = createClient();
 

--- a/runtime/tests/tui/session-transcript-subscription-failure.test.ts
+++ b/runtime/tests/tui/session-transcript-subscription-failure.test.ts
@@ -1,0 +1,72 @@
+import { PassThrough } from "node:stream";
+import { stripVTControlCharacters } from "node:util";
+import React from "react";
+import { expect, it, vi } from "vitest";
+import { createEmptyToolPermissionContext } from "../../src/permissions/types.js";
+import { DaemonEventReplay } from "../../src/tui/daemon-event-replay.js";
+import { createRoot } from "../../src/tui/ink/root.js";
+import { useSessionTranscript } from "../../src/tui/session-transcript.js";
+import type { AgenCBridgeSession } from "../../src/tui/session-types.js";
+
+it("shows a replay-gap error and cleans transcript subscriptions and timers", async () => {
+  const stdin = Object.assign(new PassThrough(), {
+    isTTY: true, setRawMode: vi.fn(), ref: vi.fn(), unref: vi.fn(),
+  });
+  const stdout = Object.assign(new PassThrough(), { isTTY: true, columns: 140, rows: 30 });
+  const stderr = new PassThrough();
+  const frames: string[] = [];
+  stdout.on("data", chunk => frames.push(String(chunk)));
+  stderr.resume();
+  const timeout = vi.spyOn(globalThis, "setTimeout");
+  const clear = vi.spyOn(globalThis, "clearTimeout");
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  const unsubscribeLog = vi.fn();
+  let coalescingTimer: ReturnType<typeof setTimeout> | undefined;
+  const replay = new DaemonEventReplay(1);
+  replay.publish("retained");
+  replay.publish("gap");
+  const session: AgenCBridgeSession = {
+    conversationId: "replay-gap-session",
+    services: { permissionModeRegistry: { current: () => createEmptyToolPermissionContext() } },
+    eventLog: {
+      subscribe: callback => {
+        callback({ id: "pending", msg: { type: "agent_message_delta", payload: { delta: "pending" } } });
+        expect(timeout.mock.lastCall?.[1]).toBe(33);
+        coalescingTimer = timeout.mock.results.at(-1)?.value;
+        return unsubscribeLog;
+      },
+    },
+    subscribeToEvents: callback => replay.subscribe(callback),
+  };
+  function Probe(): null {
+    useSessionTranscript(session);
+    return null;
+  }
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+  });
+  const exit = root.waitUntilExit().catch(error => error);
+  try {
+    root.render(React.createElement(Probe));
+    await vi.waitFor(() => expect(unsubscribeLog).toHaveBeenCalledOnce());
+    expect(coalescingTimer).toBeDefined();
+    expect(clear).toHaveBeenCalledWith(coalescingTimer);
+    await vi.waitFor(() => {
+      const display = stripVTControlCharacters(frames.join("")).replace(/\s+/g, "");
+      expect(display).toContain("Reopenthisconversation");
+    });
+    expect(replay.size).toBe(0);
+  } finally {
+    root.unmount();
+    await exit;
+    stdin.end();
+    stdout.end();
+    stderr.end();
+    timeout.mockRestore();
+    clear.mockRestore();
+    consoleError.mockRestore();
+  }
+});


### PR DESCRIPTION
## Changes

- Share the transport's 1,000-event replay capacity with the TUI adapter.
- Preserve replay/live order with bounded subscriber queues, including reentrant callbacks.
- Reject late subscribers before incomplete replay with an explicit reopen error. Existing live subscribers continue after retained history fills.
- Remove failed subscribers and clean up transcript listeners and coalescing timers.
- Roll back failed subscriptions in both production prompt/deferred wrappers without removing an already-live registration of the same callback.
- Keep canonical event-identity deduplication and document the capacity and recovery policy.

Closes #2070.

## Validation

- Original adapter fails the new 501-event, 1,000-event, and overflow regressions; all 68 existing adapter cases pass.
- Docker boundary, runtime and test-support TypeScript checks, and focused tests pass: 136 tests across 6 files, zero skips.
- Tests cover ordered replay, reentrant live delivery, bounded pending queues, callback failure isolation, unsubscribe, canonical overlap, and the real Ink error display and transcript cleanup.
- Build, SDK type mirror, all TUI startup PTY sizes, and Linux native tests pass (92 tests across 5 files).
- The first full run passed 23,799 runtime tests and failed two unrelated process-timing cases. Both unchanged files pass in isolation (85 tests across 2 files). No production or test changes were made for those failures.
- Main advanced through the independent compact-policy PR #2325. This branch is rebased with its patch verified byte-for-byte unchanged.
- Rebased head `b0d47ae7cdb9bddd711e621ab3931fba3487da36` passes build, SDK mirror, every startup PTY check, and `npm test`: all root/launcher gates and 23,805 runtime tests across 2,294 files, zero failures or skips.
- Independent review found a wrapper registration leak on that head. Both real wrapper paths now have revert-sensitive regressions: two failures before the cleanup fix and all 167 focused tests passing afterward, with both TypeScript checks in the Docker boundary.
- Final head `ee628e3b17ef8b2dd46b7c719dc42f32ad6b4378` passes build, SDK mirror, all startup checks, and independent review. Bugbot reports no issues, the prior finding is resolved, the approval review is APPROVED on this exact head, and Sonar reports OK with zero issues and duplication.
- The first final-head full run passed 23,806 runtime tests and failed one unrelated fuzzy-search timing case. That unchanged file passes alone (27 tests, zero skips). No unrelated test or production code was modified.
- The unchanged confirmation run passes `npm test`, including all root/launcher gates and all 23,807 runtime tests across 2,294 files, zero failures or skips.
- GitNexus upstream impact checked before edits. The transcript hook has high impact, so full local validation is required. Staged review covers only the 8 intended files.

Hosted test workflows remain disabled at the user's request. No Actions workflows were enabled, dispatched, or rerun. Darwin and Windows native execution is not claimed.
