### PR TITLE
fix(config): recover interrupted canonical state publication

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -76,6 +76,45 @@ it and recovery never writes bare mode into the session toggle.
 `--bare` also takes precedence over `runtimeOptions.allowUntrustedHooks`; an
 untrusted-command capability cannot lift hard hook suppression.
 
+## Interrupted runtime-state publication
+
+`RuntimeStateRepository` reconciles interrupted `state.json` publications before
+an initial read, update, or freshness reload. Recovery and normal updates use
+the same configuration authority lock. A process that dies while holding that
+lock can leave it unavailable until its existing 30-second stale interval
+expires. Do not remove the lock while another AgenC process is running.
+
+Each replacement has a versioned transaction journal and matching temporary
+and quarantine filenames. The journal binds the prior and replacement file
+identities, modes, ownership, sizes, modification times, and SHA-256 digests.
+The journal and file data are synchronized before the prior canonical file is
+moved. The exclusive link at the canonical path is the commit point.
+
+Recovery restores the prior state if publication did not reach that point.
+If the canonical path contains the recorded replacement, recovery keeps it.
+Expected two-link stages must match their recorded canonical partner before
+cleanup. Recovery synchronizes the parent directory between namespace changes
+and retains the journal until the surviving canonical file is verified.
+Direct users of the low-level publication and recovery functions must hold
+the configuration authority lock themselves.
+
+Malformed or multiple transactions, changed artifacts, unexpected links, and
+legacy stages whose unrelated IDs cannot prove a transaction stop startup
+with a recovery error. An interrupted first publication with no committed
+state also requires operator recovery. None of these cases becomes an empty
+runtime state. Preserve the reported files and the AgenC home before any
+manual recovery. Do not delete a stage because its timestamp looks older.
+
+Directory synchronization support depends on the operating system and
+filesystem. An unsupported directory sync does not establish power-loss
+durability. A sync failure before publication stops the update; a failure
+after publication preserves artifacts not yet cleaned up and reports an
+indeterminate commit durability. See the [Node.js file synchronization contract](https://nodejs.org/download/release/v26.5.0/docs/api/fs.html#fsfsyncsyncfd).
+
+The canonical JSON schema remains `state_version = 1`. After successful
+cleanup, the prior release can read the document. Finish any pending
+transaction with this release before downgrading.
+
 ## Layer order
 
 Later layers win:

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -83,6 +83,8 @@ an initial read, update, or freshness reload. Recovery and normal updates use
 the same configuration authority lock. A process that dies while holding that
 lock can leave it unavailable until its existing 30-second stale interval
 expires. Do not remove the lock while another AgenC process is running.
+Lock contention during a freshness reload invalidates the cache. The next
+read retries recovery even if `state.json` has not emitted another change.
 
 Each replacement has a versioned transaction journal and matching temporary
 and quarantine filenames. The journal binds the prior and replacement file

--- a/runtime/src/config/runtime-state-repository.ts
+++ b/runtime/src/config/runtime-state-repository.ts
@@ -1029,6 +1029,10 @@ export class RuntimeStateRepository {
       })
       .catch((error: unknown) => {
         if (this.#closed || generation !== this.#refreshGeneration) return;
+        if (error instanceof Error && "code" in error && error.code === "ELOCKED") {
+          this.#cache = { loaded: false, config: null };
+          return;
+        }
         this.#cache = {
           loaded: true,
           config: null,

--- a/runtime/src/config/runtime-state-repository.ts
+++ b/runtime/src/config/runtime-state-repository.ts
@@ -22,14 +22,14 @@ import {
 } from "node:fs";
 import { basename, join } from "node:path";
 
-import { runWithConfigAuthorityLockSync } from "./authority-lock.js";
+import { runWithConfigAuthorityLocks, runWithConfigAuthorityLockSync, withConfigAuthorityLockSync } from "./authority-lock.js";
 import { cloneRecord, isPlainRecord, type JsonRecord } from "./json.js";
 import {
   createCanonicalStateDocument,
   getGlobalRuntimeState,
-  readCanonicalState,
   readCanonicalStateSnapshotSync,
   readCanonicalStateSync,
+  recoverCanonicalStatePublicationSync,
   StateRepositoryError,
   withGlobalRuntimeState,
   writeCanonicalStateAtomicSync,
@@ -989,10 +989,14 @@ export class RuntimeStateRepository {
   }
 
   #readDocumentSync(): CanonicalStateDocument | null {
-    return readCanonicalStateSync(this.statePath);
+    return withConfigAuthorityLockSync(this.statePath, () => {
+      recoverCanonicalStatePublicationSync(this.statePath);
+      return readCanonicalStateSync(this.statePath);
+    });
   }
 
   #readSnapshotSync(): CanonicalStateFileSnapshot | null {
+    recoverCanonicalStatePublicationSync(this.statePath);
     return readCanonicalStateSnapshotSync(this.statePath);
   }
 
@@ -1010,12 +1014,17 @@ export class RuntimeStateRepository {
 
   #refreshAfterWatchEvent(): void {
     const generation = ++this.#refreshGeneration;
-    void readCanonicalState(this.statePath)
-      .then((document) => {
+    void runWithConfigAuthorityLocks([this.statePath], () => {
+      recoverCanonicalStatePublicationSync(this.statePath);
+      return readCanonicalStateSync(this.statePath);
+    })
+      .then((outcome) => {
         if (this.#closed || generation !== this.#refreshGeneration) return;
+        if (outcome.status === "failed") throw outcome.error;
+        reportAuthorityReleaseErrors(this.statePath, outcome.postOperationReleaseErrors);
         this.#cache = {
           loaded: true,
-          config: globalStateFromDocument(document, this.statePath),
+          config: globalStateFromDocument(outcome.value, this.statePath),
         };
       })
       .catch((error: unknown) => {

--- a/runtime/src/config/state-publication.ts
+++ b/runtime/src/config/state-publication.ts
@@ -1,0 +1,305 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync, constants, fstatSync, fsyncSync, linkSync, lstatSync, openSync,
+  readFileSync, readdirSync, readSync, unlinkSync, writeFileSync, type BigIntStats,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { duplicateJsonObjectPaths, isPlainRecord } from "./json.js";
+import type { CanonicalStateFileSnapshot } from "./state.js";
+
+interface FileProof {
+  readonly dev: string;
+  readonly ino: string;
+  readonly size: string;
+  readonly mtimeNs: string;
+  readonly mode: string;
+  readonly uid: string;
+  readonly digest: string;
+}
+
+interface PublicationJournal {
+  readonly version: 1;
+  readonly transactionId: string;
+  readonly previous: FileProof | null;
+  readonly replacement: FileProof;
+}
+
+interface Artifact {
+  readonly file: string;
+  readonly bytes: Buffer;
+  readonly stat: BigIntStats;
+}
+
+export interface StatePublicationIO {
+  readonly parse: (text: string, file: string) => unknown;
+  readonly synchronize: () => void;
+}
+
+function recoveryError(file: string, detail: string): Error {
+  return new Error(`State publication recovery required for ${file}: ${detail}; preserve the transaction artifacts`);
+}
+
+function missing(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function digest(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function proof(snapshot: CanonicalStateFileSnapshot): FileProof {
+  const { dev, ino, size, mtimeNs, mode, uid } = snapshot.version;
+  return {
+    dev: String(dev), ino: String(ino), size: String(size), mtimeNs: String(mtimeNs),
+    mode: String(mode), uid: String(uid), digest: digest(snapshot.bytes),
+  };
+}
+
+function regular(file: string, stat: BigIntStats): void {
+  if (!stat.isFile() || stat.isSymbolicLink() || (stat.nlink !== 1n && stat.nlink !== 2n)) {
+    throw recoveryError(file, "artifact is not a regular file with an expected link count");
+  }
+  if (process.platform !== "win32" && (
+    (stat.mode & 0o777n) !== 0o600n ||
+    (typeof process.getuid === "function" && stat.uid !== BigInt(process.getuid()))
+  )) throw recoveryError(file, "artifact ownership or mode is invalid");
+}
+
+function assertUnchangedArtifact(file: string, before: BigIntStats, observed: BigIntStats): void {
+  if (
+    observed.dev !== before.dev || observed.ino !== before.ino ||
+    observed.size !== before.size || observed.mtimeNs !== before.mtimeNs ||
+    observed.ctimeNs !== before.ctimeNs || observed.nlink !== before.nlink ||
+    observed.mode !== before.mode || observed.uid !== before.uid
+  ) throw recoveryError(file, "artifact changed while being read");
+}
+
+function readArtifactBytes(descriptor: number, maximumBytes?: number): Buffer {
+  if (maximumBytes === undefined) return readFileSync(descriptor);
+  const bytes = Buffer.alloc(maximumBytes + 1);
+  let offset = 0;
+  while (offset < bytes.length) {
+    const count = readSync(descriptor, bytes, offset, bytes.length - offset, null);
+    if (count === 0) break;
+    offset += count;
+  }
+  return bytes.subarray(0, offset);
+}
+
+function withArtifactDescriptor<Result>(descriptor: number, operation: () => Result): Result {
+  let failure: { readonly error: unknown } | null = null;
+  try {
+    return operation();
+  } catch (error) {
+    failure = { error };
+    throw error;
+  } finally {
+    try {
+      closeSync(descriptor);
+    } catch (closeError) {
+      if (failure === null) throw closeError;
+      try {
+        if (failure.error instanceof Error && Object.isExtensible(failure.error)) {
+          Object.defineProperty(failure.error, "cleanupErrors", { configurable: true, value: Object.freeze([closeError]) });
+        }
+      } catch {}
+    }
+  }
+}
+
+function readArtifact(file: string, maximumBytes?: number): Artifact | null {
+  let before: BigIntStats;
+  try { before = lstatSync(file, { bigint: true }); }
+  catch (error) {
+    if (missing(error)) return null;
+    throw error;
+  }
+  regular(file, before);
+  if (maximumBytes !== undefined && before.size > BigInt(maximumBytes)) {
+    throw recoveryError(file, "journal exceeds its size limit");
+  }
+  const descriptor = openSync(file, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  return withArtifactDescriptor(descriptor, () => {
+    const opened = fstatSync(descriptor, { bigint: true });
+    assertUnchangedArtifact(file, before, opened);
+    const bytes = readArtifactBytes(descriptor, maximumBytes);
+    const after = fstatSync(descriptor, { bigint: true });
+    const named = lstatSync(file, { bigint: true });
+    regular(file, named);
+    for (const observed of [opened, after, named]) {
+      assertUnchangedArtifact(file, before, observed);
+    }
+    if (BigInt(bytes.length) !== before.size) throw recoveryError(file, "artifact size changed");
+    return { file, bytes, stat: after };
+  });
+}
+
+function matches(artifact: Artifact, expected: FileProof): boolean {
+  const observed = artifact.stat;
+  return String(observed.dev) === expected.dev && String(observed.ino) === expected.ino &&
+    String(observed.size) === expected.size && String(observed.mtimeNs) === expected.mtimeNs &&
+    String(observed.mode) === expected.mode && String(observed.uid) === expected.uid &&
+    digest(artifact.bytes) === expected.digest;
+}
+
+function assertProof(value: unknown, file: string): asserts value is FileProof {
+  const fields = ["dev", "ino", "size", "mtimeNs", "mode", "uid", "digest"];
+  if (!isPlainRecord(value) || Object.keys(value).length !== fields.length ||
+    fields.some((field) => typeof value[field] !== "string")) {
+    throw recoveryError(file, "journal file proof is invalid");
+  }
+  if (!fields.slice(0, -1).every((field) => /^\d+$/u.test(value[field] as string)) ||
+    !/^[a-f0-9]{64}$/u.test(value.digest as string)) {
+    throw recoveryError(file, "journal file proof is malformed");
+  }
+}
+
+function parseJournal(artifact: Artifact, transactionId: string): PublicationJournal {
+  if (artifact.stat.nlink !== 1n) throw recoveryError(artifact.file, "journal must have one link");
+  const text = artifact.bytes.toString("utf8");
+  let value: unknown;
+  try { value = JSON.parse(text); }
+  catch { throw recoveryError(artifact.file, "journal JSON is invalid"); }
+  if (!isPlainRecord(value) || Object.keys(value).length !== 4 ||
+    value.version !== 1 || value.transactionId !== transactionId || duplicateJsonObjectPaths(text).length !== 0) {
+    throw recoveryError(artifact.file, "journal envelope is invalid");
+  }
+  assertProof(value.replacement, artifact.file);
+  if (value.previous !== null) assertProof(value.previous, artifact.file);
+  return value as unknown as PublicationJournal;
+}
+
+function paths(file: string, transactionId: string): { temporary: string; quarantine: string; journal: string } {
+  return {
+    temporary: `${file}.tmp-${transactionId}`,
+    quarantine: `${file}.quarantine-${transactionId}`,
+    journal: `${file}.transaction-${transactionId}.json`,
+  };
+}
+
+export function writeStatePublicationJournalSync(
+  file: string, transactionId: string, previous: CanonicalStateFileSnapshot | null,
+  replacement: CanonicalStateFileSnapshot,
+): void {
+  const journal: PublicationJournal = {
+    version: 1, transactionId, previous: previous === null ? null : proof(previous), replacement: proof(replacement),
+  };
+  const journalPath = paths(file, transactionId).journal;
+  const bytes = Buffer.from(`${JSON.stringify(journal)}\n`);
+  writeFileSync(journalPath, bytes, { flag: "wx", mode: 0o600, flush: true });
+  const observed = readArtifact(journalPath, 32_768);
+  if (observed === null || !observed.bytes.equals(bytes)) throw recoveryError(journalPath, "prepared journal changed");
+  parseJournal(observed, transactionId);
+}
+
+function readProvenState(file: string, expected: FileProof | null, io: StatePublicationIO): Artifact | null {
+  const artifact = readArtifact(file);
+  if (artifact === null) return null;
+  if (expected === null || !matches(artifact, expected)) throw recoveryError(file, "artifact does not match its journal proof");
+  io.parse(artifact.bytes.toString("utf8"), file);
+  return artifact;
+}
+
+function removeProvenState(artifact: Artifact, expected: FileProof, io: StatePublicationIO): void {
+  const current = readProvenState(artifact.file, expected, io);
+  if (current === null || current.stat.nlink !== artifact.stat.nlink) {
+    throw recoveryError(artifact.file, "artifact changed before cleanup");
+  }
+  unlinkSync(artifact.file);
+  io.synchronize();
+}
+
+function assertLinks(artifact: Artifact | null, paired: boolean): void {
+  if (artifact !== null && artifact.stat.nlink !== (paired ? 2n : 1n)) {
+    throw recoveryError(artifact.file, "artifact has an unexpected link relationship");
+  }
+}
+
+function publicationArtifacts(file: string): string[] {
+  const base = basename(file);
+  try {
+    return readdirSync(dirname(file)).filter((entry) =>
+      [".tmp-", ".quarantine-", ".transaction-"].some((suffix) => entry.startsWith(`${base}${suffix}`)),
+    );
+  } catch (error) {
+    if (missing(error)) return [];
+    throw error;
+  }
+}
+
+function loadTransaction(file: string): {
+  readonly staged: ReturnType<typeof paths>;
+  readonly journalArtifact: Artifact;
+  readonly journal: PublicationJournal;
+} | null {
+  const entries = publicationArtifacts(file);
+  if (entries.length === 0) return null;
+  const journalEntries = entries.filter((entry) => entry.startsWith(`${basename(file)}.transaction-`));
+  if (journalEntries.length !== 1) throw recoveryError(file, `ambiguous artifacts ${entries.map((entry) => join(dirname(file), entry)).join(", ")}`);
+  const journalPath = join(dirname(file), journalEntries[0]!);
+  const transactionId = journalEntries[0]!.slice(`${basename(file)}.transaction-`.length, -5);
+  if (!/^\d+-[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/u.test(transactionId)) {
+    throw recoveryError(journalPath, "transaction ID is invalid");
+  }
+  const staged = paths(file, transactionId);
+  if (entries.some((entry) => !Object.values(staged).some((candidate) => basename(candidate) === entry))) {
+    throw recoveryError(file, `unmatched artifacts ${entries.join(", ")}`);
+  }
+  const journalArtifact = readArtifact(journalPath, 32_768);
+  if (journalArtifact === null) throw recoveryError(journalPath, "journal disappeared");
+  const journal = parseJournal(journalArtifact, transactionId);
+  return { staged, journalArtifact, journal };
+}
+
+function selectCanonicalState(file: string, canonical: Artifact | null, quarantine: Artifact | null, journal: PublicationJournal): FileProof {
+  if (canonical === null) {
+    if (journal.previous === null || quarantine === null) throw recoveryError(file, "missing prior committed state");
+    return journal.previous;
+  }
+  if (matches(canonical, journal.replacement)) return journal.replacement;
+  if (journal.previous !== null && matches(canonical, journal.previous)) return journal.previous;
+  throw recoveryError(file, "canonical state does not match the transaction");
+}
+
+export function reconcileStatePublicationSync(file: string, io: StatePublicationIO): void {
+  const transaction = loadTransaction(file);
+  if (transaction === null) return;
+  const { staged, journalArtifact, journal } = transaction;
+  const journalPath = staged.journal;
+  const temporary = readProvenState(staged.temporary, journal.replacement, io);
+  let quarantine = readProvenState(staged.quarantine, journal.previous, io);
+  let canonical = readArtifact(file);
+  const selected = selectCanonicalState(file, canonical, quarantine, journal);
+  const replacementSelected = selected === journal.replacement;
+  assertLinks(canonical, replacementSelected ? temporary !== null : quarantine !== null);
+  assertLinks(temporary, replacementSelected && canonical !== null);
+  assertLinks(quarantine, !replacementSelected && canonical !== null);
+  if (canonical === null) {
+    linkSync(staged.quarantine, file);
+    io.synchronize();
+    canonical = readProvenState(file, selected, io);
+    quarantine = readProvenState(staged.quarantine, selected, io);
+    if (canonical === null || quarantine === null) throw recoveryError(file, "restored state disappeared");
+    assertLinks(canonical, true);
+    assertLinks(quarantine, true);
+  }
+  io.parse(canonical.bytes.toString("utf8"), file);
+  io.synchronize();
+  if (temporary !== null) removeProvenState(temporary, journal.replacement, io);
+  if (quarantine !== null) removeProvenState(quarantine, journal.previous!, io);
+  const verified = readProvenState(file, selected, io);
+  if (verified === null) throw recoveryError(file, "canonical state disappeared during cleanup");
+  assertLinks(verified, false);
+  const currentJournal = readArtifact(journalPath, 32_768);
+  if (currentJournal === null || currentJournal.stat.dev !== journalArtifact.stat.dev ||
+    currentJournal.stat.ino !== journalArtifact.stat.ino || !currentJournal.bytes.equals(journalArtifact.bytes)) {
+    throw recoveryError(journalPath, "journal changed before cleanup");
+  }
+  unlinkSync(journalPath);
+  io.synchronize();
+}
+
+export function syncStatePublicationDirectorySync(file: string): void {
+  const descriptor = openSync(dirname(file), "r");
+  withArtifactDescriptor(descriptor, () => fsyncSync(descriptor));
+}

--- a/runtime/src/config/state-publication.ts
+++ b/runtime/src/config/state-publication.ts
@@ -87,24 +87,24 @@ function readArtifactBytes(descriptor: number, maximumBytes?: number): Buffer {
 }
 
 function withArtifactDescriptor<Result>(descriptor: number, operation: () => Result): Result {
-  let failure: { readonly error: unknown } | null = null;
+  let outcome: { readonly succeeded: true; readonly value: Result } | { readonly succeeded: false; readonly error: unknown };
   try {
-    return operation();
+    outcome = { succeeded: true, value: operation() };
   } catch (error) {
-    failure = { error };
-    throw error;
-  } finally {
-    try {
-      closeSync(descriptor);
-    } catch (closeError) {
-      if (failure === null) throw closeError;
-      try {
-        if (failure.error instanceof Error && Object.isExtensible(failure.error)) {
-          Object.defineProperty(failure.error, "cleanupErrors", { configurable: true, value: Object.freeze([closeError]) });
-        }
-      } catch {}
-    }
+    outcome = { succeeded: false, error };
   }
+  try {
+    closeSync(descriptor);
+  } catch (closeError) {
+    if (outcome.succeeded) throw closeError;
+    try {
+      if (outcome.error instanceof Error && Object.isExtensible(outcome.error)) {
+        Object.defineProperty(outcome.error, "cleanupErrors", { configurable: true, value: Object.freeze([closeError]) });
+      }
+    } catch {}
+  }
+  if (!outcome.succeeded) throw outcome.error;
+  return outcome.value;
 }
 
 function readArtifact(file: string, maximumBytes?: number): Artifact | null {
@@ -188,7 +188,7 @@ export function writeStatePublicationJournalSync(
   const bytes = Buffer.from(`${JSON.stringify(journal)}\n`);
   writeFileSync(journalPath, bytes, { flag: "wx", mode: 0o600, flush: true });
   const observed = readArtifact(journalPath, 32_768);
-  if (observed === null || !observed.bytes.equals(bytes)) throw recoveryError(journalPath, "prepared journal changed");
+  if (!observed?.bytes.equals(bytes)) throw recoveryError(journalPath, "prepared journal changed");
   parseJournal(observed, transactionId);
 }
 

--- a/runtime/src/config/state.ts
+++ b/runtime/src/config/state.ts
@@ -3,7 +3,6 @@ import {
   closeSync,
   constants as fsConstants,
   fstatSync,
-  fsyncSync,
   linkSync,
   lstatSync,
   mkdirSync,
@@ -16,6 +15,7 @@ import {
 } from "node:fs";
 import { lstat, open } from "node:fs/promises";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { reconcileStatePublicationSync, syncStatePublicationDirectorySync, writeStatePublicationJournalSync } from "./state-publication.js";
 
 import {
   cloneRecord,
@@ -962,223 +962,121 @@ function removeExactStateArtifactSync(
   unlinkSync(path);
 }
 
-function removeLinkedStateStageSync(
-  path: string,
-  expected: CanonicalStateFileSnapshot,
-): void {
-  const current = lstatExistingStateSync(path);
-  if (
-    !current.isFile() ||
-    current.isSymbolicLink() ||
-    current.dev !== expected.version.dev ||
-    current.ino !== expected.version.ino ||
-    current.size !== expected.version.size ||
-    current.mtimeNs !== expected.version.mtimeNs ||
-    current.mode !== expected.version.mode ||
-    current.uid !== expected.version.uid ||
-    current.nlink !== 2n
-  ) {
-    throw stateFileError(
-      path,
-      "state cleanup preserved a linked stage that changed identity or metadata",
-    );
-  }
-  unlinkSync(path);
+function createStatePublicationIO(path: string) {
+  let directoryDurability: CanonicalStateDirectoryDurability = "confirmed";
+  const errors: Error[] = [];
+  return {
+    parse: parseCanonicalStateDocument,
+    errors,
+    get directoryDurability(): CanonicalStateDirectoryDurability { return directoryDurability; },
+    synchronize: (): void => {
+      if (directoryDurability === "unsupported") return;
+      try {
+        syncStatePublicationDirectorySync(path);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "EISDIR" || isUnsupportedDirectoryDurabilityError(error)) {
+          directoryDurability = "unsupported";
+          errors.push(asPostCommitError(error));
+          return;
+        }
+        directoryDurability = "indeterminate";
+        throw error;
+      }
+    },
+  };
 }
 
-/** Strict CAS state write. There is intentionally no overwrite fallback. */
+export function recoverCanonicalStatePublicationSync(path: string): void {
+  reconcileStatePublicationSync(path, createStatePublicationIO(path));
+}
+
+function publishPreparedStateSync(
+  path: string, temporary: string, quarantine: string, expected: CanonicalStateFileSnapshot | null,
+  io: ReturnType<typeof createStatePublicationIO>,
+): void {
+  if (expected !== null) {
+    const current = readCanonicalStateSnapshotSync(path);
+    if (current === null || !sameCanonicalStateSnapshot(current, expected)) {
+      throw stateFileError(path, "state publication refuses a destination that changed after read");
+    }
+    renameSync(path, quarantine);
+    const quarantined = readCanonicalStateSnapshotSync(quarantine);
+    if (quarantined === null || !sameRenamedCanonicalStateSnapshot(quarantined, expected)) {
+      throw stateFileError(quarantine, "state publication quarantined a concurrent revision; it was preserved for recovery");
+    }
+    io.synchronize();
+  } else {
+    const appeared = lstatStateOrMissingSync(path);
+    if (appeared !== null) {
+      assertRegularStatePath(path, appeared);
+      throw stateFileError(path, "state publication refuses a destination that appeared after read");
+    }
+  }
+  try {
+    linkSync(temporary, path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw stateFileError(path, "state publication refuses to overwrite a destination that appeared");
+    }
+    throw error;
+  }
+}
+
 export function writeCanonicalStateAtomicSync(
   path: string,
   state: Readonly<CanonicalStateDocument>,
   options: CanonicalStateWriteOptions = {},
 ): CanonicalStateWriteOutcome {
-  const parent = dirname(path);
-  mkdirSync(parent, { recursive: true, mode: 0o700 });
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const io = createStatePublicationIO(path);
+  reconcileStatePublicationSync(path, io);
   const expected = Object.hasOwn(options, "expected")
     ? options.expected ?? null
     : readCanonicalStateSnapshotSync(path);
   const content = serializeCanonicalState(state);
-  const temporary = `${path}.tmp-${process.pid}-${randomUUID()}`;
-  const quarantine = `${path}.quarantine-${process.pid}-${randomUUID()}`;
+  const transactionId = `${process.pid}-${randomUUID()}`;
+  const temporary = `${path}.tmp-${transactionId}`;
+  const quarantine = `${path}.quarantine-${transactionId}`;
   let temporarySnapshot: CanonicalStateFileSnapshot | null = null;
-  let quarantinedSnapshot: CanonicalStateFileSnapshot | null = null;
-  let committed = false;
+  let journalPrepared = false;
   const postCommitErrors: Error[] = [];
   try {
     writeFileSync(temporary, content, {
-      encoding: "utf8",
-      flag: "wx",
-      flush: true,
-      mode: CANONICAL_STATE_FILE_MODE,
+      encoding: "utf8", flag: "wx", flush: true, mode: CANONICAL_STATE_FILE_MODE,
     });
     temporarySnapshot = readCanonicalStateSnapshotSync(temporary);
-    if (
-      temporarySnapshot === null ||
-      !temporarySnapshot.bytes.equals(Buffer.from(content, "utf8"))
-    ) {
-      throw stateFileError(
-        temporary,
-        "state publication stage changed while it was prepared",
-      );
+    if (temporarySnapshot === null || !temporarySnapshot.bytes.equals(Buffer.from(content, "utf8"))) {
+      throw stateFileError(temporary, "state publication stage changed while it was prepared");
     }
-
-    if (expected !== null) {
-      const current = readCanonicalStateSnapshotSync(path);
-      if (current === null || !sameCanonicalStateSnapshot(current, expected)) {
-        throw stateFileError(
-          path,
-          "state publication refuses a destination that changed after read",
-        );
-      }
-      try {
-        renameSync(path, quarantine);
-      } catch (error) {
-        throw error;
-      }
-      const quarantineCandidate = readCanonicalStateSnapshotSync(quarantine);
-      if (
-        quarantineCandidate === null ||
-        !sameRenamedCanonicalStateSnapshot(quarantineCandidate, expected)
-      ) {
-        throw stateFileError(
-          quarantine,
-          "state publication quarantined a concurrent revision; it was preserved for recovery",
-        );
-      }
-      quarantinedSnapshot = quarantineCandidate;
-    } else {
-      const appeared = lstatStateOrMissingSync(path);
-      if (appeared !== null) {
-        assertRegularStatePath(path, appeared);
-        throw stateFileError(
-          path,
-          "state publication refuses a destination that appeared after read",
-        );
-      }
-    }
-
-    try {
-      linkSync(temporary, path);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-        throw stateFileError(
-          path,
-          "state publication refuses to overwrite a destination that appeared",
-        );
-      }
-      throw error;
-    }
-    committed = true;
+    writeStatePublicationJournalSync(path, transactionId, expected, temporarySnapshot);
+    journalPrepared = true;
+    io.synchronize();
+    publishPreparedStateSync(path, temporary, quarantine, expected, io);
   } catch (error) {
     const cleanupErrors: Error[] = [];
-    if (quarantinedSnapshot !== null) {
-      try {
-        if (lstatStateOrMissingSync(path) !== null) {
-          throw stateFileError(
-            path,
-            `state publication could not restore the validated state because its path reappeared; recover it from ${quarantine}`,
-          );
-        }
-        try {
-          linkSync(quarantine, path);
-        } catch (restoreError) {
-          if ((restoreError as NodeJS.ErrnoException).code === "EEXIST") {
-            throw stateFileError(
-              path,
-              `state publication could not restore the validated state because its path reappeared; recover it from ${quarantine}`,
-            );
-          }
-          throw restoreError;
-        }
-        removeLinkedStateStageSync(quarantine, quarantinedSnapshot);
-        const restored = readCanonicalStateSnapshotSync(path);
-        if (
-          restored === null ||
-          !sameRenamedCanonicalStateSnapshot(restored, quarantinedSnapshot)
-        ) {
-          throw stateFileError(
-            path,
-            `state publication restored an unexpected file; recover the validated state from ${quarantine}`,
-          );
-        }
-        quarantinedSnapshot = null;
-      } catch (restoreError) {
-        cleanupErrors.push(asStateCleanupError(restoreError));
-      }
-    }
-    if (temporarySnapshot !== null) {
-      try {
-        removeExactStateArtifactSync(temporary, temporarySnapshot);
-      } catch (cleanupError) {
-        if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
-          cleanupErrors.push(asStateCleanupError(cleanupError));
-        }
-      }
+    try {
+      if (journalPrepared) reconcileStatePublicationSync(path, io);
+      else if (temporarySnapshot !== null) removeExactStateArtifactSync(temporary, temporarySnapshot);
+    } catch (cleanupError) {
+      cleanupErrors.push(asStateCleanupError(cleanupError));
     }
     attachStateCleanupErrors(error, cleanupErrors);
     throw error;
   }
 
-  // linkSync above is the commit point. Nothing below may report a
-  // pre-commit failure while the new state remains visible at `path`.
-  if (committed && temporarySnapshot !== null) {
-    try {
-      removeLinkedStateStageSync(temporary, temporarySnapshot);
-    } catch (error) {
-      postCommitErrors.push(asStateCleanupError(error));
-    }
-  }
-  if (quarantinedSnapshot !== null) {
-    try {
-      removeExactStateArtifactSync(quarantine, quarantinedSnapshot);
-    } catch (error) {
-      postCommitErrors.push(asStateCleanupError(error));
-    }
+  try {
+    reconcileStatePublicationSync(path, io);
+  } catch (error) {
+    postCommitErrors.push(asStateCleanupError(error));
   }
   try {
     const published = readCanonicalStateSnapshotSync(path);
-    if (
-      published === null ||
-      temporarySnapshot === null ||
-      !published.bytes.equals(temporarySnapshot.bytes)
-    ) {
-      postCommitErrors.push(stateFileError(
-        path,
-        "committed state could not be verified against its publication stage",
-      ));
+    if (published === null || temporarySnapshot === null || !published.bytes.equals(temporarySnapshot.bytes)) {
+      throw stateFileError(path, "committed state could not be verified against its publication stage");
     }
   } catch (error) {
     postCommitErrors.push(asStateCleanupError(error));
   }
-
-  let directoryFd: number;
-  try {
-    directoryFd = openSync(parent, "r");
-  } catch (error) {
-    const postCommitError = asPostCommitError(error);
-    const code = (error as NodeJS.ErrnoException).code;
-    const unsupported = code === "EISDIR" ||
-      isUnsupportedDirectoryDurabilityError(error);
-    return committedStateWriteOutcome(
-      unsupported ? "unsupported" : "indeterminate",
-      [...postCommitErrors, postCommitError],
-    );
-  }
-
-  let directoryDurability: CanonicalStateDirectoryDurability = "confirmed";
-  try {
-    fsyncSync(directoryFd);
-  } catch (error) {
-    directoryDurability = isUnsupportedDirectoryDurabilityError(error)
-      ? "unsupported"
-      : "indeterminate";
-    postCommitErrors.push(asPostCommitError(error));
-  }
-  try {
-    closeSync(directoryFd);
-  } catch (error) {
-    postCommitErrors.push(asPostCommitError(error));
-  }
-
-  return committedStateWriteOutcome(directoryDurability, postCommitErrors);
+  return committedStateWriteOutcome(io.directoryDurability, [...io.errors, ...postCommitErrors]);
 }

--- a/runtime/src/config/state.ts
+++ b/runtime/src/config/state.ts
@@ -1046,7 +1046,7 @@ export function writeCanonicalStateAtomicSync(
       encoding: "utf8", flag: "wx", flush: true, mode: CANONICAL_STATE_FILE_MODE,
     });
     temporarySnapshot = readCanonicalStateSnapshotSync(temporary);
-    if (temporarySnapshot === null || !temporarySnapshot.bytes.equals(Buffer.from(content, "utf8"))) {
+    if (!temporarySnapshot?.bytes.equals(Buffer.from(content, "utf8"))) {
       throw stateFileError(temporary, "state publication stage changed while it was prepared");
     }
     writeStatePublicationJournalSync(path, transactionId, expected, temporarySnapshot);

--- a/runtime/tests/commands/permissions.test.ts
+++ b/runtime/tests/commands/permissions.test.ts
@@ -124,12 +124,16 @@ async function withInjectedDirectoryFsyncFailure<T>(
   const originalOpenSync = nodeFs.openSync;
   const originalFsyncSync = nodeFs.fsyncSync;
   const originalCloseSync = nodeFs.closeSync;
+  let directorySyncCount = 0;
   nodeFs.openSync = (path, flags, mode) =>
     path === directory && flags === "r"
       ? injectedDescriptor
       : originalOpenSync(path, flags, mode);
   nodeFs.fsyncSync = (descriptor) => {
-    if (descriptor === injectedDescriptor) throw failure;
+    if (descriptor === injectedDescriptor) {
+      if (++directorySyncCount === 2) throw failure;
+      return;
+    }
     originalFsyncSync(descriptor);
   };
   nodeFs.closeSync = (descriptor) => {
@@ -1246,7 +1250,7 @@ describe("permissionsCommand — bypassPermissions consent gate", () => {
         setDaemonPermissionMode: vi.fn(),
       } as unknown as Session;
       const failure = Object.assign(
-        new Error("injected post-rename directory fsync failure"),
+        new Error("injected post-publication directory fsync failure"),
         { code: "EIO" },
       );
       const result = await withInjectedDirectoryFsyncFailure(

--- a/runtime/tests/config/state-publication-recovery.test.ts
+++ b/runtime/tests/config/state-publication-recovery.test.ts
@@ -9,6 +9,7 @@ import { resolveHomeContext } from "../../src/config/home.js";
 import { RuntimeStateRepository } from "../../src/config/runtime-state-repository.js";
 import { createCanonicalStateDocument, writeCanonicalStateAtomicSync } from "../../src/config/state.js";
 import { syncStatePublicationDirectorySync } from "../../src/config/state-publication.js";
+import * as lockfile from "../../src/utils/lockfile.js";
 
 const directories: string[] = [];
 const repositories: RuntimeStateRepository[] = [];
@@ -77,6 +78,7 @@ function terminatePublication(file: string, transition: string, recover = false)
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const repository of repositories.splice(0)) repository.close();
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
@@ -223,6 +225,25 @@ describe("canonical state publication recovery", () => {
     terminatePublication(file, "journal-write");
     expect(() => repository.get()).toThrow(/missing prior committed state/u);
     expect(existsSync(file)).toBe(false);
+  });
+
+  test("retries a freshness lock failure without requiring another file event", async () => {
+    const { directory, file } = fixture();
+    let notify: (() => void) | undefined;
+    const repository = new RuntimeStateRepository(resolveHomeContext({ AGENC_HOME: directory, HOME: directory }), {
+      storage: "disk",
+      watchFile: (_file, _options, listener) => { notify = () => listener({} as Stats, {} as Stats); },
+      unwatchFile: () => {},
+    });
+    repositories.push(repository);
+    expect(repository.get()).toMatchObject(previousGlobal);
+    terminatePublication(file, "publication");
+    const contention = Object.assign(new Error("injected stale writer lock"), { code: "ELOCKED" });
+    const acquire = vi.spyOn(lockfile, "lock").mockRejectedValueOnce(contention);
+    notify!();
+    await vi.waitFor(() => expect(acquire).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(repository.get()).toMatchObject(replacementGlobal), { timeout: 200 });
+    expect(readdirSync(directory)).toEqual(["state.json"]);
   });
 
   test("preserves the directory sync failure when closing also fails", () => {

--- a/runtime/tests/config/state-publication-recovery.test.ts
+++ b/runtime/tests/config/state-publication-recovery.test.ts
@@ -1,0 +1,247 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, linkSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync, type Stats } from "node:fs";
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { acquireConfigAuthorityLocks } from "../../src/config/authority-lock.js";
+import { resolveHomeContext } from "../../src/config/home.js";
+import { RuntimeStateRepository } from "../../src/config/runtime-state-repository.js";
+import { createCanonicalStateDocument, writeCanonicalStateAtomicSync } from "../../src/config/state.js";
+import { syncStatePublicationDirectorySync } from "../../src/config/state-publication.js";
+
+const directories: string[] = [];
+const repositories: RuntimeStateRepository[] = [];
+const previousGlobal = { hasSeenTasksHint: false, hasUsedStash: true };
+const replacementGlobal = { hasSeenTasksHint: true, hasUsedStash: true };
+const previous = createCanonicalStateDocument({ global: previousGlobal });
+const replacement = createCanonicalStateDocument({ global: replacementGlobal });
+
+function fixture(): { readonly directory: string; readonly file: string; readonly repository: RuntimeStateRepository } {
+  const directory = mkdtempSync(join(tmpdir(), "agenc-state-crash-"));
+  directories.push(directory);
+  const home = resolveHomeContext({ AGENC_HOME: directory, HOME: directory });
+  const repository = new RuntimeStateRepository(home, { storage: "disk" });
+  repositories.push(repository);
+  writeCanonicalStateAtomicSync(home.statePath, previous);
+  return { directory, file: home.statePath, repository };
+}
+
+function terminatePublication(file: string, transition: string, recover = false): void {
+  const script = `
+    import { createRequire, syncBuiltinESMExports } from "node:module";
+    const filesystem = createRequire(import.meta.url)("node:fs");
+    const file = ${JSON.stringify(file)};
+    const transition = ${JSON.stringify(transition)};
+    const originalRename = filesystem.renameSync;
+    const originalLink = filesystem.linkSync;
+    const originalWrite = filesystem.writeFileSync;
+    const originalUnlink = filesystem.unlinkSync;
+    const originalSync = filesystem.fsyncSync;
+    let directorySyncs = 0;
+    filesystem.writeFileSync = (...arguments_) => {
+      originalWrite(...arguments_);
+      const destination = String(arguments_[0]);
+      if (transition === "temporary-write" && destination.startsWith(file + ".tmp-")) process.exit(73);
+      if (transition === "journal-write" && destination.startsWith(file + ".transaction-")) process.exit(73);
+    };
+    filesystem.unlinkSync = (destination) => {
+      originalUnlink(destination);
+      for (const [event, suffix] of [["temporary-unlink", ".tmp-"], ["quarantine-unlink", ".quarantine-"], ["journal-unlink", ".transaction-"]]) {
+        if (transition === event && destination.startsWith(file + suffix)) process.exit(73);
+      }
+    };
+    filesystem.fsyncSync = (descriptor) => {
+      originalSync(descriptor);
+      if (filesystem.fstatSync(descriptor).isDirectory() && transition === "directory-sync-" + ++directorySyncs) process.exit(73);
+    };
+    filesystem.renameSync = (source, destination) => {
+      originalRename(source, destination);
+      if (transition === "quarantine" && source === file && destination.includes(".quarantine-")) process.exit(73);
+    };
+    filesystem.linkSync = (source, destination) => {
+      originalLink(source, destination);
+      if (transition === "publication" && destination === file) process.exit(73);
+    };
+    syncBuiltinESMExports();
+    const { writeCanonicalStateAtomicSync, recoverCanonicalStatePublicationSync } = await import(${JSON.stringify(new URL("../../src/config/state.ts", import.meta.url).href)});
+    if (${JSON.stringify(recover)}) recoverCanonicalStatePublicationSync(file);
+    else writeCanonicalStateAtomicSync(file, ${JSON.stringify(replacement)});
+    process.exit(74);
+  `;
+  const child = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], {
+    encoding: "utf8", timeout: 20_000,
+  });
+  expect(child.error).toBeUndefined();
+  expect(child.status, child.stderr).toBe(73);
+}
+
+afterEach(() => {
+  for (const repository of repositories.splice(0)) repository.close();
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("canonical state publication recovery", () => {
+  test("restores committed state after termination immediately after quarantine", () => {
+    const { file, repository } = fixture();
+    terminatePublication(file, "quarantine");
+    expect(existsSync(file)).toBe(false);
+    expect(repository.get()).toMatchObject(previousGlobal);
+    repository.update((current) => ({ ...current, hasAcknowledgedCostThreshold: true }));
+    expect(JSON.parse(readFileSync(file, "utf8")).state.global).toMatchObject({
+      ...previousGlobal, hasAcknowledgedCostThreshold: true,
+    });
+  });
+
+  test("keeps replacement state after termination immediately after publication", () => {
+    const { directory, file, repository } = fixture();
+    terminatePublication(file, "publication");
+    expect(repository.get()).toMatchObject(replacementGlobal);
+    expect(readdirSync(directory)).toEqual(["state.json"]);
+  });
+
+  test("does not turn unidentifiable legacy stages into empty state", () => {
+    const { directory, file, repository } = fixture();
+    rmSync(file);
+    writeFileSync(`${file}.quarantine-1-old`, JSON.stringify(previous), { mode: 0o600 });
+    writeFileSync(`${file}.tmp-1-new`, JSON.stringify(replacement), { mode: 0o600 });
+    const entries = readdirSync(directory).sort();
+    expect(() => repository.get()).toThrow(/recover|publication|transaction/iu);
+    expect(() => repository.update((current) => ({ ...current, hasSeenTasksHint: true }))).toThrow(/recover|publication|transaction/iu);
+    expect(existsSync(file)).toBe(false);
+    expect(readdirSync(directory).sort()).toEqual(entries);
+  });
+
+  test.each([
+    ["journal-write", false], ["directory-sync-1", false], ["directory-sync-2", false],
+    ["directory-sync-3", true], ["temporary-unlink", true], ["directory-sync-4", true],
+    ["quarantine-unlink", true], ["directory-sync-5", true],
+    ["journal-unlink", true], ["directory-sync-6", true],
+  ])("recovers after the %s boundary", (transition, committed) => {
+    const { directory, file, repository } = fixture();
+    terminatePublication(file, transition as string);
+    expect(repository.get()).toMatchObject(committed ? replacementGlobal : previousGlobal);
+    expect(readdirSync(directory)).toEqual(["state.json"]);
+  });
+
+  test.each(["publication", "temporary-unlink", "quarantine-unlink", "journal-unlink", "directory-sync-1", "directory-sync-2", "directory-sync-3", "directory-sync-4", "directory-sync-5"])(
+    "can resume recovery interrupted at %s", (transition) => {
+      const { directory, file, repository } = fixture();
+      terminatePublication(file, "quarantine");
+      terminatePublication(file, transition, true);
+      expect(repository.get()).toMatchObject(previousGlobal);
+      expect(readdirSync(directory)).toEqual(["state.json"]);
+    },
+  );
+
+  test("preserves an orphan stage created before its journal", () => {
+    const { directory, file, repository } = fixture();
+    terminatePublication(file, "temporary-write");
+    const entries = readdirSync(directory).sort();
+    expect(() => repository.get()).toThrow(/recovery required/u);
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(previous);
+    expect(readdirSync(directory).sort()).toEqual(entries);
+  });
+
+  test.each(["invalid-journal", "oversized-journal", "changed-temporary", "changed-quarantine", "missing-quarantine", "extra-transaction"])(
+    "preserves evidence for %s", (defect) => {
+      const { directory, file, repository } = fixture();
+      terminatePublication(file, "quarantine");
+      const stage = (suffix: string) => join(directory, readdirSync(directory).find((entry) => entry.startsWith(`state.json.${suffix}-`))!);
+      if (defect === "invalid-journal") writeFileSync(stage("transaction"), "{", { mode: 0o600 });
+      if (defect === "oversized-journal") writeFileSync(stage("transaction"), " ".repeat(32_769), { mode: 0o600 });
+      if (defect === "changed-temporary") writeFileSync(stage("tmp"), JSON.stringify(previous), { mode: 0o600 });
+      if (defect === "changed-quarantine") writeFileSync(stage("quarantine"), JSON.stringify(replacement), { mode: 0o600 });
+      if (defect === "missing-quarantine") rmSync(stage("quarantine"));
+      if (defect === "extra-transaction") writeFileSync(`${file}.transaction-1-other.json`, "{}", { mode: 0o600 });
+      const entries = readdirSync(directory).sort();
+      expect(() => repository.get()).toThrow(/recovery required/u);
+      expect(existsSync(file)).toBe(false);
+      expect(readdirSync(directory).sort()).toEqual(entries);
+    },
+  );
+
+  test.each(["symlink", "hardlink"])("rejects an unexpected %s to a state stage", (kind) => {
+    if (process.platform === "win32") return;
+    const { directory, file, repository } = fixture();
+    terminatePublication(file, "quarantine");
+    const quarantine = join(directory, readdirSync(directory).find((entry) => entry.startsWith("state.json.quarantine-"))!);
+    const outside = join(directory, "outside.json");
+    if (kind === "symlink") {
+      writeFileSync(outside, JSON.stringify(previous), { mode: 0o600 });
+      rmSync(quarantine);
+      symlinkSync(outside, quarantine);
+    } else {
+      linkSync(quarantine, outside);
+    }
+    const bytes = readFileSync(outside);
+    expect(() => repository.get()).toThrow(/recovery required/u);
+    expect(existsSync(file)).toBe(false);
+    expect(readFileSync(outside)).toEqual(bytes);
+  });
+
+  test("recovers before an update without an earlier read", () => {
+    const { file, repository } = fixture();
+    terminatePublication(file, "quarantine");
+    repository.update((current) => ({ ...current, hasAcknowledgedCostThreshold: true }));
+    expect(repository.get()).toMatchObject({ ...previousGlobal, hasAcknowledgedCostThreshold: true });
+  });
+
+  test("recovers a published replacement during asynchronous freshness reload", async () => {
+    const { directory, file } = fixture();
+    let notify: (() => void) | undefined;
+    const repository = new RuntimeStateRepository(resolveHomeContext({ AGENC_HOME: directory, HOME: directory }), {
+      storage: "disk",
+      watchFile: (_file, _options, listener) => { notify = () => listener({} as Stats, {} as Stats); },
+      unwatchFile: () => {},
+    });
+    repositories.push(repository);
+    expect(repository.get()).toMatchObject(previousGlobal);
+    terminatePublication(file, "publication");
+    expect(notify).toBeDefined();
+    notify!();
+    await vi.waitFor(() => expect(repository.get()).toMatchObject(replacementGlobal));
+    expect(readdirSync(directory)).toEqual(["state.json"]);
+  });
+
+  test("does not reconcile while another authority operation holds the lock", async () => {
+    const { file, repository } = fixture();
+    terminatePublication(file, "quarantine");
+    const release = await acquireConfigAuthorityLocks([file]);
+    try {
+      expect(() => repository.get()).toThrow(/lock/iu);
+      expect(existsSync(file)).toBe(false);
+    } finally {
+      await release();
+    }
+    expect(repository.get()).toMatchObject(previousGlobal);
+  });
+
+  test("does not treat an interrupted first publication as an empty home", () => {
+    const { file, repository } = fixture();
+    rmSync(file);
+    terminatePublication(file, "journal-write");
+    expect(() => repository.get()).toThrow(/missing prior committed state/u);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  test("preserves the directory sync failure when closing also fails", () => {
+    const { file } = fixture();
+    const filesystem = createRequire(import.meta.url)("node:fs") as typeof import("node:fs");
+    const originalSync = filesystem.fsyncSync;
+    const originalClose = filesystem.closeSync;
+    const primary = new Error("injected sync failure");
+    const cleanup = new Error("injected close failure");
+    filesystem.fsyncSync = () => { throw primary; };
+    filesystem.closeSync = (descriptor) => { originalClose(descriptor); throw cleanup; };
+    syncBuiltinESMExports();
+    try {
+      expect(() => syncStatePublicationDirectorySync(file)).toThrow(primary);
+      expect(primary).toHaveProperty("cleanupErrors", [cleanup]);
+    } finally {
+      filesystem.fsyncSync = originalSync;
+      filesystem.closeSync = originalClose;
+      syncBuiltinESMExports();
+    }
+  });
+});

--- a/runtime/tests/config/state-publication-recovery.test.ts
+++ b/runtime/tests/config/state-publication-recovery.test.ts
@@ -28,6 +28,23 @@ function fixture(): { readonly directory: string; readonly file: string; readonl
   return { directory, file: home.statePath, repository };
 }
 
+function watchedRepository(directory: string): { readonly repository: RuntimeStateRepository; readonly notify: () => void } {
+  let listener: (() => void) | undefined;
+  const repository = new RuntimeStateRepository(resolveHomeContext({ AGENC_HOME: directory, HOME: directory }), {
+    storage: "disk",
+    watchFile: (_file, _options, callback) => { listener = () => callback({} as Stats, {} as Stats); },
+    unwatchFile: () => {},
+  });
+  repositories.push(repository);
+  return {
+    repository,
+    notify: () => {
+      if (listener === undefined) throw new Error("state watcher was not registered");
+      listener();
+    },
+  };
+}
+
 function terminatePublication(file: string, transition: string, recover = false): void {
   const script = `
     import { createRequire, syncBuiltinESMExports } from "node:module";
@@ -191,17 +208,10 @@ describe("canonical state publication recovery", () => {
 
   test("recovers a published replacement during asynchronous freshness reload", async () => {
     const { directory, file } = fixture();
-    let notify: (() => void) | undefined;
-    const repository = new RuntimeStateRepository(resolveHomeContext({ AGENC_HOME: directory, HOME: directory }), {
-      storage: "disk",
-      watchFile: (_file, _options, listener) => { notify = () => listener({} as Stats, {} as Stats); },
-      unwatchFile: () => {},
-    });
-    repositories.push(repository);
+    const { repository, notify } = watchedRepository(directory);
     expect(repository.get()).toMatchObject(previousGlobal);
     terminatePublication(file, "publication");
-    expect(notify).toBeDefined();
-    notify!();
+    notify();
     await vi.waitFor(() => expect(repository.get()).toMatchObject(replacementGlobal));
     expect(readdirSync(directory)).toEqual(["state.json"]);
   });
@@ -229,18 +239,12 @@ describe("canonical state publication recovery", () => {
 
   test("retries a freshness lock failure without requiring another file event", async () => {
     const { directory, file } = fixture();
-    let notify: (() => void) | undefined;
-    const repository = new RuntimeStateRepository(resolveHomeContext({ AGENC_HOME: directory, HOME: directory }), {
-      storage: "disk",
-      watchFile: (_file, _options, listener) => { notify = () => listener({} as Stats, {} as Stats); },
-      unwatchFile: () => {},
-    });
-    repositories.push(repository);
+    const { repository, notify } = watchedRepository(directory);
     expect(repository.get()).toMatchObject(previousGlobal);
     terminatePublication(file, "publication");
     const contention = Object.assign(new Error("injected stale writer lock"), { code: "ELOCKED" });
     const acquire = vi.spyOn(lockfile, "lock").mockRejectedValueOnce(contention);
-    notify!();
+    notify();
     await vi.waitFor(() => expect(acquire).toHaveBeenCalledOnce());
     await vi.waitFor(() => expect(repository.get()).toMatchObject(replacementGlobal), { timeout: 200 });
     expect(readdirSync(directory)).toEqual(["state.json"]);

--- a/runtime/tests/config/state.test.ts
+++ b/runtime/tests/config/state.test.ts
@@ -21,6 +21,7 @@ import {
   getGlobalRuntimeState,
   parseCanonicalStateDocument,
   readCanonicalState,
+  recoverCanonicalStatePublicationSync,
   StateRepositoryError,
   validateCanonicalStateDocument,
   withGlobalRuntimeState,
@@ -38,9 +39,10 @@ function temporaryDirectory(): string {
 function withInjectedDirectoryFsyncFailure<T>(
   failure: NodeJS.ErrnoException,
   operation: () => T,
+  failureAt = 1,
 ): T {
   const nodeFs = createRequire(import.meta.url)('node:fs') as {
-    openSync(path: string, flags: string | number): number
+    openSync(path: string, flags: string | number, mode?: number): number
     fsyncSync(descriptor: number): void
     closeSync(descriptor: number): void
   }
@@ -48,13 +50,14 @@ function withInjectedDirectoryFsyncFailure<T>(
   const originalFsyncSync = nodeFs.fsyncSync
   const originalCloseSync = nodeFs.closeSync
   let directoryDescriptor: number | undefined
-  nodeFs.openSync = (path, flags) => {
-    const descriptor = originalOpenSync(path, flags)
+  let directorySyncCount = 0
+  nodeFs.openSync = (path, flags, mode) => {
+    const descriptor = originalOpenSync(path, flags, mode)
     if (flags === 'r') directoryDescriptor = descriptor
     return descriptor
   }
   nodeFs.fsyncSync = (descriptor) => {
-    if (descriptor === directoryDescriptor) throw failure
+    if (descriptor === directoryDescriptor && ++directorySyncCount === failureAt) throw failure
     originalFsyncSync(descriptor)
   }
   nodeFs.closeSync = (descriptor) => originalCloseSync(descriptor)
@@ -543,14 +546,30 @@ describe('canonical runtime state', () => {
         path,
         document,
       ),
+      2,
     )
 
     expect(outcome).toEqual({
       committed: true,
       directoryDurability: 'indeterminate',
-      postCommitErrors: [failure],
+      postCommitErrors: expect.arrayContaining([failure]),
     })
     expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(document)
+    recoverCanonicalStatePublicationSync(path)
+    expect(readdirSync(directory)).toEqual(['state.json'])
+  })
+
+  test('keeps committed state when directory sync fails before quarantine', () => {
+    const directory = temporaryDirectory()
+    const path = join(directory, 'state.json')
+    const original = createCanonicalStateDocument({ global: { hasUsedStash: true } })
+    writeCanonicalStateAtomicSync(path, original)
+    const failure = Object.assign(new Error('injected pre-commit directory sync failure'), { code: 'EIO' })
+    expect(() => withInjectedDirectoryFsyncFailure(failure, () =>
+      writeCanonicalStateAtomicSync(path, createCanonicalStateDocument({ global: { hasSeenTasksHint: true } })),
+    )).toThrow(failure)
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(original)
+    expect(readdirSync(directory)).toEqual(['state.json'])
   })
 
   test('throws a pre-rename failure without publishing or retaining its stage', () => {


### PR DESCRIPTION
## Changes

- Give each state replacement a versioned journal and shared transaction ID. Bind prior and replacement file identities and bytes before moving the canonical file; retain the exclusive-link commit point and strict CAS checks.
- Reconcile under the existing authority lock before repository reads, updates, and freshness reloads. Restore the prior state before publication, keep the replacement after publication, and resume interrupted cleanup.
- Validate journal structure, file proofs, ownership, modes, regular-file identities, and expected link pairs before mutation. Bound journal reads and verify opened identity before reading. Preserve primary descriptor failures when close also fails.
- Synchronize the parent directory across publication and recovery transitions. Preserve pending evidence on failure and distinguish unsupported or indeterminate durability from confirmed durability.
- Fail closed on ambiguous legacy stages, malformed or multiple journals, changed artifacts, unexpected links, and interrupted first publication without committed state. Document recovery, lock expiry, and downgrade limits. The canonical JSON schema stays at state_version 1.

## Validation

- Original source fails all three initial regressions, including actual child-process termination immediately after quarantine rename and canonical publication.
- Both runtime typechecks, dedicated typechecking of both changed test files, and 918 local configuration tests across 65 files pass.
- Crash tests cover journal preparation, quarantine, publication, every directory-sync boundary, each cleanup unlink, and interruption of recovery itself. Tests also cover invalid evidence, linked stages, update-before-read, asynchronous freshness reload, held authority locks, pre/post-commit sync failures, and primary error preservation.
- A directory-sync test mock now forwards the file mode and selects the post-commit boundary explicitly. Earlier sync failure stops publication rather than being reported as a completed write.
- The FND baseline and measured source inputs are unchanged. Exact-head build, PTY startup, full suite, Linux native checks, and independent review are pending.
- Automatic hosted Actions remain disabled. Validation runs locally.

Closes #2086.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the atomic commit and recovery path for persisted runtime state; incorrect reconciliation could mis-handle `state.json` after crashes or concurrent writers.
> 
> **Overview**
> Adds **crash-safe publication** for `state.json` using a versioned transaction journal that records prior and replacement file proofs (identity, size, SHA-256) before the canonical path is moved or linked. A new `state-publication` module implements **reconcile/recovery**: unfinished transactions restore the previous state if publication never committed, keep the replacement after the exclusive link commit, and finish cleanup of temp/quarantine/journal artifacts with parent-directory `fsync` and explicit durability outcomes.
> 
> **`writeCanonicalStateAtomicSync`** now writes the journal before linking, delegates post-commit cleanup to reconciliation, and treats pre-quarantine directory sync failures as aborts rather than successful writes.
> 
> **`RuntimeStateRepository`** runs recovery under the existing config authority lock on sync reads and on freshness reloads (replacing the prior async read path). Lock contention (`ELOCKED`) drops the cache so the next read retries recovery; malformed, ambiguous, or legacy orphan stages **fail closed** with operator recovery errors instead of empty runtime state.
> 
> Operator-facing **docs** describe lock behavior, artifact preservation, and downgrade expectations. **Tests** simulate process death at each publication boundary plus invalid evidence, lock contention, and async reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9d089ee3a85ac77dc28f12dec18f35b3e7e532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->