### PR TITLE
fix(eval): validate batch resume reports and retain outcomes

### DIFF
--- a/docs/eval/real-agent-baseline-runbook.md
+++ b/docs/eval/real-agent-baseline-runbook.md
@@ -65,8 +65,9 @@ Default output dirs: `eval-executor-output` (agent) and
   `OPENAI_COMPATIBLE_API_KEY`). For a static key, omit `--key-command` and
   export the env var instead. The key travels executor env → `docker exec -e`
   → agent process; it is never on an argv and patches are scanned for it.
-- Resume after an interruption by re-running the same command: tasks with an
-  existing `agent-run-report.json` are skipped.
+- Resume after an interruption by re-running the same command. Tasks with a
+  complete, validated `agent-run-report.json` for the same source-lock task
+  are skipped. Their prior outcomes still count in the new batch summary.
 - `--tasks` accepts a comma-separated list once; repeating the flag is a
   usage error. Integer options (`--seed-slot`, timeouts) are decimal digits
   only; `0x10`, `1e3`, and a blank value are rejected instead of coerced.
@@ -98,6 +99,23 @@ exit 130/143. A second signal of either kind exits immediately without a
 second sweep. Docker spawn stdout/stderr is capped at
 `EVAL_EXECUTOR_MAXIMUM_CAPTURED_OUTPUT_BYTES` (1 MiB) unless a caller raises
 the bound for a specific exec.
+
+## Invalid resume reports
+
+Resume validates the full report schema, task ID, `sourceTaskDigest`, and
+`reportDigest`. The source-task digest binds every field of the locked task,
+including its base commit, image, issue text, and artifact digests. An offline
+mock-provider report cannot stand in for a real-provider result.
+
+An unreadable, malformed, incomplete, oversized, or mismatched report becomes
+a `driver_error`. The executor leaves its task directory unchanged and does
+not pull an image, refresh a key, or run that task. Other tasks continue.
+Reports from older executors without `sourceTaskDigest` also require recovery
+because they cannot prove which locked task produced the result.
+
+Preserve the old evidence, then move the affected task directory aside or
+choose a new `--output` directory before rerunning. Moving only the report can
+leave patch or result files that the executor refuses to overwrite.
 
 ## Outputs
 

