### PR TITLE
fix(eval): attest complete overlay inputs with a versioned manifest

### DIFF
--- a/docs/design/eval-pilot-executor-phase2b-egress.md
+++ b/docs/design/eval-pilot-executor-phase2b-egress.md
@@ -88,8 +88,38 @@ blackholed (`--dns 127.0.0.1`).
 
 A small deny-by-default HTTP `CONNECT` proxy shipped inside the read-only
 overlay (`overlay/proxy/allowlist-proxy.mjs`), run by the overlay's pinned
-`node`. It is added to `assertOverlayLayout()` and folded into
-`computeOverlayDigest()`, so the report attests which proxy enforced egress.
+`node`. The versioned overlay manifest includes both the proxy and its Node
+binary, along with the containment probe and the rest of the overlay.
+
+### Overlay manifest
+
+Every new agent report includes `overlayManifest`, with kind
+`agenc.eval.executor-overlay-manifest`, version `1.0.0`, and mode `offline` or
+`real-provider`. The manifest has two sorted arrays. `files` records each
+overlay-relative POSIX path, SHA-256 digest of the exact bytes, `sizeBytes`, and
+permission `mode` bits (`0o7777`). `links` records each internal symlink's path
+and literal target without recursively following directory aliases.
+
+The inventory includes every regular file under `node/`, `runtime/`, `mock/`,
+and `proxy/`. That includes the Node binary and distribution, compatibility
+libraries, runtime entrypoint, chunks and dependencies, raw runtime `VERSION`,
+mock provider, proxy, probe, and added helper files. Required entrypoints must
+be regular files. The runtime `VERSION` must exist and be nonempty. Unexpected
+top-level entries, special files, broken links, and links outside the overlay
+are rejected before a task container starts.
+
+The manifest digest uses the canonical JSON domain
+`agenc.eval.executor-overlay-manifest.v1`. Real-provider reports use that same
+digest for `egress.sidecarOverlayDigest` and the overlay input to
+`environmentDigest`. Offline reports use it in their environment digest too.
+The complete manifest is part of `reportDigest`. Changing a sidecar program,
+probe, runtime file, dependency, Node binary, library, or internal link changes
+the attestation.
+
+This records the staged inputs before execution. The operator must keep the
+host overlay unchanged during the run. A read-only container mount does not
+prevent a host process from editing the source directory, and the manifest
+does not claim authenticity against a malicious host.
 
 Config via env (delivered by `-e`): `AGENC_PROXY_ALLOW_HOST` (exact host),
 `AGENC_PROXY_ALLOW_PORT` (443), `AGENC_PROXY_PIN_IPS` (host-resolved A

--- a/docs/design/eval-pilot-executor.md
+++ b/docs/design/eval-pilot-executor.md
@@ -147,9 +147,12 @@ with the hidden verifier — all offline.
 - **Overlay:** the operator stages a directory with `node/` (official Node 26
   linux-x64), `runtime/` (extracted `agenc-runtime-*-linux-x64` release
   tarball), and `mock/serve.mjs` (the bundled offline provider). It is
-  bind-mounted read-only at `/agenc-overlay`. `assertOverlayLayout` checks the
-  three required entrypoints; `computeOverlayDigest` records which `agenc.js`
-  build was evaluated in the run report.
+  bind-mounted read-only at `/agenc-overlay`. `assertOverlayLayout` validates
+  the complete versioned manifest, including required entrypoints and a
+  nonempty runtime `VERSION`. Reports record every regular file and internal
+  symlink, including dependencies, Node, and compatibility libraries. The
+  manifest digest binds those inputs into the environment digest. See the
+  [overlay manifest contract](eval-pilot-executor-phase2b-egress.md#overlay-manifest).
 - **Provider:** always the in-container offline mock (`--network none`). There
   are no secrets in any container and no egress. This lane validates the
   pipeline mechanically; it does not yet measure a real model.

--- a/docs/eval/real-agent-baseline-runbook.md
+++ b/docs/eval/real-agent-baseline-runbook.md
@@ -107,6 +107,13 @@ Resume validates the full report schema, task ID, `sourceTaskDigest`, and
 including its base commit, image, issue text, and artifact digests. An offline
 mock-provider report cannot stand in for a real-provider result.
 
+New reports also carry the versioned `overlayManifest`. Resume checks its
+required components and execution mode, then recomputes its digest and checks
+the sidecar digest. Legacy reports without this manifest are rejected with a
+recovery message. Preserve them for inspection and rerun in a new output
+directory. Do not add a manifest to an old report or recompute its stored digest
+as a substitute for running the attested overlay.
+
 An unreadable, malformed, incomplete, oversized, or mismatched report becomes
 a `driver_error`. The executor leaves its task directory unchanged and does
 not pull an image, refresh a key, or run that task. Other tasks continue.

--- a/runtime/src/eval-executor/agent-run-report.ts
+++ b/runtime/src/eval-executor/agent-run-report.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import { digestCanonicalJson, type Sha256Digest } from "../eval-contract/index.js";
 import { EvalExecutorError } from "./source-lock.js";
+import { computeOverlayManifestDigest, OverlayManifestSchema } from "./overlay-manifest.js";
 import type { AgentRunReport, PilotSourceLockTask } from "./types.js";
 
 export const REPORT_DIGEST_DOMAIN = "agenc.eval.executor-agent-run-report.v1";
@@ -69,6 +70,7 @@ const ReportSchema = z.strictObject({
     patchKeyScan: z.enum(["clean", "key-substring-found", "not-run"]),
   }).nullable(),
   environmentDigest: DigestSchema,
+  overlayManifest: OverlayManifestSchema,
   reportDigest: DigestSchema,
 }) satisfies z.ZodType<AgentRunReport>;
 
