### PR TITLE
fix(runtime): enforce JSON line byte limits before dispatch

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -135,6 +135,12 @@ const client = await connect(); // socket + cookie under AGENC_HOME
 
 ## Protocol
 
+The daemon's local socket and the MCP stdio server accept at most 16 MiB of
+UTF-8 payload per JSON line, excluding the LF, CRLF, or CR delimiter. A line
+exactly at the limit is valid. An oversized line closes the input before JSON
+parsing or dispatch, including when the terminating newline arrives in the
+chunk that crosses the limit. Multiple bounded lines can share a chunk.
+
 - Envelope: **JSON-RPC 2.0** over newline-delimited messages.
 - Protocol version constant: **`1.9.0`**
   (`AGENC_DAEMON_PROTOCOL_VERSION` in `runtime/src/app-server/protocol/index.ts`).

--- a/runtime/src/app-server/transport/stdio.ts
+++ b/runtime/src/app-server/transport/stdio.ts
@@ -12,7 +12,6 @@
  */
 
 import { Buffer } from "node:buffer";
-import { createInterface, type Interface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
 import type { JsonObject, JsonValue } from "../protocol/index.js";
 import {
@@ -21,15 +20,8 @@ import {
   maxQueuedRequestsFromOptions,
 } from "../overload.js";
 import { isRecord } from "../../utils/record.js";
+import { BoundedJsonLineReader } from "../../utils/bounded-json-lines.js";
 
-/**
- * Default upper bound on a single unterminated input line, matching the
- * websocket transport's default max payload. A peer that streams bytes
- * without ever emitting a newline would otherwise grow the readline
- * internal buffer (and daemon memory) unbounded; the transport tracks the
- * bytes seen since the last newline and tears the connection down once this
- * cap is exceeded, treating it as a fatal framing violation.
- */
 export const AGENC_STDIO_DEFAULT_MAX_LINE_BYTES = 16 * 1024 * 1024;
 
 export interface AgenCStdioTransportOptions {
@@ -55,7 +47,7 @@ export class AgenCStdioTransport {
   // request that authenticates and establishes connection state.
   #initializeBarrier: Promise<void> = Promise.resolve();
   #queuedNormalMessages = 0;
-  #reader: Interface | null = null;
+  #reader: BoundedJsonLineReader | null = null;
 
   constructor(options: AgenCStdioTransportOptions) {
     this.#options = options;
@@ -66,50 +58,19 @@ export class AgenCStdioTransport {
       throw new Error("AgenC stdio transport is already started");
     }
 
-    const reader = createInterface({
+    const reader = new BoundedJsonLineReader({
       input: this.#options.input,
-      crlfDelay: Infinity,
-      terminal: false,
+      maxLineBytes:
+        this.#options.maxLineBytes ?? AGENC_STDIO_DEFAULT_MAX_LINE_BYTES,
+      onLine: (line) => this.#handleLine(line),
+      onError: (error) => this.#options.onError?.(error, ""),
+      onClose: () => {
+        this.#reader = null;
+        this.#options.onClose?.();
+      },
     });
     this.#reader = reader;
-
-    // Node's readline does not enforce a maximum line length, so a peer that
-    // streams bytes without ever emitting a newline would grow the internal
-    // line buffer (and daemon memory) unbounded. Track the number of bytes
-    // accumulated since the last newline and tear the connection down once it
-    // exceeds the cap, mirroring the websocket transport's maxPayload bound.
-    const maxLineBytes =
-      this.#options.maxLineBytes ?? AGENC_STDIO_DEFAULT_MAX_LINE_BYTES;
-    let unterminatedBytes = 0;
-    const onData = (chunk: Buffer | string): void => {
-      const data =
-        typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
-      const lastNewline = data.lastIndexOf(0x0a);
-      if (lastNewline === -1) {
-        unterminatedBytes += data.length;
-      } else {
-        unterminatedBytes = data.length - lastNewline - 1;
-      }
-      if (unterminatedBytes > maxLineBytes) {
-        this.#options.onError?.(
-          new RangeError(
-            `AgenC stdio transport line exceeded ${maxLineBytes} bytes without a newline`,
-          ),
-          "",
-        );
-        this.#options.input.destroy();
-      }
-    };
-    this.#options.input.on("data", onData);
-
-    reader.on("line", (line) => {
-      this.#handleLine(line);
-    });
-    reader.once("close", () => {
-      this.#options.input.off("data", onData);
-      this.#reader = null;
-      this.#options.onClose?.();
-    });
+    reader.start();
   }
 
   async send(message: JsonValue): Promise<void> {

--- a/runtime/src/mcp-server/stdio.ts
+++ b/runtime/src/mcp-server/stdio.ts
@@ -7,24 +7,14 @@
  *     and permission integration are later MS-* items.
  */
 
-import { Buffer } from "node:buffer";
-import { createInterface, type Interface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
+import { BoundedJsonLineReader } from "../utils/bounded-json-lines.js";
 import {
   McpServerFramework,
   ensureMcpOutgoingSerializable,
 } from "./framework.js";
 import type { McpOutgoingMessage } from "./types.js";
 
-/**
- * Default upper bound on a single unterminated input line, mirroring the
- * app-server stdio transport's `AGENC_STDIO_DEFAULT_MAX_LINE_BYTES`. Node's
- * readline imposes no maximum line length, so a peer that streams bytes
- * without ever emitting a newline would grow the readline internal buffer
- * (and MCP server memory) unbounded. The transport tracks the bytes seen
- * since the last newline and tears the connection down once this cap is
- * exceeded, treating it as a fatal framing violation.
- */
 export const AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES = 16 * 1024 * 1024;
 
 export interface McpStdioServerTransportOptions {
@@ -38,7 +28,7 @@ export interface McpStdioServerTransportOptions {
 
 export class McpStdioServerTransport {
   readonly #options: McpStdioServerTransportOptions;
-  #reader: Interface | null = null;
+  #reader: BoundedJsonLineReader | null = null;
   #startupQueue: Promise<void> = Promise.resolve();
   #writeQueue: Promise<void> = Promise.resolve();
   readonly #activeLines = new Set<Promise<void>>();
@@ -58,61 +48,20 @@ export class McpStdioServerTransport {
       throw new Error("AgenC MCP stdio transport is already closed");
     }
 
-    // A CLI peer can close its pipe while the runtime is still importing.
-    // Readable's `end` event is not replayed to listeners attached afterward,
-    // so constructing readline for an already-ended stream would leave the
-    // foreground server waiting forever. Treat the observable terminal state
-    // exactly like readline's close path before installing any listeners.
-    if (this.#options.input.readableEnded || this.#options.input.destroyed) {
-      this.#closed = true;
-      this.#notifyCloseAfterQueue();
-      return;
-    }
-
-    const reader = createInterface({
+    const reader = new BoundedJsonLineReader({
       input: this.#options.input,
-      crlfDelay: Infinity,
-      terminal: false,
+      maxLineBytes:
+        this.#options.maxLineBytes ?? AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES,
+      onLine: (line) => this.#enqueueLine(line),
+      onError: (error) => this.#options.onError?.(error),
+      onClose: () => {
+        this.#reader = null;
+        this.#closed = true;
+        this.#notifyCloseAfterQueue();
+      },
     });
     this.#reader = reader;
-
-    // Node's readline does not enforce a maximum line length, so a peer that
-    // streams bytes without ever emitting a newline would grow the internal
-    // line buffer (and MCP server memory) unbounded. Track the number of bytes
-    // accumulated since the last newline and tear the connection down once it
-    // exceeds the cap, mirroring the app-server stdio transport.
-    const maxLineBytes =
-      this.#options.maxLineBytes ?? AGENC_MCP_STDIO_DEFAULT_MAX_LINE_BYTES;
-    let unterminatedBytes = 0;
-    const onData = (chunk: Buffer | string): void => {
-      const data =
-        typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
-      const lastNewline = data.lastIndexOf(0x0a);
-      if (lastNewline === -1) {
-        unterminatedBytes += data.length;
-      } else {
-        unterminatedBytes = data.length - lastNewline - 1;
-      }
-      if (unterminatedBytes > maxLineBytes) {
-        this.#options.onError?.(
-          new RangeError(
-            `AgenC MCP stdio transport line exceeded ${maxLineBytes} bytes without a newline`,
-          ),
-        );
-        this.#options.input.destroy();
-      }
-    };
-    this.#options.input.on("data", onData);
-
-    reader.on("line", (line) => {
-      this.#enqueueLine(line);
-    });
-    reader.once("close", () => {
-      this.#options.input.off("data", onData);
-      this.#reader = null;
-      this.#closed = true;
-      this.#notifyCloseAfterQueue();
-    });
+    reader.start();
   }
 
   async send(message: McpOutgoingMessage): Promise<void> {

--- a/runtime/src/utils/bounded-json-lines.ts
+++ b/runtime/src/utils/bounded-json-lines.ts
@@ -1,0 +1,156 @@
+import { Buffer } from "node:buffer";
+import type { Readable } from "node:stream";
+
+interface BoundedJsonLineReaderOptions {
+  readonly input: Readable;
+  readonly maxLineBytes: number;
+  readonly onLine: (line: string) => void;
+  readonly onError: (error: Error) => void;
+  readonly onClose: () => void;
+}
+
+function findLineEnd(data: Buffer | string, start: number): number {
+  let end = start;
+  while (end < data.length) {
+    const character = data[end];
+    if (character === 0x0a || character === 0x0d || character === "\n" || character === "\r") {
+      return end;
+    }
+    end += 1;
+  }
+  return end;
+}
+
+export class BoundedJsonLineReader {
+  readonly #options: BoundedJsonLineReaderOptions;
+  #buffer: Buffer = Buffer.alloc(0);
+  #length = 0;
+  #skipLineFeed = false;
+  #started = false;
+  #closed = false;
+
+  constructor(options: BoundedJsonLineReaderOptions) {
+    if (!Number.isSafeInteger(options.maxLineBytes) || options.maxLineBytes < 0) {
+      throw new RangeError(
+        "JSON line byte limit must be a nonnegative safe integer",
+      );
+    }
+    this.#options = options;
+  }
+
+  start(): void {
+    if (this.#started || this.#closed) {
+      throw new Error("JSON line reader is already started or closed");
+    }
+    this.#started = true;
+    const { input } = this.#options;
+    if (input.readableEnded || input.destroyed) {
+      this.close();
+      return;
+    }
+    input.once("end", this.#onEnd);
+    input.once("close", this.#onClose);
+    input.on("error", this.#onError);
+    input.on("data", this.#onData);
+  }
+
+  close(): void {
+    if (this.#stop()) this.#options.onClose();
+  }
+
+  #stop(): boolean {
+    if (this.#closed) return false;
+    this.#closed = true;
+    const { input } = this.#options;
+    input.off("data", this.#onData);
+    input.off("end", this.#onEnd);
+    input.off("close", this.#onClose);
+    input.off("error", this.#onError);
+    input.pause();
+    this.#buffer = Buffer.alloc(0);
+    this.#length = 0;
+    return true;
+  }
+
+  readonly #onClose = (): void => {
+    this.close();
+  };
+
+  readonly #onEnd = (): void => {
+    try {
+      if (this.#length > 0) this.#emitLine();
+    } finally {
+      this.close();
+    }
+  };
+
+  readonly #onError = (error: Error): void => {
+    if (!this.#stop()) return;
+    try {
+      this.#options.onError(error);
+    } finally {
+      try {
+        this.#options.onClose();
+      } finally {
+        this.#options.input.destroy();
+      }
+    }
+  };
+
+  readonly #onData = (chunk: Buffer | string): void => {
+    const data = chunk;
+    const lineFeed = typeof data === "string" ? "\n" : 0x0a;
+    const carriageReturn = typeof data === "string" ? "\r" : 0x0d;
+    let offset = 0;
+    while (offset < data.length && !this.#closed) {
+      if (this.#skipLineFeed) {
+        this.#skipLineFeed = false;
+        if (data[offset] === lineFeed) {
+          offset += 1;
+          continue;
+        }
+      }
+      const end = findLineEnd(data, offset);
+      if (!this.#append(data, offset, end)) return;
+      if (end < data.length) {
+        this.#skipLineFeed = data[end] === carriageReturn;
+        this.#emitLine();
+      }
+      offset = end + 1;
+    }
+  };
+
+  #append(data: Buffer | string, start: number, end: number): boolean {
+    const byteLength = typeof data === "string"
+      ? Buffer.byteLength(data.slice(start, end), "utf8")
+      : end - start;
+    const required = this.#length + byteLength;
+    const { maxLineBytes } = this.#options;
+    if (required > maxLineBytes) {
+      this.#onError(new RangeError(`JSON line exceeded ${maxLineBytes} bytes`));
+      return false;
+    }
+    if (required > this.#buffer.length) {
+      const capacity = Math.min(
+        maxLineBytes,
+        Math.max(1024, required, this.#buffer.length * 2),
+      );
+      const expanded = Buffer.allocUnsafe(capacity);
+      this.#buffer.copy(expanded, 0, 0, this.#length);
+      this.#buffer = expanded;
+    }
+    if (typeof data === "string") {
+      this.#buffer.write(data.slice(start, end), this.#length, byteLength, "utf8");
+    } else {
+      data.copy(this.#buffer, this.#length, start, end);
+    }
+    this.#length = required;
+    return true;
+  }
+
+  #emitLine(): void {
+    const line = this.#buffer.toString("utf8", 0, this.#length);
+    this.#length = 0;
+    this.#options.onLine(line);
+  }
+}

--- a/runtime/tests/app-server/stdio-line-limits.contract.test.ts
+++ b/runtime/tests/app-server/stdio-line-limits.contract.test.ts
@@ -1,0 +1,163 @@
+import { PassThrough } from "node:stream";
+import { setImmediate as nextTick } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { AgenCStdioTransport } from "../../src/app-server/transport/stdio.js";
+import { McpStdioServerTransport } from "../../src/mcp-server/stdio.js";
+import { McpServerFramework } from "../../src/mcp-server/framework.js";
+
+const MAX_LINE_BYTES = 64;
+const REQUEST = { jsonrpc: "2.0", id: 1, method: "initialize" };
+
+function paddedFrame(bytes: number, request = REQUEST): Buffer {
+  const json = JSON.stringify(request);
+  return Buffer.from(json + " ".repeat(bytes - Buffer.byteLength(json)), "utf8");
+}
+
+function createTransport(kind: "app-server" | "mcp", onError?: () => void) {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  output.resume();
+  const received: unknown[] = [];
+  const errors: Error[] = [];
+  const closed = vi.fn();
+  const server = new McpServerFramework();
+  const processed = vi.spyOn(server, "handleRawMessageAsync");
+  const options = {
+    input,
+    output,
+    maxLineBytes: MAX_LINE_BYTES,
+    onError(error: Error) {
+      errors.push(error);
+      onError?.();
+    },
+    onClose: closed,
+  };
+  const transport = kind === "app-server"
+    ? new AgenCStdioTransport({
+        ...options,
+        onMessage(message) { received.push(message); },
+      })
+    : new McpStdioServerTransport({ ...options, server });
+  transport.start();
+  return {
+    input,
+    transport,
+    errors,
+    closed,
+    messages: () => kind === "app-server"
+      ? received
+      : processed.mock.calls.map(([line]) => JSON.parse(line)),
+  };
+}
+
+describe.each(["app-server", "mcp"] as const)("%s bounded input lines", (kind) => {
+  it.each(["same chunk", "crossing chunk", "later newline", "following frames"])(
+    "rejects maxLineBytes + 1 before dispatch with %s",
+    async (boundary) => {
+      const fixture = createTransport(kind);
+      const frame = paddedFrame(MAX_LINE_BYTES + 1);
+      try {
+        if (boundary === "crossing chunk") {
+          fixture.input.write(frame.subarray(0, MAX_LINE_BYTES - 1));
+          fixture.input.write(Buffer.concat([frame.subarray(MAX_LINE_BYTES - 1), Buffer.from("\n")]));
+        } else if (boundary === "later newline") {
+          fixture.input.write(frame);
+          if (!fixture.input.destroyed) fixture.input.write("\n");
+        } else {
+          const suffix = boundary === "following frames" ? `\n${JSON.stringify(REQUEST)}\n` : "\n";
+          fixture.input.write(Buffer.concat([frame, Buffer.from(suffix)]));
+        }
+        await nextTick();
+        expect(fixture.messages()).toEqual([]);
+        expect(fixture.input.destroyed).toBe(true);
+        expect(fixture.errors).toHaveLength(1);
+        expect(fixture.errors[0]).toBeInstanceOf(RangeError);
+        expect(fixture.closed).toHaveBeenCalledTimes(1);
+        expect(fixture.input.listenerCount("data")).toBe(0);
+      } finally {
+        await fixture.transport.close();
+        fixture.input.destroy();
+      }
+    },
+  );
+
+  it.each(["\n", "\r\n", "\r"])("accepts exactly the byte cap before %j", async (delimiter) => {
+    const fixture = createTransport(kind);
+    try {
+      fixture.input.write(Buffer.concat([paddedFrame(MAX_LINE_BYTES), Buffer.from(delimiter)]));
+      await nextTick();
+      expect(fixture.messages()).toEqual([REQUEST]);
+      expect(fixture.errors).toEqual([]);
+      expect(fixture.input.destroyed).toBe(false);
+    } finally {
+      await fixture.transport.close();
+      fixture.input.destroy();
+    }
+  });
+
+  it("accepts many bounded frames in one chunk", async () => {
+    const fixture = createTransport(kind);
+    try {
+      fixture.input.write(`${paddedFrame(MAX_LINE_BYTES).toString()}\n`.repeat(20));
+      await fixture.transport.close();
+      expect(fixture.messages()).toEqual(Array.from({ length: 20 }, () => REQUEST));
+      expect(fixture.errors).toEqual([]);
+    } finally {
+      await fixture.transport.close();
+      fixture.input.destroy();
+    }
+  });
+
+  it("preserves split UTF-8 and split CRLF at the exact cap", async () => {
+    const fixture = createTransport(kind);
+    const request = { ...REQUEST, id: "é🛰" };
+    const json = JSON.stringify(request);
+    const frame = Buffer.from(json + " ".repeat(MAX_LINE_BYTES - Buffer.byteLength(json)) + "\r\n");
+    try {
+      for (const byte of frame) fixture.input.write(Buffer.from([byte]));
+      await nextTick();
+      expect(fixture.messages()).toEqual([request]);
+      expect(fixture.errors).toEqual([]);
+    } finally {
+      await fixture.transport.close();
+      fixture.input.destroy();
+    }
+  });
+
+  it("flushes a bounded final line on EOF and closes once", async () => {
+    const fixture = createTransport(kind);
+    fixture.input.end(paddedFrame(MAX_LINE_BYTES));
+    await nextTick();
+    await fixture.transport.close();
+    expect(fixture.messages()).toEqual([REQUEST]);
+    expect(fixture.errors).toEqual([]);
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards a partial line on manual close", async () => {
+    const fixture = createTransport(kind);
+    fixture.input.write(paddedFrame(MAX_LINE_BYTES));
+    await fixture.transport.close();
+    fixture.input.end("\n");
+    await nextTick();
+    expect(fixture.messages()).toEqual([]);
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+    fixture.input.destroy();
+  });
+
+  it("still destroys input and closes once when overflow reporting throws", async () => {
+    const failure = new Error("error callback failed");
+    const fixture = createTransport(kind, () => { throw failure; });
+    try {
+      expect(() => fixture.input.write(paddedFrame(MAX_LINE_BYTES + 1))).toThrow(failure);
+      await nextTick();
+      expect(fixture.messages()).toEqual([]);
+      expect(fixture.input.destroyed).toBe(true);
+      expect(fixture.closed).toHaveBeenCalledTimes(1);
+      expect(fixture.input.listenerCount("data")).toBe(0);
+    } finally {
+      await fixture.transport.close();
+      fixture.input.destroy();
+    }
+  });
+});

--- a/runtime/tests/app-server/stdio-transport.contract.test.ts
+++ b/runtime/tests/app-server/stdio-transport.contract.test.ts
@@ -563,7 +563,7 @@ describe("AgenC stdio transport", () => {
     expect(input.destroyed).toBe(true);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBeInstanceOf(RangeError);
-    expect(errors[0]?.message).toMatch(/64 bytes without a newline/);
+    expect(errors[0]?.message).toMatch(/line exceeded 64 bytes/);
   });
 
   it("does not trip the cap when newlines keep lines bounded", async () => {

--- a/runtime/tests/app-server/unix-socket-transport.contract.test.ts
+++ b/runtime/tests/app-server/unix-socket-transport.contract.test.ts
@@ -14,8 +14,10 @@ import {
   isAgenCWindowsNamedPipePath,
   prepareAgenCUnixSocketPath,
   resolveAgenCPrivateUnixSocketOwnerUid,
+  type AgenCUnixSocketMessageContext,
 } from "./transport/unix-socket.js";
 import { compileAndLoadAgenCNativePeerCredentialBinding } from "./transport/peer-credentials.js";
+import { AGENC_STDIO_DEFAULT_MAX_LINE_BYTES } from "./transport/stdio.js";
 
 const itUnix = process.platform === "win32" ? it.skip : it;
 const itLinuxNative =
@@ -232,6 +234,45 @@ describe("AgenC Unix socket transport", () => {
     await server.close();
     expect(existsSync(socketPath)).toBe(false);
     await rm(dir, { recursive: true, force: true });
+  });
+
+  itUnix.each([0, 1])("enforces the default JSON line cap over a real socket with %s extra bytes", async (extraBytes) => {
+    const dir = await tempDir();
+    const socketPath = join(dir, "daemon.sock");
+    const onMessage = vi.fn(async (_message: unknown, connection: AgenCUnixSocketMessageContext) => {
+      await connection.send({ jsonrpc: JSON_RPC_VERSION, id: 1, result: {} });
+    });
+    const errors: Error[] = [];
+    const server = new AgenCUnixSocketServer({
+      socketPath,
+      onMessage,
+      onError: (error) => { errors.push(error); },
+    });
+    let client: Socket | undefined;
+    try {
+      await server.listen();
+      client = createConnection(socketPath);
+      client.on("error", () => {});
+      await once(client, "connect");
+      const frame = Buffer.alloc(AGENC_STDIO_DEFAULT_MAX_LINE_BYTES + extraBytes + 1, 0x20);
+      Buffer.from('{"jsonrpc":"2.0","id":1,"method":"agent.list"}').copy(frame);
+      frame[frame.length - 1] = 0x0a;
+      client.write(frame);
+      if (extraBytes === 0) {
+        expect(JSON.parse(await nextChunk(client))).toEqual({ jsonrpc: JSON_RPC_VERSION, id: 1, result: {} });
+        expect(onMessage).toHaveBeenCalledTimes(1);
+        expect(errors).toEqual([]);
+      } else {
+        await vi.waitFor(() => expect(client?.destroyed).toBe(true));
+        expect(onMessage).not.toHaveBeenCalled();
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toBeInstanceOf(RangeError);
+      }
+    } finally {
+      client?.destroy();
+      await server.close();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   itLinuxNative(

--- a/runtime/tests/mcp-server/stdio.test.ts
+++ b/runtime/tests/mcp-server/stdio.test.ts
@@ -279,7 +279,7 @@ describe("MCP stdio server transport", () => {
     expect(input.destroyed).toBe(true);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBeInstanceOf(RangeError);
-    expect(errors[0]?.message).toMatch(/64 bytes without a newline/);
+    expect(errors[0]?.message).toMatch(/line exceeded 64 bytes/);
 
     await transport.close();
   });

--- a/runtime/tests/utils/bounded-json-lines.test.ts
+++ b/runtime/tests/utils/bounded-json-lines.test.ts
@@ -1,0 +1,182 @@
+import { once } from "node:events";
+import { createInterface } from "node:readline";
+import { PassThrough } from "node:stream";
+import { setImmediate as nextTick } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { BoundedJsonLineReader } from "../../src/utils/bounded-json-lines.js";
+
+function createReader(maxLineBytes: number) {
+  const input = new PassThrough();
+  const lines: string[] = [];
+  const errors: Error[] = [];
+  const closed = vi.fn();
+  const reader = new BoundedJsonLineReader({
+    input,
+    maxLineBytes,
+    onLine: (line) => { lines.push(line); },
+    onError: (error) => { errors.push(error); },
+    onClose: closed,
+  });
+  reader.start();
+  return { input, lines, errors, closed, reader };
+}
+
+describe("BoundedJsonLineReader", () => {
+  it.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects the invalid cap %s before listening",
+    (maxLineBytes) => {
+      const input = new PassThrough();
+      expect(() => new BoundedJsonLineReader({
+        input,
+        maxLineBytes,
+        onLine: vi.fn(),
+        onError: vi.fn(),
+        onClose: vi.fn(),
+      })).toThrow(RangeError);
+      expect(input.listenerCount("data")).toBe(0);
+      input.destroy();
+    },
+  );
+
+  it("accepts empty lines with a zero-byte cap and rejects any payload", () => {
+    const fixture = createReader(0);
+    fixture.input.write("\r\n\n\r");
+    expect(fixture.lines).toEqual(["", "", ""]);
+    fixture.input.write("x\n");
+    expect(fixture.errors).toHaveLength(1);
+    expect(fixture.input.destroyed).toBe(true);
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([1, 2, 3, 4, 9, 64])("matches readline delimiters and UTF-8 with %s-byte chunks", async (chunkBytes) => {
+    const fixture = createReader(64);
+    const referenceInput = new PassThrough();
+    const referenceReader = createInterface({ input: referenceInput, crlfDelay: Infinity, terminal: false });
+    const expected: string[] = [];
+    referenceReader.on("line", (line) => { expected.push(line); });
+    const referenceClosed = once(referenceReader, "close");
+    const data = Buffer.from("α🛰\r\n\nsecond\rthird\r\r\nfourth\nfinalé", "utf8");
+    for (let offset = 0; offset < data.length; offset += chunkBytes) {
+      const chunk = data.subarray(offset, offset + chunkBytes);
+      fixture.input.write(chunk);
+      referenceInput.write(chunk);
+    }
+    fixture.input.end();
+    referenceInput.end();
+    await referenceClosed;
+    await nextTick();
+    expect(fixture.lines).toEqual(expected);
+    expect(fixture.errors).toEqual([]);
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds an accumulated line across many tiny chunks", () => {
+    const fixture = createReader(4096);
+    for (let count = 0; count < 4096; count += 1) fixture.input.write("x");
+    fixture.input.write("\n");
+    expect(fixture.lines).toEqual(["x".repeat(4096)]);
+    expect(fixture.errors).toEqual([]);
+    for (let count = 0; count < 4096; count += 1) fixture.input.write("y");
+    fixture.input.write("z\n");
+    expect(fixture.lines).toHaveLength(1);
+    expect(fixture.errors).toHaveLength(1);
+    expect(fixture.input.destroyed).toBe(true);
+  });
+
+  it("copies a trailing fragment rather than retaining the input chunk", () => {
+    const fixture = createReader(64);
+    const chunk = Buffer.from("short\ntail");
+    fixture.input.write(chunk);
+    chunk.fill(0);
+    fixture.input.write("\n");
+    expect(fixture.lines).toEqual(["short", "tail"]);
+    fixture.reader.close();
+    fixture.input.destroy();
+  });
+
+  it("measures decoded string chunks in UTF-8 bytes", () => {
+    const fixture = createReader(4);
+    fixture.input.setEncoding("utf8");
+    fixture.input.write("é");
+    fixture.input.write("é\r");
+    fixture.input.write("\n🛰\n");
+    expect(fixture.lines).toEqual(["éé", "🛰"]);
+    expect(fixture.errors).toEqual([]);
+    fixture.input.write("ééx\n");
+    expect(fixture.lines).toHaveLength(2);
+    expect(fixture.errors).toHaveLength(1);
+    expect(fixture.input.destroyed).toBe(true);
+  });
+
+  it("stops before later frames when the line callback closes the reader", () => {
+    const input = new PassThrough();
+    const lines: string[] = [];
+    const closed = vi.fn();
+    const reader = new BoundedJsonLineReader({
+      input,
+      maxLineBytes: 64,
+      onLine(line) {
+        lines.push(line);
+        reader.close();
+      },
+      onError: vi.fn(),
+      onClose: closed,
+    });
+    reader.start();
+    input.write("first\nsecond\npartial");
+    expect(lines).toEqual(["first"]);
+    expect(closed).toHaveBeenCalledTimes(1);
+    expect(() => reader.start()).toThrow(/already started or closed/);
+    input.destroy();
+  });
+
+  it("rejects restarting a live reader", () => {
+    const fixture = createReader(64);
+    expect(() => fixture.reader.start()).toThrow(/already started or closed/);
+    fixture.reader.close();
+    fixture.reader.close();
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+    fixture.input.destroy();
+  });
+
+  it("discards partial input and removes listeners on stream error", async () => {
+    const fixture = createReader(64);
+    const error = new Error("input failed");
+    fixture.input.write("partial");
+    fixture.input.destroy(error);
+    await nextTick();
+    expect(fixture.lines).toEqual([]);
+    expect(fixture.errors).toEqual([error]);
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+    for (const event of ["data", "end", "close", "error"]) {
+      expect(fixture.input.listenerCount(event)).toBe(0);
+    }
+  });
+
+  it("discards partial input on abrupt stream close", async () => {
+    const fixture = createReader(64);
+    fixture.input.write("partial");
+    fixture.input.destroy();
+    await nextTick();
+    expect(fixture.lines).toEqual([]);
+    expect(fixture.errors).toEqual([]);
+    expect(fixture.closed).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroys input even when the overflow close callback throws", () => {
+    const input = new PassThrough();
+    const error = new Error("close failed");
+    const reader = new BoundedJsonLineReader({
+      input,
+      maxLineBytes: 1,
+      onLine: vi.fn(),
+      onError: vi.fn(),
+      onClose: () => { throw error; },
+    });
+    reader.start();
+    expect(() => input.write("xx\n")).toThrow(error);
+    expect(input.destroyed).toBe(true);
+    expect(input.listenerCount("data")).toBe(0);
+    reader.close();
+  });
+});


### PR DESCRIPTION
## Changes

- Share one bounded input reader between daemon and MCP stdio transports. Count every line's UTF-8 bytes before decoding or dispatch, including the segment before a terminating newline.
- Keep exact-limit lines, CRLF, bare CR, split UTF-8, multiple lines per chunk, and the final bounded line at EOF. Preserve transport dispatch ordering and pending-work drain.
- Close oversized input once, discard the unfinished frame, remove listeners, and destroy input even when an error callback throws.
- Keep buffered bytes within the configured cap and copy trailing fragments without retaining the original chunk. Document the 16 MiB payload limit.

## Validation

- Fourteen regression cases fail on the original transports. The real Unix-socket case also rejects the original implementation at 16 MiB plus one byte, while its exact-limit control passes.
- Both TypeScript gates pass. The focused suite passes 103 tests across 7 files, and the Linux native checks pass 92 tests across 5 files.
- Build and real-PTY startup pass. The full local runtime suite passes all 23,941 tests across 2,297 files.
- Hosted test CI stays disabled. No workflow was enabled, dispatched, rerun, or retried.

Closes #2073.
