### PR TITLE
fix(tui): retain logical submission identity across retries

### DIFF
--- a/docs/reference/tui-workbench.md
+++ b/docs/reference/tui-workbench.md
@@ -43,6 +43,27 @@ conversation to create a fresh adapter. Retrying a subscription on the old
 adapter cannot repair its replay gap. Failed transcript subscriptions release
 their event-log listener and pending coalescing timer.
 
+## Retrying daemon submissions
+
+Each model submission gets a client message ID. If a request fails and the TUI
+restores its draft, submitting that unchanged draft again reuses the ID, model
+input, skill expansion, and attachment snapshot. Editing the draft or attaching
+new work starts a new submission. Agent and Editor drafts retain separate retry
+records; a late failure cannot replace a newer draft.
+
+For an existing daemon session, a completed duplicate reports the recorded
+success, failure, or cancellation without executing again. The recovery notice
+does not recreate missed tool events. Reopen the conversation to inspect its
+durable history. An admitted submission without a recorded terminal result
+reports an unknown outcome and refuses to run again. Inspect the history and
+any tool effects before deliberately starting a new submission.
+
+Silence is not proof that the daemon rejected a request. The acknowledgement
+watchdog reports uncertainty and does not release an outstanding request's busy
+state. Retry records last for the current TUI mount. Initial conversation
+creation and moving to a different daemon session are separate operations, not
+idempotent retries of an existing session's message.
+
 ## Layouts
 
 | Layout                                          | When                                                   |

