### PR TITLE
fix(eval): constrain task IDs and guard artifact output paths

### DIFF
--- a/docs/eval/real-agent-baseline-runbook.md
+++ b/docs/eval/real-agent-baseline-runbook.md
@@ -102,6 +102,27 @@ the bound for a specific exec.
 
 ## Invalid resume reports
 
+Source-lock `instanceId` values must be 1 to 128 ASCII characters, start with a
+letter or digit, and contain only letters, digits, periods, underscores, and
+hyphens. Trailing periods and Windows device names are rejected. IDs must also
+be unique when compared without case. These constraints keep each ID a single
+portable directory name; Windows also reserves device names with extensions.
+See [Microsoft's filename rules](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file).
+
+The loader validates IDs even when the source-lock self-digest is correct.
+Preflight, both agent lanes, and batch resume use the same guarded task-output
+directory helpers. They reject linked directories and check pinned directory
+identities before each operation. Reads remain bounded; writes use checked
+file descriptors and reject symlinks, hardlinks, and special files. New task
+artifacts still use exclusive creation. Batch progress appends and summary
+replacement use the same file checks.
+
+Keep output roots under operator control during a run. Directory identity
+checks detect replacements but do not provide a cross-platform directory lock
+against a malicious host. Unsafe legacy IDs must be corrected in a regenerated
+source lock, with its digest recomputed, before execution. Preserve any earlier
+reports rather than moving them into a differently identified task directory.
+
 Resume validates the full report schema, task ID, `sourceTaskDigest`, and
 `reportDigest`. The source-task digest binds every field of the locked task,
 including its base commit, image, issue text, and artifact digests. An offline

--- a/runtime/src/eval-executor/batch.ts
+++ b/runtime/src/eval-executor/batch.ts
@@ -1,11 +1,11 @@
 import { execFile } from "node:child_process";
-import { appendFile, lstat, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import { EvalExecutorError, findPilotTask } from "./source-lock.js";
-import { decodeStrictJson, readBoundedRegularFile } from "../eval-pilot/safe-io.js";
+import { assertPilotInstanceId, EvalExecutorError, findPilotTask } from "./source-lock.js";
+import { decodeStrictJson } from "../eval-pilot/safe-io.js";
 import { validateAgentRunReport } from "./agent-run-report.js";
 import { EVAL_EXECUTOR_MAXIMUM_ARTIFACT_BYTES, type AgentRunReport, type LoadedPilotSourceLock, type PilotSourceLockTask } from "./types.js";
+import { findTaskOutputDirectory, prepareOutputDirectory, readTaskOutputFile, writeTaskOutputFile } from "./task-output.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -119,7 +119,6 @@ export function createRealAgentBatchDeps(options: {
   readonly keyCommand?: string;
   readonly runTask: (taskId: string) => Promise<{ readonly outcome: string }>;
 }): RealAgentBatchDeps {
-  const progressLog = path.join(options.outputDir, "batch-progress.log");
   return {
     runTask: options.runTask,
     pullImage: async (imageReference) => {
@@ -128,20 +127,19 @@ export function createRealAgentBatchDeps(options: {
       });
     },
     loadReport: async (task) => {
+      assertPilotInstanceId(task.instanceId);
       const taskDir = path.join(options.outputDir, task.instanceId);
       const reportPath = path.join(taskDir, "agent-run-report.json");
       const failure = new EvalExecutorError([
         `Cannot resume ${task.instanceId}: prior report is unreadable, invalid, or not bound to this real-provider source-lock task. Move the task directory ${taskDir} aside or choose a new output directory before rerunning.`,
       ]);
       try {
-        await lstat(reportPath);
-      } catch (error) {
-        if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
-        throw failure;
-      }
-      try {
+        const directory = await findTaskOutputDirectory(options.outputDir, task.instanceId);
+        if (directory === null) return null;
+        const bytes = await readTaskOutputFile(directory, "agent-run-report.json", EVAL_EXECUTOR_MAXIMUM_ARTIFACT_BYTES);
+        if (bytes === null) return null;
         const report = validateAgentRunReport(
-          decodeStrictJson(await readBoundedRegularFile(reportPath, EVAL_EXECUTOR_MAXIMUM_ARTIFACT_BYTES), reportPath),
+          decodeStrictJson(bytes, reportPath),
           task,
         );
         if (report.egress === null) throw failure;
@@ -163,8 +161,7 @@ export function createRealAgentBatchDeps(options: {
     log: async (line) => {
       const stamped = `[${new Date().toISOString()}] ${line}\n`;
       process.stdout.write(stamped);
-      await mkdir(options.outputDir, { recursive: true });
-      await appendFile(progressLog, stamped);
+      await writeTaskOutputFile(await prepareOutputDirectory(options.outputDir), "batch-progress.log", stamped, "append");
     },
     setKeyEnv: (name, value) => {
       process.env[name] = value;
@@ -176,8 +173,5 @@ export async function writeRealAgentBatchSummary(
   outputDir: string,
   summary: RealAgentBatchSummary,
 ): Promise<string> {
-  await mkdir(outputDir, { recursive: true });
-  const summaryPath = path.join(outputDir, "batch-summary.json");
-  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
-  return summaryPath;
+  return writeTaskOutputFile(await prepareOutputDirectory(outputDir), "batch-summary.json", `${JSON.stringify(summary, null, 2)}\n`, "replace");
 }

--- a/runtime/src/eval-executor/cli.ts
+++ b/runtime/src/eval-executor/cli.ts
@@ -1,6 +1,5 @@
 import { randomBytes, randomInt } from "node:crypto";
 import { resolve4 } from "node:dns/promises";
-import { mkdir, writeFile } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import process from "node:process";
@@ -28,6 +27,7 @@ import {
 import { runTrustSuiteFromFiles } from "./trust-run.js";
 import type { LoadedPilotSourceLock } from "./types.js";
 import { decodeVerifierBundle } from "./verifier-bundle.js";
+import { prepareTaskOutputDirectory, writeTaskOutputFile } from "./task-output.js";
 
 const DEFAULT_LOCK_PATH =
   "eval/suites/competitive-coding/1.0.0/task-sets/pilot/1.0.0/source-lock.json";
@@ -156,6 +156,8 @@ async function preflight(options: {
 }): Promise<number> {
   const loaded = await loadPilotSourceLock(options.lockPath);
   const task = findPilotTask(loaded.lock, options.taskId);
+  const output = await prepareTaskOutputDirectory(options.outputDir, task.instanceId);
+  const taskDir = output.path;
   const inputs: PreflightTaskInputs = {
     task,
     bundle: decodeVerifierBundle(
@@ -171,17 +173,14 @@ async function preflight(options: {
   const result = await runTriplePreflight(runner, inputs, DEFAULT_PREFLIGHT_TIMEOUTS, {
     parserFallbackImage: options.parserFallbackImage,
   });
-  const taskDir = path.join(options.outputDir, task.instanceId);
-  await mkdir(taskDir, { recursive: true });
   for (const run of result.runs) {
-    await writeFile(
-      path.join(taskDir, `preflight-run-${run.runIndex}.json`),
+    await writeTaskOutputFile(
+      output, `preflight-run-${run.runIndex}.json`,
       `${JSON.stringify(run, null, 2)}\n`,
-      { flag: "wx" },
     );
   }
-  await writeFile(
-    path.join(taskDir, "preflight-summary.json"),
+  await writeTaskOutputFile(
+    output, "preflight-summary.json",
     `${JSON.stringify({
       taskId: result.taskId,
       qualified: result.qualified,
@@ -192,17 +191,15 @@ async function preflight(options: {
         evidenceDigest: run.evidenceDigest,
       })),
     }, null, 2)}\n`,
-    { flag: "wx" },
   );
   if (result.qualified && options.operatorTaskDigest) {
     const evidence = mintUpstreamPreflightEvidence(
       result,
       options.operatorTaskDigest as `sha256:${string}`,
     );
-    await writeFile(
-      path.join(taskDir, "upstream-preflight-evidence.json"),
+    await writeTaskOutputFile(
+      output, "upstream-preflight-evidence.json",
       `${JSON.stringify(evidence, null, 2)}\n`,
-      { flag: "wx" },
     );
   }
   process.stdout.write(`${JSON.stringify({
@@ -224,6 +221,8 @@ async function runAgent(options: {
 }): Promise<number> {
   const loaded = await loadPilotSourceLock(options.lockPath);
   const task = findPilotTask(loaded.lock, options.taskId);
+  const output = await prepareTaskOutputDirectory(options.outputDir, task.instanceId);
+  const taskDir = output.path;
   const runner = new DockerContainerRunner();
   await runner.environment();
   const { report, patchBytes, rawAgentResult } = await runAgentOnTask(
@@ -243,18 +242,15 @@ async function runAgent(options: {
     DEFAULT_PREFLIGHT_TIMEOUTS,
     { parserFallbackImage: options.parserFallbackImage },
   );
-  const taskDir = path.join(options.outputDir, task.instanceId);
-  await mkdir(taskDir, { recursive: true });
-  await writeFile(
-    path.join(taskDir, "agent-run-report.json"),
+  await writeTaskOutputFile(
+    output, "agent-run-report.json",
     `${JSON.stringify(report, null, 2)}\n`,
-    { flag: "wx" },
   );
   if (patchBytes !== null) {
-    await writeFile(path.join(taskDir, "agent-patch.diff"), patchBytes, { flag: "wx" });
+    await writeTaskOutputFile(output, "agent-patch.diff", patchBytes);
   }
   if (rawAgentResult !== null && rawAgentResult.length > 0) {
-    await writeFile(path.join(taskDir, "agent-result.json"), rawAgentResult, { flag: "wx" });
+    await writeTaskOutputFile(output, "agent-result.json", rawAgentResult);
   }
   process.stdout.write(`${JSON.stringify({
     taskId: report.taskId,
@@ -288,6 +284,8 @@ async function runRealProviderAgentTask(
   options: RealProviderRunConfig,
 ): Promise<{ readonly outcome: string; readonly summary: Record<string, unknown> }> {
   const task = findPilotTask(loaded.lock, taskId);
+  const output = await prepareTaskOutputDirectory(options.outputDir, task.instanceId);
+  const taskDir = output.path;
   const runner = new DockerContainerRunner();
   await runner.environment();
   // Resolve the provider host once, on the host, to a set of pinned IPs the
@@ -319,18 +317,15 @@ async function runRealProviderAgentTask(
     DEFAULT_PREFLIGHT_TIMEOUTS,
     { parserFallbackImage: options.parserFallbackImage },
   );
-  const taskDir = path.join(options.outputDir, task.instanceId);
-  await mkdir(taskDir, { recursive: true });
-  await writeFile(
-    path.join(taskDir, "agent-run-report.json"),
+  await writeTaskOutputFile(
+    output, "agent-run-report.json",
     `${JSON.stringify(report, null, 2)}\n`,
-    { flag: "wx" },
   );
   if (patchBytes !== null) {
-    await writeFile(path.join(taskDir, "agent-patch.diff"), patchBytes, { flag: "wx" });
+    await writeTaskOutputFile(output, "agent-patch.diff", patchBytes);
   }
   if (rawAgentResult !== null && rawAgentResult.length > 0) {
-    await writeFile(path.join(taskDir, "agent-result.json"), rawAgentResult, { flag: "wx" });
+    await writeTaskOutputFile(output, "agent-result.json", rawAgentResult);
   }
   return {
     outcome: report.outcome,

--- a/runtime/src/eval-executor/source-lock.ts
+++ b/runtime/src/eval-executor/source-lock.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { computeDocumentDigest, type Sha256Digest } from "../eval-contract/index.js";
+import { assertPortableRelativePath, computeDocumentDigest, type Sha256Digest } from "../eval-contract/index.js";
 import {
   decodeStrictJson,
   loadArtifact,
@@ -37,6 +37,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function assertString(value: unknown, label: string): string {
   if (typeof value !== "string" || value.length === 0) {
     throw new EvalExecutorError([`${label} must be a non-empty string`]);
+  }
+  return value;
+}
+
+export function assertPilotInstanceId(value: unknown, label = "instanceId"): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(value)) {
+    throw new EvalExecutorError([`${label} must be a portable identifier of 1 to 128 ASCII characters starting with a letter or digit`]);
+  }
+  try {
+    assertPortableRelativePath(value, label);
+  } catch {
+    throw new EvalExecutorError([`${label} must not be a reserved name or end with a period`]);
   }
   return value;
 }
@@ -102,7 +114,7 @@ function assertTask(value: unknown, index: number): PilotSourceLockTask {
   return {
     ordinal,
     language: assertString(value.language, `${label}.language`),
-    instanceId: assertString(value.instanceId, `${label}.instanceId`),
+    instanceId: assertPilotInstanceId(value.instanceId, `${label}.instanceId`),
     categories: assertStringArray(value.categories, `${label}.categories`),
     stressors: assertStringArray(value.stressors, `${label}.stressors`),
     sourceRowDigest: sourceRowDigest as Sha256Digest,
@@ -158,9 +170,9 @@ function assertPilotSourceLock(value: unknown, file: string): PilotSourceLock {
     throw new EvalExecutorError([`${file} tasks must be a non-empty array`]);
   }
   const tasks = value.tasks.map((task, index) => assertTask(task, index));
-  const instanceIds = new Set(tasks.map((task) => task.instanceId));
+  const instanceIds = new Set(tasks.map((task) => task.instanceId.toLowerCase()));
   if (instanceIds.size !== tasks.length) {
-    throw new EvalExecutorError([`${file} tasks must have unique instanceIds`]);
+    throw new EvalExecutorError([`${file} tasks must have unique instanceIds ignoring case`]);
   }
   const lock: PilotSourceLock = {
     kind: PILOT_SOURCE_LOCK_KIND,
@@ -211,6 +223,7 @@ export async function loadPilotSourceLock(lockFile: string): Promise<LoadedPilot
 }
 
 export function findPilotTask(lock: PilotSourceLock, instanceId: string): PilotSourceLockTask {
+  assertPilotInstanceId(instanceId);
   const task = lock.tasks.find((candidate) => candidate.instanceId === instanceId);
   if (!task) {
     throw new EvalExecutorError([

--- a/runtime/src/eval-executor/task-output.ts
+++ b/runtime/src/eval-executor/task-output.ts
@@ -17,8 +17,12 @@ function isMissing(error: unknown): boolean {
 }
 
 async function inspect(filePath: string): Promise<BigIntStats | null> {
-  try { return await lstat(filePath, { bigint: true }); }
-  catch (error) { if (isMissing(error)) return null; throw error; }
+  try {
+    return await lstat(filePath, { bigint: true });
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
 }
 
 async function openDirectory(directory: string, create: boolean): Promise<DirectoryIdentity | null> {

--- a/runtime/src/eval-executor/task-output.ts
+++ b/runtime/src/eval-executor/task-output.ts
@@ -1,0 +1,131 @@
+import { constants, type BigIntStats } from "node:fs";
+import { lstat, mkdir, open, realpath } from "node:fs/promises";
+import path from "node:path";
+import { assertPortableRelativePath } from "../eval-contract/index.js";
+import { openStableDirectory, readBoundedRegularFile } from "../eval-pilot/safe-io.js";
+import { assertPilotInstanceId, EvalExecutorError } from "./source-lock.js";
+
+type DirectoryIdentity = Awaited<ReturnType<typeof openStableDirectory>>;
+export interface TaskOutputDirectory {
+  readonly path: string;
+  readonly root: DirectoryIdentity;
+  readonly directory: DirectoryIdentity;
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+async function inspect(filePath: string): Promise<BigIntStats | null> {
+  try { return await lstat(filePath, { bigint: true }); }
+  catch (error) { if (isMissing(error)) return null; throw error; }
+}
+
+async function openDirectory(directory: string, create: boolean): Promise<DirectoryIdentity | null> {
+  const existing = await inspect(directory);
+  if (existing === null) {
+    if (!create) return null;
+    await mkdir(directory, { recursive: true });
+  }
+  return openStableDirectory(directory, "evaluation output directory");
+}
+
+async function assertPinnedDirectory(identity: DirectoryIdentity): Promise<void> {
+  const current = await lstat(identity.path, { bigint: true });
+  if (
+    current.isSymbolicLink() || !current.isDirectory() ||
+    current.dev !== identity.stat.dev || current.ino !== identity.stat.ino ||
+    await realpath(identity.path) !== identity.canonicalPath
+  ) throw new EvalExecutorError(["evaluation output directory changed identity"]);
+}
+
+export async function assertTaskOutputDirectory(output: TaskOutputDirectory): Promise<void> {
+  await assertPinnedDirectory(output.root);
+  await assertPinnedDirectory(output.directory);
+}
+
+export async function prepareOutputDirectory(outputDir: string): Promise<TaskOutputDirectory> {
+  const root = await openDirectory(path.resolve(outputDir), true);
+  if (root === null) throw new EvalExecutorError(["evaluation output directory is missing"]);
+  return { path: root.canonicalPath, root, directory: root };
+}
+
+async function taskDirectory(outputDir: string, instanceId: string, create: boolean): Promise<TaskOutputDirectory | null> {
+  assertPilotInstanceId(instanceId);
+  const root = await openDirectory(path.resolve(outputDir), create);
+  if (root === null) return null;
+  const candidate = path.resolve(root.canonicalPath, instanceId);
+  if (path.dirname(candidate) !== root.canonicalPath) {
+    throw new EvalExecutorError(["instanceId escapes the evaluation output directory"]);
+  }
+  await assertPinnedDirectory(root);
+  const directory = await openDirectory(candidate, create);
+  if (directory === null) return null;
+  if (path.dirname(directory.canonicalPath) !== root.canonicalPath) {
+    throw new EvalExecutorError(["task directory escapes the evaluation output directory"]);
+  }
+  const result = { path: directory.canonicalPath, root, directory };
+  await assertTaskOutputDirectory(result);
+  return result;
+}
+
+export async function prepareTaskOutputDirectory(outputDir: string, instanceId: string): Promise<TaskOutputDirectory> {
+  const directory = await taskDirectory(outputDir, instanceId, true);
+  if (directory === null) throw new EvalExecutorError(["task output directory is missing"]);
+  return directory;
+}
+
+export function findTaskOutputDirectory(outputDir: string, instanceId: string): Promise<TaskOutputDirectory | null> {
+  return taskDirectory(outputDir, instanceId, false);
+}
+
+function outputFile(output: TaskOutputDirectory, name: string): string {
+  assertPortableRelativePath(name, "output filename");
+  const candidate = path.resolve(output.path, name);
+  if (path.dirname(candidate) !== output.path) throw new EvalExecutorError(["output filename must be a single segment"]);
+  return candidate;
+}
+
+export async function readTaskOutputFile(output: TaskOutputDirectory, name: string, maximumBytes: number): Promise<Uint8Array | null> {
+  const filePath = outputFile(output, name);
+  await assertTaskOutputDirectory(output);
+  const existing = await inspect(filePath);
+  if (existing === null) return null;
+  if (!existing.isFile() || existing.isSymbolicLink() || existing.nlink !== 1n) {
+    throw new EvalExecutorError(["evaluation output must be a single-link regular file"]);
+  }
+  const bytes = await readBoundedRegularFile(filePath, maximumBytes, output.path);
+  await assertTaskOutputDirectory(output);
+  return bytes;
+}
+
+export async function writeTaskOutputFile(
+  output: TaskOutputDirectory, name: string, bytes: string | Uint8Array,
+  mode: "create" | "replace" | "append" = "create",
+): Promise<string> {
+  const filePath = outputFile(output, name);
+  await assertTaskOutputDirectory(output);
+  const existing = await inspect(filePath);
+  if (existing !== null && (!existing.isFile() || existing.isSymbolicLink() || existing.nlink !== 1n)) {
+    throw new EvalExecutorError(["evaluation output must be a single-link regular file"]);
+  }
+  const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+  const creation = existing === null || mode === "create" ? constants.O_CREAT | constants.O_EXCL : 0;
+  const handle = await open(filePath, constants.O_WRONLY | noFollow | creation | (mode === "append" ? constants.O_APPEND : 0), 0o600);
+  try {
+    const current = await handle.stat({ bigint: true });
+    const named = await lstat(filePath, { bigint: true });
+    if (
+      !current.isFile() || current.nlink !== 1n || named.isSymbolicLink() ||
+      current.dev !== named.dev || current.ino !== named.ino ||
+      (existing !== null && (current.dev !== existing.dev || current.ino !== existing.ino))
+    ) throw new EvalExecutorError(["evaluation output file changed identity"]);
+    await assertTaskOutputDirectory(output);
+    if (mode === "replace") await handle.truncate(0);
+    await handle.writeFile(bytes);
+    await assertTaskOutputDirectory(output);
+  } finally {
+    await handle.close();
+  }
+  return filePath;
+}

--- a/runtime/tests/eval/eval-executor-batch.test.ts
+++ b/runtime/tests/eval/eval-executor-batch.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, symlink, truncate, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { createRealAgentBatchDeps, runRealAgentBatch, type RealAgentBatchDeps } from "../../src/eval-executor/batch.js";
+import { createRealAgentBatchDeps, runRealAgentBatch, writeRealAgentBatchSummary, type RealAgentBatchDeps } from "../../src/eval-executor/batch.js";
 import { digestCanonicalJson } from "../../src/eval-contract/index.js";
 import { computeOverlayManifestDigest, type OverlayManifest } from "../../src/eval-executor/overlay-manifest.js";
 import type { AgentRunOutcome, AgentRunReport, LoadedPilotSourceLock, PilotSourceLockTask } from "../../src/eval-executor/types.js";
@@ -173,6 +173,30 @@ function makeDeps(overrides: {
 }
 
 describe("eval executor real-agent batch", () => {
+  test("refuses direct resume lookup outside outputDir even for a self-consistent report", async () => {
+    const fixture = await createDiskBatch();
+    const outside = await workspaces.create();
+    const task = { ...fixture.loaded.lock.tasks[0]!, instanceId: path.relative(fixture.outputDir, outside) };
+    const bytes = JSON.stringify(makeReport(task));
+    const outsideReport = path.join(outside, "agent-run-report.json");
+    await writeFile(outsideReport, bytes);
+    const deps = createRealAgentBatchDeps({ outputDir: fixture.outputDir, runTask: fixture.runTask });
+    await expect(deps.loadReport(task)).rejects.toThrow(/instanceId/u);
+    expect(await readFile(outsideReport, "utf8")).toBe(bytes);
+    expect(fixture.runTask).not.toHaveBeenCalled();
+  });
+
+  test.runIf(process.platform !== "win32")("refuses a linked batch summary instead of overwriting an outside file", async () => {
+    const output = await workspaces.create();
+    const outside = path.join(await workspaces.create(), "sentinel");
+    await writeFile(outside, "unchanged");
+    await symlink(outside, path.join(output, "batch-summary.json"));
+    await expect(writeRealAgentBatchSummary(output, {
+      total: 0, completed: 0, skipped: 0, driverErrors: 0, verifiedFixes: 0, results: [],
+    })).rejects.toThrow(/regular file/u);
+    expect(await readFile(outside, "utf8")).toBe("unchanged");
+  });
+
   test.each([
     ["empty", () => ""],
     ["truncated", () => '{"taskId":"t-a",'],

--- a/runtime/tests/eval/eval-executor-source-lock.test.ts
+++ b/runtime/tests/eval/eval-executor-source-lock.test.ts
@@ -8,7 +8,9 @@ import {
   findPilotTask,
   loadPilotSourceLock,
   readPilotArtifact,
+  type PilotSourceLock,
 } from "../../src/eval-executor/index.js";
+import { computeDocumentDigest } from "../../src/eval-contract/index.js";
 
 const committedLock = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -24,6 +26,38 @@ describe("eval executor pilot source-lock loader", () => {
 
   afterEach(async () => {
     await rm(scratch, { recursive: true, force: true });
+  });
+
+  async function copyLockWithIds(ids: readonly string[]): Promise<string> {
+    const original = JSON.parse(await readFile(committedLock, "utf8")) as PilotSourceLock;
+    const changed = {
+      ...original,
+      tasks: original.tasks.map((task, index) => ids[index] === undefined ? task : { ...task, instanceId: ids[index]! }),
+    };
+    const copied = path.join(scratch, "source-lock.json");
+    await mkdir(path.join(scratch, "cas", "sha256"), { recursive: true });
+    await writeFile(copied, JSON.stringify({ ...changed, documentDigest: computeDocumentDigest(changed) }));
+    return copied;
+  }
+
+  test.each([
+    "../../outside", "../outside", "/outside", "C:\\outside", "C:outside", "\\\\server\\share",
+    ".", "..", "task/child", "task\\child", "", "task\0name", "task\nname", "task\tname",
+    "task.", "task ", "task name", "CON", "nul.txt", "COM1.log", "LPT9", "task:stream",
+    "task?name", "task*name", "task|name", "a".repeat(129),
+  ])("rejects unsafe instance ID %j even in a self-digested lock", async (instanceId) => {
+    const copied = await copyLockWithIds([instanceId]);
+    await expect(loadPilotSourceLock(copied)).rejects.toThrow(/instanceId/u);
+  });
+
+  test("rejects case-folding ID collisions before portable output directories can alias", async () => {
+    const copied = await copyLockWithIds(["Owner__Repo-123", "owner__repo-123"]);
+    await expect(loadPilotSourceLock(copied)).rejects.toThrow(/unique instanceIds/iu);
+  });
+
+  test.each(["owner__repo-123", "Owner__Repo.Name-123", "a", "a".repeat(128)])("accepts portable instance ID %j", async (instanceId) => {
+    const copied = await copyLockWithIds([instanceId]);
+    expect((await loadPilotSourceLock(copied)).lock.tasks[0]!.instanceId).toBe(instanceId);
   });
 
   test("loads the committed frozen lock and resolves its CAS root", async () => {

--- a/runtime/tests/eval/eval-executor-task-output.test.ts
+++ b/runtime/tests/eval/eval-executor-task-output.test.ts
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import { link, lstat, mkdir, readFile, readdir, rename, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { computeDocumentDigest } from "../../src/eval-contract/index.js";
+import { main } from "../../src/eval-executor/cli.js";
+import { DockerContainerRunner } from "../../src/eval-executor/container-runner.js";
+import type { PilotSourceLock } from "../../src/eval-executor/types.js";
+import {
+  findTaskOutputDirectory, prepareOutputDirectory, prepareTaskOutputDirectory,
+  readTaskOutputFile, writeTaskOutputFile,
+} from "../../src/eval-executor/task-output.js";
+import { createTempWorkspaceFixture } from "../helpers/temp-workspace.js";
+
+const workspaces = createTempWorkspaceFixture("agenc-task-output-");
+const committedLock = fileURLToPath(new URL("../../eval/suites/competitive-coding/1.0.0/task-sets/pilot/1.0.0/source-lock.json", import.meta.url));
+afterEach(async () => { vi.restoreAllMocks(); await workspaces.cleanup(); });
+
+function commandArgs(command: string, lock: string, task: string, output: string): string[] {
+  const args = [command, "--lock", lock, command.endsWith("-batch") ? "--tasks" : "--task", task, "--output", output];
+  if (command !== "preflight") args.push("--overlay", "unused-overlay");
+  if (command.startsWith("run-agent-real")) args.push(
+    "--provider-host", "api.example.invalid", "--provider-base-url", "https://api.example.invalid/v1", "--provider-model", "test-model",
+  );
+  return args;
+}
+
+describe("task output containment", () => {
+  test.each(["../../outside", "/outside", "C:\\outside", "task/child", "task\\child", ".", "..", "", "CON"])("rejects ID %j before creating or reading directories", async (instanceId) => {
+    const root = await workspaces.create();
+    const output = path.join(root, "not-created");
+    await expect(prepareTaskOutputDirectory(output, instanceId)).rejects.toThrow(/instanceId/u);
+    await expect(findTaskOutputDirectory(output, instanceId)).rejects.toThrow(/instanceId/u);
+    expect(await readdir(root)).toEqual([]);
+  });
+
+  test("keeps create, replace, append, and reads beneath the selected directory", async () => {
+    const root = await workspaces.create();
+    const output = await prepareTaskOutputDirectory(root, "Owner__Repo-123");
+    expect(output.path).toBe(path.join(root, "Owner__Repo-123"));
+    await writeTaskOutputFile(output, "report.json", "first");
+    await expect(writeTaskOutputFile(output, "report.json", "do not overwrite")).rejects.toMatchObject({ code: "EEXIST" });
+    await writeTaskOutputFile(output, "report.json", "second", "replace");
+    await writeTaskOutputFile(output, "report.json", ":tail", "append");
+    expect(Buffer.from((await readTaskOutputFile(output, "report.json", 128))!).toString()).toBe("second:tail");
+    await expect(readTaskOutputFile(output, "report.json", 1)).rejects.toThrow(/exceeds/u);
+    expect(await readTaskOutputFile(output, "absent.json", 128)).toBeNull();
+    expect(await findTaskOutputDirectory(root, "not-present")).toBeNull();
+    expect(await findTaskOutputDirectory(path.join(root, "missing-root"), "task")).toBeNull();
+    await expect(lstat(path.join(root, "missing-root"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test.each(["../outside", "/outside", "nested/report.json", "C:\\outside"])("rejects output filename %j", async (name) => {
+    const root = await workspaces.create();
+    const output = await prepareTaskOutputDirectory(root, "task");
+    await expect(writeTaskOutputFile(output, name, "bytes")).rejects.toThrow();
+    await expect(readTaskOutputFile(output, name, 128)).rejects.toThrow();
+    expect(await readdir(output.path)).toEqual([]);
+  });
+
+  test.each(["root", "task"])("refuses a replaced %s directory after it was pinned", async (kind) => {
+    const root = await workspaces.create();
+    const selected = path.join(root, "output");
+    const output = await prepareTaskOutputDirectory(selected, "task");
+    const replaced = kind === "root" ? selected : output.path;
+    await rename(replaced, `${replaced}-retired`);
+    await mkdir(replaced);
+    await expect(writeTaskOutputFile(output, "report.json", "bytes")).rejects.toThrow(/changed identity/u);
+    await expect(readTaskOutputFile(output, "report.json", 128)).rejects.toThrow(/changed identity/u);
+    expect(await readdir(replaced)).toEqual([]);
+  });
+
+  test.each(["preflight", "run-agent", "run-agent-real", "run-agent-real-batch"])("%s rejects a self-digested unsafe lock before container work or output creation", async (command) => {
+    const root = await workspaces.create();
+    const original = JSON.parse(await readFile(committedLock, "utf8")) as PilotSourceLock;
+    const taskId = "../../outside";
+    const changed = { ...original, tasks: original.tasks.map((task, index) => index === 0 ? { ...task, instanceId: taskId } : task) };
+    const lock = path.join(root, "source-lock.json");
+    await mkdir(path.join(root, "cas", "sha256"), { recursive: true });
+    await writeFile(lock, JSON.stringify({ ...changed, documentDigest: computeDocumentDigest(changed) }));
+    const output = path.join(root, "output");
+    const environment = vi.spyOn(DockerContainerRunner.prototype, "environment").mockRejectedValue(new Error("must not spend"));
+    await expect(main(commandArgs(command, lock, taskId, output))).rejects.toThrow(/instanceId/u);
+    expect(environment).not.toHaveBeenCalled();
+    await expect(lstat(output)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await readdir(root)).sort()).toEqual(["cas", "source-lock.json"]);
+  });
+});
+
+describe.runIf(process.platform !== "win32")("linked evaluation output", () => {
+  test.each(["root", "task"])("refuses a symlinked %s directory", async (kind) => {
+    const root = await workspaces.create();
+    const outside = await workspaces.create();
+    const selected = path.join(root, "output");
+    if (kind === "task") await mkdir(selected);
+    await symlink(outside, kind === "root" ? selected : path.join(selected, "task"));
+    await expect(prepareTaskOutputDirectory(selected, "task")).rejects.toThrow(/non-symlink directory/u);
+    await expect(findTaskOutputDirectory(selected, "task")).rejects.toThrow(/non-symlink directory/u);
+    expect(await readdir(outside)).toEqual([]);
+  });
+
+  test.each(["symlink", "hardlink", "fifo"])("refuses %s files for every read/write mode", async (kind) => {
+    const root = await workspaces.create();
+    const outside = path.join(await workspaces.create(), "sentinel");
+    await writeFile(outside, "unchanged");
+    const output = await prepareOutputDirectory(root);
+    const file = path.join(root, "report.json");
+    if (kind === "symlink") await symlink(outside, file);
+    else if (kind === "hardlink") await link(outside, file);
+    else execFileSync("mkfifo", [file]);
+    await expect(readTaskOutputFile(output, "report.json", 128)).rejects.toThrow(/regular file/u);
+    for (const mode of ["create", "replace", "append"] as const) {
+      await expect(writeTaskOutputFile(output, "report.json", "attack", mode)).rejects.toThrow(/regular file/u);
+    }
+    expect(await readFile(outside, "utf8")).toBe("unchanged");
+  });
+
+  test.each(["preflight", "run-agent", "run-agent-real", "run-agent-real-batch"])("%s rejects a linked output root before container work", async (command) => {
+    const root = await workspaces.create();
+    const outside = await workspaces.create();
+    const selected = path.join(root, "output");
+    await symlink(outside, selected);
+    const original = JSON.parse(await readFile(committedLock, "utf8")) as PilotSourceLock;
+    const environment = vi.spyOn(DockerContainerRunner.prototype, "environment").mockRejectedValue(new Error("must not spend"));
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await expect(main(commandArgs(command, committedLock, original.tasks[0]!.instanceId, selected))).rejects.toThrow(/non-symlink directory/u);
+    expect(environment).not.toHaveBeenCalled();
+    expect(await readdir(outside)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Changes

- Validate source-lock instance IDs as bounded portable single-segment identifiers, including Windows reserved names and case-folded uniqueness. A correct self-digest no longer permits path syntax.
- Share guarded task-output directories across preflight, offline-agent, real-provider, and batch-resume paths. Reject invalid IDs and linked output roots before container/provider work.
- Check pinned directory identities and file descriptors around artifact operations. Preserve exclusive task-artifact creation, bounded reads, progress appends, and summary replacement while rejecting symlinks, hardlinks, and special files.
- Document ID compatibility and recovery. Output roots must remain under operator control; identity checks are not a cross-platform directory lock against a malicious host.

## Validation

- Original source failed 26 regressions while 10 controls passed, including all committed IDs and valid portable IDs.
- Both runtime typechecks, dedicated typechecking of all three changed test files, and 236 targeted tests across 12 files pass in the local hermetic container.
- Tests exercise all four CLI paths with self-digested unsafe locks and linked roots, direct resume lookup outside outputDir, linked summary files, directory replacement, bounded reads, and each write mode. No real provider or credentials are used.
- The benchmark baseline and measured source inputs are unchanged. GitNexus staged analysis reports low risk and no affected indexed processes. Exact-head full build, PTY startup, full suite, Linux native checks, and independent review are pending.
- Hosted Actions remain disabled. Tests run locally.

Closes #2085.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all eval artifact write/read paths and tightens lock validation, which could break locks or workflows with non-portable IDs; changes reduce path-escape and link-following risk rather than expanding attack surface.
> 
> **Overview**
> Tightens eval executor safety around **task `instanceId`s** and **artifact I/O**. Source-lock loading now rejects path-like, reserved, or case-colliding IDs even when the lock digest is valid; `findPilotTask` applies the same rules.
> 
> A new **`task-output`** layer pins output root and per-task directory identities (dev/ino + realpath), blocks symlinked roots, and routes preflight, offline/real agent runs, batch progress/summary, and resume report reads through bounded reads and checked writes that refuse symlinks, hardlinks, and non-regular files. Exclusive artifact creation is preserved; batch summary uses replace and progress log uses append.
> 
> The real-agent baseline runbook documents ID constraints, guarded output behavior, and recovery when legacy IDs or tampered directories are detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b2962a2b569aee21c614e409dbefc7442ca85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->