--- a/runtime/src/eval-executor/agent-run-report.ts
+++ b/runtime/src/eval-executor/agent-run-report.ts
@@ -1,0 +1,108 @@
+import { z } from "zod/v4";
+import { digestCanonicalJson, type Sha256Digest } from "../eval-contract/index.js";
+import { EvalExecutorError } from "./source-lock.js";
+import type { AgentRunReport, PilotSourceLockTask } from "./types.js";
+
+export const REPORT_DIGEST_DOMAIN = "agenc.eval.executor-agent-run-report.v1";
+const DigestSchema = z.custom<Sha256Digest>(
+  (value) => typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value),
+);
+const CountSchema = z.number().int().nonnegative();
+const CommandSchema = z.strictObject({
+  label: z.string(),
+  script: z.string(),
+  exitCode: z.number().int().nullable(),
+  timedOut: z.boolean(),
+  truncated: z.boolean(),
+  durationMs: z.number().nonnegative(),
+  stdoutDigest: DigestSchema,
+  stderrDigest: DigestSchema,
+  stdoutExcerpt: z.string(),
+  stderrExcerpt: z.string(),
+});
+const ReportSchema = z.strictObject({
+  taskId: z.string().min(1),
+  sourceTaskDigest: DigestSchema,
+  startedAt: z.iso.datetime({ offset: true }),
+  finishedAt: z.iso.datetime({ offset: true }),
+  promptDigest: DigestSchema,
+  agent: z.strictObject({
+    exitCode: z.number().int().nullable(),
+    timedOut: z.boolean(),
+    resultTruncated: z.boolean(),
+    sessionId: z.string().nullable(),
+    finalMessageDigest: DigestSchema.nullable(),
+    tokenUsage: z.record(z.string(), z.number()).nullable(),
+  }),
+  patch: z.strictObject({
+    digest: DigestSchema,
+    sizeBytes: CountSchema,
+    truncated: z.boolean(),
+  }).nullable(),
+  verification: z.strictObject({
+    phase: z.enum(["base", "reference"]),
+    imageDigest: z.string().min(1),
+    parserImageDigest: z.string().min(1).nullable(),
+    appliedPatches: z.array(z.string()),
+    commands: z.array(CommandSchema),
+    testResults: z.record(z.string(), z.string()).nullable(),
+  }).nullable(),
+  outcome: z.enum([
+    "verified_fix", "verification_failure", "empty_patch", "agent_error",
+    "agent_timeout", "oracle_containment_unverified", "infrastructure_error",
+  ]),
+  failureDetail: z.string().nullable(),
+  egress: z.strictObject({
+    mode: z.literal("real-provider"),
+    allowHost: z.string().min(1),
+    keyExposure: z.enum(["agent-env", "sidecar-only"]),
+    sidecarOverlayDigest: DigestSchema,
+    oracleContainment: z.enum(["unverified", "contained"]),
+    denyProbes: z.strictObject({
+      noRouteOffNet: z.boolean(),
+      githubBlocked: z.boolean(),
+      dnsBlackholed: z.boolean(),
+      ipv6Absent: z.boolean(),
+      ipLiteralRejected: z.boolean(),
+      sniPinned: z.boolean(),
+    }),
+    patchKeyScan: z.enum(["clean", "key-substring-found", "not-run"]),
+  }).nullable(),
+  environmentDigest: DigestSchema,
+  reportDigest: DigestSchema,
+}) satisfies z.ZodType<AgentRunReport>;
+
+export function computeSourceTaskDigest(task: PilotSourceLockTask): Sha256Digest {
+  return digestCanonicalJson("agenc.eval.executor-source-task.v1", task);
+}
+
+export function validateAgentRunReport(value: unknown, task: PilotSourceLockTask): AgentRunReport {
+  const parsed = ReportSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new EvalExecutorError(["Agent run report does not match the complete report schema"]);
+  }
+  const report = parsed.data;
+  if (report.taskId !== task.instanceId || report.sourceTaskDigest !== computeSourceTaskDigest(task)) {
+    throw new EvalExecutorError(["Agent run report does not match the source-lock task"]);
+  }
+  const { reportDigest, ...body } = report;
+  if (reportDigest !== digestCanonicalJson(REPORT_DIGEST_DOMAIN, body)) {
+    throw new EvalExecutorError(["Agent run report digest does not match its contents"]);
+  }
+  if (Date.parse(report.finishedAt) < Date.parse(report.startedAt)) {
+    throw new EvalExecutorError(["Agent run report finishes before it starts"]);
+  }
+  if (report.outcome === "verified_fix" && (
+    report.agent.exitCode !== 0 || report.agent.timedOut ||
+    report.patch === null || report.patch.sizeBytes === 0 || report.patch.truncated ||
+    report.verification?.phase !== "reference" || report.verification.testResults === null ||
+    report.failureDetail !== null ||
+    (report.egress !== null && (
+      report.egress.oracleContainment !== "contained" || report.egress.patchKeyScan !== "clean" ||
+      !Object.values(report.egress.denyProbes).every(Boolean)
+    ))
+  )) {
+    throw new EvalExecutorError(["Verified-fix report lacks successful agent, patch, verification, or containment evidence"]);
+  }
+  return report;
+}