--- a/runtime/src/session/autonomous-mode.ts
+++ b/runtime/src/session/autonomous-mode.ts
@@ -44,6 +44,7 @@ export interface SessionEditorInteraction {
 }
 
 export interface SessionSubmitOptions {
+  readonly clientMessageId?: string;
   readonly source?: SessionSubmitSource;
   /**
    * Transcript-facing input for this submission. `undefined` means render the

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1,4 +1,5 @@
 import { logForDebugging } from "src/utils/debug.js";
+import { isRecord } from "../../utils/record.js";
 import { createHash, randomUUID } from "node:crypto";
 import { join, resolve } from "node:path";
 import { c as _c } from "react-compiler-runtime";
@@ -232,7 +233,10 @@ import type {
   QueuedCommandOwner,
   VimMode,
 } from "../../types/textInputTypes.js";
-import type { SessionEditorInteraction } from "../../session/autonomous-mode.js";
+import type {
+  SessionEditorInteraction,
+  SessionSubmitOptions,
+} from "../../session/autonomous-mode.js";
 import {
   validateEditorProposalPayload,
   type EditorProposalPayload,
@@ -338,13 +342,32 @@ type LiveSubmitOptions = {
 };
 
 type PendingWorkbenchAttachmentAdmission = {
+  readonly clientMessageId: string;
   readonly acknowledge: () => void;
 };
 
-function sessionEventStartsTurn(event: unknown): boolean {
+type ComposerSubmission = {
+  readonly clientMessageId: string;
+  readonly draftRestoreValue: string;
+  readonly pastedContents: Record<number, any>;
+  readonly attachmentIds: readonly string[];
+  readonly acknowledge: () => void;
+  value: string;
+  options: SessionSubmitOptions;
+  inputs: readonly LLMMessage[];
+  ready: boolean;
+};
+
+function sessionEventStartsTurn(
+  event: unknown,
+  clientMessageId?: string,
+  requireIdentity = false,
+): boolean {
   if (typeof event !== "object" || event === null) return false;
   const record = event as {
     readonly type?: unknown;
+    readonly clientMessageId?: unknown;
+    readonly payload?: { readonly clientMessageId?: unknown };
     readonly msg?: { readonly type?: unknown };
   };
   const type =
@@ -353,7 +376,15 @@ function sessionEventStartsTurn(event: unknown): boolean {
       : typeof record.msg?.type === "string"
         ? record.msg.type
         : null;
-  return type === "turn_start" || type === "turn_started";
+  const observedIdentity =
+    record.clientMessageId ?? record.payload?.clientMessageId;
+  return (
+    (type === "turn_start" || type === "turn_started" ||
+      type === "turn_complete" || type === "message_submission_recovered" ||
+      (type === "user_message" && observedIdentity !== undefined)) &&
+    ((observedIdentity === undefined && !requireIdentity) ||
+      observedIdentity === clientMessageId)
+  );
 }
 
 type TuiWorkspaceEditorAuthorityState =
@@ -2685,6 +2716,11 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
   // (catch wrapper for #61). Local slash commands skip this state so
   // immediate command errors don't flash a model-request spinner.
   const [pendingSubmission, setPendingSubmission] = useState(false);
+  const pendingSubmissionIdRef = useRef<string | null>(null);
+  const latestSubmissionIdsRef = useRef<
+    Record<"agent" | "editor", string | null>
+  >({ agent: null, editor: null });
+  const activeModelSubmissionTokensRef = useRef(new Set<symbol>());
   // `pendingSubmission` can clear as soon as the daemon acknowledges the
   // request. Keep a separate count for the actual submit promises so the
   // prompt remains busy/cancellable while message.stream is still running.
@@ -2701,6 +2737,19 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     [],
   );
   const [pastedContents, setPastedContents] = useState<Record<number, any>>({});
+  const retrySubmissionsRef = useRef<
+    Record<"agent" | "editor", ComposerSubmission | null>
+  >({ agent: null, editor: null });
+  const changeComposerInput = useCallback((nextInput: string) => {
+    retrySubmissionsRef.current[latestWorkbenchStateRef.current.activeWorkspaceView] = null;
+    setInput(nextInput);
+  }, []);
+  const changeComposerPastedContents = useCallback<
+    React.Dispatch<React.SetStateAction<Record<number, any>>>
+  >((nextContents) => {
+    retrySubmissionsRef.current[latestWorkbenchStateRef.current.activeWorkspaceView] = null;
+    setPastedContents(nextContents);
+  }, []);
   const [vimMode, setVimMode] = useState<VimMode>("INSERT");
   const workspaceComposerDraftsRef = useRef<
     Record<
@@ -2800,6 +2849,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       failedDraft: {
         readonly input: string;
         readonly pastedContents?: Record<number, any>;
+        readonly submission?: ComposerSubmission;
       },
     ): void => {
       const activeView = latestWorkbenchStateRef.current.activeWorkspaceView;
@@ -2812,6 +2862,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       // either field contains newer content, preserve the whole newer draft
       // rather than splicing an old prompt and attachment into it.
       if (
+        (failedDraft.submission?.ready === true &&
+          latestSubmissionIdsRef.current[view] !== failedDraft.submission.clientMessageId) ||
         currentDraft.input.length > 0 ||
         Object.keys(currentDraft.pastedContents).length > 0
       ) {
@@ -2826,6 +2878,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
             : currentDraft.pastedContents,
       };
       workspaceComposerDraftsRef.current[view] = restoredDraft;
+      retrySubmissionsRef.current[view] =
+        failedDraft.submission?.ready === true ? failedDraft.submission : null;
       if (activeView !== view) return;
       liveComposerDraftRef.current = restoredDraft;
       setInput(restoredDraft.input);
@@ -2922,13 +2976,31 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       // React commits useSessionTranscript's state update. Consume attachments
       // here so a same-tick message.stream rejection cannot erase evidence that
       // the daemon already started the turn.
-      if (sessionEventStartsTurn(event)) {
+      const pendingAdmission = pendingWorkbenchAttachmentAdmissionRef.current;
+      if (sessionEventStartsTurn(
+        event,
+        pendingAdmission?.clientMessageId,
+        typeof props.session.getDaemonSessionSnapshot === "function",
+      )) {
         const admittedAttachments =
           pendingWorkbenchAttachmentAdmissionRef.current;
         if (admittedAttachments !== null) {
           pendingWorkbenchAttachmentAdmissionRef.current = null;
           admittedAttachments.acknowledge();
         }
+      }
+      if (isRecord(event) && event.type === "message_submission_recovered" && isRecord(event.payload)) {
+        const payload = event.payload;
+        if (payload.clientMessageId === pendingSubmissionIdRef.current) setPendingSubmission(false);
+        const outcome = payload.code === 0 ? "completed" : payload.code === 130 ? "cancelled" : "failed";
+        addNotification({
+          key: `submission-recovered:${String(payload.clientMessageId)}`,
+          text: `The previous submission ${outcome}; it was not run again.${typeof payload.message === "string" ? ` ${payload.message}` : " Reopen the session to inspect its recorded output."}`,
+          color: payload.code === 0 ? "info" : "warning",
+          priority: "immediate",
+          timeoutMs: 10_000,
+          wrap: true,
+        });
       }
       syncCollabAgentEventToAppState(event, setAppState);
       const workspaceMutation = workspaceMutationProposalFromTuiEvent(event);
@@ -4813,6 +4885,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     streamedThisTurnRef.current = false;
     if (!pendingSubmission && activeModelSubmissionCount === 0) return;
     setPendingSubmission(false);
+    activeModelSubmissionTokensRef.current.clear();
     setActiveModelSubmissionCount(0);
   }, [
     transcript.isStreaming,
@@ -5277,19 +5350,20 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
   const submitToSession = useCallback(
     async (
       value: string,
-      options?: {
-        readonly displayUserMessage?: string | null;
-        readonly editorInteraction?: SessionEditorInteraction;
-      },
+      options?: SessionSubmitOptions,
     ): Promise<void> => {
       const submitSession = props.session.submit;
       if (typeof submitSession !== "function") return;
-      setActiveModelSubmissionCount((count) => count + 1);
+      const token = Symbol("model-submission");
+      activeModelSubmissionTokensRef.current.add(token);
+      setActiveModelSubmissionCount(activeModelSubmissionTokensRef.current.size);
       effectiveInputBusyRef.current = true;
       try {
         await submitSession(value, options);
       } finally {
-        setActiveModelSubmissionCount((count) => Math.max(0, count - 1));
+        if (activeModelSubmissionTokensRef.current.delete(token)) {
+          setActiveModelSubmissionCount(activeModelSubmissionTokensRef.current.size);
+        }
       }
     },
     [props.session],
@@ -5310,17 +5384,35 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       const text_0 = value.trim();
       const historyDisplay = (options?.displayUserMessage ?? text_0).trim();
       const draftRestoreValue = options?.draftRestoreValue ?? value;
+      const submissionAttachmentIds =
+        submissionWorkspaceView === submissionWorkbenchState.activeWorkspaceView
+          ? submissionWorkbenchState.composerAttachmentIds
+          : submissionWorkspaceView === "editor"
+            ? submissionWorkbenchState.editorComposerAttachmentIds
+            : submissionWorkbenchState.agentComposerAttachmentIds;
+      const candidateRetry = retrySubmissionsRef.current[submissionWorkspaceView];
+      const retry =
+        !options?.fromQueue &&
+        candidateRetry?.draftRestoreValue === draftRestoreValue &&
+        submissionAttachmentIds.every(id => candidateRetry.attachmentIds.includes(id))
+          ? candidateRetry
+          : null;
+      const clientMessageId = retry?.clientMessageId ?? randomUUID();
       let workbenchAttachmentsAcknowledged = false;
       const acknowledgeWorkbenchAttachments = (): void => {
         if (workbenchAttachmentsAcknowledged) return;
         workbenchAttachmentsAcknowledged = true;
-        options?.onWorkbenchAttachmentsAdmitted?.();
+        if (retry !== null) retry.acknowledge();
+        else options?.onWorkbenchAttachmentsAdmitted?.();
       };
       const armWorkbenchAttachmentAdmission =
         (): PendingWorkbenchAttachmentAdmission | null => {
-          if (options?.onWorkbenchAttachmentsAdmitted === undefined)
+          if (options?.onWorkbenchAttachmentsAdmitted === undefined && retry === null)
             return null;
-          const pending = { acknowledge: acknowledgeWorkbenchAttachments };
+          const pending = {
+            clientMessageId,
+            acknowledge: acknowledgeWorkbenchAttachments,
+          };
           // Model submissions are serialized by effectiveInputBusyRef. Keep the
           // identity check below anyway so an unexpected concurrent caller can
           // only fall back to promise settlement, never steal another turn's ack.
@@ -5340,14 +5432,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         if (admitted) pending.acknowledge();
       };
       const activePastedContents =
-        options?.pastedContentsOverride ?? pastedContents;
+        retry?.pastedContents ?? options?.pastedContentsOverride ?? pastedContents;
       const hasAttachments = Object.keys(activePastedContents).length > 0;
-      const submissionAttachmentIds =
-        submissionWorkspaceView === submissionWorkbenchState.activeWorkspaceView
-          ? submissionWorkbenchState.composerAttachmentIds
-          : submissionWorkspaceView === "editor"
-            ? submissionWorkbenchState.editorComposerAttachmentIds
-            : submissionWorkbenchState.agentComposerAttachmentIds;
       const attachmentInteraction = submissionAttachmentIds
         .map((id) =>
           submissionWorkbenchState.attachments.find(
@@ -5361,7 +5447,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         )
         .at(-1);
       const editorInteraction =
-        options?.editorInteraction ??
+        retry?.options.editorInteraction ?? options?.editorInteraction ??
         (!options?.fromQueue &&
         submissionWorkspaceView === "editor" &&
         attachmentInteraction !== undefined
@@ -5473,13 +5559,13 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         });
       }
       const parsedSlashCommand =
-        editorInteraction === undefined &&
+        retry === null && editorInteraction === undefined &&
         text_0.startsWith("/") &&
         text_0.length > 1
           ? parseSlashCommand(text_0)
           : null;
       const parsedDollarSkill =
-        editorInteraction === undefined &&
+        retry === null && editorInteraction === undefined &&
         text_0.startsWith("$") &&
         text_0.length > 1
           ? parseDollarSkillCommand(text_0)
@@ -5511,6 +5597,10 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         return;
       }
       if (!options?.fromQueue && effectiveInputBusyRef.current) {
+        if (retry !== null) {
+          showTransientResult("Wait for the current request to settle before retrying the restored submission.", { display: "error" });
+          return;
+        }
         enqueue({
           value: text_0,
           preExpansionValue: text_0,
@@ -5550,6 +5640,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       // user-input clear path.
       cancelTransientResult(true);
       const startPendingSubmission = () => {
+        latestSubmissionIdsRef.current[submissionWorkspaceView] = clientMessageId;
+        pendingSubmissionIdRef.current = clientMessageId;
         setPendingSubmission(true);
         effectiveInputBusyRef.current = true;
       };
@@ -5570,6 +5662,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         submissionScrollRef.current?.scrollToBottom();
       }
       setComposerInputForView(submissionWorkspaceView, "");
+      retrySubmissionsRef.current[submissionWorkspaceView] = null;
       // Persist the submitted prompt so Up-arrow / Ctrl+R history recall
       // can find it. The daemon-backed AgenCTuiApp dispatch path used to
       // skip this, so the picker said "No history yet" right after a
@@ -5589,6 +5682,21 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       const attachmentsMessage = hasAttachments
         ? pastedContentsToLLMMessage(activePastedContents)
         : null;
+      const submission: ComposerSubmission = retry ?? {
+        clientMessageId,
+        draftRestoreValue,
+        pastedContents: activePastedContents,
+        attachmentIds: [...submissionAttachmentIds],
+        acknowledge: acknowledgeWorkbenchAttachments,
+        value,
+        options: {
+          clientMessageId,
+          displayUserMessage: options?.displayUserMessage ?? value,
+          ...(editorInteraction === undefined ? {} : { editorInteraction }),
+        },
+        inputs: attachmentsMessage === null ? [] : [attachmentsMessage],
+        ready: false,
+      };
       const admitPendingInputs = (
         inputs: readonly LLMMessage[],
       ): string | null => {
@@ -5655,11 +5763,14 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
                 new AbortController(),
               ) as PromptInputContext,
             );
-            const admissionToken = admitPendingInputs([
+            submission.inputs = [
               ...(attachmentsMessage !== null ? [attachmentsMessage] : []),
               loaded.metadata,
               { content: loaded.blocks },
-            ]);
+            ];
+            submission.value = "";
+            submission.options = { clientMessageId, displayUserMessage: displayText };
+            const admissionToken = admitPendingInputs(submission.inputs);
             admissionLease = {
               commit: () => {
                 if (admissionToken !== null) {
@@ -5677,7 +5788,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
               settle: (admitted) =>
                 settleWorkbenchAttachmentAdmission(workbenchAdmission, admitted),
             };
-            await submitToSession("", { displayUserMessage: displayText });
+            submission.ready = true;
+            await submitToSession(submission.value, submission.options);
             submitted = true;
           } finally {
             try {
@@ -5687,6 +5799,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
                 restoreComposerDraftForView(submissionWorkspaceView, {
                   input: draftRestoreValue,
                   pastedContents: activePastedContents,
+                  submission,
                 });
               }
             } finally {
@@ -5700,7 +5813,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
             key: "prompt-submit-failed",
             text: submitted
               ? `Message sent, but cleanup failed: ${message}`
-              : `Message not sent: ${message}`,
+              : `Submission failed: ${message}`,
             color: "error",
             priority: "immediate",
             timeoutMs: 10_000,
@@ -5708,7 +5821,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           });
           if (options?.rethrowSubmitError) throw error;
         } finally {
-          if (!submitted) setPendingSubmission(false);
+          if (!submitted && pendingSubmissionIdRef.current === clientMessageId) setPendingSubmission(false);
         }
       };
       // Slash-command interception. The daemon-backed TUI does not have
@@ -5912,8 +6025,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       let attachmentAdmissionToken: string | null = null;
       let workbenchAdmission: PendingWorkbenchAttachmentAdmission | null = null;
       try {
-        if (attachmentsMessage !== null) {
-          attachmentAdmissionToken = admitPendingInputs([attachmentsMessage]);
+        if (submission.inputs.length > 0) {
+          attachmentAdmissionToken = admitPendingInputs(submission.inputs);
           attachmentAdmitted = true;
         }
         setComposerPastedContentsForView(submissionWorkspaceView, {});
@@ -5933,10 +6046,8 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           activeEditorProposalTurnIdsRef.current.add(proposalTurnId);
         }
         try {
-          await submitToSession(value, {
-            displayUserMessage: options?.displayUserMessage ?? value,
-            ...(editorInteraction !== undefined ? { editorInteraction } : {}),
-          });
+          submission.ready = true;
+          await submitToSession(submission.value, submission.options);
         } finally {
           if (proposalTurnId !== null) {
             activeEditorProposalTurnIdsRef.current.delete(proposalTurnId);
@@ -5946,6 +6057,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           props.session.commitIdleInputAdmission?.(attachmentAdmissionToken);
         }
         settleWorkbenchAttachmentAdmission(workbenchAdmission, true);
+        if (retry !== null && pendingSubmissionIdRef.current === clientMessageId) setPendingSubmission(false);
       } catch (err_1) {
         settleWorkbenchAttachmentAdmission(workbenchAdmission, false);
         // Same defense as submitPromptToModel above: a daemon JSON-RPC
@@ -5966,7 +6078,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         // notification lane renders regardless of overlays.
         addNotification({
           key: "prompt-submit-failed",
-          text: `Message not sent: ${message_0}`,
+          text: `Submission failed: ${message_0}`,
           color: "error",
           priority: "immediate",
           timeoutMs: 10_000,
@@ -5975,10 +6087,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           // exactly the part the user needs.
           wrap: true,
         });
-        // Submit threw before turn_started arrived — clear the
-        // pending-submission spinner so the UI doesn't lie about
-        // waiting for a turn that will never start.
-        setPendingSubmission(false);
+        if (pendingSubmissionIdRef.current === clientMessageId) setPendingSubmission(false);
         const rolledBack =
           attachmentAdmissionToken !== null &&
           props.session.rollbackIdleInputAdmission?.(
@@ -5986,6 +6095,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           ) === true;
         restoreComposerDraftForView(submissionWorkspaceView, {
           input: draftRestoreValue,
+          submission,
           ...(!attachmentAdmitted || rolledBack
             ? { pastedContents: activePastedContents }
             : {}),
@@ -6094,15 +6204,6 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       assistantMessageCount > lastAssistantMessageCountRef.current ||
       hasActiveSessionTurn
     ) {
-      // message.stream can remain pending for the entire turn. A daemon turn
-      // signal is the durable admission boundary: consume the exact originating
-      // attachment snapshot now so a second queued prompt cannot resend it.
-      const admittedAttachments =
-        pendingWorkbenchAttachmentAdmissionRef.current;
-      if (admittedAttachments !== null) {
-        pendingWorkbenchAttachmentAdmissionRef.current = null;
-        admittedAttachments.acknowledge();
-      }
       lastAssistantMessageCountRef.current = assistantMessageCount;
       setPendingSubmission(false);
     }
@@ -6112,15 +6213,6 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     assistantMessageCount,
     hasActiveSessionTurn,
   ]);
-  // Submit-ack watchdog: the complementary failure — a turn whose events
-  // NEVER reach the client (the 403 flavor where the request dies before any
-  // turn_started is broadcast, a wedged daemon, or a dropped event
-  // subscription). Every other spinner-clearing path keys on daemon signals;
-  // with zero signals, pendingSubmission would latch true forever, Esc could
-  // not clear it (the transcript never saw a turn to abort), and prompts
-  // queued behind a phantom busy state. A cold daemon bootstrap can take
-  // ~15s to acknowledge, so the window is 20s — past that, the turn never
-  // started: clear the flag and tell the user instead of spinning forever.
   const pendingSubmissionSinceRef = useRef<number | null>(null);
   useEffect(() => {
     if (pendingSubmission && pendingSubmissionSinceRef.current === null) {
@@ -6135,16 +6227,9 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       if (since === null || Date.now() - since < SUBMIT_ACK_WATCHDOG_MS) return;
       pendingSubmissionSinceRef.current = null;
       setPendingSubmission(false);
-      // Also drop the model-submission count: a submit whose message.stream
-      // RPC never settles (known on error-terminated turns) holds the count
-      // at 1 forever, keeping isLoading true even after pendingSubmission
-      // clears — the daemon-silence watchdog would then fire "Turn aborted"
-      // every 60s while every new prompt queues behind the phantom busy
-      // state. A give-up path must reset every flag that composes isLoading.
-      setActiveModelSubmissionCount(0);
       addNotification({
         key: "submit-ack-watchdog",
-        text: "No response from the daemon — the turn never started. Resubmit, or run /login again if this was an auth failure.",
+        text: "The daemon has not acknowledged this submission. Its outcome is unknown. Wait for the request to settle or reconnect and inspect the session before sending it again.",
         priority: "immediate",
         timeoutMs: 8000,
       });
@@ -6347,6 +6432,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
     // a no-op there.
     pendingSubmissionSinceRef.current = null;
     setPendingSubmission(false);
+    activeModelSubmissionTokensRef.current.clear();
     setActiveModelSubmissionCount(0);
   }, [isLoading, turnAbortController, props.session]);
   const handleAgentsKilled = useCallback(
@@ -6947,7 +7033,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
             onAutoUpdaterResult={() => {}}
             autoUpdaterResult={null}
             input={input}
-            onInputChange={setInput}
+            onInputChange={changeComposerInput}
             mode={mode}
             onModeChange={setMode}
             stashedPrompt={stashedPrompt}
@@ -6957,7 +7043,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
             onMessageActionsEnter={handleShowMessageSelector}
             mcpClients={mcpClients as never}
             pastedContents={pastedContents}
-            setPastedContents={setPastedContents}
+            setPastedContents={changeComposerPastedContents}
             vimMode={vimMode}
             setVimMode={setVimMode}
             showBashesDialog={showBashesDialog}
@@ -7156,7 +7242,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       onAutoUpdaterResult={() => {}}
       autoUpdaterResult={null}
       input={input}
-      onInputChange={setInput}
+      onInputChange={changeComposerInput}
       mode={mode}
       onModeChange={setMode}
       stashedPrompt={stashedPrompt}
@@ -7166,7 +7252,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       onMessageActionsEnter={handleShowMessageSelector}
       mcpClients={mcpClients as never}
       pastedContents={pastedContents}
-      setPastedContents={setPastedContents}
+      setPastedContents={changeComposerPastedContents}
       vimMode={vimMode}
       setVimMode={setVimMode}
       showBashesDialog={showBashesDialog}

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -252,7 +252,7 @@ import {
 import { useMcpConnectivityStatus } from "../hooks/notifs/useMcpConnectivityStatus.js";
 import { useCostSummary } from "../../cost/hook.js";
 import { getTotalCost } from "../../cost/tracker.js";
-import { useNotifications } from "../context/notifications.js";
+import { useNotifications, type Notification } from "../context/notifications.js";
 import { hasConsoleBillingAccess } from "../../utils/billing.js";
 import { updateRuntimeState } from "../../utils/config.js";
 import { registerCleanup } from "../../utils/cleanupRegistry.js";
@@ -347,6 +347,7 @@ type PendingWorkbenchAttachmentAdmission = {
 };
 
 type ComposerSubmission = {
+  readonly conversationId: string;
   readonly clientMessageId: string;
   readonly draftRestoreValue: string;
   readonly pastedContents: Record<number, any>;
@@ -357,6 +358,32 @@ type ComposerSubmission = {
   inputs: readonly LLMMessage[];
   ready: boolean;
 };
+
+function submissionRecoveryNotification(event: unknown): {
+  readonly clientMessageId: string;
+  readonly notification: Notification;
+} | null {
+  if (!isRecord(event) || event.type !== "message_submission_recovered" || !isRecord(event.payload)) return null;
+  const payload = event.payload;
+  if (typeof payload.clientMessageId !== "string" ||
+    (payload.code !== 0 && payload.code !== 1 && payload.code !== 130)) return null;
+  const outcomes = { 0: "completed", 1: "failed", 130: "cancelled" };
+  const outcome = outcomes[payload.code];
+  const detail = typeof payload.message === "string"
+    ? ` ${payload.message}`
+    : " Reopen the session to inspect its recorded output.";
+  return {
+    clientMessageId: payload.clientMessageId,
+    notification: {
+      key: `submission-recovered:${payload.clientMessageId}`,
+      text: `The previous submission ${outcome}. It was not run again.${detail}`,
+      color: payload.code === 0 ? "info" : "warning",
+      priority: "immediate",
+      timeoutMs: 10_000,
+      wrap: true,
+    },
+  };
+}
 
 function sessionEventStartsTurn(
   event: unknown,
@@ -2989,18 +3016,10 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
           admittedAttachments.acknowledge();
         }
       }
-      if (isRecord(event) && event.type === "message_submission_recovered" && isRecord(event.payload)) {
-        const payload = event.payload;
-        if (payload.clientMessageId === pendingSubmissionIdRef.current) setPendingSubmission(false);
-        const outcome = payload.code === 0 ? "completed" : payload.code === 130 ? "cancelled" : "failed";
-        addNotification({
-          key: `submission-recovered:${String(payload.clientMessageId)}`,
-          text: `The previous submission ${outcome}; it was not run again.${typeof payload.message === "string" ? ` ${payload.message}` : " Reopen the session to inspect its recorded output."}`,
-          color: payload.code === 0 ? "info" : "warning",
-          priority: "immediate",
-          timeoutMs: 10_000,
-          wrap: true,
-        });
+      const recovered = submissionRecoveryNotification(event);
+      if (recovered !== null) {
+        if (recovered.clientMessageId === pendingSubmissionIdRef.current) setPendingSubmission(false);
+        addNotification(recovered.notification);
       }
       syncCollabAgentEventToAppState(event, setAppState);
       const workspaceMutation = workspaceMutationProposalFromTuiEvent(event);
@@ -5394,6 +5413,9 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       const retry =
         !options?.fromQueue &&
         candidateRetry?.draftRestoreValue === draftRestoreValue &&
+        candidateRetry.conversationId === props.session.conversationId &&
+        (options?.editorInteraction === undefined ||
+          candidateRetry.options.editorInteraction?.interactionId === options.editorInteraction.interactionId) &&
         submissionAttachmentIds.every(id => candidateRetry.attachmentIds.includes(id))
           ? candidateRetry
           : null;
@@ -5639,9 +5661,9 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
       // The 3s auto-clear timer is a safety net; this is the immediate
       // user-input clear path.
       cancelTransientResult(true);
+      latestSubmissionIdsRef.current[submissionWorkspaceView] = clientMessageId;
+      pendingSubmissionIdRef.current = clientMessageId;
       const startPendingSubmission = () => {
-        latestSubmissionIdsRef.current[submissionWorkspaceView] = clientMessageId;
-        pendingSubmissionIdRef.current = clientMessageId;
         setPendingSubmission(true);
         effectiveInputBusyRef.current = true;
       };
@@ -5683,6 +5705,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         ? pastedContentsToLLMMessage(activePastedContents)
         : null;
       const submission: ComposerSubmission = retry ?? {
+        conversationId: props.session.conversationId,
         clientMessageId,
         draftRestoreValue,
         pastedContents: activePastedContents,
@@ -5753,6 +5776,7 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
         let submitted = false;
         try {
           try {
+            startPendingSubmission();
             setComposerPastedContentsForView(submissionWorkspaceView, {});
             const loaded = await loadDollarSkillCommandForTurn(
               parsedCommand,
@@ -5782,7 +5806,6 @@ function AgenCTuiShell(props: AgenCTuiShellProps): React.ReactElement {
                 props.session.rollbackIdleInputAdmission?.(admissionToken) ===
                   true,
             };
-            startPendingSubmission();
             const workbenchAdmission = armWorkbenchAttachmentAdmission();
             workbenchLease = {
               settle: (admitted) =>

--- a/runtime/src/tui/daemon-session.ts
+++ b/runtime/src/tui/daemon-session.ts
@@ -19,6 +19,7 @@ import type {
   JsonValue,
   MessageContentBlock,
   MessageStreamParams,
+  MessageStreamResult,
   RequestId,
   SessionMcpStatusResult,
   SessionMcpAddServerParams,
@@ -147,7 +148,7 @@ import { mcpServerNameValidationIssue } from "../mcp-client/server-name.js";
 import { isRecord } from "../utils/record.js";
 import { logForDebugging } from "../utils/debug.js";
 import type { AgentRoleWorkspace } from "../agents/role-workspace.js";
-import type { SessionEditorInteraction } from "../session/autonomous-mode.js";
+import type { SessionSubmitOptions } from "../session/autonomous-mode.js";
 import type { RunRuntimeSettingsSnapshot } from "../contracts/run-contracts.js";
 import {
   applyDaemonTuiRuntimeSettingsAuthority,
@@ -384,10 +385,7 @@ export interface AgenCTuiBridgeSession extends AgenCCompactProgressControls {
   } | null;
   submit?(
     message: string,
-    opts?: {
-      readonly displayUserMessage?: string | null;
-      readonly editorInteraction?: SessionEditorInteraction;
-    },
+    opts?: SessionSubmitOptions,
   ): Promise<void>;
   enqueueIdleInput?(input: unknown, ownership?: IdleInputOwnership): number;
   enqueueIdleInputBatch?(
@@ -430,10 +428,7 @@ export type AgenCDaemonBackedTuiSession<
   subscribeToEvents(cb: (event: unknown) => void): () => void;
   submit(
     message: string,
-    opts?: {
-      readonly displayUserMessage?: string | null;
-      readonly editorInteraction?: SessionEditorInteraction;
-    },
+    opts?: SessionSubmitOptions,
   ): Promise<void>;
   enqueueIdleInput(input: unknown, ownership?: IdleInputOwnership): number;
   enqueueIdleInputBatch(
@@ -1187,9 +1182,12 @@ export function createDaemonTuiSession<
       if (queued.length === 0 && message.length === 0) return;
       inFlightInputCount += submittedInputCount;
       inFlightInputBytes += submittedInputBytes;
-      const streamId = `${clientId}:${Date.now()}`;
-      terminalDaemonTurnObserved = false;
-      activeTurnSnapshot = { turnId: streamId };
+      const clientMessageId = opts?.clientMessageId ?? randomUUID();
+      const streamId = `${clientId}:${randomUUID()}`;
+      if (activeTurnSnapshot === null) {
+        terminalDaemonTurnObserved = false;
+        activeTurnSnapshot = { turnId: streamId };
+      }
       const content =
         queued.length === 0
           ? message
@@ -1199,6 +1197,7 @@ export function createDaemonTuiSession<
                 ? [{ type: "text", text: message } as MessageContentBlock]
                 : []),
             ];
+      let recovered: MessageStreamResult | undefined;
       try {
         const metadata: JsonObject = {
           ...(opts?.displayUserMessage !== undefined
@@ -1236,12 +1235,31 @@ export function createDaemonTuiSession<
               }
             : {}),
         };
-        await client.request("message.stream", {
+        const result = await client.request("message.stream", {
           sessionId,
           content,
           ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+          clientMessageId,
           streamId,
         } satisfies MessageStreamParams);
+        if (result.disposition === "duplicate") {
+          if (
+            result.duplicateState !== "completed" ||
+            result.terminal === undefined
+          ) {
+            throw new Error(
+              `Submission ${clientMessageId} was already admitted, but its terminal outcome is unknown. It was not run again. Inspect the session history and tool effects before starting a new submission.`,
+            );
+          }
+          recovered = result;
+          if (
+            activeTurnSnapshot?.turnId === streamId ||
+            activeTurnSnapshot?.turnId === result.turnId
+          ) {
+            activeTurnSnapshot = null;
+            terminalDaemonTurnObserved = true;
+          }
+        }
         const submitted = new Set(queuedEntries);
         for (const [token, admission] of idleInputAdmissions) {
           if (admission.entries.every((entry) => submitted.has(entry))) {
@@ -1255,7 +1273,7 @@ export function createDaemonTuiSession<
         // startup messages) were already drained out of `queuedInputs` above;
         // if we don't roll them back the user's content is lost permanently
         // with no transcript entry. Re-prepend the drained blocks so the next
-        // submit re-sends them, preserving at-least-once delivery.
+        // submit re-sends them.
         if (queuedEntries.length > 0) {
           const originalEntries = new Set(queuedInputsBeforeSubmission);
           const admittedAfterSubmission = queuedInputs.filter(
@@ -1270,7 +1288,7 @@ export function createDaemonTuiSession<
           queuedInputCount += submittedInputCount;
           queuedInputBytes += submittedInputBytes;
         }
-        activeTurnSnapshot = null;
+        if (activeTurnSnapshot?.turnId === streamId) activeTurnSnapshot = null;
         throw error;
       } finally {
         inFlightInputCount = Math.max(
@@ -1281,6 +1299,16 @@ export function createDaemonTuiSession<
           0,
           inFlightInputBytes - submittedInputBytes,
         );
+      }
+      if (recovered?.terminal !== undefined) {
+        broadcastDaemonEvent({
+          type: "message_submission_recovered",
+          payload: {
+            clientMessageId,
+            ...(recovered.turnId === undefined ? {} : { turnId: recovered.turnId }),
+            ...recovered.terminal,
+          },
+        });
       }
     },
     enqueueIdleInput: (input, ownership) => {
@@ -2902,6 +2930,9 @@ function transcriptEventFromSessionEvent(params: JsonObject): JsonObject | null 
   if (!isJsonObject(params.event)) return null;
   return {
     ...params.event,
+    ...(typeof params.clientMessageId === "string"
+      ? { clientMessageId: params.clientMessageId }
+      : {}),
     ...(typeof params.eventId === "string" && params.eventId.length > 0
       ? { eventId: params.eventId }
       : {}),

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -26,6 +26,8 @@ import {
   managedTokenUsage,
 } from "./background-agent-runner.js";
 import { collectDaemonClientEnvOverrides } from "./agent-cli.js";
+import { createDaemonTuiSessionFixture } from "../helpers/daemon-tui-session.js";
+import type { AgenCDaemonTuiClient } from "../../src/tui/daemon-session.js";
 import { AgenCDaemonAgentManager } from "./agent-lifecycle.js";
 import { AgenCDaemonJsonRpcDispatcher } from "./daemon-dispatcher.js";
 import { AgenCDaemonSessionManager } from "./session-lifecycle.js";
@@ -9035,6 +9037,121 @@ describe("AgenC delegate background-agent runner", () => {
       }
     },
   );
+
+  it("[managed-thread] recovers a TUI response dropped after execution without resubmitting owned input", async () => {
+    const agentId = "session-tui-retry";
+    const sessionId = "session-tui-retry-client";
+    const { runner, control, stub } = makeTopLevelRunner({ conversationId: agentId });
+    const sessions = new AgenCDaemonSessionManager();
+    const manager = new AgenCDaemonAgentManager({ runner, sessionManager: sessions });
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: manager, sessionManager: sessions });
+    const connection = dispatcher.createConnection();
+    const requests: JsonObject[] = [];
+    let dropResponse = true;
+    let requestSequence = 0;
+    const client = {
+      request: async (method: string, params: JsonObject) => {
+        expect(method).toBe("message.stream");
+        requests.push(params);
+        const response = await connection.dispatch({ jsonrpc: "2.0", id: ++requestSequence, method, params });
+        expect(response).not.toHaveProperty("error");
+        if (dropResponse) {
+          dropResponse = false;
+          throw new Error("response socket closed after execution");
+        }
+        return response.result;
+      },
+      subscribeToSessionEvents: () => () => {},
+    } as unknown as AgenCDaemonTuiClient;
+    try {
+      const started = await runner.startAgent({ objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+      await sessions.restoreSession({ sessionId, agentId, status: "waiting", createdAt: started.startedAt });
+      await manager.restoreAgent({ agentId, objective: "passive", startedAt: started.startedAt, lastActiveAt: started.startedAt, sessionIds: [sessionId], runtimeAvailable: true });
+      expect(await connection.dispatch({ jsonrpc: "2.0", id: "initialize", method: "initialize", params: { protocol: { version: "1.2.0" } } })).toHaveProperty("result");
+      const adapter = createDaemonTuiSessionFixture({ baseSession: { conversationId: sessionId }, client, sessionId, clientId: "tui-retry-client" });
+      const events: unknown[] = [];
+      const unsubscribe = adapter.subscribeToEvents(event => events.push(event));
+      const admission = adapter.enqueueIdleInputBatchOwned!([{ role: "user", content: "owned attachment" }], { workspaceView: "agent" });
+      const options = { clientMessageId: "tui-logical-submission", displayUserMessage: "inspect attachment" };
+      await expect(adapter.submit("inspect attachment", options)).rejects.toThrow("response socket closed");
+      expect(stub.thread.submit).toHaveBeenCalledOnce();
+      await expect(adapter.submit("inspect attachment", options)).resolves.toBeUndefined();
+      expect(stub.thread.submit).toHaveBeenCalledOnce();
+      expect(requests.map(request => request.clientMessageId)).toEqual([options.clientMessageId, options.clientMessageId]);
+      expect(requests[0]?.streamId).not.toBe(requests[1]?.streamId);
+      expect(requests[1]?.content).toEqual(requests[0]?.content);
+      expect(adapter.rollbackIdleInputAdmission!(admission.token)).toBe(false);
+      expect(adapter.activeTurn.unsafePeek()).toBeNull();
+      expect(events).toContainEqual(expect.objectContaining({ type: "message_submission_recovered", payload: expect.objectContaining({ clientMessageId: options.clientMessageId, code: 0 }) }));
+      await adapter.submit("a different prompt");
+      await adapter.submit("a different prompt");
+      expect(control.sendInput).toHaveBeenCalledTimes(2);
+      expect(new Set(requests.slice(2).map(request => request.clientMessageId)).size).toBe(2);
+      expect(requests.slice(2).map(request => request.content)).toEqual(["a different prompt", "a different prompt"]);
+      unsubscribe();
+    } finally {
+      await connection.close();
+      await dispatcher.close();
+      await runner.stopAgent(agentId, "test_cleanup");
+    }
+  });
+
+  it.each(["incomplete", 0, 1, 130] as const)("[managed-thread] preserves the persisted TUI retry outcome %s and an unrelated active turn", async outcome => {
+    const agentId = `session-tui-persisted-${outcome}`;
+    const sessionId = `${agentId}-client`;
+    const clientMessageId = "persisted-tui-message";
+    const event = (sequence: number, msg: JsonObject) => ({ type: "event_msg", payload: { id: `event-${sequence}`, eventId: `event-${sequence}`, seq: sequence, msg } });
+    const terminal = outcome === 0
+      ? { type: "turn_complete", payload: { turnId: "persisted-turn", lastAgentMessage: "saved answer" } }
+      : outcome === 130
+        ? { type: "turn_aborted", payload: { turnId: "persisted-turn", reason: "user_cancelled" } }
+        : { type: "turn_failed", payload: { turnId: "persisted-turn", code: "provider_error", message: "saved failure" } };
+    const { runner, control, stub } = makeTopLevelRunner({ conversationId: agentId, rolloutItems: [
+      event(1, { type: "user_message", payload: { message: "retry me", messageId: clientMessageId, acceptedAt: "2026-09-08T00:00:00.000Z" } }),
+      event(2, { type: "turn_started", payload: { turnId: "persisted-turn" } }),
+      ...(outcome === "incomplete" ? [] : [event(3, terminal)]),
+    ] });
+    const sessions = new AgenCDaemonSessionManager();
+    const manager = new AgenCDaemonAgentManager({ runner, sessionManager: sessions });
+    const dispatcher = new AgenCDaemonJsonRpcDispatcher({ agentManager: manager, sessionManager: sessions });
+    const connection = dispatcher.createConnection();
+    let emit: ((event: JsonObject) => void) | undefined;
+    const client = {
+      request: async (method: string, params: JsonObject) => {
+        const response = await connection.dispatch({ jsonrpc: "2.0", id: "retry", method, params });
+        expect(response).not.toHaveProperty("error");
+        return response.result;
+      },
+      subscribeToSessionEvents: (_sessionId: string, callback: (event: JsonObject) => void) => { emit = callback; return () => {}; },
+    } as unknown as AgenCDaemonTuiClient;
+    try {
+      const started = await runner.startAgent({ objective: "passive", initialContent: [], unattendedAllow: [], unattendedDeny: [] });
+      await sessions.restoreSession({ sessionId, agentId, status: "waiting", createdAt: started.startedAt });
+      await manager.restoreAgent({ agentId, objective: "passive", startedAt: started.startedAt, lastActiveAt: started.startedAt, sessionIds: [sessionId], runtimeAvailable: true });
+      await connection.dispatch({ jsonrpc: "2.0", id: "initialize", method: "initialize", params: { protocol: { version: "1.2.0" } } });
+      const adapter = createDaemonTuiSessionFixture({ baseSession: { conversationId: sessionId }, client, sessionId, clientId: "persisted-tui" });
+      const events: unknown[] = [];
+      const unsubscribe = adapter.subscribeToEvents(event => events.push(event));
+      emit!({ type: "turn_started", payload: { turnId: "unrelated-turn" } });
+      if (outcome === "incomplete") {
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          await expect(adapter.submit("retry me", { clientMessageId })).rejects.toThrow("already admitted, but its terminal outcome is unknown");
+        }
+        expect(events).not.toContainEqual(expect.objectContaining({ type: "message_submission_recovered" }));
+      } else {
+        await expect(adapter.submit("retry me", { clientMessageId })).resolves.toBeUndefined();
+        expect(events).toContainEqual(expect.objectContaining({ type: "message_submission_recovered", payload: expect.objectContaining({ clientMessageId, turnId: "persisted-turn", code: outcome }) }));
+      }
+      expect(adapter.activeTurn.unsafePeek()).toEqual({ turnId: "unrelated-turn" });
+      expect(control.sendInput).not.toHaveBeenCalled();
+      expect(stub.thread.submit).not.toHaveBeenCalled();
+      unsubscribe();
+    } finally {
+      await connection.close();
+      await dispatcher.close();
+      await runner.stopAgent(agentId, "test_cleanup");
+    }
+  });
 
   it("[managed-thread] joins a concurrent idempotent retry and rejects conflicting content", async () => {
     const { runner, control } = makeTopLevelRunner({

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -4109,6 +4109,96 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
     );
   });
 
+  test.each(["inspect selection", "/reviewer audit this", "$reviewer audit this"])("retries the restored %s submission with its original identity and inputs", async (input) => {
+    const { AgenCTuiApp } = await import("./App.js");
+    resetShellSurfaceProbe();
+    const getPromptForCommand = vi.fn(async () => [{ type: "text", text: `expanded prompt ${getPromptForCommand.mock.calls.length}` }]);
+    mockTuiCommandList.push({ name: "reviewer", type: "prompt", loadedFrom: "skills", progressMessage: "Loading reviewer", contentLength: 1, getPromptForCommand });
+    const subscribers = new Set<(event: unknown) => void>();
+    const session = {
+      ...createSession(),
+      enqueueIdleInputBatchOwned: vi.fn(() => ({ token: "retry-owned", firstSequence: 1, lastSequence: 1, count: 1 })),
+      rollbackIdleInputAdmission: vi.fn(() => true),
+      commitIdleInputAdmission: vi.fn(() => true),
+      submit: vi.fn(async (_message: string, options?: { readonly clientMessageId?: string }) => {
+        if (session.submit.mock.calls.length === 1) throw new Error("response dropped after admission");
+        for (const subscriber of subscribers) subscriber({ type: "turn_complete", clientMessageId: options?.clientMessageId, payload: { turnId: `turn-${session.submit.mock.calls.length}`, lastAgentMessage: "Done" } });
+      }),
+      subscribeToEvents: (subscriber: (event: unknown) => void) => {
+        subscribers.add(subscriber);
+        return () => { subscribers.delete(subscriber); };
+      },
+    } satisfies AgenCBridgeSession;
+    const helpers = { clearBuffer: vi.fn(), resetHistory: vi.fn(), setCursorOffset: vi.fn() };
+    const acknowledge = vi.fn();
+    const pastedContents = { 0: { id: 0, type: "text", content: "owned context" } };
+    await withRenderedApp(<AgenCTuiApp session={session} isInteractive={false} />, async () => {
+      const initial = providerProbe.promptProps.at(-1)!;
+      (initial.onInputChange as (value: string) => void)(input);
+      (initial.setPastedContents as (value: unknown) => void)(pastedContents);
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)?.input).toBe(input));
+      const submitCurrent = () => (providerProbe.promptProps.at(-1)!.onSubmit as (
+        value: string, helpers: typeof helpers, speculation: undefined, options: { readonly onWorkbenchAttachmentsAdmitted: () => void },
+      ) => Promise<void>)(input, helpers, undefined, { onWorkbenchAttachmentsAdmitted: acknowledge });
+      await submitCurrent();
+      await new Promise(resolve => setTimeout(resolve, 25));
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)).toMatchObject({ input, isLoading: false }));
+      const original = session.submit.mock.calls[0]!;
+      const originalInputs = session.enqueueIdleInputBatchOwned.mock.calls[0];
+      expect(original[1]?.clientMessageId).toEqual(expect.any(String));
+      await submitCurrent();
+      expect(session.submit.mock.calls[1]).toEqual(original);
+      expect(session.enqueueIdleInputBatchOwned.mock.calls[1]).toEqual(originalInputs);
+      expect(session.commitIdleInputAdmission).toHaveBeenCalledOnce();
+      expect(acknowledge).toHaveBeenCalledOnce();
+      expect(getPromptForCommand).toHaveBeenCalledTimes(input.startsWith("inspect") ? 0 : 1);
+      await new Promise(resolve => setTimeout(resolve, 25));
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)?.isLoading).toBe(false));
+      (providerProbe.promptProps.at(-1)!.onInputChange as (value: string) => void)(input);
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)?.input).toBe(input));
+      await submitCurrent();
+      expect(session.submit.mock.calls[2]?.[1]?.clientMessageId).not.toBe(original[1]?.clientMessageId);
+    });
+  });
+
+  test("keeps a newer submission busy and preserves its retry identity when an old response fails late", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    resetShellSurfaceProbe();
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    const subscribers = new Set<(event: unknown) => void>();
+    const session = {
+      ...createSession(),
+      submit: vi.fn((_message: string, _options?: { readonly clientMessageId?: string }) => session.submit.mock.calls.length === 1 ? first.promise : second.promise),
+      subscribeToEvents: (subscriber: (event: unknown) => void) => { subscribers.add(subscriber); return () => { subscribers.delete(subscriber); }; },
+    } satisfies AgenCBridgeSession;
+    const helpers = { clearBuffer: vi.fn(), resetHistory: vi.fn(), setCursorOffset: vi.fn() };
+    await withRenderedApp(<AgenCTuiApp session={session} isInteractive={false} />, async () => {
+      const send = (value: string) => (providerProbe.promptProps.at(-1)!.onSubmit as (value: string, helpers: typeof helpers) => Promise<void>)(value, helpers);
+      const firstAttempt = send("first prompt");
+      await vi.waitFor(() => expect(session.submit).toHaveBeenCalledOnce());
+      const firstId = session.submit.mock.calls[0]?.[1]?.clientMessageId;
+      for (const subscriber of subscribers) subscriber({ type: "turn_started", clientMessageId: firstId, payload: { turnId: "first-turn" } });
+      await new Promise(resolve => setTimeout(resolve, 25));
+      for (const subscriber of subscribers) subscriber({ type: "turn_complete", clientMessageId: firstId, payload: { turnId: "first-turn", lastAgentMessage: "Done" } });
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)?.isLoading).toBe(false));
+      const secondAttempt = send("second prompt");
+      await vi.waitFor(() => expect(session.submit).toHaveBeenCalledTimes(2));
+      await new Promise(resolve => setTimeout(resolve, 25));
+      first.reject(new Error("old response dropped"));
+      await firstAttempt;
+      await new Promise(resolve => setTimeout(resolve, 25));
+      expect(providerProbe.promptProps.at(-1)).toMatchObject({ input: "", isLoading: true });
+      second.reject(new Error("new response dropped"));
+      await secondAttempt;
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)).toMatchObject({ input: "second prompt", isLoading: false }));
+      session.submit.mockResolvedValueOnce();
+      await send("second prompt");
+      expect(session.submit.mock.calls[2]).toEqual(session.submit.mock.calls[1]);
+      expect(session.submit.mock.calls[1]?.[1]?.clientMessageId).not.toBe(firstId);
+    });
+  });
+
   test("rolls back an owned attachment when model submission rejects", async () => {
     const { AgenCTuiApp } = await import("./App.js");
     const { applyWorkbenchCommand } = await import("../workbench/state.js");
@@ -4747,6 +4837,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
               { workspaceView: "agent" },
             );
             expect(session.submit).toHaveBeenCalledWith("", {
+              clientMessageId: expect.any(String),
               displayUserMessage: input,
             });
           }
@@ -4950,6 +5041,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         }),
       );
       expect(session.submit).toHaveBeenCalledWith("", {
+        clientMessageId: expect.any(String),
         displayUserMessage: "$reviewer audit this",
       });
     } finally {
@@ -5096,6 +5188,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
 
         expect(session.submit).toHaveBeenCalledWith("inspect the project", {
+          clientMessageId: expect.any(String),
           displayUserMessage: "inspect the project",
         });
         expect(acknowledgeWorkbenchAttachments).not.toHaveBeenCalled();
@@ -5180,6 +5273,10 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           expect(rejectSubmit).toBeDefined();
         });
 
+        for (const subscriber of subscribers) {
+          subscriber({ type: "turn_started", clientMessageId: "unrelated-submission", payload: { turnId: "unrelated-turn" } });
+        }
+        expect(acknowledgeWorkbenchAttachments).not.toHaveBeenCalled();
         for (const subscriber of subscribers) {
           subscriber({
             type: "turn_started",
@@ -6353,6 +6450,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
 
         expect(submit).toHaveBeenCalledTimes(1);
         expect(submit).toHaveBeenCalledWith("ordinary message", {
+          clientMessageId: expect.any(String),
           displayUserMessage: "ordinary message",
         });
       },
@@ -6964,6 +7062,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           1,
           "Fix the selected value.",
           expect.objectContaining({
+            clientMessageId: expect.any(String),
             displayUserMessage: "Fix the selected value.",
             editorInteraction: expect.objectContaining({
               kind: "fix",
@@ -7023,6 +7122,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         await staleEditorRenderSubmit!("Inspect the repository.", helpers);
 
         expect(submit).toHaveBeenCalledWith("Inspect the repository.", {
+          clientMessageId: expect.any(String),
           displayUserMessage: "Inspect the repository.",
         });
       },
@@ -7103,6 +7203,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           { workspaceView: "agent" },
         );
         expect(session.submit).toHaveBeenCalledWith("inspect this attachment", {
+          clientMessageId: expect.any(String),
           displayUserMessage: "inspect this attachment",
         });
       },
@@ -7237,6 +7338,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
             expect(submit).toHaveBeenCalledWith(
               `queued from ${scenario.queuedView}`,
               {
+                clientMessageId: expect.any(String),
                 displayUserMessage: `queued from ${scenario.queuedView}`,
                 ...(scenario.queuedInteraction !== undefined
                   ? { editorInteraction: scenario.queuedInteraction }
@@ -7568,6 +7670,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
           expect(submit).toHaveBeenCalledWith(
             expect.any(String),
             expect.objectContaining({
+              clientMessageId: expect.any(String),
               displayUserMessage: "Explain the delayed selection.",
               editorInteraction: expect.objectContaining({
                 kind: "ask",

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -4122,7 +4122,9 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       commitIdleInputAdmission: vi.fn(() => true),
       submit: vi.fn(async (_message: string, options?: { readonly clientMessageId?: string }) => {
         if (session.submit.mock.calls.length === 1) throw new Error("response dropped after admission");
-        for (const subscriber of subscribers) subscriber({ type: "turn_complete", clientMessageId: options?.clientMessageId, payload: { turnId: `turn-${session.submit.mock.calls.length}`, lastAgentMessage: "Done" } });
+        for (const subscriber of subscribers) subscriber(session.submit.mock.calls.length === 2
+          ? { type: "message_submission_recovered", payload: { clientMessageId: options?.clientMessageId, code: 0, message: "Saved answer" } }
+          : { type: "turn_complete", clientMessageId: options?.clientMessageId, payload: { turnId: `turn-${session.submit.mock.calls.length}`, lastAgentMessage: "Done" } });
       }),
       subscribeToEvents: (subscriber: (event: unknown) => void) => {
         subscribers.add(subscriber);
@@ -4151,6 +4153,7 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       expect(session.enqueueIdleInputBatchOwned.mock.calls[1]).toEqual(originalInputs);
       expect(session.commitIdleInputAdmission).toHaveBeenCalledOnce();
       expect(acknowledge).toHaveBeenCalledOnce();
+      await vi.waitFor(() => expect(JSON.stringify(providerProbe.currentAppState?.notifications)).toContain("The previous submission completed. It was not run again. Saved answer"));
       expect(getPromptForCommand).toHaveBeenCalledTimes(input.startsWith("inspect") ? 0 : 1);
       await new Promise(resolve => setTimeout(resolve, 25));
       await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)?.isLoading).toBe(false));
@@ -4161,14 +4164,48 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
     });
   });
 
-  test("keeps a newer submission busy and preserves its retry identity when an old response fails late", async () => {
+  test.each(["edit", "session"])("does not reuse a failed submission after a composer %s change", async change => {
+    const { AgenCTuiApp } = await import("./App.js");
+    resetShellSurfaceProbe();
+    const session = {
+      ...createSession(),
+      submit: vi.fn(async (_message: string, _options?: { readonly clientMessageId?: string }) => {
+        if (session.submit.mock.calls.length === 1) throw new Error("response dropped");
+      }),
+    } satisfies AgenCBridgeSession;
+    const helpers = { clearBuffer: vi.fn(), resetHistory: vi.fn(), setCursorOffset: vi.fn() };
+    await withRenderedApp(<AgenCTuiApp session={session} isInteractive={false} />, async () => {
+      const send = () => (providerProbe.promptProps.at(-1)!.onSubmit as (value: string, helpers: typeof helpers) => Promise<void>)("same text", helpers);
+      await send();
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)).toMatchObject({ input: "same text", isLoading: false }));
+      if (change === "edit") {
+        const edit = providerProbe.promptProps.at(-1)!.onInputChange as (value: string) => void;
+        edit("edited");
+        edit("same text");
+      } else {
+        session.conversationId = "different-conversation";
+      }
+      await new Promise(resolve => setTimeout(resolve, 25));
+      await send();
+      expect(session.submit).toHaveBeenCalledTimes(2);
+      expect(session.submit.mock.calls[1]?.[1]?.clientMessageId).not.toBe(session.submit.mock.calls[0]?.[1]?.clientMessageId);
+    });
+  });
+
+  test.each(["second prompt", "/reviewer audit this", "$reviewer audit this"])("keeps the newer %s submission and its retry identity when an old response fails late", async secondInput => {
     const { AgenCTuiApp } = await import("./App.js");
     resetShellSurfaceProbe();
     const first = Promise.withResolvers<void>();
     const second = Promise.withResolvers<void>();
+    const loaded = Promise.withResolvers<Array<{ type: string; text: string }>>();
+    const getPromptForCommand = vi.fn(() => loaded.promise);
+    mockTuiCommandList.push({ name: "reviewer", type: "prompt", loadedFrom: "skills", progressMessage: "Loading reviewer", contentLength: 1, getPromptForCommand });
     const subscribers = new Set<(event: unknown) => void>();
     const session = {
       ...createSession(),
+      enqueueIdleInputBatchOwned: vi.fn(() => ({ token: "late-owned", firstSequence: 1, lastSequence: 1, count: 1 })),
+      rollbackIdleInputAdmission: vi.fn(() => true),
+      commitIdleInputAdmission: vi.fn(() => true),
       submit: vi.fn((_message: string, _options?: { readonly clientMessageId?: string }) => session.submit.mock.calls.length === 1 ? first.promise : second.promise),
       subscribeToEvents: (subscriber: (event: unknown) => void) => { subscribers.add(subscriber); return () => { subscribers.delete(subscriber); }; },
     } satisfies AgenCBridgeSession;
@@ -4182,18 +4219,24 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
       await new Promise(resolve => setTimeout(resolve, 25));
       for (const subscriber of subscribers) subscriber({ type: "turn_complete", clientMessageId: firstId, payload: { turnId: "first-turn", lastAgentMessage: "Done" } });
       await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)?.isLoading).toBe(false));
-      const secondAttempt = send("second prompt");
-      await vi.waitFor(() => expect(session.submit).toHaveBeenCalledTimes(2));
+      const secondAttempt = send(secondInput);
+      if (secondInput === "second prompt") {
+        await vi.waitFor(() => expect(session.submit).toHaveBeenCalledTimes(2));
+      } else {
+        await vi.waitFor(() => expect(getPromptForCommand).toHaveBeenCalledOnce());
+      }
       await new Promise(resolve => setTimeout(resolve, 25));
       first.reject(new Error("old response dropped"));
       await firstAttempt;
       await new Promise(resolve => setTimeout(resolve, 25));
       expect(providerProbe.promptProps.at(-1)).toMatchObject({ input: "", isLoading: true });
+      loaded.resolve([{ type: "text", text: "expanded delayed skill" }]);
+      await vi.waitFor(() => expect(session.submit).toHaveBeenCalledTimes(2));
       second.reject(new Error("new response dropped"));
       await secondAttempt;
-      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)).toMatchObject({ input: "second prompt", isLoading: false }));
+      await vi.waitFor(() => expect(providerProbe.promptProps.at(-1)).toMatchObject({ input: secondInput, isLoading: false }));
       session.submit.mockResolvedValueOnce();
-      await send("second prompt");
+      await send(secondInput);
       expect(session.submit.mock.calls[2]).toEqual(session.submit.mock.calls[1]);
       expect(session.submit.mock.calls[1]?.[1]?.clientMessageId).not.toBe(firstId);
     });

--- a/runtime/tests/tui/coverage-swarm/swarm-027-daemon-session.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-027-daemon-session.test.ts
@@ -261,6 +261,7 @@ describe("coverage swarm daemon session adapter", () => {
             { type: "text", text: "typed text" },
           ],
           streamId: expect.stringMatching(/^tui_1:/u),
+          clientMessageId: expect.any(String),
         },
       },
     ]);

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -3433,6 +3433,7 @@ describe("AgenC TUI daemon session adapter", () => {
             },
           ],
           metadata: { displayUserMessage: null },
+          clientMessageId: expect.any(String),
           streamId: expect.stringMatching(/^tui_1:/),
         },
       },


### PR DESCRIPTION
## Changes

- Keep a client message ID with each restored Agent or Editor draft. Retry the original model input, skill expansion, and owned attachment snapshot.
- Send the logical ID on every message.stream attempt and use a separate unique stream ID. Report completed duplicate outcomes without execution; reject incomplete duplicates with recovery instructions.
- Match daemon attachment acknowledgements to the submission. Keep late replies from restoring an older draft or clearing a newer request's busy state.
- Keep the acknowledgement watchdog honest about unknown outcomes. Document recovery and the separate initial-conversation creation boundary.

## Validation

- Nine regression cases fail against the original production files, including actual repeated execution through the TUI adapter, dispatcher, manager, and runner.
- Targeted local checks cover runtime and test-support TypeScript, restored plain/slash/skill drafts, owned inputs, persisted success/failure/cancellation/incomplete outcomes, unrelated active turns, and late settlements.
- Runtime and test-support TypeScript pass. The targeted suite passes all 500 tests across 8 files.
- Build and real-PTY startup pass. The full local runtime suite passes all 23,895 tests across 2,295 files.
- Two delayed skill-loading regressions fail before the review fix. The updated commit has a clean Bugbot review, security check, approval, and Sonar gate with zero new issues.
- Hosted test CI stays disabled. No workflow was enabled, dispatched, rerun, or retried.

Closes #2072.
