### PR TITLE
fix(tui): scope assistant fallback deduplication to turns

### DIFF
--- a/docs/reference/tui-workbench.md
+++ b/docs/reference/tui-workbench.md
@@ -24,6 +24,11 @@ to preserve replay-to-live order, including events emitted from a callback.
 The transcript reducer deduplicates replay/live overlap by canonical event
 identity rather than message text.
 
+Identical assistant replies remain separate across turn starts and visible user
+messages, including queued human prompts and realtime replies. Within a turn,
+matching assistant and terminal-fallback text produces one row. Canonical event
+deduplication still prevents repeated delivery from creating extra rows.
+
 Existing live subscribers continue receiving events after the retained history
 fills. A later subscription fails before delivering any incomplete history or
 live events. A subscriber whose pending queue overflows is removed and reports

--- a/docs/reference/tui-workbench.md
+++ b/docs/reference/tui-workbench.md
@@ -28,6 +28,9 @@ Identical assistant replies remain separate across turn starts and visible user
 messages, including queued human prompts and realtime replies. Within a turn,
 matching assistant and terminal-fallback text produces one row. Canonical event
 deduplication still prevents repeated delivery from creating extra rows.
+The active turn retains its fallback correlation when another user prompt is
+shown, so a late completion does not repeat the prior answer. Repeated start
+events for that same active turn also preserve the correlation.
 
 Existing live subscribers continue receiving events after the retained history
 fills. A later subscription fails before delivering any incomplete history or

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1993,6 +1993,7 @@ export function adaptTranscriptEvents(
           typeof payload.turnId === "string" ? payload.turnId : currentTurnId;
         currentTurnTimestamp = timestampFromUnixMillis(payload.startedAt);
         currentTurnAssistantMessageIndexes = [];
+        lastAssistantText = "";
         // Clear streaming tool state when a new turn boundary arrives. Any
         // partially-streamed tool inputs from the previous turn are abandoned
         // because they will never receive a matching completion event in this
@@ -2139,6 +2140,7 @@ export function adaptTranscriptEvents(
         // so close any live assistant text here before accumulating the next
         // response.
         flushStreamingText(nextUuid);
+        lastAssistantText = "";
         if (typeof payload.queuedCommandUuid === "string") {
           durableQueuedPromptUuids.add(payload.queuedCommandUuid);
         }
@@ -2163,6 +2165,7 @@ export function adaptTranscriptEvents(
                 ? payload.content
                 : "";
           flushStreamingText(nextUuid);
+          lastAssistantText = "";
           out.push(makeUserMessage(displayText, nextUuid()));
         }
         break;
@@ -2257,6 +2260,7 @@ export function adaptTranscriptEvents(
         if (typeof payload.text === "string") {
           if (isUserRealtimeRole(payload.role)) {
             out.push(makeUserMessage(payload.text, nextUuid()));
+            lastAssistantText = "";
           } else if (payload.text !== lastAssistantText) {
             out.push(makeAssistantTextMessage(payload.text, nextUuid()));
             lastAssistantText = payload.text;

--- a/runtime/src/tui/session-transcript.ts
+++ b/runtime/src/tui/session-transcript.ts
@@ -1854,6 +1854,7 @@ export function adaptTranscriptEvents(
   let currentTurnTimestamp: string | undefined;
   let currentTurnAssistantMessageIndexes: number[] = [];
   let lastAssistantText = "";
+  let lastAssistantTextForActiveTurn = "";
   let isStreaming = false;
 
   const persistAssistantText = (
@@ -1867,6 +1868,7 @@ export function adaptTranscriptEvents(
     currentTurnAssistantMessageIndexes.push(out.length);
     out.push(makeAssistantTextMessage(content, nextUuid(), messageTimestamp));
     lastAssistantText = content;
+    lastAssistantTextForActiveTurn = content;
   };
 
   const flushStreamingText = (nextUuid: () => string): void => {
@@ -1931,6 +1933,7 @@ export function adaptTranscriptEvents(
         currentTurnTimestamp = undefined;
         currentTurnAssistantMessageIndexes = [];
         lastAssistantText = "";
+        lastAssistantTextForActiveTurn = "";
         isStreaming = false;
         break;
       case "history_replaced": {
@@ -1955,6 +1958,7 @@ export function adaptTranscriptEvents(
         currentTurnTimestamp = undefined;
         currentTurnAssistantMessageIndexes = [];
         lastAssistantText = "";
+        lastAssistantTextForActiveTurn = "";
         isStreaming = false;
         const replacement = (payload as HistoryReplacedEvent["payload"]).messages;
         if (Array.isArray(replacement)) {
@@ -1986,6 +1990,10 @@ export function adaptTranscriptEvents(
       }
       case "turn_start":
       case "turn_started":
+        if (typeof payload.turnId !== "string" || payload.turnId !== currentTurnId) {
+          lastAssistantText = "";
+          lastAssistantTextForActiveTurn = "";
+        }
         isStreaming = true;
         streamingText = "";
         turnStreamedChars = 0;
@@ -1993,7 +2001,6 @@ export function adaptTranscriptEvents(
           typeof payload.turnId === "string" ? payload.turnId : currentTurnId;
         currentTurnTimestamp = timestampFromUnixMillis(payload.startedAt);
         currentTurnAssistantMessageIndexes = [];
-        lastAssistantText = "";
         // Clear streaming tool state when a new turn boundary arrives. Any
         // partially-streamed tool inputs from the previous turn are abandoned
         // because they will never receive a matching completion event in this
@@ -2043,7 +2050,9 @@ export function adaptTranscriptEvents(
             : typeof payload.content === "string"
               ? payload.content
               : streamingText;
-        persistAssistantText(content, nextUuid, completionTimestamp);
+        if (currentTurnId === null || content !== lastAssistantTextForActiveTurn) {
+          persistAssistantText(content, nextUuid, completionTimestamp);
+        }
         if (completionTimestamp.length > 0) {
           for (const messageIndex of currentTurnAssistantMessageIndexes) {
             const assistantMessage = out[messageIndex];
@@ -2064,6 +2073,7 @@ export function adaptTranscriptEvents(
         pendingToolInputDeltas.clear();
         isStreaming = false;
         currentTurnId = null;
+        lastAssistantTextForActiveTurn = "";
         break;
       }
       case "turn_aborted":
@@ -2099,6 +2109,7 @@ export function adaptTranscriptEvents(
         currentTurnTimestamp = undefined;
         currentTurnAssistantMessageIndexes = [];
         currentTurnId = null;
+        lastAssistantTextForActiveTurn = "";
         // Clear streaming tool state on cancellation.
         // stream cancellation — any partially-streamed tool inputs are
         // abandoned because their completion events will never arrive
@@ -2264,6 +2275,7 @@ export function adaptTranscriptEvents(
           } else if (payload.text !== lastAssistantText) {
             out.push(makeAssistantTextMessage(payload.text, nextUuid()));
             lastAssistantText = payload.text;
+            lastAssistantTextForActiveTurn = payload.text;
           }
           realtimeStreamingText = "";
         }

--- a/runtime/tests/tui/session-transcript.assistant-turns.test.ts
+++ b/runtime/tests/tui/session-transcript.assistant-turns.test.ts
@@ -83,6 +83,56 @@ describe.each<InputMode>(["replay", "live", "batch"])("assistant output correlat
     ]);
   });
 
+  it.each([
+    { type: "user_message", payload: { message: "again" } },
+    { type: "queued_command", payload: { uuid: "queued-next", commandMode: "prompt", content: "again" } },
+    { type: "realtime_transcript_done", payload: { role: "user", text: "again" } },
+  ])("does not repeat the active turn's late terminal answer after $type", boundary => {
+    const events = [
+      event("start-first", "turn_started", { turnId: "first" }),
+      event("agent-first", "agent_message", { message: "Done." }),
+      event("boundary", boundary.type, boundary.payload),
+      event("complete-first", "turn_complete", { turnId: "first", lastAgentMessage: "Done." }),
+    ];
+    expect(assistantRows(project(events, mode))).toEqual([
+      { uuid: "id:agent-first:0", content: answer },
+    ]);
+    expect(assistantRows(project([
+      ...events,
+      event("start-next", "turn_started", { turnId: "next" }),
+      event("agent-next", "agent_message", { message: "Done." }),
+      event("complete-next", "turn_complete", { turnId: "next", lastAgentMessage: "Done." }),
+    ], mode))).toEqual([
+      { uuid: "id:agent-first:0", content: answer },
+      { uuid: "id:agent-next:0", content: answer },
+    ]);
+  });
+
+  it.each(["turn_start", "turn_started"])("keeps fallback correlation when %s repeats the active turn ID", startType => {
+    const events = [
+      event("start", startType, { turnId: "same" }),
+      event("agent", "agent_message", { message: "Done." }),
+      event("repeated-start", startType, { turnId: "same" }),
+      event("complete", "turn_complete", { turnId: "same", lastAgentMessage: "Done." }),
+    ];
+    expect(assistantRows(project(events, mode))).toEqual([
+      { uuid: "id:agent:0", content: answer },
+    ]);
+  });
+
+  it.each([
+    { type: "agent_message_delta", payload: { delta: "Done." }, uuid: "id:user:0" },
+    { type: "realtime_transcript_done", payload: { role: "assistant", text: "Done." }, uuid: "id:output:0" },
+  ])("retains active-turn correlation for $type across a user boundary", output => {
+    const events = [
+      event("start", "turn_started", { turnId: "active" }),
+      event("output", output.type, output.payload),
+      event("user", "user_message", { message: "next" }),
+      event("complete", "turn_complete", { turnId: "active", lastAgentMessage: "Done." }),
+    ];
+    expect(assistantRows(project(events, mode))).toEqual([{ uuid: output.uuid, content: answer }]);
+  });
+
   it.each(["agent-first", "terminal-first"])("keeps one row for a same-turn answer and terminal fallback in %s order", order => {
     const agent = event("agent", "agent_message", { message: "Done." });
     const terminal = event("terminal", "turn_complete", { turnId: "turn", lastAgentMessage: "Done." });

--- a/runtime/tests/tui/session-transcript.assistant-turns.test.ts
+++ b/runtime/tests/tui/session-transcript.assistant-turns.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  adaptTranscriptEvents,
+  appendSessionTranscriptBatchForTesting,
+  appendSessionTranscriptEventForTesting,
+  createSessionTranscriptStateForTesting,
+  type AdaptedTranscript,
+  type SessionTranscriptEvent,
+} from "../../src/tui/session-transcript.js";
+
+type InputMode = "replay" | "live" | "batch";
+
+function event(id: string, type: string, payload: Record<string, unknown>): SessionTranscriptEvent {
+  return { id, type, payload };
+}
+
+function project(events: readonly SessionTranscriptEvent[], mode: InputMode): AdaptedTranscript {
+  if (mode === "replay") return adaptTranscriptEvents(createSessionTranscriptStateForTesting(events).events);
+  let state = createSessionTranscriptStateForTesting([]);
+  if (mode === "batch") state = appendSessionTranscriptBatchForTesting(state, events);
+  else for (const entry of events) state = appendSessionTranscriptEventForTesting(state, entry);
+  return adaptTranscriptEvents(state.events);
+}
+
+function assistantRows(transcript: AdaptedTranscript): readonly { readonly uuid: string; readonly content: unknown }[] {
+  return transcript.messages.filter(message => message.type === "assistant").map(message => ({
+    uuid: message.uuid, content: message.message.content,
+  }));
+}
+
+const answer = [{ type: "text", text: "Done." }];
+
+describe.each<InputMode>(["replay", "live", "batch"])("assistant output correlation through %s input", mode => {
+  it.each(["turn_start", "turn_started"])("preserves identical answers with distinct %s, event, and message identities", startType => {
+    const events = [1, 2].flatMap(turn => [
+      event(`start-${turn}`, startType, { turnId: `turn-${turn}` }),
+      event(`user-${turn}`, "user_message", { messageId: `message-${turn}`, message: `prompt ${turn}` }),
+      event(`agent-${turn}`, "agent_message", { message: "Done." }),
+      event(`complete-${turn}`, "turn_complete", { turnId: `turn-${turn}`, lastAgentMessage: "Done." }),
+    ]);
+    const expected = [
+      { uuid: "id:agent-1:0", content: answer },
+      { uuid: "id:agent-2:0", content: answer },
+    ];
+    expect(assistantRows(project(events, mode))).toEqual(expected);
+    expect(assistantRows(project([...events, ...events], mode))).toEqual(expected);
+    const sequenced = events.map((entry, index) => ({ ...entry, seq: index + 1 }));
+    expect(assistantRows(project([...sequenced].reverse().concat(sequenced), mode))).toEqual([
+      { uuid: "seq:3:0", content: answer },
+      { uuid: "seq:7:0", content: answer },
+    ]);
+  });
+
+  it.each([
+    { type: "turn_start", payload: { turnId: "next" } },
+    { type: "turn_started", payload: { turnId: "next" } },
+    { type: "user_message", payload: { messageId: "next-message", message: "again" } },
+    { type: "queued_command", payload: { uuid: "next-queued", commandMode: "prompt", originKind: "human", content: "again" } },
+    { type: "realtime_transcript_done", payload: { role: "user", text: "again" } },
+  ])("resets assistant correlation at a $type boundary without other lifecycle events", boundary => {
+    const events = [
+      event("first", "agent_message", { message: "Done." }),
+      event("boundary", boundary.type, boundary.payload),
+      event("second", "agent_message", { message: "Done." }),
+      event("complete", "turn_complete", { turnId: "next", lastAgentMessage: "Done." }),
+    ];
+    expect(assistantRows(project(events, mode))).toEqual([
+      { uuid: "id:first:0", content: answer },
+      { uuid: "id:second:0", content: answer },
+    ]);
+  });
+
+  it("flushes prior streaming text before resetting at the next user message", () => {
+    const events = [
+      event("delta", "agent_message_delta", { delta: "Done." }),
+      event("user", "user_message", { message: "again" }),
+      event("agent", "agent_message", { message: "Done." }),
+      event("complete", "turn_complete", { turnId: "next", lastAgentMessage: "Done." }),
+    ];
+    expect(assistantRows(project(events, mode))).toEqual([
+      { uuid: "id:user:0", content: answer },
+      { uuid: "id:agent:0", content: answer },
+    ]);
+  });
+
+  it.each(["agent-first", "terminal-first"])("keeps one row for a same-turn answer and terminal fallback in %s order", order => {
+    const agent = event("agent", "agent_message", { message: "Done." });
+    const terminal = event("terminal", "turn_complete", { turnId: "turn", lastAgentMessage: "Done." });
+    const output = order === "agent-first" ? [agent, terminal] : [terminal, agent];
+    const events = [event("start", "turn_started", { turnId: "turn" }), ...output, ...output];
+    const rows = assistantRows(project(events, mode));
+    expect(rows).toEqual([{ uuid: `id:${order === "agent-first" ? "agent" : "terminal"}:0`, content: answer }]);
+  });
+
+  it.each([
+    { name: "empty final", payload: { lastAgentMessage: "" } },
+    { name: "blank final", payload: { lastAgentMessage: "   " } },
+    { name: "empty content", payload: { content: "" } },
+  ])("does not replace an explicit $name with buffered text", terminal => {
+    const events = [
+      event("first", "agent_message", { message: "Done." }),
+      event("next", "turn_started", { turnId: "next" }),
+      event("delta", "agent_message_delta", { delta: "Done." }),
+      event("complete", "turn_complete", { turnId: "next", ...terminal.payload }),
+    ];
+    const transcript = project(events, mode);
+    expect(assistantRows(transcript)).toEqual([{ uuid: "id:first:0", content: answer }]);
+    expect(transcript.streamingText).toBeNull();
+  });
+
+  it.each([
+    { name: "final message", payload: { lastAgentMessage: "Done." } },
+    { name: "content", payload: { content: "Done." } },
+    { name: "streamed text", payload: {} },
+  ])("preserves a repeated terminal-only answer from $name in a new turn", terminal => {
+    const events = [
+      event("first", "agent_message", { message: "Done." }),
+      event("next", "turn_started", { turnId: "next" }),
+      event("delta", "agent_message_delta", { delta: "Done." }),
+      event("complete", "turn_complete", { turnId: "next", ...terminal.payload }),
+    ];
+    expect(assistantRows(project(events, mode))).toEqual([
+      { uuid: "id:first:0", content: answer },
+      { uuid: "id:complete:0", content: answer },
+    ]);
+  });
+
+  it("does not create empty assistant rows for an empty turn", () => {
+    const transcript = project([
+      event("start", "turn_started", { turnId: "empty" }),
+      event("empty-agent", "agent_message", { message: "   " }),
+      event("complete", "turn_complete", { turnId: "empty" }),
+    ], mode);
+    expect(assistantRows(transcript)).toEqual([]);
+    expect(transcript.streamingText).toBeNull();
+  });
+
+  it("preserves identical realtime answers separated by a user reply", () => {
+    const events = [
+      event("first", "realtime_transcript_done", { role: "assistant", text: "Done." }),
+      event("user", "realtime_transcript_done", { role: "user", text: "again" }),
+      event("second", "realtime_transcript_done", { role: "assistant", text: "Done." }),
+    ];
+    expect(assistantRows(project([...events, ...events], mode))).toEqual([
+      { uuid: "id:first:0", content: answer },
+      { uuid: "id:second:0", content: answer },
+    ]);
+  });
+});


### PR DESCRIPTION
## Changes

- Reset assistant fallback correlation at turn starts and visible user-message boundaries, including queued human prompts and realtime replies.
- Flush prior streamed text before resetting at the next prompt.
- Keep same-turn assistant/terminal fallback suppression, canonical seq/id deduplication, and empty terminal behavior unchanged.
- Retain separate active-turn fallback text across a queued or visible user prompt, and preserve it when the active turn's start event repeats.
- Document the boundary policy without changing protocol identities or event storage.

Closes #2071.

## Validation

- The original projection fails 36 new regressions; 18 preservation cases pass.
- Docker boundary, runtime and test-support TypeScript checks, and 174 focused tests across 8 files pass, zero skips.
- The 54 new cases cover replay, incremental live delivery, batch delivery, distinct turn/message/event identities, reordered canonical sequences, duplicate events, user-only boundaries, streamed previous output, both assistant/terminal orders, and empty/fallback text.
- GitNexus upstream impact is HIGH through the transcript hook and TUI/workbench callers. Staged review covers the 3 intended files.
- The initial head passed build, SDK mirror, every startup PTY check, and `npm test` (23,861 runtime tests across 2,295 files). Review then found a late-terminal duplication case after a new prompt.
- The review fix adds 21 revert-sensitive cases for late completion, repeated same-turn starts, streamed text, and realtime text. All 195 focused tests across 8 files pass in the Docker boundary with both TypeScript checks.
- Final head `902d337d9aa49da39ea2d026ca39a19c636ecfe4` passes build, SDK mirror, every startup PTY check, and `npm test`: all root/launcher gates plus 23,882 runtime tests across 2,295 files, zero failures or skips.
- Exact-head independent review is APPROVED, Bugbot reports no issues, security review is complete, and the prior finding is resolved. Sonar reports an OK gate, zero issues, and 0.9% new-code duplication, below the 3% limit.

Hosted test workflows remain disabled. No Actions workflows were enabled, dispatched, or rerun. Native Darwin and Windows execution is not claimed.
