### PR TITLE
fix(daemon): clean routes for terminated agent sessions

### DIFF
--- a/docs/reference/daemon.md
+++ b/docs/reference/daemon.md
@@ -845,6 +845,19 @@ snapshot clears the stamp. A daemon-restart recovery that restored the
 record without an attached runtime (`recovered === true` and no
 runtime) is immediately reapable because it cannot resume on its own.
 
+### Agent session termination
+
+Agent stop, runner termination, daemon shutdown, stale-agent reaping, and
+failed-create rollback terminate sessions through the client multiplexer.
+Termination removes session routes, client attachments, and buffered
+capability events. Late events cannot recreate a closed session's route
+or reach status observers.
+
+If a termination hook throws after the session closes, routing is still
+removed and the error is reported. Agent shutdown attempts every owned
+session before reporting termination errors. A failed termination that
+leaves the session live keeps its routing so termination can be retried.
+
 ### Admission step identity on keep-alive turns
 
 Daemon sessions set `admissionRequired`. Each streamed sample is admitted

--- a/runtime/src/app-server/agent-lifecycle.ts
+++ b/runtime/src/app-server/agent-lifecycle.ts
@@ -278,6 +278,7 @@ export interface AgenCDaemonAgentManagerOptions {
   readonly now?: () => string;
   readonly runner?: AgenCBackgroundAgentRunner;
   readonly sessionManager?: AgenCDaemonSessionManager;
+  readonly terminateSession?: AgenCDaemonSessionManager["terminateSession"];
   readonly threadStore?: ThreadStore;
   readonly threadStoreForAgentLogs?: (
     route: AgenCDaemonAgentLogThreadStoreRoute,
@@ -480,6 +481,7 @@ export class AgenCDaemonAgentManager {
   readonly #now: () => string;
   readonly #runner: AgenCBackgroundAgentRunner | undefined;
   readonly #sessionManager: AgenCDaemonSessionManager | undefined;
+  readonly #terminateSession: AgenCDaemonSessionManager["terminateSession"] | undefined;
   readonly #threadStore: ThreadStore | undefined;
   readonly #threadStoreForAgentLogs:
     | ((route: AgenCDaemonAgentLogThreadStoreRoute) => ThreadStore | undefined)
@@ -552,7 +554,11 @@ export class AgenCDaemonAgentManager {
     this.#agencHome = getAgencHomeDir(options.agencHome);
     this.#now = options.now ?? (() => new Date().toISOString());
     this.#runner = options.runner;
-    this.#sessionManager = options.sessionManager;
+    const sessionManager = options.sessionManager;
+    this.#sessionManager = sessionManager;
+    this.#terminateSession = options.terminateSession ?? (sessionManager === undefined
+      ? undefined
+      : (params) => sessionManager.terminateSession(params));
     this.#threadStore = options.threadStore;
     this.#threadStoreForAgentLogs = options.threadStoreForAgentLogs;
     this.#readAgentToolOutputs = options.readAgentToolOutputs;
@@ -1185,10 +1191,10 @@ export class AgenCDaemonAgentManager {
         }
         if (
           createdLifecycleSessionId !== undefined &&
-          this.#sessionManager !== undefined
+          this.#terminateSession !== undefined
         ) {
           try {
-            await this.#sessionManager.terminateSession({
+            await this.#terminateSession({
               sessionId: createdLifecycleSessionId,
               reason: "agent.create rollback after lifecycle failure",
             });
@@ -4182,10 +4188,17 @@ export class AgenCDaemonAgentManager {
     sessionIds: readonly string[],
     reason: string,
   ): Promise<void> {
-    if (this.#sessionManager === undefined) return;
+    if (this.#terminateSession === undefined) return;
+    const errors: unknown[] = [];
     for (const sessionId of sessionIds) {
-      await this.#sessionManager.terminateSession({ sessionId, reason });
+      try {
+        await this.#terminateSession({ sessionId, reason });
+      } catch (error) {
+        errors.push(error);
+      }
     }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, "Agent session termination failed");
   }
 
   async #markAgentStopFailed(

--- a/runtime/src/app-server/client-multiplexer.ts
+++ b/runtime/src/app-server/client-multiplexer.ts
@@ -512,28 +512,17 @@ export class AgenCDaemonClientMultiplexer {
     params: SessionTerminateParams,
   ): Promise<SessionTerminateResult> {
     return this.#state.with(async (state) => {
-      const route = state.sessions.get(params.sessionId);
-      const affectedClientIds =
-        route === undefined ? [] : [...route.clientAttachmentIds.keys()];
-      const terminated = await this.#sessionManager.terminateSession(params);
-
-      if (route !== undefined) {
-        state.sessions.delete(params.sessionId);
-        for (const clientId of affectedClientIds) {
-          state.clients.get(clientId)?.sessionIds.delete(params.sessionId);
+      try {
+        const terminated = await this.#sessionManager.terminateSession(params);
+        removeSessionRouting(state, params.sessionId);
+        return terminated;
+      } catch (error) {
+        const stillLive = await this.#isSessionLive(params.sessionId).catch(() => true);
+        if (!stillLive) {
+          removeSessionRouting(state, params.sessionId);
         }
+        throw error;
       }
-      for (const [capability, buffered] of state.capabilityBuffers) {
-        const retained = buffered.filter(
-          (item) => item.sessionId !== params.sessionId,
-        );
-        if (retained.length === 0) {
-          state.capabilityBuffers.delete(capability);
-        } else if (retained.length !== buffered.length) {
-          state.capabilityBuffers.set(capability, retained);
-        }
-      }
-      return terminated;
     });
   }
 
@@ -602,6 +591,13 @@ export class AgenCDaemonClientMultiplexer {
     const { deliveries, hadLiveTargets, bufferedWithoutTarget } =
       await this.#state.with(async (state) => {
       const existingRoute = state.sessions.get(sessionId);
+      if (existingRoute === undefined && !(await this.#isSessionLive(sessionId))) {
+        return {
+          deliveries: [] as EnqueuedDelivery[],
+          hadLiveTargets: false,
+          bufferedWithoutTarget: false,
+        };
+      }
 
       const attachedClients =
         existingRoute === undefined
@@ -637,20 +633,6 @@ export class AgenCDaemonClientMultiplexer {
         // hint for an older or detached client would only pollute transcript
         // replay (and can never recover state by itself).
         if (event.method === "event.mcp_status_changed") {
-          return {
-            deliveries: [] as EnqueuedDelivery[],
-            hadLiveTargets: false,
-            bufferedWithoutTarget: false,
-          };
-        }
-        // No attached client to deliver to. Only buffer (creating a route on
-        // demand) when the session is still live: a terminated/unknown session
-        // can never gain a client to drain the buffer, and its buffer-only
-        // route is never reaped (deleteRouteIfEmpty keeps any route with
-        // buffered events), so creating one here would leak `state.sessions`
-        // unbounded on a long-lived daemon. Dropping late events for a dead
-        // session is correct — nobody can ever replay them.
-        if (existingRoute === undefined && !(await this.#isSessionLive(sessionId))) {
           return {
             deliveries: [] as EnqueuedDelivery[],
             hadLiveTargets: false,
@@ -753,6 +735,10 @@ export class AgenCDaemonClientMultiplexer {
     const rejectedDeliveries: AgenCSessionBroadcastFailure[] = [];
     const { deliveries, bufferAfterDelivery } = await this.#state.with(
       async (state) => {
+        if (!(await this.#isSessionLive(sessionId))) return {
+          deliveries: [] as EnqueuedDelivery[],
+          bufferAfterDelivery: false,
+        };
         // Map iteration order is registration order. Retaining the last match
         // makes selection deterministic and prefers the newest live phone.
         let target: MutableClient | undefined;
@@ -762,10 +748,6 @@ export class AgenCDaemonClientMultiplexer {
           }
         }
         if (target === undefined) {
-          if (!(await this.#isSessionLive(sessionId))) return {
-            deliveries: [] as EnqueuedDelivery[],
-            bufferAfterDelivery: false,
-          };
           const buffered = state.capabilityBuffers.get(capability) ?? [];
           bufferCapabilityEvent(
             buffered,
@@ -840,6 +822,21 @@ export class AgenCDaemonClientMultiplexer {
   async #isSessionLive(sessionId: string): Promise<boolean> {
     const summary = await this.#sessionManager.getSession(sessionId);
     return summary !== null && summary.status !== "closed";
+  }
+}
+
+function removeSessionRouting(state: MultiplexerState, sessionId: string): void {
+  state.sessions.delete(sessionId);
+  for (const client of state.clients.values()) {
+    client.sessionIds.delete(sessionId);
+  }
+  for (const [capability, buffered] of state.capabilityBuffers) {
+    const retained = buffered.filter((item) => item.sessionId !== sessionId);
+    if (retained.length === 0) {
+      state.capabilityBuffers.delete(capability);
+    } else if (retained.length !== buffered.length) {
+      state.capabilityBuffers.set(capability, retained);
+    }
   }
 }
 

--- a/runtime/src/app-server/daemon-cli.ts
+++ b/runtime/src/app-server/daemon-cli.ts
@@ -3511,6 +3511,7 @@ async function runAgenCDaemonForegroundLocked(
       agencHome: authStartup.daemonHome,
       runner,
       sessionManager,
+      terminateSession: (params) => clientMultiplexer.terminateSession(params),
       threadStore,
       // DAE-02: prefer client/workspace env over frozen OS cwd when params omit cwd.
       defaultCwd: () => resolveDaemonDefaultCwd(host.env),

--- a/runtime/tests/app-server/agent-session-route-cleanup.contract.test.ts
+++ b/runtime/tests/app-server/agent-session-route-cleanup.contract.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
+import { AgenCDaemonAgentManager } from "../../src/app-server/agent-lifecycle.js";
+import { AgenCDaemonClientMultiplexer } from "../../src/app-server/client-multiplexer.js";
+import { AgenCDaemonSessionManager } from "../../src/app-server/session-lifecycle.js";
+import { resolveAgentRuntimeOptions } from "../../src/session/runtime-options.js";
+import {
+  AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY,
+  type JsonObject,
+  type SessionTerminateParams,
+} from "../../src/app-server/protocol/index.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-agent-session-routes-");
+const OWNED_SESSIONS = ["session_first", "session_second"] as const;
+const CAPABILITY = "test.action";
+const NOW = "2026-09-09T00:00:00.000Z";
+type StopPath = "agent.stop" | "runner terminal" | "stopAll" | "stale reaping";
+const STOP_PATHS: readonly StopPath[] = ["agent.stop", "runner terminal", "stopAll", "stale reaping"];
+
+afterEach(async () => { await workspaces.cleanup(); });
+
+async function createComposition(path: StopPath, onSessionTerminated?: (sessionId: string) => void) {
+  const cwd = await workspaces.create();
+  const sessions = new AgenCDaemonSessionManager({ now: () => NOW, onSessionTerminated });
+  const multiplexer = new AgenCDaemonClientMultiplexer({
+    sessionManager: sessions,
+    maxBufferedEventsPerSession: 3,
+  });
+  const agents = new AgenCDaemonAgentManager({
+    agencHome: cwd,
+    sessionManager: sessions,
+    terminateSession: (params: SessionTerminateParams) => multiplexer.terminateSession(params),
+    now: () => NOW,
+    runner: {
+      startAgent: async () => ({ agentId: "agent_owner", startedAt: NOW, status: "running" }),
+      stopAgent: async () => {},
+      getAgentSnapshot: async () => path === "stale reaping" ? null : { status: "idle", lastActiveAt: NOW },
+    },
+    broadcastSessionEvent: async (sessionId, event) => { await multiplexer.broadcastSessionEvent(sessionId, event); },
+  });
+  for (const sessionId of [...OWNED_SESSIONS, "session_unrelated"]) {
+    await sessions.restoreSession({ sessionId, agentId: "agent_owner", status: "idle", createdAt: NOW, cwd });
+  }
+  await agents.restoreAgent({
+    agentId: "agent_owner", objective: "test owned sessions", status: "idle",
+    sessionIds: [...OWNED_SESSIONS], runtimeAvailable: path !== "stale reaping", cwd,
+  });
+  const sends = [vi.fn(), vi.fn()];
+  for (const [index, send] of sends.entries()) {
+    const clientId = `client_${index}`;
+    await multiplexer.registerClient({ clientId, send });
+    for (const sessionId of OWNED_SESSIONS) await multiplexer.attachClientToSession(sessionId, clientId);
+  }
+  for (const sessionId of [...OWNED_SESSIONS, "session_unrelated"]) {
+    await multiplexer.broadcastCapabilityEvent(sessionId, CAPABILITY, { sessionId, type: "buffered-action" });
+  }
+  const stop = async () => {
+    if (path === "agent.stop") return agents.stopAgent({ agentId: "agent_owner" });
+    if (path === "runner terminal") return agents.handleRunnerTerminated("agent_owner", { status: "stopped", lastActiveAt: NOW });
+    if (path === "stopAll") return agents.stopAll();
+    return agents.reapStaleAgents();
+  };
+  return { agents, sessions, multiplexer, sends, stop };
+}
+
+async function expectRoutesCleaned(fixture: Awaited<ReturnType<typeof createComposition>>) {
+  const { sessions, multiplexer, sends } = fixture;
+  for (const sessionId of OWNED_SESSIONS) {
+    expect(await sessions.getSession(sessionId)).toMatchObject({ status: "closed" });
+    expect(await multiplexer.attachedClientIds(sessionId)).toEqual([]);
+  }
+  const deliveryCounts = sends.map((send) => send.mock.calls.length);
+  for (const sessionId of OWNED_SESSIONS) {
+    for (let sequence = 0; sequence < 5; sequence += 1) {
+      const event = { type: "late-event", sequence };
+      expect(await multiplexer.broadcastSessionEvent(sessionId, event)).toEqual({ sessionId, deliveredClientIds: [], failed: [] });
+      expect(await multiplexer.broadcastCapabilityEvent(sessionId, CAPABILITY, event)).toEqual({ sessionId, deliveredClientIds: [], failed: [] });
+    }
+  }
+  expect(sends.map((send) => send.mock.calls.length)).toEqual(deliveryCounts);
+
+  const capabilitySend = vi.fn();
+  await multiplexer.registerClient({
+    clientId: "capability_client", send: capabilitySend, capabilities: { [CAPABILITY]: true },
+  });
+  expect(capabilitySend).toHaveBeenCalledExactlyOnceWith({ sessionId: "session_unrelated", type: "buffered-action" });
+  const statusSend = vi.fn();
+  await multiplexer.registerClient({
+    clientId: "status_client", send: statusSend,
+    capabilities: { [AGENC_PORTAL_MOBILE_STATUS_PUSH_CAPABILITY]: true },
+  });
+  expect(statusSend).not.toHaveBeenCalled();
+  for (const sessionId of OWNED_SESSIONS) {
+    const event: JsonObject = { method: "event.agent_status", params: { sessionId, status: "stopped" } };
+    expect(await multiplexer.broadcastSessionEvent(sessionId, event)).toEqual({ sessionId, deliveredClientIds: [], failed: [] });
+    expect(await multiplexer.broadcastCapabilityEvent(sessionId, CAPABILITY, event)).toEqual({ sessionId, deliveredClientIds: [], failed: [] });
+    expect(await multiplexer.terminateSession({ sessionId })).toMatchObject({ terminated: false, status: "closed" });
+  }
+  expect(statusSend).not.toHaveBeenCalled();
+  expect(capabilitySend).toHaveBeenCalledTimes(1);
+  const detach = vi.spyOn(sessions, "detachSession");
+  expect(await multiplexer.disconnectClient("client_0")).toEqual([]);
+  expect(await multiplexer.disconnectClient("client_1")).toEqual([]);
+  expect(detach).not.toHaveBeenCalled();
+  await multiplexer.broadcastCapabilityEvent("session_unrelated", CAPABILITY, { type: "still-live" });
+  expect(capabilitySend).toHaveBeenLastCalledWith({ type: "still-live" });
+}
+
+describe("agent-owned session route cleanup", () => {
+  it("cleans the session route when agent creation rolls back after attachment", async () => {
+    const cwd = await workspaces.create();
+    const sessions = new AgenCDaemonSessionManager({ createSessionId: () => "session_rollback" });
+    const multiplexer = new AgenCDaemonClientMultiplexer({ sessionManager: sessions });
+    const send = vi.fn();
+    await multiplexer.registerClient({ clientId: "client_rollback", send });
+    const agents = new AgenCDaemonAgentManager({
+      agencHome: cwd,
+      sessionManager: sessions,
+      terminateSession: (params) => multiplexer.terminateSession(params),
+      runner: {
+        startAgent: async () => ({ agentId: "agent_rollback", startedAt: NOW, status: "running" }),
+        stopAgent: async () => {},
+        attachAgentSessionEvents: async (_agentId, binding) => {
+          await multiplexer.attachClientToSession(binding.sessionId, "client_rollback");
+          await multiplexer.broadcastCapabilityEvent(binding.sessionId, CAPABILITY, { type: "pending" });
+          throw new Error("runner event attachment failed");
+        },
+      },
+    });
+    await expect(agents.createAgent({
+      cwd, objective: "rollback route cleanup", runtimeOptions: resolveAgentRuntimeOptions({}),
+    })).rejects.toThrow("runner event attachment failed");
+    expect(await sessions.getSession("session_rollback")).toMatchObject({ status: "closed" });
+    expect(await multiplexer.attachedClientIds("session_rollback")).toEqual([]);
+    expect(await multiplexer.disconnectClient("client_rollback")).toEqual([]);
+    await multiplexer.registerClient({ clientId: "late_client", send, capabilities: { [CAPABILITY]: true } });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it.each(STOP_PATHS)("cleans routes, reverse attachments and capability buffers through %s", async (path) => {
+    const fixture = await createComposition(path);
+    await fixture.stop();
+    await expectRoutesCleaned(fixture);
+    await expect(fixture.agents.stopAgent({ agentId: "agent_owner" })).resolves.toMatchObject({ stopped: false });
+  });
+
+  it.each(STOP_PATHS)("cleans all owned sessions when a post-termination hook fails through %s", async (path) => {
+    const failure = new Error("session termination hook failed");
+    const fixture = await createComposition(path, (sessionId) => {
+      if (sessionId === OWNED_SESSIONS[0]) throw failure;
+    });
+    await expect(fixture.stop()).rejects.toThrow();
+    await expectRoutesCleaned(fixture);
+  });
+
+  it("preserves live routing when termination fails before closing and permits a retry", async () => {
+    const fixture = await createComposition("agent.stop");
+    const failure = new Error("termination admission failed");
+    const terminate = vi.spyOn(fixture.sessions, "terminateSession").mockRejectedValueOnce(failure);
+    await expect(fixture.multiplexer.terminateSession({ sessionId: OWNED_SESSIONS[0] })).rejects.toBe(failure);
+    expect(await fixture.multiplexer.attachedClientIds(OWNED_SESSIONS[0])).toEqual(["client_0", "client_1"]);
+    expect(await fixture.sessions.getSession(OWNED_SESSIONS[0])).toMatchObject({ status: "idle" });
+    terminate.mockRestore();
+    await fixture.stop();
+    await expectRoutesCleaned(fixture);
+  });
+
+  it("preserves the termination error and live route if the liveness lookup also fails", async () => {
+    const fixture = await createComposition("agent.stop");
+    const failure = new Error("termination admission failed");
+    const terminate = vi.spyOn(fixture.sessions, "terminateSession").mockRejectedValueOnce(failure);
+    const lookup = vi.spyOn(fixture.sessions, "getSession").mockRejectedValueOnce(new Error("lookup failed"));
+    await expect(fixture.multiplexer.terminateSession({ sessionId: OWNED_SESSIONS[0] })).rejects.toBe(failure);
+    expect(await fixture.multiplexer.attachedClientIds(OWNED_SESSIONS[0])).toEqual(["client_0", "client_1"]);
+    terminate.mockRestore();
+    lookup.mockRestore();
+    await fixture.stop();
+    await expectRoutesCleaned(fixture);
+  });
+
+  it("reports every post-close hook error after cleaning every owned session", async () => {
+    const fixture = await createComposition("agent.stop", (sessionId) => {
+      throw new Error(`hook failed for ${sessionId}`);
+    });
+    await expect(fixture.stop()).rejects.toMatchObject({
+      errors: OWNED_SESSIONS.map((sessionId) => new Error(`hook failed for ${sessionId}`)),
+    });
+    await expectRoutesCleaned(fixture);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2076.

- Route agent-owned session termination and failed-create rollback through the existing multiplexer coordinator.
- Remove session routes, reverse client attachments, and capability buffers even when a post-close termination hook fails. Preserve live routing and the original error if termination has not closed the session.
- Attempt every owned session before reporting termination errors. Reject late events for closed sessions before selecting mobile status observers or capability recipients.
- Add real agent-manager, session-manager, and multiplexer composition tests for all four stop paths, rollback, repeated termination, late delivery, disconnect, and failure ordering.

## Validation

- Original-source reproduction failed all 9 initial regression cases with retained client attachments.
- Runtime and test-support typechecks passed in the local Docker boundary; 327 targeted tests passed across 9 files.
- Final route-cleanup tests passed all 12 cases, including create rollback. A dedicated TypeScript check for the new test passed.
- Staged GitNexus analysis reports 5 files, 15 indexed symbols, 0 affected processes, low risk. The diff is limited to lifecycle coordination, multiplexer cleanup, daemon wiring, tests, and documentation; shifted-line symbol matches do not add unrelated changes.
- Local build, PTY startup, full suite, and Linux native checks are pending on this commit. Results will be recorded before merge.
- Hosted CI remains disabled. No Actions workflows are dispatched, enabled, or retried.

Independent review is required before manual merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle coordination and multiplexer routing around session teardown; incorrect cleanup could leak routes or drop events, but behavior is heavily contract-tested.
> 
> **Overview**
> Routes **agent-owned session termination** (stop, runner exit, shutdown, stale reaping, and failed-create rollback) through the **client multiplexer** instead of calling the session manager alone, so closing a session also clears multiplexer routes, client attachments, and capability buffers.
> 
> **`terminateSession`** on the multiplexer now removes routing only after a successful close, or on failure when the session is already not live; if termination fails while the session stays open, routing is kept so retry still works. **`#terminateAgentSessions`** in the agent manager tries every owned session and surfaces one or aggregated errors instead of stopping at the first failure.
> 
> **Broadcast paths** check session liveness earlier so late events for closed sessions cannot recreate buffer-only routes or deliver to mobile status observers. Daemon startup wires **`terminateSession`** into **`AgenCDaemonAgentManager`**. Docs add an **Agent session termination** section; new composition contract tests cover all stop paths, rollback, hook failures, and retry semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285ddd900bbeb3722edc3cbabea5b69351796ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->