@@ -77,11 +79,19 @@ export function computeSourceTaskDigest(task: PilotSourceLockTask): Sha256Digest
 }
 
 export function validateAgentRunReport(value: unknown, task: PilotSourceLockTask): AgentRunReport {
+  if (typeof value === "object" && value !== null && !("overlayManifest" in value)) {
+    throw new EvalExecutorError(["Agent run report lacks the versioned overlay manifest; preserve the old report and rerun in a new output directory"]);
+  }
   const parsed = ReportSchema.safeParse(value);
   if (!parsed.success) {
     throw new EvalExecutorError(["Agent run report does not match the complete report schema"]);
   }
   const report = parsed.data;
+  if ((report.egress === null) !== (report.overlayManifest.mode === "offline") || (
+    report.egress !== null && report.egress.sidecarOverlayDigest !== computeOverlayManifestDigest(report.overlayManifest)
+  )) {
+    throw new EvalExecutorError(["Agent run report overlay manifest does not match its execution mode or sidecar digest"]);
+  }
   if (report.taskId !== task.instanceId || report.sourceTaskDigest !== computeSourceTaskDigest(task)) {
     throw new EvalExecutorError(["Agent run report does not match the source-lock task"]);
   }

--- a/runtime/src/eval-executor/agent-run.ts
+++ b/runtime/src/eval-executor/agent-run.ts
@@ -1,4 +1,3 @@
-import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { digestCanonicalJson, sha256Digest, type Sha256Digest } from "../eval-contract/index.js";
 import {
@@ -18,6 +17,7 @@ import {
 } from "./egress.js";
 import { EvalExecutorError } from "./source-lock.js";
 import { computeSourceTaskDigest, REPORT_DIGEST_DOMAIN } from "./agent-run-report.js";
+import { computeOverlayManifestDigest, readOverlayManifest } from "./overlay-manifest.js";
 import type {
   AgentRunOutcome,
   AgentRunReport,
@@ -34,7 +34,6 @@ import {
   AGENT_HELPER_DIR,
   AGENT_HOME,
   AGENT_RUNTIME_ENTRY,
-  OVERLAY_AGENT_ENTRY_SUBPATH,
   OVERLAY_CONTAINER_PATH,
   OVERLAY_NODE,
   OVERLAY_NODE_COMPAT_LIB,
@@ -110,51 +109,7 @@ export async function assertOverlayLayout(
   overlay: AgentOverlay,
   options: { readonly egress?: boolean } = {},
 ): Promise<void> {
-  const required = [
-    path.join(overlay.hostDir, "node", "bin", "node"),
-    // Shim for task images that lack libatomic.so.1 (portable Node needs
-    // it); missing staging fails fast here instead of as an opaque loader
-    // error inside the container.
-    path.join(overlay.hostDir, "node", "compat", "libatomic.so.1"),
-    path.join(overlay.hostDir, OVERLAY_AGENT_ENTRY_SUBPATH),
-    path.join(overlay.hostDir, "mock", "serve.mjs"),
-    // The real-model lane also needs the proxy sidecar and containment probe.
-    ...(options.egress
-      ? [
-        path.join(overlay.hostDir, "proxy", "allowlist-proxy.mjs"),
-        path.join(overlay.hostDir, "proxy", "eval-egress-probe.mjs"),
-      ]
-      : []),
-  ];
-  for (const file of required) {
-    try {
-      await access(file);
-    } catch {
-      throw new EvalExecutorError([`agent overlay is missing ${file}`]);
-    }
-  }
-}
-
-/**
- * Attest which agent build is under test by digesting the overlay's runtime
- * entrypoint (and its VERSION when present). Without this the report cannot
- * say which agenc.js produced an outcome.
- */
-async function computeOverlayDigest(overlay: AgentOverlay): Promise<Sha256Digest> {
-  const entry = await readFile(path.join(overlay.hostDir, OVERLAY_AGENT_ENTRY_SUBPATH));
-  let version = "";
-  try {
-    version = await readFile(
-      path.join(overlay.hostDir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "VERSION"),
-      "utf8",
-    );
-  } catch {
-    version = "unknown";
-  }
-  return digestCanonicalJson("agenc.eval.executor-agent-overlay.v1", {
-    entryDigest: sha256Digest(entry),
-    version: version.trim(),
-  });
+  await readOverlayManifest(overlay, options);
 }
 
 /**
@@ -424,10 +379,10 @@ export async function runAgentOnTask(
   timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
   options: PreflightExecutionOptions = {},
 ): Promise<AgentRunArtifacts> {
-  await assertOverlayLayout(config.overlay);
+  const overlayManifest = await readOverlayManifest(config.overlay);
   const startedAt = new Date().toISOString();
   const environment = await runner.environment();
-  const overlayDigest = await computeOverlayDigest(config.overlay);
+  const overlayDigest = computeOverlayManifestDigest(overlayManifest);
   const environmentDigest = digestCanonicalJson(ENVIRONMENT_DIGEST_DOMAIN, {
     ...environment,
     image: inputs.task.image,
@@ -503,6 +458,7 @@ export async function runAgentOnTask(
     outcome: outcome ?? "infrastructure_error",
     failureDetail,
     egress: null,
+    overlayManifest,
     environmentDigest,
   };
   const report: AgentRunReport = {
@@ -612,7 +568,7 @@ export async function runRealProviderAgentOnTask(
   timeouts: PreflightTimeouts = DEFAULT_PREFLIGHT_TIMEOUTS,
   options: PreflightExecutionOptions = {},
 ): Promise<AgentRunArtifacts> {
-  await assertOverlayLayout(config.overlay, { egress: true });
+  const overlayManifest = await readOverlayManifest(config.overlay, { egress: true });
   const secret = process.env[config.keyEnvVar];
   if (secret === undefined || secret.length === 0) {
     throw new EvalExecutorError([`${config.keyEnvVar} is not set in the executor environment`]);
@@ -629,7 +585,7 @@ export async function runRealProviderAgentOnTask(
   assertProviderBaseUrl(config);
   const startedAt = new Date().toISOString();
   const environment = await runner.environment();
-  const overlayDigest = await computeOverlayDigest(config.overlay);
+  const overlayDigest = computeOverlayManifestDigest(overlayManifest);
   const environmentDigest = digestCanonicalJson(ENVIRONMENT_DIGEST_DOMAIN, {
     ...environment,
     image: inputs.task.image,
@@ -749,6 +705,7 @@ export async function runRealProviderAgentOnTask(
     outcome: outcome ?? "infrastructure_error",
     failureDetail,
     egress,
+    overlayManifest,
     environmentDigest,
   };
   const report: AgentRunReport = {

--- a/runtime/src/eval-executor/overlay-manifest.ts
+++ b/runtime/src/eval-executor/overlay-manifest.ts
@@ -93,6 +93,15 @@ async function hashFile(filePath: string, expected: Stats): Promise<Sha256Digest
   }
 }
 
+async function readInternalLink(root: string, filePath: string, relativePath: string): Promise<OverlayManifest["links"][number]> {
+  const target = await readlink(filePath);
+  const resolved = path.relative(root, await realpath(filePath));
+  if (path.isAbsolute(target) || resolved === ".." || resolved.startsWith(`..${path.sep}`) || path.isAbsolute(resolved)) {
+    throw new EvalExecutorError([`agent overlay link escapes its root: ${relativePath}`]);
+  }
+  return { path: relativePath, target };
+}
+
 export async function readOverlayManifest(
   overlay: { readonly hostDir: string },
   options: { readonly egress?: boolean } = {},
@@ -116,12 +125,7 @@ export async function readOverlayManifest(
         if (metadata.isDirectory()) {
           await visit(filePath, relativePath);
         } else if (metadata.isSymbolicLink()) {
-          const target = await readlink(filePath);
-          const resolved = path.relative(root, await realpath(filePath));
-          if (path.isAbsolute(target) || resolved === ".." || resolved.startsWith(`..${path.sep}`) || path.isAbsolute(resolved)) {
-            throw new EvalExecutorError([`agent overlay link escapes its root: ${relativePath}`]);
-          }
-          links.push({ path: relativePath, target });
+          links.push(await readInternalLink(root, filePath, relativePath));
         } else if (metadata.isFile()) {
           files.push({
             path: relativePath, digest: await hashFile(filePath, metadata),

--- a/runtime/src/eval-executor/overlay-manifest.ts
+++ b/runtime/src/eval-executor/overlay-manifest.ts
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto";
+import { constants, type Stats } from "node:fs";
+import { lstat, open, readdir, readlink, realpath } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod/v4";
+import { digestCanonicalJson, type Sha256Digest } from "../eval-contract/index.js";
+import { OVERLAY_AGENT_ENTRY_SUBPATH } from "./overlay-paths.js";
+import { EvalExecutorError } from "./source-lock.js";
+
+const ROOTS = new Set(["node", "runtime", "mock", "proxy"]);
+export const OVERLAY_VERSION_SUBPATH = "runtime/node_modules/@tetsuo-ai/runtime/dist/VERSION";
+const REQUIRED_FILES = [
+  "node/bin/node", "node/compat/libatomic.so.1", OVERLAY_AGENT_ENTRY_SUBPATH,
+  OVERLAY_VERSION_SUBPATH, "mock/serve.mjs",
+];
+const EGRESS_FILES = ["proxy/allowlist-proxy.mjs", "proxy/eval-egress-probe.mjs"];
+const PathSchema = z.string().refine((value) => (
+  !/[\\\u0000-\u001f\u007f]/u.test(value) &&
+  ROOTS.has(value.split("/")[0] ?? "") &&
+  value.split("/").every((component) => component !== "" && component !== "." && component !== "..")
+));
+const DigestSchema = z.custom<Sha256Digest>(
+  (value) => typeof value === "string" && /^sha256:[0-9a-f]{64}$/u.test(value),
+);
+
+export const OverlayManifestSchema = z.strictObject({
+  kind: z.literal("agenc.eval.executor-overlay-manifest"),
+  version: z.literal("1.0.0"),
+  mode: z.enum(["offline", "real-provider"]),
+  files: z.array(z.strictObject({
+    path: PathSchema,
+    digest: DigestSchema,
+    sizeBytes: z.number().int().nonnegative(),
+    mode: z.number().int().min(0).max(0o7777),
+  })),
+  links: z.array(z.strictObject({ path: PathSchema, target: z.string().min(1) })),
+}).superRefine((manifest, context) => {
+  const names = new Set<string>();
+  for (const entries of [manifest.files, manifest.links]) {
+    let previous = "";
+    for (const entry of entries) {
+      if (entry.path <= previous || names.has(entry.path)) {
+        context.addIssue({ code: "custom", message: "overlay entries must be sorted and unique" });
+      }
+      previous = entry.path;
+      names.add(entry.path);
+    }
+  }
+  for (const link of manifest.links) {
+    const target = path.posix.join(path.posix.dirname(link.path), link.target);
+    if (path.posix.isAbsolute(link.target) || !PathSchema.safeParse(target).success) {
+      context.addIssue({ code: "custom", message: "overlay links must stay within known overlay roots" });
+    }
+  }
+  const files = new Map(manifest.files.map((file) => [file.path, file]));
+  for (const required of [...REQUIRED_FILES, ...(manifest.mode === "real-provider" ? EGRESS_FILES : [])]) {
+    if (!files.has(required)) {
+      context.addIssue({ code: "custom", message: `agent overlay is missing regular file ${required}` });
+    }
+  }
+  if (files.get(OVERLAY_VERSION_SUBPATH)?.sizeBytes === 0) {
+    context.addIssue({ code: "custom", message: "agent overlay VERSION is empty" });
+  }
+});
+
+export type OverlayManifest = z.infer<typeof OverlayManifestSchema>;
+
+export function computeOverlayManifestDigest(manifest: OverlayManifest): Sha256Digest {
+  return digestCanonicalJson("agenc.eval.executor-overlay-manifest.v1", manifest);
+}
+
+function sameFile(before: Stats, after: Stats): boolean {
+  return after.isFile() && before.dev === after.dev && before.ino === after.ino &&
+    before.size === after.size && before.mode === after.mode &&
+    before.mtimeMs === after.mtimeMs && before.ctimeMs === after.ctimeMs;
+}
+
+async function hashFile(filePath: string, expected: Stats): Promise<Sha256Digest> {
+  const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+  const handle = await open(filePath, constants.O_RDONLY | noFollow);
+  try {
+    if (!sameFile(expected, await handle.stat())) {
+      throw new EvalExecutorError([`agent overlay changed while reading ${filePath}`]);
+    }
+    const hash = createHash("sha256");
+    for await (const chunk of handle.createReadStream({ autoClose: false })) hash.update(chunk);
+    if (!sameFile(expected, await handle.stat()) || !sameFile(expected, await lstat(filePath))) {
+      throw new EvalExecutorError([`agent overlay changed while reading ${filePath}`]);
+    }
+    return `sha256:${hash.digest("hex")}`;
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function readOverlayManifest(
+  overlay: { readonly hostDir: string },
+  options: { readonly egress?: boolean } = {},
+): Promise<OverlayManifest> {
+  try {
+    const root = await realpath(overlay.hostDir);
+    const files: OverlayManifest["files"] = [];
+    const links: OverlayManifest["links"] = [];
+    const visit = async (directory: string, prefix: string): Promise<void> => {
+      const entries = await readdir(directory);
+      for (const name of entries.sort()) {
+        if (prefix === "" && !ROOTS.has(name)) {
+          throw new EvalExecutorError([`unexpected agent overlay entry ${name}`]);
+        }
+        const relativePath = prefix === "" ? name : `${prefix}/${name}`;
+        const filePath = path.join(directory, name);
+        const metadata = await lstat(filePath);
+        if (prefix === "" && !metadata.isDirectory()) {
+          throw new EvalExecutorError([`agent overlay root ${name} must be a directory`]);
+        }
+        if (metadata.isDirectory()) {
+          await visit(filePath, relativePath);
+        } else if (metadata.isSymbolicLink()) {
+          const target = await readlink(filePath);
+          const resolved = path.relative(root, await realpath(filePath));
+          if (path.isAbsolute(target) || resolved === ".." || resolved.startsWith(`..${path.sep}`) || path.isAbsolute(resolved)) {
+            throw new EvalExecutorError([`agent overlay link escapes its root: ${relativePath}`]);
+          }
+          links.push({ path: relativePath, target });
+        } else if (metadata.isFile()) {
+          files.push({
+            path: relativePath, digest: await hashFile(filePath, metadata),
+            sizeBytes: metadata.size, mode: metadata.mode & 0o7777,
+          });
+        } else {
+          throw new EvalExecutorError([`unsupported agent overlay entry ${relativePath}`]);
+        }
+      }
+    };
+    await visit(root, "");
+    const byPath = (first: { path: string }, second: { path: string }) => {
+      if (first.path === second.path) return 0;
+      return first.path < second.path ? -1 : 1;
+    };
+    const parsed = OverlayManifestSchema.safeParse({
+      kind: "agenc.eval.executor-overlay-manifest", version: "1.0.0",
+      mode: options.egress ? "real-provider" : "offline",
+      files: files.sort(byPath), links: links.sort(byPath),
+    });
+    if (!parsed.success) {
+      throw new EvalExecutorError(parsed.error.issues.map((issue) => issue.message));
+    }
+    return parsed.data;
+  } catch (error) {
+    if (error instanceof EvalExecutorError) throw error;
+    throw new EvalExecutorError([`cannot attest agent overlay: ${error instanceof Error ? error.message : String(error)}`]);
+  }
+}

--- a/runtime/src/eval-executor/types.ts
+++ b/runtime/src/eval-executor/types.ts
@@ -1,4 +1,5 @@
 import type { Sha256Digest } from "../eval-contract/index.js";
+import type { OverlayManifest } from "./overlay-manifest.js";
 
 /** Media types pinned by the frozen pilot source lock. */
 export const PILOT_SOURCE_LOCK_KIND = "agenc.eval.pilot-source-lock";
@@ -301,6 +302,7 @@ export interface AgentRunReport {
   readonly failureDetail: string | null;
   /** Present only for the real-provider lane; null for the offline mock lane. */
   readonly egress: EgressReport | null;
+  readonly overlayManifest: OverlayManifest;
   readonly environmentDigest: Sha256Digest;
   readonly reportDigest: Sha256Digest;
 }

--- a/runtime/tests/eval/eval-executor-agent-run.test.ts
+++ b/runtime/tests/eval/eval-executor-agent-run.test.ts
@@ -188,6 +188,7 @@ async function makeOverlay(): Promise<string> {
   );
   await mkdir(runtimeBin, { recursive: true });
   await writeFile(path.join(runtimeBin, "agenc.js"), "// fake agent build\n");
+  await writeFile(path.join(runtimeBin, "..", "VERSION"), "0.17.0\n");
   await mkdir(path.join(dir, "mock"), { recursive: true });
   await writeFile(path.join(dir, "mock", "serve.mjs"), "");
   return dir;

--- a/runtime/tests/eval/eval-executor-batch.test.ts
+++ b/runtime/tests/eval/eval-executor-batch.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { createRealAgentBatchDeps, runRealAgentBatch, type RealAgentBatchDeps } from "../../src/eval-executor/batch.js";
 import { digestCanonicalJson } from "../../src/eval-contract/index.js";
+import { computeOverlayManifestDigest, type OverlayManifest } from "../../src/eval-executor/overlay-manifest.js";
 import type { AgentRunOutcome, AgentRunReport, LoadedPilotSourceLock, PilotSourceLockTask } from "../../src/eval-executor/types.js";
 import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
 
@@ -11,6 +12,16 @@ const workspaces = createTempWorkspaceFixture("agenc-batch-resume-");
 afterEach(async () => { await workspaces.cleanup(); });
 
 function makeReport(task: PilotSourceLockTask, outcome: AgentRunOutcome = "verified_fix") {
+  const overlayManifest: OverlayManifest = {
+    kind: "agenc.eval.executor-overlay-manifest", version: "1.0.0", mode: "real-provider",
+    files: [
+      "node/bin/node", "node/compat/libatomic.so.1", "mock/serve.mjs",
+      "runtime/node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
+      "runtime/node_modules/@tetsuo-ai/runtime/dist/VERSION",
+      "proxy/allowlist-proxy.mjs", "proxy/eval-egress-probe.mjs",
+    ].sort().map((filePath) => ({ path: filePath, digest: digestOf("d"), sizeBytes: 1, mode: 0o644 })),
+    links: [],
+  };
   const reportBody = {
     taskId: task.instanceId,
     sourceTaskDigest: digestCanonicalJson("agenc.eval.executor-source-task.v1", task),
@@ -30,7 +41,7 @@ function makeReport(task: PilotSourceLockTask, outcome: AgentRunOutcome = "verif
     failureDetail: outcome === "verified_fix" ? null : "test failure",
     egress: {
       mode: "real-provider" as const, allowHost: "provider.invalid", keyExposure: "agent-env" as const,
-      sidecarOverlayDigest: digestOf("d"), oracleContainment: "contained" as const,
+      sidecarOverlayDigest: computeOverlayManifestDigest(overlayManifest), oracleContainment: "contained" as const,
       denyProbes: {
         noRouteOffNet: true, githubBlocked: true, dnsBlackholed: true,
         ipv6Absent: true, ipLiteralRejected: true, sniPinned: true,
@@ -38,6 +49,7 @@ function makeReport(task: PilotSourceLockTask, outcome: AgentRunOutcome = "verif
       patchKeyScan: "clean" as const,
     },
     environmentDigest: digestOf("e"),
+    overlayManifest,
   };
   return {
     ...reportBody,
@@ -170,6 +182,10 @@ describe("eval executor real-agent batch", () => {
     ["wrong task", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { taskId: "t-other" })],
     ["wrong source task", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { sourceTaskDigest: digestOf("f") })],
     ["legacy unbound", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { sourceTaskDigest: undefined })],
+    ["legacy unattested overlay", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { overlayManifest: undefined })],
+    ["mismatched overlay digest", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { egress: { ...report.egress, sidecarOverlayDigest: digestOf("f") } })],
+    ["wrong overlay lane", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { overlayManifest: { ...report.overlayManifest, mode: "offline" } })],
+    ["unsupported overlay manifest", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { overlayManifest: { ...report.overlayManifest, version: "0.0.0" } })],
     ["incomplete agent", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { agent: {} })],
     ["invalid outcome", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { outcome: "success" })],
     ["invalid timestamp", (report: ReturnType<typeof makeReport>) => serializeChangedReport(report, { finishedAt: "yesterday" })],

--- a/runtime/tests/eval/eval-executor-egress.test.ts
+++ b/runtime/tests/eval/eval-executor-egress.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -238,6 +238,7 @@ describe("real-provider lane gating (fake lane, no docker)", () => {
     const bin = path.join(overlayDir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "bin");
     await mkdir(bin, { recursive: true });
     await writeFile(path.join(bin, "agenc.js"), "");
+    await writeFile(path.join(bin, "..", "VERSION"), "0.17.0\n");
     await mkdir(path.join(overlayDir, "mock"), { recursive: true });
     await writeFile(path.join(overlayDir, "mock", "serve.mjs"), "");
     await mkdir(path.join(overlayDir, "proxy"), { recursive: true });
@@ -289,6 +290,43 @@ describe("real-provider lane gating (fake lane, no docker)", () => {
     expect(state.tornDown).toBe(true);
     // The agent script (HTTPS_PROXY + agenc.js) must never have run.
     expect(runner.execs.some((e) => e.script.includes("HTTPS_PROXY"))).toBe(false);
+  });
+
+  test.each([
+    "node/bin/node", "node/compat/libatomic.so.1", "mock/serve.mjs",
+    "runtime/node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
+    "runtime/node_modules/@tetsuo-ai/runtime/dist/VERSION",
+    "proxy/allowlist-proxy.mjs", "proxy/eval-egress-probe.mjs",
+  ])("binds a one-byte change to %s into both reported environment digests", async (relativePath) => {
+    const runner = new FakeRunner("");
+    const { factory } = laneFactory(ALL_TRUE, runner);
+    const first = await runRealProviderAgentOnTask(runner, factory, inputs(), config());
+    const identical = await runRealProviderAgentOnTask(runner, factory, inputs(), config());
+    expect(identical.report.egress?.sidecarOverlayDigest).toBe(first.report.egress?.sidecarOverlayDigest);
+    expect(identical.report.environmentDigest).toBe(first.report.environmentDigest);
+    await appendFile(path.join(overlayDir, relativePath), "1");
+    const changed = await runRealProviderAgentOnTask(runner, factory, inputs(), config());
+    expect(changed.report.egress?.sidecarOverlayDigest).not.toBe(first.report.egress?.sidecarOverlayDigest);
+    expect(changed.report.environmentDigest).not.toBe(first.report.environmentDigest);
+  });
+
+  test("binds added runtime helpers into the reported environment", async () => {
+    const runner = new FakeRunner("");
+    const { factory } = laneFactory(ALL_TRUE, runner);
+    const first = await runRealProviderAgentOnTask(runner, factory, inputs(), config());
+    await writeFile(path.join(overlayDir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "helper.mjs"), "export const value = 1;\n");
+    const changed = await runRealProviderAgentOnTask(runner, factory, inputs(), config());
+    expect(changed.report.egress?.sidecarOverlayDigest).not.toBe(first.report.egress?.sidecarOverlayDigest);
+    expect(changed.report.environmentDigest).not.toBe(first.report.environmentDigest);
+  });
+
+  test("rejects a missing runtime VERSION before creating a lane", async () => {
+    await rm(path.join(overlayDir, "runtime", "node_modules", "@tetsuo-ai", "runtime", "dist", "VERSION"));
+    const runner = new FakeRunner("");
+    let created = false;
+    const factory = async (): Promise<EgressLane> => { created = true; throw new Error("must not create lane"); };
+    await expect(runRealProviderAgentOnTask(runner, factory, inputs(), config())).rejects.toThrow(/VERSION/u);
+    expect(created).toBe(false);
   });
 
   test("passing probes + empty patch is contained; key delivered via envPassthrough, never in argv", async () => {

--- a/runtime/tests/eval/eval-executor-overlay-manifest.test.ts
+++ b/runtime/tests/eval/eval-executor-overlay-manifest.test.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from "node:child_process";
+import { chmod, mkdir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { sha256Digest } from "../../src/eval-contract/index.js";
+import { computeOverlayManifestDigest, OverlayManifestSchema, readOverlayManifest } from "../../src/eval-executor/overlay-manifest.js";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-overlay-manifest-");
+const COMPONENTS = [
+  "node/bin/node", "node/compat/libatomic.so.1", "mock/serve.mjs",
+  "runtime/node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
+  "runtime/node_modules/@tetsuo-ai/runtime/dist/VERSION",
+  "proxy/allowlist-proxy.mjs", "proxy/eval-egress-probe.mjs",
+];
+afterEach(async () => { await workspaces.cleanup(); });
+
+async function fixture(reverse = false) {
+  const hostDir = await workspaces.create();
+  for (const name of reverse ? [...COMPONENTS].reverse() : COMPONENTS) {
+    const filePath = path.join(hostDir, name);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${name}\n`, { mode: 0o644 });
+  }
+  return { hostDir };
+}
+
+describe("versioned overlay manifest", () => {
+  test("records every raw file digest and is stable across locations and creation order", async () => {
+    const firstOverlay = await fixture();
+    const first = await readOverlayManifest(firstOverlay, { egress: true });
+    const second = await readOverlayManifest(await fixture(true), { egress: true });
+    expect(first).toEqual(second);
+    expect(computeOverlayManifestDigest(first)).toBe(computeOverlayManifestDigest(second));
+    expect(first).toMatchObject({ kind: "agenc.eval.executor-overlay-manifest", version: "1.0.0", mode: "real-provider", links: [] });
+    expect(first.files).toEqual(await Promise.all([...COMPONENTS].sort().map(async (name) => ({
+      path: name, digest: sha256Digest(`${name}\n`), sizeBytes: Buffer.byteLength(`${name}\n`),
+      mode: (await stat(path.join(firstOverlay.hostDir, name))).mode & 0o7777,
+    }))));
+    const offline = await readOverlayManifest(await fixture());
+    expect(offline.mode).toBe("offline");
+    expect(computeOverlayManifestDigest(offline)).not.toBe(computeOverlayManifestDigest(first));
+  });
+
+  test.each(COMPONENTS)("rejects missing required file %s", async (name) => {
+    const overlay = await fixture();
+    await rm(path.join(overlay.hostDir, name));
+    await expect(readOverlayManifest(overlay, { egress: true })).rejects.toThrow(name);
+  });
+
+  test("rejects an empty VERSION instead of fabricating a version", async () => {
+    const overlay = await fixture();
+    await writeFile(path.join(overlay.hostDir, "runtime/node_modules/@tetsuo-ai/runtime/dist/VERSION"), "");
+    await expect(readOverlayManifest(overlay)).rejects.toThrow(/VERSION is empty/u);
+  });
+
+  test("rejects unexpected roots and non-directory root entries", async () => {
+    const overlay = await fixture();
+    await writeFile(path.join(overlay.hostDir, "unlisted-helper.mjs"), "unexpected");
+    await expect(readOverlayManifest(overlay)).rejects.toThrow(/unexpected agent overlay/u);
+    await rm(path.join(overlay.hostDir, "unlisted-helper.mjs"));
+    await rm(path.join(overlay.hostDir, "proxy"), { recursive: true });
+    await writeFile(path.join(overlay.hostDir, "proxy"), "not a directory");
+    await expect(readOverlayManifest(overlay)).rejects.toThrow(/must be a directory/u);
+  });
+
+  test("schema rejects duplicate entries, unsafe paths, unsupported versions, and missing components", async () => {
+    const manifest = await readOverlayManifest(await fixture(), { egress: true });
+    for (const changed of [
+      { ...manifest, files: [...manifest.files, manifest.files[0]] },
+      { ...manifest, files: manifest.files.slice(1) },
+      { ...manifest, version: "0.0.0" },
+      { ...manifest, files: [{ ...manifest.files[0], path: "../outside" }, ...manifest.files.slice(1)] },
+      { ...manifest, links: [{ path: "node/bin/extra", target: "../../../outside" }] },
+    ]) expect(OverlayManifestSchema.safeParse(changed).success).toBe(false);
+  });
+});
+
+describe.runIf(process.platform !== "win32")("overlay filesystem identity", () => {
+  test("binds executable mode changes", async () => {
+    const overlay = await fixture();
+    const first = await readOverlayManifest(overlay);
+    await chmod(path.join(overlay.hostDir, "node/bin/node"), 0o755);
+    const changed = await readOverlayManifest(overlay);
+    expect(computeOverlayManifestDigest(changed)).not.toBe(computeOverlayManifestDigest(first));
+  });
+
+  test("records internal symlinks without traversing directory aliases", async () => {
+    const overlay = await fixture();
+    await symlink("node", path.join(overlay.hostDir, "node/bin/node-alias"));
+    await symlink("bin", path.join(overlay.hostDir, "node/bin-alias"));
+    const manifest = await readOverlayManifest(overlay);
+    expect(manifest.links).toEqual([
+      { path: "node/bin-alias", target: "bin" }, { path: "node/bin/node-alias", target: "node" },
+    ]);
+    expect(manifest.files).toHaveLength(COMPONENTS.length);
+    await rm(path.join(overlay.hostDir, "node/bin/node-alias"));
+    await symlink("../compat/libatomic.so.1", path.join(overlay.hostDir, "node/bin/node-alias"));
+    expect(computeOverlayManifestDigest(await readOverlayManifest(overlay))).not.toBe(computeOverlayManifestDigest(manifest));
+  });
+
+  test.each(["outside", "broken", "loop"])("rejects %s symlinks", async (kind) => {
+    const overlay = await fixture();
+    const outside = await workspaces.create();
+    await writeFile(path.join(outside, "helper"), "outside");
+    const linkPath = path.join(overlay.hostDir, "node/bin/extra");
+    const targets = {
+      outside: path.relative(path.dirname(linkPath), path.join(outside, "helper")),
+      broken: "missing", loop: "extra",
+    };
+    await symlink(targets[kind as keyof typeof targets], linkPath);
+    await expect(readOverlayManifest(overlay)).rejects.toThrow(/overlay/u);
+  });
+
+  test("rejects special files without opening a blocking FIFO", async () => {
+    const overlay = await fixture();
+    execFileSync("mkfifo", [path.join(overlay.hostDir, "node/bin/extra")]);
+    await expect(readOverlayManifest(overlay)).rejects.toThrow(/unsupported agent overlay entry/u);
+  });
+});


### PR DESCRIPTION
## Changes

- Replace the entrypoint-only hash with a versioned overlay manifest containing every regular file's relative path, exact byte digest, size, and permission mode, plus internal symlink targets.
- Include the complete Node distribution, compatibility libraries, runtime and dependencies, raw VERSION, mock provider, proxy, probe, and any added helper files. Reject missing required files, empty VERSION, unexpected roots, special files, broken links, and escaping links before container creation.
- Persist the manifest in both execution lanes. Use its canonical digest in the environment and sidecar fields, and check the sidecar binding and lane during report validation.
- Fail closed on old reports without a manifest. Preserve old evidence and rerun in a new output directory rather than rewriting digests. Document that operators must keep the host overlay unchanged during execution.

## Validation

- Original source failed seven regressions, with 32 controls passing. One-byte changes to the proxy, probe, Node binary, compatibility library, and mock were previously invisible; added runtime helpers and missing VERSION also reproduced the defect.
- Regression tests cover real report generation, raw component digests, identical overlays in different directories, modes, internal symlinks, path escapes, special files, and resume validation.
- Both runtime typechecks, dedicated typechecking of all four changed test files, and 174 targeted tests across 11 files pass in the local hermetic container.
- Final head 6966503ff9666a51c25c5f55164be37408b8bd4c passes build, PTY startup, and all 24,079 tests across 2,302 runtime files after root and launcher checks. The initial head also passed the full suite. Linux native checks pass 92 tests across five files on the initial head; the final symlink-helper extraction does not change their inputs. No macOS or Windows result is claimed.
- The initial head received an APPROVED review. After the behavior-preserving extraction requested by Sonar, final-head Bugbot independently completed with no findings, and the final-head Security Reviewer completed successfully. Sonar's actual final gate is OK, with zero new issues and zero new duplication.
- Hosted Actions remain disabled, with zero Actions runs on either head. No real provider or credentials are used. No admin override or branch-rule bypass is used.
- The benchmark baseline and measured source inputs are unchanged.

Closes #2084.
