### PR TITLE
fix(eval): pass provider configuration as literal environment values

### DIFF
--- a/docs/design/eval-pilot-executor-phase2b-egress.md
+++ b/docs/design/eval-pilot-executor-phase2b-egress.md
@@ -29,8 +29,18 @@ the adversarial review:
   test (a `/proc/net/ipv6_route` parse proved fragile across kernels).
 - **Key redaction.** Beyond scanning the patch, the provider key is scanned in
   the agent's stdout result and stderr and redacted from every persisted /
-  digested text artifact; a hit quarantines the run. A too-short key and a
-  model / base URL containing shell metacharacters are rejected up front.
+  digested text artifact; a hit quarantines the run. A too-short key or invalid
+  model is rejected up front. Provider URLs must parse as HTTPS, match the
+  configured egress host and port, and contain no credentials, fragments,
+  backslashes, spaces, or control characters.
+
+The executor passes the provider URL, model, and proxy values in a per-call
+environment map. The Docker child receives those values directly, and
+`docker exec -e NAME` forwards them by name. Configuration never becomes bash
+source or a command-line value. Accepted URL path and query bytes remain
+literal, including dollar signs, parentheses, quotes, and command separators.
+Concurrent calls do not change the executor's environment. Existing secret
+name-only passthrough is retained.
 
 Phase 2a ships the offline agent-run lane (`--network none`, bundled
 in-container mock provider). Phase 2b lets the agent reach a **real** model

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -537,15 +537,10 @@ export interface RealProviderAgentConfig {
  * makes undici put the hostname in the CONNECT authority, which lets the
  * blackholed resolver be a hard boundary rather than a breakage.
  */
-export function buildRealProviderAgentScript(config: {
-  readonly proxyIp: string;
-  readonly proxyListenPort: number;
-  readonly model: string;
-  readonly baseUrl: string;
-}): string {
-  const proxyUrl = `http://${config.proxyIp}:${config.proxyListenPort}`;
+export function buildRealProviderAgentScript(): string {
   return [
     `set -u`,
+    ': "${HTTPS_PROXY:?}" "${HTTP_PROXY:?}" "${AGENC_MODEL:?}" "${OPENAI_COMPATIBLE_BASE_URL:?}"',
     `export PATH=${OVERLAY_CONTAINER_PATH}/node/bin:$PATH`,
     // libatomic shim for images that lack it; the image's own paths still
     // win for every other library via loader fallback.
@@ -561,11 +556,8 @@ export function buildRealProviderAgentScript(config: {
       `ldconfig 2>/dev/null || true; }`,
     `mkdir -p ${AGENT_HOME}`,
     buildBaselineGitScript(),
-    `export HTTPS_PROXY=${proxyUrl} HTTP_PROXY=${proxyUrl} NO_PROXY=`,
     `export AGENC_PROXY_RESOLVES_HOSTS=1`,
-    `export AGENC_PROVIDER=openai-compatible AGENC_MODEL=${config.model}`,
-    `export AGENC_MODEL=${config.model}`,
-    `export OPENAI_COMPATIBLE_BASE_URL="${config.baseUrl}" API_TIMEOUT_MS=600000`,
+    `export AGENC_PROVIDER=openai-compatible API_TIMEOUT_MS=600000`,
     `export AGENC_HOME=${AGENT_HOME} AGENC_WORKSPACE="$PWD" AGENC_AUTH_MANAGED_KEYS_ENABLED=0`,
     // OPENAI_COMPATIBLE_API_KEY is injected via `docker exec -e`, never here.
     `printf '%s' "{\\"version\\":1,\\"trustedProjects\\":[{\\"path\\":\\"$PWD\\",\\"trustedAt\\":\\"1970-01-01T00:00:00Z\\"}]}" > ${AGENT_HOME}/trusted-projects.json`,
@@ -573,6 +565,23 @@ export function buildRealProviderAgentScript(config: {
       `--output-format json --dangerously-bypass-approvals-and-sandbox > ${AGENT_HELPER_DIR}/agent-result.json 2> ${AGENT_HELPER_DIR}/agent-stderr.log`,
     `exit $?`,
   ].join("\n");
+}
+
+function assertProviderBaseUrl(config: RealProviderAgentConfig): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(config.baseUrl);
+  } catch {
+    throw new EvalExecutorError(["invalid provider base URL"]);
+  }
+  if (
+    config.baseUrl.length > 264 || !/^https:\/\/[^/]/iu.test(config.baseUrl) ||
+    /[\\\u0000-\u0020\u007f]/u.test(config.baseUrl) || config.baseUrl.includes("#") ||
+    parsed.protocol !== "https:" || parsed.username !== "" || parsed.password !== "" ||
+    parsed.hostname !== config.allowHost || Number(parsed.port || "443") !== config.allowPort
+  ) {
+    throw new EvalExecutorError(["invalid provider base URL; expected an HTTPS endpoint matching the egress allowlist"]);
+  }
 }
 
 const ALL_FALSE_PROBES: EgressContainmentProbes = {
@@ -614,14 +623,10 @@ export async function runRealProviderAgentOnTask(
   if (secret.length < 16) {
     throw new EvalExecutorError([`${config.keyEnvVar} is too short to be a provider key`]);
   }
-  // model and baseUrl are interpolated into the agent bash script; reject
-  // shell-metacharacter values (same trust discipline as allowHost).
   if (!/^[A-Za-z0-9._:-]{1,128}$/u.test(config.model)) {
     throw new EvalExecutorError([`invalid provider model ${config.model}`]);
   }
-  if (!/^https:\/\/[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]{1,256}$/u.test(config.baseUrl)) {
-    throw new EvalExecutorError([`invalid provider base URL ${config.baseUrl}`]);
-  }
+  assertProviderBaseUrl(config);
   const startedAt = new Date().toISOString();
   const environment = await runner.environment();
   const overlayDigest = await computeOverlayDigest(config.overlay);
@@ -663,13 +668,16 @@ export async function runRealProviderAgentOnTask(
     } else {
       const handle = lane.agentHandle;
       await applySetupAndPrompt(runner, handle, inputs.setupPatch, prompt, timeouts);
+      const proxyUrl = `http://${lane.proxyIp}:${lane.proxyListenPort}`;
       const executed = await runner.exec(handle, {
-        script: buildRealProviderAgentScript({
-          proxyIp: lane.proxyIp,
-          proxyListenPort: lane.proxyListenPort,
-          model: config.model,
-          baseUrl: config.baseUrl,
-        }),
+        script: buildRealProviderAgentScript(),
+        env: {
+          HTTPS_PROXY: proxyUrl,
+          HTTP_PROXY: proxyUrl,
+          NO_PROXY: "",
+          AGENC_MODEL: config.model,
+          OPENAI_COMPATIBLE_BASE_URL: config.baseUrl,
+        },
         ...(agentTimeoutMs !== undefined ? { timeoutMs: agentTimeoutMs } : {}),
         envPassthrough: [config.keyEnvVar],
       });

--- a/runtime/src/eval-executor/container-runner.ts
+++ b/runtime/src/eval-executor/container-runner.ts
@@ -33,6 +33,7 @@ interface SpawnBoundedOptions {
   readonly timeoutMs?: number;
   readonly stdin?: Uint8Array;
   readonly maxOutputBytes?: number;
+  readonly env?: NodeJS.ProcessEnv;
 }
 
 function spawnBounded(
@@ -44,6 +45,7 @@ function spawnBounded(
     const startedAt = Date.now();
     const child = spawn(command, args, {
       stdio: [options.stdin ? "pipe" : "ignore", "pipe", "pipe"],
+      ...(options.env !== undefined ? { env: options.env } : {}),
     });
     let stdout: Buffer = Buffer.alloc(0);
     let stderr: Buffer = Buffer.alloc(0);
@@ -523,20 +525,26 @@ export class DockerContainerRunner implements ContainerRunner {
   }
 
   async exec(handle: ContainerHandle, request: ContainerExecRequest): Promise<ContainerExecResult> {
-    // `-e NAME` (no `=value`) forwards the value from the executor's own
-    // environment: a secret is never on the argv the way `-e NAME=value`
-    // would be. Reject a name that could smuggle a literal value.
+    // `-e NAME` forwards values from the docker child's environment, never
+    // from shell source or `-e NAME=value` arguments.
     const envArgs: string[] = [];
-    for (const name of request.envPassthrough ?? []) {
+    const names = new Set([...Object.keys(request.env ?? {}), ...(request.envPassthrough ?? [])]);
+    for (const name of names) {
       if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name)) {
         throw new EvalExecutorError([`invalid env passthrough name ${name}`]);
       }
       envArgs.push("-e", name);
     }
+    for (const [name, value] of Object.entries(request.env ?? {})) {
+      if (typeof value !== "string" || value.includes("\0")) {
+        throw new EvalExecutorError([`invalid env value for ${name}`]);
+      }
+    }
     return spawnBounded(
       "docker",
       ["exec", ...envArgs, "-w", handle.workdir, handle.id, "bash", "-c", request.script],
       {
+        ...(request.env !== undefined ? { env: { ...process.env, ...request.env } } : {}),
         ...(request.timeoutMs !== undefined
           ? { timeoutMs: request.timeoutMs }
           : {}),

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -115,6 +115,7 @@ export interface ContainerExecRequest {
    * --env`, not visible in host `ps`.
    */
   readonly envPassthrough?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
 }
 
 export interface ContainerExecResult {

--- a/runtime/tests/eval/eval-executor-egress.test.ts
+++ b/runtime/tests/eval/eval-executor-egress.test.ts
@@ -133,13 +133,11 @@ describe("egress probe parsing + containment", () => {
 
 describe("real-provider agent script", () => {
   test("routes through the proxy and never assigns the key", () => {
-    const script = buildRealProviderAgentScript({
-      proxyIp: "10.88.7.2", proxyListenPort: 8080, model: "grok-4.5", baseUrl: "https://api.x.ai/v1",
-    });
-    expect(script).toContain("HTTPS_PROXY=http://10.88.7.2:8080");
+    const script = buildRealProviderAgentScript();
+    expect(script).toContain("${HTTPS_PROXY:?}");
     expect(script).toContain("AGENC_PROXY_RESOLVES_HOSTS=1");
-    expect(script).toContain("AGENC_MODEL=grok-4.5");
-    expect(script).toContain('OPENAI_COMPATIBLE_BASE_URL="https://api.x.ai/v1"');
+    expect(script).toContain("${AGENC_MODEL:?}");
+    expect(script).toContain("${OPENAI_COMPATIBLE_BASE_URL:?}");
     // The key is delivered via docker exec -e, never assigned in the script.
     expect(script).not.toContain("OPENAI_COMPATIBLE_API_KEY=");
     // No mock provider in the real lane.
@@ -336,6 +334,39 @@ describe("real-provider lane gating (fake lane, no docker)", () => {
     const { factory } = laneFactory(ALL_TRUE, runner);
     await expect(runRealProviderAgentOnTask(runner, factory, inputs(), config()))
       .rejects.toThrow(new RegExp(KEY_VAR));
+  });
+
+  test.each([
+    "https://api.x.ai/v1",
+    "https://api.x.ai:443/v1?api-version=2026-09&value=a+b%20c",
+    "https://api.x.ai/v1/$(true)?value='quoted'&other=();",
+  ])("passes provider URL %j as environment data, never shell source", async (baseUrl) => {
+    const runner = new FakeRunner("");
+    const { factory } = laneFactory(ALL_TRUE, runner);
+    await runRealProviderAgentOnTask(runner, factory, inputs(), { ...config(), baseUrl });
+    const agentExec = runner.execs.find((request) => request.script.includes("agenc.js") && request.script.includes("AGENC_PROVIDER"));
+    expect(agentExec).toBeDefined();
+    expect(agentExec!.script).not.toContain(baseUrl);
+    expect(agentExec!.script).not.toContain("grok-4.5");
+    expect(Reflect.get(agentExec!, "env")).toMatchObject({
+      OPENAI_COMPATIBLE_BASE_URL: baseUrl, AGENC_MODEL: "grok-4.5",
+      HTTPS_PROXY: "http://10.88.9.2:8080", HTTP_PROXY: "http://10.88.9.2:8080", NO_PROXY: "",
+    });
+  });
+
+  test.each([
+    "http://api.x.ai/v1", "https:///api.x.ai/v1", "https://user:pass@api.x.ai/v1",
+    "https://other.invalid/v1", "https://api.x.ai:444/v1", "https://api.x.ai/v1#fragment",
+    "https://api.x.ai/v1\n", "https://api.x.ai/v1\t", "https://api.x.ai/v1 with spaces",
+    "https://api.x.ai\\v1", "https://[broken", "https://api.x.ai/\0value",
+  ])("rejects provider URL %j before lane creation", async (baseUrl) => {
+    const runner = new FakeRunner("");
+    let created = false;
+    const factory = async (): Promise<EgressLane> => { created = true; throw new Error("must not create lane"); };
+    await expect(runRealProviderAgentOnTask(runner, factory, inputs(), { ...config(), baseUrl }))
+      .rejects.toThrow(/invalid provider base URL/u);
+    expect(created).toBe(false);
+    expect(runner.execs).toHaveLength(0);
   });
 
   test("a too-short key and an invalid model are rejected up front", async () => {

--- a/runtime/tests/eval/eval-executor-literal-env.test.ts
+++ b/runtime/tests/eval/eval-executor-literal-env.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { DockerContainerRunner } from "../../src/eval-executor/container-runner.js";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-eval-literal-env-");
+const handle = { id: "test-container", imageDigest: "test-image", workdir: "/testbed" };
+
+describe.runIf(process.platform !== "win32")("literal container environment", () => {
+  let root: string;
+  let argvLog: string;
+
+  beforeEach(async () => {
+    root = await workspaces.create();
+    argvLog = path.join(root, "argv.json");
+    const bin = path.join(root, "bin");
+    await mkdir(bin);
+    await writeFile(path.join(bin, "docker"), [
+      `#!${process.execPath}`,
+      'const { writeFileSync } = require("node:fs");',
+      'const { spawnSync } = require("node:child_process");',
+      'const args = process.argv.slice(2);',
+      `writeFileSync(${JSON.stringify(argvLog)}, JSON.stringify(args));`,
+      'const env = { PATH: process.env.PATH };',
+      'for (let index = 1; index < args.indexOf("bash"); index++) {',
+      '  if (args[index] === "-e") { const name = args[++index]; env[name] = process.env[name]; }',
+      '}',
+      'const result = spawnSync("bash", args.slice(args.indexOf("bash") + 1), { env, encoding: "utf8" });',
+      'process.stdout.write(result.stdout ?? "");',
+      'process.stderr.write(result.stderr ?? "");',
+      'process.exit(result.status ?? 1);',
+    ].join("\n"), { mode: 0o755 });
+    vi.stubEnv("PATH", `${bin}${path.delimiter}${process.env.PATH ?? ""}`);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await workspaces.cleanup();
+  });
+
+  test.each([
+    "https://api.example.invalid/v1?api-version=2026-09&value=a+b%20c",
+    "https://api.example.invalid/$(true)",
+    "https://api.example.invalid/`true`",
+    "https://api.example.invalid/'\";printf injected>&2\nnext",
+  ])("delivers %j as a literal value through a real shell", async (baseUrl) => {
+    const runner = new DockerContainerRunner();
+    const request = {
+      script: 'printf "%s" "$OPENAI_COMPATIBLE_BASE_URL"',
+      env: { OPENAI_COMPATIBLE_BASE_URL: baseUrl },
+    };
+    const result = await runner.exec(handle, request);
+    expect(result).toMatchObject({ exitCode: 0, stdout: baseUrl, stderr: "", timedOut: false });
+    const args: string[] = JSON.parse(await readFile(argvLog, "utf8"));
+    expect(args).toContain("OPENAI_COMPATIBLE_BASE_URL");
+    expect(args).not.toContain(baseUrl);
+    expect(args.join(" ")).not.toContain("OPENAI_COMPATIBLE_BASE_URL=");
+  });
+
+  test("isolates concurrent values and retains secret name-only passthrough", async () => {
+    vi.stubEnv("OPENAI_COMPATIBLE_BASE_URL", "unchanged-host-value");
+    vi.stubEnv("AGENC_TEST_PROVIDER_KEY", "test-only-secret-1234567890");
+    const runner = new DockerContainerRunner();
+    const results = await Promise.all(["first", "second"].map((value) => runner.exec(handle, {
+      script: 'printf "%s:%s" "$OPENAI_COMPATIBLE_BASE_URL" "$AGENC_TEST_PROVIDER_KEY"',
+      env: { OPENAI_COMPATIBLE_BASE_URL: value },
+      envPassthrough: ["AGENC_TEST_PROVIDER_KEY"],
+    })));
+    expect(results.map((result) => result.stdout)).toEqual([
+      "first:test-only-secret-1234567890", "second:test-only-secret-1234567890",
+    ]);
+    expect(process.env.OPENAI_COMPATIBLE_BASE_URL).toBe("unchanged-host-value");
+    expect(await readFile(argvLog, "utf8")).not.toContain("test-only-secret-1234567890");
+  });
+
+  test.each(["BAD=value", "BAD NAME", "-e", ""])("rejects environment name %j before spawning", async (name) => {
+    const request = { script: "true", env: { [name]: "value" } };
+    await expect(new DockerContainerRunner().exec(handle, request)).rejects.toThrow(/invalid env/u);
+    await expect(readFile(argvLog)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("rejects NUL in environment values before spawning", async () => {
+    const request = { script: "true", env: { SAFE_NAME: "bad\0value" } };
+    await expect(new DockerContainerRunner().exec(handle, request)).rejects.toThrow(/invalid env/u);
+    await expect(readFile(argvLog)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Changes

- Pass provider URL, model, and proxy configuration through a per-call Docker child environment, with only variable names in docker exec arguments. No configuration value becomes shell source or requires process-global environment changes.
- Keep secret name-only passthrough and validate environment names and NUL-free values at the runner boundary.
- Require a parsed HTTPS provider URL on the configured egress host and port. Reject credentials, fragments, backslashes, whitespace, and controls before lane creation. Preserve accepted path/query bytes, including shell syntax, as literal data.
- Remove duplicate model assignments and document the environment contract.

## Validation

- Original source failed 19 regressions while 21 controls passed.
- Both runtime typechecks and 144 tests across 10 files pass in the local hermetic container. Dedicated typechecking of both changed test files passes.
- Tests use a test-only Docker executable and a real shell to check literal delivery, secret passthrough, and concurrent-call isolation. No provider requests or real credentials are used.
- The benchmark baseline and measured source inputs are unchanged.
- On 3d254a834bceae003d1af1037760c6ac992b1a0b, the build and PTY startup checks pass. The full suite passes all 24,049 tests across 2,301 runtime files after root and launcher checks. Linux native checks pass 92 tests across five files. No macOS or Windows result is claimed.
- Cursor Bugbot completed independent review with no findings after 8 minutes 53 seconds. The approval router had timed out at 8 minutes and left a COMMENTED review, not an approval. The later completed Bugbot review supplies the required independent review. The Security Reviewer completed successfully. Sonar's actual gate is OK, with zero new issues and zero new duplication. No branch-rule or admin bypass is used.
- Hosted Actions remain disabled and this head has zero Actions runs. All test execution was local.

Closes #2083.
