### PR TITLE
fix(sdk): fail pending requests on malformed daemon frames

### DIFF
--- a/packages/agenc-sdk/README.md
+++ b/packages/agenc-sdk/README.md
@@ -21,6 +21,13 @@ Errors: `AgencRpcError`, `AgencMalformedResponseError`,
 `AgencCapabilityUnavailableError` (1.2 fail-closed), `AgencRunReplayGapError`,
 `AgencRunReplayProtocolError`. Full table: [`docs/sdk.md`](../../docs/sdk.md).
 
+The socket transport rejects every pending request and closes the connection
+when a completed line contains malformed JSON or an invalid JSON-RPC response
+or notification envelope. `onClose` receives the protocol error once, and later
+requests fail immediately. Partial lines may span chunks within the 16 MiB
+buffer limit. Valid `message.send` and `message.stream` calls remain unbounded
+by the control-request timeout.
+
 Prompt events on protocol 1.2 also include `message_committed`,
 `history_reset`, `elicitation_request`, `gap`, and `session_event`. The sample
 loop below only prints `text`.

--- a/packages/agenc-sdk/src/socket.ts
+++ b/packages/agenc-sdk/src/socket.ts
@@ -27,6 +27,7 @@ import { basename, dirname, isAbsolute, join, win32 } from "node:path";
 import { createConnection, type Socket } from "node:net";
 import { spawn as nodeSpawn } from "node:child_process";
 import {
+  AGENC_SDK_JSON_RPC_VERSION,
   isJsonObject,
   type AgencDaemonMethod,
   type AgencDaemonRequest,
@@ -162,6 +163,34 @@ export interface AgencSocketTransportOptions {
   readonly onClose?: (error: Error | null) => void;
 }
 
+function isDaemonSocketResponse(message: JsonObject): boolean {
+  const hasResult = Object.hasOwn(message, "result");
+  const hasError = Object.hasOwn(message, "error");
+  if (hasResult === hasError) return false;
+  const hasRequestId = typeof message.id === "string" ||
+    (typeof message.id === "number" && Number.isFinite(message.id));
+  if (hasResult) return hasRequestId;
+  return (hasRequestId || message.id === null) &&
+    isJsonObject(message.error) &&
+    typeof message.error.code === "number" &&
+    Number.isInteger(message.error.code) &&
+    typeof message.error.message === "string";
+}
+
+function isDaemonSocketFrame(message: unknown): message is JsonObject {
+  if (!isJsonObject(message) || message.jsonrpc !== AGENC_SDK_JSON_RPC_VERSION) {
+    return false;
+  }
+  if (Object.hasOwn(message, "method")) {
+    return typeof message.method === "string" && message.method.length > 0 &&
+      !Object.hasOwn(message, "id") &&
+      !Object.hasOwn(message, "result") &&
+      !Object.hasOwn(message, "error") &&
+      (message.params === undefined || isJsonObject(message.params) || Array.isArray(message.params));
+  }
+  return isDaemonSocketResponse(message);
+}
+
 /**
  * Persistent newline-JSON socket transport. Single connection, no reconnect
  * layer — embedders that need reconnect can recreate the client via
@@ -172,6 +201,7 @@ export class AgencSocketTransport implements AgencTransport {
   readonly #pending = new Map<RequestId, PendingRequest>();
   readonly #requestTimeoutMs: number;
   readonly #onNotification: ((message: JsonObject) => void) | undefined;
+  readonly #onClose: ((error: Error | null) => void) | undefined;
   #buffer = "";
   #closed = false;
 
@@ -180,24 +210,17 @@ export class AgencSocketTransport implements AgencTransport {
     this.#requestTimeoutMs =
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.#onNotification = options.onNotification;
+    this.#onClose = options.onClose;
 
     socket.setEncoding("utf8");
     socket.on("data", (chunk: string) => {
-      this.#handleData(chunk, options.onClose);
+      this.#handleData(chunk);
     });
     socket.once("error", (error) => {
-      this.#failAll(error);
-      if (!this.#closed) {
-        this.#closed = true;
-        options.onClose?.(error);
-      }
+      this.#terminate(error);
     });
     socket.once("close", () => {
-      this.#failAll(new Error("AgenC daemon connection closed"));
-      if (!this.#closed) {
-        this.#closed = true;
-        options.onClose?.(null);
-      }
+      this.#terminate(null);
     });
   }
 
@@ -255,30 +278,30 @@ export class AgencSocketTransport implements AgencTransport {
   }
 
   async close(): Promise<void> {
-    if (this.#closed) return;
-    this.#closed = true;
-    this.#socket.destroy();
-    this.#failAll(new Error("AgenC daemon connection closed"));
+    this.#terminate(new Error("AgenC daemon connection closed"), false);
   }
 
-  #handleData(
-    chunk: string,
-    onClose: ((error: Error | null) => void) | undefined,
-  ): void {
+  #terminate(error: Error | null, notifyClose = true): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#buffer = "";
+    this.#failAll(error ?? new Error("AgenC daemon connection closed"));
+    this.#socket.destroy();
+    if (notifyClose) this.#onClose?.(error);
+  }
+
+  #handleData(chunk: string): void {
+    if (this.#closed) return;
     this.#buffer += chunk;
     if (Buffer.byteLength(this.#buffer, "utf8") > MAX_CLIENT_BUFFER_BYTES) {
       const overflow = new Error(
         `AgenC daemon connection exceeded ${MAX_CLIENT_BUFFER_BYTES} bytes without a complete message`,
       );
-      this.#buffer = "";
-      this.#failAll(overflow);
-      this.#closed = true;
-      this.#socket.destroy(overflow);
-      onClose?.(overflow);
+      this.#terminate(overflow);
       return;
     }
     let newlineIndex = this.#buffer.indexOf("\n");
-    while (newlineIndex >= 0) {
+    while (newlineIndex >= 0 && !this.#closed) {
       const line = this.#buffer.slice(0, newlineIndex).trim();
       this.#buffer = this.#buffer.slice(newlineIndex + 1);
       if (line.length > 0) this.#handleLine(line);
@@ -291,9 +314,13 @@ export class AgencSocketTransport implements AgencTransport {
     try {
       message = JSON.parse(line);
     } catch {
-      return; // Ignore malformed frames; requests still time out safely.
+      this.#terminate(new Error("AgenC daemon sent a malformed JSON frame"));
+      return;
     }
-    if (!isJsonObject(message)) return;
+    if (!isDaemonSocketFrame(message)) {
+      this.#terminate(new Error("AgenC daemon sent an invalid JSON-RPC frame"));
+      return;
+    }
     if (typeof message.id === "string" || typeof message.id === "number") {
       const waiter = this.#pending.get(message.id);
       if (waiter === undefined) return;

--- a/runtime/tests/sdk-package/socket-protocol-errors.contract.test.ts
+++ b/runtime/tests/sdk-package/socket-protocol-errors.contract.test.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setImmediate as nextTick } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgencSocketTransport } from "../../../packages/agenc-sdk/src/socket";
+
+function startPendingRequests(transport: AgencSocketTransport) {
+  const requests = [
+    transport.request({
+      jsonrpc: "2.0", id: "send", method: "message.send",
+      params: { sessionId: "session", content: "test" },
+    }),
+    transport.request({
+      jsonrpc: "2.0", id: "stream", method: "message.stream",
+      params: { sessionId: "session", content: "test", streamId: "stream" },
+    }),
+    transport.request({ jsonrpc: "2.0", id: "control", method: "health.ping", params: {} }),
+  ];
+  const outcomes: Array<{ status: string; value: unknown }> = [];
+  const settled = Promise.all(requests.map((request) => request.then(
+    (value) => { outcomes.push({ status: "resolved", value }); },
+    (error: unknown) => { outcomes.push({ status: "rejected", value: error }); },
+  )));
+  return { outcomes, settled };
+}
+
+describe("SDK socket protocol failures", () => {
+  let transport: AgencSocketTransport;
+  let server: Server;
+  let peer: Socket;
+  let root: string;
+  let onClose: ReturnType<typeof vi.fn>;
+  let onNotification: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "agenc-sdk-protocol-"));
+    const socketPath = process.platform === "win32"
+      ? `\\\\.\\pipe\\agenc-sdk-protocol-${randomUUID()}`
+      : join(root, "daemon.sock");
+    server = createServer();
+    const accepted = once(server, "connection");
+    server.listen(socketPath);
+    await once(server, "listening");
+    onClose = vi.fn();
+    onNotification = vi.fn();
+    transport = await AgencSocketTransport.connect({
+      socketPath, requestTimeoutMs: 5000, onClose, onNotification,
+    });
+    [peer] = await accepted;
+    peer.on("error", () => {});
+    peer.resume();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await transport?.close();
+    peer?.destroy();
+    if (server !== undefined) await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (root !== undefined) await rm(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    "{malformed",
+    "null",
+    "[]",
+    "42",
+    '"text"',
+    "true",
+    "{}",
+    '{"jsonrpc":"2.0","id":"send"}',
+    '{"jsonrpc":"2.0","id":"send","result":{},"error":{"code":-32000,"message":"bad"}}',
+    '{"jsonrpc":"2.0","id":"send","error":"bad"}',
+    '{"jsonrpc":"2.0","id":"send","error":{"code":"bad","message":"bad"}}',
+    '{"jsonrpc":"2.0","id":"send","error":{"code":-32000}}',
+    '{"jsonrpc":"2.0","id":null,"result":{}}',
+    '{"jsonrpc":"2.0","id":true,"result":{}}',
+    '{"jsonrpc":"2.0","method":123}',
+    '{"jsonrpc":"2.0","method":"event.test","params":null}',
+    '{"jsonrpc":"2.0","id":"send","method":"event.test","params":{}}',
+    '{"jsonrpc":"1.0","id":"send","result":{}}',
+  ])("rejects every pending request after the invalid complete frame %s", async (line) => {
+    const pending = startPendingRequests(transport);
+    peer.write(`${line}\n`);
+    await vi.waitFor(() => expect(pending.outcomes).toHaveLength(3));
+    await pending.settled;
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+    const failure = pending.outcomes[0]?.value;
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toMatch(/daemon.*(?:malformed|invalid).*frame/i);
+    expect(pending.outcomes.every((outcome) => outcome.value === failure)).toBe(true);
+    expect(onClose).toHaveBeenCalledExactlyOnceWith(failure);
+    await vi.waitFor(() => expect(peer.destroyed).toBe(true));
+    await expect(transport.request({ jsonrpc: "2.0", id: "later", method: "health.ping" }))
+      .rejects.toThrow(/connection is closed/);
+    await transport.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch trailing responses or notifications after a malformed frame", async () => {
+    const pending = startPendingRequests(transport);
+    peer.write('{invalid\n{"jsonrpc":"2.0","id":"send","result":{}}\n{"jsonrpc":"2.0","method":"event.test","params":{}}\n');
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await pending.settled;
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+    expect(onNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not copy sensitive frame contents into the protocol error", async () => {
+    const pending = startPendingRequests(transport);
+    peer.write('{"private":"sensitive-session-value",broken}\n');
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await pending.settled;
+    const failure = pending.outcomes[0]?.value as Error;
+    expect(failure.message).not.toContain("sensitive-session-value");
+    expect(failure.cause).toBeUndefined();
+  });
+
+  it("rejects reentrant requests before invoking the close callback", async () => {
+    const pending = startPendingRequests(transport);
+    let reentrant: Promise<unknown> | undefined;
+    onClose.mockImplementation(() => {
+      reentrant = transport.request({ jsonrpc: "2.0", id: "reentrant", method: "message.send", params: { sessionId: "session", content: "test" } })
+        .catch((error: unknown) => error);
+    });
+    peer.write("{invalid\n");
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await pending.settled;
+    expect(await reentrant).toEqual(expect.objectContaining({ message: "AgenC daemon connection is closed" }));
+  });
+
+  it("accepts fragmented UTF-8 responses and valid unknown notifications and IDs", async () => {
+    const pending = startPendingRequests(transport);
+    const notification = { jsonrpc: "2.0", method: "event.future", params: { text: "é🛰" } };
+    peer.write(`${JSON.stringify(notification)}\n`);
+    peer.write('{"jsonrpc":"2.0","id":"unknown","result":{}}\n');
+    peer.write('{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"unmatched"}}\n');
+    const frame = Buffer.from('{"jsonrpc":"2.0","id":"send","result":{"text":"é🛰"}}\n');
+    const split = frame.indexOf(Buffer.from("🛰")) + 1;
+    peer.write(frame.subarray(0, split));
+    await nextTick();
+    expect(pending.outcomes).toEqual([]);
+    peer.write(frame.subarray(split));
+    peer.write('{"jsonrpc":"2.0","id":"stream","result":{}}\n');
+    peer.write('{"jsonrpc":"2.0","id":"control","error":{"code":-32000,"message":"expected"}}\n');
+    await pending.settled;
+    expect(pending.outcomes.every((outcome) => outcome.status === "resolved")).toBe(true);
+    expect(pending.outcomes[0]?.value).toMatchObject({ result: { text: "é🛰" } });
+    expect(onNotification).toHaveBeenCalledExactlyOnceWith(notification);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps incomplete frames pending until a newline completes them", async () => {
+    const pending = startPendingRequests(transport);
+    peer.write("{malformed");
+    await nextTick();
+    expect(pending.outcomes).toEqual([]);
+    expect(onClose).not.toHaveBeenCalled();
+    peer.write("\n");
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await pending.settled;
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+  });
+
+  it("still rejects incomplete-buffer overflow and closes once", async () => {
+    const pending = startPendingRequests(transport);
+    peer.write("x".repeat(16 * 1024 * 1024 + 1));
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await pending.settled;
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+    expect((pending.outcomes[0]?.value as Error).message).toContain("exceeded 16777216 bytes");
+    await vi.waitFor(() => expect(peer.destroyed).toBe(true));
+    await transport.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps deliberate local closure silent and settles pending work", async () => {
+    const pending = startPendingRequests(transport);
+    await transport.close();
+    await pending.settled;
+    await nextTick();
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("settles every request and notifies once when the peer closes", async () => {
+    const pending = startPendingRequests(transport);
+    peer.end();
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledExactlyOnceWith(null));
+    await pending.settled;
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+    expect((pending.outcomes[0]?.value as Error).message).toBe("AgenC daemon connection closed");
+    await transport.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the pending control timer on protocol failure", async () => {
+    vi.useFakeTimers();
+    const closed = new Promise<void>((resolve) => { onClose.mockImplementation(resolve); });
+    const pending = startPendingRequests(transport);
+    expect(vi.getTimerCount()).toBe(1);
+    peer.write("{invalid\n");
+    await closed;
+    await pending.settled;
+    expect(vi.getTimerCount()).toBe(0);
+    expect(pending.outcomes.every((outcome) => outcome.status === "rejected")).toBe(true);
+  });
+
+  it.each(["message.send", "message.stream"] as const)("keeps valid %s requests alive beyond the control timeout", async (method) => {
+    vi.useFakeTimers();
+    let settled = false;
+    const result = transport.request({
+      jsonrpc: "2.0", id: "long-turn", method,
+      params: { sessionId: "session", content: "test", streamId: "stream" },
+    });
+    void result.then(() => { settled = true; }, () => { settled = true; });
+    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+    expect(settled).toBe(false);
+    vi.useRealTimers();
+    peer.write('{"jsonrpc":"2.0","id":"long-turn","result":{}}\n');
+    await expect(result).resolves.toMatchObject({ id: "long-turn", result: {} });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Changes

- Treat malformed complete JSON and invalid response or notification envelopes as fatal SDK socket protocol errors.
- Use one terminal transition to mark the transport closed, clear buffered input and pending timers, reject every request, destroy the socket, and notify onClose once. Keep intentional local closure silent.
- Stop processing later frames in the same chunk after a protocol failure. Keep raw frame contents out of errors.
- Preserve unbounded full-turn RPCs, bounded control timeouts, valid fragmented UTF-8 replies, unknown response IDs, and future notification methods. Keep the SDK independent of runtime imports.

## Validation

- Twenty-two regression cases fail against the original SDK transport; three control cases pass.
- Real socket tests cover pending message.send, message.stream, and health.ping together, reentrant requests, timer cleanup, EOF, overflow, and six-hour valid full turns.
- SDK build and typecheck pass, along with runtime and test-support TypeScript. All 49 focused tests and 92 Linux native checks pass.
- Build and real-PTY startup pass. The full local runtime suite passes all 23,970 tests across 2,298 files.
- Exact-head Bugbot review has no findings, the PR is approved, security review succeeds, and Sonar reports an OK gate with zero new issues or duplication.
- Hosted test CI stays disabled. No workflow was enabled, dispatched, rerun, or retried.

Closes #2074.