--- a/runtime/src/eval-executor/agent-run-report.ts
+++ b/runtime/src/eval-executor/agent-run-report.ts
@@ -41,7 +41,7 @@ const ReportSchema = z.strictObject({
   }).nullable(),
   verification: z.strictObject({
     phase: z.enum(["base", "reference"]),
-    imageDigest: z.string().min(1),
+    imageDigest: z.string(),
     parserImageDigest: z.string().min(1).nullable(),
     appliedPatches: z.array(z.string()),
     commands: z.array(CommandSchema),
@@ -91,6 +91,9 @@ export function validateAgentRunReport(value: unknown, task: PilotSourceLockTask
   }
   if (Date.parse(report.finishedAt) < Date.parse(report.startedAt)) {
     throw new EvalExecutorError(["Agent run report finishes before it starts"]);
+  }
+  if (report.verification?.imageDigest === "" && report.outcome !== "infrastructure_error") {
+    throw new EvalExecutorError(["Only an infrastructure-error report may lack a verification image"]);
   }
   if (report.outcome === "verified_fix" && (
     report.agent.exitCode !== 0 || report.agent.timedOut ||

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -17,6 +17,7 @@ import {
   type EgressLaneFactory,
 } from "./egress.js";
 import { EvalExecutorError } from "./source-lock.js";
+import { computeSourceTaskDigest, REPORT_DIGEST_DOMAIN } from "./agent-run-report.js";
 import type {
   AgentRunOutcome,
   AgentRunReport,
@@ -74,7 +75,6 @@ export function buildCandidateCollectionScript(): string {
   ].join("\n");
 }
 const ENVIRONMENT_DIGEST_DOMAIN = "agenc.eval.executor-agent-environment.v1";
-const REPORT_DIGEST_DOMAIN = "agenc.eval.executor-agent-run-report.v1";
 const PROMPT_DIGEST_DOMAIN = "agenc.eval.executor-agent-prompt.v1";
 
 /**
@@ -493,6 +493,7 @@ export async function runAgentOnTask(
   const finishedAt = new Date().toISOString();
   const reportBody = {
     taskId: inputs.task.instanceId,
+    sourceTaskDigest: computeSourceTaskDigest(inputs.task),
     startedAt,
     finishedAt,
     promptDigest,
@@ -730,6 +731,7 @@ export async function runRealProviderAgentOnTask(
   const finishedAt = new Date().toISOString();
   const reportBody = {
     taskId: inputs.task.instanceId,
+    sourceTaskDigest: computeSourceTaskDigest(inputs.task),
     startedAt,
     finishedAt,
     promptDigest,

--- a/runtime/src/eval-executor/batch.ts
+++ b/runtime/src/eval-executor/batch.ts
@@ -1,9 +1,11 @@
 import { execFile } from "node:child_process";
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, lstat, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { EvalExecutorError, findPilotTask } from "./source-lock.js";
-import type { LoadedPilotSourceLock } from "./types.js";
+import { decodeStrictJson, readBoundedRegularFile } from "../eval-pilot/safe-io.js";
+import { validateAgentRunReport } from "./agent-run-report.js";
+import { EVAL_EXECUTOR_MAXIMUM_ARTIFACT_BYTES, type AgentRunReport, type LoadedPilotSourceLock, type PilotSourceLockTask } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -30,8 +32,7 @@ export interface RealAgentBatchDeps {
   readonly runTask: (taskId: string) => Promise<{ readonly outcome: string }>;
   /** Pre-pull the task's pinned image; failures abort only that task. */
   readonly pullImage: (imageReference: string) => Promise<void>;
-  /** True when this task already has a completed report (resume support). */
-  readonly hasReport: (taskId: string) => Promise<boolean>;
+  readonly loadReport: (task: PilotSourceLockTask) => Promise<AgentRunReport | null>;
   readonly refreshKey?: () => Promise<string>;
   readonly log: (line: string) => Promise<void>;
   readonly setKeyEnv: (name: string, value: string) => void;
@@ -74,12 +75,13 @@ export async function runRealAgentBatch(
   const results: RealAgentBatchTaskResult[] = [];
   for (const taskId of order) {
     const task = tasksById.get(taskId)!;
-    if (await deps.hasReport(taskId)) {
-      await deps.log(`${taskId} SKIP (report exists)`);
-      results.push({ taskId, status: "skipped", outcome: null, detail: null });
-      continue;
-    }
     try {
+      const report = await deps.loadReport(task);
+      if (report !== null) {
+        await deps.log(`${taskId} SKIP (validated report) outcome=${report.outcome}`);
+        results.push({ taskId, status: "skipped", outcome: report.outcome, detail: null });
+        continue;
+      }
       await deps.log(`${taskId} pull`);
       await deps.pullImage(task.image);
       if (deps.refreshKey !== undefined) {
@@ -125,14 +127,27 @@ export function createRealAgentBatchDeps(options: {
         timeout: IMAGE_PULL_TIMEOUT_MS,
       });
     },
-    hasReport: async (taskId) => {
+    loadReport: async (task) => {
+      const taskDir = path.join(options.outputDir, task.instanceId);
+      const reportPath = path.join(taskDir, "agent-run-report.json");
+      const failure = new EvalExecutorError([
+        `Cannot resume ${task.instanceId}: prior report is unreadable, invalid, or not bound to this real-provider source-lock task. Move the task directory ${taskDir} aside or choose a new output directory before rerunning.`,
+      ]);
       try {
-        await readFile(
-          path.join(options.outputDir, taskId, "agent-run-report.json"),
+        await lstat(reportPath);
+      } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+        throw failure;
+      }
+      try {
+        const report = validateAgentRunReport(
+          decodeStrictJson(await readBoundedRegularFile(reportPath, EVAL_EXECUTOR_MAXIMUM_ARTIFACT_BYTES), reportPath),
+          task,
         );
-        return true;
+        if (report.egress === null) throw failure;
+        return report;
       } catch {
-        return false;
+        throw failure;
       }
     },
     ...(options.keyCommand !== undefined

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -278,6 +278,7 @@ export interface EgressReport {
 
 export interface AgentRunReport {
   readonly taskId: string;
+  readonly sourceTaskDigest: Sha256Digest;
   readonly startedAt: string;
   readonly finishedAt: string;
   readonly promptDigest: Sha256Digest;

--- a/runtime/tests/eval/eval-executor-agent-run.test.ts
+++ b/runtime/tests/eval/eval-executor-agent-run.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
+import { validateAgentRunReport } from "../../src/eval-executor/agent-run-report.js";
 import {
   runAgentOnTask,
   EvalExecutorError,
@@ -231,6 +232,7 @@ describe("eval executor agent run", () => {
       expect(new TextDecoder().decode(patchBytes!)).toBe(PATCH);
       expect(report.verification).not.toBeNull();
       expect(report.reportDigest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+      expect(validateAgentRunReport(report, EMPTY_SETUP.task)).toEqual(report);
       // Agent container carries only the overlay mount; verification runs
       // with no mounts. (Network isolation is unconditional in the runner.)
       expect(runner.createOptions[0]!.readOnlyMounts).toHaveLength(1);

--- a/runtime/tests/eval/eval-executor-agent-run.test.ts
+++ b/runtime/tests/eval/eval-executor-agent-run.test.ts
@@ -281,6 +281,18 @@ describe("eval executor agent run", () => {
     });
   });
 
+  test("a failed verifier container still produces a complete resumable failure report", async () => {
+    await withOverlay(async (config) => {
+      const runner = new FakeAgentRunner([
+        { kind: "agent", agentResultJson: AGENT_RESULT, patchDiff: PATCH },
+      ]);
+      const { report } = await runAgentOnTask(runner, EMPTY_SETUP, config);
+      expect(report.outcome).toBe("infrastructure_error");
+      expect(report.verification).toMatchObject({ imageDigest: "", commands: [], testResults: null });
+      expect(validateAgentRunReport(report, EMPTY_SETUP.task)).toEqual(report);
+    });
+  });
+
   test("an unchanged repository is empty_patch and skips verification", async () => {
     await withOverlay(async (config) => {
       const runner = new FakeAgentRunner([

--- a/runtime/tests/eval/eval-executor-batch.test.ts
+++ b/runtime/tests/eval/eval-executor-batch.test.ts
@@ -250,6 +250,22 @@ describe("eval executor real-agent batch", () => {
     expect(await fixture.run()).toMatchObject({ skipped: 1, driverErrors: 0, verifiedFixes: 1 });
   });
 
+  test.each(["infrastructure_error", "verified_fix"] as const)("handles an uncreated verifier container for %s", async (outcome) => {
+    const fixture = await createDiskBatch();
+    const report = makeReport(fixture.loaded.lock.tasks[0]!, outcome);
+    await writeFile(fixture.reportPath, serializeChangedReport(report, {
+      verification: { ...report.verification, imageDigest: "", appliedPatches: [], commands: [], testResults: null },
+    }));
+    const summary = await fixture.run();
+    if (outcome === "infrastructure_error") {
+      expect(summary).toMatchObject({ skipped: 1, driverErrors: 0, verifiedFixes: 0 });
+      expect(summary.results[0]?.outcome).toBe(outcome);
+    } else expect(summary).toMatchObject({ skipped: 0, driverErrors: 1, verifiedFixes: 0 });
+    expect(fixture.runTask).not.toHaveBeenCalled();
+    expect(fixture.pullImage).not.toHaveBeenCalled();
+    expect(fixture.refreshKey).not.toHaveBeenCalled();
+  });
+
   test("executes absent reports but refuses a directory, symlink, oversized file, and invalid UTF-8", async () => {
     const absent = await createDiskBatch();
     expect(await absent.run()).toMatchObject({ completed: 1, skipped: 0, driverErrors: 0 });

--- a/runtime/tests/eval/eval-executor-batch.test.ts
+++ b/runtime/tests/eval/eval-executor-batch.test.ts
@@ -1,8 +1,72 @@
-import { describe, expect, test } from "vitest";
-import { runRealAgentBatch, type RealAgentBatchDeps } from "../../src/eval-executor/batch.js";
-import type { LoadedPilotSourceLock } from "../../src/eval-executor/types.js";
+import { mkdir, readFile, symlink, truncate, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createRealAgentBatchDeps, runRealAgentBatch, type RealAgentBatchDeps } from "../../src/eval-executor/batch.js";
+import { digestCanonicalJson } from "../../src/eval-contract/index.js";
+import type { AgentRunOutcome, AgentRunReport, LoadedPilotSourceLock, PilotSourceLockTask } from "../../src/eval-executor/types.js";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 
 const digestOf = (c: string): `sha256:${string}` => `sha256:${c.repeat(64)}`;
+const workspaces = createTempWorkspaceFixture("agenc-batch-resume-");
+afterEach(async () => { await workspaces.cleanup(); });
+
+function makeReport(task: PilotSourceLockTask, outcome: AgentRunOutcome = "verified_fix") {
+  const reportBody = {
+    taskId: task.instanceId,
+    sourceTaskDigest: digestCanonicalJson("agenc.eval.executor-source-task.v1", task),
+    startedAt: "2026-09-09T00:00:00.000Z",
+    finishedAt: "2026-09-09T00:01:00.000Z",
+    promptDigest: digestOf("a"),
+    agent: {
+      exitCode: 0, timedOut: false, resultTruncated: false, sessionId: "test-session",
+      finalMessageDigest: digestOf("b"), tokenUsage: { totalTokens: 0 },
+    },
+    patch: { digest: digestOf("c"), sizeBytes: 1, truncated: false },
+    verification: {
+      phase: "reference" as const, imageDigest: task.image, parserImageDigest: null,
+      appliedPatches: ["candidate"], commands: [], testResults: { target: "pass" },
+    },
+    outcome,
+    failureDetail: outcome === "verified_fix" ? null : "test failure",
+    egress: {
+      mode: "real-provider" as const, allowHost: "provider.invalid", keyExposure: "agent-env" as const,
+      sidecarOverlayDigest: digestOf("d"), oracleContainment: "contained" as const,
+      denyProbes: {
+        noRouteOffNet: true, githubBlocked: true, dnsBlackholed: true,
+        ipv6Absent: true, ipLiteralRejected: true, sniPinned: true,
+      },
+      patchKeyScan: "clean" as const,
+    },
+    environmentDigest: digestOf("e"),
+  };
+  return {
+    ...reportBody,
+    reportDigest: digestCanonicalJson("agenc.eval.executor-agent-run-report.v1", reportBody),
+  } satisfies AgentRunReport;
+}
+
+async function createDiskBatch(taskIds: readonly string[] = ["t-a"]) {
+  const outputDir = await workspaces.create();
+  const loaded = makeLoaded(taskIds);
+  const runTask = vi.fn(async () => ({ outcome: "verified_fix" }));
+  const pullImage = vi.fn(async () => {});
+  const refreshKey = vi.fn(async () => "test-provider-key");
+  const log = vi.fn(async (_line: string) => {});
+  const deps = {
+    ...createRealAgentBatchDeps({ outputDir, runTask }),
+    pullImage, refreshKey, log, setKeyEnv: vi.fn(),
+  };
+  const reportPath = path.join(outputDir, "t-a", "agent-run-report.json");
+  await mkdir(path.dirname(reportPath));
+  const run = () => runRealAgentBatch({ loaded, outputDir, keyEnvVar: "TEST_KEY" }, deps);
+  return { loaded, outputDir, reportPath, runTask, pullImage, refreshKey, log, run };
+}
+
+function serializeChangedReport(report: ReturnType<typeof makeReport>, changes: Record<string, unknown>): string {
+  const body = JSON.parse(JSON.stringify({ ...report, ...changes })) as Record<string, unknown>;
+  delete body.reportDigest;
+  return JSON.stringify({ ...body, reportDigest: digestCanonicalJson("agenc.eval.executor-agent-run-report.v1", body) });
+}
 
 function makeLoaded(taskIds: readonly string[]): LoadedPilotSourceLock {
   return {
@@ -77,8 +141,9 @@ function makeDeps(overrides: {
       pullImage: async (image) => {
         calls.push(`pull:${image.split("/")[1]?.split("@")[0]}`);
       },
-      hasReport: async (taskId) =>
-        overrides.existingReports?.includes(taskId) ?? false,
+      loadReport: async (task) => overrides.existingReports?.includes(task.instanceId)
+        ? makeReport(task)
+        : null,
       ...(keys !== undefined
         ? {
           refreshKey: async () => {
@@ -96,6 +161,115 @@ function makeDeps(overrides: {
 }
 
 describe("eval executor real-agent batch", () => {
+  test.each([
+    ["empty", () => ""],
+    ["truncated", () => '{"taskId":"t-a",'],
+    ["scalar", () => "42"],
+    ["null", () => "null"],
+    ["incomplete", () => '{"taskId":"t-a","outcome":"verified_fix"}'],
+    ["wrong task", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { taskId: "t-other" })],
+    ["wrong source task", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { sourceTaskDigest: digestOf("f") })],
+    ["legacy unbound", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { sourceTaskDigest: undefined })],
+    ["incomplete agent", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { agent: {} })],
+    ["invalid outcome", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { outcome: "success" })],
+    ["invalid timestamp", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { finishedAt: "yesterday" })],
+    ["reversed timestamps", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { finishedAt: "2026-09-08T00:00:00.000Z" })],
+    ["missing verification", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { verification: null })],
+    ["missing patch", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { patch: null })],
+    ["unverified containment", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { egress: { ...report.egress, oracleContainment: "unverified" } })],
+    ["missing deny probe", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { egress: { ...report.egress, denyProbes: {} } })],
+    ["mock-provider lane", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { egress: null })],
+    ["incomplete verification command", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { verification: { ...report.verification, commands: [{}] } })],
+    ["wrong digest", (report: ReturnType<typeof makeReport>) => JSON.stringify({ ...report, reportDigest: digestOf("0") })],
+    ["duplicate key", (report: ReturnType<typeof makeReport>) => JSON.stringify(report).replace('{"taskId":', '{"taskId":"t-a","taskId":')],
+    ["secret in malformed JSON", () => '{"sensitive":"do-not-print-this-secret"'],
+  ] as const)("reports a %s prior report as a driver error without spending", async (_label, serialize) => {
+    const fixture = await createDiskBatch();
+    const bytes = serialize(makeReport(fixture.loaded.lock.tasks[0]!));
+    await writeFile(fixture.reportPath, bytes);
+    const summary = await fixture.run();
+    expect(summary).toMatchObject({ completed: 0, skipped: 0, driverErrors: 1, verifiedFixes: 0 });
+    expect(summary.results[0]).toMatchObject({ outcome: null, status: "driver_error" });
+    expect(summary.results[0]?.detail).toMatch(/move.*task directory|new output directory/iu);
+    expect(fixture.runTask).not.toHaveBeenCalled();
+    expect(fixture.pullImage).not.toHaveBeenCalled();
+    expect(fixture.refreshKey).not.toHaveBeenCalled();
+    expect(await readFile(fixture.reportPath, "utf8")).toBe(bytes);
+    expect(JSON.stringify([summary, fixture.log.mock.calls])).not.toContain("do-not-print-this-secret");
+  });
+
+  test("retains a valid prior outcome alongside a newly completed task", async () => {
+    const fixture = await createDiskBatch(["t-a", "t-b"]);
+    await writeFile(fixture.reportPath, JSON.stringify(makeReport(fixture.loaded.lock.tasks[0]!)));
+    const summary = await fixture.run();
+    expect(summary).toMatchObject({ total: 2, completed: 1, skipped: 1, driverErrors: 0, verifiedFixes: 2 });
+    expect(summary.results[0]).toMatchObject({ status: "skipped", outcome: "verified_fix" });
+    expect(fixture.runTask).toHaveBeenCalledExactlyOnceWith("t-b");
+  });
+
+  test("retains every outcome when the entire requested batch resumes", async () => {
+    const outcomes: readonly AgentRunOutcome[] = [
+      "verified_fix", "verification_failure", "empty_patch", "agent_error", "agent_timeout",
+      "oracle_containment_unverified", "infrastructure_error",
+    ];
+    const fixture = await createDiskBatch(outcomes.map((_outcome, index) => `t-${index}`));
+    for (const [index, task] of fixture.loaded.lock.tasks.entries()) {
+      const directory = path.join(fixture.outputDir, task.instanceId);
+      await mkdir(directory, { recursive: true });
+      await writeFile(path.join(directory, "agent-run-report.json"), JSON.stringify(makeReport(task, outcomes[index])));
+    }
+    const summary = await fixture.run();
+    expect(summary).toMatchObject({ total: 7, completed: 0, skipped: 7, driverErrors: 0, verifiedFixes: 1 });
+    expect(summary.results.map((result) => result.outcome)).toEqual(outcomes);
+    expect(fixture.runTask).not.toHaveBeenCalled();
+    expect(fixture.pullImage).not.toHaveBeenCalled();
+    expect(fixture.refreshKey).not.toHaveBeenCalled();
+  });
+
+  test("keeps processing other tasks after a corrupt prior report", async () => {
+    const fixture = await createDiskBatch(["t-a", "t-b"]);
+    await writeFile(fixture.reportPath, "");
+    expect(await fixture.run()).toMatchObject({ total: 2, completed: 1, skipped: 0, driverErrors: 1, verifiedFixes: 1 });
+    expect(fixture.runTask).toHaveBeenCalledExactlyOnceWith("t-b");
+  });
+
+  test("rejects a report after the same task ID changes its locked inputs", async () => {
+    const fixture = await createDiskBatch();
+    const task = fixture.loaded.lock.tasks[0]!;
+    await writeFile(fixture.reportPath, JSON.stringify(makeReport({ ...task, baseCommit: "f".repeat(40) })));
+    expect(await fixture.run()).toMatchObject({ skipped: 0, driverErrors: 1 });
+    expect(fixture.runTask).not.toHaveBeenCalled();
+  });
+
+  test("accepts finite usage metrics and truncated agent telemetry when the patch is verified", async () => {
+    const fixture = await createDiskBatch();
+    const report = makeReport(fixture.loaded.lock.tasks[0]!);
+    await writeFile(fixture.reportPath, serializeChangedReport(report, {
+      agent: { ...report.agent, resultTruncated: true, tokenUsage: { totalTokens: 12, cost: 0.01 } },
+    }));
+    expect(await fixture.run()).toMatchObject({ skipped: 1, driverErrors: 0, verifiedFixes: 1 });
+  });
+
+  test("executes absent reports but refuses a directory, symlink, oversized file, and invalid UTF-8", async () => {
+    const absent = await createDiskBatch();
+    expect(await absent.run()).toMatchObject({ completed: 1, skipped: 0, driverErrors: 0 });
+    for (const kind of ["directory", "symlink", "oversized", "invalid-utf8"]) {
+      const fixture = await createDiskBatch();
+      if (kind === "directory") await mkdir(fixture.reportPath);
+      else if (kind === "symlink") {
+        const target = path.join(fixture.outputDir, "report-target.json");
+        await writeFile(target, JSON.stringify(makeReport(fixture.loaded.lock.tasks[0]!)));
+        await symlink(target, fixture.reportPath);
+      } else if (kind === "oversized") {
+        await writeFile(fixture.reportPath, "");
+        await truncate(fixture.reportPath, 16_777_217);
+      } else await writeFile(fixture.reportPath, Uint8Array.of(0xff, 0xfe));
+      expect(await fixture.run()).toMatchObject({ completed: 0, skipped: 0, driverErrors: 1 });
+      expect(fixture.runTask).not.toHaveBeenCalled();
+      expect(fixture.pullImage).not.toHaveBeenCalled();
+    }
+  });
+
   test("runs every lock task in order, pulling each image first", async () => {
     const loaded = makeLoaded(["t-a", "t-b", "t-c"]);
     const { deps, calls } = makeDeps({ outcomes: { "t-b": "verification_failure" } });

--- a/runtime/tests/eval/eval-executor-egress.test.ts
+++ b/runtime/tests/eval/eval-executor-egress.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { validateAgentRunReport } from "../../src/eval-executor/agent-run-report.js";
 import {
   allContainmentProbesPass,
   buildAgentEgressCreateArgs,
@@ -297,6 +298,7 @@ describe("real-provider lane gating (fake lane, no docker)", () => {
     const { factory } = laneFactory(ALL_TRUE, runner);
     const { report } = await runRealProviderAgentOnTask(runner, factory, inputs(), config());
     expect(report.outcome).toBe("empty_patch");
+    expect(validateAgentRunReport(report, inputs().task)).toEqual(report);
     expect(report.egress?.oracleContainment).toBe("contained");
     expect(report.egress?.patchKeyScan).toBe("clean");
     const agentExec = runner.execs.find((e) => e.script.includes("HTTPS_PROXY"));


### PR DESCRIPTION
## Summary

Closes #2081.

- Load and validate prior reports instead of treating readable files as completed tasks. Validate all required fields, nested records, task identity, canonical report digest, timestamps, and the evidence required by a verified-fix result.
- Include a canonical `sourceTaskDigest` in reports from both agent lanes. Resume compares it with the full task from the current source lock and rejects offline mock reports in a real-provider batch.
- Preserve resumed outcomes in per-task results and aggregate scores. Treat invalid or unreadable prior reports as driver errors without pulling images, refreshing credentials, overwriting evidence, or rerunning those tasks. Other tasks continue.
- Bound reads to regular non-symlink files and reject malformed UTF-8, duplicate JSON keys, and oversized reports. Recovery messages do not print report contents.

## Compatibility and recovery

Writers and the resume loader change together. Existing reports without `sourceTaskDigest` are not trusted for automatic resume because they cannot establish the complete locked-task identity. Their files remain unchanged. Preserve the evidence, then move the affected task directory aside or select a new output directory before an intentional rerun. No automatic migration, quarantine, or model spending is performed.

Reverting this commit does not alter stored evidence, but restores the unsafe existence-only resume behavior. Do not use the old resume loader as a recovery mechanism.

## Validation

- The original-source run failed 13 new regression tests while all 7 existing controls passed.
- Runtime and test-support typechecks passed in the local Docker boundary. The four targeted executor files passed all 77 tests.
- A dedicated TypeScript check passed for all three changed test files.
- Tests cover malformed and incomplete reports, legacy and wrong task bindings, rehashed invalid schemas, offline-lane substitution, symlinks, file bounds, every prior outcome, mixed and all-resumed batches, and no-spend recovery. Both real report producers also pass the shared validator.
- Staged GitNexus analysis reports 8 files, 20 indexed symbols, 0 affected processes, and low risk. Shifted-line matches were checked against the actual diff.
- Local build, PTY startup, full suite, and Linux native checks are pending on this commit. Results will be recorded before manual merge.
- Hosted CI stays disabled. No Actions workflows are enabled, dispatched, or retried. Independent review is required before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval batch resume and scoring semantics; mistakes could skip reruns incorrectly or miscount outcomes, but scope is executor resume/validation rather than auth or production runtime paths.
> 
> **Overview**
> **Real-agent batch resume** no longer treats a present `agent-run-report.json` as done. It loads the file with bounded, strict I/O and runs shared **`validateAgentRunReport`**: full Zod schema, **`sourceTaskDigest`** tied to the current source-lock task, **`reportDigest`**, timestamp and outcome consistency (including evidence required for **`verified_fix`**), and **non-null real-provider `egress`**. Valid reports are skipped but their **outcomes still feed per-task results and aggregates** (e.g. `verifiedFixes`).
> 
> New reports include **`sourceTaskDigest`** from both agent run paths. Invalid, legacy (no digest), mock-lane (`egress: null`), or mismatched reports become **`driver_error`** for that task only—no image pull, key refresh, overwrite, or rerun—while other tasks continue; recovery guidance is documented.
> 
> Extensive batch and agent-run tests cover malformed reports, bindings, symlinks/size limits, and mixed resume batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26cf04f095594f5cb7703f6b7e2ffa63434e1607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->